### PR TITLE
Fix buffer not printing because it contains legacy ERROR message

### DIFF
--- a/binaries/daemon/src/spawn.rs
+++ b/binaries/daemon/src/spawn.rs
@@ -430,19 +430,6 @@ impl PreparedNode {
                     }
                 };
 
-                if buffer.contains("TRACE")
-                    || buffer.contains("INFO")
-                    || buffer.contains("DEBUG")
-                    || buffer.contains("WARN")
-                    || buffer.contains("ERROR")
-                {
-                    // tracing output, potentially multi-line -> keep reading following lines
-                    // until double-newline
-                    if !buffer.ends_with("\n\n") && !finished {
-                        continue;
-                    }
-                }
-
                 // send the buffered lines
                 let lines = std::mem::take(&mut buffer);
                 let sent = stdout_tx.send(lines.clone()).await;


### PR DESCRIPTION
This fixes #1057 printing where the message contains ERROR and is therefore never printed.