### PR TITLE
Metrics refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1538,7 +1538,7 @@ version = "0.3.2"
 dependencies = [
  "opentelemetry 0.21.0",
  "opentelemetry-otlp",
- "opentelemetry_sdk 0.21.1",
+ "opentelemetry_sdk 0.21.2",
 ]
 
 [[package]]
@@ -3677,7 +3677,7 @@ dependencies = [
  "opentelemetry 0.21.0",
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions 0.13.0",
- "opentelemetry_sdk 0.21.1",
+ "opentelemetry_sdk 0.21.2",
  "prost",
  "thiserror",
  "tokio",
@@ -3691,7 +3691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2e155ce5cc812ea3d1dffbd1539aed653de4bf4882d60e6e04dcf0901d674e1"
 dependencies = [
  "opentelemetry 0.21.0",
- "opentelemetry_sdk 0.21.1",
+ "opentelemetry_sdk 0.21.2",
  "prost",
  "tonic",
 ]
@@ -3768,9 +3768,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "968ba3f2ca03e90e5187f5e4f46c791ef7f2c163ae87789c8ce5f5ca3b7b7de5"
+checksum = "2f16aec8a98a457a52664d69e0091bac3a0abd18ead9b641cb00202ba4e0efe4"
 dependencies = [
  "async-trait",
  "crossbeam-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,8 +1536,10 @@ dependencies = [
 name = "dora-metrics"
 version = "0.3.2"
 dependencies = [
+ "eyre",
  "opentelemetry 0.21.0",
  "opentelemetry-otlp",
+ "opentelemetry-system-metrics",
  "opentelemetry_sdk 0.21.2",
 ]
 
@@ -1748,8 +1750,6 @@ dependencies = [
  "futures",
  "futures-concurrency",
  "libloading",
- "opentelemetry 0.21.0",
- "opentelemetry-system-metrics",
  "pyo3",
  "pythonize",
  "serde_yaml 0.8.26",
@@ -1976,9 +1976,9 @@ dependencies = [
 
 [[package]]
 name = "eyre"
-version = "0.6.8"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
 dependencies = [
  "indenter",
  "once_cell",

--- a/apis/python/node/Cargo.toml
+++ b/apis/python/node/Cargo.toml
@@ -20,7 +20,7 @@ pyo3 = { workspace = true, features = ["eyre", "abi3-py37"] }
 eyre = "0.6"
 serde_yaml = "0.8.23"
 flume = "0.10.14"
-dora-runtime = { workspace = true, features = ["tracing", "python"] }
+dora-runtime = { workspace = true, features = ["tracing", "metrics", "python"] }
 arrow = { workspace = true, features = ["pyarrow"] }
 pythonize = { workspace = true }
 futures = "0.3.28"

--- a/binaries/runtime/Cargo.toml
+++ b/binaries/runtime/Cargo.toml
@@ -15,8 +15,6 @@ dora-operator-api-types = { workspace = true }
 dora-core = { workspace = true }
 dora-tracing = { workspace = true, optional = true }
 dora-metrics = { workspace = true, optional = true }
-opentelemetry = { version = "0.21.0", features = ["metrics"], optional = true }
-opentelemetry-system-metrics = { version = "0.1.6", optional = true }
 eyre = "0.6.8"
 futures = "0.3.21"
 futures-concurrency = "7.1.0"
@@ -37,6 +35,6 @@ aligned-vec = "0.5.0"
 [features]
 default = ["tracing", "metrics"]
 tracing = ["dora-tracing"]
-telemetry = ["tracing", "opentelemetry", "tracing-opentelemetry"]
-metrics = ["opentelemetry", "opentelemetry-system-metrics", "dora-metrics"]
+telemetry = ["tracing", "tracing-opentelemetry"]
+metrics = ["dora-metrics"]
 python = ["pyo3", "dora-operator-api-python", "pythonize", "arrow/pyarrow"]

--- a/binaries/runtime/src/lib.rs
+++ b/binaries/runtime/src/lib.rs
@@ -5,6 +5,7 @@ use dora_core::{
     daemon_messages::{NodeConfig, RuntimeConfig},
     descriptor::OperatorConfig,
 };
+use dora_metrics::init_meter_provider;
 use dora_node_api::{DoraNode, Event};
 use eyre::{bail, Context, Result};
 use futures::{Stream, StreamExt};
@@ -122,17 +123,7 @@ async fn run(
     init_done: oneshot::Receiver<Result<()>>,
 ) -> eyre::Result<()> {
     #[cfg(feature = "metrics")]
-    let _meter_provider = {
-        use dora_metrics::init_metrics;
-        use opentelemetry::metrics::MeterProvider as _;
-        use opentelemetry_system_metrics::init_process_observer;
-
-        let meter_provider = init_metrics().context("Could not create opentelemetry meter")?;
-        let meter = meter_provider.meter(config.node_id.to_string());
-        let _ =
-            init_process_observer(meter).context("could not initiale system metrics observer")?;
-        meter_provider
-    };
+    let _meter_provider = init_meter_provider(config.node_id.to_string());
     init_done
         .await
         .wrap_err("the `init_done` channel was closed unexpectedly")?

--- a/libraries/extensions/telemetry/metrics/Cargo.toml
+++ b/libraries/extensions/telemetry/metrics/Cargo.toml
@@ -12,4 +12,5 @@ license.workspace = true
 opentelemetry = { version = "0.21", features = ["metrics"] }
 opentelemetry-otlp = { version = "0.14.0", features = ["tonic", "metrics"] }
 opentelemetry_sdk = { version = "0.21", features = ["rt-tokio", "metrics"] }
-    
+eyre = "0.6.12"
+opentelemetry-system-metrics = { version = "0.1.6" }

--- a/libraries/extensions/telemetry/metrics/Cargo.toml
+++ b/libraries/extensions/telemetry/metrics/Cargo.toml
@@ -11,4 +11,5 @@ license.workspace = true
 [dependencies]
 opentelemetry = { version = "0.21", features = ["metrics"] }
 opentelemetry-otlp = { version = "0.14.0", features = ["tonic", "metrics"] }
-opentelemetry_sdk = { version = "0.21.0", features = ["rt-tokio", "metrics"] }
+opentelemetry_sdk = { version = "0.21", features = ["rt-tokio", "metrics"] }
+    

--- a/libraries/extensions/telemetry/metrics/src/lib.rs
+++ b/libraries/extensions/telemetry/metrics/src/lib.rs
@@ -12,10 +12,11 @@
 
 use std::time::Duration;
 
-use opentelemetry::metrics::{self};
-use opentelemetry_sdk::{metrics::MeterProvider, runtime};
-
+use eyre::{Context, Result};
+use opentelemetry::metrics::{self, MeterProvider as _};
 use opentelemetry_otlp::{ExportConfig, WithExportConfig};
+use opentelemetry_sdk::{metrics::MeterProvider, runtime};
+use opentelemetry_system_metrics::init_process_observer;
 /// Init opentelemetry meter
 ///
 /// Use the default Opentelemetry exporter with default config
@@ -38,4 +39,11 @@ pub fn init_metrics() -> metrics::Result<MeterProvider> {
         )
         .with_period(Duration::from_secs(10))
         .build()
+}
+
+pub fn init_meter_provider(meter_id: String) -> Result<MeterProvider> {
+    let meter_provider = init_metrics().context("Could not create opentelemetry meter")?;
+    let meter = meter_provider.meter(meter_id);
+    let _ = init_process_observer(meter).context("could not initiale system metrics observer")?;
+    Ok(meter_provider)
 }

--- a/libraries/extensions/telemetry/metrics/src/lib.rs
+++ b/libraries/extensions/telemetry/metrics/src/lib.rs
@@ -10,6 +10,8 @@
 //! [`sysinfo`]: https://github.com/GuillaumeGomez/sysinfo
 //! [`opentelemetry-rust`]: https://github.com/open-telemetry/opentelemetry-rust
 
+use std::time::Duration;
+
 use opentelemetry::metrics::{self};
 use opentelemetry_sdk::{metrics::MeterProvider, runtime};
 
@@ -34,5 +36,6 @@ pub fn init_metrics() -> metrics::Result<MeterProvider> {
                 .tonic()
                 .with_export_config(export_config),
         )
+        .with_period(Duration::from_secs(10))
         .build()
 }


### PR DESCRIPTION
Small refactoring of the metrics crate to make it more contained in the extensions telemetry library.

This makes the code slightly easier to read and easier to reuse.