### PR TITLE
fix(ci): provision Python 3.11+ before pyo3 abi3-py311 builds in nightly (closes #1866)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1333,9 +1333,12 @@ jobs:
       # compile time — they bake the minimum into the binary — so
       # disabling the interpreter probe is correct here. Fixes #1866.
       PYO3_NO_PYTHON: "1"
-      # Same value needs to reach the container `cross` spawns;
+      # Pass PYO3_NO_PYTHON through to the container `cross` spawns;
       # otherwise the in-container build sees runner-host env only.
-      CROSS_CONTAINER_ENV: "PYO3_NO_PYTHON"
+      # `CROSS_BUILD_ENV_PASSTHROUGH` maps to `build.env.passthrough`
+      # in Cross.toml — see cross-rs/cross docs. (Earlier draft used
+      # `CROSS_CONTAINER_ENV`, which is not a cross-recognized var.)
+      CROSS_BUILD_ENV_PASSTHROUGH: "PYO3_NO_PYTHON"
     strategy:
       matrix:
         include:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1323,6 +1323,19 @@ jobs:
     name: Cross-check (${{ matrix.target }})
     runs-on: ${{ matrix.runner }}
     # (PR-CI gate removed; runs independently in nightly)
+    env:
+      # The workspace pins `abi3-py311` in pyo3 features (workspace
+      # Cargo.toml:123 + apis/python/operator + ros2-bridge/python +
+      # binaries/runtime). pyo3-build-config 0.28+ asserts the build-
+      # time Python interpreter version is >= the abi3 minimum, but
+      # `cross` runs the build inside Docker images that ship Python
+      # 3.10. abi3 builds don't actually need a runtime Python at
+      # compile time — they bake the minimum into the binary — so
+      # disabling the interpreter probe is correct here. Fixes #1866.
+      PYO3_NO_PYTHON: "1"
+      # Same value needs to reach the container `cross` spawns;
+      # otherwise the in-container build sees runner-host env only.
+      CROSS_CONTAINER_ENV: "PYO3_NO_PYTHON"
     strategy:
       matrix:
         include:
@@ -1408,6 +1421,18 @@ jobs:
         with:
           required-ros-distributions: humble
       - run: 'source /opt/ros/humble/setup.bash && echo AMENT_PREFIX_PATH=${AMENT_PREFIX_PATH} >> "$GITHUB_ENV"'
+      # Provision Python 3.12 BEFORE the first cargo invocation. The
+      # workspace pins `abi3-py311` in pyo3 features (workspace
+      # Cargo.toml:123) and pyo3-build-config 0.28+ rejects build-time
+      # interpreters older than the abi3 minimum. ubuntu-22.04 ships
+      # Python 3.10 by default, which would make `cargo test -p
+      # dora-ros2-bridge-python` below fail with "cannot set a minimum
+      # Python version 3.11 higher than the interpreter version 3.10".
+      # Previously this step lived AFTER the cargo steps below, so it
+      # only protected the Python example, not the build. Fixes #1866.
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
@@ -1423,9 +1448,6 @@ jobs:
         run: |
           source /opt/ros/humble/setup.bash &&
           cargo run -p dora-ros2-bridge --example rust-ros2-dataflow
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
       - name: Python ROS2 Bridge example
         timeout-minutes: 30
         env:


### PR DESCRIPTION
## Summary

Closes #1866. Tonight's nightly (run [26082367187](https://github.com/dora-rs/dora/actions/runs/26082367187)) was the first run with the C++ catch (#1841 → #1859) and numpy (#1861) fixes both on `main`. With those two upstream signals cleared, a pre-existing Python-version gap surfaced cleanly:

```
error: failed to run custom build command for `pyo3-build-config v0.28.3`
error: cannot set a minimum Python version 3.11 higher than the
       interpreter version 3.10 (the minimum Python version is implied
       by the abi3-py311 feature)
```

Affected 5 jobs, all same root cause:
- `ROS2 Bridge Examples`
- `Cross-check (i686-unknown-linux-gnu)`
- `Cross-check (aarch64-unknown-linux-gnu)`
- `Cross-check (aarch64-unknown-linux-musl)`
- `Cross-check (armv7-unknown-linux-musleabihf)`

## Why this triggers

The workspace pins `abi3-py311` in pyo3 features at `Cargo.toml:123`, `apis/python/operator/Cargo.toml`, `libraries/extensions/ros2-bridge/python/Cargo.toml`, `binaries/runtime/Cargo.toml`. `pyo3-build-config` 0.28+ asserts the **build-time** interpreter version is ≥ the abi3 minimum. The failing jobs each have Python 3.10 in PATH:

| Job | Runner | Python source |
|---|---|---|
| `ros2-bridge` | `ubuntu-22.04` | system Python 3.10 |
| `cross-check (i686/aarch64/armv7-linux-*)` | `ubuntu-latest` host + `cross` Docker | `cross` images ship Python 3.10 |
| `cross-check (x86_64-linux-gnu)` | `ubuntu-latest` host, native cargo check | Python 3.12 (passes) |
| `cross-check (*-darwin)`, `(windows-gnu)` | `macos-latest`/`ubuntu-latest`, native | Python 3.11+ (passes) |

## Fixes

**1. `cross-check` (non-x86_64-linux):** add `PYO3_NO_PYTHON=1` + `CROSS_CONTAINER_ENV=PYO3_NO_PYTHON` as job-level env. abi3 builds bake the minimum version into the produced binary and don't actually need a runtime Python at compile time, so skipping pyo3's interpreter probe is correct. No-op for native cargo check matrix entries.

**2. `ros2-bridge`:** move the existing `actions/setup-python@v5 -> 3.12` step up to BEFORE the first cargo invocation. The step was already there but landed AFTER `cargo test -p dora-ros2-bridge-python` and `cargo run -p dora-ros2-bridge --example rust-ros2-dataflow`, so the first cargo build still saw 3.10 and bailed. Single-line reorder.

## Why this didn't fire earlier

The bug has existed since `abi3-py311` was bumped (likely #1833 / #1291's zero-copy `send_output_raw`). It was masked behind:
- The C++ catch bug (#1841) failing earlier in the run on every platform
- The numpy bug (#1861) cancelling the smoke suite before cross-check/ros2-bridge could fail

Yesterday's PR chain (#1859, #1861, #1864, #1865) cleared those upstream signals. This one is what was left underneath.

## What does NOT change

- **No Cargo.toml / pyo3 feature changes.** The `abi3-py311` floor stays. The PR fixes CI provisioning, not the underlying dependency contract.
- **No PR CI change.** `.github/workflows/ci.yml::Test (ubuntu-latest)` already provisions Python 3.12 via `actions/setup-python@v5` at line 281 before any cargo invocation. PR CI was never affected.
- **No local QA change.** `scripts/qa/all.sh` already preflights Python 3.12 via `uv python find 3.12` and bails with a clear hint if missing.

## Test plan

- [ ] CI green (PR CI is unaffected; should pass with the usual #1860 environmental noise as the only failures)
- [ ] Next nightly run (2026-05-20 06:40 UTC) shows the 5 affected jobs going from FAIL to PASS
- [ ] No regression in any other nightly job
- [ ] If anything else surfaces, we triage in the bot-filed comment on #1866

## Risk

Workflow-only change. Touches `.github/workflows/nightly.yml` only. Worst case: my env-var fix doesn't fully reach the `cross` container and the jobs still fail with the same error — in which case we add `PYO3_PYTHON=python3.11` + an explicit Python install. Easy to iterate; nightly is the test bed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
