### PR TITLE
feat: Add dora-lmdeploy node (#817)

### DIFF
--- a/node-hub/dora-lmdeploy/README.md
+++ b/node-hub/dora-lmdeploy/README.md
@@ -1,0 +1,73 @@
+# dora-lmdeploy
+
+A dora node that wraps [LMDeploy](https://github.com/InternLM/lmdeploy) for high-performance LLM and VLM inference.
+
+This node is designed to handle both text and image inputs, making it suitable for Vision-Language Models (like Qwen2-VL, InternVL) as well as standard LLMs.
+
+## Inputs
+
+- `image`: (Optional) An encoded image (JPEG/PNG bytes) or compatible Arrow binary. If provided, it is stored and used for subsequent text prompts.
+- `text`: (Required) A text prompt. Receiving this input triggers the inference using the latest stored image (if any).
+
+## Outputs
+
+- `response`: The generated text response from the model.
+- `error`: Error message if inference fails.
+
+## Configuration
+
+You can configure the model using environment variables in your dataflow YAML.
+
+- `MODEL_PATH`: The Hugging Face model ID or local path. Default: `Qwen/Qwen2.5-VL-7B-Instruct`.
+- `BACKEND`: The inference backend (`turbomind` or `pytorch`). Default: `turbomind`.
+
+## Example Dataflow
+
+```yaml
+nodes:
+  - id: camera
+    path: opencv-video-capture
+    inputs:
+      tick: dora/timer/millis/100
+    outputs:
+      - image
+
+  - id: input-text
+    path: dora-keyboard
+    inputs:
+      tick: dora/timer/millis/100
+    outputs:
+      - text
+
+  - id: model
+    build: pip install . 
+    path: dora-lmdeploy
+    inputs:
+      image: camera/image
+      text: input-text/text
+    outputs:
+      - response
+    env:
+      MODEL_PATH: Qwen/Qwen2.5-VL-7B-Instruct
+  
+  - id: plot
+    path: dora-rerun
+    inputs:
+      image: camera/image
+      text: model/response
+```
+
+## Testing
+
+**Unit Tests (Mocked)**
+Runs quickly without GPU.
+```bash
+python3 node-hub/dora-lmdeploy/tests/test_dora_lmdeploy.py
+```
+
+**Integration Tests (GPU Required)**
+Requires `lmdeploy` installed and a CUDA GPU. Use a tiny model for faster testing.
+```bash
+export e2e_gpu_test=true
+pytest node-hub/dora-lmdeploy/tests/integration_test_gpu.py
+```

--- a/node-hub/dora-lmdeploy/dora_lmdeploy.py
+++ b/node-hub/dora-lmdeploy/dora_lmdeploy.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+import os
+import io
+import pyarrow as pa
+import numpy as np
+from PIL import Image
+from dora import Node
+from lmdeploy import pipeline
+
+def get_image(value):
+    try:
+        # assume raw bytes (jpeg/png) for now as it's robust
+        image_data = value.to_pybytes()
+        image = Image.open(io.BytesIO(image_data))
+        return image
+    except Exception as e:
+        print(f"Warning: Could not decode image: {e}", flush=True)
+        return None
+
+def main():
+    model_path = os.getenv("MODEL_PATH", "Qwen/Qwen2.5-VL-7B-Instruct")
+    backend = os.getenv("BACKEND", "turbomind")
+    
+    print(f"Initializing dora-lmdeploy with model: {model_path} (backend: {backend})", flush=True)
+    
+    try:
+        # might take a while if downloading or loading onto GPU
+        pipe = pipeline(model_path)
+        print("Model loaded successfully.", flush=True)
+    except Exception as e:
+        print(f"Error loading model: {e}", flush=True)
+        return
+
+    node = Node()
+    last_image = None
+    
+    print("Node started. Loop entering...", flush=True)
+
+    for event in node:
+        if event["type"] == "INPUT":
+            event_id = event["id"]
+            
+            if event_id == "image":
+                # store input image for later use
+                img_val = event["value"]
+                last_image = get_image(img_val)
+                if last_image:
+                    print("Image received and updated.", flush=True)
+                    
+            elif event_id == "text":
+                text = event["value"][0].as_py()
+                print(f"Received prompt: {text}", flush=True)
+
+                if not text:
+                    print("Ignoring empty text input.", flush=True)
+                    continue
+                
+                try:
+                    if last_image:
+                        print("Running multimodal inference...", flush=True)
+                        response = pipe((text, last_image))
+                    else:
+                        print("Running text inference...", flush=True)
+                        response = pipe(text)
+                    
+                    output = response.text if hasattr(response, 'text') else str(response)
+                    node.send_output("response", pa.array([output]))
+                    print(f"Response sent.", flush=True)
+                    
+                except Exception as e:
+                    print(f"Inference error: {e}", flush=True)
+                    node.send_output("error", pa.array([str(e)]))
+
+if __name__ == "__main__":
+    main()

--- a/node-hub/dora-lmdeploy/pyproject.toml
+++ b/node-hub/dora-lmdeploy/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "dora-lmdeploy"
+version = "0.1.0"
+authors = [
+    { name = "Dora-rs Authors", email = "me@dora-rs.ai" }
+]
+description = "Dora node for receiving text and images and performing inference using LMDeploy."
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "dora-rs",
+    "lmdeploy",
+    "pyarrow",
+    "numpy",
+    "Pillow"
+]
+
+[project.scripts]
+dora-lmdeploy = "dora_lmdeploy:main"

--- a/node-hub/dora-lmdeploy/tests/integration_test_gpu.py
+++ b/node-hub/dora-lmdeploy/tests/integration_test_gpu.py
@@ -1,0 +1,44 @@
+import os
+import time
+import pytest
+import pyarrow as pa
+from dora import Node
+
+# this test requires a gpu and lmdeploy installed
+# run with: pytest tests/integration_test_gpu.py
+@pytest.mark.skipif(os.environ.get("e2e_gpu_test") != "true", reason="requires gpu")
+def test_full_pipeline_real_model():
+    # start the node in a separate process or thread usually
+    # here we simulate the node behavior by importing main 
+    # but strictly speaking, dora runs nodes as processes.
+    
+    # for a true integration test, we often construct a dataflow.yml
+    # and run `dora up` and `dora start`.
+    
+    # helper to check if model loads
+    try:
+        from lmdeploy import pipeline
+        # use a tiny model for fast testing if available, else standard
+        model = "Qwen/Qwen2.5-VL-7B-Instruct"
+        pipe = pipeline(model)
+        print("Model loaded.")
+        
+        # run simple inference
+        resp = pipe("hello")
+        assert resp is not None
+        print("Text inference success:", resp)
+
+        # verify multimodal inference
+        from PIL import Image
+        import numpy as np
+        # create valid dummy image
+        img = Image.fromarray(np.zeros((64, 64, 3), dtype=np.uint8))
+        print("Running multimodal check...")
+        resp_img = pipe(("Describe this black image.", img))
+        assert resp_img is not None
+        print("Multimodal inference success:", resp_img)
+        
+    except ImportError:
+        pytest.fail("lmdeploy not installed")
+    except Exception as e:
+        pytest.fail(f"Model failed to load: {e}")

--- a/node-hub/dora-lmdeploy/tests/test_dora_lmdeploy.py
+++ b/node-hub/dora-lmdeploy/tests/test_dora_lmdeploy.py
@@ -1,0 +1,90 @@
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+import os
+
+# mock deps before import
+sys.modules["dora"] = MagicMock()
+sys.modules["lmdeploy"] = MagicMock()
+sys.modules["pyarrow"] = MagicMock()
+sys.modules["numpy"] = MagicMock()
+sys.modules["PIL"] = MagicMock()
+
+# adjust path to find module
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import dora_lmdeploy
+
+class TestDoraLmdeploy(unittest.TestCase):
+    @patch("dora_lmdeploy.pipeline")
+    @patch("dora_lmdeploy.Node")
+    def test_text_inference(self, mock_node_cls, mock_pipeline_cls):
+        mock_node_instance = mock_node_cls.return_value
+        
+        # 1. input text event
+        event_text = {
+            "type": "INPUT",
+            "id": "text",
+            "value": MagicMock()
+        }
+        event_text["value"][0].as_py.return_value = "Hello World"
+        
+        # 2. simulate loop
+        mock_node_instance.__iter__.return_value = [event_text]
+        
+        # setup mock pipeline
+        mock_pipe_instance = mock_pipeline_cls.return_value
+        mock_response = MagicMock()
+        mock_response.text = "Hello there!"
+        mock_pipe_instance.side_effect = lambda x: mock_response
+
+        dora_lmdeploy.main()
+        
+        # verify call and output
+        mock_pipe_instance.assert_called_with("Hello World")
+        self.assertTrue(mock_node_instance.send_output.called)
+        args, _ = mock_node_instance.send_output.call_args
+        self.assertEqual(args[0], "response")
+        
+    @patch("dora_lmdeploy.pipeline")
+    @patch("dora_lmdeploy.Node")
+    @patch("dora_lmdeploy.Image")
+    def test_multimodal_inference(self, mock_image_cls, mock_node_cls, mock_pipeline_cls):
+        mock_node_instance = mock_node_cls.return_value
+        
+        # event 1: image
+        event_image = {
+            "type": "INPUT",
+            "id": "image",
+            "value": MagicMock()
+        }
+        event_image["value"].to_pybytes.return_value = b"fake_image_bytes"
+        
+        # event 2: text
+        event_text = {
+            "type": "INPUT",
+            "id": "text",
+            "value": MagicMock()
+        }
+        event_text["value"][0].as_py.return_value = "Describe this."
+        
+        mock_node_instance.__iter__.return_value = [event_image, event_text]
+        
+        # setup mock pipeline and image
+        mock_pipe_instance = mock_pipeline_cls.return_value
+        mock_response = MagicMock()
+        mock_response.text = "A beautiful sunset."
+        mock_pipe_instance.side_effect = lambda x: mock_response
+
+        mock_pil_image = MagicMock()
+        mock_image_cls.open.return_value = mock_pil_image
+
+        dora_lmdeploy.main()
+        
+        # verify logic
+        mock_image_cls.open.assert_called()
+        mock_pipe_instance.assert_called_with(("Describe this.", mock_pil_image))
+        mock_node_instance.send_output.assert_called()
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
dora-rs/dora-hub#24 

this PR introduces new dora-lmdeploy node, wrapping [LMDeploy](https://github.com/InternLM/lmdeploy) to bring high-performance LLM and VLM inference to dora.

uses lmdeploy.pipeline for fast inference, seamless handling of both text prompts and image inputs and added input validation to skip empty prompts and ensure stability