### PR TITLE
feat(qa): add `make qa-pgo` for Profile-Guided Optimization measurement (#331)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,7 @@ All three steps are required for every commit. Do NOT push without completing th
 
 ### Do NOT run the full QA suite on every commit/push
 
-The deeper QA gates — `make qa-full`, `make qa-deep`, `make qa-nightly`, `make qa-release-gate`, `make qa-mutation-audit`, `make qa-examples`, `make qa-coverage`, `make qa-mutants`, `make qa-semver` — are designed for **focused investigation and pre-release gating**, not the per-commit loop. Do not run them routinely, and do not add them to remote CI:
+The deeper QA gates — `make qa-full`, `make qa-deep`, `make qa-nightly`, `make qa-release-gate`, `make qa-mutation-audit`, `make qa-examples`, `make qa-coverage`, `make qa-mutants`, `make qa-semver`, `make qa-pgo` — are designed for **focused investigation and pre-release gating**, not the per-commit loop. Do not run them routinely, and do not add them to remote CI:
 
 - `make qa-full` (qa-fast + full tests + coverage) — ~5-10 minutes. Run before a significant push if you want extra confidence; coverage is too slow for every push.
 - `make qa-deep` (qa-full + mutation testing + semver) — ~15 minutes. The **target** Tier 1 local gate. Today's CI PR gate only runs the fast subset (fmt/clippy/typos/audit/unwrap-budget + tests); `qa-deep` adds coverage, adversarial review, diff-scoped mutation, and semver — kept laptop-only because they're too slow for every PR (see `docs/plan-agentic-qa-strategy.md` §5). Alias: `make qa-tier1`, kept for back-compat.
@@ -167,6 +167,7 @@ The deeper QA gates — `make qa-full`, `make qa-deep`, `make qa-nightly`, `make
 - `make qa-coverage` — generates an lcov report locally. Run when you want to see what's covered.
 - `make qa-mutants` — mutation testing, slow. Run when investigating test quality on a specific file or on the PR diff.
 - `make qa-semver` — breaking-change check. Run before publishing to crates.io.
+- `make qa-pgo` — ~30-40 min. Profile-Guided Optimization measurement: builds `dora-cli` with `cargo-pgo` (instrument → train on `examples/benchmark/` → optimize), then runs the benchmark twice (baseline vs PGO) and prints a side-by-side comparison with a +5%-throughput-geomean verdict. Run on your target platform — PGO results don't transfer across OS/arch. macOS-arm64 first-measurement showed +25% throughput geomean, latency unchanged (see [#331](https://github.com/dora-rs/dora/issues/331)). **Do not add to CI** — the build pipeline cost is release-pipeline scope, not per-commit. Install via `make qa-pgo-install`.
 
 **Remote CI is deliberately kept lean** — only the fast hard gates (fmt, clippy, test on Linux, typos, supply chain audit, unwrap budget, E2E, contract tests, benchmark regression, license check) — so it stays fast (~30-45 min critical path) and runner capacity is not a bottleneck. Do not expand PR CI with slow jobs. See [`docs/qa-runbook.md`](docs/qa-runbook.md) for when and how to use each deep gate locally.
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@
 .PHONY: qa qa-fast qa-full qa-deep qa-tier1 qa-nightly qa-release-gate qa-mutation-audit \
         qa-examples \
         qa-fmt qa-audit qa-unwrap qa-clippy qa-test qa-coverage qa-mutants qa-semver \
-        qa-adversarial qa-install
+        qa-adversarial qa-pgo qa-install qa-pgo-install
 
 qa: qa-fast
 

--- a/Makefile
+++ b/Makefile
@@ -121,8 +121,22 @@ qa-semver:
 qa-adversarial:
 	@scripts/qa/adversarial.sh
 
+# Profile-Guided Optimization measurement. Build dora-cli with cargo-pgo
+# (instrument -> train on examples/benchmark -> optimize), then run the
+# benchmark twice (baseline vs PGO) and print a side-by-side comparison.
+# Budget ~30-40 min wall time, ~5-10 GB extra target/ artifacts. PGO results
+# don't transfer across OS/arch — run this on your target platform to find
+# out if PGO helps. See dora-rs/dora#331 for the methodology and the
+# macOS-arm64 baseline data point (+25% throughput geomean).
+qa-pgo:
+	@scripts/qa/pgo.sh
+
 # One-shot tool installation
 
 qa-install:
 	cargo install cargo-audit cargo-deny cargo-llvm-cov cargo-mutants cargo-semver-checks
+	rustup component add llvm-tools-preview
+
+qa-pgo-install:
+	cargo install cargo-pgo
 	rustup component add llvm-tools-preview

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -125,6 +125,35 @@ Operators run in-process with the runtime (zero IPC overhead) but share the GIL 
 
 For cross-machine communication, Dora uses Zenoh pub-sub. Latency depends on network quality. Use local deployment (single-machine) when sub-millisecond latency is required.
 
+### Profile-Guided Optimization (PGO)
+
+PGO trains the compiler on real execution traces and can give 5-15% wins on i-cache-heavy hot loops. For dora's pub/sub data path it typically helps throughput more than latency — the throughput phase of the benchmark is the canonical "tight loop with biased branches" workload PGO is designed for.
+
+**Measurement on macOS-arm64** ([#331](https://github.com/dora-rs/dora/issues/331)):
+
+| Metric | PGO / baseline geomean | Delta |
+|---|---|---|
+| p50 latency | 1.022 | +2.2% (noise) |
+| p99 latency | 1.010 | +1.0% (noise) |
+| **Throughput** | **1.256** | **+25.6%** |
+
+**Run the measurement on your platform.** Results don't transfer across OS/arch — Linux x86 may show different numbers, and only your-platform numbers should drive your-platform decisions.
+
+```bash
+make qa-pgo-install   # one-time: cargo-pgo + llvm-tools-preview
+make qa-pgo           # ~30-40 min: instrument, train, optimize, compare
+```
+
+`make qa-pgo` prints a side-by-side comparison and an explicit verdict based on the throughput geomean. Decision rule:
+
+- **≥ +5% throughput** — PGO is worth integrating into the release pipeline for that platform
+- **within ±5%** — inconclusive, re-run with multiple iterations for stable medians
+- **≤ -5% throughput** — PGO regresses on this platform; do not ship
+
+The PGO build pipeline adds roughly 2.5-3× the wall time of a plain `--profile dist` build (~17 min total on macOS-arm64). That puts it firmly in release-pipeline territory — **don't add it to per-commit CI**. The recommended shape is a one-shot job that runs against a release tag and uploads PGO'd binaries as release artifacts.
+
+**What gets PGO'd:** only `dora-cli` (which embeds the coordinator, daemon, and runtime). User node binaries are not instrumented by this recipe; they would need their own per-binary PGO pass if their hot paths matter.
+
 ## CSV Output Format
 
 All benchmarks support `BENCH_CSV` environment variable for machine-readable output:

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -137,6 +137,8 @@ PGO trains the compiler on real execution traces and can give 5-15% wins on i-ca
 | p99 latency | 1.010 | +1.0% (noise) |
 | **Throughput** | **1.256** | **+25.6%** |
 
+Numbers above are from a **single** `make qa-pgo` run with n=100 per payload size. Geomean across sizes is the load-bearing metric; individual size rows have ~10-20% single-run noise, and the geomean itself has roughly ±5% noise floor. Re-run 3-5 times and take the median before drawing a conclusion either way.
+
 **Run the measurement on your platform.** Results don't transfer across OS/arch — Linux x86 may show different numbers, and only your-platform numbers should drive your-platform decisions.
 
 ```bash

--- a/scripts/qa/pgo.sh
+++ b/scripts/qa/pgo.sh
@@ -86,14 +86,31 @@ echo "=== [2/5] Running baseline benchmark (~2 min) ==="
 echo "Baseline CSV: $OUT_DIR/baseline.csv"
 
 # ---- 3/5: PGO instrumented build ----
+# Force --target $HOST so the instrumented binary always overwrites the
+# baseline at target/$HOST/dist/dora. Without it, if cargo-pgo's behavior
+# or the user's cargo config sends output elsewhere, the existence check
+# below would pass against the stale baseline binary from step 1, and
+# steps 4-5 would silently train+benchmark the baseline instead of the
+# instrumented build — producing a meaningless +0% comparison.
 echo ""
 echo "=== [3/5] PGO instrumented build (~10 min) ==="
 cargo pgo instrument build -- \
+  --target "$HOST" \
   -p dora-cli \
   --profile dist
 
 if [ ! -x "$PGO_DORA" ]; then
   echo "ERROR: instrumented dora not at $PGO_DORA"
+  exit 1
+fi
+
+# Sanity check: the instrumented binary must differ from the baseline copy
+# we made in step 1, otherwise step 3 silently produced the wrong artifact
+# (e.g., empty profiles, no relink, etc.) and the comparison would be a no-op.
+if cmp -s "$BASELINE_DORA" "$PGO_DORA"; then
+  echo "ERROR: instrumented binary at $PGO_DORA is byte-identical to baseline"
+  echo "       at $BASELINE_DORA — instrumentation did not take effect."
+  echo "       Check 'cargo pgo instrument build' output for issues."
   exit 1
 fi
 
@@ -107,6 +124,7 @@ echo "=== [4/5] Training run + PGO optimize build (~7 min) ==="
     > "$OUT_DIR/training.txt" 2>&1
 )
 cargo pgo optimize build -- \
