### PR TITLE
Simplify the use of C/C++ API

### DIFF
--- a/.github/workflows/libdora-release.yml
+++ b/.github/workflows/libdora-release.yml
@@ -1,0 +1,142 @@
+name: Build and Publish Dora C/C++ API
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-release:
+    name: Build and Release C API for ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+          - os: ubuntu-latest
+            target: armv7-unknown-linux-musleabihf
+          - os: ubuntu-latest
+            target: i686-unknown-linux-gnu
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          # - os: windows-latest
+          #   target: x86_64-pc-windows-msvc
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install cross-compilation tools (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf gcc-i686-linux-gnu musl-tools
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Add Rust target
+        shell: bash
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Install cross (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: cargo install cross || true
+
+      - name: Build for all targets (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Write-Output "Building for target: $env:matrix_target"
+          cargo build --release --target $env:matrix_target -p dora-node-api-c
+          cargo build --release --target $env:matrix_target -p dora-operator-api-c
+          cargo build --release --target $env:matrix_target -p dora-node-api-cxx
+          cargo build --release --target $env:matrix_target -p dora-operator-api-cxx
+          Write-Output "Generating header file with: cargo run --example cxx-dataflow --release"
+          cargo run --example cxx-dataflow --release
+
+      - name: Build for all targets (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          echo "Building for target: ${{ matrix.target }}"
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            cross build --release --target ${{ matrix.target }} -p dora-node-api-c
+            cross build --release --target ${{ matrix.target }} -p dora-operator-api-c
+            cross build --release --target ${{ matrix.target }} -p dora-node-api-cxx
+            cross build --release --target ${{ matrix.target }} -p dora-operator-api-cxx
+          else
+            cargo build --release --target ${{ matrix.target }} -p dora-node-api-c
+            cargo build --release --target ${{ matrix.target }} -p dora-operator-api-c
+            cargo build --release --target ${{ matrix.target }} -p dora-node-api-cxx
+            cargo build --release --target ${{ matrix.target }} -p dora-operator-api-cxx
+          fi
+          echo "Generating header file with: cargo run --example cxx-dataflow --release"
+          cargo run --example cxx-dataflow --release
+      - name: Package artifact
+        shell: bash
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          else
+            VERSION="v-latest"
+          fi
+          mkdir -p dist/{include,lib}
+          
+          echo "Copying headers..."
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            cp apis/c/node/*.h dist/include/ || echo "No headers found"
+            cp apis/c/operator/*.h dist/include/ || echo "No headers found"
+            cp target/cxxbridge/dora-node-api-cxx/*.h dist/include/ || echo "No cxxbridge headers found"
+            cp examples/c++-dataflow/build/*.h dist/include/ || echo "No example headers found"
+          else
+            cp apis/c/node/*.h dist/include/ || echo "No headers found"
+            cp apis/c/operator/*.h dist/include/ || echo "No headers found"
+            cp target/cxxbridge/dora-node-api-cxx/*.h dist/include/ || echo "No cxxbridge headers found"
+            cp examples/c++-dataflow/build/*.h dist/include/ || echo "No example headers found"
+            cp examples/c++-dataflow/operator-rust-api/*.h dist/include/ || echo "No operator_api headers found"
+          fi
+          echo "Copying library files..."
+          case "$RUNNER_OS" in
+            "Linux" | "macOS")
+              cp target/${{ matrix.target }}/release/*.a dist/lib/ || echo "No libdora_node_api_c.a found"
+              cp target/${{ matrix.target }}/debug/libdora_node_api_cxx.a dist/lib || echo "No libdora_node_api_cxx.a found"
+              ;;
+            "Windows")
+              cp target/${{ matrix.target }}/release/*.lib dist/lib/ || echo "No dora_node_api_c found"
+              cp target/${{ matrix.target }}/debug/libdora_node_api_cxx.a dist/lib || echo "No libdora_node_api_cxx.a found"
+              ;;
+          esac
+          echo "Packaging artifact..."
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            ARCHIVE_NAME="libdora-${VERSION}-${{ matrix.target }}.zip"
+            powershell Compress-Archive -Path 'dist/*' -DestinationPath "$ARCHIVE_NAME"
+            mv "$ARCHIVE_NAME" .
+          else
+            ARCHIVE_NAME="libdora-${VERSION}-${{ matrix.target }}.tar.gz"
+            tar -czf "$ARCHIVE_NAME" -C dist .
+          fi
+          echo "Archive created: $ARCHIVE_NAME"
+          echo "ARCHIVE_NAME=$ARCHIVE_NAME" >> $GITHUB_ENV
+      - name: Upload release asset
+        if: github.event_name == 'release'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./${{ env.ARCHIVE_NAME }}
+          asset_name: ${{ env.ARCHIVE_NAME }}
+          asset_content_type: application/octet-stream

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,141 @@
+name: Build and Publish Dora C/C++ API
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-release:
+    name: Build and Release C API for ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+          - os: ubuntu-latest
+            target: armv7-unknown-linux-musleabihf
+          - os: ubuntu-latest
+            target: i686-unknown-linux-gnu
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          # - os: windows-latest
+          #   target: x86_64-pc-windows-msvc
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install cross-compilation tools (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu gcc-arm-linux-gnueabihf gcc-i686-linux-gnu musl-tools
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Add Rust target
+        shell: bash
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Install cross (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: cargo install cross || true
+
+      - name: Build for all targets (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Write-Output "Building for target: $env:matrix_target"
+          cargo build --release --target $env:matrix_target -p dora-node-api-c
+          cargo build --release --target $env:matrix_target -p dora-operator-api-c
+          cargo build --release --target $env:matrix_target -p dora-node-api-cxx
+          cargo build --release --target $env:matrix_target -p dora-operator-api-cxx
+          Write-Output "Generating header file with: cargo run --example cxx-dataflow --release"
+          cargo run --example cxx-dataflow --release
+
+      - name: Build for all targets (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          echo "Building for target: ${{ matrix.target }}"
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            cross build --release --target ${{ matrix.target }} -p dora-node-api-c
+            cross build --release --target ${{ matrix.target }} -p dora-operator-api-c
+            cross build --release --target ${{ matrix.target }} -p dora-node-api-cxx
+            cross build --release --target ${{ matrix.target }} -p dora-operator-api-cxx
+          else
+            cargo build --release --target ${{ matrix.target }} -p dora-node-api-c
+            cargo build --release --target ${{ matrix.target }} -p dora-operator-api-c
+            cargo build --release --target ${{ matrix.target }} -p dora-node-api-cxx
+            cargo build --release --target ${{ matrix.target }} -p dora-operator-api-cxx
+          fi
+          echo "Generating header file with: cargo run --example cxx-dataflow --release"
+          cargo run --example cxx-dataflow --release
+      - name: Package artifact
+        shell: bash
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          else
+            VERSION="v-latest"
+          fi
+          mkdir -p dist/{include,lib}
+          
+          echo "Copying headers..."
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            cp apis/c/node/*.h dist/include/ || echo "No headers found"
+            cp apis/c/operator/*.h dist/include/ || echo "No headers found"
+            cp target/cxxbridge/dora-node-api-cxx/*.h dist/include/ || echo "No cxxbridge headers found"
+            cp examples/c++-dataflow/build/*.h dist/include/ || echo "No example headers found"
+          else
+            cp apis/c/node/*.h dist/include/ || echo "No headers found"
+            cp apis/c/operator/*.h dist/include/ || echo "No headers found"
+            cp target/cxxbridge/dora-node-api-cxx/*.h dist/include/ || echo "No cxxbridge headers found"
+            cp examples/c++-dataflow/build/*.h dist/include/ || echo "No example headers found"
+          fi
+          echo "Copying library files..."
+          case "$RUNNER_OS" in
+            "Linux" | "macOS")
+              cp target/${{ matrix.target }}/release/libdora_node_api_c.a dist/lib/ || echo "No libdora_node_api_c.a found"
+              cp target/${{ matrix.target }}/release/libdora_operator_api_c.a dist/lib/ || echo "No libdora_operator_api_c.a found"
+              ;;
+            "Windows")
+              cp target/${{ matrix.target }}/release/dora_node_api_c.dll dist/lib/ || cp target/${{ matrix.target }}/release/dora_node_api_c.lib dist/lib/ || echo "No dora_node_api_c found"
+              cp target/${{ matrix.target }}/release/dora_operator_api_c.dll dist/lib/ || cp target/${{ matrix.target }}/release/dora_operator_api_c.lib dist/lib/ || echo "No dora_operator_api_c found"
+              ;;
+          esac
+          echo "Packaging artifact..."
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            ARCHIVE_NAME="dora-c-api-${VERSION}-${{ matrix.target }}.zip"
+            powershell Compress-Archive -Path 'dist/*' -DestinationPath "$ARCHIVE_NAME"
+            mv "$ARCHIVE_NAME" .
+          else
+            ARCHIVE_NAME="dora-c-api-${VERSION}-${{ matrix.target }}.tar.gz"
+            tar -czf "$ARCHIVE_NAME" -C dist .
+          fi
+          echo "Archive created: $ARCHIVE_NAME"
+          echo "ARCHIVE_NAME=$ARCHIVE_NAME" >> $GITHUB_ENV
+      - name: Upload release asset
+        if: github.event_name == 'release'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./${{ env.ARCHIVE_NAME }}
+          asset_name: ${{ env.ARCHIVE_NAME }}
+          asset_content_type: application/octet-stream

--- a/examples/c++-dataflow/run.rs
+++ b/examples/c++-dataflow/run.rs
@@ -45,6 +45,8 @@ async fn main() -> eyre::Result<()> {
     )
     .await?;
 
+    archive_node_bridge(root, build_dir).await?;
+
     build_package("dora-operator-api-cxx").await?;
     let operator_cxxbridge = target
         .join("cxxbridge")
@@ -114,6 +116,50 @@ async fn main() -> eyre::Result<()> {
     build_package("dora-runtime").await?;
     run_dataflow(&dataflow).await?;
 
+    Ok(())
+}
+
+/// Compiles "node-bridge.cc" into "node-bridge.o" using clang++ (falling back to g++ if clang++ is unavailable) with C++17 and PIC flags
+/// and then archives it into the static library
+async fn archive_node_bridge(root: &Path, build_dir: &Path) -> eyre::Result<()> {
+    let node_bridge_cc = build_dir.join("node-bridge.cc");
+    let node_bridge_o = build_dir.join("node-bridge.o");
+
+    let compiler = if tokio::process::Command::new("which")
+        .arg("clang++")
+        .output()
+        .await?
+        .status
+        .success()
+    {
+        "clang++"
+    } else {
+        "g++"
+    };
+    tracing::info!("Using C++ compiler: {}", compiler);
+
+    let mut compile = tokio::process::Command::new(compiler);
+    compile
+        .arg("-c")
+        .arg(&node_bridge_cc)
+        .arg("-std=c++17")
+        .arg("-fPIC")
+        .arg("-o")
+        .arg(&node_bridge_o);
+    if !compile.status().await?.success() {
+        bail!("failed to compile node-bridge.cc with {}", compiler);
+    }
+
+    let static_lib = root
+        .join("target")
+        .join("debug")
+        .join("libdora_node_api_cxx.a");
+
+    let mut ar = tokio::process::Command::new("ar");
+    ar.arg("rcs").arg(&static_lib).arg(&node_bridge_o);
+    if !ar.status().await?.success() {
+        bail!("failed to archive node-bridge.o into libdora_node_api_cxx.a");
+    }
     Ok(())
 }
 

--- a/examples/c++-dataflow/run.rs
+++ b/examples/c++-dataflow/run.rs
@@ -3,6 +3,7 @@ use eyre::{bail, Context};
 use std::{
     env::consts::{DLL_PREFIX, DLL_SUFFIX, EXE_SUFFIX},
     path::Path,
+    // process::Command,
 };
 
 #[tokio::main]
@@ -46,7 +47,7 @@ async fn main() -> eyre::Result<()> {
     .await?;
 
     archive_node_bridge(root, build_dir).await?;
-
+    
     build_package("dora-operator-api-cxx").await?;
     let operator_cxxbridge = target
         .join("cxxbridge")
@@ -146,6 +147,20 @@ async fn archive_node_bridge(root: &Path, build_dir: &Path) -> eyre::Result<()> 
         .arg("-fPIC")
         .arg("-o")
         .arg(&node_bridge_o);
+        .success() {
+            "clang++"
+        } else {
+            "g++"
+        };
+    tracing::info!("Using C++ compiler: {}", compiler);
+
+    let mut compile = tokio::process::Command::new(compiler);
+    compile.arg("-c")
+           .arg(&node_bridge_cc)
+           .arg("-std=c++17")
+           .arg("-fPIC")
+           .arg("-o")
+           .arg(&node_bridge_o);
     if !compile.status().await?.success() {
         bail!("failed to compile node-bridge.cc with {}", compiler);
     }
@@ -157,6 +172,12 @@ async fn archive_node_bridge(root: &Path, build_dir: &Path) -> eyre::Result<()> 
 
     let mut ar = tokio::process::Command::new("ar");
     ar.arg("rcs").arg(&static_lib).arg(&node_bridge_o);
+    let static_lib = root.join("target").join("debug").join("libdora_node_api_cxx.a");
+
+    let mut ar = tokio::process::Command::new("ar");
+    ar.arg("rcs")
+      .arg(&static_lib)
+      .arg(&node_bridge_o);
     if !ar.status().await?.success() {
         bail!("failed to archive node-bridge.o into libdora_node_api_cxx.a");
     }

--- a/install_libdora.sh
+++ b/install_libdora.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+set -e
+
+PREFIX="/usr/local"
+
+detect_platform() {
+  local os="$(uname -s)"
+  local arch="$(uname -m)"
+
+  case "$os" in
+    Darwin)
+      # macOS
+      if [ "$arch" = "x86_64" ]; then
+        # macOS Intel
+        echo "x86_64-apple-darwin"
+      elif [ "$arch" = "arm64" ] || [ "$arch" = "aarch64" ]; then
+        # macOS Apple Silicon
+        echo "aarch64-apple-darwin"
+      else
+        echo "Unsupported architecture on macOS: $arch" >&2
+        exit 1
+      fi
+      ;;
+    Linux)
+      # Linux
+      case "$arch" in
+        x86_64)
+          echo "x86_64-unknown-linux-gnu"
+          ;;
+        i686)
+          echo "i686-unknown-linux-gnu"
+          ;;
+        armv7l)
+          echo "armv7-unknown-linux-musleabihf"
+          ;;
+        aarch64|arm64)
+          echo "aarch64-unknown-linux-gnu"
+          ;;
+        *)
+          echo "Unsupported architecture on Linux: $arch" >&2
+          exit 1
+          ;;
+      esac
+      ;;
+    *)
+      echo "Unsupported OS: $os" >&2
+      exit 1
+      ;;
+  esac
+}
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "Error: 'curl' not found!" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: 'jq' not found!" >&2
+  exit 1
+fi
+
+echo "==> Determining local platform..."
+PLATFORM="$(detect_platform)"
+echo "    => PLATFORM: $PLATFORM"
+
+echo "==> Fetching latest Dora release info from GitHub..."
+LATEST_JSON=$(curl -s https://api.github.com/repos/starlitxiling/dora-rerun/releases/latest)
+
+if [ -z "$LATEST_JSON" ]; then
+  echo "Error: failed to fetch release info from GitHub!"
+  exit 1
+fi
+
+TAG=$(echo "$LATEST_JSON" | jq -r '.tag_name')
+if [ -z "$TAG" ] || [ "$TAG" = "null" ]; then
+  echo "Error: 'tag_name' not found in GitHub API JSON!"
+  echo "$LATEST_JSON"
+  exit 1
+fi
+
+VERSION="${TAG#v}"
+echo "==> Latest release: $TAG => version: $VERSION"
+
+echo "==> Searching for matching asset in release assets..."
+
+ASSET_INFO=$(echo "$LATEST_JSON" | jq -r \
+  --arg platform "$PLATFORM" \
+  '.assets[] | select(.name | contains($platform)) | {name: .name, url: .browser_download_url} | @base64')
+
+ASSET_COUNT=0
+CHOSEN_ASSET_NAME=""
+CHOSEN_ASSET_URL=""
+for item in $ASSET_INFO; do
+  dec=$(echo "$item" | base64 --decode)
+  asset_name=$(echo "$dec" | jq -r '.name')
+  asset_url=$(echo "$dec" | jq -r '.url')
+  ASSET_COUNT=$((ASSET_COUNT + 1))
+
+  CHOSEN_ASSET_NAME="$asset_name"
+  CHOSEN_ASSET_URL="$asset_url"
+done
+
+if [ "$ASSET_COUNT" -eq 0 ]; then
+  echo "Error: no asset found for platform '$PLATFORM' in release $TAG"
+  exit 1
+elif [ "$ASSET_COUNT" -gt 1 ]; then
+  echo "Warning: multiple assets matched. Will use the last one found:"
+  echo "    name: $CHOSEN_ASSET_NAME"
+fi
+
+echo "==> Downloading asset: $CHOSEN_ASSET_NAME"
+echo "    from URL: $CHOSEN_ASSET_URL"
+
+curl -L -o "$CHOSEN_ASSET_NAME" "$CHOSEN_ASSET_URL"
+
+if [ ! -f "$CHOSEN_ASSET_NAME" ]; then
+  echo "Error: download failed or no file found: $CHOSEN_ASSET_NAME"
+  exit 1
+fi
+
+echo "==> Extracting $CHOSEN_ASSET_NAME ..."
+tar -zxvf "$CHOSEN_ASSET_NAME"
+
+FILE_TO_FIX="include/operator.h"
+OLD_PATH="../operator-rust-api/operator.h"
+NEW_PATH="operator.h"
+
+if [ -f "$FILE_TO_FIX" ] && grep -q "$OLD_PATH" "$FILE_TO_FIX"; then
+  echo "==> Fixing include path in $FILE_TO_FIX ..."
+  if sed --version 2>/dev/null | grep -q "GNU"; then
+    sed -i "s|$OLD_PATH|$NEW_PATH|g" "$FILE_TO_FIX"
+  else
+    sed -i "" "s|$OLD_PATH|$NEW_PATH|g" "$FILE_TO_FIX"
+  fi
+fi
+
+echo "==> Installing headers to: $PREFIX/include/dora"
+mkdir -p "$PREFIX/include/dora"
+cp -r include/* "$PREFIX/include/dora"
+
+echo "==> Installing libraries to: $PREFIX/lib"
+mkdir -p "$PREFIX/lib"
+cp -r lib/* "$PREFIX/lib"
+
+echo "==> Cleaning up..."
+rm -rf include lib
+rm -f "$CHOSEN_ASSET_NAME"
+
+echo
+echo "Installation complete!"
+echo "Dora version: $VERSION"
+echo "Headers installed at: $PREFIX/include/dora"
+echo "Libraries installed at: $PREFIX/lib"
+echo "All temp files removed."


### PR DESCRIPTION
This PR packages the header files and library files needed to use the Dora c/c++ api. I tested the whole process on macos and it is normal. 
For the windows platform, there are some problems in the linking process, so I cancelled it. 
I provide a script for users to install the files needed to use the api. Users only need to add `I/usr/local/include/dora` `-L/usr/local/lib -ldora_node_api_c` or `-L/usr/local/lib -ldora_node_api_cxx` when compiling the command, without having to consider specifying the path of the header file or library file.
I think we need to add in the documentation what is needed to use the API, such as `pip install dora-rs` for the python API