### PR TITLE
Make python default for macos

### DIFF
--- a/binaries/daemon/src/spawn.rs
+++ b/binaries/daemon/src/spawn.rs
@@ -116,6 +116,8 @@ pub async fn spawn_node(
                             let python = get_python_path().context("Could not get python path")?;
                             tracing::info!("spawning: {:?} {}", &python, resolved_path.display());
                             let mut cmd = tokio::process::Command::new(&python);
+                            // Force python to always flush stdout/stderr buffer
+                            cmd.arg("-u");
                             cmd.arg(&resolved_path);
                             cmd
                         }
@@ -221,6 +223,8 @@ pub async fn spawn_node(
                     let python = get_python_path()
                         .context("Could not find python path when spawning runtime node")?;
                     let mut command = tokio::process::Command::new(python);
+                    // Force python to always flush stdout/stderr buffer
+                    command.arg("-u");
                     command.args([
                         "-c",
                         format!("import dora; dora.start_runtime() # {}", node.id).as_str(),

--- a/libraries/core/src/lib.rs
+++ b/libraries/core/src/lib.rs
@@ -31,15 +31,16 @@ pub fn adjust_shared_library_path(path: &Path) -> Result<std::path::PathBuf, eyr
 }
 
 // Search for python binary.
-// Match `python` for windows and `python3` for other platforms.
+// Match `python` for windows and macos and `python3` for other platforms.
 pub fn get_python_path() -> Result<std::path::PathBuf, eyre::ErrReport> {
-    let python = if cfg!(windows) {
+    let python = if cfg!(windows) || cfg!(target_os = "macos")  {
         which::which("python")
             .context("failed to find `python` or `python3`. Make sure that python is available.")?
     } else {
         which::which("python3")
             .context("failed to find `python` or `python3`. Make sure that python is available.")?
     };
+
     Ok(python)
 }
 

--- a/libraries/core/src/lib.rs
+++ b/libraries/core/src/lib.rs
@@ -33,7 +33,7 @@ pub fn adjust_shared_library_path(path: &Path) -> Result<std::path::PathBuf, eyr
 // Search for python binary.
 // Match `python` for windows and macos and `python3` for other platforms.
 pub fn get_python_path() -> Result<std::path::PathBuf, eyre::ErrReport> {
-    let python = if cfg!(windows) || cfg!(target_os = "macos")  {
+    let python = if cfg!(windows) || cfg!(target_os = "macos") {
         which::which("python")
             .context("failed to find `python` or `python3`. Make sure that python is available.")?
     } else {


### PR DESCRIPTION
This makes python default to `python` and not `python3` when searching for the interpreter on macOS.

It also force python to always flush stdout buffer.