### PR TITLE
feat(cli): add Dora.toml metadata schema validation command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1576,6 +1576,7 @@ dependencies = [
  "termcolor",
  "tokio",
  "tokio-stream",
+ "toml",
  "tracing",
  "tracing-log",
  "uuid",
@@ -4672,7 +4673,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.5+spec-1.1.0",
 ]
 
 [[package]]
@@ -5828,6 +5829,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6648,6 +6658,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.0.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6658,14 +6689,28 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime",
+ "toml_datetime 1.0.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -6674,8 +6719,14 @@ version = "1.0.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
 dependencies = [
- "winnow",
+ "winnow 1.0.0",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
@@ -7889,6 +7940,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -35,6 +35,7 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_yaml = { workspace = true }
 webbrowser = "0.8.3"
 serde_json = "1.0.86"
+toml = "0.8.19"
 termcolor = "1.1.3"
 uuid = { version = "1.7", features = ["v7", "serde"] }
 inquire = "0.5.2"

--- a/binaries/cli/src/command/node/mod.rs
+++ b/binaries/cli/src/command/node/mod.rs
@@ -1,19 +1,23 @@
 use crate::command::Executable;
 
 mod list;
+mod validate_metadata;
 
 pub use list::List;
+pub use validate_metadata::ValidateMetadata;
 
 /// Manage and inspect dataflow nodes.
 #[derive(Debug, clap::Subcommand)]
 pub enum Node {
     List(List),
+    ValidateMetadata(ValidateMetadata),
 }
 
 impl Executable for Node {
     async fn execute(self) -> eyre::Result<()> {
         match self {
             Node::List(cmd) => cmd.execute().await,
+            Node::ValidateMetadata(cmd) => cmd.execute().await,
         }
     }
 }

--- a/binaries/cli/src/command/node/validate_metadata.rs
+++ b/binaries/cli/src/command/node/validate_metadata.rs
@@ -1,0 +1,39 @@
+use clap::Args;
+use eyre::Context;
+use std::path::PathBuf;
+
+use crate::{
+    command::{Executable, default_tracing},
+    dora_toml,
+};
+
+/// Validate Dora package metadata (`Dora.toml`).
+///
+/// This checks schema and semantic constraints for:
+/// - `[package]` (`name`, `version`, `entrypoint`)
+/// - `[dependencies]` source declaration (`version` | `path` | `git`)
+///
+/// Examples:
+///
+/// Validate the default file in current directory:
+///   dora node validate-metadata
+///
+/// Validate a custom path:
+///   dora node validate-metadata --path ./nodes/camera/Dora.toml
+#[derive(Debug, Args)]
+#[clap(verbatim_doc_comment)]
+pub struct ValidateMetadata {
+    /// Path to metadata file
+    #[clap(long, value_name = "PATH", default_value = "Dora.toml")]
+    path: PathBuf,
+}
+
+impl Executable for ValidateMetadata {
+    async fn execute(self) -> eyre::Result<()> {
+        default_tracing()?;
+        dora_toml::read_and_validate(&self.path)
+            .with_context(|| format!("metadata validation failed for `{}`", self.path.display()))?;
+        println!("metadata validation passed: {}", self.path.display());
+        Ok(())
+    }
+}

--- a/binaries/cli/src/dora_toml.rs
+++ b/binaries/cli/src/dora_toml.rs
@@ -1,0 +1,215 @@
+use eyre::{Context, bail};
+use semver::{Version, VersionReq};
+use std::{collections::BTreeMap, path::Path};
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DoraToml {
+    pub package: PackageMetadata,
+    #[serde(default)]
+    pub dependencies: BTreeMap<String, DependencySpec>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PackageMetadata {
+    pub name: String,
+    pub version: String,
+    pub entrypoint: String,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DependencySpec {
+    pub version: Option<String>,
+    pub path: Option<String>,
+    pub git: Option<String>,
+    pub rev: Option<String>,
+}
+
+pub fn read_and_validate(path: &Path) -> eyre::Result<DoraToml> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read metadata file `{}`", path.display()))?;
+    let metadata: DoraToml = toml::from_str(&raw)
+        .with_context(|| format!("failed to parse metadata file `{}`", path.display()))?;
+    validate(&metadata)?;
+    Ok(metadata)
+}
+
+pub fn validate(metadata: &DoraToml) -> eyre::Result<()> {
+    validate_package(&metadata.package)?;
+    for (name, spec) in &metadata.dependencies {
+        validate_dependency_name(name)?;
+        validate_dependency_spec(name, spec)?;
+    }
+    Ok(())
+}
+
+fn validate_package(package: &PackageMetadata) -> eyre::Result<()> {
+    validate_package_name(&package.name)?;
+    Version::parse(&package.version)
+        .with_context(|| format!("package.version `{}` is not valid semver", package.version))?;
+
+    if package.entrypoint.trim().is_empty() {
+        bail!("package.entrypoint must not be empty");
+    }
+    Ok(())
+}
+
+fn validate_dependency_name(name: &str) -> eyre::Result<()> {
+    validate_name_chars(name, "dependency key")
+}
+
+fn validate_package_name(name: &str) -> eyre::Result<()> {
+    validate_name_chars(name, "package.name")
+}
+
+fn validate_name_chars(name: &str, field: &str) -> eyre::Result<()> {
+    if name.is_empty() {
+        bail!("{field} must not be empty");
+    }
+
+    let valid = name
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_');
+    if !valid {
+        bail!("{field} `{name}` contains invalid characters (allowed: a-z, A-Z, 0-9, -, _)");
+    }
+    Ok(())
+}
+
+fn validate_dependency_spec(name: &str, spec: &DependencySpec) -> eyre::Result<()> {
+    let mut source_count = 0;
+    if spec.version.is_some() {
+        source_count += 1;
+    }
+    if spec.path.is_some() {
+        source_count += 1;
+    }
+    if spec.git.is_some() {
+        source_count += 1;
+    }
+    if source_count == 0 {
+        bail!("dependency `{name}` must specify one source via `version`, `path`, or `git`");
+    }
+    if source_count > 1 {
+        bail!(
+            "dependency `{name}` must not mix sources; choose exactly one of `version`, `path`, or `git`"
+        );
+    }
+
+    if let Some(version) = &spec.version {
+        VersionReq::parse(version).with_context(|| {
+            format!("dependency `{name}` has invalid version requirement `{version}`")
+        })?;
+    }
+    if let Some(path) = &spec.path {
+        if path.trim().is_empty() {
+            bail!("dependency `{name}` has an empty `path`");
+        }
+    }
+    if let Some(git) = &spec.git {
+        if git.trim().is_empty() {
+            bail!("dependency `{name}` has an empty `git` URL");
+        }
+    }
+    if spec.rev.is_some() && spec.git.is_none() {
+        bail!("dependency `{name}` sets `rev` but does not set `git`");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_metadata_passes_validation() {
+        let metadata: DoraToml = toml::from_str(
+            r#"
+[package]
+name = "camera_node"
+version = "0.1.0"
+entrypoint = "python -m camera_node"
+
+[dependencies]
+yolo = { version = "^1.2.0" }
+math = { path = "../math-node" }
+vision = { git = "https://github.com/example/vision-node.git", rev = "main" }
+"#,
+        )
+        .unwrap();
+
+        validate(&metadata).unwrap();
+    }
+
+    #[test]
+    fn invalid_package_version_fails() {
+        let metadata: DoraToml = toml::from_str(
+            r#"
+[package]
+name = "camera_node"
+version = "abc"
+entrypoint = "python -m camera_node"
+"#,
+        )
+        .unwrap();
+
+        let err = validate(&metadata).unwrap_err().to_string();
+        assert!(err.contains("not valid semver"));
+    }
+
+    #[test]
+    fn dependency_with_rev_without_git_fails() {
+        let metadata: DoraToml = toml::from_str(
+            r#"
+[package]
+name = "camera_node"
+version = "0.1.0"
+entrypoint = "python -m camera_node"
+
+[dependencies]
+vision = { rev = "main", path = "../vision" }
+"#,
+        )
+        .unwrap();
+
+        let err = validate(&metadata).unwrap_err().to_string();
+        assert!(err.contains("sets `rev` but does not set `git`"));
+    }
+
+    #[test]
+    fn dependency_with_only_rev_fails() {
+        let metadata: DoraToml = toml::from_str(
+            r#"
+[package]
+name = "camera_node"
+version = "0.1.0"
+entrypoint = "python -m camera_node"
+
+[dependencies]
+vision = { rev = "main" }
+"#,
+        )
+        .unwrap();
+
+        let err = validate(&metadata).unwrap_err().to_string();
+        assert!(err.contains("must specify one source"));
+    }
+
+    #[test]
+    fn package_with_invalid_name_fails() {
+        let metadata: DoraToml = toml::from_str(
+            r#"
+[package]
+name = "bad name"
+version = "0.1.0"
+entrypoint = "python -m camera_node"
+"#,
+        )
+        .unwrap();
+
+        let err = validate(&metadata).unwrap_err().to_string();
+        assert!(err.contains("contains invalid characters"));
+    }
+}

--- a/binaries/cli/src/lib.rs
+++ b/binaries/cli/src/lib.rs
@@ -6,6 +6,7 @@ use std::{
 
 mod command;
 mod common;
+mod dora_toml;
 mod formatting;
 pub mod output;
 pub mod session;

--- a/examples/metadata/Dora.toml
+++ b/examples/metadata/Dora.toml
@@ -1,0 +1,9 @@
+[package]
+name = "camera_node"
+version = "0.1.0"
+entrypoint = "python -m camera_node"
+
+[dependencies]
+yolo = { version = "^1.2.0" }
+math = { path = "../math-node" }
+vision = { git = "https://github.com/example/vision-node.git", rev = "main" }


### PR DESCRIPTION
## Related Issue

  Closes #1450 

  ## Problem

  `dora` does not currently expose a formal node package metadata contract (`Dora.toml`) nor a validation command.
  That blocks incremental progress toward package/dependency management workflows (Project #2).

  ## What this PR changes

  1. Adds metadata schema + validation module
     - `binaries/cli/src/dora_toml.rs`
     - Supports:
       - `[package]` (`name`, `version`, `entrypoint`)
       - `[dependencies]` map
     - Validation rules:
       - package name character constraints
       - `package.version` must be valid semver
       - `package.entrypoint` must be non-empty
       - dependency must select exactly one source: `version` | `path` | `git`
       - `rev` is only valid when `git` is set
       - empty source values rejected
     - Uses strict parsing with `deny_unknown_fields` for schema discipline.

  2. Adds new CLI subcommand
     - `dora node validate-metadata`
     - optional `--path`, default `Dora.toml`
     - prints success message on valid metadata
     - returns explicit failure context on invalid metadata

  3. Integrates command into existing `dora node` command tree
     - `binaries/cli/src/command/node/mod.rs`

  4. Adds a metadata example
     - `examples/metadata/Dora.toml`

  5. Adds required dependency
     - `toml` in `binaries/cli/Cargo.toml`

  ## Why this matters (system impact)

  This creates a concrete, enforceable metadata contract that future package operations can rely on.
  It is intentionally small, independent, and self-contained, so it can be reviewed/merged without coupling to registry or publish/install implementation.

  ## Design decisions / tradeoffs

  - Chosen as schema+validation only to keep this PR independent and low-risk.
  - `deny_unknown_fields` is deliberate to prevent silent metadata drift.
  - Source selection is exclusive (`version` vs `path` vs `git`) to simplify future resolver behavior.

  ## Tests

  Added unit tests in `binaries/cli/src/dora_toml.rs`:
  - valid metadata passes
  - invalid package version fails
  - invalid package name fails
  - `rev` without `git` fails
  - dependency with no source fails

  ## Validation checklist

  - [x] `cargo fmt --all`
  - [x] `cargo test -p dora-cli dora_toml::tests -- --nocapture`
  - [x] `cargo build -p dora-cli`
  - [x] `cargo clippy -p dora-cli --all-targets`
  - [x] No unrelated source changes included

  ———