### PR TITLE
Python Node API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,6 +697,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "dora-node-api-python"
+version = "0.1.0"
+dependencies = [
+ "dora-node-api",
+ "pyo3",
+]
+
+[[package]]
 name = "dora-operator-api"
 version = "0.1.0"
 dependencies = [
@@ -748,7 +756,6 @@ version = "0.1.0"
 dependencies = [
  "opentelemetry",
  "opentelemetry-jaeger",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "apis/rust/operator",
   "apis/rust/operator/macros",
   "apis/python/binding",
+  "apis/python/node",
   "binaries/coordinator",
   "binaries/runtime",
   "libraries/extensions/message",

--- a/apis/python/node/Cargo.toml
+++ b/apis/python/node/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "dora-node-api-python"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+dora-node-api = { path = "../../rust/node" }
+pyo3 = "0.16"

--- a/apis/python/node/Cargo.toml
+++ b/apis/python/node/Cargo.toml
@@ -8,3 +8,13 @@ edition = "2021"
 [dependencies]
 dora-node-api = { path = "../../rust/node" }
 pyo3 = "0.16"
+eyre = "0.6"
+pollster = "0.2"
+futures = "0.3.21"
+tokio = { version = "1.17.0", features = ["rt", "sync", "macros"] }
+serde_yaml = "0.8.23"
+
+
+[lib]
+name = "dora"
+crate-type = ["cdylib"]

--- a/apis/python/node/README.md
+++ b/apis/python/node/README.md
@@ -1,0 +1,12 @@
+This crate corresponds to the Node API for Dora.
+
+## Building
+
+To build the Python module for development:
+
+````bash
+python3 -m venv .env
+source .env/bin/activate
+pip install maturin
+maturin develop
+````

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -1,15 +1,93 @@
-use dora_node_api::DoraNode;
+use dora_node_api::config::DataId;
+use dora_node_api::{DoraNode, Input};
+use eyre::Context;
+use futures::StreamExt;
 use pyo3::prelude::*;
-
+use pyo3::types::PyBytes;
+use std::sync::Arc;
+use std::thread;
+use tokio::sync::mpsc;
+use tokio::sync::mpsc::{Receiver, Sender};
 #[pyclass]
-#[repr(transparent)]
+// #[repr(transparent)]
 pub struct PyDoraNode {
-    pub node: DoraNode,
+    // pub node: DoraNode,
+    pub rx_input: Receiver<Input>,
+    pub tx_output: Sender<(String, Vec<u8>)>,
+}
+
+pub struct PyInput(Input);
+
+impl IntoPy<PyObject> for PyInput {
+    fn into_py(self, py: Python) -> PyObject {
+        (self.0.id.to_string(), PyBytes::new(py, &self.0.data)).into_py(py)
+    }
+}
+
+#[pymethods]
+impl PyDoraNode {
+    #[staticmethod]
+    pub fn init_from_env() -> Self {
+        let (tx_input, rx_input) = mpsc::channel(10);
+        let (tx_output, mut rx_output) = mpsc::channel::<(String, Vec<u8>)>(10);
+
+        // Dispatching a tokio threadpool enables us to conveniently use Dora Future stream
+        // through tokio channel.
+        // It would have been difficult to expose the FutureStream of Dora directly.
+        thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_multi_thread().build().unwrap();
+            rt.block_on(async move {
+                let node = Arc::new(DoraNode::init_from_env().await.unwrap());
+                let _node = node.clone();
+                let receive_handle = tokio::spawn(async move {
+                    let mut inputs = _node.inputs().await.unwrap();
+                    loop {
+                        if let Some(input) = inputs.next().await {
+                            tx_input.send(input).await.unwrap()
+                        };
+                    }
+                });
+                let send_handle = tokio::spawn(async move {
+                    loop {
+                        if let Some((output_str, data)) = rx_output.recv().await {
+                            let output_id = DataId::from(output_str);
+                            node.send_output(&output_id, data.as_slice()).await.unwrap()
+                        };
+                    }
+                });
+                let (_, _) = tokio::join!(receive_handle, send_handle);
+            });
+        });
+
+        PyDoraNode {
+            rx_input,
+            tx_output,
+        }
+    }
+
+    pub fn next(&mut self) -> PyResult<Option<PyInput>> {
+        self.__next__()
+    }
+
+    pub fn __next__(&mut self) -> PyResult<Option<PyInput>> {
+        if let Some(input) = self.rx_input.blocking_recv() {
+            Ok(Some(PyInput(input)))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn send_output(&self, output_str: String, data: Vec<u8>) -> () {
+        self.tx_output
+            .blocking_send((output_str, data))
+            .wrap_err("Could not send output")
+            .unwrap()
+    }
 }
 
 /// This module is implemented in Rust.
 #[pymodule]
-fn wonnx(_py: Python, m: &PyModule) -> PyResult<()> {
+fn dora(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyDoraNode>().unwrap();
     Ok(())
 }

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -1,0 +1,15 @@
+use dora_node_api::DoraNode;
+use pyo3::prelude::*;
+
+#[pyclass]
+#[repr(transparent)]
+pub struct PyDoraNode {
+    pub node: DoraNode,
+}
+
+/// This module is implemented in Rust.
+#[pymodule]
+fn wonnx(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_class::<PyDoraNode>().unwrap();
+    Ok(())
+}

--- a/apis/rust/node/src/communication.rs
+++ b/apis/rust/node/src/communication.rs
@@ -12,7 +12,7 @@ use crate::{config::CommunicationConfig, BoxError};
 
 pub async fn init(
     communication_config: &CommunicationConfig,
-) -> eyre::Result<Box<dyn CommunicationLayer>> {
+) -> eyre::Result<Box<dyn CommunicationLayer + Send>> {
     match communication_config {
         CommunicationConfig::Zenoh {
             config: zenoh_config,

--- a/apis/rust/node/src/communication.rs
+++ b/apis/rust/node/src/communication.rs
@@ -12,7 +12,7 @@ use crate::{config::CommunicationConfig, BoxError};
 
 pub async fn init(
     communication_config: &CommunicationConfig,
-) -> eyre::Result<Box<dyn CommunicationLayer + Send>> {
+) -> eyre::Result<Box<dyn CommunicationLayer>> {
     match communication_config {
         CommunicationConfig::Zenoh {
             config: zenoh_config,
@@ -32,11 +32,11 @@ pub async fn init(
 }
 
 #[async_trait]
-pub trait CommunicationLayer {
+pub trait CommunicationLayer: Send + Sync {
     async fn subscribe<'a>(
         &'a self,
         topic: &str,
-    ) -> Result<Pin<Box<dyn futures::Stream<Item = Vec<u8>> + 'a>>, BoxError>;
+    ) -> Result<Pin<Box<dyn futures::Stream<Item = Vec<u8>> + Send + 'a>>, BoxError>;
 
     async fn publish(&self, topic: &str, data: &[u8]) -> Result<(), BoxError>;
 
@@ -61,12 +61,12 @@ impl CommunicationLayer for ZenohCommunicationLayer {
     async fn subscribe<'a>(
         &'a self,
         topic: &str,
-    ) -> Result<Pin<Box<dyn futures::Stream<Item = Vec<u8>> + 'a>>, BoxError> {
+    ) -> Result<Pin<Box<dyn futures::Stream<Item = Vec<u8>> + Send + 'a>>, BoxError> {
         zenoh::Session::subscribe(&self.zenoh, self.prefixed(topic))
             .reliable()
             .await
             .map(|s| {
-                let trait_object: Pin<Box<dyn futures::Stream<Item = Vec<u8>> + 'a>> =
+                let trait_object: Pin<Box<dyn futures::Stream<Item = Vec<u8>> + Send + 'a>> =
                     Box::pin(s.map(|s| s.value.payload.contiguous().into_owned()));
                 trait_object
             })

--- a/apis/rust/node/src/lib.rs
+++ b/apis/rust/node/src/lib.rs
@@ -14,7 +14,7 @@ pub const STOP_TOPIC: &str = "__dora_rs_internal__operator_stopped";
 pub struct DoraNode {
     id: NodeId,
     node_config: NodeRunConfig,
-    communication: Box<dyn CommunicationLayer + Send>,
+    communication: Box<dyn CommunicationLayer>,
 }
 
 impl DoraNode {

--- a/apis/rust/node/src/lib.rs
+++ b/apis/rust/node/src/lib.rs
@@ -14,7 +14,7 @@ pub const STOP_TOPIC: &str = "__dora_rs_internal__operator_stopped";
 pub struct DoraNode {
     id: NodeId,
     node_config: NodeRunConfig,
-    communication: Box<dyn CommunicationLayer>,
+    communication: Box<dyn CommunicationLayer + Send>,
 }
 
 impl DoraNode {
@@ -138,6 +138,7 @@ impl Drop for DoraNode {
     }
 }
 
+#[derive(Debug)]
 pub struct Input {
     pub id: DataId,
     pub data: Vec<u8>,


### PR DESCRIPTION
## Description of the API

The Python API will consist of two principal methods: `next` and `send_output`. Those methods will be connected to a `tokio` runtime through channels.

## Problem 

The Python Node API requires an async threadpool as the communication Layer defined by the Middleware Layer returns an async Future stream.

## Solution

I solve this issue by adding a `tokio` runtime on a separate thread that is connected with two channels. One for sending data and one for receiving data.

Those channels are then exposed synchronously to Python. This should not be cause for concern as channels are really fast.

## Alternatives 

Looking at Zenoh Python client, they are heavily using `pyo3-asyncio` implementation of futures to pass Rust futures into Python.

This can be a solution as well, but, from previous experiments, I'm concerned about the performance of this solution. I have experienced that putting futures from Rust into the `asyncio` queue to be slow.

I'm concerned also about mixing `async` and `sync` code in Python, as it might be blocking. This might requires 2 threadpools in Python. This might seem a heavy overhead for some operations.