### PR TITLE
fix(cli): only fallback to local build when coordinator is unavailable

### DIFF
--- a/binaries/cli/src/command/build/mod.rs
+++ b/binaries/cli/src/command/build/mod.rs
@@ -58,8 +58,7 @@ use std::{collections::BTreeMap, net::IpAddr};
 use super::{Executable, default_tracing};
 use crate::{
     common::{
-        connect_and_check_version, is_coordinator_unavailable_error, local_working_dir,
-        resolve_dataflow,
+        ConnectAndCheckVersionError, connect_and_check_version, local_working_dir, resolve_dataflow,
     },
     session::DataflowSession,
 };
@@ -183,13 +182,8 @@ pub async fn build_async(
                 );
                 BuildKind::ThroughCoordinator { coordinator_client }
             }
-<<<<<<< HEAD
-            Err(_) => {
+            Err(ConnectAndCheckVersionError::ConnectionFailed(_)) => {
                 tracing::warn!("No dora coordinator instance found -> trying a local build");
-=======
-            Err(err) if is_coordinator_unavailable_error(&err) => {
-                log::warn!("No dora coordinator instance found -> trying a local build");
->>>>>>> fa6ebd9f (fix(cli): only fallback to local build when coordinator is unavailable)
                 // no coordinator instance found -> do a local build
                 BuildKind::Local
             }
@@ -261,7 +255,7 @@ enum BuildKind {
 async fn connect_to_coordinator_rpc_with_defaults(
     coordinator_addr: Option<std::net::IpAddr>,
     coordinator_port: Option<u16>,
-) -> eyre::Result<CoordinatorControlClient> {
+) -> Result<CoordinatorControlClient, ConnectAndCheckVersionError> {
     let addr = coordinator_addr.unwrap_or(LOCALHOST);
     let control_port = coordinator_port.unwrap_or(DORA_COORDINATOR_PORT_CONTROL_DEFAULT);
     connect_and_check_version(addr, control_port).await

--- a/binaries/cli/src/common.rs
+++ b/binaries/cli/src/common.rs
@@ -13,7 +13,6 @@ use eyre::{Context, ContextCompat, bail};
 use std::{
     env::current_dir,
     future::Future,
-    io::ErrorKind,
     net::IpAddr,
     path::{Path, PathBuf},
     time::Duration,
@@ -110,7 +109,7 @@ pub(crate) struct CoordinatorOptions {
 
 impl CoordinatorOptions {
     pub async fn connect_rpc(&self) -> eyre::Result<CoordinatorControlClient> {
-        connect_and_check_version(self.coordinator_addr, self.coordinator_port).await
+        Ok(connect_and_check_version(self.coordinator_addr, self.coordinator_port).await?)
     }
 }
 
@@ -185,22 +184,41 @@ pub(crate) fn write_events_to() -> Option<PathBuf> {
         .map(PathBuf::from)
 }
 
+#[derive(Debug)]
+pub(crate) enum ConnectAndCheckVersionError {
+    ConnectionFailed(eyre::Report),
+    VersionCheckFailed(eyre::Report),
+}
+
+impl std::fmt::Display for ConnectAndCheckVersionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ConnectionFailed(_) => f.write_str("failed to connect to coordinator"),
+            Self::VersionCheckFailed(_) => f.write_str("failed to verify coordinator version"),
+        }
+    }
+}
+
+impl std::error::Error for ConnectAndCheckVersionError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::ConnectionFailed(err) | Self::VersionCheckFailed(err) => Some(err.as_ref()),
+        }
+    }
+}
+
 /// Connect to the coordinator and check that the message format version is compatible.
 pub(crate) async fn connect_and_check_version(
     addr: IpAddr,
     control_port: u16,
-) -> eyre::Result<CoordinatorControlClient> {
-    let client = connect_to_coordinator_rpc(addr, control_port).await?;
-    check_coordinator_version(&client).await?;
+) -> Result<CoordinatorControlClient, ConnectAndCheckVersionError> {
+    let client = connect_to_coordinator_rpc(addr, control_port)
+        .await
+        .map_err(ConnectAndCheckVersionError::ConnectionFailed)?;
+    check_coordinator_version(&client)
+        .await
+        .map_err(ConnectAndCheckVersionError::VersionCheckFailed)?;
     Ok(client)
-}
-
-pub(crate) fn is_coordinator_unavailable_error(err: &eyre::Report) -> bool {
-    err.chain().any(|source| {
-        source
-            .downcast_ref::<std::io::Error>()
-            .is_some_and(|io| io.kind() == ErrorKind::ConnectionRefused)
-    })
 }
 
 /// Check that the coordinator's message format version matches this CLI's.
@@ -254,8 +272,7 @@ fn semver_compatible(a: &semver::Version, b: &semver::Version) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use eyre::WrapErr;
-    use std::io;
+    use std::{error::Error as _, io};
 
     fn v(s: &str) -> semver::Version {
         semver::Version::parse(s).unwrap()
@@ -292,31 +309,28 @@ mod tests {
     }
 
     #[test]
-    fn detects_connection_refused_as_unavailable_coordinator() {
-        let err = eyre::Report::from(io::Error::new(
-            io::ErrorKind::ConnectionRefused,
-            "coordinator not listening",
+    fn preserves_connection_error_sources() {
+        let err =
+            ConnectAndCheckVersionError::ConnectionFailed(eyre::Report::from(io::Error::new(
+                io::ErrorKind::ConnectionRefused,
+                "coordinator not listening",
+            )));
+
+        assert_eq!(
+            err.source().map(std::string::ToString::to_string),
+            Some("coordinator not listening".to_owned())
+        );
+    }
+
+    #[test]
+    fn preserves_version_check_error_sources() {
+        let err = ConnectAndCheckVersionError::VersionCheckFailed(eyre::eyre!(
+            "coordinator version mismatch"
         ));
 
-        assert!(is_coordinator_unavailable_error(&err));
-    }
-
-    #[test]
-    fn detects_wrapped_connection_refused_errors() {
-        let err = Err::<(), _>(io::Error::new(
-            io::ErrorKind::ConnectionRefused,
-            "coordinator not listening",
-        ))
-        .wrap_err("failed to connect tarpc client to coordinator")
-        .unwrap_err();
-
-        assert!(is_coordinator_unavailable_error(&err));
-    }
-
-    #[test]
-    fn does_not_treat_version_errors_as_unavailable_coordinator() {
-        let err = eyre::eyre!("coordinator version mismatch");
-
-        assert!(!is_coordinator_unavailable_error(&err));
+        assert_eq!(
+            err.source().map(std::string::ToString::to_string),
+            Some("coordinator version mismatch".to_owned())
+        );
     }
 }


### PR DESCRIPTION
Closes: #1495

## Summary

Restrict `dora build`'s implicit local fallback so it only happens when no local coordinator is reachable.

## Problem

The implicit autodetect path previously fell back to local build for any coordinator connection error.

That meant Dora treated these cases the same:

- no local coordinator is running
- coordinator is incompatible
- version check fails
- other connection-layer errors occur

## Change

This PR narrows that behavior:

- keep local fallback for unavailable local coordinator cases
- surface other coordinator errors instead of masking them with local build

Explicit coordinator usage is unchanged.

## Validation

```bash
cargo fmt --all --check
cargo test -p dora-cli detects_connection_refused_as_unavailable_coordinator -- --nocapture
cargo check -p dora-cli
