### PR TITLE
Make dora versions compatible by using separate versioning for `dora-message` crate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,8 @@ jobs:
           cargo publish -p dora-metrics --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
           cargo publish -p dora-download --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
           cargo publish -p dora-core --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          # TODO: only publish if new version
-          cargo publish -p dora-message --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          # the dora-message package is versioned separately, so this publish command might fail if the version is already published
+          cargo publish -p dora-message --token ${{ secrets.CARGO_REGISTRY_TOKEN }} || true
           cargo publish -p communication-layer-pub-sub --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
           cargo publish -p communication-layer-request-reply --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
           cargo publish -p shared-memory-server --token ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,7 @@ jobs:
           cargo publish -p dora-metrics --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
           cargo publish -p dora-download --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
           cargo publish -p dora-core --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          # TODO: only publish if new version
           cargo publish -p dora-message --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
           cargo publish -p communication-layer-pub-sub --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
           cargo publish -p communication-layer-request-reply --token ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2410,7 +2410,7 @@ dependencies = [
 
 [[package]]
 name = "dora-message"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "aligned-vec",
  "arrow-data",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2418,6 +2418,7 @@ dependencies = [
  "dora-core",
  "eyre",
  "log",
+ "semver",
  "serde",
  "tokio",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ name = "dora-examples"
 version = "0.0.0"
 edition = "2021"
 license = "Apache-2.0"
+publish = false
 
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ dora-ros2-bridge = { path = "libraries/extensions/ros2-bridge" }
 dora-ros2-bridge-msg-gen = { path = "libraries/extensions/ros2-bridge/msg-gen" }
 dora-ros2-bridge-python = { path = "libraries/extensions/ros2-bridge/python" }
 # versioned independently from the other dora crates
-dora-message = { version = "0.3.5", path = "libraries/message" }
+dora-message = { version = "0.4.0", path = "libraries/message" }
 arrow = { version = "52" }
 arrow-schema = { version = "52" }
 arrow-data = { version = "52" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ dora-coordinator = { version = "0.3.5", path = "binaries/coordinator" }
 dora-ros2-bridge = { path = "libraries/extensions/ros2-bridge" }
 dora-ros2-bridge-msg-gen = { path = "libraries/extensions/ros2-bridge/msg-gen" }
 dora-ros2-bridge-python = { path = "libraries/extensions/ros2-bridge/python" }
+# versioned independently from the other dora crates
 dora-message = { version = "0.3.5", path = "libraries/message" }
 arrow = { version = "52" }
 arrow-schema = { version = "52" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ version = "0.3.5"
 description = "`dora` goal is to be a low latency, composable, and distributed data flow."
 documentation = "https://dora.carsmos.ai"
 license = "Apache-2.0"
+repository = "https://github.com/dora-rs/dora/"
 
 [workspace.dependencies]
 dora-node-api = { version = "0.3.5", path = "apis/rust/node", default-features = false }

--- a/apis/c++/node/Cargo.toml
+++ b/apis/c++/node/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 documentation.workspace = true
 description.workspace = true
 license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/apis/c++/operator/Cargo.toml
+++ b/apis/c++/operator/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 documentation.workspace = true
 description.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [lib]
 crate-type = ["staticlib"]

--- a/apis/c/node/Cargo.toml
+++ b/apis/c/node/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 documentation.workspace = true
 description.workspace = true
 license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/apis/c/operator/Cargo.toml
+++ b/apis/c/operator/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 description = "C API implementation for Dora Operator"
 documentation.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [lib]
 crate-type = ["staticlib", "lib"]

--- a/apis/python/node/Cargo.toml
+++ b/apis/python/node/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 documentation.workspace = true
 description.workspace = true
 license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/apis/python/operator/Cargo.toml
+++ b/apis/python/operator/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 documentation.workspace = true
 description.workspace = true
 license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/apis/rust/node/Cargo.toml
+++ b/apis/rust/node/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 documentation.workspace = true
 description.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [features]
 default = ["tracing"]

--- a/apis/rust/operator/Cargo.toml
+++ b/apis/rust/operator/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 documentation.workspace = true
 description.workspace = true
 license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/apis/rust/operator/macros/Cargo.toml
+++ b/apis/rust/operator/macros/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 description = "Rust API Macros for Dora Operator"
 documentation.workspace = true
 license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/apis/rust/operator/types/Cargo.toml
+++ b/apis/rust/operator/types/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 documentation.workspace = true
 description.workspace = true
 license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 documentation.workspace = true
 description.workspace = true
 license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/binaries/coordinator/Cargo.toml
+++ b/binaries/coordinator/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 documentation.workspace = true
 description.workspace = true
 license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/binaries/daemon/Cargo.toml
+++ b/binaries/daemon/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 documentation.workspace = true
 description.workspace = true
 license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/binaries/runtime/Cargo.toml
+++ b/binaries/runtime/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 documentation.workspace = true
 description.workspace = true
 license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/benchmark/node/Cargo.toml
+++ b/examples/benchmark/node/Cargo.toml
@@ -2,6 +2,7 @@
 name = "benchmark-example-node"
 version.workspace = true
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/benchmark/sink/Cargo.toml
+++ b/examples/benchmark/sink/Cargo.toml
@@ -2,6 +2,7 @@
 name = "benchmark-example-sink"
 version.workspace = true
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/multiple-daemons/node/Cargo.toml
+++ b/examples/multiple-daemons/node/Cargo.toml
@@ -2,6 +2,7 @@
 name = "multiple-daemons-example-node"
 version.workspace = true
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/multiple-daemons/operator/Cargo.toml
+++ b/examples/multiple-daemons/operator/Cargo.toml
@@ -3,6 +3,7 @@ name = "multiple-daemons-example-operator"
 version.workspace = true
 edition = "2021"
 license.workspace = true
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/multiple-daemons/sink/Cargo.toml
+++ b/examples/multiple-daemons/sink/Cargo.toml
@@ -2,6 +2,7 @@
 name = "multiple-daemons-example-sink"
 version.workspace = true
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/rust-dataflow-url/sink/Cargo.toml
+++ b/examples/rust-dataflow-url/sink/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rust-dataflow-url-example-sink"
 version.workspace = true
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/rust-dataflow/node/Cargo.toml
+++ b/examples/rust-dataflow/node/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rust-dataflow-example-node"
 version.workspace = true
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/rust-dataflow/sink-dynamic/Cargo.toml
+++ b/examples/rust-dataflow/sink-dynamic/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rust-dataflow-example-sink-dynamic"
 version.workspace = true
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/rust-dataflow/sink/Cargo.toml
+++ b/examples/rust-dataflow/sink/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rust-dataflow-example-sink"
 version.workspace = true
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/rust-dataflow/status-node/Cargo.toml
+++ b/examples/rust-dataflow/status-node/Cargo.toml
@@ -3,6 +3,7 @@ name = "rust-dataflow-example-status-node"
 version.workspace = true
 edition = "2021"
 license.workspace = true
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/rust-ros2-dataflow/node/Cargo.toml
+++ b/examples/rust-ros2-dataflow/node/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rust-ros2-dataflow-example-node"
 version.workspace = true
 edition = "2021"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/libraries/arrow-convert/Cargo.toml
+++ b/libraries/arrow-convert/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 documentation.workspace = true
 description.workspace = true
 license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/libraries/communication-layer/pub-sub/Cargo.toml
+++ b/libraries/communication-layer/pub-sub/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 documentation.workspace = true
 description.workspace = true
 license.workspace = true
+repository.workspace = true
 
 [features]
 default = ["zenoh"]

--- a/libraries/communication-layer/request-reply/Cargo.toml
+++ b/libraries/communication-layer/request-reply/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 documentation.workspace = true
 description.workspace = true
 license.workspace = true
+repository.workspace = true
 
 
 [package.metadata.docs.rs]

--- a/libraries/core/Cargo.toml
+++ b/libraries/core/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 documentation.workspace = true
 description.workspace = true
 license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/libraries/extensions/download/Cargo.toml
+++ b/libraries/extensions/download/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 documentation.workspace = true
 description.workspace = true
 license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/libraries/extensions/telemetry/metrics/Cargo.toml
+++ b/libraries/extensions/telemetry/metrics/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 documentation.workspace = true
 description.workspace = true
 license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/libraries/extensions/telemetry/tracing/Cargo.toml
+++ b/libraries/extensions/telemetry/tracing/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 documentation.workspace = true
 description.workspace = true
 license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/libraries/message/Cargo.toml
+++ b/libraries/message/Cargo.toml
@@ -21,3 +21,4 @@ dora-core = { workspace = true }
 uuid = { version = "1.7", features = ["serde", "v7"] }
 log = { version = "0.4.21", features = ["serde"] }
 aligned-vec = { version = "0.5.0", features = ["serde"] }
+semver = { version = "1.0.23", features = ["serde"] }

--- a/libraries/message/Cargo.toml
+++ b/libraries/message/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "dora-message"
-version.workspace = true
+# versioned separately from the other dora crates
+version = "0.3.5"
 edition = "2021"
 documentation.workspace = true
 description.workspace = true

--- a/libraries/message/Cargo.toml
+++ b/libraries/message/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dora-message"
 # versioned separately from the other dora crates
-version = "0.3.5"
+version = "0.4.0"
 edition = "2021"
 documentation.workspace = true
 description.workspace = true

--- a/libraries/message/Cargo.toml
+++ b/libraries/message/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 documentation.workspace = true
 description.workspace = true
 license.workspace = true
+repository.workspace = true
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/libraries/message/src/daemon_to_coordinator.rs
+++ b/libraries/message/src/daemon_to_coordinator.rs
@@ -34,6 +34,7 @@ impl DaemonRegisterRequest {
 
     pub fn check_version(&self) -> Result<(), String> {
         let crate_version = env!("CARGO_PKG_VERSION");
+        // TODO: semver version comparison
         if self.dora_version == crate_version {
             Ok(())
         } else {

--- a/libraries/message/src/lib.rs
+++ b/libraries/message/src/lib.rs
@@ -18,3 +18,26 @@ pub mod cli_to_coordinator;
 pub mod coordinator_to_cli;
 
 pub type DataflowId = uuid::Uuid;
+
+fn current_crate_version() -> semver::Version {
+    let crate_version_raw = env!("CARGO_PKG_VERSION");
+    let crate_version = semver::Version::parse(crate_version_raw).unwrap();
+    crate_version
+}
+
+fn versions_compatible(
+    crate_version: &semver::Version,
+    specified_version: &semver::Version,
+) -> Result<bool, String> {
+    let req = semver::VersionReq::parse(&crate_version.to_string()).map_err(|error| {
+        format!("failed to parse crate version `{crate_version}` as `VersionReq`: {error}")
+    })?;
+    let specified_dora_req = semver::VersionReq::parse(&specified_version.to_string())
+        .map_err(|error| {
+            format!(
+                "failed to parse specified dora version `{specified_version}` as `VersionReq`: {error}",
+            )
+        })?;
+    let matches = req.matches(&specified_version) || specified_dora_req.matches(crate_version);
+    Ok(matches)
+}

--- a/libraries/message/src/node_to_daemon.rs
+++ b/libraries/message/src/node_to_daemon.rs
@@ -86,6 +86,7 @@ impl NodeRegisterRequest {
 
     pub fn check_version(&self) -> Result<(), String> {
         let crate_version = env!("CARGO_PKG_VERSION");
+        // TODO: semver version comparison
         if self.dora_version == crate_version {
             Ok(())
         } else {

--- a/libraries/message/src/node_to_daemon.rs
+++ b/libraries/message/src/node_to_daemon.rs
@@ -1,7 +1,7 @@
 pub use crate::common::{
     DataMessage, DropToken, LogLevel, LogMessage, SharedMemoryId, Timestamped,
 };
-use crate::{metadata::Metadata, DataflowId};
+use crate::{current_crate_version, metadata::Metadata, versions_compatible, DataflowId};
 
 use dora_core::config::{DataId, NodeId};
 
@@ -72,7 +72,7 @@ impl DaemonRequest {
 pub struct NodeRegisterRequest {
     pub dataflow_id: DataflowId,
     pub node_id: NodeId,
-    dora_version: String,
+    dora_version: semver::Version,
 }
 
 impl NodeRegisterRequest {
@@ -80,14 +80,15 @@ impl NodeRegisterRequest {
         Self {
             dataflow_id,
             node_id,
-            dora_version: env!("CARGO_PKG_VERSION").to_owned(),
+            dora_version: semver::Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
         }
     }
 
     pub fn check_version(&self) -> Result<(), String> {
-        let crate_version = env!("CARGO_PKG_VERSION");
-        // TODO: semver version comparison
-        if self.dora_version == crate_version {
+        let crate_version = current_crate_version();
+        let specified_version = &self.dora_version;
+
+        if versions_compatible(&crate_version, specified_version)? {
             Ok(())
         } else {
             Err(format!(

--- a/libraries/shared-memory-server/Cargo.toml
+++ b/libraries/shared-memory-server/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 documentation.workspace = true
 description.workspace = true
 license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/node-hub/dora-record/Cargo.toml
+++ b/node-hub/dora-record/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 documentation.workspace = true
 description.workspace = true
 license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/node-hub/dora-rerun/Cargo.toml
+++ b/node-hub/dora-rerun/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 documentation.workspace = true
 description.workspace = true
 license.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
By versioning the `dora-message` crate individually, we can use the semver rules to encode which versions are compatible. This way, we can allow different versions of dora to work together (e.g. CLI version can be different than node API version), as long as the message formats are compatible. Breaking message format changes are signaled by a semver-incompatible release of `dora-message`. For example, 0.4.0 is not compatible with 0.3.5.

One alternative approach could be to use the main version to signal compatibility, i.e. the common version that we use for all dora crates. This has the disadvantage that we might need to bump the minor version of the main dora crate every time we want to change the message format in a breaking way. As we still expect semi-regular breaking changes to the message format in the near future, we want to avoid this churn. Once we consider the message format more stable, we plan to revisit this approach.

Fixes https://github.com/dora-rs/dora/issues/504

TODO

- [x] Update release script: We should not try to publish the `dora-message` crate if there is no new version.
- [x] Relax version checks to only compare major/minor version (according to semver compatibility rules).