### PR TITLE
Add a uv flag to make it possible to automatically replace `pip` with `uv pip` and prepend run command with `uv run`

### DIFF
--- a/binaries/cli/pyproject.toml
+++ b/binaries/cli/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 scripts = { "dora" = "dora_cli:py_main" }
 license = { text = "MIT" }
 requires-python = ">=3.8"
-dependencies = ['dora-rs']
+dependencies = ['dora-rs', 'uv']
 
 [tool.maturin]
 features = ["python", "pyo3/extension-module"]

--- a/binaries/cli/src/lib.rs
+++ b/binaries/cli/src/lib.rs
@@ -83,6 +83,9 @@ enum Command {
         /// Path to the dataflow descriptor file
         #[clap(value_name = "PATH")]
         dataflow: String,
+        // Use UV to build nodes.
+        #[clap(long, action)]
+        uv: bool,
     },
     /// Generate a new project or node. Choose the language between Rust, Python, C or C++.
     New {
@@ -99,6 +102,9 @@ enum Command {
         /// Path to the dataflow descriptor file
         #[clap(value_name = "PATH")]
         dataflow: String,
+        // Use UV to run nodes.
+        #[clap(long, action)]
+        uv: bool,
     },
     /// Spawn coordinator and daemon in local mode (with default config)
     Up {
@@ -345,20 +351,20 @@ fn run(args: Args) -> eyre::Result<()> {
         } => {
             graph::create(dataflow, mermaid, open)?;
         }
-        Command::Build { dataflow } => {
-            build::build(dataflow)?;
+        Command::Build { dataflow, uv } => {
+            build::build(dataflow, uv)?;
         }
         Command::New {
             args,
             internal_create_with_path_dependencies,
         } => template::create(args, internal_create_with_path_dependencies)?,
-        Command::Run { dataflow } => {
+        Command::Run { dataflow, uv } => {
             let dataflow_path = resolve_dataflow(dataflow).context("could not resolve dataflow")?;
             let rt = Builder::new_multi_thread()
                 .enable_all()
                 .build()
                 .context("tokio runtime failed")?;
-            let result = rt.block_on(Daemon::run_dataflow(&dataflow_path))?;
+            let result = rt.block_on(Daemon::run_dataflow(&dataflow_path, uv))?;
             handle_dataflow_result(result, None)?
         }
         Command::Up { config } => {
@@ -519,7 +525,7 @@ fn run(args: Args) -> eyre::Result<()> {
                             );
                         }
 
-                        let result = Daemon::run_dataflow(&dataflow_path).await?;
+                        let result = Daemon::run_dataflow(&dataflow_path, false).await?;
                         handle_dataflow_result(result, None)
                     }
                     None => {

--- a/binaries/coordinator/src/run/mod.rs
+++ b/binaries/coordinator/src/run/mod.rs
@@ -55,6 +55,7 @@ pub(super) async fn spawn_dataflow(
         nodes: nodes.clone(),
         machine_listen_ports,
         dataflow_descriptor: dataflow,
+        uv: false,
     };
     let message = serde_json::to_vec(&Timestamped {
         inner: DaemonCoordinatorEvent::Spawn(spawn_command),

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -133,7 +133,7 @@ impl Daemon {
         .map(|_| ())
     }
 
-    pub async fn run_dataflow(dataflow_path: &Path) -> eyre::Result<DataflowResult> {
+    pub async fn run_dataflow(dataflow_path: &Path, uv: bool) -> eyre::Result<DataflowResult> {
         let working_dir = dataflow_path
             .canonicalize()
             .context("failed to canonicalize dataflow path")?
@@ -152,6 +152,7 @@ impl Daemon {
             nodes,
             machine_listen_ports: BTreeMap::new(),
             dataflow_descriptor: descriptor,
+            uv,
         };
 
         let clock = Arc::new(HLC::default());
@@ -384,6 +385,7 @@ impl Daemon {
                 nodes,
                 machine_listen_ports,
                 dataflow_descriptor,
+                uv,
             }) => {
                 match dataflow_descriptor.communication.remote {
                     dora_core::config::RemoteCommunicationConfig::Tcp => {}
@@ -409,7 +411,7 @@ impl Daemon {
                 };
 
                 let result = self
-                    .spawn_dataflow(dataflow_id, working_dir, nodes, dataflow_descriptor)
+                    .spawn_dataflow(dataflow_id, working_dir, nodes, dataflow_descriptor, uv)
                     .await;
                 if let Err(err) = &result {
                     tracing::error!("{err:?}");
@@ -625,6 +627,7 @@ impl Daemon {
         working_dir: PathBuf,
         nodes: Vec<ResolvedNode>,
         dataflow_descriptor: Descriptor,
+        uv: bool,
     ) -> eyre::Result<()> {
         let dataflow = RunningDataflow::new(dataflow_id, self.machine_id.clone());
         let dataflow = match self.running.entry(dataflow_id) {
@@ -696,6 +699,7 @@ impl Daemon {
                     dataflow_descriptor.clone(),
                     self.clock.clone(),
                     node_stderr_most_recent,
+                    uv,
                 )
                 .await
                 .wrap_err_with(|| format!("failed to spawn node `{node_id}`"))

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -7,7 +7,9 @@ use std::{
     collections::{BTreeMap, HashMap},
     env::consts::EXE_EXTENSION,
     path::{Path, PathBuf},
+    process::Stdio,
 };
+use tokio::process::Command;
 
 // reexport for compatibility
 pub use dora_message::descriptor::{
@@ -210,6 +212,16 @@ pub fn resolve_path(source: &str, working_dir: &Path) -> Result<PathBuf> {
     // Search path within $PATH
     } else if let Ok(abs_path) = which::which(&path) {
         Ok(abs_path)
+    } else if which::which("uv").is_ok() {
+        // spawn: uv run which <path>
+        let _output = Command::new("uv")
+            .arg("run")
+            .arg("which")
+            .arg(&path)
+            .stdout(Stdio::null())
+            .spawn()
+            .context("Could not find binary within uv")?;
+        Ok(path)
     } else {
         bail!("Could not find source path {}", path.display())
     }

--- a/libraries/message/src/coordinator_to_daemon.rs
+++ b/libraries/message/src/coordinator_to_daemon.rs
@@ -54,4 +54,5 @@ pub struct SpawnDataflowNodes {
     pub nodes: Vec<ResolvedNode>,
     pub machine_listen_ports: BTreeMap<String, SocketAddr>,
     pub dataflow_descriptor: Descriptor,
+    pub uv: bool,
 }


### PR DESCRIPTION
This uv flag makes it possible to run dora within a `uv venv` envirement instead of a venv.

This has the advantage, to:
- not depend on a shell to run command within the virtual env.
- be faster than normal venv
- be easier to maintain a clear separation of environment.

## Example

https://github.com/user-attachments/assets/fbb58afb-76df-4447-85db-87806367846b

## Usage

```bash
uv venv
dora build dataflow.yml --uv
dora run dataflow.yml --uv
```
