### PR TITLE
Use `resolver = 2` for in workspace in Rust template

### DIFF
--- a/binaries/cli/src/template/rust/Cargo-template.toml
+++ b/binaries/cli/src/template/rust/Cargo-template.toml
@@ -1,2 +1,3 @@
 [workspace]
+resolver = "2"
 members = ["op_1", "op_2", "node_1"]


### PR DESCRIPTION
Avoids a cargo warning.

Should be merged after #491 
