### PR TITLE
Option communication config

### DIFF
--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -360,7 +360,7 @@ async fn send_watchdog_message(connection: &mut TcpStream) -> eyre::Result<()> {
 struct RunningDataflow {
     name: Option<String>,
     uuid: Uuid,
-    communication_config: CommunicationConfig,
+    communication_config: Option<CommunicationConfig>,
     /// The IDs of the machines that the dataflow is running on.
     machines: BTreeSet<String>,
 }

--- a/binaries/coordinator/src/run/mod.rs
+++ b/binaries/coordinator/src/run/mod.rs
@@ -32,10 +32,11 @@ pub async fn spawn_dataflow(
     let nodes = descriptor.resolve_aliases();
     let uuid = Uuid::new_v4();
     let communication_config = {
-        let mut config = descriptor.communication;
-        // add uuid as prefix to ensure isolation
-        config.add_topic_prefix(&uuid.to_string());
-        config
+        let config = descriptor.communication;
+        config.map(|mut config| {
+            config.add_topic_prefix(&uuid.to_string());
+            config
+        })
     };
 
     let spawn_command = SpawnDataflowNodes {
@@ -80,7 +81,7 @@ pub async fn spawn_dataflow(
 
 pub struct SpawnedDataflow {
     pub uuid: Uuid,
-    pub communication_config: CommunicationConfig,
+    pub communication_config: Option<CommunicationConfig>,
     pub machines: BTreeSet<String>,
 }
 

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -20,7 +20,7 @@ mod visualize;
 pub struct Descriptor {
     // see https://github.com/dtolnay/serde-yaml/issues/298
     #[serde(with = "serde_yaml::with::singleton_map")]
-    pub communication: CommunicationConfig,
+    pub communication: Option<CommunicationConfig>,
     pub nodes: Vec<Node>,
     #[serde(default)]
     pub daemon_config: DaemonCommunicationConfig,


### PR DESCRIPTION
As we are not currently using zenoh communication, it would be preferable to not mention it in the datalflow graph as some people might:
- A. confuse it with our shared memory.
- B. Question why it is there.
- C. Question what is zenoh. 

I think that we can support dora-rs without external communication config, as I can see many use-case in simulation.