### PR TITLE
Add package flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,54 @@
+{
+  description = "Dora CLI package for Nix";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {inherit system;};
+    in {
+      packages = {
+        dora-cli = pkgs.rustPlatform.buildRustPackage rec {
+          pname = "dora-cli";
+          version = "0.3.6";
+
+          src = pkgs.fetchFromGitHub {
+            owner = "dora-rs";
+            repo = "dora";
+            rev = "v${version}";
+            hash = "sha256-YwEqwA7Eqz7ZJYFfKoPTWkmgsudKpoATcFE6OOwxpbU=";
+          };
+
+          cargoHash = "sha256-AkungKYGHMK/tUfzh0d88zRRkQfshus7xOHzdtYAT/I=";
+          nativeBuildInputs = [pkgs.pkg-config];
+          buildInputs = [pkgs.openssl];
+          OPENSSL_NO_VENDOR = 1;
+          buildPhase = ''
+            cargo build --release -p dora-cli
+          '';
+
+
+          installPhase = ''
+            mkdir -p $out/bin
+            cp target/release/dora $out/bin
+          '';
+
+          doCheck = false;
+
+          meta = {
+            description = "Making robotic applications fast and simple!";
+            homepage = "https://dora-rs.ai/";
+            changelog = "https://github.com/dora-rs/dora/blob/main/Changelog.md";
+            license = pkgs.lib.licenses.asl20;
+          };
+        };
+      };
+    });
+}


### PR DESCRIPTION
This means that someone using nix can add this to their flake inputs:

```nix
    dora-rs = {
      url = "github:dora-rs/dora";
      inputs.nixpkgs.follows = "nixpkgs";
    };
```

and that allows them to add dora-cli, v0.3.6, as one of the declared packages of the system.

This is the first step towards adding dora to the nix package repo.