### PR TITLE
refactor(qa): rename qa-tier1 -> qa-deep + add qa-nightly / qa-release-gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,7 @@ All three steps are required for every commit. Do NOT push without completing th
 The deeper QA gates — `make qa-full`, `make qa-deep`, `make qa-nightly`, `make qa-release-gate`, `make qa-coverage`, `make qa-mutants`, `make qa-semver` — are designed for **focused investigation and pre-release gating**, not the per-commit loop. Do not run them routinely, and do not add them to remote CI:
 
 - `make qa-full` (qa-fast + full tests + coverage) — ~5-10 minutes. Run before a significant push if you want extra confidence; coverage is too slow for every push.
-- `make qa-deep` (qa-full + mutation testing + semver) — ~15 minutes. Full Tier 1 PR gate, i.e. what CI runs on your PR, locally. (Alias: `make qa-tier1`, kept for back-compat.)
+- `make qa-deep` (qa-full + mutation testing + semver) — ~15 minutes. The **target** Tier 1 local gate. Today's CI PR gate only runs the fast subset (fmt/clippy/typos/audit/unwrap-budget + tests); `qa-deep` adds coverage, adversarial review, diff-scoped mutation, and semver — kept laptop-only because they're too slow for every PR (see `docs/plan-agentic-qa-strategy.md` §5). Alias: `make qa-tier1`, kept for back-compat.
 - `make qa-nightly` (qa-deep + proptest@1000 + miri + full mutation testing) — ~4 hours. Tier 2 equivalent locally, for overnight runs on a powerful machine. Skips miri if `cargo +nightly miri` isn't installed.
 - `make qa-release-gate` (qa-deep + semver) — the automatable subset of Tier 3. The non-automatable parts (independent security audit, dogfood campaign, migration validation) are documented in `docs/plan-agentic-qa-strategy.md` §7 but not locally gateable.
 - `make qa-coverage` — generates an lcov report locally. Run when you want to see what's covered.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,10 +154,12 @@ All three steps are required for every commit. Do NOT push without completing th
 
 ### Do NOT run the full QA suite on every commit/push
 
-The deeper QA gates — `make qa-full`, `make qa-tier1`, `make qa-coverage`, `make qa-mutants`, `make qa-semver` — are designed for **focused investigation and pre-release gating**, not the per-commit loop. Do not run them routinely, and do not add them to remote CI:
+The deeper QA gates — `make qa-full`, `make qa-deep`, `make qa-nightly`, `make qa-release-gate`, `make qa-coverage`, `make qa-mutants`, `make qa-semver` — are designed for **focused investigation and pre-release gating**, not the per-commit loop. Do not run them routinely, and do not add them to remote CI:
 
 - `make qa-full` (qa-fast + full tests + coverage) — ~5-10 minutes. Run before a significant push if you want extra confidence; coverage is too slow for every push.
-- `make qa-tier1` (qa-full + mutation testing + semver) — ~1-2 hours. Run before a release or when auditing a specific crate.
+- `make qa-deep` (qa-full + mutation testing + semver) — ~15 minutes. Full Tier 1 PR gate, i.e. what CI runs on your PR, locally. (Alias: `make qa-tier1`, kept for back-compat.)
+- `make qa-nightly` (qa-deep + proptest@1000 + miri + full mutation testing) — ~4 hours. Tier 2 equivalent locally, for overnight runs on a powerful machine. Skips miri if `cargo +nightly miri` isn't installed.
+- `make qa-release-gate` (qa-deep + semver) — the automatable subset of Tier 3. The non-automatable parts (independent security audit, dogfood campaign, migration validation) are documented in `docs/plan-agentic-qa-strategy.md` §7 but not locally gateable.
 - `make qa-coverage` — generates an lcov report locally. Run when you want to see what's covered.
 - `make qa-mutants` — mutation testing, slow. Run when investigating test quality on a specific file or on the PR diff.
 - `make qa-semver` — breaking-change check. Run before publishing to crates.io.

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@
 #
 #   make qa-fast       ~1 min     pre-commit sanity
 #   make qa-full       ~5-10 min  pre-push
