### PR TITLE
Fix busy polling in EventStream::recv_async to reduce CPU usage

### DIFF
--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -245,11 +245,7 @@ impl EventStream {
                     break;
                 }
             } else {
-                match select(Delay::new(Duration::from_micros(300)), self.receiver.next()).await {
-                    Either::Left((_elapsed, _)) => break,
-                    Either::Right((Some(event), _)) => self.scheduler.add_event(event),
-                    Either::Right((None, _)) => break,
-                };
+                break;
             }
         }
         let event = self.scheduler.next();


### PR DESCRIPTION
Fix CPU leak caused by busy polling in recv_async

Remove unnecessary micro-delay polling and return scheduled events immediately
when available, preventing sustained high CPU usage in long-running nodes.