### PR TITLE
Implement runtime-provided periodic timer input for source operators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,6 +685,7 @@ dependencies = [
  "futures",
  "futures-concurrency",
  "futures-time",
+ "once_cell",
  "serde",
  "serde_yaml",
  "thiserror",
@@ -1523,9 +1524,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "opaque-debug"

--- a/apis/rust/node/Cargo.toml
+++ b/apis/rust/node/Cargo.toml
@@ -12,6 +12,7 @@ eyre = "0.6.7"
 futures = "0.3.21"
 futures-concurrency = "2.0.3"
 futures-time = "1.0.0"
+once_cell = "1.13.0"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_yaml = "0.8.23"
 thiserror = "1.0.30"

--- a/apis/rust/node/src/config.rs
+++ b/apis/rust/node/src/config.rs
@@ -222,7 +222,7 @@ pub struct UserInputMapping {
     pub output: DataId,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(deny_unknown_fields, rename_all = "lowercase")]
 pub enum CommunicationConfig {
     Zenoh {

--- a/apis/rust/node/src/lib.rs
+++ b/apis/rust/node/src/lib.rs
@@ -52,19 +52,8 @@ impl DoraNode {
 
     pub async fn inputs(&self) -> eyre::Result<impl futures::Stream<Item = Input> + '_> {
         let mut streams = Vec::new();
-        for (
-            input,
-            config::InputMapping {
-                source,
-                operator,
-                output,
-            },
-        ) in &self.node_config.inputs
-        {
-            let topic = match operator {
-                Some(operator) => format!("{source}/{operator}/{output}"),
-                None => format!("{source}/{output}"),
-            };
+        for (input, mapping) in &self.node_config.inputs {
+            let topic = mapping.to_string();
             let sub = self
                 .communication
                 .subscribe(&topic)
@@ -81,7 +70,7 @@ impl DoraNode {
             .node_config
             .inputs
             .values()
-            .map(|v| (&v.source, &v.operator))
+            .map(|v| (v.source(), v.operator()))
             .collect();
         for (source, operator) in &sources {
             let topic = match operator {

--- a/binaries/coordinator/README.md
+++ b/binaries/coordinator/README.md
@@ -31,12 +31,12 @@ There are drawbacks too, for example:
 ```bash
 cargo build -p dora-runtime --release
 cargo build -p dora-coordinator --examples --release
-cargo build --manifest-path ../runtime/examples/example-operator/Cargo.toml --release
+cargo build --manifest-path ../examples/example-operator/Cargo.toml --release
 ```
 - Compile the C example operator through:
 ```bash
-cd ../runtime/examples/c-operator
-cp ../../../apis/c/operator/api.h .
+cd ../../examples/c-operator
+cp ../../apis/c/operator/api.h .
 clang -c operator.c
 clang -shared -v operator.o -o operator.so
 ```

--- a/binaries/coordinator/examples/mini-dataflow.yml
+++ b/binaries/coordinator/examples/mini-dataflow.yml
@@ -63,5 +63,6 @@ nodes:
       python: ../runtime/examples/python-operator/op.py
       inputs:
         time: timer/time
+        dora_time: dora/timer/secs/5
       outputs:
         - counter

--- a/binaries/coordinator/examples/mini-dataflow.yml
+++ b/binaries/coordinator/examples/mini-dataflow.yml
@@ -38,20 +38,20 @@ nodes:
   - id: runtime-node
     operators:
       - id: op-1
-        shared-library: ../target/release/libexample_operator.so
+        shared-library: ../../target/release/libexample_operator.so
         inputs:
           random: random/number
           time: timer/time
         outputs:
           - timestamped-random
       - id: op-2
-        shared-library: ../runtime/examples/c-operator/operator.so
+        shared-library: ../../examples/c-operator/operator.so
         inputs:
           time: timer/time
         outputs:
           - counter
       - id: op-3
-        python: ../runtime/examples/python-operator/op.py
+        python: ../../examples/python-operator/op.py
         inputs:
           time: timer/time
           test: python-operator/counter
@@ -60,9 +60,9 @@ nodes:
 
   - id: python-operator
     operator:
-      python: ../runtime/examples/python-operator/op.py
+      python: ../../examples/python-operator/op.py
       inputs:
         time: timer/time
-        dora_time: dora/timer/secs/5
+        dora_time: dora/timer/millis/500
       outputs:
         - counter

--- a/binaries/runtime/src/main.rs
+++ b/binaries/runtime/src/main.rs
@@ -211,16 +211,15 @@ async fn subscribe_operator<'a>(
                 data,
             })
             .map(SubscribeEvent::Input)
-            .take_until(finished.clone())
-            .chain(stream::once(async {
-                SubscribeEvent::InputsStopped {
-                    target_operator: operator.id.clone(),
-                }
-            }));
+            .take_until(finished.clone());
         streams.push(stream);
     }
 
-    Ok(streams.merge())
+    Ok(streams.merge().chain(stream::once(async {
+        SubscribeEvent::InputsStopped {
+            target_operator: operator.id.clone(),
+        }
+    })))
 }
 
 async fn publish(

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -8,6 +8,7 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     path::PathBuf,
 };
+pub use visualize::collect_dora_timers;
 
 mod visualize;
 

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -43,7 +43,10 @@ impl Descriptor {
                 NodeKind::Custom(node) => node.run_config.inputs.values_mut().collect(),
                 NodeKind::Operator(operator) => operator.config.inputs.values_mut().collect(),
             };
-            for mapping in input_mappings {
+            for mapping in input_mappings.into_iter().filter_map(|m| match m {
+                InputMapping::Timer { .. } => None,
+                InputMapping::User(m) => Some(m),
+            }) {
                 if let Some(op_name) = single_operator_nodes.get(&mapping.source).copied() {
                     if mapping.operator.is_none() {
                         mapping.operator = Some(op_name.to_owned());

--- a/libraries/core/src/descriptor/visualize.rs
+++ b/libraries/core/src/descriptor/visualize.rs
@@ -15,19 +15,7 @@ pub fn visualize_nodes(nodes: &[ResolvedNode]) -> String {
         all_nodes.insert(&node.id, node);
     }
 
-    let mut dora_timers = BTreeSet::new();
-    for node in nodes {
-        match &node.kind {
-            CoreNodeKind::Runtime(node) => {
-                for operator in &node.operators {
-                    collect_dora_nodes(operator.config.inputs.values(), &mut dora_timers);
-                }
-            }
-            CoreNodeKind::Custom(node) => {
-                collect_dora_nodes(node.run_config.inputs.values(), &mut dora_timers);
-            }
-        }
-    }
+    let dora_timers = collect_dora_timers(nodes);
     if !dora_timers.is_empty() {
         writeln!(flowchart, "subgraph ___dora___ [dora]").unwrap();
         writeln!(flowchart, "  subgraph ___timer_timer___ [timer]").unwrap();
@@ -44,6 +32,23 @@ pub fn visualize_nodes(nodes: &[ResolvedNode]) -> String {
     }
 
     flowchart
+}
+
+pub fn collect_dora_timers(nodes: &[ResolvedNode]) -> BTreeSet<Duration> {
+    let mut dora_timers = BTreeSet::new();
+    for node in nodes {
+        match &node.kind {
+            CoreNodeKind::Runtime(node) => {
+                for operator in &node.operators {
+                    collect_dora_nodes(operator.config.inputs.values(), &mut dora_timers);
+                }
+            }
+            CoreNodeKind::Custom(node) => {
+                collect_dora_nodes(node.run_config.inputs.values(), &mut dora_timers);
+            }
+        }
+    }
+    dora_timers
 }
 
 fn collect_dora_nodes(


### PR DESCRIPTION
The periodic timer inputs allows operators to periodically produce values. To use the new input types, operators specify an input that maps to `dora/timer/secs/X` where `X` is the number of seconds between ticks. In addition to `secs`, the runtime also support `millis` for millisecond intervals.

The new dora timer nodes are visualized in the following way:

```mermaid
flowchart TB
  node_1[\node_1/]
  logger[/logger\]
subgraph python-operator [node]
  python-operator/op[op]
end
subgraph ___dora___ [dora]
  subgraph ___timer_timer___ [timer]
    dora/timer/secs/5[\secs/5/]
    dora/timer/millis/100[\millis/100/]
  end
end 
  python-operator/op -- counter as test --> logger
  dora/timer/secs/5 -- tick --> logger
  dora/timer/millis/100 -- dora_time --> python-operator/op
  node_1 -- data --> python-operator/op

```

TODO:

- [x] Implement parsing of new `dora/timer/...` inputs
- [x] Visualize the new timer inputs
- [x] Spawn a thread to send the timer tick messages