### PR TITLE
docs: align MSRV/workspace-version references with Cargo.toml (sweep follow-up to #1651)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ dora run examples/python-dataflow/dataflow.yml --uv --stop-after 10s
 
 ## Workspace Layout
 
-- **Rust edition 2024; MSRV and workspace version live in `[workspace.package]` in the root `Cargo.toml`** (all crates share the workspace version)
+- **Rust edition 2024; MSRV and default workspace package metadata live in `[workspace.package]` in the root `Cargo.toml`.** Most crates inherit the workspace version via `version.workspace = true`, but a few (e.g. `apis/rust/operator/types`, the `examples/error-propagation/*` samples) pin their own version independently.
 - Python packages use PyO3 0.28 and are built with **maturin**, not cargo
 
 ### Key crates

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ dora run examples/python-dataflow/dataflow.yml --uv --stop-after 10s
 
 ## Workspace Layout
 
-- **Rust edition 2024, MSRV 1.85.0, version 0.2.0** (all crates share workspace version)
+- **Rust edition 2024; MSRV and workspace version live in `[workspace.package]` in the root `Cargo.toml`** (all crates share the workspace version)
 - Python packages use PyO3 0.28 and are built with **maturin**, not cargo
 
 ### Key crates

--- a/README.md
+++ b/README.md
@@ -532,8 +532,11 @@ See [docs/patterns.md](docs/patterns.md) for the full guide.
 
 ## Development
 
-**Rust edition 2024; MSRV and workspace version are tracked in
-`[workspace.package]` of the root `Cargo.toml`.**
+**Rust edition 2024; MSRV and default workspace package metadata are
+tracked in `[workspace.package]` of the root `Cargo.toml`.** Most crates
+inherit the workspace version via `version.workspace = true`; a handful
+(e.g. `apis/rust/operator/types`, the `examples/error-propagation/*`
+samples) pin their own version independently.
 
 ### Build
 

--- a/README.md
+++ b/README.md
@@ -532,7 +532,8 @@ See [docs/patterns.md](docs/patterns.md) for the full guide.
 
 ## Development
 
-**Rust edition 2024, MSRV 1.85.0, workspace version 0.2.0.**
+**Rust edition 2024; MSRV and workspace version are tracked in
+`[workspace.package]` of the root `Cargo.toml`.**
 
 ### Build
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -457,8 +457,11 @@ examples/               # 示例数据流
 
 ## 开发
 
-**Rust 版本 2024；最低支持 Rust 版本（MSRV）和工作区版本以根
-`Cargo.toml` 的 `[workspace.package]` 为准。**
+**Rust 版本 2024；最低支持 Rust 版本（MSRV）及工作区默认包元数据以根
+`Cargo.toml` 的 `[workspace.package]` 为准。** 多数 crate 通过
+`version.workspace = true` 继承该版本；少数 crate（例如
+`apis/rust/operator/types` 与 `examples/error-propagation/*` 样例）
+自带独立版本号。
 
 ### 构建
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -457,7 +457,8 @@ examples/               # 示例数据流
 
 ## 开发
 
-**Rust 版本 2024，最低支持 Rust 版本 1.85.0，工作区版本 0.1.0。**
+**Rust 版本 2024；最低支持 Rust 版本（MSRV）和工作区版本以根
+`Cargo.toml` 的 `[workspace.package]` 为准。**
 
 ### 构建
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,8 +27,9 @@ Dora is built on four core principles:
 
 ## Workspace Structure
 
-**Rust edition 2024, MSRV 1.85.0, workspace version 0.1.0.**
-All crates share the workspace version.
+**Rust edition 2024, MSRV and workspace version tracked in the root
+`Cargo.toml` (`[workspace.package]`).** All crates share the workspace
+version.
 
 ### Binaries (7)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,9 +27,12 @@ Dora is built on four core principles:
 
 ## Workspace Structure
 
-**Rust edition 2024, MSRV and workspace version tracked in the root
-`Cargo.toml` (`[workspace.package]`).** All crates share the workspace
-version.
+**Rust edition 2024; MSRV and default workspace package metadata are
+tracked in `[workspace.package]` in the root `Cargo.toml`.** Most
+crates inherit the workspace version via `version.workspace = true`;
+a handful (e.g. `apis/rust/operator/types`, the
+`examples/error-propagation/*` samples) pin their own version
+independently.
 
 ### Binaries (7)
 

--- a/docs/octos-dora-integration-report.md
+++ b/docs/octos-dora-integration-report.md
@@ -8,7 +8,7 @@
 
 ## Executive Summary
 
-[Octos](https://github.com/octos-org/octos) (Open Cognitive Tasks Orchestration System) is a Rust-native agentic OS that can serve as Dora's "brain" — handling thinking, planning, and orchestration while Dora handles real-time execution. Both projects share the same Rust toolchain (edition 2024, MSRV 1.85.0) and Apache-2.0 license, making them a natural pairing.
+[Octos](https://github.com/octos-org/octos) (Open Cognitive Tasks Orchestration System) is a Rust-native agentic OS that can serve as Dora's "brain" — handling thinking, planning, and orchestration while Dora handles real-time execution. Both projects share the same Rust toolchain (edition 2024; see each project's `Cargo.toml` for the current MSRV) and Apache-2.0 license, making them a natural pairing.
 
 **Key finding**: The integration is viable today via Octos's `ShellTool` + Dora's JSON CLI output. A dedicated Octos skill or MCP server would make it production-grade.
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -57,7 +57,8 @@ CI tracks these via `benchmark-action/github-action-benchmark` with 120% alert t
 ### Requirements
 
 - Linux or macOS (shared memory IPC)
-- Rust 1.85+ with release profile
+- Rust toolchain at or above the workspace MSRV (see `rust-version`
+  in root `Cargo.toml`), release profile
 - Python 3.10+ with `numpy`, `pyarrow`
 - ROS2 Humble+ (for comparison only)
 


### PR DESCRIPTION
## Summary

Follow-up sweep prompted by review feedback on PR #1651. The capability matrix + `testing-guide.md` were fixed in that PR, but `grep -rn "MSRV 1\.85\|Rust 1\.85"` across the repo still surfaces stale references in six more files. All of them pre-date the 1.85 → 1.88 bump (recorded in `docs/qa-baseline-2026-04-07.md`), and several also carry a stale workspace version number (0.1.0 or 0.2.0 vs. the actual 0.2.1).

Rather than hard-code a new version number that will drift the next time the MSRV bumps, every hunk now points at the authoritative source: `[workspace.package]` in the root `Cargo.toml`.

## Files touched

| File | What changed |
|---|---|
| `CLAUDE.md` | Workspace Layout bullet |
| `README.md` | Development section intro |
| `README.zh-CN.md` | 开发 section intro (matching wording) |
| `docs/architecture.md` | Workspace Structure intro |
| `docs/performance.md` | Requirements bullet |
| `docs/octos-dora-integration-report.md` | Executive Summary |

## Intentionally left alone

- `docs/audit-report-2026-03-21.md` — historical audit finding (MSRV 1.85 was accurate *when it was written*; rewriting it would falsify the record).
- `docs/qa-baseline-2026-04-07.md` — *records* the 1.85 → 1.88 bump itself; the stale-looking text is the bump being documented.
- `docs/plan-dora-1.0-consolidation.md` — consolidation plan; the 1.85/1.88 inconsistency is already tracked in `docs/plan-consistency-sweep-2026-04-17.md`.

## Non-goals

- Not bumping the compiler.
- Not touching any version string in `Cargo.toml`.
- Just removing the drift between prose docs and the workspace manifest.

## Verification

```
$ grep -rn "MSRV 1\.85\|Rust 1\.85" docs/ README.md README.zh-CN.md CLAUDE.md \
    | grep -v "plan-consistency-sweep\|plan-dora-1.0-consolidation\|audit-report\|qa-baseline"
(no results)
```

`typos` clean.

## Test plan

- [x] `typos` clean
- [x] `grep` confirms no more stale MSRV mentions in the targeted scope
- [x] Historical/record docs left intact (documented above)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
