### PR TITLE
Improve coordinator port config

### DIFF
--- a/binaries/cli/src/check.rs
+++ b/binaries/cli/src/check.rs
@@ -4,11 +4,11 @@ use dora_core::topics::{ControlRequest, ControlRequestReply};
 use eyre::{bail, Context};
 use std::{
     io::{IsTerminal, Write},
-    net::IpAddr,
+    net::SocketAddr,
 };
 use termcolor::{Color, ColorChoice, ColorSpec, WriteColor};
 
-pub fn check_environment(coordinator_addr: IpAddr) -> eyre::Result<()> {
+pub fn check_environment(coordinator_addr: SocketAddr) -> eyre::Result<()> {
     let mut error_occured = false;
 
     let color_choice = if std::io::stdout().is_terminal() {

--- a/binaries/cli/src/check.rs
+++ b/binaries/cli/src/check.rs
@@ -8,7 +8,7 @@ use std::{
 };
 use termcolor::{Color, ColorChoice, ColorSpec, WriteColor};
 
-pub fn check_environment(coordinator_addr: Option<IpAddr>) -> eyre::Result<()> {
+pub fn check_environment(coordinator_addr: IpAddr) -> eyre::Result<()> {
     let mut error_occured = false;
 
     let color_choice = if std::io::stdout().is_terminal() {

--- a/binaries/cli/src/main.rs
+++ b/binaries/cli/src/main.rs
@@ -78,17 +78,11 @@ enum Command {
         #[clap(hide = true, long)]
         internal_create_with_path_dependencies: bool,
     },
-    /// Spawn a coordinator and a daemon.
+    /// Spawn coordinator and daemon in local mode (with default config)
     Up {
         /// Use a custom configuration
         #[clap(long, hide = true, value_name = "PATH", value_hint = clap::ValueHint::FilePath)]
         config: Option<PathBuf>,
-        /// Address of the dora coordinator
-        #[clap(long, value_name = "IP", default_value_t = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)))]
-        coordinator_addr: IpAddr,
-        /// Port number of the coordinator control server
-        #[clap(long, value_name = "PORT", default_value_t = DORA_COORDINATOR_PORT_CONTROL_DEFAULT)]
-        coordinator_port: u16,
     },
     /// Destroy running coordinator and daemon. If some dataflows are still running, they will be stopped first.
     Destroy {
@@ -295,15 +289,8 @@ fn run() -> eyre::Result<()> {
             args,
             internal_create_with_path_dependencies,
         } => template::create(args, internal_create_with_path_dependencies)?,
-        Command::Up {
-            config,
-            coordinator_addr,
-            coordinator_port,
-        } => {
-            up::up(
-                config.as_deref(),
-                (coordinator_addr, coordinator_port).into(),
-            )?;
+        Command::Up { config } => {
+            up::up(config.as_deref())?;
         }
         Command::Logs {
             dataflow,

--- a/binaries/cli/src/main.rs
+++ b/binaries/cli/src/main.rs
@@ -45,8 +45,8 @@ enum Command {
     Check {
         #[clap(long)]
         dataflow: Option<PathBuf>,
-        #[clap(long)]
-        coordinator_addr: Option<IpAddr>,
+        #[clap(long, default_value_t = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)))]
+        coordinator_addr: IpAddr,
     },
     /// Generate a visualization of the given graph using mermaid.js. Use --open to open browser.
     Graph {
@@ -69,23 +69,23 @@ enum Command {
     Up {
         #[clap(long)]
         config: Option<PathBuf>,
-        #[clap(long)]
-        coordinator_addr: Option<IpAddr>,
+        #[clap(long, default_value_t = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)))]
+        coordinator_addr: IpAddr,
     },
     /// Destroy running coordinator and daemon. If some dataflows are still running, they will be stopped first.
     Destroy {
         #[clap(long)]
         config: Option<PathBuf>,
-        #[clap(long)]
-        coordinator_addr: Option<IpAddr>,
+        #[clap(long, default_value_t = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)))]
+        coordinator_addr: IpAddr,
     },
     /// Start the given dataflow path. Attach a name to the running dataflow by using --name.
     Start {
         dataflow: PathBuf,
         #[clap(long)]
         name: Option<String>,
-        #[clap(long)]
-        coordinator_addr: Option<IpAddr>,
+        #[clap(long, default_value_t = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)))]
+        coordinator_addr: IpAddr,
         #[clap(long, action)]
         attach: bool,
         #[clap(long, action)]
@@ -99,13 +99,13 @@ enum Command {
         #[clap(long)]
         #[arg(value_parser = parse)]
         grace_duration: Option<Duration>,
-        #[clap(long)]
-        coordinator_addr: Option<IpAddr>,
+        #[clap(long, default_value_t = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)))]
+        coordinator_addr: IpAddr,
     },
     /// List running dataflows.
     List {
-        #[clap(long)]
-        coordinator_addr: Option<IpAddr>,
+        #[clap(long, default_value_t = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)))]
+        coordinator_addr: IpAddr,
     },
     // Planned for future releases:
     // Dashboard,
@@ -114,8 +114,8 @@ enum Command {
     Logs {
         dataflow: Option<String>,
         node: String,
-        #[clap(long)]
-        coordinator_addr: Option<IpAddr>,
+        #[clap(long, default_value_t = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)))]
+        coordinator_addr: IpAddr,
     },
     // Metrics,
     // Stats,
@@ -515,17 +515,10 @@ fn query_running_dataflows(
 }
 
 fn connect_to_coordinator(
-    coordinator_addr: Option<IpAddr>,
+    coordinator_addr: IpAddr,
 ) -> std::io::Result<Box<TcpRequestReplyConnection>> {
-    if let Some(coordinator_addr) = coordinator_addr {
-        TcpLayer::new().connect(SocketAddr::new(
-            coordinator_addr,
-            DORA_COORDINATOR_PORT_CONTROL_DEFAULT,
-        ))
-    } else {
-        TcpLayer::new().connect(SocketAddr::new(
-            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-            DORA_COORDINATOR_PORT_CONTROL_DEFAULT,
-        ))
-    }
+    TcpLayer::new().connect(SocketAddr::new(
+        coordinator_addr,
+        DORA_COORDINATOR_PORT_CONTROL_DEFAULT,
+    ))
 }

--- a/binaries/cli/src/up.rs
+++ b/binaries/cli/src/up.rs
@@ -1,11 +1,11 @@
 use crate::{check::daemon_running, connect_to_coordinator};
 use dora_core::topics::ControlRequest;
 use eyre::Context;
-use std::{fs, net::IpAddr, path::Path, process::Command, time::Duration};
+use std::{fs, net::SocketAddr, path::Path, process::Command, time::Duration};
 #[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
 struct UpConfig {}
 
-pub(crate) fn up(config_path: Option<&Path>, coordinator_addr: IpAddr) -> eyre::Result<()> {
+pub(crate) fn up(config_path: Option<&Path>, coordinator_addr: SocketAddr) -> eyre::Result<()> {
     let UpConfig {} = parse_dora_config(config_path)?;
     let mut session = match connect_to_coordinator(coordinator_addr) {
         Ok(session) => session,
@@ -47,7 +47,7 @@ pub(crate) fn up(config_path: Option<&Path>, coordinator_addr: IpAddr) -> eyre::
 
 pub(crate) fn destroy(
     config_path: Option<&Path>,
-    coordinator_addr: IpAddr,
+    coordinator_addr: SocketAddr,
 ) -> Result<(), eyre::ErrReport> {
     let UpConfig {} = parse_dora_config(config_path)?;
     match connect_to_coordinator(coordinator_addr) {

--- a/binaries/cli/src/up.rs
+++ b/binaries/cli/src/up.rs
@@ -5,7 +5,7 @@ use std::{fs, net::IpAddr, path::Path, process::Command, time::Duration};
 #[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
 struct UpConfig {}
 
-pub(crate) fn up(config_path: Option<&Path>, coordinator_addr: Option<IpAddr>) -> eyre::Result<()> {
+pub(crate) fn up(config_path: Option<&Path>, coordinator_addr: IpAddr) -> eyre::Result<()> {
     let UpConfig {} = parse_dora_config(config_path)?;
     let mut session = match connect_to_coordinator(coordinator_addr) {
         Ok(session) => session,
@@ -47,7 +47,7 @@ pub(crate) fn up(config_path: Option<&Path>, coordinator_addr: Option<IpAddr>) -
 
 pub(crate) fn destroy(
     config_path: Option<&Path>,
-    coordinator_addr: Option<IpAddr>,
+    coordinator_addr: IpAddr,
 ) -> Result<(), eyre::ErrReport> {
     let UpConfig {} = parse_dora_config(config_path)?;
     match connect_to_coordinator(coordinator_addr) {

--- a/binaries/cli/src/up.rs
+++ b/binaries/cli/src/up.rs
@@ -1,12 +1,23 @@
 use crate::{check::daemon_running, connect_to_coordinator};
-use dora_core::topics::ControlRequest;
+use dora_core::topics::{ControlRequest, DORA_COORDINATOR_PORT_CONTROL_DEFAULT};
 use eyre::Context;
-use std::{fs, net::SocketAddr, path::Path, process::Command, time::Duration};
+use std::{
+    fs,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    path::Path,
+    process::Command,
+    time::Duration,
+};
 #[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
 struct UpConfig {}
 
-pub(crate) fn up(config_path: Option<&Path>, coordinator_addr: SocketAddr) -> eyre::Result<()> {
+pub(crate) fn up(config_path: Option<&Path>) -> eyre::Result<()> {
     let UpConfig {} = parse_dora_config(config_path)?;
+    let coordinator_addr = (
+        IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+        DORA_COORDINATOR_PORT_CONTROL_DEFAULT,
+    )
+        .into();
     let mut session = match connect_to_coordinator(coordinator_addr) {
         Ok(session) => session,
         Err(_) => {

--- a/binaries/cli/src/up.rs
+++ b/binaries/cli/src/up.rs
@@ -1,23 +1,13 @@
-use crate::{check::daemon_running, connect_to_coordinator};
+use crate::{check::daemon_running, connect_to_coordinator, LOCALHOST};
 use dora_core::topics::{ControlRequest, DORA_COORDINATOR_PORT_CONTROL_DEFAULT};
 use eyre::Context;
-use std::{
-    fs,
-    net::{IpAddr, Ipv4Addr, SocketAddr},
-    path::Path,
-    process::Command,
-    time::Duration,
-};
+use std::{fs, net::SocketAddr, path::Path, process::Command, time::Duration};
 #[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
 struct UpConfig {}
 
 pub(crate) fn up(config_path: Option<&Path>) -> eyre::Result<()> {
     let UpConfig {} = parse_dora_config(config_path)?;
-    let coordinator_addr = (
-        IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-        DORA_COORDINATOR_PORT_CONTROL_DEFAULT,
-    )
-        .into();
+    let coordinator_addr = (LOCALHOST, DORA_COORDINATOR_PORT_CONTROL_DEFAULT).into();
     let mut session = match connect_to_coordinator(coordinator_addr) {
         Ok(session) => session,
         Err(_) => {

--- a/examples/multiple-daemons/run.rs
+++ b/examples/multiple-daemons/run.rs
@@ -1,7 +1,10 @@
 use dora_coordinator::{ControlEvent, Event};
 use dora_core::{
     descriptor::Descriptor,
-    topics::{ControlRequest, ControlRequestReply, DataflowId, DORA_COORDINATOR_PORT_DEFAULT},
+    topics::{
+        ControlRequest, ControlRequestReply, DataflowId, DORA_COORDINATOR_PORT_CONTROL_DEFAULT,
+        DORA_COORDINATOR_PORT_DEFAULT,
+    },
 };
 use dora_tracing::set_up_tracing;
 use eyre::{bail, Context};
@@ -38,9 +41,16 @@ async fn main() -> eyre::Result<()> {
         IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
         DORA_COORDINATOR_PORT_DEFAULT,
     );
-    let (coordinator_port, coordinator) =
-        dora_coordinator::start(coordinator_bind, ReceiverStream::new(coordinator_events_rx))
-            .await?;
+    let coordinator_control_bind = SocketAddr::new(
+        IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+        DORA_COORDINATOR_PORT_CONTROL_DEFAULT,
+    );
+    let (coordinator_port, coordinator) = dora_coordinator::start(
+        coordinator_bind,
+        coordinator_control_bind,
+        ReceiverStream::new(coordinator_events_rx),
+    )
+    .await?;
     let coordinator_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), coordinator_port);
     let daemon_a = run_daemon(coordinator_addr.to_string(), "A");
     let daemon_b = run_daemon(coordinator_addr.to_string(), "B");

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -1,10 +1,4 @@
-use std::{
-    collections::BTreeSet,
-    fmt::Display,
-    net::{Ipv4Addr, SocketAddr},
-    path::PathBuf,
-    time::Duration,
-};
+use std::{collections::BTreeSet, fmt::Display, path::PathBuf, time::Duration};
 use uuid::Uuid;
 
 use crate::{
@@ -13,16 +7,9 @@ use crate::{
 };
 
 pub const DORA_COORDINATOR_PORT_DEFAULT: u16 = 0xD02A;
-pub const DORA_COORDINATOR_PORT_CONTROL: u16 = 0x177C;
+pub const DORA_COORDINATOR_PORT_CONTROL_DEFAULT: u16 = 0x177C;
 
 pub const MANUAL_STOP: &str = "dora/stop";
-
-pub fn control_socket_addr() -> SocketAddr {
-    SocketAddr::new(
-        Ipv4Addr::new(127, 0, 0, 1).into(),
-        DORA_COORDINATOR_PORT_CONTROL,
-    )
-}
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub enum ControlRequest {


### PR DESCRIPTION
- Allow setting custom control port in coordinator
- Set default in CLI parsing -> default shown in `--help` output
- Add support for custom coordinator control port numbers in CLI


Follow-up to #513 