### PR TITLE
fix(ci): handle missing Docker gracefully in Windows disk cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,8 @@ jobs:
       - name: Free disk Space (Windows)
         if: runner.os == 'Windows'
         run: |
-          docker system prune --all -f
-          docker builder prune -af
+          docker system prune --all -f 2>$null; $true
+          docker builder prune -af 2>$null; $true
           Remove-Item "C:\Android" -Force -Recurse -ErrorAction SilentlyContinue
           Remove-Item "C:\hostedtoolcache\windows\Ruby" -Force -Recurse -ErrorAction SilentlyContinue
           Remove-Item "C:\hostedtoolcache\windows\go" -Force -Recurse -ErrorAction SilentlyContinue
@@ -128,8 +128,8 @@ jobs:
       - name: Free disk Space (Windows)
         if: runner.os == 'Windows'
         run: |
-          docker system prune --all -f
-          docker builder prune -af
+          docker system prune --all -f 2>$null; $true
+          docker builder prune -af 2>$null; $true
           Remove-Item "C:\Android" -Force -Recurse -ErrorAction SilentlyContinue
           Remove-Item "C:\hostedtoolcache\windows\Ruby" -Force -Recurse -ErrorAction SilentlyContinue
           Remove-Item "C:\hostedtoolcache\windows\go" -Force -Recurse -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary
- Suppress errors from `docker system prune` and `docker builder prune` in the Windows CI disk cleanup step, so the step no longer fails when Docker is unavailable on the runner
- Applies to both the `test` and `examples` jobs

Cherry-picked from 9180bd8b (was on an unmerged branch).

## Test plan
- [x] CI passes on Windows runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)