### PR TITLE
refactor(cli): introduce shared package metadata model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1576,6 +1576,7 @@ dependencies = [
  "termcolor",
  "tokio",
  "tokio-stream",
+ "toml",
  "tracing",
  "tracing-log",
  "uuid",
@@ -4672,7 +4673,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.5+spec-1.1.0",
 ]
 
 [[package]]
@@ -5828,6 +5829,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6648,6 +6658,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.0.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6658,14 +6689,28 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime",
+ "toml_datetime 1.0.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -6674,8 +6719,14 @@ version = "1.0.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
 dependencies = [
- "winnow",
+ "winnow 1.0.0",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
@@ -7889,6 +7940,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -35,6 +35,7 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_yaml = { workspace = true }
 webbrowser = "0.8.3"
 serde_json = "1.0.86"
+toml = "0.8.19"
 termcolor = "1.1.3"
 uuid = { version = "1.7", features = ["v7", "serde"] }
 inquire = "0.5.2"

--- a/binaries/cli/src/dora_toml.rs
+++ b/binaries/cli/src/dora_toml.rs
@@ -1,0 +1,199 @@
+use crate::package_metadata::{
+    DependencyRequirement, PackageDefinition, PackageIdentity, parse_version, parse_version_req,
+    validate_entrypoint, validate_name,
+};
+use eyre::{Context, bail};
+use std::{collections::BTreeMap, path::Path};
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawDoraToml {
+    pub package: RawPackageMetadata,
+    #[serde(default)]
+    pub dependencies: BTreeMap<String, RawDependencySpec>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawPackageMetadata {
+    pub name: String,
+    pub version: String,
+    pub entrypoint: String,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawDependencySpec {
+    pub version: Option<String>,
+    pub path: Option<String>,
+    pub git: Option<String>,
+    pub rev: Option<String>,
+}
+
+pub fn read_and_normalize(path: &Path) -> eyre::Result<PackageDefinition> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read metadata file `{}`", path.display()))?;
+    let metadata: RawDoraToml = toml::from_str(&raw)
+        .with_context(|| format!("failed to parse metadata file `{}`", path.display()))?;
+    normalize(metadata)
+}
+
+pub fn normalize(metadata: RawDoraToml) -> eyre::Result<PackageDefinition> {
+    validate_name(&metadata.package.name, "package.name")?;
+    let version = parse_version(&metadata.package.version, "package.version")?;
+    validate_entrypoint(&metadata.package.entrypoint, "package.entrypoint")?;
+
+    let dependencies = metadata
+        .dependencies
+        .into_iter()
+        .map(|(name, spec)| {
+            validate_name(&name, "dependency key")?;
+            let requirement = normalize_dependency_spec(&name, spec)?;
+            Ok((name, requirement))
+        })
+        .collect::<eyre::Result<BTreeMap<_, _>>>()?;
+
+    Ok(PackageDefinition {
+        identity: PackageIdentity {
+            name: metadata.package.name,
+            version,
+        },
+        entrypoint: metadata.package.entrypoint,
+        description: metadata.package.description,
+        dependencies,
+    })
+}
+
+fn normalize_dependency_spec(
+    name: &str,
+    spec: RawDependencySpec,
+) -> eyre::Result<DependencyRequirement> {
+    let mut source_count = 0;
+    if spec.version.is_some() {
+        source_count += 1;
+    }
+    if spec.path.is_some() {
+        source_count += 1;
+    }
+    if spec.git.is_some() {
+        source_count += 1;
+    }
+    if source_count == 0 {
+        bail!("dependency `{name}` must specify one source via `version`, `path`, or `git`");
+    }
+    if source_count > 1 {
+        bail!(
+            "dependency `{name}` must not mix sources; choose exactly one of `version`, `path`, or `git`"
+        );
+    }
+
+    if let Some(version) = spec.version {
+        return Ok(DependencyRequirement::Version {
+            requirement: parse_version_req(&version, &format!("dependency `{name}` version"))?,
+        });
+    }
+
+    if let Some(path) = spec.path {
+        if path.trim().is_empty() {
+            bail!("dependency `{name}` has an empty `path`");
+        }
+        if spec.rev.is_some() {
+            bail!("dependency `{name}` sets `rev` but does not set `git`");
+        }
+        return Ok(DependencyRequirement::Path { path });
+    }
+
+    if let Some(git) = spec.git {
+        if git.trim().is_empty() {
+            bail!("dependency `{name}` has an empty `git` URL");
+        }
+        return Ok(DependencyRequirement::Git {
+            repo: git,
+            rev: spec.rev,
+        });
+    }
+
+    bail!("dependency `{name}` must specify one source");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_metadata_normalizes() {
+        let metadata: RawDoraToml = toml::from_str(
+            r#"
+[package]
+name = "camera_node"
+version = "0.1.0"
+entrypoint = "python -m camera_node"
+description = "A camera node"
+
+[dependencies]
+yolo = { version = "^1.2.0" }
+math = { path = "../math-node" }
+vision = { git = "https://github.com/example/vision-node.git", rev = "main" }
+"#,
+        )
+        .unwrap();
+
+        let normalized = normalize(metadata).unwrap();
+        assert_eq!(normalized.identity.name, "camera_node");
+        assert_eq!(normalized.identity.version.to_string(), "0.1.0");
+        assert_eq!(normalized.description.as_deref(), Some("A camera node"));
+    }
+
+    #[test]
+    fn invalid_package_version_fails() {
+        let metadata: RawDoraToml = toml::from_str(
+            r#"
+[package]
+name = "camera_node"
+version = "abc"
+entrypoint = "python -m camera_node"
+"#,
+        )
+        .unwrap();
+
+        let err = normalize(metadata).unwrap_err().to_string();
+        assert!(err.contains("not valid semver"));
+    }
+
+    #[test]
+    fn dependency_with_rev_without_git_fails() {
+        let metadata: RawDoraToml = toml::from_str(
+            r#"
+[package]
+name = "camera_node"
+version = "0.1.0"
+entrypoint = "python -m camera_node"
+
+[dependencies]
+vision = { rev = "main", path = "../vision" }
+"#,
+        )
+        .unwrap();
+
+        let err = normalize(metadata).unwrap_err().to_string();
+        assert!(err.contains("sets `rev` but does not set `git`"));
+    }
+
+    #[test]
+    fn package_with_invalid_name_fails() {
+        let metadata: RawDoraToml = toml::from_str(
+            r#"
+[package]
+name = "bad name"
+version = "0.1.0"
+entrypoint = "python -m camera_node"
+"#,
+        )
+        .unwrap();
+
+        let err = normalize(metadata).unwrap_err().to_string();
+        assert!(err.contains("invalid characters"));
+    }
+}

--- a/binaries/cli/src/lib.rs
+++ b/binaries/cli/src/lib.rs
@@ -6,8 +6,11 @@ use std::{
 
 mod command;
 mod common;
+mod dora_toml;
 mod formatting;
 pub mod output;
+mod package_metadata;
+mod registry;
 pub mod session;
 mod template;
 

--- a/binaries/cli/src/package_metadata.rs
+++ b/binaries/cli/src/package_metadata.rs
@@ -1,0 +1,71 @@
+use eyre::{Context, bail};
+use semver::{Version, VersionReq};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackageIdentity {
+    pub name: String,
+    pub version: Version,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackageDefinition {
+    pub identity: PackageIdentity,
+    pub entrypoint: String,
+    pub description: Option<String>,
+    pub dependencies: BTreeMap<String, DependencyRequirement>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DependencyRequirement {
+    Version { requirement: VersionReq },
+    Path { path: String },
+    Git { repo: String, rev: Option<String> },
+}
+
+pub fn validate_name(name: &str, field: &str) -> eyre::Result<()> {
+    if name.is_empty() {
+        bail!("{field} must not be empty");
+    }
+    let valid = name
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_');
+    if !valid {
+        bail!("{field} `{name}` contains invalid characters (allowed: a-z, A-Z, 0-9, -, _)");
+    }
+    Ok(())
+}
+
+pub fn parse_version(raw: &str, field: &str) -> eyre::Result<Version> {
+    Version::parse(raw).with_context(|| format!("{field} `{raw}` is not valid semver"))
+}
+
+pub fn parse_version_req(raw: &str, field: &str) -> eyre::Result<VersionReq> {
+    VersionReq::parse(raw).with_context(|| format!("{field} `{raw}` is not valid semver"))
+}
+
+pub fn validate_entrypoint(entrypoint: &str, field: &str) -> eyre::Result<()> {
+    if entrypoint.trim().is_empty() {
+        bail!("{field} must not be empty");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_invalid_name() {
+        let err = validate_name("bad name", "package.name")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("invalid characters"));
+    }
+
+    #[test]
+    fn parses_valid_version_requirement() {
+        let req = parse_version_req("^1.2.3", "dependency.version").unwrap();
+        assert!(req.matches(&Version::parse("1.5.0").unwrap()));
+    }
+}

--- a/binaries/cli/src/registry.rs
+++ b/binaries/cli/src/registry.rs
@@ -1,0 +1,231 @@
+use crate::package_metadata::{
+    DependencyRequirement, PackageDefinition, PackageIdentity, parse_version, parse_version_req,
+    validate_entrypoint, validate_name,
+};
+use eyre::{Context, bail};
+use semver::VersionReq;
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
+
+const REGISTRY_INDEX_VERSION: u32 = 1;
+
+#[derive(Debug, Clone)]
+pub struct RegistryIndex {
+    pub version: u32,
+    pub packages: Vec<RegistryPackageRecord>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RegistryPackageRecord {
+    pub package: PackageDefinition,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawRegistryIndex {
+    pub version: u32,
+    #[serde(default)]
+    pub packages: Vec<RawRegistryPackage>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawRegistryPackage {
+    pub name: String,
+    pub version: String,
+    pub entrypoint: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub dependencies: BTreeMap<String, RawRegistryDependency>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RawRegistryDependency {
+    pub version: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct RegistrySource {
+    pub index_path: PathBuf,
+}
+
+impl RegistrySource {
+    pub fn from_path(path: &Path) -> Self {
+        let index_path = match path.extension().and_then(|ext| ext.to_str()) {
+            Some("toml") => path.to_owned(),
+            _ => path.join("index.toml"),
+        };
+        Self { index_path }
+    }
+
+    pub fn read_index(&self) -> eyre::Result<RegistryIndex> {
+        let raw = std::fs::read_to_string(&self.index_path).with_context(|| {
+            format!(
+                "failed to read registry index at `{}`",
+                self.index_path.display()
+            )
+        })?;
+        let index: RawRegistryIndex = toml::from_str(&raw).with_context(|| {
+            format!(
+                "failed to parse registry index at `{}`",
+                self.index_path.display()
+            )
+        })?;
+        normalize_index(index)
+    }
+}
+
+pub fn normalize_index(index: RawRegistryIndex) -> eyre::Result<RegistryIndex> {
+    if index.version != REGISTRY_INDEX_VERSION {
+        bail!(
+            "unsupported registry index version `{}` (expected `{}`)",
+            index.version,
+            REGISTRY_INDEX_VERSION
+        );
+    }
+
+    let packages = index
+        .packages
+        .into_iter()
+        .map(normalize_package)
+        .collect::<eyre::Result<Vec<_>>>()?;
+
+    Ok(RegistryIndex {
+        version: index.version,
+        packages,
+    })
+}
+
+pub fn resolve_package<'a>(
+    index: &'a RegistryIndex,
+    name: &str,
+    requirement: Option<&str>,
+) -> eyre::Result<Option<&'a RegistryPackageRecord>> {
+    let version_req = match requirement {
+        Some(req) => Some(
+            VersionReq::parse(req)
+                .with_context(|| format!("invalid version requirement `{req}`"))?,
+        ),
+        None => None,
+    };
+
+    let mut matching = index
+        .packages
+        .iter()
+        .filter(|pkg| pkg.package.identity.name == name)
+        .collect::<Vec<_>>();
+
+    if let Some(version_req) = version_req {
+        matching.retain(|pkg| version_req.matches(&pkg.package.identity.version));
+    }
+
+    matching.sort_by(|a, b| b.package.identity.version.cmp(&a.package.identity.version));
+    Ok(matching.into_iter().next())
+}
+
+fn normalize_package(pkg: RawRegistryPackage) -> eyre::Result<RegistryPackageRecord> {
+    validate_name(&pkg.name, "package.name")?;
+    let version = parse_version(&pkg.version, "package.version")?;
+    validate_entrypoint(&pkg.entrypoint, "package.entrypoint")?;
+
+    let dependencies = pkg
+        .dependencies
+        .into_iter()
+        .map(|(dep_name, dep_spec)| {
+            validate_name(&dep_name, "dependency key")?;
+            Ok((
+                dep_name,
+                DependencyRequirement::Version {
+                    requirement: parse_version_req(
+                        &dep_spec.version,
+                        "registry dependency version",
+                    )?,
+                },
+            ))
+        })
+        .collect::<eyre::Result<BTreeMap<_, _>>>()?;
+
+    Ok(RegistryPackageRecord {
+        package: PackageDefinition {
+            identity: PackageIdentity {
+                name: pkg.name,
+                version,
+            },
+            entrypoint: pkg.entrypoint,
+            description: pkg.description,
+            dependencies,
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_latest_matching_version() {
+        let index: RawRegistryIndex = toml::from_str(
+            r#"
+version = 1
+
+[[packages]]
+name = "camera_node"
+version = "0.1.0"
+entrypoint = "python -m camera_node"
+
+[[packages]]
+name = "camera_node"
+version = "0.2.0"
+entrypoint = "python -m camera_node"
+"#,
+        )
+        .unwrap();
+
+        let normalized = normalize_index(index).unwrap();
+        let resolved = resolve_package(&normalized, "camera_node", Some(">=0.1.0,<1.0.0"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(resolved.package.identity.version.to_string(), "0.2.0");
+    }
+
+    #[test]
+    fn resolves_none_when_no_match() {
+        let index: RawRegistryIndex = toml::from_str(
+            r#"
+version = 1
+
+[[packages]]
+name = "camera_node"
+version = "0.1.0"
+entrypoint = "python -m camera_node"
+"#,
+        )
+        .unwrap();
+
+        let normalized = normalize_index(index).unwrap();
+        let resolved = resolve_package(&normalized, "camera_node", Some(">=1.0.0")).unwrap();
+        assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn invalid_entrypoint_fails_validation() {
+        let index: RawRegistryIndex = toml::from_str(
+            r#"
+version = 1
+
+[[packages]]
+name = "camera_node"
+version = "0.1.0"
+entrypoint = "   "
+"#,
+        )
+        .unwrap();
+
+        let err = normalize_index(index).unwrap_err().to_string();
+        assert!(err.contains("must not be empty"));
+    }
+}


### PR DESCRIPTION
## Problem

`Dora.toml` metadata and registry metadata describe the same package semantics but are evolving independently.

If these paths define and validate package data independently, they can drift quickly as Project [#2](https://github.com/dora-rs/dora/wiki/GSoC_2026) grows. That would make later resolver, install, publish, and lockfile work harder to align.

## Related context
This PR is aligned with the same package-management direction being explored in:
- [#1451](https://github.com/dora-rs/dora/pull/1451) — Dora.toml metadata validation  
- [#1453](https://github.com/dora-rs/dora/pull/1453) — local registry index reader / inspect flow

## What this PR changes

This PR introduces a shared package metadata model inside the CLI crate and makes both manifest and registry parsing normalize into it. This PR is intentionally scoped to the shared semantic layer and does not introduce new CLI surface.

### Added
- a shared validated package model in `binaries/cli/src/package_metadata.rs`
- shared helpers for:
  - package/dependency name validation
  - semver parsing
  - entrypoint validation

### Refactored
- `binaries/cli/src/dora_toml.rs`
  - keeps raw `Dora.toml` parsing separate
  - normalizes manifest metadata into the shared package model

- `binaries/cli/src/registry.rs`
  - keeps raw registry index parsing separate
  - normalizes registry package records into the same shared package model

## Why this matters

This establishes a clean architectural foundation:
- Raw structs → file-oriented  
- Shared model → semantic-oriented  
- later layers like resolver, lockfile, install, and publish can build on one package model instead of multiple ad hoc ones

This prevents schema drift and ensures that future layers (resolver, lockfile, install, publish) operate on a single consistent package representation.


## Design

Inspired by Cargo’s separation of concerns:
- parsing remains format-specific  
- validation is centralized  
- normalized package model is shared  

Resolver and higher-level workflows are intentionally deferred.

## Validation

```bash
cargo fmt --all --check
cargo check -p dora-cli
cargo test -p dora-cli package_metadata
cargo test -p dora-cli dora_toml
cargo test -p dora-cli registry
cargo clippy -p dora-cli --all-targets
