### PR TITLE
Make dora cli connect to remote coordinator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,12 +272,12 @@ jobs:
           sleep 10
           dora stop --name ci-rust-test  --grace-duration 5s
           dora destroy
-          export IP="$(curl ipinfo.io/ip)" 
+          export IP=127.0.0.1
           dora up --coordinator-addr $IP:6012
           dora list --coordinator-addr $IP:6012
           dora start dataflow.yml --name ci-rust-test --coordinator-addr $IP:6012
           sleep 10
-          dora stop --name ci-rust-test  --grace-duration 5 --coordinator-addr $IP:6012
+          dora stop --name ci-rust-test  --grace-duration 5s --coordinator-addr $IP:6012
           dora destroy --coordinator-addr $IP:6012
           
       - name: "Test CLI (Python)"
@@ -302,12 +302,12 @@ jobs:
           sleep 10
           dora stop --name ci-python-test  --grace-duration 5s
           dora destroy
-          export IP="$(curl ipinfo.io/ip)" 
+          export IP=127.0.0.1
           dora up --coordinator-addr $IP:6012
           dora list --coordinator-addr $IP:6012
           dora start dataflow.yml --name ci-rust-test --coordinator-addr $IP:6012
           sleep 10
-          dora stop --name ci-rust-test  --grace-duration 5 --coordinator-addr $IP:6012
+          dora stop --name ci-rust-test  --grace-duration 5s --coordinator-addr $IP:6012
           dora destroy --coordinator-addr $IP:6012
 
   clippy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,13 +272,6 @@ jobs:
           sleep 10
           dora stop --name ci-rust-test  --grace-duration 5s
           dora destroy
-          export IP=127.0.0.1
-          dora up --coordinator-addr $IP:6012
-          dora list --coordinator-addr $IP:6012
-          dora start dataflow.yml --name ci-rust-test --coordinator-addr $IP:6012
-          sleep 10
-          dora stop --name ci-rust-test  --grace-duration 5s --coordinator-addr $IP:6012
-          dora destroy --coordinator-addr $IP:6012
           
       - name: "Test CLI (Python)"
         timeout-minutes: 30
@@ -302,13 +295,6 @@ jobs:
           sleep 10
           dora stop --name ci-python-test  --grace-duration 5s
           dora destroy
-          export IP=127.0.0.1
-          dora up --coordinator-addr $IP:6012
-          dora list --coordinator-addr $IP:6012
-          dora start dataflow.yml --name ci-rust-test --coordinator-addr $IP:6012
-          sleep 10
-          dora stop --name ci-rust-test  --grace-duration 5s --coordinator-addr $IP:6012
-          dora destroy --coordinator-addr $IP:6012
 
   clippy:
     name: "Clippy"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,6 +272,14 @@ jobs:
           sleep 10
           dora stop --name ci-rust-test  --grace-duration 5s
           dora destroy
+          export IP="$(curl ipinfo.io/ip)" 
+          dora up --coordinator-addr $IP:6012
+          dora list --coordinator-addr $IP:6012
+          dora start dataflow.yml --name ci-rust-test --coordinator-addr $IP:6012
+          sleep 10
+          dora stop --name ci-rust-test  --grace-duration 5 --coordinator-addr $IP:6012
+          dora destroy --coordinator-addr $IP:6012
+          
       - name: "Test CLI (Python)"
         timeout-minutes: 30
         # fail-fast by using bash shell explictly
@@ -294,6 +302,13 @@ jobs:
           sleep 10
           dora stop --name ci-python-test  --grace-duration 5s
           dora destroy
+          export IP="$(curl ipinfo.io/ip)" 
+          dora up --coordinator-addr $IP:6012
+          dora list --coordinator-addr $IP:6012
+          dora start dataflow.yml --name ci-rust-test --coordinator-addr $IP:6012
+          sleep 10
+          dora stop --name ci-rust-test  --grace-duration 5 --coordinator-addr $IP:6012
+          dora destroy --coordinator-addr $IP:6012
 
   clippy:
     name: "Clippy"

