### PR TITLE
Make `PublishSample` an owned type and change output API to 3-step process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1452,7 +1452,7 @@ dependencies = [
 [[package]]
 name = "iceoryx-rs"
 version = "0.1.0"
-source = "git+https://github.com/eclipse-iceoryx/iceoryx-rs.git#68fbd034a77c6ed98cb75a939d406429ef26b0dd"
+source = "git+https://github.com/phil-opp/iceoryx-rs.git?branch=arc-sample#8f97a4015eb95463250e6c7c97fdb9cebdda4b5b"
 dependencies = [
  "iceoryx-sys",
  "thiserror",
@@ -1461,7 +1461,7 @@ dependencies = [
 [[package]]
 name = "iceoryx-sys"
 version = "0.1.0"
-source = "git+https://github.com/eclipse-iceoryx/iceoryx-rs.git#68fbd034a77c6ed98cb75a939d406429ef26b0dd"
+source = "git+https://github.com/phil-opp/iceoryx-rs.git?branch=arc-sample#8f97a4015eb95463250e6c7c97fdb9cebdda4b5b"
 dependencies = [
  "cpp",
  "cpp_build",

--- a/apis/c/node/src/lib.rs
+++ b/apis/c/node/src/lib.rs
@@ -192,9 +192,10 @@ unsafe fn try_send_output(
     let id = std::str::from_utf8(unsafe { slice::from_raw_parts(id_ptr, id_len) })?;
     let output_id = id.to_owned().into();
     let data = unsafe { slice::from_raw_parts(data_ptr, data_len) };
-    context
+    let mut output = context
         .node
-        .send_output(&output_id, &Default::default(), data.len(), |out| {
-            out.copy_from_slice(data);
-        })
+        .prepare_output(&output_id, &Default::default(), data.len())?;
+    output.data_mut().copy_from_slice(data);
+    output.send()?;
+    Ok(())
 }

--- a/apis/c/operator/operator_api.h
+++ b/apis/c/operator/operator_api.h
@@ -20,7 +20,7 @@ extern "C"
 
     EXPORT OnInputResult_t dora_on_input(
         const Input_t *input,
-        const SendOutput_t *send_output,
+        const PrepareOutput_t *send_output,
         void *operator_context);
 
     void __dora_type_assertions()

--- a/apis/c/operator/operator_types.h
+++ b/apis/c/operator/operator_types.h
@@ -101,45 +101,127 @@ typedef struct Input {
     Metadata_t metadata;
 } Input_t;
 
-/** <No documentation available> */
-typedef struct Output {
-    /** <No documentation available> */
-    Vec_uint8_t id;
+/** \brief
+ *  Like [`slice_ref`] and [`slice_mut`], but with any lifetime attached
+ *  whatsoever.
+ *
+ *  It is only intended to be used as the parameter of a **callback** that
+ *  locally borrows it, due to limitations of the [`ReprC`][
+ *  `trait@crate::layout::ReprC`] design _w.r.t._ higher-rank trait bounds.
+ *
+ *  # C layout (for some given type T)
+ *
+ *  ```c
+ *  typedef struct {
+ *  // Cannot be NULL
+ *  T * ptr;
+ *  size_t len;
+ *  } slice_T;
+ *  ```
+ *
+ *  # Nullable pointer?
+ *
+ *  If you want to support the above typedef, but where the `ptr` field is
+ *  allowed to be `NULL` (with the contents of `len` then being undefined)
+ *  use the `Option< slice_ptr<_> >` type.
+ */
+typedef struct slice_raw_uint8 {
+    /** \brief
+     *  Pointer to the first element (if any).
+     */
+    uint8_t * ptr;
 
-    /** <No documentation available> */
-    Vec_uint8_t data;
-
-    /** <No documentation available> */
-    Metadata_t metadata;
-} Output_t;
+    /** \brief
+     *  Element count
+     */
+    size_t len;
+} slice_raw_uint8_t;
 
 /** \brief
- *  `Arc<dyn Send + Sync + Fn(A1) -> Ret>`
+ *  `Box<dyn 'static + Send + FnMut() -> Ret>`
  */
-typedef struct ArcDynFn1_DoraResult_Output {
+typedef struct BoxDynFnMut0_slice_raw_uint8 {
     /** <No documentation available> */
     void * env_ptr;
 
     /** <No documentation available> */
-    DoraResult_t (*call)(void *, Output_t);
+    slice_raw_uint8_t (*call)(void *);
+
+    /** <No documentation available> */
+    void (*free)(void *);
+} BoxDynFnMut0_slice_raw_uint8_t;
+
+/** \brief
+ *  `Box<dyn 'static + Send + FnMut() -> Ret>`
+ */
+typedef struct BoxDynFnMut0_DoraResult {
+    /** <No documentation available> */
+    void * env_ptr;
+
+    /** <No documentation available> */
+    DoraResult_t (*call)(void *);
+
+    /** <No documentation available> */
+    void (*free)(void *);
+} BoxDynFnMut0_DoraResult_t;
+
+/** <No documentation available> */
+typedef struct Output {
+    /** <No documentation available> */
+    BoxDynFnMut0_slice_raw_uint8_t data_mut;
+
+    /** <No documentation available> */
+    BoxDynFnMut0_DoraResult_t send;
+} Output_t;
+
+/** <No documentation available> */
+typedef struct PrepareOutputResult {
+    /** <No documentation available> */
+    DoraResult_t result;
+
+    /** <No documentation available> */
+    Output_t output;
+} PrepareOutputResult_t;
+
+/** <No documentation available> */
+typedef struct OutputMetadata {
+    /** <No documentation available> */
+    Vec_uint8_t id;
+
+    /** <No documentation available> */
+    Metadata_t metadata;
+
+    /** <No documentation available> */
+    size_t data_len;
+} OutputMetadata_t;
+
+/** \brief
+ *  `Arc<dyn Send + Sync + Fn(A1) -> Ret>`
+ */
+typedef struct ArcDynFn1_PrepareOutputResult_OutputMetadata {
+    /** <No documentation available> */
+    void * env_ptr;
+
+    /** <No documentation available> */
+    PrepareOutputResult_t (*call)(void *, OutputMetadata_t);
 
     /** <No documentation available> */
     void (*release)(void *);
 
     /** <No documentation available> */
     void (*retain)(void *);
-} ArcDynFn1_DoraResult_Output_t;
+} ArcDynFn1_PrepareOutputResult_OutputMetadata_t;
 
 /** <No documentation available> */
-typedef struct SendOutput {
+typedef struct PrepareOutput {
     /** <No documentation available> */
-    ArcDynFn1_DoraResult_Output_t send_output;
-} SendOutput_t;
+    ArcDynFn1_PrepareOutputResult_OutputMetadata_t prepare_output;
+} PrepareOutput_t;
 
 /** <No documentation available> */
 typedef struct DoraOnInput {
     /** <No documentation available> */
-    OnInputResult_t (*on_input)(Input_t const *, SendOutput_t const *, void *);
+    OnInputResult_t (*on_input)(Input_t const *, PrepareOutput_t const *, void *);
 } DoraOnInput_t;
 
 

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -51,11 +51,11 @@ impl Node {
 
     pub fn send_output(&mut self, output_id: String, data: &PyBytes) -> Result<()> {
         let data = &data.as_bytes();
-        self.node
-            .send_output(&output_id.into(), &Default::default(), data.len(), |out| {
-                out.copy_from_slice(data);
-            })
-            .wrap_err("Could not send output")
+        let mut output =
+            self.node
+                .prepare_output(&output_id.into(), &Default::default(), data.len())?;
+        output.data_mut().copy_from_slice(data);
+        output.send().wrap_err("Could not send output")
     }
 
     pub fn id(&self) -> String {

--- a/apis/rust/operator/macros/src/lib.rs
+++ b/apis/rust/operator/macros/src/lib.rs
@@ -53,11 +53,11 @@ fn register_operator_impl(item: &TokenStream2) -> syn::Result<TokenStream2> {
         #[no_mangle]
         pub unsafe extern "C" fn dora_on_input(
             input: &dora_operator_api::types::Input,
-            send_output: &dora_operator_api::types::SendOutput,
+            prepare_output: &dora_operator_api::types::PrepareOutput,
             operator_context: *mut std::ffi::c_void,
         ) -> dora_operator_api::types::OnInputResult {
             dora_operator_api::raw::dora_on_input::<#operator_ty>(
-                input, send_output, operator_context
+                input, prepare_output, operator_context
             )
         }
 

--- a/apis/rust/operator/src/lib.rs
+++ b/apis/rust/operator/src/lib.rs
@@ -4,7 +4,7 @@
 pub use dora_operator_api_macros::register_operator;
 pub use dora_operator_api_types as types;
 pub use types::DoraStatus;
-use types::{Metadata, Output, SendOutput};
+use types::{Metadata, Output, OutputMetadata, PrepareOutput};
 
 pub mod raw;
 
@@ -18,17 +18,35 @@ pub trait DoraOperator: Default {
     ) -> Result<DoraStatus, String>;
 }
 
-pub struct DoraOutputSender<'a>(&'a SendOutput);
+pub struct DoraOutputSender<'a>(&'a PrepareOutput);
 
 impl DoraOutputSender<'_> {
-    pub fn send(&mut self, id: String, data: Vec<u8>) -> Result<(), String> {
-        let result = self.0.send_output.call(Output {
+    pub fn prepare(&mut self, id: String, data_len: usize) -> Result<DoraOutput, String> {
+        let result = self.0.prepare_output.call(OutputMetadata {
             id: id.into(),
-            data: data.into(),
             metadata: Metadata {
                 open_telemetry_context: String::new().into(), // TODO
             },
+            data_len,
         });
+        match result.result.error {
+            None => Ok(DoraOutput(result.output)),
+            Some(error) => Err(error.into()),
+        }
+    }
+}
+
+#[must_use]
+pub struct DoraOutput(Output);
+
+impl DoraOutput {
+    pub fn data_mut(&mut self) -> &mut [u8] {
+        let raw = self.0.data_mut.call();
+        unsafe { std::slice::from_raw_parts_mut(raw.ptr.as_ptr(), raw.len) }
+    }
+
+    pub fn send(mut self) -> Result<(), String> {
+        let result = self.0.send.call();
         match result.error {
             None => Ok(()),
             Some(error) => Err(error.into()),

--- a/apis/rust/operator/src/raw.rs
+++ b/apis/rust/operator/src/raw.rs
@@ -1,5 +1,5 @@
 use crate::{DoraOperator, DoraOutputSender, DoraStatus};
-use dora_operator_api_types::{DoraInitResult, DoraResult, Input, OnInputResult, SendOutput};
+use dora_operator_api_types::{DoraInitResult, DoraResult, Input, OnInputResult, PrepareOutput};
 use std::ffi::c_void;
 
 pub type OutputFnRaw = unsafe extern "C" fn(
@@ -28,7 +28,7 @@ pub unsafe fn dora_drop_operator<O>(operator_context: *mut c_void) -> DoraResult
 
 pub unsafe fn dora_on_input<O: DoraOperator>(
     input: &Input,
-    send_output: &SendOutput,
+    send_output: &PrepareOutput,
     operator_context: *mut std::ffi::c_void,
 ) -> OnInputResult {
     let mut output_sender = DoraOutputSender(send_output);

--- a/examples/c++-dataflow/node-rust-api/src/main.rs
+++ b/examples/c++-dataflow/node-rust-api/src/main.rs
@@ -51,11 +51,13 @@ fn next_input(inputs: &mut Inputs) -> ffi::DoraInput {
 pub struct OutputSender<'a>(&'a mut DoraNode);
 
 fn send_output(sender: &mut OutputSender, id: String, data: &[u8]) -> ffi::DoraResult {
-    let result = sender
+    let output = sender
         .0
-        .send_output(&id.into(), &Default::default(), data.len(), |out| {
-            out.copy_from_slice(data)
-        });
+        .prepare_output(&id.into(), &Default::default(), data.len());
+    let result = output.and_then(|mut output| {
+        output.data_mut().copy_from_slice(data);
+        output.send()
+    });
     let error = match result {
         Ok(()) => String::new(),
         Err(err) => format!("{err:?}"),

--- a/examples/c++-dataflow/operator-rust-api/src/lib.rs
+++ b/examples/c++-dataflow/operator-rust-api/src/lib.rs
@@ -39,11 +39,12 @@ mod ffi {
 pub struct OutputSender<'a, 'b>(&'a mut DoraOutputSender<'b>);
 
 fn send_output(sender: &mut OutputSender, id: &str, data: &[u8]) -> SendOutputResult {
-    let error = sender
-        .0
-        .send(id.into(), data.to_owned())
-        .err()
-        .unwrap_or_default();
+    let mut result = || {
+        let mut sample = sender.0.prepare(id.into(), data.len())?;
+        sample.data_mut().copy_from_slice(data);
+        sample.send()
+    };
+    let error = result().err().unwrap_or_default();
     SendOutputResult { error }
 }
 

--- a/examples/iceoryx/node/src/main.rs
+++ b/examples/iceoryx/node/src/main.rs
@@ -17,9 +17,9 @@ fn main() -> eyre::Result<()> {
             "tick" => {
                 let random: u64 = rand::random();
                 let data: &[u8] = &random.to_le_bytes();
-                operator.send_output(&output, input.metadata(), data.len(), |out| {
-                    out.copy_from_slice(&data);
-                })?;
+                let mut output = operator.prepare_output(&output, input.metadata(), data.len())?;
+                output.data_mut().copy_from_slice(&data);
+                output.send()?;
             }
             other => eprintln!("Ignoring unexpected input `{other}`"),
         }

--- a/examples/iceoryx/operator/src/lib.rs
+++ b/examples/iceoryx/operator/src/lib.rs
@@ -31,7 +31,9 @@ impl DoraOperator for ExampleOperator {
                     "operator received random value {parsed} after {} ticks",
                     self.ticks
                 );
-                output_sender.send("status".into(), output.into_bytes())?;
+                let mut sample = output_sender.prepare("status".into(), output.len())?;
+                sample.data_mut().copy_from_slice(output.as_bytes());
+                sample.send()?;
                 self.last_random_at = Some(Instant::now());
             }
             other => eprintln!("ignoring unexpected input {other}"),

--- a/examples/rust-dataflow/node/src/main.rs
+++ b/examples/rust-dataflow/node/src/main.rs
@@ -17,9 +17,9 @@ fn main() -> eyre::Result<()> {
             "tick" => {
                 let random: u64 = rand::random();
                 let data: &[u8] = &random.to_le_bytes();
-                operator.send_output(&output, input.metadata(), data.len(), |out| {
-                    out.copy_from_slice(data);
-                })?;
+                let mut output = operator.prepare_output(&output, input.metadata(), data.len())?;
+                output.data_mut().copy_from_slice(data);
+                output.send()?;
             }
             other => eprintln!("Ignoring unexpected input `{other}`"),
         }

--- a/examples/rust-dataflow/operator/src/lib.rs
+++ b/examples/rust-dataflow/operator/src/lib.rs
@@ -27,11 +27,13 @@ impl DoraOperator for ExampleOperator {
                     let data: [u8; 8] = data.try_into().map_err(|_| "unexpected random data")?;
                     u64::from_le_bytes(data)
                 };
-                let output = format!(
+                let data = format!(
                     "operator received random value {parsed} after {} ticks",
                     self.ticks
                 );
-                output_sender.send("status".into(), output.into_bytes())?;
+                let mut output = output_sender.prepare("status".into(), data.len())?;
+                output.data_mut().copy_from_slice(data.as_bytes());
+                output.send()?;
                 self.last_random_at = Some(Instant::now());
             }
             other => eprintln!("ignoring unexpected input {other}"),

--- a/libraries/communication-layer/Cargo.toml
+++ b/libraries/communication-layer/Cargo.toml
@@ -14,8 +14,8 @@ zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", optional = true }
 zenoh-config = { git = "https://github.com/eclipse-zenoh/zenoh.git", optional = true }
 
 [target.'cfg(unix)'.dependencies]
-iceoryx-rs = { git = "https://github.com/eclipse-iceoryx/iceoryx-rs.git", optional = true }
-iceoryx-sys = { git = "https://github.com/eclipse-iceoryx/iceoryx-rs.git", optional = true }
+iceoryx-rs = { git = "https://github.com/phil-opp/iceoryx-rs.git", branch = "arc-sample", optional = true }
+iceoryx-sys = { git = "https://github.com/phil-opp/iceoryx-rs.git", branch = "arc-sample", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/libraries/communication-layer/src/lib.rs
+++ b/libraries/communication-layer/src/lib.rs
@@ -41,7 +41,7 @@ pub trait Publisher: Send + Sync {
     /// This function makes it possible to construct messages without
     /// any additional copying. The returned [`Sample`] is initialized
     /// with zeros.
-    fn prepare(&self, len: usize) -> Result<Box<dyn PublishSample + '_>, BoxError>;
+    fn prepare(&self, len: usize) -> Result<Box<dyn PublishSample>, BoxError>;
 
     /// Clone this publisher, returning the clone as a
     /// [trait object](https://doc.rust-lang.org/book/ch17-02-trait-objects.html).
@@ -61,7 +61,7 @@ pub trait Publisher: Send + Sync {
 }
 
 /// A prepared message constructed by [`Publisher::prepare`].
-pub trait PublishSample<'a>: Send + Sync {
+pub trait PublishSample: Send + Sync {
     /// Gets a reference to the prepared message.
     ///
     /// Makes it possible to construct the message in-place.

--- a/libraries/communication-layer/src/zenoh.rs
+++ b/libraries/communication-layer/src/zenoh.rs
@@ -98,7 +98,7 @@ struct ZenohPublishSample {
     publisher: zenoh::publication::Publisher<'static>,
 }
 
-impl<'a> crate::PublishSample<'a> for ZenohPublishSample {
+impl crate::PublishSample for ZenohPublishSample {
     fn as_mut_slice(&mut self) -> &mut [u8] {
         &mut self.sample
     }


### PR DESCRIPTION
Instead of passing a closure, we now `prepare` the output first, then write the data, and finally send it out. This should make it possible to enable zero-copy send operations also in Rust/C operators and C nodes since we avoid the type and lifetime complexity that an additional closure argument would cause.

This is a draft because it reqiures an experimental `SampleMutArc` interface of `iceoryx-rs`. I created a PR at https://github.com/eclipse-iceoryx/iceoryx-rs/pull/61 to propose this new `Arc`-based interface upstream.