### PR TITLE
add a comment on read_dora_input_id

### DIFF
--- a/apis/c/node/src/lib.rs
+++ b/apis/c/node/src/lib.rs
@@ -117,13 +117,13 @@ pub enum EventType {
 ///
 /// ## Safety
 ///
-/// The `event` argument must be a dora event received through
+/// - The `event` argument must be a dora event received through
 /// [`dora_next_event`]. The event must be still valid, i.e., not
 /// freed yet. The returned `out_ptr` must not be used after
 /// freeing the `event`, since it points directly into the event's
 /// memory.
 ///
-/// Note: `Out_ptr` is not a null-terminated string. The length of the string
+/// - Note: `Out_ptr` is not a null-terminated string. The length of the string
 /// is given by `out_len`.
 #[no_mangle]
 pub unsafe extern "C" fn read_dora_input_id(


### PR DESCRIPTION
`String` is not a null-terminated string which is very different from C-type string. We should mention it.

See https://github.com/dora-rs/dora/issues/577