### PR TITLE
fix: reduce CPU usage by replacing busy loops with blocking/async waits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ members = [
 ]
 
 [workspace.package]
-edition = "2024"
+edition = "2021"
 rust-version = "1.85.0"
 # Make sure to also bump `apis/node/python/__init__.py` version.
 version = "0.3.13"

--- a/binaries/daemon/src/node_communication/mod.rs
+++ b/binaries/daemon/src/node_communication/mod.rs
@@ -303,7 +303,7 @@ impl Listener {
 
     async fn handle_events(&mut self) -> eyre::Result<()> {
         if let Some(events) = &mut self.subscribed_events {
-            while let Ok(event) = events.try_recv() {
+            while let Ok(event) = events.recv().await {
                 self.queue.push_back(Box::new(Some(event)));
             }
         }


### PR DESCRIPTION
constantly checking for new task now code waits for events by  blocking and async receives this  reduces CPU usage while keeping everything working the same