### PR TITLE
Filter default log level at `warn` for `tokio::tracing`

### DIFF
--- a/libraries/extensions/telemetry/tracing/src/lib.rs
+++ b/libraries/extensions/telemetry/tracing/src/lib.rs
@@ -4,6 +4,7 @@
 //! able to serialize and deserialize context that has been sent via the middleware.
 
 use eyre::Context as EyreContext;
+use tracing::metadata::LevelFilter;
 use tracing_subscriber::{prelude::__tracing_subscriber_SubscriberExt, EnvFilter, Layer};
 
 use eyre::ContextCompat;
@@ -12,7 +13,7 @@ pub mod telemetry;
 
 pub fn set_up_tracing(name: &str) -> eyre::Result<()> {
     // Filter log using `RUST_LOG`. More useful for CLI.
-    let filter = EnvFilter::from_default_env();
+    let filter = EnvFilter::from_default_env().add_directive(LevelFilter::WARN.into());
     let stdout_log = tracing_subscriber::fmt::layer()
         .pretty()
         .with_filter(filter);


### PR DESCRIPTION
Filter log starting from `WARN` instead of `ERROR`

See: https://github.com/dora-rs/dora-drives/issues/54#issuecomment-1523327892