### PR TITLE
Allow configuring the `dora up` behavior through a `dora-config.yml` file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,6 +878,7 @@ dependencies = [
  "clap 4.0.3",
  "dora-core",
  "eyre",
+ "serde",
  "serde_json",
  "serde_yaml 0.9.11",
  "sysinfo 0.26.6",

--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 clap = { version = "4.0.3", features = ["derive"] }
 eyre = "0.6.8"
 dora-core = { path = "../../libraries/core" }
+serde = { version = "1.0.136", features = ["derive"] }
 serde_yaml = "0.9.11"
 tempfile = "3.3.0"
 webbrowser = "0.8.0"

--- a/binaries/cli/src/main.rs
+++ b/binaries/cli/src/main.rs
@@ -48,6 +48,8 @@ enum Command {
     Dashboard,
     Up {
         #[clap(long)]
+        config: Option<PathBuf>,
+        #[clap(long)]
         roudi_path: Option<PathBuf>,
         #[clap(long)]
         coordinator_path: Option<PathBuf>,
@@ -118,9 +120,14 @@ fn main() -> eyre::Result<()> {
         Command::New { args } => template::create(args)?,
         Command::Dashboard => todo!(),
         Command::Up {
+            config,
             roudi_path,
             coordinator_path,
-        } => up::up(roudi_path.as_deref(), coordinator_path.as_deref())?,
+        } => up::up(
+            config.as_deref(),
+            roudi_path.as_deref(),
+            coordinator_path.as_deref(),
+        )?,
         Command::Start { dataflow } => start_dataflow(dataflow, &mut session)?,
         Command::List => list(&mut session)?,
         Command::Stop { uuid } => stop_dataflow(uuid, &mut session)?,

--- a/binaries/cli/src/main.rs
+++ b/binaries/cli/src/main.rs
@@ -54,7 +54,10 @@ enum Command {
         #[clap(long)]
         coordinator_path: Option<PathBuf>,
     },
-    Destroy,
+    Destroy {
+        #[clap(long)]
+        config: Option<PathBuf>,
+    },
     Start {
         dataflow: PathBuf,
     },
@@ -131,7 +134,7 @@ fn main() -> eyre::Result<()> {
         Command::Start { dataflow } => start_dataflow(dataflow, &mut session)?,
         Command::List => list(&mut session)?,
         Command::Stop { uuid } => stop_dataflow(uuid, &mut session)?,
-        Command::Destroy => up::destroy(&mut session)?,
+        Command::Destroy { config } => up::destroy(config.as_deref(), &mut session)?,
         Command::Logs => todo!(),
         Command::Metrics => todo!(),
         Command::Stats => todo!(),

--- a/binaries/cli/src/up.rs
+++ b/binaries/cli/src/up.rs
@@ -21,20 +21,7 @@ pub(crate) fn up(
     roudi: Option<&Path>,
     coordinator: Option<&Path>,
 ) -> eyre::Result<()> {
-    let config = {
-        let path =
-            config_path.or_else(|| Some(Path::new("dora-config.yml")).filter(|p| p.exists()));
-        match path {
-            Some(path) => {
-                let raw = fs::read_to_string(path)
-                    .with_context(|| format!("failed to read `{}`", path.display()))?;
-                serde_yaml::from_str(&raw)
-                    .with_context(|| format!("failed to parse `{}`", path.display()))?
-            }
-            None => Default::default(),
-        }
-    };
-    let UpConfig { iceoryx } = config;
+    let UpConfig { iceoryx } = parse_dora_config(config_path)?;
 
     if !coordinator_running()? {
         start_coordinator(coordinator).wrap_err("failed to start dora-coordinator")?;
@@ -48,7 +35,12 @@ pub(crate) fn up(
     Ok(())
 }
 
-pub(crate) fn destroy(session: &mut Option<Arc<zenoh::Session>>) -> Result<(), eyre::ErrReport> {
+pub(crate) fn destroy(
+    config_path: Option<&Path>,
+    session: &mut Option<Arc<zenoh::Session>>,
+) -> Result<(), eyre::ErrReport> {
+    let UpConfig { iceoryx } = parse_dora_config(config_path)?;
+
     if coordinator_running()? {
         // send destroy command to dora-coordinator
         let reply_receiver = zenoh_control_session(session)?
@@ -64,24 +56,40 @@ pub(crate) fn destroy(session: &mut Option<Arc<zenoh::Session>>) -> Result<(), e
         eprintln!("The dora-coordinator is not running");
     }
 
-    // kill iox-roudi process
-    let system = sysinfo::System::new_all();
-    let processes: Vec<_> = system.processes_by_exact_name("iox-roudi").collect();
-    if processes.is_empty() {
-        eprintln!("No `iox-roudi` process found");
-    } else if processes.len() == 1 {
-        let process = processes[0];
-        let success = process.kill();
-        if success {
-            println!("Killed `iox-roudi` process");
+    if iceoryx {
+        // kill iox-roudi process
+        let system = sysinfo::System::new_all();
+        let processes: Vec<_> = system.processes_by_exact_name("iox-roudi").collect();
+        if processes.is_empty() {
+            eprintln!("No `iox-roudi` process found");
+        } else if processes.len() == 1 {
+            let process = processes[0];
+            let success = process.kill();
+            if success {
+                println!("Killed `iox-roudi` process");
+            } else {
+                bail!("failed to kill iox-roudi process");
+            }
         } else {
-            bail!("failed to kill iox-roudi process");
+            bail!("multiple iox-roudi processes found, please kill the correct processes manually");
         }
-    } else {
-        bail!("multiple iox-roudi processes found, please kill the correct processes manually");
     }
 
     Ok(())
+}
+
+fn parse_dora_config(config_path: Option<&Path>) -> Result<UpConfig, eyre::ErrReport> {
+    let path = config_path.or_else(|| Some(Path::new("dora-config.yml")).filter(|p| p.exists()));
+    let config = match path {
+        Some(path) => {
+            let raw = fs::read_to_string(path)
+                .with_context(|| format!("failed to read `{}`", path.display()))?;
+            serde_yaml::from_str(&raw)
+                .with_context(|| format!("failed to parse `{}`", path.display()))?
+        }
+        None => Default::default(),
+    };
+    Ok(config)
 }
 
 fn start_coordinator(coordinator: Option<&Path>) -> eyre::Result<()> {


### PR DESCRIPTION
Looks for a `dora-config.yml` file in the current directory. The format of the file is the following:

```yml
iceoryx: true
```

If `iceoryx` is set to false, `dora up` won't attempt to start the iceoryx daemon, and `dora destroy` won't kill it.

The path to the config file can also be passed as a `--config` argument.