### PR TITLE
fix(ci): include nightly failure details in issues

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1509,6 +1509,9 @@ jobs:
           set -euo pipefail
 
           DATE=$(date -u +%Y-%m-%d)
+          MAX_JOB_EXCERPT_BYTES=10000
+          MAX_FAILURE_DETAILS_BYTES=45000
+          GLOBAL_FALLBACK_EXCERPT_BYTES=4000
 
           # Per-job repro hints. Keep in sync with the job blocks above.
           # Blank entries fall back to "see workflow file" in the
@@ -1627,20 +1630,56 @@ jobs:
             logs_available=0
           fi
 
+          byte_count() {
+            LC_ALL=C wc -c | tr -d '[:space:]'
+          }
+
+          file_byte_count() {
+            LC_ALL=C wc -c < "$1" | tr -d '[:space:]'
+          }
+
+          strip_ansi_file() {
+            sed -E 's/\x1b\[[0-9;?]*[ -/]*[@-~]//g' "$1"
+          }
+
+          bounded_tail_file() {
+            local file="$1"
+            local max_bytes="$2"
+            local original_bytes
+
+            if [ "$max_bytes" -le 0 ]; then
+              echo "Excerpt omitted because the report reached the ${MAX_FAILURE_DETAILS_BYTES}-byte log budget."
+              echo "See full run log: $RUN_URL"
+              return
+            fi
+
+            original_bytes=$(file_byte_count "$file")
+            if [ "$original_bytes" -gt "$max_bytes" ]; then
+              echo "Excerpt truncated to the last ${max_bytes} bytes; see full run log: $RUN_URL"
+              echo
+              tail -c "$max_bytes" "$file"
+            else
+              cat "$file"
+            fi
+          }
+
           failure_excerpt() {
             local job="$1"
-            local pattern filtered
+            local max_bytes="$2"
+            local pattern filtered clean fallback
             filtered=$(mktemp)
+            clean=$(mktemp)
+            fallback=0
 
             if [ "$logs_available" != "1" ]; then
               echo 'Unable to fetch failed GitHub Actions log lines.'
               sed -n '1,40p' "$failed_logs_error"
-              rm -f "$filtered"
+              rm -f "$filtered" "$clean"
               return
             fi
             if [ ! -s "$failed_logs_file" ]; then
               echo 'No failed log lines were returned by GitHub Actions.'
-              rm -f "$filtered"
+              rm -f "$filtered" "$clean"
               return
             fi
 
@@ -1649,11 +1688,18 @@ jobs:
               awk -F '\t' -v pattern="$pattern" '$1 ~ pattern { print }' "$failed_logs_file" > "$filtered"
             fi
             if [ ! -s "$filtered" ]; then
-              cp "$failed_logs_file" "$filtered"
+              fallback=1
+              tail -c "$GLOBAL_FALLBACK_EXCERPT_BYTES" "$failed_logs_file" > "$filtered"
             fi
 
-            tail -n 120 "$filtered" | sed -E 's/\x1b\[[0-9;?]*[ -/]*[@-~]//g'
-            rm -f "$filtered"
+            strip_ansi_file "$filtered" > "$clean"
+            if [ "$fallback" -eq 1 ]; then
+              echo "No log lines matched this job name; showing the global failed-log tail."
+              echo "See full run log: $RUN_URL"
+              echo
+            fi
+            bounded_tail_file "$clean" "$max_bytes"
+            rm -f "$filtered" "$clean"
           }
 
           # Compose the failure-specific section.
@@ -1662,10 +1708,26 @@ jobs:
             details+=$'\n### Failed jobs\n\n'
             while IFS= read -r job; do
               [ -z "$job" ] && continue
