### PR TITLE
refactor(qa): split full-repo mutation out of qa-nightly + lower mutant timeout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,12 +154,13 @@ All three steps are required for every commit. Do NOT push without completing th
 
 ### Do NOT run the full QA suite on every commit/push
 
-The deeper QA gates — `make qa-full`, `make qa-deep`, `make qa-nightly`, `make qa-release-gate`, `make qa-coverage`, `make qa-mutants`, `make qa-semver` — are designed for **focused investigation and pre-release gating**, not the per-commit loop. Do not run them routinely, and do not add them to remote CI:
+The deeper QA gates — `make qa-full`, `make qa-deep`, `make qa-nightly`, `make qa-release-gate`, `make qa-mutation-audit`, `make qa-coverage`, `make qa-mutants`, `make qa-semver` — are designed for **focused investigation and pre-release gating**, not the per-commit loop. Do not run them routinely, and do not add them to remote CI:
 
 - `make qa-full` (qa-fast + full tests + coverage) — ~5-10 minutes. Run before a significant push if you want extra confidence; coverage is too slow for every push.
 - `make qa-deep` (qa-full + mutation testing + semver) — ~15 minutes. The **target** Tier 1 local gate. Today's CI PR gate only runs the fast subset (fmt/clippy/typos/audit/unwrap-budget + tests); `qa-deep` adds coverage, adversarial review, diff-scoped mutation, and semver — kept laptop-only because they're too slow for every PR (see `docs/plan-agentic-qa-strategy.md` §5). Alias: `make qa-tier1`, kept for back-compat.
-- `make qa-nightly` (qa-deep + proptest@1000 + miri + full mutation testing) — ~4 hours. Tier 2 equivalent locally, for overnight runs on a powerful machine. Skips miri if `cargo +nightly miri` isn't installed.
+- `make qa-nightly` (qa-deep + proptest@1000 + miri) — ~30-60 minutes. Tier 2 equivalent locally, for overnight runs on a powerful machine. Skips miri if `cargo +nightly miri` isn't installed. **Does not** include full-repo mutation testing — that's split into `qa-mutation-audit` because it takes 10-18 hours on this workspace.
 - `make qa-release-gate` (qa-deep + semver) — the automatable subset of Tier 3. The non-automatable parts (independent security audit, dogfood campaign, migration validation) are documented in `docs/plan-agentic-qa-strategy.md` §7 but not locally gateable.
+- `make qa-mutation-audit` — ~10-18 hours. Full-repo `cargo-mutants` across 6 critical crates. Deliberate test-quality audit; run before a release or when investigating a specific crate, not every nightly.
 - `make qa-coverage` — generates an lcov report locally. Run when you want to see what's covered.
 - `make qa-mutants` — mutation testing, slow. Run when investigating test quality on a specific file or on the PR diff.
 - `make qa-semver` — breaking-change check. Run before publishing to crates.io.

--- a/Makefile
+++ b/Makefile
@@ -5,17 +5,20 @@
 #
 # The ladder (increasing thoroughness, increasing runtime):
 #
-#   make qa-fast       ~1 min     pre-commit sanity
-#   make qa-full       ~5-10 min  pre-push
-#   make qa-deep       ~15 min    target Tier 1 gate, stronger than today's CI
-#                                 (adds coverage, adversarial, mutants, semver -
-#                                 kept laptop-only, see strategy doc §5)
-#   make qa-nightly    ~4 hours   Tier 2 equivalent locally (proptest, miri, full mutants)
-#   make qa-release-gate          Tier 3 automatable parts (deep + semver; audit/dogfood are human)
+#   make qa-fast             ~1 min      pre-commit sanity
+#   make qa-full             ~5-10 min   pre-push
+#   make qa-deep             ~15 min     target Tier 1 gate, stronger than today's CI
+#                                        (adds coverage, adversarial, mutants, semver -
+#                                        kept laptop-only, see strategy doc §5)
+#   make qa-nightly          ~30-60 min  Tier 2 locally (deep + proptest@1000 + miri)
+#   make qa-release-gate                 Tier 3 automatable parts (deep + semver;
+#                                        audit/dogfood are human)
+#   make qa-mutation-audit   ~10-18 hrs  full-repo cargo-mutants; deliberate
+#                                        test-quality audit, NOT every nightly
 #
 # `make qa-tier1` is a back-compat alias for `make qa-deep`.
 
