### PR TITLE
Decouple `opentelemetry` from tracing

### DIFF
--- a/binaries/runtime/Cargo.toml
+++ b/binaries/runtime/Cargo.toml
@@ -33,5 +33,6 @@ dora-download = { workspace = true }
 flume = "0.10.14"
 
 [features]
-tracing = ["opentelemetry", "dora-tracing"]
+tracing = ["dora-tracing"]
+telemetry = ["tracing", "opentelemetry", "dora-tracing/telemetry"]
 metrics = ["opentelemetry", "opentelemetry-system-metrics", "dora-metrics"]

--- a/binaries/runtime/src/lib.rs
+++ b/binaries/runtime/src/lib.rs
@@ -118,7 +118,7 @@ async fn run(
         use opentelemetry_system_metrics::init_process_observer;
 
         let _started = init_meter();
-        let meter = global::meter(Box::leak(node_id.to_string().into_boxed_str()));
+        let meter = global::meter(Box::leak(node.id().to_string().into_boxed_str()));
         init_process_observer(meter);
         _started
     };

--- a/binaries/runtime/src/operator/mod.rs
+++ b/binaries/runtime/src/operator/mod.rs
@@ -5,7 +5,7 @@ use dora_core::{
 };
 use dora_operator_api_python::metadata_to_pydict;
 use eyre::Context;
