### PR TITLE
Refactor Python CUDA IPC API

### DIFF
--- a/apis/python/node/dora/cuda.py
+++ b/apis/python/node/dora/cuda.py
@@ -8,13 +8,19 @@ from numba.cuda import to_device
 
 # Make sure to install numba with cuda
 from numba.cuda.cudadrv.devicearray import DeviceNDArray
+from numba.cuda.cudadrv.devices import get_context
+from numba.cuda.cudadrv.driver import IpcHandle
 
-# To install pyarrow.cuda, run `conda install pyarrow "arrow-cpp-proc=*=cuda" -c conda-forge`
-from pyarrow import cuda
+
+import pickle
+
+from contextlib import contextmanager
+from typing import ContextManager
 
 
 def torch_to_ipc_buffer(tensor: torch.TensorType) -> tuple[pa.array, dict]:
-    """Convert a Pytorch tensor into a pyarrow buffer containing the IPC handle and its metadata.
+    """Convert a Pytorch tensor into a pyarrow buffer containing the IPC handle
+    and its metadata.
 
     Example Use:
     ```python
@@ -24,75 +30,56 @@ def torch_to_ipc_buffer(tensor: torch.TensorType) -> tuple[pa.array, dict]:
     ```
     """
     device_arr = to_device(tensor)
-    cuda_buf = pa.cuda.CudaBuffer.from_numba(device_arr.gpu_data)
-    handle_buffer = cuda_buf.export_for_ipc().serialize()
+    ipch = get_context().get_ipc_handle(device_arr.gpu_data)
     metadata = {
         "shape": device_arr.shape,
         "strides": device_arr.strides,
         "dtype": device_arr.dtype.str,
     }
-    return pa.array(handle_buffer, type=pa.uint8()), metadata
+    return pa.array(pickle.dumps(ipch), type=pa.uint8()), metadata
 
 
-def ipc_buffer_to_ipc_handle(handle_buffer: pa.array) -> cuda.IpcMemHandle:
-    """Convert a buffer containing a serialized handler into cuda IPC MemHandle.
+def ipc_buffer_to_ipc_handle(handle_buffer: pa.array) -> IpcHandle:
+    """Convert a buffer containing a serialized handler into cuda IPC Handle.
 
     example use:
     ```python
+    from dora.cuda import ipc_buffer_to_ipc_handle, open_ipc_handle
 
-    import pyarrow as pa
-    from dora.cuda import ipc_buffer_to_ipc_handle, cudabuffer_to_torch
-
-    ctx = pa.cuda.context()
     event = node.next()
 
     ipc_handle = ipc_buffer_to_ipc_handle(event["value"])
-    cudabuffer = ctx.open_ipc_buffer(ipc_handle)
-    torch_tensor = cudabuffer_to_torch(cudabuffer, event["metadata"])  # on cuda
+    with open_ipc_handle(ipc_handle, event["metadata"]) as tensor:
+        pass
     ```
     """
     handle_buffer = handle_buffer.buffers()[1]
