### PR TITLE
Fix: Set variables outside bash script to prevent injection

### DIFF
--- a/.github/workflows/dora-bot-assign.yml
+++ b/.github/workflows/dora-bot-assign.yml
@@ -19,12 +19,11 @@ jobs:
       - name: Parses comment then assign/unassign user
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_BODY: "${{ github.event.comment.body }}"
+          ISSUE_NUMBER: "${{ github.event.issue.number }}"
+          COMMENT_AUTHOR: "${{ github.event.comment.user.login }}"
+          AUTHOR_ASSOCIATION: "${{ github.event.comment.author_association }}"
         run: |
-          COMMENT_BODY="${{ github.event.comment.body }}"
-          ISSUE_NUMBER="${{ github.event.issue.number }}"
-          COMMENT_AUTHOR="${{ github.event.comment.user.login }}"
-          AUTHOR_ASSOCIATION="${{ github.event.comment.author_association }}"
-
           # For assigning
           if [[ "$COMMENT_BODY" == "@dora-bot assign me" ]]; then
             echo "Assigning $COMMENT_AUTHOR to issue #$ISSUE_NUMBER"


### PR DESCRIPTION
Setting the variables in bash makes them vulnerable to command injection. I noticed this in https://github.com/dora-rs/dora/actions/runs/13792318552/job/38575135851 , which is the CI run for this comment: https://github.com/dora-rs/dora/pull/838#issuecomment-2714836815

The issue is that the comment contains `main` surrounded by backticks, which the `bash` shell interprets as a subcommand. So it tries to run a command named `main`.

Follow-up to https://github.com/dora-rs/dora/pull/840

