### PR TITLE
CLI check wether dora-runtime and iceoryx daemons are running

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,12 +885,16 @@ dependencies = [
 name = "dora-cli"
 version = "0.1.0"
 dependencies = [
+ "atty",
  "clap 4.0.3",
+ "communication-layer-pub-sub",
  "dora-core",
  "eyre",
  "serde_json",
  "serde_yaml 0.9.11",
  "tempfile",
+ "termcolor",
+ "uuid 1.2.1",
  "webbrowser",
  "zenoh",
 ]
@@ -990,7 +994,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "uuid 1.1.2",
+ "uuid 1.2.1",
 ]
 
 [[package]]
@@ -4040,7 +4044,7 @@ dependencies = [
  "lazy_static",
  "log",
  "serde",
- "uuid 1.1.2",
+ "uuid 1.2.1",
 ]
 
 [[package]]
@@ -4157,9 +4161,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.1.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
+checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
 dependencies = [
  "getrandom",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,6 +891,7 @@ dependencies = [
  "eyre",
  "serde_json",
  "serde_yaml 0.9.11",
+ "sysinfo 0.26.6",
  "tempfile",
  "termcolor",
  "uuid 1.2.1",
@@ -2199,6 +2200,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc51db7b362b205941f71232e56c625156eb9a929f8cf74a428fd5bc094a4afc"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2432,7 +2442,7 @@ checksum = "a848fb2d43cc8e5adabdedc6b37a88b45653d3a23b000a3d047e6953d5af42ea"
 dependencies = [
  "indexmap",
  "opentelemetry",
- "sysinfo",
+ "sysinfo 0.24.5",
 ]
 
 [[package]]
@@ -3631,7 +3641,22 @@ dependencies = [
  "cfg-if",
  "core-foundation-sys",
  "libc",
- "ntapi",
+ "ntapi 0.3.7",
+ "once_cell",
+ "rayon",
+ "winapi",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.26.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6d0dedf2e65d25b365c588382be9dc3a3ee4b0ed792366cf722d174c359d948"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi 0.4.0",
  "once_cell",
  "rayon",
  "winapi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,7 +887,6 @@ version = "0.1.0"
 dependencies = [
  "atty",
  "clap 4.0.3",
- "communication-layer-pub-sub",
  "dora-core",
  "eyre",
  "serde_json",

--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -18,3 +18,6 @@ tempfile = "3.3.0"
 webbrowser = "0.8.0"
 zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git" }
 serde_json = "1.0.86"
+termcolor = "1.1.3"
+atty = "0.2.14"
+uuid = { version = "1.2.1", features = ["v4"] }

--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -21,3 +21,4 @@ serde_json = "1.0.86"
 termcolor = "1.1.3"
 atty = "0.2.14"
 uuid = { version = "1.2.1", features = ["v4"] }
+sysinfo = "0.26.6"

--- a/binaries/cli/src/check.rs
+++ b/binaries/cli/src/check.rs
@@ -7,6 +7,7 @@ use dora_core::{
 };
 use eyre::{bail, eyre, Context};
 use std::{env::consts::EXE_EXTENSION, io::Write, path::Path};
+use sysinfo::SystemExt;
 use termcolor::{Color, ColorChoice, ColorSpec, WriteColor};
 use zenoh::{prelude::Receiver, sync::ZFuture};
 
@@ -43,8 +44,19 @@ pub fn check_environment() -> eyre::Result<()> {
     let _ = stdout.reset();
 
     // check whether roudi is running
-    // TODO, blocked on https://github.com/eclipse-iceoryx/iceoryx-rs/issues/62
-
+    write!(stdout, "Iceoryx Daemon: ")?;
+    let system = sysinfo::System::new_all();
+    match system.processes_by_exact_name("iox-roudi").next() {
+        Some(_) => {
+            let _ = stdout.set_color(ColorSpec::new().set_fg(Some(Color::Green)));
+            writeln!(stdout, "ok")?;
+        }
+        None => {
+            let _ = stdout.set_color(ColorSpec::new().set_fg(Some(Color::Red)));
+            writeln!(stdout, "not running")?;
+            error_occured = true;
+        }
+    }
     writeln!(stdout)?;
 
     if error_occured {

--- a/binaries/cli/src/check.rs
+++ b/binaries/cli/src/check.rs
@@ -11,6 +11,8 @@ use termcolor::{Color, ColorChoice, ColorSpec, WriteColor};
 use zenoh::{prelude::Receiver, sync::ZFuture};
 
 pub fn check_environment() -> eyre::Result<()> {
+    let mut error_occured = false;
+
     let mut control_session = None;
 
     let color_choice = if atty::is(atty::Stream::Stdout) {
@@ -35,13 +37,19 @@ pub fn check_environment() -> eyre::Result<()> {
         Err(_) => {
             let _ = stdout.set_color(ColorSpec::new().set_fg(Some(Color::Red)));
             writeln!(stdout, "not running")?;
+            error_occured = true;
         }
     }
     let _ = stdout.reset();
 
     // check whether roudi is running
-
     // TODO, blocked on https://github.com/eclipse-iceoryx/iceoryx-rs/issues/62
+
+    writeln!(stdout)?;
+
+    if error_occured {
+        bail!("Environment check failed.");
+    }
 
     Ok(())
 }

--- a/binaries/cli/src/check.rs
+++ b/binaries/cli/src/check.rs
@@ -162,6 +162,8 @@ pub fn check_dataflow(dataflow_path: &Path, runtime: Option<&Path>) -> eyre::Res
         };
     }
 
+    check_environment()?;
+
     Ok(())
 }
 

--- a/binaries/cli/src/main.rs
+++ b/binaries/cli/src/main.rs
@@ -26,8 +26,10 @@ struct Args {
 #[derive(Debug, clap::Subcommand)]
 enum Command {
     Check {
-        dataflow: PathBuf,
-        runtime_path: PathBuf,
+        #[clap(long)]
+        dataflow: Option<PathBuf>,
+        #[clap(long)]
+        runtime_path: Option<PathBuf>,
     },
     Graph {
         dataflow: PathBuf,
@@ -93,7 +95,10 @@ fn main() -> eyre::Result<()> {
         Command::Check {
             dataflow,
             runtime_path,
-        } => check::check(&dataflow, &runtime_path)?,
+        } => match dataflow {
+            Some(dataflow) => check::check_dataflow(&dataflow, runtime_path.as_deref())?,
+            None => check::check_environment()?,
+        },
         Command::Graph {
             dataflow,
             mermaid,


### PR DESCRIPTION
Implements a argument-less variant of the `dora check` command. Instead of checking a specific dataflow, that command checks that the `dora-runtime` is running. We also check whether the iceoryx daemon is running. Because of https://github.com/eclipse-iceoryx/iceoryx-rs/issues/62, we need to do that through a raw process name check, i.e. we search the process list for an `iox-roudi` process.

