### PR TITLE
ci: add `cargo check --examples` gate to the test job (#1679)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,13 @@ jobs:
           shared-key: workspace-test
       - name: Check
         run: cargo check --all
+      # `cargo check --all` does NOT build `[[example]]` targets —
+      # #1674 and #1677 both silently broke examples under `main`
+      # because there was no CI gate that compiled them. Cheap to run
+      # (<30s on cached builds); catches signature breakage at the
+      # source tree's most common integration surface.
+      - name: Check examples compile
+        run: cargo check --examples
       - name: Build (excluding Python packages)
         run: >
           cargo build --all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,11 +77,10 @@ jobs:
           shared-key: workspace-test
       - name: Check
         run: cargo check --all
-      # `cargo check --all` does NOT build `[[example]]` targets —
-      # #1674 and #1677 both silently broke examples under `main`
-      # because there was no CI gate that compiled them. Cheap to run
-      # (<30s on cached builds); catches signature breakage at the
-      # source tree's most common integration surface.
+      # `cargo check --all` does NOT build `[[example]]` targets, so
+      # signature breaks in `dora_cli::build` / `dora_cli::run` ship
+      # silently otherwise — example binaries are a common integration
+      # surface and deserve their own compile gate.
       - name: Check examples compile
         run: cargo check --examples
       - name: Build (excluding Python packages)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,11 @@ cargo test --all \
   --exclude dora-cli-api-python \
   --exclude dora-examples
 
+# 4. Example targets — `cargo check --all` does NOT build `[[example]]`
+# targets, so signature breaks in `dora_cli::build` / `dora_cli::run`
+# can ship silently otherwise. CI gates on this (#1680).
+cargo check --examples
+
 # Quick single-crate check while iterating:
 # cargo test -p <crate-name>
 ```


### PR DESCRIPTION
Closes #1679.

## Summary

`cargo check --all` does not build `[[example]]` targets. #1674 and #1677 both silently broke the example binaries on `main` — in both cases the break was only caught by adversarial review (`/simplify` then `/review` with Codex), after merging or just-before-merging.

Add `cargo check --examples` between `cargo check --all` and `cargo build --all` in the `test` job. Runs on all 3 platforms as part of the existing matrix, <30s on cached builds.

## Targets covered

`cargo check --examples` compiles all 11 `[[example]]` targets registered in root `Cargo.toml`:

- benchmark, c-dataflow, cmake-dataflow
- cxx-dataflow, cxx-arrow-dataflow
- multiple-daemons
- python-dataflow, python-operator-dataflow
- rust-dataflow, rust-dataflow-git, rust-dataflow-url

## Out of scope

ROS2 example `run.rs` harnesses (e.g., `examples/ros2-bridge/rust/turtle/run.rs`) are loose `.rs` files, not registered as `[[example]]` targets. They won't be caught by this gate. Converting them is worth a separate issue, but ROS2 harnesses would also need ROS2 runtime on CI to actually run — compile-only coverage is the more targeted next step.

## Test plan

- [x] `cargo check --examples` passes locally
- [x] `cargo fmt --all --check` green
- [ ] CI green across all 3 platforms

Generated with Claude Code (https://claude.com/claude-code)
