### PR TITLE
Add context argument for inputs

### DIFF
--- a/apis/rust/node/src/lib.rs
+++ b/apis/rust/node/src/lib.rs
@@ -62,6 +62,9 @@ impl DoraNode {
             streams.push(sub.map(|data| Input {
                 id: input.clone(),
                 data,
+                input_context: DoraInputContext {
+                    open_telementry: "TODO dummy".into(),
+                },
             }))
         }
 
@@ -140,6 +143,12 @@ impl Drop for DoraNode {
 pub struct Input {
     pub id: DataId,
     pub data: Vec<u8>,
+    pub input_context: DoraInputContext,
+}
+
+#[derive(Debug)]
+pub struct DoraInputContext {
+    pub open_telementry: String,
 }
 
 pub struct BoxError(Box<dyn std::error::Error + Send + Sync + 'static>);

--- a/binaries/runtime/build.rs
+++ b/binaries/runtime/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rustc-link-arg-bins=-export-dynamic");
+}

--- a/binaries/runtime/src/main.rs
+++ b/binaries/runtime/src/main.rs
@@ -5,7 +5,7 @@ use dora_node_api::{
     self,
     communication::{self, CommunicationLayer},
     config::{CommunicationConfig, DataId, InputMapping, NodeId, OperatorId, UserInputMapping},
-    STOP_TOPIC,
+    DoraInputContext, STOP_TOPIC,
 };
 use eyre::{bail, eyre, Context};
 use futures::{
@@ -87,8 +87,14 @@ async fn main() -> eyre::Result<()> {
                         }
                     };
 
+                    // let deserialized = ...;
+                    let data = input.data; // TODO replace with `deserialized.data`
+                    let context = DoraInputContext {
+                        open_telementry: "dummy context".into(),
+                    }; // TODO replace with `deserialized.context`
+
                     operator
-                        .handle_input(input.id.clone(), input.data)
+                        .handle_input(input.id.clone(), data, context)
                         .wrap_err_with(|| {
                             format!(
                                 "operator {} failed to handle input {}",

--- a/examples/c++-dataflow/operator-rust-api/src/lib.rs
+++ b/examples/c++-dataflow/operator-rust-api/src/lib.rs
@@ -1,6 +1,6 @@
 #![warn(unsafe_op_in_unsafe_fn)]
 
-use dora_operator_api::{self, register_operator, DoraOperator, DoraOutputSender, DoraStatus};
+use dora_operator_api::{self, register_operator, DoraContext, DoraOperator, DoraStatus};
 
 #[cxx::bridge]
 #[allow(unsafe_op_in_unsafe_fn)]
@@ -31,10 +31,10 @@ mod ffi {
     }
 }
 
-pub struct OutputSender<'a>(&'a mut DoraOutputSender);
+pub struct OutputSender<'a>(&'a mut DoraContext);
 
 fn send_output(sender: &mut OutputSender, id: &str, data: &[u8]) -> i32 {
-    match sender.0.send(id, data) {
+    match sender.0.send_output(id, data) {
         Ok(()) => 0,
         Err(err_code) => err_code.try_into().unwrap(),
     }
@@ -59,7 +59,7 @@ impl DoraOperator for OperatorWrapper {
         &mut self,
         id: &str,
         data: &[u8],
-        output_sender: &mut DoraOutputSender,
+        output_sender: &mut DoraContext,
     ) -> Result<DoraStatus, ()> {
         let operator = self.operator.as_mut().unwrap();
         let mut output_sender = OutputSender(output_sender);

--- a/examples/rust-dataflow/node/src/main.rs
+++ b/examples/rust-dataflow/node/src/main.rs
@@ -23,6 +23,7 @@ async fn main() -> eyre::Result<()> {
             "tick" => {
                 let random: u64 = rand::random();
                 operator.send_output(&output, &random.to_le_bytes()).await?;
+                dbg!(input.input_context.open_telementry);
             }
             other => eprintln!("Ignoring unexpected input `{other}`"),
         }

--- a/examples/rust-dataflow/operator/src/lib.rs
+++ b/examples/rust-dataflow/operator/src/lib.rs
@@ -1,6 +1,6 @@
 #![warn(unsafe_op_in_unsafe_fn)]
 
-use dora_operator_api::{register_operator, DoraOperator, DoraOutputSender, DoraStatus};
+use dora_operator_api::{register_operator, DoraContext, DoraOperator, DoraStatus};
 use std::time::{Duration, Instant};
 
 register_operator!(ExampleOperator);
@@ -16,11 +16,12 @@ impl DoraOperator for ExampleOperator {
         &mut self,
         id: &str,
         data: &[u8],
-        output_sender: &mut DoraOutputSender,
+        dora_context: &mut DoraContext,
     ) -> Result<DoraStatus, ()> {
         match id {
             "tick" => {
                 self.ticks += 1;
+                dbg!(dora_context.opentelemetry_context());
             }
             "random" => {
                 let parsed = {
@@ -31,8 +32,8 @@ impl DoraOperator for ExampleOperator {
                     "operator received random value {parsed} after {} ticks",
                     self.ticks
                 );
-                output_sender
-                    .send("status", output.as_bytes())
+                dora_context
+                    .send_output("status", output.as_bytes())
                     .map_err(|_| ())?;
                 self.last_random_at = Some(Instant::now());
             }


### PR DESCRIPTION
Allows passing additional context with inputs, e.g., an OpenTelementry context string.