### PR TITLE
Fix build command execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 env:
-  RUST_LOG: DEBUG
+  RUST_LOG: INFO
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
 
 env:
-  RUST_LOG: INFO
+  RUST_LOG: DEBUG
 
 jobs:
   test:

--- a/libraries/core/src/build/build_command.rs
+++ b/libraries/core/src/build/build_command.rs
@@ -1,14 +1,13 @@
-use std::{
-    collections::BTreeMap,
-    io::{BufRead, BufReader},
-    path::Path,
-    process::{Command, Stdio},
-};
+use std::{collections::BTreeMap, path::Path, process::Stdio};
 
 use dora_message::descriptor::EnvValue;
 use eyre::{Context, eyre};
+use tokio::{
+    io::{AsyncBufReadExt, BufReader},
+    process::Command,
+};
 
-pub fn run_build_command(
+pub async fn run_build_command(
     build: &str,
     working_dir: &Path,
     uv: bool,
@@ -56,26 +55,28 @@ pub fn run_build_command(
 
         let child_stdout = BufReader::new(child.stdout.take().expect("failed to take stdout"));
         let child_stderr = BufReader::new(child.stderr.take().expect("failed to take stderr"));
-        let stderr_tx = stdout_tx.clone();
         let stdout_tx = stdout_tx.clone();
 
-        std::thread::spawn(move || {
-            for line in child_stdout.lines() {
-                if stdout_tx.blocking_send(line).is_err() {
+        tokio::spawn(async move {
+            let mut stdout_lines = child_stdout.lines();
+            let mut stderr_lines = child_stderr.lines();
+            loop {
+                let line = tokio::select! {
+                    line = stdout_lines.next_line() => line,
+                    line = stderr_lines.next_line() => line,
+                };
+                let Some(line) = line.transpose() else {
                     break;
-                }
-            }
-        });
-        std::thread::spawn(move || {
-            for line in child_stderr.lines() {
-                if stderr_tx.blocking_send(line).is_err() {
+                };
+                if stdout_tx.send(line).await.is_err() {
                     break;
                 }
             }
         });
 
-        let exit_status = cmd
-            .status()
+        let exit_status = child
+            .wait()
+            .await
             .wrap_err_with(|| format!("failed to run `{build}`"))?;
         if !exit_status.success() {
             return Err(eyre!("build command `{build_line}` returned {exit_status}"));

--- a/libraries/core/src/build/mod.rs
+++ b/libraries/core/src/build/mod.rs
@@ -124,8 +124,9 @@ async fn build_node(
     let node_env = node_env.clone();
     let mut logger = logger.try_clone().await.context("failed to clone logger")?;
     let (stdout_tx, mut stdout) = tokio::sync::mpsc::channel(10);
-    let task = tokio::task::spawn_blocking(move || {
+    let task = tokio::spawn(async move {
         run_build_command(&build, &working_dir, uv, &node_env, stdout_tx)
+            .await
             .context("build command failed")
     });
     let stdout_task = tokio::spawn(async move {


### PR DESCRIPTION
## Description

Prior to this PR, `run_build_command` contains wrong implementation which calls `cmd.spawn()` and `cmd.status()` sequentially, and since both invocations execute the command, each build command is **executed twice**. The issue is uncovered during my investigation of issue #1090 .

This PR addresses the issue by replacing `cmd.status()` with `child.wait()`. Additionally, it also changes the process backend from `std` to `tokio` to improve concurrency.

Since the issue has been resolved, #1137 is reverted to reduce verbosity of CI logs.

## Related

Fixes #1090
