### PR TITLE
Add teleop and gampad control for so101 arm

### DIFF
--- a/examples/so101/Readme.md
+++ b/examples/so101/Readme.md
@@ -1,0 +1,60 @@
+## SO101 Arm Control
+
+This example provides gamepad control and leader-follower functionality for the SO-101 robotic arm.
+
+### Install Dependencies
+
+install the required Python packages for rerun visualization (optional):
+
+```bash
+# Install the URDF loader for Rerun visualization
+pip install git+https://github.com/dora-rs/rerun-loader-python-urdf
+```
+
+### Hardware Setup
+
+1. Connect your SO-101 arm(s) to your computer via USB/serial
+2. Note the serial port names (e.g.,for linux `/dev/ttyACM0`, `/dev/ttyACM1`)
+3. Connect your gamepad controller
+4. Update the `PORT` environment variable in the YAML files
+
+#### Single Arm Control (arm_gamepad_control.yml)
+
+Control a single SO-101 arm with gamepad input and visualization:
+
+```bash
+dora build arm.yml
+dora run arm.yml
+```
+
+#### Leader-Follower Mode (leader_follower.yml)
+
+Use one arm as a leader to control another follower arm:
+
+```bash
+dora build leader.yml
+dora run leader.yml
+```
+
+#### Serial Port Configuration
+
+Update the `PORT` environment variable in the YAML files:
+
+```yaml
+env:
+  PORT: /dev/ttyACM0  # Change to your actual port
+```
+
+## Troubleshooting
+
+### Serial Connection Issues
+- Check that the arm is powered on and connected
+- Verify the correct serial port in the YAML configuration
+- Ensure proper permissions: `sudo chmod +x PORT`
+
+### Gamepad Not Detected
+- Verify gamepad is connected and recognized by the system
+- Test with `jstest /dev/input/js0` (Linux)
+
+## Safety Notes
+- Always ensure the arm has sufficient clearance before operation

--- a/examples/so101/arm_gamepad_control.yml
+++ b/examples/so101/arm_gamepad_control.yml
@@ -1,0 +1,48 @@
+nodes:
+  - id: so101
+    build: pip install -e ../../node-hub/dora-rustypot
+    path: dora-rustypot
+    inputs:
+      tick: dora/timer/millis/10
+      pose: pytorch_kinematics/cmd_vel
+    outputs:
+      - pose
+    env:
+      PORT: /dev/ttyACM0
+      IDS: 1 2 3 4 5
+
+  - id: pytorch_kinematics
+    build: pip install -e ../../node-hub/dora-pytorch-kinematics
+    path: dora-pytorch-kinematics
+    inputs:
+      cmd_vel: gamepad/cmd_vel
+    outputs:
+      - cmd_vel
+    env:
+      MODEL_NAME: "so_arm101_description"
+      END_EFFECTOR_LINK: "gripper"  
+      TRANSFORM: "0. 0. 0. 1. 0. 0. 0."
+      POSITION_TOLERANCE: 0.01
+      ROTATION_TOLERANCE: 0.03
+
+  - id: gamepad
+    build: pip install -e ../../node-hub/gamepad
+    path: gamepad
+    outputs:
+      - cmd_vel
+      - raw_control
+    inputs:
+      tick: dora/timer/millis/10
+    env:
+      MAX_LINEAR_SPEED: 0.01
+      MAX_ANGULAR_SPEED: 0.05
+
+  # comment below path if you don't want to visualize the arm in rerun 
+  - id: plot
+    build: pip install -e ../../node-hub/dora-rerun
+    path: dora-rerun
+    inputs:
+      jointstate_so101_new_calib: pytorch_kinematics/cmd_vel
+    env:
+      so101_new_calib_urdf: "so_arm101_description"
+      so101_new_calib_transform: "0. 0. 0. 1. 0. 0. 0."

--- a/examples/so101/leader_follower.yml
+++ b/examples/so101/leader_follower.yml
@@ -1,0 +1,33 @@
+nodes:
+  - id: so101
+    build: pip install -e ../../node-hub/dora-rustypot
+    path: dora-rustypot
+    inputs:
+      tick: dora/timer/millis/10
+      pose: leader_interface/pose
+    outputs:
+      - pose
+    env:
+      PORT: /dev/ttyACM0
+      IDS: 1 2 3 4 5 6
+
+  - id: leader_interface
+    build: pip install -e ../../node-hub/dora-rustypot
+    path: dora-rustypot
+    inputs:
+      tick: dora/timer/millis/10
+    outputs:
+      - pose  
+    env:
+      PORT: /dev/ttyACM1
+      IDS: 1 2 3 4 5 6
+
+  # comment below path if you don't want to visualize the arms in rerun 
+  - id: plot
+    build: pip install -e ../../node-hub/dora-rerun
+    path: dora-rerun
+    inputs:
+      jointstate_so101_new_calib: so101/pose
+    env:
+      so101_new_calib_urdf: "so_arm101_description"
+      so101_new_calib_transform: "0. 0. 0. 1. 0. 0. 0."


### PR DESCRIPTION
This pull request introduces dataflow for controlling the SO101 arm.

-  Added `arm_gamepad_control.yml` for single-arm control, gamepad input, inverse kinematics, and visualisation in rerun.
-  Added `leader_follower.yml` for leader-follower mode, enabling one arm to control another.

