### PR TITLE
Changing `drop_operator` to `__del__` for python operators

### DIFF
--- a/binaries/runtime/src/operator/python.rs
+++ b/binaries/runtime/src/operator/python.rs
@@ -158,15 +158,8 @@ pub fn spawn(
         }
 
         Python::with_gil(|py| {
-            let operator = operator.as_ref(py);
-            if operator
-                .hasattr("drop_operator")
-                .wrap_err("failed to look for drop_operator")?
-            {
-                operator.call_method0("drop_operator")?;
-            }
-            Result::<_, eyre::Report>::Ok(())
-        })?;
+            drop(operator);
+        });
 
         Result::<_, eyre::Report>::Ok(())
     };

--- a/binaries/runtime/src/operator/python.rs
+++ b/binaries/runtime/src/operator/python.rs
@@ -157,7 +157,9 @@ pub fn spawn(
             }
         }
 
-        Python::with_gil(|py| {
+        // Dropping the operator using Python garbage collector. 
+        // Locking the GIL for immediate release.
+        Python::with_gil(|_py| {
             drop(operator);
         });
 

--- a/binaries/runtime/src/operator/python.rs
+++ b/binaries/runtime/src/operator/python.rs
@@ -157,7 +157,7 @@ pub fn spawn(
             }
         }
 
-        // Dropping the operator using Python garbage collector. 
+        // Dropping the operator using Python garbage collector.
         // Locking the GIL for immediate release.
         Python::with_gil(|_py| {
             drop(operator);

--- a/examples/python-dataflow/plot.py
+++ b/examples/python-dataflow/plot.py
@@ -81,5 +81,5 @@ class Operator:
 
         return DoraStatus.CONTINUE
 
-    def drop_operator(self):
+    def __del__(self):
         cv2.destroyAllWindows()


### PR DESCRIPTION
This changes `drop_operator` method to `__del__` for python operators.

Using the default python destructor function for dora operator simplifies the usability of dora as the user does not have to learn as many custom methods.

This also creates a symmetry with `__init__` and reduces the risk of errors if drop_operator is not present or misspelt.

It also enables the usability of dora operator outside of dora ( for testing for example ) and let it be naturally garbage collected.

Example Operator now:
```diff
class Operator:
    """
    Plot image and bounding box
    """

    def __init__(self):
        self.window = cv2.window()

    def on_input(
        self,
        dora_input: dict,
        send_output: Callable[[str, bytes], None],
    ) -> DoraStatus:
        ....
-    def drop_operator(self):
+    def __del__(self):
        cv2.destroyAllWindows()
```