### PR TITLE
Make the benchmark run in release and at full speed

### DIFF
--- a/examples/benchmark/run.rs
+++ b/examples/benchmark/run.rs
@@ -23,6 +23,7 @@ async fn build_dataflow(dataflow: &Path) -> eyre::Result<()> {
     let mut cmd = tokio::process::Command::new(&cargo);
     cmd.arg("run");
     cmd.arg("--package").arg("dora-cli");
+    cmd.arg("--release");
     cmd.arg("--").arg("build").arg(dataflow);
     if !cmd.status().await?.success() {
         bail!("failed to build dataflow");
@@ -35,6 +36,7 @@ async fn run_dataflow(dataflow: &Path) -> eyre::Result<()> {
     let mut cmd = tokio::process::Command::new(&cargo);
     cmd.arg("run");
     cmd.arg("--package").arg("dora-cli");
+    cmd.arg("--release");
     cmd.arg("--")
         .arg("daemon")
         .arg("--run-dataflow")


### PR DESCRIPTION
# Bad latency

Hi! I noticed some time ago that I was experiencing really bad latency when running:

```bash
cargo run --example benchmark
```

Even with:

```bash
cargo run --example benchmark --release
```

The latency was still completely off (which is somewhat expected, as Debug mode can cause strange behavior):

```
size 0x0     : 615.092µs
size 0x8     : 623.942µs
size 0x40    : 718.112µs
size 0x200   : 1.217172ms
size 0x800   : 2.244282ms
size 0x1000  : 612.062µs
size 0x4000  : 525.111µs
size 0xa000  : 436.742µs
size 0x64000 : 211.722µs
size 0x3e8000: 595.502371ms
```

The issue was in the `run.rs` file, which was building and running the `dora-cli` package in Debug mode by default. I added the `--release` flag, and now it works well with both:

```bash
cargo run --example benchmark
```

and

```bash
cargo run --example benchmark --release
```

```
size 0x0     : 294.362µs
size 0x8     : 254.392µs
size 0x40    : 216.332µs
size 0x200   : 260.562µs
size 0x800   : 276.582µs
size 0x1000  : 222.322µs
size 0x4000  : 322.171µs
size 0xa000  : 253.342µs
size 0x64000 : 264.991µs
size 0x3e8000: 133.882µs
```

# Bad bandwidth

I also noticed really poor bandwidth for data transfer:

```
size 0x0     : 12856 messages per second
size 0x8     : 22945 messages per second
size 0x40    : 26058 messages per second
size 0x200   : 43542 messages per second
size 0x800   : 36324 messages per second
size 0x1000  : 25768 messages per second
size 0x4000  : 6855 messages per second
size 0xa000  : 3476 messages per second
size 0x64000 : 395 messages per second
size 0x3e8000: 44 messages per second
```

This was caused by regenerating random numbers for each test. I don't think we should do that because it doesn't align with our benchmarking goals—we want to measure the latency of transmitting a known message and the associated bandwidth.

Now that I generate the data **before** transferring it, I get much better (and more representative) benchmark results:

```
size 0x0     : 8281 messages per second
size 0x8     : 24399 messages per second
size 0x40    : 19108 messages per second
size 0x200   : 19656 messages per second
size 0x800   : 34075 messages per second
size 0x1000  : 19251 messages per second
size 0x4000  : 21178 messages per second
size 0xa000  : 19627 messages per second
size 0x64000 : 8141 messages per second
size 0x3e8000: 1346 messages per second
```