### PR TITLE
Fix `python` README dependency issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ dora up
 4. Start your dataflow
 ```bash
 # Other window
+
+## Install the different requirements
+dora build dataflow.yml
+
+## Start the dataflow
 dora start dataflow.yml
 # Output: c95d118b-cded-4531-a0e4-cd85b7c3916c
 ```
@@ -112,7 +117,7 @@ dora stop c95d118b-cded-4531-a0e4-cd85b7c3916c
 
 You need to add the created operators/nodes to your dataflow YAML file.
 
-8. You can also download already implemented operators by putting links in the dataflow. This example will launch a webcam plot stream. 
+8. You can also download already implemented operators by putting links in the dataflow. This example will launch a webcam plot stream.
 
 ```yaml
 communication:
@@ -123,6 +128,7 @@ nodes:
   - id: op_1
     operator:
       python: https://raw.githubusercontent.com/dora-rs/dora-drives/main/operators/webcam.py
+      build: python3 -m pip install opencv-python
       inputs:
         tick: dora/timer/millis/100
       outputs:
@@ -130,10 +136,19 @@ nodes:
   - id: op_2
     operator:
       python: https://raw.githubusercontent.com/dora-rs/dora-drives/main/physicals/plot.py
+      build: python3 -m pip install opencv-python
       inputs:
         image: op_1/image 
 ```
-> Make sure to have a webcam and cv2 install via: `pip install opencv-python`
+
+4. Start your dataflow
+```bash
+## Install opencv-python requirements specified in the build field of the dataflow.
+dora build dataflow.yml
+
+## Start the dataflow
+dora start dataflow.yml
+```
 ---
 
 ## ✨ Features

--- a/binaries/cli/src/template/python/dataflow-template.yml
+++ b/binaries/cli/src/template/python/dataflow-template.yml
@@ -22,6 +22,7 @@ nodes:
     custom:
       source: python
       args: ./node_1/node_1.py
+      build: python -m pip install dora-rs
       inputs:
         tick: dora/timer/secs/1
         input-1: op_1/some-output


### PR DESCRIPTION
This commit introduces the concept of installing python dependencies through the `build` keyword within the dataflow.

This makes the requirements declarative and not attached to a generic `requirements.txt` file.

In the future, we can imagine that those operators will be imported from the web. Those requirements can also be imported from the web. Ex:

```bash
pip install -qr https://raw.githubusercontent.com/ultralytics/yolov5/master/requirements.txt
```
> Yolov5 documentation for the requirements.

It also solves one of the #147 errors.