### PR TITLE
Update node hub references

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@
 
 ## Node Hub
 
-The node hub is available in the [**`dora-rs/node-hub`**](https://github.com/dora-rs/node-hub/) repository.
+The node hub is available in the [**`dora-rs/dora-hub`**](https://github.com/dora-rs/dora-hub/) repository.
 
 ## Examples
 

--- a/examples/python-dataflow/dataflow.yml
+++ b/examples/python-dataflow/dataflow.yml
@@ -1,6 +1,6 @@
 nodes:
   - id: camera
-    build: pip install "git+https://github.com/dora-rs/node-hub.git#egg=opencv-video-capture&subdirectory=opencv-video-capture"
+    build: pip install "git+https://github.com/dora-rs/dora-hub.git#egg=opencv-video-capture&subdirectory=node-hub/opencv-video-capture"
     path: opencv-video-capture
     inputs:
       tick: dora/timer/millis/20
@@ -12,7 +12,7 @@ nodes:
       IMAGE_HEIGHT: 480
 
   - id: object-detection
-    build: pip install "git+https://github.com/dora-rs/node-hub.git#egg=dora-yolo&subdirectory=dora-yolo"
+    build: pip install "git+https://github.com/dora-rs/dora-hub.git#egg=dora-yolo&subdirectory=node-hub/dora-yolo"
     path: dora-yolo
     inputs:
       image: camera/image
@@ -20,7 +20,7 @@ nodes:
       - bbox
 
   - id: plot
-    build: pip install "git+https://github.com/dora-rs/node-hub.git#egg=dora-rerun&subdirectory=dora-rerun"
+    build: pip install "git+https://github.com/dora-rs/dora-hub.git#egg=dora-rerun&subdirectory=node-hub/dora-rerun"
     path: dora-rerun
     inputs:
       image: camera/image

--- a/examples/python-dataflow/dataflow_dynamic.yml
+++ b/examples/python-dataflow/dataflow_dynamic.yml
@@ -1,6 +1,6 @@
 nodes:
   - id: camera
-    build: pip install "git+https://github.com/dora-rs/node-hub.git#egg=opencv-video-capture&subdirectory=opencv-video-capture"
+    build: pip install "git+https://github.com/dora-rs/dora-hub.git#egg=opencv-video-capture&subdirectory=node-hub/opencv-video-capture"
     path: opencv-video-capture
     inputs:
       tick: dora/timer/millis/16
@@ -12,7 +12,7 @@ nodes:
       IMAGE_HEIGHT: 480
 
   - id: plot
-    build: pip install "git+https://github.com/dora-rs/node-hub.git#egg=opencv-plot&subdirectory=opencv-plot"
+    build: pip install "git+https://github.com/dora-rs/dora-hub.git#egg=opencv-plot&subdirectory=node-hub/opencv-plot"
     path: dynamic
     inputs:
       image: camera/image


### PR DESCRIPTION
- The repo is now named `dora-hub` instead of `node-hub`
- The node implementations were moved into a `node-hub` subfolder in https://github.com/dora-rs/dora-hub/pull/11
