### PR TITLE
Bump version to 0.2.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,12 +9,12 @@ on:
       - "published"
 
 jobs:
-  release:
-    name: "Release"
+  cargo-release:
+    name: "Cargo Release"
 
     strategy:
       matrix:
-        platform: [ubuntu-20.04, macos-12, windows-2022]
+        platform: [ubuntu-20.04]
         python-version: ["3.7"]
       fail-fast: false
     runs-on: ${{ matrix.platform }}
@@ -23,10 +23,6 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: r7kamura/rust-problem-matchers@v1.1.0
-
-      - name: "Build binaries"
-        timeout-minutes: 60
-        run: "cargo build --release -p dora-coordinator -p dora-cli -p dora-daemon"
 
       - name: "Publish packages on `crates.io`"
         if: runner.os == 'Linux'
@@ -66,16 +62,26 @@ jobs:
           cargo publish -p dora-runtime --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
           cargo publish -p dora-daemon --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
-      - name: "Create Archive (Unix)"
-        if: runner.os == 'Linux' || runner.os == 'macOS'
-        run: |
-          mkdir archive
-          cp target/release/dora-coordinator archive
-          cp target/release/dora-daemon archive
-          cp target/release/dora-cli archive/dora
-          cd archive
-          zip -r ../archive.zip .
-          cd ..
+
+
+  windows-release:
+    name: "Windows Release"
+
+    strategy:
+      matrix:
+        platform: [windows-2022]
+        python-version: ["3.7"]
+      fail-fast: false
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r7kamura/rust-problem-matchers@v1.1.0
+
+      - name: "Build binaries"
+        timeout-minutes: 60
+        run: "cargo build --release -p dora-coordinator -p dora-cli -p dora-daemon"
 
       - name: Create Archive (Windows)
         if: runner.os == 'Windows'
@@ -96,6 +102,62 @@ jobs:
           asset_path: archive.zip
           asset_name: dora-${{ github.ref_name }}-x86_64-${{ runner.os }}.zip
           asset_content_type: application/zip
+
+
+  unix-release:
+    name: "Unix Release"
+
+    strategy:
+      matrix:
+        platform: [macos-12, ubuntu-20.04]
+        python-version: ["3.7"]
+      fail-fast: false
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r7kamura/rust-problem-matchers@v1.1.0
+
+      - name: "Build binaries"
+        timeout-minutes: 60
+        run: "cargo build --release -p dora-coordinator -p dora-cli -p dora-daemon"
+
+      - name: "Create Archive (Unix)"
+        if: runner.os == 'Linux' || runner.os == 'macOS'
+        run: |
+          mkdir archive
+          cp target/release/dora-coordinator archive
+          cp target/release/dora-daemon archive
+          cp target/release/dora-cli archive/dora
+          cd archive
+          zip -r ../archive.zip .
+          cd ..
+
+      - name: "Upload release asset"
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: archive.zip
+          asset_name: dora-${{ github.ref_name }}-x86_64-${{ runner.os }}.zip
+          asset_content_type: application/zip
+
+  linux-arm-release:
+    name: "Linux ARM Release"
+
+    strategy:
+      matrix:
+        platform: [ubuntu-20.04]
+        python-version: ["3.7"]
+      fail-fast: false
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r7kamura/rust-problem-matchers@v1.1.0
 
       - name: "Build Linux ARM64"
         if: runner.os == 'Linux'
@@ -127,6 +189,20 @@ jobs:
           asset_name: dora-${{ github.ref_name }}-aarch64-${{ runner.os }}.zip
           asset_content_type: application/zip
 
