### PR TITLE
fix(coordinator): fail pending build/spawn waits when daemon disconnects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1599,6 +1599,7 @@ dependencies = [
  "log",
  "petname",
  "serde_json",
+ "serde_yaml 0.9.34+deprecated",
  "tokio",
  "tokio-stream",
  "tracing",

--- a/binaries/coordinator/Cargo.toml
+++ b/binaries/coordinator/Cargo.toml
@@ -31,3 +31,6 @@ log = { version = "0.4.21", features = ["serde"] }
 dora-message = { workspace = true }
 itertools = "0.14.0"
 dashmap = "6.1.0"
+
+[dev-dependencies]
+serde_yaml = { workspace = true }

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -548,6 +548,11 @@ async fn start_inner(
                     tracing::error!("Disconnecting daemons that failed watchdog: {disconnected:?}");
                     for machine_id in disconnected {
                         coordinator_state.daemon_connections.remove(&machine_id);
+                        handle_daemon_disconnect(
+                            &coordinator_state,
+                            &machine_id,
+                            "watchdog timeout (no heartbeat)",
+                        );
                     }
                 }
             }
@@ -662,6 +667,43 @@ async fn handle_destroy(
 
     let _ = coordinator_state.daemon_events_tx.send(Event::Close).await;
     result
+}
+
+pub(crate) fn handle_daemon_disconnect(
+    coordinator_state: &state::CoordinatorState,
+    daemon_id: &DaemonId,
+    reason: &str,
+) {
+    // Fail pending builds that were waiting for this daemon.
+    let mut builds_to_fail = Vec::new();
+    for mut entry in coordinator_state.running_builds.iter_mut() {
+        if entry.pending_build_results.remove(daemon_id) {
+            entry.errors.push(format!(
+                "daemon `{daemon_id}` disconnected while building: {reason}"
+            ));
+            builds_to_fail.push(entry.key().clone());
+        }
+    }
+    for build_id in builds_to_fail {
+        if let Some((build_id, mut build)) = coordinator_state.running_builds.remove(&build_id) {
+            let result = Err(format!("build failed: {}", build.errors.join("\n\n")));
+            build
+                .build_result
+                .set_result(Ok(BuildFinishedResult { build_id, result }));
+            coordinator_state
+                .finished_builds
+                .insert(build_id, build.build_result);
+        }
+    }
+
+    // Fail pending spawn requests that were waiting for this daemon.
+    for mut dataflow in coordinator_state.running_dataflows.iter_mut() {
+        if dataflow.pending_spawn_results.remove(daemon_id) {
+            dataflow.spawn_result.set_result(Err(eyre!(
+                "daemon `{daemon_id}` disconnected while waiting for spawn result: {reason}"
+            )));
+        }
+    }
 }
 
 /// Result of a completed dataflow build.

