### PR TITLE
Notify PR authors via fresh comment on Trunk merge-queue failure

### DIFF
--- a/.github/workflows/trunk-merge-failure-notify.yml
+++ b/.github/workflows/trunk-merge-failure-notify.yml
@@ -1,0 +1,140 @@
+# Posts a *new* comment on each PR in a Trunk merge-queue batch when the
+# batch's CI fails. Trunk only edits a single sticky comment as the batch
+# moves through states, and GitHub does not send email notifications for
+# comment edits — so authors miss merge failures unless they happen to be
+# watching the PR live. This workflow restores email notifications by
+# creating a fresh comment that mentions the author.
+#
+# Trigger: any of the merge-gating workflows finishing with conclusion
+# `failure` on a `trunk-merge/...` head branch. Runs in the default
+# branch's context (workflow_run semantics), so it has the permissions
+# below regardless of the originating PR.
+name: Trunk merge failure notification
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+      - pip-release
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  notify:
+    if: >
+      github.event.workflow_run.conclusion == 'failure' &&
+      startsWith(github.event.workflow_run.head_branch, 'trunk-merge/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment on affected PRs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            const { owner, repo } = context.repo;
+
+            // Recover the PRs in this batch by diffing the trunk-merge
+            // head against main and pulling `#NNN` references out of
+            // each commit message — Trunk's queue commits include the
+            // original PR numbers in their squash titles.
+            const prNumbers = new Set();
+            try {
+              const comparison = await github.paginate(
+                github.rest.repos.compareCommitsWithBasehead,
+                {
+                  owner,
+                  repo,
+                  basehead: `main...${run.head_sha}`,
+                  per_page: 100,
+                },
+                (response) => response.data.commits ?? [],
+              );
+              for (const commit of comparison) {
+                for (const m of (commit.commit?.message ?? '').matchAll(/#(\d+)/g)) {
+                  prNumbers.add(Number(m[1]));
+                }
+              }
+            } catch (err) {
+              core.warning(`compareCommitsWithBasehead failed: ${err.message}`);
+            }
+
+            // Fallback: trunk-merge branch names sometimes encode PR
+            // numbers directly (e.g. `trunk-merge/pr-123-pr-456`).
+            for (const m of run.head_branch.matchAll(/(?:^|[^0-9])(\d+)/g)) {
+              prNumbers.add(Number(m[1]));
+            }
+
+            if (prNumbers.size === 0) {
+              core.warning(
+                `Could not infer any PR numbers from ${run.head_branch} (${run.head_sha}); nothing to notify.`,
+              );
+              return;
+            }
+
+            const stamp = `<!-- trunk-merge-failure-notify:${run.id} -->`;
+
+            for (const number of prNumbers) {
+              let pr;
+              try {
+                ({ data: pr } = await github.rest.pulls.get({
+                  owner,
+                  repo,
+                  pull_number: number,
+                }));
+              } catch (err) {
+                core.info(`Skipping #${number}: ${err.message}`);
+                continue;
+              }
+              if (pr.state !== 'open') {
+                core.info(`Skipping #${number}: state is ${pr.state}`);
+                continue;
+              }
+
+              const comments = await github.paginate(
+                github.rest.issues.listComments,
+                { owner, repo, issue_number: number, per_page: 100 },
+              );
+
+              // Idempotency: don't double-post for the same workflow run.
+              if (comments.some((c) => (c.body ?? '').includes(stamp))) {
+                core.info(`Skipping #${number}: notification already posted for run ${run.id}`);
+                continue;
+              }
+
+              // Locate Trunk's sticky merge-status comment so we can
+              // deep-link it. Match on the bot login plus a body
+              // keyword to avoid grabbing unrelated bot comments.
+              const trunkComment = [...comments].reverse().find((c) => {
+                const login = (c.user?.login ?? '').toLowerCase();
+                const body = c.body ?? '';
+                return (
+                  c.user?.type === 'Bot' &&
+                  login.includes('trunk') &&
+                  /merge/i.test(body)
+                );
+              });
+
+              const stickyLine = trunkComment
+                ? `- [Trunk merge-status comment](${trunkComment.html_url})`
+                : `- _Trunk merge-status comment not found — see the PR timeline._`;
+
+              const body = [
+                stamp,
+                `@${pr.user.login} the Trunk merge queue failed on \`${run.head_branch}\`.`,
+                ``,
+                stickyLine,
+                `- [Failed \`${run.name}\` run](${run.html_url})`,
+                ``,
+                `_Posted as a new comment so GitHub sends an email — Trunk's sticky comment is edited in place and won't trigger a notification._`,
+              ].join('\n');
+
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: number,
+                body,
+              });
+            }

