### PR TITLE
Update `schemars` crate to `v1.0.4`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3012,7 +3012,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "once_cell",
- "schemars",
+ "schemars 1.0.4",
  "serde",
  "serde-with-expand-env",
  "serde_json",
@@ -3130,7 +3130,7 @@ dependencies = [
  "eyre",
  "log",
  "once_cell",
- "schemars",
+ "schemars 1.0.4",
  "semver",
  "serde",
  "serde-with-expand-env",
@@ -6918,7 +6918,7 @@ dependencies = [
  "reqwest",
  "rustc-hash 2.1.1",
  "safetensors",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "serde-big-array",
  "serde_json",
@@ -11956,7 +11956,20 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "either",
- "schemars_derive",
+ "schemars_derive 0.8.22",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive 1.0.4",
  "serde",
  "serde_json",
 ]
@@ -11966,6 +11979,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d020396d1d138dc19f1165df7545479dcd58d93810dc5d646a16e55abefa80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -16312,7 +16337,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "keyed-set",
  "rand 0.8.5",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "token-cell",
  "zenoh-result",

--- a/libraries/core/Cargo.toml
+++ b/libraries/core/Cargo.toml
@@ -24,7 +24,7 @@ uuid = { version = "1.7", features = ["serde", "v7"] }
 tracing = "0.1"
 serde-with-expand-env = "1.1.0"
 tokio = { version = "1.24.1", features = ["fs", "process", "sync", "rt"] }
-schemars = "0.8.19"
+schemars = "1.0.4"
 serde_json = "1.0.117"
 log = { version = "0.4.21", features = ["serde"] }
 dunce = "1.0.5"

--- a/libraries/message/Cargo.toml
+++ b/libraries/message/Cargo.toml
@@ -21,7 +21,7 @@ uuid = { version = "1.7", features = ["serde", "v7"] }
 log = { version = "0.4.21", features = ["serde"] }
 aligned-vec = { version = "0.5.0", features = ["serde"] }
 semver = { version = "1.0.23", features = ["serde"] }
-schemars = "0.8.19"
+schemars = "1.0.4"
 uhlc = "0.5.1"
 serde_yaml = { workspace = true }
 once_cell = "1.13.0"

--- a/libraries/message/src/config.rs
+++ b/libraries/message/src/config.rs
@@ -43,7 +43,7 @@ pub struct Input {
     pub queue_size: Option<usize>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(untagged)]
 pub enum InputDef {
     MappingOnly(InputMapping),


### PR DESCRIPTION
Most important change is https://github.com/GREsau/schemars/pull/310, which keeps newlines unchanged during schema generation. This is important to preserve the lists, markdown code blocks, and markdown headings in our docs.

Note: This PR deliberately does not update the schema file yet in order to test #1083. So it should be merged after #1083.