### PR TITLE
Documentation of methods within the code

### DIFF
--- a/apis/python/node/dora/__init__.py
+++ b/apis/python/node/dora/__init__.py
@@ -1,3 +1,15 @@
+""" 
+# dora-rs
+
+This is the dora python client for interacting with dora dataflow.
+
+You can install it via:
+
+```bash
+pip install dora-rs
+```
+"""
+
 from enum import Enum
 
 from .dora import *

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -6,6 +6,17 @@ use eyre::Context;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
+/// The custom node API lets you integrate `dora` into your application.
+/// It allows you to retrieve input and send output in any fashion you want.
+///
+/// Use with:
+///
+/// ```python
+/// from dora import Node
+///
+/// node = Node()
+/// ```
+///
 #[pyclass]
 pub struct Node {
     events: EventStream,
@@ -21,6 +32,19 @@ impl Node {
         Ok(Node { events, node })
     }
 
+    /// `.next()` gives you the next input that the node has received.
+    /// It blocks until the next input becomes available.
+    /// It will return `None` when all senders has been dropped.
+    ///
+    /// ```python
+    /// input_id, value, metadata = node.next()
+    /// ```
+    ///
+    /// You can also iterate over the node in a loop
+    ///
+    /// ```python
+    /// for input_id, value, metadata in node:
+    /// ```
     #[allow(clippy::should_implement_trait)]
     pub fn next(&mut self, py: Python) -> PyResult<Option<PyEvent>> {
         self.__next__(py)
@@ -35,6 +59,19 @@ impl Node {
         slf
     }
 
+    /// `send_output` send data from the node.
+    ///
+    /// ```python
+    /// Args:
+    ///    output_id: str,
+    ///    data: Bytes|Arrow,
+    ///    metadata: Option[Dict],
+    /// ```
+    ///
+    /// ```python
+    /// node.send_output("string", b"string", {"open_telemetry_context": "7632e76"})
+    /// ```
+    ///
     pub fn send_output(
         &mut self,
         output_id: String,
@@ -69,6 +106,7 @@ impl Node {
     }
 }
 
+/// Start a runtime for Operators
 #[pyfunction]
 fn start_runtime() -> eyre::Result<()> {
     dora_runtime::main().wrap_err("Dora Runtime raised an error.")

--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -85,6 +85,7 @@ impl EventStream {
         })
     }
 
+    /// wait for the next event on the events stream.
     pub fn recv(&mut self) -> Option<Event> {
         let event = self.receiver.recv();
         self.recv_common(event)

--- a/apis/rust/node/src/lib.rs
+++ b/apis/rust/node/src/lib.rs
@@ -1,3 +1,18 @@
+//! The custom node API allow you to integrate `dora` into your application.
+//! It allows you to retrieve input and send output in any fashion you want.                                                 
+//!
+//! Try it out with:
+//!
+//! ```bash
+//! dora new node --kind node
+//! ```
+//!
+//! You can also generate a dora rust project with
+//!
+//! ```bash
+//! dora new project_xyz --kind dataflow
+//! ```
+//!
 pub use dora_core;
 pub use dora_core::message::{uhlc, Metadata, MetadataParameters};
 pub use event_stream::{Data, Event, EventStream, MappedInputData};

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -36,8 +36,10 @@ pub struct DoraNode {
 impl DoraNode {
     /// Initiate a node from environment variables set by `dora-coordinator`
     ///
-    /// ```rust
-    /// let (mut node, mut events) = DoraNode::init_from_env()?;
+    /// ```no_run
+    /// use dora_node_api::DoraNode;
+    ///
+    /// let (mut node, mut events) = DoraNode::init_from_env().expect("Could not init node.");
     /// ```
     ///
     pub fn init_from_env() -> eyre::Result<(Self, EventStream)> {
@@ -83,14 +85,24 @@ impl DoraNode {
     /// Send data from the node to the other nodes.
     /// We take a closure as an input to enable zero copy on send.
     ///
-    /// ```rust
+    /// ```no_run
+    /// use dora_node_api::{DoraNode, MetadataParameters};
+    /// use dora_core::config::DataId;
+    ///
+    /// let (mut node, mut events) = DoraNode::init_from_env().expect("Could not init node.");
+    ///
+    /// let output = DataId::from("output_id".to_owned());
+    ///
+    /// let data: &[u8] = &[0, 1, 2, 3];
+    /// let parameters = MetadataParameters::default();
+    ///
     /// node.send_output(
-    ///    &data_id,
-    ///    metadata.parameters,
+    ///    output,
+    ///    parameters,
     ///    data.len(),
     ///    |out| {
     ///         out.copy_from_slice(data);
-    ///     })?;
+    ///     }).expect("Could not send output");
     /// ```
     ///
     pub fn send_output<F>(

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -34,6 +34,12 @@ pub struct DoraNode {
 }
 
 impl DoraNode {
+    /// Initiate a node from environment variables set by `dora-coordinator`
+    ///
+    /// ```rust
+    /// let (mut node, mut events) = DoraNode::init_from_env()?;
+    /// ```
+    ///
     pub fn init_from_env() -> eyre::Result<(Self, EventStream)> {
         let node_config: NodeConfig = {
             let raw = std::env::var("DORA_NODE_CONFIG")
@@ -74,6 +80,19 @@ impl DoraNode {
         Ok((node, event_stream))
     }
 
+    /// Send data from the node to the other nodes.
+    /// We take a closure as an input to enable zero copy on send.
+    ///
+    /// ```rust
+    /// node.send_output(
+    ///    &data_id,
+    ///    metadata.parameters,
+    ///    data.len(),
+    ///    |out| {
+    ///         out.copy_from_slice(data);
+    ///     })?;
+    /// ```
+    ///
     pub fn send_output<F>(
         &mut self,
         output_id: DataId,

--- a/apis/rust/operator/src/lib.rs
+++ b/apis/rust/operator/src/lib.rs
@@ -1,3 +1,20 @@
+//! The operator API is a framework to implement dora operators.
+//! The implemented operator will be managed by `dora`.
+//!
+//! This framework enable us to make optimisation and provide advanced features.
+//! It is the recommended way of using `dora`.
+//!
+//! An operator requires to be registered and implement the `DoraOperator` trait.
+//! It is composed of an `on_event` method that defines the behaviour
+//! of the operator when there is an event such as receiving an input for example.
+//!
+//! Try it out with:
+//!
+//! ```bash
+//! dora new op --kind operator
+//! ```
+//!
+
 #![warn(unsafe_op_in_unsafe_fn)]
 #![allow(clippy::missing_safety_doc)]
 

--- a/binaries/cli/src/main.rs
+++ b/binaries/cli/src/main.rs
@@ -44,9 +44,7 @@ enum Command {
         open: bool,
     },
     /// Run build commands provided in the given dataflow.
-    Build {
-        dataflow: PathBuf,
-    },
+    Build { dataflow: PathBuf },
     /// Generate a new project, node or operator. Choose the language between Rust, Python, C or C++.
     New {
         #[clap(flatten)]
@@ -88,10 +86,8 @@ enum Command {
     List,
     // Planned for future releases:
     // Dashboard,
-    Logs {
-        dataflow: String,
-        node: String,
-    },
+    /// Show logs of a given dataflow and node.
+    Logs { dataflow: String, node: String },
     // Metrics,
     // Stats,
     // Get,

--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -166,7 +166,7 @@ fn check_python_runtime() -> eyre::Result<()> {
         &format!(
             "
 import dora;
-assert dora.__version__=='{VERSION}',  'Python dora-rs should be {VERSION}. {reinstall_command}'
+assert dora.__version__=='{VERSION}',  'Python dora-rs should be {VERSION}, but current version is %s. {reinstall_command}' % (dora.__version__)
         "
         ),
     ]);


### PR DESCRIPTION
In the refactored documentation https://github.com/dora-rs/dora-rs.github.io , the documentation is auto-generated from the docstring documentation instead of being manually generated in markdown. 

I believe this makes it easier for us to maintain documentation. Write once, find everywhere.

I have therefore passed the documentation we have previously written in `.md` into the current code documentation. 

