### PR TITLE
Auto fetch logs and clean up error trace for better readibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2268,6 +2268,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml 0.9.34+deprecated",
+ "simple-eyre",
  "termcolor",
  "tokio",
  "tokio-stream",
@@ -8704,6 +8705,16 @@ checksum = "e041bb827d1bfca18f213411d51b665309f1afb37a04a5d1464530e13779fc0f"
 dependencies = [
  "console",
  "similar",
+]
+
+[[package]]
+name = "simple-eyre"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b561532e8ffe7ecf09108c4f662896a9ec3eac4999eba84015ec3dcb8cc630a"
+dependencies = [
+ "eyre",
+ "indenter",
 ]
 
 [[package]]

--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -19,6 +19,7 @@ tracing = ["dep:dora-tracing"]
 [dependencies]
 clap = { version = "4.0.3", features = ["derive"] }
 eyre = "0.6.8"
+simple-eyre = "0.3"
 dora-core = { workspace = true }
 dora-node-api-c = { workspace = true }
 dora-operator-api-c = { workspace = true }

--- a/binaries/cli/src/main.rs
+++ b/binaries/cli/src/main.rs
@@ -13,7 +13,7 @@ use dora_daemon::Daemon;
 #[cfg(feature = "tracing")]
 use dora_tracing::set_up_tracing;
 use duration_str::parse;
