### PR TITLE
Run dynamic node 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,7 +318,7 @@ jobs:
           dora start dataflow.yml --name ci-python-test
           sleep 10
           dora stop --name ci-python-test  --grace-duration 5s
-          pip install -r ../examples/python-dataflow/requirements.txt --cache-dir=.
+          pip install opencv-python
           dora start ../examples/python-dataflow/dataflow_dynamic.yml --name ci-python-dynamic
           python ../examples/python-dataflow/plot_dynamic.py
           sleep 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,6 +318,7 @@ jobs:
           dora start dataflow.yml --name ci-python-test
           sleep 10
           dora stop --name ci-python-test  --grace-duration 5s
+          pip install -r ../examples/python-dataflow/requirements.txt
           dora start ../examples/python-dataflow/dataflow_dynamic.yml --name ci-python-dynamic
           python ../examples/python-dataflow/plot_dynamic.py
           sleep 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,9 +318,15 @@ jobs:
           dora start dataflow.yml --name ci-python-test
           sleep 10
           dora stop --name ci-python-test  --grace-duration 5s
-          pip install -r ../examples/python-dataflow/requirements.txt
-          dora start ../examples/python-dataflow/dataflow_dynamic.yml --name ci-python-dynamic
-          python ../examples/python-dataflow/plot_dynamic.py
+          cd ..
+          if [ ! -d "examples/.env/bin" ]; then # Reuse Example venv
+            mv examples/.env/Scripts examples/.env/bin    # venv is placed under `Scripts` on Windows
+          fi
+          source examples/.env/bin/activate
+          dora destroy # Restart the daemon with the current virtual environment 
+          dora up 
+          dora start examples/python-dataflow/dataflow_dynamic.yml --name ci-python-dynamic
+          python examples/python-dataflow/plot_dynamic.py
           sleep 5
           dora stop --name ci-python-test  --grace-duration 5s
           dora destroy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,8 +289,9 @@ jobs:
           dora start dataflow.yml --name ci-rust-test
           sleep 10
           dora stop --name ci-rust-test  --grace-duration 5s
-          dora build ../examples/rust-dataflow/dataflow_dynamic.yml
-          dora start ../examples/rust-dataflow/dataflow_dynamic.yml --name ci-rust-dynamic
+          cd ..
+          dora build examples/rust-dataflow/dataflow_dynamic.yml
+          dora start examples/rust-dataflow/dataflow_dynamic.yml --name ci-rust-dynamic
           cargo run -p rust-dataflow-example-sink-dynamic
           sleep 5
           dora stop --name ci-rust-dynamic  --grace-duration 5s

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,15 +318,9 @@ jobs:
           dora start dataflow.yml --name ci-python-test
           sleep 10
           dora stop --name ci-python-test  --grace-duration 5s
-          cd ..
-          if [ ! -d "examples/.env/bin" ]; then # Reuse Example venv
-            mv examples/.env/Scripts examples/.env/bin    # venv is placed under `Scripts` on Windows
-          fi
-          source examples/.env/bin/activate
-          dora destroy # Restart the daemon with the current virtual environment 
-          dora up 
-          dora start examples/python-dataflow/dataflow_dynamic.yml --name ci-python-dynamic
-          python examples/python-dataflow/plot_dynamic.py
+          pip install -r ../examples/python-dataflow/requirements.txt --cache-dir=.
+          dora start ../examples/python-dataflow/dataflow_dynamic.yml --name ci-python-dynamic
+          python ../examples/python-dataflow/plot_dynamic.py
           sleep 5
           dora stop --name ci-python-test  --grace-duration 5s
           dora destroy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,8 +289,13 @@ jobs:
           dora start dataflow.yml --name ci-rust-test
           sleep 10
           dora stop --name ci-rust-test  --grace-duration 5s
+          dora build ../examples/rust-dataflow/dataflow_dynamic.yml
+          dora start ../examples/rust-dataflow/dataflow_dynamic.yml --name ci-rust-dynamic
+          cargo run -p rust-dataflow-example-sink-dynamic
+          sleep 5
+          dora stop --name ci-rust-dynamic  --grace-duration 5s
           dora destroy
-          
+
       - name: "Test CLI (Python)"
         timeout-minutes: 30
         # fail-fast by using bash shell explictly
@@ -311,6 +316,10 @@ jobs:
           dora list
           dora start dataflow.yml --name ci-python-test
           sleep 10
