### PR TITLE
CI: Increase stop timeout for Python operator example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,7 +467,7 @@ jobs:
         run: |
           echo "Running CI Operator Test"
           dora build examples/python-operator-dataflow/dataflow.yml --uv
-          dora run examples/python-operator-dataflow/dataflow.yml --uv --stop-after 10s
+          dora run examples/python-operator-dataflow/dataflow.yml --uv --stop-after 20s
 
       - name: "Test Python Example: Multiple Arrays"
         timeout-minutes: 30


### PR DESCRIPTION
The object detection node might be slow to initialize because of the `model = YOLO("yolov8n.pt")` line.

The stop-after timer does not wait until initialization is complete, so the stop might happen before all nodes/operators have been initialized. This led to CI failures, such as https://github.com/dora-rs/dora/actions/runs/22112921232/job/63929565837?pr=1358

By increasing the stop-after duration, we increase the chance that the operator is initialized when the stop is triggered.
