### PR TITLE
Fix high CPU usage in coordinator by properly handling closed connections

### DIFF
--- a/binaries/coordinator/src/control.rs
+++ b/binaries/coordinator/src/control.rs
@@ -81,14 +81,23 @@ fn handle_requests(
             Ok(reply)
         }));
         if let Err(err) = result {
-            if err.kind() == ErrorKind::Other {
-                let inner = err.into_inner().unwrap();
-                let downcasted = inner.downcast_ref().unwrap();
-                match downcasted {
-                    HandlerError::ParseError(err) => {
-                        tracing::warn!("failed to parse request: {err}");
+            match err.kind() {
+                ErrorKind::UnexpectedEof => {
+                    tracing::trace!("Control connection closed");
+                    break;
+                }
+                ErrorKind::Other => {
+                    let inner = err.into_inner().unwrap();
+                    let downcasted = inner.downcast_ref().unwrap();
+                    match downcasted {
+                        HandlerError::ParseError(err) => {
+                            tracing::warn!("failed to parse request: {err}");
+                        }
+                        HandlerError::ServerStopped => break,
                     }
-                    HandlerError::ServerStopped => break,
+                }
+                _ => {
+                    tracing::warn!("I/O error while trying to receive control request: {err:?}");
                 }
             }
         }

--- a/binaries/coordinator/src/control.rs
+++ b/binaries/coordinator/src/control.rs
@@ -112,6 +112,7 @@ enum HandlerError {
     ServerStopped,
 }
 
+#[derive(Debug)]
 pub enum ControlEvent {
     IncomingRequest {
         request: ControlRequest,

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -77,6 +77,7 @@ async fn start(runtime_path: &Path) -> eyre::Result<()> {
     let mut running_dataflows = HashMap::new();
 
     while let Some(event) = events.next().await {
+        tracing::trace!("Handling event {event:?}");
         match event {
             Event::Dataflow { uuid, event } => match event {
                 DataflowEvent::Finished { result } => {
@@ -319,11 +320,13 @@ async fn start_dataflow(
     })
 }
 
+#[derive(Debug)]
 enum Event {
     Dataflow { uuid: Uuid, event: DataflowEvent },
     Control(ControlEvent),
 }
 
+#[derive(Debug)]
 enum DataflowEvent {
     Finished { result: eyre::Result<()> },
 }


### PR DESCRIPTION
We forgot to handle closed control connections in the `handle_requests` loop. So instead of breaking out of that loop, we continued polling the connection for new messages again and again.

Fixes #154 