### PR TITLE
Removing legacy `libacl` which was required by Iceoryx

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -15,10 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install libacl-dev
-        run: |
-          export DEBIAN_FRONTEND=noninteractive
-          sudo apt-get install -y libacl1-dev
+
       - uses: actions/setup-python@v2
         with:
           python-version: "3.10"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,6 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
-      - name: Install libacl-dev (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          export DEBIAN_FRONTEND=noninteractive
-          sudo apt-get install -y libacl1-dev
-
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
@@ -42,12 +36,6 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3
-
-      - name: Install libacl-dev (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          export DEBIAN_FRONTEND=noninteractive
-          sudo apt-get install -y libacl1-dev
 
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
@@ -82,12 +70,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install libacl-dev (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          export DEBIAN_FRONTEND=noninteractive
-          sudo apt-get install -y libacl1-dev
-
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
@@ -120,12 +102,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install libacl-dev (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          export DEBIAN_FRONTEND=noninteractive
-          sudo apt-get install -y libacl1-dev
-
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
@@ -140,10 +116,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install libacl-dev
-        run: |
-          export DEBIAN_FRONTEND=noninteractive
-          sudo apt-get install -y libacl1-dev
 
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose

--- a/.github/workflows/pip-release.yml
+++ b/.github/workflows/pip-release.yml
@@ -21,12 +21,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
-      - name: Install libacl-dev (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          export DEBIAN_FRONTEND=noninteractive
-          sudo apt-get install -y libacl1-dev
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       
       # Publish Dora Node Python API

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,12 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install libacl-dev (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          export DEBIAN_FRONTEND=noninteractive
-          sudo apt-get install -y libacl1-dev
-
       - uses: r7kamura/rust-problem-matchers@v1.1.0
 
       - name: "Build binaries"


### PR DESCRIPTION
Removing legacy `libacl-dev` dependency from the CI that we don't need anymore.

