### PR TITLE
Fix: incorrectly rejected buffer at beginning of memory region

### DIFF
--- a/libraries/core/src/metadata.rs
+++ b/libraries/core/src/metadata.rs
@@ -74,7 +74,10 @@ impl ArrowTypeInfoExt for ArrowTypeInfo {
                         .ok_or_else(|| eyre::eyre!("region length overflow"))?;
 
                     if (ptr as usize) >= region_end {
-                        eyre::bail!("ptr {ptr:p} starts after region {region_end}");
+                        eyre::bail!(
+                            "ptr {ptr:p} starts after region {region_end:#x} \
+                        (region: {region_start:p}..{region_end:#x})"
+                        );
                     }
 
                     let end_ptr = (ptr as usize)
@@ -82,7 +85,10 @@ impl ArrowTypeInfoExt for ArrowTypeInfo {
                         .ok_or_else(|| eyre::eyre!("buffer length overflow"))?;
 
                     if end_ptr > region_end {
-                        eyre::bail!("ptr {ptr:p} ends after region {region_start:p}");
+                        eyre::bail!(
+                            "ptr {ptr:p} ends after region {region_end:#x} \
+                            (region: {region_start:p}..{region_end:#x})"
+                        );
                     }
                     let offset = usize::try_from(unsafe { ptr.offset_from(region_start) })
                         .context("offset_from is negative")?;

--- a/libraries/core/src/metadata.rs
+++ b/libraries/core/src/metadata.rs
@@ -66,7 +66,7 @@ impl ArrowTypeInfoExt for ArrowTypeInfo {
                 .iter()
                 .map(|b| {
                     let ptr = b.as_ptr();
-                    if ptr as usize <= region_start as usize {
+                    if (ptr as usize) < (region_start as usize) {
                         eyre::bail!("ptr {ptr:p} starts before region {region_start:p}");
                     }
                     let region_end = (region_start as usize)
@@ -74,7 +74,7 @@ impl ArrowTypeInfoExt for ArrowTypeInfo {
                         .ok_or_else(|| eyre::eyre!("region length overflow"))?;
 
                     if (ptr as usize) >= region_end {
-                        eyre::bail!("ptr {ptr:p} starts after region {region_start:p}");
+                        eyre::bail!("ptr {ptr:p} starts after region {region_end}");
                     }
 
                     let end_ptr = (ptr as usize)


### PR DESCRIPTION
**Problem:**

Location: `libraries/core/src/metadata.rs`
Function: `unsafe fn from_array()`

```rust
                    let ptr = b.as_ptr();
                    if ptr as usize <= region_start as usize {
                        eyre::bail!("ptr {ptr:p} starts before region {region_start:p}");
                    }
                    let region_end = (region_start as usize)
                        .checked_add(region_len)
                        .ok_or_else(|| eyre::eyre!("region length overflow"))?;

                    if (ptr as usize) >= region_end {
                        eyre::bail!("ptr {ptr:p} starts after region {region_start:p}");
                    }


```

Here, at this part of code, `<=` is causing first buffer to be rejected even if it's region_start
```rust
                   if ptr as usize <= region_start as usize {
                        eyre::bail!("ptr {ptr:p} starts before region {region_start:p}");
                    }
```



I tried unit testing, 
Which gives,
`Info is Err(ptr 0x561a72e3c520 starts before region 0x561a72e3c520)`
However, those pointers are same.


**Solution**
- Changing `<=` to `<` (Now it's work)

Also, 
```rust
                    if end_ptr > region_end {
                        eyre::bail!("ptr {ptr:p} ends after region {region_start:p}");
                    }

```
I assume, here it was meant to be `{region_end}` instead of `{region_start:p}`

- Changing `{region_start:p}` to `{region_end:#x}` and more descriptive error message