### PR TITLE
Release v0.2.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "benchmark-example-node"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "benchmark-example-sink"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "communication-layer-pub-sub"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "flume",
  "zenoh",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "communication-layer-request-reply"
-version = "0.2.5"
+version = "0.2.6"
 
 [[package]]
 name = "concurrent-queue"
@@ -1337,7 +1337,7 @@ dependencies = [
 
 [[package]]
 name = "dora-cli"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "bat",
  "clap 4.3.9",
@@ -1361,7 +1361,7 @@ dependencies = [
 
 [[package]]
 name = "dora-coordinator"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "clap 4.3.9",
  "ctrlc",
@@ -1386,7 +1386,7 @@ dependencies = [
 
 [[package]]
 name = "dora-core"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "dora-message",
  "eyre",
@@ -1403,7 +1403,7 @@ dependencies = [
 
 [[package]]
 name = "dora-daemon"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "arrow-schema",
  "async-trait",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "dora-download"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "eyre",
  "reqwest",
@@ -1460,7 +1460,7 @@ dependencies = [
 
 [[package]]
 name = "dora-message"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "arrow-data",
  "arrow-schema",
@@ -1471,7 +1471,7 @@ dependencies = [
 
 [[package]]
 name = "dora-metrics"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "futures",
  "opentelemetry 0.17.0",
@@ -1482,7 +1482,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1508,7 +1508,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-c"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-cxx"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -1528,7 +1528,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-python"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "arrow",
  "dora-node-api",
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "dora-operator-api-macros",
  "dora-operator-api-types",
@@ -1553,14 +1553,14 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-c"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "dora-operator-api-types",
 ]
 
 [[package]]
 name = "dora-operator-api-cxx"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-macros"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-python"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-types"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "safer-ffi",
 ]
@@ -1661,7 +1661,7 @@ dependencies = [
 
 [[package]]
 name = "dora-runtime"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "dora-tracing"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "eyre",
  "opentelemetry 0.18.0",
@@ -3141,7 +3141,7 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "multiple-daemons-example-node"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -3152,14 +3152,14 @@ dependencies = [
 
 [[package]]
 name = "multiple-daemons-example-operator"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "dora-operator-api",
 ]
 
 [[package]]
 name = "multiple-daemons-example-sink"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4449,7 +4449,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-node"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4460,14 +4460,14 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-operator"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "dora-operator-api",
 ]
 
 [[package]]
 name = "rust-dataflow-example-sink"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4475,7 +4475,7 @@ dependencies = [
 
 [[package]]
 name = "rust-ros2-dataflow-example-node"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "dora-node-api",
  "dora-ros2-bridge",
@@ -4860,7 +4860,7 @@ dependencies = [
 
 [[package]]
 name = "shared-memory-server"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "bincode",
  "eyre",
@@ -6494,7 +6494,7 @@ dependencies = [
 
 [[package]]
 name = "zenoh-logger"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "zenoh",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,30 +30,30 @@ members = [
 
 [workspace.package]
 # Make sure to also bump `apis/node/python/__init__.py` version.
-version = "0.2.5"
+version = "0.2.6"
 description = "`dora` goal is to be a low latency, composable, and distributed data flow."
 documentation = "https://dora.carsmos.ai"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-dora-node-api = { version = "0.2.5", path = "apis/rust/node", default-features = false }
-dora-node-api-python = { version = "0.2.5", path = "apis/python/node", default-features = false }
-dora-operator-api = { version = "0.2.5", path = "apis/rust/operator", default-features = false }
-dora-operator-api-macros = { version = "0.2.5", path = "apis/rust/operator/macros" }
-dora-operator-api-types = { version = "0.2.5", path = "apis/rust/operator/types" }
-dora-operator-api-python = { version = "0.2.5", path = "apis/python/operator" }
-dora-operator-api-c = { version = "0.2.5", path = "apis/c/operator" }
-dora-node-api-c = { version = "0.2.5", path = "apis/c/node" }
-dora-core = { version = "0.2.5", path = "libraries/core" }
-dora-tracing = { version = "0.2.5", path = "libraries/extensions/telemetry/tracing" }
-dora-metrics = { version = "0.2.5", path = "libraries/extensions/telemetry/metrics" }
-dora-download = { version = "0.2.5", path = "libraries/extensions/download" }
-shared-memory-server = { version = "0.2.5", path = "libraries/shared-memory-server" }
-communication-layer-request-reply = { version = "0.2.5", path = "libraries/communication-layer/request-reply" }
-dora-message = { version = "0.2.5", path = "libraries/message" }
-dora-runtime = { version = "0.2.5", path = "binaries/runtime" }
-dora-daemon = { version = "0.2.5", path = "binaries/daemon" }
-dora-coordinator = { version = "0.2.5", path = "binaries/coordinator" }
+dora-node-api = { version = "0.2.6", path = "apis/rust/node", default-features = false }
+dora-node-api-python = { version = "0.2.6", path = "apis/python/node", default-features = false }
+dora-operator-api = { version = "0.2.6", path = "apis/rust/operator", default-features = false }
+dora-operator-api-macros = { version = "0.2.6", path = "apis/rust/operator/macros" }
+dora-operator-api-types = { version = "0.2.6", path = "apis/rust/operator/types" }
+dora-operator-api-python = { version = "0.2.6", path = "apis/python/operator" }
+dora-operator-api-c = { version = "0.2.6", path = "apis/c/operator" }
+dora-node-api-c = { version = "0.2.6", path = "apis/c/node" }
+dora-core = { version = "0.2.6", path = "libraries/core" }
+dora-tracing = { version = "0.2.6", path = "libraries/extensions/telemetry/tracing" }
+dora-metrics = { version = "0.2.6", path = "libraries/extensions/telemetry/metrics" }
+dora-download = { version = "0.2.6", path = "libraries/extensions/download" }
+shared-memory-server = { version = "0.2.6", path = "libraries/shared-memory-server" }
+communication-layer-request-reply = { version = "0.2.6", path = "libraries/communication-layer/request-reply" }
+dora-message = { version = "0.2.6", path = "libraries/message" }
+dora-runtime = { version = "0.2.6", path = "binaries/runtime" }
+dora-daemon = { version = "0.2.6", path = "binaries/daemon" }
+dora-coordinator = { version = "0.2.6", path = "binaries/coordinator" }
 dora-ros2-bridge = { path = "libraries/extensions/ros2-bridge" }
 dora-ros2-bridge-python = { path = "libraries/extensions/ros2-bridge/python" }
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.2.6 (2023-09-14)
+
+* Update dependencies to fix some security advisories by @phil-opp in https://github.com/dora-rs/dora/pull/354
+  - Fixes `cargo install dora-daemon`
+
+
 ## v0.2.5 (2023-09-06)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -73,16 +73,16 @@ For more installation guideline, check out our installation guide here: https://
 
 1. Install the example python dependencies:
 ```bash
-pip install -r https://raw.githubusercontent.com/dora-rs/dora/v0.2.5/examples/python-operator-dataflow/requirements.txt
+pip install -r https://raw.githubusercontent.com/dora-rs/dora/v0.2.6/examples/python-operator-dataflow/requirements.txt
 ```
 
 2. Get some example operators:
 ```bash
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.2.5/examples/python-operator-dataflow/webcam.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.2.5/examples/python-operator-dataflow/plot.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.2.5/examples/python-operator-dataflow/utils.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.2.5/examples/python-operator-dataflow/object_detection.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.2.5/examples/python-operator-dataflow/dataflow.yml
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.2.6/examples/python-operator-dataflow/webcam.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.2.6/examples/python-operator-dataflow/plot.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.2.6/examples/python-operator-dataflow/utils.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.2.6/examples/python-operator-dataflow/object_detection.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.2.6/examples/python-operator-dataflow/dataflow.yml
 ```
 
 3. Start the dataflow

--- a/apis/python/node/dora/__init__.py
+++ b/apis/python/node/dora/__init__.py
@@ -15,7 +15,7 @@ from enum import Enum
 from .dora import *
 
 __author__ = "Dora-rs Authors"
-__version__ = "0.2.5"
+__version__ = "0.2.6"
 
 
 class DoraStatus(Enum):


### PR DESCRIPTION
### Changes

* Update dependencies to fix some security advisories by @phil-opp in https://github.com/dora-rs/dora/pull/354
  - Fixes `cargo install dora-daemon`

### Details

#355 reported that `cargo install dora-daemon` is currently broken. As I described in https://github.com/dora-rs/dora/issues/355#issuecomment-1718978517, the reason is quite suble:

> - The `safer-ffi` crate added a `Clone` implmentation for their `safer_ffi::Vec` type in https://github.com/getditto/safer_ffi/commit/34c73c44dc492d567a305626ae2eb4458d01c77b and released this change in `v0.1.3`. 
> - The `data.to_owned()` call in our code uses the [`ToOwned` trait](https://doc.rust-lang.org/stable/std/borrow/trait.ToOwned.html) of the standard library, which has a [blanket implementation for all clonable types](https://doc.rust-lang.org/stable/std/borrow/trait.ToOwned.html#impl-ToOwned-for-T)
> - In older `safer-ffi` releases, `safer_ffi::Vec` was not `Clone`, so it didn't implement the `ToOwned` trait either. Thus, the compiler dereferenced it to a byte slice and used the [`ToOwned` implementation for `[u8]`](https://doc.rust-lang.org/stable/std/borrow/trait.ToOwned.html), which resulted in a `std::vec::Vec`.
> - So the type of `data.to_owned()` changed from `std::vec::Vec` to `safer_ffi::Vec` just by upgrading the dependency. Only the former has an `Into` conversion to `DataSample`, so the dependency upgrade led to a build error.
> - The reason that a dependency update occurs is that `cargo install` automatically installs the latest patch versions of all dependencies, ignoring the `Cargo.lock`. The workaround is to pass the `--locked` argument, which uses the exact versions specified in the `Cargo.lock` (including the older `safer-ffi` release).

The dependency update in #354 fixed this issue in https://github.com/dora-rs/dora/pull/354/commits/0966d221bc9df1e40330ffb7ba82c913131600ae. We should create a new release to make this fix available to users.

---

Fixes #355 