### PR TITLE
V0.3.4

### DIFF
--- a/.github/workflows/pip-release.yml
+++ b/.github/workflows/pip-release.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.8"
       - name: Install dependencies
         run: |
           pip install patchelf --upgrade
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.8"
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "benchmark-example-node"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "benchmark-example-sink"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1700,7 +1700,7 @@ dependencies = [
 
 [[package]]
 name = "communication-layer-pub-sub"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "flume 0.10.14",
  "zenoh",
@@ -1708,7 +1708,7 @@ dependencies = [
 
 [[package]]
 name = "communication-layer-request-reply"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 
 [[package]]
 name = "concurrent-queue"
@@ -2241,7 +2241,7 @@ dependencies = [
 
 [[package]]
 name = "dora-arrow-convert"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "arrow",
  "eyre",
@@ -2249,7 +2249,7 @@ dependencies = [
 
 [[package]]
 name = "dora-cli"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "bat",
  "clap 4.4.6",
@@ -2280,7 +2280,7 @@ dependencies = [
 
 [[package]]
 name = "dora-coordinator"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "ctrlc",
  "dora-core",
@@ -2298,7 +2298,7 @@ dependencies = [
 
 [[package]]
 name = "dora-core"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "aligned-vec",
  "dora-message",
@@ -2315,7 +2315,7 @@ dependencies = [
 
 [[package]]
 name = "dora-daemon"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "aligned-vec",
  "async-trait",
@@ -2344,7 +2344,7 @@ dependencies = [
 
 [[package]]
 name = "dora-download"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "eyre",
  "reqwest",
@@ -2372,7 +2372,7 @@ dependencies = [
 
 [[package]]
 name = "dora-message"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "arrow-data",
  "arrow-schema",
@@ -2383,7 +2383,7 @@ dependencies = [
 
 [[package]]
 name = "dora-metrics"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "eyre",
  "opentelemetry 0.22.0",
@@ -2394,7 +2394,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -2416,7 +2416,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-c"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "arrow-array",
  "dora-node-api",
@@ -2426,7 +2426,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-cxx"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-python"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "arrow",
  "dora-node-api",
@@ -2460,7 +2460,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "dora-arrow-convert",
  "dora-operator-api-macros",
@@ -2469,14 +2469,14 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-c"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "dora-operator-api-types",
 ]
 
 [[package]]
 name = "dora-operator-api-cxx"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -2485,7 +2485,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-macros"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2494,7 +2494,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-python"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -2508,7 +2508,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-types"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "arrow",
  "dora-arrow-convert",
@@ -2517,7 +2517,7 @@ dependencies = [
 
 [[package]]
 name = "dora-record"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "chrono",
  "dora-node-api",
@@ -2529,7 +2529,7 @@ dependencies = [
 
 [[package]]
 name = "dora-rerun"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "dora-runtime"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -2620,7 +2620,7 @@ dependencies = [
 
 [[package]]
 name = "dora-tracing"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "eyre",
  "opentelemetry 0.18.0",
@@ -4826,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "multiple-daemons-example-node"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4837,14 +4837,14 @@ dependencies = [
 
 [[package]]
 name = "multiple-daemons-example-operator"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "dora-operator-api",
 ]
 
 [[package]]
 name = "multiple-daemons-example-sink"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -7867,7 +7867,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-node"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -7878,7 +7878,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-sink"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -7886,7 +7886,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-status-node"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -7905,7 +7905,7 @@ dependencies = [
 
 [[package]]
 name = "rust-ros2-dataflow-example-node"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "dora-node-api",
  "dora-ros2-bridge",
@@ -8387,7 +8387,7 @@ dependencies = [
 
 [[package]]
 name = "shared-memory-server"
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 dependencies = [
  "bincode",
  "eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "benchmark-example-node"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "benchmark-example-sink"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1700,7 +1700,7 @@ dependencies = [
 
 [[package]]
 name = "communication-layer-pub-sub"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "flume 0.10.14",
  "zenoh",
@@ -1708,7 +1708,7 @@ dependencies = [
 
 [[package]]
 name = "communication-layer-request-reply"
-version = "0.3.4-rc2"
+version = "0.3.4"
 
 [[package]]
 name = "concurrent-queue"
@@ -2241,7 +2241,7 @@ dependencies = [
 
 [[package]]
 name = "dora-arrow-convert"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "arrow",
  "eyre",
@@ -2249,7 +2249,7 @@ dependencies = [
 
 [[package]]
 name = "dora-cli"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "bat",
  "clap 4.4.6",
@@ -2280,7 +2280,7 @@ dependencies = [
 
 [[package]]
 name = "dora-coordinator"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "ctrlc",
  "dora-core",
@@ -2298,7 +2298,7 @@ dependencies = [
 
 [[package]]
 name = "dora-core"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "aligned-vec",
  "dora-message",
@@ -2315,7 +2315,7 @@ dependencies = [
 
 [[package]]
 name = "dora-daemon"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "aligned-vec",
  "async-trait",
@@ -2344,7 +2344,7 @@ dependencies = [
 
 [[package]]
 name = "dora-download"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "eyre",
  "reqwest",
@@ -2372,7 +2372,7 @@ dependencies = [
 
 [[package]]
 name = "dora-message"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "arrow-data",
  "arrow-schema",
@@ -2383,7 +2383,7 @@ dependencies = [
 
 [[package]]
 name = "dora-metrics"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "eyre",
  "opentelemetry 0.22.0",
@@ -2394,7 +2394,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -2416,7 +2416,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-c"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "arrow-array",
  "dora-node-api",
@@ -2426,7 +2426,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-cxx"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-python"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "arrow",
  "dora-node-api",
@@ -2460,7 +2460,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "dora-arrow-convert",
  "dora-operator-api-macros",
@@ -2469,14 +2469,14 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-c"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "dora-operator-api-types",
 ]
 
 [[package]]
 name = "dora-operator-api-cxx"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -2485,7 +2485,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-macros"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2494,7 +2494,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-python"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -2508,7 +2508,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-types"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "arrow",
  "dora-arrow-convert",
@@ -2517,7 +2517,7 @@ dependencies = [
 
 [[package]]
 name = "dora-record"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "dora-node-api",
@@ -2529,7 +2529,7 @@ dependencies = [
 
 [[package]]
 name = "dora-rerun"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "dora-runtime"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -2620,7 +2620,7 @@ dependencies = [
 
 [[package]]
 name = "dora-tracing"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "eyre",
  "opentelemetry 0.18.0",
@@ -4826,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "multiple-daemons-example-node"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4837,14 +4837,14 @@ dependencies = [
 
 [[package]]
 name = "multiple-daemons-example-operator"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "dora-operator-api",
 ]
 
 [[package]]
 name = "multiple-daemons-example-sink"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -7867,7 +7867,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-node"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -7878,7 +7878,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-sink"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -7886,7 +7886,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-status-node"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -7905,7 +7905,7 @@ dependencies = [
 
 [[package]]
 name = "rust-ros2-dataflow-example-node"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "dora-node-api",
  "dora-ros2-bridge",
@@ -8387,7 +8387,7 @@ dependencies = [
 
 [[package]]
 name = "shared-memory-server"
-version = "0.3.4-rc2"
+version = "0.3.4"
 dependencies = [
  "bincode",
  "eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "benchmark-example-node"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "benchmark-example-sink"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1700,7 +1700,7 @@ dependencies = [
 
 [[package]]
 name = "communication-layer-pub-sub"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "flume 0.10.14",
  "zenoh",
@@ -1708,7 +1708,7 @@ dependencies = [
 
 [[package]]
 name = "communication-layer-request-reply"
-version = "0.3.3"
+version = "0.3.4-rc1"
 
 [[package]]
 name = "concurrent-queue"
@@ -2241,7 +2241,7 @@ dependencies = [
 
 [[package]]
 name = "dora-arrow-convert"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "arrow",
  "eyre",
@@ -2249,7 +2249,7 @@ dependencies = [
 
 [[package]]
 name = "dora-cli"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "bat",
  "clap 4.4.6",
@@ -2280,7 +2280,7 @@ dependencies = [
 
 [[package]]
 name = "dora-coordinator"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "ctrlc",
  "dora-core",
@@ -2298,7 +2298,7 @@ dependencies = [
 
 [[package]]
 name = "dora-core"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "aligned-vec",
  "dora-message",
@@ -2315,7 +2315,7 @@ dependencies = [
 
 [[package]]
 name = "dora-daemon"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "aligned-vec",
  "async-trait",
@@ -2344,7 +2344,7 @@ dependencies = [
 
 [[package]]
 name = "dora-download"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "eyre",
  "reqwest",
@@ -2372,7 +2372,7 @@ dependencies = [
 
 [[package]]
 name = "dora-message"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "arrow-data",
  "arrow-schema",
@@ -2383,7 +2383,7 @@ dependencies = [
 
 [[package]]
 name = "dora-metrics"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "eyre",
  "opentelemetry 0.22.0",
@@ -2394,7 +2394,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -2416,7 +2416,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-c"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "arrow-array",
  "dora-node-api",
@@ -2426,7 +2426,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-cxx"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-python"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "arrow",
  "dora-node-api",
@@ -2460,7 +2460,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "dora-arrow-convert",
  "dora-operator-api-macros",
@@ -2469,14 +2469,14 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-c"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "dora-operator-api-types",
 ]
 
 [[package]]
 name = "dora-operator-api-cxx"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -2485,7 +2485,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-macros"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2494,7 +2494,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-python"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -2508,7 +2508,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-types"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "arrow",
  "dora-arrow-convert",
@@ -2517,7 +2517,7 @@ dependencies = [
 
 [[package]]
 name = "dora-record"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "chrono",
  "dora-node-api",
@@ -2529,7 +2529,7 @@ dependencies = [
 
 [[package]]
 name = "dora-rerun"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "dora-runtime"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -2620,7 +2620,7 @@ dependencies = [
 
 [[package]]
 name = "dora-tracing"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "eyre",
  "opentelemetry 0.18.0",
@@ -4826,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "multiple-daemons-example-node"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4837,14 +4837,14 @@ dependencies = [
 
 [[package]]
 name = "multiple-daemons-example-operator"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "dora-operator-api",
 ]
 
 [[package]]
 name = "multiple-daemons-example-sink"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -7867,7 +7867,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-node"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -7878,7 +7878,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-sink"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -7886,7 +7886,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-status-node"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -7905,7 +7905,7 @@ dependencies = [
 
 [[package]]
 name = "rust-ros2-dataflow-example-node"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "dora-node-api",
  "dora-ros2-bridge",
@@ -8387,7 +8387,7 @@ dependencies = [
 
 [[package]]
 name = "shared-memory-server"
-version = "0.3.3"
+version = "0.3.4-rc1"
 dependencies = [
  "bincode",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,31 +38,31 @@ members = [
 
 [workspace.package]
 # Make sure to also bump `apis/node/python/__init__.py` version.
-version = "0.3.4-rc2"
+version = "0.3.4"
 description = "`dora` goal is to be a low latency, composable, and distributed data flow."
 documentation = "https://dora.carsmos.ai"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-dora-node-api = { version = "0.3.4-rc2", path = "apis/rust/node", default-features = false }
-dora-node-api-python = { version = "0.3.4-rc2", path = "apis/python/node", default-features = false }
-dora-operator-api = { version = "0.3.4-rc2", path = "apis/rust/operator", default-features = false }
-dora-operator-api-macros = { version = "0.3.4-rc2", path = "apis/rust/operator/macros" }
-dora-operator-api-types = { version = "0.3.4-rc2", path = "apis/rust/operator/types" }
-dora-operator-api-python = { version = "0.3.4-rc2", path = "apis/python/operator" }
-dora-operator-api-c = { version = "0.3.4-rc2", path = "apis/c/operator" }
-dora-node-api-c = { version = "0.3.4-rc2", path = "apis/c/node" }
-dora-core = { version = "0.3.4-rc2", path = "libraries/core" }
-dora-arrow-convert = { version = "0.3.4-rc2", path = "libraries/arrow-convert" }
-dora-tracing = { version = "0.3.4-rc2", path = "libraries/extensions/telemetry/tracing" }
-dora-metrics = { version = "0.3.4-rc2", path = "libraries/extensions/telemetry/metrics" }
-dora-download = { version = "0.3.4-rc2", path = "libraries/extensions/download" }
-shared-memory-server = { version = "0.3.4-rc2", path = "libraries/shared-memory-server" }
-communication-layer-request-reply = { version = "0.3.4-rc2", path = "libraries/communication-layer/request-reply" }
-dora-message = { version = "0.3.4-rc2", path = "libraries/message" }
-dora-runtime = { version = "0.3.4-rc2", path = "binaries/runtime" }
-dora-daemon = { version = "0.3.4-rc2", path = "binaries/daemon" }
-dora-coordinator = { version = "0.3.4-rc2", path = "binaries/coordinator" }
+dora-node-api = { version = "0.3.4", path = "apis/rust/node", default-features = false }
+dora-node-api-python = { version = "0.3.4", path = "apis/python/node", default-features = false }
+dora-operator-api = { version = "0.3.4", path = "apis/rust/operator", default-features = false }
+dora-operator-api-macros = { version = "0.3.4", path = "apis/rust/operator/macros" }
+dora-operator-api-types = { version = "0.3.4", path = "apis/rust/operator/types" }
+dora-operator-api-python = { version = "0.3.4", path = "apis/python/operator" }
+dora-operator-api-c = { version = "0.3.4", path = "apis/c/operator" }
+dora-node-api-c = { version = "0.3.4", path = "apis/c/node" }
+dora-core = { version = "0.3.4", path = "libraries/core" }
+dora-arrow-convert = { version = "0.3.4", path = "libraries/arrow-convert" }
+dora-tracing = { version = "0.3.4", path = "libraries/extensions/telemetry/tracing" }
+dora-metrics = { version = "0.3.4", path = "libraries/extensions/telemetry/metrics" }
+dora-download = { version = "0.3.4", path = "libraries/extensions/download" }
+shared-memory-server = { version = "0.3.4", path = "libraries/shared-memory-server" }
+communication-layer-request-reply = { version = "0.3.4", path = "libraries/communication-layer/request-reply" }
+dora-message = { version = "0.3.4", path = "libraries/message" }
+dora-runtime = { version = "0.3.4", path = "binaries/runtime" }
+dora-daemon = { version = "0.3.4", path = "binaries/daemon" }
+dora-coordinator = { version = "0.3.4", path = "binaries/coordinator" }
 dora-ros2-bridge = { path = "libraries/extensions/ros2-bridge" }
 dora-ros2-bridge-msg-gen = { path = "libraries/extensions/ros2-bridge/msg-gen" }
 dora-ros2-bridge-python = { path = "libraries/extensions/ros2-bridge/python" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,31 +38,31 @@ members = [
 
 [workspace.package]
 # Make sure to also bump `apis/node/python/__init__.py` version.
-version = "0.3.3"
+version = "0.3.4-rc1"
 description = "`dora` goal is to be a low latency, composable, and distributed data flow."
 documentation = "https://dora.carsmos.ai"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-dora-node-api = { version = "0.3.3", path = "apis/rust/node", default-features = false }
-dora-node-api-python = { version = "0.3.3", path = "apis/python/node", default-features = false }
-dora-operator-api = { version = "0.3.3", path = "apis/rust/operator", default-features = false }
-dora-operator-api-macros = { version = "0.3.3", path = "apis/rust/operator/macros" }
-dora-operator-api-types = { version = "0.3.3", path = "apis/rust/operator/types" }
-dora-operator-api-python = { version = "0.3.3", path = "apis/python/operator" }
-dora-operator-api-c = { version = "0.3.3", path = "apis/c/operator" }
-dora-node-api-c = { version = "0.3.3", path = "apis/c/node" }
-dora-core = { version = "0.3.3", path = "libraries/core" }
-dora-arrow-convert = { version = "0.3.3", path = "libraries/arrow-convert" }
-dora-tracing = { version = "0.3.3", path = "libraries/extensions/telemetry/tracing" }
-dora-metrics = { version = "0.3.3", path = "libraries/extensions/telemetry/metrics" }
-dora-download = { version = "0.3.3", path = "libraries/extensions/download" }
-shared-memory-server = { version = "0.3.3", path = "libraries/shared-memory-server" }
-communication-layer-request-reply = { version = "0.3.3", path = "libraries/communication-layer/request-reply" }
-dora-message = { version = "0.3.3", path = "libraries/message" }
-dora-runtime = { version = "0.3.3", path = "binaries/runtime" }
-dora-daemon = { version = "0.3.3", path = "binaries/daemon" }
-dora-coordinator = { version = "0.3.3", path = "binaries/coordinator" }
+dora-node-api = { version = "0.3.4-rc1", path = "apis/rust/node", default-features = false }
+dora-node-api-python = { version = "0.3.4-rc1", path = "apis/python/node", default-features = false }
+dora-operator-api = { version = "0.3.4-rc1", path = "apis/rust/operator", default-features = false }
+dora-operator-api-macros = { version = "0.3.4-rc1", path = "apis/rust/operator/macros" }
+dora-operator-api-types = { version = "0.3.4-rc1", path = "apis/rust/operator/types" }
+dora-operator-api-python = { version = "0.3.4-rc1", path = "apis/python/operator" }
+dora-operator-api-c = { version = "0.3.4-rc1", path = "apis/c/operator" }
+dora-node-api-c = { version = "0.3.4-rc1", path = "apis/c/node" }
+dora-core = { version = "0.3.4-rc1", path = "libraries/core" }
+dora-arrow-convert = { version = "0.3.4-rc1", path = "libraries/arrow-convert" }
+dora-tracing = { version = "0.3.4-rc1", path = "libraries/extensions/telemetry/tracing" }
+dora-metrics = { version = "0.3.4-rc1", path = "libraries/extensions/telemetry/metrics" }
+dora-download = { version = "0.3.4-rc1", path = "libraries/extensions/download" }
+shared-memory-server = { version = "0.3.4-rc1", path = "libraries/shared-memory-server" }
+communication-layer-request-reply = { version = "0.3.4-rc1", path = "libraries/communication-layer/request-reply" }
+dora-message = { version = "0.3.4-rc1", path = "libraries/message" }
+dora-runtime = { version = "0.3.4-rc1", path = "binaries/runtime" }
+dora-daemon = { version = "0.3.4-rc1", path = "binaries/daemon" }
+dora-coordinator = { version = "0.3.4-rc1", path = "binaries/coordinator" }
 dora-ros2-bridge = { path = "libraries/extensions/ros2-bridge" }
 dora-ros2-bridge-msg-gen = { path = "libraries/extensions/ros2-bridge/msg-gen" }
 dora-ros2-bridge-python = { path = "libraries/extensions/ros2-bridge/python" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,31 +38,31 @@ members = [
 
 [workspace.package]
 # Make sure to also bump `apis/node/python/__init__.py` version.
-version = "0.3.4-rc1"
+version = "0.3.4-rc2"
 description = "`dora` goal is to be a low latency, composable, and distributed data flow."
 documentation = "https://dora.carsmos.ai"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-dora-node-api = { version = "0.3.4-rc1", path = "apis/rust/node", default-features = false }
-dora-node-api-python = { version = "0.3.4-rc1", path = "apis/python/node", default-features = false }
-dora-operator-api = { version = "0.3.4-rc1", path = "apis/rust/operator", default-features = false }
-dora-operator-api-macros = { version = "0.3.4-rc1", path = "apis/rust/operator/macros" }
-dora-operator-api-types = { version = "0.3.4-rc1", path = "apis/rust/operator/types" }
-dora-operator-api-python = { version = "0.3.4-rc1", path = "apis/python/operator" }
-dora-operator-api-c = { version = "0.3.4-rc1", path = "apis/c/operator" }
-dora-node-api-c = { version = "0.3.4-rc1", path = "apis/c/node" }
-dora-core = { version = "0.3.4-rc1", path = "libraries/core" }
-dora-arrow-convert = { version = "0.3.4-rc1", path = "libraries/arrow-convert" }
-dora-tracing = { version = "0.3.4-rc1", path = "libraries/extensions/telemetry/tracing" }
-dora-metrics = { version = "0.3.4-rc1", path = "libraries/extensions/telemetry/metrics" }
-dora-download = { version = "0.3.4-rc1", path = "libraries/extensions/download" }
-shared-memory-server = { version = "0.3.4-rc1", path = "libraries/shared-memory-server" }
-communication-layer-request-reply = { version = "0.3.4-rc1", path = "libraries/communication-layer/request-reply" }
-dora-message = { version = "0.3.4-rc1", path = "libraries/message" }
-dora-runtime = { version = "0.3.4-rc1", path = "binaries/runtime" }
-dora-daemon = { version = "0.3.4-rc1", path = "binaries/daemon" }
-dora-coordinator = { version = "0.3.4-rc1", path = "binaries/coordinator" }
+dora-node-api = { version = "0.3.4-rc2", path = "apis/rust/node", default-features = false }
+dora-node-api-python = { version = "0.3.4-rc2", path = "apis/python/node", default-features = false }
+dora-operator-api = { version = "0.3.4-rc2", path = "apis/rust/operator", default-features = false }
+dora-operator-api-macros = { version = "0.3.4-rc2", path = "apis/rust/operator/macros" }
+dora-operator-api-types = { version = "0.3.4-rc2", path = "apis/rust/operator/types" }
+dora-operator-api-python = { version = "0.3.4-rc2", path = "apis/python/operator" }
+dora-operator-api-c = { version = "0.3.4-rc2", path = "apis/c/operator" }
+dora-node-api-c = { version = "0.3.4-rc2", path = "apis/c/node" }
+dora-core = { version = "0.3.4-rc2", path = "libraries/core" }
+dora-arrow-convert = { version = "0.3.4-rc2", path = "libraries/arrow-convert" }
+dora-tracing = { version = "0.3.4-rc2", path = "libraries/extensions/telemetry/tracing" }
+dora-metrics = { version = "0.3.4-rc2", path = "libraries/extensions/telemetry/metrics" }
+dora-download = { version = "0.3.4-rc2", path = "libraries/extensions/download" }
+shared-memory-server = { version = "0.3.4-rc2", path = "libraries/shared-memory-server" }
+communication-layer-request-reply = { version = "0.3.4-rc2", path = "libraries/communication-layer/request-reply" }
+dora-message = { version = "0.3.4-rc2", path = "libraries/message" }
+dora-runtime = { version = "0.3.4-rc2", path = "binaries/runtime" }
+dora-daemon = { version = "0.3.4-rc2", path = "binaries/daemon" }
+dora-coordinator = { version = "0.3.4-rc2", path = "binaries/coordinator" }
 dora-ros2-bridge = { path = "libraries/extensions/ros2-bridge" }
 dora-ros2-bridge-msg-gen = { path = "libraries/extensions/ros2-bridge/msg-gen" }
 dora-ros2-bridge-python = { path = "libraries/extensions/ros2-bridge/python" }

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v0.3.4 (2024-05-17)
+
+## What's Changed
+
+- Remove `cxx_build` call, which is no longer used by @phil-opp in https://github.com/dora-rs/dora/pull/470
+- Update `ros2-client` to latest version by @phil-opp in https://github.com/dora-rs/dora/pull/457
+- Configurable bind addrs by @Michael-J-Ward in https://github.com/dora-rs/dora/pull/471
+- Simple warning fixes by @Michael-J-Ward in https://github.com/dora-rs/dora/pull/477
+- Adding `dora-rerun` as a visualization tool by @haixuanTao in https://github.com/dora-rs/dora/pull/479
+- Fix Clippy and RERUN_MEMORY_LIMIT env variable default by @haixuanTao in https://github.com/dora-rs/dora/pull/490
+- Fix CI build errors by @phil-opp in https://github.com/dora-rs/dora/pull/491
+- Use `resolver = 2` for in workspace in Rust template by @phil-opp in https://github.com/dora-rs/dora/pull/492
+- Add grace duration and kill process by @haixuanTao in https://github.com/dora-rs/dora/pull/487
+- Simplify parsing of `AMENT_PREFIX_PATH` by @haixuanTao in https://github.com/dora-rs/dora/pull/489
+- Convert rust example to node by @Michael-J-Ward in https://github.com/dora-rs/dora/pull/494
+- Adding python IDE typing by @haixuanTao in https://github.com/dora-rs/dora/pull/493
+- Fix: Wait until dora daemon is connected to coordinator on `dora up` by @phil-opp in https://github.com/dora-rs/dora/pull/496
+
+## New Contributors
+
+- @Michael-J-Ward made their first contribution in https://github.com/dora-rs/dora/pull/471
+
+**Full Changelog**: https://github.com/dora-rs/dora/compare/v0.3.3...v0.3.4
+
 ## v0.3.3 (2024-04-08)
 
 ## What's Changed

--- a/README.md
+++ b/README.md
@@ -160,17 +160,17 @@ For more info on installation, check out [our guide](https://www.dora-rs.ai/docs
 1. Install the example python dependencies:
 
 ```bash
-pip install -r https://raw.githubusercontent.com/dora-rs/dora/v0.3.3/examples/python-operator-dataflow/requirements.txt
+pip install -r https://raw.githubusercontent.com/dora-rs/dora/v0.3.4/examples/python-operator-dataflow/requirements.txt
 ```
 
 2. Get some example operators:
 
 ```bash
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.3/examples/python-operator-dataflow/webcam.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.3/examples/python-operator-dataflow/plot.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.3/examples/python-operator-dataflow/utils.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.3/examples/python-operator-dataflow/object_detection.py
-wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.3/examples/python-operator-dataflow/dataflow.yml
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.4/examples/python-operator-dataflow/webcam.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.4/examples/python-operator-dataflow/plot.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.4/examples/python-operator-dataflow/utils.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.4/examples/python-operator-dataflow/object_detection.py
+wget https://raw.githubusercontent.com/dora-rs/dora/v0.3.4/examples/python-operator-dataflow/dataflow.yml
 ```
 
 3. Start the dataflow


### PR DESCRIPTION
Bump version to 0.3.4 

- Remove `cxx_build` call, which is no longer used by @phil-opp in https://github.com/dora-rs/dora/pull/470
- Update `ros2-client` to latest version by @phil-opp in https://github.com/dora-rs/dora/pull/457
- Configurable bind addrs by @Michael-J-Ward in https://github.com/dora-rs/dora/pull/471
- Simple warning fixes by @Michael-J-Ward in https://github.com/dora-rs/dora/pull/477
- Adding `dora-rerun` as a visualization tool by @haixuanTao in https://github.com/dora-rs/dora/pull/479
- Fix Clippy and RERUN_MEMORY_LIMIT env variable default by @haixuanTao in https://github.com/dora-rs/dora/pull/490
- Fix CI build errors by @phil-opp in https://github.com/dora-rs/dora/pull/491
- Use `resolver = 2` for in workspace in Rust template by @phil-opp in https://github.com/dora-rs/dora/pull/492
- Add grace duration and kill process by @haixuanTao in https://github.com/dora-rs/dora/pull/487
- Simplify parsing of `AMENT_PREFIX_PATH` by @haixuanTao in https://github.com/dora-rs/dora/pull/489
- Convert rust example to node by @Michael-J-Ward in https://github.com/dora-rs/dora/pull/494
- Adding python IDE typing by @haixuanTao in https://github.com/dora-rs/dora/pull/493
- Fix: Wait until dora daemon is connected to coordinator on `dora up` by @phil-opp in https://github.com/dora-rs/dora/pull/496