-              details+="<details><summary>\`$job\`</summary>"$'\n\n'"Reproduce locally:"$'\n\n```\n'
-              details+="$(job_repro "$job")"$'\n```\n\n'
-              details+="Failure excerpt (last 120 failed log lines):"$'\n\n````text\n'
-              details+="$(failure_excerpt "$job")"$'\n````\n</details>\n\n'
+              job_header="<details><summary>\`$job\`</summary>"$'\n\n'"Reproduce locally:"$'\n\n```\n'"$(job_repro "$job")"$'\n```\n\n'"Failure excerpt (bounded to ${MAX_JOB_EXCERPT_BYTES} bytes per job):"$'\n\n````text\n'
+              job_footer=$'\n````\n</details>\n\n'
+              current_bytes=$(printf '%s' "$details" | byte_count)
+              overhead_bytes=$(printf '%s%s' "$job_header" "$job_footer" | byte_count)
+              remaining_bytes=$((MAX_FAILURE_DETAILS_BYTES - current_bytes - overhead_bytes))
+              if [ "$remaining_bytes" -gt $((MAX_JOB_EXCERPT_BYTES + 512)) ]; then
+                excerpt_budget=$MAX_JOB_EXCERPT_BYTES
+              elif [ "$remaining_bytes" -gt 512 ]; then
+                # Leave room for truncation/fallback notes inside the code block.
+                excerpt_budget=$((remaining_bytes - 512))
+              else
+                excerpt_budget=0
+              fi
+
+              if [ "$excerpt_budget" -gt 0 ]; then
+                excerpt="$(failure_excerpt "$job" "$excerpt_budget")"
+              else
+                excerpt="Excerpt omitted because the report reached the ${MAX_FAILURE_DETAILS_BYTES}-byte log budget."$'\n'"See full run log: $RUN_URL"
+              fi
+              details+="$job_header$excerpt$job_footer"
             done <<< "$failed_jobs"
           fi
           if [ -n "$skipped_jobs" ]; then

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1624,6 +1624,7 @@ jobs:
 
           failed_logs_file=$(mktemp)
           failed_logs_error=$(mktemp)
+          trap 'rm -f "$failed_logs_file" "$failed_logs_error"' EXIT
           if gh run view "$RUN_ID" --repo "$REPO" --log-failed > "$failed_logs_file" 2> "$failed_logs_error"; then
             logs_available=1
           else

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,6 +35,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
   issues: write
 
 env:
@@ -1496,6 +1497,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RUN_ID: ${{ github.run_id }}
           COMMIT_SHA: ${{ github.sha }}
           # `toJSON(needs)` is a map `{ job_name: { result: "failure" | "success" | ... } }`.
           # Parse in-shell to list only the jobs that actually failed
@@ -1530,35 +1532,79 @@ jobs:
                 echo 'dora run examples/streaming-example/dataflow.yml --uv --stop-after 15s'
                 ;;
               record-replay)
-                # The PR-CI contract test covers the semantic path; job
-                # itself is in .github/workflows/nightly.yml if you need
-                # the exact invocation against rust-dataflow.
-                echo 'cargo test -p dora-examples --test example-smoke contract_record_replay -- --test-threads=1'
+                echo 'scripts/qa/ci-nightly-jobs.sh record-replay'
                 ;;
               cluster-smoke)
-                # Multi-step: dora up + cluster status + dataflow + cluster down.
-                echo 'See the `cluster-smoke` job block in .github/workflows/nightly.yml for the exact sequence.'
+                echo 'scripts/qa/ci-nightly-jobs.sh cluster-smoke'
                 ;;
               topic-and-top-smoke)
-                echo 'See the `topic-and-top-smoke` job block in .github/workflows/nightly.yml.'
+                echo 'scripts/qa/ci-nightly-jobs.sh topic-and-top-smoke'
                 ;;
               cpu-affinity-smoke)
                 # Linux-only; the fixture requires sched_setaffinity.
-                echo 'cd examples/cpu-affinity-probe && dora run dataflow.yml --stop-after 3s  # Linux only'
+                echo 'scripts/qa/ci-nightly-jobs.sh cpu-affinity-smoke'
                 ;;
               redb-backend-smoke)
