### PR TITLE
Replace warn macro with cargo::warning for build script

### DIFF
--- a/libraries/extensions/ros2-bridge/msg-gen/src/parser/package.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/parser/package.rs
@@ -5,7 +5,6 @@ use std::{
 
 use anyhow::{Context, Result};
 use glob::glob;
-use tracing::warn;
 
 use super::{action::parse_action_file, message::parse_message_file, service::parse_service_file};
 use crate::types::Package;
@@ -19,7 +18,7 @@ fn get_ros_msgs_each_package<P: AsRef<Path>>(root_dirs: &[P]) -> Result<Vec<Pack
     for root_dir in root_dirs {
         if root_dir.as_ref() == Path::new("") {
             let empty_vec: Vec<Package> = vec![];
-            warn!("AMENT_PREFIX_PATH pointed to ''");
+            println!("cargo::warning=AMENT_PREFIX_PATH pointed to ''");
             return Ok(empty_vec);
         }
 
@@ -56,8 +55,8 @@ fn get_ros_msgs_each_package<P: AsRef<Path>>(root_dirs: &[P]) -> Result<Vec<Pack
                 if file_name == "libstatistics_collector" {
                     continue;
                 } else if visited_files.contains(&(package.clone(), file_name.clone())) {
-                    warn!(
-                        "found two versions of package: {:?}, message: {:?}. will skip the one in: {:#?}",
+                    println!(
+                        "cargo::warning=found two versions of package: {:?}, message: {:?}. will skip the one in: {:#?}",
                         package, file_name, path
                     );
                     continue;
@@ -84,10 +83,11 @@ fn get_ros_msgs_each_package<P: AsRef<Path>>(root_dirs: &[P]) -> Result<Vec<Pack
                 }
             }
         }
-        debug_assert!(
-            !map.is_empty(),
-            "it seems that no package was generated from your AMENT_PREFIX_PATH directory"
-        );
+        if map.is_empty() {
+            println!(
+                "cargo::warning=it seems that no package was generated from your AMENT_PREFIX_PATH directory"
+            );
+        }
     }
 
     let mut packages = Vec::new();


### PR DESCRIPTION
Replace a `debug_assert` and `warn` macro in `msg-gen` crate with `println!("cargo::warning=MESSAGE")`

It's no need to stop the whole process when there are some useless path in the AMENT_PREFIX_PATH.
The warn macro cannot display on the terminal when it is in the build script.