### PR TITLE
fix cargo run --example cmake-dataflow compile bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,4 +163,7 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+# log output file
+out/
+
 ~*

--- a/examples/cmake-dataflow/DoraTargets.cmake
+++ b/examples/cmake-dataflow/DoraTargets.cmake
@@ -7,45 +7,33 @@ set(node_bridge "${CMAKE_CURRENT_BINARY_DIR}/node_bridge.cc")
 set(operator_bridge "${CMAKE_CURRENT_BINARY_DIR}/operator_bridge.cc")
 
 if(DORA_ROOT_DIR)
-    include(FetchContent)
-    FetchContent_Declare(
-        Corrosion
-        GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-        GIT_TAG v0.4.3
-    )
-    FetchContent_MakeAvailable(Corrosion)
-    list(PREPEND CMAKE_MODULE_PATH ${Corrosion_SOURCE_DIR}/cmake)
-    find_package(Rust 1.72 REQUIRED MODULE)
-    corrosion_import_crate(MANIFEST_PATH "${DORA_ROOT_DIR}/Cargo.toml"
-        CRATES
-        dora-node-api-c
-        dora-operator-api-c
-        CRATE_TYPES
-        staticlib staticlib
-    )
-    add_custom_command(OUTPUT ${dora_c_include_dir}
-        WORKING_DIRECTORY ${DORA_ROOT_DIR}/apis/c
-        COMMAND
-            mkdir ${CMAKE_CURRENT_BINARY_DIR}/include/c -p
+    include(ExternalProject)
+    ExternalProject_Add(Dora
+        SOURCE_DIR ${DORA_ROOT_DIR}
+        BUILD_IN_SOURCE True
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND
+            cargo build
+            --package dora-node-api-c
             &&
-            cp node ${CMAKE_CURRENT_BINARY_DIR}/include/c -r
+            cargo build
+            --package dora-operator-api-c
             &&
-            cp operator ${CMAKE_CURRENT_BINARY_DIR}/include/c -r
-        DEPENDS dora-node-api-c dora-operator-api-c
+            cargo build
+            --package dora-node-api-cxx
+            &&
+            cargo build
+            --package dora-operator-api-cxx
+        INSTALL_COMMAND ""
     )
-
-    corrosion_import_crate(MANIFEST_PATH "${DORA_ROOT_DIR}/Cargo.toml"
-        CRATES
-        dora-node-api-cxx
-        dora-operator-api-cxx
-        CRATE_TYPES
-        staticlib staticlib
-    )
-    add_custom_command(OUTPUT ${node_bridge} ${dora_cxx_include_dir} ${operator_bridge}
+    
+    add_custom_command(OUTPUT ${node_bridge} ${dora_cxx_include_dir} ${operator_bridge} ${dora_c_include_dir}
         WORKING_DIRECTORY ${DORA_ROOT_DIR}
-        DEPENDS dora-node-api-cxx dora-operator-api-cxx
+        DEPENDS Dora
         COMMAND
             mkdir ${dora_cxx_include_dir} -p
+            &&
+            mkdir ${CMAKE_CURRENT_BINARY_DIR}/include/c -p
             &&
             cp target/cxxbridge/dora-node-api-cxx/src/lib.rs.cc ${node_bridge}
             &&
@@ -54,11 +42,16 @@ if(DORA_ROOT_DIR)
             cp target/cxxbridge/dora-operator-api-cxx/src/lib.rs.cc ${operator_bridge}
             &&
             cp target/cxxbridge/dora-operator-api-cxx/src/lib.rs.h ${dora_cxx_include_dir}/dora-operator-api.h
+            &&
+            cp apis/c/node ${CMAKE_CURRENT_BINARY_DIR}/include/c -r
+            &&
+            cp apis/c/operator ${CMAKE_CURRENT_BINARY_DIR}/include/c -r
+
     )
     
-    add_custom_target(Dora_c DEPENDS dora-node-api-c dora-operator-api-c ${dora_c_include_dir})
-    add_custom_target(Dora_cxx DEPENDS dora-node-api-cxx  dora-operator-api-cxx ${node_bridge} ${operator_bridge} ${dora_cxx_include_dir})
-    set(dora_link_dirs ${CMAKE_CURRENT_BINARY_DIR})
+    add_custom_target(Dora_c DEPENDS ${dora_c_include_dir})
+    add_custom_target(Dora_cxx DEPENDS ${node_bridge} ${operator_bridge} ${dora_cxx_include_dir})
+    set(dora_link_dirs ${DORA_ROOT_DIR}/target/debug)
 else()
     include(ExternalProject)
     ExternalProject_Add(Dora
@@ -85,20 +78,13 @@ else()
             --target-dir ${CMAKE_CURRENT_BINARY_DIR}/dora/src/Dora/target
         INSTALL_COMMAND ""
     )
-    add_custom_command(OUTPUT ${dora_c_include_dir}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/dora/src/Dora/apis/c
-        COMMAND
-            mkdir ${CMAKE_CURRENT_BINARY_DIR}/include/c -p
-            &&
-            cp node ${CMAKE_CURRENT_BINARY_DIR}/include/c -r
-            &&
-            cp operator ${CMAKE_CURRENT_BINARY_DIR}/include/c -r
-        DEPENDS Dora
-    )
-    add_custom_command(OUTPUT ${node_bridge} ${dora_cxx_include_dir} ${operator_bridge}
+
+    add_custom_command(OUTPUT ${node_bridge} ${dora_cxx_include_dir} ${operator_bridge} ${dora_c_include_dir}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/dora/src/Dora/target
         DEPENDS Dora
         COMMAND
+            mkdir ${CMAKE_CURRENT_BINARY_DIR}/include/c -p
+            &&
             mkdir ${dora_cxx_include_dir} -p
             &&
             cp cxxbridge/dora-node-api-cxx/src/lib.rs.cc ${node_bridge}
@@ -108,6 +94,10 @@ else()
             cp cxxbridge/dora-operator-api-cxx/src/lib.rs.cc ${operator_bridge}
             &&
             cp cxxbridge/dora-operator-api-cxx/src/lib.rs.h ${dora_cxx_include_dir}/dora-operator-api.h
+            &&
+            cp ../apis/c/node ${CMAKE_CURRENT_BINARY_DIR}/include/c -r
+            &&
+            cp ../apis/c/operator ${CMAKE_CURRENT_BINARY_DIR}/include/c -r
     )
 
     set(dora_link_dirs ${CMAKE_CURRENT_BINARY_DIR}/dora/src/Dora/target/debug)


### PR DESCRIPTION
Previous work leverage [corrosion](https://github.com/corrosion-rs/corrosion) to produce artifacts so that corrosion will put `lib.rs.cc` into another dir different from `target_dir()`.

The `cargo run --example cmake-dataflow` command will fail when the `lib.rs.cc` have never been created before.

see https://github.com/dora-rs/dora/issues/446