### PR TITLE
fix: Panic on non-UTF-8 path in `dora graph --open`

### DIFF
--- a/binaries/cli/src/command/graph.rs
+++ b/binaries/cli/src/command/graph.rs
@@ -69,7 +69,9 @@ fn create(dataflow: std::path::PathBuf, mermaid: bool, open: bool) -> eyre::Resu
         );
 
         if open {
-            webbrowser::open(path.as_os_str().to_str().unwrap())?;
+            webbrowser::open(path.to_str().ok_or_else(|| {
+                eyre::eyre!("graph output path is not valid UTF-8: {}", path.display())
+            })?)?;
         }
     }
     Ok(())


### PR DESCRIPTION
## SUMMARY

This PR fixes a panic in the `dora graph --open` command caused by unsafe handling of non-UTF-8 file paths. It updates the `create()` function in `binaries/cli/src/command/graph.rs` to gracefully handle invalid UTF-8 instead of crashing.

The change is localized to a single line and aligns with existing error-handling patterns already used in the same function.

---

## FIX 


```rust
// Before
webbrowser::open(path.as_os_str().to_str().unwrap())?;

// After
webbrowser::open(
    path.to_str()
        .ok_or_else(|| eyre::eyre!("graph output path is not valid UTF-8: {}", path.display()))?,
)?;
```

---

## VERIFICATION

Run `dora graph --open pipeline.yaml` from a directory with non-UTF-8 characters. Previously it panicked; now it returns a clear error about invalid UTF-8. Behavior on valid UTF-8 paths remains unchanged.


