### PR TITLE
Small install script update for bash

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -185,7 +185,9 @@ fi
 echo "Placing dora-rs cli in $dest"
 
 if [ -e "$dest/$bin" ] && [ "$force" = false ]; then
-  echo "\`$dest/$bin\` already exists"
+  echo " Replacing \`$dest/$bin\` with downloaded version"
+  cp "$td/$bin" "$dest/$bin"
+  chmod 755 "$dest/$bin"
 else
   mkdir -p "$dest"
   cp "$td/$bin" "$dest/$bin"
@@ -197,31 +199,28 @@ read -p "Do you want to add $dest to your PATH automatically? (y/n): " response
 
 if [[ "$response" =~ ^([yY][eE][sS]|[yY])$ ]]; then
     if [ "$SHELL" = "/bin/bash" ]; then
-        if ! grep -q "$dest" ~/.bashrc; then
-            echo "Adding $dest to PATH in ~/.bashrc"
-            echo "export PATH=\$PATH:$dest" >> ~/.bashrc
-            source ~/.bashrc
-            echo "Path added to ~/.bashrc and reloaded."
-        else
-            echo "$dest is already in the PATH in ~/.bashrc"
-        fi
-    elif [ "$SHELL" = "/bin/zsh" ]; then
-        if ! grep -q "$dest" ~/.zshrc; then
-            echo "Adding $dest to PATH in ~/.zshrc"
-            echo "export PATH=\$PATH:$dest" >> ~/.zshrc
-            source ~/.zshrc
-            echo "Path added to ~/.zshrc and reloaded."
-        else
-            echo "$dest is already in the PATH in ~/.zshrc"
-        fi
+    if ! grep -q "$dest" ~/.bashrc; then
+        echo "Adding $dest to PATH in ~/.bashrc"
+        echo "export PATH=\$PATH:$dest" >> ~/.bashrc
+        source ~/.bashrc
+        echo "Path added to ~/.bashrc and reloaded."
     else
-        echo "Unsupported shell: $SHELL"
-        echo "Please add the following to your shell's configuration file manually:"
-        echo "    export PATH=\$PATH:$dest"
+        echo "$dest is already in the PATH in ~/.bashrc"
+    fi
+elif [ "$SHELL" = "/bin/zsh" ]; then
+    if ! grep -q "$dest" ~/.zshrc; then
+        echo "Adding $dest to PATH in ~/.zshrc"
+        echo "export PATH=\$PATH:$dest" >> ~/.zshrc
+        source ~/.zshrc
+        echo "Path added to ~/.zshrc and reloaded."
+    else
+        echo "$dest is already in the PATH in ~/.zshrc"
     fi
 else
-    echo "You chose not to add $dest to your PATH."
-    echo "To run dora CLI without adding to PATH, use: '~/.dora/bin/dora'"
+    echo "Unsupported shell: $SHELL"
+    echo "Please add the following to your shell's configuration file manually:"
+    echo "    export PATH=\$PATH:$dest"
 fi
+
 
 rm -rf "$td"

--- a/install.sh
+++ b/install.sh
@@ -195,7 +195,7 @@ else
   echo ""
 fi
 
-if [ -z "$BASH" ]; then
+if [ "$SHELL" = "/bin/bash" ]; then
     if ! grep -q "$dest" ~/.bashrc; then
         echo "Adding $dest to PATH in ~/.bashrc"
         echo "export PATH=\$PATH:$dest" >> ~/.bashrc

--- a/install.sh
+++ b/install.sh
@@ -199,8 +199,9 @@ if [ "$SHELL" = "/bin/bash" ]; then
     if ! grep -q "$dest" ~/.bashrc; then
         echo "Adding $dest to PATH in ~/.bashrc"
         echo "export PATH=\$PATH:$dest" >> ~/.bashrc
-        source ~/.bashrc
-        echo "Path added to ~/.bashrc and reloaded."
+        echo "Path added to ~/.bashrc."
+        echo "Please reload with:"
+        echo "  source ~/.bashrc"
     else
         echo "$dest is already in the PATH in ~/.bashrc"
     fi
@@ -208,8 +209,9 @@ elif [ "$SHELL" = "/bin/zsh" ]; then
     if ! grep -q "$dest" ~/.zshrc; then
         echo "Adding $dest to PATH in ~/.zshrc"
         echo "export PATH=\$PATH:$dest" >> ~/.zshrc
-        source ~/.zshrc
-        echo "Path added to ~/.zshrc and reloaded."
+        echo "Path added to ~/.zshrc."
+        echo "Please reload with:"
+        echo "  source ~/.zshrc"
     else
         echo "$dest is already in the PATH in ~/.zshrc"
     fi

--- a/install.sh
+++ b/install.sh
@@ -195,10 +195,7 @@ else
   echo ""
 fi
 
-read -p "Do you want to add $dest to your PATH automatically? (y/n): " response
-
-if [[ "$response" =~ ^([yY][eE][sS]|[yY])$ ]]; then
-    if [ "$SHELL" = "/bin/bash" ]; then
+if [ -z "$BASH" ]; then
     if ! grep -q "$dest" ~/.bashrc; then
         echo "Adding $dest to PATH in ~/.bashrc"
         echo "export PATH=\$PATH:$dest" >> ~/.bashrc


### PR DESCRIPTION
Small script update to make it easier for users that use `/bin/bash`. 


- It fixes the user input that was not prompted for some unknown reason. It's probably better to update the PATH by default as it removes one user step.
- I have also made overwriting the current bin with downloaded version to avoid having conflicting version. 