### PR TITLE
Improve CI speed and caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - merge-ci-jobs
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         platform: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.platform }}
-    timeout-minutes: 90
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - uses: r7kamura/rust-problem-matchers@v1.1.0
@@ -37,6 +37,26 @@ jobs:
         run: cargo build --all
       - name: "Test"
         run: cargo test --all
+
+  # Run examples as separate job because otherwise we will exhaust the disk
+  # space of the GitHub action runners.
+  examples:
+    name: "Examples"
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.platform }}
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v3
+      - uses: r7kamura/rust-problem-matchers@v1.1.0
+      - run: cargo --version --verbose
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          # only save caches for `main` branch
+          # save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # general examples
       - name: "Build examples"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,6 @@ jobs:
 
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
-      - uses: Swatinem/rust-cache@v2
 
       - name: "Clippy"
         run: cargo clippy --all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
 
       # ROS2 bridge examples
       - uses: ros-tooling/setup-ros@v0.6
+        if: runner.os == 'Linux'
         with:
           required-ros-distributions: humble
       - run: 'source /opt/ros/humble/setup.bash && echo AMENT_PREFIX_PATH=${AMENT_PREFIX_PATH} >> "$GITHUB_ENV"'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         platform: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.platform }}
-    timeout-minutes: 30
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v3
       - uses: r7kamura/rust-problem-matchers@v1.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
         platform: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.platform }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
       - uses: r7kamura/rust-problem-matchers@v1.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ jobs:
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          # only save caches for `main` branch
+          # save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: "Check"
         run: cargo check --all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,23 @@ jobs:
         run: cargo build --all
       - name: "Test"
         run: cargo test --all
+  cli-test:
+    name: "CLI Test"
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.platform }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v3
+      - uses: r7kamura/rust-problem-matchers@v1.1.0
+      - run: cargo --version --verbose
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          # only save caches for `main` branch
+          # save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # CLI tests
       - name: "Build cli and binaries"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,63 +36,6 @@ jobs:
         run: cargo build --all
       - name: "Test"
         run: cargo test --all
