### PR TITLE
Feat/build arg with space

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3838,6 +3838,7 @@ dependencies = [
  "serde-with-expand-env",
  "serde_json",
  "serde_yaml 0.9.34+deprecated",
+ "splitty",
  "tokio",
  "tracing",
  "url",
@@ -14643,6 +14644,12 @@ dependencies = [
  "base64ct",
  "der 0.7.9",
 ]
+
+[[package]]
+name = "splitty"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2db70a1e6827e4d71c655b606caf1346862c38ae52ab4f58c32635e7c7aedd67"
 
 [[package]]
 name = "spm_precompiled"

--- a/libraries/core/Cargo.toml
+++ b/libraries/core/Cargo.toml
@@ -33,3 +33,4 @@ itertools = "0.14"
 url = { version = "2.5.4", optional = true }
 git2 = { workspace = true, optional = true }
 fs_extra = "1.3.0"
+splitty = "1.0.2"

--- a/libraries/core/src/build/build_command.rs
+++ b/libraries/core/src/build/build_command.rs
@@ -19,7 +19,7 @@ pub fn run_build_command(
 
     let lines = build.lines().collect::<Vec<_>>();
     for build_line in lines {
-        let mut split = build_line.split_whitespace();
+        let mut split = splitty::split_unquoted_whitespace(build_line).unwrap_quotes(true);
 
         let program = split
             .next()


### PR DESCRIPTION
Allow argument with space in build command.
This PR is compatible with the old single string command.

```yaml
...
build:
    - exec: program-to-run
    - args:
        - -c
        - cargo build ...
... 
```
