### PR TITLE
feat: implement dora node list command with metrics and filtering (#1202)

### DIFF
--- a/binaries/cli/src/command/mod.rs
+++ b/binaries/cli/src/command/mod.rs
@@ -9,6 +9,7 @@ mod inspect;
 mod list;
 mod logs;
 mod new;
+mod node;
 mod run;
 mod runtime;
 mod self_;
@@ -32,6 +33,7 @@ use inspect::Inspect;
 use list::ListArgs;
 use logs::LogsArgs;
 use new::NewArgs;
+use node::Node;
 use run::Run;
 use runtime::Runtime;
 use self_::SelfSubCommand;
@@ -69,6 +71,8 @@ pub enum Command {
     Coordinator(Coordinator),
     #[clap(subcommand)]
     Topic(Topic),
+    #[clap(subcommand)]
+    Node(Node),
 
     Completion(Completion),
     Self_ {
@@ -114,6 +118,7 @@ impl Executable for Command {
             Command::Self_ { command } => command.execute(),
             Command::Runtime(args) => args.execute(),
             Command::Topic(args) => args.execute(),
+            Command::Node(args) => args.execute(),
             Command::Completion(args) => args.execute(),
         }
     }

--- a/binaries/cli/src/command/node/list.rs
+++ b/binaries/cli/src/command/node/list.rs
@@ -1,0 +1,186 @@
+use std::io::Write;
+
+use clap::Args;
+use serde::Serialize;
+use tabwriter::TabWriter;
+use uuid::Uuid;
+
+use crate::{
+    command::{Executable, default_tracing},
+    common::CoordinatorOptions,
+    formatting::OutputFormat,
+};
+use communication_layer_request_reply::TcpRequestReplyConnection;
+use dora_message::{
+    cli_to_coordinator::ControlRequest,
+    coordinator_to_cli::{ControlRequestReply, NodeInfo},
+};
+use eyre::{Context, bail};
+
+/// List all currently running nodes and their status.
+///
+/// Examples:
+///
+/// List all nodes:
+///   dora node list
+///
+/// List nodes in a specific dataflow:
+///   dora node list --dataflow my-dataflow
+///
+/// List nodes as JSON:
+///   dora node list --format json
+#[derive(Debug, Args)]
+#[clap(verbatim_doc_comment)]
+pub struct List {
+    /// Filter by dataflow name or UUID
+    #[clap(long, short = 'd', value_name = "NAME_OR_UUID")]
+    pub dataflow: Option<String>,
+
+    /// Output format
+    #[clap(long, value_name = "FORMAT", default_value_t = OutputFormat::Table)]
+    pub format: OutputFormat,
+
+    #[clap(flatten)]
+    coordinator: CoordinatorOptions,
+}
+
+impl Executable for List {
+    fn execute(self) -> eyre::Result<()> {
+        default_tracing()?;
+
+        let mut session = self.coordinator.connect()?;
+        list(session.as_mut(), self.dataflow, self.format)
+    }
+}
+
+#[derive(Serialize)]
+struct OutputEntry {
+    node: String,
+    status: String,
+    pid: String,
+    cpu: String,
+    memory: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dataflow: Option<String>,
+}
+
+fn list(
+    session: &mut TcpRequestReplyConnection,
+    dataflow_filter: Option<String>,
+    format: OutputFormat,
+) -> eyre::Result<()> {
+    // Request node information from coordinator
+    let reply_raw = session
+        .request(&serde_json::to_vec(&ControlRequest::GetNodeInfo).unwrap())
+        .wrap_err("failed to send GetNodeInfo request")?;
+
+    let reply: ControlRequestReply =
+        serde_json::from_slice(&reply_raw).wrap_err("failed to parse reply")?;
+
+    let node_infos = match reply {
+        ControlRequestReply::NodeInfoList(infos) => infos,
+        ControlRequestReply::Error(err) => bail!("{err}"),
+        other => bail!("unexpected reply: {other:?}"),
+    };
+
+    // Filter by dataflow if specified
+    let filtered_nodes: Vec<NodeInfo> = if let Some(ref filter) = dataflow_filter {
+        // Try to parse as UUID first
+        let filter_uuid = Uuid::parse_str(filter).ok();
+
+        node_infos
+            .into_iter()
+            .filter(|node| {
+                // Match by UUID or name
+                if let Some(uuid) = filter_uuid {
+                    node.dataflow_id == uuid
+                } else {
+                    node.dataflow_name.as_deref() == Some(filter)
+                }
+            })
+            .collect()
+    } else {
+        node_infos
+    };
+
+    // Convert to output entries
+    let entries: Vec<OutputEntry> = filtered_nodes
+        .into_iter()
+        .map(|node| {
+            let (status, pid, cpu, memory) = if let Some(metrics) = node.metrics {
+                (
+                    "Running".to_string(),
+                    metrics.pid.to_string(),
+                    format!("{:.1}%", metrics.cpu_usage),
+                    format!("{:.0} MB", metrics.memory_mb),
+                )
+            } else {
+                // Node exists but no metrics available (might be starting or error state)
+                (
+                    "Unknown".to_string(),
+                    "-".to_string(),
+                    "-".to_string(),
+                    "-".to_string(),
+                )
+            };
+
+            OutputEntry {
+                node: node.node_id.to_string(),
+                status,
+                pid,
+                cpu,
+                memory,
+                dataflow: if dataflow_filter.is_none() {
+                    Some(
+                        node.dataflow_name
+                            .unwrap_or_else(|| node.dataflow_id.to_string()),
+                    )
+                } else {
+                    None
+                },
+            }
+        })
+        .collect();
+
+    match format {
+        OutputFormat::Table => {
+            let mut tw = TabWriter::new(std::io::stdout().lock());
+
+            // Write header
+            if dataflow_filter.is_none() {
+                tw.write_all(b"NODE\tSTATUS\tPID\tCPU\tMEMORY\tDATAFLOW\n")?;
+            } else {
+                tw.write_all(b"NODE\tSTATUS\tPID\tCPU\tMEMORY\n")?;
+            }
+
+            // Write entries
+            for entry in entries {
+                if let Some(ref dataflow) = entry.dataflow {
+                    tw.write_all(
+                        format!(
+                            "{}\t{}\t{}\t{}\t{}\t{}\n",
+                            entry.node, entry.status, entry.pid, entry.cpu, entry.memory, dataflow
+                        )
+                        .as_bytes(),
+                    )?;
+                } else {
+                    tw.write_all(
+                        format!(
+                            "{}\t{}\t{}\t{}\t{}\n",
+                            entry.node, entry.status, entry.pid, entry.cpu, entry.memory
+                        )
+                        .as_bytes(),
+                    )?;
+                }
+            }
+            tw.flush()?;
+        }
+        OutputFormat::Json => {
+            for entry in entries {
+                println!("{}", serde_json::to_string(&entry)?);
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/binaries/cli/src/command/node/mod.rs
+++ b/binaries/cli/src/command/node/mod.rs
@@ -1,0 +1,19 @@
+use crate::command::Executable;
+
+mod list;
+
+pub use list::List;
+
+/// Manage and inspect dataflow nodes.
+#[derive(Debug, clap::Subcommand)]
+pub enum Node {
+    List(List),
+}
+
+impl Executable for Node {
+    fn execute(self) -> eyre::Result<()> {
+        match self {
+            Node::List(cmd) => cmd.execute(),
+        }
+    }
+}


### PR DESCRIPTION
This PR adds dora node list command (#1202) to list all currently running nodes and their resource metrics. The command offers both table and JSON formats. It shows the node name, status, PID, CPU usage, and memory consumption. Users can filter by dataflow name or UUID.

The implementation uses current metrics collection system. The daemon collects process metrics every 2 seconds with the sysinfo crate. It sends these metrics to the coordinator through NodeMetrics events. The CLI queries the coordinator using the GetNodeInfo request/reply protocol to get node information and formats it for display.