### PR TITLE
ci+fix: stop cpu-affinity-probe exit race and raise record timeout

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -239,9 +239,13 @@ jobs:
         run: |
           # `dora record <yaml>` instruments the dataflow and runs it;
           # recording written to the specified output path.
-          # Nodes are pre-built above so the 30s timeout covers only runtime.
-          # Don't swallow errors (no `|| true`) — real failures should surface.
-          timeout 30s dora record examples/rust-dataflow/dataflow.yml -o run.drec
+          # The nodes pre-built above don't cover everything dora record
+          # re-invokes via the YAML `build:` directives — on a cold rust-cache
+          # miss it can drop back into compiling zenoh/arrow transitively
+          # (observed as exit 124 at the original 30s cap). A 300s outer
+          # timeout still guards against a hang without amputating cold
+          # compile. Runtime itself is ~1-2s. Don't swallow errors (no `|| true`).
+          timeout 300s dora record examples/rust-dataflow/dataflow.yml -o run.drec
           test -f run.drec || { echo "record did not produce run.drec"; exit 1; }
           echo "recording size: $(wc -c < run.drec) bytes"
       - name: Replay

--- a/examples/cpu-affinity-probe/src/main.rs
+++ b/examples/cpu-affinity-probe/src/main.rs
@@ -7,21 +7,24 @@
 //!
 //! On non-Linux, prints `AFFINITY_MASK:unsupported` so the test skips
 //! cleanly.
+//!
+//! After printing, the probe consumes tick events until the dora stream
+//! closes. Exiting on the first tick used to race `dora run`'s log-subscribe
+//! path (short-lived dataflows could be gone from the coordinator by the
+//! time subscribe_logs arrives → "no running dataflow with id" at
+//! binaries/cli/src/ws_client.rs:454). Staying alive for the duration of
+//! `--stop-after` closes that race on the node side.
 
-use dora_node_api::DoraNode;
+use dora_node_api::{DoraNode, Event};
 use eyre::Context;
 
 fn main() -> eyre::Result<()> {
-    // Initialize as a dora node so the daemon can manage the process
-    // lifecycle. We don't consume events; the node prints its mask and
-    // exits on the first tick (or immediately).
-    let (_node, _events) =
+    let (_node, mut events) =
         DoraNode::init_from_env().context("failed to init dora node from env")?;
 
     #[cfg(target_os = "linux")]
     {
         let mask = read_affinity_mask()?;
-        // Sort for deterministic comparison.
         let mut sorted = mask;
         sorted.sort_unstable();
         let csv = sorted
@@ -35,6 +38,12 @@ fn main() -> eyre::Result<()> {
     #[cfg(not(target_os = "linux"))]
     {
         println!("AFFINITY_MASK:unsupported");
+    }
+
+    while let Some(event) = events.recv() {
+        if matches!(event, Event::Stop(_)) {
+            break;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

Follow-up to #1636. On the re-triggered Nightly Regression after that PR merged (run [24604341954](https://github.com/dora-rs/dora/actions/runs/24604341954)):

- ✅ `redb backend end-to-end` — now green (long-running fixture works)
- ❌ `cpu_affinity end-to-end (Linux)` — still fails; my `\|\| true` surfaced the real error
- ❌ `Record/replay round-trip` — still times out

Two distinct root causes, two surgical fixes.

### 1. `cpu_affinity` — CLI `--detach` race exposed

The `\|\| true` I added in #1636 made the real error visible for the first time:

```
failed to subscribe to logs
Caused by: no running dataflow with id 019da08e-17de-7182-be37-d3c80b990a08
Location: binaries/cli/src/ws_client.rs:454:37
```

Same race I patched out of `redb-backend-smoke` by swapping to a long-running fixture — the probe exits immediately after printing `AFFINITY_MASK`, so the dataflow is already gone by the time `dora run`'s log-subscribe path reaches the coordinator. The CLI-side bug is tracked as a follow-up; this PR closes the race on the node side.

**Fix:** `examples/cpu-affinity-probe/src/main.rs` adds a standard event loop after printing. The probe now consumes tick events until the stream closes on `Event::Stop`, keeping it alive for the full `--stop-after 3s` window.

Verified locally: `dora run dataflow.yml --stop-after 3s` exits 0, prints `AFFINITY_MASK`, and shuts down cleanly on stop.

### 2. `Record/replay` — inner timeout too tight

The `timeout-minutes: 30` bump from #1636 was correct but didn't help here, because the step already had an inner `timeout 30s dora record ...`. On a cold rust-cache, `dora record` re-invokes the YAML `build:` directives and drops back into compiling zenoh / arrow / serde transitively — the log shows exit 124 mid-`Compiling zenoh-link-tcp`.

**Fix:** raise the inner bound to `300s`. Actual runtime is ~1–2s, so 300s still catches a real hang without amputating cold compile on a cache miss.

Understanding _why_ `dora record` recompiles after a workspace-level pre-build is deferred as a follow-up — bandaid first, root cause later.

## Test plan

- [x] `cargo build -p cpu-affinity-probe` clean
- [x] `dora run examples/cpu-affinity-probe/dataflow.yml --stop-after 3s` exits 0 locally; mask printed; probe receives Stop and shuts down
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — YAML valid
- [x] `typos` clean
- [x] `make qa-fast` green (unwrap count 157 vs 185)
- [ ] Nightly self-triggers on merge (paths filter on `.github/workflows/nightly.yml`)
- [ ] `cpu_affinity end-to-end (Linux)`, `Record/replay round-trip`, `redb backend end-to-end` all green on the re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
