### PR TITLE
Fix child process receiving ctrl-c by setting own process group

### DIFF
--- a/binaries/daemon/src/spawn.rs
+++ b/binaries/daemon/src/spawn.rs
@@ -155,6 +155,7 @@ pub async fn spawn_node(
             }
 
             // Set the process group to 0 to ensure that the spawned process does not spawn immediately on CTRL-C
+            #[cfg(unix)]
             command.process_group(0);
 
             command
@@ -253,8 +254,8 @@ pub async fn spawn_node(
                     command.env(key, value.to_string());
                 }
             }
-
             // Set the process group to 0 to ensure that the spawned process does not spawn immediately on CTRL-C
+            #[cfg(unix)]
             command.process_group(0);
 
             command

--- a/binaries/daemon/src/spawn.rs
+++ b/binaries/daemon/src/spawn.rs
@@ -254,7 +254,7 @@ pub async fn spawn_node(
                     command.env(key, value.to_string());
                 }
             }
-            // Set the process group to 0 to ensure that the spawned process does not spawn immediately on CTRL-C
+            // Set the process group to 0 to ensure that the spawned process does not exit immediately on CTRL-C
             #[cfg(unix)]
             command.process_group(0);
 

--- a/binaries/daemon/src/spawn.rs
+++ b/binaries/daemon/src/spawn.rs
@@ -153,6 +153,10 @@ pub async fn spawn_node(
                     command.env(key, value.to_string());
                 }
             }
+
+            // Set the process group to 0 to ensure that the spawned process does not spawn immediately on CTRL-C
+            command.process_group(0);
+
             command
                 .stdin(Stdio::null())
                 .stdout(Stdio::piped())
@@ -249,6 +253,9 @@ pub async fn spawn_node(
                     command.env(key, value.to_string());
                 }
             }
+
+            // Set the process group to 0 to ensure that the spawned process does not spawn immediately on CTRL-C
+            command.process_group(0);
 
             command
                 .stdin(Stdio::null())

--- a/binaries/daemon/src/spawn.rs
+++ b/binaries/daemon/src/spawn.rs
@@ -154,7 +154,7 @@ pub async fn spawn_node(
                 }
             }
 
-            // Set the process group to 0 to ensure that the spawned process does not spawn immediately on CTRL-C
+            // Set the process group to 0 to ensure that the spawned process does not exit immediately on CTRL-C
             #[cfg(unix)]
             command.process_group(0);
 


### PR DESCRIPTION
This fix an issue with my computer sending SIGINT to all process under `dora daemon`.

Documentation for the change:
```rust

    /// Sets the process group ID (PGID) of the child process. Equivalent to a
    /// `setpgid` call in the child process, but may be more efficient.
    ///
    /// Process groups determine which processes receive signals.
    ///
    /// # Examples
    ///
    /// Pressing Ctrl-C in a terminal will send `SIGINT` to all processes
    /// in the current foreground process group. By spawning the `sleep`
    /// subprocess in a new process group, it will not receive `SIGINT`
    /// from the terminal.
    ///
    /// The parent process could install a [signal handler] and manage the
    /// process on its own terms.
    ///
    /// A process group ID of 0 will use the process ID as the PGID.
    ///
    /// ```no_run
    /// # async fn test() { // allow using await
    /// use tokio::process::Command;
    ///
    /// let output = Command::new("sleep")
    ///     .arg("10")
    ///     .process_group(0)
    ///     .output()
    ///     .await
    ///     .unwrap();
    /// # }
    /// ```
    #[cfg(unix)]
    #[cfg_attr(docsrs, doc(cfg(unix)))]
    pub fn process_group(&mut self, pgroup: i32) -> &mut Command {
        self.std.process_group(pgroup);
        self
    }

```
From tokio doc 