### PR TITLE
feat: add example for sending multiple numpy arrays efficiently

### DIFF
--- a/examples/python-multiple-arrays/README.md
+++ b/examples/python-multiple-arrays/README.md
@@ -1,0 +1,30 @@
+# Fast Multi-Array Messaging with Dora
+
+Hi there! This example shows you how to send multiple numpy arrays (like several sensor readings or images) in a single Dora message with lightning-fast performance.
+
+## Why this matters
+You might have noticed that using `numpy_array.tolist()` to package data is... well, pretty slow. That's because it converts every single pixel or number into a Python object, which is heavy work for the CPU.
+
+## The Secret Sauce
+The trick is to keep things in binary format! We use `numpy_array.ravel()` to flatten the arrays efficiently and pass them straight to `pyarrow`. This lets us achieve near zero-copy performance.
+
+On the receiving end, we simply convert back to numpy and reshape. Easy peasy!
+
+## Give it a spin
+
+1.  **Get Set Up**: Make sure you have `dora` installed and the binary in your PATH.
+2.  **Install the goods**:
+    ```bash
+    pip install numpy pyarrow
+    ```
+3.  **Run it**:
+    ```bash
+    dora up
+    dora start dataflow.yml
+    ```
+
+You should see something awesome like this in your terminal:
+```
+Sent message with 3 arrays. Encoding time: 0.000345s
+Received and decoded. Shape1: (480, 640, 3), Shape2: (480, 640, 3), State: (1, 6). Time: 0.000210s
+```

--- a/examples/python-multiple-arrays/dataflow.yml
+++ b/examples/python-multiple-arrays/dataflow.yml
@@ -1,0 +1,12 @@
+nodes:
+  - id: sender
+    path: sender.py
+    outputs:
+      - multi_array_msg
+    inputs:
+      tick: dora/timer/millis/1000
+
+  - id: receiver
+    path: receiver.py
+    inputs:
+      multi_array_msg: sender/multi_array_msg

--- a/examples/python-multiple-arrays/receiver.py
+++ b/examples/python-multiple-arrays/receiver.py
@@ -1,0 +1,42 @@
+import numpy as np
+from dora import Node
+import time
+
+def main():
+    node = Node()
+
+    for event in node:
+        if event["type"] == "INPUT":
+            if event["id"] == "multi_array_msg":
+                t0 = time.time()
+                
+                # The event value is our PyArrow StructArray.
+                packed_data = event["value"]
+
+                # We can access the columns by name.
+                # packed_data.field('image1') gives us the column for image1.
+                
+                # Grab the arrow arrays for each field.
+                col_image1 = packed_data.field('image1')
+                col_image2 = packed_data.field('image2')
+                col_state = packed_data.field('state')
+                
+                # Now we extract the values and convert back to numpy.
+                # We take the first element since we know we sent a single batch.
+                
+                arr_image1_flat = col_image1[0].values.to_numpy(zero_copy_only=False)
+                # Reshape it back to the original image dimensions.
+                # (Ideally, you'd pass metadata for dynamic shapes, but we'll keep it simple here).
+                image1 = arr_image1_flat.view(np.uint8).reshape((480, 640, 3))
+                
+                arr_image2_flat = col_image2[0].values.to_numpy(zero_copy_only=False)
+                image2 = arr_image2_flat.view(np.uint8).reshape((480, 640, 3))
+                
+                arr_state_flat = col_state[0].values.to_numpy(zero_copy_only=False)
+                state = arr_state_flat.view(np.float32).reshape((1, 6))
+                
+                proc_time = time.time() - t0
+                print(f"Received and decoded. Shape1: {image1.shape}, Shape2: {image2.shape}, State: {state.shape}. Time: {proc_time:.6f}s", flush=True)
+
+if __name__ == "__main__":
+    main()

--- a/examples/python-multiple-arrays/sender.py
+++ b/examples/python-multiple-arrays/sender.py
@@ -1,0 +1,41 @@
+import numpy as np
+import pyarrow as pa
+from dora import Node
+import time
+
+def main():
+    node = Node()
+    
+    # Initialize some dummy data
+    # Let's create some dummy data to send.
+    # We have two images and a state vector, just like in your robotics setup.
+    image1 = np.zeros((480, 640, 3), dtype=np.uint8)
+    image2 = np.ones((480, 640, 3), dtype=np.uint8) * 255
+    state = np.array([[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]], dtype=np.float32)
+
+    for event in node:
+        if event["type"] == "INPUT":
+            if event["id"] == "tick":
+                # Efficiently package the arrays using PyArrow.
+                # We flatten the arrays with .ravel() which is super fast and avoids expensive logic.
+                # Then we wrap them in a list of length 1 to create the arrow columns.
+                
+                t0 = time.time()
+                
+                # Fast path!
+                encoded_image1 = pa.array([image1.ravel()])
+                encoded_image2 = pa.array([image2.ravel()])
+                encoded_state = pa.array([state.ravel()])
+                
+                struct_data = pa.StructArray.from_arrays(
+                    [encoded_image1, encoded_image2, encoded_state],
+                    names=['image1', 'image2', 'state']
+                )
+                
+                node.send_output("multi_array_msg", struct_data)
+                
+                proc_time = time.time() - t0
+                print(f"Sent message with 3 arrays. Encoding time: {proc_time:.6f}s", flush=True)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
#1174

I have added new example to assist anyone who has trouble with performance when sending multiple numpy arrays, such as images, in one message. Instead of using the slower tolist() method, this example shows how to use ravel() for near zero-copy transfer. This method makes things much faster for real-time applications.

