### PR TITLE
Provide help messages for CLI

### DIFF
--- a/binaries/cli/src/main.rs
+++ b/binaries/cli/src/main.rs
@@ -43,21 +43,30 @@ struct Args {
 enum Command {
     /// Check if the coordinator and the daemon is running.
     Check {
-        #[clap(long)]
+        /// Path to the dataflow descriptor file (enables additional checks)
+        #[clap(long, value_name = "PATH", value_hint = clap::ValueHint::FilePath)]
         dataflow: Option<PathBuf>,
         #[clap(long)]
         coordinator_addr: Option<IpAddr>,
     },
     /// Generate a visualization of the given graph using mermaid.js. Use --open to open browser.
     Graph {
+        /// Path to the dataflow descriptor file
+        #[clap(value_name = "PATH", value_hint = clap::ValueHint::FilePath)]
         dataflow: PathBuf,
+        /// Visualize the dataflow as a Mermaid diagram (instead of HTML)
         #[clap(long, action)]
         mermaid: bool,
+        /// Open the HTML visualization in the browser
         #[clap(long, action)]
         open: bool,
     },
     /// Run build commands provided in the given dataflow.
-    Build { dataflow: PathBuf },
+    Build {
+        /// Path to the dataflow descriptor file
+        #[clap(value_name = "PATH", value_hint = clap::ValueHint::FilePath)]
+        dataflow: PathBuf,
+    },
     /// Generate a new project, node or operator. Choose the language between Rust, Python, C or C++.
     New {
         #[clap(flatten)]
@@ -67,36 +76,48 @@ enum Command {
     },
     /// Spawn a coordinator and a daemon.
     Up {
-        #[clap(long)]
+        /// Use a custom configuration
+        #[clap(long, hide = true, value_name = "PATH", value_hint = clap::ValueHint::FilePath)]
         config: Option<PathBuf>,
+        // TODO
         #[clap(long)]
         coordinator_addr: Option<IpAddr>,
     },
     /// Destroy running coordinator and daemon. If some dataflows are still running, they will be stopped first.
     Destroy {
-        #[clap(long)]
+        /// Use a custom configuration
+        #[clap(long, hide = true)]
         config: Option<PathBuf>,
+        // TODO
         #[clap(long)]
         coordinator_addr: Option<IpAddr>,
     },
     /// Start the given dataflow path. Attach a name to the running dataflow by using --name.
     Start {
+        /// Path to the dataflow descriptor file
+        #[clap(value_name = "PATH", value_hint = clap::ValueHint::FilePath)]
         dataflow: PathBuf,
+        /// Assign a name to the dataflow
         #[clap(long)]
         name: Option<String>,
         #[clap(long)]
         coordinator_addr: Option<IpAddr>,
+        /// Attach to the dataflow and wait for its completion
         #[clap(long, action)]
         attach: bool,
+        /// Enable hot reloading (Python only)
         #[clap(long, action)]
         hot_reload: bool,
     },
     /// Stop the given dataflow UUID. If no id is provided, you will be able to choose between the running dataflows.
     Stop {
+        /// UUID of the dataflow that should be stopped
         uuid: Option<Uuid>,
+        /// Name of the dataflow that should be stopped
         #[clap(long)]
         name: Option<String>,
-        #[clap(long)]
+        /// Kill the dataflow if it doesn't stop after the given duration
+        #[clap(long, value_name = "DURATION")]
         #[arg(value_parser = parse)]
         grace_duration: Option<Duration>,
         #[clap(long)]
@@ -112,7 +133,11 @@ enum Command {
     /// Show logs of a given dataflow and node.
     #[command(allow_missing_positional = true)]
     Logs {
+        /// Identifier of the dataflow
+        #[clap(value_name = "UUID_OR_NAME")]
         dataflow: Option<String>,
+        /// Show logs for the given node
+        #[clap(value_name = "NAME")]
         node: String,
         #[clap(long)]
         coordinator_addr: Option<IpAddr>,
@@ -123,6 +148,7 @@ enum Command {
     // Upgrade,
     /// Run daemon
     Daemon {
+        /// Unique identifier for the machine (required for distributed dataflows)
         #[clap(long)]
         machine_id: Option<String>,
         /// The IP address and port this daemon will bind to.
@@ -133,7 +159,7 @@ enum Command {
         #[clap(long)]
         coordinator_addr: Option<SocketAddr>,
 
-        #[clap(long)]
+        #[clap(long, hide = true)]
         run_dataflow: Option<PathBuf>,
     },
     /// Run runtime
@@ -149,11 +175,16 @@ enum Command {
 
 #[derive(Debug, clap::Args)]
 pub struct CommandNew {
+    /// The entity that should be created
     #[clap(long, value_enum, default_value_t = Kind::Dataflow)]
     kind: Kind,
+    /// The programming language that should be used
     #[clap(long, value_enum, default_value_t = Lang::Rust)]
     lang: Lang,
+    /// Desired name of the entity
     name: String,
+    /// Where to create the entity
+    #[clap(hide = true)]
     path: Option<PathBuf>,
 }
 


### PR DESCRIPTION
Example output:

```
Start the given dataflow path. Attach a name to the running dataflow by using --name

Usage: dora start [OPTIONS] <PATH>

Arguments:
  <PATH>  Path to the dataflow descriptor file

Options:
      --name <NAME>                          Assign a name to the dataflow
      --coordinator-addr <COORDINATOR_ADDR>  
      --attach                               Attach to the dataflow and wait for its completion
      --hot-reload                           Enable hot reloading (Python only)
  -h, --help                                 Print help

```

I didn't add help output for `--coordinator-addr` yet because I want to implements some other improvements there.