### PR TITLE
Forbid `/` in node IDs

### DIFF
--- a/libraries/message/src/id.rs
+++ b/libraries/message/src/id.rs
@@ -8,10 +8,24 @@ use serde::{Deserialize, Serialize};
 )]
 pub struct NodeId(pub(crate) String);
 
+#[derive(Debug)]
+pub struct NodeIdContainsSlash;
+
+impl std::fmt::Display for NodeIdContainsSlash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "NodeId must not contain `/`")
+    }
+}
+
+impl std::error::Error for NodeIdContainsSlash {}
+
 impl FromStr for NodeId {
-    type Err = Infallible;
+    type Err = NodeIdContainsSlash;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.contains('/') {
+            return Err(NodeIdContainsSlash);
+        }
         Ok(Self(s.to_owned()))
     }
 }


### PR DESCRIPTION
We use `/` as separator for input mappings in dataflow YAML files (e.g. input: `node/output_id`).

We do support `/` characters in output IDs for runtime nodes. If we allowed `/` characters in node IDs too, splitting a `a/b/c` mapping would no longer be possible (could be node `a` with output `b/c` or node `a/b` with output `c`). Therefore we explicitly error on node IDs containing `/` characters in this commit.
