### PR TITLE
feat(cli): add `dora record` and `dora play` commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1533,6 +1533,7 @@ dependencies = [
 name = "dora-cli"
 version = "0.4.1"
 dependencies = [
+ "aligned-vec",
  "arrow",
  "arrow-json",
  "arrow-schema",

--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -21,6 +21,7 @@ tracing = ["dep:dora-tracing"]
 python = ["pyo3"]
 
 [dependencies]
+aligned-vec = "0.5.0"
 arrow = { workspace = true }
 arrow-schema = { workspace = true }
 clap = { version = "4.0.3", features = ["derive", "string"] }

--- a/binaries/cli/src/command/mod.rs
+++ b/binaries/cli/src/command/mod.rs
@@ -9,6 +9,8 @@ mod list;
 mod logs;
 mod new;
 mod node;
+mod play;
+mod record;
 mod run;
 mod runtime;
 mod self_;
@@ -34,6 +36,8 @@ use list::ListArgs;
 use logs::LogsArgs;
 use new::NewArgs;
 use node::Node;
+use play::Play;
+use record::Record;
 use runtime::Runtime;
 use self_::SelfSubCommand;
 use start::Start;
@@ -77,6 +81,8 @@ pub enum Command {
     Topic(Topic),
     #[clap(subcommand)]
     Node(Node),
+    Record(Record),
+    Play(Play),
 
     Version(Version),
 
@@ -126,6 +132,8 @@ impl Executable for Command {
             Command::Runtime(args) => args.execute().await,
             Command::Topic(args) => args.execute().await,
             Command::Node(args) => args.execute().await,
+            Command::Record(args) => args.execute().await,
+            Command::Play(args) => args.execute().await,
             Command::Version(args) => args.execute().await,
             Command::Completion(args) => args.execute().await,
         }

--- a/binaries/cli/src/command/play.rs
+++ b/binaries/cli/src/command/play.rs
@@ -18,10 +18,7 @@ use tokio::time::{Duration, sleep};
 use uuid::Uuid;
 
 use crate::{
-    command::{
-        Executable, default_tracing,
-        topic::selector::DataflowSelector,
-    },
+    command::{Executable, default_tracing, topic::selector::DataflowSelector},
     common::CoordinatorOptions,
 };
 
@@ -100,8 +97,7 @@ async fn play(
     let file_handle = std::fs::File::open(&file)
         .with_context(|| format!("failed to open recording file: {}", file.display()))?;
 
-    let reader = FileReader::try_new(file_handle, None)
-        .context("failed to open Arrow IPC file")?;
+    let reader = FileReader::try_new(file_handle, None).context("failed to open Arrow IPC file")?;
 
     // Validate schema
     validate_schema(&reader)?;
@@ -144,7 +140,8 @@ async fn play(
     println!(" ok");
 
     // Read all batches into memory for potential looping
-    let batches = reader.collect::<Result<Vec<_>, _>>()
+    let batches = reader
+        .collect::<Result<Vec<_>, _>>()
         .context("failed to read batches from recording")?;
 
     if batches.is_empty() {
@@ -173,7 +170,14 @@ async fn play(
 
 fn validate_schema(reader: &FileReader<std::fs::File>) -> eyre::Result<()> {
     let schema = reader.schema();
-    let expected_fields = ["timestamp_us", "node_id", "output_id", "data", "type_info", "metadata"];
+    let expected_fields = [
+        "timestamp_us",
+        "node_id",
+        "output_id",
+        "data",
+        "type_info",
+        "metadata",
+    ];
 
     for field_name in expected_fields {
         if schema.field_with_name(field_name).is_err() {
@@ -205,7 +209,9 @@ async fn play_batches(
 
         for i in 0..batch.num_rows() {
             let timestamp_us = timestamp_array.value(i);
-            let node_id: NodeId = node_id_array.value(i).parse()
+            let node_id: NodeId = node_id_array
+                .value(i)
+                .parse()
                 .context("failed to parse node_id")?;
             let output_id = DataId::from(output_id_array.value(i));
             let data = if data_array.is_null(i) {
@@ -217,10 +223,10 @@ async fn play_batches(
             let metadata_json = metadata_array.value(i);
 
             // Deserialize type_info and metadata
-            let type_info: ArrowTypeInfo = serde_json::from_str(type_info_json)
-                .context("failed to deserialize type_info")?;
-            let parameters: MetadataParameters = serde_json::from_str(metadata_json)
-                .context("failed to deserialize metadata")?;
+            let type_info: ArrowTypeInfo =
+                serde_json::from_str(type_info_json).context("failed to deserialize type_info")?;
+            let parameters: MetadataParameters =
+                serde_json::from_str(metadata_json).context("failed to deserialize metadata")?;
 
             // Handle timing
             if let Some(last_ts) = last_timestamp_us {

--- a/binaries/cli/src/command/play.rs
+++ b/binaries/cli/src/command/play.rs
@@ -1,0 +1,273 @@
+use std::path::PathBuf;
+
+use aligned_vec::AVec;
+use arrow::{
+    array::{Array, AsArray, RecordBatch},
+    ipc::reader::FileReader,
+};
+use clap::Args;
+use dora_core::topics::{open_zenoh_session, zenoh_output_publish_topic};
+use dora_message::{
+    common::Timestamped,
+    daemon_to_daemon::InterDaemonEvent,
+    id::{DataId, NodeId},
+    metadata::{ArrowTypeInfo, Metadata, MetadataParameters},
+};
+use eyre::{Context, bail, eyre};
+use tokio::time::{Duration, sleep};
+use uuid::Uuid;
+
+use crate::{
+    command::{
+        Executable, default_tracing,
+        topic::selector::DataflowSelector,
+    },
+    common::CoordinatorOptions,
+};
+
+/// Play back recorded dataflow messages.
+///
+/// This command reads an Arrow IPC recording file created with `dora record`
+/// and publishes the messages back into a running dataflow. Messages are
+/// replayed with their original timing, scaled by the rate parameter.
+///
+/// Examples:
+///
+/// Play back a recording at normal speed:
+///   dora play recording.arrows
+///
+/// Play at 2x speed:
+///   dora play recording.arrows --rate 2.0
+///
+/// Loop playback indefinitely:
+///   dora play recording.arrows --loop
+///
+/// Note: The target dataflow must have the following configuration:
+///
+/// ```yaml
+/// _unstable_debug:
+///   publish_all_messages_to_zenoh: true
+/// ```
+#[derive(Debug, Args)]
+#[clap(verbatim_doc_comment)]
+pub struct Play {
+    /// Path to the recorded Arrow IPC file
+    #[clap(value_name = "FILE")]
+    pub file: PathBuf,
+
+    /// Loop playback indefinitely
+    #[clap(long, short = 'l')]
+    pub loop_playback: bool,
+
+    /// Playback rate multiplier (1.0 = real-time, 2.0 = 2x speed, 0.5 = half speed)
+    #[clap(long, short = 'r', default_value = "1.0")]
+    pub rate: f64,
+
+    #[clap(flatten)]
+    selector: DataflowSelector,
+
+    #[clap(flatten)]
+    coordinator: CoordinatorOptions,
+}
+
+impl Executable for Play {
+    async fn execute(self) -> eyre::Result<()> {
+        default_tracing()?;
+
+        if self.rate <= 0.0 {
+            bail!("Rate must be positive");
+        }
+
+        play(
+            self.coordinator,
+            self.selector,
+            self.file,
+            self.loop_playback,
+            self.rate,
+        )
+        .await
+    }
+}
+
+async fn play(
+    coordinator: CoordinatorOptions,
+    selector: DataflowSelector,
+    file: PathBuf,
+    loop_playback: bool,
+    rate: f64,
+) -> eyre::Result<()> {
+    // Open and validate recording file
+    let file_handle = std::fs::File::open(&file)
+        .with_context(|| format!("failed to open recording file: {}", file.display()))?;
+
+    let reader = FileReader::try_new(file_handle, None)
+        .context("failed to open Arrow IPC file")?;
+
+    // Validate schema
+    validate_schema(&reader)?;
+
+    // Connect to coordinator and resolve dataflow
+    let client = coordinator.connect_rpc().await?;
+    let (dataflow_id, descriptor) = selector.resolve(&client).await?;
+
+    if !descriptor.debug.publish_all_messages_to_zenoh {
+        bail!(
+            "Dataflow `{dataflow_id}` does not have `publish_all_messages_to_zenoh` enabled.\n\
+            \n\
+            Tip: Add the following snippet to your dataflow descriptor:\n\
+            \n\
+            ```\n\
+            _unstable_debug:\n  publish_all_messages_to_zenoh: true\n\
+            ```"
+        );
+    }
+
+    println!("Playing back recording to dataflow {}", dataflow_id);
+
+    let zenoh_session = open_zenoh_session(Some(coordinator.coordinator_addr))
+        .await
+        .context("failed to open zenoh session")?;
+
+    // Wait for Zenoh peer connection before publishing
+    print!("Connecting to daemon...");
+    loop {
+        let mut peers = zenoh_session.info().peers_zid().await;
+        if peers.next().is_some() {
+            break;
+        }
+        let mut routers = zenoh_session.info().routers_zid().await;
+        if routers.next().is_some() {
+            break;
+        }
+        sleep(Duration::from_millis(200)).await;
+    }
+    println!(" ok");
+
+    // Read all batches into memory for potential looping
+    let batches = reader.collect::<Result<Vec<_>, _>>()
+        .context("failed to read batches from recording")?;
+
+    if batches.is_empty() {
+        println!("Recording is empty, nothing to play");
+        return Ok(());
+    }
+
+    let mut playback_iteration = 0;
+    loop {
+        playback_iteration += 1;
+        if loop_playback {
+            println!("Playback iteration {}", playback_iteration);
+        }
+
+        let messages_played = play_batches(&batches, dataflow_id, &zenoh_session, rate).await?;
+
+        println!("✓ Played {} messages", messages_played);
+
+        if !loop_playback {
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_schema(reader: &FileReader<std::fs::File>) -> eyre::Result<()> {
+    let schema = reader.schema();
+    let expected_fields = ["timestamp_us", "node_id", "output_id", "data", "type_info", "metadata"];
+
+    for field_name in expected_fields {
+        if schema.field_with_name(field_name).is_err() {
+            bail!("Invalid recording file: missing field '{field_name}'");
+        }
+    }
+
+    Ok(())
+}
+
+async fn play_batches(
+    batches: &[RecordBatch],
+    dataflow_id: Uuid,
+    zenoh_session: &zenoh::Session,
+    rate: f64,
+) -> eyre::Result<usize> {
+    let mut message_count = 0;
+    let mut last_timestamp_us: Option<u64> = None;
+
+    for batch in batches {
+        let timestamp_array = batch
+            .column(0)
+            .as_primitive::<arrow::datatypes::UInt64Type>();
+        let node_id_array = batch.column(1).as_string::<i32>();
+        let output_id_array = batch.column(2).as_string::<i32>();
+        let data_array = batch.column(3).as_binary::<i32>();
+        let type_info_array = batch.column(4).as_string::<i32>();
+        let metadata_array = batch.column(5).as_string::<i32>();
+
+        for i in 0..batch.num_rows() {
+            let timestamp_us = timestamp_array.value(i);
+            let node_id: NodeId = node_id_array.value(i).parse()
+                .context("failed to parse node_id")?;
+            let output_id = DataId::from(output_id_array.value(i));
+            let data = if data_array.is_null(i) {
+                None
+            } else {
+                Some(data_array.value(i).to_vec())
+            };
+            let type_info_json = type_info_array.value(i);
+            let metadata_json = metadata_array.value(i);
+
+            // Deserialize type_info and metadata
+            let type_info: ArrowTypeInfo = serde_json::from_str(type_info_json)
+                .context("failed to deserialize type_info")?;
+            let parameters: MetadataParameters = serde_json::from_str(metadata_json)
+                .context("failed to deserialize metadata")?;
+
+            // Handle timing
+            if let Some(last_ts) = last_timestamp_us {
+                let delta_us = timestamp_us.saturating_sub(last_ts);
+                let delay_us = (delta_us as f64 / rate) as u64;
+                if delay_us > 0 {
+                    sleep(Duration::from_micros(delay_us)).await;
+                }
+            }
+            last_timestamp_us = Some(timestamp_us);
+
+            // Create metadata with timestamp
+            let timestamp = dora_core::uhlc::HLC::default().new_timestamp();
+            let metadata = Metadata::from_parameters(timestamp, type_info, parameters);
+
+            // Create topic and publish directly
+            let topic = zenoh_output_publish_topic(dataflow_id, &node_id, &output_id);
+
+            // Create InterDaemonEvent with aligned vec
+            let data_message = data.map(|d| AVec::from_slice(128, &d));
+
+            let event = InterDaemonEvent::Output {
+                dataflow_id,
+                node_id: node_id.clone(),
+                output_id: output_id.clone(),
+                metadata,
+                data: data_message,
+            };
+
+            // Create timestamped event and serialize
+            let timestamp = dora_core::uhlc::HLC::default().new_timestamp();
+            let timestamped = Timestamped {
+                inner: event,
+                timestamp,
+            };
+            let payload = timestamped.serialize();
+
+            // Publish directly using put on the session
+            zenoh_session
+                .put(&topic, payload)
+                .await
+                .map_err(|e| eyre!(e))
+                .wrap_err_with(|| format!("failed to publish message for {node_id}/{output_id}"))?;
+
+            message_count += 1;
+        }
+    }
+
+    Ok(message_count)
+}

--- a/binaries/cli/src/command/record.rs
+++ b/binaries/cli/src/command/record.rs
@@ -1,0 +1,379 @@
+use std::{path::PathBuf, sync::Arc, time::SystemTime};
+
+use arrow::{
+    array::{BinaryBuilder, RecordBatch, StringBuilder, UInt64Builder},
+    datatypes::{DataType, Field, Schema},
+    ipc::writer::FileWriter,
+};
+use clap::Args;
+use dora_core::topics::{open_zenoh_session, zenoh_output_publish_topic};
+use dora_message::{
+    common::Timestamped,
+    daemon_to_daemon::InterDaemonEvent,
+    id::DataId,
+};
+use eyre::{Context, bail, eyre};
+use tokio::{
+    select,
+    sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
+    task::JoinSet,
+    time::{Duration, timeout},
+};
+use uuid::Uuid;
+
+use crate::{
+    command::{
+        Executable, default_tracing,
+        topic::selector::{TopicIdentifier, TopicSelector},
+    },
+    common::CoordinatorOptions,
+};
+
+/// Record dataflow messages to an Arrow IPC file.
+///
+/// This command subscribes to output topics from a running dataflow and
+/// records all messages to a file in Arrow IPC format. The recordings can
+/// later be played back using `dora play`.
+///
+/// Examples:
+///
+/// Record all outputs for 10 seconds:
+///   dora record --all -d 10 -o recording.arrows
+///
+/// Record specific topics:
+///   dora record -d my-dataflow robot/pose sensor/camera
+///
+/// Record continuously until Ctrl+C:
+///   dora record --all -o recording.arrows
+///
+/// Note: The dataflow must have the following configuration:
+///
+/// ```yaml
+/// _unstable_debug:
+///   publish_all_messages_to_zenoh: true
+/// ```
+#[derive(Debug, Args)]
+#[clap(verbatim_doc_comment)]
+pub struct Record {
+    #[clap(flatten)]
+    selector: TopicSelector,
+
+    /// Output file path (defaults to recording-{timestamp}.arrows)
+    #[clap(long, short = 'o', value_name = "FILE")]
+    pub output_file: Option<PathBuf>,
+
+    /// Duration to record in seconds (omit for continuous recording)
+    #[clap(long, short = 't', value_name = "SECS")]
+    pub duration: Option<f64>,
+
+    /// Record all outputs from the dataflow (can also specify DATA arguments)
+    #[clap(long, short = 'a')]
+    pub all: bool,
+
+    #[clap(flatten)]
+    coordinator: CoordinatorOptions,
+}
+
+#[derive(Debug)]
+struct RecordedMessage {
+    timestamp_us: u64,
+    node_id: String,
+    output_id: String,
+    data: Option<Vec<u8>>,
+    type_info: String,
+    metadata: String,
+}
+
+impl Executable for Record {
+    async fn execute(self) -> eyre::Result<()> {
+        default_tracing()?;
+
+        // Validate arguments
+        if !self.all && self.selector.data.is_empty() {
+            bail!(
+                "Either specify output topics (e.g., 'node/output') or use --all to record all outputs"
+            );
+        }
+
+        record(self.coordinator, self.selector, self.output_file, self.duration).await
+    }
+}
+
+async fn record(
+    coordinator: CoordinatorOptions,
+    selector: TopicSelector,
+    output_file: Option<PathBuf>,
+    duration: Option<f64>,
+) -> eyre::Result<()> {
+    let client = coordinator.connect_rpc().await?;
+    let (dataflow_id, topics) = selector.resolve(&client).await?;
+
+    if topics.is_empty() {
+        bail!("No topics found to record");
+    }
+
+    println!("Recording {} topics from dataflow {}", topics.len(), dataflow_id);
+    for topic in &topics {
+        println!("  - {}", topic);
+    }
+
+    // Generate output filename if not specified
+    let output_path = output_file.unwrap_or_else(|| {
+        let timestamp = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        PathBuf::from(format!("recording-{}.arrows", timestamp))
+    });
+
+    println!("Recording to: {}", output_path.display());
+
+    let zenoh_session = open_zenoh_session(Some(coordinator.coordinator_addr))
+        .await
+        .context("failed to open zenoh session")?;
+
+    // Wait for Zenoh peer connection before subscribing. Without this, short
+    // recordings can finish before the Zenoh peers discover each other via
+    // scouting, resulting in 0 captured messages.
+    print!("Connecting to daemon...");
+    let connected = loop {
+        let mut peers = zenoh_session.info().peers_zid().await;
+        if peers.next().is_some() {
+            break true;
+        }
+        let mut routers = zenoh_session.info().routers_zid().await;
+        if routers.next().is_some() {
+            break true;
+        }
+        if timeout(Duration::from_millis(200), wait_for_ctrl_c()).await.is_ok() {
+            break false;
+        }
+    };
+    if !connected {
+        println!(" interrupted");
+        return Ok(());
+    }
+    println!(" ok");
+
+    // Create channel for collecting messages from all topics
+    let (tx, rx) = unbounded_channel::<RecordedMessage>();
+
+    // Spawn subscriber tasks for each topic
+    let mut join_set = JoinSet::new();
+    for TopicIdentifier { node_id, data_id } in topics {
+        join_set.spawn(subscribe_and_record(
+            zenoh_session.clone(),
+            dataflow_id,
+            node_id,
+            data_id,
+            tx.clone(),
+        ));
+    }
+
+    // Drop the sender so the writer knows when all senders are done
+    drop(tx);
+
+    // Start the recording writer task
+    let writer_handle = tokio::spawn(write_recording(rx, output_path.clone()));
+
+    // Handle duration timeout or wait for Ctrl+C
+    if let Some(duration_secs) = duration {
+        println!("Recording for {} seconds (press Ctrl+C to stop early)", duration_secs);
+
+        select! {
+            _ = timeout(Duration::from_secs_f64(duration_secs), wait_for_ctrl_c()) => {
+                println!("\nDuration elapsed, stopping recording...");
+            }
+            _ = wait_for_ctrl_c() => {
+                println!("\nCtrl+C received, stopping recording...");
+            }
+        }
+    } else {
+        println!("Recording... (press Ctrl+C to stop)");
+        wait_for_ctrl_c().await;
+        println!("\nCtrl+C received, stopping recording...");
+    }
+
+    // Abort all subscriber tasks
+    join_set.abort_all();
+
+    // Wait for writer to finish
+    let message_count = writer_handle.await??;
+
+    println!("✓ Recorded {} messages to {}", message_count, output_path.display());
+
+    Ok(())
+}
+
+async fn subscribe_and_record(
+    zenoh_session: zenoh::Session,
+    dataflow_id: Uuid,
+    node_id: dora_message::id::NodeId,
+    output_id: DataId,
+    tx: UnboundedSender<RecordedMessage>,
+) -> eyre::Result<()> {
+    let subscribe_topic = zenoh_output_publish_topic(dataflow_id, &node_id, &output_id);
+
+    let subscriber = zenoh_session
+        .declare_subscriber(&subscribe_topic)
+        .await
+        .map_err(|e| eyre!(e))
+        .wrap_err_with(|| format!("failed to subscribe to {node_id}/{output_id}"))?;
+
+    while let Ok(sample) = subscriber.recv_async().await {
+        let event = match Timestamped::deserialize_inter_daemon_event(&sample.payload().to_bytes())
+        {
+            Ok(event) => event,
+            Err(_) => {
+                eprintln!("Received invalid event from {node_id}/{output_id}");
+                continue;
+            }
+        };
+
+        match event.inner {
+            InterDaemonEvent::Output { metadata, data, .. } => {
+                // Get current timestamp in microseconds
+                let timestamp_us = SystemTime::now()
+                    .duration_since(SystemTime::UNIX_EPOCH)
+                    .unwrap()
+                    .as_micros() as u64;
+
+                // Serialize type_info and metadata to JSON
+                let type_info_json = serde_json::to_string(&metadata.type_info)
+                    .context("failed to serialize type_info")?;
+                let metadata_json = serde_json::to_string(&metadata.parameters)
+                    .context("failed to serialize metadata")?;
+
+                let data_bytes = data.map(|data| data.to_vec());
+
+                let message = RecordedMessage {
+                    timestamp_us,
+                    node_id: node_id.to_string(),
+                    output_id: output_id.to_string(),
+                    data: data_bytes,
+                    type_info: type_info_json,
+                    metadata: metadata_json,
+                };
+
+                if tx.send(message).is_err() {
+                    // Receiver dropped, stop recording
+                    break;
+                }
+            }
+            InterDaemonEvent::OutputClosed { .. } => {
+                break;
+            }
+            InterDaemonEvent::NodeFailed { .. } => {
+                // Not relevant for recording
+                continue;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn write_recording(
+    mut rx: UnboundedReceiver<RecordedMessage>,
+    output_path: PathBuf,
+) -> eyre::Result<usize> {
+    // Define Arrow schema for recorded messages
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("timestamp_us", DataType::UInt64, false),
+        Field::new("node_id", DataType::Utf8, false),
+        Field::new("output_id", DataType::Utf8, false),
+        Field::new("data", DataType::Binary, true),
+        Field::new("type_info", DataType::Utf8, false),
+        Field::new("metadata", DataType::Utf8, false),
+    ]));
+
+    // Create temporary file for atomic write
+    let temp_path = output_path.with_extension("arrows.tmp");
+    let file = std::fs::File::create(&temp_path)
+        .with_context(|| format!("failed to create output file: {}", temp_path.display()))?;
+
+    let mut writer = FileWriter::try_new(file, &schema)
+        .context("failed to create Arrow IPC writer")?;
+
+    let mut message_count = 0;
+    let mut batch_messages = Vec::new();
+    const BATCH_SIZE: usize = 100;
+
+    // Collect messages and write in batches
+    while let Some(msg) = rx.recv().await {
+        batch_messages.push(msg);
+
+        if batch_messages.len() >= BATCH_SIZE {
+            write_batch(&mut writer, &schema, &batch_messages)?;
+            message_count += batch_messages.len();
+            batch_messages.clear();
+        }
+    }
+
+    // Write remaining messages
+    if !batch_messages.is_empty() {
+        write_batch(&mut writer, &schema, &batch_messages)?;
+        message_count += batch_messages.len();
+    }
+
+    // Finish writing and close file
+    writer.finish().context("failed to finish Arrow IPC file")?;
+    drop(writer);
+
+    // Move temp file to final location
+    std::fs::rename(&temp_path, &output_path)
+        .with_context(|| format!("failed to move temp file to {}", output_path.display()))?;
+
+    Ok(message_count)
+}
+
+fn write_batch(
+    writer: &mut FileWriter<std::fs::File>,
+    schema: &Arc<Schema>,
+    messages: &[RecordedMessage],
+) -> eyre::Result<()> {
+    let mut timestamp_builder = UInt64Builder::new();
+    let mut node_id_builder = StringBuilder::new();
+    let mut output_id_builder = StringBuilder::new();
+    let mut data_builder = BinaryBuilder::new();
+    let mut type_info_builder = StringBuilder::new();
+    let mut metadata_builder = StringBuilder::new();
+
+    for msg in messages {
+        timestamp_builder.append_value(msg.timestamp_us);
+        node_id_builder.append_value(&msg.node_id);
+        output_id_builder.append_value(&msg.output_id);
+
+        if let Some(ref data) = msg.data {
+            data_builder.append_value(data);
+        } else {
+            data_builder.append_null();
+        }
+
+        type_info_builder.append_value(&msg.type_info);
+        metadata_builder.append_value(&msg.metadata);
+    }
+
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(timestamp_builder.finish()),
+            Arc::new(node_id_builder.finish()),
+            Arc::new(output_id_builder.finish()),
+            Arc::new(data_builder.finish()),
+            Arc::new(type_info_builder.finish()),
+            Arc::new(metadata_builder.finish()),
+        ],
+    )
+    .context("failed to create RecordBatch")?;
+
+    writer.write(&batch).context("failed to write batch to Arrow IPC file")?;
+
+    Ok(())
+}
+
+async fn wait_for_ctrl_c() {
+    tokio::signal::ctrl_c()
+        .await
+        .expect("failed to listen for Ctrl+C");
+}

--- a/binaries/cli/src/command/record.rs
+++ b/binaries/cli/src/command/record.rs
@@ -7,15 +7,11 @@ use arrow::{
 };
 use clap::Args;
 use dora_core::topics::{open_zenoh_session, zenoh_output_publish_topic};
-use dora_message::{
-    common::Timestamped,
-    daemon_to_daemon::InterDaemonEvent,
-    id::DataId,
-};
+use dora_message::{common::Timestamped, daemon_to_daemon::InterDaemonEvent, id::DataId};
 use eyre::{Context, bail, eyre};
 use tokio::{
     select,
-    sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
+    sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel},
     task::JoinSet,
     time::{Duration, timeout},
 };
@@ -95,7 +91,13 @@ impl Executable for Record {
             );
         }
 
-        record(self.coordinator, self.selector, self.output_file, self.duration).await
+        record(
+            self.coordinator,
+            self.selector,
+            self.output_file,
+            self.duration,
+        )
+        .await
     }
 }
 
@@ -112,7 +114,11 @@ async fn record(
         bail!("No topics found to record");
     }
 
-    println!("Recording {} topics from dataflow {}", topics.len(), dataflow_id);
+    println!(
+        "Recording {} topics from dataflow {}",
+        topics.len(),
+        dataflow_id
+    );
     for topic in &topics {
         println!("  - {}", topic);
     }
@@ -145,7 +151,10 @@ async fn record(
         if routers.next().is_some() {
             break true;
         }
-        if timeout(Duration::from_millis(200), wait_for_ctrl_c()).await.is_ok() {
+        if timeout(Duration::from_millis(200), wait_for_ctrl_c())
+            .await
+            .is_ok()
+        {
             break false;
         }
     };
@@ -178,7 +187,10 @@ async fn record(
 
     // Handle duration timeout or wait for Ctrl+C
     if let Some(duration_secs) = duration {
-        println!("Recording for {} seconds (press Ctrl+C to stop early)", duration_secs);
+        println!(
+            "Recording for {} seconds (press Ctrl+C to stop early)",
+            duration_secs
+        );
 
         select! {
             _ = timeout(Duration::from_secs_f64(duration_secs), wait_for_ctrl_c()) => {
@@ -200,7 +212,11 @@ async fn record(
     // Wait for writer to finish
     let message_count = writer_handle.await??;
 
-    println!("✓ Recorded {} messages to {}", message_count, output_path.display());
+    println!(
+        "✓ Recorded {} messages to {}",
+        message_count,
+        output_path.display()
+    );
 
     Ok(())
 }
@@ -292,8 +308,8 @@ async fn write_recording(
     let file = std::fs::File::create(&temp_path)
         .with_context(|| format!("failed to create output file: {}", temp_path.display()))?;
 
-    let mut writer = FileWriter::try_new(file, &schema)
-        .context("failed to create Arrow IPC writer")?;
+    let mut writer =
+        FileWriter::try_new(file, &schema).context("failed to create Arrow IPC writer")?;
 
     let mut message_count = 0;
     let mut batch_messages = Vec::new();
@@ -367,7 +383,9 @@ fn write_batch(
     )
     .context("failed to create RecordBatch")?;
 
-    writer.write(&batch).context("failed to write batch to Arrow IPC file")?;
+    writer
+        .write(&batch)
+        .context("failed to write batch to Arrow IPC file")?;
 
     Ok(())
 }

--- a/binaries/cli/src/command/topic.rs
+++ b/binaries/cli/src/command/topic.rs
@@ -7,7 +7,7 @@ mod echo;
 mod hz;
 mod info;
 mod list;
-mod selector;
+pub mod selector;
 
 /// Manage and inspect dataflow topics.
 #[derive(Debug, clap::Subcommand)]


### PR DESCRIPTION
Closes #1488

## Summary
- Adds `dora record` to capture dataflow messages from Zenoh into Arrow IPC (.arrows) files
  - Supports `--all` or specific topics, configurable duration (`-t`), Ctrl+C to stop
  - Batched writing (100 msgs/batch), atomic file writes via temp file rename
- Adds `dora play` to replay recorded messages back into a running dataflow
  - Rate scaling (`--rate 2.0` for 2x speed), loop support (`--loop`)
  - Schema validation, microsecond-precision timing preservation
- Reuses existing `TopicSelector`/`DataflowSelector` from `dora topic` commands

## Test plan
- [ ] `dora record --help` / `dora play --help` show correct usage
- [ ] `dora record --all -t 5` captures messages from a dataflow with `publish_all_messages_to_zenoh: true`
- [ ] `dora play recording.arrows` replays messages with correct timing
- [ ] `dora play recording.arrows --rate 2.0` plays at double speed
- [ ] `dora play recording.arrows --loop` loops continuously
- [ ] Recording a non-existent dataflow gives a clear error
- [ ] Playing an invalid file gives a clear error