### PR TITLE
Replace `names` dependency with `petname` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,10 +972,8 @@ checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags 1.3.2",
- "clap_derive 3.2.25",
  "clap_lex 0.2.4",
  "indexmap 1.9.3",
- "once_cell",
  "strsim 0.10.0",
  "termcolor",
  "textwrap",
@@ -988,7 +986,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
 dependencies = [
  "clap_builder",
- "clap_derive 4.5.47",
+ "clap_derive",
 ]
 
 [[package]]
@@ -1002,19 +1000,6 @@ dependencies = [
  "clap_lex 0.7.5",
  "strsim 0.11.1",
  "terminal_size",
-]
-
-[[package]]
-name = "clap_derive"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
-dependencies = [
- "heck 0.4.1",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1707,7 +1692,7 @@ dependencies = [
  "futures-concurrency",
  "itertools 0.14.0",
  "log",
- "names",
+ "petname",
  "serde_json",
  "tokio",
  "tokio-stream",
@@ -2823,12 +2808,6 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -3967,16 +3946,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "names"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bddcd3bf5144b6392de80e04c347cd7fab2508f6df16a85fc496ecd5cec39bc"
-dependencies = [
- "clap 3.2.25",
- "rand 0.8.5",
-]
-
-[[package]]
 name = "nanorand"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4700,6 +4669,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "petname"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd31dcfdbbd7431a807ef4df6edd6473228e94d5c805e8cf671227a21bad068"
+dependencies = [
+ "anyhow",
+ "clap 4.5.48",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5053,30 +5036,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]

--- a/binaries/coordinator/Cargo.toml
+++ b/binaries/coordinator/Cargo.toml
@@ -25,7 +25,7 @@ tracing = "0.1.36"
 dora-tracing = { workspace = true, optional = true }
 futures-concurrency = "7.1.0"
 serde_json = "1.0.86"
-names = "0.14.0"
+petname = "2.0.2"
 ctrlc = "3.2.5"
 log = { version = "0.4.21", features = ["serde"] }
 dora-message = { workspace = true }

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -27,6 +27,7 @@ use futures::{Future, Stream, StreamExt, future::join_all, stream::FuturesUnorde
 use futures_concurrency::stream::Merge;
 use itertools::Itertools;
 use log_subscriber::LogSubscriber;
+use petname::petname;
 use run::SpawnedDataflow;
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
@@ -471,7 +472,7 @@ async fn start_inner(
                             local_working_dir,
                             uv,
                         } => {
-                            let name = name.or_else(|| names::Generator::default().next());
+                            let name = name.or_else(|| petname(2, "-"));
 
                             let inner = async {
                                 if let Some(name) = name.as_deref() {


### PR DESCRIPTION
The [`names`](https://docs.rs/names/latest/names/) crate is unmaintained (last release was 2022) and has some outdated dependencies.

The [`petname`](https://docs.rs/petname/latest/petname/) crate is more powerful and actively maintained, so let's switch to it.

This PR resolves a security vulnerability by removing the unmaintained `atty` crate from our dependency tree.
