### PR TITLE
Prepare for new rustup version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
         shell: bash
         if: runner.os == 'Windows'
 
+      - run: rustup self update
+
       - uses: actions/checkout@v3
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
@@ -80,6 +82,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 60
     steps:
+      - run: rustup self update
       - uses: actions/checkout@v3
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
@@ -141,6 +144,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 45
     steps:
+      - run: rustup self update
       - uses: actions/checkout@v3
       - uses: r7kamura/rust-problem-matchers@v1.1.0
 
@@ -219,6 +223,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 60
     steps:
+      - run: rustup self update
       - uses: actions/checkout@v3
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
@@ -242,6 +247,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 60
     steps:
+      - run: rustup self update
       - uses: actions/checkout@v3
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
@@ -406,6 +412,7 @@ jobs:
     name: "Clippy"
     runs-on: ubuntu-latest
     steps:
+      - run: rustup self update
       - uses: actions/checkout@v3
 
       - uses: r7kamura/rust-problem-matchers@v1.1.0
@@ -424,6 +431,7 @@ jobs:
     name: "Formatting"
     runs-on: ubuntu-latest
     steps:
+      - run: rustup self update
       - uses: actions/checkout@v3
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - name: "rustfmt"
@@ -433,6 +441,7 @@ jobs:
     name: "License Checks"
     runs-on: ubuntu-latest
     steps:
+      - run: rustup self update
       - uses: actions/checkout@v3
 
       - uses: r7kamura/rust-problem-matchers@v1.1.0
@@ -482,6 +491,7 @@ jobs:
             target: x86_64-apple-darwin
       fail-fast: false
     steps:
+      - run: rustup self update
       - uses: actions/checkout@v3
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - name: "Add toolchains"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       - run: rustup self update
 
       - uses: actions/checkout@v3
+      - run: rustup toolchain install
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
       - name: Free Disk Space (Ubuntu)
@@ -84,6 +85,7 @@ jobs:
     steps:
       - run: rustup self update
       - uses: actions/checkout@v3
+      - run: rustup toolchain install
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
       - name: Free Disk Space (Ubuntu)
@@ -146,6 +148,7 @@ jobs:
     steps:
       - run: rustup self update
       - uses: actions/checkout@v3
+      - run: rustup toolchain install
       - uses: r7kamura/rust-problem-matchers@v1.1.0
 
       - name: Free Disk Space (Ubuntu)
@@ -225,6 +228,7 @@ jobs:
     steps:
       - run: rustup self update
       - uses: actions/checkout@v3
+      - run: rustup toolchain install
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
       - uses: Swatinem/rust-cache@v2
@@ -249,6 +253,7 @@ jobs:
     steps:
       - run: rustup self update
       - uses: actions/checkout@v3
+      - run: rustup toolchain install
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
       - name: Free Disk Space (Ubuntu)
@@ -360,13 +365,13 @@ jobs:
 
           dora destroy
 
-          # Run Python queue latency test 
+          # Run Python queue latency test
           dora run tests/queue_size_latest_data_python/dataflow.yaml
 
           # Run Python queue latency test + timeout
           dora run tests/queue_size_and_timeout_python/dataflow.yaml
 
-          # Run Rust queue latency test 
+          # Run Rust queue latency test
           dora build tests/queue_size_latest_data_rust/dataflow.yaml
           dora run tests/queue_size_latest_data_rust/dataflow.yaml
 
@@ -414,6 +419,7 @@ jobs:
     steps:
       - run: rustup self update
       - uses: actions/checkout@v3
+      - run: rustup toolchain install
 
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
@@ -433,6 +439,7 @@ jobs:
     steps:
       - run: rustup self update
       - uses: actions/checkout@v3
+      - run: rustup toolchain install
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - name: "rustfmt"
         run: cargo fmt --all -- --check
@@ -443,6 +450,7 @@ jobs:
     steps:
       - run: rustup self update
       - uses: actions/checkout@v3
+      - run: rustup toolchain install
 
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - run: cargo --version --verbose
@@ -493,6 +501,7 @@ jobs:
     steps:
       - run: rustup self update
       - uses: actions/checkout@v3
+      - run: rustup toolchain install
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - name: "Add toolchains"
         run: rustup target add ${{ matrix.platform.target }}


### PR DESCRIPTION
Rustup 1.28 no longer installs the current toolchain automatically. Once the GitHub CI runners upgrade to that rustup version, our CI jobs will likely break. This PR updates our CI scripts to avoid this breakage.