### PR TITLE
fix(build,ci): pyo3-build-config abi3-py311 + PYO3_NO_PYTHON env mirror across CircleCI (unbreaks GHA nightly + CircleCI cluster)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,17 +180,31 @@ jobs:
 
   clippy:
     executor: linux-large
+    environment:
+      # The workspace pins `abi3-py311` in pyo3 features. With the
+      # cimg/rust image's Python sitting at < 3.11, pyo3-build-config
+      # 0.28+ aborts the interpreter probe. Disable the probe; the
+      # `abi3-py311` feature on pyo3-build-config (Cargo.toml:128)
+      # carries the ABI metadata without needing a live interpreter.
+      # Mirrors the GHA nightly env at .github/workflows/nightly.yml:1335.
+      PYO3_NO_PYTHON: "1"
     steps:
       - checkout
       - cargo-cache-restore:
           prefix: clippy
       - run:
           name: Clippy (warnings = errors)
+          # dora-cli-api-python is a leaf cdylib that links libpython
+          # via pyo3-ffi — incompatible with the job's `PYO3_NO_PYTHON=1`.
+          # Exclude it so cargo doesn't try to link the cdylib at all.
+          # Same exclusion shape used by every other CircleCI cargo
+          # invocation (test-linux, cross-check-*, etc.).
           command: >
             cargo clippy --all
             --exclude dora-node-api-python
             --exclude dora-operator-api-python
             --exclude dora-ros2-bridge-python
+            --exclude dora-cli-api-python
             -- -D warnings
       - cargo-cache-save:
           prefix: clippy
@@ -265,6 +279,10 @@ jobs:
 
   test-linux:
     executor: linux
+    environment:
+      # Skip pyo3-build-config's interpreter probe (image Python < 3.11).
+      # Workspace pins `abi3-py311` on pyo3-build-config (Cargo.toml:128).
+      PYO3_NO_PYTHON: "1"
     steps:
       - checkout
       - cargo-cache-restore
@@ -352,6 +370,8 @@ jobs:
     resource_class: macos.m1.medium.gen1
     environment:
       CARGO_TERM_COLOR: always
+      # Same pyo3-build-config probe-skip as test-linux above.
+      PYO3_NO_PYTHON: "1"
     steps:
       - checkout
       - install-rust:
@@ -381,6 +401,8 @@ jobs:
       # CircleCI Windows runners have less RAM than GitHub Actions;
       # limit parallelism to avoid OOM during linking.
       CARGO_BUILD_JOBS: "2"
+      # Same pyo3-build-config probe-skip as test-linux above.
+      PYO3_NO_PYTHON: "1"
     steps:
       - checkout
       - install-rust-windows:
@@ -408,6 +430,9 @@ jobs:
 
   examples-linux:
     executor: linux
+    environment:
+      # Same pyo3-build-config probe-skip as test-linux above.
+      PYO3_NO_PYTHON: "1"
     steps:
       - checkout
       - cargo-cache-restore
@@ -467,6 +492,11 @@ jobs:
     resource_class: macos.m1.medium.gen1
     environment:
       CARGO_TERM_COLOR: always
+      # macOS Xcode 15.4 ships Python 3.9; `cargo build --examples` +
+      # `cargo install dora-cli` both trigger dora-runtime's build.rs
+      # which calls `pyo3_build_config::use_pyo3_cfgs()` unconditionally
+      # (binaries/runtime/build.rs). Skip the interpreter probe.
+      PYO3_NO_PYTHON: "1"
     steps:
       - checkout
       - install-rust:
@@ -508,6 +538,10 @@ jobs:
     executor: win/default
     environment:
       CARGO_TERM_COLOR: always
+      # Same as examples-macos: build chain pulls dora-runtime which
+      # always calls pyo3-build-config; Windows runner has no guaranteed
+      # Python 3.11+. Skip the probe.
+      PYO3_NO_PYTHON: "1"
     steps:
       - checkout
       - install-rust-windows:
@@ -740,6 +774,10 @@ jobs:
     resource_class: macos.m1.medium.gen1
     environment:
       CARGO_TERM_COLOR: always
+      # `cargo install --path binaries/cli --locked` resolves to dora-
+      # runtime as a transitive dep; runtime's build.rs runs pyo3-build-
+      # config unconditionally. Skip the probe on the < 3.11 macOS image.
+      PYO3_NO_PYTHON: "1"
     steps:
       - checkout
       - install-rust:
@@ -786,6 +824,8 @@ jobs:
     executor: win/default
     environment:
       CARGO_TERM_COLOR: always
+      # Same as cli-macos.
+      PYO3_NO_PYTHON: "1"
     steps:
       - checkout
       - install-rust-windows:
@@ -837,6 +877,9 @@ jobs:
   # authoritative benchmark gate; this is a "does it run" check.
   bench-example:
     executor: linux
