### PR TITLE
Create release artifacts on the CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Release
+
+permissions:
+  contents: write
+
+on:
+  release:
+    types:
+      - "published"
+
+jobs:
+  release:
+    name: "Release"
+
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Cap'n Proto and libacl-dev (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get install -y capnproto libcapnp-dev libacl1-dev
+      - name: Install Cap'n Proto (macOS)
+        if: runner.os == 'macOS'
+        run: brew install capnp
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
+          HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK: 1
+          HOMEBREW_NO_INSTALL_CLEANUP: 1
+      - name: Install Cap'n Proto (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install capnproto
+          echo "$Env:Programfiles\capnproto" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: "Build binaries"
+        uses: actions-rs/cargo@v1
+        timeout-minutes: 30
+        with:
+          command: build
+          args: --release -p dora-runtime -p dora-coordinator -p dora-cli
+
+      - name: Create Archive (Linux)
+        if: runner.os == 'Linux' || runner.os == 'macOS'
+        run: zip --junk-paths archive.zip target/release/dora-runtime target/release/dora-coordinator target/release/dora-cli
+      - name: Create Archive (Windows)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: Compress-Archive target/release/dora-runtime.exe target/release/dora-coordinator.exe target/release/dora-cli.exe archive.zip
+
+      - name: "Upload release asset"
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: archive.zip
+          asset_name: dora-${{ matrix.platform }}.zip
+          asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           mkdir archive
           cp target/release/dora-runtime archive
           cp target/release/dora-coordinator archive
-          cp target/release/dora archive
+          cp target/release/dora-cli archive/dora
           mkdir archive/iceoryx
           find target -type f -wholename "*/iceoryx-install/bin/iox-roudi" -exec cp {} archive/iceoryx \;
           find target -type f -wholename "*/iceoryx-install/share/doc/iceoryx_posh/LICENSE" -exec cp {} archive/iceoryx \;
@@ -61,13 +61,15 @@ jobs:
           zip -r ../archive.zip .
           cd ..
 
-      - name: Create Archive (Unix)
-        if: runner.os == 'Linux' || runner.os == 'macOS'
-        run: zip --junk-paths archive.zip target/release/dora-runtime target/release/dora-coordinator target/release/dora iceoryx
       - name: Create Archive (Windows)
         if: runner.os == 'Windows'
         shell: powershell
-        run: Compress-Archive target/release/dora-runtime.exe,target/release/dora-coordinator.exe,target/release/dora.exe archive.zip
+        run: |
+          New-Item -Path archive -ItemType Directory
+          Copy-Item target/release/dora-runtime.exe -Destination archive
+          Copy-Item target/release/dora-coordinator.exe -Destination archive
+          Copy-Item target/release/dora-cli.exe -Destination archive/dora.exe
+          Compress-Archive -Path archive\* -DestinationPath archive.zip
 
       - name: "Upload release asset"
         uses: actions/upload-release-asset@v1.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,12 +47,19 @@ jobs:
           command: build
           args: --release -p dora-runtime -p dora-coordinator -p dora-cli
 
-      - name: "Prepare iceoryx (Unix)"
+      - name: "Create Archive (Unix)"
         if: runner.os == 'Linux' || runner.os == 'macOS'
         run: |
+          mkdir archive
+          cd archive
+          cp target/release/dora-runtime .
+          cp target/release/dora-coordinator .
+          cp target/release/dora .
           mkdir iceoryx
           find target -type f -wholename "*/iceoryx-install/bin/iox-roudi" -exec cp {} iceoryx \;
           find target -type f -wholename "*/iceoryx-install/share/doc/iceoryx_posh/LICENSE" -exec cp {} iceoryx \;
+          zip -r ../archive.zip .
+          cd ..
 
       - name: Create Archive (Unix)
         if: runner.os == 'Linux' || runner.os == 'macOS'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,9 +47,16 @@ jobs:
           command: build
           args: --release -p dora-runtime -p dora-coordinator -p dora-cli
 
