### PR TITLE
Prototype Dora-managed Python isolation for build and runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,20 @@ jobs:
       - name: Free disk Space (Windows)
         if: runner.os == 'Windows'
         run: |
-          $ErrorActionPreference = 'SilentlyContinue'
-          docker system prune --all -f 2>$null; $true
-          docker builder prune -af 2>$null; $true
+          if (Get-Command docker -ErrorAction SilentlyContinue) {
+            docker system prune --all -f 2>$null
+            if ($LASTEXITCODE -ne 0) {
+              Write-Host "docker system prune failed; continuing with Windows cleanup"
+              $global:LASTEXITCODE = 0
+            }
+            docker builder prune -af 2>$null
+            if ($LASTEXITCODE -ne 0) {
+              Write-Host "docker builder prune failed; continuing with Windows cleanup"
+              $global:LASTEXITCODE = 0
+            }
+          } else {
+            Write-Host "docker is not available; skipping docker cleanup"
+          }
           Remove-Item "C:\Android" -Force -Recurse -ErrorAction SilentlyContinue
           Remove-Item "C:\hostedtoolcache\windows\Ruby" -Force -Recurse -ErrorAction SilentlyContinue
           Remove-Item "C:\hostedtoolcache\windows\go" -Force -Recurse -ErrorAction SilentlyContinue
@@ -129,9 +140,20 @@ jobs:
       - name: Free disk Space (Windows)
         if: runner.os == 'Windows'
         run: |
-          $ErrorActionPreference = 'SilentlyContinue'
-          docker system prune --all -f 2>$null; $true
-          docker builder prune -af 2>$null; $true
+          if (Get-Command docker -ErrorAction SilentlyContinue) {
+            docker system prune --all -f 2>$null
+            if ($LASTEXITCODE -ne 0) {
+              Write-Host "docker system prune failed; continuing with Windows cleanup"
+              $global:LASTEXITCODE = 0
+            }
+            docker builder prune -af 2>$null
+            if ($LASTEXITCODE -ne 0) {
+              Write-Host "docker builder prune failed; continuing with Windows cleanup"
+              $global:LASTEXITCODE = 0
+            }
+          } else {
+            Write-Host "docker is not available; skipping docker cleanup"
+          }
           Remove-Item "C:\Android" -Force -Recurse -ErrorAction SilentlyContinue
           Remove-Item "C:\hostedtoolcache\windows\Ruby" -Force -Recurse -ErrorAction SilentlyContinue
           Remove-Item "C:\hostedtoolcache\windows\go" -Force -Recurse -ErrorAction SilentlyContinue

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,7 +440,16 @@ jobs:
 
           # Check Compliancy
           uv run ruff check .
-          uv run pytest
+          # The workspace root is not a Python package project; each generated node package owns
+          # its own Python sources and tests. Run them from the package directory instead of
+          # relying on `dora build --uv` to install editable packages into the outer CI env.
+          for node in talker-1 talker-2 listener-1; do
+            echo "Running pytest for ${node}"
+            (
+              cd "${node}"
+              PYTHONPATH="$PWD" uv run --active python -m pytest .
+            )
+          done
 
           export OPERATING_MODE=SAVE
           dora build dataflow.yml --uv

--- a/binaries/cli/src/command/build/local.rs
+++ b/binaries/cli/src/command/build/local.rs
@@ -67,13 +67,17 @@ async fn build_dataflow(
 
     let mut info = BuildInfo {
         node_working_dirs: Default::default(),
+        python_env_dirs: Default::default(),
     };
     for (node_id, task) in tasks {
         let node = task
             .await
             .with_context(|| format!("failed to build node `{node_id}`"))?;
         info.node_working_dirs
-            .insert(node_id, node.node_working_dir);
+            .insert(node_id.clone(), node.node_working_dir);
+        if let Some(python_env_dir) = node.python_env_dir {
+            info.python_env_dirs.insert(node_id, python_env_dir);
+        }
     }
     Ok(info)
 }

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1033,9 +1033,13 @@ impl Daemon {
                 )
             }
         }
-        let node_working_dirs = build_info
-            .map(|info| info.node_working_dirs.clone())
+        // Reuse build-time metadata so runtime spawn can follow the same
+        // working-directory and managed-env decisions.
+        let (node_working_dirs, python_env_dirs) = build_info
+            .as_ref()
+            .map(|info| (info.node_working_dirs.clone(), info.python_env_dirs.clone()))
             .unwrap_or_default();
