### PR TITLE
Release v0.1.1

### DIFF
--- a/.github/workflows/pip-release.yml
+++ b/.github/workflows/pip-release.yml
@@ -10,11 +10,11 @@ on:
 
 jobs:
   release:
-    name: "Release"
+    name: "Pypi Release"
 
     strategy:
       matrix:
-        platform: [ubuntu-latest, ubuntu-20.04, ubuntu-18.04, windows-latest]
+        platform: [ubuntu-latest, ubuntu-20.04]
         python-version: ["3.7"]
       fail-fast: false
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/pip-release.yml
+++ b/.github/workflows/pip-release.yml
@@ -38,6 +38,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install maturin==0.14
+          pip install patchelf --upgrade
       - name: Publish wheel
         shell: bash
         env:

--- a/.github/workflows/pip-release.yml
+++ b/.github/workflows/pip-release.yml
@@ -14,8 +14,8 @@ jobs:
 
     strategy:
       matrix:
-        platform: [ubuntu-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        platform: [ubuntu-latest, ubuntu-20.04, ubuntu-18.04, windows-latest]
+        python-version: ["3.7"]
       fail-fast: false
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-20.04, ubuntu-22.04, macos-12, windows-2022]
         python-version: ["3.7"]
       fail-fast: false
     runs-on: ${{ matrix.platform }}
@@ -65,5 +65,5 @@ jobs:
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: archive.zip
-          asset_name: dora-${{ github.ref_name }}-x86_64-${{ runner.os }}.zip
+          asset_name: dora-${{ github.ref_name }}-x86_64-${{ matrix.platform }}.zip
           asset_content_type: application/zip

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-python"
-version = "0.1.1"
+version = "0.1.1-2"
 dependencies = [
  "dora-node-api",
  "dora-operator-api-python",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "communication-layer-request-reply"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "eyre",
 ]
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "dora-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "atty",
  "clap 4.0.3",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "dora-coordinator"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bincode",
  "clap 3.2.20",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "dora-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "eyre",
  "once_cell",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "dora-download"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "eyre",
  "reqwest",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "dora-message"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "capnp",
  "capnpc",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "dora-metrics"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "futures",
  "opentelemetry",
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "capnp",
  "communication-layer-pub-sub",
@@ -1015,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-c"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-cxx"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-python"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "dora-node-api",
  "dora-operator-api-python",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "dora-operator-api-macros",
  "dora-operator-api-types",
@@ -1056,14 +1056,14 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-c"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "dora-operator-api-types",
 ]
 
 [[package]]
 name = "dora-operator-api-cxx"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-macros"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "dora-operator-api",
  "dora-operator-api-types",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-python"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1098,14 +1098,14 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-types"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "safer-ffi",
 ]
 
 [[package]]
 name = "dora-runtime"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap 3.2.20",
  "dora-core",
@@ -1136,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "dora-tracing"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "opentelemetry",
  "opentelemetry-jaeger",
