### PR TITLE
Update zenoh to remove git dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,14 +10,13 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aes"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
 dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
- "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -30,19 +29,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
+name = "anyhow"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
-name = "anyhow"
-version = "1.0.56"
+name = "array-init"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
 
 [[package]]
 name = "async-attributes"
@@ -60,38 +56,37 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
 dependencies = [
- "concurrent-queue",
+ "concurrent-queue 1.2.2",
  "event-listener",
  "futures-core",
 ]
 
 [[package]]
 name = "async-executor"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
+checksum = "17adb73da160dfb475c183343c8cccd80721ea5a605d3eb57125f0a7b7a92d0b"
 dependencies = [
+ "async-lock",
  "async-task",
- "concurrent-queue",
+ "concurrent-queue 2.1.0",
  "fastrand",
  "futures-lite",
- "once_cell",
  "slab",
 ]
 
 [[package]]
 name = "async-global-executor"
-version = "2.0.3"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c026b7e44f1316b567ee750fea85103f87fcb80792b860e979f221259796ca0a"
+checksum = "f1b6f5d7df27bd294849f8eec66ecfc63d11814df7a4f5d74168a2394467b776"
 dependencies = [
  "async-channel",
  "async-executor",
  "async-io",
- "async-mutex",
+ "async-lock",
  "blocking",
  "futures-lite",
- "num_cpus",
  "once_cell",
  "tokio",
 ]
@@ -102,7 +97,7 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a811e6a479f2439f0c04038796b5cfb3d2ad56c230e0f2d3f7b04d68cfee607b"
 dependencies = [
- "concurrent-queue",
+ "concurrent-queue 1.2.2",
  "futures-lite",
  "libc",
  "log",
@@ -117,18 +112,9 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "2.5.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97a171d191782fba31bb902b14ad94e24a68145032b7eedf871ab0bc0d077b6"
-dependencies = [
- "event-listener",
-]
-
-[[package]]
-name = "async-mutex"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
+checksum = "fa24f727524730b077666307f2734b4a1a1c57acb79193127dcc8914d5242dd7"
 dependencies = [
  "event-listener",
 ]
@@ -152,20 +138,20 @@ dependencies = [
 
 [[package]]
 name = "async-rustls"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c86f33abd5a4f3e2d6d9251a9e0c6a7e52eb1113caf893dae8429bf4a53f378"
+checksum = "93b21a03b7c21702a0110f9f8d228763a533570deb376119042dabf33c37a01a"
 dependencies = [
- "futures-lite",
- "rustls 0.19.1",
- "webpki 0.21.4",
+ "futures-io",
+ "rustls",
+ "webpki",
 ]
 
 [[package]]
 name = "async-std"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52580991739c5cdb36cde8b2a516371c0a3b70dda36d916cc08b82372916808c"
+checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
 dependencies = [
  "async-attributes",
  "async-channel",
@@ -182,7 +168,6 @@ dependencies = [
  "kv-log-macro",
  "log",
  "memchr",
- "num_cpus",
  "once_cell",
  "pin-project-lite",
  "pin-utils",
@@ -240,18 +225,9 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "autocfg"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
-dependencies = [
- "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -262,15 +238,21 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "base64ct"
-version = "1.1.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b4d9b1225d28d360ec6a231d65af1fd99a2a095154c8040689617290569c5c"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "benchmark-example-node"
@@ -328,7 +310,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
- "block-padding 0.1.5",
+ "block-padding",
  "byte-tools",
  "byteorder",
  "generic-array 0.12.4",
@@ -336,11 +318,10 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "block-padding 0.2.1",
  "generic-array 0.14.5",
 ]
 
@@ -352,12 +333,6 @@ checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
  "byte-tools",
 ]
-
-[[package]]
-name = "block-padding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "blocking"
@@ -444,33 +419,19 @@ checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "cipher"
-version = "0.3.0"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "generic-array 0.14.5",
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim 0.8.0",
- "textwrap 0.11.0",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
-version = "3.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
  "bitflags",
@@ -478,9 +439,9 @@ dependencies = [
  "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
- "textwrap 0.15.0",
+ "textwrap",
 ]
 
 [[package]]
@@ -494,7 +455,7 @@ dependencies = [
  "clap_derive 4.0.1",
  "clap_lex 0.3.0",
  "once_cell",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
 ]
 
@@ -567,8 +528,8 @@ name = "communication-layer-pub-sub"
 version = "0.1.3"
 dependencies = [
  "eyre",
+ "flume",
  "zenoh",
- "zenoh-config",
 ]
 
 [[package]]
@@ -588,10 +549,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-oid"
-version = "0.6.2"
+name = "concurrent-queue"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
+checksum = "c278839b831783b70278b14df4d45e1beb1aad306c07bb796637de9a0e323e8e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
 name = "core-foundation"
@@ -654,22 +624,21 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "cfg-if",
  "crossbeam-utils",
  "lazy_static",
- "memoffset",
+ "memoffset 0.6.5",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.8"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if",
- "lazy_static",
 ]
 
 [[package]]
@@ -698,24 +667,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-bigint"
-version = "0.2.11"
+name = "crypto-common"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array 0.14.5",
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
-dependencies = [
- "generic-array 0.14.5",
- "subtle",
+ "typenum",
 ]
 
 [[package]]
@@ -800,12 +758,13 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.4.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b71cca7d95d7681a4b3b9cdf63c8dbc3730d0584c2c74e31416d64a90493f4"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid",
- "crypto-bigint",
+ "pem-rfc7468",
+ "zeroize",
 ]
 
 [[package]]
@@ -819,11 +778,14 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "generic-array 0.14.5",
+ "block-buffer 0.10.4",
+ "const-oid",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -879,10 +841,10 @@ dependencies = [
  "inquire",
  "serde",
  "serde_json",
- "serde_yaml 0.9.11",
+ "serde_yaml 0.9.19",
  "tempfile",
  "termcolor",
- "uuid 1.2.1",
+ "uuid",
  "webbrowser",
 ]
 
@@ -891,7 +853,7 @@ name = "dora-coordinator"
 version = "0.1.3"
 dependencies = [
  "bincode",
- "clap 3.2.20",
+ "clap 3.2.23",
  "communication-layer-request-reply",
  "ctrlc",
  "dora-core",
@@ -911,7 +873,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util 0.7.1",
  "tracing",
- "uuid 1.2.1",
+ "uuid",
  "which",
  "zenoh",
 ]
@@ -925,11 +887,11 @@ dependencies = [
  "once_cell",
  "serde",
  "serde-with-expand-env",
- "serde_yaml 0.9.11",
+ "serde_yaml 0.9.19",
  "tracing",
- "uuid 1.2.1",
+ "uuid",
  "which",
- "zenoh-config",
+ "zenoh",
 ]
 
 [[package]]
@@ -938,7 +900,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "bincode",
- "clap 3.2.20",
+ "clap 3.2.23",
  "ctrlc",
  "dora-core",
  "dora-download",
@@ -954,7 +916,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "uuid 1.2.1",
+ "uuid",
 ]
 
 [[package]]
