### PR TITLE
Extend setup_integration_testing coverage to seven more example nodes

### DIFF
--- a/examples/cross-language/rust-receiver/src/main.rs
+++ b/examples/cross-language/rust-receiver/src/main.rs
@@ -1,8 +1,15 @@
-use dora_node_api::{DoraNode, Event, arrow};
+use dora_node_api::{DoraNode, Event, EventStream, arrow};
 use eyre::{ContextCompat, bail};
 
+#[cfg(test)]
+mod tests;
+
 fn main() -> eyre::Result<()> {
-    let (_node, mut events) = DoraNode::init_from_env()?;
+    let (node, events) = DoraNode::init_from_env()?;
+    run(node, events)
+}
+
+fn run(_node: DoraNode, mut events: EventStream) -> eyre::Result<()> {
     let mut received_count: i64 = 0;
 
     while let Some(event) = events.recv() {

--- a/examples/cross-language/rust-receiver/src/tests.rs
+++ b/examples/cross-language/rust-receiver/src/tests.rs
@@ -1,0 +1,154 @@
+use dora_node_api::{
+    DoraNode, flume,
+    integration_testing::{
+        IntegrationTestInput,
+        integration_testing_format::{IncomingEvent, InputData, TimedIncomingEvent},
+    },
+    serde_json,
+};
+
+fn values_input(time_offset_secs: f64, value: i64) -> TimedIncomingEvent {
+    TimedIncomingEvent {
+        time_offset_secs,
+        event: IncomingEvent::Input {
+            id: "values".into(),
+            metadata: None,
+            data: Some(Box::new(InputData::JsonObject {
+                data: serde_json::json!([value]),
+                data_type: Some(serde_json::json!("Int64")),
+            })),
+        },
+    }
+}
+
+fn run_receiver(events: Vec<TimedIncomingEvent>) -> eyre::Result<()> {
+    let inputs = dora_node_api::integration_testing::TestingInput::Input(
+        IntegrationTestInput::new("rust-receiver".parse().unwrap(), events),
+    );
+    let (tx, _rx) = flume::unbounded();
+    let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
+    let (node, events) = DoraNode::init_testing(inputs, testing_output, Default::default())?;
+
+    crate::run(node, events)
+}
+
+/// The full simulated Python output (`0, 10, ..., 90`) must be accepted —
+/// every value satisfies the modulo + range contract and the count is >= 5.
+#[test]
+fn accepts_full_python_sequence() -> eyre::Result<()> {
+    let events = (0..10)
+        .map(|i| values_input(0.001 * (i + 1) as f64, i * 10))
+        .collect::<Vec<_>>();
+
+    run_receiver(events)
+}
+
+/// A value outside the `[0, 90]` range must trip the documented modulo/range
+/// guard with the exact error message — not be silently accepted.
+#[test]
+fn rejects_value_out_of_range() {
+    let events = vec![
+        values_input(0.001, 0),
+        values_input(0.002, 100), // outside [0, 90]
+    ];
+
+    let err = run_receiver(events).expect_err("out-of-range value must error");
+    let chain: Vec<String> = err.chain().map(|e| e.to_string()).collect();
+    assert!(
+        chain
+            .iter()
+            .any(|m| m.contains("unexpected value from Python sender")),
+        "error chain should call out the bad value, got: {chain:?}"
+    );
+}
+
+/// A value that is in range but not a multiple of 10 must also be rejected.
+#[test]
+fn rejects_non_multiple_of_ten() {
+    let events = vec![values_input(0.001, 7)];
+
+    let err = run_receiver(events).expect_err("non-multiple-of-10 value must error");
+    let chain: Vec<String> = err.chain().map(|e| e.to_string()).collect();
+    assert!(
+        chain
+            .iter()
+            .any(|m| m.contains("unexpected value from Python sender")),
+        "error chain should call out the bad value, got: {chain:?}"
+    );
+}
+
+/// Fewer than 5 messages followed by `Stop` must trigger the final
+/// `received_count < 5` guard.
+#[test]
+fn rejects_too_few_messages() {
+    let events = vec![
+        values_input(0.001, 0),
+        values_input(0.002, 10),
+        TimedIncomingEvent {
+            time_offset_secs: 0.003,
+            event: IncomingEvent::Stop,
+        },
+    ];
+
+    let err = run_receiver(events).expect_err("must require at least 5 messages");
+    let chain: Vec<String> = err.chain().map(|e| e.to_string()).collect();
+    assert!(
+        chain
+            .iter()
+            .any(|m| m.contains("got only 2") && m.contains(">= 5")),
+        "error chain should mention the minimum-message contract, got: {chain:?}"
+    );
+}
+
+/// A non-`Int64` payload must surface `"expected Int64Array from Python sender"`
+/// rather than panicking on a downcast failure.
+#[test]
+fn rejects_non_int64_payload() {
+    let events = vec![TimedIncomingEvent {
+        time_offset_secs: 0.001,
+        event: IncomingEvent::Input {
+            id: "values".into(),
+            metadata: None,
+            data: Some(Box::new(InputData::JsonObject {
+                data: serde_json::json!(["not a number"]),
+                data_type: Some(serde_json::json!("Utf8")),
+            })),
+        },
+    }];
+
+    let err = run_receiver(events).expect_err("non-Int64 input must error");
+    let chain: Vec<String> = err.chain().map(|e| e.to_string()).collect();
+    assert!(
+        chain
+            .iter()
+            .any(|m| m.contains("expected Int64Array from Python sender")),
+        "error chain should mention the Int64 type contract, got: {chain:?}"
+    );
+}
+
+/// A multi-element array (Python sends single-element arrays) must trip the
+/// `expected 1 element` guard. Locks in the contract that this rust-receiver
+/// is intentionally strict about element count.
+#[test]
+fn rejects_multi_element_array() {
+    let events = vec![TimedIncomingEvent {
+        time_offset_secs: 0.001,
+        event: IncomingEvent::Input {
+            id: "values".into(),
+            metadata: None,
+            data: Some(Box::new(InputData::JsonObject {
+                data: serde_json::json!([0, 10]),
+                data_type: Some(serde_json::json!("Int64")),
+            })),
+        },
+    }];
+
+    let err = run_receiver(events).expect_err("multi-element array must error");
+    let chain: Vec<String> = err.chain().map(|e| e.to_string()).collect();
+    assert!(
+        chain
+            .iter()
+            .any(|m| m.contains("expected 1 element from Python")),
+        "error chain should mention the element-count contract, got: {chain:?}"
+    );
+}

--- a/examples/cross-language/rust-sender/src/main.rs
+++ b/examples/cross-language/rust-sender/src/main.rs
@@ -1,8 +1,15 @@
-use dora_node_api::{DoraNode, Event, IntoArrow, dora_core::config::DataId};
+use dora_node_api::{DoraNode, Event, EventStream, IntoArrow, dora_core::config::DataId};
 use eyre::Context;
 
+#[cfg(test)]
+mod tests;
+
 fn main() -> eyre::Result<()> {
-    let (mut node, mut events) = DoraNode::init_from_env()?;
+    let (node, events) = DoraNode::init_from_env()?;
+    run(node, events)
+}
+
+fn run(mut node: DoraNode, mut events: EventStream) -> eyre::Result<()> {
     let output = DataId::from("values".to_owned());
 
     // Send 10 messages with known values: [0, 10, 20, ..., 90]

--- a/examples/cross-language/rust-sender/src/tests.rs
+++ b/examples/cross-language/rust-sender/src/tests.rs
@@ -1,0 +1,69 @@
+use dora_node_api::{
+    DoraNode, flume,
+    integration_testing::{
+        IntegrationTestInput,
+        integration_testing_format::{IncomingEvent, TimedIncomingEvent},
+    },
+    serde_json,
+};
+
+fn tick(time_offset_secs: f64) -> TimedIncomingEvent {
+    TimedIncomingEvent {
+        time_offset_secs,
+        event: IncomingEvent::Input {
+            id: "tick".into(),
+            metadata: None,
+            data: None,
+        },
+    }
+}
+
+fn run_sender(events: Vec<TimedIncomingEvent>) -> eyre::Result<Vec<serde_json::Value>> {
+    let inputs = dora_node_api::integration_testing::TestingInput::Input(
+        IntegrationTestInput::new("rust-sender".parse().unwrap(), events),
+    );
+    let (tx, rx) = flume::unbounded();
+    let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
+    let (node, events) = DoraNode::init_testing(inputs, testing_output, Default::default())?;
+
+    crate::run(node, events)?;
+
+    Ok(rx
+        .try_iter()
+        .map(serde_json::Value::Object)
+        .collect::<Vec<_>>())
+}
+
+/// Ten ticks must produce the exact sequence `0, 10, 20, ..., 90` as
+/// `Int64` `values` outputs — this is the wire contract that the Python
+/// receiver depends on. Locks both count and content.
+#[test]
+fn ten_ticks_produce_zero_through_ninety_step_ten() -> eyre::Result<()> {
+    let events = (0..10)
+        .map(|i| tick(0.001 * (i + 1) as f64))
+        .collect::<Vec<_>>();
+
+    let outputs = run_sender(events)?;
+
+    assert_eq!(outputs.len(), 10);
+    for (i, output) in outputs.iter().enumerate() {
+        assert_eq!(output["id"], "values");
+        assert_eq!(output["data_type"], "Int64");
+        assert_eq!(output["data"], serde_json::json!([(i as i64) * 10]));
+    }
+    Ok(())
+}
+
+/// More than ten ticks must still produce exactly 10 outputs — the
+/// `sent < 10` budget bounds the loop.
+#[test]
+fn loop_stops_after_ten_outputs() -> eyre::Result<()> {
+    let events = (0..15)
+        .map(|i| tick(0.001 * (i + 1) as f64))
+        .collect::<Vec<_>>();
+
+    let outputs = run_sender(events)?;
+
+    assert_eq!(outputs.len(), 10);
+    Ok(())
+}

--- a/examples/multiple-daemons/node/src/main.rs
+++ b/examples/multiple-daemons/node/src/main.rs
@@ -1,11 +1,17 @@
-use dora_node_api::{self, DoraNode, Event, IntoArrow, dora_core::config::DataId};
+use dora_node_api::{self, DoraNode, Event, EventStream, IntoArrow, dora_core::config::DataId};
+
+#[cfg(test)]
+mod tests;
 
 fn main() -> eyre::Result<()> {
     println!("hello");
 
-    let output = DataId::from("random".to_owned());
+    let (node, events) = DoraNode::init_from_env()?;
+    run(node, events)
+}
 
-    let (mut node, mut events) = DoraNode::init_from_env()?;
+fn run(mut node: DoraNode, mut events: EventStream) -> eyre::Result<()> {
+    let output = DataId::from("random".to_owned());
 
     for i in 0..100 {
         let event = match events.recv() {

--- a/examples/multiple-daemons/node/src/tests.rs
+++ b/examples/multiple-daemons/node/src/tests.rs
@@ -1,0 +1,150 @@
+use dora_node_api::{
+    DoraNode, flume,
+    integration_testing::{
+        IntegrationTestInput,
+        integration_testing_format::{IncomingEvent, TimedIncomingEvent},
+    },
+    serde_json,
+};
+
+fn tick(time_offset_secs: f64) -> TimedIncomingEvent {
+    TimedIncomingEvent {
+        time_offset_secs,
+        event: IncomingEvent::Input {
+            id: "tick".into(),
+            metadata: None,
+            data: None,
+        },
+    }
+}
+
+fn run_node(events: Vec<TimedIncomingEvent>) -> eyre::Result<Vec<serde_json::Value>> {
+    let inputs = dora_node_api::integration_testing::TestingInput::Input(
+        IntegrationTestInput::new("multiple-daemons-node".parse().unwrap(), events),
+    );
+    let (tx, rx) = flume::unbounded();
+    let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
+    let (node, events) = DoraNode::init_testing(inputs, testing_output, Default::default())?;
+
+    crate::run(node, events)?;
+
+    Ok(rx
+        .try_iter()
+        .map(serde_json::Value::Object)
+        .collect::<Vec<_>>())
+}
+
+/// Each `tick` input must produce exactly one `random` output of type
+/// `UInt64`. We can't pin the value (it's `rand::random()`) but we can
+/// pin the count, the output id, and the data type — none of which the
+/// liveness-only smoke test caught.
+#[test]
+fn each_tick_produces_one_uint64_random_output() -> eyre::Result<()> {
+    let events = (0..7)
+        .map(|i| tick(0.001 * (i + 1) as f64))
+        .collect::<Vec<_>>();
+
+    let outputs = run_node(events)?;
+
+    assert_eq!(outputs.len(), 7, "expected 7 random outputs");
+    for output in &outputs {
+        assert_eq!(output["id"], "random");
+        assert_eq!(output["data_type"], "UInt64");
+        // payload must be a single-element array (rand::random::<u64>())
+        let arr = output["data"]
+            .as_array()
+            .expect("data must be a JSON array");
+        assert_eq!(arr.len(), 1, "each output must wrap a single u64");
+    }
+    Ok(())
+}
+
+/// Non-`tick` inputs are logged and skipped — they must not produce a
+/// `random` output and must not error.
+#[test]
+fn non_tick_inputs_are_ignored() -> eyre::Result<()> {
+    let events = vec![
+        TimedIncomingEvent {
+            time_offset_secs: 0.001,
+            event: IncomingEvent::Input {
+                id: "noise".into(),
+                metadata: None,
+                data: None,
+            },
+        },
+        tick(0.002),
+    ];
+
+    let outputs = run_node(events)?;
+
+    assert_eq!(outputs.len(), 1);
+    Ok(())
+}
+
+/// `Stop` ends the event stream — anything queued after `Stop` must
+/// not reach the loop. Locks in the upstream contract that `Event::Stop`
+/// terminates the inner `EventStream`, so the trailing tick is dropped.
+#[test]
+fn stop_event_terminates_stream() -> eyre::Result<()> {
+    let events = vec![
+        tick(0.001),
+        TimedIncomingEvent {
+            time_offset_secs: 0.002,
+            event: IncomingEvent::Stop,
+        },
+        tick(0.003),
+    ];
+
+    let outputs = run_node(events)?;
+
+    assert_eq!(
+        outputs.len(),
+        1,
+        "tick after Stop should be dropped: {outputs:?}"
+    );
+    Ok(())
+}
+
+/// `InputClosed` (without a `Stop`) must not end the loop — subsequent
+/// ticks should still produce outputs.
+#[test]
+fn input_closed_does_not_terminate_loop() -> eyre::Result<()> {
+    let events = vec![
+        tick(0.001),
+        TimedIncomingEvent {
+            time_offset_secs: 0.002,
+            event: IncomingEvent::InputClosed { id: "tick".into() },
+        },
+        tick(0.003),
+    ];
+
+    let outputs = run_node(events)?;
+
+    assert_eq!(outputs.len(), 2, "InputClosed must not stop the loop");
+    Ok(())
+}
+
+/// The hard cap of 100 iterations must bound the total number of `random`
+/// outputs even when more than 100 ticks are queued.
+#[test]
+fn loop_stops_after_one_hundred_iterations() -> eyre::Result<()> {
+    let events = (0..150)
+        .map(|i| tick(0.0001 * (i + 1) as f64))
+        .collect::<Vec<_>>();
+
+    let outputs = run_node(events)?;
+
+    assert_eq!(
+        outputs.len(),
+        100,
+        "loop should terminate after exactly 100 iterations"
+    );
+    // sanity: ensure at least two outputs differ — random shouldn't be constant
+    let first = &outputs[0]["data"];
+    let differs = outputs.iter().skip(1).any(|o| &o["data"] != first);
+    assert!(
+        differs,
+        "rand::random outputs should not all be equal: {outputs:?}"
+    );
+    Ok(())
+}

--- a/examples/multiple-daemons/sink/src/main.rs
+++ b/examples/multiple-daemons/sink/src/main.rs
@@ -1,9 +1,15 @@
-use dora_node_api::{self, DoraNode, Event};
+use dora_node_api::{self, DoraNode, Event, EventStream};
 use eyre::{Context, bail};
 
-fn main() -> eyre::Result<()> {
-    let (_node, mut events) = DoraNode::init_from_env()?;
+#[cfg(test)]
+mod tests;
 
+fn main() -> eyre::Result<()> {
+    let (node, events) = DoraNode::init_from_env()?;
+    run(node, events)
+}
+
+fn run(_node: DoraNode, mut events: EventStream) -> eyre::Result<()> {
     while let Some(event) = events.recv() {
         match event {
             Event::Input {

--- a/examples/multiple-daemons/sink/src/tests.rs
+++ b/examples/multiple-daemons/sink/src/tests.rs
@@ -1,0 +1,131 @@
+use dora_node_api::{
+    DoraNode, flume,
+    integration_testing::{
+        IntegrationTestInput,
+        integration_testing_format::{IncomingEvent, InputData, TimedIncomingEvent},
+    },
+    serde_json,
+};
+
+fn message_input(time_offset_secs: f64, message: &str) -> TimedIncomingEvent {
+    TimedIncomingEvent {
+        time_offset_secs,
+        event: IncomingEvent::Input {
+            id: "message".into(),
+            metadata: None,
+            data: Some(Box::new(InputData::JsonObject {
+                data: serde_json::json!([message]),
+                data_type: Some(serde_json::json!("Utf8")),
+            })),
+        },
+    }
+}
+
+fn run_sink(events: Vec<TimedIncomingEvent>) -> eyre::Result<()> {
+    let inputs = dora_node_api::integration_testing::TestingInput::Input(
+        IntegrationTestInput::new("multiple-daemons-sink".parse().unwrap(), events),
+    );
+    let (tx, _rx) = flume::unbounded();
+    let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
+    let (node, events) = DoraNode::init_testing(inputs, testing_output, Default::default())?;
+
+    crate::run(node, events)
+}
+
+/// A stream of well-formed status messages must run to completion without
+/// error. Locks in the contract that any string matching
+/// `"operator received random value … ticks"` is accepted.
+#[test]
+fn accepts_valid_status_messages() -> eyre::Result<()> {
+    let events = vec![
+        message_input(
+            0.001,
+            "operator received random value 0xdeadbeef after 0 ticks",
+        ),
+        message_input(0.002, "operator received random value 0xcafe after 7 ticks"),
+        TimedIncomingEvent {
+            time_offset_secs: 0.003,
+            event: IncomingEvent::InputClosed {
+                id: "message".into(),
+            },
+        },
+    ];
+
+    run_sink(events)
+}
+
+/// A message missing the required prefix must produce an error mentioning
+/// the prefix contract — not a generic `Ok(())` or empty error string.
+#[test]
+fn rejects_message_missing_prefix() {
+    let events = vec![message_input(0.001, "totally unrelated payload")];
+
+    let err = run_sink(events).expect_err("sink must reject malformed messages");
+    let chain: Vec<String> = err.chain().map(|e| e.to_string()).collect();
+    assert!(
+        chain
+            .iter()
+            .any(|m| m.contains("operator received random value")),
+        "error chain should mention the required prefix, got: {chain:?}"
+    );
+}
+
+/// A message that has the right prefix but the wrong suffix must trip the
+/// second `bail!` ("should end with 'ticks'"), so we cover both branches.
+#[test]
+fn rejects_message_with_wrong_suffix() {
+    let events = vec![message_input(
+        0.001,
+        "operator received random value 0xff after seven somethings",
+    )];
+
+    let err = run_sink(events).expect_err("sink must reject messages without a `ticks` suffix");
+    let chain: Vec<String> = err.chain().map(|e| e.to_string()).collect();
+    assert!(
+        chain.iter().any(|m| m.contains("ticks")),
+        "error chain should mention the `ticks` suffix contract, got: {chain:?}"
+    );
+}
+
+/// A non-string `message` payload must surface the `"expected string message"`
+/// context rather than panicking on an Arrow type mismatch.
+#[test]
+fn rejects_non_string_message_payload() {
+    let events = vec![TimedIncomingEvent {
+        time_offset_secs: 0.001,
+        event: IncomingEvent::Input {
+            id: "message".into(),
+            metadata: None,
+            data: Some(Box::new(InputData::JsonObject {
+                data: serde_json::json!([42_u64]),
+                data_type: Some(serde_json::json!("UInt64")),
+            })),
+        },
+    }];
+
+    let err = run_sink(events).expect_err("sink must reject non-string `message` payloads");
+    let chain: Vec<String> = err.chain().map(|e| e.to_string()).collect();
+    assert!(
+        chain.iter().any(|m| m.contains("expected string message")),
+        "error chain should mention the type-mismatch context, got: {chain:?}"
+    );
+}
+
+/// Non-`message` inputs are logged and skipped — they must not produce
+/// an error and must not stop the loop.
+#[test]
+fn non_message_inputs_are_ignored() -> eyre::Result<()> {
+    let events = vec![
+        TimedIncomingEvent {
+            time_offset_secs: 0.001,
+            event: IncomingEvent::Input {
+                id: "noise".into(),
+                metadata: None,
+                data: None,
+            },
+        },
+        message_input(0.002, "operator received random value 0x1 after 0 ticks"),
+    ];
+
+    run_sink(events)
+}

--- a/examples/validated-pipeline/sink/src/main.rs
+++ b/examples/validated-pipeline/sink/src/main.rs
@@ -1,8 +1,15 @@
-use dora_node_api::{DoraNode, Event, arrow};
+use dora_node_api::{DoraNode, Event, EventStream, arrow};
 use eyre::{ContextCompat, bail};
 
+#[cfg(test)]
+mod tests;
+
 fn main() -> eyre::Result<()> {
-    let (_node, mut events) = DoraNode::init_from_env()?;
+    let (node, events) = DoraNode::init_from_env()?;
+    run(node, events)
+}
+
+fn run(_node: DoraNode, mut events: EventStream) -> eyre::Result<()> {
     let mut received: i64 = 0;
 
     while let Some(event) = events.recv() {

--- a/examples/validated-pipeline/sink/src/tests.rs
+++ b/examples/validated-pipeline/sink/src/tests.rs
@@ -1,0 +1,118 @@
+use dora_node_api::{
+    DoraNode, flume,
+    integration_testing::{
+        IntegrationTestInput,
+        integration_testing_format::{IncomingEvent, InputData, TimedIncomingEvent},
+    },
+    serde_json,
+};
+
+fn doubled_input(time_offset_secs: f64, value: i64) -> TimedIncomingEvent {
+    TimedIncomingEvent {
+        time_offset_secs,
+        event: IncomingEvent::Input {
+            id: "doubled".into(),
+            metadata: None,
+            data: Some(Box::new(InputData::JsonObject {
+                data: serde_json::json!([value]),
+                data_type: Some(serde_json::json!("Int64")),
+            })),
+        },
+    }
+}
+
+fn run_sink(events: Vec<TimedIncomingEvent>) -> eyre::Result<()> {
+    let inputs = dora_node_api::integration_testing::TestingInput::Input(
+        IntegrationTestInput::new("sink".parse().unwrap(), events),
+    );
+    let (tx, _rx) = flume::unbounded();
+    let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
+    let (node, events) = DoraNode::init_testing(inputs, testing_output, Default::default())?;
+
+    crate::run(node, events)
+}
+
+/// Five sequential doubled values (`0, 2, 4, 6, 8`) match the `received * 2`
+/// invariant and meet the `received >= 5` minimum, so the run must succeed.
+#[test]
+fn accepts_valid_doubled_sequence() -> eyre::Result<()> {
+    let events = (0..5)
+        .map(|i| doubled_input(0.001 * (i + 1) as f64, (i as i64) * 2))
+        .collect::<Vec<_>>();
+
+    run_sink(events)
+}
+
+/// Skipping a value (sending `4` instead of `2` for the second message)
+/// must trip the `expected/got` invariant rather than passing silently.
+#[test]
+fn rejects_out_of_order_doubled_value() {
+    let events = vec![doubled_input(0.001, 0), doubled_input(0.002, 4)];
+
+    let err = run_sink(events).expect_err("sink must reject out-of-order values");
+    let chain: Vec<String> = err.chain().map(|e| e.to_string()).collect();
+    assert!(
+        chain.iter().any(|m| m.contains("expected 2, got 4")),
+        "error chain should mention the invariant violation, got: {chain:?}"
+    );
+}
+
+/// Receiving fewer than 5 messages and then closing the stream must fail
+/// the final `received < 5` guard, even if every individual value matched.
+#[test]
+fn rejects_too_few_messages() {
+    let events = vec![
+        doubled_input(0.001, 0),
+        doubled_input(0.002, 2),
+        doubled_input(0.003, 4),
+    ];
+
+    let err = run_sink(events).expect_err("sink must require >= 5 messages");
+    let chain: Vec<String> = err.chain().map(|e| e.to_string()).collect();
+    assert!(
+        chain
+            .iter()
+            .any(|m| m.contains("got only 3") && m.contains(">= 5")),
+        "error chain should mention the minimum-message contract, got: {chain:?}"
+    );
+}
+
+/// A non-`Int64` `doubled` payload must surface the documented
+/// `"expected Int64Array"` context rather than panicking.
+#[test]
+fn rejects_non_int64_doubled_payload() {
+    let events = vec![TimedIncomingEvent {
+        time_offset_secs: 0.001,
+        event: IncomingEvent::Input {
+            id: "doubled".into(),
+            metadata: None,
+            data: Some(Box::new(InputData::JsonObject {
+                data: serde_json::json!(["nope"]),
+                data_type: Some(serde_json::json!("Utf8")),
+            })),
+        },
+    }];
+
+    let err = run_sink(events).expect_err("non-Int64 input must produce an error");
+    let chain: Vec<String> = err.chain().map(|e| e.to_string()).collect();
+    assert!(
+        chain.iter().any(|m| m.contains("expected Int64Array")),
+        "error chain should mention the type-mismatch context, got: {chain:?}"
+    );
+}
+
+/// A `Stop` event must terminate the loop, after which the `received >= 5`
+/// guard still runs — so a happy 5-message stream followed by `Stop` is
+/// accepted, but the trailing `Stop` doesn't bypass the count check.
+#[test]
+fn stop_event_terminates_loop_then_runs_min_check() -> eyre::Result<()> {
+    let mut events: Vec<_> = (0..5)
+        .map(|i| doubled_input(0.001 * (i + 1) as f64, (i as i64) * 2))
+        .collect();
+    events.push(TimedIncomingEvent {
+        time_offset_secs: 0.010,
+        event: IncomingEvent::Stop,
+    });
+
+    run_sink(events)
+}

--- a/examples/validated-pipeline/source/src/main.rs
+++ b/examples/validated-pipeline/source/src/main.rs
@@ -1,8 +1,15 @@
-use dora_node_api::{DoraNode, Event, IntoArrow, dora_core::config::DataId};
+use dora_node_api::{DoraNode, Event, EventStream, IntoArrow, dora_core::config::DataId};
 use eyre::Context;
 
+#[cfg(test)]
+mod tests;
+
 fn main() -> eyre::Result<()> {
-    let (mut node, mut events) = DoraNode::init_from_env()?;
+    let (node, events) = DoraNode::init_from_env()?;
+    run(node, events)
+}
+
+fn run(mut node: DoraNode, mut events: EventStream) -> eyre::Result<()> {
     let output = DataId::from("value".to_owned());
 
     let mut sent: i64 = 0;

--- a/examples/validated-pipeline/source/src/tests.rs
+++ b/examples/validated-pipeline/source/src/tests.rs
@@ -1,0 +1,115 @@
+use dora_node_api::{
+    DoraNode, flume,
+    integration_testing::{
+        IntegrationTestInput,
+        integration_testing_format::{IncomingEvent, TimedIncomingEvent},
+    },
+    serde_json,
+};
+
+fn tick(time_offset_secs: f64) -> TimedIncomingEvent {
+    TimedIncomingEvent {
+        time_offset_secs,
+        event: IncomingEvent::Input {
+            id: "tick".into(),
+            metadata: None,
+            data: None,
+        },
+    }
+}
+
+fn run_source(events: Vec<TimedIncomingEvent>) -> eyre::Result<Vec<serde_json::Value>> {
+    let inputs = dora_node_api::integration_testing::TestingInput::Input(
+        IntegrationTestInput::new("source".parse().unwrap(), events),
+    );
+    let (tx, rx) = flume::unbounded();
+    let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
+    let (node, events) = DoraNode::init_testing(inputs, testing_output, Default::default())?;
+
+    crate::run(node, events)?;
+
+    Ok(rx
+        .try_iter()
+        .map(serde_json::Value::Object)
+        .collect::<Vec<_>>())
+}
+
+/// Sending 10 ticks must produce exactly 10 `value` outputs with the
+/// monotonically increasing payload `0, 1, ..., 9`. This locks in both
+/// the message count and the per-message content — the original smoke
+/// test only checked that the dataflow exited without error.
+#[test]
+fn ten_ticks_produce_zero_through_nine() -> eyre::Result<()> {
+    let events = (0..10)
+        .map(|i| tick(0.001 * (i + 1) as f64))
+        .collect::<Vec<_>>();
+
+    let outputs = run_source(events)?;
+
+    assert_eq!(outputs.len(), 10, "expected 10 outputs, got {outputs:?}");
+    for (i, output) in outputs.iter().enumerate() {
+        assert_eq!(output["id"], "value");
+        assert_eq!(output["data_type"], "Int64");
+        assert_eq!(output["data"], serde_json::json!([i as i64]));
+    }
+    Ok(())
+}
+
+/// Once `sent` has reached 10 the loop must exit even if more ticks are
+/// pending. Sending 15 ticks must still produce exactly 10 outputs.
+#[test]
+fn loop_stops_after_ten_outputs() -> eyre::Result<()> {
+    let events = (0..15)
+        .map(|i| tick(0.001 * (i + 1) as f64))
+        .collect::<Vec<_>>();
+
+    let outputs = run_source(events)?;
+
+    assert_eq!(outputs.len(), 10);
+    Ok(())
+}
+
+/// A `Stop` event must terminate the loop early without producing more
+/// outputs, even if `sent < 10`.
+#[test]
+fn stop_event_breaks_early() -> eyre::Result<()> {
+    let events = vec![
+        tick(0.001),
+        tick(0.002),
+        TimedIncomingEvent {
+            time_offset_secs: 0.003,
+            event: IncomingEvent::Stop,
+        },
+        tick(0.004),
+    ];
+
+    let outputs = run_source(events)?;
+
+    assert_eq!(outputs.len(), 2);
+    Ok(())
+}
+
+/// Non-`tick` inputs must be silently ignored — they must not consume
+/// a slot in the `sent < 10` budget.
+#[test]
+fn unknown_inputs_are_ignored() -> eyre::Result<()> {
+    let events = vec![
+        TimedIncomingEvent {
+            time_offset_secs: 0.001,
+            event: IncomingEvent::Input {
+                id: "noise".into(),
+                metadata: None,
+                data: None,
+            },
+        },
+        tick(0.002),
+        tick(0.003),
+    ];
+
+    let outputs = run_source(events)?;
+
+    assert_eq!(outputs.len(), 2);
+    assert_eq!(outputs[0]["data"], serde_json::json!([0_i64]));
+    assert_eq!(outputs[1]["data"], serde_json::json!([1_i64]));
+    Ok(())
+}

--- a/examples/validated-pipeline/transform/src/main.rs
+++ b/examples/validated-pipeline/transform/src/main.rs
@@ -1,8 +1,15 @@
-use dora_node_api::{DoraNode, Event, IntoArrow, arrow, dora_core::config::DataId};
+use dora_node_api::{DoraNode, Event, EventStream, IntoArrow, arrow, dora_core::config::DataId};
 use eyre::{ContextCompat, bail};
 
+#[cfg(test)]
+mod tests;
+
 fn main() -> eyre::Result<()> {
-    let (mut node, mut events) = DoraNode::init_from_env()?;
+    let (node, events) = DoraNode::init_from_env()?;
+    run(node, events)
+}
+
+fn run(mut node: DoraNode, mut events: EventStream) -> eyre::Result<()> {
     let output = DataId::from("doubled".to_owned());
 
     while let Some(event) = events.recv() {

--- a/examples/validated-pipeline/transform/src/tests.rs
+++ b/examples/validated-pipeline/transform/src/tests.rs
@@ -1,0 +1,112 @@
+use dora_node_api::{
+    DoraNode, flume,
+    integration_testing::{
+        IntegrationTestInput,
+        integration_testing_format::{IncomingEvent, InputData, TimedIncomingEvent},
+    },
+    serde_json,
+};
+
+fn value_input(time_offset_secs: f64, value: i64) -> TimedIncomingEvent {
+    TimedIncomingEvent {
+        time_offset_secs,
+        event: IncomingEvent::Input {
+            id: "value".into(),
+            metadata: None,
+            data: Some(Box::new(InputData::JsonObject {
+                data: serde_json::json!([value]),
+                data_type: Some(serde_json::json!("Int64")),
+            })),
+        },
+    }
+}
+
+fn run_transform(events: Vec<TimedIncomingEvent>) -> eyre::Result<Vec<serde_json::Value>> {
+    let inputs = dora_node_api::integration_testing::TestingInput::Input(
+        IntegrationTestInput::new("transform".parse().unwrap(), events),
+    );
+    let (tx, rx) = flume::unbounded();
+    let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
+    let (node, events) = DoraNode::init_testing(inputs, testing_output, Default::default())?;
+
+    crate::run(node, events)?;
+
+    Ok(rx
+        .try_iter()
+        .map(serde_json::Value::Object)
+        .collect::<Vec<_>>())
+}
+
+/// Each `value` input must produce exactly one `doubled` output whose
+/// payload is the input multiplied by 2 — including the negative,
+/// zero, and large-magnitude cases.
+#[test]
+fn doubles_each_value_input() -> eyre::Result<()> {
+    let cases: &[i64] = &[0, 1, 7, -3, i64::MAX / 2];
+    let events: Vec<_> = cases
+        .iter()
+        .enumerate()
+        .map(|(i, v)| value_input(0.001 * (i + 1) as f64, *v))
+        .collect();
+
+    let outputs = run_transform(events)?;
+
+    assert_eq!(outputs.len(), cases.len());
+    for (output, expected) in outputs.iter().zip(cases.iter().map(|v| v * 2)) {
+        assert_eq!(output["id"], "doubled");
+        assert_eq!(output["data_type"], "Int64");
+        assert_eq!(output["data"], serde_json::json!([expected]));
+    }
+    Ok(())
+}
+
+/// Inputs with a non-`value` id (and no `data`) must be ignored without
+/// emitting a `doubled` output and without erroring out.
+#[test]
+fn ignores_non_value_inputs() -> eyre::Result<()> {
+    let events = vec![
+        TimedIncomingEvent {
+            time_offset_secs: 0.001,
+            event: IncomingEvent::Input {
+                id: "tick".into(),
+                metadata: None,
+                data: None,
+            },
+        },
+        value_input(0.002, 4),
+        TimedIncomingEvent {
+            time_offset_secs: 0.003,
+            event: IncomingEvent::InputClosed { id: "tick".into() },
+        },
+    ];
+
+    let outputs = run_transform(events)?;
+
+    assert_eq!(outputs.len(), 1);
+    assert_eq!(outputs[0]["data"], serde_json::json!([8_i64]));
+    Ok(())
+}
+
+/// A non-`Int64` `value` payload must surface the documented
+/// `"expected Int64Array"` context rather than panicking.
+#[test]
+fn rejects_non_int64_value_payload() {
+    let events = vec![TimedIncomingEvent {
+        time_offset_secs: 0.001,
+        event: IncomingEvent::Input {
+            id: "value".into(),
+            metadata: None,
+            data: Some(Box::new(InputData::JsonObject {
+                data: serde_json::json!(["not a number"]),
+                data_type: Some(serde_json::json!("Utf8")),
+            })),
+        },
+    }];
+
+    let err = run_transform(events).expect_err("non-Int64 value must produce an error");
+    let chain: Vec<String> = err.chain().map(|e| e.to_string()).collect();
+    assert!(
+        chain.iter().any(|m| m.contains("expected Int64Array")),
+        "error chain should mention `expected Int64Array`, got: {chain:?}"
+    );
+}


### PR DESCRIPTION
Follows the pattern from #1766 (rust-dataflow status-node + sink) to address the "no-error" tests gap called out in #1760. Wires up \`DoraNode::init_testing\` for seven more example Rust nodes that previously had no tests:

- \`validated-pipeline\` (source, transform, sink)
- \`cross-language\` (rust-receiver, rust-sender)
- \`multiple-daemons\` (node, sink)

Each test asserts on actual output content, count, and Arrow data type — or on specific error-chain messages — instead of just on liveness. Each \`main\` is split into a small \`run\` so tests can drive it with \`init_testing\`-built \`(DoraNode, EventStream)\` pairs without going through the env-var bootstrap.

30 new tests, all passing.