### PR TITLE
Adding `recv_async` dora method to retrieve data in python async

### DIFF
--- a/apis/python/node/Cargo.toml
+++ b/apis/python/node/Cargo.toml
@@ -10,9 +10,10 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["tracing", "metrics", "telemetry"]
+default = ["tracing", "metrics", "telemetry", "async"]
 tracing = ["dora-node-api/tracing"]
 metrics = ["dora-node-api/metrics"]
+async = ["pyo3/experimental-async"]
 telemetry = ["dora-runtime/telemetry"]
 
 [dependencies]

--- a/apis/python/node/pyproject.toml
+++ b/apis/python/node/pyproject.toml
@@ -12,13 +12,13 @@ readme = "README.md"
 dependencies = ['pyarrow']
 
 [dependency-groups]
-dev = ["pytest >=8.1.1", "ruff >=0.9.1"]
+dev = ["pytest >=7.1.1", "ruff >=0.9.1"]
 
 [tool.maturin]
 features = ["pyo3/extension-module"]
 
 [tool.ruff.lint]
 extend-select = [
-  "D",   # pydocstyle
-  "UP"
+    "D",  # pydocstyle
+    "UP",
 ]

--- a/apis/python/operator/src/lib.rs
+++ b/apis/python/operator/src/lib.rs
@@ -19,14 +19,13 @@ use pyo3::{
 /// Dora Event
 pub struct PyEvent {
     pub event: MergedEvent<PyObject>,
-    pub _cleanup: Option<NodeCleanupHandle>,
 }
 
 /// Keeps the dora node alive until all event objects have been dropped.
 #[derive(Clone)]
 #[pyclass]
 pub struct NodeCleanupHandle {
-    pub _handles: Arc<(CleanupHandle<DoraNode>, CleanupHandle<EventStream>)>,
+    pub _handles: Arc<CleanupHandle<DoraNode>>,
 }
 
 /// Owned type with delayed cleanup (using `handle` method).
@@ -137,17 +136,6 @@ impl PyEvent {
             MergedEvent::External(event) => {
                 pydict.insert("value", event.clone_ref(py));
             }
-        }
-
-        if let Some(cleanup) = self._cleanup.clone() {
-            pydict.insert(
-                "_cleanup",
-                cleanup
-                    .into_pyobject(py)
-                    .context("failed to convert cleanup handle to pyobject")?
-                    .into_any()
-                    .unbind(),
-            );
         }
 
         Ok(pydict

--- a/binaries/runtime/src/operator/python.rs
+++ b/binaries/runtime/src/operator/python.rs
@@ -217,7 +217,6 @@ pub fn run(
 
                 let py_event = PyEvent {
                     event: MergedEvent::Dora(event),
-                    _cleanup: None,
                 }
                 .to_py_dict(py)
                 .context("Could not convert event to pydict bound")?;

--- a/examples/python-async/README.md
+++ b/examples/python-async/README.md
@@ -1,0 +1,10 @@
+# Python Async Example
+
+To get started:
+
+```bash
+uv venv --seed -p 3.11
+uv pip install -e ../../apis/python/node
+dora build dataflow.yaml --uv
+dora run dataflow.yaml --uv
+```

--- a/examples/python-async/dataflow.yaml
+++ b/examples/python-async/dataflow.yaml
@@ -1,0 +1,14 @@
+nodes:
+  - id: send_data
+    build: pip install asyncio
+    path: ./send_data.py
+    inputs:
+      tick: dora/timer/millis/10
+    outputs:
+      - data
+
+  - id: receive_data_with_sleep
+    build: pip install numpy pyarrow
+    path: ./receive_data.py
+    inputs:
+      tick: send_data/data

--- a/examples/python-async/receive_data.py
+++ b/examples/python-async/receive_data.py
@@ -1,0 +1,17 @@
+import asyncio
+
+from dora import Node
+
+
+async def main():
+    node = Node()
+    for _ in range(100):
+        event = await node.recv_async()
+        print(event)
+        # del event
+    print('done!')
+
+
+if __name__ ==  '__main__':
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(main())

--- a/examples/python-async/send_data.py
+++ b/examples/python-async/send_data.py
@@ -1,0 +1,18 @@
+"""TODO: Add docstring."""
+
+import time
+
+import numpy as np
+import pyarrow as pa
+from dora import Node
+
+node = Node()
+
+i = 0
+for event in node:
+    if i == 100:
+        break
+    else:
+        i += 1
+    now = time.perf_counter_ns()
+    node.send_output("data", pa.array([np.uint64(now)]))


### PR DESCRIPTION
Make it possible to retrieve data asynchronously within python asyncio.

This is possible due to `experimental-async` from pyo3.

Note that this feature should be considered experimental as long as pyo3 async is marked as experimental.

This feature required to remove events delayedcleanup as it was no longer used.

