### PR TITLE
test: cover health_check_timeout SIGKILL path (#1631)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2911,6 +2911,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "hang-after-init-node"
+version = "0.2.1"
+dependencies = [
+ "dora-node-api",
+ "eyre",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ members = [
     "tests/fault_tolerance/always_crash_node",
     "tests/fault_tolerance/clean_exit_node",
     "tests/fault_tolerance/delayed_crash_node",
+    "tests/fault_tolerance/hang_after_init_node",
     "tests/fault_tolerance/input_closed_observer_node",
     "tests/fault_tolerance/silent_source_node",
 ]

--- a/tests/dataflows/health-check-timeout.yml
+++ b/tests/dataflows/health-check-timeout.yml
@@ -1,0 +1,20 @@
+# `check_node_health` runs on `NodeHealthCheckInterval` ticks (default
+# 5 s, binaries/daemon/src/lib.rs). Override to 0.1 s so the kill path
+# fires quickly with the test's 0.5 s timeout.
+health_check_interval: 0.1
+
+nodes:
+  - id: hang-after-init
+    build: cargo build -p hang-after-init-node
+    path: ../../target/debug/hang-after-init-node
+    # `restart_policy: never` keeps the assertion on the **kill path**
+    # itself (Signal(9) in the node_result). Exercising the full
+    # kill → restart → kill loop requires handling the node_api's
+    # interaction with graceful teardown after SIGKILL, which deserves
+    # its own follow-up slice.
+    restart_policy: never
+    health_check_timeout: 2.0
+    env:
+      DORA_TEST_MARKER_FILE: /tmp/dora-health-check-timeout.log
+    inputs:
+      tick: dora/timer/millis/200

--- a/tests/fault-tolerance-e2e.rs
+++ b/tests/fault-tolerance-e2e.rs
@@ -431,6 +431,111 @@ async fn input_timeout_delivers_input_closed_to_downstream() {
     );
 }
 
+/// `health_check_timeout` kills an unresponsive node with SIGKILL (#1631).
+///
+/// The daemon's `check_node_health`
+/// (binaries/daemon/src/lib.rs:1917) compares
+/// `now - last_activity` to the per-node `health_check_timeout`.
+/// `last_activity` advances only when the daemon receives a
+/// `DaemonRequest` from the node
+/// (binaries/daemon/src/node_communication/mod.rs:339), so a node
+/// whose background event-stream thread has exited and whose main
+/// thread is asleep is silent from the daemon's perspective. When the
+/// watchdog fires, it submits `ProcessOperation::Kill` — SIGKILL, not
+/// SIGTERM — which surfaces as `NodeExitStatus::Signal(9)` in
+/// `DataflowResult::node_results`.
+///
+/// Fixture: `hang-after-init-node` registers, pumps exactly one event
+/// so `last_activity` arms past its unarmed-zero state, writes an
+/// incarnation marker, drops `DoraNode` + `EventStream` to kill the
+/// background event-stream thread, then sleeps indefinitely. With
+/// `health_check_timeout: 0.5` and the dataflow-level
+/// `health_check_interval: 0.1`, the kill fires within ~0.6 s.
+///
+/// A regression that disabled the watchdog would surface as a
+/// `NodeExitStatus::Signal(15)` (the `stop_after` SIGTERM path) or a
+/// `GraceDuration` NodeErrorCause — both of which the assertion
+/// rejects.
+///
+/// **Scope**: this slice covers the kill-path itself. Exercising the
+/// full kill → restart → kill cycle under `restart_policy: on-failure`
+/// is deferred — the node_api interaction after a health-check SIGKILL
+/// leaves the daemon in a state where subsequent spawns don't cleanly
+/// re-trigger the path, and figuring out whether that's a test-harness
+/// limitation or a real daemon bug deserves its own investigation.
+#[tokio::test(flavor = "multi_thread")]
+async fn health_check_timeout_sigkills_unresponsive_node() {
+    let status = std::process::Command::new("cargo")
+        .args(["build", "-p", "hang-after-init-node"])
+        .status()
+        .expect("failed to build hang-after-init-node");
+    assert!(status.success(), "hang-after-init-node build failed");
+
+    let marker = Path::new("/tmp/dora-health-check-timeout.log");
+    let _ = std::fs::remove_file(marker);
+
+    let dataflow_path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/dataflows/health-check-timeout.yml");
+
+    let result = Daemon::run_dataflow(
+        &dataflow_path,
+        None,
+        None,
+        SessionId::generate(),
+        false,
+        LogDestination::Tracing,
+        None,
+        // 10 s keeps stop_after well clear of the ~2.1-2.2 s kill —
+        // see fixture for why the health_check_timeout can't just be
+        // 0.5 s (init_from_env takes ~500 ms and needs to finish before
+        // the marker write races the kill).
+        Some(Duration::from_secs(10)),
+        false,
+    )
+    .await;
+
+    let dr = result.expect("dataflow should complete");
+    eprintln!(
+        "dataflow completed with {} node results",
+        dr.node_results.len()
+    );
+    for (id, r) in &dr.node_results {
+        eprintln!("  {id}: {r:?}");
+    }
+    // Marker confirms the node did reach the post-init hang state,
+    // so any observed non-kill exit is a real kill-path regression —
+    // not "the node never ran".
+    let contents = std::fs::read_to_string(marker)
+        .expect("marker file should exist — the node writes it right after init+recv");
+    let _ = std::fs::remove_file(marker);
+    eprintln!("marker:\n{contents}");
+    assert!(
+        contents.contains("incarnation"),
+        "hang-after-init-node never reached the post-init marker write — unrelated regression"
+    );
+
+    // Core contract: the kill was a SIGKILL from the watchdog, not a
+    // SIGTERM from stop_after (Signal(15)) nor a GraceDuration
+    // timeout. `NodeExitStatus::Signal(9)` in node_results is the
+    // observable proof the health-check path fired.
+    let node_result = dr
+        .node_results
+        .get(&"hang-after-init".to_string().into())
+        .expect("hang-after-init should be in node_results");
+    let err = node_result
+        .as_ref()
+        .err()
+        .expect("hang-after-init should have errored — kill is a failure exit");
+    use dora_message::common::NodeExitStatus;
+    assert!(
+        matches!(err.exit_status, NodeExitStatus::Signal(9)),
+        "expected `NodeExitStatus::Signal(9)` from health-check SIGKILL, got {:?} \
+         (cause: {:?})",
+        err.exit_status,
+        err.cause,
+    );
+}
+
 /// Input timeout fires when upstream stops producing.
 ///
 /// The status-node exits after receiving trigger-exit. The sink has input_timeout: 2.0

--- a/tests/fault_tolerance/hang_after_init_node/Cargo.toml
+++ b/tests/fault_tolerance/hang_after_init_node/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "hang-after-init-node"
+edition.workspace = true
+rust-version.workspace = true
+version.workspace = true
+description.workspace = true
+documentation.workspace = true
+license.workspace = true
+publish = false
+
+# Test-only node: registers with the daemon, appends an incarnation
+# marker, then blocks without ever calling `events.recv()` so no further
+# traffic is sent to the daemon. Paired with `health-check-timeout.yml`
+# and the `health_check_timeout_kills_unresponsive_node` test (#1631)
+# to prove the daemon's unresponsive-node kill path fires.
+
+[[bin]]
+name = "hang-after-init-node"
+path = "src/main.rs"
+
+[dependencies]
+dora-node-api = { workspace = true, default-features = false }
+eyre = { workspace = true }

--- a/tests/fault_tolerance/hang_after_init_node/src/main.rs
+++ b/tests/fault_tolerance/hang_after_init_node/src/main.rs
@@ -1,0 +1,53 @@
+//! Register as a dora node, pull one event to advance the daemon's
+//! `last_activity` past its unarmed-zero state, write an incarnation
+//! marker, then block without draining further events.
+//!
+//! The daemon's health check skips nodes whose `last_activity == 0`
+//! ("not yet connected" — binaries/daemon/src/lib.rs:1925), so a node
+//! that registers and immediately hangs is invisible to the health
+//! check. Pumping one event first guarantees `last_activity` holds a
+//! real timestamp, after which the watchdog clock can legitimately
+//! fire when we go silent.
+//!
+//! Each incarnation writes a new marker line, so the test can count
+//! how many times the daemon had to kill-and-respawn the node.
+
+use std::io::Write;
+use std::time::Duration;
+
+use dora_node_api::DoraNode;
+use eyre::Context;
+
+fn main() -> eyre::Result<()> {
+    // Write the marker BEFORE `init_from_env` so we can tell whether
+    // the node at least got spawned, separate from whether init
+    // succeeded. init_from_env is known to take ~500 ms on a cold
+    // process spawn (zenoh session setup, subscribe, thread spawn),
+    // which can race the 0.5 s health-check window.
+    let marker_path = std::env::var("DORA_TEST_MARKER_FILE")
+        .context("DORA_TEST_MARKER_FILE env var must be set by the fixture")?;
+    let mut marker = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&marker_path)
+        .with_context(|| format!("failed to open marker file {marker_path:?}"))?;
+    marker
+        .write_all(b"incarnation\n")
+        .context("failed to append incarnation marker")?;
+    drop(marker);
+
+    let (node, events) = DoraNode::init_from_env().context("failed to init dora node from env")?;
+
+    // Kill the node_api's background event_stream thread by dropping
+    // the EventStream + DoraNode. Otherwise that thread keeps sending
+    // `NextEvent` requests (apis/rust/node/src/event_stream/thread.rs)
+    // which refresh `last_activity` on the daemon and keep the health
+    // check from firing. After drop, no daemon requests are in flight,
+    // so `last_activity` goes stale and the daemon's check_node_health
+    // watchdog can finally SIGKILL us.
+    drop(events);
+    drop(node);
+
+    std::thread::sleep(Duration::from_secs(60 * 60));
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Fifth slice of **#1631**. Before this PR there was no automated coverage for `health_check_timeout`. A regression disabling the watchdog path (`check_node_health` at `binaries/daemon/src/lib.rs:1917`) would let a genuinely-hung node drift indefinitely, caught only by the much coarser `stop_after` SIGTERM escalation.

## Approach

This is a minimal slice that proves the **kill path** fires; the full kill → restart → kill-again cycle is deferred (see scope notes below).

- **New test-only crate** `tests/fault_tolerance/hang_after_init_node/`. Writes an incarnation marker, runs `DoraNode::init_from_env` (which sends a `Subscribe` to the daemon, arming `last_activity` past its unarmed-zero value at `binaries/daemon/src/lib.rs:1925`), then drops `EventStream` + `DoraNode` to kill the node_api's background event-stream thread. That thread is what ordinarily keeps the daemon-side `last_activity` fresh via `NextEvent` requests — once it exits, the watchdog clock can legitimately fire.

- **New fixture** `tests/dataflows/health-check-timeout.yml`. Sets `restart_policy: never`, `health_check_timeout: 2.0`, and `health_check_interval: 0.1` at the dataflow level. The 2 s timeout isn't tunable much lower because `init_from_env` itself takes ~500 ms on a cold spawn, which races a 0.5 s watchdog.

- **New test** `health_check_timeout_sigkills_unresponsive_node`. Asserts the node's final `exit_status` is `NodeExitStatus::Signal(9)` — the SIGKILL submitted by `check_node_health` via `ProcessOperation::Kill`. A regression that disabled the watchdog would land on `Signal(15)` (stop_after SIGTERM) or `GraceDuration`, both rejected.

## Verification

```
$ cargo test --test fault-tolerance-e2e -- --test-threads=1
test restart_recovers_from_failure ... ok
test max_restarts_limit_reached ... ok
test max_restarts_exhaustion_marks_node_failed ... ok
test restart_policy_always_restarts_on_clean_exit ... ok
test restart_window_resets_restart_counter ... ok
test input_timeout_delivers_input_closed_to_downstream ... ok
test health_check_timeout_sigkills_unresponsive_node ... ok
test input_timeout_closes_stale_input ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 77.84s
```

Individual test finishes in ~4 s (kill at ~2.5 s; `stop_after = 10 s` is a safety margin that never triggers on the happy path). `make qa-fast` green.

## Scope notes

- This slice is intentionally narrow to the kill path. Exercising the full `restart_policy: on-failure` → kill → respawn → kill-again cycle is trickier to drive deterministically with the standard node_api — after a health-check SIGKILL the daemon's state machine doesn't cleanly re-enter the watchdog path for the new incarnation in my experiments. Whether that's a test-harness limitation or a real daemon bug deserves its own investigation. Filed as a follow-up.

- Remaining #1631 slices: `NodeRestarted` / `InputRecovered` downstream delivery.

## Test plan

- [x] `cargo test --test fault-tolerance-e2e -- --test-threads=1` ⇒ 8/8 locally
- [x] `make qa-fast` green
- [x] `cargo build -p hang-after-init-node` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
