### PR TITLE
chore: Remove dead daemon modules

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -2,7 +2,7 @@ use aligned_vec::{AVec, ConstAlign};
 use crossbeam::queue::ArrayQueue;
 use dora_core::{
     build::{self, BuildInfo, PrevGitSource, TracingBuildLogger},
-    config::{DataId, Input, InputMapping, NodeId, NodeRunConfig, OperatorId},
+    config::{DataId, Input, InputMapping, NodeId, NodeRunConfig},
     descriptor::{
         CoreNodeKind, DYNAMIC_SOURCE, Descriptor, DescriptorExt, ResolvedNode, RuntimeNode,
         read_as_descriptor,
@@ -983,100 +983,6 @@ impl Daemon {
     }
 
     #[allow(clippy::too_many_arguments)]
-    async fn build_dataflow(
-        &mut self,
-        build_id: BuildId,
-        session_id: SessionId,
-        base_working_dir: PathBuf,
-        git_sources: BTreeMap<NodeId, GitSource>,
-        prev_git_sources: BTreeMap<NodeId, GitSource>,
-        dataflow_descriptor: Descriptor,
-        local_nodes: BTreeSet<NodeId>,
-        uv: bool,
-    ) -> eyre::Result<impl Future<Output = eyre::Result<BuildInfo>> + use<>> {
-        let builder = build::Builder {
-            session_id,
-            base_working_dir,
-            uv,
-        };
-        {
-            let mut git_manager = self.state.git_manager.lock().await;
-            git_manager.clear_planned_builds(session_id);
-        }
-
-        let nodes = dataflow_descriptor.resolve_aliases_and_set_defaults()?;
-
-        let mut tasks = Vec::new();
-
-        // build nodes
-        for node in nodes.into_values().filter(|n| local_nodes.contains(&n.id)) {
-            let dynamic_node = node.kind.dynamic();
-
-            let node_id = node.id.clone();
-            let mut logger = self.logger.for_node_build(build_id, node_id.clone());
-            logger.log(LogLevel::Debug, "building").await;
-            let git_source = git_sources.get(&node_id).cloned();
-            let prev_git_source = prev_git_sources.get(&node_id).cloned();
-            let prev_git = prev_git_source.map(|prev_source| PrevGitSource {
-                still_needed_for_this_build: git_sources.values().any(|s| s == &prev_source),
-                git_source: prev_source,
-            });
-
-            let logger_cloned = logger
-                .try_clone_impl()
-                .await
-                .wrap_err("failed to clone logger")?;
-
-            let mut builder = builder.clone();
-            if let Some(node_working_dir) =
-                node.deploy.as_ref().and_then(|d| d.working_dir.as_deref())
-            {
-                builder.base_working_dir = builder.base_working_dir.join(node_working_dir);
-            }
-
-            let mut git_manager = self.state.git_manager.lock().await;
-            match builder
-                .build_node(node, git_source, prev_git, logger_cloned, &mut git_manager)
-                .await
-                .wrap_err_with(|| format!("failed to build node `{node_id}`"))
-            {
-                Ok(result) => {
-                    tasks.push(NodeBuildTask {
-                        node_id,
-                        task: result,
-                        dynamic_node,
-                    });
-                }
-                Err(err) => {
-                    logger.log(LogLevel::Error, format!("{err:?}")).await;
-                    return Err(err);
-                }
-            }
-        }
-
-        let task = async move {
-            let mut info = BuildInfo {
-                node_working_dirs: Default::default(),
-            };
-            for task in tasks {
-                let NodeBuildTask {
-                    node_id,
-                    dynamic_node: _,
-                    task,
-                } = task;
-                let node = task
-                    .await
-                    .with_context(|| format!("failed to build node `{node_id}`"))?;
-                info.node_working_dirs
-                    .insert(node_id, node.node_working_dir);
-            }
-            Ok(info)
-        };
-
-        Ok(task)
-    }
-
-    #[allow(clippy::too_many_arguments)]
     async fn spawn_dataflow(
         &mut self,
         build_id: Option<BuildId>,
@@ -1690,30 +1596,6 @@ impl Daemon {
                     None => Err(format!("no running dataflow with ID `{dataflow_id}`")),
                 };
                 let _ = reply_sender.send(DaemonReply::Result(reply));
-            }
-        }
-        Ok(())
-    }
-
-    async fn send_reload(
-        &mut self,
-        dataflow_id: Uuid,
-        node_id: NodeId,
-        operator_id: Option<OperatorId>,
-    ) -> Result<(), eyre::ErrReport> {
-        let mut dataflow = self.state.running.get_mut(&dataflow_id).wrap_err_with(|| {
-            format!("Reload failed: no running dataflow with ID `{dataflow_id}`")
-        })?;
-        if let Some(channel) = dataflow.subscribe_channels.get(&node_id) {
-            match send_with_timestamp(
-                channel,
-                NodeEvent::Reload { operator_id },
-                &self.state.clock,
-            ) {
-                Ok(()) => {}
-                Err(_) => {
-                    dataflow.subscribe_channels.remove(&node_id);
-                }
             }
         }
         Ok(())
@@ -2525,14 +2407,6 @@ impl Daemon {
             }
         }
         Ok(())
-    }
-
-    fn base_working_dir(
-        &self,
-        local_working_dir: Option<PathBuf>,
-        session_id: SessionId,
-    ) -> eyre::Result<PathBuf> {
-        Self::base_working_dir_static(local_working_dir, session_id)
     }
 
     /// Static version of `base_working_dir`, usable without a `Daemon` instance.
@@ -3487,12 +3361,6 @@ pub enum DoraEvent {
         /// Whether the node will be restarted
         restart: bool,
     },
-}
-
-#[must_use]
-enum RunStatus {
-    Continue,
-    Exit,
 }
 
 fn send_with_timestamp<T>(


### PR DESCRIPTION
### Description
As part of exploring the core engine for **GSoC 2026 Project #6 (Cleanup and Refactor Unused Features)**, I am submitting this PR to address technical debt by removing unused experimental modules in the daemon.

* **Removed Dead Daemon Methods:** Safely removed `build_dataflow`, `send_reload`, and `base_working_dir` from the `Daemon` implementation as they are no longer utilized by the engine.
* **Removed Orphaned Logger:** Deleted the `NodeBuildLogger` struct, its associated implementation blocks, and the `for_node_build` method from `DaemonLogger`.
* **Cleaned up Enums & Imports:** Removed the unused `RunStatus` enum, the internal `log_build` helper, and cleaned up leftover imports (e.g., unused `oneshot::Sender`).

### Testing
* `cargo check -p dora-daemon` passes cleanly with the dead modules amputated.
* Resolved upstream merge conflicts to ensure a clean slate.