### PR TITLE
feature: service (request-reply pattern) implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1750,6 +1750,7 @@ dependencies = [
  "shared_memory_extended",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ git2 = { version = "0.20.4", features = ["vendored-openssl"] }
 serde_yaml = "0.9.33"
 zenoh = "1.1.1"
 serde_json = "1.0.145"
+uuid = { version = "1.22.0", features = ["v4"] }
 
 [package]
 name = "dora-examples"

--- a/apis/python/node/dora/__init__.pyi
+++ b/apis/python/node/dora/__init__.pyi
@@ -166,6 +166,29 @@ class Node:
         ```
         """
 
+    def send_service_reply(
+        self, service_name: str, data: pyarrow.Array, metadata: dict = None
+    ) -> None:
+        """`send_service_reply` sends a reply to a service request (server-side).
+
+        ```python
+        node.send_service_reply("get_image", image_data, event["metadata"])
+        ```
+        """
+
+    def send_request(
+        self, service_name: str, data: pyarrow.Array, metadata: dict = None
+    ) -> dict:
+        """`send_request` sends a service request and blocks until the reply arrives.
+
+        Returns a dict with 'value' (pyarrow.Array) and 'metadata' (dict).
+
+        ```python
+        reply = node.send_request("get_image", pa.array([]))
+        image = reply["value"]
+        ```
+        """
+
     def __iter__(self) -> typing.Any:
         """Implement iter(self)."""
 

--- a/apis/python/node/dora/__init__.pyi
+++ b/apis/python/node/dora/__init__.pyi
@@ -177,14 +177,14 @@ class Node:
         """
 
     def send_request(
-        self, service_name: str, data: pyarrow.Array, metadata: dict = None
+        self, service_name: str, data: pyarrow.Array, metadata: dict = None, timeout: float = None
     ) -> dict:
         """`send_request` sends a service request and blocks until the reply arrives.
 
         Returns a dict with 'value' (pyarrow.Array) and 'metadata' (dict).
-
+        If timeout (in seconds) is provided and expires, raises an error.
         ```python
-        reply = node.send_request("get_image", pa.array([]))
+        reply = node.send_request("get_image", pa.array([]), timeout=5.0)
         image = reply["value"]
         ```
         """

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -6,14 +6,16 @@ use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 use tokio::sync::Mutex;
 
-use arrow::pyarrow::{FromPyArrow, ToPyArrow};
 use arrow::array::Array;
+use arrow::pyarrow::{FromPyArrow, ToPyArrow};
 use dora_download::download_file;
 use dora_node_api::dora_core::config::{DataId, NodeId};
 use dora_node_api::dora_core::descriptor::source_is_url;
 use dora_node_api::merged::{MergeExternalSend, MergedEvent};
 use dora_node_api::{DataflowId, DoraNode, EventStream, TryRecvError, init_tracing};
-use dora_operator_api_python::{DelayedCleanup, NodeCleanupHandle, PyEvent, pydict_to_metadata, metadata_to_pydict};
+use dora_operator_api_python::{
+    DelayedCleanup, NodeCleanupHandle, PyEvent, metadata_to_pydict, pydict_to_metadata,
+};
 use dora_ros2_bridge_python::Ros2Subscription;
 use eyre::{Context, ContextCompat};
 
@@ -419,9 +421,7 @@ impl Node {
                 .get_mut()
                 .send_service_reply(service_name.into(), parameters, array)
                 .wrap_err("failed to send service reply")?;
-        } else if let Ok(arrow_array) =
-            arrow::array::ArrayData::from_pyarrow_bound(data.bind(py))
-        {
+        } else if let Ok(arrow_array) = arrow::array::ArrayData::from_pyarrow_bound(data.bind(py)) {
             self.node.get_mut().send_service_reply(
                 service_name.into(),
                 parameters,
@@ -472,9 +472,7 @@ impl Node {
             arrow::array::make_array(
                 arrow::array::UInt8Array::from(py_bytes.as_bytes().to_vec()).to_data(),
             )
-        } else if let Ok(arrow_array) =
-            arrow::array::ArrayData::from_pyarrow_bound(data.bind(py))
-        {
+        } else if let Ok(arrow_array) = arrow::array::ArrayData::from_pyarrow_bound(data.bind(py)) {
             arrow::array::make_array(arrow_array)
         } else {
             eyre::bail!("invalid `data` type, must be `PyBytes` or arrow array")
@@ -486,9 +484,13 @@ impl Node {
             let mut node = self.node.get_mut();
             let mut inner = self.events.inner.blocking_lock();
             match &mut *inner {
-                EventsInner::Dora(events) => {
-                    node.send_request(service_name_id, parameters, arrow_data, events, timeout_duration)
-                }
+                EventsInner::Dora(events) => node.send_request(
+                    service_name_id,
+                    parameters,
+                    arrow_data,
+                    events,
+                    timeout_duration,
+                ),
                 EventsInner::Merged(_) => {
                     eyre::bail!("send_request is not supported with merged external event streams")
                 }
@@ -499,8 +501,7 @@ impl Node {
         result.set_item("value", reply.data.to_data().to_pyarrow(py)?)?;
         result.set_item(
             "metadata",
-            metadata_to_pydict(&reply.metadata, py)
-                .context("Issue deserializing metadata")?,
+            metadata_to_pydict(&reply.metadata, py).context("Issue deserializing metadata")?,
         )?;
         Ok(result.into())
     }

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -7,12 +7,13 @@ use std::time::Duration;
 use tokio::sync::Mutex;
 
 use arrow::pyarrow::{FromPyArrow, ToPyArrow};
+use arrow::array::Array;
 use dora_download::download_file;
-use dora_node_api::dora_core::config::NodeId;
+use dora_node_api::dora_core::config::{DataId, NodeId};
 use dora_node_api::dora_core::descriptor::source_is_url;
 use dora_node_api::merged::{MergeExternalSend, MergedEvent};
 use dora_node_api::{DataflowId, DoraNode, EventStream, TryRecvError, init_tracing};
-use dora_operator_api_python::{DelayedCleanup, NodeCleanupHandle, PyEvent, pydict_to_metadata};
+use dora_operator_api_python::{DelayedCleanup, NodeCleanupHandle, PyEvent, pydict_to_metadata, metadata_to_pydict};
 use dora_ros2_bridge_python::Ros2Subscription;
 use eyre::{Context, ContextCompat};
 
@@ -380,6 +381,126 @@ impl Node {
         }
 
         Ok(())
+    }
+
+    /// `send_service_reply` sends a reply to a service request (server-side).
+    ///
+    /// ```python
+    /// Args:
+    ///    service_name: str,
+    ///    data: pyarrow.Array,
+    ///    metadata: Option[Dict],
+    /// ```
+    ///
+    /// ex:
+    ///
+    /// ```python
+    /// node.send_service_reply("get_image", image_data, event["metadata"])
+    /// ```
+    ///
+    /// :type service_name: str
+    /// :type data: pyarrow.Array
+    /// :type metadata: dict, optional
+    /// :rtype: None
+    #[pyo3(signature = (service_name, data, metadata=None))]
+    pub fn send_service_reply(
+        &self,
+        service_name: String,
+        data: PyObject,
+        metadata: Option<Bound<'_, PyDict>>,
+        py: Python,
+    ) -> eyre::Result<()> {
+        let parameters = pydict_to_metadata(metadata)?;
+
+        if let Ok(py_bytes) = data.downcast_bound::<PyBytes>(py) {
+            let bytes = py_bytes.as_bytes();
+            let array = arrow::array::UInt8Array::from(bytes.to_vec());
+            self.node
+                .get_mut()
+                .send_service_reply(service_name.into(), parameters, array)
+                .wrap_err("failed to send service reply")?;
+        } else if let Ok(arrow_array) =
+            arrow::array::ArrayData::from_pyarrow_bound(data.bind(py))
+        {
+            self.node.get_mut().send_service_reply(
+                service_name.into(),
+                parameters,
+                arrow::array::make_array(arrow_array),
+            )?;
+        } else {
+            eyre::bail!("invalid `data` type, must be `PyBytes` or arrow array")
+        }
+
+        Ok(())
+    }
+
+    /// `send_request` sends a service request and blocks until the reply arrives.
+    ///
+    /// Returns a dict with `"value"` (pyarrow.Array) and `"metadata"` (dict).
+    ///
+    /// ```python
+    /// Args:
+    ///    service_name: str,
+    ///    data: pyarrow.Array,
+    ///    metadata: Option[Dict],
+    /// ```
+    ///
+    /// ex:
+    ///
+    /// ```python
+    /// reply = node.send_request("get_image", pa.array([]))
+    /// image = reply["value"]
+    /// ```
+    ///
+    /// :type service_name: str
+    /// :type data: pyarrow.Array
+    /// :type metadata: dict, optional
+    /// :rtype: dict
+    #[pyo3(signature = (service_name, data, metadata=None))]
+    pub fn send_request(
+        &self,
+        service_name: String,
+        data: PyObject,
+        metadata: Option<Bound<'_, PyDict>>,
+        py: Python,
+    ) -> eyre::Result<Py<PyDict>> {
+        let parameters = pydict_to_metadata(metadata)?;
+
+        let arrow_data = if let Ok(py_bytes) = data.downcast_bound::<PyBytes>(py) {
+            arrow::array::make_array(
+                arrow::array::UInt8Array::from(py_bytes.as_bytes().to_vec()).to_data(),
+            )
+        } else if let Ok(arrow_array) =
+            arrow::array::ArrayData::from_pyarrow_bound(data.bind(py))
+        {
+            arrow::array::make_array(arrow_array)
+        } else {
+            eyre::bail!("invalid `data` type, must be `PyBytes` or arrow array")
+        };
+
+        let service_name_id = DataId::from(service_name);
+
+        let reply = py.allow_threads(|| {
+            let mut node = self.node.get_mut();
+            let mut inner = self.events.inner.blocking_lock();
+            match &mut *inner {
+                EventsInner::Dora(events) => {
+                    node.send_request(service_name_id, parameters, arrow_data, events)
+                }
+                EventsInner::Merged(_) => {
+                    eyre::bail!("send_request is not supported with merged external event streams")
+                }
+            }
+        })?;
+
+        let result = PyDict::new(py);
+        result.set_item("value", reply.data.to_data().to_pyarrow(py)?)?;
+        result.set_item(
+            "metadata",
+            metadata_to_pydict(&reply.metadata, py)
+                .context("Issue deserializing metadata")?,
+        )?;
+        Ok(result.into())
     }
 
     /// Returns the full dataflow descriptor that this node is part of.

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -456,15 +456,17 @@ impl Node {
     /// :type data: pyarrow.Array
     /// :type metadata: dict, optional
     /// :rtype: dict
-    #[pyo3(signature = (service_name, data, metadata=None))]
+    #[pyo3(signature = (service_name, data, metadata=None, timeout=None))]
     pub fn send_request(
         &self,
         service_name: String,
         data: PyObject,
         metadata: Option<Bound<'_, PyDict>>,
+        timeout: Option<f32>,
         py: Python,
     ) -> eyre::Result<Py<PyDict>> {
         let parameters = pydict_to_metadata(metadata)?;
+        let timeout_duration = timeout.map(Duration::from_secs_f32);
 
         let arrow_data = if let Ok(py_bytes) = data.downcast_bound::<PyBytes>(py) {
             arrow::array::make_array(
@@ -485,7 +487,7 @@ impl Node {
             let mut inner = self.events.inner.blocking_lock();
             match &mut *inner {
                 EventsInner::Dora(events) => {
-                    node.send_request(service_name_id, parameters, arrow_data, events)
+                    node.send_request(service_name_id, parameters, arrow_data, events, timeout_duration)
                 }
                 EventsInner::Merged(_) => {
                     eyre::bail!("send_request is not supported with merged external event streams")

--- a/apis/python/operator/src/lib.rs
+++ b/apis/python/operator/src/lib.rs
@@ -163,6 +163,7 @@ impl PyEvent {
             Event::Input { .. } => "INPUT",
             Event::InputClosed { .. } => "INPUT_CLOSED",
             Event::Error(_) => "ERROR",
+            Event::ServiceRequest { .. } => "SERVICE_REQUEST",
             _other => "UNKNOWN",
         }
     }
@@ -176,6 +177,7 @@ impl PyEvent {
                 StopCause::AllInputsClosed => Some("ALL_INPUTS_CLOSED"),
                 &_ => None,
             },
+            Event::ServiceRequest { id, .. } => Some(id),
             _ => None,
         }
     }
@@ -185,6 +187,10 @@ impl PyEvent {
         match &self.event {
             MergedEvent::Dora(Event::Input { data, .. }) => {
                 // TODO: Does this call leak data?&
+                let array_data = data.to_data().to_pyarrow(py)?;
+                Ok(Some(array_data))
+            }
+            MergedEvent::Dora(Event::ServiceRequest { data, .. }) => {
                 let array_data = data.to_data().to_pyarrow(py)?;
                 Ok(Some(array_data))
             }
@@ -199,6 +205,14 @@ impl PyEvent {
                     .context("Issue deserializing metadata")?
                     .into_pyobject(py)
                     .context("Failed to create metadata_to_pydice")?
+                    .unbind()
+                    .into(),
+            )),
+            Event::ServiceRequest { metadata, .. } => Ok(Some(
+                metadata_to_pydict(metadata, py)
+                    .context("Issue deserializing metadata")?
+                    .into_pyobject(py)
+                    .context("Failed to create metadata pydict")?
                     .unbind()
                     .into(),
             )),

--- a/apis/rust/node/Cargo.toml
+++ b/apis/rust/node/Cargo.toml
@@ -41,3 +41,4 @@ arrow-json = { workspace = true }
 arrow-schema = { workspace = true }
 colored = "3.0.0"
 is-terminal = "0.4.16"
+uuid = { workspace = true }

--- a/apis/rust/node/src/daemon_connection/interactive.rs
+++ b/apis/rust/node/src/daemon_connection/interactive.rs
@@ -82,6 +82,18 @@ impl InteractiveEvents {
                 println!("{}", "node reports EventStreamDropped".blue());
                 DaemonReply::Result(Ok(()))
             }
+            DaemonRequest::SendServiceReply {
+                service_name,
+                metadata: _,
+                data: _,
+            } => {
+                println!(
+                    "{} service reply for {}",
+                    "node sends".yellow(),
+                    service_name.bright_blue().bold()
+                );
+                DaemonReply::Empty
+            }
             DaemonRequest::NodeConfig { .. } => {
                 eyre::bail!("unexpected NodeConfig in interactive mode")
             }

--- a/apis/rust/node/src/daemon_connection/node_integration_testing.rs
+++ b/apis/rust/node/src/daemon_connection/node_integration_testing.rs
@@ -119,6 +119,14 @@ impl IntegrationTestingEvents {
                 println!("{}", "node reports EventStreamDropped".blue());
                 DaemonReply::Result(Ok(()))
             }
+            DaemonRequest::SendServiceReply {
+                service_name,
+                metadata: _,
+                data: _,
+            } => {
+                println!("{} service reply for {service_name}", "node sends".blue());
+                DaemonReply::Empty
+            }
             DaemonRequest::NodeConfig { .. } => {
                 eyre::bail!("unexpected NodeConfig in interactive mode")
             }

--- a/apis/rust/node/src/event_stream/event.rs
+++ b/apis/rust/node/src/event_stream/event.rs
@@ -74,6 +74,21 @@ pub enum Event {
         /// There is currently no case where `operator_id` is `None`.
         operator_id: Option<OperatorId>,
     },
+    /// A service request was received by this node (server-side).
+    ///
+    /// This event is sent when a client calls
+    /// [`DoraNode::send_request`](crate::DoraNode::send_request) targeting a service
+    /// declared by this node. The server should handle the request and call
+    /// [`DoraNode::send_service_reply`](crate::DoraNode::send_service_reply) to respond.
+    ServiceRequest {
+        /// The service name, as declared in the dataflow YAML file.
+        id: DataId,
+        /// Metadata including the correlation ID. This should be forwarded
+        /// back in the reply to ensure proper routing.
+        metadata: Metadata,
+        /// The request payload in Apache Arrow format.
+        data: ArrowData,
+    },
     /// Notifies the node about an unexpected error that happened inside Dora.
     ///
     /// It's a good idea to output or log this error for debugging.

--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -560,7 +560,7 @@ impl EventStream {
                         },
                         Err(err) => Event::Error(format!("{err:?}")),
                     }
-                },
+                }
                 NodeEvent::AllInputsClosed => Event::Stop(event::StopCause::AllInputsClosed),
                 NodeEvent::ServiceRequest { id, metadata, data } => {
                     let data = data_to_arrow_array(data, &metadata, ack_channel);
@@ -572,7 +572,7 @@ impl EventStream {
                         },
                         Err(err) => Event::Error(format!("{err:?}")),
                     }
-                },
+                }
             },
 
             EventItem::FatalError(err) => {

--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -273,6 +273,28 @@ impl EventStream {
         futures::executor::block_on(self.recv_async())
     }
 
+    /// Receives the next event directly from the underlying channel,
+    /// bypassing the scheduler. Used internally by `send_request` to
+    /// ensure service reply events are never held behind queued inputs.
+    pub(crate) fn recv_raw(&mut self) -> Option<Event> {
+        futures::executor::block_on(self.receiver.next()).map(Self::convert_event_item)
+    }
+
+    /// Like `recv_raw` but with a timeout. Returns `None` if no event
+    /// arrives within the given duration.
+    pub(crate) fn recv_raw_timeout(&mut self, timeout: Duration) -> Option<Event> {
+        use futures::future::Either;
+        use std::pin::pin;
+
+        let fut = async {
+            match select(Delay::new(timeout), pin!(self.receiver.next())).await {
+                Either::Left((_elapsed, _)) => None,
+                Either::Right((item, _)) => item.map(Self::convert_event_item),
+            }
+        };
+        futures::executor::block_on(fut)
+    }
+
     /// Receives the next incoming [`Event`] synchronously with a timeout.
     ///
     /// Blocks the thread until the next event arrives or the timeout is reached.

--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -69,6 +69,12 @@ pub struct EventStream {
     write_events_to: Option<WriteEventsTo>,
     start_timestamp: uhlc::Timestamp,
     use_scheduler: bool,
+    /// Events buffered during a blocking [`DoraNode::send_request`] call.
+    ///
+    /// While the node blocks waiting for a service reply, other events (inputs,
+    /// stop, etc.) may arrive. They are stored here and drained first on the
+    /// next call to [`recv`](Self::recv).
+    buffered_events: VecDeque<Event>,
 }
 
 impl EventStream {
@@ -238,6 +244,7 @@ impl EventStream {
             scheduler,
             write_events_to,
             use_scheduler,
+            buffered_events: VecDeque::new(),
         })
     }
 
