### PR TITLE
style: fmt apis/c++/node/src/lib.rs imports after #1848 merge regression

### DIFF
--- a/apis/c++/node/src/lib.rs
+++ b/apis/c++/node/src/lib.rs
@@ -9,13 +9,12 @@ use crate::ffi::MetadataValueType;
 
 use chrono::DateTime;
 use dora_node_api::{
-    self,
+    self, Event, EventStream, Metadata as DoraMetadata,
+    MetadataParameters as DoraMetadataParameters, Parameter as DoraParameter, TryRecvError,
     arrow::array::{AsArray, UInt8Array},
     merged::{MergeExternal, MergedEvent},
-    Event, EventStream, Metadata as DoraMetadata, MetadataParameters as DoraMetadataParameters,
-    Parameter as DoraParameter, TryRecvError,
 };
-use eyre::{bail, eyre, Result as EyreResult};
+use eyre::{Result as EyreResult, bail, eyre};
 use serde::Serialize;
 use serde_json::Value as JsonValue;
 
@@ -25,7 +24,7 @@ pub use prelude::*;
 pub mod prelude {
     pub use dora_ros2_bridge::prelude::*;
 }
-use futures_lite::{stream, Stream, StreamExt};
+use futures_lite::{Stream, StreamExt, stream};
 
 #[cxx::bridge]
 #[allow(clippy::needless_lifetimes)]


### PR DESCRIPTION
## Summary

- `cargo fmt --all -- --check` on current `main` (rust 1.92.0 / rustfmt 1.8.0, edition 2024) fails on `apis/c++/node/src/lib.rs` — three import groups have items in non-canonical order
- This blocks PR #1851's Format check (and any other open PR's Format check) on a regression that is unrelated to those PRs' diffs
- Same shape as the earlier `21e21f63` fix (#1715) — merge-order artifact after #1848 squash-merged

## Test plan

- [x] `cargo fmt --all -- --check` clean locally on this branch
- [x] One file changed, 4+/5- lines, no behavior change
- [ ] Format CI check goes green
