### PR TITLE
chore: remove unimplemented WASM operator source

### DIFF
--- a/binaries/runtime/src/operator/mod.rs
+++ b/binaries/runtime/src/operator/mod.rs
@@ -62,9 +62,6 @@ pub fn run_operator(
                 "Dora runtime tried spawning Python Operator outside of python environment."
             );
         }
-        OperatorSource::Wasm(_) => {
-            tracing::error!("WASM operators are not supported yet");
-        }
     }
     Ok(())
 }

--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -110,21 +110,6 @@ pub fn check_dataflow(
                                 ));
                             }
                         }
-                        OperatorSource::Wasm(path) => {
-                            if source_is_url(path) {
-                                if let Err(err) = check_url(path) {
-                                    errors.push(format!(
-                                        "node `{}`, operator `{}`: {err}",
-                                        node.id, operator_definition.id,
-                                    ));
-                                }
-                            } else if !working_dir.join(path).exists() {
-                                errors.push(format!(
-                                    "node `{}`, operator `{}`: no WASM library at `{path}`",
-                                    node.id, operator_definition.id,
-                                ));
-                            }
-                        }
                     }
                 }
             }

--- a/libraries/message/src/descriptor.rs
+++ b/libraries/message/src/descriptor.rs
@@ -609,8 +609,6 @@ pub struct OperatorConfig {
 pub enum OperatorSource {
     SharedLibrary(String),
     Python(PythonSource),
-    #[schemars(skip)]
-    Wasm(String),
 }
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(from = "PythonSourceDef", into = "PythonSourceDef")]


### PR DESCRIPTION
The WASM operator source was defined in the codebase but never implemented.  The runtime simply logged an error when a WASM operator was encountered. There are no examples, docs, or tests referencing WASM operators.

This pr cleans up Wasm across three files:
- libraries/message/src/descriptor.rs: removed Wasm(String) variant from OperatorSource
- libraries/core/src/descriptor/validate.rs: removed Wasm validation branch
- binaries/runtime/src/operator/mod.rs: removed unimplemented Wasm match arm

This pr is related to GSoC 2026 Project #6: Cleanup and Refactor Unused Features

