### PR TITLE
Add initial support for calling ROS2 services from Rust nodes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,7 @@ jobs:
           QT_QPA_PLATFORM: offscreen
         run: |
           source /opt/ros/humble/setup.bash && ros2 run turtlesim turtlesim_node &
+          source /opt/ros/humble/setup.bash && ros2 run examples_rclcpp_minimal_service service_main &
           cargo run --example rust-ros2-dataflow --features="ros2-examples"
       - uses: actions/setup-python@v2
         if: runner.os != 'Windows'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2097,6 +2097,7 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+ "num_cpus",
 ]
 
 [[package]]
@@ -2158,9 +2159,9 @@ checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -4662,6 +4663,7 @@ dependencies = [
  "dora-ros2-bridge",
  "eyre",
  "futures",
+ "futures-timer",
  "rand",
  "serde_json",
  "tokio",

--- a/apis/c++/node/src/lib.rs
+++ b/apis/c++/node/src/lib.rs
@@ -9,7 +9,7 @@ use dora_node_api::{
 use eyre::bail;
 
 #[cfg(feature = "ros2-bridge")]
-use dora_ros2_bridge::_core;
+use dora_ros2_bridge::{_core, ros2_client};
 use futures_lite::{stream, Stream, StreamExt};
 
 #[cxx::bridge]

--- a/examples/rust-ros2-dataflow/README.md
+++ b/examples/rust-ros2-dataflow/README.md
@@ -11,11 +11,14 @@ This examples requires a sourced ROS2 installation.
 - Follow tasks 1 and 2 of the [ROS2 turtlesim tutorial](https://docs.ros.org/en/iron/Tutorials/Beginner-CLI-Tools/Introducing-Turtlesim/Introducing-Turtlesim.html#id3)
   - Install the turtlesim package
   - Start the turtlesim node through `ros2 run turtlesim turtlesim_node`
+- In a separate terminal, start the `/add_two_ints` service: `ros2 run examples_rclcpp_minimal_service service_main`
 
 ## Running
 
-After sourcing the ROS2 installation and starting the `turtlesim` node, you can run this example to move the turtle in random directions:
+After sourcing the ROS2 installation and starting both the `turtlesim` node and the `/add_two_ints` service, you can run this example to move the turtle in random directions:
 
 ```
 cargo run --example rust-ros2-dataflow --features ros2-examples
 ```
+
+You should see a few random requests in the terminal where you started the `examples_rclcpp_minimal_service`.

--- a/examples/rust-ros2-dataflow/dataflow.yml
+++ b/examples/rust-ros2-dataflow/dataflow.yml
@@ -5,5 +5,6 @@ nodes:
       source: ../../target/debug/rust-ros2-dataflow-example-node
       inputs:
         tick: dora/timer/millis/500
+        service_timer: dora/timer/secs/1
       outputs:
         - pose

--- a/examples/rust-ros2-dataflow/node/Cargo.toml
+++ b/examples/rust-ros2-dataflow/node/Cargo.toml
@@ -16,7 +16,8 @@ required-features = ["ros2"]
 [dependencies]
 dora-node-api = { workspace = true, features = ["tracing"] }
 eyre = "0.6.8"
-futures = "0.3.21"
+futures = { version = "0.3.21", features = ["thread-pool"] }
+futures-timer = "3.0.3"
 rand = "0.8.5"
 tokio = { version = "1.24.2", features = ["rt", "macros"] }
 dora-ros2-bridge = { workspace = true }

--- a/examples/rust-ros2-dataflow/node/src/main.rs
+++ b/examples/rust-ros2-dataflow/node/src/main.rs
@@ -67,7 +67,7 @@ fn main() -> eyre::Result<()> {
                 }
             }
         }
-        eyre::bail!("add_to_ints service not available");
+        eyre::bail!("add_two_ints service not available");
     };
     futures::executor::block_on(service_ready)?;
 

--- a/libraries/extensions/ros2-bridge/msg-gen/src/lib.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/lib.rs
@@ -25,6 +25,8 @@ where
     let mut message_struct_impls = Vec::new();
     let mut message_topic_defs = Vec::new();
     let mut message_topic_impls = Vec::new();
