### PR TITLE
Enable zenoh peer discovery without multicast via loopback endpoint

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -9,8 +9,8 @@ use dora_core::{
         read_as_descriptor,
     },
     topics::{
-        DORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT, LOCALHOST, open_zenoh_session,
-        zenoh_output_publish_topic,
+        DORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT, LOCALHOST, open_zenoh_session_with_listen,
+        reserve_loopback_zenoh_endpoint, zenoh_output_publish_topic,
     },
     uhlc::{self, HLC},
 };
@@ -257,6 +257,11 @@ pub struct Daemon {
     pub(crate) clock: Arc<uhlc::HLC>,
     pub(crate) ft_stats: Arc<FaultToleranceStats>,
     pub(crate) zenoh_session: zenoh::Session,
+    /// Loopback endpoint that the daemon's zenoh session listens on. Injected
+    /// into spawned nodes via `DORA_ZENOH_CONNECT` so they can find their
+    /// peer without multicast (#1778). `None` when the OS rejected the
+    /// reservation; nodes then fall back to multicast scouting.
+    pub(crate) zenoh_listen_endpoint: Option<String>,
     pub(crate) zenoh_publish_tx: mpsc::Sender<ZenohOutbound>,
     pub(crate) remote_daemon_events_tx:
         Option<flume::Sender<eyre::Result<Timestamped<InterDaemonEvent>>>>,
@@ -777,7 +782,20 @@ impl Daemon {
         log_destination: LogDestination,
         health_check_interval_duration: Option<Duration>,
     ) -> eyre::Result<DaemonRunResult> {
-        let zenoh_session = open_zenoh_session(None)
+        // Reserve a loopback port and have zenoh listen on it. The endpoint is
+        // injected into spawned nodes via `DORA_ZENOH_CONNECT` so peer
+        // discovery works without multicast (#1778).
+        let zenoh_listen_endpoint = match reserve_loopback_zenoh_endpoint() {
+            Ok(ep) => Some(ep),
+            Err(err) => {
+                tracing::warn!(
+                    "failed to reserve loopback zenoh listen endpoint: {err}; \
+                     falling back to multicast scouting only"
+                );
+                None
+            }
+        };
+        let zenoh_session = open_zenoh_session_with_listen(None, zenoh_listen_endpoint.as_deref())
             .await
             .wrap_err("failed to open zenoh session")?;
         // Use a large channel capacity to prevent deadlock
@@ -825,6 +843,7 @@ impl Daemon {
             clock,
             ft_stats: Default::default(),
             zenoh_session,
+            zenoh_listen_endpoint,
             zenoh_publish_tx,
             remote_daemon_events_tx,
             git_manager: Default::default(),
@@ -1587,6 +1606,7 @@ impl Daemon {
                         uv,
                         ft_stats: self.ft_stats.clone(),
                         shutdown: dataflow.listener_shutdown_rx.clone(),
+                        zenoh_connect_endpoint: self.zenoh_listen_endpoint.clone(),
                     };
                     let mut logger = self
                         .logger
@@ -2336,6 +2356,7 @@ impl Daemon {
             uv,
             ft_stats: self.ft_stats.clone(),
             shutdown: dataflow.listener_shutdown_rx.clone(),
+            zenoh_connect_endpoint: self.zenoh_listen_endpoint.clone(),
         };
 
         let mut tasks = Vec::new();

--- a/binaries/daemon/src/spawn/spawner.rs
+++ b/binaries/daemon/src/spawn/spawner.rs
@@ -9,6 +9,7 @@ use crossbeam::queue::ArrayQueue;
 use dora_core::{
     descriptor::{Descriptor, OperatorDefinition, OperatorSource, PythonSource, ResolvedNode},
     get_python_path,
+    topics::DORA_ZENOH_CONNECT_ENV,
     uhlc::HLC,
 };
 use dora_message::{
@@ -69,9 +70,20 @@ pub struct Spawner {
     pub ft_stats: Arc<crate::FaultToleranceStats>,
     /// Signals listener loops to shut down when the dataflow finishes.
     pub shutdown: tokio::sync::watch::Receiver<bool>,
+    /// Loopback endpoint of the daemon's zenoh listener. Forwarded to spawned
+    /// nodes via `DORA_ZENOH_CONNECT` so the >=4 KiB zenoh data path works
+    /// without multicast scouting (#1778).
+    pub zenoh_connect_endpoint: Option<String>,
 }
 
 impl Spawner {
+    fn maybe_inject_zenoh_connect(&self, command: Command) -> Command {
+        match &self.zenoh_connect_endpoint {
+            Some(ep) => command.env(DORA_ZENOH_CONNECT_ENV, ep),
+            None => command,
+        }
+    }
+
     pub async fn spawn_node(
         self,
         node: ResolvedNode,
@@ -161,6 +173,7 @@ impl Spawner {
                         serde_yaml::to_string(&node_config.clone())
                             .wrap_err("failed to serialize node config")?,
                     );
+                    command = self.maybe_inject_zenoh_connect(command);
                     // Injecting the env variable defined in the `yaml` into
                     // the node runtime.
                     if let Some(envs) = &node.env {
@@ -323,6 +336,7 @@ impl Spawner {
                         serde_yaml::to_string(&runtime_config)
                             .wrap_err("failed to serialize runtime config")?,
                     );
+                    command = self.maybe_inject_zenoh_connect(command);
                     // Injecting the env variable defined in the `yaml` into
                     // the node runtime.
                     if let Some(envs) = &node.env {

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -6,10 +6,27 @@ pub const DORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT: u16 = 53291;
 pub const DORA_DAEMON_LOCAL_LISTEN_PORT_ENV: &str = "DORA_DAEMON_LOCAL_LISTEN_PORT";
 pub const DORA_COORDINATOR_PORT_WS_DEFAULT: u16 = 6013;
 
+/// Env var injected by the daemon into spawned nodes that points at the
+/// daemon's loopback zenoh listener. Lets nodes bootstrap zenoh peer discovery
+/// without multicast (dev containers, locked-down hosts, many CI runners).
+pub const DORA_ZENOH_CONNECT_ENV: &str = "DORA_ZENOH_CONNECT";
+
 pub const MANUAL_STOP: &str = "dora/stop";
 
 #[cfg(feature = "zenoh")]
 pub async fn open_zenoh_session(coordinator_addr: Option<IpAddr>) -> eyre::Result<zenoh::Session> {
+    open_zenoh_session_with_listen(coordinator_addr, None).await
+}
+
+/// Like [`open_zenoh_session`], but also configures the session to listen on
+/// the given loopback endpoint (e.g. `tcp/127.0.0.1:43217`). The daemon uses
+/// this so spawned nodes can connect via `DORA_ZENOH_CONNECT` without
+/// multicast scouting.
+#[cfg(feature = "zenoh")]
+pub async fn open_zenoh_session_with_listen(
+    coordinator_addr: Option<IpAddr>,
+    listen_endpoint: Option<&str>,
+) -> eyre::Result<zenoh::Session> {
     use eyre::{Context, eyre};
     use tracing::warn;
 
@@ -44,6 +61,33 @@ pub async fn open_zenoh_session(coordinator_addr: Option<IpAddr>) -> eyre::Resul
             // (see `zenoh-link-tcp::unicast::set_nodelay(true)`), so no
             // tcp_nodelay knob is needed here.
 
+            // Daemon-bootstrapped local discovery: when DORA_ZENOH_CONNECT is
+            // set in the process env (the daemon injects it into spawned
+            // nodes), seed connect/endpoints from it and disable multicast
+            // scouting. This makes the >=4 KiB zenoh data path work in
+            // environments without working multicast (#1778).
+            if let Ok(ep) = std::env::var(DORA_ZENOH_CONNECT_ENV) {
+                zenoh_config
+                    .insert_json5("connect/endpoints", &format!(r#"["{ep}"]"#))
+                    .unwrap();
+                zenoh_config
+                    .insert_json5("scouting/multicast/enabled", "false")
+                    .unwrap();
+            }
+
+            if let Some(ep) = listen_endpoint {
+                zenoh_config
+                    .insert_json5("listen/endpoints", &format!(r#"["{ep}"]"#))
+                    .unwrap();
+                // Tolerate a race between OS port reservation and zenoh's own
+                // bind on the same port: the connect side still works, and
+                // child nodes get a clear error rather than the daemon
+                // exiting.
+                zenoh_config
+                    .insert_json5("listen/exit_on_failure", "false")
+                    .unwrap();
+            }
+
             if let Some(addr) = coordinator_addr {
                 zenoh_config
                     .insert_json5(
@@ -74,6 +118,22 @@ pub async fn open_zenoh_session(coordinator_addr: Option<IpAddr>) -> eyre::Resul
     Ok(zenoh_session)
 }
 
+/// Reserve an unused TCP port on `127.0.0.1` for use as a zenoh listen
+/// endpoint. Returns a string suitable for the zenoh `listen/endpoints`
+/// config (e.g. `tcp/127.0.0.1:43217`).
+///
+/// There is a small race window between dropping the reservation socket and
+/// zenoh's own bind. `open_zenoh_session_with_listen` sets
+/// `listen/exit_on_failure: false` so the daemon survives that race; in
+/// practice the OS keeps allocating new ports so collisions are vanishingly
+/// rare.
+pub fn reserve_loopback_zenoh_endpoint() -> std::io::Result<String> {
+    let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))?;
+    let port = listener.local_addr()?.port();
+    drop(listener);
+    Ok(format!("tcp/127.0.0.1:{port}"))
+}
+
 #[cfg(feature = "zenoh")]
 pub fn zenoh_output_publish_topic(
     dataflow_id: uuid::Uuid,
@@ -82,4 +142,24 @@ pub fn zenoh_output_publish_topic(
 ) -> String {
     let network_id = "default";
     format!("dora/{network_id}/{dataflow_id}/output/{node_id}/{output_id}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reserve_loopback_endpoint_returns_loopback_tcp() {
+        let endpoint = reserve_loopback_zenoh_endpoint().expect("reservation succeeds");
+        assert!(
+            endpoint.starts_with("tcp/127.0.0.1:"),
+            "expected loopback tcp endpoint, got {endpoint}"
+        );
+        let port: u16 = endpoint
+            .rsplit(':')
+            .next()
+            .and_then(|p| p.parse().ok())
+            .expect("endpoint has a numeric port");
+        assert!(port > 0, "kernel must hand out a non-zero ephemeral port");
+    }
 }


### PR DESCRIPTION
## Summary
This PR enables zenoh peer discovery in environments without working multicast (dev containers, locked-down hosts, CI runners) by having the daemon listen on a loopback endpoint and injecting it into spawned nodes for direct connection.

## Key Changes
- **New environment variable `DORA_ZENOH_CONNECT`**: The daemon injects this into spawned nodes to bootstrap zenoh peer discovery without requiring multicast scouting
- **Loopback endpoint reservation**: Added `reserve_loopback_zenoh_endpoint()` function to reserve an unused TCP port on `127.0.0.1` for zenoh to listen on
- **Extended zenoh session API**: Refactored `open_zenoh_session()` into `open_zenoh_session_with_listen()` to support configuring both connect and listen endpoints
- **Daemon-side configuration**: The daemon now reserves a loopback endpoint at startup and configures zenoh to listen on it, with graceful fallback to multicast-only if reservation fails
- **Node spawning integration**: Updated the spawner to inject `DORA_ZENOH_CONNECT` into spawned node processes, enabling them to connect directly to the daemon's zenoh session
- **Configuration handling**: When `DORA_ZENOH_CONNECT` is set, nodes disable multicast scouting and seed their connect endpoints from the injected value
- **Test coverage**: Added unit test for loopback endpoint reservation

## Implementation Details
- The daemon sets `listen/exit_on_failure: false` to tolerate a small race window between OS port reservation and zenoh's bind
- Nodes check for `DORA_ZENOH_CONNECT` at session initialization and configure accordingly
- The solution is backward compatible: nodes without the environment variable fall back to standard multicast scouting
- Addresses issue #1778 (>=4 KiB zenoh data path in multicast-restricted environments)

https://claude.ai/code/session_01LZQccnxPmzEfrdgaca3CeQ