### PR TITLE
Limit pip release ci to strict minimum

### DIFF
--- a/.github/workflows/pip-release.yml
+++ b/.github/workflows/pip-release.yml
@@ -18,7 +18,10 @@ on:
       - main
   pull_request:
     paths-ignore:
-      - "!node-hub/**"
+      - "node-hub/**"
+    paths:
+      - "apis/python/node/**"
+      - "binaries/cli/**"
 
 permissions:
   contents: write


### PR DESCRIPTION
In order to accelerate our workflow, this PR reduces the CI pip release cross platform check to work that correspond to python dependent work.