### PR TITLE
fix(cli): replace unwrap with proper error on non-UTF-8 path

### DIFF
--- a/binaries/cli/src/template/cxx/mod.rs
+++ b/binaries/cli/src/template/cxx/mod.rs
@@ -69,7 +69,12 @@ fn create_cmakefile(root: PathBuf, use_path_deps: bool) -> Result<(), eyre::ErrR
             .context("Could not get manifest parent folder")?
             .parent()
             .context("Could not get manifest grandparent folder")?;
-        CMAKEFILE.replace("__DORA_PATH__", workspace_dir.to_str().unwrap())
+        CMAKEFILE.replace(
+            "__DORA_PATH__",
+            workspace_dir
+                .to_str()
+                .context("workspace directory path is not valid UTF-8")?,
+        )
     } else {
         CMAKEFILE.replace("__DORA_PATH__", "")
     };


### PR DESCRIPTION
## Summary

- `Path::to_str()` returns `Option<&str>` and yields `None` for non-UTF-8 paths
- `create_cmakefile` in `binaries/cli/src/template/cxx/mod.rs` was calling `.unwrap()` on it, causing a panic instead of a user-facing error
- Replaced with `.context(...)` so the error propagates cleanly through the existing `eyre::Result` return type, consistent with the rest of the function

## Test plan

- [ ] Run `dora new --lang cxx --use-path-deps <name>` on a system with a non-UTF-8 path — returns a clear error instead of panicking
- [ ] Run `dora new --lang cxx --use-path-deps <name>` on a normal UTF-8 path — behaviour unchanged