### PR TITLE
Don't recompile the `dora-operator-api-c` crate on every build/run

### DIFF
--- a/apis/c/operator/build.rs
+++ b/apis/c/operator/build.rs
@@ -3,4 +3,9 @@ use std::path::Path;
 fn main() {
     dora_operator_api_types::generate_headers(Path::new("operator_types.h"))
         .expect("failed to create operator_api.h");
+
+    // don't rebuild on changes (otherwise we rebuild on every run as we're
+    // writing the `operator_types.h` file; cargo will still rerun this script
+    // when the `dora_operator_api_types` crate changes)
+    println!("cargo:rerun-if-changed=");
 }


### PR DESCRIPTION
By default, cargo reruns build scripts whenever any file of the package changes. This led to lots of unnecessary rebuilds of the `dora-operator-api-c` crate. The reason is that crate has a build script that updates the `operator_types.h` file, which is considered as a modification by cargo. So it reruns the build script on the next `cargo build` or `cargo run` command, which leads to subsequent rebuilds of all crates that depend on `dora-operator-api-c`.

This commit fixes this issue by instructing cargo to never rerun the build script (through a special `println`). This way the package is considered 'fresh' on rebuilds. Cargo will still rerun the build script when the `dora_operator_api_types` crate changes, so the `operator_types.h` file still stays up-to-date.
