### PR TITLE
feat(cli): add `--mode` flag to `dora build` for parallel/sequential builds

### DIFF
--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -608,6 +608,7 @@ pub fn build(
         coordinator_port,
         uv.unwrap_or_default(),
         force_local,
+        dora_cli::BuildMode::Sequential,
     )
 }
 

--- a/binaries/cli/src/command/build/local.rs
+++ b/binaries/cli/src/command/build/local.rs
@@ -8,6 +8,7 @@ use dora_core::{
 use dora_message::{common::GitSource, id::NodeId};
 use eyre::Context;
 
+use crate::command::build::BuildMode;
 use crate::session::DataflowSession;
 
 pub async fn build_dataflow_locally(
@@ -16,8 +17,17 @@ pub async fn build_dataflow_locally(
     dataflow_session: &DataflowSession,
     working_dir: PathBuf,
     uv: bool,
+    mode: BuildMode,
 ) -> eyre::Result<BuildInfo> {
-    build_dataflow(dataflow, git_sources, dataflow_session, working_dir, uv).await
+    build_dataflow(
+        dataflow,
+        git_sources,
+        dataflow_session,
+        working_dir,
+        uv,
+        mode,
+    )
+    .await
 }
 
 async fn build_dataflow(
@@ -26,6 +36,7 @@ async fn build_dataflow(
     dataflow_session: &DataflowSession,
     base_working_dir: PathBuf,
     uv: bool,
+    mode: BuildMode,
 ) -> eyre::Result<BuildInfo> {
     let builder = Builder {
         session_id: dataflow_session.session_id,
@@ -68,12 +79,31 @@ async fn build_dataflow(
     let mut info = BuildInfo {
         node_working_dirs: Default::default(),
     };
-    for (node_id, task) in tasks {
-        let node = task
-            .await
-            .with_context(|| format!("failed to build node `{node_id}`"))?;
-        info.node_working_dirs
-            .insert(node_id, node.node_working_dir);
+
+    if mode == BuildMode::Parallel {
+        use futures::stream::{FuturesUnordered, StreamExt};
+        let mut futures = FuturesUnordered::new();
+        for (node_id, task) in tasks {
+            futures.push(async move {
+                let node = task
+                    .await
+                    .with_context(|| format!("failed to build node `{node_id}`"))?;
+                Ok::<_, eyre::Report>((node_id, node))
+            });
+        }
+        while let Some(result) = futures.next().await {
+            let (node_id, node) = result?;
+            info.node_working_dirs
+                .insert(node_id, node.node_working_dir);
+        }
+    } else {
+        for (node_id, task) in tasks {
+            let node = task
+                .await
+                .with_context(|| format!("failed to build node `{node_id}`"))?;
+            info.node_working_dirs
+                .insert(node_id, node.node_working_dir);
+        }
     }
     Ok(info)
 }

--- a/binaries/cli/src/command/build/mod.rs
+++ b/binaries/cli/src/command/build/mod.rs
@@ -86,6 +86,16 @@ pub struct Build {
     // Run build on local machine
     #[clap(long, action)]
     local: bool,
+    /// Build mode: `sequential` or `parallel`. Defaults to `sequential` for backward compatibility
+    #[clap(long, value_enum, default_value_t = BuildMode::Sequential)]
+    mode: BuildMode,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, clap::ValueEnum)]
+pub enum BuildMode {
+    #[default]
+    Sequential,
+    Parallel,
 }
 
 impl Executable for Build {
@@ -97,6 +107,7 @@ impl Executable for Build {
             self.coordinator_port,
             self.uv,
             self.local,
+            self.mode,
         )
         .await
     }
@@ -108,6 +119,7 @@ pub fn build(
     coordinator_port: Option<u16>,
     uv: bool,
     force_local: bool,
+    mode: BuildMode,
 ) -> eyre::Result<()> {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -119,6 +131,7 @@ pub fn build(
         coordinator_port,
         uv,
         force_local,
+        mode,
     ))
 }
 
@@ -128,6 +141,7 @@ pub async fn build_async(
     coordinator_port: Option<u16>,
     uv: bool,
     force_local: bool,
+    mode: BuildMode,
 ) -> eyre::Result<()> {
     let dataflow_path = resolve_dataflow(dataflow)
         .await
@@ -156,15 +170,13 @@ pub async fn build_async(
     let session = || connect_to_coordinator_rpc_with_defaults(coordinator_addr, coordinator_port);
 
     let build_kind = if force_local {
-        tracing::info!("Building locally, as requested through `--force-local`");
+        log::info!("Building locally, as requested through `--force-local`");
         BuildKind::Local
     } else if dataflow_descriptor.nodes.iter().all(|n| n.deploy.is_none()) {
-        tracing::info!("Building locally because dataflow does not contain any `deploy` sections");
+        log::info!("Building locally because dataflow does not contain any `deploy` sections");
         BuildKind::Local
     } else if coordinator_addr.is_some() || coordinator_port.is_some() {
-        tracing::info!(
-            "Building through coordinator, using the given coordinator socket information"
-        );
+        log::info!("Building through coordinator, using the given coordinator socket information");
         // explicit coordinator address or port set -> there should be a coordinator running
         BuildKind::ThroughCoordinator {
             coordinator_client: session()
@@ -175,13 +187,11 @@ pub async fn build_async(
         match session().await {
             Ok(coordinator_client) => {
                 // we found a local coordinator instance at default port -> use it for building
-                tracing::info!(
-                    "Found local dora coordinator instance -> building through coordinator"
-                );
+                log::info!("Found local dora coordinator instance -> building through coordinator");
                 BuildKind::ThroughCoordinator { coordinator_client }
             }
             Err(_) => {
-                tracing::warn!("No dora coordinator instance found -> trying a local build");
+                log::warn!("No dora coordinator instance found -> trying a local build");
                 // no coordinator instance found -> do a local build
                 BuildKind::Local
             }
@@ -190,7 +200,7 @@ pub async fn build_async(
 
     match build_kind {
         BuildKind::Local => {
-            tracing::info!("running local build");
+            log::info!("running local build");
             // use dataflow dir as base working dir
             let local_working_dir = dunce::canonicalize(&dataflow_path)
                 .context("failed to canonicalize dataflow path")?
@@ -203,6 +213,7 @@ pub async fn build_async(
                 &dataflow_session,
                 local_working_dir,
                 uv,
+                mode,
             )
             .await?;
 
@@ -257,3 +268,4 @@ async fn connect_to_coordinator_rpc_with_defaults(
     let control_port = coordinator_port.unwrap_or(DORA_COORDINATOR_PORT_CONTROL_DEFAULT);
     connect_and_check_version(addr, control_port).await
 }
+

--- a/binaries/cli/src/command/build/mod.rs
+++ b/binaries/cli/src/command/build/mod.rs
@@ -268,4 +268,3 @@ async fn connect_to_coordinator_rpc_with_defaults(
     let control_port = coordinator_port.unwrap_or(DORA_COORDINATOR_PORT_CONTROL_DEFAULT);
     connect_and_check_version(addr, control_port).await
 }
-

--- a/binaries/cli/src/command/build/mod.rs
+++ b/binaries/cli/src/command/build/mod.rs
@@ -86,7 +86,7 @@ pub struct Build {
     // Run build on local machine
     #[clap(long, action)]
     local: bool,
-    /// Build mode: `sequential` or `parallel`. Defaults to `sequential` for backward compatibility
+    /// Build mode sequential or parallel. Defaults to sequential
     #[clap(long, value_enum, default_value_t = BuildMode::Sequential)]
     mode: BuildMode,
 }

--- a/binaries/cli/src/command/mod.rs
+++ b/binaries/cli/src/command/mod.rs
@@ -1,4 +1,4 @@
-mod build;
+pub mod build;
 mod completion;
 mod coordinator;
 mod daemon;

--- a/binaries/cli/src/lib.rs
+++ b/binaries/cli/src/lib.rs
@@ -13,6 +13,7 @@ mod template;
 
 pub use command::{Executable, Run as RunCommand, run, run_func};
 pub use command::{build, build_async};
+pub use command::build::BuildMode;
 
 const LOCALHOST: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
 const LISTEN_WILDCARD: IpAddr = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));

--- a/binaries/cli/src/lib.rs
+++ b/binaries/cli/src/lib.rs
@@ -11,9 +11,9 @@ pub mod output;
 pub mod session;
 mod template;
 
+pub use command::build::BuildMode;
 pub use command::{Executable, Run as RunCommand, run, run_func};
 pub use command::{build, build_async};
-pub use command::build::BuildMode;
 
 const LOCALHOST: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
 const LISTEN_WILDCARD: IpAddr = IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0));

--- a/examples/benchmark/run.rs
+++ b/examples/benchmark/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run, BuildMode};
+use dora_cli::{BuildMode, build, run};
 use eyre::Context;
 use std::path::Path;
 
@@ -7,7 +7,14 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build("dataflow.yml".to_string(), None, None, false, true, BuildMode::Sequential)?;
+    build(
+        "dataflow.yml".to_string(),
+        None,
+        None,
+        false,
+        true,
+        BuildMode::Sequential,
+    )?;
 
     run("dataflow.yml".to_string(), false)?;
 

--- a/examples/benchmark/run.rs
+++ b/examples/benchmark/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run};
+use dora_cli::{build, run, BuildMode};
 use eyre::Context;
 use std::path::Path;
 
@@ -7,7 +7,7 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build("dataflow.yml".to_string(), None, None, false, true)?;
+    build("dataflow.yml".to_string(), None, None, false, true, BuildMode::Sequential)?;
 
     run("dataflow.yml".to_string(), false)?;
 

--- a/examples/python-dataflow/run.rs
+++ b/examples/python-dataflow/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run as dora_run, BuildMode};
+use dora_cli::{BuildMode, build, run as dora_run};
 use eyre::WrapErr;
 use std::path::Path;
 
@@ -7,7 +7,14 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build("dataflow.yml".to_string(), None, None, true, true, BuildMode::Sequential)?;
+    build(
+        "dataflow.yml".to_string(),
+        None,
+        None,
+        true,
+        true,
+        BuildMode::Sequential,
+    )?;
 
     dora_run("dataflow.yml".to_string(), true)?;
 

--- a/examples/python-dataflow/run.rs
+++ b/examples/python-dataflow/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run as dora_run};
+use dora_cli::{build, run as dora_run, BuildMode};
 use eyre::WrapErr;
 use std::path::Path;
 
@@ -7,7 +7,7 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build("dataflow.yml".to_string(), None, None, true, true)?;
+    build("dataflow.yml".to_string(), None, None, true, true, BuildMode::Sequential)?;
 
     dora_run("dataflow.yml".to_string(), true)?;
 

--- a/examples/python-operator-dataflow/run.rs
+++ b/examples/python-operator-dataflow/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run as dora_run, BuildMode};
+use dora_cli::{BuildMode, build, run as dora_run};
 use eyre::WrapErr;
 use std::path::Path;
 
@@ -7,7 +7,14 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build("dataflow.yml".to_string(), None, None, true, true, BuildMode::Sequential)?;
+    build(
+        "dataflow.yml".to_string(),
+        None,
+        None,
+        true,
+        true,
+        BuildMode::Sequential,
+    )?;
 
     dora_run("dataflow.yml".to_string(), true)?;
 

--- a/examples/python-operator-dataflow/run.rs
+++ b/examples/python-operator-dataflow/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run as dora_run};
+use dora_cli::{build, run as dora_run, BuildMode};
 use eyre::WrapErr;
 use std::path::Path;
 
@@ -7,7 +7,7 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build("dataflow.yml".to_string(), None, None, true, true)?;
+    build("dataflow.yml".to_string(), None, None, true, true, BuildMode::Sequential)?;
 
     dora_run("dataflow.yml".to_string(), true)?;
 

--- a/examples/ros2-bridge/python/turtle/run.rs
+++ b/examples/ros2-bridge/python/turtle/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run as dora_run, BuildMode};
+use dora_cli::{BuildMode, build, run as dora_run};
 use eyre::WrapErr;
 use std::path::Path;
 
@@ -9,7 +9,14 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build("dataflow.yml".to_string(), None, None, true, true, BuildMode::Sequential)?;
+    build(
+        "dataflow.yml".to_string(),
+        None,
+        None,
+        true,
+        true,
+        BuildMode::Sequential,
+    )?;
 
     let dataflow_task = std::thread::spawn(|| {
         dora_run("dataflow.yml".to_string(), true).unwrap();

--- a/examples/ros2-bridge/python/turtle/run.rs
+++ b/examples/ros2-bridge/python/turtle/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run as dora_run};
+use dora_cli::{build, run as dora_run, BuildMode};
 use eyre::WrapErr;
 use std::path::Path;
 
@@ -9,7 +9,7 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build("dataflow.yml".to_string(), None, None, true, true)?;
+    build("dataflow.yml".to_string(), None, None, true, true, BuildMode::Sequential)?;
 
     let dataflow_task = std::thread::spawn(|| {
         dora_run("dataflow.yml".to_string(), true).unwrap();

--- a/examples/ros2-bridge/rust/service-client/run.rs
+++ b/examples/ros2-bridge/rust/service-client/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run};
+use dora_cli::{build, run, BuildMode};
 use eyre::Context;
 use std::path::Path;
 
@@ -9,7 +9,7 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join("../../../").join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build("dataflow.yml".to_string(), None, None, false, true)?;
+    build("dataflow.yml".to_string(), None, None, false, true, BuildMode::Sequential)?;
 
     let dataflow_task = std::thread::spawn(|| {
         run("dataflow.yml".to_string(), false).unwrap();

--- a/examples/ros2-bridge/rust/service-client/run.rs
+++ b/examples/ros2-bridge/rust/service-client/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run, BuildMode};
+use dora_cli::{BuildMode, build, run};
 use eyre::Context;
 use std::path::Path;
 
@@ -9,7 +9,14 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join("../../../").join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build("dataflow.yml".to_string(), None, None, false, true, BuildMode::Sequential)?;
+    build(
+        "dataflow.yml".to_string(),
+        None,
+        None,
+        false,
+        true,
+        BuildMode::Sequential,
+    )?;
 
     let dataflow_task = std::thread::spawn(|| {
         run("dataflow.yml".to_string(), false).unwrap();

--- a/examples/ros2-bridge/rust/service-server/run.rs
+++ b/examples/ros2-bridge/rust/service-server/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run};
+use dora_cli::{build, run, BuildMode};
 use eyre::Context;
 use std::{path::Path, sync::mpsc};
 use tokio;
@@ -10,7 +10,7 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join("../../../").join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build("dataflow.yml".to_string(), None, None, false, true)?;
+    build("dataflow.yml".to_string(), None, None, false, true, BuildMode::Sequential)?;
 
     let (finish_tx, finish_rx) = mpsc::channel();
     let dataflow_task = std::thread::spawn(move || {

--- a/examples/ros2-bridge/rust/service-server/run.rs
+++ b/examples/ros2-bridge/rust/service-server/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run, BuildMode};
+use dora_cli::{BuildMode, build, run};
 use eyre::Context;
 use std::{path::Path, sync::mpsc};
 use tokio;
@@ -10,7 +10,14 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join("../../../").join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build("dataflow.yml".to_string(), None, None, false, true, BuildMode::Sequential)?;
+    build(
+        "dataflow.yml".to_string(),
+        None,
+        None,
+        false,
+        true,
+        BuildMode::Sequential,
+    )?;
 
     let (finish_tx, finish_rx) = mpsc::channel();
     let dataflow_task = std::thread::spawn(move || {

--- a/examples/ros2-bridge/rust/topic-pub/run.rs
+++ b/examples/ros2-bridge/rust/topic-pub/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run};
+use dora_cli::{build, run, BuildMode};
 use eyre::Context;
 use std::path::Path;
 
@@ -9,7 +9,7 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join("../../../").join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build("dataflow.yml".to_string(), None, None, false, true)?;
+    build("dataflow.yml".to_string(), None, None, false, true, BuildMode::Sequential)?;
 
     let dataflow_task = std::thread::spawn(|| {
         run("dataflow.yml".to_string(), false).unwrap();

--- a/examples/ros2-bridge/rust/topic-pub/run.rs
+++ b/examples/ros2-bridge/rust/topic-pub/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run, BuildMode};
+use dora_cli::{BuildMode, build, run};
 use eyre::Context;
 use std::path::Path;
 
@@ -9,7 +9,14 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join("../../../").join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build("dataflow.yml".to_string(), None, None, false, true, BuildMode::Sequential)?;
+    build(
+        "dataflow.yml".to_string(),
+        None,
+        None,
+        false,
+        true,
+        BuildMode::Sequential,
+    )?;
 
     let dataflow_task = std::thread::spawn(|| {
         run("dataflow.yml".to_string(), false).unwrap();

--- a/examples/ros2-bridge/rust/topic-sub/run.rs
+++ b/examples/ros2-bridge/rust/topic-sub/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run};
+use dora_cli::{build, run, BuildMode};
 use eyre::Context;
 use std::path::Path;
 
@@ -9,7 +9,7 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join("../../../").join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build("dataflow.yml".to_string(), None, None, false, true)?;
+    build("dataflow.yml".to_string(), None, None, false, true, BuildMode::Sequential)?;
 
     let dataflow_task = std::thread::spawn(|| {
         run("dataflow.yml".to_string(), false).unwrap();

--- a/examples/ros2-bridge/rust/topic-sub/run.rs
+++ b/examples/ros2-bridge/rust/topic-sub/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run, BuildMode};
+use dora_cli::{BuildMode, build, run};
 use eyre::Context;
 use std::path::Path;
 
@@ -9,7 +9,14 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join("../../../").join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build("dataflow.yml".to_string(), None, None, false, true, BuildMode::Sequential)?;
+    build(
+        "dataflow.yml".to_string(),
+        None,
+        None,
+        false,
+        true,
+        BuildMode::Sequential,
+    )?;
 
     let dataflow_task = std::thread::spawn(|| {
         run("dataflow.yml".to_string(), false).unwrap();

--- a/examples/ros2-bridge/rust/turtle/run.rs
+++ b/examples/ros2-bridge/rust/turtle/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run};
+use dora_cli::{build, run, BuildMode};
 use eyre::Context;
 use std::path::Path;
 
@@ -9,7 +9,7 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join("../../../").join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build("dataflow.yml".to_string(), None, None, false, true)?;
+    build("dataflow.yml".to_string(), None, None, false, true, BuildMode::Sequential)?;
 
     let dataflow_task = std::thread::spawn(|| {
         run("dataflow.yml".to_string(), false).unwrap();

--- a/examples/ros2-bridge/rust/turtle/run.rs
+++ b/examples/ros2-bridge/rust/turtle/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run, BuildMode};
+use dora_cli::{BuildMode, build, run};
 use eyre::Context;
 use std::path::Path;
 
@@ -9,7 +9,14 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join("../../../").join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build("dataflow.yml".to_string(), None, None, false, true, BuildMode::Sequential)?;
+    build(
+        "dataflow.yml".to_string(),
+        None,
+        None,
+        false,
+        true,
+        BuildMode::Sequential,
+    )?;
 
     let dataflow_task = std::thread::spawn(|| {
         run("dataflow.yml".to_string(), false).unwrap();

--- a/examples/rust-dataflow-git/run.rs
+++ b/examples/rust-dataflow-git/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run};
+use dora_cli::{build, run, BuildMode};
 use eyre::Context;
 use std::path::Path;
 
@@ -14,7 +14,7 @@ fn main() -> eyre::Result<()> {
         "dataflow.yml".to_string()
     };
 
-    build(dataflow.clone(), None, None, false, true)?;
+    build(dataflow.clone(), None, None, false, true, dora_cli::BuildMode::Sequential)?;
 
     run(dataflow, false)?;
 

--- a/examples/rust-dataflow-git/run.rs
+++ b/examples/rust-dataflow-git/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run, BuildMode};
+use dora_cli::{BuildMode, build, run};
 use eyre::Context;
 use std::path::Path;
 
@@ -14,7 +14,14 @@ fn main() -> eyre::Result<()> {
         "dataflow.yml".to_string()
     };
 
-    build(dataflow.clone(), None, None, false, true, dora_cli::BuildMode::Sequential)?;
+    build(
+        dataflow.clone(),
+        None,
+        None,
+        false,
+        true,
+        dora_cli::BuildMode::Sequential,
+    )?;
 
     run(dataflow, false)?;
 

--- a/examples/rust-dataflow-url/run.rs
+++ b/examples/rust-dataflow-url/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run, BuildMode};
+use dora_cli::{BuildMode, build, run};
 use eyre::Context;
 use std::path::Path;
 
@@ -7,7 +7,14 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build("dataflow.yml".to_string(), None, None, false, true, BuildMode::Sequential)?;
+    build(
+        "dataflow.yml".to_string(),
+        None,
+        None,
+        false,
+        true,
+        BuildMode::Sequential,
+    )?;
 
     run("dataflow.yml".to_string(), false)?;
 

--- a/examples/rust-dataflow-url/run.rs
+++ b/examples/rust-dataflow-url/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run};
+use dora_cli::{build, run, BuildMode};
 use eyre::Context;
 use std::path::Path;
 
@@ -7,7 +7,7 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build("dataflow.yml".to_string(), None, None, false, true)?;
+    build("dataflow.yml".to_string(), None, None, false, true, BuildMode::Sequential)?;
 
     run("dataflow.yml".to_string(), false)?;
 

--- a/examples/rust-dataflow/run.rs
+++ b/examples/rust-dataflow/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run, BuildMode};
+use dora_cli::{BuildMode, build, run};
 use eyre::Context;
 use std::path::Path;
 
@@ -14,7 +14,14 @@ fn main() -> eyre::Result<()> {
         "dataflow.yml".to_string()
     };
 
-    build(dataflow.clone(), None, None, false, true, BuildMode::Sequential)?;
+    build(
+        dataflow.clone(),
+        None,
+        None,
+        false,
+        true,
+        BuildMode::Sequential,
+    )?;
 
     run(dataflow, false)?;
 

--- a/examples/rust-dataflow/run.rs
+++ b/examples/rust-dataflow/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run};
+use dora_cli::{build, run, BuildMode};
 use eyre::Context;
 use std::path::Path;
 
@@ -14,7 +14,7 @@ fn main() -> eyre::Result<()> {
         "dataflow.yml".to_string()
     };
 
-    build(dataflow.clone(), None, None, false, true)?;
+    build(dataflow.clone(), None, None, false, true, BuildMode::Sequential)?;
 
     run(dataflow, false)?;
 


### PR DESCRIPTION
## Summary

Closes #1570

As of now, `dora build dataflow.yml` builds nodes one at a time. This is safe for low-spec hardware but wastes time on capable development machines. This PR adds a `--mode` flag to `dora build` so users can opt into parallel building.

## Usage

```bash
# Sequential (current default behavior, backward compatible)
dora build dataflow.yml

# Explicitly sequential
dora build --mode sequential dataflow.yml

# Parallel (faster on capable machines)
dora build --mode parallel dataflow.yml
```
## Note 
The feature is most valuable for use cases like dataflows with Python, Rust, and C/C++ nodes from separate projects.
Works for Any combination of independent build commands.
For a pure Rust workspace with all nodes inside it, the gain is minimal because Cargo itself serializes via locks. 
