### PR TITLE
fix(qa): scope miri run to metadata::tests so qa-nightly passes

### DIFF
--- a/scripts/qa/all.sh
+++ b/scripts/qa/all.sh
@@ -204,8 +204,16 @@ case "$MODE" in
       -- proptest
 
     # miri requires nightly Rust + miri component. Skip (with note) if missing.
+    #
+    # Scoped to the `metadata::tests::` module only. Those tests were
+    # specifically written to exercise the unsafe pointer-arithmetic
+    # path in `ArrowTypeInfoExt::from_array` under miri (see the
+    # module doc comment and docs/plan-agentic-qa-strategy.md §T2.3).
+    # Running `cargo miri test -p dora-core` without a filter tries
+    # every test in the crate; most fail because they use `tempfile`
+    # or other filesystem ops that miri's isolation sandbox rejects.
     run_optional "miri" "cargo +nightly miri --version" \
-      cargo +nightly miri test -p dora-core
+      cargo +nightly miri test -p dora-core -- metadata::tests
 
     # Full mutation testing (not diff-scoped). The default `qa-mutants` is
     # diff-scoped for the Tier 1 PR gate; --full runs every function.


### PR DESCRIPTION
## Bug

Running `make qa-nightly` (added in #1688) hit a hard failure on the miri step:

```
test descriptor::expand::tests::check_module_file_bad_mod_ref ... error:
  unsupported operation: `mkdir` not available when isolation is enabled
```

Root cause: the invocation was `cargo +nightly miri test -p dora-core` with no filter. That tried to run every test in the dora-core crate under miri — but most tests use `tempfile` / filesystem ops that miri's isolation sandbox rejects.

## Intended scope

Per `docs/plan-agentic-qa-strategy.md` §T2.3 and the module doc comment on `libraries/core/src/metadata/tests.rs`:

> These exist to make the unsafe code path testable in isolation (without spinning up real shared memory) so that:
>
> 1. Off-by-one bugs at the region boundary are caught.
> 2. The code can be analyzed by `miri` for undefined behavior in pointer arithmetic (`offset_from`, provenance).
>
> These tests are part of the T2.3 miri rollout in `docs/plan-agentic-qa-strategy.md`.

Only **5 tests** were designed for miri. 146 others weren't and shouldn't be subjected to the sandbox.

## Fix

One-line change in `scripts/qa/all.sh`:

```diff
- cargo +nightly miri test -p dora-core
+ cargo +nightly miri test -p dora-core -- metadata::tests
```

Also expanded the inline comment to explain WHY the filter matters, so a future maintainer doesn't "clean it up" by dropping the filter.

## Verified

```
$ cargo +nightly miri test -p dora-core -- metadata::tests
running 5 tests
test metadata::tests::from_array_accepts_buffer_at_region_start ... ok
test metadata::tests::from_array_accepts_empty_buffer_at_region_start ... ok
test metadata::tests::from_array_records_offset_within_region ... ok
test metadata::tests::from_array_recurses_into_child_data ... ok
test metadata::tests::from_array_rejects_buffer_extending_past_region_end ... ok
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 146 filtered out; finished in 1.41s
```

5/5 miri-designed tests pass; 146 unrelated tests correctly filtered out.

## Test plan

- [x] `cargo +nightly miri test -p dora-core -- metadata::tests` passes locally (1.4s)
- [x] The 5 miri-designed tests run; others filtered
- [ ] `make qa-nightly` completes past the miri step without the `mkdir`/isolation error

Generated with Claude Code (https://claude.com/claude-code)
