### PR TITLE
Simplify release process

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,15 @@ members = [
     "libraries/extensions/zenoh-logger",
 ]
 
+[workspace.package]
+version = "0.1.1"
+
 [package]
 name = "dora-examples"
 version = "0.0.0"
 edition = "2021"
 license = "Apache-2.0"
+
 
 [dev-dependencies]
 eyre = "0.6.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,11 @@ members = [
 [workspace.package]
 version = "0.1.1"
 
+[workspace.dependencies]
+dora-node-api = { version = "0.1.1", path = "apis/rust/node", default-features = false }
+dora-operator-api = { version = "0.1.1", path = "apis/rust/operator", default-features = false }
+dora-core = { version = "0.1.1", path = "libraries/core" }
+
 [package]
 name = "dora-examples"
 version = "0.0.0"

--- a/apis/c++/node/Cargo.toml
+++ b/apis/c++/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-node-api-cxx"
-version = "0.1.1"
+version.workspace = true
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/apis/c++/node/Cargo.toml
+++ b/apis/c++/node/Cargo.toml
@@ -10,9 +10,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 cxx = "1.0.73"
-dora-node-api = { version = "0.1.1", path = "../../../apis/rust/node", default-features = false, features = [
-    "zenoh",
-] }
+dora-node-api = { workspace = true, features = ["zenoh"] }
 eyre = "0.6.8"
 
 [build-dependencies]

--- a/apis/c++/operator/Cargo.toml
+++ b/apis/c++/operator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-operator-api-cxx"
-version = "0.1.1"
+version.workspace = true
 edition = "2021"
 
 [lib]

--- a/apis/c++/operator/Cargo.toml
+++ b/apis/c++/operator/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 cxx = "1.0.73"
-dora-operator-api = { version = "0.1.1", path = "../../../apis/rust/operator" }
+dora-operator-api = { workspace = true }
 eyre = "0.6.8"
 futures = "0.3.21"
 rand = "0.8.5"

--- a/apis/c/node/Cargo.toml
+++ b/apis/c/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-node-api-c"
-version = "0.1.1"
+version.workspace = true
 edition = "2021"
 license = "Apache-2.0"
 

--- a/apis/c/operator/Cargo.toml
+++ b/apis/c/operator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-operator-api-c"
-version = "0.1.1"
+version.workspace = true
 edition = "2021"
 license = "Apache-2.0"
 description = "C API implemetation for Dora Operator"

--- a/apis/python/operator/Cargo.toml
+++ b/apis/python/operator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-operator-api-python"
-version = "0.1.1"
+version.workspace = true
 edition = "2021"
 license = "Apache-2.0"
 

--- a/apis/rust/node/Cargo.toml
+++ b/apis/rust/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-node-api"
-version = "0.1.1"
+version.workspace = true
 edition = "2021"
 license = "Apache-2.0"
 

--- a/apis/rust/operator/Cargo.toml
+++ b/apis/rust/operator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-operator-api"
-version = "0.1.1"
+version.workspace = true
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust API implemetation for Dora Operator"

--- a/apis/rust/operator/macros/Cargo.toml
+++ b/apis/rust/operator/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-operator-api-macros"
-version = "0.1.1"
+version.workspace = true
 edition = "2021"
 license = "Apache-2.0"
 description = "Rust API Macros for Dora Operator"

--- a/apis/rust/operator/types/Cargo.toml
+++ b/apis/rust/operator/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-operator-api-types"
-version = "0.1.1"
+version.workspace = true
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-cli"
-version = "0.1.1"
+version.workspace = true
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/binaries/coordinator/Cargo.toml
+++ b/binaries/coordinator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-coordinator"
-version = "0.1.1"
+version.workspace = true
 edition = "2021"
 license = "Apache-2.0"
 

--- a/binaries/coordinator/Cargo.toml
+++ b/binaries/coordinator/Cargo.toml
@@ -20,7 +20,7 @@ clap = { version = "3.1.8", features = ["derive"] }
 uuid = { version = "1.2.1" }
 time = "0.3.9"
 rand = "0.8.5"
-dora-core = { version = "0.1.1", path = "../../libraries/core" }
+dora-core = { workspace = true }
 dora-message = { path = "../../libraries/message" }
 tracing = "0.1.36"
 tracing-subscriber = "0.3.15"

--- a/binaries/runtime/Cargo.toml
+++ b/binaries/runtime/Cargo.toml
@@ -14,7 +14,7 @@ dora-node-api = { path = "../../apis/rust/node", default-features = false, featu
 ] }
 dora-operator-api-python = { path = "../../apis/python/operator" }
 dora-operator-api-types = { path = "../../apis/rust/operator/types" }
