### PR TITLE
fix(example): use node.next() in sender to handle stop events gracefully

### DIFF
--- a/examples/python-dataflow/sender.py
+++ b/examples/python-dataflow/sender.py
@@ -1,7 +1,6 @@
 """Simple sender node that sends 100 messages and then exits."""
 
 import logging
-import time
 
 import pyarrow as pa
 from dora import Node
@@ -11,15 +10,18 @@ def main():
     node = Node()
 
     for i in range(100):
-        # Create a simple Apache Arrow array with the message number
         data = pa.array([i])
         node.send_output("message", data)
         logging.info("Sent message %d", i)
 
-        # wait a bit before sending the next message
-        time.sleep(0.1)
+        # Use node.next() with timeout instead of time.sleep()
+        # so the node can respond to stop events promptly
+        event = node.next(timeout=0.1)
+        if event is not None and event["type"] == "STOP":
+            logging.info("Sender stopping early at message %d", i)
+            break
 
-    logging.info("Sender finished - sent 100 messages")
+    logging.info("Sender finished")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Replace time.sleep(0.1) with node.next(timeout=0.1) so the sender node
can receive and respond to STOP events, preventing SIGTERM (exit 143)
when the stop-after grace duration expires during CI.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
