### PR TITLE
Send small messages directly without shared memory

### DIFF
--- a/binaries/daemon/src/listener/mod.rs
+++ b/binaries/daemon/src/listener/mod.rs
@@ -241,7 +241,9 @@ where
                 data: Some(data), ..
             }) = self.queue.remove(index)
             {
-                drop_tokens.push(data.drop_token);
+                if let Some(drop_token) = data.drop_token() {
+                    drop_tokens.push(drop_token);
+                }
             }
         }
         self.report_drop_tokens(drop_tokens).await?;
@@ -296,9 +298,10 @@ where
                 )
                 .await?;
             }
-            DaemonRequest::SendEmptyMessage {
+            DaemonRequest::SendMessage {
                 output_id,
                 metadata,
+                data,
             } => {
                 // let elapsed = metadata.timestamp().get_time().to_system_time().elapsed()?;
                 // tracing::debug!("listener SendEmptyMessage: {elapsed:?}");
@@ -307,7 +310,7 @@ where
                     node_id: self.node_id.clone(),
                     output_id,
                     metadata,
-                    data: None,
+                    data: data.into(),
                 });
                 let result = self
                     .send_daemon_event(event)

--- a/binaries/daemon/src/shared_mem_handler.rs
+++ b/binaries/daemon/src/shared_mem_handler.rs
@@ -181,7 +181,7 @@ impl SharedMemHandler {
                         node_id,
                         output_id,
                         metadata,
-                        data,
+                        data: data.into(),
                     })
                     .await;
                 let _ = reply_sender.send(DaemonReply::Result(


### PR DESCRIPTION
We currently need an additional request to prepare zero-copy shared memory messages. For small messages, it might be faster to avoid this extra round-trip and send the message directly over TCP. This PR implements support for this. Messages smaller than a threshold (currently set to 4096 bytes) are sent via TCP, while larger messages still use shared memory.

This step also enables future optimizations such as queueing output messages in order to improve the throughput.
