### PR TITLE
Use the new node syntax for examples dataflow

### DIFF
--- a/examples/benchmark/dataflow.yml
+++ b/examples/benchmark/dataflow.yml
@@ -1,15 +1,14 @@
 nodes:
   - id: rust-node
-    custom:
-      build: cargo build -p benchmark-example-node --release
-      source: ../../target/release/benchmark-example-node
-      outputs:
-        - latency
-        - throughput
+    build: cargo build -p benchmark-example-node --release
+    path: ../../target/release/benchmark-example-node
+    outputs:
+      - latency
+      - throughput
+
   - id: rust-sink
-    custom:
-      build: cargo build -p benchmark-example-sink --release
-      source: ../../target/release/benchmark-example-sink
-      inputs:
-        latency: rust-node/latency
-        throughput: rust-node/throughput
+    build: cargo build -p benchmark-example-sink --release
+    path: ../../target/release/benchmark-example-sink
+    inputs:
+      latency: rust-node/latency
+      throughput: rust-node/throughput

--- a/examples/c++-dataflow/dataflow.yml
+++ b/examples/c++-dataflow/dataflow.yml
@@ -1,18 +1,17 @@
 nodes:
   - id: cxx-node-rust-api
-    custom:
-      source: build/node_rust_api
-      inputs:
-        tick: dora/timer/millis/300
-      outputs:
-        - counter
+    path: build/node_rust_api
+    inputs:
+      tick: dora/timer/millis/300
+    outputs:
+      - counter
+
   - id: cxx-node-c-api
-    custom:
-      source: build/node_c_api
-      inputs:
-        tick: cxx-node-rust-api/counter
-      outputs:
-        - counter
+    path: build/node_c_api
+    inputs:
+      tick: cxx-node-rust-api/counter
+    outputs:
+      - counter
 
   - id: runtime-node-1
     operators:
@@ -23,6 +22,7 @@ nodes:
           counter_2: cxx-node-rust-api/counter
         outputs:
           - status
+
   - id: runtime-node-2
     operators:
       - id: operator-c-api

--- a/examples/c++-ros2-dataflow/dataflow.yml
+++ b/examples/c++-ros2-dataflow/dataflow.yml
@@ -1,8 +1,7 @@
 nodes:
   - id: cxx-node-rust-api
-    custom:
-      source: build/node_rust_api
-      inputs:
-        tick: dora/timer/millis/500
-      outputs:
-        - pose
+    path: build/node_rust_api
+    inputs:
+      tick: dora/timer/millis/500
+    outputs:
+      - pose

--- a/examples/c-dataflow/dataflow.yml
+++ b/examples/c-dataflow/dataflow.yml
@@ -1,11 +1,11 @@
 nodes:
   - id: c_node
-    custom:
-      source: build/c_node
-      inputs:
-        timer: dora/timer/millis/50
-      outputs:
-        - message
+    path: build/c_node
+    inputs:
+      timer: dora/timer/millis/50
+    outputs:
+      - message
+
   - id: runtime-node
     operators:
       - id: c_operator
@@ -14,8 +14,8 @@ nodes:
           message: c_node/message
         outputs:
           - counter
+
   - id: c_sink
-    custom:
-      source: build/c_sink
-      inputs:
-        counter: runtime-node/c_operator/counter
+    path: build/c_sink
+    inputs:
+      counter: runtime-node/c_operator/counter

--- a/examples/cmake-dataflow/dataflow.yml
+++ b/examples/cmake-dataflow/dataflow.yml
@@ -1,18 +1,17 @@
 nodes:
   - id: cxx-node-rust-api
-    custom:
-      source: bin/node_rust_api
-      inputs:
-        tick: dora/timer/millis/300
-      outputs:
-        - counter
+    path: bin/node_rust_api
+    inputs:
+      tick: dora/timer/millis/300
+    outputs:
+      - counter
+
   - id: cxx-node-c-api
-    custom:
-      source: bin/node_c_api
-      inputs:
-        tick: dora/timer/millis/300
-      outputs:
-        - counter
+    path: bin/node_c_api
+    inputs:
+      tick: dora/timer/millis/300
+    outputs:
+      - counter
 
   - id: runtime-node-1
     operators:
@@ -23,6 +22,7 @@ nodes:
           counter_2: cxx-node-rust-api/counter
         outputs:
           - status
+
   - id: runtime-node-2
     operators:
       - id: operator-c-api

--- a/examples/multiple-daemons/dataflow.yml
+++ b/examples/multiple-daemons/dataflow.yml
@@ -2,8 +2,8 @@ nodes:
   - id: rust-node
     _unstable_deploy:
       machine: A
