### PR TITLE
Add a separate `prepare` step to publishers to allow zero copy send operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,6 +480,7 @@ version = "0.1.0"
 dependencies = [
  "eyre",
  "iceoryx-rs",
+ "iceoryx-sys",
  "zenoh",
  "zenoh-config",
 ]

--- a/apis/c/node/src/lib.rs
+++ b/apis/c/node/src/lib.rs
@@ -126,7 +126,7 @@ pub unsafe extern "C" fn read_dora_input_data(
     out_len: *mut usize,
 ) {
     let input: &Input = unsafe { &*input.cast() };
-    let data = &input.message.data;
+    let data = &input.data();
     let ptr = data.as_ptr();
     let len = data.len();
     unsafe {
@@ -192,5 +192,9 @@ unsafe fn try_send_output(
     let id = std::str::from_utf8(unsafe { slice::from_raw_parts(id_ptr, id_len) })?;
     let output_id = id.to_owned().into();
     let data = unsafe { slice::from_raw_parts(data_ptr, data_len) };
-    context.node.send_output(&output_id, &data.into())
+    context
+        .node
+        .send_output(&output_id, &Default::default(), data.len(), |out| {
+            out.copy_from_slice(data);
+        })
 }

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -16,11 +16,7 @@ pub struct PyInput(Input);
 
 impl IntoPy<PyObject> for PyInput {
     fn into_py(self, py: Python) -> PyObject {
-        (
-            self.0.id.to_string(),
-            PyBytes::new(py, &self.0.message.data),
-        )
-            .into_py(py)
+        (self.0.id.to_string(), PyBytes::new(py, &self.0.data())).into_py(py)
     }
 }
 
@@ -54,8 +50,11 @@ impl Node {
     }
 
     pub fn send_output(&mut self, output_id: String, data: &PyBytes) -> Result<()> {
+        let data = &data.as_bytes();
         self.node
-            .send_output(&output_id.into(), &data.as_bytes().into())
+            .send_output(&output_id.into(), &Default::default(), data.len(), |out| {
+                out.copy_from_slice(data);
+            })
             .wrap_err("Could not send output")
     }
 

--- a/apis/rust/node/src/communication.rs
+++ b/apis/rust/node/src/communication.rs
@@ -100,7 +100,7 @@ pub fn subscribe_all(
                                 sample,
                             },
                         }),
-                        Err(err) => InputEvent::ParseMessageError(err.into()),
+                        Err(err) => InputEvent::ParseMessageError(err),
                     }
                 }
                 Some(Err(err)) => InputEvent::Error(err),
@@ -160,7 +160,7 @@ pub fn subscribe_all(
                 }
             }
             Ok(InputEvent::ParseMessageError(err)) => {
-                tracing::warn!("{err}");
+                tracing::warn!("{err:?}");
             }
             Ok(InputEvent::Error(err)) => panic!("{err}"),
             Err(_) => break,
@@ -177,7 +177,7 @@ enum InputEvent {
         operator: Option<OperatorId>,
     },
     Error(BoxError),
