### PR TITLE
feat: expose Zenoh peer ID per daemon in `dora system status`

### DIFF
--- a/binaries/cli/src/command/system/status.rs
+++ b/binaries/cli/src/command/system/status.rs
@@ -6,7 +6,9 @@ use crate::{
 use dora_core::descriptor::DescriptorExt;
 use dora_core::{descriptor::Descriptor, topics::DORA_COORDINATOR_PORT_CONTROL_DEFAULT};
 use dora_message::{
-    cli_to_coordinator::CoordinatorControlClient, coordinator_to_cli::DataflowStatus, tarpc,
+    cli_to_coordinator::CoordinatorControlClient,
+    coordinator_to_cli::{DaemonInfo, DataflowStatus},
+    tarpc,
 };
 use eyre::{Context, bail};
 use std::{
@@ -63,6 +65,21 @@ pub async fn check_environment(coordinator_addr: SocketAddr) -> eyre::Result<()>
         write!(stdout, "✓ ")?;
         let _ = stdout.reset();
         writeln!(stdout, "Daemon: Running")?;
+
+        // Show per-daemon Zenoh session info
+        if let Some(ref c) = client {
+            if let Ok(daemons) = list_daemons(c).await {
+                for d in &daemons {
+                    let zenoh_mark = if d.zenoh_ready { "✓" } else { "✗" };
+                    let peer = d.zenoh_peer_id.as_deref().unwrap_or("—");
+                    writeln!(
+                        stdout,
+                        "  Daemon {}  Zenoh: {} (peer: {})",
+                        d.daemon_id, zenoh_mark, peer
+                    )?;
+                }
+            }
+        }
     } else if client.is_some() {
         let _ = stdout.set_color(ColorSpec::new().set_fg(Some(Color::Red)));
         write!(stdout, "✗ ")?;
@@ -95,6 +112,16 @@ pub async fn daemon_running(client: &CoordinatorControlClient) -> Result<bool, e
     rpc(
         "check daemon connection",
         client.daemon_connected(tarpc::context::current()),
+    )
+    .await
+}
+
+async fn list_daemons(
+    client: &CoordinatorControlClient,
+) -> Result<Vec<DaemonInfo>, eyre::ErrReport> {
+    rpc(
+        "list daemons",
+        client.list_daemons(tarpc::context::current()),
     )
     .await
 }

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -366,6 +366,7 @@ async fn start_inner(
                 DaemonRequest::Register {
                     machine_id,
                     machine_uid,
+                    zenoh_peer_id,
                     mut connection,
                     version_check_result,
                 } => {
@@ -425,6 +426,7 @@ async fn start_inner(
                                     last_heartbeat: Instant::now(),
                                     peer_addr,
                                     machine_uid,
+                                    zenoh_peer_id,
                                 },
                             );
                         }
@@ -636,6 +638,7 @@ pub(crate) struct DaemonConnection {
     peer_addr: Option<SocketAddr>,
     /// System-level machine identifier reported by the daemon at registration.
     machine_uid: Option<String>,
+    pub(crate) zenoh_peer_id: Option<String>,
 }
 
 async fn handle_destroy(
@@ -1188,6 +1191,7 @@ pub enum DaemonRequest {
     Register {
         machine_id: Option<String>,
         machine_uid: Option<String>,
+        zenoh_peer_id: Option<String>,
         connection: TcpStream,
         version_check_result: Result<(), String>,
     },

--- a/binaries/coordinator/src/listener.rs
+++ b/binaries/coordinator/src/listener.rs
@@ -78,6 +78,7 @@ pub async fn handle_connection(
                     version_check_result: register_request.check_version(),
                     machine_id: register_request.machine_id,
                     machine_uid: register_request.machine_uid,
+                    zenoh_peer_id: register_request.zenoh_peer_id,
                 };
                 let _ = events_tx.send(Event::Daemon(event)).await;
                 break;

--- a/binaries/coordinator/src/server.rs
+++ b/binaries/coordinator/src/server.rs
@@ -6,8 +6,9 @@ use dora_message::{
     cli_to_coordinator::{BuildRequest, CoordinatorControl, StartRequest},
     common::DaemonId,
     coordinator_to_cli::{
-        CheckDataflowReply, DataflowIdAndName, DataflowInfo, DataflowList, DataflowListEntry,
-        DataflowResult, DataflowStatus, NodeInfo, NodeMetricsInfo, StopDataflowReply, VersionInfo,
+        CheckDataflowReply, DaemonInfo, DataflowIdAndName, DataflowInfo, DataflowList,
+        DataflowListEntry, DataflowResult, DataflowStatus, NodeInfo, NodeMetricsInfo,
+        StopDataflowReply, VersionInfo,
     },
     tarpc::context::Context,
 };
@@ -399,5 +400,18 @@ impl CoordinatorControl for CoordinatorControlServer {
             }
         }
         Ok(node_infos)
+    }
+
+    async fn list_daemons(self, _ctx: Context) -> Result<Vec<DaemonInfo>, String> {
+        Ok(self
+            .state
+            .daemon_connections
+            .iter()
+            .map(|r| DaemonInfo {
+                daemon_id: r.key().clone(),
+                zenoh_ready: r.value().zenoh_peer_id.is_some(),
+                zenoh_peer_id: r.value().zenoh_peer_id.clone(),
+            })
+            .collect())
     }
 }

