### PR TITLE
fix: in c++ ros2 example, too few ticks.

### DIFF
--- a/examples/c++-ros2-dataflow/node-rust-api/main.cc
+++ b/examples/c++-ros2-dataflow/node-rust-api/main.cc
@@ -73,7 +73,7 @@ int main()
                 std::cerr << "Unknown event type " << static_cast<int>(ty) << std::endl;
             }
 
-            if (received_ticks > 20)
+            if (received_ticks > 20 && responses_received > 0)
             {
                 break;
             }


### PR DESCRIPTION
It seems that too few ticks to ensure everything work correctly.

The topics and the services still not initialized, the loop has been break and there are no responses from the `add` server.
1000 events counter is considerable for the whole program, while 20 received ticks are not so reasonable.

I'm running on an AMD 6800H Laptop with Ubuntu in Docker, whose performance is totally enough for such a simple example.