### PR TITLE
test: cover NodeRestarted + InputRecovered downstream delivery (#1631)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2431,6 +2431,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-log-observer-node"
+version = "0.2.1"
+dependencies = [
+ "dora-node-api",
+ "eyre",
+]
+
+[[package]]
 name = "ext-trait"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6949,6 +6957,14 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "timed-burst-source-node"
+version = "0.2.1"
+dependencies = [
+ "dora-node-api",
+ "eyre",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,9 +64,11 @@ members = [
     "tests/fault_tolerance/always_crash_node",
     "tests/fault_tolerance/clean_exit_node",
     "tests/fault_tolerance/delayed_crash_node",
+    "tests/fault_tolerance/event_log_observer_node",
     "tests/fault_tolerance/hang_after_init_node",
     "tests/fault_tolerance/input_closed_observer_node",
     "tests/fault_tolerance/silent_source_node",
+    "tests/fault_tolerance/timed_burst_source_node",
 ]
 
 [workspace.package]

--- a/tests/dataflows/input-recovered-delivery.yml
+++ b/tests/dataflows/input-recovered-delivery.yml
@@ -1,0 +1,29 @@
+# input_timeout checks run on NodeHealthCheckInterval ticks — override
+# the default 5 s so the 0.5 s timeout can actually fire inside the
+# test's stop_after window.
+health_check_interval: 0.1
+
+nodes:
+  # Emits once, stays silent for 2 s, then emits again. The first
+  # emit arms the observer's input; the 2 s silence is long enough
+  # for `input_timeout: 0.5` to fire → `InputClosed:value`; the
+  # second emit re-arms the input → `InputRecovered:value`.
+  - id: burst-source
+    build: cargo build -p timed-burst-source-node
+    path: ../../target/debug/timed-burst-source-node
+    env:
+      DORA_TEST_BURST_GAP_MS: "2000"
+    inputs:
+      tick: dora/timer/millis/100
+    outputs:
+      - value
+
+  - id: observer
+    build: cargo build -p event-log-observer-node
+    path: ../../target/debug/event-log-observer-node
+    env:
+      DORA_TEST_MARKER_FILE: /tmp/dora-input-recovered-delivery.log
+    inputs:
+      value:
+        source: burst-source/value
+        input_timeout: 0.5

--- a/tests/dataflows/node-restarted-delivery.yml
+++ b/tests/dataflows/node-restarted-delivery.yml
@@ -1,0 +1,28 @@
+nodes:
+  # Crashes on first tick every incarnation. With max_restarts=1 the
+  # daemon restarts exactly once before giving up, so the observer
+  # downstream must see exactly one `NodeRestarted:crasher` event.
+  - id: crasher
+    build: cargo build -p always-crash-node
+    path: ../../target/debug/always-crash-node
+    restart_policy: on-failure
+    max_restarts: 1
+    restart_delay: 0.1
+    # Output is declared so the observer downstream can subscribe and
+    # therefore be entered into `mappings`, which is what the daemon
+    # iterates when emitting `NodeRestarted` (binaries/daemon/src/lib.rs:3628).
+    # The node itself never emits — it panics on the first tick — and
+    # that's fine for this test; we're asserting the lifecycle event,
+    # not data flow.
+    inputs:
+      tick: dora/timer/millis/50
+    outputs:
+      - pulse
+
+  - id: observer
+    build: cargo build -p event-log-observer-node
+    path: ../../target/debug/event-log-observer-node
+    env:
+      DORA_TEST_MARKER_FILE: /tmp/dora-node-restarted-delivery.log
+    inputs:
+      pulse: crasher/pulse

--- a/tests/fault-tolerance-e2e.rs
+++ b/tests/fault-tolerance-e2e.rs
@@ -536,6 +536,173 @@ async fn health_check_timeout_sigkills_unresponsive_node() {
     );
 }
 
+/// `NodeRestarted` is delivered to downstream nodes after an upstream
+/// node is restarted (#1631).
+///
+/// When the daemon successfully respawns a node, it emits
+/// `NodeRestarted { id }` to every downstream node whose `inputs`
+/// reference an output of the restarted upstream
+/// (binaries/daemon/src/lib.rs:3625). That signal is what service /
+/// action clients use to invalidate pre-crash correlation state
+/// (dora-rs/adora#148). A regression that dropped the signal would
+/// leave downstream nodes unaware of the restart — silently blocked
+/// on stale state.
+///
+/// Fixture: `always-crash-node` (from PR #1644) panics on every
+/// incarnation; `event-log-observer-node` subscribes to its
+/// `pulse` output and logs every `Event` variant. With
+/// `restart_policy: on-failure` and `max_restarts: 1`, the daemon
+/// respawns the upstream exactly once before giving up — the
+/// observer marker must therefore contain exactly one
+/// `NodeRestarted:crasher` line.
+#[tokio::test(flavor = "multi_thread")]
+async fn node_restarted_is_delivered_to_downstream() {
+    let status = std::process::Command::new("cargo")
+        .args([
+            "build",
+            "-p",
+            "always-crash-node",
+            "-p",
+            "event-log-observer-node",
+        ])
+        .status()
+        .expect("failed to build node-restarted test crates");
+    assert!(status.success(), "node-restarted test crates build failed");
+
+    let marker = Path::new("/tmp/dora-node-restarted-delivery.log");
+    let _ = std::fs::remove_file(marker);
+
+    let dataflow_path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/dataflows/node-restarted-delivery.yml");
+
+    let result = Daemon::run_dataflow(
+        &dataflow_path,
+        None,
+        None,
+        SessionId::generate(),
+        false,
+        LogDestination::Tracing,
+        None,
+        // Full cycle is ~250 ms (2 crashes × ~100 ms restart_delay),
+        // plus observer teardown. 5 s is generous.
+        Some(Duration::from_secs(5)),
+        false,
+    )
+    .await;
+
+    let dr = result.expect("dataflow should complete");
+    eprintln!(
+        "dataflow completed with {} node results",
+        dr.node_results.len()
+    );
+
+    let contents = std::fs::read_to_string(marker)
+        .expect("observer marker file should exist — the observer writes every event");
+    let _ = std::fs::remove_file(marker);
+    eprintln!("observer events:\n{contents}");
+
+    let node_restarted_count = contents
+        .lines()
+        .filter(|l| *l == "NodeRestarted:crasher")
+        .count();
+    assert_eq!(
+        node_restarted_count, 1,
+        "expected exactly one `NodeRestarted:crasher` line (restart_policy: on-failure + \
+         max_restarts: 1 → one respawn), got {node_restarted_count}. observer marker:\n{contents}"
+    );
+}
+
+/// `InputRecovered` is delivered after a broken input receives data
+/// again (#1631).
+///
+/// `check_input_timeouts` breaks an input when the timeout fires
+/// (binaries/daemon/src/lib.rs:1974 → `break_input` →
+/// `InputClosed`). Once broken, the entry lives in
+/// `dataflow.broken_inputs`. When a new message for that broken
+/// input arrives, the daemon clears the `broken_inputs` entry,
+/// arms a fresh `input_deadlines` slot, and emits
+/// `NodeEvent::InputRecovered` (binaries/daemon/src/lib.rs:4095).
+///
+/// Fixture: `timed-burst-source-node` emits `value` twice, separated
+/// by 2 s of silence. The observer has `input_timeout: 0.5`, so:
+///
+/// - t≈50 ms   first emit → `Input:value`
+/// - t≈550 ms  silence past the 0.5 s timeout → `InputClosed:value`
+/// - t≈2.05 s  second emit → `InputRecovered:value` + `Input:value`
+///
+/// Assertion: the marker contains the exact `InputClosed:value`
+/// → `InputRecovered:value` ordering. A regression that dropped
+/// `InputRecovered` delivery would leave the marker with only the
+/// `InputClosed` line.
+#[tokio::test(flavor = "multi_thread")]
+async fn input_recovered_is_delivered_after_broken_input_receives_data() {
+    let status = std::process::Command::new("cargo")
+        .args([
+            "build",
+            "-p",
+            "timed-burst-source-node",
+            "-p",
+            "event-log-observer-node",
+        ])
+        .status()
+        .expect("failed to build input-recovered test crates");
+    assert!(status.success(), "input-recovered test crates build failed");
+
+    let marker = Path::new("/tmp/dora-input-recovered-delivery.log");
+    let _ = std::fs::remove_file(marker);
+
+    let dataflow_path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/dataflows/input-recovered-delivery.yml");
+
+    let result = Daemon::run_dataflow(
+        &dataflow_path,
+        None,
+        None,
+        SessionId::generate(),
+        false,
+        LogDestination::Tracing,
+        None,
+        Some(Duration::from_secs(5)),
+        false,
+    )
+    .await;
+
+    let dr = result.expect("dataflow should complete");
+    eprintln!(
+        "dataflow completed with {} node results",
+        dr.node_results.len()
+    );
+
+    let contents = std::fs::read_to_string(marker)
+        .expect("observer marker file should exist — observer writes every event");
+    let _ = std::fs::remove_file(marker);
+    eprintln!("observer events:\n{contents}");
+
+    let closed_idx = contents
+        .lines()
+        .position(|l| l == "InputClosed:value")
+        .unwrap_or_else(|| {
+            panic!(
+                "never saw `InputClosed:value` — `input_timeout: 0.5` did not fire. \
+                 events:\n{contents}"
+            )
+        });
+    let recovered_idx = contents
+        .lines()
+        .position(|l| l == "InputRecovered:value")
+        .unwrap_or_else(|| {
+            panic!(
+                "never saw `InputRecovered:value` — the daemon did not deliver the \
+                 recovery event after the second emit. events:\n{contents}"
+            )
+        });
+    assert!(
+        recovered_idx > closed_idx,
+        "expected `InputRecovered:value` after `InputClosed:value` (got {closed_idx} then \
+         {recovered_idx}). events:\n{contents}"
+    );
+}
+
 /// Input timeout fires when upstream stops producing.
 ///
 /// The status-node exits after receiving trigger-exit. The sink has input_timeout: 2.0

--- a/tests/fault_tolerance/event_log_observer_node/Cargo.toml
+++ b/tests/fault_tolerance/event_log_observer_node/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "event-log-observer-node"
+edition.workspace = true
+rust-version.workspace = true
+version.workspace = true
+description.workspace = true
+documentation.workspace = true
+license.workspace = true
+publish = false
+
+# Test-only node: appends one line per event to `$DORA_TEST_MARKER_FILE`
+# for the full `Event` variants that fault-tolerance coverage cares
+# about (`Input`, `InputClosed`, `InputRecovered`, `NodeRestarted`,
+# `Stop`). Exits on `Stop` so tests don't need to juggle separate
+# shutdown paths. More general than `input-closed-observer-node`
+# which exits on the first `InputClosed`.
+
+[[bin]]
+name = "event-log-observer-node"
+path = "src/main.rs"
+
+[dependencies]
+dora-node-api = { workspace = true, default-features = false }
+eyre = { workspace = true }

--- a/tests/fault_tolerance/event_log_observer_node/src/main.rs
+++ b/tests/fault_tolerance/event_log_observer_node/src/main.rs
@@ -1,0 +1,45 @@
+//! Record every notable `Event` variant to `$DORA_TEST_MARKER_FILE`.
+//!
+//! Unlike `input-closed-observer-node` (which exits on the first
+//! `InputClosed`), this observer keeps running until it sees `Stop`.
+//! That's required for tests that need to observe events which arrive
+//! *after* a prior `InputClosed` — for example `NodeRestarted` on
+//! upstream crash+restart, or `InputRecovered` when the upstream
+//! starts emitting again after an `input_timeout` break.
+
+use std::io::Write;
+
+use dora_node_api::{DoraNode, Event};
+use eyre::Context;
+
+fn main() -> eyre::Result<()> {
+    let (_node, mut events) =
+        DoraNode::init_from_env().context("failed to init dora node from env")?;
+
+    let marker_path = std::env::var("DORA_TEST_MARKER_FILE")
+        .context("DORA_TEST_MARKER_FILE env var must be set by the fixture")?;
+    let mut marker = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&marker_path)
+        .with_context(|| format!("failed to open marker file {marker_path:?}"))?;
+
+    while let Some(event) = events.recv() {
+        let line: String = match &event {
+            Event::Input { id, .. } => format!("Input:{id}\n"),
+            Event::InputClosed { id } => format!("InputClosed:{id}\n"),
+            Event::InputRecovered { id } => format!("InputRecovered:{id}\n"),
+            Event::NodeRestarted { id } => format!("NodeRestarted:{id}\n"),
+            Event::Stop(_) => "Stop\n".to_string(),
+            _ => continue,
+        };
+        marker
+            .write_all(line.as_bytes())
+            .context("failed to append event marker")?;
+        marker.flush().ok();
+        if matches!(event, Event::Stop(_)) {
+            break;
+        }
+    }
+    Ok(())
+}

