### PR TITLE
fix(ci): install template nodes into root venv before pytest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -623,6 +623,17 @@ jobs:
             cd test_python_project
             dora build dataflow.yml --uv
             uv run ruff check .
+            # #1820 introduced per-node managed Python venvs at
+            # `.dora/python-envs/<node>/`, so `dora build --uv` no
+            # longer leaves the node packages installed in the
+            # ambient venv. The template's generated test stubs do
+            # `from <node>.main import main` and the project root has
+            # no top-level pyproject for `uv run pytest` to resolve
+            # against, so the imports fail with ModuleNotFoundError.
+            # Install each node into the active venv for the test
+            # pass; the per-node venvs continue to drive `dora build`
+            # / `dora run` themselves.
+            uv pip install -e listener-1 -e talker-1 -e talker-2
             uv run pytest
             export OPERATING_MODE=SAVE
             dora build dataflow.yml --uv


### PR DESCRIPTION
## Summary

Unblocks the Trunk merge queue by fixing the second of the two pre-existing main regressions diagnosed during PR #1839's review (the first was ros2-bridge, also fixed by #1839, just landed).

The `cli-python` CircleCI job's `Test Python template project` step has been failing on every main commit since [#1820](https://github.com/dora-rs/dora/pull/1820) (`6ae0fa9c`, "feat(uv): per-node managed Python venvs at build + runtime") — 5+ merged commits all red. Same failure-suppression pattern as the ros2-bridge regression (#1838 / #1839): a feature merge introduced a CI regression that went unaddressed because the check was already considered noise by the time anyone noticed.

## Root cause

#1820 changed `dora build --uv` to install each node's package into its own managed venv at `.dora/python-envs/<node>/` (good for deterministic per-node deps + no cross-node contamination). But the `dora new --lang python` template's generated test stubs at `tests/test_<node>.py` do:

```python
from <node>.main import main
```

The CI step's pytest invocation is `uv run pytest` from the `test_python_project` root, which resolves against the ambient venv (`VIRTUAL_ENV` set by the earlier `setup-python-uv` step to the repo-level `.venv/`). That venv has `dora-rs` + `pyarrow` + `pytest` + `ruff` but no node packages — those are in the per-node venvs. Pre-#1820, `dora build` installed nodes into whatever venv was active, so the imports worked.

Actual failure pulled from CircleCI v1.1 API for job 5882 step `Test Python template project`:

```
FAILED listener-1/tests/test_listener_1.py::test_import_main
  > from listener_1.main import main
  E ModuleNotFoundError: No module named 'listener_1'
FAILED talker-1/tests/test_talker_1.py::test_import_main
  > from talker_1.main import main
  E ModuleNotFoundError: No module named 'talker_1'
FAILED talker-2/tests/test_talker_2.py::test_import_main
  > from talker_2.main import main
  E ModuleNotFoundError: No module named 'talker_2'
3 failed, 3 passed in 0.20s
```

## Fix

After `dora build --uv` (which sets up the per-node venvs), also install the three node packages into the active venv so `uv run pytest` at the project root can resolve their imports:

```diff
       dora build dataflow.yml --uv
       uv run ruff check .
+      # [comment explaining the cause]
+      uv pip install -e listener-1 -e talker-1 -e talker-2
       uv run pytest
```

This preserves the per-node-venv isolation that #1820 introduced (those venvs still drive `dora build` and `dora run`) while giving the test pass a venv that sees all node packages. The root venv is ephemeral and only used by this CI step, so no production contamination.

## Scope and follow-ups

- **CI-only fix; the `dora new` template itself is unchanged.** Users running `pytest` in their own `dora new` projects will hit the same issue. Fixing that requires a template-level change — either a root `pyproject.toml` with path-deps on each node, or documenting "for testing, also `uv pip install -e <node>/`" in the template README. That's a separate follow-up; this PR keeps scope to "unblock the merge queue."
- **Hardcoded node names** (`listener-1`, `talker-1`, `talker-2`) match the `dora new --lang python` template at `binaries/cli/src/template/python/mod.rs:126-130`. A loop over `*/pyproject.toml` would be more robust but also more clever-shell; keeping the explicit list for clarity. If the template grows or shrinks the node set, this list needs to follow.

## Validation

Local repro is awkward (the CI step builds the whole dora CLI from source first), but the failure mode is mechanically obvious from the log and the fix is a one-line `uv pip install -e` of the same packages the build step references. CircleCI will validate on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