+        drop(build_info);
 
         // calculate info about mappings
         for node in nodes.values() {
@@ -1121,11 +1125,15 @@ impl Daemon {
                 let node_write_events_to = write_events_to
                     .as_ref()
                     .map(|p| p.join(format!("inputs-{}.json", node.id)));
+                // Thread the managed env path through spawn now; later runtime
+                // slices decide which Python launch paths consume it.
+                let configured_python_env_dir = python_env_dirs.get(&node_id).cloned();
                 match spawner
                     .clone()
                     .spawn_node(
                         node,
                         node_working_dir,
+                        configured_python_env_dir,
                         node_stderr_most_recent,
                         node_write_events_to,
                         &mut logger,

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -2532,6 +2532,7 @@ impl Daemon {
         let task = async move {
             let mut info = BuildInfo {
                 node_working_dirs: Default::default(),
+                python_env_dirs: Default::default(),
             };
             for task in tasks {
                 let NodeBuildTask {
@@ -2543,7 +2544,10 @@ impl Daemon {
                     .await
                     .with_context(|| format!("failed to build node `{node_id}`"))?;
                 info.node_working_dirs
-                    .insert(node_id, node.node_working_dir);
+                    .insert(node_id.clone(), node.node_working_dir);
+                if let Some(python_env_dir) = node.python_env_dir {
+                    info.python_env_dirs.insert(node_id, python_env_dir);
+                }
             }
             Ok(info)
         };

--- a/binaries/daemon/src/spawn/command.rs
+++ b/binaries/daemon/src/spawn/command.rs
@@ -59,7 +59,9 @@ pub(super) async fn path_spawn_command(
             let mut cmd = match resolved_path.extension().map(|ext| ext.to_str()) {
                 Some(Some("py")) => {
                     let mut cmd = if uv {
-                        if let Some(python_env_dir) = python_env_dir {
+                        if let Some(python_env_dir) =
+                            python_env_dir.filter(|_| node.build.is_some())
+                        {
                             // Reuse the interpreter from Dora's prepared env so
                             // custom Python nodes see the dependencies built there.
                             let python = managed_python_interpreter(python_env_dir);
@@ -82,6 +84,8 @@ pub(super) async fn path_spawn_command(
                                 .await;
                             Command::new(python)
                         } else {
+                            // Nodes without build-time Python setup still rely on
+                            // the caller's active uv environment for imports.
                             let mut cmd = Command::new("uv");
                             cmd = cmd.arg("run");
                             cmd = cmd.arg("python");

--- a/binaries/daemon/src/spawn/command.rs
+++ b/binaries/daemon/src/spawn/command.rs
@@ -1,5 +1,6 @@
 use crate::log::NodeLogger;
 use clonable_command::Command;
+use dora_core::build::managed_python_interpreter;
 use dora_core::{
     descriptor::{DYNAMIC_SOURCE, SHELL_SOURCE, resolve_path, source_is_url},
     get_python_path,
@@ -12,6 +13,7 @@ use std::path::Path;
 pub(super) async fn path_spawn_command(
     working_dir: &Path,
     uv: bool,
+    python_env_dir: Option<&Path>,
     logger: &mut NodeLogger<'_>,
     node: &dora_core::descriptor::CustomNode,
     permit_url: bool,
@@ -57,17 +59,44 @@ pub(super) async fn path_spawn_command(
             let mut cmd = match resolved_path.extension().map(|ext| ext.to_str()) {
                 Some(Some("py")) => {
                     let mut cmd = if uv {
-                        let mut cmd = Command::new("uv");
-                        cmd = cmd.arg("run");
-                        cmd = cmd.arg("python");
-                        logger
-                            .log(
-                                LogLevel::Info,
-                                Some("spawner".into()),
-                                format!("spawning: uv run python -u {}", resolved_path.display()),
-                            )
-                            .await;
-                        cmd
+                        if let Some(python_env_dir) = python_env_dir {
+                            // Reuse the interpreter from Dora's prepared env so
+                            // custom Python nodes see the dependencies built there.
+                            let python = managed_python_interpreter(python_env_dir);
+                            if !python.is_file() {
+                                eyre::bail!(
+                                    "managed Python interpreter `{}` is missing",
+                                    python.display()
+                                );
+                            }
+                            logger
+                                .log(
+                                    LogLevel::Info,
+                                    Some("spawner".into()),
+                                    format!(
+                                        "spawning managed Python {} -u {}",
+                                        python.display(),
+                                        resolved_path.display()
+                                    ),
+                                )
+                                .await;
+                            Command::new(python)
+                        } else {
+                            let mut cmd = Command::new("uv");
+                            cmd = cmd.arg("run");
+                            cmd = cmd.arg("python");
+                            logger
+                                .log(
+                                    LogLevel::Info,
+                                    Some("spawner".into()),
+                                    format!(
+                                        "spawning: uv run python -u {}",
+                                        resolved_path.display()
+                                    ),
+                                )
+                                .await;
+                            cmd
+                        }
                     } else {
                         let python = get_python_path()
                             .wrap_err("Could not find python path when spawning custom node")?;

--- a/binaries/daemon/src/spawn/spawner.rs
+++ b/binaries/daemon/src/spawn/spawner.rs
@@ -8,6 +8,7 @@ use crate::{
 use clonable_command::{Command, Stdio};
 use crossbeam::queue::ArrayQueue;
 use dora_core::{
+    build::managed_python_interpreter,
     descriptor::{Descriptor, OperatorDefinition, OperatorSource, PythonSource, ResolvedNode},
     get_python_path,
     uhlc::HLC,
@@ -213,14 +214,32 @@ impl Spawner {
                         Some(command)
                     } else {
                         let mut cmd = if self.uv {
-                            let mut cmd = Command::new("uv");
-                            cmd = cmd.arg("run");
-                            cmd = cmd.arg("python");
-                            tracing::info!(
-                                "spawning: uv run python -uc import dora; dora.start_runtime() # {}",
-                                node.id
-                            );
-                            cmd
+                            if let Some(python_env_dir) = python_env_dir.as_deref() {
+                                // Reuse the managed interpreter so Python operators run
+                                // against the same environment Dora prepared during build.
+                                let python = managed_python_interpreter(python_env_dir);
+                                if !python.is_file() {
+                                    eyre::bail!(
+                                        "managed Python interpreter `{}` is missing",
+                                        python.display()
+                                    );
+                                }
+                                tracing::info!(
+                                    "spawning managed Python {} -uc import dora; dora.start_runtime() # {}",
+                                    python.display(),
+                                    node.id
+                                );
+                                Command::new(python)
+                            } else {
+                                let mut cmd = Command::new("uv");
+                                cmd = cmd.arg("run");
+                                cmd = cmd.arg("python");
+                                tracing::info!(
+                                    "spawning: uv run python -uc import dora; dora.start_runtime() # {}",
+                                    node.id
+                                );
+                                cmd
+                            }
                         } else {
                             let python = get_python_path()
                                 .wrap_err("Could not find python path when spawning custom node")?;

--- a/binaries/daemon/src/spawn/spawner.rs
+++ b/binaries/daemon/src/spawn/spawner.rs
@@ -37,6 +37,7 @@ impl Spawner {
         self,
         node: ResolvedNode,
         node_working_dir: PathBuf,
+        python_env_dir: Option<PathBuf>,
         node_stderr_most_recent: Arc<ArrayQueue<String>>,
         write_events_to: Option<PathBuf>,
         logger: &mut NodeLogger<'_>,
@@ -85,6 +86,7 @@ impl Spawner {
                 .prepare_node_inner(
                     node,
                     node_working_dir,
+                    python_env_dir,
                     &mut logger,
                     dataflow_id,
                     node_config,
@@ -101,6 +103,7 @@ impl Spawner {
         self,
         node: ResolvedNode,
         node_working_dir: PathBuf,
+        python_env_dir: Option<PathBuf>,
         logger: &mut NodeLogger<'_>,
         dataflow_id: uuid::Uuid,
         node_config: NodeConfig,
@@ -110,8 +113,17 @@ impl Spawner {
             .context("failed to create node working directory")?;
         let (command, error_msg) = match &node.kind {
             dora_core::descriptor::CoreNodeKind::Custom(n) => {
-                let command =
-                    path_spawn_command(&node_working_dir, self.uv, logger, n, true).await?;
+                // Custom nodes build their command line here; pass the managed
+                // env path through so Python scripts can opt into it under --uv.
+                let command = path_spawn_command(
+                    &node_working_dir,
+                    self.uv,
+                    python_env_dir.as_deref(),
+                    logger,
+                    n,
+                    true,
+                )
+                .await?;
 
                 let command = if let Some(mut command) = command {
                     command = command.current_dir(&node_working_dir);

--- a/libraries/core/src/build/build_command.rs
+++ b/libraries/core/src/build/build_command.rs
@@ -145,21 +145,84 @@ pub async fn prepare_managed_python_env(
     if let Some(parent) = python_env_dir.parent() {
         std::fs::create_dir_all(parent).context("failed to create Python env parent dir")?;
     }
-    if managed_python_interpreter(python_env_dir).is_file() {
+    if !managed_python_interpreter(python_env_dir).is_file() {
+        let mut cmd = Command::new("uv");
+        cmd.arg("venv");
+        cmd.arg("--clear");
+        cmd.arg(python_env_dir);
+
+        if let Some(envs) = envs {
+            for (key, value) in envs {
+                cmd.env(key, value.to_string());
+            }
+        }
+
+        cmd.current_dir(dunce::simplified(working_dir));
+        cmd.stdin(Stdio::null());
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+        cmd.env("CLICOLOR", "1");
+        cmd.env("CLICOLOR_FORCE", "1");
+
+        let mut child = cmd
+            .spawn()
+            .wrap_err_with(|| format!("failed to spawn `uv venv {}`", python_env_dir.display()))?;
+
+        let child_stdout = BufReader::new(child.stdout.take().expect("failed to take stdout"));
+        let child_stderr = BufReader::new(child.stderr.take().expect("failed to take stderr"));
+        let stdout_tx = stdout_tx.clone();
+
+        tokio::spawn(async move {
+            forward_build_output(child_stdout, child_stderr, stdout_tx).await;
+        });
+
+        let exit_status = child
+            .wait()
+            .await
+            .wrap_err_with(|| format!("failed to run `uv venv {}`", python_env_dir.display()))?;
+        if !exit_status.success() {
+            return Err(eyre!(
+                "managed Python env preparation `{}` returned {exit_status}",
+                python_env_dir.display()
+            ));
+        }
+    }
+
+    ensure_managed_python_runtime(working_dir, python_env_dir, envs, stdout_tx).await
+}
+
+async fn ensure_managed_python_runtime(
+    working_dir: &Path,
+    python_env_dir: &Path,
+    envs: &Option<BTreeMap<String, EnvValue>>,
+    stdout_tx: tokio::sync::mpsc::Sender<std::io::Result<String>>,
+) -> eyre::Result<()> {
+    if managed_python_can_import_dora(working_dir, python_env_dir, envs).await? {
         return Ok(());
     }
 
+    // Prefer the local workspace package so the managed env runs against the
+    // Dora Python API from this checkout when it is available.
     let mut cmd = Command::new("uv");
-    cmd.arg("venv");
-    cmd.arg("--clear");
-    cmd.arg(python_env_dir);
+    cmd.arg("pip");
+    cmd.arg("install");
+    match local_dora_python_package_dir(working_dir) {
+        Some(package_dir) => {
+            cmd.arg("-e");
+            cmd.arg(package_dir);
+        }
+        None => {
+            cmd.arg(format!("dora-rs=={}", env!("CARGO_PKG_VERSION")));
+        }
+    }
 
     if let Some(envs) = envs {
         for (key, value) in envs {
             cmd.env(key, value.to_string());
         }
     }
-
+    apply_managed_python_env(&mut cmd, python_env_dir, envs)
+        .context("failed to target managed env for Dora runtime install")?;
     cmd.current_dir(dunce::simplified(working_dir));
     cmd.stdin(Stdio::null());
     cmd.stdout(Stdio::piped());
@@ -167,9 +230,12 @@ pub async fn prepare_managed_python_env(
     cmd.env("CLICOLOR", "1");
     cmd.env("CLICOLOR_FORCE", "1");
 
-    let mut child = cmd
-        .spawn()
-        .wrap_err_with(|| format!("failed to spawn `uv venv {}`", python_env_dir.display()))?;
+    let mut child = cmd.spawn().wrap_err_with(|| {
+        format!(
+            "failed to spawn Dora runtime install into `{}`",
+            python_env_dir.display()
+        )
+    })?;
 
     let child_stdout = BufReader::new(child.stdout.take().expect("failed to take stdout"));
     let child_stderr = BufReader::new(child.stderr.take().expect("failed to take stderr"));
@@ -178,18 +244,55 @@ pub async fn prepare_managed_python_env(
         forward_build_output(child_stdout, child_stderr, stdout_tx).await;
     });
 
-    let exit_status = child
-        .wait()
-        .await
-        .wrap_err_with(|| format!("failed to run `uv venv {}`", python_env_dir.display()))?;
+    let exit_status = child.wait().await.wrap_err_with(|| {
+        format!(
+            "failed to install Dora runtime into `{}`",
+            python_env_dir.display()
+        )
+    })?;
     if !exit_status.success() {
         return Err(eyre!(
-            "managed Python env preparation `{}` returned {exit_status}",
+            "managed Python runtime installation `{}` returned {exit_status}",
             python_env_dir.display()
         ));
     }
 
     Ok(())
+}
+
+async fn managed_python_can_import_dora(
+    working_dir: &Path,
+    python_env_dir: &Path,
+    envs: &Option<BTreeMap<String, EnvValue>>,
+) -> eyre::Result<bool> {
+    let interpreter = managed_python_interpreter(python_env_dir);
+    let mut cmd = Command::new(&interpreter);
+    apply_managed_python_env(&mut cmd, python_env_dir, envs)
+        .context("failed to target managed env for Dora runtime probe")?;
+    cmd.arg("-c");
+    cmd.arg("import dora");
+    cmd.current_dir(dunce::simplified(working_dir));
+    cmd.stdin(Stdio::null());
+    cmd.stdout(Stdio::null());
+    cmd.stderr(Stdio::null());
+
+    let exit_status = cmd.status().await.wrap_err_with(|| {
+        format!(
+            "failed to probe Dora runtime in `{}`",
+            python_env_dir.display()
+        )
+    })?;
+    Ok(exit_status.success())
+}
+
+fn local_dora_python_package_dir(working_dir: &Path) -> Option<PathBuf> {
+    working_dir.ancestors().find_map(|dir| {
+        let package_dir = dir.join("apis").join("python").join("node");
+        package_dir
+            .join("pyproject.toml")
+            .is_file()
+            .then_some(package_dir)
+    })
 }
 
 async fn forward_build_output<R1, R2>(
@@ -212,14 +315,15 @@ async fn forward_build_output<R1, R2>(
 #[cfg(test)]
 mod tests {
     use super::{
-        forward_build_output, managed_python_path, prepare_managed_python_env, run_build_command,
+        forward_build_output, local_dora_python_package_dir, managed_python_path,
+        prepare_managed_python_env, run_build_command,
     };
     use crate::build::{managed_python_bin_dir, managed_python_interpreter};
     use dora_message::descriptor::EnvValue;
     use std::{
         collections::BTreeMap,
         fs,
-        path::PathBuf,
+        path::{Path, PathBuf},
         time::{SystemTime, UNIX_EPOCH},
     };
     use tempfile::tempdir;
@@ -379,17 +483,14 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .expect("system time should be after unix epoch")
             .as_nanos();
-        let temp_root = std::env::temp_dir().join(format!("dora-managed-python-env-test-{unique}"));
+        let temp_root =
+            std::env::temp_dir().join(format!("dora-managed-python-env-test-{unique}"));
         let working_dir = temp_root.join("workdir");
         let env_dir = temp_root.join("env");
         let interpreter = managed_python_interpreter(&env_dir);
 
-        std::fs::create_dir_all(
-            interpreter
-                .parent()
-                .expect("interpreter should have parent"),
-        )
-        .expect("failed to create fake env dir");
+        std::fs::create_dir_all(interpreter.parent().expect("interpreter should have parent"))
+            .expect("failed to create fake env dir");
         std::fs::write(&interpreter, b"").expect("failed to create fake interpreter");
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
@@ -398,12 +499,38 @@ mod tests {
             .expect("existing interpreter should be reused without error");
 
         assert!(interpreter.is_file());
-        assert!(
-            rx.try_recv().is_err(),
-            "reused env should not emit build output"
-        );
+        assert!(rx.try_recv().is_err(), "reused env should not emit build output");
 
         let _ = std::fs::remove_dir_all(&temp_root);
+    }
+
+    #[test]
+    fn local_dora_python_package_dir_finds_workspace_package() {
+        let working_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("src")
+            .join("build");
+        let package_dir =
+            local_dora_python_package_dir(&working_dir).expect("workspace package should exist");
+
+        assert!(package_dir.ends_with(Path::new("apis").join("python").join("node")));
+        assert!(package_dir.join("pyproject.toml").is_file());
+    }
+
+    #[test]
+    fn local_dora_python_package_dir_returns_none_outside_workspace() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after unix epoch")
+            .as_nanos();
+        let outside_dir = std::env::temp_dir().join(format!("dora-non-workspace-test-{unique}"));
+        std::fs::create_dir_all(&outside_dir).expect("failed to create temp dir");
+
+        assert!(
+            local_dora_python_package_dir(&outside_dir).is_none(),
+            "outside dirs should not resolve a workspace package"
+        );
+
+        let _ = std::fs::remove_dir_all(&outside_dir);
     }
 
     #[test]

--- a/libraries/core/src/build/build_command.rs
+++ b/libraries/core/src/build/build_command.rs
@@ -494,7 +494,15 @@ mod tests {
                 .expect("interpreter should have parent"),
         )
         .expect("failed to create fake env dir");
-        std::fs::write(&interpreter, b"").expect("failed to create fake interpreter");
+        let stub_source = temp_root.join("fake_python.rs");
+        std::fs::write(&stub_source, "fn main() {}\n").expect("failed to write fake interpreter");
+        let status = std::process::Command::new("rustc")
+            .arg(&stub_source)
+            .arg("-o")
+            .arg(&interpreter)
+            .status()
+            .expect("failed to run rustc for fake interpreter");
+        assert!(status.success(), "failed to compile fake interpreter");
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
         prepare_managed_python_env(&working_dir, &env_dir, &None, tx)

--- a/libraries/core/src/build/build_command.rs
+++ b/libraries/core/src/build/build_command.rs
@@ -483,14 +483,17 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .expect("system time should be after unix epoch")
             .as_nanos();
-        let temp_root =
-            std::env::temp_dir().join(format!("dora-managed-python-env-test-{unique}"));
+        let temp_root = std::env::temp_dir().join(format!("dora-managed-python-env-test-{unique}"));
         let working_dir = temp_root.join("workdir");
         let env_dir = temp_root.join("env");
         let interpreter = managed_python_interpreter(&env_dir);
 
-        std::fs::create_dir_all(interpreter.parent().expect("interpreter should have parent"))
-            .expect("failed to create fake env dir");
+        std::fs::create_dir_all(
+            interpreter
+                .parent()
+                .expect("interpreter should have parent"),
+        )
+        .expect("failed to create fake env dir");
         std::fs::write(&interpreter, b"").expect("failed to create fake interpreter");
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
@@ -499,7 +502,10 @@ mod tests {
             .expect("existing interpreter should be reused without error");
 
         assert!(interpreter.is_file());
-        assert!(rx.try_recv().is_err(), "reused env should not emit build output");
+        assert!(
+            rx.try_recv().is_err(),
+            "reused env should not emit build output"
+        );
 
         let _ = std::fs::remove_dir_all(&temp_root);
     }

--- a/libraries/core/src/build/build_command.rs
+++ b/libraries/core/src/build/build_command.rs
@@ -1,3 +1,4 @@
+use crate::build::managed_python_interpreter;
 use std::{collections::BTreeMap, path::Path, process::Stdio};
 
 use dora_message::descriptor::EnvValue;
@@ -80,6 +81,63 @@ pub async fn run_build_command(
     Ok(())
 }
 
+pub async fn prepare_managed_python_env(
+    working_dir: &Path,
+    python_env_dir: &Path,
+    envs: &Option<BTreeMap<String, EnvValue>>,
+    stdout_tx: tokio::sync::mpsc::Sender<std::io::Result<String>>,
+) -> eyre::Result<()> {
+    std::fs::create_dir_all(working_dir).context("failed to create working directory")?;
+    if let Some(parent) = python_env_dir.parent() {
+        std::fs::create_dir_all(parent).context("failed to create Python env parent dir")?;
+    }
+    if managed_python_interpreter(python_env_dir).is_file() {
+        return Ok(());
+    }
+
+    let mut cmd = Command::new("uv");
+    cmd.arg("venv");
+    cmd.arg("--clear");
+    cmd.arg(python_env_dir);
+
+    if let Some(envs) = envs {
+        for (key, value) in envs {
+            cmd.env(key, value.to_string());
+        }
+    }
+
+    cmd.current_dir(dunce::simplified(working_dir));
+    cmd.stdin(Stdio::null());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    cmd.env("CLICOLOR", "1");
+    cmd.env("CLICOLOR_FORCE", "1");
+
+    let mut child = cmd
+        .spawn()
+        .wrap_err_with(|| format!("failed to spawn `uv venv {}`", python_env_dir.display()))?;
+
+    let child_stdout = BufReader::new(child.stdout.take().expect("failed to take stdout"));
+    let child_stderr = BufReader::new(child.stderr.take().expect("failed to take stderr"));
+
+    tokio::spawn(async move {
+        forward_build_output(child_stdout, child_stderr, stdout_tx).await;
+    });
+
+    let exit_status = child
+        .wait()
+        .await
+        .wrap_err_with(|| format!("failed to run `uv venv {}`", python_env_dir.display()))?;
+    if !exit_status.success() {
+        return Err(eyre!(
+            "managed Python env preparation `{}` returned {exit_status}",
+            python_env_dir.display()
+        ));
+    }
+
+    Ok(())
+}
+
 async fn forward_build_output<R1, R2>(
     stdout: R1,
     stderr: R2,
@@ -99,7 +157,8 @@ async fn forward_build_output<R1, R2>(
 
 #[cfg(test)]
 mod tests {
-    use super::{forward_build_output, run_build_command};
+    use super::{forward_build_output, prepare_managed_python_env, run_build_command};
+    use crate::build::managed_python_interpreter;
     use dora_message::descriptor::EnvValue;
     use std::{
         collections::BTreeMap,
@@ -254,6 +313,33 @@ mod tests {
         .unwrap_err();
 
         assert!(err.to_string().contains("build command is empty"));
+    }
+
+    #[tokio::test]
+    async fn prepare_managed_python_env_reuses_existing_interpreter() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after unix epoch")
+            .as_nanos();
+        let temp_root =
+            std::env::temp_dir().join(format!("dora-managed-python-env-test-{unique}"));
+        let working_dir = temp_root.join("workdir");
+        let env_dir = temp_root.join("env");
+        let interpreter = managed_python_interpreter(&env_dir);
+
+        std::fs::create_dir_all(interpreter.parent().expect("interpreter should have parent"))
+            .expect("failed to create fake env dir");
+        std::fs::write(&interpreter, b"").expect("failed to create fake interpreter");
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        prepare_managed_python_env(&working_dir, &env_dir, &None, tx)
+            .await
+            .expect("existing interpreter should be reused without error");
+
+        assert!(interpreter.is_file());
+        assert!(rx.try_recv().is_err(), "reused env should not emit build output");
+
+        let _ = std::fs::remove_dir_all(&temp_root);
     }
 
     fn test_working_dir() -> PathBuf {

--- a/libraries/core/src/build/build_command.rs
+++ b/libraries/core/src/build/build_command.rs
@@ -1,5 +1,10 @@
-use crate::build::managed_python_interpreter;
-use std::{collections::BTreeMap, path::Path, process::Stdio};
+use crate::build::{managed_python_bin_dir, managed_python_interpreter};
+use std::{
+    collections::BTreeMap,
+    ffi::OsString,
+    path::{Path, PathBuf},
+    process::Stdio,
+};
 
 use dora_message::descriptor::EnvValue;
 use eyre::{Context, eyre};
@@ -13,6 +18,7 @@ pub async fn run_build_command(
     build: &str,
     working_dir: &Path,
     uv: bool,
+    python_env_dir: Option<PathBuf>,
     envs: &Option<BTreeMap<String, EnvValue>>,
     stdout_tx: tokio::sync::mpsc::Sender<std::io::Result<String>>,
 ) -> eyre::Result<()> {
@@ -48,6 +54,12 @@ pub async fn run_build_command(
                 cmd.env(key, value);
             }
         }
+        if uv {
+            if let Some(python_env_dir) = &python_env_dir {
+                apply_managed_python_env(&mut cmd, python_env_dir, envs)
+                    .context("failed to apply managed Python env")?;
+            }
+        }
 
         cmd.current_dir(dunce::simplified(working_dir));
 
@@ -79,6 +91,48 @@ pub async fn run_build_command(
         }
     }
     Ok(())
+}
+
+fn apply_managed_python_env(
+    cmd: &mut Command,
+    python_env_dir: &Path,
+    envs: &Option<BTreeMap<String, EnvValue>>,
+) -> eyre::Result<()> {
+    let interpreter = managed_python_interpreter(python_env_dir);
+    // Fail closed here: if the managed interpreter is missing, falling through to the ambient
+    // PATH could silently pick a different Python than the one Dora prepared for this node.
+    if !interpreter.is_file() {
+        return Err(eyre!(
+            "managed Python interpreter `{}` is missing; run Dora's Python env preparation first",
+            interpreter.display()
+        ));
+    }
+    cmd.env("VIRTUAL_ENV", python_env_dir);
+    if let Some(path) = managed_python_path(python_env_dir, envs)? {
+        cmd.env("PATH", path);
+    }
+    Ok(())
+}
+
+fn managed_python_path(
+    python_env_dir: &Path,
+    envs: &Option<BTreeMap<String, EnvValue>>,
+) -> eyre::Result<Option<OsString>> {
+    // Prepend the managed env so `python`/`pip` resolve there before any machine-level entries.
+    let mut paths = vec![managed_python_bin_dir(python_env_dir)];
+    let base_path = envs
+        .as_ref()
+        .and_then(|envs| envs.get("PATH"))
+        .map(|value| OsString::from(value.to_string()))
+        .or_else(|| std::env::var_os("PATH"));
+
+    if let Some(base_path) = base_path {
+        paths.extend(std::env::split_paths(&base_path));
+    }
+
+    std::env::join_paths(paths)
+        .map(Some)
+        .wrap_err("failed to compose managed Python PATH")
 }
 
 pub async fn prepare_managed_python_env(
@@ -157,8 +211,10 @@ async fn forward_build_output<R1, R2>(
 
 #[cfg(test)]
 mod tests {
-    use super::{forward_build_output, prepare_managed_python_env, run_build_command};
-    use crate::build::managed_python_interpreter;
+    use super::{
+        forward_build_output, managed_python_path, prepare_managed_python_env, run_build_command,
+    };
+    use crate::build::{managed_python_bin_dir, managed_python_interpreter};
     use dora_message::descriptor::EnvValue;
     use std::{
         collections::BTreeMap,
@@ -257,7 +313,7 @@ mod tests {
         let envs = Some(BTreeMap::new());
         let (stdout_tx, _stdout_rx) = tokio::sync::mpsc::channel(4);
 
-        let err = run_build_command(&build, &working_dir, false, &envs, stdout_tx)
+        let err = run_build_command(&build, &working_dir, false, None, &envs, stdout_tx)
             .await
             .expect_err("missing executable should fail");
         let msg = format!("{err:#}");
@@ -280,6 +336,7 @@ mod tests {
             "cargo --version\n\ncargo --version\n",
             working_dir.path(),
             false,
+            None,
             &None::<BTreeMap<String, EnvValue>>,
             tx,
         )
@@ -306,6 +363,7 @@ mod tests {
             "\n   \n",
             working_dir.path(),
             false,
+            None,
             &None::<BTreeMap<String, EnvValue>>,
             tx,
         )
@@ -343,6 +401,57 @@ mod tests {
         assert!(
             rx.try_recv().is_err(),
             "reused env should not emit build output"
+        );
+
+        let _ = std::fs::remove_dir_all(&temp_root);
+    }
+
+    #[test]
+    fn managed_python_path_prepends_bin_dir_to_path() {
+        let env_dir = PathBuf::from("managed-env");
+        let path_sep = if cfg!(windows) { ";" } else { ":" };
+        let mut envs = BTreeMap::new();
+        envs.insert(
+            "PATH".to_owned(),
+            EnvValue::String(format!("base-one{path_sep}base-two")),
+        );
+
+        let path = managed_python_path(&env_dir, &Some(envs))
+            .expect("path composition should succeed")
+            .expect("path should be set");
+        let paths: Vec<_> = std::env::split_paths(&path).collect();
+
+        assert_eq!(paths[0], managed_python_bin_dir(&env_dir));
+        assert_eq!(paths[1], PathBuf::from("base-one"));
+        assert_eq!(paths[2], PathBuf::from("base-two"));
+    }
+
+    #[tokio::test]
+    async fn run_build_command_errors_if_managed_env_is_missing() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after unix epoch")
+            .as_nanos();
+        let temp_root =
+            std::env::temp_dir().join(format!("dora-managed-python-missing-env-test-{unique}"));
+        let working_dir = temp_root.join("workdir");
+        let env_dir = temp_root.join("env");
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+
+        let err = run_build_command(
+            "python --version",
+            &working_dir,
+            true,
+            Some(env_dir),
+            &None,
+            tx,
+        )
+        .await
+        .expect_err("missing managed env should fail before spawning build command");
+
+        assert!(
+            format!("{err:#}").contains("managed Python interpreter"),
+            "unexpected error: {err:#}"
         );
 
         let _ = std::fs::remove_dir_all(&temp_root);

--- a/libraries/core/src/build/build_command.rs
+++ b/libraries/core/src/build/build_command.rs
@@ -321,14 +321,17 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .expect("system time should be after unix epoch")
             .as_nanos();
-        let temp_root =
-            std::env::temp_dir().join(format!("dora-managed-python-env-test-{unique}"));
+        let temp_root = std::env::temp_dir().join(format!("dora-managed-python-env-test-{unique}"));
         let working_dir = temp_root.join("workdir");
         let env_dir = temp_root.join("env");
         let interpreter = managed_python_interpreter(&env_dir);
 
-        std::fs::create_dir_all(interpreter.parent().expect("interpreter should have parent"))
-            .expect("failed to create fake env dir");
+        std::fs::create_dir_all(
+            interpreter
+                .parent()
+                .expect("interpreter should have parent"),
+        )
+        .expect("failed to create fake env dir");
         std::fs::write(&interpreter, b"").expect("failed to create fake interpreter");
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
@@ -337,7 +340,10 @@ mod tests {
             .expect("existing interpreter should be reused without error");
 
         assert!(interpreter.is_file());
-        assert!(rx.try_recv().is_err(), "reused env should not emit build output");
+        assert!(
+            rx.try_recv().is_err(),
+            "reused env should not emit build output"
+        );
 
         let _ = std::fs::remove_dir_all(&temp_root);
     }

--- a/libraries/core/src/build/mod.rs
+++ b/libraries/core/src/build/mod.rs
@@ -82,11 +82,13 @@ impl Builder {
                     }
                     None => self.base_working_dir,
                 };
-                python_env_dir = managed_python_env_dir(&node, &node_working_dir);
+                python_env_dir =
+                    managed_python_env_dir(&node, &node_working_dir).filter(|_| n.build.is_some());
                 if self.uv {
                     if let Some(python_env_dir) = &python_env_dir {
-                        // Materialize Dora's managed Python env before any build commands run so
-                        // later `pip`/`python` resolution does not drift to ambient machine state.
+                        // Only build-backed custom Python nodes use Dora's managed env today, so
+                        // skip preparing one for script-only nodes that still run in the caller's
+                        // ambient uv environment.
                         prepare_python_env(
                             logger,
                             &node.env,

--- a/libraries/core/src/build/mod.rs
+++ b/libraries/core/src/build/mod.rs
@@ -85,6 +85,8 @@ impl Builder {
                 python_env_dir = managed_python_env_dir(&node, &node_working_dir);
                 if self.uv {
                     if let Some(python_env_dir) = &python_env_dir {
+                        // Materialize Dora's managed Python env before any build commands run so
+                        // later `pip`/`python` resolution does not drift to ambient machine state.
                         prepare_python_env(
                             logger,
                             &node.env,
@@ -96,7 +98,15 @@ impl Builder {
                 }
 
                 if let Some(build) = &n.build {
-                    build_node(logger, &node.env, node_working_dir.clone(), build, self.uv).await?;
+                    build_node(
+                        logger,
+                        &node.env,
+                        node_working_dir.clone(),
+                        build,
+                        self.uv,
+                        python_env_dir.clone(),
+                    )
+                    .await?;
                 }
                 node_working_dir
             }
@@ -104,6 +114,8 @@ impl Builder {
                 python_env_dir = managed_python_env_dir(&node, &self.base_working_dir);
                 if self.uv {
                     if let Some(python_env_dir) = &python_env_dir {
+                        // Runtime nodes use one managed Python env per node; prepare it once before
+                        // running any Python operator build commands.
                         prepare_python_env(
                             logger,
                             &node.env,
@@ -122,6 +134,7 @@ impl Builder {
                             self.base_working_dir.clone(),
                             build,
                             self.uv,
+                            python_env_dir.clone(),
                         )
                         .await?;
                     }
@@ -142,6 +155,7 @@ async fn build_node(
     working_dir: PathBuf,
     build: &String,
     uv: bool,
+    python_env_dir: Option<PathBuf>,
 ) -> eyre::Result<()> {
     let build_log_message = if build.contains('\n') {
         format!(
@@ -160,9 +174,16 @@ async fn build_node(
     let mut logger = logger.try_clone().await.context("failed to clone logger")?;
     let (stdout_tx, mut stdout) = tokio::sync::mpsc::channel(10);
     let task = tokio::spawn(async move {
-        run_build_command(&build, &working_dir, uv, &node_env, stdout_tx)
-            .await
-            .context("build command failed")
+        run_build_command(
+            &build,
+            &working_dir,
+            uv,
+            python_env_dir,
+            &node_env,
+            stdout_tx,
+        )
+        .await
+        .context("build command failed")
     });
     let stdout_task = tokio::spawn(async move {
         while let Some(line) = stdout.recv().await {

--- a/libraries/core/src/build/mod.rs
+++ b/libraries/core/src/build/mod.rs
@@ -172,6 +172,23 @@ pub fn managed_python_env_dir(node: &ResolvedNode, node_working_dir: &Path) -> O
         .then(|| node_working_dir.join(".dora").join("python-env"))
 }
 
+pub fn managed_python_bin_dir(python_env_dir: &Path) -> PathBuf {
+    if cfg!(windows) {
+        python_env_dir.join("Scripts")
+    } else {
+        python_env_dir.join("bin")
+    }
+}
+
+pub fn managed_python_interpreter(python_env_dir: &Path) -> PathBuf {
+    let executable = if cfg!(windows) {
+        "python.exe"
+    } else {
+        "python"
+    };
+    managed_python_bin_dir(python_env_dir).join(executable)
+}
+
 fn node_requires_managed_python_env(node: &ResolvedNode) -> bool {
     match &node.kind {
         CoreNodeKind::Custom(custom) => is_python_custom_node(custom),
@@ -197,7 +214,7 @@ pub struct PrevGitSource {
 
 #[cfg(test)]
 mod tests {
-    use super::managed_python_env_dir;
+    use super::{managed_python_bin_dir, managed_python_env_dir, managed_python_interpreter};
     use crate::descriptor::{
         CoreNodeKind, CustomNode, OperatorConfig, OperatorDefinition, OperatorSource, PythonSource,
         ResolvedNode, RuntimeNode,
@@ -280,5 +297,23 @@ mod tests {
         let build_info: super::BuildInfo =
             serde_yaml::from_str("node_working_dirs: {}\n").expect("build info should parse");
         assert!(build_info.python_env_dirs.is_empty());
+    }
+
+    #[test]
+    fn managed_python_helpers_use_platform_layout() {
+        let env_dir = PathBuf::from("env-dir");
+        let expected_bin_dir = if cfg!(windows) {
+            PathBuf::from("env-dir/Scripts")
+        } else {
+            PathBuf::from("env-dir/bin")
+        };
+        let expected_interpreter = if cfg!(windows) {
+            PathBuf::from("env-dir/Scripts/python.exe")
+        } else {
+            PathBuf::from("env-dir/bin/python")
+        };
+
+        assert_eq!(managed_python_bin_dir(&env_dir), expected_bin_dir);
+        assert_eq!(managed_python_interpreter(&env_dir), expected_interpreter);
     }
 }

--- a/libraries/core/src/build/mod.rs
+++ b/libraries/core/src/build/mod.rs
@@ -1,9 +1,13 @@
 pub use git::GitManager;
 pub use logger::{BuildLogger, LogLevelOrStdout, TracingBuildLogger};
 
-use std::{collections::BTreeMap, future::Future, path::PathBuf};
+use std::{
+    collections::BTreeMap,
+    future::Future,
+    path::{Path, PathBuf},
+};
 
-use crate::descriptor::ResolvedNode;
+use crate::descriptor::{CustomNode, OperatorSource, ResolvedNode};
 use dora_message::{
     SessionId,
     common::{GitSource, LogLevel},
@@ -63,6 +67,7 @@ impl Builder {
         git_folder: Option<GitFolder>,
     ) -> eyre::Result<BuiltNode> {
         logger.log_message(LogLevel::Debug, "building node").await;
+        let python_env_dir;
         let node_working_dir = match &node.kind {
             CoreNodeKind::Custom(n) => {
                 let node_working_dir = match git_folder {
@@ -81,6 +86,7 @@ impl Builder {
                 if let Some(build) = &n.build {
                     build_node(logger, &node.env, node_working_dir.clone(), build, self.uv).await?;
                 }
+                python_env_dir = managed_python_env_dir(&node, &node_working_dir);
                 node_working_dir
             }
             CoreNodeKind::Runtime(n) => {
@@ -97,10 +103,14 @@ impl Builder {
                         .await?;
                     }
                 }
+                python_env_dir = managed_python_env_dir(&node, &self.base_working_dir);
                 self.base_working_dir.clone()
             }
         };
-        Ok(BuiltNode { node_working_dir })
+        Ok(BuiltNode {
+            node_working_dir,
+            python_env_dir,
+        })
     }
 }
 
@@ -147,15 +157,128 @@ async fn build_node(
 
 pub struct BuiltNode {
     pub node_working_dir: PathBuf,
+    pub python_env_dir: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct BuildInfo {
     pub node_working_dirs: BTreeMap<NodeId, PathBuf>,
+    #[serde(default)]
+    pub python_env_dirs: BTreeMap<NodeId, PathBuf>,
+}
+
+pub fn managed_python_env_dir(node: &ResolvedNode, node_working_dir: &Path) -> Option<PathBuf> {
+    node_requires_managed_python_env(node)
+        .then(|| node_working_dir.join(".dora").join("python-env"))
+}
+
+fn node_requires_managed_python_env(node: &ResolvedNode) -> bool {
+    match &node.kind {
+        CoreNodeKind::Custom(custom) => is_python_custom_node(custom),
+        CoreNodeKind::Runtime(runtime) => runtime
+            .operators
+            .iter()
+            .any(|operator| matches!(operator.config.source, OperatorSource::Python(_))),
+    }
+}
+
+fn is_python_custom_node(custom: &CustomNode) -> bool {
+    Path::new(&custom.path)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("py"))
 }
 
 pub struct PrevGitSource {
     pub git_source: GitSource,
     /// `True` if any nodes of this dataflow still require the source for building.
     pub still_needed_for_this_build: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::managed_python_env_dir;
+    use crate::descriptor::{
+        CoreNodeKind, CustomNode, OperatorConfig, OperatorDefinition, OperatorSource, PythonSource,
+        ResolvedNode, RuntimeNode,
+    };
+    use dora_message::{
+        config::NodeRunConfig,
+        descriptor::RestartPolicy,
+        id::{NodeId, OperatorId},
+    };
+    use std::{collections::BTreeMap, path::PathBuf};
+
+    fn python_custom_node() -> ResolvedNode {
+        ResolvedNode {
+            id: NodeId::from("python-custom".to_owned()),
+            name: None,
+            description: None,
+            env: None,
+            deploy: None,
+            kind: CoreNodeKind::Custom(CustomNode {
+                path: "node.py".to_owned(),
+                source: dora_message::descriptor::NodeSource::Local,
+                args: None,
+                envs: None,
+                build: None,
+                send_stdout_as: None,
+                restart_policy: RestartPolicy::Never,
+                run_config: NodeRunConfig {
+                    inputs: BTreeMap::new(),
+                    outputs: Default::default(),
+                },
+            }),
+        }
+    }
+
+    fn python_runtime_node() -> ResolvedNode {
+        ResolvedNode {
+            id: NodeId::from("python-runtime".to_owned()),
+            name: None,
+            description: None,
+            env: None,
+            deploy: None,
+            kind: CoreNodeKind::Runtime(RuntimeNode {
+                operators: vec![OperatorDefinition {
+                    id: OperatorId::from("op".to_owned()),
+                    config: OperatorConfig {
+                        name: None,
+                        description: None,
+                        inputs: BTreeMap::new(),
+                        outputs: Default::default(),
+                        source: OperatorSource::Python(PythonSource {
+                            source: "operator.py".to_owned(),
+                            conda_env: None,
+                        }),
+                        build: None,
+                        send_stdout_as: None,
+                    },
+                }],
+            }),
+        }
+    }
+
+    #[test]
+    fn assigns_managed_env_dir_to_python_custom_nodes() {
+        let working_dir = PathBuf::from("workdir");
+        let env_dir = managed_python_env_dir(&python_custom_node(), &working_dir)
+            .expect("python custom node should get managed env dir");
+        assert_eq!(env_dir, PathBuf::from("workdir/.dora/python-env"));
+    }
+
+    #[test]
+    fn assigns_managed_env_dir_to_python_runtime_nodes() {
+        let working_dir = PathBuf::from("runtime-dir");
+        let env_dir = managed_python_env_dir(&python_runtime_node(), &working_dir)
+            .expect("python runtime node should get managed env dir");
+        assert_eq!(env_dir, PathBuf::from("runtime-dir/.dora/python-env"));
+    }
+
+    #[test]
+    fn build_info_deserializes_without_python_env_dirs() {
+        let build_info: super::BuildInfo =
+            serde_yaml::from_str("node_working_dirs: {}\n").expect("build info should parse");
+        assert!(build_info.python_env_dirs.is_empty());
+    }
 }

--- a/libraries/core/src/build/mod.rs
+++ b/libraries/core/src/build/mod.rs
@@ -16,7 +16,7 @@ use dora_message::{
 };
 use eyre::Context;
 
-use build_command::run_build_command;
+use build_command::{prepare_managed_python_env, run_build_command};
 use git::GitFolder;
 
 mod build_command;
@@ -82,14 +82,37 @@ impl Builder {
                     }
                     None => self.base_working_dir,
                 };
+                python_env_dir = managed_python_env_dir(&node, &node_working_dir);
+                if self.uv {
+                    if let Some(python_env_dir) = &python_env_dir {
+                        prepare_python_env(
+                            logger,
+                            &node.env,
+                            node_working_dir.clone(),
+                            python_env_dir.clone(),
+                        )
+                        .await?;
+                    }
+                }
 
                 if let Some(build) = &n.build {
                     build_node(logger, &node.env, node_working_dir.clone(), build, self.uv).await?;
                 }
-                python_env_dir = managed_python_env_dir(&node, &node_working_dir);
                 node_working_dir
             }
             CoreNodeKind::Runtime(n) => {
+                python_env_dir = managed_python_env_dir(&node, &self.base_working_dir);
+                if self.uv {
+                    if let Some(python_env_dir) = &python_env_dir {
+                        prepare_python_env(
+                            logger,
+                            &node.env,
+                            self.base_working_dir.clone(),
+                            python_env_dir.clone(),
+                        )
+                        .await?;
+                    }
+                }
                 // run build commands
                 for operator in &n.operators {
                     if let Some(build) = &operator.config.build {
@@ -103,7 +126,6 @@ impl Builder {
                         .await?;
                     }
                 }
-                python_env_dir = managed_python_env_dir(&node, &self.base_working_dir);
                 self.base_working_dir.clone()
             }
         };
@@ -141,6 +163,42 @@ async fn build_node(
         run_build_command(&build, &working_dir, uv, &node_env, stdout_tx)
             .await
             .context("build command failed")
+    });
+    let stdout_task = tokio::spawn(async move {
+        while let Some(line) = stdout.recv().await {
+            logger
+                .log_stdout(line.unwrap_or_else(|err| format!("io err: {}", err.kind())))
+                .await;
+        }
+    });
+    stdout_task.await?;
+    task.await??;
+
+    Ok(())
+}
+
+async fn prepare_python_env(
+    logger: &mut impl BuildLogger,
+    node_env: &Option<BTreeMap<String, EnvValue>>,
+    working_dir: PathBuf,
+    python_env_dir: PathBuf,
+) -> eyre::Result<()> {
+    logger
+        .log_message(
+            LogLevel::Info,
+            format!(
+                "preparing managed Python env in {}",
+                python_env_dir.display()
+            ),
+        )
+        .await;
+    let node_env = node_env.clone();
+    let mut logger = logger.try_clone().await.context("failed to clone logger")?;
+    let (stdout_tx, mut stdout) = tokio::sync::mpsc::channel(10);
+    let task = tokio::spawn(async move {
+        prepare_managed_python_env(&working_dir, &python_env_dir, &node_env, stdout_tx)
+            .await
+            .context("managed Python env preparation failed")
     });
     let stdout_task = tokio::spawn(async move {
         while let Some(line) = stdout.recv().await {


### PR DESCRIPTION
Introduce a Dora-managed Python isolation flow for Python nodes under `--uv`.

Goal:
make Python node execution reproducible by preparing an isolated environment during build and reusing that exact environment during `dora run` / `dora start`.

Initial MVP scope:
- Python only
- `Dora.toml` + `uv venv` direction
- keep C/C++ and Rust out of scope
- focus on Dora-integrated build/runtime behavior rather than a full package manager

Planned steps:
- [x] add metadata/plumbing for managed Python env paths per node
- [x] create or reuse managed Python envs during `dora build --uv`
- [x] run Python dependency/build commands against the managed env
- [x] reuse the managed env interpreter in `dora run` / `dora start`
- [ ] add focused tests for build-to-runtime env reuse
- [ ] document the Python isolation workflow and limitations

Notes:
- The intended model is per Python node/package rather than one shared env per dataflow.
- This is meant to be a prototype foundation for Project #2, not a full package manager.
- Python dependency management should remain compatible with existing Python tooling rather than replacing it outright.
