### PR TITLE
fix: Panic on non-UTF-8 workspace paths in template generation

### DIFF
--- a/binaries/cli/src/template/c/mod.rs
+++ b/binaries/cli/src/template/c/mod.rs
@@ -70,7 +70,13 @@ fn create_cmakefile(root: PathBuf, use_path_deps: bool) -> Result<(), eyre::ErrR
             .context("Could not get manifest parent folder")?
             .parent()
             .context("Could not get manifest grandparent folder")?;
-        CMAKEFILE.replace("__DORA_PATH__", workspace_dir.to_str().unwrap())
+        let workspace_str = workspace_dir.to_str().ok_or_else(|| {
+            eyre::eyre!(
+                "workspace path is not valid UTF-8: {}",
+                workspace_dir.display()
+            )
+        })?;
+        CMAKEFILE.replace("__DORA_PATH__", workspace_str)
     } else {
         CMAKEFILE.replace("__DORA_PATH__", "")
     };

--- a/binaries/cli/src/template/cxx/mod.rs
+++ b/binaries/cli/src/template/cxx/mod.rs
@@ -69,7 +69,13 @@ fn create_cmakefile(root: PathBuf, use_path_deps: bool) -> Result<(), eyre::ErrR
             .context("Could not get manifest parent folder")?
             .parent()
             .context("Could not get manifest grandparent folder")?;
-        CMAKEFILE.replace("__DORA_PATH__", workspace_dir.to_str().unwrap())
+        let workspace_str = workspace_dir.to_str().ok_or_else(|| {
+            eyre::eyre!(
+                "workspace path is not valid UTF-8: {}",
+                workspace_dir.display()
+            )
+        })?;
+        CMAKEFILE.replace("__DORA_PATH__", workspace_str)
     } else {
         CMAKEFILE.replace("__DORA_PATH__", "")
     };


### PR DESCRIPTION
## SUMMARY

This PR fixes a panic in template generation when the workspace path contains non-UTF-8 characters. It updates error handling in `create_cmakefile()` to safely propagate errors instead of unwrapping.

---

## FIX 

```rust
// Before 
CMAKEFILE.replace("__DORA_PATH__", workspace_dir.to_str().unwrap())

// After
CMAKEFILE.replace(
    "__DORA_PATH__",
    workspace_dir
        .to_str()
        .ok_or_else(|| eyre::eyre!(
            "workspace path is not valid UTF-8: {}",
            workspace_dir.display()
        ))?,
)
```

---

## VERIFICATION

Run `dora new my_node --c++` and `dora new my_node --c`. Previously, these could panic on non-UTF-8 paths; now they either succeed or return a clear error instead of crashing.