@@ -980,7 +942,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "uuid 1.2.1",
+ "uuid",
 ]
 
 [[package]]
@@ -990,7 +952,7 @@ dependencies = [
  "capnp",
  "capnpc",
  "serde",
- "uhlc 0.5.1",
+ "uhlc",
 ]
 
 [[package]]
@@ -1023,7 +985,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "uuid 1.2.1",
+ "uuid",
 ]
 
 [[package]]
@@ -1183,12 +1145,12 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
 dependencies = [
- "atty",
  "humantime",
+ "is-terminal",
  "log",
  "regex",
  "termcolor",
@@ -1217,9 +1179,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.2"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "eyre"
@@ -1298,11 +1260,10 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
- "matches",
  "percent-encoding",
 ]
 
@@ -1425,15 +1386,6 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -1569,6 +1521,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1576,12 +1543,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "crypto-mac",
- "digest 0.9.0",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -1705,7 +1671,7 @@ version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "hashbrown",
 ]
 
@@ -1716,6 +1682,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7906a9fababaeacb774f72410e497a1d18de916322e33797bb2cd29baa23c9e"
 dependencies = [
  "unindent",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array 0.14.5",
 ]
 
 [[package]]
@@ -1789,18 +1764,30 @@ checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
 name = "ipnetwork"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4088d739b183546b239688ddbc79891831df421773df95e236daf7867866d355"
+checksum = "1f84f1612606f3753f205a4e9a2efd6fe5b4c573a6269b2cc6c3003d44a0d127"
 dependencies = [
  "serde",
 ]
 
 [[package]]
-name = "itertools"
-version = "0.10.3"
+name = "is-terminal"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
@@ -1883,9 +1870,9 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libloading"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
@@ -1995,7 +1982,16 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -2186,7 +2182,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.6.5",
 ]
 
 [[package]]
@@ -2199,7 +2195,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "memoffset",
+ "memoffset 0.6.5",
 ]
 
 [[package]]
@@ -2211,8 +2207,16 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "libc",
+ "memoffset 0.7.1",
+ "pin-utils",
  "static_assertions",
 ]
+
+[[package]]
+name = "no-std-net"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
 
 [[package]]
 name = "ntapi"
@@ -2235,11 +2239,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4547ee5541c18742396ae2c895d0717d0f886d8823b8399cdaf7b07d63ad0480"
+checksum = "2399c9463abc5f909349d8aa9ba080e0b88b3ce2885389b60b993f39b1a56905"
 dependencies = [
- "autocfg 0.1.8",
  "byteorder",
  "lazy_static",
  "libm",
@@ -2257,7 +2260,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "num-traits",
 ]
 
@@ -2267,7 +2270,7 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -2278,17 +2281,17 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "libm",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
@@ -2321,12 +2324,6 @@ name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
@@ -2366,7 +2363,7 @@ version = "0.9.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5230151e44c0f05157effb743e8d517472843121cf9243e8b81393edb5acd9ce"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "cc",
  "libc",
  "pkg-config",
@@ -2460,9 +2457,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "2.10.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7940cf2ca942593318d07fcf2596cdca60a85c9e7fab408a5e21a4f9dcd40d87"
+checksum = "d84eb1409416d254e4a9c8fa56cc24701755025b458f0fcd8e59e1f5f40c23bf"
 dependencies = [
  "num-traits",
 ]