-    ParseMessageError(BoxError),
+    ParseMessageError(eyre::Report),
 }
 
 pub struct Input {

--- a/apis/rust/node/src/lib.rs
+++ b/apis/rust/node/src/lib.rs
@@ -85,7 +85,9 @@ impl DoraNode {
         let mut sample = publisher
             .prepare(full_len)
             .map_err(|err| eyre::eyre!(err))?;
-        data(sample.as_mut_slice());
+        let raw = sample.as_mut_slice();
+        raw[..serialized_metadata.len()].copy_from_slice(&serialized_metadata);
+        data(&mut raw[serialized_metadata.len()..]);
         sample
             .publish()
             .map_err(|err| eyre::eyre!(err))

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -1,5 +1,4 @@
 use dora_core::descriptor::{self, collect_dora_timers, CoreNodeKind, Descriptor};
-use dora_message::serialize_message;
 use dora_node_api::{
     communication,
     config::{format_duration, NodeId},
@@ -116,7 +115,8 @@ async fn run_dataflow(dataflow_path: PathBuf, runtime: &Path) -> eyre::Result<()
                 let duration = format_duration(interval);
                 format!("dora/timer/{duration}")
             };
-            let data = serialize_message(&Vec::new().into()).unwrap();
+            let metadata = dora_message::Metadata::default();
+            let data = metadata.serialize().unwrap();
             let mut stream = IntervalStream::new(tokio::time::interval(interval));
             while (stream.next().await).is_some() {
                 communication

--- a/binaries/runtime/src/operator/python.rs
+++ b/binaries/runtime/src/operator/python.rs
@@ -89,7 +89,7 @@ pub fn spawn(
                         "on_input",
                         (
                             input.id.to_string(),
-                            PyBytes::new(py, &input.message.data),
+                            PyBytes::new(py, &input.data()),
                             send_output.clone(),
                         ),
                     )

--- a/examples/c++-dataflow/node-rust-api/src/main.rs
+++ b/examples/c++-dataflow/node-rust-api/src/main.rs
@@ -31,11 +31,15 @@ pub struct Inputs(Receiver<Input>);
 
 fn next_input(inputs: &mut Inputs) -> ffi::DoraInput {
     match inputs.0.recv() {
-        Ok(input) => ffi::DoraInput {
-            end_of_input: false,
-            id: input.id.into(),
-            data: input.data().into_owned(),
-        },
+        Ok(input) => {
+            let id = input.id.clone().into();
+            let data = input.data();
+            ffi::DoraInput {
+                end_of_input: false,
+                id,
+                data: data.into_owned(),
+            }
+        }
         Err(_) => ffi::DoraInput {
             end_of_input: true,
             id: String::new(),
@@ -49,7 +53,7 @@ pub struct OutputSender<'a>(&'a mut DoraNode);
 fn send_output(sender: &mut OutputSender, id: String, data: &[u8]) -> ffi::DoraResult {
     let result = sender
         .0
-        .send_output(&id.into(), Default::default(), data.len(), |out| {
+        .send_output(&id.into(), &Default::default(), data.len(), |out| {
             out.copy_from_slice(data)
         });
     let error = match result {

--- a/examples/c++-dataflow/node-rust-api/src/main.rs
+++ b/examples/c++-dataflow/node-rust-api/src/main.rs
@@ -34,7 +34,7 @@ fn next_input(inputs: &mut Inputs) -> ffi::DoraInput {
         Ok(input) => ffi::DoraInput {
             end_of_input: false,
             id: input.id.into(),
-            data: input.message.data.into(),
+            data: input.data().into_owned(),
         },
         Err(_) => ffi::DoraInput {
             end_of_input: true,
@@ -47,7 +47,12 @@ fn next_input(inputs: &mut Inputs) -> ffi::DoraInput {
 pub struct OutputSender<'a>(&'a mut DoraNode);
 
 fn send_output(sender: &mut OutputSender, id: String, data: &[u8]) -> ffi::DoraResult {
-    let error = match sender.0.send_output(&id.into(), &data.into()) {
+    let result = sender
+        .0
+        .send_output(&id.into(), Default::default(), data.len(), |out| {
+            out.copy_from_slice(data)
+        });
+    let error = match result {
         Ok(()) => String::new(),
         Err(err) => format!("{err:?}"),
     };

--- a/examples/iceoryx/node/src/main.rs
+++ b/examples/iceoryx/node/src/main.rs
@@ -17,7 +17,9 @@ fn main() -> eyre::Result<()> {
             "tick" => {
                 let random: u64 = rand::random();
                 let data: &[u8] = &random.to_le_bytes();
-                operator.send_output(&output, &data.into())?;
+                operator.send_output(&output, input.metadata(), data.len(), |out| {
+                    out.copy_from_slice(&data);
+                })?;
             }
             other => eprintln!("Ignoring unexpected input `{other}`"),
         }

--- a/examples/iceoryx/sink/src/main.rs
+++ b/examples/iceoryx/sink/src/main.rs
@@ -9,8 +9,9 @@ fn main() -> eyre::Result<()> {
     while let Ok(input) = inputs.recv() {
         match input.id.as_str() {
             "message" => {
-                let received_string = String::from_utf8(input.message.data.into())
-                    .wrap_err("received message was not utf8-encoded")?;
+                let data = input.data();
+                let received_string =
+                    std::str::from_utf8(&data).wrap_err("received message was not utf8-encoded")?;
                 println!("received message: {}", received_string);
                 if !received_string.starts_with("operator received random value ") {
                     bail!("unexpected message format (should start with 'operator received random value')")

--- a/examples/rust-dataflow/node/src/main.rs
+++ b/examples/rust-dataflow/node/src/main.rs
@@ -17,7 +17,9 @@ fn main() -> eyre::Result<()> {
             "tick" => {
                 let random: u64 = rand::random();
                 let data: &[u8] = &random.to_le_bytes();
-                operator.send_output(&output, &data.into())?;
+                operator.send_output(&output, input.metadata(), data.len(), |out| {
+                    out.copy_from_slice(data);
+                })?;
             }
             other => eprintln!("Ignoring unexpected input `{other}`"),
         }

--- a/examples/rust-dataflow/sink/src/main.rs
+++ b/examples/rust-dataflow/sink/src/main.rs
@@ -9,8 +9,9 @@ fn main() -> eyre::Result<()> {
     while let Ok(input) = inputs.recv() {
         match input.id.as_str() {
             "message" => {
-                let received_string = String::from_utf8(input.message.data.into())
-                    .wrap_err("received message was not utf8-encoded")?;
+                let data = input.data();
+                let received_string =
+                    std::str::from_utf8(&data).wrap_err("received message was not utf8-encoded")?;
                 println!("received message: {}", received_string);
                 if !received_string.starts_with("operator received random value ") {
                     bail!("unexpected message format (should start with 'operator received random value')")

--- a/libraries/communication-layer/Cargo.toml
+++ b/libraries/communication-layer/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [features]
 default = ["zenoh", "iceoryx"]
 zenoh = ["dep:zenoh", "dep:zenoh-config"]
-iceoryx = ["dep:iceoryx-rs"]
+iceoryx = ["dep:iceoryx-rs", "dep:iceoryx-sys"]
 
 [dependencies]
 eyre = "0.6.8"
@@ -15,6 +15,7 @@ zenoh-config = { git = "https://github.com/eclipse-zenoh/zenoh.git", optional = 
 
 [target.'cfg(unix)'.dependencies]
 iceoryx-rs = { git = "https://github.com/eclipse-iceoryx/iceoryx-rs.git", optional = true }
+iceoryx-sys = { git = "https://github.com/eclipse-iceoryx/iceoryx-rs.git", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/libraries/communication-layer/src/zenoh.rs
+++ b/libraries/communication-layer/src/zenoh.rs
@@ -3,8 +3,8 @@
 pub use zenoh_config;
 
 use super::{CommunicationLayer, Publisher, Subscriber};
-use crate::BoxError;
-use std::{sync::Arc, time::Duration};
+use crate::{BoxError, ReceivedSample};
+use std::{borrow::Cow, sync::Arc, time::Duration};
 use zenoh::{
     prelude::{EntityFactory, Priority, Receiver as _, SplitBuffer, ZFuture},
     publication::CongestionControl,
@@ -80,8 +80,8 @@ struct ZenohPublisher {
 }
 
 impl Publisher for ZenohPublisher {
-    fn prepare(&self, len: usize) -> Result<Box<dyn crate::Sample>, BoxError> {
-        Ok(Box::new(ZenohSample {
+    fn prepare(&self, len: usize) -> Result<Box<dyn crate::PublishSample>, BoxError> {
+        Ok(Box::new(ZenohPublishSample {
             sample: vec![0; len],
             publisher: self.publisher.clone(),
         }))
@@ -93,12 +93,12 @@ impl Publisher for ZenohPublisher {
 }
 
 #[derive(Clone)]
-struct ZenohSample {
+struct ZenohPublishSample {
     sample: Vec<u8>,
     publisher: zenoh::publication::Publisher<'static>,
 }
 
-impl<'a> crate::Sample<'a> for ZenohSample {
+impl<'a> crate::PublishSample<'a> for ZenohPublishSample {
     fn as_mut_slice(&mut self) -> &mut [u8] {
         &mut self.sample
     }
@@ -111,10 +111,22 @@ impl<'a> crate::Sample<'a> for ZenohSample {
 struct ZenohReceiver(zenoh::subscriber::Subscriber<'static>);
 
 impl Subscriber for ZenohReceiver {
-    fn recv(&mut self) -> Result<Option<Vec<u8>>, BoxError> {
+    fn recv(&mut self) -> Result<Option<Box<dyn ReceivedSample>>, BoxError> {
         match self.0.recv() {
-            Ok(sample) => Ok(Some(sample.value.payload.contiguous().into_owned())),
+            Ok(sample) => Ok(Some(Box::new(ZenohReceivedSample {
+                sample: sample.value.payload,
+            }))),
             Err(_) => Ok(None),
         }
+    }
+}
+
+struct ZenohReceivedSample {
+    sample: zenoh::buf::ZBuf,
+}
+
+impl ReceivedSample for ZenohReceivedSample {
+    fn get(&self) -> Cow<[u8]> {
+        self.sample.contiguous()
     }
 }

--- a/libraries/message/Cargo.toml
+++ b/libraries/message/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-capnp = "0.14.6"
+capnp = { version = "0.14.6", features = ["unaligned"] }
 
 [build-dependencies]
 capnpc = "0.14"

--- a/libraries/message/schema/message.capnp
+++ b/libraries/message/schema/message.capnp
@@ -6,9 +6,3 @@ struct Metadata {
   deadline @2 :UInt64;
   otelContext @3 :Text; # OpenTelemetry Context allowing shared context between nodes.
 }
-
-
-struct Message {
-  metadata @0 :Metadata;
-  data @1 :Data;
-}

--- a/libraries/message/src/lib.rs
+++ b/libraries/message/src/lib.rs
@@ -6,90 +6,41 @@ pub mod message_capnp {
     include!(concat!(env!("OUT_DIR"), "/message_capnp.rs"));
 }
 
-/// Helper function to serialize message
-pub fn serialize_message(message: &Message) -> Result<Vec<u8>, capnp::Error> {
-    let Message {
-        data,
-        metadata:
-            Metadata {
-                metadata_version,
-                watermark,
-                deadline,
-                open_telemetry_context: otel_context,
-            },
-    } = message;
+impl Metadata<'_> {
+    pub fn serialize(&self) -> Result<Vec<u8>, capnp::Error> {
+        let Metadata {
+            metadata_version,
+            watermark,
+            deadline,
+            open_telemetry_context: otel_context,
+        } = self;
 
-    // Build the metadata
-    let mut meta_builder = capnp::message::Builder::new_default();
-    let mut metadata = meta_builder.init_root::<message_capnp::metadata::Builder>();
-    metadata.set_metadata_version(*metadata_version);
-    metadata.set_watermark(*watermark);
-    metadata.set_deadline(*deadline);
-    metadata.set_otel_context(otel_context);
+        let mut meta_builder = capnp::message::Builder::new_default();
+        let mut metadata = meta_builder.init_root::<message_capnp::metadata::Builder>();
+        metadata.set_metadata_version(*metadata_version);
+        metadata.set_watermark(*watermark);
+        metadata.set_deadline(*deadline);
+        metadata.set_otel_context(otel_context);
 
-    // Build the data of the message
-    let mut builder = capnp::message::Builder::new_default();
-    let mut message = builder.init_root::<message_capnp::message::Builder>();
-    message.set_data(data);
-    message.set_metadata(metadata.into_reader())?;
+        let mut buffer = Vec::new();
+        capnp::serialize::write_message(&mut buffer, &meta_builder)?;
+        Ok(buffer)
+    }
 
-    let mut buffer = Vec::new();
-    capnp::serialize::write_message(&mut buffer, &builder)?;
-    Ok(buffer)
-}
+    pub fn deserialize(raw: &mut &[u8]) -> Result<Self, capnp::Error> {
+        let deserialized = capnp::serialize::read_message_from_flat_slice(raw, Default::default())?
+            .into_typed::<message_capnp::metadata::Owned>();
 
-pub fn deserialize_message(mut raw: &[u8]) -> Result<Message, capnp::Error> {
-    let deserialized =
-        capnp::serialize::read_message_from_flat_slice(&mut raw, Default::default())?
-            .into_typed::<message_capnp::message::Owned>();
+        let metadata_reader = deserialized.get()?;
 
-    let reader = deserialized.get()?;
-    let metadata_reader = reader.get_metadata()?;
-
-    let message = Message {
-        data: reader.get_data()?.into(),
-        metadata: Metadata {
+        let metadata = Metadata {
             metadata_version: metadata_reader.get_metadata_version(),
             watermark: metadata_reader.get_watermark(),
             deadline: metadata_reader.get_deadline(),
             open_telemetry_context: metadata_reader.get_otel_context()?.into(),
-        },
-    };
+        };
 
-    // TODO: avoid copying and make this zero copy
-    Ok(message.into_owned())
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Message<'a> {
-    pub data: Cow<'a, [u8]>,
-    pub metadata: Metadata<'a>,
-}
-
-impl<'a> From<&'a [u8]> for Message<'a> {
-    fn from(data: &'a [u8]) -> Self {
-        Self {
-            data: data.into(),
-            metadata: Default::default(),
-        }
-    }
-}
-
-impl From<Vec<u8>> for Message<'static> {
-    fn from(data: Vec<u8>) -> Self {
-        Self {
-            data: data.into(),
-            metadata: Default::default(),
-        }
-    }
-}
-
-impl Message<'_> {
-    pub fn into_owned(self) -> Message<'static> {
-        Message {
-            data: self.data.into_owned().into(),
-            metadata: self.metadata.into_owned(),
-        }
+        Ok(metadata.into_owned())
     }
 }
 


### PR DESCRIPTION
There is still a `publish` method with the old behavior for convenience.