### PR TITLE
feat(daemon): add `since_revision` catch-up protocol for rejoining daemons

### DIFF
--- a/binaries/cli/src/command/topic/echo.rs
+++ b/binaries/cli/src/command/topic/echo.rs
@@ -266,6 +266,15 @@ async fn log_to_terminal(
                 // NodeFailed events are not relevant for topic echo
                 continue;
             }
+            InterDaemonEvent::StateUpdate(_) => {
+                continue;
+            }
+            InterDaemonEvent::StateCatchUpRequest { .. } => {
+                continue;
+            }
+            InterDaemonEvent::StateCatchUpResponse { .. } => {
+                continue;
+            }
         }
     }
 

--- a/binaries/cli/src/command/topic/hz.rs
+++ b/binaries/cli/src/command/topic/hz.rs
@@ -333,6 +333,15 @@ async fn subscribe_output(
                 // NodeFailed events are not relevant for topic hz
                 continue;
             }
+            InterDaemonEvent::StateUpdate(_) => {
+                continue;
+            }
+            InterDaemonEvent::StateCatchUpRequest { .. } => {
+                continue;
+            }
+            InterDaemonEvent::StateCatchUpResponse { .. } => {
+                continue;
+            }
         }
     }
 

--- a/binaries/cli/src/command/topic/info.rs
+++ b/binaries/cli/src/command/topic/info.rs
@@ -190,6 +190,15 @@ async fn info(
                         // Node failed, stop collecting statistics
                         break;
                     }
+                    InterDaemonEvent::StateUpdate(_) => {
+                        continue;
+                    }
+                    InterDaemonEvent::StateCatchUpRequest { .. } => {
+                        continue;
+                    }
+                    InterDaemonEvent::StateCatchUpResponse { .. } => {
+                        continue;
+                    }
                 }
             }
             Err(_) => break,

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -9,7 +9,7 @@ use dora_core::{
     },
     topics::{
         DORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT, LOCALHOST, open_zenoh_session,
-        zenoh_output_publish_topic,
+        zenoh_dataflow_state_topic, zenoh_output_publish_topic,
     },
     uhlc::HLC,
 };
@@ -79,6 +79,7 @@ mod pending;
 mod socket_stream_utils;
 mod spawn;
 pub(crate) mod state;
+mod state_replication;
 
 #[cfg(feature = "telemetry")]
 use dora_tracing::telemetry::serialize_context;
@@ -980,6 +981,57 @@ impl Daemon {
                 }
                 Ok(())
             }
+            InterDaemonEvent::StateUpdate(update) => {
+                // Avoid re-applying local updates that loop back through zenoh.
+                if update.source_daemon_id != *self.state.daemon_id() {
+                    let _ = self.state.replication_state.apply_remote_update(&update);
+                }
+                Ok(())
+            }
+            InterDaemonEvent::StateCatchUpRequest {
+                dataflow_id,
+                requester_daemon_id,
+                known_revisions,
+            } => {
+                if requester_daemon_id == *self.state.daemon_id() {
+                    return Ok(());
+                }
+                let since_revision = known_revisions
+                    .get(self.state.daemon_id())
+                    .copied()
+                    .unwrap_or(0);
+                let updates = self.state.replication_state.updates_since(
+                    dataflow_id,
+                    self.state.daemon_id(),
+                    since_revision,
+                );
+                if updates.is_empty() {
+                    return Ok(());
+                }
+                self.publish_state_event(
+                    dataflow_id,
+                    InterDaemonEvent::StateCatchUpResponse {
+                        dataflow_id,
+                        target_daemon_id: requester_daemon_id,
+                        updates,
+                    },
+                )
+                .await?;
+                Ok(())
+            }
+            InterDaemonEvent::StateCatchUpResponse {
+                dataflow_id: _,
+                target_daemon_id,
+                updates,
+            } => {
+                if target_daemon_id != *self.state.daemon_id() {
+                    return Ok(());
+                }
+                for update in updates {
+                    let _ = self.state.replication_state.apply_remote_update(&update);
+                }
+                Ok(())
+            }
         }
     }
 
