### PR TITLE
Update CI runners to `ubuntu-22.04`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,15 +466,15 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: ubuntu-20.04
+          - runner: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-          - runner: ubuntu-20.04
+          - runner: ubuntu-22.04
             target: i686-unknown-linux-gnu
-          - runner: ubuntu-20.04
+          - runner: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
-          - runner: ubuntu-20.04
+          - runner: ubuntu-22.04
             target: aarch64-unknown-linux-musl
-          - runner: ubuntu-20.04
+          - runner: ubuntu-22.04
             target: armv7-unknown-linux-musleabihf
           - runner: macos-13
             target: aarch64-apple-darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        platform: [ubuntu-20.04]
+        platform: [ubuntu-22.04]
       fail-fast: false
     runs-on: ${{ matrix.platform }}
 
@@ -104,15 +104,15 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: ubuntu-20.04
+          - runner: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-          - runner: ubuntu-20.04
+          - runner: ubuntu-22.04
             target: i686-unknown-linux-gnu
-          - runner: ubuntu-20.04
+          - runner: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
-          - runner: ubuntu-20.04
+          - runner: ubuntu-22.04
             target: aarch64-unknown-linux-musl
-          - runner: ubuntu-20.04
+          - runner: ubuntu-22.04
             target: armv7-unknown-linux-musleabihf
           - runner: macos-13
             target: aarch64-apple-darwin


### PR DESCRIPTION
The ubuntu 20.04 runners will be removed in April 2025. There are already scheduled `brownouts` that lead to build failures, so we should fix it right now.
