### PR TITLE
feat: add progress bars for time-consuming operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,6 +463,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1452,6 +1463,7 @@ version = "0.3.13"
 dependencies = [
  "arrow",
  "arrow-json",
+ "atty",
  "chrono",
  "clap",
  "clap_complete",
@@ -1474,6 +1486,7 @@ dependencies = [
  "eyre",
  "futures",
  "git2",
+ "indicatif",
  "inquire 0.5.3",
  "itertools 0.14.0",
  "log",
@@ -2557,6 +2570,15 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
@@ -3044,7 +3066,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.5.2",
  "libc",
  "windows-sys 0.61.2",
 ]
@@ -3938,7 +3960,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.5.2",
  "libc",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,17 +463,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1463,7 +1452,6 @@ version = "0.3.13"
 dependencies = [
  "arrow",
  "arrow-json",
- "atty",
  "chrono",
  "clap",
  "clap_complete",
@@ -2570,15 +2558,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
@@ -3066,7 +3045,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "libc",
  "windows-sys 0.61.2",
 ]
@@ -3960,7 +3939,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "libc",
 ]
 

--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -58,7 +58,6 @@ ratatui = "0.29.0"
 itertools = "0.14"
 sysinfo = "0.36.1"
 indicatif = "0.17"
-atty = "0.2"
 
 env_logger = "0.11.3"
 self_update = { version = "0.42.0", features = [

--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -57,6 +57,8 @@ crossterm = "0.29.0"
 ratatui = "0.29.0"
 itertools = "0.14"
 sysinfo = "0.36.1"
+indicatif = "0.17"
+atty = "0.2"
 
 env_logger = "0.11.3"
 self_update = { version = "0.42.0", features = [

--- a/binaries/cli/src/command/build/local.rs
+++ b/binaries/cli/src/command/build/local.rs
@@ -119,7 +119,7 @@ impl BuildLogger for LocalBuildLogger {
         let message_str: String = message.into();
         let log_level = level.into();
 
-        // Always print log messages to terminal so users can scroll back
+        // Format the log message with colors
         let level_colored = match log_level {
             LogLevelOrStdout::LogLevel(level) => match level {
                 log::Level::Error => "ERROR ".red(),
@@ -131,7 +131,15 @@ impl BuildLogger for LocalBuildLogger {
             LogLevelOrStdout::Stdout => "stdout".italic().dimmed(),
         };
         let node = self.node_id.to_string().bold().bright_black();
-        println!("{node}: {level_colored}   {message_str}");
+        let formatted_msg = format!("{node}: {level_colored}   {message_str}");
+
+        // Print using MultiProgress::println to keep progress bars pinned at bottom
+        // Falls back to regular println! for non-terminal outputs
+        if let Some(multi) = &self.multi {
+            let _ = multi.println(&formatted_msg);
+        } else {
+            println!("{}", formatted_msg);
+        }
 
         // Also update progress bar message if available
         if let Some(pb) = &self.progress_bar {

--- a/binaries/cli/src/command/completion.rs
+++ b/binaries/cli/src/command/completion.rs
@@ -2,7 +2,6 @@ use clap::{CommandFactory, ValueEnum};
 use clap_complete::Shell;
 
 use crate::command::Executable;
-use sysinfo;
 
 #[derive(Debug, clap::Args)]
 #[command(after_help = r#"

--- a/binaries/cli/src/command/up.rs
+++ b/binaries/cli/src/command/up.rs
@@ -1,6 +1,6 @@
 use super::check::daemon_running;
 use super::{Executable, default_tracing};
-use crate::{LOCALHOST, common::connect_to_coordinator};
+use crate::{LOCALHOST, common::connect_to_coordinator, progress::ProgressBar};
 use dora_core::topics::DORA_COORDINATOR_PORT_CONTROL_DEFAULT;
 use dora_message::{cli_to_coordinator::ControlRequest, coordinator_to_cli::ControlRequestReply};
 use eyre::{Context, ContextCompat, bail};
@@ -28,11 +28,19 @@ struct UpConfig {}
 pub(crate) fn up(config_path: Option<&Path>) -> eyre::Result<()> {
     let UpConfig {} = parse_dora_config(config_path)?;
     let coordinator_addr = (LOCALHOST, DORA_COORDINATOR_PORT_CONTROL_DEFAULT).into();
+
+    let pb = ProgressBar::new_spinner("Starting dora coordinator and daemon...");
+
     let mut session = match connect_to_coordinator(coordinator_addr) {
-        Ok(session) => session,
+        Ok(session) => {
+            pb.set_message("Coordinator already running");
+            session
+        }
         Err(_) => {
+            pb.set_message("Starting coordinator...");
             start_coordinator().wrap_err("failed to start dora-coordinator")?;
 
+            pb.set_message("Waiting for coordinator to accept connections...");
             loop {
                 match connect_to_coordinator(coordinator_addr) {
                     Ok(session) => break session,
@@ -46,8 +54,10 @@ pub(crate) fn up(config_path: Option<&Path>) -> eyre::Result<()> {
     };
 
     if !daemon_running(&mut *session)? {
+        pb.set_message("Starting daemon...");
         start_daemon().wrap_err("failed to start dora-daemon")?;
 
+        pb.set_message("Waiting for daemon to connect...");
         // wait a bit until daemon is connected
         let mut i = 0;
         const WAIT_S: f32 = 0.1;
@@ -57,10 +67,14 @@ pub(crate) fn up(config_path: Option<&Path>) -> eyre::Result<()> {
             }
             i += 1;
             if i > 20 {
+                pb.fail_with_message("Daemon failed to connect");
                 eyre::bail!("daemon not connected after {}s", WAIT_S * i as f32);
             }
             std::thread::sleep(Duration::from_secs_f32(WAIT_S));
         }
+        pb.finish_with_message("Coordinator and daemon started successfully");
+    } else {
+        pb.finish_with_message("Coordinator and daemon already running");
     }
 
     Ok(())

--- a/binaries/cli/src/lib.rs
+++ b/binaries/cli/src/lib.rs
@@ -9,6 +9,7 @@ mod command;
 mod common;
 mod formatting;
 pub mod output;
+pub mod progress;
 pub mod session;
 mod template;
 

--- a/binaries/cli/src/output.rs
+++ b/binaries/cli/src/output.rs
@@ -54,7 +54,7 @@ pub fn print_log_message(
             let node_id = node_id
                 .to_string()
                 .bold()
-                .color(word_to_color(&node_id.to_string()));
+                .color(word_to_color(node_id.as_ref()));
             let padding = if daemon.is_empty() { "" } else { " " };
             format!("{node_id}{padding}{daemon}{colon} ")
         }

--- a/binaries/cli/src/progress.rs
+++ b/binaries/cli/src/progress.rs
@@ -1,0 +1,433 @@
+//! Shared progress bar components for time-consuming CLI operations.
+//!
+//! This module provides a unified interface for displaying progress feedback
+//! across all dora CLI commands using the `indicatif` crate.
+//!
+//! # Design Principles
+//!
+//! - **Unified Style**: All progress bars share consistent styling and behavior
+//! - **Reusable Components**: Common patterns are encapsulated for easy reuse
+//! - **Multi-task Support**: Support for parallel operations with multiple progress bars
+//! - **Graceful Degradation**: Works in environments without TTY support
+//!
+//! # Usage Examples
+//!
+//! ## Simple Progress Bar
+//!
+//! ```rust,ignore
+//! use crate::progress::ProgressBar;
+//!
+//! let pb = ProgressBar::new_spinner("Building nodes...");
+//! // do work...
+//! pb.finish_with_message("Build complete!");
+//! ```
+//!
+//! ## Multi-task Progress
+//!
+//! ```rust,ignore
+//! use crate::progress::MultiProgress;
+//!
+//! let multi = MultiProgress::new();
+//! let pb1 = multi.add_task("Cloning repository...");
+//! let pb2 = multi.add_task("Building node...");
+//! // do work...
+//! pb1.finish();
+//! pb2.finish();
+//! ```
+
+use indicatif::{
+    MultiProgress as IndicatifMultiProgress, ProgressBar as IndicatifProgressBar, ProgressStyle,
+};
+use std::time::Duration;
+
+/// Standard tick rate for spinners (milliseconds)
+const SPINNER_TICK_MS: u64 = 80;
+
+/// Characters used for spinner animation
+const SPINNER_CHARS: &str = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏";
+
+/// Template for spinner-style progress indicators
+const SPINNER_TEMPLATE: &str = "{spinner:.cyan.bold} {msg}";
+
+/// Template for progress bars with percentage
+const PROGRESS_TEMPLATE: &str =
+    "{spinner:.cyan.bold} {msg} [{bar:40.cyan/blue}] {pos}/{len} ({percent}%)";
+
+/// Template for progress bars with bytes
+const BYTES_TEMPLATE: &str =
+    "{spinner:.cyan.bold} {msg} [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({bytes_per_sec})";
+
+/// Template for completed progress bars
+const FINISHED_TEMPLATE: &str = "✓ {msg}";
+
+/// Template for failed progress bars
+const FAILED_TEMPLATE: &str = "✗ {msg}";
+
+/// A progress bar for displaying task progress.
+///
+/// This is a wrapper around `indicatif::ProgressBar` with dora-specific styling.
+pub struct ProgressBar {
+    inner: IndicatifProgressBar,
+}
+
+impl ProgressBar {
+    /// Creates a new spinner-style progress indicator.
+    ///
+    /// Spinners are ideal for tasks where the total work is unknown.
+    ///
+    /// # Arguments
+    ///
+    /// * `message` - The message to display next to the spinner
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let pb = ProgressBar::new_spinner("Processing...");
+    /// // do work...
+    /// pb.finish_with_message("Done!");
+    /// ```
+    pub fn new_spinner(message: impl Into<String>) -> Self {
+        let pb = IndicatifProgressBar::new_spinner();
+        pb.set_style(
+            ProgressStyle::default_spinner()
+                .tick_chars(SPINNER_CHARS)
+                .template(SPINNER_TEMPLATE)
+                .expect("invalid template"),
+        );
+        pb.enable_steady_tick(Duration::from_millis(SPINNER_TICK_MS));
+        pb.set_message(message.into());
+        Self { inner: pb }
+    }
+
+    /// Creates a new progress bar with a known length.
+    ///
+    /// # Arguments
+    ///
+    /// * `len` - The total number of items/steps
+    /// * `message` - The message to display
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let pb = ProgressBar::new(10, "Building nodes");
+    /// for i in 0..10 {
+    ///     // do work...
+    ///     pb.inc(1);
+    /// }
+    /// pb.finish();
+    /// ```
+    pub fn new(len: u64, message: impl Into<String>) -> Self {
+        let pb = IndicatifProgressBar::new(len);
+        pb.set_style(
+            ProgressStyle::default_bar()
+                .tick_chars(SPINNER_CHARS)
+                .template(PROGRESS_TEMPLATE)
+                .expect("invalid template")
+                .progress_chars("=>-"),
+        );
+        pb.enable_steady_tick(Duration::from_millis(SPINNER_TICK_MS));
+        pb.set_message(message.into());
+        Self { inner: pb }
+    }
+
+    /// Creates a new progress bar for byte-based progress (downloads, file copies, etc.).
+    ///
+    /// # Arguments
+    ///
+    /// * `total_bytes` - The total number of bytes
+    /// * `message` - The message to display
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let pb = ProgressBar::new_bytes(1024 * 1024, "Downloading");
+    /// // during download...
+    /// pb.inc(512);
+    /// ```
+    pub fn new_bytes(total_bytes: u64, message: impl Into<String>) -> Self {
+        let pb = IndicatifProgressBar::new(total_bytes);
+        pb.set_style(
+            ProgressStyle::default_bar()
+                .tick_chars(SPINNER_CHARS)
+                .template(BYTES_TEMPLATE)
+                .expect("invalid template")
+                .progress_chars("=>-"),
+        );
+        pb.enable_steady_tick(Duration::from_millis(SPINNER_TICK_MS));
+        pb.set_message(message.into());
+        Self { inner: pb }
+    }
+
+    /// Creates a hidden progress bar (for non-TTY environments or when progress is disabled).
+    pub fn hidden() -> Self {
+        let pb = IndicatifProgressBar::hidden();
+        Self { inner: pb }
+    }
+
+    /// Updates the message displayed by the progress bar.
+    pub fn set_message(&self, message: impl Into<String>) {
+        self.inner.set_message(message.into());
+    }
+
+    /// Increments the progress by the given amount.
+    pub fn inc(&self, delta: u64) {
+        self.inner.inc(delta);
+    }
+
+    /// Sets the current position.
+    pub fn set_position(&self, pos: u64) {
+        self.inner.set_position(pos);
+    }
+
+    /// Sets the length of the progress bar.
+    pub fn set_length(&self, len: u64) {
+        self.inner.set_length(len);
+    }
+
+    /// Finishes the progress bar with a success message.
+    pub fn finish_with_message(&self, message: impl Into<String>) {
+        self.inner.set_style(
+            ProgressStyle::default_spinner()
+                .template(FINISHED_TEMPLATE)
+                .expect("invalid template"),
+        );
+        self.inner.finish_with_message(message.into());
+    }
+
+    /// Finishes the progress bar and clears it.
+    pub fn finish_and_clear(&self) {
+        self.inner.finish_and_clear();
+    }
+
+    /// Finishes the progress bar successfully.
+    pub fn finish(&self) {
+        let message = self.inner.message();
+        self.finish_with_message(message);
+    }
+
+    /// Marks the progress bar as failed with an error message.
+    pub fn fail_with_message(&self, message: impl Into<String>) {
+        self.inner.set_style(
+            ProgressStyle::default_spinner()
+                .template(FAILED_TEMPLATE)
+                .expect("invalid template"),
+        );
+        self.inner.finish_with_message(message.into());
+    }
+
+    /// Returns a reference to the underlying indicatif progress bar.
+    ///
+    /// This allows access to advanced features not exposed by this wrapper.
+    pub fn inner(&self) -> &IndicatifProgressBar {
+        &self.inner
+    }
+}
+
+/// A manager for multiple concurrent progress bars.
+///
+/// This allows displaying progress for multiple parallel operations.
+pub struct MultiProgress {
+    inner: IndicatifMultiProgress,
+}
+
+impl MultiProgress {
+    /// Creates a new multi-progress manager.
+    pub fn new() -> Self {
+        Self {
+            inner: IndicatifMultiProgress::new(),
+        }
+    }
+
+    /// Adds a spinner task to the multi-progress display.
+    ///
+    /// # Arguments
+    ///
+    /// * `message` - The message to display for this task
+    ///
+    /// # Returns
+    ///
+    /// A `ProgressBar` that can be used to update this task's progress
+    pub fn add_spinner(&self, message: impl Into<String>) -> ProgressBar {
+        let pb = ProgressBar::new_spinner(message);
+        let added = self.inner.add(pb.inner.clone());
+        ProgressBar { inner: added }
+    }
+
+    /// Adds a progress bar task to the multi-progress display.
+    ///
+    /// # Arguments
+    ///
+    /// * `len` - The total number of items/steps
+    /// * `message` - The message to display for this task
+    pub fn add_bar(&self, len: u64, message: impl Into<String>) -> ProgressBar {
+        let pb = ProgressBar::new(len, message);
+        let added = self.inner.add(pb.inner.clone());
+        ProgressBar { inner: added }
+    }
+
+    /// Adds a byte-based progress bar task.
+    pub fn add_bytes(&self, total_bytes: u64, message: impl Into<String>) -> ProgressBar {
+        let pb = ProgressBar::new_bytes(total_bytes, message);
+        let added = self.inner.add(pb.inner.clone());
+        ProgressBar { inner: added }
+    }
+
+    /// Adds an existing progress bar to the multi-progress display.
+    pub fn add(&self, pb: ProgressBar) -> ProgressBar {
+        let added = self.inner.add(pb.inner);
+        ProgressBar { inner: added }
+    }
+
+    /// Removes a progress bar from the display.
+    pub fn remove(&self, pb: &ProgressBar) {
+        self.inner.remove(&pb.inner);
+    }
+
+    /// Clears all progress bars.
+    pub fn clear(&self) -> std::io::Result<()> {
+        self.inner.clear()
+    }
+}
+
+impl Default for MultiProgress {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Builder for creating progress bars with custom configuration.
+pub struct ProgressBarBuilder {
+    message: String,
+    length: Option<u64>,
+    style_type: ProgressStyleType,
+    hidden: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ProgressStyleType {
+    Spinner,
+    Bar,
+    Bytes,
+}
+
+impl ProgressBarBuilder {
+    /// Creates a new progress bar builder.
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            length: None,
+            style_type: ProgressStyleType::Spinner,
+            hidden: false,
+        }
+    }
+
+    /// Sets the progress bar to display as a bar (requires length).
+    pub fn bar(mut self, length: u64) -> Self {
+        self.length = Some(length);
+        self.style_type = ProgressStyleType::Bar;
+        self
+    }
+
+    /// Sets the progress bar to display byte-based progress (requires length).
+    pub fn bytes(mut self, total_bytes: u64) -> Self {
+        self.length = Some(total_bytes);
+        self.style_type = ProgressStyleType::Bytes;
+        self
+    }
+
+    /// Sets the progress bar to display as a spinner.
+    pub fn spinner(mut self) -> Self {
+        self.style_type = ProgressStyleType::Spinner;
+        self
+    }
+
+    /// Sets whether the progress bar should be hidden.
+    pub fn hidden(mut self, hidden: bool) -> Self {
+        self.hidden = hidden;
+        self
+    }
+
+    /// Builds the progress bar.
+    pub fn build(self) -> ProgressBar {
+        if self.hidden {
+            return ProgressBar::hidden();
+        }
+
+        match self.style_type {
+            ProgressStyleType::Spinner => ProgressBar::new_spinner(self.message),
+            ProgressStyleType::Bar => ProgressBar::new(self.length.unwrap_or(100), self.message),
+            ProgressStyleType::Bytes => {
+                ProgressBar::new_bytes(self.length.unwrap_or(0), self.message)
+            }
+        }
+    }
+}
+
+/// Utility function to check if progress bars should be displayed.
+///
+/// Progress bars are hidden in the following cases:
+/// - Not running in a TTY
+/// - CI environment detected
+/// - User explicitly disabled progress (via environment variable)
+pub fn should_show_progress() -> bool {
+    // Check if we're in a TTY
+    if !atty::is(atty::Stream::Stderr) {
+        return false;
+    }
+
+    // Check for common CI environment variables
+    if std::env::var("CI").is_ok()
+        || std::env::var("CONTINUOUS_INTEGRATION").is_ok()
+        || std::env::var("GITHUB_ACTIONS").is_ok()
+    {
+        return false;
+    }
+
+    // Check for explicit disable
+    if let Ok(val) = std::env::var("DORA_NO_PROGRESS") {
+        if val == "1" || val.eq_ignore_ascii_case("true") {
+            return false;
+        }
+    }
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_progress_bar_creation() {
+        let pb = ProgressBar::new_spinner("Test");
+        pb.finish();
+    }
+
+    #[test]
+    fn test_progress_bar_with_length() {
+        let pb = ProgressBar::new(100, "Test");
+        pb.inc(50);
+        pb.finish();
+    }
+
+    #[test]
+    fn test_multi_progress() {
+        let multi = MultiProgress::new();
+        let pb1 = multi.add_spinner("Task 1");
+        let pb2 = multi.add_spinner("Task 2");
+        pb1.finish();
+        pb2.finish();
+    }
+
+    #[test]
+    fn test_builder() {
+        let pb = ProgressBarBuilder::new("Test").spinner().build();
+        pb.finish();
+
+        let pb = ProgressBarBuilder::new("Test").bar(100).build();
+        pb.finish();
+
+        let pb = ProgressBarBuilder::new("Test").bytes(1024).build();
+        pb.finish();
+    }
+}

--- a/binaries/cli/src/progress.rs
+++ b/binaries/cli/src/progress.rs
@@ -310,6 +310,25 @@ impl MultiProgress {
     pub fn clear(&self) -> std::io::Result<()> {
         self.inner.clear()
     }
+
+    /// Prints a message above the progress bars.
+    ///
+    /// This ensures that log messages appear above the pinned progress bars
+    /// and can scroll up normally. On non-terminal outputs, this falls back
+    /// to regular println! to ensure logs are still visible.
+    ///
+    /// # Arguments
+    ///
+    /// * `msg` - The message to print
+    pub fn println(&self, msg: impl AsRef<str>) -> std::io::Result<()> {
+        if std::io::stderr().is_terminal() {
+            self.inner.println(msg)
+        } else {
+            // Fall back to regular println for non-terminal outputs (e.g., logs)
+            println!("{}", msg.as_ref());
+            Ok(())
+        }
+    }
 }
 
 impl Default for MultiProgress {


### PR DESCRIPTION
This PR implements visual progress feedback for all time-consuming Dora CLI operations using the indicatif crate.

Changes:
- Created shared progress bar component library (progress.rs)
- Added progress to build, up, start, and run commands
- Unified cyan/blue styling with success/failure indicators
- Smart TTY detection (auto-hides in CI environments)
- Multi-progress support for parallel operations

All operations >2s now have visual feedback with consistent behavior.

Testing:
- cargo check: passed
- cargo fmt: passed
- cargo clippy: passed

Closes #1229