### PR TITLE
refactor(core): replace unwrap() with proper error handling in node API and core libs

### DIFF
--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -354,7 +354,15 @@ impl EventStream {
     }
 
     fn add_event(&mut self, event: EventItem) {
-        self.record_event(&event).unwrap();
+        // Event recording failure should not prevent event scheduling.
+        // If writing to the event log file fails, log a warning but continue
+        // processing events. Observability should never break the main logic.
+        if let Err(err) = self.record_event(&event) {
+            tracing::warn!(
+                "failed to record event for node {}: {err:?}",
+                self.node_id
+            );
+        }
         self.scheduler.add_event(event);
     }
 

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -758,8 +758,14 @@ impl DoraNode {
             .map(|(i, _)| i);
         let memory = match cache_index {
             Some(i) => {
-                // we know that this index exists, so we can safely unwrap here
-                self.cache.remove(i).unwrap()
+                // Index was just found via self.cache.iter().enumerate(), so removal
+                // should succeed. Using expect() instead of unwrap() provides a clear
+                // diagnostic message if this invariant is ever violated due to a bug
+                // in cache management or concurrent modification.
+                self.cache.remove(i).expect(
+                    "shared memory cache index should exist: \
+                    found via iter() but missing on remove() indicates cache corruption",
+                )
             }
             None => ShmemHandle(Box::new(
                 ShmemConf::new()
@@ -973,25 +979,49 @@ pub fn init_tracing(
     let guard: Arc<Mutex<Option<OtelGuard>>> = Arc::new(Mutex::new(None));
     let clone = guard.clone();
     let tracing_monitor = async move {
-        let mut builder = TracingBuilder::new(node_id_str);
+        let mut builder = TracingBuilder::new(node_id_str.clone());
         // Only enable OTLP if environment variable is set
         if std::env::var("DORA_OTLP_ENDPOINT").is_ok()
             || std::env::var("DORA_JAEGER_TRACING").is_ok()
         {
-            builder = builder
-                .with_otlp_tracing()
-                .context("failed to set up OTLP tracing")
-                .unwrap()
-                .with_stdout("info", true);
-            *clone.lock().unwrap() = builder.guard.take();
+            // with_otlp_tracing() consumes self, so we need to handle both
+            // success and failure cases. On failure, create a fresh builder.
+            builder = match builder.with_otlp_tracing() {
+                Ok(otlp_builder) => {
+                    otlp_builder.with_stdout("info", true)
+                }
+                Err(err) => {
+                    tracing::warn!("failed to set up OTLP tracing, falling back to stdout only: {err:?}");
+                    TracingBuilder::new(node_id_str).with_stdout("info", true)
+                }
+            };
         } else {
             builder = builder.with_stdout("info", true);
         }
 
-        builder
+        // Handle PoisonError gracefully: tracing setup failure should
+        // not crash the node. If the mutex is poisoned, recover the lock
+        // and continue (data is still valid).
+        match clone.lock() {
+            Ok(mut guard) => *guard = builder.guard.take(),
+            Err(poisoned) => {
+                tracing::warn!(
+                    "tracing guard mutex was poisoned, recovering: \
+                    another task may have panicked while holding the lock"
+                );
+                let mut guard = poisoned.into_inner();
+                *guard = builder.guard.take();
+            }
+        }
+
+        // Tracing subscriber setup failure should not crash the node.
+        // Log the error and continue with default logging.
+        if let Err(err) = builder
             .build()
             .wrap_err("failed to set up tracing subscriber")
-            .unwrap();
+        {
+            tracing::warn!("tracing subscriber setup failed, using default logging: {err:?}");
+        }
     };
 
     let rt = Handle::try_current().context("failed to get tokio runtime handle")?;

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -26,15 +26,19 @@ fn build_zenoh_config(coordinator_addr: Option<IpAddr>, listen_port: Option<u16>
     // Linkstate make it possible to connect two daemons on different network through a public daemon
     // TODO: There is currently a CI/CD Error in windows linkstate.
     if cfg!(not(target_os = "windows")) {
-        zenoh_config
+        if let Err(err) = zenoh_config
             .insert_json5("routing/peer", r#"{ mode: "linkstate" }"#)
-            .unwrap();
+        {
+            tracing::warn!("failed to set zenoh routing peer mode to linkstate: {err}");
+        }
     }
 
     if let Some(port) = listen_port {
-        zenoh_config
+        if let Err(err) = zenoh_config
             .insert_json5("listen/endpoints", &format!(r#"["tcp/0.0.0.0:{port}"]"#))
-            .unwrap();
+        {
+            tracing::warn!("failed to set zenoh listen endpoint: {err}");
+        }
     }
 
     if let Some(addr) = coordinator_addr {
@@ -44,12 +48,14 @@ fn build_zenoh_config(coordinator_addr: Option<IpAddr>, listen_port: Option<u16>
         let would_connect_to_self =
             listen_port == Some(DORA_ZENOH_PEER_PORT_DEFAULT) && addr.is_loopback();
         if !would_connect_to_self {
-            zenoh_config
+            if let Err(err) = zenoh_config
                 .insert_json5(
                     "connect/endpoints",
                     &format!(r#"["tcp/{}:{}"]"#, addr, DORA_ZENOH_PEER_PORT_DEFAULT),
                 )
-                .unwrap();
+            {
+                tracing::warn!("failed to set zenoh connect endpoint: {err}");
+            }
         }
     }
     zenoh_config


### PR DESCRIPTION
Replace 6 instances of unwrap() with graceful error handling to prevent unnecessary panics in production.