### PR TITLE
fix(daemon): spawn runtime via current_exe() instead of PATH lookup (#1797)

### DIFF
--- a/binaries/daemon/src/spawn/spawner.rs
+++ b/binaries/daemon/src/spawn/spawner.rs
@@ -310,8 +310,13 @@ impl Spawner {
                         ]);
                         Some(cmd)
                     } else {
-                        let mut cmd =
-                            Command::new(which::which("dora").wrap_err("failed to get dora path")?);
+                        // Use the daemon's own executable so we always spawn
+                        // a matching runtime. A PATH lookup for the dora
+                        // binary would pick whatever appears first on PATH,
+                        // which can be a different install (system vs cargo
+                        // install, or a daemon launched from a venv). See
+                        // #1797.
+                        let mut cmd = Command::new(&current_exe);
                         cmd = cmd.arg("runtime");
                         Some(cmd)
                     }
@@ -375,5 +380,26 @@ impl Spawner {
             last_activity,
             ft_stats: self.ft_stats,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// Regression guard for #1797: the daemon must spawn its runtime via
+    /// `std::env::current_exe()`, not the PATH-resolved `dora` binary, so
+    /// that a daemon launched from a non-PATH location (cargo install, venv,
+    /// etc.) always spawns a matching runtime.
+    ///
+    /// Built at runtime so the source file does not itself contain the
+    /// forbidden literal — otherwise `include_str!` would always trip.
+    #[test]
+    fn runtime_spawn_does_not_use_which_dora() {
+        let src = include_str!("spawner.rs");
+        let forbidden = ["which", "::", "which", "(\"", "dora", "\")"].concat();
+        assert!(
+            !src.contains(&forbidden),
+            "spawner.rs must not resolve the runtime binary via PATH lookup; \
+             use std::env::current_exe() instead (see #1797)"
+        );
     }
 }


### PR DESCRIPTION
Closes #1797.

## Summary

- `binaries/daemon/src/spawn/spawner.rs` — non-Python branch of `prepare_node_inner` was resolving the runtime binary via PATH lookup, which can pick a different `dora` than the daemon itself (system vs cargo install, or daemon launched from a venv). Reuse the `current_exe` already computed at line 273 for the sibling Python-detection check, matching the existing pattern in the same arm.
- Carry-over of @DGHX12345 original fix in `dora-rs/adora#316`, which never migrated to `dora-rs/dora` after the 1.0 consolidation.

## Why a structural test

A full behavioral test would need to:
1. Build the daemon binary.
2. Place it at a non-PATH location (or unset PATH).
3. Spawn a non-Python operator dataflow.
4. Verify the runtime is launched from the daemon's location, not a stale `dora` elsewhere on PATH.

That's E2E scope for a 3-line fix. Instead, this PR adds a tiny structural guard in `spawner.rs`'s `#[cfg(test)] mod tests` that includes the source via `include_str!` and asserts the forbidden PATH-lookup pattern never reappears. Confirmed RED before the fix (test fails on un-patched code) and GREEN after.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p dora-daemon -- -D warnings` (matching CI invocation)
- [x] `cargo test -p dora-daemon` — 33/33 pass, including new `runtime_spawn_does_not_use_which_dora`
- [x] RED check: temporarily reverted the fix, confirmed the new test fails with the exact message about #1797
- [ ] Reviewer: confirm the structural test approach is acceptable for this class of "don't use PATH lookup" regression, or request a refactor for proper unit-testing of the command-building logic
