### PR TITLE
Fix window path error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  RUST_LOG: trace
+  RUST_LOG: INFO
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,8 @@ jobs:
 
       # python examples
       - uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
       - name: "Python Dataflow example"
         run: cargo run --example python-dataflow
       - name: "Python Operator Dataflow example"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,13 +65,7 @@ jobs:
       - name: "Build"
         run: cargo build --all
       - name: "Test"
-        # Remove Windows as there is `pdb` linker issue.
-        # See: https://github.com/dora-rs/dora/pull/359#discussion_r1360268497
-        if: runner.os == 'Linux' || runner.os == 'macOS'
         run: cargo test --all
-      - name: "Test"
-        if: runner.os == 'Windows'
-        run: cargo test --all --lib
 
   # Run examples as separate job because otherwise we will exhaust the disk
   # space of the GitHub action runners.
@@ -138,14 +132,9 @@ jobs:
 
       # python examples
       - uses: actions/setup-python@v2
-        if: runner.os == 'Linux' || runner.os == 'macOS'
-        with:
-          python-version: "3.8"
       - name: "Python Dataflow example"
-        if: runner.os == 'Linux' || runner.os == 'macOS'
         run: cargo run --example python-dataflow
       - name: "Python Operator Dataflow example"
-        if: runner.os == 'Linux' || runner.os == 'macOS'
         run: cargo run --example python-operator-dataflow
 
   # ROS2 bridge examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,8 +132,13 @@ jobs:
 
       # python examples
       - uses: actions/setup-python@v2
+        if: runner.os != 'Windows'
         with:
           python-version: "3.8"
+      - uses: actions/setup-python@v2
+        if: runner.os == 'Windows'
+        with:
+          python-version: "3.10"
       - name: "Python Dataflow example"
         run: cargo run --example python-dataflow
       - name: "Python Operator Dataflow example"
@@ -167,8 +172,13 @@ jobs:
           source /opt/ros/humble/setup.bash && ros2 run turtlesim turtlesim_node &
           cargo run --example rust-ros2-dataflow --features="ros2-examples"
       - uses: actions/setup-python@v2
+        if: runner.os != 'Windows'
         with:
           python-version: "3.8"
