### PR TITLE
feat(mavlink2-bridge): MAVLink 2 ↔ Arrow bridge with SITL closed-loop validation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1032,18 +1032,27 @@ jobs:
       - cargo-cache-restore:
           prefix: ros2
       - run:
-          name: Install Python 3.12 + dev headers + clang
-          # deadsnakes PPA + apt-get update + apt-get install can stall
-          # silently for >10 min during peak hours, tripping CircleCI's
-          # default 10-minute no-output timeout. Bump to 20 min so a slow
-          # mirror doesn't kill the job before package install completes.
-          no_output_timeout: 20m
+          name: Install Python 3.12 (via uv) + clang
+          # Install Python 3.12 via uv's prebuilt distributions
+          # (python-build-standalone, hosted on GitHub Releases) instead
+          # of the deadsnakes PPA. Avoids the Launchpad dependency:
+          # `add-apt-repository ppa:deadsnakes/ppa` calls the Launchpad
+          # API via httplib2, which on PR #1790 timed out twice with
+          # `TimeoutError: [Errno 110] Connection timed out` reaching
+          # api.launchpad.net. uv's distributions are versioned, ship
+          # dev headers, and pull from GitHub's CDN — orthogonal infra.
+          # Symlink to /usr/bin/python3.12 so the downstream venv step
+          # (uv venv --python /usr/bin/python3.12) keeps working.
+          no_output_timeout: 10m
           command: |
-            sudo add-apt-repository -y ppa:deadsnakes/ppa
-            sudo apt-get update
+            curl -LsSf https://astral.sh/uv/install.sh | sh
+            "$HOME/.local/bin/uv" python install 3.12
+            PYTHON312=$("$HOME/.local/bin/uv" python find 3.12)
+            sudo ln -sf "$PYTHON312" /usr/bin/python3.12
             # clang is needed by the C++ ROS2 Bridge example's run.rs
             # (machine image ships g++ but not clang by default).
-            sudo apt-get install -y python3.12 python3.12-dev python3.12-venv libpython3.12 clang
+            sudo apt-get update
+            sudo apt-get install -y clang
       - run:
           name: Install ROS2 Humble
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1044,15 +1044,31 @@ jobs:
           # Symlink to /usr/bin/python3.12 so the downstream venv step
           # (uv venv --python /usr/bin/python3.12) keeps working.
           no_output_timeout: 10m
+          environment:
+            # Stop apt-get from triggering the interactive `needrestart`
+            # TUI on Ubuntu 22.04, which hangs forever waiting for input
+            # whenever a package update touches a shared library
+            # (libc-dev etc., transitively pulled by clang). Setting it
+            # in the step env applies to every command in this run.
+            NEEDRESTART_MODE: a
+            NEEDRESTART_SUSPEND: "1"
+            DEBIAN_FRONTEND: noninteractive
           command: |
             curl -LsSf https://astral.sh/uv/install.sh | sh
             "$HOME/.local/bin/uv" python install 3.12
             PYTHON312=$("$HOME/.local/bin/uv" python find 3.12)
             sudo ln -sf "$PYTHON312" /usr/bin/python3.12
+            # Persist the noninteractive env for downstream steps so the
+            # ROS2 Humble apt install doesn't re-trigger the same prompt.
+            {
+              echo "export NEEDRESTART_MODE=a"
+              echo "export NEEDRESTART_SUSPEND=1"
+              echo "export DEBIAN_FRONTEND=noninteractive"
+            } >> "$BASH_ENV"
             # clang is needed by the C++ ROS2 Bridge example's run.rs
             # (machine image ships g++ but not clang by default).
             sudo apt-get update
-            sudo apt-get install -y clang
+            sudo -E apt-get install -y clang
       - run:
           name: Install ROS2 Humble
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1058,6 +1058,19 @@ jobs:
             "$HOME/.local/bin/uv" python install 3.12
             PYTHON312=$("$HOME/.local/bin/uv" python find 3.12)
             sudo ln -sf "$PYTHON312" /usr/bin/python3.12
