### PR TITLE
Adding auto-documentation of C++ API 

### DIFF
--- a/apis/c++/node/build.rs
+++ b/apis/c++/node/build.rs
@@ -1,6 +1,8 @@
+use cxx_build::CFG;
 use std::path::{Path, PathBuf};
 
 fn main() {
+    CFG.doxygen = true;
     let mut bridge_files = vec![PathBuf::from("src/lib.rs")];
     #[cfg(feature = "ros2-bridge")]
     bridge_files.push(ros2::generate());

--- a/apis/c++/node/src/lib.rs
+++ b/apis/c++/node/src/lib.rs
@@ -15,11 +15,14 @@ use futures_lite::{stream, Stream, StreamExt};
 #[cxx::bridge]
 #[allow(clippy::needless_lifetimes)]
 mod ffi {
+
+    /// ---Insert Documentation Here 1---
     struct DoraNode {
         events: Box<Events>,
         send_output: Box<OutputSender>,
     }
 
+    /// ---Insert Documentation Here 2---
     pub enum DoraEventType {
         Stop,
         Input,
@@ -29,6 +32,7 @@ mod ffi {
         AllInputsClosed,
     }
 
+    /// ---Insert Documentation Here 3---
     struct DoraInput {
         id: String,
         data: Vec<u8>,


### PR DESCRIPTION
This PR adds the export of rust documentation to C++ API documentation, enabling to generate a doxygen documentation of C++.

@starlitxiling, could you pull this PR and fill the documentation of the rust structure as well test doxygen generation.

I'm able to retrieve in the C++ header the documentation:

```cxx

#ifndef CXXBRIDGE1_STRUCT_DoraNode
#define CXXBRIDGE1_STRUCT_DoraNode
/// ---Insert Documentation Here 1---
///
struct DoraNode final {
  ::rust::Box<::Events> events;
  ::rust::Box<::OutputSender> send_output;

  using IsRelocatable = ::std::true_type;
};
#endif // CXXBRIDGE1_STRUCT_DoraNode

#ifndef CXXBRIDGE1_ENUM_DoraEventType
#define CXXBRIDGE1_ENUM_DoraEventType
/// ---Insert Documentation Here 2---
///
enum class DoraEventType : ::std::uint8_t {
  Stop = 0,
  Input = 1,
  InputClosed = 2,
  Error = 3,
  Unknown = 4,
  AllInputsClosed = 5,
};
#endif // CXXBRIDGE1_ENUM_DoraEventType

#ifndef CXXBRIDGE1_STRUCT_DoraInput
#define CXXBRIDGE1_STRUCT_DoraInput
/// ---Insert Documentation Here 3---
///
struct DoraInput final {
  ::rust::String id;
  ::rust::Vec<::std::uint8_t> data;

  using IsRelocatable = ::std::true_type;
};
#endif // CXXBRIDGE1_STRUCT_DoraInput
#ifndef CXXBRIDGE1_STRUCT_DoraNode
#define CXXBRIDGE1_STRUCT_DoraNode
/// ---Insert Documentation Here 1---
///
struct DoraNode final {
  ::rust::Box<::Events> events;
  ::rust::Box<::OutputSender> send_output;

  using IsRelocatable = ::std::true_type;
};
#endif // CXXBRIDGE1_STRUCT_DoraNode

#ifndef CXXBRIDGE1_ENUM_DoraEventType
#define CXXBRIDGE1_ENUM_DoraEventType
/// ---Insert Documentation Here 2---
///
enum class DoraEventType : ::std::uint8_t {
  Stop = 0,
  Input = 1,
  InputClosed = 2,
  Error = 3,
  Unknown = 4,
  AllInputsClosed = 5,
};
#endif // CXXBRIDGE1_ENUM_DoraEventType

#ifndef CXXBRIDGE1_STRUCT_DoraInput
#define CXXBRIDGE1_STRUCT_DoraInput
/// ---Insert Documentation Here 3---
///
struct DoraInput final {
  ::rust::String id;
  ::rust::Vec<::std::uint8_t> data;

  using IsRelocatable = ::std::true_type;
};
#endif // CXXBRIDGE1_STRUCT_DoraInput
```

For information the documentation of cxx doxygen feature flag :

https://github.com/dtolnay/cxx/blob/592b53290b50eb0914de7b4c0c0b6b968089f7f5/gen/build/src/cfg.rs#L242-L317


