### PR TITLE
Json schemas for VSCode YAML Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2306,6 +2306,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde-with-expand-env",
+ "serde_json",
  "serde_yaml 0.9.30",
  "tokio",
  "tracing",
@@ -2523,8 +2524,6 @@ dependencies = [
  "dora-tracing",
  "eyre",
  "parquet",
- "schemars",
- "serde_json",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2227,7 +2227,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.3",
 ]
 
 [[package]]
@@ -2303,6 +2303,7 @@ dependencies = [
  "dora-message",
  "eyre",
  "once_cell",
+ "schemars",
  "serde",
  "serde-with-expand-env",
  "serde_yaml 0.9.30",
@@ -2522,6 +2523,8 @@ dependencies = [
  "dora-tracing",
  "eyre",
  "parquet",
+ "schemars",
+ "serde_json",
  "tokio",
 ]
 
@@ -3737,7 +3740,7 @@ dependencies = [
  "bitflags 2.4.0",
  "com",
  "libc",
- "libloading 0.7.4",
+ "libloading 0.8.3",
  "thiserror",
  "widestring",
  "winapi 0.3.9",
@@ -6200,7 +6203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19de2de2a00075bf566bee3bd4db014b11587e84184d3f7a791bc17f1a8e9e48"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -8134,6 +8137,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6e7ed6919cb46507fb01ff1654309219f62b4d603822501b0b80d42f6f21ef"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "185f2b7aa7e02d418e453790dde16890256bbd2bcd04b7dc5348811052b53f49"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8257,10 +8284,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_json"
-version = "1.0.107"
+name = "serde_derive_internals"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",
@@ -10015,7 +10053,7 @@ dependencies = [
  "js-sys",
  "khronos-egl",
  "libc",
- "libloading 0.7.4",
+ "libloading 0.8.3",
  "log",
  "metal",
  "naga",

--- a/libraries/core/Cargo.toml
+++ b/libraries/core/Cargo.toml
@@ -21,3 +21,4 @@ serde-with-expand-env = "1.1.0"
 tokio = { version = "1.24.1", features = ["fs", "process", "sync"] }
 aligned-vec = { version = "0.5.0", features = ["serde"] }
 schemars = "0.8.19"
+serde_json = "1.0.117"

--- a/libraries/core/Cargo.toml
+++ b/libraries/core/Cargo.toml
@@ -20,3 +20,4 @@ tracing = "0.1"
 serde-with-expand-env = "1.1.0"
 tokio = { version = "1.24.1", features = ["fs", "process", "sync"] }
 aligned-vec = { version = "0.5.0", features = ["serde"] }
+schemars = "0.8.19"

--- a/libraries/core/README.md
+++ b/libraries/core/README.md
@@ -1,0 +1,7 @@
+# Core library for dora
+
+## Generating dora schema
+
+```bash
+cargo run -p dora-core generate_schemas
+```

--- a/libraries/core/README.md
+++ b/libraries/core/README.md
@@ -5,3 +5,27 @@
 ```bash
 cargo run -p dora-core generate_schemas
 ```
+
+## VSCode YAML Dataflow Support
+
+We can pass the JSON Schema to VSCode [`redhat.vscode-yaml`](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) to enables features such as:
+
+- Type validation
+- Suggestions
+- Documentation
+
+### Getting started
+
+1. Install [`redhat.vscode-yaml`](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)
+
+2. Open User Settings(JSON) in VSCode within `ctrl`+ `shift` + `p` search bar.
+
+3. Add the following:
+
+```json
+  "yaml.schemas": {
+    "https://raw.githubusercontent.com/dora-rs/dora/json-schemas/libraries/core/dora-schema.json": "/*"
+  },
+```
+
+And you should be set! 🔥

--- a/libraries/core/dora-schema.json
+++ b/libraries/core/dora-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Descriptor",
+  "title": "dora-rs specification",
   "description": "Dataflow description",
   "type": "object",
   "required": [

--- a/libraries/core/dora-schema.json
+++ b/libraries/core/dora-schema.json
@@ -7,27 +7,6 @@
     "nodes"
   ],
   "properties": {
-    "_unstable_deploy": {
-      "default": {
-        "machine": null
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/Deploy"
-        }
-      ]
-    },
-    "communication": {
-      "default": {
-        "_unstable_local": "Tcp",
-        "_unstable_remote": "tcp"
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/CommunicationConfig"
-        }
-      ]
-    },
     "nodes": {
       "type": "array",
       "items": {
@@ -37,20 +16,6 @@
   },
   "additionalProperties": true,
   "definitions": {
-    "CommunicationConfig": {
-      "type": "object",
-      "properties": {
-        "_unstable_local": {
-          "default": "Tcp",
-          "type": "string"
-        },
-        "_unstable_remote": {
-          "default": "tcp",
-          "type": "string"
-        }
-      },
-      "additionalProperties": true
-    },
     "CustomNode": {
       "type": "object",
       "required": [
@@ -81,7 +46,7 @@
           }
         },
         "inputs": {
-          "description": "Inputs for the nodes as a map from input ID to input configuration\n\ne.g.\n\ninputs:\n\nexample_input: example_node/example_output1",
+          "description": "Inputs for the nodes as a map from input ID to `<node_id>/<output_id>`.\n\ne.g.\n\ninputs:\n\nexample_input: example_node/example_output1",
           "default": {},
           "type": "object",
           "additionalProperties": true
@@ -110,18 +75,6 @@
     },
     "DataId": {
       "type": "string"
-    },
-    "Deploy": {
-      "type": "object",
-      "properties": {
-        "machine": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "additionalProperties": true
     },
     "Duration": {
       "type": "object",
@@ -262,17 +215,6 @@
         "id"
       ],
       "properties": {
-        "_unstable_deploy": {
-          "description": "Unstable machine deployment configuration",
-          "default": {
-            "machine": null
-          },
-          "allOf": [
-            {
-              "$ref": "#/definitions/Deploy"
-            }
-          ]
-        },
         "description": {
           "description": "Description of the node",
           "type": [
@@ -332,18 +274,6 @@
           ],
           "properties": {
             
-          },
-          "additionalProperties": true
-        },
-        {
-          "type": "object",
-          "required": [
-            "wasm"
-          ],
-          "properties": {
-            "wasm": {
-              "type": "string"
-            }
           },
           "additionalProperties": true
         }
@@ -437,18 +367,6 @@
           ],
           "properties": {
             
-          },
-          "additionalProperties": true
-        },
-        {
-          "type": "object",
-          "required": [
-            "wasm"
-          ],
-          "properties": {
-            "wasm": {
-              "type": "string"
-            }
           },
           "additionalProperties": true
         }

--- a/libraries/core/dora-schema.json
+++ b/libraries/core/dora-schema.json
@@ -1,0 +1,523 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Descriptor",
+  "description": "Dataflow description",
+  "type": "object",
+  "required": [
+    "nodes"
+  ],
+  "properties": {
+    "_unstable_deploy": {
+      "default": {
+        "machine": null
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Deploy"
+        }
+      ]
+    },
+    "communication": {
+      "default": {
+        "_unstable_local": "Tcp",
+        "_unstable_remote": "tcp"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/CommunicationConfig"
+        }
+      ]
+    },
+    "nodes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Node"
+      }
+    }
+  },
+  "additionalProperties": true,
+  "definitions": {
+    "CommunicationConfig": {
+      "type": "object",
+      "properties": {
+        "_unstable_local": {
+          "default": "Tcp",
+          "type": "string"
+        },
+        "_unstable_remote": {
+          "default": "tcp",
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
+    },
+    "CustomNode": {
+      "type": "object",
+      "required": [
+        "source"
+      ],
+      "properties": {
+        "args": {
+          "description": "Args for the executable.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "build": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "envs": {
+          "description": "Environment variables for the custom nodes",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/definitions/EnvValue"
+          }
+        },
+        "inputs": {
+          "description": "Inputs for the nodes as a map from input ID to input configuration\n\ne.g.\n\ninputs:\n\nexample_input: example_node/example_output1",
+          "default": {},
+          "type": "object",
+          "additionalProperties": true
+        },
+        "outputs": {
+          "description": "Outputs as a list of outputs.\n\ne.g.\n\noutputs:\n\n- output_1\n\n- output_2",
+          "default": [],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DataId"
+          },
+          "uniqueItems": true
+        },
+        "send_stdout_as": {
+          "description": "Send stdout and stderr to another node",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source": {
+          "description": "Path of the source code\n\nIf you want to use a specific `conda` environment. Provide the python path within the source.\n\nsource: /home/peter/miniconda3/bin/python\n\nargs: some_node.py\n\nSource can match any executable in PATH.",
+          "type": "string"
+        }
+      }
+    },
+    "DataId": {
+      "type": "string"
+    },
+    "Deploy": {
+      "type": "object",
+      "properties": {
+        "machine": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": true
+    },
+    "Duration": {
+      "type": "object",
+      "required": [
+        "nanos",
+        "secs"
+      ],
+      "properties": {
+        "nanos": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "secs": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      }
+    },
+    "EnvValue": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "Input": {
+      "type": "object",
+      "required": [
+        "mapping"
+      ],
+      "properties": {
+        "mapping": {
+          "$ref": "#/definitions/InputMapping"
+        },
+        "queue_size": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": true
+    },
+    "InputMapping": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "Timer"
+          ],
+          "properties": {
+            "Timer": {
+              "type": "object",
+              "required": [
+                "interval"
+              ],
+              "properties": {
+                "interval": {
+                  "$ref": "#/definitions/Duration"
+                }
+              }
+            }
+          },
+          "additionalProperties": true
+        },
+        {
+          "type": "object",
+          "required": [
+            "User"
+          ],
+          "properties": {
+            "User": {
+              "$ref": "#/definitions/UserInputMapping"
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "Node": {
+      "description": "Dora Node",
+      "type": "object",
+      "oneOf": [
+        {
+          "description": "Dora runtime node",
+          "type": "object",
+          "required": [
+            "operators"
+          ],
+          "properties": {
+            "operators": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/OperatorDefinition"
+              }
+            }
+          },
+          "additionalProperties": true
+        },
+        {
+          "type": "object",
+          "required": [
+            "custom"
+          ],
+          "properties": {
+            "custom": {
+              "$ref": "#/definitions/CustomNode"
+            }
+          },
+          "additionalProperties": true
+        },
+        {
+          "type": "object",
+          "required": [
+            "operator"
+          ],
+          "properties": {
+            "operator": {
+              "$ref": "#/definitions/SingleOperatorDefinition"
+            }
+          },
+          "additionalProperties": true
+        }
+      ],
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "_unstable_deploy": {
+          "description": "Unstable machine deployment configuration",
+          "default": {
+            "machine": null
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/Deploy"
+            }
+          ]
+        },
+        "description": {
+          "description": "Description of the node",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "env": {
+          "description": "Environment variables",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/definitions/EnvValue"
+          }
+        },
+        "id": {
+          "description": "Node identifier",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NodeId"
+            }
+          ]
+        },
+        "name": {
+          "description": "Node name",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "NodeId": {
+      "type": "string"
+    },
+    "OperatorDefinition": {
+      "type": "object",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "shared-library"
+          ],
+          "properties": {
+            "shared-library": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": true
+        },
+        {
+          "type": "object",
+          "required": [
+            "python"
+          ],
+          "properties": {
+            
+          },
+          "additionalProperties": true
+        },
+        {
+          "type": "object",
+          "required": [
+            "wasm"
+          ],
+          "properties": {
+            "wasm": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": true
+        }
+      ],
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "build": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "id": {
+          "$ref": "#/definitions/OperatorId"
+        },
+        "inputs": {
+          "default": {},
+          "type": "object",
+          "additionalProperties": true
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "outputs": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DataId"
+          },
+          "uniqueItems": true
+        },
+        "send_stdout_as": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "OperatorId": {
+      "type": "string"
+    },
+    "PythonSource": {
+      "type": "object",
+      "required": [
+        "source"
+      ],
+      "properties": {
+        "conda_env": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
+    },
+    "SingleOperatorDefinition": {
+      "type": "object",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "shared-library"
+          ],
+          "properties": {
+            "shared-library": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": true
+        },
+        {
+          "type": "object",
+          "required": [
+            "python"
+          ],
+          "properties": {
+            
+          },
+          "additionalProperties": true
+        },
+        {
+          "type": "object",
+          "required": [
+            "wasm"
+          ],
+          "properties": {
+            "wasm": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": true
+        }
+      ],
+      "properties": {
+        "build": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "id": {
+          "description": "ID is optional if there is only a single operator.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OperatorId"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "inputs": {
+          "default": {},
+          "type": "object",
+          "additionalProperties": true
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "outputs": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DataId"
+          },
+          "uniqueItems": true
+        },
+        "send_stdout_as": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "UserInputMapping": {
+      "type": "object",
+      "required": [
+        "output",
+        "source"
+      ],
+      "properties": {
+        "output": {
+          "$ref": "#/definitions/DataId"
+        },
+        "source": {
+          "$ref": "#/definitions/NodeId"
+        }
+      }
+    }
+  }
+}

