### PR TITLE
refactor: replace unwrap with warn-and-continue in event log + zenoh config (rescue of #1608)

### DIFF
--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -568,7 +568,15 @@ impl EventStream {
     }
 
     fn add_event(&mut self, event: EventItem) {
-        self.record_event(&event).unwrap();
+        // Event recording is observability-only (writes to the optional
+        // `write_events_to` log). A write failure must not panic the event
+        // loop — drop the log line and continue scheduling. Rescue of #1608.
+        if let Err(err) = self.record_event(&event) {
+            tracing::warn!(
+                node = %self.node_id,
+                "failed to record event to write_events_to log: {err:?}"
+            );
+        }
         self.scheduler.add_event(event);
     }
 

--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -570,7 +570,7 @@ impl EventStream {
     fn add_event(&mut self, event: EventItem) {
         // Event recording is observability-only (writes to the optional
         // `write_events_to` log). A write failure must not panic the event
-        // loop — drop the log line and continue scheduling. Rescue of #1608.
+        // loop — drop the log line and continue scheduling.
         if let Err(err) = self.record_event(&event) {
             tracing::warn!(
                 node = %self.node_id,

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -785,7 +785,7 @@ impl Daemon {
         // Reserve a loopback port and have zenoh listen on it. The endpoint is
         // injected into spawned nodes via `DORA_ZENOH_CONNECT` so peer
         // discovery works without multicast (#1778).
-        let zenoh_listen_endpoint = match reserve_loopback_zenoh_endpoint() {
+        let requested_listen_endpoint = match reserve_loopback_zenoh_endpoint() {
             Ok(ep) => Some(ep),
             Err(err) => {
                 tracing::warn!(
@@ -795,9 +795,21 @@ impl Daemon {
                 None
             }
         };
-        let zenoh_session = open_zenoh_session_with_listen(None, zenoh_listen_endpoint.as_deref())
-            .await
-            .wrap_err("failed to open zenoh session")?;
+        // The helper is the source of truth for whether the listener actually
+        // bound: `zenoh_listen_endpoint` only becomes `Some` if zenoh accepted
+        // the listen/endpoints insert. Otherwise we must not inject
+        // `DORA_ZENOH_CONNECT` into spawned nodes — they would try to connect
+        // to an endpoint that nothing is listening on (#1856).
+        let (zenoh_session, zenoh_listen_endpoint) =
+            open_zenoh_session_with_listen(None, requested_listen_endpoint.as_deref())
+                .await
+                .wrap_err("failed to open zenoh session")?;
+        if requested_listen_endpoint.is_some() && zenoh_listen_endpoint.is_none() {
+            tracing::warn!(
+                "requested zenoh listener but zenoh did not bind it; \
+                 spawned nodes will use multicast scouting only"
+            );
+        }
         // Use a large channel capacity to prevent deadlock
         let (dora_events_tx, dora_events_rx) = mpsc::channel(1000);
 

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -15,20 +15,35 @@ pub const MANUAL_STOP: &str = "dora/stop";
 
 #[cfg(feature = "zenoh")]
 pub async fn open_zenoh_session(coordinator_addr: Option<IpAddr>) -> eyre::Result<zenoh::Session> {
-    open_zenoh_session_with_listen(coordinator_addr, None).await
+    let (session, _) = open_zenoh_session_with_listen(coordinator_addr, None).await?;
+    Ok(session)
 }
 
 /// Like [`open_zenoh_session`], but also configures the session to listen on
 /// the given loopback endpoint (e.g. `tcp/127.0.0.1:43217`). The daemon uses
 /// this so spawned nodes can connect via `DORA_ZENOH_CONNECT` without
 /// multicast scouting.
+///
+/// Returns `(session, effective_listen_endpoint)`. The second element is
+/// `Some(ep)` only when `listen_endpoint` was requested AND zenoh accepted
+/// the `listen/endpoints` insert. It is `None` if `listen_endpoint` was
+/// `None`, the insert failed, or the open path used the
+/// `ZENOH_CONFIG_PATH`-from-file branch. Callers must inject the returned
+/// endpoint into peers (e.g. via `DORA_ZENOH_CONNECT`) instead of the value
+/// they passed in, so peers never receive a stale endpoint the listener
+/// did not actually bind (#1856).
 #[cfg(feature = "zenoh")]
 pub async fn open_zenoh_session_with_listen(
     coordinator_addr: Option<IpAddr>,
     listen_endpoint: Option<&str>,
-) -> eyre::Result<zenoh::Session> {
+) -> eyre::Result<(zenoh::Session, Option<String>)> {
     use eyre::{Context, eyre};
     use tracing::warn;
+
+    // Source-of-truth for the listener: stays `None` unless we actually
+    // accepted `listen/endpoints` into the config below. Callers use this
+    // (not their requested endpoint) to advertise the listener to peers.
+    let mut effective_listen_endpoint: Option<String> = None;
 
     let zenoh_session = match std::env::var(zenoh::Config::DEFAULT_CONFIG_PATH_ENV) {
         Ok(path) => {
@@ -70,9 +85,7 @@ pub async fn open_zenoh_session_with_listen(
             if let Ok(ep) = std::env::var(DORA_ZENOH_CONNECT_ENV) {
                 // Only disable multicast scouting if we successfully replaced
                 // it with an explicit connect endpoint — otherwise the node
-                // would have neither and open an isolated session. Interim
-                // mitigation for #1856; full required-vs-optional config
-                // classification still pending there.
+                // would have neither and open an isolated session (#1856).
                 let connect_inserted = match zenoh_config
                     .insert_json5("connect/endpoints", &format!(r#"["{ep}"]"#))
                 {
@@ -95,10 +108,17 @@ pub async fn open_zenoh_session_with_listen(
             if let Some(ep) = listen_endpoint {
                 // `listen/exit_on_failure: false` is a tuning knob for the
                 // listener; only set it if the listener itself got
-                // configured. Interim mitigation for #1856.
+                // configured (#1856).
                 let listen_inserted =
                     match zenoh_config.insert_json5("listen/endpoints", &format!(r#"["{ep}"]"#)) {
-                        Ok(()) => true,
+                        Ok(()) => {
+                            // Helper became the source of truth: the daemon
+                            // reads this on return and only injects
+                            // `DORA_ZENOH_CONNECT` into spawned nodes when
+                            // listen actually bound (#1856).
+                            effective_listen_endpoint = Some(ep.to_string());
+                            true
+                        }
                         Err(err) => {
                             warn!("failed to set zenoh listen/endpoints to `{ep}`: {err}");
                             false
@@ -142,7 +162,7 @@ pub async fn open_zenoh_session_with_listen(
             zenoh::Config::DEFAULT_CONFIG_PATH_ENV
         ),
     };
-    Ok(zenoh_session)
+    Ok((zenoh_session, effective_listen_endpoint))
 }
 
 /// Reserve an unused TCP port on `127.0.0.1` for use as a zenoh listen

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -44,10 +44,11 @@ pub async fn open_zenoh_session_with_listen(
             let mut zenoh_config = zenoh::Config::default();
             // Linkstate make it possible to connect two daemons on different network through a public daemon
             // TODO: There is currently a CI/CD Error in windows linkstate.
-            if cfg!(not(target_os = "windows")) {
-                zenoh_config
-                    .insert_json5("routing/peer", r#"{ mode: "linkstate" }"#)
-                    .unwrap();
+            if cfg!(not(target_os = "windows"))
+                && let Err(err) =
+                    zenoh_config.insert_json5("routing/peer", r#"{ mode: "linkstate" }"#)
+            {
+                warn!("failed to set zenoh routing/peer to linkstate: {err}");
             }
 
             // Latency note: each data-plane publisher in
@@ -67,37 +68,41 @@ pub async fn open_zenoh_session_with_listen(
             // scouting. This makes the >=4 KiB zenoh data path work in
             // environments without working multicast (#1778).
             if let Ok(ep) = std::env::var(DORA_ZENOH_CONNECT_ENV) {
-                zenoh_config
-                    .insert_json5("connect/endpoints", &format!(r#"["{ep}"]"#))
-                    .unwrap();
-                zenoh_config
-                    .insert_json5("scouting/multicast/enabled", "false")
-                    .unwrap();
+                if let Err(err) =
+                    zenoh_config.insert_json5("connect/endpoints", &format!(r#"["{ep}"]"#))
+                {
+                    warn!("failed to set zenoh connect/endpoints from DORA_ZENOH_CONNECT: {err}");
+                }
+                if let Err(err) = zenoh_config.insert_json5("scouting/multicast/enabled", "false") {
+                    warn!("failed to disable zenoh scouting/multicast: {err}");
+                }
             }
 
             if let Some(ep) = listen_endpoint {
-                zenoh_config
-                    .insert_json5("listen/endpoints", &format!(r#"["{ep}"]"#))
-                    .unwrap();
+                if let Err(err) =
+                    zenoh_config.insert_json5("listen/endpoints", &format!(r#"["{ep}"]"#))
+                {
+                    warn!("failed to set zenoh listen/endpoints to `{ep}`: {err}");
+                }
                 // Tolerate a race between OS port reservation and zenoh's own
                 // bind on the same port: the connect side still works, and
                 // child nodes get a clear error rather than the daemon
                 // exiting.
-                zenoh_config
-                    .insert_json5("listen/exit_on_failure", "false")
-                    .unwrap();
+                if let Err(err) = zenoh_config.insert_json5("listen/exit_on_failure", "false") {
+                    warn!("failed to set zenoh listen/exit_on_failure: {err}");
+                }
             }
 
-            if let Some(addr) = coordinator_addr {
-                zenoh_config
-                    .insert_json5(
-                        "connect/endpoints",
-                        &format!(
-                            r#"{{ router: ["tcp/[::]:7447"], peer: ["tcp/{}:5456"] }}"#,
-                            addr
-                        ),
-                    )
-                    .unwrap();
+            if let Some(addr) = coordinator_addr
+                && let Err(err) = zenoh_config.insert_json5(
+                    "connect/endpoints",
+                    &format!(
+                        r#"{{ router: ["tcp/[::]:7447"], peer: ["tcp/{}:5456"] }}"#,
+                        addr
+                    ),
+                )
+            {
+                warn!("failed to set zenoh connect/endpoints for coordinator {addr}: {err}");
             }
             if let Ok(zenoh_session) = zenoh::open(zenoh_config).await {
                 zenoh_session

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -105,6 +105,12 @@ pub async fn open_zenoh_session_with_listen(
                 }
             }
 
+            // Track whether listen/endpoints was accepted into THIS config.
+            // We don't promote it to `effective_listen_endpoint` until the
+            // configured open succeeds — the fallback default-config path
+            // below has no listener and must not advertise one (#1856).
+            let mut listen_inserted_into_configured: Option<String> = None;
+
             if let Some(ep) = listen_endpoint {
                 // `listen/exit_on_failure: false` is a tuning knob for the
                 // listener; only set it if the listener itself got
@@ -112,11 +118,7 @@ pub async fn open_zenoh_session_with_listen(
                 let listen_inserted =
                     match zenoh_config.insert_json5("listen/endpoints", &format!(r#"["{ep}"]"#)) {
                         Ok(()) => {
-                            // Helper became the source of truth: the daemon
-                            // reads this on return and only injects
-                            // `DORA_ZENOH_CONNECT` into spawned nodes when
-                            // listen actually bound (#1856).
-                            effective_listen_endpoint = Some(ep.to_string());
+                            listen_inserted_into_configured = Some(ep.to_string());
                             true
                         }
                         Err(err) => {
@@ -147,9 +149,15 @@ pub async fn open_zenoh_session_with_listen(
                 warn!("failed to set zenoh connect/endpoints for coordinator {addr}: {err}");
             }
             if let Ok(zenoh_session) = zenoh::open(zenoh_config).await {
+                // The configured session opened — promote the (possibly None)
+                // listener now that we know it's actually live.
+                effective_listen_endpoint = listen_inserted_into_configured;
                 zenoh_session
             } else {
                 warn!("failed to open zenoh session, retrying with default config");
+                // Default fallback has no listener; `effective_listen_endpoint`
+                // stays `None` so peers don't try to reach a bind that isn't
+                // there (#1856).
                 let zenoh_config = zenoh::Config::default();
                 zenoh::open(zenoh_config)
                     .await

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -68,27 +68,49 @@ pub async fn open_zenoh_session_with_listen(
             // scouting. This makes the >=4 KiB zenoh data path work in
             // environments without working multicast (#1778).
             if let Ok(ep) = std::env::var(DORA_ZENOH_CONNECT_ENV) {
-                if let Err(err) =
-                    zenoh_config.insert_json5("connect/endpoints", &format!(r#"["{ep}"]"#))
+                // Only disable multicast scouting if we successfully replaced
+                // it with an explicit connect endpoint — otherwise the node
+                // would have neither and open an isolated session. Interim
+                // mitigation for #1856; full required-vs-optional config
+                // classification still pending there.
+                let connect_inserted = match zenoh_config
+                    .insert_json5("connect/endpoints", &format!(r#"["{ep}"]"#))
                 {
-                    warn!("failed to set zenoh connect/endpoints from DORA_ZENOH_CONNECT: {err}");
-                }
-                if let Err(err) = zenoh_config.insert_json5("scouting/multicast/enabled", "false") {
+                    Ok(()) => true,
+                    Err(err) => {
+                        warn!(
+                            "failed to set zenoh connect/endpoints from DORA_ZENOH_CONNECT ({err}); leaving multicast scouting enabled as fallback"
+                        );
+                        false
+                    }
+                };
+                if connect_inserted
+                    && let Err(err) =
+                        zenoh_config.insert_json5("scouting/multicast/enabled", "false")
+                {
                     warn!("failed to disable zenoh scouting/multicast: {err}");
                 }
             }
 
             if let Some(ep) = listen_endpoint {
-                if let Err(err) =
-                    zenoh_config.insert_json5("listen/endpoints", &format!(r#"["{ep}"]"#))
-                {
-                    warn!("failed to set zenoh listen/endpoints to `{ep}`: {err}");
-                }
+                // `listen/exit_on_failure: false` is a tuning knob for the
+                // listener; only set it if the listener itself got
+                // configured. Interim mitigation for #1856.
+                let listen_inserted =
+                    match zenoh_config.insert_json5("listen/endpoints", &format!(r#"["{ep}"]"#)) {
+                        Ok(()) => true,
+                        Err(err) => {
+                            warn!("failed to set zenoh listen/endpoints to `{ep}`: {err}");
+                            false
+                        }
+                    };
                 // Tolerate a race between OS port reservation and zenoh's own
                 // bind on the same port: the connect side still works, and
                 // child nodes get a clear error rather than the daemon
                 // exiting.
-                if let Err(err) = zenoh_config.insert_json5("listen/exit_on_failure", "false") {
+                if listen_inserted
+                    && let Err(err) = zenoh_config.insert_json5("listen/exit_on_failure", "false")
+                {
                     warn!("failed to set zenoh listen/exit_on_failure: {err}");
                 }
             }


### PR DESCRIPTION
## Summary

Rescues the still-applicable parts of @LeonRust's #1608 ("replace unwrap with proper error handling in node API and core libs") against current `main`. That PR is `CONFLICTING` and has been stale since 2026-04-22; main has moved on. Of its three target sites, only two remain valid:

- **`apis/rust/node/src/event_stream/mod.rs`** — `EventStream::add_event()` still has `self.record_event(&event).unwrap()`. `record_event` writes the optional `write_events_to` event-log file (observability only). A write failure (disk full, handle revoked, etc.) currently panics the event loop. Replaced with `tracing::warn!` so observability never breaks the main path.
- **`libraries/core/src/topics.rs`** — `open_zenoh_session_with_listen()` has six `.unwrap()` calls on `zenoh_config.insert_json5(...)` results. Static keys, effectively infallible today, but flagged by the unwrap-budget ratchet. Replaced each with `if let Err(err) = ... { warn!(...) }` so a future zenoh schema change degrades to a warning rather than a daemon panic.

`binaries/daemon/src/lib.rs` is also touched, but as a downstream call-site update: the source-of-truth refactor described in the "Pre-landing /review notes" section below changed `open_zenoh_session_with_listen`'s return type from `Result<Session>` to `Result<(Session, Option<String>)>`, and the daemon's only call site now reads `zenoh_listen_endpoint` from the helper return (gating `DORA_ZENOH_CONNECT` injection on it) instead of from its own locally-reserved port. This is a different daemon file from the `apis/rust/node/src/node/mod.rs` work in PR 1608 that's listed as dropped below.

### What was dropped from #1608, and why

The PR's third target — `apis/rust/node/src/node/mod.rs` (the `cache.remove(i).unwrap()` and three unwraps in `init_tracing`) — is no longer applicable:

- The whole shared-memory `cache` mechanism was deleted by #1745 ("Remove custom shared memory and drop token infrastructure"). `cache.remove(i)` no longer exists.
- The three `init_tracing` unwraps (`with_otlp_tracing()`, `clone.lock()`, `builder.build()`) were already replaced with graceful `match` / `if let Err(...)` handling on current main. PR 1608's version is strictly redundant; main's version is also marginally better (uses `eprintln!` because the `tracing` subscriber is not yet built when these run).

### Pre-landing /review notes

`/review` ran against this branch (Claude structured + Codex adversarial, medium tier). One auto-fix applied (dropped a "Rescue of #1608." trailer from a code comment — provenance lives in commit/PR per #1850, #1854 precedent). Two structural concerns surfaced by Codex are real but **out of scope for a panel-faithful rescue of #1608**, filed as follow-up issues:

1. **#1856 — `topics.rs` recovery semantics + daemon source-of-truth (CLOSED IN THIS PR):**
   - First pass: the sequenced `insert_json5` calls had a regression-shaped failure mode (e.g. `connect/endpoints` insert fails but `scouting/multicast/enabled = false` still runs → isolated session). Commit `3be41dfe` gated dependent inserts on their primary succeeding.
   - Reviewer caught a deeper inconsistency: even after that, the daemon kept its locally-reserved `zenoh_listen_endpoint` regardless of whether the helper actually bound the listener, then injected it into spawned nodes via `DORA_ZENOH_CONNECT`. Commit `e92f2c50` made the helper the source of truth: `open_zenoh_session_with_listen` now returns `(Session, Option<String>)` and the daemon uses the helper's returned endpoint. Spawned nodes only get `DORA_ZENOH_CONNECT` when the listener actually bound. The commit message includes `closes #1856`.
2. **#1857 — `event_stream` recorder corruption:** when `DORA_WRITE_EVENTS_TO` is set and `record_event` fails (Arrow/JSON conversion or file I/O), the event is now dropped silently and the final `inputs-{node_id}.json` is a partial-but-syntactically-valid file. Loud panic → quiet truncation. For replay/audit users this matters; proper fix is a poisoned-recorder state. Left for follow-up.
3. **#1858 — bind-race in `open_zenoh_session_with_listen`:** the second `/review` pass (Codex) caught that the source-of-truth refactor uses `zenoh::open(...) returned Ok` as proxy for "listener bound," but with `listen/exit_on_failure: false` zenoh can `Ok` a session even if the bind silently failed (e.g. another process grabbed the reserved port in the race window between `reserve_loopback_zenoh_endpoint` dropping its socket and zenoh binding). Pre-existing race that predates #1608 — pre-#1608 `.unwrap()` didn't verify bind either — but the source-of-truth contract makes the residual gap structurally visible. Doc-honesty + reservation-hold fix sketched in #1858. Out of scope for this rescue.

The recorder-corruption concern (#1857) and the bind-race (#1858) both predate #1608's design; the recovery-semantics concern (#1856) was introduced by the rescue and is now resolved end-to-end in this PR.

### Local QA

- `cargo fmt --all -- --check` ✓
- `cargo clippy --all --exclude dora-{node-api,operator-api,ros2-bridge}-python -- -D warnings` ✓ (project-standard gate, matches CI)
- `cargo test -p dora-core -p dora-node-api -p dora-daemon --lib` ✓ (79 + 32 = 111 tests pass)
- `cargo check --examples` ✓

## Test plan

- [ ] CI green (Linux fmt/clippy/test, E2E, contract tests, benchmark, typos, supply-chain audit, unwrap-budget, license)
- [ ] No regression in any node startup path (the changed code only runs at session/event-stream init)
- [ ] (Manual, optional) Verify the warning message format renders cleanly: trigger by setting `DORA_OTLP_ENDPOINT` and pointing `write_events_to` to a read-only path

Credit to @LeonRust for the original analysis in #1608.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

