### PR TITLE
Expose ROS2 constants in generated bindings (Rust and C++)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1235,9 +1235,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.107"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe98ba1789d56fb3db3bee5e032774d4f421b685de7ba703643584ba24effbe"
+checksum = "2673ca5ae28334544ec2a6b18ebe666c42a2650abfb48abbd532ed409a44be2b"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1247,9 +1247,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.111"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bc81d2664db24cf1d35405f66e18a85cffd4d49ab930c71a5c6342a410f38c"
+checksum = "9df46fe0eb43066a332586114174c449a62c25689f85a08f28fdcc8e12c380b9"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1262,15 +1262,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.107"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20888d9e1d2298e2ff473cee30efe7d5036e437857ab68bbfea84c74dba91da2"
+checksum = "886acf875df67811c11cd015506b3392b9e1820b1627af1a6f4e93ccdfc74d11"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.107"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fa16a70dd58129e4dfffdff535fb1bce66673f7bbeec4a5a1765a504e1ccd84"
+checksum = "1d151cc139c3080e07f448f93a1284577ab2283d2a44acd902c6fba9ec20b6de"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/apis/c++/node/README.md
+++ b/apis/c++/node/README.md
@@ -228,3 +228,15 @@ else
 }
 ```
 
+### Constants
+
+Some ROS2 message definitions define constants, e.g. to specify the values of an enum-like integer field.
+The Dora ROS2 bridge exposes these constants in the generated bindings as functions.
+
+For example, the `STATUS_NO_FIX` constant of the [`NavSatStatus` message](https://docs.ros.org/en/jade/api/sensor_msgs/html/msg/NavSatStatus.html) can be accessed as follows:
+
+```c++
+assert((sensor_msgs::const_NavSatStatus_STATUS_NO_FIX() == -1));
+```
+
+(Note: Exposing them as C++ constants is not possible because it's [not supported by `cxx` yet](https://github.com/dtolnay/cxx/issues/1051).)

--- a/examples/c++-ros2-dataflow/node-rust-api/main.cc
+++ b/examples/c++-ros2-dataflow/node-rust-api/main.cc
@@ -78,6 +78,9 @@ int main()
         }
     }
 
+    // try to access a constant for testing
+    assert((sensor_msgs::const_NavSatStatus_STATUS_NO_FIX() == -1));
+
     std::cout << "GOODBYE FROM C++ node (using Rust API)" << std::endl;
 
     return 0;

--- a/libraries/extensions/ros2-bridge/msg-gen/src/types/message.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/types/message.rs
@@ -107,6 +107,28 @@ impl Constant {
         let value = self.r#type.value_tokens(&self.value);
         quote! { pub const #name: #type_ = #value; }
     }
+
+    fn cxx_method_def_token_stream(
+        &self,
+        struct_name: &Ident,
+        package_name: &str,
+    ) -> impl ToTokens {
+        let name = format_ident!("const_{struct_name}_{}", self.name);
+        let cxx_name = format_ident!("const_{}", self.name);
+        let type_ = self.r#type.type_tokens();
+        quote! {
+            #[namespace = #package_name]
+            #[cxx_name = #cxx_name]
+            pub fn #name (self: &#struct_name) -> #type_;
+        }
+    }
+
+    fn cxx_method_impl_token_stream(&self, struct_name: &Ident) -> impl ToTokens {
+        let const_name = format_ident!("{}", self.name);
+        let name = format_ident!("const_{struct_name}_{}", self.name);
+        let type_ = self.r#type.type_tokens();
+        quote! { pub fn #name (self: &ffi::#struct_name) -> #type_ { Self::#const_name }}
+    }
 }
 
 /// A message definition
@@ -133,15 +155,29 @@ impl Message {
 
         let rust_type_def_inner = self.members.iter().map(|m| m.rust_type_def(&self.package));
         let constants_def_inner = self.constants.iter().map(|c| c.token_stream());
+        let cxx_const_def_inner = self
+            .constants
+            .iter()
+            .map(|c| c.cxx_method_def_token_stream(&struct_raw_name, package_name));
+        let cxx_const_impl_inner = self
+            .constants
+            .iter()
+            .map(|c| c.cxx_method_impl_token_stream(&struct_raw_name));
         let rust_type_default_inner = self.members.iter().map(|m| m.default_value());
 
-        let attributes = if gen_cxx_bridge {
-            quote! {
+        let (attributes, cxx_consts) = if gen_cxx_bridge {
+            let attributes = quote! {
                 #[namespace = #package_name]
                 #[cxx_name = #cxx_name]
-            }
+            };
+            let consts = quote! {
+                extern "Rust" {
+                    #(#cxx_const_def_inner)*
+                }
+            };
+            (attributes, consts)
         } else {
-            quote! {}
+            (quote! {}, quote! {})
         };
 
         if self.members.is_empty() {
@@ -154,8 +190,16 @@ impl Message {
                 pub struct #struct_raw_name {
                     #(#rust_type_def_inner)*
                 }
+
+                #cxx_consts
             };
             let impls = quote! {
+                impl ffi::#struct_raw_name {
+                    #(#constants_def_inner)*
+
+                    #(#cxx_const_impl_inner)*
+                }
+
                 impl crate::_core::InternalDefault for ffi::#struct_raw_name {
                     fn _default() -> Self {
                         Self {

--- a/libraries/extensions/ros2-bridge/msg-gen/src/types/message.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/types/message.rs
@@ -127,7 +127,7 @@ impl Constant {
         let const_name = format_ident!("{}", self.name);
         let name = format_ident!("const_{struct_name}_{}", self.name);
         let type_ = self.r#type.type_tokens();
-        quote! { pub fn #name (self: &ffi::#struct_name) -> #type_ { Self::#const_name }}
+        quote! { fn #name (self: &ffi::#struct_name) -> #type_ { Self::#const_name }}
     }
 }
 


### PR DESCRIPTION
Some ROS2 message definitions define constants, e.g. to specify the values of an enum-like integer field.
The Dora ROS2 bridge exposes these constants in the generated bindings as functions.

For example, the `STATUS_NO_FIX` constant of the [`NavSatStatus` message](https://docs.ros.org/en/jade/api/sensor_msgs/html/msg/NavSatStatus.html) can be accessed as follows:

```c++
assert((sensor_msgs::const_NavSatStatus_STATUS_NO_FIX() == -1));
```

(Note: Exposing them as C++ constants is not possible because it's [not supported by `cxx` yet](https://github.com/dtolnay/cxx/issues/1051).)



Requires https://github.com/dtolnay/cxx/pull/1320