--- a/libraries/core/src/bin/generate_schema.rs
+++ b/libraries/core/src/bin/generate_schema.rs
@@ -7,6 +7,11 @@ fn main() -> () {
     let schema = schema_for!(Descriptor);
     let raw_schema =
         serde_json::to_string_pretty(&schema).expect("Could not serialize schema to json");
+
+    // Add additional properties to True, as #[derive(transparent)] of enums are not well handled.
+    //
+    // 'OneOf' such as Custom Nodes, Operators and Single Operators overwrite property values of the initial struct `Nodes`.`
+    // which make the original properties such as `id` and `name` not validated by IDE extensions.
     let raw_schema = raw_schema.replace(
         "\"additionalProperties\": false",
         "\"additionalProperties\": true",
@@ -25,7 +30,6 @@ fn main() -> () {
           }",
         "true",
     );
-    let raw_schema = raw_schema.replace("Descriptor", "dora-rs specification");
 
     // Get the Cargo root manifest directory
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is not set");

--- a/libraries/core/src/bin/generate_schema.rs
+++ b/libraries/core/src/bin/generate_schema.rs
@@ -1,0 +1,37 @@
+use std::{env, path::Path};
+
+use dora_core::descriptor::Descriptor;
+use schemars::schema_for;
+
+fn main() -> () {
+    let schema = schema_for!(Descriptor);
+    let raw_schema =
+        serde_json::to_string_pretty(&schema).expect("Could not serialize schema to json");
+    let raw_schema = raw_schema.replace(
+        "\"additionalProperties\": false",
+        "\"additionalProperties\": true",
+    );
+
+    // Remove `serde(from=` nested field as they are not handled properly by `schemars`
+    let raw_schema = raw_schema.replace(
+        "\"python\": {
+              \"$ref\": \"#/definitions/PythonSource\"
+            }",
+        "",
+    );
+    let raw_schema = raw_schema.replace(
+        "{
+            \"$ref\": \"#/definitions/Input\"
+          }",
+        "true",
+    );
+
+    // Get the Cargo root manifest directory
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is not set");
+
+    // Create the path for the new file next to Cargo.toml
+    let new_file_path = Path::new(&manifest_dir).join("dora-schema.json");
+
+    // write to file
+    std::fs::write(new_file_path, raw_schema).expect("Could not write schema to file");
+}

