### PR TITLE
Fix rerun-viewer example.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,6 +182,10 @@ name = "cxx-ros2-dataflow"
 path = "examples/c++-ros2-dataflow/run.rs"
 required-features = ["ros2-examples"]
 
+[[example]]
+name = "rerun-viewer"
+path = "examples/rerun-viewer/run.rs"
+
 # The profile that 'dist' will build with
 [profile.dist]
 inherits = "release"

--- a/examples/rerun-viewer/dataflow.yml
+++ b/examples/rerun-viewer/dataflow.yml
@@ -14,7 +14,7 @@ nodes:
 
   - id: rerun
     build: cargo build -p dora-rerun --release
-    path: dora-rerun
+    path: ../../target/release/dora-rerun
     inputs:
       image: camera/image
     env:

--- a/examples/rerun-viewer/run.rs
+++ b/examples/rerun-viewer/run.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
-    set_up_tracing("python-dataflow-runner")?;
+    set_up_tracing("rerun-viewer-runner")?;
 
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
     std::env::set_current_dir(root.join(file!()).parent().unwrap())
@@ -13,18 +13,24 @@ async fn main() -> eyre::Result<()> {
 
     let uv = get_uv_path().context("Could not get uv binary")?;
 
-    run(&uv, &["venv", "-p", "3.10", "--seed"], None)
+    run(&uv, &["venv", "-p", "3.11", "--seed"], None)
         .await
         .context("failed to create venv")?;
     run(
         &uv,
-        &["pip", "install", "-e", "../../apis/python/node", "--reinstall"],
+        &[
+            "pip",
+            "install",
+            "-e",
+            "../../apis/python/node",
+            "--reinstall",
+        ],
         None,
     )
     .await
     .context("Unable to install develop dora-rs API")?;
 
-    let dataflow = Path::new("qwen2-5-vl-vision-only-dev.yml");
+    let dataflow = Path::new("dataflow.yml");
     run_dataflow(dataflow).await?;
 
     Ok(())


### PR DESCRIPTION
### Summary

This example had two issues:
 - the path to the dora rerun executable in the dataflow file was wrongly set
 - it wasn't able to be run via cargo run command (only using uv installation + dora build + dora run)

### Test it
via cargo run:

`cargo run --example rerun-viewer`

via uv setup:
```
uv venv -p 3.11 --seed
uv pip install -e ../../apis/python/node --reinstall
dora build dataflow.yml --uv
dora run dataflow.yml --uv
```