--- a/binaries/coordinator/src/listener.rs
+++ b/binaries/coordinator/src/listener.rs
@@ -286,6 +286,11 @@ impl CoordinatorNotify for CoordinatorNotifyServer {
         self.coordinator_state
             .daemon_connections
             .remove(&self.daemon_id);
+        crate::handle_daemon_disconnect(
+            &self.coordinator_state,
+            &self.daemon_id,
+            "daemon exit notification",
+        );
     }
 
     async fn node_metrics(

--- a/binaries/coordinator/src/server.rs
+++ b/binaries/coordinator/src/server.rs
@@ -401,3 +401,140 @@ impl CoordinatorControl for CoordinatorControlServer {
         Ok(node_infos)
     }
 }
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::{BTreeMap, BTreeSet},
+        sync::Arc,
+    };
+
+    use dora_core::{descriptor::DescriptorExt, uhlc::HLC};
+    use dora_message::{BuildId, common::DaemonId};
+    use tokio::sync::{mpsc, oneshot};
+    use uuid::Uuid;
+
+    use crate::{CachedResult, RunningBuild, RunningDataflow, state::CoordinatorState};
+
+    fn make_state() -> Arc<CoordinatorState> {
+        let (_abortable, abort_handle) =
+            futures::stream::abortable(futures::stream::empty::<crate::Event>());
+        let (daemon_events_tx, _daemon_events_rx) = mpsc::channel(8);
+        Arc::new(CoordinatorState {
+            clock: Arc::new(HLC::default()),
+            running_builds: Default::default(),
+            finished_builds: Default::default(),
+            running_dataflows: Default::default(),
+            dataflow_results: Default::default(),
+            archived_dataflows: Default::default(),
+            daemon_connections: Default::default(),
+            daemon_events_tx,
+            abort_handle,
+        })
+    }
+
+    fn make_running_dataflow(
+        dataflow_id: Uuid,
+        daemon_id: DaemonId,
+    ) -> (RunningDataflow, dora_message::id::NodeId) {
+        let descriptor_yaml = r#"
+nodes:
+  - id: demo-node
+    path: /bin/echo
+"#;
+        let descriptor: dora_message::descriptor::Descriptor =
+            serde_yaml::from_str(descriptor_yaml).expect("failed to parse descriptor yaml");
+        let nodes = descriptor
+            .resolve_aliases_and_set_defaults()
+            .expect("failed to resolve descriptor");
+        let node_id = nodes.keys().next().expect("expected one node").clone();
+
+        let node_to_daemon = BTreeMap::from([(node_id.clone(), daemon_id.clone())]);
+        let daemons = BTreeSet::from([daemon_id.clone()]);
+
+        (
+            RunningDataflow {
+                name: Some("disconnect-test".to_string()),
+                uuid: dataflow_id,
+                descriptor,
+                daemons: daemons.clone(),
+                pending_daemons: BTreeSet::new(),
+                exited_before_subscribe: Vec::new(),
+                nodes,
+                node_to_daemon,
+                node_metrics: BTreeMap::new(),
+                spawn_result: CachedResult::default(),
+                stop_reply_senders: Vec::new(),
+                buffered_log_messages: Vec::new(),
+                log_subscribers: Vec::new(),
+                pending_spawn_results: daemons,
+            },
+            node_id,
+        )
+    }
+
+    #[tokio::test]
+    async fn daemon_disconnect_fails_pending_waiters_immediately() {
+        let state = make_state();
+        let daemon_id = DaemonId::new(Some("timeout-daemon".to_string()));
+
+        let build_id = BuildId::generate();
+        state.running_builds.insert(
+            build_id,
+            RunningBuild {
+                errors: Vec::new(),
+                build_result: CachedResult::default(),
+                buffered_log_messages: Vec::new(),
+                log_subscribers: Vec::new(),
+                pending_build_results: BTreeSet::from([daemon_id.clone()]),
+            },
+        );
+
+        let dataflow_id = Uuid::new_v4();
+        let (running_dataflow, _node_id) = make_running_dataflow(dataflow_id, daemon_id.clone());
+        state.running_dataflows.insert(dataflow_id, running_dataflow);
+
+        let (build_tx, build_rx) = oneshot::channel();
+        state
+            .running_builds
+            .get_mut(&build_id)
+            .expect("missing running build")
+            .build_result
+            .register(build_tx);
+
+        let (spawn_tx, spawn_rx) = oneshot::channel();
+        state
+            .running_dataflows
+            .get_mut(&dataflow_id)
+            .expect("missing running dataflow")
+            .spawn_result
+            .register(spawn_tx);
+
+        crate::handle_daemon_disconnect(&state, &daemon_id, "watchdog timeout");
+
+        let build_result = build_rx.await.expect("build waiter dropped unexpectedly");
+        let build_finished = build_result.expect("build waiter should receive cached result");
+        let err = build_finished
+            .result
+            .expect_err("build should fail after daemon disconnect");
+        assert!(
+            err.contains("timeout-daemon"),
+            "expected daemon id in build error, got: {err}"
+        );
+
+        let spawn_result = spawn_rx.await.expect("spawn waiter dropped unexpectedly");
+        let spawn_err = spawn_result.expect_err("spawn should fail after daemon disconnect");
+        assert!(
+            spawn_err.to_string().contains("timeout-daemon"),
+            "expected daemon id in spawn error, got: {spawn_err}"
+        );
+
+        assert!(
+            state.running_builds.get(&build_id).is_none(),
+            "running build should be moved to finished cache"
+        );
+        assert!(
+            state.finished_builds.get(&build_id).is_some(),
+            "finished build cache should contain failed build result"
+        );
+    }
+}

