### PR TITLE
Fix and update Rust template to be ready after `dora new`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,6 +912,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid 0.8.2",
+ "which",
  "zenoh",
 ]
 
@@ -4422,13 +4423,13 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.2.5"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
+checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
 dependencies = [
  "either",
- "lazy_static",
  "libc",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4595,7 +4595,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
 dependencies = [
  "async-global-executor",
  "async-std",
@@ -4639,7 +4639,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
 dependencies = [
  "async-std",
  "bincode",
@@ -4654,7 +4654,7 @@ dependencies = [
 [[package]]
 name = "zenoh-cfg-properties"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
 dependencies = [
  "zenoh-core",
  "zenoh-macros",
@@ -4663,7 +4663,7 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
 dependencies = [
  "async-std",
  "async-trait",
@@ -4676,7 +4676,7 @@ dependencies = [
 [[package]]
 name = "zenoh-config"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
 dependencies = [
  "flume",
  "json5",
@@ -4694,7 +4694,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -4703,7 +4703,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
 dependencies = [
  "aes",
  "hmac",
@@ -4716,7 +4716,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
 dependencies = [
  "async-std",
  "async-trait",
@@ -4735,7 +4735,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
 dependencies = [
  "async-std",
  "async-trait",
@@ -4750,7 +4750,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
 dependencies = [
  "async-std",
  "async-trait",
@@ -4773,7 +4773,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
 dependencies = [
  "async-std",
  "async-trait",
@@ -4788,7 +4788,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
 dependencies = [
  "async-rustls",
  "async-std",
@@ -4807,7 +4807,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
 dependencies = [
  "async-std",
  "async-trait",
@@ -4824,7 +4824,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
 dependencies = [
  "async-std",
  "async-trait",
@@ -4849,7 +4849,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4861,7 +4861,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
 dependencies = [
  "libloading",
  "log",
@@ -4874,7 +4874,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
 dependencies = [
  "log",
  "uhlc 0.4.1",
@@ -4886,7 +4886,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol-core"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
 dependencies = [
  "hex",
  "lazy_static",
@@ -4899,7 +4899,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
 dependencies = [
  "async-std",
  "event-listener",
@@ -4912,7 +4912,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
 dependencies = [
  "async-executor",
  "async-global-executor",
@@ -4939,7 +4939,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
 dependencies = [
  "async-std",
  "clap 2.34.0",

--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -16,7 +16,7 @@ dora-core = { path = "../../libraries/core" }
 serde_yaml = "0.9.11"
 tempfile = "3.3.0"
 webbrowser = "0.8.0"
-zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git" }
+zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "79a136e4fd90b11ff5d775ced981af53c4f1071b" }
 serde_json = "1.0.86"
 termcolor = "1.1.3"
 atty = "0.2.14"

--- a/binaries/cli/src/template/c/dataflow-template.yml
+++ b/binaries/cli/src/template/c/dataflow-template.yml
@@ -3,25 +3,25 @@ communication:
     prefix: /___name___
 
 nodes:
-  - id: runtime-node-1
+  - id: runtime-node_1
     operators:
-      - id: op-1
-        shared-library: build/op-1
+      - id: op_1
+        shared-library: build/op_1
         inputs:
           tick: dora/timer/millis/100
         outputs:
           - some-output
-      - id: op-2
-        shared-library: build/op-2
+      - id: op_2
+        shared-library: build/op_2
         inputs:
           tick: dora/timer/secs/2
         outputs:
           - some-output
 
-  - id: custom-node-1
+  - id: custom-node_1
     custom:
-      source: build/node-1
+      source: build/node_1
       inputs:
         tick: dora/timer/secs/1
-        input-1: op-1/some-output
-        input-2: op-2/some-output
+        input-1: op_1/some-output
+        input-2: op_2/some-output

--- a/binaries/cli/src/template/c/mod.rs
+++ b/binaries/cli/src/template/c/mod.rs
@@ -39,9 +39,9 @@ fn create_dataflow(name: String, path: Option<PathBuf>) -> Result<(), eyre::ErrR
     fs::write(&dataflow_yml_path, &dataflow_yml)
         .with_context(|| format!("failed to write `{}`", dataflow_yml_path.display()))?;
 
-    create_operator("op-1".into(), Some(root.join("op-1")))?;
-    create_operator("op-2".into(), Some(root.join("op-2")))?;
-    create_custom_node("node-1".into(), Some(root.join("node-1")))?;
+    create_operator("op_1".into(), Some(root.join("op_1")))?;
+    create_operator("op_2".into(), Some(root.join("op_2")))?;
+    create_custom_node("node_1".into(), Some(root.join("node_1")))?;
 
     println!(
         "Created new C dataflow at `{name}` at {}",
@@ -57,6 +57,9 @@ fn create_operator(name: String, path: Option<PathBuf>) -> Result<(), eyre::ErrR
 
     if name.contains('/') {
         bail!("operator name must not contain `/` separators");
+    }
+    if name.contains('-') {
+        bail!("operator name must not contain `-` separators");
     }
     if !name.is_ascii() {
         bail!("operator name must be ASCII");

--- a/binaries/cli/src/template/rust/Cargo-template.toml
+++ b/binaries/cli/src/template/rust/Cargo-template.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["op-1", "op-2", "node-1"]
+members = ["op_1", "op_2", "node_1"]

--- a/binaries/cli/src/template/rust/dataflow-template.yml
+++ b/binaries/cli/src/template/rust/dataflow-template.yml
@@ -3,28 +3,28 @@ communication:
     prefix: /___name___
 
 nodes:
-  - id: runtime-node-1
+  - id: runtime-node_1
     operators:
-      - id: op-1
-        build: cargo build -p op-1
-        shared-library: target/debug/op-1
+      - id: op_1
+        build: cargo build -p op_1
+        shared-library: target/debug/op_1
         inputs:
           tick: dora/timer/millis/100
         outputs:
           - some-output
-      - id: op-2
-        build: cargo build -p op-2
-        shared-library: target/debug/op-2
+      - id: op_2
+        build: cargo build -p op_2
+        shared-library: target/debug/op_2
         inputs:
           tick: dora/timer/secs/2
         outputs:
           - some-output
 
-  - id: custom-node-1
+  - id: custom-node_1
     custom:
-      build: cargo build -p node-1
-      source: target/debug/node-1
+      build: cargo build -p node_1
+      source: target/debug/node_1
       inputs:
         tick: dora/timer/secs/1
-        input-1: op-1/some-output
-        input-2: op-2/some-output
+        input-1: op_1/some-output
+        input-2: op_2/some-output

--- a/binaries/cli/src/template/rust/mod.rs
+++ b/binaries/cli/src/template/rust/mod.rs
@@ -44,9 +44,9 @@ fn create_dataflow(name: String, path: Option<PathBuf>) -> Result<(), eyre::ErrR
     fs::write(&cargo_toml_path, &cargo_toml)
         .with_context(|| format!("failed to write `{}`", cargo_toml_path.display()))?;
 
-    create_operator("op-1".into(), Some(root.join("op-1")))?;
-    create_operator("op-2".into(), Some(root.join("op-2")))?;
-    create_custom_node("node-1".into(), Some(root.join("node-1")))?;
+    create_operator("op_1".into(), Some(root.join("op_1")))?;
+    create_operator("op_2".into(), Some(root.join("op_2")))?;
+    create_custom_node("node_1".into(), Some(root.join("node_1")))?;
 
     println!(
         "Created new Rust dataflow at `{name}` at {}",
@@ -62,6 +62,12 @@ fn create_operator(name: String, path: Option<PathBuf>) -> Result<(), eyre::ErrR
 
     if name.contains('/') {
         bail!("operator name must not contain `/` separators");
+    }
+    if name.contains('-') {
+        bail!(
+            "operator name must not contain `-` separators as 
+        it get replaced by `_` as a static library."
+        );
     }
     if !name.is_ascii() {
         bail!("operator name must be ASCII");

--- a/binaries/cli/src/template/rust/node/Cargo-template.toml
+++ b/binaries/cli/src/template/rust/node/Cargo-template.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dora-node-api = "0.1.0"
+dora-node-api = { git = "https://github.com/dora-rs/dora.git" }

--- a/binaries/cli/src/template/rust/node/main-template.rs
+++ b/binaries/cli/src/template/rust/node/main-template.rs
@@ -1,4 +1,4 @@
-use dora_node_api::{self, config::DataId, DoraNode};
+use dora_node_api::{self, core::config::DataId, DoraNode};
 use std::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -7,7 +7,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     while let Ok(input) = inputs.recv() {
         match input.id.as_str() {
-            other => eprintln!("Ignoring unexpected input `{other}`"),
+            other => eprintln!("Received input `{other}`"),
         }
     }
 

--- a/binaries/cli/src/template/rust/operator/Cargo-template.toml
+++ b/binaries/cli/src/template/rust/operator/Cargo-template.toml
@@ -9,4 +9,4 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-dora-operator-api = "0.1.0"
+dora-operator-api = { git = "https://github.com/dora-rs/dora.git" }

--- a/binaries/cli/src/template/rust/operator/lib-template.rs
+++ b/binaries/cli/src/template/rust/operator/lib-template.rs
@@ -15,7 +15,7 @@ impl DoraOperator for ExampleOperator {
         output_sender: &mut DoraOutputSender,
     ) -> Result<DoraStatus, String> {
         match id {
-            other => eprintln!("ignoring unexpected input {other}"),
+            other => eprintln!("Received input {other}"),
         }
         Ok(DoraStatus::Continue)
     }

--- a/binaries/cli/src/template/rust/operator/lib-template.rs
+++ b/binaries/cli/src/template/rust/operator/lib-template.rs
@@ -1,5 +1,4 @@
 use dora_operator_api::{register_operator, DoraOperator, DoraOutputSender, DoraStatus};
-use std::time::{Duration, Instant};
 
 register_operator!(ExampleOperator);
 

--- a/binaries/coordinator/Cargo.toml
+++ b/binaries/coordinator/Cargo.toml
@@ -25,6 +25,6 @@ dora-message = { path = "../../libraries/message" }
 tracing = "0.1.36"
 tracing-subscriber = "0.3.15"
 futures-concurrency = "5.0.1"
-zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git" }
+zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "79a136e4fd90b11ff5d775ced981af53c4f1071b" }
 serde_json = "1.0.86"
 dora-download = { path = "../../libraries/extensions/download" }

--- a/binaries/coordinator/Cargo.toml
+++ b/binaries/coordinator/Cargo.toml
@@ -28,3 +28,4 @@ futures-concurrency = "5.0.1"
 zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "79a136e4fd90b11ff5d775ced981af53c4f1071b" }
 serde_json = "1.0.86"
 dora-download = { path = "../../libraries/extensions/download" }
+which = "4.3.0"

--- a/binaries/coordinator/src/run/mod.rs
+++ b/binaries/coordinator/src/run/mod.rs
@@ -45,7 +45,7 @@ pub async fn spawn_dataflow(runtime: &Path, dataflow_path: &Path) -> eyre::Resul
         .iter()
         .any(|n| matches!(n.kind, CoreNodeKind::Runtime(_)))
     {
-        match runtime.canonicalize() {
+        match which::which(runtime.as_os_str()) {
             Ok(path) => {
                 runtime = path;
             }

--- a/binaries/runtime/Cargo.toml
+++ b/binaries/runtime/Cargo.toml
@@ -29,8 +29,8 @@ libloading = "0.7.3"
 serde_yaml = "0.8.23"
 tokio = { version = "1.17.0", features = ["full"] }
 tokio-stream = "0.1.8"
-zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git" }
-zenoh-config = { git = "https://github.com/eclipse-zenoh/zenoh.git" }
+zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "79a136e4fd90b11ff5d775ced981af53c4f1071b" }
+zenoh-config = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "79a136e4fd90b11ff5d775ced981af53c4f1071b" }
 fern = "0.6.1"
 pyo3 = { version = "0.16.5", features = ["auto-initialize", "eyre"] }
 flume = "0.10.14"

--- a/libraries/communication-layer/Cargo.toml
+++ b/libraries/communication-layer/Cargo.toml
@@ -10,8 +10,8 @@ iceoryx = ["dep:iceoryx-rs", "dep:iceoryx-sys"]
 
 [dependencies]
 eyre = "0.6.8"
-zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", optional = true }
-zenoh-config = { git = "https://github.com/eclipse-zenoh/zenoh.git", optional = true }
+zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "79a136e4fd90b11ff5d775ced981af53c4f1071b", optional = true }
+zenoh-config = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "79a136e4fd90b11ff5d775ced981af53c4f1071b", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 iceoryx-rs = { git = "https://github.com/eclipse-iceoryx/iceoryx-rs.git", optional = true }

--- a/libraries/core/Cargo.toml
+++ b/libraries/core/Cargo.toml
@@ -11,4 +11,4 @@ eyre = "0.6.8"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_yaml = "0.9.11"
 once_cell = "1.13.0"
-zenoh-config = { git = "https://github.com/eclipse-zenoh/zenoh.git" }
+zenoh-config = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "79a136e4fd90b11ff5d775ced981af53c4f1071b" }

--- a/libraries/extensions/zenoh-logger/Cargo.toml
+++ b/libraries/extensions/zenoh-logger/Cargo.toml
@@ -7,5 +7,5 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git" }
-zenoh-config = { git = "https://github.com/eclipse-zenoh/zenoh.git" }
+zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "79a136e4fd90b11ff5d775ced981af53c4f1071b" }
+zenoh-config = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "79a136e4fd90b11ff5d775ced981af53c4f1071b" }


### PR DESCRIPTION
There were couple of issues in the Rust dataflow template:
- the zenoh version within dora wasn't pinned making the compilation of the Rust API from git not successful.
- I removed `-` of the operator name as the static library transform `-` into `_` ex: `op-1` -> `libop_1.so` and the user has to know that, which is confusing.
- I made the default message less error-like.
- Use which to find dora-runtime in PATH
 