### PR TITLE
Use new `dora run --stop-after` argument to simplify CI testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,7 +526,6 @@ jobs:
           # Test C++ template Project
           dora new test_cxx_project --lang cxx --internal-create-with-path-dependencies
           cd test_cxx_project
-          dora list
           cmake -B build
           cmake --build build
           cmake --install build


### PR DESCRIPTION
Use the new `--stop-after` argument introduced in #1308