+          dora stop --name ci-python-test  --grace-duration 5s
+          dora start ../examples/python-dataflow/dataflow_dynamic.yml --name ci-python-dynamic
+          python ../examples/python-dataflow/plot_dynamic.py
+          sleep 5
           dora stop --name ci-python-test  --grace-duration 5s
           dora destroy
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2395,6 +2395,7 @@ dependencies = [
  "futures",
  "futures-concurrency",
  "futures-timer",
+ "serde_json",
  "serde_yaml 0.8.26",
  "shared-memory-server",
  "shared_memory_extended",
@@ -8032,6 +8033,14 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-sink"
+version = "0.3.4"
+dependencies = [
+ "dora-node-api",
+ "eyre",
+]
+
+[[package]]
+name = "rust-dataflow-example-sink-dynamic"
 version = "0.3.4"
 dependencies = [
  "dora-node-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "examples/rust-dataflow/node",
     "examples/rust-dataflow/status-node",
     "examples/rust-dataflow/sink",
+    "examples/rust-dataflow/sink-dynamic",
     "examples/rust-ros2-dataflow/node",
     "examples/benchmark/node",
     "examples/benchmark/sink",

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -35,9 +35,10 @@ impl Node {
     #[new]
     pub fn new(node_id: Option<String>) -> eyre::Result<Self> {
         let (node, events) = if let Some(node_id) = node_id {
-            DoraNode::init_from_node_id(NodeId::from(node_id))?
+            DoraNode::init_flexible(NodeId::from(node_id))
+                .context("Could not setup node from node id. Make sure to have a running dataflow with this dynamic node")?
         } else {
-            DoraNode::init_from_env()?
+            DoraNode::init_from_env().context("Couldn not initiate node from environment variable. For dynamic node, please add a node id in the initialization function.")?
         };
 
         Ok(Node {

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -3,6 +3,7 @@
 use std::time::Duration;
 
 use arrow::pyarrow::{FromPyArrow, ToPyArrow};
+use dora_node_api::dora_core::config::NodeId;
 use dora_node_api::merged::{MergeExternalSend, MergedEvent};
 use dora_node_api::{DoraNode, EventStream};
 use dora_operator_api_python::{pydict_to_metadata, PyEvent};
@@ -32,8 +33,12 @@ pub struct Node {
 #[pymethods]
 impl Node {
     #[new]
-    pub fn new() -> eyre::Result<Self> {
-        let (node, events) = DoraNode::init_from_env()?;
+    pub fn new(node_id: Option<String>) -> eyre::Result<Self> {
+        let (node, events) = if let Some(node_id) = node_id {
+            DoraNode::init_from_node_id(NodeId::from(node_id))?
+        } else {
+            DoraNode::init_from_env()?
+        };
 
         Ok(Node {
             events: Events::Dora(events),

--- a/apis/rust/node/Cargo.toml
+++ b/apis/rust/node/Cargo.toml
@@ -26,6 +26,7 @@ futures-concurrency = "7.3.0"
 futures-timer = "3.0.2"
 dora-arrow-convert = { workspace = true }
 aligned-vec = "0.5.0"
+serde_json = "1.0.86"
 
 [dev-dependencies]
 tokio = { version = "1.24.2", features = ["rt"] }

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -12,7 +12,7 @@ use dora_core::{
     daemon_messages::{DaemonRequest, DataMessage, DataflowId, DropToken, NodeConfig, Timestamped},
     descriptor::Descriptor,
     message::{uhlc, ArrowTypeInfo, Metadata, MetadataParameters},
-    topics::{DORA_DAEMON_DYNAMIC_NODE_PORT_DEFAULT, LOCALHOST},
+    topics::{DORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT, LOCALHOST},
 };
 
 use eyre::{bail, WrapErr};
@@ -90,7 +90,7 @@ impl DoraNode {
             return Self::init(node_config);
         }
 
-        let daemon_address = (LOCALHOST, DORA_DAEMON_DYNAMIC_NODE_PORT_DEFAULT).into();
+        let daemon_address = (LOCALHOST, DORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT).into();
 
         let mut channel =
             DaemonChannel::new_tcp(daemon_address).context("Could not connect to the daemon")?;

--- a/binaries/cli/src/main.rs
+++ b/binaries/cli/src/main.rs
@@ -379,7 +379,7 @@ fn run() -> eyre::Result<()> {
             match (uuid, name) {
                 (Some(uuid), _) => stop_dataflow(uuid, grace_duration, &mut *session)?,
                 (None, Some(name)) => stop_dataflow_by_name(name, grace_duration, &mut *session)?,
-                (None, None) => stop_dataflow_dynamic(grace_duration, &mut *session)?,
+                (None, None) => stop_dataflow_interactive(grace_duration, &mut *session)?,
             }
         }
         Command::Destroy {
@@ -480,7 +480,7 @@ fn start_dataflow(
     }
 }
 
-fn stop_dataflow_dynamic(
+fn stop_dataflow_interactive(
     grace_duration: Option<Duration>,
     session: &mut TcpRequestReplyConnection,
 ) -> eyre::Result<()> {

--- a/binaries/cli/src/main.rs
+++ b/binaries/cli/src/main.rs
@@ -6,7 +6,7 @@ use dora_core::{
     descriptor::Descriptor,
     topics::{
         ControlRequest, ControlRequestReply, DataflowId, DORA_COORDINATOR_PORT_CONTROL_DEFAULT,
-        DORA_COORDINATOR_PORT_DEFAULT, DORA_DAEMON_DYNAMIC_NODE_PORT_DEFAULT,
+        DORA_COORDINATOR_PORT_DEFAULT, DORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT,
     },
 };
 use dora_daemon::Daemon;
@@ -176,10 +176,10 @@ enum Command {
         machine_id: Option<String>,
         /// The inter daemon IP address and port this daemon will bind to.
         #[clap(long, default_value_t = SocketAddr::new(LISTEN_WILDCARD, 0))]
-        addr: SocketAddr,
-        /// The dynamic node port this daemon will bind to.
-        #[clap(long, default_value_t = DORA_DAEMON_DYNAMIC_NODE_PORT_DEFAULT)]
-        dynamic_node_port: u16,
+        inter_daemon_addr: SocketAddr,
+        /// Local listen port for event such as dynamic node.
+        #[clap(long, default_value_t = DORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT)]
+        local_listen_port: u16,
         /// Address and port number of the dora coordinator
         #[clap(long, default_value_t = SocketAddr::new(LOCALHOST, DORA_COORDINATOR_PORT_DEFAULT))]
         coordinator_addr: SocketAddr,
@@ -413,8 +413,8 @@ fn run() -> eyre::Result<()> {
         }
         Command::Daemon {
             coordinator_addr,
-            addr,
-            dynamic_node_port,
+            inter_daemon_addr,
+            local_listen_port,
             machine_id,
             run_dataflow,
         } => {
@@ -439,7 +439,7 @@ fn run() -> eyre::Result<()> {
                         if coordinator_addr.ip() == LOCALHOST {
                             tracing::info!("Starting in local mode");
                         }
-                        Daemon::run(coordinator_addr, machine_id.unwrap_or_default(), addr, dynamic_node_port).await
+                        Daemon::run(coordinator_addr, machine_id.unwrap_or_default(), inter_daemon_addr, local_listen_port).await
                     }
                 }
             })

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -655,7 +655,7 @@ async fn send_heartbeat_message(
         inner: DaemonCoordinatorEvent::Heartbeat,
         timestamp,
     })
-    .unwrap();
+    .context("Could not serialize heartbeat message")?;
 
     tcp_send(connection, &message)
         .await

--- a/binaries/daemon/src/dynamic_node.rs
+++ b/binaries/daemon/src/dynamic_node.rs
@@ -1,0 +1,138 @@
+use crate::tcp_utils::{tcp_receive, tcp_send};
+use dora_core::daemon_messages::{DaemonReply, DaemonRequest, DynamicNodeEvent, Timestamped};
+use eyre::Context;
+use std::{io::ErrorKind, net::SocketAddr};
+use tokio::{
+    net::{TcpListener, TcpStream},
+    sync::oneshot,
+};
+
+#[derive(Debug)]
+pub struct DynamicNodeEventWrapper {
+    pub event: DynamicNodeEvent,
+    pub reply_tx: oneshot::Sender<Option<DaemonReply>>,
+}
+
+pub async fn spawn_listener_loop(
+    bind: SocketAddr,
+    machine_id: String,
+    events_tx: flume::Sender<Timestamped<DynamicNodeEventWrapper>>,
+) -> eyre::Result<u16> {
+    let socket = match TcpListener::bind(bind).await {
+        Ok(socket) => socket,
+        Err(err) => {
+            return Err(eyre::Report::new(err).wrap_err("failed to create local TCP listener"))
+        }
+    };
+    let listen_port = socket
+        .local_addr()
+        .wrap_err("failed to get local addr of socket")?
+        .port();
+
+    tokio::spawn(async move {
+        listener_loop(socket, events_tx).await;
+        tracing::debug!("Dynamic node listener loop finished for machine `{machine_id}`");
+    });
+
+    Ok(listen_port)
+}
+
+async fn listener_loop(
+    listener: TcpListener,
+    events_tx: flume::Sender<Timestamped<DynamicNodeEventWrapper>>,
+) {
+    loop {
+        match listener
+            .accept()
+            .await
+            .wrap_err("failed to accept new connection")
+        {
+            Err(err) => {
+                tracing::info!("{err}");
+            }
+            Ok((connection, _)) => {
+                tokio::spawn(handle_connection_loop(connection, events_tx.clone()));
+            }
+        }
+    }
+}
+
+async fn handle_connection_loop(
+    mut connection: TcpStream,
+    events_tx: flume::Sender<Timestamped<DynamicNodeEventWrapper>>,
+) {
+    if let Err(err) = connection.set_nodelay(true) {
+        tracing::warn!("failed to set nodelay for connection: {err}");
+    }
+
+    loop {
+        match receive_message(&mut connection).await {
+            Ok(Some(Timestamped {
+                inner: DaemonRequest::NodeConfig { node_id },
+                timestamp,
+            })) => {
+                let (reply_tx, reply_rx) = oneshot::channel();
+                if events_tx
+                    .send_async(Timestamped {
+                        inner: DynamicNodeEventWrapper {
+                            event: DynamicNodeEvent::NodeConfig { node_id },
+                            reply_tx,
+                        },
+                        timestamp,
+                    })
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+                let Ok(reply) = reply_rx.await else {
+                    tracing::warn!("daemon sent no reply");
+                    continue;
+                };
+                if let Some(reply) = reply {
+                    let serialized = match serde_json::to_vec(&reply)
+                        .wrap_err("failed to serialize DaemonReply")
+                    {
+                        Ok(r) => r,
+                        Err(err) => {
+                            tracing::error!("{err:?}");
+                            continue;
+                        }
+                    };
+                    if let Err(err) = tcp_send(&mut connection, &serialized).await {
+                        tracing::warn!("failed to send reply to dynamic node: {err}");
+                        continue;
+                    };
+                }
+            }
+            Ok(None) => break,
+            Err(err) => {
+                tracing::warn!("{err:?}");
+                break;
+            }
+            _ => tracing::warn!(
+                "Unexpected Daemon Request that is not yet by Additional dynamic node controls"
+            ),
+        }
+    }
+}
+
+async fn receive_message(
+    connection: &mut TcpStream,
+) -> eyre::Result<Option<Timestamped<DaemonRequest>>> {
+    let raw = match tcp_receive(connection).await {
+        Ok(raw) => raw,
+        Err(err) => match err.kind() {
+            ErrorKind::UnexpectedEof
+            | ErrorKind::ConnectionAborted
+            | ErrorKind::ConnectionReset => return Ok(None),
+            _other => {
+                return Err(err)
+                    .context("unexpected I/O error while trying to receive DynamicNodeEvent")
+            }
+        },
+    };
+    bincode::deserialize(&raw)
+        .wrap_err("failed to deserialize DynamicNodeEvent")
+        .map(Some)
+}

--- a/binaries/daemon/src/local_listener.rs
+++ b/binaries/daemon/src/local_listener.rs
@@ -31,7 +31,7 @@ pub async fn spawn_listener_loop(
 
     tokio::spawn(async move {
         listener_loop(socket, events_tx).await;
-        tracing::debug!("Dynamic node listener loop finished for machine `{machine_id}`");
+        tracing::debug!("Local listener loop finished for machine `{machine_id}`");
     });
 
     Ok(listen_port)
@@ -100,7 +100,7 @@ async fn handle_connection_loop(
                         }
                     };
                     if let Err(err) = tcp_send(&mut connection, &serialized).await {
-                        tracing::warn!("failed to send reply to dynamic node: {err}");
+                        tracing::warn!("failed to send reply: {err}");
                         continue;
                     };
                 }
@@ -111,7 +111,7 @@ async fn handle_connection_loop(
                 break;
             }
             _ => tracing::warn!(
-                "Unexpected Daemon Request that is not yet by Additional dynamic node controls"
+                "Unexpected Daemon Request that is not yet by Additional local listener controls"
             ),
         }
     }
@@ -128,11 +128,11 @@ async fn receive_message(
             | ErrorKind::ConnectionReset => return Ok(None),
             _other => {
                 return Err(err)
-                    .context("unexpected I/O error while trying to receive DynamicNodeEvent")
+                    .context("unexpected I/O error while trying to receive DaemonRequest")
             }
         },
     };
     bincode::deserialize(&raw)
-        .wrap_err("failed to deserialize DynamicNodeEvent")
+        .wrap_err("failed to deserialize DaemonRequest")
         .map(Some)
 }

--- a/binaries/daemon/src/node_communication/mod.rs
+++ b/binaries/daemon/src/node_communication/mod.rs
@@ -6,6 +6,7 @@ use dora_core::{
         Timestamped,
     },
     message::uhlc,
+    topics::LOCALHOST,
 };
 use eyre::{eyre, Context};
 use futures::{future, task, Future};
@@ -13,7 +14,6 @@ use shared_memory_server::{ShmemConf, ShmemServer};
 use std::{
     collections::{BTreeMap, VecDeque},
     mem,
-    net::Ipv4Addr,
     sync::Arc,
     task::Poll,
 };
@@ -39,8 +39,7 @@ pub async fn spawn_listener_loop(
 ) -> eyre::Result<DaemonCommunication> {
     match config {
         LocalCommunicationConfig::Tcp => {
-            let localhost = Ipv4Addr::new(127, 0, 0, 1);
-            let socket = match TcpListener::bind((localhost, 0)).await {
+            let socket = match TcpListener::bind((LOCALHOST, 0)).await {
                 Ok(socket) => socket,
                 Err(err) => {
                     return Err(
@@ -343,6 +342,12 @@ impl Listener {
         match message.inner {
             DaemonRequest::Register { .. } => {
                 let reply = DaemonReply::Result(Err("unexpected register message".into()));
+                self.send_reply(reply, connection)
+                    .await
+                    .wrap_err("failed to send register reply")?;
+            }
+            DaemonRequest::NodeConfig { .. } => {
+                let reply = DaemonReply::Result(Err("unexpected node config message".into()));
                 self.send_reply(reply, connection)
                     .await
                     .wrap_err("failed to send register reply")?;

--- a/binaries/daemon/src/spawn.rs
+++ b/binaries/daemon/src/spawn.rs
@@ -1,15 +1,15 @@
 use crate::{
-    log, node_communication::spawn_listener_loop, node_inputs, runtime_node_inputs,
-    runtime_node_outputs, DoraEvent, Event, NodeExitStatus, OutputId,
+    log, node_communication::spawn_listener_loop, node_inputs, DoraEvent, Event, NodeExitStatus,
+    OutputId, RunningNode,
 };
 use aligned_vec::{AVec, ConstAlign};
 use dora_arrow_convert::IntoArrow;
 use dora_core::{
-    config::{DataId, NodeRunConfig},
+    config::DataId,
     daemon_messages::{DataMessage, DataflowId, NodeConfig, RuntimeConfig, Timestamped},
     descriptor::{
         resolve_path, source_is_url, Descriptor, OperatorDefinition, OperatorSource, PythonSource,
-        ResolvedNode, SHELL_SOURCE,
+        ResolvedNode, DYNAMIC_SOURCE, SHELL_SOURCE,
     },
     get_python_path,
     message::uhlc::HLC,
@@ -42,7 +42,7 @@ pub async fn spawn_node(
     daemon_tx: mpsc::Sender<Timestamped<Event>>,
     dataflow_descriptor: Descriptor,
     clock: Arc<HLC>,
-) -> eyre::Result<u32> {
+) -> eyre::Result<RunningNode> {
     let node_id = node.id.clone();
     tracing::debug!("Spawning node `{dataflow_id}/{node_id}`");
 
@@ -63,9 +63,24 @@ pub async fn spawn_node(
         .send_stdout_as()
         .context("Could not resolve `send_stdout_as` configuration")?;
 
+    let node_config = NodeConfig {
+        dataflow_id,
+        node_id: node_id.clone(),
+        run_config: node.kind.run_config(),
+        daemon_communication,
+        dataflow_descriptor,
+        dynamic: node.kind.dynamic(),
+    };
+
     let mut child = match node.kind {
         dora_core::descriptor::CoreNodeKind::Custom(n) => {
             let mut command = match n.source.as_str() {
+                DYNAMIC_SOURCE => {
+                    return Ok(RunningNode {
+                        pid: None,
+                        node_config,
+                    });
+                }
                 SHELL_SOURCE => {
                     if cfg!(target_os = "windows") {
                         let mut cmd = tokio::process::Command::new("cmd");
@@ -117,17 +132,11 @@ pub async fn spawn_node(
 
             command.current_dir(working_dir);
             command.stdin(Stdio::null());
-            let node_config = NodeConfig {
-                dataflow_id,
-                node_id: node_id.clone(),
-                run_config: n.run_config.clone(),
-                daemon_communication,
-                dataflow_descriptor,
-            };
 
             command.env(
                 "DORA_NODE_CONFIG",
-                serde_yaml::to_string(&node_config).wrap_err("failed to serialize node config")?,
+                serde_yaml::to_string(&node_config.clone())
+                    .wrap_err("failed to serialize node config")?,
             );
             // Injecting the env variable defined in the `yaml` into
             // the node runtime.
@@ -223,16 +232,7 @@ pub async fn spawn_node(
             command.current_dir(working_dir);
 
             let runtime_config = RuntimeConfig {
-                node: NodeConfig {
-                    dataflow_id,
-                    node_id: node_id.clone(),
-                    run_config: NodeRunConfig {
-                        inputs: runtime_node_inputs(&n),
-                        outputs: runtime_node_outputs(&n),
-                    },
-                    daemon_communication,
-                    dataflow_descriptor,
-                },
+                node: node_config.clone(),
                 operators: n.operators,
             };
             command.env(
@@ -271,6 +271,10 @@ pub async fn spawn_node(
     let mut child_stdout =
         tokio::io::BufReader::new(child.stdout.take().expect("failed to take stdout"));
     let pid = child.id().unwrap();
+    let running_node = RunningNode {
+        pid: Some(pid),
+        node_config,
+    };
     let stdout_tx = tx.clone();
 
     // Stdout listener stream
@@ -454,5 +458,5 @@ pub async fn spawn_node(
             .send(())
             .map_err(|_| error!("Could not inform that log file thread finished"));
     });
-    Ok(pid)
+    Ok(running_node)
 }

--- a/binaries/daemon/src/spawn.rs
+++ b/binaries/daemon/src/spawn.rs
@@ -270,7 +270,9 @@ pub async fn spawn_node(
         .expect("Failed to create log file");
     let mut child_stdout =
         tokio::io::BufReader::new(child.stdout.take().expect("failed to take stdout"));
-    let pid = child.id().unwrap();
+    let pid = child.id().context(
+        "Could not get the pid for the just spawned node and indicate that there is an error",
+    )?;
     let running_node = RunningNode {
         pid: Some(pid),
         node_config,

--- a/examples/multiple-daemons/run.rs
+++ b/examples/multiple-daemons/run.rs
@@ -214,7 +214,7 @@ async fn build_dataflow(dataflow: &Path) -> eyre::Result<()> {
 async fn run_daemon(
     coordinator: String,
     machine_id: &str,
-    dynamic_node_port: u16,
+    local_listen_port: u16,
 ) -> eyre::Result<()> {
     let cargo = std::env::var("CARGO").unwrap();
     let mut cmd = tokio::process::Command::new(&cargo);
@@ -227,7 +227,7 @@ async fn run_daemon(
         .arg("--coordinator-addr")
         .arg(coordinator)
         .arg("--dynamic-node-port")
-        .arg(dynamic_node_port.to_string());
+        .arg(local_listen_port.to_string());
     if !cmd.status().await?.success() {
         bail!("failed to run dataflow");
     };

--- a/examples/multiple-daemons/run.rs
+++ b/examples/multiple-daemons/run.rs
@@ -52,8 +52,8 @@ async fn main() -> eyre::Result<()> {
     )
     .await?;
     let coordinator_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), coordinator_port);
-    let daemon_a = run_daemon(coordinator_addr.to_string(), "A");
-    let daemon_b = run_daemon(coordinator_addr.to_string(), "B");
+    let daemon_a = run_daemon(coordinator_addr.to_string(), "A", 9843); // Random port
+    let daemon_b = run_daemon(coordinator_addr.to_string(), "B", 9842);
 
     tracing::info!("Spawning coordinator and daemons");
     let mut tasks = JoinSet::new();
@@ -211,7 +211,11 @@ async fn build_dataflow(dataflow: &Path) -> eyre::Result<()> {
     Ok(())
 }
 
-async fn run_daemon(coordinator: String, machine_id: &str) -> eyre::Result<()> {
+async fn run_daemon(
+    coordinator: String,
+    machine_id: &str,
+    dynamic_node_port: u16,
+) -> eyre::Result<()> {
     let cargo = std::env::var("CARGO").unwrap();
     let mut cmd = tokio::process::Command::new(&cargo);
     cmd.arg("run");
@@ -221,7 +225,9 @@ async fn run_daemon(coordinator: String, machine_id: &str) -> eyre::Result<()> {
         .arg("--machine-id")
         .arg(machine_id)
         .arg("--coordinator-addr")
-        .arg(coordinator);
+        .arg(coordinator)
+        .arg("--dynamic-node-port")
+        .arg(dynamic_node_port.to_string());
     if !cmd.status().await?.success() {
         bail!("failed to run dataflow");
     };

--- a/examples/multiple-daemons/run.rs
+++ b/examples/multiple-daemons/run.rs
@@ -226,7 +226,7 @@ async fn run_daemon(
         .arg(machine_id)
         .arg("--coordinator-addr")
         .arg(coordinator)
-        .arg("--dynamic-node-port")
+        .arg("--local-listen-port")
         .arg(local_listen_port.to_string());
     if !cmd.status().await?.success() {
         bail!("failed to run dataflow");

--- a/examples/python-dataflow/dataflow_dynamic.yml
+++ b/examples/python-dataflow/dataflow_dynamic.yml
@@ -9,17 +9,8 @@ nodes:
       outputs:
         - image
 
-  - id: object_detection
-    custom:
-      source: ./object_detection.py
-      inputs:
-        image: webcam/image
-      outputs:
-        - bbox
-
   - id: plot
     custom:
       source: dynamic
       inputs:
         image: webcam/image
-        bbox: object_detection/bbox

--- a/examples/python-dataflow/dataflow_dynamic.yml
+++ b/examples/python-dataflow/dataflow_dynamic.yml
@@ -1,0 +1,25 @@
+nodes:
+  - id: webcam
+    custom:
+      source: ./webcam.py
+      inputs:
+        tick:
+          source: dora/timer/millis/50
+          queue_size: 1000
+      outputs:
+        - image
+
+  - id: object_detection
+    custom:
+      source: ./object_detection.py
+      inputs:
+        image: webcam/image
+      outputs:
+        - bbox
+
+  - id: plot
+    custom:
+      source: dynamic
+      inputs:
+        image: webcam/image
+        bbox: object_detection/bbox

--- a/examples/python-dataflow/plot_dynamic.py
+++ b/examples/python-dataflow/plot_dynamic.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os
+from dora import Node
+from dora import DoraStatus
+
+import cv2
+import numpy as np
+from utils import LABELS
+
+CI = os.environ.get("CI")
+
+font = cv2.FONT_HERSHEY_SIMPLEX
+
+
+class Plotter:
+    """
+    Plot image and bounding box
+    """
+
+    def __init__(self):
+        self.image = []
+        self.bboxs = []
+
+    def on_input(
+        self,
+        dora_input,
+    ) -> DoraStatus:
+        """
+        Put image and bounding box on cv2 window.
+
+        Args:
+            dora_input["id"] (str): Id of the dora_input declared in the yaml configuration
+            dora_input["value"] (arrow array): message of the dora_input
+        """
+        if dora_input["id"] == "image":
+            frame = dora_input["value"].to_numpy()
+            frame = cv2.imdecode(frame, -1)
+            self.image = frame
+
+        elif dora_input["id"] == "bbox" and len(self.image) != 0:
+            bboxs = dora_input["value"].to_numpy()
+            self.bboxs = np.reshape(bboxs, (-1, 6))
+        for bbox in self.bboxs:
+            [
+                min_x,
+                min_y,
+                max_x,
+                max_y,
+                confidence,
+                label,
+            ] = bbox
+            cv2.rectangle(
+                self.image,
+                (int(min_x), int(min_y)),
+                (int(max_x), int(max_y)),
+                (0, 255, 0),
+                2,
+            )
+
+            cv2.putText(
+                self.image,
+                LABELS[int(label)] + f", {confidence:0.2f}",
+                (int(max_x), int(max_y)),
+                font,
+                0.75,
+                (0, 255, 0),
+                2,
+                1,
+            )
+
+        if CI != "true":
+            cv2.imshow("frame", self.image)
+            if cv2.waitKey(1) & 0xFF == ord("q"):
+                return DoraStatus.STOP
+
+        return DoraStatus.CONTINUE
+
+
+plotter = Plotter()
+
+node = Node("plot")
+
+for event in node:
+    event_type = event["type"]
+    if event_type == "INPUT":
+        status = plotter.on_input(event)
+        if status == DoraStatus.CONTINUE:
+            pass
+        elif status == DoraStatus.STOP:
+            print("plotter returned stop status")
+            break
+    elif event_type == "STOP":
+        print("received stop")
+    else:
+        print("received unexpected event:", event_type)

--- a/examples/rust-dataflow/dataflow_dynamic.yml
+++ b/examples/rust-dataflow/dataflow_dynamic.yml
@@ -1,0 +1,31 @@
+nodes:
+  - id: rust-node
+    custom:
+      build: cargo build -p rust-dataflow-example-node
+      source: ../../target/debug/rust-dataflow-example-node
+      inputs:
+        tick: dora/timer/millis/100
+      outputs:
+        - random
+  - id: rust-status-node
+    custom:
+      build: cargo build -p rust-dataflow-example-status-node
+      source: ../../target/debug/rust-dataflow-example-status-node
+      inputs:
+        tick: dora/timer/millis/100
+        random: rust-node/random
+      outputs:
+        - status
+  - id: rust-sink-dynamic
+    custom:
+      build: cargo build -p rust-dataflow-example-sink-dynamic
+      source: dynamic
+      inputs:
+        message: rust-status-node/status
+  - id: dora-record
+    custom:
+      build: cargo build -p dora-record
+      source: ../../target/debug/dora-record
+      inputs:
+        message: rust-status-node/status
+        random: rust-node/random

--- a/examples/rust-dataflow/sink-dynamic/Cargo.toml
+++ b/examples/rust-dataflow/sink-dynamic/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "rust-dataflow-example-sink-dynamic"
+version.workspace = true
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+dora-node-api = { workspace = true, features = ["tracing"] }
+eyre = "0.6.8"

--- a/examples/rust-dataflow/sink-dynamic/src/main.rs
+++ b/examples/rust-dataflow/sink-dynamic/src/main.rs
@@ -1,0 +1,39 @@
+use dora_node_api::{self, dora_core::config::NodeId, DoraNode, Event};
+use eyre::{bail, Context};
+
+fn main() -> eyre::Result<()> {
+    let (_node, mut events) =
+        DoraNode::init_from_node_id(NodeId::from("rust-sink-dynamic".to_string()))?;
+
+    while let Some(event) = events.recv() {
+        match event {
+            Event::Input {
+                id,
+                metadata: _,
+                data,
+            } => match id.as_str() {
+                "message" => {
+                    let received_string: &str =
+                        TryFrom::try_from(&data).context("expected string message")?;
+                    println!("sink received message: {}", received_string);
+                    if !received_string.starts_with("operator received random value ") {
+                        bail!("unexpected message format (should start with 'operator received random value')")
+                    }
+                    if !received_string.ends_with(" ticks") {
+                        bail!("unexpected message format (should end with 'ticks')")
+                    }
+                }
+                other => eprintln!("Ignoring unexpected input `{other}`"),
+            },
+            Event::Stop => {
+                println!("Received manual stop");
+            }
+            Event::InputClosed { id } => {
+                println!("Input `{id}` was closed");
+            }
+            other => eprintln!("Received unexpected input: {other:?}"),
+        }
+    }
+
+    Ok(())
+}

--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -9,7 +9,7 @@ use eyre::{bail, eyre, Context};
 use std::{path::Path, process::Command};
 use tracing::info;
 
-use super::{resolve_path, Descriptor, SHELL_SOURCE};
+use super::{resolve_path, Descriptor, DYNAMIC_SOURCE, SHELL_SOURCE};
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn check_dataflow(dataflow: &Descriptor, working_dir: &Path) -> eyre::Result<()> {
@@ -21,6 +21,7 @@ pub fn check_dataflow(dataflow: &Descriptor, working_dir: &Path) -> eyre::Result
         match &node.kind {
             descriptor::CoreNodeKind::Custom(node) => match node.source.as_str() {
                 SHELL_SOURCE => (),
+                DYNAMIC_SOURCE => (),
                 source => {
                     if source_is_url(source) {
                         info!("{source} is a URL."); // TODO: Implement url check.

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -1,4 +1,10 @@
-use std::{collections::BTreeSet, fmt::Display, path::PathBuf, time::Duration};
+use std::{
+    collections::BTreeSet,
+    fmt::Display,
+    net::{IpAddr, Ipv4Addr},
+    path::PathBuf,
+    time::Duration,
+};
 use uuid::Uuid;
 
 use crate::{
@@ -6,7 +12,9 @@ use crate::{
     descriptor::Descriptor,
 };
 
+pub const LOCALHOST: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
 pub const DORA_COORDINATOR_PORT_DEFAULT: u16 = 0xD02A;
+pub const DORA_DAEMON_DYNAMIC_NODE_PORT_DEFAULT: u16 = 0xD02B;
 pub const DORA_COORDINATOR_PORT_CONTROL_DEFAULT: u16 = 0x177C;
 
 pub const MANUAL_STOP: &str = "dora/stop";

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -14,7 +14,7 @@ use crate::{
 
 pub const LOCALHOST: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
 pub const DORA_COORDINATOR_PORT_DEFAULT: u16 = 0xD02A;
-pub const DORA_DAEMON_DYNAMIC_NODE_PORT_DEFAULT: u16 = 0xD02B;
+pub const DORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT: u16 = 0xD02B;
 pub const DORA_COORDINATOR_PORT_CONTROL_DEFAULT: u16 = 0x177C;
 
 pub const MANUAL_STOP: &str = "dora/stop";

--- a/tool_nodes/dora-record/README.md
+++ b/tool_nodes/dora-record/README.md
@@ -1,0 +1,56 @@
+# dora-record
+
+dora data recording using Apache Arrow Parquet.
+
+This nodes is still experimental.
+
+## Getting Started
+
+```bash
+cargo install dora-record --locked
+```
+
+## Adding to existing graph:
+
+```yaml
+- id: dora-record
+  custom:
+    source: dora-record
+    inputs:
+      image: webcam/image
+      text: webcam/text
+      # You can add any input and it is going to be logged.
+```
+
+## Output Files
+
+Format: Parquet file
+
+path: `out/<DATAFLOW_ID>/<INPUT>.parquet`
+
+Columns:
+
+- trace_id: String, representing the id of the current trace
+- span_id: String, representing the unique span id
+- timestamp_uhlc: u64, representing the timestamp in [Unique Hybrid Logical Clock time](https://github.com/atolab/uhlc-rs)
+- timestamp_utc: DataType::Timestamp(Milliseconds), representing the timestamp in Coordinated Universal Time.
+- `<INPUT>` : Column containing the input in its defined format.
+
+Example:
+
+```json
+{
+  "trace_id": "2fd23ddf1b5d2aa38ddb86ceedb55928",
+  "span_id": "15aef03e0f052bbf",
+  "timestamp_uhlc": "7368873278370007008",
+  "timestamp_utc": 1715699508406,
+  "random": [1886295351360621740]
+}
+```
+
+## merging multiple file
+
+We can merge input files using the `trace_id` that is going to be shared when using opentelemetry features.
+
+- `trace_id` can also be queried from UI such as jaeger UI, influxDB and so on...
+- `trace_id` keep tracks of the logical flow of data, compared to timestamp based merging that might not reflect the actual logical flow of data.


### PR DESCRIPTION
## Description

This PR makes it possible to run process as a dynamic process to be able to debug, run tests as well as run python file interactively.

## Getting started

### In the YAML graph

```yaml
nodes:
  - id: webcam
    source: ./webcam.py
    inputs:
      tick:
        source: dora/timer/millis/50
        queue_size: 1000
    outputs:
      - image

  - id: object_detection
    source: ./object_detection.py
    inputs:
      image: webcam/image
    outputs:
      - bbox

  - id: plot
    source: dynamic
    inputs:
      image: webcam/image
      bbox: object_detection/bbox

```

### For python

```python
# Simply add a node_id when you initialize a node

node = Node("plot")
```

### For rust

```rust
        DoraNode::init_from_node_id(None, NodeId::from("rust-sink-detached".to_string()), None)?;
```

### To run

#### For python

```bash
dora start examples/python-dataflow/dataflow_detached.yml --name ci-python-detached
python examples/python-dataflow/plot_detached.py
sleep 5
dora stop --name ci-python-test  --grace-duration 5s
```

#### For rust

```bash
dora start examples/rust-dataflow/dataflow_detached.yml --name ci-rust-detached
cargo run -p rust-dataflow-example-sink-detached
sleep 5
dora stop --name ci-rust-detached  --grace-duration 5s
````
