### PR TITLE
Fix opentelemetry context span trace duration

### DIFF
--- a/apis/python/operator/src/lib.rs
+++ b/apis/python/operator/src/lib.rs
@@ -4,7 +4,7 @@ use dora_node_api::Metadata;
 use eyre::{Context, Result};
 use pyo3::{prelude::*, types::PyDict};
 
-pub fn pydict_to_metadata<'a>(dict: Option<&'a PyDict>) -> Result<Metadata<'a>> {
+pub fn pydict_to_metadata(dict: Option<&PyDict>) -> Result<Metadata> {
     let mut default_metadata = Metadata::default();
     if let Some(metadata) = dict {
         for (key, value) in metadata.iter() {

--- a/binaries/runtime/src/operator/python.rs
+++ b/binaries/runtime/src/operator/python.rs
@@ -96,7 +96,7 @@ pub fn spawn(
                 use opentelemetry::trace::TraceContextExt;
                 use opentelemetry::{trace::Tracer, Context as OtelContext};
 
-                let cx = deserialize_context(&input.metadata.open_telemetry_context.to_string());
+                let cx = deserialize_context(&input.metadata.open_telemetry_context);
                 let span = tracer.start_with_context(format!("{}", input.id), &cx);
 
                 let child_cx = OtelContext::current_with_span(span);

--- a/binaries/runtime/src/operator/python.rs
+++ b/binaries/runtime/src/operator/python.rs
@@ -4,7 +4,6 @@ use super::{OperatorEvent, Tracer};
 use dora_node_api::{communication::Publisher, config::DataId};
 use dora_operator_api_python::metadata_to_pydict;
 use eyre::{bail, eyre, Context};
-use opentelemetry::trace::TraceContextExt;
 use pyo3::{
     pyclass,
     types::IntoPyDict,
@@ -94,7 +93,9 @@ pub fn spawn(
             #[cfg(feature = "tracing")]
             let (_child_cx, string_cx) = {
                 use dora_tracing::{deserialize_context, serialize_context};
+                use opentelemetry::trace::TraceContextExt;
                 use opentelemetry::{trace::Tracer, Context as OtelContext};
+
                 let cx = deserialize_context(&input.metadata.open_telemetry_context.to_string());
                 let span = tracer.start_with_context(format!("{}", input.id), &cx);
 

--- a/binaries/runtime/src/operator/shared_lib.rs
+++ b/binaries/runtime/src/operator/shared_lib.rs
@@ -133,7 +133,7 @@ impl<'lib> SharedLibraryOperator<'lib> {
 
                 let span = tracer.start_with_context(
                     format!("{}", input.id),
-                    &deserialize_context(&input.metadata.open_telemetry_context.to_string()),
+                    &deserialize_context(&input.metadata.open_telemetry_context),
                 );
                 let child_cx = OtelContext::current_with_span(span);
                 let string_cx = serialize_context(&child_cx);

--- a/examples/python-dataflow/run.rs
+++ b/examples/python-dataflow/run.rs
@@ -17,7 +17,7 @@ async fn main() -> eyre::Result<()> {
 async fn build_package(package: &str) -> eyre::Result<()> {
     let cargo = std::env::var("CARGO").unwrap();
     let mut cmd = tokio::process::Command::new(&cargo);
-    cmd.arg("build").arg("--release");
+    cmd.arg("build");
     cmd.arg("--package").arg(package);
     if !cmd.status().await?.success() {
         bail!("failed to build {package}");

--- a/examples/python-dataflow/run.sh
+++ b/examples/python-dataflow/run.sh
@@ -10,4 +10,4 @@ cd ../../../examples/python-dataflow
 pip install --upgrade pip
 pip install -r requirements.txt
 
-cargo run -p dora-coordinator --release -- --run-dataflow dataflow_without_webcam.yml
+cargo run -p dora-coordinator -- --run-dataflow dataflow_without_webcam.yml


### PR DESCRIPTION
## Problem

There used to be a bug in the duration of the open telemetry span trace. It appeared that creating an `otel_context` took ownership of the `span` trace. 

## Solution

By making the open telemetry context live long enough, the span trace duration registers the right duration.