### PR TITLE
feat(cli): add progress bars to time-consuming operations

### DIFF
--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -77,6 +77,7 @@ git2 = { workspace = true }
 zenoh = { workspace = true }
 arrow-json.workspace = true
 chrono = "0.4.42"
+indicatif = "0.17"
 
 [build-dependencies]
 pyo3-build-config = "0.23"

--- a/binaries/cli/src/command/build/local.rs
+++ b/binaries/cli/src/command/build/local.rs
@@ -8,6 +8,7 @@ use dora_core::{
 use dora_message::{common::GitSource, id::NodeId};
 use eyre::Context;
 
+use crate::progress::BuildProgress;
 use crate::session::DataflowSession;
 
 pub async fn build_dataflow_locally(
@@ -38,6 +39,9 @@ async fn build_dataflow(
     let prev_git_sources = &dataflow_session.git_sources;
 
     let mut tasks = Vec::new();
+
+    let total_nodes = nodes.len() as u64;
+    let progress = BuildProgress::new(total_nodes, "Building nodes...");
 
     // build nodes
     for node in nodes.into_values() {
@@ -74,7 +78,9 @@ async fn build_dataflow(
             .with_context(|| format!("failed to build node `{node_id}`"))?;
         info.node_working_dirs
             .insert(node_id, node.node_working_dir);
+        progress.inc(1);
     }
+    progress.finish();
     Ok(info)
 }
 

--- a/binaries/cli/src/command/start/mod.rs
+++ b/binaries/cli/src/command/start/mod.rs
@@ -11,6 +11,7 @@ use crate::{
         write_events_to,
     },
     output::print_log_message,
+    progress::Spinner,
     session::DataflowSession,
 };
 use dora_core::{
@@ -189,11 +190,13 @@ async fn wait_until_dataflow_started(
         }
     });
 
+    let spinner = Spinner::new("Waiting for dataflow to start...");
     rpc(
         "wait for dataflow spawn",
         client.wait_for_spawn(long_context(), dataflow_id),
     )
     .await?;
+    spinner.finish_with_message("Dataflow started");
     eprintln!("dataflow started: {dataflow_id}");
 
     Ok(())

--- a/binaries/cli/src/command/up.rs
+++ b/binaries/cli/src/command/up.rs
@@ -3,6 +3,7 @@ use super::{Executable, default_tracing};
 use crate::{
     LOCALHOST,
     common::{connect_and_check_version, connect_to_coordinator_rpc, long_context, rpc},
+    progress::Spinner,
 };
 use dora_core::topics::DORA_COORDINATOR_PORT_CONTROL_DEFAULT;
 
@@ -37,7 +38,8 @@ pub(crate) async fn up(config_path: Option<&Path>) -> eyre::Result<()> {
         Err(_) => {
             start_coordinator().wrap_err("failed to start dora-coordinator")?;
 
-            loop {
+            let spinner = Spinner::new("Starting coordinator...");
+            let client = loop {
                 match connect_to_coordinator_rpc(coordinator_addr, control_port).await {
                     Ok(client) => break client,
                     Err(_) => {
@@ -45,13 +47,16 @@ pub(crate) async fn up(config_path: Option<&Path>) -> eyre::Result<()> {
                         tokio::time::sleep(Duration::from_millis(50)).await;
                     }
                 }
-            }
+            };
+            spinner.finish_with_message("Coordinator started");
+            client
         }
     };
 
     if !daemon_running(&client).await? {
         start_daemon().wrap_err("failed to start dora-daemon")?;
 
+        let spinner = Spinner::new("Starting daemon...");
         // wait a bit until daemon is connected
         let mut i = 0;
         const WAIT_S: f32 = 0.1;
@@ -61,10 +66,12 @@ pub(crate) async fn up(config_path: Option<&Path>) -> eyre::Result<()> {
             }
             i += 1;
             if i > 20 {
+                spinner.fail_with_message("Daemon failed to start");
                 eyre::bail!("daemon not connected after {}s", WAIT_S * i as f32);
             }
             tokio::time::sleep(Duration::from_secs_f32(WAIT_S)).await;
         }
+        spinner.finish_with_message("Daemon started");
     }
 
     Ok(())

--- a/binaries/cli/src/lib.rs
+++ b/binaries/cli/src/lib.rs
@@ -8,6 +8,7 @@ mod command;
 mod common;
 mod formatting;
 pub mod output;
+pub mod progress;
 pub mod session;
 mod template;
 

--- a/binaries/cli/src/progress.rs
+++ b/binaries/cli/src/progress.rs
@@ -1,0 +1,61 @@
+use indicatif::{ProgressBar, ProgressStyle};
+
+/// A spinner for indeterminate-length operations.
+pub struct Spinner {
+    bar: ProgressBar,
+}
+
+impl Spinner {
+    pub fn new(msg: &str) -> Self {
+        let bar = ProgressBar::new_spinner();
+        bar.set_style(
+            ProgressStyle::with_template("{spinner:.green} {msg}")
+                .expect("invalid spinner template"),
+        );
+        bar.enable_steady_tick(std::time::Duration::from_millis(100));
+        bar.set_message(msg.to_string());
+        Self { bar }
+    }
+
+    pub fn finish_with_message(&self, msg: &str) {
+        self.bar.finish_with_message(msg.to_string());
+    }
+
+    pub fn fail_with_message(&self, msg: &str) {
+        self.bar.set_style(
+            ProgressStyle::with_template("{spinner:.red} {msg}")
+                .expect("invalid spinner template"),
+        );
+        self.bar.finish_with_message(msg.to_string());
+    }
+
+    pub fn set_message(&self, msg: &str) {
+        self.bar.set_message(msg.to_string());
+    }
+}
+
+/// A progress bar for counted operations.
+pub struct BuildProgress {
+    bar: ProgressBar,
+}
+
+impl BuildProgress {
+    pub fn new(total: u64, msg: &str) -> Self {
+        let bar = ProgressBar::new(total);
+        bar.set_style(
+            ProgressStyle::with_template("{spinner:.green} {msg} [{bar:30.cyan/blue}] {pos}/{len}")
+                .expect("invalid progress bar template")
+                .progress_chars("=>-"),
+        );
+        bar.set_message(msg.to_string());
+        Self { bar }
+    }
+
+    pub fn inc(&self, n: u64) {
+        self.bar.inc(n);
+    }
+
+    pub fn finish(&self) {
+        self.bar.finish_with_message("Build complete");
+    }
+}


### PR DESCRIPTION
## Summary
- Added `indicatif` dependency and new `progress` module with `Spinner` and `BuildProgress` wrappers
- `dora build` now shows a progress bar (`Building nodes... [=====>---] 3/5`)
- `dora up` shows spinners for coordinator and daemon startup
- `dora start` shows a spinner while waiting for dataflow to start

## Test plan
- [x] `cargo check -p dora-cli` passes (rust:1.85-bookworm)
- [ ] Manual test: `dora build` shows progress bar
- [ ] Manual test: `dora up` shows coordinator/daemon spinners
- [ ] Manual test: `dora start` shows dataflow spinner

Closes #1229