### PR TITLE
docs(c-api): document thread-safety contract per function (#540)

### DIFF
--- a/apis/c/node/node_api.h
+++ b/apis/c/node/node_api.h
@@ -1,9 +1,48 @@
 #include <stddef.h>
 
+/*
+ * dora C node API
+ *
+ * ## Threading model
+ *
+ * The dora context (returned by init_dora_context_from_env) and any event
+ * pointer (returned by dora_next_event) are NOT internally synchronized.
+ * Each function below is annotated with its thread-safety contract.
+ *
+ * Rule of thumb:
+ *   - A single context pointer must be accessed by at most one thread at a
+ *     time. The dora-cli has not yet stabilized a Sync-safe context, so
+ *     calling dora_next_event / dora_send_output / dora_log concurrently
+ *     with the same context is undefined behavior.
+ *   - Event pointers are read-only after creation, so multiple threads
+ *     may read fields from the same event concurrently (each thread
+ *     supplying its own out_ptr / out_len storage).
+ *   - free_dora_context and free_dora_event take ownership; the caller
+ *     must guarantee no other thread is touching the context / event when
+ *     free is called.
+ *
+ * See dora-rs/dora#540 for the audit that produced these annotations.
+ */
+
+/* Thread-safe: yes. Creates a fresh dora context from env vars; no shared
+ * state at entry. Typically called once at node startup. */
 void *init_dora_context_from_env();
+
+/* Thread-safe: NO. Takes ownership of the context and drops it. The caller
+ * must guarantee no other thread is using `dora_context` when this is
+ * called, and the pointer must not be reused afterward. */
 void free_dora_context(void *dora_context);
 
+/* Thread-safe: NO. Mutates the context's internal event-stream cursor.
+ * Concurrent calls with the same `dora_context` are undefined behavior.
+ * If you need to fan out events to worker threads, drain events from a
+ * single thread and dispatch by event type. */
 void *dora_next_event(void *dora_context);
+
+/* Thread-safe: NO. Takes ownership of `dora_event` and drops it. After
+ * freeing, neither the event pointer nor any pointer returned by the
+ * read_dora_event_* / read_dora_input_* family for that event may be
+ * used. */
 void free_dora_event(void *dora_event);
 
 enum DoraEventType
@@ -14,12 +53,28 @@ enum DoraEventType
     DoraEventType_Error,
     DoraEventType_Unknown,
 };
+/* Thread-safe: yes (read-only). The returned enum value is by-value; no
+ * state is mutated on the event. */
 enum DoraEventType read_dora_event_type(void *dora_event);
 
+/* Thread-safe: yes (read-only on `dora_event`). The caller is responsible
+ * for ensuring the `out_ptr` / `out_len` destinations are not aliased by
+ * other concurrent calls. */
 void read_dora_input_id(void *dora_event, char **out_ptr, size_t *out_len);
+
+/* Thread-safe: yes (read-only on `dora_event`). Same caveat as
+ * read_dora_input_id about caller-owned out destinations. */
 void read_dora_input_data(void *dora_event, char **out_ptr, size_t *out_len);
+
+/* Thread-safe: yes (read-only). Returns by value. */
 unsigned long long read_dora_input_timestamp(void *dora_event);
+
+/* Thread-safe: NO. Mutates the context's internal sender state. Concurrent
+ * calls with the same `dora_context` are undefined behavior. */
 int dora_send_output(void *dora_context, const char *id_ptr, size_t id_len, const char *data_ptr, size_t data_len);
+
+/* Thread-safe: NO. Mutates the context's internal logger state. Concurrent
+ * calls with the same `dora_context` are undefined behavior. */
 int dora_log(void *dora_context, const char *level_ptr, size_t level_len, const char *msg_ptr, size_t msg_len);
 
 /* Backward-compatible aliases for dora-hub C nodes. */


### PR DESCRIPTION
Addresses #540 — adds thread-safety documentation to the C node API header.

## Summary

`apis/c/node/node_api.h` had **zero** thread-safety annotations. This PR adds:

- A top-of-file **Threading model** block-comment documenting the overall contract (contexts not Sync, events read-only after creation, free_* exclusive).
- A per-function `/* Thread-safe: yes/no */` block-comment for each of the 10 `extern "C"` declarations, with a one-line rationale.

## How the verdicts were derived

I read every `extern "C"` function in `apis/c/node/src/lib.rs` and looked at its underlying Rust borrow:

| Function | Source line | Borrow / state | Verdict |
|---|---|---|---|
| `init_dora_context_from_env` | `lib.rs:28` | no shared state — fresh context | thread-safe |
| `free_dora_context` | `lib.rs:54` | `Box::from_raw` (drops) | not thread-safe (exclusive) |
| `dora_next_event` | `lib.rs:79` | `&mut *context.cast()` | **not thread-safe** |
| `free_dora_event` | `lib.rs:232` | `Box::from_raw` (drops) | not thread-safe (exclusive) |
| `read_dora_event_type` | `lib.rs:95` | `&*event.cast()` (shared) | thread-safe (read-only) |
| `read_dora_input_id` | `lib.rs:137` | `&*event.cast()` (shared) | thread-safe (read-only) |
| `read_dora_input_data` | `lib.rs:177` | `&*event.cast()` (shared) | thread-safe (read-only) |
| `read_dora_input_timestamp` | `lib.rs:214` | `&*event.cast()` (shared) | thread-safe (read-only) |
| `dora_send_output` | `lib.rs:277` | `&mut *context.cast()` | **not thread-safe** |
| `dora_log` | `lib.rs:330` | `&mut *context.cast()` | **not thread-safe** |

The mechanical rule is: `&mut T` cast in the body → concurrent calls on the same pointer are UB; `&T` cast → safe; `Box::from_raw` → exclusive ownership during drop.

## Scope: docs-only, deliberately

#540's body had two asks:

1. **Document which functions are thread-safe.** ← shipped here.
2. **Where the underlying Rust type supports it, make C functions thread-safe** (e.g. `dora_next_event` could use a shared `flume::Receiver` instead of `&mut DoraContext`).

(2) is an API-stability change — it would require either a new function name or a coordinated version bump (existing C users assume the `&mut`-equivalent contract). That conversation deserves its own focused issue/PR.

This PR is **docs-only**: the existing API contract is unchanged, callers just now have a written description of what it is. That alone closes the most actionable part of the issue and unblocks users who need to know whether they can call `dora_next_event` from a worker thread (answer: no, drain from one thread and dispatch by type).

## Test plan

- [x] `cargo build -p dora-node-api-c` — clean (the header is included into `lib.rs` via `include_str!` so any malformed contents would fail the workspace build)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p dora-node-api-c -- -D warnings` — clean
- [x] `typos apis/c/node/node_api.h` — clean
- [ ] Reviewer: confirm the per-function verdicts match your reading of `lib.rs`. Anywhere I'm wrong, the fix is a one-line comment edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
