### PR TITLE
Added depth image and data output for the dora-pyorbbecksdk node

### DIFF
--- a/node-hub/dora-pyorbbecksdk/pyproject.toml
+++ b/node-hub/dora-pyorbbecksdk/pyproject.toml
@@ -1,7 +1,10 @@
 [tool.poetry]
 name = "dora-pyorbbecksdk"
 version = "0.3.8"
-authors = ["Haixuan Xavier Tao <tao.xavier@outlook.com>"]
+authors = [
+    "Haixuan Xavier Tao <tao.xavier@outlook.com>",
+    "Xiang Yang <Ryu-Yang@qq.com>",
+]
 description = "Dora Node for capturing video with PyOrbbeck SDK"
 readme = "README.md"
 


### PR DESCRIPTION
The code has been validated through the dora-rerun node.
```
nodes:
  - id: dora-pyorbbecksdk
    path: dora-pyorbbecksdk
    inputs:
      tick: dora/timer/millis/30
    outputs:
      - image
      - depth_image
      - depth_data

  - id: view
    path: dora-rerun
    inputs:
      image_1:
        source: dora-pyorbbecksdk/image
        queue_size: 1
      depth_image:
        source: dora-pyorbbecksdk/depth_image
        queue_size: 1
```
![屏幕截图 2025-01-03 143912](https://github.com/user-attachments/assets/2564bb53-6da0-47d1-824f-214f893135f1)

In addition to depth images, I also added output depth data to facilitate the processing of depth information.
