### PR TITLE
fix(cli): narrow rev fallback to hex-looking commit hashes

### DIFF
--- a/binaries/cli/src/command/build/git.rs
+++ b/binaries/cli/src/command/build/git.rs
@@ -29,7 +29,7 @@ pub fn fetch_commit_hash(repo_url: String, rev: Option<GitRepoRev>) -> eyre::Res
     if commit_hash.is_none() {
         if let Some(GitRepoRev::Rev(rev)) = &rev {
             // rev might be a commit hash instead of a reference
-            if rev.is_ascii() && rev.bytes().all(|b| b.is_ascii_alphanumeric()) {
+            if is_commit_hash_candidate(rev) {
                 commit_hash = Some(rev.clone());
             }
         }
@@ -41,5 +41,29 @@ pub fn fetch_commit_hash(repo_url: String, rev: Option<GitRepoRev>) -> eyre::Res
             commit_hash,
         }),
         None => eyre::bail!("no matching commit for `{rev:?}`"),
+    }
+}
+
+fn is_commit_hash_candidate(rev: &str) -> bool {
+    !rev.is_empty() && rev.is_ascii() && rev.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_commit_hash_candidate;
+
+    #[test]
+    fn accepts_hex_commit_hash_candidates() {
+        assert!(is_commit_hash_candidate("deadbeef"));
+        assert!(is_commit_hash_candidate("0123456789abcdef"));
+        assert!(is_commit_hash_candidate("ABCDEF1234"));
+    }
+
+    #[test]
+    fn rejects_non_hex_commit_hash_candidates() {
+        assert!(!is_commit_hash_candidate(""));
+        assert!(!is_commit_hash_candidate("release1"));
+        assert!(!is_commit_hash_candidate("abcdefg"));
+        assert!(!is_commit_hash_candidate("abc-def"));
     }
 }


### PR DESCRIPTION
Closes : #1507

## Summary

Narrow the `rev` fallback in the build git helper so only hex-looking values are treated as direct commit hash candidates.

## Problem

After ref lookup fails, the current fallback accepts any ASCII alphanumeric `rev` as a possible commit hash.

That is broader than a git hash and can misclassify invalid values like `release1` as direct hash candidates.

## Change

This PR updates the fallback in `binaries/cli/src/command/build/git.rs` to only accept non-empty ASCII hex strings as direct commit hash candidates.

Branch/tag/ref lookup remains unchanged and still happens first.

## Validation

```bash
cargo fmt --all --check
cargo check -p dora-cli
