### PR TITLE
Share CI cache across jobs

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -24,7 +24,7 @@ jobs:
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "ubuntu-latest"
+          shared-key: ""
 
       - name: "Python Dataflow example"
         run: cargo run --example python-dataflow

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -24,7 +24,7 @@ jobs:
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ""
+          shared-key: "dora"
 
       - name: "Python Dataflow example"
         run: cargo run --example python-dataflow

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -23,6 +23,8 @@ jobs:
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "ubuntu-latest"
 
       - name: "Python Dataflow example"
         run: cargo run --example python-dataflow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ${{ matrix.platform }}
+          shared-key: ""
 
       - name: "Check"
         run: cargo check --all
@@ -43,7 +43,7 @@ jobs:
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ${{ matrix.platform }}
+          shared-key: ""
 
       - name: "Build examples"
         timeout-minutes: 30
@@ -78,7 +78,7 @@ jobs:
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ${{ matrix.platform }}
+          shared-key: ""
 
       - name: "Build cli and binaries"
         timeout-minutes: 30
@@ -116,7 +116,7 @@ jobs:
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ${{ matrix.platform }}
+          shared-key: ""
 
       - name: "Remote Rust Dataflow example"
         if: false # skip this example for now until we uploaded new test nodes
@@ -133,7 +133,7 @@ jobs:
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ubuntu-latest
+          shared-key: ""
 
       - name: "Clippy"
         run: cargo clippy --all
@@ -163,7 +163,7 @@ jobs:
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ubuntu-latest
+          shared-key: ""
 
       - run: cargo install cargo-lichking
       - name: "Check dependency licenses"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ""
+          shared-key: "dora"
 
       - name: "Check"
         run: cargo check --all
@@ -43,7 +43,7 @@ jobs:
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ""
+          shared-key: "dora"
 
       - name: "Build examples"
         timeout-minutes: 30
@@ -78,7 +78,7 @@ jobs:
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ""
+          shared-key: "dora"
 
       - name: "Build cli and binaries"
         timeout-minutes: 30
@@ -116,7 +116,7 @@ jobs:
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ""
+          shared-key: "dora"
 
       - name: "Remote Rust Dataflow example"
         if: false # skip this example for now until we uploaded new test nodes
@@ -133,7 +133,7 @@ jobs:
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ""
+          shared-key: "dora"
 
       - name: "Clippy"
         run: cargo clippy --all
@@ -163,7 +163,7 @@ jobs:
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ""
+          shared-key: "dora"
 
       - run: cargo install cargo-lichking
       - name: "Check dependency licenses"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ matrix.platform }}
 
       - name: "Check"
         run: cargo check --all
@@ -40,6 +42,8 @@ jobs:
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ matrix.platform }}
 
       - name: "Build examples"
         timeout-minutes: 30
@@ -73,6 +77,8 @@ jobs:
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ matrix.platform }}
 
       - name: "Build cli and binaries"
         timeout-minutes: 30
@@ -98,13 +104,19 @@ jobs:
 
   examples-remote:
     name: "Examples (Remote)"
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [ubuntu-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3
 
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ matrix.platform }}
 
       - name: "Remote Rust Dataflow example"
         if: false # skip this example for now until we uploaded new test nodes
@@ -120,6 +132,8 @@ jobs:
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ubuntu-latest
 
       - name: "Clippy"
         run: cargo clippy --all
@@ -148,6 +162,8 @@ jobs:
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ubuntu-latest
 
       - run: cargo install cargo-lichking
       - name: "Check dependency licenses"


### PR DESCRIPTION
This should reduce our cache storage and thus hopefully prevent cache overflows, which makes the CI very slow.