### PR TITLE
Replace unmaintained `atty` crate with `std::io::IsTerminal`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,7 +1270,6 @@ dependencies = [
 name = "dora-cli"
 version = "0.2.3"
 dependencies = [
- "atty",
  "bat",
  "clap 4.3.0",
  "communication-layer-request-reply",

--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -27,7 +27,6 @@ serde_yaml = "0.9.11"
 webbrowser = "0.8.3"
 serde_json = "1.0.86"
 termcolor = "1.1.3"
-atty = "0.2.14"
 uuid = { version = "1.2.1", features = ["v4", "serde"] }
 inquire = "0.5.2"
 communication-layer-request-reply = { workspace = true }

--- a/binaries/cli/src/check.rs
+++ b/binaries/cli/src/check.rs
@@ -2,13 +2,13 @@ use crate::connect_to_coordinator;
 use communication_layer_request_reply::TcpRequestReplyConnection;
 use dora_core::topics::{ControlRequest, ControlRequestReply};
 use eyre::{bail, Context};
-use std::io::Write;
+use std::io::{IsTerminal, Write};
 use termcolor::{Color, ColorChoice, ColorSpec, WriteColor};
 
 pub fn check_environment() -> eyre::Result<()> {
     let mut error_occured = false;
 
-    let color_choice = if atty::is(atty::Stream::Stdout) {
+    let color_choice = if std::io::stdout().is_terminal() {
         ColorChoice::Auto
     } else {
         ColorChoice::Never


### PR DESCRIPTION
There is a current vulnerability (low severity) and the crate appears to be unmaintained. Since Rust 1.70, we should be able to use the new `IsTerminal` trait of the standard library instead.
