### PR TITLE
Use dependabot for automatic lockfile updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    versioning-strategy: "lockfile-only"
+    allow:
+      - dependency-type: "all"
+    groups:
+      version-updates:
+        patterns:
+          - "*"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Opens weekly PRs to keep our dependencies up-to-date.