### PR TITLE
ci: share cache between test and contract-tests, bump timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,8 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: workspace-test
       - name: Check
         run: cargo check --all
       - name: Build (excluding Python packages)
@@ -529,13 +531,15 @@ jobs:
     name: Semantic contract tests
     runs-on: ubuntu-latest
     needs: test
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: workspace-test
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"


### PR DESCRIPTION
## Summary
- Semantic contract tests job was cancelling at its 20-min timeout: ~18m40s cold compile, ~1.5 min tests.
- Cancelled runs don't save cache, so every run was cold — 5 consecutive cancellations.
- Add `shared-key: workspace-test` to both `test` and `contract-tests` so contract-tests (needs: test) restores the workspace cache the test job just populated.
- Bump `timeout-minutes` 20 to 30 as a safety net for the first run that populates the shared cache on a new branch.

## Why this works
- `Swatinem/rust-cache@v2` keys are per-job by default. Two jobs in the same workflow don't share unless you give them the same `shared-key`.
- The action automatically includes runner OS in the final key, so the `test` matrix's macOS/Windows slots remain independent; only `test@ubuntu-latest` and `contract-tests` collide on key, which is the intent.
- `contract-tests` already depends on `test`; by the time it runs, the ubuntu `test` slot has saved a warm workspace cache.

## Test plan
- [ ] First push on this branch: test job populates cache (~6-8 min on cold branch), contract-tests restores and runs in ~3-5 min total (compile `dora-examples` on top of cached deps + run tests).
- [ ] Subsequent pushes: both jobs restore warm cache; contract-tests finishes well under 10 min.
- [ ] Confirm no regression on `test` job duration across the matrix.

Generated with Claude Code (https://claude.com/claude-code)