@@ -1113,8 +1165,10 @@ impl Daemon {
                 bail!("there is already a running dataflow with ID `{dataflow_id}`")
             }
         };
+        self.state.replication_state.ensure_dataflow(dataflow_id);
 
         let mut stopped = Vec::new();
+        let mut has_remote_nodes = false;
 
         let build_info = build_id.and_then(|build_id| self.state.builds.get(&build_id));
         let node_with_git_source = nodes.values().find(|n| n.has_git_source());
@@ -1255,6 +1309,7 @@ impl Daemon {
                     }
                 }
             } else {
+                has_remote_nodes = true;
                 // wait until node is ready before starting
                 dataflow.pending_nodes.set_external_nodes(true);
 
@@ -1317,7 +1372,60 @@ impl Daemon {
                 }
             }
         }
+
+        if has_remote_nodes {
+            let tx = self
+                .state
+                .remote_daemon_events_tx
+                .clone()
+                .wrap_err("no remote_daemon_events_tx channel")?;
+            let mut finished_rx = dataflow.finished_tx.subscribe();
+            let subscribe_topic = zenoh_dataflow_state_topic(dataflow.id);
+            tracing::debug!("declaring state subscriber on {subscribe_topic}");
+            let zenoh = self
+                .state
+                .zenoh_session
+                .as_ref()
+                .wrap_err("no zenoh session")?;
+            let subscriber = zenoh
+                .declare_subscriber(subscribe_topic)
+                .await
+                .map_err(|e| eyre!(e))
+                .wrap_err("failed to subscribe to dataflow state topic")?;
+            tokio::spawn(async move {
+                let mut finished = pin!(finished_rx.recv());
+                loop {
+                    let finished_or_next =
+                        futures::future::select(finished, subscriber.recv_async());
+                    match finished_or_next.await {
+                        future::Either::Left((finished, _)) => match finished {
+                            Err(broadcast::error::RecvError::Closed) => break,
+                            _ => break,
+                        },
+                        future::Either::Right((sample, f)) => {
+                            finished = f;
+                            let event = sample.map_err(|e| eyre!(e)).and_then(|s| {
+                                Timestamped::deserialize_inter_daemon_event(&s.payload().to_bytes())
+                            });
+                            if tx.send_async(event).await.is_err() {
+                                break;
+                            }
+                        }
+                    }
+                }
+            });
+        }
+
         drop(dataflow);
+        if has_remote_nodes {
+            let catch_up_request = InterDaemonEvent::StateCatchUpRequest {
+                dataflow_id,
+                requester_daemon_id: self.state.daemon_id().clone(),
+                known_revisions: self.state.replication_state.known_revisions(dataflow_id),
+            };
+            self.publish_state_event(dataflow_id, catch_up_request)
+                .await?;
+        }
         for (node_id, dynamic) in stopped {
             self.handle_node_stop(dataflow_id, &node_id, dynamic)
                 .await?;
@@ -1945,6 +2053,61 @@ impl Daemon {
         Ok(())
     }
 
+    async fn publish_state_event(
+        &mut self,
+        dataflow_id: Uuid,
+        event: InterDaemonEvent,
+    ) -> eyre::Result<()> {
+        {
+            let has_publisher = self
+                .state
+                .running
+                .get(&dataflow_id)
+                .map(|d| d.state_publisher.is_some())
+                .unwrap_or(false);
+            if !has_publisher {
+                let topic = zenoh_dataflow_state_topic(dataflow_id);
+                let zenoh = self
+                    .state
+                    .zenoh_session
+                    .as_ref()
+                    .wrap_err("no zenoh session")?;
+                let publisher = zenoh
+                    .declare_publisher(topic)
+                    .await
+                    .map_err(|e| eyre!(e))
+                    .context("failed to create state publisher")?;
+                let mut dataflow = self
+                    .state
+                    .running
+                    .get_mut(&dataflow_id)
+                    .wrap_err_with(|| format!("no running dataflow with ID `{dataflow_id}`"))?;
+                dataflow.state_publisher = Some(publisher);
+            }
+        }
+
+        let dataflow = self
+            .state
+            .running
+            .get(&dataflow_id)
+            .wrap_err_with(|| format!("no running dataflow with ID `{dataflow_id}`"))?;
+        let publisher = dataflow
+            .state_publisher
+            .as_ref()
+            .wrap_err("state publisher disappeared")?;
+        let serialized_event = Timestamped {
+            inner: event,
+            timestamp: self.state.clock.new_timestamp(),
+        }
+        .serialize();
+        publisher
+            .put(serialized_event)
+            .await
+            .map_err(|e| eyre!(e))
+            .context("zenoh put failed for state event")?;
+        Ok(())
+    }
+
     async fn send_output_closed_events(
         &mut self,
         dataflow_id: DataflowId,
@@ -2294,6 +2457,7 @@ impl Daemon {
             });
         }
         self.state.running.remove(&dataflow_id);