@@ -1665,7 +1665,7 @@ dependencies = [
 
 [[package]]
 name = "iceoryx-example-node"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1674,14 +1674,14 @@ dependencies = [
 
 [[package]]
 name = "iceoryx-example-operator"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "dora-operator-api",
 ]
 
 [[package]]
 name = "iceoryx-example-sink"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -3251,7 +3251,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-node"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -3262,14 +3262,14 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-operator"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "dora-operator-api",
 ]
 
 [[package]]
 name = "rust-dataflow-example-sink"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4924,7 +4924,7 @@ dependencies = [
 
 [[package]]
 name = "zenoh-logger"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "zenoh",
  "zenoh-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,7 +529,7 @@ dependencies = [
 
 [[package]]
 name = "communication-layer-pub-sub"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "eyre",
  "iceoryx-rs",

--- a/README.md
+++ b/README.md
@@ -35,30 +35,6 @@ PATH=$PATH:$(pwd):$(pwd)/iceoryx
 dora --help
 ```
 
-<details>
-  <summary> For Macos </summary>
-
-```bash
-wget https://github.com/dora-rs/dora/releases/download/<version>/dora-<version>-x86_64-macOS.zip
-unzip dora-<version>-x86_64-macOS.zip
-PATH=$PATH:$(pwd):$(pwd)/iceoryx
-dora --help
-```
-
-</details>
-
-<details>
-  <summary> For Windows </summary>
-
-```bash
-wget https://github.com/dora-rs/dora/releases/download/<version>/dora-<version>-x86_64-Windows.zip
-unzip dora-<version>-x86_64-Windows.zip
-PATH=$PATH:$(pwd):$(pwd)/iceoryx
-dora --help
-```
-
-</details>
-
 > This is `x86_64` only for the moment.
 
 2. Create a new dataflow

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Dataflow Oriented Robotic Architecture ⚡
 
 This project is in early development, and many features have yet to be implemented with breaking changes. Please don't take for granted the current design.
 
+`dora` primary support is with `Linux` ( Ubuntu 20.04 and Ubuntu 22.04 ) as it is the primary OS for both Cloud and small computers. If you wish to use `dora` with another OS, please compile from source.
+
 ---
 ## 📖 Documentation
 

--- a/apis/c++/node/Cargo.toml
+++ b/apis/c++/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-node-api-cxx"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -10,7 +10,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 cxx = "1.0.73"
-dora-node-api = { version = "0.1.0", path = "../../../apis/rust/node", default-features = false, features = [
+dora-node-api = { version = "0.1.1", path = "../../../apis/rust/node", default-features = false, features = [
     "zenoh",
 ] }
 eyre = "0.6.8"

--- a/apis/c++/operator/Cargo.toml
+++ b/apis/c++/operator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-operator-api-cxx"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [lib]
@@ -8,7 +8,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 cxx = "1.0.73"
-dora-operator-api = { version = "0.1.0", path = "../../../apis/rust/operator" }
+dora-operator-api = { version = "0.1.1", path = "../../../apis/rust/operator" }
 eyre = "0.6.8"
 futures = "0.3.21"
 rand = "0.8.5"

--- a/apis/c/node/Cargo.toml
+++ b/apis/c/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-node-api-c"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/apis/c/operator/Cargo.toml
+++ b/apis/c/operator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-operator-api-c"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "C API implemetation for Dora Operator"

--- a/apis/python/node/Cargo.toml
+++ b/apis/python/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-node-api-python"
-version = "0.1.1"
+version = "0.1.1-2"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/apis/python/node/Cargo.toml
+++ b/apis/python/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-node-api-python"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/apis/python/operator/Cargo.toml
+++ b/apis/python/operator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-operator-api-python"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/apis/rust/node/Cargo.toml
+++ b/apis/rust/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-node-api"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/apis/rust/node/src/lib.rs
+++ b/apis/rust/node/src/lib.rs
@@ -144,7 +144,6 @@ fn set_up_tracing() -> eyre::Result<()> {
         .context("failed to set tracing global subscriber")
 }
 
-#[must_use]
 pub fn manual_stop_publisher(
     communication: &mut dyn CommunicationLayer,
 ) -> eyre::Result<Box<dyn Publisher>> {

--- a/apis/rust/operator/Cargo.toml
+++ b/apis/rust/operator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-operator-api"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust API implemetation for Dora Operator"

--- a/apis/rust/operator/macros/Cargo.toml
+++ b/apis/rust/operator/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-operator-api-macros"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust API Macros for Dora Operator"

--- a/apis/rust/operator/types/Cargo.toml
+++ b/apis/rust/operator/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-operator-api-types"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-cli"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/binaries/cli/src/check.rs
+++ b/binaries/cli/src/check.rs
@@ -3,7 +3,6 @@ use dora_core::{
     adjust_shared_library_path,
     config::{InputMapping, UserInputMapping},
     descriptor::{self, source_is_url, CoreNodeKind, OperatorSource},
-    topics::ControlRequest,
 };
 use eyre::{bail, eyre, Context};
 use std::{env::consts::EXE_EXTENSION, io::Write, path::Path};

--- a/binaries/cli/src/template/cxx/mod.rs
+++ b/binaries/cli/src/template/cxx/mod.rs
@@ -64,7 +64,7 @@ fn create_operator(name: String, path: Option<PathBuf>) -> Result<(), eyre::ErrR
 
     // create directories
     let root = path.as_deref().unwrap_or_else(|| Path::new(&name));
-    fs::create_dir(&root)
+    fs::create_dir(root)
         .with_context(|| format!("failed to create directory `{}`", root.display()))?;
 
     let operator_path = root.join("operator.cc");
@@ -96,7 +96,7 @@ fn create_custom_node(name: String, path: Option<PathBuf>) -> Result<(), eyre::E
 
     // create directories
     let root = path.as_deref().unwrap_or_else(|| Path::new(&name));
-    fs::create_dir(&root)
+    fs::create_dir(root)
         .with_context(|| format!("failed to create directory `{}`", root.display()))?;
 
     let node_path = root.join("node.cc");

--- a/binaries/cli/src/template/rust/node/Cargo-template.toml
+++ b/binaries/cli/src/template/rust/node/Cargo-template.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dora-node-api = { git = "https://github.com/dora-rs/dora.git" }
+dora-node-api = { git = "https://github.com/dora-rs/dora.git", tag = "v0.1.1" }

--- a/binaries/cli/src/template/rust/node/main-template.rs
+++ b/binaries/cli/src/template/rust/node/main-template.rs
@@ -1,4 +1,4 @@
-use dora_node_api::{self, core::config::DataId, DoraNode};
+use dora_node_api::DoraNode;
 use std::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {

--- a/binaries/cli/src/template/rust/operator/Cargo-template.toml
+++ b/binaries/cli/src/template/rust/operator/Cargo-template.toml
@@ -9,4 +9,4 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-dora-operator-api = { git = "https://github.com/dora-rs/dora.git" }
+dora-operator-api = { git = "https://github.com/dora-rs/dora.git", tag = "v0.1.1" }

--- a/binaries/coordinator/Cargo.toml
+++ b/binaries/coordinator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-coordinator"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 
@@ -20,7 +20,7 @@ clap = { version = "3.1.8", features = ["derive"] }
 uuid = { version = "1.2.1" }
 time = "0.3.9"
 rand = "0.8.5"
-dora-core = { version = "0.1.0", path = "../../libraries/core" }
+dora-core = { version = "0.1.1", path = "../../libraries/core" }
 dora-message = { path = "../../libraries/message" }
 tracing = "0.1.36"
 tracing-subscriber = "0.3.15"

--- a/binaries/runtime/Cargo.toml
+++ b/binaries/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-runtime"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 
@@ -14,7 +14,7 @@ dora-node-api = { path = "../../apis/rust/node", default-features = false, featu
 ] }
 dora-operator-api-python = { path = "../../apis/python/operator" }
 dora-operator-api-types = { path = "../../apis/rust/operator/types" }
-dora-core = { version = "0.1.0", path = "../../libraries/core" }
+dora-core = { version = "0.1.1", path = "../../libraries/core" }
 dora-tracing = { path = "../../libraries/extensions/telemetry/tracing", optional = true }
 dora-metrics = { path = "../../libraries/extensions/telemetry/metrics", optional = true }
 opentelemetry = { version = "0.17", features = [

--- a/binaries/runtime/src/main.rs
+++ b/binaries/runtime/src/main.rs
@@ -1,5 +1,3 @@
-use dora_runtime;
-
 fn main() -> Result<(), eyre::Report> {
     dora_runtime::main()
 }

--- a/binaries/runtime/src/operator/python.rs
+++ b/binaries/runtime/src/operator/python.rs
@@ -50,7 +50,7 @@ pub fn spawn(
     let path = if source_is_url(source) {
         let target_path = Path::new("build")
             .join(node_id.to_string())
-            .join(format!("{}.py", operator_id.to_string()));
+            .join(format!("{}.py", operator_id));
         // try to download the shared library
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()

--- a/examples/iceoryx/node/Cargo.toml
+++ b/examples/iceoryx/node/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "iceoryx-example-node"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dora-node-api = { version = "0.1.0", path = "../../../apis/rust/node" }
+dora-node-api = { version = "0.1.1", path = "../../../apis/rust/node" }
 eyre = "0.6.8"
 rand = "0.8.5"

--- a/examples/iceoryx/operator/Cargo.toml
+++ b/examples/iceoryx/operator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iceoryx-example-operator"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/examples/iceoryx/sink/Cargo.toml
+++ b/examples/iceoryx/sink/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "iceoryx-example-sink"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dora-node-api = { version = "0.1.0", path = "../../../apis/rust/node" }
+dora-node-api = { version = "0.1.1", path = "../../../apis/rust/node" }
 eyre = "0.6.8"
 futures = "0.3.21"
 tokio = { version = "1.20.1", features = ["macros"] }

--- a/examples/rust-dataflow-url/sink/Cargo.toml
+++ b/examples/rust-dataflow-url/sink/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "rust-dataflow-example-sink"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dora-node-api = { version = "0.1.0", path = "../../../apis/rust/node" }
+dora-node-api = { version = "0.1.1", path = "../../../apis/rust/node" }
 eyre = "0.6.8"

--- a/examples/rust-dataflow/node/Cargo.toml
+++ b/examples/rust-dataflow/node/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "rust-dataflow-example-node"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dora-node-api = { version = "0.1.0", path = "../../../apis/rust/node" }
+dora-node-api = { version = "0.1.1", path = "../../../apis/rust/node" }
 eyre = "0.6.8"
 futures = "0.3.21"
 rand = "0.8.5"

--- a/examples/rust-dataflow/operator/Cargo.toml
+++ b/examples/rust-dataflow/operator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-dataflow-example-operator"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/examples/rust-dataflow/sink/Cargo.toml
+++ b/examples/rust-dataflow/sink/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "rust-dataflow-example-sink"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dora-node-api = { version = "0.1.0", path = "../../../apis/rust/node" }
+dora-node-api = { version = "0.1.1", path = "../../../apis/rust/node" }
 eyre = "0.6.8"

--- a/libraries/communication-layer/pub-sub/Cargo.toml
+++ b/libraries/communication-layer/pub-sub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communication-layer-pub-sub"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [features]

--- a/libraries/communication-layer/request-reply/Cargo.toml
+++ b/libraries/communication-layer/request-reply/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communication-layer-request-reply"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [features]

--- a/libraries/communication-layer/request-reply/src/tcp.rs
+++ b/libraries/communication-layer/request-reply/src/tcp.rs
@@ -125,7 +125,7 @@ impl TcpConnection {
     fn send(&mut self, request: &[u8]) -> std::io::Result<()> {
         let len_raw = (request.len() as u64).to_le_bytes();
         self.stream.write_all(&len_raw)?;
-        self.stream.write_all(&request)?;
+        self.stream.write_all(request)?;
         Ok(())
     }
 

--- a/libraries/core/Cargo.toml
+++ b/libraries/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-core"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/libraries/extensions/download/Cargo.toml
+++ b/libraries/extensions/download/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-download"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/libraries/extensions/telemetry/metrics/Cargo.toml
+++ b/libraries/extensions/telemetry/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-metrics"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/libraries/extensions/telemetry/tracing/Cargo.toml
+++ b/libraries/extensions/telemetry/tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-tracing"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/libraries/extensions/zenoh-logger/Cargo.toml
+++ b/libraries/extensions/zenoh-logger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zenoh-logger"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/libraries/message/Cargo.toml
+++ b/libraries/message/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-message"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
This Pull Request changes the version of all rust crates to `0.1.1`.
It also fixes most of `Clippy` warnings.

