### PR TITLE
Push error into the `init_done` channel for debugging context

### DIFF
--- a/binaries/runtime/src/lib.rs
+++ b/binaries/runtime/src/lib.rs
@@ -117,7 +117,7 @@ async fn run(
     config: NodeConfig,
     operator_events: impl Stream<Item = Event> + Unpin,
     mut operator_channels: HashMap<OperatorId, flume::Sender<operator::IncomingEvent>>,
-    init_done: oneshot::Receiver<()>,
+    init_done: oneshot::Receiver<Result<()>>,
 ) -> eyre::Result<()> {
     #[cfg(feature = "metrics")]
     let _started = {
@@ -133,7 +133,8 @@ async fn run(
 
     init_done
         .await
-        .wrap_err("the `init_done` channel was closed unexpectedly")?;
+        .wrap_err("the `init_done` channel was closed unexpectedly")?
+        .wrap_err("failed to init an operator")?;
     tracing::info!("All operators are ready, starting runtime");
 
     let (mut node, daemon_events) = DoraNode::init(config)?;

--- a/binaries/runtime/src/operator/mod.rs
+++ b/binaries/runtime/src/operator/mod.rs
@@ -4,7 +4,7 @@ use dora_core::{
     message::{Metadata, MetadataParameters},
 };
 use dora_operator_api_python::metadata_to_pydict;
-use eyre::Context;
+use eyre::{Context, Result};
 #[cfg(feature = "telemetry")]
 use opentelemetry::sdk::trace::Tracer;
 use pyo3::{
@@ -26,7 +26,7 @@ pub fn run_operator(
     operator_definition: OperatorDefinition,
     incoming_events: flume::Receiver<IncomingEvent>,
     events_tx: Sender<OperatorEvent>,
-    init_done: oneshot::Sender<()>,
+    init_done: oneshot::Sender<Result<()>>,
 ) -> eyre::Result<()> {
     #[cfg(feature = "telemetry")]
     let tracer = dora_tracing::telemetry::init_tracing(


### PR DESCRIPTION
After adding #236 , error of initialization is shadowed by bailing on the sender channel.

# Cause
The reported error used to be this one: https://github.com/dora-rs/dora/blob/ccec196234c46fc5df7a0f7c7cd15d29a2bda670/binaries/runtime/src/lib.rs#L136

as the runtime would fail on initialisation and would close the `init_done` channel before using it.

This makes it hard to debug.

# Solution

This PR will push the error into the sender channel, and report any error of initialization making it easier to debug.

Now the channel is used without error, but any error of initialization will bail the runtime here: https://github.com/dora-rs/dora/blob/bfd32f1fd7767ec28c6ed0090fbef1b45b4cba64/binaries/runtime/src/lib.rs#L137