### PR TITLE
[Python] Show node name in process and put Traceback before the actual Error for more natural error

### DIFF
--- a/binaries/daemon/src/spawn.rs
+++ b/binaries/daemon/src/spawn.rs
@@ -111,7 +111,10 @@ pub async fn spawn_node(
             let mut command = if has_python_operator && !has_other_operator {
                 // Use python to spawn runtime if there is a python operator
                 let mut command = tokio::process::Command::new("python3");
-                command.args(["-c", "import dora; dora.start_runtime()"]);
+                command.args([
+                    "-c",
+                    format!("import dora; dora.start_runtime() # {}", node.id).as_str(),
+                ]);
                 command
             } else if !has_python_operator && has_other_operator {
                 tokio::process::Command::new(

--- a/binaries/runtime/src/operator/python.rs
+++ b/binaries/runtime/src/operator/python.rs
@@ -25,7 +25,7 @@ use tracing::{error, field, span, warn};
 fn traceback(err: pyo3::PyErr) -> eyre::Report {
     let traceback = Python::with_gil(|py| err.traceback(py).and_then(|t| t.format().ok()));
     if let Some(traceback) = traceback {
-        eyre::eyre!("{err}{traceback}")
+        eyre::eyre!("{traceback}\n{err}")
     } else {
         eyre::eyre!("{err}")
     }


### PR DESCRIPTION
In #229, I renamed `eyre::eyre!("{err}{traceback}")`  where it should have `eyre::eyre!("{traceback}\n{err}")` . This PR fix this issue.

This Pull Request also add the name of the node process at the end of the process call to help with debugging.