### PR TITLE
Use `DoraStatus` from dora library in template

### DIFF
--- a/binaries/cli/src/template/python/mod.rs
+++ b/binaries/cli/src/template/python/mod.rs
@@ -89,7 +89,7 @@ fn create_dataflow(name: String, path: Option<PathBuf>) -> Result<(), eyre::ErrR
     create_custom_node("node_1".into(), Some(root.join("node_1")))?;
 
     println!(
-        "Created new C dataflow at `{name}` at {}",
+        "Created new yaml dataflow `{name}` at {}",
         Path::new(".").join(root).display()
     );
 

--- a/binaries/cli/src/template/python/operator/operator-template.py
+++ b/binaries/cli/src/template/python/operator/operator-template.py
@@ -1,11 +1,6 @@
 from typing import Callable
 
-from enum import Enum
-
-
-class DoraStatus(Enum):
-    CONTINUE = 0
-    STOP = 1
+from dora import DoraStatus
 
 
 class Operator:


### PR DESCRIPTION
Small refactoring of the template manager in order to push for the use of the newly defined `DoraStatus` from the `dora` library.