### PR TITLE
Enable passing Environment variables to Runtime and single operators node

### DIFF
--- a/binaries/coordinator/src/run/custom.rs
+++ b/binaries/coordinator/src/run/custom.rs
@@ -1,16 +1,17 @@
 use super::command_init_common_env;
 use dora_core::{
     config::NodeId,
-    descriptor::{self, source_is_url},
+    descriptor::{self, source_is_url, EnvValue},
 };
 use dora_download::download_file;
 use eyre::{eyre, WrapErr};
-use std::{env::consts::EXE_EXTENSION, path::Path};
+use std::{collections::BTreeMap, env::consts::EXE_EXTENSION, path::Path};
 
 #[tracing::instrument]
 pub(super) async fn spawn_custom_node(
     node_id: NodeId,
     node: &descriptor::CustomNode,
+    envs: &Option<BTreeMap<String, EnvValue>>,
     communication: &dora_core::config::CommunicationConfig,
     working_dir: &Path,
 ) -> eyre::Result<tokio::task::JoinHandle<eyre::Result<(), eyre::Error>>> {
@@ -51,7 +52,7 @@ pub(super) async fn spawn_custom_node(
 
     // Injecting the env variable defined in the `yaml` into
     // the node runtime.
-    if let Some(envs) = &node.env {
+    if let Some(envs) = envs {
         for (key, value) in envs {
             command.env(key, value.to_string());
         }

--- a/binaries/coordinator/src/run/mod.rs
+++ b/binaries/coordinator/src/run/mod.rs
@@ -63,19 +63,25 @@ pub async fn spawn_dataflow(runtime: &Path, dataflow_path: &Path) -> eyre::Resul
         let node_id = node.id.clone();
 
         match node.kind {
-            descriptor::CoreNodeKind::Custom(node) => {
-                let result =
-                    spawn_custom_node(node_id.clone(), &node, &communication_config, &working_dir)
-                        .await
-                        .wrap_err_with(|| format!("failed to spawn custom node {node_id}"))?;
+            descriptor::CoreNodeKind::Custom(custom) => {
+                let result = spawn_custom_node(
+                    node_id.clone(),
+                    &custom,
+                    &node.env,
+                    &communication_config,
+                    &working_dir,
+                )
+                .await
+                .wrap_err_with(|| format!("failed to spawn custom node {node_id}"))?;
                 tasks.push(result);
             }
-            descriptor::CoreNodeKind::Runtime(node) => {
-                if !node.operators.is_empty() {
+            descriptor::CoreNodeKind::Runtime(runtime_node) => {
+                if !runtime_node.operators.is_empty() {
                     let result = spawn_runtime_node(
                         &runtime,
                         node_id.clone(),
-                        &node,
+                        &runtime_node,
+                        &node.env,
                         &communication_config,
                         &working_dir,
                     )

--- a/binaries/coordinator/src/run/runtime.rs
+++ b/binaries/coordinator/src/run/runtime.rs
@@ -1,13 +1,17 @@
 use super::command_init_common_env;
-use dora_core::{config::NodeId, descriptor};
+use dora_core::{
+    config::NodeId,
+    descriptor::{self, EnvValue},
+};
 use eyre::{eyre, WrapErr};
-use std::path::Path;
+use std::{collections::BTreeMap, path::Path};
 
 #[tracing::instrument(skip(node))]
 pub fn spawn_runtime_node(
     runtime: &Path,
     node_id: NodeId,
     node: &descriptor::RuntimeNode,
+    envs: &Option<BTreeMap<String, EnvValue>>,
     communication: &dora_core::config::CommunicationConfig,
     working_dir: &Path,
 ) -> eyre::Result<tokio::task::JoinHandle<eyre::Result<(), eyre::Error>>> {
@@ -21,7 +25,7 @@ pub fn spawn_runtime_node(
 
     // Injecting the env variable defined in the `yaml` into
     // the node runtime.
-    if let Some(envs) = &node.env {
+    if let Some(envs) = &envs {
         for (key, value) in envs {
             command.env(key, value.to_string());
         }

--- a/binaries/coordinator/src/run/runtime.rs
+++ b/binaries/coordinator/src/run/runtime.rs
@@ -18,6 +18,15 @@ pub fn spawn_runtime_node(
         serde_yaml::to_string(&node.operators)
             .wrap_err("failed to serialize custom node run config")?,
     );
+
+    // Injecting the env variable defined in the `yaml` into
+    // the node runtime.
+    if let Some(envs) = &node.env {
+        for (key, value) in envs {
+            command.env(key, value.to_string());
+        }
+    }
+
     command.current_dir(working_dir);
 
     let mut child = command

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -64,13 +64,13 @@ impl Descriptor {
                         id: op.id.unwrap_or_else(|| default_op_id.clone()),
                         config: op.config,
                     }],
-                    env: op.env,
                 }),
             };
             resolved.push(ResolvedNode {
                 id: node.id,
                 name: node.name,
                 description: node.description,
+                env: node.env,
                 kind,
             });
         }
@@ -90,6 +90,7 @@ pub struct Node {
     pub id: NodeId,
     pub name: Option<String>,
     pub description: Option<String>,
+    pub env: Option<BTreeMap<String, EnvValue>>,
 
     #[serde(flatten)]
     pub kind: NodeKind,
@@ -110,6 +111,7 @@ pub struct ResolvedNode {
     pub id: NodeId,
     pub name: Option<String>,
     pub description: Option<String>,
+    pub env: Option<BTreeMap<String, EnvValue>>,
 
     #[serde(flatten)]
     pub kind: CoreNodeKind,
@@ -125,9 +127,9 @@ pub enum CoreNodeKind {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct RuntimeNode {
     pub operators: Vec<OperatorDefinition>,
-    pub env: Option<BTreeMap<String, EnvValue>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -143,7 +145,6 @@ pub struct SingleOperatorDefinition {
     pub id: Option<OperatorId>,
     #[serde(flatten)]
     pub config: OperatorConfig,
-    pub env: Option<BTreeMap<String, EnvValue>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -189,7 +190,6 @@ pub struct CustomNode {
     pub source: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub args: Option<String>,
-    pub env: Option<BTreeMap<String, EnvValue>>,
     pub working_directory: Option<BTreeMap<String, EnvValue>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub build: Option<String>,

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -64,6 +64,7 @@ impl Descriptor {
                         id: op.id.unwrap_or_else(|| default_op_id.clone()),
                         config: op.config,
                     }],
+                    env: op.env,
                 }),
             };
             resolved.push(ResolvedNode {
@@ -124,9 +125,9 @@ pub enum CoreNodeKind {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(transparent)]
 pub struct RuntimeNode {
     pub operators: Vec<OperatorDefinition>,
+    pub env: Option<BTreeMap<String, EnvValue>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -142,6 +143,7 @@ pub struct SingleOperatorDefinition {
     pub id: Option<OperatorId>,
     #[serde(flatten)]
     pub config: OperatorConfig,
+    pub env: Option<BTreeMap<String, EnvValue>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/libraries/core/src/descriptor/visualize.rs
+++ b/libraries/core/src/descriptor/visualize.rs
@@ -69,7 +69,7 @@ fn visualize_node(node: &ResolvedNode, flowchart: &mut String) {
     let node_id = &node.id;
     match &node.kind {
         CoreNodeKind::Custom(node) => visualize_custom_node(node_id, node, flowchart),
-        CoreNodeKind::Runtime(RuntimeNode { operators }) => {
+        CoreNodeKind::Runtime(RuntimeNode { operators, .. }) => {
             visualize_runtime_node(node_id, operators, flowchart)
         }
     }
@@ -124,7 +124,7 @@ fn visualize_node_inputs(
             flowchart,
             nodes,
         ),
-        CoreNodeKind::Runtime(RuntimeNode { operators }) => {
+        CoreNodeKind::Runtime(RuntimeNode { operators, .. }) => {
             for operator in operators {
                 visualize_inputs(
                     &format!("{node_id}/{}", operator.id),
@@ -181,7 +181,7 @@ fn visualize_user_mapping(
                     source_found = true;
                 }
             }
-            (CoreNodeKind::Runtime(RuntimeNode { operators }), Some(operator_id)) => {
+            (CoreNodeKind::Runtime(RuntimeNode { operators, .. }), Some(operator_id)) => {
                 if let Some(operator) = operators.iter().find(|o| &o.id == operator_id) {
                     if operator.config.outputs.contains(output) {
                         let data = if output == input_id {


### PR DESCRIPTION
This changes add the capacity to pass env variables to runtime and single operators node
with the same logic as custom nodes.

i.e.:
```yaml
  - id: plot
    operator:
      python: plot.py
      inputs:
        image: webcam/image
        bbox: object_detection/bbox
      env:
        ENV_1: variable_1
        ENV_2: variable_2
```

and:
```yaml
  - id: plot
    runtime:
      operators:
        python: plot.py
        inputs:
            image: webcam/image
            bbox: object_detection/bbox
      env:
        ENV_1: variable_1
        ENV_2: variable_2
```

