### PR TITLE
fix(ci): add `--features ros2-examples` to cxx-ros2-dataflow invocation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1140,7 +1140,7 @@ jobs:
           name: C++ ROS2 Bridge example
           command: |
             source /opt/ros/humble/setup.bash
-            cargo run -p dora-ros2-bridge --example cxx-ros2-dataflow
+            cargo run -p dora-ros2-bridge --example cxx-ros2-dataflow --features ros2-examples
           no_output_timeout: 30m
       - cargo-cache-save:
           prefix: ros2


### PR DESCRIPTION
## Summary

Unblocks Trunk merge queue by fixing the `ci/circleci: ros2-bridge` job, which has been failing on every `main` commit since [#1816](https://github.com/dora-rs/dora/pull/1816) (`a1d0f3f6`, 2026-05-14). Five PRs have shipped via admin-bypass since the regression landed; this restores normal queue flow.

Closes #1838.

## Root cause

#1816 added `required-features = ["ros2-examples"]` to the `[[example]]` block for `cxx-ros2-dataflow` (`libraries/extensions/ros2-bridge/Cargo.toml:81`) and updated `examples/ros2-bridge/c++/turtle/README.md:24` to document the new invocation, but missed `.circleci/config.yml:1143` where the CI job invokes the example without the flag.

Cargo correctly refuses:

```
error: target `cxx-ros2-dataflow` in package `dora-ros2-bridge` requires the features: `ros2-examples`
Consider enabling them by passing, e.g., `--features="ros2-examples"`
```

(Pulled from the v1.1 CircleCI API for the failing step on main HEAD; see #1838 for the per-commit status-check table.)

Pre-#1816 the example had no `required-features`, so the bare invocation worked. The 1.0 consolidation (commit `145ccce0`) had previously stripped `required-features` from three other examples in the same Cargo.toml (`rust-ros2-dataflow`, `rust-ros2-dataflow-topic-sub`, `rust-ros2-dataflow-topic-pub`), which is why the "CI invokes without the flag" pattern stayed viable until `cxx-ros2-dataflow` re-acquired the gate.

## Fix

```diff
       - run:
           name: C++ ROS2 Bridge example
           command: |
             source /opt/ros/humble/setup.bash
-            cargo run -p dora-ros2-bridge --example cxx-ros2-dataflow
+            cargo run -p dora-ros2-bridge --example cxx-ros2-dataflow --features ros2-examples
```

Mirrors the README's documented invocation.

## Test plan

- [x] Diff is exactly the one-line append to `.circleci/config.yml:1143`
- [x] `cargo run -p dora-ros2-bridge --example cxx-ros2-dataflow --features ros2-examples` is what the README at `examples/ros2-bridge/c++/turtle/README.md:24` already tells users to run, so this is purely "make CI invoke it the way users invoke it"
- [ ] Verified by CircleCI on this PR — the `ros2-bridge` job should go green

## Out of scope (follow-up if desired)

#1816 also added two new examples that the ros2-bridge CircleCI job does not invoke at all:

- `cxx-ros2-dataflow-action-client` (`libraries/extensions/ros2-bridge/Cargo.toml:84`)
- `rust-ros2-dataflow-action-client` (`libraries/extensions/ros2-bridge/Cargo.toml:73`)

Both also need `--features ros2-examples`. Worth wiring them into the CI job so the action-client codegen actually gets exercised, but that's a scope decision — keeping this PR minimal to restore queue health first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