-    path: cargo build -p multiple-daemons-example-node
-    source: ../../target/debug/multiple-daemons-example-node
+    build: cargo build -p multiple-daemons-example-node
+    path: ../../target/debug/multiple-daemons-example-node
     inputs:
       tick: dora/timer/millis/10
     outputs:

--- a/examples/multiple-daemons/dataflow.yml
+++ b/examples/multiple-daemons/dataflow.yml
@@ -2,13 +2,13 @@ nodes:
   - id: rust-node
     _unstable_deploy:
       machine: A
-    custom:
-      build: cargo build -p multiple-daemons-example-node
-      source: ../../target/debug/multiple-daemons-example-node
-      inputs:
-        tick: dora/timer/millis/10
-      outputs:
-        - random
+    path: cargo build -p multiple-daemons-example-node
+    source: ../../target/debug/multiple-daemons-example-node
+    inputs:
+      tick: dora/timer/millis/10
+    outputs:
+      - random
+
   - id: runtime-node
     _unstable_deploy:
       machine: A
@@ -21,11 +21,11 @@ nodes:
           random: rust-node/random
         outputs:
           - status
+
   - id: rust-sink
     _unstable_deploy:
       machine: B
-    custom:
-      build: cargo build -p multiple-daemons-example-sink
-      source: ../../target/debug/multiple-daemons-example-sink
-      inputs:
-        message: runtime-node/rust-operator/status
+    build: cargo build -p multiple-daemons-example-sink
+    path: ../../target/debug/multiple-daemons-example-sink
+    inputs:
+      message: runtime-node/rust-operator/status

--- a/examples/python-ros2-dataflow/dataflow.yml
+++ b/examples/python-ros2-dataflow/dataflow.yml
@@ -1,17 +1,15 @@
 nodes:
   - id: turtle
-    custom:
-      source: ./random_turtle.py
-      inputs:
-        direction: control/direction
-      outputs:
-        - turtle_pose
+    path: ./random_turtle.py
+    inputs:
+      direction: control/direction
+    outputs:
+      - turtle_pose
 
   - id: control
-    custom:
-      source: ./control_node.py
-      inputs:
-        turtle_pose: turtle/turtle_pose
-        tick: dora/timer/millis/500
-      outputs:
-        - direction
+    path: ./control_node.py
+    inputs:
+      turtle_pose: turtle/turtle_pose
+      tick: dora/timer/millis/500
+    outputs:
+      - direction

--- a/examples/rust-dataflow-url/dataflow.yml
+++ b/examples/rust-dataflow-url/dataflow.yml
@@ -1,11 +1,11 @@
 nodes:
   - id: rust-node
-    custom:
-      source: https://github.com/dora-rs/dora/releases/download/v0.0.0-test.4/rust-dataflow-example-node
-      inputs:
-        tick: dora/timer/millis/300
-      outputs:
-        - random
+    path: https://github.com/dora-rs/dora/releases/download/v0.0.0-test.4/rust-dataflow-example-node
+    inputs:
+      tick: dora/timer/millis/300
+    outputs:
+      - random
+
   - id: runtime-node
     operators:
       - id: rust-operator
@@ -15,9 +15,9 @@ nodes:
           random: rust-node/random
         outputs:
           - status
+
   - id: rust-sink
-    custom:
-      build: cargo build -p rust-dataflow-example-sink
-      source: ../../target/debug/rust-dataflow-url-example-sink
-      inputs:
-        message: runtime-node/rust-operator/status
+    build: cargo build -p rust-dataflow-example-sink
+    path: ../../target/debug/rust-dataflow-url-example-sink
+    inputs:
+      message: runtime-node/rust-operator/status

--- a/examples/rust-dataflow/dataflow.yml
+++ b/examples/rust-dataflow/dataflow.yml
@@ -6,20 +6,22 @@ nodes:
       tick: dora/timer/millis/10
     outputs:
       - random
+
   - id: rust-status-node
-    custom:
-      build: cargo build -p rust-dataflow-example-status-node
-      source: ../../target/debug/rust-dataflow-example-status-node
-      inputs:
-        tick: dora/timer/millis/100
-        random: rust-node/random
-      outputs:
-        - status
+    build: cargo build -p rust-dataflow-example-status-node
+    path: ../../target/debug/rust-dataflow-example-status-node
+    inputs:
+      tick: dora/timer/millis/100
+      random: rust-node/random
+    outputs:
+      - status
+
   - id: rust-sink
     build: cargo build -p rust-dataflow-example-sink
     path: ../../target/debug/rust-dataflow-example-sink
     inputs:
       message: rust-status-node/status
