### PR TITLE
fix(daemon): improve error messages for node spawn failures

### DIFF
--- a/binaries/daemon/src/spawn/command.rs
+++ b/binaries/daemon/src/spawn/command.rs
@@ -39,8 +39,18 @@ pub(super) async fn path_spawn_command(
                     .wrap_err("failed to download custom node")?
             } else {
                 let source = shellexpand::env(source)?;
-                resolve_path(source.as_ref(), working_dir)
-                    .wrap_err_with(|| format!("failed to resolve node source `{source}`"))?
+                resolve_path(source.as_ref(), working_dir).wrap_err_with(|| {
+                    if let Some(build_cmd) = &node.build {
+                        format!(
+                            "failed to resolve node source `{source}`\n  \
+                                Hint: this node defines a `build` command:\n    \
+                                {build_cmd}\n  \
+                                Did you forget to run `dora build <dataflow.yml>` first?"
+                        )
+                    } else {
+                        format!("failed to resolve node source `{source}`")
+                    }
+                })?
             };
 
             // If extension is .py, use python to run the script

--- a/binaries/daemon/src/spawn/spawner.rs
+++ b/binaries/daemon/src/spawn/spawner.rs
@@ -254,8 +254,16 @@ impl Spawner {
                         ]);
                         Some(cmd)
                     } else {
-                        let mut cmd =
-                            Command::new(which::which("dora").wrap_err("failed to get dora path")?);
+                        let dora_path = which::which("dora").wrap_err(
+                            "failed to find the `dora` binary in PATH.\n  \
+                            \n  \
+                            Hint: install it with:\n    \
+                            cargo install dora-cli\n  \
+                            \n  \
+                            Or if you built from source, add the build output to your PATH:\n    \
+                            export PATH=\"$PWD/target/debug:$PATH\"",
+                        )?;
+                        let mut cmd = Command::new(dora_path);
                         cmd = cmd.arg("runtime");
                         Some(cmd)
                     }


### PR DESCRIPTION
Closes #1486 

When a node binary is missing or [dora](cci:1://file:///Users/fayekelmith/Kelmith/Projects/dora/binaries/daemon/src/lib.rs:2300:4-2528:5) itself can't be found in PATH,
the previous error messages gave no hint on how to fix the situation.

This PR adds actionable hints to both failure paths:

- If a node's binary is missing **and** the node defines a [build](cci:1://file:///Users/fayekelmith/Kelmith/Projects/dora/binaries/daemon/src/lib.rs:985:4-1077:5) command,
  the error now suggests running `dora build <dataflow.yml>` first.
- If the [dora](cci:1://file:///Users/fayekelmith/Kelmith/Projects/dora/binaries/daemon/src/lib.rs:2300:4-2528:5) binary can't be found in PATH (needed to spawn runtime nodes
  with Rust operators), the error now tells you to install it via
  `cargo install dora-cli` or add your build output to PATH.

Both of these are things I hit as a new contributor getting familiar with
the project. The changes are purely in error messaging — no functional logic
is touched.



@phil-opp @haixuanTao can you review please?