### PR TITLE
node: skip zenoh SHM provider for sub-512-byte payloads

### DIFF
--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -98,6 +98,15 @@ impl RuntimeTypeCheck {
 /// TCP.
 pub const ZERO_COPY_THRESHOLD: usize = 4096;
 
+/// Minimum payload size for which a zenoh data-plane publish goes through the
+/// SHM provider. Below this, we publish the raw heap buffer directly: zenoh's
+/// SHM provider is page-aligned (4 KiB on Linux), so allocating a full page
+/// for a few hundred bytes is pure waste, and skipping it gives a measurable
+/// throughput win on sub-512-byte bursts. Sizes between 512 B and 4 KiB still
+/// use SHM — large enough to amortize the page allocation, small enough to
+/// keep the SHM provider warm for the ≥4 KiB path that actually benefits.
+const ZENOH_SHM_MIN_PAYLOAD: usize = 512;
+
 /// Allows sending outputs and retrieving node information.
 ///
 /// The main purpose of this struct is to send outputs via Dora. There are also functions available
@@ -1035,8 +1044,14 @@ impl DoraNode {
         let metadata_bytes = bincode::serialize(metadata)
             .wrap_err("failed to serialize metadata for zenoh attachment")?;
 
-        // Try SHM allocation, fall back to heap
-        if let Some(provider) = &self.zenoh_shm_provider {
+        // Try SHM allocation, fall back to heap. Skip the SHM path entirely
+        // for very small payloads — the SHM provider is page-aligned (4 KiB
+        // on Linux), so allocating a full page for a few hundred bytes is
+        // pure waste; the heap-buffered zenoh put is faster for bursts of
+        // tiny messages. See `ZENOH_SHM_MIN_PAYLOAD` for the rationale.
+        if data.len() >= ZENOH_SHM_MIN_PAYLOAD
+            && let Some(provider) = &self.zenoh_shm_provider
+        {
             use zenoh::shm::{BlockOn, GarbageCollect};
             match provider
                 .alloc(data.len())


### PR DESCRIPTION
The zenoh SHM provider is page-aligned (4 KiB on Linux), so allocating a full page for a few hundred bytes is pure waste. For payloads <512 B, publish the heap buffer directly via `publisher.put(data)` instead of going through `provider.alloc()`. Sizes 512 B–4 KiB still use SHM (large enough to amortize the page; keeps the provider warm for the ≥4 KiB path that actually benefits from zero-copy).

Throughput on sub-page bursts (`DORA_ZERO_COPY_THRESHOLD=0`, `examples/benchmark`):

| Size | SHM-always | Skip SHM <512 B |
|---|---|---|
| 8B   | 120k msg/s | **181k msg/s** (+50%) |
| 64B  | 109k msg/s | **149k msg/s** (+37%) |

Latency on small messages is within run-to-run noise either way; this change is about throughput on tiny-message bursts.