### PR TITLE
Fix Python async example build dependencies causing CI failure

### DIFF
--- a/examples/python-async/dataflow.yaml
+++ b/examples/python-async/dataflow.yaml
@@ -1,6 +1,6 @@
 nodes:
   - id: send_data
-    build: pip install asyncio
+    build: pip install numpy pyarrow
     path: ./send_data.py
     inputs:
       tick: dora/timer/millis/10
@@ -8,7 +8,7 @@ nodes:
       - data
 
   - id: receive_data_with_sleep
-    build: pip install numpy pyarrow
+    build: pip install asyncio
     path: ./receive_data.py
     inputs:
       tick: send_data/data


### PR DESCRIPTION
The build dependencies in the async example dataflow were swapped:
send_data.py imports numpy+pyarrow but its build step only installed
asyncio, while receive_data.py only needs asyncio+dora but its build
step installed numpy+pyarrow. This causes an ImportError when
pyarrow >= 15 is resolved (which no longer bundles numpy).