### PR TITLE
fix: handle empty parent path when resolving dataflow working directory

### DIFF
--- a/binaries/cli/src/command/expand.rs
+++ b/binaries/cli/src/command/expand.rs
@@ -25,6 +25,7 @@ impl Executable for Expand {
         let working_dir = self
             .dataflow
             .parent()
+            .filter(|p| !p.as_os_str().is_empty())
             .unwrap_or_else(|| std::path::Path::new("."));
         let descriptor = Descriptor::blocking_read(&self.dataflow)
             .with_context(|| format!("failed to read dataflow at `{}`", self.dataflow.display()))?

--- a/binaries/cli/src/command/graph.rs
+++ b/binaries/cli/src/command/graph.rs
@@ -87,6 +87,7 @@ pub fn visualize_as_html(dataflow: &Path) -> eyre::Result<String> {
 pub fn visualize_as_mermaid(dataflow: &Path) -> eyre::Result<String> {
     let working_dir = dataflow
         .parent()
+        .filter(|p| !p.as_os_str().is_empty())
         .unwrap_or_else(|| std::path::Path::new("."));
     let raw = Descriptor::blocking_read(dataflow)
         .with_context(|| format!("failed to read dataflow at `{}`", dataflow.display()))?;

--- a/binaries/cli/src/command/start/mod.rs
+++ b/binaries/cli/src/command/start/mod.rs
@@ -114,6 +114,7 @@ fn start_dataflow(
     let dataflow = resolve_dataflow(dataflow).context("could not resolve dataflow")?;
     let working_dir = dataflow
         .parent()
+        .filter(|p| !p.as_os_str().is_empty())
         .unwrap_or_else(|| std::path::Path::new("."));
     let mut dataflow_descriptor = Descriptor::blocking_read(&dataflow)
         .wrap_err_with(|| {

--- a/binaries/cli/src/command/validate.rs
+++ b/binaries/cli/src/command/validate.rs
@@ -25,6 +25,7 @@ impl Executable for Validate {
         let working_dir = self
             .dataflow
             .parent()
+            .filter(|p| !p.as_os_str().is_empty())
             .unwrap_or_else(|| std::path::Path::new("."));
 
         println!("Validating {}...", self.dataflow.display());

--- a/binaries/cli/src/common.rs
+++ b/binaries/cli/src/common.rs
@@ -232,7 +232,10 @@ pub(crate) fn working_dir_or_parent<'a>(
 ) -> &'a Path {
     match override_ {
         Some(p) => p,
-        None => dataflow_path.parent().unwrap_or_else(|| Path::new(".")),
+        None => dataflow_path
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new(".")),
     }
 }
 
@@ -323,7 +326,7 @@ mod tests {
         // `Path::parent()` on "dataflow.yml" returns `Some("")` not `None`.
         // The helper should ultimately treat this as "." (current dir).
         let dataflow = Path::new("dataflow.yml");
-        assert_eq!(working_dir_or_parent(None, dataflow), Path::new(""));
+        assert_eq!(working_dir_or_parent(None, dataflow), Path::new("."));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`Path::parent()` returns `Some("")` for bare filenames like
`"dataflow.yml"`, not `None`. The existing `.unwrap_or(Path::new("."))`
fallback only triggers on `None`, so `canonicalize("")` fails with
"No such file or directory" when the CLI tries to expand module
references.

Added `.filter(|p| !p.as_os_str().is_empty())` before the fallback in
the central `working_dir_or_parent()` helper and all 4 direct call
sites (start, expand, graph, validate). Updated the unit test to assert
the corrected behavior.

## Exposed by

Running `examples/module-dataflow` — `dora run dataflow.yml` from the
example directory triggers the empty base_dir path, failing module
expansion.