### PR TITLE
test: cover restart_window counter reset (#1631)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1455,6 +1455,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "delayed-crash-node"
+version = "0.2.1"
+dependencies = [
+ "dora-node-api",
+ "eyre",
+]
+
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ members = [
     "tests/queue_size_latest_data_rust/receive_data",
     "tests/fault_tolerance/always_crash_node",
     "tests/fault_tolerance/clean_exit_node",
+    "tests/fault_tolerance/delayed_crash_node",
 ]
 
 [workspace.package]

--- a/tests/dataflows/restart-window-reset.yml
+++ b/tests/dataflows/restart-window-reset.yml
@@ -1,0 +1,18 @@
+nodes:
+  - id: delayed-crash
+    build: cargo build -p delayed-crash-node
+    path: ../../target/debug/delayed-crash-node
+    # max_restarts: 1 + restart_window: 0.3 means "at most 1 restart per
+    # 300 ms". Because DORA_TEST_CRASH_AFTER_MS=500 makes each incarnation
+    # live longer than the window, the counter resets on every crash — so
+    # the node can restart indefinitely. Without restart_window, the
+    # second crash would exhaust the budget and the daemon would give up.
+    restart_policy: on-failure
+    max_restarts: 1
+    restart_window: 0.3
+    restart_delay: 0.1
+    env:
+      DORA_TEST_MARKER_FILE: /tmp/dora-restart-window-reset.log
+      DORA_TEST_CRASH_AFTER_MS: "500"
+    inputs:
+      tick: dora/timer/millis/100

--- a/tests/fault-tolerance-e2e.rs
+++ b/tests/fault-tolerance-e2e.rs
@@ -270,6 +270,82 @@ async fn restart_policy_always_restarts_on_clean_exit() {
     );
 }
 
+/// `restart_window` resets the restart counter after the window
+/// elapses (#1631).
+///
+/// The daemon's restart accounting (binaries/daemon/src/spawn/prepared.rs:
+/// around the `restart` check) resets `window_count` when
+/// `window_start.elapsed() > window`. That means a node whose restarts
+/// are spaced further apart than `restart_window` can recover budget
+/// indefinitely, even with a tiny `max_restarts`.
+///
+/// Fixture: `delayed-crash-node` appends an incarnation marker, sleeps
+/// 500 ms, then panics. With `restart_window: 0.3`, every crash arrives
+/// after the previous window has already expired — the counter resets,
+/// and the node is re-spawned. Without the window reset (or with
+/// `restart_window` misconfigured), `max_restarts: 1` would exhaust
+/// after the second crash and the node would stop at 2 incarnations.
+///
+/// Expected over a 10 s stop_after window (cycle ≈ 600 ms): ~16–17
+/// incarnations. We assert `>= 3` — the minimum that could *only* be
+/// produced by a window reset (without reset, `max_restarts: 1` caps
+/// incarnations at 2). A regression that disables the reset lands at
+/// exactly 2, which the assertion rejects.
+#[tokio::test(flavor = "multi_thread")]
+async fn restart_window_resets_restart_counter() {
+    let status = std::process::Command::new("cargo")
+        .args(["build", "-p", "delayed-crash-node"])
+        .status()
+        .expect("failed to build delayed-crash-node");
+    assert!(status.success(), "delayed-crash-node build failed");
+
+    // Fixture writes to this hardcoded path; tests run with
+    // --test-threads=1 so there's no cross-test contention. Pre-clean
+    // in case a prior crash left stale markers around.
+    let marker = Path::new("/tmp/dora-restart-window-reset.log");
+    let _ = std::fs::remove_file(marker);
+
+    let dataflow_path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/dataflows/restart-window-reset.yml");
+
+    let result = Daemon::run_dataflow(
+        &dataflow_path,
+        None,
+        None,
+        SessionId::generate(),
+        false,
+        LogDestination::Tracing,
+        None,
+        Some(Duration::from_secs(10)),
+        false,
+    )
+    .await;
+
+    let dr = result.expect("dataflow should complete");
+    eprintln!(
+        "dataflow completed with {} node results",
+        dr.node_results.len()
+    );
+    for (id, r) in &dr.node_results {
+        eprintln!("  {id}: {r:?}");
+    }
+
+    let contents = std::fs::read_to_string(marker)
+        .expect("marker file should exist — the node writes it on every spawn");
+    let incarnations = contents.lines().count();
+    let _ = std::fs::remove_file(marker);
+    eprintln!("delayed-crash-node incarnations observed: {incarnations}");
+
+    // `max_restarts: 1` with no window reset → exactly 2 incarnations.
+    // Anything strictly greater proves the counter reset path fired.
+    assert!(
+        incarnations >= 3,
+        "restart_window: 0.3 with max_restarts: 1 should let the node restart \
+         many times via window reset; got {incarnations} incarnations. Without \
+         reset this would cap at 2. marker contents:\n{contents}"
+    );
+}
+
 /// Input timeout fires when upstream stops producing.
 ///
 /// The status-node exits after receiving trigger-exit. The sink has input_timeout: 2.0

