### PR TITLE
docs(readme): sync badges and feature defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 <div align="center">
   <a href="https://github.com/dora-rs/dora/actions"><img src="https://github.com/dora-rs/dora/workflows/CI/badge.svg" alt="Build and test"/></a>
-  <a href="https://crates.io/crates/dora-rs"><img src="https://img.shields.io/crates/v/dora_node_api.svg" alt="crates.io"/></a>
+  <a href="https://crates.io/crates/dora-cli"><img src="https://img.shields.io/crates/v/dora-cli.svg" alt="crates.io"/></a>
   <a href="https://docs.rs/dora-node-api/latest/dora_node_api/"><img src="https://docs.rs/dora-node-api/badge.svg" alt="docs.rs"/></a>
   <a href="https://pypi.org/project/dora-rs/"><img src="https://img.shields.io/pypi/v/dora-rs.svg" alt="PyPI"/></a>
   <a href="https://github.com/dora-rs/dora/blob/main/LICENSE"><img src="https://img.shields.io/github/license/dora-rs/dora" alt="License"/></a>

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ powershell -ExecutionPolicy ByPass -c "irm https://github.com/dora-rs/dora/relea
 |---------|-------------|---------|
 | `tracing` | OpenTelemetry tracing support | Yes |
 | `metrics` | OpenTelemetry metrics collection | Yes |
-| `python` | Python operator support (PyO3) | Yes |
+| `python` | Python operator support (PyO3) | No |
 | `redb-backend` | Persistent coordinator state (redb) | Yes |
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -18,7 +18,7 @@
 
 <div align="center">
   <a href="https://github.com/dora-rs/dora/actions"><img src="https://github.com/dora-rs/dora/workflows/CI/badge.svg" alt="Build and test"/></a>
-  <a href="https://crates.io/crates/dora-rs"><img src="https://img.shields.io/crates/v/dora_node_api.svg" alt="crates.io"/></a>
+  <a href="https://crates.io/crates/dora-cli"><img src="https://img.shields.io/crates/v/dora-cli.svg" alt="crates.io"/></a>
   <a href="https://docs.rs/dora-node-api/latest/dora_node_api/"><img src="https://docs.rs/dora-node-api/badge.svg" alt="docs.rs"/></a>
   <a href="https://pypi.org/project/dora-rs/"><img src="https://img.shields.io/pypi/v/dora-rs.svg" alt="PyPI"/></a>
   <a href="https://github.com/dora-rs/dora/blob/main/LICENSE"><img src="https://img.shields.io/github/license/dora-rs/dora" alt="License"/></a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -127,10 +127,9 @@ powershell -ExecutionPolicy ByPass -c "irm https://github.com/dora-rs/dora/relea
 | 特性 | 描述 | 默认开启 |
 |------|------|----------|
 | `tracing` | OpenTelemetry 追踪支持 | 是 |
-| `metrics` | OpenTelemetry 指标收集 | 否 |
+| `metrics` | OpenTelemetry 指标收集 | 是 |
 | `python` | Python 算子支持（PyO3） | 否 |
-| `redb-backend` | 持久化协调器状态（redb） | 否 |
-| `prometheus` | 协调器上的 Prometheus `/metrics` 端点 | 否 |
+| `redb-backend` | 持久化协调器状态（redb） | 是 |
 
 ```bash
 cargo install dora-cli --features redb-backend

--- a/guide/src/getting-started/installation.md
+++ b/guide/src/getting-started/installation.md
@@ -40,9 +40,9 @@ powershell -ExecutionPolicy ByPass -c "irm https://github.com/dora-rs/dora/relea
 | Feature | Description | Default |
 |---------|-------------|---------|
 | `tracing` | OpenTelemetry tracing support | Yes |
-| `metrics` | OpenTelemetry metrics collection | No |
+| `metrics` | OpenTelemetry metrics collection | Yes |
 | `python` | Python operator support (PyO3) | No |
-| `redb-backend` | Persistent coordinator state (redb) | No |
+| `redb-backend` | Persistent coordinator state (redb) | Yes |
 
 ```bash
 cargo install dora-cli --features redb-backend


### PR DESCRIPTION
The README badges and feature tables were out of sync with the CLI defaults. This updates both README variants plus the installation guide to match the current `dora-cli` defaults for `metrics`, `python`, and `redb-backend`. Fixes #1700.