### PR TITLE
feat(cli): implement 'dora node info' command (#1203)

### DIFF
--- a/binaries/cli/src/command/mod.rs
+++ b/binaries/cli/src/command/mod.rs
@@ -15,7 +15,6 @@ mod self_;
 mod start;
 mod stop;
 mod system;
-mod topic;
 mod up;
 mod version;
 
@@ -39,7 +38,6 @@ use self_::SelfSubCommand;
 use start::Start;
 use stop::Stop;
 use system::System;
-use topic::Topic;
 use up::Up;
 use version::Version;
 
@@ -77,9 +75,7 @@ pub enum Command {
     Node(Node),
     #[clap(subcommand)]
     Topic(Topic),
-
     Version(Version),
-
     Completion(Completion),
     Self_ {
         #[clap(subcommand)]

--- a/binaries/cli/src/command/mod.rs
+++ b/binaries/cli/src/command/mod.rs
@@ -74,9 +74,9 @@ pub enum Command {
     Runtime(Runtime),
     Coordinator(Coordinator),
     #[clap(subcommand)]
-    Topic(Topic),
-    #[clap(subcommand)]
     Node(Node),
+    #[clap(subcommand)]
+    Topic(Topic),
 
     Version(Version),
 

--- a/binaries/cli/src/command/mod.rs
+++ b/binaries/cli/src/command/mod.rs
@@ -15,6 +15,7 @@ mod self_;
 mod start;
 mod stop;
 mod system;
+mod topic;
 mod up;
 mod version;
 
@@ -38,6 +39,7 @@ use self_::SelfSubCommand;
 use start::Start;
 use stop::Stop;
 use system::System;
+use topic::Topic;
 use up::Up;
 use version::Version;
 

--- a/binaries/cli/src/command/node/info.rs
+++ b/binaries/cli/src/command/node/info.rs
@@ -1,0 +1,284 @@
+use clap::Args;
+use dora_message::{
+    cli_to_coordinator::ControlRequest,
+    coordinator_to_cli::{ControlRequestReply, NodeInfo},
+    id::NodeId,
+};
+use eyre::{Context, bail};
+
+use crate::{
+    command::{Executable, default_tracing},
+    common::CoordinatorOptions,
+    formatting::OutputFormat,
+};
+
+/// Display detailed information about a specified node.
+///
+/// Examples:
+///
+/// Show info for a node:
+///   dora node info detector_node
+///
+/// Show info for a node in a specific dataflow:
+///   dora node info detector_node --dataflow my-dataflow
+///
+/// Show info as JSON:
+///   dora node info detector_node --format json
+#[derive(Debug, Args)]
+#[clap(verbatim_doc_comment)]
+pub struct Info {
+    /// Name of the node to inspect
+    #[clap(value_name = "NODE_NAME")]
+    node_name: NodeId,
+
+    /// Dataflow UUID or name to filter nodes (required if multiple dataflows have nodes with the same name)
+    #[clap(short, long, value_name = "UUID_OR_NAME")]
+    dataflow: Option<String>,
+
+    /// Output format
+    #[clap(long, value_name = "FORMAT", default_value_t = OutputFormat::Table)]
+    pub format: OutputFormat,
+
+    #[clap(flatten)]
+    coordinator: CoordinatorOptions,
+}
+
+impl Executable for Info {
+    fn execute(self) -> eyre::Result<()> {
+        default_tracing()?;
+
+        info(
+            self.coordinator,
+            self.node_name,
+            self.dataflow,
+            self.format,
+        )
+    }
+}
+
+fn info(
+    coordinator: CoordinatorOptions,
+    node_name: NodeId,
+    dataflow_filter: Option<String>,
+    format: OutputFormat,
+) -> eyre::Result<()> {
+    let mut session = coordinator.connect()?;
+
+    // Query all running nodes from coordinator
+    let reply_raw = session
+        .request(&serde_json::to_vec(&ControlRequest::GetNodeInfo).unwrap())
+        .wrap_err("failed to send GetNodeInfo request")?;
+
+    let node_list: Vec<NodeInfo> = match serde_json::from_slice(&reply_raw)
+        .wrap_err("failed to parse reply")?
+    {
+        ControlRequestReply::NodeInfoList(list) => list,
+        ControlRequestReply::Error(err) => bail!("{err}"),
+        other => bail!("unexpected reply to GetNodeInfo: {other:?}"),
+    };
+
+    // Filter nodes by name
+    let matching_nodes: Vec<&NodeInfo> = node_list
+        .iter()
+        .filter(|node| node.node_id == node_name)
+        .collect();
+
+    if matching_nodes.is_empty() {
+        bail!("No running node with name `{node_name}` found");
+    }
+
+    // Further filter by dataflow if specified
+    let selected_node = if let Some(dataflow_id_or_name) = dataflow_filter {
+        // Try to parse as UUID first
+        let matching_by_dataflow: Vec<&NodeInfo> = if let Ok(uuid) =
+            uuid::Uuid::parse_str(&dataflow_id_or_name)
+        {
+            matching_nodes
+                .iter()
+                .filter(|node| node.dataflow_id == uuid)
+                .copied()
+                .collect()
+        } else {
+            // Filter by dataflow name
+            matching_nodes
+                .iter()
+                .filter(|node| {
+                    node.dataflow_name.as_deref() == Some(dataflow_id_or_name.as_str())
+                })
+                .copied()
+                .collect()
+        };
+
+        if matching_by_dataflow.is_empty() {
+            bail!(
+                "No node `{node_name}` found in dataflow `{dataflow_id_or_name}`"
+            );
+        } else if matching_by_dataflow.len() == 1 {
+            matching_by_dataflow[0]
+        } else {
+            bail!(
+                "Multiple nodes with name `{node_name}` found in dataflow `{dataflow_id_or_name}`. This should not happen."
+            );
+        }
+    } else {
+        // No dataflow filter specified
+        if matching_nodes.len() == 1 {
+            matching_nodes[0]
+        } else {
+            // Multiple nodes with same name in different dataflows - prompt user
+            let choices: Vec<String> = matching_nodes
+                .iter()
+                .map(|node| {
+                    let dataflow_name = node
+                        .dataflow_name
+                        .as_ref()
+                        .map(|n| n.as_str())
+                        .unwrap_or("<unnamed>");
+                    format!("[{}] {}", dataflow_name, node.dataflow_id)
+                })
+                .collect();
+
+            let selection = inquire::Select::new(
+                "Multiple dataflows have a node with this name. Choose dataflow:",
+                choices.clone(),
+            )
+            .prompt()?;
+
+            // Find the matching node by comparing the formatted string
+            matching_nodes
+                .iter()
+                .find(|node| {
+                    let dataflow_name = node
+                        .dataflow_name
+                        .as_ref()
+                        .map(|n| n.as_str())
+                        .unwrap_or("<unnamed>");
+                    let formatted = format!("[{}] {}", dataflow_name, node.dataflow_id);
+                    formatted == selection
+                })
+                .expect("selected node not found")
+        }
+    };
+
+    // Now we need to get the full descriptor to show inputs/outputs
+    // Query dataflow info to get the descriptor
+    let dataflow_info_raw = session
+        .request(
+            &serde_json::to_vec(&ControlRequest::Info {
+                dataflow_uuid: selected_node.dataflow_id,
+            })
+            .unwrap(),
+        )
+        .wrap_err("failed to send Info request")?;
+
+    let descriptor = match serde_json::from_slice(&dataflow_info_raw)
+        .wrap_err("failed to parse dataflow info reply")?
+    {
+        ControlRequestReply::DataflowInfo { descriptor, .. } => descriptor,
+        ControlRequestReply::Error(err) => bail!("{err}"),
+        other => bail!("unexpected reply to Info: {other:?}"),
+    };
+
+    // Find the node in the descriptor to get inputs/outputs
+    let node_descriptor = descriptor
+        .nodes
+        .iter()
+        .find(|n| n.id == node_name)
+        .ok_or_else(|| eyre::eyre!("Node `{node_name}` not found in dataflow descriptor"))?;
+
+    // Display the information
+    match format {
+        OutputFormat::Table => {
+            println!("Name: {}", selected_node.node_id);
+            println!("Status: Running");
+            
+            if let Some(metrics) = &selected_node.metrics {
+                println!("PID: {}", metrics.pid);
+                // TODO: Calculate uptime if we have node start time
+                // For now, we don't have this information from the coordinator
+            }
+
+            println!("Dataflow: {} ({})", 
+                selected_node.dataflow_name.as_deref().unwrap_or("<unnamed>"),
+                selected_node.dataflow_id
+            );
+            println!("Daemon: {}", selected_node.daemon_id);
+
+            // Display inputs
+            if node_descriptor.inputs.is_empty() {
+                println!("Inputs: (none)");
+            } else {
+                println!("Inputs:");
+                for (input_id, input) in &node_descriptor.inputs {
+                    println!("  - {} (from {})", input_id, input.mapping);
+                }
+            }
+
+            // Display outputs
+            if node_descriptor.outputs.is_empty() {
+                println!("Outputs: (none)");
+            } else {
+                println!("Outputs:");
+                for output_id in &node_descriptor.outputs {
+                    println!("  - {}", output_id);
+                }
+            }
+
+            // Display metrics if available
+            if let Some(metrics) = &selected_node.metrics {
+                println!("\nMetrics:");
+                println!("  CPU Usage: {:.1}%", metrics.cpu_usage);
+                println!("  Memory: {:.1} MB", metrics.memory_mb);
+                if let Some(disk_read) = metrics.disk_read_mb_s {
+                    println!("  Disk Read: {:.2} MB/s", disk_read);
+                }
+                if let Some(disk_write) = metrics.disk_write_mb_s {
+                    println!("  Disk Write: {:.2} MB/s", disk_write);
+                }
+            }
+        }
+        OutputFormat::Json => {
+            // Create a JSON representation
+            let mut json_output = serde_json::Map::new();
+            json_output.insert("name".to_string(), serde_json::json!(selected_node.node_id));
+            json_output.insert("status".to_string(), serde_json::json!("Running"));
+            json_output.insert("dataflow_id".to_string(), serde_json::json!(selected_node.dataflow_id));
+            json_output.insert("dataflow_name".to_string(), serde_json::json!(selected_node.dataflow_name));
+            json_output.insert("daemon_id".to_string(), serde_json::json!(selected_node.daemon_id));
+
+            if let Some(metrics) = &selected_node.metrics {
+                let mut metrics_map = serde_json::Map::new();
+                metrics_map.insert("pid".to_string(), serde_json::json!(metrics.pid));
+                metrics_map.insert("cpu_usage".to_string(), serde_json::json!(metrics.cpu_usage));
+                metrics_map.insert("memory_mb".to_string(), serde_json::json!(metrics.memory_mb));
+                if let Some(disk_read) = metrics.disk_read_mb_s {
+                    metrics_map.insert("disk_read_mb_s".to_string(), serde_json::json!(disk_read));
+                }
+                if let Some(disk_write) = metrics.disk_write_mb_s {
+                    metrics_map.insert("disk_write_mb_s".to_string(), serde_json::json!(disk_write));
+                }
+                json_output.insert("metrics".to_string(), serde_json::json!(metrics_map));
+            }
+
+            // Add inputs
+            let inputs: Vec<String> = node_descriptor
+                .inputs
+                .iter()
+                .map(|(id, input)| format!("{} (from {})", id, input.mapping))
+                .collect();
+            json_output.insert("inputs".to_string(), serde_json::json!(inputs));
+
+            // Add outputs
+            let outputs: Vec<String> = node_descriptor
+                .outputs
+                .iter()
+                .map(|id| id.to_string())
+                .collect();
+            json_output.insert("outputs".to_string(), serde_json::json!(outputs));
+
+            println!("{}", serde_json::to_string_pretty(&json_output)?);
+        }
+    }
+
+    Ok(())
+}

--- a/binaries/cli/src/command/node/info.rs
+++ b/binaries/cli/src/command/node/info.rs
@@ -1,9 +1,5 @@
 use clap::Args;
-use dora_message::{
-    coordinator_to_cli::NodeInfo,
-    id::NodeId,
-    tarpc,
-};
+use dora_message::{coordinator_to_cli::NodeInfo, id::NodeId, tarpc};
 use eyre::{Context, bail};
 
 use crate::{

--- a/binaries/cli/src/command/node/info.rs
+++ b/binaries/cli/src/command/node/info.rs
@@ -184,20 +184,20 @@ fn info(
             if let Some(metrics) = &selected_node.metrics {
                 println!("PID: {}", metrics.pid);
                 if let Some(start_time) = metrics.start_time {
-                     let uptime = std::time::SystemTime::now()
+                    let uptime = std::time::SystemTime::now()
                         .duration_since(start_time.get_time().to_system_time())
                         .unwrap_or_default();
-                     let secs = uptime.as_secs();
-                     let hours = secs / 3600;
-                     let minutes = (secs % 3600) / 60;
-                     let seconds = secs % 60;
-                     if hours > 0 {
+                    let secs = uptime.as_secs();
+                    let hours = secs / 3600;
+                    let minutes = (secs % 3600) / 60;
+                    let seconds = secs % 60;
+                    if hours > 0 {
                         println!("Uptime: {}h {}m {}s", hours, minutes, seconds);
-                     } else if minutes > 0 {
+                    } else if minutes > 0 {
                         println!("Uptime: {}m {}s", minutes, seconds);
-                     } else {
+                    } else {
                         println!("Uptime: {}s", seconds);
-                     }
+                    }
                 }
             }
 

--- a/binaries/cli/src/command/node/mod.rs
+++ b/binaries/cli/src/command/node/mod.rs
@@ -1,18 +1,22 @@
 use crate::command::Executable;
 
+mod info;
 mod list;
 
+pub use info::Info;
 pub use list::List;
 
 /// Manage and inspect dataflow nodes.
 #[derive(Debug, clap::Subcommand)]
 pub enum Node {
+    Info(Info),
     List(List),
 }
 
 impl Executable for Node {
     async fn execute(self) -> eyre::Result<()> {
         match self {
+            Node::Info(cmd) => cmd.execute().await,
             Node::List(cmd) => cmd.execute().await,
         }
     }

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -545,6 +545,7 @@ async fn start_inner(
             },
 
             Event::Control(event) => match event {
+
                 ControlEvent::Error(err) => tracing::error!("{err:?}"),
                 ControlEvent::LogSubscribe {
                     dataflow_id,

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -545,7 +545,6 @@ async fn start_inner(
             },
 
             Event::Control(event) => match event {
-
                 ControlEvent::Error(err) => tracing::error!("{err:?}"),
                 ControlEvent::LogSubscribe {
                     dataflow_id,

--- a/binaries/coordinator/src/server.rs
+++ b/binaries/coordinator/src/server.rs
@@ -388,6 +388,7 @@ impl CliControl for ControlServer {
                             memory_mb: m.memory_bytes as f64 / 1000.0 / 1000.0,
                             disk_read_mb_s: m.disk_read_bytes.map(|b| b as f64 / 1000.0 / 1000.0),
                             disk_write_mb_s: m.disk_write_bytes.map(|b| b as f64 / 1000.0 / 1000.0),
+                            start_time: m.start_time,
                         }
                     });
 

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1742,6 +1742,10 @@ impl Daemon {
                         let _ = reply_sender.send(DaemonReply::Result(Err(err)));
                     }
                     Ok(dataflow) => {
+                        if let Some(node) = dataflow.running_nodes.get_mut(&node_id) {
+                            node.start_time = Some(self.clock.new_timestamp());
+                        }
+
                         Self::subscribe(dataflow, node_id.clone(), event_sender, &self.clock).await;
 
                         let status = dataflow

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1034,6 +1034,7 @@ impl Daemon {
                                         (disk_usage.written_bytes as f64 / METRICS_INTERVAL_SECS)
                                             as u64,
                                     ),
+                                    start_time: running_node.start_time,
                                 },
                             );
                         }
@@ -2862,6 +2863,7 @@ pub struct RunningNode {
     /// Abort handle for this node's listener task, carried here until the dataflow
     /// collects it into `RunningDataflow::_listener_tasks`.
     listener_abort_handle: Option<tokio::task::AbortHandle>,
+    start_time: Option<uhlc::Timestamp>,
 }
 
 impl RunningNode {

--- a/binaries/daemon/src/spawn/prepared.rs
+++ b/binaries/daemon/src/spawn/prepared.rs
@@ -90,6 +90,7 @@ impl PreparedNode {
                 }
             },
             listener_abort_handle: self.listener_abort_handle.clone(),
+            start_time: Some(self.clock.new_timestamp()),
         };
 
         tokio::spawn(self.restart_loop(logger, finished_rx, disable_restart, pid));

--- a/binaries/daemon/src/spawn/prepared.rs
+++ b/binaries/daemon/src/spawn/prepared.rs
@@ -90,7 +90,7 @@ impl PreparedNode {
                 }
             },
             listener_abort_handle: self.listener_abort_handle.clone(),
-            start_time: Some(self.clock.new_timestamp()),
+            start_time: None,
         };
 
         tokio::spawn(self.restart_loop(logger, finished_rx, disable_restart, pid));

--- a/libraries/message/src/coordinator_to_cli.rs
+++ b/libraries/message/src/coordinator_to_cli.rs
@@ -27,6 +27,8 @@ pub struct NodeMetricsInfo {
     pub disk_read_mb_s: Option<f64>,
     /// Disk write MB/s (if available)
     pub disk_write_mb_s: Option<f64>,
+    /// Node start time
+    pub start_time: Option<uhlc::Timestamp>,
 }
 
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]

--- a/libraries/message/src/daemon_to_coordinator.rs
+++ b/libraries/message/src/daemon_to_coordinator.rs
@@ -86,6 +86,8 @@ pub struct NodeMetrics {
     pub disk_read_bytes: Option<u64>,
     /// Disk write bytes per second (if available)
     pub disk_write_bytes: Option<u64>,
+    /// Node start time
+    pub start_time: Option<uhlc::Timestamp>,
 }
 
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]


### PR DESCRIPTION
This PR introduces new dora node info command that offers detailed information about running nodes in dataflows. This makes it easier to monitor node status, connections, and resource usage.

The new command provides a clear view of any node in dataflow:
- Status & Process Info: Shows the node's running status and process ID (PID).  
- Dataflow Context: Displays which dataflow the node belongs to, along with the daemon or machine it's running on.  
- Topology: Lists all input topics that the node subscribes to and the output topics it publishes.  
- Resource Metrics: Shows real-time CPU usage, memory consumption, and disk I/O statistics.  

Resolves #1203