### PR TITLE
ci: run pip-release only on Mergify merge-queue branches and gate merge on it

### DIFF
--- a/.github/workflows/pip-release.yml
+++ b/.github/workflows/pip-release.yml
@@ -8,6 +8,16 @@
 
 name: pip-release
 
+# Triggers: release (publish to PyPI), workflow_dispatch (manual),
+# push to main (post-merge verification), and push to Mergify's
+# batched merge-queue branches. Building 24 wheels per PR push was
+# wasteful — now we build once per merge-queue batch (up to 5 PRs),
+# matching the expensive-job gating in .github/workflows/ci.yml.
+#
+# No `paths:` filter: pip-release is a required merge condition
+# (`pip-release all green` in .mergify.yml), so the check must always
+# be produced on merge-queue branches. A paths filter would cause
+# Mergify to wait forever on batches that don't touch Python/CLI.
 on:
   release:
     types:
@@ -16,16 +26,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
-    paths:
-      - "apis/python/node/**"
-      - "binaries/cli/**"
-      - "Cargo.toml"
+      - "mergify/merge-queue/**"
 
 env:
   RUST_VERSION: "1.92.0"
@@ -264,6 +265,23 @@ jobs:
         with:
           name: ${{ matrix.repository.name }}-sdist
           path: ${{ matrix.repository.path }}/dist
+
+  # Single aggregator check Mergify can gate on. Listing each matrix
+  # expansion in `.mergify.yml` merge_conditions is fragile (~24 names
+  # with generated suffixes); this one job fails if any build job
+  # failed and succeeds only when all matrix jobs succeeded.
+  pip-release-all-green:
+    name: pip-release all green
+    runs-on: ubuntu-22.04
+    needs: [linux, musllinux, musleabi, windows, macos, sdist]
+    if: always()
+    steps:
+      - name: Verify all build jobs succeeded
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "One or more pip-release build jobs failed or were cancelled."
+            exit 1
+          fi
 
   release:
     name: Release

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -53,6 +53,7 @@ queue_rules:
       - check-success=E2E Tests
       - check-success=Semantic contract tests
       - check-success=Benchmark regression check
+      - check-success=pip-release all green
 
 pull_request_rules:
   - name: queue approved PRs labelled `queue`


### PR DESCRIPTION
Swap the pull_request trigger for a push trigger on mergify/merge-queue/** so the ~24 wheel-build jobs run once per batched queue merge instead of on every PR push. Add a `pip-release all green` aggregator job and add it to the Mergify merge_conditions so a broken wheel build blocks the batch from merging. No paths filter on the push trigger — the aggregator check must always be produced on merge-queue branches, otherwise Mergify waits forever on batches that don't touch Python/CLI.