### PR TITLE
feat: add global environment variables support for dataflow

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1319,10 +1319,20 @@ impl Daemon {
             }
         }
 
+        let dataflow_descriptor_with_env = {
+            let mut desc = dataflow_descriptor.clone();
+            for node in desc.nodes.iter_mut() {
+                if let Some(resolved_node) = nodes.get(&node.id) {
+                    node.env = resolved_node.env.clone();
+                }
+            }
+            desc
+        };
+
         let spawner = Spawner {
             dataflow_id,
             daemon_tx: self.events_tx.clone(),
-            dataflow_descriptor,
+            dataflow_descriptor: dataflow_descriptor_with_env,
             clock: self.clock.clone(),
             uv,
         };

--- a/libraries/core/dora-schema.json
+++ b/libraries/core/dora-schema.json
@@ -4,6 +4,15 @@
   "description": "The main configuration structure for defining a Dora dataflow. Dataflows are\nspecified through YAML files that describe the nodes, their connections, and\nexecution parameters.\n\n## Structure\n\nA dataflow consists of:\n- **Nodes**: The computational units that process data\n- **Communication**: Optional communication configuration\n- **Deployment**: Optional deployment configuration (unstable)\n- **Debug options**: Optional development and debugging settings (unstable)\n\n## Example\n\n```yaml\nnodes:\n - id: webcam\n    operator:\n      python: webcam.py\n      inputs:\n        tick: dora/timer/millis/100\n      outputs:\n        - image\n  - id: plot\n    operator:\n      python: plot.py\n      inputs:\n        image: webcam/image\n```",
   "type": "object",
   "properties": {
+    "env": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": {
+        "$ref": "#/$defs/EnvValue"
+      }
+    },
     "nodes": {
       "description": "List of nodes in the dataflow\n\nThis is the most important field of the dataflow specification.\nEach node must be identified by a unique `id`:\n\n## Example\n\n```yaml\nnodes:\n  - id: foo\n    path: path/to/the/executable\n    # ... (see below)\n  - id: bar\n    path: path/to/another/executable\n    # ... (see below)\n```\n\nFor each node, you need to specify the `path` of the executable or script that Dora should run when starting the node.\nMost of the other node fields are optional, but you typically want to specify at least some `inputs` and/or `outputs`.",
       "type": "array",

--- a/libraries/message/src/descriptor.rs
+++ b/libraries/message/src/descriptor.rs
@@ -53,6 +53,9 @@ pub const DYNAMIC_SOURCE: &str = "dynamic";
 #[serde(deny_unknown_fields)]
 #[schemars(title = "dora-rs specification")]
 pub struct Descriptor {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub env: Option<BTreeMap<String, EnvValue>>,
+
     /// List of nodes in the dataflow
     ///
     /// This is the most important field of the dataflow specification.


### PR DESCRIPTION
# Add Global Environment Variables Support

Closes #1330

## Summary

Adds support for defining global environment variables at the top level of `dataflow.yml` that are automatically inherited by all nodes. Node-level `env` overrides global values.

## Changes

- **libraries/message/src/descriptor.rs**: Added `env` field to `Descriptor` struct at the dataflow root level
- **libraries/core/src/descriptor/mod.rs**: Added `merge_env()` helper and merge logic in `resolve_aliases_and_set_defaults()` (global + node, node overrides)
- **binaries/daemon/src/lib.rs**: Build descriptor with merged env before passing to spawner so dynamic nodes receive merged values
- **libraries/core/dora-schema.json**: Added `env` property to schema for IDE/tooling support

## Usage

```yaml
env:
  HAND_JOINT: "X1"
  CONTROL_RATE: "30"
  WEB_PORT: "8000"

nodes:
  - id: node-a
    env:
      WEB_PORT: "9000"

  - id: node-b
```

- `node-a` gets `HAND_JOINT`, `CONTROL_RATE`, and `WEB_PORT: "9000"`
- `node-b` gets all global env vars

## Backward Compatibility

Existing dataflows without a top-level `env` continue to work as before. The field is optional.
