### PR TITLE
feat(doctor): add /dev/shm permission check on Linux (rescue of #1352)

### DIFF
--- a/binaries/cli/src/command/doctor.rs
+++ b/binaries/cli/src/command/doctor.rs
@@ -233,6 +233,37 @@ fn warn(stdout: &mut termcolor::StandardStream, msg: &str) -> eyre::Result<()> {
     Ok(())
 }
 
+/// Pure evaluation of a directory's suitability as a POSIX shared-memory mount.
+///
+/// Returns one of four states based on `path`'s existence, type, and mode.
+/// Separated from the I/O wrapper so it can be unit-tested against a tempdir.
+#[cfg(target_os = "linux")]
+#[derive(Debug)]
+enum ShmState {
+    Inaccessible(std::io::Error),
+    NotADirectory,
+    WrongMode { actual: u32, expected: u32 },
+    Ok,
+}
+
+#[cfg(target_os = "linux")]
+fn evaluate_shm(path: &std::path::Path) -> ShmState {
+    use std::os::unix::fs::PermissionsExt;
+    let metadata = match std::fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(e) => return ShmState::Inaccessible(e),
+    };
+    if !metadata.is_dir() {
+        return ShmState::NotADirectory;
+    }
+    let actual = metadata.permissions().mode() & 0o7777;
+    let expected = 0o1777;
+    if actual != expected {
+        return ShmState::WrongMode { actual, expected };
+    }
+    ShmState::Ok
+}
+
 /// Check `/dev/shm` is a directory with mode `1777` (sticky, world-rwx).
 ///
 /// dora's zero-copy fast path for large payloads uses zenoh SHM, which
