### PR TITLE
docs: restore external resource links at top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,29 @@
 [English](README.md) | [简体中文](README.zh-CN.md)
 
+<p align="center">
+    <img src="https://raw.githubusercontent.com/dora-rs/dora/main/docs/src/logo.svg" width="400"/>
+</p>
+
+<h2 align="center">
+  <a href="https://www.dora-rs.ai">Website</a>
+  |
+  <a href="https://dora-rs.ai/docs/guides/getting-started/conversation_py/">Python API</a>
+  |
+  <a href="https://docs.rs/dora-node-api/latest/dora_node_api/">Rust API</a>
+  |
+  <a href="https://www.dora-rs.ai/docs/guides/">Guide</a>
+  |
+  <a href="https://discord.gg/6eMGGutkfE">Discord</a>
+</h2>
+
+<div align="center">
+  <a href="https://github.com/dora-rs/dora/actions"><img src="https://github.com/dora-rs/dora/workflows/CI/badge.svg" alt="Build and test"/></a>
+  <a href="https://crates.io/crates/dora-rs"><img src="https://img.shields.io/crates/v/dora_node_api.svg" alt="crates.io"/></a>
+  <a href="https://docs.rs/dora-node-api/latest/dora_node_api/"><img src="https://docs.rs/dora-node-api/badge.svg" alt="docs.rs"/></a>
+  <a href="https://pypi.org/project/dora-rs/"><img src="https://img.shields.io/pypi/v/dora-rs.svg" alt="PyPI"/></a>
+  <a href="https://github.com/dora-rs/dora/blob/main/LICENSE"><img src="https://img.shields.io/github/license/dora-rs/dora" alt="License"/></a>
+</div>
+
 # Dora
 
 **Agentic Dataflow-Oriented Robotic Architecture** -- a 100% Rust framework for building real-time robotics and AI applications.


### PR DESCRIPTION
## Summary

The Q1 2026 Rust-first rewrite consolidation (`145ccce0`) replaced the old README header with a minimal language switcher plus a single User Guide link, dropping the logo, the external-resource link bar, and the status badges. This restores them above the `# Dora` title.

Added block (inserted between the language switcher and `# Dora`):

- Logo (`docs/src/logo.svg`)
- Link bar: Website, Python API, Rust API, Guide, Discord
- Status badges: CI, crates.io, docs.rs, PyPI, License

Everything below the title (tagline, TOC, features, install, CLI reference, architecture, examples, development, QA) is untouched.

URLs taken verbatim from `git show 145ccce0^:README.md`, so no links are invented. The Discord invite matches the existing `## Contributing` section.

## Preview

```
[English](README.md) | [简体中文](README.zh-CN.md)

<logo>

Website | Python API | Rust API | Guide | Discord

[CI]  [crates.io]  [docs.rs]  [PyPI]  [License]

# Dora

Agentic Dataflow-Oriented Robotic Architecture ...
```

## Test plan

- [x] `typos` — clean
- [ ] GitHub preview renders the `<h2 align="center">` link bar and badge row correctly
- [ ] Follow-up: same restoration on `README.zh-CN.md` (not bundled to keep diff focused)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
