### PR TITLE
Spawn daemon and coordinator in quiet mode on `dora up`

### DIFF
--- a/binaries/cli/src/up.rs
+++ b/binaries/cli/src/up.rs
@@ -85,6 +85,7 @@ fn start_coordinator() -> eyre::Result<()> {
     let mut cmd =
         Command::new(std::env::current_exe().wrap_err("failed to get current executable path")?);
     cmd.arg("coordinator");
+    cmd.arg("--quiet");
     cmd.spawn().wrap_err("failed to run `dora coordinator`")?;
 
     println!("started dora coordinator");
@@ -96,6 +97,7 @@ fn start_daemon() -> eyre::Result<()> {
     let mut cmd =
         Command::new(std::env::current_exe().wrap_err("failed to get current executable path")?);
     cmd.arg("daemon");
+    cmd.arg("--quiet");
     cmd.spawn().wrap_err("failed to run `dora daemon`")?;
 
     println!("started dora daemon");


### PR DESCRIPTION
Avoids clobbering the stdout with daemon and coordinator log messages. The logs are still available as files.

Builds upon #549 