### PR TITLE
added deprecated note

### DIFF
--- a/libraries/message/src/descriptor.rs
+++ b/libraries/message/src/descriptor.rs
@@ -677,7 +677,7 @@ pub struct CustomNode {
     pub source: NodeSource,
     /// Args for the executable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub args: Option<String>, 
+    pub args: Option<String>,
     /// Environment variables for the custom nodes.
     #[deprecated(note = "Use the outer-level `env` field on `Node` instead")]
     pub envs: Option<BTreeMap<String, EnvValue>>,


### PR DESCRIPTION
Replaced the informal deprecation notice in the doc comment of `CustomNode::envs` with a proper `Rust #[deprecated]` attribute, so the compiler emits warnings when this field is used.