### PR TITLE
Fix out-of-tree builds in cmake example

### DIFF
--- a/examples/cmake-dataflow/DoraTargets.cmake
+++ b/examples/cmake-dataflow/DoraTargets.cmake
@@ -96,7 +96,7 @@ else()
         DEPENDS Dora
     )
     add_custom_command(OUTPUT ${node_bridge} ${dora_cxx_include_dir} ${operator_bridge}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/dora/src/Dora/target/debug
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/dora/src/Dora/target
         DEPENDS Dora
         COMMAND
             mkdir ${dora_cxx_include_dir} -p


### PR DESCRIPTION
See https://github.com/dora-rs/dora/issues/446#issuecomment-2028002267
