### PR TITLE
add try from for floats

### DIFF
--- a/libraries/arrow-convert/src/from_impls.rs
+++ b/libraries/arrow-convert/src/from_impls.rs
@@ -107,6 +107,25 @@ impl TryFrom<&ArrowData> for i64 {
     }
 }
 
+impl TryFrom<&ArrowData> for f32 {
+    type Error = eyre::Report;
+    fn try_from(value: &ArrowData) -> Result<Self, Self::Error> {
+        let array = value
+            .as_primitive_opt::<arrow::datatypes::Float32Type>()
+            .context("not a primitive Float32Type array")?;
+        extract_single_primitive(array)
+    }
+}
+impl TryFrom<&ArrowData> for f64 {
+    type Error = eyre::Report;
+    fn try_from(value: &ArrowData) -> Result<Self, Self::Error> {
+        let array = value
+            .as_primitive_opt::<arrow::datatypes::Float64Type>()
+            .context("not a primitive Float64Type array")?;
+        extract_single_primitive(array)
+    }
+}
+
 impl<'a> TryFrom<&'a ArrowData> for &'a str {
     type Error = eyre::Report;
     fn try_from(value: &'a ArrowData) -> Result<Self, Self::Error> {


### PR DESCRIPTION
TryFrom for floats appears to be missing from : libraries/arrow-convert/src/from_impls.rs. I'm assuming it should be there, as it exists in into_impls.rs.

When parsing an event the below is currently invalid the try from for f32 and f64 doesn't exist:

`let value: f32 = TryFrom::try_from(&data).context("expected f32 message")?;`

Hopefully it's alright I made a pr without an issue, however this felt trivial. Let me know if I'm missing something.