### PR TITLE
Remove default zenoh endpoint peer config

### DIFF
--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -42,14 +42,6 @@ pub async fn open_zenoh_session(coordinator_addr: Option<IpAddr>) -> eyre::Resul
                         ),
                     )
                     .unwrap();
-                if cfg!(target_os = "macos") {
-                    warn!(
-                        "disabling multicast on macos systems. Enable it with the ZENOH_CONFIG env variable or file"
-                    );
-                    zenoh_config
-                        .insert_json5("scouting/multicast", r#"{ enabled: false }"#)
-                        .unwrap();
-                }
             }
             if let Ok(zenoh_session) = zenoh::open(zenoh_config).await {
                 zenoh_session


### PR DESCRIPTION
With the default config we get a lot of `CONNECTION_TO_SELF` errors since https://github.com/eclipse-zenoh/zenoh/pull/2110 was merged.
