### PR TITLE
Update to `macos-14` in `cross-check` CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -564,9 +564,9 @@ jobs:
             target: armv7-unknown-linux-musleabihf
           - runner: ubuntu-22.04
             target: x86_64-pc-windows-gnu
-          - runner: macos-13
+          - runner: macos-14
             target: aarch64-apple-darwin
-          - runner: macos-13
+          - runner: macos-14
             target: x86_64-apple-darwin
       fail-fast: false
     steps:


### PR DESCRIPTION
The macOS-13 based runner images are now retired. For more details, see https://github.com/actions/runner-images/issues/13046.