### PR TITLE
test: unblock python-dataflow-builder coverage via YAML contract (#1654)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,7 +416,13 @@ jobs:
       # runs on every PR.
       - name: Test Python Dataflow Builder API (YAML generation)
         timeout-minutes: 5
-        run: python examples/python-dataflow-builder/test_builder_api.py
+        shell: bash
+        # `uv run` is needed so the step uses the project venv from
+        # the "Set up Python venv" step above — `source .venv/bin/activate`
+        # doesn't persist to later steps. `--with PyYAML` provisions
+        # the one extra dep the contract test needs, without polluting
+        # the dora-rs install with a transitive upgrade from PyPI.
+        run: uv run --with PyYAML python examples/python-dataflow-builder/test_builder_api.py
 
       - name: Python Queue Latency Test
         timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,13 +404,19 @@ jobs:
           OTEL_SDK_DISABLED: true
         run: dora run examples/python-drain/dataflow.yaml --uv
 
-      # TODO: re-enable once dora 1.0 is published to PyPI (supersedes upstream 0.5.0).
-      # The builder example installs dora-hub packages (opencv-video-capture,
-      # dora-yolo) from PyPI which pull upstream dora-rs 0.5.0, overwriting
-      # our local build and introducing incompatible type definitions.
-      # - name: Test Python Dataflow Builder
-      #   timeout-minutes: 30
-      #   run: uv run examples/python-dataflow-builder/simple_example.py
+      # `simple_example.py` itself still can't run here — its `build:`
+      # directives pip-install hub packages (opencv-video-capture,
+      # dora-yolo, opencv-plot) which transitively pull the PyPI
+      # `dora-rs` 0.5.0 and clobber the locally-built workspace
+      # version. Re-enable that path after 1.0 PyPI publish.
+      #
+      # In the meantime, exercise the builder API itself (the part
+      # the capability matrix cares about) via a hub-package-free
+      # YAML generation contract test (#1654). This is fast and
+      # runs on every PR.
+      - name: Test Python Dataflow Builder API (YAML generation)
+        timeout-minutes: 5
+        run: python examples/python-dataflow-builder/test_builder_api.py
 
       - name: Python Queue Latency Test
         timeout-minutes: 30

--- a/docs/testing-capabilities.md
+++ b/docs/testing-capabilities.md
@@ -168,7 +168,8 @@ Known gap: `dora self update` destructive swap path (tracked in
 | Python node template + `dora run` | `cli` job (ci.yml) | PR | Smoke |
 | Python async / drain / echo / log / multiple-arrays / concurrent-rw examples | `smoke_python_*` + `smoke_local_python_*` | Nightly | Smoke |
 | Python operator hot reload | no automated coverage | — | Gap |
-| Python builder API (programmatic dataflow construction) | no automated coverage | — | Gap |
+| Python builder API (programmatic dataflow construction → YAML) | `examples/python-dataflow-builder/test_builder_api.py` invoked by the `cli` job | PR | Contract |
+| Python builder API → `build()` + `run()` end-to-end with hub packages (`simple_example.py`) | not covered — blocked on PyPI `dora-rs` 0.5.0 clobbering the local workspace install; re-enable after 1.0 PyPI publish (#1654) | — | Gap (infrastructural) |
 
 ## C / C++ template & examples
 
@@ -235,7 +236,7 @@ Known gap: `dora self update` destructive swap path (tracked in
 The rows labeled "Gap" are consolidated here so follow-up work can be
 filed and tracked:
 
-- Python builder API — no tests.
+- Python builder `build()` + `run()` with hub packages — blocked on PyPI 1.0 publish; builder API itself is covered.
 - Service pattern: timeout / retry paths — #1630 follow-up.
 - Action pattern: cancellation — #1630 follow-up.
 - Streaming pattern: `flush=true` + interruption — #1630 follow-up.

--- a/examples/python-dataflow-builder/test_builder_api.py
+++ b/examples/python-dataflow-builder/test_builder_api.py
@@ -1,0 +1,98 @@
+"""Contract test for the Python DataflowBuilder API (#1654).
+
+Exercises `dora.builder.DataflowBuilder` end-to-end at the YAML-generation
+layer:
+
+- construct a two-node dataflow programmatically,
+- call `.to_yaml(path)`,
+- parse the generated file,
+- assert the structural contract users depend on
+  (node IDs, ports, wiring between source and sink, env passthrough).
+
+Deliberately does NOT call `build()` or `run()` — the sibling
+`simple_example.py` exercises those paths, but it can't run in CI today
+because its `build:` commands pull hub packages (`opencv-video-capture`,
+`dora-yolo`, `opencv-plot`) which transitively install the PyPI
+`dora-rs` 0.5.0 and clobber the locally-installed workspace version.
+Covering the builder API without those packages restores the
+coverage lane (#1654) until the hub + 1.0 PyPI story settles.
+
+Run locally:
+
+    uv pip install -e apis/python/node  # if not already installed
+    uv pip install PyYAML
+    python examples/python-dataflow-builder/test_builder_api.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+
+import yaml
+from dora.builder import DataflowBuilder
+
+
+def main() -> int:
+    dataflow = DataflowBuilder(name="builder-contract-test")
+
+    source = dataflow.add_node(
+        id="source",
+        path="source.py",
+        env={"SOURCE_MODE": "test"},
+    )
+    source.add_input("tick", "dora/timer/millis/100")
+    value_out = source.add_output("value")
+
+    sink = dataflow.add_node(id="sink", path="sink.py")
+    sink.add_input("value", value_out)
+
+    # Write to a tempfile so the test cleans up after itself.
+    fd, path = tempfile.mkstemp(suffix=".yml", prefix="builder-contract-")
+    os.close(fd)
+    try:
+        dataflow.to_yaml(path)
+        with open(path) as f:
+            generated = yaml.safe_load(f)
+    finally:
+        os.unlink(path)
+
+    # ---- Structural contract ----
+    assert "nodes" in generated, f"no `nodes` key in generated YAML: {generated!r}"
+    by_id = {n["id"]: n for n in generated["nodes"]}
+    assert set(by_id) == {"source", "sink"}, (
+        f"expected exactly source/sink, got {sorted(by_id)}"
+    )
+
+    src = by_id["source"]
+    assert src["path"] == "source.py"
+    # dora accepts `inputs` as a map of `input_id → producer_spec`.
+    assert src["inputs"]["tick"] == "dora/timer/millis/100", (
+        f"source tick wiring wrong: {src['inputs']}"
+    )
+    assert "value" in src["outputs"], f"source outputs: {src['outputs']}"
+    # env passthrough must survive YAML round-trip intact.
+    assert src.get("env", {}).get("SOURCE_MODE") == "test", (
+        f"source env not preserved: {src.get('env')}"
+    )
+
+    snk = by_id["sink"]
+    assert snk["path"] == "sink.py"
+    # Core builder contract: the output handle returned by
+    # `source.add_output("value")` must be resolved to the
+    # "source/value" wire format in the generated YAML. A regression
+    # that left the handle object un-rendered or dropped the prefix
+    # would fail here.
+    assert snk["inputs"]["value"] == "source/value", (
+        f"sink input not wired to source/value, got {snk['inputs']!r}"
+    )
+
+    print(
+        "python-dataflow-builder: SUCCESS - generated YAML has expected structure"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes **#1654** — the last issue in the 7-issue audit slate.

The existing `simple_example.py` can't run in CI because its `build:` directives pip-install hub packages (`opencv-video-capture`, `dora-yolo`, `opencv-plot`) which transitively pull PyPI `dora-rs` 0.5.0 and clobber the locally-built workspace version. The step was commented out with a TODO to re-enable after 1.0 PyPI publish.

Waiting for 1.0 on PyPI to close this gap leaves the **Python builder API itself** — `dora.builder.DataflowBuilder`, the capability the matrix cares about — untested on every PR in the meantime.

## Approach

Separate the "builder API" capability from the "end-to-end dataflow with hub deps" capability:

- **Builder API** — testable today. Just call the API and assert the generated YAML.
- **End-to-end with hub deps** — blocked on PyPI 1.0. Stays deferred.

## What's new

- **`examples/python-dataflow-builder/test_builder_api.py`** — constructs a two-node `source → sink` dataflow programmatically, calls `.to_yaml(path)`, parses the generated YAML, and asserts:
  - Node IDs present
  - `path:` preserved
  - `inputs` map has expected entries
  - `outputs` map preserved
  - `env` passthrough survives YAML round-trip
  - The output handle from `source.add_output("value")` resolves to `"source/value"` in sink's input wiring (the core builder correctness invariant)
  - Deliberately does NOT call `build()` or `run()`

- **`.github/workflows/ci.yml`** — the disabled `Test Python Dataflow Builder` step is replaced with `Test Python Dataflow Builder API (YAML generation)` invoking the new contract. Fast (~1s), runs on all three platforms via the existing `cli` job. Updated comment explains why `simple_example.py` itself stays deferred.

- **`docs/testing-capabilities.md`** — Python operator path section gains two rows:
  - Builder API (programmatic dataflow construction → YAML): PR / Contract
  - `simple_example.py` end-to-end with hub packages: Gap (infrastructural — re-enable post-PyPI-1.0)

  Open gaps index narrowed accordingly.

## Verification

```
$ python3 examples/python-dataflow-builder/test_builder_api.py
python-dataflow-builder: SUCCESS - generated YAML has expected structure
```

`make qa-fast` green.

## Test plan

- [x] Local run passes
- [x] CI YAML still parses
- [x] `typos` clean
- [x] Capability matrix reflects the real (not aspirational) coverage
- [ ] CI green on all 3 platforms (the `cli` job runs on ubuntu/macos/windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
