### PR TITLE
Fix not-null terminated string print within C template

### DIFF
--- a/binaries/cli/src/template/c/listener/listener-template.c
+++ b/binaries/cli/src/template/c/listener/listener-template.c
@@ -43,7 +43,7 @@ int main()
             read_dora_input_data(event, &data_ptr, &data_len);
 
             unsigned long long timestamp = read_dora_input_timestamp(event);
-            printf("I heard %s from %s at %llu\n", data_ptr, id_ptr, timestamp);
+            printf("I heard %s from %.*s at %llu\n", data_ptr, (int)id_len, id_ptr, timestamp);
         }
         else if (ty == DoraEventType_Stop)
         {


### PR DESCRIPTION
C Node Template used to read the ID string that was not null terminated making it read non UTF8 strings,

This fixes this issue by using the `id_len` to define the string.

## Before

```
[c node] dora context initialized
I heard Hello World from speech-2 at 7413312390293631648
I heard Hello World from speech-1� at 7413312390293852048
I heard Hello World from speech-1rld at 7413312390724241040
I heard Hello World from speech-1 at 7413312391153242512
I heard Hello World from speech-1rld at 7413312391583614704
I heard Hello World from speech-1 at 7413312392013829936
I heard Hello World from speech-1 at 7413312392445357008
I heard Hello World from speech-1 at 7413312392869967824
I heard Hello World from speech-1 at 7413312393300188464
I heard Hello World from speech-1 at 7413312393728743248
I heard Hello World from speech-1 at 7413312394163419488
[c node] received input closed event
I heard Hello World from speech-2 at 7413312398882741200
[c node] received stop event
```

## After

```
[c node] dora context initialized
I heard Hello World from speech-2 at 7413314362653395744
I heard Hello World from speech-1 at 7413314362653612304
I heard Hello World from speech-1 at 7413314363085816864
I heard Hello World from speech-1 at 7413314363514843808
I heard Hello World from speech-1 at 7413314363944633504
I heard Hello World from speech-1 at 7413314364373638000
I heard Hello World from speech-1 at 7413314364802237744
I heard Hello World from speech-1 at 7413314365230875824
I heard Hello World from speech-1 at 7413314365659380208
I heard Hello World from speech-1 at 7413314366092720496
I heard Hello World from speech-1 at 7413314366519381008
[c node] received input closed event
[c node] received stop event

```