+      - uses: actions/setup-python@v2
+        if: runner.os == 'Windows'
+        with:
+          python-version: "3.10"
       - name: "python-ros2-dataflow"
         timeout-minutes: 30
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # Remove arrow file from dora-record
 **/*.arrow
+*.pt
 
 # Removing images.
 *.jpg

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1241,9 +1241,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.107"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ce20f6b8433da4841b1dadfb9468709868022d829d5ca1f2ffbda928455ea3"
+checksum = "51bc81d2664db24cf1d35405f66e18a85cffd4d49ab930c71a5c6342a410f38c"
 dependencies = [
  "cc",
  "codespan-reporting",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1491,6 +1491,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "uuid",
+ "which",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1511,6 +1511,7 @@ dependencies = [
  "dora-coordinator",
  "dora-core",
  "dora-daemon",
+ "dora-download",
  "dora-tracing",
  "dunce",
  "eyre",
@@ -2494,6 +2495,20 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "rustls 0.21.10",
+ "tokio",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -4508,6 +4523,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "ipnet",
  "js-sys",
  "log",
@@ -4516,16 +4532,19 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.10",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "system-configuration",
  "tokio",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 0.25.3",
  "winreg",
 ]
 
@@ -5556,6 +5575,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.10",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6073,6 +6102,12 @@ checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
 
 [[package]]
 name = "which"
@@ -6706,7 +6741,7 @@ dependencies = [
  "log",
  "rustls-pemfile",
  "webpki",
- "webpki-roots",
+ "webpki-roots 0.22.6",
  "zenoh-cfg-properties",
  "zenoh-config",
  "zenoh-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,12 +61,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
-
-[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,166 +796,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
 
 [[package]]
-name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.11+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
-name = "cab"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6b4de23c7d39c0631fd3cc952d87951c86c75a13812d7247cb7a896e7b3551"
-dependencies = [
- "byteorder",
- "flate2",
- "lzxd",
- "time",
-]
-
-[[package]]
 name = "cache-padded"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "981520c98f422fcc584dc1a95c334e6953900b9106bc47a9839b81790009eb21"
 
 [[package]]
-name = "camino"
-version = "1.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "capnp"
 version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dca085c2c7d9d65ad749d450b19b551efaa8e3476a439bdca07aca8533097f3"
-
-[[package]]
-name = "cargo-config2"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90811f7e462b86622e20549c1c43bb3861d1bf011a08c2ceceaeb51fdfc27402"
-dependencies = [
- "home",
- "serde",
- "serde_derive",
- "toml_edit",
-]
-
-[[package]]
-name = "cargo-options"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad71bf996c8e5b9d28ef3472d7ee41f277edf4e38cd597f51ad0438d05d76ea"
-dependencies = [
- "anstyle",
- "clap 4.4.6",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceed8ef69d8518a5dda55c07425450b58a4e1946f4951eab6d7191ee86c2443d"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo-xwin"
-version = "0.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6afd4dab5fb38f9ec394ff7cd2aab95e5ddf581448afb9c42349ff849daed858"
-dependencies = [
- "anyhow",
- "cargo-config2",
- "cargo-options",
- "clap 4.4.6",
- "dirs 5.0.1",
- "fs-err",
- "indicatif",
- "paste",
- "path-slash",
- "rustls 0.21.10",
- "rustls-pemfile 2.0.0",
- "tracing-subscriber",
- "ureq",
- "which",
- "xwin",
-]
-
-[[package]]
-name = "cargo-zigbuild"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187bb78a5f84e16e6c09df00e9b9e7b456ae13a156fbdde6a877f064f1e2c5dd"
-dependencies = [
- "anyhow",
- "cargo-options",
- "cargo_metadata",
- "clap 4.4.6",
- "dirs 5.0.1",
- "fs-err",
- "path-slash",
- "rustc_version",
- "semver",
- "serde",
- "serde_json",
- "shlex",
- "target-lexicon",
- "which",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "cbindgen"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da6bc11b07529f16944307272d5bd9b22530bc7d05751717c9d416586cedab49"
-dependencies = [
- "heck 0.4.1",
- "indexmap 1.9.3",
- "log",
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "syn 1.0.109",
- "tempfile",
- "toml 0.5.11",
-]
 
 [[package]]
 name = "cc"
@@ -1000,17 +844,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
-name = "cfb"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b390793e912300f1aa713429f7fd0c391024e6c18b988962558bc4f96a349b1f"
-dependencies = [
- "byteorder",
- "fnv",
- "uuid",
-]
-
-[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,16 +854,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "charset"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e9079d1a12a2cc2bffb5db039c43661836ead4082120d5844f02555aca2d46"
-dependencies = [
- "base64 0.13.1",
- "encoding_rs",
-]
 
 [[package]]
 name = "chrono"
@@ -1045,16 +868,6 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "chumsky"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eebd66744a15ded14960ab4ccdbfb51ad3b81f51f3f04a80adac98c985396c9"
-dependencies = [
- "hashbrown 0.14.3",
- "stacker",
 ]
 
 [[package]]
@@ -1108,47 +921,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap_complete"
-version = "4.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97aeaa95557bd02f23fbb662f981670c3d20c5a26e69f7354b28f57092437fcd"
-dependencies = [
- "clap 4.4.6",
-]
-
-[[package]]
-name = "clap_complete_command"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183495371ea78d4c9ff638bfc6497d46fed2396e4f9c50aebc1278a4a9919a3d"
-dependencies = [
- "clap 4.4.6",
- "clap_complete",
- "clap_complete_fig",
- "clap_complete_nushell",
-]
-
-[[package]]
-name = "clap_complete_fig"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e571d70e22ec91d34e1c5317c8308035a2280d925167646bf094fc5de1737c"
-dependencies = [
- "clap 4.4.6",
- "clap_complete",
-]
-
-[[package]]
-name = "clap_complete_nushell"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d02bc8b1a18ee47c4d2eec3fb5ac034dc68ebea6125b1509e9ccdffcddce66e"
-dependencies = [
- "clap 4.4.6",
- "clap_complete",
-]
-
-[[package]]
 name = "clap_derive"
 version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1187,16 +959,6 @@ name = "clap_lex"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
-
-[[package]]
-name = "cli-table"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfbb116d9e2c4be7011360d0c0bee565712c11e969c9609b25b619366dc379d"
-dependencies = [
- "termcolor",
- "unicode-width",
-]
 
 [[package]]
 name = "clircle"
@@ -1256,12 +1018,6 @@ checksum = "f057a694a54f12365049b0958a1685bb52d567f5593b355fbf685838e873d400"
 dependencies = [
  "crossbeam-utils",
 ]
-
-[[package]]
-name = "configparser"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec6d3da8e550377a85339063af6e3735f4b1d9392108da4e083a1b3b9820288"
 
 [[package]]
 name = "console"
@@ -1563,12 +1319,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "data-encoding"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
-
-[[package]]
 name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1584,18 +1334,6 @@ name = "deranged"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
-
-[[package]]
-name = "dialoguer"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
-dependencies = [
- "console",
- "shell-words",
- "thiserror",
- "zeroize",
-]
 
 [[package]]
 name = "digest"
@@ -1714,7 +1452,6 @@ dependencies = [
  "aligned-vec",
  "dora-message",
  "eyre",
- "maturin",
  "once_cell",
  "serde",
  "serde-with-expand-env",
@@ -2258,15 +1995,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
-name = "fat-macho"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63fa117c7dcabeb8c83d5c229764cfa46518545d2dba5a9a08912014711f997b"
-dependencies = [
- "goblin 0.7.1",
-]
-
-[[package]]
 name = "filetime"
 version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2330,15 +2058,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fs-err"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -2602,28 +2321,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "goblin"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27c1b4369c2cd341b5de549380158b105a04c331be5db9110eef7b6d2742134"
-dependencies = [
- "log",
- "plain",
- "scroll 0.11.0",
-]
-
-[[package]]
-name = "goblin"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb07a4ffed2093b118a525b1d8f5204ae274faed5604537caf7135d0f18d9887"
-dependencies = [
- "log",
- "plain",
- "scroll 0.12.0",
-]
-
-[[package]]
 name = "grep-cli"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2680,10 +2377,6 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "heck"
@@ -2865,22 +2558,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ignore"
-version = "0.4.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
-dependencies = [
- "crossbeam-deque",
- "globset",
- "log",
- "memchr",
- "regex-automata 0.4.3",
- "same-file",
- "walkdir",
- "winapi-util",
-]
-
-[[package]]
 name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2904,20 +2581,6 @@ checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
- "serde",
-]
-
-[[package]]
-name = "indicatif"
-version = "0.17.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb28741c9db9a713d93deb3bb9515c20788cef5815265bee4980e87bde7e0f25"
-dependencies = [
- "console",
- "instant",
- "number_prefix",
- "portable-atomic",
- "unicode-width",
 ]
 
 [[package]]
@@ -3086,24 +2749,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3222,17 +2867,6 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
-name = "lddtree"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f88a93876d2485ede9c97d698c164cf5c024491908483964a998faae9705dea6"
-dependencies = [
- "fs-err",
- "glob",
- "goblin 0.8.0",
-]
 
 [[package]]
 name = "lexical-core"
@@ -3412,12 +3046,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lzxd"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784462f20dddd9dfdb45de963fa4ad4a288cb10a7889ac5d2c34fb6481c6b213"
-
-[[package]]
 name = "macro_rules_attribute"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3432,17 +3060,6 @@ name = "macro_rules_attribute-proc_macro"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58093314a45e00c77d5c508f76e77c3396afbbc0d01506e7fae47b018bac2b1d"
-
-[[package]]
-name = "mailparse"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b56570f5f8c0047260d1c8b5b331f62eb9c660b9dd4071a8c46f8c7d3f280aa"
-dependencies = [
- "charset",
- "data-encoding",
- "quoted_printable",
-]
 
 [[package]]
 name = "malloc_buf"
@@ -3467,72 +3084,6 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
-name = "maturin"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a36720938833f89c67b698065cf6707a95f6df954a2c7796097ddafe2ef45c5"
-dependencies = [
- "anyhow",
- "base64 0.21.4",
- "bytesize",
- "cargo-config2",
- "cargo-options",
- "cargo-xwin",
- "cargo-zigbuild",
- "cargo_metadata",
- "cbindgen",
- "cc",
- "clap 4.4.6",
- "clap_complete_command",
- "configparser",
- "console",
- "dialoguer",
- "dirs 5.0.1",
- "dunce",
- "fat-macho",
- "flate2",
- "fs-err",
- "glob",
- "goblin 0.7.1",
- "ignore",
- "indexmap 2.0.2",
- "itertools 0.12.0",
- "lddtree",
- "minijinja",
- "multipart",
- "normpath",
- "once_cell",
- "path-slash",
- "pep440_rs",
- "pep508_rs",
- "platform-info",
- "pyproject-toml",
- "python-pkginfo",
- "regex",
- "rustc_version",
- "rustls 0.21.10",
- "rustls-pemfile 2.0.0",
- "semver",
- "serde",
- "serde_json",
- "sha2",
- "tar",
- "target-lexicon",
- "tempfile",
- "textwrap",
- "thiserror",
- "time",
- "toml 0.8.8",
- "toml_edit",
- "tracing",
- "tracing-subscriber",
- "ureq",
- "url",
- "wild",
- "zip",
-]
 
 [[package]]
 name = "md5"
@@ -3587,25 +3138,6 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "mime_guess"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
-name = "minijinja"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "431d72874542d43aba1ca605870eacab134fdeb0c8fe27666ecf4b2662239df2"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "minimal-lexical"
@@ -3675,31 +3207,6 @@ dependencies = [
  "net2",
  "winapi 0.2.8",
  "ws2_32-sys",
-]
-
-[[package]]
-name = "msi"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226b2404f03d2cf47375b9715c8adfae4e388bb2377cff908e8a40f31e421514"
-dependencies = [
- "byteorder",
- "cfb",
- "encoding_rs",
- "uuid",
-]
-
-[[package]]
-name = "multipart"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00dec633863867f29cb39df64a397cdf4a6354708ddd7759f70c7fb51c5f9182"
-dependencies = [
- "log",
- "mime",
- "mime_guess",
- "rand",
- "tempfile",
 ]
 
 [[package]]
@@ -3849,15 +3356,6 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "normpath"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec60c60a693226186f5d6edf073232bfb6464ed97eb22cf3b01c1e8198fd97f5"
-dependencies = [
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4020,12 +3518,6 @@ dependencies = [
  "hermit-abi 0.3.3",
  "libc",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "nvml-wrapper"
@@ -4349,12 +3841,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
-name = "path-slash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
-
-[[package]]
 name = "path_abs"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4370,34 +3856,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
 dependencies = [
  "base64ct",
-]
-
-[[package]]
-name = "pep440_rs"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "887f66cc62717ea72caac4f1eb4e6f392224da3ffff3f40ec13ab427802746d6"
-dependencies = [
- "lazy_static",
- "regex",
- "serde",
- "unicode-width",
-]
-
-[[package]]
-name = "pep508_rs"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4516b53d9ea6112ebb38b4af08d5707d30b994fb7f98ff133c5dcf7ed8fa854"
-dependencies = [
- "once_cell",
- "pep440_rs",
- "regex",
- "serde",
- "thiserror",
- "tracing",
- "unicode-width",
- "url",
 ]
 
 [[package]]
@@ -4533,22 +3991,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
-name = "platform-info"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6259c4860e53bf665016f1b2f46a8859cadfa717581dc9d597ae4069de6300f"
-dependencies = [
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "plist"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4668,12 +4110,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "portable-atomic"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4745,19 +4181,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "psm"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -4821,34 +4248,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
-]
-
-[[package]]
-name = "pyproject-toml"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46d4a5e69187f23a29f8aa0ea57491d104ba541bc55f76552c2a74962aa20e04"
-dependencies = [
- "indexmap 2.0.2",
- "pep440_rs",
- "pep508_rs",
- "serde",
- "toml 0.8.8",
-]
-
-[[package]]
-name = "python-pkginfo"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037469c164f08c891bf6d69ca02f1d56210011451e229618669777df82124cfa"
-dependencies = [
- "flate2",
- "fs-err",
- "mailparse",
- "rfc2047-decoder",
- "tar",
- "thiserror",
- "zip",
 ]
 
 [[package]]
@@ -4928,12 +4327,6 @@ checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "quoted_printable"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3866219251662ec3b26fc217e3e05bf9c4f84325234dfb96bf0bf840889e49"
 
 [[package]]
 name = "radium"
@@ -5024,15 +4417,6 @@ name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
@@ -5143,20 +4527,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
-]
-
-[[package]]
-name = "rfc2047-decoder"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61fc4b4e52897c3e30b12b7e9b04461215b647fbe66f6def60dd8edbce14ec2e"
-dependencies = [
- "base64 0.21.4",
- "charset",
- "chumsky",
- "memchr",
- "quoted_printable",
- "thiserror",
 ]
 
 [[package]]
@@ -5399,7 +4769,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 1.0.3",
+ "rustls-pemfile",
  "schannel",
  "security-framework",
 ]
@@ -5412,22 +4782,6 @@ checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
  "base64 0.21.4",
 ]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e4980fa29e4c4b212ffb3db068a564cbf560e51d3944b7c88bd8bf5bec64f4"
-dependencies = [
- "base64 0.21.4",
- "rustls-pki-types",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9d979b3ce68192e42760c7810125eb6cf2ea10efae545a156063e61f314e2a"
 
 [[package]]
 name = "rustls-webpki"
@@ -5519,46 +4873,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3cf7c11c38cb994f3d40e8a8cde3bbd1f72a435e4c49e85d6553d8312306152"
 
 [[package]]
-name = "scroll"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
-dependencies = [
- "scroll_derive 0.11.1",
-]
-
-[[package]]
-name = "scroll"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
-dependencies = [
- "scroll_derive 0.12.0",
-]
-
-[[package]]
-name = "scroll_derive"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
-name = "scroll_derive"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
 name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5596,9 +4910,6 @@ name = "semver"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad977052201c6de01a8ef2aa3378c4bd23217a056337d1d6da40468d267a4fb0"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "serde"
@@ -5668,15 +4979,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -5802,12 +5104,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shlex"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
-
-[[package]]
 name = "signal-hook"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5863,12 +5159,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
-name = "smawk"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
-
-[[package]]
 name = "socket2"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5899,17 +5189,6 @@ dependencies = [
  "rustix 0.38.28",
  "uuid",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "socks"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
-dependencies = [
- "byteorder",
- "libc",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -5956,19 +5235,6 @@ checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
  "der",
-]
-
-[[package]]
-name = "stacker"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
-dependencies = [
- "cc",
- "cfg-if 1.0.0",
- "libc",
- "psm",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -6115,34 +5381,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
-name = "tar"
-version = "0.4.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
-
-[[package]]
 name = "target-lexicon"
 version = "0.12.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a"
-
-[[package]]
-name = "tempfile"
-version = "3.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
-dependencies = [
- "cfg-if 1.0.0",
- "fastrand 2.0.1",
- "redox_syscall 0.4.1",
- "rustix 0.38.28",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "termcolor"
@@ -6168,11 +5410,6 @@ name = "textwrap"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
-dependencies = [
- "smawk",
- "unicode-linebreak",
- "unicode-width",
-]
 
 [[package]]
 name = "thiserror"
@@ -6344,49 +5581,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
-dependencies = [
- "indexmap 2.0.2",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow",
-]
-
-[[package]]
 name = "tonic"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6452,7 +5646,6 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -6505,16 +5698,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6524,15 +5707,12 @@ dependencies = [
  "nu-ansi-term 0.46.0",
  "once_cell",
  "regex",
- "serde",
- "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]
@@ -6540,17 +5720,6 @@ name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
-
-[[package]]
-name = "twox-hash"
-version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if 1.0.0",
- "rand",
- "static_assertions",
-]
 
 [[package]]
 name = "typenum"
@@ -6580,15 +5749,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicase"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6599,12 +5759,6 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "unicode-linebreak"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization"
@@ -6678,25 +5832,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ureq"
-version = "2.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cdd25c339e200129fe4de81451814e5228c9b771d57378817d6117cc2b3f97"
-dependencies = [
- "base64 0.21.4",
- "flate2",
- "log",
- "once_cell",
- "rustls 0.21.10",
- "rustls-webpki",
- "serde",
- "serde_json",
- "socks",
- "url",
- "webpki-roots 0.25.3",
-]
-
-[[package]]
 name = "url"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6705,7 +5840,6 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
- "serde",
 ]
 
 [[package]]
@@ -6796,16 +5930,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "versions"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c73a36bc44e3039f51fbee93e39f41225f6b17b380eb70cc2aab942df06b34dd"
-dependencies = [
- "itertools 0.11.0",
- "nom",
-]
 
 [[package]]
 name = "waker-fn"
@@ -6949,12 +6073,6 @@ checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
 
 [[package]]
 name = "which"
@@ -7302,15 +6420,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
-name = "winnow"
-version = "0.5.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7520bbdec7211caa7c4e682eb1fbe07abe20cee6756b6e00f537c82c11816aa"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7369,51 +6478,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
-]
-
-[[package]]
-name = "xattr"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914566e6413e7fa959cc394fb30e563ba80f3541fbd40816d4c05a0fc3f2a0f1"
-dependencies = [
- "libc",
- "linux-raw-sys 0.4.12",
- "rustix 0.38.28",
-]
-
-[[package]]
-name = "xwin"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43e0202f5457b48558096cb7b36d0e473f267551a89c82ed72d73b01dfd4007"
-dependencies = [
- "anyhow",
- "bytes",
- "cab",
- "camino",
- "clap 4.4.6",
- "cli-table",
- "crossbeam-channel",
- "flate2",
- "indicatif",
- "memchr",
- "msi",
- "parking_lot",
- "rayon",
- "regex",
- "serde",
- "serde_json",
- "sha2",
- "tempfile",
- "toml 0.8.8",
- "tracing",
- "tracing-subscriber",
- "twox-hash",
- "ureq",
- "versions",
- "walkdir",
- "zip",
 ]
 
 [[package]]
@@ -7602,7 +6666,7 @@ dependencies = [
  "quinn",
  "rustls 0.20.9",
  "rustls-native-certs",
- "rustls-pemfile 1.0.3",
+ "rustls-pemfile",
  "webpki",
  "zenoh-cfg-properties",
  "zenoh-config",
@@ -7640,9 +6704,9 @@ dependencies = [
  "async-trait",
  "futures",
  "log",
- "rustls-pemfile 1.0.3",
+ "rustls-pemfile",
  "webpki",
- "webpki-roots 0.22.6",
+ "webpki-roots",
  "zenoh-cfg-properties",
  "zenoh-config",
  "zenoh-core",
@@ -7735,7 +6799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdf3eaea2095d2c13fefdae25aca813b3644fc15e1441e16a4398b5113033753"
 dependencies = [
  "hex",
- "itertools 0.10.5",
+ "itertools",
  "lazy_static",
  "rand",
  "serde",
@@ -7839,17 +6903,3 @@ name = "zeroize"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
-
-[[package]]
-name = "zip"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
-dependencies = [
- "byteorder",
- "bzip2",
- "crc32fast",
- "crossbeam-utils",
- "flate2",
- "time",
-]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,15 +30,16 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
 dependencies = [
  "cfg-if 1.0.0",
  "const-random",
  "getrandom",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -58,6 +59,12 @@ checksum = "4aa90d7ce82d4be67b64039a3d588d38dbcc6736577de4a847025ce5b0c468d1"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "android-tzdata"
@@ -193,7 +200,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "hashbrown 0.14.1",
+ "hashbrown 0.14.3",
  "num",
 ]
 
@@ -317,7 +324,7 @@ dependencies = [
  "arrow-data",
  "arrow-schema",
  "half",
- "hashbrown 0.14.1",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -511,7 +518,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -795,16 +802,166 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
 
 [[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "cab"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae6b4de23c7d39c0631fd3cc952d87951c86c75a13812d7247cb7a896e7b3551"
+dependencies = [
+ "byteorder",
+ "flate2",
+ "lzxd",
+ "time",
+]
+
+[[package]]
 name = "cache-padded"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "981520c98f422fcc584dc1a95c334e6953900b9106bc47a9839b81790009eb21"
 
 [[package]]
+name = "camino"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "capnp"
 version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dca085c2c7d9d65ad749d450b19b551efaa8e3476a439bdca07aca8533097f3"
+
+[[package]]
+name = "cargo-config2"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90811f7e462b86622e20549c1c43bb3861d1bf011a08c2ceceaeb51fdfc27402"
+dependencies = [
+ "home",
+ "serde",
+ "serde_derive",
+ "toml_edit",
+]
+
+[[package]]
+name = "cargo-options"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad71bf996c8e5b9d28ef3472d7ee41f277edf4e38cd597f51ad0438d05d76ea"
+dependencies = [
+ "anstyle",
+ "clap 4.4.6",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceed8ef69d8518a5dda55c07425450b58a4e1946f4951eab6d7191ee86c2443d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-xwin"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6afd4dab5fb38f9ec394ff7cd2aab95e5ddf581448afb9c42349ff849daed858"
+dependencies = [
+ "anyhow",
+ "cargo-config2",
+ "cargo-options",
+ "clap 4.4.6",
+ "dirs 5.0.1",
+ "fs-err",
+ "indicatif",
+ "paste",
+ "path-slash",
+ "rustls 0.21.10",
+ "rustls-pemfile 2.0.0",
+ "tracing-subscriber",
+ "ureq",
+ "which",
+ "xwin",
+]
+
+[[package]]
+name = "cargo-zigbuild"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "187bb78a5f84e16e6c09df00e9b9e7b456ae13a156fbdde6a877f064f1e2c5dd"
+dependencies = [
+ "anyhow",
+ "cargo-options",
+ "cargo_metadata",
+ "clap 4.4.6",
+ "dirs 5.0.1",
+ "fs-err",
+ "path-slash",
+ "rustc_version",
+ "semver",
+ "serde",
+ "serde_json",
+ "shlex",
+ "target-lexicon",
+ "which",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "cbindgen"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da6bc11b07529f16944307272d5bd9b22530bc7d05751717c9d416586cedab49"
+dependencies = [
+ "heck 0.4.1",
+ "indexmap 1.9.3",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 1.0.109",
+ "tempfile",
+ "toml 0.5.11",
+]
 
 [[package]]
 name = "cc"
@@ -843,6 +1000,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cfb"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b390793e912300f1aa713429f7fd0c391024e6c18b988962558bc4f96a349b1f"
+dependencies = [
+ "byteorder",
+ "fnv",
+ "uuid",
+]
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,6 +1021,16 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "charset"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e9079d1a12a2cc2bffb5db039c43661836ead4082120d5844f02555aca2d46"
+dependencies = [
+ "base64 0.13.1",
+ "encoding_rs",
+]
 
 [[package]]
 name = "chrono"
@@ -867,6 +1045,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "chumsky"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eebd66744a15ded14960ab4ccdbfb51ad3b81f51f3f04a80adac98c985396c9"
+dependencies = [
+ "hashbrown 0.14.3",
+ "stacker",
 ]
 
 [[package]]
@@ -920,6 +1108,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97aeaa95557bd02f23fbb662f981670c3d20c5a26e69f7354b28f57092437fcd"
+dependencies = [
+ "clap 4.4.6",
+]
+
+[[package]]
+name = "clap_complete_command"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183495371ea78d4c9ff638bfc6497d46fed2396e4f9c50aebc1278a4a9919a3d"
+dependencies = [
+ "clap 4.4.6",
+ "clap_complete",
+ "clap_complete_fig",
+ "clap_complete_nushell",
+]
+
+[[package]]
+name = "clap_complete_fig"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e571d70e22ec91d34e1c5317c8308035a2280d925167646bf094fc5de1737c"
+dependencies = [
+ "clap 4.4.6",
+ "clap_complete",
+]
+
+[[package]]
+name = "clap_complete_nushell"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d02bc8b1a18ee47c4d2eec3fb5ac034dc68ebea6125b1509e9ccdffcddce66e"
+dependencies = [
+ "clap 4.4.6",
+ "clap_complete",
+]
+
+[[package]]
 name = "clap_derive"
 version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -941,7 +1170,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -958,6 +1187,16 @@ name = "clap_lex"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+
+[[package]]
+name = "cli-table"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adfbb116d9e2c4be7011360d0c0bee565712c11e969c9609b25b619366dc379d"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
 
 [[package]]
 name = "clircle"
@@ -1019,6 +1258,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "configparser"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec6d3da8e550377a85339063af6e3735f4b1d9392108da4e083a1b3b9820288"
+
+[[package]]
 name = "console"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,23 +1284,21 @@ checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
 
 [[package]]
 name = "const-random"
-version = "0.1.15"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368a7a772ead6ce7e1de82bfb04c485f3db8ec744f72925af5735e29a22cc18e"
+checksum = "5aaf16c9c2c612020bcfd042e170f6e32de9b9d75adb5277cdbbd2e2c8c8299a"
 dependencies = [
  "const-random-macro",
- "proc-macro-hack",
 ]
 
 [[package]]
 name = "const-random-macro"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d7d6ab3c3a2282db210df5f02c4dab6e0a7057af0fb7ebd4070f30fe05c0ddb"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
  "getrandom",
  "once_cell",
- "proc-macro-hack",
  "tiny-keccak",
 ]
 
@@ -1251,7 +1494,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1268,7 +1511,7 @@ checksum = "2fa16a70dd58129e4dfffdff535fb1bce66673f7bbeec4a5a1765a504e1ccd84"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1313,11 +1556,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if 1.0.0",
- "hashbrown 0.14.1",
+ "hashbrown 0.14.3",
  "lock_api",
  "once_cell",
  "parking_lot_core",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
 name = "der"
@@ -1335,6 +1584,18 @@ name = "deranged"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+
+[[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "thiserror",
+ "zeroize",
+]
 
 [[package]]
 name = "digest"
@@ -1453,6 +1714,7 @@ dependencies = [
  "aligned-vec",
  "dora-message",
  "eyre",
+ "maturin",
  "once_cell",
  "serde",
  "serde-with-expand-env",
@@ -1903,7 +2165,7 @@ checksum = "f95e2801cd355d4a1a3e3953ce6ee5ae9603a5c833455343a8bfe3f44d418246"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1927,23 +2189,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.4"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add4f07d43996f76ef320709726a556a9d4f965d9410d8d0271132d2f8293480"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
- "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2007,6 +2258,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
+name = "fat-macho"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63fa117c7dcabeb8c83d5c229764cfa46518545d2dba5a9a08912014711f997b"
+dependencies = [
+ "goblin 0.7.1",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2065,11 +2325,20 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs-err"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -2187,7 +2456,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2257,7 +2526,7 @@ checksum = "ba330b70a5341d3bc730b8e205aaee97ddab5d9c448c4f51a7c2d924266fa8f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2309,15 +2578,15 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "globset"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759c97c1e17c55525b57192c06a267cda0ac5210b222d6b82189a2338fa1c13d"
+checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
 dependencies = [
  "aho-corasick",
  "bstr",
- "fnv",
  "log",
- "regex",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -2330,6 +2599,28 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "goblin"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27c1b4369c2cd341b5de549380158b105a04c331be5db9110eef7b6d2742134"
+dependencies = [
+ "log",
+ "plain",
+ "scroll 0.11.0",
+]
+
+[[package]]
+name = "goblin"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb07a4ffed2093b118a525b1d8f5204ae274faed5604537caf7135d0f18d9887"
+dependencies = [
+ "log",
+ "plain",
+ "scroll 0.12.0",
 ]
 
 [[package]]
@@ -2386,9 +2677,13 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -2551,9 +2846,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -2567,6 +2862,22 @@ checksum = "cabb0019d51a643781ff15c9c8a3e5dedc365c47211270f4e8f82812fedd8f0a"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata 0.4.3",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -2592,7 +2903,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.1",
+ "hashbrown 0.14.3",
+ "serde",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.17.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb28741c9db9a713d93deb3bb9515c20788cef5815265bee4980e87bde7e0f25"
+dependencies = [
+ "console",
+ "instant",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2747,7 +3072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.3",
- "rustix 0.38.20",
+ "rustix 0.38.28",
  "windows-sys 0.48.0",
 ]
 
@@ -2756,6 +3081,24 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
 dependencies = [
  "either",
 ]
@@ -2881,6 +3224,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
+name = "lddtree"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f88a93876d2485ede9c97d698c164cf5c024491908483964a998faae9705dea6"
+dependencies = [
+ "fs-err",
+ "glob",
+ "goblin 0.8.0",
+]
+
+[[package]]
 name = "lexical-core"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2946,9 +3300,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "libgit2-sys"
@@ -3022,9 +3376,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.8"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3852614a3bd9ca9804678ba6be5e3b8ce76dfc902cae004e3e0c44051b6e88db"
+checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 
 [[package]]
 name = "local-ip-address"
@@ -3058,6 +3412,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lzxd"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784462f20dddd9dfdb45de963fa4ad4a288cb10a7889ac5d2c34fb6481c6b213"
+
+[[package]]
 name = "macro_rules_attribute"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3072,6 +3432,17 @@ name = "macro_rules_attribute-proc_macro"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58093314a45e00c77d5c508f76e77c3396afbbc0d01506e7fae47b018bac2b1d"
+
+[[package]]
+name = "mailparse"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b56570f5f8c0047260d1c8b5b331f62eb9c660b9dd4071a8c46f8c7d3f280aa"
+dependencies = [
+ "charset",
+ "data-encoding",
+ "quoted_printable",
+]
 
 [[package]]
 name = "malloc_buf"
@@ -3096,6 +3467,72 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "maturin"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a36720938833f89c67b698065cf6707a95f6df954a2c7796097ddafe2ef45c5"
+dependencies = [
+ "anyhow",
+ "base64 0.21.4",
+ "bytesize",
+ "cargo-config2",
+ "cargo-options",
+ "cargo-xwin",
+ "cargo-zigbuild",
+ "cargo_metadata",
+ "cbindgen",
+ "cc",
+ "clap 4.4.6",
+ "clap_complete_command",
+ "configparser",
+ "console",
+ "dialoguer",
+ "dirs 5.0.1",
+ "dunce",
+ "fat-macho",
+ "flate2",
+ "fs-err",
+ "glob",
+ "goblin 0.7.1",
+ "ignore",
+ "indexmap 2.0.2",
+ "itertools 0.12.0",
+ "lddtree",
+ "minijinja",
+ "multipart",
+ "normpath",
+ "once_cell",
+ "path-slash",
+ "pep440_rs",
+ "pep508_rs",
+ "platform-info",
+ "pyproject-toml",
+ "python-pkginfo",
+ "regex",
+ "rustc_version",
+ "rustls 0.21.10",
+ "rustls-pemfile 2.0.0",
+ "semver",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tar",
+ "target-lexicon",
+ "tempfile",
+ "textwrap",
+ "thiserror",
+ "time",
+ "toml 0.8.8",
+ "toml_edit",
+ "tracing",
+ "tracing-subscriber",
+ "ureq",
+ "url",
+ "wild",
+ "zip",
+]
 
 [[package]]
 name = "md5"
@@ -3150,6 +3587,25 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "minijinja"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "431d72874542d43aba1ca605870eacab134fdeb0c8fe27666ecf4b2662239df2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -3219,6 +3675,31 @@ dependencies = [
  "net2",
  "winapi 0.2.8",
  "ws2_32-sys",
+]
+
+[[package]]
+name = "msi"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "226b2404f03d2cf47375b9715c8adfae4e388bb2377cff908e8a40f31e421514"
+dependencies = [
+ "byteorder",
+ "cfb",
+ "encoding_rs",
+ "uuid",
+]
+
+[[package]]
+name = "multipart"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00dec633863867f29cb39df64a397cdf4a6354708ddd7759f70c7fb51c5f9182"
+dependencies = [
+ "log",
+ "mime",
+ "mime_guess",
+ "rand",
+ "tempfile",
 ]
 
 [[package]]
@@ -3368,6 +3849,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "normpath"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec60c60a693226186f5d6edf073232bfb6464ed97eb22cf3b01c1e8198fd97f5"
+dependencies = [
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3530,6 +4020,12 @@ dependencies = [
  "hermit-abi 0.3.3",
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "nvml-wrapper"
@@ -3853,6 +4349,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
+name = "path-slash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
+
+[[package]]
 name = "path_abs"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3871,10 +4373,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "percent-encoding"
-version = "2.3.0"
+name = "pep440_rs"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "887f66cc62717ea72caac4f1eb4e6f392224da3ffff3f40ec13ab427802746d6"
+dependencies = [
+ "lazy_static",
+ "regex",
+ "serde",
+ "unicode-width",
+]
+
+[[package]]
+name = "pep508_rs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4516b53d9ea6112ebb38b4af08d5707d30b994fb7f98ff133c5dcf7ed8fa854"
+dependencies = [
+ "once_cell",
+ "pep440_rs",
+ "regex",
+ "serde",
+ "thiserror",
+ "tracing",
+ "unicode-width",
+ "url",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
@@ -3907,7 +4437,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3948,7 +4478,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4001,6 +4531,22 @@ name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "platform-info"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6259c4860e53bf665016f1b2f46a8859cadfa717581dc9d597ae4069de6300f"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "plist"
@@ -4122,6 +4668,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4169,9 +4721,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.68"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1106fec09662ec6dd98ccac0f81cef56984d0b49f75c92d8cbad76e20c005c"
+checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
 dependencies = [
  "unicode-ident",
 ]
@@ -4193,10 +4745,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -4247,7 +4808,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4259,7 +4820,35 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "pyproject-toml"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46d4a5e69187f23a29f8aa0ea57491d104ba541bc55f76552c2a74962aa20e04"
+dependencies = [
+ "indexmap 2.0.2",
+ "pep440_rs",
+ "pep508_rs",
+ "serde",
+ "toml 0.8.8",
+]
+
+[[package]]
+name = "python-pkginfo"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037469c164f08c891bf6d69ca02f1d56210011451e229618669777df82124cfa"
+dependencies = [
+ "flate2",
+ "fs-err",
+ "mailparse",
+ "rfc2047-decoder",
+ "tar",
+ "thiserror",
+ "zip",
 ]
 
 [[package]]
@@ -4307,7 +4896,7 @@ checksum = "c956be1b23f4261676aed05a0046e204e8a6836e50203902683a718af0797989"
 dependencies = [
  "bytes",
  "rand",
- "ring",
+ "ring 0.16.20",
  "rustc-hash",
  "rustls 0.20.9",
  "rustls-native-certs",
@@ -4333,12 +4922,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "quoted_printable"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3866219251662ec3b26fc217e3e05bf9c4f84325234dfb96bf0bf840889e49"
 
 [[package]]
 name = "radium"
@@ -4434,6 +5029,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4477,6 +5081,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4516,7 +5131,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.7",
+ "rustls 0.21.10",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -4528,6 +5143,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "rfc2047-decoder"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61fc4b4e52897c3e30b12b7e9b04461215b647fbe66f6def60dd8edbce14ec2e"
+dependencies = [
+ "base64 0.21.4",
+ "charset",
+ "chumsky",
+ "memchr",
+ "quoted_printable",
+ "thiserror",
 ]
 
 [[package]]
@@ -4549,9 +5178,23 @@ dependencies = [
  "libc",
  "once_cell",
  "spin 0.5.2",
- "untrusted",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
+dependencies = [
+ "cc",
+ "getrandom",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4714,15 +5357,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.20"
+version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ce50cb2e16c2903e30d1cbccfd8387a74b9d4c938b6a4c5ec6cc7556f7a8a0"
+checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.8",
- "windows-sys 0.48.0",
+ "linux-raw-sys 0.4.12",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4732,19 +5375,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
 dependencies = [
  "log",
- "ring",
+ "ring 0.16.20",
  "sct",
  "webpki",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.21.7"
+version = "0.21.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
+checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
- "ring",
+ "ring 0.17.7",
  "rustls-webpki",
  "sct",
 ]
@@ -4756,7 +5399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.3",
  "schannel",
  "security-framework",
 ]
@@ -4771,13 +5414,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-webpki"
-version = "0.101.6"
+name = "rustls-pemfile"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
+checksum = "35e4980fa29e4c4b212ffb3db068a564cbf560e51d3944b7c88bd8bf5bec64f4"
 dependencies = [
- "ring",
- "untrusted",
+ "base64 0.21.4",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e9d979b3ce68192e42760c7810125eb6cf2ea10efae545a156063e61f314e2a"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring 0.17.7",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -4860,13 +5519,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3cf7c11c38cb994f3d40e8a8cde3bbd1f72a435e4c49e85d6553d8312306152"
 
 [[package]]
+name = "scroll"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
+dependencies = [
+ "scroll_derive 0.11.1",
+]
+
+[[package]]
+name = "scroll"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+dependencies = [
+ "scroll_derive 0.12.0",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -4897,12 +5596,15 @@ name = "semver"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad977052201c6de01a8ef2aa3378c4bd23217a056337d1d6da40468d267a4fb0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
 dependencies = [
  "serde_derive",
 ]
@@ -4937,13 +5639,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4965,7 +5667,16 @@ checksum = "8725e1dfadb3a50f7e5ce0b1a540466f6ed3fe7a0fca2ac2b8b831d31316bd00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -5091,6 +5802,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5146,6 +5863,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "socket2"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5173,9 +5896,20 @@ checksum = "2a004c141c54615778c01a6722f6453fae7013e501b2b1f2dfe5684037174721"
 dependencies = [
  "io-extras",
  "io-lifetimes 2.0.2",
- "rustix 0.38.20",
+ "rustix 0.38.28",
  "uuid",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -5196,7 +5930,7 @@ checksum = "7d395866cb6778625150f77a430cc0af764ce0300f6a3d3413477785fa34b6c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5222,6 +5956,19 @@ checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "psm",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -5279,9 +6026,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5368,10 +6115,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a"
+
+[[package]]
+name = "tempfile"
+version = "3.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fastrand 2.0.1",
+ "redox_syscall 0.4.1",
+ "rustix 0.38.28",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "termcolor"
@@ -5388,7 +6159,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
- "rustix 0.38.20",
+ "rustix 0.38.28",
  "windows-sys 0.48.0",
 ]
 
@@ -5397,6 +6168,11 @@ name = "textwrap"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
 
 [[package]]
 name = "thiserror"
@@ -5415,7 +6191,7 @@ checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5539,7 +6315,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5565,6 +6341,49 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
+dependencies = [
+ "indexmap 2.0.2",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -5633,6 +6452,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -5646,7 +6466,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5685,6 +6505,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5694,12 +6524,15 @@ dependencies = [
  "nu-ansi-term 0.46.0",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -5707,6 +6540,17 @@ name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if 1.0.0",
+ "rand",
+ "static_assertions",
+]
 
 [[package]]
 name = "typenum"
@@ -5736,6 +6580,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5746,6 +6599,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization"
@@ -5796,6 +6655,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "unwind_safe"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5813,14 +6678,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "url"
-version = "2.4.1"
+name = "ureq"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
+checksum = "f8cdd25c339e200129fe4de81451814e5228c9b771d57378817d6117cc2b3f97"
+dependencies = [
+ "base64 0.21.4",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls 0.21.10",
+ "rustls-webpki",
+ "serde",
+ "serde_json",
+ "socks",
+ "url",
+ "webpki-roots 0.25.3",
+]
+
+[[package]]
+name = "url"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -5855,7 +6740,7 @@ checksum = "f7e1ba1f333bd65ce3c9f27de592fcbc256dafe3af2717f56d7c87761fbaccf4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -5913,6 +6798,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "versions"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c73a36bc44e3039f51fbee93e39f41225f6b17b380eb70cc2aab942df06b34dd"
+dependencies = [
+ "itertools 0.11.0",
+ "nom",
+]
+
+[[package]]
 name = "waker-fn"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5964,7 +6859,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
  "wasm-bindgen-shared",
 ]
 
@@ -5998,7 +6893,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6042,8 +6937,8 @@ version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07ecc0cd7cac091bf682ec5efa18b1cff79d617b84181f38b3951dbe135f607f"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -6056,15 +6951,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "4.4.2"
+name = "webpki-roots"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
+
+[[package]]
+name = "which"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bf3ea8596f3a0dd5980b46430f2058dfe2c36a27ccfbb1845d6fbfcd9ba6e14"
 dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.20",
+ "rustix 0.38.28",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6190,6 +7092,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6220,6 +7131,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6230,6 +7156,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -6250,6 +7182,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6266,6 +7204,12 @@ name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6286,6 +7230,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6304,6 +7254,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6314,6 +7270,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6332,6 +7294,21 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "winnow"
+version = "0.5.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7520bbdec7211caa7c4e682eb1fbe07abe20cee6756b6e00f537c82c11816aa"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"
@@ -6392,6 +7369,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "xattr"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914566e6413e7fa959cc394fb30e563ba80f3541fbd40816d4c05a0fc3f2a0f1"
+dependencies = [
+ "libc",
+ "linux-raw-sys 0.4.12",
+ "rustix 0.38.28",
+]
+
+[[package]]
+name = "xwin"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43e0202f5457b48558096cb7b36d0e473f267551a89c82ed72d73b01dfd4007"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "cab",
+ "camino",
+ "clap 4.4.6",
+ "cli-table",
+ "crossbeam-channel",
+ "flate2",
+ "indicatif",
+ "memchr",
+ "msi",
+ "parking_lot",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "toml 0.8.8",
+ "tracing",
+ "tracing-subscriber",
+ "twox-hash",
+ "ureq",
+ "versions",
+ "walkdir",
+ "zip",
 ]
 
 [[package]]
@@ -6580,7 +7602,7 @@ dependencies = [
  "quinn",
  "rustls 0.20.9",
  "rustls-native-certs",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.3",
  "webpki",
  "zenoh-cfg-properties",
  "zenoh-config",
@@ -6618,9 +7640,9 @@ dependencies = [
  "async-trait",
  "futures",
  "log",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.3",
  "webpki",
- "webpki-roots",
+ "webpki-roots 0.22.6",
  "zenoh-cfg-properties",
  "zenoh-config",
  "zenoh-core",
@@ -6713,7 +7735,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdf3eaea2095d2c13fefdae25aca813b3644fc15e1441e16a4398b5113033753"
 dependencies = [
  "hex",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "rand",
  "serde",
@@ -6793,7 +7815,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "bzip2",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "time",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1512,6 +1512,7 @@ dependencies = [
  "dora-coordinator",
  "dora-core",
  "dora-daemon",
+ "dora-tracing",
  "dunce",
  "eyre",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ tokio = "1.24.2"
 dora-daemon = { workspace = true }
 dora-coordinator = { workspace = true }
 dora-core = { workspace = true }
+dora-tracing = { workspace = true }
 dunce = "1.0.2"
 serde_yaml = "0.8.23"
 uuid = { version = "1.2.1", features = ["v4", "serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ dora-daemon = { workspace = true }
 dora-coordinator = { workspace = true }
 dora-core = { workspace = true }
 dora-tracing = { workspace = true }
+dora-download = { workspace = true }
 dunce = "1.0.2"
 serde_yaml = "0.8.23"
 uuid = { version = "1.2.1", features = ["v4", "serde"] }

--- a/apis/python/node/README.md
+++ b/apis/python/node/README.md
@@ -4,9 +4,9 @@ This crate corresponds to the Node API for Dora.
 
 To build the Python module for development:
 
-````bash
-python3 -m venv .env
+```bash
+python -m venv .env
 source .env/bin/activate
 pip install maturin
 maturin develop
-````
+```

--- a/binaries/cli/src/template/python/dataflow-template.yml
+++ b/binaries/cli/src/template/python/dataflow-template.yml
@@ -16,7 +16,7 @@ nodes:
 
   - id: custom-node_1
     custom:
-      source: python3
+      source: python
       args: ./node_1/node_1.py
       inputs:
         tick: dora/timer/secs/1

--- a/binaries/cli/src/template/python/dataflow-template.yml
+++ b/binaries/cli/src/template/python/dataflow-template.yml
@@ -16,8 +16,7 @@ nodes:
 
   - id: custom-node_1
     custom:
-      source: python
-      args: ./node_1/node_1.py
+      source: ./node_1/node_1.py
       inputs:
         tick: dora/timer/secs/1
         input-1: op_1/some-output

--- a/binaries/coordinator/Cargo.toml
+++ b/binaries/coordinator/Cargo.toml
@@ -27,7 +27,7 @@ dora-tracing = { workspace = true, optional = true }
 futures-concurrency = "7.1.0"
 zenoh = "0.7.0-rc"
 serde_json = "1.0.86"
-which = "4.3.0"
+which = "5.0.0"
 thiserror = "1.0.37"
 ctrlc = "3.2.5"
 clap = { version = "4.0.3", features = ["derive"] }

--- a/binaries/daemon/Cargo.toml
+++ b/binaries/daemon/Cargo.toml
@@ -39,4 +39,4 @@ bincode = "1.3.3"
 async-trait = "0.1.64"
 arrow-schema = { workspace = true }
 aligned-vec = "0.5.0"
-which = "4.3.0"
+which = "5.0.0"

--- a/binaries/daemon/Cargo.toml
+++ b/binaries/daemon/Cargo.toml
@@ -39,3 +39,4 @@ bincode = "1.3.3"
 async-trait = "0.1.64"
 arrow-schema = { workspace = true }
 aligned-vec = "0.5.0"
+which = "4.3.0"

--- a/binaries/daemon/src/pending.rs
+++ b/binaries/daemon/src/pending.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{HashMap, HashSet},
-    intrinsics::mir::Len,
-};
+use std::collections::{HashMap, HashSet};
 
 use dora_core::{
     config::NodeId,
@@ -9,7 +6,7 @@ use dora_core::{
     daemon_messages::{DaemonReply, DataflowId, Timestamped},
     message::uhlc::{Timestamp, HLC},
 };
-use eyre::{bail, Context, ContextCompat};
+use eyre::{bail, Context};
 use tokio::{net::TcpStream, sync::oneshot};
 
 use crate::tcp_utils::tcp_send;

--- a/binaries/daemon/src/spawn.rs
+++ b/binaries/daemon/src/spawn.rs
@@ -133,9 +133,10 @@ pub async fn spawn_node(
                 .spawn()
                 .wrap_err_with(move || {
                     format!(
-                        "failed to run `{}` with args `{}`",
+                        "failed to run `{}` with args `{}`. If this was run with python, the python used was: {:?}",
                         n.source,
-                        n.args.as_deref().unwrap_or_default()
+                        n.args.as_deref().unwrap_or_default(),
+                        get_python_path().unwrap_or_default()
                     )
                 })?
         }

--- a/binaries/daemon/src/spawn.rs
+++ b/binaries/daemon/src/spawn.rs
@@ -133,7 +133,7 @@ pub async fn spawn_node(
                 .spawn()
                 .wrap_err_with(move || {
                     format!(
-                        "failed to run `{}` with args `{}.",
+                        "failed to run `{}` with args `{}`",
                         n.source,
                         n.args.as_deref().unwrap_or_default(),
                     )

--- a/binaries/daemon/src/spawn.rs
+++ b/binaries/daemon/src/spawn.rs
@@ -137,7 +137,12 @@ pub async fn spawn_node(
 
             let mut command = if has_python_operator && !has_other_operator {
                 // Use python to spawn runtime if there is a python operator
-                let mut command = tokio::process::Command::new("python3");
+                let python = match which::which("python3") {
+                    Ok(python) => python,
+                    Err(_) => which::which("python")
+                        .context("failed to find `python` or `python3` in dora-daemon path. Make sure that python is available for the daemon.")?,
+                };
+                let mut command = tokio::process::Command::new(python);
                 command.args([
                     "-c",
                     format!("import dora; dora.start_runtime() # {}", node.id).as_str(),

--- a/examples/benchmark/run.rs
+++ b/examples/benchmark/run.rs
@@ -1,7 +1,6 @@
+use dora_tracing::set_up_tracing;
 use eyre::{bail, Context};
 use std::path::Path;
-use tracing::metadata::LevelFilter;
-use tracing_subscriber::Layer;
 
 #[derive(Debug, Clone, clap::Parser)]
 pub struct Args {
@@ -17,7 +16,7 @@ async fn main() -> eyre::Result<()> {
         return tokio::task::block_in_place(dora_daemon::run_dora_runtime);
     }
 
-    set_up_tracing().wrap_err("failed to set up tracing subscriber")?;
+    set_up_tracing("benchmark-runner").wrap_err("failed to set up tracing subscriber")?;
 
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
     std::env::set_current_dir(root.join(file!()).parent().unwrap())
@@ -41,15 +40,4 @@ async fn build_dataflow(dataflow: &Path) -> eyre::Result<()> {
         bail!("failed to build dataflow");
     };
     Ok(())
-}
-
-fn set_up_tracing() -> eyre::Result<()> {
-    use tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt;
-
-    let stdout_log = tracing_subscriber::fmt::layer()
-        .pretty()
-        .with_filter(LevelFilter::DEBUG);
-    let subscriber = tracing_subscriber::Registry::default().with(stdout_log);
-    tracing::subscriber::set_global_default(subscriber)
-        .context("failed to set tracing global subscriber")
 }

--- a/examples/c++-dataflow/run.rs
+++ b/examples/c++-dataflow/run.rs
@@ -1,10 +1,9 @@
+use dora_tracing::set_up_tracing;
 use eyre::{bail, Context};
 use std::{
     env::consts::{DLL_PREFIX, DLL_SUFFIX, EXE_SUFFIX},
     path::Path,
 };
-use tracing::metadata::LevelFilter;
-use tracing_subscriber::Layer;
 
 #[derive(Debug, Clone, clap::Parser)]
 pub struct Args {
@@ -19,7 +18,7 @@ async fn main() -> eyre::Result<()> {
     if run_dora_runtime {
         return tokio::task::block_in_place(dora_daemon::run_dora_runtime);
     }
-    set_up_tracing().wrap_err("failed to set up tracing")?;
+    set_up_tracing("c++-dataflow-runner").wrap_err("failed to set up tracing")?;
 
     if cfg!(windows) {
         tracing::error!(
@@ -293,15 +292,4 @@ async fn build_cxx_operator(
     };
 
     Ok(())
-}
-
-fn set_up_tracing() -> eyre::Result<()> {
-    use tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt;
-
-    let stdout_log = tracing_subscriber::fmt::layer()
-        .pretty()
-        .with_filter(LevelFilter::DEBUG);
-    let subscriber = tracing_subscriber::Registry::default().with(stdout_log);
-    tracing::subscriber::set_global_default(subscriber)
-        .context("failed to set tracing global subscriber")
 }

--- a/examples/c-dataflow/run.rs
+++ b/examples/c-dataflow/run.rs
@@ -1,10 +1,9 @@
+use dora_tracing::set_up_tracing;
 use eyre::{bail, Context};
 use std::{
     env::consts::{DLL_PREFIX, DLL_SUFFIX, EXE_SUFFIX},
     path::Path,
 };
-use tracing::metadata::LevelFilter;
-use tracing_subscriber::Layer;
 
 #[derive(Debug, Clone, clap::Parser)]
 pub struct Args {
@@ -20,7 +19,7 @@ async fn main() -> eyre::Result<()> {
         return tokio::task::block_in_place(dora_daemon::run_dora_runtime);
     }
 
-    set_up_tracing().wrap_err("failed to set up tracing")?;
+    set_up_tracing("c-dataflow-runner").wrap_err("failed to set up tracing")?;
 
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
     std::env::set_current_dir(root.join(file!()).parent().unwrap())
@@ -181,15 +180,4 @@ async fn build_c_operator(root: &Path) -> eyre::Result<()> {
     };
 
     Ok(())
-}
-
-fn set_up_tracing() -> eyre::Result<()> {
-    use tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt;
-
-    let stdout_log = tracing_subscriber::fmt::layer()
-        .pretty()
-        .with_filter(LevelFilter::DEBUG);
-    let subscriber = tracing_subscriber::Registry::default().with(stdout_log);
-    tracing::subscriber::set_global_default(subscriber)
-        .context("failed to set tracing global subscriber")
 }

--- a/examples/cmake-dataflow/run.rs
+++ b/examples/cmake-dataflow/run.rs
@@ -1,7 +1,6 @@
+use dora_tracing::set_up_tracing;
 use eyre::{bail, Context};
 use std::path::Path;
-use tracing::metadata::LevelFilter;
-use tracing_subscriber::Layer;
 
 #[derive(Debug, Clone, clap::Parser)]
 pub struct Args {
@@ -16,7 +15,7 @@ async fn main() -> eyre::Result<()> {
     if run_dora_runtime {
         return tokio::task::block_in_place(dora_daemon::run_dora_runtime);
     }
-    set_up_tracing().wrap_err("failed to set up tracing")?;
+    set_up_tracing("cmake-dataflow-runner").wrap_err("failed to set up tracing")?;
 
     if cfg!(windows) {
         tracing::error!(
@@ -66,15 +65,4 @@ async fn build_package(package: &str) -> eyre::Result<()> {
         bail!("failed to build {package}");
     }
     Ok(())
-}
-
-fn set_up_tracing() -> eyre::Result<()> {
-    use tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt;
-
-    let stdout_log = tracing_subscriber::fmt::layer()
-        .pretty()
-        .with_filter(LevelFilter::DEBUG);
-    let subscriber = tracing_subscriber::Registry::default().with(stdout_log);
-    tracing::subscriber::set_global_default(subscriber)
-        .context("failed to set tracing global subscriber")
 }

--- a/examples/python-dataflow/object_detection.py
+++ b/examples/python-dataflow/object_detection.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from typing import Callable
-from dora import Node
-
+import os
 import cv2
 import numpy as np
 import torch
 
-model = torch.hub.load("ultralytics/yolov5", "yolov5n")
+from dora import Node
+
+# Reload only if on Windows
+reload = os.name == "nt"
+model = torch.hub.load("ultralytics/yolov5", "yolov5n", force_reload=reload)
 
 node = Node()
 

--- a/examples/python-dataflow/object_detection.py
+++ b/examples/python-dataflow/object_detection.py
@@ -24,8 +24,8 @@ for event in node:
             results = model(frame)  # includes NMS
             # Process results
             boxes = np.array(results[0].boxes.xyxy.cpu())
-            conf = np.array(results[0].boxes.conf)
-            label = np.array(results[0].boxes.cls)
+            conf = np.array(results[0].boxes.conf.cpu())
+            label = np.array(results[0].boxes.cls.cpu())
             # concatenate them together
             arrays = np.concatenate((boxes, conf[:, None], label[:, None]), axis=1)
 

--- a/examples/python-dataflow/object_detection.py
+++ b/examples/python-dataflow/object_detection.py
@@ -9,8 +9,7 @@ import torch
 from dora import Node
 
 # Reload only if on Windows
-reload = os.name == "nt"
-model = torch.hub.load("ultralytics/yolov5", "yolov5n", force_reload=reload)
+model = torch.hub.load("ultralytics/yolov5", "yolov5n")
 
 node = Node()
 

--- a/examples/python-dataflow/plot.py
+++ b/examples/python-dataflow/plot.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 import os
-from typing import Callable
 from dora import Node
 from dora import DoraStatus
 

--- a/examples/python-dataflow/requirements.txt
+++ b/examples/python-dataflow/requirements.txt
@@ -14,10 +14,8 @@ PyYAML>=5.3.1
 requests>=2.23.0
 scipy>=1.4.1
 thop>=0.1.1  # FLOPs computation
---extra-index-url https://download.pytorch.org/whl/cpu
-torch>=1.7.0  # see https://pytorch.org/get-started/locally (recommended)
---extra-index-url https://download.pytorch.org/whl/cpu
-torchvision>=0.8.1
+torch  # see https://pytorch.org/get-started/locally (recommended)
+torchvision
 tqdm>=4.64.0
 
 # Logging -------------------------------------

--- a/examples/python-dataflow/run.rs
+++ b/examples/python-dataflow/run.rs
@@ -23,7 +23,7 @@ async fn main() -> eyre::Result<()> {
                 .context("Could not convert python path to string")?,
             "-m",
             "venv",
-            "../.env",
+            ".env",
         ],
         None,
     )

--- a/examples/python-dataflow/run.rs
+++ b/examples/python-dataflow/run.rs
@@ -31,13 +31,24 @@ async fn main() -> eyre::Result<()> {
     } else {
         venv.join("bin")
     };
-    std::env::set_var(
-        "PATH",
-        format!(
-            "{}:{orig_path}",
-            venv_bin.to_str().context("venv path not valid unicode")?
-        ),
-    );
+
+    if cfg!(windows) {
+        std::env::set_var(
+            "PATH",
+            format!(
+                "{};{orig_path}",
+                venv_bin.to_str().context("venv path not valid unicode")?
+            ),
+        );
+    } else {
+        std::env::set_var(
+            "PATH",
+            format!(
+                "{}:{orig_path}",
+                venv_bin.to_str().context("venv path not valid unicode")?
+            ),
+        );
+    }
 
     run(
         get_pip_path().context("Could not get pip binary")?,

--- a/examples/python-dataflow/run.rs
+++ b/examples/python-dataflow/run.rs
@@ -1,4 +1,5 @@
 use dora_core::{get_pip_path, get_python_path, run};
+use dora_download::download_file;
 use dora_tracing::set_up_tracing;
 use eyre::{ContextCompat, WrapErr};
 use std::path::Path;
@@ -72,6 +73,12 @@ async fn main() -> eyre::Result<()> {
     )
     .await
     .context("maturin develop failed")?;
+    download_file(
+        "https://github.com/ultralytics/assets/releases/download/v0.0.0/yolov8n.pt",
+        Path::new("yolov8n.pt"),
+    )
+    .await
+    .context("Could not download weights.")?;
 
     let dataflow = Path::new("dataflow.yml");
     dora_daemon::Daemon::run_dataflow(dataflow).await?;

--- a/examples/python-dataflow/run.rs
+++ b/examples/python-dataflow/run.rs
@@ -51,8 +51,8 @@ async fn main() -> eyre::Result<()> {
     }
 
     run(
-        get_pip_path().context("Could not get pip binary")?,
-        &["install", "--upgrade", "pip"],
+        get_python_path().context("Could not get pip binary")?,
+        &["-m", "pip", "install", "--upgrade", "pip"],
         None,
     )
     .await

--- a/examples/python-dataflow/run.rs
+++ b/examples/python-dataflow/run.rs
@@ -1,3 +1,4 @@
+use dora_core::{get_pip_path, get_python_path, run};
 use dora_tracing::set_up_tracing;
 use eyre::{ContextCompat, WrapErr};
 use std::path::Path;
@@ -11,15 +12,8 @@ async fn main() -> eyre::Result<()> {
         .wrap_err("failed to set working dir")?;
 
     run(
-        &[
-            get_python_path()
-                .context("Could not get python binary")?
-                .to_str()
-                .context("Could not convert python path to string")?,
-            "-m",
-            "venv",
-            ".env",
-        ],
+        get_python_path().context("Could not get python binary")?,
+        &["-m", "venv", "../.env"],
         None,
     )
     .await
@@ -39,15 +33,24 @@ async fn main() -> eyre::Result<()> {
         ),
     );
 
-    run(&["pip", "install", "--upgrade", "pip"], None)
-        .await
-        .context("failed to install pip")?;
-    run(&["pip", "install", "-r", "requirements.txt"], None)
-        .await
-        .context("pip install failed")?;
+    run(
+        get_pip_path().context("Could not get pip binary")?,
+        &["install", "--upgrade", "pip"],
+        None,
+    )
+    .await
+    .context("failed to install pip")?;
+    run(
+        get_pip_path().context("Could not get pip binary")?,
+        &["install", "-r", "requirements.txt"],
+        None,
+    )
+    .await
+    .context("pip install failed")?;
 
     run(
-        &["maturin", "develop"],
+        "maturin",
+        &["develop"],
         Some(&root.join("apis").join("python").join("node")),
     )
     .await

--- a/examples/python-dataflow/run.rs
+++ b/examples/python-dataflow/run.rs
@@ -24,7 +24,13 @@ async fn main() -> eyre::Result<()> {
         venv.to_str().context("venv path not valid unicode")?,
     );
     let orig_path = std::env::var("PATH")?;
-    let venv_bin = venv.join("bin");
+    // bin folder is named Scripts on windows.
+    // 🤦‍♂️ See: https://github.com/pypa/virtualenv/commit/993ba1316a83b760370f5a3872b3f5ef4dd904c1
+    let venv_bin = if cfg!(windows) {
+        venv.join("Scripts")
+    } else {
+        venv.join("bin")
+    };
     std::env::set_var(
         "PATH",
         format!(

--- a/examples/python-dataflow/run.rs
+++ b/examples/python-dataflow/run.rs
@@ -1,3 +1,4 @@
+use dora_core::get_python_path;
 use eyre::{ContextCompat, WrapErr};
 use std::path::Path;
 use tracing_subscriber::{
@@ -14,9 +15,20 @@ async fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    run(&["python3", "-m", "venv", "../.env"], None)
-        .await
-        .context("failed to create venv")?;
+    run(
+        &[
+            get_python_path()
+                .context("Could not get python binary")?
+                .to_str()
+                .context("Could not convert python path to string")?,
+            "-m",
+            "venv",
+            "../.env",
+        ],
+        None,
+    )
+    .await
+    .context("failed to create venv")?;
     let venv = &root.join("examples").join(".env");
     std::env::set_var(
         "VIRTUAL_ENV",

--- a/examples/python-operator-dataflow/dataflow.yml
+++ b/examples/python-operator-dataflow/dataflow.yml
@@ -21,10 +21,3 @@ nodes:
       inputs:
         image: webcam/image
         bbox: object_detection/bbox
-  - id: dora-record
-    custom:
-      build: cargo build -p dora-record
-      source: ../../target/debug/dora-record
-      inputs:
-        image: webcam/image
-        bbox: object_detection/bbox

--- a/examples/python-operator-dataflow/object_detection.py
+++ b/examples/python-operator-dataflow/object_detection.py
@@ -57,5 +57,5 @@ class Operator:
         # concatenate them together
         arrays = np.concatenate((boxes, conf[:, None], label[:, None]), axis=1)
 
-        send_output("bbox", pa.array(arrays), dora_input["metadata"])
+        send_output("bbox", pa.array(arrays.ravel()), dora_input["metadata"])
         return DoraStatus.CONTINUE

--- a/examples/python-operator-dataflow/object_detection.py
+++ b/examples/python-operator-dataflow/object_detection.py
@@ -2,11 +2,10 @@
 # -*- coding: utf-8 -*-
 
 
-import cv2
 import numpy as np
 import pyarrow as pa
 import torch
-
+import os
 from dora import DoraStatus
 
 pa.array([])
@@ -21,7 +20,11 @@ class Operator:
     """
 
     def __init__(self):
-        self.model = torch.hub.load("ultralytics/yolov5", "yolov5n")
+        # Reload only if on Windows
+        reload = os.name == "nt"
+        self.model = torch.hub.load(
+            "ultralytics/yolov5", "yolov5n", force_reload=reload
+        )
 
     def on_event(
         self,

--- a/examples/python-operator-dataflow/object_detection.py
+++ b/examples/python-operator-dataflow/object_detection.py
@@ -4,9 +4,9 @@
 
 import numpy as np
 import pyarrow as pa
-import torch
-import os
+
 from dora import DoraStatus
+from ultralytics import YOLO
 
 pa.array([])
 
@@ -20,7 +20,7 @@ class Operator:
     """
 
     def __init__(self):
-        self.model = torch.hub.load("ultralytics/yolov5", "yolov5n")
+        self.model = YOLO("yolov8n.pt")
 
     def on_event(
         self,
@@ -50,6 +50,12 @@ class Operator:
         frame = dora_input["value"].to_numpy().reshape((CAMERA_HEIGHT, CAMERA_WIDTH, 3))
         frame = frame[:, :, ::-1]  # OpenCV image (BGR to RGB)
         results = self.model(frame)  # includes NMS
-        arrays = pa.array(np.array(results.xyxy[0].cpu()).ravel())
+        # Process results
+        boxes = np.array(results[0].boxes.xyxy.cpu())
+        conf = np.array(results[0].boxes.conf)
+        label = np.array(results[0].boxes.cls)
+        # concatenate them together
+        arrays = np.concatenate((boxes, conf[:, None], label[:, None]), axis=1)
+
         send_output("bbox", arrays, dora_input["metadata"])
         return DoraStatus.CONTINUE

--- a/examples/python-operator-dataflow/object_detection.py
+++ b/examples/python-operator-dataflow/object_detection.py
@@ -57,5 +57,5 @@ class Operator:
         # concatenate them together
         arrays = np.concatenate((boxes, conf[:, None], label[:, None]), axis=1)
 
-        send_output("bbox", arrays, dora_input["metadata"])
+        send_output("bbox", pa.array(arrays), dora_input["metadata"])
         return DoraStatus.CONTINUE

--- a/examples/python-operator-dataflow/object_detection.py
+++ b/examples/python-operator-dataflow/object_detection.py
@@ -20,11 +20,7 @@ class Operator:
     """
 
     def __init__(self):
-        # Reload only if on Windows
-        reload = os.name == "nt"
-        self.model = torch.hub.load(
-            "ultralytics/yolov5", "yolov5n", force_reload=reload
-        )
+        self.model = torch.hub.load("ultralytics/yolov5", "yolov5n")
 
     def on_event(
         self,

--- a/examples/python-operator-dataflow/object_detection.py
+++ b/examples/python-operator-dataflow/object_detection.py
@@ -52,8 +52,8 @@ class Operator:
         results = self.model(frame)  # includes NMS
         # Process results
         boxes = np.array(results[0].boxes.xyxy.cpu())
-        conf = np.array(results[0].boxes.conf)
-        label = np.array(results[0].boxes.cls)
+        conf = np.array(results[0].boxes.conf.cpu())
+        label = np.array(results[0].boxes.cls.cpu())
         # concatenate them together
         arrays = np.concatenate((boxes, conf[:, None], label[:, None]), axis=1)
 

--- a/examples/python-operator-dataflow/requirements.txt
+++ b/examples/python-operator-dataflow/requirements.txt
@@ -3,17 +3,20 @@
 
 # Base ----------------------------------------
 ultralytics
+gitpython
+ipython  # interactive notebook
 matplotlib>=3.2.2
 numpy>=1.18.5
 opencv-python>=4.1.1
 Pillow>=7.1.2
+psutil  # system resources
 PyYAML>=5.3.1
 requests>=2.23.0
 scipy>=1.4.1
+thop>=0.1.1  # FLOPs computation
 torch  # see https://pytorch.org/get-started/locally (recommended)
 torchvision
 tqdm>=4.64.0
-protobuf<=3.20.1  # https://github.com/ultralytics/yolov5/issues/8012
 
 # Logging -------------------------------------
 tensorboard>=2.4.1
@@ -36,13 +39,9 @@ seaborn>=0.11.0
 # openvino-dev  # OpenVINO export
 
 # Extras --------------------------------------
-ipython  # interactive notebook
-psutil  # system utilization
-thop>=0.1.1  # FLOPs computation
 # albumentations>=1.0.3
 # pycocotools>=2.0  # COCO mAP
 # roboflow
 
 opencv-python>=4.1.1
-pyarrow
 maturin

--- a/examples/python-operator-dataflow/requirements.txt
+++ b/examples/python-operator-dataflow/requirements.txt
@@ -10,10 +10,8 @@ Pillow>=7.1.2
 PyYAML>=5.3.1
 requests>=2.23.0
 scipy>=1.4.1
---extra-index-url https://download.pytorch.org/whl/cpu
-torch>=1.7.0
---extra-index-url https://download.pytorch.org/whl/cpu
-torchvision>=0.8.1
+torch  # see https://pytorch.org/get-started/locally (recommended)
+torchvision
 tqdm>=4.64.0
 protobuf<=3.20.1  # https://github.com/ultralytics/yolov5/issues/8012
 

--- a/examples/python-operator-dataflow/run.rs
+++ b/examples/python-operator-dataflow/run.rs
@@ -23,7 +23,7 @@ async fn main() -> eyre::Result<()> {
                 .context("Could not convert python path to string")?,
             "-m",
             "venv",
-            "../.env",
+            ".env",
         ],
         None,
     )

--- a/examples/python-operator-dataflow/run.rs
+++ b/examples/python-operator-dataflow/run.rs
@@ -1,15 +1,10 @@
-use dora_core::get_python_path;
+use dora_tracing::set_up_tracing;
 use eyre::{ContextCompat, WrapErr};
 use std::path::Path;
-use tracing_subscriber::{
-    filter::{FilterExt, LevelFilter},
-    prelude::*,
-    EnvFilter, Registry,
-};
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
-    set_up_tracing()?;
+    set_up_tracing("python-operator-dataflow-runner")?;
 
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
     std::env::set_current_dir(root.join(file!()).parent().unwrap())
@@ -62,30 +57,4 @@ async fn main() -> eyre::Result<()> {
     dora_daemon::Daemon::run_dataflow(dataflow).await?;
 
     Ok(())
-}
-
-async fn run(cmd: &[&str], pwd: Option<&Path>) -> eyre::Result<()> {
-    let mut run = tokio::process::Command::new(cmd[0]);
-    run.args(&cmd[1..]);
-
-    if let Some(pwd) = pwd {
-        run.current_dir(pwd);
-    }
-    if !run.status().await?.success() {
-        eyre::bail!("failed to run {cmd:?}");
-    };
-    Ok(())
-}
-
-pub fn set_up_tracing() -> eyre::Result<()> {
-    // Filter log using `RUST_LOG`. More useful for CLI.
-    let filter = EnvFilter::from_default_env().or(LevelFilter::DEBUG);
-    let stdout_log = tracing_subscriber::fmt::layer()
-        .pretty()
-        .with_filter(filter);
-
-    let registry = Registry::default().with(stdout_log);
-
-    tracing::subscriber::set_global_default(registry)
-        .context("failed to set tracing global subscriber")
 }

--- a/examples/python-operator-dataflow/run.rs
+++ b/examples/python-operator-dataflow/run.rs
@@ -31,13 +31,24 @@ async fn main() -> eyre::Result<()> {
     } else {
         venv.join("bin")
     };
-    std::env::set_var(
-        "PATH",
-        format!(
-            "{}:{orig_path}",
-            venv_bin.to_str().context("venv path not valid unicode")?
-        ),
-    );
+
+    if cfg!(windows) {
+        std::env::set_var(
+            "PATH",
+            format!(
+                "{};{orig_path}",
+                venv_bin.to_str().context("venv path not valid unicode")?
+            ),
+        );
+    } else {
+        std::env::set_var(
+            "PATH",
+            format!(
+                "{}:{orig_path}",
+                venv_bin.to_str().context("venv path not valid unicode")?
+            ),
+        );
+    }
 
     run(
         get_pip_path().context("Could not get pip binary")?,

--- a/examples/python-operator-dataflow/run.rs
+++ b/examples/python-operator-dataflow/run.rs
@@ -51,8 +51,8 @@ async fn main() -> eyre::Result<()> {
     }
 
     run(
-        get_pip_path().context("Could not get pip binary")?,
-        &["install", "--upgrade", "pip"],
+        get_python_path().context("Could not get pip binary")?,
+        &["-m", "pip", "install", "--upgrade", "pip"],
         None,
     )
     .await

--- a/examples/python-operator-dataflow/run.rs
+++ b/examples/python-operator-dataflow/run.rs
@@ -1,3 +1,4 @@
+use dora_core::{get_pip_path, get_python_path, run};
 use dora_tracing::set_up_tracing;
 use eyre::{ContextCompat, WrapErr};
 use std::path::Path;
@@ -11,15 +12,8 @@ async fn main() -> eyre::Result<()> {
         .wrap_err("failed to set working dir")?;
 
     run(
-        &[
-            get_python_path()
-                .context("Could not get python binary")?
-                .to_str()
-                .context("Could not convert python path to string")?,
-            "-m",
-            "venv",
-            ".env",
-        ],
+        get_python_path().context("Could not get python binary")?,
+        &["-m", "venv", "../.env"],
         None,
     )
     .await
@@ -39,15 +33,24 @@ async fn main() -> eyre::Result<()> {
         ),
     );
 
-    run(&["pip", "install", "--upgrade", "pip"], None)
-        .await
-        .context("failed to install pip")?;
-    run(&["pip", "install", "-r", "requirements.txt"], None)
-        .await
-        .context("pip install failed")?;
+    run(
+        get_pip_path().context("Could not get pip binary")?,
+        &["install", "--upgrade", "pip"],
+        None,
+    )
+    .await
+    .context("failed to install pip")?;
+    run(
+        get_pip_path().context("Could not get pip binary")?,
+        &["install", "-r", "requirements.txt"],
+        None,
+    )
+    .await
+    .context("pip install failed")?;
 
     run(
-        &["maturin", "develop"],
+        "maturin",
+        &["develop"],
         Some(&root.join("apis").join("python").join("node")),
     )
     .await

--- a/examples/python-operator-dataflow/run.rs
+++ b/examples/python-operator-dataflow/run.rs
@@ -24,7 +24,13 @@ async fn main() -> eyre::Result<()> {
         venv.to_str().context("venv path not valid unicode")?,
     );
     let orig_path = std::env::var("PATH")?;
-    let venv_bin = venv.join("bin");
+    // bin folder is named Scripts on windows.
+    // 🤦‍♂️ See: https://github.com/pypa/virtualenv/commit/993ba1316a83b760370f5a3872b3f5ef4dd904c1
+    let venv_bin = if cfg!(windows) {
+        venv.join("Scripts")
+    } else {
+        venv.join("bin")
+    };
     std::env::set_var(
         "PATH",
         format!(

--- a/examples/python-operator-dataflow/run.rs
+++ b/examples/python-operator-dataflow/run.rs
@@ -1,4 +1,5 @@
 use dora_core::{get_pip_path, get_python_path, run};
+use dora_download::download_file;
 use dora_tracing::set_up_tracing;
 use eyre::{ContextCompat, WrapErr};
 use std::path::Path;
@@ -73,6 +74,12 @@ async fn main() -> eyre::Result<()> {
     .await
     .context("maturin develop failed")?;
 
+    download_file(
+        "https://github.com/ultralytics/assets/releases/download/v0.0.0/yolov8n.pt",
+        Path::new("yolov8n.pt"),
+    )
+    .await
+    .context("Could not download weights.")?;
     let dataflow = Path::new("dataflow.yml");
     dora_daemon::Daemon::run_dataflow(dataflow).await?;
 

--- a/examples/python-operator-dataflow/run.rs
+++ b/examples/python-operator-dataflow/run.rs
@@ -1,3 +1,4 @@
+use dora_core::get_python_path;
 use eyre::{ContextCompat, WrapErr};
 use std::path::Path;
 use tracing_subscriber::{
@@ -14,9 +15,20 @@ async fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    run(&["python3", "-m", "venv", "../.env"], None)
-        .await
-        .context("failed to create venv")?;
+    run(
+        &[
+            get_python_path()
+                .context("Could not get python binary")?
+                .to_str()
+                .context("Could not convert python path to string")?,
+            "-m",
+            "venv",
+            "../.env",
+        ],
+        None,
+    )
+    .await
+    .context("failed to create venv")?;
     let venv = &root.join("examples").join(".env");
     std::env::set_var(
         "VIRTUAL_ENV",

--- a/examples/python-ros2-dataflow/run.rs
+++ b/examples/python-ros2-dataflow/run.rs
@@ -31,13 +31,24 @@ async fn main() -> eyre::Result<()> {
     } else {
         venv.join("bin")
     };
-    std::env::set_var(
-        "PATH",
-        format!(
-            "{}:{orig_path}",
-            venv_bin.to_str().context("venv path not valid unicode")?
-        ),
-    );
+
+    if cfg!(windows) {
+        std::env::set_var(
+            "PATH",
+            format!(
+                "{};{orig_path}",
+                venv_bin.to_str().context("venv path not valid unicode")?
+            ),
+        );
+    } else {
+        std::env::set_var(
+            "PATH",
+            format!(
+                "{}:{orig_path}",
+                venv_bin.to_str().context("venv path not valid unicode")?
+            ),
+        );
+    }
 
     run(
         get_pip_path().context("Could not get pip binary")?,

--- a/examples/python-ros2-dataflow/run.rs
+++ b/examples/python-ros2-dataflow/run.rs
@@ -14,9 +14,20 @@ async fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    run(&["python3", "-m", "venv", "../.env"], None)
-        .await
-        .context("failed to create venv")?;
+    run(
+        &[
+            get_python_path()
+                .context("Could not get python binary")?
+                .to_str()
+                .context("Could not convert python path to string")?,
+            "-m",
+            "venv",
+            "../.env",
+        ],
+        None,
+    )
+    .await
+    .context("failed to create venv")?;
     let venv = &root.join("examples").join(".env");
     std::env::set_var(
         "VIRTUAL_ENV",

--- a/examples/python-ros2-dataflow/run.rs
+++ b/examples/python-ros2-dataflow/run.rs
@@ -51,8 +51,8 @@ async fn main() -> eyre::Result<()> {
     }
 
     run(
-        get_pip_path().context("Could not get pip binary")?,
-        &["install", "--upgrade", "pip"],
+        get_python_path().context("Could not get pip binary")?,
+        &["-m", "pip", "install", "--upgrade", "pip"],
         None,
     )
     .await

--- a/examples/python-ros2-dataflow/run.rs
+++ b/examples/python-ros2-dataflow/run.rs
@@ -1,4 +1,4 @@
-use dora_core::{get_pip_path, get_python_path, run, set_up_tracing};
+use dora_core::{get_pip_path, get_python_path, run};
 use dora_tracing::set_up_tracing;
 use eyre::{ContextCompat, WrapErr};
 use std::path::Path;

--- a/examples/python-ros2-dataflow/run.rs
+++ b/examples/python-ros2-dataflow/run.rs
@@ -24,7 +24,13 @@ async fn main() -> eyre::Result<()> {
         venv.to_str().context("venv path not valid unicode")?,
     );
     let orig_path = std::env::var("PATH")?;
-    let venv_bin = venv.join("bin");
+    // bin folder is named Scripts on windows.
+    // 🤦‍♂️ See: https://github.com/pypa/virtualenv/commit/993ba1316a83b760370f5a3872b3f5ef4dd904c1
+    let venv_bin = if cfg!(windows) {
+        venv.join("Scripts")
+    } else {
+        venv.join("bin")
+    };
     std::env::set_var(
         "PATH",
         format!(

--- a/examples/python-ros2-dataflow/run.rs
+++ b/examples/python-ros2-dataflow/run.rs
@@ -1,3 +1,4 @@
+use dora_core::{get_pip_path, get_python_path, run, set_up_tracing};
 use dora_tracing::set_up_tracing;
 use eyre::{ContextCompat, WrapErr};
 use std::path::Path;
@@ -11,15 +12,8 @@ async fn main() -> eyre::Result<()> {
         .wrap_err("failed to set working dir")?;
 
     run(
-        &[
-            get_python_path()
-                .context("Could not get python binary")?
-                .to_str()
-                .context("Could not convert python path to string")?,
-            "-m",
-            "venv",
-            ".env",
-        ],
+        get_python_path().context("Could not get python binary")?,
+        &["-m", "venv", "../.env"],
         None,
     )
     .await
@@ -27,9 +21,7 @@ async fn main() -> eyre::Result<()> {
     let venv = &root.join("examples").join(".env");
     std::env::set_var(
         "VIRTUAL_ENV",
-        venv.to_str()
-            .context("venv path not valid unicode")?
-            .to_owned(),
+        venv.to_str().context("venv path not valid unicode")?,
     );
     let orig_path = std::env::var("PATH")?;
     let venv_bin = venv.join("bin");
@@ -41,15 +33,24 @@ async fn main() -> eyre::Result<()> {
         ),
     );
 
-    run(&["pip", "install", "--upgrade", "pip"], None)
-        .await
-        .context("failed to install pip")?;
-    run(&["pip", "install", "-r", "requirements.txt"], None)
-        .await
-        .context("pip install failed")?;
+    run(
+        get_pip_path().context("Could not get pip binary")?,
+        &["install", "--upgrade", "pip"],
+        None,
+    )
+    .await
+    .context("failed to install pip")?;
+    run(
+        get_pip_path().context("Could not get pip binary")?,
+        &["install", "-r", "requirements.txt"],
+        None,
+    )
+    .await
+    .context("pip install failed")?;
 
     run(
-        &["maturin", "develop"],
+        "maturin",
+        &["develop"],
         Some(&root.join("apis").join("python").join("node")),
     )
     .await

--- a/examples/python-ros2-dataflow/run.rs
+++ b/examples/python-ros2-dataflow/run.rs
@@ -1,15 +1,10 @@
-use dora_core::get_python_path;
+use dora_tracing::set_up_tracing;
 use eyre::{ContextCompat, WrapErr};
 use std::path::Path;
-use tracing_subscriber::{
-    filter::{FilterExt, LevelFilter},
-    prelude::*,
-    EnvFilter, Registry,
-};
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
-    set_up_tracing()?;
+    set_up_tracing("python-ros2-dataflow-runner")?;
 
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
     std::env::set_current_dir(root.join(file!()).parent().unwrap())
@@ -64,30 +59,4 @@ async fn main() -> eyre::Result<()> {
     dora_daemon::Daemon::run_dataflow(dataflow).await?;
 
     Ok(())
-}
-
-async fn run(cmd: &[&str], pwd: Option<&Path>) -> eyre::Result<()> {
-    let mut run = tokio::process::Command::new(cmd[0]);
-    run.args(&cmd[1..]);
-
-    if let Some(pwd) = pwd {
-        run.current_dir(pwd);
-    }
-    if !run.status().await?.success() {
-        eyre::bail!("failed to run {cmd:?}");
-    };
-    Ok(())
-}
-
-pub fn set_up_tracing() -> eyre::Result<()> {
-    // Filter log using `RUST_LOG`. More useful for CLI.
-    let filter = EnvFilter::from_default_env().or(LevelFilter::DEBUG);
-    let stdout_log = tracing_subscriber::fmt::layer()
-        .pretty()
-        .with_filter(filter);
-
-    let registry = Registry::default().with(stdout_log);
-
-    tracing::subscriber::set_global_default(registry)
-        .context("failed to set tracing global subscriber")
 }

--- a/examples/python-ros2-dataflow/run.rs
+++ b/examples/python-ros2-dataflow/run.rs
@@ -1,3 +1,4 @@
+use dora_core::get_python_path;
 use eyre::{ContextCompat, WrapErr};
 use std::path::Path;
 use tracing_subscriber::{
@@ -22,7 +23,7 @@ async fn main() -> eyre::Result<()> {
                 .context("Could not convert python path to string")?,
             "-m",
             "venv",
-            "../.env",
+            ".env",
         ],
         None,
     )

--- a/examples/rust-dataflow-url/run.rs
+++ b/examples/rust-dataflow-url/run.rs
@@ -1,7 +1,6 @@
+use dora_tracing::set_up_tracing;
 use eyre::{bail, Context};
 use std::path::Path;
-use tracing::metadata::LevelFilter;
-use tracing_subscriber::Layer;
 
 #[derive(Debug, Clone, clap::Parser)]
 pub struct Args {
@@ -16,7 +15,7 @@ async fn main() -> eyre::Result<()> {
         return tokio::task::block_in_place(dora_daemon::run_dora_runtime);
     }
 
-    set_up_tracing().wrap_err("failed to set up tracing")?;
+    set_up_tracing("rust-dataflow-url-runner").wrap_err("failed to set up tracing")?;
 
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
     std::env::set_current_dir(root.join(file!()).parent().unwrap())
@@ -40,15 +39,4 @@ async fn build_dataflow(dataflow: &Path) -> eyre::Result<()> {
         bail!("failed to build dataflow");
     };
     Ok(())
-}
-
-fn set_up_tracing() -> eyre::Result<()> {
-    use tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt;
-
-    let stdout_log = tracing_subscriber::fmt::layer()
-        .pretty()
-        .with_filter(LevelFilter::DEBUG);
-    let subscriber = tracing_subscriber::Registry::default().with(stdout_log);
-    tracing::subscriber::set_global_default(subscriber)
-        .context("failed to set tracing global subscriber")
 }

--- a/examples/rust-dataflow/run.rs
+++ b/examples/rust-dataflow/run.rs
@@ -1,7 +1,6 @@
+use dora_tracing::set_up_tracing;
 use eyre::{bail, Context};
 use std::path::Path;
-use tracing::metadata::LevelFilter;
-use tracing_subscriber::Layer;
 
 #[derive(Debug, Clone, clap::Parser)]
 pub struct Args {
@@ -17,7 +16,7 @@ async fn main() -> eyre::Result<()> {
         return tokio::task::block_in_place(dora_daemon::run_dora_runtime);
     }
 
-    set_up_tracing().wrap_err("failed to set up tracing subscriber")?;
+    set_up_tracing("rust-dataflow-runner").wrap_err("failed to set up tracing subscriber")?;
 
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
     std::env::set_current_dir(root.join(file!()).parent().unwrap())
@@ -41,15 +40,4 @@ async fn build_dataflow(dataflow: &Path) -> eyre::Result<()> {
         bail!("failed to build dataflow");
     };
     Ok(())
-}
-
-fn set_up_tracing() -> eyre::Result<()> {
-    use tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt;
-
-    let stdout_log = tracing_subscriber::fmt::layer()
-        .pretty()
-        .with_filter(LevelFilter::DEBUG);
-    let subscriber = tracing_subscriber::Registry::default().with(stdout_log);
-    tracing::subscriber::set_global_default(subscriber)
-        .context("failed to set tracing global subscriber")
 }

--- a/examples/rust-ros2-dataflow/run.rs
+++ b/examples/rust-ros2-dataflow/run.rs
@@ -1,7 +1,6 @@
+use dora_tracing::set_up_tracing;
 use eyre::{bail, Context};
 use std::path::Path;
-use tracing::metadata::LevelFilter;
-use tracing_subscriber::Layer;
 
 #[derive(Debug, Clone, clap::Parser)]
 pub struct Args {
@@ -17,7 +16,7 @@ async fn main() -> eyre::Result<()> {
         return tokio::task::block_in_place(dora_daemon::run_dora_runtime);
     }
 
-    set_up_tracing().wrap_err("failed to set up tracing subscriber")?;
+    set_up_tracing("rust-ros2-dataflow-runner").wrap_err("failed to set up tracing subscriber")?;
 
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
     std::env::set_current_dir(root.join(file!()).parent().unwrap())
@@ -41,15 +40,4 @@ async fn build_dataflow(dataflow: &Path) -> eyre::Result<()> {
         bail!("failed to build dataflow");
     };
     Ok(())
-}
-
-fn set_up_tracing() -> eyre::Result<()> {
-    use tracing_subscriber::prelude::__tracing_subscriber_SubscriberExt;
-
-    let stdout_log = tracing_subscriber::fmt::layer()
-        .pretty()
-        .with_filter(LevelFilter::DEBUG);
-    let subscriber = tracing_subscriber::Registry::default().with(stdout_log);
-    tracing::subscriber::set_global_default(subscriber)
-        .context("failed to set tracing global subscriber")
 }

--- a/libraries/core/Cargo.toml
+++ b/libraries/core/Cargo.toml
@@ -19,5 +19,5 @@ uuid = { version = "1.2.1", features = ["serde"] }
 dora-message = { workspace = true }
 tracing = "0.1"
 serde-with-expand-env = "1.1.0"
-tokio = { version = "1.24.1", features = ["fs"] }
+tokio = { version = "1.24.1", features = ["fs", "process"] }
 aligned-vec = { version = "0.5.0", features = ["serde"] }

--- a/libraries/core/Cargo.toml
+++ b/libraries/core/Cargo.toml
@@ -14,7 +14,7 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_yaml = "0.9.11"
 serde_bytes = "0.11.12"
 once_cell = "1.13.0"
-which = "4.3.0"
+which = "5.0.0"
 uuid = { version = "1.2.1", features = ["serde"] }
 dora-message = { workspace = true }
 tracing = "0.1"

--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -2,6 +2,7 @@ use crate::{
     adjust_shared_library_path,
     config::{DataId, Input, InputMapping, OperatorId, UserInputMapping},
     descriptor::{self, source_is_url, CoreNodeKind, OperatorSource},
+    get_python_path,
 };
 
 use eyre::{bail, eyre, Context};
@@ -152,7 +153,7 @@ fn check_python_runtime() -> eyre::Result<()> {
     // Check if python dora-rs is installed and match cli version
     let reinstall_command =
         format!("Please reinstall it with: `pip install dora-rs=={VERSION} --force`");
-    let mut command = Command::new("python3");
+    let mut command = Command::new(get_python_path().context("Could not get python binary")?);
     command.args([
         "-c",
         &format!(

--- a/libraries/core/src/lib.rs
+++ b/libraries/core/src/lib.rs
@@ -61,24 +61,8 @@ pub async fn run<S>(program: S, args: &[&str], pwd: Option<&Path>) -> eyre::Resu
 where
     S: AsRef<OsStr>,
 {
-    // if platform is windows, use a shell
-    let mut run = if cfg!(windows) {
-        let mut run = tokio::process::Command::new("cmd.exe");
-        let mut wrapped_args = vec![
-            "/c",
-            program
-                .as_ref()
-                .to_str()
-                .context("Could not get path string")?,
-        ];
-        wrapped_args.extend(args);
-        run.args(wrapped_args);
-        run
-    } else {
-        let mut run = tokio::process::Command::new(program);
-        run.args(args);
-        run
-    };
+    let mut run = tokio::process::Command::new(program);
+    run.args(args);
 
     if let Some(pwd) = pwd {
         run.current_dir(pwd);

--- a/libraries/core/src/lib.rs
+++ b/libraries/core/src/lib.rs
@@ -1,4 +1,4 @@
-use eyre::{bail, eyre};
+use eyre::{bail, eyre, Context};
 use std::{
     env::consts::{DLL_PREFIX, DLL_SUFFIX},
     path::Path,
@@ -29,4 +29,16 @@ pub fn adjust_shared_library_path(path: &Path) -> Result<std::path::PathBuf, eyr
 
     let path = path.with_file_name(library_filename);
     Ok(path)
+}
+
+// Search for python binary.
+// First search for `python3` of python as for ubuntu <20, `python` resolves to `python2,7`
+// Then search for `python`, this will resolve for windows.
+pub fn get_python_path() -> Result<std::path::PathBuf, eyre::ErrReport> {
+    let python = match which::which("python3") {
+                    Ok(python) => python,
+                    Err(_) => which::which("python")
+                        .context("failed to find `python` or `python3` in dora-daemon path. Make sure that python is available for the daemon.")?,
+                };
+    Ok(python)
 }

--- a/libraries/core/src/lib.rs
+++ b/libraries/core/src/lib.rs
@@ -1,5 +1,4 @@
-use eyre::{bail, eyre, Context, ContextCompat};
-use maturin::BuildOptions;
+use eyre::{bail, eyre, Context};
 use std::{
     env::consts::{DLL_PREFIX, DLL_SUFFIX},
     ffi::OsStr,

--- a/libraries/core/src/lib.rs
+++ b/libraries/core/src/lib.rs
@@ -1,6 +1,7 @@
 use eyre::{bail, eyre, Context};
 use std::{
     env::consts::{DLL_PREFIX, DLL_SUFFIX},
+    ffi::OsStr,
     path::Path,
 };
 
@@ -33,12 +34,41 @@ pub fn adjust_shared_library_path(path: &Path) -> Result<std::path::PathBuf, eyr
 
 // Search for python binary.
 // First search for `python3` of python as for ubuntu <20, `python` resolves to `python2,7`
-// Then search for `python`, this will resolve for windows.
+// Then search for `python`, this will resolve for windows as python3.
 pub fn get_python_path() -> Result<std::path::PathBuf, eyre::ErrReport> {
     let python = match which::which("python3") {
-                    Ok(python) => python,
-                    Err(_) => which::which("python")
-                        .context("failed to find `python` or `python3` in dora-daemon path. Make sure that python is available for the daemon.")?,
-                };
+        Ok(python) => python,
+        Err(_) => which::which("python")
+            .context("failed to find `python` or `python3`. Make sure that python is available.")?,
+    };
     Ok(python)
+}
+
+// Search for pip binary.
+// First search for `pip3` as for ubuntu <20, `pip` can resolves to `python2,7 -m pip`
+// Then search for `pip`, this will resolve for windows to python3 -m pip.
+pub fn get_pip_path() -> Result<std::path::PathBuf, eyre::ErrReport> {
+    let python = match which::which("pip3") {
+        Ok(python) => python,
+        Err(_) => which::which("pip")
+            .context("failed to find `pip3` or `pip`. Make sure that python is available.")?,
+    };
+    Ok(python)
+}
+
+// Helper function to run a program
+pub async fn run<S>(program: S, args: &[&str], pwd: Option<&Path>) -> eyre::Result<()>
+where
+    S: AsRef<OsStr>,
+{
+    let mut run = tokio::process::Command::new(program);
+    run.args(args);
+
+    if let Some(pwd) = pwd {
+        run.current_dir(pwd);
+    }
+    if !run.status().await?.success() {
+        eyre::bail!("failed to run {args:?}");
+    };
+    Ok(())
 }

--- a/libraries/core/src/lib.rs
+++ b/libraries/core/src/lib.rs
@@ -1,4 +1,4 @@
-use eyre::{bail, eyre, Context, ContextCompat};
+use eyre::{bail, eyre, Context};
 use std::{
     env::consts::{DLL_PREFIX, DLL_SUFFIX},
     ffi::OsStr,

--- a/libraries/core/src/lib.rs
+++ b/libraries/core/src/lib.rs
@@ -33,13 +33,14 @@ pub fn adjust_shared_library_path(path: &Path) -> Result<std::path::PathBuf, eyr
 }
 
 // Search for python binary.
-// First search for `python3` of python as for ubuntu <20, `python` resolves to `python2,7`
-// Then search for `python`, this will resolve for windows as python3.
+// Match `python` for windows and `python3` for other platforms.
 pub fn get_python_path() -> Result<std::path::PathBuf, eyre::ErrReport> {
-    let python = match which::which("python3") {
-        Ok(python) => python,
-        Err(_) => which::which("python")
-            .context("failed to find `python` or `python3`. Make sure that python is available.")?,
+    let python = if cfg!(windows) {
+        which::which("python")
+            .context("failed to find `python` or `python3`. Make sure that python is available.")?
+    } else {
+        which::which("python3")
+            .context("failed to find `python` or `python3`. Make sure that python is available.")?
     };
     Ok(python)
 }

--- a/libraries/core/src/lib.rs
+++ b/libraries/core/src/lib.rs
@@ -1,4 +1,5 @@
-use eyre::{bail, eyre, Context};
+use eyre::{bail, eyre, Context, ContextCompat};
+use maturin::BuildOptions;
 use std::{
     env::consts::{DLL_PREFIX, DLL_SUFFIX},
     ffi::OsStr,

--- a/libraries/extensions/download/Cargo.toml
+++ b/libraries/extensions/download/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 [dependencies]
 eyre = "0.6.8"
 reqwest = { version = "0.11.12", default-features = false, features = [
-    "rustls",
+    "rustls-tls",
 ] }
 tokio = { version = "1.24.2", features = ["fs"] }
 tracing = "0.1.36"


### PR DESCRIPTION
Fix window path issue by using `which::which` (Cross Platform) to see if `python3` is in path. 

If python3 is not in path, try to use `python` alone. 

Else it return an error with: `failed to find `python` or `python3` in dora-daemon path. Make sure that python is available for the daemon`

Put back windows test into the CI