### PR TITLE
docs: improve Getting Started — fix root README example, expand python-async README, document dora run vs dora start

### DIFF
--- a/examples/python-async/README.md
+++ b/examples/python-async/README.md
@@ -1,10 +1,58 @@
 # Python Async Example
 
-To get started:
+This example shows how to use Python's `asyncio` with dora nodes. Instead of the
+blocking synchronous API (`for event in node:` or `node.next()`), nodes can use
+`await node.recv_async()` to receive events without blocking the thread — allowing
+other coroutines to run concurrently.
+
+Use the async API when your node needs to integrate with async frameworks (e.g.
+`asyncio`, web servers, async I/O libraries).
+
+## Overview
+
+The [`dataflow.yaml`](./dataflow.yaml) defines two nodes:
+
+- **send_data** — triggered every 10ms by a built-in dora timer, sends the current
+  timestamp (nanoseconds, `uint64`) as output `data`. Stops after 100 sends.
+- **receive_data_with_sleep** — receives each timestamp using `await node.recv_async()`
+  inside an `asyncio` event loop. Processes 50 events, then prints `done!` and exits.
+
+```
+dora/timer/millis/10 ──► send_data ──► receive_data_with_sleep
+```
+
+### Sync vs async API
+
+| | Sync | Async |
+|---|---|---|
+| Receive next event | `for event in node:` or `node.next()` | `await node.recv_async()` |
+| Thread behaviour | Blocks until event arrives | Yields to event loop while waiting |
+| Use when | Simple scripts | Integrating with asyncio / async frameworks |
+
+## Getting started
+
+Install dependencies and build the dataflow:
 
 ```bash
+cd examples/python-async
 uv venv --seed -p 3.11
 uv pip install -e ../../apis/python/node
 dora build dataflow.yaml --uv
+```
+
+Run the dataflow:
+
+```bash
 dora run dataflow.yaml --uv
 ```
+
+## Expected output
+
+The `receive_data_with_sleep` node prints a single line after processing 50 events:
+
+```
+done!
+```
+
+No output is produced by `send_data` — it sends timestamps silently and exits after
+100 sends.


### PR DESCRIPTION
## What this fixes

### Root `README.md`
- The "Run" section described a YOLO/webcam example but pointed to `examples/python-dataflow/dataflow.yml`, which is actually the `sender → transformer → receiver` pipeline — not a YOLO pipeline and no webcam required.
- Corrected the shown YAML to match the actual file.
- Removed the misleading `> Make sure to have a webcam` note.
- Added a `dora run` vs `dora start` comparison table (sourced from code comments in `binaries/cli/src/command/run.rs` and `start/mod.rs`).

### `examples/python-async/README.md`
- Was 4 lines with no explanation of what the example demonstrates or what "async" means in this context.
- Rewrote to include: node descriptions, ASCII dataflow diagram, sync vs async API comparison table, and expected output.

## Why
Both files were entry points for new users. The root README mismatch (YOLO description + non-YOLO URL) would cause confusion on first run. The `python-async` README gave no signal to readers about when or why to use the async API.

## Testing
- Verified YAML structure against `examples/python-dataflow/dataflow.yml` directly.
- Verified `dora run` vs `dora start` distinction against source in `binaries/cli/src/command/run.rs` (lines 1–6) and `start/mod.rs` (lines 1–3).
- Verified `python-async` node behaviour by reading `send_data.py` and `receive_data.py`.
