### PR TITLE
fix(qa): portable timeout shim so ci-nightly-jobs.sh works on macOS

### DIFF
--- a/scripts/qa/ci-nightly-jobs.sh
+++ b/scripts/qa/ci-nightly-jobs.sh
@@ -65,6 +65,30 @@ FAILED=()
 SKIPPED=()
 MANAGED_PIDS=()
 
+# -----------------------------------------------------------------------------
+# Portable `timeout` shim
+# -----------------------------------------------------------------------------
+# GNU coreutils `timeout` is standard on Linux but not on default macOS.
+# Homebrew's coreutils package installs it as `gtimeout` to avoid colliding
+# with BSD tools. If neither is available, fall back to running unbounded
+# with a loud warning so the user knows the time limit isn't enforced.
+if ! command -v timeout > /dev/null 2>&1; then
+  if command -v gtimeout > /dev/null 2>&1; then
+    timeout() { gtimeout "$@"; }
+  else
+    echo
+    echo "WARN: no 'timeout' or 'gtimeout' binary found."
+    echo "      On macOS, install via: brew install coreutils"
+    echo "      Jobs will run UNBOUNDED until they complete or you Ctrl-C."
+    echo
+    timeout() {
+      # Silently drop the duration arg and run the command unbounded.
+      shift
+      "$@"
+    }
+  fi
+fi
+
 # Install dora CLI into a scratch root we own, so we don't clobber the user's
 # ~/.cargo/bin/dora. Prepend to PATH for this script only. CLI_ROOT is also
 # the unique pattern we use to identify our own processes (see PROCESS SAFETY


### PR DESCRIPTION
Small fix for #1717 follow-up.

## Problem

`make qa-nightly` on macOS fails 4 jobs in a row because the script uses GNU coreutils `timeout` which isn't on default macOS:

```
=== record-replay ===
scripts/qa/ci-nightly-jobs.sh:219: timeout: command not found
ERROR: dora record failed or exceeded 300s
  FAIL: record-replay

=== topic-and-top-smoke ===
ERROR: --check-only didn't enter update-check path
  FAIL: topic-and-top-smoke
```

The `topic-and-top-smoke` failure is secondary: `timeout 30 dora self update --check-only 2>&1 || true` silently swallows the command-not-found error, then the subsequent `grep -q "Checking for updates"` assertion fires.

**Same cascade hit `cli-tests` and `bench-example`**, which both use `timeout` on long-running steps.

## Fix

Bash function `timeout()` defined at script top that shadows the missing binary:

```bash
if ! command -v timeout > /dev/null 2>&1; then
  if command -v gtimeout > /dev/null 2>&1; then
    timeout() { gtimeout "$@"; }
  else
    echo "WARN: no 'timeout' or 'gtimeout' binary found."
    echo "      On macOS, install via: brew install coreutils"
    echo "      Jobs will run UNBOUNDED until they complete or you Ctrl-C."
    timeout() { shift; "$@"; }
  fi
fi
```

All existing call sites (`timeout 60s cmd`, `timeout 300s dora record`, etc.) work unchanged.

## Behavior matrix

| Platform | `timeout` on PATH | `gtimeout` on PATH | Behavior |
|---|---|---|---|
| Linux | yes | typically no | Uses `/usr/bin/timeout` (no shim defined) |
| macOS + `brew install coreutils` | no | **yes** | Function delegates to `gtimeout` |
| macOS vanilla | no | no | Runs unbounded + prints WARN (once) |

Ubuntu CI runners are unaffected.

## Test plan

- [x] `bash -n scripts/qa/ci-nightly-jobs.sh` clean
- [ ] On macOS, `make qa-nightly` gets past record-replay / topic-and-top / cli-tests / bench-example without "command not found"
- [ ] On Linux CI, behavior unchanged (function not defined; built-in `timeout` used)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
