### PR TITLE
fix(operator-api): propagate OpenTelemetry context in Rust operators

### DIFF
--- a/apis/rust/operator/src/lib.rs
+++ b/apis/rust/operator/src/lib.rs
@@ -47,21 +47,35 @@ pub trait DoraOperator: Default {
     ) -> Result<DoraStatus, String>;
 }
 
-pub struct DoraOutputSender<'a>(&'a SendOutput);
+pub struct DoraOutputSender<'a> {
+    send_output: &'a SendOutput,
+    open_telemetry_context: String,
+}
 
 impl DoraOutputSender<'_> {
+    pub(crate) fn new(send_output: &SendOutput) -> DoraOutputSender<'_> {
+        DoraOutputSender {
+            send_output,
+            open_telemetry_context: String::new(),
+        }
+    }
+
+    pub(crate) fn set_open_telemetry_context(&mut self, open_telemetry_context: &str) {
+        self.open_telemetry_context = open_telemetry_context.to_owned();
+    }
+
     ///  Send an output from the operator:
     ///  - `id` is the `output_id` as defined in your dataflow.
     ///  - `data` is the data that should be sent
     pub fn send(&mut self, id: String, data: impl Array) -> Result<(), String> {
         let (data_array, schema) =
             arrow::ffi::to_ffi(&data.into_data()).map_err(|err| err.to_string())?;
-        let result = self.0.send_output.call(Output {
+        let result = self.send_output.send_output.call(Output {
             id: id.into(),
             data_array,
             schema,
             metadata: Metadata {
-                open_telemetry_context: String::new().into(), // TODO
+                open_telemetry_context: self.open_telemetry_context.clone().into(),
             },
         });
         result.into_result()

--- a/apis/rust/operator/src/raw.rs
+++ b/apis/rust/operator/src/raw.rs
@@ -33,11 +33,12 @@ pub unsafe fn dora_on_event<O: DoraOperator>(
     send_output: &SendOutput,
     operator_context: *mut std::ffi::c_void,
 ) -> OnEventResult {
-    let mut output_sender = DoraOutputSender(send_output);
+    let mut output_sender = DoraOutputSender::new(send_output);
 
     let operator: &mut O = unsafe { &mut *operator_context.cast() };
 
     let event_variant = if let Some(input) = &mut event.input {
+        output_sender.set_open_telemetry_context(&input.metadata.open_telemetry_context);
         let Some(data_array) = input.data_array.take() else {
             return OnEventResult {
                 result: DoraResult::from_error("data already taken".to_string()),
@@ -76,5 +77,79 @@ pub unsafe fn dora_on_event<O: DoraOperator>(
             result: DoraResult::from_error(error),
             status: DoraStatus::Stop,
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::dora_on_event;
+    use crate::{DoraOperator, DoraOutputSender, DoraStatus, Event};
+    use dora_operator_api_types::{
+        DoraResult, Input, Metadata, OnEventResult, Output, RawEvent, SendOutput,
+        arrow::array::{Array, UInt8Array},
+        safer_ffi::closure::ArcDynFn1,
+    };
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Default)]
+    struct EchoOperator;
+
+    impl DoraOperator for EchoOperator {
+        fn on_event(
+            &mut self,
+            event: &Event,
+            output_sender: &mut DoraOutputSender,
+        ) -> Result<DoraStatus, String> {
+            if let Event::Input { .. } = event {
+                output_sender.send("out".to_string(), UInt8Array::from(vec![1_u8, 2_u8, 3_u8]))?;
+            }
+            Ok(DoraStatus::Continue)
+        }
+    }
+
+    #[test]
+    fn forwards_open_telemetry_context_to_output_metadata() {
+        let received_context = Arc::new(Mutex::new(String::new()));
+        let context_target = Arc::clone(&received_context);
+        let send_output = SendOutput {
+            send_output: ArcDynFn1::new(Arc::new(move |output: Output| {
+                *context_target.lock().expect("poisoned mutex") =
+                    output.metadata.open_telemetry_context.to_string();
+                DoraResult::SUCCESS
+            })),
+        };
+
+        let input_array = UInt8Array::from(vec![1_u8, 2_u8]);
+        let (data_array, schema) =
+            dora_operator_api_types::arrow::ffi::to_ffi(&input_array.to_data())
+                .expect("failed to convert input to FFI");
+        let mut event = RawEvent {
+            input: Some(
+                Box::new(Input {
+                    id: "in".to_string().into(),
+                    data_array: Some(data_array),
+                    schema,
+                    metadata: Metadata {
+                        open_telemetry_context: "traceparent-context".to_string().into(),
+                    },
+                })
+                .into(),
+            ),
+            input_closed: None,
+            stop: false,
+            error: None,
+        };
+
+        let operator_context: *mut std::ffi::c_void = Box::into_raw(Box::new(EchoOperator)).cast();
+        let OnEventResult { result, status } =
+            unsafe { dora_on_event::<EchoOperator>(&mut event, &send_output, operator_context) };
+        unsafe { drop(Box::from_raw(operator_context.cast::<EchoOperator>())) };
+
+        assert!(result.error.is_none());
+        assert_eq!(status as u8, DoraStatus::Continue as u8);
+        assert_eq!(
+            *received_context.lock().expect("poisoned mutex"),
+            "traceparent-context"
+        );
     }
 }


### PR DESCRIPTION
## Summary
  Propagates `open_telemetry_context` through the Rust operator API so outputs preserve tracing context from incoming inputs.

  ## Motivation
  Without this, Rust operators emit outputs with empty telemetry context, causing broken distributed traces through operator boundaries.

  ## Changes
  - `DoraOutputSender` now stores per-event `open_telemetry_context`.
  - `dora_on_event` reads context from input metadata and sets it on the sender before invoking operator logic.
  - `DoraOutputSender::send` now writes propagated context into output metadata.
  - Added a regression test to verify context is forwarded input -> output.

  ## Scope
  This PR is intentionally limited to:
  - `apis/rust/operator/src/lib.rs`
  - `apis/rust/operator/src/raw.rs`

  No unrelated refactors or subsystem changes.

  ## Validation
  - `cargo fmt --all -- --check`
  - `cargo test -p dora-operator-api`
  - `cargo clippy -p dora-operator-api --all-targets`

  All passed locally.

  ## Related
  Closes #1432 