### PR TITLE
fix #829 : replace deprecated typing.List with list in Python stubs

### DIFF
--- a/apis/python/node/dora/__init__.pyi
+++ b/apis/python/node/dora/__init__.pyi
@@ -190,7 +190,7 @@ class Ros2Context:
     context = Ros2Context()
     ```"""
 
-    def __init__(self, ros_paths: typing.List[str] = None) -> None:
+    def __init__(self, ros_paths: list[str] = None) -> None:
         """ROS2 Context holding all messages definition for receiving and sending messages to ROS2.
 
         By default, Ros2Context will use env `AMENT_PREFIX_PATH` to search for message definition.


### PR DESCRIPTION
Fixes #829
- Changed typing.List[str] to list[str] in Ros2Context.__init__
- Follows PEP 585 for modern Python type hints
- Verified with ruff check --select UP (all checks pass) Note: experimental-inspect was tested by multiple contributors and confirmed not to work for auto-generating stubs.