### PR TITLE
feat(api) add timestamp function to node api

### DIFF
--- a/apis/python/node/dora/__init__.pyi
+++ b/apis/python/node/dora/__init__.pyi
@@ -1,3 +1,4 @@
+import datetime
 import typing
 
 import pyarrow
@@ -148,6 +149,10 @@ class Node:
         """Returns how many times this node has been restarted.
 
         Returns 0 on the first run, 1 after the first restart, etc."""
+
+    def timestamp(self) -> "datetime.datetime":
+        """Returns the current timestamp from the node's Hybrid Logical Clock
+        as a UTC datetime object."""
 
     def merge_external_events(self, subscription: dora.Ros2Subscription) -> None:
         """Merge an external event stream with dora main loop.

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -8,7 +8,9 @@ use arrow::pyarrow::{FromPyArrow, ToPyArrow};
 use dora_node_api::dora_core::config::NodeId;
 use dora_node_api::merged::{MergeExternalSend, MergedEvent};
 use dora_node_api::{DataflowId, DoraNode, EventStream, TryRecvError, init_tracing};
-use dora_operator_api_python::{DelayedCleanup, NodeCleanupHandle, PyEvent, pydict_to_metadata};
+use dora_operator_api_python::{
+    DelayedCleanup, NodeCleanupHandle, PyEvent, datetime_module, pydict_to_metadata,
+};
 use dora_ros2_bridge_python::Ros2Subscription;
 use eyre::{Context, ContextCompat};
 
@@ -617,6 +619,26 @@ impl Node {
     /// :rtype: int
     pub fn restart_count(&self) -> u32 {
         self.node.get_mut().restart_count()
+    }
+
+    /// Returns the current timestamp from the node's Hybrid Logical Clock
+    /// as a UTC datetime object.
+    ///
+    /// :rtype: datetime.datetime
+    pub fn timestamp(&self, py: Python) -> eyre::Result<Py<PyAny>> {
+        let ts = self.node.get_mut().timestamp();
+        let system_time = ts.get_time().to_system_time();
+        let duration_since_epoch = system_time
+            .duration_since(std::time::UNIX_EPOCH)
+            .context("Failed to calculate duration since epoch")?;
+        let total_seconds = duration_since_epoch.as_secs() as f64
+            + duration_since_epoch.subsec_micros() as f64 / 1_000_000.0;
+        let dt_module = datetime_module(py).context("Failed to import datetime module")?;
+        let datetime_class = dt_module.getattr("datetime")?;
+        let utc_timezone = dt_module.getattr("timezone")?.getattr("utc")?;
+        let py_datetime =
+            datetime_class.call_method1("fromtimestamp", (total_seconds, utc_timezone))?;
+        Ok(py_datetime.unbind())
     }
 
     /// Merge an external event stream with dora main loop.

--- a/apis/python/operator/src/lib.rs
+++ b/apis/python/operator/src/lib.rs
@@ -22,7 +22,7 @@ use std::time::UNIX_EPOCH;
 /// Cached Python `datetime` module to avoid repeated `PyModule::import` on the hot path.
 static DATETIME_MODULE: PyOnceLock<Py<PyModule>> = PyOnceLock::new();
 
-fn datetime_module<'py>(py: Python<'py>) -> PyResult<&'py Bound<'py, PyModule>> {
+pub fn datetime_module<'py>(py: Python<'py>) -> PyResult<&'py Bound<'py, PyModule>> {
     Ok(DATETIME_MODULE
         .get_or_try_init(py, || PyModule::import(py, "datetime").map(|m| m.unbind()))?
         .bind(py))

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -1142,6 +1142,15 @@ impl DoraNode {
         self.restart_count
     }
 
+    /// Returns the current timestamp from the node's Hybrid Logical Clock.
+    ///
+    /// This generates a new HLC timestamp, which combines the physical
+    /// wall-clock time with a logical counter to ensure uniqueness and
+    /// monotonicity even across nodes.
+    pub fn timestamp(&self) -> uhlc::Timestamp {
+        self.clock.new_timestamp()
+    }
+
     /// Send a structured log message.
     ///
     /// Outputs a JSONL line to stdout that the daemon parses automatically.


### PR DESCRIPTION
## Summary

- Add `timestamp()` method to the Rust `DoraNode` that returns the current HLC timestamp from the node's internal clock
- Expose `timestamp()` on the Python `Node` class, returning a timezone-aware UTC `datetime.datetime`
- Make the cached `datetime_module()` helper public in `dora-operator-api-python` so the node crate can reuse it instead of calling `PyModule::import` on every invocation

## Motivation

`DoraNode` already maintains an internal `uhlc::HLC` clock used to timestamp every outgoing message, but there was no way for user code to read the current clock value directly. This is useful for:

- Measuring processing latency by comparing the current clock against an input event's timestamp
- Correlating log entries or external events with the same logical clock used by dora's data plane
- Profiling node processing time without introducing a separate clock source

## Changes

| File | Change |
|------|--------|
| `apis/rust/node/src/node/mod.rs` | Add `pub fn timestamp(&self) -> uhlc::Timestamp` |
| `apis/python/node/src/lib.rs` | Add `timestamp()` PyO3 method returning `datetime.datetime` (UTC) |
| `apis/python/operator/src/lib.rs` | Make `datetime_module()` `pub` for cross-crate reuse |
| `apis/python/node/dora/__init__.pyi` | Add type stub for `timestamp()` |

## Usage

**Rust:**
```rust
let node = DoraNode::init_from_env()?;
let ts = node.timestamp();
println!("Current HLC time: {ts}");
```

**Python:**
```python
from dora import Node

node = Node()
print(f"Current HLC time: {node.timestamp()}")

for event in node:
    if event["type"] == "INPUT":
        latency = node.timestamp() - event["metadata"]["timestamp"]
        print(f"Processing latency: {latency}")
```