### PR TITLE
Python dataflow template

### DIFF
--- a/binaries/cli/src/main.rs
+++ b/binaries/cli/src/main.rs
@@ -69,7 +69,7 @@ enum Command {
 
 #[derive(Debug, clap::Args)]
 pub struct CommandNew {
-    #[clap(long, value_enum, default_value_t = Kind::Operator)]
+    #[clap(long, value_enum, default_value_t = Kind::Dataflow)]
     kind: Kind,
     #[clap(long, value_enum, default_value_t = Lang::Rust)]
     lang: Lang,

--- a/binaries/cli/src/template/python/dataflow-template.yml
+++ b/binaries/cli/src/template/python/dataflow-template.yml
@@ -1,0 +1,27 @@
+communication:
+  zenoh:
+    prefix: /___name___
+
+nodes:
+  - id: op_1
+    operator:
+      python: op_2/op_2.py
+      inputs:
+        tick: dora/timer/millis/100
+      outputs:
+        - some-output
+  - id: op_2
+    operator:
+      python: op_2/op_2.py
+      inputs:
+        tick: dora/timer/secs/2
+      outputs:
+        - some-output
+
+  - id: custom-node_1
+    custom:
+      source: ./node_1/node_1.py
+      inputs:
+        tick: dora/timer/secs/1
+        input-1: op_1/some-output
+        input-2: op_2/some-output

--- a/binaries/cli/src/template/python/mod.rs
+++ b/binaries/cli/src/template/python/mod.rs
@@ -1,4 +1,4 @@
-use eyre::Context;
+use eyre::{bail, Context};
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -15,7 +15,7 @@ pub fn create(args: crate::CommandNew) -> eyre::Result<()> {
     match kind {
         crate::Kind::Operator => create_operator(name, path),
         crate::Kind::CustomNode => create_custom_node(name, path),
-        crate::Kind::Dataflow => todo!(),
+        crate::Kind::Dataflow => create_dataflow(name, path),
     }
 }
 
@@ -27,7 +27,7 @@ fn create_operator(name: String, path: Option<PathBuf>) -> Result<(), eyre::ErrR
     fs::create_dir(&root)
         .with_context(|| format!("failed to create directory `{}`", root.display()))?;
 
-    let operator_path = root.join("operator.py");
+    let operator_path = root.join(format!("{name}.py"));
     fs::write(&operator_path, OPERATOR_PY)
         .with_context(|| format!("failed to write `{}`", operator_path.display()))?;
 
@@ -46,12 +46,44 @@ fn create_custom_node(name: String, path: Option<PathBuf>) -> Result<(), eyre::E
     fs::create_dir(&root)
         .with_context(|| format!("failed to create directory `{}`", root.display()))?;
 
-    let node_path = root.join("node.py");
+    let node_path = root.join(format!("{name}.py"));
     fs::write(&node_path, NODE_PY)
         .with_context(|| format!("failed to write `{}`", node_path.display()))?;
 
     println!(
         "Created new Python node `{name}` at {}",
+        Path::new(".").join(root).display()
+    );
+
+    Ok(())
+}
+
+fn create_dataflow(name: String, path: Option<PathBuf>) -> Result<(), eyre::ErrReport> {
+    const DATAFLOW_YML: &str = include_str!("dataflow-template.yml");
+
+    if name.contains('/') {
+        bail!("dataflow name must not contain `/` separators");
+    }
+    if !name.is_ascii() {
+        bail!("dataflow name must be ASCII");
+    }
+
+    // create directories
+    let root = path.as_deref().unwrap_or_else(|| Path::new(&name));
+    fs::create_dir(&root)
+        .with_context(|| format!("failed to create directory `{}`", root.display()))?;
+
+    let dataflow_yml = DATAFLOW_YML.replace("___name___", &name);
+    let dataflow_yml_path = root.join("dataflow.yml");
+    fs::write(&dataflow_yml_path, &dataflow_yml)
+        .with_context(|| format!("failed to write `{}`", dataflow_yml_path.display()))?;
+
+    create_operator("op_1".into(), Some(root.join("op_1")))?;
+    create_operator("op_2".into(), Some(root.join("op_2")))?;
+    create_custom_node("node_1".into(), Some(root.join("node_1")))?;
+
+    println!(
+        "Created new C dataflow at `{name}` at {}",
         Path::new(".").join(root).display()
     );
 

--- a/binaries/cli/src/template/python/node/node-template.py
+++ b/binaries/cli/src/template/python/node/node-template.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 from dora import Node
 
 node = Node()

--- a/binaries/cli/src/template/python/operator/operator-template.py
+++ b/binaries/cli/src/template/python/operator/operator-template.py
@@ -35,6 +35,10 @@ class Operator:
                 STOP means that the operator stop listening for inputs.
 
         """
+        print(
+            f"Received input {dora_input['id']}, with data: {dora_input['data']}"
+        )
+
         return DoraStatus.CONTINUE
 
     def __del__(self):


### PR DESCRIPTION
This generates a python dataflow inspired by the other language dataflow generation.

It also makes `dataflow` the default kind when using `dora new`. This allow user to simplify starting commands:

```diff
+ # Starting a new project
+ dora new abc_project
- # Instead of
- dora new abc_project --kind dataflow

# And then later...
dora new abc_operator --kind operator
```


Should be merged after #127 