### PR TITLE
docs: add class-based agentic QA policy (#1634)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,12 @@ Relevant test entry points:
 
 ## Validation Expectations
 
+> The per-class policy (Class A low-risk / Class B behavior change /
+> Class C high-risk subsystem) lives in
+> [`docs/agentic-qa-policy.md`](docs/agentic-qa-policy.md). The
+> commands below are what the policy asks for; this section is the
+> agent-facing cheat sheet.
+
 Before finishing substantial code changes, run the smallest set that proves correctness:
 
 - Always: targeted tests for touched crates or behavior

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,12 @@ Internal transport:
 
 **Every commit MUST pass these gates before pushing.** This is a BLOCKING REQUIREMENT — do not skip any step. Remote CI is slower than your laptop and has limited capacity; catching failures locally saves 5-15 minutes per round-trip.
 
+> The bar below is the **Class A** (low-risk) baseline. Behavior
+> changes and high-risk subsystem edits have additional requirements
+> — see [`docs/agentic-qa-policy.md`](docs/agentic-qa-policy.md)
+> (#1634) for the per-class expectations and the PR validation
+> summary template.
+
 ### Step 1: Run /review
 
 Run the `/review` skill on your changes before committing. This catches structural issues, security problems, and logic errors that tests and clippy miss.

--- a/docs/agentic-qa-policy.md
+++ b/docs/agentic-qa-policy.md
@@ -1,0 +1,186 @@
+# Agentic QA Policy
+
+The validation bar a change must clear before merging, **keyed to what
+the change does**, not who (or what) authored it.
+
+This document is the authoritative policy surface for
+[#1634](https://github.com/dora-rs/dora/issues/1634). Operational
+details — how to run each gate, how to read the output — live in
+[`qa-runbook.md`](qa-runbook.md). Strategy and rationale live in
+[`plan-agentic-qa-strategy.md`](plan-agentic-qa-strategy.md).
+
+---
+
+## Change classifications
+
+Every PR falls into exactly one of these three classes. When a PR
+spans multiple classes (e.g. a high-risk fix bundled with an
+unrelated cosmetic change), split it or apply the **stricter**
+class's requirements to the whole PR.
+
+### Class A — Low-risk
+
+Cosmetic or mechanical changes that can't alter observable behavior:
+
+- Formatting, typo fixes, rewording in docs/comments.
+- Pure renames (with grep-replace across the repo) when the symbol is
+  already equivalent — no signature or semantics change.
+- Test-only additions (new test fixture, new assertion).
+- Dependency bumps that don't change semver-compatible behavior.
+- CI config changes that don't change what's tested (e.g. runner image
+  update, timeout bump).
+
+### Class B — Behavior change
+
+Anything user-visible or downstream-visible that isn't in Class C:
+
+- Bug fixes that change an output, exit code, log line, or timing.
+- New features or new CLI flags.
+- Refactors that touch a public API but are meant to be
+  behavior-preserving (they often aren't).
+- Performance work that changes how code paths are exercised.
+- Dependency bumps that change public API surface (even if
+  semver-major on our side is not required).
+
+### Class C — High-risk subsystem
+
+Changes touching code paths where a silent regression has outsized
+impact. Current list (update when a new subsystem earns it):
+
+- `binaries/daemon/**` — lifecycle, routing, spawn loop, node kill/restart.
+- `binaries/coordinator/**` — state machine, dataflow registry, recovery.
+- `libraries/core/src/descriptor/**` — dataflow parsing and validation.
+- `libraries/message/**` — wire protocol / enum additions / variant renames.
+- `libraries/shared-memory-server/**` — transport + zero-copy path.
+- Fault-tolerance paths: `restart_*`, `health_check_*`, `input_timeout`,
+  `NodeRestarted` / `InputClosed` / `InputRecovered` delivery.
+- Record/replay format or session semantics.
+- Public Rust API of `apis/rust/node` and `apis/rust/operator`.
+- Python API exports in `apis/python/node`.
+
+---
+
+## Required QA per class
+
+### Class A — Low-risk
+
+- [ ] `make qa-fast` (fmt + clippy + audit + unwrap-budget).
+- [ ] `typos` (covered by `qa-fast` via remote CI, but run locally first when the change touches prose).
+
+That's the whole bar. Don't over-test cosmetic changes — reviewers can
+eyeball them and CI backs it up.
+
+### Class B — Behavior change
+
+- [ ] `make qa-fast`.
+- [ ] Targeted tests for the touched crate(s): at minimum
+      `cargo test -p <touched-crate>`.
+- [ ] A test that demonstrates the new behavior (new feature) **or** a
+      regression test for the fixed bug. If you can't write one,
+      explain why in the PR description.
+- [ ] If the touched feature is covered by a `smoke_*` or
+      `contract_*` test in `tests/example-smoke.rs`, run the relevant
+      one locally and paste the result in the PR description.
+- [ ] PR validation summary (template below).
+
+### Class C — High-risk subsystem
+
+All of Class B, plus:
+
+- [ ] Full `cargo test --all` (workspace-wide; Python crates excluded
+      per the commands in [`CLAUDE.md`](../CLAUDE.md)).
+- [ ] Fault-tolerance E2E:
+      `cargo test --test fault-tolerance-e2e -- --test-threads=1`.
+- [ ] Contract tests:
+      `cargo test -p dora-examples --test example-smoke contract_ -- --test-threads=1`.
+- [ ] Decide, and state explicitly in the PR:
+  - New semantic contract test for the touched behavior (preferred), **or**
+  - Diff-coverage threshold demonstrated on touched lines, **or**
+  - Focused mutation-testing run on touched files
+    (`make qa-mutants` scoped), **or**
+  - Explicit manual-validation notes when automation is genuinely
+    infeasible.
+
+**Adversarial review** (`make qa-adversarial`) is expected for
+Class C when the diff is within size limits ([see
+`plan-agentic-qa-strategy.md`](plan-agentic-qa-strategy.md) for the
+caveats). Not a hard gate — a reasoned skip in the PR description is
+fine.
+
+---
+
+## PR validation summary template
+
+Class B and C PRs should include a block like this in the description.
+Agents authoring PRs: render this section by default so reviewers can
+see the evidence without asking.
+
+```markdown
+## Validation
+
+**Class**: B  <!-- or C -->
+
+- `make qa-fast`: ✅
+- `cargo test -p <crate>`: ✅ (N passed)
+- Targeted reproduction / feature test: <test name, output excerpt>
+- Contract / fault-tolerance tests (Class C): <names, passes>
+- Adversarial review (Class C, when applicable): <skipped with reason | ran, notes>
+```
+
+Class A PRs don't need a formal block — the diff speaks for itself.
+
+---
+
+## Enforcement
+
+- The policy is **self-enforced at PR-author level**. There's no bot
+  that checks the checklist.
+- Reviewers are expected to **block on missing Class C evidence** and
+  to **lean-in on Class B evidence**. Class A can merge on a green
+  `qa-fast` alone.
+- `enforce_admins: false` on `main` lets maintainers admin-merge when
+  CI is green but branch-protection review is procedurally blocked
+  (e.g. self-review during the release-freeze window). Admin-merge
+  does not waive the policy above — the validation evidence should
+  still be in the PR description.
+
+## Mapping to existing tools
+
+| Policy item | Command | Runbook reference |
+|---|---|---|
+| Baseline fast gate | `make qa-fast` | [`qa-runbook.md` §TL;DR](qa-runbook.md#1-tldr) |
+| Workspace tests | `cargo test --all --exclude <python-crates>` | [`CLAUDE.md`](../CLAUDE.md) |
+| Fault-tolerance E2E | `cargo test --test fault-tolerance-e2e` | [`testing-capabilities.md`](testing-capabilities.md#fault-tolerance) |
+| Semantic contracts | `cargo test -p dora-examples --test example-smoke contract_` | [`testing-capabilities.md`](testing-capabilities.md) |
+| Diff coverage | `make qa-coverage` | [`qa-runbook.md`](qa-runbook.md) |
+| Mutation testing | `make qa-mutants` | [`qa-runbook.md`](qa-runbook.md) |
+| Adversarial review | `make qa-adversarial` | [`plan-agentic-qa-strategy.md`](plan-agentic-qa-strategy.md) |
+
+## When the classification is ambiguous
+
+- If the PR touches any file matching the Class C list and cannot be
+  characterized as strictly Class A (comments-only, for example), it
+  is Class C.
+- If unsure whether a Class B change is "behavior" or "refactor", ask
+  whether a downstream user could write a test today that the PR
+  would break. If yes → Class B. If no → Class A.
+- "Fix a typo in an error message string" is Class A *unless* users
+  grep for that string (CLI error-message golden files, automation
+  scripts). Default to Class B if in doubt.
+
+## Why this policy exists
+
+Agentic coding workflows land more code per hour than a human
+reviewer can fully load into their head. The traditional "trust the
+author" gate degrades when the author is an LLM. This policy
+re-introduces validation as an explicit, per-class expectation so:
+
+- Low-risk changes stay fast and don't drown in ceremony.
+- Behavior changes always carry a concrete demonstration of the
+  behavior.
+- High-risk subsystem changes always carry evidence beyond
+  "compiles + unit tests pass".
+
+See [`plan-agentic-qa-strategy.md`](plan-agentic-qa-strategy.md) for
+the longer-form rationale and the open experiments (coverage gates,
+mutants scoping, adversarial-review CI integration).

--- a/docs/agentic-qa-policy.md
+++ b/docs/agentic-qa-policy.md
@@ -95,7 +95,10 @@ All of Class B, plus:
       `cargo test -p dora-examples --test example-smoke contract_ -- --test-threads=1`.
 - [ ] Decide, and state explicitly in the PR:
   - New semantic contract test for the touched behavior (preferred), **or**
-  - Diff-coverage threshold demonstrated on touched lines, **or**
+  - Thresholded diff coverage on the touched lines
+    (`pip install diff-cover` then
+    `DIFF_COVERAGE_FAIL_UNDER=80 make qa-coverage`; `make qa-coverage`
+    alone produces a report but does not gate), **or**
   - Focused mutation-testing run on touched files
     (`make qa-mutants` scoped), **or**
   - Explicit manual-validation notes when automation is genuinely
@@ -152,7 +155,8 @@ Class A PRs don't need a formal block — the diff speaks for itself.
 | Workspace tests | `cargo test --all --exclude <python-crates>` | [`CLAUDE.md`](../CLAUDE.md) |
 | Fault-tolerance E2E | `cargo test --test fault-tolerance-e2e` | [`testing-capabilities.md`](testing-capabilities.md#fault-tolerance) |
 | Semantic contracts | `cargo test -p dora-examples --test example-smoke contract_` | [`testing-capabilities.md`](testing-capabilities.md) |
-| Diff coverage | `make qa-coverage` | [`qa-runbook.md`](qa-runbook.md) |
+| Coverage report (lcov) | `make qa-coverage` | [`qa-runbook.md`](qa-runbook.md) |
+| Thresholded diff coverage (optional gate) | `pip install diff-cover` + `DIFF_COVERAGE_FAIL_UNDER=80 make qa-coverage` | `scripts/qa/coverage.sh` header |
 | Mutation testing | `make qa-mutants` | [`qa-runbook.md`](qa-runbook.md) |
 | Adversarial review | `make qa-adversarial` | [`plan-agentic-qa-strategy.md`](plan-agentic-qa-strategy.md) |
 

--- a/docs/qa-runbook.md
+++ b/docs/qa-runbook.md
@@ -4,6 +4,7 @@
 **Purpose**: tell you which command to run, how to read the output, and what to do when something fails.
 **Deep dives**: see [`plan-agentic-qa-strategy.md`](plan-agentic-qa-strategy.md) for the strategy and rationale; this document is the operational reference.
 **Coverage by capability**: see [`testing-capabilities.md`](testing-capabilities.md) (#1633) when you need to know *which* tests cover a feature before touching it.
+**Validation bar by change class**: see [`agentic-qa-policy.md`](agentic-qa-policy.md) (#1634) to know *how much* validation a change needs.
 
 ---
 

--- a/docs/testing-matrix.md
+++ b/docs/testing-matrix.md
@@ -7,6 +7,9 @@ See issue #215 for the original audit. See `CLAUDE.md` for the CI philosophy
 
 > Looking for coverage by Dora **capability** rather than by test tier?
 > See [`testing-capabilities.md`](testing-capabilities.md) (#1633).
+>
+> Looking for **how much validation** a given change needs (Class A /
+> B / C)? See [`agentic-qa-policy.md`](agentic-qa-policy.md) (#1634).
 
 ## Tier 0 — Remote CI (every push and PR)
 


### PR DESCRIPTION
## Summary

Closes **#1634** — the last sub-issue of the #1628 QA epic. Defines an explicit, per-change validation bar so agents (and human reviewers) can determine expected QA evidence from **what the change does**, not who authored it.

## New `docs/agentic-qa-policy.md`

### Three change classes

| Class | Examples | QA expectations |
|---|---|---|
| **A — Low-risk** | Cosmetic, mechanical renames, test-only, dep bumps | `make qa-fast` + `typos` |
| **B — Behavior change** | Bug fixes, features, refactors touching public surface | qa-fast + targeted `cargo test -p <crate>` + demonstration test + validation summary in PR |
| **C — High-risk subsystem** | daemon, coordinator, descriptor, message wire protocol, shared-memory, fault tolerance, record/replay, public Rust/Python API | All of B + full `cargo test --all` + fault-tolerance E2E + contract tests + choice of (new semantic test / diff-coverage / focused mutation / manual notes) + adversarial review when diff fits |

### PR validation summary template

Class B and C PRs carry a block in the description showing exactly which commands ran and what they produced. Class A doesn't — green `qa-fast` speaks for itself.

### Rules for ambiguous / mixed PRs

- Multi-class PRs apply the **stricter** class.
- Any file matching the Class C list → Class C unless the change is strictly Class A (comments-only).
- "Is this Class A or B?" test: *could a downstream user write a test today that this PR would break?* Yes → B. No → A.

## Cross-links added

The new doc is reachable from every existing QA entry point so a reader doesn't have to stumble on it:

- `CLAUDE.md` Pre-commit Quality Gates — notes the Class A baseline and points to the full per-class policy.
- `AGENTS.md` Validation Expectations — same, from the agent-facing side.
- `docs/qa-runbook.md` — adds "Validation bar by change class" next to the existing "Coverage by capability" pointer (#1633).
- `docs/testing-matrix.md` — adds the agentic-qa-policy blockquote next to the testing-capabilities blockquote in the intro.

## Non-goals (kept verbatim from the issue)

- No bot enforces the checklist. Policy is self-enforced at PR-author level; reviewers lean in on missing evidence.
- CI isn't expanded to run heavy QA gates — the existing Tier 0 lane stays lean per `testing-matrix.md` + `CLAUDE.md` policy.
- Mutation testing and diff coverage stay local/manual per `plan-agentic-qa-strategy.md`.

## #1628 epic state after this merges

All six sub-issues closed:

- #1629 Sync smoke/docs ✅
- #1630 Semantic contract tests ✅
- #1631 Fault-tolerance coverage ✅
- #1632 PR CI vs nightly rebalance ✅
- #1633 Capability-to-test matrix ✅
- **#1634 Agentic QA policy — this PR**

## Test plan

- [x] `typos` clean
- [x] All forward links resolve (in-repo relative paths)
- [x] New doc references match existing `make` targets and `cargo test` invocations verbatim
- [x] No code changes, no `Cargo.toml` changes, no workflow changes — policy only
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
