### PR TITLE
fix(runtime): replace unwrap with guard in Reload event handler (rescue of #1439)

### DIFF
--- a/binaries/runtime/src/lib.rs
+++ b/binaries/runtime/src/lib.rs
@@ -243,9 +243,11 @@ async fn run(
             RuntimeEvent::Event(Event::Reload {
                 operator_id: Some(operator_id),
             }) => {
-                let _ = operator_channels
-                    .get(&operator_id)
-                    .unwrap()
+                let Some(operator_channel) = operator_channels.get(&operator_id) else {
+                    tracing::warn!("received Reload event for unknown operator `{operator_id}`");
+                    continue;
+                };
+                let _ = operator_channel
                     .send_async(Event::Reload {
                         operator_id: Some(operator_id),
                     })


### PR DESCRIPTION
## Summary

Rescue of [#1439](https://github.com/dora-rs/dora/pull/1439) (@ashnaaseth2325-oss). @phil-opp [approved the original on 2026-03-29](https://github.com/dora-rs/dora/pull/1439#pullrequestreview-2779820349) with one ask — "Needs a rebase, then we can merge" — but the author hasn't returned in 7 weeks. Reapplying the fix to current main.

Closes #1439.

## What the fix does

Replaces an `unwrap()` on `operator_channels.get(&operator_id)` with a `let-else` guard that logs a warning and continues. Without this, a `RuntimeEvent::Event(Event::Reload { operator_id: Some(_) })` for an unknown operator panics the entire runtime.

```diff
 RuntimeEvent::Event(Event::Reload {
     operator_id: Some(operator_id),
 }) => {
-    let _ = operator_channels
-        .get(&operator_id)
-        .unwrap()
+    let Some(operator_channel) = operator_channels.get(&operator_id) else {
+        tracing::warn!("received Reload event for unknown operator `{operator_id}`");
+        continue;
+    };
+    let _ = operator_channel
         .send_async(Event::Reload {
             operator_id: Some(operator_id),
         })
         .await;
 }
```

This matches the pattern already used by the neighboring `Event::Input` (line 264) and `Event::InputClosed` (line 291) handlers in the same match block. The Reload handler was the only outlier.

## Why a fresh PR

The original #1439 was approved but needed a rebase against 329 commits of main movement. Author follow-up went quiet 7 weeks ago after phil-opp's review (which approved + asked for rebase, with a gentle ping-frequency note). Cherry-picking the approved commit onto fresh main is a low-cost way to land the fix without leaving an approved-but-stale PR sitting indefinitely.

The original author is preserved as the git Author of the commit (cherry-pick preserves authorship); credit retained.

## Test plan

- [x] `cargo check -p dora-runtime` — clean
- [x] Diff matches the approved version verbatim (no design changes)
- [x] Pattern alignment with neighbor handlers verified (`Event::Input` at line 264, `Event::InputClosed` at line 291 both use the same `let-else` shape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
