### PR TITLE
add an attribute that disables the `dead_code` lint

### DIFF
--- a/binaries/runtime/src/operator/mod.rs
+++ b/binaries/runtime/src/operator/mod.rs
@@ -67,6 +67,7 @@ pub fn run_operator(
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum OperatorEvent {
     AllocateOutputSample {
         len: usize,


### PR DESCRIPTION
to disable the lint warn about unused functions, according to the following instructions:
https://doc.rust-lang.org/rust-by-example/attribute/unused.html

In order to solve this issue: https://github.com/dora-rs/dora/issues/284