### PR TITLE
feat(cli): add local registry index reader and inspect command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1576,6 +1576,7 @@ dependencies = [
  "termcolor",
  "tokio",
  "tokio-stream",
+ "toml",
  "tracing",
  "tracing-log",
  "uuid",
@@ -4672,7 +4673,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.5+spec-1.1.0",
 ]
 
 [[package]]
@@ -5828,6 +5829,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6648,6 +6658,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.0.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6658,14 +6689,28 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime",
+ "toml_datetime 1.0.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -6674,8 +6719,14 @@ version = "1.0.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
 dependencies = [
- "winnow",
+ "winnow 1.0.0",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
@@ -7889,6 +7940,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -35,6 +35,7 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_yaml = { workspace = true }
 webbrowser = "0.8.3"
 serde_json = "1.0.86"
+toml = "0.8.19"
 termcolor = "1.1.3"
 uuid = { version = "1.7", features = ["v7", "serde"] }
 inquire = "0.5.2"

--- a/binaries/cli/src/command/node/inspect_registry.rs
+++ b/binaries/cli/src/command/node/inspect_registry.rs
@@ -1,0 +1,161 @@
+use clap::Args;
+use serde::Serialize;
+use std::{io::Write, path::PathBuf};
+use tabwriter::TabWriter;
+
+use crate::{
+    command::{Executable, default_tracing},
+    formatting::OutputFormat,
+    registry::{RegistryPackage, RegistrySource, resolve_package},
+};
+
+/// Inspect a local filesystem node registry index.
+///
+/// The registry path can point to:
+/// - a directory containing `index.toml`
+/// - an explicit `index.toml` file path
+///
+/// Examples:
+///
+/// List all packages in a registry:
+///   dora node inspect-registry --registry ./registry
+///
+/// Resolve latest package by name:
+///   dora node inspect-registry --registry ./registry --name camera_node
+///
+/// Resolve with version requirement:
+///   dora node inspect-registry --registry ./registry --name camera_node --requirement "^0.2"
+#[derive(Debug, Args)]
+#[clap(verbatim_doc_comment)]
+pub struct InspectRegistry {
+    /// Registry directory or index.toml path
+    #[clap(long, value_name = "PATH")]
+    registry: PathBuf,
+    /// Package name to resolve
+    #[clap(long, value_name = "NAME")]
+    name: Option<String>,
+    /// Optional semver requirement for resolution
+    #[clap(long, value_name = "REQ")]
+    requirement: Option<String>,
+    /// Output format
+    #[clap(long, value_name = "FORMAT", default_value_t = OutputFormat::Table)]
+    format: OutputFormat,
+}
+
+#[derive(Serialize)]
+struct PackageRow<'a> {
+    name: &'a str,
+    version: &'a str,
+    entrypoint: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<&'a str>,
+}
+
+impl Executable for InspectRegistry {
+    async fn execute(self) -> eyre::Result<()> {
+        default_tracing()?;
+        if self.requirement.is_some() && self.name.is_none() {
+            eyre::bail!("`--requirement` requires `--name`");
+        }
+
+        let source = RegistrySource::from_path(&self.registry);
+        let index = source.read_index()?;
+
+        match self.name {
+            Some(name) => {
+                let resolved = resolve_package(&index, &name, self.requirement.as_deref())?;
+                match resolved {
+                    Some(pkg) => print_packages(std::slice::from_ref(pkg), self.format)?,
+                    None => eyre::bail!("no matching package found for `{name}`"),
+                }
+            }
+            None => {
+                print_packages(&index.packages, self.format)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn print_packages(packages: &[RegistryPackage], format: OutputFormat) -> eyre::Result<()> {
+    match format {
+        OutputFormat::Json => {
+            for pkg in packages {
+                let row = PackageRow {
+                    name: &pkg.name,
+                    version: &pkg.version,
+                    entrypoint: &pkg.entrypoint,
+                    description: pkg.description.as_deref(),
+                };
+                println!("{}", serde_json::to_string(&row)?);
+            }
+        }
+        OutputFormat::Table => {
+            let mut tw = TabWriter::new(std::io::stdout().lock());
+            tw.write_all(b"NAME\tVERSION\tENTRYPOINT\tDESCRIPTION\n")?;
+            for pkg in packages {
+                let description = pkg.description.as_deref().unwrap_or("-");
+                tw.write_all(
+                    format!(
+                        "{}\t{}\t{}\t{}\n",
+                        pkg.name, pkg.version, pkg.entrypoint, description
+                    )
+                    .as_bytes(),
+                )?;
+            }
+            tw.flush()?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_requirement_without_name() {
+        let args = InspectRegistry {
+            registry: PathBuf::from("./registry"),
+            name: None,
+            requirement: Some("^0.1".to_owned()),
+            format: OutputFormat::Json,
+        };
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let err = rt.block_on(args.execute()).unwrap_err().to_string();
+        assert!(err.contains("requires `--name`"));
+    }
+
+    #[test]
+    fn can_build_registry_source_from_directory() {
+        let base = PathBuf::from("./registry");
+        let source = RegistrySource::from_path(base.as_path());
+        assert_eq!(source.index_path, base.join("index.toml"));
+    }
+
+    #[test]
+    fn can_build_registry_source_from_file() {
+        let source = RegistrySource::from_path(PathBuf::from("./registry/index.toml").as_path());
+        assert!(source.index_path.ends_with("registry/index.toml"));
+    }
+
+    #[test]
+    fn parser_accepts_valid_index_shape() {
+        use crate::registry::RegistryIndex;
+
+        let raw = r#"
+version = 1
+
+[[packages]]
+name = "camera_node"
+version = "0.1.0"
+entrypoint = "python -m camera_node"
+"#;
+        let index: RegistryIndex = toml::from_str(raw).unwrap();
+        assert_eq!(index.packages.len(), 1);
+    }
+}

--- a/binaries/cli/src/command/node/mod.rs
+++ b/binaries/cli/src/command/node/mod.rs
@@ -1,19 +1,23 @@
 use crate::command::Executable;
 
+mod inspect_registry;
 mod list;
 
+pub use inspect_registry::InspectRegistry;
 pub use list::List;
 
 /// Manage and inspect dataflow nodes.
 #[derive(Debug, clap::Subcommand)]
 pub enum Node {
     List(List),
+    InspectRegistry(InspectRegistry),
 }
 
 impl Executable for Node {
     async fn execute(self) -> eyre::Result<()> {
         match self {
             Node::List(cmd) => cmd.execute().await,
+            Node::InspectRegistry(cmd) => cmd.execute().await,
         }
     }
 }

--- a/binaries/cli/src/lib.rs
+++ b/binaries/cli/src/lib.rs
@@ -8,6 +8,7 @@ mod command;
 mod common;
 mod formatting;
 pub mod output;
+mod registry;
 pub mod session;
 mod template;
 

--- a/binaries/cli/src/registry.rs
+++ b/binaries/cli/src/registry.rs
@@ -1,0 +1,222 @@
+use eyre::{Context, bail};
+use semver::{Version, VersionReq};
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
+
+const REGISTRY_INDEX_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RegistryIndex {
+    pub version: u32,
+    #[serde(default)]
+    pub packages: Vec<RegistryPackage>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RegistryPackage {
+    pub name: String,
+    pub version: String,
+    pub entrypoint: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub dependencies: BTreeMap<String, RegistryDependency>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RegistryDependency {
+    pub version: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct RegistrySource {
+    pub index_path: PathBuf,
+}
+
+impl RegistrySource {
+    pub fn from_path(path: &Path) -> Self {
+        // Resolve registry source without requiring the path to already exist.
+        // `*.toml` is treated as an explicit index file; everything else is a
+        // registry directory containing `index.toml`.
+        let index_path = match path.extension().and_then(|ext| ext.to_str()) {
+            Some("toml") => path.to_owned(),
+            _ => path.join("index.toml"),
+        };
+        Self { index_path }
+    }
+
+    pub fn read_index(&self) -> eyre::Result<RegistryIndex> {
+        let raw = std::fs::read_to_string(&self.index_path).with_context(|| {
+            format!(
+                "failed to read registry index at `{}`",
+                self.index_path.display()
+            )
+        })?;
+        let index: RegistryIndex = toml::from_str(&raw).with_context(|| {
+            format!(
+                "failed to parse registry index at `{}`",
+                self.index_path.display()
+            )
+        })?;
+
+        if index.version != REGISTRY_INDEX_VERSION {
+            bail!(
+                "unsupported registry index version `{}` (expected `{}`)",
+                index.version,
+                REGISTRY_INDEX_VERSION
+            );
+        }
+        validate_index(&index)?;
+        Ok(index)
+    }
+}
+
+pub fn resolve_package<'a>(
+    index: &'a RegistryIndex,
+    name: &str,
+    requirement: Option<&str>,
+) -> eyre::Result<Option<&'a RegistryPackage>> {
+    let version_req = match requirement {
+        Some(req) => Some(
+            VersionReq::parse(req)
+                .with_context(|| format!("invalid version requirement `{req}`"))?,
+        ),
+        None => None,
+    };
+
+    let mut matching = index
+        .packages
+        .iter()
+        .filter(|pkg| pkg.name == name)
+        .map(|pkg| {
+            let parsed = Version::parse(&pkg.version).with_context(|| {
+                format!(
+                    "registry package `{}` has invalid version `{}`",
+                    pkg.name, pkg.version
+                )
+            })?;
+            Ok((pkg, parsed))
+        })
+        .collect::<eyre::Result<Vec<_>>>()?;
+
+    if let Some(version_req) = version_req {
+        matching.retain(|(_, version)| version_req.matches(version));
+    }
+
+    matching.sort_by(|(_, a), (_, b)| b.cmp(a));
+    Ok(matching.first().map(|(pkg, _)| *pkg))
+}
+
+fn validate_index(index: &RegistryIndex) -> eyre::Result<()> {
+    for pkg in &index.packages {
+        validate_package(pkg)?;
+    }
+    Ok(())
+}
+
+fn validate_package(pkg: &RegistryPackage) -> eyre::Result<()> {
+    validate_name(&pkg.name)?;
+    Version::parse(&pkg.version).with_context(|| {
+        format!(
+            "package `{}` has invalid semver `{}`",
+            pkg.name, pkg.version
+        )
+    })?;
+    if pkg.entrypoint.trim().is_empty() {
+        bail!("package `{}` has empty `entrypoint`", pkg.name);
+    }
+    for (dep_name, dep_spec) in &pkg.dependencies {
+        validate_name(dep_name)?;
+        VersionReq::parse(&dep_spec.version).with_context(|| {
+            format!(
+                "dependency `{dep_name}` in package `{}` has invalid version requirement `{}`",
+                pkg.name, dep_spec.version
+            )
+        })?;
+    }
+    Ok(())
+}
+
+fn validate_name(name: &str) -> eyre::Result<()> {
+    if name.is_empty() {
+        bail!("package/dependency name must not be empty");
+    }
+    if !name
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
+    {
+        bail!("invalid package/dependency name `{name}`");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_latest_matching_version() {
+        let index: RegistryIndex = toml::from_str(
+            r#"
+version = 1
+
+[[packages]]
+name = "camera_node"
+version = "0.1.0"
+entrypoint = "python -m camera_node"
+
+[[packages]]
+name = "camera_node"
+version = "0.2.0"
+entrypoint = "python -m camera_node"
+"#,
+        )
+        .unwrap();
+
+        let resolved = resolve_package(&index, "camera_node", Some(">=0.1.0,<1.0.0"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(resolved.version, "0.2.0");
+    }
+
+    #[test]
+    fn resolves_none_when_no_match() {
+        let index: RegistryIndex = toml::from_str(
+            r#"
+version = 1
+
+[[packages]]
+name = "camera_node"
+version = "0.1.0"
+entrypoint = "python -m camera_node"
+"#,
+        )
+        .unwrap();
+
+        let resolved = resolve_package(&index, "camera_node", Some(">=1.0.0")).unwrap();
+        assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn invalid_entrypoint_fails_validation() {
+        let index: RegistryIndex = toml::from_str(
+            r#"
+version = 1
+
+[[packages]]
+name = "camera_node"
+version = "0.1.0"
+entrypoint = "   "
+"#,
+        )
+        .unwrap();
+
+        let err = validate_index(&index).unwrap_err().to_string();
+        assert!(err.contains("empty `entrypoint`"));
+    }
+}

--- a/examples/registry/index.toml
+++ b/examples/registry/index.toml
@@ -1,0 +1,16 @@
+version = 1
+
+[[packages]]
+name = "camera_node"
+version = "0.1.0"
+entrypoint = "python -m camera_node"
+description = "Camera capture node"
+
+[packages.dependencies]
+yolo = { version = "^1.2.0" }
+
+[[packages]]
+name = "camera_node"
+version = "0.2.0"
+entrypoint = "python -m camera_node"
+description = "Camera capture node (improved)"


### PR DESCRIPTION
  ## Issue Related: #1452 
 
 ## Problem 
  Project #2 (Package and Dependency Management) needs an incremental registry foundation, but Dora currently has no local registry index read/resolution path to validate package lookup
  behavior.

  ## Why this matters
  This PR establishes a self-contained, read-only registry prototype that enables reproducible dependency resolution semantics without introducing publish/write complexity yet.

  ## What changed
  - Added new registry module:
    - `RegistryIndex` schema (TOML)
    - strict index version check (`version = 1`)
    - package/dependency validation (name rules, semver parsing, non-empty entrypoint)
    - resolver API selecting latest version matching optional semver requirement
  - Added CLI command:
    - `dora node inspect-registry`
    - supports registry path as directory (`index.toml`) or explicit file
    - supports list-all mode and resolve-by-name mode
    - optional `--requirement` semver filter (validated)
    - output in `table` or `json`
  - Added example:
    - `examples/registry/index.toml`
  - Added tests for:
    - resolver behavior
    - invalid metadata validation
    - command argument guardrails
    - source path handling for file vs directory

  ## Design choices / tradeoffs
  - Read-only scope only (no publish/write) to keep PR independent and low-risk.
  - Deterministic source resolution:
    - `*.toml` => explicit index file
    - otherwise => `<path>/index.toml`
    This avoids relying on filesystem pre-existence for path interpretation.
  - Kept schema minimal and future-extensible for install/publish follow-ups.

  ## Validation
  - [x] `cargo fmt --all`
  - [x] `cargo build -p dora-cli`
  - [x] `cargo test -p dora-cli`
  - [x] `cargo clippy -p dora-cli --all-targets`

  (Existing unrelated workspace warnings are unchanged.)