-.PHONY: qa qa-fast qa-full qa-deep qa-tier1 qa-nightly qa-release-gate \
+.PHONY: qa qa-fast qa-full qa-deep qa-tier1 qa-nightly qa-release-gate qa-mutation-audit \
         qa-fmt qa-audit qa-unwrap qa-clippy qa-test qa-coverage qa-mutants qa-semver \
         qa-adversarial qa-install
 
@@ -38,6 +41,9 @@ qa-nightly:
 
 qa-release-gate:
 	@scripts/qa/all.sh --release-gate
+
+qa-mutation-audit:
+	@scripts/qa/all.sh --mutation-audit
 
 # Individual gates
 

--- a/README.md
+++ b/README.md
@@ -591,8 +591,9 @@ make qa-install        # one-time: install cargo-audit, cargo-deny, cargo-llvm-c
 make qa-fast           # ~15s    -- fmt + clippy + audit + unwrap-budget + typos (pre-commit)
 make qa-full           # ~5-10m  -- qa-fast + tests + coverage (pre-push)
 make qa-deep           # ~15m    -- qa-full + mutation testing + semver (target Tier 1 gate, stronger than today's CI; alias: qa-tier1)
-make qa-nightly        # ~4h     -- qa-deep + proptest@1000 + miri + full mutation (overnight runs)
+make qa-nightly        # ~30-60m -- qa-deep + proptest@1000 + miri (Tier 2 locally; overnight runs)
 make qa-release-gate   #         -- qa-deep + semver (Tier 3 automatable; audit/dogfood are human)
+make qa-mutation-audit # ~10-18h -- full-repo cargo-mutants; deliberate test-quality audit
 ```
 
 On Ubuntu, install `ripgrep` separately and install `typos-cli` with Cargo:

--- a/docs/contributor-qa-cheatsheet.md
+++ b/docs/contributor-qa-cheatsheet.md
@@ -97,12 +97,13 @@ they're too slow for every PR (see `docs/plan-agentic-qa-strategy.md` §5):
 ### Overnight run on a powerful machine (Tier 2 equivalent)
 
 ```bash
-make qa-nightly    # ~4 hours
+make qa-nightly    # ~30-60 min
 ```
 
-Runs `qa-deep` plus property tests at 1000 cases, miri on unsafe code
-(skipped if `cargo +nightly miri` isn't installed), and full-repo
-mutation testing.
+Runs `qa-deep` plus property tests at 1000 cases and miri on unsafe
+code (skipped if `cargo +nightly miri` isn't installed). **Does not**
+include full-repo mutation testing -- that's split into
+`qa-mutation-audit` because it takes 10-18 hours on this workspace.
 
 ### Before tagging a release
 
@@ -113,6 +114,21 @@ make qa-release-gate
 The automatable subset of Tier 3. The non-automatable parts (external
 security audit, dogfood campaign, migration validation) are documented
 in `docs/plan-agentic-qa-strategy.md` §7.
+
+### Deliberate full-repo test-quality audit
+
+```bash
+make qa-mutation-audit    # ~10-18 hours
+```
+
+Runs `cargo-mutants --full` on the 6 critical crates (dora-core,
+dora-daemon, dora-coordinator, dora-message, dora-coordinator-store,
+shared-memory-server). About 1679 mutants. Background it, check the
+morning after. Use when:
+
+- Investigating low test coverage in a specific crate.
+- Before a major release to score test-suite quality overall.
+- Adding a new critical crate and want a baseline.
 
 ## 4. Most useful manual commands
 

--- a/docs/qa-followups.md
+++ b/docs/qa-followups.md
@@ -81,7 +81,7 @@ Expensive but unsupervised work. Kick off in a terminal, come back later.
 - **Trigger**: before citing the daemon/coordinator mutation scores in any formal report
 - **Owner**: heyong4725
 - **Why**: the current 5.8% / 26.1% numbers are scoping artifacts, not real scores. `test_workspace = true` is now the default in `.cargo/mutants.toml` but the re-run hasn't been done
-- **Command**: `cargo mutants --package dora-daemon --jobs 4 --timeout 120 --output /tmp/mutation/daemon-workspace` (similar for coordinator)
+- **Command**: `cargo mutants --package dora-daemon --jobs 4 --timeout 45 --output /tmp/mutation/daemon-workspace` (similar for coordinator; timeout was 120 → 45 after the qa-nightly split — see scripts/qa/mutants.sh)
 - **Expected outcome**: scores likely jump to 40-60%+ range based on the `fault_tolerance.rs` single-file experiment (21 missed → 21 caught)
 - **Reference**: `.cargo/mutants.toml` comment block, commit `9e0c2c6`
 

--- a/docs/qa-runbook.md
+++ b/docs/qa-runbook.md
@@ -20,11 +20,14 @@ make qa-full
 # Target Tier 1 gate -- stronger than today's CI (~15 minutes)
 make qa-deep
 
-# Overnight run on a beefy machine -- Tier 2 equivalent (~4 hours)
+# Overnight run on a beefy machine -- Tier 2 equivalent (~30-60 min)
 make qa-nightly
 
 # Before tagging a release
 make qa-release-gate
+
+# Deliberate test-quality audit (NOT every nightly; takes 10-18 hrs)
+make qa-mutation-audit
 ```
 
 If you only remember one command: **`make qa-fast`**.
