### PR TITLE
feat(cli): add dora.lock prototype for git-backed nodes

### DIFF
--- a/binaries/cli/src/command/build/mod.rs
+++ b/binaries/cli/src/command/build/mod.rs
@@ -255,7 +255,7 @@ pub async fn build_async(
             )
             .await?;
 
-            dataflow_session.git_sources = git_sources;
+            dataflow_session.git_sources = git_sources.clone();
             dataflow_session.build_id = Some(build_id);
             dataflow_session.local_build = None;
             dataflow_session

--- a/binaries/cli/src/command/build/mod.rs
+++ b/binaries/cli/src/command/build/mod.rs
@@ -25,6 +25,8 @@
 //!     - not when using `tag` or `rev`, because these are not expected to change
 //! - after fetching changes, the `build` command will be executed again
 //!     - _tip:_ use a build tool that supports incremental builds (e.g. `cargo`) to make this rebuild faster
+//! - resolved git commits are written to `dora.lock` in the dataflow directory
+//!     - if a matching entry is present in `dora.lock`, it is reused on the next build
 //!
 //! The **working directory** will be set to the git repository.
 //! This means that both the `build` and `path` keys will be run from this folder.
@@ -58,6 +60,7 @@ use std::{collections::BTreeMap, net::IpAddr};
 use super::{Executable, default_tracing};
 use crate::{
     common::{connect_and_check_version, local_working_dir, resolve_dataflow},
+    lockfile::DoraLock,
     session::DataflowSession,
 };
 
@@ -138,6 +141,10 @@ pub async fn build_async(
         DataflowSession::read_session(&dataflow_path).context("failed to read DataflowSession")?;
 
     let mut git_sources = BTreeMap::new();
+    let mut lockfile = DoraLock::read_for_dataflow(&dataflow_path)
+        .context("failed to read dora.lock for this dataflow")?;
+    let mut next_lockfile = DoraLock::new();
+    let mut lock_hits = 0usize;
     let resolved_nodes = dataflow_descriptor
         .resolve_aliases_and_set_defaults()
         .context("failed to resolve nodes")?;
@@ -147,11 +154,29 @@ pub async fn build_async(
             ..
         }) = node.kind
         {
-            let source = git::fetch_commit_hash(repo, rev)
-                .with_context(|| format!("failed to find commit hash for `{node_id}`"))?;
+            let source = if let Some(locked_source) =
+                lockfile.resolve_git_source(&node_id, &repo, rev.as_ref())
+            {
+                lock_hits += 1;
+                log::info!("using locked git source for node `{node_id}`");
+                locked_source
+            } else {
+                git::fetch_commit_hash(repo.clone(), rev.clone())
+                    .with_context(|| format!("failed to find commit hash for `{node_id}`"))?
+            };
+            next_lockfile.set_git_source(node_id.clone(), repo, rev, source.commit_hash.clone());
             git_sources.insert(node_id, source);
         }
     }
+    if !git_sources.is_empty() {
+        log::info!(
+            "resolved git sources using dora.lock ({} cached, {} fetched)",
+            lock_hits,
+            git_sources.len().saturating_sub(lock_hits)
+        );
+    }
+    // Drop old parsed lockfile to ensure all future reads use the normalized representation.
+    lockfile = next_lockfile;
 
     let session = || connect_to_coordinator_rpc_with_defaults(coordinator_addr, coordinator_port);
 
@@ -206,7 +231,7 @@ pub async fn build_async(
             )
             .await?;
 
-            dataflow_session.git_sources = git_sources;
+            dataflow_session.git_sources = git_sources.clone();
             // generate a random BuildId and store the associated build info
             dataflow_session.build_id = Some(BuildId::generate());
             dataflow_session.local_build = Some(build_info);
@@ -238,6 +263,12 @@ pub async fn build_async(
                 .context("failed to write out dataflow session file")?;
         }
     };
+
+    if !git_sources.is_empty() {
+        lockfile
+            .write_for_dataflow(&dataflow_path)
+            .context("failed to write dora.lock for this dataflow")?;
+    }
 
     Ok(())
 }

--- a/binaries/cli/src/command/build/mod.rs
+++ b/binaries/cli/src/command/build/mod.rs
@@ -25,8 +25,8 @@
 //!     - not when using `tag` or `rev`, because these are not expected to change
 //! - after fetching changes, the `build` command will be executed again
 //!     - _tip:_ use a build tool that supports incremental builds (e.g. `cargo`) to make this rebuild faster
