### PR TITLE
test: full kill→respawn→kill cycle under health_check_timeout (#1668)

### DIFF
--- a/tests/dataflows/health-check-cycle.yml
+++ b/tests/dataflows/health-check-cycle.yml
@@ -1,0 +1,22 @@
+# Fixture for the full health_check_timeout kill → respawn → kill → Err
+# cycle (#1668). Same node as `health-check-timeout.yml` but with
+# `restart_policy: on-failure` + `max_restarts: 1` so the daemon must
+# attempt exactly one respawn after the first SIGKILL and then give up.
+#
+# Why 2 s timeout (not tighter): `init_from_env` takes ~500 ms on a
+# cold spawn, so a shorter watchdog races the post-init marker write
+# (verified in #1648).
+health_check_interval: 0.1
+
+nodes:
+  - id: hang-after-init
+    build: cargo build -p hang-after-init-node
+    path: ../../target/debug/hang-after-init-node
+    restart_policy: on-failure
+    max_restarts: 1
+    restart_delay: 0.1
+    health_check_timeout: 2.0
+    env:
+      DORA_TEST_MARKER_FILE: /tmp/dora-health-check-cycle.log
+    inputs:
+      tick: dora/timer/millis/200

--- a/tests/fault-tolerance-e2e.rs
+++ b/tests/fault-tolerance-e2e.rs
@@ -711,3 +711,89 @@ async fn input_recovered_is_delivered_after_broken_input_receives_data() {
 // `input_timeout_delivers_input_closed_to_downstream` (PR #1647),
 // which actively drives the timeout path via a silent-source + event
 // observer fixture.
+
+/// Full `health_check_timeout` kill → respawn → kill → Err cycle (#1668).
+///
+/// Extends `health_check_timeout_sigkills_unresponsive_node` from
+/// PR #1648, which only exercised the first kill. Here the fixture
+/// uses `restart_policy: on-failure` + `max_restarts: 1`, so the
+/// daemon must respawn the node once after the first SIGKILL, let
+/// the new incarnation hang, watchdog-kill it again, and then give
+/// up with a final `Err` in node_results.
+///
+/// Cycle timing with the fixture:
+///
+/// - t=0         first incarnation spawned
+/// - t=~0.5 s    init_from_env, marker write, drop(events)+drop(node)
+/// - t=~2.1 s    watchdog fires, SIGKILL, restart_delay 0.1 s
+/// - t=~2.2 s    second incarnation spawned
+/// - t=~2.7 s    marker write #2, drop
+/// - t=~4.8 s    watchdog fires, SIGKILL — max_restarts: 1 exhausted
+/// - node_results['hang-after-init'] → Err(…Signal(9)…)
+///
+/// 10 s stop_after gives ~5 s of headroom above the ~5 s expected
+/// total runtime, so the assertion lands on behavior not stop_after.
+#[tokio::test(flavor = "multi_thread")]
+async fn health_check_timeout_exhausts_restart_budget() {
+    let status = std::process::Command::new("cargo")
+        .args(["build", "-p", "hang-after-init-node"])
+        .status()
+        .expect("failed to build hang-after-init-node");
+    assert!(status.success(), "hang-after-init-node build failed");
+
+    let marker = Path::new("/tmp/dora-health-check-cycle.log");
+    let _ = std::fs::remove_file(marker);
+
+    let dataflow_path =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/dataflows/health-check-cycle.yml");
+
+    let result = Daemon::run_dataflow(
+        &dataflow_path,
+        None,
+        None,
+        SessionId::generate(),
+        false,
+        LogDestination::Tracing,
+        None,
+        Some(Duration::from_secs(10)),
+        false,
+    )
+    .await;
+
+    let dr = result.expect("dataflow should complete");
+    eprintln!(
+        "dataflow completed with {} node results",
+        dr.node_results.len()
+    );
+    for (id, r) in &dr.node_results {
+        eprintln!("  {id}: {r:?}");
+    }
+
+    let contents = std::fs::read_to_string(marker)
+        .expect("marker file should exist — the node writes it on every spawn");
+    let incarnations = contents.lines().count();
+    let _ = std::fs::remove_file(marker);
+    eprintln!("hang-after-init-node incarnations observed: {incarnations}");
+
+    // Core contract: with max_restarts=1 the daemon spawns the node
+    // exactly twice (initial + one respawn). A regression that lost
+    // track of the restart budget across health-check kills would
+    // either loop forever (>>2) or stop at 1.
+    assert_eq!(
+        incarnations, 2,
+        "expected exactly 2 incarnations (initial + 1 respawn), got {incarnations}. marker:\n{contents}"
+    );
+
+    // After exhausting max_restarts the daemon must record an Err
+    // for the node. Same assertion class as
+    // `max_restarts_exhaustion_marks_node_failed` but driven by
+    // health-check SIGKILL rather than self-inflicted panics.
+    let node_result = dr
+        .node_results
+        .get(&"hang-after-init".to_string().into())
+        .expect("hang-after-init should be in node_results");
+    assert!(
+        node_result.is_err(),
+        "after two health-check SIGKILLs with max_restarts: 1, expected Err; got {node_result:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes **#1668**. PR #1648 only covered the *first* SIGKILL from the health-check watchdog. The full restart-budget cycle was deferred because my experiments at the time suggested the daemon "didn't cleanly re-enter the watchdog path for the respawn."

Revisiting with more generous timing: the blocker was a pure timing race, not a daemon bug. With a 0.5 s `health_check_timeout`, `init_from_env` (~500 ms cold spawn) and the marker write race the watchdog, so the first incarnation's marker never lands and the respawn's doesn't either. Bumping to 2 s — matching the pattern already in `health_check_timeout_sigkills_unresponsive_node` — lets both incarnations finish bookkeeping before the watchdog fires. Full cycle runs cleanly inside a 10 s `stop_after`.

## What's new

**Fixture** `tests/dataflows/health-check-cycle.yml`:

```yaml
restart_policy: on-failure
max_restarts: 1
health_check_timeout: 2.0
restart_delay: 0.1
```

**Test** `health_check_timeout_exhausts_restart_budget` asserts:
- Exactly **2 incarnations** (initial + 1 respawn per `max_restarts: 1`)
- Final `node_result` is `Err` (SIGKILL after exhaustion)

## Cycle timing observed locally

| Time | Event |
|---|---|
| t=0 | first incarnation spawned |
| t=~0.5 s | init_from_env, marker write, drop(events)+drop(node) |
| t=~2.1 s | watchdog fires, SIGKILL, `restart_delay: 0.1` |
| t=~2.2 s | second incarnation spawned |
| t=~2.7 s | marker write #2, drop |
| t=~4.8 s | watchdog fires, SIGKILL — `max_restarts: 1` exhausted |
| **node_result** | `Err(…Signal(9)…)` |

Total ~6.5 s including Tokio teardown. 10 s `stop_after` gives ~3.5 s of headroom.

## Verification

```
$ cargo test --test fault-tolerance-e2e -- --test-threads=1
…
test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 91.58s
```

11 passing tests (was 10 before; 9 after the #1669 legacy removal; +1 from this PR). No regressions.

`make qa-fast` green.

## Task #10 closure

Task #10 (#1631 follow-ups) had two items:
1. Full kill→respawn→kill cycle under health-check SIGKILL — **this PR**.
2. Rename/delete legacy `input_timeout_closes_stale_input` — **#1669 via PR #1670**.

Both shipped. Task can be closed once both PRs merge.

## Test plan

- [x] `cargo test --test fault-tolerance-e2e -- --test-threads=1` ⇒ 11/11 locally
- [x] `make qa-fast` green
- [x] New test passes in ~6 s; marker shows 2 incarnations; node_result is Err
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