--- a/binaries/daemon/src/coordinator.rs
+++ b/binaries/daemon/src/coordinator.rs
@@ -74,9 +74,11 @@ pub async fn register(
         .set_nodelay(true)
         .wrap_err("failed to set TCP_NODELAY")?;
 
+    let zenoh_peer_id = state.zenoh_session.as_ref().map(|s| s.zid().to_string());
+
     // Registration handshake (raw length-prefixed JSON)
     let register = serde_json::to_vec(&Timestamped {
-        inner: CoordinatorRequest::Register(DaemonRegisterRequest::new(machine_id)),
+        inner: CoordinatorRequest::Register(DaemonRegisterRequest::new(machine_id, zenoh_peer_id)),
         timestamp: clock.new_timestamp(),
     })?;
     socket_stream_send(&mut stream, &register)

--- a/libraries/message/src/cli_to_coordinator.rs
+++ b/libraries/message/src/cli_to_coordinator.rs
@@ -8,7 +8,8 @@ use crate::{
     BuildId, SessionId,
     common::{DaemonId, GitSource},
     coordinator_to_cli::{
-        CheckDataflowReply, DataflowInfo, DataflowList, NodeInfo, StopDataflowReply, VersionInfo,
+        CheckDataflowReply, DaemonInfo, DataflowInfo, DataflowList, NodeInfo, StopDataflowReply,
+        VersionInfo,
     },
     descriptor::Descriptor,
     id::{NodeId, OperatorId},
@@ -99,4 +100,5 @@ pub trait CoordinatorControl {
     async fn cli_and_default_daemon_on_same_machine(machine_uid: Option<String>) -> Result<bool>;
     async fn get_node_info() -> Result<Vec<NodeInfo>>;
     async fn get_version() -> VersionInfo;
+    async fn list_daemons() -> Result<Vec<DaemonInfo>>;
 }

--- a/libraries/message/src/coordinator_to_cli.rs
+++ b/libraries/message/src/coordinator_to_cli.rs
@@ -121,3 +121,13 @@ pub struct VersionInfo {
     /// The dora-message crate version used by the coordinator (e.g. "0.7.0")
     pub message_format_version: String,
 }
+
+/// Information about a single connected daemon, returned by `list_daemons`.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DaemonInfo {
+    pub daemon_id: DaemonId,
+    /// Whether the daemon opened a Zenoh session.
+    pub zenoh_ready: bool,
+    /// The Zenoh ZID of the daemon's session, if open.
+    pub zenoh_peer_id: Option<String>,
+}

--- a/libraries/message/src/daemon_to_coordinator.rs
+++ b/libraries/message/src/daemon_to_coordinator.rs
@@ -37,14 +37,18 @@ pub struct DaemonRegisterRequest {
     /// even behind NAT.
     #[serde(default)]
     pub machine_uid: Option<String>,
+    /// Zenoh ZID reported by the daemon's local zenoh::Session, if one was opened.
+    #[serde(default)]
+    pub zenoh_peer_id: Option<String>,
 }
 
 impl DaemonRegisterRequest {
-    pub fn new(machine_id: Option<String>) -> Self {
+    pub fn new(machine_id: Option<String>, zenoh_peer_id: Option<String>) -> Self {
         Self {
             dora_version: current_crate_version(),
             machine_id,
             machine_uid: crate::common::machine_uid(),
+            zenoh_peer_id,
         }
     }
 


### PR DESCRIPTION
Closes: #1533 

 - `dora system status` now shows each connected daemon's Zenoh session status right below the "Daemon: Running" line:
 
<img width="748" height="115" alt="Screenshot 2026-03-25 at 8 18 54 PM" src="https://github.com/user-attachments/assets/1c343760-0f52-480b-ae28-9ca8a922160a" />

- If the daemon has no Zenoh session, it shows ✗ with a — for the peer ID.

---

**How it works**
- DaemonRegisterRequest — added `zenoh_peer_id: Option<String>`, extracted from `state.zenoh_session.zid()` at registration
 - `listener.rs` — forwards the field from the raw TCP registration into the internal `DaemonRequest::Register` event
- DaemonConnection (coordinator) — stores the ZID per connected daemon
- New `list_daemons()` RPC on `CoordinatorControl` — returns a `Vec<DaemonInfo>` with ID + Zenoh status
- `system/status.rs` — calls `list_daemons()` and prints the rows

All fields use `#[serde(default)]` so old daemons connecting to a new coordinator (or vice versa) don't break — they just show `✗`.