### PR TITLE
chore: Support RISCV64

### DIFF
--- a/libraries/extensions/download/Cargo.toml
+++ b/libraries/extensions/download/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 
 [dependencies]
 eyre = "0.6.8"
-reqwest = { version = "0.11.12", default-features = false, features = [
+reqwest = { version = "0.12.4", default-features = false, features = [
     "rustls-tls",
 ] }
 tokio = { version = "1.24.2", features = ["fs"] }


### PR DESCRIPTION
The file libraries/extensions/download/Cargo.toml has a reqwest dependency with a version number of 0.11.12. 
This package enables the rustld-tls feature. rustls depends on ring, and ring already supports RISCV64 in the latest version 0.17.

Upgrade reqwest to the latest version 0.12.4 to support RISCV64.

Reviewed-by: LyonRust

For screenshots of the verified content, see [https://echoli.cn/dora/riscv64.html](https://echoli.cn/dora/riscv64.html)