### PR TITLE
fix(daemon): treat SIGTERM exit code 143 as success after stop

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -2287,8 +2287,18 @@ impl Daemon {
                     )
                     .await;
 
+                let stop_sent = self
+                    .state
+                    .running
+                    .get(&dataflow_id)
+                    .map_or(false, |d| d.stop_sent);
+
                 let node_result = match exit_status {
                     NodeExitStatus::Success => Ok(()),
+                    // Exit code 143 (128 + SIGTERM) is the conventional exit code used by
+                    // processes that catch SIGTERM and exit explicitly (e.g. Python nodes).
+                    // When a stop was already requested for the dataflow, treat this as success.
+                    NodeExitStatus::ExitCode(143) if stop_sent => Ok(()),
                     exit_status => {
                         // Extract all needed info from the dataflow Ref in one shot
                         let (caused_by_node, grace_duration_kill, stderr_lines) =


### PR DESCRIPTION
## Summary

When a dataflow stop has been requested, exit code 143 (128 + SIGTERM) from a node is now treated as success rather than an error.

## Why

Exit code 143 is the conventional exit code for processes that receive SIGTERM and exit explicitly rather than being killed by the kernel (e.g. Python nodes with a signal handler). Previously, the daemon would report these as node failures even though the stop was intentional, producing spurious error logs and potentially incorrect dataflow state.

The check is guarded by `stop_sent` so that an unexpected SIGTERM (not preceded by a stop request) still surfaces as an error.