### PR TITLE
Add convenience function `send_output_bytes`

### DIFF
--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -133,6 +133,18 @@ impl DoraNode {
         self.send_output_sample(output_id, parameters, Some(sample))
     }
 
+    pub fn send_output_bytes(
+        &mut self,
+        output_id: DataId,
+        parameters: MetadataParameters,
+        data_len: usize,
+        data: &[u8],
+    ) -> eyre::Result<()> {
+        self.send_output(output_id, parameters, data_len, |sample| {
+            sample.copy_from_slice(data)
+        })
+    }
+
     pub fn send_output_sample(
         &mut self,
         output_id: DataId,


### PR DESCRIPTION
It's common to send a byte array that already exists, so it makes sense to provide a convenience function for this use case.
