### PR TITLE
fix(install): implement --force flag parsing

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -78,6 +78,9 @@ while test $# -gt 0; do
       help
       exit 0
       ;;
+    --force | -f)
+      force=true
+      ;;
     --repo)
       repo=$2
       shift


### PR DESCRIPTION
This PR adds parsing for `--force/-f` in `install.sh`.

The flag is already documented in the help text, but it is currently ignored. This change keeps behavior aligned with the documented CLI options.