### PR TITLE
expose the node_config method in python's api

### DIFF
--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -235,6 +235,11 @@ impl Node {
         )
     }
 
+    /// Returns the node configuration.
+    pub fn node_config(&mut self, py: Python) -> eyre::Result<PyObject> {
+        Ok(pythonize::pythonize(py, &self.node.get_mut().node_config()).map(|x| x.unbind())?)
+    }
+
     /// Returns the dataflow id.
     ///
     /// :rtype: str


### PR DESCRIPTION
With the node_config method, nodes in python for some bridge works can forward the specific content according to the outputs configuration.