### PR TITLE
feat(cli): add progress bars to time-consuming operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1558,6 +1558,7 @@ dependencies = [
  "eyre",
  "futures",
  "git2",
+ "indicatif",
  "inquire 0.5.3",
  "itertools 0.14.0",
  "log",
@@ -6646,18 +6647,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.0.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.4+spec-1.1.0"
+version = "0.25.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
+checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
 dependencies = [
  "indexmap 2.13.0",
  "toml_datetime",
@@ -6667,9 +6668,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.0.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
 dependencies = [
  "winnow",
 ]
@@ -7889,9 +7890,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 dependencies = [
  "memchr",
 ]

--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -77,6 +77,7 @@ git2 = { workspace = true }
 zenoh = { workspace = true }
 arrow-json.workspace = true
 chrono = "0.4.42"
+indicatif = "0.17"
 
 [build-dependencies]
 pyo3-build-config = "0.23"

--- a/binaries/cli/src/command/build/local.rs
+++ b/binaries/cli/src/command/build/local.rs
@@ -7,6 +7,7 @@ use dora_core::{
 };
 use dora_message::{common::GitSource, id::NodeId};
 use eyre::Context;
+use indicatif::ProgressBar;
 
 use crate::progress::BuildProgress;
 use crate::session::DataflowSession;
@@ -61,6 +62,7 @@ async fn build_dataflow(
                 prev_git,
                 LocalBuildLogger {
                     node_id: node_id.clone(),
+                    bar: progress.clone_bar(),
                 },
                 &mut git_manager,
             )
@@ -86,6 +88,7 @@ async fn build_dataflow(
 
 struct LocalBuildLogger {
     node_id: NodeId,
+    bar: ProgressBar,
 }
 
 impl BuildLogger for LocalBuildLogger {
@@ -108,12 +111,14 @@ impl BuildLogger for LocalBuildLogger {
         };
         let node = self.node_id.to_string().bold().bright_black();
         let message: String = message.into();
-        println!("{node}: {level}   {message}");
+        // Print above the progress bar so it stays pinned at the bottom.
+        self.bar.println(format!("{node}: {level}   {message}"));
     }
 
     async fn try_clone(&self) -> eyre::Result<Self::Clone> {
         Ok(LocalBuildLogger {
             node_id: self.node_id.clone(),
+            bar: self.bar.clone(),
         })
     }
 }

--- a/binaries/cli/src/command/build/local.rs
+++ b/binaries/cli/src/command/build/local.rs
@@ -8,6 +8,7 @@ use dora_core::{
 use dora_message::{common::GitSource, id::NodeId};
 use eyre::Context;
 
+use crate::progress::BuildProgress;
 use crate::session::DataflowSession;
 
 pub async fn build_dataflow_locally(
@@ -38,6 +39,9 @@ async fn build_dataflow(
     let prev_git_sources = &dataflow_session.git_sources;
 
     let mut tasks = Vec::new();
+
+    let total_nodes = nodes.len() as u64;
+    let progress = BuildProgress::new(total_nodes, "Building nodes...");
 
     // build nodes
     for node in nodes.into_values() {
@@ -74,7 +78,9 @@ async fn build_dataflow(
             .with_context(|| format!("failed to build node `{node_id}`"))?;
         info.node_working_dirs
             .insert(node_id, node.node_working_dir);
+        progress.inc(1);
     }
+    progress.finish();
     Ok(info)
 }
 

--- a/binaries/cli/src/command/start/mod.rs
+++ b/binaries/cli/src/command/start/mod.rs
@@ -11,6 +11,7 @@ use crate::{
         write_events_to,
     },
     output::print_log_message,
+    progress::Spinner,
     session::DataflowSession,
 };
 use dora_core::{
@@ -189,11 +190,13 @@ async fn wait_until_dataflow_started(
         }
     });
 
+    let spinner = Spinner::new("Waiting for dataflow to start...");
     rpc(
         "wait for dataflow spawn",
         client.wait_for_spawn(long_context(), dataflow_id),
     )
     .await?;
+    spinner.finish_with_message("Dataflow started");
     eprintln!("dataflow started: {dataflow_id}");
 
     Ok(())

--- a/binaries/cli/src/command/start/mod.rs
+++ b/binaries/cli/src/command/start/mod.rs
@@ -10,7 +10,7 @@ use crate::{
         connect_and_check_version, local_working_dir, long_context, resolve_dataflow, rpc,
         write_events_to,
     },
-    output::print_log_message,
+    output::format_log_message,
     progress::Spinner,
     session::DataflowSession,
 };
@@ -175,13 +175,16 @@ async fn wait_until_dataflow_started(
         )
         .await
         .wrap_err("failed to send log subscribe request to coordinator")?;
+    let spinner = Spinner::new("Waiting for dataflow to start...");
+    let bar = spinner.clone_bar();
     tokio::spawn(async move {
         while let Ok(raw) = log_session.receive().await {
             let parsed: eyre::Result<LogMessage> =
                 serde_json::from_slice(&raw).context("failed to parse log message");
             match parsed {
                 Ok(log_message) => {
-                    print_log_message(log_message, false, print_daemon_id);
+                    // Print above the spinner so it stays pinned at the bottom.
+                    bar.println(format_log_message(log_message, false, print_daemon_id));
                 }
                 Err(err) => {
                     tracing::warn!("failed to parse log message: {err:?}")
@@ -190,14 +193,12 @@ async fn wait_until_dataflow_started(
         }
     });
 
-    let spinner = Spinner::new("Waiting for dataflow to start...");
     rpc(
         "wait for dataflow spawn",
         client.wait_for_spawn(long_context(), dataflow_id),
     )
     .await?;
-    spinner.finish_with_message("Dataflow started");
-    eprintln!("dataflow started: {dataflow_id}");
+    spinner.finish_with_message(&format!("Dataflow started: {dataflow_id}"));
 
     Ok(())
 }

--- a/binaries/cli/src/command/up.rs
+++ b/binaries/cli/src/command/up.rs
@@ -3,6 +3,7 @@ use super::{Executable, default_tracing};
 use crate::{
     LOCALHOST,
     common::{connect_and_check_version, connect_to_coordinator_rpc, long_context, rpc},
+    progress::Spinner,
 };
 use dora_core::topics::DORA_COORDINATOR_PORT_CONTROL_DEFAULT;
 
@@ -37,7 +38,8 @@ pub(crate) async fn up(config_path: Option<&Path>) -> eyre::Result<()> {
         Err(_) => {
             start_coordinator().wrap_err("failed to start dora-coordinator")?;
 
-            loop {
+            let spinner = Spinner::new("Starting coordinator...");
+            let client = loop {
                 match connect_to_coordinator_rpc(coordinator_addr, control_port).await {
                     Ok(client) => break client,
                     Err(_) => {
@@ -45,13 +47,16 @@ pub(crate) async fn up(config_path: Option<&Path>) -> eyre::Result<()> {
                         tokio::time::sleep(Duration::from_millis(50)).await;
                     }
                 }
-            }
+            };
+            spinner.finish_with_message("Coordinator started");
+            client
         }
     };
 
     if !daemon_running(&client).await? {
         start_daemon().wrap_err("failed to start dora-daemon")?;
 
+        let spinner = Spinner::new("Starting daemon...");
         // wait a bit until daemon is connected
         let mut i = 0;
         const WAIT_S: f32 = 0.1;
@@ -61,10 +66,12 @@ pub(crate) async fn up(config_path: Option<&Path>) -> eyre::Result<()> {
             }
             i += 1;
             if i > 20 {
+                spinner.fail_with_message("Daemon failed to start");
                 eyre::bail!("daemon not connected after {}s", WAIT_S * i as f32);
             }
             tokio::time::sleep(Duration::from_secs_f32(WAIT_S)).await;
         }
+        spinner.finish_with_message("Daemon started");
     }
 
     Ok(())

--- a/binaries/cli/src/command/up.rs
+++ b/binaries/cli/src/command/up.rs
@@ -124,8 +124,6 @@ fn start_coordinator() -> eyre::Result<()> {
     cmd.arg("--quiet");
     cmd.spawn().wrap_err("failed to run `dora coordinator`")?;
 
-    println!("started dora coordinator");
-
     Ok(())
 }
 
@@ -143,8 +141,6 @@ fn start_daemon() -> eyre::Result<()> {
     cmd.arg("daemon");
     cmd.arg("--quiet");
     cmd.spawn().wrap_err("failed to run `dora daemon`")?;
-
-    println!("started dora daemon");
 
     Ok(())
 }

--- a/binaries/cli/src/lib.rs
+++ b/binaries/cli/src/lib.rs
@@ -8,6 +8,7 @@ mod command;
 mod common;
 mod formatting;
 pub mod output;
+pub mod progress;
 pub mod session;
 mod template;
 

--- a/binaries/cli/src/output.rs
+++ b/binaries/cli/src/output.rs
@@ -9,7 +9,10 @@ pub fn print_log_message(
     print_dataflow_id: bool,
     print_daemon_name: bool,
 ) {
-    println!("{}", format_log_message(log_message, print_dataflow_id, print_daemon_name));
+    println!(
+        "{}",
+        format_log_message(log_message, print_dataflow_id, print_daemon_name)
+    );
 }
 
 /// Format a log message into a string without printing it.

--- a/binaries/cli/src/output.rs
+++ b/binaries/cli/src/output.rs
@@ -9,6 +9,18 @@ pub fn print_log_message(
     print_dataflow_id: bool,
     print_daemon_name: bool,
 ) {
+    println!("{}", format_log_message(log_message, print_dataflow_id, print_daemon_name));
+}
+
+/// Format a log message into a string without printing it.
+///
+/// Use this when output must be routed through a progress bar
+/// (via `ProgressBar::println`) to avoid mangling the display.
+pub fn format_log_message(
+    log_message: LogMessage,
+    print_dataflow_id: bool,
+    print_daemon_name: bool,
+) -> String {
     let LogMessage {
         build_id: _,
         dataflow_id,
@@ -65,7 +77,7 @@ pub fn print_log_message(
         Some(target) => format!("{target} ").dimmed(),
         None => "".normal(),
     };
-    println!("{time} {level} {dataflow} {node}{target} {message}");
+    format!("{time} {level} {dataflow} {node}{target} {message}")
 }
 
 /// Generate a color for a word based on its semantic features

--- a/binaries/cli/src/progress.rs
+++ b/binaries/cli/src/progress.rs
@@ -1,6 +1,9 @@
 use indicatif::{ProgressBar, ProgressStyle};
 
 /// A spinner for indeterminate-length operations.
+///
+/// All output while a spinner is active should go through [`Spinner::println`]
+/// so that the spinner stays pinned at the bottom of the terminal.
 pub struct Spinner {
     bar: ProgressBar,
 }
@@ -28,12 +31,24 @@ impl Spinner {
         self.bar.finish_with_message(msg.to_string());
     }
 
-    pub fn set_message(&self, msg: &str) {
-        self.bar.set_message(msg.to_string());
+    /// Print a line above the spinner without mangling its display.
+    pub fn println(&self, msg: impl AsRef<str>) {
+        self.bar.println(msg);
+    }
+
+    /// Get a clone of the underlying [`ProgressBar`] for sharing across threads.
+    ///
+    /// Use `ProgressBar::println` on the clone to print without mangling the
+    /// spinner.
+    pub fn clone_bar(&self) -> ProgressBar {
+        self.bar.clone()
     }
 }
 
 /// A progress bar for counted operations.
+///
+/// All output while the bar is active should go through [`BuildProgress::println`]
+/// so that the bar stays pinned at the bottom of the terminal.
 pub struct BuildProgress {
     bar: ProgressBar,
 }
@@ -56,5 +71,15 @@ impl BuildProgress {
 
     pub fn finish(&self) {
         self.bar.finish_with_message("Build complete");
+    }
+
+    /// Print a line above the progress bar without mangling its display.
+    pub fn println(&self, msg: impl AsRef<str>) {
+        self.bar.println(msg);
+    }
+
+    /// Get a clone of the underlying [`ProgressBar`] for sharing across threads.
+    pub fn clone_bar(&self) -> ProgressBar {
+        self.bar.clone()
     }
 }

--- a/binaries/cli/src/progress.rs
+++ b/binaries/cli/src/progress.rs
@@ -1,0 +1,60 @@
+use indicatif::{ProgressBar, ProgressStyle};
+
+/// A spinner for indeterminate-length operations.
+pub struct Spinner {
+    bar: ProgressBar,
+}
+
+impl Spinner {
+    pub fn new(msg: &str) -> Self {
+        let bar = ProgressBar::new_spinner();
+        bar.set_style(
+            ProgressStyle::with_template("{spinner:.green} {msg}")
+                .expect("invalid spinner template"),
+        );
+        bar.enable_steady_tick(std::time::Duration::from_millis(100));
+        bar.set_message(msg.to_string());
+        Self { bar }
+    }
+
+    pub fn finish_with_message(&self, msg: &str) {
+        self.bar.finish_with_message(msg.to_string());
+    }
+
+    pub fn fail_with_message(&self, msg: &str) {
+        self.bar.set_style(
+            ProgressStyle::with_template("{spinner:.red} {msg}").expect("invalid spinner template"),
+        );
+        self.bar.finish_with_message(msg.to_string());
+    }
+
+    pub fn set_message(&self, msg: &str) {
+        self.bar.set_message(msg.to_string());
+    }
+}
+
+/// A progress bar for counted operations.
+pub struct BuildProgress {
+    bar: ProgressBar,
+}
+
+impl BuildProgress {
+    pub fn new(total: u64, msg: &str) -> Self {
+        let bar = ProgressBar::new(total);
+        bar.set_style(
+            ProgressStyle::with_template("{spinner:.green} {msg} [{bar:30.cyan/blue}] {pos}/{len}")
+                .expect("invalid progress bar template")
+                .progress_chars("=>-"),
+        );
+        bar.set_message(msg.to_string());
+        Self { bar }
+    }
+
+    pub fn inc(&self, n: u64) {
+        self.bar.inc(n);
+    }
+
+    pub fn finish(&self) {
+        self.bar.finish_with_message("Build complete");
+    }
+}


### PR DESCRIPTION
## Summary
- Added `indicatif` dependency and new `progress` module with `Spinner` and `BuildProgress` wrappers
- `dora build` now shows a progress bar (`Building nodes... [=====>---] 3/5`)
- `dora up` shows spinners for coordinator and daemon startup
- `dora start` shows a spinner while waiting for dataflow to start
- All existing `println!`/`eprintln!` output is routed through `ProgressBar::println()` during active progress bars, preventing the display mangling that affected PRs #1249 and #1349

## Changes
- **`progress.rs`** — `Spinner` and `BuildProgress` wrappers with `println()` and `clone_bar()` for output coordination across threads
- **`local.rs`** — `LocalBuildLogger` holds a `ProgressBar` clone; `log_message()` uses `bar.println()` instead of `println!()` so build logs scroll above the pinned progress bar
- **`start/mod.rs`** — Background log-streaming task receives a `ProgressBar` clone via `spinner.clone_bar()` and uses `bar.println(format_log_message(...))` instead of direct `print_log_message()`
- **`up.rs`** — Removed redundant `println!("started dora coordinator/daemon")` from `start_coordinator()`/`start_daemon()` (spinner finish messages handle this)
- **`output.rs`** — Extracted `format_log_message() -> String` from `print_log_message()` for progress-bar-aware callers

## Test plan
- [x] `cargo check -p dora-cli` passes (rust:1.85-bookworm)
- [x] `dora build dataflow.yml` — build logs scroll above the progress bar, bar stays pinned at bottom, counter increments 0/3 → 3/3 → "Build complete"
- [x] `dora up` — spinners animate for coordinator/daemon startup, finish cleanly with "Coordinator started" / "Daemon started", no duplicate println output
- [x] `dora start dataflow.yml --detach` — log messages from spawned nodes print above the spinner via `bar.println()`, spinner finishes with "Dataflow started: {uuid}"
- [x] All tested manually in Docker (`rust:1.85-bookworm`) with TTY

Closes #1229