### PR TITLE
chore: apply 3 clippy fixes cherry-picked from #1868 (replaces #1868)

### DIFF
--- a/binaries/cli/src/command/logs.rs
+++ b/binaries/cli/src/command/logs.rs
@@ -182,7 +182,7 @@ fn read_local_logs(args: &LogsArgs) -> Result<()> {
     for path in &log_files {
         all_messages.extend(read_log_file(path)?);
     }
-    all_messages.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+    all_messages.sort_by_key(|a| a.timestamp);
     let filtered = apply_time_filters(all_messages, args.since, args.until, now);
     let grepped = apply_grep(filtered, args.grep.as_deref());
     let display = apply_tail(grepped, args.tail);
@@ -227,7 +227,7 @@ fn follow_local_logs(args: &LogsArgs) -> Result<()> {
     for path in &files {
         all_messages.extend(read_log_file(path)?);
     }
-    all_messages.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+    all_messages.sort_by_key(|a| a.timestamp);
     let filtered = apply_time_filters(all_messages, args.since, args.until, now);
     let grepped = apply_grep(filtered, args.grep.as_deref());
     let display = apply_tail(grepped, args.tail);
@@ -266,7 +266,7 @@ fn follow_local_logs(args: &LogsArgs) -> Result<()> {
             file_positions.insert(path.clone(), current_size);
         }
 
-        new_messages.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+        new_messages.sort_by_key(|a| a.timestamp);
         for msg in new_messages {
             if matches_grep(&msg, args.grep.as_deref()) {
                 print_log_message(msg, &config);

--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -1031,21 +1031,18 @@ fn check_edge_mismatches_with_compat(
                 let downstream_urn = input_types.get(input_id);
 
                 match (upstream_urn, downstream_urn) {
-                    (Some(out_urn), Some(in_urn)) => {
-                        if !compat.is_compatible(out_urn, in_urn) {
-                            let schema_detail = check_schema_compat(out_urn, in_urn, registry);
-                            let detail =
-                                schema_detail.map(|d| format!(" ({d})")).unwrap_or_default();
-                            warnings.push(TypeWarning {
-                                node_id: node_id.to_string(),
-                                message: format!(
-                                    "type mismatch on input \"{input_id}\": \
-                                     upstream {}/{} declares \"{out_urn}\", \
-                                     but expected \"{in_urn}\"{detail}",
-                                    mapping.source, mapping.output,
-                                ),
-                            });
-                        }
+                    (Some(out_urn), Some(in_urn)) if !compat.is_compatible(out_urn, in_urn) => {
+                        let schema_detail = check_schema_compat(out_urn, in_urn, registry);
+                        let detail = schema_detail.map(|d| format!(" ({d})")).unwrap_or_default();
+                        warnings.push(TypeWarning {
+                            node_id: node_id.to_string(),
+                            message: format!(
+                                "type mismatch on input \"{input_id}\": \
+                                 upstream {}/{} declares \"{out_urn}\", \
+                                 but expected \"{in_urn}\"{detail}",
+                                mapping.source, mapping.output,
+                            ),
+                        });
                     }
                     (Some(out_urn), None) => {
                         inferences.push(TypeInference {

--- a/tests/fault_tolerance/silent_source_node/src/main.rs
+++ b/tests/fault_tolerance/silent_source_node/src/main.rs
@@ -17,15 +17,14 @@ fn main() -> eyre::Result<()> {
     let mut sent = false;
     while let Some(event) = events.recv() {
         match event {
-            Event::Input { id, metadata, .. } if id.as_str() == "tick" => {
-                if !sent {
-                    node.send_output(output.clone(), metadata.parameters, 42i64.into_arrow())
-                        .context("failed to send value")?;
-                    sent = true;
-                }
-                // Subsequent ticks are intentionally ignored so the
-                // downstream must rely on `input_timeout` to notice
-                // that data has gone stale.
+            // First tick only: send the value, then go silent. Subsequent
+            // ticks fall through to the catch-all arm below, where they're
+            // intentionally ignored so the downstream consumer must rely
+            // on `input_timeout` to notice that data has gone stale.
+            Event::Input { id, metadata, .. } if id.as_str() == "tick" && !sent => {
+                node.send_output(output.clone(), metadata.parameters, 42i64.into_arrow())
+                    .context("failed to send value")?;
+                sent = true;
             }
             Event::Stop(_) => break,
             _ => {}


### PR DESCRIPTION
## Summary

Cherry-picks ONLY the actual clippy fixes from #1868, dropped onto current `main`. Replaces #1868.

### Why a new PR instead of merging #1868

The automated clippy-fix workflow opened #1868 at **2026-05-19T09:18Z**, but **three later PRs landed today**:

- **#1867** Cargo.lock weekly bump (merged 16:46 UTC)
- **#1869** Python 3.11+ in nightly, closes #1866 (merged 13:51 UTC)
- **#1870** Zenoh listener bind verification, closes #1858 (merged 16:35 UTC)

Because #1868's branch was generated before those merged, its diff includes reversions of all three. Merging it as-is would silently undo #1867 + #1869 + #1870 — reopening #1866 (Python build break in nightly) and #1858 (zenoh phantom-endpoint race).

`/pr-review` on #1868 caught this. Closing #1868 in favor of this PR which contains only the legitimate clippy fixes.

### The 3 clippy fixes

| File | Lint | Change |
|---|---|---|
| `binaries/cli/src/command/logs.rs` (3 sites: lines 185, 230, 269) | `clippy::unnecessary_sort_by` | `.sort_by(\|a, b\| a.timestamp.cmp(&b.timestamp))` → `.sort_by_key(\|a\| a.timestamp)` |
| `libraries/core/src/descriptor/validate.rs::check_edge_mismatches_with_compat` | `clippy::collapsible_if` / match-arm collapse | Nested `(Some, Some) => { if !cond { ... } }` → guarded `(Some, Some) if !cond => { ... }` |
| `tests/fault_tolerance/silent_source_node/src/main.rs::main` | same `clippy::collapsible_if` pattern | Inner `if !sent` collapsed into the match guard |

### Correctness verification

- **`logs.rs`**: `sort_by_key` is functionally identical to the cmp lambda when sorting by a single key. Three independent sites, all the same trivial transformation.
- **`validate.rs`**: match exhaustiveness preserved by the existing `_ => {}` catch-all at the end of the same `match` block (line 1067 pre-edit, line 1064 post-edit). The (Some, Some)-and-compatible case falls through to the catch-all and does nothing — identical to the pre-collapse `if !cond { ... } else { /* implicit no-op */ }`.
- **`silent_source_node/main.rs`**: When `sent == true` and a tick arrives, the new arm doesn't match (guard fails) and the event falls through to `_ => {}`. Semantically identical to the pre-collapse `if !sent { ... } else { /* implicit no-op */ }`. The orphaned comment from #1868's auto-refactor (over-indented between arms) was rewritten above the arm to describe the actual new control flow.

### Test plan

- [x] `cargo fmt --all -- --check` ✓
- [x] `cargo clippy --all --exclude dora-{node-api,operator-api,ros2-bridge}-python -- -D warnings` ✓
- [x] `cargo test -p dora-core -p dora-node-api -p dora-cli --lib` ✓ (82 tests pass)
- [x] `cargo check --examples` ✓
- [ ] CI green

## Closes

- #1868 (by replacement — that PR will be closed manually with a link back to this one)

## Risk

Three independent mechanical clippy fixes, no behavior change. Diff is +23/-27 across 3 files. The new code is what the lint asked for in each case; the legacy patterns were tolerated previously but flagged on the next auto-clippy run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
