### PR TITLE
Add yuv420 encoding to opencv-video-capture

### DIFF
--- a/node-hub/opencv-video-capture/opencv_video_capture/main.py
+++ b/node-hub/opencv-video-capture/opencv_video_capture/main.py
@@ -128,6 +128,8 @@ def main():
                 # Get the right encoding
                 if encoding == "rgb8":
                     frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+                elif encoding == "yuv420":
+                    frame = cv2.cvtColor(frame, cv2.COLOR_BGR2YUV_I420)
                 elif encoding in ["jpeg", "jpg", "jpe", "bmp", "webp", "png"]:
                     ret, frame = cv2.imencode("." + encoding, frame)
                     if not ret:


### PR DESCRIPTION
YUV420 encoding has the advantage to be slightly more compressed when comparing to a raw images.

Ex: raw size in RGB (480, 640, 3)  -> size in YUV420 (720, 640) 

This will enable encoding in av1.