### PR TITLE
Removing patchelf

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -17,7 +17,11 @@ env:
 jobs:
   examples:
     name: "Python Examples"
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3
 

--- a/examples/python-dataflow/run.sh
+++ b/examples/python-dataflow/run.sh
@@ -1,9 +1,8 @@
 set -e
 
-python3 -m venv .env
-. $(pwd)/.env/bin/activate
+python3 -m venv ../.env
+. $(pwd)/../.env/bin/activate
 # Dev dependencies
-pip install patchelf
 pip install maturin
 cd ../../apis/python/node
 maturin develop

--- a/examples/python-operator-dataflow/run.sh
+++ b/examples/python-operator-dataflow/run.sh
@@ -4,7 +4,6 @@ python3 -m venv .env
 . $(pwd)/.env/bin/activate
 # Dev dependencies
 pip install maturin
-pip install patchelf
 cd ../../apis/python/node
 maturin develop
 cd ../../../examples/python-operator-dataflow


### PR DESCRIPTION
This PR:
- removes `patchelf` that should not be necessary. `patchelf` fix broken links but I believe that this should not happen with `maturin develop`.
- link the venv of `python-dataflow` to the one in `python-operator-dataflow` to avoid using too much memory space.
- Add `macos` to the Python CI to avoid #329 