-#   make qa-deep       ~15 min    full Tier 1 PR gate (what CI runs on your PR)
+#   make qa-deep       ~15 min    target Tier 1 gate, stronger than today's CI
+#                                 (adds coverage, adversarial, mutants, semver -
+#                                 kept laptop-only, see strategy doc §5)
 #   make qa-nightly    ~4 hours   Tier 2 equivalent locally (proptest, miri, full mutants)
 #   make qa-release-gate          Tier 3 automatable parts (deep + semver; audit/dogfood are human)
 #

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,18 @@
 #
 # Local-first quality gates. Same scripts run in CI.
 # See docs/plan-agentic-qa-strategy.md for the full strategy.
+#
+# The ladder (increasing thoroughness, increasing runtime):
+#
+#   make qa-fast       ~1 min     pre-commit sanity
+#   make qa-full       ~5-10 min  pre-push
+#   make qa-deep       ~15 min    full Tier 1 PR gate (what CI runs on your PR)
+#   make qa-nightly    ~4 hours   Tier 2 equivalent locally (proptest, miri, full mutants)
+#   make qa-release-gate          Tier 3 automatable parts (deep + semver; audit/dogfood are human)
+#
+# `make qa-tier1` is a back-compat alias for `make qa-deep`.
 
-.PHONY: qa qa-fast qa-full qa-tier1 \
+.PHONY: qa qa-fast qa-full qa-deep qa-tier1 qa-nightly qa-release-gate \
         qa-fmt qa-audit qa-unwrap qa-clippy qa-test qa-coverage qa-mutants qa-semver \
         qa-adversarial qa-install
 
@@ -15,8 +25,17 @@ qa-fast:
 qa-full:
 	@scripts/qa/all.sh --full
 
-qa-tier1:
-	@scripts/qa/all.sh --tier1
+qa-deep:
+	@scripts/qa/all.sh --deep
+
+# Back-compat alias. Prefer `make qa-deep` in new docs/scripts.
+qa-tier1: qa-deep
+
+qa-nightly:
+	@scripts/qa/all.sh --nightly
+
+qa-release-gate:
+	@scripts/qa/all.sh --release-gate
 
 # Individual gates
 

--- a/README.md
+++ b/README.md
@@ -590,7 +590,7 @@ Dora ships with a three-tier QA system designed for AI-authored code. Everything
 make qa-install        # one-time: install cargo-audit, cargo-deny, cargo-llvm-cov, cargo-mutants, cargo-semver-checks
 make qa-fast           # ~15s    -- fmt + clippy + audit + unwrap-budget + typos (pre-commit)
 make qa-full           # ~5-10m  -- qa-fast + tests + coverage (pre-push)
-make qa-deep           # ~15m    -- qa-full + mutation testing + semver (simulate the PR gate; alias: qa-tier1)
+make qa-deep           # ~15m    -- qa-full + mutation testing + semver (target Tier 1 gate, stronger than today's CI; alias: qa-tier1)
 make qa-nightly        # ~4h     -- qa-deep + proptest@1000 + miri + full mutation (overnight runs)
 make qa-release-gate   #         -- qa-deep + semver (Tier 3 automatable; audit/dogfood are human)
 ```

--- a/README.md
+++ b/README.md
@@ -587,10 +587,12 @@ cargo run --example benchmark --release
 Dora ships with a three-tier QA system designed for AI-authored code. Everything runs locally first; CI mirrors the same scripts.
 
 ```bash
