### PR TITLE
Clean up: Remove workspace path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "dora-daemon"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,18 @@ version = "0.2.0"
 [workspace.dependencies]
 dora-node-api = { version = "0.2.0", path = "apis/rust/node", default-features = false }
 dora-operator-api = { version = "0.2.0", path = "apis/rust/operator", default-features = false }
+dora-operator-api-macros = { version = "0.2.0", path = "apis/rust/operator/macros" }
+dora-operator-api-types = { version = "0.2.0", path = "apis/rust/operator/types" }
+dora-operator-api-python = { version = "0.2.0", path = "apis/python/operator" }
 dora-core = { version = "0.2.0", path = "libraries/core" }
 dora-tracing = { version = "0.2.0", path = "libraries/extensions/telemetry/tracing" }
+dora-metrics = { version = "0.2.0", path = "libraries/extensions/telemetry/metrics" }
+dora-download = { version = "0.2.0", path = "libraries/extensions/download" }
+shared-memory-server = { version = "0.2.0", path = "libraries/shared-memory-server" }
+communication-layer-request-reply = { version = "0.2.0", path = "libraries/communication-layer/request-reply" }
+dora-message = { version = "0.2.0", path = "libraries/message" }
+dora-runtime = { version = "0.2.0", path = "binaries/runtime" }
+dora-daemon = { version = "0.2.0", path = "binaries/daemon" }
 
 [package]
 name = "dora-examples"
@@ -41,8 +51,8 @@ license = "Apache-2.0"
 [dev-dependencies]
 eyre = "0.6.8"
 tokio = "1.24.2"
-dora-daemon = { path = "binaries/daemon" }
-dora-core = { path = "libraries/core" }
+dora-daemon = { workspace = true }
+dora-core = { workspace = true }
 dunce = "1.0.2"
 serde_yaml = "0.8.23"
 uuid = { version = "1.2.1", features = ["v4", "serde"] }

--- a/apis/c/operator/Cargo.toml
+++ b/apis/c/operator/Cargo.toml
@@ -6,4 +6,4 @@ license = "Apache-2.0"
 description = "C API implemetation for Dora Operator"
 
 [build-dependencies]
-dora-operator-api-types = { path = "../../rust/operator/types" }
+dora-operator-api-types = { workspace = true }

--- a/apis/python/node/Cargo.toml
+++ b/apis/python/node/Cargo.toml
@@ -11,13 +11,13 @@ default = ["tracing"]
 tracing = ["dora-node-api/tracing"]
 
 [dependencies]
-dora-node-api = { path = "../../rust/node" }
-dora-operator-api-python = { path = "../operator" }
+dora-node-api = { workspace = true }
+dora-operator-api-python = { workspace = true }
 pyo3 = { version = "0.16", features = ["eyre", "abi3-py37"] }
 eyre = "0.6"
 serde_yaml = "0.8.23"
 flume = "0.10.14"
-dora-runtime = { path = "../../../binaries/runtime" }
+dora-runtime = { workspace = true }
 
 [lib]
 name = "dora"

--- a/apis/python/operator/Cargo.toml
+++ b/apis/python/operator/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dora-node-api = { path = "../../rust/node" }
+dora-node-api = { workspace = true }
 pyo3 = { version = "0.16", features = ["eyre", "abi3-py37"] }
 eyre = "0.6"
 serde_yaml = "0.8.23"

--- a/apis/rust/node/Cargo.toml
+++ b/apis/rust/node/Cargo.toml
@@ -9,8 +9,8 @@ default = ["tracing"]
 tracing = ["dep:dora-tracing"]
 
 [dependencies]
-dora-core = { path = "../../../libraries/core" }
-shared-memory-server = { path = "../../../libraries/shared-memory-server" }
+dora-core = { workspace = true }
+shared-memory-server = { workspace = true }
 eyre = "0.6.7"
 once_cell = "1.13.0"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/apis/rust/operator/Cargo.toml
+++ b/apis/rust/operator/Cargo.toml
@@ -8,5 +8,5 @@ description = "Rust API implemetation for Dora Operator"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dora-operator-api-macros = { path = "macros" }
-dora-operator-api-types = { path = "types" }
+dora-operator-api-macros = { workspace = true }
+dora-operator-api-types = { workspace = true }

--- a/apis/rust/operator/macros/Cargo.toml
+++ b/apis/rust/operator/macros/Cargo.toml
@@ -16,5 +16,5 @@ quote = "1.0.10"
 proc-macro2 = "1.0.32"
 
 [dev-dependencies]
-dora-operator-api = { path = ".." }
-dora-operator-api-types = { path = "../types" }
+dora-operator-api = { workspace = true }
+dora-operator-api-types = { workspace = true }

