### PR TITLE
CLI: Improve error messages when coordinator is not running

### DIFF
--- a/binaries/cli/src/main.rs
+++ b/binaries/cli/src/main.rs
@@ -124,8 +124,6 @@ fn main() -> eyre::Result<()> {
     set_up_tracing("dora-cli").context("failed to set up tracing subscriber")?;
     let args = Args::parse();
 
-    let mut session = None;
-
     match args.command {
         Command::Check {
             dataflow,
@@ -171,25 +169,36 @@ fn main() -> eyre::Result<()> {
             dataflow_description
                 .check(&dataflow, None)
                 .wrap_err("Could not validate yaml")?;
-            let dataflow_id = start_dataflow(dataflow.clone(), name, &mut session)?;
+            let mut session =
+                connect_to_coordinator().wrap_err("failed to connect to dora coordinator")?;
+            let dataflow_id = start_dataflow(dataflow.clone(), name, &mut *session)?;
 
             if attach {
                 attach_dataflow(
                     dataflow_description,
                     dataflow,
                     dataflow_id,
-                    &mut session,
+                    &mut *session,
                     hot_reload,
                 )?
             }
         }
-        Command::List => list(&mut session)?,
-        Command::Stop { uuid, name } => match (uuid, name) {
-            (Some(uuid), _) => stop_dataflow(uuid, &mut session)?,
-            (None, Some(name)) => stop_dataflow_by_name(name, &mut session)?,
-            (None, None) => stop_dataflow_interactive(&mut session)?,
+        Command::List => match connect_to_coordinator() {
+            Ok(mut session) => list(&mut *session)?,
+            Err(_) => {
+                eprintln!("No dora coordinator seems to be running.");
+            }
         },
-        Command::Destroy { config } => up::destroy(config.as_deref(), &mut session)?,
+        Command::Stop { uuid, name } => {
+            let mut session =
+                connect_to_coordinator().wrap_err("could not connect to dora coordinator")?;
+            match (uuid, name) {
+                (Some(uuid), _) => stop_dataflow(uuid, &mut *session)?,
+                (None, Some(name)) => stop_dataflow_by_name(name, &mut *session)?,
+                (None, None) => stop_dataflow_interactive(&mut *session)?,
+            }
+        }
+        Command::Destroy { config } => up::destroy(config.as_deref())?,
     }
 
     Ok(())
@@ -198,12 +207,12 @@ fn main() -> eyre::Result<()> {
 fn start_dataflow(
     dataflow: PathBuf,
     name: Option<String>,
-    session: &mut Option<Box<TcpRequestReplyConnection>>,
+    session: &mut TcpRequestReplyConnection,
 ) -> Result<Uuid, eyre::ErrReport> {
     let canonicalized = dataflow
         .canonicalize()
         .wrap_err("given dataflow file does not exist")?;
-    let reply_raw = control_connection(session)?
+    let reply_raw = session
         .request(
             &serde_json::to_vec(&ControlRequest::Start {
                 dataflow_path: canonicalized,
@@ -225,9 +234,7 @@ fn start_dataflow(
     }
 }
 
-fn stop_dataflow_interactive(
-    session: &mut Option<Box<TcpRequestReplyConnection>>,
-) -> eyre::Result<()> {
+fn stop_dataflow_interactive(session: &mut TcpRequestReplyConnection) -> eyre::Result<()> {
     let uuids = query_running_dataflows(session).wrap_err("failed to query running dataflows")?;
     if uuids.is_empty() {
         eprintln!("No dataflows are running");
@@ -241,9 +248,9 @@ fn stop_dataflow_interactive(
 
 fn stop_dataflow(
     uuid: Uuid,
-    session: &mut Option<Box<TcpRequestReplyConnection>>,
+    session: &mut TcpRequestReplyConnection,
 ) -> Result<(), eyre::ErrReport> {
-    let reply_raw = control_connection(session)?
+    let reply_raw = session
         .request(
             &serde_json::to_vec(&ControlRequest::Stop {
                 dataflow_uuid: uuid,
@@ -262,9 +269,9 @@ fn stop_dataflow(
 
 fn stop_dataflow_by_name(
     name: String,
-    session: &mut Option<Box<TcpRequestReplyConnection>>,
+    session: &mut TcpRequestReplyConnection,
 ) -> Result<(), eyre::ErrReport> {
-    let reply_raw = control_connection(session)?
+    let reply_raw = session
         .request(&serde_json::to_vec(&ControlRequest::StopByName { name }).unwrap())
         .wrap_err("failed to send dataflow stop_by_name message")?;
     let result: ControlRequestReply =
@@ -276,7 +283,7 @@ fn stop_dataflow_by_name(
     }
 }
 
-fn list(session: &mut Option<Box<TcpRequestReplyConnection>>) -> Result<(), eyre::ErrReport> {
+fn list(session: &mut TcpRequestReplyConnection) -> Result<(), eyre::ErrReport> {
     let ids = query_running_dataflows(session)?;
 
     if ids.is_empty() {
@@ -292,9 +299,9 @@ fn list(session: &mut Option<Box<TcpRequestReplyConnection>>) -> Result<(), eyre
 }
 
 fn query_running_dataflows(
-    session: &mut Option<Box<TcpRequestReplyConnection>>,
+    session: &mut TcpRequestReplyConnection,
 ) -> Result<Vec<DataflowId>, eyre::ErrReport> {
-    let reply_raw = control_connection(session)?
+    let reply_raw = session
         .request(&serde_json::to_vec(&ControlRequest::List).unwrap())
         .wrap_err("failed to send list message")?;
     let reply: ControlRequestReply =
@@ -308,11 +315,6 @@ fn query_running_dataflows(
     Ok(ids)
 }
 
-fn control_connection(
-    session: &mut Option<Box<TcpRequestReplyConnection>>,
-) -> eyre::Result<&mut Box<TcpRequestReplyConnection>> {
-    Ok(match session {
-        Some(session) => session,
-        None => session.insert(TcpLayer::new().connect(control_socket_addr())?),
-    })
+fn connect_to_coordinator() -> std::io::Result<Box<TcpRequestReplyConnection>> {
+    TcpLayer::new().connect(control_socket_addr())
 }

--- a/binaries/cli/src/main.rs
+++ b/binaries/cli/src/main.rs
@@ -186,7 +186,7 @@ fn main() -> eyre::Result<()> {
         Command::List => match connect_to_coordinator() {
             Ok(mut session) => list(&mut *session)?,
             Err(_) => {
-                eprintln!("No dora coordinator seems to be running.");
+                bail!("No dora coordinator seems to be running.");
             }
         },
         Command::Stop { uuid, name } => {

--- a/binaries/cli/src/main.rs
+++ b/binaries/cli/src/main.rs
@@ -119,7 +119,14 @@ enum Lang {
     Cxx,
 }
 
-fn main() -> eyre::Result<()> {
+fn main() {
+    if let Err(err) = run() {
+        eprintln!("{err:#}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> eyre::Result<()> {
     #[cfg(feature = "tracing")]
     set_up_tracing("dora-cli").context("failed to set up tracing subscriber")?;
     let args = Args::parse();

--- a/binaries/cli/src/up.rs
+++ b/binaries/cli/src/up.rs
@@ -49,7 +49,7 @@ pub(crate) fn destroy(config_path: Option<&Path>) -> Result<(), eyre::ErrReport>
             println!("Send destroy command to dora-coordinator");
         }
         Err(_) => {
-            eprintln!("The dora-coordinator does not seem to be running");
+            eprintln!("Could not connect to dora-coordinator");
         }
     }
 


### PR DESCRIPTION
This PR improves the reported errors when the CLI fails to connect to dora daemon. Instead of a "connection refused" error, we now output a "could not connect to dora coordinator" error.

Fixes #250 