+  --target "$HOST" \
   -p dora-cli \
   --profile dist
 

--- a/scripts/qa/pgo.sh
+++ b/scripts/qa/pgo.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# scripts/qa/pgo.sh — Profile-Guided Optimization measurement
+#
+# Builds dora-cli with cargo-pgo (instrument -> train on examples/benchmark
+# -> optimize), then runs the benchmark twice (baseline vs PGO) and prints
+# a side-by-side comparison.
+#
+# Origin: dora-rs/dora#331. On macOS-arm64 (the platform where this was
+# first measured) PGO gave roughly +25% throughput geomean across 10 payload
+# sizes with latency unchanged. Run this on your target platform to find out
+# if the same holds — PGO results don't transfer across OS/arch.
+#
+# Install:
+#   cargo install cargo-pgo
+#   rustup component add llvm-tools-preview
+#
+# Runtime: ~30-40 min wall time. Disk: ~5-10 GB extra target/ artifacts.
+# Run on a quiet machine — benchmarks are sensitive to other CPU load.
+#
+# Decision rule: throughput geomean >= +5% on your platform -> PGO is worth
+# adding to that platform's release-pipeline. Below that, the build-time cost
+# (~17 min extra per release) outweighs the win.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+REPO_ROOT="$PWD"
+
+# ---- Preflight ----
+if ! command -v cargo-pgo >/dev/null; then
+  echo "ERROR: cargo-pgo not installed. Run:"
+  echo "  cargo install cargo-pgo"
+  echo "  rustup component add llvm-tools-preview"
+  exit 1
+fi
+
+if ! cargo pgo info 2>&1 | grep -q "llvm-profdata.*found at"; then
+  echo "ERROR: llvm-profdata not found (needed for PGO profile merging)."
+  echo "Install the rustup component:"
+  echo "  rustup component add llvm-tools-preview"
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null; then
+  echo "ERROR: python3 not found (needed for the comparison summary)."
+  exit 1
+fi
+
+HOST=$(rustc -vV | awk '/host:/ {print $2}')
+OUT_DIR="$REPO_ROOT/target/pgo-bench"
+BASELINE_DORA="$REPO_ROOT/target/dist/dora"
+PGO_DORA="$REPO_ROOT/target/$HOST/dist/dora"
+
+mkdir -p "$OUT_DIR"
+
+# ---- 1/5: baseline build ----
+echo "=== [1/5] Building baseline (--profile dist) ==="
+cargo build --profile dist \
+  -p dora-cli \
+  -p benchmark-example-node \
+  -p benchmark-example-sink
+
+if [ ! -x "$BASELINE_DORA" ]; then
+  echo "ERROR: baseline dora not built at $BASELINE_DORA"
+  exit 1
+fi
+
+# ---- 2/5: baseline benchmark ----
+echo ""
+echo "=== [2/5] Running baseline benchmark (~2 min) ==="
+(
+  cd examples/benchmark
+  BENCH_CSV="$OUT_DIR/baseline.csv" "$BASELINE_DORA" run dataflow.yml \
+    > "$OUT_DIR/baseline.txt" 2>&1
+)
+echo "Baseline CSV: $OUT_DIR/baseline.csv"
+
+# ---- 3/5: PGO instrumented build ----
+echo ""
+echo "=== [3/5] PGO instrumented build (~10 min) ==="
+cargo pgo instrument build -- \
+  -p dora-cli \
+  --profile dist
+
+if [ ! -x "$PGO_DORA" ]; then
+  echo "ERROR: instrumented dora not at $PGO_DORA"
+  exit 1
+fi
+
+# ---- 4/5: training run + optimize ----
+echo ""
+echo "=== [4/5] Training run + PGO optimize build (~7 min) ==="
+(
+  cd examples/benchmark
+  LLVM_PROFILE_FILE="$REPO_ROOT/target/pgo-profiles/dora_%m_%p.profraw" \
+    "$PGO_DORA" run dataflow.yml \
+    > "$OUT_DIR/training.txt" 2>&1
+)
+cargo pgo optimize build -- \
+  -p dora-cli \
+  --profile dist
+
+# ---- 5/5: PGO benchmark ----
+echo ""
+echo "=== [5/5] Running PGO benchmark (~2 min) ==="
+(
+  cd examples/benchmark
+  BENCH_CSV="$OUT_DIR/pgo.csv" "$PGO_DORA" run dataflow.yml \
+    > "$OUT_DIR/pgo.txt" 2>&1
+)
+echo "PGO CSV:      $OUT_DIR/pgo.csv"
+
+# ---- Analysis ----
+echo ""
+echo "=== Comparison ==="
+python3 - "$OUT_DIR/baseline.csv" "$OUT_DIR/pgo.csv" <<'PYEOF'
+import csv, math, sys
+
+baseline_csv, pgo_csv = sys.argv[1], sys.argv[2]
+
+def load(path):
+    rows = {}
+    with open(path) as f:
+        for r in csv.reader(f):
+            mode, bytes_, label, n, avg, p50, p95, p99, p999, _mn, _mx = r
+            rows[(mode, label)] = {
+                'bytes': int(bytes_), 'n': int(n),
+                'avg': int(avg), 'p50': int(p50), 'p95': int(p95),
+                'p99': int(p99), 'p999': int(p999),
+            }
+    return rows
+
+base = load(baseline_csv)
+pgo = load(pgo_csv)
+
+def pct(b, p):
+    return 0 if b == 0 else (p - b) / b * 100
+
+def gmean(xs):
+    return math.exp(sum(math.log(x) for x in xs) / len(xs)) if xs else 1.0
+
+# Discover sizes from baseline keys, preserving insertion order
+sizes = []
+for (mode, label) in base.keys():
+    if mode == 'latency' and label not in sizes:
+        sizes.append(label)
+
+# --- Throughput table ---
+print()
+print("Throughput (msg/s, higher = better)")
+print(f"  {'size':>6}  {'baseline':>12}  {'pgo':>12}  {'delta':>10}  verdict")
+print(f"  {'-'*6}  {'-'*12}  {'-'*12}  {'-'*10}  -------")
+throughput_ratios = []
+for size in sizes:
+    bt, pt = base.get(('throughput', size)), pgo.get(('throughput', size))
+    if not bt or not pt:
+        continue
+    d = pct(bt['avg'], pt['avg'])
+    verdict = 'better' if d >= 5 else ('worse' if d <= -5 else 'noise')
+    print(f"  {size:>6}  {bt['avg']:>10} m/s  {pt['avg']:>10} m/s  {d:>+8.1f}%  {verdict}")
+    throughput_ratios.append(pt['avg'] / bt['avg'])
+
+# --- Latency p50/p99 aggregate ---
+p50_ratios, p99_ratios = [], []
+for size in sizes:
+    bl, pl = base.get(('latency', size)), pgo.get(('latency', size))
+    if not bl or not pl:
+        continue
+    p50_ratios.append(pl['p50'] / bl['p50'])
+    p99_ratios.append(pl['p99'] / bl['p99'])
+
+print()
+print("Aggregate (geomean across all sizes)")
+print(f"  p50 latency  pgo/baseline = {gmean(p50_ratios):.3f}  ({(gmean(p50_ratios)-1)*100:+.1f}%)")
+print(f"  p99 latency  pgo/baseline = {gmean(p99_ratios):.3f}  ({(gmean(p99_ratios)-1)*100:+.1f}%)")
+print(f"  throughput   pgo/baseline = {gmean(throughput_ratios):.3f}  ({(gmean(throughput_ratios)-1)*100:+.1f}%)")
+
+# --- Decision ---
+print()
+throughput_delta = (gmean(throughput_ratios) - 1) * 100
+if throughput_delta >= 5:
+    print(f"VERDICT: PGO improves throughput by {throughput_delta:+.1f}% geomean on this platform.")
+    print("        Worth integrating into the release pipeline if the +5% rule applies.")
+elif throughput_delta <= -5:
+    print(f"VERDICT: PGO regresses throughput by {throughput_delta:+.1f}% geomean on this platform.")
+    print("        Do NOT ship PGO for this platform.")
+else:
+    print(f"VERDICT: PGO throughput change is {throughput_delta:+.1f}% geomean — within noise floor.")
+    print("        Inconclusive — re-run with multiple iterations for stable medians.")
+
+print()
+print(f"Raw CSVs: {baseline_csv}  {pgo_csv}")
+print(f"Logs:     {baseline_csv.replace('.csv', '.txt')}  {pgo_csv.replace('.csv', '.txt')}")
+PYEOF

