### PR TITLE
feat(c++/node): add event receive variants (rescue of #1409)

### DIFF
--- a/apis/c++/node/src/lib.rs
+++ b/apis/c++/node/src/lib.rs
@@ -238,7 +238,15 @@ fn next_event(events: &mut Box<Events>) -> Box<DoraEvent> {
 /// matching on a wrapped `Event::Error(msg.contains("timed out"))`
 /// would be fragile (#1409 review feedback).
 fn next_event_timeout(events: &mut Box<Events>, timeout_ms: u64) -> Box<DoraEvent> {
-    let deadline = Instant::now() + Duration::from_millis(timeout_ms);
+    // `timeout_ms` arrives across the cxx::bridge as `u64`, so a C++
+    // caller can supply values that would panic the underlying
+    // `Instant + Duration` arithmetic on platforms with a bounded
+    // Instant range. Use `checked_add` and treat overflow as
+    // "effectively no deadline" -- keep polling indefinitely until
+    // an event arrives or the stream closes. Never returns
+    // `TimedOut` in the overflow case, matching the caller's
+    // intent ("wait as long as needed").
+    let deadline = Instant::now().checked_add(Duration::from_millis(timeout_ms));
     // 1 ms keeps the busy-wait cost negligible while bounding overshoot
     // of the caller-supplied deadline to ~1 ms in the worst case.
     let poll_interval = Duration::from_millis(1);
@@ -246,13 +254,16 @@ fn next_event_timeout(events: &mut Box<Events>, timeout_ms: u64) -> Box<DoraEven
         match events.0.try_recv() {
             Ok(event) => return Box::new(DoraEvent(EventOrReason::Event(event))),
             Err(TryRecvError::Closed) => return Box::new(DoraEvent(EventOrReason::Closed)),
-            Err(TryRecvError::Empty) => {
-                let now = Instant::now();
-                if now >= deadline {
-                    return Box::new(DoraEvent(EventOrReason::TimedOut));
+            Err(TryRecvError::Empty) => match deadline {
+                Some(d) => {
+                    let now = Instant::now();
+                    if now >= d {
+                        return Box::new(DoraEvent(EventOrReason::TimedOut));
+                    }
+                    std::thread::sleep(std::cmp::min(d - now, poll_interval));
                 }
-                std::thread::sleep(std::cmp::min(deadline - now, poll_interval));
-            }
+                None => std::thread::sleep(poll_interval),
+            },
         }
     }
 }

--- a/apis/c++/node/src/lib.rs
+++ b/apis/c++/node/src/lib.rs
@@ -1,11 +1,16 @@
-use std::{any::Any, collections::BTreeMap, vec};
+use std::{
+    any::Any,
+    collections::{BTreeMap, VecDeque},
+    time::{Duration, Instant},
+    vec,
+};
 
 use crate::ffi::MetadataValueType;
 
 use chrono::DateTime;
 use dora_node_api::{
     self, Event, EventStream, Metadata as DoraMetadata,
-    MetadataParameters as DoraMetadataParameters, Parameter as DoraParameter,
+    MetadataParameters as DoraMetadataParameters, Parameter as DoraParameter, TryRecvError,
     arrow::array::{AsArray, UInt8Array},
     merged::{MergeExternal, MergedEvent},
 };
@@ -36,6 +41,14 @@ mod ffi {
         Error,
         Unknown,
         AllInputsClosed,
+        /// Non-blocking poll (`try_next_event`) found no event ready,
+        /// and the same value is returned by `drained_events_next` once
+        /// a drained queue is exhausted. Distinct from `Timeout` —
+        /// `Empty` is returned even when no timeout was set.
+        Empty,
+        /// `next_event_timeout` returned without an event because the
+        /// caller-supplied deadline elapsed first.
+        Timeout,
     }
 
     struct DoraInput {
@@ -76,6 +89,7 @@ mod ffi {
         type Events;
         type OutputSender;
         type DoraEvent;
+        type DrainedEvents;
         type MergedEvents;
         type MergedDoraEvent;
         type Metadata;
@@ -86,6 +100,27 @@ mod ffi {
         fn empty_combined_events() -> CombinedEvents;
         fn next(self: &mut Events) -> Box<DoraEvent>;
         fn next_event(events: &mut Box<Events>) -> Box<DoraEvent>;
+        /// Block up to `timeout_ms` milliseconds for the next event.
+        /// Returns an event with `event_type == Timeout` if the deadline
+        /// elapses before one arrives, or `AllInputsClosed` if the
+        /// stream closed first.
+        fn next_event_timeout(events: &mut Box<Events>, timeout_ms: u64) -> Box<DoraEvent>;
+        /// Non-blocking poll. Returns an event with `event_type ==
+        /// Empty` if no event is immediately available, or
+        /// `AllInputsClosed` if the stream is closed.
+        fn try_next_event(events: &mut Box<Events>) -> Box<DoraEvent>;
+        /// True when the event queue is currently empty (no events
+        /// buffered). Note this can race against the daemon producing a
+        /// new event; treat it as a hint, not a guarantee.
+        fn events_is_empty(events: &Box<Events>) -> bool;
+        /// Take a snapshot of all currently-buffered events. Subsequent
+        /// `next_event` / `try_next_event` calls see only events that
+        /// arrive after this point.
+        fn drain_events(events: &mut Box<Events>) -> Box<DrainedEvents>;
+        fn drained_events_len(drained: &Box<DrainedEvents>) -> usize;
+        /// Pop the next event from a drained snapshot. Returns
+        /// `event_type == Empty` once the snapshot is exhausted.
+        fn drained_events_next(drained: &mut Box<DrainedEvents>) -> Box<DoraEvent>;
         fn event_type(event: &Box<DoraEvent>) -> DoraEventType;
         fn event_as_input(event: Box<DoraEvent>) -> Result<DoraInput>;
         fn send_output(
@@ -185,12 +220,83 @@ pub struct Events(EventStream);
 
 impl Events {
     fn next(&mut self) -> Box<DoraEvent> {
-        Box::new(DoraEvent(self.0.recv()))
+        Box::new(DoraEvent(match self.0.recv() {
+            Some(e) => EventOrReason::Event(e),
+            None => EventOrReason::Closed,
+        }))
     }
 }
 
 fn next_event(events: &mut Box<Events>) -> Box<DoraEvent> {
     events.next()
+}
+
+/// Block up to `timeout_ms` for the next event. Polls `try_recv` with
+/// an `Instant`-based deadline (and a short sleep between polls) so we
+/// can distinguish "timed out" from "stream closed" structurally —
+/// `EventStream::recv_timeout` returns `None` for both cases and
+/// matching on a wrapped `Event::Error(msg.contains("timed out"))`
+/// would be fragile (#1409 review feedback).
+fn next_event_timeout(events: &mut Box<Events>, timeout_ms: u64) -> Box<DoraEvent> {
+    let deadline = Instant::now() + Duration::from_millis(timeout_ms);
+    // 1 ms keeps the busy-wait cost negligible while bounding overshoot
+    // of the caller-supplied deadline to ~1 ms in the worst case.
+    let poll_interval = Duration::from_millis(1);
+    loop {
+        match events.0.try_recv() {
+            Ok(event) => return Box::new(DoraEvent(EventOrReason::Event(event))),
+            Err(TryRecvError::Closed) => return Box::new(DoraEvent(EventOrReason::Closed)),
+            Err(TryRecvError::Empty) => {
+                let now = Instant::now();
+                if now >= deadline {
+                    return Box::new(DoraEvent(EventOrReason::TimedOut));
+                }
+                std::thread::sleep(std::cmp::min(deadline - now, poll_interval));
+            }
+        }
+    }
+}
+
+/// Non-blocking single poll. Returns `EventOrReason::Empty` (surfaced
+/// as `DoraEventType::Empty` on the C++ side) when no event is
+/// available; distinct from a real timeout because no timeout was
+/// requested.
+fn try_next_event(events: &mut Box<Events>) -> Box<DoraEvent> {
+    Box::new(DoraEvent(match events.0.try_recv() {
+        Ok(event) => EventOrReason::Event(event),
+        Err(TryRecvError::Empty) => EventOrReason::Empty,
+        Err(TryRecvError::Closed) => EventOrReason::Closed,
+    }))
+}
+
+#[allow(clippy::borrowed_box)] // signature dictated by cxx::bridge
+fn events_is_empty(events: &Box<Events>) -> bool {
+    events.0.is_empty()
+}
+
+/// Snapshot of buffered events at a point in time. Subsequent
+/// receives on the `Events` stream see only events that arrive after
+/// this snapshot.
+pub struct DrainedEvents(VecDeque<Event>);
+
+fn drain_events(events: &mut Box<Events>) -> Box<DrainedEvents> {
+    let drained = events.0.drain().unwrap_or_default();
+    Box::new(DrainedEvents(drained.into()))
+}
+
+#[allow(clippy::borrowed_box)] // signature dictated by cxx::bridge
+fn drained_events_len(drained: &Box<DrainedEvents>) -> usize {
+    drained.0.len()
+}
+
+fn drained_events_next(drained: &mut Box<DrainedEvents>) -> Box<DoraEvent> {
+    Box::new(DoraEvent(match drained.0.pop_front() {
+        Some(e) => EventOrReason::Event(e),
+        // Drained snapshots cannot transition from non-empty to closed
+        // (the snapshot is frozen at `drain_events` time), so an
+        // exhausted drain is `Empty`, not `Closed`.
+        None => EventOrReason::Empty,
+    }))
 }
 
 fn dora_events_into_combined(events: Box<Events>) -> ffi::CombinedEvents {
@@ -212,23 +318,46 @@ fn empty_combined_events() -> ffi::CombinedEvents {
     }
 }
 
-pub struct DoraEvent(Option<Event>);
+pub struct DoraEvent(EventOrReason);
+
+/// Internal representation that lets `try_next_event` /
+/// `next_event_timeout` / `drained_events_next` report "no event"
+/// outcomes to C++ without overloading `Option<Event>` (#1409 review).
+//
+// `Event` is much larger than the unit variants (Closed/Empty/TimedOut),
+// but this enum is always wrapped in `Box<DoraEvent>` at the FFI boundary
+// so the size delta isn't paid per-stack-slot. Boxing the `Event` variant
+// would add a second allocation on every event delivery for no benefit.
+#[allow(clippy::large_enum_variant)]
+pub(crate) enum EventOrReason {
+    Event(Event),
+    /// Source stream closed; surfaces as `DoraEventType::AllInputsClosed`.
+    Closed,
+    /// Non-blocking poll found no event ready, or a drained snapshot
+    /// was exhausted. Surfaces as `DoraEventType::Empty`.
+    Empty,
+    /// `next_event_timeout` deadline elapsed before an event arrived.
+    /// Surfaces as `DoraEventType::Timeout`.
+    TimedOut,
+}
 
 fn event_type(event: &DoraEvent) -> ffi::DoraEventType {
     match &event.0 {
-        Some(event) => match event {
+        EventOrReason::Event(event) => match event {
             Event::Stop(_) => ffi::DoraEventType::Stop,
             Event::Input { .. } => ffi::DoraEventType::Input,
             Event::InputClosed { .. } => ffi::DoraEventType::InputClosed,
             Event::Error(_) => ffi::DoraEventType::Error,
             _ => ffi::DoraEventType::Unknown,
         },
-        None => ffi::DoraEventType::AllInputsClosed,
+        EventOrReason::Closed => ffi::DoraEventType::AllInputsClosed,
+        EventOrReason::Empty => ffi::DoraEventType::Empty,
+        EventOrReason::TimedOut => ffi::DoraEventType::Timeout,
     }
 }
 
 fn event_as_input(event: Box<DoraEvent>) -> eyre::Result<ffi::DoraInput> {
-    let Some(Event::Input { id, metadata, data }) = event.0 else {
+    let EventOrReason::Event(Event::Input { id, metadata, data }) = event.0 else {
         bail!("not an input event");
     };
     let data = match metadata.type_info.data_type {
@@ -260,7 +389,7 @@ unsafe fn event_as_arrow_input(
     let out_array = out_array as *mut arrow::ffi::FFI_ArrowArray;
     let out_schema = out_schema as *mut arrow::ffi::FFI_ArrowSchema;
 
-    let Some(Event::Input {
+    let EventOrReason::Event(Event::Input {
         id: _,
         metadata: _,
         data,
@@ -552,7 +681,7 @@ unsafe fn event_as_arrow_input_with_info(
     let out_array = out_array as *mut arrow::ffi::FFI_ArrowArray;
     let out_schema = out_schema as *mut arrow::ffi::FFI_ArrowSchema;
 
-    let Some(Event::Input { id, metadata, data }) = event.0 else {
+    let EventOrReason::Event(Event::Input { id, metadata, data }) = event.0 else {
         return ffi::ArrowInputInfo {
             id: String::new(),
             metadata: Box::new(Metadata::empty()),
@@ -765,7 +894,11 @@ impl ffi::CombinedEvent {
 
 fn downcast_dora(event: ffi::CombinedEvent) -> eyre::Result<Box<DoraEvent>> {
     match event.event.0 {
-        Some(MergedEvent::Dora(event)) => Ok(Box::new(DoraEvent(Some(event)))),
-        _ => eyre::bail!("not an external event"),
+        Some(MergedEvent::Dora(event)) => Ok(Box::new(DoraEvent(EventOrReason::Event(event)))),
+        // None means the merged stream closed; pass that through as Closed
+        // so C++ sees `DoraEventType::AllInputsClosed` rather than a
+        // bail-out error.
+        None => Ok(Box::new(DoraEvent(EventOrReason::Closed))),
+        _ => eyre::bail!("not a dora event"),
     }
 }

--- a/examples/c++-dataflow/node-rust-api/main.cc
+++ b/examples/c++-dataflow/node-rust-api/main.cc
@@ -10,6 +10,16 @@ int main()
 
     auto dora_node = init_dora_node();
 
+    // Demonstrate try_next_event (non-blocking poll). Before the main
+    // receive loop starts pulling events, the event queue is typically
+    // empty so the poll should return an `Empty` marker rather than
+    // blocking. `Empty` is distinct from `Timeout` (no timeout was set)
+    // and from `AllInputsClosed` (stream still open).
+    auto poll = try_next_event(dora_node.events);
+    if (event_type(poll) == DoraEventType::Empty) {
+        std::cout << "No event ready yet (non-blocking poll)" << std::endl;
+    }
+
     for (int i = 0; i < 20; i++)
     {
 

--- a/examples/c++-dataflow/node-rust-api/main.cc
+++ b/examples/c++-dataflow/node-rust-api/main.cc
@@ -10,19 +10,6 @@ int main()
 
     auto dora_node = init_dora_node();
 
-    // Demonstrate the non-blocking helpers. We check `events_is_empty`
-    // FIRST so the subsequent `try_next_event` can't accidentally
-    // consume (and drop) an in-flight event from the daemon — the
-    // dataflow timer ticks every 300ms and if one happens to land
-    // before this code runs, popping it here would shorten the main
-    // receive loop's tick count by one.
-    if (events_is_empty(dora_node.events)) {
-        auto poll = try_next_event(dora_node.events);
-        if (event_type(poll) == DoraEventType::Empty) {
-            std::cout << "No event ready yet (non-blocking poll)" << std::endl;
-        }
-    }
-
     for (int i = 0; i < 20; i++)
     {
 

--- a/examples/c++-dataflow/node-rust-api/main.cc
+++ b/examples/c++-dataflow/node-rust-api/main.cc
@@ -10,14 +10,17 @@ int main()
 
     auto dora_node = init_dora_node();
 
-    // Demonstrate try_next_event (non-blocking poll). Before the main
-    // receive loop starts pulling events, the event queue is typically
-    // empty so the poll should return an `Empty` marker rather than
-    // blocking. `Empty` is distinct from `Timeout` (no timeout was set)
-    // and from `AllInputsClosed` (stream still open).
-    auto poll = try_next_event(dora_node.events);
-    if (event_type(poll) == DoraEventType::Empty) {
-        std::cout << "No event ready yet (non-blocking poll)" << std::endl;
+    // Demonstrate the non-blocking helpers. We check `events_is_empty`
+    // FIRST so the subsequent `try_next_event` can't accidentally
+    // consume (and drop) an in-flight event from the daemon — the
+    // dataflow timer ticks every 300ms and if one happens to land
+    // before this code runs, popping it here would shorten the main
+    // receive loop's tick count by one.
+    if (events_is_empty(dora_node.events)) {
+        auto poll = try_next_event(dora_node.events);
+        if (event_type(poll) == DoraEventType::Empty) {
+            std::cout << "No event ready yet (non-blocking poll)" << std::endl;
+        }
     }
 
     for (int i = 0; i < 20; i++)


### PR DESCRIPTION
## Summary

Rescue of [#1409](https://github.com/dora-rs/dora/pull/1409) (@PavelGuzenfeld) with phil-opp's [review fixes](https://github.com/dora-rs/dora/pull/1409#pullrequestreview-2761090773) applied — the author replied "Fixed" on 2026-03-18 but never actually pushed those fixes, so this rescue does them.

This is the **first PR in a 4-PR rescue stack** for PavelGuzenfeld's C++ API parity work. The full series:

- **#TBD (this PR)** — event receive variants (rescues #1409)
- TBD — close_outputs + NodeFailed/Reload event types (rescues #1410)
- TBD — node_config_json + dataflow_descriptor_json introspection (rescues #1413)
- TBD — operator InputClosed/Stop callback forwarding (rescues #1414, behavior bug fix)

Closes #1409.

## New FFI surface

| Function | Behavior |
|---|---|
| `try_next_event(events)` | Non-blocking poll. Returns `DoraEventType::Empty` if no event is ready, `AllInputsClosed` if the stream is closed. |
| `next_event_timeout(events, timeout_ms)` | Timed-blocking receive. Returns `DoraEventType::Timeout` on deadline elapse, `AllInputsClosed` if the stream closes first. |
| `events_is_empty(events)` | Queue-empty hint (treat as advisory — can race against new events). |
| `drain_events(events) -> DrainedEvents` | Snapshot of currently buffered events; `next_event` only sees later events. |
| `drained_events_len(drained)` | Snapshot size. |
| `drained_events_next(drained)` | Pop next from snapshot. Returns `Empty` after exhaustion. |

Two new `DoraEventType` variants:
- `Empty` — non-blocking poll found nothing / drain exhausted
- `Timeout` — `next_event_timeout` deadline elapsed

## Design fixes vs. the original PR

@phil-opp's review on #1409 raised three issues that the author acknowledged in replies but never pushed. The rescue applies them:

### 1. No more string-matching of error messages

Original `next_event_timeout`:

```rust
let timed_out = matches!(&event, Event::Error(msg) if msg.contains("timed out"));
```

Brittle — any change to the timeout error message silently breaks detection.

Rescue:

```rust
let deadline = Instant::now() + Duration::from_millis(timeout_ms);
let poll_interval = Duration::from_millis(1);
loop {
    match events.0.try_recv() {
        Ok(event) => return EventOrReason::Event(event),
        Err(TryRecvError::Closed) => return EventOrReason::Closed,
        Err(TryRecvError::Empty) => {
            let now = Instant::now();
            if now >= deadline { return EventOrReason::TimedOut; }
            std::thread::sleep(std::cmp::min(deadline - now, poll_interval));
        }
    }
}
```

Timeout is detected structurally via `Instant`; `Empty` / `Closed` from `try_recv` disambiguate timeout from stream close cleanly. No string parsing.

### 2. `try_next_event` returns `Empty`, not `Timeout`

Original code returned `DoraEventType::Timeout` when the non-blocking poll found nothing. But the caller never set a timeout — calling it a "timeout" overloaded the meaning. The rescue introduces `EventOrReason::Empty` and `DoraEventType::Empty` so the no-event-ready case has its own surface.

### 3. `drained_events_next` returns `Empty` when exhausted

Same fix — a drained snapshot is frozen at `drain_events()` time and can't time out. `Empty` is the honest answer.

## Internal representation

`DoraEvent` switches from `(Option<Event>)` to `(EventOrReason)` so the no-event-available state can carry its reason (Closed / Empty / TimedOut):

```rust
pub(crate) enum EventOrReason {
    Event(Event),
    Closed,    // -> DoraEventType::AllInputsClosed
    Empty,     // -> DoraEventType::Empty
    TimedOut,  // -> DoraEventType::Timeout
}
```

All existing call sites (`event_type`, `event_as_input`, `event_as_arrow_input`, `event_as_arrow_input_with_info`, `downcast_dora`) are updated to match. The external `DoraEventType` surface is purely additive — existing variants unchanged, two new variants added.

## What was dropped from the original PR

The original PR #1409 bundled several other changes that have been outdated by main's evolution since 2026-03-16:

| Original PR included | Disposition | Why |
|---|---|---|
| `init_dora_node_from_id`, `init_dora_node_flexible` | **Dropped** | Built on top of #1403 (`node_id`/`dataflow_id` accessors) which was wiped by the 1.0 consolidation `145ccce0`. Separate PR if/when the node-id surface comes back. |
| `node_id()`, `dataflow_id()` accessors | **Dropped** | Same — 1.0 consolidation removed these. |
| Zero-copy `DataSampleHandle` API | **Dropped** | Already shipped in main via #1431 with a different shape. Re-adding would duplicate. |
| `log_message` removal | **Not applied** | Current main uses `log_message` for C/C++ logging (added after #1409 was opened). Kept. |

So this rescue is a narrow extraction of just the event-receive variants (the named feature in the PR title) + phil-opp's review fixes applied.

## Test plan

- [x] `cargo build -p dora-node-api-cxx` — clean compile, no warnings
- [x] `cargo clippy -p dora-node-api-cxx -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Manual review of all 5 `event.0` / `DoraEvent(...)` call sites updated to match the new `EventOrReason` shape
- [ ] CircleCI cli-rust and examples-linux jobs will exercise the new functions via the example demo (added to `examples/c++-dataflow/node-rust-api/main.cc`)

The example demo on the non-blocking poll case:

```cpp
auto poll = try_next_event(dora_node.events);
if (event_type(poll) == DoraEventType::Empty) {
    std::cout << "No event ready yet (non-blocking poll)" << std::endl;
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
