### PR TITLE
fix(nightly): install numpy for ROS2 bridge embedded Python test

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1440,8 +1440,14 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
-      - name: Install pyarrow
-        run: pip install pyarrow
+      - name: Install pyarrow + numpy
+        # numpy is needed by the embedded Python test fixture
+        # `libraries/extensions/ros2-bridge/python/test_utils.py:3`
+        # which the Rust test `typed::tests::test_python_array_code`
+        # loads via `PyModule::import(py, "test_utils")`. Missing here
+        # surfaced as `ModuleNotFoundError: No module named 'numpy'` in
+        # the 2026-05-20 nightly.
+        run: pip install pyarrow numpy
       - name: Test ROS2 bridge
         run: cargo test -p dora-ros2-bridge-python
       - name: Rust ROS2 Bridge example


### PR DESCRIPTION
## Summary

**Scope reduced after review feedback.** Original branch bundled a fix attempt for #1882 (CLI Tests macOS SIGTERM) alongside a ROS2 numpy install. Reviewer correctly pointed out that the sender.py poll fix didn't actually make the nightly test pass — re-running the exact CI invocation still produced ExitCode(143) on all three nodes. Subsequent local investigation found the bug is deeper than the sender's stop polling. Reverted that part; this PR is now scoped narrowly to the ROS2 numpy fix.

## The fix (1 line)

`typed::tests::test_python_array_code` at `libraries/extensions/ros2-bridge/python/src/typed/mod.rs:58` loads `libraries/extensions/ros2-bridge/python/test_utils.py:3` which does `import numpy as np`. The `ros2-bridge` nightly job installs only pyarrow:

```diff
-        run: pip install pyarrow
+        run: pip install pyarrow numpy
```

That's it.

## What I learned about #1882 (out of scope, posting on the issue)

For anyone following along — the SIGTERM bug is NOT just the sender being fire-and-exit. With current main + a fresh `cargo build --release -p dora-cli`, every variation reproduces:

- Original sender (range(100) × sleep(0.1)) + receiver/transformer with proper `break` on STOP → all three exit 143
- Sender trimmed to range(10) (~1s natural runtime, exits well before --stop-after) → all three still exit 143
- `--stop-after 30s` (20s margin past sender's runtime) → all three still exit 143

The daemon code at `running_dataflow.rs:361-367` does send `NodeEvent::Stop` through each node's subscribe channel before the 10-second SIGTERM grace. But debug prints added to receiver.py after `node = Node()` never appear in the captured stdout, suggesting either `Node()` is blocking on macOS or the daemon's stdout-capture buffers until process exit. Either way the fix is daemon-side, not example-side. #1882 stays open for that.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/nightly.yml'))"` — YAML OK
- [x] `git diff --check --cached` clean
- [ ] Next nightly green on `ROS2 Bridge Examples`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