--- a/tests/fault_tolerance/delayed_crash_node/Cargo.toml
+++ b/tests/fault_tolerance/delayed_crash_node/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "delayed-crash-node"
+edition.workspace = true
+rust-version.workspace = true
+version.workspace = true
+description.workspace = true
+documentation.workspace = true
+license.workspace = true
+publish = false
+
+# Test-only node: sleeps `$DORA_TEST_CRASH_AFTER_MS` ms then panics.
+# Appends an incarnation marker to `$DORA_TEST_MARKER_FILE` first so the
+# harness can count how many times the daemon re-spawned it. Paired with
+# `restart-window-reset.yml` to prove the `restart_window` counter reset
+# (strengthens #1631).
+
+[[bin]]
+name = "delayed-crash-node"
+path = "src/main.rs"
+
+[dependencies]
+dora-node-api = { workspace = true, default-features = false }
+eyre = { workspace = true }

--- a/tests/fault_tolerance/delayed_crash_node/src/main.rs
+++ b/tests/fault_tolerance/delayed_crash_node/src/main.rs
@@ -1,0 +1,40 @@
+//! Test-only node: appends an incarnation marker, sleeps
+//! `$DORA_TEST_CRASH_AFTER_MS` ms, then panics.
+//!
+//! Paired with `tests/dataflows/restart-window-reset.yml` and
+//! `fault-tolerance-e2e.rs::restart_window_resets_restart_counter` (#1631).
+//!
+//! Each incarnation lives long enough to exceed the fixture's
+//! `restart_window`, so the daemon's window reset path fires on every
+//! crash — the node would otherwise exhaust `max_restarts` in a handful
+//! of incarnations.
+
+use std::io::Write;
+use std::time::Duration;
+
+use dora_node_api::DoraNode;
+use eyre::Context;
+
+fn main() -> eyre::Result<()> {
+    let (_node, _events) =
+        DoraNode::init_from_env().context("failed to init dora node from env")?;
+
+    let marker_path = std::env::var("DORA_TEST_MARKER_FILE")
+        .context("DORA_TEST_MARKER_FILE env var must be set by the fixture")?;
+    let mut marker = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&marker_path)
+        .with_context(|| format!("failed to open marker file {marker_path:?}"))?;
+    marker
+        .write_all(b"incarnation\n")
+        .context("failed to append incarnation marker")?;
+    drop(marker);
+
+    let delay_ms: u64 = std::env::var("DORA_TEST_CRASH_AFTER_MS")
+        .context("DORA_TEST_CRASH_AFTER_MS env var must be set by the fixture")?
+        .parse()
+        .context("DORA_TEST_CRASH_AFTER_MS must be a u64")?;
+    std::thread::sleep(Duration::from_millis(delay_ms));
+    panic!("delayed-crash-node: simulated failure after {delay_ms} ms uptime");
+}


### PR DESCRIPTION
## Summary

Third slice of **#1631**. Before this PR `restart_window` had no automated coverage. A regression that disabled the counter-reset path would let `max_restarts: 1` permanently cap the node at 2 incarnations — silently stopping a design the docs explicitly advertise ("N restarts per time window").

## The contract under test

From `binaries/daemon/src/spawn/prepared.rs`:

```rust
if let Some(window) = config.restart_window
    && window_start.elapsed() > window
{
    window_count = 0;
    window_start = tokio::time::Instant::now();
}
window_count += 1;

if config.max_restarts > 0 && window_count > config.max_restarts {
    // give up
}
```

So a node whose crashes are spaced further apart than `restart_window` recovers full budget on every crash and can restart indefinitely.

## Approach

- **New test-only crate** `tests/fault_tolerance/delayed_crash_node/` — appends an incarnation marker, sleeps `$DORA_TEST_CRASH_AFTER_MS` ms, then panics.
- **New fixture** `tests/dataflows/restart-window-reset.yml` — `restart_policy: on-failure`, `max_restarts: 1`, `restart_window: 0.3`, `restart_delay: 0.1`, `DORA_TEST_CRASH_AFTER_MS: 500`. Each incarnation lives ~500 ms, comfortably past the 300 ms window, so the counter resets on every crash.
- **New test** `restart_window_resets_restart_counter` — counts lines in the marker file. Assertion: `incarnations >= 3`. Without the reset, `max_restarts: 1` caps incarnations at exactly 2 — so `>= 3` is the minimum value that's only reachable through at least one window reset. Locally observed **15** incarnations over the 10 s stop_after window, far above the threshold.

The `>= 3` bound stays loose on purpose: the exact count (~16–17 expected) depends on process spawn overhead and OS scheduler variance, and a slow CI runner could reasonably land anywhere in that range. Tightening to an exact count would risk flakiness; the point of the test is to catch a regression that disables the reset, which lands exactly at 2.

## Verification

```
$ cargo test --test fault-tolerance-e2e -- --test-threads=1
test restart_recovers_from_failure ... ok
test max_restarts_limit_reached ... ok
test max_restarts_exhaustion_marks_node_failed ... ok
test restart_policy_always_restarts_on_clean_exit ... ok
test restart_window_resets_restart_counter ... ok
test input_timeout_closes_stale_input ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 67.53s
```

`make qa-fast` green (fmt, clippy, audit, unwrap 157/185).

## Remaining under #1631

- `health_check_timeout` kill/restart path
- `NodeRestarted` / `InputClosed` / `InputRecovered` downstream delivery
- Tighter assertion on `input_timeout_closes_stale_input`

Each warrants its own slice.

## Test plan

- [x] `cargo test --test fault-tolerance-e2e -- --test-threads=1` ⇒ 6/6 passing locally
- [x] `make qa-fast` green
- [x] `cargo build -p delayed-crash-node` builds clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
