### PR TITLE
Update dependencies to fix some security advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1364,7 +1364,7 @@ dependencies = [
 name = "dora-coordinator"
 version = "0.2.5"
 dependencies = [
- "clap 3.2.25",
+ "clap 4.3.9",
  "ctrlc",
  "dora-core",
  "dora-tracing",
@@ -1409,7 +1409,7 @@ dependencies = [
  "arrow-schema",
  "async-trait",
  "bincode",
- "clap 3.2.25",
+ "clap 4.3.9",
  "ctrlc",
  "dora-core",
  "dora-download",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,18 +830,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "defd4e7873dbddba6c7c91e199c7fcb946abc4a6a4ac3195400bcfb01b5de877"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
- "time 0.1.45",
  "wasm-bindgen",
- "winapi 0.3.9",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -2147,7 +2146,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -3100,7 +3099,7 @@ checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.48.0",
 ]
 
@@ -3832,7 +3831,7 @@ dependencies = [
  "line-wrap",
  "quick-xml",
  "serde",
- "time 0.3.22",
+ "time",
 ]
 
 [[package]]
@@ -5252,17 +5251,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "time"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
@@ -5781,12 +5769,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2152,9 +2152,9 @@ dependencies = [
 
 [[package]]
 name = "ghost"
-version = "0.1.9"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77ac7b51b8e6313251737fcef4b1c01a2ea102bde68415b62c0ee9268fec357"
+checksum = "fae7e09da323fc46f010e455cac340af26159678ba00ab18e963a5880ca6a9b6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2575,6 +2575,12 @@ dependencies = [
  "ghost",
  "inventory-impl",
 ]
+
+[[package]]
+name = "inventory"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1be380c410bf0595e94992a648ea89db4dd3f3354ba54af206fd2a68cf5ac8e"
 
 [[package]]
 name = "inventory-impl"
@@ -4621,7 +4627,8 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9c1d19b288ca9898cd421c7b105fb7269918a7f8e9253a991e228981ca421ad"
 dependencies = [
- "inventory",
+ "inventory 0.1.11",
+ "inventory 0.3.12",
  "libc",
  "macro_rules_attribute",
  "paste",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4617,9 +4617,9 @@ checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "safer-ffi"
-version = "0.1.0"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62fd645a8c0b4a71f0883dce1bc48e358fcc02b99c83613f62ede5660b3572c1"
+checksum = "e9c1d19b288ca9898cd421c7b105fb7269918a7f8e9253a991e228981ca421ad"
 dependencies = [
  "inventory",
  "libc",
@@ -4634,9 +4634,9 @@ dependencies = [
 
 [[package]]
 name = "safer_ffi-proc_macros"
-version = "0.1.0"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39be56c8f7e5878594154dd0d2c03e2b12c66fa5a5ba3fe302412bd89bad774"
+checksum = "e2d7a04caa3ca2224f5ea4ddd850e2629c3b36b2b83621f87a8303bf41020110"
 dependencies = [
  "macro_rules_attribute",
  "prettyplease",

--- a/apis/rust/operator/types/Cargo.toml
+++ b/apis/rust/operator/types/Cargo.toml
@@ -9,5 +9,5 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies.safer-ffi]
-version = "0.1.0-rc1"
-features = ["headers"]
+version = "0.1.3"
+features = ["headers", "inventory-0-3-1"]

--- a/binaries/coordinator/Cargo.toml
+++ b/binaries/coordinator/Cargo.toml
@@ -30,5 +30,5 @@ serde_json = "1.0.86"
 which = "4.3.0"
 thiserror = "1.0.37"
 ctrlc = "3.2.5"
-clap = { version = "3.1.8", features = ["derive"] }
+clap = { version = "4.0.3", features = ["derive"] }
 names = "0.14.0"

--- a/binaries/daemon/Cargo.toml
+++ b/binaries/daemon/Cargo.toml
@@ -32,7 +32,7 @@ dora-tracing = { workspace = true, optional = true }
 serde_yaml = "0.8.23"
 uuid = { version = "1.1.2", features = ["v4"] }
 futures = "0.3.25"
-clap = { version = "3.1.8", features = ["derive"] }
+clap = { version = "4.0.3", features = ["derive"] }
 shared-memory-server = { workspace = true }
 ctrlc = "3.2.5"
 bincode = "1.3.3"

--- a/binaries/runtime/src/operator/shared_lib.rs
+++ b/binaries/runtime/src/operator/shared_lib.rs
@@ -124,7 +124,7 @@ impl<'lib> SharedLibraryOperator<'lib> {
                 output_id: DataId::from(String::from(output_id)),
                 type_info: ArrowTypeInfo::byte_array(data.len()),
                 parameters,
-                data: Some(data.to_owned().into()),
+                data: Some(Vec::from(data).into()),
             };
 
             let result = self


### PR DESCRIPTION
- Update clap to v0.4.3
- Update chrono to v0.4.30
- Update safer-ffi to v0.1.3
- Make `safer-ffi` use `inventory v0.3`


Unfortunately, the `inventory v0.1` dependency cannot be removed yet because of https://github.com/getditto/safer_ffi/issues/188. We also cannot remove the `atty` dependency yet because the latest versions of `names` and `zenoh` still depend on `clap v3`, which uses `atty`.

