### PR TITLE
Release version v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "benchmark-example-node"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "benchmark-example-sink"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "communication-layer-pub-sub"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "flume",
  "zenoh",
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "communication-layer-request-reply"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 
 [[package]]
 name = "concurrent-queue"
@@ -1403,7 +1403,7 @@ dependencies = [
 
 [[package]]
 name = "dora-arrow-convert"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "arrow",
  "eyre",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "dora-cli"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "bat",
  "clap 4.4.6",
@@ -1435,7 +1435,7 @@ dependencies = [
 
 [[package]]
 name = "dora-coordinator"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "clap 4.4.6",
  "ctrlc",
@@ -1460,7 +1460,7 @@ dependencies = [
 
 [[package]]
 name = "dora-core"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "aligned-vec",
  "dora-message",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "dora-daemon"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "aligned-vec",
  "arrow-schema",
@@ -1508,7 +1508,7 @@ dependencies = [
 
 [[package]]
 name = "dora-download"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "eyre",
  "reqwest",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "dora-message"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "arrow-data",
  "arrow-schema",
@@ -1550,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "dora-metrics"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "futures",
  "opentelemetry 0.21.0",
@@ -1561,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-c"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "arrow-array",
  "dora-node-api",
@@ -1601,7 +1601,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-cxx"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -1611,7 +1611,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-python"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "arrow",
  "dora-node-api",
@@ -1628,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "dora-arrow-convert",
  "dora-operator-api-macros",
@@ -1637,14 +1637,14 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-c"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "dora-operator-api-types",
 ]
 
 [[package]]
 name = "dora-operator-api-cxx"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-macros"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-python"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -1676,7 +1676,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-types"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "arrow",
  "dora-arrow-convert",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "dora-record"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "chrono",
  "dora-node-api",
@@ -1758,7 +1758,7 @@ dependencies = [
 
 [[package]]
 name = "dora-runtime"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "dora-tracing"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "eyre",
  "opentelemetry 0.18.0",
@@ -3269,7 +3269,7 @@ dependencies = [
 
 [[package]]
 name = "multiple-daemons-example-node"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -3280,14 +3280,14 @@ dependencies = [
 
 [[package]]
 name = "multiple-daemons-example-operator"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "dora-operator-api",
 ]
 
 [[package]]
 name = "multiple-daemons-example-sink"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4688,7 +4688,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-node"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4699,14 +4699,14 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-operator"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "dora-operator-api",
 ]
 
 [[package]]
 name = "rust-dataflow-example-sink"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4714,7 +4714,7 @@ dependencies = [
 
 [[package]]
 name = "rust-ros2-dataflow-example-node"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "dora-node-api",
  "dora-ros2-bridge",
@@ -5118,7 +5118,7 @@ dependencies = [
 
 [[package]]
 name = "shared-memory-server"
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 dependencies = [
  "bincode",
  "eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "benchmark-example-node"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "benchmark-example-sink"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "communication-layer-pub-sub"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "flume",
  "zenoh",
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "communication-layer-request-reply"
-version = "0.3.0"
+version = "0.3.1-rc5"
 
 [[package]]
 name = "concurrent-queue"
@@ -1403,7 +1403,7 @@ dependencies = [
 
 [[package]]
 name = "dora-arrow-convert"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "arrow",
  "eyre",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "dora-cli"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "bat",
  "clap 4.4.6",
@@ -1435,7 +1435,7 @@ dependencies = [
 
 [[package]]
 name = "dora-coordinator"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "clap 4.4.6",
  "ctrlc",
@@ -1460,7 +1460,7 @@ dependencies = [
 
 [[package]]
 name = "dora-core"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "aligned-vec",
  "dora-message",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "dora-daemon"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "aligned-vec",
  "arrow-schema",
@@ -1508,7 +1508,7 @@ dependencies = [
 
 [[package]]
 name = "dora-download"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "eyre",
  "reqwest",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "dora-message"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "arrow-data",
  "arrow-schema",
@@ -1550,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "dora-metrics"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "futures",
  "opentelemetry 0.21.0",
@@ -1561,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-c"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "arrow-array",
  "dora-node-api",
@@ -1601,7 +1601,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-cxx"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -1611,7 +1611,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-python"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "arrow",
  "dora-node-api",
@@ -1628,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "dora-arrow-convert",
  "dora-operator-api-macros",
@@ -1637,14 +1637,14 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-c"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "dora-operator-api-types",
 ]
 
 [[package]]
 name = "dora-operator-api-cxx"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-macros"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-python"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -1676,7 +1676,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-types"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "arrow",
  "dora-arrow-convert",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "dora-record"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "chrono",
  "dora-node-api",
@@ -1758,7 +1758,7 @@ dependencies = [
 
 [[package]]
 name = "dora-runtime"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "dora-tracing"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "eyre",
  "opentelemetry 0.18.0",
@@ -3269,7 +3269,7 @@ dependencies = [
 
 [[package]]
 name = "multiple-daemons-example-node"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -3280,14 +3280,14 @@ dependencies = [
 
 [[package]]
 name = "multiple-daemons-example-operator"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "dora-operator-api",
 ]
 
 [[package]]
 name = "multiple-daemons-example-sink"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -3521,7 +3521,7 @@ checksum = "cfb77679af88f8b125209d354a202862602672222e7f2313fdd6dc349bad4712"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -4688,7 +4688,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-node"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4699,14 +4699,14 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-operator"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "dora-operator-api",
 ]
 
 [[package]]
 name = "rust-dataflow-example-sink"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4714,7 +4714,7 @@ dependencies = [
 
 [[package]]
 name = "rust-ros2-dataflow-example-node"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "dora-node-api",
  "dora-ros2-bridge",
@@ -5118,7 +5118,7 @@ dependencies = [
 
 [[package]]
 name = "shared-memory-server"
-version = "0.3.0"
+version = "0.3.1-rc5"
 dependencies = [
  "bincode",
  "eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4881,9 +4881,9 @@ checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "safer-ffi"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c1d19b288ca9898cd421c7b105fb7269918a7f8e9253a991e228981ca421ad"
+checksum = "395ace5aff9629c7268ca8255aceb945525b2cb644015f3caec5131a6a537c11"
 dependencies = [
  "inventory 0.1.11",
  "inventory 0.3.12",
@@ -4899,9 +4899,9 @@ dependencies = [
 
 [[package]]
 name = "safer_ffi-proc_macros"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d7a04caa3ca2224f5ea4ddd850e2629c3b36b2b83621f87a8303bf41020110"
+checksum = "9255504d5467bae9e07d58b8de446ba6739b29bf72e1fa35b2387e30d29dcbfe"
 dependencies = [
  "macro_rules_attribute",
  "prettyplease",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "benchmark-example-node"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "benchmark-example-sink"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "communication-layer-pub-sub"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "flume",
  "zenoh",
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "communication-layer-request-reply"
-version = "0.3.1-rc6"
+version = "0.3.1"
 
 [[package]]
 name = "concurrent-queue"
@@ -1403,7 +1403,7 @@ dependencies = [
 
 [[package]]
 name = "dora-arrow-convert"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "arrow",
  "eyre",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "dora-cli"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "bat",
  "clap 4.4.6",
@@ -1435,7 +1435,7 @@ dependencies = [
 
 [[package]]
 name = "dora-coordinator"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "clap 4.4.6",
  "ctrlc",
@@ -1460,7 +1460,7 @@ dependencies = [
 
 [[package]]
 name = "dora-core"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "aligned-vec",
  "dora-message",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "dora-daemon"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "aligned-vec",
  "arrow-schema",
@@ -1508,7 +1508,7 @@ dependencies = [
 
 [[package]]
 name = "dora-download"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "eyre",
  "reqwest",
@@ -1539,7 +1539,7 @@ dependencies = [
 
 [[package]]
 name = "dora-message"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "arrow-data",
  "arrow-schema",
@@ -1550,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "dora-metrics"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "futures",
  "opentelemetry 0.21.0",
@@ -1561,7 +1561,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-c"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "arrow-array",
  "dora-node-api",
@@ -1601,7 +1601,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-cxx"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -1611,7 +1611,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-python"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "arrow",
  "dora-node-api",
@@ -1628,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "dora-arrow-convert",
  "dora-operator-api-macros",
@@ -1637,14 +1637,14 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-c"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "dora-operator-api-types",
 ]
 
 [[package]]
 name = "dora-operator-api-cxx"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -1653,7 +1653,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-macros"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-python"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -1676,7 +1676,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-types"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "arrow",
  "dora-arrow-convert",
@@ -1685,7 +1685,7 @@ dependencies = [
 
 [[package]]
 name = "dora-record"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "dora-node-api",
@@ -1758,7 +1758,7 @@ dependencies = [
 
 [[package]]
 name = "dora-runtime"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "dora-tracing"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "eyre",
  "opentelemetry 0.18.0",
@@ -3269,7 +3269,7 @@ dependencies = [
 
 [[package]]
 name = "multiple-daemons-example-node"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -3280,14 +3280,14 @@ dependencies = [
 
 [[package]]
 name = "multiple-daemons-example-operator"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "dora-operator-api",
 ]
 
 [[package]]
 name = "multiple-daemons-example-sink"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4688,7 +4688,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-node"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4699,14 +4699,14 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-operator"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "dora-operator-api",
 ]
 
 [[package]]
 name = "rust-dataflow-example-sink"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4714,7 +4714,7 @@ dependencies = [
 
 [[package]]
 name = "rust-ros2-dataflow-example-node"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "dora-node-api",
  "dora-ros2-bridge",
@@ -5118,7 +5118,7 @@ dependencies = [
 
 [[package]]
 name = "shared-memory-server"
-version = "0.3.1-rc6"
+version = "0.3.1"
 dependencies = [
  "bincode",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,31 +33,31 @@ members = [
 
 [workspace.package]
 # Make sure to also bump `apis/node/python/__init__.py` version.
-version = "0.3.0"
+version = "0.3.1-rc5"
 description = "`dora` goal is to be a low latency, composable, and distributed data flow."
 documentation = "https://dora.carsmos.ai"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-dora-node-api = { version = "0.3.0", path = "apis/rust/node", default-features = false }
-dora-node-api-python = { version = "0.3.0", path = "apis/python/node", default-features = false }
-dora-operator-api = { version = "0.3.0", path = "apis/rust/operator", default-features = false }
-dora-operator-api-macros = { version = "0.3.0", path = "apis/rust/operator/macros" }
-dora-operator-api-types = { version = "0.3.0", path = "apis/rust/operator/types" }
-dora-operator-api-python = { version = "0.3.0", path = "apis/python/operator" }
-dora-operator-api-c = { version = "0.3.0", path = "apis/c/operator" }
-dora-node-api-c = { version = "0.3.0", path = "apis/c/node" }
-dora-core = { version = "0.3.0", path = "libraries/core" }
-dora-arrow-convert = { version = "0.3.0", path = "libraries/arrow-convert" }
-dora-tracing = { version = "0.3.0", path = "libraries/extensions/telemetry/tracing" }
-dora-metrics = { version = "0.3.0", path = "libraries/extensions/telemetry/metrics" }
-dora-download = { version = "0.3.0", path = "libraries/extensions/download" }
-shared-memory-server = { version = "0.3.0", path = "libraries/shared-memory-server" }
-communication-layer-request-reply = { version = "0.3.0", path = "libraries/communication-layer/request-reply" }
-dora-message = { version = "0.3.0", path = "libraries/message" }
-dora-runtime = { version = "0.3.0", path = "binaries/runtime" }
-dora-daemon = { version = "0.3.0", path = "binaries/daemon" }
-dora-coordinator = { version = "0.3.0", path = "binaries/coordinator" }
+dora-node-api = { version = "0.3.1-rc5", path = "apis/rust/node", default-features = false }
+dora-node-api-python = { version = "0.3.1-rc5", path = "apis/python/node", default-features = false }
+dora-operator-api = { version = "0.3.1-rc5", path = "apis/rust/operator", default-features = false }
+dora-operator-api-macros = { version = "0.3.1-rc5", path = "apis/rust/operator/macros" }
+dora-operator-api-types = { version = "0.3.1-rc5", path = "apis/rust/operator/types" }
+dora-operator-api-python = { version = "0.3.1-rc5", path = "apis/python/operator" }
+dora-operator-api-c = { version = "0.3.1-rc5", path = "apis/c/operator" }
+dora-node-api-c = { version = "0.3.1-rc5", path = "apis/c/node" }
+dora-core = { version = "0.3.1-rc5", path = "libraries/core" }
+dora-arrow-convert = { version = "0.3.1-rc5", path = "libraries/arrow-convert" }
+dora-tracing = { version = "0.3.1-rc5", path = "libraries/extensions/telemetry/tracing" }
+dora-metrics = { version = "0.3.1-rc5", path = "libraries/extensions/telemetry/metrics" }
+dora-download = { version = "0.3.1-rc5", path = "libraries/extensions/download" }
+shared-memory-server = { version = "0.3.1-rc5", path = "libraries/shared-memory-server" }
+communication-layer-request-reply = { version = "0.3.1-rc5", path = "libraries/communication-layer/request-reply" }
+dora-message = { version = "0.3.1-rc5", path = "libraries/message" }
+dora-runtime = { version = "0.3.1-rc5", path = "binaries/runtime" }
+dora-daemon = { version = "0.3.1-rc5", path = "binaries/daemon" }
+dora-coordinator = { version = "0.3.1-rc5", path = "binaries/coordinator" }
 dora-ros2-bridge = { path = "libraries/extensions/ros2-bridge" }
 dora-ros2-bridge-python = { path = "libraries/extensions/ros2-bridge/python" }
 arrow = "48.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,31 +33,31 @@ members = [
 
 [workspace.package]
 # Make sure to also bump `apis/node/python/__init__.py` version.
-version = "0.3.1-rc5"
+version = "0.3.1-rc6"
 description = "`dora` goal is to be a low latency, composable, and distributed data flow."
 documentation = "https://dora.carsmos.ai"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-dora-node-api = { version = "0.3.1-rc5", path = "apis/rust/node", default-features = false }
-dora-node-api-python = { version = "0.3.1-rc5", path = "apis/python/node", default-features = false }
-dora-operator-api = { version = "0.3.1-rc5", path = "apis/rust/operator", default-features = false }
-dora-operator-api-macros = { version = "0.3.1-rc5", path = "apis/rust/operator/macros" }
-dora-operator-api-types = { version = "0.3.1-rc5", path = "apis/rust/operator/types" }
-dora-operator-api-python = { version = "0.3.1-rc5", path = "apis/python/operator" }
-dora-operator-api-c = { version = "0.3.1-rc5", path = "apis/c/operator" }
-dora-node-api-c = { version = "0.3.1-rc5", path = "apis/c/node" }
-dora-core = { version = "0.3.1-rc5", path = "libraries/core" }
-dora-arrow-convert = { version = "0.3.1-rc5", path = "libraries/arrow-convert" }
-dora-tracing = { version = "0.3.1-rc5", path = "libraries/extensions/telemetry/tracing" }
-dora-metrics = { version = "0.3.1-rc5", path = "libraries/extensions/telemetry/metrics" }
-dora-download = { version = "0.3.1-rc5", path = "libraries/extensions/download" }
-shared-memory-server = { version = "0.3.1-rc5", path = "libraries/shared-memory-server" }
-communication-layer-request-reply = { version = "0.3.1-rc5", path = "libraries/communication-layer/request-reply" }
-dora-message = { version = "0.3.1-rc5", path = "libraries/message" }
-dora-runtime = { version = "0.3.1-rc5", path = "binaries/runtime" }
-dora-daemon = { version = "0.3.1-rc5", path = "binaries/daemon" }
-dora-coordinator = { version = "0.3.1-rc5", path = "binaries/coordinator" }
+dora-node-api = { version = "0.3.1-rc6", path = "apis/rust/node", default-features = false }
+dora-node-api-python = { version = "0.3.1-rc6", path = "apis/python/node", default-features = false }
+dora-operator-api = { version = "0.3.1-rc6", path = "apis/rust/operator", default-features = false }
+dora-operator-api-macros = { version = "0.3.1-rc6", path = "apis/rust/operator/macros" }
+dora-operator-api-types = { version = "0.3.1-rc6", path = "apis/rust/operator/types" }
+dora-operator-api-python = { version = "0.3.1-rc6", path = "apis/python/operator" }
+dora-operator-api-c = { version = "0.3.1-rc6", path = "apis/c/operator" }
+dora-node-api-c = { version = "0.3.1-rc6", path = "apis/c/node" }
+dora-core = { version = "0.3.1-rc6", path = "libraries/core" }
+dora-arrow-convert = { version = "0.3.1-rc6", path = "libraries/arrow-convert" }
+dora-tracing = { version = "0.3.1-rc6", path = "libraries/extensions/telemetry/tracing" }
+dora-metrics = { version = "0.3.1-rc6", path = "libraries/extensions/telemetry/metrics" }
+dora-download = { version = "0.3.1-rc6", path = "libraries/extensions/download" }
+shared-memory-server = { version = "0.3.1-rc6", path = "libraries/shared-memory-server" }
+communication-layer-request-reply = { version = "0.3.1-rc6", path = "libraries/communication-layer/request-reply" }
+dora-message = { version = "0.3.1-rc6", path = "libraries/message" }
+dora-runtime = { version = "0.3.1-rc6", path = "binaries/runtime" }
+dora-daemon = { version = "0.3.1-rc6", path = "binaries/daemon" }
+dora-coordinator = { version = "0.3.1-rc6", path = "binaries/coordinator" }
 dora-ros2-bridge = { path = "libraries/extensions/ros2-bridge" }
 dora-ros2-bridge-python = { path = "libraries/extensions/ros2-bridge/python" }
 arrow = "48.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,31 +33,31 @@ members = [
 
 [workspace.package]
 # Make sure to also bump `apis/node/python/__init__.py` version.
-version = "0.3.1-rc6"
+version = "0.3.1"
 description = "`dora` goal is to be a low latency, composable, and distributed data flow."
 documentation = "https://dora.carsmos.ai"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-dora-node-api = { version = "0.3.1-rc6", path = "apis/rust/node", default-features = false }
-dora-node-api-python = { version = "0.3.1-rc6", path = "apis/python/node", default-features = false }
-dora-operator-api = { version = "0.3.1-rc6", path = "apis/rust/operator", default-features = false }
-dora-operator-api-macros = { version = "0.3.1-rc6", path = "apis/rust/operator/macros" }
-dora-operator-api-types = { version = "0.3.1-rc6", path = "apis/rust/operator/types" }
-dora-operator-api-python = { version = "0.3.1-rc6", path = "apis/python/operator" }
-dora-operator-api-c = { version = "0.3.1-rc6", path = "apis/c/operator" }
-dora-node-api-c = { version = "0.3.1-rc6", path = "apis/c/node" }
-dora-core = { version = "0.3.1-rc6", path = "libraries/core" }
-dora-arrow-convert = { version = "0.3.1-rc6", path = "libraries/arrow-convert" }
-dora-tracing = { version = "0.3.1-rc6", path = "libraries/extensions/telemetry/tracing" }
-dora-metrics = { version = "0.3.1-rc6", path = "libraries/extensions/telemetry/metrics" }
-dora-download = { version = "0.3.1-rc6", path = "libraries/extensions/download" }
-shared-memory-server = { version = "0.3.1-rc6", path = "libraries/shared-memory-server" }
-communication-layer-request-reply = { version = "0.3.1-rc6", path = "libraries/communication-layer/request-reply" }
-dora-message = { version = "0.3.1-rc6", path = "libraries/message" }
-dora-runtime = { version = "0.3.1-rc6", path = "binaries/runtime" }
-dora-daemon = { version = "0.3.1-rc6", path = "binaries/daemon" }
-dora-coordinator = { version = "0.3.1-rc6", path = "binaries/coordinator" }
+dora-node-api = { version = "0.3.1", path = "apis/rust/node", default-features = false }
+dora-node-api-python = { version = "0.3.1", path = "apis/python/node", default-features = false }
+dora-operator-api = { version = "0.3.1", path = "apis/rust/operator", default-features = false }
+dora-operator-api-macros = { version = "0.3.1", path = "apis/rust/operator/macros" }
+dora-operator-api-types = { version = "0.3.1", path = "apis/rust/operator/types" }
+dora-operator-api-python = { version = "0.3.1", path = "apis/python/operator" }
+dora-operator-api-c = { version = "0.3.1", path = "apis/c/operator" }
+dora-node-api-c = { version = "0.3.1", path = "apis/c/node" }
+dora-core = { version = "0.3.1", path = "libraries/core" }
+dora-arrow-convert = { version = "0.3.1", path = "libraries/arrow-convert" }
+dora-tracing = { version = "0.3.1", path = "libraries/extensions/telemetry/tracing" }
+dora-metrics = { version = "0.3.1", path = "libraries/extensions/telemetry/metrics" }
+dora-download = { version = "0.3.1", path = "libraries/extensions/download" }
+shared-memory-server = { version = "0.3.1", path = "libraries/shared-memory-server" }
+communication-layer-request-reply = { version = "0.3.1", path = "libraries/communication-layer/request-reply" }
+dora-message = { version = "0.3.1", path = "libraries/message" }
+dora-runtime = { version = "0.3.1", path = "binaries/runtime" }
+dora-daemon = { version = "0.3.1", path = "binaries/daemon" }
+dora-coordinator = { version = "0.3.1", path = "binaries/coordinator" }
 dora-ros2-bridge = { path = "libraries/extensions/ros2-bridge" }
 dora-ros2-bridge-python = { path = "libraries/extensions/ros2-bridge/python" }
 arrow = "48.0.0"

--- a/Changelog.md
+++ b/Changelog.md
@@ -24,7 +24,7 @@
 
 - @XxChang made their first contribution in https://github.com/dora-rs/dora/pull/381
 
-**Full Changelog**: https://github.com/dora-rs/dora/compare/v0.3.0...v0.3.1-rc5
+**Full Changelog**: https://github.com/dora-rs/dora/compare/v0.3.0...v0.3.1
 
 ## v0.3.0 (2023-11-01)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## v0.3.1 (2024-01-09)
+
+## Features
+
+- Support legacy python by @haixuanTao in https://github.com/dora-rs/dora/pull/382
+- Add an error catch in python `on_event` when using hot-reloading by @haixuanTao in https://github.com/dora-rs/dora/pull/372
+- add cmake example by @XxChang in https://github.com/dora-rs/dora/pull/381
+- Bump opentelemetry metrics to 0.21 by @haixuanTao in https://github.com/dora-rs/dora/pull/383
+- Trace send_output as it can be a big source of overhead for large messages by @haixuanTao in https://github.com/dora-rs/dora/pull/384
+- Adding a timeout method to not block indefinitely next event by @haixuanTao in https://github.com/dora-rs/dora/pull/386
+- Adding `Vec<u8>` conversion by @haixuanTao in https://github.com/dora-rs/dora/pull/387
+- Dora cli renaming by @haixuanTao in https://github.com/dora-rs/dora/pull/399
+- Update `ros2-client` and `rustdds` dependencies to latest fork version by @phil-opp in https://github.com/dora-rs/dora/pull/397
+
+## Fix
+
+- Fix window path error by @haixuanTao in https://github.com/dora-rs/dora/pull/398
+- Fix read error in C++ node input by @haixuanTao in https://github.com/dora-rs/dora/pull/406
+- Bump unsafe-libyaml from 0.2.9 to 0.2.10 by @dependabot in https://github.com/dora-rs/dora/pull/400
+
+## New Contributors
+
+- @XxChang made their first contribution in https://github.com/dora-rs/dora/pull/381
+
+**Full Changelog**: https://github.com/dora-rs/dora/compare/v0.3.0...v0.3.1-rc5
+
 ## v0.3.0 (2023-11-01)
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -71,17 +71,17 @@ For more installation guideline, check out our installation guide here: https://
 1. Install the example python dependencies:
 
 ```bash
-pip install -r https://raw.githubusercontent.com/dora-rs/dora/v0.3.1-rc5/examples/python-operator-dataflow/requirements.txt
+pip install -r https://raw.githubusercontent.com/dora-rs/dora/v0.3.1/examples/python-operator-dataflow/requirements.txt
 ```
 
 2. Get some example operators:
 
 ```bash
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.1-rc5/examples/python-operator-dataflow/webcam.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.1-rc5/examples/python-operator-dataflow/plot.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.1-rc5/examples/python-operator-dataflow/utils.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.1-rc5/examples/python-operator-dataflow/object_detection.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.1-rc5/examples/python-operator-dataflow/dataflow.yml
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.1/examples/python-operator-dataflow/webcam.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.1/examples/python-operator-dataflow/plot.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.1/examples/python-operator-dataflow/utils.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.1/examples/python-operator-dataflow/object_detection.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.1/examples/python-operator-dataflow/dataflow.yml
 ```
 
 3. Start the dataflow

--- a/README.md
+++ b/README.md
@@ -71,17 +71,17 @@ For more installation guideline, check out our installation guide here: https://
 1. Install the example python dependencies:
 
 ```bash
-pip install -r https://raw.githubusercontent.com/dora-rs/dora/v0.3.0/examples/python-operator-dataflow/requirements.txt
+pip install -r https://raw.githubusercontent.com/dora-rs/dora/v0.3.1-rc5/examples/python-operator-dataflow/requirements.txt
 ```
 
 2. Get some example operators:
 
 ```bash
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.0/examples/python-operator-dataflow/webcam.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.0/examples/python-operator-dataflow/plot.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.0/examples/python-operator-dataflow/utils.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.0/examples/python-operator-dataflow/object_detection.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.0/examples/python-operator-dataflow/dataflow.yml
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.1-rc5/examples/python-operator-dataflow/webcam.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.1-rc5/examples/python-operator-dataflow/plot.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.1-rc5/examples/python-operator-dataflow/utils.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.1-rc5/examples/python-operator-dataflow/object_detection.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.1-rc5/examples/python-operator-dataflow/dataflow.yml
 ```
 
 3. Start the dataflow

--- a/apis/c++/node/src/lib.rs
+++ b/apis/c++/node/src/lib.rs
@@ -82,7 +82,12 @@ fn event_type(event: &DoraEvent) -> ffi::DoraEventType {
 }
 
 fn event_as_input(event: Box<DoraEvent>) -> eyre::Result<ffi::DoraInput> {
-    let Some(Event::Input { id, metadata: _, data }) = event.0 else {
+    let Some(Event::Input {
+        id,
+        metadata: _,
+        data,
+    }) = event.0
+    else {
         bail!("not an input event");
     };
     let data: Option<&BinaryArray> = data.as_binary_opt();

--- a/apis/python/node/dora/__init__.py
+++ b/apis/python/node/dora/__init__.py
@@ -15,7 +15,7 @@ from enum import Enum
 from .dora import *
 
 __author__ = "Dora-rs Authors"
-__version__ = "0.3.1-rc5"
+__version__ = "0.3.1-rc6"
 
 
 class DoraStatus(Enum):

--- a/apis/python/node/dora/__init__.py
+++ b/apis/python/node/dora/__init__.py
@@ -15,7 +15,7 @@ from enum import Enum
 from .dora import *
 
 __author__ = "Dora-rs Authors"
-__version__ = "0.3.1-rc6"
+__version__ = "0.3.1"
 
 
 class DoraStatus(Enum):

--- a/apis/python/node/dora/__init__.py
+++ b/apis/python/node/dora/__init__.py
@@ -15,7 +15,7 @@ from enum import Enum
 from .dora import *
 
 __author__ = "Dora-rs Authors"
-__version__ = "0.3.0"
+__version__ = "0.3.1-rc5"
 
 
 class DoraStatus(Enum):

--- a/apis/rust/operator/src/raw.rs
+++ b/apis/rust/operator/src/raw.rs
@@ -24,7 +24,7 @@ pub unsafe fn dora_init_operator<O: DoraOperator>() -> DoraInitResult {
 
 pub unsafe fn dora_drop_operator<O>(operator_context: *mut c_void) -> DoraResult {
     let raw: *mut O = operator_context.cast();
-    unsafe { Box::from_raw(raw) };
+    let _ = unsafe { Box::from_raw(raw) };
     DoraResult { error: None }
 }
 
@@ -40,10 +40,12 @@ pub unsafe fn dora_on_event<O: DoraOperator>(
     let event_variant = if let Some(input) = &mut event.input {
         let Some(data_array) = input.data_array.take() else {
             return OnEventResult {
-                result: DoraResult { error: Some("data already taken".to_string().into()) },
+                result: DoraResult {
+                    error: Some("data already taken".to_string().into()),
+                },
                 status: DoraStatus::Continue,
             };
-         };
+        };
         let data = arrow::ffi::from_ffi(data_array, &input.schema);
 
         match data {

--- a/apis/rust/operator/types/Cargo.toml
+++ b/apis/rust/operator/types/Cargo.toml
@@ -13,5 +13,5 @@ arrow = { workspace = true, features = ["ffi"] }
 dora-arrow-convert = { workspace = true }
 
 [dependencies.safer-ffi]
-version = "0.1.3"
+version = "0.1.4"
 features = ["headers", "inventory-0-3-1"]

--- a/apis/rust/operator/types/src/lib.rs
+++ b/apis/rust/operator/types/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(elided_lifetimes_in_paths)] // required for safer-ffi
+#![allow(improper_ctypes_definitions)]
 
 pub use arrow;
 use dora_arrow_convert::{ArrowData, IntoArrow};

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -251,8 +251,11 @@ async fn start_inner(
 
                                 // notify all machines that run parts of the dataflow
                                 for machine_id in &dataflow.machines {
-                                    let Some(connection) = daemon_connections.get_mut(machine_id) else {
-                                        tracing::warn!("no daemon connection found for machine `{machine_id}`");
+                                    let Some(connection) = daemon_connections.get_mut(machine_id)
+                                    else {
+                                        tracing::warn!(
+                                            "no daemon connection found for machine `{machine_id}`"
+                                        );
                                         continue;
                                     };
                                     tcp_send(&mut connection.stream, &message)

--- a/binaries/daemon/src/node_communication/mod.rs
+++ b/binaries/daemon/src/node_communication/mod.rs
@@ -299,7 +299,11 @@ impl Listener {
 
         // iterate over queued events, newest first
         for event in self.queue.iter_mut().rev() {
-            let Some(Timestamped { inner: NodeEvent::Input { id, data, .. }, ..}) = event.as_mut() else {
+            let Some(Timestamped {
+                inner: NodeEvent::Input { id, data, .. },
+                ..
+            }) = event.as_mut()
+            else {
                 continue;
             };
             match queue_size_remaining.get_mut(id) {

--- a/binaries/daemon/src/spawn.rs
+++ b/binaries/daemon/src/spawn.rs
@@ -93,8 +93,7 @@ pub async fn spawn_node(
                         }
                         _ => {
                             tracing::info!("spawning: {}", resolved_path.display());
-                            let cmd = tokio::process::Command::new(&resolved_path);
-                            cmd
+                            tokio::process::Command::new(&resolved_path)
                         }
                     };
 

--- a/binaries/runtime/src/lib.rs
+++ b/binaries/runtime/src/lib.rs
@@ -190,7 +190,9 @@ async fn run(
                         }
 
                         let Some(config) = operators.get(&operator_id) else {
-                            tracing::warn!("received Finished event for unknown operator `{operator_id}`");
+                            tracing::warn!(
+                                "received Finished event for unknown operator `{operator_id}`"
+                            );
                             continue;
                         };
                         let outputs = config

--- a/binaries/runtime/src/operator/python.rs
+++ b/binaries/runtime/src/operator/python.rs
@@ -123,7 +123,9 @@ pub fn run(
         let mut reload = false;
         let reason = loop {
             #[allow(unused_mut)]
-            let Ok(mut event) = incoming_events.recv() else { break StopReason::InputsClosed };
+            let Ok(mut event) = incoming_events.recv() else {
+                break StopReason::InputsClosed;
+            };
 
             if let Event::Reload { .. } = event {
                 reload = true;

--- a/binaries/runtime/src/operator/shared_lib.rs
+++ b/binaries/runtime/src/operator/shared_lib.rs
@@ -168,7 +168,7 @@ impl<'lib> SharedLibraryOperator<'lib> {
         let reason = loop {
             #[allow(unused_mut)]
             let Ok(mut event) = self.incoming_events.recv() else {
-                break StopReason::InputsClosed
+                break StopReason::InputsClosed;
             };
 
             let span = span!(tracing::Level::TRACE, "on_event", input_id = field::Empty);

--- a/examples/cmake-dataflow/DoraTargets.cmake
+++ b/examples/cmake-dataflow/DoraTargets.cmake
@@ -15,7 +15,7 @@ if(DORA_ROOT_DIR)
     )
     FetchContent_MakeAvailable(Corrosion)
     list(PREPEND CMAKE_MODULE_PATH ${Corrosion_SOURCE_DIR}/cmake)
-    find_package(Rust 1.70 REQUIRED MODULE)
+    find_package(Rust 1.72 REQUIRED MODULE)
     corrosion_import_crate(MANIFEST_PATH "${DORA_ROOT_DIR}/Cargo.toml"
         CRATES
         dora-node-api-c

--- a/libraries/extensions/ros2-bridge/python/src/lib.rs
+++ b/libraries/extensions/ros2-bridge/python/src/lib.rs
@@ -238,7 +238,7 @@ impl Ros2Subscription {
             .take_seed(self.deserializer.clone())
             .context("failed to take next message from subscription")?;
         let Some((value, _info)) = message else {
-            return Ok(None)
+            return Ok(None);
         };
 
         let message = value.to_pyarrow(py)?;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.70"
+channel = "1.72"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
This version should fix a lot of small annoying things and new welcomed features.

## v0.3.1 (2024-01-09)

## Features

- Support legacy python by @haixuanTao in https://github.com/dora-rs/dora/pull/382
- Add an error catch in python `on_event` when using hot-reloading by @haixuanTao in https://github.com/dora-rs/dora/pull/372
- add cmake example by @XxChang in https://github.com/dora-rs/dora/pull/381
- Bump opentelemetry metrics to 0.21 by @haixuanTao in https://github.com/dora-rs/dora/pull/383
- Trace send_output as it can be a big source of overhead for large messages by @haixuanTao in https://github.com/dora-rs/dora/pull/384
- Adding a timeout method to not block indefinitely next event by @haixuanTao in https://github.com/dora-rs/dora/pull/386
- Adding `Vec<u8>` conversion by @haixuanTao in https://github.com/dora-rs/dora/pull/387
- Dora cli renaming by @haixuanTao in https://github.com/dora-rs/dora/pull/399
- Update `ros2-client` and `rustdds` dependencies to latest fork version by @phil-opp in https://github.com/dora-rs/dora/pull/397

## Fix

- Fix window path error by @haixuanTao in https://github.com/dora-rs/dora/pull/398
- Fix read error in C++ node input by @haixuanTao in https://github.com/dora-rs/dora/pull/406
- Bump unsafe-libyaml from 0.2.9 to 0.2.10 by @dependabot in https://github.com/dora-rs/dora/pull/400

## New Contributors

- @XxChang made their first contribution in https://github.com/dora-rs/dora/pull/381
