### PR TITLE
Downgrade `opentelemetry` to `v0.29` again in `dora-metrics`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1423,7 +1423,7 @@ dependencies = [
  "rustversion",
  "serde",
  "sync_wrapper",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]
@@ -4080,10 +4080,10 @@ name = "dora-metrics"
 version = "0.3.12"
 dependencies = [
  "eyre",
- "opentelemetry 0.30.0",
+ "opentelemetry 0.29.1",
  "opentelemetry-otlp",
  "opentelemetry-system-metrics",
- "opentelemetry_sdk 0.30.0",
+ "opentelemetry_sdk 0.29.0",
 ]
 
 [[package]]
@@ -6457,7 +6457,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -6573,7 +6573,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -9254,6 +9254,20 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e87237e2775f74896f9ad219d26a2081751187eb7c9f5c58dde20a23b95d16c"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.16",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
@@ -9268,15 +9282,16 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.30.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f6639e842a97dbea8886e3439710ae463120091e2e064518ba8e716e6ac36d"
+checksum = "46d7ab32b827b5b495bd90fa95a6cb65ccc293555dcc3199ae2937d2d237c8ed"
 dependencies = [
  "async-trait",
  "bytes",
  "http 1.3.1",
- "opentelemetry 0.30.0",
+ "opentelemetry 0.29.1",
  "reqwest",
+ "tracing",
 ]
 
 [[package]]
@@ -9297,33 +9312,34 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.30.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
+checksum = "d899720fe06916ccba71c01d04ecd77312734e2de3467fd30d9d580c8ce85656"
 dependencies = [
+ "futures-core",
  "http 1.3.1",
- "opentelemetry 0.30.0",
+ "opentelemetry 0.29.1",
  "opentelemetry-http",
  "opentelemetry-proto",
- "opentelemetry_sdk 0.30.0",
+ "opentelemetry_sdk 0.29.0",
  "prost",
  "reqwest",
  "thiserror 2.0.16",
  "tokio",
- "tonic",
+ "tonic 0.12.3",
  "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.30.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
+checksum = "8c40da242381435e18570d5b9d50aca2a4f4f4d8e146231adb4e7768023309b3"
 dependencies = [
- "opentelemetry 0.30.0",
- "opentelemetry_sdk 0.30.0",
+ "opentelemetry 0.29.1",
+ "opentelemetry_sdk 0.29.0",
  "prost",
- "tonic",
+ "tonic 0.12.3",
 ]
 
 [[package]]
@@ -9369,20 +9385,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.30.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
+checksum = "afdefb21d1d47394abc1ba6c57363ab141be19e27cc70d0e422b7f303e4d290b"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry 0.30.0",
+ "glob",
+ "opentelemetry 0.29.1",
  "percent-encoding",
  "rand 0.9.2",
  "serde_json",
  "thiserror 2.0.16",
  "tokio",
  "tokio-stream",
+ "tracing",
 ]
 
 [[package]]
@@ -10953,7 +10971,7 @@ dependencies = [
  "re_log",
  "serde",
  "thiserror 1.0.69",
- "tonic",
+ "tonic 0.13.1",
 ]
 
 [[package]]
@@ -11349,7 +11367,7 @@ dependencies = [
  "re_log_types",
  "re_protos",
  "tokio-stream",
- "tonic",
+ "tonic 0.13.1",
  "tracing",
  "wasm-bindgen-futures",
 ]
@@ -11477,9 +11495,9 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.13.1",
  "tonic-web-wasm-client",
- "tower",
+ "tower 0.5.2",
  "tracing",
  "url",
  "wasm-bindgen-futures",
@@ -11511,7 +11529,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tonic",
+ "tonic 0.13.1",
  "tonic-web",
  "tower-http",
 ]
@@ -11663,7 +11681,7 @@ dependencies = [
  "re_tuid",
  "serde",
  "thiserror 1.0.69",
- "tonic",
+ "tonic 0.13.1",
  "url",
 ]
 
@@ -11748,7 +11766,7 @@ dependencies = [
  "serde",
  "smallvec",
  "thiserror 1.0.69",
- "tonic",
+ "tonic 0.13.1",
  "url",
 ]
 
@@ -12850,7 +12868,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
- "tower",
+ "tower 0.5.2",
  "tower-http",
  "tower-service",
  "url",
@@ -13775,7 +13793,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-tungstenite 0.27.0",
- "tower",
+ "tower 0.5.2",
  "tracing",
  "ulid",
 ]
@@ -13797,7 +13815,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-tungstenite 0.27.0",
- "tower",
+ "tower 0.5.2",
  "tracing",
  "ulid",
 ]
@@ -15776,6 +15794,32 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
@@ -15799,7 +15843,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -15817,7 +15861,7 @@ dependencies = [
  "http-body 1.0.1",
  "pin-project",
  "tokio-stream",
- "tonic",
+ "tonic 0.13.1",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -15840,12 +15884,32 @@ dependencies = [
  "js-sys",
  "pin-project",
  "thiserror 2.0.16",
- "tonic",
+ "tonic 0.13.1",
  "tower-service",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -15880,7 +15944,7 @@ dependencies = [
  "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]

--- a/libraries/extensions/telemetry/metrics/Cargo.toml
+++ b/libraries/extensions/telemetry/metrics/Cargo.toml
@@ -12,12 +12,12 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-opentelemetry = { version = "0.30.0", features = ["metrics"] }
-opentelemetry-otlp = { version = "0.30.0", features = [
+opentelemetry = { version = "0.29.1", features = ["metrics"] }
+opentelemetry-otlp = { version = "0.29.0", features = [
     "tonic",
     "metrics",
     "grpc-tonic",
 ] }
-opentelemetry_sdk = { version = "0.30.0", features = ["rt-tokio", "metrics"] }
+opentelemetry_sdk = { version = "0.29.0", features = ["rt-tokio", "metrics"] }
 eyre = "0.6.12"
-opentelemetry-system-metrics = { version = "0.4.1" }
+opentelemetry-system-metrics = { version = "0.4.2" }


### PR DESCRIPTION
Version `v0.4.3` of `opentelemetry-system-metrics`, which updated to `opentelemetry v0.30`, was yanked (as it violated semver). This causes some build errors when dataflows/nodes are created through `dora new` because those then use `opentelemetry-system-metrics v0.4.2` again, which requires `opentelemetry v0.29`.

This PR fixes this issue by downgrading the `opentelemetry` dependencies to v0.29 again (until `opentelemetry-system-metrics v0.5` is published).
