### PR TITLE
feat(python-api): add structured logging and builder queue_policy

### DIFF
--- a/apis/python/node/dora/__init__.pyi
+++ b/apis/python/node/dora/__init__.pyi
@@ -92,6 +92,39 @@ class Node:
         ```
         """
 
+    def log(
+        self,
+        level: str,
+        message: str,
+        target: typing.Optional[str] = None,
+        fields: typing.Optional[typing.Dict[str, str]] = None,
+    ) -> None:
+        """Send a structured log message.
+
+        Outputs a JSONL line to stdout that the daemon parses automatically.
+        Works with ``min_log_level`` filtering and ``send_logs_as`` routing.
+
+        :param level: Log level string (error, warn, info, debug, trace)
+        :param message: The log message
+        :param target: Optional target/module path
+        :param fields: Optional key-value pairs for structured context
+        """
+
+    def log_error(self, message: str) -> None:
+        """Log an error message. Shorthand for ``node.log("error", message)``."""
+
+    def log_warn(self, message: str) -> None:
+        """Log a warning message. Shorthand for ``node.log("warn", message)``."""
+
+    def log_info(self, message: str) -> None:
+        """Log an info message. Shorthand for ``node.log("info", message)``."""
+
+    def log_debug(self, message: str) -> None:
+        """Log a debug message. Shorthand for ``node.log("debug", message)``."""
+
+    def log_trace(self, message: str) -> None:
+        """Log a trace message. Shorthand for ``node.log("trace", message)``."""
+
     def dataflow_descriptor(self) -> dict:
         """Returns the full dataflow descriptor that this node is part of.
 

--- a/apis/python/node/dora/builder.py
+++ b/apis/python/node/dora/builder.py
@@ -44,6 +44,9 @@ class Output:
         return f"{self.node.id}/{self.output_id}"
 
 
+_VALID_QUEUE_POLICIES = frozenset({"drop_oldest", "backpressure"})
+
+
 class Node:
     """A node in a dora dataflow."""
 
@@ -100,29 +103,41 @@ class Node:
         return Output(self, output_id)
 
     def add_input(
-        self, input_id: str, source: str | Output, queue_size: int = None
+        self,
+        input_id: str,
+        source: str | Output,
+        queue_size: int = None,
+        queue_policy: str = None,
     ) -> Node:
-        """Adds a user-defined input to the node. Source can be a string or an Output object."""
+        """Adds a user-defined input to the node. Source can be a string or an Output object.
+
+        Args:
+            input_id: The input identifier.
+            source: Source node/output (e.g. "node_a/output_1") or an Output object.
+            queue_size: Input buffer size. When full, behavior depends on queue_policy.
+            queue_policy: "drop_oldest" (default) or "backpressure" (buffers 10x queue_size).
+        """
+        if queue_policy is not None and queue_policy not in _VALID_QUEUE_POLICIES:
+            raise ValueError(
+                f"queue_policy must be one of {_VALID_QUEUE_POLICIES}, got {queue_policy!r}"
+            )
+        if queue_size is not None and queue_size < 1:
+            raise ValueError(f"queue_size must be >= 1, got {queue_size}")
+
         if "inputs" not in self.config:
             self.config["inputs"] = {}
 
-        if isinstance(source, Output):
-            source_str = str(source)
+        source_str = str(source) if isinstance(source, Output) else source
+        has_options = queue_size is not None or queue_policy is not None
+        if has_options:
+            opts = {"source": source_str}
             if queue_size is not None:
-                self.config["inputs"][input_id] = {
-                    "source": source_str,
-                    "queue_size": queue_size,
-                }
-            else:
-                self.config["inputs"][input_id] = source_str
+                opts["queue_size"] = queue_size
+            if queue_policy is not None:
+                opts["queue_policy"] = queue_policy
+            self.config["inputs"][input_id] = opts
         else:
-            if queue_size is not None:
-                self.config["inputs"][input_id] = {
-                    "source": source,
-                    "queue_size": queue_size,
-                }
-            else:
-                self.config["inputs"][input_id] = source
+            self.config["inputs"][input_id] = source_str
         return self
 
     def to_dict(self) -> dict:

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -381,6 +381,89 @@ impl Node {
         Ok(())
     }
 
+    /// Send a structured log message.
+    ///
+    /// Outputs a JSONL line to stdout that the daemon parses automatically.
+    /// Works with ``min_log_level`` filtering and ``send_logs_as`` routing.
+    ///
+    /// :param level: Log level string (error, warn, info, debug, trace)
+    /// :type level: str
+    /// :param message: The log message
+    /// :type message: str
+    /// :param target: Optional target/module path
+    /// :type target: str, optional
+    /// :param fields: Optional key-value pairs for structured context
+    /// :type fields: dict[str, str], optional
+    /// :rtype: None
+    #[pyo3(signature = (level, message, target=None, fields=None))]
+    pub fn log(
+        &self,
+        level: &str,
+        message: &str,
+        target: Option<&str>,
+        fields: Option<std::collections::HashMap<String, String>>,
+    ) {
+        let ordered = fields.map(|f| f.into_iter().collect::<std::collections::BTreeMap<_, _>>());
+        self.node
+            .get_mut()
+            .log_with_fields(level, message, target, ordered.as_ref());
+    }
+
+    /// Log an error message.
+    ///
+    /// Shorthand for ``node.log("error", message)``.
+    ///
+    /// :param message: The log message
+    /// :type message: str
+    /// :rtype: None
+    pub fn log_error(&self, message: &str) {
+        self.node.get_mut().log_error(message);
+    }
+
+    /// Log a warning message.
+    ///
+    /// Shorthand for ``node.log("warn", message)``.
+    ///
+    /// :param message: The log message
+    /// :type message: str
+    /// :rtype: None
+    pub fn log_warn(&self, message: &str) {
+        self.node.get_mut().log_warn(message);
+    }
+
+    /// Log an info message.
+    ///
+    /// Shorthand for ``node.log("info", message)``.
+    ///
+    /// :param message: The log message
+    /// :type message: str
+    /// :rtype: None
+    pub fn log_info(&self, message: &str) {
+        self.node.get_mut().log_info(message);
+    }
+
+    /// Log a debug message.
+    ///
+    /// Shorthand for ``node.log("debug", message)``.
+    ///
+    /// :param message: The log message
+    /// :type message: str
+    /// :rtype: None
+    pub fn log_debug(&self, message: &str) {
+        self.node.get_mut().log_debug(message);
+    }
+
+    /// Log a trace message.
+    ///
+    /// Shorthand for ``node.log("trace", message)``.
+    ///
+    /// :param message: The log message
+    /// :type message: str
+    /// :rtype: None
+    pub fn log_trace(&self, message: &str) {
+        self.node.get_mut().log_trace(message);
+    }
+
     /// Returns the full dataflow descriptor that this node is part of.
     ///
     /// This method returns the parsed dataflow YAML file.

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -812,6 +812,87 @@ impl DoraNode {
             ),
         }
     }
+
+    /// Send a structured log message.
+    ///
+    /// Outputs a JSONL line to stdout that the daemon parses automatically.
+    /// Works with `min_log_level` filtering and `send_logs_as` routing.
+    ///
+    /// `level` should be one of: `"error"`, `"warn"`, `"info"`, `"debug"`, `"trace"`.
+    /// Unknown levels default to `"info"`.
+    pub fn log(&self, level: &str, message: &str, target: Option<&str>) {
+        self.log_with_fields(level, message, target, None);
+    }
+
+    /// Maximum total size of log fields before they are dropped (60 KB).
+    const MAX_LOG_FIELDS_BYTES: usize = 60 * 1024;
+
+    /// Send a structured log message with optional key-value fields.
+    ///
+    /// Like [`log`](Self::log), but accepts additional structured fields that
+    /// are included in the JSON payload and preserved through `send_logs_as`.
+    pub fn log_with_fields(
+        &self,
+        level: &str,
+        message: &str,
+        target: Option<&str>,
+        fields: Option<&std::collections::BTreeMap<String, String>>,
+    ) {
+        let level_str = match level.to_lowercase().as_str() {
+            "error" => "error",
+            "warn" | "warning" => "warn",
+            "info" => "info",
+            "debug" => "debug",
+            "trace" => "trace",
+            _ => "info",
+        };
+        let mut entry = serde_json::json!({
+            "level": level_str,
+            "node_id": self.id.to_string(),
+            "message": message,
+        });
+        if let Some(target) = target {
+            entry["target"] = serde_json::Value::String(target.to_string());
+        }
+        if let Some(fields) = fields {
+            let total: usize = fields.iter().map(|(k, v)| k.len() + v.len()).sum();
+            if total <= Self::MAX_LOG_FIELDS_BYTES {
+                entry["fields"] = serde_json::json!(fields);
+            } else {
+                eprintln!("dora log: fields too large ({total} bytes), dropping fields");
+                entry["fields_dropped"] = serde_json::Value::Bool(true);
+            }
+        }
+        match serde_json::to_string(&entry) {
+            Ok(json) => println!("{json}"),
+            Err(e) => eprintln!("dora log serialization error: {e}"),
+        }
+    }
+
+    /// Log an error message.
+    pub fn log_error(&self, message: &str) {
+        self.log("error", message, None);
+    }
+
+    /// Log a warning message.
+    pub fn log_warn(&self, message: &str) {
+        self.log("warn", message, None);
+    }
+
+    /// Log an info message.
+    pub fn log_info(&self, message: &str) {
+        self.log("info", message, None);
+    }
+
+    /// Log a debug message.
+    pub fn log_debug(&self, message: &str) {
+        self.log("debug", message, None);
+    }
+
+    /// Log a trace message.
+    pub fn log_trace(&self, message: &str) {
+        self.log("trace", message, None);
+    }
 }
 
 impl Drop for DoraNode {


### PR DESCRIPTION
## Summary
- Add `node.log(level, message, target, fields)` and shorthand `log_error/warn/info/debug/trace()` methods to the Python Node API, backed by new Rust `DoraNode` methods that output structured JSONL to stdout for daemon parsing
- Enhance `DataflowBuilder.add_input()` with `queue_policy` parameter (`"drop_oldest"` or `"backpressure"`) alongside existing `queue_size`, with input validation
- Update type stubs (`.pyi`) for IDE autocompletion

Ported from [dora-rs/adora](https://github.com/dora-rs/adora).

## Test plan
- [ ] Verify `cargo check -p dora-node-api` passes (confirmed locally)
- [ ] Test `node.log_info("hello")` outputs valid JSONL to stdout
- [ ] Test `DataflowBuilder` with `queue_policy="backpressure"` generates correct YAML
- [ ] Test validation rejects invalid `queue_policy` values and `queue_size < 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)