### PR TITLE
feat(cli): add Zenoh Key to `dora topic list` column

### DIFF
--- a/binaries/cli/src/command/topic/list.rs
+++ b/binaries/cli/src/command/topic/list.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, io::Write};
 
 use clap::Args;
-use dora_core::config::InputMapping;
+use dora_core::{config::InputMapping, topics::zenoh_output_publish_topic};
 use dora_message::id::{DataId, NodeId};
 use serde::Serialize;
 use tabwriter::TabWriter;
@@ -47,6 +47,7 @@ struct OutputEntry {
     node: NodeId,
     name: DataId,
     subscribers: Vec<String>,
+    zenoh_key: String,
 }
 
 async fn list(
@@ -55,7 +56,7 @@ async fn list(
     format: OutputFormat,
 ) -> eyre::Result<()> {
     let client = coordinator.connect_rpc().await?;
-    let (_dataflow_id, descriptor) = selector.resolve(&client).await?;
+    let (dataflow_id, descriptor) = selector.resolve(&client).await?;
 
     let mut subscribers = BTreeMap::<(&NodeId, &DataId), Vec<(&NodeId, &DataId)>>::new();
     for node in &descriptor.nodes {
@@ -81,6 +82,7 @@ async fn list(
                     .into_iter()
                     .map(|(node, data)| format!("{node}/{data}"))
                     .collect(),
+                zenoh_key: zenoh_output_publish_topic(dataflow_id, &node.id, output),
             });
         }
     }
@@ -88,13 +90,14 @@ async fn list(
     match format {
         OutputFormat::Table => {
             let mut tw = TabWriter::new(std::io::stdout().lock());
-            tw.write_all(b"Node\tName\tSubscribers\n")?;
+            tw.write_all(b"Node\tName\tZenoh Key\tSubscribers\n")?;
             for entry in entries {
                 tw.write_all(
                     format!(
-                        "{}\t{}\t{}\n",
+                        "{}\t{}\t{}\t{}\n",
                         entry.node,
                         entry.name,
+                        entry.zenoh_key,
                         entry.subscribers.join(", ")
                     )
                     .as_bytes(),


### PR DESCRIPTION
Closes #1529 

Running dora topic list now displays the computed Zenoh topic key alongside the node and subscribers. This makes it a lot easier to inspect the networking layer.

Changes:
- Extracted `dataflow_id` in `list.rs`
- Added the `zenoh_key` field to the `OutputEntry`structs.
- Formatted `zenoh_output_publish_topic` into the table and JSON outputs.

<img width="1006" height="92" alt="Screenshot 2026-03-25 at 2 59 23 PM" src="https://github.com/user-attachments/assets/58d4d4a3-391e-4d5a-95f7-ef7f26fdc24d" />
