### PR TITLE
Collect and report all errors in `dora check`

### DIFF
--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -49,10 +49,7 @@ pub fn check_dataflow(
                         } else if custom.build.is_some() {
                             info!("skipping path check for node with build command");
                         } else if let Err(err) = resolve_path(source, working_dir) {
-                            errors.push(format!(
-                                "node `{}`: could not find source path `{source}`: {err}",
-                                node.id
-                            ));
+                            errors.push(format!("node `{}`: {err}", node.id));
                         };
                     }
                 },


### PR DESCRIPTION
Instead of failing at the first error

Suggested in #1356 