### PR TITLE
fix(core): fix flaky check_url GET-fallback test

### DIFF
--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -399,7 +399,7 @@ mod tests {
                 let method = read_request_method(&mut stream);
                 if method == "HEAD" {
                     stream
-                        .write_all(b"HTTP/1.1 405 Method Not Allowed\r\nContent-Length: 0\r\n\r\n")
+                        .write_all(b"HTTP/1.1 405 Method Not Allowed\r\nConnection: close\r\nContent-Length: 0\r\n\r\n")
                         .expect("failed to write response");
                 } else {
                     stream


### PR DESCRIPTION
## Summary
- Fix race condition in `check_url_falls_back_to_get_when_head_not_allowed` test introduced in #1430
- The test server expected two separate TCP connections (HEAD then GET), but `reqwest` reuses the connection via HTTP/1.1 keep-alive, causing intermittent timeouts
- Add `Connection: close` header to the 405 response so the client opens a fresh connection for the GET fallback

## Test plan
- [x] `cargo test -p dora-core -- check_url` passes all 3 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)