-      - name: Create Archive (Linux)
+      - name: "Prepare iceoryx (Unix)"
         if: runner.os == 'Linux' || runner.os == 'macOS'
-        run: zip --junk-paths archive.zip target/release/dora-runtime target/release/dora-coordinator target/release/dora
+        run: |
+          mkdir iceoryx
+          find target -type f -wholename "*/iceoryx-install/bin/iox-roudi" -exec cp {} iceoryx \;
+          find target -type f -wholename "*/iceoryx-install/share/doc/iceoryx_posh/LICENSE" -exec cp {} iceoryx \;
+
+      - name: Create Archive (Unix)
+        if: runner.os == 'Linux' || runner.os == 'macOS'
+        run: zip --junk-paths archive.zip target/release/dora-runtime target/release/dora-coordinator target/release/dora iceoryx
       - name: Create Archive (Windows)
         if: runner.os == 'Windows'
         shell: powershell

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Create Archive (Windows)
         if: runner.os == 'Windows'
         shell: powershell
-        run: Compress-Archive target/release/dora-runtime.exe target/release/dora-coordinator.exe target/release/dora-cli.exe archive.zip
+        run: Compress-Archive target/release/dora-runtime.exe,target/release/dora-coordinator.exe,target/release/dora-cli.exe archive.zip
 
       - name: "Upload release asset"
         uses: actions/upload-release-asset@v1.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,5 +76,5 @@ jobs:
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: archive.zip
-          asset_name: dora-${{ matrix.platform }}.zip
+          asset_name: dora-${{ github.ref_name }}-x86_64-${{ runner.os }}.zip
           asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,11 +49,11 @@ jobs:
 
       - name: Create Archive (Linux)
         if: runner.os == 'Linux' || runner.os == 'macOS'
-        run: zip --junk-paths archive.zip target/release/dora-runtime target/release/dora-coordinator target/release/dora-cli
+        run: zip --junk-paths archive.zip target/release/dora-runtime target/release/dora-coordinator target/release/dora
       - name: Create Archive (Windows)
         if: runner.os == 'Windows'
         shell: powershell
-        run: Compress-Archive target/release/dora-runtime.exe,target/release/dora-coordinator.exe,target/release/dora-cli.exe archive.zip
+        run: Compress-Archive target/release/dora-runtime.exe,target/release/dora-coordinator.exe,target/release/dora.exe archive.zip
 
       - name: "Upload release asset"
         uses: actions/upload-release-asset@v1.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,13 +51,13 @@ jobs:
         if: runner.os == 'Linux' || runner.os == 'macOS'
         run: |
           mkdir archive
+          cp target/release/dora-runtime archive
+          cp target/release/dora-coordinator archive
+          cp target/release/dora archive
+          mkdir archive/iceoryx
+          find target -type f -wholename "*/iceoryx-install/bin/iox-roudi" -exec cp {} archive/iceoryx \;
+          find target -type f -wholename "*/iceoryx-install/share/doc/iceoryx_posh/LICENSE" -exec cp {} archive/iceoryx \;
           cd archive
-          cp target/release/dora-runtime .
-          cp target/release/dora-coordinator .
-          cp target/release/dora .
-          mkdir iceoryx
-          find target -type f -wholename "*/iceoryx-install/bin/iox-roudi" -exec cp {} iceoryx \;
-          find target -type f -wholename "*/iceoryx-install/share/doc/iceoryx_posh/LICENSE" -exec cp {} iceoryx \;
           zip -r ../archive.zip .
           cd ..
 

--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [[bin]]
-name = "dora"
+name = "dora-cli"
 path = "src/main.rs"
 
 [dependencies]


### PR DESCRIPTION
Builds the dora cli, runtime, and coordinator for Linux, macOS, and Windows whenever a new GitHub release is created. The binaries are then compressed as a zip archive and added to the release as artifacts. On platforms where iceoryx is supported (Linux and macOS), we also include the `iox-roudi` binary in the release (together with its LICENSE file).

Test release: https://github.com/dora-rs/dora/releases/tag/v0.0.0-test.4

Should be merged after https://github.com/dora-rs/dora/pull/84.