@@ -2510,24 +2507,24 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.7"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.2.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84e93a3b1cc0510b03020f33f21e62acdde3dcaef432edc95bea377fbd4c2cd4"
+checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
 dependencies = [
  "base64ct",
 ]
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
@@ -2574,9 +2571,9 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.6.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
+checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -2616,26 +2613,24 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
-version = "0.2.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "116bee8279d783c0cf370efa1a94632f2108e5ef0bb32df31f051647810a4e2c"
+checksum = "eff33bdbdfc54cc98a2eca766ebdec3e1b8fb7387523d5c9c9a2891da856f719"
 dependencies = [
  "der",
- "pem-rfc7468",
+ "pkcs8",
+ "spki",
  "zeroize",
 ]
 
 [[package]]
 name = "pkcs8"
-version = "0.7.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3ef9b64d26bad0536099c816c6734379e45bbd5f14798def6809e5cc350447"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
  "der",
- "pem-rfc7468",
- "pkcs1",
  "spki",
- "zeroize",
 ]
 
 [[package]]
@@ -2646,29 +2641,30 @@ checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "pnet"
-version = "0.28.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6d2a0409666964722368ef5fb74b9f93fac11c18bef3308693c16c6733f103"
+checksum = "0caaf5b11fd907ff15cf14a4477bfabca4b37ab9e447a4f8dead969a59cdafad"
 dependencies = [
- "ipnetwork",
  "pnet_base",
  "pnet_datalink",
  "pnet_packet",
- "pnet_sys",
  "pnet_transport",
 ]
 
 [[package]]
 name = "pnet_base"
-version = "0.28.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25488cd551a753dcaaa6fffc9f69a7610a412dd8954425bf7ffad5f7d1156fb8"
+checksum = "f9d3a993d49e5fd5d4d854d6999d4addca1f72d86c65adf224a36757161c02b6"
+dependencies = [
+ "no-std-net",
+]
 
 [[package]]
 name = "pnet_datalink"
