### PR TITLE
C timestamp

### DIFF
--- a/apis/c/node/node_api.h
+++ b/apis/c/node/node_api.h
@@ -18,5 +18,5 @@ enum DoraEventType read_dora_event_type(void *dora_event);
 
 void read_dora_input_id(void *dora_event, char **out_ptr, size_t *out_len);
 void read_dora_input_data(void *dora_event, char **out_ptr, size_t *out_len);
-uint64_t read_dora_input_timestamp(void *dora_event);
+unsigned long long read_dora_input_timestamp(void *dora_event);
 int dora_send_output(void *dora_context, char *id_ptr, size_t id_len, char *data_ptr, size_t data_len);

--- a/apis/c/node/node_api.h
+++ b/apis/c/node/node_api.h
@@ -18,5 +18,5 @@ enum DoraEventType read_dora_event_type(void *dora_event);
 
 void read_dora_input_id(void *dora_event, char **out_ptr, size_t *out_len);
 void read_dora_input_data(void *dora_event, char **out_ptr, size_t *out_len);
-
+uint64_t read_dora_input_timestamp(void *dora_event);
 int dora_send_output(void *dora_context, char *id_ptr, size_t id_len, char *data_ptr, size_t data_len);

--- a/apis/c/node/src/lib.rs
+++ b/apis/c/node/src/lib.rs
@@ -197,6 +197,8 @@ pub unsafe extern "C" fn read_dora_input_data(
 
 /// Reads out the timestamp of the given input event from metadata.
 ///
+/// ## Safety
+/// 
 /// Return `0` if the given event is not an input event.
 #[no_mangle]
 pub unsafe extern "C" fn read_dora_input_timestamp(event: *const ()) -> core::ffi::c_ulonglong {

--- a/apis/c/node/src/lib.rs
+++ b/apis/c/node/src/lib.rs
@@ -196,12 +196,10 @@ pub unsafe extern "C" fn read_dora_input_data(
 }
 
 /// Reads out the timestamp of the given input event from metadata.
-/// 
+///
 /// Return `0` if the given event is not an input event.
 #[no_mangle]
-pub unsafe extern "C" fn read_dora_input_data_timestamp(
-    event: *const (),
-) -> core::ffi::c_ulonglong {
+pub unsafe extern "C" fn read_dora_input_timestamp(event: *const ()) -> core::ffi::c_ulonglong {
     let event: &Event = unsafe { &*event.cast() };
     match event {
         Event::Input { metadata, .. } => metadata.timestamp().get_time().as_u64(),

--- a/apis/c/node/src/lib.rs
+++ b/apis/c/node/src/lib.rs
@@ -195,6 +195,20 @@ pub unsafe extern "C" fn read_dora_input_data(
     }
 }
 
+/// Reads out the timestamp of the given input event from metadata.
+/// 
+/// Return `0` if the given event is not an input event.
+#[no_mangle]
+pub unsafe extern "C" fn read_dora_input_data_timestamp(
+    event: *const (),
+) -> core::ffi::c_ulonglong {
+    let event: &Event = unsafe { &*event.cast() };
+    match event {
+        Event::Input { metadata, .. } => metadata.timestamp().get_time().as_u64(),
+        _ => 0,
+    }
+}
+
 /// Frees the given dora event.
 ///
 /// ## Safety

--- a/apis/c/node/src/lib.rs
+++ b/apis/c/node/src/lib.rs
@@ -198,7 +198,7 @@ pub unsafe extern "C" fn read_dora_input_data(
 /// Reads out the timestamp of the given input event from metadata.
 ///
 /// ## Safety
-/// 
+///
 /// Return `0` if the given event is not an input event.
 #[no_mangle]
 pub unsafe extern "C" fn read_dora_input_timestamp(event: *const ()) -> core::ffi::c_ulonglong {

--- a/binaries/cli/src/template/c/listener/listener-template.c
+++ b/binaries/cli/src/template/c/listener/listener-template.c
@@ -42,7 +42,8 @@ int main()
             size_t data_len;
             read_dora_input_data(event, &data_ptr, &data_len);
 
-            printf("I heard %s from %s\n", data_ptr, id_ptr);
+            unsigned long long timestamp = read_dora_input_timestamp(event);
+            printf("I heard %s from %s at %llu\n", data_ptr, id_ptr, timestamp);
         }
         else if (ty == DoraEventType_Stop)
         {


### PR DESCRIPTION
Add a `read_dora_input_timestamp` method to c-node-api.

Some users report there is a real-time communication bug in c-node-api. Add a method to get input timestamp may be useful for debugging.