### PR TITLE
dora_tcp

### DIFF
--- a/node-hub/dora-tcp/README.md
+++ b/node-hub/dora-tcp/README.md
@@ -1,0 +1,34 @@
+# dora-tcp
+
+Basic TCP Implementation for streaming data to a TCP Destination. 
+
+
+## Getting Started
+Copy the node to your dora project and build it
+
+
+Example:
+- Streaming drive commands to a Unity simulation hosting a TCP server.
+
+Example dataflow.yml
+```shell
+nodes:
+  - id: drive_director
+    build: cargo build -p drive_director
+    path: target/debug/drive_director
+    inputs:
+      tick: dora/timer/millis/100
+    outputs:
+      - command
+  - id: dora-tcp
+    build: cargo build -p dora-tcp
+    path: target/debug/dora-tcp
+    inputs:
+      command: drive_director/command
+```
+
+## Input definition
+
+- command: String
+
+Note: I used a colon to separate the commands ie drive:10 but you can modify as needed.

--- a/node-hub/dora-tcp/cargo.toml
+++ b/node-hub/dora-tcp/cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "dora-tcp"
+version.workspace = true
+edition.workspace = true
+documentation.workspace = true
+description.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+dora-node-api = { workspace = true }
+tokio = { version = "1.45.0", features = ["full"] }

--- a/node-hub/dora-tcp/src/lib.rs
+++ b/node-hub/dora-tcp/src/lib.rs
@@ -1,0 +1,40 @@
+/*
+    Basic TCP implementation for streaming events to a TCP Destination
+*/
+use dora_node_api::{DoraNode, Event};
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpStream;
+use std::error::Error;
+
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+
+    // NOTE: Hard-coded address
+    let mut stream = TcpStream::connect("localhost:8052").await?;
+
+    let (_, mut events) = DoraNode::init_from_env()?;
+
+    while let Some(event) = events.recv() {
+        match event {
+            Event::Input {
+                id,
+                metadata: _,
+                data,
+            } => match id.as_str() {
+                "command" => {
+                    
+                    // Extract the command
+                    let command: &str = (&data).try_into()?;
+
+                    // Send the command to the Unity over tcp
+                    stream.write_all(command.as_bytes()).await?;
+                },
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Adding an example of a dora node that sends data over TCP. This is useful for simulation/visualization engines like Unity & Unreal Engine that can manage a TCP server.