### PR TITLE
Replacing deprecated functions of pyo3 and removing other clippy warnings

### DIFF
--- a/apis/c/node/src/lib.rs
+++ b/apis/c/node/src/lib.rs
@@ -118,13 +118,13 @@ pub enum EventType {
 /// ## Safety
 ///
 /// - The `event` argument must be a dora event received through
-/// [`dora_next_event`]. The event must be still valid, i.e., not
-/// freed yet. The returned `out_ptr` must not be used after
-/// freeing the `event`, since it points directly into the event's
-/// memory.
+///   [`dora_next_event`]. The event must be still valid, i.e., not
+///   freed yet. The returned `out_ptr` must not be used after
+///   freeing the `event`, since it points directly into the event's
+///   memory.
 ///
 /// - Note: `Out_ptr` is not a null-terminated string. The length of the string
-/// is given by `out_len`.
+///   is given by `out_len`.
 #[no_mangle]
 pub unsafe extern "C" fn read_dora_input_id(
     event: *const (),

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -218,9 +218,9 @@ impl Node {
                         value
                             .to_pyarrow(py)
                             .context("failed to convert value to pyarrow")
-                            .unwrap_or_else(|err| PyErr::from(err).to_object(py))
+                            .unwrap_or_else(|err| PyErr::from(err).into_pyobject(py).unwrap().unbind().into())
                     }),
-                    Err(err) => Python::with_gil(|py| PyErr::from(err).to_object(py)),
+                    Err(err) => Python::with_gil(|py| PyErr::from(err).into_pyobject(py).unwrap().unbind().into()),
                 }
             });
             futures::pin_mut!(s);

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -218,9 +218,7 @@ impl Node {
                         value
                             .to_pyarrow(py)
                             .context("failed to convert value to pyarrow")
-                            .unwrap_or_else(|err| {
-                                PyErr::from(err).to_object(py)
-                            })
+                            .unwrap_or_else(|err| PyErr::from(err).to_object(py))
                     }),
                     Err(err) => Python::with_gil(|py| PyErr::from(err).to_object(py)),
                 }

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -218,7 +218,9 @@ impl Node {
                         value
                             .to_pyarrow(py)
                             .context("failed to convert value to pyarrow")
-                            .unwrap_or_else(|err| PyErr::from(err).to_object(py))
+                            .unwrap_or_else(|err| {
+                                PyErr::from(err).to_object(py)
+                            })
                     }),
                     Err(err) => Python::with_gil(|py| PyErr::from(err).to_object(py)),
                 }

--- a/apis/python/operator/src/lib.rs
+++ b/apis/python/operator/src/lib.rs
@@ -218,7 +218,7 @@ pub fn metadata_to_pydict<'a>(
     metadata: &'a Metadata,
     py: Python<'a>,
 ) -> Result<pyo3::Bound<'a, PyDict>> {
