### PR TITLE
Downgrade dev dependency for better support for old python version

### DIFF
--- a/binaries/cli/src/template/python/__node-name__/pyproject.toml
+++ b/binaries/cli/src/template/python/__node-name__/pyproject.toml
@@ -12,13 +12,13 @@ packages = [{ include = "__node_name__" }]
 [tool.poetry.dependencies]
 dora-rs = "^0.3.6"
 numpy = "< 2.0.0"
-pyarrow = ">= 5.0.0"
+pyarrow = ">= 15.0.0"
 python = "^3.7"
 
 [tool.poetry.dev-dependencies]
-pytest = ">= 8.3.4"
+pytest = ">= 6.3.4"
 pylint = ">= 3.3.2"
-black = ">= 24.10"
+black = ">= 22.10"
 
 [tool.poetry.scripts]
 __node-name__ = "__node_name__.main:main"

--- a/binaries/cli/src/template/python/mod.rs
+++ b/binaries/cli/src/template/python/mod.rs
@@ -77,9 +77,10 @@ fn create_custom_node(
         .with_context(|| format!("failed to write `{}`", node_path.display()))?;
 
     // tests/tests___node_name__.py
-    let node_path = root
-        .join("tests")
-        .join(format!("test_{}.py", name.replace(" ", "_")));
+    let node_path = root.join("tests").join(format!(
+        "test_{}.py",
+        name.replace(" ", "_").replace("-", "_")
+    ));
     let file = replace_space(_TEST_PY, &name);
     fs::write(&node_path, file)
         .with_context(|| format!("failed to write `{}`", node_path.display()))?;


### PR DESCRIPTION
This makes it possible to use `poetry add ...` when adding dependency avoiding issues of conflicting dependencies