### PR TITLE
Add support for replies in CLI and implement stop command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,12 +886,13 @@ name = "dora-cli"
 version = "0.1.0"
 dependencies = [
  "clap 4.0.3",
- "communication-layer-pub-sub",
  "dora-core",
  "eyre",
+ "serde_json",
  "serde_yaml 0.9.11",
  "tempfile",
  "webbrowser",
+ "zenoh",
 ]
 
 [[package]]
@@ -900,7 +901,6 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "clap 3.2.20",
- "communication-layer-pub-sub",
  "dora-core",
  "dora-message",
  "dora-node-api",
@@ -909,6 +909,7 @@ dependencies = [
  "futures-concurrency 5.0.1",
  "rand",
  "serde",
+ "serde_json",
  "serde_yaml 0.8.23",
  "time",
  "tokio",
@@ -917,6 +918,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid 0.8.2",
+ "zenoh",
 ]
 
 [[package]]
@@ -3234,9 +3236,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.79"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+checksum = "41feea4228a6f1cd09ec7a3593a682276702cd67b5273544757dae23c096f074"
 dependencies = [
  "itoa",
  "ryu",

--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -16,6 +16,5 @@ dora-core = { path = "../../libraries/core" }
 serde_yaml = "0.9.11"
 tempfile = "3.3.0"
 webbrowser = "0.8.0"
-communication-layer-pub-sub = { path = "../../libraries/communication-layer", default-features = false, features = [
-    "zenoh",
-] }
+zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git" }
+serde_json = "1.0.86"

--- a/binaries/cli/src/main.rs
+++ b/binaries/cli/src/main.rs
@@ -1,11 +1,12 @@
 use clap::Parser;
-use communication_layer_pub_sub::{zenoh::ZenohCommunicationLayer, CommunicationLayer};
-use dora_core::topics::{
-    ZENOH_CONTROL_PREFIX, ZENOH_CONTROL_START_DATAFLOW, ZENOH_CONTROL_STOP_ALL,
-};
-use eyre::{eyre, Context};
-use std::{io::Write, path::PathBuf};
+use dora_core::topics::{StartDataflowResult, ZENOH_CONTROL_DESTROY, ZENOH_CONTROL_START};
+use eyre::{bail, eyre, Context};
+use std::{io::Write, path::PathBuf, sync::Arc};
 use tempfile::NamedTempFile;
+use zenoh::{
+    prelude::{Receiver, Selector, SplitBuffer},
+    sync::ZFuture,
+};
 
 mod build;
 mod check;
@@ -124,34 +125,9 @@ fn main() -> eyre::Result<()> {
         Command::New { args } => template::create(args)?,
         Command::Dashboard => todo!(),
         Command::Up => todo!(),
-        Command::Start { dataflow } => {
-            let canonicalized = dataflow
-                .canonicalize()
-                .wrap_err("given dataflow file does not exist")?;
-            let path = &canonicalized
-                .to_str()
-                .ok_or_else(|| eyre!("dataflow path must be valid UTF-8"))?;
-
-            let publisher = zenoh_control_session(&mut session)?
-                .publisher(ZENOH_CONTROL_START_DATAFLOW)
-                .map_err(|err| eyre!(err))
-                .wrap_err("failed to create publisher for start dataflow message")?;
-            publisher
-                .publish(path.as_bytes())
-                .map_err(|err| eyre!(err))
-                .wrap_err("failed to publish start dataflow message")?;
-        }
+        Command::Start { dataflow } => start_dataflow(dataflow, &mut session)?,
         Command::Stop => todo!(),
-        Command::Destroy => {
-            let publisher = zenoh_control_session(&mut session)?
-                .publisher(ZENOH_CONTROL_STOP_ALL)
-                .map_err(|err| eyre!(err))
-                .wrap_err("failed to create publisher for stop message")?;
-            publisher
-                .publish(&[])
-                .map_err(|err| eyre!(err))
-                .wrap_err("failed to publish stop message")?;
-        }
+        Command::Destroy => destroy(&mut session)?,
         Command::Logs => todo!(),
         Command::Metrics => todo!(),
         Command::Stats => todo!(),
@@ -163,15 +139,61 @@ fn main() -> eyre::Result<()> {
     Ok(())
 }
 
+fn start_dataflow(
+    dataflow: PathBuf,
+    session: &mut Option<Arc<zenoh::Session>>,
+) -> Result<(), eyre::ErrReport> {
+    let canonicalized = dataflow
+        .canonicalize()
+        .wrap_err("given dataflow file does not exist")?;
+    let path = canonicalized
+        .to_str()
+        .ok_or_else(|| eyre!("dataflow path must be valid UTF-8"))?;
+    let reply_receiver = zenoh_control_session(session)?
+        .get(Selector {
+            key_selector: ZENOH_CONTROL_START.into(),
+            value_selector: path.into(),
+        })
+        .wait()
+        .map_err(|err| eyre!(err))
+        .wrap_err("failed to create publisher for start dataflow message")?;
+    let reply = reply_receiver
+        .recv()
+        .wrap_err("failed to receive reply from coordinator")?;
+    let raw = reply.sample.value.payload.contiguous();
+    let result: StartDataflowResult =
+        serde_json::from_slice(&raw).wrap_err("failed to parse reply")?;
+    match result {
+        StartDataflowResult::Ok { uuid } => {
+            println!("Started dataflow under ID `{uuid}`");
+            Ok(())
+        }
+        StartDataflowResult::Error(err) => bail!(err),
+    }
+}
+
+fn destroy(session: &mut Option<Arc<zenoh::Session>>) -> Result<(), eyre::ErrReport> {
+    let reply_receiver = zenoh_control_session(session)?
+        .get(ZENOH_CONTROL_DESTROY)
+        .wait()
+        .map_err(|err| eyre!(err))
+        .wrap_err("failed to create publisher for start dataflow message")?;
+    reply_receiver
+        .recv()
+        .wrap_err("failed to receive reply from coordinator")?;
+    Ok(())
+}
+
 fn zenoh_control_session(
-    session: &mut Option<ZenohCommunicationLayer>,
-) -> eyre::Result<&mut ZenohCommunicationLayer> {
+    session: &mut Option<Arc<zenoh::Session>>,
+) -> eyre::Result<&Arc<zenoh::Session>> {
     Ok(match session {
         Some(session) => session,
         None => session.insert(
-            ZenohCommunicationLayer::init(Default::default(), ZENOH_CONTROL_PREFIX.into())
-                .map_err(|err| eyre!(err))
-                .wrap_err("failed to open zenoh control session")?,
+            zenoh::open(zenoh::config::Config::default())
+                .wait()
+                .map_err(|err| eyre!(err))?
+                .into_arc(),
         ),
     })
 }

--- a/binaries/coordinator/Cargo.toml
+++ b/binaries/coordinator/Cargo.toml
@@ -25,6 +25,5 @@ dora-message = { path = "../../libraries/message" }
 tracing = "0.1.36"
 tracing-subscriber = "0.3.15"
 futures-concurrency = "5.0.1"
-communication-layer-pub-sub = { path = "../../libraries/communication-layer", default-features = false, features = [
-    "zenoh",
-] }
+zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git" }
+serde_json = "1.0.86"

--- a/binaries/coordinator/src/control.rs
+++ b/binaries/coordinator/src/control.rs
@@ -1,112 +1,20 @@
 use crate::Event;
-use communication_layer_pub_sub::{CommunicationLayer, Subscriber};
-use dora_core::topics::{
-    ZENOH_CONTROL_PREFIX, ZENOH_CONTROL_START_DATAFLOW, ZENOH_CONTROL_STOP_ALL,
-};
-use eyre::{eyre, WrapErr};
+use dora_core::topics::ZENOH_CONTROL_QUERYABLE;
+use eyre::eyre;
 use futures::{Stream, StreamExt};
-use std::path::Path;
-use tokio_stream::wrappers::ReceiverStream;
+use futures_concurrency::stream::IntoStream;
+use zenoh::{prelude::EntityFactory, sync::ZFuture};
 
-pub(crate) fn control_events() -> impl Stream<Item = Event> {
-    let (tx, rx) = tokio::sync::mpsc::channel(2);
+pub(crate) async fn control_events() -> eyre::Result<impl Stream<Item = Event>> {
+    let zenoh = zenoh::open(zenoh::config::Config::default())
+        .wait()
+        .map_err(|err| eyre!(err))?
+        .into_arc();
 
-    tokio::task::spawn_blocking(move || {
-        let result = subscribe_control_sync(tx.clone());
-        match result {
-            Ok(()) => {}
-            Err(error) => {
-                let _ = tx.blocking_send(Event::ControlChannelError(error));
-            }
-        }
-    });
+    let queryable = zenoh
+        .queryable(ZENOH_CONTROL_QUERYABLE)
+        .wait()
+        .map_err(|err| eyre!(err))?;
 
-    ReceiverStream::new(rx).chain(futures::stream::iter(std::iter::from_fn(|| {
-        tracing::info!("control channel closed");
-        None
-    })))
-}
-
-fn subscribe_control_sync(tx: tokio::sync::mpsc::Sender<Event>) -> eyre::Result<()> {
-    let mut zenoh_control_session =
-        communication_layer_pub_sub::zenoh::ZenohCommunicationLayer::init(
-            Default::default(),
-            ZENOH_CONTROL_PREFIX.into(),
-        )
-        .map_err(|err| eyre!(err))
-        .wrap_err("failed to open zenoh control session")?;
-
-    let start_dataflow = zenoh_control_session
-        .subscribe(ZENOH_CONTROL_START_DATAFLOW)
-        .map_err(|err| eyre!(err))
-        .wrap_err("failed to subscribe to start dataflow topic")?;
-    let start_tx = tx.downgrade();
-    let _start_dataflow_thread =
-        std::thread::spawn(move || start_dataflow_handler(start_dataflow, start_tx));
-
-    let stop_tx = tx;
-    let stop = zenoh_control_session
-        .subscribe(ZENOH_CONTROL_STOP_ALL)
-        .map_err(|err| eyre!(err))
-        .wrap_err("failed to subscribe to stop all topic")?;
-    let _stop_thread = tokio::task::spawn_blocking(move || {
-        stop_handler(stop, stop_tx);
-    });
-
-    Ok(())
-}
-
-fn stop_handler(mut stop: Box<dyn Subscriber>, stop_tx: tokio::sync::mpsc::Sender<Event>) {
-    let send_result = match stop.recv().map_err(|err| eyre!(err)) {
-        Ok(_) => stop_tx.blocking_send(Event::Stop),
-        Err(err) => stop_tx.blocking_send(Event::ControlChannelError(
-            err.wrap_err("failed to receive on control channel"),
-        )),
-    };
-    let _ = send_result;
-}
-
-fn start_dataflow_handler(
-    mut start_dataflow: Box<dyn Subscriber>,
-    start_tx: tokio::sync::mpsc::WeakSender<Event>,
-) {
-    loop {
-        let recv_result = start_dataflow.recv();
-        let start_tx = match start_tx.upgrade() {
-            Some(tx) => tx,
-            None => {
-                // control channel was closed after receiving stop message
-                break;
-            }
-        };
-        let message = match recv_result {
-            Ok(Some(message)) => message,
-            Ok(None) => break,
-            Err(err) => {
-                let send_result = start_tx.blocking_send(Event::ControlChannelError(
-                    eyre!(err).wrap_err("failed to receive on start_dataflow topic"),
-                ));
-                match send_result {
-                    Ok(()) => continue,
-                    Err(_) => break,
-                }
-            }
-        };
-        let data = message.get();
-        let path = match std::str::from_utf8(&data) {
-            Ok(path) => Path::new(path),
-            Err(err) => {
-                let send_result = start_tx.blocking_send(Event::ParseError(
-                    eyre!(err).wrap_err("failed to parse start_dataflow message"),
-                ));
-                match send_result {
-                    Ok(()) => continue,
-                    Err(_) => break,
-                }
-            }
-        };
-        let _ = start_tx.blocking_send(Event::StartDataflow {
-            path: path.to_owned(),
-        });
-    }
+    Ok(queryable.into_stream().map(Event::Control))
 }

--- a/binaries/coordinator/src/run/mod.rs
+++ b/binaries/coordinator/src/run/mod.rs
@@ -3,16 +3,21 @@ use dora_core::descriptor::{self, collect_dora_timers, CoreNodeKind, Descriptor,
 use dora_node_api::{communication, config::format_duration};
 use eyre::{bail, eyre, WrapErr};
 use futures::{stream::FuturesUnordered, StreamExt};
-use std::{
-    env::consts::EXE_EXTENSION,
-    path::{Path, PathBuf},
-};
+use std::{env::consts::EXE_EXTENSION, path::Path};
 use tokio_stream::wrappers::IntervalStream;
+use uuid::Uuid;
 
 mod custom;
 mod runtime;
 
-pub async fn run_dataflow(dataflow_path: PathBuf, runtime: &Path) -> eyre::Result<()> {
+pub async fn run_dataflow(dataflow_path: &Path, runtime: &Path) -> eyre::Result<()> {
+    spawn_dataflow(runtime, dataflow_path)
+        .await?
+        .await_tasks()
+        .await
+}
+
+pub async fn spawn_dataflow(runtime: &Path, dataflow_path: &Path) -> eyre::Result<SpawnedDataflow> {
     let mut runtime = runtime.with_extension(EXE_EXTENSION);
     let descriptor = read_descriptor(&dataflow_path).await.wrap_err_with(|| {
         format!(
@@ -20,23 +25,21 @@ pub async fn run_dataflow(dataflow_path: PathBuf, runtime: &Path) -> eyre::Resul
             dataflow_path.display()
         )
     })?;
-
     let working_dir = dataflow_path
         .canonicalize()
         .context("failed to canoncialize dataflow path")?
         .parent()
         .ok_or_else(|| eyre!("canonicalized dataflow path has no parent"))?
         .to_owned();
-
     let nodes = descriptor.resolve_aliases();
     let dora_timers = collect_dora_timers(&nodes);
+    let uuid = Uuid::new_v4();
     let communication_config = {
         let mut config = descriptor.communication;
         // add uuid as prefix to ensure isolation
-        config.add_topic_prefix(&uuid::Uuid::new_v4().to_string());
+        config.add_topic_prefix(&uuid.to_string());
         config
     };
-
     if nodes
         .iter()
         .any(|n| matches!(n.kind, CoreNodeKind::Runtime(_)))
@@ -54,8 +57,7 @@ pub async fn run_dataflow(dataflow_path: PathBuf, runtime: &Path) -> eyre::Resul
             }
         }
     }
-
-    let mut tasks = FuturesUnordered::new();
+    let tasks = FuturesUnordered::new();
     for node in nodes {
         let node_id = node.id.clone();
 
@@ -81,7 +83,6 @@ pub async fn run_dataflow(dataflow_path: PathBuf, runtime: &Path) -> eyre::Resul
             }
         }
     }
-
     for interval in dora_timers {
         let communication_config = communication_config.clone();
         let mut communication =
@@ -106,14 +107,23 @@ pub async fn run_dataflow(dataflow_path: PathBuf, runtime: &Path) -> eyre::Resul
             }
         });
     }
