### PR TITLE
Implement file-based logging in daemon and coordinator

### DIFF
--- a/binaries/cli/src/main.rs
+++ b/binaries/cli/src/main.rs
@@ -250,16 +250,24 @@ fn run() -> eyre::Result<()> {
     let args = Args::parse();
 
     #[cfg(feature = "tracing")]
-    match args.command {
-        Command::Daemon { quiet, .. } => {
-            set_up_tracing_opts("dora-daemon", !quiet, true)
+    match &args.command {
+        Command::Daemon {
+            quiet, machine_id, ..
+        } => {
+            let name = "dora-daemon";
+            let filename = machine_id
+                .as_ref()
+                .map(|id| format!("{name}-{id}"))
+                .unwrap_or(name.to_string());
+            set_up_tracing_opts(name, !quiet, Some(&filename))
                 .context("failed to set up tracing subscriber")?;
         }
         Command::Runtime => {
             // Do not set the runtime in the cli.
         }
         Command::Coordinator { quiet, .. } => {
-            set_up_tracing_opts("dora-coordinator", !quiet, true)
+            let name = "dora-coordinator";
+            set_up_tracing_opts(name, !quiet, Some(name))
                 .context("failed to set up tracing subscriber")?;
         }
         _ => {

--- a/binaries/cli/src/main.rs
+++ b/binaries/cli/src/main.rs
@@ -252,14 +252,14 @@ fn run() -> eyre::Result<()> {
     #[cfg(feature = "tracing")]
     match args.command {
         Command::Daemon { quiet, .. } => {
-            set_up_tracing_opts("dora-daemon", !quiet)
+            set_up_tracing_opts("dora-daemon", !quiet, true)
                 .context("failed to set up tracing subscriber")?;
         }
         Command::Runtime => {
             // Do not set the runtime in the cli.
         }
         Command::Coordinator { quiet, .. } => {
-            set_up_tracing_opts("dora-coordinator", !quiet)
+            set_up_tracing_opts("dora-coordinator", !quiet, true)
                 .context("failed to set up tracing subscriber")?;
         }
         _ => {

--- a/libraries/extensions/telemetry/tracing/src/lib.rs
+++ b/libraries/extensions/telemetry/tracing/src/lib.rs
@@ -26,7 +26,7 @@ pub fn set_up_tracing_opts(name: &str, stdout: bool, file: bool) -> eyre::Result
         // Filter log using `RUST_LOG`. More useful for CLI.
         let env_filter = EnvFilter::from_default_env().or(LevelFilter::WARN);
         let layer = tracing_subscriber::fmt::layer()
-            .pretty()
+            .compact()
             .with_filter(env_filter);
         layers.push(layer.boxed());
     }

--- a/libraries/extensions/telemetry/tracing/src/lib.rs
+++ b/libraries/extensions/telemetry/tracing/src/lib.rs
@@ -3,6 +3,8 @@
 //! This module init a tracing propagator for Rust code that requires tracing, and is
 //! able to serialize and deserialize context that has been sent via the middleware.
 
+use std::path::Path;
+
 use eyre::Context as EyreContext;
 use tracing::metadata::LevelFilter;
 use tracing_subscriber::{
@@ -14,23 +16,38 @@ use tracing_subscriber::Registry;
 pub mod telemetry;
 
 pub fn set_up_tracing(name: &str) -> eyre::Result<()> {
-    set_up_tracing_opts(name, true)
+    set_up_tracing_opts(name, true, false)
 }
 
-pub fn set_up_tracing_opts(name: &str, stdout: bool) -> eyre::Result<()> {
-    let stdout_filter = if stdout {
-        LevelFilter::TRACE
-    } else {
-        LevelFilter::OFF
-    };
-    // Filter log using `RUST_LOG`. More useful for CLI.
-    let env_filter = EnvFilter::from_default_env().or(LevelFilter::WARN);
-    let stdout_log = tracing_subscriber::fmt::layer()
-        .pretty()
-        .with_filter(stdout_filter)
-        .with_filter(env_filter);
+pub fn set_up_tracing_opts(name: &str, stdout: bool, file: bool) -> eyre::Result<()> {
+    let mut layers = Vec::new();
 
-    let registry = Registry::default().with(stdout_log);
+    if stdout {
+        // Filter log using `RUST_LOG`. More useful for CLI.
+        let env_filter = EnvFilter::from_default_env().or(LevelFilter::WARN);
+        let layer = tracing_subscriber::fmt::layer()
+            .pretty()
+            .with_filter(env_filter);
+        layers.push(layer.boxed());
+    }
+
+    if file {
+        let out_dir = Path::new("out");
+        std::fs::create_dir_all(out_dir).context("failed to create `out` directory")?;
+        let path = out_dir.join(format!("{name}.txt"));
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .context("failed to create log file")?;
+        // Filter log using `RUST_LOG`. More useful for CLI.
+        let layer = tracing_subscriber::fmt::layer()
+            .with_ansi(false)
+            .with_writer(file)
+            .with_filter(LevelFilter::INFO);
+        layers.push(layer.boxed());
+    }
+
     if let Some(endpoint) = std::env::var_os("DORA_JAEGER_TRACING") {
         let endpoint = endpoint
             .to_str()
@@ -38,13 +55,11 @@ pub fn set_up_tracing_opts(name: &str, stdout: bool) -> eyre::Result<()> {
         let tracer = crate::telemetry::init_jaeger_tracing(name, endpoint)
             .wrap_err("Could not instantiate tracing")?;
         let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
-        let subscriber = registry.with(telemetry);
-        tracing::subscriber::set_global_default(subscriber).context(format!(
-            "failed to set tracing global subscriber for {name}"
-        ))
-    } else {
-        tracing::subscriber::set_global_default(registry).context(format!(
-            "failed to set tracing global subscriber for {name}"
-        ))
+        layers.push(telemetry.boxed());
     }
+
+    let registry = Registry::default().with(layers);
+    tracing::subscriber::set_global_default(registry).context(format!(
+        "failed to set tracing global subscriber for {name}"
+    ))
 }

--- a/libraries/extensions/telemetry/tracing/src/lib.rs
+++ b/libraries/extensions/telemetry/tracing/src/lib.rs
@@ -16,10 +16,10 @@ use tracing_subscriber::Registry;
 pub mod telemetry;
 
 pub fn set_up_tracing(name: &str) -> eyre::Result<()> {
-    set_up_tracing_opts(name, true, false)
+    set_up_tracing_opts(name, true, None)
 }
 
-pub fn set_up_tracing_opts(name: &str, stdout: bool, file: bool) -> eyre::Result<()> {
+pub fn set_up_tracing_opts(name: &str, stdout: bool, filename: Option<&str>) -> eyre::Result<()> {
     let mut layers = Vec::new();
 
     if stdout {
@@ -31,10 +31,10 @@ pub fn set_up_tracing_opts(name: &str, stdout: bool, file: bool) -> eyre::Result
         layers.push(layer.boxed());
     }
 
-    if file {
+    if let Some(filename) = filename {
         let out_dir = Path::new("out");
         std::fs::create_dir_all(out_dir).context("failed to create `out` directory")?;
-        let path = out_dir.join(format!("{name}.txt"));
+        let path = out_dir.join(filename).with_extension("txt");
         let file = std::fs::OpenOptions::new()
             .create(true)
             .append(true)


### PR DESCRIPTION
- Log deamon and coordinator output to files
- Use compact formatting for stdout logs
- Include machine ID in daemon log file name if set

Builds upon #548 