### PR TITLE
fix(coordinator): reconcile running dataflows on daemon disconnect

### DIFF
--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -15,7 +15,7 @@ use dora_message::{
         CoordinatorControlResponse,
     },
     common::{DaemonId, NodeError, NodeErrorCause, NodeExitStatus},
-    coordinator_to_cli::{DataflowResult, LogMessage, StopDataflowReply},
+    coordinator_to_cli::{DataflowResult, StopDataflowReply},
     coordinator_to_daemon::{
         BuildDataflowNodes, DaemonControlClient, DaemonControlRequest, DaemonControlResponse,
         RegisterResult, Timestamped,
@@ -524,21 +524,6 @@ async fn start_inner(
     tracing::info!("stopped");
 
     Ok(())
-}
-
-pub(crate) async fn send_log_message(
-    log_subscribers: &mut Vec<LogSubscriber>,
-    message: &LogMessage,
-) {
-    for subscriber in log_subscribers.iter_mut() {
-        let send_result =
-            tokio::time::timeout(Duration::from_millis(100), subscriber.send_message(message));
-
-        if send_result.await.is_err() {
-            subscriber.close();
-        }
-    }
-    log_subscribers.retain(|s| !s.is_closed());
 }
 
 pub(crate) async fn handle_daemon_disconnect(
@@ -1309,8 +1294,6 @@ mod tests {
                 node_metrics: BTreeMap::new(),
                 spawn_result: CachedResult::default(),
                 stop_reply_senders: vec![stop_tx],
-                buffered_log_messages: Vec::new(),
-                log_subscribers: Vec::new(),
                 pending_spawn_results: [daemon_id.clone()].into_iter().collect(),
             },
         );

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -14,8 +14,8 @@ use dora_message::{
         BuildRequest, CoordinatorControl, CoordinatorControlClient, CoordinatorControlRequest,
         CoordinatorControlResponse,
     },
-    common::DaemonId,
-    coordinator_to_cli::{DataflowResult, StopDataflowReply},
+    common::{DaemonId, NodeError, NodeErrorCause, NodeExitStatus},
+    coordinator_to_cli::{DataflowResult, LogMessage, StopDataflowReply},
     coordinator_to_daemon::{
         BuildDataflowNodes, DaemonControlClient, DaemonControlRequest, DaemonControlResponse,
         RegisterResult, Timestamped,
@@ -501,7 +501,7 @@ async fn start_inner(
                     tracing::error!("Disconnecting daemons that failed watchdog: {disconnected:?}");
                     for machine_id in disconnected {
                         coordinator_state.daemon_connections.remove(&machine_id);
-                        handle_daemon_disconnect(&coordinator_state, &machine_id);
+                        handle_daemon_disconnect(&coordinator_state, &machine_id).await;
                     }
                 }
             }
@@ -541,11 +541,11 @@ pub(crate) async fn send_log_message(
     log_subscribers.retain(|s| !s.is_closed());
 }
 
-pub(crate) fn handle_daemon_disconnect(
+pub(crate) async fn handle_daemon_disconnect(
     coordinator_state: &state::CoordinatorState,
     daemon_id: &DaemonId,
 ) {
-    let mut dataflows_to_finalize = Vec::new();
+    let mut affected_dataflows = Vec::new();
     for mut dataflow in coordinator_state.running_dataflows.iter_mut() {
         let removed = dataflow.daemons.remove(daemon_id);
         if !removed {
@@ -560,12 +560,68 @@ pub(crate) fn handle_daemon_disconnect(
             dataflow.uuid
         );
 
-        if dataflow.daemons.is_empty() {
-            dataflows_to_finalize.push(dataflow.uuid);
-        }
+        let error = eyre!(
+            "daemon `{daemon_id}` disconnected while dataflow `{}` was active",
+            dataflow.uuid
+        );
+        dataflow.spawn_result.set_result(Err(error));
+
+        let failed_nodes: BTreeMap<NodeId, Result<(), NodeError>> = dataflow
+            .node_to_daemon
+            .iter()
+            .filter(|(_, assigned_daemon)| *assigned_daemon == daemon_id)
+            .map(|(node_id, _)| {
+                let node_error = NodeError {
+                    timestamp: coordinator_state.clock.new_timestamp(),
+                    cause: NodeErrorCause::Other {
+                        stderr: format!("daemon `{daemon_id}` disconnected"),
+                    },
+                    exit_status: NodeExitStatus::Unknown,
+                };
+                (node_id.clone(), Err(node_error))
+            })
+            .collect();
+        coordinator_state
+            .dataflow_results
+            .entry(dataflow.uuid)
+            .or_default()
+            .insert(
+                daemon_id.clone(),
+                DataflowDaemonResult {
+                    timestamp: coordinator_state.clock.new_timestamp(),
+                    node_results: failed_nodes,
+                },
+            );
+
+        let remaining_daemons = dataflow.daemons.iter().cloned().collect::<Vec<_>>();
+        affected_dataflows.push((dataflow.uuid, remaining_daemons));
     }
 
-    for dataflow_id in dataflows_to_finalize {
+    for (dataflow_id, remaining_daemons) in affected_dataflows {
+        for remaining_daemon in remaining_daemons {
+            let Some(connection) = coordinator_state.daemon_connections.get(&remaining_daemon)
+            else {
+                tracing::warn!(
+                    "failed to stop dataflow `{dataflow_id}` on daemon `{remaining_daemon}` after disconnect: no daemon connection"
+                );
+                continue;
+            };
+            let client = connection.client.clone();
+            drop(connection);
+            match client
+                .stop_dataflow(tarpc::context::current(), dataflow_id, None, false)
+                .await
+            {
+                Err(err) => tracing::warn!(
+                    "failed to stop dataflow `{dataflow_id}` on daemon `{remaining_daemon}` after disconnect: {err}"
+                ),
+                Ok(Err(err)) => tracing::warn!(
+                    "daemon `{remaining_daemon}` reported stop_dataflow error for `{dataflow_id}` after disconnect: {err}"
+                ),
+                Ok(Ok(())) => {}
+            }
+        }
+
         let Some((_, mut finished_dataflow)) =
             coordinator_state.running_dataflows.remove(&dataflow_id)
         else {
@@ -592,9 +648,7 @@ pub(crate) fn handle_daemon_disconnect(
             let _ = sender.send(Ok(reply.clone()));
         }
 
-        tracing::warn!(
-            "finalized dataflow `{dataflow_id}` after daemon disconnect because no daemons remained"
-        );
+        tracing::warn!("failed active dataflow `{dataflow_id}` after daemon disconnect");
     }
 }
 pub(crate) fn dataflow_result(
@@ -1220,10 +1274,11 @@ mod tests {
         }
     }
 
-    #[test]
-    fn daemon_disconnect_removes_daemon_and_finalizes_dataflow_when_last_daemon_drops() {
+    #[tokio::test]
+    async fn daemon_disconnect_fails_dataflow_when_last_daemon_drops() {
         let daemon_id = dora_message::common::DaemonId::new(Some("machine-1".into()));
         let dataflow_id = Uuid::new_v4();
+        let node_id = dora_core::config::NodeId::from("node-a".to_owned());
 
         let (abort_handle, _registration) = futures::stream::AbortHandle::new_pair();
         let (daemon_events_tx, _daemon_events_rx) = mpsc::channel(1);
@@ -1250,7 +1305,7 @@ mod tests {
                 pending_daemons: [daemon_id.clone()].into_iter().collect(),
                 exited_before_subscribe: Vec::new(),
                 nodes: BTreeMap::new(),
-                node_to_daemon: BTreeMap::new(),
+                node_to_daemon: BTreeMap::from([(node_id.clone(), daemon_id.clone())]),
                 node_metrics: BTreeMap::new(),
                 spawn_result: CachedResult::default(),
                 stop_reply_senders: vec![stop_tx],
@@ -1260,7 +1315,7 @@ mod tests {
             },
         );
 
-        handle_daemon_disconnect(&coordinator_state, &daemon_id);
+        handle_daemon_disconnect(&coordinator_state, &daemon_id).await;
 
         assert!(
             coordinator_state
@@ -1278,14 +1333,14 @@ mod tests {
         );
 
         let stop_reply = stop_rx
-            .blocking_recv()
+            .await
             .expect("stop waiter should be resolved")
             .expect("stop waiter should get success reply");
         assert_eq!(stop_reply.uuid, dataflow_id);
         assert_eq!(stop_reply.result.uuid, dataflow_id);
         assert!(
-            stop_reply.result.node_results.is_empty(),
-            "finalized dataflow without daemon results should be empty"
+            !stop_reply.result.node_results.is_empty(),
+            "daemon disconnect should mark at least one node as failed"
         );
     }
 }

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -501,6 +501,7 @@ async fn start_inner(
                     tracing::error!("Disconnecting daemons that failed watchdog: {disconnected:?}");
                     for machine_id in disconnected {
                         coordinator_state.daemon_connections.remove(&machine_id);
+                        handle_daemon_disconnect(&coordinator_state, &machine_id);
                     }
                 }
             }
@@ -525,6 +526,77 @@ async fn start_inner(
     Ok(())
 }
 
+pub(crate) async fn send_log_message(
+    log_subscribers: &mut Vec<LogSubscriber>,
+    message: &LogMessage,
+) {
+    for subscriber in log_subscribers.iter_mut() {
+        let send_result =
+            tokio::time::timeout(Duration::from_millis(100), subscriber.send_message(message));
+
+        if send_result.await.is_err() {
+            subscriber.close();
+        }
+    }
+    log_subscribers.retain(|s| !s.is_closed());
+}
+
+pub(crate) fn handle_daemon_disconnect(
+    coordinator_state: &state::CoordinatorState,
+    daemon_id: &DaemonId,
+) {
+    let mut dataflows_to_finalize = Vec::new();
+    for mut dataflow in coordinator_state.running_dataflows.iter_mut() {
+        let removed = dataflow.daemons.remove(daemon_id);
+        if !removed {
+            continue;
+        }
+
+        dataflow.pending_daemons.remove(daemon_id);
+        dataflow.pending_spawn_results.remove(daemon_id);
+
+        tracing::info!(
+            "removed disconnected daemon `{daemon_id}` from running dataflow `{}`",
+            dataflow.uuid
+        );
+
+        if dataflow.daemons.is_empty() {
+            dataflows_to_finalize.push(dataflow.uuid);
+        }
+    }
+
+    for dataflow_id in dataflows_to_finalize {
+        let Some((_, mut finished_dataflow)) =
+            coordinator_state.running_dataflows.remove(&dataflow_id)
+        else {
+            continue;
+        };
+
+        coordinator_state
+            .archived_dataflows
+            .entry(dataflow_id)
+            .or_insert_with(|| ArchivedDataflow::from(&finished_dataflow));
+
+        let reply = StopDataflowReply {
+            uuid: dataflow_id,
+            result: coordinator_state
+                .dataflow_results
+                .get(&dataflow_id)
+                .map(|r| dataflow_result(r.value(), dataflow_id, &coordinator_state.clock))
+                .unwrap_or_else(|| {
+                    DataflowResult::ok_empty(dataflow_id, coordinator_state.clock.new_timestamp())
+                }),
+        };
+
+        for sender in finished_dataflow.stop_reply_senders.drain(..) {
+            let _ = sender.send(Ok(reply.clone()));
+        }
+
+        tracing::warn!(
+            "finalized dataflow `{dataflow_id}` after daemon disconnect because no daemons remained"
+        );
+    }
+}
 pub(crate) fn dataflow_result(
     results: &BTreeMap<DaemonId, DataflowDaemonResult>,
     dataflow_uuid: Uuid,
@@ -1123,4 +1195,97 @@ fn set_up_ctrlc_handler() -> Result<impl Stream<Item = Event>, eyre::ErrReport> 
     .wrap_err("failed to set ctrl-c handler")?;
 
     Ok(ReceiverStream::new(ctrlc_rx))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CachedResult, DaemonConnections, RunningDataflow, handle_daemon_disconnect, state,
+    };
+    use dora_message::{
+        config::CommunicationConfig,
+        descriptor::{Debug, Descriptor},
+    };
+    use std::{collections::BTreeMap, sync::Arc};
+    use tokio::sync::{mpsc, oneshot};
+    use uuid::Uuid;
+
+    fn test_descriptor() -> Descriptor {
+        Descriptor {
+            nodes: Vec::new(),
+            env: None,
+            communication: CommunicationConfig::default(),
+            deploy: None,
+            debug: Debug::default(),
+        }
+    }
+
+    #[test]
+    fn daemon_disconnect_removes_daemon_and_finalizes_dataflow_when_last_daemon_drops() {
+        let daemon_id = dora_message::common::DaemonId::new(Some("machine-1".into()));
+        let dataflow_id = Uuid::new_v4();
+
+        let (abort_handle, _registration) = futures::stream::AbortHandle::new_pair();
+        let (daemon_events_tx, _daemon_events_rx) = mpsc::channel(1);
+        let coordinator_state = state::CoordinatorState {
+            clock: Arc::new(dora_core::uhlc::HLC::default()),
+            running_builds: Default::default(),
+            finished_builds: Default::default(),
+            running_dataflows: Default::default(),
+            dataflow_results: Default::default(),
+            archived_dataflows: Default::default(),
+            daemon_connections: DaemonConnections::default(),
+            daemon_events_tx,
+            abort_handle,
+        };
+
+        let (stop_tx, stop_rx) = oneshot::channel();
+        coordinator_state.running_dataflows.insert(
+            dataflow_id,
+            RunningDataflow {
+                name: Some("disconnect-test".into()),
+                uuid: dataflow_id,
+                descriptor: test_descriptor(),
+                daemons: [daemon_id.clone()].into_iter().collect(),
+                pending_daemons: [daemon_id.clone()].into_iter().collect(),
+                exited_before_subscribe: Vec::new(),
+                nodes: BTreeMap::new(),
+                node_to_daemon: BTreeMap::new(),
+                node_metrics: BTreeMap::new(),
+                spawn_result: CachedResult::default(),
+                stop_reply_senders: vec![stop_tx],
+                buffered_log_messages: Vec::new(),
+                log_subscribers: Vec::new(),
+                pending_spawn_results: [daemon_id.clone()].into_iter().collect(),
+            },
+        );
+
+        handle_daemon_disconnect(&coordinator_state, &daemon_id);
+
+        assert!(
+            coordinator_state
+                .running_dataflows
+                .get(&dataflow_id)
+                .is_none(),
+            "dataflow should be removed from running map when last daemon disconnects"
+        );
+        assert!(
+            coordinator_state
+                .archived_dataflows
+                .get(&dataflow_id)
+                .is_some(),
+            "dataflow should be archived after finalization"
+        );
+
+        let stop_reply = stop_rx
+            .blocking_recv()
+            .expect("stop waiter should be resolved")
+            .expect("stop waiter should get success reply");
+        assert_eq!(stop_reply.uuid, dataflow_id);
+        assert_eq!(stop_reply.result.uuid, dataflow_id);
+        assert!(
+            stop_reply.result.node_results.is_empty(),
+            "finalized dataflow without daemon results should be empty"
+        );
+    }
 }

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -531,6 +531,7 @@ pub(crate) async fn handle_daemon_disconnect(
     daemon_id: &DaemonId,
 ) {
     let mut affected_dataflows = Vec::new();
+    let mut dataflows_to_finalize = Vec::new();
     for mut dataflow in coordinator_state.running_dataflows.iter_mut() {
         let removed = dataflow.daemons.remove(daemon_id);
         if !removed {
@@ -551,11 +552,16 @@ pub(crate) async fn handle_daemon_disconnect(
         );
         dataflow.spawn_result.set_result(Err(error));
 
-        let failed_nodes: BTreeMap<NodeId, Result<(), NodeError>> = dataflow
+        let failed_nodes: Vec<NodeId> = dataflow
             .node_to_daemon
             .iter()
             .filter(|(_, assigned_daemon)| *assigned_daemon == daemon_id)
-            .map(|(node_id, _)| {
+            .map(|(node_id, _)| node_id.clone())
+            .collect();
+
+        let failed_node_results: BTreeMap<NodeId, Result<(), NodeError>> = failed_nodes
+            .iter()
+            .map(|node_id| {
                 let node_error = NodeError {
                     timestamp: coordinator_state.clock.new_timestamp(),
                     cause: NodeErrorCause::Other {
@@ -566,74 +572,86 @@ pub(crate) async fn handle_daemon_disconnect(
                 (node_id.clone(), Err(node_error))
             })
             .collect();
-        coordinator_state
-            .dataflow_results
-            .entry(dataflow.uuid)
-            .or_default()
-            .insert(
-                daemon_id.clone(),
-                DataflowDaemonResult {
-                    timestamp: coordinator_state.clock.new_timestamp(),
-                    node_results: failed_nodes,
-                },
-            );
+
+        if !failed_node_results.is_empty() {
+            coordinator_state
+                .dataflow_results
+                .entry(dataflow.uuid)
+                .or_default()
+                .insert(
+                    daemon_id.clone(),
+                    DataflowDaemonResult {
+                        timestamp: coordinator_state.clock.new_timestamp(),
+                        node_results: failed_node_results,
+                    },
+                );
+        }
 
         let remaining_daemons = dataflow.daemons.iter().cloned().collect::<Vec<_>>();
-        affected_dataflows.push((dataflow.uuid, remaining_daemons));
+        affected_dataflows.push((dataflow.uuid, remaining_daemons, failed_nodes));
+        if dataflow.daemons.is_empty() {
+            dataflows_to_finalize.push(dataflow.uuid);
+        }
     }
 
-    for (dataflow_id, remaining_daemons) in affected_dataflows {
+    // Notify surviving daemons so they can emit local NodeFailed events for impacted inputs.
+    for (dataflow_id, remaining_daemons, failed_nodes) in affected_dataflows {
         for remaining_daemon in remaining_daemons {
             let Some(connection) = coordinator_state.daemon_connections.get(&remaining_daemon)
             else {
                 tracing::warn!(
-                    "failed to stop dataflow `{dataflow_id}` on daemon `{remaining_daemon}` after disconnect: no daemon connection"
+                    "failed to notify daemon `{remaining_daemon}` about disconnect in dataflow `{dataflow_id}`: no daemon connection"
                 );
                 continue;
             };
             let client = connection.client.clone();
             drop(connection);
-            match client
-                .stop_dataflow(tarpc::context::current(), dataflow_id, None, false)
+            if let Err(err) = client
+                .daemon_disconnected(
+                    tarpc::context::current(),
+                    dataflow_id,
+                    daemon_id.clone(),
+                    failed_nodes.clone(),
+                )
                 .await
             {
-                Err(err) => tracing::warn!(
-                    "failed to stop dataflow `{dataflow_id}` on daemon `{remaining_daemon}` after disconnect: {err}"
-                ),
-                Ok(Err(err)) => tracing::warn!(
-                    "daemon `{remaining_daemon}` reported stop_dataflow error for `{dataflow_id}` after disconnect: {err}"
-                ),
-                Ok(Ok(())) => {}
+                tracing::warn!(
+                    "failed to notify daemon `{remaining_daemon}` about disconnect in dataflow `{dataflow_id}`: {err}"
+                );
             }
         }
+    }
 
-        let Some((_, mut finished_dataflow)) =
-            coordinator_state.running_dataflows.remove(&dataflow_id)
-        else {
-            continue;
-        };
+    for dataflow_id in dataflows_to_finalize {
+        finalize_dataflow(coordinator_state, dataflow_id);
+    }
+}
 
-        coordinator_state
-            .archived_dataflows
-            .entry(dataflow_id)
-            .or_insert_with(|| ArchivedDataflow::from(&finished_dataflow));
+pub(crate) fn finalize_dataflow(coordinator_state: &state::CoordinatorState, dataflow_id: Uuid) {
+    let Some((_, mut finished_dataflow)) = coordinator_state.running_dataflows.remove(&dataflow_id)
+    else {
+        return;
+    };
 
-        let reply = StopDataflowReply {
-            uuid: dataflow_id,
-            result: coordinator_state
-                .dataflow_results
-                .get(&dataflow_id)
-                .map(|r| dataflow_result(r.value(), dataflow_id, &coordinator_state.clock))
-                .unwrap_or_else(|| {
-                    DataflowResult::ok_empty(dataflow_id, coordinator_state.clock.new_timestamp())
-                }),
-        };
+    coordinator_state
+        .archived_dataflows
+        .entry(dataflow_id)
+        .or_insert_with(|| ArchivedDataflow::from(&finished_dataflow));
 
-        for sender in finished_dataflow.stop_reply_senders.drain(..) {
-            let _ = sender.send(Ok(reply.clone()));
-        }
-
-        tracing::warn!("failed active dataflow `{dataflow_id}` after daemon disconnect");
+    let clock = &coordinator_state.clock;
+    let reply = StopDataflowReply {
+        uuid: dataflow_id,
+        result: coordinator_state
+            .dataflow_results
+            .get(&dataflow_id)
+            .map(|r| dataflow_result(r.value(), dataflow_id, clock))
+            .unwrap_or_else(|| DataflowResult::ok_empty(dataflow_id, clock.new_timestamp())),
+    };
+    for sender in finished_dataflow.stop_reply_senders.drain(..) {
+        let _ = sender.send(Ok(reply.clone()));
+    }
+    if !matches!(finished_dataflow.spawn_result, CachedResult::Cached { .. }) {
+        log::error!("pending spawn result on dataflow finish");
     }
 }
 pub(crate) fn dataflow_result(
@@ -1234,96 +1252,4 @@ fn set_up_ctrlc_handler() -> Result<impl Stream<Item = Event>, eyre::ErrReport> 
     .wrap_err("failed to set ctrl-c handler")?;
 
     Ok(ReceiverStream::new(ctrlc_rx))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{
-        CachedResult, DaemonConnections, RunningDataflow, handle_daemon_disconnect, state,
-    };
-    use dora_message::{
-        config::CommunicationConfig,
-        descriptor::{Debug, Descriptor},
-    };
-    use std::{collections::BTreeMap, sync::Arc};
-    use tokio::sync::{mpsc, oneshot};
-    use uuid::Uuid;
-
-    fn test_descriptor() -> Descriptor {
-        Descriptor {
-            nodes: Vec::new(),
-            env: None,
-            communication: CommunicationConfig::default(),
-            deploy: None,
-            debug: Debug::default(),
-        }
-    }
-
-    #[tokio::test]
-    async fn daemon_disconnect_fails_dataflow_when_last_daemon_drops() {
-        let daemon_id = dora_message::common::DaemonId::new(Some("machine-1".into()));
-        let dataflow_id = Uuid::new_v4();
-        let node_id = dora_core::config::NodeId::from("node-a".to_owned());
-
-        let (abort_handle, _registration) = futures::stream::AbortHandle::new_pair();
-        let (daemon_events_tx, _daemon_events_rx) = mpsc::channel(1);
-        let coordinator_state = state::CoordinatorState {
-            clock: Arc::new(dora_core::uhlc::HLC::default()),
-            running_builds: Default::default(),
-            finished_builds: Default::default(),
-            running_dataflows: Default::default(),
-            dataflow_results: Default::default(),
-            archived_dataflows: Default::default(),
-            daemon_connections: DaemonConnections::default(),
-            daemon_events_tx,
-            abort_handle,
-        };
-
-        let (stop_tx, stop_rx) = oneshot::channel();
-        coordinator_state.running_dataflows.insert(
-            dataflow_id,
-            RunningDataflow {
-                name: Some("disconnect-test".into()),
-                uuid: dataflow_id,
-                descriptor: test_descriptor(),
-                daemons: [daemon_id.clone()].into_iter().collect(),
-                pending_daemons: [daemon_id.clone()].into_iter().collect(),
-                exited_before_subscribe: Vec::new(),
-                nodes: BTreeMap::new(),
-                node_to_daemon: BTreeMap::from([(node_id.clone(), daemon_id.clone())]),
-                node_metrics: BTreeMap::new(),
-                spawn_result: CachedResult::default(),
-                stop_reply_senders: vec![stop_tx],
-                pending_spawn_results: [daemon_id.clone()].into_iter().collect(),
-            },
-        );
-
-        handle_daemon_disconnect(&coordinator_state, &daemon_id).await;
-
-        assert!(
-            coordinator_state
-                .running_dataflows
-                .get(&dataflow_id)
-                .is_none(),
-            "dataflow should be removed from running map when last daemon disconnects"
-        );
-        assert!(
-            coordinator_state
-                .archived_dataflows
-                .get(&dataflow_id)
-                .is_some(),
-            "dataflow should be archived after finalization"
-        );
-
-        let stop_reply = stop_rx
-            .await
-            .expect("stop waiter should be resolved")
-            .expect("stop waiter should get success reply");
-        assert_eq!(stop_reply.uuid, dataflow_id);
-        assert_eq!(stop_reply.result.uuid, dataflow_id);
-        assert!(
-            !stop_reply.result.node_results.is_empty(),
-            "daemon disconnect should mark at least one node as failed"
-        );
-    }
 }

--- a/binaries/coordinator/src/listener.rs
+++ b/binaries/coordinator/src/listener.rs
@@ -236,7 +236,7 @@ impl CoordinatorNotify for CoordinatorNotifyServer {
         self.coordinator_state
             .daemon_connections
             .remove(&self.daemon_id);
-        handle_daemon_disconnect(&self.coordinator_state, &self.daemon_id);
+        handle_daemon_disconnect(&self.coordinator_state, &self.daemon_id).await;
     }
 
     async fn node_metrics(

--- a/binaries/coordinator/src/listener.rs
+++ b/binaries/coordinator/src/listener.rs
@@ -1,11 +1,10 @@
 use crate::{
-    ArchivedDataflow, BuildFinishedResult, CachedResult, DaemonRequest, Event, dataflow_result,
-    handle_daemon_disconnect, state, tcp_utils::tcp_receive,
+    BuildFinishedResult, DaemonRequest, Event, finalize_dataflow, handle_daemon_disconnect, state,
+    tcp_utils::tcp_receive,
 };
 use dora_core::uhlc::HLC;
 use dora_message::{
     common::DaemonId,
-    coordinator_to_cli::{DataflowResult, StopDataflowReply},
     daemon_to_coordinator::{
         CoordinatorNotify, CoordinatorRequest, DataflowDaemonResult, NodeMetrics, Timestamped,
     },
@@ -175,44 +174,23 @@ impl CoordinatorNotify for CoordinatorNotifyServer {
         );
         match self.coordinator_state.running_dataflows.entry(dataflow_id) {
             dashmap::Entry::Occupied(mut entry) => {
-                let dataflow = entry.get_mut();
-                dataflow.daemons.remove(&daemon_id);
-                tracing::info!(
-                    "removed machine id: {daemon_id} from dataflow: {:#?}",
-                    dataflow.uuid
-                );
-                self.coordinator_state
-                    .dataflow_results
-                    .entry(dataflow_id)
-                    .or_default()
-                    .insert(daemon_id, result);
-
-                if dataflow.daemons.is_empty() {
-                    // Archive finished dataflow
+                let should_finalize = {
+                    let dataflow = entry.get_mut();
+                    dataflow.daemons.remove(&daemon_id);
+                    tracing::info!(
+                        "removed machine id: {daemon_id} from dataflow: {:#?}",
+                        dataflow.uuid
+                    );
                     self.coordinator_state
-                        .archived_dataflows
+                        .dataflow_results
                         .entry(dataflow_id)
-                        .or_insert_with(|| ArchivedDataflow::from(entry.get()));
-                    let finished_dataflow = entry.remove();
-                    let clock = &self.coordinator_state.clock;
-
-                    let reply = StopDataflowReply {
-                        uuid: dataflow_id,
-                        result: self
-                            .coordinator_state
-                            .dataflow_results
-                            .get(&dataflow_id)
-                            .map(|r| dataflow_result(r.value(), dataflow_id, clock))
-                            .unwrap_or_else(|| {
-                                DataflowResult::ok_empty(dataflow_id, clock.new_timestamp())
-                            }),
-                    };
-                    for sender in finished_dataflow.stop_reply_senders {
-                        let _ = sender.send(Ok(reply.clone()));
-                    }
-                    if !matches!(finished_dataflow.spawn_result, CachedResult::Cached { .. }) {
-                        log::error!("pending spawn result on dataflow finish");
-                    }
+                        .or_default()
+                        .insert(daemon_id, result);
+                    dataflow.daemons.is_empty()
+                };
+                if should_finalize {
+                    drop(entry);
+                    finalize_dataflow(&self.coordinator_state, dataflow_id);
                 }
             }
             dashmap::Entry::Vacant(_) => {

--- a/binaries/coordinator/src/listener.rs
+++ b/binaries/coordinator/src/listener.rs
@@ -1,6 +1,6 @@
 use crate::{
     ArchivedDataflow, BuildFinishedResult, CachedResult, DaemonRequest, Event, dataflow_result,
-    state, tcp_utils::tcp_receive,
+    handle_daemon_disconnect, state, tcp_utils::tcp_receive,
 };
 use dora_core::uhlc::HLC;
 use dora_message::{
@@ -236,6 +236,7 @@ impl CoordinatorNotify for CoordinatorNotifyServer {
         self.coordinator_state
             .daemon_connections
             .remove(&self.daemon_id);
+        handle_daemon_disconnect(&self.coordinator_state, &self.daemon_id);
     }
 
     async fn node_metrics(

--- a/binaries/daemon/src/coordinator.rs
+++ b/binaries/daemon/src/coordinator.rs
@@ -322,6 +322,34 @@ impl DaemonControl for DaemonControlServer {
         }
     }
 
+    async fn daemon_disconnected(
+        self,
+        _ctx: tarpc::context::Context,
+        dataflow_id: DataflowId,
+        disconnected_daemon_id: DaemonId,
+        failed_nodes: Vec<NodeId>,
+    ) {
+        let Some(mut dataflow) = self.state.running.get_mut(&dataflow_id) else {
+            tracing::warn!(
+                "received daemon_disconnected for unknown dataflow `{dataflow_id}` (daemon `{disconnected_daemon_id}`)"
+            );
+            return;
+        };
+
+        let error_message = format!("daemon `{disconnected_daemon_id}` disconnected");
+        for source_node_id in failed_nodes {
+            // Deduplicate in case multiple notifications reference the same failed node.
+            if dataflow.handled_node_failed.insert(source_node_id.clone()) {
+                let (_outputs, _remote_receivers) = crate::Daemon::find_and_notify_local_receivers(
+                    &mut dataflow,
+                    &source_node_id,
+                    &error_message,
+                    &self.state.clock,
+                );
+            }
+        }
+    }
+
     async fn stop_dataflow(
         self,
         _ctx: tarpc::context::Context,

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1653,7 +1653,7 @@ impl Daemon {
     /// Find all receivers affected by a node failure and send NodeFailed events to local ones.
     ///
     /// Returns the list of outputs and a set of remote receiver node IDs (nodes not on this daemon).
-    fn find_and_notify_local_receivers(
+    pub(crate) fn find_and_notify_local_receivers(
         dataflow: &mut RunningDataflow,
         source_node_id: &NodeId,
         error_message: &str,

--- a/libraries/message/src/coordinator_to_daemon.rs
+++ b/libraries/message/src/coordinator_to_daemon.rs
@@ -86,6 +86,14 @@ pub trait DaemonControl {
     async fn spawn(request: SpawnDataflowNodes) -> DaemonResult<()>;
     /// Notify the daemon that all nodes across all daemons are ready.
     async fn all_nodes_ready(dataflow_id: DataflowId, exited_before_subscribe: Vec<NodeId>);
+    /// Notify the daemon that one peer daemon disconnected while this dataflow was active.
+    ///
+    /// `failed_nodes` contains node IDs that were running on the disconnected daemon.
+    async fn daemon_disconnected(
+        dataflow_id: DataflowId,
+        disconnected_daemon_id: DaemonId,
+        failed_nodes: Vec<NodeId>,
+    );
     /// Stop a running dataflow on this daemon.
     async fn stop_dataflow(
         dataflow_id: DataflowId,


### PR DESCRIPTION
Closes: #1476

  ## Problem

  When a daemon disconnects/crashes, coordinator state can become inconsistent with runtime reality:

  - disconnected daemon membership may remain in `running_dataflows`
  - pending sets can become stale (`pending_daemons`, `pending_spawn_results`)
  - failure impact on nodes running on the disconnected machine is not propagated to remaining daemons

  ## Why It Matters

  A daemon disconnect is a failure scenario, not a normal completion path.
  Coordinator and daemon behavior should converge on a consistent failure model without special stop simulation logic.

  ## What This PR Changes

  ### 1) Reconcile coordinator membership state on daemon disconnect

  In `handle_daemon_disconnect(...)`, for each affected running dataflow:

  - remove disconnected daemon from `daemons`
  - remove disconnected daemon from `pending_daemons`
  - remove disconnected daemon from `pending_spawn_results`
  - mark spawn waiters as failed for the affected dataflow (`spawn_result` error)

  ### 2) Record failed nodes for disconnected daemon in coordinator results

  For nodes assigned to the disconnected daemon (`node_to_daemon` mapping), coordinator records `NodeError` results in `dataflow_results` so final dataflow result reflects the failure.

  ### 3) New coordinator → daemon notification RPC for disconnect impact

  Added new daemon control RPC:

  - `daemon_disconnected(dataflow_id, disconnected_daemon_id, failed_nodes)`

  Coordinator calls this on remaining daemons of the affected dataflow.

  ### 4) Daemon-side failure propagation via existing local NodeFailed path

  On receiving `daemon_disconnected(...)`, daemon:

  - maps `failed_nodes` to local affected receivers
  - emits local `NodeFailed` propagation using existing receiver-notification logic

  This follows the maintainer-requested flow: treat disconnected-daemon nodes as failed and propagate via daemon/node failure semantics (instead of coordinator-side stop simulation).

  ### 5) Shared finalization logic, no duplicated finish path logic

  Introduced shared `finalize_dataflow(...)` helper in coordinator and reused it where needed (`all_nodes_finished` and disconnect path when no daemons remain), reducing duplication.

  ### 6) Removed previous disconnect test

  Per review feedback, removed the prior test that validated the old behavior.

  ## Files Changed

  - `binaries/coordinator/src/lib.rs`
  - `binaries/coordinator/src/listener.rs`
  - `binaries/daemon/src/coordinator.rs`
  - `binaries/daemon/src/lib.rs`
  - `libraries/message/src/coordinator_to_daemon.rs`

  ## Validation

  - [x] `cargo fmt --all`
  - [x] `cargo check -p dora-message -p dora-coordinator -p dora-daemon`
  - [x] `cargo test -p dora-coordinator --lib -- --nocapture`
  - [x] `cargo test -p dora-message --lib -- --nocapture`
  - [x] `cargo test -p dora-daemon --lib -- --nocapture`

  No unrelated functional changes were made.