-    return pa.cuda.IpcMemHandle.from_buffer(handle_buffer)
+    return pickle.loads(handle_buffer.to_pybytes())
 
 
-def cudabuffer_to_numba(buffer: cuda.CudaBuffer, metadata: dict) -> DeviceNDArray:
-    """Convert a pyarrow CUDA buffer to numba.
+@contextmanager
+def open_ipc_handle(
+    ipc_handle: IpcHandle, metadata: dict
+) -> ContextManager[torch.TensorType]:
+    """Open a CUDA IPC handle and return a Pytorch tensor.
 
     example use:
     ```python
+    from dora.cuda import ipc_buffer_to_ipc_handle, open_ipc_handle
 
-    import pyarrow as pa
-    from dora.cuda import ipc_buffer_to_ipc_handle, cudabuffer_to_torch
-
-    ctx = pa.cuda.context()
     event = node.next()
 
     ipc_handle = ipc_buffer_to_ipc_handle(event["value"])
-    cudabuffer = ctx.open_ipc_buffer(ipc_handle)
-    numba_tensor = cudabuffer_to_numbda(cudabuffer, event["metadata"])
+    with open_ipc_handle(ipc_handle, event["metadata"]) as tensor:
+        pass
     ```
     """
     shape = metadata["shape"]
     strides = metadata["strides"]
     dtype = metadata["dtype"]
-    return DeviceNDArray(shape, strides, dtype, gpu_data=buffer.to_numba())
-
-
-def cudabuffer_to_torch(buffer: cuda.CudaBuffer, metadata: dict) -> torch.Tensor:
-    """Convert a pyarrow CUDA buffer to a torch tensor.
-
-    example use:
-    ```python
-
-    import pyarrow as pa
-    from dora.cuda import ipc_buffer_to_ipc_handle, cudabuffer_to_torch
-
-    ctx = pa.cuda.context()
-    event = node.next()
-
-    ipc_handle = ipc_buffer_to_ipc_handle(event["value"])
-    cudabuffer = ctx.open_ipc_buffer(ipc_handle)
-    torch_tensor = cudabuffer_to_torch(cudabuffer, event["metadata"])  # on cuda
-    ```
-    """
-    return torch.as_tensor(cudabuffer_to_numba(buffer, metadata), device="cuda")
+    try:
+        buffer = ipc_handle.open(get_context())
+        device_arr = DeviceNDArray(shape, strides, dtype, gpu_data=buffer)
+        yield torch.as_tensor(device_arr, device="cuda")
+    finally:
+        ipc_handle.close()

--- a/examples/cuda-benchmark/demo_receiver.py
+++ b/examples/cuda-benchmark/demo_receiver.py
@@ -49,7 +49,7 @@ while True:
             torch_tensor = torch.tensor(handle, device="cuda")
         else:
             # AFTER
-            ipc_handle = ipc_buffer_to_ipc_handle(event["value"])
+            ipc_handle = ipc_buffer_to_ipc_handle(event["value"], event["metadata"])
             scope = open_ipc_handle(ipc_handle, event["metadata"])
             torch_tensor = scope.__enter__()
     else:

--- a/examples/cuda-benchmark/demo_receiver.py
+++ b/examples/cuda-benchmark/demo_receiver.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 """TODO: Add docstring."""
 
-
 import os
 import time
 
@@ -9,7 +8,7 @@ import numpy as np
 import pyarrow as pa
 import torch
 from dora import Node
-from dora.cuda import cudabuffer_to_torch, ipc_buffer_to_ipc_handle
+from dora.cuda import ipc_buffer_to_ipc_handle, open_ipc_handle
 from helper import record_results
 from tqdm import tqdm
 
@@ -17,7 +16,6 @@ torch.tensor([], device="cuda")
 
 
 pa.array([])
-context = pa.cuda.Context()
 node = Node("node_2")
 
 current_size = 8
@@ -28,8 +26,6 @@ mean_cpu = mean_cuda = 0
 DEVICE = os.getenv("DEVICE", "cuda")
 
 NAME = f"dora torch {DEVICE}"
-
-ctx = pa.cuda.Context()
 
 print()
 print("Receiving 40MB packets using default dora-rs")
@@ -49,13 +45,13 @@ while True:
         if event["metadata"]["device"] != "cuda":
             # BEFORE
             handle = event["value"].to_numpy()
+            scope = None
             torch_tensor = torch.tensor(handle, device="cuda")
         else:
             # AFTER
-            # storage needs to be spawned in the same file as where it's used. Don't ask me why.
             ipc_handle = ipc_buffer_to_ipc_handle(event["value"])
-            cudabuffer = ctx.open_ipc_buffer(ipc_handle)
-            torch_tensor = cudabuffer_to_torch(cudabuffer, event["metadata"])  # on cuda
+            scope = open_ipc_handle(ipc_handle, event["metadata"])
+            torch_tensor = scope.__enter__()
     else:
         break
     t_received = time.perf_counter_ns()
@@ -73,6 +69,9 @@ while True:
         latencies = []
     n += 1
 
+    if scope:
+        scope.__exit__(None, None, None)
+
 
 mean_cuda = np.array(latencies).mean()
 pbar.close()
@@ -81,9 +80,9 @@ time.sleep(2)
 
 print()
 print("----")
-print(f"Node communication duration with default dora-rs: {mean_cpu/1000:.1f}ms")
-print(f"Node communication duration with dora CUDA->CUDA: {mean_cuda/1000:.1f}ms")
+print(f"Node communication duration with default dora-rs: {mean_cpu / 1000:.1f}ms")
+print(f"Node communication duration with dora CUDA->CUDA: {mean_cuda / 1000:.1f}ms")
 
 print("----")
-print(f"Speed Up: {(mean_cpu)/(mean_cuda):.0f}")
+print(f"Speed Up: {(mean_cpu) / (mean_cuda):.0f}")
 record_results(NAME, current_size, latencies)

--- a/examples/cuda-benchmark/receiver.py
+++ b/examples/cuda-benchmark/receiver.py
@@ -39,7 +39,7 @@ while True:
             scope = None
         else:
             # AFTER
-            ipc_handle = ipc_buffer_to_ipc_handle(event["value"])
+            ipc_handle = ipc_buffer_to_ipc_handle(event["value"], event["metadata"])
             scope = open_ipc_handle(ipc_handle, event["metadata"])
             torch_tensor = scope.__enter__()
     else:


### PR DESCRIPTION
As noted in #978, the current Python CUDA IPC API fails when sending specific tensors.

My investigation suggests that `pyarrow.cuda` (used by `dora.cuda`), is likely the source of this failure. During testing with two processes (sender and receiver), the receiver receives `pyarrow.CudaBuffer` with corrupted content, and it appears that there's nothing we can do about this.

However, I found that the `numba.cuda` module is a suitable alternative for implementing CUDA IPC. As we already depend on `numba`, no new dependencies are introduced. I have refactored the API to use `numba.cuda`, and it has passed the tests proposed in #978.

Example & docstrings are updated accordingly.

**Note**: this change is not backward compatible.