### PR TITLE
fix: address nightly regression 1825

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,14 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: workspace-test
+      - name: Free disk space
+        shell: bash
+        run: |
+          set -eux
+          df -h
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /opt/hostedtoolcache/CodeQL || true
+          docker system prune -af || true
+          df -h
       - name: Build (excluding Python packages)
         run: >
           cargo build --all

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1174,6 +1174,7 @@ jobs:
           dora new test_python_project --lang python --internal-create-with-path-dependencies
           cd test_python_project
           dora build dataflow.yml --uv
+          uv pip install -e ../apis/python/node -e talker-1 -e talker-2 -e listener-1
           uv run ruff check .
           uv run pytest
           export OPERATING_MODE=SAVE
@@ -1442,7 +1443,7 @@ jobs:
           QT_QPA_PLATFORM: offscreen
         run: |
           source /opt/ros/humble/setup.bash &&
-          cargo run -p dora-ros2-bridge --example cxx-ros2-dataflow
+          cargo run -p dora-ros2-bridge --example cxx-ros2-dataflow --features ros2-examples
 
   # ===== MSRV check =====
   # Restored from upstream dora CI — verifies the minimum supported

--- a/binaries/cli/src/template/python/README.md
+++ b/binaries/cli/src/template/python/README.md
@@ -32,9 +32,12 @@ uv run ruff check .
 
 ```bash
 uv pip install pytest
-uv pip install -e talker-1 -e talker-2 -e listener-1
+uv pip install -e <each-node-package>
 uv run pytest . # Test
 ```
+
+For the default template, the node packages are `talker-1`, `talker-2`, and
+`listener-1`.
 
 When testing this template from a Dora source checkout, install the checkout's
 Python API into the same root environment before running pytest, for example:

--- a/binaries/cli/src/template/python/README.md
+++ b/binaries/cli/src/template/python/README.md
@@ -32,7 +32,15 @@ uv run ruff check .
 
 ```bash
 uv pip install pytest
+uv pip install -e talker-1 -e talker-2 -e listener-1
 uv run pytest . # Test
+```
+
+When testing this template from a Dora source checkout, install the checkout's
+Python API into the same root environment before running pytest, for example:
+
+```bash
+uv pip install -e ../apis/python/node -e talker-1 -e talker-2 -e listener-1
 ```
 
 ## YAML Specification

--- a/examples/ros2-bridge/c++/turtle/README.md
+++ b/examples/ros2-bridge/c++/turtle/README.md
@@ -21,7 +21,7 @@ This examples requires a sourced ROS2 installation.
 ```bash
 source /opt/ros/<ros-distro>/setup.bash
 export RMW_IMPLEMENTATION=rmw_fastrtps_cpp
-cargo run --package dora-ros2-bridge --example cxx-ros2-dataflow
+cargo run --package dora-ros2-bridge --example cxx-ros2-dataflow --features ros2-examples
 ```
 
 ## Alternative (manual)

--- a/libraries/core/src/build/build_command.rs
+++ b/libraries/core/src/build/build_command.rs
@@ -1,9 +1,11 @@
 use std::{
     collections::BTreeMap,
     ffi::OsString,
+    fs,
     path::{Path, PathBuf},
     process::Stdio,
     sync::LazyLock,
+    time::Duration,
 };
 
 use crate::build::{managed_python_bin_dir, managed_python_interpreter};
@@ -15,8 +17,20 @@ use tokio::{
 };
 use tokio_stream::{StreamExt, wrappers::LinesStream};
 
