### PR TITLE
fix(runtime): prevent panic on unknown operator_id in reload handler

### DIFF
--- a/binaries/runtime/src/lib.rs
+++ b/binaries/runtime/src/lib.rs
@@ -242,9 +242,11 @@ async fn run(
             RuntimeEvent::Event(Event::Reload {
                 operator_id: Some(operator_id),
             }) => {
-                let _ = operator_channels
-                    .get(&operator_id)
-                    .unwrap()
+                let Some(channel) = operator_channels.get(&operator_id) else {
+                    tracing::warn!("received reload event for unknown operator `{operator_id}`");
+                    continue;
+                };
+                let _ = channel
                     .send_async(Event::Reload {
                         operator_id: Some(operator_id),
                     })


### PR DESCRIPTION
### 1. SUMMARY

Fixes a panic in the runtime reload handler when an unknown `operator_id` is received.
Updates `binaries/runtime/src/lib.rs` to safely handle missing operators instead of crashing.

---

### 2. FIX

* **Before**

```rust id="p0i3n2"
operator_channels
    .get(&operator_id)
    .unwrap()
```

* **After**

```rust id="k9x2bz"
let Some(channel) = operator_channels.get(&operator_id) else {
    tracing::warn!("received reload event for unknown operator `{operator_id}`");
    continue;
};
```

---

### 3. VERIFICATION

Run `dora run examples/python-operator/dataflow.yml` and trigger a reload while an operator is being removed (or simulate a stale `operator_id`).

After this change, the runtime no longer panics. Instead, it logs a warning for the unknown operator and continues running normally.
