### PR TITLE
feat(cli): add progress spinners to build and list commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1514,6 +1514,7 @@ dependencies = [
  "eyre",
  "futures",
  "git2",
+ "indicatif",
  "inquire 0.5.3",
  "itertools 0.14.0",
  "log",

--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -58,7 +58,7 @@ crossterm = "0.29.0"
 ratatui = "0.29.0"
 itertools = "0.14"
 sysinfo = "0.36.1"
-
+indicatif = "0.17"
 env_logger = "0.11.3"
 self_update = { version = "0.42.0", features = [
     "rustls",

--- a/binaries/cli/src/command/build/mod.rs
+++ b/binaries/cli/src/command/build/mod.rs
@@ -62,8 +62,8 @@ use crate::{
 };
 
 use distributed::{build_distributed_dataflow, wait_until_dataflow_built};
+use indicatif::{ProgressBar, ProgressStyle};
 use local::build_dataflow_locally;
-
 mod distributed;
 mod git;
 mod local;
@@ -193,6 +193,7 @@ pub async fn build_async(
                 .parent()
                 .ok_or_else(|| eyre::eyre!("dataflow path has no parent dir"))?
                 .to_owned();
+            let sp = spinner("Building dataflow locally...");
             let build_info = build_dataflow_locally(
                 dataflow_descriptor,
                 &git_sources,
@@ -201,7 +202,7 @@ pub async fn build_async(
                 uv,
             )
             .await?;
-
+            sp.finish_with_message("Build complete ✓");
             dataflow_session.git_sources = git_sources;
             // generate a random BuildId and store the associated build info
             dataflow_session.build_id = Some(BuildId::generate());
@@ -215,6 +216,8 @@ pub async fn build_async(
             let local_working_dir =
                 local_working_dir(&dataflow_path, &dataflow_descriptor, &coordinator_client)
                     .await?;
+            let sp = spinner("Building dataflow through coordinator...");
+
             let build_id = build_distributed_dataflow(
                 &coordinator_client,
                 dataflow_descriptor,
@@ -224,12 +227,12 @@ pub async fn build_async(
                 uv,
             )
             .await?;
-
+            sp.finish_with_message("Build submitted to coordinator ✓");
             dataflow_session.git_sources = git_sources;
             dataflow_session
                 .write_out_for_dataflow(&dataflow_path)
                 .context("failed to write out dataflow session file")?;
-
+            let sp = spinner("Waiting for build to complete...");
             // wait until dataflow build is finished
 
             wait_until_dataflow_built(
@@ -239,7 +242,7 @@ pub async fn build_async(
                 log::LevelFilter::Info,
             )
             .await?;
-
+            sp.finish_with_message("Build complete ✓");
             dataflow_session.build_id = Some(build_id);
             dataflow_session.local_build = None;
             dataflow_session
@@ -274,4 +277,15 @@ fn coordinator_socket(
     let coordinator_addr = coordinator_addr.unwrap_or(LOCALHOST);
     let coordinator_port = coordinator_port.unwrap_or(DORA_COORDINATOR_PORT_CONTROL_DEFAULT);
     (coordinator_addr, coordinator_port).into()
+}
+fn spinner(message: &str) -> ProgressBar {
+    let sp = ProgressBar::new_spinner();
+    sp.set_style(
+        ProgressStyle::default_spinner()
+            .template("{spinner:.green} {msg}")
+            .unwrap(),
+    );
+    sp.set_message(message.to_string());
+    sp.enable_steady_tick(std::time::Duration::from_millis(100));
+    sp
 }

--- a/binaries/cli/src/command/list.rs
+++ b/binaries/cli/src/command/list.rs
@@ -12,10 +12,10 @@ use dora_message::{
     cli_to_coordinator::CliControlClient, coordinator_to_cli::DataflowStatus, tarpc,
 };
 use eyre::{Context, eyre};
+use indicatif::{ProgressBar, ProgressStyle};
 use serde::Serialize;
 use tabwriter::TabWriter;
 use uuid::Uuid;
-
 #[derive(Debug, Args)]
 /// List running dataflows.
 pub struct ListArgs {
@@ -75,15 +75,17 @@ async fn list(
     name_filter: Option<String>,
     sort_by: Option<String>,
 ) -> Result<(), eyre::ErrReport> {
+    let sp = spinner("Fetching running dataflows...");
     let list = query_running_dataflows(client).await?;
-
+    sp.finish_with_message("Dataflows fetched ✓");
+    let sp = spinner("Fetching node metrics...");
     // Get node information via tarpc
     let node_infos = rpc(
         "get node info",
         client.get_node_info(tarpc::context::current()),
     )
     .await?;
-
+    sp.finish_with_message("Node metrics fetched ✓");
     // Aggregate metrics by dataflow UUID
     let mut dataflow_metrics: std::collections::BTreeMap<Uuid, DataflowMetrics> =
         std::collections::BTreeMap::new();
@@ -213,4 +215,15 @@ async fn list(
     }
 
     Ok(())
+}
+fn spinner(message: &str) -> ProgressBar {
+    let sp = ProgressBar::new_spinner();
+    sp.set_style(
+        ProgressStyle::default_spinner()
+            .template("{spinner:.green} {msg}")
+            .unwrap(),
+    );
+    sp.set_message(message.to_string());
+    sp.enable_steady_tick(std::time::Duration::from_millis(100));
+    sp
 }


### PR DESCRIPTION
Title: feat(cli): add progress spinners to build and list commands

## Description
This PR improves the UX of the CLI by adding visual feedback (spinners) for long-running operations.

## Changes
- Added `indicatif` dependency to `dora-cli`.
- Added spinners to `dora build` (resolving, fetching git, building).
- Added spinners to `dora list` (fetching dataflows, fetching nodes).

## Testing
- ran `cargo build -p dora-cli` ✅
- ran `dora build dataflow.yaml` and verified spinners appear.
- ran `dora list` and verified spinners appear.