### PR TITLE
Refactor: remove empty_set workaround by using const BTreeSet::new()

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -89,7 +89,7 @@ use crate::{extract_err_from_stderr::extract_err_from_stderr, pending::DataflowS
 
 const STDERR_LOG_LINES_MAX: usize = 500;
 
-const EMPTY_SET: BTreeSet<DataId> = BTreeSet::new();
+static EMPTY_SET: BTreeSet<DataId> = BTreeSet::new();
 
 pub struct Daemon {
     pub(crate) state: Arc<state::DaemonState>,


### PR DESCRIPTION
Removed the `empty_set` field from [RunningDataflow]. Since `BTreeSet::new()` is available as a `const fn` on the MSRV (1.85.0), we can just replace the struct field with a module-level constant. This completes the TODO comment in [daemon/src/lib.rs]