### PR TITLE
Fixed CommunicationConfig deserialization and added tests for YAML parsing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "cmake.sourceDirectory": "D:/CODE/dora/examples/cmake-dataflow"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cmake.sourceDirectory": "D:/CODE/dora/examples/cmake-dataflow"
+}

--- a/libraries/message/src/config.rs
+++ b/libraries/message/src/config.rs
@@ -229,12 +229,28 @@ pub struct CommunicationConfig {
     pub remote: RemoteCommunicationConfig,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 pub enum LocalCommunicationConfig {
-    #[serde(rename = "tcp")]
     Tcp,
-    #[serde(rename = "unixdomain")]
     UnixDomain,
+}
+
+impl<'de> Deserialize<'de> for LocalCommunicationConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+
+        match value.as_str() {
+            "Tcp" | "tcp" => Ok(Self::Tcp),
+            "UnixDomain" | "unixdomain" => Ok(Self::UnixDomain),
+            other => Err(serde::de::Error::unknown_variant(
+                other,
+                &["Tcp", "tcp", "UnixDomain", "unixdomain"],
+            )),
+        }
+    }
 }
 
 impl Default for LocalCommunicationConfig {
@@ -243,11 +259,23 @@ impl Default for LocalCommunicationConfig {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Serialize, Clone)]
 pub enum RemoteCommunicationConfig {
-    #[serde(rename = "tcp")]
     Tcp,
+}
+
+impl<'de> Deserialize<'de> for RemoteCommunicationConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+
+        match value.as_str() {
+            "Tcp" | "tcp" => Ok(Self::Tcp),
+            other => Err(serde::de::Error::unknown_variant(other, &["Tcp", "tcp"])),
+        }
+    }
 }
 
 impl Default for RemoteCommunicationConfig {

--- a/libraries/message/src/config.rs
+++ b/libraries/message/src/config.rs
@@ -231,7 +231,9 @@ pub struct CommunicationConfig {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum LocalCommunicationConfig {
+    #[serde(rename = "tcp")]
     Tcp,
+    #[serde(rename = "unixdomain")]
     UnixDomain,
 }
 
@@ -242,18 +244,32 @@ impl Default for LocalCommunicationConfig {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(deny_unknown_fields, rename_all = "lowercase")]
+#[serde(deny_unknown_fields)]
 pub enum RemoteCommunicationConfig {
+    #[serde(rename = "tcp")]
     Tcp,
-    // TODO:a
-    // Zenoh {
-    //     config: Option<serde_yaml::Value>,
-    //     prefix: String,
-    // },
 }
 
 impl Default for RemoteCommunicationConfig {
     fn default() -> Self {
         Self::Tcp
+    }
+}
+
+
+impl fmt::Display for LocalCommunicationConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LocalCommunicationConfig::Tcp => write!(f, "tcp"),
+            LocalCommunicationConfig::UnixDomain => write!(f, "unixdomain"),
+        }
+    }
+}
+
+impl fmt::Display for RemoteCommunicationConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RemoteCommunicationConfig::Tcp => write!(f, "tcp"),
+        }
     }
 }

--- a/libraries/message/src/config.rs
+++ b/libraries/message/src/config.rs
@@ -256,7 +256,6 @@ impl Default for RemoteCommunicationConfig {
     }
 }
 
-
 impl fmt::Display for LocalCommunicationConfig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/tests/communication_config_tests.rs
+++ b/tests/communication_config_tests.rs
@@ -1,5 +1,5 @@
-use serde_yaml;
 use dora_message::config::CommunicationConfig;
+use serde_yaml;
 
 #[test]
 fn test_valid_tcp_config() {

--- a/tests/communication_config_tests.rs
+++ b/tests/communication_config_tests.rs
@@ -1,0 +1,46 @@
+use serde_yaml;
+use dora_message::config::CommunicationConfig;
+
+#[test]
+fn test_valid_tcp_config() {
+    let yaml = r#"
+_unstable_local: tcp
+_unstable_remote: tcp
+"#;
+
+    let config: CommunicationConfig = serde_yaml::from_str(yaml).unwrap();
+    assert_eq!(config.local.to_string(), "tcp");
+    assert_eq!(config.remote.to_string(), "tcp");
+}
+
+#[test]
+fn test_valid_unixdomain_config() {
+    let yaml = r#"
+_unstable_local: unixdomain
+_unstable_remote: tcp
+"#;
+
+    let config: CommunicationConfig = serde_yaml::from_str(yaml).unwrap();
+    assert_eq!(config.local.to_string(), "unixdomain");
+}
+
+#[test]
+fn test_invalid_local_config() {
+    let yaml = r#"
+_unstable_local: bluetooth
+"#;
+
+    let result: Result<CommunicationConfig, _> = serde_yaml::from_str(yaml);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_unknown_field_should_fail() {
+    let yaml = r#"
+_unstable_local: tcp
+unknown_field: test
+"#;
+
+    let result: Result<CommunicationConfig, _> = serde_yaml::from_str(yaml);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
Fixes #1582 

## Summary

This PR fixes YAML deserialization for `CommunicationConfig` in `libraries/message/src/config.rs` and adds tests for communication configuration parsing.

## Problem

YAML values like:

```yaml
_unstable_local: tcp
_unstable_remote: tcp
```

were failing to deserialize because the enum variants expected `Tcp` and `UnixDomain`.

## Changes

* added explicit serde renames for enum variants (`tcp`, `unixdomain`)
* implemented `Display` for `LocalCommunicationConfig` and `RemoteCommunicationConfig`
* added tests for:

  * valid tcp config
  * valid unixdomain config
  * invalid config
  * unknown fields

## Testing

```bash
cargo test --test communication_config_tests
```

## Notes

I started exploring the unstable communication config area as part of the cleanup/refactor work mentioned in the GSoC project ideas and plan to contribute more in this area.