@@ -47,8 +50,9 @@ rustup component add miri --toolchain nightly   # optional; for unsafe-code anal
 | `make qa-full` | `qa-fast` + full test suite + coverage | ~5-10 min | Pre-push |
 | `make qa-deep` | `qa-full` + mutation testing on diff + semver | ~15 min | Target Tier 1 local gate (stronger than today's CI: adds coverage, adversarial, mutants, semver) |
 | `make qa-tier1` | alias for `qa-deep` | — | Back-compat; prefer `qa-deep` |
-| `make qa-nightly` | `qa-deep` + proptest@1000 + miri (if installed) + full-repo mutation testing | ~4 hrs | Tier 2 equivalent locally -- overnight runs on a powerful machine |
+| `make qa-nightly` | `qa-deep` + proptest@1000 + miri (if installed) | ~30-60 min | Tier 2 equivalent locally -- overnight runs on a powerful machine. Does NOT include full-repo mutation testing (see `qa-mutation-audit`) |
 | `make qa-release-gate` | `qa-deep` + semver | ~15 min | The automatable subset of Tier 3. Non-automatable: security audit + dogfood + migration validation (see strategy doc §7) |
+| `make qa-mutation-audit` | `cargo-mutants --full` on 6 critical crates | ~10-18 hrs | Deliberate test-quality audit, not every nightly |
 | `make qa-fmt` | `cargo fmt --all -- --check` | ~2 s | Spot-check |
 | `make qa-clippy` | `cargo clippy --all -- -D warnings` (excluding Python) | ~1 min | After mechanical edits |
 | `make qa-audit` | `cargo audit` + `cargo deny check` | ~10 s | After bumping deps |

--- a/docs/qa-runbook.md
+++ b/docs/qa-runbook.md
@@ -270,7 +270,10 @@ Failed proptest cases are saved in `libraries/message/proptest-regressions/` and
 
 ```bash
 # Mutation test a single file
-cargo mutants --package <pkg> --file <path/to/file.rs> --jobs 4 --timeout 120
+# (Timeout 45s mirrors scripts/qa/mutants.sh default. Was 120s until the
+# qa-nightly split; real passing tests fit comfortably under 45s and the
+# shorter cap prevents broken-channel mutations from burning 2m each.)
+cargo mutants --package <pkg> --file <path/to/file.rs> --jobs 4 --timeout 45
 
 # List mutations without running (fast)
 cargo mutants --package <pkg> --file <path/to/file.rs> --list

--- a/docs/testing-matrix.md
+++ b/docs/testing-matrix.md
@@ -88,7 +88,8 @@ Documented in `CLAUDE.md`. Invoke via `make`:
 |---|---|---|
 | Full QA (fast + tests + coverage) | `make qa-full` | before significant push |
 | Target Tier 1 gate (qa-full + mutants + semver) | `make qa-deep` (alias: `make qa-tier1`) | stronger than today's CI — laptop-only extras (coverage, adversarial, mutants, semver) |
-| Tier 2 locally (qa-deep + proptest@1000 + miri + full mutants) | `make qa-nightly` | overnight runs on a powerful machine |
+| Tier 2 locally (qa-deep + proptest@1000 + miri) | `make qa-nightly` | overnight runs on a powerful machine; ~30-60 min |
+| Full-repo mutation audit (~10-18 hrs) | `make qa-mutation-audit` | deliberate test-quality audit, NOT every nightly |
 | Tier 3 automatable (qa-deep + semver) | `make qa-release-gate` | before tagging a release |
 | Coverage (lcov report) | `make qa-coverage` | when investigating coverage |
 | Mutation testing | `make qa-mutants` | when auditing test quality |

--- a/scripts/qa/all.sh
+++ b/scripts/qa/all.sh
@@ -5,14 +5,16 @@
 # Designed for local-first execution: same script runs locally and in CI.
 #
 # Modes (increasing thoroughness):
-#   --fast          ~1 min     pre-commit sanity (fmt, clippy, audit, unwrap, typos)
-#   --full          ~5-10 min  pre-push (fast + tests + coverage + optional adversarial)
-#   --deep          ~15 min    target Tier 1 gate, stronger than today's CI
-#                              (full + mutants on diff + semver; see strategy doc §5 for why the
-#                              extras are laptop-only)
-#   --tier1                    back-compat alias for --deep
-#   --nightly       ~4 hours   Tier 2 locally (deep + proptest@1000 + miri + full mutants)
-#   --release-gate             Tier 3 automatable (deep + semver; audit+dogfood are human gates)
+#   --fast            ~1 min     pre-commit sanity (fmt, clippy, audit, unwrap, typos)
+#   --full            ~5-10 min  pre-push (fast + tests + coverage + optional adversarial)
+#   --deep            ~15 min    target Tier 1 gate, stronger than today's CI
+#                                (full + mutants on diff + semver; see strategy doc §5 for why the
+#                                extras are laptop-only)
+#   --tier1                      back-compat alias for --deep
+#   --nightly         ~30-60 min Tier 2 locally (deep + proptest@1000 + miri)
+#   --release-gate               Tier 3 automatable (deep + semver; audit+dogfood are human gates)
+#   --mutation-audit  ~10-18 hrs full-repo cargo-mutants across 6 critical crates
+#                                (1679+ mutants). Deliberate test-quality audit, not every nightly.
 #
 # Without flags, runs --fast.
 
@@ -108,18 +110,42 @@ Will run:
 EOF
       ;;
     --nightly)
-      header="qa-nightly -- Tier 2 locally (~4 hours)"
+      header="qa-nightly -- Tier 2 locally (~30-60 min)"
       cat <<EOF
 ============================================================
 $header
 For overnight runs on a powerful machine. Will run:
   1-5.  everything from qa-fast
   6-8.  everything from qa-full                 (test, coverage, adversarial)
-  9.    semver                                  -- cargo-semver-checks vs last tag
-  10.   proptest @ 1000 cases per property      (vs 50 cases in Tier 1)
-  11.   miri                                    -- undefined-behavior check (SKIP if cargo +nightly miri missing)
-  12.   mutants (full-repo, not just diff)      -- every function, every critical crate
-Expect ~4 hours. See docs/plan-agentic-qa-strategy.md §6.
+  9.    mutants (diff-scoped)                   -- same as qa-deep
+  10.   semver                                  -- cargo-semver-checks vs last tag
+  11.   proptest @ 1000 cases per property      (vs 50 cases in Tier 1)
+  12.   miri                                    -- undefined-behavior check (SKIP if cargo +nightly miri missing)
+
+Full-repo mutation testing is a SEPARATE target (qa-mutation-audit)
+because in practice it takes 10-18 hours on this workspace -- too long
+to bundle with a "nightly" run most devs will actually use. See
+docs/plan-agentic-qa-strategy.md §6.
+============================================================
+EOF
+      ;;
+    --mutation-audit)
+      header="qa-mutation-audit -- full-repo cargo-mutants (10-18 hours)"
+      cat <<EOF
+============================================================
+$header
+Runs cargo-mutants --full on 6 critical crates: dora-core, dora-daemon,
+dora-coordinator, dora-message, dora-coordinator-store,
+shared-memory-server. About 1679 mutants last measured.
+
+A test-quality audit, NOT a code gate. Run when:
+  - Investigating low test coverage in a specific crate.
+  - Before a major release to score test-suite quality overall.
+  - Adding a new critical crate and want a baseline.
+
+Expect 10-18 hours on a fast machine. Background it and check the
+morning after. Timeouts are capped at 45s per mutant (was 120s,
+lowered after observed 52 full-timeout waits per 1008 mutants).
 ============================================================
 EOF
       ;;
@@ -170,22 +196,22 @@ case "$MODE" in
     # Adversarial LLM review skips cleanly on machines without codex/claude.
     run "adversarial" scripts/qa/adversarial.sh --optional
     ;;
+  --mutation-audit)
+    # Handled entirely below; skip the common test/coverage/adversarial path
+    # because this mode is explicitly about mutation testing, nothing else.
+    :
+    ;;
   *)
     echo "Unknown mode: $MODE"
-    echo "Usage: $0 [--fast|--full|--deep|--tier1|--nightly|--release-gate]"
+    echo "Usage: $0 [--fast|--full|--deep|--tier1|--nightly|--release-gate|--mutation-audit]"
     exit 2
     ;;
 esac
 
 case "$MODE" in
-  --deep|--release-gate)
+  --deep|--nightly|--release-gate)
     run "mutants (diff-scoped)" scripts/qa/mutants.sh
     run "semver"                scripts/qa/semver.sh
-    ;;
-  --nightly)
-    # Tier 2 skips the diff-scoped mutants run -- `mutants --full` below
-    # subsumes it.
-    run "semver" scripts/qa/semver.sh
     ;;
 esac
 
@@ -214,9 +240,9 @@ case "$MODE" in
     # or other filesystem ops that miri's isolation sandbox rejects.
     run_optional "miri" "cargo +nightly miri --version" \
       cargo +nightly miri test -p dora-core -- metadata::tests
-
-    # Full mutation testing (not diff-scoped). The default `qa-mutants` is
-    # diff-scoped for the Tier 1 PR gate; --full runs every function.
+    ;;
+  --mutation-audit)
+    # Deliberate full-repo mutation audit. Expect 10-18 hours.
     run "mutants (full-repo)" scripts/qa/mutants.sh --full
     ;;
 esac

--- a/scripts/qa/all.sh
+++ b/scripts/qa/all.sh
@@ -55,6 +55,18 @@ if [[ "$MODE" == "--tier1" ]]; then
   MODE="--deep"
 fi
 
+# Validate mode up front. An unknown mode should fail fast with zero side
+# effects -- do NOT run fast gates then error out at the end.
+case "$MODE" in
+  --fast|--full|--deep|--nightly|--release-gate|--mutation-audit)
+    ;;
+  *)
+    echo "Unknown mode: $MODE"
+    echo "Usage: $0 [--fast|--full|--deep|--tier1|--nightly|--release-gate|--mutation-audit]"
+    exit 2
+    ;;
+esac
+
 # Print a per-mode overview so a developer knows what they're about to
 # sit through. The actual checks follow the same order listed here.
 print_overview() {
@@ -197,14 +209,9 @@ case "$MODE" in
     run "adversarial" scripts/qa/adversarial.sh --optional
     ;;
   --mutation-audit)
-    # Handled entirely below; skip the common test/coverage/adversarial path
-    # because this mode is explicitly about mutation testing, nothing else.
+    # Skips the common test/coverage/adversarial path -- this mode is
+    # explicitly about mutation testing, nothing else.
     :
-    ;;
-  *)
-    echo "Unknown mode: $MODE"
-    echo "Usage: $0 [--fast|--full|--deep|--tier1|--nightly|--release-gate|--mutation-audit]"
-    exit 2
     ;;
 esac
 

--- a/scripts/qa/mutants.sh
+++ b/scripts/qa/mutants.sh
@@ -5,6 +5,13 @@
 # changed vs origin/main (--in-diff). Pass --full for the full repo.
 #
 # Install: cargo install cargo-mutants
+#
+# Timeout: 45s per mutant. 9x longer than a normal test, but short
+# enough that hang-inducing mutations (e.g. broken channels) fail
+# fast instead of burning 2 minutes each. Was 120s; lowered after an
+# observed --full run saw 52 120-second timeouts in the first 1008
+# mutants (= ~1h 44min pure timeout waste). If a real passing test
+# legitimately takes >45s, bump this back up.
 
 set -euo pipefail
 
@@ -24,12 +31,16 @@ CRITICAL_CRATES=(
   --package shared-memory-server
 )
 
+TIMEOUT=45
+
 if [[ "${1:-}" == "--full" ]]; then
-  echo "Running full-repo mutation test (this takes 1-4 hours)..."
+  echo "Running full-repo mutation test."
+  echo "On the dora workspace this has been measured at 10-18 hours."
+  echo "Use only when deliberately auditing test quality; not every nightly."
   cargo mutants \
     "${CRITICAL_CRATES[@]}" \
     --jobs 4 \
-    --timeout 120
+    --timeout "$TIMEOUT"
 else
   echo "Running diff mutation test vs origin/main..."
   DIFF_FILE="$(mktemp)"
@@ -39,5 +50,5 @@ else
     --in-diff "$DIFF_FILE" \
     "${CRITICAL_CRATES[@]}" \
     --jobs 4 \
-    --timeout 120
+    --timeout "$TIMEOUT"
 fi


### PR DESCRIPTION
## Problem

`qa-nightly` was advertised as a ~30-60 min / ~4 hour overnight Tier 2 run. A real run by a user hit **11 hours elapsed with ~7 hours remaining** (~18 hours total) because `mutants.sh --full` on the workspace generates **1679 mutants** and 52 of the first 1008 hit the **120-second mutation timeout wall each** (~1h 44m of pure timeout waste).

Sample log:

```
TIMEOUT  binaries/daemon/src/lib.rs:89:9: replace bench_support::setup_routing ... 148s build + 120s test
TIMEOUT  binaries/daemon/src/lib.rs:89:9: ... (9 consecutive mutations of same line, all 120s timeouts)
...
1008/1679 mutants tested, 52 timeout, 824 caught, 132 unviable, 11h elapsed, about 7h remaining
```

## Changes

### 1. Split full-repo mutation out of `qa-nightly`

`qa-nightly` now runs: `qa-deep + proptest@1000 + miri`. Expected **~30-60 min** instead of ~18 hours.

### 2. New target `qa-mutation-audit`

Full-repo `cargo-mutants --full` lives here now. Banner warns 10-18h. Run deliberately when:

- Investigating low test coverage in a specific crate.
- Before a release, to score test-suite quality overall.
- Adding a new critical crate and wanting a baseline.

### 3. Lower `cargo-mutants --timeout` from 120s to 45s

45s is still 9× longer than a normal test. Real passing tests won't hit it; hung mutations (e.g. broken channels) fail fast instead of burning 2 minutes each. Cuts timeout waste by ~63%.

### 4. Filed #1696 for the underlying test-quality bug

The 9 consecutive TIMEOUTs on `bench_support::setup_routing` indicate those daemon tests hang on broken routing state instead of asserting on the return shape. Real fix belongs in daemon tests, not the QA runner.

## Final ladder

```
qa-fast              ~1 min       pre-commit sanity
qa-full              ~5-10 min    pre-push
qa-deep              ~15 min      target Tier 1 gate (alias: qa-tier1)
qa-nightly           ~30-60 min   Tier 2 locally (proptest@1000 + miri, NO full mutation)
qa-release-gate                   Tier 3 automatable (audit/dogfood are human)
qa-mutation-audit    ~10-18 hrs   deliberate test-quality audit, NOT every nightly
```

## Docs swept

All consistent: `CLAUDE.md`, `Makefile` header comment, `README.md`, `docs/qa-runbook.md`, `docs/testing-matrix.md`, `docs/contributor-qa-cheatsheet.md`, plus the new `--mutation-audit` banner in `scripts/qa/all.sh`.

## Test plan

- [x] `make -n qa-nightly / qa-mutation-audit` dispatch correctly
- [x] Banners print accurate expectations for each mode
- [x] `scripts/qa/mutants.sh` timeout lowered to 45s
- [ ] CI green

Generated with Claude Code (https://claude.com/claude-code)
