### PR TITLE
Break daemon listener infinite loop when node event channel is disconnected

### DIFF
--- a/binaries/daemon/src/listener/mod.rs
+++ b/binaries/daemon/src/listener/mod.rs
@@ -195,9 +195,14 @@ impl Listener {
                     }
                     future::Either::Right((message, _)) => break message,
                 };
+
                 if let Some(event) = event {
                     self.queue.push_back(Box::new(Some(event)));
                     self.handle_events().await?;
+                } else {
+                    // the channel is disconnected
+                    drop(next_message);
+                    break Ok(None);
                 }
             };
 


### PR DESCRIPTION
It seems that this loop is infinite if the channel is disconnected meaning that the sending end of the channel is closed and there is no more node event.

This will result in `events.recv()` always returning `None`.

This should be linked to #235 .