### PR TITLE
Add uv flag within start cli command

### DIFF
--- a/binaries/cli/src/lib.rs
+++ b/binaries/cli/src/lib.rs
@@ -147,6 +147,9 @@ enum Command {
         /// Enable hot reloading (Python only)
         #[clap(long, action)]
         hot_reload: bool,
+        // Use UV to run nodes.
+        #[clap(long, action)]
+        uv: bool,
     },
     /// Stop the given dataflow UUID. If no id is provided, you will be able to choose between the running dataflows.
     Stop {
@@ -402,6 +405,7 @@ fn run(args: Args) -> eyre::Result<()> {
             attach,
             detach,
             hot_reload,
+            uv,
         } => {
             let dataflow = resolve_dataflow(dataflow).context("could not resolve dataflow")?;
             let dataflow_descriptor =
@@ -421,6 +425,7 @@ fn run(args: Args) -> eyre::Result<()> {
                 name,
                 working_dir,
                 &mut *session,
+                uv,
             )?;
 
             let attach = match (attach, detach) {
@@ -546,6 +551,7 @@ fn start_dataflow(
     name: Option<String>,
     local_working_dir: PathBuf,
     session: &mut TcpRequestReplyConnection,
+    uv: bool,
 ) -> Result<Uuid, eyre::ErrReport> {
     let reply_raw = session
         .request(
@@ -553,6 +559,7 @@ fn start_dataflow(
                 dataflow,
                 name,
                 local_working_dir,
+                uv,
             })
             .unwrap(),
         )

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -317,6 +317,7 @@ async fn start_inner(
                             dataflow,
                             name,
                             local_working_dir,
+                            uv,
                         } => {
                             let name = name.or_else(|| names::Generator::default().next());
 
@@ -336,6 +337,7 @@ async fn start_inner(
                                     name,
                                     &mut daemon_connections,
                                     &clock,
+                                    uv,
                                 )
                                 .await?;
                                 Ok(dataflow)
@@ -901,12 +903,13 @@ async fn start_dataflow(
     name: Option<String>,
     daemon_connections: &mut HashMap<String, DaemonConnection>,
     clock: &HLC,
+    uv: bool,
 ) -> eyre::Result<RunningDataflow> {
     let SpawnedDataflow {
         uuid,
         machines,
         nodes,
-    } = spawn_dataflow(dataflow, working_dir, daemon_connections, clock).await?;
+    } = spawn_dataflow(dataflow, working_dir, daemon_connections, clock, uv).await?;
     Ok(RunningDataflow {
         uuid,
         name,

--- a/binaries/coordinator/src/run/mod.rs
+++ b/binaries/coordinator/src/run/mod.rs
@@ -22,6 +22,7 @@ pub(super) async fn spawn_dataflow(
     working_dir: PathBuf,
     daemon_connections: &mut HashMap<String, DaemonConnection>,
     clock: &HLC,
+    uv: bool,
 ) -> eyre::Result<SpawnedDataflow> {
     let remote_machine_id: Vec<_> = daemon_connections
         .iter()
@@ -55,7 +56,7 @@ pub(super) async fn spawn_dataflow(
         nodes: nodes.clone(),
         machine_listen_ports,
         dataflow_descriptor: dataflow,
-        uv: false,
+        uv,
     };
     let message = serde_json::to_vec(&Timestamped {
         inner: DaemonCoordinatorEvent::Spawn(spawn_command),

--- a/examples/multiple-daemons/run.rs
+++ b/examples/multiple-daemons/run.rs
@@ -135,6 +135,7 @@ async fn start_dataflow(
                 dataflow: dataflow_descriptor,
                 local_working_dir: working_dir,
                 name: None,
+                uv: false,
             },
             reply_sender,
         }))

--- a/libraries/message/src/cli_to_coordinator.rs
+++ b/libraries/message/src/cli_to_coordinator.rs
@@ -15,6 +15,7 @@ pub enum ControlRequest {
         // TODO: remove this once we figure out deploying of node/operator
         // binaries from CLI to coordinator/daemon
         local_working_dir: PathBuf,
+        uv: bool,
     },
     Reload {
         dataflow_id: Uuid,


### PR DESCRIPTION
This allows using up and start with uv:

## How to use:

```bash
cd examples/python-dataflow
dora up
dora start dataflow.yaml --uv
```

Fixes: https://github.com/dora-rs/dora/issues/780

This would help the CI as well