### PR TITLE
Fix environment activation command in README

### DIFF
--- a/examples/python-operator-dataflow/README.md
+++ b/examples/python-operator-dataflow/README.md
@@ -21,7 +21,7 @@ cargo run --example python-operator-dataflow
 
 ```bash
 conda create -n example_env python=3.11
-conda activate test_env
+conda activate example_env
 pip install -r requirements.txt
 pip install -r requirements_llm.txt
 ```


### PR DESCRIPTION
Fixed README.md by making environment name consistent
