### PR TITLE
Ignore-quicker-pending-drop-token

### DIFF
--- a/apis/rust/node/src/event_stream/thread.rs
+++ b/apis/rust/node/src/event_stream/thread.rs
@@ -220,14 +220,14 @@ fn report_remaining_drop_tokens(
 
         let mut still_pending = Vec::new();
         for (token, rx, since, _) in pending_drop_tokens.drain(..) {
-            match rx.recv_timeout(Duration::from_millis(100)) {
+            match rx.recv_timeout(Duration::from_millis(50)) {
                 Ok(()) => return Err(eyre!("Node API should not send anything on ACK channel")),
                 Err(flume::RecvTimeoutError::Disconnected) => {
                     // the event was dropped -> add the drop token to the list
                     drop_tokens.push(token);
                 }
                 Err(flume::RecvTimeoutError::Timeout) => {
-                    let duration = Duration::from_secs(1);
+                    let duration = Duration::from_millis(200);
                     if since.elapsed() > duration {
                         tracing::warn!(
                             "timeout: node finished, but token {token:?} was still not \

--- a/apis/rust/node/src/event_stream/thread.rs
+++ b/apis/rust/node/src/event_stream/thread.rs
@@ -227,7 +227,7 @@ fn report_remaining_drop_tokens(
                     drop_tokens.push(token);
                 }
                 Err(flume::RecvTimeoutError::Timeout) => {
-                    let duration = Duration::from_secs(30);
+                    let duration = Duration::from_secs(1);
                     if since.elapsed() > duration {
                         tracing::warn!(
                             "timeout: node finished, but token {token:?} was still not \

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -401,7 +401,7 @@ impl Drop for DoraNode {
                 );
             }
 
-            match self.drop_stream.recv_timeout(Duration::from_secs(10)) {
+            match self.drop_stream.recv_timeout(Duration::from_millis(500)) {
                 Ok(token) => {
                     self.sent_out_shared_memory.remove(&token);
                 }

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1567,7 +1567,7 @@ impl RunningDataflow {
         let running_nodes = self.running_nodes.clone();
         let grace_duration_kills = self.grace_duration_kills.clone();
         tokio::spawn(async move {
-            let duration = grace_duration.unwrap_or(Duration::from_millis(500));
+            let duration = grace_duration.unwrap_or(Duration::from_millis(1000));
             tokio::time::sleep(duration).await;
             let mut system = sysinfo::System::new();
             system.refresh_processes();

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1567,7 +1567,7 @@ impl RunningDataflow {
         let running_nodes = self.running_nodes.clone();
         let grace_duration_kills = self.grace_duration_kills.clone();
         tokio::spawn(async move {
-            let duration = grace_duration.unwrap_or(Duration::from_millis(1000));
+            let duration = grace_duration.unwrap_or(Duration::from_millis(2000));
             tokio::time::sleep(duration).await;
             let mut system = sysinfo::System::new();
             system.refresh_processes();


### PR DESCRIPTION
This PR reduces the time required to ignore unsent drop token from 30s to 1s as in Python this error is linked to a drop token race condition with the GIL.

