### PR TITLE
Pretty Print Rust object when called from Python print

### DIFF
--- a/apis/python/operator/src/lib.rs
+++ b/apis/python/operator/src/lib.rs
@@ -5,6 +5,7 @@ use pyo3::{exceptions::PyLookupError, prelude::*, types::PyDict};
 
 /// Dora Event
 #[pyclass]
+#[derive(Debug)]
 pub struct PyEvent {
     event: MergedEvent<PyObject>,
     data: Option<ArrayRef>,
@@ -55,6 +56,10 @@ impl PyEvent {
             MergedEvent::Dora(_) => None,
             MergedEvent::External(event) => Some(event),
         }
+    }
+
+    fn __str__(&self) -> PyResult<String> {
+        Ok(format!("{:#?}", &self.event))
     }
 }
 

--- a/apis/rust/node/src/event_stream/merged.rs
+++ b/apis/rust/node/src/event_stream/merged.rs
@@ -1,6 +1,7 @@
 use futures::{Stream, StreamExt};
 use futures_concurrency::stream::Merge;
 
+#[derive(Debug)]
 pub enum MergedEvent<E> {
     Dora(super::Event),
     External(E),


### PR DESCRIPTION
This will make it possible to print dora event object within python for debugging purposes:

Ex:

```python
print(dora_event)
```

```rust
Dora(
    Input {
        id: DataId(
            "image",
        ),
        metadata: Metadata {
            metadata_version: 0,
            timestamp: 664b45b2bfe51ff0/FC05639A0C7747D6BF87A894CEF83935,
            type_info: ArrowTypeInfo {
                data_type: UInt8,
                len: 65786,
                null_count: 0,
                validity: None,
                offset: 0,
                buffer_offsets: [
                    BufferOffset {
                        offset: 0,
                        len: 65786,
                    },
                ],
                child_data: [],
            },
            parameters: MetadataParameters {
                watermark: 0,
                deadline: 0,
                open_telemetry_context: "traceparent:00-392f4871c115bdaa8dd1e316187a03c5-55debb0964f25de8-01;tracestate:;",
            },
        },
        data: ArrowData(
            PrimitiveArray<UInt8>
            [
              255,
              216,
              255,
              224,
              0,
              16,
              74,
              70,
              73,
              70,
              ...65766 elements...,
              123,
              86,
              240,
              106,
              196,
              74,
              61,
              79,
              255,
              217,
            ],
        ),
    },
)
```