### PR TITLE
feat(api): add node.timestamp() accessor for the node's HLC (rescue of #1789)

### DIFF
--- a/apis/python/node/dora/__init__.pyi
+++ b/apis/python/node/dora/__init__.pyi
@@ -1,3 +1,4 @@
+import datetime
 import typing
 
 import pyarrow
@@ -148,6 +149,10 @@ class Node:
         """Returns how many times this node has been restarted.
 
         Returns 0 on the first run, 1 after the first restart, etc."""
+
+    def timestamp(self) -> "datetime.datetime":
+        """Returns the current timestamp from the node's Hybrid Logical Clock
+        as a UTC datetime object."""
 
     def merge_external_events(self, subscription: dora.Ros2Subscription) -> None:
         """Merge an external event stream with dora main loop.

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -8,7 +8,9 @@ use arrow::pyarrow::{FromPyArrow, ToPyArrow};
 use dora_node_api::dora_core::config::{DataId, NodeId};
 use dora_node_api::merged::{MergeExternalSend, MergedEvent};
 use dora_node_api::{DataflowId, DoraNode, EventStream, TryRecvError, init_tracing};
-use dora_operator_api_python::{DelayedCleanup, NodeCleanupHandle, PyEvent, pydict_to_metadata};
+use dora_operator_api_python::{
+    DelayedCleanup, NodeCleanupHandle, PyEvent, datetime_module, pydict_to_metadata,
+};
 use dora_ros2_bridge_python::Ros2Subscription;
 use eyre::{Context, ContextCompat};
 
@@ -686,6 +688,45 @@ impl Node {
     /// :rtype: int
     pub fn restart_count(&self) -> u32 {
         self.node.get_mut().restart_count()
+    }
+
+    /// Returns the current timestamp from the node's Hybrid Logical Clock
+    /// as a UTC datetime object.
+    ///
+    /// Use this against ``event["metadata"]["timestamp"]`` from an INPUT
+    /// event to compute per-event processing latency against the same
+    /// clock dora uses on its data plane.
+    ///
+    /// **Resolution & ordering caveats** — Python ``datetime`` is
+    /// microsecond-resolution and only carries the HLC's physical
+    /// component; its logical counter is dropped. Two messages produced
+    /// in the same HLC microsecond will compare equal here even though
+    /// the underlying HLC distinguishes them. For strict ordering use
+    /// the Rust API (``DoraNode::timestamp() -> uhlc::Timestamp``).
+    ///
+    /// **Threading** — like every other ``Node`` method, this acquires
+    /// the node's internal mutex via ``try_lock`` and will panic if
+    /// another thread is mid-call into the same ``Node`` instance. The
+    /// Python GIL serialises in-process calls, so this is only
+    /// reachable if a caller releases the GIL (e.g. via
+    /// ``allow_threads``) and another thread re-enters the same Node.
+    /// Don't do that.
+    ///
+    /// :rtype: datetime.datetime
+    pub fn timestamp(&self, py: Python) -> eyre::Result<Py<PyAny>> {
+        let ts = self.node.get_mut().timestamp();
+        let system_time = ts.get_time().to_system_time();
+        let duration_since_epoch = system_time
+            .duration_since(std::time::UNIX_EPOCH)
+            .context("Failed to calculate duration since epoch")?;
+        let total_seconds = duration_since_epoch.as_secs() as f64
+            + duration_since_epoch.subsec_micros() as f64 / 1_000_000.0;
+        let dt_module = datetime_module(py).context("Failed to import datetime module")?;
+        let datetime_class = dt_module.getattr("datetime")?;
+        let utc_timezone = dt_module.getattr("timezone")?.getattr("utc")?;
+        let py_datetime =
+            datetime_class.call_method1("fromtimestamp", (total_seconds, utc_timezone))?;
+        Ok(py_datetime.unbind())
     }
 
     /// Merge an external event stream with dora main loop.

--- a/apis/python/operator/src/lib.rs
+++ b/apis/python/operator/src/lib.rs
@@ -22,7 +22,7 @@ use std::time::UNIX_EPOCH;
 /// Cached Python `datetime` module to avoid repeated `PyModule::import` on the hot path.
 static DATETIME_MODULE: PyOnceLock<Py<PyModule>> = PyOnceLock::new();
 
-fn datetime_module<'py>(py: Python<'py>) -> PyResult<&'py Bound<'py, PyModule>> {
+pub fn datetime_module<'py>(py: Python<'py>) -> PyResult<&'py Bound<'py, PyModule>> {
     Ok(DATETIME_MODULE
         .get_or_try_init(py, || PyModule::import(py, "datetime").map(|m| m.unbind()))?
         .bind(py))

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -1149,6 +1149,20 @@ impl DoraNode {
         self.restart_count
     }
 
+    /// Returns the current timestamp from the node's Hybrid Logical Clock.
+    ///
+    /// This generates a new HLC timestamp, which combines the physical
+    /// wall-clock time with a logical counter to ensure uniqueness and
+    /// monotonicity even across nodes. The HLC is the same clock dora
+    /// stamps every outgoing message with, so this is the right value
+    /// to subtract from an input event's `metadata.timestamp` when
+    /// measuring per-event processing latency — using
+    /// `std::time::SystemTime::now()` instead would mix two unrelated
+    /// clocks and give meaningless results across daemons.
+    pub fn timestamp(&self) -> uhlc::Timestamp {
+        self.clock.new_timestamp()
+    }
+
     /// Send a structured log message.
     ///
     /// Outputs a JSONL line to stdout that the daemon parses automatically.
@@ -1689,6 +1703,38 @@ mod tests {
     fn new_goal_id_returns_valid_uuid() {
         let id = DoraNode::new_goal_id();
         uuid::Uuid::parse_str(&id).expect("should be valid UUID");
+    }
+
+    /// `DoraNode::timestamp()` must read from the SAME HLC the node
+    /// uses to stamp outgoing messages. If a refactor accidentally
+    /// gives `timestamp()` its own clock, the latency-measurement use
+    /// case in the docstring silently breaks (subtracting against an
+    /// `event.metadata.timestamp` from the data plane would mix two
+    /// unrelated HLCs). Guard by asserting two calls share an HLC ID
+    /// and that the second reads strictly later than the first.
+    ///
+    /// The strict `t2 > t1` assertion holds by HLC construction: if
+    /// the wall clock advanced between calls, the physical component
+    /// strictly increases; if not, the logical counter bumps. The
+    /// lexicographic ordering on `uhlc::Timestamp` puts `t2` strictly
+    /// after `t1` in either case, so this assertion does not flake on
+    /// fast machines whose OS clock rounds both calls to the same tick.
+    #[test]
+    fn timestamp_uses_node_clock_and_is_monotonic() {
+        let (node, events, _rx) = test_node();
+        let t1 = node.timestamp();
+        let t2 = node.timestamp();
+        assert_eq!(
+            t1.get_id(),
+            t2.get_id(),
+            "two timestamp() calls must come from the same HLC instance",
+        );
+        assert!(
+            t2 > t1,
+            "HLC timestamps must be strictly monotonic: {t1:?} >= {t2:?}"
+        );
+        drop(node);
+        drop(events);
     }
 
     /// Helper: create a minimal test node with a channel output.


### PR DESCRIPTION
## Summary

Rescues @oceanusxiv's #1789 against current `main`. The PR sat 18 days with no reviews and cherry-picks cleanly, so this is a near-verbatim re-application plus expanded docstrings and a regression test.

## Why

`DoraNode` already maintains an internal `uhlc::HLC` clock that stamps every outgoing message, but user code had no way to read it. Without this method, a node measuring per-event latency falls back to `std::time::SystemTime::now()` — a different physical clock from the HLC, so subtracting that from `event.metadata.timestamp` mixes two unrelated clocks and gives meaningless results across daemons.

Three concrete use cases from #1789:

1. `latency = node.timestamp() - event.metadata.timestamp` measured against the same clock dora's data plane uses.
2. Correlating log lines / external observations with the HLC.
3. Profiling node processing time without introducing a second clock source.

## Changes

| File | Change |
|------|--------|
| `apis/rust/node/src/node/mod.rs` | `pub fn DoraNode::timestamp() -> uhlc::Timestamp` (one-liner: `self.clock.new_timestamp()`). Docstring spells out the "use HLC, not `SystemTime::now()`" rule. |
| `apis/python/node/src/lib.rs` | `Node.timestamp() -> datetime.datetime` (UTC-aware). Docstring notes microsecond resolution and that the HLC logical counter is dropped — strict-ordering callers should use the Rust API. |
| `apis/python/operator/src/lib.rs` | Promote `datetime_module()` from private to `pub` so the node crate reuses the cached `PyModule::import("datetime")` instead of re-importing on every call. Same cache pattern dora already uses for outgoing metadata conversions. |
| `apis/python/node/dora/__init__.pyi` | Type stub for `timestamp()`. |

## What was added on top of #1789

- Both docstrings expanded with the load-bearing "use the HLC, not `SystemTime`" guidance and (Python only) the resolution caveats.
- New regression test `node::tests::timestamp_uses_node_clock_and_is_monotonic` asserts (a) two consecutive `timestamp()` calls share an HLC ID — i.e., they read the *node's* clock, not a freshly-created one — and (b) are strictly monotonic. Without this, a refactor that gives `timestamp()` its own clock would silently break the latency-measurement use case spelled out in the docstring.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --exclude dora-{node-api,operator-api,ros2-bridge}-python -- -D warnings`
- [x] `cargo test -p dora-node-api --lib` — **83/83 pass** including the new `timestamp_uses_node_clock_and_is_monotonic`
- [x] `cargo check --examples`
- [ ] CI green

## Credits

- Original design + code: @oceanusxiv in #1789
- Closes #1789 by replacement

🤖 Generated with [Claude Code](https://claude.com/claude-code)