### PR TITLE
test: cover restart_policy: always (#1631)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,6 +915,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clean-exit-node"
+version = "0.2.1"
+dependencies = [
+ "dora-node-api",
+ "eyre",
+]
+
+[[package]]
 name = "clonable-command"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ members = [
     "libraries/extensions/ros2-bridge/arrow",
     "tests/queue_size_latest_data_rust/receive_data",
     "tests/fault_tolerance/always_crash_node",
+    "tests/fault_tolerance/clean_exit_node",
 ]
 
 [workspace.package]

--- a/tests/dataflows/restart-policy-always.yml
+++ b/tests/dataflows/restart-policy-always.yml
@@ -1,0 +1,11 @@
+nodes:
+  - id: clean-exit
+    build: cargo build -p clean-exit-node
+    path: ../../target/debug/clean-exit-node
+    restart_policy: always
+    max_restarts: 2
+    restart_delay: 0.1
+    env:
+      DORA_TEST_MARKER_FILE: /tmp/dora-restart-policy-always.log
+    inputs:
+      tick: dora/timer/millis/50

--- a/tests/fault-tolerance-e2e.rs
+++ b/tests/fault-tolerance-e2e.rs
@@ -197,6 +197,77 @@ async fn max_restarts_exhaustion_marks_node_failed() {
     );
 }
 
+/// `restart_policy: always` restarts the node even on a clean exit
+/// (#1631).
+///
+/// `on-failure` and `never` both leave a cleanly-exiting node alone.
+/// Only `always` re-spawns after `Ok`. This test proves the difference
+/// observable, not just inferred.
+///
+/// Fixture: `clean-exit-node` appends one `incarnation\n` line to
+/// `$DORA_TEST_MARKER_FILE` on every spawn, then exits `Ok(())` after
+/// the first tick. With `restart_policy: always` + `max_restarts: 2`,
+/// the daemon must spawn the node three times (initial + 2 restarts)
+/// — so the marker file grows to exactly three lines. With
+/// `restart_policy: never`, it would contain one.
+#[tokio::test(flavor = "multi_thread")]
+async fn restart_policy_always_restarts_on_clean_exit() {
+    let status = std::process::Command::new("cargo")
+        .args(["build", "-p", "clean-exit-node"])
+        .status()
+        .expect("failed to build clean-exit-node");
+    assert!(status.success(), "clean-exit-node build failed");
+
+    // Fixture writes to this hardcoded path; tests already run with
+    // --test-threads=1, so there is no cross-test contention. Clean
+    // before and after so a prior crash doesn't pollute.
+    let marker = Path::new("/tmp/dora-restart-policy-always.log");
+    let _ = std::fs::remove_file(marker);
+
+    let dataflow_path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/dataflows/restart-policy-always.yml");
+
+    let result = Daemon::run_dataflow(
+        &dataflow_path,
+        None,
+        None,
+        SessionId::generate(),
+        false,
+        LogDestination::Tracing,
+        None,
+        Some(Duration::from_secs(10)),
+        false,
+    )
+    .await;
+
+    let dr = result.expect("dataflow should complete");
+    eprintln!(
+        "dataflow completed with {} node results",
+        dr.node_results.len()
+    );
+    for (id, r) in &dr.node_results {
+        eprintln!("  {id}: {r:?}");
+    }
+
+    let contents = std::fs::read_to_string(marker)
+        .expect("marker file should exist — the node writes it on every spawn");
+    let incarnations = contents.lines().count();
+    let _ = std::fs::remove_file(marker);
+    eprintln!("clean-exit-node incarnations observed: {incarnations}");
+
+    // Core contract: `restart_policy: always` + `max_restarts: 2`
+    // produces ≥2 incarnations. Exactly 3 is the happy path
+    // (initial + 2 restarts within the stop_after window); we accept
+    // ≥2 to tolerate stop_after racing the final restart on a slow
+    // runner. `never`/`on-failure` would give exactly 1, which the
+    // assertion rejects.
+    assert!(
+        incarnations >= 2,
+        "restart_policy: always + max_restarts: 2 should produce at least 2 \
+         incarnations after clean exits; got {incarnations}. marker contents:\n{contents}"
+    );
+}
+
 /// Input timeout fires when upstream stops producing.
 ///
 /// The status-node exits after receiving trigger-exit. The sink has input_timeout: 2.0