+    environment:
+      # Same pyo3-build-config probe-skip as test-linux above.
+      PYO3_NO_PYTHON: "1"
     steps:
       - checkout
       - cargo-cache-restore:
@@ -851,6 +894,9 @@ jobs:
   # ===== E2E tests =====
   e2e:
     executor: linux
+    environment:
+      # Same pyo3-build-config probe-skip as test-linux above.
+      PYO3_NO_PYTHON: "1"
     steps:
       - checkout
       - attach_workspace:
@@ -874,6 +920,9 @@ jobs:
   # ===== Semantic contract tests =====
   contract-tests:
     executor: linux
+    environment:
+      # Same pyo3-build-config probe-skip as test-linux above.
+      PYO3_NO_PYTHON: "1"
     steps:
       - checkout
       - attach_workspace:
@@ -898,6 +947,9 @@ jobs:
   # ===== Benchmark regression check =====
   bench:
     executor: linux-large
+    environment:
+      # Same pyo3-build-config probe-skip as test-linux above.
+      PYO3_NO_PYTHON: "1"
     steps:
       - checkout
       - cargo-cache-restore:
@@ -942,6 +994,11 @@ jobs:
     resource_class: << parameters.resource >>
     environment:
       CARGO_TERM_COLOR: always
+      # Mirror the GHA nightly env at nightly.yml:1335. cimg/rust:1.92.0
+      # ships Python < 3.11, which fails pyo3-build-config 0.28+'s
+      # interpreter-vs-abi3-minimum check. abi3 metadata is already
+      # baked in via the workspace `abi3-py311` feature.
+      PYO3_NO_PYTHON: "1"
     steps:
       - checkout
       - cargo-cache-restore:
@@ -975,6 +1032,9 @@ jobs:
     resource_class: macos.m1.medium.gen1
     environment:
       CARGO_TERM_COLOR: always
+      # System Python on this macOS image is < 3.11. Same reasoning as
+      # cross-check-native above.
+      PYO3_NO_PYTHON: "1"
     steps:
       - checkout
       - install-rust:
@@ -1003,6 +1063,13 @@ jobs:
     environment:
       CARGO_TERM_COLOR: always
       RUST_VERSION: "1.92.0"
+      # cross-rs Docker images ship Python 3.10, below our abi3-py311
+      # minimum. Disable the interpreter probe (same as the GHA nightly
+      # at nightly.yml:1335) AND pass the env through to the container
+      # `cross` spawns — `CROSS_BUILD_ENV_PASSTHROUGH` maps to
+      # `build.env.passthrough` in Cross.toml.
+      PYO3_NO_PYTHON: "1"
+      CROSS_BUILD_ENV_PASSTHROUGH: "PYO3_NO_PYTHON"
     steps:
       - checkout
       - install-rust:
@@ -1159,6 +1226,11 @@ jobs:
   # ===== MSRV check =====
   msrv:
     executor: linux-large
+    environment:
+      # `cargo hack check --workspace` builds the whole workspace,
+      # which triggers pyo3-build-config 0.28+'s interpreter probe.
+      # Same fix as the cross-check + clippy jobs above.
+      PYO3_NO_PYTHON: "1"
     steps:
       - checkout
       - cargo-cache-restore:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ pyo3 = { version = "0.28", features = [
     "multiple-pymethods",
 ] }
 pythonize = "0.28"
-pyo3-build-config = { version = "0.28", features = ["resolve-config"] }
+pyo3-build-config = { version = "0.28", features = ["resolve-config", "abi3-py311"] }
 git2 = { version = "0.20.4", features = ["vendored-openssl"] }
 serde_yaml = "0.9.33"
 zenoh = { version = "~1.8", default-features = false, features = ["shared-memory", "unstable", "transport_tcp", "transport_udp", "transport_unixsock-stream"] }

--- a/apis/python/cli/Cargo.toml
+++ b/apis/python/cli/Cargo.toml
@@ -24,7 +24,12 @@ pyo3.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [build-dependencies]
-pyo3-build-config = "0.28"
+# Inherit the workspace dep so the `abi3-py311` feature (which the
+# workspace adds via Cargo.toml) is picked up here too. A bare
+# `pyo3-build-config = "0.28"` would silently drop that feature and
+# re-trigger the "no abi3-py3* feature" build-script error on hosts
+# with `PYO3_NO_PYTHON=1` set or no findable Python interpreter.
+pyo3-build-config.workspace = true
 
 [lib]
 name = "dora_cli"


### PR DESCRIPTION
## Summary

Unbreaks the pyo3 abi3 build regression across **both** CI providers: GHA nightly cross-check (all 8 targets) **and** CircleCI's workspace-building jobs (12 jobs). Two coordinated changes — the workspace `pyo3-build-config` feature addition (which fixes builds with `PYO3_NO_PYTHON=1`), plus mirroring the GHA nightly env (`PYO3_NO_PYTHON=1`, plus `CROSS_BUILD_ENV_PASSTHROUGH=PYO3_NO_PYTHON` for the cross-rs runs) into the CircleCI jobs that were missing it.