+        self.state.replication_state.remove_dataflow(dataflow_id);
 
         Ok(())
     }
@@ -3031,6 +3195,7 @@ pub struct RunningDataflow {
     node_stderr_most_recent: BTreeMap<NodeId, Arc<ArrayQueue<String>>>,
 
     publishers: BTreeMap<OutputId, zenoh::pubsub::Publisher<'static>>,
+    state_publisher: Option<zenoh::pubsub::Publisher<'static>>,
 
     finished_tx: broadcast::Sender<()>,
 
@@ -3077,6 +3242,7 @@ impl RunningDataflow {
             handled_node_failed: BTreeSet::new(),
             node_stderr_most_recent: BTreeMap::new(),
             publishers: Default::default(),
+            state_publisher: None,
             finished_tx,
             publish_all_messages_to_zenoh: dataflow_descriptor.debug.publish_all_messages_to_zenoh,
             descriptor: dataflow_descriptor,

--- a/binaries/daemon/src/state.rs
+++ b/binaries/daemon/src/state.rs
@@ -1,5 +1,6 @@
 use std::{collections::BTreeMap, path::PathBuf, sync::Arc, time::Instant};
 
+use crate::{Event, InterDaemonEvent, RunningDataflow, state_replication::ReplicationLogStore};
 use dashmap::DashMap;
 use dora_core::{
     build::{BuildInfo, GitManager},
@@ -14,9 +15,6 @@ use dora_message::{
     tarpc,
 };
 use tokio::sync::{Mutex, mpsc};
-use uuid::Uuid;
-
-use crate::{Event, InterDaemonEvent, RunningDataflow};
 
 /// Shared daemon state accessible from both the event loop and the RPC server.
 ///
@@ -47,6 +45,8 @@ pub(crate) struct DaemonState {
     /// Channel to send remote daemon events into the event loop.
     pub(crate) remote_daemon_events_tx:
         Option<flume::Sender<eyre::Result<Timestamped<InterDaemonEvent>>>>,
+    /// In-memory replicated state with a bounded operation log for catch-up.
+    pub(crate) replication_state: ReplicationLogStore,
 }
 
 impl DaemonState {
@@ -70,6 +70,7 @@ impl DaemonState {
             git_manager: Mutex::new(Default::default()),
             zenoh_session,
             remote_daemon_events_tx,
+            replication_state: Default::default(),
         }
     }
 
@@ -101,6 +102,7 @@ impl DaemonState {
             git_manager: Mutex::new(Default::default()),
             zenoh_session: Some(zenoh_session),
             remote_daemon_events_tx: None,
+            replication_state: Default::default(),
         };
         let _ = state.daemon_id.set(daemon_id);
         state
@@ -162,6 +164,7 @@ impl DaemonState {
             });
         }
         self.running.remove(&dataflow_id);
+        self.replication_state.remove_dataflow(dataflow_id);
 
         Ok(())
     }

