### PR TITLE
fix(cli): dora stop/restart accept name positional + dora stop --all (#1683)

### DIFF
--- a/binaries/cli/src/command/restart.rs
+++ b/binaries/cli/src/command/restart.rs
@@ -14,10 +14,11 @@ use uuid::Uuid;
 ///
 /// If no id or name is provided, you will be able to choose between the running dataflows.
 pub struct Restart {
-    /// UUID of the dataflow that should be restarted
-    uuid: Option<Uuid>,
-    /// Name of the dataflow that should be restarted
-    #[clap(long, short = 'n')]
+    /// Name or UUID of the dataflow that should be restarted
+    #[clap(value_name = "NAME_OR_UUID")]
+    identifier: Option<String>,
+    /// Name of the dataflow (alternative to positional; kept for back-compat)
+    #[clap(long, short = 'n', conflicts_with = "identifier")]
     name: Option<String>,
     /// Kill the dataflow if it doesn't stop after the given duration before restarting
     #[clap(
@@ -39,12 +40,14 @@ impl Executable for Restart {
     fn execute(self) -> eyre::Result<()> {
         default_tracing()?;
         let session = self.coordinator.connect()?;
-        match (self.uuid, self.name) {
-            (Some(uuid), _) => restart_dataflow(uuid, self.grace_duration, self.force, &session),
-            (None, Some(name)) => {
-                restart_dataflow_by_name(name, self.grace_duration, self.force, &session)
-            }
-            (None, None) => restart_dataflow_interactive(self.grace_duration, self.force, &session),
+
+        let ident = self.identifier.or(self.name);
+        match ident {
+            Some(s) => match Uuid::parse_str(&s) {
+                Ok(uuid) => restart_dataflow(uuid, self.grace_duration, self.force, &session),
+                Err(_) => restart_dataflow_by_name(s, self.grace_duration, self.force, &session),
+            },
+            None => restart_dataflow_interactive(self.grace_duration, self.force, &session),
         }
     }
 }

--- a/binaries/cli/src/command/stop.rs
+++ b/binaries/cli/src/command/stop.rs
@@ -16,11 +16,15 @@ use uuid::Uuid;
 ///
 /// You could specify the strategy to stop the dataflow with `--grace-duration` or `--force`.
 pub struct Stop {
-    /// UUID of the dataflow that should be stopped
-    uuid: Option<Uuid>,
-    /// Name of the dataflow that should be stopped
-    #[clap(long, short = 'n')]
+    /// Name or UUID of the dataflow that should be stopped
+    #[clap(value_name = "NAME_OR_UUID", conflicts_with = "all")]
+    identifier: Option<String>,
+    /// Name of the dataflow (alternative to positional; kept for back-compat)
+    #[clap(long, short = 'n', conflicts_with_all = ["identifier", "all"])]
     name: Option<String>,
+    /// Stop every running dataflow.
+    #[clap(long, conflicts_with_all = ["identifier", "name"])]
+    all: bool,
     /// Kill the dataflow if it doesn't stop after the given duration
     ///
     /// Specifically, it does the following:
@@ -46,14 +50,52 @@ impl Executable for Stop {
     fn execute(self) -> eyre::Result<()> {
         default_tracing()?;
         let session = self.coordinator.connect()?;
-        match (self.uuid, self.name) {
-            (Some(uuid), _) => stop_dataflow(uuid, self.grace_duration, self.force, &session),
-            (None, Some(name)) => {
-                stop_dataflow_by_name(name, self.grace_duration, self.force, &session)
-            }
-            (None, None) => stop_dataflow_interactive(self.grace_duration, self.force, &session),
+
+        if self.all {
+            return stop_all(self.grace_duration, self.force, &session);
+        }
+
+        let ident = self.identifier.or(self.name);
+        match ident {
+            // Identifier parses as UUID -> dispatch by UUID. Otherwise treat
+            // as a dataflow name. Users who want strict name-only lookup can
+            // still use `-n/--name` (which takes the explicit-name path).
+            Some(s) => match Uuid::parse_str(&s) {
+                Ok(uuid) => stop_dataflow(uuid, self.grace_duration, self.force, &session),
+                Err(_) => stop_dataflow_by_name(s, self.grace_duration, self.force, &session),
+            },
+            None => stop_dataflow_interactive(self.grace_duration, self.force, &session),
         }
     }
+}
+
+fn stop_all(
+    grace_duration: Option<Duration>,
+    force: bool,
+    session: &WsSession,
+) -> eyre::Result<()> {
+    let list = query_running_dataflows(session).wrap_err("failed to query running dataflows")?;
+    let active = list.get_active();
+    if active.is_empty() {
+        println!("No dataflows are running.");
+        return Ok(());
+    }
+    let total = active.len();
+    let mut errors = Vec::new();
+    for entry in active {
+        if let Err(e) = stop_dataflow(entry.uuid, grace_duration, force, session) {
+            errors.push(format!("{}: {e}", entry.uuid));
+        }
+    }
+    if !errors.is_empty() {
+        bail!(
+            "{} of {total} dataflow(s) failed to stop:\n  {}",
+            errors.len(),
+            errors.join("\n  ")
+        );
+    }
+    println!("Stopped {total} dataflow(s).");
+    Ok(())
 }
 
 fn stop_dataflow_interactive(

--- a/examples/dynamic-add-remove/README.md
+++ b/examples/dynamic-add-remove/README.md
@@ -70,7 +70,7 @@ on the original `value` input.
 ### Step 5: Clean up
 
 ```bash
-dora stop --all
+dora stop demo
 dora down
 ```
 

--- a/examples/dynamic-agent-tools/README.md
+++ b/examples/dynamic-agent-tools/README.md
@@ -69,7 +69,7 @@ Back to echo-only. Calc requests go unanswered again.
 ### Step 4: Clean up
 
 ```bash
-dora stop --all
+dora stop agent-demo
 dora down
 ```
 


### PR DESCRIPTION
Closes #1683 (PR A split).

## Before

Walking through the dynamic-topology README snippets hit two different clap rejections:

```
$ dora stop demo
error: invalid value 'demo' for '[UUID]': invalid character: found `m` at 3

$ dora stop --all
error: unexpected argument '--all' found
```

Both forms were documented in user-facing READMEs and referenced from `tests/example-smoke.rs` cleanup (silently swallowing the error via `let _ = ...`).

## Change

- **`dora stop` positional** becomes `[NAME_OR_UUID]`. Parse at runtime: UUID → UUID dispatch, otherwise → name dispatch. `--name/-n` flag preserved for back-compat.
- **`dora stop --all`** is now a real flag. Iterates running dataflows, aggregates failures into a single error.
- **`dora restart`** gets the same positional change. No `--all` (restart-everything isn't a clean operation).
- README fixes: `examples/dynamic-add-remove/README.md` + `examples/dynamic-agent-tools/README.md` — clean-up snippet updated to a form that actually works.

Mutual exclusivity handled via clap `conflicts_with_all`:

```
$ dora stop demo --all
error: the argument '[NAME_OR_UUID]' cannot be used with '--all'

$ dora stop -n demo --all
error: the argument '--name <NAME>' cannot be used with '--all'
```

## No breaking changes

Every existing form still works:
- `dora stop <UUID>` ✓
- `dora stop --name <NAME>` ✓
- `dora stop -n <NAME>` ✓
- `dora restart <UUID>` ✓
- `dora restart --name <NAME>` ✓

## Verification

- **Arg-parse** (no coordinator): `dora stop demo`, `dora stop --all`, `dora stop <UUID>`, `dora restart demo` — all accepted. Conflict cases rejected with clear clap error.
- **E2E**: started a long-running `python-dataflow` with `--name longrunning`; `dora stop longrunning` transitioned it Running → Failed (same as UUID-based stop).
- `cargo fmt --all --check` green.
- `cargo clippy --all ... -- -D warnings` green.
- `cargo check --examples` green.
- `cargo test -p dora-cli --lib` 142/142 pass.

## Out of scope

PR B from the issue (relabel `<DATAFLOW>` → `<NAME_OR_UUID>` in `dora node add/remove/connect/disconnect` help text) stays as a follow-up. Docs-only, zero behavior change there.

## Test plan

- [x] All back-compat forms still work
- [x] Bare-name, `--all`, and conflict cases behave correctly
- [x] E2E stop works against a running dataflow
- [x] fmt + clippy green
- [ ] CI green

Generated with Claude Code (https://claude.com/claude-code)
