### PR TITLE
refactor(cli): extract BuildConfig::from_python_args helper (#1678)

### DIFF
--- a/apis/python/cli/src/lib.rs
+++ b/apis/python/cli/src/lib.rs
@@ -27,7 +27,7 @@ pub fn build(
     coordinator_port: Option<u16>,
     force_local: bool,
 ) -> eyre::Result<()> {
-    dora_cli::build(dora_cli::BuildConfig::from_python_args(
+    dora_cli::build(dora_cli::BuildConfig::from_str_args(
         dataflow_path,
         uv,
         coordinator_addr,

--- a/apis/python/cli/src/lib.rs
+++ b/apis/python/cli/src/lib.rs
@@ -27,17 +27,13 @@ pub fn build(
     coordinator_port: Option<u16>,
     force_local: bool,
 ) -> eyre::Result<()> {
-    dora_cli::build(dora_cli::BuildConfig {
-        dataflow: dataflow_path,
-        coordinator_addr: coordinator_addr
-            .map(|addr| addr.parse())
-            .transpose()
-            .wrap_err("invalid coordinator_addr")?,
+    dora_cli::build(dora_cli::BuildConfig::from_python_args(
+        dataflow_path,
+        uv,
+        coordinator_addr,
         coordinator_port,
-        uv: uv.unwrap_or_default(),
         force_local,
-        ..Default::default()
-    })
+    )?)
 }
 
 /// Run a Dataflow, exactly the same way as `dora run` command line tool.

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -798,17 +798,13 @@ pub fn build(
     coordinator_port: Option<u16>,
     force_local: bool,
 ) -> eyre::Result<()> {
-    dora_cli::build(dora_cli::BuildConfig {
-        dataflow: dataflow_path,
-        coordinator_addr: coordinator_addr
-            .map(|addr| addr.parse())
-            .transpose()
-            .wrap_err("invalid coordinator_addr")?,
+    dora_cli::build(dora_cli::BuildConfig::from_python_args(
+        dataflow_path,
+        uv,
+        coordinator_addr,
         coordinator_port,
-        uv: uv.unwrap_or_default(),
         force_local,
-        ..Default::default()
-    })
+    )?)
 }
 
 /// Run a Dataflow, exactly the same way as `dora run` command line tool.

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -798,7 +798,7 @@ pub fn build(
     coordinator_port: Option<u16>,
     force_local: bool,
 ) -> eyre::Result<()> {
-    dora_cli::build(dora_cli::BuildConfig::from_python_args(
+    dora_cli::build(dora_cli::BuildConfig::from_str_args(
         dataflow_path,
         uv,
         coordinator_addr,

--- a/binaries/cli/src/command/build/mod.rs
+++ b/binaries/cli/src/command/build/mod.rs
@@ -450,3 +450,54 @@ fn connect_to_coordinator_with_defaults(
     let coordinator_port = coordinator_port.unwrap_or(DORA_COORDINATOR_PORT_WS_DEFAULT);
     connect_to_coordinator((coordinator_addr, coordinator_port).into())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_str_args_parses_valid_coordinator_addr() {
+        let cfg = BuildConfig::from_str_args(
+            "dataflow.yml".into(),
+            None,
+            Some("127.0.0.1".into()),
+            None,
+            false,
+        )
+        .expect("valid IP should parse");
+        assert_eq!(
+            cfg.coordinator_addr,
+            Some("127.0.0.1".parse::<IpAddr>().unwrap())
+        );
+    }
+
+    #[test]
+    fn from_str_args_accepts_none_addr() {
+        let cfg = BuildConfig::from_str_args("dataflow.yml".into(), None, None, None, false)
+            .expect("None addr should be fine");
+        assert!(cfg.coordinator_addr.is_none());
+    }
+
+    #[test]
+    fn from_str_args_errors_on_invalid_addr() {
+        let err = BuildConfig::from_str_args(
+            "dataflow.yml".into(),
+            None,
+            Some("not-an-ip".into()),
+            None,
+            false,
+        )
+        .expect_err("malformed addr should error");
+        assert!(
+            err.to_string().contains("invalid coordinator_addr"),
+            "error should carry context: {err}"
+        );
+    }
+
+    #[test]
+    fn from_str_args_unwraps_uv_default_to_false() {
+        let cfg =
+            BuildConfig::from_str_args("dataflow.yml".into(), None, None, None, false).unwrap();
+        assert!(!cfg.uv, "uv should default to false when None");
+    }
+}

--- a/binaries/cli/src/command/build/mod.rs
+++ b/binaries/cli/src/command/build/mod.rs
@@ -161,11 +161,14 @@ pub struct BuildConfig {
 }
 
 impl BuildConfig {
-    /// Construct a `BuildConfig` from the string-typed argument shape
-    /// that the PyO3 Python bindings expose. Parses `coordinator_addr`
-    /// and returns a parse error if it isn't a valid IP. All other
-    /// fields default.
-    pub fn from_python_args(
+    /// Shared constructor for callers that marshal arguments as
+    /// strings (`coordinator_addr: Option<String>`) and optional
+    /// booleans (`uv: Option<bool>`) rather than as pre-parsed
+    /// `IpAddr` / `bool`. Keeps the `addr.parse()` + `unwrap_or_default`
+    /// glue in one place instead of duplicating it in every binding
+    /// that exposes a simplified build API (PyO3 today, potentially
+    /// a C FFI or WASM shim later).
+    pub fn from_str_args(
         dataflow: String,
         uv: Option<bool>,
         coordinator_addr: Option<String>,

--- a/binaries/cli/src/command/build/mod.rs
+++ b/binaries/cli/src/command/build/mod.rs
@@ -160,6 +160,32 @@ pub struct BuildConfig {
     pub working_dir_override: Option<PathBuf>,
 }
 
+impl BuildConfig {
+    /// Construct a `BuildConfig` from the string-typed argument shape
+    /// that the PyO3 Python bindings expose. Parses `coordinator_addr`
+    /// and returns a parse error if it isn't a valid IP. All other
+    /// fields default.
+    pub fn from_python_args(
+        dataflow: String,
+        uv: Option<bool>,
+        coordinator_addr: Option<String>,
+        coordinator_port: Option<u16>,
+        force_local: bool,
+    ) -> eyre::Result<Self> {
+        Ok(Self {
+            dataflow,
+            coordinator_addr: coordinator_addr
+                .map(|addr| addr.parse())
+                .transpose()
+                .wrap_err("invalid coordinator_addr")?,
+            coordinator_port,
+            uv: uv.unwrap_or_default(),
+            force_local,
+            ..Default::default()
+        })
+    }
+}
+
 pub fn build(cfg: BuildConfig) -> eyre::Result<()> {
     let BuildConfig {
         dataflow,


### PR DESCRIPTION
Closes #1678.

## Summary

After #1677, `apis/python/cli/src/lib.rs::build` and `apis/python/node/src/lib.rs::build` had identical bodies — both took the same string-typed argument shape and constructed the same `BuildConfig` (parsing `coordinator_addr`, unwrapping `uv`, etc.).

Deduplicate by adding `BuildConfig::from_python_args(...)` on `dora_cli`:

```rust
impl BuildConfig {
    pub fn from_python_args(
        dataflow: String,
        uv: Option<bool>,
        coordinator_addr: Option<String>,
        coordinator_port: Option<u16>,
        force_local: bool,
    ) -> eyre::Result<Self> { ... }
}
```

Both PyO3 wrappers become a single delegation:

```rust
dora_cli::build(dora_cli::BuildConfig::from_python_args(
    dataflow_path, uv, coordinator_addr, coordinator_port, force_local,
)?)
```

## Scope note

The two PyO3 `#[pyfunction]` + `#[pyo3(signature = ...)]` declarations stay separate by design. Each binding crate exports its own `build` symbol into its own Python module (`dora_cli.build` vs `dora.build`), so the macro wiring has to live in each crate. What was duplicated and now isn't is the **body**.

## Verification

- `cargo check --all` (excl. Python) — green
- `cargo check --examples` — green (11 `[[example]]` targets)
- `cargo fmt --all --check` — green
- `cargo clippy --all ... -- -D warnings` — green
- `dora record examples/rust-dataflow/dataflow.yml` — produces 58KB .drec end-to-end

## Test plan

- [x] Build + check green across workspace + examples
- [x] fmt + clippy green
- [x] `dora record` end-to-end smoke
- [ ] CI green on all platforms

Generated with Claude Code (https://claude.com/claude-code)
