### PR TITLE
fix: initialize Operator::counter to 0 in C++ operator examples

### DIFF
--- a/examples/c++-dataflow/operator-rust-api/operator.h
+++ b/examples/c++-dataflow/operator-rust-api/operator.h
@@ -6,7 +6,7 @@ class Operator
 {
 public:
     Operator();
-    unsigned char counter;
+    unsigned char counter = 0;
 };
 
 #include "../build/dora-operator-api.h"

--- a/examples/cmake-dataflow/operator-rust-api/operator.h
+++ b/examples/cmake-dataflow/operator-rust-api/operator.h
@@ -6,7 +6,7 @@ class Operator
 {
 public:
     Operator();
-    unsigned char counter;
+    unsigned char counter = 0;
 };
 
 #include "dora-operator-api.h"


### PR DESCRIPTION
## Summary

`unsigned char counter` in the `Operator` class was left uninitialized,
causing undefined behavior — the internal counter started at a garbage
value (e.g. 210) on the first tick instead of 0.

Added an in-class member initializer `= 0` to both `c++-dataflow` and
`cmake-dataflow` examples.

## Exposed by

Running `examples/c++-dataflow` — operator output showed
`internal counter: 210` on the first tick instead of `1`.

## Test results

- `examples/c++-dataflow`: first tick prints `internal counter: 1` ✅