### PR TITLE
feat(c++/node): add event receive variants (timeout, non-blocking, drain)

### DIFF
--- a/apis/c++/node/src/lib.rs
+++ b/apis/c++/node/src/lib.rs
@@ -1,11 +1,11 @@
-use std::{any::Any, collections::BTreeMap, vec};
+use std::{any::Any, collections::BTreeMap, time::Duration, vec};
 
 use crate::ffi::MetadataValueType;
 
 use chrono::DateTime;
 use dora_node_api::{
     self, Event, EventStream, Metadata as DoraMetadata,
-    MetadataParameters as DoraMetadataParameters, Parameter as DoraParameter,
+    MetadataParameters as DoraMetadataParameters, Parameter as DoraParameter, TryRecvError,
     arrow::array::{AsArray, UInt8Array},
     merged::{MergeExternal, MergedEvent},
 };
@@ -36,6 +36,7 @@ mod ffi {
         Error,
         Unknown,
         AllInputsClosed,
+        Timeout,
     }
 
     struct DoraInput {
@@ -80,6 +81,7 @@ mod ffi {
         type MergedDoraEvent;
         type Metadata;
         type DataSampleHandle;
+        type DrainedEvents;
 
         fn init_dora_node() -> Result<DoraNode>;
         fn init_dora_node_from_id(node_id: String) -> Result<DoraNode>;
@@ -92,7 +94,14 @@ mod ffi {
         fn empty_combined_events() -> CombinedEvents;
         fn next(self: &mut Events) -> Box<DoraEvent>;
         fn next_event(events: &mut Box<Events>) -> Box<DoraEvent>;
+        fn next_event_timeout(events: &mut Box<Events>, timeout_ms: u64) -> Box<DoraEvent>;
+        fn try_next_event(events: &mut Box<Events>) -> Box<DoraEvent>;
+        fn events_is_empty(events: &Box<Events>) -> bool;
         fn event_type(event: &Box<DoraEvent>) -> DoraEventType;
+
+        fn drain_events(events: &mut Box<Events>) -> Box<DrainedEvents>;
+        fn drained_events_len(drained: &Box<DrainedEvents>) -> usize;
+        fn drained_events_next(drained: &mut Box<DrainedEvents>) -> Box<DoraEvent>;
         fn event_as_input(event: Box<DoraEvent>) -> Result<DoraInput>;
         fn send_output(
             output_sender: &mut Box<OutputSender>,
@@ -231,12 +240,84 @@ pub struct Events(EventStream);
 
 impl Events {
     fn next(&mut self) -> Box<DoraEvent> {
-        Box::new(DoraEvent(self.0.recv()))
+        Box::new(DoraEvent {
+            event: self.0.recv(),
+            timed_out: false,
+        })
     }
 }
 
 fn next_event(events: &mut Box<Events>) -> Box<DoraEvent> {
     events.next()
+}
+
+fn next_event_timeout(events: &mut Box<Events>, timeout_ms: u64) -> Box<DoraEvent> {
+    let dur = Duration::from_millis(timeout_ms);
+    match events.0.recv_timeout(dur) {
+        Some(event) => {
+            let timed_out = matches!(&event, Event::Error(msg) if msg.contains("timed out"));
+            if timed_out {
+                Box::new(DoraEvent {
+                    event: None,
+                    timed_out: true,
+                })
+            } else {
+                Box::new(DoraEvent {
+                    event: Some(event),
+                    timed_out: false,
+                })
+            }
+        }
+        None => Box::new(DoraEvent {
+            event: None,
+            timed_out: false,
+        }),
+    }
+}
+
+fn try_next_event(events: &mut Box<Events>) -> Box<DoraEvent> {
+    match events.0.try_recv() {
+        Ok(event) => Box::new(DoraEvent {
+            event: Some(event),
+            timed_out: false,
+        }),
+        Err(TryRecvError::Empty) => Box::new(DoraEvent {
+            event: None,
+            timed_out: true,
+        }),
+        Err(TryRecvError::Closed) => Box::new(DoraEvent {
+            event: None,
+            timed_out: false,
+        }),
+    }
+}
+
+fn events_is_empty(events: &Box<Events>) -> bool {
+    events.0.is_empty()
+}
+
+pub struct DrainedEvents(std::collections::VecDeque<Event>);
+
+fn drain_events(events: &mut Box<Events>) -> Box<DrainedEvents> {
+    let evts = events.0.drain().unwrap_or_default();
+    Box::new(DrainedEvents(evts.into()))
+}
+
+fn drained_events_len(drained: &Box<DrainedEvents>) -> usize {
+    drained.0.len()
+}
+
+fn drained_events_next(drained: &mut Box<DrainedEvents>) -> Box<DoraEvent> {
+    match drained.0.pop_front() {
+        Some(e) => Box::new(DoraEvent {
+            event: Some(e),
+            timed_out: false,
+        }),
+        None => Box::new(DoraEvent {
+            event: None,
+            timed_out: true,
+        }),
+    }
 }
 
 fn dora_events_into_combined(events: Box<Events>) -> ffi::CombinedEvents {
@@ -258,10 +339,16 @@ fn empty_combined_events() -> ffi::CombinedEvents {
     }
 }
 
-pub struct DoraEvent(Option<Event>);
+pub struct DoraEvent {
+    event: Option<Event>,
+    timed_out: bool,
+}
 
 fn event_type(event: &DoraEvent) -> ffi::DoraEventType {
-    match &event.0 {
+    if event.timed_out {
+        return ffi::DoraEventType::Timeout;
+    }
+    match &event.event {
         Some(event) => match event {
             Event::Stop(_) => ffi::DoraEventType::Stop,
             Event::Input { .. } => ffi::DoraEventType::Input,
@@ -274,7 +361,7 @@ fn event_type(event: &DoraEvent) -> ffi::DoraEventType {
 }
 
 fn event_as_input(event: Box<DoraEvent>) -> eyre::Result<ffi::DoraInput> {
-    let Some(Event::Input { id, metadata, data }) = event.0 else {
+    let Some(Event::Input { id, metadata, data }) = event.event else {
         bail!("not an input event");
     };
     let data = match metadata.type_info.data_type {
@@ -310,7 +397,7 @@ unsafe fn event_as_arrow_input(
         id: _,
         metadata: _,
         data,
-    }) = event.0
+    }) = event.event
     else {
         return ffi::DoraResult {
             error: "Not an input event".to_string(),
@@ -598,7 +685,7 @@ unsafe fn event_as_arrow_input_with_info(
     let out_array = out_array as *mut arrow::ffi::FFI_ArrowArray;
     let out_schema = out_schema as *mut arrow::ffi::FFI_ArrowSchema;
 
-    let Some(Event::Input { id, metadata, data }) = event.0 else {
+    let Some(Event::Input { id, metadata, data }) = event.event else {
         return ffi::ArrowInputInfo {
             id: String::new(),
             metadata: Box::new(Metadata::empty()),
@@ -902,7 +989,10 @@ impl ffi::CombinedEvent {
 
 fn downcast_dora(event: ffi::CombinedEvent) -> eyre::Result<Box<DoraEvent>> {
     match event.event.0 {
-        Some(MergedEvent::Dora(event)) => Ok(Box::new(DoraEvent(Some(event)))),
+        Some(MergedEvent::Dora(event)) => Ok(Box::new(DoraEvent {
+            event: Some(event),
+            timed_out: false,
+        })),
         _ => eyre::bail!("not an external event"),
     }
 }

--- a/examples/c++-dataflow/node-rust-api/main.cc
+++ b/examples/c++-dataflow/node-rust-api/main.cc
@@ -21,6 +21,12 @@ int main()
         return -1;
     }
 
+    // Demonstrate try_next_event (non-blocking poll)
+    auto poll = try_next_event(dora_node.events);
+    if (event_type(poll) == DoraEventType::Timeout) {
+        std::cout << "No event ready yet (non-blocking)" << std::endl;
+    }
+
     for (int i = 0; i < 20; i++)
     {
 


### PR DESCRIPTION
## Summary
- Add `try_next_event()` for non-blocking event polling
- Add `next_event_timeout(events, timeout_ms)` for timed blocking receive
- Add `events_is_empty()` to check if events are buffered
- Add `drain_events()` / `drained_events_len()` / `drained_events_next()` for batch draining
- Add `DoraEventType::Timeout` variant to distinguish timeout from stream closure

Refactors `DoraEvent` from tuple struct to named fields (`event`, `timed_out`) to cleanly distinguish timeout from real errors — `recv_timeout` returns `Event::Error("Receiver timed out")` on timeout, which we intercept.

## Usage (C++)
```cpp
// Non-blocking poll
auto poll = try_next_event(dora_node.events);
if (event_type(poll) == DoraEventType::Timeout) {
    // no event ready
}

// Timed blocking (100ms)
auto ev = next_event_timeout(dora_node.events, 100);

// Drain all buffered events
auto drained = drain_events(dora_node.events);
auto len = drained_events_len(drained);
```