### PR TITLE
feat(observability): add structured node runtime health API and wire to `dora node list`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1599,6 +1599,7 @@ dependencies = [
  "log",
  "petname",
  "serde_json",
+ "serde_yaml 0.9.34+deprecated",
  "tokio",
  "tokio-stream",
  "tracing",

--- a/binaries/cli/src/command/node/list.rs
+++ b/binaries/cli/src/command/node/list.rs
@@ -11,7 +11,9 @@ use crate::{
     formatting::OutputFormat,
 };
 use dora_message::{
-    cli_to_coordinator::CoordinatorControlClient, coordinator_to_cli::NodeInfo, tarpc,
+    cli_to_coordinator::CoordinatorControlClient,
+    coordinator_to_cli::{NodeHealth, NodeInfo},
+    tarpc,
 };
 
 /// List all currently running nodes and their status.
@@ -97,26 +99,19 @@ async fn list(
     let entries: Vec<OutputEntry> = filtered_nodes
         .into_iter()
         .map(|node| {
-            let (status, pid, cpu, memory) = if let Some(metrics) = node.metrics {
+            let (pid, cpu, memory) = if let Some(metrics) = node.metrics {
                 (
-                    "Running".to_string(),
                     metrics.pid.to_string(),
                     format!("{:.1}%", metrics.cpu_usage),
                     format!("{:.0} MB", metrics.memory_mb),
                 )
             } else {
-                // Node exists but no metrics available (might be starting or error state)
-                (
-                    "Unknown".to_string(),
-                    "-".to_string(),
-                    "-".to_string(),
-                    "-".to_string(),
-                )
+                ("-".to_string(), "-".to_string(), "-".to_string())
             };
 
             OutputEntry {
                 node: node.node_id.to_string(),
-                status,
+                status: format_node_health(node.health).to_string(),
                 pid,
                 cpu,
                 memory,
@@ -173,4 +168,31 @@ async fn list(
     }
 
     Ok(())
+}
+
+fn format_node_health(health: NodeHealth) -> &'static str {
+    match health {
+        NodeHealth::Pending => "Pending",
+        NodeHealth::Running => "Running",
+        NodeHealth::Stopping => "Stopping",
+        NodeHealth::Stopped => "Stopped",
+        NodeHealth::Failed => "Failed",
+        NodeHealth::Unknown => "Unknown",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_node_health;
+    use dora_message::coordinator_to_cli::NodeHealth;
+
+    #[test]
+    fn formats_all_node_health_variants() {
+        assert_eq!(format_node_health(NodeHealth::Pending), "Pending");
+        assert_eq!(format_node_health(NodeHealth::Running), "Running");
+        assert_eq!(format_node_health(NodeHealth::Stopping), "Stopping");
+        assert_eq!(format_node_health(NodeHealth::Stopped), "Stopped");
+        assert_eq!(format_node_health(NodeHealth::Failed), "Failed");
+        assert_eq!(format_node_health(NodeHealth::Unknown), "Unknown");
+    }
 }

--- a/binaries/coordinator/Cargo.toml
+++ b/binaries/coordinator/Cargo.toml
@@ -31,3 +31,6 @@ log = { version = "0.4.21", features = ["serde"] }
 dora-message = { workspace = true }
 itertools = "0.14.0"
 dashmap = "6.1.0"
+
+[dev-dependencies]
+serde_yaml = { workspace = true }

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -694,6 +694,8 @@ pub(crate) struct RunningDataflow {
     nodes: BTreeMap<NodeId, ResolvedNode>,
     /// Maps each node to the daemon it's running on
     node_to_daemon: BTreeMap<NodeId, DaemonId>,
+    /// Latest runtime health snapshot for each node (from daemons)
+    node_runtime: BTreeMap<NodeId, dora_message::daemon_to_coordinator::NodeRuntime>,
     /// Latest metrics for each node (from daemons)
     node_metrics: BTreeMap<NodeId, dora_message::daemon_to_coordinator::NodeMetrics>,
 
@@ -1091,6 +1093,7 @@ async fn start_dataflow(
             daemons: daemons.clone(),
             nodes,
             node_to_daemon,
+            node_runtime: BTreeMap::new(),
             node_metrics: BTreeMap::new(),
             spawn_result: CachedResult::default(),
             stop_reply_senders: Vec::new(),

--- a/binaries/coordinator/src/listener.rs
+++ b/binaries/coordinator/src/listener.rs
@@ -7,7 +7,8 @@ use dora_message::{
     common::DaemonId,
     coordinator_to_cli::{DataflowResult, LogLevel, LogMessage, StopDataflowReply},
     daemon_to_coordinator::{
-        CoordinatorNotify, CoordinatorRequest, DataflowDaemonResult, NodeMetrics, Timestamped,
+        CoordinatorNotify, CoordinatorRequest, DataflowDaemonResult, NodeMetrics, NodeRuntime,
+        Timestamped,
     },
     tarpc,
 };
@@ -301,6 +302,28 @@ impl CoordinatorNotify for CoordinatorNotifyServer {
         {
             for (node_id, node_metrics) in metrics {
                 dataflow.node_metrics.insert(node_id, node_metrics);
+            }
+        }
+    }
+
+    async fn node_runtime(
+        self,
+        _ctx: tarpc::context::Context,
+        dataflow_id: Uuid,
+        runtime: BTreeMap<dora_message::id::NodeId, NodeRuntime>,
+    ) {
+        if let Some(mut dataflow) = self
+            .coordinator_state
+            .running_dataflows
+            .get_mut(&dataflow_id)
+        {
+            for (node_id, runtime_state) in runtime {
+                if let Some(metrics) = runtime_state.metrics.clone() {
+                    dataflow.node_metrics.insert(node_id.clone(), metrics);
+                } else {
+                    dataflow.node_metrics.remove(&node_id);
+                }
+                dataflow.node_runtime.insert(node_id, runtime_state);
             }
         }
     }

--- a/binaries/coordinator/src/server.rs
+++ b/binaries/coordinator/src/server.rs
@@ -7,7 +7,8 @@ use dora_message::{
     common::DaemonId,
     coordinator_to_cli::{
         CheckDataflowReply, DataflowIdAndName, DataflowInfo, DataflowList, DataflowListEntry,
-        DataflowResult, DataflowStatus, NodeInfo, NodeMetricsInfo, StopDataflowReply, VersionInfo,
+        DataflowResult, DataflowStatus, NodeHealth, NodeInfo, NodeMetricsInfo, StopDataflowReply,
+        VersionInfo,
     },
     tarpc::context::Context,
 };
@@ -387,17 +388,194 @@ impl CoordinatorControl for CoordinatorControlServer {
                             disk_write_mb_s: m.disk_write_bytes.map(|b| b as f64 / 1000.0 / 1000.0),
                         }
                     });
+                    let health = dataflow
+                        .node_runtime
+                        .get(node_id)
+                        .map(|runtime| runtime.health)
+                        .unwrap_or_else(|| {
+                            if metrics.is_some() {
+                                NodeHealth::Running
+                            } else {
+                                NodeHealth::Unknown
+                            }
+                        });
 
                     node_infos.push(NodeInfo {
                         dataflow_id: dataflow.uuid,
                         dataflow_name: dataflow.name.clone(),
                         node_id: node_id.clone(),
                         daemon_id: daemon_id.clone(),
+                        health,
                         metrics,
                     });
                 }
             }
         }
         Ok(node_infos)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::{BTreeMap, BTreeSet},
+        sync::Arc,
+    };
+
+    use dora_core::{descriptor::DescriptorExt, uhlc::HLC};
+    use dora_message::{
+        cli_to_coordinator::CoordinatorControl,
+        common::DaemonId,
+        coordinator_to_cli::NodeHealth,
+        daemon_to_coordinator::{CoordinatorNotify, NodeMetrics, NodeRuntime},
+        tarpc,
+    };
+    use tokio::sync::mpsc;
+    use uuid::Uuid;
+
+    use crate::{
+        CachedResult, RunningDataflow, listener::CoordinatorNotifyServer, state::CoordinatorState,
+    };
+
+    fn make_state() -> Arc<CoordinatorState> {
+        let (_abortable, abort_handle) =
+            futures::stream::abortable(futures::stream::empty::<crate::Event>());
+        let (daemon_events_tx, _daemon_events_rx) = mpsc::channel(8);
+        Arc::new(CoordinatorState {
+            clock: Arc::new(HLC::default()),
+            running_builds: Default::default(),
+            finished_builds: Default::default(),
+            running_dataflows: Default::default(),
+            dataflow_results: Default::default(),
+            archived_dataflows: Default::default(),
+            daemon_connections: Default::default(),
+            daemon_events_tx,
+            abort_handle,
+        })
+    }
+
+    fn make_running_dataflow(
+        dataflow_id: Uuid,
+        daemon_id: DaemonId,
+    ) -> (RunningDataflow, dora_message::id::NodeId) {
+        let descriptor_yaml = r#"
+nodes:
+  - id: demo-node
+    path: /bin/echo
+"#;
+        let descriptor: dora_message::descriptor::Descriptor =
+            serde_yaml::from_str(descriptor_yaml).expect("failed to parse descriptor yaml");
+        let nodes = descriptor
+            .resolve_aliases_and_set_defaults()
+            .expect("failed to resolve descriptor");
+        let node_id = nodes.keys().next().expect("expected one node").clone();
+
+        let node_to_daemon = BTreeMap::from([(node_id.clone(), daemon_id.clone())]);
+        let daemons = BTreeSet::from([daemon_id.clone()]);
+
+        (
+            RunningDataflow {
+                name: Some("health-test".to_string()),
+                uuid: dataflow_id,
+                descriptor,
+                daemons: daemons.clone(),
+                pending_daemons: BTreeSet::new(),
+                exited_before_subscribe: Vec::new(),
+                nodes,
+                node_to_daemon,
+                node_runtime: BTreeMap::new(),
+                node_metrics: BTreeMap::new(),
+                spawn_result: CachedResult::default(),
+                stop_reply_senders: Vec::new(),
+                buffered_log_messages: Vec::new(),
+                log_subscribers: Vec::new(),
+                pending_spawn_results: daemons,
+            },
+            node_id,
+        )
+    }
+
+    #[tokio::test]
+    async fn get_node_info_reflects_runtime_health_transitions() {
+        let state = make_state();
+        let daemon_id = DaemonId::new(Some("health-daemon".to_string()));
+        let dataflow_id = Uuid::new_v4();
+        let (running_dataflow, node_id) = make_running_dataflow(dataflow_id, daemon_id.clone());
+        state
+            .running_dataflows
+            .insert(dataflow_id, running_dataflow);
+
+        let notify = CoordinatorNotifyServer {
+            daemon_id: daemon_id.clone(),
+            coordinator_state: state.clone(),
+        };
+        let control = super::CoordinatorControlServer {
+            state: state.clone(),
+            client_ip: None,
+        };
+
+        notify
+            .clone()
+            .node_runtime(
+                tarpc::context::current(),
+                dataflow_id,
+                BTreeMap::from([(
+                    node_id.clone(),
+                    NodeRuntime {
+                        health: NodeHealth::Running,
+                        metrics: Some(NodeMetrics {
+                            pid: 42,
+                            cpu_usage: 1.5,
+                            memory_bytes: 1024,
+                            disk_read_bytes: Some(10),
+                            disk_write_bytes: Some(20),
+                        }),
+                    },
+                )]),
+            )
+            .await;
+
+        let infos = control
+            .clone()
+            .get_node_info(tarpc::context::current())
+            .await
+            .expect("get_node_info failed");
+        let running = infos
+            .iter()
+            .find(|i| i.node_id == node_id)
+            .expect("missing node info after running update");
+        assert_eq!(running.health, NodeHealth::Running);
+        assert!(
+            running.metrics.is_some(),
+            "expected metrics for running node"
+        );
+
+        notify
+            .node_runtime(
+                tarpc::context::current(),
+                dataflow_id,
+                BTreeMap::from([(
+                    node_id.clone(),
+                    NodeRuntime {
+                        health: NodeHealth::Failed,
+                        metrics: None,
+                    },
+                )]),
+            )
+            .await;
+
+        let infos = control
+            .get_node_info(tarpc::context::current())
+            .await
+            .expect("get_node_info failed");
+        let failed = infos
+            .iter()
+            .find(|i| i.node_id == node_id)
+            .expect("missing node info after failed update");
+        assert_eq!(failed.health, NodeHealth::Failed);
+        assert!(
+            failed.metrics.is_none(),
+            "expected no metrics for failed node"
+        );
     }
 }

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -544,7 +544,7 @@ impl Daemon {
                     let _ = reply_tx.send(result);
                 }
                 Event::MetricsInterval => {
-                    self.collect_and_send_metrics().await?;
+                    self.collect_and_send_runtime().await?;
                 }
                 Event::CtrlC => {
                     tracing::info!("received ctrlc signal -> stopping all dataflows");
@@ -775,8 +775,9 @@ impl Daemon {
         trigger_result
     }
 
-    async fn collect_and_send_metrics(&mut self) -> eyre::Result<()> {
-        use dora_message::daemon_to_coordinator::NodeMetrics;
+    async fn collect_and_send_runtime(&mut self) -> eyre::Result<()> {
+        use dora_message::coordinator_to_cli::NodeHealth;
+        use dora_message::daemon_to_coordinator::{NodeMetrics, NodeRuntime};
         use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate};
 
         if self.state.coordinator_client().is_none() {
@@ -789,10 +790,10 @@ impl Daemon {
         // Metrics are collected every 2 seconds (metrics_interval)
         const METRICS_INTERVAL_SECS: f64 = 2.0;
 
-        // Collect metrics for all running dataflows
+        // Collect runtime health for all local nodes in running dataflows.
         for entry in self.state.running.iter() {
             let (dataflow_id, dataflow) = (entry.key(), entry.value());
-            let mut metrics = BTreeMap::new();
+            let mut runtime = BTreeMap::new();
 
             // Collect all PIDs for this dataflow
             let pids: Vec<Pid> = dataflow
@@ -817,28 +818,36 @@ impl Daemon {
                     refresh_kind,
                 );
 
-                // Collect metrics for each node
+                // Collect metrics for each running node.
                 for (node_id, running_node) in &dataflow.running_nodes {
                     if let Some(pid) = running_node.pid.as_ref() {
                         let pid = pid.load(atomic::Ordering::Acquire);
                         let sys_pid = Pid::from_u32(pid);
                         if let Some(process) = system.process(sys_pid) {
                             let disk_usage = process.disk_usage();
-                            // Divide by metrics_interval to get per-second averages
-                            metrics.insert(
+                            // Divide by metrics_interval to get per-second averages.
+                            let metrics = NodeMetrics {
+                                pid,
+                                cpu_usage: process.cpu_usage(),
+                                memory_bytes: process.memory(),
+                                disk_read_bytes: Some(
+                                    (disk_usage.read_bytes as f64 / METRICS_INTERVAL_SECS) as u64,
+                                ),
+                                disk_write_bytes: Some(
+                                    (disk_usage.written_bytes as f64 / METRICS_INTERVAL_SECS)
+                                        as u64,
+                                ),
+                            };
+                            let health = if dataflow.stop_sent {
+                                NodeHealth::Stopping
+                            } else {
+                                NodeHealth::Running
+                            };
+                            runtime.insert(
                                 node_id.clone(),
-                                NodeMetrics {
-                                    pid,
-                                    cpu_usage: process.cpu_usage(),
-                                    memory_bytes: process.memory(),
-                                    disk_read_bytes: Some(
-                                        (disk_usage.read_bytes as f64 / METRICS_INTERVAL_SECS)
-                                            as u64,
-                                    ),
-                                    disk_write_bytes: Some(
-                                        (disk_usage.written_bytes as f64 / METRICS_INTERVAL_SECS)
-                                            as u64,
-                                    ),
+                                NodeRuntime {
+                                    health,
+                                    metrics: Some(metrics),
                                 },
                             );
                         }
@@ -846,14 +855,39 @@ impl Daemon {
                 }
             }
 
-            // Send metrics to coordinator if we have any (fire-and-forget).
-            if !metrics.is_empty() {
+            // Add non-running local nodes (pending/stopped/failed) without metrics.
+            let node_results = self
+                .state
+                .dataflow_node_results
+                .get(dataflow_id)
+                .map(|entry| entry.value().clone())
+                .unwrap_or_default();
+
+            for node_id in dataflow.pending_nodes.local_nodes_snapshot() {
+                runtime.entry(node_id).or_insert(NodeRuntime {
+                    health: NodeHealth::Pending,
+                    metrics: None,
+                });
+            }
+
+            for (node_id, node_result) in node_results {
+                runtime.entry(node_id).or_insert_with(|| NodeRuntime {
+                    health: if node_result.is_ok() {
+                        NodeHealth::Stopped
+                    } else {
+                        NodeHealth::Failed
+                    },
+                    metrics: None,
+                });
+            }
+
+            if !runtime.is_empty() {
                 if let Some(client) = self.state.coordinator_client() {
                     let client = client.clone();
                     let dataflow_id = *dataflow_id;
                     tokio::spawn(async move {
                         let _ = client
-                            .node_metrics(tarpc::context::current(), dataflow_id, metrics)
+                            .node_runtime(tarpc::context::current(), dataflow_id, runtime)
                             .await;
                     });
                 }

--- a/binaries/daemon/src/pending.rs
+++ b/binaries/daemon/src/pending.rs
@@ -77,6 +77,10 @@ impl PendingNodes {
         !self.local_nodes.is_empty()
     }
 
+    pub fn local_nodes_snapshot(&self) -> Vec<NodeId> {
+        self.local_nodes.iter().cloned().collect()
+    }
+
     pub async fn handle_node_subscription(
         &mut self,
         node_id: NodeId,

--- a/libraries/message/src/coordinator_to_cli.rs
+++ b/libraries/message/src/coordinator_to_cli.rs
@@ -11,7 +11,18 @@ pub struct NodeInfo {
     pub dataflow_name: Option<String>,
     pub node_id: NodeId,
     pub daemon_id: DaemonId,
+    pub health: NodeHealth,
     pub metrics: Option<NodeMetricsInfo>,
+}
+
+#[derive(Debug, Clone, Copy, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
+pub enum NodeHealth {
+    Pending,
+    Running,
+    Stopping,
+    Stopped,
+    Failed,
+    Unknown,
 }
 
 /// Resource metrics for a node (from daemon)

--- a/libraries/message/src/daemon_to_coordinator.rs
+++ b/libraries/message/src/daemon_to_coordinator.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 pub use crate::common::{
     DataMessage, LogLevel, LogMessage, NodeError, NodeErrorCause, NodeExitStatus, Timestamped,
 };
+use crate::coordinator_to_cli::NodeHealth;
 use crate::{
     BuildId, DataflowId, common::DaemonId, current_crate_version, id::NodeId, versions_compatible,
 };
@@ -79,6 +80,13 @@ pub struct NodeMetrics {
     pub disk_write_bytes: Option<u64>,
 }
 
+/// Runtime health snapshot for a node process.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct NodeRuntime {
+    pub health: NodeHealth,
+    pub metrics: Option<NodeMetrics>,
+}
+
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct DataflowDaemonResult {
     pub timestamp: uhlc::Timestamp,
@@ -110,6 +118,8 @@ pub trait CoordinatorNotify {
     async fn daemon_exit();
     /// Report resource metrics for running nodes.
     async fn node_metrics(dataflow_id: DataflowId, metrics: BTreeMap<NodeId, NodeMetrics>);
+    /// Report runtime health and optional metrics for local nodes.
+    async fn node_runtime(dataflow_id: DataflowId, runtime: BTreeMap<NodeId, NodeRuntime>);
     /// Report that a build has completed (or failed) on this daemon.
     async fn build_result(build_id: BuildId, result: Result<(), String>);
     /// Report that a dataflow spawn has completed (or failed) on this daemon.


### PR DESCRIPTION
## Closes: #1463 

## Problem
  Node health visibility in control-plane APIs is heuristic today (derived from optional metrics). This loses lifecycle semantics and makes failure/recovery diagnosis harder.

  ## Why it matters
  For robust orchestration and diagnostics, especially in distributed and stateful environments, node lifecycle state must be explicit and queryable. Metrics presence alone is not sufficient to
  represent `Pending`, `Stopping`, or `Failed`.

  ## What this PR changes
  - Add `NodeHealth` enum to coordinator-to-CLI model.
  - Extend `NodeInfo` with `health`.
  - Add daemon-to-coordinator runtime payload:
    - `NodeRuntime { health, metrics }`
  - Add new daemon notify RPC:
    - `node_runtime(dataflow_id, runtime_map)`

  ### 2) Daemon runtime reporting
  - Replace metrics-only periodic publish with runtime health snapshots:
    - running nodes report `Running` (or `Stopping` when stop has been initiated)
    - pending local nodes report `Pending`
    - completed node results report `Stopped` or `Failed`
  - Runtime payload includes optional metrics when available.

  ### 3) Coordinator state + ingestion
  - Add `node_runtime` map on running dataflow state.
  - Ingest `node_runtime` notifications and keep metrics map synchronized.
  - Keep legacy `node_metrics` handler for compatibility.

  ### 4) Coordinator API behavior
  - `get_node_info` now returns explicit health from coordinator runtime state.
  - Fallback logic remains (`Running` if metrics-only legacy path, else `Unknown`).

  ### 5) CLI behavior
  - `dora node list` now renders status from `NodeHealth` directly.
  - Removes metrics-presence status heuristic.
  - Adds unit test covering all health label mappings.

  ### 6) Tests
  - Added coordinator test for transition correctness:
    - `get_node_info_reflects_runtime_health_transitions`
    - validates notify path (`node_runtime`) -> state update -> API response
    - asserts `Running -> Failed` and metrics presence semantics

  ## Design notes / tradeoffs
  - Kept `node_metrics` RPC to avoid breaking older producers.
  - New `node_runtime` becomes preferred path for health correctness.
  - Full process-level network integration test was not kept due sandbox socket restrictions; replaced with control-plane integration-style test inside coordinator crate.

  ## Validation
  - `cargo fmt --all`
  - `cargo check -p dora-message -p dora-daemon -p dora-coordinator -p dora-cli`
  - `cargo test -p dora-cli formats_all_node_health_variants`
  - `cargo test -p dora-coordinator get_node_info_reflects_runtime_health_transitions`

  - [x] Formatting applied
  - [x] Tests added/updated
  - [x] No unrelated functional changes included