### PR TITLE
Manage node failure: Await all nodes to finish before marking dataflow as finished

### DIFF
--- a/binaries/coordinator/src/run/mod.rs
+++ b/binaries/coordinator/src/run/mod.rs
@@ -8,6 +8,7 @@ use eyre::{bail, eyre, WrapErr};
 use futures::{stream::FuturesUnordered, StreamExt};
 use std::{env::consts::EXE_EXTENSION, path::Path};
 use tokio_stream::wrappers::IntervalStream;
+use tracing::warn;
 use uuid::Uuid;
 
 mod custom;
@@ -135,7 +136,8 @@ pub async fn await_tasks(
     while let Some(task_result) = tasks.next().await {
         task_result
             .wrap_err("failed to join async task")?
-            .wrap_err("custom node failed")?;
+            .wrap_err("One node failed!")
+            .unwrap_or_else(|err| warn!("{err}"))
     }
     Ok(())
 }


### PR DESCRIPTION
Previouly, if one node failed we would immidiately mark the dataflow as
finished even though other nodes might still be running.

This meant that if one node failed, it would not be possible to stop the
dataflow through the cli as it is marked as finished.

This commit will just warn the user that one node failed but will keep
await that all nodes within the dataflow finishes.

