### PR TITLE
fix(ci): suppress terminating errors in Windows disk cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Free disk Space (Windows)
         if: runner.os == 'Windows'
         run: |
+          $ErrorActionPreference = 'SilentlyContinue'
           docker system prune --all -f 2>$null; $true
           docker builder prune -af 2>$null; $true
           Remove-Item "C:\Android" -Force -Recurse -ErrorAction SilentlyContinue
@@ -128,6 +129,7 @@ jobs:
       - name: Free disk Space (Windows)
         if: runner.os == 'Windows'
         run: |
+          $ErrorActionPreference = 'SilentlyContinue'
           docker system prune --all -f 2>$null; $true
           docker builder prune -af 2>$null; $true
           Remove-Item "C:\Android" -Force -Recurse -ErrorAction SilentlyContinue


### PR DESCRIPTION
GitHub Actions sets $ErrorActionPreference = 'Stop' by default in PowerShell, which causes Remove-Item to throw terminating errors on locked files. -ErrorAction SilentlyContinue only handles non-terminating errors.

Setting $ErrorActionPreference = 'SilentlyContinue' at the script level ensures this best-effort cleanup step never fails the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)