### PR TITLE
Reduce event stream timeout

### DIFF
--- a/apis/rust/node/src/event_stream/thread.rs
+++ b/apis/rust/node/src/event_stream/thread.rs
@@ -237,12 +237,13 @@ fn report_remaining_drop_tokens(
                     drop_tokens.push(token);
                 }
                 Err(flume::RecvTimeoutError::Timeout) => {
-                    let duration = Duration::from_secs(30);
+                    let duration = Duration::from_secs(2);
                     if since.elapsed() > duration {
                         tracing::warn!(
                             "timeout: node finished, but token {token:?} was still not \
                             dropped after {duration:?} -> ignoring it"
                         );
+                        drop_tokens.push(token);
                     } else {
                         still_pending.push((token, rx, since, 0));
                     }

--- a/apis/rust/node/src/event_stream/thread.rs
+++ b/apis/rust/node/src/event_stream/thread.rs
@@ -237,13 +237,12 @@ fn report_remaining_drop_tokens(
                     drop_tokens.push(token);
                 }
                 Err(flume::RecvTimeoutError::Timeout) => {
-                    let duration = Duration::from_secs(2);
+                    let duration = Duration::from_secs(1);
                     if since.elapsed() > duration {
                         tracing::warn!(
                             "timeout: node finished, but token {token:?} was still not \
                             dropped after {duration:?} -> ignoring it"
                         );
-                        drop_tokens.push(token);
                     } else {
                         still_pending.push((token, rx, since, 0));
                     }

--- a/apis/rust/node/src/event_stream/thread.rs
+++ b/apis/rust/node/src/event_stream/thread.rs
@@ -60,7 +60,14 @@ impl Drop for EventStreamThreadHandle {
         if self.handle.is_empty() {
             tracing::trace!("waiting for event stream thread");
         }
-        match self.handle.recv_timeout(Duration::from_secs(20)) {
+
+        // TODO: The event stream duration has been shorten due to
+        // Python Reference Counting not working properly and deleting the node
+        // before deleting event creating a race condition.
+        //
+        // In the future, we hope to fix this issue so that
+        // the event stream can be properly waited for every time.
+        match self.handle.recv_timeout(Duration::from_secs(1)) {
             Ok(Ok(())) => {
                 tracing::trace!("event stream thread finished");
             }

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -409,14 +409,14 @@ impl Drop for DoraNode {
                 );
             }
 
-            match self.drop_stream.recv_timeout(Duration::from_secs(10)) {
+            match self.drop_stream.recv_timeout(Duration::from_secs(2)) {
                 Ok(token) => {
                     self.sent_out_shared_memory.remove(&token);
                 }
                 Err(flume::RecvTimeoutError::Disconnected) => {
                     tracing::warn!(
                         "finished_drop_tokens channel closed while still waiting for drop tokens; \
-                        closing {} shared memory regions that might still be used",
+                        closing {} shared memory regions that might not yet been mapped.",
                         self.sent_out_shared_memory.len()
                     );
                     break;
@@ -424,7 +424,7 @@ impl Drop for DoraNode {
                 Err(flume::RecvTimeoutError::Timeout) => {
                     tracing::warn!(
                         "timeout while waiting for drop tokens; \
-                        closing {} shared memory regions that might still be used",
+                        closing {} shared memory regions that might not yet been mapped.",
                         self.sent_out_shared_memory.len()
                     );
                     break;


### PR DESCRIPTION
This is a followup PR to #724, I have found out that the issue is that the reference counting of the dora node does not delay the cleanup and the node is still cleaned up before the pyarrow array creating a deadlock.

This PR reduces the timeout time to start cleanup drop tokens to make sure that the process does not endlessly hangs creating a cascading effect of nodes not ending.

In the future, I hope that we can create a **python based** reference counting between the python node and its generated event so that each event holds a reference to the nodes and get cleaned up before the node gets cleaned up