-make qa-install     # one-time: install cargo-audit, cargo-deny, cargo-llvm-cov, cargo-mutants, cargo-semver-checks
-make qa-fast        # ~15s  -- fmt + clippy + audit + unwrap-budget + typos (pre-commit)
-make qa-full        # ~5-10 min -- qa-fast + tests + coverage (pre-push)
-make qa-tier1       # ~1-2 hrs  -- qa-full + mutation testing + semver (pre-release)
+make qa-install        # one-time: install cargo-audit, cargo-deny, cargo-llvm-cov, cargo-mutants, cargo-semver-checks
+make qa-fast           # ~15s    -- fmt + clippy + audit + unwrap-budget + typos (pre-commit)
+make qa-full           # ~5-10m  -- qa-fast + tests + coverage (pre-push)
+make qa-deep           # ~15m    -- qa-full + mutation testing + semver (simulate the PR gate; alias: qa-tier1)
+make qa-nightly        # ~4h     -- qa-deep + proptest@1000 + miri + full mutation (overnight runs)
+make qa-release-gate   #         -- qa-deep + semver (Tier 3 automatable; audit/dogfood are human)
 ```
 
 On Ubuntu, install `ripgrep` separately and install `typos-cli` with Cargo:

--- a/docs/contributor-qa-cheatsheet.md
+++ b/docs/contributor-qa-cheatsheet.md
@@ -80,14 +80,17 @@ Runs `qa-fast` plus:
 - coverage report
 - optional adversarial review if supported tools are installed
 
-### Simulate the full PR gate locally
+### Target Tier 1 gate (stronger than today's CI)
 
 ```bash
 make qa-deep    # alias: make qa-tier1
 ```
 
-Runs `qa-full` plus:
+Runs `qa-full` plus the Tier 1 extras that stay laptop-only because
+they're too slow for every PR (see `docs/plan-agentic-qa-strategy.md` §5):
 
+- coverage (already in `qa-full`)
+- adversarial LLM review (already in `qa-full`; skipped if tools missing)
 - mutation testing (diff-scoped)
 - semver checks
 

--- a/docs/contributor-qa-cheatsheet.md
+++ b/docs/contributor-qa-cheatsheet.md
@@ -80,16 +80,36 @@ Runs `qa-fast` plus:
 - coverage report
 - optional adversarial review if supported tools are installed
 
-### Before release or deep audit
+### Simulate the full PR gate locally
 
 ```bash
-make qa-tier1
+make qa-deep    # alias: make qa-tier1
 ```
 
 Runs `qa-full` plus:
 
-- mutation testing
+- mutation testing (diff-scoped)
 - semver checks
+
+### Overnight run on a powerful machine (Tier 2 equivalent)
+
+```bash
+make qa-nightly    # ~4 hours
+```
+
+Runs `qa-deep` plus property tests at 1000 cases, miri on unsafe code
+(skipped if `cargo +nightly miri` isn't installed), and full-repo
+mutation testing.
+
+### Before tagging a release
+
+```bash
+make qa-release-gate
+```
+
+The automatable subset of Tier 3. The non-automatable parts (external
+security audit, dogfood campaign, migration validation) are documented
+in `docs/plan-agentic-qa-strategy.md` §7.
 
 ## 4. Most useful manual commands
 

--- a/docs/qa-runbook.md
+++ b/docs/qa-runbook.md
@@ -17,7 +17,7 @@ make qa-fast
 # Before every push (~5-10 minutes)
 make qa-full
 
-# Simulate the full Tier 1 PR gate locally (~15 minutes)
+# Target Tier 1 gate -- stronger than today's CI (~15 minutes)
 make qa-deep
 
 # Overnight run on a beefy machine -- Tier 2 equivalent (~4 hours)
@@ -45,7 +45,7 @@ rustup component add miri --toolchain nightly   # optional; for unsafe-code anal
 |---|---|---|---|
 | `make qa-fast` | fmt + clippy + audit + unwrap-budget + typos | ~15 s | Pre-commit |
 | `make qa-full` | `qa-fast` + full test suite + coverage | ~5-10 min | Pre-push |
-| `make qa-deep` | `qa-full` + mutation testing on diff + semver | ~15 min | Simulate the full Tier 1 PR gate locally |
+| `make qa-deep` | `qa-full` + mutation testing on diff + semver | ~15 min | Target Tier 1 local gate (stronger than today's CI: adds coverage, adversarial, mutants, semver) |
 | `make qa-tier1` | alias for `qa-deep` | — | Back-compat; prefer `qa-deep` |
 | `make qa-nightly` | `qa-deep` + proptest@1000 + miri (if installed) + full-repo mutation testing | ~4 hrs | Tier 2 equivalent locally -- overnight runs on a powerful machine |
 | `make qa-release-gate` | `qa-deep` + semver | ~15 min | The automatable subset of Tier 3. Non-automatable: security audit + dogfood + migration validation (see strategy doc §7) |

--- a/docs/qa-runbook.md
+++ b/docs/qa-runbook.md
@@ -17,8 +17,14 @@ make qa-fast
 # Before every push (~5-10 minutes)
 make qa-full
 
-# Before a release or a focused mutation audit (~1+ hour)
-make qa-tier1
+# Simulate the full Tier 1 PR gate locally (~15 minutes)
+make qa-deep
+
+# Overnight run on a beefy machine -- Tier 2 equivalent (~4 hours)
+make qa-nightly
+
+# Before tagging a release
+make qa-release-gate
 ```
 
 If you only remember one command: **`make qa-fast`**.
