### PR TITLE
Support legacy python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,12 @@ jobs:
       - run: cargo --version --verbose
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
-        if: runner.os == 'Linux' 
+        if: runner.os == 'Linux'
         with:
           # this might remove tools that are actually needed,
           # if set to "true" but frees about 6 GB
           tool-cache: false
-        
+
           # all of these default to true, but feel free to set to
           # "false" if necessary for your workflow
           android: true
@@ -48,7 +48,7 @@ jobs:
           docker-images: true
           swap-storage: false
       - name: Free disk Space (Windows)
-        if: runner.os == 'Windows' 
+        if: runner.os == 'Windows'
         run: |
           docker system prune --all -f
           Remove-Item "C:\Android" -Force -Recurse
@@ -89,12 +89,12 @@ jobs:
       - run: cargo --version --verbose
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
-        if: runner.os == 'Linux' 
+        if: runner.os == 'Linux'
         with:
           # this might remove tools that are actually needed,
           # if set to "true" but frees about 6 GB
           tool-cache: false
-        
+
           # all of these default to true, but feel free to set to
           # "false" if necessary for your workflow
           android: true
@@ -104,7 +104,7 @@ jobs:
           docker-images: true
           swap-storage: false
       - name: Free disk Space (Windows)
-        if: runner.os == 'Windows' 
+        if: runner.os == 'Windows'
         run: |
           docker system prune --all -f
           Remove-Item "C:\Android" -Force -Recurse
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/setup-python@v2
         if: runner.os == 'Linux' || runner.os == 'macOS'
         with:
-          python-version: "3.10"
+          python-version: "3.8"
       - name: "Python Dataflow example"
         if: runner.os == 'Linux' || runner.os == 'macOS'
         run: cargo run --example python-dataflow
@@ -173,7 +173,7 @@ jobs:
           cargo run --example rust-ros2-dataflow --features="ros2-examples"
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.8"
       - name: "python-ros2-dataflow"
         timeout-minutes: 30
         env:

--- a/binaries/cli/src/template/python/operator/operator-template.py
+++ b/binaries/cli/src/template/python/operator/operator-template.py
@@ -1,5 +1,3 @@
-from typing import Callable, Optional
-
 from dora import DoraStatus
 
 
@@ -14,22 +12,13 @@ class Operator:
 
     def on_event(
         self,
-        dora_event: dict,
-        send_output: Callable[[str, bytes, Optional[dict]], None],
+        dora_event,
+        send_output,
     ) -> DoraStatus:
-        if dora_event["type"] == "INPUT":
-            return self.on_input(dora_event, send_output)
-        return DoraStatus.CONTINUE
-
-    def on_input(
-        self,
-        dora_input: dict,
-        send_output: Callable[[str, bytes, Optional[dict]], None],
-    ):
         """
 
         Args:
-            dora_input (dict): Input dict containing an `id`, `data` and `metadata`.
+            dora_event: Event containing an `id`, `data` and `metadata`.
             send_output Callable[[str, bytes | pa.Array, Optional[dict]], None]:
                 Function for sending output to the dataflow:
                 - First argument is the `output_id`
@@ -44,7 +33,10 @@ class Operator:
                 STOP means that the operator stop listening for inputs.
 
         """
-        print(f"Received input {dora_input['id']}, with data: {dora_input['value']}")
+        if dora_event["type"] == "INPUT":
+            print(
+                f"Received input {dora_input['id']}, with data: {dora_input['value']}"
+            )
 
         return DoraStatus.CONTINUE
 