-use eyre::{bail, Context};
+use eyre::{bail, Context, Result};
 use std::net::SocketAddr;
 use std::{
     net::{IpAddr, Ipv4Addr},
@@ -232,11 +232,13 @@ enum Lang {
     Cxx,
 }
 
-fn main() {
+fn main() -> Result<()> {
+    simple_eyre::install()?;
     if let Err(err) = run() {
         eprintln!("{err:#}");
         std::process::exit(1);
     }
+    Ok(())
 }
 
 fn run() -> eyre::Result<()> {

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -612,7 +612,7 @@ fn dataflow_result(
     if errors.is_empty() {
         Ok(())
     } else {
-        let mut formatted = format!("errors occurred in dataflow {dataflow_uuid}:\n");
+        let mut formatted = format!("{dataflow_uuid} failed on:\n");
         formatted.push_str(&errors.join("\n"));
         Err(formatted)
     }

--- a/binaries/daemon/src/log.rs
+++ b/binaries/daemon/src/log.rs
@@ -1,9 +1,31 @@
-use std::path::{Path, PathBuf};
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
 
 use dora_core::config::NodeId;
+use eyre::{Context, Report};
+use tokio::task::JoinHandle;
 use uuid::Uuid;
 
 pub fn log_path(working_dir: &Path, dataflow_id: &Uuid, node_id: &NodeId) -> PathBuf {
     let dataflow_dir = working_dir.join("out").join(dataflow_id.to_string());
     dataflow_dir.join(format!("log_{node_id}.txt"))
+}
+
+pub async fn pretty_string_dataflow_errors(
+    node_errors: BTreeMap<NodeId, JoinHandle<Result<Option<Report>, Report>>>,
+) -> eyre::Result<String> {
+    let mut output = "".to_owned();
+    for (_node, error) in node_errors {
+        use std::fmt::Write;
+        if let Some(error) = error
+            .await
+            .context("Could not join error")?
+            .context("Could not get error logs")?
+        {
+            write!(&mut output, "- {error}").context("could not write error")?;
+        }
+    }
+    Ok(output)
 }

--- a/binaries/daemon/src/pending.rs
+++ b/binaries/daemon/src/pending.rs
@@ -77,7 +77,7 @@ impl PendingNodes {
         clock: &HLC,
     ) -> eyre::Result<()> {
         if self.local_nodes.remove(node_id) {
-            tracing::warn!("node `{node_id}` exited before initializing dora connection");
+            tracing::info!("node `{node_id}` exited before initializing dora connection");
             self.exited_before_subscribe.insert(node_id.clone());
             self.update_dataflow_status(coordinator_connection, clock)
                 .await?;

--- a/binaries/daemon/src/spawn.rs
+++ b/binaries/daemon/src/spawn.rs
@@ -364,14 +364,6 @@ pub async fn spawn_node(
                 }
             };
 
-            if buffer.starts_with("Traceback (most recent call last):") {
-                if !finished {
-                    continue;
-                } else {
-                    tracing::error!("{dataflow_id}/{}: \n{buffer}", node_id);
-                }
-            }
-
             // send the buffered lines
             let lines = std::mem::take(&mut buffer);
             let sent = stderr_tx.send(lines.clone()).await;

--- a/examples/python-dataflow/object_detection.py
+++ b/examples/python-dataflow/object_detection.py
@@ -10,7 +10,12 @@ import pyarrow as pa
 
 model = YOLO("yolov8n.pt")
 
-node = Node()
+try:
+    node = Node()
+except RuntimeError as e:
+    print("Dataflow initialization failed: ", e)
+    exit(0)
+
 
 for event in node:
     event_type = event["type"]

--- a/examples/python-dataflow/plot.py
+++ b/examples/python-dataflow/plot.py
@@ -79,7 +79,12 @@ class Plotter:
 
 
 plotter = Plotter()
-node = Node()
+
+try:
+    node = Node()
+except RuntimeError as e:
+    print("Dataflow initialization failed: ", e)
+    exit(0)
 
 for event in node:
     event_type = event["type"]

--- a/examples/python-dataflow/webcam.py
+++ b/examples/python-dataflow/webcam.py
@@ -8,7 +8,11 @@ import cv2
 
 from dora import Node
 
-node = Node()
+try:
+    node = Node()
+except RuntimeError as e:
+    print("Could not initiate node with error: ", e)
+    exit(0)
 
 CAMERA_INDEX = int(os.getenv("CAMERA_INDEX", 0))
 CAMERA_WIDTH = 640

--- a/examples/rust-dataflow/node/src/main.rs
+++ b/examples/rust-dataflow/node/src/main.rs
@@ -5,7 +5,10 @@ fn main() -> eyre::Result<()> {
 
     let output = DataId::from("random".to_owned());
 
-    let (mut node, mut events) = DoraNode::init_from_env()?;
+    let Ok((mut node, mut events)) = DoraNode::init_from_env() else {
+        println!("Could not initiate dora node");
+        return Ok(());
+    };
 
     for i in 0..100 {
         let event = match events.recv() {

--- a/examples/rust-dataflow/sink/src/main.rs
+++ b/examples/rust-dataflow/sink/src/main.rs
@@ -2,7 +2,10 @@ use dora_node_api::{self, DoraNode, Event};
 use eyre::{bail, Context};
 
 fn main() -> eyre::Result<()> {
-    let (_node, mut events) = DoraNode::init_from_env()?;
+    let Ok((_node, mut events)) = DoraNode::init_from_env() else {
+        println!("Could not initiate dora node");
+        return Ok(());
+    };
 
     while let Some(event) = events.recv() {
         match event {

--- a/examples/rust-dataflow/status-node/src/main.rs
+++ b/examples/rust-dataflow/status-node/src/main.rs
@@ -5,7 +5,10 @@ fn main() -> eyre::Result<()> {
     println!("hello");
 
     let status_output = DataId::from("status".to_owned());
-    let (mut node, mut events) = DoraNode::init_from_env()?;
+    let Ok((mut node, mut events)) = DoraNode::init_from_env() else {
+        println!("Could not initiate dora node");
+        return Ok(());
+    };
 
     let mut ticks = 0;
     while let Some(event) = events.recv() {

--- a/libraries/core/src/bin/generate_schema.rs
+++ b/libraries/core/src/bin/generate_schema.rs
@@ -3,7 +3,7 @@ use std::{env, path::Path};
 use dora_core::descriptor::Descriptor;
 use schemars::schema_for;
 
-fn main() -> () {
+fn main() {
     let schema = schema_for!(Descriptor);
     let raw_schema =
         serde_json::to_string_pretty(&schema).expect("Could not serialize schema to json");

--- a/tool_nodes/dora-record/src/main.rs
+++ b/tool_nodes/dora-record/src/main.rs
@@ -19,7 +19,10 @@ use tokio::sync::mpsc;
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
-    let (node, mut events) = DoraNode::init_from_env()?;
+    let Ok((node, mut events)) = DoraNode::init_from_env() else {
+        println!("Could not initiate dora node");
+        return Ok(());
+    };
     let dataflow_id = node.dataflow_id();
     let mut writers = HashMap::new();
 

--- a/tool_nodes/dora-rerun/src/main.rs
+++ b/tool_nodes/dora-rerun/src/main.rs
@@ -16,8 +16,10 @@ fn main() -> Result<()> {
     let rt = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
     let _guard = rt.enter();
 
-    let (_node, mut events) =
-        DoraNode::init_from_env().context("Could not initialize dora node")?;
+    let Ok((_node, mut events)) = DoraNode::init_from_env() else {
+        println!("Could not initiate dora node");
+        return Ok(());
+    };
 
     // Limit memory usage
     let mut options = SpawnOptions::default();


### PR DESCRIPTION
This PR auto fetch logs instead of asking for users to search for logs.

It also reduces error summary to let users directly get the most useful information.

## Before

```bash
018ffe79-1c0c-7b68-8886-d8cff079c232
  2024-06-09T19:28:21.162169Z ERROR dora_daemon::spawn: 018ffe79-1c0c-7b68-8886-d8cff079c232/plot: 
Traceback (most recent call last):
  File "/home/peter/Documents/work/dora/examples/python-dataflow/plot.py", line 83, in <module>
    assert False, "test PR"
AssertionError: test PR

    at binaries/daemon/src/spawn.rs:371

  2024-06-09T19:28:21.170014Z ERROR dora_daemon: 
    018ffe79-1c0c-7b68-8886-d8cff079c232/plot failed with exit code 1.

    Check logs using: dora logs 018ffe79-1c0c-7b68-8886-d8cff079c232 plot
                            
    at binaries/daemon/src/lib.rs:1077

  2024-06-09T19:28:21.170037Z  WARN dora_daemon::pending: node `plot` exited before initializing dora connection
    at binaries/daemon/src/pending.rs:80


  2024-06-09T19:28:22.877741Z ERROR dora_daemon::spawn: 018ffe79-1c0c-7b68-8886-d8cff079c232/webcam: 
Traceback (most recent call last):
  File "/home/peter/Documents/work/dora/examples/python-dataflow/webcam.py", line 11, in <module>
    node = Node()
RuntimeError: failed to init event stream

Caused by:
    subscribe failed: Some nodes exited before subscribing to dora: {NodeId("plot")}

    This is typically happens when an initialization error occurs
                    in the node or operator. To check the output of the failed
                    nodes, run `dora logs 018ffe79-1c0c-7b68-8886-d8cff079c232 plot`.

Location:
    apis/rust/node/src/event_stream/mod.rs:90:17

    at binaries/daemon/src/spawn.rs:371

  2024-06-09T19:28:22.893596Z ERROR dora_daemon: 
    018ffe79-1c0c-7b68-8886-d8cff079c232/webcam failed with exit code 1.

    Check logs using: dora logs 018ffe79-1c0c-7b68-8886-d8cff079c232 webcam
                            
    at binaries/daemon/src/lib.rs:1077

  2024-06-09T19:28:23.247953Z ERROR dora_daemon::spawn: 018ffe79-1c0c-7b68-8886-d8cff079c232/object_detection: 
Traceback (most recent call last):
  File "/home/peter/Documents/work/dora/examples/python-dataflow/object_detection.py", line 13, in <module>
    node = Node()
RuntimeError: failed to init event stream

Caused by:
    subscribe failed: Some nodes exited before subscribing to dora: {NodeId("plot")}

    This is typically happens when an initialization error occurs
                    in the node or operator. To check the output of the failed
                    nodes, run `dora logs 018ffe79-1c0c-7b68-8886-d8cff079c232 plot`.

Location:
    apis/rust/node/src/event_stream/mod.rs:90:17

    at binaries/daemon/src/spawn.rs:371

  2024-06-09T19:28:23.263843Z ERROR dora_daemon: 
    018ffe79-1c0c-7b68-8886-d8cff079c232/object_detection failed with exit code 1.

    Check logs using: dora logs 018ffe79-1c0c-7b68-8886-d8cff079c232 object_detection
                            
    at binaries/daemon/src/lib.rs:1077

  2024-06-09T19:28:23.264003Z ERROR dora_coordinator: some nodes failed:
  - object_detection: 
    018ffe79-1c0c-7b68-8886-d8cff079c232/object_detection failed with exit code 1.

    Check logs using: dora logs 018ffe79-1c0c-7b68-8886-d8cff079c232 object_detection
                            
  - plot: 
    018ffe79-1c0c-7b68-8886-d8cff079c232/plot failed with exit code 1.

    Check logs using: dora logs 018ffe79-1c0c-7b68-8886-d8cff079c232 plot
                            
  - webcam: 
    018ffe79-1c0c-7b68-8886-d8cff079c232/webcam failed with exit code 1.

    Check logs using: dora logs 018ffe79-1c0c-7b68-8886-d8cff079c232 webcam
                            

Location:
    /home/peter/Documents/work/dora/binaries/coordinator/src/listener.rs:90:56
    at binaries/coordinator/src/lib.rs:279

dataflow failed: errors occurred in dataflow 018ffe79-1c0c-7b68-8886-d8cff079c232:
- machine ``:
    some nodes failed:
      - object_detection: 
        018ffe79-1c0c-7b68-8886-d8cff079c232/object_detection failed with exit code 1.
    
        Check logs using: dora logs 018ffe79-1c0c-7b68-8886-d8cff079c232 object_detection
                                
      - plot: 
        018ffe79-1c0c-7b68-8886-d8cff079c232/plot failed with exit code 1.
    
        Check logs using: dora logs 018ffe79-1c0c-7b68-8886-d8cff079c232 plot
                                
      - webcam: 
        018ffe79-1c0c-7b68-8886-d8cff079c232/webcam failed with exit code 1.
    
        Check logs using: dora logs 018ffe79-1c0c-7b68-8886-d8cff079c232 webcam
                                
    
    Location:
        /home/peter/Documents/work/dora/binaries/coordinator/src/listener.rs:90:56

```

## After

```bash
018ffe7b-39d7-725a-a812-ac9c220a11c8
  2024-06-09T19:30:41.604627Z ERROR dora_daemon: 018ffe7b-39d7-725a-a812-ac9c220a11c8/plot exited with code 1 with last logs:
    
Traceback (most recent call last):
  File "/home/peter/Documents/work/dora/examples/python-dataflow/plot.py", line 88, in <module>
    assert False, "test PR"
AssertionError: test PR


    at binaries/daemon/src/lib.rs:1109


  2024-06-09T19:30:52.237132Z ERROR dora_coordinator: - 018ffe7b-39d7-725a-a812-ac9c220a11c8/plot exited with code 1 with last logs:
    
Traceback (most recent call last):
  File "/home/peter/Documents/work/dora/examples/python-dataflow/plot.py", line 88, in <module>
    assert False, "test PR"
AssertionError: test PR


    at binaries/coordinator/src/lib.rs:279

dataflow failed: 018ffe7b-39d7-725a-a812-ac9c220a11c8 failed on:
- machine ``:
    - 018ffe7b-39d7-725a-a812-ac9c220a11c8/plot exited with code 1 with last logs:
        
    Traceback (most recent call last):
      File "/home/peter/Documents/work/dora/examples/python-dataflow/plot.py", line 88, in <module>
        assert False, "test PR"
    AssertionError: test PR
    
```

---

On a terminal without stdout from `dora up`

## Before

```bash
~/D/w/d/e/python-dataflow ❯❯❯ dora start dataflow.yml --attach        
018ffe7e-f6fa-7431-9dad-3c127137ac43
^Cdataflow failed: errors occurred in dataflow 018ffe7e-f6fa-7431-9dad-3c127137ac43:
- machine ``:
    some nodes failed:
      - plot: 
        018ffe7e-f6fa-7431-9dad-3c127137ac43/plot failed with exit code 1.
    
        Check logs using: dora logs 018ffe7e-f6fa-7431-9dad-3c127137ac43 plot
                                
      - webcam: 
        018ffe7e-f6fa-7431-9dad-3c127137ac43/webcam failed with signal `SIGKILL`
    
        Check logs using: dora logs 018ffe7e-f6fa-7431-9dad-3c127137ac43 webcam
                                
    
    Location:
        /home/peter/Documents/work/dora/binaries/coordinator/src/listener.rs:90:56
```

## After

```bash
~/D/w/d/e/python-dataflow ❯❯❯ dora start dataflow.yml --attach          
018ffe7d-6648-7177-8986-f5734988eee2
^Cdataflow failed: 018ffe7d-6648-7177-8986-f5734988eee2 failed on:
- machine ``:
    - 018ffe7d-6648-7177-8986-f5734988eee2/plot exited with code 1 with last logs:
        
    Traceback (most recent call last):
      File "/home/peter/Documents/work/dora/examples/python-dataflow/plot.py", line 88, in <module>
        assert False, "test PR"
    AssertionError: test PR
    
    - 018ffe7d-6648-7177-8986-f5734988eee2/webcam exited with `SIGKILL` with last logs:
        
 ``` 