### PR TITLE
Add a `--listen-addr` flag to `dora coordinator` command

### DIFF
--- a/binaries/cli/src/main.rs
+++ b/binaries/cli/src/main.rs
@@ -358,13 +358,8 @@ fn run() -> eyre::Result<()> {
                 .build()
                 .context("tokio runtime failed")?;
             rt.block_on(async {
-                let extern_events = if let Some(_listen_addr) = listen_addr {
-                    futures::stream::empty::<Event>()
-                } else {
-                    futures::stream::empty::<Event>()
-                };
                 let (_port, task) =
-                    dora_coordinator::start(addr, extern_events).await?;
+                    dora_coordinator::start(addr, futures::stream::empty::<Event>(), listen_addr).await?;
                 task.await
             })
             .context("failed to run dora-coordinator")?

--- a/binaries/cli/src/main.rs
+++ b/binaries/cli/src/main.rs
@@ -171,7 +171,7 @@ enum Command {
         )]
         addr: SocketAddr,
         #[clap(long)]
-        listen_addr: Option<SocketAddr>
+        listen_addr: Option<SocketAddr>,
     },
 }
 
@@ -352,14 +352,15 @@ fn run() -> eyre::Result<()> {
             config,
             coordinator_addr,
         } => up::destroy(config.as_deref(), coordinator_addr)?,
