### PR TITLE
Add support for single operator nodes in YAML dataflow specification

### DIFF
--- a/apis/rust/node/src/config.rs
+++ b/apis/rust/node/src/config.rs
@@ -6,7 +6,7 @@ use std::{
     str::FromStr,
 };
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct NodeRunConfig {
     #[serde(default)]

--- a/binaries/coordinator/examples/mini-dataflow.yml
+++ b/binaries/coordinator/examples/mini-dataflow.yml
@@ -54,5 +54,14 @@ nodes:
         python: ../runtime/examples/python-operator/op.py
         inputs:
           time: timer/time
+          test: python-operator/counter
         outputs:
           - counter
+
+  - id: python-operator
+    python:
+      path: ../runtime/examples/python-operator/op.py
+      inputs:
+        time: timer/time
+      outputs:
+        - counter

--- a/binaries/coordinator/examples/mini-dataflow.yml
+++ b/binaries/coordinator/examples/mini-dataflow.yml
@@ -59,8 +59,8 @@ nodes:
           - counter
 
   - id: python-operator
-    python:
-      path: ../runtime/examples/python-operator/op.py
+    operator:
+      python: ../runtime/examples/python-operator/op.py
       inputs:
         time: timer/time
       outputs:

--- a/binaries/runtime/src/main.rs
+++ b/binaries/runtime/src/main.rs
@@ -107,7 +107,7 @@ async fn main() -> eyre::Result<()> {
                     .ok_or_else(|| eyre!("received event from unknown operator {id}"))?;
                 match event {
                     OperatorEvent::Output { id: data_id, value } => {
-                        if !operator.config().config.outputs.contains(&data_id) {
+                        if !operator.definition().config.outputs.contains(&data_id) {
                             eyre::bail!("unknown output {data_id} for operator {id}");
                         }
                         publish(&node_id, id, data_id, &value, communication.as_ref())

--- a/binaries/runtime/src/main.rs
+++ b/binaries/runtime/src/main.rs
@@ -1,6 +1,6 @@
 #![warn(unsafe_op_in_unsafe_fn)]
 
-use dora_core::descriptor::OperatorConfig;
+use dora_core::descriptor::OperatorDefinition;
 use dora_node_api::{
     self,
     communication::{self, CommunicationLayer},
@@ -37,7 +37,7 @@ async fn main() -> eyre::Result<()> {
             .wrap_err("env variable DORA_COMMUNICATION_CONFIG must be set")?;
         serde_yaml::from_str(&raw).context("failed to deserialize communication config")?
     };
-    let operators: Vec<OperatorConfig> = {
+    let operators: Vec<OperatorDefinition> = {
         let raw =
             std::env::var("DORA_OPERATORS").wrap_err("env variable DORA_OPERATORS must be set")?;
         serde_yaml::from_str(&raw).context("failed to deserialize operator config")?
@@ -107,7 +107,7 @@ async fn main() -> eyre::Result<()> {
                     .ok_or_else(|| eyre!("received event from unknown operator {id}"))?;
                 match event {
                     OperatorEvent::Output { id: data_id, value } => {
-                        if !operator.config().outputs.contains(&data_id) {
+                        if !operator.config().config.outputs.contains(&data_id) {
                             eyre::bail!("unknown output {data_id} for operator {id}");
                         }
                         publish(&node_id, id, data_id, &value, communication.as_ref())
@@ -154,7 +154,7 @@ async fn main() -> eyre::Result<()> {
 }
 
 async fn subscribe<'a>(
-    operators: &'a [OperatorConfig],
+    operators: &'a [OperatorDefinition],
     communication: &'a dyn CommunicationLayer,
 ) -> eyre::Result<impl futures::Stream<Item = SubscribeEvent> + 'a> {
     let mut streams = Vec::new();
@@ -168,11 +168,11 @@ async fn subscribe<'a>(
 }
 
 async fn subscribe_operator<'a>(
-    operator: &'a OperatorConfig,
+    operator: &'a OperatorDefinition,
     communication: &'a dyn CommunicationLayer,
 ) -> Result<impl futures::Stream<Item = SubscribeEvent> + 'a, eyre::Error> {
     let stop_messages = FuturesUnordered::new();
-    for input in operator.inputs.values() {
+    for input in operator.config.inputs.values() {
         let InputMapping {
             source, operator, ..
         } = input;
@@ -189,7 +189,7 @@ async fn subscribe_operator<'a>(
     let finished = Box::pin(stop_messages.all(|_| async { true }).shared());
 
     let mut streams = Vec::new();
-    for (input, mapping) in &operator.inputs {
+    for (input, mapping) in &operator.config.inputs {
         let InputMapping {
             source,
             operator: source_operator,

--- a/binaries/runtime/src/operator/mod.rs
+++ b/binaries/runtime/src/operator/mod.rs
@@ -9,28 +9,31 @@ mod shared_lib;
 
 pub struct Operator {
     operator_task: Sender<OperatorInput>,
-    config: OperatorDefinition,
+    definition: OperatorDefinition,
 }
 
 impl Operator {
     pub async fn init(
-        operator_config: OperatorDefinition,
+        operator_definition: OperatorDefinition,
         events_tx: Sender<OperatorEvent>,
     ) -> eyre::Result<Self> {
         let (operator_task, operator_rx) = mpsc::channel(10);
 
-        match &operator_config.config.source {
+        match &operator_definition.config.source {
             OperatorSource::SharedLibrary(path) => {
                 shared_lib::spawn(path, events_tx, operator_rx).wrap_err_with(|| {
                     format!(
                         "failed ot spawn shared library operator for {}",
-                        operator_config.id
+                        operator_definition.id
                     )
                 })?;
             }
             OperatorSource::Python(path) => {
                 python::spawn(path, events_tx, operator_rx).wrap_err_with(|| {
-                    format!("failed ot spawn Python operator for {}", operator_config.id)
+                    format!(
+                        "failed ot spawn Python operator for {}",
+                        operator_definition.id
+                    )
                 })?;
             }
             OperatorSource::Wasm(path) => {
@@ -39,7 +42,7 @@ impl Operator {
         }
         Ok(Self {
             operator_task,
-            config: operator_config,
+            definition: operator_definition,
         })
     }
 
@@ -52,10 +55,10 @@ impl Operator {
             })
     }
 
-    /// Get a reference to the operator's config.
+    /// Get a reference to the operator's definition.
     #[must_use]
-    pub fn config(&self) -> &OperatorDefinition {
-        &self.config
+    pub fn definition(&self) -> &OperatorDefinition {
+        &self.definition
     }
 }
 

--- a/binaries/runtime/src/operator/mod.rs
+++ b/binaries/runtime/src/operator/mod.rs
@@ -1,4 +1,4 @@
-use dora_core::descriptor::{OperatorConfig, OperatorSource};
+use dora_core::descriptor::{OperatorDefinition, OperatorSource};
 use dora_node_api::config::DataId;
 use eyre::{eyre, Context};
 use std::any::Any;
@@ -9,17 +9,17 @@ mod shared_lib;
 
 pub struct Operator {
     operator_task: Sender<OperatorInput>,
-    config: OperatorConfig,
+    config: OperatorDefinition,
 }
 
 impl Operator {
     pub async fn init(
-        operator_config: OperatorConfig,
+        operator_config: OperatorDefinition,
         events_tx: Sender<OperatorEvent>,
     ) -> eyre::Result<Self> {
         let (operator_task, operator_rx) = mpsc::channel(10);
 
-        match &operator_config.source {
+        match &operator_config.config.source {
             OperatorSource::SharedLibrary(path) => {
                 shared_lib::spawn(path, events_tx, operator_rx).wrap_err_with(|| {
                     format!(
@@ -54,7 +54,7 @@ impl Operator {
 
     /// Get a reference to the operator's config.
     #[must_use]
-    pub fn config(&self) -> &OperatorConfig {
+    pub fn config(&self) -> &OperatorDefinition {
         &self.config
     }
 }

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -2,6 +2,7 @@ use dora_node_api::config::{
     CommunicationConfig, DataId, InputMapping, NodeId, NodeRunConfig, OperatorId,
 };
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::fmt;
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -18,14 +19,69 @@ pub struct Descriptor {
 }
 
 impl Descriptor {
+    pub fn resolve_aliases(&self) -> Vec<ResolvedNode> {
+        const PYTHON_OP_NAME: &str = "op";
+
+        let python_nodes: HashSet<_> = self
+            .nodes
+            .iter()
+            .filter(|n| matches!(n.kind, NodeKind::Python(_)))
+            .map(|n| &n.id)
+            .collect();
+
+        let mut resolved = vec![];
+        for mut node in self.nodes.clone() {
+            // adjust input mappings
+            let input_mappings: Vec<_> = match &mut node.kind {
+                NodeKind::Runtime(node) => node
+                    .operators
+                    .iter_mut()
+                    .flat_map(|op| op.inputs.values_mut())
+                    .collect(),
+                NodeKind::Custom(node) => node.run_config.inputs.values_mut().collect(),
+                NodeKind::Python(node) => node.inputs.values_mut().collect(),
+            };
+            for mapping in input_mappings {
+                if python_nodes.contains(&mapping.source) {
+                    assert_eq!(mapping.operator, None);
+                    mapping.operator = Some(OperatorId::from(PYTHON_OP_NAME.to_string()));
+                }
+            }
+
+            // resolve nodes
+            let kind = match node.kind {
+                NodeKind::Custom(node) => CoreNodeKind::Custom(node),
+                NodeKind::Runtime(node) => CoreNodeKind::Runtime(node),
+                NodeKind::Python(node) => CoreNodeKind::Runtime(RuntimeNode {
+                    operators: vec![OperatorConfig {
+                        id: OperatorId::from(PYTHON_OP_NAME.to_string()),
+                        name: None,
+                        description: None,
+                        inputs: node.inputs,
+                        outputs: node.outputs,
+                        source: OperatorSource::Python(node.path),
+                    }],
+                }),
+            };
+            resolved.push(ResolvedNode {
+                id: node.id,
+                name: node.name,
+                description: node.description,
+                kind,
+            });
+        }
+        resolved
+    }
+
     pub fn visualize_as_mermaid(&self) -> eyre::Result<String> {
-        let flowchart = visualize::visualize_nodes(&self.nodes);
+        let resolved = self.resolve_aliases();
+        let flowchart = visualize::visualize_nodes(&resolved);
 
         Ok(flowchart)
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Node {
     pub id: NodeId,
     pub name: Option<String>,
@@ -35,16 +91,36 @@ pub struct Node {
     pub kind: NodeKind,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum NodeKind {
     /// Dora runtime node
     #[serde(rename = "operators")]
     Runtime(RuntimeNode),
     Custom(CustomNode),
+    Python(PythonOperatorConfig),
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct ResolvedNode {
+    pub id: NodeId,
+    pub name: Option<String>,
+    pub description: Option<String>,
+
+    #[serde(flatten)]
+    pub kind: CoreNodeKind,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CoreNodeKind {
+    /// Dora runtime node
+    #[serde(rename = "operators")]
+    Runtime(RuntimeNode),
+    Custom(CustomNode),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct RuntimeNode {
     pub operators: Vec<OperatorConfig>,
@@ -73,7 +149,16 @@ pub enum OperatorSource {
     Wasm(PathBuf),
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PythonOperatorConfig {
+    pub path: PathBuf,
+    #[serde(default)]
+    pub inputs: BTreeMap<DataId, InputMapping>,
+    #[serde(default)]
+    pub outputs: BTreeSet<DataId>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CustomNode {
     pub run: String,
     pub env: Option<BTreeMap<String, EnvValue>>,
@@ -83,7 +168,7 @@ pub struct CustomNode {
     pub run_config: NodeRunConfig,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum EnvValue {
     Bool(bool),


### PR DESCRIPTION
Single operator nodes are specified through an `operator` field, in contrast to the `operators` list of normal runtime nodes. Since there is only a single operator on such nodes, specifying an additional operator ID is not necessary. If no operator ID is given, the `coordinator` will assign the ID `op`.

Other nodes can also reference outputs of single-operator nodes by only specifying the node ID, the operator ID is optional here as well. The coordinator will automatically resolve these links.

This feature is useful for Python operators because all operators on the same node use a single global interpreter lock (GIL). By using a separate node for each Python operator, they run in different processes without GIL contention.
