### PR TITLE
Use read_line instead of next_line in stderr

### DIFF
--- a/binaries/cli/src/logs.rs
+++ b/binaries/cli/src/logs.rs
@@ -31,9 +31,9 @@ pub fn logs(
     };
 
     PrettyPrinter::new()
-        .header(true)
-        .grid(true)
-        .line_numbers(true)
+        .header(false)
+        .grid(false)
+        .line_numbers(false)
         .paging_mode(bat::PagingMode::QuitIfOneScreen)
         .inputs(vec![Input::from_bytes(&logs)
             .name("Logs")

--- a/binaries/cli/src/template/rust/mod.rs
+++ b/binaries/cli/src/template/rust/mod.rs
@@ -93,9 +93,7 @@ fn create_operator(
     let dep = if use_path_deps {
         r#"dora-operator-api = { path = "../../apis/rust/operator" }"#.to_string()
     } else {
-        format!(
-            r#"dora-operator-api = {{ git = "https://github.com/dora-rs/dora.git", tag = "v{VERSION}" }}"#
-        )
+        format!(r#"dora-operator-api = "{VERSION}""#)
     };
     let cargo_toml = CARGO_TOML
         .replace("___name___", &name)
@@ -143,9 +141,7 @@ fn create_custom_node(
     let dep = if use_path_deps {
         r#"dora-node-api = { path = "../../apis/rust/node" }"#.to_string()
     } else {
-        format!(
-            r#"dora-node-api = {{ git = "https://github.com/dora-rs/dora.git", tag = "v{VERSION}" }}"#
-        )
+        format!(r#"dora-node-api = "{VERSION}""#)
     };
     let cargo_toml = CARGO_TOML
         .replace("___name___", &name)

--- a/binaries/daemon/src/spawn.rs
+++ b/binaries/daemon/src/spawn.rs
@@ -244,20 +244,47 @@ pub async fn spawn_node(
         }
     });
 
-    let mut stderr_lines =
-        (tokio::io::BufReader::new(child.stderr.take().expect("failed to take stderr"))).lines();
+    let mut child_stderr =
+        tokio::io::BufReader::new(child.stderr.take().expect("failed to take stderr"));
 
     // Stderr listener stream
     let stderr_tx = tx.clone();
+    let node_id = node.id.clone();
     tokio::spawn(async move {
-        while let Ok(Some(line)) = stderr_lines.next_line().await {
-            let sent = stderr_tx.send(line.clone()).await;
+        let mut buffer = String::new();
+        let mut finished = false;
+        while !finished {
+            finished = match child_stderr
+                .read_line(&mut buffer)
+                .await
+                .wrap_err("failed to read stderr line from spawned node")
+            {
+                Ok(0) => true,
+                Ok(_) => false,
+                Err(err) => {
+                    tracing::warn!("{err:?}");
+                    true
+                }
+            };
+
+            if buffer.starts_with("Traceback (most recent call last):") {
+                if !finished {
+                    continue;
+                } else {
+                    tracing::error!("{dataflow_id}/{}: \n{buffer}", node_id);
+                }
+            }
+
+            // send the buffered lines
+            let lines = std::mem::take(&mut buffer);
+            let sent = stderr_tx.send(lines.clone()).await;
             if sent.is_err() {
-                eprintln!("Could not log: {line}");
+                println!("Could not log: {lines}");
             }
         }
     });
 
+    let node_id = node.id.clone();
     let (log_finish_tx, log_finish_rx) = oneshot::channel();
     tokio::spawn(async move {
         let exit_status = NodeExitStatus::from(child.wait().await);

--- a/binaries/daemon/src/spawn.rs
+++ b/binaries/daemon/src/spawn.rs
@@ -282,10 +282,6 @@ pub async fn spawn_node(
                 .write_all(message.as_bytes())
                 .await
                 .map_err(|err| error!("Could not log {message} to file due to {err}"));
-            let _ = file
-                .write(b"\n")
-                .await
-                .map_err(|err| error!("Could not add newline to log file due to {err}"));
             let formatted: String = message.lines().map(|l| format!("      {l}\n")).collect();
             debug!("{dataflow_id}/{} logged:\n{formatted}", node.id.clone());
             // Make sure that all data has been synced to disk.


### PR DESCRIPTION
By using read_line, we make stderr behave similarly to stdout.

`stderr` that use `next_line` use to not add newline at the end of each line which made me open #320. 
This made `stdout` that use `read_line` have two newlines. This was introduced here: #300

This PR fix this issue.

Moreover,  I have added functionality in the stderr thread to retrieve python traceback and output it as one block in the DEBUG traces but also push it as an ERROR trace in daemon so that user don't have to check log file.

This is done by replicating the functionality in stdout in stderr and retrieve the full traceback for python nodes. 


