### PR TITLE
Change macOS CI runner to `macos-13`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -456,9 +456,9 @@ jobs:
             target: aarch64-unknown-linux-musl
           - runner: ubuntu-20.04
             target: armv7-unknown-linux-musleabihf
-          - runner: macos-12
+          - runner: macos-13
             target: aarch64-apple-darwin
-          - runner: macos-12
+          - runner: macos-13
             target: x86_64-apple-darwin
       fail-fast: false
     steps:

--- a/.github/workflows/pip-release.yml
+++ b/.github/workflows/pip-release.yml
@@ -181,9 +181,9 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-12
+          - runner: macos-13
             target: x86_64
-          - runner: macos-12
+          - runner: macos-13
             target: aarch64
         repository:
           - path: apis/python/node

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,9 +114,9 @@ jobs:
             target: aarch64-unknown-linux-musl
           - runner: ubuntu-20.04
             target: armv7-unknown-linux-musleabihf
-          - runner: macos-12
+          - runner: macos-13
             target: aarch64-apple-darwin
-          - runner: macos-12
+          - runner: macos-13
             target: x86_64-apple-darwin
       fail-fast: false
     steps:


### PR DESCRIPTION
The CI currently fails because the macos-12 runners are deprecated. This PR upgrades the runners to `macos-13` to fix the build errors.
