### PR TITLE
Improve benchmark implementation & Add warning for discarding events

### DIFF
--- a/apis/rust/node/src/event_stream/scheduler.rs
+++ b/apis/rust/node/src/event_stream/scheduler.rs
@@ -54,7 +54,7 @@ impl Scheduler {
         if let Some((size, queue)) = self.event_queues.get_mut(event_id) {
             // Remove the oldest event if at limit
             if &queue.len() >= size {
-                tracing::warn!("Discarding event for input `{event_id}` due to queue size limit");
+                tracing::debug!("Discarding event for input `{event_id}` due to queue size limit");
                 queue.pop_front();
             }
             queue.push_back(event);

--- a/apis/rust/node/src/event_stream/scheduler.rs
+++ b/apis/rust/node/src/event_stream/scheduler.rs
@@ -54,6 +54,7 @@ impl Scheduler {
         if let Some((size, queue)) = self.event_queues.get_mut(event_id) {
             // Remove the oldest event if at limit
             if &queue.len() >= size {
+                tracing::warn!("Discarding event for input `{event_id}` due to queue size limit");
                 queue.pop_front();
             }
             queue.push_back(event);

--- a/examples/benchmark/dataflow.yml
+++ b/examples/benchmark/dataflow.yml
@@ -11,4 +11,6 @@ nodes:
     path: ../../target/release/benchmark-example-sink
     inputs:
       latency: rust-node/latency
-      throughput: rust-node/throughput
+      throughput:
+        source: rust-node/throughput
+        queue_size: 1000

--- a/examples/benchmark/sink/src/main.rs
+++ b/examples/benchmark/sink/src/main.rs
@@ -24,7 +24,8 @@ fn main() -> eyre::Result<()> {
                 // check if new size bracket
                 let data_len = data.len();
                 if data_len != current_size {
-                    if n > 0 {
+                    // data of length 1 is used to sync
+                    if n > 0 && current_size != 1 {
                         record_results(start, current_size, n, latencies, latency);
                     }
                     current_size = data_len;
@@ -62,8 +63,6 @@ fn main() -> eyre::Result<()> {
             other => eprintln!("Received unexpected input: {other:?}"),
         }
     }
-
-    record_results(start, current_size, n, latencies, latency);
 
     Ok(())
 }


### PR DESCRIPTION
Resolves #966

This PR improves current benchmark implementation by increasing the queue size for throughput testing, and adding time gap between throughput tests of different sizes to ensure accurate measurement.

Besides, a warning message will be logged now on discarding events due to queue size limit.