### PR TITLE
Remove save cache on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-provider: buildjet
-          cache-on-failure: true
           # only save caches for `main` branch
           save-if: ${{ github.ref == 'refs/heads/main' }}
 


### PR DESCRIPTION
Removing cache as it seems that the cache does not work on Github Action image update.

Fix: https://github.com/dora-rs/dora/actions/runs/11051842699/job/30708702889