### PR TITLE
Fix: Create working directory if it doesn't exist

### DIFF
--- a/binaries/daemon/src/spawn.rs
+++ b/binaries/daemon/src/spawn.rs
@@ -121,6 +121,8 @@ impl Spawner {
         node_config: NodeConfig,
         node_stderr_most_recent: Arc<ArrayQueue<String>>,
     ) -> eyre::Result<PreparedNode> {
+        std::fs::create_dir_all(&node_working_dir)
+            .context("failed to create node working directory")?;
         let (command, error_msg) = match &node.kind {
             dora_core::descriptor::CoreNodeKind::Custom(n) => {
                 let mut command =

--- a/libraries/core/src/build/build_command.rs
+++ b/libraries/core/src/build/build_command.rs
@@ -15,6 +15,8 @@ pub fn run_build_command(
     envs: &Option<BTreeMap<String, EnvValue>>,
     stdout_tx: tokio::sync::mpsc::Sender<std::io::Result<String>>,
 ) -> eyre::Result<()> {
+    std::fs::create_dir_all(working_dir).context("failed to create working directory")?;
+
     let lines = build.lines().collect::<Vec<_>>();
     for build_line in lines {
         let mut split = build_line.split_whitespace();


### PR DESCRIPTION
We forgot to create the working directory in a few cases in #901. This PR fixes this by adding the proper `create_dir_all` calls.

Alternative to https://github.com/dora-rs/dora/pull/1064