--- a/tests/fault-tolerance-e2e.rs
+++ b/tests/fault-tolerance-e2e.rs
@@ -256,15 +256,17 @@ async fn restart_policy_always_restarts_on_clean_exit() {
     eprintln!("clean-exit-node incarnations observed: {incarnations}");
 
     // Core contract: `restart_policy: always` + `max_restarts: 2`
-    // produces ≥2 incarnations. Exactly 3 is the happy path
-    // (initial + 2 restarts within the stop_after window); we accept
-    // ≥2 to tolerate stop_after racing the final restart on a slow
-    // runner. `never`/`on-failure` would give exactly 1, which the
-    // assertion rejects.
-    assert!(
-        incarnations >= 2,
-        "restart_policy: always + max_restarts: 2 should produce at least 2 \
-         incarnations after clean exits; got {incarnations}. marker contents:\n{contents}"
+    // produces exactly 3 incarnations (initial spawn + 2 restarts).
+    // With the fixture's 50 ms tick + 100 ms restart_delay the full
+    // cycle completes in roughly 500 ms, leaving ample headroom under
+    // the 10 s stop_after — there's no legitimate race that would cut
+    // the count short, so a weaker `>= 2` assertion would let an
+    // off-by-one regression slip through (addressing review feedback
+    // on PR #1645).
+    assert_eq!(
+        incarnations, 3,
+        "restart_policy: always + max_restarts: 2 should produce exactly 3 \
+         incarnations (initial + 2 restarts); got {incarnations}. marker contents:\n{contents}"
     );
 }
 

--- a/tests/fault_tolerance/clean_exit_node/Cargo.toml
+++ b/tests/fault_tolerance/clean_exit_node/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "clean-exit-node"
+edition.workspace = true
+rust-version.workspace = true
+version.workspace = true
+description.workspace = true
+documentation.workspace = true
+license.workspace = true
+publish = false
+
+# Test-only node: exits cleanly (Ok) on the first tick of every
+# incarnation and appends an incarnation marker to
+# `$DORA_TEST_MARKER_FILE`. Paired with `restart-policy-always.yml`
+# and `fault-tolerance-e2e.rs::restart_policy_always_restarts_on_clean_exit`.
+#
+# `restart_policy: on-failure` would never restart a node that exited
+# Ok, so counting markers distinguishes `always` from `on-failure` /
+# `never`.
+
+[[bin]]
+name = "clean-exit-node"
+path = "src/main.rs"
+
+[dependencies]
+dora-node-api = { workspace = true, default-features = false }
+eyre = { workspace = true }

--- a/tests/fault_tolerance/clean_exit_node/src/main.rs
+++ b/tests/fault_tolerance/clean_exit_node/src/main.rs
@@ -1,0 +1,33 @@
+//! Test-only node that exits cleanly after its first tick, once per
+//! incarnation.
+//!
+//! Writes a single `incarnation\n` line to the file at `$DORA_TEST_MARKER_FILE`
+//! *before* exiting, so the test harness can count how many times the node
+//! was spawned. With `restart_policy: always` + `max_restarts: N`, the file
+//! should grow to `N + 1` lines (initial spawn + N restarts). With
+//! `restart_policy: never` or `on-failure`, it would contain exactly one.
+
+use std::io::Write;
+
+use dora_node_api::DoraNode;
+use eyre::Context;
+
+fn main() -> eyre::Result<()> {
+    let (_node, mut events) =
+        DoraNode::init_from_env().context("failed to init dora node from env")?;
+
+    let marker_path = std::env::var("DORA_TEST_MARKER_FILE")
+        .context("DORA_TEST_MARKER_FILE env var must be set by the fixture")?;
+    let mut marker = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&marker_path)
+        .with_context(|| format!("failed to open marker file {marker_path:?}"))?;
+    marker
+        .write_all(b"incarnation\n")
+        .context("failed to append incarnation marker")?;
+
+    // Wait for one event (tick), then exit cleanly.
+    let _ = events.recv();
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Second slice of **#1631**. Before this PR there was no automated coverage for `restart_policy: always` — the only restart-policy variant whose core contract (re-spawn on *clean* exit) differs from `on-failure` and `never`.

## Approach

- **New test-only crate** `tests/fault_tolerance/clean_exit_node/`. Appends one `incarnation\n` line to `$DORA_TEST_MARKER_FILE` before returning `Ok(())` after the first tick. Because it always exits cleanly, `restart_policy: never` and `on-failure` would both leave it alone — only `always` re-spawns.
- **New fixture** `tests/dataflows/restart-policy-always.yml`: `restart_policy: always`, `max_restarts: 2`, `restart_delay: 0.1`, 50 ms tick, writes to `/tmp/dora-restart-policy-always.log`.
- **New test** `restart_policy_always_restarts_on_clean_exit` counts lines in the marker file. With `always` + `max_restarts: 2` the daemon spawns the node 3 times (initial + 2 restarts); the assertion is `>=2` to tolerate stop_after racing the last restart on a slow runner. `never`/`on-failure` would produce exactly 1, which the assertion rejects.

## Verification

```
$ cargo test --test fault-tolerance-e2e -- --test-threads=1
test restart_recovers_from_failure ... ok
test max_restarts_limit_reached ... ok
test max_restarts_exhaustion_marks_node_failed ... ok
test restart_policy_always_restarts_on_clean_exit ... ok
test input_timeout_closes_stale_input ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 56.52s
```

`make qa-fast` green (fmt, clippy, audit, unwrap 157/185).

## Remaining under #1631

Each warrants its own slice:

- `restart_window` reset behavior
- `health_check_timeout` kill/restart path
- `NodeRestarted` / `InputClosed` / `InputRecovered` downstream delivery
- Tighter assertion on `input_timeout_closes_stale_input` (currently only checks `result.is_ok()`)

## Test plan

- [x] `cargo test --test fault-tolerance-e2e -- --test-threads=1` ⇒ 5/5 passing locally
- [x] `make qa-fast` green
- [x] `cargo build -p clean-exit-node` builds clean (no warnings)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
