### PR TITLE
fix(uv): pin python runtime to active venv for daemon-spawned nodes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -492,7 +492,11 @@ jobs:
         if: runner.os != 'Windows'
         env:
           RUST_LOG: debug
-        run: dora run examples/python-async/dataflow.yaml --uv --stop-after 5m
+        run: |
+          # Ensure uv execution does not leak to parent `.python-version` / global interpreters.
+          echo "3.11.14" > .python-version
+          trap 'rm -f .python-version' EXIT
+          dora run examples/python-async/dataflow.yaml --uv --stop-after 5m
       - name: "Test Python Example: Drain"
         timeout-minutes: 30
         env:

--- a/binaries/daemon/src/spawn/command.rs
+++ b/binaries/daemon/src/spawn/command.rs
@@ -7,7 +7,26 @@ use dora_core::{
 use dora_download::download_file;
 use dora_message::common::LogLevel;
 use eyre::WrapErr;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+pub(super) fn uv_python_interpreter_from_env() -> Option<PathBuf> {
+    uv_python_interpreter_from_virtual_env(std::env::var_os("VIRTUAL_ENV").map(PathBuf::from))
+}
+
+fn uv_python_interpreter_from_virtual_env(virtual_env: Option<PathBuf>) -> Option<PathBuf> {
+    let mut python = virtual_env?;
+    #[cfg(target_os = "windows")]
+    {
+        python.push("Scripts");
+        python.push("python.exe");
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        python.push("bin");
+        python.push("python");
+    }
+    python.exists().then_some(python)
+}
 
 pub(super) async fn path_spawn_command(
     working_dir: &Path,
@@ -47,14 +66,33 @@ pub(super) async fn path_spawn_command(
             let mut cmd = match resolved_path.extension().map(|ext| ext.to_str()) {
                 Some(Some("py")) => {
                     let mut cmd = if uv {
+                        let uv_python = uv_python_interpreter_from_env();
                         let mut cmd = Command::new("uv");
                         cmd = cmd.arg("run");
+                        cmd = cmd.arg("--no-project");
+                        if let Some(ref uv_python) = uv_python {
+                            cmd = cmd.arg("--python");
+                            cmd = cmd.arg(uv_python);
+                        } else {
+                            cmd = cmd.arg("--active");
+                        }
+                        cmd = cmd.arg("--no-managed-python");
                         cmd = cmd.arg("python");
                         logger
                             .log(
                                 LogLevel::Info,
                                 Some("spawner".into()),
-                                format!("spawning: uv run python -u {}", resolved_path.display()),
+                                match uv_python {
+                                    Some(path) => format!(
+                                        "spawning: uv run --no-project --python {} --no-managed-python python -u {}",
+                                        path.display(),
+                                        resolved_path.display()
+                                    ),
+                                    None => format!(
+                                        "spawning: uv run --active --no-project --no-managed-python python -u {}",
+                                        resolved_path.display()
+                                    ),
+                                },
                             )
                             .await;
                         cmd
@@ -96,4 +134,40 @@ pub(super) async fn path_spawn_command(
     };
 
     Ok(Some(cmd))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::uv_python_interpreter_from_virtual_env;
+
+    #[test]
+    fn resolves_python_from_virtual_env_layout() {
+        let temp_root =
+            std::env::temp_dir().join(format!("dora-daemon-test-{}", uuid::Uuid::new_v4()));
+        #[cfg(target_os = "windows")]
+        let python_path = temp_root.join("Scripts").join("python.exe");
+        #[cfg(not(target_os = "windows"))]
+        let python_path = temp_root.join("bin").join("python");
+
+        std::fs::create_dir_all(python_path.parent().expect("python path has parent"))
+            .expect("failed to create python parent dir");
+        std::fs::write(&python_path, b"").expect("failed to create python executable stub");
+
+        let resolved = uv_python_interpreter_from_virtual_env(Some(temp_root.clone()));
+        assert_eq!(resolved.as_deref(), Some(python_path.as_path()));
+
+        std::fs::remove_dir_all(temp_root).expect("failed to clean temp test directory");
+    }
+
+    #[test]
+    fn returns_none_if_virtual_env_python_missing() {
+        let temp_root =
+            std::env::temp_dir().join(format!("dora-daemon-test-missing-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&temp_root).expect("failed to create temp test directory");
+
+        let resolved = uv_python_interpreter_from_virtual_env(Some(temp_root.clone()));
+        assert!(resolved.is_none());
+
+        std::fs::remove_dir_all(temp_root).expect("failed to clean temp test directory");
+    }
 }

--- a/binaries/daemon/src/spawn/spawner.rs
+++ b/binaries/daemon/src/spawn/spawner.rs
@@ -3,7 +3,10 @@ use crate::{
     log::NodeLogger,
     node_communication::spawn_listener_loop,
     node_inputs,
-    spawn::{command::path_spawn_command, prepared::PreparedNode},
+    spawn::{
+        command::{path_spawn_command, uv_python_interpreter_from_env},
+        prepared::PreparedNode,
+    },
 };
 use clonable_command::{Command, Stdio};
 use crossbeam::queue::ArrayQueue;
@@ -200,14 +203,30 @@ impl Spawner {
                         ]);
                         Some(command)
                     } else {
+                        let uv_python = uv_python_interpreter_from_env();
                         let mut cmd = if self.uv {
                             let mut cmd = Command::new("uv");
                             cmd = cmd.arg("run");
+                            cmd = cmd.arg("--no-project");
+                            if let Some(ref uv_python) = uv_python {
+                                cmd = cmd.arg("--python");
+                                cmd = cmd.arg(uv_python);
+                            } else {
+                                cmd = cmd.arg("--active");
+                            }
+                            cmd = cmd.arg("--no-managed-python");
                             cmd = cmd.arg("python");
-                            tracing::info!(
-                                "spawning: uv run python -uc import dora; dora.start_runtime() # {}",
-                                node.id
-                            );
+                            match uv_python {
+                                Some(path) => tracing::info!(
+                                    "spawning: uv run --no-project --python {} --no-managed-python python -uc import dora; dora.start_runtime() # {}",
+                                    path.display(),
+                                    node.id
+                                ),
+                                None => tracing::info!(
+                                    "spawning: uv run --active --no-project --no-managed-python python -uc import dora; dora.start_runtime() # {}",
+                                    node.id
+                                ),
+                            }
                             cmd
                         } else {
                             let python = get_python_path()


### PR DESCRIPTION
## Problem

  `dora run/start --uv` currently spawns Python nodes via `uv run python ...`, but interpreter selection can drift to parent/global discovery rules (e.g. repo-level `.python-version`) instead of
  the active virtual environment.

  That causes non-reproducible behavior:
  - same dataflow passes/fails depending on host Python state,
  - `ModuleNotFoundError` appears even when dependencies are installed in the active venv,
  - runtime isolation expectations for Python nodes are violated.

  ## Why this matters

  This is a reproducibility and dependency-isolation gap in the execution path (not just build path).
  For Project #2-aligned work, runtime determinism is required before introducing higher-level packaging/install workflows.

  ## What changed

  ### 1) Pin UV interpreter to active venv for Python node spawn
  File: `binaries/daemon/src/spawn/command.rs`

  - Added helper to resolve `VIRTUAL_ENV` Python path:
    - Unix: `$VIRTUAL_ENV/bin/python`
    - Windows: `$VIRTUAL_ENV/Scripts/python.exe`
  - Updated Python spawn command under `--uv`:
    - from: `uv run python -u <script>`
    - to: `uv run --no-project --python <venv-python> --no-managed-python python -u <script>`
  - Fallback behavior:
    - if no valid `VIRTUAL_ENV` Python is available, use `--active` path.

  ### 2) Apply same behavior for Python runtime operator spawn
  File: `binaries/daemon/src/spawn/spawner.rs`

  - Updated runtime launch path (`import dora; dora.start_runtime()`) to use the same pinned-venv logic under `--uv`.

  ### 3) Add regression tests
  File: `binaries/daemon/src/spawn/command.rs`

  - Added unit tests for interpreter resolution:
    - resolves Python path from virtual env layout,
    - returns `None` when venv Python path does not exist.

  ### 4) Add CI regression coverage
  File: `.github/workflows/ci.yml`

  - In `Test CLI (Python): Async Example`, inject conflicting `.python-version` before run:
    - verifies daemon-side `--uv` spawn does not leak to parent Python selection.

  ## Design notes / tradeoffs

  - This is intentionally narrow: it hardens daemon Python spawn behavior without introducing a new package-manager surface.
  - We prefer deterministic interpreter selection (`--python <venv>`) over ambient resolution.
  - `--no-project` avoids inheriting unrelated parent project settings; fallback still exists when `VIRTUAL_ENV` is unavailable.

  ## Validation

  - `cargo fmt --all`
  - `cargo test -p dora-daemon spawn::command::tests -- --nocapture`
  - `cargo check -p dora-daemon`
  - Local end-to-end repro with conflicting `.python-version`:
    - `cargo run -p dora-cli -- run examples/python-async/dataflow.yaml --uv --stop-after 30s` ✅

  ## Related

  - Proposed issue: #1460 `dora run/start --uv can leak to parent Python selection and break reproducibility`