--- a/binaries/cli/src/template/python/operator/operator-template.py
+++ b/binaries/cli/src/template/python/operator/operator-template.py
@@ -35,7 +35,7 @@ class Operator:
         """
         if dora_event["type"] == "INPUT":
             print(
-                f"Received input {dora_input['id']}, with data: {dora_input['value']}"
+                f"Received input {dora_event['id']}, with data: {dora_event['value']}"
             )
 
         return DoraStatus.CONTINUE

--- a/examples/python-dataflow/object_detection.py
+++ b/examples/python-dataflow/object_detection.py
@@ -13,23 +13,23 @@ model = torch.hub.load("ultralytics/yolov5", "yolov5n")
 node = Node()
 
 for event in node:
-    match event["type"]:
-        case "INPUT":
-            match event["id"]:
-                case "image":
-                    print("[object detection] received image input")
-                    frame = event["value"].to_numpy()
-                    frame = cv2.imdecode(frame, -1)
-                    frame = frame[:, :, ::-1]  # OpenCV image (BGR to RGB)
-                    results = model(frame)  # includes NMS
-                    arrays = np.array(results.xyxy[0].cpu()).tobytes()
+    event_type = event["type"]
+    if event_type == "INPUT":
+        event_id = event["id"]
+        if event_id == "image":
+            print("[object detection] received image input")
+            frame = event["value"].to_numpy()
+            frame = cv2.imdecode(frame, -1)
+            frame = frame[:, :, ::-1]  # OpenCV image (BGR to RGB)
+            results = model(frame)  # includes NMS
+            arrays = np.array(results.xyxy[0].cpu()).tobytes()
 
-                    node.send_output("bbox", arrays, event["metadata"])
-                case other:
-                    print("[object detection] ignoring unexpected input:", other)
-        case "STOP":
-            print("[object detection] received stop")
-        case "ERROR":
-            print("[object detection] error: ", event["error"])
-        case other:
-            print("[object detection] received unexpected event:", other)
+            node.send_output("bbox", arrays, event["metadata"])
+        else:
+            print("[object detection] ignoring unexpected input:", event_id)
+    elif event_type == "INPUT":
+        print("[object detection] received stop")
+    elif event_type == "ERROR":
+        print("[object detection] error: ", event["error"])
+    else:
+        print("[object detection] received unexpected event:", event_type)

--- a/examples/python-dataflow/object_detection.py
+++ b/examples/python-dataflow/object_detection.py
@@ -27,7 +27,7 @@ for event in node:
             node.send_output("bbox", arrays, event["metadata"])
         else:
             print("[object detection] ignoring unexpected input:", event_id)
-    elif event_type == "INPUT":
+    elif event_type == "STOP":
         print("[object detection] received stop")
     elif event_type == "ERROR":
         print("[object detection] error: ", event["error"])

--- a/examples/python-dataflow/plot.py
+++ b/examples/python-dataflow/plot.py
@@ -26,7 +26,7 @@ class Plotter:
 
     def on_input(
         self,
-        dora_input: dict,
+        dora_input,
     ) -> DoraStatus:
         """
         Put image and bounding box on cv2 window.

--- a/examples/python-dataflow/plot.py
+++ b/examples/python-dataflow/plot.py
@@ -86,12 +86,11 @@ for event in node:
     event_type = event["type"]
     if event_type == "INPUT":
         status = plotter.on_input(event)
-        match status:
-            case DoraStatus.CONTINUE:
-                pass
-            case DoraStatus.STOP:
-                print("plotter returned stop status")
-                break
+        if status == DoraStatus.CONTINUE:
+            pass
+        elif status == DoraStatus.STOP:
+            print("plotter returned stop status")
+            break
     elif event_type == "STOP":
         print("received stop")
     else:

--- a/examples/python-dataflow/plot.py
+++ b/examples/python-dataflow/plot.py
@@ -83,16 +83,16 @@ plotter = Plotter()
 node = Node()
 
 for event in node:
-    match event["type"]:
-        case "INPUT":
-            status = plotter.on_input(event)
-            match status:
-                case DoraStatus.CONTINUE:
-                    pass
-                case DoraStatus.STOP:
-                    print("plotter returned stop status")
-                    break
-        case "STOP":
-            print("received stop")
-        case other:
-            print("received unexpected event:", other)
+    event_type = event["type"]
+    if event_type == "INPUT":
+        status = plotter.on_input(event)
+        match status:
+            case DoraStatus.CONTINUE:
+                pass
+            case DoraStatus.STOP:
+                print("plotter returned stop status")
+                break
+    elif event_type == "INPUT":
+        print("received stop")
+    else:
+        print("received unexpected event:", event_type)

--- a/examples/python-dataflow/plot.py
+++ b/examples/python-dataflow/plot.py
@@ -92,7 +92,7 @@ for event in node:
             case DoraStatus.STOP:
                 print("plotter returned stop status")
                 break
-    elif event_type == "INPUT":
+    elif event_type == "STOP":
         print("received stop")
     else:
         print("received unexpected event:", event_type)

--- a/examples/python-dataflow/webcam.py
+++ b/examples/python-dataflow/webcam.py
@@ -22,31 +22,31 @@ start = time.time()
 while time.time() - start < 10:
     # Wait next dora_input
     event = node.next()
