### PR TITLE
docs(cli): label --dataflow as NAME_OR_UUID on node add/remove/connect/disconnect (#1683 PR B)

### DIFF
--- a/binaries/cli/src/command/node/add.rs
+++ b/binaries/cli/src/command/node/add.rs
@@ -11,7 +11,8 @@ use std::path::PathBuf;
 pub struct Add {
     #[clap(flatten)]
     coordinator: CoordinatorOptions,
-    #[clap(long)]
+    /// Dataflow name or UUID to add the node to
+    #[clap(long, short = 'd', value_name = "NAME_OR_UUID")]
     dataflow: Option<String>,
     #[clap(long = "from-yaml")]
     from_yaml: PathBuf,

--- a/binaries/cli/src/command/node/connect.rs
+++ b/binaries/cli/src/command/node/connect.rs
@@ -14,7 +14,8 @@ use eyre::bail;
 pub struct Connect {
     #[clap(flatten)]
     coordinator: CoordinatorOptions,
-    #[clap(long)]
+    /// Dataflow name or UUID to add the mapping in
+    #[clap(long, short = 'd', value_name = "NAME_OR_UUID")]
     dataflow: Option<String>,
     /// Source in "node/output" format.
     source: String,

--- a/binaries/cli/src/command/node/disconnect.rs
+++ b/binaries/cli/src/command/node/disconnect.rs
@@ -14,7 +14,8 @@ use eyre::bail;
 pub struct Disconnect {
     #[clap(flatten)]
     coordinator: CoordinatorOptions,
-    #[clap(long)]
+    /// Dataflow name or UUID to remove the mapping from
+    #[clap(long, short = 'd', value_name = "NAME_OR_UUID")]
     dataflow: Option<String>,
     /// Source in "node/output" format.
     source: String,

--- a/binaries/cli/src/command/node/remove.rs
+++ b/binaries/cli/src/command/node/remove.rs
@@ -12,7 +12,8 @@ use eyre::bail;
 pub struct Remove {
     #[clap(flatten)]
     coordinator: CoordinatorOptions,
-    #[clap(long)]
+    /// Dataflow name or UUID to remove the node from
+    #[clap(long, short = 'd', value_name = "NAME_OR_UUID")]
     dataflow: Option<String>,
     node: String,
     /// Grace period in seconds before force-killing the node.


### PR DESCRIPTION
Issue #1683 PR B (docs-only follow-up split from #1685).

## Before

`dora node list/info/restart/stop` advertised `-d, --dataflow <NAME_OR_UUID>` with "Dataflow name or UUID" help text. The four dynamic-topology siblings didn't:

```
$ dora node add --help
      --dataflow <DATAFLOW>     # <-- opaque label; no hint a name works
$ dora node remove --help
      --dataflow <DATAFLOW>
$ dora node connect --help
      --dataflow <DATAFLOW>
$ dora node disconnect --help
      --dataflow <DATAFLOW>
```

All four already call `resolve_dataflow_identifier_interactive` and accept names just fine — it's only the help text that misled users.

## After

```
$ dora node add --help
  -d, --dataflow <NAME_OR_UUID>  Dataflow name or UUID to add the node to
$ dora node remove --help
  -d, --dataflow <NAME_OR_UUID>  Dataflow name or UUID to remove the node from
$ dora node connect --help
  -d, --dataflow <NAME_OR_UUID>  Dataflow name or UUID to add the mapping in
$ dora node disconnect --help
  -d, --dataflow <NAME_OR_UUID>  Dataflow name or UUID to remove the mapping from
```

Uniform label across all 8 `dora node` subcommands, plus the `-d` short flag on the four that were missing it.

## Scope

Zero behavior change. Clap attributes (`value_name`, `short = 'd'`, `///` doc comment) only. All 4 subcommands still accept both names and UUIDs exactly as they did before.

## Unrelated to #1682

#1682 is a daemon runtime bug that affects `dora node add` specifically. This PR doesn't touch that code path at all.

## Verification

- Built `dora` and checked `--help` output on all 4 subcommands (see above).
- `cargo fmt --all --check` green.
- `cargo clippy --all ... -- -D warnings` green.

## Test plan

- [x] `--help` shows new label on all 4 subcommands
- [x] fmt + clippy green
- [ ] CI green

Generated with Claude Code (https://claude.com/claude-code)
