### PR TITLE
increase delay duration

### DIFF
--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -176,7 +176,7 @@ impl EventStream {
                 }
             } else {
                 match select(
-                    Delay::new(Duration::from_nanos(10_000)),
+                    Delay::new(Duration::from_micros(300)),
                     self.receiver.next(),
                 )
                 .await


### PR DESCRIPTION
Following CI/CD issues in synchronizing the node queue. I'm going to increase the latency for pulling event from the side event queue.