### PR TITLE
Use forward slash as it is default way of defining ros2 topic

### DIFF
--- a/examples/python-ros2-dataflow/random_turtle.py
+++ b/examples/python-ros2-dataflow/random_turtle.py
@@ -21,14 +21,12 @@ topic_qos = dora.experimental.ros2_bridge.Ros2QosPolicies(
 
 # Create a publisher to cmd_vel topic
 turtle_twist_topic = ros2_node.create_topic(
-    "/turtle1/cmd_vel", "geometry_msgs::Twist", topic_qos
+    "/turtle1/cmd_vel", "geometry_msgs/Twist", topic_qos
 )
 twist_writer = ros2_node.create_publisher(turtle_twist_topic)
 
 # Create a listener to pose topic
-turtle_pose_topic = ros2_node.create_topic(
-    "/turtle1/pose", "turtlesim::Pose", topic_qos
-)
+turtle_pose_topic = ros2_node.create_topic("/turtle1/pose", "turtlesim/Pose", topic_qos)
 pose_reader = ros2_node.create_subscription(turtle_pose_topic)
 
 # Create a dora node

--- a/libraries/extensions/ros2-bridge/python/src/lib.rs
+++ b/libraries/extensions/ros2-bridge/python/src/lib.rs
@@ -101,12 +101,13 @@ impl Ros2Node {
         message_type: String,
         qos: qos::Ros2QosPolicies,
     ) -> eyre::Result<Ros2Topic> {
-        let (namespace_name, message_name) = message_type.split_once("/").with_context(|| {
-            format!(
-                "message type must be of form `package::type`, is `{}`",
-                message_type
-            )
-        })?;
+        let (namespace_name, message_name) =
+            match (message_type.split_once("/"), message_type.split_once("::")) {
+                (Some(msg), None) => msg,
+                (None, Some(msg)) => msg,
+                _ => eyre::bail!("Expected message type in the format `namespace/message` or `namespace::message`, such as `std_msgs/UInt8` but got: {}", message_type),
+            };
+
         let message_type_name = ros2_client::MessageTypeName::new(namespace_name, message_name);
         let topic_name = ros2_client::Name::parse(name)
             .map_err(|err| eyre!("failed to parse ROS2 topic name: {err}"))?;

--- a/libraries/extensions/ros2-bridge/python/src/lib.rs
+++ b/libraries/extensions/ros2-bridge/python/src/lib.rs
@@ -101,7 +101,7 @@ impl Ros2Node {
         message_type: String,
         qos: qos::Ros2QosPolicies,
     ) -> eyre::Result<Ros2Topic> {
-        let (namespace_name, message_name) = message_type.split_once("::").with_context(|| {
+        let (namespace_name, message_name) = message_type.split_once("/").with_context(|| {
             format!(
                 "message type must be of form `package::type`, is `{}`",
                 message_type


### PR DESCRIPTION
As we are introducing breaking changes with #415, I propose that we use forward slash to define topics within Python as it seems to be the default ROS2 Specification.