### PR TITLE
Adding mqtt Communication layer

### DIFF
--- a/api/node/Cargo.toml
+++ b/api/node/Cargo.toml
@@ -18,6 +18,7 @@ tracing = "0.1.33"
 uuid = "0.8.2"
 zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git" }
 zenoh-config = { git = "https://github.com/eclipse-zenoh/zenoh.git" }
+paho-mqtt = "0.11"
 
 [dev-dependencies]
 tokio = { version = "1.17.0", features = ["rt"] }

--- a/api/node/src/config.rs
+++ b/api/node/src/config.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, BTreeSet},
     convert::Infallible,
+    fmt::Display,
     str::FromStr,
 };
 
@@ -99,6 +100,16 @@ impl Serialize for InputMapping {
             serializer.collect_str(&format_args!("{}/{operator}/{}", self.source, self.output))
         } else {
             serializer.collect_str(&format_args!("{}/{}", self.source, self.output))
+        }
+    }
+}
+
+impl Display for InputMapping {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(operator) = &self.operator {
+            write!(f, "{}/{operator}/{}", self.source, self.output)
+        } else {
+            write!(f, "{}/{}", self.source, self.output)
         }
     }
 }

--- a/coordinator/examples/example_sink_logger.rs
+++ b/coordinator/examples/example_sink_logger.rs
@@ -37,7 +37,8 @@ async fn main() -> eyre::Result<()> {
                 }
             }
             "timestamped-random" => {
-                let data = String::from_utf8(input.data)?;
+                let data = String::from_utf8(input.data)
+                    .unwrap_or("Malformed `timestamped` messages".to_string());
                 println!("received timestamped random value: {data}");
             }
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -18,3 +18,5 @@ tokio = { version = "1.17.0", features = ["full"] }
 tokio-stream = "0.1.8"
 zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git" }
 zenoh-config = { git = "https://github.com/eclipse-zenoh/zenoh.git" }
+
+paho-mqtt = "0.11"

--- a/runtime/src/main.rs
+++ b/runtime/src/main.rs
@@ -36,6 +36,7 @@ async fn create_client(
 ) {
     let create_opts = mqtt::CreateOptionsBuilder::new()
         .server_uri(host)
+        .mqtt_version(mqtt::MQTT_VERSION_5)
         .client_id(id)
         .finalize();
     // Create the client connection
@@ -46,7 +47,7 @@ async fn create_client(
 
     let conn_opts = mqtt::ConnectOptionsBuilder::new()
         .keep_alive_interval(Duration::from_secs(10))
-        .mqtt_version(mqtt::MQTT_VERSION_3_1_1)
+        .mqtt_version(mqtt::MQTT_VERSION_5)
         .clean_session(false)
         .will_message(lwt)
         .finalize();


### PR DESCRIPTION
Example of a MQTT Client replacing Zenoh and implementing the CommunicationLayer trait.

To make it work, you will need a MQTT broker such as Mosquitto: https://github.com/eclipse/mosquitto listening on the default port 1883

