### PR TITLE
test: cover input_timeout InputClosed delivery (#1631)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3352,6 +3352,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "input-closed-observer-node"
+version = "0.2.1"
+dependencies = [
+ "dora-node-api",
+ "eyre",
+]
+
+[[package]]
 name = "inquire"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6384,6 +6392,14 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "silent-source-node"
+version = "0.2.1"
+dependencies = [
+ "dora-node-api",
+ "eyre",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,8 @@ members = [
     "tests/fault_tolerance/always_crash_node",
     "tests/fault_tolerance/clean_exit_node",
     "tests/fault_tolerance/delayed_crash_node",
+    "tests/fault_tolerance/input_closed_observer_node",
+    "tests/fault_tolerance/silent_source_node",
 ]
 
 [workspace.package]

--- a/tests/dataflows/input-timeout-delivery.yml
+++ b/tests/dataflows/input-timeout-delivery.yml
@@ -1,0 +1,25 @@
+# `input_timeout` checks run on `NodeHealthCheckInterval` ticks, which
+# default to 5 s (binaries/daemon/src/lib.rs:857). A 0.5 s input_timeout
+# paired with the 5 s default would only fire on the first post-startup
+# health-check tick, racing `stop_after`. Override to 0.1 s so the
+# timeout path fires promptly and the test runtime stays short.
+health_check_interval: 0.1
+
+nodes:
+  - id: silent-source
+    build: cargo build -p silent-source-node
+    path: ../../target/debug/silent-source-node
+    inputs:
+      tick: dora/timer/millis/50
+    outputs:
+      - value
+
+  - id: observer
+    build: cargo build -p input-closed-observer-node
+    path: ../../target/debug/input-closed-observer-node
+    env:
+      DORA_TEST_MARKER_FILE: /tmp/dora-input-timeout-delivery.log
+    inputs:
+      value:
+        source: silent-source/value
+        input_timeout: 0.5

--- a/tests/fault-tolerance-e2e.rs
+++ b/tests/fault-tolerance-e2e.rs
@@ -346,6 +346,91 @@ async fn restart_window_resets_restart_counter() {
     );
 }
 
+/// `input_timeout` actually delivers `InputClosed` to downstream (#1631).
+///
+/// The pre-existing `input_timeout_closes_stale_input` test below uses a
+/// fixture whose sink exits on the first `exit` input, ~500 ms after
+/// startup. That's well before the 2 s `input_timeout` could possibly
+/// fire — so `input_timeout` in that test is dead config and the
+/// `result.is_ok()` assertion only proves the dataflow completes at all.
+///
+/// This test closes the gap by driving the timeout path directly:
+///
+/// - `silent-source-node` emits exactly one output on the first tick
+///   then stays alive but silent (so channel-close doesn't fire — the
+///   only way the downstream can learn the input went stale is via
+///   `input_timeout`).
+/// - `input-closed-observer-node` appends one line per event
+///   (`Input:<id>` or `InputClosed:<id>`) to
+///   `$DORA_TEST_MARKER_FILE`, exiting on the first `InputClosed`.
+/// - Fixture `input-timeout-delivery.yml` sets `input_timeout: 0.5`.
+///
+/// Assertion: the marker records both `Input:value` (so we know the
+/// initial message arrived) **and** `InputClosed:value` (so we know
+/// the daemon delivered the timeout-triggered close). A regression that
+/// silently dropped the timeout path would leave the marker with a
+/// single `Input:value` line and the observer would hang until
+/// `stop_after`, which the assertion rejects.
+#[tokio::test(flavor = "multi_thread")]
+async fn input_timeout_delivers_input_closed_to_downstream() {
+    let status = std::process::Command::new("cargo")
+        .args([
+            "build",
+            "-p",
+            "silent-source-node",
+            "-p",
+            "input-closed-observer-node",
+        ])
+        .status()
+        .expect("failed to build input-timeout test nodes");
+    assert!(status.success(), "input-timeout test nodes build failed");
+
+    let marker = Path::new("/tmp/dora-input-timeout-delivery.log");
+    let _ = std::fs::remove_file(marker);
+
+    let dataflow_path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/dataflows/input-timeout-delivery.yml");
+
+    let result = Daemon::run_dataflow(
+        &dataflow_path,
+        None,
+        None,
+        SessionId::generate(),
+        false,
+        LogDestination::Tracing,
+        None,
+        // 5 s is plenty — the observer should see Input at ~50 ms and
+        // InputClosed at ~550 ms (input_timeout = 0.5 s), then exit.
+        Some(Duration::from_secs(5)),
+        false,
+    )
+    .await;
+
+    let dr = result.expect("dataflow should complete");
+    eprintln!(
+        "dataflow completed with {} node results",
+        dr.node_results.len()
+    );
+    for (id, r) in &dr.node_results {
+        eprintln!("  {id}: {r:?}");
+    }
+
+    let contents = std::fs::read_to_string(marker)
+        .expect("observer marker file should exist — the observer writes on every event");
+    let _ = std::fs::remove_file(marker);
+    eprintln!("observer events:\n{contents}");
+
+    assert!(
+        contents.contains("Input:value"),
+        "observer never saw the initial `value` input — silent-source is not emitting. contents:\n{contents}"
+    );
+    assert!(
+        contents.contains("InputClosed:value"),
+        "observer never saw `InputClosed:value` — `input_timeout: 0.5` did not fire even though \
+         silent-source stayed alive without producing. contents:\n{contents}"
+    );
+}
+
 /// Input timeout fires when upstream stops producing.
 ///
 /// The status-node exits after receiving trigger-exit. The sink has input_timeout: 2.0

--- a/tests/fault_tolerance/input_closed_observer_node/Cargo.toml
+++ b/tests/fault_tolerance/input_closed_observer_node/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "input-closed-observer-node"
+edition.workspace = true
+rust-version.workspace = true
+version.workspace = true
+description.workspace = true
+documentation.workspace = true
+license.workspace = true
+publish = false
+
+# Test-only node: records every `Input`/`InputClosed` event it sees to
+# `$DORA_TEST_MARKER_FILE`, one line each. Paired with
+# `silent-source-node` and the `input_timeout_delivers_input_closed`
+# test to prove the daemon fires `InputClosed` on timeout expiry.
+
+[[bin]]
+name = "input-closed-observer-node"
+path = "src/main.rs"
+
+[dependencies]
+dora-node-api = { workspace = true, default-features = false }
+eyre = { workspace = true }

--- a/tests/fault_tolerance/input_closed_observer_node/src/main.rs
+++ b/tests/fault_tolerance/input_closed_observer_node/src/main.rs
@@ -1,0 +1,41 @@
+//! Record every `Input` / `InputClosed` the daemon delivers.
+//!
+//! Appends one line per event to `$DORA_TEST_MARKER_FILE` so the test
+//! harness can assert the specific sequence without parsing logs. Exits
+//! cleanly as soon as it sees `InputClosed` on the watched input, which
+//! keeps the test short when `input_timeout` fires as expected.
+
+use std::io::Write;
+
+use dora_node_api::{DoraNode, Event};
+use eyre::Context;
+
+fn main() -> eyre::Result<()> {
+    let (_node, mut events) =
+        DoraNode::init_from_env().context("failed to init dora node from env")?;
+
+    let marker_path = std::env::var("DORA_TEST_MARKER_FILE")
+        .context("DORA_TEST_MARKER_FILE env var must be set by the fixture")?;
+    let mut marker = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&marker_path)
+        .with_context(|| format!("failed to open marker file {marker_path:?}"))?;
+
+    while let Some(event) = events.recv() {
+        match event {
+            Event::Input { id, .. } => {
+                writeln!(marker, "Input:{id}").context("failed to log Input event")?;
+            }
+            Event::InputClosed { id } => {
+                writeln!(marker, "InputClosed:{id}").context("failed to log InputClosed event")?;
+                // First InputClosed is the signal we're waiting for —
+                // exiting keeps the test short.
+                break;
+            }
+            Event::Stop(_) => break,
+            _ => {}
+        }
+    }
+    Ok(())
+}

