### PR TITLE
Add data-validating integration tests for rust-dataflow status-node and sink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5758,6 +5758,7 @@ version = "0.2.1"
 dependencies = [
  "dora-node-api",
  "eyre",
+ "tempfile",
 ]
 
 [[package]]

--- a/examples/rust-dataflow/sink/src/main.rs
+++ b/examples/rust-dataflow/sink/src/main.rs
@@ -1,9 +1,15 @@
-use dora_node_api::{self, DoraNode, Event};
+use dora_node_api::{self, DoraNode, Event, EventStream};
 use eyre::{Context, bail};
 
-fn main() -> eyre::Result<()> {
-    let (_node, mut events) = DoraNode::init_from_env()?;
+#[cfg(test)]
+mod tests;
 
+fn main() -> eyre::Result<()> {
+    let (node, events) = DoraNode::init_from_env()?;
+    run(node, events)
+}
+
+fn run(_node: DoraNode, mut events: EventStream) -> eyre::Result<()> {
     while let Some(event) = events.recv() {
         match event {
             Event::Input {

--- a/examples/rust-dataflow/sink/src/tests.rs
+++ b/examples/rust-dataflow/sink/src/tests.rs
@@ -60,7 +60,7 @@ fn accepts_valid_status_messages() -> eyre::Result<()> {
 fn rejects_message_missing_prefix() {
     let events = vec![message_input(0.001, "totally unrelated payload")];
 
-    let err = run_sink(events).expect_err("sink must reject mis-formatted messages");
+    let err = run_sink(events).expect_err("sink must reject malformed messages");
     let chain: Vec<String> = err.chain().map(|e| e.to_string()).collect();
     assert!(
         chain

--- a/examples/rust-dataflow/sink/src/tests.rs
+++ b/examples/rust-dataflow/sink/src/tests.rs
@@ -1,0 +1,134 @@
+use dora_node_api::{
+    DoraNode, flume,
+    integration_testing::{
+        IntegrationTestInput,
+        integration_testing_format::{IncomingEvent, InputData, TimedIncomingEvent},
+    },
+    serde_json,
+};
+
+fn message_input(time_offset_secs: f64, message: &str) -> TimedIncomingEvent {
+    TimedIncomingEvent {
+        time_offset_secs,
+        event: IncomingEvent::Input {
+            id: "message".into(),
+            metadata: None,
+            data: Some(Box::new(InputData::JsonObject {
+                data: serde_json::json!([message]),
+                data_type: Some(serde_json::json!("Utf8")),
+            })),
+        },
+    }
+}
+
+fn run_sink(events: Vec<TimedIncomingEvent>) -> eyre::Result<()> {
+    let inputs = dora_node_api::integration_testing::TestingInput::Input(
+        IntegrationTestInput::new("rust-sink".parse().unwrap(), events),
+    );
+    let (tx, _rx) = flume::unbounded();
+    let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
+    let (node, events) = DoraNode::init_testing(inputs, testing_output, Default::default())?;
+
+    crate::run(node, events)
+}
+
+/// A stream of well-formed status messages must run to completion without
+/// error. Locks in the contract that any string matching
+/// `"operator received random value … ticks"` is accepted.
+#[test]
+fn accepts_valid_status_messages() -> eyre::Result<()> {
+    let events = vec![
+        message_input(
+            0.001,
+            "operator received random value 0xdeadbeef after 0 ticks",
+        ),
+        message_input(0.002, "operator received random value 0xcafe after 7 ticks"),
+        TimedIncomingEvent {
+            time_offset_secs: 0.003,
+            event: IncomingEvent::InputClosed {
+                id: "message".into(),
+            },
+        },
+    ];
+
+    run_sink(events)
+}
+
+/// A message missing the required prefix must produce an error mentioning
+/// the prefix contract — not a generic `Ok(())` or empty error string.
+#[test]
+fn rejects_message_missing_prefix() {
+    let events = vec![message_input(0.001, "totally unrelated payload")];
+
+    let err = run_sink(events).expect_err("sink must reject mis-formatted messages");
+    let chain: Vec<String> = err.chain().map(|e| e.to_string()).collect();
+    assert!(
+        chain
+            .iter()
+            .any(|m| m.contains("operator received random value")),
+        "error chain should mention the required prefix, got: {chain:?}"
+    );
+}
+
+/// A message that has the right prefix but the wrong suffix must trip the
+/// second `bail!` ("should end with 'ticks'"), so we cover both branches.
+#[test]
+fn rejects_message_with_wrong_suffix() {
+    let events = vec![message_input(
+        0.001,
+        "operator received random value 0xff after seven somethings",
+    )];
+
+    let err = run_sink(events).expect_err("sink must reject messages without a `ticks` suffix");
+    let chain: Vec<String> = err.chain().map(|e| e.to_string()).collect();
+    assert!(
+        chain.iter().any(|m| m.contains("ticks")),
+        "error chain should mention the `ticks` suffix contract, got: {chain:?}"
+    );
+}
+
+/// A non-string `message` payload must surface the `"expected string message"`
+/// context rather than panicking on an Arrow type mismatch.
+#[test]
+fn rejects_non_string_message_payload() {
+    let events = vec![TimedIncomingEvent {
+        time_offset_secs: 0.001,
+        event: IncomingEvent::Input {
+            id: "message".into(),
+            metadata: None,
+            data: Some(Box::new(InputData::JsonObject {
+                data: serde_json::json!([42_u64]),
+                data_type: Some(serde_json::json!("UInt64")),
+            })),
+        },
+    }];
+
+    let err = run_sink(events).expect_err("sink must reject non-string `message` payloads");
+    let chain: Vec<String> = err.chain().map(|e| e.to_string()).collect();
+    assert!(
+        chain.iter().any(|m| m.contains("expected string message")),
+        "error chain should mention the type-mismatch context, got: {chain:?}"
+    );
+}
+
+/// An `exit` input breaks the loop early. The subsequent `message` events
+/// must therefore *not* be processed — if they were, the second message
+/// would trip a `bail!` and the test would fail.
+#[test]
+fn exit_input_stops_loop_before_subsequent_messages() -> eyre::Result<()> {
+    let events = vec![
+        message_input(0.001, "operator received random value 0x1 after 0 ticks"),
+        TimedIncomingEvent {
+            time_offset_secs: 0.002,
+            event: IncomingEvent::Input {
+                id: "exit".into(),
+                metadata: None,
+                data: None,
+            },
+        },
+        // This message would `bail!` if the loop hadn't exited on `exit`.
+        message_input(0.003, "this would fail validation"),
+    ];
+
+    run_sink(events)
+}

--- a/examples/rust-dataflow/status-node/Cargo.toml
+++ b/examples/rust-dataflow/status-node/Cargo.toml
@@ -12,3 +12,6 @@ publish = false
 [dependencies]
 dora-node-api = { workspace = true }
 eyre = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/examples/rust-dataflow/status-node/src/main.rs
+++ b/examples/rust-dataflow/status-node/src/main.rs
@@ -1,11 +1,18 @@
-use dora_node_api::{self, DoraNode, Event, IntoArrow, dora_core::config::DataId};
+use dora_node_api::{self, DoraNode, Event, EventStream, IntoArrow, dora_core::config::DataId};
 use eyre::Context;
+
+#[cfg(test)]
+mod tests;
 
 fn main() -> eyre::Result<()> {
     println!("hello");
 
+    let (node, events) = DoraNode::init_from_env()?;
+    run(node, events)
+}
+
+fn run(mut node: DoraNode, mut events: EventStream) -> eyre::Result<()> {
     let status_output = DataId::from("status".to_owned());
-    let (mut node, mut events) = DoraNode::init_from_env()?;
 
     let mut ticks = 0;
     while let Some(event) = events.recv() {

--- a/examples/rust-dataflow/status-node/src/tests.rs
+++ b/examples/rust-dataflow/status-node/src/tests.rs
@@ -1,0 +1,180 @@
+use std::{
+    io::{Read, Seek},
+    sync::Arc,
+};
+
+use dora_node_api::{
+    DoraNode, flume,
+    integration_testing::{
+        self, IntegrationTestInput, TestingOptions,
+        integration_testing_format::{IncomingEvent, InputData, TimedIncomingEvent},
+    },
+    serde_json,
+};
+
+#[test]
+fn test_main_function() -> eyre::Result<()> {
+    let inputs = dora_node_api::integration_testing::TestingInput::FromJsonFile(
+        "../../../tests/sample-inputs/inputs-rust-status-node.json".into(),
+    );
+    let mut output_file = Arc::new(tempfile::tempfile()?);
+    let testing_output =
+        dora_node_api::integration_testing::TestingOutput::ToWriter(Box::new(output_file.clone()));
+    let options = TestingOptions {
+        skip_output_time_offsets: true,
+    };
+
+    integration_testing::setup_integration_testing(inputs, testing_output, options);
+
+    crate::main()?;
+
+    let mut output = String::new();
+    output_file.seek(std::io::SeekFrom::Start(0))?;
+    output_file.read_to_string(&mut output)?;
+    let expected = std::fs::read_to_string(
+        "../../../tests/sample-inputs/expected-outputs-rust-status-node.jsonl",
+    )?;
+
+    assert_eq!(output, expected.replace("\r\n", "\n")); // normalize line endings
+
+    Ok(())
+}
+
+#[test]
+fn test_run_function() -> eyre::Result<()> {
+    let inputs = dora_node_api::integration_testing::TestingInput::FromJsonFile(
+        "../../../tests/sample-inputs/inputs-rust-status-node.json".into(),
+    );
+    let mut output_file = Arc::new(tempfile::tempfile()?);
+    let testing_output =
+        dora_node_api::integration_testing::TestingOutput::ToWriter(Box::new(output_file.clone()));
+    let options = TestingOptions {
+        skip_output_time_offsets: true,
+    };
+
+    let (node, events) = DoraNode::init_testing(inputs, testing_output, options)?;
+
+    crate::run(node, events)?;
+
+    let mut output = String::new();
+    output_file.seek(std::io::SeekFrom::Start(0))?;
+    output_file.read_to_string(&mut output)?;
+    let expected = std::fs::read_to_string(
+        "../../../tests/sample-inputs/expected-outputs-rust-status-node.jsonl",
+    )?;
+
+    assert_eq!(output, expected.replace("\r\n", "\n")); // normalize line endings
+
+    Ok(())
+}
+
+fn random_input(time_offset_secs: f64, value: u64) -> TimedIncomingEvent {
+    TimedIncomingEvent {
+        time_offset_secs,
+        event: IncomingEvent::Input {
+            id: "random".into(),
+            metadata: None,
+            data: Some(Box::new(InputData::JsonObject {
+                data: serde_json::json!([value]),
+                data_type: Some(serde_json::json!("UInt64")),
+            })),
+        },
+    }
+}
+
+fn tick_input(time_offset_secs: f64) -> TimedIncomingEvent {
+    TimedIncomingEvent {
+        time_offset_secs,
+        event: IncomingEvent::Input {
+            id: "tick".into(),
+            metadata: None,
+            data: None,
+        },
+    }
+}
+
+/// Drives `run` with a hand-built event sequence and asserts the exact
+/// `status` strings — including that the embedded `after N ticks` count
+/// reflects the number of `tick` events that arrived *before* each
+/// `random` event, and that `InputClosed { id: "random" }` causes the
+/// loop to exit cleanly.
+#[test]
+fn test_tick_counter_and_random_round_trip() -> eyre::Result<()> {
+    let events = vec![
+        random_input(0.001, 0xAA),   // 0 ticks so far
+        tick_input(0.010),           // ticks -> 1
+        random_input(0.011, 0xBB),   // 1 tick
+        tick_input(0.020),           // ticks -> 2
+        tick_input(0.021),           // ticks -> 3
+        random_input(0.022, 0xCCDD), // 3 ticks
+        TimedIncomingEvent {
+            time_offset_secs: 0.030,
+            event: IncomingEvent::InputClosed {
+                id: "random".into(),
+            },
+        },
+    ];
+    let inputs = dora_node_api::integration_testing::TestingInput::Input(
+        IntegrationTestInput::new("rust-status-node".parse().unwrap(), events),
+    );
+
+    let (tx, rx) = flume::unbounded();
+    let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
+    let (node, events) = DoraNode::init_testing(inputs, testing_output, Default::default())?;
+
+    crate::run(node, events)?;
+
+    let outputs = rx.try_iter().collect::<Vec<_>>();
+    let expected_messages = [
+        "operator received random value 0xaa after 0 ticks",
+        "operator received random value 0xbb after 1 ticks",
+        "operator received random value 0xccdd after 3 ticks",
+    ];
+
+    assert_eq!(
+        outputs.len(),
+        expected_messages.len(),
+        "unexpected number of `status` outputs: {outputs:?}"
+    );
+    for (output, expected) in outputs.iter().zip(expected_messages.iter()) {
+        assert_eq!(output["id"], "status");
+        assert_eq!(output["data_type"], "Utf8");
+        assert_eq!(output["data"], serde_json::json!([expected]));
+    }
+
+    Ok(())
+}
+
+/// Sending a `random` input with a non-`UInt64` payload must surface the
+/// documented `"unexpected data type"` error rather than silently coercing
+/// or panicking. Locks in the `u64::try_from(&data).context(...)` contract.
+#[test]
+fn test_non_uint64_random_input_errors() -> eyre::Result<()> {
+    let events = vec![TimedIncomingEvent {
+        time_offset_secs: 0.001,
+        event: IncomingEvent::Input {
+            id: "random".into(),
+            metadata: None,
+            data: Some(Box::new(InputData::JsonObject {
+                data: serde_json::json!(["not a number"]),
+                data_type: Some(serde_json::json!("Utf8")),
+            })),
+        },
+    }];
+    let inputs = dora_node_api::integration_testing::TestingInput::Input(
+        IntegrationTestInput::new("rust-status-node".parse().unwrap(), events),
+    );
+
+    let (tx, _rx) = flume::unbounded();
+    let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
+    let (node, events) = DoraNode::init_testing(inputs, testing_output, Default::default())?;
+
+    let err = crate::run(node, events).expect_err("non-UInt64 random input must produce an error");
+    let chain: Vec<String> = err.chain().map(|e| e.to_string()).collect();
+    assert!(
+        chain.iter().any(|m| m.contains("unexpected data type")),
+        "error chain should mention the type-mismatch context, got: {chain:?}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Both nodes previously had no tests at all, so a regression in tick-counting, message format, or InputClosed handling would not have been caught. Uses \`setup_integration_testing\` / \`DoraNode::init_testing\` to assert on actual output content (status-node — including a golden-file diff against the existing \`expected-outputs-rust-status-node.jsonl\`) and on specific error-chain messages (sink), addressing the "no-error" tests gap called out in #1760.