### PR TITLE
Add a new event type to notify nodes about dropped inputs

### DIFF
--- a/apis/c++/node/src/lib.rs
+++ b/apis/c++/node/src/lib.rs
@@ -142,6 +142,7 @@ fn event_as_input(event: Box<DoraEvent>) -> eyre::Result<ffi::DoraInput> {
         id,
         metadata: _,
         data,
+        dropped,
     }) = event.0
     else {
         bail!("not an input event");

--- a/apis/c++/node/src/lib.rs
+++ b/apis/c++/node/src/lib.rs
@@ -142,7 +142,7 @@ fn event_as_input(event: Box<DoraEvent>) -> eyre::Result<ffi::DoraInput> {
         id,
         metadata: _,
         data,
-        dropped,
+        ..
     }) = event.0
     else {
         bail!("not an input event");

--- a/apis/rust/node/src/event_stream/event.rs
+++ b/apis/rust/node/src/event_stream/event.rs
@@ -2,6 +2,7 @@ use std::{ptr::NonNull, sync::Arc};
 
 use aligned_vec::{AVec, ConstAlign};
 use dora_arrow_convert::{ArrowData, IntoArrow};
+pub use dora_core::daemon_messages::InputDropReason;
 use dora_core::{
     config::{DataId, OperatorId},
     message::{ArrowTypeInfo, BufferOffset, Metadata},
@@ -25,6 +26,10 @@ pub enum Event {
         id: DataId,
     },
     Error(String),
+    DroppedInputs {
+        reason: InputDropReason,
+        number: usize,
+    },
 }
 
 pub enum RawData {

--- a/apis/rust/node/src/event_stream/event.rs
+++ b/apis/rust/node/src/event_stream/event.rs
@@ -2,7 +2,6 @@ use std::{ptr::NonNull, sync::Arc};
 
 use aligned_vec::{AVec, ConstAlign};
 use dora_arrow_convert::{ArrowData, IntoArrow};
-pub use dora_core::daemon_messages::InputDropReason;
 use dora_core::{
     config::{DataId, OperatorId},
     message::{ArrowTypeInfo, BufferOffset, Metadata},
@@ -21,15 +20,15 @@ pub enum Event {
         id: DataId,
         metadata: Metadata,
         data: ArrowData,
+        /// Number of dropped inputs of this ID.
+        ///
+        /// Specifies the number of inputs of this ID that were dropped _before_ this input.
+        dropped: usize,
     },
     InputClosed {
         id: DataId,
     },
     Error(String),
-    DroppedInputs {
-        reason: InputDropReason,
-        number: usize,
-    },
 }
 
 pub enum RawData {

--- a/apis/rust/node/src/event_stream/event.rs
+++ b/apis/rust/node/src/event_stream/event.rs
@@ -16,6 +16,7 @@ pub enum Event {
     Reload {
         operator_id: Option<OperatorId>,
     },
+    #[non_exhaustive]
     Input {
         id: DataId,
         metadata: Metadata,
@@ -29,6 +30,17 @@ pub enum Event {
         id: DataId,
     },
     Error(String),
+}
+
+impl Event {
+    pub fn new_input(id: DataId, metadata: Metadata, data: ArrowData) -> Event {
+        Event::Input {
+            id,
+            metadata,
+            data,
+            dropped: 0,
+        }
+    }
 }
 
 pub enum RawData {

--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -175,6 +175,9 @@ impl EventStream {
                     tracing::error!("{err:?}");
                     Event::Error(err.wrap_err("internal error").to_string())
                 }
+                NodeEvent::DroppedInputs { reason, number } => {
+                    Event::DroppedInputs { reason, number }
+                }
             },
 
             EventItem::FatalError(err) => {

--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -136,7 +136,12 @@ impl EventStream {
                 NodeEvent::Stop => Event::Stop,
                 NodeEvent::Reload { operator_id } => Event::Reload { operator_id },
                 NodeEvent::InputClosed { id } => Event::InputClosed { id },
-                NodeEvent::Input { id, metadata, data } => {
+                NodeEvent::Input {
+                    id,
+                    metadata,
+                    data,
+                    dropped,
+                } => {
                     let data = match data {
                         None => Ok(None),
                         Some(daemon_messages::DataMessage::Vec(v)) => Ok(Some(RawData::Vec(v))),
@@ -164,6 +169,7 @@ impl EventStream {
                             id,
                             metadata,
                             data: data.into(),
+                            dropped,
                         },
                         Err(err) => Event::Error(format!("{err:?}")),
                     }
@@ -174,9 +180,6 @@ impl EventStream {
                     );
                     tracing::error!("{err:?}");
                     Event::Error(err.wrap_err("internal error").to_string())
-                }
-                NodeEvent::DroppedInputs { reason, number } => {
-                    Event::DroppedInputs { reason, number }
                 }
             },
 

--- a/binaries/cli/src/template/rust/node/main-template.rs
+++ b/binaries/cli/src/template/rust/node/main-template.rs
@@ -10,6 +10,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 id,
                 metadata,
                 data: _,
+                ..
             } => match id.as_str() {
                 other => eprintln!("Received input `{other}`"),
             },

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -984,6 +984,7 @@ impl Daemon {
                             id: input_id.clone(),
                             metadata: metadata.clone(),
                             data: None,
+                            dropped: 0,
                         },
                         &self.clock,
                     );
@@ -1031,6 +1032,7 @@ impl Daemon {
                             id: input_id.clone(),
                             metadata: metadata.clone(),
                             data: Some(message.clone()),
+                            dropped: 0,
                         },
                         &self.clock,
                     );
@@ -1162,6 +1164,7 @@ async fn send_output_to_local_receivers(
                 id: input_id.clone(),
                 metadata: metadata.clone(),
                 data: data.clone(),
+                dropped: 0,
             };
             match channel.send(Timestamped {
                 inner: item,

--- a/binaries/daemon/src/node_communication/mod.rs
+++ b/binaries/daemon/src/node_communication/mod.rs
@@ -315,10 +315,7 @@ impl Listener {
             };
             match queue_size_remaining.get_mut(id) {
                 Some(0) => {
-                    self.dropped_inputs
-                        .entry(id.clone())
-                        .or_default()
-                        .saturating_add(*dropped + 1);
+                    *self.dropped_inputs.entry(id.clone()).or_default() += *dropped + 1;
 
                     if let Some(drop_token) = data.as_ref().and_then(|d| d.drop_token()) {
                         drop_tokens.push(drop_token);

--- a/binaries/runtime/src/lib.rs
+++ b/binaries/runtime/src/lib.rs
@@ -248,7 +248,12 @@ async fn run(
             RuntimeEvent::Event(Event::Reload { operator_id: None }) => {
                 tracing::warn!("Reloading runtime nodes is not supported");
             }
-            RuntimeEvent::Event(Event::Input { id, metadata, data }) => {
+            RuntimeEvent::Event(Event::Input {
+                id,
+                metadata,
+                data,
+                dropped,
+            }) => {
                 let Some((operator_id, input_id)) = id.as_str().split_once('/') else {
                     tracing::warn!("received non-operator input {id}");
                     continue;
@@ -265,6 +270,7 @@ async fn run(
                         id: input_id.clone(),
                         metadata,
                         data,
+                        dropped,
                     })
                     .await
                     .wrap_err_with(|| {

--- a/binaries/runtime/src/lib.rs
+++ b/binaries/runtime/src/lib.rs
@@ -249,10 +249,7 @@ async fn run(
                 tracing::warn!("Reloading runtime nodes is not supported");
             }
             RuntimeEvent::Event(Event::Input {
-                id,
-                metadata,
-                data,
-                dropped,
+                id, metadata, data, ..
             }) => {
                 let Some((operator_id, input_id)) = id.as_str().split_once('/') else {
                     tracing::warn!("received non-operator input {id}");
@@ -266,12 +263,7 @@ async fn run(
                 };
 
                 if let Err(err) = operator_channel
-                    .send_async(Event::Input {
-                        id: input_id.clone(),
-                        metadata,
-                        data,
-                        dropped,
-                    })
+                    .send_async(Event::new_input(input_id.clone(), metadata, data))
                     .await
                     .wrap_err_with(|| {
                         format!("failed to send input `{input_id}` to operator `{operator_id}`")

--- a/binaries/runtime/src/operator/shared_lib.rs
+++ b/binaries/runtime/src/operator/shared_lib.rs
@@ -191,7 +191,7 @@ impl<'lib> SharedLibraryOperator<'lib> {
                     id: input_id,
                     metadata,
                     data,
-                    dropped,
+                    ..
                 } => {
                     let (data_array, schema) = arrow::ffi::to_ffi(&data.to_data())?;
 

--- a/binaries/runtime/src/operator/shared_lib.rs
+++ b/binaries/runtime/src/operator/shared_lib.rs
@@ -191,6 +191,7 @@ impl<'lib> SharedLibraryOperator<'lib> {
                     id: input_id,
                     metadata,
                     data,
+                    dropped,
                 } => {
                     let (data_array, schema) = arrow::ffi::to_ffi(&data.to_data())?;
 

--- a/examples/benchmark/sink/src/main.rs
+++ b/examples/benchmark/sink/src/main.rs
@@ -21,10 +21,7 @@ fn main() -> eyre::Result<()> {
     while let Some(event) = events.recv() {
         match event {
             Event::Input {
-                id,
-                metadata,
-                data,
-                dropped,
+                id, metadata, data, ..
             } => {
                 // check if new size bracket
                 let data_len = data.len();

--- a/examples/benchmark/sink/src/main.rs
+++ b/examples/benchmark/sink/src/main.rs
@@ -20,7 +20,12 @@ fn main() -> eyre::Result<()> {
 
     while let Some(event) = events.recv() {
         match event {
-            Event::Input { id, metadata, data } => {
+            Event::Input {
+                id,
+                metadata,
+                data,
+                dropped,
+            } => {
                 // check if new size bracket
                 let data_len = data.len();
                 if data_len != current_size {

--- a/examples/multiple-daemons/node/src/main.rs
+++ b/examples/multiple-daemons/node/src/main.rs
@@ -18,6 +18,7 @@ fn main() -> eyre::Result<()> {
                 id,
                 metadata,
                 data: _,
+                dropped,
             } => match id.as_str() {
                 "tick" => {
                     let random: u64 = rand::random();

--- a/examples/multiple-daemons/node/src/main.rs
+++ b/examples/multiple-daemons/node/src/main.rs
@@ -18,7 +18,7 @@ fn main() -> eyre::Result<()> {
                 id,
                 metadata,
                 data: _,
-                dropped,
+                ..
             } => match id.as_str() {
                 "tick" => {
                     let random: u64 = rand::random();

--- a/examples/multiple-daemons/sink/src/main.rs
+++ b/examples/multiple-daemons/sink/src/main.rs
@@ -10,6 +10,7 @@ fn main() -> eyre::Result<()> {
                 id,
                 metadata: _,
                 data,
+                dropped,
             } => match id.as_str() {
                 "message" => {
                     let received_string: &str =

--- a/examples/multiple-daemons/sink/src/main.rs
+++ b/examples/multiple-daemons/sink/src/main.rs
@@ -10,7 +10,7 @@ fn main() -> eyre::Result<()> {
                 id,
                 metadata: _,
                 data,
-                dropped,
+                ..
             } => match id.as_str() {
                 "message" => {
                     let received_string: &str =

--- a/examples/rust-dataflow/node/src/main.rs
+++ b/examples/rust-dataflow/node/src/main.rs
@@ -18,6 +18,7 @@ fn main() -> eyre::Result<()> {
                 id,
                 metadata,
                 data: _,
+                dropped,
             } => match id.as_str() {
                 "tick" => {
                     let random: u64 = rand::random();

--- a/examples/rust-dataflow/node/src/main.rs
+++ b/examples/rust-dataflow/node/src/main.rs
@@ -18,7 +18,7 @@ fn main() -> eyre::Result<()> {
                 id,
                 metadata,
                 data: _,
-                dropped,
+                ..
             } => match id.as_str() {
                 "tick" => {
                     let random: u64 = rand::random();

--- a/examples/rust-dataflow/sink/src/main.rs
+++ b/examples/rust-dataflow/sink/src/main.rs
@@ -10,6 +10,7 @@ fn main() -> eyre::Result<()> {
                 id,
                 metadata: _,
                 data,
+                ..
             } => match id.as_str() {
                 "message" => {
                     let received_string: &str =

--- a/examples/rust-dataflow/status-node/src/main.rs
+++ b/examples/rust-dataflow/status-node/src/main.rs
@@ -10,7 +10,9 @@ fn main() -> eyre::Result<()> {
     let mut ticks = 0;
     while let Some(event) = events.recv() {
         match event {
-            Event::Input { id, metadata, data } => match id.as_ref() {
+            Event::Input {
+                id, metadata, data, ..
+            } => match id.as_ref() {
                 "tick" => {
                     ticks += 1;
                 }

--- a/libraries/core/src/daemon_messages.rs
+++ b/libraries/core/src/daemon_messages.rs
@@ -155,21 +155,15 @@ pub enum NodeEvent {
         id: DataId,
         metadata: Metadata,
         data: Option<DataMessage>,
+        /// Number of dropped inputs of this ID.
+        ///
+        /// Specifies the number of inputs of this ID that were dropped _before_ this input.
+        dropped: usize,
     },
     InputClosed {
         id: DataId,
     },
     AllInputsClosed,
-    DroppedInputs {
-        reason: InputDropReason,
-        number: usize,
-    },
-}
-
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[non_exhaustive]
-pub enum InputDropReason {
-    QueueSize,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/libraries/core/src/daemon_messages.rs
+++ b/libraries/core/src/daemon_messages.rs
@@ -160,6 +160,16 @@ pub enum NodeEvent {
         id: DataId,
     },
     AllInputsClosed,
+    DroppedInputs {
+        reason: InputDropReason,
+        number: usize,
+    },
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
+pub enum InputDropReason {
+    QueueSize,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/tool_nodes/dora-record/src/main.rs
+++ b/tool_nodes/dora-record/src/main.rs
@@ -26,10 +26,7 @@ async fn main() -> eyre::Result<()> {
     while let Some(event) = events.recv() {
         match event {
             Event::Input {
-                id,
-                data,
-                metadata,
-                dropped,
+                id, data, metadata, ..
             } => {
                 match writers.get(&id) {
                     None => {

--- a/tool_nodes/dora-record/src/main.rs
+++ b/tool_nodes/dora-record/src/main.rs
@@ -25,7 +25,12 @@ async fn main() -> eyre::Result<()> {
 
     while let Some(event) = events.recv() {
         match event {
-            Event::Input { id, data, metadata } => {
+            Event::Input {
+                id,
+                data,
+                metadata,
+                dropped,
+            } => {
                 match writers.get(&id) {
                     None => {
                         let field_uhlc = Field::new("timestamp_uhlc", DataType::UInt64, false);

--- a/tool_nodes/dora-rerun/src/main.rs
+++ b/tool_nodes/dora-rerun/src/main.rs
@@ -43,6 +43,7 @@ fn main() -> Result<()> {
             id,
             data,
             metadata: _,
+            ..
         } = event
         {
             if id.as_str().contains("image") {


### PR DESCRIPTION
This gives nodes a way to check whether some inputs have been dropped by dora. The event also includes a drop reason, which is currently only the queue size.

This might make it easier to debug issues such as https://github.com/dora-rs/dora/issues/515