### PR TITLE
Implement `Stream` for `EventStream`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1420,6 +1420,7 @@ dependencies = [
  "dora-tracing",
  "eyre",
  "flume",
+ "futures",
  "once_cell",
  "serde",
  "serde_json",

--- a/apis/rust/node/Cargo.toml
+++ b/apis/rust/node/Cargo.toml
@@ -27,6 +27,7 @@ bincode = "1.3.3"
 shared_memory = "0.12.0"
 dora-tracing = { workspace = true, optional = true }
 arrow = "35.0.0"
+futures = "0.3.28"
 
 [dev-dependencies]
 tokio = { version = "1.24.2", features = ["rt"] }


### PR DESCRIPTION
The [`Stream`](https://docs.rs/futures/0.3.28/futures/prelude/trait.Stream.html) trait is the asynchronous equivalent of iterators. By implementing it, we allow asynchronous nodes to use the various [combinator methods](https://docs.rs/futures/0.3.28/futures/stream/trait.StreamExt.html) instead of just the `recv_async` method.

To implement the trait, we convert the [`flume::Receiver`](https://docs.rs/flume/0.10.14/flume/struct.Receiver.html) into a async stream by using `into_stream` directly when the `EventStream` is constructed. I also tried  keeping the `flume::Receiver` and only using [`Receiver::stream`](https://docs.rs/flume/0.10.14/flume/struct.Receiver.html#method.stream) to get a temporary stream instance when needed, but this doesn't work because it does not keep the waker around (and thus never wakes it).