### PR TITLE
Make dora and its examples work on Windows and macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,10 @@ on:
 jobs:
   test:
     name: "Test"
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2
       - name: Install Cap'n Proto

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,6 @@ jobs:
 
       - name: "Build examples"
         uses: actions-rs/cargo@v1
-        env:
-          RUSTFLAGS: "--print link-args"
         timeout-minutes: 30
         with:
           command: build
@@ -90,24 +88,18 @@ jobs:
 
       - name: "Rust Dataflow example"
         uses: actions-rs/cargo@v1
-        env:
-          RUSTFLAGS: "--print link-args"
         timeout-minutes: 30
         with:
           command: run
           args: --example rust-dataflow
       - name: "C Dataflow example"
         uses: actions-rs/cargo@v1
-        env:
-          RUSTFLAGS: "--print link-args"
         timeout-minutes: 15
         with:
           command: run
           args: --example c-dataflow
       - name: "C++ Dataflow example"
         uses: actions-rs/cargo@v1
-        env:
-          RUSTFLAGS: "--print link-args"
         timeout-minutes: 15
         with:
           command: run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
         uses: actions-rs/cargo@v1
         env:
           RUSTFLAGS: "--print link-args"
+        timeout-minutes: 30
         with:
           command: run
           args: --example rust-dataflow
@@ -90,6 +91,7 @@ jobs:
         uses: actions-rs/cargo@v1
         env:
           RUSTFLAGS: "--print link-args"
+        timeout-minutes: 15
         with:
           command: run
           args: --example c-dataflow
@@ -97,6 +99,7 @@ jobs:
         uses: actions-rs/cargo@v1
         env:
           RUSTFLAGS: "--print link-args"
+        timeout-minutes: 15
         with:
           command: run
           args: --example cxx-dataflow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,13 +52,32 @@ jobs:
 
   examples:
     name: "Examples"
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2
-      - name: Install Cap'n Proto
+
+      - name: Install Cap'n Proto (Linux)
+        if: runner.os == 'Linux'
         run: |
           export DEBIAN_FRONTEND=noninteractive
           sudo apt-get install -y capnproto libcapnp-dev
+      - name: Install Cap'n Proto (macOS)
+        if: runner.os == 'macOS'
+        run: brew install capnp
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+          HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK: 1
+          HOMEBREW_NO_INSTALL_CLEANUP: 1
+      - name: Install Cap'n Proto (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install capnproto
+          echo "$Env:Programfiles\capnproto" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
       - name: "Rust Dataflow example"
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,16 +81,22 @@ jobs:
 
       - name: "Rust Dataflow example"
         uses: actions-rs/cargo@v1
+        env:
+          RUSTFLAGS: "--print link-args"
         with:
           command: run
           args: --example rust-dataflow -vv
       - name: "C Dataflow example"
         uses: actions-rs/cargo@v1
+        env:
+          RUSTFLAGS: "--print link-args"
         with:
           command: run
           args: --example c-dataflow -vv
       - name: "C++ Dataflow example"
         uses: actions-rs/cargo@v1
+        env:
+          RUSTFLAGS: "--print link-args"
         with:
           command: run
           args: --example cxx-dataflow -vv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,15 @@ jobs:
           choco install capnproto
           echo "$Env:Programfiles\capnproto" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
+      - name: "Build examples"
+        uses: actions-rs/cargo@v1
+        env:
+          RUSTFLAGS: "--print link-args"
+        timeout-minutes: 30
+        with:
+          command: build
+          args: --examples
+
       - name: "Rust Dataflow example"
         uses: actions-rs/cargo@v1
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,17 +83,17 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: run
-          args: --example rust-dataflow
+          args: --example rust-dataflow -vv
       - name: "C Dataflow example"
         uses: actions-rs/cargo@v1
         with:
           command: run
-          args: --example c-dataflow
+          args: --example c-dataflow -vv
       - name: "C++ Dataflow example"
         uses: actions-rs/cargo@v1
         with:
           command: run
-          args: --example cxx-dataflow
+          args: --example cxx-dataflow -vv
 
   clippy:
     name: "Clippy"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,13 @@ jobs:
           HOMEBREW_NO_AUTO_UPDATE: 1
           HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK: 1
           HOMEBREW_NO_INSTALL_CLEANUP: 1
+      - name: Install Cap'n Proto (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install capnproto
+          echo "$Env:Programfiles\capnproto" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
       - name: "Check"
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,18 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2
-      - name: Install Cap'n Proto
+      - name: Install Cap'n Proto (Linux)
+        if: runner.os == 'Linux'
         run: |
           export DEBIAN_FRONTEND=noninteractive
           sudo apt-get install -y capnproto libcapnp-dev
+      - name: Install Cap'n Proto (macOS)
+        if: runner.os == 'macOS'
+        run: brew install capnp
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+          HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK: 1
+          HOMEBREW_NO_INSTALL_CLEANUP: 1
       - name: "Check"
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,21 +85,21 @@ jobs:
           RUSTFLAGS: "--print link-args"
         with:
           command: run
-          args: --example rust-dataflow -vv
+          args: --example rust-dataflow
       - name: "C Dataflow example"
         uses: actions-rs/cargo@v1
         env:
           RUSTFLAGS: "--print link-args"
         with:
           command: run
-          args: --example c-dataflow -vv
+          args: --example c-dataflow
       - name: "C++ Dataflow example"
         uses: actions-rs/cargo@v1
         env:
           RUSTFLAGS: "--print link-args"
         with:
           command: run
-          args: --example cxx-dataflow -vv
+          args: --example cxx-dataflow
 
   clippy:
     name: "Clippy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,6 +742,7 @@ name = "dora-examples"
 version = "0.0.0"
 dependencies = [
  "dora-coordinator",
+ "dunce",
  "eyre",
  "tokio",
 ]
