### PR TITLE
qa: add typos to make qa-fast (#1657)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ cargo test --all \
 # cargo test -p <crate-name>
 ```
 
-**Shortcut**: `make qa-fast` runs fmt + clippy + supply-chain audit + unwrap budget in ~30 seconds. Use it as a sanity check before every commit. Then run the full `cargo test` above before `git push`.
+**Shortcut**: `make qa-fast` runs fmt + clippy + supply-chain audit + unwrap budget + typos in ~30 seconds. Use it as a sanity check before every commit. Then run the full `cargo test` above before `git push`.
 
 If you add new example dataflows, also run `./scripts/smoke-all.sh --rust-only` to verify smoke tests pass.
 

--- a/docs/agentic-qa-policy.md
+++ b/docs/agentic-qa-policy.md
@@ -64,11 +64,11 @@ impact. Current list (update when a new subsystem earns it):
 
 ### Class A — Low-risk
 
-- [ ] `make qa-fast` (fmt + clippy + audit + unwrap-budget).
-- [ ] `typos` (covered by `qa-fast` via remote CI, but run locally first when the change touches prose).
+- [ ] `make qa-fast` (fmt + clippy + audit + unwrap-budget + typos).
 
 That's the whole bar. Don't over-test cosmetic changes — reviewers can
-eyeball them and CI backs it up.
+eyeball them and CI backs it up. `typos` is now part of `qa-fast`
+itself (#1657) so docs-heavy PRs don't need a separate manual step.
 
 ### Class B — Behavior change
 

--- a/docs/qa-runbook.md
+++ b/docs/qa-runbook.md
@@ -37,7 +37,7 @@ rustup component add miri --toolchain nightly   # optional; for unsafe-code anal
 
 | Target | Runs | Budget | When to use |
 |---|---|---|---|
-| `make qa-fast` | fmt + clippy + audit + unwrap-budget | ~15 s | Pre-commit |
+| `make qa-fast` | fmt + clippy + audit + unwrap-budget + typos | ~15 s | Pre-commit |
 | `make qa-full` | `qa-fast` + full test suite + coverage | ~5-10 min | Pre-push |
 | `make qa-tier1` | `qa-full` + mutation testing on diff + semver | ~1-2 hrs | Pre-release or focused audit |
 | `make qa-fmt` | `cargo fmt --all -- --check` | ~2 s | Spot-check |

--- a/scripts/qa/all.sh
+++ b/scripts/qa/all.sh
@@ -5,7 +5,7 @@
 # Designed for local-first execution: same script runs locally and in CI.
 #
 # Modes:
-#   --fast    pre-commit budget (~1 minute) — fmt, clippy, audit, unwrap
+#   --fast    pre-commit budget (~1 minute) — fmt, clippy, audit, unwrap, typos
 #   --full    pre-push budget (~5-10 minutes) — fast + tests + coverage
 #   --tier1   full Tier 1 gate (~15 minutes) — full + mutants + semver
 #
@@ -39,6 +39,7 @@ run "clippy"        cargo clippy --all \
                       -- -D warnings
 run "audit"         scripts/qa/audit.sh
 run "unwrap-budget" scripts/qa/unwrap-budget.sh
+run "typos"         scripts/qa/typos.sh
 
 if [[ "$MODE" == "--fast" ]]; then
   : # done

--- a/scripts/qa/typos.sh
+++ b/scripts/qa/typos.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# scripts/qa/typos.sh — spelling/prose gate
+#
+# Wraps `crate-ci/typos` so `make qa-fast` (and every tier above it)
+# runs the same prose check remote CI runs. Added per #1657 so
+# docs-heavy changes don't need a separate manual step after qa-fast.
+#
+# Install:
+#   cargo install typos-cli
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+if ! command -v typos >/dev/null; then
+  echo "typos not installed. Run: cargo install typos-cli"
+  exit 2
+fi
+
+typos


### PR DESCRIPTION
## Summary

Closes **#1657**. The Class A baseline in `docs/agentic-qa-policy.md` expected both `make qa-fast` and `typos`, but `qa-fast` didn't actually run `typos` — meaning docs-heavy changes needed a separate manual step after the advertised fast path. Easy to forget; easy to have CI flag a typo that a local run would have caught.

## Changes

- **`scripts/qa/typos.sh`** — thin wrapper with the install-hint pattern every other QA gate uses (fail with `cargo install typos-cli` hint when typos is missing).
- **`scripts/qa/all.sh`** — add `run "typos"` to the always-run fast block so every tier (fast, full, tier1) exercises typos.
- **`CLAUDE.md`**, **`docs/qa-runbook.md`** — tighten the "fmt + clippy + audit + unwrap-budget" description to also list typos.
- **`docs/agentic-qa-policy.md`** — drop the separate "run typos locally first" sub-bullet from Class A; `qa-fast` now covers it.

## Runtime impact

typos processes the tree in < 1 s locally, well inside the ~15 s `qa-fast` budget the runbook advertises.

## Verification

```
$ make qa-fast
…
=== typos ===
  PASS: typos

============================================================
All checks passed.
```

## Test plan

- [x] `make qa-fast` passes all five steps (fmt, clippy, audit, unwrap-budget, typos)
- [x] Install-hint path: `typos` not on PATH → exit 2 with `cargo install typos-cli` hint (inherited from existing QA-script pattern in `audit.sh`)
- [x] `typos` clean (PR's own content)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