-                echo 'See the `redb-backend-smoke` job block in .github/workflows/nightly.yml (Session 1 + Session 2).'
+                echo 'scripts/qa/ci-nightly-jobs.sh redb-backend-smoke'
                 ;;
               daemon-reconnect-smoke)
                 # Uses SIGSTOP / SIGCONT — Linux only.
-                echo 'See the `daemon-reconnect-smoke` job block in .github/workflows/nightly.yml (Linux only).'
+                echo 'scripts/qa/ci-nightly-jobs.sh daemon-reconnect-smoke'
                 ;;
               state-reconstruction-smoke)
-                echo 'See the `state-reconstruction-smoke` job block in .github/workflows/nightly.yml.'
+                echo 'scripts/qa/ci-nightly-jobs.sh state-reconstruction-smoke'
+                ;;
+              test-cross-platform)
+                echo 'scripts/qa/ci-nightly-jobs.sh test-cross-platform'
+                ;;
+              examples)
+                echo 'scripts/qa/ci-nightly-jobs.sh examples'
+                ;;
+              cli-tests)
+                echo 'scripts/qa/ci-nightly-jobs.sh cli-tests'
+                ;;
+              bench-example)
+                echo 'scripts/qa/ci-nightly-jobs.sh bench-example'
+                ;;
+              msrv)
+                echo 'scripts/qa/ci-nightly-jobs.sh msrv'
+                ;;
+              cross-check)
+                echo 'scripts/qa/ci-nightly-jobs.sh cross-check'
+                ;;
+              ros2-bridge)
+                echo 'scripts/qa/ci-nightly-jobs.sh ros2-bridge'
                 ;;
               *)
                 echo 'No job-specific repro recorded. See the run log for this subjob.'
                 ;;
+            esac
+          }
+
+          # GitHub's run log uses display names, while `needs` uses job IDs.
+          # Keep this map in sync with the job `name:` fields above.
+          job_log_pattern() {
+            case "$1" in
+              build-cli) echo '^Build dora CLI \(shared\)$' ;;
+              smoke-suite) echo '^Smoke suite \(tests/example-smoke\.rs\)$' ;;
+              log-sinks) echo '^Log-sink examples \(Python sources\)$' ;;
+              service-action) echo '^Service / Action patterns \(Rust-only\)$' ;;
+              streaming) echo '^Streaming example \(Python\)$' ;;
+              record-replay) echo '^Record/replay round-trip$' ;;
+              cluster-smoke) echo '^Cluster lifecycle smoke$' ;;
+              topic-and-top-smoke) echo '^Topic & top inspection smoke$' ;;
+              cpu-affinity-smoke) echo '^cpu_affinity end-to-end \(Linux\)$' ;;
+              redb-backend-smoke) echo '^redb backend end-to-end$' ;;
+              daemon-reconnect-smoke) echo '^daemon auto-reconnect end-to-end \(Linux\)$' ;;
+              state-reconstruction-smoke) echo '^state reconstruction end-to-end \(partial\)$' ;;
+              test-cross-platform) echo '^Test \(.+\) \[nightly\]$' ;;
+              examples) echo '^Examples \(.+\)$' ;;
+              cli-tests) echo '^CLI Tests \(.+\)$' ;;
+              bench-example) echo '^Bench Example \(.+\)$' ;;
+              cross-check) echo '^Cross-check \(.+\)$' ;;
+              ros2-bridge) echo '^ROS2 Bridge Examples$' ;;
+              msrv) echo '^MSRV check$' ;;
+              *) echo '' ;;
             esac
           }
 
@@ -1573,6 +1619,43 @@ jobs:
             | jq -r 'to_entries | map(select(.value.result == "skipped")) | .[].key' \
             | sort)
 