@@ -258,6 +265,11 @@ impl EventStream {
     /// asynchronous [`StreamExt::next`] method instead ([`EventStream`] implements the
     /// [`Stream`] trait).
     pub fn recv(&mut self) -> Option<Event> {
+        // drain events that were buffered during a blocking send_request call
+        if let Some(event) = self.buffered_events.pop_front() {
+            return Some(event);
+        }
+
         futures::executor::block_on(self.recv_async())
     }
 
@@ -280,6 +292,11 @@ impl EventStream {
     /// asynchronous [`StreamExt::next`] method instead ([`EventStream`] implements the
     /// [`Stream`] trait).
     pub fn recv_timeout(&mut self, dur: Duration) -> Option<Event> {
+        // drain events that were buffered during a blocking send_request call
+        if let Some(event) = self.buffered_events.pop_front() {
+            return Some(event);
+        }
+
         futures::executor::block_on(self.recv_async_timeout(dur))
     }
 
@@ -297,6 +314,11 @@ impl EventStream {
     /// [`StreamExt::next`] method with a custom timeout future instead
     /// ([`EventStream`] implements the [`Stream`] trait).
     pub async fn recv_async(&mut self) -> Option<Event> {
+        // drain events that were buffered during a blocking send_request call
+        if let Some(event) = self.buffered_events.pop_front() {
+            return Some(event);
+        }
+
         if !self.use_scheduler {
             return self.receiver.next().await.map(Self::convert_event_item);
         }
@@ -326,6 +348,14 @@ impl EventStream {
     fn add_event(&mut self, event: EventItem) {
         self.record_event(&event).unwrap();
         self.scheduler.add_event(event);
+    }
+
+    /// Buffer an event to be returned on the next [`recv`](Self::recv) call.
+    ///
+    /// This is used internally during blocking [`DoraNode::send_request`] calls
+    /// to preserve events that arrive while waiting for a service reply.
+    pub(crate) fn buffer_event(&mut self, event: Event) {
+        self.buffered_events.push_back(event);
     }
 
     fn record_event(&mut self, event: &EventItem) -> eyre::Result<()> {
@@ -396,6 +426,7 @@ impl EventStream {
                         });
                         Some(event_json)
                     }
+                    NodeEvent::ServiceRequest { .. } => None,
                 },
                 _ => None,
             };
@@ -507,8 +538,19 @@ impl EventStream {
                         },
                         Err(err) => Event::Error(format!("{err:?}")),
                     }
-                }
+                },
                 NodeEvent::AllInputsClosed => Event::Stop(event::StopCause::AllInputsClosed),
