### PR TITLE
fix(core): improve error context for multi-line build commands

### DIFF
--- a/libraries/core/src/build/build_command.rs
+++ b/libraries/core/src/build/build_command.rs
@@ -52,7 +52,7 @@ pub async fn run_build_command(
 
         let mut child = cmd
             .spawn()
-            .wrap_err_with(|| format!("failed to spawn `{build}`"))?;
+            .wrap_err_with(|| format!("failed to spawn `{build_line}`"))?;
 
         let child_stdout = BufReader::new(child.stdout.take().expect("failed to take stdout"));
         let child_stderr = BufReader::new(child.stderr.take().expect("failed to take stderr"));
@@ -65,7 +65,7 @@ pub async fn run_build_command(
         let exit_status = child
             .wait()
             .await
-            .wrap_err_with(|| format!("failed to run `{build}`"))?;
+            .wrap_err_with(|| format!("failed to run `{build_line}`"))?;
         if !exit_status.success() {
             return Err(eyre!("build command `{build_line}` returned {exit_status}"));
         }
@@ -92,7 +92,13 @@ async fn forward_build_output<R1, R2>(
 
 #[cfg(test)]
 mod tests {
-    use super::forward_build_output;
+    use super::{forward_build_output, run_build_command};
+    use std::{
+        collections::BTreeMap,
+        fs,
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
     use tokio::io::{AsyncWriteExt, BufReader};
 
     #[tokio::test]
@@ -167,5 +173,46 @@ mod tests {
         assert_eq!(lines.len(), 256);
         assert_eq!(lines.first().map(String::as_str), Some("line-0"));
         assert_eq!(lines.last().map(String::as_str), Some("line-255"));
+    }
+
+    #[tokio::test]
+    async fn reports_the_failing_line_for_multi_line_build_errors() {
+        let working_dir = test_working_dir();
+        let first_line = format!(
+            "\"{}\" --help",
+            std::env::current_exe()
+                .expect("failed to locate test binary")
+                .display()
+        );
+        let failing_line = "definitely-not-a-real-command";
+        let build = format!("{first_line}\n{failing_line}");
+        let envs = Some(BTreeMap::new());
+        let (stdout_tx, _stdout_rx) = tokio::sync::mpsc::channel(4);
+
+        let err = run_build_command(&build, &working_dir, false, &envs, stdout_tx)
+            .await
+            .expect_err("missing executable should fail");
+        let msg = format!("{err:#}");
+
+        assert!(msg.contains(failing_line));
+        assert!(
+            !msg.contains(&first_line),
+            "error should reference the failing line instead of the full build block: {msg}"
+        );
+
+        let _ = fs::remove_dir_all(&working_dir);
+    }
+
+    fn test_working_dir() -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "dora-build-command-test-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&dir).expect("failed to create test working dir");
+        dir
     }
 }

--- a/libraries/core/src/build/mod.rs
+++ b/libraries/core/src/build/mod.rs
@@ -111,15 +111,18 @@ async fn build_node(
     build: &String,
     uv: bool,
 ) -> eyre::Result<()> {
-    logger
-        .log_message(
-            LogLevel::Info,
-            format!(
-                "running build command: `{build}` in {}",
-                working_dir.display()
-            ),
+    let build_log_message = if build.contains('\n') {
+        format!(
+            "running build commands in {}:\n{build}",
+            working_dir.display()
         )
-        .await;
+    } else {
+        format!(
+            "running build command: `{build}` in {}",
+            working_dir.display()
+        )
+    };
+    logger.log_message(LogLevel::Info, build_log_message).await;
     let build = build.to_owned();
     let node_env = node_env.clone();
     let mut logger = logger.try_clone().await.context("failed to clone logger")?;


### PR DESCRIPTION
Closes : #1503

## Summary

Improve logging and error context for multi-line `build` commands.

## Problem

Dora executes multi-line `build: |` blocks one line at a time, but the current logging and error context can still reference the full build block.

That makes failures look like one large command instead of pointing to the specific line that failed.

## Change

This PR updates the build path so that:

- spawn/run errors reference the failing build line
- multi-line build logging is reported as build commands rather than a single command block

It also adds a regression test covering a multi-line build where only one line fails.

## Validation

```bash
cargo fmt --all --check
cargo test -p dora-core --features build reports_the_failing_line_for_multi_line_build_errors -- --nocapture
cargo check -p dora-core --features build
