### PR TITLE
fix: Panic on missing operator in Reload handler

### DIFF
--- a/binaries/runtime/src/lib.rs
+++ b/binaries/runtime/src/lib.rs
@@ -242,9 +242,11 @@ async fn run(
             RuntimeEvent::Event(Event::Reload {
                 operator_id: Some(operator_id),
             }) => {
-                let _ = operator_channels
-                    .get(&operator_id)
-                    .unwrap()
+                let Some(operator_channel) = operator_channels.get(&operator_id) else {
+                    tracing::warn!("received Reload event for unknown operator `{operator_id}`");
+                    continue;
+                };
+                let _ = operator_channel
                     .send_async(Event::Reload {
                         operator_id: Some(operator_id),
                     })


### PR DESCRIPTION
## 1. SUMMARY

This PR fixes a runtime panic in the `Reload` event handler by safely handling missing operator channels instead of unwrapping. The change is localized to `binaries/runtime/src/lib.rs` in the `run()` function and aligns behavior with existing patterns used in other event handlers.

---

## 2. FIX

```rust
// BEFORE
operator_channels
    .get(&operator_id)
    .unwrap()
    .send_async(Event::Reload { operator_id: Some(operator_id) })
    .await;

// AFTER
let Some(operator_channel) = operator_channels.get(&operator_id) else {
    tracing::warn!("received Reload event for unknown operator `{operator_id}`");
    continue;
};

operator_channel
    .send_async(Event::Reload { operator_id: Some(operator_id) })
    .await;
```

---

## 3. VERIFICATION

Triggered a `Reload` event with a missing `operator_id`. Previously, this caused a panic; now it logs a warning and continues execution, confirming the fix.
