### PR TITLE
fix(daemon): emit --rt setup diagnostics before tracing init (#1701)

### DIFF
--- a/binaries/cli/src/command/daemon.rs
+++ b/binaries/cli/src/command/daemon.rs
@@ -124,8 +124,11 @@ impl Executable for Daemon {
                         );
                     }
                 }
+                // Note: the previous "(mlockall applied)" parenthetical here
+                // could lie on macOS where `mlockall` returns ENOTSUP, so the
+                // message now stands on its own.
                 #[cfg(not(target_os = "linux"))]
-                eprintln!("RT: SCHED_FIFO not available on this platform (mlockall applied)");
+                eprintln!("RT: SCHED_FIFO not available on this platform");
             }
             #[cfg(not(unix))]
             eprintln!("RT: --rt flag is only supported on Unix systems");

--- a/binaries/cli/src/command/daemon.rs
+++ b/binaries/cli/src/command/daemon.rs
@@ -81,15 +81,24 @@ impl Executable for Daemon {
         let rt = builder.build().context("tokio runtime failed")?;
 
         // Apply real-time profile if requested.
+        //
+        // These diagnostics use `eprintln!` rather than `tracing::*` because
+        // the tracing subscriber is not yet installed at this point (see the
+        // `init_tracing_subscriber` call below) — `tracing::info!`/`warn!`
+        // calls before global subscriber registration route to
+        // `NoSubscriber` and are silently dropped (#1701). Going to stderr
+        // also ensures these are visible even with `--quiet`, which matters
+        // because a failed RT setup is an operational warning the user must
+        // see.
         if self.rt {
             #[cfg(unix)]
             {
                 // Lock all memory to prevent page faults.
                 let lock_result = unsafe { libc::mlockall(libc::MCL_CURRENT | libc::MCL_FUTURE) };
                 if lock_result == 0 {
-                    tracing::info!("RT: mlockall enabled (memory locked)");
+                    eprintln!("RT: mlockall enabled (memory locked)");
                 } else {
-                    tracing::warn!(
+                    eprintln!(
                         "RT: mlockall failed: {}. Ensure CAP_IPC_LOCK or ulimit -l unlimited.",
                         std::io::Error::last_os_error()
                     );
@@ -107,19 +116,19 @@ impl Executable for Daemon {
                     let sched_result =
                         unsafe { libc::sched_setscheduler(0, libc::SCHED_FIFO, &param) };
                     if sched_result == 0 {
-                        tracing::info!("RT: SCHED_FIFO priority 50 enabled");
+                        eprintln!("RT: SCHED_FIFO priority 50 enabled");
                     } else {
-                        tracing::warn!(
+                        eprintln!(
                             "RT: sched_setscheduler failed: {}. Ensure CAP_SYS_NICE.",
                             std::io::Error::last_os_error()
                         );
                     }
                 }
                 #[cfg(not(target_os = "linux"))]
-                tracing::info!("RT: SCHED_FIFO not available on this platform (mlockall applied)");
+                eprintln!("RT: SCHED_FIFO not available on this platform (mlockall applied)");
             }
             #[cfg(not(unix))]
-            tracing::warn!("RT: --rt flag is only supported on Unix systems");
+            eprintln!("RT: --rt flag is only supported on Unix systems");
         }
 
         #[cfg(feature = "tracing")]

--- a/docs/realtime-tuning.md
+++ b/docs/realtime-tuning.md
@@ -32,6 +32,11 @@ This sets:
 - `mlockall(MCL_CURRENT | MCL_FUTURE)` — pin all memory, prevent page faults
 - `SCHED_FIFO` priority 50 — real-time scheduling for the main daemon thread
 
+The setup writes `RT: ...` success/failure diagnostics to **stderr**
+unconditionally — even with `--quiet`. The flag affects structured log
+filtering, but a failed mlockall or SCHED_FIFO promotion is an operational
+warning that must always be visible.
+
 **Important:** `SCHED_FIFO` applies only to the main thread (the one calling
 `block_on`). Tokio worker threads remain at `SCHED_OTHER`. For full RT
 coverage, use `taskset` + `chrt` to promote the entire process, or use
@@ -239,9 +244,18 @@ dora run examples/benchmark/dataflow.yml --stop-after 30s
 
 ## CI Coverage
 
-The `--rt` / mlock / SCHED_FIFO paths are **manual Tier 2** (see
-[`testing-matrix.md`](testing-matrix.md#soft-real-time)). Not automated
-on GitHub Actions for two reasons:
+**Minimum gate (automated):** `tests/example-smoke.rs::smoke_daemon_rt_emits_setup_messages`
+and `smoke_daemon_rt_quiet_still_emits_setup_messages` (both `#[cfg(unix)]`)
+assert that the RT branch fires and writes its diagnostics to stderr — under
+both default and `--quiet` flags. They do **not** require `CAP_IPC_LOCK` /
+`CAP_SYS_NICE`: the fallback `RT: mlockall failed: …` / `RT: sched_setscheduler
+failed: …` messages are accepted, which is exactly what an unprivileged GHA
+runner produces. This catches regressions where the RT block is bypassed,
+silenced, or reordered (the #1701 silent-fallback class of bug).
+
+**Full validation (manual Tier 2):** Verifying that `mlockall` actually
+locked memory and `SCHED_FIFO` actually promoted the thread is still not
+automated, for two reasons:
 
 1. **Privilege.** `--rt` needs `CAP_SYS_NICE` and `CAP_IPC_LOCK`. GHA
    runners are unprivileged and refuse `sudo` for anything that touches

--- a/tests/example-smoke.rs
+++ b/tests/example-smoke.rs
@@ -1437,6 +1437,70 @@ fn smoke_local_queue_size_latest_data_rust() {
 }
 
 // ---------------------------------------------------------------------------
+// Daemon `--rt` smoke (issue #1701)
+// ---------------------------------------------------------------------------
+//
+// Asserts the RT setup code path actually emits its diagnostic messages.
+// We deliberately do NOT require CAP_IPC_LOCK / CAP_SYS_NICE — unprivileged
+// CI runners hit the documented fallback branch, which is exactly the
+// "useful error vs. silent fallback" guarantee #1701 calls out as untested.
+//
+// Linux exercises both mlockall and SCHED_FIFO branches; macOS exercises
+// the mlockall + "SCHED_FIFO not available" branches. Windows is not
+// covered because the daemon does not run on Windows.
+
+#[test]
+#[cfg(unix)]
+fn smoke_daemon_rt_emits_setup_messages() {
+    ensure_cli_built();
+    let dora = dora_bin();
+
+    // Stale coordinator on 6013 would let the daemon connect and run
+    // indefinitely — we only need ~1s to capture the RT prints.
+    cleanup_stale(&dora);
+
+    let mut child = Command::new(&dora)
+        .args(["daemon", "--rt"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn dora daemon --rt");
+
+    // RT setup runs synchronously at startup, before the daemon tries to
+    // dial the coordinator. ~1.5s is enough for the eprintln!s to land on
+    // the captured stderr pipe.
+    std::thread::sleep(Duration::from_millis(1500));
+
+    let _ = child.kill();
+    let output = child
+        .wait_with_output()
+        .expect("daemon wait_with_output failed");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        stderr.contains("RT: mlockall"),
+        "expected 'RT: mlockall' line on stderr (success or failure variant).\n\
+         stderr was:\n{stderr}"
+    );
+
+    #[cfg(target_os = "linux")]
+    assert!(
+        stderr.contains("RT: SCHED_FIFO priority 50 enabled")
+            || stderr.contains("RT: sched_setscheduler failed:"),
+        "expected SCHED_FIFO success-or-failure line on stderr.\n\
+         stderr was:\n{stderr}"
+    );
+
+    #[cfg(not(target_os = "linux"))]
+    assert!(
+        stderr.contains("RT: SCHED_FIFO not available on this platform"),
+        "expected non-Linux SCHED_FIFO fallback line on stderr.\n\
+         stderr was:\n{stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Examples under `examples/` that do NOT have a corresponding `smoke_*` or
 // `contract_*` test in this file. Some are blocked (filed issue or external
 // dep); others are intentionally covered by a DIFFERENT CI job. Keep this

--- a/tests/example-smoke.rs
+++ b/tests/example-smoke.rs
@@ -1446,8 +1446,10 @@ fn smoke_local_queue_size_latest_data_rust() {
 // "useful error vs. silent fallback" guarantee #1701 calls out as untested.
 //
 // Linux exercises both mlockall and SCHED_FIFO branches; macOS exercises
-// the mlockall + "SCHED_FIFO not available" branches. Windows is not
-// covered because the daemon does not run on Windows.
+// the mlockall + "SCHED_FIFO not available" branches. Windows is excluded
+// via `#[cfg(unix)]` because the assertions below only cover unix RT
+// branches — the Windows fallback at `binaries/cli/src/command/daemon.rs`
+// (`#[cfg(not(unix))]` arm) is not exercised here.
 
 #[test]
 #[cfg(unix)]
@@ -1496,6 +1498,56 @@ fn smoke_daemon_rt_emits_setup_messages() {
     assert!(
         stderr.contains("RT: SCHED_FIFO not available on this platform"),
         "expected non-Linux SCHED_FIFO fallback line on stderr.\n\
+         stderr was:\n{stderr}"
+    );
+}
+
+/// `--quiet` must NOT suppress RT setup diagnostics. The fix in #1701
+/// deliberately uses `eprintln!` so a failed mlockall/SCHED_FIFO promotion
+/// is always visible — silencing operational warnings via the existing log
+/// filter would be unsafe.
+#[test]
+#[cfg(unix)]
+fn smoke_daemon_rt_quiet_still_emits_setup_messages() {
+    ensure_cli_built();
+    let dora = dora_bin();
+
+    cleanup_stale(&dora);
+
+    let mut child = Command::new(&dora)
+        .args(["daemon", "--rt", "--quiet"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn dora daemon --rt --quiet");
+
+    std::thread::sleep(Duration::from_millis(1500));
+
+    let _ = child.kill();
+    let output = child
+        .wait_with_output()
+        .expect("daemon wait_with_output failed");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        stderr.contains("RT: mlockall"),
+        "expected 'RT: mlockall' line on stderr under --quiet.\n\
+         stderr was:\n{stderr}"
+    );
+
+    #[cfg(target_os = "linux")]
+    assert!(
+        stderr.contains("RT: SCHED_FIFO priority 50 enabled")
+            || stderr.contains("RT: sched_setscheduler failed:"),
+        "expected SCHED_FIFO line on stderr under --quiet.\n\
+         stderr was:\n{stderr}"
+    );
+
+    #[cfg(not(target_os = "linux"))]
+    assert!(
+        stderr.contains("RT: SCHED_FIFO not available on this platform"),
+        "expected non-Linux SCHED_FIFO fallback on stderr under --quiet.\n\
          stderr was:\n{stderr}"
     );
 }


### PR DESCRIPTION
## Summary

- Fixes the latent silent-fallback bug in `dora daemon --rt`: the RT setup at `binaries/cli/src/command/daemon.rs:84-122` ran **before** `init_tracing_subscriber` registered the global default subscriber, so the previous `tracing::info!`/`warn!` calls about `mlockall` and `SCHED_FIFO` success/failure were routed to `NoSubscriber` and silently dropped — exactly the "useful error vs. silent fallback" gap #1701 flagged as untested.
- Switches those six call sites to `eprintln!` so the diagnostics are visible unconditionally. Going to stderr also (correctly) means `--quiet` no longer suppresses them: a failed RT promotion is an operational warning the user must see.
- Adds a regression gate in `tests/example-smoke.rs::smoke_daemon_rt_emits_setup_messages` (`#[cfg(unix)]`) that asserts the messages actually appear. Linux accepts either the success or `failed:` variant of both `mlockall` and `SCHED_FIFO`, so it runs on unprivileged CI without needing `CAP_IPC_LOCK` / `CAP_SYS_NICE`. macOS asserts the documented "SCHED_FIFO not available" fallback path.

Closes #1701.

## Why eprintln! instead of reordering tracing init

Two clean options were on the table:

1. Move the `init_tracing_subscriber` block above the RT setup so `tracing::*` calls work.
2. Replace the six `tracing::*` calls in the RT block with `eprintln!`.

Option 2 was chosen because (a) it is more surgical (six lines vs. moving ~25 lines of subscriber/OtelGuard setup past the runtime construction, with new ordering subtleties), and (b) it aligns with the "RT failures must always be visible" semantic — the existing `--quiet` flag should not silence a mlockall/SCHED_FIFO warning that materially changes daemon behavior.

## Verified RED to GREEN

Empirical confirmation that the test guards the bug:

- With the daemon fix stashed (original `tracing::*` code restored):
  ```
  thread smoke_daemon_rt_emits_setup_messages panicked at tests/example-smoke.rs:1481:5:
  expected RT: mlockall line on stderr (success or failure variant).
  stderr was:
  ```
  Empty stderr — confirms the messages are dropped by `NoSubscriber`.

- With the fix applied:
  ```
  test result: ok. 1 passed; 0 failed
  ```

Manual stderr capture under the fix (macOS):
```
RT: mlockall failed: Function not implemented (os error 78). Ensure CAP_IPC_LOCK or ulimit -l unlimited.
RT: SCHED_FIFO not available on this platform (mlockall applied)
```

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p dora-cli --tests -- -D warnings`
- [x] `cargo test -p dora-cli --lib` — 146 passed
- [x] `cargo test --test example-smoke smoke_daemon_rt_emits_setup_messages` — passes on macOS
- [ ] CI Linux: same test should pass on unprivileged GHA runner (asserts either success or `failed:` variant of mlockall + SCHED_FIFO)
- [ ] Manual: confirm `dora daemon --rt --quiet` still prints RT messages (operational correctness — must not be suppressed by `--quiet`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