-version = "0.28.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d1f8ab1ef6c914cf51dc5dfe0be64088ea5f3b08bbf5a31abc70356d271198"
+checksum = "e466faf03a98ad27f6e15cd27a2b7cc89e73e640a43527742977bc503c37f8aa"
 dependencies = [
  "ipnetwork",
  "libc",
@@ -2679,9 +2675,9 @@ dependencies = [
 
 [[package]]
 name = "pnet_macros"
-version = "0.28.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30490e0852e58402b8fae0d39897b08a24f493023a4d6cf56b2e30f31ed57548"
+checksum = "48dd52a5211fac27e7acb14cfc9f30ae16ae0e956b7b779c8214c74559cef4c3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2691,18 +2687,18 @@ dependencies = [
 
 [[package]]
 name = "pnet_macros_support"
-version = "0.28.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4714e10f30cab023005adce048f2d30dd4ac4f093662abf2220855655ef8f90"
+checksum = "89de095dc7739349559913aed1ef6a11e73ceade4897dadc77c5e09de6740750"
 dependencies = [
  "pnet_base",
 ]
 
 [[package]]
 name = "pnet_packet"
-version = "0.28.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8588067671d03c9f4254b2e66fecb4d8b93b5d3e703195b84f311cd137e32130"
+checksum = "bc3b5111e697c39c8b9795b9fdccbc301ab696699e88b9ea5a4e4628978f495f"
 dependencies = [
  "glob",
  "pnet_base",
@@ -2712,9 +2708,9 @@ dependencies = [
 
 [[package]]
 name = "pnet_sys"
-version = "0.28.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a3f32b0df45515befd19eed04616f6b56a488da92afc61164ef455e955f07f"
+checksum = "328e231f0add6d247d82421bf3790b4b33b39c8930637f428eef24c4c6a90805"
 dependencies = [
  "libc",
  "winapi",
@@ -2722,9 +2718,9 @@ dependencies = [
 
 [[package]]
 name = "pnet_transport"
-version = "0.28.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "932b2916d693bcc5fa18443dc99142e0a6fd31a6ce75a511868f7174c17e2bce"
+checksum = "ff597185e6f1f5671b3122e4dba892a1c73e17c17e723d7669bd9299cbe7f124"
 dependencies = [
  "libc",
  "pnet_base",
@@ -2915,62 +2911,59 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.8.3"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7542006acd6e057ff632307d219954c44048f818898da03113d6c0086bfddd9"
+checksum = "445cbfe2382fa023c4f2f3c7e1c95c03dcc1df2bf23cebcb2b13e1402c4394d1"
 dependencies = [
  "bytes",
- "futures-channel",
- "futures-util",
- "fxhash",
+ "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustls 0.20.6",
+ "rustc-hash",
+ "rustls",
  "thiserror",
  "tokio",
  "tracing",
- "webpki 0.22.0",
+ "webpki",
 ]
 
 [[package]]
 name = "quinn-proto"
-version = "0.8.3"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a13a5c0a674c1ce7150c9df7bc4a1e46c2fbbe7c710f56c0dc78b1a810e779e"
+checksum = "72ef4ced82a24bb281af338b9e8f94429b6eca01b4e66d899f40031f074e74c9"
 dependencies = [
  "bytes",
- "fxhash",
  "rand",
  "ring",
- "rustls 0.20.6",
+ "rustc-hash",
+ "rustls",
  "rustls-native-certs",
- "rustls-pemfile 0.2.1",
  "slab",
  "thiserror",
  "tinyvec",
  "tracing",
- "webpki 0.22.0",
+ "webpki",
 ]
 
 [[package]]
 name = "quinn-udp"
-version = "0.1.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3149f7237331015f1a6adf065c397d1be71e032fcf110ba41da52e7926b882f"
+checksum = "641538578b21f5e5c8ea733b736895576d0fe329bb883b937db6f4d163dbaaf4"
 dependencies = [
- "futures-util",
  "libc",
  "quinn-proto",
  "socket2",
- "tokio",
  "tracing",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.17"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -3038,7 +3031,7 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -3099,9 +3092,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.5"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3119,9 +3112,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "reqwest"
@@ -3129,7 +3122,7 @@ version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3176,21 +3169,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "rsa"
-version = "0.5.0"
+name = "ringbuffer-spsc"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c2603e2823634ab331437001b411b9ed11660fbc4066f3908c84a9439260d"
+checksum = "2fd1938faa63a2362ee1747afb2d10567d0fb1413b9cbd6198a8541485c4f773"
+dependencies = [
+ "array-init",
+ "cache-padded",
+]
+
+[[package]]
+name = "rsa"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "094052d5470cbcef561cb848a7209968c9f12dfa6d668f4bca048ac5de51099c"
 dependencies = [
  "byteorder",
- "digest 0.9.0",
- "lazy_static",
+ "digest 0.10.6",
  "num-bigint-dig",
  "num-integer",
  "num-iter",
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand",
+ "rand_core",
+ "signature",
+ "smallvec",
  "subtle",
  "zeroize",
 ]
@@ -3222,6 +3226,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3246,27 +3256,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
-dependencies = [
- "base64",
- "log",
- "ring",
- "sct 0.6.1",
- "webpki 0.21.4",
-]
-
-[[package]]
-name = "rustls"
 version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
 dependencies = [
  "log",
  "ring",
- "sct 0.7.0",
- "webpki 0.22.0",
+ "sct",
+ "webpki",
 ]
 
 [[package]]
@@ -3276,36 +3273,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 1.0.0",
+ "rustls-pemfile",
  "schannel",
  "security-framework",
 ]
 
 [[package]]
 name = "rustls-pemfile"
-version = "0.2.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
-dependencies = [
- "base64",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7522c9de787ff061458fe9a829dc790a3f5b22dc571694fc5883f448b94d9a9"
-dependencies = [
- "base64",
+ "base64 0.21.0",
 ]
 
 [[package]]
@@ -3375,16 +3354,6 @@ checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
 
 [[package]]
 name = "sct"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
@@ -3438,7 +3407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "888d884a3be3a209308d0b66f1918ff18f60e93db837259e53ea7d8dd14e7e98"
 dependencies = [
  "serde",
- "shellexpand",
+ "shellexpand 2.1.0",
 ]
 
 [[package]]
@@ -3489,9 +3458,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.11"
+version = "0.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89f31df3f50926cdf2855da5fd8812295c34752cb20438dae42a67f79e021ac3"
+checksum = "f82e6c8c047aa50a7328632d067bcae6ef38772a79e28daf32f735e0e4f3dd10"
 dependencies = [
  "indexmap",
  "itoa",
@@ -3509,19 +3478,17 @@ dependencies = [
  "block-buffer 0.7.3",
  "digest 0.8.1",
  "fake-simd",
- "opaque-debug 0.2.3",
+ "opaque-debug",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.9.1"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
+checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
 dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
+ "digest 0.10.6",
  "keccak",
- "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -3568,6 +3535,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "shellexpand"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd1c7ddea665294d484c39fd0c0d2b7e35bbfe10035c5fe1854741a57f6880e1"
+dependencies = [
+ "dirs",
+]
+
+[[package]]
 name = "signal-hook"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3598,6 +3574,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+dependencies = [
+ "digest 0.10.6",
+ "rand_core",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3611,9 +3597,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "socket2"
-version = "0.4.4"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
@@ -3636,10 +3622,11 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.4.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c01a0c15da1b0b0e1494112e7af814a678fec9bd157881b49beac661e9b6f32"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
+ "base64ct",
  "der",
 ]
 
@@ -3663,12 +3650,6 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -3688,18 +3669,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
 ]
 
 [[package]]
@@ -3753,18 +3722,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
@@ -3848,7 +3808,7 @@ version = "1.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a12a59981d9e3c38d216785b0c37399f6e415e8d0712047620f189371b0bb"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "bytes",
  "libc",
  "memchr",
@@ -3940,7 +3900,7 @@ checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
 dependencies = [
  "async-stream",
  "async-trait",
- "base64",
+ "base64 0.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4100,20 +4060,6 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "uhlc"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d74cc14aac0f650dae365e42250073bc0f89602bad5751d6159642be37690d6"
-dependencies = [
- "hex",
- "humantime",
- "lazy_static",
- "log",
- "serde",
- "uuid 0.8.2",
-]
-
-[[package]]
-name = "uhlc"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7908438f98a5824af02b34c2b31fb369c5764ef835d26df0badbb9897fb28245"
@@ -4123,7 +4069,7 @@ dependencies = [
  "lazy_static",
  "log",
  "serde",
- "uuid 1.2.1",
+ "uuid",
 ]
 
 [[package]]
@@ -4160,12 +4106,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
 name = "unindent"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4173,9 +4113,9 @@ checksum = "514672a55d7380da379785a4d70ca8386c8883ff7eaae877be4d2081cebe73d8"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.2"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "931179334a56395bcf64ba5e0ff56781381c1a5832178280c7d7f91d1679aeb0"
+checksum = "ad2024452afd3874bf539695e04af6732ba06517424dbf958fdb16a01f3bef6c"
 
 [[package]]
 name = "untrusted"
@@ -4206,14 +4146,14 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97acb4c28a254fd7a4aeec976c46a7fa404eac4d7c134b30c75144846d7cb8f"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "chunked_transfer",
  "flate2",
  "log",
  "once_cell",
- "rustls 0.20.6",
+ "rustls",
  "url",
- "webpki 0.22.0",
+ "webpki",
  "webpki-roots",
 ]
 
@@ -4231,18 +4171,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "0.8.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
-name = "uuid"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
+checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 dependencies = [
  "getrandom",
  "serde",
@@ -4444,16 +4375,6 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
@@ -4464,11 +4385,11 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.4"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
- "webpki 0.22.0",
+ "webpki",
 ]
 
 [[package]]
@@ -4744,22 +4665,24 @@ dependencies = [
 
 [[package]]
 name = "zenoh"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44140d6ebcf2e52ee48acad0e9d960c2b1e868eec021da2538e58373d615fc18"
 dependencies = [
  "async-global-executor",
  "async-std",
  "async-trait",
- "base64",
+ "base64 0.13.1",
  "env_logger",
  "event-listener",
  "flume",
+ "form_urlencoded",
  "futures",
  "git-version",
  "hex",
  "lazy_static",
  "log",
- "ordered-float 2.10.0",
+ "ordered-float 3.4.0",
  "petgraph",
  "rand",
  "regex",
@@ -4768,8 +4691,8 @@ dependencies = [
  "serde_json",
  "socket2",
  "stop-token",
- "uhlc 0.4.1",
- "uuid 0.8.2",
+ "uhlc",
+ "uuid",
  "vec_map",
  "zenoh-buffers",
  "zenoh-cfg-properties",
@@ -4788,23 +4711,21 @@ dependencies = [
 
 [[package]]
 name = "zenoh-buffers"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "244d54f1228d3c53fc69483faafcfcc1b4d670b60cffce17696fc49fbc7a6608"
 dependencies = [
  "async-std",
- "bincode",
  "hex",
- "log",
- "serde",
- "shared_memory",
  "zenoh-collections",
  "zenoh-core",
 ]
 
 [[package]]
 name = "zenoh-cfg-properties"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a963395194bf1b64f67d89333e8089f01568ec7ac28c305847f505452a98006e"
 dependencies = [
  "zenoh-core",
  "zenoh-macros",
@@ -4812,8 +4733,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-collections"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e256d7aff2c9af765d77efbfae7fcb708d2d7f4e179aa201bff2f81ad7a3845"
 dependencies = [
  "async-std",
  "async-trait",
@@ -4825,15 +4747,16 @@ dependencies = [
 
 [[package]]
 name = "zenoh-config"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad1ff61abf28c57e8879ec4286fa29becf7e9bf12555df9a7faddff3bc9ea1b"
 dependencies = [
  "flume",
  "json5",
  "num_cpus",
  "serde",
  "serde_json",
- "serde_yaml 0.8.23",
+ "serde_yaml 0.9.19",
  "validated_struct",
  "zenoh-cfg-properties",
  "zenoh-core",
@@ -4843,17 +4766,21 @@ dependencies = [
 
 [[package]]
 name = "zenoh-core"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b0f55158f3f83555db74d4cf5ebc34f90df5d2992cc0de67eba69b99628605e"
 dependencies = [
  "anyhow",
+ "async-std",
  "lazy_static",
+ "zenoh-macros",
 ]
 
 [[package]]
 name = "zenoh-crypto"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "653ba15479a0e3f1a94d7f079babc52f742f3a2bd995c59bc250cfc9a789dbbc"
 dependencies = [
  "aes",
  "hmac",
@@ -4865,8 +4792,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e58770c73cf0b5ec8fbe104d609eec83f9bc3463ea23a583c8b465de77f7d27"
 dependencies = [
  "async-std",
  "async-trait",
@@ -4884,12 +4812,14 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-commons"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21aab9eeb2aba53e37aae57467ffca1268d209811c5e2f39761aab4c1343bce3"
 dependencies = [
  "async-std",
  "async-trait",
  "flume",
+ "serde",
  "zenoh-buffers",
  "zenoh-cfg-properties",
  "zenoh-core",
@@ -4899,18 +4829,19 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-quic"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9f1354094eb4d5e4b864b5aa385efce46f94a43f6ba57dd9ea9a017e6e74176"
 dependencies = [
  "async-std",
  "async-trait",
  "futures",
  "log",
  "quinn",
- "rustls 0.20.6",
+ "rustls",
  "rustls-native-certs",
- "rustls-pemfile 0.3.0",
- "webpki 0.22.0",
+ "rustls-pemfile",
+ "webpki",
  "zenoh-cfg-properties",
  "zenoh-config",
  "zenoh-core",
@@ -4922,8 +4853,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-tcp"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ffc29707a50680dba124dd4d8bc3bc19feb158db8312433bfc3078f7b8f1ef"
 dependencies = [
  "async-std",
  "async-trait",
@@ -4937,14 +4869,18 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-tls"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a5630b3a218c7179191dab78ebc45da1837793951bddb8fda4f5900b47da552"
 dependencies = [
  "async-rustls",
  "async-std",
  "async-trait",
  "futures",
  "log",
+ "rustls-pemfile",
+ "webpki",
+ "webpki-roots",
  "zenoh-cfg-properties",
  "zenoh-config",
  "zenoh-core",
@@ -4956,8 +4892,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-udp"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "176494947bd3a6aa10baa469afa4572635822683830808cd71d5554ce15dfebb"
 dependencies = [
  "async-std",
  "async-trait",
@@ -4973,15 +4910,16 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-unixsock_stream"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9974305820f92478490ba8b8f119eb5b7d7b4998a7125d1510f6e69f3f81d1"
 dependencies = [
  "async-std",
  "async-trait",
  "futures",
  "log",
- "nix 0.23.1",
- "uuid 0.8.2",
+ "nix 0.26.2",
+ "uuid",
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol-core",
@@ -4993,13 +4931,13 @@ name = "zenoh-logger"
 version = "0.1.3"
 dependencies = [
  "zenoh",
- "zenoh-config",
 ]
 
 [[package]]
 name = "zenoh-macros"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a9ac20b120990778cca204ee46c43a37ed4ffbc331e95702615490f9c169de8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5010,8 +4948,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-plugin-trait"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b8bfb8e2625e1150dab46b7a4433f866aa06af763237d564b1aa8f6aaf0b29"
 dependencies = [
  "libloading",
  "log",
@@ -5023,11 +4962,12 @@ dependencies = [
 
 [[package]]
 name = "zenoh-protocol"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "174a00456e29d941a4230148fd184953e95883bde47a4cfc1a508e0aaec89a89"
 dependencies = [
  "log",
- "uhlc 0.4.1",
+ "uhlc",
  "zenoh-buffers",
  "zenoh-core",
  "zenoh-protocol-core",
@@ -5035,21 +4975,25 @@ dependencies = [
 
 [[package]]
 name = "zenoh-protocol-core"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf3eaea2095d2c13fefdae25aca813b3644fc15e1441e16a4398b5113033753"
 dependencies = [
  "hex",
+ "itertools",
  "lazy_static",
+ "rand",
  "serde",
- "uhlc 0.4.1",
- "uuid 0.8.2",
+ "uhlc",
+ "uuid",
  "zenoh-core",
 ]
 
 [[package]]
 name = "zenoh-sync"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "821070b62a55d4c8a22e1e06c939c1f2d94767e660df9fcbea377781f72f59bf"
 dependencies = [
  "async-std",
  "event-listener",
@@ -5061,8 +5005,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-transport"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce4387cfc02cb86383de8e65ab1eb204e3908c5f1db9e6b4defd8ad530c9ddea"
 dependencies = [
  "async-executor",
  "async-global-executor",
@@ -5072,6 +5017,7 @@ dependencies = [
  "log",
  "paste",
  "rand",
+ "ringbuffer-spsc",
  "rsa",
  "serde",
  "zenoh-buffers",
@@ -5088,11 +5034,12 @@ dependencies = [
 
 [[package]]
 name = "zenoh-util"
-version = "0.6.0-dev.0"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=79a136e4fd90b11ff5d775ced981af53c4f1071b#79a136e4fd90b11ff5d775ced981af53c4f1071b"
+version = "0.7.0-rc"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54646455dad3940535e97cce03f1b604265177349133903d989bc72e00011404"
 dependencies = [
  "async-std",
- "clap 2.34.0",
+ "clap 3.2.23",
  "futures",
  "hex",
  "home",
@@ -5102,7 +5049,8 @@ dependencies = [
  "libloading",
  "log",
  "pnet",
- "shellexpand",
+ "pnet_datalink",
+ "shellexpand 3.0.0",
  "winapi",
  "zenoh-cfg-properties",
  "zenoh-collections",
@@ -5113,21 +5061,6 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.4.3"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ You need to add the created operators/nodes to your dataflow YAML file.
 ```yaml
 communication:
   zenoh:
-    prefix: /abc_project
+    prefix: abc_project
 
 nodes:
   - id: op_1

--- a/binaries/cli/src/template/c/dataflow-template.yml
+++ b/binaries/cli/src/template/c/dataflow-template.yml
@@ -1,6 +1,6 @@
 communication:
   zenoh:
-    prefix: /___name___
+    prefix: ___name___
 
 nodes:
   - id: runtime-node_1

--- a/binaries/cli/src/template/cxx/dataflow-template.yml
+++ b/binaries/cli/src/template/cxx/dataflow-template.yml
@@ -1,6 +1,6 @@
 communication:
   zenoh:
-    prefix: /___name___
+    prefix: ___name___
 
 nodes:
   - id: runtime-node_1

--- a/binaries/cli/src/template/python/dataflow-template.yml
+++ b/binaries/cli/src/template/python/dataflow-template.yml
@@ -1,6 +1,6 @@
 communication:
   zenoh:
-    prefix: /___name___
+    prefix: ___name___
 
 nodes:
   - id: op_1

--- a/binaries/cli/src/template/rust/dataflow-template.yml
+++ b/binaries/cli/src/template/rust/dataflow-template.yml
@@ -1,6 +1,6 @@
 communication:
   zenoh:
-    prefix: /___name___
+    prefix: ___name___
 
 nodes:
   - id: runtime-node_1

--- a/binaries/coordinator/Cargo.toml
+++ b/binaries/coordinator/Cargo.toml
@@ -27,7 +27,7 @@ rand = "0.8.5"
 dora-core = { workspace = true }
 tracing = "0.1.36"
 futures-concurrency = "7.1.0"
-zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "79a136e4fd90b11ff5d775ced981af53c4f1071b" }
+zenoh = "0.7.0-rc"
 serde_json = "1.0.86"
 dora-download = { path = "../../libraries/extensions/download" }
 dora-tracing = { workspace = true, optional = true }

--- a/docs/src/dataflow-config.md
+++ b/docs/src/dataflow-config.md
@@ -108,7 +108,7 @@ The mandatory `communication` key specifies how dora nodes and operators should 
   ```yaml
   communication:
     zenoh:
-      prefix: /some-unique-prefix
+      prefix: some-unique-prefix
   ```
 
   The specified `prefix` is added to all pub/sub topics. It is useful for filtering messages (e.g. in a logger) when other applications use `zenoh` in parallel. Dora will extend the given prefix with a newly generated UUID on each run, to ensure that multiple instances of the same dataflow run concurrently without interfering with each other.

--- a/examples/benchmark/dataflow.yml
+++ b/examples/benchmark/dataflow.yml
@@ -1,6 +1,6 @@
 communication:
   zenoh:
-    prefix: /benchmark-example
+    prefix: benchmark-example
 
 nodes:
   - id: rust-node

--- a/examples/c++-dataflow/dataflow.yml
+++ b/examples/c++-dataflow/dataflow.yml
@@ -1,6 +1,6 @@
 communication:
   zenoh:
-    prefix: /example-cxx-dataflow
+    prefix: example-cxx-dataflow
 
 nodes:
   - id: cxx-node-rust-api

--- a/examples/c-dataflow/dataflow.yml
+++ b/examples/c-dataflow/dataflow.yml
@@ -1,6 +1,6 @@
 communication:
   zenoh:
-    prefix: /example-c-dataflow
+    prefix: example-c-dataflow
 
 nodes:
   - id: c_node

--- a/examples/python-dataflow/dataflow.yml
+++ b/examples/python-dataflow/dataflow.yml
@@ -1,6 +1,6 @@
 communication:
   zenoh:
-    prefix: /example-python-dataflow
+    prefix: example-python-dataflow
 
 nodes:
   - id: webcam

--- a/examples/python-dataflow/dataflow_without_webcam.yml
+++ b/examples/python-dataflow/dataflow_without_webcam.yml
@@ -1,6 +1,6 @@
 communication:
   zenoh:
-    prefix: /example-python-no-webcam-dataflow
+    prefix: example-python-no-webcam-dataflow
 
 nodes:
   - id: no_webcam

--- a/examples/python-operator-dataflow/dataflow.yml
+++ b/examples/python-operator-dataflow/dataflow.yml
@@ -1,6 +1,6 @@
 communication:
   zenoh:
-    prefix: /example-python-dataflow
+    prefix: example-python-dataflow
 
 nodes:
   - id: webcam

--- a/examples/python-operator-dataflow/dataflow_without_webcam.yml
+++ b/examples/python-operator-dataflow/dataflow_without_webcam.yml
@@ -1,6 +1,6 @@
 communication:
   zenoh:
-    prefix: /example-python-no-webcam-dataflow
+    prefix: example-python-no-webcam-dataflow
 
 nodes:
   - id: no_webcam

--- a/examples/rust-dataflow-url/dataflow.yml
+++ b/examples/rust-dataflow-url/dataflow.yml
@@ -1,6 +1,6 @@
 communication:
   zenoh:
-    prefix: /example-rust-dataflow
+    prefix: example-rust-dataflow
 
 nodes:
   - id: rust-node

--- a/examples/rust-dataflow/dataflow.yml
+++ b/examples/rust-dataflow/dataflow.yml
@@ -1,6 +1,6 @@
 communication:
   zenoh:
-    prefix: /example-rust-dataflow
+    prefix: example-rust-dataflow
 
 daemon_config: Tcp # or Shmem
 

--- a/libraries/communication-layer/pub-sub/Cargo.toml
+++ b/libraries/communication-layer/pub-sub/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 
 [features]
 default = ["zenoh"]
-zenoh = ["dep:zenoh", "dep:zenoh-config"]
+zenoh = ["dep:zenoh"]
 
 [dependencies]
+zenoh = { version = "0.7.0-rc", optional = true, features = ["transport_tcp"] }
 eyre = "0.6.8"
-zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "79a136e4fd90b11ff5d775ced981af53c4f1071b", optional = true }
-zenoh-config = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "79a136e4fd90b11ff5d775ced981af53c4f1071b", optional = true }
+flume = "0.10"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/libraries/communication-layer/pub-sub/src/zenoh.rs
+++ b/libraries/communication-layer/pub-sub/src/zenoh.rs
@@ -1,12 +1,10 @@
 //! Provides [`ZenohCommunicationLayer`] to communicate over `zenoh`.
 
-pub use zenoh_config;
-
 use super::{CommunicationLayer, Publisher, Subscriber};
 use crate::{BoxError, ReceivedSample};
 use std::{borrow::Cow, sync::Arc, time::Duration};
 use zenoh::{
-    prelude::{EntityFactory, Priority, Receiver as _, SplitBuffer, ZFuture},
+    prelude::{sync::SyncResolve, Config, Priority, SessionDeclarations, SplitBuffer},
     publication::CongestionControl,
 };
 
@@ -22,9 +20,9 @@ impl ZenohCommunicationLayer {
     /// The `prefix` is added to all topic names when using the [`publisher`][Self::publisher]
     /// and [`subscriber`][Self::subscribe] methods. Pass an empty string if no prefix is
     /// desired.
-    pub fn init(config: zenoh_config::Config, prefix: String) -> Result<Self, BoxError> {
+    pub fn init(config: Config, prefix: String) -> Result<Self, BoxError> {
         let zenoh = ::zenoh::open(config)
-            .wait()
+            .res_sync()
             .map_err(BoxError::from)?
             .into_arc();
         Ok(Self {
@@ -42,10 +40,10 @@ impl CommunicationLayer for ZenohCommunicationLayer {
     fn publisher(&mut self, topic: &str) -> Result<Box<dyn Publisher>, BoxError> {
         let publisher = self
             .zenoh
-            .publish(self.prefixed(topic))
+            .declare_publisher(self.prefixed(topic))
             .congestion_control(CongestionControl::Block)
             .priority(Priority::RealTime)
-            .wait()
+            .res_sync()
             .map_err(BoxError::from)?;
 
         Ok(Box::new(ZenohPublisher { publisher }))
@@ -54,9 +52,9 @@ impl CommunicationLayer for ZenohCommunicationLayer {
     fn subscribe(&mut self, topic: &str) -> Result<Box<dyn Subscriber>, BoxError> {
         let subscriber = self
             .zenoh
-            .subscribe(self.prefixed(topic))
+            .declare_subscriber(self.prefixed(topic))
             .reliable()
-            .wait()
+            .res_sync()
             .map_err(BoxError::from)?;
 
         Ok(Box::new(ZenohReceiver(subscriber)))
@@ -104,11 +102,16 @@ impl<'a> crate::PublishSample<'a> for ZenohPublishSample {
     }
 
     fn publish(self: Box<Self>) -> Result<(), BoxError> {
-        self.publisher.send(self.sample).map_err(BoxError::from)
+        self.publisher
+            .put(self.sample)
+            .res_sync()
+            .map_err(BoxError::from)
     }
 }
 
-struct ZenohReceiver(zenoh::subscriber::Subscriber<'static>);
+struct ZenohReceiver(
+    zenoh::subscriber::Subscriber<'static, flume::Receiver<zenoh::sample::Sample>>,
+);
 
 impl Subscriber for ZenohReceiver {
     fn recv(&mut self) -> Result<Option<Box<dyn ReceivedSample>>, BoxError> {
@@ -122,7 +125,7 @@ impl Subscriber for ZenohReceiver {
 }
 
 struct ZenohReceivedSample {
-    sample: zenoh::buf::ZBuf,
+    sample: zenoh::buffers::ZBuf,
 }
 
 impl ReceivedSample for ZenohReceivedSample {

--- a/libraries/core/Cargo.toml
+++ b/libraries/core/Cargo.toml
@@ -11,9 +11,9 @@ eyre = "0.6.8"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_yaml = "0.9.11"
 once_cell = "1.13.0"
-zenoh-config = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "79a136e4fd90b11ff5d775ced981af53c4f1071b" }
 which = "4.3.0"
 uuid = { version = "1.2.1", features = ["serde"] }
 dora-message = { path = "../message" }
 tracing = "0.1"
 serde-with-expand-env = "1.1.0"
+zenoh = "0.7.0-rc"

--- a/libraries/core/src/config.rs
+++ b/libraries/core/src/config.rs
@@ -254,7 +254,7 @@ pub struct NodeRunConfig {
 pub enum CommunicationConfig {
     Zenoh {
         #[serde(default)]
-        config: Box<zenoh_config::Config>,
+        config: Box<zenoh::prelude::Config>,
         prefix: String,
     },
 }

--- a/libraries/extensions/zenoh-logger/Cargo.toml
+++ b/libraries/extensions/zenoh-logger/Cargo.toml
@@ -7,5 +7,4 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-zenoh = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "79a136e4fd90b11ff5d775ced981af53c4f1071b" }
-zenoh-config = { git = "https://github.com/eclipse-zenoh/zenoh.git", rev = "79a136e4fd90b11ff5d775ced981af53c4f1071b" }
+zenoh = "0.7.0-rc"

--- a/libraries/extensions/zenoh-logger/src/main.rs
+++ b/libraries/extensions/zenoh-logger/src/main.rs
@@ -1,11 +1,15 @@
-use zenoh::prelude::{Receiver, ZFuture};
+use zenoh::prelude::{sync::SyncResolve, Config};
 
 fn main() {
-    let zenoh = zenoh::open(zenoh_config::Config::default()).wait().unwrap();
-    let mut sub = zenoh.subscribe("/**").reliable().wait().unwrap();
+    let zenoh = zenoh::open(Config::default()).res_sync().unwrap();
+    let sub = zenoh
+        .declare_subscriber("/**")
+        .reliable()
+        .res_sync()
+        .unwrap();
 
     loop {
-        let msg = sub.receiver().recv().unwrap();
+        let msg = sub.recv().unwrap();
         println!("{}", msg.key_expr);
     }
 }


### PR DESCRIPTION
This new branch is based on https://github.com/dora-rs/dora/pull/94 . As we are not using zenoh at the moment. I haven't extensively tested this branch.

This however makes us able to push our crates to `crates.io`.