@@ -244,48 +275,80 @@ fn warn(stdout: &mut termcolor::StandardStream, msg: &str) -> eyre::Result<()> {
 /// one — surface it as `WARN`, not `FAIL`. See dora-rs/dora#1352.
 #[cfg(target_os = "linux")]
 fn check_shared_memory(stdout: &mut termcolor::StandardStream) -> eyre::Result<()> {
-    use std::fs;
-    use std::os::unix::fs::PermissionsExt;
     use std::path::Path;
-
-    let shm_path = Path::new("/dev/shm");
-    let metadata = match fs::metadata(shm_path) {
-        Ok(metadata) => metadata,
-        Err(_) => {
-            warn(
-                stdout,
-                "Shared memory: /dev/shm not accessible — dora will run via heap fallback; \
-                 for the zero-copy fast path run `sudo mkdir -p /dev/shm && sudo chmod 1777 /dev/shm`",
-            )?;
-            return Ok(());
-        }
-    };
-
-    if !metadata.is_dir() {
-        warn(
+    match evaluate_shm(Path::new("/dev/shm")) {
+        ShmState::Inaccessible(e) => warn(
+            stdout,
+            &format!(
+                "Shared memory: /dev/shm not accessible ({e}) — dora will run via heap fallback; \
+                 for the zero-copy fast path run \
+                 `sudo mkdir -p /dev/shm && sudo chmod 1777 /dev/shm` \
+                 (in a container, pass `--shm-size=...` or mount a tmpfs at /dev/shm)"
+            ),
+        )?,
+        ShmState::NotADirectory => warn(
             stdout,
             "Shared memory: /dev/shm exists but is not a directory — dora will run via heap fallback; \
              for the zero-copy fast path run `sudo chmod 1777 /dev/shm`",
-        )?;
-        return Ok(());
-    }
-
-    let mode = metadata.permissions().mode() & 0o7777;
-    let expected = 0o1777;
-    if mode != expected {
-        warn(
+        )?,
+        ShmState::WrongMode { actual, expected } => warn(
             stdout,
             &format!(
-                "Shared memory: /dev/shm has mode {mode:#o}, expected {expected:#o} — \
+                "Shared memory: /dev/shm has mode {actual:#o}, expected {expected:#o} — \
                  dora will run via heap fallback if SHM allocation is denied; \
                  for the zero-copy fast path run `sudo chmod 1777 /dev/shm`"
             ),
-        )?;
-        return Ok(());
+        )?,
+        ShmState::Ok => pass(stdout, "Shared memory: /dev/shm mode is 1777")?,
+    }
+    Ok(())
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod shm_tests {
+    use super::{ShmState, evaluate_shm};
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use tempfile::tempdir;
+
+    #[test]
+    fn inaccessible_when_path_is_missing() {
+        let dir = tempdir().unwrap();
+        let missing = dir.path().join("nope");
+        assert!(matches!(evaluate_shm(&missing), ShmState::Inaccessible(_)));
     }
 
-    pass(stdout, "Shared memory: /dev/shm mode is 1777")?;
-    Ok(())
+    #[test]
+    fn not_a_directory_when_path_is_file() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("not-a-dir");
+        fs::write(&file, b"").unwrap();
+        assert!(matches!(evaluate_shm(&file), ShmState::NotADirectory));
+    }
+
+    #[test]
+    fn wrong_mode_when_directory_is_0755() {
+        let dir = tempdir().unwrap();
+        let shm = dir.path().join("shm");
+        fs::create_dir(&shm).unwrap();
+        fs::set_permissions(&shm, fs::Permissions::from_mode(0o755)).unwrap();
+        match evaluate_shm(&shm) {
+            ShmState::WrongMode { actual, expected } => {
+                assert_eq!(actual, 0o755);
+                assert_eq!(expected, 0o1777);
+            }
+            other => panic!("expected WrongMode, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ok_when_directory_is_1777() {
+        let dir = tempdir().unwrap();
+        let shm = dir.path().join("shm");
+        fs::create_dir(&shm).unwrap();
+        fs::set_permissions(&shm, fs::Permissions::from_mode(0o1777)).unwrap();
+        assert!(matches!(evaluate_shm(&shm), ShmState::Ok));
+    }
 }
 
 fn check_daemon(session: &WsSession) -> eyre::Result<bool> {

--- a/binaries/cli/src/command/doctor.rs
+++ b/binaries/cli/src/command/doctor.rs
@@ -60,10 +60,12 @@ fn doctor(args: Doctor) -> eyre::Result<()> {
     )?;
 
     // Shared memory permissions (Linux only). dora uses /dev/shm for the
-    // >4KiB shared-memory data path; wrong permissions there manifest as
-    // obscure spawn failures rather than a clear error message.
+    // zero-copy SHM fast path on large payloads, but the node runtime
+    // gracefully falls back to heap-buffered zenoh publishes when SHM is
+    // unavailable, so a misconfigured /dev/shm is a perf concern, not a
+    // correctness one — surface it as a WARN.
     #[cfg(target_os = "linux")]
-    check_shared_memory(&mut stdout, &mut failures)?;
+    check_shared_memory(&mut stdout)?;
 
     // 2. Coordinator connectivity
     let addr = args.coordinator.socket_addr();
@@ -233,17 +235,15 @@ fn warn(stdout: &mut termcolor::StandardStream, msg: &str) -> eyre::Result<()> {
 
 /// Check `/dev/shm` is a directory with mode `1777` (sticky, world-rwx).
 ///
-/// dora's shared-memory IPC for large messages requires `/dev/shm` to be
-/// world-writable so unprivileged daemon-spawned node processes can mmap
-/// regions there. The sticky bit (`1`) prevents nodes from removing each
-/// other's segments. When the permissions drift (e.g. `0755` on hardened
-/// systems), large messages fail with cryptic mmap errors at runtime; this
-/// check surfaces the misconfiguration up front. See dora-rs/dora#1352.
+/// dora's zero-copy fast path for large payloads uses zenoh SHM, which
+/// allocates segments in `/dev/shm`. The node runtime treats SHM as
+/// best-effort: if the provider can't be created or allocation fails,
+/// it falls back to heap-buffered publishes (see
+/// `apis/rust/node/src/node/mod.rs`). So a misconfigured `/dev/shm` is
+/// a perf concern (heap copy on every large message), not a correctness
+/// one — surface it as `WARN`, not `FAIL`. See dora-rs/dora#1352.
 #[cfg(target_os = "linux")]
-fn check_shared_memory(
-    stdout: &mut termcolor::StandardStream,
-    failures: &mut u32,
-) -> eyre::Result<()> {
+fn check_shared_memory(stdout: &mut termcolor::StandardStream) -> eyre::Result<()> {
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
     use std::path::Path;
@@ -252,37 +252,35 @@ fn check_shared_memory(
     let metadata = match fs::metadata(shm_path) {
         Ok(metadata) => metadata,
         Err(_) => {
-            fail(
+            warn(
                 stdout,
-                "Shared memory: /dev/shm not accessible — \
-                 run `sudo mkdir -p /dev/shm && sudo chmod 1777 /dev/shm`",
+                "Shared memory: /dev/shm not accessible — dora will run via heap fallback; \
+                 for the zero-copy fast path run `sudo mkdir -p /dev/shm && sudo chmod 1777 /dev/shm`",
             )?;
-            *failures += 1;
             return Ok(());
         }
     };
 
     if !metadata.is_dir() {
-        fail(
+        warn(
             stdout,
-            "Shared memory: /dev/shm exists but is not a directory — \
-             run `sudo chmod 1777 /dev/shm`",
+            "Shared memory: /dev/shm exists but is not a directory — dora will run via heap fallback; \
+             for the zero-copy fast path run `sudo chmod 1777 /dev/shm`",
         )?;
-        *failures += 1;
         return Ok(());
     }
 
     let mode = metadata.permissions().mode() & 0o7777;
     let expected = 0o1777;
     if mode != expected {
-        fail(
+        warn(
             stdout,
             &format!(
                 "Shared memory: /dev/shm has mode {mode:#o}, expected {expected:#o} — \
-                 run `sudo chmod 1777 /dev/shm`"
+                 dora will run via heap fallback if SHM allocation is denied; \
+                 for the zero-copy fast path run `sudo chmod 1777 /dev/shm`"
             ),
         )?;
-        *failures += 1;
         return Ok(());
     }
 

--- a/binaries/cli/src/command/doctor.rs
+++ b/binaries/cli/src/command/doctor.rs
@@ -59,6 +59,12 @@ fn doctor(args: Doctor) -> eyre::Result<()> {
         &format!("CLI version: {}", env!("CARGO_PKG_VERSION")),
     )?;
 
+    // Shared memory permissions (Linux only). dora uses /dev/shm for the
+    // >4KiB shared-memory data path; wrong permissions there manifest as
+    // obscure spawn failures rather than a clear error message.
+    #[cfg(target_os = "linux")]
+    check_shared_memory(&mut stdout, &mut failures)?;
+
     // 2. Coordinator connectivity
     let addr = args.coordinator.socket_addr();
     let session = match connect_to_coordinator(addr) {
@@ -222,6 +228,65 @@ fn warn(stdout: &mut termcolor::StandardStream, msg: &str) -> eyre::Result<()> {
     write!(stdout, "  WARN ")?;
     let _ = stdout.reset();
     writeln!(stdout, " {msg}")?;
+    Ok(())
+}
+
+/// Check `/dev/shm` is a directory with mode `1777` (sticky, world-rwx).
+///
+/// dora's shared-memory IPC for large messages requires `/dev/shm` to be
+/// world-writable so unprivileged daemon-spawned node processes can mmap
+/// regions there. The sticky bit (`1`) prevents nodes from removing each
+/// other's segments. When the permissions drift (e.g. `0755` on hardened
+/// systems), large messages fail with cryptic mmap errors at runtime; this
+/// check surfaces the misconfiguration up front. See dora-rs/dora#1352.
+#[cfg(target_os = "linux")]
+fn check_shared_memory(
+    stdout: &mut termcolor::StandardStream,
+    failures: &mut u32,
+) -> eyre::Result<()> {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::Path;
+
+    let shm_path = Path::new("/dev/shm");
+    let metadata = match fs::metadata(shm_path) {
+        Ok(metadata) => metadata,
+        Err(_) => {
+            fail(
+                stdout,
+                "Shared memory: /dev/shm not accessible — \
+                 run `sudo mkdir -p /dev/shm && sudo chmod 1777 /dev/shm`",
+            )?;
+            *failures += 1;
+            return Ok(());
+        }
+    };
+
+    if !metadata.is_dir() {
+        fail(
+            stdout,
+            "Shared memory: /dev/shm exists but is not a directory — \
+             run `sudo chmod 1777 /dev/shm`",
+        )?;
+        *failures += 1;
+        return Ok(());
+    }
+
+    let mode = metadata.permissions().mode() & 0o7777;
+    let expected = 0o1777;
+    if mode != expected {
+        fail(
+            stdout,
+            &format!(
+                "Shared memory: /dev/shm has mode {mode:#o}, expected {expected:#o} — \
+                 run `sudo chmod 1777 /dev/shm`"
+            ),
+        )?;
+        *failures += 1;
+        return Ok(());
+    }
+
+    pass(stdout, "Shared memory: /dev/shm mode is 1777")?;
     Ok(())
 }
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -441,10 +441,11 @@ dora doctor --dataflow dataflow.yml
 ```
 
 Checks performed:
-1. Coordinator reachability
-2. Connected daemon status
-3. Active dataflow health
-4. Dataflow YAML validation (if `--dataflow` provided)
+1. Shared memory permissions (Linux only — verifies `/dev/shm` has mode `1777` for zero-copy IPC)
+2. Coordinator reachability
+3. Connected daemon status
+4. Active dataflow health
+5. Dataflow YAML validation (if `--dataflow` provided)
 
 Use this as a first step when debugging any issue, or in CI to validate the environment before running tests.
 


### PR DESCRIPTION
Adds `/dev/shm` permission validation to the existing `dora doctor` command on Linux. Rescues the genuinely-useful check from closed PR #1352 and lands it where it belongs.

## What this adds

Inserted between the existing `CLI version` check and the `Coordinator connectivity` check in `binaries/cli/src/command/doctor.rs`:

| Scenario | Output |
|---|---|
| `/dev/shm` not accessible | `WARN Shared memory: /dev/shm not accessible — dora will run via heap fallback; for the zero-copy fast path run \`sudo mkdir -p /dev/shm && sudo chmod 1777 /dev/shm\`` |
| `/dev/shm` exists but is not a directory | `WARN Shared memory: /dev/shm exists but is not a directory — dora will run via heap fallback; for the zero-copy fast path run \`sudo chmod 1777 /dev/shm\`` |
| Wrong mode | `WARN Shared memory: /dev/shm has mode 0o755, expected 0o1777 — dora will run via heap fallback if SHM allocation is denied; for the zero-copy fast path run \`sudo chmod 1777 /dev/shm\`` |
| Mode `1777` | `PASS Shared memory: /dev/shm mode is 1777` |

Non-Linux platforms (macOS, Windows) skip this check silently — the underlying `/dev/shm` mechanism does not apply there.

## Why WARN and not FAIL

The node runtime treats SHM as best-effort:

- `apis/rust/node/src/node/mod.rs:602-619` — `ShmProviderBuilder::default_backend()` failure logs a warn and stores `None`
- `apis/rust/node/src/node/mod.rs:1064-1088` — `send_output_sample` checks `if let Some(provider)` and falls back to heap buffer if allocation fails

So a misconfigured `/dev/shm` is a perf concern (heap copy on every large message instead of zero-copy), not a correctness one. `dora doctor` should not exit non-zero on a system that actually runs.

## Why this matters

When `/dev/shm` has the wrong permissions (e.g. `0755` on some hardened systems, or `0700` after a chown), the zero-copy fast path is silently disabled and large messages get copied through the heap on every publish. Users don't notice until they wonder why throughput is lower than expected. Surfacing it as a `WARN` in `dora doctor` lets them spot the misconfiguration without digging into daemon stderr.

## Why not a separate `dora system doctor` command (as PR #1352 proposed)

PR #1352 (@Harsh-Sahu43) added this check as a new `dora system doctor` command under a new `system` namespace. That namespace rename was declined as part of the umbrella decision on [#1196](https://github.com/dora-rs/dora/issues/1196) ("the `dora system *` rename was not adopted; existing top-level commands stay"). The check itself is good engineering; only the command-naming was off.

This PR lifts the core check logic into the existing `dora doctor` and credits @Harsh-Sahu43 via `Co-Authored-By`. See the close comment on [#1352](https://github.com/dora-rs/dora/pull/1352) for the redirect context.

## Test plan

- [x] `cargo check -p dora-cli` — clean on host (macOS)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p dora-cli -- -D warnings` — clean
- [x] `cargo test -p dora-cli` — clean (no regressions; check is `#[cfg(target_os = "linux")]` so it does not run in dora-cli's host-target test suite on macOS)
- [ ] **Authoritative**: a Linux user running `dora doctor` should see one of the four outcomes above depending on `/dev/shm` state. Reviewer with a Linux box can validate manually:
  - `dora doctor` — expect `PASS Shared memory: /dev/shm mode is 1777` on a default Ubuntu/Debian/Fedora install
  - `sudo chmod 0755 /dev/shm && dora doctor` — expect the `WARN ... mode 0o755 ...` case
  - `sudo chmod 1777 /dev/shm` to restore

## What this PR does NOT do

- Doesn't add other `dora doctor` checks (CPU isolation, swap, ulimits, etc.). Those can ship as follow-up PRs.
- Doesn't introduce a `dora system` namespace. The check goes in the existing `dora doctor`.
- Doesn't add behavioral changes to dora's SHM code — purely diagnostic.

Co-Authored-By: Harsh-Sahu43

🤖 Generated with [Claude Code](https://claude.com/claude-code)
