### PR TITLE
fix(daemon): fall back to PATH when current_exe is not the dora binary (#1805)

### DIFF
--- a/binaries/daemon/src/spawn/spawner.rs
+++ b/binaries/daemon/src/spawn/spawner.rs
@@ -309,14 +309,23 @@ impl Spawner {
                             format!("import dora; dora.start_runtime() # {}", node.id).as_str(),
                         ]);
                         Some(cmd)
-                    } else {
-                        // Use the daemon's own executable so we always spawn
-                        // a matching runtime. A PATH lookup for the dora
-                        // binary would pick whatever appears first on PATH,
-                        // which can be a different install (system vs cargo
-                        // install, or a daemon launched from a venv). See
-                        // #1797.
+                    } else if file_name == "dora" {
+                        // current_exe is the dora binary — use it so the
+                        // spawned runtime always matches the daemon version.
+                        // See #1797.
                         let mut cmd = Command::new(&current_exe);
+                        cmd = cmd.arg("runtime");
+                        Some(cmd)
+                    } else {
+                        // current_exe is something else, e.g. an embedded
+                        // example runner that calls `dora_cli::run()` —
+                        // see examples/c-dataflow/run.rs:21. Spawning
+                        // current_exe with `runtime` would recurse into
+                        // the example runner. Fall back to PATH lookup
+                        // for the dora binary. See #1805.
+                        let mut cmd = Command::new(
+                            which::which("dora").wrap_err("failed to find dora binary on PATH")?,
+                        );
                         cmd = cmd.arg("runtime");
                         Some(cmd)
                     }
@@ -380,26 +389,5 @@ impl Spawner {
             last_activity,
             ft_stats: self.ft_stats,
         })
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    /// Regression guard for #1797: the daemon must spawn its runtime via
-    /// `std::env::current_exe()`, not the PATH-resolved `dora` binary, so
-    /// that a daemon launched from a non-PATH location (cargo install, venv,
-    /// etc.) always spawns a matching runtime.
-    ///
-    /// Built at runtime so the source file does not itself contain the
-    /// forbidden literal — otherwise `include_str!` would always trip.
-    #[test]
-    fn runtime_spawn_does_not_use_which_dora() {
-        let src = include_str!("spawner.rs");
-        let forbidden = ["which", "::", "which", "(\"", "dora", "\")"].concat();
-        assert!(
-            !src.contains(&forbidden),
-            "spawner.rs must not resolve the runtime binary via PATH lookup; \
-             use std::env::current_exe() instead (see #1797)"
-        );
     }
 }


### PR DESCRIPTION
Fixes #1805 — regression from #1797/#1801.

## Summary

#1797 switched the non-Python runtime spawn path from `which::which("dora")` to `std::env::current_exe()` so the spawned runtime always matches the daemon's version. That works for normal daemon installs (where `current_exe` *is* the dora binary), but breaks **embedded example runners** like `examples/c-dataflow/run.rs:21` — those call `dora_cli::run(...)` from inside `target/debug/examples/c-dataflow`, so `current_exe` returns the example runner, and spawning it with the `runtime` argument recurses into a second embedded coordinator on the same port → "Address already in use" in nightly CI.

Diagnosis credit @phil-opp on [#1805](https://github.com/dora-rs/dora/issues/1805#issuecomment-4441943866).

## Fix

`binaries/daemon/src/spawn/spawner.rs:312-332` — split the non-Python `else` branch on `file_name == "dora"`:

- **Primary path** (`current_exe` is dora): use `current_exe` directly. Preserves #1797's guarantee that runtime nodes match the daemon version.
- **Fallback** (`current_exe` is something else, e.g. embedded example runner): fall back to `which::which("dora")` for the spawn target. Restores the pre-#1797 behavior that nightly CI relied on.

Symmetric in shape with the Python-binary detection right above (`file_name.ends_with("python")` at line 296).

## Why remove the structural test from #1797

The test added in #1797 (`runtime_spawn_does_not_use_which_dora`) asserted that `which::which("dora")` never appears in `spawner.rs`. It would have rejected this fix even though the fix is correct. The test was a syntactic check, not a semantic one — it gave false confidence and didn't catch the actual regression (current_exe doesn't have to be the dora binary).

The real invariant we want — "spawned runtime matches daemon version when the daemon is a real dora binary" — needs a behavioral test that exercises the spawn path, which requires refactoring `prepare_node_inner` for testability. That's out of scope for this hotfix. **Nightly CI is the authoritative guard until that refactor lands** — it caught what the structural test missed.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p dora-daemon -- -D warnings` clean
- [x] `cargo test -p dora-daemon` — 32/32 pass (test count dropped from 33 to 32 with the structural test removal)
- [ ] **Authoritative check**: nightly CI on this branch needs to go green on the `examples` job that failed in #1805
