### PR TITLE
Fix weird daemon folder

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -2158,9 +2158,7 @@ impl Daemon {
                 // use subfolder of daemon working dir
                 let daemon_working_dir =
                     current_dir().context("failed to get daemon working dir")?;
-                Ok(daemon_working_dir
-                    .join("_work")
-                    .join(session_id.uuid().to_string()))
+                Ok(daemon_working_dir)
             }
         }
     }


### PR DESCRIPTION
The current working folder when using distributed dora-daemon is a folder that does not exist making it impossible to spawn build command.