### PR TITLE
Simple warning fixes

### DIFF
--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -90,7 +90,7 @@ impl DoraNode {
 
         let node = Self {
             id: node_id,
-            dataflow_id: dataflow_id,
+            dataflow_id,
             node_config: run_config,
             control_channel,
             clock,

--- a/apis/rust/operator/types/src/lib.rs
+++ b/apis/rust/operator/types/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(elided_lifetimes_in_paths)] // required for safer-ffi
 #![allow(improper_ctypes_definitions)]
+#![allow(clippy::missing_safety_doc)]
 
 pub use arrow;
 use dora_arrow_convert::{ArrowData, IntoArrow};

--- a/binaries/cli/src/up.rs
+++ b/binaries/cli/src/up.rs
@@ -70,8 +70,7 @@ fn start_coordinator() -> eyre::Result<()> {
     let mut cmd =
         Command::new(std::env::current_exe().wrap_err("failed to get current executable path")?);
     cmd.arg("coordinator");
-    cmd.spawn()
-        .wrap_err_with(|| format!("failed to run `dora coordinator`"))?;
+    cmd.spawn().wrap_err("failed to run `dora coordinator`")?;
 
     println!("started dora coordinator");
 
@@ -82,8 +81,7 @@ fn start_daemon() -> eyre::Result<()> {
     let mut cmd =
         Command::new(std::env::current_exe().wrap_err("failed to get current executable path")?);
     cmd.arg("daemon");
-    cmd.spawn()
-        .wrap_err_with(|| format!("failed to run `dora daemon`"))?;
+    cmd.spawn().wrap_err("failed to run `dora daemon`")?;
 
     println!("started dora daemon");
 

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -575,6 +575,19 @@ async fn stop_dataflow_by_uuid(
     Ok(())
 }
 
+fn format_error(machine: &str, err: &str) -> String {
+    let mut error = err
+        .lines()
+        .fold(format!("- machine `{machine}`:\n"), |mut output, line| {
+            output.push_str("    ");
+            output.push_str(line);
+            output.push('\n');
+            output
+        });
+    error.push('\n');
+    error
+}
+
 fn dataflow_result(
     results: &BTreeMap<String, Result<(), String>>,
     dataflow_uuid: Uuid,
@@ -582,8 +595,7 @@ fn dataflow_result(
     let mut errors = Vec::new();
     for (machine, result) in results {
         if let Err(err) = result {
-            let err: String = err.lines().map(|line| format!("    {line}\n")).collect();
-            errors.push(format!("- machine `{machine}`:\n{err}\n"));
+            errors.push(format_error(machine, err));
         }
     }
 
@@ -940,4 +952,22 @@ fn set_up_ctrlc_handler() -> Result<impl Stream<Item = Event>, eyre::ErrReport> 
     .wrap_err("failed to set ctrl-c handler")?;
 
     Ok(ReceiverStream::new(ctrlc_rx))
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_format_error() {
+        let machine = "machine A";
+        let err = "foo\nbar\nbuzz";
+
+        // old method
+        let old_error = {
+            #[allow(clippy::format_collect)]
+            let err: String = err.lines().map(|line| format!("    {line}\n")).collect();
+            format!("- machine `{machine}`:\n{err}\n")
+        };
+        let new_error = super::format_error(machine, err);
+        assert_eq!(old_error, new_error)
+    }
 }

--- a/binaries/daemon/src/spawn.rs
+++ b/binaries/daemon/src/spawn.rs
@@ -405,7 +405,12 @@ pub async fn spawn_node(
                 .write_all(message.as_bytes())
                 .await
                 .map_err(|err| error!("Could not log {message} to file due to {err}"));
-            let formatted: String = message.lines().map(|l| format!("      {l}\n")).collect();
+            let formatted = message.lines().fold(String::default(), |mut output, line| {
+                output.push_str("      ");
+                output.push_str(line);
+                output.push('\n');
+                output
+            });
             debug!("{dataflow_id}/{} logged:\n{formatted}", node.id.clone());
             // Make sure that all data has been synced to disk.
             let _ = file

--- a/binaries/daemon/src/spawn.rs
+++ b/binaries/daemon/src/spawn.rs
@@ -254,7 +254,7 @@ pub async fn spawn_node(
         }
     };
 
-    let dataflow_dir = PathBuf::from(working_dir.join("out").join(dataflow_id.to_string()));
+    let dataflow_dir: PathBuf = working_dir.join("out").join(dataflow_id.to_string());
     if !dataflow_dir.exists() {
         std::fs::create_dir_all(&dataflow_dir).context("could not create dataflow_dir")?;
     }

--- a/binaries/runtime/src/operator/python.rs
+++ b/binaries/runtime/src/operator/python.rs
@@ -130,6 +130,7 @@ pub fn run(
             if let Event::Reload { .. } = event {
                 reload = true;
                 // Reloading method
+                #[allow(clippy::blocks_in_conditions)]
                 match Python::with_gil(|py| -> Result<Py<PyAny>> {
                     // Saving current state
                     let current_state = operator

--- a/examples/multiple-daemons/run.rs
+++ b/examples/multiple-daemons/run.rs
@@ -42,8 +42,8 @@ async fn main() -> eyre::Result<()> {
         dora_coordinator::start(coordinator_bind, ReceiverStream::new(coordinator_events_rx))
             .await?;
     let coordinator_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), coordinator_port);
-    let daemon_a = run_daemon(coordinator_addr.to_string(), "A".into());
-    let daemon_b = run_daemon(coordinator_addr.to_string(), "B".into());
+    let daemon_a = run_daemon(coordinator_addr.to_string(), "A");
+    let daemon_b = run_daemon(coordinator_addr.to_string(), "B");
 
     tracing::info!("Spawning coordinator and daemons");
     let mut tasks = JoinSet::new();

--- a/libraries/communication-layer/request-reply/src/lib.rs
+++ b/libraries/communication-layer/request-reply/src/lib.rs
@@ -18,6 +18,7 @@ pub trait RequestReplyLayer: Send + Sync {
     type ReplyData;
     type Error;
 
+    #[allow(clippy::type_complexity)]
     fn listen(
         &mut self,
         addr: Self::Address,
@@ -39,6 +40,7 @@ pub trait RequestReplyLayer: Send + Sync {
         Self::Error,
     >;
 
+    #[allow(clippy::type_complexity)]
     fn connect(
         &mut self,
         addr: Self::Address,
@@ -59,6 +61,7 @@ pub trait ListenConnection: Send + Sync {
     type ReplyData;
     type Error;
 
+    #[allow(clippy::type_complexity)]
     fn handle_next(
         &mut self,
         handler: Box<dyn FnOnce(Self::RequestData) -> Result<Self::ReplyData, Self::Error>>,

--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -53,7 +53,7 @@ pub fn check_dataflow(dataflow: &Descriptor, working_dir: &Path) -> eyre::Result
                         OperatorSource::Python(python_source) => {
                             has_python_operator = true;
                             let path = &python_source.source;
-                            if source_is_url(&path) {
+                            if source_is_url(path) {
                                 info!("{path} is a URL."); // TODO: Implement url check.
                             } else if !working_dir.join(path).exists() {
                                 bail!("no Python library at `{path}`");

--- a/libraries/extensions/ros2-bridge/build.rs
+++ b/libraries/extensions/ros2-bridge/build.rs
@@ -17,6 +17,7 @@ fn main() {
     println!("cargo:rustc-env=MESSAGES_PATH={}", target_file.display());
 }
 
+#[cfg(feature = "generate-messages")]
 fn ament_prefix_paths() -> Vec<PathBuf> {
     let ament_prefix_path: String = match std::env::var("AMENT_PREFIX_PATH") {
         Ok(path) => path,

--- a/libraries/extensions/ros2-bridge/msg-gen/src/parser/literal.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/parser/literal.rs
@@ -107,6 +107,7 @@ fn bool_literal(s: &str) -> IResult<&str, bool> {
     ))(s)
 }
 
+#[allow(clippy::type_complexity)]
 pub fn get_string_literal_parser(
     string_type: GenericString,
 ) -> Box<dyn FnMut(&str) -> IResult<&str, String>> {

--- a/libraries/extensions/ros2-bridge/msg-gen/src/parser/types.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/parser/types.rs
@@ -54,9 +54,11 @@ pub fn parse_constant_type(s: &str) -> IResult<&str, ConstantType> {
             opt(delimited(char('['), usize_literal, char(']'))),
             peek(alt((space1, eof))),
         )),
-        |(value_type, size, _)| match size {
-            None => value_type.into(),
-            Some(size) => PrimitiveArray { value_type, size }.into(),
+        |(value_type, size, _)| {
+            size.map_or_else(
+                || value_type.into(),
+                |size| PrimitiveArray { value_type, size }.into(),
+            )
         },
     )(s)
 }

--- a/libraries/extensions/ros2-bridge/msg-gen/src/types/constant.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/types/constant.rs
@@ -25,11 +25,11 @@ pub enum ConstantType {
 impl ConstantType {
     pub fn type_tokens(&self) -> impl ToTokens {
         match self {
-            ConstantType::PrimitiveType(t) => {
+            Self::PrimitiveType(t) => {
                 let token = t.type_tokens();
                 quote! { #token }
             }
-            ConstantType::PrimitiveArray(t) => {
+            Self::PrimitiveArray(t) => {
                 let token = t.type_tokens();
                 quote! { #token }
             }
@@ -38,12 +38,12 @@ impl ConstantType {
 
     pub fn value_tokens(&self, values: &[String]) -> impl ToTokens {
         match self {
-            ConstantType::PrimitiveType(t) => {
+            Self::PrimitiveType(t) => {
                 assert_eq!(values.len(), 1);
                 let token = t.value_tokens(&values[0]);
                 quote! { #token }
             }
-            ConstantType::PrimitiveArray(t) => {
+            Self::PrimitiveArray(t) => {
                 assert_eq!(values.len(), t.size);
                 let tokens = values.iter().map(|v| t.value_type.value_tokens(v));
                 quote! { [#(#tokens,)*] }

--- a/libraries/extensions/ros2-bridge/msg-gen/src/types/package.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/types/package.rs
@@ -126,7 +126,7 @@ impl Package {
         }
     }
 
-    pub fn token_stream(&self, gen_cxx_bridge: bool) -> impl ToTokens {
+    pub fn token_stream(&self, _gen_cxx_bridge: bool) -> impl ToTokens {
         let name = Ident::new(&self.name, Span::call_site());
         let services_block = self.services_block();
         let actions_block = self.actions_block();

--- a/libraries/extensions/ros2-bridge/python/src/lib.rs
+++ b/libraries/extensions/ros2-bridge/python/src/lib.rs
@@ -105,7 +105,7 @@ impl Ros2Node {
         qos: qos::Ros2QosPolicies,
     ) -> eyre::Result<Ros2Topic> {
         let (namespace_name, message_name) =
-            match (message_type.split_once("/"), message_type.split_once("::")) {
+            match (message_type.split_once('/'), message_type.split_once("::")) {
                 (Some(msg), None) => msg,
                 (None, Some(msg)) => msg,
                 _ => eyre::bail!("Expected message type in the format `namespace/message` or `namespace::message`, such as `std_msgs/UInt8` but got: {}", message_type),

--- a/libraries/extensions/ros2-bridge/src/_core/string.rs
+++ b/libraries/extensions/ros2-bridge/src/_core/string.rs
@@ -29,6 +29,7 @@ impl U16String {
         Self(widestring::U16String::new())
     }
 
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(arg: &str) -> U16String {
         Self(widestring::U16String::from_str(arg))
     }

--- a/libraries/extensions/ros2-bridge/src/lib.rs
+++ b/libraries/extensions/ros2-bridge/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::missing_safety_doc)]
+
 pub use flume;
 pub use futures;
 pub use futures_timer;

--- a/libraries/extensions/telemetry/metrics/src/lib.rs
+++ b/libraries/extensions/telemetry/metrics/src/lib.rs
@@ -44,6 +44,6 @@ pub fn init_metrics() -> metrics::Result<SdkMeterProvider> {
 pub fn init_meter_provider(meter_id: String) -> Result<SdkMeterProvider> {
     let meter_provider = init_metrics().context("Could not create opentelemetry meter")?;
     let meter = meter_provider.meter(meter_id);
-    let _ = init_process_observer(meter).context("could not initiale system metrics observer")?;
+    init_process_observer(meter).context("could not initiale system metrics observer")?;
     Ok(meter_provider)
 }

--- a/libraries/message/src/lib.rs
+++ b/libraries/message/src/lib.rs
@@ -1,6 +1,8 @@
 //! Enable serialisation and deserialisation of capnproto messages
 //!
 
+#![allow(clippy::missing_safety_doc)]
+
 use arrow_data::ArrayData;
 use arrow_schema::DataType;
 use eyre::Context;

--- a/libraries/shared-memory-server/src/lib.rs
+++ b/libraries/shared-memory-server/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::missing_safety_doc)]
+
 use self::channel::ShmemChannel;
 use eyre::{eyre, Context};
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
clippy lights up my editor with warnings. Here are a few of the simple fixes.

If you want, I can address the rest sans the `unsafe function's docs miss #Safety section` warnings.