### PR TITLE
Add minimal Dockerfile with Python and uv for easy onboarding

### DIFF
--- a/docker/minimal/Dockerfile
+++ b/docker/minimal/Dockerfile
@@ -7,6 +7,9 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     pkg-config \
     libssl-dev \
+    ffmpeg \
+    libsm6 \
+    libxext6 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Rust (required for Dora)

--- a/docker/minimal/Dockerfile
+++ b/docker/minimal/Dockerfile
@@ -17,7 +17,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 RUN pip install --no-cache-dir uv
 
 # Install latest Dora
-RUN pip install --no-cache-dir dora-rs
+RUN pip install --no-cache-dir dora-rs-cli
 
 # Create a working directory
 WORKDIR /app

--- a/docker/minimal/Dockerfile
+++ b/docker/minimal/Dockerfile
@@ -1,0 +1,29 @@
+FROM python:3.12-slim
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    build-essential \
+    pkg-config \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Rust (required for Dora)
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install uv
+RUN pip install --no-cache-dir uv
+
+# Install latest Dora
+RUN pip install --no-cache-dir dora-rs
+
+# Create a working directory
+WORKDIR /app
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1
+
+# Default command when container starts
+CMD ["bash"]

--- a/docker/minimal/README.md
+++ b/docker/minimal/README.md
@@ -1,0 +1,28 @@
+# Minimal Dora Docker Environment
+
+This Dockerfile provides a minimal environment for running Dora applications with Python and uv package manager.
+
+## What's Included
+
+- Python 3.12
+- Rust (required for Dora)
+- uv package manager
+- Latest Dora release
+
+## Building the Image
+
+docker build -t dora-minimal 
+
+## Running the Container
+
+docker run -it --rm -v $(pwd):/app dora-minimal
+
+## Usage
+
+Once inside the container, you can:
+
+- Run Dora commands: `dora --help`
+- Use uv for package management: `uv install numpy`
+- Develop and test your Dora applications
+
+This container is designed to provide a consistent environment for Dora development without requiring complex setup on the host machine.

--- a/docker/minimal/README.md
+++ b/docker/minimal/README.md
@@ -11,11 +11,27 @@ This Dockerfile provides a minimal environment for running Dora applications wit
 
 ## Building the Image
 
-docker build -t dora-minimal 
+```bash
+docker build . -t dora-minimal
+```
 
 ## Running the Container
 
-docker run -it --rm -v $(pwd):/app dora-minimal
+```bash
+docker run -it --rm dora-minimal
+```
+
+## Running not in interactive
+
+```bash
+docker run --rm dora-minimal dora --help
+```
+
+## Running with privilege as well as USB connection
+
+```bash
+docker run --rm  --device=/dev/ttyUSB0 dora-minimal dora --help
+```
 
 ## Usage
 


### PR DESCRIPTION
This PR address issue #837 

**Description of changes**
This PR adds a minimal Dockerfile and accompanying README to help new users get started with Dora quickly. The Dockerfile includes Python 3.12, Rust, uv package manager, and the latest Dora release, creating a consistent environment for development without requiring complex setup.

**What problem does this solve?**
New users currently need to install multiple dependencies (Python, Rust, etc.) to get started with Dora. This Docker setup simplifies onboarding by providing a pre-configured environment that works across different platforms.

**Implementation details**
1. Created a docker/minimal directory
2. Added a Dockerfile with all necessary dependencies
3. Included a comprehensive README with build and usage instructions
4. Optimized the Docker image size by using the slim Python base image and cleaning up after installations