@@ -39,7 +45,10 @@ rustup component add miri --toolchain nightly   # optional; for unsafe-code anal
 |---|---|---|---|
 | `make qa-fast` | fmt + clippy + audit + unwrap-budget + typos | ~15 s | Pre-commit |
 | `make qa-full` | `qa-fast` + full test suite + coverage | ~5-10 min | Pre-push |
-| `make qa-tier1` | `qa-full` + mutation testing on diff + semver | ~1-2 hrs | Pre-release or focused audit |
+| `make qa-deep` | `qa-full` + mutation testing on diff + semver | ~15 min | Simulate the full Tier 1 PR gate locally |
+| `make qa-tier1` | alias for `qa-deep` | — | Back-compat; prefer `qa-deep` |
+| `make qa-nightly` | `qa-deep` + proptest@1000 + miri (if installed) + full-repo mutation testing | ~4 hrs | Tier 2 equivalent locally -- overnight runs on a powerful machine |
+| `make qa-release-gate` | `qa-deep` + semver | ~15 min | The automatable subset of Tier 3. Non-automatable: security audit + dogfood + migration validation (see strategy doc §7) |
 | `make qa-fmt` | `cargo fmt --all -- --check` | ~2 s | Spot-check |
 | `make qa-clippy` | `cargo clippy --all -- -D warnings` (excluding Python) | ~1 min | After mechanical edits |
 | `make qa-audit` | `cargo audit` + `cargo deny check` | ~10 s | After bumping deps |

--- a/docs/testing-matrix.md
+++ b/docs/testing-matrix.md
@@ -87,7 +87,9 @@ Documented in `CLAUDE.md`. Invoke via `make`:
 | Gate | Command | When |
 |---|---|---|
 | Full QA (fast + tests + coverage) | `make qa-full` | before significant push |
-| Tier 1 (qa-full + mutants + semver) | `make qa-tier1` | before release, or crate audit |
+| Tier 1 PR gate locally (qa-full + mutants + semver) | `make qa-deep` (alias: `make qa-tier1`) | simulate the full PR gate before pushing |
+| Tier 2 locally (qa-deep + proptest@1000 + miri + full mutants) | `make qa-nightly` | overnight runs on a powerful machine |
+| Tier 3 automatable (qa-deep + semver) | `make qa-release-gate` | before tagging a release |
 | Coverage (lcov report) | `make qa-coverage` | when investigating coverage |
 | Mutation testing | `make qa-mutants` | when auditing test quality |
 | Semver check | `make qa-semver` | before publishing to crates.io |