+    let mut service_defs = Vec::new();
+    let mut service_impls = Vec::new();
     let mut aliases = Vec::new();
     for package in &packages {
         for message in &package.messages {
@@ -37,6 +39,13 @@ where
                 message_topic_impls.push(topic_impl);
             }
         }
+
+        for service in &package.services {
+            let (def, imp) = service.struct_token_stream(&package.name, create_cxx_bridge);
+            service_defs.push(def);
+            service_impls.push(imp);
+        }
+
         aliases.push(package.aliases_token_stream());
     }
 
@@ -212,6 +221,7 @@ where
             }
 
             #(#shared_type_defs)*
+            #(#service_defs)*
         }
 
 
@@ -226,6 +236,8 @@ where
         #cxx_bridge_impls
         #(#message_topic_impls)*
 
+
+        #(#service_impls)*
 
         #(#aliases)*
     }

--- a/libraries/extensions/ros2-bridge/msg-gen/src/types/message.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/types/message.rs
@@ -235,7 +235,7 @@ impl Message {
                 }
             }
 
-            impl ros2_client::Message for ffi::#struct_raw_name {}
+            impl crate::ros2_client::Message for ffi::#struct_raw_name {}
 
             #(#cxx_const_impl_inner)*
         };
@@ -312,8 +312,8 @@ impl Message {
             impl Ros2Node {
                 #[allow(non_snake_case)]
                 pub fn #create_topic(&self, name_space: &str, base_name: &str, qos: ffi::Ros2QosPolicies) -> eyre::Result<Box<#topic_name>> {
-                    let name = ros2_client::Name::new(name_space, base_name).map_err(|e| eyre::eyre!(e))?;
-                    let type_name = ros2_client::MessageTypeName::new(#package_name, #self_name);
+                    let name = crate::ros2_client::Name::new(name_space, base_name).map_err(|e| eyre::eyre!(e))?;
+                    let type_name = crate::ros2_client::MessageTypeName::new(#package_name, #self_name);
                     let topic = self.0.create_topic(&name, type_name, &qos.into())?;
                     Ok(Box::new(#topic_name(topic)))
                 }
@@ -339,7 +339,7 @@ impl Message {
             }
 
             #[allow(non_camel_case_types)]
-            pub struct #publisher_name(ros2_client::Publisher<ffi::#struct_raw_name>);
+            pub struct #publisher_name(crate::ros2_client::Publisher<ffi::#struct_raw_name>);
 
             impl #publisher_name {
                 #[allow(non_snake_case)]
@@ -368,7 +368,7 @@ impl Message {
 
                     match (*event.event).0 {
                         Some(crate::MergedEvent::External(event)) if event.id == self.id  => {
-                            let result = event.event.downcast::<rustdds::dds::result::ReadResult<(ffi::#struct_raw_name, ros2_client::MessageInfo)>>()
+                            let result = event.event.downcast::<rustdds::dds::result::ReadResult<(ffi::#struct_raw_name, crate::ros2_client::MessageInfo)>>()
                                 .map_err(|_| eyre::eyre!("downcast to {} failed", #struct_raw_name_str))?;
 
                             let (data, _info) = result.with_context(|| format!("failed to receive {} event", #subscription_name_str))?;

--- a/libraries/extensions/ros2-bridge/msg-gen/src/types/message.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/types/message.rs
@@ -180,44 +180,45 @@ impl Message {
         };
 
         if self.members.is_empty() {
-            (quote! {}, quote! {})
-        } else {
-            let def = quote! {
-                #[allow(non_camel_case_types)]
-                #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-                #attributes
-                pub struct #struct_raw_name {
-                    #(#rust_type_def_inner)*
-                }
-
-                #cxx_consts
-            };
-            let impls = quote! {
-                impl ffi::#struct_raw_name {
-                    #(#constants_def_inner)*
-
-                }
-
-                impl crate::_core::InternalDefault for ffi::#struct_raw_name {
-                    fn _default() -> Self {
-                        Self {
-                            #(#rust_type_default_inner)*
-                        }
-                    }
-                }
-
-                impl std::default::Default for ffi::#struct_raw_name {
-                    #[inline]
-                    fn default() -> Self {
-                        crate::_core::InternalDefault::_default()
-                    }
-                }
-
-                #(#cxx_const_impl_inner)*
-            };
-
-            (def, impls)
+            (quote! {}, quote! {});
         }
+        let def = quote! {
+            #[allow(non_camel_case_types)]
+            #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+            #attributes
+            pub struct #struct_raw_name {
+                #(#rust_type_def_inner)*
+            }
+
+            #cxx_consts
+        };
+        let impls = quote! {
+            impl ffi::#struct_raw_name {
+                #(#constants_def_inner)*
+
+            }
+
+            impl crate::_core::InternalDefault for ffi::#struct_raw_name {
+                fn _default() -> Self {
+                    Self {
+                        #(#rust_type_default_inner)*
+                    }
+                }
+            }
+
+            impl std::default::Default for ffi::#struct_raw_name {
+                #[inline]
+                fn default() -> Self {
+                    crate::_core::InternalDefault::_default()
+                }
+            }
+
+            impl ros2_client::Message for ffi::#struct_raw_name {}
+
+            #(#cxx_const_impl_inner)*
+        };
+
+        (def, impls)
     }
 
     pub fn topic_def(&self, package_name: &str) -> (impl ToTokens, impl ToTokens) {
@@ -368,18 +369,6 @@ impl Message {
         } else {
             quote! {
                 pub use super::super::ffi::#struct_raw_name as #cxx_name;
-            }
-        }
-    }
-
-    pub fn token_stream_with_mod(&self, gen_cxx_bridge: bool) -> impl ToTokens {
-        let mod_name = format_ident!("_{}", self.name.to_snake_case());
-        let inner = self.token_stream_args(gen_cxx_bridge);
-
-        quote! {
-            pub use #mod_name::*;
-            mod #mod_name {
-                #inner
             }
         }
     }

--- a/libraries/extensions/ros2-bridge/msg-gen/src/types/service.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/types/service.rs
@@ -59,7 +59,7 @@ impl Service {
             #[derive(std::fmt::Debug)]
             pub struct #srv_type;
 
-            impl ros2_client::Service for #srv_type {
+            impl crate::ros2_client::Service for #srv_type {
                 type Request = #req_type;
                 type Response = #res_type;
 

--- a/libraries/extensions/ros2-bridge/msg-gen/src/types/service.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/types/service.rs
@@ -45,10 +45,11 @@ impl Service {
 
     pub fn alias_token_stream(&self, package_name: &Ident) -> impl ToTokens {
         let srv_type = format_ident!("{}", self.name);
-        let req_type = format_ident!("{}_Request", self.name);
-        let req_type_raw = format_ident!("{package_name}__{}", req_type);
-        let res_type = format_ident!("{}_Response", self.name);
-        let res_type_raw = format_ident!("{package_name}__{}", res_type);
+        let req_type_raw = format_ident!("{package_name}__{}_Request", self.name);
+        let res_type_raw = format_ident!("{package_name}__{}_Response", self.name);
+
+        let req_type = format_ident!("{}Request", self.name);
+        let res_type = format_ident!("{}Response", self.name);
 
         let request_type_name = req_type.to_string();
         let response_type_name = res_type.to_string();

--- a/libraries/extensions/ros2-bridge/msg-gen/src/types/service.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/types/service.rs
@@ -1,5 +1,6 @@
 use heck::SnakeCase;
 use quote::{format_ident, quote, ToTokens};
+use syn::Ident;
 
 use super::Message;
 
@@ -17,6 +18,63 @@ pub struct Service {
 }
 
 impl Service {
+    pub fn struct_token_stream(
+        &self,
+        package_name: &str,
+        gen_cxx_bridge: bool,
+    ) -> (impl ToTokens, impl ToTokens) {
+        let (request_def, request_impl) = self
+            .request
+            .struct_token_stream(package_name, gen_cxx_bridge);
+        let (response_def, response_impl) = self
+            .response
+            .struct_token_stream(package_name, gen_cxx_bridge);
+
+        let def = quote! {
+            #request_def
+            #response_def
+        };
+
+        let impls = quote! {
+            #request_impl
+            #response_impl
+        };
+
+        (def, impls)
+    }
+
+    pub fn alias_token_stream(&self, package_name: &Ident) -> impl ToTokens {
+        let srv_type = format_ident!("{}", self.name);
+        let req_type = format_ident!("{}_Request", self.name);
+        let req_type_raw = format_ident!("{package_name}__{}", req_type);
+        let res_type = format_ident!("{}_Response", self.name);
+        let res_type_raw = format_ident!("{package_name}__{}", res_type);
+
+        let request_type_name = req_type.to_string();
+        let response_type_name = res_type.to_string();
+
+        quote! {
+            #[allow(non_camel_case_types)]
+            #[derive(std::fmt::Debug)]
+            pub struct #srv_type;
+
+            impl ros2_client::Service for #srv_type {
+                type Request = #req_type;
+                type Response = #res_type;
+
+                fn request_type_name(&self) -> &str {
+                    #request_type_name
+                }
+                fn response_type_name(&self) -> &str {
+                    #response_type_name
+                }
+            }
+
+            pub use super::super::ffi::#req_type_raw as #req_type;
+            pub use super::super::ffi::#res_type_raw as #res_type;
+        }
+    }
+
     pub fn token_stream_with_mod(&self) -> impl ToTokens {
         let mod_name = format_ident!("_{}", self.name.to_snake_case());
         let inner = self.token_stream();

--- a/libraries/extensions/ros2-bridge/src/_core/mod.rs
+++ b/libraries/extensions/ros2-bridge/src/_core/mod.rs
@@ -6,7 +6,4 @@ pub mod traits;
 
 pub use sequence::{FFISeq, OwnedFFISeq, RefFFISeq};
 pub use string::{FFIString, FFIWString, OwnedFFIString, OwnedFFIWString};
-pub use traits::{ActionT, FFIFromRust, FFIToRust, InternalDefault, MessageT, ServiceT};
-
-pub type ServiceRequestRaw<Srv> = <<Srv as ServiceT>::Request as MessageT>::Raw;
-pub type ServiceResponseRaw<Srv> = <<Srv as ServiceT>::Response as MessageT>::Raw;
+pub use traits::{ActionT, FFIFromRust, FFIToRust, InternalDefault, MessageT};

--- a/libraries/extensions/ros2-bridge/src/_core/traits.rs
+++ b/libraries/extensions/ros2-bridge/src/_core/traits.rs
@@ -16,17 +16,12 @@ pub trait MessageT: Default + Send + Sync {
     }
 }
 
-pub trait ServiceT: Send {
-    type Request: MessageT;
-    type Response: MessageT;
-}
-
 pub trait ActionT: Send {
     type Goal: MessageT;
     type Result: MessageT;
     type Feedback: MessageT;
-    type SendGoal: ServiceT;
-    type GetResult: ServiceT;
+    type SendGoal;
+    type GetResult;
     type FeedbackMessage: MessageT;
 }
 


### PR DESCRIPTION
- Implement message generation for ROS2 services in Rust API
- Update `rust-ros2-dataflow` example with ROS2 service call

## Notes

- I also tried to use the synchronous service API of the `ros2-client` crate, but I ran into issues (see https://github.com/jhelovuo/ros2-client/issues/24)
- The service detection requires a background event loop provided by the [`Spinner`](https://docs.rs/ros2-client/0.6.1/ros2_client/struct.Spinner.html) type. This spinner needs to be run in parallel to the main thread. The easiest way to do that is to create a multi-threaded executor and spawn it there. For example, using the [`ThreadPool`](https://docs.rs/futures/0.3.30/futures/executor/struct.ThreadPool.html) executor provided by the `futures` crate:
    ```rust
    let pool = futures::executor::ThreadPool::new()?;

    let spinner = ros_node.spinner();
    pool.spawn(async {
        if let Err(err) = spinner.spin().await {
            eprintln!("ros2 spinner failed: {err:?}");
        }
    })
    .context("failed to spawn ros2 spinner")?;
    ```
    If you're already using an async runtime such as `tokio` or `smol`, you can spawn the spinner there as well (provided that you're using a multi-threaded executor).
- The generated type format might still change because we want to support service calls from C++ nodes as well. The `cxx` crate, which we use for bridging Rust to C++ code, doesn't work with generics, so we have to find another way.
- We might want to provide direct service support in our node API. For example, we might want to spawn the spinner thread already in the library or provide a way to merge service responses into the event stream.