### PR TITLE
Don't send `AllInputsClosed` event to source nodes

### DIFF
--- a/apis/rust/node/src/event_stream/event.rs
+++ b/apis/rust/node/src/event_stream/event.rs
@@ -45,16 +45,7 @@ pub enum Event {
     ///
     /// The [`StopCause`] field contains the reason for the event stream closure.
     ///
-    /// Typically, nodes should exit once the event stream closes. One notable
-    /// exception are nodes with no inputs, which will receive aa
-    /// `Event::Stop(StopCause::AllInputsClosed)` right at startup. Source nodes
-    /// might want to keep producing outputs still. (There is currently an open
-    /// discussion of changing this behavior and not sending `AllInputsClosed`
-    /// to nodes without inputs.)
-    ///
-    /// Note: Stop events with `StopCause::Manual` indicate a manual stop operation
-    /// issued through `dora stop` or a `ctrl-c`. Nodes **must exit** once receiving
-    /// such a stop event, otherwise they will be killed by Dora.
+    /// Nodes should exit once the event stream closes.
     Stop(StopCause),
     /// Instructs the node to reload itself or one of its operators.
     ///
@@ -87,5 +78,7 @@ pub enum StopCause {
     /// receiving such a stop event.
     Manual,
     /// The event stream is closed because all of the node's inputs were closed.
+    ///
+    /// This stop event type is only sent for nodes that have at least one input.
     AllInputsClosed,
 }

--- a/libraries/message/src/daemon_to_node.rs
+++ b/libraries/message/src/daemon_to_node.rs
@@ -73,6 +73,9 @@ pub enum NodeEvent {
     InputClosed {
         id: DataId,
     },
+    /// Notifies a node that all its inputs have been closed.
+    ///
+    /// This event is only sent to nodes that have at least one input.
     AllInputsClosed,
 }
 


### PR DESCRIPTION
This keeps the event channel open for source nodes so that they can receive manual stop events. It also simplifies our policy around dealing with event stream closure: All nodes (including source nodes) should now exit once the event stream closes (i.e. after receiving a stop event of any kind).

Note that this is technically a _breaking change_. However, we don't expect that there are nodes that rely on the immediate stop event and event stream closure. Because of this, we plan to treat this as a bugfix without doing a semver-breaking release. We should mention it prominently in the release docs though.

Alternative to #992 

Fixes #500