--- a/docs/testing-matrix.md
+++ b/docs/testing-matrix.md
@@ -87,7 +87,7 @@ Documented in `CLAUDE.md`. Invoke via `make`:
 | Gate | Command | When |
 |---|---|---|
 | Full QA (fast + tests + coverage) | `make qa-full` | before significant push |
-| Tier 1 PR gate locally (qa-full + mutants + semver) | `make qa-deep` (alias: `make qa-tier1`) | simulate the full PR gate before pushing |
+| Target Tier 1 gate (qa-full + mutants + semver) | `make qa-deep` (alias: `make qa-tier1`) | stronger than today's CI — laptop-only extras (coverage, adversarial, mutants, semver) |
 | Tier 2 locally (qa-deep + proptest@1000 + miri + full mutants) | `make qa-nightly` | overnight runs on a powerful machine |
 | Tier 3 automatable (qa-deep + semver) | `make qa-release-gate` | before tagging a release |
 | Coverage (lcov report) | `make qa-coverage` | when investigating coverage |

--- a/scripts/qa/all.sh
+++ b/scripts/qa/all.sh
@@ -4,10 +4,13 @@
 # Runs the QA gates from docs/plan-agentic-qa-strategy.md.
 # Designed for local-first execution: same script runs locally and in CI.
 #
-# Modes:
-#   --fast    pre-commit budget (~1 minute) — fmt, clippy, audit, unwrap, typos
-#   --full    pre-push budget (~5-10 minutes) — fast + tests + coverage
-#   --tier1   full Tier 1 gate (~15 minutes) — full + mutants + semver
+# Modes (increasing thoroughness):
+#   --fast          ~1 min     pre-commit sanity (fmt, clippy, audit, unwrap, typos)
+#   --full          ~5-10 min  pre-push (fast + tests + coverage + optional adversarial)
+#   --deep          ~15 min    full Tier 1 PR gate (full + mutants on diff + semver)
+#   --tier1                    back-compat alias for --deep
+#   --nightly       ~4 hours   Tier 2 locally (deep + proptest@1000 + miri + full mutants)
+#   --release-gate             Tier 3 automatable (deep + semver; audit+dogfood are human gates)
 #
 # Without flags, runs --fast.
 
@@ -30,6 +33,24 @@ run() {
   fi
 }
 
+# Optional run: skip (without failing) if the required tool is missing.
+# Used for Tier 2 items like miri that need nightly Rust.
+run_optional() {
+  local name="$1" check="$2"; shift 2
+  if ! eval "$check" > /dev/null 2>&1; then
+    echo
+    echo "=== $name (SKIP: prerequisite missing) ==="
+    return
+  fi
+  run "$name" "$@"
+}
+
+# Normalize --tier1 to --deep so the rest of the script only branches on one.
+if [[ "$MODE" == "--tier1" ]]; then
+  echo "(note: --tier1 is a deprecated alias for --deep)"
+  MODE="--deep"
+fi
+
 # ----- Always run (fast) -----
 run "fmt"           cargo fmt --all -- --check
 run "clippy"        cargo clippy --all \
@@ -41,28 +62,63 @@ run "audit"         scripts/qa/audit.sh
 run "unwrap-budget" scripts/qa/unwrap-budget.sh
 run "typos"         scripts/qa/typos.sh
 
