### PR TITLE
Handle node errors during initialization phase

### DIFF
--- a/binaries/coordinator/src/control.rs
+++ b/binaries/coordinator/src/control.rs
@@ -44,7 +44,7 @@ async fn listen(
     let incoming = match result {
         Ok(incoming) => incoming,
         Err(err) => {
-            let _ = tx.blocking_send(err.into());
+            let _ = tx.send(err.into()).await;
             return;
         }
     };

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -99,7 +99,7 @@ async fn start_inner(
         .wrap_err("failed to create control events")?;
 
     let daemon_watchdog_interval =
-        tokio_stream::wrappers::IntervalStream::new(tokio::time::interval(Duration::from_secs(1)))
+        tokio_stream::wrappers::IntervalStream::new(tokio::time::interval(Duration::from_secs(3)))
             .map(|_| Event::DaemonWatchdogInterval);
 
     // events that should be aborted on `dora destroy`
@@ -399,7 +399,7 @@ async fn start_inner(
                 let mut disconnected = BTreeSet::new();
                 for (machine_id, connection) in &mut daemon_connections {
                     let result: eyre::Result<()> =
-                        tokio::time::timeout(Duration::from_millis(100), send_watchdog_message(&mut connection.stream))
+                        tokio::time::timeout(Duration::from_millis(500), send_watchdog_message(&mut connection.stream))
                             .await
                             .wrap_err("timeout")
                             .and_then(|r| r).wrap_err_with(||

--- a/binaries/coordinator/src/listener.rs
+++ b/binaries/coordinator/src/listener.rs
@@ -60,10 +60,16 @@ pub async fn handle_connection(mut connection: TcpStream, events_tx: mpsc::Sende
                 break;
             }
             coordinator_messages::CoordinatorRequest::Event { machine_id, event } => match event {
-                coordinator_messages::DaemonEvent::AllNodesReady { dataflow_id } => {
+                coordinator_messages::DaemonEvent::AllNodesReady {
+                    dataflow_id,
+                    success,
+                } => {
                     let event = Event::Dataflow {
                         uuid: dataflow_id,
-                        event: DataflowEvent::ReadyOnMachine { machine_id },
+                        event: DataflowEvent::ReadyOnMachine {
+                            machine_id,
+                            success,
+                        },
                     };
                     if events_tx.send(event).await.is_err() {
                         break;

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -744,7 +744,6 @@ impl Daemon {
             format!("failed to get downstream nodes: no running dataflow with ID `{dataflow_id}`")
         })?;
 
-        tracing::warn!("node `{node_id}` exited before initializing dora connection");
         dataflow
             .pending_nodes
             .handle_node_stop(node_id, &mut self.coordinator_connection)

--- a/binaries/daemon/src/pending.rs
+++ b/binaries/daemon/src/pending.rs
@@ -1,0 +1,104 @@
+use std::collections::{HashMap, HashSet};
+
+use dora_core::{config::NodeId, daemon_messages::DaemonReply};
+use tokio::sync::oneshot;
+
+#[derive(Default)]
+pub struct PendingNodes {
+    /// The local nodes that are still waiting to start.
+    local_nodes: HashSet<NodeId>,
+    /// Whether there are external nodes for this dataflow.
+    external_nodes: bool,
+
+    /// Used to synchronize node starts.
+    ///
+    /// Subscribe requests block the node until all other nodes are ready too.
+    waiting_subscribers: HashMap<NodeId, oneshot::Sender<DaemonReply>>,
+    /// List of nodes that finished before connecting to the dora daemon.
+    ///
+    /// If this list is non-empty, we should not start the dataflow at all. Instead,
+    /// we report an error to the other nodes.
+    exited_before_subscribe: HashSet<NodeId>,
+}
+
+impl PendingNodes {
+    pub fn insert(&mut self, node_id: NodeId) {
+        self.local_nodes.insert(node_id);
+    }
+
+    pub fn set_external_nodes(&mut self, value: bool) {
+        self.external_nodes = value;
+    }
+
+    pub async fn handle_node_subscription(
+        &mut self,
+        node_id: NodeId,
+        reply_sender: oneshot::Sender<DaemonReply>,
+    ) -> eyre::Result<DataflowStatus> {
+        self.waiting_subscribers
+            .insert(node_id.clone(), reply_sender);
+
+        self.local_nodes.remove(&node_id);
+        if self.local_nodes.is_empty() {
+            if self.external_nodes {
+                Ok(DataflowStatus::LocalNodesReady { success: true })
+            } else {
+                self.answer_subscribe_requests(None).await;
+                Ok(DataflowStatus::AllNodesReady)
+            }
+        } else {
+            Ok(DataflowStatus::LocalNodesPending)
+        }
+    }
+
+    pub async fn handle_node_stop(&mut self, node_id: &NodeId) -> DataflowStatus {
+        self.exited_before_subscribe.insert(node_id.clone());
+
+        self.local_nodes.remove(node_id);
+        if self.local_nodes.is_empty() {
+            if self.external_nodes {
+                DataflowStatus::LocalNodesReady { success: false }
+            } else {
+                self.answer_subscribe_requests(None).await;
+                DataflowStatus::AllNodesReady
+            }
+        } else {
+            // continue waiting for other nodes
+            DataflowStatus::LocalNodesPending
+        }
+    }
+
+    pub async fn handle_external_all_nodes_ready(&mut self, success: bool) {
+        let external_error = if success {
+            None
+        } else {
+            Some("some nodes failed to initalize on remote machines".to_string())
+        };
+        self.answer_subscribe_requests(external_error).await
+    }
+
+    async fn answer_subscribe_requests(&mut self, external_error: Option<String>) {
+        let result = if self.exited_before_subscribe.is_empty() {
+            match external_error {
+                Some(err) => Err(err),
+                None => Ok(()),
+            }
+        } else {
+            Err(format!(
+                "Nodes failed before subscribing: {:?}",
+                self.exited_before_subscribe
+            ))
+        };
+        // answer all subscribe requests
+        let subscribe_replies = std::mem::take(&mut self.waiting_subscribers);
+        for reply_sender in subscribe_replies.into_values() {
+            let _ = reply_sender.send(DaemonReply::Result(result.clone()));
+        }
+    }
+}
+
+pub enum DataflowStatus {
+    AllNodesReady,
+    LocalNodesPending,
+    LocalNodesReady { success: bool },
+}

--- a/binaries/daemon/src/pending.rs
+++ b/binaries/daemon/src/pending.rs
@@ -122,8 +122,11 @@ impl PendingNodes {
             }
         } else {
             Err(format!(
-                "Nodes failed before subscribing: {:?}",
-                self.exited_before_subscribe
+                "Some nodes exited before subscribing to dora: {:?}\n\n\
+                This is typically happens when an initialization error occurs
+                in the node or operator. To check the output of the failed
+                nodes, run `dora logs {} <node_id>`.",
+                self.exited_before_subscribe, self.dataflow_id
             ))
         };
         // answer all subscribe requests

--- a/libraries/core/src/coordinator_messages.rs
+++ b/libraries/core/src/coordinator_messages.rs
@@ -19,6 +19,7 @@ pub enum CoordinatorRequest {
 pub enum DaemonEvent {
     AllNodesReady {
         dataflow_id: DataflowId,
+        success: bool,
     },
     AllNodesFinished {
         dataflow_id: DataflowId,

--- a/libraries/core/src/daemon_messages.rs
+++ b/libraries/core/src/daemon_messages.rs
@@ -201,6 +201,7 @@ pub enum DaemonCoordinatorEvent {
     Spawn(SpawnDataflowNodes),
     AllNodesReady {
         dataflow_id: DataflowId,
+        success: bool,
     },
     StopDataflow {
         dataflow_id: DataflowId,

--- a/libraries/core/src/daemon_messages.rs
+++ b/libraries/core/src/daemon_messages.rs
@@ -127,6 +127,7 @@ impl fmt::Debug for Data {
 type SharedMemoryId = String;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[must_use]
 pub enum DaemonReply {
     Result(Result<(), String>),
     PreparedMessage { shared_memory_id: SharedMemoryId },


### PR DESCRIPTION
We synchronize the start of nodes (even across machines) to avoid missed messages. This led to deadlock issues when nodes exited before they initialized the connection to the dora daemon. The reason was that the other nodes were still waiting for the stopped node to become ready.

This commit fixes this issue by properly handling node exits that occur before sending the subscribe message. If nodes exit, they are removed from the pending list and added to a new  'exited before init' list. Once all nodes have subscribed or exited, we answer the pending subscribe requests. If nodes exited before subscribing we send an error reply to the other nodes because a synchronized start is no longer possible.

To make this logic work across different machines too, we add a `success` field to the `AllNodesReady` message that the daemon sends to the coordinator. The coordinator forwards this flag to other daemons so that they can act accordingly.

This fix also works for operators.

Fixes https://github.com/dora-rs/dora/issues/271
Alternative to #273 