-    match event["type"]:
-        case "INPUT":
-            ret, frame = video_capture.read()
-            if not ret:
-                frame = np.zeros((CAMERA_HEIGHT, CAMERA_WIDTH, 3), dtype=np.uint8)
-                cv2.putText(
-                    frame,
-                    "No Webcam was found at index %d" % (CAMERA_INDEX),
-                    (int(30), int(30)),
-                    font,
-                    0.75,
-                    (255, 255, 255),
-                    2,
-                    1,
-                )
-            node.send_output(
-                "image",
-                cv2.imencode(".jpg", frame)[1].tobytes(),
-                event["metadata"],
+    event_type = event["type"]
+    if event_type == "INPUT":
+        ret, frame = video_capture.read()
+        if not ret:
+            frame = np.zeros((CAMERA_HEIGHT, CAMERA_WIDTH, 3), dtype=np.uint8)
+            cv2.putText(
+                frame,
+                "No Webcam was found at index %d" % (CAMERA_INDEX),
+                (int(30), int(30)),
+                font,
+                0.75,
+                (255, 255, 255),
+                2,
+                1,
             )
-        case "STOP":
-            print("received stop")
-            break
-        case other:
-            print("received unexpected event:", other)
-            break
+        node.send_output(
+            "image",
+            cv2.imencode(".jpg", frame)[1].tobytes(),
+            event["metadata"],
+        )
+    elif event_type == "INPUT":
+        print("received stop")
+        break
+    else:
+        print("received unexpected event:", event_type)
+        break
 
 video_capture.release()

--- a/examples/python-dataflow/webcam.py
+++ b/examples/python-dataflow/webcam.py
@@ -42,7 +42,7 @@ while time.time() - start < 10:
             cv2.imencode(".jpg", frame)[1].tobytes(),
             event["metadata"],
         )
-    elif event_type == "INPUT":
+    elif event_type == "STOP":
         print("received stop")
         break
     else:

--- a/examples/python-operator-dataflow/object_detection.py
+++ b/examples/python-operator-dataflow/object_detection.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from typing import Callable, Optional
 
 import cv2
 import numpy as np
@@ -26,8 +25,8 @@ class Operator:
 
     def on_event(
         self,
-        dora_event: dict,
-        send_output: Callable[[str, bytes | pa.Array, Optional[dict]], None],
+        dora_event,
+        send_output,
     ) -> DoraStatus:
         if dora_event["type"] == "INPUT":
             return self.on_input(dora_event, send_output)
@@ -35,12 +34,12 @@ class Operator:
 
     def on_input(
         self,
-        dora_input: dict,
-        send_output: Callable[[str, bytes | pa.Array, Optional[dict]], None],
+        dora_input,
+        send_output,
     ) -> DoraStatus:
         """Handle image
         Args:
-            dora_input (dict): Dict containing the "id", value, and "metadata"
+            dora_input (dict) containing the "id", value, and "metadata"
             send_output Callable[[str, bytes | pa.Array, Optional[dict]], None]:
                 Function for sending output to the dataflow:
                 - First argument is the `output_id`

--- a/examples/python-operator-dataflow/plot.py
+++ b/examples/python-operator-dataflow/plot.py
@@ -2,14 +2,13 @@
 # -*- coding: utf-8 -*-
 
 import os
-from typing import Callable, Optional
 
 import cv2
 import numpy as np
 import pyarrow as pa
-from utils import LABELS
 
 from dora import DoraStatus
+from utils import LABELS
 
 pa.array([])
 
@@ -33,8 +32,8 @@ class Operator:
 
     def on_event(
         self,
-        dora_event: dict,
-        send_output: Callable[[str, bytes | pa.Array, Optional[dict]], None],
+        dora_event,
+        send_output,
     ) -> DoraStatus:
         if dora_event["type"] == "INPUT":
             return self.on_input(dora_event, send_output)
@@ -42,8 +41,8 @@ class Operator:
 
     def on_input(
         self,
-        dora_input: dict,
-        send_output: Callable[[str, bytes | pa.Array, Optional[dict]], None],
+        dora_input,
+        send_output,
     ) -> DoraStatus:
         """
         Put image and bounding box on cv2 window.

--- a/examples/python-operator-dataflow/webcam.py
+++ b/examples/python-operator-dataflow/webcam.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import time
-from typing import Callable, Optional
-
 import os
+import time
+
 import cv2
 import numpy as np
 import pyarrow as pa
@@ -32,7 +31,7 @@ class Operator:
     def on_event(
         self,
         dora_event: str,
-        send_output: Callable[[str, bytes | pa.Array, Optional[dict]], None],
+        send_output,
     ) -> DoraStatus:
         match dora_event["type"]:
             case "INPUT":

--- a/examples/python-operator-dataflow/webcam.py
+++ b/examples/python-operator-dataflow/webcam.py
@@ -58,7 +58,7 @@ class Operator:
                 pa.array(frame.ravel()),
                 dora_event["metadata"],
             )
-        elif event_type == "INPUT":
+        elif event_type == "STOP":
             print("received stop")
         else:
             print("received unexpected event:", event_type)

--- a/examples/python-operator-dataflow/webcam.py
+++ b/examples/python-operator-dataflow/webcam.py
@@ -33,35 +33,35 @@ class Operator:
         dora_event: str,
         send_output,
     ) -> DoraStatus:
