### PR TITLE
Use debug logging in CI to debug `uv` lock deadlock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 env:
-  RUST_LOG: INFO
+  RUST_LOG: DEBUG
 
 jobs:
   test:


### PR DESCRIPTION
We often see `uv` hanging at this line https://github.com/astral-sh/uv/blob/d178e453684437889a30b3ffd17e56d695fba60d/crates/uv-fs/src/lib.rs#L677-L680 . By enabling debug output, we can hopefully see where the lock was acquired before.

See https://github.com/dora-rs/dora/issues/1090