### PR TITLE
CI: Increase timeout for 'build CLI and binaries' step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: "Build cli and binaries"
-        timeout-minutes: 30
+        timeout-minutes: 45
         run: |
           cargo install --path binaries/coordinator
           cargo install --path binaries/daemon


### PR DESCRIPTION
Apparently the step can take longer on macOS if no cache is found.
