### PR TITLE
fix high cpu usage when event/drop stream errors keep retrying 

### DIFF
--- a/apis/rust/node/src/event_stream/thread.rs
+++ b/apis/rust/node/src/event_stream/thread.rs
@@ -129,8 +129,7 @@ fn event_stream_loop(
             }
             Err(err) => {
                 let err = err.wrap_err("failed to receive incoming event");
-                tracing::warn!("{err:?}");
-                continue;
+                break 'outer Err(err);
             }
         };
         for Timestamped { inner, timestamp } in events {

--- a/apis/rust/node/src/node/drop_stream.rs
+++ b/apis/rust/node/src/node/drop_stream.rs
@@ -128,8 +128,8 @@ fn drop_stream_loop(
             }
             Err(err) => {
                 let err = eyre!(err).wrap_err("failed to receive incoming drop event");
-                tracing::warn!("{err:?}");
-                continue;
+                tracing::error!("{err:?}");
+                break;
             }
         };
         for Timestamped { inner, timestamp } in events {


### PR DESCRIPTION
Fixes #1124

The event_stream_loop and drop_stream_loop  functions have a continue branch for error conditions (daemon errors, unexpected reply, channel errors). Without a delay, this results in a tight spin loop in the event of an error, and this is what causes the increasing CPU load in a data flow.

Added a sleep before each continue to make the thread back off instead of spinning on the channel.