### PR TITLE
feat(coordinator): open Zenoh session on startup and log peer ID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1579,6 +1579,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "uuid",
+ "zenoh",
 ]
 
 [[package]]

--- a/binaries/coordinator/Cargo.toml
+++ b/binaries/coordinator/Cargo.toml
@@ -20,7 +20,8 @@ futures = "0.3.21"
 tokio = { version = "1.24.2", features = ["full"] }
 tokio-stream = { version = "0.1.8", features = ["io-util", "net"] }
 uuid = { version = "1.2.1" }
-dora-core = { workspace = true, features = ["build"] }
+dora-core = { workspace = true, features = ["build", "zenoh"] }
+zenoh = { workspace = true }
 tracing = "0.1.36"
 dora-tracing = { workspace = true, optional = true }
 futures-concurrency = "7.1.0"

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -6,6 +6,7 @@ use dashmap::{
 use dora_core::{
     config::{NodeId, OperatorId},
     descriptor::DescriptorExt,
+    topics::open_zenoh_session,
     uhlc::{self, HLC},
 };
 use dora_message::{
@@ -135,6 +136,13 @@ async fn init_coordinator(
 )> {
     use tokio_stream::wrappers::TcpListenerStream;
 
+    let zenoh_session = Arc::new(
+        open_zenoh_session(Some(bind.ip()))
+            .await
+            .wrap_err("failed to open Zenoh session for coordinator")?,
+    );
+    tracing::info!("coordinator Zenoh peer ID: {}", zenoh_session.zid());
+
     let daemon_listener = listener::create_listener(bind).await?;
     let daemon_port = daemon_listener
         .local_addr()
@@ -162,6 +170,7 @@ async fn init_coordinator(
     let (daemon_events_tx, daemon_events) = tokio::sync::mpsc::channel(100);
     let coordinator_state = Arc::new(state::CoordinatorState {
         clock: Arc::new(HLC::default()),
+        zenoh_session,
         running_builds: Default::default(),
         finished_builds: Default::default(),
         running_dataflows: Default::default(),

--- a/binaries/coordinator/src/state.rs
+++ b/binaries/coordinator/src/state.rs
@@ -14,6 +14,7 @@ use crate::{
 
 pub struct CoordinatorState {
     pub clock: Arc<HLC>,
+    pub zenoh_session: Arc<zenoh::Session>,
     pub running_builds: DashMap<BuildId, RunningBuild>,
     pub finished_builds: DashMap<BuildId, CachedResult<BuildFinishedResult>>,
     pub running_dataflows: DashMap<DataflowId, RunningDataflow>,


### PR DESCRIPTION
Closes #1571 

Every daemon opens a Zenoh session on startup — the coordinator didn't. This PR adds that, using the same `open_zenoh_session()` helper already used by daemons. The coordinator's ZID is logged at startup and the session is stored in `CoordinatorState`, leveling it up with `DaemonState`