### PR TITLE
fix(daemon): replace expect with context in spawn_inner

### DIFF
--- a/binaries/daemon/src/spawn/prepared.rs
+++ b/binaries/daemon/src/spawn/prepared.rs
@@ -296,9 +296,9 @@ impl PreparedNode {
             &self.node.id,
         ))
         .await
-        .expect("Failed to create log file");
+        .context("failed to create log file")?;
         let mut child_stdout =
-            tokio::io::BufReader::new(child.stdout().take().expect("failed to take stdout"));
+            tokio::io::BufReader::new(child.stdout().take().context("failed to take stdout")?);
         let stdout_tx = tx.clone();
         let node_id = self.node.id.clone();
         let mut logger_c = logger.try_clone().await?;
@@ -352,7 +352,7 @@ impl PreparedNode {
         });
 
         let mut child_stderr =
-            tokio::io::BufReader::new(child.stderr().take().expect("failed to take stderr"));
+            tokio::io::BufReader::new(child.stderr().take().context("failed to take stderr")?);
 
         // Stderr listener stream
         let stderr_tx = tx.clone();


### PR DESCRIPTION
## SUMMARY

Fixes daemon crashes by replacing `.expect()` with proper error handling in `spawn_inner()`. Errors now return cleanly instead of panicking.

---

## FIX

```rust
// before
.expect("Failed to create log file")

// after
.context("failed to create log file")?
```

---

## VERIFICATION

* Break log path / fill disk → no crash
* Disable stdout/stderr → no crash

**Result:** daemon stays up, errors are logged properly.