### PR TITLE
Fix: RUST_LOG=.  dora run bug

### DIFF
--- a/binaries/cli/src/lib.rs
+++ b/binaries/cli/src/lib.rs
@@ -312,7 +312,8 @@ fn run(args: Args) -> eyre::Result<()> {
                 .context("failed to set up tracing subscriber")?;
         }
         Command::Run { .. } => {
-            set_up_tracing_opts("run", Some("info"), None)
+            let log_level = std::env::var("RUST_LOG").ok().or(Some("info".to_string()));
+            set_up_tracing_opts("run", log_level.as_deref(), None)
                 .context("failed to set up tracing subscriber")?;
         }
         _ => {


### PR DESCRIPTION
This PR fixes the bug that the specified log level is invalid when using dora run