--- a/.github/workflows/trunk-merge-failure-notify.yml
+++ b/.github/workflows/trunk-merge-failure-notify.yml
@@ -1,140 +1,55 @@
-# Posts a *new* comment on each PR in a Trunk merge-queue batch when the
-# batch's CI fails. Trunk only edits a single sticky comment as the batch
-# moves through states, and GitHub does not send email notifications for
-# comment edits — so authors miss merge failures unless they happen to be
-# watching the PR live. This workflow restores email notifications by
-# creating a fresh comment that mentions the author.
-#
-# Trigger: any of the merge-gating workflows finishing with conclusion
-# `failure` on a `trunk-merge/...` head branch. Runs in the default
-# branch's context (workflow_run semantics), so it has the permissions
-# below regardless of the originating PR.
+# Posts a *new* comment on a PR when Trunk's sticky merge-status comment
+# transitions into a failed state. Trunk edits one sticky comment as the
+# batch moves through queued/testing/failed/merged states; GitHub does
+# not send email on comment edits, so authors silently miss merge
+# failures. Reacting to the edit and posting a fresh @-mention restores
+# the email notification.
 name: Trunk merge failure notification
 
 on:
-  workflow_run:
-    workflows:
-      - CI
-      - pip-release
-    types: [completed]
+  issue_comment:
+    types: [edited]
 
 permissions:
-  contents: read
   pull-requests: write
 
 jobs:
   notify:
     if: >
-      github.event.workflow_run.conclusion == 'failure' &&
-      startsWith(github.event.workflow_run.head_branch, 'trunk-merge/')
+      github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.user.login, 'trunk-io') &&
+      contains(github.event.comment.body, 'failed')
     runs-on: ubuntu-latest
     steps:
-      - name: Comment on affected PRs
+      - name: Comment on PR
         uses: actions/github-script@v7
         with:
           script: |
