### PR TITLE
Revert "Fix weird daemon folder"

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -2158,7 +2158,9 @@ impl Daemon {
                 // use subfolder of daemon working dir
                 let daemon_working_dir =
                     current_dir().context("failed to get daemon working dir")?;
-                Ok(daemon_working_dir)
+                Ok(daemon_working_dir
+                    .join("_work")
+                    .join(session_id.uuid().to_string()))
             }
         }
     }


### PR DESCRIPTION
The working directory deliberatly included the session ID in distributed settings to avoid conflicts when multiple dataflows are run on the same daemon.

The session ID is a unique identifier created for each dataflow.yaml file. By using this ID as part of the working directory, we can ensure that no other dataflow is running in the same directory. Sharing a working directory between multiple distinct dataflows could easily lead to unexpected behavior, e.g. by overwriting files of the other dataflow run. So it's better to avoid this.

By using the session ID, the daemon will still be able to reuse build artifacts etc of previous dataflow runs. So incremental compilation still works.

Reverts dora-rs/dora#1064