+          failed_logs_file=$(mktemp)
+          failed_logs_error=$(mktemp)
+          if gh run view "$RUN_ID" --repo "$REPO" --log-failed > "$failed_logs_file" 2> "$failed_logs_error"; then
+            logs_available=1
+          else
+            logs_available=0
+          fi
+
+          failure_excerpt() {
+            local job="$1"
+            local pattern filtered
+            filtered=$(mktemp)
+
+            if [ "$logs_available" != "1" ]; then
+              echo 'Unable to fetch failed GitHub Actions log lines.'
+              sed -n '1,40p' "$failed_logs_error"
+              rm -f "$filtered"
+              return
+            fi
+            if [ ! -s "$failed_logs_file" ]; then
+              echo 'No failed log lines were returned by GitHub Actions.'
+              rm -f "$filtered"
+              return
+            fi
+
+            pattern=$(job_log_pattern "$job")
+            if [ -n "$pattern" ]; then
+              awk -F '\t' -v pattern="$pattern" '$1 ~ pattern { print }' "$failed_logs_file" > "$filtered"
+            fi
+            if [ ! -s "$filtered" ]; then
+              cp "$failed_logs_file" "$filtered"
+            fi
+
+            tail -n 120 "$filtered" | sed -E 's/\x1b\[[0-9;?]*[ -/]*[@-~]//g'
+            rm -f "$filtered"
+          }
+
           # Compose the failure-specific section.
           details=""
           if [ -n "$failed_jobs" ]; then
@@ -1580,7 +1663,9 @@ jobs:
             while IFS= read -r job; do
               [ -z "$job" ] && continue
               details+="<details><summary>\`$job\`</summary>"$'\n\n'"Reproduce locally:"$'\n\n```\n'
-              details+="$(job_repro "$job")"$'\n```\n</details>\n\n'
+              details+="$(job_repro "$job")"$'\n```\n\n'
+              details+="Failure excerpt (last 120 failed log lines):"$'\n\n````text\n'
+              details+="$(failure_excerpt "$job")"$'\n````\n</details>\n\n'
             done <<< "$failed_jobs"
           fi
           if [ -n "$skipped_jobs" ]; then

--- a/scripts/qa/ci-nightly-jobs.sh
+++ b/scripts/qa/ci-nightly-jobs.sh
@@ -65,6 +65,7 @@ FAILED=()
 SKIPPED=()
 MANAGED_PIDS=()
 SELECTED_JOBS=("$@")
+SELECTED_JOB_COUNT=$#
 CLI_ROOT=""
 CLI_INSTALLED=0
 
@@ -109,13 +110,15 @@ if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
   exit 0
 fi
 
-for selected in "${SELECTED_JOBS[@]}"; do
-  if ! known_job "$selected"; then
-    echo "ERROR: unknown nightly job: $selected" >&2
-    usage >&2
-    exit 2
-  fi
-done
+if [ "$SELECTED_JOB_COUNT" -gt 0 ]; then
+  for selected in "${SELECTED_JOBS[@]}"; do
+    if ! known_job "$selected"; then
+      echo "ERROR: unknown nightly job: $selected" >&2
+      usage >&2
+      exit 2
+    fi
+  done
+fi
 
 # -----------------------------------------------------------------------------
 # Portable `timeout` shim
