### PR TITLE
Report when shared memory region is mapped to allow faster cleanup

### DIFF
--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use dora_message::{
-    daemon_to_node::{DaemonCommunication, DaemonReply, DataMessage, NodeEvent},
+    daemon_to_node::{DaemonCommunication, DaemonReply},
     id::DataId,
     node_to_daemon::{DaemonRequest, Timestamped},
     DataflowId,
@@ -19,10 +19,7 @@ use futures::{
 use futures_timer::Delay;
 use scheduler::{Scheduler, NON_INPUT_EVENT};
 
-use self::{
-    event::SharedMemoryData,
-    thread::{EventItem, EventStreamThreadHandle},
-};
+use self::thread::{EventItem, EventStreamThreadHandle};
 use crate::daemon_connection::DaemonChannel;
 use dora_core::{
     config::{Input, NodeId},
@@ -199,51 +196,7 @@ impl EventStream {
 
     fn convert_event_item(item: EventItem) -> Event {
         match item {
-            EventItem::NodeEvent { event, ack_channel } => match event {
-                NodeEvent::Stop => Event::Stop,
-                NodeEvent::Reload { operator_id } => Event::Reload { operator_id },
-                NodeEvent::InputClosed { id } => Event::InputClosed { id },
-                NodeEvent::Input { id, metadata, data } => {
-                    let data = match data {
-                        None => Ok(None),
-                        Some(DataMessage::Vec(v)) => Ok(Some(RawData::Vec(v))),
-                        Some(DataMessage::SharedMemory {
-                            shared_memory_id,
-                            len,
-                            drop_token: _, // handled in `event_stream_loop`
-                        }) => unsafe {
-                            MappedInputData::map(&shared_memory_id, len).map(|data| {
-                                Some(RawData::SharedMemory(SharedMemoryData {
-                                    data,
-                                    _drop: ack_channel,
-                                }))
-                            })
-                        },
-                    };
-                    let data = data.and_then(|data| {
-                        let raw_data = data.unwrap_or(RawData::Empty);
-                        raw_data
-                            .into_arrow_array(&metadata.type_info)
-                            .map(arrow::array::make_array)
-                    });
-                    match data {
-                        Ok(data) => Event::Input {
-                            id,
-                            metadata,
-                            data: data.into(),
-                        },
-                        Err(err) => Event::Error(format!("{err:?}")),
-                    }
-                }
-                NodeEvent::AllInputsClosed => {
-                    let err = eyre!(
-                        "received `AllInputsClosed` event, which should be handled by background task"
-                    );
-                    tracing::error!("{err:?}");
-                    Event::Error(err.wrap_err("internal error").to_string())
-                }
-            },
-
+            EventItem::NodeEvent { event } => event,
             EventItem::FatalError(err) => {
                 Event::Error(format!("fatal event stream error: {err:?}"))
             }

--- a/apis/rust/node/src/event_stream/scheduler.rs
+++ b/apis/rust/node/src/event_stream/scheduler.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, VecDeque};
 
 use dora_message::{daemon_to_node::NodeEvent, id::DataId};
 
-use super::thread::EventItem;
+use super::{thread::EventItem, Event};
 pub const NON_INPUT_EVENT: &str = "dora/non_input_event";
 
 // This scheduler will make sure that there is fairness between
@@ -40,13 +40,7 @@ impl Scheduler {
     pub fn add_event(&mut self, event: EventItem) {
         let event_id = match &event {
             EventItem::NodeEvent {
-                event:
-                    NodeEvent::Input {
-                        id,
-                        metadata: _,
-                        data: _,
-                    },
-                ack_channel: _,
+                event: Event::Input { id, .. },
             } => id,
             _ => &DataId::from(NON_INPUT_EVENT.to_string()),
         };

--- a/binaries/daemon/src/node_communication/mod.rs
+++ b/binaries/daemon/src/node_communication/mod.rs
@@ -5,7 +5,7 @@ use dora_core::{
     uhlc,
 };
 use dora_message::{
-    common::{DropToken, Timestamped},
+    common::{DropTokenState, DropTokenStatus, Timestamped},
     daemon_to_node::{DaemonCommunication, DaemonReply, NodeDropEvent, NodeEvent},
     node_to_daemon::DaemonRequest,
     DataflowId,
@@ -461,13 +461,13 @@ impl Listener {
         Ok(())
     }
 
-    async fn report_drop_tokens(&mut self, drop_tokens: Vec<DropToken>) -> eyre::Result<()> {
+    async fn report_drop_tokens(&mut self, drop_tokens: Vec<DropTokenStatus>) -> eyre::Result<()> {
         if !drop_tokens.is_empty() {
             let event = Event::Node {
                 dataflow_id: self.dataflow_id,
                 node_id: self.node_id.clone(),
-                event: DaemonNodeEvent::ReportDrop {
-                    tokens: drop_tokens,
+                event: DaemonNodeEvent::ReportTokenState {
+                    token_events: drop_tokens,
                 },
             };
             let event = Timestamped {

--- a/libraries/message/src/common.rs
+++ b/libraries/message/src/common.rs
@@ -192,6 +192,22 @@ impl fmt::Debug for DataMessage {
 #[derive(
     Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
 )]
+pub struct DropTokenStatus {
+    pub token: DropToken,
+    pub state: DropTokenState,
+}
+
+#[derive(
+    Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
+pub enum DropTokenState {
+    Mapped,
+    Dropped,
+}
+
+#[derive(
+    Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
 pub struct DropToken(Uuid);
 
 impl DropToken {

--- a/libraries/message/src/daemon_to_node.rs
+++ b/libraries/message/src/daemon_to_node.rs
@@ -74,5 +74,6 @@ pub enum NodeEvent {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum NodeDropEvent {
+    OutputMapped { drop_token: DropToken },
     OutputDropped { drop_token: DropToken },
 }

--- a/libraries/message/src/node_to_daemon.rs
+++ b/libraries/message/src/node_to_daemon.rs
@@ -2,6 +2,7 @@ pub use crate::common::{
     DataMessage, DropToken, LogLevel, LogMessage, SharedMemoryId, Timestamped,
 };
 use crate::{
+    common::DropTokenStatus,
     current_crate_version,
     id::{DataId, NodeId},
     metadata::Metadata,
@@ -22,10 +23,10 @@ pub enum DaemonRequest {
     /// required drop tokens.
     OutputsDone,
     NextEvent {
-        drop_tokens: Vec<DropToken>,
+        drop_tokens: Vec<DropTokenStatus>,
     },
     ReportDropTokens {
-        drop_tokens: Vec<DropToken>,
+        drop_tokens: Vec<DropTokenStatus>,
     },
     SubscribeDrop,
     NextFinishedDropTokens,


### PR DESCRIPTION
The shared memory region can be safely removed by the sender once it's mapped in the receiver. The OS will just delete the file handle associated with the shared memory region, but keep the data alive until it has been unmapped from all address spaces.

By notifying the sender that a message has been mapped to the address space we enable faster cleanup on exit. The sender can safely close all of its shared memory regions once all of its sent messages are at least mapped. So it does not need to wait until all messages have been _dropped_ anymore, which can take considerably longer, especially if the Python GC is involved.

This commit modifies the message format, so we need to bump the version of the `dora-message` crate to `0.5.0`.

This PR leads to a quicker exit of the `camera` node of #625.