### PR TITLE
Refactor python error

### DIFF
--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -104,7 +104,7 @@ impl Node {
 
 #[pyfunction]
 fn start_runtime() -> Result<()> {
-    dora_runtime::main().wrap_err("Python Dora Runtime failed.")
+    dora_runtime::main().wrap_err("Dora Runtime raised an error.")
 }
 
 #[pymodule]

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -104,10 +104,7 @@ impl Node {
 
 #[pyfunction]
 fn start_runtime() -> Result<()> {
-    dora_runtime::main()
-        .wrap_err("Python Dora Runtime failed.")
-        .unwrap();
-    Ok(())
+    dora_runtime::main().wrap_err("Python Dora Runtime failed.")
 }
 
 #[pymodule]

--- a/binaries/runtime/src/lib.rs
+++ b/binaries/runtime/src/lib.rs
@@ -136,7 +136,10 @@ async fn run(
             } => {
                 match event {
                     OperatorEvent::Error(err) => {
-                        bail!(err.wrap_err(format!("operator {operator_id} failed")))
+                        bail!(err.wrap_err(format!(
+                            "operator {}/{operator_id} raised an error",
+                            node.id()
+                        )))
                     }
                     OperatorEvent::Panic(payload) => {
                         bail!("operator {operator_id} panicked: {payload:?}");

--- a/binaries/runtime/src/operator/python.rs
+++ b/binaries/runtime/src/operator/python.rs
@@ -19,7 +19,7 @@ use tokio::sync::mpsc::Sender;
 fn traceback(err: pyo3::PyErr) -> eyre::Report {
     let traceback = Python::with_gil(|py| err.traceback(py).and_then(|t| t.format().ok()));
     if let Some(traceback) = traceback {
-        eyre::eyre!("{err}:\n{traceback}")
+        eyre::eyre!("{err}{traceback}")
     } else {
         eyre::eyre!("{err}")
     }


### PR DESCRIPTION
Small refactoring of the issue that mainly impact how Python error are going to be displayed.

From:
```bash
pyo3_runtime.PanicException: called `Result::unwrap()` on an `Err` value: Python Dora Runtime failed.

Caused by:
   0: main task failed
   1: operator op failed
   2: error in Python module at /home/peter/Documents/CONTRIB/dora/examples/python-operator-dataflow/plot.py
   3: AssertionError: :
      Traceback (most recent call last):
        File "/home/peter/Documents/CONTRIB/dora/examples/python-operator-dataflow/plot.py", line 34, in on_event
          assert False


Location:
    binaries/runtime/src/operator/python.rs:22:9
```

To:
```bash
RuntimeError: Dora Runtime raised an error.

Caused by:
   0: main task failed
   1: operator plot/op raised an error
   2: error in Python module at /home/peter/Documents/CONTRIB/dora/examples/python-operator-dataflow/plot.py
   3: AssertionError: Traceback (most recent call last):
        File "/home/peter/Documents/CONTRIB/dora/examples/python-operator-dataflow/plot.py", line 34, in on_event
          assert False


Location:
    binaries/runtime/src/operator/python.rs:22:9
```

This is a small PR for current purposes but in the future I wish to refactor it even further and probably bind it to `tracing::error` 