### PR TITLE
fix(cli): tolerate dataflow-already-finished race in start --detach and run

### DIFF
--- a/binaries/cli/src/command/run.rs
+++ b/binaries/cli/src/command/run.rs
@@ -5,7 +5,10 @@
 use super::{Executable, system::status::daemon_running};
 use crate::{
     LOCALHOST, build as build_dataflow,
-    common::{connect_with_retry, handle_dataflow_result, resolve_dataflow, write_events_to},
+    common::{
+        connect_with_retry, error_indicates_dataflow_finished, handle_dataflow_result,
+        resolve_dataflow, write_events_to,
+    },
     output::{
         LogFormat, LogOutputConfig, parse_log_filter, parse_log_level_str, print_log_message,
     },
@@ -312,6 +315,14 @@ impl Executable for Run {
         };
 
         // --- Wait for spawn ---
+        //
+        // Sub-second dataflows race against this request: the coordinator
+        // drops the running-dataflow entry on completion, so a WaitForSpawn
+        // that arrives afterwards comes back as `Error("unknown dataflow X")`.
+        // That's not a startup failure — the DataflowStartTriggered we
+        // already received proves the coordinator accepted the spawn. Treat
+        // it as evidence the dataflow ran to completion.
+        let mut spawn_already_finished = false;
         {
             let reply_raw = session
                 .request(
@@ -322,6 +333,12 @@ impl Executable for Run {
                 serde_json::from_slice(&reply_raw).context("failed to parse reply")?;
             match result {
                 ControlRequestReply::DataflowSpawned { uuid: _ } => {}
+                ControlRequestReply::Error(err) if error_indicates_dataflow_finished(&err) => {
+                    tracing::debug!(
+                        "dataflow {dataflow_id} finished before WaitForSpawn arrived: {err}"
+                    );
+                    spawn_already_finished = true;
+                }
                 ControlRequestReply::Error(err) => bail!(
                     "dataflow failed to start: {err}\n\n  \
                      hint: if nodes require building, run `dora build <dataflow.yml>` first"
@@ -355,35 +372,52 @@ impl Executable for Run {
             print_daemon_name: false,
         };
 
-        let log_rx = session
-            .subscribe_logs(
-                &serde_json::to_vec(&ControlRequest::LogSubscribe {
-                    dataflow_id,
-                    level: log_level,
-                })
-                .context("failed to serialize log subscribe")?,
-            )
-            .context("failed to subscribe to logs")?;
-
-        let log_event_tx = event_tx.clone();
-        std::thread::spawn(move || {
-            // Forward log messages to the print loop.
-            // When the log subscription closes (coordinator shuts down), the thread exits.
-            while let Ok(raw) = log_rx.recv() {
-                let parsed: eyre::Result<LogMessage> = match raw {
-                    Ok(bytes) => {
-                        serde_json::from_slice(&bytes).context("failed to parse log message")
-                    }
-                    Err(err) => Err(err),
-                };
-                match parsed {
-                    Ok(msg) => print_log_message(msg, &log_config),
-                    Err(err) => tracing::warn!("failed to parse log message: {err:#}"),
+        // Subscribing to logs also races against sub-second dataflows: the
+        // ack can come back with "no running dataflow with id X" even after
+        // a successful WaitForSpawn. Skip the stream (nothing to tail) but
+        // keep running so the remaining lifecycle bookkeeping still
+        // reports the dataflow exit status correctly.
+        let log_subscribe_request = serde_json::to_vec(&ControlRequest::LogSubscribe {
+            dataflow_id,
+            level: log_level,
+        })
+        .context("failed to serialize log subscribe")?;
+        let log_subscription = if spawn_already_finished {
+            None
+        } else {
+            match session.subscribe_logs(&log_subscribe_request) {
+                Ok(rx) => Some(rx),
+                Err(err) if error_indicates_dataflow_finished(&err.to_string()) => {
+                    tracing::debug!(
+                        "dataflow {dataflow_id} finished before log subscribe arrived: {err}"
+                    );
+                    None
                 }
+                Err(err) => return Err(err).context("failed to subscribe to logs"),
             }
-            // Signal the main loop when log subscription closes (coordinator shutting down)
-            let _ = log_event_tx;
-        });
+        };
+
+        if let Some(log_rx) = log_subscription {
+            let log_event_tx = event_tx.clone();
+            std::thread::spawn(move || {
+                // Forward log messages to the print loop.
+                // When the log subscription closes (coordinator shuts down), the thread exits.
+                while let Ok(raw) = log_rx.recv() {
+                    let parsed: eyre::Result<LogMessage> = match raw {
+                        Ok(bytes) => {
+                            serde_json::from_slice(&bytes).context("failed to parse log message")
+                        }
+                        Err(err) => Err(err),
+                    };
+                    match parsed {
+                        Ok(msg) => print_log_message(msg, &log_config),
+                        Err(err) => tracing::warn!("failed to parse log message: {err:#}"),
+                    }
+                }
+                // Signal the main loop when log subscription closes (coordinator shutting down)
+                let _ = log_event_tx;
+            });
+        }
 
         // --- Stop-after timer ---
         if let Some(stop_after) = self.stop_after {

--- a/binaries/cli/src/command/start/mod.rs
+++ b/binaries/cli/src/command/start/mod.rs
@@ -6,8 +6,8 @@ use super::{Executable, default_tracing};
 use crate::{
     command::start::attach::attach_dataflow,
     common::{
-        CoordinatorOptions, connect_to_coordinator, expect_reply, local_working_dir,
-        resolve_dataflow, send_control_request, write_events_to,
+        CoordinatorOptions, connect_to_coordinator, error_indicates_dataflow_finished,
+        expect_reply, local_working_dir, resolve_dataflow, send_control_request, write_events_to,
     },
     output::{LogOutputConfig, print_log_message},
     session::DataflowSession,
@@ -163,39 +163,64 @@ fn wait_until_dataflow_started(
     log_level: log::LevelFilter,
     print_daemon_id: bool,
 ) -> eyre::Result<()> {
-    // subscribe to log messages
-    let log_rx = session.subscribe_logs(
+    // Subscribe to log messages. This can race against sub-second
+    // dataflows: the coordinator drops the running-dataflow entry on
+    // completion, so a LogSubscribe that arrives after the dataflow
+    // finished fails with "no running dataflow with id X". That's a
+    // valid state — the dataflow ran and exited — not an error for
+    // the --detach caller. Warn and continue without a log stream.
+    match session.subscribe_logs(
         &serde_json::to_vec(&ControlRequest::LogSubscribe {
             dataflow_id,
             level: log_level,
         })
         .wrap_err("failed to serialize message")?,
-    )?;
-    std::thread::spawn(move || {
-        while let Ok(Ok(raw)) = log_rx.recv() {
-            let parsed: eyre::Result<LogMessage> =
-                serde_json::from_slice(&raw).context("failed to parse log message");
-            match parsed {
-                Ok(log_message) => {
-                    let config = LogOutputConfig {
-                        print_daemon_name: print_daemon_id,
-                        ..LogOutputConfig::default()
-                    };
-                    print_log_message(log_message, &config);
+    ) {
+        Ok(log_rx) => {
+            std::thread::spawn(move || {
+                while let Ok(Ok(raw)) = log_rx.recv() {
+                    let parsed: eyre::Result<LogMessage> =
+                        serde_json::from_slice(&raw).context("failed to parse log message");
+                    match parsed {
+                        Ok(log_message) => {
+                            let config = LogOutputConfig {
+                                print_daemon_name: print_daemon_id,
+                                ..LogOutputConfig::default()
+                            };
+                            print_log_message(log_message, &config);
+                        }
+                        Err(err) => {
+                            tracing::warn!("failed to parse log message: {err:?}")
+                        }
+                    }
                 }
-                Err(err) => {
-                    tracing::warn!("failed to parse log message: {err:?}")
-                }
-            }
+            });
         }
-    });
+        Err(err) if error_indicates_dataflow_finished(&err.to_string()) => {
+            tracing::debug!("dataflow {dataflow_id} completed before log subscribe arrived");
+        }
+        Err(err) => return Err(err).wrap_err("failed to subscribe to logs"),
+    }
 
-    let reply = send_control_request(session, &ControlRequest::WaitForSpawn { dataflow_id })
-        .wrap_err(
-            "dataflow failed to start\n\n  \
-             hint: if nodes require building, run `dora build <dataflow.yml>` first",
-        )?;
-    let uuid = expect_reply!(reply, DataflowSpawned { uuid })?;
-    println!("dataflow started: {uuid}");
+    // Same race on WaitForSpawn: a dataflow that exited before this
+    // request landed is reported as "unknown dataflow X". The
+    // DataflowStartTriggered reply we already observed is proof that
+    // the coordinator accepted the spawn — treat "unknown" as evidence
+    // the dataflow ran to completion, not as a startup failure.
+    match send_control_request(session, &ControlRequest::WaitForSpawn { dataflow_id }) {
+        Ok(reply) => {
+            let uuid = expect_reply!(reply, DataflowSpawned { uuid })?;
+            println!("dataflow started: {uuid}");
+        }
+        Err(err) if error_indicates_dataflow_finished(&err.to_string()) => {
+            println!("dataflow started and finished: {dataflow_id}");
+        }
+        Err(err) => {
+            return Err(err).wrap_err(
+                "dataflow failed to start\n\n  \
+                 hint: if nodes require building, run `dora build <dataflow.yml>` first",
+            );
+        }
+    }
     Ok(())
 }

--- a/binaries/cli/src/common.rs
+++ b/binaries/cli/src/common.rs
@@ -18,6 +18,20 @@ use std::{
 use tokio::runtime::Builder;
 use uuid::Uuid;
 
+/// Whether a coordinator error message indicates the dataflow has already
+/// completed and been dropped from the running-dataflows table.
+///
+/// `LogSubscribe` reports `"no running dataflow with id X"` (see
+/// `binaries/coordinator/src/ws_control.rs:164`) and `WaitForSpawn` reports
+/// `"unknown dataflow X"` (see `binaries/coordinator/src/lib.rs:696`). Both
+/// hit this race for sub-second dataflows: the coordinator removes the
+/// entry as soon as the dataflow finishes, so any request that arrives
+/// afterwards errors — even though the dataflow ran successfully and the
+/// CLI already received `DataflowStartTriggered`.
+pub(crate) fn error_indicates_dataflow_finished(msg: &str) -> bool {
+    msg.contains("no running dataflow with id") || msg.contains("unknown dataflow")
+}
+
 pub(crate) fn handle_dataflow_result(
     result: DataflowResult,
     uuid: Option<Uuid>,


### PR DESCRIPTION
## Summary

Fixes the underlying bug I worked around on the test side in #1636 / #1639 (task #6).

Both `dora start --detach` and `dora run` race against sub-second dataflows: the coordinator drops the running-dataflow entry on completion, so a `LogSubscribe` or `WaitForSpawn` request that arrives afterwards errors with `"no running dataflow with id X"` or `"unknown dataflow X"`. The CLI surfaces that as a hard failure, even though the dataflow ran successfully and `DataflowStartTriggered` was already acknowledged.

### What changed

- **New predicate** `common::error_indicates_dataflow_finished(msg: &str) -> bool` — centralizes the "coordinator says the dataflow is no longer tracked" pattern. Matches both error strings (`"no running dataflow with id"` from `binaries/coordinator/src/ws_control.rs:164` and `"unknown dataflow"` from `binaries/coordinator/src/lib.rs:696`).

- **`binaries/cli/src/command/start/mod.rs` (`wait_until_dataflow_started`)**:
  - `subscribe_logs` failure on "already finished" → warn at `debug` level, continue without log stream
  - `WaitForSpawn` failure on "already finished" → print `dataflow started and finished: UUID`, return `Ok(())`
  - Any other error still bails normally

- **`binaries/cli/src/command/run.rs`**:
  - `WaitForSpawn` reply of `ControlRequestReply::Error("unknown dataflow …")` → set `spawn_already_finished = true`, skip log subscription entirely
  - `subscribe_logs` failure on "already finished" → warn at `debug`, run without logs so `--stop-after` / exit-status bookkeeping still complete

### Why not also fix the coordinator side

The coordinator's current behavior (drop entry → error on late lookup) is semantically correct for the _protocol_ — it reports accurate state. The right place to absorb the race is the client, which already has `DataflowStartTriggered` as proof of successful submission.

### Impact on existing workarounds

- #1639's probe event-loop fix is still correct defense-in-depth — no need to revert.
- #1636's redb-backend-smoke fixture swap (short-lived probe → long-running dataflow) is still correct — the test's actual intent is exercising the redb persistence layer, not the CLI race.

## Verification

Reproduced locally against a temporarily-neutered cpu-affinity-probe (event loop removed, exits immediately after init):

**Before fix** — `dora run examples/cpu-affinity-probe/dataflow.yml --stop-after 3s` errors at `binaries/cli/src/ws_client.rs:454` with:
```
failed to subscribe to logs
Caused by: no running dataflow with id 019da08e-...
```

**After fix** — both `dora run` and `dora start --detach` exit `0`, print the mask, and shut down cleanly. Probe reverted to its event-loop form before commit.

## Test plan

- [x] `cargo build -p dora-cli` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `make qa-fast` green (unwrap count 157 vs 185)
- [x] Local repro: `dora run` short-lived dataflow — exit 0 with fix
- [x] Local repro: `dora start --detach` short-lived dataflow — exit 0 with fix
- [ ] CI green on this PR
- [ ] Nightly `cpu_affinity end-to-end (Linux)` continues green (was fixed on node side in #1639; CLI fix is belt-and-suspenders)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
