### PR TITLE
Return dataflow result to CLI on `dora stop`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,8 @@ jobs:
 
       - name: "Build cli and binaries"
         timeout-minutes: 45
+        # fail-fast by using bash shell explictly
+        shell: bash
         run: |
           cargo install --path binaries/coordinator
           cargo install --path binaries/daemon
@@ -90,6 +92,8 @@ jobs:
 
       - name: "Test CLI"
         timeout-minutes: 30
+        # fail-fast by using bash shell explictly
+        shell: bash
         run: |
           dora-cli up
           dora-cli list

--- a/binaries/cli/src/attach.rs
+++ b/binaries/cli/src/attach.rs
@@ -128,9 +128,11 @@ pub fn attach_dataflow(
             serde_json::from_slice(&reply_raw).wrap_err("failed to parse reply")?;
         match result {
             ControlRequestReply::DataflowStarted { uuid: _ } => (),
-            ControlRequestReply::DataflowStopped { uuid } => {
+            ControlRequestReply::DataflowStopped { uuid, result } => {
                 info!("dataflow {uuid} stopped");
-                break;
+                break result
+                    .map_err(|err| eyre::eyre!(err))
+                    .wrap_err("dataflow failed");
             }
             ControlRequestReply::DataflowReloaded { uuid } => {
                 info!("dataflow {uuid} reloaded")
@@ -138,6 +140,4 @@ pub fn attach_dataflow(
             other => error!("Received unexpected Coordinator Reply: {:#?}", other),
         };
     }
-
-    Ok(())
 }

--- a/binaries/cli/src/main.rs
+++ b/binaries/cli/src/main.rs
@@ -288,7 +288,9 @@ fn stop_dataflow(
     let result: ControlRequestReply =
         serde_json::from_slice(&reply_raw).wrap_err("failed to parse reply")?;
     match result {
-        ControlRequestReply::DataflowStopped { uuid: _ } => Ok(()),
+        ControlRequestReply::DataflowStopped { uuid: _, result } => result
+            .map_err(|err| eyre::eyre!(err))
+            .wrap_err("dataflow failed"),
         ControlRequestReply::Error(err) => bail!("{err}"),
         other => bail!("unexpected stop dataflow reply: {other:?}"),
     }
@@ -304,7 +306,9 @@ fn stop_dataflow_by_name(
     let result: ControlRequestReply =
         serde_json::from_slice(&reply_raw).wrap_err("failed to parse reply")?;
     match result {
-        ControlRequestReply::DataflowStopped { uuid: _ } => Ok(()),
+        ControlRequestReply::DataflowStopped { uuid: _, result } => result
+            .map_err(|err| eyre::eyre!(err))
+            .wrap_err("dataflow failed"),
         ControlRequestReply::Error(err) => bail!("{err}"),
         other => bail!("unexpected stop dataflow reply: {other:?}"),
     }

--- a/binaries/daemon/src/spawn.rs
+++ b/binaries/daemon/src/spawn.rs
@@ -262,7 +262,7 @@ pub async fn spawn_node(
                 .write_all(message.as_bytes())
                 .await
                 .map_err(|err| error!("Could not log {message} to file due to {err}"));
-            let formatted: String = message.lines().map(|l| format!("  {l}")).collect();
+            let formatted: String = message.lines().map(|l| format!("      {l}\n")).collect();
             debug!("{dataflow_id}/{} logged:\n{formatted}", node.id.clone());
             // Make sure that all data has been synced to disk.
             let _ = file

--- a/binaries/daemon/src/spawn.rs
+++ b/binaries/daemon/src/spawn.rs
@@ -184,17 +184,47 @@ pub async fn spawn_node(
         File::create(&log_dir.join(log::log_path(&dataflow_id, &node_id).with_extension("txt")))
             .await
             .expect("Failed to create log file");
-    let mut stdout_lines =
-        (tokio::io::BufReader::new(child.stdout.take().expect("failed to take stdout"))).lines();
+    let mut child_stdout =
+        tokio::io::BufReader::new(child.stdout.take().expect("failed to take stdout"));
 
     let stdout_tx = tx.clone();
 
     // Stdout listener stream
     tokio::spawn(async move {
-        while let Ok(Some(line)) = stdout_lines.next_line().await {
-            let sent = stdout_tx.send(line.clone()).await;
+        let mut buffer = String::new();
+        let mut finished = false;
+        while !finished {
+            finished = match child_stdout
+                .read_line(&mut buffer)
+                .await
+                .wrap_err("failed to read stdout line from spawned node")
+            {
+                Ok(0) => true,
+                Ok(_) => false,
+                Err(err) => {
+                    tracing::warn!("{err:?}");
+                    true
+                }
+            };
+
+            if buffer.contains("TRACE")
+                || buffer.contains("INFO")
+                || buffer.contains("DEBUG")
+                || buffer.contains("WARN")
+                || buffer.contains("ERROR")
+            {
+                // tracing output, potentially multi-line -> keep reading following lines
+                // until double-newline
+                if !buffer.ends_with("\n\n") && !finished {
+                    continue;
+                }
+            }
+
+            // send the buffered lines
+            let lines = std::mem::take(&mut buffer);
+            let sent = stdout_tx.send(lines.clone()).await;
             if sent.is_err() {
-                println!("Could not log: {line}");
+                println!("Could not log: {lines}");
             }
         }
     });
@@ -227,16 +257,13 @@ pub async fn spawn_node(
 
     // Log to file stream.
     tokio::spawn(async move {
-        while let Some(line) = rx.recv().await {
+        while let Some(message) = rx.recv().await {
             let _ = file
-                .write_all(line.as_bytes())
+                .write_all(message.as_bytes())
                 .await
-                .map_err(|err| error!("Could not log {line} to file due to {err}"));
-            let _ = file
-                .write(b"\n")
-                .await
-                .map_err(|err| error!("Could not add newline to log file due to {err}"));
-            debug!("{dataflow_id}/{} logged {line}", node.id.clone());
+                .map_err(|err| error!("Could not log {message} to file due to {err}"));
+            let formatted: String = message.lines().map(|l| format!("  {l}")).collect();
+            debug!("{dataflow_id}/{} logged:\n{formatted}", node.id.clone());
             // Make sure that all data has been synced to disk.
             let _ = file
                 .sync_all()

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -240,20 +240,20 @@ pub fn source_is_url(source: &str) -> bool {
 
 pub fn resolve_path(source: &str, working_dir: &Path) -> Result<PathBuf> {
     let path = Path::new(&source);
-    if path.extension().is_none() {
+    let path = if path.extension().is_none() {
         path.with_extension(EXE_EXTENSION)
     } else {
         path.to_owned()
     };
 
     // Search path within current working directory
-    if let Ok(abs_path) = working_dir.join(path).canonicalize() {
+    if let Ok(abs_path) = working_dir.join(&path).canonicalize() {
         Ok(abs_path)
     // Search path within $PATH
-    } else if let Ok(abs_path) = which::which(path) {
+    } else if let Ok(abs_path) = which::which(&path) {
         Ok(abs_path)
     } else {
-        bail!("Could not find source path.")
+        bail!("Could not find source path {}", path.display())
     }
 }
 

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -57,10 +57,19 @@ pub enum ControlRequest {
 pub enum ControlRequestReply {
     Error(String),
     CoordinatorStopped,
-    DataflowStarted { uuid: Uuid },
-    DataflowReloaded { uuid: Uuid },
-    DataflowStopped { uuid: Uuid },
-    DataflowList { dataflows: Vec<DataflowId> },
+    DataflowStarted {
+        uuid: Uuid,
+    },
+    DataflowReloaded {
+        uuid: Uuid,
+    },
+    DataflowStopped {
+        uuid: Uuid,
+        result: Result<(), String>,
+    },
+    DataflowList {
+        dataflows: Vec<DataflowId>,
+    },
     DestroyOk,
     DaemonConnected(bool),
     ConnectedMachines(BTreeSet<String>),

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -53,7 +53,7 @@ pub enum ControlRequest {
     ConnectedMachines,
 }
 
-#[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub enum ControlRequestReply {
     Error(String),
     CoordinatorStopped,
@@ -67,6 +67,7 @@ pub enum ControlRequestReply {
         uuid: Uuid,
         result: Result<(), String>,
     },
+
     DataflowList {
         dataflows: Vec<DataflowId>,
     },


### PR DESCRIPTION
This PR changes the `dora stop` command to wait until the dataflow is stopped. This makes it possible to return the dataflow result back to the CLI. It also fixes a bug in the node spawn code on Windows and it improves the printed output for multi-line log messages of nodes.

The main motivation for this change is that I noticed some error messages in our Windows CLI test, e.g. here: https://github.com/dora-rs/dora/actions/runs/5090976696/jobs/9150446325#step:7:636 . However, these errors did not lead to any CI errors because the `dora stop` command did not check the dataflow result.

### Details

- Don't break up multi-line log messages of nodes
  - I noticed that the stdout capture code introduced in #259 always worked on each output line separately. This breaks up multi-line log messages, which makes the logs hard to read. For example: 
![image](https://github.com/dora-rs/dora/assets/1131315/95859120-2116-419b-8f5d-27ae5ad7d4dc)
  - To avoid this, I exploited the fact that we're using a log format that puts two newlines between individual messages. I used the following approach: if the first line contains a log level (e.g. `INFO` or `TRACE`), we include the following lines in the same message until we reach a `\n\n`. Otherwise, we keep the previous line-splitting (this applies to things that nodes print via `println`).
- Report node errors to coordinator on stop
  - Previously, the daemons always send an `Ok(())` result after stopping a dataflow.
  - This commit changes this to pass the actual result of the dataflow.
- Pass dataflow result to CLI
  - Updates the coordinator to pass the dataflow result to the CLI on `dora stop` _if known_.
  - This only applies to dataflows that are stopped already when `dora stop` is sent because we don't know the result of running dataflows yet.
- Wait for dataflow finish on `dora stop`
  - Delay the `dora stop` reply in the coordinator until the dataflow was stopped. 
  - This makes it possible to always pass the dataflow result to the CLI.
- Improve formatting of collected log messages
  - increase indentation and keep newlines of multi-line messages
- CI: fail-fast by using bash shell explictly
  - apparently the CI ignores error in multi-line `run` scripts, unless bash shell is specified explicitly
  - now the error messages that I were seeing for the Windows CLI test finally lead to the desired CI failure
- Return dataflow result when trying to stop stopped dataflow
  - If the dataflow stops early because of an error, we still want `dora stop` to return the dataflow result
- Fix adding of `.exe` extension
  - Fixes a subtle regression introduced in https://github.com/dora-rs/dora/commit/03b86518a8202d7871b8b76174b0a0236395e951. As the `with_extension` method returns a new path (instead of modifying in in-place), the `EXE_EXTENSION` was not added properly.