@@ -852,6 +853,12 @@ dependencies = [
  "opentelemetry-jaeger",
  "tokio",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
 
 [[package]]
 name = "either"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ license = "Apache-2.0"
 eyre = "0.6.8"
 tokio = "1.20.1"
 dora-coordinator = { path = "binaries/coordinator" }
+dunce = "1.0.2"
 
 [[example]]
 name = "c-dataflow"

--- a/apis/c/operator/operator_api.h
+++ b/apis/c/operator/operator_api.h
@@ -1,10 +1,17 @@
 #include <stddef.h>
 
-int dora_init_operator(void **operator_context);
+#ifdef _WIN32
+#define EXPORT __declspec(dllexport)
+#endif
+#ifdef __unix__
+#define EXPORT
+#endif
 
-void dora_drop_operator(void *operator_context);
+EXPORT int dora_init_operator(void **operator_context);
 
-int dora_on_input(
+EXPORT void dora_drop_operator(void *operator_context);
+
+EXPORT int dora_on_input(
     const char *id_start,
     size_t id_len,
     const char *data_start,

--- a/apis/c/operator/operator_api.h
+++ b/apis/c/operator/operator_api.h
@@ -2,8 +2,7 @@
 
 #ifdef _WIN32
 #define EXPORT __declspec(dllexport)
-#endif
-#ifdef __unix__
+#else
 #define EXPORT
 #endif
 

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -5,7 +5,10 @@ use dora_node_api::{
 };
 use eyre::{bail, eyre, WrapErr};
 use futures::{stream::FuturesUnordered, StreamExt};
-use std::path::{Path, PathBuf};
+use std::{
+    env::consts::EXE_EXTENSION,
+    path::{Path, PathBuf},
+};
 use tokio_stream::wrappers::IntervalStream;
 
 #[derive(Debug, Clone, clap::Parser)]
@@ -51,6 +54,7 @@ pub async fn run(command: Command) -> eyre::Result<()> {
 }
 
 async fn run_dataflow(dataflow_path: PathBuf, runtime: &Path) -> eyre::Result<()> {
+    let runtime = runtime.with_extension(EXE_EXTENSION);
     let descriptor = read_descriptor(&dataflow_path).await.wrap_err_with(|| {
         format!(
             "failed to read dataflow descriptor at {}",
@@ -89,7 +93,7 @@ async fn run_dataflow(dataflow_path: PathBuf, runtime: &Path) -> eyre::Result<()
             descriptor::CoreNodeKind::Runtime(node) => {
                 if !node.operators.is_empty() {
                     let result =
-                        spawn_runtime_node(runtime, node_id.clone(), &node, &communication)
+                        spawn_runtime_node(&runtime, node_id.clone(), &node, &communication)
                             .wrap_err_with(|| format!("failed to spawn runtime node {node_id}"))?;
                     tasks.push(result);
                 }

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -138,7 +138,8 @@ fn spawn_custom_node(
             args.next()
                 .ok_or_else(|| eyre!("`run` field must not be empty"))?,
         );
-        raw.canonicalize()
+        let path = raw.with_extension(EXE_EXTENSION);
+        path.canonicalize()
             .wrap_err_with(|| format!("no node exists at `{}`", raw.display()))?
     };
 

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -138,7 +138,11 @@ fn spawn_custom_node(
             args.next()
                 .ok_or_else(|| eyre!("`run` field must not be empty"))?,
         );
-        let path = raw.with_extension(EXE_EXTENSION);
+        let path = if raw.extension().is_none() {
+            raw.with_extension(EXE_EXTENSION)
+        } else {
+            raw.to_owned()
+        };
         path.canonicalize()
             .wrap_err_with(|| format!("no node exists at `{}`", path.display()))?
     };

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -140,7 +140,7 @@ fn spawn_custom_node(
         );
         let path = raw.with_extension(EXE_EXTENSION);
         path.canonicalize()
-            .wrap_err_with(|| format!("no node exists at `{}`", raw.display()))?
+            .wrap_err_with(|| format!("no node exists at `{}`", path.display()))?
     };
 
     let mut command = tokio::process::Command::new(cmd);

--- a/binaries/runtime/src/operator/mod.rs
+++ b/binaries/runtime/src/operator/mod.rs
@@ -24,7 +24,7 @@ impl Operator {
             OperatorSource::SharedLibrary(path) => {
                 shared_lib::spawn(path, events_tx, operator_rx).wrap_err_with(|| {
                     format!(
-                        "failed ot spawn shared library operator for {}",
+                        "failed to spawn shared library operator for {}",
                         operator_definition.id
                     )
                 })?;
@@ -32,7 +32,7 @@ impl Operator {
             OperatorSource::Python(path) => {
                 python::spawn(path, events_tx, operator_rx).wrap_err_with(|| {
                     format!(
-                        "failed ot spawn Python operator for {}",
+                        "failed to spawn Python operator for {}",
                         operator_definition.id
                     )
                 })?;

--- a/docs/src/dataflow-config.md
+++ b/docs/src/dataflow-config.md
@@ -79,7 +79,7 @@ Operators are defined through the following format:
     - output_1
   
   ## ONE OF:
-  shared_library: "path/to/shared_lib.so"
+  shared_library: "path/to/shared_lib" # file extension and `lib` prefix are added automatically
   python: "path/to/python_file.py"
   wasm: "path/to/wasm_file.wasm"
 ```

--- a/examples/c++-dataflow/README.md
+++ b/examples/c++-dataflow/README.md
@@ -3,3 +3,55 @@
 This example shows how to create dora operators and custom nodes with C++.
 
 Dora does not provide a C++ API yet, but we can create adapters for either the C or Rust API. The `operator-rust-api` and `node-rust-api` folders implement an example operator and node based on dora's Rust API, using the `cxx` crate for bridging. The `operator-c-api` and `node-c-api` show how to create operators and nodes based on dora's C API. Both approaches work, so you can choose the API that fits your application better.
+
+## Compile and Run
+
+To try it out, you can use the [`run.rs`](./run.rs) binary. It performs all required build steps and then starts the dataflow. Use the following command to run it: `cargo run --example cxx-dataflow`.
+
+For a manual build, follow these steps:
+
+- Create a `build` folder in this directory (i.e., next to the `node.c` file)
+- Build the `cxx-dataflow-example-node-rust-api` and `cxx-dataflow-example-operator-rust-api` crates:
+  ```
+  cargo build -p cxx-dataflow-example-node-rust-api --release
+  cargo build -p cxx-dataflow-example-operator-rust-api --release
+  ```
+- Compile the `dora-node-api-c` crate into a static library.
+  - Run `cargo build -p dora-node-api-c --release`
+  - The resulting staticlib is then available under `../../target/release/libdora-node-api-c.a`.
+- Compile the `node-c-api/main.cc` (e.g. using `clang++`) and link the staticlib
+  - For example, use the following command:
+    ```
+    clang++ node-c-api/main.cc <FLAGS> -std=c++14 -ldora_node_api_c -L ../../target/release --output build/node_c_api
+    ```
+  - The `<FLAGS>` depend on the operating system and the libraries that the C node uses. The following flags are required for each OS:
+    - Linux: `-lm -lrt -ldl -pthread`
+    - macOS: `-framework CoreServices -framework Security -l System -l resolv -l pthread -l c -l m`
+    - Windows:
+      ```
+      -ladvapi32 -luserenv -lkernel32 -lws2_32 -lbcrypt -lncrypt -lschannel -lntdll -liphlpapi
+      -lcfgmgr32 -lcredui -lcrypt32 -lcryptnet -lfwpuclnt -lgdi32 -lmsimg32 -lmswsock -lole32
+      -lopengl32 -lsecur32 -lshell32 -lsynchronization -luser32 -lwinspool
+      -Wl,-nodefaultlib:libcmt -D_DLL -lmsvcrt
+      ```
+      Also: On Windows, the output file should have an `.exe` extension: `--output build/c_node.exe`
+- Compile the `operator-c-api/operator.cc` file into a shared library.
+  - For example, use the following commands:
+    ```
+    clang++ -c operator-c-api/operator.cc -std=c++14 -o build/operator_c_api.o -fPIC
+    clang++ -shared build/operator_c_api.o -o build/liboperator_c_api.so
+    ```
+    Omit the `-fPIC` argument on Windows. Replace the `liboperator_c_api.so` name with the shared library standard library prefix/extensions used on your OS, e.g. `.dll` on Windows.
+
+**Build the dora coordinator and runtime:**
+
+- Build the `dora-coordinator` executable using `cargo build -p dora-coordinator --release`
+- Build the `dora-runtime` executable using `cargo build -p dora-runtime --release`
+
+**Run the dataflow:**
+
+- Start the `dora-coordinator`, passing the paths to the dataflow file and the `dora-runtime` as arguments:
+
+  ```
+  ../../target/release/dora-coordinator run dataflow.yml ../../target/release/dora-runtime
+  ```

--- a/examples/c++-dataflow/dataflow.yml
+++ b/examples/c++-dataflow/dataflow.yml
@@ -21,14 +21,14 @@ nodes:
   - id: runtime-node
     operators:
       - id: operator-rust-api
-        shared-library: ../../target/release/libcxx_dataflow_example_operator_rust_api.so
+        shared-library: ../../target/release/cxx_dataflow_example_operator_rust_api
         inputs:
           counter_1: cxx-node-c-api/counter
           counter_2: cxx-node-rust-api/counter
         outputs:
           - status
       - id: operator-c-api
-        shared-library: build/operator_c_api.so
+        shared-library: build/operator_c_api
         inputs:
           op_status: runtime-node/operator-rust-api/status
         outputs:

--- a/examples/c++-dataflow/node-rust-api/build.rs
+++ b/examples/c++-dataflow/node-rust-api/build.rs
@@ -1,7 +1,7 @@
 fn main() {
     cxx_build::bridge("src/main.rs") // returns a cc::Build
         .file("src/main.cc")
-        .flag_if_supported("-std=c++11")
+        .flag_if_supported("-std=c++14")
         .compile("cxx-example-dataflow-node");
 
     println!("cargo:rerun-if-changed=src/main.rs");

--- a/examples/c++-dataflow/node-rust-api/src/main.cc
+++ b/examples/c++-dataflow/node-rust-api/src/main.cc
@@ -1,4 +1,4 @@
-#include "main.h"
+#include "cxx-dataflow-example-node-rust-api/src/main.h"
 
 #include <iostream>
 #include <vector>

--- a/examples/c++-dataflow/operator-rust-api/src/operator.cc
+++ b/examples/c++-dataflow/operator-rust-api/src/operator.cc
@@ -1,4 +1,5 @@
 #include "operator.h"
+#include "cxx-dataflow-example-operator-rust-api/src/lib.rs.h"
 #include <iostream>
 
 Operator::Operator() {}

--- a/examples/c++-dataflow/operator-rust-api/src/operator.cc
+++ b/examples/c++-dataflow/operator-rust-api/src/operator.cc
@@ -1,4 +1,4 @@
-#include "operator.h"
+#include "cxx-dataflow-example-operator-rust-api/src/operator.h"
 #include "cxx-dataflow-example-operator-rust-api/src/lib.rs.h"
 #include <iostream>
 

--- a/examples/c++-dataflow/operator-rust-api/src/operator.cc
+++ b/examples/c++-dataflow/operator-rust-api/src/operator.cc
@@ -1,5 +1,4 @@
 #include "operator.h"
-#include "cxx-dataflow-example-operator-rust-api/src/lib.rs.h"
 #include <iostream>
 
 Operator::Operator() {}

--- a/examples/c++-dataflow/operator-rust-api/src/operator.h
+++ b/examples/c++-dataflow/operator-rust-api/src/operator.h
@@ -1,6 +1,5 @@
 #pragma once
 #include "rust/cxx.h"
-#include "cxx-dataflow-example-operator-rust-api/src/lib.rs.h"
 #include <memory>
 
 class Operator

--- a/examples/c++-dataflow/operator-rust-api/src/operator.h
+++ b/examples/c++-dataflow/operator-rust-api/src/operator.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "rust/cxx.h"
+#include "cxx-dataflow-example-operator-rust-api/src/lib.rs.h"
 #include <memory>
 
 class Operator

--- a/examples/c++-dataflow/run.rs
+++ b/examples/c++-dataflow/run.rs
@@ -72,9 +72,26 @@ async fn build_cxx_node(root: &Path, path: &Path, out_name: &str) -> eyre::Resul
         clang.arg("-lkernel32");
         clang.arg("-lws2_32");
         clang.arg("-lbcrypt");
+        clang.arg("-lncrypt");
         clang.arg("-lschannel");
         clang.arg("-lntdll");
         clang.arg("-liphlpapi");
+
+        clang.arg("-lcfgmgr32");
+        clang.arg("-lcredui");
+        clang.arg("-lcrypt32");
+        clang.arg("-lcryptnet");
+        clang.arg("-lfwpuclnt");
+        clang.arg("-lgdi32");
+        clang.arg("-lmsimg32");
+        clang.arg("-lmswsock");
+        clang.arg("-lole32");
+        clang.arg("-lopengl32");
+        clang.arg("-lsecur32");
+        clang.arg("-lshell32");
+        clang.arg("-lsynchronization");
+        clang.arg("-luser32");
+        clang.arg("-lwinspool");
 
         clang.arg("-Wl,-nodefaultlib:libcmt");
         clang.arg("-D_DLL");

--- a/examples/c++-dataflow/run.rs
+++ b/examples/c++-dataflow/run.rs
@@ -68,6 +68,9 @@ async fn build_cxx_node(root: &Path, path: &Path, out_name: &str) -> eyre::Resul
     #[cfg(target_os = "windows")]
     {
         clang.arg("-lws2_32");
+        clang.arg("-Wl,-nodefaultlib:libcmt");
+        clang.arg("-D_DLL");
+        clang.arg("-lmsvcrt");
     }
     #[cfg(target_os = "macos")]
     {

--- a/examples/c++-dataflow/run.rs
+++ b/examples/c++-dataflow/run.rs
@@ -1,6 +1,6 @@
 use eyre::{bail, Context};
 use std::{
-    env::consts::{DLL_PREFIX, DLL_SUFFIX},
+    env::consts::{DLL_PREFIX, DLL_SUFFIX, EXE_SUFFIX},
     ffi::{OsStr, OsString},
     path::Path,
 };
@@ -110,7 +110,7 @@ async fn build_cxx_node(root: &Path, path: &Path, out_name: &str) -> eyre::Resul
     clang.arg("-L").arg(root.join("target").join("release"));
     clang
         .arg("--output")
-        .arg(Path::new("../build").join(out_name));
+        .arg(Path::new("../build").join(format!("{out_name}{EXE_SUFFIX}")));
     if let Some(parent) = path.parent() {
         clang.current_dir(parent);
     }

--- a/examples/c++-dataflow/run.rs
+++ b/examples/c++-dataflow/run.rs
@@ -88,7 +88,7 @@ async fn build_cxx_operator(path: &Path, out_name: &str) -> eyre::Result<()> {
     let mut link = tokio::process::Command::new("clang++");
     link.arg("-shared").arg(&object_file_path);
     link.arg("-o")
-        .arg(Path::new("../build").join(out_name).with_extension("so"));
+        .arg(Path::new("../build").join(format!("lib{out_name}.so")));
     if let Some(parent) = path.parent() {
         link.current_dir(parent);
     }

--- a/examples/c++-dataflow/run.rs
+++ b/examples/c++-dataflow/run.rs
@@ -57,10 +57,13 @@ async fn build_cxx_node(root: &Path, path: &Path, out_name: &str) -> eyre::Resul
     let mut clang = tokio::process::Command::new("clang++");
     clang.arg(path);
     clang.arg("-l").arg("dora_node_api_c");
-    clang.arg("-l").arg("m");
-    clang.arg("-l").arg("rt");
-    clang.arg("-l").arg("dl");
-    clang.arg("-pthread");
+    #[cfg(target_os = "linux")]
+    {
+        clang.arg("-l").arg("m");
+        clang.arg("-l").arg("rt");
+        clang.arg("-l").arg("dl");
+        clang.arg("-pthread");
+    }
     clang.arg("-L").arg(root.join("target").join("release"));
     clang
         .arg("--output")

--- a/examples/c++-dataflow/run.rs
+++ b/examples/c++-dataflow/run.rs
@@ -73,6 +73,7 @@ async fn build_cxx_node(root: &Path, path: &Path, out_name: &str) -> eyre::Resul
     #[cfg(target_os = "macos")]
     {
         clang.arg("-framework").arg("CoreServices");
+        clang.arg("-framework").arg("Security");
         clang.arg("-l").arg("System");
         clang.arg("-l").arg("resolv");
         clang.arg("-l").arg("pthread");

--- a/examples/c++-dataflow/run.rs
+++ b/examples/c++-dataflow/run.rs
@@ -67,8 +67,6 @@ async fn build_cxx_node(root: &Path, path: &Path, out_name: &str) -> eyre::Resul
     #[cfg(target_os = "windows")]
     {
         clang.arg("-lws2_32");
-        clang.arg("-lcrypto");
-        clang.arg("-lcrypto32");
     }
     #[cfg(target_os = "macos")]
     {

--- a/examples/c++-dataflow/run.rs
+++ b/examples/c++-dataflow/run.rs
@@ -72,7 +72,12 @@ async fn build_cxx_node(root: &Path, path: &Path, out_name: &str) -> eyre::Resul
     }
     #[cfg(target_os = "macos")]
     {
-        clang.arg("-stdlib=libstdc++");
+        clang.arg("-framework").arg("CoreServices");
+        clang.arg("-l").arg("System");
+        clang.arg("-l").arg("resolv");
+        clang.arg("-l").arg("pthread");
+        clang.arg("-l").arg("c");
+        clang.arg("-l").arg("m");
     }
     clang.arg("-L").arg(root.join("target").join("release"));
     clang

--- a/examples/c++-dataflow/run.rs
+++ b/examples/c++-dataflow/run.rs
@@ -67,7 +67,12 @@ async fn build_cxx_node(root: &Path, path: &Path, out_name: &str) -> eyre::Resul
     }
     #[cfg(target_os = "windows")]
     {
+        clang.arg("-ladvapi32");
+        clang.arg("-luserenv");
+        clang.arg("-lkernel32");
         clang.arg("-lws2_32");
+        clang.arg("-lbcrypt");
+
         clang.arg("-Wl,-nodefaultlib:libcmt");
         clang.arg("-D_DLL");
         clang.arg("-lmsvcrt");

--- a/examples/c++-dataflow/run.rs
+++ b/examples/c++-dataflow/run.rs
@@ -72,6 +72,9 @@ async fn build_cxx_node(root: &Path, path: &Path, out_name: &str) -> eyre::Resul
         clang.arg("-lkernel32");
         clang.arg("-lws2_32");
         clang.arg("-lbcrypt");
+        clang.arg("-lschannel");
+        clang.arg("-lntdll");
+        clang.arg("-liphlpapi");
 
         clang.arg("-Wl,-nodefaultlib:libcmt");
         clang.arg("-D_DLL");

--- a/examples/c++-dataflow/run.rs
+++ b/examples/c++-dataflow/run.rs
@@ -56,6 +56,7 @@ async fn build_package(package: &str) -> eyre::Result<()> {
 async fn build_cxx_node(root: &Path, path: &Path, out_name: &str) -> eyre::Result<()> {
     let mut clang = tokio::process::Command::new("clang++");
     clang.arg(path);
+    clang.arg("-std=c++11");
     clang.arg("-l").arg("dora_node_api_c");
     #[cfg(target_os = "linux")]
     {
@@ -97,6 +98,7 @@ async fn build_cxx_operator(path: &Path, out_name: &str) -> eyre::Result<()> {
 
     let mut compile = tokio::process::Command::new("clang++");
     compile.arg("-c").arg(path);
+    compile.arg("-std=c++11");
     compile.arg("-o").arg(&object_file_path);
     compile.arg("-fPIC");
     if let Some(parent) = path.parent() {

--- a/examples/c++-dataflow/run.rs
+++ b/examples/c++-dataflow/run.rs
@@ -64,6 +64,16 @@ async fn build_cxx_node(root: &Path, path: &Path, out_name: &str) -> eyre::Resul
         clang.arg("-l").arg("dl");
         clang.arg("-pthread");
     }
+    #[cfg(target_os = "windows")]
+    {
+        clang.arg("-lws2_32");
+        clang.arg("-lcrypto");
+        clang.arg("-lcrypto32");
+    }
+    #[cfg(target_os = "macos")]
+    {
+        clang.arg("-stdlib=libstdc++");
+    }
     clang.arg("-L").arg(root.join("target").join("release"));
     clang
         .arg("--output")

--- a/examples/c++-dataflow/run.rs
+++ b/examples/c++-dataflow/run.rs
@@ -19,14 +19,12 @@ async fn main() -> eyre::Result<()> {
     build_package("dora-node-api-c").await?;
     build_cxx_node(
         root,
-        &Path::new("node-c-api").join("main.cc").canonicalize()?,
+        &dunce::canonicalize(Path::new("node-c-api").join("main.cc"))?,
         "node_c_api",
     )
     .await?;
     build_cxx_operator(
-        &Path::new("operator-c-api")
-            .join("operator.cc")
-            .canonicalize()?,
+        &dunce::canonicalize(Path::new("operator-c-api").join("operator.cc"))?,
         "operator_c_api",
     )
     .await?;

--- a/examples/c++-dataflow/run.rs
+++ b/examples/c++-dataflow/run.rs
@@ -137,32 +137,16 @@ async fn build_cxx_operator(path: &Path, out_name: &str) -> eyre::Result<()> {
         bail!("failed to compile cxx operator");
     };
 
-    let out_path = Path::new("../build").join(library_filename(out_name));
-    #[cfg(unix)]
-    {
-        let mut link = tokio::process::Command::new("clang++");
-        link.arg("-shared").arg(&object_file_path);
-        link.arg("-o").arg(out_path);
-        if let Some(parent) = path.parent() {
-            link.current_dir(parent);
-        }
-        if !link.status().await?.success() {
-            bail!("failed to create shared library from cxx operator (c api)");
-        };
+    let mut link = tokio::process::Command::new("clang++");
+    link.arg("-shared").arg(&object_file_path);
+    link.arg("-o")
+        .arg(Path::new("../build").join(library_filename(out_name)));
+    if let Some(parent) = path.parent() {
+        link.current_dir(parent);
     }
-    #[cfg(windows)]
-    {
-        let mut link = tokio::process::Command::new("LINK.EXE");
-        link.arg("/DLL");
-        link.arg(format!("/OUT:{}", out_path.display()));
-        link.arg(&object_file_path);
-        if let Some(parent) = path.parent() {
-            link.current_dir(parent);
-        }
-        if !link.status().await?.success() {
-            bail!("failed to link c++ operator (c api)");
-        };
-    }
+    if !link.status().await?.success() {
+        bail!("failed to create shared library from cxx operator (c api)");
+    };
 
     Ok(())
 }

--- a/examples/c++-dataflow/run.rs
+++ b/examples/c++-dataflow/run.rs
@@ -128,6 +128,7 @@ async fn build_cxx_operator(path: &Path, out_name: &str) -> eyre::Result<()> {
     compile.arg("-c").arg(path);
     compile.arg("-std=c++14");
     compile.arg("-o").arg(&object_file_path);
+    #[cfg(unix)]
     compile.arg("-fPIC");
     if let Some(parent) = path.parent() {
         compile.current_dir(parent);

--- a/examples/c++-dataflow/run.rs
+++ b/examples/c++-dataflow/run.rs
@@ -1,5 +1,9 @@
 use eyre::{bail, Context};
-use std::path::Path;
+use std::{
+    env::consts::{DLL_PREFIX, DLL_SUFFIX},
+    ffi::{OsStr, OsString},
+    path::Path,
+};
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
@@ -88,7 +92,7 @@ async fn build_cxx_operator(path: &Path, out_name: &str) -> eyre::Result<()> {
     let mut link = tokio::process::Command::new("clang++");
     link.arg("-shared").arg(&object_file_path);
     link.arg("-o")
-        .arg(Path::new("../build").join(format!("lib{out_name}.so")));
+        .arg(Path::new("../build").join(library_filename(out_name)));
     if let Some(parent) = path.parent() {
         link.current_dir(parent);
     }
@@ -97,4 +101,15 @@ async fn build_cxx_operator(path: &Path, out_name: &str) -> eyre::Result<()> {
     };
 
     Ok(())
+}
+
+// taken from `rust_libloading` crate by Simonas Kazlauskas, licensed under the ISC license (
+// see https://github.com/nagisa/rust_libloading/blob/master/LICENSE)
+pub fn library_filename<S: AsRef<OsStr>>(name: S) -> OsString {
+    let name = name.as_ref();
+    let mut string = OsString::with_capacity(name.len() + DLL_PREFIX.len() + DLL_SUFFIX.len());
+    string.push(DLL_PREFIX);
+    string.push(name);
+    string.push(DLL_SUFFIX);
+    string
 }

--- a/examples/c++-dataflow/run.rs
+++ b/examples/c++-dataflow/run.rs
@@ -56,7 +56,7 @@ async fn build_package(package: &str) -> eyre::Result<()> {
 async fn build_cxx_node(root: &Path, path: &Path, out_name: &str) -> eyre::Result<()> {
     let mut clang = tokio::process::Command::new("clang++");
     clang.arg(path);
-    clang.arg("-std=c++11");
+    clang.arg("-std=c++14");
     clang.arg("-l").arg("dora_node_api_c");
     #[cfg(target_os = "linux")]
     {
@@ -101,7 +101,7 @@ async fn build_cxx_operator(path: &Path, out_name: &str) -> eyre::Result<()> {
 
     let mut compile = tokio::process::Command::new("clang++");
     compile.arg("-c").arg(path);
-    compile.arg("-std=c++11");
+    compile.arg("-std=c++14");
     compile.arg("-o").arg(&object_file_path);
     compile.arg("-fPIC");
     if let Some(parent) = path.parent() {

--- a/examples/c-dataflow/README.md
+++ b/examples/c-dataflow/README.md
@@ -42,7 +42,7 @@ For a manual build, follow these steps:
   - For example, use the following commands:
     ```
     clang -c operator.c -o build/operator.o -fPIC
-    clang -shared build/operator.o -o build/operator.so
+    clang -shared build/operator.o -o libbuild/operator.so
     ```
 
 **Build the dora coordinator and runtime:**

--- a/examples/c-dataflow/README.md
+++ b/examples/c-dataflow/README.md
@@ -31,8 +31,19 @@ For a manual build, follow these steps:
 - Compile the `node.c` (e.g. using `clang`) and link the staticlib
   - For example, use the following command:
     ```
-    clang node.c -lm -lrt -ldl -pthread -ldora_node_api_c -L ../../target/release --output build/c_node
+    clang node.c <FLAGS> -ldora_node_api_c -L ../../target/release --output build/c_node
     ```
+  - The `<FLAGS>` depend on the operating system and the libraries that the C node uses. The following flags are required for each OS:
+    - Linux: `-lm -lrt -ldl -pthread`
+    - macOS: `-framework CoreServices -framework Security -l System -l resolv -l pthread -l c -l m`
+    - Windows:
+      ```
+      -ladvapi32 -luserenv -lkernel32 -lws2_32 -lbcrypt -lncrypt -lschannel -lntdll -liphlpapi
+      -lcfgmgr32 -lcredui -lcrypt32 -lcryptnet -lfwpuclnt -lgdi32 -lmsimg32 -lmswsock -lole32
+      -lopengl32 -lsecur32 -lshell32 -lsynchronization -luser32 -lwinspool
+      -Wl,-nodefaultlib:libcmt -D_DLL -lmsvcrt
+      ```
+      Also: On Windows, the output file should have an `.exe` extension: `--output build/c_node.exe`
 - Repeat the previous step for the `sink.c` executable
 
 **Build the operator:**
@@ -41,9 +52,10 @@ For a manual build, follow these steps:
 - Compile the `operator.c` file into a shared library.
   - For example, use the following commands:
     ```
-    clang -c operator.c -o build/operator.o -fPIC
-    clang -shared build/operator.o -o libbuild/operator.so
+    clang -c operator.c -o build/operator.o -fdeclspec -fPIC
+    clang -shared build/operator.o -o build/liboperator.so
     ```
+    Omit the `-fPIC` argument on Windows. Replace the `liboperator.so` name with the shared library standard library prefix/extensions used on your OS, e.g. `.dll` on Windows.
 
 **Build the dora coordinator and runtime:**
 

--- a/examples/c-dataflow/dataflow.yml
+++ b/examples/c-dataflow/dataflow.yml
@@ -13,7 +13,7 @@ nodes:
   - id: runtime-node
     operators:
       - id: c_operator
-        shared-library: build/operator.so
+        shared-library: build/operator
         inputs:
           tick: c_node/tick
         outputs:

--- a/examples/c-dataflow/node.c
+++ b/examples/c-dataflow/node.c
@@ -35,7 +35,11 @@ int main()
         free_dora_input(input);
     }
 
+    printf("node.c about to free dora context\n");
+
     free_dora_context(dora_context);
+
+    printf("node.c finished successful\n");
 
     return 0;
 }

--- a/examples/c-dataflow/node.c
+++ b/examples/c-dataflow/node.c
@@ -27,6 +27,11 @@ int main()
     {
         printf("[c node] waiting for next input\n");
         void *input = dora_next_input(dora_context);
+        if (input == NULL)
+        {
+            printf("[c node] ERROR: unexpected end of input\n");
+            return -1;
+        }
 
         char *data;
         size_t data_len;

--- a/examples/c-dataflow/node.c
+++ b/examples/c-dataflow/node.c
@@ -12,6 +12,8 @@
 
 int main()
 {
+    printf("[c node] Hello World\n");
+
     void *dora_context = init_dora_context_from_env();
     if (dora_context == NULL)
     {
@@ -19,8 +21,11 @@ int main()
         return -1;
     }
 
+    printf("[c node] dora context initialized\n");
+
     for (char i = 0; i < 10; i++)
     {
+        printf("[c node] waiting for next input\n");
         void *input = dora_next_input(dora_context);
 
         char *data;
@@ -35,11 +40,11 @@ int main()
         free_dora_input(input);
     }
 
-    printf("node.c about to free dora context\n");
+    printf("[c node] received 10 inputs\n");
 
     free_dora_context(dora_context);
 
-    printf("node.c finished successful\n");
+    printf("[c node] finished successfully\n");
 
     return 0;
 }

--- a/examples/c-dataflow/operator.c
+++ b/examples/c-dataflow/operator.c
@@ -4,14 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#ifdef _WIN32
-#define EXPORT __declspec(dllexport)
-#endif
-#ifdef __unix__
-#define EXPORT
-#endif
-
-EXPORT int dora_init_operator(void **operator_context)
+int dora_init_operator(void **operator_context)
 {
     void *context = malloc(1);
     char *context_char = (char *)context;
@@ -22,12 +15,12 @@ EXPORT int dora_init_operator(void **operator_context)
     return 0;
 }
 
-EXPORT void dora_drop_operator(void *operator_context)
+void dora_drop_operator(void *operator_context)
 {
     free(operator_context);
 }
 
-EXPORT int dora_on_input(
+int dora_on_input(
     const char *id_start,
     size_t id_len,
     const char *data_start,

--- a/examples/c-dataflow/operator.c
+++ b/examples/c-dataflow/operator.c
@@ -4,7 +4,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-int dora_init_operator(void **operator_context)
+#ifdef _WIN32
+#define EXPORT __declspec(dllexport)
+#endif
+#ifdef __unix__
+#define EXPORT
+#endif
+
+EXPORT int dora_init_operator(void **operator_context)
 {
     void *context = malloc(1);
     char *context_char = (char *)context;
@@ -15,12 +22,12 @@ int dora_init_operator(void **operator_context)
     return 0;
 }
 
-void dora_drop_operator(void *operator_context)
+EXPORT void dora_drop_operator(void *operator_context)
 {
     free(operator_context);
 }
 
-int dora_on_input(
+EXPORT int dora_on_input(
     const char *id_start,
     size_t id_len,
     const char *data_start,

--- a/examples/c-dataflow/run.rs
+++ b/examples/c-dataflow/run.rs
@@ -129,26 +129,14 @@ async fn build_c_operator(root: &Path) -> eyre::Result<()> {
         bail!("failed to compile c operator");
     };
 
-    let out_path = Path::new("build").join(library_filename("operator"));
-    #[cfg(unix)]
-    {
-        let mut link = tokio::process::Command::new("clang");
-        link.arg("-shared").arg("build/operator.o");
-        link.arg("-o").arg(out_path);
-        if !link.status().await?.success() {
-            bail!("failed to link c operator");
-        };
-    }
-    #[cfg(windows)]
-    {
-        let mut link = tokio::process::Command::new("LINK.EXE");
-        link.arg("/DLL");
-        link.arg(format!("/OUT:{}", out_path.display()));
-        link.arg("build/operator.o");
-        if !link.status().await?.success() {
-            bail!("failed to link c operator");
-        };
-    }
+    let mut link = tokio::process::Command::new("clang");
+    link.arg("-shared").arg("build/operator.o");
+    link.arg("-o")
+        .arg(Path::new("build").join(library_filename("operator")));
+    if !link.status().await?.success() {
+        bail!("failed to link c operator");
+    };
+
     Ok(())
 }
 

--- a/examples/c-dataflow/run.rs
+++ b/examples/c-dataflow/run.rs
@@ -64,6 +64,9 @@ async fn build_c_node(root: &Path, name: &str, out_name: &str) -> eyre::Result<(
         clang.arg("-lkernel32");
         clang.arg("-lws2_32");
         clang.arg("-lbcrypt");
+        clang.arg("-lschannel");
+        clang.arg("-lntdll");
+        clang.arg("-liphlpapi");
 
         clang.arg("-Wl,-nodefaultlib:libcmt");
         clang.arg("-D_DLL");

--- a/examples/c-dataflow/run.rs
+++ b/examples/c-dataflow/run.rs
@@ -1,6 +1,6 @@
 use eyre::{bail, Context};
 use std::{
-    env::consts::{DLL_PREFIX, DLL_SUFFIX},
+    env::consts::{DLL_PREFIX, DLL_SUFFIX, EXE_SUFFIX},
     ffi::{OsStr, OsString},
     path::Path,
 };
@@ -100,7 +100,9 @@ async fn build_c_node(root: &Path, name: &str, out_name: &str) -> eyre::Result<(
         clang.arg("-l").arg("m");
     }
     clang.arg("-L").arg(root.join("target").join("release"));
-    clang.arg("--output").arg(Path::new("build").join(out_name));
+    clang
+        .arg("--output")
+        .arg(Path::new("build").join(format!("{out_name}{EXE_SUFFIX}")));
     if !clang.status().await?.success() {
         bail!("failed to compile c node");
     };

--- a/examples/c-dataflow/run.rs
+++ b/examples/c-dataflow/run.rs
@@ -60,6 +60,9 @@ async fn build_c_node(root: &Path, name: &str, out_name: &str) -> eyre::Result<(
     #[cfg(target_os = "windows")]
     {
         clang.arg("-lws2_32");
+        clang.arg("-Wl,-nodefaultlib:libcmt");
+        clang.arg("-D_DLL");
+        clang.arg("-lmsvcrt");
     }
     #[cfg(target_os = "macos")]
     {

--- a/examples/c-dataflow/run.rs
+++ b/examples/c-dataflow/run.rs
@@ -79,7 +79,7 @@ async fn build_c_operator(root: &Path) -> eyre::Result<()> {
 
     let mut link = tokio::process::Command::new("clang");
     link.arg("-shared").arg("build/operator.o");
-    link.arg("-o").arg("build/operator.so");
+    link.arg("-o").arg("build/liboperator.so");
     if !link.status().await?.success() {
         bail!("failed to link c operator");
     };

--- a/examples/c-dataflow/run.rs
+++ b/examples/c-dataflow/run.rs
@@ -64,9 +64,26 @@ async fn build_c_node(root: &Path, name: &str, out_name: &str) -> eyre::Result<(
         clang.arg("-lkernel32");
         clang.arg("-lws2_32");
         clang.arg("-lbcrypt");
+        clang.arg("-lncrypt");
         clang.arg("-lschannel");
         clang.arg("-lntdll");
         clang.arg("-liphlpapi");
+
+        clang.arg("-lcfgmgr32");
+        clang.arg("-lcredui");
+        clang.arg("-lcrypt32");
+        clang.arg("-lcryptnet");
+        clang.arg("-lfwpuclnt");
+        clang.arg("-lgdi32");
+        clang.arg("-lmsimg32");
+        clang.arg("-lmswsock");
+        clang.arg("-lole32");
+        clang.arg("-lopengl32");
+        clang.arg("-lsecur32");
+        clang.arg("-lshell32");
+        clang.arg("-lsynchronization");
+        clang.arg("-luser32");
+        clang.arg("-lwinspool");
 
         clang.arg("-Wl,-nodefaultlib:libcmt");
         clang.arg("-D_DLL");

--- a/examples/c-dataflow/run.rs
+++ b/examples/c-dataflow/run.rs
@@ -50,10 +50,13 @@ async fn build_c_node(root: &Path, name: &str, out_name: &str) -> eyre::Result<(
     let mut clang = tokio::process::Command::new("clang");
     clang.arg(name);
     clang.arg("-l").arg("dora_node_api_c");
-    clang.arg("-l").arg("m");
-    clang.arg("-l").arg("rt");
-    clang.arg("-l").arg("dl");
-    clang.arg("-pthread");
+    #[cfg(target_os = "linux")]
+    {
+        clang.arg("-l").arg("m");
+        clang.arg("-l").arg("rt");
+        clang.arg("-l").arg("dl");
+        clang.arg("-pthread");
+    }
     clang.arg("-L").arg(root.join("target").join("release"));
     clang.arg("--output").arg(Path::new("build").join(out_name));
     if !clang.status().await?.success() {

--- a/examples/c-dataflow/run.rs
+++ b/examples/c-dataflow/run.rs
@@ -123,6 +123,7 @@ async fn build_c_operator(root: &Path) -> eyre::Result<()> {
     let mut compile = tokio::process::Command::new("clang");
     compile.arg("-c").arg("operator.c");
     compile.arg("-o").arg("build/operator.o");
+    compile.arg("-fdeclspec");
     #[cfg(unix)]
     compile.arg("-fPIC");
     if !compile.status().await?.success() {

--- a/examples/c-dataflow/run.rs
+++ b/examples/c-dataflow/run.rs
@@ -129,14 +129,26 @@ async fn build_c_operator(root: &Path) -> eyre::Result<()> {
         bail!("failed to compile c operator");
     };
 
-    let mut link = tokio::process::Command::new("clang");
-    link.arg("-shared").arg("build/operator.o");
-    link.arg("-o")
-        .arg(Path::new("build").join(library_filename("operator")));
-    if !link.status().await?.success() {
-        bail!("failed to link c operator");
-    };
-
+    let out_path = Path::new("build").join(library_filename("operator"));
+    #[cfg(unix)]
+    {
+        let mut link = tokio::process::Command::new("clang");
+        link.arg("-shared").arg("build/operator.o");
+        link.arg("-o").arg(out_path);
+        if !link.status().await?.success() {
+            bail!("failed to link c operator");
+        };
+    }
+    #[cfg(windows)]
+    {
+        let mut link = tokio::process::Command::new("LINK.EXE");
+        link.arg("/DLL");
+        link.arg(format!("/OUT:{}", out_path.display()));
+        link.arg("build/operator.o");
+        if !link.status().await?.success() {
+            bail!("failed to link c operator");
+        };
+    }
     Ok(())
 }
 

--- a/examples/c-dataflow/run.rs
+++ b/examples/c-dataflow/run.rs
@@ -65,6 +65,7 @@ async fn build_c_node(root: &Path, name: &str, out_name: &str) -> eyre::Result<(
     #[cfg(target_os = "macos")]
     {
         clang.arg("-framework").arg("CoreServices");
+        clang.arg("-framework").arg("Security");
         clang.arg("-l").arg("System");
         clang.arg("-l").arg("resolv");
         clang.arg("-l").arg("pthread");

--- a/examples/c-dataflow/run.rs
+++ b/examples/c-dataflow/run.rs
@@ -65,7 +65,12 @@ async fn build_c_node(root: &Path, name: &str, out_name: &str) -> eyre::Result<(
     }
     #[cfg(target_os = "macos")]
     {
-        clang.arg("-stdlib=libstdc++");
+        clang.arg("-framework").arg("CoreServices");
+        clang.arg("-l").arg("System");
+        clang.arg("-l").arg("resolv");
+        clang.arg("-l").arg("pthread");
+        clang.arg("-l").arg("c");
+        clang.arg("-l").arg("m");
     }
     clang.arg("-L").arg(root.join("target").join("release"));
     clang.arg("--output").arg(Path::new("build").join(out_name));

--- a/examples/c-dataflow/run.rs
+++ b/examples/c-dataflow/run.rs
@@ -59,7 +59,12 @@ async fn build_c_node(root: &Path, name: &str, out_name: &str) -> eyre::Result<(
     }
     #[cfg(target_os = "windows")]
     {
+        clang.arg("-ladvapi32");
+        clang.arg("-luserenv");
+        clang.arg("-lkernel32");
         clang.arg("-lws2_32");
+        clang.arg("-lbcrypt");
+
         clang.arg("-Wl,-nodefaultlib:libcmt");
         clang.arg("-D_DLL");
         clang.arg("-lmsvcrt");

--- a/examples/c-dataflow/run.rs
+++ b/examples/c-dataflow/run.rs
@@ -60,7 +60,6 @@ async fn build_c_node(root: &Path, name: &str, out_name: &str) -> eyre::Result<(
     #[cfg(target_os = "windows")]
     {
         clang.arg("-lws2_32");
-        clang.arg("-lcrypto");
         clang.arg("-lcrypto32");
     }
     #[cfg(target_os = "macos")]

--- a/examples/c-dataflow/run.rs
+++ b/examples/c-dataflow/run.rs
@@ -57,6 +57,16 @@ async fn build_c_node(root: &Path, name: &str, out_name: &str) -> eyre::Result<(
         clang.arg("-l").arg("dl");
         clang.arg("-pthread");
     }
+    #[cfg(target_os = "windows")]
+    {
+        clang.arg("-lws2_32");
+        clang.arg("-lcrypto");
+        clang.arg("-lcrypto32");
+    }
+    #[cfg(target_os = "macos")]
+    {
+        clang.arg("-stdlib=libstdc++");
+    }
     clang.arg("-L").arg(root.join("target").join("release"));
     clang.arg("--output").arg(Path::new("build").join(out_name));
     if !clang.status().await?.success() {

--- a/examples/c-dataflow/run.rs
+++ b/examples/c-dataflow/run.rs
@@ -60,7 +60,6 @@ async fn build_c_node(root: &Path, name: &str, out_name: &str) -> eyre::Result<(
     #[cfg(target_os = "windows")]
     {
         clang.arg("-lws2_32");
-        clang.arg("-lcrypto32");
     }
     #[cfg(target_os = "macos")]
     {

--- a/examples/c-dataflow/run.rs
+++ b/examples/c-dataflow/run.rs
@@ -121,6 +121,7 @@ async fn build_c_operator(root: &Path) -> eyre::Result<()> {
     let mut compile = tokio::process::Command::new("clang");
     compile.arg("-c").arg("operator.c");
     compile.arg("-o").arg("build/operator.o");
+    #[cfg(unix)]
     compile.arg("-fPIC");
     if !compile.status().await?.success() {
         bail!("failed to compile c operator");

--- a/examples/c-dataflow/sink.c
+++ b/examples/c-dataflow/sink.c
@@ -5,18 +5,24 @@
 
 int main()
 {
+    printf("[c sink] Hello World\n");
+
     void *dora_context = init_dora_context_from_env();
     if (dora_context == NULL)
     {
         fprintf(stderr, "failed to init dora context\n");
         return -1;
+
+        printf("[c sink] dora context initialized\n");
     }
 
     while (1)
     {
+        printf("[c sink] waiting for next input\n");
         void *input = dora_next_input(dora_context);
         if (input == NULL)
         {
+            printf("[c sink] end of input\n");
             break;
         }
 
@@ -38,6 +44,8 @@ int main()
     }
 
     free_dora_context(dora_context);
+
+    printf("[c sink] finished successfully\n");
 
     return 0;
 }

--- a/examples/rust-dataflow/dataflow.yml
+++ b/examples/rust-dataflow/dataflow.yml
@@ -13,7 +13,7 @@ nodes:
   - id: runtime-node
     operators:
       - id: rust-operator
-        shared-library: ../../target/release/librust_dataflow_example_operator.so
+        shared-library: ../../target/release/rust_dataflow_example_operator
         inputs:
           tick: dora/timer/millis/100
           random: rust-node/random


### PR DESCRIPTION
This PR updates the CI jobs to test dora and run the examples also on Windows and macOS. It also adds the executable and shared library file extensions automatically (e.g., `.exe` and `.dll` on Windows) and changes the example dataflow files to be cross-platform. To make the C and C++ examples buildable on Windows and macOS, this PR add conditional compilation to add the respective `clang` and linker flags.

TODO:

- [x] Update C/C++ build instructions in READMEs to be cross-platform
- [x] Fix Python Example
- [x] Sink: check for end of input

---

Note: This PR contains many debug commits, so it should be squashed on merging.