### PR TITLE
Temporary fix qwenvl2 queue error

### DIFF
--- a/examples/vlm/dataflow.yml
+++ b/examples/vlm/dataflow.yml
@@ -18,7 +18,7 @@ nodes:
       image:
         source: camera/image
         queue_size: 1
-      tick: dora/timer/millis/300
+      tick: dora/timer/millis/100
     outputs:
       - text
       - tick

--- a/node-hub/dora-qwenvl/dora_qwenvl/main.py
+++ b/node-hub/dora-qwenvl/dora_qwenvl/main.py
@@ -102,6 +102,7 @@ def main():
 
         if event_type == "INPUT":
 
+            # pylint: disable=fixme
             # TODO: Remove this after https://github.com/dora-rs/dora/pull/652
             while True:
                 next_event = node.next(timeout=0.001)

--- a/node-hub/dora-qwenvl/dora_qwenvl/main.py
+++ b/node-hub/dora-qwenvl/dora_qwenvl/main.py
@@ -101,6 +101,15 @@ def main():
         event_type = event["type"]
 
         if event_type == "INPUT":
+
+            # TODO: Remove this after https://github.com/dora-rs/dora/pull/652
+            while True:
+                next_event = node.next(timeout=0.001)
+                if next_event is not None and next_event["type"] == "INPUT":
+                    event = next_event
+                else:
+                    break
+
             event_id = event["id"]
 
             if "image" in event_id:

--- a/node-hub/dora-qwenvl/pyproject.toml
+++ b/node-hub/dora-qwenvl/pyproject.toml
@@ -20,6 +20,7 @@ transformers = "^4.45"
 qwen-vl-utils = "^0.0.2"
 accelerate = "^0.33"
 opencv-python = ">= 4.1.1"
+modelscope = "^1.18.1"
 # flash_attn = "^2.6.1" # Install using: pip install -U flash-attn --no-build-isolation
 
 


### PR DESCRIPTION
In order to get the best performance from Qwenvl2, we need to temporary add  this piece of code that is going to unqueue qwenvl queue. 

This is directly linked to: https://github.com/dora-rs/dora/pull/652 which is that we currently having a queue issue within nodes for `queue_size: 1` where the queue is actually pending older data and not the newest one.
