### PR TITLE
Make list an available type for metadata

### DIFF
--- a/libraries/message/src/metadata.rs
+++ b/libraries/message/src/metadata.rs
@@ -60,6 +60,7 @@ pub enum Parameter {
     Bool(bool),
     Integer(i64),
     String(String),
+    ListInt(Vec<i64>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
This enables to pass PyList and PyTuple as a metadata value.