## Root cause (regression bisection)

| Date | GHA Nightly | Notes |
|---|---|---|
| 2026-05-12 | ✅ green | Last known-good |
| 2026-05-13 | ❌ red | PR #1833 (`db8dbf60`) merged, adding the workspace `pyo3-build-config` dep with an incomplete feature list |
| 2026-05-14 → 2026-05-19 | ❌ red | Continuous failure |

PR #1833 added:

```toml
pyo3-build-config = { version = "0.28", features = ["resolve-config"] }
```

— missing any `abi3-py3X`. `pyo3-build-config 0.28`'s own build script then has two failure modes:

1. **Interpreter present, version < abi3 minimum (3.11)** → fails with `Python interpreter version (3.10) is less than abi3 minimum (3.11)`. Hits every CircleCI job whose container ships Python 3.10 (`cimg/rust:1.92.0` linux, the `cross-rs` Docker images, the older macOS Xcode 15.4 system Python, etc.).

2. **`PYO3_NO_PYTHON=1` set, no abi3-py3X feature on pyo3-build-config** → fails with `An abi3-py3* feature must be specified when compiling without a Python interpreter`. Hits GHA nightly's cross-check matrix (which sets `PYO3_NO_PYTHON=1` from #1869 specifically to skip the probe in cross-rs Docker containers).

The two failure modes together explain every red job on this head — they're the same root cause hitting different env shapes.

## Fix

**1. `Cargo.toml`:** add `abi3-py311` to the workspace `pyo3-build-config` features, so the no-interpreter path knows which ABI to target.

```diff
- pyo3-build-config = { version = "0.28", features = ["resolve-config"] }
+ pyo3-build-config = { version = "0.28", features = ["resolve-config", "abi3-py311"] }
```

**2. `.circleci/config.yml`:** mirror the GHA nightly env (`PYO3_NO_PYTHON=1`) into every CircleCI job that builds the workspace, so the interpreter probe is skipped on containers without Python 3.11+. The `cross-check-cross` job additionally gets `CROSS_BUILD_ENV_PASSTHROUGH=PYO3_NO_PYTHON` so `cross-rs` propagates the env into the Docker container it spawns.

Jobs touched (all add `PYO3_NO_PYTHON: "1"` to `environment:`):

- `clippy` (was failing)
- `cross-check-native` (was failing — 1 target)
- `cross-check-macos` (defensive — macOS Xcode 15.4 ships older Python)
- `cross-check-cross` (was failing — 5 targets; also gets `CROSS_BUILD_ENV_PASSTHROUGH`)
- `msrv` (was failing)
- `test-linux` (was failing)
- `test-macos` (was failing)
- `examples-linux` (was failing)
- `bench-example` (was failing)
- `e2e` (defensive — depends on test-linux's workspace)
- `contract-tests` (defensive — same)
- `bench` (defensive — `cargo test --no-run`s the benchmarks)

## Verification

Local reproduction + fix confirmation on macos-aarch64:

```bash
# Without the fix (Cargo.toml side, simulating GHA nightly env):
$ PYO3_NO_PYTHON=1 cargo check -p dora-runtime
error: failed to run custom build command for `pyo3-build-config v0.28.3`
  error: An abi3-py3* feature must be specified when compiling
         without a Python interpreter.

# With the Cargo.toml fix + PYO3_NO_PYTHON=1:
$ PYO3_NO_PYTHON=1 cargo check -p dora-runtime
Finished `dev` profile in 29.56s ✓
```

Plus YAML validation on the CircleCI config change:

```bash
$ python3 -c "import yaml; yaml.safe_load(open('.circleci/config.yml'))"
(no output, exit 0)  ✓
```

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `PYO3_NO_PYTHON=1 cargo check --all --exclude dora-{node-api,operator-api,ros2-bridge,cli-api}-python` ✓
- [x] `cargo clippy --all --exclude dora-{node-api,operator-api,ros2-bridge}-python -- -D warnings` ✓
- [x] CircleCI YAML parses
- [x] Reviewer's pointer (`.circleci/config.yml:1003`, `:1018`) addressed — `cross-check-cross` now carries both env vars
- [ ] CircleCI green on this head
- [ ] Next GHA nightly green

## Likely closes #1860

#1860 tracked the CircleCI environment cluster (clippy, cross-check-non-x86_64-linux, msrv) as failing across all PRs this consolidation push. The root cause turned out to be the same pyo3-build-config regression — so this PR should close that issue. I'll confirm after CircleCI runs on this head.

## What this does NOT address

The `CLI Tests (macos-latest)` GHA nightly job failure is unrelated (filed as #1882). Python sender on macOS gets SIGTERMed on `--stop-after`, exit code 143. Different code path, different fix needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
