### PR TITLE
Add timestamps generated by hybrid logical clocks to all sent events

### DIFF
--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -12,6 +12,7 @@ use shared_memory::{Shmem, ShmemConf};
 use std::{
     collections::{HashMap, VecDeque},
     ops::{Deref, DerefMut},
+    sync::Arc,
     time::Duration,
 };
 
@@ -27,7 +28,7 @@ pub struct DoraNode {
     id: NodeId,
     node_config: NodeRunConfig,
     control_channel: ControlChannel,
-    hlc: uhlc::HLC,
+    hlc: Arc<uhlc::HLC>,
 
     sent_out_shared_memory: HashMap<DropToken, ShmemHandle>,
     drop_stream: DropStream,
@@ -67,10 +68,14 @@ impl DoraNode {
             dataflow_descriptor,
         } = node_config;
 
-        let event_stream = EventStream::init(dataflow_id, &node_id, &daemon_communication)
-            .wrap_err("failed to init event stream")?;
-        let drop_stream = DropStream::init(dataflow_id, &node_id, &daemon_communication)
-            .wrap_err("failed to init drop stream")?;
+        let hlc = Arc::new(uhlc::HLC::default());
+
+        let event_stream =
+            EventStream::init(dataflow_id, &node_id, &daemon_communication, hlc.clone())
+                .wrap_err("failed to init event stream")?;
+        let drop_stream =
+            DropStream::init(dataflow_id, &node_id, &daemon_communication, hlc.clone())
+                .wrap_err("failed to init drop stream")?;
         let control_channel = ControlChannel::init(dataflow_id, &node_id, &daemon_communication)
             .wrap_err("failed to init control channel")?;
 
@@ -78,7 +83,7 @@ impl DoraNode {
             id: node_id,
             node_config: run_config,
             control_channel,
-            hlc: uhlc::HLC::default(),
+            hlc,
             sent_out_shared_memory: HashMap::new(),
             drop_stream,
             cache: VecDeque::new(),

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -28,7 +28,7 @@ pub struct DoraNode {
     id: NodeId,
     node_config: NodeRunConfig,
     control_channel: ControlChannel,
-    hlc: Arc<uhlc::HLC>,
+    clock: Arc<uhlc::HLC>,
 
     sent_out_shared_memory: HashMap<DropToken, ShmemHandle>,
     drop_stream: DropStream,
@@ -68,22 +68,23 @@ impl DoraNode {
             dataflow_descriptor,
         } = node_config;
 
-        let hlc = Arc::new(uhlc::HLC::default());
+        let clock = Arc::new(uhlc::HLC::default());
 
         let event_stream =
-            EventStream::init(dataflow_id, &node_id, &daemon_communication, hlc.clone())
+            EventStream::init(dataflow_id, &node_id, &daemon_communication, clock.clone())
                 .wrap_err("failed to init event stream")?;
         let drop_stream =
-            DropStream::init(dataflow_id, &node_id, &daemon_communication, hlc.clone())
+            DropStream::init(dataflow_id, &node_id, &daemon_communication, clock.clone())
                 .wrap_err("failed to init drop stream")?;
-        let control_channel = ControlChannel::init(dataflow_id, &node_id, &daemon_communication)
-            .wrap_err("failed to init control channel")?;
+        let control_channel =
+            ControlChannel::init(dataflow_id, &node_id, &daemon_communication, clock.clone())
+                .wrap_err("failed to init control channel")?;
 
         let node = Self {
             id: node_id,
             node_config: run_config,
             control_channel,
-            hlc,
+            clock,
             sent_out_shared_memory: HashMap::new(),
             drop_stream,
             cache: VecDeque::new(),
@@ -143,7 +144,8 @@ impl DoraNode {
         if !self.node_config.outputs.contains(&output_id) {
             eyre::bail!("unknown output");
         }
-        let metadata = Metadata::from_parameters(self.hlc.new_timestamp(), parameters.into_owned());
+        let metadata =
+            Metadata::from_parameters(self.clock.new_timestamp(), parameters.into_owned());
 
         let (data, shmem) = match sample {
             Some(sample) => sample.finalize(),

--- a/binaries/daemon/src/coordinator.rs
+++ b/binaries/daemon/src/coordinator.rs
@@ -5,6 +5,7 @@ use crate::{
 use dora_core::{
     coordinator_messages::{CoordinatorRequest, RegisterResult},
     daemon_messages::{DaemonCoordinatorReply, Timestamped},
+    message::uhlc::HLC,
 };
 use eyre::{eyre, Context};
 use std::{io::ErrorKind, net::SocketAddr};
@@ -24,6 +25,7 @@ pub async fn register(
     addr: SocketAddr,
     machine_id: String,
     listen_socket: SocketAddr,
+    clock: &HLC,
 ) -> eyre::Result<impl Stream<Item = Timestamped<CoordinatorEvent>>> {
     let mut stream = TcpStream::connect(addr)
         .await
@@ -31,10 +33,13 @@ pub async fn register(
     stream
         .set_nodelay(true)
         .wrap_err("failed to set TCP_NODELAY")?;
-    let register = serde_json::to_vec(&CoordinatorRequest::Register {
-        dora_version: env!("CARGO_PKG_VERSION").to_owned(),
-        machine_id,
-        listen_socket,
+    let register = serde_json::to_vec(&Timestamped {
+        inner: CoordinatorRequest::Register {
+            dora_version: env!("CARGO_PKG_VERSION").to_owned(),
+            machine_id,
+            listen_socket,
+        },
+        timestamp: clock.new_timestamp(),
     })?;
     tcp_send(&mut stream, &register)
         .await
@@ -42,9 +47,13 @@ pub async fn register(
     let reply_raw = tcp_receive(&mut stream)
         .await
         .wrap_err("failed to register reply from dora-coordinator")?;
-    let result: RegisterResult = serde_json::from_slice(&reply_raw)
+    let result: Timestamped<RegisterResult> = serde_json::from_slice(&reply_raw)
         .wrap_err("failed to deserialize dora-coordinator reply")?;
-    result.to_result()?;
+    result.inner.to_result()?;
+    if let Err(err) = clock.update_with_timestamp(&result.timestamp) {
+        tracing::warn!("failed to update timestamp after register: {err}");
+    }
+
     tracing::info!("Connected to dora-coordinator at {:?}", addr);
 
     let (tx, rx) = mpsc::channel(1);

--- a/binaries/daemon/src/coordinator.rs
+++ b/binaries/daemon/src/coordinator.rs
@@ -67,11 +67,14 @@ pub async fn register(
                     continue;
                 }
             };
-            let Timestamped { event, timestamp } = event;
+            let Timestamped {
+                inner: event,
+                timestamp,
+            } = event;
             let (reply_tx, reply_rx) = oneshot::channel();
             match tx
                 .send(Timestamped {
-                    event: CoordinatorEvent { event, reply_tx },
+                    inner: CoordinatorEvent { event, reply_tx },
                     timestamp,
                 })
                 .await

--- a/binaries/daemon/src/inter_daemon.rs
+++ b/binaries/daemon/src/inter_daemon.rs
@@ -46,7 +46,7 @@ impl InterDaemonConnection {
 pub async fn send_inter_daemon_event(
     target_machines: &[String],
     inter_daemon_connections: &mut BTreeMap<String, InterDaemonConnection>,
-    event: &InterDaemonEvent,
+    event: &Timestamped<InterDaemonEvent>,
 ) -> eyre::Result<()> {
     let message = bincode::serialize(event).wrap_err("failed to serialize InterDaemonEvent")?;
     for target_machine in target_machines {

--- a/binaries/daemon/src/main.rs
+++ b/binaries/daemon/src/main.rs
@@ -63,7 +63,7 @@ async fn run() -> eyre::Result<()> {
             } else {
                 tracing::info!("received ctrlc signal");
                 let event = Timestamped {
-                    event: Event::CtrlC,
+                    inner: Event::CtrlC,
                     timestamp: clock.new_timestamp(),
                 };
                 if ctrl_c_tx.blocking_send(event).is_err() {

--- a/binaries/daemon/src/node_communication/mod.rs
+++ b/binaries/daemon/src/node_communication/mod.rs
@@ -181,7 +181,7 @@ impl Listener {
             tracing::warn!("failed to update HLC: {err}");
         }
 
-        match message.event {
+        match message.inner {
             DaemonRequest::Register {
                 dataflow_id,
                 node_id,
@@ -299,7 +299,7 @@ impl Listener {
 
         // iterate over queued events, newest first
         for event in self.queue.iter_mut().rev() {
-            let Some(Timestamped { event: NodeEvent::Input { id, data, .. }, ..}) = event.as_mut() else {
+            let Some(Timestamped { inner: NodeEvent::Input { id, data, .. }, ..}) = event.as_mut() else {
                 continue;
             };
             match queue_size_remaining.get_mut(id) {
@@ -336,7 +336,7 @@ impl Listener {
         if let Err(err) = self.clock.update_with_timestamp(&timestamp) {
             tracing::warn!("failed to update HLC: {err}");
         }
-        match message.event {
+        match message.inner {
             DaemonRequest::Register { .. } => {
                 let reply = DaemonReply::Result(Err("unexpected register message".into()));
                 self.send_reply(reply, connection)
@@ -484,7 +484,7 @@ impl Listener {
                 },
             };
             let event = Timestamped {
-                event,
+                inner: event,
                 timestamp: self.clock.new_timestamp(),
             };
             self.daemon_tx
@@ -508,7 +508,7 @@ impl Listener {
             event,
         };
         let event = Timestamped {
-            event,
+            inner: event,
             timestamp: self.clock.new_timestamp(),
         };
         self.daemon_tx

--- a/binaries/daemon/src/spawn.rs
+++ b/binaries/daemon/src/spawn.rs
@@ -239,7 +239,7 @@ pub async fn spawn_node(
         }
         .into();
         let event = Timestamped {
-            event,
+            inner: event,
             timestamp: clock.new_timestamp(),
         };
         let _ = daemon_tx.send(event).await;

--- a/examples/c-dataflow/sink.c
+++ b/examples/c-dataflow/sink.c
@@ -12,9 +12,8 @@ int main()
     {
         fprintf(stderr, "failed to init dora context\n");
         return -1;
-
-        printf("[c sink] dora context initialized\n");
     }
+    printf("[c sink] dora context initialized\n");
 
     while (1)
     {
@@ -39,7 +38,7 @@ int main()
 
             printf("[c sink] received input `");
             fwrite(id, id_len, 1, stdout);
-            printf("` with data: %s\n", data);
+            printf("` with data: %.*s\n", (int)data_len, data);
         }
         else if (ty == DoraEventType_InputClosed)
         {

--- a/libraries/core/src/daemon_messages.rs
+++ b/libraries/core/src/daemon_messages.rs
@@ -139,7 +139,7 @@ pub enum DaemonReply {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Timestamped<T> {
-    pub event: T,
+    pub inner: T,
     pub timestamp: uhlc::Timestamp,
 }
 

--- a/libraries/core/src/daemon_messages.rs
+++ b/libraries/core/src/daemon_messages.rs
@@ -9,7 +9,7 @@ use crate::{
     config::{DataId, NodeId, NodeRunConfig, OperatorId},
     descriptor::{Descriptor, OperatorDefinition, ResolvedNode},
 };
-use dora_message::Metadata;
+use dora_message::{uhlc, Metadata};
 use uuid::Uuid;
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -132,9 +132,15 @@ type SharedMemoryId = String;
 pub enum DaemonReply {
     Result(Result<(), String>),
     PreparedMessage { shared_memory_id: SharedMemoryId },
-    NextEvents(Vec<NodeEvent>),
-    NextDropEvents(Vec<NodeDropEvent>),
+    NextEvents(Vec<Timestamped<NodeEvent>>),
+    NextDropEvents(Vec<Timestamped<NodeDropEvent>>),
     Empty,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Timestamped<T> {
+    pub event: T,
+    pub timestamp: uhlc::Timestamp,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
Adds a [hybrid logical clock](https://docs.rs/uhlc/0.6.0/uhlc/struct.HLC.html) to all nodes, daemons, and to the coordinator. Whenever an event is sent, the current timestamp is included. This allows receivers to update their logical clocks.

By adding an [`uhlc::Timestamp`](https://docs.rs/uhlc/0.6.0/uhlc/struct.Timestamp.html) to each event, we define a global order for all events in the distributed system. This is a requirement for implementing a log&replay feature in the future.