### PR TITLE
Fix: Wait until dora daemon is connected to coordinator on `dora up`

### DIFF
--- a/binaries/cli/src/up.rs
+++ b/binaries/cli/src/up.rs
@@ -28,6 +28,20 @@ pub(crate) fn up(config_path: Option<&Path>) -> eyre::Result<()> {
 
     if !daemon_running(&mut *session)? {
         start_daemon().wrap_err("failed to start dora-daemon")?;
+
+        // wait a bit until daemon is connected
+        let mut i = 0;
+        const WAIT_S: f32 = 0.1;
+        loop {
+            if daemon_running(&mut *session)? {
+                break;
+            }
+            i += 1;
+            if i > 20 {
+                eyre::bail!("daemon not connected after {}s", WAIT_S * i as f32);
+            }
+            std::thread::sleep(Duration::from_secs_f32(WAIT_S));
+        }
     }
 
     Ok(())


### PR DESCRIPTION
It might take a short time until the daemon is connected to the coordinator after start-up. This could lead to issues when using `dora up` in a script because a subsequent `dora start` command might fail when the daemon is not connected at that point.

This commit fixes this issue by waiting until the coordinator confirms that a daemon is connected before returning from `dora up`.
