### PR TITLE
ci(nightly): bump record step inner timeout 60s -> 300s (#1691)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -255,10 +255,14 @@ jobs:
           -p dora-record-node
       - name: Record rust-dataflow
         run: |
-          # All node binaries pre-built above, so this step is pure
-          # dataflow runtime. 60s catches genuine hangs without being
-          # sensitive to cargo incremental check overhead.
-          timeout 60s dora record examples/rust-dataflow/dataflow.yml -o run.drec
+          # Node binaries are pre-built above, but cargo's feature-
+          # unification across the prebuild and the descriptor's per-node
+          # `build: cargo build -p <node>` isn't reliable on cold caches:
+          # deps can re-link with different features and trigger a ~30s
+          # re-compile inside the record step (#1691, 2026-04-21 nightly).
+          # 300s absorbs that variance while still bounding genuine hangs
+          # well under the 30-min job timeout.
+          timeout 300s dora record examples/rust-dataflow/dataflow.yml -o run.drec
           test -f run.drec || { echo "record did not produce run.drec"; exit 1; }
           echo "recording size: $(wc -c < run.drec) bytes"
       - name: Replay


### PR DESCRIPTION
## Summary

- Bump the inner `timeout` on the nightly `Record rust-dataflow` step from 60s to 300s.
- The 2026-04-21 nightly hit exit 124 (#1691) with `rust-sink` still compiling `dora-node-api` + transitive zenoh deps when the wrapper fired — ~30s of rebuild happened *inside* `dora record` despite the prebuild step.

## Why the prebuild didn't hold

`nightly.yml:238-255` pre-builds the example nodes + `dora-record-node` in one cargo invocation so features unify across both. That keeps the record step at "pure runtime (~1-2s)" *on warm caches*. On cold caches, cargo's feature resolution between the prebuild and the descriptor's per-node `build: cargo build -p <node>` entries isn't reliable — deps can re-link with different feature sets and trigger a re-compile inside the record step.

Logs from `run 24708078409`:

```
06:55:36  Downloaded thiserror-impl v2.0.18
06:56:14  Compiling thiserror v2.0.18             <- prebuild
06:57:30  timeout 60s dora record ...              <- record step starts
06:58:14  rust-sink: stdout   Compiling thiserror-impl v2.0.18   <- same crate, recompiling
06:58:15  rust-sink: stdout   Compiling thiserror v2.0.18
06:58:27  rust-sink: stdout   Compiling dora-node-api v0.2.1
06:58:30  ##[error]Process completed with exit code 124            <- 60s wrapper hit
```

## Why 300s and not remove the wrapper entirely

300s bounds genuine hangs (daemon stuck, zenoh deadlock) well under the 30-min job timeout, without being sensitive to cold-cache cargo variance. Warm-cache runs still complete in ~1-2s as designed — no behavior change there.

## Notes

- 04-19 and 04-20 nightly failures on the same job were a different bug (the `/tmp` cargo bug, already fixed in #1674 / `badf0e42`). This PR addresses only the 04-21 failure mode.
- Comment in the workflow updated to explain *why* the 60s budget wasn't actually tight enough in practice, so future readers don't tighten it back.

## Test plan

- [ ] Local `git diff` shows only the nightly.yml timeout + comment change
- [ ] Next scheduled nightly run (2026-04-22 06:40 UTC) clears `Record/replay round-trip`
- [ ] Issue #1691 can be closed once the next nightly is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
