### PR TITLE
CI: Stop Python async example after 5m

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -481,7 +481,7 @@ jobs:
         if: runner.os != 'Windows'
         env:
           RUST_LOG: debug
-        run: dora run examples/python-async/dataflow.yaml --uv
+        run: dora run examples/python-async/dataflow.yaml --uv --stop-after 5m
       - name: "Test Python Example: Drain"
         timeout-minutes: 30
         run: dora run examples/python-drain/dataflow.yaml --uv


### PR DESCRIPTION
The example often hangs for some reason. We assume that it's a async wakeup issue caused by some bug in the `experimental-async` feature of `pyo3`. This commits works around that issue by sending a stop signal after 5 minutes.
