### PR TITLE
fix: use current_exe() instead of which("dora") to locate runtime binary

### DIFF
--- a/binaries/daemon/src/spawn/spawner.rs
+++ b/binaries/daemon/src/spawn/spawner.rs
@@ -297,8 +297,9 @@ impl Spawner {
                         ]);
                         Some(cmd)
                     } else {
-                        let mut cmd =
-                            Command::new(which::which("dora").wrap_err("failed to get dora path")?);
+                        let current_exe = std::env::current_exe()
+                            .wrap_err("failed to get current executable path")?;
+                        let mut cmd = Command::new(current_exe);
                         cmd = cmd.arg("runtime");
                         Some(cmd)
                     }


### PR DESCRIPTION
## Summary

The daemon used `which::which("dora")` to resolve the binary path for
spawning runtime nodes. This resolves to whichever `dora` appears first
in `$PATH`, which may be a different version than the running daemon.

Changed to `std::env::current_exe()` so the daemon always invokes its
own binary with the `runtime` subcommand, guaranteeing version
consistency.

## Exposed by

Running `examples/c++-dataflow` with a locally-built binary while a
different version of `dora` was present in `$PATH` — runtime nodes
failed with "No such file or directory".