### PR TITLE
fix(coordinator): validate AddNode daemon reply, forward errors to CLI (rescue of #1757)

### DIFF
--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -1555,31 +1555,58 @@ async fn start_inner(
                                                                     .send_and_receive(&msg)
                                                                     .await
                                                                 {
-                                                                    Ok(_) => {
-                                                                        dataflow
-                                                                            .node_to_daemon
-                                                                            .insert(
-                                                                                node_id.clone(),
-                                                                                did,
-                                                                            );
-                                                                        // Update the stored descriptor
-                                                                        // and resolved nodes so
-                                                                        // `dora info` reflects the
-                                                                        // new node.
-                                                                        dataflow
-                                                                            .descriptor
-                                                                            .nodes
-                                                                            .push(original_node);
-                                                                        dataflow.nodes.insert(
-                                                                            node_id.clone(),
-                                                                            resolved_node,
-                                                                        );
-                                                                        Ok(
-                                                                            ControlRequestReply::NodeAdded {
-                                                                                dataflow_id,
-                                                                                node_id,
-                                                                            },
-                                                                        )
+                                                                    Ok(reply_raw) => {
+                                                                        // Validate the daemon reply is
+                                                                        // specifically an `AddNodeResult`
+                                                                        // (not just any non-error reply)
+                                                                        // before committing state. Without
+                                                                        // this, a `SetParamResult` or an
+                                                                        // explicit `AddNodeResult(Err)`
+                                                                        // would still be reported as
+                                                                        // applied and corrupt the dataflow
+                                                                        // state (#1682, rescue of #1757).
+                                                                        // The validator's error is folded
+                                                                        // into the `Err` arm of `result`
+                                                                        // (via explicit `Err(e) => Err(e)`
+                                                                        // below — no `?`), which the
+                                                                        // coordinator's main loop sends
+                                                                        // back to the CLI as
+                                                                        // `ControlRequestReply::Error`.
+                                                                        // Addresses phil-opp's review of
+                                                                        // #1757 (do not tear down the
+                                                                        // event loop on a recoverable
+                                                                        // per-request failure).
+                                                                        match ensure_add_node_applied(
+                                                                            &reply_raw, &node_id,
+                                                                        ) {
+                                                                            Ok(()) => {
+                                                                                dataflow
+                                                                                    .node_to_daemon
+                                                                                    .insert(
+                                                                                        node_id.clone(),
+                                                                                        did,
+                                                                                    );
+                                                                                // Update the stored descriptor
+                                                                                // and resolved nodes so
+                                                                                // `dora info` reflects the
+                                                                                // new node.
+                                                                                dataflow
+                                                                                    .descriptor
+                                                                                    .nodes
+                                                                                    .push(original_node);
+                                                                                dataflow.nodes.insert(
+                                                                                    node_id.clone(),
+                                                                                    resolved_node,
+                                                                                );
+                                                                                Ok(
+                                                                                    ControlRequestReply::NodeAdded {
+                                                                                        dataflow_id,
+                                                                                        node_id,
+                                                                                    },
+                                                                                )
+                                                                            }
+                                                                            Err(e) => Err(e),
+                                                                        }
                                                                     }
                                                                     Err(e) => Err(eyre!(
                                                                         "daemon dispatch failed: {e}"
@@ -1625,6 +1652,15 @@ async fn start_inner(
                                                 Some(conn) => {
                                                     match conn.send_and_receive(&msg).await {
                                                         Ok(_) => {
+                                                            // TODO: validate the daemon reply
+                                                            // is specifically a successful
+                                                            // `RemoveNodeResult`, parallel to
+                                                            // the AddNode fix (#1682, rescue of
+                                                            // #1757). Same `Ok(_)` shape can
+                                                            // accept a stale or wrong-variant
+                                                            // reply and corrupt state. Tracked
+                                                            // separately to keep this rescue
+                                                            // panel-faithful to #1757's scope.
                                                             // Clean up coordinator state
                                                             // (inverse of AddNode inserts)
                                                             if let Some(dataflow) =
@@ -3414,6 +3450,27 @@ fn build_set_param_message_from_raw_json(
     .map_err(Into::into)
 }
 
+/// Validate that the daemon's reply to `DaemonCoordinatorEvent::AddNode`
+/// is a successful `AddNodeResult`. Returns `Err` for both an explicit
+/// daemon failure and an unexpected reply variant; callers should forward
+/// the error to the CLI as a `ControlRequestReply::Error` and NOT use `?`
+/// to bubble out of the coordinator's main loop. Rescue of #1757,
+/// addresses #1682.
+fn ensure_add_node_applied(
+    reply_raw: &[u8],
+    node_id: &dora_core::config::NodeId,
+) -> eyre::Result<()> {
+    match serde_json::from_slice(reply_raw)? {
+        DaemonCoordinatorReply::AddNodeResult(Ok(())) => Ok(()),
+        DaemonCoordinatorReply::AddNodeResult(Err(err)) => {
+            Err(eyre!("daemon failed to add node `{node_id}`: {err}"))
+        }
+        other => Err(eyre!(
+            "unexpected daemon reply for AddNode on node `{node_id}`: {other:?}"
+        )),
+    }
+}
+
 fn ensure_set_param_forward_applied(
     reply_raw: &[u8],
     node_id: &dora_core::config::NodeId,
@@ -4708,6 +4765,62 @@ mod tests {
         let err = ensure_set_param_forward_applied(&reply, &node_id)
             .expect_err("daemon rejection should fail strict forwarding");
         assert!(err.to_string().contains("failed to apply SetParam"));
+    }
+
+    // -------------------------------------------------------------------
+    // AddNode reply validation (rescue of #1757, addresses #1682)
+    // -------------------------------------------------------------------
+    //
+    // The bug: coordinator's `Ok(_) =>` arm in the AddNode dispatch
+    // (lib.rs:1558 pre-fix) accepted any successful `send_and_receive`
+    // reply and committed dataflow state, even when the daemon returned
+    // an `AddNodeResult(Err(...))` or a stale reply from a different
+    // request. The three tests below pin the validator's contract: it
+    // must accept ONLY a successful `AddNodeResult` and forward every
+    // other shape as an error to the call site (which then surfaces it
+    // to the CLI without bringing down the coordinator's main loop).
+
+    #[test]
+    fn add_node_reply_accepts_daemon_success() {
+        let reply = serde_json::to_vec(&DaemonCoordinatorReply::AddNodeResult(Ok(()))).unwrap();
+        let node_id: dora_core::config::NodeId = "filter".to_string().into();
+
+        ensure_add_node_applied(&reply, &node_id).expect("successful AddNode reply should pass");
+    }
+
+    #[test]
+    fn add_node_reply_reports_daemon_rejection() {
+        let reply = serde_json::to_vec(&DaemonCoordinatorReply::AddNodeResult(Err(
+            "failed to spawn node".to_string(),
+        )))
+        .unwrap();
+        let node_id: dora_core::config::NodeId = "filter".to_string().into();
+
+        let err = ensure_add_node_applied(&reply, &node_id)
+            .expect_err("daemon rejection should fail AddNode forwarding");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("failed to add node") && msg.contains("filter"),
+            "error must name the operation and node: {msg}"
+        );
+    }
+
+    #[test]
+    fn add_node_reply_rejects_wrong_reply_variant() {
+        // This is the regression scenario for #1682: the daemon returned
+        // a stale or otherwise unrelated reply variant (here:
+        // `SetParamResult(Ok)`). Before the fix, the coordinator's
+        // `Ok(_) =>` arm would accept this and commit state for a node
+        // the daemon never actually added.
+        let reply = serde_json::to_vec(&DaemonCoordinatorReply::SetParamResult(Ok(()))).unwrap();
+        let node_id: dora_core::config::NodeId = "filter".to_string().into();
+
+        let err = ensure_add_node_applied(&reply, &node_id)
+            .expect_err("unexpected reply variant should fail AddNode forwarding");
+        assert!(
+            err.to_string().contains("unexpected daemon reply"),
+            "error must call out the wrong-reply-type failure mode: {err}"
+        );
     }
 
     #[test]

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1770,7 +1770,13 @@ impl Daemon {
                 if let Err(err) = &result {
                     tracing::error!(%dataflow_id, %node_id, "AddNode failed: {err:?}");
                 }
-                let _ = reply_tx.send(None);
+                // Return a specific `AddNodeResult` variant so the
+                // coordinator can validate the reply against its
+                // expected request, instead of treating any non-error
+                // reply as success (#1682, rescue of #1757).
+                let reply =
+                    DaemonCoordinatorReply::AddNodeResult(result.map_err(|err| format!("{err:?}")));
+                let _ = reply_tx.send(Some(reply));
                 RunStatus::Continue
             }
             DaemonCoordinatorEvent::RemoveNode {

--- a/libraries/message/src/daemon_to_coordinator.rs
+++ b/libraries/message/src/daemon_to_coordinator.rs
@@ -202,6 +202,14 @@ pub enum DaemonCoordinatorReply {
         notify: Option<tokio::sync::oneshot::Sender<()>>,
     },
     Logs(Result<Vec<u8>, String>),
+    /// Reply for `DaemonCoordinatorEvent::AddNode`. Previously the daemon
+    /// returned `None` and the coordinator accepted any successful TCP
+    /// response as proof that AddNode applied, even a `SetParamResult` or
+    /// other unrelated reply — committing state for a node the daemon
+    /// may have rejected (#1682). This variant lets the coordinator
+    /// pattern-match a specific reply and forward daemon errors to the
+    /// CLI instead of corrupting the dataflow state. Rescue of #1757.
+    AddNodeResult(Result<(), String>),
     RestartNodeResult(Result<(), String>),
     StopNodeResult(Result<(), String>),
     SetParamResult(Result<(), String>),


### PR DESCRIPTION
## Summary

Rescues @imwyvern's #1757 against current `main`, addressing both items in @phil-opp's 2026-04-28 review (which left it `waiting-for-author` for 3 weeks). Fixes #1682.

## The bug

`binaries/coordinator/src/lib.rs:1558` (pre-fix) had:

```rust
match conn.send_and_receive(&msg).await {
    Ok(_) => {
        dataflow.node_to_daemon.insert(node_id.clone(), did);
        dataflow.descriptor.nodes.push(original_node);
        dataflow.nodes.insert(node_id.clone(), resolved_node);
        Ok(ControlRequestReply::NodeAdded { ... })
    }
    ...
}
```

The `Ok(_)` arm accepted **any** successful TCP reply as proof that AddNode applied. The daemon's handler actually sent `reply_tx.send(None)` — a null reply — and the coordinator still committed state. When the daemon's connection happened to be carrying a stale `SetParamResult` or other variant (concurrent requests against a flaky daemon), the coordinator committed AddNode state for a node the daemon never actually added — exactly the failure mode reported in #1682:

```
$ dora node add  <node>          # times out
$ dora node list                  # <node> shows as present
$ dora node remove <node>         # corrupt: daemon doesn't know about it
```

## Three coordinated changes

1. **`libraries/message/src/daemon_to_coordinator.rs`** — new `DaemonCoordinatorReply::AddNodeResult(Result<(), String>)` variant so the daemon can identify its AddNode reply specifically.

2. **`binaries/daemon/src/lib.rs`** — the `DaemonCoordinatorEvent::AddNode` handler now sends `Some(AddNodeResult(...))` instead of `None`.

3. **`binaries/coordinator/src/lib.rs`** —
   - New `ensure_add_node_applied` helper validates the reply is specifically `AddNodeResult`.
   - The call site funnels the validator's error into the existing `Err` arm of `result`, which the coordinator's main loop sends back to the CLI as a `ControlRequestReply::Error`.
   - **Critically:** the error does **NOT** propagate via `?` past the dispatch arm. Addresses @phil-opp's first review comment about not tearing down the coordinator's main loop on a recoverable per-request failure.

## How phil's two review concerns were addressed

| Concern (2026-04-28) | This rescue |
|---|---|
| "This brings the whole coordinator down on error, no? We should instead forward the result to the CLI and let it deal with the failure." | Validator's `Err` is converted into the `Err` arm of `result`, which becomes `ControlRequestReply::Error` to the CLI. Coordinator loop continues. No `?` propagation. |
| "These tests are not testing anything non-trivial. Ideally, there would be a test that fails before this PR and succeeds after this PR." | The third test (`add_node_reply_rejects_wrong_reply_variant`) directly captures the #1682 regression scenario: a `SetParamResult(Ok)` reply (the exact failure mode that caused state corruption) must be rejected with "unexpected daemon reply". If the validator is removed or weakened, the test fails. Full e2e against a mock daemon would require extracting the AddNode handler from `start_inner`'s async loop — out of scope for the rescue; called out in the commit message. |

## What did NOT change

- **No new public API.** The reply enum gains one variant alongside the existing `SetParamResult` / `DeleteParamResult` pattern.
- **No happy-path change.** Successful AddNode still returns `ControlRequestReply::NodeAdded { dataflow_id, node_id }` to the CLI exactly as before.
- **No new dependencies.**
- **No semver-affecting type changes.**

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --exclude dora-{node-api,operator-api,ros2-bridge}-python -- -D warnings`
- [x] `cargo test -p dora-coordinator --lib add_node_reply` — **3/3 new tests pass**
- [x] `cargo test -p dora-coordinator -p dora-daemon -p dora-message --lib` — 103+/all pass
- [x] `cargo check --examples`
- [ ] CI green
- [ ] Manual verification against the #1682 repro recipe (`dora up` → `dora build examples/dynamic-add-remove/dataflow.yml --uv` → `dora start --detach --name demo` → `dora node add <node>`) shows daemon errors as CLI-visible failures instead of timeouts + state corruption

## Credits

- Original PR: #1757 by @imwyvern (Wesley) — protocol shape and daemon-side change preserved verbatim
- Review: @phil-opp's 2026-04-28 feedback drove the coordinator-side error-forwarding shape and the regression-style test

Closes #1682. Closes #1757 by replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