-static LOCAL_DORA_WHEEL_CACHE: LazyLock<tokio::sync::Mutex<BTreeMap<PathBuf, PathBuf>>> =
-    LazyLock::new(|| tokio::sync::Mutex::new(BTreeMap::new()));
+static LOCAL_DORA_WHEEL_CACHE: LazyLock<
+    tokio::sync::Mutex<BTreeMap<LocalDoraPythonSource, PathBuf>>,
+> = LazyLock::new(|| tokio::sync::Mutex::new(BTreeMap::new()));
+
+const LOCAL_DORA_RUNTIME_MARKER: &str = ".dora-local-runtime-fingerprint";
+const LOCAL_DORA_WHEEL_CACHE_MAX_AGE: Duration = Duration::from_secs(24 * 60 * 60);
+const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
+const FNV_PRIME: u64 = 0x00000100000001b3;
+
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+struct LocalDoraPythonSource {
+    package_dir: PathBuf,
+    fingerprint: String,
+}
 
 pub async fn run_build_command(
     build: &str,
@@ -211,14 +225,24 @@ async fn ensure_managed_python_runtime(
     envs: &Option<BTreeMap<String, EnvValue>>,
     stdout_tx: tokio::sync::mpsc::Sender<std::io::Result<String>>,
 ) -> eyre::Result<()> {
-    if managed_python_can_import_dora(working_dir, python_env_dir, envs).await? {
+    let local_source = local_dora_python_source(working_dir)?;
+    let can_import_dora = managed_python_can_import_dora(working_dir, python_env_dir, envs).await?;
+    if local_source
+        .as_ref()
+        .is_some_and(|source| local_runtime_marker_matches(python_env_dir, &source.fingerprint))
+        && can_import_dora
+    {
+        return Ok(());
+    }
+    if local_source.is_none() && can_import_dora {
         return Ok(());
     }
 
     let mut cmd = Command::new("uv");
     cmd.arg("pip");
     cmd.arg("install");
-    let install_args = dora_runtime_install_args(working_dir, envs, stdout_tx.clone()).await?;
+    let install_args =
+        dora_runtime_install_args(local_source.as_ref(), envs, stdout_tx.clone()).await?;
     cmd.args(install_args);
 
     if let Some(envs) = envs {
@@ -242,8 +266,18 @@ async fn ensure_managed_python_runtime(
         )
     })?;
 
-    let child_stdout = BufReader::new(child.stdout.take().expect("failed to take stdout"));
-    let child_stderr = BufReader::new(child.stderr.take().expect("failed to take stderr"));
+    let child_stdout = BufReader::new(
+        child
+            .stdout
+            .take()
+            .ok_or_else(|| eyre!("failed to capture stdout pipe from Dora runtime install"))?,
+    );
+    let child_stderr = BufReader::new(
+        child
+            .stderr
+            .take()
+            .ok_or_else(|| eyre!("failed to capture stderr pipe from Dora runtime install"))?,
+    );
 
     tokio::spawn(async move {
         forward_build_output(child_stdout, child_stderr, stdout_tx).await;
@@ -260,6 +294,10 @@ async fn ensure_managed_python_runtime(
             "managed Python runtime installation `{}` returned {exit_status}",
             python_env_dir.display()
         ));
+    }
+
+    if let Some(source) = local_source {
+        write_local_runtime_marker(python_env_dir, &source.fingerprint)?;
     }
 
     Ok(())
@@ -304,15 +342,35 @@ fn local_dora_python_package_dir(working_dir: &Path) -> Option<PathBuf> {
     })
 }
 
