### PR TITLE
Remove zenoh dependency from dora node API to speed up build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,7 +891,6 @@ dependencies = [
  "tracing",
  "uuid",
  "which",
- "zenoh",
 ]
 
 [[package]]

--- a/libraries/core/Cargo.toml
+++ b/libraries/core/Cargo.toml
@@ -16,4 +16,3 @@ uuid = { version = "1.2.1", features = ["serde"] }
 dora-message = { workspace = true }
 tracing = "0.1"
 serde-with-expand-env = "1.1.0"
-zenoh = "0.7.0-rc"

--- a/libraries/core/src/config.rs
+++ b/libraries/core/src/config.rs
@@ -249,8 +249,7 @@ pub struct NodeRunConfig {
 #[serde(deny_unknown_fields, rename_all = "lowercase")]
 pub enum CommunicationConfig {
     Zenoh {
-        #[serde(default)]
-        config: Box<zenoh::prelude::Config>,
+        config: Option<serde_yaml::Value>,
         prefix: String,
     },
 }


### PR DESCRIPTION
This avoids the need to compile the full zenoh dependency for every node. We can do the config parsing in the coordinator when we actually need it.