### PR TITLE
Release-v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,7 +529,7 @@ dependencies = [
 
 [[package]]
 name = "communication-layer-pub-sub"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "eyre",
  "iceoryx-rs",
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "communication-layer-request-reply"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "eyre",
 ]
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "dora-cli"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "atty",
  "clap 4.0.3",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "dora-coordinator"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bincode",
  "clap 3.2.20",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "dora-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "eyre",
  "once_cell",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "dora-download"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "eyre",
  "reqwest",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "dora-message"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "capnp",
  "capnpc",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "dora-metrics"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "futures",
  "opentelemetry",
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "capnp",
  "communication-layer-pub-sub",
@@ -1015,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-c"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-cxx"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-python"
-version = "0.1.1-2"
+version = "0.1.2"
 dependencies = [
  "dora-node-api",
  "dora-operator-api-python",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "dora-operator-api-macros",
  "dora-operator-api-types",
@@ -1056,14 +1056,14 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-c"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "dora-operator-api-types",
 ]
 
 [[package]]
 name = "dora-operator-api-cxx"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-macros"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "dora-operator-api",
  "dora-operator-api-types",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-python"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1098,14 +1098,14 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-types"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "safer-ffi",
 ]
 
 [[package]]
 name = "dora-runtime"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap 3.2.20",
  "dora-core",
@@ -1136,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "dora-tracing"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "opentelemetry",
  "opentelemetry-jaeger",
@@ -1665,7 +1665,7 @@ dependencies = [
 
 [[package]]
 name = "iceoryx-example-node"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1674,14 +1674,14 @@ dependencies = [
 
 [[package]]
 name = "iceoryx-example-operator"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "dora-operator-api",
 ]
 
 [[package]]
 name = "iceoryx-example-sink"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -3251,7 +3251,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-node"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -3262,14 +3262,14 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-operator"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "dora-operator-api",
 ]
 
 [[package]]
 name = "rust-dataflow-example-sink"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4924,7 +4924,7 @@ dependencies = [
 
 [[package]]
 name = "zenoh-logger"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "zenoh",
  "zenoh-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,12 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 
 [workspace.dependencies]
-dora-node-api = { version = "0.1.1", path = "apis/rust/node", default-features = false }
-dora-operator-api = { version = "0.1.1", path = "apis/rust/operator", default-features = false }
-dora-core = { version = "0.1.1", path = "libraries/core" }
+dora-node-api = { version = "0.1.2", path = "apis/rust/node", default-features = false }
+dora-operator-api = { version = "0.1.2", path = "apis/rust/operator", default-features = false }
+dora-core = { version = "0.1.2", path = "libraries/core" }
 
 [package]
 name = "dora-examples"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Dataflow Oriented Robotic Architecture ⚡
 
 This project is in early development, and many features have yet to be implemented with breaking changes. Please don't take for granted the current design.
 
-`dora` primary support is with `Linux` ( Ubuntu 20.04 and Ubuntu 22.04 ) as it is the primary OS for both Cloud and small computers. If you wish to use `dora` with another OS, please compile from source.
+`dora` primary support is with `Linux` as it is the primary OS for both Cloud and small computers. If you wish to use `dora` with another OS, please compile from source.
 
 ---
 ## 📖 Documentation
@@ -101,7 +101,7 @@ communication:
 nodes:
   - id: op_1
     operator:
-      python: https://raw.githubusercontent.com/dora-rs/dora-drives/main/operators/webcam.py
+      python: https://raw.githubusercontent.com/dora-rs/dora-drives/main/operators/webcam_op.py
       inputs:
         tick: dora/timer/millis/100
       outputs:

--- a/apis/python/node/Cargo.toml
+++ b/apis/python/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-node-api-python"
-version = "0.1.1-2"
+version.workspace = true
 edition = "2021"
 license = "Apache-2.0"
 

--- a/binaries/cli/src/template/rust/node/Cargo-template.toml
+++ b/binaries/cli/src/template/rust/node/Cargo-template.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dora-node-api = { git = "https://github.com/dora-rs/dora.git", tag = "v0.1.1" }
+dora-node-api = { git = "https://github.com/dora-rs/dora.git", tag = "v0.1.2" }

--- a/binaries/cli/src/template/rust/operator/Cargo-template.toml
+++ b/binaries/cli/src/template/rust/operator/Cargo-template.toml
@@ -9,4 +9,4 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-dora-operator-api = { git = "https://github.com/dora-rs/dora.git", tag = "v0.1.1" }
+dora-operator-api = { git = "https://github.com/dora-rs/dora.git", tag = "v0.1.2" }

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -2,28 +2,31 @@
 
 This project is in early development, and many features have yet to be implemented with breaking changes. Please don't take for granted the current design. The installation process will be streamlined in the future.
 
-### 1. Compile the dora-coordinator
+### Download the binaries from Github
 
-The `dora-coordinator` is responsible for reading the dataflow descriptor file and launching the operators accordingly. 
+
+Install `dora` binaries from GitHub releases:
+
+```bash
+wget https://github.com/dora-rs/dora/releases/download/<version>/dora-<version>-x86_64-Linux.zip
+unzip dora-<version>-x86_64-Linux.zip
+python3 -m pip install dora-rs==<version> ## For Python API
+PATH=$PATH:$(pwd):$(pwd)/iceoryx
+dora --help
+```
+
+#### Or compile from Source
 
 Build it using:
 ```bash
 git clone https://github.com/dora-rs/dora.git
 cd dora
-cargo build -p dora-coordinator --release
+cargo build -p dora-coordinator -p dora-runtime --release
+PATH=$PATH:$(pwd)/target/release
 ```
 
-### 2. Compile the dora-runtime for operators
-
-The `dora-runtime` is responsible for managing a set of operators. 
+If you want to use `Iceoryx`. Add `iox-roudi` to the path.
+You can find `iox-roudi` with:
 ```bash
-cargo build -p dora-runtime --release
-```
-
-### 3. Add those binaries to your path
-
-This step is optional. You can also refer to the executables using their full path or copy them somewhere else.
-
-```bash
-export PATH=$PATH:$(pwd)/target/release
+find target -type f -wholename "*/iceoryx-install/bin/iox-roudi"
 ```


### PR DESCRIPTION
Releasing the v0.1.2 that fixes: 
- the infinite loop in the coordinator. https://github.com/dora-rs/dora/pull/155
- simplify the release process. https://github.com/dora-rs/dora/pull/157
- Use generic linux distribution. https://github.com/dora-rs/dora/pull/159