-if [[ "$MODE" == "--fast" ]]; then
-  : # done
-elif [[ "$MODE" == "--full" || "$MODE" == "--tier1" ]]; then
-  run "test" cargo test --all \
-    --exclude dora-node-api-python \
-    --exclude dora-operator-api-python \
-    --exclude dora-ros2-bridge-python \
-    --exclude dora-cli-api-python \
-    --exclude dora-examples
-  run "coverage" scripts/qa/coverage.sh
-  # Adversarial LLM review skips cleanly on machines without codex/claude.
-  run "adversarial" scripts/qa/adversarial.sh --optional
+case "$MODE" in
+  --fast)
+    : # done
+    ;;
+  --full|--deep|--nightly|--release-gate)
+    run "test" cargo test --all \
+      --exclude dora-node-api-python \
+      --exclude dora-operator-api-python \
+      --exclude dora-ros2-bridge-python \
+      --exclude dora-cli-api-python \
+      --exclude dora-examples
+    run "coverage" scripts/qa/coverage.sh
+    # Adversarial LLM review skips cleanly on machines without codex/claude.
+    run "adversarial" scripts/qa/adversarial.sh --optional
+    ;;
+  *)
+    echo "Unknown mode: $MODE"
+    echo "Usage: $0 [--fast|--full|--deep|--tier1|--nightly|--release-gate]"
+    exit 2
+    ;;
+esac
 
-  if [[ "$MODE" == "--tier1" ]]; then
-    run "mutants" scripts/qa/mutants.sh
-    run "semver"  scripts/qa/semver.sh
-  fi
-else
-  echo "Unknown mode: $MODE"
-  echo "Usage: $0 [--fast|--full|--tier1]"
-  exit 2
-fi
+case "$MODE" in
+  --deep|--release-gate)
+    run "mutants (diff-scoped)" scripts/qa/mutants.sh
+    run "semver"                scripts/qa/semver.sh
+    ;;
+  --nightly)
+    # Tier 2 skips the diff-scoped mutants run -- `mutants --full` below
+    # subsumes it.
+    run "semver" scripts/qa/semver.sh
+    ;;
+esac
+
+case "$MODE" in
+  --nightly)
+    # Tier 2 locally. See docs/plan-agentic-qa-strategy.md §6.
+    #
+    # proptest: the existing property tests run under `cargo test` with a
+    # reduced case count in Tier 1. Here we bump to 1000 cases per property.
+    run "proptest-1000" env PROPTEST_CASES=1000 cargo test --all \
+      --exclude dora-node-api-python \
+      --exclude dora-operator-api-python \
+      --exclude dora-ros2-bridge-python \
+      --exclude dora-cli-api-python \
+      --exclude dora-examples \
+      -- proptest
+
+    # miri requires nightly Rust + miri component. Skip (with note) if missing.
+    run_optional "miri" "cargo +nightly miri --version" \
+      cargo +nightly miri test -p dora-core
+
+    # Full mutation testing (not diff-scoped). The default `qa-mutants` is
+    # diff-scoped for the Tier 1 PR gate; --full runs every function.
+    run "mutants (full-repo)" scripts/qa/mutants.sh --full
+    ;;
+esac
 
 echo
 echo "============================================================"

--- a/scripts/qa/all.sh
+++ b/scripts/qa/all.sh
@@ -51,6 +51,89 @@ if [[ "$MODE" == "--tier1" ]]; then
   MODE="--deep"
 fi
 
