### PR TITLE
test(cli): E2E coverage for --allow-shell-nodes security gate (#1702)

### DIFF
--- a/tests/example-smoke.rs
+++ b/tests/example-smoke.rs
@@ -1498,6 +1498,17 @@ fn smoke_shell_node_allowed_with_flag() {
         .expect("failed to run dora run --allow-shell-nodes");
 
     let stderr = String::from_utf8_lossy(&output.stderr);
+    // Assert dora exited cleanly BEFORE checking the marker. Otherwise a
+    // regression where the shell node runs successfully but a subsequent
+    // lifecycle/result step fails (e.g. dataflow result handling returns
+    // non-zero) would still produce the marker file and slip past the
+    // test (review feedback on PR #1898).
+    assert!(
+        output.status.success(),
+        "dora run --allow-shell-nodes exited non-zero (status={:?}); \
+         marker file alone is not enough.\nstderr:\n{stderr}",
+        output.status.code()
+    );
     assert!(
         marker.exists(),
         "shell command did not produce marker file at {marker:?}; \

--- a/tests/example-smoke.rs
+++ b/tests/example-smoke.rs
@@ -1437,6 +1437,128 @@ fn smoke_local_queue_size_latest_data_rust() {
 }
 
 // ---------------------------------------------------------------------------
+// Shell-node gate (issue #1702)
+// ---------------------------------------------------------------------------
+//
+// `dora run --allow-shell-nodes` toggles a security gate enforced at
+// `binaries/daemon/src/spawn/command.rs:24`. Both branches of that `if`
+// matter: without the flag, dora MUST refuse to spawn shell nodes.
+// The negative test is therefore load-bearing security coverage —
+// a regression that silently allowed shell execution would bypass the
+// security model. Linux + macOS only (`sh -c` form); Windows uses
+// `cmd /C` and would need a separate fixture.
+
+fn unique_temp_path(stem: &str) -> std::path::PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "dora-shell-gate-{stem}-{}-{nanos}",
+        std::process::id()
+    ))
+}
+
+#[cfg(unix)]
+fn write_shell_dataflow(yaml_path: &std::path::Path, marker: &std::path::Path) {
+    // Use single quotes around the marker path so spaces or shell
+    // metacharacters in `$TMPDIR` cannot break out of the `echo`.
+    let yaml = format!(
+        "nodes:\n  - id: shell-test\n    path: shell\n    args: \"echo hello > '{}'\"\n",
+        marker.display()
+    );
+    std::fs::write(yaml_path, yaml).expect("failed to write shell dataflow YAML");
+}
+
+#[test]
+#[cfg(unix)]
+fn smoke_shell_node_allowed_with_flag() {
+    ensure_cli_built();
+    let dora = dora_bin();
+
+    let yaml = unique_temp_path("allowed-yaml");
+    let marker = unique_temp_path("allowed-marker");
+    let _ = std::fs::remove_file(&marker);
+    write_shell_dataflow(&yaml, &marker);
+
+    let output = Command::new(&dora)
+        .args([
+            "run",
+            yaml.to_str().unwrap(),
+            "--allow-shell-nodes",
+            "--stop-after",
+            "10s",
+        ])
+        // Don't let an inherited DORA_ALLOW_SHELL_NODES=true bias the
+        // result — the CLI flag must be the sole source of truth.
+        .env_remove("DORA_ALLOW_SHELL_NODES")
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to run dora run --allow-shell-nodes");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        marker.exists(),
+        "shell command did not produce marker file at {marker:?}; \
+         dora exit={:?}\nstderr:\n{stderr}",
+        output.status.code()
+    );
+    let body = std::fs::read_to_string(&marker).expect("read marker");
+    assert!(
+        body.contains("hello"),
+        "marker contents unexpected: {body:?}\nstderr:\n{stderr}"
+    );
+
+    let _ = std::fs::remove_file(&marker);
+    let _ = std::fs::remove_file(&yaml);
+}
+
+#[test]
+#[cfg(unix)]
+fn smoke_shell_node_blocked_without_flag() {
+    ensure_cli_built();
+    let dora = dora_bin();
+
+    let yaml = unique_temp_path("blocked-yaml");
+    let marker = unique_temp_path("blocked-marker");
+    let _ = std::fs::remove_file(&marker);
+    write_shell_dataflow(&yaml, &marker);
+
+    let output = Command::new(&dora)
+        .args(["run", yaml.to_str().unwrap(), "--stop-after", "10s"])
+        // Belt-and-suspenders: explicitly strip the env var from the
+        // child. Without this, a parent shell that exported the flag
+        // (or a leftover from a prior test) would silently let the
+        // gate pass — and we'd never know.
+        .env_remove("DORA_ALLOW_SHELL_NODES")
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to run dora run (gate-blocked)");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "dora run unexpectedly SUCCEEDED without --allow-shell-nodes — \
+         the security gate failed.\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Shell nodes are disabled"),
+        "error message missing the documented gate string \
+         'Shell nodes are disabled'.\nstderr:\n{stderr}"
+    );
+    assert!(
+        !marker.exists(),
+        "shell command produced output at {marker:?} despite the gate — \
+         the security gate failed.\nstderr:\n{stderr}"
+    );
+
+    let _ = std::fs::remove_file(&yaml);
+}
+
+// ---------------------------------------------------------------------------
 // Examples under `examples/` that do NOT have a corresponding `smoke_*` or
 // `contract_*` test in this file. Some are blocked (filed issue or external
 // dep); others are intentionally covered by a DIFFERENT CI job. Keep this

