### PR TITLE
Update to Rust v1.70

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.68"
+channel = "1.70"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
The new [sparse crates.io protocol](https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html#sparse-by-default-for-cratesio) should speed up the build process.