+# Print a per-mode overview so a developer knows what they're about to
+# sit through. The actual checks follow the same order listed here.
+print_overview() {
+  local mode="$1"
+  local header
+  case "$mode" in
+    --fast)
+      header="qa-fast -- pre-commit sanity (~1 min)"
+      cat <<EOF
+============================================================
+$header
+Will run:
+  1. fmt            -- cargo fmt --all -- --check
+  2. clippy         -- cargo clippy --all -- -D warnings (excluding Python)
+  3. audit          -- cargo-audit + cargo-deny on the dependency tree
+  4. unwrap-budget  -- count production .unwrap() / .expect( regressions
+  5. typos          -- spell-check against _typos.toml allowlist
+============================================================
+EOF
+      ;;
+    --full)
+      header="qa-full -- pre-push gate (~5-10 min)"
+      cat <<EOF
+============================================================
+$header
+Will run:
+  1-5. everything from qa-fast                  (fmt/clippy/audit/unwrap/typos)
+  6.   test         -- cargo test --all         (workspace test suite)
+  7.   coverage     -- cargo llvm-cov           (writes lcov.info)
+  8.   adversarial  -- codex/claude review      (optional; skipped if unavailable)
+============================================================
+EOF
+      ;;
+    --deep)
+      header="qa-deep -- full Tier 1 PR gate locally (~15 min)"
+      cat <<EOF
+============================================================
+$header
+Mirrors what CI runs on every PR. Will run:
+  1-5.  everything from qa-fast
+  6-8.  everything from qa-full                 (test, coverage, adversarial)
+  9.    mutants (diff-scoped)                   -- cargo-mutants on changed code
+  10.   semver                                  -- cargo-semver-checks vs last tag
+============================================================
+EOF
+      ;;
+    --nightly)
+      header="qa-nightly -- Tier 2 locally (~4 hours)"
+      cat <<EOF
+============================================================
+$header
+For overnight runs on a powerful machine. Will run:
+  1-5.  everything from qa-fast
+  6-8.  everything from qa-full                 (test, coverage, adversarial)
+  9.    semver                                  -- cargo-semver-checks vs last tag
+  10.   proptest @ 1000 cases per property      (vs 50 cases in Tier 1)
+  11.   miri                                    -- undefined-behavior check (SKIP if cargo +nightly miri missing)
+  12.   mutants (full-repo, not just diff)      -- every function, every critical crate
+Expect ~4 hours. See docs/plan-agentic-qa-strategy.md §6.
+============================================================
+EOF
+      ;;
+    --release-gate)
+      header="qa-release-gate -- Tier 3 automatable subset"
+      cat <<EOF
+============================================================
+$header
+The automatable parts of the Tier 3 release gate. Will run:
+  1-5.   everything from qa-fast
+  6-8.   everything from qa-full                 (test, coverage, adversarial)
+  9.     mutants (diff-scoped)
+  10.    semver
+Non-automatable Tier 3 gates (external security audit, 7-day dogfood
+campaign, migration validation on external repos) are human-gated --
+see docs/plan-agentic-qa-strategy.md §7.
+============================================================
+EOF
+      ;;
+  esac
+}
+
+print_overview "$MODE"
+
 # ----- Always run (fast) -----
 run "fmt"           cargo fmt --all -- --check
 run "clippy"        cargo clippy --all \

--- a/scripts/qa/all.sh
+++ b/scripts/qa/all.sh
@@ -7,7 +7,9 @@
 # Modes (increasing thoroughness):
 #   --fast          ~1 min     pre-commit sanity (fmt, clippy, audit, unwrap, typos)
 #   --full          ~5-10 min  pre-push (fast + tests + coverage + optional adversarial)
-#   --deep          ~15 min    full Tier 1 PR gate (full + mutants on diff + semver)
+#   --deep          ~15 min    target Tier 1 gate, stronger than today's CI
+#                              (full + mutants on diff + semver; see strategy doc §5 for why the
+#                              extras are laptop-only)
 #   --tier1                    back-compat alias for --deep
 #   --nightly       ~4 hours   Tier 2 locally (deep + proptest@1000 + miri + full mutants)
 #   --release-gate             Tier 3 automatable (deep + semver; audit+dogfood are human gates)

--- a/scripts/qa/all.sh
+++ b/scripts/qa/all.sh
@@ -85,15 +85,23 @@ Will run:
 EOF
       ;;
     --deep)
-      header="qa-deep -- full Tier 1 PR gate locally (~15 min)"
+      header="qa-deep -- target Tier 1 gate, stronger than today's CI (~15 min)"
       cat <<EOF
 ============================================================
 $header
