### PR TITLE
Enable multiline build for better packaging of dora node.

### DIFF
--- a/binaries/cli/src/build.rs
+++ b/binaries/cli/src/build.rs
@@ -59,22 +59,24 @@ pub fn build(dataflow: &Path) -> eyre::Result<()> {
 
 fn run_build_command(build: Option<&str>, working_dir: &Path) -> eyre::Result<()> {
     if let Some(build) = build {
-        let mut split = build.split_whitespace();
-        let mut cmd = Command::new(
-            split
-                .next()
-                .ok_or_else(|| eyre!("build command is empty"))?,
-        );
-        cmd.args(split);
-        cmd.current_dir(working_dir);
-        let exit_status = cmd
-            .status()
-            .wrap_err_with(|| format!("failed to run `{}`", build))?;
-        if exit_status.success() {
-            Ok(())
-        } else {
-            Err(eyre!("build command returned an error code"))
+        let lines = build.lines().collect::<Vec<_>>();
+        for build_line in lines {
+            let mut split = build_line.split_whitespace();
+            let mut cmd = Command::new(
+                split
+                    .next()
+                    .ok_or_else(|| eyre!("build command is empty"))?,
+            );
+            cmd.args(split);
+            cmd.current_dir(working_dir);
+            let exit_status = cmd
+                .status()
+                .wrap_err_with(|| format!("failed to run `{}`", build))?;
+            if !exit_status.success() {
+                return Err(eyre!("build command `{build_line}` returned {exit_status}"));
+            }
         }
+        Ok(())
     } else {
         Ok(())
     }

--- a/tests/multiline_build/dataflow.yml
+++ b/tests/multiline_build/dataflow.yml
@@ -1,0 +1,6 @@
+nodes:
+  - id: dora-microphone
+    build: |
+      pip install -e ../../node-hub/dora-microphone
+      pip install -e ../../node-hub/dora-vad
+    path: dora-microphone

--- a/tests/multiline_build/dataflow.yml
+++ b/tests/multiline_build/dataflow.yml
@@ -1,6 +1,6 @@
 nodes:
   - id: dora-microphone
     build: |
-      pip install -e ../../node-hub/dora-microphone
+      pip install -e ../../node-hub/dora-microphones
       pip install -e ../../node-hub/dora-vad
     path: dora-microphone


### PR DESCRIPTION
It is necessary to make build multiline in order to build certain node. 

This allow users to do the following:

```bash
nodes:
  - id: dora-microphone
    build: |
      pip install -e ../../node-hub/dora-microphones
      pip install -e ../../node-hub/dora-vad
    path: dora-microphone
```

or

```bash
nodes:
  - id: dora-microphone
    build: |
      sudo apt install abc
      pip install bar
    path: dora-microphone
```

