### PR TITLE
Add automatic issue labeler to organize opened issues

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,43 +1,42 @@
 # Add/remove 'critical' label if issue contains the words 'urgent' or 'critical'
 critical:
-    - '(critical|urgent)'
+  - "(critical|urgent)"
 
 cli:
-    - 'cli'
+  - "/(cli|command)/i"
 
 daemon:
-    - 'daemon'
+  - "daemon"
 
 coordinator:
-    - 'coordinator'
+  - "coordinator"
 
 runtime:
-    - 'runtime'
+  - "runtime"
 
 python:
-    - 'python'
+  - "python"
 
 c:
-    - 'c'
+  - "/\bc\b/i"
 
 c++:
-    - '(c++/cxx)'
+  - "/(c++/cxx)/i"
 
 rust:
-    - 'rust'
+  - "rust"
 
 windows:
-    - 'windows'
+  - "windows"
 
 macos:
-    - 'macos' 
+  - "macos"
 
 linux:
-    - '(linux|ubuntu)' 
+  - "(linux|ubuntu)"
 
 bug:
-    - 'bug' 
+  - "bug"
 
 documentation:
-    - '(doc|documentation)'
-    
+  - "(doc|documentation)"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,43 @@
+# Add/remove 'critical' label if issue contains the words 'urgent' or 'critical'
+critical:
+    - '(critical|urgent)'
+
+cli:
+    - 'cli'
+
+daemon:
+    - 'daemon'
+
+coordinator:
+    - 'coordinator'
+
+runtime:
+    - 'runtime'
+
+python:
+    - 'python'
+
+c:
+    - 'c'
+
+c++:
+    - '(c++/cxx)'
+
+rust:
+    - 'rust'
+
+windows:
+    - 'windows'
+
+macos:
+    - 'macos' 
+
+linux:
+    - '(linux|ubuntu)' 
+
+bug:
+    - 'bug' 
+
+documentation:
+    - '(doc|documentation)'
+    

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,15 @@
+name: "Issue Labeler"
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: github/issue-labeler@v3.1 #May not be the latest version
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        configuration-path: .github/labeler.yml
+        enable-versioned-regex: 0
+        include-title: 1


### PR DESCRIPTION
This PR is based on Github Regex labeler https://github.com/marketplace/actions/regex-issue-labeler?version=v3.1 and use a configuration file to set label to issues.

I want to organize issues based on which part of dora they affect.