-        Command::Coordinator { addr , listen_addr} => {
+        Command::Coordinator { addr, listen_addr } => {
             let rt = Builder::new_multi_thread()
                 .enable_all()
                 .build()
                 .context("tokio runtime failed")?;
             rt.block_on(async {
                 let (_port, task) =
-                    dora_coordinator::start(addr, futures::stream::empty::<Event>(), listen_addr).await?;
+                    dora_coordinator::start(addr, futures::stream::empty::<Event>(), listen_addr)
+                        .await?;
                 task.await
             })
             .context("failed to run dora-coordinator")?

--- a/binaries/coordinator/src/control.rs
+++ b/binaries/coordinator/src/control.rs
@@ -13,7 +13,10 @@ use futures_concurrency::future::Race;
 use std::{io::ErrorKind, net::SocketAddr};
 use tokio::{
     net::{TcpListener, TcpStream},
-    sync::{mpsc::{self, Receiver}, oneshot},
+    sync::{
+        mpsc::{self, Receiver},
+        oneshot,
+    },
     task::JoinHandle,
 };
 use tokio_stream::wrappers::ReceiverStream;
@@ -39,7 +42,7 @@ impl ControlRequestSource for ExternalControlSocket {
 pub(crate) async fn control_events<T>(
     control_listen_addr: SocketAddr,
     tasks: &FuturesUnordered<JoinHandle<()>>,
-) -> eyre::Result<impl Stream<Item = Event>> 
+) -> eyre::Result<impl Stream<Item = Event>>
 where
     T: ControlRequestSource,
 {
@@ -50,7 +53,7 @@ where
     tasks.push(tokio::spawn(async move {
         while let Some(()) = finish_rx.recv().await {}
     }));
-    
+
     T::source(rx)
 }
 

--- a/binaries/coordinator/src/control.rs
+++ b/binaries/coordinator/src/control.rs
@@ -13,15 +13,36 @@ use futures_concurrency::future::Race;
 use std::{io::ErrorKind, net::SocketAddr};
 use tokio::{
     net::{TcpListener, TcpStream},
-    sync::{mpsc, oneshot},
+    sync::{mpsc::{self, Receiver}, oneshot},
     task::JoinHandle,
 };
 use tokio_stream::wrappers::ReceiverStream;
 
-pub(crate) async fn control_events(
+pub trait ControlRequestSource {
+    fn source(rx: Receiver<ControlEvent>) -> eyre::Result<impl Stream<Item = Event>>;
+}
+
+pub(crate) struct InnerControlSocket;
+impl ControlRequestSource for InnerControlSocket {
+    fn source(rx: Receiver<ControlEvent>) -> eyre::Result<impl Stream<Item = Event>> {
+        Ok(ReceiverStream::new(rx).map(Event::Control))
+    }
+}
+
+pub(crate) struct ExternalControlSocket;
+impl ControlRequestSource for ExternalControlSocket {
+    fn source(rx: Receiver<ControlEvent>) -> eyre::Result<impl Stream<Item = Event>> {
+        Ok(ReceiverStream::new(rx).map(Event::ExternalControl))
+    }
+}
+
+pub(crate) async fn control_events<T>(
     control_listen_addr: SocketAddr,
     tasks: &FuturesUnordered<JoinHandle<()>>,
-) -> eyre::Result<impl Stream<Item = Event>> {
+) -> eyre::Result<impl Stream<Item = Event>> 
+where
+    T: ControlRequestSource,
+{
     let (tx, rx) = mpsc::channel(10);
 
     let (finish_tx, mut finish_rx) = mpsc::channel(1);
@@ -29,8 +50,8 @@ pub(crate) async fn control_events(
     tasks.push(tokio::spawn(async move {
         while let Some(()) = finish_rx.recv().await {}
     }));
-
-    Ok(ReceiverStream::new(rx).map(Event::Control))
+    
+    T::source(rx)
 }
 
 async fn listen(

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -329,7 +329,18 @@ async fn start_inner(
                     }
                 }
             },
-
+            Event::ExternalControl(ControlEvent::IncomingRequest {
+                request:
+                    ControlRequest::Start {
+                        dataflow: _,
+                        name: _,
+                        local_working_dir: _,
+                    },
+                reply_sender,
+            }) => {
+                let status = ControlRequestReply::Error("not supported yet".to_owned());
+                let _ = reply_sender.send(Ok(status));
+            }
             Event::Control(event) | Event::ExternalControl(event) => match event {
                 ControlEvent::IncomingRequest {
                     request,

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -340,7 +340,7 @@ async fn start_inner(
             }) => {
                 let status = ControlRequestReply::Error("not supported yet".to_owned());
                 let _ = reply_sender.send(Ok(status));
-            }
+            },
             Event::Control(event) | Event::ExternalControl(event) => match event {
                 ControlEvent::IncomingRequest {
                     request,

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -340,7 +340,7 @@ async fn start_inner(
             }) => {
                 let status = ControlRequestReply::Error("not supported yet".to_owned());
                 let _ = reply_sender.send(Ok(status));
-            },
+            }
             Event::Control(event) | Event::ExternalControl(event) => match event {
                 ControlEvent::IncomingRequest {
                     request,

--- a/examples/multiple-daemons/run.rs
+++ b/examples/multiple-daemons/run.rs
@@ -38,9 +38,12 @@ async fn main() -> eyre::Result<()> {
         IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
         DORA_COORDINATOR_PORT_DEFAULT,
     );
-    let (coordinator_port, coordinator) =
-        dora_coordinator::start(coordinator_bind, ReceiverStream::new(coordinator_events_rx), None)
-            .await?;
+    let (coordinator_port, coordinator) = dora_coordinator::start(
+        coordinator_bind,
+        ReceiverStream::new(coordinator_events_rx),
+        None,
+    )
+    .await?;
     let coordinator_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), coordinator_port);
     let daemon_a = run_daemon(coordinator_addr.to_string(), "A");
     let daemon_b = run_daemon(coordinator_addr.to_string(), "B");

--- a/examples/multiple-daemons/run.rs
+++ b/examples/multiple-daemons/run.rs
@@ -39,7 +39,7 @@ async fn main() -> eyre::Result<()> {
         DORA_COORDINATOR_PORT_DEFAULT,
     );
     let (coordinator_port, coordinator) =
-        dora_coordinator::start(coordinator_bind, ReceiverStream::new(coordinator_events_rx))
+        dora_coordinator::start(coordinator_bind, ReceiverStream::new(coordinator_events_rx), None)
             .await?;
     let coordinator_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), coordinator_port);
     let daemon_a = run_daemon(coordinator_addr.to_string(), "A");


### PR DESCRIPTION
add an optional `--listen-port flags` to dora coordinator command. If user sets this flag, coordinator will open an external control port as same as inner control port. However, every ControlRequest will be convert to ExternalControlEvent different than ControlEvent .

Separate external ControlRequest from ControlEvent for security.