### PR TITLE
feat(cli) : add system doctor command with shared memory feature

### DIFF
--- a/binaries/cli/src/command/system/doctor.rs
+++ b/binaries/cli/src/command/system/doctor.rs
@@ -1,0 +1,90 @@
+use crate::command::{Executable, default_tracing};
+use std::io::{IsTerminal, Write};
+use termcolor::{Color, ColorChoice, ColorSpec, WriteColor};
+
+#[derive(Debug, clap::Args)]
+pub struct Doctor {}
+
+impl Executable for Doctor {
+    fn execute(self) -> eyre::Result<()> {
+        default_tracing()?;
+        run_doctor_checks()
+    }
+}
+
+fn run_doctor_checks() -> eyre::Result<()> {
+    #[cfg(target_os = "linux")]
+    let mut issue_detected = false;
+
+    let color_choice = if std::io::stdout().is_terminal() {
+        ColorChoice::Auto
+    } else {
+        ColorChoice::Never
+    };
+    let mut stdout = termcolor::StandardStream::stdout(color_choice);
+
+    #[cfg(target_os = "linux")]
+    {
+        if let Some((message, fix_hint)) = shared_memory_issue() {
+            let _ = stdout.set_color(ColorSpec::new().set_fg(Some(Color::Yellow)));
+            write!(stdout, "⚠ ")?;
+            let _ = stdout.reset();
+            writeln!(stdout, "Shared memory: {message}")?;
+            writeln!(stdout, "  → Run: {fix_hint}")?;
+            issue_detected = true;
+        } else {
+            let _ = stdout.set_color(ColorSpec::new().set_fg(Some(Color::Green)));
+            write!(stdout, "✓ ")?;
+            let _ = stdout.reset();
+            writeln!(stdout, "Shared memory: Permissions OK")?;
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = stdout.set_color(ColorSpec::new().set_fg(Some(Color::Yellow)));
+        write!(stdout, "⚠ ")?;
+        let _ = stdout.reset();
+        writeln!(
+            stdout,
+            "Shared memory: Check skipped (only implemented for Linux /dev/shm)"
+        )?;
+    }
+
+    #[cfg(target_os = "linux")]
+    if issue_detected {
+        eyre::bail!("System doctor found issues.");
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn shared_memory_issue() -> Option<(&'static str, &'static str)> {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::Path;
+
+    let shm_path = Path::new("/dev/shm");
+    let metadata = match fs::metadata(shm_path) {
+        Ok(metadata) => metadata,
+        Err(_) => {
+            return Some((
+                "Directory not accessible",
+                "sudo mkdir -p /dev/shm && sudo chmod 1777 /dev/shm",
+            ));
+        }
+    };
+
+    if !metadata.is_dir() {
+        return Some(("Permission issue detected", "sudo chmod 1777 /dev/shm"));
+    }
+
+    let mode = metadata.permissions().mode() & 0o7777;
+    let expected = 0o1777;
+    if mode != expected {
+        return Some(("Permission issue detected", "sudo chmod 1777 /dev/shm"));
+    }
+
+    None
+}

--- a/binaries/cli/src/command/system/mod.rs
+++ b/binaries/cli/src/command/system/mod.rs
@@ -1,20 +1,24 @@
+pub mod doctor;
 pub mod status;
 
 pub use status::check_environment;
 
 use super::Executable;
+use doctor::Doctor;
 use status::Status;
 
 /// System management commands
 #[derive(Debug, clap::Subcommand)]
 pub enum System {
     Status(Status),
+    Doctor(Doctor),
 }
 
 impl Executable for System {
     fn execute(self) -> eyre::Result<()> {
         match self {
             System::Status(args) => args.execute(),
+            System::Doctor(args) => args.execute(),
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR introduces the initial implementation of the `dora system doctor` command, focusing on shared memory validation for Linux systems.

Dora relies on `/dev/shm` for inter-process communication. Incorrect permissions (expected `1777`) can lead to runtime issues when spawning or coordinating nodes. This command validates the shared memory configuration and provides actionable fix suggestions when misconfigured.

This addresses (#1211).
---
## What This PR Implements

- Adds new CLI command: `dora system doctor`
- Linux-only shared memory validation:
  - Verifies `/dev/shm` exists
  - Ensures it is a directory
  - Validates permissions are `1777` (sticky bit enabled)
- Clear CLI output:
  - `✓` when configuration is correct
  - `⚠` with fix suggestion when misconfigured
- Returns non-zero exit code if an issue is detected
- Gracefully skips the check on non-Linux platforms


## Scope & Rationale

The original issue (#1211) proposes multiple diagnostic checks (toolchains, ports, config integrity, etc.).

To keep the implementation incremental and well-scoped, this PR introduces a runtime-level diagnostic focused on shared memory only.

##  Example Output

```bash
$ dora system doctor

⚠ Shared memory: Incorrect permissions (expected 1777)
  → Run: sudo chmod 1777 /dev/shm

