### PR TITLE
Add support for duplicating operators and nodes

### DIFF
--- a/binaries/coordinator/src/run/runtime.rs
+++ b/binaries/coordinator/src/run/runtime.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 pub fn spawn_runtime_node(
     runtime: &Path,
     node_id: NodeId,
-    node: &descriptor::RuntimeNode,
+    node: &descriptor::ResolvedRuntimeNode,
     communication: &dora_node_api::config::CommunicationConfig,
     working_dir: &Path,
 ) -> eyre::Result<tokio::task::JoinHandle<eyre::Result<(), eyre::Error>>> {

--- a/libraries/core/src/descriptor/visualize.rs
+++ b/libraries/core/src/descriptor/visualize.rs
@@ -1,4 +1,6 @@
-use super::{CoreNodeKind, CustomNode, OperatorDefinition, ResolvedNode, RuntimeNode};
+use super::{
+    CoreNodeKind, CustomNode, ResolvedNode, ResolvedOperatorDefinition, ResolvedRuntimeNode,
+};
 use dora_node_api::config::{format_duration, DataId, InputMapping, NodeId, UserInputMapping};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
@@ -69,7 +71,7 @@ fn visualize_node(node: &ResolvedNode, flowchart: &mut String) {
     let node_id = &node.id;
     match &node.kind {
         CoreNodeKind::Custom(node) => visualize_custom_node(node_id, node, flowchart),
-        CoreNodeKind::Runtime(RuntimeNode { operators }) => {
+        CoreNodeKind::Runtime(ResolvedRuntimeNode { operators }) => {
             visualize_runtime_node(node_id, operators, flowchart)
         }
     }
@@ -90,7 +92,7 @@ fn visualize_custom_node(node_id: &NodeId, node: &CustomNode, flowchart: &mut St
 
 fn visualize_runtime_node(
     node_id: &NodeId,
-    operators: &[OperatorDefinition],
+    operators: &[ResolvedOperatorDefinition],
     flowchart: &mut String,
 ) {
     writeln!(flowchart, "subgraph {node_id}").unwrap();
@@ -124,7 +126,7 @@ fn visualize_node_inputs(
             flowchart,
             nodes,
         ),
-        CoreNodeKind::Runtime(RuntimeNode { operators }) => {
+        CoreNodeKind::Runtime(ResolvedRuntimeNode { operators }) => {
             for operator in operators {
                 visualize_inputs(
                     &format!("{node_id}/{}", operator.id),
@@ -181,7 +183,7 @@ fn visualize_user_mapping(
                     source_found = true;
                 }
             }
-            (CoreNodeKind::Runtime(RuntimeNode { operators }), Some(operator_id)) => {
+            (CoreNodeKind::Runtime(ResolvedRuntimeNode { operators }), Some(operator_id)) => {
                 if let Some(operator) = operators.iter().find(|o| &o.id == operator_id) {
                     if operator.config.outputs.contains(output) {
                         let data = if output == input_id {


### PR DESCRIPTION
To support creating multiple copies of operators and nodes, for example for handling multiple identical cameras.

Proposed in the meeting on Wednesday.