-//! - resolved git commits are written to `dora.lock` in the dataflow directory
-//!     - if a matching entry is present in `dora.lock`, it is reused on the next build
+//! - resolved git commits are written to `<dataflow-name>.dora.lock` in the dataflow directory
+//!     - if a matching entry is present in that lockfile, it is reused on the next build
 //!
 //! The **working directory** will be set to the git repository.
 //! This means that both the `build` and `path` keys will be run from this folder.
@@ -141,8 +141,8 @@ pub async fn build_async(
         DataflowSession::read_session(&dataflow_path).context("failed to read DataflowSession")?;
 
     let mut git_sources = BTreeMap::new();
-    let mut lockfile = DoraLock::read_for_dataflow(&dataflow_path)
-        .context("failed to read dora.lock for this dataflow")?;
+    let mut lockfile =
+        DoraLock::read_for_dataflow(&dataflow_path).context("failed to read lockfile")?;
     let mut next_lockfile = DoraLock::new();
     let mut lock_hits = 0usize;
     let resolved_nodes = dataflow_descriptor
@@ -170,7 +170,7 @@ pub async fn build_async(
     }
     if !git_sources.is_empty() {
         log::info!(
-            "resolved git sources using dora.lock ({} cached, {} fetched)",
+            "resolved git sources using lockfile ({} cached, {} fetched)",
             lock_hits,
             git_sources.len().saturating_sub(lock_hits)
         );
@@ -267,7 +267,7 @@ pub async fn build_async(
     if !git_sources.is_empty() {
         lockfile
             .write_for_dataflow(&dataflow_path)
-            .context("failed to write dora.lock for this dataflow")?;
+            .context("failed to write lockfile")?;
     }
 
     Ok(())

--- a/binaries/cli/src/lib.rs
+++ b/binaries/cli/src/lib.rs
@@ -7,6 +7,7 @@ use std::{
 mod command;
 mod common;
 mod formatting;
+mod lockfile;
 pub mod output;
 pub mod session;
 mod template;

--- a/binaries/cli/src/lockfile.rs
+++ b/binaries/cli/src/lockfile.rs
@@ -1,0 +1,209 @@
+use dora_message::{common::GitSource, descriptor::GitRepoRev, id::NodeId};
+use eyre::Context;
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
+
+const LOCKFILE_NAME: &str = "dora.lock";
+const LOCKFILE_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DoraLock {
+    pub version: u32,
+    #[serde(default)]
+    pub git_sources: BTreeMap<NodeId, LockedGitSource>,
+}
+
+impl DoraLock {
+    pub fn new() -> Self {
+        Self {
+            version: LOCKFILE_VERSION,
+            git_sources: BTreeMap::new(),
+        }
+    }
+
+    pub fn read_for_dataflow(dataflow_path: &Path) -> eyre::Result<Self> {
+        let lockfile_path = lockfile_path(dataflow_path)?;
+        if !lockfile_path.exists() {
+            return Ok(Self::new());
+        }
+
+        let contents = std::fs::read_to_string(&lockfile_path)
+            .with_context(|| format!("failed to read lockfile `{}`", lockfile_path.display()))?;
+        let lockfile: DoraLock = serde_yaml::from_str(&contents).with_context(|| {
+            format!(
+                "failed to parse lockfile `{}` as YAML",
+                lockfile_path.display()
+            )
+        })?;
+
+        if lockfile.version != LOCKFILE_VERSION {
+            eyre::bail!(
+                "unsupported lockfile version {} in `{}` (expected {})",
+                lockfile.version,
+                lockfile_path.display(),
+                LOCKFILE_VERSION
+            );
+        }
+
+        Ok(lockfile)
+    }
+
+    pub fn write_for_dataflow(&self, dataflow_path: &Path) -> eyre::Result<()> {
+        let lockfile_path = lockfile_path(dataflow_path)?;
+        let serialized = serde_yaml::to_string(self).context("failed to serialize lockfile")?;
+        std::fs::write(&lockfile_path, serialized)
+            .with_context(|| format!("failed to write lockfile `{}`", lockfile_path.display()))?;
+        Ok(())
+    }
+
+    pub fn resolve_git_source(
+        &self,
+        node_id: &NodeId,
+        repo: &str,
+        requested_rev: Option<&GitRepoRev>,
+    ) -> Option<GitSource> {
+        let entry = self.git_sources.get(node_id)?;
+        if entry.repo != repo {
+            return None;
+        }
+        if entry.requested_rev != requested_rev.map(LockedGitRev::from_repo_rev) {
+            return None;
+        }
+
+        Some(GitSource {
+            repo: entry.repo.clone(),
+            commit_hash: entry.commit_hash.clone(),
+        })
+    }
+
+    pub fn set_git_source(
+        &mut self,
+        node_id: NodeId,
+        repo: String,
+        requested_rev: Option<GitRepoRev>,
+        commit_hash: String,
+    ) {
+        self.git_sources.insert(
+            node_id,
+            LockedGitSource {
+                repo,
+                requested_rev: requested_rev.as_ref().map(LockedGitRev::from_repo_rev),
+                commit_hash,
+            },
+        );
+    }
+}
+
+impl Default for DoraLock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct LockedGitSource {
+    pub repo: String,
+    #[serde(default)]
+    pub requested_rev: Option<LockedGitRev>,
+    pub commit_hash: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum LockedGitRev {
+    Branch(String),
+    Tag(String),
+    Rev(String),
+}
+
+impl LockedGitRev {
+    fn from_repo_rev(rev: &GitRepoRev) -> Self {
+        match rev {
+            GitRepoRev::Branch(branch) => Self::Branch(branch.clone()),
+            GitRepoRev::Tag(tag) => Self::Tag(tag.clone()),
+            GitRepoRev::Rev(rev) => Self::Rev(rev.clone()),
+        }
+    }
+}
+
+fn lockfile_path(dataflow_path: &Path) -> eyre::Result<PathBuf> {
+    let dir = dataflow_path
+        .parent()
+        .ok_or_else(|| eyre::eyre!("dataflow path has no parent directory"))?;
+    Ok(dir.join(LOCKFILE_NAME))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dora_message::descriptor::GitRepoRev;
+    use uuid::Uuid;
+
+    #[test]
+    fn resolve_git_source_matches_repo_and_rev() {
+        let node_id = NodeId::from("camera".to_owned());
+        let mut lock = DoraLock::new();
+        lock.set_git_source(
+            node_id.clone(),
+            "https://github.com/dora-rs/dora.git".to_owned(),
+            Some(GitRepoRev::Branch("main".to_owned())),
+            "abc123".to_owned(),
+        );
+
+        let resolved = lock.resolve_git_source(
+            &node_id,
+            "https://github.com/dora-rs/dora.git",
+            Some(&GitRepoRev::Branch("main".to_owned())),
+        );
+
+        assert!(resolved.is_some());
+        assert_eq!(resolved.unwrap().commit_hash, "abc123");
+    }
+
+    #[test]
+    fn resolve_git_source_rejects_mismatched_rev() {
+        let node_id = NodeId::from("camera".to_owned());
+        let mut lock = DoraLock::new();
+        lock.set_git_source(
+            node_id.clone(),
+            "https://github.com/dora-rs/dora.git".to_owned(),
+            Some(GitRepoRev::Branch("main".to_owned())),
+            "abc123".to_owned(),
+        );
+
+        let resolved = lock.resolve_git_source(
+            &node_id,
+            "https://github.com/dora-rs/dora.git",
+            Some(&GitRepoRev::Tag("v0.1.0".to_owned())),
+        );
+
+        assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn lockfile_roundtrip() {
+        let dir = std::env::temp_dir().join(format!("dora-lock-test-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let dataflow_path = dir.join("dataflow.yml");
+        std::fs::write(&dataflow_path, "nodes: []\n").unwrap();
+
+        let mut lock = DoraLock::new();
+        lock.set_git_source(
+            NodeId::from("node-a".to_owned()),
+            "https://github.com/dora-rs/dora.git".to_owned(),
+            None,
+            "deadbeef".to_owned(),
+        );
+        lock.write_for_dataflow(&dataflow_path).unwrap();
+
+        let loaded = DoraLock::read_for_dataflow(&dataflow_path).unwrap();
+        assert_eq!(loaded.version, LOCKFILE_VERSION);
+        assert_eq!(loaded.git_sources.len(), 1);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/binaries/cli/src/lockfile.rs
+++ b/binaries/cli/src/lockfile.rs
@@ -5,7 +5,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-const LOCKFILE_NAME: &str = "dora.lock";
+const LOCKFILE_EXTENSION: &str = "dora.lock";
 const LOCKFILE_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -134,7 +134,12 @@ fn lockfile_path(dataflow_path: &Path) -> eyre::Result<PathBuf> {
     let dir = dataflow_path
         .parent()
         .ok_or_else(|| eyre::eyre!("dataflow path has no parent directory"))?;
-    Ok(dir.join(LOCKFILE_NAME))
+    let stem = dataflow_path
+        .file_stem()
+        .ok_or_else(|| eyre::eyre!("dataflow path has no file stem"))?
+        .to_string_lossy();
+
+    Ok(dir.join(format!("{stem}.{LOCKFILE_EXTENSION}")))
 }
 
 #[cfg(test)]
@@ -203,6 +208,63 @@ mod tests {
         let loaded = DoraLock::read_for_dataflow(&dataflow_path).unwrap();
         assert_eq!(loaded.version, LOCKFILE_VERSION);
         assert_eq!(loaded.git_sources.len(), 1);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn lockfile_isolated_per_dataflow_in_same_directory() {
+        let dir = std::env::temp_dir().join(format!("dora-lock-test-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let df_a = dir.join("a.yml");
+        let df_b = dir.join("b.yaml");
+        std::fs::write(&df_a, "nodes: []\n").unwrap();
+        std::fs::write(&df_b, "nodes: []\n").unwrap();
+
+        let mut lock_a = DoraLock::new();
+        lock_a.set_git_source(
+            NodeId::from("node-a".to_owned()),
+            "https://github.com/dora-rs/dora.git".to_owned(),
+            None,
+            "aaaa".to_owned(),
+        );
+        lock_a.write_for_dataflow(&df_a).unwrap();
+
+        let mut lock_b = DoraLock::new();
+        lock_b.set_git_source(
+            NodeId::from("node-b".to_owned()),
+            "https://github.com/dora-rs/dora.git".to_owned(),
+            None,
+            "bbbb".to_owned(),
+        );
+        lock_b.write_for_dataflow(&df_b).unwrap();
+
+        let loaded_a = DoraLock::read_for_dataflow(&df_a).unwrap();
+        let loaded_b = DoraLock::read_for_dataflow(&df_b).unwrap();
+
+        assert_eq!(loaded_a.git_sources.len(), 1);
+        assert!(
+            loaded_a
+                .git_sources
+                .contains_key(&NodeId::from("node-a".to_owned()))
+        );
+        assert!(
+            !loaded_a
+                .git_sources
+                .contains_key(&NodeId::from("node-b".to_owned()))
+        );
+
+        assert_eq!(loaded_b.git_sources.len(), 1);
+        assert!(
+            loaded_b
+                .git_sources
+                .contains_key(&NodeId::from("node-b".to_owned()))
+        );
+        assert!(
+            !loaded_b
+                .git_sources
+                .contains_key(&NodeId::from("node-a".to_owned()))
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }


### PR DESCRIPTION
##Related Issue: #1441 

## Context
  This PR targets reproducibility for git-backed node dependencies in `dora build`.

  Per CONTRIBUTING, this is a non-trivial change and is paired with issue discussion.

  ## Problem
  Git commit resolutions are not currently represented as a first-class, source-controlled lock artifact, which makes deterministic rebuilds and review of dependency resolution harder.

  ## What this solves
  Adds a `dora.lock` prototype so resolved git sources are explicit, shareable, and reusable.

  ## Changes
  - Added CLI lockfile module:
    - reads/writes `dora.lock` next to the dataflow
    - lockfile schema versioning (`version: 1`)
    - stores per-node git source resolution:
      - `repo`
      - `requested_rev` (branch/tag/rev/none)
      - `commit_hash`
  - Integrated into `dora build`:
    - consume matching lock entries first
    - fetch unresolved git refs only for misses
    - write normalized lockfile after build flow
  - Added unit tests:
    - lock hit on matching repo+rev
    - lock miss on mismatched rev
    - lockfile roundtrip read/write

  ## Why this matters
  - Improves reproducibility across local/dev/CI environments.
  - Makes dependency resolution reviewable in PRs.
  - Establishes a foundation for broader package/dependency management work.

  ## Validation
  - [x] `cargo fmt --all`
  - [x] `cargo build -p dora-cli`
  - [x] `cargo test -p dora-cli`
  - [x] `cargo clippy -p dora-cli --all-targets`
