### PR TITLE
Allow the issue labeler to write issues

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,9 +9,9 @@ jobs:
     permissions:
       issues: write
     steps:
-    - uses: github/issue-labeler@v3.1 #May not be the latest version
-      with:
-        repo-token: "${{ github.token }}"
-        configuration-path: .github/labeler.yml
-        enable-versioned-regex: 0
-        include-title: 1
+      - uses: github/issue-labeler@v3.1 #May not be the latest version
+        with:
+          repo-token: "${{ github.token }}"
+          configuration-path: .github/labeler.yml
+          enable-versioned-regex: 0
+          include-title: 1

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   triage:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
     - uses: github/issue-labeler@v3.1 #May not be the latest version
       with:


### PR DESCRIPTION
I think this permission is required for setting the labels.

Unfortunately the [error message](https://github.com/dora-rs/dora/actions/runs/4817842548/jobs/8579065872) is not really useful, so I'm not sure if this is really a permission issue.

Follow-up to #265 