### PR TITLE
Add an internal cli argument to create template with path dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,9 +87,9 @@ jobs:
         run: |
           dora-cli up
           dora-cli list
-          dora-cli new test_project
+          dora-cli new test_project --internal-create-with-path-dependencies
           cd test_project
-          cargo build --all --config "patch.'https://github.com/dora-rs/dora.git'.dora-node-api.path=\"../apis/rust/node\"" --config "patch.'https://github.com/dora-rs/dora.git'.dora-operator-api.path=\"../apis/rust/operator\""
+          cargo build --all
           UUID=$(dora-cli start dataflow.yml)
           sleep 10
           dora-cli stop $UUID

--- a/binaries/cli/src/main.rs
+++ b/binaries/cli/src/main.rs
@@ -39,6 +39,8 @@ enum Command {
     New {
         #[clap(flatten)]
         args: CommandNew,
+        #[clap(hide = true, long)]
+        internal_create_with_path_dependencies: bool,
     },
     Up {
         #[clap(long)]
@@ -120,7 +122,10 @@ fn main() -> eyre::Result<()> {
         Command::Build { dataflow } => {
             build::build(&dataflow)?;
         }
-        Command::New { args } => template::create(args)?,
+        Command::New {
+            args,
+            internal_create_with_path_dependencies,
+        } => template::create(args, internal_create_with_path_dependencies)?,
         Command::Up {
             config,
             coordinator_path,

--- a/binaries/cli/src/template/mod.rs
+++ b/binaries/cli/src/template/mod.rs
@@ -3,9 +3,9 @@ mod cxx;
 mod python;
 mod rust;
 
-pub fn create(args: crate::CommandNew) -> eyre::Result<()> {
+pub fn create(args: crate::CommandNew, use_path_deps: bool) -> eyre::Result<()> {
     match args.lang {
-        crate::Lang::Rust => rust::create(args),
+        crate::Lang::Rust => rust::create(args, use_path_deps),
         crate::Lang::Python => python::create(args),
         crate::Lang::C => c::create(args),
         crate::Lang::Cxx => cxx::create(args),

--- a/binaries/cli/src/template/rust/node/Cargo-template.toml
+++ b/binaries/cli/src/template/rust/node/Cargo-template.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dora-node-api = { git = "https://github.com/dora-rs/dora.git", tag = "v___version___" }
+dora-node-api = {}

--- a/binaries/cli/src/template/rust/operator/Cargo-template.toml
+++ b/binaries/cli/src/template/rust/operator/Cargo-template.toml
@@ -9,4 +9,4 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-dora-operator-api = { git = "https://github.com/dora-rs/dora.git", tag = "v___version___" }
+dora-operator-api = {}


### PR DESCRIPTION
When we use git dependencies and update the version number, we might reference a tag that does not exist, which leads to build failures. We used to work around this by creating a temporary tag for the new version and replace it with the proper tag later when we do the release. However, this violates the principle that git tags should be fixed and point to the exact commit that created the release.

In https://github.com/dora-rs/dora/commit/d69c87e2c7867baa6c31f19ff2f8e8df14385850, I tried to fix this by patching the git dependencies. Unfortunately it seems like this only works if the original dependency source exists, otherwise cargo will error out before applying the patches.

This PR tries to solve the problem by adding a new internal flag to our CLI (not shown in the help output). When this flag is given, the Rust template will use path dependencies instead of git dependencies. By using this flag in our CLI test, we don't depend on the planned release tag anymore. 