--- a/tests/fault_tolerance/timed_burst_source_node/Cargo.toml
+++ b/tests/fault_tolerance/timed_burst_source_node/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "timed-burst-source-node"
+edition.workspace = true
+rust-version.workspace = true
+version.workspace = true
+description.workspace = true
+documentation.workspace = true
+license.workspace = true
+publish = false
+
+# Test-only node: emits exactly two `value` outputs, separated by
+# `$DORA_TEST_BURST_GAP_MS` ms. Between the two emits the source is
+# alive but silent — long enough for `input_timeout` on a downstream
+# to fire. The second emit then triggers `InputRecovered` delivery.
+
+[[bin]]
+name = "timed-burst-source-node"
+path = "src/main.rs"
+
+[dependencies]
+dora-node-api = { workspace = true, default-features = false }
+eyre = { workspace = true }

--- a/tests/fault_tolerance/timed_burst_source_node/src/main.rs
+++ b/tests/fault_tolerance/timed_burst_source_node/src/main.rs
@@ -1,0 +1,50 @@
+//! Emit `value` twice with a silence gap in between.
+//!
+//! Between the two emits the node is alive but not producing — long
+//! enough for the downstream's `input_timeout` to fire, break the
+//! input, and deliver `InputClosed`. The second emit re-arms the
+//! input, which the daemon surfaces as `InputRecovered` (see
+//! binaries/daemon/src/lib.rs:4095).
+
+use std::time::{Duration, Instant};
+
+use dora_node_api::{DoraNode, Event, IntoArrow, dora_core::config::DataId};
+use eyre::Context;
+
+fn main() -> eyre::Result<()> {
+    let (mut node, mut events) =
+        DoraNode::init_from_env().context("failed to init dora node from env")?;
+    let output = DataId::from("value".to_owned());
+
+    let gap_ms: u64 = std::env::var("DORA_TEST_BURST_GAP_MS")
+        .context("DORA_TEST_BURST_GAP_MS env var must be set by the fixture")?
+        .parse()
+        .context("DORA_TEST_BURST_GAP_MS must be a u64")?;
+
+    let mut emitted = 0;
+    let mut next_emit_after: Option<Instant> = None;
+
+    while let Some(event) = events.recv() {
+        match event {
+            Event::Input { id, metadata, .. } if id.as_str() == "tick" => {
+                if emitted >= 2 {
+                    continue;
+                }
+                let ok = match next_emit_after {
+                    None => true,
+                    Some(t) => Instant::now() >= t,
+                };
+                if !ok {
+                    continue;
+                }
+                node.send_output(output.clone(), metadata.parameters, 42i64.into_arrow())
+                    .context("failed to send value")?;
+                emitted += 1;
+                next_emit_after = Some(Instant::now() + Duration::from_millis(gap_ms));
+            }
+            Event::Stop(_) => break,
+            _ => {}
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Sixth and final planned slice of **#1631**. Closes the downstream lifecycle-event coverage gap:

- **`NodeRestarted { id }`** is emitted to every downstream node after an upstream is respawned (`binaries/daemon/src/lib.rs:3625`). Service / action clients rely on it to invalidate pre-crash correlation state. A regression that dropped the signal would leave them silently blocked on stale state.

- **`InputRecovered { id }`** is emitted when a previously-broken input (one that had hit `input_timeout` and been circuit-broken) receives new data (`binaries/daemon/src/lib.rs:4095`). A regression that dropped this would leave `input_tracker` out of sync with reality.

Neither signal had automated coverage before this PR.

## Approach

- **New test-only crate** `tests/fault_tolerance/event_log_observer_node/` — general-purpose observer that appends one line per notable `Event` variant to `$DORA_TEST_MARKER_FILE` and exits on `Stop`. Unlike the earlier `input-closed-observer-node` (which exits on the first `InputClosed`), this one keeps recording so tests can observe events that arrive after an earlier break.

- **New test-only crate** `tests/fault_tolerance/timed_burst_source_node/` — emits `value` twice separated by `$DORA_TEST_BURST_GAP_MS` ms of silence. Drives the input-close-then-recover pattern required for the `InputRecovered` test.

- **New fixture** `tests/dataflows/node-restarted-delivery.yml` — reuses `always-crash-node` (#1644) as a crashing upstream; the observer subscribes to its declared `pulse` output and records the delivered `NodeRestarted:crasher` event. `restart_policy: on-failure` + `max_restarts: 1` means exactly one respawn, so the test asserts **exactly one** `NodeRestarted:crasher` line (avoids the over-permissive `>= 1` pattern).

- **New fixture** `tests/dataflows/input-recovered-delivery.yml` — `timed-burst-source-node` with `DORA_TEST_BURST_GAP_MS: 2000` paired with observer `input_timeout: 0.5` drives the first-emit → timeout (InputClosed) → second-emit (InputRecovered) sequence.

- **Two new tests** in `fault-tolerance-e2e.rs`:
  - `node_restarted_is_delivered_to_downstream`
  - `input_recovered_is_delivered_after_broken_input_receives_data`

## Verification

```
$ cargo test --test fault-tolerance-e2e -- --test-threads=1
test restart_recovers_from_failure ... ok
test max_restarts_limit_reached ... ok
test max_restarts_exhaustion_marks_node_failed ... ok
test restart_policy_always_restarts_on_clean_exit ... ok
test restart_window_resets_restart_counter ... ok
test input_timeout_delivers_input_closed_to_downstream ... ok
test health_check_timeout_sigkills_unresponsive_node ... ok
test node_restarted_is_delivered_to_downstream ... ok
test input_recovered_is_delivered_after_broken_input_receives_data ... ok
test input_timeout_closes_stale_input ... ok

test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 85.40s
```

Observer marker from `NodeRestarted` test (excerpt):
```
NodeRestarted:crasher
InputClosed:pulse
Stop
```

Observer marker from `InputRecovered` test (excerpt):
```
Input:value
InputClosed:value
Input:value
InputRecovered:value
```

`make qa-fast` green.

## Remaining under #1631 (follow-ups, not blockers for #1628)

- Full `restart_policy: on-failure` kill → respawn → kill cycle under health-check-induced SIGKILL (noted in PR #1648).
- Rename of the historical `input_timeout_closes_stale_input` smoke test to reflect what it actually proves (its fixture doesn't actually exercise `input_timeout` — the sink exits on the first `exit` signal).

## Test plan

- [x] `cargo test --test fault-tolerance-e2e -- --test-threads=1` ⇒ 10/10 locally
- [x] `make qa-fast` green
- [x] New crates build clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