-Mirrors what CI runs on every PR. Will run:
-  1-5.  everything from qa-fast
-  6-8.  everything from qa-full                 (test, coverage, adversarial)
-  9.    mutants (diff-scoped)                   -- cargo-mutants on changed code
-  10.   semver                                  -- cargo-semver-checks vs last tag
+Today's CI PR gate only runs a subset of this: fmt, clippy, typos,
+audit, unwrap-budget, and the workspace test suite. qa-deep adds the
+planned Tier 1 extras (see docs/plan-agentic-qa-strategy.md §5) that
+are kept laptop-only today because they're too slow for every PR:
+coverage, adversarial review, diff-scoped mutation testing, semver.
+
+Will run:
+  1-5.  everything from qa-fast                 (in CI today)
+  6.    test         -- cargo test --all        (in CI today)
+  7.    coverage     -- cargo llvm-cov          (NOT in CI; laptop-only)
+  8.    adversarial  -- codex/claude review     (NOT in CI; skipped w/o tools)
+  9.    mutants      -- cargo-mutants on diff   (NOT in CI; laptop-only)
+  10.   semver       -- cargo-semver-checks     (NOT in CI; pre-release only)
 ============================================================
 EOF
       ;;


### PR DESCRIPTION
Resolves two QA UX issues raised in the PR discussion:

1. `make qa-tier1` broke the naming pattern (qa-fast / qa-full / qa-tier1 mixes adjectives with structural names) and implied missing siblings `qa-tier2` / `qa-tier3` that never existed.
2. Tier 2 (nightly CI, ~4 hours) and Tier 3 (release gates) were CI-only — no way to run their automatable parts on a powerful developer machine even when desired.

## Changes

### Rename

`make qa-tier1` → `make qa-deep`. `qa-tier1` kept as a back-compat Make alias; `scripts/qa/all.sh --tier1` prints a deprecation note and dispatches to `--deep`.

### New targets

- `make qa-nightly` (~4 hours) — `qa-deep` + proptest @ 1000 cases + miri (skipped if `cargo +nightly miri` isn't installed) + full-repo mutation testing. For overnight runs on fast machines.
- `make qa-release-gate` — Tier 3 automatable subset (`qa-deep` + semver). Documented non-automatable Tier 3 items (security audit, dogfood, migration validation) stay human-gated.

### Optimization

`--nightly` skips the diff-scoped mutants step since `mutants --full` later in the pipeline subsumes it.

## Final ladder

```
qa-fast        ~1 min      pre-commit sanity
qa-full        ~5-10 min   pre-push
qa-deep        ~15 min     target Tier 1 gate, stronger than today's CI
qa-nightly     ~4 hours    Tier 2 locally (powerful machine)
qa-release-gate            Tier 3 automatable (audit/dogfood are human gates)
```

All adjectives, increasing thoroughness, no gaps.

## No CI impact

CI workflows invoke individual scripts (`audit.sh`, `typos.sh`, etc.), not Makefile targets. Zero hits for `qa-tier1` or `qa-deep` in `.github/workflows/`.

## Verified

- `make -n qa-fast / qa-full / qa-deep / qa-tier1 / qa-nightly / qa-release-gate` all dispatch correctly.
- `scripts/qa/all.sh --tier1` prints deprecation note then runs `--deep` flow.
- `scripts/qa/all.sh --unknown` errors with usage line listing all 6 modes.
- `scripts/qa/all.sh --deep` fast gates pass on this branch.

## Docs

- `CLAUDE.md` "Do NOT run the full QA suite" section updated with the new ladder.
- `docs/qa-runbook.md` TL;DR + target table updated.

## Test plan

- [x] All Make targets dispatch correctly
- [x] `--tier1` alias works with deprecation note
- [x] Unknown mode errors with correct usage line
- [x] Docs reflect the new ladder
- [ ] CI green

Generated with Claude Code (https://claude.com/claude-code)

