### PR TITLE
CI: Use `paths-ignore` instead of negated `paths`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ on:
     branches:
       - main
   pull_request:
-    paths:
-      - "!node-hub/**"
+    paths-ignore:
+      - "node-hub/**"
   workflow_dispatch:
 
 env:

--- a/.github/workflows/pip-release.yml
+++ b/.github/workflows/pip-release.yml
@@ -17,7 +17,7 @@ on:
     branches:
       - main
   pull_request:
-    paths:
+    paths-ignore:
       - "!node-hub/**"
 
 permissions:


### PR DESCRIPTION
The GitHub workflow docs specify: 'If you define a path with the ! character, you must also define at least one path without the ! character. If you only want to exclude paths, use paths-ignore instead.'

See https://github.com/dora-rs/dora/pull/779#issuecomment-2656276945