### PR TITLE
Provide an explict method to report node failure errors

### DIFF
--- a/apis/rust/node/src/daemon_connection/interactive.rs
+++ b/apis/rust/node/src/daemon_connection/interactive.rs
@@ -85,6 +85,10 @@ impl InteractiveEvents {
             DaemonRequest::NodeConfig { .. } => {
                 eyre::bail!("unexpected NodeConfig in interactive mode")
             }
+            DaemonRequest::Fail(failure) => {
+                tracing::error!("node reports failure: {}", failure.to_string().red());
+                DaemonReply::Result(Ok(()))
+            }
         };
         Ok(reply)
     }

--- a/apis/rust/node/src/daemon_connection/node_integration_testing.rs
+++ b/apis/rust/node/src/daemon_connection/node_integration_testing.rs
@@ -122,6 +122,10 @@ impl IntegrationTestingEvents {
             DaemonRequest::NodeConfig { .. } => {
                 eyre::bail!("unexpected NodeConfig in interactive mode")
             }
+            DaemonRequest::Fail(failure) => {
+                tracing::error!("node reports failure: {}", failure.to_string().red());
+                DaemonReply::Result(Ok(()))
+            }
         };
         Ok(reply)
     }

--- a/apis/rust/node/src/lib.rs
+++ b/apis/rust/node/src/lib.rs
@@ -92,6 +92,7 @@ pub use dora_core::{self, uhlc};
 pub use dora_message::{
     DataflowId,
     metadata::{Metadata, MetadataParameters, Parameter},
+    node_to_daemon::NodeFailureError,
 };
 use dora_message::{
     common::Timestamped,
@@ -112,6 +113,7 @@ use tokio::sync::oneshot;
 mod daemon_connection;
 mod event_stream;
 pub mod integration_testing;
+mod macros;
 mod node;
 
 #[derive(Debug)]

--- a/apis/rust/node/src/macros.rs
+++ b/apis/rust/node/src/macros.rs
@@ -1,0 +1,30 @@
+/// Create a [`NodeFailureError`][crate::NodeFailureError] with file, line, and column information.
+///
+/// Sets the `file`, `line`, and `column` fields of the error to the location where the macro is
+/// invoked.
+///
+/// Expects a single expression that can be converted into a `String`, which will be used as the
+/// `summary` field of the `NodeFailureError`.
+///
+/// ## Example
+///
+/// ```
+/// let mut error = node_failure_error!("an error occurred");
+/// error.detailed = Some("something error details".into());
+/// assert_eq!(error.summary, "an error occurred");
+/// assert_eq!(error.file.unwrap(), file!());
+/// assert_eq!(error.line.unwrap(), line!() - 3);
+/// ```
+#[macro_export]
+macro_rules! node_failure_error {
+    ($summary:expr) => {{
+        let file = file!().into();
+        let line = line!();
+        let column = column!();
+        let mut error = $crate::NodeFailureError::new($summary);
+        error.file = Some(file);
+        error.line = Some(line);
+        error.column = Some(column);
+        error
+    }};
+}

--- a/apis/rust/node/src/macros.rs
+++ b/apis/rust/node/src/macros.rs
@@ -9,11 +9,13 @@
 /// ## Example
 ///
 /// ```
+/// use dora_node_api::node_failure_error;
+///
 /// let mut error = node_failure_error!("an error occurred");
 /// error.detailed = Some("something error details".into());
 /// assert_eq!(error.summary, "an error occurred");
 /// assert_eq!(error.file.unwrap(), file!());
-/// assert_eq!(error.line.unwrap(), line!() - 3);
+/// assert_eq!(error.line.unwrap(), line!() - 4);
 /// ```
 #[macro_export]
 macro_rules! node_failure_error {

--- a/binaries/daemon/src/node_communication/mod.rs
+++ b/binaries/daemon/src/node_communication/mod.rs
@@ -8,7 +8,7 @@ use dora_message::{
     DataflowId,
     common::{DropToken, Timestamped},
     daemon_to_node::{DaemonCommunication, DaemonReply, NodeDropEvent, NodeEvent},
-    node_to_daemon::DaemonRequest,
+    node_to_daemon::{DaemonRequest, NodeFailureError},
 };
 use eyre::{Context, eyre};
 use futures::{Future, future, task};
@@ -456,6 +456,10 @@ impl Listener {
                     connection,
                 )
                 .await?;
+            }
+            DaemonRequest::Fail(failure) => {
+                self.process_daemon_event(DaemonNodeEvent::Fail(failure), None, connection)
+                    .await?;
             }
         }
         Ok(())

--- a/libraries/message/src/common.rs
+++ b/libraries/message/src/common.rs
@@ -7,7 +7,10 @@ use eyre::Context as _;
 use serde::{Deserialize, Deserializer};
 use uuid::Uuid;
 
-use crate::{BuildId, DataflowId, daemon_to_daemon::InterDaemonEvent, id::NodeId};
+use crate::{
+    BuildId, DataflowId, daemon_to_daemon::InterDaemonEvent, id::NodeId,
+    node_to_daemon::NodeFailureError,
+};
 
 pub use log::Level as LogLevel;
 
@@ -167,6 +170,8 @@ impl std::fmt::Display for NodeError {
                 let stderr = stderr.trim_end();
                 write!(f, " with stderr output:\n{line}{stderr}\n{line}")?
             }
+            NodeErrorCause::DataflowNotFound => write!(f, " <dataflow not found>")?,
+            NodeErrorCause::Failure(failure) => write!(f, ": {failure}")?,
         }
 
         Ok(())
@@ -182,9 +187,13 @@ pub enum NodeErrorCause {
         caused_by_node: NodeId,
     },
     FailedToSpawn(String),
+    /// Node reported an explicit failure reason.
+    Failure(NodeFailureError),
     Other {
         stderr: String,
     },
+    /// We cannot find out why the node failed because the dataflow is not known.
+    DataflowNotFound,
 }
 
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]


### PR DESCRIPTION
Allows nodes to report errors in a structured way before they exit with a non-zero exit code. By using this method, the daemon does not have to try to extract a meaningful error message from `stderr` after node failure.

---

I'm not 100% happy with the `NodeFailureError` and `report_failure_error` names. I wanted to make it clear that this is an error message that corresponds to the node failure, but does not cause/report a node failure itself (you still have to do exit(1)). Still, maybe names like `NodeFailed` and `report_failure` are still better?