### PR TITLE
Implementing Self update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1372,7 +1372,7 @@ dependencies = [
  "path_abs",
  "plist",
  "regex",
- "semver",
+ "semver 1.0.23",
  "serde",
  "serde_yaml 0.9.34+deprecated",
  "shell-words",
@@ -1693,7 +1693,7 @@ checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver",
+ "semver 1.0.23",
  "serde",
  "serde_json",
 ]
@@ -1706,7 +1706,7 @@ checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver",
+ "semver 1.0.23",
  "serde",
  "serde_json",
  "thiserror 1.0.66",
@@ -2614,6 +2614,7 @@ dependencies = [
  "log",
  "notify 5.2.0",
  "pyo3",
+ "self_update",
  "serde",
  "serde_json",
  "serde_yaml 0.9.34+deprecated",
@@ -2754,7 +2755,7 @@ dependencies = [
  "log",
  "once_cell",
  "schemars",
- "semver",
+ "semver 1.0.23",
  "serde",
  "serde-with-expand-env",
  "serde_yaml 0.9.34+deprecated",
@@ -4823,6 +4824,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7baab56125e25686df467fe470785512329883aab42696d661247aca2a2896e4"
+dependencies = [
+ "console",
+ "lazy_static",
+ "number_prefix",
+ "regex",
+]
+
+[[package]]
 name = "indoc"
 version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6240,6 +6253,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
+
+[[package]]
 name = "nvml-wrapper"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7631,6 +7650,15 @@ checksum = "91a6ee7a084f913f98d70cdc3ebec07e852b735ae3059a1500db2661265da9ff"
 dependencies = [
  "pyo3",
  "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26aab6b48e2590e4a64d1ed808749ba06257882b461d01ca71baeb747074a6dd"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -9960,7 +9988,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver",
+ "semver 1.0.23",
 ]
 
 [[package]]
@@ -10346,12 +10374,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "self_update"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb85f1802f7b987237b8525c0fde86ea86f31c957c1875467c727d5b921179c"
+dependencies = [
+ "hyper 0.14.30",
+ "indicatif",
+ "log",
+ "quick-xml 0.20.0",
+ "regex",
+ "reqwest 0.11.27",
+ "semver 0.11.0",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
+dependencies = [
+ "pest",
 ]
 
 [[package]]

--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -50,7 +50,12 @@ tabwriter = "1.4.0"
 log = { version = "0.4.21", features = ["serde"] }
 colored = "2.1.0"
 env_logger = "0.11.3"
-self_update = { version = "0.27.0", features = ["rustls", "archive-zip"], default-features = false }
+self_update = { version = "0.27.0", features = [
+    "rustls",
+    "archive-zip",
+    "archive-tar",
+    "compression-flate2",
+], default-features = false }
 pyo3 = { workspace = true, features = [
     "extension-module",
     "abi3",

--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -50,7 +50,7 @@ tabwriter = "1.4.0"
 log = { version = "0.4.21", features = ["serde"] }
 colored = "2.1.0"
 env_logger = "0.11.3"
-self_update = { version = "0.27.0", features = ["rustls"], default-features = false }
+self_update = { version = "0.27.0", features = ["rustls", "archive-zip"], default-features = false }
 pyo3 = { workspace = true, features = [
     "extension-module",
     "abi3",

--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -50,7 +50,7 @@ tabwriter = "1.4.0"
 log = { version = "0.4.21", features = ["serde"] }
 colored = "2.1.0"
 env_logger = "0.11.3"
-self_update = "0.42.0"
+self_update = { version = "0.27.0", features = ["rustls"], default-features = false }
 pyo3 = { workspace = true, features = [
     "extension-module",
     "abi3",

--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -50,6 +50,7 @@ tabwriter = "1.4.0"
 log = { version = "0.4.21", features = ["serde"] }
 colored = "2.1.0"
 env_logger = "0.11.3"
+self_update = "0.42.0"
 pyo3 = { workspace = true, features = [
     "extension-module",
     "abi3",

--- a/binaries/cli/build.rs
+++ b/binaries/cli/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!(
+        "cargo:rustc-env=TARGET={}",
+        std::env::var("TARGET").unwrap()
+    );
+}

--- a/binaries/cli/src/lib.rs
+++ b/binaries/cli/src/lib.rs
@@ -241,8 +241,16 @@ enum Command {
         quiet: bool,
     },
 
-    SelfUpdate {
+    Self_ {
         /// Only check for updates without installing
+        #[clap(subcommand)]
+        command: SelfSubCommand,
+    },
+}
+
+#[derive(Debug, clap::Subcommand)]
+enum SelfSubCommand {
+    Update {
         #[clap(long)]
         check_only: bool,
     },
@@ -543,51 +551,53 @@ fn run(args: Args) -> eyre::Result<()> {
             .context("failed to run dora-daemon")?
         }
         Command::Runtime => dora_runtime::main().context("Failed to run dora-runtime")?,
-        Command::SelfUpdate { check_only } => {
-            println!("Checking for updates...");
+        Command::Self_ { command } => match command {
+            SelfSubCommand::Update { check_only } => {
+                println!("Checking for updates...");
 
-            let status = self_update::backends::github::Update::configure()
-                .repo_owner("dora-rs")
-                .repo_name("dora")
-                .bin_name("dora")
-                .show_download_progress(true)
-                .current_version(env!("CARGO_PKG_VERSION"))
-                .build()?;
+                let status = self_update::backends::github::Update::configure()
+                    .repo_owner("dora-rs")
+                    .repo_name("dora")
+                    .bin_name("dora")
+                    .show_download_progress(true)
+                    .current_version(env!("CARGO_PKG_VERSION"))
+                    .build()?;
 
-            if check_only {
-                // Only check if an update is available
-                match status.get_latest_release() {
-                    Ok(release) => {
-                        let current_version = self_update::cargo_crate_version!();
-                        if current_version != release.version {
-                            println!(
-                                "An update is available: {}. Run 'dora self-update' to update",
-                                release.version
-                            );
-                        } else {
-                            println!(
-                                "Dora CLI is already at the latest version: {}",
-                                current_version
-                            );
+                if check_only {
+                    // Only check if an update is available
+                    match status.get_latest_release() {
+                        Ok(release) => {
+                            let current_version = self_update::cargo_crate_version!();
+                            if current_version != release.version {
+                                println!(
+                                    "An update is available: {}. Run 'dora self-update' to update",
+                                    release.version
+                                );
+                            } else {
+                                println!(
+                                    "Dora CLI is already at the latest version: {}",
+                                    current_version
+                                );
+                            }
                         }
+                        Err(e) => println!("Failed to check for updates: {}", e),
                     }
-                    Err(e) => println!("Failed to check for updates: {}", e),
-                }
-            } else {
-                // Perform the actual update
-                match status.update() {
-                    Ok(update_status) => match update_status {
-                        self_update::Status::UpToDate(version) => {
-                            println!("Dora CLI is already at the latest version: {}", version);
-                        }
-                        self_update::Status::Updated(version) => {
-                            println!("Successfully updated Dora CLI to version: {}", version);
-                        }
-                    },
-                    Err(e) => println!("Failed to update: {}", e),
+                } else {
+                    // Perform the actual update
+                    match status.update() {
+                        Ok(update_status) => match update_status {
+                            self_update::Status::UpToDate(version) => {
+                                println!("Dora CLI is already at the latest version: {}", version);
+                            }
+                            self_update::Status::Updated(version) => {
+                                println!("Successfully updated Dora CLI to version: {}", version);
+                            }
+                        },
+                        Err(e) => println!("Failed to update: {}", e),
+                    }
                 }
             }
-        }
+        },
     };
 
     Ok(())

--- a/binaries/cli/src/lib.rs
+++ b/binaries/cli/src/lib.rs
@@ -555,9 +555,17 @@ fn run(args: Args) -> eyre::Result<()> {
             SelfSubCommand::Update { check_only } => {
                 println!("Checking for updates...");
 
+                #[cfg(target_os = "linux")]
+                let bin_path_in_archive = format!("dora-cli-{}/dora", env!("TARGET"));
+                #[cfg(target_os = "macos")]
+                let bin_path_in_archive = format!("dora-cli-{}/dora", env!("TARGET"));
+                #[cfg(target_os = "windows")]
+                let bin_path_in_archive = String::from("dora.exe");
+
                 let status = self_update::backends::github::Update::configure()
                     .repo_owner("dora-rs")
                     .repo_name("dora")
+                    .bin_path_in_archive(&bin_path_in_archive)
                     .bin_name("dora")
                     .show_download_progress(true)
                     .current_version(env!("CARGO_PKG_VERSION"))

--- a/binaries/cli/src/lib.rs
+++ b/binaries/cli/src/lib.rs
@@ -242,7 +242,6 @@ enum Command {
     },
 
     Self_ {
-        /// Only check for updates without installing
         #[clap(subcommand)]
         command: SelfSubCommand,
     },
@@ -251,6 +250,7 @@ enum Command {
 #[derive(Debug, clap::Subcommand)]
 enum SelfSubCommand {
     Update {
+        /// Only check for updates without installing
         #[clap(long)]
         check_only: bool,
     },

--- a/binaries/cli/src/lib.rs
+++ b/binaries/cli/src/lib.rs
@@ -570,7 +570,7 @@ fn run(args: Args) -> eyre::Result<()> {
                             let current_version = self_update::cargo_crate_version!();
                             if current_version != release.version {
                                 println!(
-                                    "An update is available: {}. Run 'dora self-update' to update",
+                                    "An update is available: {}. Run 'dora self update' to update",
                                     release.version
                                 );
                             } else {


### PR DESCRIPTION
So, As mentioned [here](https://github.com/dora-rs/dora/pull/913#issuecomment-2747339237). I did these changes and tried it with "Hennzau" fork and it seems to be working fine.
```Checking for updates...
Checking target-arch... x86_64-unknown-linux-gnu
Checking current version... v0.3.10
Checking latest released version... v0.3.11
New release found! v0.3.10 --> v0.3.11
New release is compatible

dora release status:
  * Current exe: "/home/arlott/gsoc/dora/dora/target/debug/dora"
  * New exe release: "dora-cli-x86_64-unknown-linux-gnu.tar.gz"
  * New exe download url: "https://api.github.com/repos/Hennzau/dora/releases/assets/240150528"

The new release will be downloaded/extracted and the existing binary will be replaced.
Do you want to continue? [Y/n] Y
Downloading...
[00:00:03] [========================================] 15.41MB/15.41MB (0s) Done
Extracting archive... Done
Replacing binary file... Done
Successfully updated Dora CLI to version: 0.3.11```