### PR TITLE
Increasing grace duration to 2 seconds so that drop token get well returned

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1567,7 +1567,7 @@ impl RunningDataflow {
         let running_nodes = self.running_nodes.clone();
         let grace_duration_kills = self.grace_duration_kills.clone();
         tokio::spawn(async move {
-            let duration = grace_duration.unwrap_or(Duration::from_millis(500));
+            let duration = grace_duration.unwrap_or(Duration::from_millis(2000));
             tokio::time::sleep(duration).await;
             let mut system = sysinfo::System::new();
             system.refresh_processes();


### PR DESCRIPTION
Increasing grace duration from 500ms to 2000ms makes it simpler to hit timeout on drop token for Python in case it get stuck by a race condition with the GIL.