### PR TITLE
Make CICD check the CLI commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,31 +92,34 @@ jobs:
 
       - name: "Build cli and binaries"
         timeout-minutes: 30
-        run: cargo build --all
+        run: |
+          cargo install --path binaries/coordinator
+          cargo install --path binaries/runtime
+          cargo install --path binaries/cli
 
       - name: "Test dora-coordinator"
         run: |
-            cargo run -p dora-coordinator &
+          dora-coordinator &
 
       - name: "Test dora `list"
-        run: cargo run -p dora-cli -- list
+        run: dora-cli list
 
       - name: "Test new command"
         run: |
-            cargo run -p dora-cli -- new test_project
+            dora-cli new test_project
             cd test_project
 
       - name: "Test start and stop command"
         timeout-minutes: 30
         run: |
             cargo build --all
-            UUID=$(../target/debug/dora-cli start dataflow.yml)
+            UUID=$(dora-cli start dataflow.yml)
             sleep 10
-            ../target/debug/dora-cli stop $UUID
+            dora-cli stop $UUID
             cd .. 
 
       - name: "Test dora `destroy"
-        run: cargo run -p dora-cli -- destroy
+        run: dora-cli destroy
 
   examples-remote:
     name: "Examples (Remote)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
     name: "CLI Test"
     strategy:
       matrix:
-        platform: [ubuntu-latest]
+        platform: [ubuntu-latest, macos-latest]
       fail-fast: false
     runs-on: ${{ matrix.platform }}
     steps:
@@ -94,11 +94,9 @@ jobs:
         timeout-minutes: 30
         run: cargo build --all
 
-      - name: "Test dora `up`"
+      - name: "Test dora-coordinator"
         run: |
-            echo "$(pwd)/target/debug" >> $GITHUB_PATH
-            find $(pwd) -type f  -wholename "*/iceoryx-install/bin/iox-roudi" | head -n 1 | xargs dirname >> $GITHUB_PATH
-            cargo run -p dora-cli -- up
+            cargo run -p dora-coordinator &
 
       - name: "Test dora `check`"
         run: cargo run -p dora-cli -- check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,11 +107,11 @@ jobs:
       - name: "Test new command"
         run: |
             dora-cli new test_project
-            cd test_project
 
       - name: "Test start and stop command"
         timeout-minutes: 30
         run: |
+            cd test_project
             cargo build --all
             UUID=$(dora-cli start dataflow.yml)
             sleep 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,9 +98,6 @@ jobs:
         run: |
             cargo run -p dora-coordinator &
 
-      - name: "Test dora `check`"
-        run: cargo run -p dora-cli -- check
-
       - name: "Test dora `list"
         run: cargo run -p dora-cli -- list
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,15 +66,62 @@ jobs:
       - name: "C++ Dataflow example"
         timeout-minutes: 15
         run: cargo run --example cxx-dataflow
-
       - name: "Start RouDi (iceoryx)"
         if: runner.os != 'Windows'
         run: find target -type f -wholename "*/iceoryx-install/bin/iox-roudi" -exec {} \; &
-
       - name: "Rust iceoryx example"
         if: runner.os != 'Windows'
         timeout-minutes: 30
         run: cargo run --example iceoryx
+
+  CLI:
+    name: "CLI Test"
+    strategy:
+      matrix:
+        platform: [ubuntu-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install libacl-dev (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get install -y libacl1-dev
+
+      - name: "Build cli and binaries"
+        timeout-minutes: 30
+        run: cargo build --all
+
+      - name: "Test dora `up`"
+        run: |
+            echo "$(pwd)/target/debug" >> $GITHUB_PATH
+            find $(pwd) -type f  -wholename "*/iceoryx-install/bin/iox-roudi" | head -n 1 | xargs dirname >> $GITHUB_PATH
+            cargo run -p dora-cli -- up
+
+      - name: "Test dora `check`"
+        run: cargo run -p dora-cli -- check
+
+      - name: "Test dora `list"
+        run: cargo run -p dora-cli -- list
+
+      - name: "Test new command"
+        run: |
+            cargo run -p dora-cli -- new test_project
+            cd test_project
+
+      - name: "Test start and stop command"
+        timeout-minutes: 30
+        run: |
+            cargo build --all
+            UUID=$(../target/debug/dora-cli start dataflow.yml)
+            sleep 10
+            ../target/debug/dora-cli stop $UUID
+            cd .. 
+
+      - name: "Test dora `destroy"
+        run: cargo run -p dora-cli -- destroy
 
   examples-remote:
     name: "Examples (Remote)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           cargo install --path binaries/runtime
           cargo install --path binaries/cli
 
-      - name: "Test dora-coordinator"
+      - name: "Start dora-coordinator"
         run: |
           dora-coordinator &
 


### PR DESCRIPTION
This commit improves the CI/CD by testing the newly added CLI commands:
- `up`
- `list`
- `check`
- `destroy`

This commit also removes not needed anymore capnp dependencies to simplify the CI.

This can be merged after `v0.1.0` release that is going to be tagged to #143