### PR TITLE
docs: add capability-to-test coverage matrix (#1633)

### DIFF
--- a/docs/qa-runbook.md
+++ b/docs/qa-runbook.md
@@ -3,6 +3,7 @@
 **Audience**: dora developers (human or agent) running QA locally.
 **Purpose**: tell you which command to run, how to read the output, and what to do when something fails.
 **Deep dives**: see [`plan-agentic-qa-strategy.md`](plan-agentic-qa-strategy.md) for the strategy and rationale; this document is the operational reference.
+**Coverage by capability**: see [`testing-capabilities.md`](testing-capabilities.md) (#1633) when you need to know *which* tests cover a feature before touching it.
 
 ---
 

--- a/docs/testing-capabilities.md
+++ b/docs/testing-capabilities.md
@@ -201,7 +201,7 @@ Known gap: `dora self update` destructive swap path (tracked in
 | `cargo clippy -D warnings` | `clippy` job | PR | Structural |
 | `cargo-deny` license check | `audit` job / `check-license` | PR | Structural |
 | `typos` | `typos` job | PR | Structural |
-| MSRV (1.85) | `msrv` job | PR | Structural |
+| MSRV (workspace `rust-version` in `Cargo.toml`) | `msrv` job | PR | Structural |
 | 8 target triples compile | `cross-check` matrix | PR | Structural |
 | Benchmark regression vs. cached baseline | `bench` job | PR | Structural |
 

--- a/docs/testing-capabilities.md
+++ b/docs/testing-capabilities.md
@@ -1,0 +1,248 @@
+# Capability-to-Test Matrix
+
+Where each Dora capability is covered, at what tier, and how strongly.
+
+Answers three questions that the test-type-oriented
+[`testing-matrix.md`](testing-matrix.md) and the command-oriented
+[`testing-guide.md`](testing-guide.md) leave implicit:
+
+- If I change this feature, what tests should I run?
+- Is this documented capability actually validated anywhere?
+- Where are the known coverage gaps?
+
+Addresses [#1633](https://github.com/dora-rs/dora/issues/1633); parent
+[#1628](https://github.com/dora-rs/dora/issues/1628).
+
+---
+
+## Legend
+
+- **Tier**: `PR`, `Nightly`, `Manual` — per
+  [`testing-matrix.md`](testing-matrix.md)'s tier policy.
+- **Strength**:
+  - **Contract** — asserts a specific behavioral outcome (exact
+    markers, counts, orderings). A regression in the feature will
+    fail the test.
+  - **Smoke** — proves the code path ran to completion without an
+    obvious error. A regression that silently changes behavior may
+    still pass.
+  - **Structural** — formatting / lint / supply chain / etc. Enforces
+    repo invariants, not feature behavior.
+
+---
+
+## CLI lifecycle & validation
+
+| Sub-capability | Test(s) | Tier | Strength |
+|---|---|---|---|
+| `dora --help` + per-subcommand `--help` | `test` job argparse block (ci.yml) | PR | Contract |
+| `dora validate` (basic + `--strict-types`) | `test` job validate block | PR | Contract |
+| `dora expand`, `dora graph` | `test` job CLI smoke block | PR | Contract |
+| `dora new` templates (rust, python) on 3 platforms | `cli` job (ci.yml) | PR | Smoke |
+| `dora new` templates (c, cxx, cmake) on Linux | `cli` job (ci.yml) | PR | Smoke |
+| `dora run` local mode, wide set of examples | `examples` job (3 platforms) | PR | Smoke |
+| `dora up`/`start`/`stop`/`down` lifecycle | `smoke_*` in `example-smoke.rs` | Nightly | Smoke |
+| `dora run --stop-after` contract on 4 examples | `contract_*` in `example-smoke.rs` | PR | Contract |
+| `dora self update --check-only` (read-only path) | `topic-and-top-smoke` job | Nightly | Smoke |
+
+Known gap: `dora self update` destructive swap path (tracked in
+[#215](https://github.com/dora-rs/dora/issues/215)).
+
+## Dataflow execution modes
+
+| Sub-capability | Test(s) | Tier | Strength |
+|---|---|---|---|
+| `dora run` (embedded coord + daemon) | `smoke_local_*`, `contract_*` | PR (contract) / Nightly (smoke) | Contract + Smoke |
+| `dora up` + `dora start --detach` (full network mode) | `smoke_*` (networked siblings) | Nightly | Smoke |
+| Module expansion (`module:` inline inclusion) | `smoke_module_dataflow`, `smoke_local_module_dataflow` | Nightly | Smoke |
+| Module loading from URL | `smoke_rust_dataflow_url` | Nightly | Smoke |
+| Dynamic dataflow (`dora run` dynamic variant) | `smoke_rust_dataflow_dynamic` | Nightly | Smoke |
+| Python builder API | no automated coverage | — | Gap |
+
+## Service pattern (request / reply)
+
+| Sub-capability | Test(s) | Tier | Strength |
+|---|---|---|---|
+| request_id correlation, arithmetic contract | `contract_service_example_correlates_requests_and_responses` | PR | Contract |
+| Two clients fan-in to one server | `smoke_service_example`, `smoke_local_service_example` | Nightly | Smoke |
+| Timeout / retry paths | no automated coverage | — | Gap (#1630 follow-up) |
+
+## Action pattern (goal / feedback / result)
+
+| Sub-capability | Test(s) | Tier | Strength |
+|---|---|---|---|
+| feedback precedes terminal `succeeded` | `contract_action_example_feedback_precedes_success_result` | PR | Contract |
+| Two clients fan-in, countdown | `smoke_action_example`, `smoke_local_action_example` | Nightly | Smoke |
+| Cancellation path | no automated coverage | — | Gap (#1630 follow-up) |
+
+## Streaming pattern (session / segment / chunk)
+
+| Sub-capability | Test(s) | Tier | Strength |
+|---|---|---|---|
+| `fin=true` triggers session reassembly | `contract_streaming_example_reassembles_session_on_fin` | PR | Contract |
+| Multi-session token streams | `smoke_streaming_example`, `smoke_local_streaming_example` | Nightly | Smoke |
+| `flush=true` + interruption semantics | no automated coverage | — | Gap (#1630 follow-up) |
+
+## Validated pipeline (deterministic source → transform → sink)
+
+| Sub-capability | Test(s) | Tier | Strength |
+|---|---|---|---|
+| Source emits 10, transform doubles, sink asserts match | `contract_validated_pipeline_produces_exactly_ten_doubled_outputs` | PR | Contract |
+| Liveness smoke on same fixture | `smoke_validated_pipeline`, `smoke_local_validated_pipeline` | Nightly | Smoke |
+
+## Topic / trace / top inspection
+
+| Sub-capability | Test(s) | Tier | Strength |
+|---|---|---|---|
+| `dora top --once` (JSON snapshot) | `topic-and-top-smoke` | Nightly | Contract |
+| `dora topic list --format json` (NDJSON) | `topic-and-top-smoke` | Nightly | Contract |
+| `dora topic info --duration N` (≥10 msgs on 10 Hz fixture) | `topic-and-top-smoke` | Nightly | Contract |
+| `dora topic echo --count N` (N frames matched) | `topic-and-top-smoke` | Nightly | Contract |
+| `dora topic hz --duration N` (≥10 samples on 10 Hz fixture) | `topic-and-top-smoke` | Nightly | Contract |
+| `dora topic pub --count N` | `topic-and-top-smoke` | Nightly | Contract |
+| `dora trace list` / `trace view` empty-state + prefix errors | `topic-and-top-smoke` | Nightly | Contract |
+| `dora top` interactive TUI mode | no automated coverage | — | Gap (needs expect harness) |
+
+## Parameter operations
+
+| Sub-capability | Test(s) | Tier | Strength |
+|---|---|---|---|
+| `dora param get/set/list/delete` | no automated coverage | — | Gap |
+
+## Record / replay
+
+| Sub-capability | Test(s) | Tier | Strength |
+|---|---|---|---|
+| `dora record` → `.drec` file + `dora replay` round-trip (existence + size) | `record-replay` job | Nightly | Smoke |
+| Semantic replay equivalence | no automated coverage | — | Gap (#1632 follow-up candidate) |
+
+## Fault tolerance
+
+| Sub-capability | Test(s) | Tier | Strength |
+|---|---|---|---|
+| `restart_policy: on-failure` recovery | `restart_recovers_from_failure` | PR | Contract |
+| `max_restarts` exhaustion marks node failed | `max_restarts_exhaustion_marks_node_failed` | PR | Contract |
+| `restart_policy: always` re-spawns on clean exit | `restart_policy_always_restarts_on_clean_exit` | PR | Contract |
+| `restart_window` counter reset | `restart_window_resets_restart_counter` | PR | Contract |
+| `input_timeout` delivers `InputClosed` | `input_timeout_delivers_input_closed_to_downstream` | PR | Contract |
+| `health_check_timeout` SIGKILLs unresponsive node | `health_check_timeout_sigkills_unresponsive_node` | PR | Contract |
+| `NodeRestarted` delivery to downstream | `node_restarted_is_delivered_to_downstream` | PR | Contract |
+| `InputRecovered` delivery after break | `input_recovered_is_delivered_after_broken_input_receives_data` | PR | Contract |
+| Full kill→respawn→kill cycle under health check | no automated coverage | — | Gap (#1631 follow-up) |
+
+## Cluster lifecycle
+
+| Sub-capability | Test(s) | Tier | Strength |
+|---|---|---|---|
+| `dora cluster status` (lists daemons + dataflows) | `cluster-smoke` | Nightly | Contract |
+| `dora cluster down` tears everything cleanly | `cluster-smoke` | Nightly | Contract |
+| `dora cluster up` (SSH-backed) | no automated coverage | — | Manual (infra-dependent) |
+| `dora cluster install/uninstall/upgrade` | no automated coverage | — | Manual (systemd + SSH) |
+
+## redb persistence & state reconstruction
+
+| Sub-capability | Test(s) | Tier | Strength |
+|---|---|---|---|
+| redb store writes dataflow record + survives coord restart | `redb-backend-smoke` | Nightly | Contract |
+| Running → Recovering transition on coord restart | `state-reconstruction-smoke` | Nightly | Contract |
+| Daemon auto-reconnect after coord freeze | `daemon-reconnect-smoke` (Linux only) | Nightly | Contract |
+| Full reconciliation back to Running post-restart | no automated coverage | — | Gap (aspirational per `state-reconstruction-smoke` docstring) |
+
+## Cross-language interop
+
+| Sub-capability | Test(s) | Tier | Strength |
+|---|---|---|---|
+| Rust → Python dataflow | `smoke_cross_language_rust_to_python`, `smoke_local_cross_language_rust_to_python` | Nightly | Smoke |
+| Python → Rust dataflow | `smoke_cross_language_python_to_rust`, `smoke_local_cross_language_python_to_rust` | Nightly | Smoke |
+| Semantic assertion on cross-language payload | no automated coverage | — | Gap (#1632 follow-up candidate) |
+
+## Python operator path
+
+| Sub-capability | Test(s) | Tier | Strength |
+|---|---|---|---|
+| Python node template + `dora run` | `cli` job (ci.yml) | PR | Smoke |
+| Python async / drain / echo / log / multiple-arrays / concurrent-rw examples | `smoke_python_*` + `smoke_local_python_*` | Nightly | Smoke |
+| Python operator hot reload | no automated coverage | — | Gap |
+| Python builder API (programmatic dataflow construction) | no automated coverage | — | Gap |
+
+## C / C++ template & examples
+
+| Sub-capability | Test(s) | Tier | Strength |
+|---|---|---|---|
+| `dora new --lang c/cxx` + CMake build (Linux) | `cli` job | PR | Smoke |
+| `c-dataflow`, `c++-dataflow` examples (Linux) | `examples` job | PR | Smoke |
+| `c++-arrow-dataflow` (Linux / macOS) | `examples` job | PR | Smoke |
+| `cmake-dataflow` (Linux) | `examples` job | PR | Smoke |
+| C/C++ on macOS / Windows | not covered | — | Gap — platform-parity policy in [`testing-matrix.md`](testing-matrix.md#platform-parity) |
+
+## ROS2 bridge
+
+| Sub-capability | Test(s) | Tier | Strength |
+|---|---|---|---|
+| Rust ROS2 example | `ros2-bridge` job (ci.yml, Linux) | PR | Smoke |
+| Python ROS2 example | `ros2-bridge` job | PR | Smoke |
+| C++ ROS2 example | `ros2-bridge` job | PR | Smoke |
+| YAML bridge (topic / service / action) | `ros2-bridge` job subset | PR | Smoke |
+
+## Soft real-time (`--rt`, SCHED_FIFO, mlock)
+
+| Sub-capability | Test(s) | Tier | Strength |
+|---|---|---|---|
+| `cpu_affinity` mask actually applied | `cpu-affinity-smoke` (Linux only) | Nightly | Contract |
+| `mlockall` + SCHED_FIFO enforcement | no automated coverage | — | Manual — needs privileged execution (tracked in [#256](https://github.com/dora-rs/dora/issues/256)) |
+
+## Supply chain / repo invariants (structural)
+
+| Sub-capability | Test(s) | Tier | Strength |
+|---|---|---|---|
+| `cargo-audit` + `cargo-deny` (advisories, licenses, sources) | `audit` job | PR | Structural |
+| Unwrap budget ratchet | `unwrap-budget` job | PR | Structural |
+| `cargo fmt --check` | `fmt` job | PR | Structural |
+| `cargo clippy -D warnings` | `clippy` job | PR | Structural |
+| `cargo-deny` license check | `audit` job / `check-license` | PR | Structural |
+| `typos` | `typos` job | PR | Structural |
+| MSRV (1.85) | `msrv` job | PR | Structural |
+| 8 target triples compile | `cross-check` matrix | PR | Structural |
+| Benchmark regression vs. cached baseline | `bench` job | PR | Structural |
+
+---
+
+## How to use this document
+
+- **Before changing a feature**: find its row, run the listed tests
+  locally (`cargo test --test <file> <name>`).
+- **Before merging a PR that touches a "Gap" row**: decide whether to
+  add coverage in this PR or file a follow-up issue and link it.
+- **When adding a new capability**: add a new row here in the same PR
+  that ships the feature. Treat this file as a gate, not a wiki.
+
+## Related docs
+
+- [`testing-matrix.md`](testing-matrix.md) — tier-oriented view (what
+  runs in PR CI vs nightly vs manual).
+- [`testing-guide.md`](testing-guide.md) — command-oriented
+  reference (how to run each test locally).
+- [`qa-runbook.md`](qa-runbook.md) — deep-gate investigation playbook
+  (coverage, mutants, semver).
+
+## Open coverage gaps (quick index)
+
+The rows labeled "Gap" are consolidated here so follow-up work can be
+filed and tracked:
+
+- Python builder API — no tests.
+- Service pattern: timeout / retry paths — #1630 follow-up.
+- Action pattern: cancellation — #1630 follow-up.
+- Streaming pattern: `flush=true` + interruption — #1630 follow-up.
+- `dora top` interactive TUI — needs expect harness (#215).
+- Parameter operations — no tests.
+- Record/replay semantic equivalence — candidate for PR promotion.
+- Fault tolerance: full kill→respawn→kill cycle under health check —
+  #1631 follow-up.
+- `dora cluster up` (SSH) — manual, needs dedicated infra.
+- State reconstruction: full Recovering→Running reconciliation —
+  aspirational per current docstring.
+- Cross-language semantic assertions — #1632 follow-up candidate.
+- Python operator hot reload — no tests.
+- C/C++ on macOS/Windows — platform-parity policy.
+- `mlockall` / SCHED_FIFO — #256 (manual, privileged).

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -8,7 +8,7 @@ This guide covers how to run, write, and troubleshoot tests across the Dora work
 
 ## Prerequisites
 
-- Rust toolchain (MSRV 1.85.0)
+- Rust toolchain — MSRV is the workspace `rust-version` in `Cargo.toml` (currently 1.88.0)
 - Python 3 with `numpy` and `pyarrow` installed (`pip install numpy pyarrow`) — required for Python smoke tests
 
 ## Quick Start (5-minute validation)

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -2,6 +2,10 @@
 
 This guide covers how to run, write, and troubleshoot tests across the Dora workspace.
 
+> Looking for **which tests cover which capability**? See
+> [`testing-capabilities.md`](testing-capabilities.md) (#1633) — the
+> capability-oriented source-of-truth companion to this guide.
+
 ## Prerequisites
 
 - Rust toolchain (MSRV 1.85.0)

--- a/docs/testing-matrix.md
+++ b/docs/testing-matrix.md
@@ -5,6 +5,9 @@ Where each feature is tested, and how to run the manual gates.
 See issue #215 for the original audit. See `CLAUDE.md` for the CI philosophy
 (remote CI is deliberately lean; deep gates run on laptops and nightly).
 
+> Looking for coverage by Dora **capability** rather than by test tier?
+> See [`testing-capabilities.md`](testing-capabilities.md) (#1633).
+
 ## Tier 0 — Remote CI (every push and PR)
 
 Fast gates. Must pass for every PR.


### PR DESCRIPTION
## Summary

Closes **#1633** — third-from-last sub-issue of the #1628 QA epic.

Existing test docs are organized by test tier (`testing-matrix.md`) and by command (`testing-guide.md`); neither answers the question an agent or engineer most often needs:

> If I change this feature, what tests should I run? Is it actually covered anywhere? Where are the gaps?

New `docs/testing-capabilities.md` answers that directly.

## What it contains

For each major Dora capability:

- sub-capability breakdown
- the specific test(s) that cover it
- the tier (PR / Nightly / Manual)
- **strength** classification:
  - **Contract** — asserts specific behavior (markers, counts, orderings)
  - **Smoke** — proves path ran without obvious error
  - **Structural** — fmt / lint / supply chain
- known gaps, with the relevant follow-up issue linked

### Capability groups covered

CLI lifecycle & validation · Dataflow execution modes · Service pattern · Action pattern · Streaming pattern · Validated pipeline · Topic/trace/top inspection · Parameter operations · Record/replay · Fault tolerance · Cluster lifecycle · redb persistence & state reconstruction · Cross-language interop · Python operator path · C/C++ templates · ROS2 bridge · Soft real-time · Supply chain / repo invariants

## Cross-references

Added forward links from:

- `docs/testing-matrix.md` (tier-oriented view)
- `docs/testing-guide.md` (command-oriented reference)
- `docs/qa-runbook.md` (operational playbook)

so the new file shows up from every test-doc entry point.

## Open gaps index

A consolidated "Open coverage gaps" list at the bottom pulls every "Gap" row into one place, keyed to the relevant follow-up issues (#1630 follow-ups, #1631 follow-ups, #215, #256, etc.). Future work doesn't have to re-derive what's missing.

## Policy stance

The "How to use" section treats the matrix as a **gate, not a wiki**: new capabilities land with a matrix row in the same PR. That aligns with the Tier policy in `testing-matrix.md` (added in #1650).

## Test plan

- [x] `typos` clean
- [x] `cargo fmt --all -- --check` clean
- [x] All cross-doc links are in-repo relative paths (no absolute URLs to guess)
- [x] Every `Gap` row has either a tracked issue or a reason documented
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
