### PR TITLE
fix(examples): catch by std::exception in c++ node-rust-api introspection (closes #1841)

### DIFF
--- a/examples/c++-dataflow/node-rust-api/main.cc
+++ b/examples/c++-dataflow/node-rust-api/main.cc
@@ -1,5 +1,6 @@
 #include "../build/dora-node-api.h"
 
+#include <exception>
 #include <iostream>
 #include <vector>
 
@@ -21,8 +22,13 @@ int main()
         auto descriptor = dataflow_descriptor_json(dora_node.send_output);
         std::cout << "Dataflow descriptor length: " << descriptor.length() << std::endl;
     }
-    catch (const rust::Error &e)
+    catch (const std::exception &e)
     {
+        // cxx throws `rust::Error` (a `std::exception` subclass) when a
+        // Rust function returning `Result<T>` fails. We catch by
+        // `std::exception` because `rust::Error` is part of cxx's runtime
+        // (`rust/cxx.h`) and is not re-exported into the bridge-specific
+        // header that user code sees.
         std::cerr << "Introspection failed: " << e.what() << std::endl;
     }
 


### PR DESCRIPTION
## Summary

Fixes the C++ example build failure that's been red on `Examples (ubuntu-latest|macos-latest|windows-latest)` since 2026-05-17, tracked in #1841.

## Root cause

PR #1848 added a `try { ... } catch (const rust::Error &e)` block to `examples/c++-dataflow/node-rust-api/main.cc` to demonstrate cxx `Result<T>` handling. But cxx 1.0.x splits its runtime across two headers:

- `target/cxxbridge/<crate>/src/lib.rs.h` — the bridge-specific header (copied to `examples/c++-dataflow/build/dora-node-api.h` by `run.rs`). Re-exports only the runtime types that appear in the bridge's public ABI: `rust::Box`, `rust::Slice`, `rust::String`, `rust::Vec`.
- `target/cxxbridge/rust/cxx.h` — the full cxx runtime, where `rust::Error` is defined.

`rust::Error` is thrown internally when a Rust `Result<T>::Err` propagates across the FFI boundary, but it never appears in a bridge signature, so the cxxbridge codegen does **not** re-export it into `lib.rs.h`. User code that only includes the bridge-specific header therefore can't reference `rust::Error` directly.

This slipped past local builds where stale `build/dora-node-api.h` artifacts from earlier iterations sometimes contained the full cxx.h inline. It only fails reproducibly on clean CI builds — exactly what nightly does.

## Why nightly has been red

PR #1848 merged with `ci/circleci: examples-linux` showing **FAILURE** — that's the job that would have caught this. Nightly's three `Examples` matrix jobs (ubuntu/macos/windows) all started failing on the next nightly run and have stayed red across 5 subsequent commits. #1841 is the umbrella nightly-regression issue.

## Fix

One-line: catch by `std::exception` instead. `rust::Error` extends `std::exception`, so the catch still triggers on `Result<T>` failure. Added a comment explaining the bridge-header split so the next person doesn't trip.

## Reproduction

```bash
$ rm -rf examples/c++-dataflow/build/
$ cargo run --example cxx-dataflow
```

**Before:**
```
error: no type named 'Error' in namespace 'rust'
   24 |     catch (const rust::Error &e)
```

**After:** Dataflow runs end-to-end, both C++ nodes produce HELLO/GOODBYE, and the new introspection prints work:
```
Node config: {"inputs":{"tick":"dora/timer/millis/300"},"outputs":["counter"]}
Dataflow descriptor length: 1375
```

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --exclude dora-{node-api,operator-api,ros2-bridge}-python -- -D warnings`
- [x] `cargo check --examples`
- [x] Local reproduction `cargo run --example cxx-dataflow` succeeds end-to-end
- [ ] CI green
- [ ] Nightly green on next run

## Related

- Closes #1841 (nightly regression umbrella)
- Caused by #1848 (which merged with the relevant CircleCI examples job already failing — see "lessons" below)

## Lessons / follow-up worth considering

Nightly has actually been red since 2026-05-13, on different jobs across different commits. This is the second case in two weeks where a CircleCI failure was tolerated at merge time and only caught by nightly N hours later. Worth considering:

1. **Don't merge with `ci/circleci: examples-*` FAILURE.** This same pattern also produced #1841 (CLI tests, examples) and likely contributes to the chronic red nightly. The CLAUDE.md "Pre-commit Quality Gates" already say `cargo check --examples` is mandatory — adding "and the examples-linux CircleCI job must be green" is one line.
2. **Treat the `Examples` nightly job as a blocking PR gate when an example file is touched.** Or strip cxx examples from CI entirely if they're too flaky to maintain. The current state (nightly red for a week, with no humans noticing until #1841 hit) is the worst of both worlds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