--- a/tests/example-smoke.rs
+++ b/tests/example-smoke.rs
@@ -32,17 +32,29 @@ fn dora_bin() -> String {
     // to a bare "dora" on PATH would silently let a stale globally-
     // installed CLI shadow whatever ensure_cli_built() just produced;
     // the test would then "pass" against the wrong binary.
+    //
+    // Limitations not handled here (would need cargo metadata or
+    // --message-format=json parsing in ensure_cli_built):
+    //   - `.cargo/config.toml` `[build] target-dir`
+    //   - target-triple subdirs from `CARGO_BUILD_TARGET` / cargo
+    //     config (`target/<triple>/debug/...`)
+    // Neither is used in this project today; the panic below points at
+    // the cause if a future config hits them.
     let target_root = std::env::var("CARGO_TARGET_DIR")
         .map(std::path::PathBuf::from)
         .unwrap_or_else(|_| Path::new(manifest).join("target"));
-    let candidate = target_root.join("debug").join("dora");
+    // `EXE_SUFFIX` is `.exe` on Windows, empty elsewhere. Without this,
+    // dora_bin() panics on Windows where the artifact is `dora.exe`,
+    // breaking every smoke test on that platform.
+    let exe_name = format!("dora{}", std::env::consts::EXE_SUFFIX);
+    let candidate = target_root.join("debug").join(&exe_name);
     if candidate.exists() {
         return candidate.to_string_lossy().to_string();
     }
     panic!(
         "dora binary not found at {} after ensure_cli_built(); \
-         check CARGO_TARGET_DIR consistency between the test runner \
-         and the cargo invocation",
+         if you use .cargo/config.toml or CARGO_BUILD_TARGET, ensure \
+         CARGO_TARGET_DIR points at the resolved artifact directory",
         candidate.display()
     );
 }
@@ -1501,12 +1513,19 @@ fn ensure_marker_absent(marker: &std::path::Path) {
     );
 }
 
-/// Defense in depth: `dora run` embeds a coordinator on the hardcoded
-/// default port `binaries/cli/src/command/run.rs:226`. The file is
-/// documented to be run with `--test-threads=1`, but if someone forgets,
-/// at least our two shell-gate tests will serialize against each other
-/// here. Project-wide serialization across all smoke_local_* tests
-/// would require a separate refactor and is out of scope for #1702.
+/// Defense in depth, narrow scope: serializes ONLY these two shell-gate
+/// tests against each other. `dora run` embeds a coordinator on the
+/// hardcoded default port `binaries/cli/src/command/run.rs:226`, so two
+/// `dora run` instances race on bind(). The lock does NOT protect
+/// against:
+///   - Other tests in this file that also invoke `dora run` (e.g.
+///     `run_smoke_test_local` callers). Those would need a file-level
+///     lock or a project-wide refactor.
+///   - Multi-process runners like `cargo nextest run` or sharded CI:
+///     the mutex is process-local. A file lock (`fs2::FileExt::lock_exclusive`
+///     or similar) would cover that case.
+/// Both are out of scope for #1702. The file is documented to run with
+/// `--test-threads=1`, which is the canonical fix.
 static SHELL_GATE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[test]

