### PR TITLE
fix: prevent auto-recovery race and handle LogSubscribe for finished …

### DIFF
--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -1575,6 +1575,11 @@ async fn start_inner(
                             send_log_message(&mut dataflow.log_subscribers, &message).await;
                         }
                         let _ = found_tx.send(true);
+                    } else if archived_dataflows.contains_key(&dataflow_id) {
+                        // Dataflow already finished before the CLI could subscribe.
+                        // Acknowledge the subscription so the CLI doesn't error, then
+                        // drop `sender` immediately — the closed channel signals EOF.
+                        let _ = found_tx.send(true);
                     } else {
                         let _ = found_tx.send(false);
                     }
@@ -2034,6 +2039,10 @@ async fn start_inner(
                     if let Some(last) = df.last_recovery_attempt.get(&daemon_id)
                         && now.duration_since(*last) < RECOVERY_BACKOFF
                     {
+                        continue;
+                    }
+                    // Skip if a spawn is already in-flight for this daemon
+                    if df.pending_spawn_results.contains(&daemon_id) {
                         continue;
                     }
                     // Collect nodes assigned to this daemon


### PR DESCRIPTION
## Summary

Two bugs found while running `examples/cpu-affinity-probe`:

**Bug 1 — auto-recovery race condition**

When a daemon first connects, it sends a `DaemonStatusReport` with zero
running dataflows because the spawn is still in-flight. The
auto-recovery block treated this as a missing dataflow and triggered a
redundant re-spawn. Fix: skip recovery if `pending_spawn_results`
already contains the daemon.

**Bug 2 — LogSubscribe for already-finished dataflows**

Short-lived nodes finish before the CLI can subscribe to logs. The
handler only checked `running_dataflows`, returning `found=false` for
finished dataflows. Fix: check `archived_dataflows` and return
`found=true` so the CLI receives a clean EOF instead of an error.

## Exposed by

Running `examples/cpu-affinity-probe` — the node exits in under 100ms,
reliably triggering both the spawn race and the log-subscribe timing
window.
