### PR TITLE
test: semantic cross-language payload contracts (#1658)

### DIFF
--- a/docs/testing-capabilities.md
+++ b/docs/testing-capabilities.md
@@ -158,7 +158,8 @@ Known gap: `dora self update` destructive swap path (tracked in
 |---|---|---|---|
 | Rust → Python dataflow | `smoke_cross_language_rust_to_python`, `smoke_local_cross_language_rust_to_python` | Nightly | Smoke |
 | Python → Rust dataflow | `smoke_cross_language_python_to_rust`, `smoke_local_cross_language_python_to_rust` | Nightly | Smoke |
-| Semantic assertion on cross-language payload | no automated coverage | — | Gap (#1632 follow-up candidate) |
+| Semantic Rust → Python payload delivery (exact count + value validation) | `contract_cross_language_rust_to_python_delivers_all_ten_values` | PR | Contract |
+| Semantic Python → Rust payload delivery (exact count + value validation) | `contract_cross_language_python_to_rust_delivers_all_ten_values` | PR | Contract |
 
 ## Python operator path
 
@@ -244,7 +245,6 @@ filed and tracked:
 - `dora cluster up` (SSH) — manual, needs dedicated infra.
 - State reconstruction: full Recovering→Running reconciliation —
   aspirational per current docstring.
-- Cross-language semantic assertions — #1632 follow-up candidate.
 - Python operator hot reload — no tests.
 - C/C++ on macOS/Windows — platform-parity policy.
 - `mlockall` / SCHED_FIFO — #256 (manual, privileged).

--- a/tests/example-smoke.rs
+++ b/tests/example-smoke.rs
@@ -720,6 +720,66 @@ fn smoke_local_cross_language_python_to_rust() {
     );
 }
 
+/// Semantic cross-language contracts (#1658).
+///
+/// The `smoke_cross_language_*` tests above only check for non-Failed
+/// state via `dora list` — they'd still pass if every payload arrived
+/// with a wrong value as long as the receivers didn't `bail!`/`sys.exit`.
+/// The receivers (`cross-language/python_receiver.py`,
+/// `cross-language/rust-receiver/src/main.rs`) already validate each
+/// payload against the sender's deterministic sequence `[0, 10, …, 90]`
+/// and print a specific `SUCCESS - validated N messages` marker on
+/// clean completion; the smoke lane just never looks.
+///
+/// These two tests run `dora run --stop-after`, capture combined
+/// stdout+stderr, and assert the marker contains exactly the number
+/// the senders emit (10). A regression in the Rust ↔ Python Arrow
+/// payload path (for example: byte-order drift, length mismatch,
+/// type-widening, or a message being dropped on the wire) fails
+/// either the receiver's in-process validation (no marker) or the
+/// count check here.
+#[test]
+fn contract_cross_language_rust_to_python_delivers_all_ten_values() {
+    ensure_cross_language_nodes_built();
+    let (status, stdout, stderr) = run_dora_capture(
+        "contract-cross-language-rust-to-python",
+        "examples/cross-language/rust-to-python.yml",
+        15,
+        true, // Python receiver needs uv-provisioned venv
+    );
+    let combined = format!("{stdout}\n{stderr}");
+    assert!(
+        combined.contains("python-receiver: SUCCESS - validated 10 messages"),
+        "rust → python did not deliver exactly 10 validated messages.\n\
+         ---- stdout ----\n{stdout}\n---- stderr ----\n{stderr}"
+    );
+    assert!(
+        status.success(),
+        "dora run exited non-zero: {status:?}\n---- stdout ----\n{stdout}\n---- stderr ----\n{stderr}"
+    );
+}
+
+#[test]
+fn contract_cross_language_python_to_rust_delivers_all_ten_values() {
+    ensure_cross_language_nodes_built();
+    let (status, stdout, stderr) = run_dora_capture(
+        "contract-cross-language-python-to-rust",
+        "examples/cross-language/python-to-rust.yml",
+        15,
+        true, // Python sender needs uv-provisioned venv
+    );
+    let combined = format!("{stdout}\n{stderr}");
+    assert!(
+        combined.contains("rust-receiver: SUCCESS - validated 10 messages"),
+        "python → rust did not deliver exactly 10 validated messages.\n\
+         ---- stdout ----\n{stdout}\n---- stderr ----\n{stderr}"
+    );
+    assert!(
+        status.success(),
+        "dora run exited non-zero: {status:?}\n---- stdout ----\n{stdout}\n---- stderr ----\n{stderr}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Python recv_async() smoke test (GIL/async deadlock regression)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes **#1658**. The `smoke_cross_language_*` tests only checked for non-Failed state via `dora list` — they'd still pass if every payload arrived with a wrong value as long as the receivers didn't `bail!` / `sys.exit`. The receivers already validate each payload against the sender's deterministic sequence `[0, 10, …, 90]` and print `SUCCESS - validated N messages` markers; the smoke lane just never looked.

## New tests

- **`contract_cross_language_rust_to_python_delivers_all_ten_values`** — asserts the marker `python-receiver: SUCCESS - validated 10 messages` appears in combined stdout+stderr.
- **`contract_cross_language_python_to_rust_delivers_all_ten_values`** — asserts `rust-receiver: SUCCESS - validated 10 messages`.

Both assertions require the **exact count** (10), not just the `>= 5` threshold the receivers use internally — so a regression that drops a single message still fails this lane.

### Regression coverage

A bug in the Rust ↔ Python Arrow payload path (byte-order drift, length mismatch, type-widening, a dropped message, wrong integer width) will fail either:
- **the receiver's in-process validation** (`rust-receiver: ERROR unexpected value X`, `python-receiver: ERROR unexpected value X`) → no SUCCESS marker prints, or
- **the exact-count assertion here** (marker shows "validated 8 messages" instead of 10).

## Tier

PR CI, added to the `contract-tests` job. Runtime ~26 s for both combined, well under the job's budget.

## Capability matrix

Cross-language interop gains two Contract rows; "Cross-language semantic assertions" removed from the Open gaps index.

## Verification

```
$ cargo test -p dora-examples --test example-smoke contract_cross_language -- --test-threads=1
test contract_cross_language_python_to_rust_delivers_all_ten_values ... ok
test contract_cross_language_rust_to_python_delivers_all_ten_values ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 50 filtered out; finished in 26.19s
```

`make qa-fast` green.

## Test plan

- [x] Both contract tests pass locally
- [x] Existing `smoke_cross_language_*` tests still pass (not touched)
- [x] Capability matrix reflects new coverage
- [x] `make qa-fast` green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
