### PR TITLE
feat(cli): enforce --locked validation for start and run

### DIFF
--- a/binaries/cli/src/command/run.rs
+++ b/binaries/cli/src/command/run.rs
@@ -8,9 +8,11 @@
 use super::Executable;
 use crate::{
     common::{handle_dataflow_result, resolve_dataflow, write_events_to},
+    lockfile::validate_locked_dataflow,
     output::print_log_message,
     session::DataflowSession,
 };
+use dora_core::descriptor::{Descriptor, DescriptorExt};
 use dora_daemon::{Daemon, LogDestination, flume};
 use duration_str::parse as parse_duration_str;
 use eyre::Context;
@@ -40,6 +42,12 @@ pub struct Run {
     #[clap(long, value_name = "DURATION", verbatim_doc_comment)]
     #[arg(value_parser = parse_duration_str)]
     pub stop_after: Option<Duration>,
+    /// Require lockfile-consistent dependency state before running.
+    ///
+    /// With this flag, `dora run` fails if `dora.lock` is missing or if lockfile,
+    /// descriptor, and current session git sources diverge.
+    #[clap(long, action)]
+    pub locked: bool,
 }
 
 impl Run {
@@ -48,6 +56,7 @@ impl Run {
             dataflow,
             uv: false,
             stop_after: None,
+            locked: false,
         }
     }
 }
