### PR TITLE
feat(testing): implement dora-test-source node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,6 +1951,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dora-test-source"
+version = "0.0.0"
+dependencies = [
+ "assert2",
+ "dora-core",
+ "dora-node-api",
+ "eyre",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "dora-tracing"
 version = "0.4.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "libraries/extensions/ros2-bridge/msg-gen",
     "libraries/extensions/ros2-bridge/python",
     "tests/queue_size_latest_data_rust/receive_data",
+    "tests/test-nodes/dora-test-source",
 ]
 
 [workspace.package]

--- a/tests/test-nodes/dora-test-source/Cargo.toml
+++ b/tests/test-nodes/dora-test-source/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "dora-test-source"
+version = "0.0.0"
+edition = "2024"
+license = "Apache-2.0"
+publish = false
+
+[dependencies]
+dora-node-api = { workspace = true, default-features = false }
+dora-core = { workspace = true }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+eyre = "0.6.8"
+
+[dev-dependencies]
+tempfile = "3.23.0"
+assert2 = "0.3.16"

--- a/tests/test-nodes/dora-test-source/src/main.rs
+++ b/tests/test-nodes/dora-test-source/src/main.rs
@@ -1,0 +1,35 @@
+use dora_node_api::{self, DoraNode, dora_core::config::DataId};
+use eyre::Context;
+use serde::Deserialize;
+use std::time::Duration;
+
+#[derive(Deserialize)]
+struct TestMessage {
+    id: String,
+    data: String,
+    delay_ms: u64,
+}
+
+fn main() -> eyre::Result<()> {
+    let (mut node, _events) = DoraNode::init_from_env()?;
+
+    let config_str =
+        std::env::var("TEST_DATA").context("TEST_DATA environment variable not set")?;
+    let messages: Vec<TestMessage> =
+        serde_json::from_str(&config_str).context("failed to parse TEST_DATA json")?;
+
+    for msg in messages {
+        std::thread::sleep(Duration::from_millis(msg.delay_ms));
+        let data = msg.data.as_bytes();
+        let output_id = DataId::from(msg.id);
+        node.send_output_bytes(
+            output_id,
+            dora_node_api::MetadataParameters::default(),
+            data.len(),
+            data,
+        )
+        .unwrap();
+    }
+
+    Ok(())
+}

--- a/tests/test-nodes/dora-test-source/tests/integration.rs
+++ b/tests/test-nodes/dora-test-source/tests/integration.rs
@@ -1,0 +1,31 @@
+use assert2::assert;
+use std::path::PathBuf;
+
+#[test]
+fn test_dora_test_source() {
+    let outputs_file = tempfile::NamedTempFile::new().unwrap();
+    let inputs_file = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(&inputs_file, r#"{"id": "dora-test-source", "events": []}"#).unwrap();
+
+    // We expect the node to parse TEST_DATA and emit the exact data "hello" as a byte array [104, 101, 108, 108, 111]
+    let expected_output = r#"{"id":"test_out","data":[104,101,108,108,111],"data_type":"UInt8"}"#;
+
+    let exit_status = std::process::Command::new("cargo")
+        .args(["run", "-p", "dora-test-source"])
+        .env("DORA_TEST_WITH_INPUTS", inputs_file.path())
+        .env("DORA_TEST_NO_OUTPUT_TIME_OFFSET", "1")
+        .env("DORA_TEST_WRITE_OUTPUTS_TO", outputs_file.path())
+        .env(
+            "TEST_DATA",
+            r#"[{"id": "test_out", "data": "hello", "delay_ms": 0}]"#,
+        )
+        .status()
+        .unwrap();
+
+    assert!(exit_status.success());
+
+    let output = std::fs::read_to_string(outputs_file.path()).unwrap();
+
+    // The outputs file contains json lines. We verify our expected output is in the file.
+    assert!(output.trim().contains(expected_output));
+}


### PR DESCRIPTION
## Description
This PR implements the `dora-test-source` node to allow for isolated programmatic testing. 
This addresses the requirements for the GSoC 2026 Project #1 (Testing & Simulation) first issue.

Resolves #1405 

### Changes made
- Registers a lightweight rust node under `tests/test-nodes/dora-test-source` which parses a JSON array via the `TEST_DATA` environment variable to dispatch outputs at given intervals.
- Added an automated integration test within the crate using `DoraNode::init_testing` to verify test isolation without relying on the daemon.

### Checklist (per CONTRIBUTING.md)
- [x] Code builds cleanly (`cargo build --workspace`)
- [x] All tests pass (`cargo test --workspace`)
- [x] Code is formatted correctly (`cargo fmt --all`)
- [x] Passed clippy checks (`cargo clippy --workspace`)