--- a/tests/fault_tolerance/silent_source_node/Cargo.toml
+++ b/tests/fault_tolerance/silent_source_node/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "silent-source-node"
+edition.workspace = true
+rust-version.workspace = true
+version.workspace = true
+description.workspace = true
+documentation.workspace = true
+license.workspace = true
+publish = false
+
+# Test-only node: emits a single `value` output on the first tick, then
+# stays alive indefinitely without producing anything more. Paired with
+# `input-timeout.yml` + `input_closed_observer_node` to prove the
+# daemon delivers `InputClosed` on `input_timeout` expiry even when the
+# upstream node is still running (#1631).
+
+[[bin]]
+name = "silent-source-node"
+path = "src/main.rs"
+
+[dependencies]
+dora-node-api = { workspace = true, default-features = false }
+eyre = { workspace = true }

--- a/tests/fault_tolerance/silent_source_node/src/main.rs
+++ b/tests/fault_tolerance/silent_source_node/src/main.rs
@@ -1,0 +1,35 @@
+//! Emit one `value` on the first tick, then stay alive and silent.
+//!
+//! The silence-after-first-message pattern is what drives the
+//! `input_timeout` path in the daemon: the upstream process is still
+//! running (so channel-close doesn't fire) but no new data is flowing,
+//! so the consumer must rely on `input_timeout` to be told the input
+//! has gone stale.
+
+use dora_node_api::{DoraNode, Event, IntoArrow, dora_core::config::DataId};
+use eyre::Context;
+
+fn main() -> eyre::Result<()> {
+    let (mut node, mut events) =
+        DoraNode::init_from_env().context("failed to init dora node from env")?;
+    let output = DataId::from("value".to_owned());
+
+    let mut sent = false;
+    while let Some(event) = events.recv() {
+        match event {
+            Event::Input { id, metadata, .. } if id.as_str() == "tick" => {
+                if !sent {
+                    node.send_output(output.clone(), metadata.parameters, 42i64.into_arrow())
+                        .context("failed to send value")?;
+                    sent = true;
+                }
+                // Subsequent ticks are intentionally ignored so the
+                // downstream must rely on `input_timeout` to notice
+                // that data has gone stale.
+            }
+            Event::Stop(_) => break,
+            _ => {}
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Fourth slice of **#1631**. The pre-existing `input_timeout_closes_stale_input` test doesn't actually exercise the `input_timeout` path — the sink exits on the first `exit` signal at ~500 ms, well before the 2 s timeout could fire. The `input_timeout` config in that fixture is effectively dead.

This PR closes the gap with a fixture that drives the timeout path end-to-end.

## Approach

- **New test-only crate** `tests/fault_tolerance/silent_source_node/` — emits one `value` output on the first tick, then stays alive and silent. Because the node stays running, channel-close doesn't fire and the downstream can only learn the input has gone stale via `input_timeout`.
- **New test-only crate** `tests/fault_tolerance/input_closed_observer_node/` — appends one line per event (`Input:<id>` or `InputClosed:<id>`) to `$DORA_TEST_MARKER_FILE`, exiting on the first `InputClosed`.
- **New fixture** `tests/dataflows/input-timeout-delivery.yml` — sets `input_timeout: 0.5` on the observer and overrides the dataflow-level `health_check_interval` to 0.1 s. The daemon's `check_input_timeouts` only runs on `NodeHealthCheckInterval` ticks (`binaries/daemon/src/lib.rs:971`); the default 5 s would race `stop_after`.
- **New test** `input_timeout_delivers_input_closed_to_downstream` — reads the marker file and asserts both `Input:value` (initial delivery worked) and `InputClosed:value` (timeout fired). A regression that dropped the timeout path would leave only `Input:value`, which the assertion rejects.

## Verification

Observer marker after a local run:

```
Input:value
InputClosed:value
```

Full suite:

```
$ cargo test --test fault-tolerance-e2e -- --test-threads=1
test restart_recovers_from_failure ... ok
test max_restarts_limit_reached ... ok
test max_restarts_exhaustion_marks_node_failed ... ok
test restart_policy_always_restarts_on_clean_exit ... ok
test restart_window_resets_restart_counter ... ok
test input_timeout_delivers_input_closed_to_downstream ... ok
test input_timeout_closes_stale_input ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 74.28s
```

`make qa-fast` green.

## Scope notes

The pre-existing `input_timeout_closes_stale_input` test is untouched. Its fixture is effectively a smoke test (proves the dataflow completes with `input_timeout` configured) and could be renamed or rewritten, but this PR is scoped to closing the real coverage gap.

## Remaining under #1631

- `health_check_timeout` kill/restart path (next up per user direction)
- `NodeRestarted` / other downstream event delivery

## Test plan

- [x] `cargo test --test fault-tolerance-e2e -- --test-threads=1` ⇒ 7/7 locally
- [x] `make qa-fast` green
- [x] Both test crates build clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
