### PR TITLE
add a multiple node forward benchmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,6 +251,10 @@ jobs:
       - name: "Benchmark example"
         timeout-minutes: 30
         run: cargo run --example benchmark --release
+      
+      - name: "Multiple Nodes Benchmark example"
+        timeout-minutes: 30
+        run: cargo run --release --example multi-node-benchmark -- 3
 
   CLI:
     name: "CLI Test"

--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,5 @@ cython_debug/
 out/
 
 ~*
+
+__dataflow.yml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,3 +150,7 @@ path = "examples/cmake-dataflow/run.rs"
 name = "cxx-ros2-dataflow"
 path = "examples/c++-ros2-dataflow/run.rs"
 required-features = ["ros2-examples"]
+
+[[example]]
+name = "multi-node-benchmark"
+path = "examples/multi-node-benchmark/run.rs"

--- a/examples/benchmark/node/src/main.rs
+++ b/examples/benchmark/node/src/main.rs
@@ -1,61 +1,194 @@
-use dora_node_api::{self, dora_core::config::DataId, DoraNode};
+use dora_node_api::{self, dora_core::config::DataId, DoraNode, Event};
 use eyre::Context;
 use rand::Rng;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tracing_subscriber::Layer;
 
 fn main() -> eyre::Result<()> {
     set_up_tracing().wrap_err("failed to set up tracing subscriber")?;
 
-    let latency = DataId::from("latency".to_owned());
-    let throughput = DataId::from("throughput".to_owned());
+    let node_id = std::env::var("NODE_ID");
+    if let Ok(node_id) = node_id {
+        let node_id = node_id.parse::<u32>().context("failed to parse NODE_ID")?;
+        if node_id == 0 {
+            let latency = DataId::from("latency0".to_owned());
+            let throughput = DataId::from("throughput0".to_owned());
 
-    let (mut node, _events) = DoraNode::init_from_env()?;
-    let sizes = [
-        0,
-        8,
-        64,
-        512,
-        2048,
-        4096,
-        4 * 4096,
-        10 * 4096,
-        100 * 4096,
-        1000 * 4096,
-    ];
+            let (mut node, _events) = DoraNode::init_from_env()?;
+            let sizes = [
+                0,
+                8,
+                64,
+                512,
+                2048,
+                4096,
+                4 * 4096,
+                10 * 4096,
+                100 * 4096,
+                1000 * 4096,
+            ];
 
-    // test latency first
-    for size in sizes {
-        for _ in 0..100 {
-            let data: Vec<u8> = rand::thread_rng()
-                .sample_iter(rand::distributions::Standard)
-                .take(size)
-                .collect();
-            node.send_output_raw(latency.clone(), Default::default(), data.len(), |out| {
-                out.copy_from_slice(&data);
-            })?;
+            // test latency first
+            for size in sizes {
+                for _ in 0..100 {
+                    let data: Vec<u8> = rand::thread_rng()
+                        .sample_iter(rand::distributions::Standard)
+                        .take(size)
+                        .collect();
+                    node.send_output_raw(latency.clone(), Default::default(), data.len(), |out| {
+                        out.copy_from_slice(&data);
+                    })?;
 
-            // sleep a bit to avoid queue buildup
-            std::thread::sleep(Duration::from_millis(10));
+                    // sleep a bit to avoid queue buildup
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+            }
+
+            // wait a bit to ensure that all throughput messages reached their target
+            std::thread::sleep(Duration::from_secs(2));
+
+            // then throughput with full speed
+            for size in sizes {
+                for _ in 0..100 {
+                    let data: Vec<u8> = rand::thread_rng()
+                        .sample_iter(rand::distributions::Standard)
+                        .take(size)
+                        .collect();
+                    node.send_output_raw(
+                        throughput.clone(),
+                        Default::default(),
+                        data.len(),
+                        |out| {
+                            out.copy_from_slice(&data);
+                        },
+                    )?;
+                }
+            }
+        } else {
+            let latency_id = DataId::from(format!("latency{}", node_id));
+            let throughput = DataId::from(format!("throughput{}", node_id));
+            let (mut node, mut events) = DoraNode::init_from_env()?;
+            let mut latency = true;
+            let mut current_size = 0;
+            let mut n = 0;
+            let mut start = Instant::now();
+            let mut latencies = Vec::new();
+
+            println!("Latency:");
+
+            while let Some(event) = events.recv() {
+                match event {
+                    Event::Input { id, metadata, data } => {
+                        let data_len = data.len();
+                        if data_len != current_size {
+                            if n > 0 {
+                                record_results(start, current_size, n, latencies, latency)
+                            }
+                            current_size = data_len;
+                            n = 0;
+                            start = Instant::now();
+                            latencies = Vec::new();
+                        }
+
+                        match id.as_str() {
+                            "latency" if latency => {
+                                node.send_output(
+                                    latency_id.clone(),
+                                    Default::default(),
+                                    data.to_owned(),
+                                )?;
+                            }
+                            "throughput" if latency => {
+                                latency = false;
+                                node.send_output(
+                                    throughput.clone(),
+                                    Default::default(),
+                                    data.to_owned(),
+                                )?;
+                                println!("Throughput:");
+                            }
+                            "throughput" => {
+                                node.send_output(
+                                    throughput.clone(),
+                                    Default::default(),
+                                    data.to_owned(),
+                                )?;
+                            }
+                            other => {
+                                eprintln!("Ignoring unexpected input `{other}`");
+                                continue;
+                            }
+                        }
+
+                        n += 1;
+                        latencies.push(
+                            metadata
+                                .timestamp()
+                                .get_time()
+                                .to_system_time()
+                                .elapsed()
+                                .unwrap_or_default(),
+                        );
+                    }
+                    Event::InputClosed { id } => {
+                        println!("Input `{id}` was closed");
+                    }
+                    other => eprintln!("Received unexpected input: {other:?}"),
+                }
+            }
+
+            record_results(start, current_size, n, latencies, latency);
+        }
+    } else {
+        let latency = DataId::from("latency".to_owned());
+        let throughput = DataId::from("throughput".to_owned());
+
+        let (mut node, _events) = DoraNode::init_from_env()?;
+        let sizes = [
+            0,
+            8,
+            64,
+            512,
+            2048,
+            4096,
+            4 * 4096,
+            10 * 4096,
+            100 * 4096,
+            1000 * 4096,
+        ];
+
+        // test latency first
+        for size in sizes {
+            for _ in 0..100 {
+                let data: Vec<u8> = rand::thread_rng()
+                    .sample_iter(rand::distributions::Standard)
+                    .take(size)
+                    .collect();
+                node.send_output_raw(latency.clone(), Default::default(), data.len(), |out| {
+                    out.copy_from_slice(&data);
+                })?;
+
+                // sleep a bit to avoid queue buildup
+                std::thread::sleep(Duration::from_millis(10));
+            }
+        }
+
+        // wait a bit to ensure that all throughput messages reached their target
+        std::thread::sleep(Duration::from_secs(2));
+
+        // then throughput with full speed
+        for size in sizes {
+            for _ in 0..100 {
+                let data: Vec<u8> = rand::thread_rng()
+                    .sample_iter(rand::distributions::Standard)
+                    .take(size)
+                    .collect();
+                node.send_output_raw(throughput.clone(), Default::default(), data.len(), |out| {
+                    out.copy_from_slice(&data);
+                })?;
+            }
         }
     }
-
-    // wait a bit to ensure that all throughput messages reached their target
-    std::thread::sleep(Duration::from_secs(2));
-
-    // then throughput with full speed
-    for size in sizes {
-        for _ in 0..100 {
-            let data: Vec<u8> = rand::thread_rng()
-                .sample_iter(rand::distributions::Standard)
-                .take(size)
-                .collect();
-            node.send_output_raw(throughput.clone(), Default::default(), data.len(), |out| {
-                out.copy_from_slice(&data);
-            })?;
-        }
-    }
-
     Ok(())
 }
 
@@ -68,4 +201,22 @@ fn set_up_tracing() -> eyre::Result<()> {
     let subscriber = tracing_subscriber::Registry::default().with(stdout_log);
     tracing::subscriber::set_global_default(subscriber)
         .context("failed to set tracing global subscriber")
+}
+
+fn record_results(
+    start: Instant,
+    current_size: usize,
+    n: u32,
+    latencies: Vec<Duration>,
+    latency: bool,
+) {
+    let msg = if latency {
+        let avg_latency = latencies.iter().sum::<Duration>() / n;
+        format!("size {current_size:<#8x}: {avg_latency:?}")
+    } else {
+        let duration = start.elapsed();
+        let msg_per_sec = n as f64 / duration.as_secs_f64();
+        format!("size {current_size:<#8x}: {msg_per_sec:.0} messages per second")
+    };
+    println!("{msg}");
 }

--- a/examples/multi-node-benchmark/node.template
+++ b/examples/multi-node-benchmark/node.template
@@ -1,0 +1,9 @@
+  - id: rust-node-#
+    custom:
+      source: ../../target/release/benchmark-example-node
+      envs:
+        NODE_ID: #
+      outputs:
+        - latency#
+        - throughput#
+      __INPUTS__

--- a/examples/multi-node-benchmark/run.rs
+++ b/examples/multi-node-benchmark/run.rs
@@ -1,0 +1,113 @@
+use dora_tracing::set_up_tracing;
+use eyre::{bail, Context};
+use std::path::Path;
+use tokio::{fs, io::AsyncWriteExt};
+
+#[tokio::main]
+async fn main() -> eyre::Result<()> {
+    set_up_tracing("multi-node-benchmark-runner")
+        .wrap_err("failed to set up tracing subscriber")?;
+
+    let args: Vec<String> = std::env::args().collect();
+    let nodes_num = if args.len() > 1 {
+        args[1]
+            .parse::<usize>()
+            .wrap_err("failed to parse num_nodes")?
+    } else {
+        bail!("cargo run --release --example multi-node-benchmark -- <num_nodes>")
+    };
+
+    build_benchmakr().await?;
+
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    std::env::set_current_dir(root.join(file!()).parent().unwrap())
+        .wrap_err("failed to set working dir")?;
+
+    let dataflow = Path::new("__dataflow.yml");
+    create_dataflow_yaml(dataflow, nodes_num).await?;
+
+    run_dataflow(dataflow).await?;
+    Ok(())
+}
+
+async fn create_dataflow_yaml(dataflow: &Path, num: usize) -> eyre::Result<()> {
+    const NODE_TEMPLATE: &str = include_str!("node.template");
+    let _ = fs::File::create(dataflow).await?;
+    let mut dataflow_file = fs::OpenOptions::new()
+        .write(true)
+        .append(true)
+        .open(dataflow)
+        .await?;
+
+    dataflow_file.write_all(b"nodes:\n").await?;
+    if num == 0 {
+        let node_description = NODE_TEMPLATE.replace("#", "0");
+        let node_description = node_description.replace("__INPUTS__", "");
+        dataflow_file.write_all(node_description.as_bytes()).await?;
+        dataflow_file.write_all(b"\n").await?;
+    } else {
+        for i in 0..num {
+            let node_description = NODE_TEMPLATE.replace("#", &i.to_string());
+            let node_description = if i == 0 {
+                node_description.replace("__INPUTS__", "")
+            } else {
+                node_description.replace("__INPUTS__", 
+                &format!("inputs:\n        latency: rust-node-{}/latency{}\n        throughput: rust-node-{}/throughput{}", i - 1, i - 1, i - 1, i - 1)
+                )
+            };
+            dataflow_file.write_all(node_description.as_bytes()).await?;
+            dataflow_file.write_all(b"\n").await?;
+        }
+    }
+
+    const SINK_TEMPLATE: &str = include_str!("sink.template");
+    if num == 0 {
+        let sink_description = SINK_TEMPLATE.replace("#", "0");
+        dataflow_file.write_all(sink_description.as_bytes()).await?;
+    } else {
+        let sink_description = SINK_TEMPLATE.replace("#", &(num - 1).to_string());
+        dataflow_file.write_all(sink_description.as_bytes()).await?;
+    }
+    dataflow_file.write_all(b"\n").await?;
+
+    Ok(())
+}
+
+async fn build_benchmakr() -> eyre::Result<()> {
+    let cargo = std::env::var("CARGO").unwrap();
+    let mut build = tokio::process::Command::new(&cargo);
+    build
+        .arg("build")
+        .arg("--release")
+        .arg("-p")
+        .arg("benchmark-example-node");
+    if !build.status().await?.success() {
+        bail!("failed to build benchmark-example-node");
+    };
+    let mut build = tokio::process::Command::new(&cargo);
+    build
+        .arg("build")
+        .arg("--release")
+        .arg("-p")
+        .arg("benchmark-example-sink");
+    if !build.status().await?.success() {
+        bail!("failed to build benchmark-example-sinik");
+    };
+    Ok(())
+}
+
+async fn run_dataflow(dataflow: &Path) -> eyre::Result<()> {
+    let cargo = std::env::var("CARGO").unwrap();
+    let mut cmd = tokio::process::Command::new(&cargo);
+    cmd.arg("run");
+    cmd.arg("--release");
+    cmd.arg("--package").arg("dora-cli");
+    cmd.arg("--")
+        .arg("daemon")
+        .arg("--run-dataflow")
+        .arg(dataflow);
+    if !cmd.status().await?.success() {
+        bail!("failed to run dataflow");
+    };
+    Ok(())
+}

--- a/examples/multi-node-benchmark/sink.template
+++ b/examples/multi-node-benchmark/sink.template
@@ -1,0 +1,6 @@
+  - id: rust-sink
+    custom:
+      source: ../../target/release/benchmark-example-sink
+      inputs:
+        latency: rust-node-#/latency#
+        throughput: rust-node-#/throughput#


### PR DESCRIPTION
Some users found that the number of nodes decrease the performance of dora-0.3.2. So I add this benchmark to test multiple-nodes case.

In the current version, with the growing number of nodes, the latency is stable, but the throughput drop down.

```
rust-node-0 -> rust-node-1 -> rust-node-2 -> ... -> rust-sink
```

Am I missing something?

Please be free to try it with `cargo run --release --example multi-node-benchmark -- 20` (CPU Intel i9-12900H)