--- a/scripts/qa/pgo.sh
+++ b/scripts/qa/pgo.sh
@@ -48,22 +48,32 @@ fi
 
 HOST=$(rustc -vV | awk '/host:/ {print $2}')
 OUT_DIR="$REPO_ROOT/target/pgo-bench"
-BASELINE_DORA="$REPO_ROOT/target/dist/dora"
-PGO_DORA="$REPO_ROOT/target/$HOST/dist/dora"
+# Force --target $HOST for both baseline and PGO builds so paths are
+# predictable regardless of user's cargo config. Step 3 (instrument) will
+# overwrite the binary at target/$HOST/dist/dora, but step 2 has already
+# captured the baseline CSV by then, so we also copy the binary to OUT_DIR
+# so it survives the overwrite and can be re-inspected.
+HOST_DIST_DORA="$REPO_ROOT/target/$HOST/dist/dora"
+BASELINE_DORA="$OUT_DIR/baseline-dora"
+PGO_DORA="$HOST_DIST_DORA"
 
 mkdir -p "$OUT_DIR"
 
 # ---- 1/5: baseline build ----
 echo "=== [1/5] Building baseline (--profile dist) ==="
-cargo build --profile dist \
+cargo build --target "$HOST" --profile dist \
   -p dora-cli \
   -p benchmark-example-node \
   -p benchmark-example-sink
 
