### PR TITLE
docs: point coordinator-HA known-limitation links at #1799

### DIFF
--- a/guide/src/operations/distributed.md
+++ b/guide/src/operations/distributed.md
@@ -553,7 +553,7 @@ This means a node that crashes immediately will only be re-spawned once every 30
 
 - Auto-recovery only applies to dataflows started via `dora start` (coordinator-managed). Local `dora run` dataflows are not tracked by the coordinator.
 - Recovery re-spawns all nodes assigned to the reconnecting daemon, not individual nodes. For per-node restart on crash, use [restart policies](fault-tolerance.md#restart-policies).
-- **Known issue ([#260](https://github.com/dora-rs/adora/issues/260)):** when the daemon's WebSocket connection to the coordinator drops, the daemon currently kills all running node processes before reconnecting. This means the coordinator's auto-recovery path re-spawns the nodes from scratch rather than reclaiming still-running processes. The net effect is a brief disruption (nodes restart) rather than seamless continuity. A fix to preserve running processes across reconnect cycles is planned.
+- **Known issue ([#1799](https://github.com/dora-rs/dora/issues/1799)):** when the daemon's WebSocket connection to the coordinator drops, the daemon currently kills all running node processes before reconnecting. This means the coordinator's auto-recovery path re-spawns the nodes from scratch rather than reclaiming still-running processes. The net effect is a brief disruption (nodes restart) rather than seamless continuity. A fix to preserve running processes across reconnect cycles is planned (see [`docs/plan-coordinator-ha.md`](../../../docs/plan-coordinator-ha.md) Phase 1.4).
 
 ---
 

--- a/guide/src/operations/fault-tolerance.md
+++ b/guide/src/operations/fault-tolerance.md
@@ -867,7 +867,7 @@ The node processes one batch, exits with code 0, waits 10s, then restarts to pro
 
 **Use `--store redb` for production deployments**. The redb backend ensures the coordinator retains dataflow history across crashes and restarts. The in-memory default is fine for development but loses all state on exit. The redb file is small (proportional to the number of dataflow records) and adds negligible overhead.
 
-**Known limitation:** when the coordinator disconnects, the daemon currently kills running node processes before reconnecting ([#260](https://github.com/dora-rs/adora/issues/260)). Dataflow *records* survive coordinator restart (via redb), but running *processes* are restarted from scratch. Seamless process reclaim across reconnect is planned.
+**Known limitation:** when the coordinator disconnects, the daemon currently kills running node processes before reconnecting ([#1799](https://github.com/dora-rs/dora/issues/1799)). Dataflow *records* survive coordinator restart (via redb), but running *processes* are restarted from scratch. Seamless process reclaim across reconnect is planned (see [`docs/plan-coordinator-ha.md`](../../../docs/plan-coordinator-ha.md) Phase 1.4).
 
 **Combine features for defense in depth**:
 - `restart_policy` + `restart_delay` -> recover from node crashes


### PR DESCRIPTION
Bookkeeping for #1799.

## Summary

`guide/src/operations/distributed.md:556` and `guide/src/operations/fault-tolerance.md:870` both pointed at the closed adora-side issue `dora-rs/adora#260` for the "daemon kills running dataflows on coordinator disconnect" known limitation. That link is a dead end on this repo.

This PR retargets both references to #1799, which has been rescoped to track the remaining Phase 1.4 work specifically (see issue body for the status table of what's already shipped vs. what's left).

Also inlines a link to `docs/plan-coordinator-ha.md` Phase 1.4 in both notes so a contributor landing on the limitation can find the implementation plan without a GitHub round-trip.

## Test plan

- [x] `grep -rn "adora/issues/260\|adora#260" --include="*.md" --include="*.rs"` returns empty
- [x] Relative path `../../../docs/plan-coordinator-ha.md` from `guide/src/operations/*.md` resolves to a real file
- [ ] Reviewer: confirm the link retarget is the right call vs. keeping the historical adora reference somewhere