-        match dora_event["type"]:
-            case "INPUT":
-                ret, frame = self.video_capture.read()
-                if ret:
-                    frame = cv2.resize(frame, (CAMERA_WIDTH, CAMERA_HEIGHT))
+        event_type = dora_event["type"]
+        if event_type == "INPUT":
+            ret, frame = self.video_capture.read()
+            if ret:
+                frame = cv2.resize(frame, (CAMERA_WIDTH, CAMERA_HEIGHT))
 
-                ## Push an error image in case the camera is not available.
-                else:
-                    frame = np.zeros((CAMERA_HEIGHT, CAMERA_WIDTH, 3), dtype=np.uint8)
-                    cv2.putText(
-                        frame,
-                        "No Webcam was found at index %d" % (CAMERA_INDEX),
-                        (int(30), int(30)),
-                        font,
-                        0.75,
-                        (255, 255, 255),
-                        2,
-                        1,
-                    )
-
-                send_output(
-                    "image",
-                    pa.array(frame.ravel()),
-                    dora_event["metadata"],
+            ## Push an error image in case the camera is not available.
+            else:
+                frame = np.zeros((CAMERA_HEIGHT, CAMERA_WIDTH, 3), dtype=np.uint8)
+                cv2.putText(
+                    frame,
+                    "No Webcam was found at index %d" % (CAMERA_INDEX),
+                    (int(30), int(30)),
+                    font,
+                    0.75,
+                    (255, 255, 255),
+                    2,
+                    1,
                 )
-            case "STOP":
-                print("received stop")
-            case other:
-                print("received unexpected event:", other)
+
+            send_output(
+                "image",
+                pa.array(frame.ravel()),
+                dora_event["metadata"],
+            )
+        elif event_type == "INPUT":
+            print("received stop")
+        else:
+            print("received unexpected event:", event_type)
 
         if time.time() - self.start_time < 20:
             return DoraStatus.CONTINUE

--- a/examples/python-ros2-dataflow/control_node.py
+++ b/examples/python-ros2-dataflow/control_node.py
@@ -12,22 +12,22 @@ for i in range(500):
     if event is None:
         break
     if event["type"] == "INPUT":
-        match event["id"]:
-            case "turtle_pose":
-                print(
-                    f"""Pose: {event["value"].tolist()}""".replace("\r", "").replace(
-                        "\n", " "
-                    )
+        event_id = event["id"]
+        if event_id == "turtle_pose":
+            print(
+                f"""Pose: {event["value"].tolist()}""".replace("\r", "").replace(
+                    "\n", " "
                 )
-            case "tick":
-                direction = {
-                    "linear": {
-                        "x": 1.0 + random.random(),
-                    },
-                    "angular": {"z": (random.random() - 0.5) * 5},
-                }
+            )
+        elif event_id == "tick":
+            direction = {
+                "linear": {
+                    "x": 1.0 + random.random(),
+                },
+                "angular": {"z": (random.random() - 0.5) * 5},
+            }
 
-                node.send_output(
-                    "direction",
-                    pa.array([direction]),
-                )
+            node.send_output(
+                "direction",
+                pa.array([direction]),
+            )

--- a/examples/python-ros2-dataflow/random_turtle.py
+++ b/examples/python-ros2-dataflow/random_turtle.py
@@ -43,20 +43,20 @@ for i in range(500):
     event = dora_node.next()
     if event is None:
         break
-    match event["kind"]:
-        # Dora event
-        case "dora":
-            match event["type"]:
-                case "INPUT":
-                    match event["id"]:
-                        case "direction":
-                            twist_writer.publish(event["value"])
+    event_kind = event["kind"]
+    # Dora event
+    if event_kind == "dora":
+        event_type = event["type"]
+        if event_type == "INPUT":
+            event_id = event["id"]
+            if event_id == "direction":
+                twist_writer.publish(event["value"])
 
         # ROS2 Event
-        case "external":
-            pose = event.inner()[0].as_py()
-            if i == CHECK_TICK:
-                assert (
-                    pose["x"] != 5.544444561004639
-                ), "turtle should not be at initial x axis"
-            dora_node.send_output("turtle_pose", event.inner())
+    elif event_kind == "external":
+        pose = event.inner()[0].as_py()
+        if i == CHECK_TICK:
+            assert (
+                pose["x"] != 5.544444561004639
+            ), "turtle should not be at initial x axis"
+        dora_node.send_output("turtle_pose", event.inner())


### PR DESCRIPTION
This PR removes:
- type hinting as it is a source of errors for legacy python version
- removes `match` as it is only supported since python `3.10` 


that is unfortunately that legacy python is still so common

 FIx: #379 