### PR TITLE
style: fmt replay.rs imports after #1714 merge regression

### DIFF
--- a/binaries/cli/src/command/replay.rs
+++ b/binaries/cli/src/command/replay.rs
@@ -7,7 +7,7 @@ use std::{
 
 use clap::Args;
 use dora_recording::RecordingReader;
-use eyre::{bail, Context};
+use eyre::{Context, bail};
 
 use crate::command::{Executable, Run};
 


### PR DESCRIPTION
Follow-up to #1714.

## Problem

`make qa-nightly` on `main` fails the fmt gate immediately:

```
=== fmt ===
Diff in /path/to/binaries/cli/src/command/replay.rs:7:
 use clap::Args;
 use dora_recording::RecordingReader;
-use eyre::{bail, Context};
+use eyre::{Context, bail};
  FAIL: fmt
```

## Cause

`#1714`'s squash-merge landed `use eyre::{bail, Context};` but rustfmt wants the items sorted case-sensitively → `{Context, bail}` (uppercase `C` < lowercase `b` in ASCII).

My local `cargo fmt -- --check` was clean on the PR branch before merge. The squash-merge apparently re-applied the commit diffs in an order that reverted the sort (the pre-formatter state landed instead of the post-formatter state). I don't have a clean explanation for why admin-squash did this, but the state on `main` right now is what matters.

## Fix

Re-run `cargo fmt --all`. One line changed.

```diff
-use eyre::{bail, Context};
+use eyre::{Context, bail};
```

## Test plan

- [x] `cargo fmt --all -- --check` clean locally
- [ ] CI fmt job passes on this PR
- [ ] `make qa-nightly` on main passes the fmt gate after merge

Trivial, no behavior change. Happy to land as a fixup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
