### PR TITLE
Fix: Don't try to create two global tracing subscribers when using bundled runtime

### DIFF
--- a/binaries/daemon/src/main.rs
+++ b/binaries/daemon/src/main.rs
@@ -36,9 +36,6 @@ async fn main() -> eyre::Result<()> {
 }
 
 async fn run() -> eyre::Result<()> {
-    #[cfg(feature = "tracing")]
-    set_up_tracing("dora-daemon").wrap_err("failed to set up tracing subscriber")?;
-
     let Args {
         run_dataflow,
         machine_id,
@@ -49,6 +46,9 @@ async fn run() -> eyre::Result<()> {
     if run_dora_runtime {
         return tokio::task::block_in_place(dora_daemon::run_dora_runtime);
     }
+
+    #[cfg(feature = "tracing")]
+    set_up_tracing("dora-daemon").wrap_err("failed to set up tracing subscriber")?;
 
     let ctrl_c_events = {
         let (ctrl_c_tx, ctrl_c_rx) = mpsc::channel(1);


### PR DESCRIPTION
Small follow-up fix for #257. The `run_dora_runtime` method tries to set its own tracing subscriber, so we should not set up a global subscriber beforehand.