### PR TITLE
Add additional image encoding

### DIFF
--- a/examples/camera/dataflow_jupyter.yml
+++ b/examples/camera/dataflow_jupyter.yml
@@ -1,0 +1,20 @@
+nodes:
+  - id: camera
+    build: pip install ../../node-hub/opencv-video-capture
+    path: opencv-video-capture
+    inputs:
+      tick: dora/timer/millis/20
+    outputs:
+      - image
+    env:
+      CAPTURE_PATH: 0
+      IMAGE_WIDTH: 640
+      IMAGE_HEIGHT: 480
+      ENCODING: "jpeg"
+
+  - id: plot
+    path: dynamic
+    inputs:
+      image:
+        source: camera/image
+        queue_size: 1

--- a/examples/camera/notebook.ipynb
+++ b/examples/camera/notebook.ipynb
@@ -1,0 +1,53 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dora import Node\n",
+    "import IPython.display\n",
+    "from IPython.display import clear_output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "node = Node(\"plot\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "for event in node:\n",
+    "    if event[\"type\"] != \"INPUT\":\n",
+    "        continue\n",
+    "    data = event[\"value\"].to_numpy()\n",
+    "    IPython.display.display(IPython.display.Image(data=data))\n",
+    "    clear_output(wait=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/node-hub/opencv-plot/opencv_plot/main.py
+++ b/node-hub/opencv-plot/opencv_plot/main.py
@@ -70,6 +70,11 @@ def plot_frame(plot):
             cv2.imshow("Dora Node: opencv-plot", plot.frame)
 
 
+def yuv420p_to_bgr_opencv(yuv_array, width, height):
+    yuv = yuv_array.reshape((height * 3 // 2, width))
+    return cv2.cvtColor(yuv, cv2.COLOR_YUV420p2RGB)
+
+
 def main():
 
     # Handle dynamic nodes, ask for the name of the node in the dataflow, and the same values as the ENV variables.
@@ -155,6 +160,22 @@ def main():
                     )
 
                     plot.frame = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+                elif encoding == "jpeg":
+                    channels = 3
+                    storage_type = np.uint8
+                    storage = storage.to_numpy()
+                    plot.frame = cv2.imdecode(storage, cv2.IMREAD_COLOR)
+
+                elif encoding == "yuv420":
+
+                    storage = storage.to_numpy()
+
+                    # Convert back to BGR results in more saturated image.
+                    channels = 3
+                    storage_type = np.uint8
+                    img_bgr_restored = yuv420p_to_bgr_opencv(storage, width, height)
+
+                    plot.frame = img_bgr_restored
                 else:
                     raise RuntimeError(f"Unsupported image encoding: {encoding}")
 

--- a/node-hub/opencv-plot/opencv_plot/main.py
+++ b/node-hub/opencv-plot/opencv_plot/main.py
@@ -160,7 +160,8 @@ def main():
                     )
 
                     plot.frame = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
-                elif encoding == "jpeg":
+
+                elif encoding in ["jpeg", "jpg", "jpe", "bmp", "webp", "png"]:
                     channels = 3
                     storage_type = np.uint8
                     storage = storage.to_numpy()

--- a/node-hub/opencv-plot/opencv_plot/tests/test_opencv_plot.py
+++ b/node-hub/opencv-plot/opencv_plot/tests/test_opencv_plot.py
@@ -1,9 +1,0 @@
-import pytest
-
-
-def test_import_main():
-    from opencv_plot.main import main
-
-    # Check that everything is working, and catch dora Runtime Exception as we're not running in a dora dataflow.
-    with pytest.raises(RuntimeError):
-        main()

--- a/node-hub/opencv-plot/opencv_plot/tests/test_opencv_plot.py
+++ b/node-hub/opencv-plot/opencv_plot/tests/test_opencv_plot.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+def test_import_main():
+    from opencv_plot.main import main
+
+    # Check that everything is working, and catch dora Runtime Exception as we're not running in a dora dataflow.
+    with pytest.raises(RuntimeError):
+        main()

--- a/node-hub/opencv-video-capture/opencv_video_capture/main.py
+++ b/node-hub/opencv-video-capture/opencv_video_capture/main.py
@@ -119,8 +119,8 @@ def main():
                 # Get the right encoding
                 if encoding == "rgb8":
                     frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-                elif encoding == "jpeg":
-                    frame = cv2.imencode(".jpeg", frame)[1]
+                elif encoding in ["jpeg", "jpg", "jpe", "bmp", "webp", "png"]:
+                    frame = cv2.imencode("." + encoding, frame)[1]
 
                 storage = pa.array(frame.ravel())
 

--- a/node-hub/opencv-video-capture/opencv_video_capture/main.py
+++ b/node-hub/opencv-video-capture/opencv_video_capture/main.py
@@ -101,6 +101,11 @@ def main():
                         1,
                     )
 
+                metadata = event["metadata"]
+                metadata["encoding"] = encoding
+                metadata["width"] = int(frame.shape[1])
+                metadata["height"] = int(frame.shape[0])
+
                 # resize the frame
                 if (
                     image_width is not None
@@ -114,13 +119,10 @@ def main():
                 # Get the right encoding
                 if encoding == "rgb8":
                     frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+                elif encoding == "jpeg":
+                    frame = cv2.imencode(".jpeg", frame)[1]
 
                 storage = pa.array(frame.ravel())
-
-                metadata = event["metadata"]
-                metadata["width"] = int(frame.shape[1])
-                metadata["height"] = int(frame.shape[0])
-                metadata["encoding"] = encoding
 
                 node.send_output("image", storage, metadata)
 


### PR DESCRIPTION
Enable the use of `jpeg` encoding to send camera data as jpeg as it is more efficient when using remote connections.

I also provided a notebook example to run the camera example within a jupyter notebook for fast protoyping.