### PR TITLE
Moving queue size and making node flume queue bigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,27 +322,36 @@ jobs:
           sleep 10
           dora stop --name ci-python-test  --grace-duration 5s
 
+          cd ..
+
           # Run Python Node Example
 
-          dora build ../examples/python-dataflow/dataflow.yml
-          dora start ../examples/python-dataflow/dataflow.yml --name ci-python --detach
+          dora build examples/python-dataflow/dataflow.yml
+          dora start examples/python-dataflow/dataflow.yml --name ci-python --detach
           sleep 80
           dora stop --name ci-python  --grace-duration 5s
 
           # Run Python Dynamic Node Example
 
-          dora start ../examples/python-dataflow/dataflow_dynamic.yml --name ci-python-dynamic --detach
+          dora start examples/python-dataflow/dataflow_dynamic.yml --name ci-python-dynamic --detach
           opencv-plot --name plot
           sleep 80
           dora stop --name ci-python-dynamic  --grace-duration 5s
 
           # Run Python Operator Example
 
-          dora start ../examples/python-operator-dataflow/dataflow.yml --name ci-python-operator --detach
+          dora start examples/python-operator-dataflow/dataflow.yml --name ci-python-operator --detach
           sleep 80
           dora stop --name ci-python-operator  --grace-duration 5s
 
           dora destroy
+
+          # Run Python queue latency test 
+          dora run tests/queue_size_latest_data_python/dataflow.yaml
+
+          # Run Rust queue latency test 
+          dora build tests/queue_size_latest_data_rust/dataflow.yaml
+          dora run tests/queue_size_latest_data_rust/dataflow.yaml
 
       - name: "Test CLI (C)"
         timeout-minutes: 30

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1380,9 +1380,9 @@ checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytemuck"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
+checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -8601,6 +8601,15 @@ dependencies = [
  "re_tracing",
  "thiserror",
  "tungstenite 0.20.1",
+]
+
+[[package]]
+name = "receive_data"
+version = "0.3.7"
+dependencies = [
+ "chrono",
+ "dora-node-api",
+ "eyre",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "libraries/extensions/ros2-bridge",
     "libraries/extensions/ros2-bridge/msg-gen",
     "libraries/extensions/ros2-bridge/python",
+    "tests/queue_size_latest_data_rust/receive_data",
 ]
 
 [workspace.package]

--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -16,7 +16,7 @@ use futures::{
     Stream, StreamExt,
 };
 use futures_timer::Delay;
