### PR TITLE
Injecting `env` variable into node runtimes

### DIFF
--- a/common/src/descriptor/mod.rs
+++ b/common/src/descriptor/mod.rs
@@ -2,6 +2,7 @@ use dora_node_api::config::{
     CommunicationConfig, DataId, InputMapping, NodeId, NodeRunConfig, OperatorId,
 };
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use std::{
     collections::{BTreeMap, BTreeSet},
     path::PathBuf,
@@ -88,4 +89,14 @@ pub enum EnvValue {
     Bool(bool),
     Integer(u64),
     String(String),
+}
+
+impl fmt::Display for EnvValue {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            EnvValue::Bool(bool) => fmt.write_str(&bool.to_string()),
+            EnvValue::Integer(u64) => fmt.write_str(&u64.to_string()),
+            EnvValue::String(str) => fmt.write_str(str),
+        }
+    }
 }

--- a/coordinator/src/main.rs
+++ b/coordinator/src/main.rs
@@ -116,6 +116,15 @@ fn spawn_custom_node(
         serde_yaml::to_string(&node.run_config)
             .wrap_err("failed to serialize custom node run config")?,
     );
+
+    // Injecting the env variable defined in the `yaml` into
+    // the node runtime.
+    if let Some(envs) = &node.env {
+        for (key, value) in envs {
+            command.env(key, value.to_string());
+        }
+    }
+
     let mut child = command
         .spawn()
         .wrap_err_with(|| format!("failed to run command `{}`", &node.run))?;


### PR DESCRIPTION
Injecting the env variable declared in the YAML into the node runtime.

This requires to re-serialize the parsed env variables into string.