### PR TITLE
Deny unknown field to avoid typography

### DIFF
--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -92,6 +92,7 @@ impl Descriptor {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Node {
     pub id: NodeId,
     pub name: Option<String>,
@@ -113,6 +114,7 @@ pub enum NodeKind {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ResolvedNode {
     pub id: NodeId,
     pub name: Option<String>,
@@ -139,6 +141,7 @@ pub struct RuntimeNode {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct OperatorDefinition {
     pub id: OperatorId,
     #[serde(flatten)]
@@ -146,6 +149,7 @@ pub struct OperatorDefinition {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct SingleOperatorDefinition {
     /// ID is optional if there is only a single operator.
     pub id: Option<OperatorId>,
@@ -154,6 +158,7 @@ pub struct SingleOperatorDefinition {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct OperatorConfig {
     pub name: Option<String>,
     pub description: Option<String>,
@@ -202,6 +207,7 @@ pub fn resolve_path(source: &str, working_dir: &Path) -> Result<PathBuf> {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct PythonOperatorConfig {
     pub path: PathBuf,
     #[serde(default)]
@@ -211,6 +217,7 @@ pub struct PythonOperatorConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CustomNode {
     pub source: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -92,7 +92,6 @@ impl Descriptor {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct Node {
     pub id: NodeId,
     pub name: Option<String>,
@@ -114,7 +113,6 @@ pub enum NodeKind {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct ResolvedNode {
     pub id: NodeId,
     pub name: Option<String>,
@@ -141,7 +139,6 @@ pub struct RuntimeNode {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(deny_unknown_fields)]
 pub struct OperatorDefinition {
     pub id: OperatorId,
     #[serde(flatten)]
@@ -149,7 +146,6 @@ pub struct OperatorDefinition {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(deny_unknown_fields)]
 pub struct SingleOperatorDefinition {
     /// ID is optional if there is only a single operator.
     pub id: Option<OperatorId>,


### PR DESCRIPTION
This pull request deny dataflow with misspelled field. 

Ex:
```yaml
  - id: object_detection
    custom:
      source: ./object_detection.py
      input: # missing a `s`
        image: webcam/image
```