-#[cfg(feature = "tracing")]
+#[cfg(feature = "telemetry")]
 use opentelemetry::sdk::trace::Tracer;
 use pyo3::{
     types::{PyBytes, PyDict},
@@ -14,7 +14,7 @@ use pyo3::{
 use std::any::Any;
 use tokio::sync::mpsc::Sender;
 
-#[cfg(not(feature = "tracing"))]
+#[cfg(not(feature = "telemetry"))]
 type Tracer = ();
 
 pub mod channel;
@@ -27,11 +27,12 @@ pub fn run_operator(
     incoming_events: flume::Receiver<IncomingEvent>,
     events_tx: Sender<OperatorEvent>,
 ) -> eyre::Result<()> {
-    #[cfg(feature = "tracing")]
-    let tracer =
-        dora_tracing::init_tracing(format!("{node_id}/{}", operator_definition.id).as_str())
-            .wrap_err("could not initiate tracing for operator")?;
-    #[cfg(not(feature = "tracing"))]
+    #[cfg(feature = "telemetry")]
+    let tracer = dora_tracing::telemetry::init_tracing(
+        format!("{node_id}/{}", operator_definition.id).as_str(),
+    )
+    .wrap_err("could not initiate tracing for operator")?;
+    #[cfg(not(feature = "telemetry"))]
     #[allow(clippy::let_unit_value)]
     let tracer = ();
 

--- a/binaries/runtime/src/operator/python.rs
+++ b/binaries/runtime/src/operator/python.rs
@@ -106,9 +106,9 @@ pub fn run(
                 input_id, metadata, ..
             } = &mut event
             {
-                #[cfg(feature = "tracing")]
+                #[cfg(feature = "telemetry")]
                 let (_child_cx, string_cx) = {
-                    use dora_tracing::{deserialize_context, serialize_context};
+                    use dora_tracing::telemetry::{deserialize_context, serialize_context};
                     use opentelemetry::trace::TraceContextExt;
                     use opentelemetry::{trace::Tracer, Context as OtelContext};
 
@@ -120,7 +120,7 @@ pub fn run(
                     (child_cx, string_cx)
                 };
 
-                #[cfg(not(feature = "tracing"))]
+                #[cfg(not(feature = "telemetry"))]
                 let string_cx = {
                     let _ = input_id;
                     let () = tracer;

--- a/binaries/runtime/src/operator/shared_lib.rs
+++ b/binaries/runtime/src/operator/shared_lib.rs
@@ -142,9 +142,9 @@ impl<'lib> SharedLibraryOperator<'lib> {
                 input_id, metadata, ..
             } = &mut event
             {
-                #[cfg(feature = "tracing")]
+                #[cfg(feature = "telemetry")]
                 let (_child_cx, string_cx) = {
-                    use dora_tracing::{deserialize_context, serialize_context};
+                    use dora_tracing::telemetry::{deserialize_context, serialize_context};
                     use opentelemetry::{
                         trace::{TraceContextExt, Tracer},
                         Context as OtelContext,
@@ -158,7 +158,7 @@ impl<'lib> SharedLibraryOperator<'lib> {
                     let string_cx = serialize_context(&child_cx);
                     (child_cx, string_cx)
                 };
-                #[cfg(not(feature = "tracing"))]
+                #[cfg(not(feature = "telemetry"))]
                 let string_cx = {
                     let () = tracer;
                     let _ = input_id;

--- a/libraries/extensions/telemetry/tracing/Cargo.toml
+++ b/libraries/extensions/telemetry/tracing/Cargo.toml
@@ -6,10 +6,18 @@ license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+telemetry = ["dep:opentelemetry", "dep:opentelemetry-jaeger"]
+
 [dependencies]
-opentelemetry = { version = "0.17", features = ["rt-tokio", "metrics"] }
-opentelemetry-jaeger = { version = "0.16", features = ["rt-tokio"] }
 tokio = { version = "1.24.2", features = ["full"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 eyre = "0.6.8"
 tracing = "0.1.36"
+opentelemetry = { version = "0.17", features = [
+    "rt-tokio",
+    "metrics",
+], optional = true }
+opentelemetry-jaeger = { version = "0.16", features = [
+    "rt-tokio",
+], optional = true }

--- a/libraries/extensions/telemetry/tracing/src/lib.rs
+++ b/libraries/extensions/telemetry/tracing/src/lib.rs
@@ -3,74 +3,11 @@
 //! This module init a tracing propagator for Rust code that requires tracing, and is
 //! able to serialize and deserialize context that has been sent via the middleware.
 
-use std::collections::HashMap;
-
 use eyre::Context as EyreContext;
-use opentelemetry::propagation::Extractor;
-use opentelemetry::sdk::{propagation::TraceContextPropagator, trace as sdktrace};
-use opentelemetry::trace::TraceError;
-use opentelemetry::{global, Context};
 use tracing_subscriber::{EnvFilter, Layer};
 
-struct MetadataMap<'a>(HashMap<&'a str, &'a str>);
-
-impl<'a> Extractor for MetadataMap<'a> {
-    /// Get a value for a key from the MetadataMap.  If the value can't be converted to &str, returns None
-    fn get(&self, key: &str) -> Option<&str> {
-        self.0.get(key).cloned()
-    }
-
-    /// Collect all the keys from the MetadataMap.
-    fn keys(&self) -> Vec<&str> {
-        self.0.keys().cloned().collect()
-    }
-}
-
-/// Init opentelemetry tracing
-///
-/// Use the default exporter Jaeger as exporter with
-/// - host: `172.17.0.1` which correspond to the docker address
-/// - port: 6831 which is the default Jaeger port.
-///
-/// To launch the associated Jaeger docker container, launch the
-/// following command:
-/// ```bash
-/// docker run -d -p 6831:6831/udp -p 6832:6832/udp -p 16686:16686 -p 14268:14268 jaegertracing/all-in-one:latest
-/// ```
-///
-/// TODO: Make Jaeger configurable
-///
-pub fn init_tracing(name: &str) -> Result<sdktrace::Tracer, TraceError> {
-    global::set_text_map_propagator(TraceContextPropagator::new());
-    opentelemetry_jaeger::new_pipeline()
-        .with_agent_endpoint("172.17.0.1:6831")
-        .with_service_name(name)
-        .install_simple()
-}
-
-pub fn serialize_context(context: &Context) -> String {
-    let mut map = HashMap::new();
-    global::get_text_map_propagator(|propagator| propagator.inject_context(context, &mut map));
-    let mut string_context = String::new();
-    for (k, v) in map.iter() {
-        string_context.push_str(k);
-        string_context.push(':');
-        string_context.push_str(v);
-        string_context.push(';');
-    }
-    string_context
-}
-
-pub fn deserialize_context(string_context: &str) -> Context {
-    let mut map = MetadataMap(HashMap::new());
-    for s in string_context.split(';') {
-        let mut values = s.split(':');
-        let key = values.next().unwrap();
-        let value = values.next().unwrap_or("");
-        map.0.insert(key, value);
-    }
-    global::get_text_map_propagator(|prop| prop.extract(&map))
-}
+#[cfg(feature = "telemetry")]
+pub mod telemetry;
 
 pub fn set_up_tracing() -> eyre::Result<()> {
     use tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt;

--- a/libraries/extensions/telemetry/tracing/src/telemetry.rs
+++ b/libraries/extensions/telemetry/tracing/src/telemetry.rs
@@ -1,0 +1,65 @@
+use opentelemetry::propagation::Extractor;
+use opentelemetry::sdk::{propagation::TraceContextPropagator, trace as sdktrace};
+use opentelemetry::trace::TraceError;
+use opentelemetry::{global, Context};
+use std::collections::HashMap;
+
+struct MetadataMap<'a>(HashMap<&'a str, &'a str>);
+
+impl<'a> Extractor for MetadataMap<'a> {
+    /// Get a value for a key from the MetadataMap.  If the value can't be converted to &str, returns None
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).cloned()
+    }
+
+    /// Collect all the keys from the MetadataMap.
+    fn keys(&self) -> Vec<&str> {
+        self.0.keys().cloned().collect()
+    }
+}
+
+/// Init opentelemetry tracing
+///
+/// Use the default exporter Jaeger as exporter with
+/// - host: `172.17.0.1` which correspond to the docker address
+/// - port: 6831 which is the default Jaeger port.
+///
+/// To launch the associated Jaeger docker container, launch the
+/// following command:
+/// ```bash
+/// docker run -d -p 6831:6831/udp -p 6832:6832/udp -p 16686:16686 -p 14268:14268 jaegertracing/all-in-one:latest
+/// ```
+///
+/// TODO: Make Jaeger configurable
+///
+pub fn init_tracing(name: &str) -> Result<sdktrace::Tracer, TraceError> {
+    global::set_text_map_propagator(TraceContextPropagator::new());
+    opentelemetry_jaeger::new_pipeline()
+        .with_agent_endpoint("172.17.0.1:6831")
+        .with_service_name(name)
+        .install_simple()
+}
+
+pub fn serialize_context(context: &Context) -> String {
+    let mut map = HashMap::new();
+    global::get_text_map_propagator(|propagator| propagator.inject_context(context, &mut map));
+    let mut string_context = String::new();
+    for (k, v) in map.iter() {
+        string_context.push_str(k);
+        string_context.push(':');
+        string_context.push_str(v);
+        string_context.push(';');
+    }
+    string_context
+}
+
+pub fn deserialize_context(string_context: &str) -> Context {
+    let mut map = MetadataMap(HashMap::new());
+    for s in string_context.split(';') {
+        let mut values = s.split(':');
+        let key = values.next().unwrap();
+        let value = values.next().unwrap_or("");
+        map.0.insert(key, value);
+    }
+    global::get_text_map_propagator(|prop| prop.extract(&map))
+}


### PR DESCRIPTION
Only the `dora-runtime` uses the `opentelemetry` features right now, but most other crates depend on our tracing sub-crate too after #197. This PR adds a new `telemetry` feature to allow enabling the `tracing-subscriber` without bringing in the whole `opentelementry` dependency tree.