+fn local_dora_python_source(working_dir: &Path) -> eyre::Result<Option<LocalDoraPythonSource>> {
+    local_dora_python_package_dir(working_dir)
+        .map(|package_dir| {
+            let package_dir = dunce::canonicalize(&package_dir).wrap_err_with(|| {
+                format!(
+                    "failed to canonicalize local Dora Python package `{}`",
+                    package_dir.display()
+                )
+            })?;
+            let fingerprint = local_dora_python_source_fingerprint(&package_dir)?;
+            Ok(LocalDoraPythonSource {
+                package_dir,
+                fingerprint,
+            })
+        })
+        .transpose()
+}
+
 /// Returns the package argument for installing `dora-rs` into a managed Python env.
 async fn dora_runtime_install_args(
-    working_dir: &Path,
+    local_source: Option<&LocalDoraPythonSource>,
     envs: &Option<BTreeMap<String, EnvValue>>,
     stdout_tx: tokio::sync::mpsc::Sender<std::io::Result<String>>,
 ) -> eyre::Result<Vec<OsString>> {
-    match local_dora_python_package_dir(working_dir) {
-        Some(package_dir) => Ok(vec![
-            ensure_local_dora_python_wheel(&package_dir, envs, stdout_tx)
+    match local_source {
+        Some(source) => Ok(vec![
+            OsString::from("--reinstall-package"),
+            OsString::from("dora-rs"),
+            ensure_local_dora_python_wheel(source, envs, stdout_tx)
                 .await?
                 .into_os_string(),
         ]),
@@ -329,24 +387,18 @@ async fn dora_runtime_install_args(
 /// node env. A wheel install keeps local checkout behavior while sharing that build
 /// across all node envs created by the current CLI invocation.
 async fn ensure_local_dora_python_wheel(
-    package_dir: &Path,
+    source: &LocalDoraPythonSource,
     envs: &Option<BTreeMap<String, EnvValue>>,
     stdout_tx: tokio::sync::mpsc::Sender<std::io::Result<String>>,
 ) -> eyre::Result<PathBuf> {
-    let package_dir = dunce::canonicalize(package_dir).wrap_err_with(|| {
-        format!(
-            "failed to canonicalize local Dora Python package `{}`",
-            package_dir.display()
-        )
-    })?;
     let mut cache = LOCAL_DORA_WHEEL_CACHE.lock().await;
-    if let Some(wheel) = cache.get(&package_dir)
+    if let Some(wheel) = cache.get(source)
         && wheel.is_file()
     {
         return Ok(wheel.clone());
     }
 
-    let wheel_dir = local_dora_python_wheel_dir(&package_dir)?;
+    let wheel_dir = local_dora_python_wheel_dir(&source.package_dir)?;
     std::fs::create_dir_all(&wheel_dir).wrap_err_with(|| {
         format!(
             "failed to create local Dora Python wheel cache `{}`",
@@ -361,14 +413,14 @@ async fn ensure_local_dora_python_wheel(
     cmd.arg("--no-create-gitignore");
     cmd.arg("--out-dir");
     cmd.arg(&wheel_dir);
-    cmd.arg(&package_dir);
+    cmd.arg(&source.package_dir);
 
     if let Some(envs) = envs {
         for (key, value) in envs {
             cmd.env(key, value.to_string());
         }
     }
-    cmd.current_dir(dunce::simplified(&package_dir));
+    cmd.current_dir(dunce::simplified(&source.package_dir));
     cmd.stdin(Stdio::null());
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
@@ -378,12 +430,22 @@ async fn ensure_local_dora_python_wheel(
     let mut child = cmd.spawn().wrap_err_with(|| {
         format!(
             "failed to spawn local Dora Python wheel build for `{}`",
-            package_dir.display()
+            source.package_dir.display()
         )
     })?;
 
-    let child_stdout = BufReader::new(child.stdout.take().expect("failed to take stdout"));
-    let child_stderr = BufReader::new(child.stderr.take().expect("failed to take stderr"));
+    let child_stdout = BufReader::new(
+        child
+            .stdout
+            .take()
+            .ok_or_else(|| eyre!("failed to capture stdout pipe from local Dora wheel build"))?,
+    );
+    let child_stderr = BufReader::new(
+        child
+            .stderr
+            .take()
+            .ok_or_else(|| eyre!("failed to capture stderr pipe from local Dora wheel build"))?,
+    );
 
     tokio::spawn(async move {
         forward_build_output(child_stdout, child_stderr, stdout_tx).await;
@@ -392,36 +454,30 @@ async fn ensure_local_dora_python_wheel(
     let exit_status = child.wait().await.wrap_err_with(|| {
         format!(
             "failed to build local Dora Python wheel from `{}`",
-            package_dir.display()
+            source.package_dir.display()
         )
     })?;
     if !exit_status.success() {
         return Err(eyre!(
             "local Dora Python wheel build `{}` returned {exit_status}",
-            package_dir.display()
+            source.package_dir.display()
         ));
     }
 
     let wheel = find_local_dora_python_wheel(&wheel_dir)?;
-    cache.insert(package_dir, wheel.clone());
+    cache.insert(source.clone(), wheel.clone());
     Ok(wheel)
 }
 
 fn local_dora_python_wheel_dir(package_dir: &Path) -> eyre::Result<PathBuf> {
-    let workspace_root = package_dir
-        .parent()
-        .and_then(|path| path.parent())
-        .and_then(|path| path.parent())
-        .ok_or_else(|| {
-            eyre!(
-                "local Dora Python package `{}` is not under apis/python/node",
-                package_dir.display()
-            )
-        })?;
-    Ok(workspace_root
-        .join("target")
-        .join("dora-python-wheels")
-        .join(format!("process-{}", std::process::id())))
+    let workspace_root = local_dora_workspace_root(package_dir)?;
+    let wheel_root = workspace_root.join("target").join("dora-python-wheels");
+    cleanup_stale_local_dora_python_wheel_dirs(
+        &wheel_root,
+        LOCAL_DORA_WHEEL_CACHE_MAX_AGE,
+        std::process::id(),
+    );
+    Ok(wheel_root.join(format!("process-{}", std::process::id())))
 }
 
 fn find_local_dora_python_wheel(wheel_dir: &Path) -> eyre::Result<PathBuf> {
@@ -437,12 +493,173 @@ fn find_local_dora_python_wheel(wheel_dir: &Path) -> eyre::Result<PathBuf> {
         })
         .collect::<Vec<_>>();
     wheels.sort();
-    wheels.into_iter().next().ok_or_else(|| {
+    wheels.into_iter().next_back().ok_or_else(|| {
         eyre!(
             "local Dora Python wheel build did not create a dora-rs wheel in `{}`",
             wheel_dir.display()
         )
     })
+}
+
+fn cleanup_stale_local_dora_python_wheel_dirs(
+    wheel_root: &Path,
+    max_age: Duration,
+    current_pid: u32,
+) {
+    let Ok(entries) = fs::read_dir(wheel_root) else {
+        return;
+    };
+
+    for entry in entries.filter_map(Result::ok) {
+        let path = entry.path();
+        if !entry.file_type().is_ok_and(|file_type| file_type.is_dir()) {
+            continue;
+        }
+
+        let Some(pid) = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .and_then(|name| name.strip_prefix("process-"))
+            .and_then(|pid| pid.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        if pid == current_pid {
+            continue;
+        }
+
+        let stale = path
+            .metadata()
+            .and_then(|metadata| metadata.modified())
+            .and_then(|modified| modified.elapsed().map_err(std::io::Error::other))
+            .is_ok_and(|age| age >= max_age);
+        if stale {
+            let _ = fs::remove_dir_all(path);
+        }
+    }
+}
+
+fn local_runtime_marker_path(python_env_dir: &Path) -> PathBuf {
+    python_env_dir.join(LOCAL_DORA_RUNTIME_MARKER)
+}
+
+fn local_runtime_marker_matches(python_env_dir: &Path, fingerprint: &str) -> bool {
+    std::fs::read_to_string(local_runtime_marker_path(python_env_dir))
+        .is_ok_and(|existing| existing.trim() == fingerprint)
+}
+
+fn write_local_runtime_marker(python_env_dir: &Path, fingerprint: &str) -> eyre::Result<()> {
+    std::fs::write(local_runtime_marker_path(python_env_dir), fingerprint).wrap_err_with(|| {
+        format!(
+            "failed to write local Dora runtime marker in `{}`",
+            python_env_dir.display()
+        )
+    })
+}
+
+fn local_dora_workspace_root(package_dir: &Path) -> eyre::Result<PathBuf> {
+    package_dir
+        .parent()
+        .and_then(|path| path.parent())
+        .and_then(|path| path.parent())
+        .map(Path::to_path_buf)
+        .ok_or_else(|| {
+            eyre!(
+                "local Dora Python package `{}` is not under apis/python/node",
+                package_dir.display()
+            )
+        })
+}
+
+fn local_dora_python_source_fingerprint(package_dir: &Path) -> eyre::Result<String> {
+    let workspace_root = local_dora_workspace_root(package_dir)?;
+    let mut files = Vec::new();
+    for file_name in ["Cargo.lock", "Cargo.toml"] {
+        let path = workspace_root.join(file_name);
+        if path.is_file() {
+            files.push(path);
+        }
+    }
+    collect_fingerprint_files(package_dir, &mut files)?;
+    files.sort();
+
+    let mut hash = FNV_OFFSET_BASIS;
+    for path in files {
+        let relative = path.strip_prefix(&workspace_root).unwrap_or(&path);
+        hash_fingerprint_bytes(&mut hash, relative.to_string_lossy().as_bytes());
+        hash_fingerprint_bytes(&mut hash, b"\0");
+        let contents = fs::read(&path)
+            .wrap_err_with(|| format!("failed to read `{}` for fingerprint", path.display()))?;
+        hash_fingerprint_bytes(&mut hash, &contents);
+        hash_fingerprint_bytes(&mut hash, b"\0");
+    }
+
+    Ok(format!("{hash:016x}"))
+}
+
+fn collect_fingerprint_files(dir: &Path, files: &mut Vec<PathBuf>) -> eyre::Result<()> {
+    let mut entries = fs::read_dir(dir)
+        .wrap_err_with(|| format!("failed to read `{}` for fingerprint", dir.display()))?
+        .collect::<Result<Vec<_>, _>>()
+        .wrap_err_with(|| format!("failed to read entry under `{}`", dir.display()))?;
+    entries.sort_by_key(|entry| entry.path());
+
+    for entry in entries {
+        let path = entry.path();
+        let file_type = entry
+            .file_type()
+            .wrap_err_with(|| format!("failed to inspect `{}` for fingerprint", path.display()))?;
+        if file_type.is_dir() {
+            if should_skip_fingerprint_dir(&path) {
+                continue;
+            }
+            collect_fingerprint_files(&path, files)?;
+        } else if file_type.is_file() && is_fingerprint_file(&path) {
+            files.push(path);
+        }
+    }
+
+    Ok(())
+}
+
+fn should_skip_fingerprint_dir(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| {
+            matches!(
+                name,
+                ".direnv"
+                    | ".mypy_cache"
+                    | ".pytest_cache"
+                    | ".ruff_cache"
+                    | ".tox"
+                    | ".venv"
+                    | "__pycache__"
+                    | "out"
+                    | "target"
+            )
+        })
+}
+
+fn is_fingerprint_file(path: &Path) -> bool {
+    if path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| matches!(name, "Cargo.toml" | "build.rs" | "pyproject.toml"))
+    {
+        return true;
+    }
+
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| matches!(extension, "py" | "rs" | "toml"))
+}
+
+fn hash_fingerprint_bytes(hash: &mut u64, bytes: &[u8]) {
+    for byte in bytes {
+        *hash ^= u64::from(*byte);
+        *hash = hash.wrapping_mul(FNV_PRIME);
+    }
 }
 
 /// Forwards stdout and stderr to the build logger until both streams close.
@@ -467,10 +684,12 @@ async fn forward_build_output<R1, R2>(
 #[cfg(test)]
 mod tests {
     use super::{
-        dora_runtime_install_args, find_local_dora_python_wheel, forward_build_output,
-        local_dora_python_package_dir, local_dora_python_wheel_dir,
+        cleanup_stale_local_dora_python_wheel_dirs, dora_runtime_install_args,
+        find_local_dora_python_wheel, forward_build_output, local_dora_python_package_dir,
+        local_dora_python_source_fingerprint, local_dora_python_wheel_dir,
+        local_runtime_marker_matches, write_local_runtime_marker,
     };
-    use std::{ffi::OsString, fs};
+    use std::{ffi::OsString, fs, time::Duration};
     use tokio::io::{AsyncWriteExt, BufReader};
 
     #[test]
@@ -495,11 +714,10 @@ mod tests {
 
     #[tokio::test]
     async fn runtime_install_falls_back_to_versioned_pypi_requirement() {
-        let temp = tempfile::tempdir().unwrap();
         let (stdout_tx, _stdout_rx) = tokio::sync::mpsc::channel(1);
 
         assert_eq!(
-            dora_runtime_install_args(temp.path(), &None, stdout_tx)
+            dora_runtime_install_args(None, &None, stdout_tx)
                 .await
                 .unwrap(),
             vec![OsString::from(format!(
@@ -527,13 +745,80 @@ mod tests {
     #[test]
     fn finds_built_local_runtime_wheel() {
         let temp = tempfile::tempdir().unwrap();
+        let old_wheel = temp
+            .path()
+            .join("dora_rs-0.2.0-cp37-abi3-manylinux_2_34_x86_64.whl");
         let wheel = temp
             .path()
             .join("dora_rs-0.2.1-cp37-abi3-manylinux_2_34_x86_64.whl");
+        fs::write(old_wheel, "").unwrap();
         fs::write(&wheel, "").unwrap();
         fs::write(temp.path().join("other-0.1.0-py3-none-any.whl"), "").unwrap();
 
         assert_eq!(find_local_dora_python_wheel(temp.path()).unwrap(), wheel);
+    }
+
+    #[test]
+    fn local_runtime_source_fingerprint_changes_when_source_changes() {
+        let temp = tempfile::tempdir().unwrap();
+        let package_dir = create_local_python_package(temp.path());
+
+        let before = local_dora_python_source_fingerprint(&package_dir).unwrap();
+        fs::write(
+            package_dir.join("dora").join("__init__.py"),
+            "version = 2\n",
+        )
+        .unwrap();
+        let after = local_dora_python_source_fingerprint(&package_dir).unwrap();
+
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn local_runtime_source_fingerprint_ignores_build_outputs() {
+        let temp = tempfile::tempdir().unwrap();
+        let package_dir = create_local_python_package(temp.path());
+
+        let before = local_dora_python_source_fingerprint(&package_dir).unwrap();
+        let target_dir = temp.path().join("target").join("debug");
+        fs::create_dir_all(&target_dir).unwrap();
+        fs::write(target_dir.join("generated.rs"), "fn ignored() {}\n").unwrap();
+        let dora_dir = temp.path().join(".dora").join("python-envs");
+        fs::create_dir_all(&dora_dir).unwrap();
+        fs::write(dora_dir.join("marker.py"), "ignored = True\n").unwrap();
+        let after = local_dora_python_source_fingerprint(&package_dir).unwrap();
+
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn stale_process_wheel_dirs_are_removed_without_touching_current_process() {
+        let temp = tempfile::tempdir().unwrap();
+        let old_dir = temp.path().join("process-1");
+        let current_dir = temp.path().join("process-2");
+        let unrelated_dir = temp.path().join("not-a-process");
+        fs::create_dir_all(&old_dir).unwrap();
+        fs::create_dir_all(&current_dir).unwrap();
+        fs::create_dir_all(&unrelated_dir).unwrap();
+
+        cleanup_stale_local_dora_python_wheel_dirs(temp.path(), Duration::ZERO, 2);
+
+        assert!(!old_dir.exists());
+        assert!(current_dir.exists());
+        assert!(unrelated_dir.exists());
+    }
+
+    #[test]
+    fn local_runtime_marker_must_match_fingerprint() {
+        let temp = tempfile::tempdir().unwrap();
+        let env_dir = temp.path().join("env");
+        fs::create_dir_all(&env_dir).unwrap();
+
+        assert!(!local_runtime_marker_matches(&env_dir, "fingerprint-a"));
+
+        write_local_runtime_marker(&env_dir, "fingerprint-a").unwrap();
+        assert!(local_runtime_marker_matches(&env_dir, "fingerprint-a"));
+        assert!(!local_runtime_marker_matches(&env_dir, "fingerprint-b"));
     }
 
     #[tokio::test]
@@ -608,5 +893,34 @@ mod tests {
         assert_eq!(lines.len(), 256);
         assert_eq!(lines.first().map(String::as_str), Some("line-0"));
         assert_eq!(lines.last().map(String::as_str), Some("line-255"));
+    }
+
+    fn create_local_python_package(root: &std::path::Path) -> std::path::PathBuf {
+        fs::write(root.join("Cargo.toml"), "[workspace]\n").unwrap();
+        fs::write(root.join("Cargo.lock"), "# lock\n").unwrap();
+        let package_dir = root.join("apis").join("python").join("node");
+        fs::create_dir_all(package_dir.join("dora")).unwrap();
+        fs::create_dir_all(package_dir.join("src")).unwrap();
+        fs::write(
+            package_dir.join("pyproject.toml"),
+            "[project]\nname = \"dora-rs\"\n",
+        )
+        .unwrap();
+        fs::write(
+            package_dir.join("Cargo.toml"),
+            "[package]\nname = \"node\"\n",
+        )
+        .unwrap();
+        fs::write(
+            package_dir.join("dora").join("__init__.py"),
+            "version = 1\n",
+        )
+        .unwrap();
+        fs::write(
+            package_dir.join("src").join("lib.rs"),
+            "pub fn marker() {}\n",
+        )
+        .unwrap();
+        package_dir
     }
 }

--- a/libraries/core/src/build/build_command.rs
+++ b/libraries/core/src/build/build_command.rs
@@ -3,6 +3,7 @@ use std::{
     ffi::OsString,
     path::{Path, PathBuf},
     process::Stdio,
+    sync::LazyLock,
 };
 
 use crate::build::{managed_python_bin_dir, managed_python_interpreter};
@@ -13,6 +14,9 @@ use tokio::{
     process::Command,
 };
 use tokio_stream::{StreamExt, wrappers::LinesStream};
+
+static LOCAL_DORA_WHEEL_CACHE: LazyLock<tokio::sync::Mutex<BTreeMap<PathBuf, PathBuf>>> =
+    LazyLock::new(|| tokio::sync::Mutex::new(BTreeMap::new()));
 
 pub async fn run_build_command(
     build: &str,
@@ -211,20 +215,11 @@ async fn ensure_managed_python_runtime(
         return Ok(());
     }
 
-    // Prefer the local workspace package so the managed env runs against the
-    // Dora Python API from this checkout when it is available.
     let mut cmd = Command::new("uv");
     cmd.arg("pip");
     cmd.arg("install");
-    match local_dora_python_package_dir(working_dir) {
-        Some(package_dir) => {
-            cmd.arg("-e");
-            cmd.arg(package_dir);
-        }
-        None => {
-            cmd.arg(format!("dora-rs=={}", env!("CARGO_PKG_VERSION")));
-        }
-    }
+    let install_args = dora_runtime_install_args(working_dir, envs, stdout_tx.clone()).await?;
+    cmd.args(install_args);
 
     if let Some(envs) = envs {
         for (key, value) in envs {
@@ -309,6 +304,147 @@ fn local_dora_python_package_dir(working_dir: &Path) -> Option<PathBuf> {
     })
 }
 
+/// Returns the package argument for installing `dora-rs` into a managed Python env.
+async fn dora_runtime_install_args(
+    working_dir: &Path,
+    envs: &Option<BTreeMap<String, EnvValue>>,
+    stdout_tx: tokio::sync::mpsc::Sender<std::io::Result<String>>,
+) -> eyre::Result<Vec<OsString>> {
+    match local_dora_python_package_dir(working_dir) {
+        Some(package_dir) => Ok(vec![
+            ensure_local_dora_python_wheel(&package_dir, envs, stdout_tx)
+                .await?
+                .into_os_string(),
+        ]),
+        None => Ok(vec![OsString::from(format!(
+            "dora-rs=={}",
+            env!("CARGO_PKG_VERSION")
+        ))]),
+    }
+}
+
+/// Builds the in-tree Python API once per Dora process and returns its wheel path.
+///
+/// Installing the local source tree directly asks maturin to build once per managed
+/// node env. A wheel install keeps local checkout behavior while sharing that build
+/// across all node envs created by the current CLI invocation.
+async fn ensure_local_dora_python_wheel(
+    package_dir: &Path,
+    envs: &Option<BTreeMap<String, EnvValue>>,
+    stdout_tx: tokio::sync::mpsc::Sender<std::io::Result<String>>,
+) -> eyre::Result<PathBuf> {
+    let package_dir = dunce::canonicalize(package_dir).wrap_err_with(|| {
+        format!(
+            "failed to canonicalize local Dora Python package `{}`",
+            package_dir.display()
+        )
+    })?;
+    let mut cache = LOCAL_DORA_WHEEL_CACHE.lock().await;
+    if let Some(wheel) = cache.get(&package_dir)
+        && wheel.is_file()
+    {
+        return Ok(wheel.clone());
+    }
+
+    let wheel_dir = local_dora_python_wheel_dir(&package_dir)?;
+    std::fs::create_dir_all(&wheel_dir).wrap_err_with(|| {
+        format!(
+            "failed to create local Dora Python wheel cache `{}`",
+            wheel_dir.display()
+        )
+    })?;
+
+    let mut cmd = Command::new("uv");
+    cmd.arg("build");
+    cmd.arg("--wheel");
+    cmd.arg("--clear");
+    cmd.arg("--no-create-gitignore");
+    cmd.arg("--out-dir");
+    cmd.arg(&wheel_dir);
+    cmd.arg(&package_dir);
+
+    if let Some(envs) = envs {
+        for (key, value) in envs {
+            cmd.env(key, value.to_string());
+        }
+    }
+    cmd.current_dir(dunce::simplified(&package_dir));
+    cmd.stdin(Stdio::null());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    cmd.env("CLICOLOR", "1");
+    cmd.env("CLICOLOR_FORCE", "1");
+
+    let mut child = cmd.spawn().wrap_err_with(|| {
+        format!(
+            "failed to spawn local Dora Python wheel build for `{}`",
+            package_dir.display()
+        )
+    })?;
+
+    let child_stdout = BufReader::new(child.stdout.take().expect("failed to take stdout"));
+    let child_stderr = BufReader::new(child.stderr.take().expect("failed to take stderr"));
+
+    tokio::spawn(async move {
+        forward_build_output(child_stdout, child_stderr, stdout_tx).await;
+    });
+
+    let exit_status = child.wait().await.wrap_err_with(|| {
+        format!(
+            "failed to build local Dora Python wheel from `{}`",
+            package_dir.display()
+        )
+    })?;
+    if !exit_status.success() {
+        return Err(eyre!(
+            "local Dora Python wheel build `{}` returned {exit_status}",
+            package_dir.display()
+        ));
+    }
+
+    let wheel = find_local_dora_python_wheel(&wheel_dir)?;
+    cache.insert(package_dir, wheel.clone());
+    Ok(wheel)
+}
+
+fn local_dora_python_wheel_dir(package_dir: &Path) -> eyre::Result<PathBuf> {
+    let workspace_root = package_dir
+        .parent()
+        .and_then(|path| path.parent())
+        .and_then(|path| path.parent())
+        .ok_or_else(|| {
+            eyre!(
+                "local Dora Python package `{}` is not under apis/python/node",
+                package_dir.display()
+            )
+        })?;
+    Ok(workspace_root
+        .join("target")
+        .join("dora-python-wheels")
+        .join(format!("process-{}", std::process::id())))
+}
+
+fn find_local_dora_python_wheel(wheel_dir: &Path) -> eyre::Result<PathBuf> {
+    let mut wheels = std::fs::read_dir(wheel_dir)
+        .wrap_err_with(|| format!("failed to read wheel cache `{}`", wheel_dir.display()))?
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.extension().is_some_and(|extension| extension == "whl")
+                && path
+                    .file_name()
+                    .is_some_and(|name| name.to_string_lossy().starts_with("dora_rs-"))
+        })
+        .collect::<Vec<_>>();
+    wheels.sort();
+    wheels.into_iter().next().ok_or_else(|| {
+        eyre!(
+            "local Dora Python wheel build did not create a dora-rs wheel in `{}`",
+            wheel_dir.display()
+        )
+    })
+}
+
 /// Forwards stdout and stderr to the build logger until both streams close.
 async fn forward_build_output<R1, R2>(
     child_stdout: R1,
@@ -330,8 +466,75 @@ async fn forward_build_output<R1, R2>(
 
 #[cfg(test)]
 mod tests {
-    use super::forward_build_output;
+    use super::{
+        dora_runtime_install_args, find_local_dora_python_wheel, forward_build_output,
+        local_dora_python_package_dir, local_dora_python_wheel_dir,
+    };
+    use std::{ffi::OsString, fs};
     use tokio::io::{AsyncWriteExt, BufReader};
+
+    #[test]
+    fn local_runtime_install_discovers_workspace_package() {
+        let temp = tempfile::tempdir().unwrap();
+        let package_dir = temp.path().join("apis").join("python").join("node");
+        fs::create_dir_all(&package_dir).unwrap();
+        fs::write(
+            package_dir.join("pyproject.toml"),
+            "[project]\nname = \"dora-rs\"\n",
+        )
+        .unwrap();
+
+        let working_dir = temp.path().join("examples").join("python-dataflow");
+        fs::create_dir_all(&working_dir).unwrap();
+
+        assert_eq!(
+            local_dora_python_package_dir(&working_dir),
+            Some(package_dir)
+        );
+    }
+
+    #[tokio::test]
+    async fn runtime_install_falls_back_to_versioned_pypi_requirement() {
+        let temp = tempfile::tempdir().unwrap();
+        let (stdout_tx, _stdout_rx) = tokio::sync::mpsc::channel(1);
+
+        assert_eq!(
+            dora_runtime_install_args(temp.path(), &None, stdout_tx)
+                .await
+                .unwrap(),
+            vec![OsString::from(format!(
+                "dora-rs=={}",
+                env!("CARGO_PKG_VERSION")
+            ))]
+        );
+    }
+
+    #[test]
+    fn local_runtime_wheel_cache_is_under_workspace_target() {
+        let temp = tempfile::tempdir().unwrap();
+        let package_dir = temp.path().join("apis").join("python").join("node");
+        fs::create_dir_all(&package_dir).unwrap();
+
+        assert_eq!(
+            local_dora_python_wheel_dir(&package_dir).unwrap(),
+            temp.path()
+                .join("target")
+                .join("dora-python-wheels")
+                .join(format!("process-{}", std::process::id()))
+        );
+    }
+
+    #[test]
+    fn finds_built_local_runtime_wheel() {
+        let temp = tempfile::tempdir().unwrap();
+        let wheel = temp
+            .path()
+            .join("dora_rs-0.2.1-cp37-abi3-manylinux_2_34_x86_64.whl");
+        fs::write(&wheel, "").unwrap();
+        fs::write(temp.path().join("other-0.1.0-py3-none-any.whl"), "").unwrap();
+
+        assert_eq!(find_local_dora_python_wheel(temp.path()).unwrap(), wheel);
+    }
 
     #[tokio::test]
     async fn keeps_draining_stdout_after_stderr_closes() {

--- a/libraries/extensions/ros2-bridge/Cargo.toml
+++ b/libraries/extensions/ros2-bridge/Cargo.toml
@@ -14,6 +14,7 @@ links = "dora-ros2-bridge"
 [features]
 default = ["generate-messages"]
 generate-messages = ["dep:dora-ros2-bridge-msg-gen", "dep:rust-format"]
+ros2-examples = []
 
 [dependencies]
 array-init = "2.1.0"

--- a/scripts/qa/ci-nightly-jobs.sh
+++ b/scripts/qa/ci-nightly-jobs.sh
@@ -871,6 +871,8 @@ job_cli_tests() {
     source "$venv_dir/bin/activate"
     uv pip install --quiet pyarrow "ruff>=0.9" pytest
     uv pip install --quiet -e apis/python/node
+    local dora_python_api
+    dora_python_api="$PWD/apis/python/node"
 
     # Python template: dora new + dora build + ruff + pytest + dora run
     local tmpd2
@@ -880,6 +882,7 @@ job_cli_tests() {
       dora new test_python_project --lang python --internal-create-with-path-dependencies
       cd test_python_project
       dora build dataflow.yml --uv
+      uv pip install --quiet -e "$dora_python_api" -e talker-1 -e talker-2 -e listener-1
       uv run ruff check .
       uv run pytest
       export OPERATING_MODE=SAVE
@@ -1066,6 +1069,7 @@ job_ros2_bridge() {
   source /opt/ros/humble/setup.bash
   timeout 600s cargo test -p dora-ros2-bridge-python
   timeout 1800s env QT_QPA_PLATFORM=offscreen cargo run -p dora-ros2-bridge --example rust-ros2-dataflow
+  timeout 1800s env QT_QPA_PLATFORM=offscreen cargo run -p dora-ros2-bridge --example cxx-ros2-dataflow --features ros2-examples
 }
 
 # -----------------------------------------------------------------------------

--- a/scripts/qa/ci-nightly-jobs.sh
+++ b/scripts/qa/ci-nightly-jobs.sh
@@ -872,6 +872,7 @@ job_cli_tests() {
     uv pip install --quiet pyarrow "ruff>=0.9" pytest
     uv pip install --quiet -e apis/python/node
     local dora_python_api
+    # Capture an absolute path before the template subshell changes directory.
     dora_python_api="$PWD/apis/python/node"
 
     # Python template: dora new + dora build + ruff + pytest + dora run


### PR DESCRIPTION
Fixes #1825.

Summary:
- Install generated Python template node packages, plus the local Python API, before root-level pytest.
- Cache the local dora-rs Python runtime as a wheel for managed node envs to avoid repeated maturin builds.
- Add and use the ros2-examples feature for ROS2 C++ examples.

Validation:
- cargo test -p dora-core --features build build::build_command::tests
- cargo test -p dora-cli
- cargo clippy -p dora-core --features build -- -D warnings
- cargo fmt --all -- --check
- Generated Python template: dora build dataflow.yml --uv, uv run ruff check ., uv run pytest

Not run:
- ROS2 Humble example, because /opt/ros/humble/setup.bash was not available locally.