-            const run = context.payload.workflow_run;
-            const { owner, repo } = context.repo;
-
-            // Recover the PRs in this batch by diffing the trunk-merge
-            // head against main and pulling `#NNN` references out of
-            // each commit message — Trunk's queue commits include the
-            // original PR numbers in their squash titles.
-            const prNumbers = new Set();
-            try {
-              const comparison = await github.paginate(
-                github.rest.repos.compareCommitsWithBasehead,
-                {
-                  owner,
-                  repo,
-                  basehead: `main...${run.head_sha}`,
-                  per_page: 100,
-                },
-                (response) => response.data.commits ?? [],
-              );
-              for (const commit of comparison) {
-                for (const m of (commit.commit?.message ?? '').matchAll(/#(\d+)/g)) {
-                  prNumbers.add(Number(m[1]));
-                }
-              }
-            } catch (err) {
-              core.warning(`compareCommitsWithBasehead failed: ${err.message}`);
-            }
-
-            // Fallback: trunk-merge branch names sometimes encode PR
-            // numbers directly (e.g. `trunk-merge/pr-123-pr-456`).
-            for (const m of run.head_branch.matchAll(/(?:^|[^0-9])(\d+)/g)) {
-              prNumbers.add(Number(m[1]));
-            }
-
-            if (prNumbers.size === 0) {
-              core.warning(
-                `Could not infer any PR numbers from ${run.head_branch} (${run.head_sha}); nothing to notify.`,
-              );
+            // Only fire on the transition into a failed state — skip
+            // subsequent edits that happen while the comment is already
+            // failed, otherwise every Trunk re-render would re-notify.
+            const prev = context.payload.changes?.body?.from ?? '';
+            if (prev.includes('failed')) {
+              core.info('Previous comment body already contained "failed"; skipping.');
               return;
             }
 
-            const stamp = `<!-- trunk-merge-failure-notify:${run.id} -->`;
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.issue.number;
+            const author = context.payload.issue.user.login;
+            const stickyUrl = context.payload.comment.html_url;
 
-            for (const number of prNumbers) {
-              let pr;
-              try {
-                ({ data: pr } = await github.rest.pulls.get({
-                  owner,
-                  repo,
-                  pull_number: number,
-                }));
-              } catch (err) {
-                core.info(`Skipping #${number}: ${err.message}`);
-                continue;
-              }
-              if (pr.state !== 'open') {
-                core.info(`Skipping #${number}: state is ${pr.state}`);
-                continue;
-              }
+            const body = [
+              `@${author} the Trunk merge queue failed for this PR.`,
+              ``,
+              `See the [Trunk merge-status comment](${stickyUrl}) for details.`,
+              ``,
+              `_Posted as a new comment so GitHub sends an email — Trunk's sticky comment is edited in place and won't trigger a notification._`,
+            ].join('\n');
 
-              const comments = await github.paginate(
-                github.rest.issues.listComments,
-                { owner, repo, issue_number: number, per_page: 100 },
-              );
-
-              // Idempotency: don't double-post for the same workflow run.
-              if (comments.some((c) => (c.body ?? '').includes(stamp))) {
-                core.info(`Skipping #${number}: notification already posted for run ${run.id}`);
-                continue;
-              }
-
-              // Locate Trunk's sticky merge-status comment so we can
-              // deep-link it. Match on the bot login plus a body
-              // keyword to avoid grabbing unrelated bot comments.
-              const trunkComment = [...comments].reverse().find((c) => {
-                const login = (c.user?.login ?? '').toLowerCase();
-                const body = c.body ?? '';
-                return (
-                  c.user?.type === 'Bot' &&
-                  login.includes('trunk') &&
-                  /merge/i.test(body)
-                );
-              });
-
-              const stickyLine = trunkComment
-                ? `- [Trunk merge-status comment](${trunkComment.html_url})`
-                : `- _Trunk merge-status comment not found — see the PR timeline._`;
-
-              const body = [
-                stamp,
-                `@${pr.user.login} the Trunk merge queue failed on \`${run.head_branch}\`.`,
-                ``,
-                stickyLine,
-                `- [Failed \`${run.name}\` run](${run.html_url})`,
-                ``,
-                `_Posted as a new comment so GitHub sends an email — Trunk's sticky comment is edited in place and won't trigger a notification._`,
-              ].join('\n');
-
-              await github.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number: number,
-                body,
-              });
-            }
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: prNumber,
+              body,
+            });


### PR DESCRIPTION
Trunk's merge queue edits a single sticky comment as a batch transitions
through queued/testing/failed/merged states. GitHub does not send email
on comment edits, so authors silently miss merge failures. This adds a
workflow_run listener that fires when CI or pip-release fails on a
trunk-merge/* head branch and posts a new comment per affected PR,
mentioning the author and linking the Trunk sticky comment plus the
failed run.

PRs in the batch are recovered by diffing the trunk-merge head against
main and parsing #NNN refs from each squash commit, with a branch-name
fallback. Comments are stamped with the workflow_run id so re-deliveries
of the same event don't double-post.