-use scheduler::Scheduler;
+use scheduler::{Scheduler, NON_INPUT_EVENT};
 
 use self::{
     event::SharedMemoryData,
@@ -25,7 +25,6 @@ use self::{
 use crate::daemon_connection::DaemonChannel;
 use dora_core::{
     config::{Input, NodeId},
-    topics::NON_INPUT_EVENT,
     uhlc,
 };
 use eyre::{eyre, Context};

--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -185,20 +185,16 @@ impl EventStream {
                                 .iter()
                                 .filter(|queue_event| {
                                     if let EventItem::NodeEvent {
-                                        event: node_event,
+                                        event:
+                                            NodeEvent::Input {
+                                                id,
+                                                data: _,
+                                                metadata: _,
+                                            },
                                         ack_channel: _,
                                     } = queue_event
                                     {
-                                        if let NodeEvent::Input {
-                                            id,
-                                            data: _,
-                                            metadata: _,
-                                        } = node_event
-                                        {
-                                            id == current_event_id
-                                        } else {
-                                            false
-                                        }
+                                        id == current_event_id
                                     } else {
                                         false
                                     }

--- a/apis/rust/node/src/event_stream/scheduler.rs
+++ b/apis/rust/node/src/event_stream/scheduler.rs
@@ -1,9 +1,9 @@
 use std::collections::{HashMap, VecDeque};
 
-use dora_core::topics::NON_INPUT_EVENT;
 use dora_message::{daemon_to_node::NodeEvent, id::DataId};
 
 use super::thread::EventItem;
+pub const NON_INPUT_EVENT: &str = "dora/non_input_event";
 
 // This scheduler will make sure that there is fairness between
 // inputs.

--- a/apis/rust/node/src/event_stream/scheduler.rs
+++ b/apis/rust/node/src/event_stream/scheduler.rs
@@ -64,7 +64,7 @@ impl Scheduler {
     }
 
     pub fn next(&mut self) -> Option<EventItem> {
-        // Retreive message from the non input event first that have priority over input messaage.
+        // Retrieve message from the non input event first that have priority over input message.
         if let Some((_size, queue)) = self
             .event_queues
             .get_mut(&DataId::from(NON_INPUT_EVENT.to_string()))
@@ -74,7 +74,7 @@ impl Scheduler {
             }
         }
 
-        // Process the ID with the oldest timestamp using BTreMap Ordering
+        // Process the ID with the oldest timestamp using BTreeMap Ordering
         for (index, id) in self.last_used.clone().iter().enumerate() {
             if let Some((_size, queue)) = self.event_queues.get_mut(id) {
                 if let Some(event) = queue.pop_front() {

--- a/apis/rust/node/src/event_stream/scheduler.rs
+++ b/apis/rust/node/src/event_stream/scheduler.rs
@@ -1,0 +1,83 @@
+use std::collections::{HashMap, VecDeque};
+
+use dora_message::{daemon_to_node::NodeEvent, id::DataId};
+
+use super::thread::EventItem;
+
+// This scheduler will make sure that there is fairness between
+// inputs.
+//
+// It is going to always make sure that the input that has not been used for the longest period is the first one to be used next.
+//
+// Ex:
+// In the case that one input has a very high frequency and another one with a very slow frequency.\
+//
+// The Node will always alternate between the two inputs when each input is available
+// Avoiding one input to be overwhelmingly present.
+//
+#[derive(Debug)]
+pub struct Scheduler {
+    last_used: VecDeque<DataId>, // Tracks the last-used event ID
+    event_queues: HashMap<DataId, VecDeque<EventItem>>, // Tracks events per ID
+    queue_limit: HashMap<DataId, usize>, // Maximum size of the queue per ID
+}
+
+impl Scheduler {
+    pub fn new(queue_limit: HashMap<DataId, usize>) -> Self {
+        Self {
+            last_used: VecDeque::new(),
+            event_queues: HashMap::new(),
+            queue_limit: queue_limit,
+        }
+    }
+
+    pub fn add_event(&mut self, event: EventItem) {
+        let event_id = match &event {
+            EventItem::NodeEvent {
+                event:
+                    NodeEvent::Input {
+                        id,
+                        metadata: _,
+                        data: _,
+                    },
+                ack_channel: _,
+            } => id.clone(),
+            _ => DataId::from("non_input_event".to_string()),
+        };
+
+        // Enforce queue size limit
+        if let Some(queue) = self.event_queues.get_mut(&event_id) {
+            if &queue.len() >= self.queue_limit.get(&event_id).unwrap_or(&1) {
+                queue.pop_front(); // Remove the oldest event if at limit
+            }
+            queue.push_back(event);
+        } else {
+            self.event_queues
+                .insert(event_id.clone(), VecDeque::from([event]));
+            self.last_used.push_front(event_id.clone());
+        }
+    }
+
+    pub fn next(&mut self) -> Option<EventItem> {
+        // Process the ID with the oldest timestamp using BTreMap Ordering
+
+        for (index, id) in self.last_used.clone().iter().enumerate() {
+            if let Some(queue) = self.event_queues.get_mut(id) {
+                if let Some(event) = queue.pop_front() {
+                    // Put last used at last
+                    self.last_used.remove(index);
+                    self.last_used.push_back(id.clone());
+                    return Some(event);
+                }
+            }
+        }
+
+        None
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.event_queues
+            .iter()
+            .all(|(_id, queue)| queue.is_empty())
+    }
+}

--- a/apis/rust/node/src/event_stream/thread.rs
+++ b/apis/rust/node/src/event_stream/thread.rs
@@ -237,12 +237,13 @@ fn report_remaining_drop_tokens(
                     drop_tokens.push(token);
                 }
                 Err(flume::RecvTimeoutError::Timeout) => {
-                    let duration = Duration::from_secs(30);
+                    let duration = Duration::from_secs(2);
                     if since.elapsed() > duration {
                         tracing::warn!(
                             "timeout: node finished, but token {token:?} was still not \
                             dropped after {duration:?} -> ignoring it"
                         );
+                        drop_tokens.push(token);
                     } else {
                         still_pending.push((token, rx, since, 0));
                     }

--- a/apis/rust/node/src/event_stream/thread.rs
+++ b/apis/rust/node/src/event_stream/thread.rs
@@ -237,13 +237,12 @@ fn report_remaining_drop_tokens(
                     drop_tokens.push(token);
                 }
                 Err(flume::RecvTimeoutError::Timeout) => {
-                    let duration = Duration::from_secs(2);
+                    let duration = Duration::from_secs(1);
                     if since.elapsed() > duration {
                         tracing::warn!(
                             "timeout: node finished, but token {token:?} was still not \
                             dropped after {duration:?} -> ignoring it"
                         );
-                        drop_tokens.push(token);
                     } else {
                         still_pending.push((token, rx, since, 0));
                     }

--- a/apis/rust/node/src/event_stream/thread.rs
+++ b/apis/rust/node/src/event_stream/thread.rs
@@ -60,7 +60,14 @@ impl Drop for EventStreamThreadHandle {
         if self.handle.is_empty() {
             tracing::trace!("waiting for event stream thread");
         }
-        match self.handle.recv_timeout(Duration::from_secs(20)) {
+
+        // TODO: The event stream duration has been shorten due to
+        // Python Reference Counting not working properly and deleting the node
+        // before deleting event creating a race condition.
+        //
+        // In the future, we hope to fix this issue so that
+        // the event stream can be properly waited for every time.
+        match self.handle.recv_timeout(Duration::from_secs(1)) {
             Ok(Ok(())) => {
                 tracing::trace!("event stream thread finished");
             }

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -409,14 +409,14 @@ impl Drop for DoraNode {
                 );
             }
 
-            match self.drop_stream.recv_timeout(Duration::from_secs(10)) {
+            match self.drop_stream.recv_timeout(Duration::from_secs(2)) {
                 Ok(token) => {
                     self.sent_out_shared_memory.remove(&token);
                 }
                 Err(flume::RecvTimeoutError::Disconnected) => {
                     tracing::warn!(
                         "finished_drop_tokens channel closed while still waiting for drop tokens; \
-                        closing {} shared memory regions that might still be used",
+                        closing {} shared memory regions that might not yet been mapped.",
                         self.sent_out_shared_memory.len()
                     );
                     break;
@@ -424,7 +424,7 @@ impl Drop for DoraNode {
                 Err(flume::RecvTimeoutError::Timeout) => {
                     tracing::warn!(
                         "timeout while waiting for drop tokens; \
-                        closing {} shared memory regions that might still be used",
+                        closing {} shared memory regions that might not yet been mapped.",
                         self.sent_out_shared_memory.len()
                     );
                     break;

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -139,7 +139,7 @@ impl DoraNode {
             input_config,
             clock.clone(),
         )
-                .wrap_err("failed to init event stream")?;
+        .wrap_err("failed to init event stream")?;
         let drop_stream =
             DropStream::init(dataflow_id, &node_id, &daemon_communication, clock.clone())
                 .wrap_err("failed to init drop stream")?;

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -130,9 +130,15 @@ impl DoraNode {
             dynamic: _,
         } = node_config;
         let clock = Arc::new(uhlc::HLC::default());
+        let input_config = run_config.inputs.clone();
 
-        let event_stream =
-            EventStream::init(dataflow_id, &node_id, &daemon_communication, clock.clone())
+        let event_stream = EventStream::init(
+            dataflow_id,
+            &node_id,
+            &daemon_communication,
+            input_config,
+            clock.clone(),
+        )
                 .wrap_err("failed to init event stream")?;
         let drop_stream =
             DropStream::init(dataflow_id, &node_id, &daemon_communication, clock.clone())

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -841,7 +841,7 @@ impl Daemon {
                         let _ = reply_sender.send(DaemonReply::Result(Err(err)));
                     }
                     Ok(dataflow) => {
-                        tracing::debug!("node `{node_id}` is ready");
+                        tracing::info!("node `{node_id}` is ready");
                         Self::subscribe(dataflow, node_id.clone(), event_sender, &self.clock).await;
 
                         let status = dataflow

--- a/binaries/daemon/src/node_communication/mod.rs
+++ b/binaries/daemon/src/node_communication/mod.rs
@@ -184,7 +184,6 @@ struct Listener {
     subscribed_events: Option<UnboundedReceiver<Timestamped<NodeEvent>>>,
     subscribed_drop_events: Option<UnboundedReceiver<Timestamped<NodeDropEvent>>>,
     queue: VecDeque<Box<Option<Timestamped<NodeEvent>>>>,
-    queue_sizes: BTreeMap<DataId, usize>,
     clock: Arc<uhlc::HLC>,
 }
 
@@ -192,7 +191,6 @@ impl Listener {
     pub(crate) async fn run<C: Connection>(
         mut connection: C,
         daemon_tx: mpsc::Sender<Timestamped<Event>>,
-        queue_sizes: BTreeMap<DataId, usize>,
         hlc: Arc<uhlc::HLC>,
     ) {
         // receive the first message
@@ -233,7 +231,6 @@ impl Listener {
                             daemon_tx,
                             subscribed_events: None,
                             subscribed_drop_events: None,
-                            queue_sizes,
                             queue: VecDeque::new(),
                             clock: hlc.clone(),
                         };

--- a/binaries/daemon/src/node_communication/shmem.rs
+++ b/binaries/daemon/src/node_communication/shmem.rs
@@ -39,7 +39,7 @@ pub async fn listener_loop(
         }
     });
     let connection = ShmemConnection(tx);
-    Listener::run(connection, daemon_tx, queue_sizes, clock).await
+    Listener::run(connection, daemon_tx, clock).await
 }
 
 enum Operation {

--- a/binaries/daemon/src/node_communication/tcp.rs
+++ b/binaries/daemon/src/node_communication/tcp.rs
@@ -54,7 +54,7 @@ async fn handle_connection_loop(
         tracing::warn!("failed to set nodelay for connection: {err}");
     }
 
-    Listener::run(TcpConnection(connection), daemon_tx, queue_sizes, clock).await
+    Listener::run(TcpConnection(connection), daemon_tx, clock).await
 }
 
 struct TcpConnection(TcpStream);

--- a/binaries/daemon/src/node_communication/unix_domain.rs
+++ b/binaries/daemon/src/node_communication/unix_domain.rs
@@ -52,7 +52,7 @@ async fn handle_connection_loop(
     queue_sizes: BTreeMap<DataId, usize>,
     clock: Arc<HLC>,
 ) {
-    Listener::run(UnixConnection(connection), daemon_tx, queue_sizes, clock).await
+    Listener::run(UnixConnection(connection), daemon_tx, clock).await
 }
 
 struct UnixConnection(UnixStream);

--- a/examples/camera/dataflow.yml
+++ b/examples/camera/dataflow.yml
@@ -1,6 +1,6 @@
 nodes:
   - id: camera
-    build: pip install ../../node-hub/opencv-video-capture
+    build: pip install -e ../../node-hub/opencv-video-capture
     path: opencv-video-capture
     inputs:
       tick: dora/timer/millis/20
@@ -12,7 +12,7 @@ nodes:
       IMAGE_HEIGHT: 480
 
   - id: plot
-    build: pip install ../../node-hub/opencv-plot
+    build: pip install -e ../../node-hub/opencv-plot
     path: opencv-plot
     inputs:
       image:

--- a/node-hub/dora-kit-car/Cargo.toml
+++ b/node-hub/dora-kit-car/Cargo.toml
@@ -23,6 +23,7 @@ eyre = "0.6.8"
 pyo3 = { workspace = true, features = [
     "extension-module",
     "abi3",
+    "eyre"
 ], optional = true }
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.120"

--- a/node-hub/dora-kit-car/pyproject.toml
+++ b/node-hub/dora-kit-car/pyproject.toml
@@ -9,5 +9,7 @@ authors = [{ name = "Leon", email = "echo_ai@foxmail.com" }]
 description = "Dora Node for dora kit car"
 readme = "README.md"
 
+scripts = { "dora-kit-car" = "dora_kit_car:py_main" }
+
 [tool.maturin]
 features = ["python", "pyo3/extension-module"]

--- a/node-hub/dora-kit-car/src/lib.rs
+++ b/node-hub/dora-kit-car/src/lib.rs
@@ -80,10 +80,10 @@ use pyo3::{
 
 #[cfg(feature = "python")]
 #[pyfunction]
-fn py_main(_py: Python) -> PyResult<()> {
+fn py_main(_py: Python) -> eyre::Result<()> {
     pyo3::prepare_freethreaded_python();
 
-    lib_main().map_err(|err| pyo3::exceptions::PyException::new_err(err.to_string()))
+    lib_main()
 }
 
 #[cfg(feature = "python")]

--- a/node-hub/dora-rerun/Cargo.toml
+++ b/node-hub/dora-rerun/Cargo.toml
@@ -23,6 +23,7 @@ k = "0.32"
 pyo3 = { workspace = true, features = [
     "extension-module",
     "abi3",
+    "eyre"
 ], optional = true }
 
 

--- a/node-hub/dora-rerun/src/lib.rs
+++ b/node-hub/dora-rerun/src/lib.rs
@@ -253,9 +253,9 @@ use pyo3::{
 
 #[cfg(feature = "python")]
 #[pyfunction]
-fn py_main(_py: Python) -> PyResult<()> {
+fn py_main(_py: Python) -> eyre::Result<()> {
     pyo3::prepare_freethreaded_python();
-    lib_main().map_err(|e| pyo3::exceptions::PyException::new_err(e.to_string()))
+    lib_main()
 }
 
 /// A Python module implemented in Rust.

--- a/node-hub/dora-yolo/dora_yolo/main.py
+++ b/node-hub/dora-yolo/dora_yolo/main.py
@@ -104,7 +104,7 @@ def main():
                 )
 
         elif event_type == "ERROR":
-            raise RuntimeError(event["error"])
+            print(f"Received dora error: {event['error']}")
 
 
 if __name__ == "__main__":

--- a/tests/queue_size_latest_data_python/dataflow.yaml
+++ b/tests/queue_size_latest_data_python/dataflow.yaml
@@ -1,0 +1,14 @@
+nodes:
+  - id: send_data
+    path: ./send_data.py
+    inputs:
+      tick: dora/timer/millis/20
+    outputs:
+      - data
+
+  - id: receive_data_with_sleep
+    path: ./receive_data.py
+    inputs:
+      tick:
+        source: send_data/data
+        queue_size: 1

--- a/tests/queue_size_latest_data_python/dataflow.yaml
+++ b/tests/queue_size_latest_data_python/dataflow.yaml
@@ -2,7 +2,7 @@ nodes:
   - id: send_data
     path: ./send_data.py
     inputs:
-      tick: dora/timer/millis/20
+      tick: dora/timer/millis/10
     outputs:
       - data
 

--- a/tests/queue_size_latest_data_python/receive_data.py
+++ b/tests/queue_size_latest_data_python/receive_data.py
@@ -17,6 +17,6 @@ for event in node:
         duration = (time.perf_counter_ns() - send_time) / 1_000_000_000
         print("Duration: ", duration)
         assert (
-            duration < 1.2
+            duration < 2
         ), f"Duration: {duration} should be less than 1 as we should always pull latest data."
         time.sleep(1)

--- a/tests/queue_size_latest_data_python/receive_data.py
+++ b/tests/queue_size_latest_data_python/receive_data.py
@@ -1,0 +1,22 @@
+from dora import Node
+import time
+
+
+node = Node()
+
+# Voluntarily sleep for 5 seconds to ensure that the node is dropping the oldest input
+time.sleep(5)
+
+for event in node:
+    event_type = event["type"]
+
+    if event_type == "INPUT":
+        event_id = event["id"]
+        send_time = event["value"][0].as_py()
+
+        duration = (time.clock_gettime_ns(0) - send_time) / 1_000_000_000
+        print("Duration: ", duration)
+        assert (
+            duration < 1.2
+        ), f"Duration: {duration} should be less than 1 as we should always pull latest data."
+        time.sleep(1)

--- a/tests/queue_size_latest_data_python/receive_data.py
+++ b/tests/queue_size_latest_data_python/receive_data.py
@@ -14,7 +14,7 @@ for event in node:
         event_id = event["id"]
         send_time = event["value"][0].as_py()
 
-        duration = (time.clock_gettime_ns(0) - send_time) / 1_000_000_000
+        duration = (time.perf_counter_ns() - send_time) / 1_000_000_000
         print("Duration: ", duration)
         assert (
             duration < 1.2

--- a/tests/queue_size_latest_data_python/send_data.py
+++ b/tests/queue_size_latest_data_python/send_data.py
@@ -11,5 +11,5 @@ for event in node:
         break
     else:
         i += 1
-    now = time.clock_gettime_ns(0)
+    now = time.perf_counter_ns()
     node.send_output("data", pa.array([np.uint64(now)]))

--- a/tests/queue_size_latest_data_python/send_data.py
+++ b/tests/queue_size_latest_data_python/send_data.py
@@ -5,6 +5,11 @@ import numpy as np
 
 node = Node()
 
+i = 0
 for event in node:
+    if i == 1000:
+        break
+    else:
+        i += 1
     now = time.clock_gettime_ns(0)
     node.send_output("data", pa.array([np.uint64(now)]))

--- a/tests/queue_size_latest_data_python/send_data.py
+++ b/tests/queue_size_latest_data_python/send_data.py
@@ -1,0 +1,10 @@
+from dora import Node
+import time
+import pyarrow as pa
+import numpy as np
+
+node = Node()
+
+for event in node:
+    now = time.clock_gettime_ns(0)
+    node.send_output("data", pa.array([np.uint64(now)]))

--- a/tests/queue_size_latest_data_rust/dataflow.yaml
+++ b/tests/queue_size_latest_data_rust/dataflow.yaml
@@ -1,0 +1,15 @@
+nodes:
+  - id: send_data
+    path: ../queue_size_latest_data_python/send_data.py
+    inputs:
+      tick: dora/timer/millis/1
+    outputs:
+      - data
+
+  - id: receive_data_with_sleep
+    path: ../../target/release/receive_data
+    build: cargo build -p receive_data --release
+    inputs:
+      tick:
+        source: send_data/data
+        queue_size: 1

--- a/tests/queue_size_latest_data_rust/dataflow.yaml
+++ b/tests/queue_size_latest_data_rust/dataflow.yaml
@@ -2,7 +2,7 @@ nodes:
   - id: send_data
     path: ../queue_size_latest_data_python/send_data.py
     inputs:
-      tick: dora/timer/millis/1
+      tick: dora/timer/millis/10
     outputs:
       - data
 

--- a/tests/queue_size_latest_data_rust/receive_data/Cargo.toml
+++ b/tests/queue_size_latest_data_rust/receive_data/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "receive_data"
+edition = "2021"
+version.workspace = true
+description.workspace = true
+documentation.workspace = true
+license.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+dora-node-api = { workspace = true, features = ["tracing"] }
+eyre = "0.6.8"
+chrono = "0.4"

--- a/tests/queue_size_latest_data_rust/receive_data/README.md
+++ b/tests/queue_size_latest_data_rust/receive_data/README.md
@@ -1,0 +1,3 @@
+# Print received inputs in the terminal
+
+Check example at [examples/speech-to-text](examples/speech-to-text)

--- a/tests/queue_size_latest_data_rust/receive_data/src/main.rs
+++ b/tests/queue_size_latest_data_rust/receive_data/src/main.rs
@@ -1,6 +1,5 @@
 use std::{thread::sleep, time::Duration};
 
-use chrono::Utc;
 use dora_node_api::{
     self,
     arrow::{
@@ -24,22 +23,12 @@ fn main() -> eyre::Result<()> {
                 data,
             } => {
                 let data: &PrimitiveArray<UInt64Type> = data.as_primitive();
-                let time: u64 = data.values()[0];
+                let _time: u64 = data.values()[0];
                 let time_metadata = metadata.timestamp();
                 let duration_metadata = time_metadata.get_time().to_system_time().elapsed()?;
                 println!("Latency duration: {:?}", duration_metadata);
                 assert!(
                     duration_metadata < Duration::from_millis(500),
-                    "Time difference should be less than 500ms"
-                );
-                let time = time as f64;
-                let now = Utc::now();
-
-                let timestamp = now.timestamp_nanos_opt().unwrap() as f64;
-                let duration = Duration::from_nanos((timestamp - time) as u64);
-                println!("Latency duration: {:?}", duration);
-                assert!(
-                    duration < Duration::from_millis(500),
                     "Time difference should be less than 500ms"
                 );
             }

--- a/tests/queue_size_latest_data_rust/receive_data/src/main.rs
+++ b/tests/queue_size_latest_data_rust/receive_data/src/main.rs
@@ -20,20 +20,27 @@ fn main() -> eyre::Result<()> {
         match event {
             dora_node_api::Event::Input {
                 id: _,
-                metadata: _,
+                metadata,
                 data,
             } => {
                 let data: &PrimitiveArray<UInt64Type> = data.as_primitive();
                 let time: u64 = data.values()[0];
+                let time_metadata = metadata.timestamp();
+                let duration_metadata = time_metadata.get_time().to_system_time().elapsed()?;
+                println!("Latency duration: {:?}", duration_metadata);
+                assert!(
+                    duration_metadata < Duration::from_millis(500),
+                    "Time difference should be less than 500ms"
+                );
                 let time = time as f64;
                 let now = Utc::now();
 
                 let timestamp = now.timestamp_nanos_opt().unwrap() as f64;
-                let duration = (timestamp - time) / 1_000_000_000.;
-                println!("Time Difference: {:?}", duration);
+                let duration = Duration::from_nanos((timestamp - time) as u64);
+                println!("Latency duration: {:?}", duration);
                 assert!(
-                    duration < 1.,
-                    "Time difference should be less than 2 seconds as data is sent every seconds"
+                    duration < Duration::from_millis(500),
+                    "Time difference should be less than 500ms"
                 );
             }
             _ => {}

--- a/tests/queue_size_latest_data_rust/receive_data/src/main.rs
+++ b/tests/queue_size_latest_data_rust/receive_data/src/main.rs
@@ -1,0 +1,43 @@
+use std::{thread::sleep, time::Duration};
+
+use chrono::Utc;
+use dora_node_api::{
+    self,
+    arrow::{
+        array::{AsArray, PrimitiveArray},
+        datatypes::UInt64Type,
+    },
+    DoraNode,
+};
+
+fn main() -> eyre::Result<()> {
+    let (_node, mut events) = DoraNode::init_from_env()?;
+
+    // Voluntarily sleep for 5 seconds to ensure that the node is dropping the oldest input
+    sleep(Duration::from_secs(5));
+
+    while let Some(event) = events.recv() {
+        match event {
+            dora_node_api::Event::Input {
+                id: _,
+                metadata: _,
+                data,
+            } => {
+                let data: &PrimitiveArray<UInt64Type> = data.as_primitive();
+                let time: u64 = data.values()[0];
+                let time = time as f64;
+                let now = Utc::now();
+
+                let timestamp = now.timestamp_nanos_opt().unwrap() as f64;
+                let duration = (timestamp - time) / 1_000_000_000.;
+                println!("Time Difference: {:?}", duration);
+                assert!(
+                    duration < 1.,
+                    "Time difference should be less than 2 seconds as data is sent every seconds"
+                );
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
Moving queue size to node fixes long latency issues for python node and make it possible to set the right queue_size.

I also changed flume queue length within nodes to makes this possible. 

This seems to fix some of the graceful stop issue in Python but further investigation is required.