--- a/libraries/core/src/bin/generate_schema.rs
+++ b/libraries/core/src/bin/generate_schema.rs
@@ -25,6 +25,7 @@ fn main() -> () {
           }",
         "true",
     );
+    let raw_schema = raw_schema.replace("Descriptor", "dora-rs specification");
 
     // Get the Cargo root manifest directory
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is not set");

--- a/libraries/core/src/config.rs
+++ b/libraries/core/src/config.rs
@@ -245,8 +245,25 @@ pub fn format_duration(interval: Duration) -> FormattedDuration {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct NodeRunConfig {
+    /// Inputs for the nodes as a map from input ID to input configuration
+    ///
+    /// e.g.
+    ///
+    /// inputs:
+    ///
+    ///   example_input: example_node/example_output1
+    ///
     #[serde(default)]
     pub inputs: BTreeMap<DataId, Input>,
+    /// Outputs as a list of outputs.
+    ///
+    /// e.g.
+    ///
+    /// outputs:
+    ///
+    ///  - output_1
+    ///
+    ///  - output_2
     #[serde(default)]
     pub outputs: BTreeSet<DataId>,
 }

--- a/libraries/core/src/config.rs
+++ b/libraries/core/src/config.rs
@@ -1,4 +1,5 @@
 use once_cell::sync::OnceCell;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::{
     borrow::Borrow,
@@ -9,7 +10,9 @@ use std::{
     time::Duration,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
+)]
 pub struct NodeId(String);
 
 impl FromStr for NodeId {
@@ -32,7 +35,9 @@ impl std::fmt::Display for NodeId {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
+)]
 pub struct OperatorId(String);
 
 impl FromStr for OperatorId {
@@ -61,7 +66,9 @@ impl AsRef<str> for OperatorId {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
+)]
 pub struct DataId(String);
 
 impl From<DataId> for String {
@@ -114,7 +121,7 @@ impl Borrow<str> for DataId {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
 pub enum InputMapping {
     Timer { interval: Duration },
     User(UserInputMapping),
@@ -214,7 +221,7 @@ impl<'de> Deserialize<'de> for InputMapping {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
 pub struct UserInputMapping {
     pub source: NodeId,
     pub output: DataId,
@@ -236,7 +243,7 @@ pub fn format_duration(interval: Duration) -> FormattedDuration {
     FormattedDuration(interval)
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct NodeRunConfig {
     #[serde(default)]
     pub inputs: BTreeMap<DataId, Input>,
@@ -244,7 +251,7 @@ pub struct NodeRunConfig {
     pub outputs: BTreeSet<DataId>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields, from = "InputDef", into = "InputDef")]
 pub struct Input {
     pub mapping: InputMapping,
@@ -294,7 +301,7 @@ impl From<InputDef> for Input {
     }
 }
 
-#[derive(Debug, Default, Serialize, Deserialize, Clone)]
+#[derive(Debug, Default, Serialize, Deserialize, JsonSchema, Clone)]
 #[serde(deny_unknown_fields, rename_all = "lowercase")]
 pub struct CommunicationConfig {
     // see https://github.com/dtolnay/serde-yaml/issues/298
@@ -303,16 +310,15 @@ pub struct CommunicationConfig {
         with = "serde_yaml::with::singleton_map",
         rename = "_unstable_local"
     )]
+    #[schemars(with = "String")]
     pub local: LocalCommunicationConfig,
     #[serde(
         default,
         with = "serde_yaml::with::singleton_map",
         rename = "_unstable_remote"
     )]
+    #[schemars(with = "String")]
     pub remote: RemoteCommunicationConfig,
-
-    // deprecated
-    pub zenoh: Option<serde_yaml::Value>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]

--- a/libraries/core/src/config.rs
+++ b/libraries/core/src/config.rs
@@ -245,7 +245,7 @@ pub fn format_duration(interval: Duration) -> FormattedDuration {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct NodeRunConfig {
-    /// Inputs for the nodes as a map from input ID to input configuration
+    /// Inputs for the nodes as a map from input ID to `node_id/output_id`.
     ///
     /// e.g.
     ///
@@ -255,7 +255,7 @@ pub struct NodeRunConfig {
     ///
     #[serde(default)]
     pub inputs: BTreeMap<DataId, Input>,
-    /// Outputs as a list of outputs.
+    /// List of output IDs.
     ///
     /// e.g.
     ///

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -126,13 +126,19 @@ pub struct Deploy {
     pub machine: Option<String>,
 }
 
+/// Dora Node
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct Node {
+    /// Node identifier
     pub id: NodeId,
+    /// Node name
     pub name: Option<String>,
+    /// Description of the node
     pub description: Option<String>,
+    /// Environment variables
     pub env: Option<BTreeMap<String, EnvValue>>,
 
+    /// Unstable machine deployment configuration
     #[serde(default, rename = "_unstable_deploy")]
     pub deploy: Deploy,
 
@@ -342,12 +348,25 @@ pub struct PythonOperatorConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct CustomNode {
+    /// Path of the source code
+    ///
+    /// If you want to use a specific `conda` environment.
+    /// Provide the python path within the source.
+    ///
+    /// source: /home/peter/miniconda3/bin/python
+    ///
+    /// args: some_node.py
+    ///
+    /// Source can match any executable in PATH.
     pub source: String,
+    /// Args for the executable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub args: Option<String>,
+    /// Environment variables for the custom nodes
     pub envs: Option<BTreeMap<String, EnvValue>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub build: Option<String>,
+    /// Send stdout and stderr to another node
     #[serde(skip_serializing_if = "Option::is_none")]
     pub send_stdout_as: Option<String>,
 

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -20,9 +20,12 @@ pub const SHELL_SOURCE: &str = "shell";
 /// Dataflow description
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
+#[schemars(title = "dora-rs specification")]
 pub struct Descriptor {
+    #[schemars(skip)]
     #[serde(default)]
     pub communication: CommunicationConfig,
+    #[schemars(skip)]
     #[serde(default, rename = "_unstable_deploy")]
     pub deploy: Deploy,
     pub nodes: Vec<Node>,
@@ -139,6 +142,7 @@ pub struct Node {
     pub env: Option<BTreeMap<String, EnvValue>>,
 
     /// Unstable machine deployment configuration
+    #[schemars(skip)]
     #[serde(default, rename = "_unstable_deploy")]
     pub deploy: Deploy,
 
@@ -266,6 +270,7 @@ pub struct OperatorConfig {
 pub enum OperatorSource {
     SharedLibrary(String),
     Python(PythonSource),
+    #[schemars(skip)]
     Wasm(String),
 }
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -2,6 +2,7 @@ use crate::config::{
     CommunicationConfig, DataId, Input, InputMapping, NodeId, NodeRunConfig, OperatorId,
 };
 use eyre::{bail, eyre, Context, Result};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_with_expand_env::with_expand_envs;
 use std::{
@@ -12,19 +13,16 @@ use std::{
 };
 use tracing::warn;
 pub use visualize::collect_dora_timers;
-
 mod validate;
 mod visualize;
 pub const SHELL_SOURCE: &str = "shell";
 
 /// Dataflow description
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Descriptor {
     #[serde(default)]
     pub communication: CommunicationConfig,
-    // deprecated
-    pub daemon_config: Option<serde_yaml::Value>,
     #[serde(default, rename = "_unstable_deploy")]
     pub deploy: Deploy,
     pub nodes: Vec<Node>,
@@ -122,13 +120,13 @@ impl Descriptor {
     }
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Deploy {
     pub machine: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct Node {
     pub id: NodeId,
     pub name: Option<String>,
@@ -142,7 +140,7 @@ pub struct Node {
     pub kind: NodeKind,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum NodeKind {
     /// Dora runtime node
@@ -217,20 +215,20 @@ pub enum CoreNodeKind {
     Custom(CustomNode),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(transparent)]
 pub struct RuntimeNode {
     pub operators: Vec<OperatorDefinition>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
 pub struct OperatorDefinition {
     pub id: OperatorId,
     #[serde(flatten)]
     pub config: OperatorConfig,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
 pub struct SingleOperatorDefinition {
     /// ID is optional if there is only a single operator.
     pub id: Option<OperatorId>,
@@ -238,7 +236,7 @@ pub struct SingleOperatorDefinition {
     pub config: OperatorConfig,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
 pub struct OperatorConfig {
     pub name: Option<String>,
     pub description: Option<String>,
@@ -257,14 +255,14 @@ pub struct OperatorConfig {
     pub send_stdout_as: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub enum OperatorSource {
     SharedLibrary(String),
     Python(PythonSource),
     Wasm(String),
 }
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(
     deny_unknown_fields,
     from = "PythonSourceDef",
@@ -275,7 +273,7 @@ pub struct PythonSource {
     pub conda_env: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(untagged)]
 pub enum PythonSourceDef {
     SourceOnly(String),
@@ -342,7 +340,7 @@ pub struct PythonOperatorConfig {
     pub outputs: BTreeSet<DataId>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct CustomNode {
     pub source: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -357,7 +355,7 @@ pub struct CustomNode {
     pub run_config: NodeRunConfig,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(untagged)]
 pub enum EnvValue {
     #[serde(deserialize_with = "with_expand_envs")]

--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -13,13 +13,6 @@ use super::{resolve_path, Descriptor, SHELL_SOURCE};
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn check_dataflow(dataflow: &Descriptor, working_dir: &Path) -> eyre::Result<()> {
-    if dataflow.daemon_config.is_some() {
-        tracing::warn!("ignoring deprecated `daemon_config` key in dataflow config");
-    }
-    if dataflow.communication.zenoh.is_some() {
-        tracing::warn!("ignoring deprecated `communication.zenoh` key in dataflow config");
-    }
-
     let nodes = dataflow.resolve_aliases_and_set_defaults();
     let mut has_python_operator = false;
 


### PR DESCRIPTION
In an effort to address, developers difficulty in discovering dora-rs functionality, I'm adding a way to:
- Generate JSON Schema: https://json-schema.org/ using `schemars`
- JSON Schema can be interpreted by many extension to give us YAML validation, documentation and suggestions. In my case, I'm using VSCode most popular extension for YAML which is  [`redhat.vscode-yaml`](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)

This enables:
- Documentation that is directly generated from the docstring within the rust code
- Suggestions from the field defined in the Rust Code
- Validation of type

## Edge cases

### Failure to auto-generate schema

Some auto-generation of some of our rust struct definition did not work. They are the one that are using `serde(from=` such as:
https://github.com/dora-rs/dora/blob/558fa149079368a7abca01e35f23aafcff86f575/libraries/core/src/descriptor/mod.rs#L270-L280

In those case I had to remove the validation so that our current dataflow passes.

### Failure to manage #[serde(flatten)] with additional properties

In our Nodes definition, we are using #[serde(flatten)] of an enum with some additional properties.

In order to validate those additional properties, I had to set `additionalproperties` to true.

# Demo



https://github.com/dora-rs/dora/assets/22787340/4839f248-e9cc-47e6-a015-4ca53226864e

