### PR TITLE
Add Claude Code GitHub Action workflow

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -1,0 +1,37 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow that integrates Claude Code into the repository
- Enables @claude mentions in issues, PR comments, and PR reviews
- Claude can review code, answer questions, and create PRs to implement features

## Setup Required
After merging, you'll need to add the `ANTHROPIC_API_KEY` secret to the repository settings.

## Test plan
- [x] Merge the PR
- [x] Add the `ANTHROPIC_API_KEY` secret to repository settings
- [ ] Create a test issue mentioning @claude to verify the workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)