### PR TITLE
feat(c++/node): add close_outputs, NodeFailed and Reload event types

### DIFF
--- a/apis/c++/node/src/lib.rs
+++ b/apis/c++/node/src/lib.rs
@@ -1,11 +1,11 @@
-use std::{any::Any, collections::BTreeMap, vec};
+use std::{any::Any, collections::BTreeMap, time::Duration, vec};
 
 use crate::ffi::MetadataValueType;
 
 use chrono::DateTime;
 use dora_node_api::{
     self, Event, EventStream, Metadata as DoraMetadata,
-    MetadataParameters as DoraMetadataParameters, Parameter as DoraParameter,
+    MetadataParameters as DoraMetadataParameters, Parameter as DoraParameter, TryRecvError,
     arrow::array::{AsArray, UInt8Array},
     merged::{MergeExternal, MergedEvent},
 };
@@ -36,6 +36,7 @@ mod ffi {
         Error,
         Unknown,
         AllInputsClosed,
+        Timeout,
     }
 
     struct DoraInput {
@@ -80,6 +81,7 @@ mod ffi {
         type MergedDoraEvent;
         type Metadata;
         type DataSampleHandle;
+        type DrainedEvents;
 
         fn init_dora_node() -> Result<DoraNode>;
         fn init_dora_node_from_id(node_id: String) -> Result<DoraNode>;
@@ -92,7 +94,14 @@ mod ffi {
         fn empty_combined_events() -> CombinedEvents;
         fn next(self: &mut Events) -> Box<DoraEvent>;
         fn next_event(events: &mut Box<Events>) -> Box<DoraEvent>;
+        fn next_event_timeout(events: &mut Box<Events>, timeout_ms: u64) -> Box<DoraEvent>;
+        fn try_next_event(events: &mut Box<Events>) -> Box<DoraEvent>;
+        fn events_is_empty(events: &Box<Events>) -> bool;
         fn event_type(event: &Box<DoraEvent>) -> DoraEventType;
+
+        fn drain_events(events: &mut Box<Events>) -> Box<DrainedEvents>;
+        fn drained_events_len(drained: &Box<DrainedEvents>) -> usize;
+        fn drained_events_next(drained: &mut Box<DrainedEvents>) -> Box<DoraEvent>;
         fn event_as_input(event: Box<DoraEvent>) -> Result<DoraInput>;
         fn send_output(
             output_sender: &mut Box<OutputSender>,
@@ -231,12 +240,84 @@ pub struct Events(EventStream);
 
 impl Events {
     fn next(&mut self) -> Box<DoraEvent> {
-        Box::new(DoraEvent(self.0.recv()))
+        Box::new(DoraEvent {
+            event: self.0.recv(),
+            timed_out: false,
+        })
     }
 }
 
 fn next_event(events: &mut Box<Events>) -> Box<DoraEvent> {
     events.next()
+}
+
+fn next_event_timeout(events: &mut Box<Events>, timeout_ms: u64) -> Box<DoraEvent> {
+    let dur = Duration::from_millis(timeout_ms);
+    match events.0.recv_timeout(dur) {
+        Some(event) => {
+            let timed_out = matches!(&event, Event::Error(msg) if msg.contains("timed out"));
+            if timed_out {
+                Box::new(DoraEvent {
+                    event: None,
+                    timed_out: true,
+                })
+            } else {
+                Box::new(DoraEvent {
+                    event: Some(event),
+                    timed_out: false,
+                })
+            }
+        }
+        None => Box::new(DoraEvent {
+            event: None,
+            timed_out: false,
+        }),
+    }
+}
+
+fn try_next_event(events: &mut Box<Events>) -> Box<DoraEvent> {
+    match events.0.try_recv() {
+        Ok(event) => Box::new(DoraEvent {
+            event: Some(event),
+            timed_out: false,
+        }),
+        Err(TryRecvError::Empty) => Box::new(DoraEvent {
+            event: None,
+            timed_out: true,
+        }),
+        Err(TryRecvError::Closed) => Box::new(DoraEvent {
+            event: None,
+            timed_out: false,
+        }),
+    }
+}
+
+fn events_is_empty(events: &Box<Events>) -> bool {
+    events.0.is_empty()
+}
+
+pub struct DrainedEvents(std::collections::VecDeque<Event>);
+
+fn drain_events(events: &mut Box<Events>) -> Box<DrainedEvents> {
+    let evts = events.0.drain().unwrap_or_default();
+    Box::new(DrainedEvents(evts.into()))
+}
+
+fn drained_events_len(drained: &Box<DrainedEvents>) -> usize {
+    drained.0.len()
+}
+
+fn drained_events_next(drained: &mut Box<DrainedEvents>) -> Box<DoraEvent> {
+    match drained.0.pop_front() {
+        Some(e) => Box::new(DoraEvent {
+            event: Some(e),
+            timed_out: false,
+        }),
+        None => Box::new(DoraEvent {
+            event: None,
+            timed_out: true,
+        }),
+    }
 }
 
 fn dora_events_into_combined(events: Box<Events>) -> ffi::CombinedEvents {
@@ -258,10 +339,16 @@ fn empty_combined_events() -> ffi::CombinedEvents {
     }
 }
 
-pub struct DoraEvent(Option<Event>);
+pub struct DoraEvent {
+    event: Option<Event>,
+    timed_out: bool,
+}
 
 fn event_type(event: &DoraEvent) -> ffi::DoraEventType {
-    match &event.0 {
+    if event.timed_out {
+        return ffi::DoraEventType::Timeout;
+    }
+    match &event.event {
         Some(event) => match event {
             Event::Stop(_) => ffi::DoraEventType::Stop,
             Event::Input { .. } => ffi::DoraEventType::Input,
@@ -274,7 +361,7 @@ fn event_type(event: &DoraEvent) -> ffi::DoraEventType {
 }
 
 fn event_as_input(event: Box<DoraEvent>) -> eyre::Result<ffi::DoraInput> {
-    let Some(Event::Input { id, metadata, data }) = event.0 else {
+    let Some(Event::Input { id, metadata, data }) = event.event else {
         bail!("not an input event");
     };
     let data = match metadata.type_info.data_type {
@@ -310,7 +397,7 @@ unsafe fn event_as_arrow_input(
         id: _,
         metadata: _,
         data,
-    }) = event.0
+    }) = event.event
     else {
         return ffi::DoraResult {
             error: "Not an input event".to_string(),
@@ -598,7 +685,7 @@ unsafe fn event_as_arrow_input_with_info(
     let out_array = out_array as *mut arrow::ffi::FFI_ArrowArray;
     let out_schema = out_schema as *mut arrow::ffi::FFI_ArrowSchema;
 
-    let Some(Event::Input { id, metadata, data }) = event.0 else {
+    let Some(Event::Input { id, metadata, data }) = event.event else {
         return ffi::ArrowInputInfo {
             id: String::new(),
             metadata: Box::new(Metadata::empty()),
@@ -902,7 +989,10 @@ impl ffi::CombinedEvent {
 
 fn downcast_dora(event: ffi::CombinedEvent) -> eyre::Result<Box<DoraEvent>> {
     match event.event.0 {
-        Some(MergedEvent::Dora(event)) => Ok(Box::new(DoraEvent(Some(event)))),
+        Some(MergedEvent::Dora(event)) => Ok(Box::new(DoraEvent {
+            event: Some(event),
+            timed_out: false,
+        })),
         _ => eyre::bail!("not an external event"),
     }
 }

--- a/apis/c++/node/src/lib.rs
+++ b/apis/c++/node/src/lib.rs
@@ -37,6 +37,8 @@ mod ffi {
         Unknown,
         AllInputsClosed,
         Timeout,
+        NodeFailed,
+        Reload,
     }
 
     struct DoraInput {
@@ -46,6 +48,12 @@ mod ffi {
 
     struct DoraResult {
         error: String,
+    }
+
+    struct DoraNodeFailed {
+        affected_input_ids: Vec<String>,
+        error: String,
+        source_node_id: String,
     }
 
     struct ArrowInputInfo {
@@ -103,6 +111,11 @@ mod ffi {
         fn drained_events_len(drained: &Box<DrainedEvents>) -> usize;
         fn drained_events_next(drained: &mut Box<DrainedEvents>) -> Box<DoraEvent>;
         fn event_as_input(event: Box<DoraEvent>) -> Result<DoraInput>;
+        fn event_as_node_failed(event: Box<DoraEvent>) -> Result<DoraNodeFailed>;
+        fn close_outputs(
+            output_sender: &mut Box<OutputSender>,
+            output_ids: Vec<String>,
+        ) -> DoraResult;
         fn send_output(
             output_sender: &mut Box<OutputSender>,
             id: String,
@@ -354,6 +367,8 @@ fn event_type(event: &DoraEvent) -> ffi::DoraEventType {
             Event::Input { .. } => ffi::DoraEventType::Input,
             Event::InputClosed { .. } => ffi::DoraEventType::InputClosed,
             Event::Error(_) => ffi::DoraEventType::Error,
+            Event::NodeFailed { .. } => ffi::DoraEventType::NodeFailed,
+            Event::Reload { .. } => ffi::DoraEventType::Reload,
             _ => ffi::DoraEventType::Unknown,
         },
         None => ffi::DoraEventType::AllInputsClosed,
@@ -382,6 +397,38 @@ fn event_as_input(event: Box<DoraEvent>) -> eyre::Result<ffi::DoraInput> {
         id: id.into(),
         data,
     })
+}
+
+fn event_as_node_failed(event: Box<DoraEvent>) -> eyre::Result<ffi::DoraNodeFailed> {
+    let Some(Event::NodeFailed {
+        affected_input_ids,
+        error,
+        source_node_id,
+    }) = event.event
+    else {
+        bail!("not a NodeFailed event");
+    };
+    Ok(ffi::DoraNodeFailed {
+        affected_input_ids: affected_input_ids
+            .into_iter()
+            .map(|id| id.to_string())
+            .collect(),
+        error,
+        source_node_id: source_node_id.to_string(),
+    })
+}
+
+fn close_outputs(sender: &mut Box<OutputSender>, output_ids: Vec<String>) -> ffi::DoraResult {
+    let ids: Vec<dora_node_api::dora_core::config::DataId> =
+        output_ids.into_iter().map(|s| s.into()).collect();
+    match sender.0.close_outputs(ids) {
+        Ok(()) => ffi::DoraResult {
+            error: String::new(),
+        },
+        Err(err) => ffi::DoraResult {
+            error: format!("{err:?}"),
+        },
+    }
 }
 
 unsafe fn event_as_arrow_input(

--- a/examples/c++-dataflow/node-rust-api/main.cc
+++ b/examples/c++-dataflow/node-rust-api/main.cc
@@ -21,6 +21,12 @@ int main()
         return -1;
     }
 
+    // Demonstrate try_next_event (non-blocking poll)
+    auto poll = try_next_event(dora_node.events);
+    if (event_type(poll) == DoraEventType::Timeout) {
+        std::cout << "No event ready yet (non-blocking)" << std::endl;
+    }
+
     for (int i = 0; i < 20; i++)
     {
 

--- a/examples/c++-dataflow/node-rust-api/main.cc
+++ b/examples/c++-dataflow/node-rust-api/main.cc
@@ -55,6 +55,16 @@ int main()
                 return -1;
             }
         }
+        else if (ty == DoraEventType::NodeFailed)
+        {
+            auto failed = event_as_node_failed(std::move(event));
+            std::cerr << "Node failed: source=" << std::string(failed.source_node_id)
+                      << " error=" << std::string(failed.error) << std::endl;
+        }
+        else if (ty == DoraEventType::Reload)
+        {
+            std::cout << "Reload event received" << std::endl;
+        }
         else
         {
             std::cerr << "Unknown event type " << static_cast<int>(ty) << std::endl;


### PR DESCRIPTION
## Summary
- Add `close_outputs(sender, output_ids)` to selectively close node outputs from C++
- Add `DoraEventType::NodeFailed` and `DoraEventType::Reload` enum variants
- Add `event_as_node_failed(event)` accessor returning `DoraNodeFailed` struct with affected input IDs, error message, and source node ID

> **Stacked on** #1409 (Phase 2) — merge that first, then this PR's diff is just the 1 new commit.

## Usage (C++)
```cpp
// Close specific outputs
rust::Vec<rust::String> ids;
ids.push_back("output_a");
auto result = close_outputs(dora_node.send_output, ids);

// Handle node failure events
if (ty == DoraEventType::NodeFailed) {
    auto failed = event_as_node_failed(std::move(event));
    std::cerr << "Node " << failed.source_node_id << " failed: " << failed.error;
}
```