### PR TITLE
ci: promote semantic contract tests to PR CI (#1632)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -494,6 +494,59 @@ jobs:
           cargo test --test fault-tolerance-e2e -- --test-threads=1
         timeout-minutes: 15
 
+  # Semantic contract tests — promoted from nightly per #1632.
+  #
+  # These are the `contract_*` tests in tests/example-smoke.rs added by
+  # PR #1642. Unlike the liveness-oriented `smoke_*` tests (which just
+  # prove the dataflow completed without crashing), each `contract_*`
+  # test asserts a specific feature behavior: validated-pipeline's
+  # SUCCESS marker for exactly 10 doubled values, service-example's
+  # request_id correlation, action-example's feedback-before-result
+  # ordering, streaming-example's fin-triggered session reassembly.
+  #
+  # Promotion rationale (per #1632 criteria):
+  # - deterministic (each test waits for a specific log marker)
+  # - ~75 s total runtime — well under any reasonable PR budget
+  # - Linux-only to dodge the macOS/Windows Python setup overhead
+  # - no privileged execution or multi-host infra needed
+  #
+  # The liveness `smoke_*` siblings (45 tests) stay in nightly — they
+  # exist to catch crash-class regressions, which the contract tests
+  # already cover for the four examples they touch.
+  contract-tests:
+    name: Semantic contract tests
+    runs-on: ubuntu-latest
+    needs: test
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+      - name: Set up Python venv
+        # contract_streaming_example uses `--uv`; the other three are
+        # Rust-only but share the same test binary so the setup has
+        # to land before any of them run.
+        run: |
+          uv venv --seed -p 3.12
+          echo "VIRTUAL_ENV=$PWD/.venv" >> "$GITHUB_ENV"
+          source .venv/bin/activate
+          uv pip install pyarrow
+          uv pip install -e apis/python/node
+      - name: Run semantic contract tests
+        run: >
+          cargo test -p dora-examples --test example-smoke contract_
+          --
+          --test-threads=1
+          --nocapture
+
   # Benchmark regression check — Ubuntu only (intentional).
   # Upstream dora runs bench on 3 platforms but only for the benchmark
   # example (not criterion regression). Our `examples` job already runs

--- a/docs/testing-matrix.md
+++ b/docs/testing-matrix.md
@@ -18,7 +18,8 @@ Fast gates. Must pass for every PR.
 | Example dataflows (Rust/C/C++/Python) | `.github/workflows/ci.yml` `examples` | `cargo run --example ...` on 3 platforms |
 | CLI template + basic Python examples | `.github/workflows/ci.yml` `cli` | `dora new` + `dora run` on 3 platforms |
 | E2E WS control plane | `.github/workflows/ci.yml` `e2e` | `cargo test --test ws-cli-e2e` |
-| Fault tolerance E2E | `.github/workflows/ci.yml` `fault-tolerance-e2e` | `cargo test --test fault-tolerance-e2e` |
+| Fault tolerance E2E | `.github/workflows/ci.yml` `e2e` | `cargo test --test fault-tolerance-e2e` |
+| Semantic contract tests (service, action, streaming, validated-pipeline) | `.github/workflows/ci.yml` `contract-tests` | `cargo test -p dora-examples --test example-smoke contract_` |
 | Supply chain (cargo-audit / cargo-deny) | `.github/workflows/ci.yml` `audit` | `scripts/qa/audit.sh` |
 | Unwrap budget | `.github/workflows/ci.yml` `unwrap-budget` | `scripts/qa/unwrap-budget.sh` |
 | Benchmark regression | `.github/workflows/ci.yml` `benchmark-regression` | |
@@ -29,9 +30,16 @@ Fast gates. Must pass for every PR.
 Runs daily at 06:00 UTC and via `workflow_dispatch`. Failures file issues with
 the `nightly-regression` label but do not block PRs.
 
+The liveness-oriented `smoke_*` tests in `tests/example-smoke.rs` stay
+nightly-only — they catch crash-class regressions and, for the four
+capabilities with a `contract_*` sibling (service, action, streaming,
+validated-pipeline), the contract tests in Tier 0 already provide
+stronger per-PR coverage. See "Tier policy" below for the promotion
+criteria used in #1632.
+
 | Area | Job |
 |---|---|
-| Full smoke suite (`tests/example-smoke.rs`, 45 tests) | `smoke-suite` |
+| Full smoke suite (`tests/example-smoke.rs`, 45 `smoke_*` tests) | `smoke-suite` |
 | Log-sink examples (file, alert, tcp) | `log-sinks` |
 | Service / Action patterns (Rust-only) | `service-action` |
 | Streaming example (Python nodes) | `streaming` |
@@ -186,12 +194,39 @@ regression is reported, the fix is to lift the `if: runner.os == 'Linux'` gate o
 the relevant step and add platform-specific install logic — not to keep shipping
 broken.
 
-## Promotion policy
+## Tier policy (promotion / demotion criteria)
 
-If a nightly failure reproduces for **3 consecutive runs**, promote the
-corresponding test to the remote CI gate (move from `nightly.yml` to
-`ci.yml`). Keep lean-CI-first: only promote gates that catch real bugs,
-not flaky infra.
+See issue #1632 for the policy discussion; this section is the
+authoritative summary.
 
-If a remote CI gate is flaky (>10% false-positive rate over a month),
-demote it to nightly.
+**Promote to Tier 0 (PR CI)** when a test is:
+
+- Deterministic — no "either outcome is fine" fallbacks, no retries on
+  flakiness.
+- Fast — adds a reasonable slice of per-PR runtime. The
+  `contract-tests` job runs in ~2 min; that's roughly the ceiling for
+  anything else promoted without a compelling reason.
+- High-signal — catches user-visible feature regressions, not just
+  "did not crash".
+- Hosted-runner-friendly — no privileged execution, no multi-host
+  infra, no per-runner timing hacks.
+
+**Keep in Tier 1 (nightly)** when a test is useful but slow, mildly
+flaky on shared runners, timing-sensitive, or only catches a
+lower-frequency regression class.
+
+**Keep in Tier 2 (laptop / manual)** when a test needs SSH-backed
+cluster deployment, real multi-host networking, privileged RT / mlock
+paths, or destructive operations (for example, an actual `self update`
+binary swap).
+
+### Demotion
+
+If a Tier 0 gate flakes > 10% false-positive over a month, demote it
+to Tier 1 and open an issue to harden it before re-promoting.
+
+### Reactive promotion
+
+If a Tier 1 failure reproduces for **3 consecutive nightly runs**,
+promote the corresponding test to Tier 0. Keep lean-CI-first: promote
+only gates that catch real regressions, not flaky infra.


### PR DESCRIPTION
## Summary

First slice of **#1632**. The four `contract_*` tests in `tests/example-smoke.rs` (added by #1642 for #1630) were landing in the nightly tier even though they meet every PR-CI promotion criterion.

## What's promoted

| Test | Catches |
|---|---|
| `contract_validated_pipeline_produces_exactly_ten_doubled_outputs` | Source emits 10 → transform doubles → sink hits `SUCCESS - validated 10 doubled values` |
| `contract_service_example_correlates_requests_and_responses` | request_id correlation + arithmetic across ≥3 responses |
| `contract_action_example_feedback_precedes_success_result` | Action-pattern ordering: feedback before terminal `succeeded` |
| `contract_streaming_example_reassembles_session_on_fin` | Session-tagged token reassembly on `fin=true` |

Each meets the Tier 0 bar:

- **Deterministic**: each waits for a specific marker, no "either outcome is fine" fallbacks.
- **Fast**: ~75 s total for all four, under any reasonable PR budget.
- **High-signal**: catches feature semantic regressions, not just "did not crash".
- **Hosted-runner-friendly**: no privileged execution, no multi-host infra.

## Changes

- **New `contract-tests` job** in `.github/workflows/ci.yml`. Linux-only (to dodge macOS/Windows Python setup overhead), depends on `test` so the rust-cache is warm. Runs `cargo test -p dora-examples --test example-smoke contract_`. Python/uv venv is set up first because `contract_streaming_example` uses `--uv`.

- **`docs/testing-matrix.md`** updated:
  - Tier 0 table gains the contract-tests row and fixes the existing fault-tolerance row's job name (`fault-tolerance-e2e` → `e2e`, where the test actually lives).
  - Tier 1 preamble explains why `smoke_*` siblings stay nightly for the four promoted capabilities.
  - New "Tier policy (promotion / demotion criteria)" section replaces the older, terser "Promotion policy" — states the Tier 0/1/2 bars, demotion trigger (>10% flake / month), and reactive promotion rule (3 consecutive nightly failures).

## What's NOT promoted

The liveness `smoke_*` tests (45 of them) stay in nightly — they exist to catch crash-class regressions, and for the four capabilities with a promoted `contract_*` sibling the Tier 0 coverage is already stronger.

## Remaining under #1632

Capability-by-capability review of the rest of nightly for additional promotion candidates (cross-language assertions, record/replay semantic verification, etc.). Each promotion deserves its own evaluation; not bundling them here to keep this PR focused on the clearest case.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — YAML valid
- [x] `typos` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Local `cargo test -p dora-examples --test example-smoke contract_ -- --test-threads=1` ⇒ 4/4 passing (verified in #1642)
- [ ] CI shows the new `Semantic contract tests` job running and green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
