### PR TITLE
refactor(cli): replace positional params on build() with BuildConfig (#1675)

### DIFF
--- a/apis/python/cli/src/lib.rs
+++ b/apis/python/cli/src/lib.rs
@@ -28,6 +28,7 @@ pub fn build(
     force_local: bool,
 ) -> eyre::Result<()> {
     dora_cli::build(dora_cli::BuildConfig {
+        dataflow: dataflow_path,
         coordinator_addr: coordinator_addr
             .map(|addr| addr.parse())
             .transpose()
@@ -35,7 +36,7 @@ pub fn build(
         coordinator_port,
         uv: uv.unwrap_or_default(),
         force_local,
-        ..dora_cli::BuildConfig::new(dataflow_path)
+        ..Default::default()
     })
 }
 

--- a/apis/python/cli/src/lib.rs
+++ b/apis/python/cli/src/lib.rs
@@ -27,22 +27,16 @@ pub fn build(
     coordinator_port: Option<u16>,
     force_local: bool,
 ) -> eyre::Result<()> {
-    dora_cli::build(
-        dataflow_path,
-        coordinator_addr
+    dora_cli::build(dora_cli::BuildConfig {
+        coordinator_addr: coordinator_addr
             .map(|addr| addr.parse())
             .transpose()
             .wrap_err("invalid coordinator_addr")?,
         coordinator_port,
-        uv.unwrap_or_default(),
+        uv: uv.unwrap_or_default(),
         force_local,
-        false,
-        false,
-        false,
-        None,
-        false,
-        None,
-    )
+        ..dora_cli::BuildConfig::new(dataflow_path)
+    })
 }
 
 /// Run a Dataflow, exactly the same way as `dora run` command line tool.

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -798,22 +798,16 @@ pub fn build(
     coordinator_port: Option<u16>,
     force_local: bool,
 ) -> eyre::Result<()> {
-    dora_cli::build(
-        dataflow_path,
-        coordinator_addr
+    dora_cli::build(dora_cli::BuildConfig {
+        coordinator_addr: coordinator_addr
             .map(|addr| addr.parse())
             .transpose()
             .wrap_err("invalid coordinator_addr")?,
         coordinator_port,
-        uv.unwrap_or_default(),
+        uv: uv.unwrap_or_default(),
         force_local,
-        false,
-        false,
-        false,
-        None,
-        false,
-        None,
-    )
+        ..dora_cli::BuildConfig::new(dataflow_path)
+    })
 }
 
 /// Run a Dataflow, exactly the same way as `dora run` command line tool.

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -799,6 +799,7 @@ pub fn build(
     force_local: bool,
 ) -> eyre::Result<()> {
     dora_cli::build(dora_cli::BuildConfig {
+        dataflow: dataflow_path,
         coordinator_addr: coordinator_addr
             .map(|addr| addr.parse())
             .transpose()
@@ -806,7 +807,7 @@ pub fn build(
         coordinator_port,
         uv: uv.unwrap_or_default(),
         force_local,
-        ..dora_cli::BuildConfig::new(dataflow_path)
+        ..Default::default()
     })
 }
 

--- a/binaries/cli/src/command/build/mod.rs
+++ b/binaries/cli/src/command/build/mod.rs
@@ -114,36 +114,83 @@ pub struct Build {
 impl Executable for Build {
     fn execute(self) -> eyre::Result<()> {
         default_tracing()?;
-        build(
-            self.dataflow,
-            self.coordinator_addr,
-            self.coordinator_port,
-            self.uv,
-            self.local,
-            self.strict_types,
-            self.locked,
-            self.write_lockfile,
-            self.lockfile,
-            self.parallel,
-            None,
-        )
+        build(BuildConfig {
+            coordinator_addr: self.coordinator_addr,
+            coordinator_port: self.coordinator_port,
+            uv: self.uv,
+            force_local: self.local,
+            strict_types: self.strict_types,
+            locked: self.locked,
+            write_lockfile: self.write_lockfile,
+            lockfile_override: self.lockfile,
+            parallel: self.parallel,
+            ..BuildConfig::new(self.dataflow)
+        })
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-pub fn build(
-    dataflow: String,
-    coordinator_addr: Option<IpAddr>,
-    coordinator_port: Option<u16>,
-    uv: bool,
-    force_local: bool,
-    strict_types: bool,
-    locked: bool,
-    write_lockfile: bool,
-    lockfile_override: Option<PathBuf>,
-    parallel: bool,
-    working_dir_override: Option<PathBuf>,
-) -> eyre::Result<()> {
+/// Configuration for a [`build`] invocation. Construct via
+/// [`BuildConfig::new`] and override only the fields you care about
+/// using struct-update syntax:
+///
+/// ```ignore
+/// build(BuildConfig {
+///     uv: true,
+///     force_local: true,
+///     ..BuildConfig::new(path)
+/// })?;
+/// ```
+#[derive(Debug, Clone)]
+pub struct BuildConfig {
+    pub dataflow: String,
+    pub coordinator_addr: Option<IpAddr>,
+    pub coordinator_port: Option<u16>,
+    pub uv: bool,
+    pub force_local: bool,
+    pub strict_types: bool,
+    pub locked: bool,
+    pub write_lockfile: bool,
+    pub lockfile_override: Option<PathBuf>,
+    pub parallel: bool,
+    /// See `binaries/cli/src/command/run.rs::Run::working_dir` for why
+    /// this exists — `dora record` rewrites the YAML into /tmp but the
+    /// cargo invocations must still resolve `Cargo.toml` from the
+    /// original source directory.
+    pub working_dir_override: Option<PathBuf>,
+}
+
+impl BuildConfig {
+    pub fn new(dataflow: String) -> Self {
+        Self {
+            dataflow,
+            coordinator_addr: None,
+            coordinator_port: None,
+            uv: false,
+            force_local: false,
+            strict_types: false,
+            locked: false,
+            write_lockfile: false,
+            lockfile_override: None,
+            parallel: false,
+            working_dir_override: None,
+        }
+    }
+}
+
+pub fn build(cfg: BuildConfig) -> eyre::Result<()> {
+    let BuildConfig {
+        dataflow,
+        coordinator_addr,
+        coordinator_port,
+        uv,
+        force_local,
+        strict_types,
+        locked,
+        write_lockfile,
+        lockfile_override,
+        parallel,
+        working_dir_override,
+    } = cfg;
     let dataflow_path = resolve_dataflow(dataflow).context("could not resolve dataflow")?;
     if lockfile_override.is_some() && !(locked || write_lockfile) {
         eyre::bail!("`--lockfile` requires either `--locked` or `--write-lockfile`");

--- a/binaries/cli/src/command/build/mod.rs
+++ b/binaries/cli/src/command/build/mod.rs
@@ -115,6 +115,7 @@ impl Executable for Build {
     fn execute(self) -> eyre::Result<()> {
         default_tracing()?;
         build(BuildConfig {
+            dataflow: self.dataflow,
             coordinator_addr: self.coordinator_addr,
             coordinator_port: self.coordinator_port,
             uv: self.uv,
@@ -124,23 +125,23 @@ impl Executable for Build {
             write_lockfile: self.write_lockfile,
             lockfile_override: self.lockfile,
             parallel: self.parallel,
-            ..BuildConfig::new(self.dataflow)
+            ..Default::default()
         })
     }
 }
 
-/// Configuration for a [`build`] invocation. Construct via
-/// [`BuildConfig::new`] and override only the fields you care about
-/// using struct-update syntax:
+/// Configuration for a [`build`] invocation. Set `dataflow` and
+/// override only the fields you care about using struct-update syntax:
 ///
 /// ```ignore
 /// build(BuildConfig {
+///     dataflow: path,
 ///     uv: true,
 ///     force_local: true,
-///     ..BuildConfig::new(path)
+///     ..Default::default()
 /// })?;
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct BuildConfig {
     pub dataflow: String,
     pub coordinator_addr: Option<IpAddr>,
@@ -152,29 +153,11 @@ pub struct BuildConfig {
     pub write_lockfile: bool,
     pub lockfile_override: Option<PathBuf>,
     pub parallel: bool,
-    /// See `binaries/cli/src/command/run.rs::Run::working_dir` for why
-    /// this exists — `dora record` rewrites the YAML into /tmp but the
-    /// cargo invocations must still resolve `Cargo.toml` from the
-    /// original source directory.
+    /// Overrides the working directory for cargo invocations and
+    /// module expansion. Needed when the dataflow path points at a
+    /// rewritten copy (e.g. a tempfile) whose parent can't resolve the
+    /// original `build:` directives or relative node binaries.
     pub working_dir_override: Option<PathBuf>,
-}
-
-impl BuildConfig {
-    pub fn new(dataflow: String) -> Self {
-        Self {
-            dataflow,
-            coordinator_addr: None,
-            coordinator_port: None,
-            uv: false,
-            force_local: false,
-            strict_types: false,
-            locked: false,
-            write_lockfile: false,
-            lockfile_override: None,
-            parallel: false,
-            working_dir_override: None,
-        }
-    }
 }
 
 pub fn build(cfg: BuildConfig) -> eyre::Result<()> {

--- a/binaries/cli/src/command/build/mod.rs
+++ b/binaries/cli/src/command/build/mod.rs
@@ -174,6 +174,15 @@ pub fn build(cfg: BuildConfig) -> eyre::Result<()> {
         parallel,
         working_dir_override,
     } = cfg;
+    // `BuildConfig` derives `Default` so `..Default::default()` works at
+    // call sites, but that gives `dataflow: String::new()` which would
+    // fail late with a confusing "failed to read ``" error. Catch it up
+    // front with a clear message.
+    if dataflow.is_empty() {
+        eyre::bail!(
+            "BuildConfig::dataflow is empty — set it to a YAML path or URL before calling build()"
+        );
+    }
     let dataflow_path = resolve_dataflow(dataflow).context("could not resolve dataflow")?;
     if lockfile_override.is_some() && !(locked || write_lockfile) {
         eyre::bail!("`--lockfile` requires either `--locked` or `--write-lockfile`");

--- a/binaries/cli/src/command/mod.rs
+++ b/binaries/cli/src/command/mod.rs
@@ -28,7 +28,7 @@ mod trace;
 mod up;
 mod validate;
 
-pub use build::build;
+pub use build::{BuildConfig, build};
 pub use run::{Run, run};
 
 use build::Build;

--- a/binaries/cli/src/command/run.rs
+++ b/binaries/cli/src/command/run.rs
@@ -175,13 +175,14 @@ impl Executable for Run {
         let dataflow_path =
             resolve_dataflow(self.dataflow.clone()).context("could not resolve dataflow")?;
         build_dataflow(BuildConfig {
+            dataflow: dataflow_path.to_string_lossy().into_owned(),
             uv: self.uv,
             force_local: true,
             locked: self.locked,
             write_lockfile: self.write_lockfile,
             lockfile_override: self.lockfile.clone(),
             working_dir_override: self.working_dir.clone(),
-            ..BuildConfig::new(dataflow_path.to_string_lossy().into_owned())
+            ..Default::default()
         })
         .context("failed to build dataflow before run")?;
         let dataflow_session = DataflowSession::read_session(&dataflow_path)

--- a/binaries/cli/src/command/run.rs
+++ b/binaries/cli/src/command/run.rs
@@ -4,7 +4,7 @@
 
 use super::{Executable, system::status::daemon_running};
 use crate::{
-    LOCALHOST, build as build_dataflow,
+    BuildConfig, LOCALHOST, build as build_dataflow,
     common::{
         canonicalize_working_dir, connect_with_retry, error_indicates_dataflow_finished,
         handle_dataflow_result, resolve_dataflow, working_dir_or_parent, write_events_to,
@@ -174,19 +174,15 @@ impl Executable for Run {
 
         let dataflow_path =
             resolve_dataflow(self.dataflow.clone()).context("could not resolve dataflow")?;
-        build_dataflow(
-            dataflow_path.to_string_lossy().into_owned(),
-            None,
-            None,
-            self.uv,
-            true,
-            false,
-            self.locked,
-            self.write_lockfile,
-            self.lockfile.clone(),
-            false, // sequential build for `dora run`
-            self.working_dir.clone(),
-        )
+        build_dataflow(BuildConfig {
+            uv: self.uv,
+            force_local: true,
+            locked: self.locked,
+            write_lockfile: self.write_lockfile,
+            lockfile_override: self.lockfile.clone(),
+            working_dir_override: self.working_dir.clone(),
+            ..BuildConfig::new(dataflow_path.to_string_lossy().into_owned())
+        })
         .context("failed to build dataflow before run")?;
         let dataflow_session = DataflowSession::read_session(&dataflow_path)
             .context("failed to read DataflowSession")?;

--- a/binaries/cli/src/lib.rs
+++ b/binaries/cli/src/lib.rs
@@ -13,7 +13,7 @@ mod template;
 mod ws_client;
 pub use ws_client::WsSession;
 
-pub use command::build;
+pub use command::{BuildConfig, build};
 pub use command::{Executable, Run as RunCommand, run};
 
 /// Default address for *connecting* to a coordinator (client side).

--- a/examples/benchmark/run.rs
+++ b/examples/benchmark/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run};
+use dora_cli::{BuildConfig, build, run};
 use eyre::Context;
 use std::path::Path;
 
@@ -7,18 +7,11 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build(
-        "dataflow.yml".to_string(),
-        None,
-        None,
-        false,
-        true,
-        false,
-        false,
-        false,
-        None,
-        false,
-    )?;
+    build(BuildConfig {
+        dataflow: "dataflow.yml".to_string(),
+        force_local: true,
+        ..Default::default()
+    })?;
 
     run("dataflow.yml".to_string(), false)?;
 

--- a/examples/python-dataflow/run.rs
+++ b/examples/python-dataflow/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run as dora_run};
+use dora_cli::{BuildConfig, build, run as dora_run};
 use eyre::WrapErr;
 use std::path::Path;
 
@@ -7,18 +7,12 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build(
-        "dataflow.yml".to_string(),
-        None,
-        None,
-        true,
-        true,
-        false,
-        false,
-        false,
-        None,
-        false,
-    )?;
+    build(BuildConfig {
+        dataflow: "dataflow.yml".to_string(),
+        uv: true,
+        force_local: true,
+        ..Default::default()
+    })?;
 
     dora_run("dataflow.yml".to_string(), true)?;
 

--- a/examples/python-operator-dataflow/run.rs
+++ b/examples/python-operator-dataflow/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run as dora_run};
+use dora_cli::{BuildConfig, build, run as dora_run};
 use eyre::WrapErr;
 use std::path::Path;
 
@@ -7,18 +7,12 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build(
-        "dataflow.yml".to_string(),
-        None,
-        None,
-        true,
-        true,
-        false,
-        false,
-        false,
-        None,
-        false,
-    )?;
+    build(BuildConfig {
+        dataflow: "dataflow.yml".to_string(),
+        uv: true,
+        force_local: true,
+        ..Default::default()
+    })?;
 
     dora_run("dataflow.yml".to_string(), true)?;
 

--- a/examples/ros2-bridge/python/turtle/run.rs
+++ b/examples/ros2-bridge/python/turtle/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run as dora_run};
+use dora_cli::{BuildConfig, build, run as dora_run};
 use eyre::WrapErr;
 use std::path::Path;
 
@@ -9,18 +9,12 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build(
-        "dataflow.yml".to_string(),
-        None,
-        None,
-        true,
-        true,
-        false,
-        false,
-        false,
-        None,
-        false,
-    )?;
+    build(BuildConfig {
+        dataflow: "dataflow.yml".to_string(),
+        uv: true,
+        force_local: true,
+        ..Default::default()
+    })?;
 
     let dataflow_task = std::thread::spawn(|| {
         dora_run("dataflow.yml".to_string(), true).unwrap();

--- a/examples/ros2-bridge/rust/service-client/run.rs
+++ b/examples/ros2-bridge/rust/service-client/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run};
+use dora_cli::{BuildConfig, build, run};
 use eyre::Context;
 use std::path::Path;
 
@@ -9,18 +9,11 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join("../../../").join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build(
-        "dataflow.yml".to_string(),
-        None,
-        None,
-        false,
-        true,
-        false,
-        false,
-        false,
-        None,
-        false,
-    )?;
+    build(BuildConfig {
+        dataflow: "dataflow.yml".to_string(),
+        force_local: true,
+        ..Default::default()
+    })?;
 
     let dataflow_task = std::thread::spawn(|| {
         run("dataflow.yml".to_string(), false).unwrap();

--- a/examples/ros2-bridge/rust/service-server/run.rs
+++ b/examples/ros2-bridge/rust/service-server/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run};
+use dora_cli::{BuildConfig, build, run};
 use eyre::Context;
 use std::{path::Path, sync::mpsc};
 use tokio;
@@ -10,18 +10,11 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join("../../../").join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build(
-        "dataflow.yml".to_string(),
-        None,
-        None,
-        false,
-        true,
-        false,
-        false,
-        false,
-        None,
-        false,
-    )?;
+    build(BuildConfig {
+        dataflow: "dataflow.yml".to_string(),
+        force_local: true,
+        ..Default::default()
+    })?;
 
     let (finish_tx, finish_rx) = mpsc::channel();
     let dataflow_task = std::thread::spawn(move || {

--- a/examples/ros2-bridge/rust/topic-pub/run.rs
+++ b/examples/ros2-bridge/rust/topic-pub/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run};
+use dora_cli::{BuildConfig, build, run};
 use eyre::Context;
 use std::path::Path;
 
@@ -9,18 +9,11 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join("../../../").join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build(
-        "dataflow.yml".to_string(),
-        None,
-        None,
-        false,
-        true,
-        false,
-        false,
-        false,
-        None,
-        false,
-    )?;
+    build(BuildConfig {
+        dataflow: "dataflow.yml".to_string(),
+        force_local: true,
+        ..Default::default()
+    })?;
 
     let dataflow_task = std::thread::spawn(|| {
         run("dataflow.yml".to_string(), false).unwrap();

--- a/examples/ros2-bridge/rust/topic-sub/run.rs
+++ b/examples/ros2-bridge/rust/topic-sub/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run};
+use dora_cli::{BuildConfig, build, run};
 use eyre::Context;
 use std::path::Path;
 
@@ -9,18 +9,11 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join("../../../").join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build(
-        "dataflow.yml".to_string(),
-        None,
-        None,
-        false,
-        true,
-        false,
-        false,
-        false,
-        None,
-        false,
-    )?;
+    build(BuildConfig {
+        dataflow: "dataflow.yml".to_string(),
+        force_local: true,
+        ..Default::default()
+    })?;
 
     let dataflow_task = std::thread::spawn(|| {
         run("dataflow.yml".to_string(), false).unwrap();

--- a/examples/ros2-bridge/rust/turtle/run.rs
+++ b/examples/ros2-bridge/rust/turtle/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run};
+use dora_cli::{BuildConfig, build, run};
 use eyre::Context;
 use std::path::Path;
 
@@ -9,18 +9,11 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join("../../../").join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build(
-        "dataflow.yml".to_string(),
-        None,
-        None,
-        false,
-        true,
-        false,
-        false,
-        false,
-        None,
-        false,
-    )?;
+    build(BuildConfig {
+        dataflow: "dataflow.yml".to_string(),
+        force_local: true,
+        ..Default::default()
+    })?;
 
     let dataflow_task = std::thread::spawn(|| {
         run("dataflow.yml".to_string(), false).unwrap();

--- a/examples/rust-dataflow-git/run.rs
+++ b/examples/rust-dataflow-git/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run};
+use dora_cli::{BuildConfig, build, run};
 use eyre::Context;
 use std::path::Path;
 
@@ -14,18 +14,11 @@ fn main() -> eyre::Result<()> {
         "dataflow.yml".to_string()
     };
 
-    build(
-        dataflow.clone(),
-        None,
-        None,
-        false,
-        true,
-        false,
-        false,
-        false,
-        None,
-        false,
-    )?;
+    build(BuildConfig {
+        dataflow: dataflow.clone(),
+        force_local: true,
+        ..Default::default()
+    })?;
 
     run(dataflow, false)?;
 

--- a/examples/rust-dataflow-url/README.md
+++ b/examples/rust-dataflow-url/README.md
@@ -22,10 +22,14 @@ timer (10ms) --> rust-node --> random --> rust-status-node --> status --> rust-s
 The `run.rs` harness calls dora CLI functions as a library:
 
 ```rust
-use dora_cli::{build, run};
+use dora_cli::{BuildConfig, build, run};
 
 fn main() -> eyre::Result<()> {
-    build("dataflow.yml".to_string(), None, None, false, true)?;
+    build(BuildConfig {
+        dataflow: "dataflow.yml".to_string(),
+        force_local: true,
+        ..Default::default()
+    })?;
     run("dataflow.yml".to_string(), false)?;
     Ok(())
 }

--- a/examples/rust-dataflow-url/run.rs
+++ b/examples/rust-dataflow-url/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run};
+use dora_cli::{BuildConfig, build, run};
 use eyre::Context;
 use std::path::Path;
 
@@ -7,18 +7,11 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build(
-        "dataflow.yml".to_string(),
-        None,
-        None,
-        false,
-        true,
-        false,
-        false,
-        false,
-        None,
-        false,
-    )?;
+    build(BuildConfig {
+        dataflow: "dataflow.yml".to_string(),
+        force_local: true,
+        ..Default::default()
+    })?;
 
     run("dataflow.yml".to_string(), false)?;
 

--- a/examples/rust-dataflow/run.rs
+++ b/examples/rust-dataflow/run.rs
@@ -1,4 +1,4 @@
-use dora_cli::{build, run};
+use dora_cli::{BuildConfig, build, run};
 use eyre::Context;
 use std::path::Path;
 
@@ -14,18 +14,11 @@ fn main() -> eyre::Result<()> {
         "dataflow.yml".to_string()
     };
 
-    build(
-        dataflow.clone(),
-        None,
-        None,
-        false,
-        true,
-        false,
-        false,
-        false,
-        None,
-        false,
-    )?;
+    build(BuildConfig {
+        dataflow: dataflow.clone(),
+        force_local: true,
+        ..Default::default()
+    })?;
 
     run(dataflow, false)?;
 


### PR DESCRIPTION
Closes #1675.

## Summary

`dora_cli::build()` had grown to 12 positional parameters, with `#[allow(clippy::too_many_arguments)]` papering over the sprawl. Three of the four call sites passed a trailing run of `false, false, false, None, false, None` to get default behavior. Any future reorder or param insertion is a silent correctness bug — the compiler only catches type mismatches, not semantic ones (a bool in the wrong slot compiles fine).

## Change

Introduce a `BuildConfig` struct + `BuildConfig::new(dataflow)` constructor. Callers opt into non-default fields explicitly via struct-update syntax:

```rust
build(BuildConfig {
    uv: true,
    force_local: true,
    ..BuildConfig::new(path)
})?;
```

Before vs. after at the Run::execute call site:

```diff
-build_dataflow(
-    dataflow_path.to_string_lossy().into_owned(),
-    None,
-    None,
-    self.uv,
-    true,
-    false,
-    self.locked,
-    self.write_lockfile,
-    self.lockfile.clone(),
-    false,
-    self.working_dir.clone(),
-)
+build_dataflow(BuildConfig {
+    uv: self.uv,
+    force_local: true,
+    locked: self.locked,
+    write_lockfile: self.write_lockfile,
+    lockfile_override: self.lockfile.clone(),
+    working_dir_override: self.working_dir.clone(),
+    ..BuildConfig::new(dataflow_path.to_string_lossy().into_owned())
+})
```

## Call sites updated

- `binaries/cli/src/command/build/mod.rs` — `Build::execute`
- `binaries/cli/src/command/run.rs` — `Run::execute`
- `apis/python/cli/src/lib.rs` — PyO3 wrapper
- `apis/python/node/src/lib.rs` — PyO3 wrapper (near-duplicate of the cli one; consolidation deferred, not in scope)

`BuildConfig` and `build` are re-exported from `dora_cli::`. Dropped the `#[allow(clippy::too_many_arguments)]` escape hatch.

## No behavior change

This is a pure refactor. Verified:

- `cargo check --all` (excl. Python) — green
- `cargo clippy --all --exclude <py packages> -- -D warnings` — green
- `cargo fmt --all --check` — green
- `cargo test -p dora-cli --lib common::` — 6/6 pass
- `dora record examples/rust-dataflow/dataflow.yml -o /tmp/rd-refactor.drec` — produces 58KB .drec end-to-end (regression-checks the #1673 fix landed in #1674).

## Test plan

- [x] Build + check green
- [x] fmt + clippy green
- [x] helper unit tests pass
- [x] `dora record` end-to-end smoke still green
- [ ] CI green on all platforms

Generated with Claude Code (https://claude.com/claude-code)


---

## Update (post-/review)

`/review` with Codex adversarial caught that **12 example binaries were already broken on `main`** — they still called the old positional `dora_cli::build()` signature. Pre-existing regression from #1674 which added the 11th positional param: CI only runs `cargo check --all`, which doesn't build `[[example]]` targets, so the break shipped silently.

Scope expanded to cover the pre-existing breakage:

- 12 `examples/**/run.rs` binaries migrated to `BuildConfig`
- `examples/rust-dataflow-url/README.md` code snippet updated
- Added early `bail!` in `build()` for empty `dataflow` (so `..Default::default()` without setting `dataflow` gives a clear error instead of a deep-stack file-not-found)

Filed follow-up issue **#1679**: CI should run `cargo check --examples`.
