### PR TITLE
Print python stdout without buffer even for script

### DIFF
--- a/binaries/daemon/src/spawn.rs
+++ b/binaries/daemon/src/spawn.rs
@@ -116,8 +116,6 @@ pub async fn spawn_node(
                             let python = get_python_path().context("Could not get python path")?;
                             tracing::info!("spawning: {:?} {}", &python, resolved_path.display());
                             let mut cmd = tokio::process::Command::new(&python);
-                            // Force python to always flush stdout/stderr buffer
-                            cmd.arg("-u");
                             cmd.arg(&resolved_path);
                             cmd
                         }
@@ -160,6 +158,7 @@ pub async fn spawn_node(
             #[cfg(unix)]
             command.process_group(0);
 
+            command.env("PYTHONUNBUFFERED", "1");
             command
                 .stdin(Stdio::null())
                 .stdout(Stdio::piped())


### PR DESCRIPTION
Adding ** PYTHONUNBUFFERED=1** makes python script print out to stdout without buffering.

Previously this was fixed with a python flag but that was not called when python was used as a script.

This resolve the previous issue.