### PR TITLE
qa: make ci-nightly cli-tests honest about per-node failures (closes #1862, #1863)

### DIFF
--- a/scripts/qa/ci-nightly-jobs.sh
+++ b/scripts/qa/ci-nightly-jobs.sh
@@ -69,6 +69,47 @@ SELECTED_JOB_COUNT=$#
 CLI_ROOT=""
 CLI_INSTALLED=0
 
+# Scan a dataflow's `out/<UUID>/log_*.jsonl` for per-node failure
+# markers. `dora run --stop-after Ns` exits 0 if the daemon ran for N
+# seconds regardless of whether any node actually succeeded inside —
+# so callers need an explicit assertion on top to catch silent
+# crashes. Without this, the cli-tests phase reports PASS even when
+# `listener_1` failed to build and `talker_1` never received an event
+# (#1863).
+#
+# Patterns chosen because `level:error` in dora's JSONL is noisy
+# (zenoh emits "Unable to publish transport event: session closed"
+# on every clean teardown). The patterns below are unambiguous node
+# failures that don't appear in the happy path.
+assert_clean_dataflow_run() {
+  local outdir="${1:-out}"
+  local fail_re='panicked at|failed to build node|ModuleNotFoundError:|Traceback \(most recent|^Caused by:|"level":"stderr".*"msg":"Error:'
+  local issues=()
+
+  if [ ! -d "$outdir" ]; then
+    # No output at all means `dora run` produced nothing — the
+    # caller's own exit-code check already covered that case.
+    return 0
+  fi
+
+  while IFS= read -r logfile; do
+    local node
+    node=$(basename "$logfile" .jsonl | sed 's/^log_//')
+    # Internal dora bookkeeping nodes (record/replay etc.) — skip.
+    case "$node" in __dora_*) continue ;; esac
+    if grep -qE "$fail_re" "$logfile" 2>/dev/null; then
+      issues+=("$node (see $logfile)")
+    fi
+  done < <(find "$outdir" -name 'log_*.jsonl' -type f 2>/dev/null)
+
+  if [ ${#issues[@]} -gt 0 ]; then
+    echo "ERROR: cli-tests assertion: dora run exit was clean but these nodes had failures:" >&2
+    printf '  - %s\n' "${issues[@]}" >&2
+    return 1
+  fi
+  return 0
+}
+
 known_job() {
   case "$1" in
     record-replay|cluster-smoke|topic-and-top-smoke|cpu-affinity-smoke|redb-backend-smoke|daemon-reconnect-smoke|state-reconstruction-smoke|test-cross-platform|examples|cli-tests|bench-example|msrv|cross-check|ros2-bridge)
@@ -830,17 +871,21 @@ job_cli_tests() {
   # cargo install --path binaries/cli --locked is redundant here; skip it
   # to save ~45 min per local run.
 
-  # Rust template project: all platforms
-  local tmpd
-  tmpd=$(mktemp -d -t dora-tpl-XXXXXX)
+  # Rust template project: all platforms. Generated at repo root so
+  # the CLI template's relative path dep `dora-node-api = { path =
+  # "../../apis/rust/node" }` resolves to the actual workspace
+  # (#1862). Matches `.github/workflows/nightly.yml::cli-tests`.
+  # Pre-clean in case a prior interrupted run left state behind.
+  rm -rf test_rust_project
   (
-    cd "$tmpd"
     dora new test_rust_project --internal-create-with-path-dependencies
     cd test_rust_project
     cargo build --all
     timeout 120s dora run dataflow.yml --stop-after 10s
+    # Assert no per-node failures hid behind dora-run's 10s timer (#1863).
+    assert_clean_dataflow_run "out"
   )
-  rm -rf "$tmpd"
+  rm -rf test_rust_project
 
   # Dynamic Rust Dataflow
   dora up
@@ -875,11 +920,13 @@ job_cli_tests() {
     # Capture an absolute path before the template subshell changes directory.
     dora_python_api="$PWD/apis/python/node"
 
-    # Python template: dora new + dora build + ruff + pytest + dora run
-    local tmpd2
-    tmpd2=$(mktemp -d -t dora-pytpl-XXXXXX)
+    # Python template: dora new + dora build + ruff + pytest + dora run.
+    # Generated at repo root for the same reason as the Rust template
+    # above — the CLI template's relative path-dep needs the dora
+    # workspace as a parent (#1862). Matches
+    # `.github/workflows/nightly.yml::cli-tests`.
+    rm -rf test_python_project
     (
-      cd "$tmpd2"
       dora new test_python_project --lang python --internal-create-with-path-dependencies
       cd test_python_project
       dora build dataflow.yml --uv
@@ -889,12 +936,19 @@ job_cli_tests() {
       export OPERATING_MODE=SAVE
       dora build dataflow.yml --uv
       timeout 120s dora run dataflow.yml --uv --stop-after 10s
+      # Assert no per-node failures hid behind dora-run's 10s timer (#1863).
+      assert_clean_dataflow_run "out"
     )
-    rm -rf "$tmpd2"
+    rm -rf test_python_project
 
-    # Python Node example
+    # Python Node example. `dora run X/dataflow.yml` puts `out/` next
+    # to the yaml, so the assertion scans `examples/python-dataflow/out`.
+    # Pre-clean stale logs from prior runs so the assert only sees
+    # this invocation's per-node behavior (#1863).
+    rm -rf examples/python-dataflow/out
     dora build examples/python-dataflow/dataflow.yml --uv
     timeout 60s dora run examples/python-dataflow/dataflow.yml --uv --stop-after 10s
+    assert_clean_dataflow_run examples/python-dataflow/out
 
     # Python Dynamic Node example
     # dora-hub deps pull dora-rs from PyPI, overriding local build;
@@ -911,13 +965,17 @@ job_cli_tests() {
 
     # Python Operator example
     # dora-hub deps pull dora-rs from PyPI; re-install local version.
+    rm -rf examples/python-operator-dataflow/out
     dora build examples/python-operator-dataflow/dataflow.yml --uv
     uv pip install --quiet -e apis/python/node
     timeout 120s dora run examples/python-operator-dataflow/dataflow.yml --uv --stop-after 20s
+    assert_clean_dataflow_run examples/python-operator-dataflow/out
 
     # Python Multiple Arrays
+    rm -rf examples/python-multiple-arrays/out
     dora build examples/python-multiple-arrays/dataflow.yml --uv
     timeout 120s dora run examples/python-multiple-arrays/dataflow.yml --uv --stop-after 30s
+    assert_clean_dataflow_run examples/python-multiple-arrays/out
 
     # Python Async example (5-min run; skipped on Windows per GHA)
     case "$OS" in


### PR DESCRIPTION
## Summary

Closes #1862 and #1863. Makes `make qa-nightly`'s `cli-tests` phase actually validate what it claims to validate.

Two bugs surfaced on tonight's local qa-nightly run (post-#1861 main):

### #1862 — tmp-dir + path-dep mismatch (local-only)

`scripts/qa/ci-nightly-jobs.sh::job_cli_tests` `cd`-ed into a `mktemp -d` before `dora new --internal-create-with-path-dependencies`. The CLI template generates a **relative** path dep:

```toml
# binaries/cli/src/template/rust/mod.rs:106
dora-node-api = { path = "../../apis/rust/node" }
```

From `/tmp/dora-tpl-XXX/test_rust_project/talker_1/`, that resolves to `/tmp/apis/rust/node` — which doesn't exist. cargo barfs:

```
error: failed to load manifest for workspace member `.../talker_1`
Caused by: failed to load manifest for dependency `dora-node-api`
Caused by: failed to read `.../apis/rust/node/Cargo.toml`
Caused by: No such file or directory (os error 2)
```

Same shape for the Python template. GHA's `nightly.yml::cli-tests` doesn't hit this because it runs from `$GITHUB_WORKSPACE` (the checkout root).

**Fix:** drop the `cd $tmpd` in both Rust and Python template tests. Generate `test_rust_project` / `test_python_project` at repo root, pre-clean + cleanup. Mirrors GHA exactly.

### #1863 — cli-tests reports PASS when nodes silently crash

`dora run --stop-after 10s` returns 0 if the daemon ran for 10s, regardless of per-node success. Same shape as #1857 — soft success masks failure. From the prior failed qa-nightly:

```
listener_1: stdout   error: failed to load manifest...
[ERROR] failed to build node `listener_1`
...
  PASS: cli-tests   ← lying
```

**Fix:** add `assert_clean_dataflow_run()` that scans `out/<UUID>/log_*.jsonl` for unambiguous failure markers (panics, `failed to build node`, `ModuleNotFoundError:`, Python tracebacks, `Caused by:` chains). `level:error` is too noisy for this purpose (zenoh emits "Unable to publish transport event: session closed" on every clean teardown), so the assert matches on message content. Internal `__dora_*` nodes are skipped.

Wired into all 5 `dora run --stop-after` sites in `job_cli_tests`:

| Site | What it tests |
|---|---|
| Rust template | `dora new test_rust_project` → cargo build → run |
| Python template | `dora new test_python_project` → build → pytest → run |
| Python Node example | `examples/python-dataflow/dataflow.yml --uv` |
| Python Operator example | `examples/python-operator-dataflow/dataflow.yml --uv` |
| Python Multiple Arrays | `examples/python-multiple-arrays/dataflow.yml --uv` |

Each site pre-cleans `out/` so the assert only sees the current invocation's logs.

## Test plan

**Negative test (assert must fire on real failures):**
```bash
# Synthesize a node log with panicked at + ModuleNotFoundError
$ assert_clean_dataflow_run /tmp/negtest/out
ERROR: cli-tests assertion: dora run exit was clean but these nodes had failures:
  - talker_1 (see /tmp/negtest/out/test-uuid/log_talker_1.jsonl)
  - listener_1 (see /tmp/negtest/out/test-uuid/log_listener_1.jsonl)
RC=1   ✓ correctly flagged
```

**Positive test (assert must not false-fire on real successes):**
```bash
$ scripts/qa/ci-nightly-jobs.sh cli-tests
... <all 5 dora runs complete> ...
  PASS: cli-tests
$ echo $?
0
```

Full `cli-tests` job exit code: 0. All 5 assert sites ran, none fired.

## Follow-ups discovered (out of scope)

- **Python `--internal-create-with-path-dependencies` is silently ignored.** `binaries/cli/src/template/mod.rs:9` calls `python::create(args)` without the `use_path_deps` flag. Doesn't surface on Linux x86_64 (PyPI has wheels there) but breaks Python cli-tests on macOS arm64 / any platform without a published wheel. Worth a fresh issue.
- **GHA `nightly.yml::cli-tests` has the same soft-PASS shape** but doesn't currently hit #1862 (different cwd). Worth porting these asserts to the workflow YAML if anyone cares; less urgent than the local script.

## Risk

Script-only change. Doesn't touch CLI source, doesn't change behavior for any user not running `make qa-nightly`. The assert may surface real-but-historically-tolerated failures on first run — that's the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
