### PR TITLE
Add teleop and gampad control for so101 arm

### DIFF
--- a/examples/so101/Readme.md
+++ b/examples/so101/Readme.md
@@ -1,0 +1,146 @@
+# SO-101 Robotic Arm Control with Dora-rs
+
+This project provides gamepad control and leader-follower functionality for the SO-101 robotic arm using the Dora-rs framework. It includes real-time inverse kinematics, gripper control, and 3D visualization through Rerun.
+
+## Features
+
+- **Gamepad Control**: Real-time control of the SO-101 arm using a gamepad controller
+- **Inverse Kinematics**: Differential IK control for smooth end-effector positioning
+- **Gripper Control**: Precise gripper operation with button controls
+- **3D Visualization**: Real-time robot visualization using Rerun
+- **Leader-Follower Mode**: Map one arm's pose to control another arm
+- **Speed Scaling**: Adjustable movement speed with gamepad bumpers
+
+## Prerequisites
+
+- Python 3.8+
+- Dora-rs framework
+- Compatible gamepad controller
+- SO-101 robotic arm(s) with serial connection
+
+## Installation
+
+### 1. Install Dependencies
+
+install the required Python packages for rerun visualization (optional):
+
+```bash
+# Install the URDF loader for Rerun visualization
+pip install git+https://github.com/dora-rs/rerun-loader-python-urdf
+```
+### 2. Download URDF Files
+
+The URDF files and assets for So-arm 101 can be downloaded from here:
+
+```bash
+# Use this cmd in the terminal to download the assets 
+git clone --depth 1 https://huggingface.co/datasets/SGPatil/so_arm_101 && mv so_arm_101/SO101 . && rm -rf so_arm_101
+```
+
+
+### 3. Hardware Setup
+
+1. Connect your SO-101 arm(s) to your computer via USB/serial
+2. Note the serial port names (e.g.,for linux `/dev/ttyACM0`, `/dev/ttyACM1`)
+3. Connect your gamepad controller
+4. Update the `PORT` environment variables in the YAML files
+
+## Usage
+
+### Single Arm Control (arm.yml)
+
+Control a single SO-101 arm with gamepad input and visualization:
+
+```bash
+dora build arm.yml
+dora run arm.yml
+```
+
+This dataflow includes:
+- **Gamepad input** for real-time control using [gamepad node](https://github.com/dora-rs/dora/tree/add-robot-descriptions/node-hub/gamepad)
+- **Inverse kinematics controller** for smooth movement
+- **Physical arm interface** via serial communication via `dora-rustypot` node
+- **3D visualization** in Rerun
+
+### Leader-Follower Mode (leader.yml)
+
+Use one arm as a leader to control another follower arm:
+
+```bash
+dora build leader.yml
+dora run leader.yml
+```
+
+This dataflow includes:
+- **Leader arm** (manual control)
+- **Follower arm** (mirrors leader movements)
+- **3D visualization** of the follower arm
+
+## Gamepad Controls
+
+### Movement Controls
+> NOTE: the mapping may differ based your controller.
+- **D-pad**: Move end-effector in X-Y plane
+- **Right Stick**: Move end-effector in Z axis and rotate around Z (yaw)
+
+### Gripper Controls
+- **Button A**: Open gripper (increase angle)
+- **Button B**: Close gripper (decrease angle)
+- Gripper range: 0° (closed) to 95° (fully open)
+
+### Speed Controls
+- **Left Bumper (LB)**: Decrease movement speed
+- **Right Bumper (RB)**: Increase movement speed
+- Speed range: 0.1x to 1.0x
+
+## Configuration
+
+### Serial Port Configuration
+
+Update the `PORT` environment variable in the YAML files:
+
+```yaml
+env:
+  PORT: /dev/ttyACM0  # Change to your actual port
+  IDS: 1 2 3 4 5 6    # Servo IDs
+```
+
+### URDF Path Configuration
+
+Ensure the URDF path is correct in the configuration:
+
+```yaml
+env:
+  URDF_PATH: SO101/so101_new_calib.urdf # make sure this path is correct
+  so101_new_calib_urdf: SO101/so101_new_calib.urdf
+```
+
+## Control Parameters
+
+The controller includes several tunable parameters in `so_101_controller.py`:
+
+- `Kpos`: Position gain (default: 0.95)
+- `Kori`: Orientation gain (default: 0.95)
+- `damping`: IK damping factor (default: 1e-4)
+- `max_angvel`: Maximum joint velocity (default: 1.57 rad/s)
+- `gripper_rate`: Gripper movement rate (default: 5.0 deg/s)
+
+## Troubleshooting
+
+### Serial Connection Issues
+- Check that the arm is powered on and connected
+- Verify the correct serial port in the YAML configuration
+- Ensure proper permissions: `sudo usermod -a -G dialout $USER`
+
+### Gamepad Not Detected
+- Verify gamepad is connected and recognized by the system
+- Test with `jstest /dev/input/js0` (Linux)
+
+### URDF Loading Errors
+- Ensure all URDF files and mesh assets are in the correct location
+- Verify the installation of `rerun-loader-python-urdf` plugin
+
+## Safety Notes
+
+- Always ensure the arm has sufficient clearance before operation
+- Keep the emergency stop (if available) within reach

--- a/examples/so101/arm.yml
+++ b/examples/so101/arm.yml
@@ -1,0 +1,62 @@
+nodes:
+  - id: gamepad
+    build: pip install -e ../../node-hub/gamepad
+    path: gamepad
+    outputs:
+      - cmd_vel
+      - raw_control
+    inputs:
+      tick: dora/timer/millis/10
+
+  - id: arm_interface
+    build: pip install -e ../../node-hub/dora-rustypot
+    path: dora-rustypot
+    inputs:
+      tick: dora/timer/millis/10
+      pose: gamepad_controller/joint_commands
+    outputs:
+      - pose
+    env:
+      PORT: /dev/ttyACM0
+      IDS: 1 2 3 4 5 6
+
+  - id: gamepad_controller
+    path: nodes/so_101_controller.py
+    inputs:
+      joint_positions: arm_interface/pose
+      raw_control: gamepad/raw_control
+      cmd_vel: gamepad/cmd_vel
+      fk_result: pytorch_kinematics/fk_request
+      jacobian_result: pytorch_kinematics/jacobian_request
+    outputs:
+      - joint_commands
+      - fk_request
+      - jacobian_request
+
+  - id: pytorch_kinematics
+    build: pip install -e ../../node-hub/dora-pytorch-kinematics
+    path: dora-pytorch-kinematics
+    inputs:
+      fk_request: gamepad_controller/fk_request
+      jacobian_request: gamepad_controller/jacobian_request
+    outputs:
+      - fk_request  
+      - jacobian_request  
+    env:
+      URDF_PATH: SO101/so101_new_calib.urdf
+      END_EFFECTOR_LINK: "gripper"  
+      TRANSFORM: "0. 0. 0. 1. 0. 0. 0."
+
+  - id: plot
+    build: pip install -e ../../node-hub/dora-rerun
+    path: dora-rerun
+    inputs:
+      jointstate_so101_new_calib: arm_interface/pose
+      # camera/image: camera/image
+      # camera/depth: camera/depth
+    env:
+      # Link to your installation of so100-urdf.
+      # https://huggingface.co/datasets/haixuantao/urdfs/resolve/main/so100/so100_urdf.zip
+      so101_new_calib_urdf:  SO101/so101_new_calib.urdf
+      so101_new_calib_transform: "0. 0. 0. 1. 0. 0. 0."
+      # CAMERA_PITCH: -3.1415

--- a/examples/so101/leader.yml
+++ b/examples/so101/leader.yml
@@ -1,0 +1,41 @@
+nodes:
+  - id: gamepad
+    build: pip install -e ../../node-hub/gamepad
+    path: gamepad
+    outputs:
+      - cmd_vel
+      - raw_control
+    inputs:
+      tick: dora/timer/millis/10
+
+  - id: arm_interface
+    build: pip install -e ../../node-hub/dora-rustypot
+    path: dora-rustypot
+    inputs:
+      tick: dora/timer/millis/10
+      pose: leader_interface/pose
+    outputs:
+      - pose
+    env:
+      PORT: /dev/ttyACM0
+      IDS: 1 2 3 4 5 6
+
+  - id: leader_interface
+    build: pip install -e ../../node-hub/dora-rustypot
+    path: dora-rustypot
+    inputs:
+      tick: dora/timer/millis/10
+    outputs:
+      - pose  
+    env:
+      PORT: /dev/ttyACM1
+      IDS: 1 2 3 4 5 6
+
+  - id: plot
+    build: pip install -e ../../node-hub/dora-rerun
+    path: dora-rerun
+    inputs:
+      jointstate_so101_new_calib: arm_interface/pose
+    env:
+      so101_new_calib_urdf:  SO101/so101_new_calib.urdf
+      so101_new_calib_transform: "0. 0. 0. 1. 0. 0. 0."

--- a/examples/so101/nodes/so_101_controller.py
+++ b/examples/so101/nodes/so_101_controller.py
@@ -1,0 +1,224 @@
+import json
+import time
+import numpy as np
+import pyarrow as pa
+from dora import Node
+from scipy.spatial.transform import Rotation
+
+class GamepadController:
+    def __init__(self):
+        # Control parameters
+        self.integration_dt = 0.1
+        self.damping = 1e-4
+        self.Kpos = 0.95  # Position gain
+        self.Kori = 0.95  # Orientation gain
+
+        # Gamepad control parameters
+        self.speed_scale = 0.5
+        self.max_angvel = 1.57 * self.speed_scale  # Max joint velocity (rad/s)
+        
+        # Robot state variables
+        self.dof = None
+        self.current_joint_pos = None  # Full robot state
+        self.home_pos = None  # Home position for arm joints only
+        
+        # Target pose (independent of DOF)
+        self.target_pos = np.array([0.0, -0.2, 0.15])  # Conservative default target
+        self.target_rpy = [0.0, 0.0, 0.0]  # Downward orientation
+        
+        # Gripper control (0° = closed, 95° = fully open)
+        self.gripper_position = 0.0  # Current gripper position in degrees
+        self.gripper_rate = 5.0  
+        
+        # Cache for external computations
+        self.current_ee_pose = None  # End-effector pose
+        self.current_jacobian = None  # Jacobian matrix
+        
+        print("Gamepad Controller initialized")
+    
+    def _initialize_robot(self, positions, jacobian_dof=None):
+        self.full_joint_count = len(positions)
+        self.dof = jacobian_dof if jacobian_dof is not None else self.full_joint_count
+        self.current_joint_pos = positions.copy()
+        self.home_pos = np.zeros(self.dof)
+    
+    def process_cmd_vel(self, cmd_vel):
+        # print(f"Processing cmd_vel: {cmd_vel}")
+        
+        # Position control (first 3 elements)
+        delta_pos = cmd_vel[:3] * 0.03 * self.speed_scale
+        dy, dx, dz = delta_pos
+        
+        # Update target position incrementally
+        if abs(dx) > 0 or abs(dy) > 0 or abs(dz) > 0:
+            self.target_pos += np.array([-dx, -dy, dz])
+        
+        # Orientation control (last 3 elements) - convert to degrees
+        delta_rpy = cmd_vel[3:6] * 5.0 * self.speed_scale  # Scale factor for rotation (degrees)
+        droll, dpitch, dyaw = delta_rpy
+        
+        # Update target orientation incrementally (in degrees)
+        self.target_rpy[0] += droll   # Roll
+        self.target_rpy[1] += dpitch  # Pitch  
+        self.target_rpy[2] += dyaw    # Yaw
+        
+        # Keep angles in reasonable range (-180 to 180 degrees)
+        self.target_rpy = [(angle + 180) % 360 - 180 for angle in self.target_rpy]
+        
+        # print(f"Updated target position: {self.target_pos}, target orientation (RPY degrees): {self.target_rpy}")
+    
+    def process_gamepad_input(self, raw_control):
+        buttons = raw_control["buttons"]
+
+        # Speed scaling with bumpers (LB/RB)
+        if len(buttons) > 4 and buttons[4]:  # LB
+            self.speed_scale = max(0.1, self.speed_scale - 0.1)
+            print(f"Speed: {self.speed_scale:.1f}")
+        if len(buttons) > 5 and buttons[5]:  # RB
+            self.speed_scale = min(1.0, self.speed_scale + 0.1)
+            print(f"Speed: {self.speed_scale:.1f}")
+        
+        # Button A  - Open gripper (increase angle)
+        if buttons[1]:
+            self.gripper_position += self.gripper_rate * self.integration_dt
+            
+        # Button B - Close gripper (decrease angle)
+        if buttons[2]:
+            self.gripper_position -= self.gripper_rate * self.integration_dt
+            
+        # Clamp gripper position to valid range (0° = closed, 95° = fully open)
+        self.gripper_position = np.clip(self.gripper_position, 0.0, 95.0)
+
+    def get_target_rotation_matrix(self):
+        roll_rad, pitch_rad, yaw_rad = np.radians(self.target_rpy)
+        desired_rot = Rotation.from_euler('ZYX', [yaw_rad, pitch_rad, roll_rad])
+        return desired_rot.as_matrix()
+    
+    def update_jacobian(self, jacobian_flat, shape):
+        jacobian_dof = shape[1]
+        self.current_jacobian = jacobian_flat.reshape(shape)
+
+        if self.dof is None:
+            if self.current_joint_pos is not None:
+                self._initialize_robot(self.current_joint_pos, jacobian_dof)
+            else:
+                self.dof = jacobian_dof
+        elif self.dof != jacobian_dof:
+            self.dof = jacobian_dof
+            self.home_pos = np.zeros(self.dof)
+    
+    def apply_differential_ik_control(self):
+        # Return current position if no data available
+        if self.current_ee_pose is None or self.current_jacobian is None:
+            if self.current_joint_pos is not None:
+                # Update gripper position
+                new_joints = self.current_joint_pos.copy()
+                if len(new_joints) > self.dof:
+                    new_joints[self.dof] = np.radians(self.gripper_position)
+                return new_joints
+            return self.current_joint_pos
+            
+        current_ee_pos = self.current_ee_pose['position']
+        current_ee_rpy = self.current_ee_pose['rpy']
+
+        # print(f"Current EE Position: {current_ee_pos}, RPY: {current_ee_rpy}")
+        # print(f"Updated target position: {self.target_pos}, target orientation (RPY degrees): {self.target_rpy}")
+        pos_error = self.target_pos - current_ee_pos
+        twist = np.zeros(6)
+        twist[:3] = self.Kpos * pos_error / self.integration_dt
+        
+        # Convert current RPY to rotation matrix
+        current_rot = Rotation.from_euler('XYZ', current_ee_rpy)
+        desired_rot = Rotation.from_matrix(self.get_target_rotation_matrix())
+        rot_error = (desired_rot * current_rot.inv()).as_rotvec()
+        twist[3:] = self.Kori * rot_error / self.integration_dt
+        
+        jac = self.current_jacobian
+        
+        # Damped least squares inverse kinematics
+        diag = self.damping * np.eye(6)
+        dq = jac.T @ np.linalg.solve(jac @ jac.T + diag, twist)
+        
+        # # Apply nullspace control
+        current_arm = self.current_joint_pos[:self.dof]
+        jac_pinv = np.linalg.pinv(jac)
+        N = np.eye(self.dof) - jac_pinv @ jac
+        k_null = np.ones(self.dof) * 5.0
+        dq_null = k_null * (self.home_pos - current_arm)
+        dq += N @ dq_null
+        
+        # Limit joint velocities
+        dq_abs_max = np.abs(dq).max()
+        if dq_abs_max > self.max_angvel:
+            dq *= self.max_angvel / dq_abs_max
+            
+        # Create full joint command
+        new_joints = self.current_joint_pos.copy()
+        new_joints[:self.dof] += dq * self.integration_dt
+        new_joints[self.dof] = np.radians(self.gripper_position)
+        
+        return new_joints
+
+
+def main():
+    node = Node()
+    controller = GamepadController()
+    
+    for event in node:
+        if event["type"] == "INPUT":
+            
+            if event["id"] == "joint_positions":
+                # dora-rustypot sends joint positions as Vec<f64>
+                joint_pos = event["value"].to_numpy().astype(np.float64)
+                
+                if controller.current_joint_pos is None:
+                    controller._initialize_robot(joint_pos)
+                else:
+                    controller.current_joint_pos = joint_pos
+                
+                # Request FK computation
+                node.send_output(
+                    "fk_request", 
+                    pa.array(controller.current_joint_pos, type=pa.float32()),
+                    metadata={"encoding": "jointstate", "timestamp": time.time()}
+                )
+                
+                # Request Jacobian computation
+                node.send_output(
+                    "jacobian_request", 
+                    pa.array(controller.current_joint_pos, type=pa.float32()),
+                    metadata={"encoding": "jacobian", "timestamp": time.time()}
+                )
+                
+                # Apply differential IK control
+                joint_commands = controller.apply_differential_ik_control()
+                # Send control commands to the robot
+                node.send_output(
+                    "joint_commands", 
+                    pa.array(joint_commands.astype(np.float64), type=pa.float64()),
+                    metadata={"timestamp": time.time()}
+                )
+                
+            elif event["id"] == "raw_control":
+                raw_control = json.loads(event["value"].to_pylist()[0])
+                controller.process_gamepad_input(raw_control)
+                
+            elif event["id"] == "cmd_vel":
+                cmd_vel = event["value"].to_numpy()
+                controller.process_cmd_vel(cmd_vel)
+            
+            # Handle FK results
+            if event["id"] == "fk_result":
+                if event["metadata"].get("encoding") == "xyzrpy":
+                    ee_pose = event["value"].to_numpy()
+                    controller.current_ee_pose = {'position': ee_pose[:3], 'rpy': ee_pose[3:6]}
+                    
+            # Handle Jacobian results
+            if event["id"] == "jacobian_result":
+                if event["metadata"].get("encoding") == "jacobian_result":
+                    jacobian_flat = event["value"].to_numpy()
+                    jacobian_shape = event["metadata"]["jacobian_shape"]
+                    controller.update_jacobian(jacobian_flat, jacobian_shape)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request introduces setup for controlling the SO-101 robotic arm. 

* Added `arm.yml` for single-arm control, defining nodes for gamepad input, inverse kinematics, and visualization in rerun.
* Added `leader.yml` for leader-follower mode, enabling one arm to control another.