### PR TITLE
Better error handling for unknown output

### DIFF
--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -253,7 +253,7 @@ impl DoraNode {
         self.handle_finished_drop_tokens()?;
 
         if !self.node_config.outputs.contains(&output_id) {
-            eyre::bail!("unknown output");
+            eyre::bail!("unknown dora node output `{output_id}` called by `send_output`. Double-check if this output is defined within your dataflow YAML file.",);
         }
         let metadata = Metadata::from_parameters(self.clock.new_timestamp(), type_info, parameters);
 

--- a/examples/echo/dataflow.yml
+++ b/examples/echo/dataflow.yml
@@ -11,7 +11,7 @@ nodes:
     build: pip install -e ../../node-hub/dora-echo
     path: dora-echo
     inputs:
-      input: terminal-input/data
+      echo: terminal-input/data
     outputs:
       - echo
 


### PR DESCRIPTION
This PR makes it easier to debug when an output id is used but not present within the dataflow output list of a node.