### PR TITLE
Remove `cxx_build` call, which is no longer used

### DIFF
--- a/libraries/extensions/ros2-bridge/build.rs
+++ b/libraries/extensions/ros2-bridge/build.rs
@@ -15,9 +15,6 @@ fn main() {
     let target_file = out_dir.join("messages.rs");
     std::fs::write(&target_file, generated_string).unwrap();
     println!("cargo:rustc-env=MESSAGES_PATH={}", target_file.display());
-
-    #[cfg(feature = "cxx-bridge")]
-    let _build = cxx_build::bridge(&target_file);
 }
 
 fn ament_prefix_paths() -> Vec<PathBuf> {


### PR DESCRIPTION
The message generation is now done in the C++ node API. This feature-gated call is never activated.

Reported by @Michael-J-Ward on Discord.