### PR TITLE
Allow operators to stop themselves

### DIFF
--- a/apis/rust/operator/src/lib.rs
+++ b/apis/rust/operator/src/lib.rs
@@ -14,7 +14,13 @@ pub trait DoraOperator: Default {
         id: &str,
         data: &[u8],
         output_sender: &mut DoraOutputSender,
-    ) -> Result<(), ()>;
+    ) -> Result<DoraStatus, ()>;
+}
+
+#[repr(isize)]
+pub enum DoraStatus {
+    Continue = 0,
+    Stop = 1,
 }
 
 pub struct DoraOutputSender {

--- a/apis/rust/operator/src/raw.rs
+++ b/apis/rust/operator/src/raw.rs
@@ -45,7 +45,7 @@ pub unsafe fn dora_on_input<O: DoraOperator>(
     let operator: &mut O = unsafe { &mut *operator_context.cast() };
 
     match operator.on_input(id, data, &mut output_sender) {
-        Ok(()) => 0,
+        Ok(status) => status as isize,
         Err(_) => -1,
     }
 }

--- a/binaries/coordinator/examples/mini-dataflow.yml
+++ b/binaries/coordinator/examples/mini-dataflow.yml
@@ -60,9 +60,9 @@ nodes:
 
   - id: python-operator
     operator:
-      python: ../../examples/python-operator/op.py
+      python: ../../examples/python-operator/op2.py
       inputs:
         time: timer/time
-        dora_time: dora/timer/millis/500
+        dora_time: dora/timer/millis/50
       outputs:
         - counter

--- a/binaries/coordinator/examples/nodes/rust/rate_limit.rs
+++ b/binaries/coordinator/examples/nodes/rust/rate_limit.rs
@@ -46,5 +46,7 @@ async fn main() -> eyre::Result<()> {
         }
     }
 
+    println!("rate limit finished");
+
     Ok(())
 }

--- a/binaries/coordinator/examples/nodes/rust/sink_logger.rs
+++ b/binaries/coordinator/examples/nodes/rust/sink_logger.rs
@@ -12,7 +12,7 @@ async fn main() -> eyre::Result<()> {
     let mut last_timestamp = None;
 
     loop {
-        let timeout = Duration::from_secs(2);
+        let timeout = Duration::from_secs(5);
         let input = match tokio::time::timeout(timeout, inputs.next()).await {
             Ok(Some(input)) => input,
             Ok(None) => break,

--- a/binaries/coordinator/src/main.rs
+++ b/binaries/coordinator/src/main.rs
@@ -100,11 +100,10 @@ async fn run_dataflow(dataflow_path: PathBuf, runtime: &Path) -> eyre::Result<()
     }
 
     for interval in dora_timers {
-        let communication = communication.clone();
-        let task = tokio::spawn(async move {
-            let communication = communication::init(&communication)
-                .await
-                .wrap_err("failed to init communication layer")?;
+        let communication = communication::init(&communication)
+            .await
+            .wrap_err("failed to init communication layer")?;
+        tokio::spawn(async move {
             let topic = {
                 let duration = format_duration(interval);
                 format!("dora/timer/{duration}")
@@ -112,13 +111,9 @@ async fn run_dataflow(dataflow_path: PathBuf, runtime: &Path) -> eyre::Result<()
             let mut stream = IntervalStream::new(tokio::time::interval(interval));
             while let Some(_) = stream.next().await {
                 let publish = communication.publish(&topic, &[]);
-                publish
-                    .await
-                    .wrap_err("failed to publish timer tick message")?;
+                publish.await.expect("failed to publish timer tick message");
             }
-            Ok(())
         });
-        tasks.push(task);
     }
 
     while let Some(task_result) = tasks.next().await {

--- a/binaries/runtime/src/operator/python.rs
+++ b/binaries/runtime/src/operator/python.rs
@@ -79,9 +79,8 @@ pub fn spawn(
             let status: i32 = Python::with_gil(|py| status_val.extract(py))
                 .wrap_err("on_input has invalid return value")?;
             match status {
-                0 => {}                                    // ok
-                1 => break,                                // stop
-                -1 => bail!("on_input returned an error"), // err
+                0 => {}     // ok
+                1 => break, // stop
                 other => bail!("on_input returned invalid status {other}"),
             }
         }

--- a/examples/example-operator/src/lib.rs
+++ b/examples/example-operator/src/lib.rs
@@ -1,6 +1,6 @@
 #![warn(unsafe_op_in_unsafe_fn)]
 
-use dora_operator_api::{register_operator, DoraOperator, DoraOutputSender};
+use dora_operator_api::{register_operator, DoraOperator, DoraOutputSender, DoraStatus};
 
 register_operator!(ExampleOperator);
 
@@ -15,7 +15,7 @@ impl DoraOperator for ExampleOperator {
         id: &str,
         data: &[u8],
         output_sender: &mut DoraOutputSender,
-    ) -> Result<(), ()> {
+    ) -> Result<DoraStatus, ()> {
         match id {
             "time" => {
                 let parsed = std::str::from_utf8(data).map_err(|_| ())?;
@@ -35,6 +35,6 @@ impl DoraOperator for ExampleOperator {
             }
             other => eprintln!("ignoring unexpected input {other}"),
         }
-        Ok(())
+        Ok(DoraStatus::Continue)
     }
 }

--- a/examples/python-operator/op.py
+++ b/examples/python-operator/op.py
@@ -2,7 +2,7 @@ from typing import Callable
 from enum import Enum
 
 class DoraStatus(Enum):
-    OK = 0
+    CONTINUE = 0
     ERR = -1
     STOP = 1
 

--- a/examples/python-operator/op.py
+++ b/examples/python-operator/op.py
@@ -3,7 +3,6 @@ from enum import Enum
 
 class DoraStatus(Enum):
     CONTINUE = 0
-    ERR = -1
     STOP = 1
 
 class Operator:

--- a/examples/python-operator/op2.py
+++ b/examples/python-operator/op2.py
@@ -3,7 +3,6 @@ from enum import Enum
 
 class DoraStatus(Enum):
     OK = 0
-    ERR = -1
     STOP = 1
 
 class Operator:

--- a/examples/python-operator/op2.py
+++ b/examples/python-operator/op2.py
@@ -34,4 +34,7 @@ class Operator:
         send_output("counter", (self.counter % 256).to_bytes(1, "little"))
         self.counter = self.counter + 1
 
-        return DoraStatus.OK
+        if self.counter > 500:
+            return DoraStatus.STOP
+        else:
+            return DoraStatus.OK


### PR DESCRIPTION
This is useful for operators that take dora timers as inputs because these timers will run indefinitely. Such operators have now the choice to stop themselves by returning a special status value from `on_input`.

TODO:
- [x] rebase as soon as #51 is merged
- [ ] we probably want to make the Python interface a bit nicer?