### PR TITLE
fix(coordinator): validate remove node daemon replies

### DIFF
--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -1651,35 +1651,39 @@ async fn start_inner(
                                             match daemon_connections.get_mut(daemon_id) {
                                                 Some(conn) => {
                                                     match conn.send_and_receive(&msg).await {
-                                                        Ok(_) => {
-                                                            // TODO: validate the daemon reply
-                                                            // is specifically a successful
-                                                            // `RemoveNodeResult`, parallel to
-                                                            // the AddNode fix (#1682, rescue of
-                                                            // #1757). Same `Ok(_)` shape can
-                                                            // accept a stale or wrong-variant
-                                                            // reply and corrupt state. Tracked
-                                                            // separately to keep this rescue
-                                                            // panel-faithful to #1757's scope.
-                                                            // Clean up coordinator state
-                                                            // (inverse of AddNode inserts)
-                                                            if let Some(dataflow) =
-                                                                running_dataflows
-                                                                    .get_mut(&dataflow_id)
-                                                            {
-                                                                dataflow
-                                                                    .node_to_daemon
-                                                                    .remove(&node_id);
-                                                                dataflow
-                                                                    .descriptor
-                                                                    .nodes
-                                                                    .retain(|n| n.id != node_id);
-                                                                dataflow.nodes.remove(&node_id);
+                                                        Ok(reply_raw) => {
+                                                            match ensure_remove_node_applied(
+                                                                &reply_raw, &node_id,
+                                                            ) {
+                                                                Ok(()) => {
+                                                                    // Clean up coordinator state
+                                                                    // (inverse of AddNode inserts)
+                                                                    if let Some(dataflow) =
+                                                                        running_dataflows
+                                                                            .get_mut(&dataflow_id)
+                                                                    {
+                                                                        dataflow
+                                                                            .node_to_daemon
+                                                                            .remove(&node_id);
+                                                                        dataflow
+                                                                            .descriptor
+                                                                            .nodes
+                                                                            .retain(|n| {
+                                                                                n.id != node_id
+                                                                            });
+                                                                        dataflow
+                                                                            .nodes
+                                                                            .remove(&node_id);
+                                                                    }
+                                                                    Ok(
+                                                                        ControlRequestReply::NodeRemoved {
+                                                                            dataflow_id,
+                                                                            node_id,
+                                                                        },
+                                                                    )
+                                                                }
+                                                                Err(e) => Err(e),
                                                             }
-                                                            Ok(ControlRequestReply::NodeRemoved {
-                                                                dataflow_id,
-                                                                node_id,
-                                                            })
                                                         }
                                                         Err(e) => Err(eyre!(
                                                             "daemon dispatch failed: {e}"
@@ -3501,6 +3505,27 @@ fn ensure_delete_param_forward_applied(
     }
 }
 
+/// Validate that the daemon's reply to `DaemonCoordinatorEvent::RemoveNode`
+/// is a successful `RemoveNodeResult`. Returns `Err` for both an explicit
+/// daemon failure and an unexpected reply variant; callers should forward
+/// the error to the CLI as a `ControlRequestReply::Error` and NOT use `?`
+/// to bubble out of the coordinator's main loop. Parallel to
+/// `ensure_add_node_applied` (#1873). Closes #1874.
+fn ensure_remove_node_applied(
+    reply_raw: &[u8],
+    node_id: &dora_core::config::NodeId,
+) -> eyre::Result<()> {
+    match serde_json::from_slice(reply_raw)? {
+        DaemonCoordinatorReply::RemoveNodeResult(Ok(())) => Ok(()),
+        DaemonCoordinatorReply::RemoveNodeResult(Err(err)) => {
+            Err(eyre!("daemon failed to remove node `{node_id}`: {err}"))
+        }
+        other => Err(eyre!(
+            "unexpected daemon reply for RemoveNode on node `{node_id}`: {other:?}"
+        )),
+    }
+}
+
 fn schedule_param_replay_for_ready_dataflow(
     dataflow_id: DataflowId,
     dataflow: &RunningDataflow,
@@ -4821,6 +4846,14 @@ mod tests {
             err.to_string().contains("unexpected daemon reply"),
             "error must call out the wrong-reply-type failure mode: {err}"
         );
+
+        let reply = serde_json::to_vec(&DaemonCoordinatorReply::RemoveNodeResult(Ok(()))).unwrap();
+        let err = ensure_add_node_applied(&reply, &node_id)
+            .expect_err("RemoveNodeResult reply must not be accepted by AddNode validator");
+        assert!(
+            err.to_string().contains("unexpected daemon reply"),
+            "error must call out the wrong-reply-type failure mode: {err}"
+        );
     }
 
     #[test]
@@ -4831,6 +4864,53 @@ mod tests {
         let err = ensure_delete_param_forward_applied(&reply, &node_id)
             .expect_err("unexpected reply variant should fail strict forwarding");
         assert!(err.to_string().contains("unexpected daemon reply"));
+    }
+
+    #[test]
+    fn remove_node_reply_accepts_daemon_success() {
+        let reply = serde_json::to_vec(&DaemonCoordinatorReply::RemoveNodeResult(Ok(()))).unwrap();
+        let node_id: dora_core::config::NodeId = "camera".to_string().into();
+
+        ensure_remove_node_applied(&reply, &node_id)
+            .expect("successful RemoveNode reply should pass");
+    }
+
+    #[test]
+    fn remove_node_reply_reports_daemon_rejection() {
+        let reply = serde_json::to_vec(&DaemonCoordinatorReply::RemoveNodeResult(Err(
+            "node `camera` not found in running dataflow".to_string(),
+        )))
+        .unwrap();
+        let node_id: dora_core::config::NodeId = "camera".to_string().into();
+
+        let err = ensure_remove_node_applied(&reply, &node_id)
+            .expect_err("daemon rejection should fail RemoveNode forwarding");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("failed to remove node") && msg.contains("camera"),
+            "error must name the operation and node: {msg}"
+        );
+    }
+
+    #[test]
+    fn remove_node_reply_rejects_wrong_reply_variant() {
+        let reply = serde_json::to_vec(&DaemonCoordinatorReply::SetParamResult(Ok(()))).unwrap();
+        let node_id: dora_core::config::NodeId = "camera".to_string().into();
+
+        let err = ensure_remove_node_applied(&reply, &node_id)
+            .expect_err("unexpected reply variant should fail RemoveNode forwarding");
+        assert!(
+            err.to_string().contains("unexpected daemon reply"),
+            "error must call out the wrong-reply-type failure mode: {err}"
+        );
+
+        let reply = serde_json::to_vec(&DaemonCoordinatorReply::AddNodeResult(Ok(()))).unwrap();
+        let err = ensure_remove_node_applied(&reply, &node_id)
+            .expect_err("AddNodeResult reply must not be accepted by RemoveNode validator");
+        assert!(
+            err.to_string().contains("unexpected daemon reply"),
+            "error must call out the wrong-reply-type failure mode: {err}"
+        );
     }
 
     // -------------------------------------------------------------------

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1785,8 +1785,12 @@ impl Daemon {
                 grace_duration,
             } => {
                 tracing::info!(%dataflow_id, %node_id, "removing node from running dataflow");
-                if let Some(dataflow) = self.running.get_mut(&dataflow_id) {
-                    let _ = dataflow.stop_single_node(&node_id, &self.clock, grace_duration);
+                let result: eyre::Result<()> = (|| {
+                    let dataflow = self
+                        .running
+                        .get_mut(&dataflow_id)
+                        .ok_or_else(|| eyre!("no running dataflow with ID `{dataflow_id}`"))?;
+                    dataflow.stop_single_node(&node_id, &self.clock, grace_duration)?;
 
                     // Clean up routing tables: remove all mappings where this
                     // node is a source, and close inputs on downstream nodes.
@@ -1818,8 +1822,16 @@ impl Daemon {
                     // Remove from stored descriptor (inverse of AddNode
                     // push) so descriptor-based lookups stay consistent.
                     dataflow.descriptor.nodes.retain(|n| n.id != node_id);
+                    Ok(())
+                })();
+
+                if let Err(err) = &result {
+                    tracing::error!(%dataflow_id, %node_id, "RemoveNode failed: {err:?}");
                 }
-                let _ = reply_tx.send(None);
+                let reply = DaemonCoordinatorReply::RemoveNodeResult(
+                    result.map_err(|err| format!("{err:?}")),
+                );
+                let _ = reply_tx.send(Some(reply));
                 RunStatus::Continue
             }
             DaemonCoordinatorEvent::AddMapping {

--- a/libraries/message/src/daemon_to_coordinator.rs
+++ b/libraries/message/src/daemon_to_coordinator.rs
@@ -212,6 +212,7 @@ pub enum DaemonCoordinatorReply {
     AddNodeResult(Result<(), String>),
     RestartNodeResult(Result<(), String>),
     StopNodeResult(Result<(), String>),
+    RemoveNodeResult(Result<(), String>),
     SetParamResult(Result<(), String>),
     DeleteParamResult(Result<(), String>),
     StartTopicDebugStreamResult(Result<(), String>),


### PR DESCRIPTION
Closes #1874.

## Summary
- adds an explicit `RemoveNodeResult` daemon reply
- returns RemoveNode success/failure from the daemon instead of `None`
- validates the exact `RemoveNodeResult(Ok(()))` reply before the coordinator removes node state
- adds regression tests for success, daemon rejection, and wrong reply variants

## Validation
- `cargo fmt --all`
- `cargo fmt --all -- --check` -> passed after rebase
- `cargo check -p dora-daemon -p dora-coordinator -p dora-message` -> passed after rebase
- `cargo test -p dora-coordinator remove_node_reply --lib` -> 3 passed after rebase
- `cargo test -p dora-coordinator --lib` -> 66 passed after rebase
- `cargo test -p dora-daemon --lib` -> 32 passed after rebase
- `cargo clippy -p dora-daemon -p dora-message -- -D warnings` -> passed after rebase
- `cargo clippy -p dora-coordinator -- -D warnings -A clippy::unnecessary_sort_by` -> passed after rebase
- `git diff --check` -> passed
- `git diff origin/main..HEAD --check` -> passed after rebase
- `git diff origin/main..HEAD | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found after rebase
- `gitleaks protect --redact --verbose` -> no leaks found
- `gitleaks protect --staged --redact --verbose` -> no leaks found before the original commit

## Not run
- End-to-end daemon/coordinator integration was not run locally.
- Strict `cargo clippy -p dora-daemon -p dora-coordinator -p dora-message -- -D warnings` on local rustc 1.95 fails on an unrelated existing `clippy::unnecessary_sort_by` lint at `binaries/coordinator/src/lib.rs:3644`; I did not change that unrelated code.