-dora-core = { version = "0.1.1", path = "../../libraries/core" }
+dora-core = { workspace = true }
 dora-tracing = { path = "../../libraries/extensions/telemetry/tracing", optional = true }
 dora-metrics = { path = "../../libraries/extensions/telemetry/metrics", optional = true }
 opentelemetry = { version = "0.17", features = [

--- a/binaries/runtime/Cargo.toml
+++ b/binaries/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-runtime"
-version = "0.1.1"
+version.workspace = true
 edition = "2021"
 license = "Apache-2.0"
 

--- a/examples/iceoryx/node/Cargo.toml
+++ b/examples/iceoryx/node/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dora-node-api = { version = "0.1.1", path = "../../../apis/rust/node" }
+dora-node-api = { workspace = true }
 eyre = "0.6.8"
 rand = "0.8.5"

--- a/examples/iceoryx/node/Cargo.toml
+++ b/examples/iceoryx/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iceoryx-example-node"
-version = "0.1.1"
+version.workspace = true
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/iceoryx/node/Cargo.toml
+++ b/examples/iceoryx/node/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true, features = ["iceoryx"] }
 eyre = "0.6.8"
 rand = "0.8.5"

--- a/examples/iceoryx/operator/Cargo.toml
+++ b/examples/iceoryx/operator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iceoryx-example-operator"
-version = "0.1.1"
+version.workspace = true
 edition = "2021"
 license = "Apache-2.0"
 

--- a/examples/iceoryx/sink/Cargo.toml
+++ b/examples/iceoryx/sink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iceoryx-example-sink"
-version = "0.1.1"
+version.workspace = true
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/iceoryx/sink/Cargo.toml
+++ b/examples/iceoryx/sink/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true, features = ["iceoryx"] }
 eyre = "0.6.8"
 futures = "0.3.21"
 tokio = { version = "1.20.1", features = ["macros"] }

--- a/examples/iceoryx/sink/Cargo.toml
+++ b/examples/iceoryx/sink/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dora-node-api = { version = "0.1.1", path = "../../../apis/rust/node" }
+dora-node-api = { workspace = true }
 eyre = "0.6.8"
 futures = "0.3.21"
 tokio = { version = "1.20.1", features = ["macros"] }

--- a/examples/rust-dataflow-url/sink/Cargo.toml
+++ b/examples/rust-dataflow-url/sink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-dataflow-example-sink"
-version = "0.1.1"
+version.workspace = true
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/rust-dataflow-url/sink/Cargo.toml
+++ b/examples/rust-dataflow-url/sink/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true, features = ["zenoh"] }
 eyre = "0.6.8"

--- a/examples/rust-dataflow-url/sink/Cargo.toml
+++ b/examples/rust-dataflow-url/sink/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dora-node-api = { version = "0.1.1", path = "../../../apis/rust/node" }
+dora-node-api = { workspace = true }
 eyre = "0.6.8"

--- a/examples/rust-dataflow/node/Cargo.toml
+++ b/examples/rust-dataflow/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true, features = ["zenoh"] }
 eyre = "0.6.8"
 futures = "0.3.21"
 rand = "0.8.5"

--- a/examples/rust-dataflow/node/Cargo.toml
+++ b/examples/rust-dataflow/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-dataflow-example-node"
-version = "0.1.1"
+version.workspace = true
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/rust-dataflow/node/Cargo.toml
+++ b/examples/rust-dataflow/node/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dora-node-api = { version = "0.1.1", path = "../../../apis/rust/node" }
+dora-node-api = { workspace = true }
 eyre = "0.6.8"
 futures = "0.3.21"
 rand = "0.8.5"

--- a/examples/rust-dataflow/operator/Cargo.toml
+++ b/examples/rust-dataflow/operator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-dataflow-example-operator"
-version = "0.1.1"
+version.workspace = true
 edition = "2021"
 license = "Apache-2.0"
 

--- a/examples/rust-dataflow/sink/Cargo.toml
+++ b/examples/rust-dataflow/sink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-dataflow-example-sink"
-version = "0.1.1"
+version.workspace = true
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/rust-dataflow/sink/Cargo.toml
+++ b/examples/rust-dataflow/sink/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true, features = ["zenoh"] }
 eyre = "0.6.8"

--- a/examples/rust-dataflow/sink/Cargo.toml
+++ b/examples/rust-dataflow/sink/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dora-node-api = { version = "0.1.1", path = "../../../apis/rust/node" }
+dora-node-api = { workspace = true }
 eyre = "0.6.8"

--- a/libraries/communication-layer/pub-sub/Cargo.toml
+++ b/libraries/communication-layer/pub-sub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communication-layer-pub-sub"
-version = "0.1.1"
+version.workspace = true
 edition = "2021"
 
 [features]

--- a/libraries/communication-layer/request-reply/Cargo.toml
+++ b/libraries/communication-layer/request-reply/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "communication-layer-request-reply"
-version = "0.1.1"
+version.workspace = true
 edition = "2021"
 
 [features]

--- a/libraries/core/Cargo.toml
+++ b/libraries/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-core"
-version = "0.1.1"
+version.workspace = true
 edition = "2021"
 license = "Apache-2.0"
 

--- a/libraries/extensions/download/Cargo.toml
+++ b/libraries/extensions/download/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-download"
-version = "0.1.1"
+version.workspace = true
 edition = "2021"
 license = "Apache-2.0"
 

--- a/libraries/extensions/telemetry/metrics/Cargo.toml
+++ b/libraries/extensions/telemetry/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-metrics"
-version = "0.1.1"
+version.workspace = true
 edition = "2021"
 license = "Apache-2.0"
 

--- a/libraries/extensions/telemetry/tracing/Cargo.toml
+++ b/libraries/extensions/telemetry/tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-tracing"
-version = "0.1.1"
+version.workspace = true
 edition = "2021"
 license = "Apache-2.0"
 

--- a/libraries/extensions/zenoh-logger/Cargo.toml
+++ b/libraries/extensions/zenoh-logger/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zenoh-logger"
-version = "0.1.1"
+version.workspace = true
 edition = "2021"
 license = "Apache-2.0"
 

--- a/libraries/message/Cargo.toml
+++ b/libraries/message/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-message"
-version = "0.1.1"
+version.workspace = true
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
- Inherit package version from workspace root
- Set dora sub-crate dependencies as workspace dependencies

With these changes, we only need to change the top-level `Cargo.toml` on new releases.