### PR TITLE
Validate shell command as source and url source.

### DIFF
--- a/binaries/daemon/src/spawn.rs
+++ b/binaries/daemon/src/spawn.rs
@@ -5,14 +5,12 @@ use crate::{
 use dora_core::{
     config::NodeRunConfig,
     daemon_messages::{DaemonCommunicationConfig, DataflowId, NodeConfig, RuntimeConfig},
-    descriptor::{resolve_path, source_is_url, OperatorSource, ResolvedNode},
+    descriptor::{resolve_path, source_is_url, OperatorSource, ResolvedNode, SHELL_SOURCE},
 };
 use dora_download::download_file;
 use eyre::WrapErr;
 use std::{env::consts::EXE_EXTENSION, path::Path, process::Stdio};
 use tokio::sync::mpsc;
-
-const SHELL_SOURCE: &str = "shell";
 
 pub async fn spawn_node(
     dataflow_id: DataflowId,

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -21,6 +21,7 @@ pub const SHELL_SOURCE: &str = "shell";
 #[serde(deny_unknown_fields)]
 pub struct Descriptor {
     // see https://github.com/dtolnay/serde-yaml/issues/298
+    #[serde(default)]
     #[serde(with = "serde_yaml::with::singleton_map")]
     pub communication: Option<CommunicationConfig>,
     pub nodes: Vec<Node>,

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -15,6 +15,7 @@ pub use visualize::collect_dora_timers;
 
 mod validate;
 mod visualize;
+pub const SHELL_SOURCE: &str = "shell";
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]


### PR DESCRIPTION
In #237, I have centralised the validation of yaml graph, so that every process that read a yaml graph can validate it, avoiding propagating failing yaml graph. 

This validation method was copied from the `cli check` method. 

However, in the original `cli check`, we did not add validation for shell command and we failed source that were url.

This Pull Request validate both sources.

P.S: I have left the `TODO:` testing of url source as I'm not sure of what the best appropriate approach is at the moment, especially in a case of distributed `dora-daemon`

P.S.2: I have added a small default in the Descriptor communication to remove the need to specify the communication in the yaml file. 