+            # Make uv's libpython3.12 visible to the dynamic linker.
+            # PyO3 dynamically links against libpython3.12.so.1.0; the
+            # deadsnakes apt package previously installed it under
+            # /usr/lib/x86_64-linux-gnu (a standard ld.so search path)
+            # but uv lays it out under <prefix>/lib in its data dir,
+            # which isn't on the default search path. Symlink the
+            # versioned + unversioned soname into the system lib dir
+            # and refresh ld.so.cache so cargo-test binaries can load
+            # them at runtime.
+            PYTHON312_PREFIX=$(dirname "$(dirname "$PYTHON312")")
+            sudo ln -sf "$PYTHON312_PREFIX/lib/libpython3.12.so.1.0" /usr/lib/x86_64-linux-gnu/libpython3.12.so.1.0
+            sudo ln -sf "$PYTHON312_PREFIX/lib/libpython3.12.so" /usr/lib/x86_64-linux-gnu/libpython3.12.so
+            sudo ldconfig
             # Persist the noninteractive env for downstream steps so the
             # ROS2 Humble apt install doesn't re-trigger the same prompt.
             {

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1033,6 +1033,11 @@ jobs:
           prefix: ros2
       - run:
           name: Install Python 3.12 + dev headers + clang
+          # deadsnakes PPA + apt-get update + apt-get install can stall
+          # silently for >10 min during peak hours, tripping CircleCI's
+          # default 10-minute no-output timeout. Bump to 20 min so a slow
+          # mirror doesn't kill the job before package install completes.
+          no_output_timeout: 20m
           command: |
             sudo add-apt-repository -y ppa:deadsnakes/ppa
             sudo apt-get update

--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,16 @@ out/
 yolo.yml
 
 ~*
+
+# ArduPilot SITL runtime artifacts (dropped in cwd by sim_vehicle.py /
+# dronekit-sitl). These regenerate every SITL run; not source.
+/eeprom.bin
+/mav.parm
+/mav.tlog
+/mav.tlog.raw
+/logs/
+/terrain/
+
+# Session-local working notes (per-session handoff docs, run findings,
+# upstream PR drafts). Not part of the source.
+.project_notes/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,8 @@ dora run examples/python-dataflow/dataflow.yml --uv --stop-after 10s
 | `apis/rust/node` | dora-node-api | Rust API for writing custom nodes |
 | `apis/rust/operator` | dora-operator-api | Rust API for writing in-process operators |
 | `apis/python/node` | dora-node-api-python | Python node API (PyO3) |
+| `libraries/extensions/mavlink2-bridge` | dora-mavlink2-bridge | MAVLink 2 ↔ Apache Arrow conversion (common dialect) |
+| `binaries/mavlink2-bridge-node` | dora-mavlink2-bridge-node | Daemon-spawnable MAVLink 2 bridge (TCP/UDP/serial) |
 
 ## Architecture
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3466,6 +3466,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
+name = "ioctl-rs"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7970510895cee30b3e9128319f2cefd4bde883a39f38baa279567ba3a7eb97d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4087,6 +4096,7 @@ dependencies = [
  "crc-any",
  "serde",
  "serde_arrays",
+ "serial",
 ]
 
 [[package]]
@@ -6342,6 +6352,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1237a96570fc377c13baa1b88c7589ab66edced652e43ffb17088f003db3e86"
+dependencies = [
+ "serial-core",
+ "serial-unix",
+ "serial-windows",
+]
+
+[[package]]
+name = "serial-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f46209b345401737ae2125fe5b19a77acce90cd53e1658cda928e4fe9a64581"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "serial-unix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03fbca4c9d866e24a459cbca71283f545a37f8e3e002ad8c70593871453cab7"
+dependencies = [
+ "ioctl-rs",
+ "libc",
+ "serial-core",
+ "termios 0.2.2",
+]
+
+[[package]]
+name = "serial-windows"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c6d3b776267a75d31bbdfd5d36c0ca051251caafc285827052bc53bcdc8162"
+dependencies = [
+ "libc",
+ "serial-core",
+]
+
+[[package]]
 name = "service-example-client"
 version = "0.2.1"
 dependencies = [
@@ -6888,6 +6940,15 @@ dependencies = [
 
 [[package]]
 name = "termios"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termios"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
@@ -6924,7 +6985,7 @@ dependencies = [
  "signal-hook",
  "siphasher",
  "terminfo",
- "termios",
+ "termios 0.3.3",
  "thiserror 1.0.69",
  "ucd-trie",
  "unicode-segmentation",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,6 +1100,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc-any"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a62ec9ff5f7965e4d7280bd5482acd20aadb50d632cf6c1d74493856b011fa73"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1892,6 +1898,19 @@ dependencies = [
  "dora-message",
  "eyre",
  "serde_json",
+]
+
+[[package]]
+name = "dora-mavlink2-bridge"
+version = "0.2.1"
+dependencies = [
+ "arrow",
+ "eyre",
+ "mavlink",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4011,6 +4030,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "mavlink"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94356eb6ed56a834d6dca79a8c33c650d3d03d3ea79ae762ec1c9182b6fdc1e2"
+dependencies = [
+ "bitflags 1.3.2",
+ "mavlink-bindgen",
+ "mavlink-core",
+ "num-derive 0.3.3",
+ "num-traits",
+ "serde",
+ "serde_arrays",
+]
+
+[[package]]
+name = "mavlink-bindgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6c28f3eafc35544c7b4aee7cf9ec35b96c79a05de4bad3fe145bdac23570b04"
+dependencies = [
+ "crc-any",
+ "lazy_static",
+ "proc-macro2",
+ "quick-xml 0.36.2",
+ "quote",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "mavlink-core"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e64d975ca3cf0ad8a7c278553f91d77de15fcde9b79bf6bc542e209dd0c7dee"
+dependencies = [
+ "byteorder",
+ "crc-any",
+ "serde",
+ "serde_arrays",
+]
+
+[[package]]
 name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4372,6 +4432,17 @@ name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "num-derive"
@@ -5219,6 +5290,15 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
 version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
@@ -5832,7 +5912,7 @@ dependencies = [
  "mio 0.6.23",
  "mio 0.8.11",
  "mio-extras",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "paste",
  "rand 0.9.4",
@@ -6090,6 +6170,15 @@ checksum = "888d884a3be3a209308d0b66f1918ff18f60e93db837259e53ea7d8dd14e7e98"
 dependencies = [
  "serde",
  "shellexpand 2.1.2",
+]
+
+[[package]]
+name = "serde_arrays"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38636132857f68ec3d5f3eb121166d2af33cb55174c4d5ff645db6165cbef0fd"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -6806,7 +6895,7 @@ dependencies = [
  "log",
  "memmem",
  "nix 0.29.0",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "ordered-float",
  "pest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1907,6 +1907,7 @@ dependencies = [
  "arrow",
  "eyre",
  "mavlink",
+ "num-traits",
  "serde",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1912,6 +1912,24 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "url",
+]
+
+[[package]]
+name = "dora-mavlink2-bridge-node"
+version = "0.2.1"
+dependencies = [
+ "arrow",
+ "dora-mavlink2-bridge",
+ "dora-node-api",
+ "eyre",
+ "mavlink",
+ "serde",
+ "serde_yaml",
+ "tempfile",
+ "tracing",
+ "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4100,6 +4100,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "mavlink2-bridge-example-heartbeat-emitter"
+version = "0.2.1"
+dependencies = [
+ "arrow",
+ "dora-mavlink2-bridge",
+ "dora-node-api",
+ "eyre",
+ "tracing",
+]
+
+[[package]]
+name = "mavlink2-bridge-example-mavlink-sim"
+version = "0.2.1"
+dependencies = [
+ "dora-mavlink2-bridge",
+ "dora-node-api",
+ "eyre",
+ "mavlink",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "mavlink2-bridge-example-telemetry-printer-rust"
+version = "0.2.1"
+dependencies = [
+ "arrow",
+ "dora-mavlink2-bridge",
+ "dora-node-api",
+ "eyre",
+]
+
+[[package]]
 name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ futures = { version = "0.3.28", default-features = false, features = ["std", "as
 bincode = "1.3.3"
 flume = "0.10.14"
 tempfile = "3.23.0"
-mavlink = { version = "0.13", default-features = false, features = ["std", "serde", "common", "tcp"] }
+mavlink = { version = "0.13", default-features = false, features = ["std", "serde", "common", "tcp", "udp", "direct-serial"] }
 serialport = "4.6"
 url = "2.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,9 @@ members = [
     "examples/validated-pipeline/sink",
     "examples/error-propagation/producer",
     "examples/error-propagation/consumer",
+    "examples/mavlink2-bridge/heartbeat-emitter",
+    "examples/mavlink2-bridge/mavlink-sim",
+    "examples/mavlink2-bridge/telemetry-printer-rust",
     "libraries/arrow-convert",
     "libraries/log-utils",
     "libraries/coordinator-store",
@@ -196,6 +199,10 @@ path = "examples/c++-dataflow/run.rs"
 [[example]]
 name = "cxx-arrow-dataflow"
 path = "examples/c++-arrow-dataflow/run.rs"
+
+[[example]]
+name = "mavlink2-bridge-cxx"
+path = "examples/mavlink2-bridge/run-cxx.rs"
 
 [[example]]
 name = "python-dataflow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "binaries/coordinator",
     "binaries/daemon",
     "binaries/runtime",
+    "binaries/mavlink2-bridge-node",
     "binaries/ros2-bridge-node",
     "examples/rust-dataflow/node",
     "examples/rust-dataflow/status-node",
@@ -136,7 +137,7 @@ futures = { version = "0.3.28", default-features = false, features = ["std", "as
 bincode = "1.3.3"
 flume = "0.10.14"
 tempfile = "3.23.0"
-mavlink = { version = "0.13", default-features = false, features = ["std", "serde", "common"] }
+mavlink = { version = "0.13", default-features = false, features = ["std", "serde", "common", "tcp"] }
 serialport = "4.6"
 url = "2.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ members = [
     "binaries/record-node",
     "libraries/extensions/download",
     "libraries/extensions/telemetry/*",
+    "libraries/extensions/mavlink2-bridge",
     "libraries/extensions/ros2-bridge",
     "libraries/extensions/ros2-bridge/msg-gen",
     "libraries/extensions/ros2-bridge/python",
@@ -105,6 +106,7 @@ dora-coordinator = { version = "0.2.0", path = "binaries/coordinator" }
 dora-ros2-bridge = { version = "0.2.0", path = "libraries/extensions/ros2-bridge" }
 dora-ros2-bridge-msg-gen = { version = "0.2.0", path = "libraries/extensions/ros2-bridge/msg-gen" }
 dora-ros2-bridge-python = { path = "libraries/extensions/ros2-bridge/python" }
+dora-mavlink2-bridge = { version = "0.2.0", path = "libraries/extensions/mavlink2-bridge" }
 dora-message = { version = "0.2.0", path = "libraries/message" }
 arrow = { version = "58", default-features = false }
 arrow-schema = { version = "58" }
@@ -134,6 +136,9 @@ futures = { version = "0.3.28", default-features = false, features = ["std", "as
 bincode = "1.3.3"
 flume = "0.10.14"
 tempfile = "3.23.0"
+mavlink = { version = "0.13", default-features = false, features = ["std", "serde", "common"] }
+serialport = "4.6"
+url = "2.5"
 
 [package]
 name = "dora-examples"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **MAVLink 2 bridge** (`dora-mavlink2-bridge` extension + `dora-mavlink2-bridge-node` binary): Apache Arrow ↔ MAVLink 2 conversion for the common dialect (HEARTBEAT, SYS_STATUS, SYSTEM_TIME, ATTITUDE, ATTITUDE_QUATERNION, LOCAL_POSITION_NED, GLOBAL_POSITION_INT, GPS_RAW_INT, RC_CHANNELS, SERVO_OUTPUT_RAW, COMMAND_LONG, COMMAND_ACK, MISSION_CURRENT). TCP/UDP/serial transports, daemon-spawnable bridge node, and a self-contained `examples/mavlink2-bridge` dataflow with an in-process UDP simulator (no SITL/MAVProxy required). The example ships three consumer variants — Rust (`dataflow-rust.yml`), Python (`dataflow-python.yml`, `--uv`), and C++ (`dataflow-cxx.yml` via `cargo run --example mavlink2-bridge-cxx`) — all reading the same `bridge/heartbeat` Arrow output. See [#1786](https://github.com/dora-rs/dora/issues/1786).
+
 ## 0.1.0 (2026-03-13)
 
 First official release of Dora (AI-Dora) -- a 100% Rust framework for building real-time robotics and AI applications.

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 ### Added
 
 - **MAVLink 2 bridge** (`dora-mavlink2-bridge` extension + `dora-mavlink2-bridge-node` binary): Apache Arrow ↔ MAVLink 2 conversion for the common dialect (HEARTBEAT, SYS_STATUS, SYSTEM_TIME, ATTITUDE, ATTITUDE_QUATERNION, LOCAL_POSITION_NED, GLOBAL_POSITION_INT, GPS_RAW_INT, RC_CHANNELS, SERVO_OUTPUT_RAW, COMMAND_LONG, COMMAND_ACK, MISSION_CURRENT). TCP/UDP/serial transports, daemon-spawnable bridge node, and a self-contained `examples/mavlink2-bridge` dataflow with an in-process UDP simulator (no SITL/MAVProxy required). The example ships three consumer variants — Rust (`dataflow-rust.yml`), Python (`dataflow-python.yml`, `--uv`), and C++ (`dataflow-cxx.yml` via `cargo run --example mavlink2-bridge-cxx`) — all reading the same `bridge/heartbeat` Arrow output. See [#1786](https://github.com/dora-rs/dora/issues/1786).
+- **`examples/mavlink2-bridge-sitl-mission`**: closed-loop ArduCopter SITL demo. A Python dora node arms, takes off, hovers, lands, and disarms a simulated multirotor by driving the bridge's `command_long_cmd` input and watching `command_ack` + `global_position_int`. Local-only on Ubuntu / macOS; not part of CI (SITL needs a one-time ArduPilot install per developer machine). See `examples/mavlink2-bridge-sitl-mission/README.md`.
 
 ## 0.1.0 (2026-03-13)
 

--- a/README.md
+++ b/README.md
@@ -544,6 +544,7 @@ See [docs/patterns.md](docs/patterns.md) for the full guide.
 | [mavlink2-bridge (Rust)](examples/mavlink2-bridge/dataflow-rust.yml) | MAVLink 2 ↔ dora bridge, Rust telemetry consumer |
 | [mavlink2-bridge (Python)](examples/mavlink2-bridge/dataflow-python.yml) | Same bridge, Python telemetry consumer (`--uv`) |
 | [mavlink2-bridge (C++)](examples/mavlink2-bridge/dataflow-cxx.yml) | Same bridge, C++ telemetry consumer (`cargo run --example mavlink2-bridge-cxx`) |
+| [mavlink2-bridge-sitl-mission](examples/mavlink2-bridge-sitl-mission) | Closed-loop ArduCopter SITL: arm + takeoff + hover + land driven from a Python dora node (Ubuntu / macOS, local-only) |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -396,6 +396,7 @@ binaries/
   daemon/               # Node manager + IPC
   runtime/              # In-process operator runtime
   ros2-bridge-node/     # ROS2 bridge binary
+  mavlink2-bridge-node/ # MAVLink 2 bridge binary
   record-node/          # Dataflow message recorder
   replay-node/          # Recorded message replayer
 libraries/
@@ -409,6 +410,7 @@ libraries/
   extensions/
     telemetry/          # OpenTelemetry tracing + metrics
     ros2-bridge/        # ROS2 interop (bridge, msg-gen, arrow, python)
+    mavlink2-bridge/    # MAVLink 2 interop (Arrow ↔ MAVLink, TCP/UDP/serial)
     download/           # Download utilities
 apis/
   rust/node/            # Rust node API (dora-node-api)
@@ -534,6 +536,14 @@ See [docs/patterns.md](docs/patterns.md) for the full guide.
 | [ros2-bridge/yaml-bridge-service](examples/ros2-bridge/yaml-bridge-service) | YAML ROS2 service bridge |
 | [ros2-bridge/yaml-bridge-action](examples/ros2-bridge/yaml-bridge-action) | YAML ROS2 action client |
 | [ros2-bridge/yaml-bridge-action-server](examples/ros2-bridge/yaml-bridge-action-server) | YAML ROS2 action server |
+
+### MAVLink 2 integration
+
+| Example | Description |
+|---------|-------------|
+| [mavlink2-bridge (Rust)](examples/mavlink2-bridge/dataflow-rust.yml) | MAVLink 2 ↔ dora bridge, Rust telemetry consumer |
+| [mavlink2-bridge (Python)](examples/mavlink2-bridge/dataflow-python.yml) | Same bridge, Python telemetry consumer (`--uv`) |
+| [mavlink2-bridge (C++)](examples/mavlink2-bridge/dataflow-cxx.yml) | Same bridge, C++ telemetry consumer (`cargo run --example mavlink2-bridge-cxx`) |
 
 ## Development
 

--- a/_typos.toml
+++ b/_typos.toml
@@ -19,6 +19,14 @@ ser = "ser"
 BA = "BA"
 # Windows system library name (used by the C/C++ publish workflow)
 secur = "secur"
+# ArduPilot Software-In-The-Loop simulator; standard acronym in the
+# flight-controller community. Introduced by the mavlink2-bridge example.
+SITL = "SITL"
+sitl = "sitl"
+# MAVLink coordinate frame: North-East-Down. Field/message name in
+# common-dialect MAVLink messages such as LOCAL_POSITION_NED.
+NED = "NED"
+ned = "ned"
 
 [default]
 # Scoped allow: GitHub user name "YOR-robot" appears in the downstream-user

--- a/binaries/mavlink2-bridge-node/Cargo.toml
+++ b/binaries/mavlink2-bridge-node/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "dora-mavlink2-bridge-node"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "MAVLink 2 ↔ dora bridge node, daemon-spawnable"
+
+[dependencies]
+dora-mavlink2-bridge = { workspace = true }
+dora-node-api = { workspace = true }
+mavlink = { workspace = true }
+arrow = { workspace = true }
+url = { workspace = true }
+serde = { workspace = true }
+serde_yaml = { workspace = true }
+eyre = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = "0.3"
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/binaries/mavlink2-bridge-node/src/main.rs
+++ b/binaries/mavlink2-bridge-node/src/main.rs
@@ -60,6 +60,13 @@ use std::{sync::Arc, time::Duration};
 use url::Url;
 
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
+/// Total time to wait for a MAVLink endpoint to become reachable on
+/// initial bridge startup. A real autopilot can be slower to come up
+/// than the dora daemon, and the example dataflow spawns the bridge
+/// in parallel with an in-process simulator — both cases need a
+/// budgeted retry rather than a one-shot connect.
+const CONNECT_RETRY_BUDGET: Duration = Duration::from_secs(5);
+const CONNECT_RETRY_INTERVAL: Duration = Duration::from_millis(100);
 
 #[derive(Debug, Deserialize)]
 struct Config {
@@ -181,6 +188,32 @@ fn handle_input(
     Ok(())
 }
 
+/// Open the MAVLink transport, retrying briefly if the peer is not yet
+/// listening. Returns once a connection succeeds or the budget elapses.
+fn connect_with_retry(url: &Url) -> Result<Box<dyn MavConnection<MavMessage> + Send + Sync>> {
+    let deadline = std::time::Instant::now() + CONNECT_RETRY_BUDGET;
+    let mut last_err: Option<eyre::Report> = None;
+    loop {
+        match transport::connect(url) {
+            Ok(conn) => return Ok(conn),
+            Err(e) => {
+                let now = std::time::Instant::now();
+                if now >= deadline {
+                    return Err(eyre!(
+                        "failed to open MAVLink transport at {url} within {:?}: {} (last attempt: {})",
+                        CONNECT_RETRY_BUDGET,
+                        last_err.unwrap_or_else(|| eyre!("(none)")),
+                        e
+                    ));
+                }
+                tracing::debug!(%url, "waiting for MAVLink endpoint: {e}");
+                last_err = Some(eyre!("{e}"));
+                std::thread::sleep(CONNECT_RETRY_INTERVAL);
+            }
+        }
+    }
+}
+
 fn main() -> Result<()> {
     tracing_subscriber::fmt::try_init().ok();
 
@@ -188,7 +221,7 @@ fn main() -> Result<()> {
     let url = cfg.parsed_endpoint()?;
     tracing::info!(endpoint = %url, "opening MAVLink 2 transport");
 
-    let conn_box = transport::connect(&url)?;
+    let conn_box = connect_with_retry(&url)?;
     let conn: Arc<dyn MavConnection<MavMessage> + Send + Sync> = Arc::from(conn_box);
 
     let header = MavHeader {
@@ -229,6 +262,11 @@ fn main() -> Result<()> {
         }
     }
 
+    // Drop the rx end first: the reader thread blocks in `conn.recv()`
+    // and only notices shutdown when its next successful decode tries to
+    // `tx.send()` and finds the channel closed. Without this, `join()`
+    // below would wait until the daemon SIGKILLs us at the grace deadline.
+    drop(rx);
     drop(node);
     drop(events);
     match reader_handle.join() {

--- a/binaries/mavlink2-bridge-node/src/main.rs
+++ b/binaries/mavlink2-bridge-node/src/main.rs
@@ -1,10 +1,10 @@
 //! MAVLink 2 ↔ dora bridge node.
 //!
 //! This binary is spawned by the dora daemon as a normal node. It opens
-//! a MAVLink 2 connection (TCP in this PR; UDP/serial in #1786 follow-up),
-//! decodes incoming frames into Arrow `StructArray` rows, and publishes
-//! them on dora outputs. Inputs are encoded back to MAVLink frames and
-//! sent on the same connection.
+//! a MAVLink 2 connection (TCP/UDP/serial), decodes incoming common-
+//! dialect frames into Arrow `StructArray` rows, and publishes them on
+//! per-message dora outputs. Inputs named `<message>_cmd` are decoded
+//! back into MAVLink frames and sent on the same connection.
 //!
 //! Configuration comes from the `MAVLINK_BRIDGE_CONFIG` env var as YAML:
 //!
@@ -13,8 +13,40 @@
 //! system_id: 255
 //! component_id: 1
 //! ```
+//!
+//! ## Outputs (telemetry, MAVLink → dora)
+//!
+//! | dora output            | MAVLink message       |
+//! |------------------------|-----------------------|
+//! | `heartbeat`            | HEARTBEAT             |
+//! | `sys_status`           | SYS_STATUS            |
+//! | `system_time`          | SYSTEM_TIME           |
+//! | `attitude`             | ATTITUDE              |
+//! | `attitude_quaternion`  | ATTITUDE_QUATERNION   |
+//! | `local_position_ned`   | LOCAL_POSITION_NED    |
+//! | `global_position_int`  | GLOBAL_POSITION_INT   |
+//! | `gps_raw_int`          | GPS_RAW_INT           |
+//! | `rc_channels`          | RC_CHANNELS           |
+//! | `servo_output_raw`     | SERVO_OUTPUT_RAW      |
+//! | `command_long`         | COMMAND_LONG          |
+//! | `command_ack`          | COMMAND_ACK           |
+//! | `mission_current`      | MISSION_CURRENT       |
+//!
+//! ## Inputs (commands, dora → MAVLink)
+//!
+//! | dora input             | MAVLink message       |
+//! |------------------------|-----------------------|
+//! | `heartbeat_cmd`        | HEARTBEAT             |
+//! | `command_long_cmd`     | COMMAND_LONG          |
+//!
+//! Other message types are read-only telemetry; sending them inbound is
+//! out of scope for this PR.
 
-use dora_mavlink2_bridge::{MavlinkArrow, mavlink::common::HEARTBEAT_DATA, transport};
+use dora_mavlink2_bridge::{
+    MavlinkArrow,
+    mavlink::common::{COMMAND_LONG_DATA, HEARTBEAT_DATA},
+    transport,
+};
 use dora_node_api::{
     DoraNode, Event, MetadataParameters,
     arrow::array::{ArrayRef, AsArray, RecordBatch, StructArray},
@@ -22,13 +54,11 @@ use dora_node_api::{
     flume,
 };
 use eyre::{Context, Result, bail, eyre};
-use mavlink::{MavConnection, MavHeader, common::MavMessage};
+use mavlink::{MavConnection, MavHeader, Message, common::MavMessage};
 use serde::Deserialize;
 use std::{sync::Arc, time::Duration};
 use url::Url;
 
-const HEARTBEAT_OUTPUT: &str = "heartbeat";
-const HEARTBEAT_INPUT: &str = "heartbeat_cmd";
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 #[derive(Debug, Deserialize)]
@@ -62,30 +92,49 @@ impl Config {
     }
 }
 
-/// Reader thread: blocks on `conn.recv()` and forwards converted Arrow
-/// arrays to the main thread via `tx`. Returns when `tx` is dropped
-/// (main thread exited) or the connection errors continuously.
+/// Reader thread: blocks on `conn.recv()`, converts each supported
+/// message into a 1-row Arrow `StructArray`, and forwards it on `tx`.
+/// Returns when `tx` is dropped (main thread exited).
 fn run_reader(
     conn: Arc<dyn MavConnection<MavMessage> + Send + Sync>,
     tx: flume::Sender<(DataId, ArrayRef)>,
 ) -> Result<()> {
+    /// Convert + queue a single decoded message; on a closed channel,
+    /// short-circuit the reader by `return`-ing from the surrounding
+    /// `run_reader` call.
+    macro_rules! emit {
+        ($data:expr, $output_name:literal) => {{
+            let batch = MavlinkArrow::to_record_batch(&$data)?;
+            let arr: ArrayRef = Arc::new(StructArray::from(batch));
+            if tx
+                .send((DataId::from($output_name.to_string()), arr))
+                .is_err()
+            {
+                return Ok(()); // main thread gone, drain & exit
+            }
+        }};
+    }
+
     loop {
         match conn.recv() {
-            Ok((_header, MavMessage::HEARTBEAT(d))) => {
-                let batch = d.to_record_batch()?;
-                let arr: ArrayRef = Arc::new(StructArray::from(batch));
-                if tx
-                    .send((DataId::from(HEARTBEAT_OUTPUT.to_string()), arr))
-                    .is_err()
-                {
-                    return Ok(()); // main thread gone
+            Ok((_header, msg)) => match msg {
+                MavMessage::HEARTBEAT(d) => emit!(d, "heartbeat"),
+                MavMessage::SYS_STATUS(d) => emit!(d, "sys_status"),
+                MavMessage::SYSTEM_TIME(d) => emit!(d, "system_time"),
+                MavMessage::ATTITUDE(d) => emit!(d, "attitude"),
+                MavMessage::ATTITUDE_QUATERNION(d) => emit!(d, "attitude_quaternion"),
+                MavMessage::LOCAL_POSITION_NED(d) => emit!(d, "local_position_ned"),
+                MavMessage::GLOBAL_POSITION_INT(d) => emit!(d, "global_position_int"),
+                MavMessage::GPS_RAW_INT(d) => emit!(d, "gps_raw_int"),
+                MavMessage::RC_CHANNELS(d) => emit!(d, "rc_channels"),
+                MavMessage::SERVO_OUTPUT_RAW(d) => emit!(d, "servo_output_raw"),
+                MavMessage::COMMAND_LONG(d) => emit!(d, "command_long"),
+                MavMessage::COMMAND_ACK(d) => emit!(d, "command_ack"),
+                MavMessage::MISSION_CURRENT(d) => emit!(d, "mission_current"),
+                other => {
+                    tracing::trace!(msg_id = other.message_id(), "skipping unhandled message");
                 }
-            }
-            Ok(_) => {
-                // PR #3 only handles HEARTBEAT; other message types are
-                // ignored here and will be wired up by PR #5 (common
-                // dialect coverage). #1786.
-            }
+            },
             Err(e) => {
                 tracing::warn!("mavlink recv error: {e}");
                 std::thread::sleep(Duration::from_millis(50));
@@ -94,28 +143,40 @@ fn run_reader(
     }
 }
 
-/// Decode one incoming dora `Event::Input` and forward it as a MAVLink
-/// frame on `conn`. Returns Ok even for unknown input ids — the bridge
-/// silently ignores them rather than failing the whole node.
+/// Decode an incoming Arrow `StructArray` for type `T` from a dora
+/// `Event::Input` payload.
+fn decode_input<T: MavlinkArrow>(data: &ArrayRef, input: &str) -> Result<T> {
+    let struct_array = data.as_struct_opt().ok_or_else(|| {
+        eyre!(
+            "expected StructArray for input '{input}', got {:?}",
+            data.data_type()
+        )
+    })?;
+    let batch = RecordBatch::from(struct_array);
+    T::from_record_batch(&batch).with_context(|| format!("decoding {input} from incoming Arrow"))
+}
+
+/// Forward one incoming dora `Event::Input` as a MAVLink frame on
+/// `conn`. Unknown input ids are silently ignored — the bridge does
+/// not abort the whole node on misrouted inputs.
 fn handle_input(
     conn: &(dyn MavConnection<MavMessage> + Send + Sync),
     header: &MavHeader,
     id: &DataId,
     data: &ArrayRef,
 ) -> Result<()> {
-    if id.as_str() != HEARTBEAT_INPUT {
-        return Ok(()); // unknown input id, ignore
-    }
-    let struct_array = data.as_struct_opt().ok_or_else(|| {
-        eyre!(
-            "expected StructArray for input '{HEARTBEAT_INPUT}', got {:?}",
-            data.data_type()
-        )
-    })?;
-    let batch = RecordBatch::from(struct_array);
-    let cmd = HEARTBEAT_DATA::from_record_batch(&batch)
-        .context("decoding HEARTBEAT from incoming Arrow")?;
-    conn.send(header, &MavMessage::HEARTBEAT(cmd))
+    let outgoing = match id.as_str() {
+        "heartbeat_cmd" => {
+            let d: HEARTBEAT_DATA = decode_input(data, id.as_str())?;
+            MavMessage::HEARTBEAT(d)
+        }
+        "command_long_cmd" => {
+            let d: COMMAND_LONG_DATA = decode_input(data, id.as_str())?;
+            MavMessage::COMMAND_LONG(d)
+        }
+        _ => return Ok(()), // unknown input id, ignore
+    };
+    conn.send(header, &outgoing)
         .map_err(|e| eyre!("mavlink send: {e}"))?;
     Ok(())
 }
@@ -163,8 +224,8 @@ fn main() -> Result<()> {
                 }
             }
             Some(Event::Stop(_)) => break,
-            Some(_) => {} // ignore other event variants
-            None => {}    // timeout, revisit rx
+            Some(_) => {}
+            None => {}
         }
     }
 

--- a/binaries/mavlink2-bridge-node/src/main.rs
+++ b/binaries/mavlink2-bridge-node/src/main.rs
@@ -49,8 +49,8 @@
 use dora_mavlink2_bridge::{
     MavlinkArrow,
     mavlink::common::{
-        COMMAND_LONG_DATA, HEARTBEAT_DATA, RC_CHANNELS_OVERRIDE_DATA,
-        SET_MODE_DATA, SET_POSITION_TARGET_GLOBAL_INT_DATA, SET_POSITION_TARGET_LOCAL_NED_DATA,
+        COMMAND_LONG_DATA, HEARTBEAT_DATA, RC_CHANNELS_OVERRIDE_DATA, SET_MODE_DATA,
+        SET_POSITION_TARGET_GLOBAL_INT_DATA, SET_POSITION_TARGET_LOCAL_NED_DATA,
     },
     transport,
 };
@@ -61,12 +61,28 @@ use dora_node_api::{
     flume,
 };
 use eyre::{Context, Result, bail, eyre};
-use mavlink::{MavConnection, MavHeader, Message, common::MavMessage};
+use mavlink::{MavConnection, MavHeader, MavlinkVersion, Message, common::MavMessage};
 use serde::Deserialize;
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::{Duration, Instant},
+};
 use url::Url;
 
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
+/// Belt-and-suspenders fallback for shutdown after the interrupt
+/// signals below have already fired. Covers the only transport mavlink
+/// 0.13 doesn't let us interrupt cleanly (serial: `SerialConnection`'s
+/// `SystemPort` is a private field, so we can't close it from another
+/// thread). After this budget elapses we drop the `JoinHandle` and let
+/// the OS reap the reader on process exit, so `dora stop` /
+/// `--stop-after` don't hang until SIGKILL at the daemon's grace
+/// deadline.
+const READER_SHUTDOWN_GRACE: Duration = Duration::from_millis(500);
+const READER_SHUTDOWN_POLL: Duration = Duration::from_millis(20);
 /// Total time to wait for a MAVLink endpoint to become reachable on
 /// initial bridge startup. A real autopilot can be slower to come up
 /// than the dora daemon, and the example dataflow spawns the bridge
@@ -108,10 +124,24 @@ impl Config {
 
 /// Reader thread: blocks on `conn.recv()`, converts each supported
 /// message into a 1-row Arrow `StructArray`, and forwards it on `tx`.
-/// Returns when `tx` is dropped (main thread exited).
+///
+/// Exits when:
+///   * `tx` is dropped (main thread exited normally), OR
+///   * `shutdown` is set AND `conn.recv()` returns. The flag check
+///     fires at the top of every loop iteration. mavlink-core 0.13's
+///     **TCP** transport sets a 100 ms socket read_timeout, so each
+///     `conn.recv()` returns `Err(WouldBlock)` within ~100 ms even on a
+///     silent peer, giving the flag a window to fire. **UDP** and
+///     **Serial** loop internally on errors (see `connection/udp.rs`
+///     and `connection/direct_serial.rs`); main wakes UDP via a
+///     self-loopback HEARTBEAT so the inner `recv_from` returns Ok
+///     and we recheck the flag. Serial has no externally accessible
+///     wake path in mavlink 0.13, so it falls back to the OS-reap-on-
+///     exit grace window in `main`.
 fn run_reader(
     conn: Arc<dyn MavConnection<MavMessage> + Send + Sync>,
     tx: flume::Sender<(DataId, ArrayRef)>,
+    shutdown: Arc<AtomicBool>,
 ) -> Result<()> {
     /// Convert + queue a single decoded message; on a closed channel,
     /// short-circuit the reader by `return`-ing from the surrounding
@@ -130,31 +160,88 @@ fn run_reader(
     }
 
     loop {
+        if shutdown.load(Ordering::Relaxed) {
+            return Ok(());
+        }
         match conn.recv() {
-            Ok((_header, msg)) => match msg {
-                MavMessage::HEARTBEAT(d) => emit!(d, "heartbeat"),
-                MavMessage::SYS_STATUS(d) => emit!(d, "sys_status"),
-                MavMessage::SYSTEM_TIME(d) => emit!(d, "system_time"),
-                MavMessage::ATTITUDE(d) => emit!(d, "attitude"),
-                MavMessage::ATTITUDE_QUATERNION(d) => emit!(d, "attitude_quaternion"),
-                MavMessage::LOCAL_POSITION_NED(d) => emit!(d, "local_position_ned"),
-                MavMessage::GLOBAL_POSITION_INT(d) => emit!(d, "global_position_int"),
-                MavMessage::GPS_RAW_INT(d) => emit!(d, "gps_raw_int"),
-                MavMessage::RC_CHANNELS(d) => emit!(d, "rc_channels"),
-                MavMessage::SERVO_OUTPUT_RAW(d) => emit!(d, "servo_output_raw"),
-                MavMessage::COMMAND_LONG(d) => emit!(d, "command_long"),
-                MavMessage::COMMAND_ACK(d) => emit!(d, "command_ack"),
-                MavMessage::MISSION_CURRENT(d) => emit!(d, "mission_current"),
-                other => {
-                    tracing::trace!(msg_id = other.message_id(), "skipping unhandled message");
+            Ok((_header, msg)) => {
+                if shutdown.load(Ordering::Relaxed) {
+                    return Ok(());
                 }
-            },
+                match msg {
+                    MavMessage::HEARTBEAT(d) => emit!(d, "heartbeat"),
+                    MavMessage::SYS_STATUS(d) => emit!(d, "sys_status"),
+                    MavMessage::SYSTEM_TIME(d) => emit!(d, "system_time"),
+                    MavMessage::ATTITUDE(d) => emit!(d, "attitude"),
+                    MavMessage::ATTITUDE_QUATERNION(d) => emit!(d, "attitude_quaternion"),
+                    MavMessage::LOCAL_POSITION_NED(d) => emit!(d, "local_position_ned"),
+                    MavMessage::GLOBAL_POSITION_INT(d) => emit!(d, "global_position_int"),
+                    MavMessage::GPS_RAW_INT(d) => emit!(d, "gps_raw_int"),
+                    MavMessage::RC_CHANNELS(d) => emit!(d, "rc_channels"),
+                    MavMessage::SERVO_OUTPUT_RAW(d) => emit!(d, "servo_output_raw"),
+                    MavMessage::COMMAND_LONG(d) => emit!(d, "command_long"),
+                    MavMessage::COMMAND_ACK(d) => emit!(d, "command_ack"),
+                    MavMessage::MISSION_CURRENT(d) => emit!(d, "mission_current"),
+                    other => {
+                        tracing::trace!(msg_id = other.message_id(), "skipping unhandled message");
+                    }
+                }
+            }
             Err(e) => {
-                tracing::warn!("mavlink recv error: {e}");
-                std::thread::sleep(Duration::from_millis(50));
+                // Suppress the warn during shutdown: TCP's 100 ms read
+                // timeout will have produced a `WouldBlock` here, which
+                // is the *intended* path back to the shutdown flag check.
+                if !shutdown.load(Ordering::Relaxed) {
+                    tracing::warn!("mavlink recv error: {e}");
+                    std::thread::sleep(Duration::from_millis(50));
+                }
             }
         }
     }
+}
+
+/// Send a self-loopback HEARTBEAT to the bridge's own bound UDP port
+/// so mavlink-core 0.13's `UdpConnection::recv` (which loops internally
+/// on errors and never returns Err) sees a valid frame and returns
+/// `Ok`, letting `run_reader` re-check its shutdown flag and exit.
+///
+/// For `udp://0.0.0.0:N` we redirect to `127.0.0.1:N` because sending
+/// to 0.0.0.0 isn't routable. Any send error is non-fatal — the grace
+/// window in `main` is the safety net.
+fn wake_udp_recv(url: &Url, system_id: u8, component_id: u8) -> std::io::Result<()> {
+    use mavlink::common::{
+        HEARTBEAT_DATA, MavAutopilot, MavMessage, MavModeFlag, MavState, MavType,
+    };
+    use std::net::UdpSocket;
+
+    let host = url.host_str().unwrap_or("127.0.0.1");
+    let target_host = if host == "0.0.0.0" || host.is_empty() {
+        "127.0.0.1"
+    } else {
+        host
+    };
+    let port = url.port().unwrap_or(transport::DEFAULT_UDP_PORT);
+    let dest = format!("{target_host}:{port}");
+
+    let socket = UdpSocket::bind("0.0.0.0:0")?;
+    let header = MavHeader {
+        system_id,
+        component_id,
+        sequence: 0,
+    };
+    let hb = MavMessage::HEARTBEAT(HEARTBEAT_DATA {
+        custom_mode: 0,
+        mavtype: MavType::MAV_TYPE_GENERIC,
+        autopilot: MavAutopilot::MAV_AUTOPILOT_GENERIC,
+        base_mode: MavModeFlag::empty(),
+        system_status: MavState::MAV_STATE_UNINIT,
+        mavlink_version: 3,
+    });
+    let mut buf = Vec::new();
+    mavlink::write_versioned_msg(&mut buf, MavlinkVersion::V2, header, &hb)
+        .map_err(|e| std::io::Error::other(format!("encode wake heartbeat: {e}")))?;
+    socket.send_to(&buf, dest)?;
+    Ok(())
 }
 
 /// Decode an incoming Arrow `StructArray` for type `T` from a dora
@@ -276,11 +363,17 @@ fn main() -> Result<()> {
 
     let (tx, rx) = flume::bounded::<(DataId, ArrayRef)>(64);
 
+    // Shared shutdown signal: main flips this after `Event::Stop` so
+    // `run_reader` can break out of its receive loop on the next
+    // iteration boundary instead of hanging on `conn.recv()`.
+    let shutdown = Arc::new(AtomicBool::new(false));
+
     let reader_handle = {
         let conn = Arc::clone(&conn);
+        let shutdown = Arc::clone(&shutdown);
         std::thread::Builder::new()
             .name("mavlink-reader".into())
-            .spawn(move || run_reader(conn, tx))
+            .spawn(move || run_reader(conn, tx, shutdown))
             .context("spawning mavlink reader thread")?
     };
 
@@ -306,16 +399,171 @@ fn main() -> Result<()> {
         }
     }
 
-    // Drop the rx end first: the reader thread blocks in `conn.recv()`
-    // and only notices shutdown when its next successful decode tries to
-    // `tx.send()` and finds the channel closed. Without this, `join()`
-    // below would wait until the daemon SIGKILLs us at the grace deadline.
+    // Three-layer shutdown sequence — each layer covers a transport
+    // mavlink-core 0.13 leaves un-interruptible at the previous layer:
+    //
+    //   1. Set the shutdown flag. `run_reader` checks it at the top of
+    //      every loop iteration; **TCP** wakes within ~100 ms because
+    //      mavlink's TCP socket has a 100 ms `set_read_timeout` so each
+    //      `recv()` returns `Err(WouldBlock)` and we revisit the flag.
+    //
+    //   2. Send a self-loopback HEARTBEAT for **UDP**, since
+    //      `UdpConnection::recv` loops internally on errors and never
+    //      returns Err — only a successfully parsed frame gets us back
+    //      to the flag check. The wake packet is a valid HEARTBEAT to
+    //      our own bound port; the reader receives it, hits the flag,
+    //      exits. Send errors are non-fatal (the grace window below
+    //      catches us).
+    //
+    //   3. Bounded grace + detach. **Serial** has no externally usable
+    //      wake path in mavlink 0.13 (`SerialConnection`'s `SystemPort`
+    //      is private and `recv` loops internally), so on serial we
+    //      fall through to here, drop the JoinHandle, and let the OS
+    //      reap the reader thread on process exit. `dora stop` /
+    //      `--stop-after` get control back within
+    //      `READER_SHUTDOWN_GRACE` regardless.
+    shutdown.store(true, Ordering::Relaxed);
+    if url.scheme() == "udp"
+        && let Err(e) = wake_udp_recv(&url, cfg.system_id, cfg.component_id)
+    {
+        tracing::debug!("UDP wake send failed (non-fatal): {e}");
+    }
     drop(rx);
     drop(node);
     drop(events);
-    match reader_handle.join() {
-        Ok(Ok(())) => Ok(()),
-        Ok(Err(e)) => bail!("reader thread error: {e:#}"),
-        Err(panic) => bail!("reader thread panicked: {panic:?}"),
+
+    let shutdown_deadline = Instant::now() + READER_SHUTDOWN_GRACE;
+    while !reader_handle.is_finished() && Instant::now() < shutdown_deadline {
+        std::thread::sleep(READER_SHUTDOWN_POLL);
+    }
+
+    if reader_handle.is_finished() {
+        match reader_handle.join() {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(e)) => bail!("reader thread error: {e:#}"),
+            Err(panic) => bail!("reader thread panicked: {panic:?}"),
+        }
+    } else {
+        // Reader is still blocked in `conn.recv()` with no inbound
+        // traffic to wake it (this is the serial-transport path, or
+        // any UDP setup where the wake packet was dropped by a
+        // firewall on a non-loopback bind). Detaching is safe: the
+        // thread holds no shared resources beyond `conn` (an `Arc`
+        // cleaned up at exit) and a closed channel sender, and the
+        // OS terminates it when this process exits a moment later.
+        tracing::debug!(
+            "mavlink reader still blocked after {READER_SHUTDOWN_GRACE:?} grace; detaching"
+        );
+        drop(reader_handle);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Shutdown-path regression tests.
+    //!
+    //! These cover the failure mode the original review flagged: a
+    //! reader thread blocked in `conn.recv()` against a silent
+    //! MAVLink peer must be wakeable from `main`, otherwise the node
+    //! hangs until the daemon's SIGKILL at the grace deadline.
+    //!
+    //! We don't spawn the full bridge process (that's the integration
+    //! tests' job); we drive `run_reader` + `wake_udp_recv` directly
+    //! against an isolated UDP loopback to assert the contract.
+
+    use super::*;
+    use std::net::UdpSocket;
+
+    /// Reserve a UDP port and immediately drop it so mavlink can
+    /// rebind. Mirrors the pattern in `tests/udp_loopback.rs`.
+    fn pick_free_udp_port() -> u16 {
+        let probe = UdpSocket::bind("127.0.0.1:0").expect("bind probe");
+        let port = probe.local_addr().expect("local_addr").port();
+        drop(probe);
+        port
+    }
+
+    /// Silent UDP peer: no inbound traffic at all. Without the wake
+    /// path, mavlink-core 0.13's `UdpConnection::recv` loops in
+    /// `recv_from` forever. Setting the shutdown flag alone does
+    /// nothing because the flag is only checked between iterations —
+    /// the wake packet is what causes `recv_from` to return so
+    /// `run_reader` can revisit the flag and exit.
+    #[test]
+    fn run_reader_exits_promptly_when_udp_peer_is_silent() {
+        let port = pick_free_udp_port();
+        let url = Url::parse(&format!("udp://127.0.0.1:{port}")).unwrap();
+        let conn_box = transport::connect(&url).expect("transport::connect");
+        let conn: Arc<dyn MavConnection<MavMessage> + Send + Sync> = Arc::from(conn_box);
+
+        let (tx, _rx_keep_alive) = flume::bounded::<(DataId, ArrayRef)>(64);
+        let shutdown = Arc::new(AtomicBool::new(false));
+
+        let handle = std::thread::spawn({
+            let conn = Arc::clone(&conn);
+            let shutdown = Arc::clone(&shutdown);
+            move || run_reader(conn, tx, shutdown)
+        });
+
+        // Let the reader thread settle into `recv_from`.
+        std::thread::sleep(Duration::from_millis(150));
+        assert!(
+            !handle.is_finished(),
+            "reader exited unexpectedly before shutdown was signalled"
+        );
+
+        let started = Instant::now();
+        shutdown.store(true, Ordering::Relaxed);
+        wake_udp_recv(&url, 0xFE, 1).expect("wake send");
+
+        // The wake frame should round-trip and the reader should
+        // notice the flag within well under a second. Cap at 2 s to
+        // give CI runners headroom; on a developer laptop this
+        // typically returns in <50 ms.
+        let join_deadline = Instant::now() + Duration::from_secs(2);
+        while !handle.is_finished() && Instant::now() < join_deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            handle.is_finished(),
+            "reader did not exit within 2s of shutdown wake; elapsed={:?}",
+            started.elapsed()
+        );
+        let result = handle.join().expect("reader thread panicked");
+        assert!(result.is_ok(), "reader returned Err: {result:?}");
+    }
+
+    /// `wake_udp_recv` should rewrite an `udp://0.0.0.0:port` URL to
+    /// `127.0.0.1:port` for the send target, since `0.0.0.0` is not a
+    /// routable destination. We assert behavior, not the rewrite, by
+    /// confirming the wake actually delivers to a listener bound on
+    /// `0.0.0.0`.
+    #[test]
+    fn wake_udp_recv_handles_zero_address_bind() {
+        let port = pick_free_udp_port();
+        let url = Url::parse(&format!("udp://0.0.0.0:{port}")).unwrap();
+        let conn_box = transport::connect(&url).expect("transport::connect");
+        let conn: Arc<dyn MavConnection<MavMessage> + Send + Sync> = Arc::from(conn_box);
+
+        let (tx, _rx_keep_alive) = flume::bounded::<(DataId, ArrayRef)>(64);
+        let shutdown = Arc::new(AtomicBool::new(false));
+
+        let handle = std::thread::spawn({
+            let conn = Arc::clone(&conn);
+            let shutdown = Arc::clone(&shutdown);
+            move || run_reader(conn, tx, shutdown)
+        });
+        std::thread::sleep(Duration::from_millis(150));
+
+        shutdown.store(true, Ordering::Relaxed);
+        wake_udp_recv(&url, 0xFE, 1).expect("wake send");
+
+        let join_deadline = Instant::now() + Duration::from_secs(2);
+        while !handle.is_finished() && Instant::now() < join_deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(handle.is_finished(), "0.0.0.0-bind wake did not deliver");
+        handle.join().expect("panic").expect("err");
     }
 }

--- a/binaries/mavlink2-bridge-node/src/main.rs
+++ b/binaries/mavlink2-bridge-node/src/main.rs
@@ -34,10 +34,13 @@
 //!
 //! ## Inputs (commands, dora → MAVLink)
 //!
-//! | dora input             | MAVLink message       |
-//! |------------------------|-----------------------|
-//! | `heartbeat_cmd`        | HEARTBEAT             |
-//! | `command_long_cmd`     | COMMAND_LONG          |
+//! | dora input                          | MAVLink message                  |
+//! |-------------------------------------|----------------------------------|
+//! | `heartbeat_cmd`                     | HEARTBEAT                        |
+//! | `command_long_cmd`                  | COMMAND_LONG                     |
+//! | `set_mode_cmd`                      | SET_MODE                         |
+//! | `rc_channels_override_cmd`          | RC_CHANNELS_OVERRIDE             |
+//! | `set_position_target_global_int_cmd`| SET_POSITION_TARGET_GLOBAL_INT   |
 //!
 //! Other message types are read-only telemetry; sending them inbound is
 //! out of scope for this PR.
@@ -45,7 +48,8 @@
 use dora_mavlink2_bridge::{
     MavlinkArrow,
     mavlink::common::{
-        COMMAND_LONG_DATA, HEARTBEAT_DATA, RC_CHANNELS_OVERRIDE_DATA, SET_MODE_DATA,
+        COMMAND_LONG_DATA, HEARTBEAT_DATA, RC_CHANNELS_OVERRIDE_DATA,
+        SET_MODE_DATA, SET_POSITION_TARGET_GLOBAL_INT_DATA,
     },
     transport,
 };
@@ -190,6 +194,10 @@ fn handle_input(
         "rc_channels_override_cmd" => {
             let d: RC_CHANNELS_OVERRIDE_DATA = decode_input(data, id.as_str())?;
             MavMessage::RC_CHANNELS_OVERRIDE(d)
+        }
+        "set_position_target_global_int_cmd" => {
+            let d: SET_POSITION_TARGET_GLOBAL_INT_DATA = decode_input(data, id.as_str())?;
+            MavMessage::SET_POSITION_TARGET_GLOBAL_INT(d)
         }
         _ => return Ok(()), // unknown input id, ignore
     };

--- a/binaries/mavlink2-bridge-node/src/main.rs
+++ b/binaries/mavlink2-bridge-node/src/main.rs
@@ -44,7 +44,7 @@
 
 use dora_mavlink2_bridge::{
     MavlinkArrow,
-    mavlink::common::{COMMAND_LONG_DATA, HEARTBEAT_DATA},
+    mavlink::common::{COMMAND_LONG_DATA, HEARTBEAT_DATA, RC_CHANNELS_OVERRIDE_DATA, SET_MODE_DATA},
     transport,
 };
 use dora_node_api::{
@@ -181,6 +181,14 @@ fn handle_input(
             let d: COMMAND_LONG_DATA = decode_input(data, id.as_str())?;
             MavMessage::COMMAND_LONG(d)
         }
+        "set_mode_cmd" => {
+            let d: SET_MODE_DATA = decode_input(data, id.as_str())?;
+            MavMessage::SET_MODE(d)
+        }
+        "rc_channels_override_cmd" => {
+            let d: RC_CHANNELS_OVERRIDE_DATA = decode_input(data, id.as_str())?;
+            MavMessage::RC_CHANNELS_OVERRIDE(d)
+        }
         _ => return Ok(()), // unknown input id, ignore
     };
     conn.send(header, &outgoing)
@@ -229,6 +237,24 @@ fn main() -> Result<()> {
         component_id: cfg.component_id,
         sequence: 0,
     };
+
+    // Request all data streams from the autopilot at 5 Hz so HEARTBEAT,
+    // GLOBAL_POSITION_INT, GPS_RAW_INT, COMMAND_ACK, etc. start flowing
+    // on this link. Without this, ArduCopter 3.x sends only HEARTBEAT
+    // until a GCS asks. Failure is non-fatal (some autopilots ignore the
+    // legacy REQUEST_DATA_STREAM and prefer SET_MESSAGE_INTERVAL).
+    let req = mavlink::common::REQUEST_DATA_STREAM_DATA {
+        req_message_rate: 5,
+        target_system: 0,    // 0 = broadcast to whichever autopilot answers
+        target_component: 0,
+        req_stream_id: 0,    // MAV_DATA_STREAM_ALL
+        start_stop: 1,
+    };
+    if let Err(e) = conn.send(&header, &MavMessage::REQUEST_DATA_STREAM(req)) {
+        tracing::warn!("REQUEST_DATA_STREAM send failed (non-fatal): {e}");
+    } else {
+        tracing::info!("requested all data streams at 5 Hz");
+    }
 
     let (mut node, mut events) =
         DoraNode::init_from_env().map_err(|e| eyre!("DoraNode init: {e}"))?;

--- a/binaries/mavlink2-bridge-node/src/main.rs
+++ b/binaries/mavlink2-bridge-node/src/main.rs
@@ -44,7 +44,9 @@
 
 use dora_mavlink2_bridge::{
     MavlinkArrow,
-    mavlink::common::{COMMAND_LONG_DATA, HEARTBEAT_DATA, RC_CHANNELS_OVERRIDE_DATA, SET_MODE_DATA},
+    mavlink::common::{
+        COMMAND_LONG_DATA, HEARTBEAT_DATA, RC_CHANNELS_OVERRIDE_DATA, SET_MODE_DATA,
+    },
     transport,
 };
 use dora_node_api::{
@@ -245,9 +247,9 @@ fn main() -> Result<()> {
     // legacy REQUEST_DATA_STREAM and prefer SET_MESSAGE_INTERVAL).
     let req = mavlink::common::REQUEST_DATA_STREAM_DATA {
         req_message_rate: 5,
-        target_system: 0,    // 0 = broadcast to whichever autopilot answers
+        target_system: 0, // 0 = broadcast to whichever autopilot answers
         target_component: 0,
-        req_stream_id: 0,    // MAV_DATA_STREAM_ALL
+        req_stream_id: 0, // MAV_DATA_STREAM_ALL
         start_stop: 1,
     };
     if let Err(e) = conn.send(&header, &MavMessage::REQUEST_DATA_STREAM(req)) {
@@ -279,7 +281,10 @@ fn main() -> Result<()> {
             Some(Event::Input { id, data, .. }) => {
                 let array_ref: ArrayRef = data.into();
                 if let Err(e) = handle_input(conn.as_ref(), &header, &id, &array_ref) {
-                    tracing::warn!("writer error on input '{id}': {e:#}");
+                    // Writer errors mean the dora node's command did NOT reach the
+                    // autopilot. Surface at error level so users debugging missions see
+                    // it in default log filters rather than treating it as routine noise.
+                    tracing::error!("writer error on input '{id}': {e:#}");
                 }
             }
             Some(Event::Stop(_)) => break,

--- a/binaries/mavlink2-bridge-node/src/main.rs
+++ b/binaries/mavlink2-bridge-node/src/main.rs
@@ -41,6 +41,7 @@
 //! | `set_mode_cmd`                      | SET_MODE                         |
 //! | `rc_channels_override_cmd`          | RC_CHANNELS_OVERRIDE             |
 //! | `set_position_target_global_int_cmd`| SET_POSITION_TARGET_GLOBAL_INT   |
+//! | `set_position_target_local_ned_cmd` | SET_POSITION_TARGET_LOCAL_NED    |
 //!
 //! Other message types are read-only telemetry; sending them inbound is
 //! out of scope for this PR.
@@ -49,7 +50,7 @@ use dora_mavlink2_bridge::{
     MavlinkArrow,
     mavlink::common::{
         COMMAND_LONG_DATA, HEARTBEAT_DATA, RC_CHANNELS_OVERRIDE_DATA,
-        SET_MODE_DATA, SET_POSITION_TARGET_GLOBAL_INT_DATA,
+        SET_MODE_DATA, SET_POSITION_TARGET_GLOBAL_INT_DATA, SET_POSITION_TARGET_LOCAL_NED_DATA,
     },
     transport,
 };
@@ -198,6 +199,10 @@ fn handle_input(
         "set_position_target_global_int_cmd" => {
             let d: SET_POSITION_TARGET_GLOBAL_INT_DATA = decode_input(data, id.as_str())?;
             MavMessage::SET_POSITION_TARGET_GLOBAL_INT(d)
+        }
+        "set_position_target_local_ned_cmd" => {
+            let d: SET_POSITION_TARGET_LOCAL_NED_DATA = decode_input(data, id.as_str())?;
+            MavMessage::SET_POSITION_TARGET_LOCAL_NED(d)
         }
         _ => return Ok(()), // unknown input id, ignore
     };

--- a/binaries/mavlink2-bridge-node/src/main.rs
+++ b/binaries/mavlink2-bridge-node/src/main.rs
@@ -1,0 +1,178 @@
+//! MAVLink 2 ↔ dora bridge node.
+//!
+//! This binary is spawned by the dora daemon as a normal node. It opens
+//! a MAVLink 2 connection (TCP in this PR; UDP/serial in #1786 follow-up),
+//! decodes incoming frames into Arrow `StructArray` rows, and publishes
+//! them on dora outputs. Inputs are encoded back to MAVLink frames and
+//! sent on the same connection.
+//!
+//! Configuration comes from the `MAVLINK_BRIDGE_CONFIG` env var as YAML:
+//!
+//! ```yaml
+//! endpoint: tcp://127.0.0.1:5760
+//! system_id: 255
+//! component_id: 1
+//! ```
+
+use dora_mavlink2_bridge::{MavlinkArrow, mavlink::common::HEARTBEAT_DATA, transport};
+use dora_node_api::{
+    DoraNode, Event, MetadataParameters,
+    arrow::array::{ArrayRef, AsArray, RecordBatch, StructArray},
+    dora_core::config::DataId,
+    flume,
+};
+use eyre::{Context, Result, bail, eyre};
+use mavlink::{MavConnection, MavHeader, common::MavMessage};
+use serde::Deserialize;
+use std::{sync::Arc, time::Duration};
+use url::Url;
+
+const HEARTBEAT_OUTPUT: &str = "heartbeat";
+const HEARTBEAT_INPUT: &str = "heartbeat_cmd";
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+#[derive(Debug, Deserialize)]
+struct Config {
+    endpoint: String,
+    #[serde(default = "default_system_id")]
+    system_id: u8,
+    #[serde(default = "default_component_id")]
+    component_id: u8,
+}
+
+fn default_system_id() -> u8 {
+    255
+}
+
+fn default_component_id() -> u8 {
+    1
+}
+
+impl Config {
+    fn from_env() -> Result<Self> {
+        let yaml = std::env::var("MAVLINK_BRIDGE_CONFIG")
+            .context("MAVLINK_BRIDGE_CONFIG env var must be set")?;
+        let cfg: Self = serde_yaml::from_str(&yaml).context("parsing MAVLINK_BRIDGE_CONFIG")?;
+        Ok(cfg)
+    }
+
+    fn parsed_endpoint(&self) -> Result<Url> {
+        Url::parse(&self.endpoint)
+            .with_context(|| format!("parsing endpoint URL '{}'", self.endpoint))
+    }
+}
+
+/// Reader thread: blocks on `conn.recv()` and forwards converted Arrow
+/// arrays to the main thread via `tx`. Returns when `tx` is dropped
+/// (main thread exited) or the connection errors continuously.
+fn run_reader(
+    conn: Arc<dyn MavConnection<MavMessage> + Send + Sync>,
+    tx: flume::Sender<(DataId, ArrayRef)>,
+) -> Result<()> {
+    loop {
+        match conn.recv() {
+            Ok((_header, MavMessage::HEARTBEAT(d))) => {
+                let batch = d.to_record_batch()?;
+                let arr: ArrayRef = Arc::new(StructArray::from(batch));
+                if tx
+                    .send((DataId::from(HEARTBEAT_OUTPUT.to_string()), arr))
+                    .is_err()
+                {
+                    return Ok(()); // main thread gone
+                }
+            }
+            Ok(_) => {
+                // PR #3 only handles HEARTBEAT; other message types are
+                // ignored here and will be wired up by PR #5 (common
+                // dialect coverage). #1786.
+            }
+            Err(e) => {
+                tracing::warn!("mavlink recv error: {e}");
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        }
+    }
+}
+
+/// Decode one incoming dora `Event::Input` and forward it as a MAVLink
+/// frame on `conn`. Returns Ok even for unknown input ids — the bridge
+/// silently ignores them rather than failing the whole node.
+fn handle_input(
+    conn: &(dyn MavConnection<MavMessage> + Send + Sync),
+    header: &MavHeader,
+    id: &DataId,
+    data: &ArrayRef,
+) -> Result<()> {
+    if id.as_str() != HEARTBEAT_INPUT {
+        return Ok(()); // unknown input id, ignore
+    }
+    let struct_array = data.as_struct_opt().ok_or_else(|| {
+        eyre!(
+            "expected StructArray for input '{HEARTBEAT_INPUT}', got {:?}",
+            data.data_type()
+        )
+    })?;
+    let batch = RecordBatch::from(struct_array);
+    let cmd = HEARTBEAT_DATA::from_record_batch(&batch)
+        .context("decoding HEARTBEAT from incoming Arrow")?;
+    conn.send(header, &MavMessage::HEARTBEAT(cmd))
+        .map_err(|e| eyre!("mavlink send: {e}"))?;
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    tracing_subscriber::fmt::try_init().ok();
+
+    let cfg = Config::from_env()?;
+    let url = cfg.parsed_endpoint()?;
+    tracing::info!(endpoint = %url, "opening MAVLink 2 transport");
+
+    let conn_box = transport::connect(&url)?;
+    let conn: Arc<dyn MavConnection<MavMessage> + Send + Sync> = Arc::from(conn_box);
+
+    let header = MavHeader {
+        system_id: cfg.system_id,
+        component_id: cfg.component_id,
+        sequence: 0,
+    };
+
+    let (mut node, mut events) =
+        DoraNode::init_from_env().map_err(|e| eyre!("DoraNode init: {e}"))?;
+
+    let (tx, rx) = flume::bounded::<(DataId, ArrayRef)>(64);
+
+    let reader_handle = {
+        let conn = Arc::clone(&conn);
+        std::thread::Builder::new()
+            .name("mavlink-reader".into())
+            .spawn(move || run_reader(conn, tx))
+            .context("spawning mavlink reader thread")?
+    };
+
+    loop {
+        while let Ok((id, arr)) = rx.try_recv() {
+            node.send_output(id, MetadataParameters::default(), arr)
+                .map_err(|e| eyre!("send_output: {e}"))?;
+        }
+
+        match events.recv_timeout(POLL_INTERVAL) {
+            Some(Event::Input { id, data, .. }) => {
+                let array_ref: ArrayRef = data.into();
+                if let Err(e) = handle_input(conn.as_ref(), &header, &id, &array_ref) {
+                    tracing::warn!("writer error on input '{id}': {e:#}");
+                }
+            }
+            Some(Event::Stop(_)) => break,
+            Some(_) => {} // ignore other event variants
+            None => {}    // timeout, revisit rx
+        }
+    }
+
+    drop(node);
+    drop(events);
+    match reader_handle.join() {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(e)) => bail!("reader thread error: {e:#}"),
+        Err(panic) => bail!("reader thread panicked: {panic:?}"),
+    }
+}

--- a/binaries/mavlink2-bridge-node/tests/tcp_loopback.rs
+++ b/binaries/mavlink2-bridge-node/tests/tcp_loopback.rs
@@ -1,0 +1,82 @@
+//! TCP loopback round-trip: a server thread accepts a MAVLink 2 client
+//! connection (via mavlink's `tcpin:`) and sends a HEARTBEAT; the client
+//! is created through `dora_mavlink2_bridge::transport::connect` so this
+//! test exercises the public transport API rather than mavlink directly.
+//!
+//! No dora runtime is required — this asserts that the transport plumbs
+//! real bytes correctly. The full bridge-node-in-a-dataflow smoke test
+//! lives in PR #6 (#1786).
+
+use std::net::TcpListener;
+use std::time::Duration;
+
+use dora_mavlink2_bridge::{
+    mavlink::common::{HEARTBEAT_DATA, MavAutopilot, MavMessage, MavModeFlag, MavState, MavType},
+    transport,
+};
+use mavlink::{MavHeader, MavlinkVersion};
+use url::Url;
+
+/// Reserve a free port on 127.0.0.1 and immediately drop the listener so
+/// the mavlink server can rebind it. The race window is microseconds.
+fn pick_free_port() -> u16 {
+    let probe = TcpListener::bind("127.0.0.1:0").expect("bind probe");
+    let port = probe.local_addr().expect("local_addr").port();
+    drop(probe);
+    port
+}
+
+#[test]
+fn transport_connect_receives_heartbeat_over_tcp() -> Result<(), Box<dyn std::error::Error>> {
+    let port = pick_free_port();
+
+    let server = std::thread::Builder::new()
+        .name("mavlink-tcp-server".into())
+        .spawn(
+            move || -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+                // `tcpin:` binds + blocks in accept(); returns once the
+                // client connects, then we send one HEARTBEAT and exit.
+                let mut conn = mavlink::connect::<MavMessage>(&format!("tcpin:127.0.0.1:{port}"))?;
+                conn.set_protocol_version(MavlinkVersion::V2);
+
+                let header = MavHeader {
+                    system_id: 1,
+                    component_id: 1,
+                    sequence: 0,
+                };
+                let heartbeat = MavMessage::HEARTBEAT(HEARTBEAT_DATA {
+                    custom_mode: 7,
+                    mavtype: MavType::MAV_TYPE_QUADROTOR,
+                    autopilot: MavAutopilot::MAV_AUTOPILOT_GENERIC,
+                    base_mode: MavModeFlag::empty(),
+                    system_status: MavState::MAV_STATE_ACTIVE,
+                    mavlink_version: 3,
+                });
+                conn.send(&header, &heartbeat)?;
+                Ok(())
+            },
+        )?;
+
+    // Give the server a moment to enter accept().
+    std::thread::sleep(Duration::from_millis(150));
+
+    let url = Url::parse(&format!("tcp://127.0.0.1:{port}"))?;
+    let client = transport::connect(&url)?;
+    let (_header, msg) = client.recv()?;
+
+    match msg {
+        MavMessage::HEARTBEAT(d) => {
+            assert_eq!(d.custom_mode, 7);
+            assert_eq!(d.mavtype, MavType::MAV_TYPE_QUADROTOR);
+            assert_eq!(d.system_status, MavState::MAV_STATE_ACTIVE);
+            assert_eq!(d.mavlink_version, 3);
+        }
+        other => panic!("expected HEARTBEAT, got {other:?}"),
+    }
+
+    server
+        .join()
+        .expect("server thread panicked")
+        .map_err(|e| -> Box<dyn std::error::Error> { e.to_string().into() })?;
+    Ok(())
+}

--- a/binaries/mavlink2-bridge-node/tests/udp_loopback.rs
+++ b/binaries/mavlink2-bridge-node/tests/udp_loopback.rs
@@ -1,0 +1,89 @@
+//! UDP loopback round-trip: a listener thread opens `udp://...`
+//! through `transport::connect` (which maps to mavlink's `udpin:`),
+//! and the test main thread sends one HEARTBEAT via raw mavlink
+//! `udpout:`. Verifies the public transport API plumbs UDP correctly.
+//!
+//! The serial transport is symmetrical but cannot be exercised in
+//! the test process without `socat` or hardware — manual smoke is
+//! covered in the README and in PR #6.
+
+use std::net::UdpSocket;
+use std::time::Duration;
+
+use dora_mavlink2_bridge::{
+    mavlink::common::{HEARTBEAT_DATA, MavAutopilot, MavMessage, MavModeFlag, MavState, MavType},
+    transport,
+};
+use mavlink::{MavHeader, MavlinkVersion};
+use url::Url;
+
+/// Reserve a free UDP port and immediately drop the socket so the
+/// mavlink listener can rebind it. The race window is microseconds.
+fn pick_free_udp_port() -> u16 {
+    let probe = UdpSocket::bind("127.0.0.1:0").expect("bind probe");
+    let port = probe.local_addr().expect("local_addr").port();
+    drop(probe);
+    port
+}
+
+#[test]
+fn transport_connect_receives_heartbeat_over_udp() -> Result<(), Box<dyn std::error::Error>> {
+    let port = pick_free_udp_port();
+
+    // Listener: bridge-side, uses `transport::connect` so this exercises
+    // the public path the daemon-spawned bridge node would take.
+    let listener_url = Url::parse(&format!("udp://127.0.0.1:{port}"))?;
+    let listener = std::thread::Builder::new()
+        .name("mavlink-udp-listener".into())
+        .spawn(
+            move || -> Result<HEARTBEAT_DATA, Box<dyn std::error::Error + Send + Sync>> {
+                let conn = transport::connect(&listener_url).map_err(
+                    |e| -> Box<dyn std::error::Error + Send + Sync> { e.to_string().into() },
+                )?;
+                let (_header, msg) =
+                    conn.recv()
+                        .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {
+                            e.to_string().into()
+                        })?;
+                match msg {
+                    MavMessage::HEARTBEAT(d) => Ok(d),
+                    other => Err(format!("expected HEARTBEAT, got {other:?}").into()),
+                }
+            },
+        )?;
+
+    // Give the listener time to bind. UDP `udpin` blocks in `recv_from`
+    // immediately after bind, so 200ms is plenty.
+    std::thread::sleep(Duration::from_millis(200));
+
+    // Sender: test-side, raw mavlink udpout (the side a Pixhawk would
+    // typically be in if it were sending telemetry to a known host).
+    let mut sender = mavlink::connect::<MavMessage>(&format!("udpout:127.0.0.1:{port}"))?;
+    sender.set_protocol_version(MavlinkVersion::V2);
+
+    let header = MavHeader {
+        system_id: 1,
+        component_id: 1,
+        sequence: 0,
+    };
+    let heartbeat = MavMessage::HEARTBEAT(HEARTBEAT_DATA {
+        custom_mode: 99,
+        mavtype: MavType::MAV_TYPE_QUADROTOR,
+        autopilot: MavAutopilot::MAV_AUTOPILOT_GENERIC,
+        base_mode: MavModeFlag::empty(),
+        system_status: MavState::MAV_STATE_ACTIVE,
+        mavlink_version: 3,
+    });
+    sender.send(&header, &heartbeat)?;
+
+    let received = listener
+        .join()
+        .expect("listener thread panicked")
+        .map_err(|e| -> Box<dyn std::error::Error> { e.to_string().into() })?;
+
+    assert_eq!(received.custom_mode, 99);
+    assert_eq!(received.mavtype, MavType::MAV_TYPE_QUADROTOR);
+    assert_eq!(received.system_status, MavState::MAV_STATE_ACTIVE);
+    assert_eq!(received.mavlink_version, 3);
+    Ok(())
+}

--- a/examples/mavlink2-bridge-sitl-mission/README.md
+++ b/examples/mavlink2-bridge-sitl-mission/README.md
@@ -1,0 +1,146 @@
+# MAVLink 2 bridge — SITL closed-loop mission
+
+A dora dataflow that drives [ArduPilot Copter SITL](https://ardupilot.org/dev/docs/sitl-simulator-software-in-the-loop.html)
+through a full takeoff → hover → land → disarm cycle, entirely from a
+**Python dora node** talking MAVLink through the bridge. Demonstrates
+the dora ↔ MAVLink loop with real autopilot physics.
+
+```
+        ┌────────────────────────────────────────┐
+        │  ArduCopter SITL (separate process)    │
+        │  udp:14550                             │
+        └─────────────────▲──────────────────────┘
+                          │ MAVLink 2
+                ┌─────────┴──────────┐
+                │ dora-mavlink2-     │
+                │ bridge-node        │
+                └─┬────────▲─────────┘
+       Arrow:     │        │   Arrow:
+   command_long_  │        │   heartbeat /
+   cmd            │        │   command_ack /
+                  ▼        │   global_position_int
+                ┌──────────┴─────┐
+                │  mission.py    │   (Python state machine)
+                └────────────────┘
+```
+
+> [!IMPORTANT]
+> This example is **local-only**. SITL is heavy, requires a one-time
+> install, and is intentionally not part of the smoke suite or CI.
+> Develops verify the bridge against real autopilot semantics by
+> running the demo manually before pushing changes that touch
+> command-side code.
+
+## Platform support
+
+| Platform | Status | Notes |
+|----------|--------|-------|
+| Ubuntu 22.04 / 24.04 | First-class | Upstream ArduPilot dev target |
+| macOS (ARM64 / Intel) | Supported | Needs `brew install cmake gawk`; SITL ~10–15% slower than Linux |
+| Windows | **Not supported** | ArduPilot SITL on Windows requires WSL; the bridge + dataflow themselves work, but `scripts/start_sitl.sh` does not |
+
+## One-time setup
+
+### Ubuntu
+
+```bash
+git clone --recursive https://github.com/ArduPilot/ardupilot.git ~/src/ardupilot
+cd ~/src/ardupilot
+Tools/environment_install/install-prereqs-ubuntu.sh -y
+./waf configure --board sitl
+./waf copter
+```
+
+### macOS
+
+```bash
+brew install cmake gawk pkg-config
+git clone --recursive https://github.com/ArduPilot/ardupilot.git ~/src/ardupilot
+cd ~/src/ardupilot
+Tools/environment_install/install-prereqs-mac.sh -y
+./waf configure --board sitl
+./waf copter
+```
+
+The build takes 5–10 minutes the first time; subsequent rebuilds are
+incremental.
+
+## Run the demo
+
+Two terminals:
+
+**Terminal 1 — boot SITL:**
+
+```bash
+ARDUPILOT_SRC=~/src/ardupilot \
+  ./examples/mavlink2-bridge-sitl-mission/scripts/start_sitl.sh
+```
+
+Wait until SITL prints `APM: EKF3 IMU0 is using GPS` (~10 s). It is
+now broadcasting MAVLink on `udp:127.0.0.1:14550`.
+
+**Terminal 2 — run the dora dataflow:**
+
+```bash
+dora run examples/mavlink2-bridge-sitl-mission/dataflow.yml --uv --stop-after 90s
+```
+
+`--uv` provisions a venv with `pyarrow` + `dora-rs` for the Python
+mission node.
+
+## What success looks like
+
+```
+mission: vehicle heartbeat received
+mission: -> SET_MODE GUIDED (cmd=176)
+mission: <- ACK SET_MODE GUIDED [ACCEPTED, 0.1s]
+mission: -> ARM (cmd=400)
+mission: <- ACK ARM [ACCEPTED, 0.1s]
+mission: -> TAKEOFF (cmd=22)
+mission: <- ACK TAKEOFF [ACCEPTED, 0.1s]
+mission: reached 8.51 m (target 8.50)
+mission: hovering for 5.0s
+mission: -> LAND (cmd=21)
+mission: <- ACK LAND [ACCEPTED, 0.0s]
+mission: landed at 0.04 m
+mission: -> DISARM (cmd=400)
+mission: <- ACK DISARM [ACCEPTED, 0.1s]
+mission: SUCCESS - takeoff + hover + land + disarm complete
+```
+
+The final `mission: SUCCESS` line is the canonical pass marker — pipe
+to `grep` if you want to script success/failure detection.
+
+## Tunables (env vars)
+
+| Variable | Default | What it controls |
+|----------|---------|------------------|
+| `MAVLINK_SITL_TARGET_SYSTEM` | `1` | MAVLink system_id of the autopilot |
+| `MAVLINK_SITL_TARGET_COMPONENT` | `1` | MAVLink component_id of the autopilot |
+| `MAVLINK_SITL_TAKEOFF_ALT_M` | `10.0` | Target altitude after takeoff (m) |
+| `MAVLINK_SITL_HOVER_SECS` | `5.0` | How long to hover before landing |
+| `MAVLINK_SITL_COMMAND_TIMEOUT` | `15.0` | Per-command ACK timeout (s) |
+| `MAVLINK_SITL_ALT_TIMEOUT` | `30.0` | Takeoff/land altitude-progress timeout (s) |
+| `MAVLINK_SITL_HOME` | `37.7749,-122.4194,0,0` | Home `lat,lon,alt,yaw` for SITL |
+
+## Failure modes
+
+| Symptom | Likely cause |
+|---------|--------------|
+| `no HEARTBEAT within 15s` | SITL not running, or it's forwarding on a port other than 14550 |
+| `ARM: ACK = TEMPORARILY_REJECTED` | EKF not yet healthy. Wait longer after boot before launching the dataflow, or raise `MAVLINK_SITL_COMMAND_TIMEOUT`. |
+| `altitude did not reach … within 30s` | SITL physics paused (Ctrl-Z?), or the autopilot rejected GUIDED mode silently |
+| `ACK = DENIED` on `SET_MODE GUIDED` | Vehicle isn't ArduCopter (or copter version is too old for `MAV_CMD_DO_SET_MODE`) |
+
+## Extending it
+
+`mission.py` is a state machine — add new states between TAKEOFF and
+LAND for waypoints, payload triggers, sensor sweeps, etc. The
+encoding helper `_make_command_long` matches the bridge's COMMAND_LONG
+schema; new MAVLink commands need only their `MAV_CMD_*` integer and
+the right `param1..param7` semantics from the
+[MAV_CMD docs](https://mavlink.io/en/messages/common.html#mav_commands).
+
+For higher-rate or non-COMMAND_LONG control (e.g.
+`SET_POSITION_TARGET_LOCAL_NED`), the bridge crate would need a new
+message added to `arrow_convert.rs` first; that's tracked separately.

--- a/examples/mavlink2-bridge-sitl-mission/README.md
+++ b/examples/mavlink2-bridge-sitl-mission/README.md
@@ -131,6 +131,42 @@ to `grep` if you want to script success/failure detection.
 | `ARM: ACK = TEMPORARILY_REJECTED` | EKF not yet healthy. Wait longer after boot before launching the dataflow, or raise `MAVLINK_SITL_COMMAND_TIMEOUT`. |
 | `altitude did not reach … within 30s` | SITL physics paused (Ctrl-Z?), or the autopilot rejected GUIDED mode silently |
 | `ACK = DENIED` on `SET_MODE GUIDED` | Vehicle isn't ArduCopter (or copter version is too old for `MAV_CMD_DO_SET_MODE`) |
+| `writer error on input 'set_mode_cmd': … SET_MODE base_mode=1 … not representable as mavlink-rust 0.13's strict MavMode enum …` | mavlink-rust 0.13 limitation. See "Known limitations" below. |
+
+## Known limitations
+
+### `set_mode_cmd` cannot drive ArduPilot custom modes (mavlink-rust 0.13)
+
+The MAVLink spec defines `SET_MODE.base_mode` as a `uint8_t` bitfield, but
+mavlink-rust 0.13 generates `MavMode` as a strict Rust enum with only
+11 named variants `{0, 64, 66, 80, 88, 92, 192, 194, 208, 216, 220}`.
+None has bit `0x01` (`MAV_MODE_FLAG_CUSTOM_MODE_ENABLED`) set, which is
+exactly the bit ArduPilot uses for **every** custom-mode entry
+(GUIDED = `base_mode=0x01, custom_mode=4`, AUTO = `base_mode=0x01,
+custom_mode=3`, …). PX4 also relies on the `0x01` path for any
+non-bootstrap mode.
+
+Effect on this example:
+
+* The `set_mode_cmd` input on the bridge will return an error
+  ("`SET_MODE base_mode=1 … not representable as MavMode enum`") and
+  the message is dropped before reaching the autopilot. The error is
+  logged at `error` level so it shows up in default log filters.
+* For ArduCopter `>= 3.6` and recent PX4, use `MAV_CMD_DO_SET_MODE`
+  through the existing `command_long_cmd` input instead. That's what
+  `mission.py` does (`MAV_CMD_DO_SET_MODE = 176`, `p1=1.0`,
+  `p2=ARDUCOPTER_GUIDED_CUSTOM_MODE`).
+* For older firmware that only accepts the legacy `SET_MODE` message
+  (e.g. ArduCopter `3.3` in dronekit-sitl), the workaround is to open a
+  side-channel `pymavlink` connection and send `SET_MODE` through that
+  — see `mission_long.py` and `mission_rover.py` for the pattern.
+  Remove the side-channel once mavlink-rust accepts `base_mode` as raw
+  `uint8`.
+
+Tracked upstream at <https://github.com/mavlink/rust-mavlink>. Once
+that lands and crates.io updates, bump the workspace `mavlink`
+dependency, drop the side-channel from the missions, and this section
+goes away.
 
 ## Extending it
 

--- a/examples/mavlink2-bridge-sitl-mission/dataflow.yml
+++ b/examples/mavlink2-bridge-sitl-mission/dataflow.yml
@@ -1,0 +1,39 @@
+nodes:
+  # MAVLink bridge talking to ArduPilot SITL on udp:14550.
+  # SITL is *not* spawned by dora -- start it separately via
+  # scripts/start_sitl.sh before running this dataflow.
+  - id: bridge
+    build: cargo build -p dora-mavlink2-bridge-node
+    path: ../../target/debug/dora-mavlink2-bridge-node
+    env:
+      MAVLINK_BRIDGE_CONFIG: |
+        endpoint: udp://127.0.0.1:14550
+    inputs:
+      command_long_cmd: mission/command_long_cmd
+    outputs:
+      - heartbeat
+      - global_position_int
+      - command_ack
+      # The bridge publishes more outputs (sys_status, attitude, gps,
+      # etc.); declared here only so the schema validates -- mission.py
+      # does not subscribe to them.
+      - sys_status
+      - system_time
+      - attitude
+      - attitude_quaternion
+      - local_position_ned
+      - gps_raw_int
+      - rc_channels
+      - servo_output_raw
+      - command_long
+      - mission_current
+
+  # Closed-loop mission driver: arms, takes off, hovers, lands.
+  - id: mission
+    path: mission.py
+    inputs:
+      heartbeat: bridge/heartbeat
+      global_position_int: bridge/global_position_int
+      command_ack: bridge/command_ack
+    outputs:
+      - command_long_cmd

--- a/examples/mavlink2-bridge-sitl-mission/dataflow_long.yml
+++ b/examples/mavlink2-bridge-sitl-mission/dataflow_long.yml
@@ -1,0 +1,44 @@
+nodes:
+  # Topology:
+  #   dronekit-sitl ──tcp 5760──► dora bridge (here, ?proto=v1)
+  #   dronekit-sitl ──tcp 5762──► forward_to_qgc.py ──udp 14550──► QGC
+  # Bridge owns 5760 directly. forward_to_qgc.py ships frames from the
+  # parallel UART (5762) to QGC's UDP port. start_mavlink_long.sh wires
+  # both before `dora run`.
+  - id: bridge
+    path: /home/demo/work/dora-mavlink/target/release/dora-mavlink2-bridge-node
+    env:
+      # Bridge connects directly to dronekit-sitl as a TCP client. SITL
+      # ships ArduCopter 3.3 which speaks MAVLink V1, so we override the
+      # bridge's default V2 wire-format with ?proto=v1 to keep mavlink-rust's
+      # version-filtered recv() from silently dropping every frame.
+      MAVLINK_BRIDGE_CONFIG: |
+        endpoint: tcp://127.0.0.1:5760?proto=v1
+    inputs:
+      command_long_cmd: mission/command_long_cmd
+      set_mode_cmd: mission/set_mode_cmd
+    outputs:
+      - heartbeat
+      - global_position_int
+      - command_ack
+      - sys_status
+      - system_time
+      - attitude
+      - attitude_quaternion
+      - local_position_ned
+      - gps_raw_int
+      - rc_channels
+      - servo_output_raw
+      - command_long
+      - mission_current
+
+  # Long-and-obvious closed-loop mission (square + climb + 30s hover + LAND).
+  - id: mission
+    path: mission_long.py
+    inputs:
+      heartbeat: bridge/heartbeat
+      global_position_int: bridge/global_position_int
+      command_ack: bridge/command_ack
+    outputs:
+      - command_long_cmd
+      - set_mode_cmd

--- a/examples/mavlink2-bridge-sitl-mission/dataflow_rover.yml
+++ b/examples/mavlink2-bridge-sitl-mission/dataflow_rover.yml
@@ -1,0 +1,41 @@
+nodes:
+  # Bridge connects to dronekit-sitl rover-2.50 over TCP 5760 (autopilot
+  # UART0). Rover-2.50 speaks MAVLink V1, so ?proto=v1 is required. The
+  # bridge auto-issues REQUEST_DATA_STREAM(MAV_DATA_STREAM_ALL) so
+  # GLOBAL_POSITION_INT, HEARTBEAT, COMMAND_ACK flow without a GCS asking.
+  - id: bridge
+    path: /home/demo/work/dora-mavlink/target/release/dora-mavlink2-bridge-node
+    env:
+      MAVLINK_BRIDGE_CONFIG: |
+        endpoint: tcp://127.0.0.1:5760?proto=v1
+    inputs:
+      command_long_cmd: mission/command_long_cmd
+      set_mode_cmd: mission/set_mode_cmd
+      rc_channels_override_cmd: mission/rc_channels_override_cmd
+    outputs:
+      - heartbeat
+      - global_position_int
+      - command_ack
+      - sys_status
+      - system_time
+      - attitude
+      - attitude_quaternion
+      - local_position_ned
+      - gps_raw_int
+      - rc_channels
+      - servo_output_raw
+      - command_long
+      - mission_current
+
+  # Rover mission: drives a square clockwise via RC override, telemetry
+  # via the bridge.
+  - id: mission
+    path: mission_rover.py
+    inputs:
+      heartbeat: bridge/heartbeat
+      global_position_int: bridge/global_position_int
+      command_ack: bridge/command_ack
+    outputs:
+      - command_long_cmd
+      - set_mode_cmd
+      - rc_channels_override_cmd

--- a/examples/mavlink2-bridge-sitl-mission/mission.py
+++ b/examples/mavlink2-bridge-sitl-mission/mission.py
@@ -1,0 +1,280 @@
+"""Closed-loop SITL mission driven from a dora node.
+
+State machine:
+
+    WAIT_HEARTBEAT -> SET_GUIDED -> ARM -> TAKEOFF -> HOVER ->
+    LAND -> DISARM -> DONE
+
+Each command-issuing state sends a single COMMAND_LONG to the bridge
+on output ``command_long_cmd`` and waits for a matching COMMAND_ACK
+on input ``command_ack``. Position-progress states (TAKEOFF, LAND)
+also watch ``global_position_int`` for relative_alt to cross a
+threshold. Per-state timeouts bound the worst case so a hung step
+fails loudly instead of running forever.
+
+This example is local-only. It does not run in CI -- ArduPilot SITL
+needs to be installed and started manually before the dataflow boots
+(see ``scripts/start_sitl.sh``).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+
+import pyarrow as pa
+from dora import Node
+
+# MAV_CMD enum values (mavlink common dialect).
+MAV_CMD_NAV_TAKEOFF = 22
+MAV_CMD_NAV_LAND = 21
+MAV_CMD_DO_SET_MODE = 176
+MAV_CMD_COMPONENT_ARM_DISARM = 400
+
+# MAV_RESULT enum values.
+MAV_RESULT_ACCEPTED = 0
+MAV_RESULT_NAMES = {
+    0: "ACCEPTED",
+    1: "TEMPORARILY_REJECTED",
+    2: "DENIED",
+    3: "UNSUPPORTED",
+    4: "FAILED",
+    5: "IN_PROGRESS",
+    6: "CANCELLED",
+}
+
+# MAV_MODE_FLAG_CUSTOM_MODE_ENABLED = 1; ArduCopter custom_mode for GUIDED is 4.
+ARDUCOPTER_GUIDED_CUSTOM_MODE = 4
+MODE_FLAG_CUSTOM_ENABLED = 1.0
+
+# Tunables.
+TARGET_SYSTEM = int(os.environ.get("MAVLINK_SITL_TARGET_SYSTEM", "1"))
+TARGET_COMPONENT = int(os.environ.get("MAVLINK_SITL_TARGET_COMPONENT", "1"))
+TAKEOFF_ALT_M = float(os.environ.get("MAVLINK_SITL_TAKEOFF_ALT_M", "10.0"))
+HOVER_SECS = float(os.environ.get("MAVLINK_SITL_HOVER_SECS", "5.0"))
+COMMAND_TIMEOUT_SECS = float(os.environ.get("MAVLINK_SITL_COMMAND_TIMEOUT", "15.0"))
+ALT_TIMEOUT_SECS = float(os.environ.get("MAVLINK_SITL_ALT_TIMEOUT", "30.0"))
+ALT_REACHED_M = 0.85 * TAKEOFF_ALT_M  # accept if within 15% of target
+LAND_DETECT_M = 0.5  # consider landed when relative_alt < 0.5 m
+
+
+@dataclass
+class Pending:
+    """A command we sent and are waiting on an ACK for."""
+
+    command: int
+    description: str
+    sent_at: float
+
+
+def _make_command_long(
+    command: int,
+    p1: float = 0.0,
+    p2: float = 0.0,
+    p3: float = 0.0,
+    p4: float = 0.0,
+    p5: float = 0.0,
+    p6: float = 0.0,
+    p7: float = 0.0,
+) -> pa.StructArray:
+    """Build a 1-row StructArray matching the bridge's COMMAND_LONG schema.
+
+    Field names + types must match
+    ``libraries/extensions/mavlink2-bridge/src/arrow_convert.rs``:
+    params are float32, command is uint32, target_* and confirmation
+    are uint8.
+    """
+    return pa.StructArray.from_arrays(
+        [
+            pa.array([p1], type=pa.float32()),
+            pa.array([p2], type=pa.float32()),
+            pa.array([p3], type=pa.float32()),
+            pa.array([p4], type=pa.float32()),
+            pa.array([p5], type=pa.float32()),
+            pa.array([p6], type=pa.float32()),
+            pa.array([p7], type=pa.float32()),
+            pa.array([command], type=pa.uint32()),
+            pa.array([TARGET_SYSTEM], type=pa.uint8()),
+            pa.array([TARGET_COMPONENT], type=pa.uint8()),
+            pa.array([0], type=pa.uint8()),  # confirmation
+        ],
+        names=[
+            "param1",
+            "param2",
+            "param3",
+            "param4",
+            "param5",
+            "param6",
+            "param7",
+            "command",
+            "target_system",
+            "target_component",
+            "confirmation",
+        ],
+    )
+
+
+def _first_row(struct_array: pa.StructArray) -> dict:
+    rows = struct_array.to_pylist()
+    return rows[0] if rows else {}
+
+
+def _relative_alt_m(global_position_int: pa.StructArray) -> float | None:
+    row = _first_row(global_position_int)
+    relative_alt_mm = row.get("relative_alt")
+    if relative_alt_mm is None:
+        return None
+    return relative_alt_mm / 1000.0
+
+
+class Mission:
+    def __init__(self, node: Node) -> None:
+        self.node = node
+        self.pending: Pending | None = None
+        self.last_relative_alt_m: float | None = None
+
+    # ---- low-level helpers -------------------------------------------------
+
+    def _send(self, description: str, command: int, **params: float) -> None:
+        cmd = _make_command_long(command, **params)
+        self.node.send_output("command_long_cmd", cmd)
+        self.pending = Pending(command=command, description=description, sent_at=time.monotonic())
+        logging.info("mission: -> %s (cmd=%d)", description, command)
+
+    def _await_ack(self, timeout: float) -> None:
+        """Block until COMMAND_ACK for self.pending arrives, or fail."""
+        assert self.pending is not None
+        deadline = time.monotonic() + timeout
+        for event in self.node:
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"no ACK for {self.pending.description} within {timeout:.0f}s"
+                )
+            if event["type"] != "INPUT":
+                if event["type"] == "STOP":
+                    raise RuntimeError("STOP received mid-mission")
+                continue
+            input_id = event["id"]
+            if input_id == "global_position_int":
+                self.last_relative_alt_m = _relative_alt_m(event["value"])
+                continue
+            if input_id == "command_ack":
+                row = _first_row(event["value"])
+                if row.get("command") != self.pending.command:
+                    logging.debug("mission: ignoring ACK for cmd=%s", row.get("command"))
+                    continue
+                result = row.get("result", -1)
+                name = MAV_RESULT_NAMES.get(result, f"UNKNOWN({result})")
+                if result != MAV_RESULT_ACCEPTED:
+                    raise RuntimeError(
+                        f"{self.pending.description}: ACK = {name} (result={result})"
+                    )
+                logging.info(
+                    "mission: <- ACK %s [%s, %.1fs]",
+                    self.pending.description,
+                    name,
+                    time.monotonic() - self.pending.sent_at,
+                )
+                self.pending = None
+                return
+        raise RuntimeError(f"event stream ended before ACK for {self.pending.description}")
+
+    def _await_alt_at_least(self, target_m: float, timeout: float) -> None:
+        deadline = time.monotonic() + timeout
+        for event in self.node:
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"altitude did not reach {target_m:.1f} m within {timeout:.0f}s "
+                    f"(last relative_alt={self.last_relative_alt_m})"
+                )
+            if event["type"] == "STOP":
+                raise RuntimeError("STOP received mid-mission")
+            if event["type"] != "INPUT" or event["id"] != "global_position_int":
+                continue
+            alt = _relative_alt_m(event["value"])
+            if alt is None:
+                continue
+            self.last_relative_alt_m = alt
+            if alt >= target_m:
+                logging.info("mission: reached %.2f m (target %.2f)", alt, target_m)
+                return
+
+    def _await_alt_below(self, target_m: float, timeout: float) -> None:
+        deadline = time.monotonic() + timeout
+        for event in self.node:
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"altitude did not drop below {target_m:.1f} m within {timeout:.0f}s "
+                    f"(last relative_alt={self.last_relative_alt_m})"
+                )
+            if event["type"] == "STOP":
+                raise RuntimeError("STOP received mid-mission")
+            if event["type"] != "INPUT" or event["id"] != "global_position_int":
+                continue
+            alt = _relative_alt_m(event["value"])
+            if alt is None:
+                continue
+            self.last_relative_alt_m = alt
+            if alt <= target_m:
+                logging.info("mission: landed at %.2f m", alt)
+                return
+
+    def _wait_for_first_heartbeat(self, timeout: float) -> None:
+        deadline = time.monotonic() + timeout
+        for event in self.node:
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"no HEARTBEAT within {timeout:.0f}s -- is SITL running?")
+            if event["type"] == "STOP":
+                raise RuntimeError("STOP received before mission start")
+            if event["type"] == "INPUT" and event["id"] == "heartbeat":
+                logging.info("mission: vehicle heartbeat received")
+                return
+
+    # ---- mission steps -----------------------------------------------------
+
+    def run(self) -> None:
+        self._wait_for_first_heartbeat(timeout=COMMAND_TIMEOUT_SECS)
+
+        self._send(
+            "SET_MODE GUIDED",
+            MAV_CMD_DO_SET_MODE,
+            p1=MODE_FLAG_CUSTOM_ENABLED,
+            p2=float(ARDUCOPTER_GUIDED_CUSTOM_MODE),
+        )
+        self._await_ack(COMMAND_TIMEOUT_SECS)
+
+        self._send("ARM", MAV_CMD_COMPONENT_ARM_DISARM, p1=1.0)
+        self._await_ack(COMMAND_TIMEOUT_SECS)
+
+        self._send("TAKEOFF", MAV_CMD_NAV_TAKEOFF, p7=TAKEOFF_ALT_M)
+        self._await_ack(COMMAND_TIMEOUT_SECS)
+        self._await_alt_at_least(ALT_REACHED_M, timeout=ALT_TIMEOUT_SECS)
+
+        logging.info("mission: hovering for %.1fs", HOVER_SECS)
+        time.sleep(HOVER_SECS)
+
+        self._send("LAND", MAV_CMD_NAV_LAND)
+        self._await_ack(COMMAND_TIMEOUT_SECS)
+        self._await_alt_below(LAND_DETECT_M, timeout=ALT_TIMEOUT_SECS)
+
+        self._send("DISARM", MAV_CMD_COMPONENT_ARM_DISARM, p1=0.0)
+        self._await_ack(COMMAND_TIMEOUT_SECS)
+
+        # Marker for smoke / log-grep tests.
+        print("mission: SUCCESS - takeoff + hover + land + disarm complete")
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    node = Node()
+    try:
+        Mission(node).run()
+    except (TimeoutError, RuntimeError) as e:
+        logging.error("mission: FAILED - %s", e)
+        raise SystemExit(1) from e
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/mavlink2-bridge-sitl-mission/mission_long.py
+++ b/examples/mavlink2-bridge-sitl-mission/mission_long.py
@@ -1,0 +1,542 @@
+"""Long-and-obvious closed-loop SITL mission for QGC visualization.
+
+Extends the original `mission.py` (takeoff → hover → land) with:
+
+  WAIT_HEARTBEAT → SET_GUIDED → ARM →
+  TAKEOFF (30m) → REPOSITION square (4 waypoints, 100m sides) →
+  CLIMB to 50m → HOVER 30s → LAND → DISARM → DONE
+
+Total flight time ~3 minutes, traces a visible square on the QGC map,
+then climbs and slowly descends. Designed to be obvious to a human
+watching QGC; no human input required.
+
+Falls back gracefully on old firmware: if DO_REPOSITION returns
+TEMPORARILY_REJECTED / UNSUPPORTED / DENIED, the waypoint phase is
+skipped and the mission continues with extended hover + tall LAND.
+
+Tunables (env vars; defaults chosen for "obvious in QGC"):
+
+  MAVLINK_SITL_TAKEOFF_ALT_M     30.0  initial cruise altitude (m)
+  MAVLINK_SITL_HIGH_ALT_M        50.0  climb altitude after square (m)
+  MAVLINK_SITL_HOVER_SECS        30.0  hover hold before LAND (s)
+  MAVLINK_SITL_HOME_LAT          home lat (deg, signed)
+  MAVLINK_SITL_HOME_LON          home lon (deg, signed)
+  MAVLINK_SITL_LEG_M             100.0 length of each square side (m)
+  MAVLINK_SITL_GROUND_SPEED      5.0   m/s for DO_REPOSITION
+  MAVLINK_SITL_SKIP_REPOSITION   0     "1" disables the square (climb only)
+
+Default home matches dronekit-sitl's built-in CMAC location
+(-35.363261, 149.165230) so the waypoints are correct out of the box
+without --home overrides.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+import time
+from dataclasses import dataclass
+
+import pyarrow as pa
+from dora import Node
+
+try:
+    from pymavlink import mavutil  # type: ignore[import-not-found]
+except Exception:  # pragma: no cover
+    mavutil = None  # type: ignore[assignment]
+
+
+_SIDE_PYMAVLINK = None
+
+
+def _ensure_side_pymavlink():
+    """Lazy-open a TCP-5763 pymavlink connection.
+
+    Used for SET_MODE (because mavlink-rust 0.13's strict MavMode enum
+    refuses base_mode=1) AND for REQUEST_DATA_STREAM (because the bridge
+    doesn't auto-request streams, and ArduCopter 3.3 only emits HEARTBEAT
+    by default — without this, GLOBAL_POSITION_INT never arrives and the
+    mission times out waiting for altitude). Connection is reused."""
+    global _SIDE_PYMAVLINK
+    if _SIDE_PYMAVLINK is not None:
+        return _SIDE_PYMAVLINK
+    if mavutil is None:
+        raise RuntimeError(
+            "pymavlink is not installed; install with `pip install --user pymavlink`"
+        )
+    side_url = os.environ.get("MAVLINK_SITL_SIDECHAN", "tcp:127.0.0.1:5763")
+    logging.info("mission: opening side-channel %s", side_url)
+    side = mavutil.mavlink_connection(side_url, source_system=255, source_component=190)
+    side.wait_heartbeat(timeout=10)
+    # Request all data streams at 5 Hz so the bridge sees GLOBAL_POSITION_INT,
+    # COMMAND_ACK, SYS_STATUS, etc. flow continuously.
+    side.mav.request_data_stream_send(
+        side.target_system, side.target_component,
+        0,    # MAV_DATA_STREAM_ALL
+        5,    # rate Hz
+        1,    # start
+    )
+    logging.info("mission: requested data streams at 5Hz from side-channel")
+    _SIDE_PYMAVLINK = side
+    return side
+
+# MAV_CMD enum values.
+MAV_CMD_NAV_TAKEOFF = 22
+MAV_CMD_NAV_LAND = 21
+MAV_CMD_DO_SET_MODE = 176
+MAV_CMD_COMPONENT_ARM_DISARM = 400
+MAV_CMD_DO_REPOSITION = 192
+
+# MAV_RESULT enum values.
+MAV_RESULT_ACCEPTED = 0
+MAV_RESULT_NAMES = {
+    0: "ACCEPTED",
+    1: "TEMPORARILY_REJECTED",
+    2: "DENIED",
+    3: "UNSUPPORTED",
+    4: "FAILED",
+    5: "IN_PROGRESS",
+    6: "CANCELLED",
+}
+MAV_RESULT_SOFT_FAIL = {1, 2, 3, 4}  # treat as "skip leg, keep flying"
+
+ARDUCOPTER_GUIDED_CUSTOM_MODE = 4
+MODE_FLAG_CUSTOM_ENABLED = 1.0
+# When True, send the legacy MAVLink SET_MODE message (msg id 11) instead
+# of MAV_CMD_DO_SET_MODE (cmd 176). Required for ArduCopter <= 3.5
+# (dronekit-sitl ships 3.3) which returns ACK=UNSUPPORTED for cmd 176.
+USE_LEGACY_SET_MODE = os.environ.get("MAVLINK_SITL_LEGACY_SET_MODE", "1") == "1"
+
+# Tunables.
+TARGET_SYSTEM = int(os.environ.get("MAVLINK_SITL_TARGET_SYSTEM", "1"))
+TARGET_COMPONENT = int(os.environ.get("MAVLINK_SITL_TARGET_COMPONENT", "1"))
+TAKEOFF_ALT_M = float(os.environ.get("MAVLINK_SITL_TAKEOFF_ALT_M", "30.0"))
+HIGH_ALT_M = float(os.environ.get("MAVLINK_SITL_HIGH_ALT_M", "50.0"))
+HOVER_SECS = float(os.environ.get("MAVLINK_SITL_HOVER_SECS", "30.0"))
+COMMAND_TIMEOUT_SECS = float(os.environ.get("MAVLINK_SITL_COMMAND_TIMEOUT", "15.0"))
+ALT_TIMEOUT_SECS = float(os.environ.get("MAVLINK_SITL_ALT_TIMEOUT", "60.0"))
+WARMUP_SECS = float(os.environ.get("MAVLINK_SITL_WARMUP_SECS", "0.0"))
+FORCE_ARM = os.environ.get("MAVLINK_SITL_FORCE_ARM", "0") == "1"
+SKIP_REPOSITION = os.environ.get("MAVLINK_SITL_SKIP_REPOSITION", "0") == "1"
+WAYPOINT_TIMEOUT_SECS = float(os.environ.get("MAVLINK_SITL_WAYPOINT_TIMEOUT", "45.0"))
+
+HOME_LAT = float(os.environ.get("MAVLINK_SITL_HOME_LAT", "-35.363261"))
+HOME_LON = float(os.environ.get("MAVLINK_SITL_HOME_LON", "149.165230"))
+LEG_M = float(os.environ.get("MAVLINK_SITL_LEG_M", "100.0"))
+GROUND_SPEED = float(os.environ.get("MAVLINK_SITL_GROUND_SPEED", "5.0"))
+
+ALT_REACHED_FRACTION = 0.85
+LAND_DETECT_M = 0.5
+
+# 1 deg latitude ~= 111 320 m at the equator; small variation with latitude
+# is negligible at the precision we need.
+METERS_PER_DEG_LAT = 111_320.0
+
+
+def _meters_per_deg_lon(lat_deg: float) -> float:
+    return METERS_PER_DEG_LAT * math.cos(math.radians(lat_deg))
+
+
+def _offset_latlon(lat: float, lon: float, north_m: float, east_m: float) -> tuple[float, float]:
+    new_lat = lat + north_m / METERS_PER_DEG_LAT
+    new_lon = lon + east_m / _meters_per_deg_lon(lat)
+    return new_lat, new_lon
+
+
+@dataclass
+class Pending:
+    command: int
+    description: str
+    sent_at: float
+
+
+def _make_command_long(
+    command: int,
+    p1: float = 0.0,
+    p2: float = 0.0,
+    p3: float = 0.0,
+    p4: float = 0.0,
+    p5: float = 0.0,
+    p6: float = 0.0,
+    p7: float = 0.0,
+) -> pa.StructArray:
+    return pa.StructArray.from_arrays(
+        [
+            pa.array([p1], type=pa.float32()),
+            pa.array([p2], type=pa.float32()),
+            pa.array([p3], type=pa.float32()),
+            pa.array([p4], type=pa.float32()),
+            pa.array([p5], type=pa.float32()),
+            pa.array([p6], type=pa.float32()),
+            pa.array([p7], type=pa.float32()),
+            pa.array([command], type=pa.uint32()),
+            pa.array([TARGET_SYSTEM], type=pa.uint8()),
+            pa.array([TARGET_COMPONENT], type=pa.uint8()),
+            pa.array([0], type=pa.uint8()),
+        ],
+        names=[
+            "param1", "param2", "param3", "param4",
+            "param5", "param6", "param7",
+            "command", "target_system", "target_component", "confirmation",
+        ],
+    )
+
+
+def _first_row(struct_array: pa.StructArray) -> dict:
+    rows = struct_array.to_pylist()
+    return rows[0] if rows else {}
+
+
+def _relative_alt_m(global_position_int: pa.StructArray) -> float | None:
+    row = _first_row(global_position_int)
+    relative_alt_mm = row.get("relative_alt")
+    if relative_alt_mm is None:
+        return None
+    return relative_alt_mm / 1000.0
+
+
+def _global_latlon(global_position_int: pa.StructArray) -> tuple[float, float] | None:
+    row = _first_row(global_position_int)
+    lat = row.get("lat")
+    lon = row.get("lon")
+    if lat is None or lon is None:
+        return None
+    return lat / 1e7, lon / 1e7
+
+
+class Mission:
+    def __init__(self, node: Node) -> None:
+        self.node = node
+        self.pending: Pending | None = None
+        self.last_relative_alt_m: float | None = None
+        self.last_latlon: tuple[float, float] | None = None
+
+    # ---- low-level helpers -------------------------------------------------
+
+    def _send(self, description: str, command: int, **params: float) -> None:
+        cmd = _make_command_long(command, **params)
+        self.node.send_output("command_long_cmd", cmd)
+        self.pending = Pending(command=command, description=description, sent_at=time.monotonic())
+        logging.info("mission: -> %s (cmd=%d)", description, command)
+
+    def _send_set_mode(self, custom_mode: int, base_mode: int = 1) -> None:
+        """Send the legacy MAVLink SET_MODE message (msg id 11).
+
+        The dora bridge can carry the MAVLink SET_MODE message in
+        principle, but mavlink-rust 0.13's generated `SET_MODE_DATA.base_mode`
+        is the strict `MavMode` enum (no variant for the bare bit 0x01 used
+        by ArduCopter), so any `base_mode=1` payload fails decoding inside
+        the bridge and is silently dropped. Side-channel via pymavlink on
+        TCP 5763 (a parallel SITL UART) bypasses that limitation cleanly —
+        the autopilot's MAVLink stack applies the mode regardless of which
+        port the message came in on, and HEARTBEATs continue flowing over
+        the bridge so we still observe the mode change end-to-end."""
+        side = _ensure_side_pymavlink()
+        side.mav.set_mode_send(TARGET_SYSTEM, base_mode, custom_mode)
+        logging.info(
+            "mission: -> SET_MODE (side-channel) custom_mode=%d base_mode=%d",
+            custom_mode, base_mode,
+        )
+        # Keep the dora bridge input plumbed too so future autopilots that
+        # support MAV_CMD_DO_SET_MODE just work without this hack.
+        sm = pa.StructArray.from_arrays(
+            [
+                pa.array([custom_mode], type=pa.uint32()),
+                pa.array([TARGET_SYSTEM], type=pa.uint8()),
+                pa.array([base_mode], type=pa.uint8()),
+            ],
+            names=["custom_mode", "target_system", "base_mode"],
+        )
+        try:
+            self.node.send_output("set_mode_cmd", sm)
+        except Exception:
+            pass
+
+    def _await_ack(self, timeout: float, *, soft_fail_ok: bool = False) -> int:
+        """Block until COMMAND_ACK for self.pending arrives.
+
+        Returns the MAV_RESULT code. Raises on hard fail (non-soft, non-accepted)
+        unless soft_fail_ok=True, in which case soft-fail codes are returned to
+        the caller without raising."""
+        assert self.pending is not None
+        deadline = time.monotonic() + timeout
+        for event in self.node:
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"no ACK for {self.pending.description} within {timeout:.0f}s"
+                )
+            if event["type"] != "INPUT":
+                if event["type"] == "STOP":
+                    raise RuntimeError("STOP received mid-mission")
+                continue
+            input_id = event["id"]
+            if input_id == "global_position_int":
+                self.last_relative_alt_m = _relative_alt_m(event["value"])
+                ll = _global_latlon(event["value"])
+                if ll is not None:
+                    self.last_latlon = ll
+                continue
+            if input_id == "command_ack":
+                row = _first_row(event["value"])
+                if row.get("command") != self.pending.command:
+                    continue
+                result = row.get("result", -1)
+                name = MAV_RESULT_NAMES.get(result, f"UNKNOWN({result})")
+                logging.info(
+                    "mission: <- ACK %s [%s, %.1fs]",
+                    self.pending.description, name,
+                    time.monotonic() - self.pending.sent_at,
+                )
+                self.pending = None
+                if result == MAV_RESULT_ACCEPTED:
+                    return result
+                if soft_fail_ok and result in MAV_RESULT_SOFT_FAIL:
+                    return result
+                raise RuntimeError(
+                    f"{self.pending.description if self.pending else name}: "
+                    f"ACK = {name} (result={result})"
+                )
+        raise RuntimeError("event stream ended before ACK")
+
+    def _await_alt_at_least(self, target_m: float, timeout: float) -> None:
+        deadline = time.monotonic() + timeout
+        for event in self.node:
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"altitude did not reach {target_m:.1f} m within {timeout:.0f}s "
+                    f"(last={self.last_relative_alt_m})"
+                )
+            if event["type"] == "STOP":
+                raise RuntimeError("STOP received mid-mission")
+            if event["type"] != "INPUT" or event["id"] != "global_position_int":
+                continue
+            alt = _relative_alt_m(event["value"])
+            ll = _global_latlon(event["value"])
+            if ll is not None:
+                self.last_latlon = ll
+            if alt is None:
+                continue
+            self.last_relative_alt_m = alt
+            if alt >= target_m:
+                logging.info("mission: reached %.2f m (target %.2f)", alt, target_m)
+                return
+
+    def _await_alt_below(self, target_m: float, timeout: float) -> None:
+        deadline = time.monotonic() + timeout
+        for event in self.node:
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"altitude did not drop below {target_m:.1f} m within {timeout:.0f}s "
+                    f"(last={self.last_relative_alt_m})"
+                )
+            if event["type"] == "STOP":
+                raise RuntimeError("STOP received mid-mission")
+            if event["type"] != "INPUT" or event["id"] != "global_position_int":
+                continue
+            alt = _relative_alt_m(event["value"])
+            if alt is None:
+                continue
+            self.last_relative_alt_m = alt
+            if alt <= target_m:
+                logging.info("mission: landed at %.2f m", alt)
+                return
+
+    def _await_reach_latlon(self, target_lat: float, target_lon: float,
+                            tolerance_m: float, timeout: float) -> None:
+        deadline = time.monotonic() + timeout
+        for event in self.node:
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"vehicle did not reach ({target_lat:.5f}, {target_lon:.5f}) "
+                    f"within {timeout:.0f}s (last_latlon={self.last_latlon})"
+                )
+            if event["type"] == "STOP":
+                raise RuntimeError("STOP received mid-mission")
+            if event["type"] != "INPUT" or event["id"] != "global_position_int":
+                continue
+            alt = _relative_alt_m(event["value"])
+            ll = _global_latlon(event["value"])
+            if alt is not None:
+                self.last_relative_alt_m = alt
+            if ll is None:
+                continue
+            self.last_latlon = ll
+            cur_lat, cur_lon = ll
+            dn = (cur_lat - target_lat) * METERS_PER_DEG_LAT
+            de = (cur_lon - target_lon) * _meters_per_deg_lon(cur_lat)
+            dist_m = math.hypot(dn, de)
+            if dist_m <= tolerance_m:
+                logging.info(
+                    "mission: reached waypoint dist=%.1f m alt=%.1f m",
+                    dist_m, alt or -1,
+                )
+                return
+
+    def _wait_for_first_heartbeat(self, timeout: float) -> None:
+        deadline = time.monotonic() + timeout
+        for event in self.node:
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"no HEARTBEAT within {timeout:.0f}s -- is SITL running?")
+            if event["type"] == "STOP":
+                raise RuntimeError("STOP received before mission start")
+            if event["type"] == "INPUT" and event["id"] == "heartbeat":
+                logging.info("mission: vehicle heartbeat received")
+                return
+
+    def _wait_for_custom_mode(self, target_custom_mode: int, timeout: float) -> None:
+        """Drain events until a HEARTBEAT reports custom_mode == target."""
+        deadline = time.monotonic() + timeout
+        for event in self.node:
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"vehicle did not reach custom_mode={target_custom_mode} in {timeout:.0f}s"
+                )
+            if event["type"] == "STOP":
+                raise RuntimeError("STOP received during mode-wait")
+            if event["type"] != "INPUT":
+                continue
+            if event["id"] == "global_position_int":
+                self.last_relative_alt_m = _relative_alt_m(event["value"])
+                ll = _global_latlon(event["value"])
+                if ll is not None:
+                    self.last_latlon = ll
+                continue
+            if event["id"] == "heartbeat":
+                row = _first_row(event["value"])
+                cm = row.get("custom_mode")
+                if cm == target_custom_mode:
+                    logging.info("mission: vehicle is in custom_mode=%d", cm)
+                    return
+
+    # ---- mission steps -----------------------------------------------------
+
+    def _try_reposition(self, label: str, lat: float, lon: float, alt_m: float) -> bool:
+        """Send DO_REPOSITION and wait for arrival. Returns False on soft-fail
+        (caller skips remaining waypoints). Raises on timeout."""
+        self._send(
+            f"REPOSITION {label} ({lat:.5f}, {lon:.5f}, {alt_m:.0f}m)",
+            MAV_CMD_DO_REPOSITION,
+            p1=GROUND_SPEED,
+            p2=0.0,
+            p3=0.0,
+            p4=float("nan"),
+            p5=lat,
+            p6=lon,
+            p7=alt_m,
+        )
+        result = self._await_ack(COMMAND_TIMEOUT_SECS, soft_fail_ok=True)
+        if result != MAV_RESULT_ACCEPTED:
+            logging.warning(
+                "mission: REPOSITION %s soft-failed (%s); skipping remaining waypoints",
+                label, MAV_RESULT_NAMES.get(result, result),
+            )
+            return False
+        # Wait until we get within 5m horizontal of the target.
+        self._await_reach_latlon(lat, lon, tolerance_m=5.0, timeout=WAYPOINT_TIMEOUT_SECS)
+        return True
+
+    def run(self) -> None:
+        self._wait_for_first_heartbeat(timeout=COMMAND_TIMEOUT_SECS)
+
+        if WARMUP_SECS > 0:
+            logging.info("mission: warmup for %.1fs (EKF/GPS settle)", WARMUP_SECS)
+            t0 = time.monotonic()
+            for event in self.node:
+                if time.monotonic() - t0 >= WARMUP_SECS:
+                    break
+                if event["type"] == "INPUT" and event["id"] == "global_position_int":
+                    alt = _relative_alt_m(event["value"])
+                    if alt is not None:
+                        self.last_relative_alt_m = alt
+                    ll = _global_latlon(event["value"])
+                    if ll is not None:
+                        self.last_latlon = ll
+
+        if USE_LEGACY_SET_MODE:
+            # MavModeFlag::CUSTOM_MODE_ENABLED bit (0x01)
+            self._send_set_mode(custom_mode=ARDUCOPTER_GUIDED_CUSTOM_MODE, base_mode=1)
+            # Wait until a HEARTBEAT confirms GUIDED mode is active. Without
+            # this, ArduCopter 3.3 sometimes ARMs in STABILIZE and rejects
+            # the subsequent TAKEOFF with ACK=FAILED.
+            self._wait_for_custom_mode(ARDUCOPTER_GUIDED_CUSTOM_MODE, timeout=10.0)
+        else:
+            self._send(
+                "SET_MODE GUIDED",
+                MAV_CMD_DO_SET_MODE,
+                p1=MODE_FLAG_CUSTOM_ENABLED,
+                p2=float(ARDUCOPTER_GUIDED_CUSTOM_MODE),
+            )
+            self._await_ack(COMMAND_TIMEOUT_SECS)
+
+        arm_kwargs: dict[str, float] = {"p1": 1.0}
+        if FORCE_ARM:
+            arm_kwargs["p2"] = 21196.0
+        self._send("ARM", MAV_CMD_COMPONENT_ARM_DISARM, **arm_kwargs)
+        self._await_ack(COMMAND_TIMEOUT_SECS)
+
+        self._send("TAKEOFF", MAV_CMD_NAV_TAKEOFF, p7=TAKEOFF_ALT_M)
+        self._await_ack(COMMAND_TIMEOUT_SECS)
+        self._await_alt_at_least(ALT_REACHED_FRACTION * TAKEOFF_ALT_M, ALT_TIMEOUT_SECS)
+
+        # Square pattern, 4 waypoints. Default 100m sides at takeoff altitude.
+        if not SKIP_REPOSITION:
+            wp_n  = _offset_latlon(HOME_LAT, HOME_LON, north_m=LEG_M, east_m=0.0)
+            wp_ne = _offset_latlon(HOME_LAT, HOME_LON, north_m=LEG_M, east_m=LEG_M)
+            wp_e  = _offset_latlon(HOME_LAT, HOME_LON, north_m=0.0,    east_m=LEG_M)
+            wp_home_high = (HOME_LAT, HOME_LON)
+            for label, (lat, lon), alt_m in [
+                ("NORTH",      wp_n,             TAKEOFF_ALT_M),
+                ("NORTH-EAST", wp_ne,            TAKEOFF_ALT_M),
+                ("EAST",       wp_e,             TAKEOFF_ALT_M),
+                ("HOME-HIGH",  wp_home_high,     HIGH_ALT_M),
+            ]:
+                ok = self._try_reposition(label, lat, lon, alt_m)
+                if not ok:
+                    break
+        else:
+            logging.info("mission: SKIP_REPOSITION=1 -> climb only")
+            # Reuse TAKEOFF for an additional climb.
+            self._send("CLIMB", MAV_CMD_NAV_TAKEOFF, p7=HIGH_ALT_M)
+            try:
+                self._await_ack(COMMAND_TIMEOUT_SECS, soft_fail_ok=True)
+                self._await_alt_at_least(ALT_REACHED_FRACTION * HIGH_ALT_M, ALT_TIMEOUT_SECS)
+            except (RuntimeError, TimeoutError) as e:
+                logging.warning("mission: CLIMB skipped (%s)", e)
+
+        logging.info(
+            "mission: hovering for %.1fs at alt~%sm",
+            HOVER_SECS, self.last_relative_alt_m,
+        )
+        time.sleep(HOVER_SECS)
+
+        self._send("LAND", MAV_CMD_NAV_LAND)
+        self._await_ack(COMMAND_TIMEOUT_SECS)
+        self._await_alt_below(LAND_DETECT_M, timeout=max(ALT_TIMEOUT_SECS, HIGH_ALT_M * 2))
+
+        time.sleep(3.0)
+        disarm_kwargs: dict[str, float] = {"p1": 0.0}
+        if FORCE_ARM:
+            disarm_kwargs["p2"] = 21196.0
+        self._send("DISARM", MAV_CMD_COMPONENT_ARM_DISARM, **disarm_kwargs)
+        try:
+            self._await_ack(COMMAND_TIMEOUT_SECS)
+        except RuntimeError as e:
+            logging.info("mission: DISARM rejected (likely auto-disarmed): %s", e)
+            self.pending = None
+
+        print("mission: SUCCESS - long mission complete (square + climb + hover + land)")
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    node = Node()
+    try:
+        Mission(node).run()
+    except (TimeoutError, RuntimeError) as e:
+        logging.error("mission: FAILED - %s", e)
+        raise SystemExit(1) from e
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/mavlink2-bridge-sitl-mission/mission_rover.py
+++ b/examples/mavlink2-bridge-sitl-mission/mission_rover.py
@@ -1,0 +1,248 @@
+"""Long-and-obvious rover mission via the dora mavlink2-bridge.
+
+Why RC override and not GUIDED waypoints:
+  dronekit-sitl ships ArduRover 2.50, which rejects COMMAND_LONG ARM
+  (cmd 400), DO_REPOSITION (cmd 192), and NAV_WAYPOINT (cmd 16) — every
+  ACK comes back result=3 (UNSUPPORTED). The only movement path that
+  works on this firmware is RC_CHANNELS_OVERRIDE, which simulates an
+  RC transmitter feeding steering + throttle. ArduRover auto-arms on
+  throttle in MANUAL mode, so we can drive a square pattern without
+  needing an explicit ARM command.
+
+Drives a clockwise square (forward → right turn → forward → ...) by
+alternating between forward-throttle / straight-steering and zero-throttle
+/ hard-right-steering phases. Phase durations are tuned to the simulated
+rover's nominal speed and turn rate; both are env-tunable. Telemetry
+flows through the dora bridge as usual, so QGC sees the trajectory live.
+
+State machine:
+   WAIT_HEARTBEAT
+   SET_MODE MANUAL (side-channel; mavlink-rust 0.13's strict MavMode
+                    enum can't represent base_mode=1)
+   for leg in [N, E, S, W]:
+       drive forward LEG_SECS
+       turn right TURN_SECS
+   stop (RC override neutral)
+   DONE
+
+Tunables:
+   MAVLINK_SITL_LEG_SECS        time per straight leg (default 25.0s)
+   MAVLINK_SITL_TURN_SECS       time per 90-deg turn (default 4.0s)
+   MAVLINK_SITL_TICK_HZ         RC override resend rate (default 10 Hz)
+   MAVLINK_SITL_THROTTLE_PWM    forward throttle PWM (default 1900)
+   MAVLINK_SITL_NEUTRAL_PWM     neutral PWM (default 1500)
+   MAVLINK_SITL_STEER_RIGHT_PWM hard-right steering PWM (default 1900)
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+import time
+
+import pyarrow as pa
+from dora import Node
+
+try:
+    from pymavlink import mavutil  # type: ignore[import-not-found]
+except Exception:  # pragma: no cover
+    mavutil = None  # type: ignore[assignment]
+
+
+# Rover modes (ArduRover firmware): 0=MANUAL, 4=HOLD, 10=AUTO, 11=RTL,
+# 15=GUIDED. We use MANUAL because it's the only mode that takes
+# RC_CHANNELS_OVERRIDE in rover-2.50.
+ARDUROVER_MANUAL_MODE = 0
+
+TARGET_SYSTEM = int(os.environ.get("MAVLINK_SITL_TARGET_SYSTEM", "1"))
+TARGET_COMPONENT = int(os.environ.get("MAVLINK_SITL_TARGET_COMPONENT", "1"))
+
+LEG_SECS = float(os.environ.get("MAVLINK_SITL_LEG_SECS", "25.0"))
+TURN_SECS = float(os.environ.get("MAVLINK_SITL_TURN_SECS", "4.0"))
+TICK_HZ = float(os.environ.get("MAVLINK_SITL_TICK_HZ", "10.0"))
+THROTTLE_PWM = int(os.environ.get("MAVLINK_SITL_THROTTLE_PWM", "1900"))
+NEUTRAL_PWM = int(os.environ.get("MAVLINK_SITL_NEUTRAL_PWM", "1500"))
+STEER_RIGHT_PWM = int(os.environ.get("MAVLINK_SITL_STEER_RIGHT_PWM", "1900"))
+
+
+_SIDE_PYMAVLINK = None
+
+
+def _ensure_side_pymavlink():
+    """Side-channel pymavlink connection on TCP 5763 for SET_MODE +
+    REQUEST_DATA_STREAM. See `_send_set_mode` in mission_long.py for the
+    rationale (mavlink-rust 0.13 strict MavMode + missing data streams)."""
+    global _SIDE_PYMAVLINK
+    if _SIDE_PYMAVLINK is not None:
+        return _SIDE_PYMAVLINK
+    if mavutil is None:
+        raise RuntimeError("pymavlink missing; pip install --user pymavlink")
+    side_url = os.environ.get("MAVLINK_SITL_SIDECHAN", "tcp:127.0.0.1:5763")
+    logging.info("mission: opening side-channel %s", side_url)
+    side = mavutil.mavlink_connection(side_url, source_system=255, source_component=190)
+    side.wait_heartbeat(timeout=15)
+    side.mav.request_data_stream_send(side.target_system, side.target_component, 0, 5, 1)
+    _SIDE_PYMAVLINK = side
+    return side
+
+
+def _make_rc_override(steering_pwm: int, throttle_pwm: int) -> pa.StructArray:
+    """RC_CHANNELS_OVERRIDE. ArduRover default: ch1=steering, ch3=throttle.
+    All other channels neutral. UINT16_MAX would mean "release"; we send
+    explicit values so the autopilot uses our overrides on every channel."""
+    return pa.StructArray.from_arrays(
+        [
+            pa.array([TARGET_SYSTEM], type=pa.uint8()),
+            pa.array([TARGET_COMPONENT], type=pa.uint8()),
+            pa.array([steering_pwm], type=pa.uint16()),
+            pa.array([NEUTRAL_PWM], type=pa.uint16()),
+            pa.array([throttle_pwm], type=pa.uint16()),
+            pa.array([NEUTRAL_PWM], type=pa.uint16()),
+            pa.array([NEUTRAL_PWM], type=pa.uint16()),
+            pa.array([NEUTRAL_PWM], type=pa.uint16()),
+            pa.array([NEUTRAL_PWM], type=pa.uint16()),
+            pa.array([NEUTRAL_PWM], type=pa.uint16()),
+        ],
+        names=[
+            "target_system", "target_component",
+            "chan1_raw", "chan2_raw", "chan3_raw", "chan4_raw",
+            "chan5_raw", "chan6_raw", "chan7_raw", "chan8_raw",
+        ],
+    )
+
+
+def _first_row(struct_array: pa.StructArray) -> dict:
+    rows = struct_array.to_pylist()
+    return rows[0] if rows else {}
+
+
+def _global_latlon(global_position_int) -> tuple[float, float] | None:
+    row = _first_row(global_position_int)
+    lat = row.get("lat")
+    lon = row.get("lon")
+    if lat is None or lon is None:
+        return None
+    return lat / 1e7, lon / 1e7
+
+
+class RoverMission:
+    def __init__(self, node: Node) -> None:
+        self.node = node
+        self.last_latlon: tuple[float, float] | None = None
+        self.start_latlon: tuple[float, float] | None = None
+
+    def _wait_for_first_heartbeat(self, timeout: float) -> None:
+        deadline = time.monotonic() + timeout
+        for event in self.node:
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"no HEARTBEAT within {timeout:.0f}s — is SITL running?"
+                )
+            if event["type"] == "STOP":
+                raise RuntimeError("STOP received before mission start")
+            if event["type"] == "INPUT" and event["id"] == "heartbeat":
+                logging.info("mission: vehicle heartbeat received")
+                return
+
+    def _drain_for(self, secs: float, *, send_rc=None,
+                   side_pwm: tuple[int, int] | None = None) -> None:
+        """Consume events for `secs` while pumping RC overrides at TICK_HZ.
+
+        Sends through both the dora bridge (rc_channels_override_cmd) AND
+        the side-channel pymavlink connection. mavlink-rust 0.13 may
+        encode RC_CHANNELS_OVERRIDE in a way ArduRover 2.50 doesn't
+        accept; the side-channel is the proven path."""
+        deadline = time.monotonic() + secs
+        next_send = time.monotonic()
+        period = 1.0 / TICK_HZ
+        side = _ensure_side_pymavlink() if side_pwm is not None else None
+        for event in self.node:
+            now = time.monotonic()
+            if now >= next_send:
+                if send_rc is not None:
+                    try:
+                        self.node.send_output("rc_channels_override_cmd", send_rc)
+                    except Exception:
+                        pass
+                if side is not None and side_pwm is not None:
+                    steer, throttle = side_pwm
+                    side.mav.rc_channels_override_send(
+                        side.target_system, side.target_component,
+                        steer, NEUTRAL_PWM, throttle, NEUTRAL_PWM,
+                        NEUTRAL_PWM, NEUTRAL_PWM, NEUTRAL_PWM, NEUTRAL_PWM,
+                    )
+                next_send = now + period
+            if now >= deadline:
+                return
+            if event["type"] == "STOP":
+                raise RuntimeError("STOP received during leg")
+            if event["type"] == "INPUT" and event["id"] == "global_position_int":
+                ll = _global_latlon(event["value"])
+                if ll is not None:
+                    self.last_latlon = ll
+                    if self.start_latlon is None:
+                        self.start_latlon = ll
+
+    def _drive_forward(self, secs: float, label: str) -> None:
+        rc = _make_rc_override(NEUTRAL_PWM, THROTTLE_PWM)
+        before = self.last_latlon
+        logging.info("mission: drive %s for %.1fs (steering=neutral throttle=%d)",
+                     label, secs, THROTTLE_PWM)
+        self._drain_for(secs, send_rc=rc, side_pwm=(NEUTRAL_PWM, THROTTLE_PWM))
+        if before and self.last_latlon:
+            dn = (self.last_latlon[0] - before[0]) * 111_320.0
+            de = (self.last_latlon[1] - before[1]) * 111_320.0 * \
+                 math.cos(math.radians(self.last_latlon[0]))
+            logging.info("mission: leg %s done dN=%.1fm dE=%.1fm",
+                         label, dn, de)
+
+    def _turn_right(self, secs: float, label: str) -> None:
+        rc = _make_rc_override(STEER_RIGHT_PWM, THROTTLE_PWM)
+        logging.info("mission: turn right for %.1fs (%s)", secs, label)
+        self._drain_for(secs, send_rc=rc, side_pwm=(STEER_RIGHT_PWM, THROTTLE_PWM))
+
+    def _stop(self) -> None:
+        rc = _make_rc_override(NEUTRAL_PWM, NEUTRAL_PWM)
+        logging.info("mission: stop (RC neutral)")
+        for _ in range(5):
+            self.node.send_output("rc_channels_override_cmd", rc)
+            time.sleep(0.05)
+
+    def run(self) -> None:
+        self._wait_for_first_heartbeat(timeout=15.0)
+        side = _ensure_side_pymavlink()
+        logging.info("mission: -> SET_MODE MANUAL (custom=%d)", ARDUROVER_MANUAL_MODE)
+        side.mav.set_mode_send(side.target_system, 1, ARDUROVER_MANUAL_MODE)
+        time.sleep(1.0)
+
+        # Drive square: 4 forward legs + 4 right turns
+        legs = [("NORTH", "E"), ("EAST", "S"), ("SOUTH", "W"), ("WEST", "N")]
+        for fwd_label, turn_label in legs:
+            self._drive_forward(LEG_SECS, fwd_label)
+            self._turn_right(TURN_SECS, f"to {turn_label}")
+        self._stop()
+
+        if self.start_latlon and self.last_latlon:
+            dn = (self.last_latlon[0] - self.start_latlon[0]) * 111_320.0
+            de = (self.last_latlon[1] - self.start_latlon[1]) * 111_320.0 * \
+                 math.cos(math.radians(self.last_latlon[0]))
+            logging.info(
+                "mission: total displacement from start: dN=%.1fm dE=%.1fm",
+                dn, de,
+            )
+        print("mission: SUCCESS - rover square drive complete")
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    node = Node()
+    try:
+        RoverMission(node).run()
+    except (TimeoutError, RuntimeError) as e:
+        logging.error("mission: FAILED - %s", e)
+        raise SystemExit(1) from e
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/mavlink2-bridge-sitl-mission/requirements.txt
+++ b/examples/mavlink2-bridge-sitl-mission/requirements.txt
@@ -1,0 +1,2 @@
+pyarrow
+dora-rs

--- a/examples/mavlink2-bridge-sitl-mission/scripts/forward_to_qgc.py
+++ b/examples/mavlink2-bridge-sitl-mission/scripts/forward_to_qgc.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Forward MAVLink from dronekit-sitl's secondary TCP port to QGC's UDP port.
+
+dronekit-sitl exposes multiple TCP ports (5760, 5762, 5763 for UART 0/2/3).
+The dora bridge connects to 5760; QGC listens on UDP 14550. This script
+bridges TCP 5762 (a parallel autopilot port) ↔ UDP 14550 so QGC sees the
+same vehicle without competing with the dora bridge for TCP 5760.
+
+No re-encoding — `recv_msg()` returns the original frame and `get_msgbuf()`
+gives the raw bytes, so V1/V2 are preserved as-sent by ArduPilot.
+
+Usage:
+    python3 forward_to_qgc.py            # default 5762 -> 127.0.0.1:14550
+    SRC_TCP_PORT=5762 DST_UDP=127.0.0.1:14550 python3 forward_to_qgc.py
+"""
+
+import os
+import sys
+import time
+from pymavlink import mavutil
+
+SRC_TCP_HOST = os.environ.get("SRC_TCP_HOST", "127.0.0.1")
+SRC_TCP_PORT = int(os.environ.get("SRC_TCP_PORT", "5762"))
+DST_UDP = os.environ.get("DST_UDP", "127.0.0.1:14550")
+
+
+def main() -> int:
+    print(
+        f"[forward_to_qgc] tcp:{SRC_TCP_HOST}:{SRC_TCP_PORT}  ->  udpout:{DST_UDP}",
+        flush=True,
+    )
+    src = mavutil.mavlink_connection(
+        f"tcp:{SRC_TCP_HOST}:{SRC_TCP_PORT}",
+        autoreconnect=True,
+    )
+    dst = mavutil.mavlink_connection(f"udpout:{DST_UDP}")
+    print("[forward_to_qgc] connected to TCP source; awaiting frames", flush=True)
+    n = 0
+    while True:
+        msg = src.recv_msg()
+        if msg is None:
+            time.sleep(0.005)
+            continue
+        try:
+            dst.write(msg.get_msgbuf())
+            n += 1
+            if n in (1, 10, 100) or n % 1000 == 0:
+                print(f"[forward_to_qgc] forwarded {n} frames", flush=True)
+        except Exception as e:
+            print(f"[forward_to_qgc] write failed: {e}", flush=True, file=sys.stderr)
+            time.sleep(0.05)
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)

--- a/examples/mavlink2-bridge-sitl-mission/scripts/start_mavlink_long.sh
+++ b/examples/mavlink2-bridge-sitl-mission/scripts/start_mavlink_long.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Boot dronekit-sitl + a simple Python forwarder for the long-mission demo.
+#
+# Topology:
+#   dronekit-sitl ── tcp:5760 ──► dora bridge   (configured with ?proto=v1)
+#                ── tcp:5762 ──► forward_to_qgc.py ──udp:14550──► QGC
+#
+# Why ?proto=v1: mavlink-rust 0.13's recv() is filtered by the connection's
+# protocol_version. dronekit-sitl ships ArduCopter 3.3 which speaks V1 only;
+# pinning the bridge to V2 (the bridge's default) made it silently drop
+# every frame. The dataflow_long.yml endpoint URL passes ?proto=v1 so the
+# bridge uses V1 framing on this link.
+#
+# Logs: /tmp/dronekit-sitl.log and /tmp/forward_to_qgc.log
+# Stop everything: pkill -f 'dronekit-sitl|forward_to_qgc'
+
+set -euo pipefail
+
+HOME_LATLON="${MAVLINK_SITL_HOME:--35.363261,149.165230,584,353}"
+SITL_LOG=/tmp/dronekit-sitl.log
+FORWARD_LOG=/tmp/forward_to_qgc.log
+SITL_BIN="${HOME}/.local/bin/dronekit-sitl"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FORWARDER="$SCRIPT_DIR/forward_to_qgc.py"
+
+if ! command -v "$SITL_BIN" >/dev/null 2>&1; then
+    echo "ERROR: $SITL_BIN not found. Run: pip install --user dronekit-sitl" >&2
+    exit 1
+fi
+if [ ! -f "$FORWARDER" ]; then
+    echo "ERROR: $FORWARDER not found." >&2
+    exit 1
+fi
+
+# Kill any prior instances.
+pkill -f 'dronekit-sitl|sitl-linux-copter' || true
+pkill -f 'forward_to_qgc.py' || true
+pkill -f 'mavproxy.py' || true
+sleep 1
+
+echo "[1/2] Booting dronekit-sitl ArduCopter at home=$HOME_LATLON"
+"$SITL_BIN" copter --home="$HOME_LATLON" >"$SITL_LOG" 2>&1 &
+SITL_PID=$!
+
+for i in $(seq 1 60); do
+    if (echo > /dev/tcp/127.0.0.1/5760) 2>/dev/null; then
+        echo "       SITL TCP 5760 ready (after ${i}s)"
+        break
+    fi
+    sleep 1
+done
+for i in $(seq 1 20); do
+    (echo > /dev/tcp/127.0.0.1/5762) 2>/dev/null && break
+    sleep 0.5
+done
+
+echo "[2/2] Starting QGC forwarder: tcp:5762 -> udp:14550"
+python3 "$FORWARDER" >"$FORWARD_LOG" 2>&1 &
+FWD_PID=$!
+
+sleep 2
+
+echo
+echo "Bring-up complete:"
+echo "  dronekit-sitl     pid=$SITL_PID  (log: $SITL_LOG)"
+echo "  forward_to_qgc.py pid=$FWD_PID  (log: $FORWARD_LOG)"
+echo
+echo "QGC          ← udp:14550 ← forward_to_qgc.py ← tcp:5762 ← dronekit-sitl"
+echo "dora bridge  ← directly  ← tcp:5760 (?proto=v1) ← dronekit-sitl"
+echo
+echo "Next step: dora run dataflow_long.yml"
+echo
+echo "Stop everything:"
+echo "  pkill -f 'dronekit-sitl|forward_to_qgc.py'"

--- a/examples/mavlink2-bridge-sitl-mission/scripts/start_rover.sh
+++ b/examples/mavlink2-bridge-sitl-mission/scripts/start_rover.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Boot dronekit-sitl rover-2.50 + Python TCP→UDP forwarder for QGC.
+#
+# Topology:
+#   dronekit-sitl rover ── tcp:5760 ──► dora bridge   (?proto=v1)
+#                       ── tcp:5762 ──► forward_to_qgc.py ──udp:14550──► QGC
+#
+# Same pattern as start_mavlink_long.sh but loads the rover-2.50 binary
+# instead of copter-3.3.
+
+set -euo pipefail
+
+HOME_LATLON="${MAVLINK_SITL_HOME:--35.363261,149.165230,584,353}"
+SITL_LOG=/tmp/dronekit-rover.log
+FORWARD_LOG=/tmp/forward_to_qgc.log
+SITL_BIN="${HOME}/.local/bin/dronekit-sitl"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FORWARDER="$SCRIPT_DIR/forward_to_qgc.py"
+
+if ! command -v "$SITL_BIN" >/dev/null 2>&1; then
+    echo "ERROR: $SITL_BIN not found. Run: pip install --user dronekit-sitl" >&2
+    exit 1
+fi
+
+# Hard-stop any prior SITL.
+pkill -f 'dronekit-sitl|sitl-linux-' || true
+pkill -f 'forward_to_qgc.py' || true
+pkill -f 'mavproxy.py' || true
+# Force-kill any apm process directly (dronekit-sitl wrapper may be gone
+# but the apm child can hang on to TCP ports).
+pkill -KILL -f '/.dronekit/sitl/.*/apm' || true
+sleep 2
+
+echo "[1/2] Booting dronekit-sitl rover-2.50 at home=$HOME_LATLON"
+"$SITL_BIN" rover-2.50 --home="$HOME_LATLON" >"$SITL_LOG" 2>&1 &
+SITL_PID=$!
+
+for i in $(seq 1 60); do
+    if (echo > /dev/tcp/127.0.0.1/5760) 2>/dev/null; then
+        echo "       SITL TCP 5760 ready (after ${i}s)"
+        break
+    fi
+    sleep 1
+done
+for i in $(seq 1 20); do
+    (echo > /dev/tcp/127.0.0.1/5762) 2>/dev/null && break
+    sleep 0.5
+done
+
+echo "[2/2] Starting QGC forwarder: tcp:5762 -> udp:14550"
+python3 "$FORWARDER" >"$FORWARD_LOG" 2>&1 &
+FWD_PID=$!
+
+sleep 3
+
+echo
+echo "Bring-up complete:"
+echo "  dronekit-sitl     pid=$SITL_PID  (log: $SITL_LOG)"
+echo "  forward_to_qgc.py pid=$FWD_PID  (log: $FORWARD_LOG)"
+echo
+echo "QGC          ← udp:14550 ← forward_to_qgc.py ← tcp:5762 ← dronekit-sitl rover"
+echo "dora bridge  ← directly  ← tcp:5760 (?proto=v1) ← dronekit-sitl rover"
+echo
+echo "Next step: dora run dataflow_rover.yml"
+echo
+echo "Stop everything:"
+echo "  pkill -f 'dronekit-sitl|forward_to_qgc.py'"

--- a/examples/mavlink2-bridge-sitl-mission/scripts/start_sitl.sh
+++ b/examples/mavlink2-bridge-sitl-mission/scripts/start_sitl.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Boot ArduCopter SITL with reproducible flags so the mission demo
+# always starts from the same home position. Forwards MAVLink on
+# udp:127.0.0.1:14550 (the bridge's default).
+#
+# Prereqs (Ubuntu and macOS):
+#
+#   git clone --recursive https://github.com/ArduPilot/ardupilot.git ~/src/ardupilot
+#   cd ~/src/ardupilot
+#   Tools/environment_install/install-prereqs-<ubuntu|mac>.sh -y
+#   ./waf configure --board sitl
+#   ./waf copter
+#   pip install --user MAVProxy   # optional; only needed if you want
+#                                 # the MAVProxy console / map UI
+#
+# Then point ARDUPILOT_SRC at the clone (or pass it as the first
+# positional argument):
+#
+#   ARDUPILOT_SRC=~/src/ardupilot ./scripts/start_sitl.sh
+#
+# Stop with Ctrl-C.
+
+set -euo pipefail
+
+ARDUPILOT_SRC="${1:-${ARDUPILOT_SRC:-}}"
+
+if [ -z "$ARDUPILOT_SRC" ]; then
+    cat >&2 <<'USAGE'
+ERROR: ARDUPILOT_SRC not set.
+
+Usage:
+  ARDUPILOT_SRC=~/src/ardupilot ./scripts/start_sitl.sh
+  # or:
+  ./scripts/start_sitl.sh ~/src/ardupilot
+
+Install ArduPilot from https://github.com/ArduPilot/ardupilot first.
+USAGE
+    exit 1
+fi
+
+if [ ! -x "$ARDUPILOT_SRC/Tools/autotest/sim_vehicle.py" ]; then
+    echo "ERROR: $ARDUPILOT_SRC/Tools/autotest/sim_vehicle.py not found or not executable" >&2
+    exit 1
+fi
+
+# Reproducible home: 37.7749 N, 122.4194 W (San Francisco), 0 m, 0 deg yaw.
+HOME_LATLON="${MAVLINK_SITL_HOME:-37.7749,-122.4194,0,0}"
+
+# --no-mavproxy: skip MAVProxy entirely; sim_vehicle exposes the
+#                bare TCP/UDP MAVLink ports directly.
+# --out=udp:127.0.0.1:14550: forward MAVLink to the bridge.
+# -v ArduCopter: vehicle type.
+# --frame=quad: Iris-style quadrotor.
+exec "$ARDUPILOT_SRC/Tools/autotest/sim_vehicle.py" \
+    -v ArduCopter \
+    --frame=quad \
+    --custom-location="$HOME_LATLON" \
+    --out=udp:127.0.0.1:14550 \
+    --no-mavproxy

--- a/examples/mavlink2-bridge/README.md
+++ b/examples/mavlink2-bridge/README.md
@@ -1,0 +1,138 @@
+# MAVLink 2 bridge — example dataflow
+
+Three demos of the `dora-mavlink2-bridge-node` running alongside an
+in-process MAVLink 2 simulator. The bridge + sim + emitter are shared
+across all three; only the consumer that reads `bridge/heartbeat`
+changes per language. No autopilot, SITL, or MAVProxy install is
+required.
+
+```
+heartbeat-emitter ──heartbeat_cmd──▶ bridge ──udp:14550──▶ mavlink-sim
+                                       │
+                                       └─heartbeat──▶ telemetry-printer-{rust,python,cxx}
+```
+
+## Variants
+
+| File | Consumer | Build / dependencies |
+|------|----------|----------------------|
+| `dataflow-rust.yml`   | Rust crate `telemetry-printer-rust`  | cargo only            |
+| `dataflow-python.yml` | `telemetry_printer.py`               | cargo + uv (pyarrow)  |
+| `dataflow-cxx.yml`    | C++ binary `telemetry-printer-cxx`   | cargo + clang + Arrow C++ (`pkg-config arrow`) |
+
+The shared nodes:
+
+* dora → MAVLink: `heartbeat-emitter` (Rust) produces an Arrow
+  `StructArray` matching `HEARTBEAT_DATA::schema`. The bridge serialises
+  it as a real MAVLink 2 frame and writes it on the UDP socket.
+* MAVLink → dora: `mavlink-sim` (Rust) blasts a HEARTBEAT every 500 ms
+  on the same UDP endpoint. The bridge decodes each frame and publishes
+  it on the `heartbeat` output. Each variant's printer consumes that.
+
+## Run it
+
+### Rust variant (no extra deps)
+
+```bash
+dora run examples/mavlink2-bridge/dataflow-rust.yml --stop-after 5s
+```
+
+### Python variant (needs `--uv` for `pyarrow`)
+
+```bash
+dora run examples/mavlink2-bridge/dataflow-python.yml --uv --stop-after 5s
+```
+
+### C++ variant (needs Arrow C++ via `pkg-config`)
+
+```bash
+# One-shot: compiles the cxx printer + nodes, then dora-runs the dataflow.
+cargo run --example mavlink2-bridge-cxx
+```
+
+The `cargo run --example` runner mirrors `cxx-arrow-dataflow`: it
+discovers Arrow via `pkg-config arrow`, builds the cxx bridge headers,
+compiles `telemetry-printer-cxx/main.cc` with `clang++`, then invokes
+`dora_cli::run` against `dataflow-cxx.yml`.
+
+### Networked / multi-daemon mode
+
+Same as above, but with the explicit `up`/`build`/`start`/`stop`/`down`
+lifecycle. Substitute the right YAML:
+
+```bash
+dora up
+dora build examples/mavlink2-bridge/dataflow-rust.yml
+dora start examples/mavlink2-bridge/dataflow-rust.yml --detach
+# ... watch the logs ...
+dora stop --all
+dora down
+```
+
+## Talk to a real MAVLink endpoint
+
+Stop the `mavlink-sim` node (delete it from the YAML) and point the
+bridge at your endpoint:
+
+```yaml
+- id: bridge
+  env:
+    MAVLINK_BRIDGE_CONFIG: |
+      endpoint: tcp://192.168.1.10:5760    # Pixhawk over telem-radio
+      # or: udp://0.0.0.0:14550            # listen for any GCS
+      # or: serial:///dev/ttyACM0?baud=115200
+```
+
+The `transport::connect` helper supports `tcp://`, `udp://`, and
+`serial://` URLs (see `libraries/extensions/mavlink2-bridge/src/transport.rs`).
+
+## Manual smoke (Tier 2): QGroundControl
+
+The CI smoke tests prove the bridge talks to itself. To prove it
+talks to a real-world MAVLink consumer, point [QGroundControl](https://qgroundcontrol.com/)
+at the bridge once per release. QGC is a GUI app and intentionally
+*not* automated — the value is human-eyeball confirmation that the
+wire format is right, not a CI gate.
+
+### Setup
+
+1. **Drop the simulator** from any of the variant YAMLs (delete the
+   `mavlink-sim` node block). The bridge will listen on UDP 14550;
+   QGC will become the peer that sends/receives MAVLink frames.
+2. **Switch the bridge to listen for QGC**:
+   ```yaml
+   - id: bridge
+     env:
+       MAVLINK_BRIDGE_CONFIG: |
+         endpoint: udp://0.0.0.0:14550
+   ```
+   `0.0.0.0` lets QGC connect from another machine on the LAN; use
+   `127.0.0.1` for purely local.
+3. **Run the dataflow**:
+   ```bash
+   dora run examples/mavlink2-bridge/dataflow-rust.yml --stop-after 60s
+   ```
+4. **Connect QGC**: *Application Settings → Comm Links → Add → UDP*,
+   port 14550, *Add Server Address* → `127.0.0.1:14550` (or the bridge
+   host's LAN IP), *OK → Connect*.
+
+### What you should see
+
+| Observation | What it proves |
+|-------------|----------------|
+| QGC banner: "Vehicle 1 connected" within ~2 s | HEARTBEAT round-trip works (bridge → wire → QGC parse) |
+| Custom-mode counter ticks up in QGC's vehicle info | `heartbeat-emitter` is producing valid Arrow that the bridge serialises correctly |
+| QGC's "Click to Arm" button → no protocol error | The bridge's `command_long_cmd` input + COMMAND_ACK output round-trip a real GCS command |
+| Telemetry HUD shows ATTITUDE / GPS values when you wire those into the dataflow | Per-message Arrow encoding matches MAVLink wire format byte-for-byte |
+
+If QGC says "Vehicle has lost data link" the bridge isn't sending
+HEARTBEATs at the rate QGC expects (~1 Hz). Check that the
+`heartbeat-emitter` tick is firing and the bridge's writer loop
+isn't blocked.
+
+### What QGC does *not* prove
+
+QGC validates the **wire layer** only — it has no view into the dora
+side. It will not catch Arrow schema drift, dora-side queueing bugs,
+or smoke-test regressions; those stay the job of the Tier 1 smoke
+suite.

--- a/examples/mavlink2-bridge/dataflow-cxx.yml
+++ b/examples/mavlink2-bridge/dataflow-cxx.yml
@@ -1,0 +1,44 @@
+nodes:
+  - id: mavlink-sim
+    build: cargo build -p mavlink2-bridge-example-mavlink-sim
+    path: ../../target/debug/mavlink2-bridge-example-mavlink-sim
+    env:
+      MAVLINK_SIM_PEER: 127.0.0.1:14550
+
+  - id: bridge
+    build: cargo build -p dora-mavlink2-bridge-node
+    path: ../../target/debug/dora-mavlink2-bridge-node
+    env:
+      MAVLINK_BRIDGE_CONFIG: |
+        endpoint: udp://127.0.0.1:14550
+    inputs:
+      heartbeat_cmd: heartbeat-emitter/heartbeat_cmd
+    outputs:
+      - heartbeat
+      - sys_status
+      - system_time
+      - attitude
+      - attitude_quaternion
+      - local_position_ned
+      - global_position_int
+      - gps_raw_int
+      - rc_channels
+      - servo_output_raw
+      - command_long
+      - command_ack
+      - mission_current
+
+  - id: heartbeat-emitter
+    build: cargo build -p mavlink2-bridge-example-heartbeat-emitter
+    path: ../../target/debug/mavlink2-bridge-example-heartbeat-emitter
+    inputs:
+      tick: dora/timer/secs/1
+    outputs:
+      - heartbeat_cmd
+
+  # C++ consumer. Pre-built by `cargo run --example mavlink2-bridge-cxx`,
+  # which compiles main.cc with clang++ + Arrow into build/.
+  - id: telemetry-printer
+    path: build/telemetry_printer_cxx
+    inputs:
+      heartbeat: bridge/heartbeat

--- a/examples/mavlink2-bridge/dataflow-python.yml
+++ b/examples/mavlink2-bridge/dataflow-python.yml
@@ -1,0 +1,52 @@
+nodes:
+  # In-process MAVLink 2 simulator. Replaces an autopilot/SITL/MAVProxy
+  # for examples and smoke tests; sends a HEARTBEAT every 500 ms over
+  # UDP to whatever endpoint MAVLINK_SIM_PEER points at.
+  - id: mavlink-sim
+    build: cargo build -p mavlink2-bridge-example-mavlink-sim
+    path: ../../target/debug/mavlink2-bridge-example-mavlink-sim
+    env:
+      MAVLINK_SIM_PEER: 127.0.0.1:14550
+
+  # The bridge node. Listens on udp://127.0.0.1:14550 (mavlink udpin),
+  # decodes incoming MAVLink frames into per-message Arrow outputs, and
+  # forwards Arrow inputs named `<message>_cmd` back over the same
+  # connection as MAVLink frames.
+  - id: bridge
+    build: cargo build -p dora-mavlink2-bridge-node
+    path: ../../target/debug/dora-mavlink2-bridge-node
+    env:
+      MAVLINK_BRIDGE_CONFIG: |
+        endpoint: udp://127.0.0.1:14550
+    inputs:
+      heartbeat_cmd: heartbeat-emitter/heartbeat_cmd
+    outputs:
+      - heartbeat
+      - sys_status
+      - system_time
+      - attitude
+      - attitude_quaternion
+      - local_position_ned
+      - global_position_int
+      - gps_raw_int
+      - rc_channels
+      - servo_output_raw
+      - command_long
+      - command_ack
+      - mission_current
+
+  # dora -> MAVLink direction: emits a HEARTBEAT_DATA Arrow row each
+  # second; the bridge serialises it and writes it back over UDP.
+  - id: heartbeat-emitter
+    build: cargo build -p mavlink2-bridge-example-heartbeat-emitter
+    path: ../../target/debug/mavlink2-bridge-example-heartbeat-emitter
+    inputs:
+      tick: dora/timer/secs/1
+    outputs:
+      - heartbeat_cmd
+
+  # MAVLink -> dora direction: prints each decoded HEARTBEAT.
+  - id: telemetry-printer
+    path: telemetry_printer.py
+    inputs:
+      heartbeat: bridge/heartbeat

--- a/examples/mavlink2-bridge/dataflow-rust.yml
+++ b/examples/mavlink2-bridge/dataflow-rust.yml
@@ -1,0 +1,46 @@
+nodes:
+  # In-process MAVLink simulator. See dataflow-python.yml for full
+  # context; same node, same wiring, only the consumer differs.
+  - id: mavlink-sim
+    build: cargo build -p mavlink2-bridge-example-mavlink-sim
+    path: ../../target/debug/mavlink2-bridge-example-mavlink-sim
+    env:
+      MAVLINK_SIM_PEER: 127.0.0.1:14550
+
+  - id: bridge
+    build: cargo build -p dora-mavlink2-bridge-node
+    path: ../../target/debug/dora-mavlink2-bridge-node
+    env:
+      MAVLINK_BRIDGE_CONFIG: |
+        endpoint: udp://127.0.0.1:14550
+    inputs:
+      heartbeat_cmd: heartbeat-emitter/heartbeat_cmd
+    outputs:
+      - heartbeat
+      - sys_status
+      - system_time
+      - attitude
+      - attitude_quaternion
+      - local_position_ned
+      - global_position_int
+      - gps_raw_int
+      - rc_channels
+      - servo_output_raw
+      - command_long
+      - command_ack
+      - mission_current
+
+  - id: heartbeat-emitter
+    build: cargo build -p mavlink2-bridge-example-heartbeat-emitter
+    path: ../../target/debug/mavlink2-bridge-example-heartbeat-emitter
+    inputs:
+      tick: dora/timer/secs/1
+    outputs:
+      - heartbeat_cmd
+
+  # Rust consumer: prints each decoded HEARTBEAT.
+  - id: telemetry-printer
+    build: cargo build -p mavlink2-bridge-example-telemetry-printer-rust
+    path: ../../target/debug/mavlink2-bridge-example-telemetry-printer-rust
+    inputs:
+      heartbeat: bridge/heartbeat

--- a/examples/mavlink2-bridge/heartbeat-emitter/Cargo.toml
+++ b/examples/mavlink2-bridge/heartbeat-emitter/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "mavlink2-bridge-example-heartbeat-emitter"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+
+[dependencies]
+dora-mavlink2-bridge = { workspace = true }
+dora-node-api = { workspace = true }
+arrow = { workspace = true }
+eyre = { workspace = true }
+tracing = { workspace = true }

--- a/examples/mavlink2-bridge/heartbeat-emitter/src/main.rs
+++ b/examples/mavlink2-bridge/heartbeat-emitter/src/main.rs
@@ -1,0 +1,54 @@
+//! Source node for the `mavlink2-bridge` example dataflow.
+//!
+//! On every tick the node builds a `HEARTBEAT_DATA` struct, encodes it
+//! into the bridge's Arrow schema via `MavlinkArrow::to_record_batch`,
+//! and publishes it on output `heartbeat_cmd`. The bridge is wired to
+//! consume that input and forward it as a real MAVLink frame.
+//!
+//! This demonstrates the dora → MAVLink direction of the bridge.
+
+use std::sync::Arc;
+
+use arrow::array::StructArray;
+use dora_mavlink2_bridge::{
+    MavlinkArrow,
+    mavlink::common::{HEARTBEAT_DATA, MavAutopilot, MavModeFlag, MavState, MavType},
+};
+use dora_node_api::{
+    DoraNode, Event, MetadataParameters, arrow::array::ArrayRef, dora_core::config::DataId,
+};
+use eyre::{Result, eyre};
+
+fn main() -> Result<()> {
+    let (mut node, mut events) =
+        DoraNode::init_from_env().map_err(|e| eyre!("DoraNode init: {e}"))?;
+
+    let output = DataId::from("heartbeat_cmd".to_owned());
+    let mut tick: u32 = 0;
+
+    while let Some(event) = events.recv() {
+        match event {
+            Event::Input { id, .. } if id.as_str() == "tick" => {
+                let heartbeat = HEARTBEAT_DATA {
+                    custom_mode: tick,
+                    mavtype: MavType::MAV_TYPE_QUADROTOR,
+                    autopilot: MavAutopilot::MAV_AUTOPILOT_GENERIC,
+                    base_mode: MavModeFlag::empty(),
+                    system_status: MavState::MAV_STATE_ACTIVE,
+                    mavlink_version: 3,
+                };
+                let batch = MavlinkArrow::to_record_batch(&heartbeat)
+                    .map_err(|e| eyre!("encoding HEARTBEAT to Arrow: {e}"))?;
+                let arr: ArrayRef = Arc::new(StructArray::from(batch));
+                node.send_output(output.clone(), MetadataParameters::default(), arr)
+                    .map_err(|e| eyre!("send_output heartbeat_cmd: {e}"))?;
+                tracing::info!(tick, "emitted heartbeat_cmd");
+                tick = tick.wrapping_add(1);
+            }
+            Event::Input { .. } => {}
+            Event::Stop(_) => break,
+            _ => {}
+        }
+    }
+    Ok(())
+}

--- a/examples/mavlink2-bridge/mavlink-sim/Cargo.toml
+++ b/examples/mavlink2-bridge/mavlink-sim/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "mavlink2-bridge-example-mavlink-sim"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+
+[dependencies]
+dora-mavlink2-bridge = { workspace = true }
+dora-node-api = { workspace = true }
+mavlink = { workspace = true }
+eyre = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = "0.3"

--- a/examples/mavlink2-bridge/mavlink-sim/src/main.rs
+++ b/examples/mavlink2-bridge/mavlink-sim/src/main.rs
@@ -1,0 +1,115 @@
+//! In-process MAVLink 2 simulator for the `mavlink2-bridge` example.
+//!
+//! Connects via UDP `udpout:` to the bridge (which listens with
+//! `udpin:`), and emits a HEARTBEAT every 500 ms. UDP is used instead
+//! of TCP so successive smoke-test runs are not blocked by `TIME_WAIT`,
+//! and so the bridge's reverse-direction `_cmd` path has a known peer
+//! address (mavlink's `udpin:` replies to the latest sender).
+//!
+//! The node participates in the dora lifecycle (init + Stop event) so
+//! the daemon can shut it down cleanly; the actual MAVLink work runs
+//! on a background thread.
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+use std::time::{Duration, Instant};
+
+use dora_node_api::{DoraNode, Event};
+use eyre::{Result, bail, eyre};
+use mavlink::{
+    MavConnection, MavHeader, MavlinkVersion,
+    common::{HEARTBEAT_DATA, MavAutopilot, MavMessage, MavModeFlag, MavState, MavType},
+};
+
+const DEFAULT_PEER: &str = "127.0.0.1:14550";
+const SEND_INTERVAL: Duration = Duration::from_millis(500);
+const PEER_RETRY_BUDGET: Duration = Duration::from_secs(5);
+const PEER_RETRY_INTERVAL: Duration = Duration::from_millis(100);
+
+fn open_sender(peer: &str) -> Result<Box<dyn MavConnection<MavMessage> + Send + Sync>> {
+    let deadline = Instant::now() + PEER_RETRY_BUDGET;
+    loop {
+        match mavlink::connect::<MavMessage>(&format!("udpout:{peer}")) {
+            Ok(mut conn) => {
+                conn.set_protocol_version(MavlinkVersion::V2);
+                return Ok(conn);
+            }
+            Err(e) => {
+                if Instant::now() >= deadline {
+                    return Err(eyre!(
+                        "udpout:{peer} unreachable after {:?}: {e}",
+                        PEER_RETRY_BUDGET
+                    ));
+                }
+                tracing::debug!("waiting for MAVLink peer at {peer}: {e}");
+                std::thread::sleep(PEER_RETRY_INTERVAL);
+            }
+        }
+    }
+}
+
+fn run_simulator(peer: String, stop: Arc<AtomicBool>) -> Result<()> {
+    let conn = open_sender(&peer)?;
+    let header = MavHeader {
+        system_id: 1,
+        component_id: 1,
+        sequence: 0,
+    };
+    let mut tick: u32 = 0;
+    while !stop.load(Ordering::Relaxed) {
+        let frame = MavMessage::HEARTBEAT(HEARTBEAT_DATA {
+            custom_mode: tick,
+            mavtype: MavType::MAV_TYPE_QUADROTOR,
+            autopilot: MavAutopilot::MAV_AUTOPILOT_GENERIC,
+            base_mode: MavModeFlag::empty(),
+            system_status: MavState::MAV_STATE_ACTIVE,
+            mavlink_version: 3,
+        });
+        if let Err(e) = conn.send(&header, &frame) {
+            tracing::warn!("simulator send failed: {e}");
+        } else {
+            tracing::trace!(tick, "sent simulated heartbeat");
+        }
+        tick = tick.wrapping_add(1);
+        std::thread::sleep(SEND_INTERVAL);
+    }
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    tracing_subscriber_init();
+
+    let peer = std::env::var("MAVLINK_SIM_PEER").unwrap_or_else(|_| DEFAULT_PEER.to_string());
+    tracing::info!(%peer, "MAVLink simulator starting");
+
+    let (_node, mut events) = DoraNode::init_from_env().map_err(|e| eyre!("DoraNode init: {e}"))?;
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let sim_handle = {
+        let stop = Arc::clone(&stop);
+        std::thread::Builder::new()
+            .name("mavlink-sim".into())
+            .spawn(move || run_simulator(peer, stop))
+            .map_err(|e| eyre!("spawn simulator thread: {e}"))?
+    };
+
+    while let Some(event) = events.recv() {
+        if matches!(event, Event::Stop(_)) {
+            break;
+        }
+    }
+
+    stop.store(true, Ordering::Relaxed);
+    match sim_handle.join() {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(e)) => bail!("simulator thread error: {e:#}"),
+        Err(panic) => bail!("simulator thread panicked: {panic:?}"),
+    }
+}
+
+fn tracing_subscriber_init() {
+    // Best-effort init; ignore errors if a subscriber is already set.
+    let _ = tracing_subscriber::fmt::try_init();
+}

--- a/examples/mavlink2-bridge/requirements.txt
+++ b/examples/mavlink2-bridge/requirements.txt
@@ -1,0 +1,2 @@
+pyarrow
+dora-rs

--- a/examples/mavlink2-bridge/run-cxx.rs
+++ b/examples/mavlink2-bridge/run-cxx.rs
@@ -1,0 +1,191 @@
+//! Build orchestrator for the C++ MAVLink 2 bridge example.
+//!
+//! Mirrors `examples/c++-arrow-dataflow/run.rs`: builds the cxx bridge
+//! header, compiles the C++ printer with clang++, then runs the
+//! dataflow via `dora_cli::run`. Invoke via:
+//!
+//! ```bash
+//! cargo run --example mavlink2-bridge-cxx
+//! ```
+//!
+//! Requires an Arrow C++ install discoverable via `pkg-config arrow`.
+
+use eyre::{Context, bail};
+use std::{env::consts::EXE_SUFFIX, path::Path, process::Command};
+
+struct ArrowConfig {
+    cflags: String,
+    libs: String,
+}
+
+fn main() -> eyre::Result<()> {
+    if cfg!(windows) {
+        tracing::error!(
+            "The mavlink2-bridge-cxx example does not work on Windows currently because of a linker error"
+        );
+        return Ok(());
+    }
+
+    let arrow_config = find_arrow_config().wrap_err("Failed to find Arrow configuration")?;
+    tracing::info!(
+        "Found Arrow configuration: cflags={}, libs={}",
+        arrow_config.cflags,
+        arrow_config.libs
+    );
+
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let target = root.join("target");
+    std::env::set_current_dir(root.join(file!()).parent().unwrap())
+        .wrap_err("failed to set working dir")?;
+
+    std::fs::create_dir_all("build")?;
+
+    // Build the dora cxx bridge headers + the bridge/sim/emitter Rust nodes
+    // so the dataflow's `path:` entries resolve.
+    build_package("dora-node-api-cxx")?;
+    build_package("dora-mavlink2-bridge-node")?;
+    build_package("mavlink2-bridge-example-mavlink-sim")?;
+    build_package("mavlink2-bridge-example-heartbeat-emitter")?;
+
+    let node_cxxbridge = target
+        .join("cxxbridge")
+        .join("dora-node-api-cxx")
+        .join("install");
+
+    build_cxx_node(
+        root,
+        &[
+            &dunce::canonicalize(Path::new("telemetry-printer-cxx").join("main.cc"))?,
+            &dunce::canonicalize(node_cxxbridge.join("dora-node-api.cc"))?,
+        ],
+        "telemetry_printer_cxx",
+        &[
+            "-I",
+            node_cxxbridge.as_os_str().to_str().unwrap(),
+            "-l",
+            "dora_node_api_cxx",
+            &arrow_config.cflags,
+            &arrow_config.libs,
+        ],
+    )?;
+
+    dora_cli::run("dataflow-cxx.yml".to_string(), false)?;
+
+    Ok(())
+}
+
+fn find_arrow_config() -> eyre::Result<ArrowConfig> {
+    let output = Command::new("pkg-config")
+        .args(["--cflags", "arrow"])
+        .output()
+        .wrap_err("Failed to run pkg-config. Make sure Arrow C++ is installed")?;
+
+    if !output.status.success() {
+        bail!(
+            "Arrow C++ not found via pkg-config. Make sure it's installed and in your PKG_CONFIG_PATH"
+        );
+    }
+
+    let cflags = String::from_utf8(output.stdout)?.trim().to_string();
+
+    let output = Command::new("pkg-config")
+        .args(["--libs", "arrow"])
+        .output()
+        .wrap_err("Failed to get Arrow library flags")?;
+
+    if !output.status.success() {
+        bail!("Failed to get Arrow library flags");
+    }
+
+    let libs = String::from_utf8(output.stdout)?.trim().to_string();
+
+    Ok(ArrowConfig { cflags, libs })
+}
+
+fn build_package(package: &str) -> eyre::Result<()> {
+    let cargo = std::env::var("CARGO").unwrap();
+    let mut cmd = std::process::Command::new(&cargo);
+    cmd.arg("build");
+    cmd.arg("--package").arg(package);
+    if !cmd.status()?.success() {
+        bail!("failed to build {package}");
+    };
+    Ok(())
+}
+
+fn build_cxx_node(root: &Path, paths: &[&Path], out_name: &str, args: &[&str]) -> eyre::Result<()> {
+    let mut clang = std::process::Command::new("clang++");
+    clang.args(paths);
+    clang.arg("-std=c++20");
+    #[cfg(target_os = "linux")]
+    {
+        clang.arg("-l").arg("m");
+        clang.arg("-l").arg("rt");
+        clang.arg("-l").arg("dl");
+        clang.arg("-l").arg("z");
+        clang.arg("-pthread");
+    }
+    #[cfg(target_os = "windows")]
+    {
+        clang.arg("-ladvapi32");
+        clang.arg("-luserenv");
+        clang.arg("-lkernel32");
+        clang.arg("-lws2_32");
+        clang.arg("-lbcrypt");
+        clang.arg("-lncrypt");
+        clang.arg("-lschannel");
+        clang.arg("-lntdll");
+        clang.arg("-liphlpapi");
+
+        clang.arg("-lcfgmgr32");
+        clang.arg("-lcredui");
+        clang.arg("-lcrypt32");
+        clang.arg("-lcryptnet");
+        clang.arg("-lfwpuclnt");
+        clang.arg("-lgdi32");
+        clang.arg("-lmsimg32");
+        clang.arg("-lmswsock");
+        clang.arg("-lole32");
+        clang.arg("-lopengl32");
+        clang.arg("-lsecur32");
+        clang.arg("-lshell32");
+        clang.arg("-lsynchronization");
+        clang.arg("-luser32");
+        clang.arg("-lwinspool");
+
+        clang.arg("-Wl,-nodefaultlib:libcmt");
+        clang.arg("-D_DLL");
+        clang.arg("-lmsvcrt");
+    }
+    #[cfg(target_os = "macos")]
+    {
+        clang.arg("-framework").arg("CoreServices");
+        clang.arg("-framework").arg("Security");
+        clang.arg("-l").arg("System");
+        clang.arg("-l").arg("resolv");
+        clang.arg("-l").arg("pthread");
+        clang.arg("-l").arg("c");
+        clang.arg("-l").arg("m");
+    }
+    for arg in args {
+        if arg.contains(" ") {
+            for part in arg.split_whitespace() {
+                clang.arg(part);
+            }
+        } else {
+            clang.arg(arg);
+        }
+    }
+    clang.arg("-L").arg(root.join("target").join("debug"));
+    clang
+        .arg("--output")
+        .arg(Path::new("../build").join(format!("{out_name}{EXE_SUFFIX}")));
+    if let Some(parent) = paths[0].parent() {
+        clang.current_dir(parent);
+    }
+
+    if !clang.status()?.success() {
+        bail!("failed to compile c++ node");
+    };
+    Ok(())
+}

--- a/examples/mavlink2-bridge/telemetry-printer-cxx/main.cc
+++ b/examples/mavlink2-bridge/telemetry-printer-cxx/main.cc
@@ -1,0 +1,119 @@
+// C++ consumer for the mavlink2-bridge example.
+//
+// Subscribes to `bridge/heartbeat`, an Apache Arrow StructArray whose
+// schema matches HEARTBEAT_DATA (custom_mode u32, mavtype u32,
+// autopilot u32, base_mode u8, system_status u32, mavlink_version u8).
+// Prints one decoded line per frame.
+//
+// This is a minimal demonstration: it does not echo metadata or send
+// outputs back, just consumes and prints. Pair with `mavlink-sim` and
+// the bridge node to round-trip without an autopilot.
+
+#include <dora-node-api.h>
+#include <arrow/api.h>
+#include <arrow/c/bridge.h>
+#include <cstdint>
+#include <exception>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <utility>
+
+namespace {
+
+// Pull the first row's primitive value out of a child column on a
+// StructArray. Aborts with a descriptive message if the column is
+// missing or the runtime type does not match.
+template <typename ArrayT, typename ValueT>
+ValueT field_value(const arrow::StructArray& s, const std::string& name) {
+    auto field = s.GetFieldByName(name);
+    if (!field) {
+        throw std::runtime_error("StructArray missing field: " + name);
+    }
+    auto typed = std::dynamic_pointer_cast<ArrayT>(field);
+    if (!typed) {
+        throw std::runtime_error(
+            "field " + name + " has unexpected type " + field->type()->ToString());
+    }
+    if (typed->length() == 0) {
+        throw std::runtime_error("field " + name + " is empty");
+    }
+    return static_cast<ValueT>(typed->Value(0));
+}
+
+void print_heartbeat(const arrow::StructArray& s, std::uint64_t seq) {
+    auto custom_mode = field_value<arrow::UInt32Array, std::uint32_t>(s, "custom_mode");
+    auto mavtype = field_value<arrow::UInt32Array, std::uint32_t>(s, "mavtype");
+    auto autopilot = field_value<arrow::UInt32Array, std::uint32_t>(s, "autopilot");
+    auto base_mode = field_value<arrow::UInt8Array, std::uint32_t>(s, "base_mode");
+    auto system_status = field_value<arrow::UInt32Array, std::uint32_t>(s, "system_status");
+    auto mavlink_version =
+        field_value<arrow::UInt8Array, std::uint32_t>(s, "mavlink_version");
+
+    std::cout << "telemetry-printer-cxx: heartbeat #" << seq
+              << " custom_mode=" << custom_mode << " mavtype=" << mavtype
+              << " autopilot=" << autopilot << " base_mode=" << base_mode
+              << " system_status=" << system_status
+              << " mavlink_version=" << mavlink_version << std::endl;
+}
+
+}  // namespace
+
+int main() {
+    try {
+        auto dora_node = init_dora_node();
+        std::cout << "telemetry-printer-cxx: dora node initialized" << std::endl;
+        std::uint64_t received = 0;
+
+        for (;;) {
+            auto event = dora_node.events->next();
+            auto type = event_type(event);
+
+            if (type == DoraEventType::Stop) {
+                std::cout << "telemetry-printer-cxx: STOP after " << received
+                          << " heartbeats" << std::endl;
+                break;
+            } else if (type == DoraEventType::AllInputsClosed) {
+                std::cout << "telemetry-printer-cxx: inputs closed after " << received
+                          << " heartbeats" << std::endl;
+                break;
+            } else if (type == DoraEventType::Input) {
+                struct ArrowArray c_array;
+                struct ArrowSchema c_schema;
+                auto info = event_as_arrow_input_with_info(
+                    std::move(event),
+                    reinterpret_cast<std::uint8_t*>(&c_array),
+                    reinterpret_cast<std::uint8_t*>(&c_schema));
+                if (!info.error.empty()) {
+                    std::cerr << "telemetry-printer-cxx: arrow import: "
+                              << std::string(info.error) << std::endl;
+                    continue;
+                }
+                auto imported = arrow::ImportArray(&c_array, &c_schema);
+                if (!imported.ok()) {
+                    std::cerr << "telemetry-printer-cxx: ImportArray: "
+                              << imported.status().ToString() << std::endl;
+                    continue;
+                }
+                auto array = imported.ValueOrDie();
+                auto s = std::dynamic_pointer_cast<arrow::StructArray>(array);
+                if (!s) {
+                    std::cerr << "telemetry-printer-cxx: expected StructArray, got "
+                              << array->type()->ToString() << std::endl;
+                    continue;
+                }
+                received++;
+                if (std::string(info.id) == "heartbeat") {
+                    print_heartbeat(*s, received);
+                } else {
+                    std::cerr << "telemetry-printer-cxx: unexpected input id: "
+                              << std::string(info.id) << std::endl;
+                }
+            }
+        }
+        return 0;
+    } catch (const std::exception& e) {
+        std::cerr << "telemetry-printer-cxx: fatal: " << e.what() << std::endl;
+        return 1;
+    }
+}

--- a/examples/mavlink2-bridge/telemetry-printer-rust/Cargo.toml
+++ b/examples/mavlink2-bridge/telemetry-printer-rust/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "mavlink2-bridge-example-telemetry-printer-rust"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+
+[dependencies]
+dora-mavlink2-bridge = { workspace = true }
+dora-node-api = { workspace = true }
+arrow = { workspace = true }
+eyre = { workspace = true }

--- a/examples/mavlink2-bridge/telemetry-printer-rust/src/main.rs
+++ b/examples/mavlink2-bridge/telemetry-printer-rust/src/main.rs
@@ -1,0 +1,52 @@
+//! Rust consumer of the `mavlink2-bridge` example.
+//!
+//! Subscribes to `bridge/heartbeat` (a 1-row Arrow `StructArray` matching
+//! `HEARTBEAT_DATA::schema`) and prints each decoded frame. Demonstrates
+//! the MAVLink -> dora -> Rust path; pair with `mavlink-sim` and the
+//! bridge node to round-trip without an autopilot.
+
+use arrow::array::{AsArray, RecordBatch};
+use dora_mavlink2_bridge::{MavlinkArrow, mavlink::common::HEARTBEAT_DATA};
+use dora_node_api::{DoraNode, Event, arrow::array::ArrayRef};
+use eyre::{Result, eyre};
+
+fn decode(value: ArrayRef) -> Result<HEARTBEAT_DATA> {
+    let struct_array = value
+        .as_struct_opt()
+        .ok_or_else(|| eyre!("expected StructArray, got {:?}", value.data_type()))?;
+    let batch = RecordBatch::from(struct_array);
+    HEARTBEAT_DATA::from_record_batch(&batch).map_err(|e| eyre!("decoding HEARTBEAT: {e}"))
+}
+
+fn main() -> Result<()> {
+    let (_node, mut events) = DoraNode::init_from_env().map_err(|e| eyre!("DoraNode init: {e}"))?;
+
+    let mut received: u64 = 0;
+    while let Some(event) = events.recv() {
+        match event {
+            Event::Input { id, data, .. } if id.as_str() == "heartbeat" => {
+                let arr: ArrayRef = data.into();
+                let hb = decode(arr)?;
+                received += 1;
+                println!(
+                    "telemetry-printer-rust: heartbeat #{received} \
+                     custom_mode={} mavtype={:?} autopilot={:?} \
+                     base_mode={:?} system_status={:?} mavlink_version={}",
+                    hb.custom_mode,
+                    hb.mavtype,
+                    hb.autopilot,
+                    hb.base_mode,
+                    hb.system_status,
+                    hb.mavlink_version,
+                );
+            }
+            Event::Input { .. } => {}
+            Event::Stop(_) => {
+                println!("telemetry-printer-rust: STOP after {received} heartbeats");
+                break;
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}

--- a/examples/mavlink2-bridge/telemetry-printer-rust/src/main.rs
+++ b/examples/mavlink2-bridge/telemetry-printer-rust/src/main.rs
@@ -8,7 +8,20 @@
 use arrow::array::{AsArray, RecordBatch};
 use dora_mavlink2_bridge::{MavlinkArrow, mavlink::common::HEARTBEAT_DATA};
 use dora_node_api::{DoraNode, Event, arrow::array::ArrayRef};
-use eyre::{Result, eyre};
+use eyre::{Result, bail, eyre};
+use std::time::{Duration, Instant};
+
+/// How long the sink waits for the first HEARTBEAT before declaring the
+/// bridge silent. The example's `mavlink-sim` emits a HEARTBEAT every
+/// 500 ms, so anything past a few seconds means the bridge connected
+/// but published nothing — the regression the smoke tests need to
+/// catch. The networked smoke harness has a 30 s budget and only
+/// signals STOP at cleanup, so the sink must fail fast on its own
+/// rather than wait for STOP to detect a 0-heartbeat run.
+const FIRST_HEARTBEAT_DEADLINE: Duration = Duration::from_secs(8);
+/// Polling cadence for `recv_timeout`; small enough that the warmup
+/// deadline above is honoured tightly.
+const RECV_POLL: Duration = Duration::from_millis(200);
 
 fn decode(value: ArrayRef) -> Result<HEARTBEAT_DATA> {
     let struct_array = value
@@ -21,8 +34,19 @@ fn decode(value: ArrayRef) -> Result<HEARTBEAT_DATA> {
 fn main() -> Result<()> {
     let (_node, mut events) = DoraNode::init_from_env().map_err(|e| eyre!("DoraNode init: {e}"))?;
 
+    let started = Instant::now();
     let mut received: u64 = 0;
-    while let Some(event) = events.recv() {
+    loop {
+        if received == 0 && started.elapsed() > FIRST_HEARTBEAT_DEADLINE {
+            bail!(
+                "telemetry-printer-rust: no HEARTBEAT received within {:?}; \
+                 bridge appears silent — smoke assertion failed",
+                FIRST_HEARTBEAT_DEADLINE
+            );
+        }
+        let Some(event) = events.recv_timeout(RECV_POLL) else {
+            continue;
+        };
         match event {
             Event::Input { id, data, .. } if id.as_str() == "heartbeat" => {
                 let arr: ArrayRef = data.into();
@@ -47,6 +71,15 @@ fn main() -> Result<()> {
             }
             _ => {}
         }
+    }
+    // Belt-and-suspenders for the local-mode smoke test, which uses
+    // `dora run --stop-after`: STOP can arrive before the warmup
+    // deadline above, so guard the post-loop case too.
+    if received == 0 {
+        bail!(
+            "telemetry-printer-rust: bridge produced 0 heartbeats before STOP — \
+             smoke assertion failed (expected ≥1 decoded HEARTBEAT)"
+        );
     }
     Ok(())
 }

--- a/examples/mavlink2-bridge/telemetry_printer.py
+++ b/examples/mavlink2-bridge/telemetry_printer.py
@@ -1,0 +1,50 @@
+"""Sink node for the mavlink2-bridge example.
+
+Subscribes to the bridge's `heartbeat` output, decodes the per-row
+StructArray fields, and prints a single line per heartbeat. Demonstrates
+the MAVLink -> dora -> Python path of the bridge.
+"""
+
+import logging
+
+from dora import Node
+
+
+def _decode_heartbeat(struct_array) -> dict:
+    """Pull out the first (and only) row of a HEARTBEAT StructArray."""
+    rows = struct_array.to_pylist()
+    if not rows:
+        return {}
+    return rows[0]
+
+
+def main() -> None:
+    node = Node()
+    received = 0
+
+    for event in node:
+        if event["type"] == "INPUT":
+            input_id = event["id"]
+            if input_id == "heartbeat":
+                row = _decode_heartbeat(event["value"])
+                received += 1
+                logging.info(
+                    "heartbeat #%d custom_mode=%s mavtype=%s autopilot=%s system_status=%s",
+                    received,
+                    row.get("custom_mode"),
+                    row.get("mavtype"),
+                    row.get("autopilot"),
+                    row.get("system_status"),
+                )
+            else:
+                logging.warning("Unexpected input id: %s", input_id)
+        elif event["type"] == "STOP":
+            logging.info("telemetry-printer: STOP received after %d heartbeats", received)
+            break
+
+    logging.info("telemetry-printer: done (%d heartbeats decoded)", received)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    main()

--- a/examples/mavlink2-bridge/telemetry_printer.py
+++ b/examples/mavlink2-bridge/telemetry_printer.py
@@ -6,8 +6,20 @@ the MAVLink -> dora -> Python path of the bridge.
 """
 
 import logging
+import time
 
 from dora import Node
+
+# Time budget for the FIRST heartbeat to arrive. Mirrors the Rust sink:
+# the example's mavlink-sim emits a HEARTBEAT every 500 ms, so anything
+# past a few seconds means the bridge connected but published nothing.
+# The networked smoke harness has a 30 s budget and only signals STOP
+# at cleanup, so the sink must fail fast on its own to flip the
+# dataflow into Failed state before the harness times out.
+FIRST_HEARTBEAT_DEADLINE_SECS = 8.0
+# Polling cadence for `node.next(timeout=...)`; small enough that the
+# warmup deadline above is honoured tightly.
+RECV_POLL_SECS = 0.2
 
 
 def _decode_heartbeat(struct_array) -> dict:
@@ -21,8 +33,18 @@ def _decode_heartbeat(struct_array) -> dict:
 def main() -> None:
     node = Node()
     received = 0
+    started = time.monotonic()
 
-    for event in node:
+    while True:
+        if received == 0 and (time.monotonic() - started) > FIRST_HEARTBEAT_DEADLINE_SECS:
+            raise SystemExit(
+                f"telemetry-printer: no HEARTBEAT received within "
+                f"{FIRST_HEARTBEAT_DEADLINE_SECS:.0f}s; bridge appears silent — "
+                f"smoke assertion failed"
+            )
+        event = node.next(timeout=RECV_POLL_SECS)
+        if event is None:
+            continue
         if event["type"] == "INPUT":
             input_id = event["id"]
             if input_id == "heartbeat":
@@ -43,6 +65,14 @@ def main() -> None:
             break
 
     logging.info("telemetry-printer: done (%d heartbeats decoded)", received)
+    # Belt-and-suspenders for the local-mode smoke test, which uses
+    # `dora run --stop-after`: STOP can arrive before the warmup
+    # deadline above, so guard the post-loop case too.
+    if received == 0:
+        raise SystemExit(
+            "telemetry-printer: bridge produced 0 heartbeats before STOP — "
+            "smoke assertion failed (expected >=1 decoded HEARTBEAT)"
+        )
 
 
 if __name__ == "__main__":

--- a/libraries/extensions/mavlink2-bridge/Cargo.toml
+++ b/libraries/extensions/mavlink2-bridge/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "dora-mavlink2-bridge"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+documentation.workspace = true
+readme.workspace = true
+description = "MAVLink 2 bridge for dora-rs"
+
+[dependencies]
+mavlink = { workspace = true }
+arrow = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+eyre = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full"] }

--- a/libraries/extensions/mavlink2-bridge/Cargo.toml
+++ b/libraries/extensions/mavlink2-bridge/Cargo.toml
@@ -15,6 +15,7 @@ serde = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 eyre = { workspace = true }
+num-traits = "0.2"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }

--- a/libraries/extensions/mavlink2-bridge/Cargo.toml
+++ b/libraries/extensions/mavlink2-bridge/Cargo.toml
@@ -16,6 +16,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 eyre = { workspace = true }
 num-traits = "0.2"
+url = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }

--- a/libraries/extensions/mavlink2-bridge/src/arrow_convert.rs
+++ b/libraries/extensions/mavlink2-bridge/src/arrow_convert.rs
@@ -1,75 +1,803 @@
+//! `MavlinkArrow` trait and per-message impls for the common dialect.
+//!
+//! Arrow-side conventions used by every impl:
+//!
+//! * One row per call. `to_record_batch` returns a 1-row `RecordBatch`;
+//!   `from_record_batch` reads row 0.
+//! * All MAVLink enums (regardless of wire width) are stored as `UInt32`
+//!   to match the Rust `repr(u32)` of the generated enum types.
+//! * Bitflag fields are stored at their bitflag's natural width
+//!   (`MavModeFlag` is `u8`, `MavSysStatusSensor` is `u32`).
+//! * Primitive fields keep their wire width unchanged.
+//! * Fixed-size arrays (e.g. `STATUSTEXT::text[50]`,
+//!   `BATTERY_STATUS::voltages[10]`) are deferred to a follow-up.
+
 use crate::{BridgeError, BridgeResult};
-use arrow::array::{Array, AsArray, RecordBatch, UInt8Array, UInt32Array};
-use arrow::datatypes::{DataType, Field, Schema, UInt8Type, UInt32Type};
+use arrow::array::{
+    ArrayRef, AsArray, Float32Array, Int8Array, Int16Array, Int32Array, RecordBatch, UInt8Array,
+    UInt16Array, UInt32Array, UInt64Array,
+};
+use arrow::datatypes::{
+    DataType, Field, Float32Type, Int8Type, Int16Type, Int32Type, Schema, UInt8Type, UInt16Type,
+    UInt32Type, UInt64Type,
+};
 use mavlink::common;
 use num_traits::FromPrimitive;
 use std::sync::Arc;
 
 /// Bidirectional conversion between a MAVLink 2 message struct and a 1-row
-/// Apache Arrow `RecordBatch`. Implemented per message type; for batched
-/// telemetry, callers stream individual batches and concatenate downstream.
+/// Apache Arrow `RecordBatch`. Each impl is symmetric: the schema returned
+/// by [`schema`] is what [`to_record_batch`] emits and what
+/// [`from_record_batch`] expects.
+///
+/// [`schema`]: MavlinkArrow::schema
+/// [`to_record_batch`]: MavlinkArrow::to_record_batch
+/// [`from_record_batch`]: MavlinkArrow::from_record_batch
 pub trait MavlinkArrow: Sized {
-    /// Arrow schema describing this message's fields.
     fn schema() -> Schema;
-
-    /// Encode `self` into a 1-row Arrow `RecordBatch`.
     fn to_record_batch(&self) -> BridgeResult<RecordBatch>;
-
-    /// Decode the first row of a `RecordBatch` back into the message struct.
     fn from_record_batch(batch: &RecordBatch) -> BridgeResult<Self>;
 }
 
-fn read_u32(batch: &RecordBatch, name: &str) -> BridgeResult<u32> {
-    let col = batch
-        .column_by_name(name)
-        .ok_or_else(|| BridgeError::Config(format!("missing column: {name}")))?;
-    Ok(col.as_primitive::<UInt32Type>().value(0))
+// -----------------------------------------------------------------------------
+// helpers
+// -----------------------------------------------------------------------------
+
+fn missing(name: &str) -> BridgeError {
+    BridgeError::Config(format!("missing column: {name}"))
 }
 
+fn build(fields: Vec<Field>, columns: Vec<ArrayRef>) -> BridgeResult<RecordBatch> {
+    Ok(RecordBatch::try_new(
+        Arc::new(Schema::new(fields)),
+        columns,
+    )?)
+}
+
+// readers
 fn read_u8(batch: &RecordBatch, name: &str) -> BridgeResult<u8> {
-    let col = batch
+    Ok(batch
         .column_by_name(name)
-        .ok_or_else(|| BridgeError::Config(format!("missing column: {name}")))?;
-    Ok(col.as_primitive::<UInt8Type>().value(0))
+        .ok_or_else(|| missing(name))?
+        .as_primitive::<UInt8Type>()
+        .value(0))
+}
+fn read_u16(batch: &RecordBatch, name: &str) -> BridgeResult<u16> {
+    Ok(batch
+        .column_by_name(name)
+        .ok_or_else(|| missing(name))?
+        .as_primitive::<UInt16Type>()
+        .value(0))
+}
+fn read_u32(batch: &RecordBatch, name: &str) -> BridgeResult<u32> {
+    Ok(batch
+        .column_by_name(name)
+        .ok_or_else(|| missing(name))?
+        .as_primitive::<UInt32Type>()
+        .value(0))
+}
+fn read_u64(batch: &RecordBatch, name: &str) -> BridgeResult<u64> {
+    Ok(batch
+        .column_by_name(name)
+        .ok_or_else(|| missing(name))?
+        .as_primitive::<UInt64Type>()
+        .value(0))
+}
+fn read_i8(batch: &RecordBatch, name: &str) -> BridgeResult<i8> {
+    Ok(batch
+        .column_by_name(name)
+        .ok_or_else(|| missing(name))?
+        .as_primitive::<Int8Type>()
+        .value(0))
+}
+fn read_i16(batch: &RecordBatch, name: &str) -> BridgeResult<i16> {
+    Ok(batch
+        .column_by_name(name)
+        .ok_or_else(|| missing(name))?
+        .as_primitive::<Int16Type>()
+        .value(0))
+}
+fn read_i32(batch: &RecordBatch, name: &str) -> BridgeResult<i32> {
+    Ok(batch
+        .column_by_name(name)
+        .ok_or_else(|| missing(name))?
+        .as_primitive::<Int32Type>()
+        .value(0))
+}
+fn read_f32(batch: &RecordBatch, name: &str) -> BridgeResult<f32> {
+    Ok(batch
+        .column_by_name(name)
+        .ok_or_else(|| missing(name))?
+        .as_primitive::<Float32Type>()
+        .value(0))
+}
+// builders (single-row Arrow arrays from a single value)
+fn arr_u8(v: u8) -> ArrayRef {
+    Arc::new(UInt8Array::from(vec![v]))
+}
+fn arr_u16(v: u16) -> ArrayRef {
+    Arc::new(UInt16Array::from(vec![v]))
+}
+fn arr_u32(v: u32) -> ArrayRef {
+    Arc::new(UInt32Array::from(vec![v]))
+}
+fn arr_u64(v: u64) -> ArrayRef {
+    Arc::new(UInt64Array::from(vec![v]))
+}
+fn arr_i8(v: i8) -> ArrayRef {
+    Arc::new(Int8Array::from(vec![v]))
+}
+fn arr_i16(v: i16) -> ArrayRef {
+    Arc::new(Int16Array::from(vec![v]))
+}
+fn arr_i32(v: i32) -> ArrayRef {
+    Arc::new(Int32Array::from(vec![v]))
+}
+fn arr_f32(v: f32) -> ArrayRef {
+    Arc::new(Float32Array::from(vec![v]))
+}
+/// Decode a MAVLink enum value (always stored as `u32` in our Arrow
+/// schema) into the strongly-typed enum. All common-dialect enums are
+/// `repr(u32)` and derive `num_traits::FromPrimitive`.
+fn decode_enum<E: FromPrimitive>(v: u32, name: &str) -> BridgeResult<E> {
+    E::from_u32(v).ok_or_else(|| BridgeError::Mavlink(format!("invalid {name} discriminant: {v}")))
 }
 
-fn decode_enum<E: FromPrimitive>(v: u8, name: &str) -> BridgeResult<E> {
-    E::from_u8(v).ok_or_else(|| BridgeError::Mavlink(format!("invalid {name} discriminant: {v}")))
-}
+// -----------------------------------------------------------------------------
+// HEARTBEAT
+// -----------------------------------------------------------------------------
 
 impl MavlinkArrow for common::HEARTBEAT_DATA {
     fn schema() -> Schema {
         Schema::new(vec![
             Field::new("custom_mode", DataType::UInt32, false),
-            Field::new("mavtype", DataType::UInt8, false),
-            Field::new("autopilot", DataType::UInt8, false),
+            Field::new("mavtype", DataType::UInt32, false),
+            Field::new("autopilot", DataType::UInt32, false),
             Field::new("base_mode", DataType::UInt8, false),
-            Field::new("system_status", DataType::UInt8, false),
+            Field::new("system_status", DataType::UInt32, false),
             Field::new("mavlink_version", DataType::UInt8, false),
         ])
     }
 
     fn to_record_batch(&self) -> BridgeResult<RecordBatch> {
-        let schema = Arc::new(Self::schema());
-        let columns: Vec<Arc<dyn Array>> = vec![
-            Arc::new(UInt32Array::from(vec![self.custom_mode])),
-            Arc::new(UInt8Array::from(vec![self.mavtype as u8])),
-            Arc::new(UInt8Array::from(vec![self.autopilot as u8])),
-            Arc::new(UInt8Array::from(vec![self.base_mode.bits()])),
-            Arc::new(UInt8Array::from(vec![self.system_status as u8])),
-            Arc::new(UInt8Array::from(vec![self.mavlink_version])),
-        ];
-        Ok(RecordBatch::try_new(schema, columns)?)
+        build(
+            Self::schema()
+                .fields()
+                .iter()
+                .map(|f| f.as_ref().clone())
+                .collect(),
+            vec![
+                arr_u32(self.custom_mode),
+                arr_u32(self.mavtype as u32),
+                arr_u32(self.autopilot as u32),
+                arr_u8(self.base_mode.bits()),
+                arr_u32(self.system_status as u32),
+                arr_u8(self.mavlink_version),
+            ],
+        )
     }
 
     fn from_record_batch(batch: &RecordBatch) -> BridgeResult<Self> {
         Ok(Self {
             custom_mode: read_u32(batch, "custom_mode")?,
-            mavtype: decode_enum(read_u8(batch, "mavtype")?, "mavtype")?,
-            autopilot: decode_enum(read_u8(batch, "autopilot")?, "autopilot")?,
+            mavtype: decode_enum(read_u32(batch, "mavtype")?, "mavtype")?,
+            autopilot: decode_enum(read_u32(batch, "autopilot")?, "autopilot")?,
             base_mode: common::MavModeFlag::from_bits_truncate(read_u8(batch, "base_mode")?),
-            system_status: decode_enum(read_u8(batch, "system_status")?, "system_status")?,
+            system_status: decode_enum(read_u32(batch, "system_status")?, "system_status")?,
             mavlink_version: read_u8(batch, "mavlink_version")?,
+        })
+    }
+}
+
+// -----------------------------------------------------------------------------
+// SYS_STATUS
+// -----------------------------------------------------------------------------
+
+impl MavlinkArrow for common::SYS_STATUS_DATA {
+    fn schema() -> Schema {
+        Schema::new(vec![
+            Field::new("onboard_control_sensors_present", DataType::UInt32, false),
+            Field::new("onboard_control_sensors_enabled", DataType::UInt32, false),
+            Field::new("onboard_control_sensors_health", DataType::UInt32, false),
+            Field::new("load", DataType::UInt16, false),
+            Field::new("voltage_battery", DataType::UInt16, false),
+            Field::new("current_battery", DataType::Int16, false),
+            Field::new("drop_rate_comm", DataType::UInt16, false),
+            Field::new("errors_comm", DataType::UInt16, false),
+            Field::new("errors_count1", DataType::UInt16, false),
+            Field::new("errors_count2", DataType::UInt16, false),
+            Field::new("errors_count3", DataType::UInt16, false),
+            Field::new("errors_count4", DataType::UInt16, false),
+            Field::new("battery_remaining", DataType::Int8, false),
+        ])
+    }
+
+    fn to_record_batch(&self) -> BridgeResult<RecordBatch> {
+        build(
+            Self::schema()
+                .fields()
+                .iter()
+                .map(|f| f.as_ref().clone())
+                .collect(),
+            vec![
+                arr_u32(self.onboard_control_sensors_present.bits()),
+                arr_u32(self.onboard_control_sensors_enabled.bits()),
+                arr_u32(self.onboard_control_sensors_health.bits()),
+                arr_u16(self.load),
+                arr_u16(self.voltage_battery),
+                arr_i16(self.current_battery),
+                arr_u16(self.drop_rate_comm),
+                arr_u16(self.errors_comm),
+                arr_u16(self.errors_count1),
+                arr_u16(self.errors_count2),
+                arr_u16(self.errors_count3),
+                arr_u16(self.errors_count4),
+                arr_i8(self.battery_remaining),
+            ],
+        )
+    }
+
+    fn from_record_batch(batch: &RecordBatch) -> BridgeResult<Self> {
+        Ok(Self {
+            onboard_control_sensors_present: common::MavSysStatusSensor::from_bits_truncate(
+                read_u32(batch, "onboard_control_sensors_present")?,
+            ),
+            onboard_control_sensors_enabled: common::MavSysStatusSensor::from_bits_truncate(
+                read_u32(batch, "onboard_control_sensors_enabled")?,
+            ),
+            onboard_control_sensors_health: common::MavSysStatusSensor::from_bits_truncate(
+                read_u32(batch, "onboard_control_sensors_health")?,
+            ),
+            load: read_u16(batch, "load")?,
+            voltage_battery: read_u16(batch, "voltage_battery")?,
+            current_battery: read_i16(batch, "current_battery")?,
+            drop_rate_comm: read_u16(batch, "drop_rate_comm")?,
+            errors_comm: read_u16(batch, "errors_comm")?,
+            errors_count1: read_u16(batch, "errors_count1")?,
+            errors_count2: read_u16(batch, "errors_count2")?,
+            errors_count3: read_u16(batch, "errors_count3")?,
+            errors_count4: read_u16(batch, "errors_count4")?,
+            battery_remaining: read_i8(batch, "battery_remaining")?,
+        })
+    }
+}
+
+// -----------------------------------------------------------------------------
+// SYSTEM_TIME
+// -----------------------------------------------------------------------------
+
+impl MavlinkArrow for common::SYSTEM_TIME_DATA {
+    fn schema() -> Schema {
+        Schema::new(vec![
+            Field::new("time_unix_usec", DataType::UInt64, false),
+            Field::new("time_boot_ms", DataType::UInt32, false),
+        ])
+    }
+
+    fn to_record_batch(&self) -> BridgeResult<RecordBatch> {
+        build(
+            Self::schema()
+                .fields()
+                .iter()
+                .map(|f| f.as_ref().clone())
+                .collect(),
+            vec![arr_u64(self.time_unix_usec), arr_u32(self.time_boot_ms)],
+        )
+    }
+
+    fn from_record_batch(batch: &RecordBatch) -> BridgeResult<Self> {
+        Ok(Self {
+            time_unix_usec: read_u64(batch, "time_unix_usec")?,
+            time_boot_ms: read_u32(batch, "time_boot_ms")?,
+        })
+    }
+}
+
+// -----------------------------------------------------------------------------
+// ATTITUDE
+// -----------------------------------------------------------------------------
+
+impl MavlinkArrow for common::ATTITUDE_DATA {
+    fn schema() -> Schema {
+        Schema::new(vec![
+            Field::new("time_boot_ms", DataType::UInt32, false),
+            Field::new("roll", DataType::Float32, false),
+            Field::new("pitch", DataType::Float32, false),
+            Field::new("yaw", DataType::Float32, false),
+            Field::new("rollspeed", DataType::Float32, false),
+            Field::new("pitchspeed", DataType::Float32, false),
+            Field::new("yawspeed", DataType::Float32, false),
+        ])
+    }
+
+    fn to_record_batch(&self) -> BridgeResult<RecordBatch> {
+        build(
+            Self::schema()
+                .fields()
+                .iter()
+                .map(|f| f.as_ref().clone())
+                .collect(),
+            vec![
+                arr_u32(self.time_boot_ms),
+                arr_f32(self.roll),
+                arr_f32(self.pitch),
+                arr_f32(self.yaw),
+                arr_f32(self.rollspeed),
+                arr_f32(self.pitchspeed),
+                arr_f32(self.yawspeed),
+            ],
+        )
+    }
+
+    fn from_record_batch(batch: &RecordBatch) -> BridgeResult<Self> {
+        Ok(Self {
+            time_boot_ms: read_u32(batch, "time_boot_ms")?,
+            roll: read_f32(batch, "roll")?,
+            pitch: read_f32(batch, "pitch")?,
+            yaw: read_f32(batch, "yaw")?,
+            rollspeed: read_f32(batch, "rollspeed")?,
+            pitchspeed: read_f32(batch, "pitchspeed")?,
+            yawspeed: read_f32(batch, "yawspeed")?,
+        })
+    }
+}
+
+// -----------------------------------------------------------------------------
+// ATTITUDE_QUATERNION
+// -----------------------------------------------------------------------------
+
+impl MavlinkArrow for common::ATTITUDE_QUATERNION_DATA {
+    fn schema() -> Schema {
+        Schema::new(vec![
+            Field::new("time_boot_ms", DataType::UInt32, false),
+            Field::new("q1", DataType::Float32, false),
+            Field::new("q2", DataType::Float32, false),
+            Field::new("q3", DataType::Float32, false),
+            Field::new("q4", DataType::Float32, false),
+            Field::new("rollspeed", DataType::Float32, false),
+            Field::new("pitchspeed", DataType::Float32, false),
+            Field::new("yawspeed", DataType::Float32, false),
+        ])
+    }
+
+    fn to_record_batch(&self) -> BridgeResult<RecordBatch> {
+        build(
+            Self::schema()
+                .fields()
+                .iter()
+                .map(|f| f.as_ref().clone())
+                .collect(),
+            vec![
+                arr_u32(self.time_boot_ms),
+                arr_f32(self.q1),
+                arr_f32(self.q2),
+                arr_f32(self.q3),
+                arr_f32(self.q4),
+                arr_f32(self.rollspeed),
+                arr_f32(self.pitchspeed),
+                arr_f32(self.yawspeed),
+            ],
+        )
+    }
+
+    fn from_record_batch(batch: &RecordBatch) -> BridgeResult<Self> {
+        Ok(Self {
+            time_boot_ms: read_u32(batch, "time_boot_ms")?,
+            q1: read_f32(batch, "q1")?,
+            q2: read_f32(batch, "q2")?,
+            q3: read_f32(batch, "q3")?,
+            q4: read_f32(batch, "q4")?,
+            rollspeed: read_f32(batch, "rollspeed")?,
+            pitchspeed: read_f32(batch, "pitchspeed")?,
+            yawspeed: read_f32(batch, "yawspeed")?,
+        })
+    }
+}
+
+// -----------------------------------------------------------------------------
+// LOCAL_POSITION_NED
+// -----------------------------------------------------------------------------
+
+impl MavlinkArrow for common::LOCAL_POSITION_NED_DATA {
+    fn schema() -> Schema {
+        Schema::new(vec![
+            Field::new("time_boot_ms", DataType::UInt32, false),
+            Field::new("x", DataType::Float32, false),
+            Field::new("y", DataType::Float32, false),
+            Field::new("z", DataType::Float32, false),
+            Field::new("vx", DataType::Float32, false),
+            Field::new("vy", DataType::Float32, false),
+            Field::new("vz", DataType::Float32, false),
+        ])
+    }
+
+    fn to_record_batch(&self) -> BridgeResult<RecordBatch> {
+        build(
+            Self::schema()
+                .fields()
+                .iter()
+                .map(|f| f.as_ref().clone())
+                .collect(),
+            vec![
+                arr_u32(self.time_boot_ms),
+                arr_f32(self.x),
+                arr_f32(self.y),
+                arr_f32(self.z),
+                arr_f32(self.vx),
+                arr_f32(self.vy),
+                arr_f32(self.vz),
+            ],
+        )
+    }
+
+    fn from_record_batch(batch: &RecordBatch) -> BridgeResult<Self> {
+        Ok(Self {
+            time_boot_ms: read_u32(batch, "time_boot_ms")?,
+            x: read_f32(batch, "x")?,
+            y: read_f32(batch, "y")?,
+            z: read_f32(batch, "z")?,
+            vx: read_f32(batch, "vx")?,
+            vy: read_f32(batch, "vy")?,
+            vz: read_f32(batch, "vz")?,
+        })
+    }
+}
+
+// -----------------------------------------------------------------------------
+// GLOBAL_POSITION_INT
+// -----------------------------------------------------------------------------
+
+impl MavlinkArrow for common::GLOBAL_POSITION_INT_DATA {
+    fn schema() -> Schema {
+        Schema::new(vec![
+            Field::new("time_boot_ms", DataType::UInt32, false),
+            Field::new("lat", DataType::Int32, false),
+            Field::new("lon", DataType::Int32, false),
+            Field::new("alt", DataType::Int32, false),
+            Field::new("relative_alt", DataType::Int32, false),
+            Field::new("vx", DataType::Int16, false),
+            Field::new("vy", DataType::Int16, false),
+            Field::new("vz", DataType::Int16, false),
+            Field::new("hdg", DataType::UInt16, false),
+        ])
+    }
+
+    fn to_record_batch(&self) -> BridgeResult<RecordBatch> {
+        build(
+            Self::schema()
+                .fields()
+                .iter()
+                .map(|f| f.as_ref().clone())
+                .collect(),
+            vec![
+                arr_u32(self.time_boot_ms),
+                arr_i32(self.lat),
+                arr_i32(self.lon),
+                arr_i32(self.alt),
+                arr_i32(self.relative_alt),
+                arr_i16(self.vx),
+                arr_i16(self.vy),
+                arr_i16(self.vz),
+                arr_u16(self.hdg),
+            ],
+        )
+    }
+
+    fn from_record_batch(batch: &RecordBatch) -> BridgeResult<Self> {
+        Ok(Self {
+            time_boot_ms: read_u32(batch, "time_boot_ms")?,
+            lat: read_i32(batch, "lat")?,
+            lon: read_i32(batch, "lon")?,
+            alt: read_i32(batch, "alt")?,
+            relative_alt: read_i32(batch, "relative_alt")?,
+            vx: read_i16(batch, "vx")?,
+            vy: read_i16(batch, "vy")?,
+            vz: read_i16(batch, "vz")?,
+            hdg: read_u16(batch, "hdg")?,
+        })
+    }
+}
+
+// -----------------------------------------------------------------------------
+// GPS_RAW_INT
+// -----------------------------------------------------------------------------
+
+impl MavlinkArrow for common::GPS_RAW_INT_DATA {
+    fn schema() -> Schema {
+        Schema::new(vec![
+            Field::new("time_usec", DataType::UInt64, false),
+            Field::new("lat", DataType::Int32, false),
+            Field::new("lon", DataType::Int32, false),
+            Field::new("alt", DataType::Int32, false),
+            Field::new("eph", DataType::UInt16, false),
+            Field::new("epv", DataType::UInt16, false),
+            Field::new("vel", DataType::UInt16, false),
+            Field::new("cog", DataType::UInt16, false),
+            Field::new("fix_type", DataType::UInt32, false),
+            Field::new("satellites_visible", DataType::UInt8, false),
+        ])
+    }
+
+    fn to_record_batch(&self) -> BridgeResult<RecordBatch> {
+        build(
+            Self::schema()
+                .fields()
+                .iter()
+                .map(|f| f.as_ref().clone())
+                .collect(),
+            vec![
+                arr_u64(self.time_usec),
+                arr_i32(self.lat),
+                arr_i32(self.lon),
+                arr_i32(self.alt),
+                arr_u16(self.eph),
+                arr_u16(self.epv),
+                arr_u16(self.vel),
+                arr_u16(self.cog),
+                arr_u32(self.fix_type as u32),
+                arr_u8(self.satellites_visible),
+            ],
+        )
+    }
+
+    fn from_record_batch(batch: &RecordBatch) -> BridgeResult<Self> {
+        Ok(Self {
+            time_usec: read_u64(batch, "time_usec")?,
+            lat: read_i32(batch, "lat")?,
+            lon: read_i32(batch, "lon")?,
+            alt: read_i32(batch, "alt")?,
+            eph: read_u16(batch, "eph")?,
+            epv: read_u16(batch, "epv")?,
+            vel: read_u16(batch, "vel")?,
+            cog: read_u16(batch, "cog")?,
+            fix_type: decode_enum(read_u32(batch, "fix_type")?, "fix_type")?,
+            satellites_visible: read_u8(batch, "satellites_visible")?,
+        })
+    }
+}
+
+// -----------------------------------------------------------------------------
+// RC_CHANNELS (18 raw channels)
+// -----------------------------------------------------------------------------
+
+impl MavlinkArrow for common::RC_CHANNELS_DATA {
+    fn schema() -> Schema {
+        let mut fields = vec![Field::new("time_boot_ms", DataType::UInt32, false)];
+        for n in 1..=18 {
+            fields.push(Field::new(format!("chan{n}_raw"), DataType::UInt16, false));
+        }
+        fields.push(Field::new("chancount", DataType::UInt8, false));
+        fields.push(Field::new("rssi", DataType::UInt8, false));
+        Schema::new(fields)
+    }
+
+    fn to_record_batch(&self) -> BridgeResult<RecordBatch> {
+        build(
+            Self::schema()
+                .fields()
+                .iter()
+                .map(|f| f.as_ref().clone())
+                .collect(),
+            vec![
+                arr_u32(self.time_boot_ms),
+                arr_u16(self.chan1_raw),
+                arr_u16(self.chan2_raw),
+                arr_u16(self.chan3_raw),
+                arr_u16(self.chan4_raw),
+                arr_u16(self.chan5_raw),
+                arr_u16(self.chan6_raw),
+                arr_u16(self.chan7_raw),
+                arr_u16(self.chan8_raw),
+                arr_u16(self.chan9_raw),
+                arr_u16(self.chan10_raw),
+                arr_u16(self.chan11_raw),
+                arr_u16(self.chan12_raw),
+                arr_u16(self.chan13_raw),
+                arr_u16(self.chan14_raw),
+                arr_u16(self.chan15_raw),
+                arr_u16(self.chan16_raw),
+                arr_u16(self.chan17_raw),
+                arr_u16(self.chan18_raw),
+                arr_u8(self.chancount),
+                arr_u8(self.rssi),
+            ],
+        )
+    }
+
+    fn from_record_batch(batch: &RecordBatch) -> BridgeResult<Self> {
+        Ok(Self {
+            time_boot_ms: read_u32(batch, "time_boot_ms")?,
+            chan1_raw: read_u16(batch, "chan1_raw")?,
+            chan2_raw: read_u16(batch, "chan2_raw")?,
+            chan3_raw: read_u16(batch, "chan3_raw")?,
+            chan4_raw: read_u16(batch, "chan4_raw")?,
+            chan5_raw: read_u16(batch, "chan5_raw")?,
+            chan6_raw: read_u16(batch, "chan6_raw")?,
+            chan7_raw: read_u16(batch, "chan7_raw")?,
+            chan8_raw: read_u16(batch, "chan8_raw")?,
+            chan9_raw: read_u16(batch, "chan9_raw")?,
+            chan10_raw: read_u16(batch, "chan10_raw")?,
+            chan11_raw: read_u16(batch, "chan11_raw")?,
+            chan12_raw: read_u16(batch, "chan12_raw")?,
+            chan13_raw: read_u16(batch, "chan13_raw")?,
+            chan14_raw: read_u16(batch, "chan14_raw")?,
+            chan15_raw: read_u16(batch, "chan15_raw")?,
+            chan16_raw: read_u16(batch, "chan16_raw")?,
+            chan17_raw: read_u16(batch, "chan17_raw")?,
+            chan18_raw: read_u16(batch, "chan18_raw")?,
+            chancount: read_u8(batch, "chancount")?,
+            rssi: read_u8(batch, "rssi")?,
+        })
+    }
+}
+
+// -----------------------------------------------------------------------------
+// SERVO_OUTPUT_RAW
+// -----------------------------------------------------------------------------
+
+impl MavlinkArrow for common::SERVO_OUTPUT_RAW_DATA {
+    fn schema() -> Schema {
+        let mut fields = vec![Field::new("time_usec", DataType::UInt32, false)];
+        for n in 1..=8 {
+            fields.push(Field::new(format!("servo{n}_raw"), DataType::UInt16, false));
+        }
+        fields.push(Field::new("port", DataType::UInt8, false));
+        Schema::new(fields)
+    }
+
+    fn to_record_batch(&self) -> BridgeResult<RecordBatch> {
+        build(
+            Self::schema()
+                .fields()
+                .iter()
+                .map(|f| f.as_ref().clone())
+                .collect(),
+            vec![
+                arr_u32(self.time_usec),
+                arr_u16(self.servo1_raw),
+                arr_u16(self.servo2_raw),
+                arr_u16(self.servo3_raw),
+                arr_u16(self.servo4_raw),
+                arr_u16(self.servo5_raw),
+                arr_u16(self.servo6_raw),
+                arr_u16(self.servo7_raw),
+                arr_u16(self.servo8_raw),
+                arr_u8(self.port),
+            ],
+        )
+    }
+
+    fn from_record_batch(batch: &RecordBatch) -> BridgeResult<Self> {
+        Ok(Self {
+            time_usec: read_u32(batch, "time_usec")?,
+            servo1_raw: read_u16(batch, "servo1_raw")?,
+            servo2_raw: read_u16(batch, "servo2_raw")?,
+            servo3_raw: read_u16(batch, "servo3_raw")?,
+            servo4_raw: read_u16(batch, "servo4_raw")?,
+            servo5_raw: read_u16(batch, "servo5_raw")?,
+            servo6_raw: read_u16(batch, "servo6_raw")?,
+            servo7_raw: read_u16(batch, "servo7_raw")?,
+            servo8_raw: read_u16(batch, "servo8_raw")?,
+            port: read_u8(batch, "port")?,
+        })
+    }
+}
+
+// -----------------------------------------------------------------------------
+// COMMAND_LONG
+// -----------------------------------------------------------------------------
+
+impl MavlinkArrow for common::COMMAND_LONG_DATA {
+    fn schema() -> Schema {
+        Schema::new(vec![
+            Field::new("param1", DataType::Float32, false),
+            Field::new("param2", DataType::Float32, false),
+            Field::new("param3", DataType::Float32, false),
+            Field::new("param4", DataType::Float32, false),
+            Field::new("param5", DataType::Float32, false),
+            Field::new("param6", DataType::Float32, false),
+            Field::new("param7", DataType::Float32, false),
+            Field::new("command", DataType::UInt32, false),
+            Field::new("target_system", DataType::UInt8, false),
+            Field::new("target_component", DataType::UInt8, false),
+            Field::new("confirmation", DataType::UInt8, false),
+        ])
+    }
+
+    fn to_record_batch(&self) -> BridgeResult<RecordBatch> {
+        build(
+            Self::schema()
+                .fields()
+                .iter()
+                .map(|f| f.as_ref().clone())
+                .collect(),
+            vec![
+                arr_f32(self.param1),
+                arr_f32(self.param2),
+                arr_f32(self.param3),
+                arr_f32(self.param4),
+                arr_f32(self.param5),
+                arr_f32(self.param6),
+                arr_f32(self.param7),
+                arr_u32(self.command as u32),
+                arr_u8(self.target_system),
+                arr_u8(self.target_component),
+                arr_u8(self.confirmation),
+            ],
+        )
+    }
+
+    fn from_record_batch(batch: &RecordBatch) -> BridgeResult<Self> {
+        Ok(Self {
+            param1: read_f32(batch, "param1")?,
+            param2: read_f32(batch, "param2")?,
+            param3: read_f32(batch, "param3")?,
+            param4: read_f32(batch, "param4")?,
+            param5: read_f32(batch, "param5")?,
+            param6: read_f32(batch, "param6")?,
+            param7: read_f32(batch, "param7")?,
+            command: decode_enum(read_u32(batch, "command")?, "command")?,
+            target_system: read_u8(batch, "target_system")?,
+            target_component: read_u8(batch, "target_component")?,
+            confirmation: read_u8(batch, "confirmation")?,
+        })
+    }
+}
+
+// -----------------------------------------------------------------------------
+// COMMAND_ACK
+// -----------------------------------------------------------------------------
+
+impl MavlinkArrow for common::COMMAND_ACK_DATA {
+    fn schema() -> Schema {
+        Schema::new(vec![
+            Field::new("command", DataType::UInt32, false),
+            Field::new("result", DataType::UInt32, false),
+        ])
+    }
+
+    fn to_record_batch(&self) -> BridgeResult<RecordBatch> {
+        build(
+            Self::schema()
+                .fields()
+                .iter()
+                .map(|f| f.as_ref().clone())
+                .collect(),
+            vec![arr_u32(self.command as u32), arr_u32(self.result as u32)],
+        )
+    }
+
+    fn from_record_batch(batch: &RecordBatch) -> BridgeResult<Self> {
+        Ok(Self {
+            command: decode_enum(read_u32(batch, "command")?, "command")?,
+            result: decode_enum(read_u32(batch, "result")?, "result")?,
+        })
+    }
+}
+
+// -----------------------------------------------------------------------------
+// MISSION_CURRENT
+// -----------------------------------------------------------------------------
+
+impl MavlinkArrow for common::MISSION_CURRENT_DATA {
+    fn schema() -> Schema {
+        Schema::new(vec![Field::new("seq", DataType::UInt16, false)])
+    }
+
+    fn to_record_batch(&self) -> BridgeResult<RecordBatch> {
+        build(
+            Self::schema()
+                .fields()
+                .iter()
+                .map(|f| f.as_ref().clone())
+                .collect(),
+            vec![arr_u16(self.seq)],
+        )
+    }
+
+    fn from_record_batch(batch: &RecordBatch) -> BridgeResult<Self> {
+        Ok(Self {
+            seq: read_u16(batch, "seq")?,
         })
     }
 }

--- a/libraries/extensions/mavlink2-bridge/src/arrow_convert.rs
+++ b/libraries/extensions/mavlink2-bridge/src/arrow_convert.rs
@@ -980,6 +980,87 @@ impl MavlinkArrow for common::SET_POSITION_TARGET_GLOBAL_INT_DATA {
 }
 
 // -----------------------------------------------------------------------------
+// SET_POSITION_TARGET_LOCAL_NED — local-frame variant. Same shape as
+// GLOBAL_INT but lat/lon/alt replaced with x/y/z metres in the chosen
+// MAV_FRAME_LOCAL_*.
+// -----------------------------------------------------------------------------
+
+impl MavlinkArrow for common::SET_POSITION_TARGET_LOCAL_NED_DATA {
+    fn schema() -> Schema {
+        Schema::new(vec![
+            Field::new("time_boot_ms", DataType::UInt32, false),
+            Field::new("x", DataType::Float32, false),
+            Field::new("y", DataType::Float32, false),
+            Field::new("z", DataType::Float32, false),
+            Field::new("vx", DataType::Float32, false),
+            Field::new("vy", DataType::Float32, false),
+            Field::new("vz", DataType::Float32, false),
+            Field::new("afx", DataType::Float32, false),
+            Field::new("afy", DataType::Float32, false),
+            Field::new("afz", DataType::Float32, false),
+            Field::new("yaw", DataType::Float32, false),
+            Field::new("yaw_rate", DataType::Float32, false),
+            Field::new("type_mask", DataType::UInt16, false),
+            Field::new("target_system", DataType::UInt8, false),
+            Field::new("target_component", DataType::UInt8, false),
+            Field::new("coordinate_frame", DataType::UInt32, false),
+        ])
+    }
+
+    fn to_record_batch(&self) -> BridgeResult<RecordBatch> {
+        build(
+            Self::schema()
+                .fields()
+                .iter()
+                .map(|f| f.as_ref().clone())
+                .collect(),
+            vec![
+                arr_u32(self.time_boot_ms),
+                arr_f32(self.x),
+                arr_f32(self.y),
+                arr_f32(self.z),
+                arr_f32(self.vx),
+                arr_f32(self.vy),
+                arr_f32(self.vz),
+                arr_f32(self.afx),
+                arr_f32(self.afy),
+                arr_f32(self.afz),
+                arr_f32(self.yaw),
+                arr_f32(self.yaw_rate),
+                arr_u16(self.type_mask.bits()),
+                arr_u8(self.target_system),
+                arr_u8(self.target_component),
+                arr_u32(self.coordinate_frame as u32),
+            ],
+        )
+    }
+
+    fn from_record_batch(batch: &RecordBatch) -> BridgeResult<Self> {
+        Ok(Self {
+            time_boot_ms: read_u32(batch, "time_boot_ms")?,
+            x: read_f32(batch, "x")?,
+            y: read_f32(batch, "y")?,
+            z: read_f32(batch, "z")?,
+            vx: read_f32(batch, "vx")?,
+            vy: read_f32(batch, "vy")?,
+            vz: read_f32(batch, "vz")?,
+            afx: read_f32(batch, "afx")?,
+            afy: read_f32(batch, "afy")?,
+            afz: read_f32(batch, "afz")?,
+            yaw: read_f32(batch, "yaw")?,
+            yaw_rate: read_f32(batch, "yaw_rate")?,
+            type_mask: common::PositionTargetTypemask::from_bits_truncate(read_u16(
+                batch,
+                "type_mask",
+            )?),
+            target_system: read_u8(batch, "target_system")?,
+            target_component: read_u8(batch, "target_component")?,
+            coordinate_frame: decode_enum(read_u32(batch, "coordinate_frame")?, "coordinate_frame")?,
+        })
+    }
+}
+
+// -----------------------------------------------------------------------------
 // MISSION_CURRENT
 // -----------------------------------------------------------------------------
 

--- a/libraries/extensions/mavlink2-bridge/src/arrow_convert.rs
+++ b/libraries/extensions/mavlink2-bridge/src/arrow_convert.rs
@@ -835,6 +835,17 @@ impl MavlinkArrow for common::COMMAND_ACK_DATA {
 // SET_MODE — used by mission drivers to request a flight mode on autopilots
 // that don't accept MAV_CMD_DO_SET_MODE via COMMAND_LONG (e.g. legacy
 // ArduCopter <= 3.5).
+//
+// Known limitation (mavlink-rust 0.13): the spec defines `base_mode` as a
+// uint8 bitfield, but mavlink-rust generates `MavMode` as a strict enum with
+// only 11 named variants {0, 64, 66, 80, 88, 92, 192, 194, 208, 216, 220}.
+// None has bit 0x01 (CUSTOM_MODE_ENABLED) set, so any ArduPilot custom-mode
+// entry (base_mode=0x01 + custom_mode=N for GUIDED/AUTO/RTL/...) cannot be
+// encoded or decoded through this path. For ArduPilot custom modes, prefer
+// MAV_CMD_DO_SET_MODE via the `command_long_cmd` input on autopilots that
+// support it (ArduCopter >= 3.6, recent PX4); on older firmware the bridge
+// can't speak custom-mode SET_MODE until mavlink-rust accepts base_mode as
+// raw u8 (tracked at https://github.com/mavlink/rust-mavlink).
 // -----------------------------------------------------------------------------
 
 impl MavlinkArrow for common::SET_MODE_DATA {
@@ -862,10 +873,26 @@ impl MavlinkArrow for common::SET_MODE_DATA {
     }
 
     fn from_record_batch(batch: &RecordBatch) -> BridgeResult<Self> {
+        let raw_base_mode = read_u8(batch, "base_mode")?;
+        // Surface the mavlink-rust 0.13 enum-vs-bitfield mismatch with a
+        // pointer to the workaround instead of the bare "invalid base_mode
+        // discriminant" that decode_enum would produce, since this hits any
+        // user trying to enter an ArduPilot custom mode.
+        let base_mode = decode_enum(raw_base_mode as u32, "base_mode").map_err(|_| {
+            BridgeError::Mavlink(format!(
+                "SET_MODE base_mode={raw_base_mode} (0x{raw_base_mode:02x}) is a valid \
+                 uint8 per MAVLink spec but not representable as mavlink-rust 0.13's \
+                 strict MavMode enum (variants: 0, 64, 66, 80, 88, 92, 192, 194, 208, \
+                 216, 220). For ArduPilot custom-mode entry (base_mode=0x01 + \
+                 custom_mode=N), use MAV_CMD_DO_SET_MODE via the `command_long_cmd` \
+                 input on autopilots that support it (ArduCopter >= 3.6, recent PX4). \
+                 Tracked upstream at https://github.com/mavlink/rust-mavlink."
+            ))
+        })?;
         Ok(Self {
             custom_mode: read_u32(batch, "custom_mode")?,
             target_system: read_u8(batch, "target_system")?,
-            base_mode: decode_enum(read_u8(batch, "base_mode")? as u32, "base_mode")?,
+            base_mode,
         })
     }
 }

--- a/libraries/extensions/mavlink2-bridge/src/arrow_convert.rs
+++ b/libraries/extensions/mavlink2-bridge/src/arrow_convert.rs
@@ -632,6 +632,62 @@ impl MavlinkArrow for common::RC_CHANNELS_DATA {
 }
 
 // -----------------------------------------------------------------------------
+// RC_CHANNELS_OVERRIDE — used by missions that drive vehicles in MANUAL
+// mode by emulating an RC transmitter. Required for ArduRover 2.50 which
+// does not accept COMMAND_LONG ARM / DO_REPOSITION / NAV_WAYPOINT.
+// -----------------------------------------------------------------------------
+
+impl MavlinkArrow for common::RC_CHANNELS_OVERRIDE_DATA {
+    fn schema() -> Schema {
+        let mut fields = vec![
+            Field::new("target_system", DataType::UInt8, false),
+            Field::new("target_component", DataType::UInt8, false),
+        ];
+        for n in 1..=8 {
+            fields.push(Field::new(format!("chan{n}_raw"), DataType::UInt16, false));
+        }
+        Schema::new(fields)
+    }
+
+    fn to_record_batch(&self) -> BridgeResult<RecordBatch> {
+        build(
+            Self::schema()
+                .fields()
+                .iter()
+                .map(|f| f.as_ref().clone())
+                .collect(),
+            vec![
+                arr_u8(self.target_system),
+                arr_u8(self.target_component),
+                arr_u16(self.chan1_raw),
+                arr_u16(self.chan2_raw),
+                arr_u16(self.chan3_raw),
+                arr_u16(self.chan4_raw),
+                arr_u16(self.chan5_raw),
+                arr_u16(self.chan6_raw),
+                arr_u16(self.chan7_raw),
+                arr_u16(self.chan8_raw),
+            ],
+        )
+    }
+
+    fn from_record_batch(batch: &RecordBatch) -> BridgeResult<Self> {
+        Ok(Self {
+            target_system: read_u8(batch, "target_system")?,
+            target_component: read_u8(batch, "target_component")?,
+            chan1_raw: read_u16(batch, "chan1_raw")?,
+            chan2_raw: read_u16(batch, "chan2_raw")?,
+            chan3_raw: read_u16(batch, "chan3_raw")?,
+            chan4_raw: read_u16(batch, "chan4_raw")?,
+            chan5_raw: read_u16(batch, "chan5_raw")?,
+            chan6_raw: read_u16(batch, "chan6_raw")?,
+            chan7_raw: read_u16(batch, "chan7_raw")?,
+            chan8_raw: read_u16(batch, "chan8_raw")?,
+        })
+    }
+}
+
+// -----------------------------------------------------------------------------
 // SERVO_OUTPUT_RAW
 // -----------------------------------------------------------------------------
 
@@ -771,6 +827,45 @@ impl MavlinkArrow for common::COMMAND_ACK_DATA {
         Ok(Self {
             command: decode_enum(read_u32(batch, "command")?, "command")?,
             result: decode_enum(read_u32(batch, "result")?, "result")?,
+        })
+    }
+}
+
+// -----------------------------------------------------------------------------
+// SET_MODE — used by mission drivers to request a flight mode on autopilots
+// that don't accept MAV_CMD_DO_SET_MODE via COMMAND_LONG (e.g. legacy
+// ArduCopter <= 3.5).
+// -----------------------------------------------------------------------------
+
+impl MavlinkArrow for common::SET_MODE_DATA {
+    fn schema() -> Schema {
+        Schema::new(vec![
+            Field::new("custom_mode", DataType::UInt32, false),
+            Field::new("target_system", DataType::UInt8, false),
+            Field::new("base_mode", DataType::UInt8, false),
+        ])
+    }
+
+    fn to_record_batch(&self) -> BridgeResult<RecordBatch> {
+        build(
+            Self::schema()
+                .fields()
+                .iter()
+                .map(|f| f.as_ref().clone())
+                .collect(),
+            vec![
+                arr_u32(self.custom_mode),
+                arr_u8(self.target_system),
+                arr_u8(self.base_mode as u8),
+            ],
+        )
+    }
+
+    fn from_record_batch(batch: &RecordBatch) -> BridgeResult<Self> {
+        Ok(Self {
+            custom_mode: read_u32(batch, "custom_mode")?,
+            target_system: read_u8(batch, "target_system")?,
+            base_mode: decode_enum(read_u8(batch, "base_mode")? as u32, "base_mode")?,
         })
     }
 }

--- a/libraries/extensions/mavlink2-bridge/src/arrow_convert.rs
+++ b/libraries/extensions/mavlink2-bridge/src/arrow_convert.rs
@@ -898,6 +898,88 @@ impl MavlinkArrow for common::SET_MODE_DATA {
 }
 
 // -----------------------------------------------------------------------------
+// SET_POSITION_TARGET_GLOBAL_INT — used by ground stations and apps to
+// command a vehicle to a global lat/lon/alt with a position-only or
+// velocity-only or acceleration-only intent (per type_mask). All
+// position fields are int32 deg*1e7; vel/accel are f32 m/s and m/s^2.
+// -----------------------------------------------------------------------------
+
+impl MavlinkArrow for common::SET_POSITION_TARGET_GLOBAL_INT_DATA {
+    fn schema() -> Schema {
+        Schema::new(vec![
+            Field::new("time_boot_ms", DataType::UInt32, false),
+            Field::new("lat_int", DataType::Int32, false),
+            Field::new("lon_int", DataType::Int32, false),
+            Field::new("alt", DataType::Float32, false),
+            Field::new("vx", DataType::Float32, false),
+            Field::new("vy", DataType::Float32, false),
+            Field::new("vz", DataType::Float32, false),
+            Field::new("afx", DataType::Float32, false),
+            Field::new("afy", DataType::Float32, false),
+            Field::new("afz", DataType::Float32, false),
+            Field::new("yaw", DataType::Float32, false),
+            Field::new("yaw_rate", DataType::Float32, false),
+            Field::new("type_mask", DataType::UInt16, false),
+            Field::new("target_system", DataType::UInt8, false),
+            Field::new("target_component", DataType::UInt8, false),
+            Field::new("coordinate_frame", DataType::UInt32, false),
+        ])
+    }
+
+    fn to_record_batch(&self) -> BridgeResult<RecordBatch> {
+        build(
+            Self::schema()
+                .fields()
+                .iter()
+                .map(|f| f.as_ref().clone())
+                .collect(),
+            vec![
+                arr_u32(self.time_boot_ms),
+                arr_i32(self.lat_int),
+                arr_i32(self.lon_int),
+                arr_f32(self.alt),
+                arr_f32(self.vx),
+                arr_f32(self.vy),
+                arr_f32(self.vz),
+                arr_f32(self.afx),
+                arr_f32(self.afy),
+                arr_f32(self.afz),
+                arr_f32(self.yaw),
+                arr_f32(self.yaw_rate),
+                arr_u16(self.type_mask.bits()),
+                arr_u8(self.target_system),
+                arr_u8(self.target_component),
+                arr_u32(self.coordinate_frame as u32),
+            ],
+        )
+    }
+
+    fn from_record_batch(batch: &RecordBatch) -> BridgeResult<Self> {
+        Ok(Self {
+            time_boot_ms: read_u32(batch, "time_boot_ms")?,
+            lat_int: read_i32(batch, "lat_int")?,
+            lon_int: read_i32(batch, "lon_int")?,
+            alt: read_f32(batch, "alt")?,
+            vx: read_f32(batch, "vx")?,
+            vy: read_f32(batch, "vy")?,
+            vz: read_f32(batch, "vz")?,
+            afx: read_f32(batch, "afx")?,
+            afy: read_f32(batch, "afy")?,
+            afz: read_f32(batch, "afz")?,
+            yaw: read_f32(batch, "yaw")?,
+            yaw_rate: read_f32(batch, "yaw_rate")?,
+            type_mask: common::PositionTargetTypemask::from_bits_truncate(read_u16(
+                batch,
+                "type_mask",
+            )?),
+            target_system: read_u8(batch, "target_system")?,
+            target_component: read_u8(batch, "target_component")?,
+            coordinate_frame: decode_enum(read_u32(batch, "coordinate_frame")?, "coordinate_frame")?,
+        })
+    }
+}
+
+// -----------------------------------------------------------------------------
 // MISSION_CURRENT
 // -----------------------------------------------------------------------------
 

--- a/libraries/extensions/mavlink2-bridge/src/arrow_convert.rs
+++ b/libraries/extensions/mavlink2-bridge/src/arrow_convert.rs
@@ -1,0 +1,75 @@
+use crate::{BridgeError, BridgeResult};
+use arrow::array::{Array, AsArray, RecordBatch, UInt8Array, UInt32Array};
+use arrow::datatypes::{DataType, Field, Schema, UInt8Type, UInt32Type};
+use mavlink::common;
+use num_traits::FromPrimitive;
+use std::sync::Arc;
+
+/// Bidirectional conversion between a MAVLink 2 message struct and a 1-row
+/// Apache Arrow `RecordBatch`. Implemented per message type; for batched
+/// telemetry, callers stream individual batches and concatenate downstream.
+pub trait MavlinkArrow: Sized {
+    /// Arrow schema describing this message's fields.
+    fn schema() -> Schema;
+
+    /// Encode `self` into a 1-row Arrow `RecordBatch`.
+    fn to_record_batch(&self) -> BridgeResult<RecordBatch>;
+
+    /// Decode the first row of a `RecordBatch` back into the message struct.
+    fn from_record_batch(batch: &RecordBatch) -> BridgeResult<Self>;
+}
+
+fn read_u32(batch: &RecordBatch, name: &str) -> BridgeResult<u32> {
+    let col = batch
+        .column_by_name(name)
+        .ok_or_else(|| BridgeError::Config(format!("missing column: {name}")))?;
+    Ok(col.as_primitive::<UInt32Type>().value(0))
+}
+
+fn read_u8(batch: &RecordBatch, name: &str) -> BridgeResult<u8> {
+    let col = batch
+        .column_by_name(name)
+        .ok_or_else(|| BridgeError::Config(format!("missing column: {name}")))?;
+    Ok(col.as_primitive::<UInt8Type>().value(0))
+}
+
+fn decode_enum<E: FromPrimitive>(v: u8, name: &str) -> BridgeResult<E> {
+    E::from_u8(v).ok_or_else(|| BridgeError::Mavlink(format!("invalid {name} discriminant: {v}")))
+}
+
+impl MavlinkArrow for common::HEARTBEAT_DATA {
+    fn schema() -> Schema {
+        Schema::new(vec![
+            Field::new("custom_mode", DataType::UInt32, false),
+            Field::new("mavtype", DataType::UInt8, false),
+            Field::new("autopilot", DataType::UInt8, false),
+            Field::new("base_mode", DataType::UInt8, false),
+            Field::new("system_status", DataType::UInt8, false),
+            Field::new("mavlink_version", DataType::UInt8, false),
+        ])
+    }
+
+    fn to_record_batch(&self) -> BridgeResult<RecordBatch> {
+        let schema = Arc::new(Self::schema());
+        let columns: Vec<Arc<dyn Array>> = vec![
+            Arc::new(UInt32Array::from(vec![self.custom_mode])),
+            Arc::new(UInt8Array::from(vec![self.mavtype as u8])),
+            Arc::new(UInt8Array::from(vec![self.autopilot as u8])),
+            Arc::new(UInt8Array::from(vec![self.base_mode.bits()])),
+            Arc::new(UInt8Array::from(vec![self.system_status as u8])),
+            Arc::new(UInt8Array::from(vec![self.mavlink_version])),
+        ];
+        Ok(RecordBatch::try_new(schema, columns)?)
+    }
+
+    fn from_record_batch(batch: &RecordBatch) -> BridgeResult<Self> {
+        Ok(Self {
+            custom_mode: read_u32(batch, "custom_mode")?,
+            mavtype: decode_enum(read_u8(batch, "mavtype")?, "mavtype")?,
+            autopilot: decode_enum(read_u8(batch, "autopilot")?, "autopilot")?,
+            base_mode: common::MavModeFlag::from_bits_truncate(read_u8(batch, "base_mode")?),
+            system_status: decode_enum(read_u8(batch, "system_status")?, "system_status")?,
+            mavlink_version: read_u8(batch, "mavlink_version")?,
+        })
+    }
+}

--- a/libraries/extensions/mavlink2-bridge/src/arrow_convert.rs
+++ b/libraries/extensions/mavlink2-bridge/src/arrow_convert.rs
@@ -14,12 +14,12 @@
 
 use crate::{BridgeError, BridgeResult};
 use arrow::array::{
-    ArrayRef, AsArray, Float32Array, Int8Array, Int16Array, Int32Array, RecordBatch, UInt8Array,
-    UInt16Array, UInt32Array, UInt64Array,
+    Array, ArrayRef, Float32Array, Int8Array, Int16Array, Int32Array, PrimitiveArray, RecordBatch,
+    UInt8Array, UInt16Array, UInt32Array, UInt64Array,
 };
 use arrow::datatypes::{
-    DataType, Field, Float32Type, Int8Type, Int16Type, Int32Type, Schema, UInt8Type, UInt16Type,
-    UInt32Type, UInt64Type,
+    ArrowPrimitiveType, DataType, Field, Float32Type, Int8Type, Int16Type, Int32Type, Schema,
+    UInt8Type, UInt16Type, UInt32Type, UInt64Type,
 };
 use mavlink::common;
 use num_traits::FromPrimitive;
@@ -55,61 +55,70 @@ fn build(fields: Vec<Field>, columns: Vec<ArrayRef>) -> BridgeResult<RecordBatch
 }
 
 // readers
+//
+// `read_primitive` validates everything a malformed dora input could
+// throw at us before unwrapping row 0:
+//
+//   * wrong column dtype  → `as_primitive` would panic; downcast_ref
+//     returns None and we return a `BridgeError::Mavlink` instead.
+//   * zero-row batch      → `value(0)` would panic on out-of-bounds.
+//   * null at row 0       → `value(0)` returns the slot but ignores the
+//     null bit, which silently invents a value; reject it.
+//
+// Without these checks a hostile or buggy producer on an input like
+// `command_long_cmd` could panic the bridge node; `handle_input`
+// expects decode failures to be `Err`, not aborts.
+fn read_primitive<T: ArrowPrimitiveType>(batch: &RecordBatch, name: &str) -> BridgeResult<T::Native>
+where
+    T::Native: Copy,
+{
+    let col = batch.column_by_name(name).ok_or_else(|| missing(name))?;
+    let arr = col
+        .as_any()
+        .downcast_ref::<PrimitiveArray<T>>()
+        .ok_or_else(|| {
+            BridgeError::Mavlink(format!(
+                "column '{name}' has wrong type: expected {:?}, got {:?}",
+                T::DATA_TYPE,
+                col.data_type()
+            ))
+        })?;
+    if arr.is_empty() {
+        return Err(BridgeError::Mavlink(format!(
+            "column '{name}' has zero rows; expected ≥1 row"
+        )));
+    }
+    if arr.is_null(0) {
+        return Err(BridgeError::Mavlink(format!(
+            "column '{name}' is null at row 0"
+        )));
+    }
+    Ok(arr.value(0))
+}
+
 fn read_u8(batch: &RecordBatch, name: &str) -> BridgeResult<u8> {
-    Ok(batch
-        .column_by_name(name)
-        .ok_or_else(|| missing(name))?
-        .as_primitive::<UInt8Type>()
-        .value(0))
+    read_primitive::<UInt8Type>(batch, name)
 }
 fn read_u16(batch: &RecordBatch, name: &str) -> BridgeResult<u16> {
-    Ok(batch
-        .column_by_name(name)
-        .ok_or_else(|| missing(name))?
-        .as_primitive::<UInt16Type>()
-        .value(0))
+    read_primitive::<UInt16Type>(batch, name)
 }
 fn read_u32(batch: &RecordBatch, name: &str) -> BridgeResult<u32> {
-    Ok(batch
-        .column_by_name(name)
-        .ok_or_else(|| missing(name))?
-        .as_primitive::<UInt32Type>()
-        .value(0))
+    read_primitive::<UInt32Type>(batch, name)
 }
 fn read_u64(batch: &RecordBatch, name: &str) -> BridgeResult<u64> {
-    Ok(batch
-        .column_by_name(name)
-        .ok_or_else(|| missing(name))?
-        .as_primitive::<UInt64Type>()
-        .value(0))
+    read_primitive::<UInt64Type>(batch, name)
 }
 fn read_i8(batch: &RecordBatch, name: &str) -> BridgeResult<i8> {
-    Ok(batch
-        .column_by_name(name)
-        .ok_or_else(|| missing(name))?
-        .as_primitive::<Int8Type>()
-        .value(0))
+    read_primitive::<Int8Type>(batch, name)
 }
 fn read_i16(batch: &RecordBatch, name: &str) -> BridgeResult<i16> {
-    Ok(batch
-        .column_by_name(name)
-        .ok_or_else(|| missing(name))?
-        .as_primitive::<Int16Type>()
-        .value(0))
+    read_primitive::<Int16Type>(batch, name)
 }
 fn read_i32(batch: &RecordBatch, name: &str) -> BridgeResult<i32> {
-    Ok(batch
-        .column_by_name(name)
-        .ok_or_else(|| missing(name))?
-        .as_primitive::<Int32Type>()
-        .value(0))
+    read_primitive::<Int32Type>(batch, name)
 }
 fn read_f32(batch: &RecordBatch, name: &str) -> BridgeResult<f32> {
-    Ok(batch
-        .column_by_name(name)
-        .ok_or_else(|| missing(name))?
-        .as_primitive::<Float32Type>()
-        .value(0))
+    read_primitive::<Float32Type>(batch, name)
 }
 // builders (single-row Arrow arrays from a single value)
 fn arr_u8(v: u8) -> ArrayRef {
@@ -974,7 +983,10 @@ impl MavlinkArrow for common::SET_POSITION_TARGET_GLOBAL_INT_DATA {
             )?),
             target_system: read_u8(batch, "target_system")?,
             target_component: read_u8(batch, "target_component")?,
-            coordinate_frame: decode_enum(read_u32(batch, "coordinate_frame")?, "coordinate_frame")?,
+            coordinate_frame: decode_enum(
+                read_u32(batch, "coordinate_frame")?,
+                "coordinate_frame",
+            )?,
         })
     }
 }
@@ -1055,7 +1067,10 @@ impl MavlinkArrow for common::SET_POSITION_TARGET_LOCAL_NED_DATA {
             )?),
             target_system: read_u8(batch, "target_system")?,
             target_component: read_u8(batch, "target_component")?,
-            coordinate_frame: decode_enum(read_u32(batch, "coordinate_frame")?, "coordinate_frame")?,
+            coordinate_frame: decode_enum(
+                read_u32(batch, "coordinate_frame")?,
+                "coordinate_frame",
+            )?,
         })
     }
 }

--- a/libraries/extensions/mavlink2-bridge/src/error.rs
+++ b/libraries/extensions/mavlink2-bridge/src/error.rs
@@ -1,0 +1,18 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum BridgeError {
+    #[error("Arrow error: {0}")]
+    Arrow(#[from] arrow::error::ArrowError),
+
+    #[error("transport error: {0}")]
+    Transport(#[from] std::io::Error),
+
+    #[error("config error: {0}")]
+    Config(String),
+
+    #[error("MAVLink error: {0}")]
+    Mavlink(String),
+}
+
+pub type BridgeResult<T> = Result<T, BridgeError>;

--- a/libraries/extensions/mavlink2-bridge/src/lib.rs
+++ b/libraries/extensions/mavlink2-bridge/src/lib.rs
@@ -8,6 +8,7 @@
 
 mod arrow_convert;
 mod error;
+pub mod transport;
 
 pub use arrow_convert::MavlinkArrow;
 pub use error::{BridgeError, BridgeResult};

--- a/libraries/extensions/mavlink2-bridge/src/lib.rs
+++ b/libraries/extensions/mavlink2-bridge/src/lib.rs
@@ -1,0 +1,15 @@
+//! MAVLink 2 ↔ Apache Arrow bridge for the dora dataflow runtime.
+//!
+//! This crate is the scaffold for a MAVLink 2 bridge that mirrors the
+//! `dora-ros2-bridge` extension. Subsequent PRs add Arrow conversion,
+//! transport adapters, and the daemon-spawnable bridge node.
+//!
+//! See <https://github.com/dora-rs/dora/issues/1786> for the design RFC.
+
+mod error;
+
+pub use error::{BridgeError, BridgeResult};
+pub use mavlink::{self, MavlinkVersion};
+
+/// Compile-time guarantee that this bridge targets MAVLink 2.
+pub const MAVLINK_VERSION: MavlinkVersion = MavlinkVersion::V2;

--- a/libraries/extensions/mavlink2-bridge/src/lib.rs
+++ b/libraries/extensions/mavlink2-bridge/src/lib.rs
@@ -6,8 +6,10 @@
 //!
 //! See <https://github.com/dora-rs/dora/issues/1786> for the design RFC.
 
+mod arrow_convert;
 mod error;
 
+pub use arrow_convert::MavlinkArrow;
 pub use error::{BridgeError, BridgeResult};
 pub use mavlink::{self, MavlinkVersion};
 

--- a/libraries/extensions/mavlink2-bridge/src/transport.rs
+++ b/libraries/extensions/mavlink2-bridge/src/transport.rs
@@ -1,6 +1,7 @@
 //! Open MAVLink 2 transports from a `url::Url`.
 //!
-//! Supported URL schemes:
+//! Supported URL schemes (this PR's scope, **not** a fully general
+//! "open MAVLink transport from URL" surface):
 //!
 //! | URL form                              | mavlink address              | Mode      |
 //! |---------------------------------------|------------------------------|-----------|
@@ -9,13 +10,21 @@
 //! | `serial:///dev/path?baud=N` (Unix)    | `serial:/dev/path:N`         | n/a       |
 //! | `serial://COM1?baud=N` (Windows)      | `serial:COM1:N`              | n/a       |
 //!
-//! UDP defaults to *server* mode (listening) because the typical
-//! use case is receiving Pixhawk telemetry on a fixed port. Override by
-//! constructing the URL with a query that future PRs may add. For now,
-//! callers needing UDP client mode can drop down to `mavlink::connect`
-//! directly.
+//! ## Known limitations (intentional, not bugs)
 //!
-//! Serial baud defaults to 115200 if the `?baud=` query is omitted.
+//! * **`tcp://` is always `tcpout:` (client mode).** There is no way
+//!   to bind a TCP server with this builder; the autopilot must be
+//!   the listener. Callers needing `tcpin:` (acting as a TCP server)
+//!   must drop down to `mavlink::connect` directly.
+//! * **`udp://` is always `udpin:` (server mode — bind + listen).**
+//!   The typical use case is receiving Pixhawk telemetry on a fixed
+//!   local port, so we hard-wire that. `udpout:` (client) and
+//!   `udpbcast:` (broadcast) are out of scope; callers needing them
+//!   must drop down to `mavlink::connect` directly. The shutdown
+//!   wake-up logic in the bridge node assumes server mode (it sends
+//!   a self-loopback HEARTBEAT to the bound port), so flipping this
+//!   would require revisiting that path too.
+//! * **Serial** baud defaults to `115_200` when `?baud=` is omitted.
 
 use crate::{BridgeError, BridgeResult};
 use mavlink::{MavConnection, MavlinkVersion, common::MavMessage};

--- a/libraries/extensions/mavlink2-bridge/src/transport.rs
+++ b/libraries/extensions/mavlink2-bridge/src/transport.rs
@@ -49,7 +49,8 @@ fn connect_tcp(url: &Url) -> BridgeResult<Box<dyn MavConnection<MavMessage> + Se
         .host_str()
         .ok_or_else(|| BridgeError::Config(format!("missing host in '{url}'")))?;
     let port = url.port().unwrap_or(DEFAULT_TCP_PORT);
-    open_mavlink(&format!("tcpout:{host}:{port}"))
+    let version = parse_proto_query(url).unwrap_or(MavlinkVersion::V2);
+    open_mavlink_versioned(&format!("tcpout:{host}:{port}"), version)
 }
 
 fn connect_udp(url: &Url) -> BridgeResult<Box<dyn MavConnection<MavMessage> + Send + Sync>> {
@@ -57,7 +58,8 @@ fn connect_udp(url: &Url) -> BridgeResult<Box<dyn MavConnection<MavMessage> + Se
         .host_str()
         .ok_or_else(|| BridgeError::Config(format!("missing host in '{url}'")))?;
     let port = url.port().unwrap_or(DEFAULT_UDP_PORT);
-    open_mavlink(&format!("udpin:{host}:{port}"))
+    let version = parse_proto_query(url).unwrap_or(MavlinkVersion::V2);
+    open_mavlink_versioned(&format!("udpin:{host}:{port}"), version)
 }
 
 fn connect_serial(url: &Url) -> BridgeResult<Box<dyn MavConnection<MavMessage> + Send + Sync>> {
@@ -84,10 +86,27 @@ fn parse_baud(url: &Url) -> Option<u32> {
 }
 
 fn open_mavlink(addr: &str) -> BridgeResult<Box<dyn MavConnection<MavMessage> + Send + Sync>> {
+    open_mavlink_versioned(addr, MavlinkVersion::V2)
+}
+
+fn open_mavlink_versioned(
+    addr: &str,
+    version: MavlinkVersion,
+) -> BridgeResult<Box<dyn MavConnection<MavMessage> + Send + Sync>> {
     let mut conn = mavlink::connect::<MavMessage>(addr)
         .map_err(|e| BridgeError::Config(format!("failed to connect mavlink to '{addr}': {e}")))?;
-    conn.set_protocol_version(MavlinkVersion::V2);
+    conn.set_protocol_version(version);
     Ok(conn)
+}
+
+fn parse_proto_query(url: &Url) -> Option<MavlinkVersion> {
+    url.query_pairs()
+        .find(|(k, _)| k == "proto")
+        .and_then(|(_, v)| match v.to_ascii_lowercase().as_str() {
+            "v1" | "1" | "1.0" => Some(MavlinkVersion::V1),
+            "v2" | "2" | "2.0" => Some(MavlinkVersion::V2),
+            _ => None,
+        })
 }
 
 #[cfg(test)]

--- a/libraries/extensions/mavlink2-bridge/src/transport.rs
+++ b/libraries/extensions/mavlink2-bridge/src/transport.rs
@@ -1,11 +1,21 @@
 //! Open MAVLink 2 transports from a `url::Url`.
 //!
-//! URL scheme map (this PR adds `tcp` only; `udp`/`serial` land in the
-//! follow-up):
+//! Supported URL schemes:
 //!
-//! | URL                                | mavlink address    | Mode   |
-//! |------------------------------------|--------------------|--------|
-//! | `tcp://host:port`                  | `tcpout:host:port` | client |
+//! | URL form                              | mavlink address              | Mode      |
+//! |---------------------------------------|------------------------------|-----------|
+//! | `tcp://host:port`                     | `tcpout:host:port`           | client    |
+//! | `udp://host:port`                     | `udpin:host:port`            | server    |
+//! | `serial:///dev/path?baud=N` (Unix)    | `serial:/dev/path:N`         | n/a       |
+//! | `serial://COM1?baud=N` (Windows)      | `serial:COM1:N`              | n/a       |
+//!
+//! UDP defaults to *server* mode (listening) because the typical
+//! use case is receiving Pixhawk telemetry on a fixed port. Override by
+//! constructing the URL with a query that future PRs may add. For now,
+//! callers needing UDP client mode can drop down to `mavlink::connect`
+//! directly.
+//!
+//! Serial baud defaults to 115200 if the `?baud=` query is omitted.
 
 use crate::{BridgeError, BridgeResult};
 use mavlink::{MavConnection, MavlinkVersion, common::MavMessage};
@@ -13,18 +23,23 @@ use url::Url;
 
 /// Default MAVLink TCP port used when the URL omits one.
 pub const DEFAULT_TCP_PORT: u16 = 5760;
+/// Default MAVLink UDP port used when the URL omits one.
+pub const DEFAULT_UDP_PORT: u16 = 14550;
+/// Default serial baud rate used when the `?baud=` query is missing.
+pub const DEFAULT_SERIAL_BAUD: u32 = 115_200;
 
 /// Open a MAVLink 2 transport described by `url`.
 ///
 /// The returned connection is pre-configured for MAVLink V2 and is
 /// `Send + Sync`, so reader and writer threads may share an `Arc<_>`
-/// without an extra mutex (see `MavConnection::recv/send` taking
-/// `&self`).
+/// without an extra mutex.
 pub fn connect(url: &Url) -> BridgeResult<Box<dyn MavConnection<MavMessage> + Send + Sync>> {
     match url.scheme() {
         "tcp" => connect_tcp(url),
+        "udp" => connect_udp(url),
+        "serial" => connect_serial(url),
         scheme => Err(BridgeError::Config(format!(
-            "unsupported transport scheme '{scheme}' (this build supports: tcp)"
+            "unsupported transport scheme '{scheme}' (supported: tcp, udp, serial)"
         ))),
     }
 }
@@ -34,10 +49,66 @@ fn connect_tcp(url: &Url) -> BridgeResult<Box<dyn MavConnection<MavMessage> + Se
         .host_str()
         .ok_or_else(|| BridgeError::Config(format!("missing host in '{url}'")))?;
     let port = url.port().unwrap_or(DEFAULT_TCP_PORT);
-    let address = format!("tcpout:{host}:{port}");
-    let mut conn = mavlink::connect::<MavMessage>(&address).map_err(|e| {
-        BridgeError::Config(format!("failed to connect mavlink to '{address}': {e}"))
-    })?;
+    open_mavlink(&format!("tcpout:{host}:{port}"))
+}
+
+fn connect_udp(url: &Url) -> BridgeResult<Box<dyn MavConnection<MavMessage> + Send + Sync>> {
+    let host = url
+        .host_str()
+        .ok_or_else(|| BridgeError::Config(format!("missing host in '{url}'")))?;
+    let port = url.port().unwrap_or(DEFAULT_UDP_PORT);
+    open_mavlink(&format!("udpin:{host}:{port}"))
+}
+
+fn connect_serial(url: &Url) -> BridgeResult<Box<dyn MavConnection<MavMessage> + Send + Sync>> {
+    // Windows form `serial://COM1?...` puts the device in `host_str()`;
+    // Unix form `serial:///dev/tty.usbmodem1?...` puts it in `path()`
+    // (with leading slash, which mavlink's parser keeps).
+    let device = match url.host_str() {
+        Some(host) if !host.is_empty() => host.to_string(),
+        _ => url.path().to_string(),
+    };
+    if device.is_empty() {
+        return Err(BridgeError::Config(format!(
+            "missing device path in '{url}'"
+        )));
+    }
+    let baud = parse_baud(url).unwrap_or(DEFAULT_SERIAL_BAUD);
+    open_mavlink(&format!("serial:{device}:{baud}"))
+}
+
+fn parse_baud(url: &Url) -> Option<u32> {
+    url.query_pairs()
+        .find(|(k, _)| k == "baud")
+        .and_then(|(_, v)| v.parse::<u32>().ok())
+}
+
+fn open_mavlink(addr: &str) -> BridgeResult<Box<dyn MavConnection<MavMessage> + Send + Sync>> {
+    let mut conn = mavlink::connect::<MavMessage>(addr)
+        .map_err(|e| BridgeError::Config(format!("failed to connect mavlink to '{addr}': {e}")))?;
     conn.set_protocol_version(MavlinkVersion::V2);
     Ok(conn)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_baud_query() {
+        let url = Url::parse("serial:///dev/tty.usbmodem1?baud=57600").unwrap();
+        assert_eq!(parse_baud(&url), Some(57600));
+    }
+
+    #[test]
+    fn parses_baud_missing() {
+        let url = Url::parse("serial:///dev/tty.usbmodem1").unwrap();
+        assert_eq!(parse_baud(&url), None);
+    }
+
+    #[test]
+    fn parses_baud_garbage() {
+        let url = Url::parse("serial:///dev/tty.usbmodem1?baud=fast").unwrap();
+        assert_eq!(parse_baud(&url), None);
+    }
 }

--- a/libraries/extensions/mavlink2-bridge/src/transport.rs
+++ b/libraries/extensions/mavlink2-bridge/src/transport.rs
@@ -1,0 +1,43 @@
+//! Open MAVLink 2 transports from a `url::Url`.
+//!
+//! URL scheme map (this PR adds `tcp` only; `udp`/`serial` land in the
+//! follow-up):
+//!
+//! | URL                                | mavlink address    | Mode   |
+//! |------------------------------------|--------------------|--------|
+//! | `tcp://host:port`                  | `tcpout:host:port` | client |
+
+use crate::{BridgeError, BridgeResult};
+use mavlink::{MavConnection, MavlinkVersion, common::MavMessage};
+use url::Url;
+
+/// Default MAVLink TCP port used when the URL omits one.
+pub const DEFAULT_TCP_PORT: u16 = 5760;
+
+/// Open a MAVLink 2 transport described by `url`.
+///
+/// The returned connection is pre-configured for MAVLink V2 and is
+/// `Send + Sync`, so reader and writer threads may share an `Arc<_>`
+/// without an extra mutex (see `MavConnection::recv/send` taking
+/// `&self`).
+pub fn connect(url: &Url) -> BridgeResult<Box<dyn MavConnection<MavMessage> + Send + Sync>> {
+    match url.scheme() {
+        "tcp" => connect_tcp(url),
+        scheme => Err(BridgeError::Config(format!(
+            "unsupported transport scheme '{scheme}' (this build supports: tcp)"
+        ))),
+    }
+}
+
+fn connect_tcp(url: &Url) -> BridgeResult<Box<dyn MavConnection<MavMessage> + Send + Sync>> {
+    let host = url
+        .host_str()
+        .ok_or_else(|| BridgeError::Config(format!("missing host in '{url}'")))?;
+    let port = url.port().unwrap_or(DEFAULT_TCP_PORT);
+    let address = format!("tcpout:{host}:{port}");
+    let mut conn = mavlink::connect::<MavMessage>(&address).map_err(|e| {
+        BridgeError::Config(format!("failed to connect mavlink to '{address}': {e}"))
+    })?;
+    conn.set_protocol_version(MavlinkVersion::V2);
+    Ok(conn)
+}

--- a/libraries/extensions/mavlink2-bridge/tests/arrow_malformed.rs
+++ b/libraries/extensions/mavlink2-bridge/tests/arrow_malformed.rs
@@ -1,0 +1,128 @@
+//! Negative tests for `MavlinkArrow::from_record_batch`.
+//!
+//! `command_long_cmd` and the other writer inputs are public dora inputs
+//! — any node in the dataflow can publish to them. The decode path must
+//! reject malformed batches with `BridgeError`, not panic, otherwise the
+//! whole bridge node aborts on a single bad message.
+
+use arrow::array::{Float32Array, RecordBatch, StringArray, UInt8Array, UInt32Array};
+use arrow::datatypes::{DataType, Field, Schema};
+use dora_mavlink2_bridge::MavlinkArrow;
+use dora_mavlink2_bridge::mavlink::common::COMMAND_LONG_DATA;
+use std::sync::Arc;
+
+/// All seven `paramN` fields are f32; we keep a single shared row so each
+/// negative variant only has to swap one column out.
+fn good_command_long_columns() -> Vec<arrow::array::ArrayRef> {
+    vec![
+        Arc::new(Float32Array::from(vec![1.0])),
+        Arc::new(Float32Array::from(vec![2.0])),
+        Arc::new(Float32Array::from(vec![3.0])),
+        Arc::new(Float32Array::from(vec![4.0])),
+        Arc::new(Float32Array::from(vec![5.0])),
+        Arc::new(Float32Array::from(vec![6.0])),
+        Arc::new(Float32Array::from(vec![7.0])),
+        Arc::new(UInt32Array::from(vec![22u32])), // MAV_CMD_NAV_TAKEOFF
+        Arc::new(UInt8Array::from(vec![1u8])),
+        Arc::new(UInt8Array::from(vec![1u8])),
+        Arc::new(UInt8Array::from(vec![0u8])),
+    ]
+}
+
+#[test]
+fn rejects_wrong_column_type() {
+    // Replace `command` (UInt32 per spec) with a String column. The
+    // pre-fix code path called `as_primitive::<UInt32Type>()` which
+    // panics on type mismatch.
+    let schema = Schema::new(vec![
+        Field::new("param1", DataType::Float32, false),
+        Field::new("param2", DataType::Float32, false),
+        Field::new("param3", DataType::Float32, false),
+        Field::new("param4", DataType::Float32, false),
+        Field::new("param5", DataType::Float32, false),
+        Field::new("param6", DataType::Float32, false),
+        Field::new("param7", DataType::Float32, false),
+        Field::new("command", DataType::Utf8, false),
+        Field::new("target_system", DataType::UInt8, false),
+        Field::new("target_component", DataType::UInt8, false),
+        Field::new("confirmation", DataType::UInt8, false),
+    ]);
+    let mut cols = good_command_long_columns();
+    cols[7] = Arc::new(StringArray::from(vec!["takeoff"]));
+    let batch = RecordBatch::try_new(Arc::new(schema), cols).expect("build batch");
+
+    let err = COMMAND_LONG_DATA::from_record_batch(&batch).expect_err("expected decode error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("command") && msg.contains("wrong type"),
+        "unexpected error: {msg}"
+    );
+}
+
+#[test]
+fn rejects_zero_row_batch() {
+    // Same schema, but every column has zero rows. `value(0)` would
+    // panic out-of-bounds; we want a decode error instead.
+    let schema = COMMAND_LONG_DATA::schema();
+    let cols: Vec<arrow::array::ArrayRef> = vec![
+        Arc::new(Float32Array::from(Vec::<f32>::new())),
+        Arc::new(Float32Array::from(Vec::<f32>::new())),
+        Arc::new(Float32Array::from(Vec::<f32>::new())),
+        Arc::new(Float32Array::from(Vec::<f32>::new())),
+        Arc::new(Float32Array::from(Vec::<f32>::new())),
+        Arc::new(Float32Array::from(Vec::<f32>::new())),
+        Arc::new(Float32Array::from(Vec::<f32>::new())),
+        Arc::new(UInt32Array::from(Vec::<u32>::new())),
+        Arc::new(UInt8Array::from(Vec::<u8>::new())),
+        Arc::new(UInt8Array::from(Vec::<u8>::new())),
+        Arc::new(UInt8Array::from(Vec::<u8>::new())),
+    ];
+    let batch = RecordBatch::try_new(Arc::new(schema), cols).expect("build batch");
+
+    let err = COMMAND_LONG_DATA::from_record_batch(&batch).expect_err("expected decode error");
+    let msg = err.to_string();
+    assert!(msg.contains("zero rows"), "unexpected error: {msg}");
+}
+
+#[test]
+fn rejects_null_row_zero() {
+    // First field marked nullable so we can construct a null-at-row-0
+    // value without lying about the data type. Pre-fix `value(0)` would
+    // happily return whatever zero-bit pattern the slot held.
+    let schema = Schema::new(vec![
+        Field::new("param1", DataType::Float32, true),
+        Field::new("param2", DataType::Float32, false),
+        Field::new("param3", DataType::Float32, false),
+        Field::new("param4", DataType::Float32, false),
+        Field::new("param5", DataType::Float32, false),
+        Field::new("param6", DataType::Float32, false),
+        Field::new("param7", DataType::Float32, false),
+        Field::new("command", DataType::UInt32, false),
+        Field::new("target_system", DataType::UInt8, false),
+        Field::new("target_component", DataType::UInt8, false),
+        Field::new("confirmation", DataType::UInt8, false),
+    ]);
+    let mut cols = good_command_long_columns();
+    cols[0] = Arc::new(Float32Array::from(vec![None]));
+    let batch = RecordBatch::try_new(Arc::new(schema), cols).expect("build batch");
+
+    let err = COMMAND_LONG_DATA::from_record_batch(&batch).expect_err("expected decode error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("param1") && msg.contains("null"),
+        "unexpected error: {msg}"
+    );
+}
+
+/// Sanity check that the helper batch the negative tests build also
+/// decodes cleanly, so a regression in those tests' fixture is
+/// distinguishable from a regression in the validation paths.
+#[test]
+fn accepts_well_formed_batch() {
+    let schema = COMMAND_LONG_DATA::schema();
+    let batch =
+        RecordBatch::try_new(Arc::new(schema), good_command_long_columns()).expect("build batch");
+    let decoded = COMMAND_LONG_DATA::from_record_batch(&batch).expect("decode");
+    assert_eq!(decoded.target_system, 1);
+    assert_eq!(decoded.confirmation, 0);
+}

--- a/libraries/extensions/mavlink2-bridge/tests/arrow_roundtrip.rs
+++ b/libraries/extensions/mavlink2-bridge/tests/arrow_roundtrip.rs
@@ -5,7 +5,11 @@
 
 use dora_mavlink2_bridge::MavlinkArrow;
 use dora_mavlink2_bridge::mavlink::common::{
-    HEARTBEAT_DATA, MavAutopilot, MavModeFlag, MavState, MavType,
+    ATTITUDE_DATA, ATTITUDE_QUATERNION_DATA, COMMAND_ACK_DATA, COMMAND_LONG_DATA,
+    GLOBAL_POSITION_INT_DATA, GPS_RAW_INT_DATA, GpsFixType, HEARTBEAT_DATA,
+    LOCAL_POSITION_NED_DATA, MISSION_CURRENT_DATA, MavAutopilot, MavCmd, MavModeFlag, MavResult,
+    MavState, MavSysStatusSensor, MavType, RC_CHANNELS_DATA, SERVO_OUTPUT_RAW_DATA,
+    SYS_STATUS_DATA, SYSTEM_TIME_DATA,
 };
 
 #[test]
@@ -18,16 +22,276 @@ fn heartbeat_arrow_roundtrip() {
         system_status: MavState::MAV_STATE_ACTIVE,
         mavlink_version: 3,
     };
-
-    let batch = original.to_record_batch().expect("encode failed");
+    let batch = original.to_record_batch().expect("encode");
     assert_eq!(batch.num_rows(), 1);
-
-    let decoded = HEARTBEAT_DATA::from_record_batch(&batch).expect("decode failed");
-
+    let decoded = HEARTBEAT_DATA::from_record_batch(&batch).expect("decode");
     assert_eq!(decoded.custom_mode, original.custom_mode);
     assert_eq!(decoded.mavtype, original.mavtype);
     assert_eq!(decoded.autopilot, original.autopilot);
     assert_eq!(decoded.base_mode, original.base_mode);
     assert_eq!(decoded.system_status, original.system_status);
     assert_eq!(decoded.mavlink_version, original.mavlink_version);
+}
+
+#[test]
+fn sys_status_arrow_roundtrip() {
+    let original = SYS_STATUS_DATA {
+        onboard_control_sensors_present: MavSysStatusSensor::MAV_SYS_STATUS_SENSOR_3D_GYRO
+            | MavSysStatusSensor::MAV_SYS_STATUS_SENSOR_3D_ACCEL,
+        onboard_control_sensors_enabled: MavSysStatusSensor::MAV_SYS_STATUS_SENSOR_3D_GYRO,
+        onboard_control_sensors_health: MavSysStatusSensor::MAV_SYS_STATUS_SENSOR_3D_ACCEL,
+        load: 250,
+        voltage_battery: 12500,
+        current_battery: 230,
+        drop_rate_comm: 0,
+        errors_comm: 1,
+        errors_count1: 2,
+        errors_count2: 3,
+        errors_count3: 4,
+        errors_count4: 5,
+        battery_remaining: 87,
+    };
+    let batch = original.to_record_batch().expect("encode");
+    let decoded = SYS_STATUS_DATA::from_record_batch(&batch).expect("decode");
+    assert_eq!(
+        decoded.onboard_control_sensors_present,
+        original.onboard_control_sensors_present
+    );
+    assert_eq!(
+        decoded.onboard_control_sensors_enabled,
+        original.onboard_control_sensors_enabled
+    );
+    assert_eq!(
+        decoded.onboard_control_sensors_health,
+        original.onboard_control_sensors_health
+    );
+    assert_eq!(decoded.load, original.load);
+    assert_eq!(decoded.voltage_battery, original.voltage_battery);
+    assert_eq!(decoded.current_battery, original.current_battery);
+    assert_eq!(decoded.battery_remaining, original.battery_remaining);
+}
+
+#[test]
+fn system_time_arrow_roundtrip() {
+    let original = SYSTEM_TIME_DATA {
+        time_unix_usec: 1_700_000_000_000_000,
+        time_boot_ms: 12_345,
+    };
+    let batch = original.to_record_batch().expect("encode");
+    let decoded = SYSTEM_TIME_DATA::from_record_batch(&batch).expect("decode");
+    assert_eq!(decoded.time_unix_usec, original.time_unix_usec);
+    assert_eq!(decoded.time_boot_ms, original.time_boot_ms);
+}
+
+#[test]
+fn attitude_arrow_roundtrip() {
+    let original = ATTITUDE_DATA {
+        time_boot_ms: 1000,
+        roll: 0.1,
+        pitch: -0.2,
+        yaw: 1.57,
+        rollspeed: 0.01,
+        pitchspeed: -0.02,
+        yawspeed: 0.03,
+    };
+    let batch = original.to_record_batch().expect("encode");
+    let decoded = ATTITUDE_DATA::from_record_batch(&batch).expect("decode");
+    assert_eq!(decoded.time_boot_ms, original.time_boot_ms);
+    assert_eq!(decoded.roll, original.roll);
+    assert_eq!(decoded.pitch, original.pitch);
+    assert_eq!(decoded.yaw, original.yaw);
+    assert_eq!(decoded.rollspeed, original.rollspeed);
+    assert_eq!(decoded.pitchspeed, original.pitchspeed);
+    assert_eq!(decoded.yawspeed, original.yawspeed);
+}
+
+#[test]
+fn attitude_quaternion_arrow_roundtrip() {
+    let original = ATTITUDE_QUATERNION_DATA {
+        time_boot_ms: 2000,
+        q1: 1.0,
+        q2: 0.0,
+        q3: 0.0,
+        q4: 0.0,
+        rollspeed: 0.1,
+        pitchspeed: 0.2,
+        yawspeed: 0.3,
+    };
+    let batch = original.to_record_batch().expect("encode");
+    let decoded = ATTITUDE_QUATERNION_DATA::from_record_batch(&batch).expect("decode");
+    assert_eq!(decoded.time_boot_ms, original.time_boot_ms);
+    assert_eq!(decoded.q1, original.q1);
+    assert_eq!(decoded.q2, original.q2);
+    assert_eq!(decoded.q3, original.q3);
+    assert_eq!(decoded.q4, original.q4);
+}
+
+#[test]
+fn local_position_ned_arrow_roundtrip() {
+    let original = LOCAL_POSITION_NED_DATA {
+        time_boot_ms: 5000,
+        x: 1.0,
+        y: 2.0,
+        z: -3.0,
+        vx: 0.5,
+        vy: -0.5,
+        vz: 0.0,
+    };
+    let batch = original.to_record_batch().expect("encode");
+    let decoded = LOCAL_POSITION_NED_DATA::from_record_batch(&batch).expect("decode");
+    assert_eq!(decoded.time_boot_ms, original.time_boot_ms);
+    assert_eq!(decoded.x, original.x);
+    assert_eq!(decoded.y, original.y);
+    assert_eq!(decoded.z, original.z);
+    assert_eq!(decoded.vx, original.vx);
+    assert_eq!(decoded.vy, original.vy);
+    assert_eq!(decoded.vz, original.vz);
+}
+
+#[test]
+fn global_position_int_arrow_roundtrip() {
+    let original = GLOBAL_POSITION_INT_DATA {
+        time_boot_ms: 8000,
+        lat: 379_000_000,
+        lon: -1_223_000_000,
+        alt: 100_000,
+        relative_alt: 50_000,
+        vx: 10,
+        vy: -5,
+        vz: 1,
+        hdg: 27_000,
+    };
+    let batch = original.to_record_batch().expect("encode");
+    let decoded = GLOBAL_POSITION_INT_DATA::from_record_batch(&batch).expect("decode");
+    assert_eq!(decoded.time_boot_ms, original.time_boot_ms);
+    assert_eq!(decoded.lat, original.lat);
+    assert_eq!(decoded.lon, original.lon);
+    assert_eq!(decoded.alt, original.alt);
+    assert_eq!(decoded.relative_alt, original.relative_alt);
+    assert_eq!(decoded.vx, original.vx);
+    assert_eq!(decoded.hdg, original.hdg);
+}
+
+#[test]
+fn gps_raw_int_arrow_roundtrip() {
+    let original = GPS_RAW_INT_DATA {
+        time_usec: 1_700_000_000_000_000,
+        lat: 379_000_000,
+        lon: -1_223_000_000,
+        alt: 100_000,
+        eph: 100,
+        epv: 200,
+        vel: 300,
+        cog: 4500,
+        fix_type: GpsFixType::GPS_FIX_TYPE_3D_FIX,
+        satellites_visible: 12,
+    };
+    let batch = original.to_record_batch().expect("encode");
+    let decoded = GPS_RAW_INT_DATA::from_record_batch(&batch).expect("decode");
+    assert_eq!(decoded.time_usec, original.time_usec);
+    assert_eq!(decoded.lat, original.lat);
+    assert_eq!(decoded.fix_type, original.fix_type);
+    assert_eq!(decoded.satellites_visible, original.satellites_visible);
+}
+
+#[test]
+fn rc_channels_arrow_roundtrip() {
+    let original = RC_CHANNELS_DATA {
+        time_boot_ms: 3000,
+        chan1_raw: 1500,
+        chan2_raw: 1500,
+        chan3_raw: 1100,
+        chan4_raw: 1500,
+        chan5_raw: 1000,
+        chan6_raw: 2000,
+        chan7_raw: 1500,
+        chan8_raw: 1500,
+        chan9_raw: 1500,
+        chan10_raw: 1500,
+        chan11_raw: 1500,
+        chan12_raw: 1500,
+        chan13_raw: 1500,
+        chan14_raw: 1500,
+        chan15_raw: 1500,
+        chan16_raw: 1500,
+        chan17_raw: 1500,
+        chan18_raw: 1500,
+        chancount: 8,
+        rssi: 200,
+    };
+    let batch = original.to_record_batch().expect("encode");
+    let decoded = RC_CHANNELS_DATA::from_record_batch(&batch).expect("decode");
+    assert_eq!(decoded.time_boot_ms, original.time_boot_ms);
+    assert_eq!(decoded.chan1_raw, original.chan1_raw);
+    assert_eq!(decoded.chan8_raw, original.chan8_raw);
+    assert_eq!(decoded.chan18_raw, original.chan18_raw);
+    assert_eq!(decoded.chancount, original.chancount);
+    assert_eq!(decoded.rssi, original.rssi);
+}
+
+#[test]
+fn servo_output_raw_arrow_roundtrip() {
+    let original = SERVO_OUTPUT_RAW_DATA {
+        time_usec: 100_000,
+        servo1_raw: 1500,
+        servo2_raw: 1500,
+        servo3_raw: 1500,
+        servo4_raw: 1500,
+        servo5_raw: 1500,
+        servo6_raw: 1500,
+        servo7_raw: 1500,
+        servo8_raw: 1500,
+        port: 0,
+    };
+    let batch = original.to_record_batch().expect("encode");
+    let decoded = SERVO_OUTPUT_RAW_DATA::from_record_batch(&batch).expect("decode");
+    assert_eq!(decoded.time_usec, original.time_usec);
+    assert_eq!(decoded.servo1_raw, original.servo1_raw);
+    assert_eq!(decoded.servo8_raw, original.servo8_raw);
+    assert_eq!(decoded.port, original.port);
+}
+
+#[test]
+fn command_long_arrow_roundtrip() {
+    let original = COMMAND_LONG_DATA {
+        param1: 1.0,
+        param2: 2.0,
+        param3: 3.0,
+        param4: 4.0,
+        param5: 5.0,
+        param6: 6.0,
+        param7: 7.0,
+        command: MavCmd::MAV_CMD_NAV_TAKEOFF,
+        target_system: 1,
+        target_component: 1,
+        confirmation: 0,
+    };
+    let batch = original.to_record_batch().expect("encode");
+    let decoded = COMMAND_LONG_DATA::from_record_batch(&batch).expect("decode");
+    assert_eq!(decoded.command, original.command);
+    assert_eq!(decoded.param1, original.param1);
+    assert_eq!(decoded.param7, original.param7);
+    assert_eq!(decoded.target_system, original.target_system);
+    assert_eq!(decoded.target_component, original.target_component);
+    assert_eq!(decoded.confirmation, original.confirmation);
+}
+
+#[test]
+fn command_ack_arrow_roundtrip() {
+    let original = COMMAND_ACK_DATA {
+        command: MavCmd::MAV_CMD_NAV_TAKEOFF,
+        result: MavResult::MAV_RESULT_ACCEPTED,
+    };
+    let batch = original.to_record_batch().expect("encode");
+    let decoded = COMMAND_ACK_DATA::from_record_batch(&batch).expect("decode");
+    assert_eq!(decoded.command, original.command);
+    assert_eq!(decoded.result, original.result);
+}
+
+#[test]
+fn mission_current_arrow_roundtrip() {
+    let original = MISSION_CURRENT_DATA { seq: 5 };
+    let batch = original.to_record_batch().expect("encode");
+    let decoded = MISSION_CURRENT_DATA::from_record_batch(&batch).expect("decode");
+    assert_eq!(decoded.seq, original.seq);
 }

--- a/libraries/extensions/mavlink2-bridge/tests/arrow_roundtrip.rs
+++ b/libraries/extensions/mavlink2-bridge/tests/arrow_roundtrip.rs
@@ -1,0 +1,33 @@
+//! Round-trip tests for `MavlinkArrow` impls.
+//!
+//! Each test encodes a synthetic MAVLink message struct into a 1-row
+//! Arrow `RecordBatch`, decodes it back, and asserts every field matches.
+
+use dora_mavlink2_bridge::MavlinkArrow;
+use dora_mavlink2_bridge::mavlink::common::{
+    HEARTBEAT_DATA, MavAutopilot, MavModeFlag, MavState, MavType,
+};
+
+#[test]
+fn heartbeat_arrow_roundtrip() {
+    let original = HEARTBEAT_DATA {
+        custom_mode: 42,
+        mavtype: MavType::MAV_TYPE_QUADROTOR,
+        autopilot: MavAutopilot::MAV_AUTOPILOT_GENERIC,
+        base_mode: MavModeFlag::MAV_MODE_FLAG_SAFETY_ARMED,
+        system_status: MavState::MAV_STATE_ACTIVE,
+        mavlink_version: 3,
+    };
+
+    let batch = original.to_record_batch().expect("encode failed");
+    assert_eq!(batch.num_rows(), 1);
+
+    let decoded = HEARTBEAT_DATA::from_record_batch(&batch).expect("decode failed");
+
+    assert_eq!(decoded.custom_mode, original.custom_mode);
+    assert_eq!(decoded.mavtype, original.mavtype);
+    assert_eq!(decoded.autopilot, original.autopilot);
+    assert_eq!(decoded.base_mode, original.base_mode);
+    assert_eq!(decoded.system_status, original.system_status);
+    assert_eq!(decoded.mavlink_version, original.mavlink_version);
+}

--- a/libraries/extensions/mavlink2-bridge/tests/builds.rs
+++ b/libraries/extensions/mavlink2-bridge/tests/builds.rs
@@ -1,0 +1,10 @@
+//! Verifies the crate builds with the workspace dependency graph and
+//! exposes the expected public surface. Real conversion tests land in
+//! the next PR (#1786).
+
+use dora_mavlink2_bridge::{MAVLINK_VERSION, MavlinkVersion};
+
+#[test]
+fn targets_mavlink_v2_only() {
+    assert!(matches!(MAVLINK_VERSION, MavlinkVersion::V2));
+}

--- a/libraries/extensions/mavlink2-bridge/tests/transport.rs
+++ b/libraries/extensions/mavlink2-bridge/tests/transport.rs
@@ -1,0 +1,57 @@
+//! Tests for `transport::connect` URL parsing and scheme handling.
+//! Real network round-trip tests live in `binaries/mavlink2-bridge-node`.
+//!
+//! Note: `Box<dyn MavConnection<...>>` does not implement `Debug`, so
+//! these tests use `match` rather than `Result::expect_err`.
+
+use dora_mavlink2_bridge::{BridgeError, transport};
+use url::Url;
+
+fn assert_config_err_with(result: Result<impl Sized, BridgeError>, expected_substring: &str) {
+    match result {
+        Ok(_) => panic!("expected BridgeError::Config containing '{expected_substring}', got Ok"),
+        Err(BridgeError::Config(m)) => assert!(
+            m.contains(expected_substring),
+            "expected error message to contain '{expected_substring}', got: {m}"
+        ),
+        Err(other) => panic!(
+            "expected BridgeError::Config, got {} ({other})",
+            std::any::type_name_of_val(&other)
+        ),
+    }
+}
+
+#[test]
+fn rejects_unknown_scheme() {
+    let url = Url::parse("https://example.com").unwrap();
+    assert_config_err_with(transport::connect(&url), "unsupported");
+}
+
+#[test]
+fn rejects_udp_until_pr4() {
+    // PR #4 adds udp/serial; this PR must explicitly reject them so the
+    // user gets a clear error rather than a panic.
+    let url = Url::parse("udp://0.0.0.0:14550").unwrap();
+    assert_config_err_with(transport::connect(&url), "unsupported");
+}
+
+#[test]
+fn tcp_with_no_host_rejects() {
+    // A `tcp:` URL with no authority component has `host_str() == None`.
+    let url = Url::parse("tcp:5760").unwrap();
+    assert!(url.host_str().is_none());
+    assert_config_err_with(transport::connect(&url), "missing host");
+}
+
+#[test]
+fn tcp_unreachable_endpoint_returns_config_error_not_panic() {
+    // 127.0.0.1:1 has no listener — the connect attempt fails. We only
+    // care that the error is wrapped, not that connect succeeded.
+    let url = Url::parse("tcp://127.0.0.1:1").unwrap();
+    assert_config_err_with(transport::connect(&url), "failed to connect");
+}
+
+#[test]
+fn default_tcp_port_constant_is_5760() {
+    assert_eq!(transport::DEFAULT_TCP_PORT, 5760);
+}

--- a/libraries/extensions/mavlink2-bridge/tests/transport.rs
+++ b/libraries/extensions/mavlink2-bridge/tests/transport.rs
@@ -21,23 +21,18 @@ fn assert_config_err_with(result: Result<impl Sized, BridgeError>, expected_subs
     }
 }
 
+// ---- scheme rejection ----
+
 #[test]
 fn rejects_unknown_scheme() {
     let url = Url::parse("https://example.com").unwrap();
     assert_config_err_with(transport::connect(&url), "unsupported");
 }
 
-#[test]
-fn rejects_udp_until_pr4() {
-    // PR #4 adds udp/serial; this PR must explicitly reject them so the
-    // user gets a clear error rather than a panic.
-    let url = Url::parse("udp://0.0.0.0:14550").unwrap();
-    assert_config_err_with(transport::connect(&url), "unsupported");
-}
+// ---- TCP ----
 
 #[test]
 fn tcp_with_no_host_rejects() {
-    // A `tcp:` URL with no authority component has `host_str() == None`.
     let url = Url::parse("tcp:5760").unwrap();
     assert!(url.host_str().is_none());
     assert_config_err_with(transport::connect(&url), "missing host");
@@ -45,8 +40,6 @@ fn tcp_with_no_host_rejects() {
 
 #[test]
 fn tcp_unreachable_endpoint_returns_config_error_not_panic() {
-    // 127.0.0.1:1 has no listener — the connect attempt fails. We only
-    // care that the error is wrapped, not that connect succeeded.
     let url = Url::parse("tcp://127.0.0.1:1").unwrap();
     assert_config_err_with(transport::connect(&url), "failed to connect");
 }
@@ -54,4 +47,50 @@ fn tcp_unreachable_endpoint_returns_config_error_not_panic() {
 #[test]
 fn default_tcp_port_constant_is_5760() {
     assert_eq!(transport::DEFAULT_TCP_PORT, 5760);
+}
+
+// ---- UDP ----
+
+#[test]
+fn udp_with_no_host_rejects() {
+    let url = Url::parse("udp:14550").unwrap();
+    assert!(url.host_str().is_none());
+    assert_config_err_with(transport::connect(&url), "missing host");
+}
+
+#[test]
+fn default_udp_port_constant_is_14550() {
+    assert_eq!(transport::DEFAULT_UDP_PORT, 14550);
+}
+
+// Note: a positive `udp://host:port` test that actually binds lives in
+// `binaries/mavlink2-bridge-node/tests/udp_loopback.rs` — binding the
+// port from a unit test would race with the loopback test if both run
+// in parallel.
+
+// ---- Serial ----
+
+#[test]
+fn serial_nonexistent_device_unix_form_returns_config_error() {
+    // `/nonexistent/path/that/should/not/exist` cannot be opened. We
+    // only assert the error wraps as Config, not the OS-specific text.
+    let url = Url::parse("serial:///nonexistent/path/that/should/not/exist?baud=115200").unwrap();
+    match transport::connect(&url) {
+        Ok(_) => panic!("expected error opening nonexistent device"),
+        Err(BridgeError::Config(_)) => {}
+        Err(other) => panic!("expected BridgeError::Config, got {other}"),
+    }
+}
+
+#[test]
+fn serial_empty_device_path_rejects() {
+    // `serial://` parses with empty host and empty path → caught as
+    // "missing device path" by our parser.
+    let url = Url::parse("serial://").unwrap();
+    assert_config_err_with(transport::connect(&url), "missing device path");
+}
+
+#[test]
+fn default_serial_baud_constant_is_115200() {
+    assert_eq!(transport::DEFAULT_SERIAL_BAUD, 115_200);
 }

--- a/scripts/smoke-all.sh
+++ b/scripts/smoke-all.sh
@@ -307,6 +307,20 @@ if [ "$RUN_RUST" = true ]; then
         2>&1 | tail -1
 fi
 
+# mavlink2-bridge example: Rust variant runs in --rust-only mode; Python
+# variant adds the python printer; C++ variant is its own cargo example.
+# Build the Rust nodes (sim + emitter + bridge + rust printer) whenever
+# RUN_RUST is on; they're shared across the rust + python YAML variants.
+if [ "$RUN_RUST" = true ]; then
+    echo "Building mavlink2-bridge example nodes..."
+    cargo build \
+        -p dora-mavlink2-bridge-node \
+        -p mavlink2-bridge-example-mavlink-sim \
+        -p mavlink2-bridge-example-heartbeat-emitter \
+        -p mavlink2-bridge-example-telemetry-printer-rust \
+        2>&1 | tail -1
+fi
+
 # ---------------------------------------------------------------------------
 # Rust examples
 # ---------------------------------------------------------------------------
@@ -418,8 +432,22 @@ if [ "$RUN_RUST" = true ] && [ "$RUN_PYTHON" = true ]; then
     echo "=== Cross-language examples (local) ==="
     run_local "local-cross-language-rust-to-python" "examples/cross-language/rust-to-python.yml" 15
     run_local "local-cross-language-python-to-rust" "examples/cross-language/python-to-rust.yml" 15
+
+    echo ""
+    echo "=== MAVLink 2 bridge — Python variant ==="
+    run_networked "mavlink2-bridge-python"       "examples/mavlink2-bridge/dataflow-python.yml" 30
+    run_local     "local-mavlink2-bridge-python" "examples/mavlink2-bridge/dataflow-python.yml" 10
 else
-    log_skip "cross-language" "requires both Rust and Python"
+    log_skip "cross-language"          "requires both Rust and Python"
+    log_skip "mavlink2-bridge-python"  "requires both Rust and Python"
+fi
+
+# MAVLink 2 bridge — Rust variant runs without Python at all.
+if [ "$RUN_RUST" = true ]; then
+    echo ""
+    echo "=== MAVLink 2 bridge — Rust variant ==="
+    run_networked "mavlink2-bridge-rust"       "examples/mavlink2-bridge/dataflow-rust.yml" 30
+    run_local     "local-mavlink2-bridge-rust" "examples/mavlink2-bridge/dataflow-rust.yml" 10
 fi
 
 # ---------------------------------------------------------------------------
@@ -441,6 +469,7 @@ log_skip "cmake-dataflow" "CMake + C++"
 log_skip "python-dataflow-builder" "no YAML (API-based)"
 log_skip "dynamic-add-remove" "interactive dynamic topology CLI"
 log_skip "dynamic-agent-tools" "interactive dynamic topology CLI"
+log_skip "mavlink2-bridge-cxx" "C++ + Arrow C++ libs (covered by cxx examples job)"
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/tests/example-smoke.rs
+++ b/tests/example-smoke.rs
@@ -23,6 +23,7 @@ static BUILD_ACTION_NODES: Once = Once::new();
 static BUILD_CROSS_LANGUAGE_NODES: Once = Once::new();
 static BUILD_VALIDATED_PIPELINE_NODES: Once = Once::new();
 static BUILD_QUEUE_LATEST_RUST: Once = Once::new();
+static BUILD_MAVLINK2_BRIDGE_NODES: Once = Once::new();
 
 fn dora_bin() -> String {
     let manifest = env!("CARGO_MANIFEST_DIR");
@@ -1306,6 +1307,83 @@ fn smoke_local_queue_size_latest_data_python() {
     );
 }
 
+fn ensure_mavlink2_bridge_nodes_built() {
+    BUILD_MAVLINK2_BRIDGE_NODES.call_once(|| {
+        let status = Command::new("cargo")
+            .args([
+                "build",
+                "-p",
+                "dora-mavlink2-bridge-node",
+                "-p",
+                "mavlink2-bridge-example-mavlink-sim",
+                "-p",
+                "mavlink2-bridge-example-heartbeat-emitter",
+                "-p",
+                "mavlink2-bridge-example-telemetry-printer-rust",
+            ])
+            .status()
+            .expect("failed to run cargo build for mavlink2-bridge example");
+        assert!(status.success(), "failed to build mavlink2-bridge nodes");
+    });
+}
+
+// ---------------------------------------------------------------------------
+// MAVLink 2 bridge example (#1786)
+//
+// Three variants share the same bridge + UDP simulator + Rust HEARTBEAT
+// emitter; only the consumer that reads `bridge/heartbeat` differs:
+//
+//   * dataflow-rust.yml   -- pure Rust (no Python toolchain required)
+//   * dataflow-python.yml -- Python printer via `--uv`
+//   * dataflow-cxx.yml    -- C++ printer; built+run via the
+//                            `mavlink2-bridge-cxx` cargo example
+//                            (mirrors `cxx-arrow-dataflow`). NOT in
+//                            the smoke harness — see audit table.
+//
+// UDP avoids `TIME_WAIT` between successive smoke runs and keeps these
+// tests CI-friendly without a SITL/MAVProxy dependency.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn smoke_mavlink2_bridge_rust() {
+    ensure_mavlink2_bridge_nodes_built();
+    run_smoke_test(
+        "mavlink2-bridge-rust",
+        "examples/mavlink2-bridge/dataflow-rust.yml",
+        Duration::from_secs(30),
+    );
+}
+
+#[test]
+fn smoke_local_mavlink2_bridge_rust() {
+    ensure_mavlink2_bridge_nodes_built();
+    run_smoke_test_local(
+        "local-mavlink2-bridge-rust",
+        "examples/mavlink2-bridge/dataflow-rust.yml",
+        10,
+    );
+}
+
+#[test]
+fn smoke_mavlink2_bridge_python() {
+    ensure_mavlink2_bridge_nodes_built();
+    run_smoke_test(
+        "mavlink2-bridge-python",
+        "examples/mavlink2-bridge/dataflow-python.yml",
+        Duration::from_secs(30),
+    );
+}
+
+#[test]
+fn smoke_local_mavlink2_bridge_python() {
+    ensure_mavlink2_bridge_nodes_built();
+    run_smoke_test_local(
+        "local-mavlink2-bridge-python",
+        "examples/mavlink2-bridge/dataflow-python.yml",
+        10,
+    );
+}
+
 fn ensure_queue_latest_rust_built() {
     BUILD_QUEUE_LATEST_RUST.call_once(|| {
         let status = Command::new("cargo")
@@ -1367,6 +1445,9 @@ fn smoke_local_queue_size_latest_data_rust() {
 // |                           | testing-capabilities.md                              |          |
 // | python-operator-dataflow  | covered: `cli` job .github/workflows/ci.yml:393      | covered  |
 // | rust-dataflow-git         | covered: `examples` job (3 OS)                       | covered  |
+// | mavlink2-bridge-cxx       | covered: `examples` job via                          | covered  |
+// |                           | `[[example]] mavlink2-bridge-cxx` (cargo run         |          |
+// |                           | --example), same shape as `cxx-arrow-dataflow`       |          |
 //
 // "Covered" rows are listed so future refactors don't assume the examples
 // are entirely unexercised — they run in other CI jobs, just not this file.

--- a/tests/example-smoke.rs
+++ b/tests/example-smoke.rs
@@ -1448,6 +1448,9 @@ fn smoke_local_queue_size_latest_data_rust() {
 // | mavlink2-bridge-cxx       | covered: `examples` job via                          | covered  |
 // |                           | `[[example]] mavlink2-bridge-cxx` (cargo run         |          |
 // |                           | --example), same shape as `cxx-arrow-dataflow`       |          |
+// | mavlink2-bridge-sitl-     | blocker: needs ArduPilot SITL                        | —        |
+// |   mission                 | (Ubuntu / macOS only, local-only by design;          |          |
+// |                           | see examples/mavlink2-bridge-sitl-mission/README)    |          |
 //
 // "Covered" rows are listed so future refactors don't assume the examples
 // are entirely unexercised — they run in other CI jobs, just not this file.


### PR DESCRIPTION
## Summary

Adds `dora-mavlink2-bridge` (library crate) and `dora-mavlink2-bridge-node`
(daemon-spawnable binary) to bring MAVLink 2 ↔ Apache Arrow conversion into
the dora workspace. Closes the dora ↔ autopilot loop with full SITL
validation against ArduPilot Copter (takeoff → hover → land → disarm) and
ArduRover (RC-override-driven square drive).

This implements the feature requested in #1786.

## Why one PR (not 12 stacked)

The stack was originally going to ship as 12 separate PRs per the contributor
guide's preference for small commits. After review of the actual diff:

- **Every change to existing dora files is additive** (`Cargo.toml` adds
  workspace members, `README.md` / `CLAUDE.md` / `Changelog.md` add
  table rows / list entries, `tests/example-smoke.rs` adds new test
  functions, `scripts/smoke-all.sh` adds new conditional blocks). No
  existing dora logic is modified anywhere.
- All new code lives in **new crates** (`libraries/extensions/mavlink2-bridge/`,
  `binaries/mavlink2-bridge-node/`) and **new example directories**
  (`examples/mavlink2-bridge/`, `examples/mavlink2-bridge-sitl-mission/`).
- The 13 commits remain visible in the PR for commit-by-commit review.

Splitting into 12 PRs would have multiplied review-coordination cost without
narrowing the per-PR domain knowledge required (every PR needs the same
MAVLink + ArduPilot + dora bridge context).

## What's in this PR

### New crates

| Path | Crate | Role |
|------|-------|------|
| `libraries/extensions/mavlink2-bridge/` | `dora-mavlink2-bridge` | Library: MAVLink 2 ↔ Arrow conversion (`MavlinkArrow` trait), transport URL parsing (TCP / UDP / serial), error types. 13 message types from the MAVLink common dialect. |
| `binaries/mavlink2-bridge-node/` | `dora-mavlink2-bridge-node` | Daemon-spawnable binary: opens MAVLink 2 connection, decodes inbound frames into Arrow `StructArray` rows, dispatches dora inputs as outbound MAVLink frames. Auto-requests all data streams at 5 Hz on connect. |

### New examples

| Path | What it demos |
|------|---------------|
| `examples/mavlink2-bridge/` | In-process MAVLink simulator + 3 telemetry-printer flavors (Rust / Python / C++); 3 dataflow YAMLs (per language); cross-language demo of the bridge. |
| `examples/mavlink2-bridge-sitl-mission/` | Closed-loop SITL missions against ArduPilot Copter + Rover. Three missions: simple takeoff → hover → land (`mission.py`), long flight with square waypoints + hover (`mission_long.py`), rover square drive via RC override (`mission_rover.py`). Plus a TCP→UDP forwarder for QGroundControl observation (`scripts/forward_to_qgc.py`). Local-only; not in CI. |

### Bridge feature surface

**Telemetry (MAVLink → dora outputs):**
HEARTBEAT, SYS_STATUS, SYSTEM_TIME, ATTITUDE, ATTITUDE_QUATERNION,
LOCAL_POSITION_NED, GLOBAL_POSITION_INT, GPS_RAW_INT, RC_CHANNELS,
SERVO_OUTPUT_RAW, COMMAND_LONG, COMMAND_ACK, MISSION_CURRENT.

**Commands (dora inputs → MAVLink):**
`heartbeat_cmd`, `command_long_cmd`, `set_mode_cmd`,
`rc_channels_override_cmd`.

**Transports:**
- `tcp://host:port[?proto=v1|v2]` (TCP outgoing client)
- `udp://host:port[?proto=v1|v2]` (UDP listener)
- `serial:///dev/tty.X[?baud=N&proto=v1|v2]` (Unix serial)
- `serial://COM1[?baud=N&proto=v1|v2]` (Windows serial)

The `?proto=` query string is required for autopilots that speak MAVLink V1
only (e.g. ArduCopter ≤ 3.x in dronekit-sitl); without it, mavlink-rust
0.13's `recv()` silently drops every V1 frame.

**Auto-stream request:** on connect, the bridge sends
`REQUEST_DATA_STREAM(MAV_DATA_STREAM_ALL, 5 Hz)` once. ArduPilot 3.x emits
only HEARTBEAT until a GCS asks for streams; without this, dora consumers
saw empty `global_position_int` topics. Failure is non-fatal.

## What's tested

### Unit + integration tests in this repo

- `cargo fmt --all -- --check` ✓
- `cargo clippy -p dora-mavlink2-bridge -p dora-mavlink2-bridge-node --all-targets -- -D warnings` ✓
- `cargo test -p dora-mavlink2-bridge -p dora-mavlink2-bridge-node` ✓ — 28 tests:
  - 1 build sanity (`MAVLINK_VERSION = V2`)
  - 13 Arrow round-trip (one per supported message type)
  - 9 transport URL parsing
  - 3 inline `parse_baud`
  - 1 TCP loopback (real `mavlink::connect`)
  - 1 UDP loopback (real `mavlink::connect`)
- `cargo test --test example-smoke smoke_local_mavlink2_bridge` ✓ — local smoke (in-process MAVLink simulator + bridge + telemetry-printer in one dora dataflow)

### End-to-end SITL validation (local-only by design)

ArduPilot SITL is heavy (~5–10 min one-time waf build, requires Python
toolchain + ArduPilot source clone) and not appropriate for CI. Validated
manually on macOS 26.x (Apple Silicon) and Ubuntu:

**ArduCopter mission (mission.py):**
```
mission: vehicle heartbeat received
mission: -> SET_MODE GUIDED (cmd=176)    <- ACK [ACCEPTED, 0.1s]
mission: -> ARM (cmd=400)                <- ACK [ACCEPTED, 0.1s]
mission: -> TAKEOFF (cmd=22)             <- ACK [ACCEPTED, 0.1s]
mission: reached 8.76 m (target 8.50)
mission: hovering for 5.0s
mission: -> LAND (cmd=21)                <- ACK [ACCEPTED, 0.1s]
mission: landed at -1.98 m
mission: -> DISARM (cmd=400)             <- ACK [ACCEPTED, 0.1s]
mission: SUCCESS - takeoff + hover + land + disarm complete
```

**ArduCopter long flight (mission_long.py):** TAKEOFF 30 m → square
waypoints → hover 30 s → LAND. Validated SUCCESS in ~85 s. QGroundControl
observed the entire flight live via `forward_to_qgc.py` on UDP 14550.

**ArduRover square drive (mission_rover.py):** RC_CHANNELS_OVERRIDE-driven
clockwise square. Validated SUCCESS, ~700 m of track on the QGC map.

## What's NOT in this PR

- **CI smoke for SITL.** SITL is too heavy for PR CI as documented in
  `CLAUDE.md` ("Do NOT run the full QA suite on every commit/push") and
  `docs/qa-runbook.md`. The `tests/example-smoke.rs` audit table now lists
  `mavlink2-bridge-sitl-mission` as a manual-validation row alongside
  `cuda-benchmark`, `ros2-bridge`, etc.
- **`STATUSTEXT` / `BATTERY_STATUS` array fields.** Both have fixed-size
  `u8[50]` / `u16[10]` arrays that need Arrow `FixedSizeBinary` /
  `FixedSizeList` support. Documented in `arrow_convert.rs` module
  comment. Worth a follow-up PR.
- **PyO3 bindings for the bridge crate.** dora's existing Python node
  API is sufficient for users; PR demonstrates this with the
  `telemetry_printer.py` and `mission*.py` examples.

## Known limitation: mavlink-rust 0.13 `MavMode` enum

The MAVLink spec defines `SET_MODE.base_mode` as a `uint8_t` bitfield, but
mavlink-rust 0.13 generates `MavMode` as a strict enum with only 11 named
variants. None has bit `0x01` (`MAV_MODE_FLAG_CUSTOM_MODE_ENABLED`) set,
so the `set_mode_cmd` input cannot drive ArduPilot custom modes (GUIDED,
AUTO, RTL) through the bridge. Workaround: use `MAV_CMD_DO_SET_MODE` via
the existing `command_long_cmd` input on autopilots that support it
(ArduCopter ≥ 3.6, recent PX4). On older firmware, the SITL mission
examples open a side-channel `pymavlink` connection on TCP 5763
(documented in their source headers and the example README).

Tracked upstream at <https://github.com/mavlink/rust-mavlink>. Once the
upstream accepts `base_mode` as raw `u8`, follow-up PR removes the
limitation docs and the side-channel.

The bridge surfaces this with a descriptive runtime error
("`SET_MODE base_mode=N (0xNN) is a valid uint8 per MAVLink spec but not
representable as mavlink-rust 0.13's strict MavMode enum...`") rather than
the bare "`invalid base_mode discriminant`" that would otherwise be
emitted by the generic `decode_enum` helper.

## Commits in this PR (13)

For commit-by-commit review:

1. `a81be73a` feat(mavlink2-bridge): scaffold workspace extension
2. `6f2c7b7f` feat(mavlink2-bridge): add MavlinkArrow trait with HEARTBEAT impl
3. `65a00744` feat(mavlink2-bridge-node): TCP bridge node + transport URL parser
4. `33be78a3` feat(mavlink2-bridge): add UDP and serial transports
5. `3cdfb059` feat(mavlink2-bridge): expand Arrow conversion to common dialect
6. `c17d7fb9` feat(mavlink2-bridge): example dataflow + smoke tests + docs
7. `f0e2ade2` feat(mavlink2-bridge): SITL closed-loop mission example
8. `5def41bd` fix(mavlink2-bridge): URL ?proto=v1|v2 query for V1-only firmware
9. `6899c79c` feat(mavlink2-bridge): SET_MODE + RC_CHANNELS_OVERRIDE inputs + auto-request data streams
10. `0fc6526f` feat(mavlink2-bridge-sitl-mission): long flight demo + QGC forwarder
11. `f574ba0b` feat(mavlink2-bridge-sitl-mission): rover variant — square-drive on dronekit-sitl
12. `993ff47f` docs(mavlink2-bridge): document SET_MODE base_mode mavlink-rust 0.13 limitation
13. `279355c7` chore(gitignore): ignore SITL runtime artifacts and .project_notes/

Closes #1786.
