### PR TITLE
[Refactor] Remove deprecated with_jaeger_tracing from dora-tracing

### DIFF
--- a/libraries/extensions/telemetry/tracing/src/lib.rs
+++ b/libraries/extensions/telemetry/tracing/src/lib.rs
@@ -166,12 +166,6 @@ impl TracingBuilder {
         Ok(self)
     }
 
-    /// Legacy method name for backward compatibility.
-    #[deprecated(since = "0.4.0", note = "Use `with_otlp_tracing` instead")]
-    pub fn with_jaeger_tracing(self) -> eyre::Result<Self> {
-        self.with_otlp_tracing()
-    }
-
     pub fn add_layer<L>(mut self, layer: L) -> Self
     where
         L: Layer<Registry> + Send + Sync + 'static,


### PR DESCRIPTION
## Change Summary

Removed the deprecated `with_jaeger_tracing` method from the [TracingBuilder] in the `dora-tracing` crate.

| Item                 | Detail                                                                                     |
|----------------------|--------------------------------------------------------------------------------------------|
| **File modified**     | [`lib.rs`]                                |
| **Lines removed**     | 6 (doc comment, attribute, method body, blank line)                                         |
| **Deprecated since**  | v0.4.0                                                                                     |
| **Replacement**       | [`with_otlp_tracing`] (same file, actively used) |
| **Callers found**     | 0 — confirmed via case-insensitive [rg] across entire repo |

## Why This Is Safe

1. **Zero callers** — `rg -i "with_jaeger_tracing"` returned only the definition site itself.
2. **Trivial delegation** — The removed method was simply delegating to `self.with_otlp_tracing()`, adding no extra logic.
3. **Published crate, but version-controlled** — The deprecation was introduced in v0.4.0, and the workspace is currently at v0.4.1, meaning a full minor version has passed since the deprecation notice.

## Verification Results

The two methods are functionally identical — `with_jaeger_tracing` was merely a direct delegation to [`with_otlp_tracing`]

## Verification Checklist

- [x] `cargo check -p dora-tracing` — Compiles cleanly.
- [x] `cargo clippy -p dora-tracing -- -D warnings` — No warnings.
- [x] `cargo check --all` — Full workspace compiles with no downstream breakage.
- [x] `cargo fmt -p dora-tracing -- --check` — No formatting diffs.
- [x] Codebase-wide search (`rg -i "with_jaeger_tracing"`) confirms no remaining references.