### PR TITLE
Start to make Rust node API typed using arrow

### DIFF
--- a/apis/c/node/src/lib.rs
+++ b/apis/c/node/src/lib.rs
@@ -169,14 +169,19 @@ pub unsafe extern "C" fn read_dora_input_data(
 ) {
     let event: &Event = unsafe { &*event.cast() };
     match event {
-        Event::Input {
-            data: Some(data), ..
-        } => {
-            let ptr = data.as_ptr();
-            let len = data.len();
-            unsafe {
-                *out_ptr = ptr;
-                *out_len = len;
+        Event::Input { data, .. } => {
+            if let Ok(data) = data.as_byte_slice() {
+                let ptr = data.as_ptr();
+                let len = data.len();
+                unsafe {
+                    *out_ptr = ptr;
+                    *out_len = len;
+                }
+            } else {
+                unsafe {
+                    *out_ptr = ptr::null();
+                    *out_len = 0;
+                }
             }
         }
         _ => unsafe {

--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -1,9 +1,12 @@
 use std::sync::Arc;
 
-pub use event::{Data, Event, MappedInputData};
+pub use event::{ArrowData, Event, MappedInputData};
 use futures::{Stream, StreamExt};
 
-use self::thread::{EventItem, EventStreamThreadHandle};
+use self::{
+    event::Data,
+    thread::{EventItem, EventStreamThreadHandle},
+};
 use crate::daemon_connection::DaemonChannel;
 use dora_core::{
     config::NodeId,
@@ -131,6 +134,7 @@ impl EventStream {
                             })
                         },
                     };
+                    let data = data.and_then(|data| ArrowData::new(data, &metadata));
                     match data {
                         Ok(data) => Event::Input { id, metadata, data },
                         Err(err) => Event::Error(format!("{err:?}")),

--- a/apis/rust/node/src/lib.rs
+++ b/apis/rust/node/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 pub use dora_core;
 pub use dora_core::message::{uhlc, Metadata, MetadataParameters};
-pub use event_stream::{merged, Data, Event, EventStream, MappedInputData};
+pub use event_stream::{merged, ArrowData, Event, EventStream, MappedInputData};
 pub use flume::Receiver;
 pub use node::{DataSample, DoraNode, ZERO_COPY_THRESHOLD};
 

--- a/binaries/runtime/src/operator/shared_lib.rs
+++ b/binaries/runtime/src/operator/shared_lib.rs
@@ -182,7 +182,12 @@ impl<'lib> SharedLibraryOperator<'lib> {
                 } => {
                     let operator_input = dora_operator_api_types::Input {
                         id: String::from(input_id).into(),
-                        data: data.map(|d| d.to_vec()).unwrap_or_default().into(),
+                        data: data
+                            .as_byte_slice()
+                            .map(|d| d.to_vec())
+                            // TODO: don't silence error
+                            .unwrap_or_default()
+                            .into(),
                         metadata: Metadata {
                             open_telemetry_context: metadata
                                 .parameters

--- a/examples/rust-dataflow/sink/src/main.rs
+++ b/examples/rust-dataflow/sink/src/main.rs
@@ -1,19 +1,14 @@
 use dora_node_api::{self, DoraNode, Event};
-use eyre::{bail, Context, ContextCompat};
+use eyre::{bail, Context};
 
 fn main() -> eyre::Result<()> {
     let (_node, mut events) = DoraNode::init_from_env()?;
 
     while let Some(event) = events.recv() {
         match event {
-            Event::Input {
-                id,
-                metadata: _,
-                data,
-            } => match id.as_str() {
+            Event::Input { id, metadata, data } => match id.as_str() {
                 "message" => {
-                    let data = data.wrap_err("no data")?;
-                    let received_string = std::str::from_utf8(&data)
+                    let received_string = std::str::from_utf8(data.as_byte_slice()?)
                         .wrap_err("received message was not utf8-encoded")?;
                     println!("sink received message: {}", received_string);
                     if !received_string.starts_with("operator received random value ") {


### PR DESCRIPTION
Open questions:

- How can we construct arrow arrays from Rust in an ergonomic way?
- Is zero-copy construction possible?
- How can we convert received data to higher-level types without copying?