### PR TITLE
feat(c++/node): node_config_json and dataflow_descriptor_json (rescue of #1413)

### DIFF
--- a/apis/c++/node/src/lib.rs
+++ b/apis/c++/node/src/lib.rs
@@ -153,6 +153,17 @@ mod ffi {
             output_sender: &mut Box<OutputSender>,
             output_ids: Vec<String>,
         ) -> DoraResult;
+        /// Return this node's `NodeRunConfig` (inputs / outputs /
+        /// metadata block from the dataflow descriptor) serialized as
+        /// JSON. Useful for runtime introspection: the C++ node can
+        /// reason about its own declared interface without re-parsing
+        /// the dataflow yaml.
+        fn node_config_json(output_sender: &Box<OutputSender>) -> Result<String>;
+        /// Return the full `Descriptor` (the parsed dataflow yaml)
+        /// serialized as JSON. Useful for introspecting peer nodes,
+        /// listing all topics, etc. May fail if the daemon hasn't
+        /// delivered the descriptor yet.
+        fn dataflow_descriptor_json(output_sender: &Box<OutputSender>) -> Result<String>;
         fn send_output(
             output_sender: &mut Box<OutputSender>,
             id: String,
@@ -472,6 +483,18 @@ fn close_outputs(
             error: format!("{err:?}"),
         },
     }
+}
+
+#[allow(clippy::borrowed_box)] // signature dictated by cxx::bridge
+fn node_config_json(output_sender: &Box<OutputSender>) -> eyre::Result<String> {
+    serde_json::to_string(output_sender.0.node_config())
+        .map_err(|e| eyre!("failed to serialize node config: {e}"))
+}
+
+#[allow(clippy::borrowed_box)] // signature dictated by cxx::bridge
+fn dataflow_descriptor_json(output_sender: &Box<OutputSender>) -> eyre::Result<String> {
+    let desc = output_sender.0.dataflow_descriptor()?;
+    serde_json::to_string(desc).map_err(|e| eyre!("failed to serialize dataflow descriptor: {e}"))
 }
 
 unsafe fn event_as_arrow_input(

--- a/apis/c++/node/src/lib.rs
+++ b/apis/c++/node/src/lib.rs
@@ -163,6 +163,16 @@ mod ffi {
         /// serialized as JSON. Useful for introspecting peer nodes,
         /// listing all topics, etc. May fail if the daemon hasn't
         /// delivered the descriptor yet.
+        ///
+        /// **Caution:** the returned JSON includes any `env` blocks
+        /// declared on nodes in the dataflow yaml. Inline literals
+        /// (`API_KEY: "..."`) and host-environment substitutions
+        /// (`API_KEY: "${HOST_VAR}"`, expanded at descriptor parse
+        /// time per `libraries/message/src/descriptor.rs`'s
+        /// `with_expand_envs`) both appear as plain strings in the
+        /// output. Don't pipe this into shared logs or telemetry
+        /// without sanitizing if your dataflow can carry secrets in
+        /// env vars.
         fn dataflow_descriptor_json(output_sender: &Box<OutputSender>) -> Result<String>;
         fn send_output(
             output_sender: &mut Box<OutputSender>,

--- a/docs/api-cxx.md
+++ b/docs/api-cxx.md
@@ -249,6 +249,28 @@ DoraResult close_outputs(
 
 `output_ids` are validated as `DataId`s; an invalid id (e.g. one containing characters not allowed by the data-id grammar) returns a `DoraResult` whose `error` names the offending id and the underlying validation message, instead of aborting the process.
 
+#### node_config_json
+
+Return this node's `NodeRunConfig` (inputs, outputs, type annotations, framing overrides, etc. — the per-node block from the dataflow descriptor) serialized as JSON. Lets a C++ node reason about its own declared interface at runtime without re-parsing the dataflow yaml.
+
+```cpp
+rust::String node_config_json(const rust::Box<OutputSender>& sender);
+```
+
+Throws `rust::Error` if serialization fails (rare — `NodeRunConfig` has no fields that can produce serde errors in practice).
+
+#### dataflow_descriptor_json
+
+Return the full parsed `Descriptor` (the entire dataflow yaml) serialized as JSON. Useful for introspecting peer nodes, listing all topics, etc.
+
+```cpp
+rust::String dataflow_descriptor_json(const rust::Box<OutputSender>& sender);
+```
+
+Throws `rust::Error` if the daemon hasn't delivered the descriptor yet, or on serialization failure.
+
+> **Caution:** the returned JSON includes any `env` blocks declared on nodes in the dataflow yaml. Inline literals (`API_KEY: "..."`) **and** host-environment substitutions (`API_KEY: "${HOST_VAR}"`, expanded at descriptor parse time) both appear as plain strings in the output. Don't pipe the result into shared logs or telemetry without sanitizing if your dataflow can carry secrets in env vars.
+
 #### log_message
 
 Send a log message through the Dora logging system.

--- a/examples/c++-dataflow/node-rust-api/main.cc
+++ b/examples/c++-dataflow/node-rust-api/main.cc
@@ -10,6 +10,22 @@ int main()
 
     auto dora_node = init_dora_node();
 
+    // Demonstrate runtime introspection: a node can ask the daemon
+    // what its own declared inputs/outputs look like, and what the
+    // full dataflow descriptor is, without re-parsing the yaml.
+    try
+    {
+        auto config = node_config_json(dora_node.send_output);
+        std::cout << "Node config: " << std::string(config) << std::endl;
+
+        auto descriptor = dataflow_descriptor_json(dora_node.send_output);
+        std::cout << "Dataflow descriptor length: " << descriptor.length() << std::endl;
+    }
+    catch (const rust::Error &e)
+    {
+        std::cerr << "Introspection failed: " << e.what() << std::endl;
+    }
+
     for (int i = 0; i < 20; i++)
     {
 


### PR DESCRIPTION
## Summary

Rescue of [#1413](https://github.com/dora-rs/dora/pull/1413) (@PavelGuzenfeld). Third PR in the 4-PR rescue stack for C++ API parity.

**Stacked on top of [#1847](https://github.com/dora-rs/dora/pull/1847)** (close_outputs + NodeFailed/Reload). Will rebase onto main once the lower stack lands.

Closes #1413.

## New FFI surface

| Function | Behavior |
|---|---|
| `node_config_json(output_sender) -> Result<String>` | Returns this node's `NodeRunConfig` (inputs/outputs/metadata) serialized as JSON. Lets C++ nodes introspect their own declared interface at runtime without re-parsing the yaml. |
| `dataflow_descriptor_json(output_sender) -> Result<String>` | Returns the full parsed `Descriptor` (the dataflow yaml) serialized as JSON. Useful for introspecting peer nodes, listing all topics, etc. May fail if the daemon hasn't delivered the descriptor yet. |

Both wrap existing methods on `dora_node_api::DoraNode` (`apis/rust/node/src/node/mod.rs:1116` and `:1317`) via `serde_json::to_string`. No new dora-rs API surface; this is purely exposing existing Rust APIs to C++.

## Test plan

- [x] `cargo build -p dora-node-api-cxx` — clean
- [x] `cargo clippy -p dora-node-api-cxx -- -D warnings` — clean
- [x] Example demonstrates both calls with a `try/catch` around `rust::Error` (introspection can fail if the daemon hasn't yet delivered the descriptor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
