### PR TITLE
[node-hub] opencv-plot: allow specifying encoding and bbox format in uppercase letters

### DIFF
--- a/node-hub/opencv-plot/opencv_plot/main.py
+++ b/node-hub/opencv-plot/opencv_plot/main.py
@@ -150,7 +150,7 @@ def main():
                 storage = event["value"]
 
                 metadata = event["metadata"]
-                encoding = metadata["encoding"]
+                encoding = metadata["encoding"].lower()
                 width = metadata["width"]
                 height = metadata["height"]
                 if encoding == "bgr8":
@@ -206,7 +206,7 @@ def main():
 
             elif event_id == "bbox":
                 arrow_bbox = event["value"][0]
-                bbox_format = event["metadata"]["format"]
+                bbox_format = event["metadata"]["format"].lower()
 
                 if bbox_format == "xyxy":
                     bbox = arrow_bbox["bbox"].values.to_numpy().reshape(-1, 4)


### PR DESCRIPTION
## Target
opencv-plot on node-hub.

## Problem
Another node on hub like [kornia-v4l-capture](https://github.com/kornia/dora-nodes-hub/tree/main/kornia-v4l-capture) may output encoding in uppercase (e.g. RGB8)

The current code only allows lower case (rgb8) and causes error between kornia-v4l-capture and this node.

## This PR
Take lowercase string for encodings and bbox formats before compairing them.