### PR TITLE
fix(examples): use os.path.join for object_detection.py path in llm_op

### DIFF
--- a/examples/python-operator-dataflow/llm_op.py
+++ b/examples/python-operator-dataflow/llm_op.py
@@ -299,7 +299,7 @@ if __name__ == "__main__":
     # Directory of the current file
     current_directory = os.path.dirname(current_file_path)
 
-    path = current_directory + "object_detection.py"
+    path = os.path.join(current_directory, "object_detection.py")
     with open(path, encoding="utf8") as f:
         raw = f.read()
 


### PR DESCRIPTION
## Summary

Rescue of [#1389](https://github.com/dora-rs/dora/pull/1389) (@RithamSharma).

The `__main__` block of `examples/python-operator-dataflow/llm_op.py` (a developer-mode entry point for exercising the operator directly, distinct from the operator import path used by the dora dataflow) built a path via string concatenation:

```python
current_directory = os.path.dirname(current_file_path)
path = current_directory + "object_detection.py"
```

This produces `<dir>object_detection.py` with no separator, so `python llm_op.py` would always fail to open the file unless it happened to be in a directory whose name ended in `/`. Fix replaces the `+` with `os.path.join`.

## What this rescues

@RithamSharma identified the bug and the correct fix in #1389 back in March. The fix is reimplemented here with two small cleanups so it can land:

1. Removed the trailing `# ← FIXED` debug annotation
2. Added PEP 8 spacing after the comma in `os.path.join(a, b)`

Credit retained via `Co-Authored-By` on the commit.

## Test plan

- [x] `python examples/python-operator-dataflow/llm_op.py` no longer fails on the path (verified locally that `os.path.join(current_directory, "object_detection.py")` produces a valid path)
- [x] `cargo fmt --all -- --check` clean (no Rust changes, but standard PR gate)
- [x] Example imported by dora as an operator is unaffected (the change is in the `__main__` guard)

The example is exercised in nightly CI via `dora build/run examples/python-operator-dataflow/dataflow.yml --uv --stop-after 20s` (see `.github/workflows/nightly.yml:1210`); that path does not hit the `__main__` block, so this is a pure dev-ergonomics fix with no runtime risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
