### PR TITLE
ci: align nightly trigger comment with the actual paths filter (#1656)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,13 @@ name: Nightly Regression
 # Triggers:
 #   - schedule: daily at 06:00 UTC
 #   - workflow_dispatch: manual run from Actions UI
-#   - push to main: re-run on every push (validates nightly jobs on each commit)
+#   - push to main under `paths:` — ONLY re-runs when this workflow
+#     file itself changes, so maintainers editing the nightly pipeline
+#     get an immediate validation run. Every-push triggering was
+#     considered and rejected: the suite is intentionally expensive
+#     (~11 min smoke + 11 fault-tolerance subjobs) and the Tier 1
+#     policy in docs/testing-matrix.md treats it as lower-frequency
+#     regression coverage, not a per-commit gate (#1656).
 
 on:
   schedule:


### PR DESCRIPTION
## Summary

Closes **#1656**. The header comment in `.github/workflows/nightly.yml` said "push to main: re-run on every push" but the actual trigger had `paths: [".github/workflows/nightly.yml"]`, so effective behavior was workflow-file-only. The mismatch undermined the Tier 1 promotion policy (#1632) which relies on readers knowing how often the suite actually runs.

## Decision: Option B (align comment to workflow)

Keeping the current narrow trigger is correct — the nightly suite is intentionally expensive:

- ~11 min smoke-suite job
- 11 fault-tolerance subjobs at ~2-10 min each
- Plus service/action/streaming/log-sink/record-replay/cluster/topic-and-top/cpu-affinity/redb/daemon-reconnect/state-reconstruction

Expanding to every push to `main` would burn a large chunk of hosted-runner budget for marginal signal gain. The Tier 1 policy in `docs/testing-matrix.md` already frames nightly as lower-frequency regression coverage, not a per-commit gate.

## What changed

Header comment now describes the actual trigger set plus the *reason* the restricted push path exists (maintainers editing the pipeline get an immediate validation run without burning hosted-runner time on every unrelated commit):

```yaml
# Triggers:
#   - schedule: daily at 06:00 UTC
#   - workflow_dispatch: manual run from Actions UI
#   - push to main under `paths:` — ONLY re-runs when this workflow
#     file itself changes, so maintainers editing the nightly pipeline
#     get an immediate validation run. Every-push triggering was
#     considered and rejected: the suite is intentionally expensive
#     (~11 min smoke + 11 fault-tolerance subjobs) and the Tier 1
#     policy in docs/testing-matrix.md treats it as lower-frequency
#     regression coverage, not a per-commit gate (#1656).
```

No changes to the actual `on:` block — behavior is preserved.

## Docs

`docs/testing-matrix.md` already said "daily at 06:00 UTC and via `workflow_dispatch`" without claiming every-push behavior, so no doc change is needed there.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` valid
- [x] `typos` clean
- [x] No behavior change to the `on:` triggers (comment-only)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
