### PR TITLE
fix(coordinator,daemon): typed reply for AddMapping/RemoveMapping (unblocks dora node connect/disconnect)

### DIFF
--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -1726,13 +1726,29 @@ async fn start_inner(
                                         })?;
                                         match daemon_connections.get_mut(daemon_id) {
                                             Some(conn) => match conn.send_and_receive(&msg).await {
-                                                Ok(_) => Ok(ControlRequestReply::MappingAdded {
-                                                    dataflow_id,
-                                                    source_node,
-                                                    source_output,
-                                                    target_node,
-                                                    target_input,
-                                                }),
+                                                Ok(reply_raw) => {
+                                                    // Validate the daemon reply is specifically an
+                                                    // `AddMappingResult` before reporting success,
+                                                    // mirroring the #1682 / #1873 rescue for AddNode.
+                                                    let src =
+                                                        format!("{source_node}/{source_output}");
+                                                    let tgt =
+                                                        format!("{target_node}/{target_input}");
+                                                    match ensure_add_mapping_applied(
+                                                        &reply_raw, &src, &tgt,
+                                                    ) {
+                                                        Ok(()) => {
+                                                            Ok(ControlRequestReply::MappingAdded {
+                                                                dataflow_id,
+                                                                source_node,
+                                                                source_output,
+                                                                target_node,
+                                                                target_input,
+                                                            })
+                                                        }
+                                                        Err(e) => Err(e),
+                                                    }
+                                                }
                                                 Err(e) => Err(eyre!("daemon dispatch failed: {e}")),
                                             },
                                             None => {
@@ -1770,13 +1786,26 @@ async fn start_inner(
                                         })?;
                                         match daemon_connections.get_mut(daemon_id) {
                                             Some(conn) => match conn.send_and_receive(&msg).await {
-                                                Ok(_) => Ok(ControlRequestReply::MappingRemoved {
-                                                    dataflow_id,
-                                                    source_node,
-                                                    source_output,
-                                                    target_node,
-                                                    target_input,
-                                                }),
+                                                Ok(reply_raw) => {
+                                                    let src =
+                                                        format!("{source_node}/{source_output}");
+                                                    let tgt =
+                                                        format!("{target_node}/{target_input}");
+                                                    match ensure_remove_mapping_applied(
+                                                        &reply_raw, &src, &tgt,
+                                                    ) {
+                                                        Ok(()) => Ok(
+                                                            ControlRequestReply::MappingRemoved {
+                                                                dataflow_id,
+                                                                source_node,
+                                                                source_output,
+                                                                target_node,
+                                                                target_input,
+                                                            },
+                                                        ),
+                                                        Err(e) => Err(e),
+                                                    }
+                                                }
                                                 Err(e) => Err(eyre!("daemon dispatch failed: {e}")),
                                             },
                                             None => {
@@ -3526,6 +3555,38 @@ fn ensure_remove_node_applied(
     }
 }
 
+/// Validate that the daemon's reply to `DaemonCoordinatorEvent::AddMapping`
+/// is a successful `AddMappingResult`. Parallel to `ensure_add_node_applied`.
+/// Before the daemon returned an explicit `AddMappingResult`, the coordinator's
+/// `send_and_receive` for `AddMapping` timed out after 30s because the WS
+/// layer dropped the daemon's `None` reply; closing that hole means we now
+/// have a typed reply to check against — same #1682 class.
+fn ensure_add_mapping_applied(reply_raw: &[u8], source: &str, target: &str) -> eyre::Result<()> {
+    match serde_json::from_slice(reply_raw)? {
+        DaemonCoordinatorReply::AddMappingResult(Ok(())) => Ok(()),
+        DaemonCoordinatorReply::AddMappingResult(Err(err)) => Err(eyre!(
+            "daemon failed to add mapping `{source}` -> `{target}`: {err}"
+        )),
+        other => Err(eyre!(
+            "unexpected daemon reply for AddMapping `{source}` -> `{target}`: {other:?}"
+        )),
+    }
+}
+
+/// Validate that the daemon's reply to `DaemonCoordinatorEvent::RemoveMapping`
+/// is a successful `RemoveMappingResult`. See `ensure_add_mapping_applied`.
+fn ensure_remove_mapping_applied(reply_raw: &[u8], source: &str, target: &str) -> eyre::Result<()> {
+    match serde_json::from_slice(reply_raw)? {
+        DaemonCoordinatorReply::RemoveMappingResult(Ok(())) => Ok(()),
+        DaemonCoordinatorReply::RemoveMappingResult(Err(err)) => Err(eyre!(
+            "daemon failed to remove mapping `{source}` -> `{target}`: {err}"
+        )),
+        other => Err(eyre!(
+            "unexpected daemon reply for RemoveMapping `{source}` -> `{target}`: {other:?}"
+        )),
+    }
+}
+
 fn schedule_param_replay_for_ready_dataflow(
     dataflow_id: DataflowId,
     dataflow: &RunningDataflow,
@@ -4907,6 +4968,103 @@ mod tests {
         let reply = serde_json::to_vec(&DaemonCoordinatorReply::AddNodeResult(Ok(()))).unwrap();
         let err = ensure_remove_node_applied(&reply, &node_id)
             .expect_err("AddNodeResult reply must not be accepted by RemoveNode validator");
+        assert!(
+            err.to_string().contains("unexpected daemon reply"),
+            "error must call out the wrong-reply-type failure mode: {err}"
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // AddMapping / RemoveMapping reply validation (silent-reply rescue
+    // for the connect/disconnect timeouts — same class as #1682).
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn add_mapping_reply_accepts_daemon_success() {
+        let reply = serde_json::to_vec(&DaemonCoordinatorReply::AddMappingResult(Ok(()))).unwrap();
+        ensure_add_mapping_applied(&reply, "sender/value", "filter/input")
+            .expect("successful AddMapping reply should pass");
+    }
+
+    #[test]
+    fn add_mapping_reply_reports_daemon_rejection() {
+        let reply = serde_json::to_vec(&DaemonCoordinatorReply::AddMappingResult(Err(
+            "no running dataflow with ID `xyz`".to_string(),
+        )))
+        .unwrap();
+        let err = ensure_add_mapping_applied(&reply, "sender/value", "filter/input")
+            .expect_err("daemon rejection should fail AddMapping forwarding");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("failed to add mapping")
+                && msg.contains("sender/value")
+                && msg.contains("filter/input"),
+            "error must name the operation and the mapping endpoints: {msg}"
+        );
+    }
+
+    #[test]
+    fn add_mapping_reply_rejects_wrong_reply_variant() {
+        // Pre-fix #1682-equivalent regression: daemon returned `None`,
+        // WS layer dropped it, coordinator's `Ok(_) =>` arm reported
+        // success on any wire response. With AddMappingResult now typed,
+        // a foreign reply variant must NOT be accepted.
+        let reply = serde_json::to_vec(&DaemonCoordinatorReply::SetParamResult(Ok(()))).unwrap();
+        let err = ensure_add_mapping_applied(&reply, "sender/value", "filter/input")
+            .expect_err("unexpected reply variant should fail AddMapping forwarding");
+        assert!(
+            err.to_string().contains("unexpected daemon reply"),
+            "error must call out the wrong-reply-type failure mode: {err}"
+        );
+
+        let reply =
+            serde_json::to_vec(&DaemonCoordinatorReply::RemoveMappingResult(Ok(()))).unwrap();
+        let err = ensure_add_mapping_applied(&reply, "sender/value", "filter/input")
+            .expect_err("RemoveMappingResult must not be accepted by AddMapping validator");
+        assert!(
+            err.to_string().contains("unexpected daemon reply"),
+            "error must call out the wrong-reply-type failure mode: {err}"
+        );
+    }
+
+    #[test]
+    fn remove_mapping_reply_accepts_daemon_success() {
+        let reply =
+            serde_json::to_vec(&DaemonCoordinatorReply::RemoveMappingResult(Ok(()))).unwrap();
+        ensure_remove_mapping_applied(&reply, "sender/value", "filter/input")
+            .expect("successful RemoveMapping reply should pass");
+    }
+
+    #[test]
+    fn remove_mapping_reply_reports_daemon_rejection() {
+        let reply = serde_json::to_vec(&DaemonCoordinatorReply::RemoveMappingResult(Err(
+            "no running dataflow with ID `xyz`".to_string(),
+        )))
+        .unwrap();
+        let err = ensure_remove_mapping_applied(&reply, "sender/value", "filter/input")
+            .expect_err("daemon rejection should fail RemoveMapping forwarding");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("failed to remove mapping")
+                && msg.contains("sender/value")
+                && msg.contains("filter/input"),
+            "error must name the operation and the mapping endpoints: {msg}"
+        );
+    }
+
+    #[test]
+    fn remove_mapping_reply_rejects_wrong_reply_variant() {
+        let reply = serde_json::to_vec(&DaemonCoordinatorReply::SetParamResult(Ok(()))).unwrap();
+        let err = ensure_remove_mapping_applied(&reply, "sender/value", "filter/input")
+            .expect_err("unexpected reply variant should fail RemoveMapping forwarding");
+        assert!(
+            err.to_string().contains("unexpected daemon reply"),
+            "error must call out the wrong-reply-type failure mode: {err}"
+        );
+
+        let reply = serde_json::to_vec(&DaemonCoordinatorReply::AddMappingResult(Ok(()))).unwrap();
+        let err = ensure_remove_mapping_applied(&reply, "sender/value", "filter/input")
+            .expect_err("AddMappingResult must not be accepted by RemoveMapping validator");
         assert!(
             err.to_string().contains("unexpected daemon reply"),
             "error must call out the wrong-reply-type failure mode: {err}"

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1842,7 +1842,13 @@ impl Daemon {
                 target_input,
             } => {
                 tracing::info!(%dataflow_id, "{source_node}/{source_output} -> {target_node}/{target_input}");
-                if let Some(dataflow) = self.running.get_mut(&dataflow_id) {
+                // Previously this handler ignored unknown dataflow_id and
+                // always replied `None`, which the WS layer dropped on the
+                // floor → coordinator timed out after 30s without ever
+                // knowing whether the mapping applied. Reply with an
+                // explicit `AddMappingResult` so the coordinator can pattern-
+                // match the outcome (same class as #1682's AddNodeResult).
+                let result = if let Some(dataflow) = self.running.get_mut(&dataflow_id) {
                     let output_id = OutputId(source_node, source_output);
                     dataflow
                         .mappings
@@ -1854,8 +1860,11 @@ impl Daemon {
                         .entry(target_node)
                         .or_default()
                         .insert(target_input);
-                }
-                let _ = reply_tx.send(None);
+                    Ok(())
+                } else {
+                    Err(format!("no running dataflow with ID `{dataflow_id}`"))
+                };
+                let _ = reply_tx.send(Some(DaemonCoordinatorReply::AddMappingResult(result)));
                 RunStatus::Continue
             }
             DaemonCoordinatorEvent::RemoveMapping {
@@ -1866,15 +1875,19 @@ impl Daemon {
                 target_input,
             } => {
                 tracing::info!(%dataflow_id, "{source_node}/{source_output} -x- {target_node}/{target_input}");
-                if let Some(dataflow) = self.running.get_mut(&dataflow_id) {
+                // Same silent-reply fix as AddMapping above.
+                let result = if let Some(dataflow) = self.running.get_mut(&dataflow_id) {
                     let output_id = OutputId(source_node, source_output);
                     if let Some(receivers) = dataflow.mappings.get_mut(&output_id)
                         && receivers.remove(&(target_node.clone(), target_input.clone()))
                     {
                         close_input(dataflow, &target_node, &target_input, &self.clock);
                     }
-                }
-                let _ = reply_tx.send(None);
+                    Ok(())
+                } else {
+                    Err(format!("no running dataflow with ID `{dataflow_id}`"))
+                };
+                let _ = reply_tx.send(Some(DaemonCoordinatorReply::RemoveMappingResult(result)));
                 RunStatus::Continue
             }
             DaemonCoordinatorEvent::StartTopicDebugStream {

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1876,14 +1876,27 @@ impl Daemon {
             } => {
                 tracing::info!(%dataflow_id, "{source_node}/{source_output} -x- {target_node}/{target_input}");
                 // Same silent-reply fix as AddMapping above.
+                // Errors on missing-mapping (rather than silently succeeding)
+                // to match the `RemoveNode` semantics in stop_single_node,
+                // which surface "node not found" as a daemon Err. A double-
+                // disconnect or typo'd edge then produces a clear CLI error
+                // instead of a misleading "Mapping removed" message.
                 let result = if let Some(dataflow) = self.running.get_mut(&dataflow_id) {
-                    let output_id = OutputId(source_node, source_output);
-                    if let Some(receivers) = dataflow.mappings.get_mut(&output_id)
-                        && receivers.remove(&(target_node.clone(), target_input.clone()))
-                    {
+                    let output_id = OutputId(source_node.clone(), source_output.clone());
+                    let removed = dataflow
+                        .mappings
+                        .get_mut(&output_id)
+                        .map(|r| r.remove(&(target_node.clone(), target_input.clone())))
+                        .unwrap_or(false);
+                    if removed {
                         close_input(dataflow, &target_node, &target_input, &self.clock);
+                        Ok(())
+                    } else {
+                        Err(format!(
+                            "mapping `{source_node}/{source_output}` -> \
+                             `{target_node}/{target_input}` not found"
+                        ))
                     }
-                    Ok(())
                 } else {
                     Err(format!("no running dataflow with ID `{dataflow_id}`"))
                 };

--- a/libraries/message/src/daemon_to_coordinator.rs
+++ b/libraries/message/src/daemon_to_coordinator.rs
@@ -213,6 +213,16 @@ pub enum DaemonCoordinatorReply {
     RestartNodeResult(Result<(), String>),
     StopNodeResult(Result<(), String>),
     RemoveNodeResult(Result<(), String>),
+    /// Reply for `DaemonCoordinatorEvent::AddMapping`. Previously the daemon
+    /// returned `None`, which the coordinator's WS layer skipped instead
+    /// of forwarding as a reply, causing `send_and_receive` to time out
+    /// after 30s with `daemon dispatch failed: timeout waiting for daemon
+    /// WS reply`. Same bug class as #1682's AddNode silent-reply hole;
+    /// applied to mappings here.
+    AddMappingResult(Result<(), String>),
+    /// Reply for `DaemonCoordinatorEvent::RemoveMapping`. See
+    /// `AddMappingResult` doc for the silent-reply bug class.
+    RemoveMappingResult(Result<(), String>),
     SetParamResult(Result<(), String>),
     DeleteParamResult(Result<(), String>),
     StartTopicDebugStreamResult(Result<(), String>),

--- a/tests/ws-cli-e2e.rs
+++ b/tests/ws-cli-e2e.rs
@@ -814,12 +814,27 @@ mod param_cli {
 
     fn dora_bin() -> String {
         let manifest = env!("CARGO_MANIFEST_DIR");
-        let target = Path::new(manifest).join("target/debug/dora");
-        if target.exists() {
-            target.to_string_lossy().to_string()
-        } else {
-            "dora".to_string()
+        // Honor $CARGO_TARGET_DIR + EXE_SUFFIX so Windows finds
+        // `dora.exe` instead of falling back to a stale globally-
+        // installed `dora` on PATH — that fallback ran the pre-fix
+        // CLI/daemon against new-coordinator code and caused
+        // test-windows to fail with the silent-reply timeout this PR
+        // is meant to fix. Same shape as the example-smoke.rs fix
+        // for #1701.
+        let target_root = std::env::var("CARGO_TARGET_DIR")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| Path::new(manifest).join("target"));
+        let exe_name = format!("dora{}", std::env::consts::EXE_SUFFIX);
+        let candidate = target_root.join("debug").join(&exe_name);
+        if candidate.exists() {
+            return candidate.to_string_lossy().to_string();
         }
+        panic!(
+            "dora binary not found at {} after ensure_cli_built(); \
+             if you use .cargo/config.toml or CARGO_BUILD_TARGET, ensure \
+             CARGO_TARGET_DIR points at the resolved artifact directory",
+            candidate.display()
+        );
     }
 
     fn ensure_cli_built() {
@@ -984,11 +999,22 @@ mod real_dataflow {
 
     fn dora_bin() -> String {
         let manifest = env!("CARGO_MANIFEST_DIR");
-        let target_dir = Path::new(manifest).join("target/debug/dora");
-        if target_dir.exists() {
-            return target_dir.to_string_lossy().to_string();
+        // Honor $CARGO_TARGET_DIR + EXE_SUFFIX. See the matching copy
+        // of this helper earlier in the file for the rationale.
+        let target_root = std::env::var("CARGO_TARGET_DIR")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| Path::new(manifest).join("target"));
+        let exe_name = format!("dora{}", std::env::consts::EXE_SUFFIX);
+        let candidate = target_root.join("debug").join(&exe_name);
+        if candidate.exists() {
+            return candidate.to_string_lossy().to_string();
         }
-        "dora".to_string()
+        panic!(
+            "dora binary not found at {} after ensure_built(); \
+             if you use .cargo/config.toml or CARGO_BUILD_TARGET, ensure \
+             CARGO_TARGET_DIR points at the resolved artifact directory",
+            candidate.display()
+        );
     }
 
     fn ensure_built() {


### PR DESCRIPTION
## Summary

`dora node connect` and `dora node disconnect` always timed out after 30s with `daemon dispatch failed: timeout waiting for daemon WS reply`. Reproducible against `examples/dynamic-add-remove` on a freshly-built binary, surfaced while trying to add E2E coverage for the `dora node *` matrix in #1703.

Root cause is the silent-reply class of bug previously fixed for `AddNode` (#1682 / #1873): the daemon's `AddMapping` / `RemoveMapping` handlers replied `None`, which the WS shim (`binaries/daemon/src/coordinator.rs:262`) drops without sending a wire response. The coordinator's `send_and_receive` then waited for a `daemon_command` reply that never came until `TCP_READ_TIMEOUT` (30s) elapsed — even though the mapping had already been applied locally on the daemon side.

## Changes

- `libraries/message/src/daemon_to_coordinator.rs` — add `AddMappingResult(Result<(), String>)` and `RemoveMappingResult(Result<(), String>)` variants to `DaemonCoordinatorReply`.
- `binaries/daemon/src/lib.rs` — daemon's `AddMapping` / `RemoveMapping` handlers now return the typed outcome via `Some(reply)`, including an explicit `Err` for unknown `dataflow_id` (previously silently ignored).
- `binaries/coordinator/src/lib.rs` — add `ensure_add_mapping_applied` / `ensure_remove_mapping_applied` helpers mirroring `ensure_add_node_applied`. Coordinator's CLI dispatch validates the reply variant before committing state, so a foreign reply or an explicit daemon `Err` surfaces to the CLI as `ControlRequestReply::Error` instead of committing on any successful TCP response.

## Tests

Six new unit tests for the validators (same shape as `add_node_reply_*` / `remove_node_reply_*`):

- `add_mapping_reply_accepts_daemon_success`
- `add_mapping_reply_reports_daemon_rejection`
- `add_mapping_reply_rejects_wrong_reply_variant`
- `remove_mapping_reply_accepts_daemon_success`
- `remove_mapping_reply_reports_daemon_rejection`
- `remove_mapping_reply_rejects_wrong_reply_variant`

All six pass. Existing coordinator/daemon tests unchanged.

## Verified end-to-end

Against `examples/dynamic-add-remove` (Python sender/receiver + filter add):

| Command | Before this PR | After |
|---|---|---|
| `dora node add --from-yaml filter-node.yml` | OK | OK |
| `dora node connect sender/value filter/input` | 30s timeout, mapping silently applied | OK |
| `dora node connect filter/output receiver/filtered` | 30s timeout | OK |
| `dora node disconnect filter/output receiver/filtered` | 30s timeout | OK |
| `dora node remove filter` | timeout (cascading) | OK |
| `dora node list` afterward | filter still visible | filter gone |

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --exclude dora-node-api-python --exclude dora-operator-api-python --exclude dora-ros2-bridge-python -- -D warnings`
- [x] `cargo test -p dora-coordinator --lib mapping` — 6/6 pass
- [x] Manual reproduction with `examples/dynamic-add-remove` (results above)
- [ ] CI Linux + macOS + Windows (full test matrix on the merge queue)

## Follow-ups

- Issue #1703 (E2E coverage for all 8 `dora node` subcommands across Rust/Python/C++) — this PR is the prerequisite that unblocks meaningful coverage on 4 of the 8 subcommands.
- The earlier manual probe also surfaced that `dora node stop <node>` returns success but the node remains in `Running` state on the next `dora node list`. That looks like a separate bug (not a wire-protocol timeout), so I have not bundled a fix here. Will investigate in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