@@ -253,14 +256,15 @@ cleanup_all_managed() {
 run_job() {
   local name="$1"
   local fn="$2"
-  if [ "${#SELECTED_JOBS[@]}" -gt 0 ]; then
-    local selected
+  if [ "$SELECTED_JOB_COUNT" -gt 0 ]; then
+    local selected found=0
     for selected in "${SELECTED_JOBS[@]}"; do
       if [ "$selected" = "$name" ]; then
+        found=1
         break
       fi
     done
-    if [ "$selected" != "$name" ]; then
+    if [ "$found" -ne 1 ]; then
       return 0
     fi
   fi
@@ -1090,7 +1094,7 @@ if [ ${#SKIPPED[@]} -gt 0 ]; then
   printf '  - %s\n' "${SKIPPED[@]}"
 fi
 if [ ${#FAILED[@]} -eq 0 ]; then
-  if [ "${#SELECTED_JOBS[@]}" -gt 0 ]; then
+  if [ "$SELECTED_JOB_COUNT" -gt 0 ]; then
     echo "All selected CI-nightly jobs passed."
   else
     echo "All CI-nightly jobs passed."

--- a/scripts/qa/ci-nightly-jobs.sh
+++ b/scripts/qa/ci-nightly-jobs.sh
@@ -64,6 +64,56 @@ OS="$(uname -s)"
 FAILED=()
 SKIPPED=()
 MANAGED_PIDS=()
+SELECTED_JOBS=("$@")
+
+known_job() {
+  case "$1" in
+    record-replay|cluster-smoke|topic-and-top-smoke|cpu-affinity-smoke|redb-backend-smoke|daemon-reconnect-smoke|state-reconstruction-smoke|test-cross-platform|examples|cli-tests|bench-example|msrv|cross-check|ros2-bridge)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/qa/ci-nightly-jobs.sh [job ...]
+
+Run local equivalents for the long-running GitHub Actions nightly jobs.
+With no job names, runs every supported job for the current platform.
+
+Supported jobs:
+  record-replay
+  cluster-smoke
+  topic-and-top-smoke
+  cpu-affinity-smoke
+  redb-backend-smoke
+  daemon-reconnect-smoke
+  state-reconstruction-smoke
+  test-cross-platform
+  examples
+  cli-tests
+  bench-example
+  msrv
+  cross-check
+  ros2-bridge
+EOF
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+for selected in "${SELECTED_JOBS[@]}"; do
+  if ! known_job "$selected"; then
+    echo "ERROR: unknown nightly job: $selected" >&2
+    usage >&2
+    exit 2
+  fi
+done
 
 # -----------------------------------------------------------------------------
 # Portable `timeout` shim
@@ -191,6 +241,18 @@ cleanup_all_managed() {
 run_job() {
   local name="$1"
   local fn="$2"
+  if [ "${#SELECTED_JOBS[@]}" -gt 0 ]; then
+    local selected
+    for selected in "${SELECTED_JOBS[@]}"; do
+      if [ "$selected" = "$name" ]; then
+        break
+      fi
+    done
+    if [ "$selected" != "$name" ]; then
+      return 0
+    fi
+  fi
+
   echo
   echo "============================================================"
   echo "=== $name ==="
@@ -1001,7 +1063,11 @@ if [ ${#SKIPPED[@]} -gt 0 ]; then
   printf '  - %s\n' "${SKIPPED[@]}"
 fi
 if [ ${#FAILED[@]} -eq 0 ]; then
-  echo "All CI-nightly jobs passed."
+  if [ "${#SELECTED_JOBS[@]}" -gt 0 ]; then
+    echo "All selected CI-nightly jobs passed."
+  else
+    echo "All CI-nightly jobs passed."
+  fi
   exit 0
 else
   echo "FAILED:"

--- a/scripts/qa/ci-nightly-jobs.sh
+++ b/scripts/qa/ci-nightly-jobs.sh
@@ -65,6 +65,8 @@ FAILED=()
 SKIPPED=()
 MANAGED_PIDS=()
 SELECTED_JOBS=("$@")
+CLI_ROOT=""
+CLI_INSTALLED=0
 
 known_job() {
   case "$1" in
@@ -139,26 +141,33 @@ if ! command -v timeout > /dev/null 2>&1; then
   fi
 fi
 
-# Install dora CLI into a scratch root we own, so we don't clobber the user's
-# ~/.cargo/bin/dora. Prepend to PATH for this script only. CLI_ROOT is also
-# the unique pattern we use to identify our own processes (see PROCESS SAFETY
-# in the header).
-CLI_ROOT="$(mktemp -d -t dora-qa-XXXXXX)"
-trap 'cleanup_all_managed; rm -rf "$CLI_ROOT"' EXIT
+trap 'cleanup_all_managed; if [ -n "$CLI_ROOT" ]; then rm -rf "$CLI_ROOT"; fi' EXIT
 
-echo
-echo "=== install dora CLI to $CLI_ROOT (so ~/.cargo/bin/dora is not clobbered) ==="
-cargo install --path binaries/cli --locked --root "$CLI_ROOT" --quiet
-export PATH="$CLI_ROOT/bin:$PATH"
-dora --version
+ensure_cli_installed() {
+  if [ "$CLI_INSTALLED" -eq 1 ]; then
+    return 0
+  fi
 
-# Port 6013 is the default coordinator WS port. If something is already
-# listening, bail out with a clear message instead of racing.
-if command -v lsof > /dev/null 2>&1 && lsof -iTCP:6013 -sTCP:LISTEN > /dev/null 2>&1; then
-  echo "ERROR: port 6013 is already in use. A dora coordinator is likely already"
-  echo "running. Stop that coordinator with \`dora destroy\` before re-running."
-  exit 1
-fi
+  # Port 6013 is the default coordinator WS port. Jobs that spawn dora services
+  # need it free; pure cargo jobs should not be blocked by this preflight.
+  if command -v lsof > /dev/null 2>&1 && lsof -iTCP:6013 -sTCP:LISTEN > /dev/null 2>&1; then
+    echo "ERROR: port 6013 is already in use. A dora coordinator is likely already"
+    echo "running. Stop that coordinator with \`dora destroy\` before re-running."
+    exit 1
+  fi
+
+  # Install dora CLI into a scratch root we own, so we don't clobber the user's
+  # ~/.cargo/bin/dora. Prepend to PATH for this script only. CLI_ROOT is also
+  # the unique pattern we use to identify our own processes (see PROCESS SAFETY
+  # in the header).
+  CLI_ROOT="$(mktemp -d -t dora-qa-XXXXXX)"
+  echo
+  echo "=== install dora CLI to $CLI_ROOT (so ~/.cargo/bin/dora is not clobbered) ==="
+  cargo install --path binaries/cli --locked --root "$CLI_ROOT" --quiet
+  export PATH="$CLI_ROOT/bin:$PATH"
+  dora --version
+  CLI_INSTALLED=1
+}
 
 # -----------------------------------------------------------------------------
 # Safe process management (replaces broad pkill)
@@ -185,6 +194,9 @@ terminate_pid() {
 # never touch dora binaries installed elsewhere -- $CLI_ROOT is a unique
 # per-run mktemp path.
 terminate_our_dora_children() {
+  if [ -z "$CLI_ROOT" ]; then
+    return 0
+  fi
   if ! command -v pgrep > /dev/null 2>&1; then
     return 0
   fi
@@ -222,7 +234,7 @@ cleanup_all_managed() {
       wait "$pid" 2>/dev/null || true
     done
   fi
-  if command -v pgrep > /dev/null 2>&1; then
+  if [ -n "$CLI_ROOT" ] && command -v pgrep > /dev/null 2>&1; then
     local remaining
     remaining=$(pgrep -f "$CLI_ROOT/bin/dora" 2>/dev/null || true)
     if [ -n "$remaining" ]; then
@@ -284,6 +296,8 @@ run_job() {
 # class of bug. Keep this function in lockstep with the GHA step bodies.
 # -----------------------------------------------------------------------------
 job_record_replay() {
+  ensure_cli_installed
+
   cargo build --quiet \
     -p rust-dataflow-example-node \
     -p rust-dataflow-example-status-node \
@@ -325,6 +339,8 @@ job_record_replay() {
 # Job 2: cluster-smoke
 # -----------------------------------------------------------------------------
 job_cluster_smoke() {
+  ensure_cli_installed
+
   cargo build --quiet \
     -p rust-dataflow-example-node \
     -p rust-dataflow-example-status-node \
@@ -386,6 +402,7 @@ job_topic_and_top() {
     SKIPPED+=("topic-and-top-smoke: uv missing")
     return 0
   fi
+  ensure_cli_installed
 
   local venv_dir
   venv_dir="$(mktemp -d -t dora-qa-venv-XXXXXX)"
@@ -503,6 +520,7 @@ job_cpu_affinity() {
     SKIPPED+=("cpu-affinity-smoke: non-Linux ($OS)")
     return 0
   fi
+  ensure_cli_installed
 
   cargo build --quiet -p cpu-affinity-probe
 
@@ -529,6 +547,8 @@ job_cpu_affinity() {
 # Job 4: redb-backend-smoke
 # -----------------------------------------------------------------------------
 job_redb_backend() {
+  ensure_cli_installed
+
   cargo build --quiet -p rust-dataflow-example-node
 
   local STORE=/tmp/dora-redb-smoke.db
@@ -602,6 +622,7 @@ job_daemon_reconnect() {
     SKIPPED+=("daemon-reconnect-smoke: non-Linux ($OS)")
     return 0
   fi
+  ensure_cli_installed
 
   dora coordinator > /tmp/coord.log 2>&1 &
   track_pid "$!"
@@ -654,6 +675,8 @@ job_daemon_reconnect() {
 # Job 6: state-reconstruction-smoke
 # -----------------------------------------------------------------------------
 job_state_reconstruction() {
+  ensure_cli_installed
+
   cargo build --quiet -p rust-dataflow-example-node
 
   local STORE=/tmp/state-reconstruct.db
@@ -747,10 +770,12 @@ job_test_cross_platform() {
 # Mirrors nightly.yml `examples`.
 # -----------------------------------------------------------------------------
 job_examples() {
+  ensure_cli_installed
+
   cargo build --quiet --examples
   cargo build --quiet -p dora-cli
   # NOTE: $CLI_ROOT/bin/dora is already on PATH (set by the script
-  # preamble), so the daemon's which::which("dora") will find it. Do
+  # ensure_cli_installed), so the daemon's which::which("dora") will find it. Do
   # NOT prepend target/debug here -- a naive `export PATH=...` leaks
   # past this function and subsequent jobs' spawned `dora up` children
   # would end up at target/debug/dora, which `terminate_our_dora_children`
@@ -795,7 +820,9 @@ job_examples() {
 # Mirrors nightly.yml `cli-tests` (was the `cli` job in old ci.yml).
 # -----------------------------------------------------------------------------
 job_cli_tests() {
-  # CLI already installed at $CLI_ROOT/bin/dora by this script's preamble.
+  ensure_cli_installed
+
+  # CLI already installed at $CLI_ROOT/bin/dora by ensure_cli_installed.
   # cargo install --path binaries/cli --locked is redundant here; skip it
   # to save ~45 min per local run.
 


### PR DESCRIPTION
Nightly regression issues only listed the failed job IDs and often fell back to a generic "see the run log" repro note. That made the automated issue hard to act on because maintainers had to open the Actions run, find the failing matrix job, and reconstruct the local command manually.

Grant the workflow actions:read permission and have the issue filing job fetch failed log lines with gh run view --log-failed. The issue body now filters those lines by failed job display name and embeds the last 120 relevant lines inside each failed-job details block.

Also fill in concrete repro commands for the previously unmapped nightly jobs. The long-running local parity driver now accepts one or more job names, so generated issues can point at targeted commands such as scripts/qa/ci-nightly-jobs.sh cli-tests or scripts/qa/ci-nightly-jobs.sh ros2-bridge.

Validation: bash -n scripts/qa/ci-nightly-jobs.sh; extracted nightly issue shell block with bash -n; scripts/qa/ci-nightly-jobs.sh --help; unknown job validation; git diff --check.
