### PR TITLE
CI: Combine test, example, and cli jobs for better caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: "true"
 
       - name: "Check"
         run: cargo check --all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
           cargo install --path binaries/cli
 
       - name: "Test CLI"
+        if: runner.os == 'Linux' || runner.os == 'macOS'
         timeout-minutes: 30
         run: |
           dora-cli up

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         platform: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.platform }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
       - uses: r7kamura/rust-problem-matchers@v1.1.0
@@ -26,20 +26,6 @@ jobs:
         run: cargo build --all
       - name: "Test"
         run: cargo test --all
-
-  examples:
-    name: "Examples"
-    strategy:
-      matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
-      fail-fast: false
-    runs-on: ${{ matrix.platform }}
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: r7kamura/rust-problem-matchers@v1.1.0
-      - run: cargo --version --verbose
-      - uses: Swatinem/rust-cache@v2
 
       - name: "Build examples"
         timeout-minutes: 30
@@ -60,19 +46,10 @@ jobs:
         timeout-minutes: 15
         run: cargo run --example cxx-dataflow
 
-  CLI:
-    name: "CLI Test"
-    strategy:
-      matrix:
-        platform: [ubuntu-latest, macos-latest]
-      fail-fast: false
-    runs-on: ${{ matrix.platform }}
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: r7kamura/rust-problem-matchers@v1.1.0
-      - run: cargo --version --verbose
-      - uses: Swatinem/rust-cache@v2
+      - name: "Remote Rust Dataflow example"
+        if: runner.os == 'Linux' && false # skip this example for now until we uploaded new test nodes
+        timeout-minutes: 30
+        run: cargo run --example rust-dataflow-url
 
       - name: "Build cli and binaries"
         timeout-minutes: 30
@@ -95,21 +72,6 @@ jobs:
           dora-cli stop $UUID
           cd ..
           dora-cli destroy
-
-  examples-remote:
-    name: "Examples (Remote)"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: r7kamura/rust-problem-matchers@v1.1.0
-      - run: cargo --version --verbose
-      - uses: Swatinem/rust-cache@v2
-
-      - name: "Remote Rust Dataflow example"
-        if: false # skip this example for now until we uploaded new test nodes
-        timeout-minutes: 30
-        run: cargo run --example rust-dataflow-url
 
   clippy:
     name: "Clippy"


### PR DESCRIPTION
By running a single job, we only need to store one cache per OS. Since the jobs share large parts of the dependencies, the total cache size of our workflow becomes smaller. This makes cache eviction less likely (GitHub only keeps the newest 10GB of caches).