+  mac-arm-release:
+    name: "MacOS ARM Release"
+
+    strategy:
+      matrix:
+        platform: [macos-12]
+        python-version: ["3.7"]
+      fail-fast: false
+    runs-on: ${{ matrix.platform }}
+    
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r7kamura/rust-problem-matchers@v1.1.0
       - name: "Add macOS ARM64 toolchains"
         if: runner.os == 'macOS'
         run: rustup target add aarch64-apple-darwin

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "benchmark-example-node"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "benchmark-example-sink"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -977,7 +977,7 @@ dependencies = [
 
 [[package]]
 name = "communication-layer-pub-sub"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "flume",
  "zenoh",
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "communication-layer-request-reply"
-version = "0.2.4"
+version = "0.2.5"
 
 [[package]]
 name = "concurrent-queue"
@@ -1338,7 +1338,7 @@ dependencies = [
 
 [[package]]
 name = "dora-cli"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "bat",
  "clap 4.3.9",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "dora-coordinator"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "clap 3.2.25",
  "ctrlc",
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "dora-core"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "dora-message",
  "eyre",
@@ -1404,7 +1404,7 @@ dependencies = [
 
 [[package]]
 name = "dora-daemon"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "arrow-schema",
  "async-trait",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "dora-download"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "eyre",
  "reqwest",
@@ -1461,7 +1461,7 @@ dependencies = [
 
 [[package]]
 name = "dora-message"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "arrow-data",
  "arrow-schema",
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "dora-metrics"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "futures",
  "opentelemetry 0.17.0",
@@ -1483,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-c"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-cxx"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -1529,7 +1529,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-python"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "arrow",
  "dora-node-api",
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "dora-operator-api-macros",
  "dora-operator-api-types",
@@ -1554,14 +1554,14 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-c"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "dora-operator-api-types",
 ]
 
 [[package]]
 name = "dora-operator-api-cxx"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-macros"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-python"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-types"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "safer-ffi",
 ]
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "dora-runtime"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1693,7 +1693,7 @@ dependencies = [
 
 [[package]]
 name = "dora-tracing"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "eyre",
  "opentelemetry 0.18.0",
@@ -3136,7 +3136,7 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "multiple-daemons-example-node"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -3147,14 +3147,14 @@ dependencies = [
 
 [[package]]
 name = "multiple-daemons-example-operator"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "dora-operator-api",
 ]
 
 [[package]]
 name = "multiple-daemons-example-sink"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4444,7 +4444,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-node"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4455,14 +4455,14 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-operator"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "dora-operator-api",
 ]
 
 [[package]]
 name = "rust-dataflow-example-sink"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4470,7 +4470,7 @@ dependencies = [
 
 [[package]]
 name = "rust-ros2-dataflow-example-node"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "dora-node-api",
  "dora-ros2-bridge",
@@ -4854,7 +4854,7 @@ dependencies = [
 
 [[package]]
 name = "shared-memory-server"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "bincode",
  "eyre",
@@ -6505,7 +6505,7 @@ dependencies = [
 
 [[package]]
 name = "zenoh-logger"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "zenoh",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "benchmark-example-node"
-version = "0.2.5-rc"
+version = "0.2.5"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "benchmark-example-sink"
-version = "0.2.5-rc"
+version = "0.2.5"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -977,7 +977,7 @@ dependencies = [
 
 [[package]]
 name = "communication-layer-pub-sub"
-version = "0.2.5-rc"
+version = "0.2.5"
 dependencies = [
  "flume",
  "zenoh",
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "communication-layer-request-reply"
-version = "0.2.5-rc"
+version = "0.2.5"
 
 [[package]]
 name = "concurrent-queue"
@@ -1338,7 +1338,7 @@ dependencies = [
 
 [[package]]
 name = "dora-cli"
-version = "0.2.5-rc"
+version = "0.2.5"
 dependencies = [
  "bat",
  "clap 4.3.9",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "dora-coordinator"
-version = "0.2.5-rc"
+version = "0.2.5"
 dependencies = [
  "clap 3.2.25",
  "ctrlc",
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "dora-core"
-version = "0.2.5-rc"
+version = "0.2.5"
 dependencies = [
  "dora-message",
  "eyre",
@@ -1404,7 +1404,7 @@ dependencies = [
 
 [[package]]
 name = "dora-daemon"
-version = "0.2.5-rc"
+version = "0.2.5"
 dependencies = [
  "arrow-schema",
  "async-trait",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "dora-download"
-version = "0.2.5-rc"
+version = "0.2.5"
 dependencies = [
  "eyre",
  "reqwest",
@@ -1461,7 +1461,7 @@ dependencies = [
 
 [[package]]
 name = "dora-message"
-version = "0.2.5-rc"
+version = "0.2.5"
 dependencies = [
  "arrow-data",
  "arrow-schema",
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "dora-metrics"
-version = "0.2.5-rc"
+version = "0.2.5"
 dependencies = [
  "futures",
  "opentelemetry 0.17.0",
@@ -1483,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api"
-version = "0.2.5-rc"
+version = "0.2.5"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-c"
-version = "0.2.5-rc"
+version = "0.2.5"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-cxx"
-version = "0.2.5-rc"
+version = "0.2.5"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -1529,7 +1529,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-python"
-version = "0.2.5-rc"
+version = "0.2.5"
 dependencies = [
  "arrow",
  "dora-node-api",
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api"
-version = "0.2.5-rc"
+version = "0.2.5"
 dependencies = [
  "dora-operator-api-macros",
  "dora-operator-api-types",
@@ -1554,14 +1554,14 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-c"
-version = "0.2.5-rc"
+version = "0.2.5"
 dependencies = [
  "dora-operator-api-types",
 ]
 
 [[package]]
 name = "dora-operator-api-cxx"
-version = "0.2.5-rc"
+version = "0.2.5"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-macros"
-version = "0.2.5-rc"
+version = "0.2.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-python"
-version = "0.2.5-rc"
+version = "0.2.5"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-types"
-version = "0.2.5-rc"
+version = "0.2.5"
 dependencies = [
  "safer-ffi",
 ]
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "dora-runtime"
-version = "0.2.5-rc"
+version = "0.2.5"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1693,7 +1693,7 @@ dependencies = [
 
 [[package]]
 name = "dora-tracing"
-version = "0.2.5-rc"
+version = "0.2.5"
 dependencies = [
  "eyre",
  "opentelemetry 0.18.0",
@@ -3136,7 +3136,7 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "multiple-daemons-example-node"
-version = "0.2.5-rc"
+version = "0.2.5"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -3147,14 +3147,14 @@ dependencies = [
 
 [[package]]
 name = "multiple-daemons-example-operator"
-version = "0.2.5-rc"
+version = "0.2.5"
 dependencies = [
  "dora-operator-api",
 ]
 
 [[package]]
 name = "multiple-daemons-example-sink"
-version = "0.2.5-rc"
+version = "0.2.5"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4444,7 +4444,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-node"
-version = "0.2.5-rc"
+version = "0.2.5"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4455,14 +4455,14 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-operator"
-version = "0.2.5-rc"
+version = "0.2.5"
 dependencies = [
  "dora-operator-api",
 ]
 
 [[package]]
 name = "rust-dataflow-example-sink"
-version = "0.2.5-rc"
+version = "0.2.5"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4470,7 +4470,7 @@ dependencies = [
 
 [[package]]
 name = "rust-ros2-dataflow-example-node"
-version = "0.2.5-rc"
+version = "0.2.5"
 dependencies = [
  "dora-node-api",
  "dora-ros2-bridge",
@@ -4854,7 +4854,7 @@ dependencies = [
 
 [[package]]
 name = "shared-memory-server"
-version = "0.2.5-rc"
+version = "0.2.5"
 dependencies = [
  "bincode",
  "eyre",
@@ -6505,7 +6505,7 @@ dependencies = [
 
 [[package]]
 name = "zenoh-logger"
-version = "0.2.5-rc"
+version = "0.2.5"
 dependencies = [
  "zenoh",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "benchmark-example-node"
-version = "0.2.5"
+version = "0.2.5-rc"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "benchmark-example-sink"
-version = "0.2.5"
+version = "0.2.5-rc"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -977,7 +977,7 @@ dependencies = [
 
 [[package]]
 name = "communication-layer-pub-sub"
-version = "0.2.5"
+version = "0.2.5-rc"
 dependencies = [
  "flume",
  "zenoh",
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "communication-layer-request-reply"
-version = "0.2.5"
+version = "0.2.5-rc"
 
 [[package]]
 name = "concurrent-queue"
@@ -1338,7 +1338,7 @@ dependencies = [
 
 [[package]]
 name = "dora-cli"
-version = "0.2.5"
+version = "0.2.5-rc"
 dependencies = [
  "bat",
  "clap 4.3.9",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "dora-coordinator"
-version = "0.2.5"
+version = "0.2.5-rc"
 dependencies = [
  "clap 3.2.25",
  "ctrlc",
@@ -1387,7 +1387,7 @@ dependencies = [
 
 [[package]]
 name = "dora-core"
-version = "0.2.5"
+version = "0.2.5-rc"
 dependencies = [
  "dora-message",
  "eyre",
@@ -1404,7 +1404,7 @@ dependencies = [
 
 [[package]]
 name = "dora-daemon"
-version = "0.2.5"
+version = "0.2.5-rc"
 dependencies = [
  "arrow-schema",
  "async-trait",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "dora-download"
-version = "0.2.5"
+version = "0.2.5-rc"
 dependencies = [
  "eyre",
  "reqwest",
@@ -1461,7 +1461,7 @@ dependencies = [
 
 [[package]]
 name = "dora-message"
-version = "0.2.5"
+version = "0.2.5-rc"
 dependencies = [
  "arrow-data",
  "arrow-schema",
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "dora-metrics"
-version = "0.2.5"
+version = "0.2.5-rc"
 dependencies = [
  "futures",
  "opentelemetry 0.17.0",
@@ -1483,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api"
-version = "0.2.5"
+version = "0.2.5-rc"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-c"
-version = "0.2.5"
+version = "0.2.5-rc"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1519,7 +1519,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-cxx"
-version = "0.2.5"
+version = "0.2.5-rc"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -1529,7 +1529,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-python"
-version = "0.2.5"
+version = "0.2.5-rc"
 dependencies = [
  "arrow",
  "dora-node-api",
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api"
-version = "0.2.5"
+version = "0.2.5-rc"
 dependencies = [
  "dora-operator-api-macros",
  "dora-operator-api-types",
@@ -1554,14 +1554,14 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-c"
-version = "0.2.5"
+version = "0.2.5-rc"
 dependencies = [
  "dora-operator-api-types",
 ]
 
 [[package]]
 name = "dora-operator-api-cxx"
-version = "0.2.5"
+version = "0.2.5-rc"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -1570,7 +1570,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-macros"
-version = "0.2.5"
+version = "0.2.5-rc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-python"
-version = "0.2.5"
+version = "0.2.5-rc"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1592,7 +1592,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-types"
-version = "0.2.5"
+version = "0.2.5-rc"
 dependencies = [
  "safer-ffi",
 ]
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "dora-runtime"
-version = "0.2.5"
+version = "0.2.5-rc"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1693,7 +1693,7 @@ dependencies = [
 
 [[package]]
 name = "dora-tracing"
-version = "0.2.5"
+version = "0.2.5-rc"
 dependencies = [
  "eyre",
  "opentelemetry 0.18.0",
@@ -3136,7 +3136,7 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "multiple-daemons-example-node"
-version = "0.2.5"
+version = "0.2.5-rc"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -3147,14 +3147,14 @@ dependencies = [
 
 [[package]]
 name = "multiple-daemons-example-operator"
-version = "0.2.5"
+version = "0.2.5-rc"
 dependencies = [
  "dora-operator-api",
 ]
 
 [[package]]
 name = "multiple-daemons-example-sink"
-version = "0.2.5"
+version = "0.2.5-rc"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4444,7 +4444,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-node"
-version = "0.2.5"
+version = "0.2.5-rc"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4455,14 +4455,14 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-operator"
-version = "0.2.5"
+version = "0.2.5-rc"
 dependencies = [
  "dora-operator-api",
 ]
 
 [[package]]
 name = "rust-dataflow-example-sink"
-version = "0.2.5"
+version = "0.2.5-rc"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4470,7 +4470,7 @@ dependencies = [
 
 [[package]]
 name = "rust-ros2-dataflow-example-node"
-version = "0.2.5"
+version = "0.2.5-rc"
 dependencies = [
  "dora-node-api",
  "dora-ros2-bridge",
@@ -4854,7 +4854,7 @@ dependencies = [
 
 [[package]]
 name = "shared-memory-server"
-version = "0.2.5"
+version = "0.2.5-rc"
 dependencies = [
  "bincode",
  "eyre",
@@ -6505,7 +6505,7 @@ dependencies = [
 
 [[package]]
 name = "zenoh-logger"
-version = "0.2.5"
+version = "0.2.5-rc"
 dependencies = [
  "zenoh",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,30 +30,30 @@ members = [
 
 [workspace.package]
 # Make sure to also bump `apis/node/python/__init__.py` version.
-version = "0.2.5"
+version = "0.2.5-rc"
 description = "`dora` goal is to be a low latency, composable, and distributed data flow."
 documentation = "https://dora.carsmos.ai"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-dora-node-api = { version = "0.2.5", path = "apis/rust/node", default-features = false }
-dora-node-api-python = { version = "0.2.5", path = "apis/python/node", default-features = false }
-dora-operator-api = { version = "0.2.5", path = "apis/rust/operator", default-features = false }
-dora-operator-api-macros = { version = "0.2.5", path = "apis/rust/operator/macros" }
-dora-operator-api-types = { version = "0.2.5", path = "apis/rust/operator/types" }
-dora-operator-api-python = { version = "0.2.5", path = "apis/python/operator" }
-dora-operator-api-c = { version = "0.2.5", path = "apis/c/operator" }
-dora-node-api-c = { version = "0.2.5", path = "apis/c/node" }
-dora-core = { version = "0.2.5", path = "libraries/core" }
-dora-tracing = { version = "0.2.5", path = "libraries/extensions/telemetry/tracing" }
-dora-metrics = { version = "0.2.5", path = "libraries/extensions/telemetry/metrics" }
-dora-download = { version = "0.2.5", path = "libraries/extensions/download" }
-shared-memory-server = { version = "0.2.5", path = "libraries/shared-memory-server" }
-communication-layer-request-reply = { version = "0.2.5", path = "libraries/communication-layer/request-reply" }
-dora-message = { version = "0.2.5", path = "libraries/message" }
-dora-runtime = { version = "0.2.5", path = "binaries/runtime" }
-dora-daemon = { version = "0.2.5", path = "binaries/daemon" }
-dora-coordinator = { version = "0.2.5", path = "binaries/coordinator" }
+dora-node-api = { version = "0.2.5-rc", path = "apis/rust/node", default-features = false }
+dora-node-api-python = { version = "0.2.5-rc", path = "apis/python/node", default-features = false }
+dora-operator-api = { version = "0.2.5-rc", path = "apis/rust/operator", default-features = false }
+dora-operator-api-macros = { version = "0.2.5-rc", path = "apis/rust/operator/macros" }
+dora-operator-api-types = { version = "0.2.5-rc", path = "apis/rust/operator/types" }
+dora-operator-api-python = { version = "0.2.5-rc", path = "apis/python/operator" }
+dora-operator-api-c = { version = "0.2.5-rc", path = "apis/c/operator" }
+dora-node-api-c = { version = "0.2.5-rc", path = "apis/c/node" }
+dora-core = { version = "0.2.5-rc", path = "libraries/core" }
+dora-tracing = { version = "0.2.5-rc", path = "libraries/extensions/telemetry/tracing" }
+dora-metrics = { version = "0.2.5-rc", path = "libraries/extensions/telemetry/metrics" }
+dora-download = { version = "0.2.5-rc", path = "libraries/extensions/download" }
+shared-memory-server = { version = "0.2.5-rc", path = "libraries/shared-memory-server" }
+communication-layer-request-reply = { version = "0.2.5-rc", path = "libraries/communication-layer/request-reply" }
+dora-message = { version = "0.2.5-rc", path = "libraries/message" }
+dora-runtime = { version = "0.2.5-rc", path = "binaries/runtime" }
+dora-daemon = { version = "0.2.5-rc", path = "binaries/daemon" }
+dora-coordinator = { version = "0.2.5-rc", path = "binaries/coordinator" }
 dora-ros2-bridge = { path = "libraries/extensions/ros2-bridge" }
 dora-ros2-bridge-python = { path = "libraries/extensions/ros2-bridge/python" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,30 +30,30 @@ members = [
 
 [workspace.package]
 # Make sure to also bump `apis/node/python/__init__.py` version.
-version = "0.2.5-rc"
+version = "0.2.5"
 description = "`dora` goal is to be a low latency, composable, and distributed data flow."
 documentation = "https://dora.carsmos.ai"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-dora-node-api = { version = "0.2.5-rc", path = "apis/rust/node", default-features = false }
-dora-node-api-python = { version = "0.2.5-rc", path = "apis/python/node", default-features = false }
-dora-operator-api = { version = "0.2.5-rc", path = "apis/rust/operator", default-features = false }
-dora-operator-api-macros = { version = "0.2.5-rc", path = "apis/rust/operator/macros" }
-dora-operator-api-types = { version = "0.2.5-rc", path = "apis/rust/operator/types" }
-dora-operator-api-python = { version = "0.2.5-rc", path = "apis/python/operator" }
-dora-operator-api-c = { version = "0.2.5-rc", path = "apis/c/operator" }
-dora-node-api-c = { version = "0.2.5-rc", path = "apis/c/node" }
-dora-core = { version = "0.2.5-rc", path = "libraries/core" }
-dora-tracing = { version = "0.2.5-rc", path = "libraries/extensions/telemetry/tracing" }
-dora-metrics = { version = "0.2.5-rc", path = "libraries/extensions/telemetry/metrics" }
-dora-download = { version = "0.2.5-rc", path = "libraries/extensions/download" }
-shared-memory-server = { version = "0.2.5-rc", path = "libraries/shared-memory-server" }
-communication-layer-request-reply = { version = "0.2.5-rc", path = "libraries/communication-layer/request-reply" }
-dora-message = { version = "0.2.5-rc", path = "libraries/message" }
-dora-runtime = { version = "0.2.5-rc", path = "binaries/runtime" }
-dora-daemon = { version = "0.2.5-rc", path = "binaries/daemon" }
-dora-coordinator = { version = "0.2.5-rc", path = "binaries/coordinator" }
+dora-node-api = { version = "0.2.5", path = "apis/rust/node", default-features = false }
+dora-node-api-python = { version = "0.2.5", path = "apis/python/node", default-features = false }
+dora-operator-api = { version = "0.2.5", path = "apis/rust/operator", default-features = false }
+dora-operator-api-macros = { version = "0.2.5", path = "apis/rust/operator/macros" }
+dora-operator-api-types = { version = "0.2.5", path = "apis/rust/operator/types" }
+dora-operator-api-python = { version = "0.2.5", path = "apis/python/operator" }
+dora-operator-api-c = { version = "0.2.5", path = "apis/c/operator" }
+dora-node-api-c = { version = "0.2.5", path = "apis/c/node" }
+dora-core = { version = "0.2.5", path = "libraries/core" }
+dora-tracing = { version = "0.2.5", path = "libraries/extensions/telemetry/tracing" }
+dora-metrics = { version = "0.2.5", path = "libraries/extensions/telemetry/metrics" }
+dora-download = { version = "0.2.5", path = "libraries/extensions/download" }
+shared-memory-server = { version = "0.2.5", path = "libraries/shared-memory-server" }
+communication-layer-request-reply = { version = "0.2.5", path = "libraries/communication-layer/request-reply" }
+dora-message = { version = "0.2.5", path = "libraries/message" }
+dora-runtime = { version = "0.2.5", path = "binaries/runtime" }
+dora-daemon = { version = "0.2.5", path = "binaries/daemon" }
+dora-coordinator = { version = "0.2.5", path = "binaries/coordinator" }
 dora-ros2-bridge = { path = "libraries/extensions/ros2-bridge" }
 dora-ros2-bridge-python = { path = "libraries/extensions/ros2-bridge/python" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,30 +30,30 @@ members = [
 
 [workspace.package]
 # Make sure to also bump `apis/node/python/__init__.py` version.
-version = "0.2.4"
+version = "0.2.5"
 description = "`dora` goal is to be a low latency, composable, and distributed data flow."
 documentation = "https://dora.carsmos.ai"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-dora-node-api = { version = "0.2.4", path = "apis/rust/node", default-features = false }
-dora-node-api-python = { version = "0.2.4", path = "apis/python/node", default-features = false }
-dora-operator-api = { version = "0.2.4", path = "apis/rust/operator", default-features = false }
-dora-operator-api-macros = { version = "0.2.4", path = "apis/rust/operator/macros" }
-dora-operator-api-types = { version = "0.2.4", path = "apis/rust/operator/types" }
-dora-operator-api-python = { version = "0.2.4", path = "apis/python/operator" }
-dora-operator-api-c = { version = "0.2.4", path = "apis/c/operator" }
-dora-node-api-c = { version = "0.2.4", path = "apis/c/node" }
-dora-core = { version = "0.2.4", path = "libraries/core" }
-dora-tracing = { version = "0.2.4", path = "libraries/extensions/telemetry/tracing" }
-dora-metrics = { version = "0.2.4", path = "libraries/extensions/telemetry/metrics" }
-dora-download = { version = "0.2.4", path = "libraries/extensions/download" }
-shared-memory-server = { version = "0.2.4", path = "libraries/shared-memory-server" }
-communication-layer-request-reply = { version = "0.2.4", path = "libraries/communication-layer/request-reply" }
-dora-message = { version = "0.2.4", path = "libraries/message" }
-dora-runtime = { version = "0.2.4", path = "binaries/runtime" }
-dora-daemon = { version = "0.2.4", path = "binaries/daemon" }
-dora-coordinator = { version = "0.2.4", path = "binaries/coordinator" }
+dora-node-api = { version = "0.2.5", path = "apis/rust/node", default-features = false }
+dora-node-api-python = { version = "0.2.5", path = "apis/python/node", default-features = false }
+dora-operator-api = { version = "0.2.5", path = "apis/rust/operator", default-features = false }
+dora-operator-api-macros = { version = "0.2.5", path = "apis/rust/operator/macros" }
+dora-operator-api-types = { version = "0.2.5", path = "apis/rust/operator/types" }
+dora-operator-api-python = { version = "0.2.5", path = "apis/python/operator" }
+dora-operator-api-c = { version = "0.2.5", path = "apis/c/operator" }
+dora-node-api-c = { version = "0.2.5", path = "apis/c/node" }
+dora-core = { version = "0.2.5", path = "libraries/core" }
+dora-tracing = { version = "0.2.5", path = "libraries/extensions/telemetry/tracing" }
+dora-metrics = { version = "0.2.5", path = "libraries/extensions/telemetry/metrics" }
+dora-download = { version = "0.2.5", path = "libraries/extensions/download" }
+shared-memory-server = { version = "0.2.5", path = "libraries/shared-memory-server" }
+communication-layer-request-reply = { version = "0.2.5", path = "libraries/communication-layer/request-reply" }
+dora-message = { version = "0.2.5", path = "libraries/message" }
+dora-runtime = { version = "0.2.5", path = "binaries/runtime" }
+dora-daemon = { version = "0.2.5", path = "binaries/daemon" }
+dora-coordinator = { version = "0.2.5", path = "binaries/coordinator" }
 dora-ros2-bridge = { path = "libraries/extensions/ros2-bridge" }
 dora-ros2-bridge-python = { path = "libraries/extensions/ros2-bridge/python" }
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v0.2.5 (2023-09-06)
+
+### Features
+* Use cargo instead of git in Rust `Cargo.toml` template by @haixuanTao in https://github.com/dora-rs/dora/pull/326
+* Use read_line instead of next_line in stderr by @haixuanTao in https://github.com/dora-rs/dora/pull/325
+* Add a `rust-ros2-dataflow` example using the dora-ros2-bridge by @phil-opp in https://github.com/dora-rs/dora/pull/324
+* Removing patchelf by @haixuanTao in https://github.com/dora-rs/dora/pull/333
+* Improving python example readibility by @haixuanTao in https://github.com/dora-rs/dora/pull/334
+* Use `serde_bytes` to serialize `Vec<u8>` by @haixuanTao in https://github.com/dora-rs/dora/pull/336
+* Adding support for `Arrow List(*)`  for Python by @haixuanTao in https://github.com/dora-rs/dora/pull/337
+* Bump rustls-webpki from 0.100.1 to 0.100.2 by @dependabot in https://github.com/dora-rs/dora/pull/340
+* Add support for event stream merging for Python node API by @phil-opp in https://github.com/dora-rs/dora/pull/339
+* Merge `dora-ros2-bridge` by @phil-opp in https://github.com/dora-rs/dora/pull/341
+* Update dependencies by @phil-opp in https://github.com/dora-rs/dora/pull/345
+* Add support for arbitrary Arrow types in Python API by @phil-opp in https://github.com/dora-rs/dora/pull/343
+* Use typed inputs in Python ROS2 example by @phil-opp in https://github.com/dora-rs/dora/pull/346
+* Use struct type instead of array for ros2 messages by @haixuanTao in https://github.com/dora-rs/dora/pull/349
+
+### Other
+
+* Add Discord :speech_balloon:  by @haixuanTao in https://github.com/dora-rs/dora/pull/348
+* Small refactoring by @haixuanTao in https://github.com/dora-rs/dora/pull/342
+
+
 ## v0.2.4 (2023-07-18)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pip install -r https://raw.githubusercontent.com/dora-rs/dora/v0.2.5/examples/py
 
 2. Get some example operators:
 ```bash
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.2,4/examples/python-operator-dataflow/webcam.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.2.5/examples/python-operator-dataflow/webcam.py
 wget https://raw.githubusercontent.com/dora-rs/dora/v0.2.5/examples/python-operator-dataflow/plot.py
 wget https://raw.githubusercontent.com/dora-rs/dora/v0.2.5/examples/python-operator-dataflow/utils.py
 wget https://raw.githubusercontent.com/dora-rs/dora/v0.2.5/examples/python-operator-dataflow/object_detection.py

--- a/README.md
+++ b/README.md
@@ -73,16 +73,16 @@ For more installation guideline, check out our installation guide here: https://
 
 1. Install the example python dependencies:
 ```bash
-pip install -r https://raw.githubusercontent.com/dora-rs/dora/v0.2.4/examples/python-operator-dataflow/requirements.txt
+pip install -r https://raw.githubusercontent.com/dora-rs/dora/v0.2.5/examples/python-operator-dataflow/requirements.txt
 ```
 
 2. Get some example operators:
 ```bash
 wget https://raw.githubusercontent.com/dora-rs/dora/v0.2,4/examples/python-operator-dataflow/webcam.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.2.4/examples/python-operator-dataflow/plot.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.2.4/examples/python-operator-dataflow/utils.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.2.4/examples/python-operator-dataflow/object_detection.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.2.4/examples/python-operator-dataflow/dataflow.yml
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.2.5/examples/python-operator-dataflow/plot.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.2.5/examples/python-operator-dataflow/utils.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.2.5/examples/python-operator-dataflow/object_detection.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.2.5/examples/python-operator-dataflow/dataflow.yml
 ```
 
 3. Start the dataflow

--- a/apis/python/node/dora/__init__.py
+++ b/apis/python/node/dora/__init__.py
@@ -15,7 +15,7 @@ from enum import Enum
 from .dora import *
 
 __author__ = "Dora-rs Authors"
-__version__ = "0.2.4"
+__version__ = "0.2.5"
 
 
 class DoraStatus(Enum):


### PR DESCRIPTION
# Changelog

### Features
* Use cargo instead of git in Rust `Cargo.toml` template by @haixuanTao in https://github.com/dora-rs/dora/pull/326
* Use read_line instead of next_line in stderr by @haixuanTao in https://github.com/dora-rs/dora/pull/325
* Add a `rust-ros2-dataflow` example using the dora-ros2-bridge by @phil-opp in https://github.com/dora-rs/dora/pull/324
* Removing patchelf by @haixuanTao in https://github.com/dora-rs/dora/pull/333
* Improving python example readibility by @haixuanTao in https://github.com/dora-rs/dora/pull/334
* Use `serde_bytes` to serialize `Vec<u8>` by @haixuanTao in https://github.com/dora-rs/dora/pull/336
* Adding support for `Arrow List(*)`  for Python by @haixuanTao in https://github.com/dora-rs/dora/pull/337
* Bump rustls-webpki from 0.100.1 to 0.100.2 by @dependabot in https://github.com/dora-rs/dora/pull/340
* Add support for event stream merging for Python node API by @phil-opp in https://github.com/dora-rs/dora/pull/339
* Merge `dora-ros2-bridge` by @phil-opp in https://github.com/dora-rs/dora/pull/341
* Update dependencies by @phil-opp in https://github.com/dora-rs/dora/pull/345
* Add support for arbitrary Arrow types in Python API by @phil-opp in https://github.com/dora-rs/dora/pull/343
* Use typed inputs in Python ROS2 example by @phil-opp in https://github.com/dora-rs/dora/pull/346
* Use struct type instead of array for ros2 messages by @haixuanTao in https://github.com/dora-rs/dora/pull/349

### Other

* Add Discord :speech_balloon:  by @haixuanTao in https://github.com/dora-rs/dora/pull/348
* Small refactoring by @haixuanTao in https://github.com/dora-rs/dora/pull/342
