### PR TITLE
fix(build): keep draining build output streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1807,6 +1807,7 @@ dependencies = [
  "syn 2.0.117",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "tracing",
  "url",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,7 @@ thiserror = "2.0"
 colored = "3.0.0"
 inquire = { version = "0.7.5", default-features = false }
 tokio = { version = "1.28", default-features = false }
+tokio-stream = "0.1.11"
 eyre = "0.6.8"
 serde = { version = "1", features = ["derive"] }
 tracing = "0.1.36"

--- a/libraries/core/Cargo.toml
+++ b/libraries/core/Cargo.toml
@@ -27,6 +27,7 @@ uuid = { workspace = true }
 tracing = { workspace = true }
 serde-with-expand-env = "1.1.0"
 tokio = { workspace = true, features = ["fs", "io-util", "macros", "process", "sync", "rt"] }
+tokio-stream = { workspace = true, features = ["io-util"] }
 schemars = "1.0.4"
 serde_json = { workspace = true }
 log = { version = "0.4.21", features = ["serde"] }

--- a/libraries/core/src/build/build_command.rs
+++ b/libraries/core/src/build/build_command.rs
@@ -9,9 +9,10 @@ use crate::build::{managed_python_bin_dir, managed_python_interpreter};
 use dora_message::descriptor::EnvValue;
 use eyre::{Context, eyre};
 use tokio::{
-    io::{AsyncBufReadExt, BufReader},
+    io::{AsyncBufRead, AsyncBufReadExt, BufReader},
     process::Command,
 };
+use tokio_stream::{StreamExt, wrappers::LinesStream};
 
 pub async fn run_build_command(
     build: &str,
@@ -79,20 +80,7 @@ pub async fn run_build_command(
         let stdout_tx = stdout_tx.clone();
 
         tokio::spawn(async move {
-            let mut stdout_lines = child_stdout.lines();
-            let mut stderr_lines = child_stderr.lines();
-            loop {
-                let line = tokio::select! {
-                    line = stdout_lines.next_line() => line,
-                    line = stderr_lines.next_line() => line,
-                };
-                let Some(line) = line.transpose() else {
-                    break;
-                };
-                if stdout_tx.send(line).await.is_err() {
-                    break;
-                }
-            }
+            forward_build_output(child_stdout, child_stderr, stdout_tx).await;
         });
 
         let exit_status = child
@@ -321,24 +309,101 @@ fn local_dora_python_package_dir(working_dir: &Path) -> Option<PathBuf> {
     })
 }
 
-/// Forwards stdout and stderr to the build logger using interleaved select.
-async fn forward_build_output(
-    child_stdout: BufReader<tokio::process::ChildStdout>,
-    child_stderr: BufReader<tokio::process::ChildStderr>,
+/// Forwards stdout and stderr to the build logger until both streams close.
+async fn forward_build_output<R1, R2>(
+    child_stdout: R1,
+    child_stderr: R2,
     stdout_tx: tokio::sync::mpsc::Sender<std::io::Result<String>>,
-) {
-    let mut stdout_lines = child_stdout.lines();
-    let mut stderr_lines = child_stderr.lines();
-    loop {
-        let line = tokio::select! {
-            line = stdout_lines.next_line() => line,
-            line = stderr_lines.next_line() => line,
-        };
-        let Some(line) = line.transpose() else {
-            break;
-        };
+) where
+    R1: AsyncBufRead + Unpin,
+    R2: AsyncBufRead + Unpin,
+{
+    let mut merged =
+        LinesStream::new(child_stdout.lines()).merge(LinesStream::new(child_stderr.lines()));
+
+    while let Some(line) = merged.next().await {
         if stdout_tx.send(line).await.is_err() {
             break;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::forward_build_output;
+    use tokio::io::{AsyncWriteExt, BufReader};
+
+    #[tokio::test]
+    async fn keeps_draining_stdout_after_stderr_closes() {
+        run_forward_output_test(true).await;
+    }
+
+    #[tokio::test]
+    async fn keeps_draining_stderr_after_stdout_closes() {
+        run_forward_output_test(false).await;
+    }
+
+    async fn run_forward_output_test(stdout_stays_open: bool) {
+        let (stdout_reader, mut stdout_writer) = tokio::io::duplex(64);
+        let (stderr_reader, mut stderr_writer) = tokio::io::duplex(64);
+        let (tx, mut rx) = tokio::sync::mpsc::channel(16);
+
+        let forward_task = tokio::spawn(forward_build_output(
+            BufReader::new(stdout_reader),
+            BufReader::new(stderr_reader),
+            tx,
+        ));
+
+        let writer_task = tokio::spawn(async move {
+            if stdout_stays_open {
+                stderr_writer
+                    .shutdown()
+                    .await
+                    .expect("failed to close stderr writer");
+
+                for index in 0..256 {
+                    stdout_writer
+                        .write_all(format!("line-{index}\n").as_bytes())
+                        .await
+                        .expect("failed to write test line");
+                }
+                stdout_writer
+                    .shutdown()
+                    .await
+                    .expect("failed to close stdout writer");
+            } else {
+                stdout_writer
+                    .shutdown()
+                    .await
+                    .expect("failed to close stdout writer");
+
+                for index in 0..256 {
+                    stderr_writer
+                        .write_all(format!("line-{index}\n").as_bytes())
+                        .await
+                        .expect("failed to write test line");
+                }
+                stderr_writer
+                    .shutdown()
+                    .await
+                    .expect("failed to close stderr writer");
+            }
+        });
+
+        let collect_task = tokio::spawn(async move {
+            let mut lines = Vec::new();
+            while let Some(line) = rx.recv().await {
+                lines.push(line.expect("unexpected line forwarding error"));
+            }
+            lines
+        });
+
+        writer_task.await.expect("writer task failed");
+        forward_task.await.expect("forward task failed");
+        let lines = collect_task.await.expect("collector task failed");
+
+        assert_eq!(lines.len(), 256);
+        assert_eq!(lines.first().map(String::as_str), Some("line-0"));
+        assert_eq!(lines.last().map(String::as_str), Some("line-255"));
     }
 }


### PR DESCRIPTION
Fixes #1821.

## Summary
- Replace EOF-sensitive stdout/stderr select loops with merged stream forwarding.
- Reuse the helper across build command and managed Python env output forwarding.
- Add regression coverage for both stdout-first and stderr-first close orders.

## Validation
- cargo test -p dora-core --features build keeps_draining
- cargo test -p dora-core --features build
- cargo fmt --all -- --check
- cargo clippy -p dora-core --features build -- -D warnings