### PR TITLE
Fix ros2 array bug

### DIFF
--- a/binaries/runtime/src/operator/mod.rs
+++ b/binaries/runtime/src/operator/mod.rs
@@ -13,6 +13,7 @@ pub mod channel;
 mod python;
 mod shared_lib;
 
+#[allow(unused_variables)]
 pub fn run_operator(
     node_id: &NodeId,
     operator_definition: OperatorDefinition,

--- a/libraries/extensions/ros2-bridge/python/src/lib.rs
+++ b/libraries/extensions/ros2-bridge/python/src/lib.rs
@@ -6,7 +6,7 @@ use std::{
 
 use ::dora_ros2_bridge::{ros2_client, rustdds};
 use arrow::{
-    array::ArrayData,
+    array::{make_array, ArrayData},
     pyarrow::{FromPyArrow, ToPyArrow},
 };
 use dora_ros2_bridge_msg_gen::types::Message;
@@ -52,6 +52,7 @@ impl Ros2Context {
                 ament_prefix_path_parsed.split(':').map(Path::new).collect()
             }
         };
+
         let packages = dora_ros2_bridge_msg_gen::get_packages(&paths)
             .map_err(|err| eyre!(err))
             .context("failed to parse ROS2 message types")?;
@@ -209,7 +210,7 @@ impl Ros2Publisher {
         //// add type info to ensure correct serialization (e.g. struct types
         //// and map types need to be serialized differently)
         let typed_value = TypedValue {
-            value: &value,
+            value: &make_array(value),
             type_info: &self.type_info,
         };
 

--- a/libraries/extensions/ros2-bridge/python/src/typed/serialize.rs
+++ b/libraries/extensions/ros2-bridge/python/src/typed/serialize.rs
@@ -1,4 +1,7 @@
-use arrow::array::ArrayData;
+use arrow::array::make_array;
+use arrow::array::Array;
+use arrow::array::ArrayRef;
+use arrow::array::AsArray;
 use arrow::array::Float32Array;
 use arrow::array::Float64Array;
 use arrow::array::Int16Array;
@@ -20,7 +23,7 @@ use super::TypeInfo;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct TypedValue<'a> {
-    pub value: &'a ArrayData,
+    pub value: &'a ArrayRef,
     pub type_info: &'a TypeInfo,
 }
 
@@ -31,81 +34,154 @@ impl serde::Serialize for TypedValue<'_> {
     {
         match &self.type_info.data_type {
             DataType::UInt8 => {
-                let uint_array: UInt8Array = self.value.clone().into();
-                let number = uint_array.value(0);
-                serializer.serialize_u8(number)
+                let uint_array: &UInt8Array = self.value.as_primitive();
+                if uint_array.len() == 1 {
+                    let number = uint_array.value(0);
+                    serializer.serialize_u8(number)
+                } else {
+                    let mut s = serializer.serialize_seq(Some(uint_array.len()))?;
+                    for value in uint_array.iter() {
+                        s.serialize_element(&value)?;
+                    }
+                    s.end()
+                }
             }
             DataType::UInt16 => {
-                let uint_array: UInt16Array = self.value.clone().into();
-                let number = uint_array.value(0);
-                serializer.serialize_u16(number)
+                let uint_array: &UInt16Array = self.value.as_primitive();
+                if uint_array.len() == 1 {
+                    let number = uint_array.value(0);
+                    serializer.serialize_u16(number)
+                } else {
+                    let mut s = serializer.serialize_seq(Some(uint_array.len()))?;
+                    for value in uint_array.iter() {
+                        s.serialize_element(&value)?;
+                    }
+                    s.end()
+                }
             }
             DataType::UInt32 => {
-                let uint_array: UInt32Array = self.value.clone().into();
-                let number = uint_array.value(0);
-                serializer.serialize_u32(number)
+                let array: &UInt32Array = self.value.as_primitive();
+                if array.len() == 1 {
+                    let number = array.value(0);
+                    serializer.serialize_u32(number)
+                } else {
+                    let mut s = serializer.serialize_seq(Some(array.len()))?;
+                    for value in array.iter() {
+                        s.serialize_element(&value)?;
+                    }
+                    s.end()
+                }
             }
             DataType::UInt64 => {
-                let uint_array: UInt64Array = self.value.clone().into();
-                let number = uint_array.value(0);
-                serializer.serialize_u64(number)
+                let array: &UInt64Array = self.value.as_primitive();
+                if array.len() == 1 {
+                    let number = array.value(0);
+                    serializer.serialize_u64(number)
+                } else {
+                    let mut s = serializer.serialize_seq(Some(array.len()))?;
+                    for value in array.iter() {
+                        s.serialize_element(&value)?;
+                    }
+                    s.end()
+                }
             }
             DataType::Int8 => {
-                let int_array: Int8Array = self.value.clone().into();
-                let number = int_array.value(0);
-                serializer.serialize_i8(number)
+                let array: &Int8Array = self.value.as_primitive();
+                if array.len() == 1 {
+                    let number = array.value(0);
+                    serializer.serialize_i8(number)
+                } else {
+                    let mut s = serializer.serialize_seq(Some(array.len()))?;
+                    for value in array.iter() {
+                        s.serialize_element(&value)?;
+                    }
+                    s.end()
+                }
             }
             DataType::Int16 => {
-                let int_array: Int16Array = self.value.clone().into();
-                let number = int_array.value(0);
-                serializer.serialize_i16(number)
+                let array: &Int16Array = self.value.as_primitive();
+                if array.len() == 1 {
+                    let number = array.value(0);
+                    serializer.serialize_i16(number)
+                } else {
+                    let mut s = serializer.serialize_seq(Some(array.len()))?;
+                    for value in array.iter() {
+                        s.serialize_element(&value)?;
+                    }
+                    s.end()
+                }
             }
             DataType::Int32 => {
-                let int_array: Int32Array = self.value.clone().into();
-                let number = int_array.value(0);
-                serializer.serialize_i32(number)
+                let array: &Int32Array = self.value.as_primitive();
+                if array.len() == 1 {
+                    let number = array.value(0);
+                    serializer.serialize_i32(number)
+                } else {
+                    let mut s = serializer.serialize_seq(Some(array.len()))?;
+                    for value in array.iter() {
+                        s.serialize_element(&value)?;
+                    }
+                    s.end()
+                }
             }
             DataType::Int64 => {
-                let int_array: Int64Array = self.value.clone().into();
-                let number = int_array.value(0);
-                serializer.serialize_i64(number)
+                let array: &Int64Array = self.value.as_primitive();
+                if array.len() == 1 {
+                    let number = array.value(0);
+                    serializer.serialize_i64(number)
+                } else {
+                    let mut s = serializer.serialize_seq(Some(array.len()))?;
+                    for value in array.iter() {
+                        s.serialize_element(&value)?;
+                    }
+                    s.end()
+                }
             }
             DataType::Float32 => {
-                let int_array: Float32Array = self.value.clone().into();
-                let number = int_array.value(0);
-                serializer.serialize_f32(number)
+                let array: &Float32Array = self.value.as_primitive();
+                if array.len() == 1 {
+                    let number = array.value(0);
+                    serializer.serialize_f32(number)
+                } else {
+                    let mut s = serializer.serialize_seq(Some(array.len()))?;
+                    for value in array.iter() {
+                        s.serialize_element(&value)?;
+                    }
+                    s.end()
+                }
             }
             DataType::Float64 => {
-                let int_array: Float64Array = self.value.clone().into();
-                let number = int_array.value(0);
-                serializer.serialize_f64(number)
+                let array: &Float64Array = self.value.as_primitive();
+                if array.len() == 1 {
+                    let number = array.value(0);
+                    serializer.serialize_f64(number)
+                } else {
+                    let mut s = serializer.serialize_seq(Some(array.len()))?;
+                    for value in array.iter() {
+                        s.serialize_element(&value)?;
+                    }
+                    s.end()
+                }
             }
             DataType::Utf8 => {
-                let int_array: StringArray = self.value.clone().into();
+                let int_array: &StringArray = self.value.as_string();
                 let string = int_array.value(0);
                 serializer.serialize_str(string)
             }
             DataType::List(field) => {
-                let list_array: ListArray = self.value.clone().into();
-                let values = list_array.values();
-                let mut s = serializer.serialize_seq(Some(values.len()))?;
+                let list_array: &ListArray = self.value.as_list();
+                // let values: &UInt16Array = list_array.values().as_primitive();
+                let mut s = serializer.serialize_seq(Some(list_array.len()))?;
                 for value in list_array.iter() {
-                    let value = match value {
-                        Some(value) => value.to_data(),
-                        None => {
-                            return Err(serde::ser::Error::custom(
-                                "Value in ListArray is null and not yet supported".to_string(),
-                            ))
-                        }
-                    };
-
-                    s.serialize_element(&TypedValue {
-                        value: &value,
-                        type_info: &TypeInfo {
-                            data_type: field.data_type().clone(),
-                            defaults: self.type_info.defaults.clone(),
-                        },
-                    })?;
+                    if let Some(value) = value {
+                        s.serialize_element(&TypedValue {
+                            value: &value,
+                            type_info: &TypeInfo {
+                                data_type: field.data_type().clone(),
+                                defaults: self.type_info.defaults.clone(),
+                            },
+                        })?;
+                    }
                 }
                 s.end()
             }
@@ -121,7 +197,7 @@ impl serde::Serialize for TypedValue<'_> {
                 const DUMMY_STRUCT_NAME: &str = "struct";
                 const DUMMY_FIELD_NAME: &str = "field";
 
-                let struct_array: StructArray = self.value.clone().into();
+                let struct_array: &StructArray = self.value.as_struct();
                 let mut s = serializer.serialize_struct(DUMMY_STRUCT_NAME, fields.len())?;
                 let defaults: StructArray = self.type_info.defaults.clone().into();
                 for field in fields.iter() {
@@ -134,15 +210,16 @@ impl serde::Serialize for TypedValue<'_> {
                             )))
                         }
                     };
