### PR TITLE
[refactor] nix-environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,7 @@ out/
 yolo.yml
 
 ~*
+
+# nix
+result
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1743964447,
+        "narHash": "sha256-nEo1t3Q0F+0jQ36HJfbJtiRU4OI+/0jX/iITURKe3EE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "063dece00c5a77e4a0ea24e5e5a5bd75232806f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,41 @@
+{
+  rustPlatform,
+  fetchFromGitHub,
+  lib,
+  pkg-config,
+  openssl,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "dora-cli";
+  version = "0.3.11";
+
+  src = fetchFromGitHub {
+    owner = "dora-rs";
+    repo = "dora";
+    rev = "v${version}";
+    hash = "sha256-dnCHDGTtNZLjKOYmNfRMsop5CeiElctlGoWxuvmIxdA=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-kwJGkxRvCht+aVN8X/elcESuNdYtU1pc0IgNkrlc9a0=";
+  # nativeBuildInputs = [pkg-config];
+  # buildInputs = [openssl];
+  # OPENSSL_NO_VENDOR = 1;
+  buildPhase = ''
+    cargo build --release -p dora-cli
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp target/release/dora $out/bin
+  '';
+
+  # doCheck = false;
+
+  meta = {
+    description = "Making robotic applications fast and simple!";
+    homepage = "https://dora-rs.ai/";
+    changelog = "https://github.com/dora-rs/dora/blob/main/Changelog.md";
+    license = lib.licenses.asl20;
+  };
+}


### PR DESCRIPTION
I wanted to test dora on my NixOS machine and needed to refactor the nix files. With the provided dev-shell in the flake it was also possible to run the python example from the [getting started](https://dora-rs.ai/docs/guides/getting-started/conversation_py).
After this PR is merged it would also be possible to get a working dora dev-shell via nix by calling the following command:
```bash
nix develop github:dora-rs/dora
```