--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4.0.3", features = ["derive"] }
 eyre = "0.6.8"
-dora-core = { path = "../../libraries/core" }
+dora-core = { workspace = true }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_yaml = "0.9.11"
 tempfile = "3.4.0"
@@ -22,4 +22,4 @@ termcolor = "1.1.3"
 atty = "0.2.14"
 uuid = { version = "1.2.1", features = ["v4", "serde"] }
 inquire = "0.5.2"
-communication-layer-request-reply = { path = "../../libraries/communication-layer/request-reply" }
+communication-layer-request-reply = { workspace = true }

--- a/binaries/coordinator/Cargo.toml
+++ b/binaries/coordinator/Cargo.toml
@@ -12,7 +12,7 @@ tracing = ["dep:dora-tracing"]
 
 [dependencies]
 bincode = "1.3.3"
-dora-node-api = { path = "../../apis/rust/node" }
+dora-node-api = { workspace = true }
 eyre = "0.6.7"
 futures = "0.3.21"
 serde = { version = "1.0.136", features = ["derive"] }
@@ -29,9 +29,9 @@ tracing = "0.1.36"
 futures-concurrency = "7.1.0"
 zenoh = "0.7.0-rc"
 serde_json = "1.0.86"
-dora-download = { path = "../../libraries/extensions/download" }
+dora-download = { workspace = true }
 dora-tracing = { workspace = true, optional = true }
 which = "4.3.0"
-communication-layer-request-reply = { path = "../../libraries/communication-layer/request-reply" }
+communication-layer-request-reply = { workspace = true }
 thiserror = "1.0.37"
 ctrlc = "3.2.5"

--- a/binaries/daemon/Cargo.toml
+++ b/binaries/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dora-daemon"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -17,15 +17,15 @@ tracing = "0.1.36"
 futures-concurrency = "7.1.0"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.86"
-dora-core = { path = "../../libraries/core" }
+dora-core = { workspace = true }
 flume = "0.10.14"
-dora-download = { path = "../../libraries/extensions/download" }
+dora-download = { workspace = true }
 dora-tracing = { workspace = true, optional = true }
 serde_yaml = "0.8.23"
 uuid = { version = "1.1.2", features = ["v4"] }
 futures = "0.3.25"
 clap = { version = "3.1.8", features = ["derive"] }
-shared-memory-server = { path = "../../libraries/shared-memory-server" }
+shared-memory-server = { workspace = true }
 ctrlc = "3.2.5"
 bincode = "1.3.3"
 async-trait = "0.1.64"

--- a/binaries/runtime/Cargo.toml
+++ b/binaries/runtime/Cargo.toml
@@ -7,12 +7,12 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dora-node-api = { path = "../../apis/rust/node", default-features = false }
-dora-operator-api-python = { path = "../../apis/python/operator" }
-dora-operator-api-types = { path = "../../apis/rust/operator/types" }
+dora-node-api = { workspace = true, default-features = false }
+dora-operator-api-python = { workspace = true }
+dora-operator-api-types = { workspace = true }
 dora-core = { workspace = true }
-dora-tracing = { path = "../../libraries/extensions/telemetry/tracing", optional = true }
-dora-metrics = { path = "../../libraries/extensions/telemetry/metrics", optional = true }
+dora-tracing = { workspace = true, optional = true }
+dora-metrics = { workspace = true, optional = true }
 opentelemetry = { version = "0.17", features = [
     "rt-tokio",
     "metrics",
@@ -29,7 +29,7 @@ tokio-stream = "0.1.8"
 pyo3 = { version = "0.16", features = ["eyre", "abi3-py37"] }
 tracing = "0.1.36"
 tracing-subscriber = "0.3.15"
-dora-download = { path = "../../libraries/extensions/download" }
+dora-download = { workspace = true }
 flume = "0.10.14"
 
 [features]

--- a/examples/rust-dataflow/operator/Cargo.toml
+++ b/examples/rust-dataflow/operator/Cargo.toml
@@ -10,4 +10,4 @@ license = "Apache-2.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-dora-operator-api = { path = "../../../apis/rust/operator" }
+dora-operator-api = { workspace = true }

--- a/libraries/core/Cargo.toml
+++ b/libraries/core/Cargo.toml
@@ -13,7 +13,7 @@ serde_yaml = "0.9.11"
 once_cell = "1.13.0"
 which = "4.3.0"
 uuid = { version = "1.2.1", features = ["serde"] }
-dora-message = { path = "../message" }
+dora-message = { workspace = true }
 tracing = "0.1"
 serde-with-expand-env = "1.1.0"
 zenoh = "0.7.0-rc"


### PR DESCRIPTION
Removing those path make it easier to move package, reduce path management, reduce complexity and make it easier to export crates to `crates.io`