+                    let value = make_array(default.clone());
                     let field_value = match struct_array.column_by_name(field.name()) {
-                        Some(value) => value.to_data(),
-                        None => default.clone(),
+                        Some(value) => value,
+                        None => &value,
                     };
 
                     s.serialize_field(
                         DUMMY_FIELD_NAME,
                         &TypedValue {
-                            value: &field_value,
+                            value: &field_value.clone(),
                             type_info: &TypeInfo {
                                 data_type: field.data_type().clone(),
                                 defaults: default,

--- a/libraries/extensions/ros2-bridge/python/src/typed/serialize.rs
+++ b/libraries/extensions/ros2-bridge/python/src/typed/serialize.rs
@@ -34,153 +34,200 @@ impl serde::Serialize for TypedValue<'_> {
     {
         match &self.type_info.data_type {
             DataType::UInt8 => {
-                let uint_array: &UInt8Array = self.value.as_primitive();
-                if uint_array.len() == 1 {
-                    let number = uint_array.value(0);
-                    serializer.serialize_u8(number)
-                } else {
-                    let mut s = serializer.serialize_seq(Some(uint_array.len()))?;
-                    for value in uint_array.iter() {
-                        s.serialize_element(&value)?;
-                    }
-                    s.end()
-                }
+                let array: &UInt8Array = self.value.as_primitive();
+                debug_assert!(array.len() == 1, "array length was: {}", array.len());
+                let number = array.value(0);
+                serializer.serialize_u8(number)
             }
             DataType::UInt16 => {
-                let uint_array: &UInt16Array = self.value.as_primitive();
-                if uint_array.len() == 1 {
-                    let number = uint_array.value(0);
-                    serializer.serialize_u16(number)
-                } else {
-                    let mut s = serializer.serialize_seq(Some(uint_array.len()))?;
-                    for value in uint_array.iter() {
-                        s.serialize_element(&value)?;
-                    }
-                    s.end()
-                }
+                let array: &UInt16Array = self.value.as_primitive();
+                debug_assert!(array.len() == 1);
+                let number = array.value(0);
+                serializer.serialize_u16(number)
             }
             DataType::UInt32 => {
                 let array: &UInt32Array = self.value.as_primitive();
-                if array.len() == 1 {
-                    let number = array.value(0);
-                    serializer.serialize_u32(number)
-                } else {
-                    let mut s = serializer.serialize_seq(Some(array.len()))?;
-                    for value in array.iter() {
-                        s.serialize_element(&value)?;
-                    }
-                    s.end()
-                }
+                debug_assert!(array.len() == 1);
+                let number = array.value(0);
+                serializer.serialize_u32(number)
             }
             DataType::UInt64 => {
                 let array: &UInt64Array = self.value.as_primitive();
-                if array.len() == 1 {
-                    let number = array.value(0);
-                    serializer.serialize_u64(number)
-                } else {
-                    let mut s = serializer.serialize_seq(Some(array.len()))?;
-                    for value in array.iter() {
-                        s.serialize_element(&value)?;
-                    }
-                    s.end()
-                }
+                debug_assert!(array.len() == 1);
+                let number = array.value(0);
+                serializer.serialize_u64(number)
             }
             DataType::Int8 => {
                 let array: &Int8Array = self.value.as_primitive();
-                if array.len() == 1 {
-                    let number = array.value(0);
-                    serializer.serialize_i8(number)
-                } else {
-                    let mut s = serializer.serialize_seq(Some(array.len()))?;
-                    for value in array.iter() {
-                        s.serialize_element(&value)?;
-                    }
-                    s.end()
-                }
+                debug_assert!(array.len() == 1);
+                let number = array.value(0);
+                serializer.serialize_i8(number)
             }
             DataType::Int16 => {
                 let array: &Int16Array = self.value.as_primitive();
-                if array.len() == 1 {
-                    let number = array.value(0);
-                    serializer.serialize_i16(number)
-                } else {
-                    let mut s = serializer.serialize_seq(Some(array.len()))?;
-                    for value in array.iter() {
-                        s.serialize_element(&value)?;
-                    }
-                    s.end()
-                }
+                debug_assert!(array.len() == 1);
+                let number = array.value(0);
+                serializer.serialize_i16(number)
             }
             DataType::Int32 => {
                 let array: &Int32Array = self.value.as_primitive();
-                if array.len() == 1 {
-                    let number = array.value(0);
-                    serializer.serialize_i32(number)
-                } else {
-                    let mut s = serializer.serialize_seq(Some(array.len()))?;
-                    for value in array.iter() {
-                        s.serialize_element(&value)?;
-                    }
-                    s.end()
-                }
+                debug_assert!(array.len() == 1);
+                let number = array.value(0);
+                serializer.serialize_i32(number)
             }
             DataType::Int64 => {
                 let array: &Int64Array = self.value.as_primitive();
-                if array.len() == 1 {
-                    let number = array.value(0);
-                    serializer.serialize_i64(number)
-                } else {
-                    let mut s = serializer.serialize_seq(Some(array.len()))?;
-                    for value in array.iter() {
-                        s.serialize_element(&value)?;
-                    }
-                    s.end()
-                }
+                debug_assert!(array.len() == 1, "array was: {:#?}", array);
+                let number = array.value(0);
+                serializer.serialize_i64(number)
             }
             DataType::Float32 => {
                 let array: &Float32Array = self.value.as_primitive();
-                if array.len() == 1 {
-                    let number = array.value(0);
-                    serializer.serialize_f32(number)
-                } else {
-                    let mut s = serializer.serialize_seq(Some(array.len()))?;
-                    for value in array.iter() {
-                        s.serialize_element(&value)?;
-                    }
-                    s.end()
-                }
+                debug_assert!(array.len() == 1);
+                let number = array.value(0);
+                serializer.serialize_f32(number)
             }
             DataType::Float64 => {
                 let array: &Float64Array = self.value.as_primitive();
-                if array.len() == 1 {
-                    let number = array.value(0);
-                    serializer.serialize_f64(number)
-                } else {
-                    let mut s = serializer.serialize_seq(Some(array.len()))?;
-                    for value in array.iter() {
-                        s.serialize_element(&value)?;
-                    }
-                    s.end()
-                }
+                debug_assert!(array.len() == 1);
+                let number = array.value(0);
+                serializer.serialize_f64(number)
             }
             DataType::Utf8 => {
                 let int_array: &StringArray = self.value.as_string();
                 let string = int_array.value(0);
                 serializer.serialize_str(string)
             }
-            DataType::List(field) => {
+            DataType::List(_field) => {
                 let list_array: &ListArray = self.value.as_list();
-                // let values: &UInt16Array = list_array.values().as_primitive();
                 let mut s = serializer.serialize_seq(Some(list_array.len()))?;
-                for value in list_array.iter() {
-                    if let Some(value) = value {
-                        s.serialize_element(&TypedValue {
-                            value: &value,
-                            type_info: &TypeInfo {
-                                data_type: field.data_type().clone(),
-                                defaults: self.type_info.defaults.clone(),
-                            },
-                        })?;
+                for root in list_array.iter() {
+                    if let Some(values) = root {
+                        match values.data_type() {
+                            DataType::UInt8 => {
+                                let values: &UInt8Array = values.as_primitive();
+                                for value in values.iter() {
+                                    if let Some(value) = value {
+                                        s.serialize_element(&value)?;
+                                    } else {
+                                        todo!("Implement null management");
+                                    }
+                                }
+                            }
+                            DataType::UInt16 => {
+                                let values: &UInt16Array = values.as_primitive();
+                                for value in values.iter() {
+                                    if let Some(value) = value {
+                                        s.serialize_element(&value)?;
+                                    } else {
+                                        todo!("Implement null management");
+                                    }
+                                }
+                            }
+                            DataType::UInt32 => {
+                                let values: &UInt32Array = values.as_primitive();
+                                for value in values.iter() {
+                                    if let Some(value) = value {
+                                        s.serialize_element(&value)?;
+                                    } else {
+                                        todo!("Implement null management");
+                                    }
+                                }
+                            }
+                            DataType::UInt64 => {
+                                let values: &UInt64Array = values.as_primitive();
+                                for value in values.iter() {
+                                    if let Some(value) = value {
+                                        s.serialize_element(&value)?;
+                                    } else {
+                                        todo!("Implement null management");
+                                    }
+                                }
+                            }
+                            DataType::Int8 => {
+                                let values: &Int8Array = values.as_primitive();
+                                for value in values.iter() {
+                                    if let Some(value) = value {
+                                        s.serialize_element(&value)?;
+                                    } else {
+                                        todo!("Implement null management");
+                                    }
+                                }
+                            }
+                            DataType::Int16 => {
+                                let values: &Int16Array = values.as_primitive();
+                                for value in values.iter() {
+                                    if let Some(value) = value {
+                                        s.serialize_element(&value)?;
+                                    } else {
+                                        todo!("Implement null management");
+                                    }
+                                }
+                            }
+                            DataType::Int32 => {
+                                let values: &Int32Array = values.as_primitive();
+                                for value in values.iter() {
+                                    if let Some(value) = value {
+                                        s.serialize_element(&value)?;
+                                    } else {
+                                        todo!("Implement null management");
+                                    }
+                                }
+                            }
+                            DataType::Int64 => {
+                                let values: &Int64Array = values.as_primitive();
+                                for value in values.iter() {
+                                    if let Some(value) = value {
+                                        s.serialize_element(&value)?;
+                                    } else {
+                                        todo!("Implement null management");
+                                    }
+                                }
+                            }
+                            DataType::Float32 => {
+                                let values: &Float32Array = values.as_primitive();
+                                for value in values.iter() {
+                                    if let Some(value) = value {
+                                        s.serialize_element(&value)?;
+                                    } else {
+                                        todo!("Implement null management");
+                                    }
+                                }
+                            }
+                            DataType::Float64 => {
+                                let values: &Float64Array = values.as_primitive();
+                                for value in values.iter() {
+                                    if let Some(value) = value {
+                                        s.serialize_element(&value)?;
+                                    } else {
+                                        todo!("Implement null management");
+                                    }
+                                }
+                            }
+                            DataType::Utf8 => {
+                                let values: &StringArray = values.as_string();
+                                for value in values.iter() {
+                                    if let Some(value) = value {
+                                        s.serialize_element(&value)?;
+                                    } else {
+                                        todo!("Implement null management");
+                                    }
+                                }
+                            }
+                            DataType::Struct(_fields) => {
+                                let list_array: ListArray = self.type_info.defaults.clone().into();
+                                s.serialize_element(&TypedValue {
+                                    value: &values,
+                                    type_info: &TypeInfo {
+                                        data_type: values.data_type().clone(),
+                                        defaults: list_array.value(0).to_data(),
+                                    },
+                                })?;
+                            }
+                            op => todo!("Implement additional type: {:?}", op),
+                        }
+                    } else {
+                        todo!("Implement null management");
                     }
                 }
                 s.end()


### PR DESCRIPTION
This PR contains two fixes:
- The first one fix the issue were if some ros2 array data was missing within the ros2 arrow array, the message failed: https://github.com/dora-rs/dora-autoware/discussions/9#discussioncomment-8133366
- The second one is a fix of how ros2 array was only serializing the first value of an array. To fix this I looped over the length of the array. I have used `ArrayRef` to avoid having to clone the data each time.

This should fix https://github.com/dora-rs/dora-autoware/discussions/9#discussioncomment-8133366

This should be merged after #410 