+                NodeEvent::ServiceRequest { id, metadata, data } => {
+                    let data = data_to_arrow_array(data, &metadata, ack_channel);
+                    match data {
+                        Ok(data) => Event::ServiceRequest {
+                            id,
+                            metadata,
+                            data: data.into(),
+                        },
+                        Err(err) => Event::Error(format!("{err:?}")),
+                    }
+                },
             },
 
             EventItem::FatalError(err) => {

--- a/apis/rust/node/src/event_stream/thread.rs
+++ b/apis/rust/node/src/event_stream/thread.rs
@@ -1,5 +1,5 @@
 use dora_core::{
-    config::{NodeId, DataId},
+    config::{DataId, NodeId},
     uhlc::{self, Timestamp},
 };
 use dora_message::{

--- a/apis/rust/node/src/event_stream/thread.rs
+++ b/apis/rust/node/src/event_stream/thread.rs
@@ -1,5 +1,5 @@
 use dora_core::{
-    config::NodeId,
+    config::{NodeId, DataId},
     uhlc::{self, Timestamp},
 };
 use dora_message::{
@@ -150,6 +150,19 @@ fn event_stream_loop(
 
             if let Some(tx) = tx.as_ref() {
                 let (drop_tx, drop_rx) = flume::bounded(0);
+                let inner = if let NodeEvent::Input { id, metadata, data } = inner {
+                    if let Some(service_name) = id.as_str().strip_prefix("__service_request_") {
+                        NodeEvent::ServiceRequest {
+                            id: DataId::from(service_name.to_string()),
+                            metadata,
+                            data,
+                        }
+                    } else {
+                        NodeEvent::Input { id, metadata, data }
+                    }
+                } else {
+                    inner
+                };
                 match tx.send(EventItem::NodeEvent {
                     event: inner,
                     ack_channel: drop_tx,

--- a/apis/rust/node/src/node/control_channel.rs
+++ b/apis/rust/node/src/node/control_channel.rs
@@ -120,4 +120,28 @@ impl ControlChannel {
             other => bail!("unexpected SendMessage reply: {other:?}"),
         }
     }
+
+    pub fn send_service_reply(
+        &mut self,
+        service_name: DataId,
+        metadata: Metadata,
+        data: Option<DataMessage>,
+    ) -> eyre::Result<()> {
+        let request = DaemonRequest::SendServiceReply {
+            service_name,
+            metadata,
+            data,
+        };
+        let reply = self
+            .channel
+            .request(&Timestamped {
+                inner: request,
+                timestamp: self.clock.new_timestamp(),
+            })
+            .wrap_err("failed to send SendServiceReply request to dora-daemon")?;
+        match reply {
+            DaemonReply::Empty => Ok(()),
+            other => bail!("unexpected SendServiceReply reply: {other:?}"),
+        }
+    }
 }

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    DaemonCommunicationWrapper, EventStream,
+    ArrowData, DaemonCommunicationWrapper, Event, EventStream,
     daemon_connection::{DaemonChannel, IntegrationTestingEvents},
     integration_testing::{
         TestingCommunication, TestingInput, TestingOptions, TestingOutput,
@@ -25,7 +25,7 @@ use dora_core::{
 use dora_message::{
     DataflowId,
     daemon_to_node::{DaemonCommunication, DaemonReply, NodeConfig},
-    metadata::{ArrowTypeInfo, Metadata, MetadataParameters},
+    metadata::{ArrowTypeInfo, Metadata, MetadataParameters, Parameter},
     node_to_daemon::{DaemonRequest, DataMessage, DropToken, Timestamped},
 };
 use eyre::{WrapErr, bail};
@@ -65,6 +65,13 @@ mod drop_stream;
 /// shared memory. Messages that are smaller than this threshold are sent through
 /// TCP.
 pub const ZERO_COPY_THRESHOLD: usize = 4096;
+
+/// Metadata key used to carry service correlation IDs.
+///
+/// The client generates a [`Uuid::now_v7`](uuid::Uuid::now_v7) value, inserts it under this key,
+/// and sends the request. The server forwards it back in the reply metadata so the client can
+/// match replies to outstanding requests and discard stale responses.
+pub const SERVICE_CORRELATION_ID_KEY: &str = "__service_correlation_id";
 
 /// Allows sending outputs and retrieving node information.
 ///
@@ -359,6 +366,7 @@ impl DoraNode {
             run_config: NodeRunConfig {
                 inputs: Default::default(),
                 outputs: Default::default(),
+                services: Default::default(),
             },
             daemon_communication: Some(DaemonCommunication::Interactive),
             dataflow_descriptor: serde_yaml::Value::Null,
@@ -388,6 +396,7 @@ impl DoraNode {
             run_config: NodeRunConfig {
                 inputs: Default::default(),
                 outputs: Default::default(),
+                services: Default::default(),
             },
             daemon_communication: None,
             dataflow_descriptor: serde_yaml::Value::Null,
@@ -626,6 +635,99 @@ impl DoraNode {
         })
     }
 
+    /// Sends a reply to a service request (server-side).
+    ///
+    /// The `parameters` argument should contain the metadata from the received
+    /// [`Event::ServiceRequest`] -- it carries the correlation ID that the daemon
+    /// uses to route the reply back to the correct client.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use dora_node_api::{DoraNode, Event, MetadataParameters};
+    /// # let (mut node, mut events) = DoraNode::init_from_env().unwrap();
+    /// if let Some(Event::ServiceRequest { id, metadata, data }) = events.recv() {
+    ///     let reply = process_request(&data);
+    ///     node.send_service_reply(id, metadata.parameters.clone(), reply)
+    ///         .expect("failed to send service reply");
+    /// }
+    /// # fn process_request(_: &dora_node_api::ArrowData) -> arrow::array::ArrayRef { todo!() }
+    /// ```
+    pub fn send_service_reply(
+        &mut self,
+        service_name: DataId,
+        parameters: MetadataParameters,
+        data: impl Array,
+    ) -> eyre::Result<()> {
+        let arrow_array = data.to_data();
+        let total_len = required_data_size(&arrow_array);
+        let mut sample = self.allocate_data_sample(total_len)?;
+        let type_info = copy_array_into_sample(&mut sample, &arrow_array);
+        let output_id = DataId::from(format!("__service_reply_{service_name}"));
+        self.send_output_sample(output_id, type_info, parameters, Some(sample))
+    }
+
+    /// Sends a service request and blocks until a matching reply arrives.
+    ///
+    /// Events received while waiting (regular inputs, stop signals, etc.) are
+    /// buffered internally and will be returned by subsequent
+    /// [`EventStream::recv`] calls, so no messages are lost.
+    ///
+    /// The `events` parameter must be the [`EventStream`] associated with this
+    /// node -- it is needed to receive the reply.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a [`Event::Stop`] is received or the event stream
+    /// closes before a reply arrives.
+    pub fn send_request(
+        &mut self,
+        service_name: DataId,
+        parameters: MetadataParameters,
+        data: impl Array,
+        events: &mut EventStream,
+    ) -> eyre::Result<ServiceReply> {
+        let correlation_id = uuid::Uuid::now_v7().to_string();
+        let mut params = parameters;
+        params.insert(
+            SERVICE_CORRELATION_ID_KEY.to_string(),
+            Parameter::String(correlation_id.clone()),
+        );
+
+        // send via the synthetic __service_request_ output channel
+        let output_id = DataId::from(format!("__service_request_{service_name}"));
+        self.send_output(output_id, params, data)?;
+
+        // block until a reply with a matching correlation ID arrives
+        let reply_input_id = format!("__service_reply_{service_name}");
+        loop {
+            match events.recv() {
+                Some(Event::Input { id, metadata, data })
+                    if id.as_str() == reply_input_id =>
+                {
+                    let reply_corr = metadata
+                        .get(SERVICE_CORRELATION_ID_KEY)
+                        .and_then(|p| String::try_from(p).ok());
+                    if reply_corr.as_deref() == Some(&correlation_id) {
+                        return Ok(ServiceReply { metadata, data });
+                    }
+                    // stale reply from a timed-out request - discard
+                }
+                Some(Event::Stop(_)) => {
+                    eyre::bail!("received Stop while waiting for service reply");
+                }
+                Some(other) => {
+                    events.buffer_event(other);
+                }
+                None => {
+                    eyre::bail!("event stream closed while waiting for service reply");
+                }
+            }
+        }
+    }
+
+    
+
     /// Send the give raw byte data with the provided type information.
     ///
     /// It is recommended to use a function like [`send_output`][Self::send_output] instead.
@@ -812,6 +914,16 @@ impl DoraNode {
             ),
         }
     }
+}
+
+/// Reply received from a service request.
+///
+/// Returned by [`DoraNode::send_request`].
+pub struct ServiceReply {
+    /// Metadata from the server's reply.
+    pub metadata: Metadata,
+    /// The reply payload in Apache Arrow format.
+    pub data: ArrowData,
 }
 
 impl Drop for DoraNode {

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -686,6 +686,7 @@ impl DoraNode {
         parameters: MetadataParameters,
         data: impl Array,
         events: &mut EventStream,
+        timeout: Option<Duration>,
     ) -> eyre::Result<ServiceReply> {
         let correlation_id = uuid::Uuid::now_v7().to_string();
         let mut params = parameters;
@@ -700,8 +701,20 @@ impl DoraNode {
 
         // block until a reply with a matching correlation ID arrives
         let reply_input_id = format!("__service_reply_{service_name}");
+        let deadline = timeout.map(|t| std::time::Instant::now() + t);
+
         loop {
-            match events.recv() {
+            let event = if let Some(deadline) = deadline {
+                let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+                if remaining.is_zero() {
+                    eyre::bail!("service request timed out waiting for reply");
+                }
+                events.recv_raw_timeout(remaining)
+            } else {
+                events.recv_raw()
+            };
+
+            match event {
                 Some(Event::Input { id, metadata, data })
                     if id.as_str() == reply_input_id =>
                 {
@@ -711,7 +724,6 @@ impl DoraNode {
                     if reply_corr.as_deref() == Some(&correlation_id) {
                         return Ok(ServiceReply { metadata, data });
                     }
-                    // stale reply from a timed-out request - discard
                 }
                 Some(Event::Stop(_)) => {
                     eyre::bail!("received Stop while waiting for service reply");
@@ -720,6 +732,9 @@ impl DoraNode {
                     events.buffer_event(other);
                 }
                 None => {
+                    if deadline.is_some() {
+                        eyre::bail!("service request timed out waiting for reply");
+                    }
                     eyre::bail!("event stream closed while waiting for service reply");
                 }
             }

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -715,9 +715,7 @@ impl DoraNode {
             };
 
             match event {
-                Some(Event::Input { id, metadata, data })
-                    if id.as_str() == reply_input_id =>
-                {
+                Some(Event::Input { id, metadata, data }) if id.as_str() == reply_input_id => {
                     let reply_corr = metadata
                         .get(SERVICE_CORRELATION_ID_KEY)
                         .and_then(|p| String::try_from(p).ok());
@@ -740,8 +738,6 @@ impl DoraNode {
             }
         }
     }
-
-    
 
     /// Send the give raw byte data with the provided type information.
     ///

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -24,8 +24,8 @@ use dora_message::{
     daemon_to_coordinator::DataflowDaemonResult,
     daemon_to_daemon::InterDaemonEvent,
     daemon_to_node::{DaemonReply, NodeConfig, NodeDropEvent, NodeEvent},
-    descriptor::{NodeSource, RestartPolicy},
     descriptor::ServiceEndpoint,
+    descriptor::{NodeSource, RestartPolicy},
     metadata::{self, ArrowTypeInfo},
     node_to_daemon::{DynamicNodeEvent, Timestamped},
     tarpc,
@@ -1077,31 +1077,53 @@ impl Daemon {
         // build service mappings (request and reply channels)
         for node in nodes.values() {
             let services: Vec<(String, &ServiceEndpoint)> = match &node.kind {
-                CoreNodeKind::Custom(n) => n.run_config.services.iter().map(|(k, v)| (k.clone(), v)).collect(),
-                CoreNodeKind::Runtime(n) => n.operators.iter().flat_map(|op| {
-                    op.config.services.iter().map(move |(k, v)| (format!("{}/{k}", op.id), v))
-                }).collect(),
+                CoreNodeKind::Custom(n) => n
+                    .run_config
+                    .services
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v))
+                    .collect(),
+                CoreNodeKind::Runtime(n) => n
+                    .operators
+                    .iter()
+                    .flat_map(|op| {
+                        op.config
+                            .services
+                            .iter()
+                            .map(move |(k, v)| (format!("{}/{k}", op.id), v))
+                    })
+                    .collect(),
             };
             for (service_name, endpoint) in services {
                 if let ServiceEndpoint::Client { server } = endpoint {
-                    let (server_node_str, _server_svc) = server.split_once('/').unwrap();
+                    let Some((server_node_str, server_svc)) = server.split_once('/') else {
+                        continue;
+                    };
                     let server_node = NodeId::from(server_node_str.to_string());
-                    let request_id = DataId::from(format!("__service_request_{service_name}"));
-                    let reply_id = DataId::from(format!("__service_reply_{service_name}"));
+
+                    // Client sends on __service_request_{client_service_name}
+                    let client_request_id =
+                        DataId::from(format!("__service_request_{service_name}"));
+                    // Server receives on __service_request_{server_service_name}
+                    let server_request_id = DataId::from(format!("__service_request_{server_svc}"));
+                    // Server sends on __service_reply_{server_service_name}
+                    let server_reply_id = DataId::from(format!("__service_reply_{server_svc}"));
+                    // Client receives on __service_reply_{client_service_name}
+                    let client_reply_id = DataId::from(format!("__service_reply_{service_name}"));
 
                     // client -> server (requests)
                     dataflow
                         .service_mappings
-                        .entry(OutputId(node.id.clone(), request_id.clone()))
+                        .entry(OutputId(node.id.clone(), client_request_id))
                         .or_default()
-                        .insert((server_node.clone(), request_id));
+                        .insert((server_node.clone(), server_request_id));
 
                     // server -> client (replies)
                     dataflow
                         .service_reply_mappings
-                        .entry(OutputId(server_node, reply_id.clone()))
+                        .entry(OutputId(server_node, server_reply_id))
                         .or_default()
-                        .insert((node.id.clone(), reply_id));
+                        .insert((node.id.clone(), client_reply_id));
                 }
             }
         }
@@ -2703,9 +2725,15 @@ async fn send_output_to_local_receivers(
     let empty_set = BTreeSet::new();
     let output_id = OutputId(node_id, output_id);
     let local_receivers = if output_id.1.as_str().starts_with("__service_request_") {
-        dataflow.service_mappings.get(&output_id).unwrap_or(&empty_set)
+        dataflow
+            .service_mappings
+            .get(&output_id)
+            .unwrap_or(&empty_set)
     } else if output_id.1.as_str().starts_with("__service_reply_") {
-        dataflow.service_reply_mappings.get(&output_id).unwrap_or(&empty_set)
+        dataflow
+            .service_reply_mappings
+            .get(&output_id)
+            .unwrap_or(&empty_set)
     } else {
         dataflow.mappings.get(&output_id).unwrap_or(&empty_set)
     };
@@ -2784,12 +2812,24 @@ fn node_inputs(node: &ResolvedNode) -> BTreeMap<DataId, Input> {
     // register synthetic inputs for service endpoints so that the daemon
     // creates receive channels for service request/reply messages
     let services: Vec<(String, &ServiceEndpoint)> = match &node.kind {
-        CoreNodeKind::Custom(n) => n.run_config.services.iter().map(|(k, v)| (k.clone(), v)).collect(),
-        CoreNodeKind::Runtime(n) => n.operators.iter().flat_map(|op| {
-            op.config.services.iter().map(move |(k, v)| (format!("{}/{k}", op.id), v))
-        }).collect(),
+        CoreNodeKind::Custom(n) => n
+            .run_config
+            .services
+            .iter()
+            .map(|(k, v)| (k.clone(), v))
+            .collect(),
+        CoreNodeKind::Runtime(n) => n
+            .operators
+            .iter()
+            .flat_map(|op| {
+                op.config
+                    .services
+                    .iter()
+                    .map(move |(k, v)| (format!("{}/{k}", op.id), v))
+            })
+            .collect(),
     };
-    
+
     for (service_name, endpoint) in services {
         let synthetic_id = match endpoint {
             ServiceEndpoint::Server => {
@@ -3585,36 +3625,44 @@ impl CoreNodeKindExt for CoreNodeKind {
                         services.insert(prefixed_name.clone(), endpoint.clone());
                         match endpoint {
                             ServiceEndpoint::Client { .. } => {
-                                outputs.insert(DataId::from(format!("__service_request_{prefixed_name}")));
+                                outputs.insert(DataId::from(format!(
+                                    "__service_request_{prefixed_name}"
+                                )));
                             }
                             ServiceEndpoint::Server => {
-                                outputs.insert(DataId::from(format!("__service_reply_{prefixed_name}")));
+                                outputs.insert(DataId::from(format!(
+                                    "__service_reply_{prefixed_name}"
+                                )));
                             }
                         }
                     }
                 }
-                NodeRunConfig { inputs, outputs, services }
-            },
+                NodeRunConfig {
+                    inputs,
+                    outputs,
+                    services,
+                }
+            }
             CoreNodeKind::Custom(n) => {
                 let mut config = n.run_config.clone();
                 for (service_name, endpoint) in &config.services {
                     match endpoint {
                         ServiceEndpoint::Client { .. } => {
                             // client sends requests via this synthetic output
-                            config.outputs.insert(
-                                DataId::from(format!("__service_request_{service_name}"))
-                            );
+                            config
+                                .outputs
+                                .insert(DataId::from(format!("__service_request_{service_name}")));
                         }
                         ServiceEndpoint::Server => {
                             // server sends replies via this synthetic output
-                            config.outputs.insert(
-                                DataId::from(format!("__service_reply_{service_name}"))
-                            );
+                            config
+                                .outputs
+                                .insert(DataId::from(format!("__service_reply_{service_name}")));
                         }
                     }
                 }
                 config
-            },
+            }
         }
     }
 

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1076,9 +1076,11 @@ impl Daemon {
 
         // build service mappings (request and reply channels)
         for node in nodes.values() {
-            let services = match &node.kind {
-                CoreNodeKind::Custom(n) => &n.run_config.services,
-                CoreNodeKind::Runtime(_) => continue, // TODO: operator services ( CURRENTLY ONLY CUSTOM NODES )
+            let services: Vec<(String, &ServiceEndpoint)> = match &node.kind {
+                CoreNodeKind::Custom(n) => n.run_config.services.iter().map(|(k, v)| (k.clone(), v)).collect(),
+                CoreNodeKind::Runtime(n) => n.operators.iter().flat_map(|op| {
+                    op.config.services.iter().map(move |(k, v)| (format!("{}/{k}", op.id), v))
+                }).collect(),
             };
             for (service_name, endpoint) in services {
                 if let ServiceEndpoint::Client { server } = endpoint {
@@ -2781,10 +2783,13 @@ fn node_inputs(node: &ResolvedNode) -> BTreeMap<DataId, Input> {
 
     // register synthetic inputs for service endpoints so that the daemon
     // creates receive channels for service request/reply messages
-    let services = match &node.kind {
-        CoreNodeKind::Custom(n) => &n.run_config.services,
-        CoreNodeKind::Runtime(_) => return inputs, // operator services handled separately
+    let services: Vec<(String, &ServiceEndpoint)> = match &node.kind {
+        CoreNodeKind::Custom(n) => n.run_config.services.iter().map(|(k, v)| (k.clone(), v)).collect(),
+        CoreNodeKind::Runtime(n) => n.operators.iter().flat_map(|op| {
+            op.config.services.iter().map(move |(k, v)| (format!("{}/{k}", op.id), v))
+        }).collect(),
     };
+    
     for (service_name, endpoint) in services {
         let synthetic_id = match endpoint {
             ServiceEndpoint::Server => {
@@ -3570,10 +3575,25 @@ trait CoreNodeKindExt {
 impl CoreNodeKindExt for CoreNodeKind {
     fn run_config(&self) -> NodeRunConfig {
         match self {
-            CoreNodeKind::Runtime(n) => NodeRunConfig {
-                inputs: runtime_node_inputs(n),
-                outputs: runtime_node_outputs(n),
-                services: BTreeMap::new(),
+            CoreNodeKind::Runtime(n) => {
+                let inputs = runtime_node_inputs(n);
+                let mut outputs = runtime_node_outputs(n);
+                let mut services = BTreeMap::new();
+                for operator in &n.operators {
+                    for (service_name, endpoint) in &operator.config.services {
+                        let prefixed_name = format!("{}/{service_name}", operator.id);
+                        services.insert(prefixed_name.clone(), endpoint.clone());
+                        match endpoint {
+                            ServiceEndpoint::Client { .. } => {
+                                outputs.insert(DataId::from(format!("__service_request_{prefixed_name}")));
+                            }
+                            ServiceEndpoint::Server => {
+                                outputs.insert(DataId::from(format!("__service_reply_{prefixed_name}")));
+                            }
+                        }
+                    }
+                }
+                NodeRunConfig { inputs, outputs, services }
             },
             CoreNodeKind::Custom(n) => {
                 let mut config = n.run_config.clone();

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -3575,7 +3575,26 @@ impl CoreNodeKindExt for CoreNodeKind {
                 outputs: runtime_node_outputs(n),
                 services: BTreeMap::new(),
             },
-            CoreNodeKind::Custom(n) => n.run_config.clone(),
+            CoreNodeKind::Custom(n) => {
+                let mut config = n.run_config.clone();
+                for (service_name, endpoint) in &config.services {
+                    match endpoint {
+                        ServiceEndpoint::Client { .. } => {
+                            // client sends requests via this synthetic output
+                            config.outputs.insert(
+                                DataId::from(format!("__service_request_{service_name}"))
+                            );
+                        }
+                        ServiceEndpoint::Server => {
+                            // server sends replies via this synthetic output
+                            config.outputs.insert(
+                                DataId::from(format!("__service_reply_{service_name}"))
+                            );
+                        }
+                    }
+                }
+                config
+            },
         }
     }
 

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -2,7 +2,7 @@ use aligned_vec::{AVec, ConstAlign};
 use crossbeam::queue::ArrayQueue;
 use dora_core::{
     build::{self, BuildInfo, PrevGitSource, TracingBuildLogger},
-    config::{DataId, Input, InputMapping, NodeId, NodeRunConfig},
+    config::{DataId, Input, InputMapping, NodeId, NodeRunConfig, UserInputMapping},
     descriptor::{
         CoreNodeKind, DYNAMIC_SOURCE, Descriptor, DescriptorExt, ResolvedNode, RuntimeNode,
         read_as_descriptor,
@@ -25,6 +25,7 @@ use dora_message::{
     daemon_to_daemon::InterDaemonEvent,
     daemon_to_node::{DaemonReply, NodeConfig, NodeDropEvent, NodeEvent},
     descriptor::{NodeSource, RestartPolicy},
+    descriptor::ServiceEndpoint,
     metadata::{self, ArrowTypeInfo},
     node_to_daemon::{DynamicNodeEvent, Timestamped},
     tarpc,
@@ -1069,6 +1070,36 @@ impl Daemon {
                     dataflow
                         .open_external_mappings
                         .insert(OutputId(mapping.source, mapping.output));
+                }
+            }
+        }
+
+        // build service mappings (request and reply channels)
+        for node in nodes.values() {
+            let services = match &node.kind {
+                CoreNodeKind::Custom(n) => &n.run_config.services,
+                CoreNodeKind::Runtime(_) => continue, // TODO: operator services ( CURRENTLY ONLY CUSTOM NODES )
+            };
+            for (service_name, endpoint) in services {
+                if let ServiceEndpoint::Client { server } = endpoint {
+                    let (server_node_str, _server_svc) = server.split_once('/').unwrap();
+                    let server_node = NodeId::from(server_node_str.to_string());
+                    let request_id = DataId::from(format!("__service_request_{service_name}"));
+                    let reply_id = DataId::from(format!("__service_reply_{service_name}"));
+
+                    // client -> server (requests)
+                    dataflow
+                        .service_mappings
+                        .entry(OutputId(node.id.clone(), request_id.clone()))
+                        .or_default()
+                        .insert((server_node.clone(), request_id));
+
+                    // server -> client (replies)
+                    dataflow
+                        .service_reply_mappings
+                        .entry(OutputId(server_node, reply_id.clone()))
+                        .or_default()
+                        .insert((node.id.clone(), reply_id));
                 }
             }
         }
@@ -2669,7 +2700,13 @@ async fn send_output_to_local_receivers(
     let timestamp = metadata.timestamp();
     let empty_set = BTreeSet::new();
     let output_id = OutputId(node_id, output_id);
-    let local_receivers = dataflow.mappings.get(&output_id).unwrap_or(&empty_set);
+    let local_receivers = if output_id.1.as_str().starts_with("__service_request_") {
+        dataflow.service_mappings.get(&output_id).unwrap_or(&empty_set)
+    } else if output_id.1.as_str().starts_with("__service_reply_") {
+        dataflow.service_reply_mappings.get(&output_id).unwrap_or(&empty_set)
+    } else {
+        dataflow.mappings.get(&output_id).unwrap_or(&empty_set)
+    };
     let OutputId(node_id, _) = output_id;
     let mut closed = Vec::new();
     for (receiver_id, input_id) in local_receivers {
@@ -2737,10 +2774,41 @@ async fn send_output_to_local_receivers(
 }
 
 fn node_inputs(node: &ResolvedNode) -> BTreeMap<DataId, Input> {
-    match &node.kind {
+    let mut inputs = match &node.kind {
         CoreNodeKind::Custom(n) => n.run_config.inputs.clone(),
         CoreNodeKind::Runtime(n) => runtime_node_inputs(n),
+    };
+
+    // register synthetic inputs for service endpoints so that the daemon
+    // creates receive channels for service request/reply messages
+    let services = match &node.kind {
+        CoreNodeKind::Custom(n) => &n.run_config.services,
+        CoreNodeKind::Runtime(_) => return inputs, // operator services handled separately
+    };
+    for (service_name, endpoint) in services {
+        let synthetic_id = match endpoint {
+            ServiceEndpoint::Server => {
+                // server receives requests on this synthetic input
+                DataId::from(format!("__service_request_{service_name}"))
+            }
+            ServiceEndpoint::Client { .. } => {
+                // client receives replies on this synthetic input
+                DataId::from(format!("__service_reply_{service_name}"))
+            }
+        };
+        inputs.insert(
+            synthetic_id,
+            Input {
+                mapping: InputMapping::User(UserInputMapping {
+                    source: NodeId::from("__service__".to_string()),
+                    output: DataId::from("__synthetic__".to_string()),
+                }),
+                queue_size: Some(10),
+            },
+        );
     }
+
+    inputs
 }
 
 fn close_input(
@@ -2891,6 +2959,21 @@ pub struct RunningDataflow {
     subscribe_channels: HashMap<NodeId, UnboundedSender<Timestamped<NodeEvent>>>,
     drop_channels: HashMap<NodeId, UnboundedSender<Timestamped<NodeDropEvent>>>,
     mappings: HashMap<OutputId, BTreeSet<InputId>>,
+    /// Routes service requests from clients to servers.
+    ///
+    /// Key: `OutputId(client_node, "__service_request_{name}")`.
+    /// Value: `InputId(server_node, "__service_request_{name}")`.
+    ///
+    /// This map is intentionally separate from `mappings` so that `OutputClosed`
+    /// and `AllInputsClosed` lifecycle handlers never consult service channels.
+    service_mappings: HashMap<OutputId, BTreeSet<InputId>>,
+    /// Routes service replies from servers back to clients.
+    ///
+    /// Key: `OutputId(server_node, "__service_reply_{name}")`.
+    /// Value: `InputId(client_node, "__service_reply_{name}")`.
+    ///
+    /// Same lifecycle isolation rationale as `service_mappings`.
+    service_reply_mappings: HashMap<OutputId, BTreeSet<InputId>>,
     timers: BTreeMap<Duration, BTreeSet<InputId>>,
     open_inputs: BTreeMap<NodeId, BTreeSet<DataId>>,
     running_nodes: BTreeMap<NodeId, RunningNode>,
@@ -2960,6 +3043,8 @@ impl RunningDataflow {
             subscribe_channels: HashMap::new(),
             drop_channels: HashMap::new(),
             mappings: HashMap::new(),
+            service_mappings: HashMap::new(),
+            service_reply_mappings: HashMap::new(),
             timers: BTreeMap::new(),
             open_inputs: BTreeMap::new(),
             running_nodes: BTreeMap::new(),
@@ -3488,6 +3573,7 @@ impl CoreNodeKindExt for CoreNodeKind {
             CoreNodeKind::Runtime(n) => NodeRunConfig {
                 inputs: runtime_node_inputs(n),
                 outputs: runtime_node_outputs(n),
+                services: BTreeMap::new(),
             },
             CoreNodeKind::Custom(n) => n.run_config.clone(),
         }

--- a/binaries/daemon/src/node_communication/mod.rs
+++ b/binaries/daemon/src/node_communication/mod.rs
@@ -290,6 +290,21 @@ impl Listener {
                 };
                 self.process_daemon_event(event, None, connection).await?;
             }
+            DaemonRequest::SendServiceReply {
+                service_name,
+                metadata,
+                data,
+            } => {
+                // route via the synthetic __service_reply_ output channel
+                let output_id =
+                    DataId::from(format!("__service_reply_{}", service_name.as_str()));
+                let event = crate::DaemonNodeEvent::SendOut {
+                    output_id,
+                    metadata,
+                    data,
+                };
+                self.process_daemon_event(event, None, connection).await?;
+            }
             DaemonRequest::Subscribe => {
                 let (tx, rx) = mpsc::unbounded_channel();
                 let (reply_sender, reply) = oneshot::channel();

--- a/binaries/daemon/src/node_communication/mod.rs
+++ b/binaries/daemon/src/node_communication/mod.rs
@@ -296,8 +296,7 @@ impl Listener {
                 data,
             } => {
                 // route via the synthetic __service_reply_ output channel
-                let output_id =
-                    DataId::from(format!("__service_reply_{}", service_name.as_str()));
+                let output_id = DataId::from(format!("__service_reply_{}", service_name.as_str()));
                 let event = crate::DaemonNodeEvent::SendOut {
                     output_id,
                     metadata,

--- a/binaries/runtime/src/lib.rs
+++ b/binaries/runtime/src/lib.rs
@@ -231,8 +231,23 @@ async fn run(
                         .wrap_err("failed to wait for send_output task")?;
                         result.wrap_err("failed to send node output")?;
                     }
-                    OperatorEvent::ServiceReply { .. } => {
-                        // TODO: implement operator service reply forwarding later, gonna test first
+                    OperatorEvent::ServiceReply {
+                        service_name,
+                        type_info,
+                        parameters,
+                        data,
+                    } => {
+                        let output_id =
+                            DataId::from(format!("__service_reply_{operator_id}/{service_name}"));
+                        let result;
+                        (node, result) = tokio::task::spawn_blocking(move || {
+                            let result =
+                                node.send_output_sample(output_id, type_info, parameters, data);
+                            (node, result)
+                        })
+                        .await
+                        .wrap_err("failed to wait for send_service_reply task")?;
+                        result.wrap_err("failed to send operator service reply")?;
                     }
                 }
             }
@@ -332,9 +347,7 @@ async fn run(
                 let service_name = DataId::from(service_name.to_owned());
 
                 let Some(operator_channel) = operator_channels.get(&operator_id) else {
-                    tracing::warn!(
-                        "received service request for unknown operator `{operator_id}`"
-                    );
+                    tracing::warn!("received service request for unknown operator `{operator_id}`");
                     continue;
                 };
                 if let Err(err) = operator_channel

--- a/binaries/runtime/src/lib.rs
+++ b/binaries/runtime/src/lib.rs
@@ -231,6 +231,9 @@ async fn run(
                         .wrap_err("failed to wait for send_output task")?;
                         result.wrap_err("failed to send node output")?;
                     }
+                    OperatorEvent::ServiceReply { .. } => {
+                        // TODO: implement operator service reply forwarding later, gonna test first
+                    }
                 }
             }
             RuntimeEvent::Event(Event::Stop(cause)) => {
@@ -318,6 +321,37 @@ async fn run(
                         open_operator_inputs.remove(&operator_id);
                         operator_channels.remove(&operator_id);
                     }
+                }
+            }
+            RuntimeEvent::Event(Event::ServiceRequest { id, metadata, data }) => {
+                let Some((operator_id_str, service_name)) = id.as_str().split_once('/') else {
+                    tracing::warn!("received service request for non-operator: {id}");
+                    continue;
+                };
+                let operator_id = OperatorId::from(operator_id_str.to_owned());
+                let service_name = DataId::from(service_name.to_owned());
+
+                let Some(operator_channel) = operator_channels.get(&operator_id) else {
+                    tracing::warn!(
+                        "received service request for unknown operator `{operator_id}`"
+                    );
+                    continue;
+                };
+                if let Err(err) = operator_channel
+                    .send_async(Event::ServiceRequest {
+                        id: service_name.clone(),
+                        metadata,
+                        data,
+                    })
+                    .await
+                    .wrap_err_with(|| {
+                        format!(
+                            "failed to send ServiceRequest({service_name}) \
+                             to operator `{operator_id}`"
+                        )
+                    })
+                {
+                    tracing::warn!("{err}");
                 }
             }
             RuntimeEvent::Event(Event::Error(err)) => eyre::bail!("received error event: {err}"),

--- a/binaries/runtime/src/operator/mod.rs
+++ b/binaries/runtime/src/operator/mod.rs
@@ -84,6 +84,11 @@ pub enum OperatorEvent {
     Finished {
         reason: StopReason,
     },
+    ServiceReply {
+        service_name: DataId,
+        parameters: MetadataParameters,
+        data: Option<DataSample>,
+    },
 }
 
 #[derive(Debug)]

--- a/binaries/runtime/src/operator/mod.rs
+++ b/binaries/runtime/src/operator/mod.rs
@@ -86,6 +86,7 @@ pub enum OperatorEvent {
     },
     ServiceReply {
         service_name: DataId,
+        type_info: ArrowTypeInfo,
         parameters: MetadataParameters,
         data: Option<DataSample>,
     },

--- a/binaries/runtime/src/operator/python.rs
+++ b/binaries/runtime/src/operator/python.rs
@@ -106,6 +106,7 @@ pub fn run(
         Result::<_, eyre::Report>::Ok(Py::from(operator))
     };
 
+    let finish_tx = events_tx.clone();
     let python_runner = move || {
         let mut operator =
             match Python::with_gil(init_operator).wrap_err("failed to init python operator") {
@@ -120,6 +121,7 @@ pub fn run(
             };
 
         let mut reload = false;
+        let service_reply_tx = events_tx.clone();
         let reason = loop {
             #[allow(unused_mut)]
             let Ok(mut event) = incoming_events.recv() else {
@@ -222,6 +224,14 @@ pub fn run(
                 .to_py_dict(py)
                 .context("Could not convert event to pydict bound")?;
 
+                let send_service_reply = SendServiceReplyCallback {
+                    events_tx: service_reply_tx.clone(),
+                };
+
+                let _ = py_event
+                    .bind(py)
+                    .set_item("send_service_reply", send_service_reply);
+
                 let status_enum = operator
                     .call_method1(py, "on_event", (py_event, send_output.clone()))
                     .map_err(traceback);
@@ -266,13 +276,13 @@ pub fn run(
 
     match catch_unwind(closure) {
         Ok(Ok(reason)) => {
-            let _ = events_tx.send(OperatorEvent::Finished { reason });
+            let _ = finish_tx.send(OperatorEvent::Finished { reason });
         }
         Ok(Err(err)) => {
-            let _ = events_tx.send(OperatorEvent::Error(err));
+            let _ = finish_tx.send(OperatorEvent::Error(err));
         }
         Err(panic) => {
-            let _ = events_tx.send(OperatorEvent::Panic(panic));
+            let _ = finish_tx.send(OperatorEvent::Panic(panic));
         }
     }
 
@@ -285,12 +295,18 @@ struct SendOutputCallback {
     events_tx: flume::Sender<OperatorEvent>,
 }
 
+#[pyclass]
+#[derive(Clone)]
+struct SendServiceReplyCallback {
+    events_tx: flume::Sender<OperatorEvent>,
+}
+
 #[allow(unsafe_op_in_unsafe_fn)]
 mod callback_impl {
 
     use crate::operator::OperatorEvent;
 
-    use super::SendOutputCallback;
+    use super::{SendOutputCallback, SendServiceReplyCallback};
     use aligned_vec::{AVec, ConstAlign};
     use arrow::{array::ArrayData, pyarrow::FromPyArrow};
     use dora_core::metadata::ArrowTypeInfoExt;
@@ -392,6 +408,50 @@ mod callback_impl {
                     .send(event)
                     .map_err(|_| eyre!("failed to send output to runtime"))
             })?;
+
+            Ok(())
+        }
+    }
+
+    /// Send a service reply from the operator:
+    /// - the first argument is the `service_name` matching the original request.
+    /// - the second argument is the data as either bytes or pyarrow.Array.
+    /// - the third argument is dora metadata forwarded from the request.
+    /// `e.g.:  send_service_reply("compute", pa.array([42], type=pa.int64()), dora_event["metadata"])`
+    #[pymethods]
+    impl SendServiceReplyCallback {
+        #[pyo3(signature = (service_name, data, metadata=None))]
+        fn __call__(
+            &mut self,
+            service_name: &str,
+            data: PyObject,
+            metadata: Option<Bound<'_, PyDict>>,
+            py: Python,
+        ) -> Result<()> {
+            let parameters = pydict_to_metadata(metadata).wrap_err("failed to parse metadata")?;
+
+            let (sample, type_info) = if let Ok(py_bytes) = data.downcast_bound::<PyBytes>(py) {
+                let data = py_bytes.as_bytes();
+                let mut sample: AVec<u8, ConstAlign<128>> = AVec::__from_elem(128, 0, data.len());
+                sample.copy_from_slice(data);
+                (sample.into(), ArrowTypeInfo::byte_array(data.len()))
+            } else if let Ok(arrow_array) = ArrayData::from_pyarrow_bound(data.bind(py)) {
+                let total_len = required_data_size(&arrow_array);
+                let mut sample: AVec<u8, ConstAlign<128>> = AVec::__from_elem(128, 0, total_len);
+                let type_info = copy_array_into_sample(&mut sample, &arrow_array);
+                (sample.into(), type_info)
+            } else {
+                eyre::bail!("invalid `data` type, must be `PyBytes` or arrow array")
+            };
+
+            self.events_tx
+                .send(OperatorEvent::ServiceReply {
+                    service_name: service_name.into(),
+                    type_info,
+                    parameters,
+                    data: Some(sample),
+                })
+                .map_err(|_| eyre!("failed to send service reply to runtime"))?;
 
             Ok(())
         }

--- a/examples/request-reply/dataflow.yml
+++ b/examples/request-reply/dataflow.yml
@@ -8,8 +8,8 @@ nodes:
   - id: requester-node
     path: requester_node.py
     inputs:
-      request_tick: dora/timer/millis/200
-      tick: dora/timer/millis/50
+      request_tick: dora/timer/millis/500
+      tick: dora/timer/millis/200
     services:
       compute:
         type: client

--- a/examples/request-reply/dataflow.yml
+++ b/examples/request-reply/dataflow.yml
@@ -1,18 +1,15 @@
 nodes:
-  # The "service" node: receives a request and sends back a reply.
-  # It acts like a server — it listens for tick inputs and replies with computed data.
   - id: service-node
     path: service_node.py
-    inputs:
-      request: dora/timer/millis/100   # simulates receiving a tick/request trigger
-    outputs:
-      - reply
+    services:
+      compute:
+        type: server
 
-  # The "requester" node: sends a request and blocks until it receives a reply.
   - id: requester-node
     path: requester_node.py
     inputs:
       tick: dora/timer/millis/200
-      reply: service-node/reply
-    outputs:
-      - request
+    services:
+      compute:
+        type: client
+        server: service-node/compute

--- a/examples/request-reply/dataflow.yml
+++ b/examples/request-reply/dataflow.yml
@@ -1,0 +1,18 @@
+nodes:
+  # The "service" node: receives a request and sends back a reply.
+  # It acts like a server — it listens for tick inputs and replies with computed data.
+  - id: service-node
+    path: service_node.py
+    inputs:
+      request: dora/timer/millis/100   # simulates receiving a tick/request trigger
+    outputs:
+      - reply
+
+  # The "requester" node: sends a request and blocks until it receives a reply.
+  - id: requester-node
+    path: requester_node.py
+    inputs:
+      tick: dora/timer/millis/200
+      reply: service-node/reply
+    outputs:
+      - request

--- a/examples/request-reply/dataflow.yml
+++ b/examples/request-reply/dataflow.yml
@@ -8,8 +8,8 @@ nodes:
   - id: requester-node
     path: requester_node.py
     inputs:
-      request_tick: dora/timer/millis/500
-      tick: dora/timer/millis/200
+      request_tick: dora/timer/millis/200
+      tick: dora/timer/millis/20
     services:
       compute:
         type: client

--- a/examples/request-reply/dataflow.yml
+++ b/examples/request-reply/dataflow.yml
@@ -8,7 +8,8 @@ nodes:
   - id: requester-node
     path: requester_node.py
     inputs:
-      tick: dora/timer/millis/200
+      request_tick: dora/timer/millis/200
+      tick: dora/timer/millis/50
     services:
       compute:
         type: client

--- a/examples/request-reply/dataflow_operator.yml
+++ b/examples/request-reply/dataflow_operator.yml
@@ -1,0 +1,18 @@
+nodes:
+  - id: service-runtime
+    operator:
+      id: service-op
+      python: service_operator.py
+      services:
+        compute:
+          type: server
+
+  - id: requester-node
+    path: requester_node.py
+    inputs:
+      request_tick: dora/timer/millis/200
+      tick: dora/timer/millis/20
+    services:
+      compute:
+        type: client
+        server: service-runtime/service-op/compute

--- a/examples/request-reply/requester_node.py
+++ b/examples/request-reply/requester_node.py
@@ -4,65 +4,62 @@ from dora import Node
 
 def main():
     node = Node()
-    counter = 0
     ticks = 0
-    total_rounds = 10
     all_passed = True
+    phase = "data_types"
     print("[requester-node] Starting up...")
 
     for event in node:
         if event["type"] == "INPUT":
             if event["id"] == "request_tick":
-                counter += 1
-                request_value = counter * 10
-                print(f"[requester-node] Sending request #{counter} with value: {request_value}")
-                print(f"[requester-node] Ticks buffered so far: {ticks}")
+                if phase == "data_types":
+                    phase = "buffering"
 
-                reply = node.send_request(
-                    "compute",
-                    pa.array([request_value], type=pa.int64()),
-                    timeout=5.0,
-                )
-                reply_value = reply["value"][0].as_py()
-                expected = request_value * 2
+                    print("[requester-node] --- Data type tests ---")
+                    test_cases = [
+                        ("int64", pa.array([10, 20, 30], type=pa.int64())),
+                        ("float64", pa.array([1.5, 2.7, 3.14], type=pa.float64())),
+                        ("uint8", pa.array([0, 127, 255], type=pa.uint8())),
+                        ("string", pa.array(["hello", "world"])),
+                        ("bool", pa.array([True, False, True])),
+                        ("int32", pa.array([42], type=pa.int32())),
+                        ("empty", pa.array([], type=pa.int64())),
+                    ]
 
-                if reply_value == expected:
-                    print(
-                        f"[requester-node] PASS -- Reply {reply_value} matches expected {expected}"
-                    )
-                else:
-                    print(
-                        f"[requester-node] FAIL -- Reply {reply_value} does NOT match expected {expected}"
-                    )
-                    all_passed = False
+                    for name, data in test_cases:
+                        try:
+                            reply = node.send_request("compute", data, timeout=5.0)
+                            if reply["value"] == data:
+                                print(f"[requester-node] PASS -- {name}")
+                            else:
+                                print(f"[requester-node] FAIL -- {name} mismatch")
+                                all_passed = False
+                        except Exception as e:
+                            print(f"[requester-node] FAIL -- {name}: {e}")
+                            all_passed = False
 
-                if counter >= total_rounds:
-                    print(f"[requester-node] --- Final results ---")
-                    print(f"[requester-node] Round-trips completed: {counter}/{total_rounds}")
+                elif phase == "buffering":
+                    phase = "done"
+
+                    print(f"[requester-node] --- Buffering test ---")
+                    print(f"[requester-node] Ticks buffered: {ticks}")
                     if ticks > 0:
-                        print(
-                            f"[requester-node] PASS -- {ticks} ticks buffered during blocking requests"
-                        )
+                        print(f"[requester-node] PASS -- {ticks} ticks not lost")
                     else:
-                        print(
-                            f"[requester-node] FAIL -- No ticks received, event buffering may be broken"
-                        )
+                        print(f"[requester-node] FAIL -- no ticks buffered")
                         all_passed = False
 
-                    # Test timeout: send a request with a short timeout
-                    # and no server to reply (service already handled all
-                    # requests but we send one more with a 1s timeout)
-                    print(f"[requester-node] Testing timeout (1s)...")
+                    print(f"[requester-node] --- Timeout test ---")
                     try:
                         node.send_request(
                             "nonexistent_service",
                             pa.array([0], type=pa.int64()),
                             timeout=1.0,
                         )
-                        print(f"[requester-node] FAIL -- Should have timed out")
+                        print(f"[requester-node] FAIL -- should have timed out")
                         all_passed = False
-                    except Exception as e:
-                        print(f"[requester-node] PASS -- Timed out as expected: {e}")
+                    except Exception:
+                        print(f"[requester-node] PASS -- timed out as expected")
 
                     if all_passed:
                         print(f"[requester-node] ALL TESTS PASSED")

--- a/examples/request-reply/requester_node.py
+++ b/examples/request-reply/requester_node.py
@@ -1,82 +1,29 @@
-"""
-requester_node.py — Simulates the "requester" in the request-reply pattern.
-
-On each tick, sends a request value to the service node and then waits
-for the corresponding reply. This node acts as the client side.
-
-This example tests the request-reply feature by verifying that:
-  1. A request is sent successfully as an output.
-  2. The reply is received as an input and its value is correct.
-  3. The round-trip works repeatedly without dropping messages.
-"""
-
 import pyarrow as pa
 from dora import Node
 
-
 def main():
     node = Node()
-
     counter = 0
-    pending_request_value = None
-    replies_received = 0
-
     print("[requester-node] Starting up...")
 
     for event in node:
-        if event["type"] == "INPUT":
-            input_id = event["id"]
+        if event["type"] == "INPUT" and event["id"] == "tick":
+            counter += 1
+            request_value = counter * 10
+            print(f"[requester-node] Sending request #{counter} with value: {request_value}")
 
-            if input_id == "tick":
-                # On each tick, send a new request
-                counter += 1
-                request_value = counter * 10  # e.g. 10, 20, 30, ...
+            reply = node.send_request("compute", pa.array([request_value], type=pa.int64()))
+            reply_value = reply["value"][0].as_py()
+            expected = request_value * 2
 
-                print(f"[requester-node] Sending request #{counter} with value: {request_value}")
-
-                pending_request_value = request_value
-
-                node.send_output(
-                    output_id="request",
-                    data=pa.array([request_value], type=pa.int64()),
-                    metadata={},
-                )
-
-            elif input_id == "reply":
-                # Receive the reply from the service node
-                reply_data = event["value"]
-                reply_value = reply_data[0].as_py()
-
-                print(f"[requester-node] Received reply: {reply_value}")
-                replies_received += 1
-
-                # Verify correctness: reply should be exactly double the last sent request
-                if pending_request_value is not None:
-                    expected = pending_request_value * 2
-                    if reply_value == expected:
-                        print(
-                            f"[requester-node] ✅ PASS — Reply {reply_value} matches expected {expected}"
-                        )
-                    else:
-                        print(
-                            f"[requester-node] ❌ FAIL — Reply {reply_value} does NOT match expected {expected}"
-                        )
-                    pending_request_value = None
-                else:
-                    print(
-                        f"[requester-node] ⚠️  WARNING — Received unsolicited reply: {reply_value}"
-                    )
-
-                # Stop after 5 successful round-trips
-                if replies_received >= 5:
-                    print(
-                        f"[requester-node] Completed {replies_received} request-reply round-trips. Stopping."
-                    )
-                    break
-
+            if reply_value == expected:
+                print(f"[requester-node] ✅ PASS — Reply {reply_value} matches expected {expected}")
             else:
-                print(f"[requester-node] Ignoring unknown input: {input_id}")
+                print(f"[requester-node] ❌ FAIL — Reply {reply_value} does NOT match expected {expected}")
 
+            if counter >= 5:
+                print(f"[requester-node] Completed {counter} round-trips. Stopping.")
+                break
 
 if __name__ == "__main__":
     main()

--- a/examples/request-reply/requester_node.py
+++ b/examples/request-reply/requester_node.py
@@ -1,0 +1,82 @@
+"""
+requester_node.py — Simulates the "requester" in the request-reply pattern.
+
+On each tick, sends a request value to the service node and then waits
+for the corresponding reply. This node acts as the client side.
+
+This example tests the request-reply feature by verifying that:
+  1. A request is sent successfully as an output.
+  2. The reply is received as an input and its value is correct.
+  3. The round-trip works repeatedly without dropping messages.
+"""
+
+import pyarrow as pa
+from dora import Node
+
+
+def main():
+    node = Node()
+
+    counter = 0
+    pending_request_value = None
+    replies_received = 0
+
+    print("[requester-node] Starting up...")
+
+    for event in node:
+        if event["type"] == "INPUT":
+            input_id = event["id"]
+
+            if input_id == "tick":
+                # On each tick, send a new request
+                counter += 1
+                request_value = counter * 10  # e.g. 10, 20, 30, ...
+
+                print(f"[requester-node] Sending request #{counter} with value: {request_value}")
+
+                pending_request_value = request_value
+
+                node.send_output(
+                    output_id="request",
+                    data=pa.array([request_value], type=pa.int64()),
+                    metadata={},
+                )
+
+            elif input_id == "reply":
+                # Receive the reply from the service node
+                reply_data = event["value"]
+                reply_value = reply_data[0].as_py()
+
+                print(f"[requester-node] Received reply: {reply_value}")
+                replies_received += 1
+
+                # Verify correctness: reply should be exactly double the last sent request
+                if pending_request_value is not None:
+                    expected = pending_request_value * 2
+                    if reply_value == expected:
+                        print(
+                            f"[requester-node] ✅ PASS — Reply {reply_value} matches expected {expected}"
+                        )
+                    else:
+                        print(
+                            f"[requester-node] ❌ FAIL — Reply {reply_value} does NOT match expected {expected}"
+                        )
+                    pending_request_value = None
+                else:
+                    print(
+                        f"[requester-node] ⚠️  WARNING — Received unsolicited reply: {reply_value}"
+                    )
+
+                # Stop after 5 successful round-trips
+                if replies_received >= 5:
+                    print(
+                        f"[requester-node] Completed {replies_received} request-reply round-trips. Stopping."
+                    )
+                    break
+
+            else:
+                print(f"[requester-node] Ignoring unknown input: {input_id}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/request-reply/requester_node.py
+++ b/examples/request-reply/requester_node.py
@@ -1,29 +1,41 @@
 import pyarrow as pa
 from dora import Node
 
+
 def main():
     node = Node()
     counter = 0
+    ticks = 0
     print("[requester-node] Starting up...")
 
     for event in node:
-        if event["type"] == "INPUT" and event["id"] == "tick":
-            counter += 1
-            request_value = counter * 10
-            print(f"[requester-node] Sending request #{counter} with value: {request_value}")
+        if event["type"] == "INPUT":
+            if event["id"] == "request_tick":
+                counter += 1
+                request_value = counter * 10
+                print(f"[requester-node] Sending request #{counter} with value: {request_value}")
+                print(f"[requester-node] Ticks so far: {ticks}")
 
-            reply = node.send_request("compute", pa.array([request_value], type=pa.int64()))
-            reply_value = reply["value"][0].as_py()
-            expected = request_value * 2
+                reply = node.send_request("compute", pa.array([request_value], type=pa.int64()))
+                reply_value = reply["value"][0].as_py()
+                expected = request_value * 2
 
-            if reply_value == expected:
-                print(f"[requester-node] ✅ PASS — Reply {reply_value} matches expected {expected}")
-            else:
-                print(f"[requester-node] ❌ FAIL — Reply {reply_value} does NOT match expected {expected}")
+                if reply_value == expected:
+                    print(f"[requester-node] PASS -- Reply {reply_value} matches expected {expected}")
+                else:
+                    print(f"[requester-node] FAIL -- Reply {reply_value} does NOT match expected {expected}")
 
-            if counter >= 5:
-                print(f"[requester-node] Completed {counter} round-trips. Stopping.")
-                break
+                if counter >= 5:
+                    if ticks > 0:
+                        print(f"[requester-node] PASS -- {ticks} ticks buffered (not lost during blocking requests)")
+                    else:
+                        print(f"[requester-node] FAIL -- No ticks received, buffering may be broken")
+                    print(f"[requester-node] Completed {counter} round-trips. Stopping.")
+                    break
+
+            elif event["id"] == "tick":
+                ticks += 1
+
 
 if __name__ == "__main__":
     main()

--- a/examples/request-reply/requester_node.py
+++ b/examples/request-reply/requester_node.py
@@ -6,6 +6,8 @@ def main():
     node = Node()
     counter = 0
     ticks = 0
+    total_rounds = 10
+    all_passed = True
     print("[requester-node] Starting up...")
 
     for event in node:
@@ -14,23 +16,58 @@ def main():
                 counter += 1
                 request_value = counter * 10
                 print(f"[requester-node] Sending request #{counter} with value: {request_value}")
-                print(f"[requester-node] Ticks so far: {ticks}")
+                print(f"[requester-node] Ticks buffered so far: {ticks}")
 
-                reply = node.send_request("compute", pa.array([request_value], type=pa.int64()))
+                reply = node.send_request(
+                    "compute",
+                    pa.array([request_value], type=pa.int64()),
+                    timeout=5.0,
+                )
                 reply_value = reply["value"][0].as_py()
                 expected = request_value * 2
 
                 if reply_value == expected:
-                    print(f"[requester-node] PASS -- Reply {reply_value} matches expected {expected}")
+                    print(
+                        f"[requester-node] PASS -- Reply {reply_value} matches expected {expected}"
+                    )
                 else:
-                    print(f"[requester-node] FAIL -- Reply {reply_value} does NOT match expected {expected}")
+                    print(
+                        f"[requester-node] FAIL -- Reply {reply_value} does NOT match expected {expected}"
+                    )
+                    all_passed = False
 
-                if counter >= 5:
+                if counter >= total_rounds:
+                    print(f"[requester-node] --- Final results ---")
+                    print(f"[requester-node] Round-trips completed: {counter}/{total_rounds}")
                     if ticks > 0:
-                        print(f"[requester-node] PASS -- {ticks} ticks buffered (not lost during blocking requests)")
+                        print(
+                            f"[requester-node] PASS -- {ticks} ticks buffered during blocking requests"
+                        )
                     else:
-                        print(f"[requester-node] FAIL -- No ticks received, buffering may be broken")
-                    print(f"[requester-node] Completed {counter} round-trips. Stopping.")
+                        print(
+                            f"[requester-node] FAIL -- No ticks received, event buffering may be broken"
+                        )
+                        all_passed = False
+
+                    # Test timeout: send a request with a short timeout
+                    # and no server to reply (service already handled all
+                    # requests but we send one more with a 1s timeout)
+                    print(f"[requester-node] Testing timeout (1s)...")
+                    try:
+                        node.send_request(
+                            "nonexistent_service",
+                            pa.array([0], type=pa.int64()),
+                            timeout=1.0,
+                        )
+                        print(f"[requester-node] FAIL -- Should have timed out")
+                        all_passed = False
+                    except Exception as e:
+                        print(f"[requester-node] PASS -- Timed out as expected: {e}")
+
+                    if all_passed:
+                        print(f"[requester-node] ALL TESTS PASSED")
+                    else:
+                        print(f"[requester-node] SOME TESTS FAILED")
                     break
 
             elif event["id"] == "tick":

--- a/examples/request-reply/service_node.py
+++ b/examples/request-reply/service_node.py
@@ -6,6 +6,8 @@ def main():
     print("[service-node] Starting up, waiting for requests...")
 
     for event in node:
+        print(f"[service-node] Got event: type={event['type']}, id={event.get('id', 'N/A')}")
+
         if event["type"] == "SERVICE_REQUEST":
             request_data = event["value"]
             request_value = request_data[0].as_py()

--- a/examples/request-reply/service_node.py
+++ b/examples/request-reply/service_node.py
@@ -9,19 +9,12 @@ def main():
 
     for event in node:
         if event["type"] == "SERVICE_REQUEST":
-            request_data = event["value"]
-            request_value = request_data[0].as_py()
             requests_handled += 1
-
-            reply_value = request_value * 2
-            print(
-                f"[service-node] Request #{requests_handled}: "
-                f"received {request_value}, replying {reply_value}"
-            )
+            print(f"[service-node] Request #{requests_handled}: type={event['value'].type}")
 
             node.send_service_reply(
                 event["id"],
-                pa.array([reply_value], type=pa.int64()),
+                event["value"],
                 event["metadata"],
             )
         elif event["type"] == "STOP":

--- a/examples/request-reply/service_node.py
+++ b/examples/request-reply/service_node.py
@@ -1,25 +1,33 @@
 import pyarrow as pa
 from dora import Node
 
+
 def main():
     node = Node()
+    requests_handled = 0
     print("[service-node] Starting up, waiting for requests...")
 
     for event in node:
-        print(f"[service-node] Got event: type={event['type']}, id={event.get('id', 'N/A')}")
-
         if event["type"] == "SERVICE_REQUEST":
             request_data = event["value"]
             request_value = request_data[0].as_py()
-            print(f"[service-node] Received request with value: {request_value}")
+            requests_handled += 1
 
             reply_value = request_value * 2
-            print(f"[service-node] Sending reply: {reply_value}")
+            print(
+                f"[service-node] Request #{requests_handled}: "
+                f"received {request_value}, replying {reply_value}"
+            )
+
             node.send_service_reply(
                 event["id"],
                 pa.array([reply_value], type=pa.int64()),
                 event["metadata"],
             )
+        elif event["type"] == "STOP":
+            print(f"[service-node] Handled {requests_handled} requests total. Stopping.")
+            break
+
 
 if __name__ == "__main__":
     main()

--- a/examples/request-reply/service_node.py
+++ b/examples/request-reply/service_node.py
@@ -1,0 +1,41 @@
+"""
+service_node.py — Simulates a "service" in the request-reply pattern.
+
+Receives a numeric value in a request, computes a result (doubles it),
+and sends back a reply. This node acts as the server side.
+"""
+
+from dora import Node
+
+
+def main():
+    node = Node()
+
+    print("[service-node] Starting up, waiting for requests...")
+
+    for event in node:
+        if event["type"] == "INPUT":
+            input_id = event["id"]
+
+            if input_id == "request":
+                # Extract the request value — expected to be a single integer
+                request_data = event["value"]
+                request_value = request_data[0].as_py()
+
+                print(f"[service-node] Received request with value: {request_value}")
+
+                # Compute the reply: double the input value
+                reply_value = request_value * 2
+
+                print(f"[service-node] Sending reply: {reply_value}")
+                node.send_output(
+                    output_id="reply",
+                    data=pa.array([reply_value], type=pa.int64()),
+                    metadata=event["metadata"],  # propagate metadata (e.g. timestamps)
+                )
+            else:
+                print(f"[service-node] Ignoring unknown input: {input_id}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/request-reply/service_node.py
+++ b/examples/request-reply/service_node.py
@@ -1,41 +1,23 @@
-"""
-service_node.py — Simulates a "service" in the request-reply pattern.
-
-Receives a numeric value in a request, computes a result (doubles it),
-and sends back a reply. This node acts as the server side.
-"""
-
+import pyarrow as pa
 from dora import Node
-
 
 def main():
     node = Node()
-
     print("[service-node] Starting up, waiting for requests...")
 
     for event in node:
-        if event["type"] == "INPUT":
-            input_id = event["id"]
+        if event["type"] == "SERVICE_REQUEST":
+            request_data = event["value"]
+            request_value = request_data[0].as_py()
+            print(f"[service-node] Received request with value: {request_value}")
 
-            if input_id == "request":
-                # Extract the request value — expected to be a single integer
-                request_data = event["value"]
-                request_value = request_data[0].as_py()
-
-                print(f"[service-node] Received request with value: {request_value}")
-
-                # Compute the reply: double the input value
-                reply_value = request_value * 2
-
-                print(f"[service-node] Sending reply: {reply_value}")
-                node.send_output(
-                    output_id="reply",
-                    data=pa.array([reply_value], type=pa.int64()),
-                    metadata=event["metadata"],  # propagate metadata (e.g. timestamps)
-                )
-            else:
-                print(f"[service-node] Ignoring unknown input: {input_id}")
-
+            reply_value = request_value * 2
+            print(f"[service-node] Sending reply: {reply_value}")
+            node.send_service_reply(
+                event["id"],
+                pa.array([reply_value], type=pa.int64()),
+                event["metadata"],
+            )
 
 if __name__ == "__main__":
     main()

--- a/examples/request-reply/service_operator.py
+++ b/examples/request-reply/service_operator.py
@@ -1,0 +1,24 @@
+from dora import DoraStatus
+
+
+class Operator:
+    def __init__(self):
+        self.requests_handled = 0
+
+    def on_event(self, dora_event, send_output) -> DoraStatus:
+        if dora_event["type"] == "SERVICE_REQUEST":
+            self.requests_handled += 1
+            print(
+                f"[service-operator] Request #{self.requests_handled}: "
+                f"type={dora_event['value'].type}"
+            )
+            dora_event["send_service_reply"](
+                dora_event["id"],
+                dora_event["value"],
+                dora_event["metadata"],
+            )
+        elif dora_event["type"] == "STOP":
+            print(
+                f"[service-operator] Handled {self.requests_handled} requests. Stopping."
+            )
+        return DoraStatus.CONTINUE

--- a/libraries/core/dora-schema.json
+++ b/libraries/core/dora-schema.json
@@ -86,6 +86,14 @@
             "null"
           ]
         },
+        "services": {
+          "description": "Service endpoints for request-reply communication.\n\ne.g.\n\nservices:\n\n  get_image:\n    type: server",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/ServiceEndpoint"
+          },
+          "default": {}
+        },
         "source": {
           "$ref": "#/$defs/NodeSource"
         }
@@ -374,6 +382,13 @@
             "null"
           ]
         },
+        "services": {
+          "description": "Service endpoints declared by this node.\n\nDefines the request-reply services that this node provides or consumes.\nEach service must have a unique name within the node. Server endpoints handle\nincoming requests, while client endpoints send requests to a specified server.\n\n## Example\n\n```yaml\nnodes:\n  - id: webcam\n    path: ./webcam.py\n    services:\n      get_image:\n        type: server\n  - id: detector\n    path: ./detector.py\n    services:\n      get_image:\n        type: client\n        server: webcam/get_image\n```",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/ServiceEndpoint"
+          }
+        },
         "tag": {
           "description": "Git tag to checkout after cloning.\n\nThe `tag` field is only allowed in combination with the [`git`](#git) field.\nIt specifies the git tag that should be checked out after cloning.\nOnly one of `branch`, `tag`, or `rev` can be specified.\n\n## Example\n\n```yaml\nnodes:\n  - id: rust-node\n    git: https://github.com/dora-rs/dora.git\n    tag: v0.3.0\n```",
           "type": [
@@ -481,6 +496,13 @@
             "string",
             "null"
           ]
+        },
+        "services": {
+          "description": "Service endpoints for request-reply communication",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/ServiceEndpoint"
+          }
         }
       },
       "oneOf": [
@@ -565,6 +587,42 @@
         "$ref": "#/$defs/OperatorDefinition"
       }
     },
+    "ServiceEndpoint": {
+      "description": "Defines a service endpoint for the request-reply pattern.\n\nA service endpoint is either a server (which receives requests and sends replies)\nor a client (which sends requests and receives replies). Both sides must declare\ntheir service endpoints in the dataflow YAML.\n\n## Example\n\n```yaml\nnodes:\n  - id: webcam\n    services:\n      get_image:\n        type: server\n  - id: detector\n    services:\n      get_image:\n        type: client\n        server: webcam/get_image\n```",
+      "oneOf": [
+        {
+          "description": "This node provides the service and handles incoming requests.",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "server"
+            }
+          },
+          "required": [
+            "type"
+          ]
+        },
+        {
+          "description": "This node consumes the service by sending requests.",
+          "type": "object",
+          "properties": {
+            "server": {
+              "description": "Reference to the server endpoint in the format `node_id/service_name`.",
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "const": "client"
+            }
+          },
+          "required": [
+            "type",
+            "server"
+          ]
+        }
+      ]
+    },
     "SingleOperatorDefinition": {
       "type": "object",
       "properties": {
@@ -623,6 +681,13 @@
             "string",
             "null"
           ]
+        },
+        "services": {
+          "description": "Service endpoints for request-reply communication",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/ServiceEndpoint"
+          }
         }
       },
       "oneOf": [

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -89,6 +89,7 @@ impl DescriptorExt for Descriptor {
                     run_config: NodeRunConfig {
                         inputs: node.inputs,
                         outputs: node.outputs,
+                        services: node.services.clone(),
                     },
                     envs: None,
                     restart_policy: node.restart_policy,

--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -4,6 +4,7 @@ use crate::{
     get_python_path,
 };
 
+use dora_message::descriptor::ServiceEndpoint;
 use dora_message::{
     config::{Input, InputMapping, UserInputMapping},
     descriptor::{CoreNodeKind, DYNAMIC_SOURCE, OperatorSource, ResolvedNode, SHELL_SOURCE},
@@ -12,7 +13,6 @@ use dora_message::{
 use eyre::{Context, bail, eyre};
 use std::{collections::BTreeMap, path::Path, process::Command, time::Duration};
 use tracing::info;
-use dora_message::descriptor::ServiceEndpoint;
 
 use super::{Descriptor, DescriptorExt, resolve_path};
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -182,7 +182,27 @@ pub fn check_dataflow(
                     ));
                     continue;
                 };
-                match server_node.services.get(server_service_name) {
+                let found = server_node.services.get(server_service_name).or_else(|| {
+                    // Check operator services for runtime nodes
+                    let (op_id, svc_name) = server_service_name.split_once('/')?;
+                    // Check `operators` field (multiple operators)
+                    if let Some(runtime) = &server_node.operators {
+                        for op in &runtime.operators {
+                            if op.id.as_ref() == op_id {
+                                return op.config.services.get(svc_name);
+                            }
+                        }
+                    }
+                    // Check `operator` field (single operator)
+                    if let Some(op) = &server_node.operator {
+                        let id = op.id.as_ref().map(|i| i.as_ref()).unwrap_or("op");
+                        if id == op_id {
+                            return op.config.services.get(svc_name);
+                        }
+                    }
+                    None
+                });
+                match found {
                     Some(ServiceEndpoint::Server) => {} // valid
                     Some(ServiceEndpoint::Client { .. }) => {
                         errors.push(format!(

--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -12,6 +12,7 @@ use dora_message::{
 use eyre::{Context, bail, eyre};
 use std::{collections::BTreeMap, path::Path, process::Command, time::Duration};
 use tracing::info;
+use dora_message::descriptor::ServiceEndpoint;
 
 use super::{Descriptor, DescriptorExt, resolve_path};
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -156,6 +157,49 @@ pub fn check_dataflow(
     if has_python_operator {
         if let Err(err) = check_python_runtime() {
             errors.push(format!("{err}"));
+        }
+    }
+
+    // check that all service client references point to a valid server
+    for node in &dataflow.nodes {
+        for (service_name, endpoint) in &node.services {
+            if let ServiceEndpoint::Client { server } = endpoint {
+                let Some((server_node_str, server_service_name)) = server.split_once('/') else {
+                    errors.push(format!(
+                        "node `{}`, service `{service_name}`: invalid server reference `{server}`, \
+                         expected format `node_id/service_name`",
+                        node.id
+                    ));
+                    continue;
+                };
+                let server_node_id = NodeId::from(server_node_str.to_string());
+                let Some(server_node) = dataflow.nodes.iter().find(|n| n.id == server_node_id)
+                else {
+                    errors.push(format!(
+                        "node `{}`, service `{service_name}`: server node \
+                         `{server_node_str}` not found",
+                        node.id
+                    ));
+                    continue;
+                };
+                match server_node.services.get(server_service_name) {
+                    Some(ServiceEndpoint::Server) => {} // valid
+                    Some(ServiceEndpoint::Client { .. }) => {
+                        errors.push(format!(
+                            "node `{}`, service `{service_name}`: `{server}` is a client, \
+                             not a server",
+                            node.id
+                        ));
+                    }
+                    None => {
+                        errors.push(format!(
+                            "node `{}`, service `{service_name}`: server `{server_node_str}` \
+                             does not declare service `{server_service_name}`",
+                            node.id
+                        ));
+                    }
+                }
+            }
         }
     }
 

--- a/libraries/message/src/config.rs
+++ b/libraries/message/src/config.rs
@@ -9,6 +9,7 @@ use once_cell::sync::OnceCell;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::descriptor::ServiceEndpoint;
 pub use crate::id::{DataId, NodeId, OperatorId};
 
 /// Contains the input and output configuration of the node.
@@ -35,6 +36,17 @@ pub struct NodeRunConfig {
     ///  - output_2
     #[serde(default)]
     pub outputs: BTreeSet<DataId>,
+
+    /// Service endpoints for request-reply communication.
+    ///
+    /// e.g.
+    ///
+    /// services:
+    ///
+    ///   get_image:
+    ///     type: server
+    #[serde(default)]
+    pub services: BTreeMap<String, ServiceEndpoint>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]

--- a/libraries/message/src/daemon_to_node.rs
+++ b/libraries/message/src/daemon_to_node.rs
@@ -76,6 +76,21 @@ pub enum NodeEvent {
         error: String,
         source_node_id: NodeId,
     },
+
+    /// A service request received by a server node.
+    ///
+    /// The daemon creates this event when a client sends a request to a service
+    /// declared by this node. The server should process the request and reply
+    /// using [`DaemonRequest::SendServiceReply`](crate::node_to_daemon::DaemonRequest::SendServiceReply).
+    ServiceRequest {
+        /// The service name (e.g., `"get_image"`).
+        id: DataId,
+        /// Metadata for this request, including the correlation ID used to
+        /// route the reply back to the correct client.
+        metadata: Metadata,
+        /// The request payload.
+        data: Option<DataMessage>,
+    },
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/libraries/message/src/descriptor.rs
+++ b/libraries/message/src/descriptor.rs
@@ -129,6 +129,40 @@ pub enum RestartPolicy {
     Always,
 }
 
+/// Defines a service endpoint for the request-reply pattern.
+///
+/// A service endpoint is either a server (which receives requests and sends replies)
+/// or a client (which sends requests and receives replies). Both sides must declare
+/// their service endpoints in the dataflow YAML.
+///
+/// ## Example
+///
+/// ```yaml
+/// nodes:
+///   - id: webcam
+///     services:
+///       get_image:
+///         type: server
+///   - id: detector
+///     services:
+///       get_image:
+///         type: client
+///         server: webcam/get_image
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(tag = "type")]
+pub enum ServiceEndpoint {
+    /// This node provides the service and handles incoming requests.
+    #[serde(rename = "server")]
+    Server,
+    /// This node consumes the service by sending requests.
+    #[serde(rename = "client")]
+    Client {
+        /// Reference to the server endpoint in the format `node_id/service_name`.
+        server: String,
+    },
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Deploy {
@@ -511,6 +545,31 @@ pub struct Node {
     #[schemars(skip)]
     #[serde(rename = "_unstable_deploy")]
     pub deploy: Option<Deploy>,
+
+    /// Service endpoints declared by this node.
+    ///
+    /// Defines the request-reply services that this node provides or consumes.
+    /// Each service must have a unique name within the node. Server endpoints handle
+    /// incoming requests, while client endpoints send requests to a specified server.
+    ///
+    /// ## Example
+    ///
+    /// ```yaml
+    /// nodes:
+    ///   - id: webcam
+    ///     path: ./webcam.py
+    ///     services:
+    ///       get_image:
+    ///         type: server
+    ///   - id: detector
+    ///     path: ./detector.py
+    ///     services:
+    ///       get_image:
+    ///         type: client
+    ///         server: webcam/get_image
+    /// ```
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub services: BTreeMap<String, ServiceEndpoint>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -591,6 +650,10 @@ pub struct OperatorConfig {
     /// Output data identifiers
     #[serde(default)]
     pub outputs: BTreeSet<DataId>,
+
+    /// Service endpoints for request-reply communication
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub services: BTreeMap<String, ServiceEndpoint>,
 
     /// Operator source configuration (Python, shared library, etc.)
     #[serde(flatten)]

--- a/libraries/message/src/node_to_daemon.rs
+++ b/libraries/message/src/node_to_daemon.rs
@@ -30,6 +30,18 @@ pub enum DaemonRequest {
     SubscribeDrop,
     NextFinishedDropTokens,
     EventStreamDropped,
+    /// Server sends a reply to a service request.
+    ///
+    /// The daemon routes this reply back to the requesting client using the
+    /// correlation ID in the metadata.
+    SendServiceReply {
+        /// The service name matching the original request.
+        service_name: DataId,
+        /// Metadata forwarded from the request (includes the correlation ID).
+        metadata: Metadata,
+        /// The reply payload.
+        data: Option<DataMessage>,
+    },
     NodeConfig {
         node_id: NodeId,
     },
@@ -41,7 +53,8 @@ impl DaemonRequest {
         match self {
             DaemonRequest::SendMessage { .. }
             | DaemonRequest::NodeConfig { .. }
-            | DaemonRequest::ReportDropTokens { .. } => false,
+            | DaemonRequest::ReportDropTokens { .. } 
+            | DaemonRequest::SendServiceReply { .. } => false,
             DaemonRequest::Register(NodeRegisterRequest { .. })
             | DaemonRequest::Subscribe
             | DaemonRequest::CloseOutputs(_)
@@ -66,7 +79,8 @@ impl DaemonRequest {
             | DaemonRequest::NextFinishedDropTokens
             | DaemonRequest::ReportDropTokens { .. }
             | DaemonRequest::SendMessage { .. }
-            | DaemonRequest::EventStreamDropped => false,
+            | DaemonRequest::EventStreamDropped 
+            | DaemonRequest::SendServiceReply { .. } => false,
         }
     }
 }

--- a/libraries/message/src/node_to_daemon.rs
+++ b/libraries/message/src/node_to_daemon.rs
@@ -53,7 +53,7 @@ impl DaemonRequest {
         match self {
             DaemonRequest::SendMessage { .. }
             | DaemonRequest::NodeConfig { .. }
-            | DaemonRequest::ReportDropTokens { .. } 
+            | DaemonRequest::ReportDropTokens { .. }
             | DaemonRequest::SendServiceReply { .. } => false,
             DaemonRequest::Register(NodeRegisterRequest { .. })
             | DaemonRequest::Subscribe
@@ -79,7 +79,7 @@ impl DaemonRequest {
             | DaemonRequest::NextFinishedDropTokens
             | DaemonRequest::ReportDropTokens { .. }
             | DaemonRequest::SendMessage { .. }
-            | DaemonRequest::EventStreamDropped 
+            | DaemonRequest::EventStreamDropped
             | DaemonRequest::SendServiceReply { .. } => false,
         }
     }


### PR DESCRIPTION
Closes [#390](https://github.com/dora-rs/dora/issues/390)

## Summary

Implements the services (request-reply) pattern for dora-rs, allowing nodes and operators to perform synchronous request-reply communication built on top of the existing pub-sub infrastructure.

NOTE: The service implementation does not support operators to be a client as its on_event callback should not be blocked. This could be a future additional implementation (e.g., via an async callback or a separate on_service_reply handler).

## Changes

### YAML Dataflow Configuration
- New `services` block on nodes and operators with `type: server` and `type: client` (with `server: node_id/service_name` reference)
- JSON schema updated with `ServiceEndpoint` definition
- YAML validation ensures client references point to valid server endpoints, including operator-level services

### Rust Node API (`apis/rust/node/`)
- `DoraNode::send_request()` -- blocking call that sends a request and waits for a matching reply using correlation IDs (UUID v7). Supports optional timeout. Events received while waiting are buffered and returned by subsequent `recv()` calls.
- `DoraNode::send_service_reply()` -- sends a reply to a service request
- `Event::ServiceRequest` variant for server-side event handling
- `ServiceReply` struct returned by `send_request()`
- `recv_raw()` and `recv_raw_timeout()` on `EventStream` to bypass the scheduler during blocking request calls

### Python Node API (`apis/python/node/`)
- `node.send_request(service_name, data, metadata=None, timeout=None)` -- blocking, returns dict with `value` and `metadata`
- `node.send_service_reply(service_name, data, metadata=None)`
- `SERVICE_REQUEST` event type delivered to the Python event loop
- Type stubs updated in `__init__.pyi`

### Daemon (`binaries/daemon/`)
- Synthetic `__service_request_` and `__service_reply_` channels auto-created from service declarations
- `node_inputs()` injects synthetic inputs for both custom nodes and operators
- `CoreNodeKindExt::run_config()` injects synthetic outputs for both custom nodes and operators
- Service mappings translate between client-side and server-side channel names (supporting operator-prefixed names)
- `DaemonRequest::SendServiceReply` added to the control channel
- `send_output_to_local_receivers()` routes service messages through dedicated mapping tables

### Event Stream (`apis/rust/node/src/event_stream/`)
- `event_stream_loop` converts incoming `__service_request_*` inputs into `NodeEvent::ServiceRequest` events with the prefix stripped
- `convert_event_item` handles `NodeEvent::ServiceRequest` to `Event::ServiceRequest` conversion

### Runtime / Operator Support (`binaries/runtime/`)
- `ServiceRequest` events routed to operators with operator prefix stripped
- `SendServiceReplyCallback` added to the Python operator event dict as `send_service_reply` key (backward compatible, no signature change to `on_event`)
- `OperatorEvent::ServiceReply` forwarded through the runtime to the daemon with correct output id formatting

### Examples (`examples/request-reply/`)
- `dataflow.yml` -- custom node service example
- `dataflow_operator.yml` -- operator service example
- `requester_node.py` -- client node testing data types (int64, float64, uint8, string, bool, int32, empty), event buffering, and timeout
- `service_node.py` -- custom node echo server
- `service_operator.py` -- operator echo server

## Testing

Both dataflows pass all tests:
- 7 Arrow data types round-tripped correctly
- Event buffering verified (ticks not lost during blocking requests)
- Timeout on unanswered requests verified
- Custom node and operator server paths both validated