### PR TITLE
Adding newline between lines within logs for formatting

### DIFF
--- a/binaries/daemon/src/spawn.rs
+++ b/binaries/daemon/src/spawn.rs
@@ -282,6 +282,10 @@ pub async fn spawn_node(
                 .write_all(message.as_bytes())
                 .await
                 .map_err(|err| error!("Could not log {message} to file due to {err}"));
+            let _ = file
+                .write(b"\n")
+                .await
+                .map_err(|err| error!("Could not add newline to log file due to {err}"));
             let formatted: String = message.lines().map(|l| format!("      {l}\n")).collect();
             debug!("{dataflow_id}/{} logged:\n{formatted}", node.id.clone());
             // Make sure that all data has been synced to disk.


### PR DESCRIPTION
Newline between each line in the log file seems to have been removed when fixing logs in the CI.

I have readded it, so that logs look like this:

```bash
─────┬───────────────────────────────────────────────────────────────
     │ Logs from webcam.
─────┬───────────────────────────────────────────────────────────────
   1 │ Traceback (most recent call last):
   2 │   File "<string>", line 1, in <module>
   3 │ RuntimeError: Dora Runtime raised an error.
   4 │
   5 │ Caused by:
   6 │    0: main task failed
   7 │    1: failed to init an operator
   8 │    2: failed to init python operator
   9 │    3: Traceback (most recent call last):
  10 │         File "/home/peter/abc_project/webcam.py", line 7, in <module>
  11 │           import cv2
  12 │
  13 │
  14 │       ModuleNotFoundError: No module named 'cv2'
  15 │
  16 │ Location:
  17 │     binaries/runtime/src/operator/python.rs:28:9
─────┴───────────────────────────────────────────────────────────
```

instead of
```bash
─────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
     │ Logs from webcam.
─────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1 │ Exception ignored in: <function Operator.__del__ at 0x7fa0339ff7f0>Traceback (most recent call last):  File "/home/peter/abc_project/webcam.py", line 53, in __del__    self.video_capture.release()AttributeError: 'Operator' object has no attribute 'video_capture'Traceback (most recent call last):  File "<string>", line 1, in <module>RuntimeError: Dora Runtime raised an error.Caused by:   0: main task failed   1: failed to init an operator   2: failed to init python operator   3: Traceback (most recent call last):        File "<string>", line 1, in <module>        File "/home/peter/abc_project/webcam.py", line 22, in __init__          self.video_capture = cv2.VideoCapture(0)      AttributeError: module 'cv2' has no attribute 'VideoCapture'Location:    binaries/runtime/src/operator/python.rs:28:9
─────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```


