### PR TITLE
fix(ros2-bridge): restore CycloneDDS service mapping detection (#449)

### DIFF
--- a/apis/c++/node/build.rs
+++ b/apis/c++/node/build.rs
@@ -119,6 +119,10 @@ mod ros2 {
             }
         };
         println!("cargo:rerun-if-env-changed=AMENT_PREFIX_PATH");
+        // Codegen picks ServiceMapping based on these — invalidate when
+        // they change. See dora-rs/dora#449.
+        println!("cargo:rerun-if-env-changed=RMW_IMPLEMENTATION");
+        println!("cargo:rerun-if-env-changed=ROS_DISTRO");
 
         let paths: Vec<_> = ament_prefix_path.split(':').map(PathBuf::from).collect();
         for path in &paths {

--- a/binaries/ros2-bridge-node/src/main.rs
+++ b/binaries/ros2-bridge-node/src/main.rs
@@ -38,6 +38,42 @@ use dora_message::metadata::{
     REQUEST_ID,
 };
 
+/// Pick the `ros2_client::ServiceMapping` variant that matches the user's
+/// ROS2 middleware, based on `RMW_IMPLEMENTATION` (primary) and `ROS_DISTRO`
+/// (fallback). Falls back to `Enhanced` with a `tracing::warn!` if neither
+/// env var gives a usable answer — Enhanced is the historical default and
+/// keeps existing setups working when env is unset.
+///
+/// See dora-rs/dora#449 (restored from lost commit `e2c1370f`).
+fn detect_service_mapping() -> ros2_client::ServiceMapping {
+    match std::env::var("RMW_IMPLEMENTATION").ok().as_deref() {
+        Some("rmw_fastrtps_cpp") => return ros2_client::ServiceMapping::Enhanced,
+        Some("rmw_cyclonedds_cpp") => return ros2_client::ServiceMapping::Cyclone,
+        Some(other) => {
+            tracing::warn!(
+                "unknown RMW_IMPLEMENTATION `{other}`, falling back to \
+                 ServiceMapping::Enhanced (see dora-rs/dora#449)"
+            );
+            return ros2_client::ServiceMapping::Enhanced;
+        }
+        None => {}
+    }
+    match std::env::var("ROS_DISTRO").ok().as_deref() {
+        Some("humble" | "iron" | "jazzy" | "kilted" | "rolling") => {
+            ros2_client::ServiceMapping::Enhanced
+        }
+        Some("galactic") => ros2_client::ServiceMapping::Cyclone,
+        Some(other) => {
+            tracing::warn!(
+                "unknown ROS_DISTRO `{other}`, falling back to \
+                 ServiceMapping::Enhanced (see dora-rs/dora#449)"
+            );
+            ros2_client::ServiceMapping::Enhanced
+        }
+        None => ros2_client::ServiceMapping::Enhanced,
+    }
+}
+
 fn main() -> eyre::Result<()> {
     tracing_subscriber::fmt::init();
 
@@ -186,7 +222,7 @@ fn run_service_mode(
         Ros2Role::Client => {
             let client = ros_node
                 .create_client::<BridgeServiceType>(
-                    ros2_client::ServiceMapping::Enhanced,
+                    detect_service_mapping(),
                     &ros2_client::Name::new("/", service_name.trim_start_matches('/'))
                         .map_err(|e| eyre!("failed to create service name: {e}"))?,
                     &ros2_client::ServiceTypeName::new(&package, &type_name),
@@ -203,7 +239,7 @@ fn run_service_mode(
         Ros2Role::Server => {
             let server = ros_node
                 .create_server::<BridgeServiceType>(
-                    ros2_client::ServiceMapping::Enhanced,
+                    detect_service_mapping(),
                     &ros2_client::Name::new("/", service_name.trim_start_matches('/'))
                         .map_err(|e| eyre!("failed to create service name: {e}"))?,
                     &ros2_client::ServiceTypeName::new(&package, &type_name),
@@ -423,7 +459,7 @@ fn run_action_mode(
 
             let client = ros_node
                 .create_action_client::<BridgeActionType>(
-                    ros2_client::ServiceMapping::Enhanced,
+                    detect_service_mapping(),
                     &action_ros2_name,
                     &action_type_name,
                     action_qos,
@@ -449,7 +485,7 @@ fn run_action_mode(
 
             let server = ros_node
                 .create_action_server::<BridgeActionType>(
-                    ros2_client::ServiceMapping::Enhanced,
+                    detect_service_mapping(),
                     &action_ros2_name,
                     &action_type_name,
                     action_qos,

--- a/libraries/extensions/ros2-bridge/build.rs
+++ b/libraries/extensions/ros2-bridge/build.rs
@@ -34,6 +34,10 @@ fn ament_prefix_paths() -> Vec<PathBuf> {
         }
     };
     println!("cargo:rerun-if-env-changed=AMENT_PREFIX_PATH");
+    // Codegen picks ServiceMapping based on these — invalidate when they
+    // change. See dora-rs/dora#449.
+    println!("cargo:rerun-if-env-changed=RMW_IMPLEMENTATION");
+    println!("cargo:rerun-if-env-changed=ROS_DISTRO");
 
     let paths: Vec<_> = ament_prefix_path.split(':').map(PathBuf::from).collect();
     for path in &paths {

--- a/libraries/extensions/ros2-bridge/msg-gen/src/lib.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/lib.rs
@@ -9,6 +9,7 @@
 
 use std::path::Path;
 
+use proc_macro2::Ident;
 use quote::{format_ident, quote};
 
 pub mod parser;
@@ -16,6 +17,57 @@ pub mod types;
 
 pub use crate::parser::get_packages;
 use crate::types::Package;
+
+/// Pick the `ros2_client::ServiceMapping` variant for the user's ROS2 middleware.
+///
+/// Reads `RMW_IMPLEMENTATION` (primary) and `ROS_DISTRO` (fallback). Falls
+/// back to `Enhanced` with a warning if neither env var gives a usable
+/// answer — `Enhanced` is the historical default and keeps existing builds
+/// working when env is unset.
+///
+/// Restores the logic from `dora-rs/dora@e2c1370f`, which was lost during
+/// the 1.0 consolidation. See dora-rs/dora#449.
+pub fn detect_ros_service_mapping_ident() -> Ident {
+    let enhanced = || format_ident!("Enhanced");
+    let cyclone = || format_ident!("Cyclone");
+
+    match std::env::var("RMW_IMPLEMENTATION") {
+        Ok(middleware) => match middleware.as_str() {
+            "rmw_fastrtps_cpp" => return enhanced(),
+            "rmw_cyclonedds_cpp" => return cyclone(),
+            other => {
+                eprintln!(
+                    "cargo:warning=unknown RMW_IMPLEMENTATION `{other}`, \
+                     falling back to ServiceMapping::Enhanced (see dora-rs/dora#449)"
+                );
+                return enhanced();
+            }
+        },
+        Err(std::env::VarError::NotUnicode(_)) => {
+            eprintln!(
+                "cargo:warning=RMW_IMPLEMENTATION is not valid unicode, \
+                 falling back to ServiceMapping::Enhanced"
+            );
+            return enhanced();
+        }
+        Err(std::env::VarError::NotPresent) => {}
+    }
+
+    std::env::var("ROS_DISTRO").map_or_else(
+        |_| enhanced(),
+        |distro| match distro.as_str() {
+            "humble" | "iron" | "jazzy" | "kilted" | "rolling" => enhanced(),
+            "galactic" => cyclone(),
+            other => {
+                eprintln!(
+                    "cargo:warning=unknown ROS_DISTRO `{other}`, \
+                     falling back to ServiceMapping::Enhanced (see dora-rs/dora#449)"
+                );
+                enhanced()
+            }
+        },
+    )
+}
 
 #[allow(clippy::cognitive_complexity)]
 pub fn generate_package(package: &Package, create_cxx_bridge: bool) -> proc_macro2::TokenStream {

--- a/libraries/extensions/ros2-bridge/msg-gen/src/lib.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/lib.rs
@@ -28,10 +28,23 @@ use crate::types::Package;
 /// Restores the logic from `dora-rs/dora@e2c1370f`, which was lost during
 /// the 1.0 consolidation. See dora-rs/dora#449.
 pub fn detect_ros_service_mapping_ident() -> Ident {
+    detect_ros_service_mapping_ident_from(
+        std::env::var("RMW_IMPLEMENTATION"),
+        std::env::var("ROS_DISTRO"),
+    )
+}
+
+/// Pure inner version of [`detect_ros_service_mapping_ident`]: takes the
+/// env-var results as arguments so it can be unit-tested without mutating
+/// the process environment.
+fn detect_ros_service_mapping_ident_from(
+    rmw_implementation: Result<String, std::env::VarError>,
+    ros_distro: Result<String, std::env::VarError>,
+) -> Ident {
     let enhanced = || format_ident!("Enhanced");
     let cyclone = || format_ident!("Cyclone");
 
-    match std::env::var("RMW_IMPLEMENTATION") {
+    match rmw_implementation {
         Ok(middleware) => match middleware.as_str() {
             "rmw_fastrtps_cpp" => return enhanced(),
             "rmw_cyclonedds_cpp" => return cyclone(),
@@ -53,7 +66,7 @@ pub fn detect_ros_service_mapping_ident() -> Ident {
         Err(std::env::VarError::NotPresent) => {}
     }
 
-    std::env::var("ROS_DISTRO").map_or_else(
+    ros_distro.map_or_else(
         |_| enhanced(),
         |distro| match distro.as_str() {
             "humble" | "iron" | "jazzy" | "kilted" | "rolling" => enhanced(),
@@ -541,5 +554,120 @@ fn generate_rust_imports_for_cxx() -> proc_macro2::TokenStream {
     quote! {
         #[allow(unused_imports)]
         use crate::prelude::*;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::env::VarError;
+    use std::ffi::OsString;
+
+    use super::*;
+
+    fn detect(rmw: Result<&str, VarError>, distro: Result<&str, VarError>) -> String {
+        detect_ros_service_mapping_ident_from(rmw.map(String::from), distro.map(String::from))
+            .to_string()
+    }
+
+    // ---- RMW_IMPLEMENTATION ----
+
+    #[test]
+    fn rmw_fastrtps_returns_enhanced() {
+        assert_eq!(
+            detect(Ok("rmw_fastrtps_cpp"), Err(VarError::NotPresent)),
+            "Enhanced"
+        );
+    }
+
+    #[test]
+    fn rmw_cyclonedds_returns_cyclone() {
+        assert_eq!(
+            detect(Ok("rmw_cyclonedds_cpp"), Err(VarError::NotPresent)),
+            "Cyclone"
+        );
+    }
+
+    #[test]
+    fn rmw_unknown_falls_back_to_enhanced() {
+        assert_eq!(
+            detect(Ok("rmw_some_third_party_dds"), Err(VarError::NotPresent)),
+            "Enhanced"
+        );
+    }
+
+    #[test]
+    fn rmw_not_unicode_falls_back_to_enhanced() {
+        let bytes = OsString::from("placeholder");
+        let result = detect_ros_service_mapping_ident_from(
+            Err(VarError::NotUnicode(bytes)),
+            Err(VarError::NotPresent),
+        );
+        assert_eq!(result.to_string(), "Enhanced");
+    }
+
+    // ---- RMW takes precedence over ROS_DISTRO ----
+
+    #[test]
+    fn rmw_takes_precedence_over_distro_for_enhanced() {
+        // RMW says fastrtps -> Enhanced, even though distro says galactic.
+        assert_eq!(detect(Ok("rmw_fastrtps_cpp"), Ok("galactic")), "Enhanced");
+    }
+
+    #[test]
+    fn rmw_takes_precedence_over_distro_for_cyclone() {
+        // RMW says cyclonedds -> Cyclone, even though distro says humble.
+        assert_eq!(detect(Ok("rmw_cyclonedds_cpp"), Ok("humble")), "Cyclone");
+    }
+
+    // ---- ROS_DISTRO fallback ----
+
+    #[test]
+    fn distro_humble_returns_enhanced() {
+        assert_eq!(detect(Err(VarError::NotPresent), Ok("humble")), "Enhanced");
+    }
+
+    #[test]
+    fn distro_iron_returns_enhanced() {
+        assert_eq!(detect(Err(VarError::NotPresent), Ok("iron")), "Enhanced");
+    }
+
+    #[test]
+    fn distro_jazzy_returns_enhanced() {
+        assert_eq!(detect(Err(VarError::NotPresent), Ok("jazzy")), "Enhanced");
+    }
+
+    #[test]
+    fn distro_kilted_returns_enhanced() {
+        assert_eq!(detect(Err(VarError::NotPresent), Ok("kilted")), "Enhanced");
+    }
+
+    #[test]
+    fn distro_rolling_returns_enhanced() {
+        assert_eq!(detect(Err(VarError::NotPresent), Ok("rolling")), "Enhanced");
+    }
+
+    #[test]
+    fn distro_galactic_returns_cyclone() {
+        assert_eq!(detect(Err(VarError::NotPresent), Ok("galactic")), "Cyclone");
+    }
+
+    #[test]
+    fn distro_unknown_falls_back_to_enhanced() {
+        assert_eq!(
+            detect(Err(VarError::NotPresent), Ok("future_distro_99")),
+            "Enhanced"
+        );
+    }
+
+    // ---- No env at all ----
+
+    #[test]
+    fn no_env_falls_back_to_enhanced() {
+        // Most common case: neither env var set. Preserves historical
+        // hardcoded-Enhanced behavior so existing builds keep working.
+        assert_eq!(
+            detect(Err(VarError::NotPresent), Err(VarError::NotPresent)),
+            "Enhanced"
+        );
     }
 }

--- a/libraries/extensions/ros2-bridge/msg-gen/src/types/action.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/types/action.rs
@@ -238,6 +238,10 @@ impl Action {
 
         let result_type_raw_str = result_type_raw.to_string();
 
+        // Pick the ROS2 service mapping based on RMW_IMPLEMENTATION /
+        // ROS_DISTRO at codegen time. See dora-rs/dora#449.
+        let ros_service_mapping = crate::detect_ros_service_mapping_ident();
+
         let def = quote! {
             #[namespace = #package_name]
             #[cxx_name = #cxx_client_name]
@@ -274,7 +278,7 @@ impl Action {
                 use futures::StreamExt as _;
 
                 let client = node.node.create_action_client::< action :: #self_name >(
-                    crate::ros2_client::ServiceMapping::Enhanced,
+                    crate::ros2_client::ServiceMapping:: #ros_service_mapping,
                     &crate::ros2_client::Name::new(name_space, base_name).unwrap(),
                     &crate::ros2_client::ActionTypeName::new(#package_name, #self_name_str),
                     qos.into(),

--- a/libraries/extensions/ros2-bridge/msg-gen/src/types/service.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/types/service.rs
@@ -102,6 +102,10 @@ impl Service {
         let downcast = format_ident!("downcast__{package_name}__{}", self.name);
         let cxx_downcast = format_ident!("downcast");
 
+        // Pick the ROS2 service mapping based on RMW_IMPLEMENTATION /
+        // ROS_DISTRO at codegen time. See dora-rs/dora#449.
+        let ros_service_mapping = crate::detect_ros_service_mapping_ident();
+
         let def = quote! {
             #[namespace = #package_name]
             #[cxx_name = #cxx_client_name]
@@ -130,7 +134,7 @@ impl Service {
                 use futures::StreamExt as _;
 
                 let client = node.node.create_client::< service :: #self_name >(
-                    crate::ros2_client::ServiceMapping::Enhanced,
+                    crate::ros2_client::ServiceMapping:: #ros_service_mapping,
                     &crate::ros2_client::Name::new(name_space, base_name).unwrap(),
                     &crate::ros2_client::ServiceTypeName::new(#package_name, #self_name_str),
                     qos.clone().into(),


### PR DESCRIPTION
Addresses #449 by restoring the RMW_IMPLEMENTATION / ROS_DISTRO-driven `ServiceMapping` detection that was lost during the 1.0 consolidation.

## Background

`dora-rs/dora` shipped this fix once in 2024-04 as commit `e2c1370f` ("Use correct service mapping based on `RMW_IMPLEMENTATION` and ROS distro", @phil-opp). The 1.0 consolidation commit `145ccce0` rewrote `libraries/extensions/ros2-bridge/` and dropped the detection — current main has `ServiceMapping::Enhanced` hardcoded in **6 places**, so Cyclone DDS users get the wrong topic mapping with no way to override it.

This PR ports phil-opp's approach to current main, fixes a few things that were either missing or new since 2024, and applies the same fix consistently across all 6 sites.

## What the 6 sites are

| File | Line | Context |
|---|---|---|
| `libraries/extensions/ros2-bridge/msg-gen/src/types/service.rs` | 133 (was) | C++ FFI service client codegen |
| `libraries/extensions/ros2-bridge/msg-gen/src/types/action.rs` | 277 (was) | C++ FFI action client codegen |
| `binaries/ros2-bridge-node/src/main.rs` | 189 (was) | runtime: `create_client` |
| `binaries/ros2-bridge-node/src/main.rs` | 206 (was) | runtime: `create_server` |
| `binaries/ros2-bridge-node/src/main.rs` | 426 (was) | runtime: `create_action_client` |
| `binaries/ros2-bridge-node/src/main.rs` | 452 (was) | runtime: `create_action_server` |

## What ships

1. **Shared codegen helper** in `libraries/extensions/ros2-bridge/msg-gen/src/lib.rs::detect_ros_service_mapping_ident()` — reads RMW_IMPLEMENTATION (primary) and ROS_DISTRO (fallback). Returns the right `proc_macro2::Ident` for the codegen template to interpolate.
2. **Codegen call sites** (`types/service.rs`, `types/action.rs`) — call the helper at codegen time, interpolate `crate::ros2_client::ServiceMapping:: #ros_service_mapping`.
3. **Runtime helper** in `binaries/ros2-bridge-node/src/main.rs::detect_service_mapping()` — same logic, evaluated at runtime, returns `ros2_client::ServiceMapping` directly. Used at all 4 runtime call sites.
4. **`cargo:rerun-if-env-changed`** for both `RMW_IMPLEMENTATION` and `ROS_DISTRO` in both ros2-bridge build.rs files — cargo invalidates codegen when the user switches RMW.

## Differences from phil-opp's `e2c1370f`

| Aspect | `e2c1370f` (lost) | This PR |
|---|---|---|
| On unknown / missing env | `anyhow::bail!` — build fails | falls back to `Enhanced` + warning |
| Coverage | service codegen only | service codegen + action codegen + all 4 runtime sites |
| Supported distros | humble, iron, galactic | humble, iron, jazzy, kilted, rolling (Enhanced) + galactic (Cyclone) |

The bail-out-on-missing behavior would break every existing build that doesn't set `ROS_DISTRO` — current main works fine without it (because it hardcodes Enhanced). Falling back to Enhanced with a warning preserves the current default while making it overridable, which is the actual user-facing ask in #449.

## What this PR does NOT do

- Doesn't change the build profile or default RMW. The default is still Enhanced when no env var is set.
- Doesn't add a CLI override (e.g. `--service-mapping=cyclone`). The env-var path covers the ROS2 idiom; CLI override is scope creep.
- Doesn't add ROS2-specific tests. The current main has none, and this PR doesn't introduce a regression that needs test coverage — the detection function is mechanical and isolated.

## Test plan

- [x] `cargo build -p dora-ros2-bridge-node` — compiles
- [x] `cargo check -p dora-ros2-bridge-msg-gen` — compiles
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p dora-ros2-bridge-msg-gen -p dora-ros2-bridge-node -- -D warnings` — clean
- [ ] **Authoritative**: nightly's `ros2-bridge-examples` job on Linux + ROS2 Humble (currently in `.github/workflows/nightly.yml`) needs to be green on this branch. If it stays green, the codegen still works when targeting Enhanced (default). A Cyclone DDS validator would need to set `RMW_IMPLEMENTATION=rmw_cyclonedds_cpp` and re-run — out of scope for this PR's CI; that's the ROS2-bridge-on-Cyclone test surface the issue was asking for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
