### PR TITLE
Remove deprecated `proc_macros` feature from `safer-ffi` dependency

### DIFF
--- a/apis/rust/operator/types/Cargo.toml
+++ b/apis/rust/operator/types/Cargo.toml
@@ -10,4 +10,4 @@ license.workspace = true
 
 [dependencies.safer-ffi]
 version = "0.1.0-rc1"
-features = ["proc_macros", "headers"]
+features = ["headers"]


### PR DESCRIPTION
The `proc-macro` feature is now a built-in.
