### PR TITLE
qa: exclude bench_support from cargo-mutants scope (#1696 A)

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -66,4 +66,22 @@ exclude_re = [
     # The mutation name uniquely identifies this specific || → &&
     # replacement inside types_match (only one such mutation exists).
     "libraries/core/src/types\\.rs:.*replace \\|\\| with && in types_match",
+
+    # `bench_support` is gated behind `#[cfg(feature = "bench")]` and only
+    # called from `binaries/daemon/benches/routing.rs` (a criterion
+    # benchmark, not a test). No workspace test reaches these functions,
+    # so mutating them is guaranteed to MISS regardless of test quality
+    # -- adds noise to the mutation score and, when workspace tests are
+    # cache-invalidated, TIMEOUT noise too.
+    #
+    # See dora-rs/dora#1696 for the investigation. ~15 mutants skipped.
+    # Remove this waiver only if `bench_support::*` functions gain a
+    # caller inside the test build (i.e. no longer require the `bench`
+    # feature).
+    #
+    # Two regex flavors cover the two mutation text shapes:
+    # - "replace bench_support::<fn> -> <ty> with <expr>" (return-value mutations)
+    # - "delete ! in bench_support::<fn>" / "replace X with Y in bench_support::<fn>"
+    #   (operator/expr mutations inside the function body)
+    "binaries/daemon/src/lib\\.rs:.*bench_support::",
 ]


### PR DESCRIPTION
Addresses #1696 item A.

## Context

Re-investigation in #1696 showed that `bench_support` in `binaries/daemon/src/lib.rs:75-122` is:

- Gated behind `#[cfg(feature = "bench")]`, not in default features.
- Called only from `binaries/daemon/benches/routing.rs` (criterion benchmark binary).
- Unreachable from any workspace test.

So mutating these functions is guaranteed to produce MISSED or TIMEOUT regardless of test quality. At 30-120s per mutant and ~15 mutants affected, that's 7-30 min of wall time wasted per `qa-mutation-audit`.

## Change

Add one entry to `.cargo/mutants.toml` `exclude_re`:

```toml
"binaries/daemon/src/lib\\.rs:.*bench_support::",
```

**Regex-shape note** — cargo-mutants emits two mutation text flavors for a function in a module path:

- `replace bench_support::<fn> -> <ty> with <expr>` — return-value mutations
- `... in bench_support::<fn>` — operator/expr mutations inside the body

The simple substring `bench_support::` catches both. (First attempt used `in bench_support::` which missed the return-value shape — fixed after a `cargo mutants --list` check still showed 16 mutants.)

## Verified

```
$ cargo mutants --list --package dora-daemon | grep -c "bench_support"
0
```

Existing `types_match` waiver still effective:

```
$ cargo mutants --list --package dora-core | grep "replace || with && in types_match"
# no output (waived, as intended)
```

## What this does NOT address

Issue #1696 item B (strategy-level question about `test_workspace = true` interacting with per-mutation timeout) is still open. That's a design question, not a quick fix.

## Test plan

- [x] `cargo mutants --list --package dora-daemon` — 0 `bench_support` mutants
- [x] Existing `types_match` waiver still effective
- [x] Waiver comment explains when to remove (if `bench_support` gains a test-build caller)
- [ ] Next `make qa-mutation-audit` runs without the 9 `setup_routing` TIMEOUTs

Generated with Claude Code (https://claude.com/claude-code)