--- a/binaries/daemon/src/state_replication.rs
+++ b/binaries/daemon/src/state_replication.rs
@@ -1,0 +1,244 @@
+use std::collections::{BTreeMap, VecDeque};
+
+use dora_message::{DataflowId, common::DaemonId, daemon_to_daemon::StateUpdate};
+
+/// Number of state operations retained per dataflow for incremental catch-up.
+pub const DEFAULT_LOG_CAPACITY: usize = 1024;
+
+#[derive(Debug, Default)]
+pub struct DataflowReplicationState {
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) local_revision: u64,
+    pub(crate) kv: BTreeMap<String, Vec<u8>>,
+    pub(crate) operation_log: VecDeque<StateUpdate>,
+    pub(crate) known_revisions: BTreeMap<DaemonId, u64>,
+}
+
+impl DataflowReplicationState {
+    fn apply_update(&mut self, update: &StateUpdate) {
+        match &update.value {
+            Some(value) => {
+                self.kv.insert(update.key.clone(), value.clone());
+            }
+            None => {
+                self.kv.remove(&update.key);
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ReplicationLogStore {
+    log_capacity: usize,
+    states: dashmap::DashMap<DataflowId, DataflowReplicationState>,
+}
+
+impl Default for ReplicationLogStore {
+    fn default() -> Self {
+        Self::new(DEFAULT_LOG_CAPACITY)
+    }
+}
+
+impl ReplicationLogStore {
+    pub fn new(log_capacity: usize) -> Self {
+        Self {
+            log_capacity,
+            states: Default::default(),
+        }
+    }
+
+    pub fn ensure_dataflow(&self, dataflow_id: DataflowId) {
+        self.states.entry(dataflow_id).or_default();
+    }
+
+    pub fn remove_dataflow(&self, dataflow_id: DataflowId) {
+        self.states.remove(&dataflow_id);
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn apply_local_update(
+        &self,
+        dataflow_id: DataflowId,
+        source_daemon_id: DaemonId,
+        key: String,
+        value: Option<Vec<u8>>,
+    ) -> StateUpdate {
+        let mut state = self.states.entry(dataflow_id).or_default();
+        let state_ref = state.value_mut();
+
+        state_ref.local_revision = state_ref.local_revision.saturating_add(1);
+        let update = StateUpdate {
+            dataflow_id,
+            source_daemon_id: source_daemon_id.clone(),
+            revision: state_ref.local_revision,
+            key,
+            value,
+        };
+        state_ref.apply_update(&update);
+        state_ref
+            .known_revisions
+            .insert(source_daemon_id, update.revision);
+
+        state_ref.operation_log.push_back(update.clone());
+        while state_ref.operation_log.len() > self.log_capacity {
+            state_ref.operation_log.pop_front();
+        }
+        update
+    }
+
+    /// Applies a remote update if it advances the known revision.
+    pub fn apply_remote_update(&self, update: &StateUpdate) -> bool {
+        let mut state = self.states.entry(update.dataflow_id).or_default();
+        let state_ref = state.value_mut();
+
+        let known = state_ref
+            .known_revisions
+            .get(&update.source_daemon_id)
+            .copied()
+            .unwrap_or(0);
+        if update.revision <= known {
+            return false;
+        }
+
+        state_ref.apply_update(update);
+        state_ref
+            .known_revisions
+            .insert(update.source_daemon_id.clone(), update.revision);
+        state_ref.operation_log.push_back(update.clone());
+        while state_ref.operation_log.len() > self.log_capacity {
+            state_ref.operation_log.pop_front();
+        }
+        true
+    }
+
+    pub fn known_revisions(&self, dataflow_id: DataflowId) -> BTreeMap<DaemonId, u64> {
+        self.states
+            .get(&dataflow_id)
+            .map(|entry| entry.known_revisions.clone())
+            .unwrap_or_default()
+    }
+
+    pub fn updates_since(
+        &self,
+        dataflow_id: DataflowId,
+        source_daemon_id: &DaemonId,
+        since_revision: u64,
+    ) -> Vec<StateUpdate> {
+        self.states
+            .get(&dataflow_id)
+            .map(|entry| {
+                entry
+                    .operation_log
+                    .iter()
+                    .filter(|u| {
+                        &u.source_daemon_id == source_daemon_id && u.revision > since_revision
+                    })
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub fn values_snapshot(&self, dataflow_id: DataflowId) -> BTreeMap<String, Vec<u8>> {
+        self.states
+            .get(&dataflow_id)
+            .map(|entry| entry.kv.clone())
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ReplicationLogStore;
+    use dora_message::{common::DaemonId, daemon_to_daemon::InterDaemonEvent};
+    use uuid::Uuid;
+
+    #[test]
+    fn catch_up_after_rejoin_replays_only_missing_updates() {
+        let dataflow_id = Uuid::new_v4();
+        let daemon_a = DaemonId::new(Some("A".to_owned()));
+        let daemon_b = DaemonId::new(Some("B".to_owned()));
+
+        let store_a = ReplicationLogStore::new(64);
+        let store_b = ReplicationLogStore::new(64);
+
+        // A produces first two updates.
+        let u1 = store_a.apply_local_update(
+            dataflow_id,
+            daemon_a.clone(),
+            "k1".to_owned(),
+            Some(b"v1".to_vec()),
+        );
+        let u2 = store_a.apply_local_update(
+            dataflow_id,
+            daemon_a.clone(),
+            "k2".to_owned(),
+            Some(b"v2".to_vec()),
+        );
+
+        // B receives only these two (before disconnect).
+        assert!(store_b.apply_remote_update(&u1));
+        assert!(store_b.apply_remote_update(&u2));
+        assert_eq!(
+            store_b
+                .known_revisions(dataflow_id)
+                .get(&daemon_a)
+                .copied()
+                .unwrap_or(0),
+            2
+        );
+
+        // A keeps producing while B is disconnected.
+        let _u3 = store_a.apply_local_update(
+            dataflow_id,
+            daemon_a.clone(),
+            "k1".to_owned(),
+            Some(b"v1b".to_vec()),
+        );
+        let _u4 = store_a.apply_local_update(
+            dataflow_id,
+            daemon_a.clone(),
+            "k3".to_owned(),
+            Some(b"v3".to_vec()),
+        );
+
+        // B rejoins and asks for deltas since what it knows for A.
+        let known_revisions = store_b.known_revisions(dataflow_id);
+        let request = InterDaemonEvent::StateCatchUpRequest {
+            dataflow_id,
+            requester_daemon_id: daemon_b.clone(),
+            known_revisions,
+        };
+
+        let updates = match request {
+            InterDaemonEvent::StateCatchUpRequest {
+                known_revisions, ..
+            } => {
+                let since = known_revisions.get(&daemon_a).copied().unwrap_or(0);
+                store_a.updates_since(dataflow_id, &daemon_a, since)
+            }
+            _ => unreachable!(),
+        };
+        assert_eq!(updates.len(), 2);
+        assert_eq!(updates[0].revision, 3);
+        assert_eq!(updates[1].revision, 4);
+
+        for update in &updates {
+            assert!(store_b.apply_remote_update(update));
+        }
+
+        let snapshot = store_b.values_snapshot(dataflow_id);
+        assert_eq!(snapshot.get("k1").cloned(), Some(b"v1b".to_vec()));
+        assert_eq!(snapshot.get("k2").cloned(), Some(b"v2".to_vec()));
+        assert_eq!(snapshot.get("k3").cloned(), Some(b"v3".to_vec()));
+        assert_eq!(
+            store_b
+                .known_revisions(dataflow_id)
+                .get(&daemon_a)
+                .copied()
+                .unwrap_or(0),
+            4
+        );
+    }
+}

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -77,3 +77,9 @@ pub fn zenoh_output_publish_topic(
     let network_id = "default";
     format!("dora/{network_id}/{dataflow_id}/output/{node_id}/{output_id}")
 }
+
+#[cfg(feature = "zenoh")]
+pub fn zenoh_dataflow_state_topic(dataflow_id: uuid::Uuid) -> String {
+    let network_id = "default";
+    format!("dora/{network_id}/{dataflow_id}/state")
+}

--- a/libraries/message/src/daemon_to_daemon.rs
+++ b/libraries/message/src/daemon_to_daemon.rs
@@ -1,10 +1,22 @@
 use aligned_vec::{AVec, ConstAlign};
+use std::collections::BTreeMap;
 
 use crate::{
     DataflowId,
+    common::DaemonId,
     id::{DataId, NodeId},
     metadata::Metadata,
 };
+
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct StateUpdate {
+    pub dataflow_id: DataflowId,
+    pub source_daemon_id: DaemonId,
+    pub revision: u64,
+    pub key: String,
+    /// `None` means delete.
+    pub value: Option<Vec<u8>>,
+}
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 #[allow(clippy::large_enum_variant)]
@@ -25,5 +37,19 @@ pub enum InterDaemonEvent {
         dataflow_id: DataflowId,
         source_node_id: NodeId,
         error: String,
+    },
+    /// Replicated state update produced by one daemon.
+    StateUpdate(StateUpdate),
+    /// Ask peer daemons for all missing updates since known revisions.
+    StateCatchUpRequest {
+        dataflow_id: DataflowId,
+        requester_daemon_id: DaemonId,
+        known_revisions: BTreeMap<DaemonId, u64>,
+    },
+    /// Catch-up response carrying incremental updates to a specific daemon.
+    StateCatchUpResponse {
+        dataflow_id: DataflowId,
+        target_daemon_id: DaemonId,
+        updates: Vec<StateUpdate>,
     },
 }


### PR DESCRIPTION
## Related Issue: #1523 

## Problem

  Distributed state replication requires a recovery path when a daemon misses updates (disconnect/restart).
  Before this PR, Dora had no generic mechanism to replay only the missing operations from peers.

  ## Impact

  Without incremental catch-up:
  - rejoined daemons may remain stale/divergent
  - failover/rejoin scenarios are not reliable
  - future shared-state API work lacks a recovery foundation

  This PR introduces daemon-level replay semantics aligned with current inter-daemon transport.

  ## What Changed

  ### Protocol additions (`dora-message`)
  - Added `StateUpdate`
  - Added `StateCatchUpRequest { requester_daemon_id, known_revisions }`
  - Added `StateCatchUpResponse { target_daemon_id, updates }`

  ### Topic additions (`dora-core`)
  - Added dedicated zenoh state topic helper:
  - `zenoh_dataflow_state_topic(dataflow_id)`

  ### Daemon replication state (`dora-daemon`)
  - Added in-memory bounded replication log store:
  - per-dataflow key/value mirror
  - known revision map per source daemon
  - `updates_since(...)` for delta replay
  - Integrated store into daemon state lifecycle (create on spawn, cleanup on finish)

  ### Runtime wiring (`dora-daemon`)
  - Subscribes to dataflow state topic when distributed topology is present
  - Sends `StateCatchUpRequest` on spawn with local `known_revisions`
  - Replies to catch-up requests with deltas only
  - Applies incoming `StateUpdate`/`StateCatchUpResponse` with revision checks

  ## Key Design Decisions / Tradeoffs

  - **Bounded in-memory log**: simple and fast for prototype; does not provide durable recovery after full cluster restart.
  - **Per-source revision tracking**: enables deterministic `since_revision` replay without global total ordering.
  - **Daemon-boundary implementation first**: avoids premature node API commitments; keeps compatibility with existing event architecture.

  ## Tests

  - Added unit/integration-style daemon test:
  - `catch_up_after_rejoin_replays_only_missing_updates`
  - verifies only missing revisions are replayed and final state converges.

  ## Validation

  - [x] `cargo fmt --all`
  - [x] `cargo test -p dora-daemon state_replication -- --nocapture`
  - [x] `cargo check -p dora-daemon -p dora-message -p dora-core`
  - [x] `cargo clippy -p dora-daemon --all-targets`
  - [ ] Full workspace strict `-D warnings` cleanup (blocked by pre-existing warnings outside this change)

  ## Follow-ups (Out of Scope)

  - Node-facing state API (`get/set/delete/watch`)
  - Durable WAL/snapshot backend
  - Backfill/compaction policy beyond fixed in-memory capacity