--- a/binaries/coordinator/src/server.rs
+++ b/binaries/coordinator/src/server.rs
@@ -491,7 +491,9 @@ nodes:
 
         let dataflow_id = Uuid::new_v4();
         let (running_dataflow, _node_id) = make_running_dataflow(dataflow_id, daemon_id.clone());
-        state.running_dataflows.insert(dataflow_id, running_dataflow);
+        state
+            .running_dataflows
+            .insert(dataflow_id, running_dataflow);
 
         let (build_tx, build_rx) = oneshot::channel();
         state

--- a/examples/python-async/dataflow.yaml
+++ b/examples/python-async/dataflow.yaml
@@ -1,6 +1,6 @@
 nodes:
   - id: send_data
-    build: pip install numpy pyarrow
+    build: pip install pyarrow
     path: ./send_data.py
     inputs:
       tick: dora/timer/millis/10

--- a/examples/python-async/send_data.py
+++ b/examples/python-async/send_data.py
@@ -2,7 +2,6 @@
 
 import time
 
-import numpy as np
 import pyarrow as pa
 from dora import Node
 
@@ -15,4 +14,4 @@ for event in node:
     else:
         i += 1
     now = time.perf_counter_ns()
-    node.send_output("data", pa.array([np.uint64(now)]))
+    node.send_output("data", pa.array([now], type=pa.uint64()))


### PR DESCRIPTION
## Closes: #1465 
## Problem

  The coordinator watchdog currently removes dead daemon connections, but pending lifecycle waits can remain unresolved:

  - `wait_for_build` can stay blocked when a build was waiting for a disconnected daemon.
  - `wait_for_spawn` can stay blocked when spawn acknowledgements are pending from a disconnected daemon.

  This creates long hangs (up to client RPC deadline) instead of fast, deterministic failure.

  ## Why It Matters

  This is a daemon ↔ coordinator state-consistency issue.
  Once a daemon is known disconnected, lifecycle operations that depend on it are no longer satisfiable and should fail immediately. Fast failure improves operator feedback, retry logic, and
  distributed robustness.

  ## What This PR Changes

  ### 1) Centralized disconnect handling in coordinator
  - Added `handle_daemon_disconnect(...)` to coordinator core logic.
  - On disconnect, it:
    - removes the daemon from pending build result sets,
    - records a structured build error reason,
    - finalizes affected builds as failed and moves them to `finished_builds`,
    - removes the daemon from pending spawn result sets,
    - fails affected spawn waiters immediately.

  ### 2) Wired into watchdog timeout path
  - In `Event::DaemonHeartbeatInterval`, when a daemon is dropped for missing heartbeat, coordinator now also triggers pending lifecycle failure propagation (not just connection removal).

  ### 3) Wired into daemon-exit notification path
  - In `CoordinatorNotify::daemon_exit`, after removing the connection, coordinator now triggers the same failure propagation logic.

  ### 4) Regression test
  Added coordinator regression test:
  - `daemon_disconnect_fails_pending_waiters_immediately`

  The test validates:
  - pending `build_result` waiters resolve promptly with an error,
  - pending `spawn_result` waiters resolve promptly with an error,
  - build state transitions from `running_builds` to `finished_builds`.

  ## Scope / Tradeoffs

  - No protocol/API shape changes.
  - No behavior change for healthy daemon flows.
  - Focused on correctness under failure paths only.

  ## Files Changed

  - `binaries/coordinator/src/lib.rs`
  - `binaries/coordinator/src/listener.rs`
  - `binaries/coordinator/src/server.rs`
  - `binaries/coordinator/Cargo.toml` (test dependency)
  - `Cargo.lock`

  ## Validation

  - [x] `cargo fmt --all`
  - [x] `cargo check -p dora-coordinator`
  - [x] `cargo test -p dora-coordinator daemon_disconnect_fails_pending_waiters_immediately -- --nocapture`
