### PR TITLE
fix(ci): fix PR check and exclude ros2 in clippy workflow

### DIFF
--- a/.github/workflows/cargo-update.yml
+++ b/.github/workflows/cargo-update.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Run cargo clippy fix
         if: steps.check_pr.outputs.exists == 'false'
-        run: cargo clippy --fix --allow-dirty --allow-staged --all-targets --all-features
+        run: cargo clippy --fix --allow-dirty --allow-staged --workspace --exclude rust-ros2-example-node --exclude dora-ros2-bridge --exclude dora-ros2-bridge-msg-gen --exclude dora-ros2-bridge-python --all-targets --all-features
 
       - name: Configure git
         if: steps.check_pr.outputs.exists == 'false'


### PR DESCRIPTION
## Summary
This PR fixes an issue where the weekly automated cargo-clippy-fix job fails to generate and push clippy fixes due to missing ROS 2 dependencies in the GitHub Actions environment.

## Issue 
The cargo-clippy-fix workflow runs cargo clippy across the workspace with the --all-features flag. This correctly enables the ros2 features, however, trying to compile the ROS 2 integration packages (rust-ros2-example-node, dora-ros2-bridge, etc.) requires a sourced, local ROS 2 installation to dynamically generate message definitions. Ubuntu-latest runner does not have ROS 2 installed out of the box, cargo fails to compile these packages with E0433: could not find std_msgs in messages. This compilation error causes the entire clippy job to crash immediately, preventing it from ever getting to the step where it creates a PR.