### PR TITLE
Synchronize node and operator start

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -289,7 +289,7 @@ impl Daemon {
         nodes: Vec<ResolvedNode>,
         daemon_communication_config: DaemonCommunicationConfig,
     ) -> eyre::Result<()> {
-        let dataflow = RunningDataflow::new(&nodes);
+        let dataflow = RunningDataflow::new(dataflow_id, &nodes);
         let dataflow = match self.running.entry(dataflow_id) {
             std::collections::hash_map::Entry::Vacant(entry) => entry.insert(dataflow),
             std::collections::hash_map::Entry::Occupied(_) => {
@@ -336,31 +336,7 @@ impl Daemon {
             .await
             .wrap_err_with(|| format!("failed to spawn node `{node_id}`"))?;
         }
-        for interval in dataflow.timers.keys().copied() {
-            let events_tx = self.events_tx.clone();
-            let task = async move {
-                let mut interval_stream = tokio::time::interval(interval);
-                let hlc = HLC::default();
-                loop {
-                    interval_stream.tick().await;
 
-                    let event = DoraEvent::Timer {
-                        dataflow_id,
-                        interval,
-                        metadata: dora_core::message::Metadata::from_parameters(
-                            hlc.new_timestamp(),
-                            Default::default(),
-                        ),
-                    };
-                    if events_tx.send(event.into()).await.is_err() {
-                        break;
-                    }
-                }
-            };
-            let (task, handle) = task.remote_handle();
-            tokio::spawn(task);
-            dataflow._timer_handles.push(handle);
-        }
         Ok(())
     }
 
@@ -391,11 +367,7 @@ impl Daemon {
                     // TODO synchronize with dora-coordinator if dataflow is
                     // split across multiple daemons
                     tracing::info!("all nodes are ready, starting dataflow `{dataflow_id}`");
-                    // answer all subscribe requests
-                    let subscribe_replies = std::mem::take(&mut dataflow.subscribe_replies);
-                    for (reply_sender, subscribe_result) in subscribe_replies.into_values() {
-                        let _ = reply_sender.send(DaemonReply::Result(subscribe_result));
-                    }
+                    dataflow.start(&self.events_tx).await?;
                 }
             }
             DaemonNodeEvent::CloseOutputs {
@@ -801,6 +773,7 @@ where
 }
 
 pub struct RunningDataflow {
+    id: Uuid,
     /// Nodes that are not started yet
     pending_nodes: HashSet<NodeId>,
     /// Used to synchronize node starts.
@@ -827,8 +800,9 @@ pub struct RunningDataflow {
 }
 
 impl RunningDataflow {
-    fn new(nodes: &[ResolvedNode]) -> RunningDataflow {
+    fn new(id: Uuid, nodes: &[ResolvedNode]) -> RunningDataflow {
         Self {
+            id,
             pending_nodes: nodes.iter().map(|n| n.id.clone()).collect(),
             subscribe_replies: HashMap::new(),
             subscribe_channels: HashMap::new(),
@@ -841,6 +815,43 @@ impl RunningDataflow {
             stop_sent: false,
             empty_set: BTreeSet::new(),
         }
+    }
+
+    async fn start(&mut self, events_tx: &mpsc::Sender<Event>) -> eyre::Result<()> {
+        // answer all subscribe requests
+        let subscribe_replies = std::mem::take(&mut self.subscribe_replies);
+        for (reply_sender, subscribe_result) in subscribe_replies.into_values() {
+            let _ = reply_sender.send(DaemonReply::Result(subscribe_result));
+        }
+
+        for interval in self.timers.keys().copied() {
+            let events_tx = events_tx.clone();
+            let dataflow_id = self.id;
+            let task = async move {
+                let mut interval_stream = tokio::time::interval(interval);
+                let hlc = HLC::default();
+                loop {
+                    interval_stream.tick().await;
+
+                    let event = DoraEvent::Timer {
+                        dataflow_id,
+                        interval,
+                        metadata: dora_core::message::Metadata::from_parameters(
+                            hlc.new_timestamp(),
+                            Default::default(),
+                        ),
+                    };
+                    if events_tx.send(event.into()).await.is_err() {
+                        break;
+                    }
+                }
+            };
+            let (task, handle) = task.remote_handle();
+            tokio::spawn(task);
+            self._timer_handles.push(handle);
+        }
+
+        Ok(())
     }
 
     async fn stop_all(&mut self) {

--- a/binaries/runtime/src/operator/mod.rs
+++ b/binaries/runtime/src/operator/mod.rs
@@ -12,7 +12,7 @@ use pyo3::{
     IntoPy, PyObject, Python,
 };
 use std::any::Any;
-use tokio::sync::mpsc::Sender;
+use tokio::sync::{mpsc::Sender, oneshot};
 
 #[cfg(not(feature = "telemetry"))]
 type Tracer = ();
@@ -26,6 +26,7 @@ pub fn run_operator(
     operator_definition: OperatorDefinition,
     incoming_events: flume::Receiver<IncomingEvent>,
     events_tx: Sender<OperatorEvent>,
+    init_done: oneshot::Sender<()>,
 ) -> eyre::Result<()> {
     #[cfg(feature = "telemetry")]
     let tracer = dora_tracing::telemetry::init_tracing(
@@ -45,6 +46,7 @@ pub fn run_operator(
                 events_tx,
                 incoming_events,
                 tracer,
+                init_done,
             )
             .wrap_err_with(|| {
                 format!(
@@ -61,6 +63,7 @@ pub fn run_operator(
                 events_tx,
                 incoming_events,
                 tracer,
+                init_done,
             )
             .wrap_err_with(|| {
                 format!(


### PR DESCRIPTION
- Synchronize startup of nodes through subscribe request
  - Nodes wait for a reply after sending a subscribe request.
  - By delaying that reply until all nodes are subscribed, we can synchronize the start time of the dataflow.
- Only start timer tasks once dataflow is ready to start
  - This way, we don't fill the queue with tick events that occured before the synchronized start happened.
- dora-runtime: Only subscribe to daemon once all operators are ready
  - The `dora-runtime` uses the normal node API, so it uses the same synchronization system.
  - By running the `DoraNode::init` function only after all operators were initialized, we ensure that they are ready when the dataflow starts.

Resolves #233