### PR TITLE
fix(cli): remove redundant sysinfo import in completion command

### DIFF
--- a/binaries/cli/src/command/completion.rs
+++ b/binaries/cli/src/command/completion.rs
@@ -2,7 +2,6 @@ use clap::{CommandFactory, ValueEnum};
 use clap_complete::Shell;
 
 use crate::command::Executable;
-use sysinfo;
 
 #[derive(Debug, clap::Args)]
 #[command(after_help = r#"


### PR DESCRIPTION
## Summary

Removes a redundant bare `use sysinfo;` import from the completion 
command.

Fixes #1411

## Problem

`completion.rs` had `use sysinfo;` on line 4, but `sysinfo` is 
already referenced via full paths (`sysinfo::get_current_pid()`, 
`sysinfo::System::new_all()`) throughout the file. The bare import 
is unnecessary.

## Changes

- `binaries/cli/src/command/completion.rs` — removed `use sysinfo;`