### PR TITLE
Error if node with `git` field was not built before dataflow start

### DIFF
--- a/libraries/message/src/descriptor.rs
+++ b/libraries/message/src/descriptor.rs
@@ -482,6 +482,15 @@ pub struct ResolvedNode {
     pub kind: CoreNodeKind,
 }
 
+impl ResolvedNode {
+    pub fn has_git_source(&self) -> bool {
+        self.kind
+            .as_custom()
+            .map(|n| n.source.is_git())
+            .unwrap_or_default()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 #[allow(clippy::large_enum_variant)]
@@ -490,6 +499,15 @@ pub enum CoreNodeKind {
     #[serde(rename = "operators")]
     Runtime(RuntimeNode),
     Custom(CustomNode),
+}
+
+impl CoreNodeKind {
+    pub fn as_custom(&self) -> Option<&CustomNode> {
+        match self {
+            CoreNodeKind::Runtime(_) => None,
+            CoreNodeKind::Custom(custom_node) => Some(custom_node),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -638,6 +656,12 @@ pub enum NodeSource {
         repo: String,
         rev: Option<GitRepoRev>,
     },
+}
+
+impl NodeSource {
+    pub fn is_git(&self) -> bool {
+        matches!(self, Self::GitBranch { .. })
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]


### PR DESCRIPTION
The working directory of nodes with git fields is only decided on `dora build` because that's where we translate the branch/tag name into the commit hash.

Before, we fell back to using the base working directory if no build was done. However, this is confusing since the reason for the different working directory is not communicated in any.

This commit throws an error if no build happened before starting a dataflow with git nodes.
