### PR TITLE
Bump dora version to 0.3.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,10 +57,10 @@ jobs:
           cargo publish -p dora-node-api-c --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
           # Publish binaries crates
-          cargo publish -p dora-cli --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
           cargo publish -p dora-coordinator --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
           cargo publish -p dora-runtime --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
           cargo publish -p dora-daemon --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          cargo publish -p dora-cli --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
           # Publish extension crates
           cargo publish -p dora-record --token ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "benchmark-example-node"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "benchmark-example-sink"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "communication-layer-pub-sub"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "flume",
  "zenoh",
@@ -1015,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "communication-layer-request-reply"
-version = "0.3.2-rc2"
+version = "0.3.2"
 
 [[package]]
 name = "concurrent-queue"
@@ -1397,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "dora-arrow-convert"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "arrow",
  "eyre",
@@ -1405,7 +1405,7 @@ dependencies = [
 
 [[package]]
 name = "dora-cli"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "bat",
  "clap 4.4.6",
@@ -1435,7 +1435,7 @@ dependencies = [
 
 [[package]]
 name = "dora-coordinator"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "ctrlc",
  "dora-core",
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "dora-core"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "aligned-vec",
  "dora-message",
@@ -1470,7 +1470,7 @@ dependencies = [
 
 [[package]]
 name = "dora-daemon"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "aligned-vec",
  "async-trait",
@@ -1495,7 +1495,7 @@ dependencies = [
 
 [[package]]
 name = "dora-download"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "eyre",
  "reqwest",
@@ -1523,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "dora-message"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "arrow-data",
  "arrow-schema",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "dora-metrics"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "opentelemetry 0.21.0",
  "opentelemetry-otlp",
@@ -1543,7 +1543,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -1565,7 +1565,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-c"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "arrow-array",
  "dora-node-api",
@@ -1575,7 +1575,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-cxx"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -1585,7 +1585,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-python"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "arrow",
  "dora-node-api",
@@ -1602,7 +1602,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "dora-arrow-convert",
  "dora-operator-api-macros",
@@ -1611,14 +1611,14 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-c"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "dora-operator-api-types",
 ]
 
 [[package]]
 name = "dora-operator-api-cxx"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -1627,7 +1627,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-macros"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1636,7 +1636,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-python"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -1650,7 +1650,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-types"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "arrow",
  "dora-arrow-convert",
@@ -1659,7 +1659,7 @@ dependencies = [
 
 [[package]]
 name = "dora-record"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "dora-node-api",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "dora-runtime"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "dora-tracing"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "eyre",
  "opentelemetry 0.18.0",
@@ -3239,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "multiple-daemons-example-node"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -3250,14 +3250,14 @@ dependencies = [
 
 [[package]]
 name = "multiple-daemons-example-operator"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "dora-operator-api",
 ]
 
 [[package]]
 name = "multiple-daemons-example-sink"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4658,7 +4658,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-node"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4669,14 +4669,14 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-operator"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "dora-operator-api",
 ]
 
 [[package]]
 name = "rust-dataflow-example-sink"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4684,7 +4684,7 @@ dependencies = [
 
 [[package]]
 name = "rust-ros2-dataflow-example-node"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "dora-node-api",
  "dora-ros2-bridge",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "shared-memory-server"
-version = "0.3.2-rc2"
+version = "0.3.2"
 dependencies = [
  "bincode",
  "eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "benchmark-example-node"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "benchmark-example-sink"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "communication-layer-pub-sub"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "flume",
  "zenoh",
@@ -1015,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "communication-layer-request-reply"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 
 [[package]]
 name = "concurrent-queue"
@@ -1397,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "dora-arrow-convert"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "arrow",
  "eyre",
@@ -1405,7 +1405,7 @@ dependencies = [
 
 [[package]]
 name = "dora-cli"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "bat",
  "clap 4.4.6",
@@ -1435,7 +1435,7 @@ dependencies = [
 
 [[package]]
 name = "dora-coordinator"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "ctrlc",
  "dora-core",
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "dora-core"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "aligned-vec",
  "dora-message",
@@ -1470,7 +1470,7 @@ dependencies = [
 
 [[package]]
 name = "dora-daemon"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "aligned-vec",
  "async-trait",
@@ -1495,7 +1495,7 @@ dependencies = [
 
 [[package]]
 name = "dora-download"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "eyre",
  "reqwest",
@@ -1523,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "dora-message"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "arrow-data",
  "arrow-schema",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "dora-metrics"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "opentelemetry 0.21.0",
  "opentelemetry-otlp",
@@ -1543,7 +1543,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -1565,7 +1565,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-c"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "arrow-array",
  "dora-node-api",
@@ -1575,7 +1575,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-cxx"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -1585,7 +1585,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-python"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "arrow",
  "dora-node-api",
@@ -1602,7 +1602,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "dora-arrow-convert",
  "dora-operator-api-macros",
@@ -1611,14 +1611,14 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-c"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "dora-operator-api-types",
 ]
 
 [[package]]
 name = "dora-operator-api-cxx"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -1627,7 +1627,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-macros"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1636,7 +1636,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-python"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -1650,7 +1650,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-types"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "arrow",
  "dora-arrow-convert",
@@ -1659,7 +1659,7 @@ dependencies = [
 
 [[package]]
 name = "dora-record"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "chrono",
  "dora-node-api",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "dora-runtime"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "dora-tracing"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "eyre",
  "opentelemetry 0.18.0",
@@ -3239,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "multiple-daemons-example-node"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -3250,14 +3250,14 @@ dependencies = [
 
 [[package]]
 name = "multiple-daemons-example-operator"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "dora-operator-api",
 ]
 
 [[package]]
 name = "multiple-daemons-example-sink"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4658,7 +4658,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-node"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4669,14 +4669,14 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-operator"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "dora-operator-api",
 ]
 
 [[package]]
 name = "rust-dataflow-example-sink"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4684,7 +4684,7 @@ dependencies = [
 
 [[package]]
 name = "rust-ros2-dataflow-example-node"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "dora-node-api",
  "dora-ros2-bridge",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "shared-memory-server"
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 dependencies = [
  "bincode",
  "eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "benchmark-example-node"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "benchmark-example-sink"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "communication-layer-pub-sub"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "flume",
  "zenoh",
@@ -1015,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "communication-layer-request-reply"
-version = "0.3.1"
+version = "0.3.2-rc1"
 
 [[package]]
 name = "concurrent-queue"
@@ -1397,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "dora-arrow-convert"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "arrow",
  "eyre",
@@ -1405,7 +1405,7 @@ dependencies = [
 
 [[package]]
 name = "dora-cli"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "bat",
  "clap 4.4.6",
@@ -1435,7 +1435,7 @@ dependencies = [
 
 [[package]]
 name = "dora-coordinator"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "ctrlc",
  "dora-core",
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "dora-core"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "aligned-vec",
  "dora-message",
@@ -1470,7 +1470,7 @@ dependencies = [
 
 [[package]]
 name = "dora-daemon"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "aligned-vec",
  "async-trait",
@@ -1495,7 +1495,7 @@ dependencies = [
 
 [[package]]
 name = "dora-download"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "eyre",
  "reqwest",
@@ -1523,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "dora-message"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "arrow-data",
  "arrow-schema",
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "dora-metrics"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "opentelemetry 0.21.0",
  "opentelemetry-otlp",
@@ -1543,7 +1543,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -1565,7 +1565,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-c"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "arrow-array",
  "dora-node-api",
@@ -1575,7 +1575,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-cxx"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -1585,7 +1585,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-python"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "arrow",
  "dora-node-api",
@@ -1602,7 +1602,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "dora-arrow-convert",
  "dora-operator-api-macros",
@@ -1611,14 +1611,14 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-c"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "dora-operator-api-types",
 ]
 
 [[package]]
 name = "dora-operator-api-cxx"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -1627,7 +1627,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-macros"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1636,7 +1636,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-python"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -1650,7 +1650,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-types"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "arrow",
  "dora-arrow-convert",
@@ -1659,7 +1659,7 @@ dependencies = [
 
 [[package]]
 name = "dora-record"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "chrono",
  "dora-node-api",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "dora-runtime"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "dora-tracing"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "eyre",
  "opentelemetry 0.18.0",
@@ -3239,7 +3239,7 @@ dependencies = [
 
 [[package]]
 name = "multiple-daemons-example-node"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -3250,14 +3250,14 @@ dependencies = [
 
 [[package]]
 name = "multiple-daemons-example-operator"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "dora-operator-api",
 ]
 
 [[package]]
 name = "multiple-daemons-example-sink"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4658,7 +4658,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-node"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4669,14 +4669,14 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-operator"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "dora-operator-api",
 ]
 
 [[package]]
 name = "rust-dataflow-example-sink"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4684,7 +4684,7 @@ dependencies = [
 
 [[package]]
 name = "rust-ros2-dataflow-example-node"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "dora-node-api",
  "dora-ros2-bridge",
@@ -5088,7 +5088,7 @@ dependencies = [
 
 [[package]]
 name = "shared-memory-server"
-version = "0.3.1"
+version = "0.3.2-rc1"
 dependencies = [
  "bincode",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,31 +33,31 @@ members = [
 
 [workspace.package]
 # Make sure to also bump `apis/node/python/__init__.py` version.
-version = "0.3.2-rc2"
+version = "0.3.2"
 description = "`dora` goal is to be a low latency, composable, and distributed data flow."
 documentation = "https://dora.carsmos.ai"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-dora-node-api = { version = "0.3.2-rc2", path = "apis/rust/node", default-features = false }
-dora-node-api-python = { version = "0.3.2-rc2", path = "apis/python/node", default-features = false }
-dora-operator-api = { version = "0.3.2-rc2", path = "apis/rust/operator", default-features = false }
-dora-operator-api-macros = { version = "0.3.2-rc2", path = "apis/rust/operator/macros" }
-dora-operator-api-types = { version = "0.3.2-rc2", path = "apis/rust/operator/types" }
-dora-operator-api-python = { version = "0.3.2-rc2", path = "apis/python/operator" }
-dora-operator-api-c = { version = "0.3.2-rc2", path = "apis/c/operator" }
-dora-node-api-c = { version = "0.3.2-rc2", path = "apis/c/node" }
-dora-core = { version = "0.3.2-rc2", path = "libraries/core" }
-dora-arrow-convert = { version = "0.3.2-rc2", path = "libraries/arrow-convert" }
-dora-tracing = { version = "0.3.2-rc2", path = "libraries/extensions/telemetry/tracing" }
-dora-metrics = { version = "0.3.2-rc2", path = "libraries/extensions/telemetry/metrics" }
-dora-download = { version = "0.3.2-rc2", path = "libraries/extensions/download" }
-shared-memory-server = { version = "0.3.2-rc2", path = "libraries/shared-memory-server" }
-communication-layer-request-reply = { version = "0.3.2-rc2", path = "libraries/communication-layer/request-reply" }
-dora-message = { version = "0.3.2-rc2", path = "libraries/message" }
-dora-runtime = { version = "0.3.2-rc2", path = "binaries/runtime" }
-dora-daemon = { version = "0.3.2-rc2", path = "binaries/daemon" }
-dora-coordinator = { version = "0.3.2-rc2", path = "binaries/coordinator" }
+dora-node-api = { version = "0.3.2", path = "apis/rust/node", default-features = false }
+dora-node-api-python = { version = "0.3.2", path = "apis/python/node", default-features = false }
+dora-operator-api = { version = "0.3.2", path = "apis/rust/operator", default-features = false }
+dora-operator-api-macros = { version = "0.3.2", path = "apis/rust/operator/macros" }
+dora-operator-api-types = { version = "0.3.2", path = "apis/rust/operator/types" }
+dora-operator-api-python = { version = "0.3.2", path = "apis/python/operator" }
+dora-operator-api-c = { version = "0.3.2", path = "apis/c/operator" }
+dora-node-api-c = { version = "0.3.2", path = "apis/c/node" }
+dora-core = { version = "0.3.2", path = "libraries/core" }
+dora-arrow-convert = { version = "0.3.2", path = "libraries/arrow-convert" }
+dora-tracing = { version = "0.3.2", path = "libraries/extensions/telemetry/tracing" }
+dora-metrics = { version = "0.3.2", path = "libraries/extensions/telemetry/metrics" }
+dora-download = { version = "0.3.2", path = "libraries/extensions/download" }
+shared-memory-server = { version = "0.3.2", path = "libraries/shared-memory-server" }
+communication-layer-request-reply = { version = "0.3.2", path = "libraries/communication-layer/request-reply" }
+dora-message = { version = "0.3.2", path = "libraries/message" }
+dora-runtime = { version = "0.3.2", path = "binaries/runtime" }
+dora-daemon = { version = "0.3.2", path = "binaries/daemon" }
+dora-coordinator = { version = "0.3.2", path = "binaries/coordinator" }
 dora-ros2-bridge = { path = "libraries/extensions/ros2-bridge" }
 dora-ros2-bridge-python = { path = "libraries/extensions/ros2-bridge/python" }
 arrow = "48.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,31 +33,31 @@ members = [
 
 [workspace.package]
 # Make sure to also bump `apis/node/python/__init__.py` version.
-version = "0.3.2-rc1"
+version = "0.3.2-rc2"
 description = "`dora` goal is to be a low latency, composable, and distributed data flow."
 documentation = "https://dora.carsmos.ai"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-dora-node-api = { version = "0.3.2-rc1", path = "apis/rust/node", default-features = false }
-dora-node-api-python = { version = "0.3.2-rc1", path = "apis/python/node", default-features = false }
-dora-operator-api = { version = "0.3.2-rc1", path = "apis/rust/operator", default-features = false }
-dora-operator-api-macros = { version = "0.3.2-rc1", path = "apis/rust/operator/macros" }
-dora-operator-api-types = { version = "0.3.2-rc1", path = "apis/rust/operator/types" }
-dora-operator-api-python = { version = "0.3.2-rc1", path = "apis/python/operator" }
-dora-operator-api-c = { version = "0.3.2-rc1", path = "apis/c/operator" }
-dora-node-api-c = { version = "0.3.2-rc1", path = "apis/c/node" }
-dora-core = { version = "0.3.2-rc1", path = "libraries/core" }
-dora-arrow-convert = { version = "0.3.2-rc1", path = "libraries/arrow-convert" }
-dora-tracing = { version = "0.3.2-rc1", path = "libraries/extensions/telemetry/tracing" }
-dora-metrics = { version = "0.3.2-rc1", path = "libraries/extensions/telemetry/metrics" }
-dora-download = { version = "0.3.2-rc1", path = "libraries/extensions/download" }
-shared-memory-server = { version = "0.3.2-rc1", path = "libraries/shared-memory-server" }
-communication-layer-request-reply = { version = "0.3.2-rc1", path = "libraries/communication-layer/request-reply" }
-dora-message = { version = "0.3.2-rc1", path = "libraries/message" }
-dora-runtime = { version = "0.3.2-rc1", path = "binaries/runtime" }
-dora-daemon = { version = "0.3.2-rc1", path = "binaries/daemon" }
-dora-coordinator = { version = "0.3.2-rc1", path = "binaries/coordinator" }
+dora-node-api = { version = "0.3.2-rc2", path = "apis/rust/node", default-features = false }
+dora-node-api-python = { version = "0.3.2-rc2", path = "apis/python/node", default-features = false }
+dora-operator-api = { version = "0.3.2-rc2", path = "apis/rust/operator", default-features = false }
+dora-operator-api-macros = { version = "0.3.2-rc2", path = "apis/rust/operator/macros" }
+dora-operator-api-types = { version = "0.3.2-rc2", path = "apis/rust/operator/types" }
+dora-operator-api-python = { version = "0.3.2-rc2", path = "apis/python/operator" }
+dora-operator-api-c = { version = "0.3.2-rc2", path = "apis/c/operator" }
+dora-node-api-c = { version = "0.3.2-rc2", path = "apis/c/node" }
+dora-core = { version = "0.3.2-rc2", path = "libraries/core" }
+dora-arrow-convert = { version = "0.3.2-rc2", path = "libraries/arrow-convert" }
+dora-tracing = { version = "0.3.2-rc2", path = "libraries/extensions/telemetry/tracing" }
+dora-metrics = { version = "0.3.2-rc2", path = "libraries/extensions/telemetry/metrics" }
+dora-download = { version = "0.3.2-rc2", path = "libraries/extensions/download" }
+shared-memory-server = { version = "0.3.2-rc2", path = "libraries/shared-memory-server" }
+communication-layer-request-reply = { version = "0.3.2-rc2", path = "libraries/communication-layer/request-reply" }
+dora-message = { version = "0.3.2-rc2", path = "libraries/message" }
+dora-runtime = { version = "0.3.2-rc2", path = "binaries/runtime" }
+dora-daemon = { version = "0.3.2-rc2", path = "binaries/daemon" }
+dora-coordinator = { version = "0.3.2-rc2", path = "binaries/coordinator" }
 dora-ros2-bridge = { path = "libraries/extensions/ros2-bridge" }
 dora-ros2-bridge-python = { path = "libraries/extensions/ros2-bridge/python" }
 arrow = "48.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,31 +33,31 @@ members = [
 
 [workspace.package]
 # Make sure to also bump `apis/node/python/__init__.py` version.
-version = "0.3.1"
+version = "0.3.2-rc1"
 description = "`dora` goal is to be a low latency, composable, and distributed data flow."
 documentation = "https://dora.carsmos.ai"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-dora-node-api = { version = "0.3.1", path = "apis/rust/node", default-features = false }
-dora-node-api-python = { version = "0.3.1", path = "apis/python/node", default-features = false }
-dora-operator-api = { version = "0.3.1", path = "apis/rust/operator", default-features = false }
-dora-operator-api-macros = { version = "0.3.1", path = "apis/rust/operator/macros" }
-dora-operator-api-types = { version = "0.3.1", path = "apis/rust/operator/types" }
-dora-operator-api-python = { version = "0.3.1", path = "apis/python/operator" }
-dora-operator-api-c = { version = "0.3.1", path = "apis/c/operator" }
-dora-node-api-c = { version = "0.3.1", path = "apis/c/node" }
-dora-core = { version = "0.3.1", path = "libraries/core" }
-dora-arrow-convert = { version = "0.3.1", path = "libraries/arrow-convert" }
-dora-tracing = { version = "0.3.1", path = "libraries/extensions/telemetry/tracing" }
-dora-metrics = { version = "0.3.1", path = "libraries/extensions/telemetry/metrics" }
-dora-download = { version = "0.3.1", path = "libraries/extensions/download" }
-shared-memory-server = { version = "0.3.1", path = "libraries/shared-memory-server" }
-communication-layer-request-reply = { version = "0.3.1", path = "libraries/communication-layer/request-reply" }
-dora-message = { version = "0.3.1", path = "libraries/message" }
-dora-runtime = { version = "0.3.1", path = "binaries/runtime" }
-dora-daemon = { version = "0.3.1", path = "binaries/daemon" }
-dora-coordinator = { version = "0.3.1", path = "binaries/coordinator" }
+dora-node-api = { version = "0.3.2-rc1", path = "apis/rust/node", default-features = false }
+dora-node-api-python = { version = "0.3.2-rc1", path = "apis/python/node", default-features = false }
+dora-operator-api = { version = "0.3.2-rc1", path = "apis/rust/operator", default-features = false }
+dora-operator-api-macros = { version = "0.3.2-rc1", path = "apis/rust/operator/macros" }
+dora-operator-api-types = { version = "0.3.2-rc1", path = "apis/rust/operator/types" }
+dora-operator-api-python = { version = "0.3.2-rc1", path = "apis/python/operator" }
+dora-operator-api-c = { version = "0.3.2-rc1", path = "apis/c/operator" }
+dora-node-api-c = { version = "0.3.2-rc1", path = "apis/c/node" }
+dora-core = { version = "0.3.2-rc1", path = "libraries/core" }
+dora-arrow-convert = { version = "0.3.2-rc1", path = "libraries/arrow-convert" }
+dora-tracing = { version = "0.3.2-rc1", path = "libraries/extensions/telemetry/tracing" }
+dora-metrics = { version = "0.3.2-rc1", path = "libraries/extensions/telemetry/metrics" }
+dora-download = { version = "0.3.2-rc1", path = "libraries/extensions/download" }
+shared-memory-server = { version = "0.3.2-rc1", path = "libraries/shared-memory-server" }
+communication-layer-request-reply = { version = "0.3.2-rc1", path = "libraries/communication-layer/request-reply" }
+dora-message = { version = "0.3.2-rc1", path = "libraries/message" }
+dora-runtime = { version = "0.3.2-rc1", path = "binaries/runtime" }
+dora-daemon = { version = "0.3.2-rc1", path = "binaries/daemon" }
+dora-coordinator = { version = "0.3.2-rc1", path = "binaries/coordinator" }
 dora-ros2-bridge = { path = "libraries/extensions/ros2-bridge" }
 dora-ros2-bridge-python = { path = "libraries/extensions/ros2-bridge/python" }
 arrow = "48.0.0"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v0.3.2 (2024-01-26)
+
+## Features
+
+- Wait until `DestroyResult` is sent before exiting dora-daemon by @phil-opp in https://github.com/dora-rs/dora/pull/413
+- Reduce dora-rs to a single binary by @haixuanTao in https://github.com/dora-rs/dora/pull/410
+- Rework python ROS2 (de)serialization using parsed ROS2 messages directly by @phil-opp in https://github.com/dora-rs/dora/pull/415
+- Fix ros2 array bug by @haixuanTao in https://github.com/dora-rs/dora/pull/412
+- Test ros2 type info by @haixuanTao in https://github.com/dora-rs/dora/pull/418
+- Use forward slash as it is default way of defining ros2 topic by @haixuanTao in https://github.com/dora-rs/dora/pull/419
+
+## Minor
+
+- Bump h2 from 0.3.21 to 0.3.24 by @dependabot in https://github.com/dora-rs/dora/pull/414
+
 ## v0.3.1 (2024-01-09)
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -69,17 +69,17 @@ For more installation guideline, check out our installation guide here: https://
 1. Install the example python dependencies:
 
 ```bash
-pip install -r https://raw.githubusercontent.com/dora-rs/dora/v0.3.2-rc2/examples/python-operator-dataflow/requirements.txt
+pip install -r https://raw.githubusercontent.com/dora-rs/dora/v0.3.2/examples/python-operator-dataflow/requirements.txt
 ```
 
 2. Get some example operators:
 
 ```bash
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.2-rc2/examples/python-operator-dataflow/webcam.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.2-rc2/examples/python-operator-dataflow/plot.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.2-rc2/examples/python-operator-dataflow/utils.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.2-rc2/examples/python-operator-dataflow/object_detection.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.2-rc2/examples/python-operator-dataflow/dataflow.yml
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.2/examples/python-operator-dataflow/webcam.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.2/examples/python-operator-dataflow/plot.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.2/examples/python-operator-dataflow/utils.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.2/examples/python-operator-dataflow/object_detection.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.2/examples/python-operator-dataflow/dataflow.yml
 ```
 
 3. Start the dataflow

--- a/README.md
+++ b/README.md
@@ -57,8 +57,6 @@ Quickest way:
 
 ```bash
 cargo install dora-cli
-cargo install dora-coordinator
-cargo install dora-daemon
 pip install dora-rs ## For Python API
 
 dora --help
@@ -71,17 +69,17 @@ For more installation guideline, check out our installation guide here: https://
 1. Install the example python dependencies:
 
 ```bash
-pip install -r https://raw.githubusercontent.com/dora-rs/dora/v0.3.1/examples/python-operator-dataflow/requirements.txt
+pip install -r https://raw.githubusercontent.com/dora-rs/dora/v0.3.2-rc1/examples/python-operator-dataflow/requirements.txt
 ```
 
 2. Get some example operators:
 
 ```bash
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.1/examples/python-operator-dataflow/webcam.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.1/examples/python-operator-dataflow/plot.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.1/examples/python-operator-dataflow/utils.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.1/examples/python-operator-dataflow/object_detection.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.1/examples/python-operator-dataflow/dataflow.yml
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.2-rc1/examples/python-operator-dataflow/webcam.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.2-rc1/examples/python-operator-dataflow/plot.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.2-rc1/examples/python-operator-dataflow/utils.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.2-rc1/examples/python-operator-dataflow/object_detection.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.2-rc1/examples/python-operator-dataflow/dataflow.yml
 ```
 
 3. Start the dataflow

--- a/README.md
+++ b/README.md
@@ -69,17 +69,17 @@ For more installation guideline, check out our installation guide here: https://
 1. Install the example python dependencies:
 
 ```bash
-pip install -r https://raw.githubusercontent.com/dora-rs/dora/v0.3.2-rc1/examples/python-operator-dataflow/requirements.txt
+pip install -r https://raw.githubusercontent.com/dora-rs/dora/v0.3.2-rc2/examples/python-operator-dataflow/requirements.txt
 ```
 
 2. Get some example operators:
 
 ```bash
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.2-rc1/examples/python-operator-dataflow/webcam.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.2-rc1/examples/python-operator-dataflow/plot.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.2-rc1/examples/python-operator-dataflow/utils.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.2-rc1/examples/python-operator-dataflow/object_detection.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.2-rc1/examples/python-operator-dataflow/dataflow.yml
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.2-rc2/examples/python-operator-dataflow/webcam.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.2-rc2/examples/python-operator-dataflow/plot.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.2-rc2/examples/python-operator-dataflow/utils.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.2-rc2/examples/python-operator-dataflow/object_detection.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.2-rc2/examples/python-operator-dataflow/dataflow.yml
 ```
 
 3. Start the dataflow

--- a/apis/python/node/dora/__init__.py
+++ b/apis/python/node/dora/__init__.py
@@ -15,7 +15,7 @@ from enum import Enum
 from .dora import *
 
 __author__ = "Dora-rs Authors"
-__version__ = "0.3.1"
+__version__ = "0.3.2-rc1"
 
 
 class DoraStatus(Enum):

--- a/apis/python/node/dora/__init__.py
+++ b/apis/python/node/dora/__init__.py
@@ -15,7 +15,7 @@ from enum import Enum
 from .dora import *
 
 __author__ = "Dora-rs Authors"
-__version__ = "0.3.2-rc2"
+__version__ = "0.3.2"
 
 
 class DoraStatus(Enum):

--- a/apis/python/node/dora/__init__.py
+++ b/apis/python/node/dora/__init__.py
@@ -15,7 +15,7 @@ from enum import Enum
 from .dora import *
 
 __author__ = "Dora-rs Authors"
-__version__ = "0.3.2-rc1"
+__version__ = "0.3.2-rc2"
 
 
 class DoraStatus(Enum):


### PR DESCRIPTION
## v0.3.2 (2024-01-26)

## Features

- Wait until `DestroyResult` is sent before exiting dora-daemon by @phil-opp in https://github.com/dora-rs/dora/pull/413
- Reduce dora-rs to a single binary by @haixuanTao in https://github.com/dora-rs/dora/pull/410
- Rework python ROS2 (de)serialization using parsed ROS2 messages directly by @phil-opp in https://github.com/dora-rs/dora/pull/415
- Fix ros2 array bug by @haixuanTao in https://github.com/dora-rs/dora/pull/412
- Test ros2 type info by @haixuanTao in https://github.com/dora-rs/dora/pull/418
- Use forward slash as it is default way of defining ros2 topic by @haixuanTao in https://github.com/dora-rs/dora/pull/419

## Minor

- Bump h2 from 0.3.21 to 0.3.24 by @dependabot in https://github.com/dora-rs/dora/pull/414