-if [ ! -x "$BASELINE_DORA" ]; then
-  echo "ERROR: baseline dora not built at $BASELINE_DORA"
+if [ ! -x "$HOST_DIST_DORA" ]; then
+  echo "ERROR: baseline dora not built at $HOST_DIST_DORA"
   exit 1
 fi
+
+# Preserve the baseline binary so step 3's instrument build doesn't clobber
+# the only copy we have for re-inspection / re-running step 2.
+cp "$HOST_DIST_DORA" "$BASELINE_DORA"
 
 # ---- 2/5: baseline benchmark ----
 echo ""
@@ -178,12 +188,18 @@ print(f"  throughput   pgo/baseline = {gmean(throughput_ratios):.3f}  ({(gmean(t
 # --- Decision ---
 print()
 throughput_delta = (gmean(throughput_ratios) - 1) * 100
+single_run_caveat = (
+    "        Single run with n=100/size — the geomean itself has ~5% noise floor."
+    "\n        Re-run 3-5 times and take the median to confirm the signal is real."
+)
 if throughput_delta >= 5:
     print(f"VERDICT: PGO improves throughput by {throughput_delta:+.1f}% geomean on this platform.")
     print("        Worth integrating into the release pipeline if the +5% rule applies.")
+    print(single_run_caveat)
 elif throughput_delta <= -5:
     print(f"VERDICT: PGO regresses throughput by {throughput_delta:+.1f}% geomean on this platform.")
     print("        Do NOT ship PGO for this platform.")
+    print(single_run_caveat)
 else:
     print(f"VERDICT: PGO throughput change is {throughput_delta:+.1f}% geomean — within noise floor.")
     print("        Inconclusive — re-run with multiple iterations for stable medians.")

--- a/scripts/qa/pgo.sh
+++ b/scripts/qa/pgo.sh
@@ -34,10 +34,18 @@ if ! command -v cargo-pgo >/dev/null; then
   exit 1
 fi
 
-if ! cargo pgo info 2>&1 | grep -q "llvm-profdata.*found at"; then
+# cargo-pgo's `info` exits non-zero when *optional* BOLT tools are missing,
+# even if llvm-profdata is found. We only need llvm-profdata for the PGO
+# (no-BOLT) path, so capture the output without letting pipefail abort us
+# on a BOLT-only failure, then grep for what we actually need.
+PGO_INFO=$(cargo pgo info 2>&1 || true)
+if ! grep -q "llvm-profdata.*found at" <<<"$PGO_INFO"; then
   echo "ERROR: llvm-profdata not found (needed for PGO profile merging)."
   echo "Install the rustup component:"
   echo "  rustup component add llvm-tools-preview"
+  echo ""
+  echo "cargo pgo info output was:"
+  echo "$PGO_INFO"
   exit 1
 fi
 


### PR DESCRIPTION
Captures the PGO measurement work from #331 as a reproducible `make qa-pgo` target so other platforms can run the same loop and decide for themselves.

## Why

[#331](https://github.com/dora-rs/dora/issues/331) was filed in 2023 asking dora to evaluate PGO. I ran the measurement on macOS-arm64 yesterday and posted the results in the issue — **+25.6% throughput geomean, latency unchanged**. That's a real signal, but PGO results don't transfer across OS/arch, so the next person needs to run the same thing on Linux x86 before any decision to ship a `--profile pgo-dist` recipe.

This PR makes that reproducible: `make qa-pgo` runs the full instrument → train → optimize → benchmark-vs-baseline loop and prints a verdict.

## What ships

| File | Change |
|---|---|
| `scripts/qa/pgo.sh` | The runner: preflight checks (cargo-pgo, llvm-tools-preview, python3), 5-step pipeline (baseline build → baseline bench → instrumented build → training run + optimize → PGO bench), then a side-by-side comparison table with explicit verdict |
| `Makefile` | Two new targets: `qa-pgo` (run the measurement) and `qa-pgo-install` (one-time tool install) |
| `docs/performance.md` | New "Profile-Guided Optimization (PGO)" section under Performance Tuning, including the macOS-arm64 reference data point and the +5%-throughput decision rule |
| `CLAUDE.md` | `qa-pgo` added to the qa-* registry with the do-not-add-to-CI guidance |

## Cost / scope

- ~30-40 min wall time per run.
- ~5-10 GB extra `target/` artifacts.
- Build pipeline alone is 2.5-3× plain `--profile dist`: ~17 min vs ~6 min.

That puts this firmly in release-pipeline territory if anyone ever decides to ship PGO'd binaries. The script and Makefile target are deliberately **not** added to any CI workflow — this is investigation scope, alongside `qa-mutation-audit` and `qa-coverage`.

## What the script prints

End of run:

```
Throughput (msg/s, higher = better)
    size      baseline           pgo       delta  verdict
  ------  ------------  ------------  ----------  -------
      0B       18843 m/s       24819 m/s     +31.7%  better
     8B       13157 m/s       24887 m/s     +89.2%  better
   ... (10 rows total)

Aggregate (geomean across all sizes)
  p50 latency  pgo/baseline = 1.022  (+2.2%)
  p99 latency  pgo/baseline = 1.010  (+1.0%)
  throughput   pgo/baseline = 1.256  (+25.6%)

VERDICT: PGO improves throughput by +25.6% geomean on this platform.
        Worth integrating into the release pipeline if the +5% rule applies.
```

Verdict logic has three branches: `+5%` ship-worthy, `±5%` inconclusive (re-run with more iterations), `−5%` regression (do not ship).

## What's NOT in scope for this PR

- **Linux x86 measurement** — needs the next person.
- **Multi-iteration runs** — script does one baseline + one PGO benchmark. The output explicitly notes that individual size rows have ~10-20% noise and only the geomean across sizes is reliable. Adding iterations is straightforward (wrap the bench in a loop, take median) but adds another 10+ min and is better done as a follow-up if needed.
- **Ship PGO'd binaries from release pipeline** — gated on second-platform validation.
- **LLVM BOLT** — separate post-link optimizer that can add another 3-5% on top of PGO. Requires building LLVM with BOLT, which is non-trivial; out of scope.

## Test plan

- [x] `bash -n scripts/qa/pgo.sh` — syntax clean
- [x] `make -n qa-pgo` / `make -n qa-pgo-install` — Makefile targets parse
- [x] `typos` on all changed files — clean
- [x] Python heredoc compiles + runs end-to-end with sample CSV data (verdict logic exercised on the macOS-arm64 numbers from #331)
- [ ] **Authoritative**: someone with a Linux x86 machine runs `make qa-pgo-install && make qa-pgo` and posts the verdict in #331

The PR doesn't unblock #331 by itself (the close decision still needs second-platform data), but it removes the friction of "where do I even start?" — the recipe is now one command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
