### PR TITLE
test: deterministic max_restarts exhaustion coverage (#1631)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "always-crash-node"
+version = "0.2.1"
+dependencies = [
+ "dora-node-api",
+ "eyre",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ members = [
     "libraries/extensions/ros2-bridge/python",
     "libraries/extensions/ros2-bridge/arrow",
     "tests/queue_size_latest_data_rust/receive_data",
+    "tests/fault_tolerance/always_crash_node",
 ]
 
 [workspace.package]

--- a/tests/dataflows/max-restarts-truly-exhausted.yml
+++ b/tests/dataflows/max-restarts-truly-exhausted.yml
@@ -1,0 +1,9 @@
+nodes:
+  - id: always-crash
+    build: cargo build -p always-crash-node
+    path: ../../target/debug/always-crash-node
+    restart_policy: on-failure
+    max_restarts: 2
+    restart_delay: 0.1
+    inputs:
+      tick: dora/timer/millis/50

--- a/tests/fault-tolerance-e2e.rs
+++ b/tests/fault-tolerance-e2e.rs
@@ -125,6 +125,78 @@ async fn max_restarts_limit_reached() {
     eprintln!("status-node final result: {status_result:?} (both Ok and Err are valid)");
 }
 
+/// Max restarts are **actually exhausted** — strengthens
+/// `max_restarts_limit_reached` (#1631).
+///
+/// Background: the pre-existing `max_restarts_limit_reached` test uses the
+/// shared `rust-dataflow-example-status-node`, which panics only on
+/// `restart_count() == 0`. With the fail timer firing every 50 ms, the
+/// first incarnation crashes, the daemon restarts the node, and every
+/// incarnation after that ignores the fail signal. `max_restarts: 2` is
+/// therefore **never** reached, so the test falls back to a permissive
+/// "both `Ok` and `Err` are valid" comment that defeats the point.
+///
+/// This test drives exhaustion deterministically with a dedicated test
+/// crate (`always-crash-node`) that panics on every incarnation. With
+/// `max_restarts: 2` and a 50 ms tick, the budget is consumed within
+/// ~300 ms (3 crashes × 100 ms restart_delay) and the daemon must end
+/// the dataflow with an `Err` for the always-crash node. The assertion
+/// is now: the node's final `node_result` is `Err`, not "either is fine".
+#[tokio::test(flavor = "multi_thread")]
+async fn max_restarts_exhaustion_marks_node_failed() {
+    ensure_nodes_built();
+    // Shares the `BUILD_NODES` Once gate above only because rustfmt likes it
+    // co-located; the always-crash-node crate is a separate workspace
+    // member and has its own compile here.
+    let status = std::process::Command::new("cargo")
+        .args(["build", "-p", "always-crash-node"])
+        .status()
+        .expect("failed to build always-crash-node");
+    assert!(status.success(), "always-crash-node build failed");
+
+    let dataflow_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/dataflows/max-restarts-truly-exhausted.yml");
+
+    let result = Daemon::run_dataflow(
+        &dataflow_path,
+        None,
+        None,
+        SessionId::generate(),
+        false,
+        LogDestination::Tracing,
+        None,
+        Some(Duration::from_secs(10)),
+        false,
+    )
+    .await;
+
+    let dr =
+        result.expect("dataflow run itself should not error — per-node exhaustion is expected");
+    eprintln!(
+        "dataflow completed with {} node results",
+        dr.node_results.len()
+    );
+    for (id, r) in &dr.node_results {
+        eprintln!("  {id}: {r:?}");
+    }
+
+    let crash_result = dr
+        .node_results
+        .get(&"always-crash".to_string().into())
+        .expect("always-crash node should be present in node_results");
+
+    // Core contract: after `max_restarts` is truly exhausted, the daemon
+    // records an `Err` for the affected node. An `Ok` here would indicate
+    // either a silent restart bypass or stop_after racing ahead of the
+    // final crash before the daemon published the terminal result — both
+    // are regressions we want to catch.
+    assert!(
+        crash_result.is_err(),
+        "always-crash node exhausted max_restarts: 2 but final result is Ok — \
+         restart budget was not properly tracked as exhausted. got: {crash_result:?}"
+    );
+}
+
 /// Input timeout fires when upstream stops producing.
 ///
 /// The status-node exits after receiving trigger-exit. The sink has input_timeout: 2.0

--- a/tests/fault_tolerance/always_crash_node/Cargo.toml
+++ b/tests/fault_tolerance/always_crash_node/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "always-crash-node"
+edition.workspace = true
+rust-version.workspace = true
+version.workspace = true
+description.workspace = true
+documentation.workspace = true
+license.workspace = true
+publish = false
+
+# Test-only node: panics on the first tick of every incarnation so that
+# `max_restarts` is reliably exhausted (unlike the shared status-node
+# which only crashes on incarnation 0). Used by fault-tolerance-e2e.rs
+# to prove the restart-budget path is actually traversed.
+
+[[bin]]
+name = "always-crash-node"
+path = "src/main.rs"
+
+[dependencies]
+dora-node-api = { workspace = true, default-features = false }
+eyre = { workspace = true }

--- a/tests/fault_tolerance/always_crash_node/src/main.rs
+++ b/tests/fault_tolerance/always_crash_node/src/main.rs
@@ -1,0 +1,28 @@
+//! Test-only node that panics on the first input of every incarnation.
+//!
+//! Paired with `tests/dataflows/max-restarts-truly-exhausted.yml` and
+//! `tests/fault-tolerance-e2e.rs::max_restarts_exhaustion_marks_node_failed`.
+//!
+//! The shared `rust-dataflow-example-status-node` only crashes on
+//! `restart_count() == 0` so it can show off *successful* recovery.
+//! That makes it unsuitable for exhaustion testing: `max_restarts` is
+//! never reached, and the existing e2e test has to settle for a
+//! permissive "both Ok and Err are valid" assertion. This node crashes
+//! every time so the restart budget is guaranteed to be consumed.
+
+use dora_node_api::{DoraNode, Event};
+use eyre::Context;
+
+fn main() -> eyre::Result<()> {
+    let (_node, mut events) =
+        DoraNode::init_from_env().context("failed to init dora node from env")?;
+
+    while let Some(event) = events.recv() {
+        if let Event::Input { id, .. } = event
+            && id.as_str() == "tick"
+        {
+            panic!("always-crash-node: simulated failure on tick (every incarnation)");
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

First slice of **#1631** (sub-issue of the #1628 QA epic): tightens the `max_restarts` coverage from the permissive "either Ok or Err is fine" pattern the issue flags to a specific, deterministic exhaustion assertion.

### Why the existing test is weak

`max_restarts_limit_reached` in `tests/fault-tolerance-e2e.rs` reuses the shared `rust-dataflow-example-status-node`, which panics only when `node.restart_count() == 0` — deliberately, so the example can *demonstrate* successful recovery. That means:

1. The 1st incarnation crashes.
2. The daemon restarts it (restart_count → 1).
3. The 2nd incarnation ignores every subsequent `fail` tick.
4. `max_restarts: 2` is **never** reached.

The test's current docstring admits this indirectly via the comment `"both Ok and Err are valid"` — that's exactly the anti-pattern #1631 calls out.

### What this PR does

Adds a dedicated exhaustion test without touching the existing one:

- **New test-only crate** `tests/fault_tolerance/always_crash_node/` — panics on the first tick of *every* incarnation. `publish = false`; never reaches users or crates.io. Registered as a workspace member.
- **New fixture** `tests/dataflows/max-restarts-truly-exhausted.yml` — `max_restarts: 2`, `restart_delay: 0.1`, 50 ms tick. Budget is consumed in ~300 ms.
- **New test** `max_restarts_exhaustion_marks_node_failed` — asserts the specific contract: after exhaustion, the daemon records an `Err` for the affected node in `DataflowResult::node_results`. No more "either outcome is fine".

The existing `max_restarts_limit_reached` test is left intact — fixing its fixture would require changes to the shared status-node example code, which is out of scope for this first slice.

## Verification

```
$ cargo test --test fault-tolerance-e2e -- --test-threads=1
test restart_recovers_from_failure ... ok
test max_restarts_limit_reached ... ok
test max_restarts_exhaustion_marks_node_failed ... ok
test input_timeout_closes_stale_input ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 53.49s
```

`make qa-fast` green (fmt, clippy, audit, unwrap 157/185).

## What's still to do under #1631 (follow-ups, not in this PR)

- `restart_policy: always` semantics (no test today)
- `restart_window` reset behavior
- `health_check_timeout` kill/restart path
- `NodeRestarted` / `InputClosed` / `InputRecovered` delivery to downstream nodes
- Stronger assertion on `input_timeout_closes_stale_input` (currently only checks `result.is_ok()`)

Each warrants its own fixture + test slice.

## Test plan

- [x] `cargo test --test fault-tolerance-e2e -- --test-threads=1` passes locally (4/4)
- [x] `make qa-fast` green
- [x] `always-crash-node` builds via `cargo build -p always-crash-node`
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
