### PR TITLE
Refactoring `dora-cli` start and stop to uuid only

### DIFF
--- a/binaries/cli/src/main.rs
+++ b/binaries/cli/src/main.rs
@@ -196,10 +196,7 @@ fn stop_dataflow(
     let result: StopDataflowResult =
         serde_json::from_slice(&raw).wrap_err("failed to parse reply")?;
     match result {
-        StopDataflowResult::Ok => {
-            println!("{uuid}");
-            Ok(())
-        }
+        StopDataflowResult::Ok => Ok(()),
         StopDataflowResult::Error(err) => bail!(err),
     }
 }

--- a/binaries/cli/src/main.rs
+++ b/binaries/cli/src/main.rs
@@ -170,7 +170,7 @@ fn start_dataflow(
         serde_json::from_slice(&raw).wrap_err("failed to parse reply")?;
     match result {
         StartDataflowResult::Ok { uuid } => {
-            println!("Started dataflow with UUID `{uuid}`");
+            println!("{uuid}");
             Ok(())
         }
         StartDataflowResult::Error(err) => bail!(err),
@@ -197,7 +197,7 @@ fn stop_dataflow(
         serde_json::from_slice(&raw).wrap_err("failed to parse reply")?;
     match result {
         StopDataflowResult::Ok => {
-            println!("Stopped dataflow with UUID `{uuid}`");
+            println!("{uuid}");
             Ok(())
         }
         StopDataflowResult::Error(err) => bail!(err),


### PR DESCRIPTION
To make selection of the `uuid` simpler, I removed the text of the start and stop command.

This makes `dora-cli` closer to the `docker-cli`.

This change make me able to do the following:
```bash
UUID=$(dora-cli start dataflow.yml)
dora-cli stop $UUID
```