### PR TITLE
Ease of use changes in benches for issue #957

### DIFF
--- a/benches/llms/README.md
+++ b/benches/llms/README.md
@@ -1,6 +1,12 @@
 # Benchmark LLM Speed
 
-Use the following command to run the benchmark:
+If you do not have a python virtual environment setup run
+
+'''bash
+uv venv --seed -p 3.11
+'''
+
+Then Use the following command to run the benchmark:
 
 ```bash
 dora build transformers.yaml --uv

--- a/benches/llms/llama_cpp_python.yaml
+++ b/benches/llms/llama_cpp_python.yaml
@@ -1,5 +1,7 @@
 nodes:
   - id: benchmark_script
+    build: |
+      pip install ../mllm
     path: ../mllm/benchmark_script.py
     inputs:
       text: llm/text

--- a/benches/llms/mistralrs.yaml
+++ b/benches/llms/mistralrs.yaml
@@ -1,5 +1,7 @@
 nodes:
   - id: benchmark_script
+    build: |
+      pip install ../mllm
     path: ../mllm/benchmark_script.py
     inputs:
       text: llm/text

--- a/benches/llms/phi4.yaml
+++ b/benches/llms/phi4.yaml
@@ -1,5 +1,7 @@
 nodes:
   - id: benchmark_script
+    build: |
+      pip install ../mllm
     path: ../mllm/benchmark_script.py
     inputs:
       text: llm/text

--- a/benches/llms/qwen2.5.yaml
+++ b/benches/llms/qwen2.5.yaml
@@ -1,5 +1,7 @@
 nodes:
   - id: benchmark_script
+    build: |
+      pip install ../mllm
     path: ../mllm/benchmark_script.py
     inputs:
       text: llm/text

--- a/benches/llms/transformers.yaml
+++ b/benches/llms/transformers.yaml
@@ -1,5 +1,7 @@
 nodes:
   - id: benchmark_script
+    build: |
+      pip install ../mllm
     path: ../mllm/benchmark_script.py
     inputs:
       text: llm/text

--- a/benches/mllm/pyproject.toml
+++ b/benches/mllm/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "dora-bench"
+version = "0.1.0"
+description = "Script to benchmark performance of llms while using dora"
+authors = [{ name = "Haixuan Xavier Tao", email = "tao.xavier@outlook.com" }]
+license = { text = "MIT" }
+readme = "README.md"
+requires-python = ">=3.11"
+
+dependencies = [
+    "dora-rs>=0.3.9",
+    "librosa>=0.10.0",
+    "opencv-python>=4.8",
+    "Pillow>=10",
+]
+
+[project.scripts]
+dora-benches = "benchmark_script.main:main"
+
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Added a build command in llms yaml file to automatically install libraries needed to run benchmark_script.py useful for beginners and cases where you have freshly cloned the project and a python virtual environment has not been setup with the necessary dependencies to run the benchmark_script