### PR TITLE
feat(cli): generate CMakeLists.txt for standalone C/C++ nodes

### DIFF
--- a/binaries/cli/src/template/c/mod.rs
+++ b/binaries/cli/src/template/c/mod.rs
@@ -8,6 +8,7 @@ use std::{
 const NODE: &str = include_str!("node/node-template.c");
 const TALKER: &str = include_str!("talker/talker-template.c");
 const LISTENER: &str = include_str!("listener/listener-template.c");
+const NODE_CMAKE: &str = include_str!("node-cmake-template.txt");
 
 pub fn create(args: crate::CommandNew, use_path_deps: bool) -> eyre::Result<()> {
     let crate::CommandNew {
@@ -18,7 +19,7 @@ pub fn create(args: crate::CommandNew, use_path_deps: bool) -> eyre::Result<()> 
     } = args;
 
     match kind {
-        crate::Kind::Node => create_custom_node(name, path, NODE),
+        crate::Kind::Node => create_custom_node(name, path, NODE, use_path_deps),
         crate::Kind::Dataflow => create_dataflow(name, path, use_path_deps),
     }
 }
@@ -47,9 +48,9 @@ fn create_dataflow(
     fs::write(&dataflow_yml_path, dataflow_yml)
         .with_context(|| format!("failed to write `{}`", dataflow_yml_path.display()))?;
 
-    create_custom_node("talker_1".into(), Some(root.join("talker_1")), TALKER)?;
-    create_custom_node("talker_2".into(), Some(root.join("talker_2")), TALKER)?;
-    create_custom_node("listener_1".into(), Some(root.join("listener_1")), LISTENER)?;
+    create_custom_node("talker_1".into(), Some(root.join("talker_1")), TALKER, use_path_deps)?;
+    create_custom_node("talker_2".into(), Some(root.join("talker_2")), TALKER, use_path_deps)?;
+    create_custom_node("listener_1".into(), Some(root.join("listener_1")), LISTENER, use_path_deps)?;
     create_cmakefile(root.to_path_buf(), use_path_deps)?;
 
     println!(
@@ -87,6 +88,7 @@ fn create_custom_node(
     name: String,
     path: Option<PathBuf>,
     template_scripts: &str,
+    use_path_deps: bool,
 ) -> Result<(), eyre::ErrReport> {
     if name.contains('/') {
         bail!("node name must not contain `/` separators");
@@ -107,12 +109,41 @@ fn create_custom_node(
     fs::write(&header_path, HEADER_NODE_API)
         .with_context(|| format!("failed to write `{}`", header_path.display()))?;
 
-    // TODO: Makefile?
+    create_node_cmakefile(&name, root, use_path_deps)?;
 
     println!(
         "Created new C custom node `{name}` at {}",
         Path::new(".").join(root).display()
     );
 
+    Ok(())
+}
+
+fn create_node_cmakefile(
+    name: &str,
+    root: &Path,
+    use_path_deps: bool,
+) -> Result<(), eyre::ErrReport> {
+    let cmake_content = if use_path_deps {
+        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let workspace_dir = manifest_dir
+            .parent()
+            .context("Could not get manifest parent folder")?
+            .parent()
+            .context("Could not get manifest grandparent folder")?;
+        NODE_CMAKE
+            .replace("___name___", name)
+            .replace("__DORA_PATH__", workspace_dir.to_str().unwrap())
+    } else {
+        NODE_CMAKE
+            .replace("___name___", name)
+            .replace("__DORA_PATH__", "")
+    };
+
+    let cmake_path = root.join("CMakeLists.txt");
+    fs::write(&cmake_path, cmake_content)
+        .with_context(|| format!("failed to write `{}`", cmake_path.display()))?;
+
+    println!("Created new CMakeLists.txt at {}", cmake_path.display());
     Ok(())
 }

--- a/binaries/cli/src/template/c/mod.rs
+++ b/binaries/cli/src/template/c/mod.rs
@@ -48,9 +48,24 @@ fn create_dataflow(
     fs::write(&dataflow_yml_path, dataflow_yml)
         .with_context(|| format!("failed to write `{}`", dataflow_yml_path.display()))?;
 
-    create_custom_node("talker_1".into(), Some(root.join("talker_1")), TALKER, use_path_deps)?;
-    create_custom_node("talker_2".into(), Some(root.join("talker_2")), TALKER, use_path_deps)?;
-    create_custom_node("listener_1".into(), Some(root.join("listener_1")), LISTENER, use_path_deps)?;
+    create_custom_node(
+        "talker_1".into(),
+        Some(root.join("talker_1")),
+        TALKER,
+        use_path_deps,
+    )?;
+    create_custom_node(
+        "talker_2".into(),
+        Some(root.join("talker_2")),
+        TALKER,
+        use_path_deps,
+    )?;
+    create_custom_node(
+        "listener_1".into(),
+        Some(root.join("listener_1")),
+        LISTENER,
+        use_path_deps,
+    )?;
     create_cmakefile(root.to_path_buf(), use_path_deps)?;
 
     println!(

--- a/binaries/cli/src/template/c/node-cmake-template.txt
+++ b/binaries/cli/src/template/c/node-cmake-template.txt
@@ -1,0 +1,68 @@
+cmake_minimum_required(VERSION 3.21)
+project(___name___ LANGUAGES C)
+
+set(DORA_ROOT_DIR "__DORA_PATH__" CACHE FILEPATH "Path to the root of dora")
+
+set(dora_c_include_dir "${CMAKE_CURRENT_BINARY_DIR}/include/c")
+
+if(DORA_ROOT_DIR)
+    include(ExternalProject)
+    ExternalProject_Add(Dora
+        SOURCE_DIR ${DORA_ROOT_DIR}
+        BUILD_IN_SOURCE True
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND
+            cargo build
+            --package dora-node-api-c
+        INSTALL_COMMAND ""
+    )
+
+    add_custom_command(OUTPUT ${dora_c_include_dir}
+        WORKING_DIRECTORY ${DORA_ROOT_DIR}
+        DEPENDS Dora
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${dora_c_include_dir}
+        COMMAND ${CMAKE_COMMAND} -E copy_directory apis/c/node ${dora_c_include_dir}/node
+    )
+
+    add_custom_target(Dora_c DEPENDS ${dora_c_include_dir})
+    set(dora_link_dirs ${DORA_ROOT_DIR}/target/debug)
+else()
+    include(ExternalProject)
+    ExternalProject_Add(Dora
+        PREFIX ${CMAKE_CURRENT_BINARY_DIR}/dora
+        GIT_REPOSITORY https://github.com/dora-rs/dora.git
+        GIT_TAG main
+        BUILD_IN_SOURCE True
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND
+            cargo build
+            --package dora-node-api-c
+            --target-dir ${CMAKE_CURRENT_BINARY_DIR}/dora/src/Dora/target
+        INSTALL_COMMAND ""
+    )
+
+    add_custom_command(OUTPUT ${dora_c_include_dir}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/dora/src/Dora/target
+        DEPENDS Dora
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${dora_c_include_dir}
+        COMMAND ${CMAKE_COMMAND} -E copy_directory ../apis/c/node ${dora_c_include_dir}/node
+    )
+
+    set(dora_link_dirs ${CMAKE_CURRENT_BINARY_DIR}/dora/src/Dora/target/debug)
+
+    add_custom_target(Dora_c DEPENDS ${dora_c_include_dir})
+endif()
+
+link_directories(${dora_link_dirs})
+
+add_executable(___name___ node.c)
+add_dependencies(___name___ Dora_c)
+target_include_directories(___name___ PRIVATE ${dora_c_include_dir})
+
+if(WIN32)
+    target_link_libraries(___name___ dora_node_api_c ws2_32 userenv ntdll bcrypt)
+else()
+    target_link_libraries(___name___ dora_node_api_c m z)
+endif()
+
+install(TARGETS ___name___ DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/bin)

--- a/binaries/cli/src/template/cxx/mod.rs
+++ b/binaries/cli/src/template/cxx/mod.rs
@@ -47,9 +47,24 @@ fn create_dataflow(
     fs::write(&dataflow_yml_path, dataflow_yml)
         .with_context(|| format!("failed to write `{}`", dataflow_yml_path.display()))?;
 
-    create_custom_node("talker_1".into(), Some(root.join("talker_1")), TALKER, use_path_deps)?;
-    create_custom_node("talker_2".into(), Some(root.join("talker_2")), TALKER, use_path_deps)?;
-    create_custom_node("listener_1".into(), Some(root.join("listener_1")), LISTENER, use_path_deps)?;
+    create_custom_node(
+        "talker_1".into(),
+        Some(root.join("talker_1")),
+        TALKER,
+        use_path_deps,
+    )?;
+    create_custom_node(
+        "talker_2".into(),
+        Some(root.join("talker_2")),
+        TALKER,
+        use_path_deps,
+    )?;
+    create_custom_node(
+        "listener_1".into(),
+        Some(root.join("listener_1")),
+        LISTENER,
+        use_path_deps,
+    )?;
     create_cmakefile(root.to_path_buf(), use_path_deps)?;
 
     println!(

--- a/binaries/cli/src/template/cxx/mod.rs
+++ b/binaries/cli/src/template/cxx/mod.rs
@@ -7,6 +7,7 @@ use std::{
 const NODE: &str = include_str!("node-template.cc");
 const TALKER: &str = include_str!("talker-template.cc");
 const LISTENER: &str = include_str!("listener-template.cc");
+const NODE_CMAKE: &str = include_str!("node-cmake-template.txt");
 
 pub fn create(args: crate::CommandNew, use_path_deps: bool) -> eyre::Result<()> {
     let crate::CommandNew {
@@ -17,7 +18,7 @@ pub fn create(args: crate::CommandNew, use_path_deps: bool) -> eyre::Result<()> 
     } = args;
 
     match kind {
-        crate::Kind::Node => create_custom_node(name, path, NODE),
+        crate::Kind::Node => create_custom_node(name, path, NODE, use_path_deps),
         crate::Kind::Dataflow => create_dataflow(name, path, use_path_deps),
     }
 }
@@ -46,9 +47,9 @@ fn create_dataflow(
     fs::write(&dataflow_yml_path, dataflow_yml)
         .with_context(|| format!("failed to write `{}`", dataflow_yml_path.display()))?;
 
-    create_custom_node("talker_1".into(), Some(root.join("talker_1")), TALKER)?;
-    create_custom_node("talker_2".into(), Some(root.join("talker_2")), TALKER)?;
-    create_custom_node("listener_1".into(), Some(root.join("listener_1")), LISTENER)?;
+    create_custom_node("talker_1".into(), Some(root.join("talker_1")), TALKER, use_path_deps)?;
+    create_custom_node("talker_2".into(), Some(root.join("talker_2")), TALKER, use_path_deps)?;
+    create_custom_node("listener_1".into(), Some(root.join("listener_1")), LISTENER, use_path_deps)?;
     create_cmakefile(root.to_path_buf(), use_path_deps)?;
 
     println!(
@@ -86,6 +87,7 @@ fn create_custom_node(
     name: String,
     path: Option<PathBuf>,
     template_scripts: &str,
+    use_path_deps: bool,
 ) -> Result<(), eyre::ErrReport> {
     if name.contains('/') {
         bail!("node name must not contain `/` separators");
@@ -103,12 +105,41 @@ fn create_custom_node(
     fs::write(&node_path, template_scripts)
         .with_context(|| format!("failed to write `{}`", node_path.display()))?;
 
-    // TODO: Makefile?
+    create_node_cmakefile(&name, root, use_path_deps)?;
 
     println!(
         "Created new C++ custom node `{name}` at {}",
         Path::new(".").join(root).display()
     );
 
+    Ok(())
+}
+
+fn create_node_cmakefile(
+    name: &str,
+    root: &Path,
+    use_path_deps: bool,
+) -> Result<(), eyre::ErrReport> {
+    let cmake_content = if use_path_deps {
+        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let workspace_dir = manifest_dir
+            .parent()
+            .context("Could not get manifest parent folder")?
+            .parent()
+            .context("Could not get manifest grandparent folder")?;
+        NODE_CMAKE
+            .replace("___name___", name)
+            .replace("__DORA_PATH__", workspace_dir.to_str().unwrap())
+    } else {
+        NODE_CMAKE
+            .replace("___name___", name)
+            .replace("__DORA_PATH__", "")
+    };
+
+    let cmake_path = root.join("CMakeLists.txt");
+    fs::write(&cmake_path, cmake_content)
+        .with_context(|| format!("failed to write `{}`", cmake_path.display()))?;
+
+    println!("Created new CMakeLists.txt at {}", cmake_path.display());
     Ok(())
 }

--- a/binaries/cli/src/template/cxx/node-cmake-template.txt
+++ b/binaries/cli/src/template/cxx/node-cmake-template.txt
@@ -1,0 +1,73 @@
+cmake_minimum_required(VERSION 3.21)
+project(___name___ LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+
+set(DORA_ROOT_DIR "__DORA_PATH__" CACHE FILEPATH "Path to the root of dora")
+
+set(dora_cxx_include_dir "${CMAKE_CURRENT_BINARY_DIR}/include/cxx")
+set(node_bridge "${CMAKE_CURRENT_BINARY_DIR}/node_bridge.cc")
+
+if(DORA_ROOT_DIR)
+    include(ExternalProject)
+    ExternalProject_Add(Dora
+        SOURCE_DIR ${DORA_ROOT_DIR}
+        BUILD_IN_SOURCE True
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND
+            cargo build
+            --package dora-node-api-cxx
+        INSTALL_COMMAND ""
+    )
+
+    add_custom_command(OUTPUT ${node_bridge} ${dora_cxx_include_dir}
+        WORKING_DIRECTORY ${DORA_ROOT_DIR}
+        DEPENDS Dora
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${dora_cxx_include_dir}
+        COMMAND ${CMAKE_COMMAND} -E copy target/cxxbridge/dora-node-api-cxx/src/lib.rs.cc ${node_bridge}
+        COMMAND ${CMAKE_COMMAND} -E copy target/cxxbridge/dora-node-api-cxx/src/lib.rs.h ${dora_cxx_include_dir}/dora-node-api.h
+    )
+
+    add_custom_target(Dora_cxx DEPENDS ${node_bridge} ${dora_cxx_include_dir})
+    set(dora_link_dirs ${DORA_ROOT_DIR}/target/debug)
+else()
+    include(ExternalProject)
+    ExternalProject_Add(Dora
+        PREFIX ${CMAKE_CURRENT_BINARY_DIR}/dora
+        GIT_REPOSITORY https://github.com/dora-rs/dora.git
+        GIT_TAG main
+        BUILD_IN_SOURCE True
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND
+            cargo build
+            --package dora-node-api-cxx
+            --target-dir ${CMAKE_CURRENT_BINARY_DIR}/dora/src/Dora/target
+        INSTALL_COMMAND ""
+    )
+
+    add_custom_command(OUTPUT ${node_bridge} ${dora_cxx_include_dir}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/dora/src/Dora/target
+        DEPENDS Dora
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${dora_cxx_include_dir}
+        COMMAND ${CMAKE_COMMAND} -E copy cxxbridge/dora-node-api-cxx/src/lib.rs.cc ${node_bridge}
+        COMMAND ${CMAKE_COMMAND} -E copy cxxbridge/dora-node-api-cxx/src/lib.rs.h ${dora_cxx_include_dir}/dora-node-api.h
+    )
+
+    set(dora_link_dirs ${CMAKE_CURRENT_BINARY_DIR}/dora/src/Dora/target/debug)
+
+    add_custom_target(Dora_cxx DEPENDS ${node_bridge} ${dora_cxx_include_dir})
+endif()
+
+link_directories(${dora_link_dirs})
+
+add_executable(___name___ node.cc ${node_bridge})
+add_dependencies(___name___ Dora_cxx)
+target_include_directories(___name___ PRIVATE ${dora_cxx_include_dir})
+
+if(WIN32)
+    target_link_libraries(___name___ dora_node_api_cxx ws2_32 userenv ntdll bcrypt)
+else()
+    target_link_libraries(___name___ dora_node_api_cxx z)
+endif()
+
+install(TARGETS ___name___ DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/bin)


### PR DESCRIPTION
## Summary
Generate a cross-platform CMakeLists.txt when scaffolding standalone C and C++ nodes via dora new --kind node.

## Problem
Running dora new --kind node --lang c or --lang cxx produced only the source files but no build file. There was a // TODO: Makefile? left in both template modules. Users had to write their own build setup manually.

## Solution
Added a per-node CMakeLists.txt template for both C and C++ nodes. Uses CMake (not Makefile) to stay consistent with the existing dataflow templates. The templates are cross-platform — they use cmake -E commands instead of Unix-only cp/mkdir -p, and conditionally link platform-specific libraries (Unix: m z, Windows: ws2_32 userenv ntdll bcrypt).

## Testing
- [x] cargo build -p dora-cli compiles without errors
- [x] cargo clippy -p dora-cli --no-deps produces no new warnings
- [x] Scaffolding a standalone C/C++ node now outputs CMakeLists.txt alongside source files
- [x] Dataflow scaffolding is unaffected

## Changes
New:  `binaries/cli/src/template/c/node-cmake-template.txt`
New: `binaries/cli/src/template/cxx/node-cmake-template.txt`
Modified: `binaries/cli/src/template/c/mod.rs`  added create_node_cmakefile() , removed TODO
Modified: `binaries/cli/src/template/cxx/mod.rs` added create_node_cmakefile() , removed TODO