@@ -84,8 +93,14 @@ impl Executable for Run {
         let dataflow_path = resolve_dataflow(self.dataflow)
             .await
             .context("could not resolve dataflow")?;
+        let dataflow_descriptor =
+            Descriptor::blocking_read(&dataflow_path).wrap_err("Failed to read yaml dataflow")?;
         let dataflow_session = DataflowSession::read_session(&dataflow_path)
             .context("failed to read DataflowSession")?;
+        if self.locked {
+            validate_locked_dataflow(&dataflow_path, &dataflow_descriptor, &dataflow_session)
+                .wrap_err("`--locked` validation failed")?;
+        }
 
         let (log_tx, log_rx) = flume::bounded(100);
         std::thread::spawn(move || {

--- a/binaries/cli/src/command/start/mod.rs
+++ b/binaries/cli/src/command/start/mod.rs
@@ -10,6 +10,7 @@ use crate::{
         connect_and_check_version, local_working_dir, long_context, resolve_dataflow, rpc,
         write_events_to,
     },
+    lockfile::validate_locked_dataflow,
     output::print_log_message,
     session::DataflowSession,
 };
@@ -58,6 +59,12 @@ pub struct Start {
     // Use UV to run nodes.
     #[clap(long, action)]
     uv: bool,
+    /// Require lockfile-consistent dependency state before starting.
+    ///
+    /// With this flag, `dora start` fails if `dora.lock` is missing or if lockfile,
+    /// descriptor, and current session git sources diverge.
+    #[clap(long, action)]
+    locked: bool,
 }
 
 impl Executable for Start {
@@ -65,8 +72,14 @@ impl Executable for Start {
         default_tracing()?;
         let coordinator_socket: SocketAddr = (self.coordinator_addr, self.coordinator_port).into();
 
-        let (dataflow, dataflow_descriptor, client, dataflow_id) =
-            start_dataflow(self.dataflow, self.name, coordinator_socket, self.uv).await?;
+        let (dataflow, dataflow_descriptor, client, dataflow_id) = start_dataflow(
+            self.dataflow,
+            self.name,
+            coordinator_socket,
+            self.uv,
+            self.locked,
+        )
+        .await?;
 
         let attach = match (self.attach, self.detach) {
             (true, true) => eyre::bail!("both `--attach` and `--detach` are given"),
@@ -115,6 +128,7 @@ async fn start_dataflow(
     name: Option<String>,
     coordinator_socket: SocketAddr,
     uv: bool,
+    locked: bool,
 ) -> Result<(PathBuf, Descriptor, CoordinatorControlClient, Uuid), eyre::Error> {
     let dataflow = resolve_dataflow(dataflow)
         .await
@@ -123,6 +137,10 @@ async fn start_dataflow(
         Descriptor::blocking_read(&dataflow).wrap_err("Failed to read yaml dataflow")?;
     let dataflow_session =
         DataflowSession::read_session(&dataflow).context("failed to read DataflowSession")?;
+    if locked {
+        validate_locked_dataflow(&dataflow, &dataflow_descriptor, &dataflow_session)
+            .wrap_err("`--locked` validation failed")?;
+    }
 
     let client = connect_and_check_version(coordinator_socket.ip(), coordinator_socket.port())
         .await

--- a/binaries/cli/src/lib.rs
+++ b/binaries/cli/src/lib.rs
@@ -7,6 +7,7 @@ use std::{
 mod command;
 mod common;
 mod formatting;
+mod lockfile;
 pub mod output;
 pub mod session;
 mod template;

--- a/binaries/cli/src/lockfile.rs
+++ b/binaries/cli/src/lockfile.rs
@@ -1,0 +1,267 @@
+use crate::session::DataflowSession;
+use dora_core::descriptor::{CoreNodeKind, CustomNode, Descriptor, DescriptorExt};
+use dora_message::{descriptor::GitRepoRev, id::NodeId};
+use eyre::{Context, bail};
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
+
+const LOCKFILE_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DoraLockfile {
+    pub version: u32,
+    #[serde(default)]
+    pub git_sources: BTreeMap<NodeId, LockedGitSource>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct LockedGitSource {
+    pub repo: String,
+    pub requested_rev: Option<GitRepoRev>,
+    pub commit_hash: String,
+}
+
+pub fn validate_locked_dataflow(
+    dataflow_path: &Path,
+    descriptor: &Descriptor,
+    dataflow_session: &DataflowSession,
+) -> eyre::Result<()> {
+    let lockfile = read_lockfile(dataflow_path)?;
+    if lockfile.version != LOCKFILE_VERSION {
+        bail!(
+            "unsupported dora.lock version `{}` (expected `{}`)",
+            lockfile.version,
+            LOCKFILE_VERSION
+        );
+    }
+
+    let expected = collect_git_dependencies(descriptor)?;
+    let mut remaining = lockfile.git_sources;
+
+    for (node_id, expected_source) in expected {
+        let Some(locked_source) = remaining.remove(&node_id) else {
+            bail!(
+                "missing lock entry for git node `{node_id}` in `{}`",
+                lockfile_path(dataflow_path).display()
+            );
+        };
+
+        if locked_source.repo != expected_source.repo {
+            bail!(
+                "locked repository mismatch for node `{node_id}`: descriptor=`{}` lock=`{}`",
+                expected_source.repo,
+                locked_source.repo
+            );
+        }
+
+        if !same_git_rev(
+            expected_source.requested_rev.as_ref(),
+            locked_source.requested_rev.as_ref(),
+        ) {
+            bail!(
+                "locked revision selector mismatch for node `{node_id}` (descriptor and dora.lock differ)"
+            );
+        }
+
+        let Some(session_git_source) = dataflow_session.git_sources.get(&node_id) else {
+            bail!(
+                "missing built git source for node `{node_id}` in session state; run `dora build` before using `--locked`"
+            );
+        };
+
+        if session_git_source.repo != locked_source.repo
+            || session_git_source.commit_hash != locked_source.commit_hash
+        {
+            bail!(
+                "session git source mismatch for node `{node_id}`; locked commit is `{}`, session commit is `{}`. Re-run `dora build` to rebuild with the lockfile state",
+                locked_source.commit_hash,
+                session_git_source.commit_hash
+            );
+        }
+    }
+
+    if !remaining.is_empty() {
+        let stale_entries = remaining
+            .keys()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(", ");
+        bail!("dora.lock contains stale git entries not present in descriptor: {stale_entries}");
+    }
+
+    Ok(())
+}
+
+fn read_lockfile(dataflow_path: &Path) -> eyre::Result<DoraLockfile> {
+    let path = lockfile_path(dataflow_path);
+    let file = std::fs::read_to_string(&path)
+        .with_context(|| format!("failed to read dora lockfile `{}`", path.display()))?;
+    serde_yaml::from_str(&file)
+        .with_context(|| format!("failed to parse dora lockfile `{}`", path.display()))
+}
+
+fn lockfile_path(dataflow_path: &Path) -> PathBuf {
+    dataflow_path.with_file_name("dora.lock")
+}
+
+fn collect_git_dependencies(
+    descriptor: &Descriptor,
+) -> eyre::Result<BTreeMap<NodeId, GitDependency>> {
+    let resolved_nodes = descriptor
+        .resolve_aliases_and_set_defaults()
+        .context("failed to resolve nodes while validating lockfile")?;
+    let mut dependencies = BTreeMap::new();
+    for (node_id, node) in resolved_nodes {
+        if let CoreNodeKind::Custom(CustomNode {
+            source: dora_message::descriptor::NodeSource::GitBranch { repo, rev },
+            ..
+        }) = node.kind
+        {
+            dependencies.insert(
+                node_id,
+                GitDependency {
+                    repo,
+                    requested_rev: rev,
+                },
+            );
+        }
+    }
+    Ok(dependencies)
+}
+
+fn same_git_rev(left: Option<&GitRepoRev>, right: Option<&GitRepoRev>) -> bool {
+    match (left, right) {
+        (None, None) => true,
+        (Some(GitRepoRev::Branch(a)), Some(GitRepoRev::Branch(b))) => a == b,
+        (Some(GitRepoRev::Tag(a)), Some(GitRepoRev::Tag(b))) => a == b,
+        (Some(GitRepoRev::Rev(a)), Some(GitRepoRev::Rev(b))) => a == b,
+        _ => false,
+    }
+}
+
+struct GitDependency {
+    repo: String,
+    requested_rev: Option<GitRepoRev>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dora_core::build::BuildInfo;
+    use dora_message::{BuildId, SessionId, common::GitSource};
+
+    #[test]
+    fn locked_validation_accepts_matching_descriptor_lock_and_session() {
+        let dataflow = dataflow_descriptor("https://example.com/repo.git", Some("main"));
+        let temp = tmp_dir();
+        let dataflow_path = temp.join("dataflow.yml");
+        std::fs::write(&dataflow_path, "nodes: []").unwrap();
+
+        write_lock(
+            &dataflow_path,
+            "https://example.com/repo.git",
+            Some(GitRepoRev::Branch("main".to_owned())),
+            "abc123",
+        );
+
+        let session = session_with_commit("https://example.com/repo.git", "abc123");
+        validate_locked_dataflow(&dataflow_path, &dataflow, &session).unwrap();
+    }
+
+    #[test]
+    fn locked_validation_fails_when_session_commit_differs() {
+        let dataflow = dataflow_descriptor("https://example.com/repo.git", Some("main"));
+        let temp = tmp_dir();
+        let dataflow_path = temp.join("dataflow.yml");
+        std::fs::write(&dataflow_path, "nodes: []").unwrap();
+
+        write_lock(
+            &dataflow_path,
+            "https://example.com/repo.git",
+            Some(GitRepoRev::Branch("main".to_owned())),
+            "abc123",
+        );
+        let session = session_with_commit("https://example.com/repo.git", "def456");
+
+        let err = validate_locked_dataflow(&dataflow_path, &dataflow, &session)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("session git source mismatch"));
+    }
+
+    #[test]
+    fn locked_validation_fails_when_descriptor_rev_differs() {
+        let dataflow = dataflow_descriptor("https://example.com/repo.git", Some("release"));
+        let temp = tmp_dir();
+        let dataflow_path = temp.join("dataflow.yml");
+        std::fs::write(&dataflow_path, "nodes: []").unwrap();
+
+        write_lock(
+            &dataflow_path,
+            "https://example.com/repo.git",
+            Some(GitRepoRev::Branch("main".to_owned())),
+            "abc123",
+        );
+        let session = session_with_commit("https://example.com/repo.git", "abc123");
+
+        let err = validate_locked_dataflow(&dataflow_path, &dataflow, &session)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("revision selector mismatch"));
+    }
+
+    fn dataflow_descriptor(repo: &str, branch: Option<&str>) -> Descriptor {
+        let mut rev = String::new();
+        if let Some(branch) = branch {
+            rev = format!("    branch: {branch}\n");
+        }
+        let yaml = format!(
+            "nodes:\n  - id: node-a\n    path: ./bin/node-a\n    git: {repo}\n{rev}    outputs: [out]\n"
+        );
+        serde_yaml::from_str::<Descriptor>(&yaml).unwrap()
+    }
+
+    fn session_with_commit(repo: &str, commit: &str) -> DataflowSession {
+        DataflowSession {
+            build_id: Some(BuildId::generate()),
+            session_id: SessionId::generate(),
+            git_sources: BTreeMap::from([(
+                NodeId::from("node-a".to_owned()),
+                GitSource {
+                    repo: repo.to_owned(),
+                    commit_hash: commit.to_owned(),
+                },
+            )]),
+            local_build: Some(BuildInfo {
+                node_working_dirs: BTreeMap::new(),
+            }),
+        }
+    }
+
+    fn write_lock(dataflow_path: &Path, repo: &str, rev: Option<GitRepoRev>, commit_hash: &str) {
+        let lock = DoraLockfile {
+            version: LOCKFILE_VERSION,
+            git_sources: BTreeMap::from([(
+                NodeId::from("node-a".to_owned()),
+                LockedGitSource {
+                    repo: repo.to_owned(),
+                    requested_rev: rev,
+                    commit_hash: commit_hash.to_owned(),
+                },
+            )]),
+        };
+        std::fs::write(
+            lockfile_path(dataflow_path),
+            serde_yaml::to_string(&lock).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn tmp_dir() -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("dora-cli-lock-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+}


### PR DESCRIPTION
## Related Issue

  Closes #1448 

  ## Problem

  `dora.lock` exists as a reproducibility artifact, but `dora start` / `dora run` do not strictly enforce lock consistency.

  ## What this PR changes

  1. Adds lock validation module:
     - `binaries/cli/src/lockfile.rs`
     - reads/parses `dora.lock`
     - validates schema version (`version: 1`)
     - validates git-backed node consistency across:
       - descriptor (`repo` + requested rev)
       - lockfile (`repo` + requested rev + commit)
       - session (`git_sources` commit)

  2. Adds `--locked` to:
     - `dora run`
     - `dora start`

  3. Execution behavior with `--locked`:
     - fail if lockfile missing/unreadable/invalid version
     - fail on repo mismatch
     - fail on revision selector mismatch
     - fail on session commit mismatch
     - fail on stale lock entries

  ## Why this matters (system impact)

  This turns lockfiles from advisory metadata into enforceable execution policy, improving reproducibility and trust in dependency state for Project #2 workflows.

  ## Design decisions / tradeoffs

  - Enforcement is opt-in via `--locked` to avoid changing default behavior.
  - Scope is intentionally narrow and independent:
    - no lock generation flow changes
    - no registry/package manager additions

  ## Tests added

  In `binaries/cli/src/lockfile.rs`:
  - matching descriptor + lock + session passes
  - session commit mismatch fails
  - descriptor revision mismatch fails

  ## Validation

  - [x] `cargo fmt --all`
  - [x] `cargo test -p dora-cli lockfile::tests -- --nocapture`
  - [x] `cargo build -p dora-cli`
  - [x] `cargo clippy -p dora-cli --all-targets`
  - [x] no unrelated source changes included
