### PR TITLE
Force removal of Pyo3 Object to avoid memory leak

### DIFF
--- a/apis/python/node/Cargo.toml
+++ b/apis/python/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
+version = "0.1.2"
 name = "dora-node-api-python"
-version.workspace = true
 edition = "2021"
 license = "Apache-2.0"
 

--- a/examples/python-dataflow/plot.py
+++ b/examples/python-dataflow/plot.py
@@ -81,6 +81,3 @@ class Operator:
                 return DoraStatus.STOP
 
         return DoraStatus.CONTINUE
-
-    def __del__(self):
-        cv2.destroyAllWindows()

--- a/examples/python-dataflow/requirements.txt
+++ b/examples/python-dataflow/requirements.txt
@@ -2,17 +2,20 @@
 # Usage: pip install -r requirements.txt
 
 # Base ----------------------------------------
+gitpython
+ipython  # interactive notebook
 matplotlib>=3.2.2
 numpy>=1.18.5
 opencv-python>=4.1.1
 Pillow>=7.1.2
+psutil  # system resources
 PyYAML>=5.3.1
 requests>=2.23.0
 scipy>=1.4.1
-torch>=1.7.0
+thop>=0.1.1  # FLOPs computation
+torch>=1.7.0  # see https://pytorch.org/get-started/locally (recommended)
 torchvision>=0.8.1
 tqdm>=4.64.0
-protobuf<=3.20.1  # https://github.com/ultralytics/yolov5/issues/8012
 
 # Logging -------------------------------------
 tensorboard>=2.4.1
@@ -35,9 +38,6 @@ seaborn>=0.11.0
 # openvino-dev  # OpenVINO export
 
 # Extras --------------------------------------
-ipython  # interactive notebook
-psutil  # system utilization
-thop>=0.1.1  # FLOPs computation
 # albumentations>=1.0.3
 # pycocotools>=2.0  # COCO mAP
 # roboflow


### PR DESCRIPTION
This PR fix the memory leak happening in the dora API operator. This is seemingly due to pyo3 leaking memory on object created in Rust. Using standard `drop` did not drop the memory on the `PyBytes` included in the `PyDict`.

See: https://github.com/PyO3/pyo3/issues/1801

Fixes https://github.com/dora-rs/dora/issues/163