### PR TITLE
fix(daemon): insert into grace_duration_kills before sending SIGTERM

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -3185,9 +3185,8 @@ impl RunningDataflow {
 
                 for (node, proc) in &running_processes {
                     if let Some(proc) = proc {
-                        if proc.submit(crate::ProcessOperation::SoftKill) {
-                            grace_duration_kills.insert(node.clone());
-                        }
+                        grace_duration_kills.insert(node.clone());
+                        proc.submit(crate::ProcessOperation::SoftKill);
                     }
                 }
 
@@ -3196,13 +3195,12 @@ impl RunningDataflow {
 
                 for (node, proc) in &running_processes {
                     if let Some(proc) = proc {
-                        if proc.submit(crate::ProcessOperation::Kill) {
-                            grace_duration_kills.insert(node.clone());
-                            warn!(
-                                "{node} was killed due to not stopping within the {:#?} grace period",
-                                duration + kill_duration
-                            );
-                        }
+                        grace_duration_kills.insert(node.clone());
+                        proc.submit(crate::ProcessOperation::Kill);
+                        warn!(
+                            "{node} was killed due to not stopping within the {:#?} grace period",
+                            duration + kill_duration
+                        );
                     }
                 }
             });
@@ -3249,9 +3247,8 @@ impl RunningDataflow {
 
                 for (node, proc) in &running_processes {
                     if let Some(proc) = proc {
-                        if proc.submit(crate::ProcessOperation::SoftKill) {
-                            grace_duration_kills.insert(node.clone());
-                        }
+                        grace_duration_kills.insert(node.clone());
+                        proc.submit(crate::ProcessOperation::SoftKill);
                     }
                 }
 
@@ -3260,13 +3257,12 @@ impl RunningDataflow {
 
                 for (node, proc) in &running_processes {
                     if let Some(proc) = proc {
-                        if proc.submit(crate::ProcessOperation::Kill) {
-                            grace_duration_kills.insert(node.clone());
-                            warn!(
-                                "{node} was killed due to not stopping within the {:#?} grace period",
-                                duration + kill_duration
-                            );
-                        }
+                        grace_duration_kills.insert(node.clone());
+                        proc.submit(crate::ProcessOperation::Kill);
+                        warn!(
+                            "{node} was killed due to not stopping within the {:#?} grace period",
+                            duration + kill_duration
+                        );
                     }
                 }
             });


### PR DESCRIPTION
This fixes a race condition where nodes killed by SIGTERM during a managed
--stop-after shutdown were incorrectly treated as failures. The node exit
handler checks grace_duration_kills to distinguish intentional kills from
crashes, but the insert happened after submit, allowing the node to exit
and be processed before being marked.

By inserting into grace_duration_kills before sending the signal, the exit
handler will always see the node as intentionally killed.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
