### PR TITLE
Autogenerate a name for started dataflows if none is given

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,6 +1304,7 @@ dependencies = [
  "eyre",
  "futures",
  "futures-concurrency",
+ "names",
  "rand",
  "serde",
  "serde_json",
@@ -2841,6 +2842,16 @@ version = "0.2.3-rc6"
 dependencies = [
  "dora-node-api",
  "eyre",
+]
+
+[[package]]
+name = "names"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bddcd3bf5144b6392de80e04c347cd7fab2508f6df16a85fc496ecd5cec39bc"
+dependencies = [
+ "clap 3.2.23",
+ "rand",
 ]
 
 [[package]]

--- a/binaries/coordinator/Cargo.toml
+++ b/binaries/coordinator/Cargo.toml
@@ -31,3 +31,4 @@ which = "4.3.0"
 thiserror = "1.0.37"
 ctrlc = "3.2.5"
 clap = { version = "3.1.8", features = ["derive"] }
+names = "0.14.0"

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -159,6 +159,8 @@ async fn start_inner(
     let mut archived_dataflows: HashMap<Uuid, ArchivedDataflow> = HashMap::new();
     let mut daemon_connections: HashMap<_, DaemonConnection> = HashMap::new();
 
+    let mut name_generator = names::Generator::default();
+
     while let Some(event) = events.next().await {
         if event.log() {
             tracing::trace!("Handling event {event:?}");
@@ -303,6 +305,8 @@ async fn start_inner(
                             name,
                             local_working_dir,
                         } => {
+                            let name = name.or_else(|| name_generator.next());
+
                             let inner = async {
                                 if let Some(name) = name.as_deref() {
                                     // check that name is unique

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -159,8 +159,6 @@ async fn start_inner(
     let mut archived_dataflows: HashMap<Uuid, ArchivedDataflow> = HashMap::new();
     let mut daemon_connections: HashMap<_, DaemonConnection> = HashMap::new();
 
-    let mut name_generator = names::Generator::default();
-
     while let Some(event) = events.next().await {
         if event.log() {
             tracing::trace!("Handling event {event:?}");
@@ -305,7 +303,7 @@ async fn start_inner(
                             name,
                             local_working_dir,
                         } => {
-                            let name = name.or_else(|| name_generator.next());
+                            let name = name.or_else(|| names::Generator::default().next());
 
                             let inner = async {
                                 if let Some(name) = name.as_deref() {


### PR DESCRIPTION
Generates random `adjective-noun` names such as `faded-eye` or `grubby-bath`.

Fixes #266 