### PR TITLE
feat(cli): use --node for dora logs node selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ See the [Distributed Deployment Guide](docs/distributed-deployment.md) for clust
 |---------|-------------|
 | `dora list` | List running dataflows (alias: `ps`) |
 | `dora clean` | Remove finished and failed dataflows from the coordinator |
-| `dora logs <ID>` | Show logs for a dataflow or node |
+| `dora logs <ID> [--node <NAME>]` | Show logs for a dataflow or node |
 | `dora top` | Real-time resource monitor (TUI); also `dora inspect top` |
 | `dora topic list` | List topics in a dataflow |
 | `dora topic hz <TOPIC>` | Measure topic publish frequency (TUI) |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -236,7 +236,7 @@ dora cluster down
 | 命令 | 描述 |
 |------|------|
 | `dora list` | 列出运行中的数据流（别名：`ps`） |
-| `dora logs <ID>` | 显示数据流或节点的日志 |
+| `dora logs <ID> [--node <NAME>]` | 显示数据流或节点的日志 |
 | `dora top` | 实时资源监控（TUI）；也可使用 `dora inspect top` |
 | `dora topic list` | 列出数据流中的主题 |
 | `dora topic hz <TOPIC>` | 测量主题发布频率（TUI） |

--- a/binaries/cli/src/command/logs.rs
+++ b/binaries/cli/src/command/logs.rs
@@ -30,7 +30,7 @@ pub struct LogsArgs {
     #[clap(value_name = "UUID_OR_NAME")]
     pub dataflow: Option<String>,
     /// Deprecated positional node name. Use --node instead.
-    #[clap(value_name = "NAME", hide = true)]
+    #[clap(value_name = "NAME", hide = true, conflicts_with_all = ["node", "all_nodes"])]
     pub legacy_node: Option<NodeId>,
     /// Show logs for the given node
     #[clap(long, short = 'n', value_name = "NAME", conflicts_with = "all_nodes")]
@@ -184,7 +184,7 @@ fn resolve_logs_dataflow_identifier(
             Err(err).wrap_err_with(|| {
                 format!(
                     "failed to resolve dataflow `{node}`\n\n  \
-                     hint: if `{node}` is a node name, use `dora logs --node {node}`"
+                     hint: if you intended `{node}` as a node name, use `dora logs --node {node}`"
                 )
             })
         }
@@ -200,7 +200,7 @@ fn find_logs_dataflow_dir(out_dir: &Path, args: &LogsArgs) -> Result<PathBuf> {
             Err(err).wrap_err_with(|| {
                 format!(
                     "failed to resolve local log dataflow `{node}`\n\n  \
-                     hint: if `{node}` is a node name, use `dora logs --local --node {node}`"
+                     hint: if you intended `{node}` as a node name, use `dora logs --local --node {node}`"
                 )
             })
         }

--- a/binaries/cli/src/command/logs.rs
+++ b/binaries/cli/src/command/logs.rs
@@ -24,17 +24,17 @@ use eyre::{Context, Result, bail};
 use uuid::Uuid;
 
 #[derive(Debug, Args)]
-/// Show logs of a given dataflow and node.
+/// Show logs of a given dataflow.
 pub struct LogsArgs {
-    /// Identifier of the dataflow
+    /// Identifier of the dataflow (UUID or name)
     #[clap(value_name = "UUID_OR_NAME")]
     pub dataflow: Option<String>,
-    /// Show logs for the given node (omit with --all-nodes)
-    #[clap(value_name = "NAME")]
+    /// Show logs for the given node
+    #[clap(long, short = 'n', value_name = "NAME", conflicts_with = "all_nodes")]
     pub node: Option<NodeId>,
     /// Show logs from all nodes merged by timestamp.
     /// Streams from coordinator by default, falls back to local out/ directory.
-    #[clap(long)]
+    #[clap(long, conflicts_with = "node")]
     pub all_nodes: bool,
     /// Number of lines to show from the end of the logs
     #[clap(long)]
@@ -102,14 +102,12 @@ impl Executable for LogsArgs {
             return read_local_logs(&self);
         }
 
-        // Single node via coordinator (unchanged)
-        if let Some(ref _node) = self.node
-            && !self.all_nodes
-        {
-            let node = self.node.clone().unwrap();
+        // Single node via coordinator
+        if let Some(ref node) = self.node {
+            let node = node.clone();
             let config = build_log_config(&self)?;
             let session = self.coordinator.connect()?;
-            let uuid = resolve_dataflow_identifier_interactive(&session, self.dataflow.as_deref())?;
+            let uuid = resolve_logs_dataflow_identifier(&session, self.dataflow.as_deref(), None)?;
             return logs(
                 &session,
                 uuid,
@@ -128,8 +126,11 @@ impl Executable for LogsArgs {
         // Try coordinator first, fall back to local
         match self.coordinator.connect() {
             Ok(session) => {
-                let uuid =
-                    resolve_dataflow_identifier_interactive(&session, self.dataflow.as_deref())?;
+                let uuid = resolve_logs_dataflow_identifier(
+                    &session,
+                    self.dataflow.as_deref(),
+                    legacy_positional_node(&self),
+                )?;
                 let config = build_log_config(&self)?;
                 stream_logs_from_coordinator(
                     &session,
@@ -149,24 +150,66 @@ impl Executable for LogsArgs {
     }
 }
 
+fn legacy_positional_node(args: &LogsArgs) -> Option<&str> {
+    args.dataflow
+        .as_deref()
+        .filter(|_| args.node.is_none() && !args.all_nodes)
+}
+
+fn resolve_logs_dataflow_identifier(
+    session: &WsSession,
+    dataflow: Option<&str>,
+    legacy_node_hint: Option<&str>,
+) -> Result<Uuid> {
+    match resolve_dataflow_identifier_interactive(session, dataflow) {
+        Ok(uuid) => Ok(uuid),
+        Err(err) if legacy_node_hint.is_some() => {
+            let node = legacy_node_hint.unwrap();
+            Err(err).wrap_err_with(|| {
+                format!(
+                    "failed to resolve dataflow `{node}`\n\n  \
+                     hint: if `{node}` is a node name, use `dora logs --node {node}`"
+                )
+            })
+        }
+        Err(err) => Err(err),
+    }
+}
+
+fn find_logs_dataflow_dir(out_dir: &Path, args: &LogsArgs) -> Result<PathBuf> {
+    match find_dataflow_dir(out_dir, args.dataflow.as_deref()) {
+        Ok(dir) => Ok(dir),
+        Err(err) if legacy_positional_node(args).is_some() => {
+            let node = legacy_positional_node(args).unwrap();
+            Err(err).wrap_err_with(|| {
+                format!(
+                    "failed to resolve local log dataflow `{node}`\n\n  \
+                     hint: if `{node}` is a node name, use `dora logs --local --node {node}`"
+                )
+            })
+        }
+        Err(err) => Err(err),
+    }
+}
+
 fn read_local_logs(args: &LogsArgs) -> Result<()> {
     let out_dir = Path::new("out");
     if !out_dir.exists() {
         bail!(
             "no out/ directory found in current directory\n\n  \
              hint: local logs are stored in ./out/ when running with `dora run`.\n  \
-             For remote dataflows, connect to the coordinator with `dora logs -d <DATAFLOW>`"
+             For remote dataflows, connect to the coordinator with `dora logs <DATAFLOW>`"
         );
     }
 
     // Find the dataflow directory (most recent if not specified)
-    let dataflow_dir = find_dataflow_dir(out_dir, args.dataflow.as_deref())?;
+    let dataflow_dir = find_logs_dataflow_dir(out_dir, args)?;
 
     let config = build_log_config(args)?;
     let now = Utc::now();
 
     let log_files = match &args.node {
-        Some(node) if !args.all_nodes => find_node_log_files(&dataflow_dir, node)?,
+        Some(node) => find_node_log_files(&dataflow_dir, node)?,
         _ => find_log_files(&dataflow_dir)?,
     };
     if log_files.is_empty() {
@@ -200,16 +243,16 @@ fn follow_local_logs(args: &LogsArgs) -> Result<()> {
         bail!(
             "no out/ directory found in current directory\n\n  \
              hint: local logs are stored in ./out/ when running with `dora run`.\n  \
-             For remote dataflows, connect to the coordinator with `dora logs -d <DATAFLOW>`"
+             For remote dataflows, connect to the coordinator with `dora logs <DATAFLOW>`"
         );
     }
 
-    let dataflow_dir = find_dataflow_dir(out_dir, args.dataflow.as_deref())?;
+    let dataflow_dir = find_logs_dataflow_dir(out_dir, args)?;
     let config = build_log_config(args)?;
     let now = Utc::now();
 
     let files = match &args.node {
-        Some(node) if !args.all_nodes => find_node_log_files(&dataflow_dir, node)?,
+        Some(node) => find_node_log_files(&dataflow_dir, node)?,
         _ => find_log_files(&dataflow_dir)?,
     };
 

--- a/binaries/cli/src/command/logs.rs
+++ b/binaries/cli/src/command/logs.rs
@@ -29,6 +29,9 @@ pub struct LogsArgs {
     /// Identifier of the dataflow (UUID or name)
     #[clap(value_name = "UUID_OR_NAME")]
     pub dataflow: Option<String>,
+    /// Deprecated positional node name. Use --node instead.
+    #[clap(value_name = "NAME", hide = true)]
+    pub legacy_node: Option<NodeId>,
     /// Show logs for the given node
     #[clap(long, short = 'n', value_name = "NAME", conflicts_with = "all_nodes")]
     pub node: Option<NodeId>,
@@ -94,6 +97,8 @@ impl Executable for LogsArgs {
     fn execute(self) -> eyre::Result<()> {
         default_tracing()?;
 
+        reject_legacy_node_arg(&self)?;
+
         // --local always uses local file path
         if self.local {
             if self.follow {
@@ -148,6 +153,17 @@ impl Executable for LogsArgs {
             }
         }
     }
+}
+
+fn reject_legacy_node_arg(args: &LogsArgs) -> Result<()> {
+    if let Some(node) = &args.legacy_node {
+        let dataflow = args.dataflow.as_deref().unwrap_or("<DATAFLOW>");
+        bail!(
+            "positional node argument `{node}` is no longer supported\n\n  \
+             hint: use `dora logs {dataflow} --node {node}` instead"
+        );
+    }
+    Ok(())
 }
 
 fn legacy_positional_node(args: &LogsArgs) -> Option<&str> {

--- a/binaries/cli/src/command/mod.rs
+++ b/binaries/cli/src/command/mod.rs
@@ -326,6 +326,16 @@ mod tests {
     }
 
     #[test]
+    fn reject_logs_legacy_positional_node_with_node_flag() {
+        parse_err(&["dora", "logs", "my-dataflow", "sensor", "--node", "other"]);
+    }
+
+    #[test]
+    fn reject_logs_legacy_positional_node_with_all_nodes_flag() {
+        parse_err(&["dora", "logs", "my-dataflow", "sensor", "--all-nodes"]);
+    }
+
+    #[test]
     fn reject_logs_node_and_all_nodes() {
         parse_err(&[
             "dora",

--- a/binaries/cli/src/command/mod.rs
+++ b/binaries/cli/src/command/mod.rs
@@ -321,8 +321,8 @@ mod tests {
     }
 
     #[test]
-    fn reject_logs_positional_node() {
-        parse_err(&["dora", "logs", "my-dataflow", "sensor"]);
+    fn parse_logs_legacy_positional_node_for_runtime_hint() {
+        parse_ok(&["dora", "logs", "my-dataflow", "sensor"]);
     }
 
     #[test]

--- a/binaries/cli/src/command/mod.rs
+++ b/binaries/cli/src/command/mod.rs
@@ -98,8 +98,7 @@ pub enum Command {
     /// Remove finished and failed dataflows from the coordinator
     #[clap(display_order = 10)]
     Clean(CleanArgs),
-    /// Show logs of a given dataflow and node
-    #[command(allow_missing_positional = true)]
+    /// Show logs of a given dataflow
     #[clap(display_order = 11)]
     Logs(LogsArgs),
     /// Inspect running dataflows in real-time
@@ -298,6 +297,44 @@ mod tests {
     #[test]
     fn parse_logs() {
         parse_ok(&["dora", "logs"]);
+    }
+
+    #[test]
+    fn parse_logs_dataflow() {
+        parse_ok(&["dora", "logs", "my-dataflow"]);
+    }
+
+    #[test]
+    fn parse_logs_node_flag() {
+        parse_ok(&["dora", "logs", "--node", "sensor"]);
+        parse_ok(&["dora", "logs", "-n", "sensor"]);
+    }
+
+    #[test]
+    fn parse_logs_dataflow_node_flag() {
+        parse_ok(&["dora", "logs", "my-dataflow", "--node", "sensor"]);
+    }
+
+    #[test]
+    fn parse_logs_all_nodes() {
+        parse_ok(&["dora", "logs", "my-dataflow", "--all-nodes"]);
+    }
+
+    #[test]
+    fn reject_logs_positional_node() {
+        parse_err(&["dora", "logs", "my-dataflow", "sensor"]);
+    }
+
+    #[test]
+    fn reject_logs_node_and_all_nodes() {
+        parse_err(&[
+            "dora",
+            "logs",
+            "my-dataflow",
+            "--node",
+            "sensor",
+            "--all-nodes",
+        ]);
     }
 
     #[test]

--- a/binaries/daemon/src/pending.rs
+++ b/binaries/daemon/src/pending.rs
@@ -183,7 +183,7 @@ impl PendingNodes {
         let result = match &node_exited_before_subscribe {
             Some(causing_node) => Err(format!(
                 "Node {causing_node} exited before initializing dora. For \
-                more information, run `dora logs {} {causing_node}`.",
+                more information, run `dora logs {} --node {causing_node}`.",
                 self.dataflow_id
             )),
             None => Ok(()),

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -540,16 +540,16 @@ dora clean --format json
 
 #### `dora logs`
 
-Show and follow logs of a dataflow and node.
+Show and follow logs of a dataflow.
 
 ```
-dora logs [UUID_OR_NAME] [NODE] [OPTIONS]
+dora logs [UUID_OR_NAME] [OPTIONS]
 ```
 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `[UUID_OR_NAME]` | | Dataflow UUID or name |
-| `[NODE]` | | Node name (required unless `--all-nodes`) |
+| `--node <NAME>`, `-n` | | Node name |
 | `--all-nodes` | false | Merge logs from all nodes by timestamp |
 | `--tail <N>` | all | Show last N lines |
 | `--follow`, `-f` | false | Stream new log entries |
@@ -572,7 +572,7 @@ dora logs [UUID_OR_NAME] [NODE] [OPTIONS]
 dora logs my-dataflow --all-nodes --follow
 
 # Last 50 errors from a specific node
-dora logs my-dataflow sensor --level error --tail 50
+dora logs my-dataflow --node sensor --level error --tail 50
 
 # Search logs from last 5 minutes
 dora logs my-dataflow --all-nodes --since 5m --grep "timeout"
@@ -581,7 +581,7 @@ dora logs my-dataflow --all-nodes --since 5m --grep "timeout"
 dora logs --local --all-nodes --tail 100
 
 # Post-mortem analysis: errors in time window
-dora logs --local sensor --since 1h --until 30m --level error
+dora logs --local --node sensor --since 1h --until 30m --level error
 ```
 
 **Duration formats:** `30` (seconds), `30s`, `5m`, `1h`, `2d`
@@ -1582,7 +1582,7 @@ dora start dataflow.yml --name my-robot --attach
 dora top
 
 # Logs from any node regardless of machine
-dora logs my-robot inference --follow
+dora logs my-robot --node inference --follow
 
 # List all dataflows
 dora list
@@ -1653,7 +1653,7 @@ dora run dataflow.yml --log-level trace --debug
 dora node info -d my-dataflow problem-node
 
 # 4. Monitor specific node logs
-dora logs my-dataflow problem-node --follow --level debug
+dora logs my-dataflow --node problem-node --follow --level debug
 
 # 5. Check resource usage
 dora top
@@ -1696,5 +1696,5 @@ Read directly with:
 
 ```bash
 dora logs --local --all-nodes
-dora logs --local <node-name> --tail 50
+dora logs --local --node <node-name> --tail 50
 ```

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -82,7 +82,7 @@ dora node info -d my-dataflow problem-node
 dora top
 
 # 5. Stream logs from the problem node
-dora logs my-dataflow problem-node --follow --level debug
+dora logs my-dataflow --node problem-node --follow --level debug
 
 # 6. Is the node producing output?
 dora topic echo -d my-dataflow problem-node/output
@@ -539,13 +539,13 @@ Note: CPU percentages are per-core, so values can exceed 100% for multi-threaded
 
 ```bash
 # Stream logs from a specific node
-dora logs my-dataflow sensor-node --follow
+dora logs my-dataflow --node sensor-node --follow
 
 # Stream logs from all nodes
 dora logs my-dataflow --all-nodes --follow
 
 # Filter by log level
-dora logs my-dataflow sensor-node --follow --level debug
+dora logs my-dataflow --node sensor-node --follow --level debug
 
 # Stream with grep filter
 dora logs my-dataflow --all-nodes --follow --grep "error"
@@ -572,7 +572,7 @@ Read directly:
 dora logs --local --all-nodes
 
 # Specific node, last 50 lines
-dora logs --local sensor-node --tail 50
+dora logs --local --node sensor-node --tail 50
 ```
 
 ### Filtering and Searching
@@ -660,7 +660,7 @@ dora list
 dora top
 
 # 2. Check its logs
-dora logs my-dataflow problem-node --follow --level trace
+dora logs my-dataflow --node problem-node --follow --level trace
 
 # 3. Check if upstream nodes are publishing
 dora topic echo -d my-dataflow upstream-node/output

--- a/docs/distributed-deployment.md
+++ b/docs/distributed-deployment.md
@@ -747,7 +747,7 @@ dora list
 dora top
 
 # View node logs
-dora logs my-app <node-id> --follow
+dora logs my-app --node <node-id> --follow
 
 # Stop a dataflow
 dora stop my-app

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -239,15 +239,15 @@ Read historical logs or stream live logs from a running dataflow.
 
 ```bash
 # Read logs for a specific node (via coordinator)
-dora logs <dataflow_uuid> <node_name>
+dora logs <dataflow_uuid> --node <node_name>
 
 # Read local log files directly
-dora logs --local <node_name>
+dora logs --local --node <node_name>
 dora logs --local --all-nodes
 
 # Stream live logs
-dora logs <dataflow_uuid> <node_name> --follow
-dora logs --local <node_name> --follow
+dora logs <dataflow_uuid> --node <node_name> --follow
+dora logs --local --node <node_name> --follow
 ```
 
 ### Flags
@@ -255,8 +255,9 @@ dora logs --local <node_name> --follow
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--local` | | false | Read from local `out/` directory instead of coordinator |
+| `--node NAME` | `-n` | none | Show logs for a single node |
 | `--all-nodes` | | false | Merge logs from all nodes, sorted by timestamp |
-| `--tail N` | `-n` | all | Show only the last N lines |
+| `--tail N` | | all | Show only the last N lines |
 | `--follow` | `-f` | false | Stream new log entries as they arrive |
 | `--since DURATION` | | none | Only show logs newer than this duration ago |
 | `--until DURATION` | | none | Only show logs older than this duration ago |
@@ -271,13 +272,13 @@ dora logs --local <node_name> --follow
 
 ```bash
 # Logs from the last 5 minutes
-dora logs --local sensor --since 5m
+dora logs --local --node sensor --since 5m
 
 # Logs from 1 hour ago to 30 minutes ago
-dora logs --local sensor --since 1h --until 30m
+dora logs --local --node sensor --since 1h --until 30m
 
 # Last 10 errors from the past hour
-dora logs --local sensor --since 1h --level error --tail 10
+dora logs --local --node sensor --since 1h --level error --tail 10
 ```
 
 Supported duration formats: `30` (seconds), `30s`, `5m`, `1h`, `2d`.
@@ -294,7 +295,7 @@ Supported duration formats: `30` (seconds), `30s`, `5m`, `1h`, `2d`.
 dora logs --local --all-nodes --grep "timeout"
 
 # Find errors from a specific module
-dora logs --local sensor --grep "camera::driver" --level error
+dora logs --local --node sensor --grep "camera::driver" --level error
 ```
 
 ### Filter Pipeline
@@ -979,10 +980,10 @@ dora start examples/python-logging/dataflow.yml --attach
 
 # Or start detached and query logs separately
 dora start examples/python-logging/dataflow.yml
-dora logs <dataflow-id> sensor --follow                    # stream one node
-dora logs <dataflow-id> sensor --follow --level warn       # only warnings
+dora logs <dataflow-id> --node sensor --follow             # stream one node
+dora logs <dataflow-id> --node sensor --follow --level warn # only warnings
 dora logs <dataflow-id> --all-nodes --tail 20              # last 20 lines
-dora logs <dataflow-id> processor --grep "error" --since 5m  # targeted search
+dora logs <dataflow-id> --node processor --grep "error" --since 5m # targeted search
 ```
 
 In distributed mode, logs flow Node -> Daemon -> Coordinator -> CLI over WebSocket. The coordinator buffers log messages until a subscriber connects, so you won't miss logs even if you attach late. YAML-level settings (`min_log_level`, `send_logs_as`, `max_log_size`) work identically since they are applied at the daemon.
@@ -1001,7 +1002,7 @@ In distributed mode, logs flow Node -> Daemon -> Coordinator -> CLI over WebSock
 dora logs --local --all-nodes --tail 20
 
 # Search for warnings in sensor logs
-dora logs --local sensor --grep "high temp"
+dora logs --local --node sensor --grep "high temp"
 
 # Check that rotation created multiple files
 ls -la out/*/log_sensor*.jsonl
@@ -1118,7 +1119,7 @@ dora logs --local --all-nodes --since 5m --level error
 dora logs --local --all-nodes --grep "out of memory"
 
 # Drill into a specific node
-dora logs --local detector --since 2m
+dora logs --local --node detector --since 2m
 
 # Export as JSON for external analysis
 dora run dataflow.yml --log-format json 2>logs.json
@@ -1181,19 +1182,19 @@ dora start dataflow.yml
 # Open targeted log streams in separate terminals:
 
 # Terminal 1: all sensor warnings
-dora logs <dataflow-id> sensor --follow --level warn
+dora logs <dataflow-id> --node sensor --follow --level warn
 
 # Terminal 2: processor errors with text search
-dora logs <dataflow-id> processor --follow --level error --grep "timeout"
+dora logs <dataflow-id> --node processor --follow --level error --grep "timeout"
 
 # Terminal 3: all nodes merged
 dora logs <dataflow-id> --all-nodes --follow
 
 # Terminal 4: historical + live (errors from the last hour, then stream)
-dora logs <dataflow-id> processor --since 1h --level error --follow
+dora logs <dataflow-id> --node processor --since 1h --level error --follow
 
 # Monitor a remote coordinator from another machine:
-dora logs <dataflow-id> sensor --follow --coordinator-addr 192.168.1.10
+dora logs <dataflow-id> --node sensor --follow --coordinator-addr 192.168.1.10
 ```
 
 **How it works internally:**
@@ -1271,6 +1272,6 @@ nodes:
 
 **Use `--local` for post-mortem debugging.** After a crash, `dora logs --local --all-nodes` works without a running coordinator and merges all node logs chronologically.
 
-**Combine `--since` with `--grep` for targeted debugging.** Instead of scrolling through thousands of lines, narrow the window: `dora logs --local sensor --since 5m --grep "error"`.
+**Combine `--since` with `--grep` for targeted debugging.** Instead of scrolling through thousands of lines, narrow the window: `dora logs --local --node sensor --since 5m --grep "error"`.
 
 **Use JSON format for log pipelines.** When feeding logs to external systems (ELK, Grafana Loki, Datadog), use `--log-format json` for structured ingestion.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -68,7 +68,7 @@ dora start dataflow.yml
 
 # Monitor
 dora list          # show running dataflows
-dora logs my-node  # stream node logs
+dora logs --node my-node  # stream node logs
 dora top           # resource usage
 dora clean         # drop finished/failed entries from the list (keeps coordinator running)
 


### PR DESCRIPTION
Fixes #1880

## Summary
- make `dora logs` node selection explicit with `--node/-n`
- reject the old `dora logs DATAFLOW NODE` shape in parser tests
- update CLI/logging docs and user-facing hints to show the new form

## Validation
- `cargo test -p dora-cli command::tests::` passed: 74 passed, 0 failed, 78 filtered out
- `cargo fmt --all -- --check` passed
- `git diff origin/main..HEAD --check` passed
- `gitleaks detect --source . --log-opts=origin/main..HEAD --redact --no-banner` passed: no leaks found
- `cargo clippy -p dora-cli --all-targets -- -A clippy::unnecessary-sort-by -D warnings` passed

Note: strict clippy without the allow currently hits the existing Rust 1.95 `clippy::unnecessary_sort_by` warning in `binaries/coordinator/src/lib.rs:3698`, outside this change.