### PR TITLE
Bump pyo3 to 0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,19 +363,38 @@ version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaf3437355979f1e93ba84ba108c38be5767713051f3c8ffbf07c094e2e61f9f"
 dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
+ "arrow-arith 53.4.0",
+ "arrow-array 53.4.0",
+ "arrow-buffer 53.4.0",
+ "arrow-cast 53.4.0",
+ "arrow-data 53.4.0",
+ "arrow-ipc 53.4.0",
+ "arrow-ord 53.4.0",
+ "arrow-row 53.4.0",
+ "arrow-schema 53.4.0",
+ "arrow-select 53.4.0",
+ "arrow-string 53.4.0",
+]
+
+[[package]]
+name = "arrow"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc208515aa0151028e464cc94a692156e945ce5126abd3537bb7fd6ba2143ed1"
+dependencies = [
+ "arrow-arith 54.2.1",
+ "arrow-array 54.2.1",
+ "arrow-buffer 54.2.1",
+ "arrow-cast 54.2.1",
  "arrow-csv",
- "arrow-data",
- "arrow-ipc",
+ "arrow-data 54.2.1",
+ "arrow-ipc 54.2.1",
  "arrow-json",
- "arrow-ord",
- "arrow-row",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
+ "arrow-ord 54.2.1",
+ "arrow-row 54.2.1",
+ "arrow-schema 54.2.1",
+ "arrow-select 54.2.1",
+ "arrow-string 54.2.1",
  "pyo3",
 ]
 
@@ -385,12 +404,26 @@ version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31dce77d2985522288edae7206bffd5fc4996491841dda01a13a58415867e681"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 53.4.0",
+ "arrow-buffer 53.4.0",
+ "arrow-data 53.4.0",
+ "arrow-schema 53.4.0",
  "chrono",
  "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e07e726e2b3f7816a85c6a45b6ec118eeeabf0b2a8c208122ad949437181f49a"
+dependencies = [
+ "arrow-array 54.2.1",
+ "arrow-buffer 54.2.1",
+ "arrow-data 54.2.1",
+ "arrow-schema 54.2.1",
+ "chrono",
  "num",
 ]
 
