### PR TITLE
Fix read error in C++ node input

### DIFF
--- a/examples/c++-dataflow/dataflow.yml
+++ b/examples/c++-dataflow/dataflow.yml
@@ -10,7 +10,7 @@ nodes:
     custom:
       source: build/node_c_api
       inputs:
-        tick: dora/timer/millis/300
+        tick: cxx-node-rust-api/counter
       outputs:
         - counter
 


### PR DESCRIPTION
Thwy were an error of typecasting within the C++ node input.

This fixes #403

I have not adressed all input type as I think a solution based on arrow FFI would be better.