-  cli-test:
-    name: "CLI Test"
-    strategy:
-      matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
-      fail-fast: false
-    runs-on: ${{ matrix.platform }}
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v3
-      - uses: r7kamura/rust-problem-matchers@v1.1.0
-      - run: cargo --version --verbose
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-provider: buildjet
-          cache-on-failure: true
-          # only save caches for `main` branch
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-
-      # CLI tests
-      - name: "Build cli and binaries"
-        timeout-minutes: 45
-        # fail-fast by using bash shell explictly
-        shell: bash
-        run: |
-          cargo install --path binaries/coordinator --locked
-          cargo install --path binaries/daemon --locked
-          cargo install --path binaries/cli --locked
-      - name: "Test CLI"
-        timeout-minutes: 30
-        # fail-fast by using bash shell explictly
-        shell: bash
-        run: |
-          dora-cli up
-          dora-cli list
-
-          # Test Rust template Project
-          dora-cli new test_rust_project --internal-create-with-path-dependencies
-          cd test_rust_project
-          cargo build --all
-          dora-cli start dataflow.yml --name ci-rust-test
-          sleep 10
-          dora-cli stop --name ci-rust-test
-          cd ..
-
-          # Test Python template Project
-          pip3 install maturin
-          maturin build -m apis/python/node/Cargo.toml
-          pip3 install target/wheels/*
-          dora-cli new test_python_project --lang python --internal-create-with-path-dependencies
-          cd test_python_project
-          dora-cli start dataflow.yml --name ci-python-test
-          sleep 10
-          dora-cli stop --name ci-python-test
-          cd ..
-
-          dora-cli destroy
 
   # Run examples as separate job because otherwise we will exhaust the disk
   # space of the GitHub action runners.
@@ -204,6 +147,64 @@ jobs:
       - name: "Benchmark example"
         timeout-minutes: 30
         run: cargo run --example benchmark --release
+
+  cli-test:
+    name: "CLI Test"
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.platform }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v3
+      - uses: r7kamura/rust-problem-matchers@v1.1.0
+      - run: cargo --version --verbose
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-provider: buildjet
+          cache-on-failure: true
+          # only save caches for `main` branch
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      # CLI tests
+      - name: "Build cli and binaries"
+        timeout-minutes: 45
+        # fail-fast by using bash shell explictly
+        shell: bash
+        run: |
+          cargo install --path binaries/coordinator --locked
+          cargo install --path binaries/daemon --locked
+          cargo install --path binaries/cli --locked
+      - name: "Test CLI"
+        timeout-minutes: 30
+        # fail-fast by using bash shell explictly
+        shell: bash
+        run: |
+          dora-cli up
+          dora-cli list
+
+          # Test Rust template Project
+          dora-cli new test_rust_project --internal-create-with-path-dependencies
+          cd test_rust_project
+          cargo build --all
+          dora-cli start dataflow.yml --name ci-rust-test
+          sleep 10
+          dora-cli stop --name ci-rust-test
+          cd ..
+
+          # Test Python template Project
+          pip3 install maturin
+          maturin build -m apis/python/node/Cargo.toml
+          pip3 install target/wheels/*
+          dora-cli new test_python_project --lang python --internal-create-with-path-dependencies
+          cd test_python_project
+          dora-cli start dataflow.yml --name ci-python-test
+          sleep 10
+          dora-cli stop --name ci-python-test
+          cd ..
+
+          dora-cli destroy
 
   clippy:
     name: "Clippy"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,20 +33,6 @@ jobs:
       - name: "Test"
         run: cargo test --all
 
-  examples:
-    name: "Examples"
-    strategy:
-      matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
-      fail-fast: false
-    runs-on: ${{ matrix.platform }}
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: r7kamura/rust-problem-matchers@v1.1.0
-      - run: cargo --version --verbose
-      - uses: Swatinem/rust-cache@v2
-
       - name: "Build examples"
         timeout-minutes: 30
         run: cargo build --examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,22 +34,19 @@ jobs:
       - name: "Test"
         run: cargo test --all
 
+      # general examples
       - name: "Build examples"
         timeout-minutes: 30
         run: cargo build --examples
-
       - name: "Rust Dataflow example"
         timeout-minutes: 30
         run: cargo run --example rust-dataflow
-
       - name: "Multiple Daemons example"
         timeout-minutes: 30
         run: cargo run --example multiple-daemons
-
       - name: "Benchmark example"
         timeout-minutes: 30
         run: cargo run --example benchmark --release
-
       - name: "C Dataflow example"
         timeout-minutes: 15
         run: cargo run --example c-dataflow
@@ -57,6 +54,19 @@ jobs:
         timeout-minutes: 15
         run: cargo run --example cxx-dataflow
 
+      # python examples
+      - uses: actions/setup-python@v2
+        if: runner.os == 'Linux' || runner.os == 'macOS'
+        with:
+          python-version: "3.10"
+      - name: "Python Dataflow example"
+        if: runner.os == 'Linux' || runner.os == 'macOS'
+        run: cargo run --example python-dataflow
+      - name: "Python Operator Dataflow example"
+        if: runner.os == 'Linux' || runner.os == 'macOS'
+        run: cargo run --example python-operator-dataflow
+
+      # ROS2 bridge examples
       - uses: ros-tooling/setup-ros@v0.6
         with:
           required-ros-distributions: humble
@@ -70,7 +80,16 @@ jobs:
         run: |
           source /opt/ros/humble/setup.bash && ros2 run turtlesim turtlesim_node &
           cargo run --example rust-ros2-dataflow --features="ros2-examples"
+      - name: "python-ros2-dataflow"
+        timeout-minutes: 30
+        if: runner.os == 'Linux'
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: |
+          source /opt/ros/humble/setup.bash && ros2 run turtlesim turtlesim_node &
+          cargo run --example python-ros2-dataflow --features="ros2-examples"
 
+      # CLI tests
       - name: "Build cli and binaries"
         timeout-minutes: 45
         # fail-fast by using bash shell explictly
@@ -79,7 +98,6 @@ jobs:
           cargo install --path binaries/coordinator
           cargo install --path binaries/daemon
           cargo install --path binaries/cli
-
       - name: "Test CLI"
         timeout-minutes: 30
         # fail-fast by using bash shell explictly
@@ -109,44 +127,6 @@ jobs:
           cd ..
 
           dora-cli destroy
-
-  python-examples:
-    name: "Python Examples"
-    strategy:
-      matrix:
-        platform: [ubuntu-latest, macos-latest]
-      fail-fast: false
-    runs-on: ${{ matrix.platform }}
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-python@v2
-        with:
-          python-version: "3.10"
-
-      - uses: r7kamura/rust-problem-matchers@v1.1.0
-      - run: cargo --version --verbose
-      - uses: Swatinem/rust-cache@v2
-
-      - name: "Python Dataflow example"
-        run: cargo run --example python-dataflow
-
-      - name: "Python Operator Dataflow example"
-        run: cargo run --example python-operator-dataflow
-
-      - uses: ros-tooling/setup-ros@v0.6
-        with:
-          required-ros-distributions: humble
-      - run: 'source /opt/ros/humble/setup.bash && echo AMENT_PREFIX_PATH=${AMENT_PREFIX_PATH} >> "$GITHUB_ENV"'
-        if: runner.os == 'Linux'
-      - name: "python-ros2-dataflow"
-        timeout-minutes: 30
-        if: runner.os == 'Linux'
-        env:
-          QT_QPA_PLATFORM: offscreen
-        run: |
-          source /opt/ros/humble/setup.bash && ros2 run turtlesim turtlesim_node &
-          cargo run --example python-ros2-dataflow --features="ros2-examples"
 
   clippy:
     name: "Clippy"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,45 @@ jobs:
       - name: "Test"
         run: cargo test --all
 
+      # CLI tests
+      - name: "Build cli and binaries"
+        timeout-minutes: 45
+        # fail-fast by using bash shell explictly
+        shell: bash
+        run: |
+          cargo install --path binaries/coordinator
+          cargo install --path binaries/daemon
+          cargo install --path binaries/cli
+      - name: "Test CLI"
+        timeout-minutes: 30
+        # fail-fast by using bash shell explictly
+        shell: bash
+        run: |
+          dora-cli up
+          dora-cli list
+
+          # Test Rust template Project
+          dora-cli new test_rust_project --internal-create-with-path-dependencies
+          cd test_rust_project
+          cargo build --all
+          dora-cli start dataflow.yml --name ci-rust-test
+          sleep 10
+          dora-cli stop --name ci-rust-test
+          cd ..
+
+          # Test Python template Project
+          pip3 install maturin
+          maturin build -m apis/python/node/Cargo.toml
+          pip3 install target/wheels/*
+          dora-cli new test_python_project --lang python --internal-create-with-path-dependencies
+          cd test_python_project
+          dora-cli start dataflow.yml --name ci-python-test
+          sleep 10
+          dora-cli stop --name ci-python-test
+          cd ..
+
+          dora-cli destroy
+
   # Run examples as separate job because otherwise we will exhaust the disk
   # space of the GitHub action runners.
   examples:
@@ -86,68 +125,43 @@ jobs:
         if: runner.os == 'Linux' || runner.os == 'macOS'
         run: cargo run --example python-operator-dataflow
 
-      # ROS2 bridge examples
+  # ROS2 bridge examples
+  ros2-bridge-examples:
+    name: "ROS2 Bridge Examples"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v3
+      - uses: r7kamura/rust-problem-matchers@v1.1.0
+      - run: cargo --version --verbose
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          # only save caches for `main` branch
+          # save-if: ${{ github.ref == 'refs/heads/main' }}
+
       - uses: ros-tooling/setup-ros@v0.6
-        if: runner.os == 'Linux'
         with:
           required-ros-distributions: humble
       - run: 'source /opt/ros/humble/setup.bash && echo AMENT_PREFIX_PATH=${AMENT_PREFIX_PATH} >> "$GITHUB_ENV"'
-        if: runner.os == 'Linux'
       - name: "Rust ROS2 Bridge example"
         timeout-minutes: 30
-        if: runner.os == 'Linux'
         env:
           QT_QPA_PLATFORM: offscreen
         run: |
           source /opt/ros/humble/setup.bash && ros2 run turtlesim turtlesim_node &
           cargo run --example rust-ros2-dataflow --features="ros2-examples"
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
       - name: "python-ros2-dataflow"
         timeout-minutes: 30
-        if: runner.os == 'Linux'
         env:
           QT_QPA_PLATFORM: offscreen
         run: |
           source /opt/ros/humble/setup.bash && ros2 run turtlesim turtlesim_node &
           cargo run --example python-ros2-dataflow --features="ros2-examples"
 
-      # CLI tests
-      - name: "Build cli and binaries"
-        timeout-minutes: 45
-        # fail-fast by using bash shell explictly
-        shell: bash
-        run: |
-          cargo install --path binaries/coordinator
-          cargo install --path binaries/daemon
-          cargo install --path binaries/cli
-      - name: "Test CLI"
-        timeout-minutes: 30
-        # fail-fast by using bash shell explictly
-        shell: bash
-        run: |
-          dora-cli up
-          dora-cli list
-
-          # Test Rust template Project
-          dora-cli new test_rust_project --internal-create-with-path-dependencies
-          cd test_rust_project
-          cargo build --all
-          dora-cli start dataflow.yml --name ci-rust-test
-          sleep 10
-          dora-cli stop --name ci-rust-test
-          cd ..
-
-          # Test Python template Project
-          pip3 install maturin
-          maturin build -m apis/python/node/Cargo.toml
-          pip3 install target/wheels/*
-          dora-cli new test_python_project --lang python --internal-create-with-path-dependencies
-          cd test_python_project
-          dora-cli start dataflow.yml --name ci-python-test
-          sleep 10
-          dora-cli stop --name ci-python-test
-          cd ..
-
-          dora-cli destroy
   bench:
     name: "Bench"
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,11 @@ jobs:
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
+        with:
+          cache-provider: buildjet
+          cache-on-failure: true
+          # only save caches for `main` branch
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - run: cargo install cargo-lichking
       - name: "Check dependency licenses"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           cache-provider: buildjet
           cache-on-failure: true
           # only save caches for `main` branch
-          # save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: "Check"
         run: cargo check --all
@@ -53,7 +53,7 @@ jobs:
           cache-provider: buildjet
           cache-on-failure: true
           # only save caches for `main` branch
-          # save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # CLI tests
       - name: "Build cli and binaries"
@@ -113,7 +113,7 @@ jobs:
           cache-provider: buildjet
           cache-on-failure: true
           # only save caches for `main` branch
-          # save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # general examples
       - name: "Build examples"
@@ -158,7 +158,7 @@ jobs:
           cache-provider: buildjet
           cache-on-failure: true
           # only save caches for `main` branch
-          # save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - uses: ros-tooling/setup-ros@v0.6
         with:
@@ -199,7 +199,7 @@ jobs:
           cache-provider: buildjet
           cache-on-failure: true
           # only save caches for `main` branch
-          # save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: "Benchmark example"
         timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
         with:
+          cache-provider: buildjet
           cache-on-failure: true
           # only save caches for `main` branch
           # save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -50,6 +51,7 @@ jobs:
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
         with:
+          cache-provider: buildjet
           cache-on-failure: true
           # only save caches for `main` branch
           # save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -109,6 +111,7 @@ jobs:
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
         with:
+          cache-provider: buildjet
           cache-on-failure: true
           # only save caches for `main` branch
           # save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -153,6 +156,7 @@ jobs:
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
         with:
+          cache-provider: buildjet
           cache-on-failure: true
           # only save caches for `main` branch
           # save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -193,6 +197,7 @@ jobs:
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
         with:
+          cache-provider: buildjet
           cache-on-failure: true
           # only save caches for `main` branch
           # save-if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
 
 env:
   RUST_LOG: trace
-  CARGO_TERM_COLOR: always
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
         timeout-minutes: 30
         run: cargo run --example benchmark --release
 
-  cli-test:
+  CLI:
     name: "CLI Test"
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,59 +71,6 @@ jobs:
           source /opt/ros/humble/setup.bash && ros2 run turtlesim turtlesim_node &
           cargo run --example rust-ros2-dataflow --features="ros2-examples"
 
-  python-examples:
-    name: "Python Examples"
-    strategy:
-      matrix:
-        platform: [ubuntu-latest, macos-latest]
-      fail-fast: false
-    runs-on: ${{ matrix.platform }}
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-python@v2
-        with:
-          python-version: "3.10"
-
-      - uses: r7kamura/rust-problem-matchers@v1.1.0
-      - run: cargo --version --verbose
-      - uses: Swatinem/rust-cache@v2
-
-      - name: "Python Dataflow example"
-        run: cargo run --example python-dataflow
-
-      - name: "Python Operator Dataflow example"
-        run: cargo run --example python-operator-dataflow
-
-      - uses: ros-tooling/setup-ros@v0.6
-        with:
-          required-ros-distributions: humble
-      - run: 'source /opt/ros/humble/setup.bash && echo AMENT_PREFIX_PATH=${AMENT_PREFIX_PATH} >> "$GITHUB_ENV"'
-        if: runner.os == 'Linux'
-      - name: "python-ros2-dataflow"
-        timeout-minutes: 30
-        if: runner.os == 'Linux'
-        env:
-          QT_QPA_PLATFORM: offscreen
-        run: |
-          source /opt/ros/humble/setup.bash && ros2 run turtlesim turtlesim_node &
-          cargo run --example python-ros2-dataflow --features="ros2-examples"
-
-
-  CLI:
-    name: "CLI Test"
-    strategy:
-      matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
-      fail-fast: false
-    runs-on: ${{ matrix.platform }}
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: r7kamura/rust-problem-matchers@v1.1.0
-      - run: cargo --version --verbose
-      - uses: Swatinem/rust-cache@v2
-
       - name: "Build cli and binaries"
         timeout-minutes: 45
         # fail-fast by using bash shell explictly
@@ -163,20 +110,43 @@ jobs:
 
           dora-cli destroy
 
-  examples-remote:
-    name: "Examples (Remote)"
-    runs-on: ubuntu-latest
+  python-examples:
+    name: "Python Examples"
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
 
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
 
-      - name: "Remote Rust Dataflow example"
-        if: false # skip this example for now until we uploaded new test nodes
+      - name: "Python Dataflow example"
+        run: cargo run --example python-dataflow
+
+      - name: "Python Operator Dataflow example"
+        run: cargo run --example python-operator-dataflow
+
+      - uses: ros-tooling/setup-ros@v0.6
+        with:
+          required-ros-distributions: humble
+      - run: 'source /opt/ros/humble/setup.bash && echo AMENT_PREFIX_PATH=${AMENT_PREFIX_PATH} >> "$GITHUB_ENV"'
+        if: runner.os == 'Linux'
+      - name: "python-ros2-dataflow"
         timeout-minutes: 30
-        run: cargo run --example rust-dataflow-url
+        if: runner.os == 'Linux'
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: |
+          source /opt/ros/humble/setup.bash && ros2 run turtlesim turtlesim_node &
+          cargo run --example python-ros2-dataflow --features="ros2-examples"
 
   clippy:
     name: "Clippy"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,6 @@ jobs:
       - name: "Multiple Daemons example"
         timeout-minutes: 30
         run: cargo run --example multiple-daemons
-      - name: "Benchmark example"
-        timeout-minutes: 30
-        run: cargo run --example benchmark --release
       - name: "C Dataflow example"
         timeout-minutes: 15
         run: cargo run --example c-dataflow
@@ -131,6 +128,27 @@ jobs:
           cd ..
 
           dora-cli destroy
+  bench:
+    name: "Bench"
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.platform }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v3
+      - uses: r7kamura/rust-problem-matchers@v1.1.0
+      - run: cargo --version --verbose
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          # only save caches for `main` branch
+          # save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: "Benchmark example"
+        timeout-minutes: 30
+        run: cargo run --example benchmark --release
 
   clippy:
     name: "Clippy"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - merge-ci-jobs
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,9 +62,9 @@ jobs:
         # fail-fast by using bash shell explictly
         shell: bash
         run: |
-          cargo install --path binaries/coordinator
-          cargo install --path binaries/daemon
-          cargo install --path binaries/cli
+          cargo install --path binaries/coordinator --locked
+          cargo install --path binaries/daemon --locked
+          cargo install --path binaries/cli --locked
       - name: "Test CLI"
         timeout-minutes: 30
         # fail-fast by using bash shell explictly


### PR DESCRIPTION
This PR applies various improvements to our CI script to speed up builds:

- Use [buildjet](https://buildjet.com/for-github-actions) for caches, which provides 20 GB of free cache space.
  - Previously, we used the official GitHub cache, which is limited to 10GB. Our repo needs ~13 GB, so we experienced lots of cache evictions, which caused slow build times.
- Only write caches from `main` branch.
  - Because our cache size is still limited, we don't want to clutter it with caches from PRs. The PRs can still load the cache of the `main` branch.
- Sometimes a test failes spuriously, e.g. because of a rate limit error. We still want to save the cache in this case.
- Remove the empty remote example job.
- Move the benchmark example to a different job because it compiles in release mode and thus shares almost no build artifacts with the other examples.
- Since the ROS2 setup can be quite slow, we move it to a different job as well to increase parallelism.
- The Python setup is relatively quick in comparison, so we merge the python examples into the general examples job (to limit the number of checks that we're running).
- The `CARGO_TERM_COLOR` env variable broke the problem matching, so we remove it again.

The commit log of this PR is quite messy since I tried many different approaches. We should squash-merge it.