--- a/tests/example-smoke.rs
+++ b/tests/example-smoke.rs
@@ -27,11 +27,24 @@ static BUILD_MAVLINK2_BRIDGE_NODES: Once = Once::new();
 
 fn dora_bin() -> String {
     let manifest = env!("CARGO_MANIFEST_DIR");
-    let target_dir = Path::new(manifest).join("target/debug/dora");
-    if target_dir.exists() {
-        return target_dir.to_string_lossy().to_string();
+    // Honor $CARGO_TARGET_DIR if set — devs and some CI setups redirect
+    // builds out of the workspace `target/` dir. The previous fall-back
+    // to a bare "dora" on PATH would silently let a stale globally-
+    // installed CLI shadow whatever ensure_cli_built() just produced;
+    // the test would then "pass" against the wrong binary.
+    let target_root = std::env::var("CARGO_TARGET_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| Path::new(manifest).join("target"));
+    let candidate = target_root.join("debug").join("dora");
+    if candidate.exists() {
+        return candidate.to_string_lossy().to_string();
     }
-    "dora".to_string()
+    panic!(
+        "dora binary not found at {} after ensure_cli_built(); \
+         check CARGO_TARGET_DIR consistency between the test runner \
+         and the cargo invocation",
+        candidate.display()
+    );
 }
 
 fn ensure_cli_built() {
@@ -1488,9 +1501,18 @@ fn ensure_marker_absent(marker: &std::path::Path) {
     );
 }
 
+/// Defense in depth: `dora run` embeds a coordinator on the hardcoded
+/// default port `binaries/cli/src/command/run.rs:226`. The file is
+/// documented to be run with `--test-threads=1`, but if someone forgets,
+/// at least our two shell-gate tests will serialize against each other
+/// here. Project-wide serialization across all smoke_local_* tests
+/// would require a separate refactor and is out of scope for #1702.
+static SHELL_GATE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[test]
 #[cfg(unix)]
 fn smoke_shell_node_allowed_with_flag() {
+    let _guard = SHELL_GATE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
     ensure_cli_built();
     let dora = dora_bin();
 
@@ -1561,6 +1583,7 @@ fn smoke_shell_node_allowed_with_flag() {
 #[test]
 #[cfg(unix)]
 fn smoke_shell_node_blocked_without_flag() {
+    let _guard = SHELL_GATE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
     ensure_cli_built();
     let dora = dora_bin();
 

--- a/tests/example-smoke.rs
+++ b/tests/example-smoke.rs
@@ -1461,13 +1461,31 @@ fn unique_temp_path(stem: &str) -> std::path::PathBuf {
 
 #[cfg(unix)]
 fn write_shell_dataflow(yaml_path: &std::path::Path, marker: &std::path::Path) {
-    // Use single quotes around the marker path so spaces or shell
-    // metacharacters in `$TMPDIR` cannot break out of the `echo`.
+    // Wrap the marker path in single quotes so spaces or most shell
+    // metacharacters in `$TMPDIR` cannot break out of the `echo`. This
+    // does NOT protect against a literal single quote in $TMPDIR — that
+    // would corrupt the shell args and the test would fail loudly (not
+    // silently mis-execute). On any sane CI/dev system $TMPDIR is a
+    // well-formed path; the residual risk is acceptable for a test
+    // fixture in an environment we control.
     let yaml = format!(
         "nodes:\n  - id: shell-test\n    path: shell\n    args: \"echo hello > '{}'\"\n",
         marker.display()
     );
     std::fs::write(yaml_path, yaml).expect("failed to write shell dataflow YAML");
+}
+
+/// Guarantee the marker path is clean before the test runs. A silent
+/// `remove_file` failure (permissions, symlink to unwritable target)
+/// could otherwise let the positive test pass against a stale marker
+/// without proving this run wrote it.
+fn ensure_marker_absent(marker: &std::path::Path) {
+    let _ = std::fs::remove_file(marker);
+    assert!(
+        !marker.exists(),
+        "marker path {marker:?} pre-existed and could not be removed; \
+         a stale file would make the positive test pass spuriously"
+    );
 }
 
 #[test]
@@ -1478,7 +1496,7 @@ fn smoke_shell_node_allowed_with_flag() {
 
     let yaml = unique_temp_path("allowed-yaml");
     let marker = unique_temp_path("allowed-marker");
-    let _ = std::fs::remove_file(&marker);
+    ensure_marker_absent(&marker);
     write_shell_dataflow(&yaml, &marker);
 
     let output = Command::new(&dora)
@@ -1492,11 +1510,16 @@ fn smoke_shell_node_allowed_with_flag() {
         // Don't let an inherited DORA_ALLOW_SHELL_NODES=true bias the
         // result — the CLI flag must be the sole source of truth.
         .env_remove("DORA_ALLOW_SHELL_NODES")
-        .stdout(Stdio::null())
+        // Capture both streams: the audit-trail warning is emitted via
+        // the daemon's tracing subscriber, which routes to stdout in
+        // `dora run` (single-process mode), while CLI-level errors go
+        // to stderr. We need both to verify the gate's side effects.
+        .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()
         .expect("failed to run dora run --allow-shell-nodes");
 
+    let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
     // Assert dora exited cleanly BEFORE checking the marker. Otherwise a
     // regression where the shell node runs successfully but a subsequent
@@ -1506,19 +1529,29 @@ fn smoke_shell_node_allowed_with_flag() {
     assert!(
         output.status.success(),
         "dora run --allow-shell-nodes exited non-zero (status={:?}); \
-         marker file alone is not enough.\nstderr:\n{stderr}",
+         marker file alone is not enough.\nstdout:\n{stdout}\nstderr:\n{stderr}",
         output.status.code()
+    );
+    // The audit-trail warning at binaries/daemon/src/spawn/command.rs:34
+    // is the operator's only signal that shell execution is happening.
+    // If the gate works but this warning is silenced, dora becomes
+    // quietly unsafe — the marker check alone wouldn't catch it.
+    assert!(
+        stdout.contains("DORA_ALLOW_SHELL_NODES is set:")
+            || stderr.contains("DORA_ALLOW_SHELL_NODES is set:"),
+        "audit-trail warning missing — operators would lose the only \
+         signal that shell execution is happening.\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
     assert!(
         marker.exists(),
         "shell command did not produce marker file at {marker:?}; \
-         dora exit={:?}\nstderr:\n{stderr}",
+         dora exit={:?}\nstdout:\n{stdout}\nstderr:\n{stderr}",
         output.status.code()
     );
     let body = std::fs::read_to_string(&marker).expect("read marker");
     assert!(
         body.contains("hello"),
-        "marker contents unexpected: {body:?}\nstderr:\n{stderr}"
+        "marker contents unexpected: {body:?}\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
 
     let _ = std::fs::remove_file(&marker);
@@ -1533,7 +1566,7 @@ fn smoke_shell_node_blocked_without_flag() {
 
     let yaml = unique_temp_path("blocked-yaml");
     let marker = unique_temp_path("blocked-marker");
-    let _ = std::fs::remove_file(&marker);
+    ensure_marker_absent(&marker);
     write_shell_dataflow(&yaml, &marker);
 
     let output = Command::new(&dora)

--- a/tests/example-smoke.rs
+++ b/tests/example-smoke.rs
@@ -1489,10 +1489,10 @@ fn write_shell_dataflow(yaml_path: &std::path::Path, marker: &std::path::Path) {
     // Wrap the marker path in single quotes so spaces or most shell
     // metacharacters in `$TMPDIR` cannot break out of the `echo`. This
     // does NOT protect against a literal single quote in $TMPDIR — that
-    // would corrupt the shell args and the test would fail loudly (not
-    // silently mis-execute). On any sane CI/dev system $TMPDIR is a
-    // well-formed path; the residual risk is acceptable for a test
-    // fixture in an environment we control.
+    // would corrupt the shell args and the test would fail loudly
+    // rather than silently execute the wrong command. On any sane
+    // CI/dev system $TMPDIR is a well-formed path; the residual risk
+    // is acceptable for a test fixture in an environment we control.
     let yaml = format!(
         "nodes:\n  - id: shell-test\n    path: shell\n    args: \"echo hello > '{}'\"\n",
         marker.display()


### PR DESCRIPTION
## Summary

Add paired E2E smoke tests for the `dora run --allow-shell-nodes` security gate (`binaries/daemon/src/spawn/command.rs:24`). Closes #1702.

- `smoke_shell_node_allowed_with_flag` — positive path: tiny `path: shell` dataflow + `--allow-shell-nodes` → asserts the shell command produced the marker file with the expected content.
- `smoke_shell_node_blocked_without_flag` — negative path (load-bearing for the security model): same dataflow WITHOUT the flag → asserts dora exits non-zero, stderr contains the documented `"Shell nodes are disabled"` string, and **no marker file is created**.

Both tests `#[cfg(unix)]` (Linux + macOS `sh -c` form). Each child is launched with `.env_remove("DORA_ALLOW_SHELL_NODES")` so the CLI flag is the sole source of truth — an inherited env var (CI runner, shell session, previous test contamination) cannot silently let the gate pass.

## Why the negative test matters

A regression that silently dropped the gate check would let shell nodes execute by default, bypassing the security model without anyone noticing. This test is the canary — `dora` exiting cleanly on a `path: shell` dataflow without the flag would be a real vulnerability, not just a missing test.

## Verified RED → GREEN

Temporarily replaced the gate condition with `if false && std::env::var(...)` and re-ran:

```
thread 'smoke_shell_node_blocked_without_flag' panicked at tests/example-smoke.rs:1542:5:
dora run unexpectedly SUCCEEDED without --allow-shell-nodes — the security gate failed.
```

Restoring the gate makes the test pass. The negative test is genuinely load-bearing against the security regression class.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p dora-cli --tests -- -D warnings`
- [x] `cargo test --test example-smoke smoke_shell_node -- --test-threads=1` — 2/2 pass on macOS
- [ ] CI Linux: same tests should pass under unprivileged GHA runner
- [x] Adversarial: replaced the gate with `if false && ...` and confirmed the negative test catches it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