+    Ok(SpawnedDataflow { tasks, uuid })
+}
 
-    while let Some(task_result) = tasks.next().await {
-        task_result
-            .wrap_err("failed to join async task")?
-            .wrap_err("custom node failed")?;
+pub struct SpawnedDataflow {
+    pub uuid: Uuid,
+    pub tasks: FuturesUnordered<tokio::task::JoinHandle<Result<(), eyre::ErrReport>>>,
+}
+
+impl SpawnedDataflow {
+    pub async fn await_tasks(mut self) -> eyre::Result<()> {
+        while let Some(task_result) = self.tasks.next().await {
+            task_result
+                .wrap_err("failed to join async task")?
+                .wrap_err("custom node failed")?;
+        }
+        Ok(())
     }
-
-    Ok(())
 }
 
 async fn read_descriptor(file: &Path) -> Result<Descriptor, eyre::Error> {

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -1,3 +1,9 @@
-pub const ZENOH_CONTROL_PREFIX: &str = "dora_control";
-pub const ZENOH_CONTROL_STOP_ALL: &str = "stop_all";
-pub const ZENOH_CONTROL_START_DATAFLOW: &str = "start_dataflow";
+pub const ZENOH_CONTROL_QUERYABLE: &str = "dora_control/*";
+pub const ZENOH_CONTROL_START: &str = "dora_control/start";
+pub const ZENOH_CONTROL_DESTROY: &str = "dora_control/destroy";
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub enum StartDataflowResult {
+    Ok { uuid: String },
+    Error(String),
+}


### PR DESCRIPTION
Allows replying to requests. We use this to send the dataflow UUID back to the CLI after starting it. This UUID can then be used to stop the dataflow again using the new `stop` command (not implemented yet).

If an error occurs when trying to start the dataflow, this error is now also reported back to the CLI.