@@ -401,9 +434,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d45fe6d3faed0435b7313e59a02583b14c6c6339fa7729e94c32a20af319a79"
 dependencies = [
  "ahash",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-buffer 53.4.0",
+ "arrow-data 53.4.0",
+ "arrow-schema 53.4.0",
+ "chrono",
+ "half",
+ "hashbrown 0.15.2",
+ "num",
+]
+
+[[package]]
+name = "arrow-array"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2262eba4f16c78496adfd559a29fe4b24df6088efc9985a873d58e92be022d5"
+dependencies = [
+ "ahash",
+ "arrow-buffer 54.2.1",
+ "arrow-data 54.2.1",
+ "arrow-schema 54.2.1",
  "chrono",
  "half",
  "hashbrown 0.15.2",
@@ -422,16 +471,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-buffer"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e899dade2c3b7f5642eb8366cfd898958bcca099cde6dfea543c7e8d3ad88d4"
+dependencies = [
+ "bytes",
+ "half",
+ "num",
+]
+
+[[package]]
 name = "arrow-cast"
 version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c73c6233c5b5d635a56f6010e6eb1ab9e30e94707db21cea03da317f67d84cf3"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 53.4.0",
+ "arrow-buffer 53.4.0",
+ "arrow-data 53.4.0",
+ "arrow-schema 53.4.0",
+ "arrow-select 53.4.0",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4103d88c5b441525ed4ac23153be7458494c2b0c9a11115848fdb9b81f6f886a"
+dependencies = [
+ "arrow-array 54.2.1",
+ "arrow-buffer 54.2.1",
+ "arrow-data 54.2.1",
+ "arrow-schema 54.2.1",
+ "arrow-select 54.2.1",
  "atoi",
  "base64 0.22.1",
  "chrono",
@@ -443,20 +523,17 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "53.4.0"
+version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec222848d70fea5a32af9c3602b08f5d740d5e2d33fbd76bf6fd88759b5b13a7"
+checksum = "43d3cb0914486a3cae19a5cad2598e44e225d53157926d0ada03c20521191a65"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 54.2.1",
+ "arrow-cast 54.2.1",
+ "arrow-schema 54.2.1",
  "chrono",
  "csv",
  "csv-core",
  "lazy_static",
- "lexical-core",
  "regex",
 ]
 
@@ -466,8 +543,20 @@ version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f2861ffa86f107b8ab577d86cff7c7a490243eabe961ba1e1af4f27542bb79"
 dependencies = [
- "arrow-buffer",
- "arrow-schema",
+ "arrow-buffer 53.4.0",
+ "arrow-schema 53.4.0",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-data"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a329fb064477c9ec5f0870d2f5130966f91055c7c5bce2b3a084f116bc28c3b"
+dependencies = [
+ "arrow-buffer 54.2.1",
+ "arrow-schema 54.2.1",
  "half",
  "num",
 ]
@@ -488,25 +577,38 @@ version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0270dc511f11bb5fa98a25020ad51a99ca5b08d8a8dfbd17503bb9dba0388f0b"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 53.4.0",
+ "arrow-buffer 53.4.0",
+ "arrow-cast 53.4.0",
+ "arrow-data 53.4.0",
+ "arrow-schema 53.4.0",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddecdeab02491b1ce88885986e25002a3da34dd349f682c7cfe67bab7cc17b86"
+dependencies = [
+ "arrow-array 54.2.1",
+ "arrow-buffer 54.2.1",
+ "arrow-data 54.2.1",
+ "arrow-schema 54.2.1",
  "flatbuffers",
 ]
 
 [[package]]
 name = "arrow-json"
-version = "53.4.0"
+version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eff38eeb8a971ad3a4caf62c5d57f0cff8a48b64a55e3207c4fd696a9234aad"
+checksum = "d03b9340013413eb84868682ace00a1098c81a5ebc96d279f7ebf9a4cac3c0fd"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 54.2.1",
+ "arrow-buffer 54.2.1",
+ "arrow-cast 54.2.1",
+ "arrow-data 54.2.1",
+ "arrow-schema 54.2.1",
  "chrono",
  "half",
  "indexmap 2.6.0",
@@ -522,13 +624,26 @@ version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f202a879d287099139ff0d121e7f55ae5e0efe634b8cf2106ebc27a8715dee"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 53.4.0",
+ "arrow-buffer 53.4.0",
+ "arrow-data 53.4.0",
+ "arrow-schema 53.4.0",
+ "arrow-select 53.4.0",
  "half",
  "num",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f841bfcc1997ef6ac48ee0305c4dfceb1f7c786fe31e67c1186edf775e1f1160"
+dependencies = [
+ "arrow-array 54.2.1",
+ "arrow-buffer 54.2.1",
+ "arrow-data 54.2.1",
+ "arrow-schema 54.2.1",
+ "arrow-select 54.2.1",
 ]
 
 [[package]]
@@ -538,10 +653,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f936954991c360ba762dff23f5dda16300774fafd722353d9683abd97630ae"
 dependencies = [
  "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 53.4.0",
+ "arrow-buffer 53.4.0",
+ "arrow-data 53.4.0",
+ "arrow-schema 53.4.0",
+ "half",
+]
+
+[[package]]
+name = "arrow-row"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eeb55b0a0a83851aa01f2ca5ee5648f607e8506ba6802577afdda9d75cdedcd"
+dependencies = [
+ "arrow-array 54.2.1",
+ "arrow-buffer 54.2.1",
+ "arrow-data 54.2.1",
+ "arrow-schema 54.2.1",
  "half",
 ]
 
@@ -550,6 +678,12 @@ name = "arrow-schema"
 version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9579b9d8bce47aa41389fe344f2c6758279983b7c0ebb4013e283e3e91bb450e"
+
+[[package]]
+name = "arrow-schema"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85934a9d0261e0fa5d4e2a5295107d743b543a6e0484a835d4b8db2da15306f9"
 dependencies = [
  "bitflags 2.8.0",
  "serde",
@@ -562,10 +696,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7471ba126d0b0aaa24b50a36bc6c25e4e74869a1fd1a5553357027a0b1c8d1f1"
 dependencies = [
  "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 53.4.0",
+ "arrow-buffer 53.4.0",
+ "arrow-data 53.4.0",
+ "arrow-schema 53.4.0",
+ "num",
+]
+
+[[package]]
+name = "arrow-select"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e2932aece2d0c869dd2125feb9bd1709ef5c445daa3838ac4112dcfa0fda52c"
+dependencies = [
+ "ahash",
+ "arrow-array 54.2.1",
+ "arrow-buffer 54.2.1",
+ "arrow-data 54.2.1",
+ "arrow-schema 54.2.1",
  "num",
 ]
 
@@ -575,11 +723,28 @@ version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72993b01cb62507b06f1fb49648d7286c8989ecfabdb7b77a750fcb54410731b"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 53.4.0",
+ "arrow-buffer 53.4.0",
+ "arrow-data 53.4.0",
+ "arrow-schema 53.4.0",
+ "arrow-select 53.4.0",
+ "memchr",
+ "num",
+ "regex",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "arrow-string"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "912e38bd6a7a7714c1d9b61df80315685553b7455e8a6045c27531d8ecd5b458"
+dependencies = [
+ "arrow-array 54.2.1",
+ "arrow-buffer 54.2.1",
+ "arrow-data 54.2.1",
+ "arrow-schema 54.2.1",
+ "arrow-select 54.2.1",
  "memchr",
  "num",
  "regex",
@@ -1301,14 +1466,8 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec",
 ]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -1690,9 +1849,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -2468,7 +2627,7 @@ dependencies = [
 name = "dora-arrow-convert"
 version = "0.3.9"
 dependencies = [
- "arrow",
+ "arrow 54.2.1",
  "eyre",
 ]
 
@@ -2631,8 +2790,8 @@ name = "dora-message"
 version = "0.4.3"
 dependencies = [
  "aligned-vec",
- "arrow-data",
- "arrow-schema",
+ "arrow-data 54.2.1",
+ "arrow-schema 54.2.1",
  "bincode",
  "eyre",
  "log",
@@ -2663,7 +2822,7 @@ name = "dora-node-api"
 version = "0.3.9"
 dependencies = [
  "aligned-vec",
- "arrow",
+ "arrow 54.2.1",
  "bincode",
  "dora-arrow-convert",
  "dora-core",
@@ -2686,7 +2845,7 @@ dependencies = [
 name = "dora-node-api-c"
 version = "0.3.9"
 dependencies = [
- "arrow-array",
+ "arrow-array 54.2.1",
  "dora-node-api",
  "eyre",
  "tracing",
@@ -2713,7 +2872,7 @@ dependencies = [
 name = "dora-node-api-python"
 version = "0.3.9"
 dependencies = [
- "arrow",
+ "arrow 54.2.1",
  "dora-node-api",
  "dora-operator-api-python",
  "dora-ros2-bridge-python",
@@ -2722,7 +2881,6 @@ dependencies = [
  "flume 0.10.14",
  "futures",
  "pyo3",
- "pyo3_special_method_derive",
  "pythonize",
  "serde_yaml 0.8.26",
 ]
@@ -2796,8 +2954,8 @@ name = "dora-operator-api-python"
 version = "0.3.9"
 dependencies = [
  "aligned-vec",
- "arrow",
- "arrow-schema",
+ "arrow 54.2.1",
+ "arrow-schema 54.2.1",
  "dora-node-api",
  "eyre",
  "flume 0.10.14",
@@ -2811,7 +2969,7 @@ dependencies = [
 name = "dora-operator-api-types"
 version = "0.3.9"
 dependencies = [
- "arrow",
+ "arrow 54.2.1",
  "dora-arrow-convert",
  "safer-ffi",
 ]
@@ -2824,7 +2982,7 @@ dependencies = [
  "dora-node-api",
  "dora-tracing",
  "eyre",
- "parquet",
+ "parquet 54.2.1",
  "tokio",
 ]
 
@@ -2885,13 +3043,12 @@ dependencies = [
 name = "dora-ros2-bridge-python"
 version = "0.1.0"
 dependencies = [
- "arrow",
+ "arrow 54.2.1",
  "dora-ros2-bridge",
  "dora-ros2-bridge-msg-gen",
  "eyre",
  "futures",
  "pyo3",
- "pyo3_special_method_derive",
  "serde",
  "serde_assert",
 ]
@@ -2901,7 +3058,7 @@ name = "dora-runtime"
 version = "0.3.9"
 dependencies = [
  "aligned-vec",
- "arrow",
+ "arrow 54.2.1",
  "dora-core",
  "dora-download",
  "dora-message",
@@ -4645,9 +4802,9 @@ dependencies = [
 
 [[package]]
 name = "if-addrs"
-version = "0.11.1"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624c5448ba529e74f594c65b7024f31b2de7b64a9b228b8df26796bbb6e32c36"
+checksum = "a78a89907582615b19f6f0da1af18abf6ff08be259395669b834b057a7ee92d8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -6709,13 +6866,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8957c0c95a6a1804f3e51a18f69df29be53856a8c5768cc9b6d00fcafcd2917c"
 dependencies = [
  "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-ipc",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 53.4.0",
+ "arrow-buffer 53.4.0",
+ "arrow-cast 53.4.0",
+ "arrow-data 53.4.0",
+ "arrow-ipc 53.4.0",
+ "arrow-schema 53.4.0",
+ "arrow-select 53.4.0",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "half",
+ "hashbrown 0.15.2",
+ "num",
+ "num-bigint",
+ "paste",
+ "seq-macro",
+ "snap",
+ "thrift 0.17.0",
+ "twox-hash",
+]
+
+[[package]]
+name = "parquet"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f88838dca3b84d41444a0341b19f347e8098a3898b0f21536654b8b799e11abd"
+dependencies = [
+ "ahash",
+ "arrow-array 54.2.1",
+ "arrow-buffer 54.2.1",
+ "arrow-cast 54.2.1",
+ "arrow-data 54.2.1",
+ "arrow-ipc 54.2.1",
+ "arrow-schema 54.2.1",
+ "arrow-select 54.2.1",
  "base64 0.22.1",
  "brotli",
  "bytes",
@@ -6729,6 +6914,7 @@ dependencies = [
  "num-bigint",
  "paste",
  "seq-macro",
+ "simdutf8",
  "snap",
  "thrift 0.17.0",
  "tokio",
@@ -7437,9 +7623,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.22.5"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d922163ba1f79c04bc49073ba7b32fd5a8d3b76a87c955921234b8e77333c51"
+checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
 dependencies = [
  "cfg-if 1.0.0",
  "eyre",
@@ -7458,9 +7644,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.5"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc38c5feeb496c8321091edf3d63e9a6829eab4b863b4a6a65f26f3e9cc6b179"
+checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -7468,9 +7654,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.5"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94845622d88ae274d2729fcefc850e63d7a3ddff5e3ce11bd88486db9f1d357d"
+checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -7478,9 +7664,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.5"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e655aad15e09b94ffdb3ce3d217acf652e26bbc37697ef012f5e5e348c716e5e"
+checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -7490,9 +7676,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.5"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1e3f09eecd94618f60a455a23def79f79eba4dc561a97324bf9ac8c6df30ce"
+checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -7502,33 +7688,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pyo3_special_method_derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2500665e90af52c404fc2960838872881084a007590bc8a73a0fabd31c3b23cc"
-dependencies = [
- "pyo3",
- "pyo3_special_method_derive_macro",
-]
-
-[[package]]
-name = "pyo3_special_method_derive_macro"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c529af0492b9f0690b50ceecf3d4fc9468985bef00b5362f160c04164cb3b96e"
-dependencies = [
- "proc-macro2",
- "pyo3",
- "quote",
- "quote_into",
- "syn 2.0.94",
-]
-
-[[package]]
 name = "pythonize"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90fcf491425978bd889015d5430f6473d91bdfa2097262f1e731aadcf6c2113e"
+checksum = "91a6ee7a084f913f98d70cdc3ebec07e852b735ae3059a1500db2661265da9ff"
 dependencies = [
  "pyo3",
  "serde",
@@ -7676,28 +7839,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quote_into"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93886ed56f228a5d960fc4d26afa3736df12a251872869cf24f5efe5f07699b9"
-dependencies = [
- "proc-macro2",
- "quote",
- "quote_into_macro",
-]
-
-[[package]]
-name = "quote_into_macro"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b828998c40452b5afe441c75194e93181432e669585f4ceb7b0d32a3f73525"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7828,11 +7969,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6973c87de24c9de7292447fa896f229278b010cb3fb5e7f4f857447e64e1bb6f"
 dependencies = [
  "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
+ "arrow-array 53.4.0",
+ "arrow-buffer 53.4.0",
+ "arrow-data 53.4.0",
  "arrow-format",
- "arrow-schema",
+ "arrow-schema 53.4.0",
  "bytemuck",
  "chrono",
  "dyn-clone",
@@ -7854,7 +7995,7 @@ version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53e5a9c65130a285afabd6d260ab28772e777c80b13f1ad9690e7f88a470656f"
 dependencies = [
- "arrow",
+ "arrow 53.4.0",
  "itertools 0.13.0",
  "re_log",
  "re_tracing",
@@ -7913,7 +8054,7 @@ version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87a3cca3e568c4347be3de3079a52511b885d585459492a68631c22b99554c50"
 dependencies = [
- "arrow",
+ "arrow 53.4.0",
  "half",
  "smallvec",
 ]
@@ -7946,7 +8087,7 @@ checksum = "45a65597e34899c3467e36debb0f63ab31b72bc97cf82885f539369db4862cc5"
 dependencies = [
  "ahash",
  "anyhow",
- "arrow",
+ "arrow 53.4.0",
  "bytemuck",
  "crossbeam",
  "document-features",
@@ -7977,7 +8118,7 @@ checksum = "771083f86c1899d8251cd8cc8cfa85a8da72f21704499017821fb0794d63df86"
 dependencies = [
  "ahash",
  "anyhow",
- "arrow",
+ "arrow 53.4.0",
  "document-features",
  "indent",
  "itertools 0.13.0",
@@ -8005,7 +8146,7 @@ version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cadc0032e8000b2f371b82a3bde27c27a6abbe1fea117b07e44ef9daf14a9151"
 dependencies = [
- "arrow",
+ "arrow 53.4.0",
  "egui",
  "egui_extras",
  "itertools 0.13.0",
@@ -8024,7 +8165,7 @@ version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4fd51b398bfaf417f024f1e426f5f628c8028b1e7811d080cd912a33b7846a"
 dependencies = [
- "arrow",
+ "arrow 53.4.0",
  "egui",
  "egui_extras",
  "egui_plot",
@@ -8086,14 +8227,14 @@ checksum = "027a0ac4d8dd0cdf10a819d6832c8dae2b353f99678ae5fb9b7493f2201b823e"
 dependencies = [
  "ahash",
  "anyhow",
- "arrow",
+ "arrow 53.4.0",
  "crossbeam",
  "image",
  "itertools 0.13.0",
  "notify 6.1.1",
  "once_cell",
  "parking_lot",
- "parquet",
+ "parquet 53.4.0",
  "rayon",
  "re_arrow_util",
  "re_build_info",
@@ -8172,7 +8313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "640bb9350ab451b9acd068947421d642c64d3a60fadf80c57a6296dafe47ff42"
 dependencies = [
  "anyhow",
- "arrow",
+ "arrow 53.4.0",
  "insta",
  "itertools 0.13.0",
  "nohash-hasher",
@@ -8240,7 +8381,7 @@ version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3401e90f499202df7ca8a80bedc30435c5d2b82bcd6e79b7234b27e7816c016"
 dependencies = [
- "arrow",
+ "arrow 53.4.0",
  "comfy-table",
  "itertools 0.13.0",
  "re_arrow_util",
@@ -8279,7 +8420,7 @@ version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e381b54191aaab469501a39908da84f118150d1dfd4027e34bb43b6fbd7af97"
 dependencies = [
- "arrow",
+ "arrow 53.4.0",
  "bytes",
  "ehttp",
  "js-sys",
@@ -8311,7 +8452,7 @@ checksum = "593ce0f20b522b49f7af9111f6117d07b0fc99437e416f86d69f8b39f464e512"
 dependencies = [
  "ahash",
  "anyhow",
- "arrow",
+ "arrow 53.4.0",
  "backtrace",
  "bytemuck",
  "clean-path",
@@ -8396,7 +8537,7 @@ version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d3731719bf29d23b0922813f3cfeaf00eda303dfaa47821065a225b1a07b884"
 dependencies = [
- "arrow",
+ "arrow 53.4.0",
  "prost 0.13.4",
  "re_build_info",
  "re_byte_size",
@@ -8416,7 +8557,7 @@ checksum = "24fd2cfa139497fc8a3ca08fdaf5f7e2a639bc9e271b87cb4fe518d130bf9735"
 dependencies = [
  "ahash",
  "anyhow",
- "arrow",
+ "arrow 53.4.0",
  "backtrace",
  "indent",
  "itertools 0.13.0",
@@ -8567,7 +8708,7 @@ version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc3abc4843c32a5ec6dec66ca83c2f27931c1cdb16873d896067dc23661cb424"
 dependencies = [
- "arrow",
+ "arrow 53.4.0",
  "egui",
  "egui_tiles",
  "itertools 0.13.0",
@@ -8610,7 +8751,7 @@ version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b7f361fb581b99145dd9d7a19d1f5859fa66fd54923ace3074a0b63f7a684ab"
 dependencies = [
- "arrow",
+ "arrow 53.4.0",
  "re_log",
  "re_log_types",
  "re_types_core",
@@ -8695,7 +8836,7 @@ checksum = "cb54e2ab3b830a2bf5b046bf8cfe988232877ee24f8ae5bd4a9b6ddb15044c2d"
 dependencies = [
  "anyhow",
  "array-init",
- "arrow",
+ "arrow 53.4.0",
  "bytemuck",
  "document-features",
  "ecolor",
@@ -8736,7 +8877,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e70a48296d818032a5d48145f7ce2df527f5f483544046d3bcb48a7ab3873fc"
 dependencies = [
  "anyhow",
- "arrow",
+ "arrow 53.4.0",
  "camino",
  "clang-format",
  "colored",
@@ -8769,7 +8910,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08b4d6ea5eb0c3d7fc7a7dcdb28271193cac539cc297f70ea68791537a3ed34f"
 dependencies = [
  "anyhow",
- "arrow",
+ "arrow 53.4.0",
  "backtrace",
  "bytemuck",
  "document-features",
@@ -8796,7 +8937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d857207b83314273b0425b3151913cf085389b99d33f40a50984152ade3cccbc"
 dependencies = [
  "ahash",
- "arrow",
+ "arrow 53.4.0",
  "eframe",
  "egui",
  "egui_commonmark",
@@ -8828,7 +8969,7 @@ version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e128090fb57ae644aaa29a511d46ea44f24e7f87cd125087da38a1d074bc93c5"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec",
  "cfg_aliases",
  "crossbeam",
  "econtext",
@@ -8857,7 +8998,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d13558c036126190dc41835a213daa62c9816dd5b1ead69f74c3f8818e22e2a1"
 dependencies = [
  "ahash",
- "arrow",
+ "arrow 53.4.0",
  "egui",
  "glam",
  "itertools 0.13.0",
@@ -8903,7 +9044,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419943c8955a9cdca6c5139368ccdbf3cdbc988250acf0ca980535af69e4fdd"
 dependencies = [
  "anyhow",
- "arrow",
+ "arrow 53.4.0",
  "egui",
  "egui_table",
  "itertools 0.13.0",
@@ -8985,7 +9126,7 @@ checksum = "c892006527f9ec96cd1ed284b1930c60d328ade331e04007d3cad28ea8e2a7b8"
 dependencies = [
  "ahash",
  "anyhow",
- "arrow",
+ "arrow 53.4.0",
  "bitflags 2.8.0",
  "bytemuck",
  "egui",
@@ -9196,8 +9337,8 @@ checksum = "85fabe3a1b70d8264abb9d0e8409f1b943dd6400c5a4aee027b29c9435126a4b"
 dependencies = [
  "ahash",
  "anyhow",
- "arrow",
- "bit-vec 0.8.0",
+ "arrow 53.4.0",
+ "bit-vec",
  "bitflags 2.8.0",
  "bytemuck",
  "crossbeam",
@@ -9278,7 +9419,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34584952b9ffd0655f73394429c024cb7403187a27bea53f9e087b22a930d5bd"
 dependencies = [
  "ahash",
- "arrow",
+ "arrow 53.4.0",
  "egui",
  "egui_tiles",
  "itertools 0.13.0",
@@ -9560,7 +9701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee0a19185405072621c2e82866bb0a38ea3e703d79950f0789259d59e69831a0"
 dependencies = [
  "anyhow",
- "arrow",
+ "arrow 53.4.0",
  "document-features",
  "env_logger 0.10.2",
  "itertools 0.13.0",
@@ -9715,9 +9856,9 @@ dependencies = [
 
 [[package]]
 name = "ros2-client"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5cb46881eb723c83bdff51053b8362762289e1ad5f08dd46cebdb2cb4952e99"
+checksum = "f76464eca6fc4aab37ca03de853654b2c558dde54a4b3c3850cd8771f091d373"
 dependencies = [
  "async-channel 2.3.1",
  "bstr 1.9.1",
@@ -9887,11 +10028,11 @@ dependencies = [
 
 [[package]]
 name = "rustdds"
-version = "0.10.3"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d7e52bbc8b96db37e61a54e3f7fe3397ab109de64c772822a308cd7ac456858"
+checksum = "ced67e71763ec86d1390737f71e2fa728ed0b01ccf1ac13ed15b2bf56ecb75b4"
 dependencies = [
- "bit-vec 0.6.3",
+ "bit-vec",
  "byteorder",
  "bytes",
  "cdr-encoding",
@@ -9917,7 +10058,7 @@ dependencies = [
  "socketpair",
  "speedy",
  "static_assertions",
- "thiserror 1.0.66",
+ "thiserror 2.0.9",
 ]
 
 [[package]]
@@ -10668,9 +10809,9 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "simdutf8"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -12616,7 +12757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a39b8842dc9ffcbe34346e3ab6d496b32a47f6497e119d762c97fcaae3cb37"
 dependencies = [
  "arrayvec",
- "bit-vec 0.8.0",
+ "bit-vec",
  "bitflags 2.8.0",
  "cfg_aliases",
  "document-features",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,17 +75,17 @@ dora-ros2-bridge-msg-gen = { path = "libraries/extensions/ros2-bridge/msg-gen" }
 dora-ros2-bridge-python = { path = "libraries/extensions/ros2-bridge/python" }
 # versioned independently from the other dora crates
 dora-message = { version = "0.4.3", path = "libraries/message" }
-arrow = { version = "53" }
-arrow-schema = { version = "53" }
-arrow-data = { version = "53" }
-arrow-array = { version = "53" }
-pyo3 = { version = "0.22.2", features = [
+arrow = { version = "54.2.1" }
+arrow-schema = { version = "54.2.1" }
+arrow-data = { version = "54.2.1" }
+arrow-array = { version = "54.2.1" }
+parquet = { version = "54.2.1" }
+pyo3 = { version = "0.23", features = [
     "eyre",
     "abi3-py37",
     "multiple-pymethods",
 ] }
-pythonize = "0.22"
-chrono = ">=0.4.34,<0.4.40"
+pythonize = "0.23"
 
 [package]
 name = "dora-examples"

--- a/apis/python/node/Cargo.toml
+++ b/apis/python/node/Cargo.toml
@@ -26,7 +26,7 @@ arrow = { workspace = true, features = ["pyarrow"] }
 pythonize = { workspace = true }
 futures = "0.3.28"
 dora-ros2-bridge-python = { workspace = true }
-pyo3_special_method_derive = "0.4.2"
+# pyo3_special_method_derive = "0.4.2"
 
 [lib]
 name = "dora"

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -265,7 +265,7 @@ impl Events {
 
 enum EventsInner {
     Dora(DelayedCleanup<EventStream>),
-    Merged(Box<dyn Stream<Item = MergedEvent<PyObject>> + Unpin + Send>),
+    Merged(Box<dyn Stream<Item = MergedEvent<PyObject>> + Unpin + Send + Sync>),
 }
 
 impl<'a> MergeExternalSend<'a, PyObject> for EventsInner {
@@ -273,8 +273,8 @@ impl<'a> MergeExternalSend<'a, PyObject> for EventsInner {
 
     fn merge_external_send(
         self,
-        external_events: impl Stream<Item = PyObject> + Unpin + Send + 'a,
-    ) -> Box<dyn Stream<Item = Self::Item> + Unpin + Send + 'a> {
+        external_events: impl Stream<Item = PyObject> + Unpin + Send + Sync + 'a,
+    ) -> Box<dyn Stream<Item = Self::Item> + Unpin + Send + Sync + 'a> {
         match self {
             EventsInner::Dora(events) => events.merge_external_send(external_events),
             EventsInner::Merged(events) => {

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -13,7 +13,7 @@ use eyre::Context;
 use futures::{Stream, StreamExt};
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict};
-use pyo3_special_method_derive::{Dict, Dir, Repr, Str};
+/// use pyo3_special_method_derive::{Dict, Dir, Repr, Str};
 
 /// The custom node API lets you integrate `dora` into your application.
 /// It allows you to retrieve input and send output in any fashion you want.
@@ -28,7 +28,7 @@ use pyo3_special_method_derive::{Dict, Dir, Repr, Str};
 ///
 /// :type node_id: str, optional
 #[pyclass]
-#[derive(Dir, Dict, Str, Repr)]
+/// #[derive(Dir, Dict, Str, Repr)]
 pub struct Node {
     events: Events,
     node: DelayedCleanup<DoraNode>,

--- a/apis/python/operator/src/lib.rs
+++ b/apis/python/operator/src/lib.rs
@@ -66,8 +66,8 @@ where
 
     fn merge_external_send(
         self,
-        external_events: impl Stream<Item = E> + Unpin + Send + 'a,
-    ) -> Box<dyn Stream<Item = Self::Item> + Unpin + Send + 'a> {
+        external_events: impl Stream<Item = E> + Unpin + Send + Sync + 'a,
+    ) -> Box<dyn Stream<Item = Self::Item> + Unpin + Send + Sync + 'a> {
         let dora = self.map(MergedEvent::Dora);
         let external = external_events.map(MergedEvent::External);
         Box::new((dora, external).merge())

--- a/apis/rust/node/src/event_stream/merged.rs
+++ b/apis/rust/node/src/event_stream/merged.rs
@@ -36,8 +36,8 @@ pub trait MergeExternalSend<'a, E> {
 
     fn merge_external_send(
         self,
-        external_events: impl Stream<Item = E> + Unpin + Send + 'a,
-    ) -> Box<dyn Stream<Item = Self::Item> + Unpin + Send + 'a>;
+        external_events: impl Stream<Item = E> + Unpin + Send + Sync + 'a,
+    ) -> Box<dyn Stream<Item = Self::Item> + Unpin + Send + Sync + 'a>;
 }
 
 impl<'a, E> MergeExternal<'a, E> for super::EventStream
@@ -64,8 +64,8 @@ where
 
     fn merge_external_send(
         self,
-        external_events: impl Stream<Item = E> + Unpin + Send + 'a,
-    ) -> Box<dyn Stream<Item = Self::Item> + Unpin + Send + 'a> {
+        external_events: impl Stream<Item = E> + Unpin + Send + Sync + 'a,
+    ) -> Box<dyn Stream<Item = Self::Item> + Unpin + Send + Sync + 'a> {
         let dora = self.map(MergedEvent::Dora);
         let external = external_events.map(MergedEvent::External);
         Box::new((dora, external).merge())
@@ -95,7 +95,7 @@ where
 
 impl<'a, E, F, S> MergeExternalSend<'a, F> for S
 where
-    S: Stream<Item = MergedEvent<E>> + Unpin + Send + 'a,
+    S: Stream<Item = MergedEvent<E>> + Unpin + Send + Sync + 'a,
     E: 'a,
     F: 'a,
 {
@@ -103,8 +103,8 @@ where
 
     fn merge_external_send(
         self,
-        external_events: impl Stream<Item = F> + Unpin + Send + 'a,
-    ) -> Box<dyn Stream<Item = Self::Item> + Unpin + Send + 'a> {
+        external_events: impl Stream<Item = F> + Unpin + Send + Sync + 'a,
+    ) -> Box<dyn Stream<Item = Self::Item> + Unpin + Send + Sync + 'a> {
         let first = self.map(|e| match e {
             MergedEvent::Dora(d) => MergedEvent::Dora(d),
             MergedEvent::External(e) => MergedEvent::External(Either::First(e)),

--- a/binaries/cli/src/template/rust/listener/Cargo-template.toml
+++ b/binaries/cli/src/template/rust/listener/Cargo-template.toml
@@ -7,4 +7,3 @@ edition = "2021"
 
 [dependencies]
 dora-node-api = {}
-chrono = ">=0.4.34,<0.4.40"

--- a/binaries/cli/src/template/rust/node/Cargo-template.toml
+++ b/binaries/cli/src/template/rust/node/Cargo-template.toml
@@ -7,4 +7,3 @@ edition = "2021"
 
 [dependencies]
 dora-node-api = {}
-chrono = ">=0.4.34,<0.4.40"

--- a/binaries/cli/src/template/rust/operator/Cargo-template.toml
+++ b/binaries/cli/src/template/rust/operator/Cargo-template.toml
@@ -10,4 +10,3 @@ crate-type = ["cdylib"]
 
 [dependencies]
 dora-operator-api = {}
-chrono = ">=0.4.34,<0.4.40"

--- a/libraries/extensions/ros2-bridge/Cargo.toml
+++ b/libraries/extensions/ros2-bridge/Cargo.toml
@@ -17,8 +17,8 @@ array-init = "2.1.0"
 serde = { version = "1.0.164", features = ["derive"] }
 serde-big-array = "0.5.1"
 widestring = "1.0.2"
-ros2-client = "0.7.1"
-rustdds = "0.10.0"
+ros2-client = "0.8.0"
+rustdds = "0.11.0"
 eyre = { version = "0.6.8", optional = true }
 tokio = { version = "1.29.1", features = ["full"], optional = true }
 dora-daemon = { path = "../../../binaries/daemon", optional = true }

--- a/libraries/extensions/ros2-bridge/python/Cargo.toml
+++ b/libraries/extensions/ros2-bridge/python/Cargo.toml
@@ -12,7 +12,7 @@ eyre = "0.6"
 serde = "1.0.166"
 arrow = { workspace = true, features = ["pyarrow"] }
 futures = "0.3.28"
-pyo3_special_method_derive = "0.4.2"
+# pyo3_special_method_derive = "0.4.2"
 
 [dev-dependencies]
 serde_assert = "0.7.1"

--- a/libraries/extensions/ros2-bridge/python/src/lib.rs
+++ b/libraries/extensions/ros2-bridge/python/src/lib.rs
@@ -18,7 +18,7 @@ use pyo3::{
     types::{PyAnyMethods, PyDict, PyList, PyModule, PyModuleMethods},
     Bound, PyAny, PyObject, PyResult, Python,
 };
-use pyo3_special_method_derive::{Dict, Dir, Repr, Str};
+//// use pyo3_special_method_derive::{Dict, Dir, Repr, Str};
 use typed::{deserialize::StructDeserializer, TypeInfo, TypedValue};
 
 pub mod qos;
@@ -46,7 +46,7 @@ pub mod typed;
 /// :type ros_paths: typing.List[str], optional
 ///
 #[pyclass]
-#[derive(Str, Repr, Dir, Dict)]
+/// #[derive(Str, Repr, Dir, Dict)]
 pub struct Ros2Context {
     context: ros2_client::Context,
     messages: Arc<HashMap<String, HashMap<String, Message>>>,
@@ -150,7 +150,7 @@ impl Ros2Context {
 ///   See: https://github.com/jhelovuo/ros2-client/issues/4
 ///
 #[pyclass]
-#[derive(Str, Repr, Dir, Dict)]
+/// #[derive(Str, Repr, Dir, Dict)]
 pub struct Ros2Node {
     node: ros2_client::Node,
     messages: Arc<HashMap<String, HashMap<String, Message>>>,
@@ -257,7 +257,8 @@ impl Ros2Node {
 /// ROS2 Node Options
 /// :type rosout: bool, optional
 ///
-#[derive(Clone, Default, Str, Repr, Dir, Dict)]
+#[derive(Clone, Default)]
+/// , Str, Repr, Dir, Dict)]
 #[pyclass]
 #[non_exhaustive]
 pub struct Ros2NodeOptions {
@@ -288,7 +289,7 @@ impl From<Ros2NodeOptions> for ros2_client::NodeOptions {
 /// - dora Ros2 bridge functionality is considered **unstable**. It may be changed
 ///   at any point without it being considered a breaking change.
 #[pyclass]
-#[derive(Str, Repr, Dir, Dict)]
+/// #[derive(Str, Repr, Dir, Dict)]
 #[non_exhaustive]
 pub struct Ros2Topic {
     topic: rustdds::Topic,
@@ -301,7 +302,7 @@ pub struct Ros2Topic {
 /// - dora Ros2 bridge functionality is considered **unstable**. It may be changed
 ///   at any point without it being considered a breaking change.
 #[pyclass]
-#[derive(Str, Repr, Dir, Dict)]
+/// #[derive(Str, Repr, Dir, Dict)]
 #[non_exhaustive]
 pub struct Ros2Publisher {
     publisher: ros2_client::Publisher<TypedValue<'static>>,
@@ -372,7 +373,7 @@ impl Ros2Publisher {
 /// - dora Ros2 bridge functionality is considered **unstable**. It may be changed
 ///   at any point without it being considered a breaking change.
 #[pyclass]
-#[derive(Str, Repr, Dir, Dict)]
+/// #[derive(Str, Repr, Dir, Dict)]
 #[non_exhaustive]
 pub struct Ros2Subscription {
     deserializer: StructDeserializer<'static>,

--- a/libraries/extensions/ros2-bridge/python/src/qos.rs
+++ b/libraries/extensions/ros2-bridge/python/src/qos.rs
@@ -1,6 +1,6 @@
 use ::dora_ros2_bridge::rustdds::{self, policy};
 use pyo3::prelude::{pyclass, pymethods};
-use pyo3_special_method_derive::{Dict, Dir, Repr, Str};
+/// use pyo3_special_method_derive::{Dict, Dir, Repr, Str};
 
 /// ROS2 QoS Policy
 ///
@@ -13,7 +13,8 @@ use pyo3_special_method_derive::{Dict, Dir, Repr, Str};
 /// :type keep_last: int, optional
 /// :rtype: dora.Ros2QoSPolicies
 ///
-#[derive(Clone, Str, Repr, Dir, Dict)]
+#[derive(Clone)]
+/// , Str, Repr, Dir, Dict)]
 #[pyclass]
 #[non_exhaustive]
 pub struct Ros2QosPolicies {
@@ -79,7 +80,8 @@ impl From<Ros2QosPolicies> for rustdds::QosPolicies {
 /// DDS 2.2.3.4 DURABILITY
 ///
 /// :rtype: dora.Ros2Durability
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Str, Repr, Dir, Dict)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+/// , Str, Repr, Dir, Dict)]
 #[pyclass(eq, eq_int)]
 pub enum Ros2Durability {
     Volatile,
@@ -105,7 +107,8 @@ impl From<Ros2Durability> for policy::Durability {
 
 /// DDS 2.2.3.11 LIVELINESS
 /// :rtype: dora.Ros2Liveliness
-#[derive(Copy, Clone, PartialEq, Str, Repr, Dir, Dict)]
+#[derive(Copy, Clone, PartialEq)]
+/// , Str, Repr, Dir, Dict)]
 #[pyclass(eq, eq_int)]
 pub enum Ros2Liveliness {
     Automatic,

--- a/libraries/shared-memory-server/src/channel.rs
+++ b/libraries/shared-memory-server/src/channel.rs
@@ -217,6 +217,7 @@ fn offset_ptrs(next_free: *mut u8) -> (*mut AtomicBool, *mut AtomicU64, *mut u8)
 }
 
 unsafe impl Send for ShmemChannel {}
+unsafe impl Sync for ShmemChannel {}
 
 impl Drop for ShmemChannel {
     fn drop(&mut self) {

--- a/node-hub/dora-kokoro-tts/dora_kokoro_tts/main.py
+++ b/node-hub/dora-kokoro-tts/dora_kokoro_tts/main.py
@@ -1,5 +1,4 @@
 import pyarrow as pa
-import soundfile as sf
 from dora import Node
 from kokoro import KPipeline
 

--- a/node-hub/dora-qwen/pyproject.toml
+++ b/node-hub/dora-qwen/pyproject.toml
@@ -31,7 +31,7 @@ dev = ["pytest >=8.1.1", "ruff >=0.9.1"]
 
 [[tool.uv.index]]
 name = "llama_cpp_python_cu121"
-url = "https://abetlen.github.io/llama-cpp-python/whl/metal"
+url = "https://abetlen.github.io/llama-cpp-python/whl/cu121"
 explicit = true
 
 [[tool.uv.index]]

--- a/node-hub/dora-record/Cargo.toml
+++ b/node-hub/dora-record/Cargo.toml
@@ -15,4 +15,4 @@ dora-node-api = { workspace = true, features = ["tracing"] }
 eyre = "0.6.8"
 chrono = "0.4.31"
 dora-tracing = { workspace = true }
-parquet = { version = "53", features = ["async"] }
+parquet = { workspace = true, features = ["async"] }


### PR DESCRIPTION
This PR makes it possible to bump couple of dependency up:
- Arrow 0.54
- Pyo3 0.23
- ros2-client 0.8

The biggest blocker being pyo3 with a more restricting python class requiring to be sync.