### PR TITLE
Derive pyo3 special method for node

### DIFF
--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -12,7 +12,7 @@ use eyre::Context;
 use futures::{Stream, StreamExt};
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict};
-use pyo3_special_method_derive::Dir;
+use pyo3_special_method_derive::{Dict, Dir, Repr, Str};
 
 /// The custom node API lets you integrate `dora` into your application.
 /// It allows you to retrieve input and send output in any fashion you want.
@@ -27,9 +27,10 @@ use pyo3_special_method_derive::Dir;
 ///
 /// :type node_id: str, optional
 #[pyclass]
-#[derive(Dir)]
+#[derive(Dir, Dict, Str, Repr)]
 pub struct Node {
     events: Events,
+    #[pyo3_smd(skip)]
     pub node: DoraNode,
 }
 


### PR DESCRIPTION
Derive `Node` to make it more readable for Python users.

cc @EricLBuehler 