+
   - id: dora-record
     build: cargo build -p dora-record
     path: ../../target/debug/dora-record

--- a/examples/rust-dataflow/dataflow_dynamic.yml
+++ b/examples/rust-dataflow/dataflow_dynamic.yml
@@ -1,31 +1,30 @@
 nodes:
   - id: rust-node
-    custom:
-      build: cargo build -p rust-dataflow-example-node
-      source: ../../target/debug/rust-dataflow-example-node
-      inputs:
-        tick: dora/timer/millis/100
-      outputs:
-        - random
+    build: cargo build -p rust-dataflow-example-node
+    path: ../../target/debug/rust-dataflow-example-node
+    inputs:
+      tick: dora/timer/millis/100
+    outputs:
+      - random
+
   - id: rust-status-node
-    custom:
-      build: cargo build -p rust-dataflow-example-status-node
-      source: ../../target/debug/rust-dataflow-example-status-node
-      inputs:
-        tick: dora/timer/millis/100
-        random: rust-node/random
-      outputs:
-        - status
+    build: cargo build -p rust-dataflow-example-status-node
+    path: ../../target/debug/rust-dataflow-example-status-node
+    inputs:
+      tick: dora/timer/millis/100
+      random: rust-node/random
+    outputs:
+      - status
+
   - id: rust-sink-dynamic
-    custom:
-      build: cargo build -p rust-dataflow-example-sink-dynamic
-      source: dynamic
-      inputs:
-        message: rust-status-node/status
+    build: cargo build -p rust-dataflow-example-sink-dynamic
+    path: dynamic
+    inputs:
+      message: rust-status-node/status
+
   - id: dora-record
-    custom:
-      build: cargo build -p dora-record
-      source: ../../target/debug/dora-record
-      inputs:
-        message: rust-status-node/status
-        random: rust-node/random
+    build: cargo build -p dora-record
+    path: ../../target/debug/dora-record
+    inputs:
+      message: rust-status-node/status
+      random: rust-node/random

--- a/examples/rust-dataflow/dataflow_socket.yml
+++ b/examples/rust-dataflow/dataflow_socket.yml
@@ -1,7 +1,6 @@
 communication:
-  _unstable_local:
-    UnixDomain
-    
+  _unstable_local: UnixDomain
+
 nodes:
   - id: rust-node
     build: cargo build -p rust-dataflow-example-node
@@ -10,20 +9,22 @@ nodes:
       tick: dora/timer/millis/10
     outputs:
       - random
+
   - id: rust-status-node
-    custom:
-      build: cargo build -p rust-dataflow-example-status-node
-      source: ../../target/debug/rust-dataflow-example-status-node
-      inputs:
-        tick: dora/timer/millis/100
-        random: rust-node/random
-      outputs:
-        - status
+    build: cargo build -p rust-dataflow-example-status-node
+    path: ../../target/debug/rust-dataflow-example-status-node
+    inputs:
+      tick: dora/timer/millis/100
+      random: rust-node/random
+    outputs:
+      - status
+
   - id: rust-sink
     build: cargo build -p rust-dataflow-example-sink
     path: ../../target/debug/rust-dataflow-example-sink
     inputs:
       message: rust-status-node/status
+
   - id: dora-record
     build: cargo build -p dora-record
     path: ../../target/debug/dora-record

--- a/examples/rust-ros2-dataflow/dataflow.yml
+++ b/examples/rust-ros2-dataflow/dataflow.yml
@@ -1,10 +1,9 @@
 nodes:
   - id: rust-node
-    custom:
-      build: cargo build -p rust-ros2-dataflow-example-node --features ros2
-      source: ../../target/debug/rust-ros2-dataflow-example-node
-      inputs:
-        tick: dora/timer/millis/500
-        service_timer: dora/timer/secs/1
-      outputs:
-        - pose
+    build: cargo build -p rust-ros2-dataflow-example-node --features ros2
+    path: ../../target/debug/rust-ros2-dataflow-example-node
+    inputs:
+      tick: dora/timer/millis/500
+      service_timer: dora/timer/secs/1
+    outputs:
+      - pose


### PR DESCRIPTION
Hi! I took a look at our `examples` directory, and while reading through some dataflows, I noticed that there are a lot of outdated node syntaxes:

```YML
nodes:
  - id: rust-node
    custom:
      build: cargo build -p benchmark-example-node --release
      source: ../../target/release/benchmark-example-node
```

I think it would be better if we avoided using deprecated syntax in our example folder, as it will be one of the first things people look at.