### PR TITLE
CI: Switch Rust problem matcher back to upstream

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           python-version: 3.8.10
 
-      - uses: r7kamura/rust-problem-matchers@v1
+      - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           python-version: 3.8.10
 
-      - uses: phil-opp/rust-problem-matchers@node-16
+      - uses: r7kamura/rust-problem-matchers@v1
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           choco install capnproto
           echo "$Env:Programfiles\capnproto" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-      - uses: phil-opp/rust-problem-matchers@node-16
+      - uses: r7kamura/rust-problem-matchers@v1
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
 
@@ -75,7 +75,7 @@ jobs:
           choco install capnproto
           echo "$Env:Programfiles\capnproto" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-      - uses: phil-opp/rust-problem-matchers@node-16
+      - uses: r7kamura/rust-problem-matchers@v1
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
 
@@ -114,7 +114,7 @@ jobs:
           export DEBIAN_FRONTEND=noninteractive
           sudo apt-get install -y capnproto libcapnp-dev libacl1-dev
 
-      - uses: phil-opp/rust-problem-matchers@node-16
+      - uses: r7kamura/rust-problem-matchers@v1
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
 
@@ -132,7 +132,7 @@ jobs:
           export DEBIAN_FRONTEND=noninteractive
           sudo apt-get install -y capnproto libcapnp-dev libacl1-dev
 
-      - uses: phil-opp/rust-problem-matchers@node-16
+      - uses: r7kamura/rust-problem-matchers@v1
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
 
@@ -148,7 +148,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: phil-opp/rust-problem-matchers@node-16
+      - uses: r7kamura/rust-problem-matchers@v1
       - name: "rustfmt"
         run: cargo fmt --all -- --check
 
@@ -158,7 +158,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: phil-opp/rust-problem-matchers@node-16
+      - uses: r7kamura/rust-problem-matchers@v1
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           choco install capnproto
           echo "$Env:Programfiles\capnproto" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-      - uses: r7kamura/rust-problem-matchers@v1
+      - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
 
@@ -75,7 +75,7 @@ jobs:
           choco install capnproto
           echo "$Env:Programfiles\capnproto" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-      - uses: r7kamura/rust-problem-matchers@v1
+      - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
 
@@ -114,7 +114,7 @@ jobs:
           export DEBIAN_FRONTEND=noninteractive
           sudo apt-get install -y capnproto libcapnp-dev libacl1-dev
 
-      - uses: r7kamura/rust-problem-matchers@v1
+      - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
 
@@ -132,7 +132,7 @@ jobs:
           export DEBIAN_FRONTEND=noninteractive
           sudo apt-get install -y capnproto libcapnp-dev libacl1-dev
 
-      - uses: r7kamura/rust-problem-matchers@v1
+      - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
 
@@ -148,7 +148,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: r7kamura/rust-problem-matchers@v1
+      - uses: r7kamura/rust-problem-matchers@v1.1.0
       - name: "rustfmt"
         run: cargo fmt --all -- --check
 
@@ -158,7 +158,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: r7kamura/rust-problem-matchers@v1
+      - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           choco install capnproto
           echo "$Env:Programfiles\capnproto" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-      - uses: r7kamura/rust-problem-matchers@v1
+      - uses: r7kamura/rust-problem-matchers@v1.1.0
 
       - name: "Build binaries"
         timeout-minutes: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           choco install capnproto
           echo "$Env:Programfiles\capnproto" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-      - uses: phil-opp/rust-problem-matchers@node-16
+      - uses: r7kamura/rust-problem-matchers@v1
 
       - name: "Build binaries"
         timeout-minutes: 30


### PR DESCRIPTION
https://github.com/r7kamura/rust-problem-matchers/pull/1 was merged, so we can switch back to the upstream action.