-    let dict = PyDict::new_bound(py);
+    let dict = PyDict::new(py);
     for (k, v) in metadata.parameters.iter() {
         match v {
             Parameter::Bool(bool) => dict

--- a/binaries/runtime/src/operator/python.rs
+++ b/binaries/runtime/src/operator/python.rs
@@ -16,7 +16,6 @@ use pyo3::{
     types::{IntoPyDict, PyAnyMethods, PyDict, PyDictMethods, PyTracebackMethods},
     Py, PyAny, Python,
 };
-use std::ffi::CString;
 use std::{
     panic::{catch_unwind, AssertUnwindSafe},
     path::Path,

--- a/binaries/runtime/src/operator/python.rs
+++ b/binaries/runtime/src/operator/python.rs
@@ -10,6 +10,7 @@ use dora_node_api::{merged::MergedEvent, Event, Parameter};
 use dora_operator_api_python::PyEvent;
 use dora_operator_api_types::DoraStatus;
 use eyre::{bail, eyre, Context, Result};
+use pyo3::ffi::c_str;
 use pyo3::{
     pyclass,
     types::{IntoPyDict, PyAnyMethods, PyDict, PyDictMethods, PyTracebackMethods},
@@ -96,7 +97,7 @@ pub fn run(
         let locals = [("Operator", operator_class)].into_py_dict_bound(py);
         let operator = py
             .eval(
-                &CString::new("Operator()").expect("CString creation failed"),
+                c_str!("import sys; sys.path.append(str(path))"),
                 None,
                 Some(&locals),
             )
@@ -161,7 +162,7 @@ pub fn run(
                     let locals = [("Operator", reloaded_operator_class)].into_py_dict_bound(py);
                     let operator: Py<pyo3::PyAny> = py
                         .eval(
-                            &CString::new("Operator()").expect("CString creation failed"),
+                            c_str!("import sys; sys.path.append(str(path))"),
                             None,
                             Some(&locals),
                         )

--- a/libraries/extensions/ros2-bridge/python/src/lib.rs
+++ b/libraries/extensions/ros2-bridge/python/src/lib.rs
@@ -60,7 +60,7 @@ impl Ros2Context {
     pub fn new(ros_paths: Option<Vec<PathBuf>>) -> eyre::Result<Self> {
         Python::with_gil(|py| -> Result<()> {
             let warnings = py
-                .import_bound("warnings")
+                .import("warnings")
                 .wrap_err("failed to import `warnings` module")?;
             warnings
             .call_method1("warn", ("dora-rs ROS2 Bridge is unstable and may change at any point without it being considered a breaking change",))

--- a/libraries/extensions/ros2-bridge/python/src/typed/mod.rs
+++ b/libraries/extensions/ros2-bridge/python/src/typed/mod.rs
@@ -25,7 +25,7 @@ const DUMMY_STRUCT_NAME: &str = "struct";
 
 #[cfg(test)]
 mod tests {
-    use std::ffi::CString;
+    
     use std::path::PathBuf;
 
     use crate::typed::deserialize::StructDeserializer;

--- a/libraries/extensions/ros2-bridge/python/src/typed/mod.rs
+++ b/libraries/extensions/ros2-bridge/python/src/typed/mod.rs
@@ -45,6 +45,7 @@ mod tests {
     use pyo3::types::PyListMethods;
     use pyo3::types::PyModule;
     use pyo3::types::PyTuple;
+    use pyo3::ffi::c_str;
 
     use pyo3::Python;
     use serde::de::DeserializeSeed;
@@ -67,8 +68,7 @@ mod tests {
 
             // Add the Python module's directory to sys.path
             py.run(
-                &CString::new("import sys; sys.path.append(str(path))")
-                    .expect("Unable to build CString"),
+                c_str!("import sys; sys.path.append(str(path))"),
                 Some(&[("path", path)].into_py_dict_bound(py)),
                 None,
             )?;
@@ -119,8 +119,7 @@ mod tests {
 
                 let _ = py
                     .eval(
-                        &CString::new("test_utils.is_subset(in_pyarrow, out_pyarrow)")
-                            .expect("CString not created"),
+                        c_str!("import sys; sys.path.append(str(path))"),
                         Some(&context),
                         None,
                     )

--- a/libraries/extensions/ros2-bridge/python/src/typed/mod.rs
+++ b/libraries/extensions/ros2-bridge/python/src/typed/mod.rs
@@ -38,6 +38,7 @@ mod tests {
     use arrow::pyarrow::ToPyArrow;
 
     use eyre::eyre;
+    use pyo3::ffi::c_str;
     use pyo3::types::IntoPyDict;
     use pyo3::types::PyAnyMethods;
     use pyo3::types::PyDict;
@@ -45,7 +46,6 @@ mod tests {
     use pyo3::types::PyListMethods;
     use pyo3::types::PyModule;
     use pyo3::types::PyTuple;
-    use pyo3::ffi::c_str;
 
     use pyo3::Python;
     use serde::de::DeserializeSeed;


### PR DESCRIPTION
I have replaced some deprecated functions of pyo3. I tried to replace them all as was mentioned in #806 but it causes some type mismatching to arise. So i will try to replace them iteratively.