--- a/binaries/cli/src/check.rs
+++ b/binaries/cli/src/check.rs
@@ -4,11 +4,11 @@ use dora_core::topics::{ControlRequest, ControlRequestReply};
 use eyre::{bail, Context};
 use std::{
     io::{IsTerminal, Write},
-    net::SocketAddr,
+    net::IpAddr,
 };
 use termcolor::{Color, ColorChoice, ColorSpec, WriteColor};
 
-pub fn check_environment(coordinator_addr: Option<SocketAddr>) -> eyre::Result<()> {
+pub fn check_environment(coordinator_addr: Option<IpAddr>) -> eyre::Result<()> {
     let mut error_occured = false;
 
     let color_choice = if std::io::stdout().is_terminal() {

--- a/binaries/cli/src/check.rs
+++ b/binaries/cli/src/check.rs
@@ -1,11 +1,15 @@
 use crate::connect_to_coordinator;
 use communication_layer_request_reply::TcpRequestReplyConnection;
+use dora_core::topics::control_socket_addr;
 use dora_core::topics::{ControlRequest, ControlRequestReply};
 use eyre::{bail, Context};
-use std::io::{IsTerminal, Write};
+use std::{
+    io::{IsTerminal, Write},
+    net::SocketAddr,
+};
 use termcolor::{Color, ColorChoice, ColorSpec, WriteColor};
 
-pub fn check_environment() -> eyre::Result<()> {
+pub fn check_environment(coordinator_addr: Option<SocketAddr>) -> eyre::Result<()> {
     let mut error_occured = false;
 
     let color_choice = if std::io::stdout().is_terminal() {
@@ -17,7 +21,8 @@ pub fn check_environment() -> eyre::Result<()> {
 
     // check whether coordinator is running
     write!(stdout, "Dora Coordinator: ")?;
-    let mut session = match connect_to_coordinator() {
+    let coordination_addr = coordinator_addr.unwrap_or_else(|| control_socket_addr());
+    let mut session = match connect_to_coordinator(coordination_addr) {
         Ok(session) => {
             let _ = stdout.set_color(ColorSpec::new().set_fg(Some(Color::Green)));
             writeln!(stdout, "ok")?;

--- a/binaries/cli/src/check.rs
+++ b/binaries/cli/src/check.rs
@@ -1,6 +1,5 @@
 use crate::connect_to_coordinator;
 use communication_layer_request_reply::TcpRequestReplyConnection;
-use dora_core::topics::control_socket_addr;
 use dora_core::topics::{ControlRequest, ControlRequestReply};
 use eyre::{bail, Context};
 use std::{
@@ -21,8 +20,7 @@ pub fn check_environment(coordinator_addr: Option<SocketAddr>) -> eyre::Result<(
 
     // check whether coordinator is running
     write!(stdout, "Dora Coordinator: ")?;
-    let coordination_addr = coordinator_addr.unwrap_or_else(|| control_socket_addr());
-    let mut session = match connect_to_coordinator(coordination_addr) {
+    let mut session = match connect_to_coordinator(coordinator_addr) {
         Ok(session) => {
             let _ = stdout.set_color(ColorSpec::new().set_fg(Some(Color::Green)));
             writeln!(stdout, "ok")?;

--- a/binaries/cli/src/main.rs
+++ b/binaries/cli/src/main.rs
@@ -45,6 +45,7 @@ enum Command {
     Check {
         #[clap(long)]
         dataflow: Option<PathBuf>,
+        #[clap(long)]
         coordinator_addr: Option<IpAddr>,
     },
     /// Generate a visualization of the given graph using mermaid.js. Use --open to open browser.

--- a/binaries/cli/src/main.rs
+++ b/binaries/cli/src/main.rs
@@ -5,7 +5,8 @@ use dora_coordinator::Event;
 use dora_core::{
     descriptor::Descriptor,
     topics::{
-        control_socket_addr, ControlRequest, ControlRequestReply, DataflowId, DORA_COORDINATOR_PORT_CONTROL, DORA_COORDINATOR_PORT_DEFAULT
+        control_socket_addr, ControlRequest, ControlRequestReply, DataflowId,
+        DORA_COORDINATOR_PORT_CONTROL, DORA_COORDINATOR_PORT_DEFAULT,
     },
 };
 use dora_daemon::Daemon;
@@ -500,7 +501,10 @@ fn connect_to_coordinator(
     coordinator_addr: Option<IpAddr>,
 ) -> std::io::Result<Box<TcpRequestReplyConnection>> {
     if let Some(coordinator_addr) = coordinator_addr {
-        TcpLayer::new().connect(SocketAddr::new(coordinator_addr, DORA_COORDINATOR_PORT_CONTROL))
+        TcpLayer::new().connect(SocketAddr::new(
+            coordinator_addr,
+            DORA_COORDINATOR_PORT_CONTROL,
+        ))
     } else {
         TcpLayer::new().connect(control_socket_addr())
     }

--- a/binaries/cli/src/up.rs
+++ b/binaries/cli/src/up.rs
@@ -5,10 +5,7 @@ use std::{fs, net::IpAddr, path::Path, process::Command, time::Duration};
 #[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
 struct UpConfig {}
 
-pub(crate) fn up(
-    config_path: Option<&Path>,
-    coordinator_addr: Option<IpAddr>,
-) -> eyre::Result<()> {
+pub(crate) fn up(config_path: Option<&Path>, coordinator_addr: Option<IpAddr>) -> eyre::Result<()> {
     let UpConfig {} = parse_dora_config(config_path)?;
     let mut session = match connect_to_coordinator(coordinator_addr) {
         Ok(session) => session,

--- a/binaries/cli/src/up.rs
+++ b/binaries/cli/src/up.rs
@@ -1,13 +1,13 @@
 use crate::{check::daemon_running, connect_to_coordinator};
 use dora_core::topics::ControlRequest;
 use eyre::Context;
-use std::{fs, net::SocketAddr, path::Path, process::Command, time::Duration};
+use std::{fs, net::IpAddr, path::Path, process::Command, time::Duration};
 #[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
 struct UpConfig {}
 
 pub(crate) fn up(
     config_path: Option<&Path>,
-    coordinator_addr: Option<SocketAddr>,
+    coordinator_addr: Option<IpAddr>,
 ) -> eyre::Result<()> {
     let UpConfig {} = parse_dora_config(config_path)?;
     let mut session = match connect_to_coordinator(coordinator_addr) {
@@ -50,7 +50,7 @@ pub(crate) fn up(
 
 pub(crate) fn destroy(
     config_path: Option<&Path>,
-    coordinator_addr: Option<SocketAddr>,
+    coordinator_addr: Option<IpAddr>,
 ) -> Result<(), eyre::ErrReport> {
     let UpConfig {} = parse_dora_config(config_path)?;
     match connect_to_coordinator(coordinator_addr) {

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -13,11 +13,15 @@ use crate::{
 };
 
 pub const DORA_COORDINATOR_PORT_DEFAULT: u16 = 0xD02A;
+pub const DORA_COORDINATOR_PORT_CONTROL: u16 = 0x177C;
 
 pub const MANUAL_STOP: &str = "dora/stop";
 
 pub fn control_socket_addr() -> SocketAddr {
-    SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 6012)
+    SocketAddr::new(
+        Ipv4Addr::new(127, 0, 0, 1).into(),
+        DORA_COORDINATOR_PORT_CONTROL,
+    )
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]


### PR DESCRIPTION
To make CLI coordinator connection configurable, such as 
`dora start dataflow.yaml --coordinator-addr IP`
Allow users to pass a parameter when dora up, dora start, and dora list --coordinator-address to specify the address or the default address control_socket_addr().

To test this PR:
```
# In a remote terminal
dora up
# In a local terminal
dora list --coordinator-addr REMOTE_IP
dora start dataflow.yaml --coordinator-addr REMOTE_IP
dora logs [DATAFLOW] <NODE> --coordinator-addr REMOTE_IP
dora destroy --coordinator-addr REMOTE_IP
dora check --coordinator-addr REMOTE_IP
```
 now, there are no CLI CI test to test it.