### PR TITLE
Making cli install the default api avoiding confusion on install

### DIFF
--- a/.github/workflows/pip-release.yml
+++ b/.github/workflows/pip-release.yml
@@ -25,6 +25,7 @@ jobs:
   linux:
     runs-on: ${{ matrix.platform.runner }}
     strategy:
+      fail-fast: false
       matrix:
         platform:
           - runner: ubuntu-22.04
@@ -58,7 +59,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --zig -i 3.8
+          args: --release --out dist
           manylinux: manylinux_2_28
           working-directory: ${{ matrix.repository.path }}
       - name: Upload wheels
@@ -71,6 +72,7 @@ jobs:
   musllinux:
     runs-on: ${{ matrix.platform.runner }}
     strategy:
+      fail-fast: false
       matrix:
         platform:
           - runner: ubuntu-22.04
@@ -93,10 +95,11 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i 3.8
+          args: --release --out dist
           sccache: "true"
           manylinux: musllinux_1_2
           working-directory: ${{ matrix.repository.path }}
+
       - name: Upload wheels
         if: github.event_name == 'release'
         uses: actions/upload-artifact@v4
@@ -107,6 +110,7 @@ jobs:
   musleabi:
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         platform:
           [
@@ -135,7 +139,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           manylinux: auto
           container: off
-          args: --release -o dist -i 3.8
+          args: --release -o dist
           working-directory: ${{ matrix.repository.path }}
       - name: Upload wheels
         if: github.event_name == 'release'
@@ -147,6 +151,7 @@ jobs:
   windows:
     runs-on: ${{ matrix.platform.runner }}
     strategy:
+      fail-fast: false
       matrix:
         platform:
           - runner: windows-latest
@@ -179,6 +184,7 @@ jobs:
   macos:
     runs-on: ${{ matrix.platform.runner }}
     strategy:
+      fail-fast: false
       matrix:
         platform:
           - runner: macos-13
@@ -200,7 +206,6 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist -i 3.8
-          sccache: "true"
           working-directory: ${{ matrix.repository.path }}
       - name: Upload wheels
         if: github.event_name == 'release'
@@ -212,6 +217,7 @@ jobs:
   sdist:
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         repository:
           - path: apis/python/node
@@ -239,6 +245,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'release' && startsWith(github.ref, 'refs/tags/')
     needs: [linux, musllinux, musleabi, windows, macos, sdist]
     strategy:
+      fail-fast: false
       matrix:
         repository:
           - path: apis/python/node

--- a/.github/workflows/pip-release.yml
+++ b/.github/workflows/pip-release.yml
@@ -59,7 +59,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist
+          args: --release --out dist --zig
           manylinux: manylinux_2_28
           working-directory: ${{ matrix.repository.path }}
       - name: Upload wheels

--- a/apis/python/node/pyproject.toml
+++ b/apis/python/node/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "dora-rs"
+dynamic = ["version"]
 # Install pyarrow at the same time of dora-rs
 dependencies = ['pyarrow']
 

--- a/binaries/cli/pyproject.toml
+++ b/binaries/cli/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "maturin"
 name = "dora-rs-cli"
 
 scripts = { "dora" = "dora_cli:py_main" }
+dependencies = ['dora-rs']
 
 
 [tool.maturin]

--- a/binaries/cli/pyproject.toml
+++ b/binaries/cli/pyproject.toml
@@ -4,10 +4,10 @@ build-backend = "maturin"
 
 [project]
 name = "dora-rs-cli"
+dynamic = ["version"]
 
 scripts = { "dora" = "dora_cli:py_main" }
 dependencies = ['dora-rs']
-
 
 [tool.maturin]
 features = ["python", "pyo3/extension-module"]

--- a/binaries/cli/src/lib.rs
+++ b/binaries/cli/src/lib.rs
@@ -735,5 +735,6 @@ fn py_main(_py: Python) -> PyResult<()> {
 #[pymodule]
 fn dora_cli(_py: Python, m: Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_main, &m)?)?;
+    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     Ok(())
 }

--- a/node-hub/dora-kit-car/pyproject.toml
+++ b/node-hub/dora-kit-car/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "dora-kit-car"
-version = "0.3.8"
+dynamic = ["version"]
 authors = [{ name = "Leon", email = "echo_ai@foxmail.com" }]
 description = "Dora Node for dora kit car"
 readme = "README.md"

--- a/node-hub/dora-kit-car/src/lib.rs
+++ b/node-hub/dora-kit-car/src/lib.rs
@@ -90,5 +90,6 @@ fn py_main(_py: Python) -> eyre::Result<()> {
 #[pymodule]
 fn dora_kit_car(_py: Python, m: Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_main, &m)?)?;
+    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     Ok(())
 }

--- a/node-hub/dora-rerun/pyproject.toml
+++ b/node-hub/dora-rerun/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "dora-rerun"
+dynamic = ["version"]
 dependencies = [
     'rerun_sdk==0.19.1',
     # "rerun-loader-urdf @ git+https://github.com/rerun-io/rerun-loader-python-example-urdf.git",

--- a/node-hub/dora-rerun/src/lib.rs
+++ b/node-hub/dora-rerun/src/lib.rs
@@ -307,5 +307,6 @@ fn py_main(_py: Python) -> eyre::Result<()> {
 #[pymodule]
 fn dora_rerun(_py: Python, m: Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_main, &m)?)?;
+    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     Ok(())
 }


### PR DESCRIPTION
Making installing the cli from pip auto install the api from pip. If there's already one installed it will skip it, if there's none it's going to install the latest version.