### PR TITLE
ci(Mergify): set merge_queue max_parallel_checks to 1

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -55,6 +55,9 @@ queue_rules:
       - check-success=Benchmark regression check
       - check-success=pip-release all green
 
+merge_queue:
+  max_parallel_checks: 1
+
 pull_request_rules:
   - name: queue approved PRs labelled `queue`
     conditions:


### PR DESCRIPTION
Serializes merge-queue CI runs so only one batched queue branch's checks run at a time, matching our limited CI parallelism budget. Without this, Mergify can kick off checks on multiple queue branches in parallel and saturate the runner pool.