### PR TITLE
feat(c++/operator): add on_input_parse_error callback (closes #1879)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,6 +177,9 @@ tokio-stream = "0.1.11"
 tempfile = { workspace = true }
 assert2 = "0.3.16"
 tokio-tungstenite = "0.28"
+libloading = "0.8"
+dora-operator-api-types = { workspace = true }
+arrow-array = { workspace = true }
 
 [[example]]
 name = "c-dataflow"
@@ -226,6 +229,10 @@ path = "examples/multiple-daemons/run.rs"
 [[example]]
 name = "cmake-dataflow"
 path = "examples/cmake-dataflow/run.rs"
+
+[[test]]
+name = "cpp-operator-cxx-bridge"
+path = "tests/cpp-operator-cxx-bridge.rs"
 
 [[test]]
 name = "ws-cli-e2e"

--- a/apis/c++/operator/src/lib.rs
+++ b/apis/c++/operator/src/lib.rs
@@ -60,6 +60,20 @@ mod ffi {
         /// operator can emit a final output (e.g. flush buffered
         /// state, send a "shutdown summary") before returning.
         fn on_stop(op: Pin<&mut Operator>, output_sender: &mut OutputSender) -> DoraOnInputResult;
+
+        /// Called when an input's Arrow data fails to deserialize
+        /// (`Event::InputParseError { id, error }`). The daemon emits
+        /// this when `arrow::ffi::from_ffi` returns `Err` for a
+        /// received input. Without this callback the error was silently
+        /// swallowed by the catch-all `_ => Continue` arm, leaving the
+        /// operator with no way to log, surface as health, or reroute
+        /// malformed inputs.
+        fn on_input_parse_error(
+            op: Pin<&mut Operator>,
+            id: &str,
+            error: &str,
+            output_sender: &mut OutputSender,
+        ) -> DoraOnInputResult;
     }
 }
 
@@ -133,6 +147,19 @@ impl DoraOperator for OperatorWrapper {
                 let operator = self.operator.as_mut().unwrap();
                 let mut output_sender = OutputSender(output_sender);
                 let result = ffi::on_stop(operator, &mut output_sender);
+                if result.error.is_empty() {
+                    Ok(match result.stop {
+                        false => DoraStatus::Continue,
+                        true => DoraStatus::Stop,
+                    })
+                } else {
+                    Err(result.error)
+                }
+            }
+            Event::InputParseError { id, error } => {
+                let operator = self.operator.as_mut().unwrap();
+                let mut output_sender = OutputSender(output_sender);
+                let result = ffi::on_input_parse_error(operator, id, error, &mut output_sender);
                 if result.error.is_empty() {
                     Ok(match result.stop {
                         false => DoraStatus::Continue,

--- a/apis/rust/operator/src/lib.rs
+++ b/apis/rust/operator/src/lib.rs
@@ -80,7 +80,7 @@ impl DoraOutputSender<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Arc, Mutex};
+    use std::sync::Arc;
 
     struct RecordingOperator {
         parse_errors: Vec<(String, String)>,
@@ -223,59 +223,4 @@ mod tests {
         assert_send_sync::<SendOutput>();
     }
 
-    #[test]
-    fn parse_errors_accumulated_from_concurrent_event_streams() {
-        // Simulates two independent operator instances processing events
-        // concurrently — exercises the no-shared-state invariant.
-        let results: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
-        let results2 = Arc::clone(&results);
-
-        let h1 = std::thread::spawn(move || {
-            let sender = noop_send_output();
-            let mut output_sender = DoraOutputSender(&sender);
-            let mut op = RecordingOperator::default();
-            for i in 0..100u32 {
-                op.on_event(
-                    &Event::InputParseError {
-                        id: "thread-1",
-                        error: format!("err-{i}"),
-                    },
-                    &mut output_sender,
-                )
-                .unwrap();
-            }
-            results2
-                .lock()
-                .unwrap()
-                .push(format!("t1:{}", op.parse_errors.len()));
-        });
-
-        let results3 = Arc::clone(&results);
-        let h2 = std::thread::spawn(move || {
-            let sender = noop_send_output();
-            let mut output_sender = DoraOutputSender(&sender);
-            let mut op = RecordingOperator::default();
-            for i in 0..100u32 {
-                op.on_event(
-                    &Event::InputParseError {
-                        id: "thread-2",
-                        error: format!("err-{i}"),
-                    },
-                    &mut output_sender,
-                )
-                .unwrap();
-            }
-            results3
-                .lock()
-                .unwrap()
-                .push(format!("t2:{}", op.parse_errors.len()));
-        });
-
-        h1.join().unwrap();
-        h2.join().unwrap();
-
-        let r = results.lock().unwrap();
-        assert!(r.contains(&"t1:100".to_string()));
-        assert!(r.contains(&"t2:100".to_string()));
-    }
 }

--- a/apis/rust/operator/src/lib.rs
+++ b/apis/rust/operator/src/lib.rs
@@ -76,3 +76,206 @@ impl DoraOutputSender<'_> {
         result.into_result()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    struct RecordingOperator {
+        parse_errors: Vec<(String, String)>,
+    }
+
+    impl Default for RecordingOperator {
+        fn default() -> Self {
+            RecordingOperator {
+                parse_errors: Vec::new(),
+            }
+        }
+    }
+
+    impl DoraOperator for RecordingOperator {
+        fn on_event(
+            &mut self,
+            event: &Event,
+            _output_sender: &mut DoraOutputSender,
+        ) -> Result<DoraStatus, String> {
+            if let Event::InputParseError { id, error } = event {
+                self.parse_errors.push((id.to_string(), error.clone()));
+            }
+            Ok(DoraStatus::Continue)
+        }
+    }
+
+    fn noop_send_output() -> SendOutput {
+        use types::safer_ffi::closure::ArcDynFn1;
+        SendOutput {
+            send_output: ArcDynFn1::new(Arc::new(|_output| types::DoraResult::SUCCESS)),
+        }
+    }
+
+    #[test]
+    fn input_parse_error_dispatched_to_on_event() {
+        let sender = noop_send_output();
+        let mut output_sender = DoraOutputSender(&sender);
+        let mut op = RecordingOperator::default();
+
+        let event = Event::InputParseError {
+            id: "my-input",
+            error: "bad arrow data".to_string(),
+        };
+        let status = op.on_event(&event, &mut output_sender).unwrap();
+
+        assert!(matches!(status, DoraStatus::Continue));
+        assert_eq!(op.parse_errors.len(), 1);
+        assert_eq!(op.parse_errors[0].0, "my-input");
+        assert_eq!(op.parse_errors[0].1, "bad arrow data");
+    }
+
+    #[test]
+    fn other_events_do_not_trigger_parse_error_handler() {
+        let sender = noop_send_output();
+        let mut output_sender = DoraOutputSender(&sender);
+        let mut op = RecordingOperator::default();
+
+        let status = op.on_event(&Event::Stop, &mut output_sender).unwrap();
+        assert!(matches!(status, DoraStatus::Continue));
+        assert!(op.parse_errors.is_empty());
+    }
+
+    #[test]
+    fn multiple_parse_errors_accumulated_in_order() {
+        let sender = noop_send_output();
+        let mut output_sender = DoraOutputSender(&sender);
+        let mut op = RecordingOperator::default();
+
+        let ids: Vec<String> = (0..5u32).map(|i| format!("input-{i}")).collect();
+        let errors: Vec<String> = (0..5u32).map(|i| format!("corrupt-{i}")).collect();
+        for i in 0..5usize {
+            let event = Event::InputParseError {
+                id: &ids[i],
+                error: errors[i].clone(),
+            };
+            op.on_event(&event, &mut output_sender).unwrap();
+        }
+
+        assert_eq!(op.parse_errors.len(), 5);
+        for i in 0..5usize {
+            assert_eq!(op.parse_errors[i].0, ids[i]);
+            assert_eq!(op.parse_errors[i].1, errors[i]);
+        }
+    }
+
+    #[test]
+    fn empty_id_and_error_strings_are_preserved() {
+        let sender = noop_send_output();
+        let mut output_sender = DoraOutputSender(&sender);
+        let mut op = RecordingOperator::default();
+
+        let event = Event::InputParseError {
+            id: "",
+            error: String::new(),
+        };
+        op.on_event(&event, &mut output_sender).unwrap();
+
+        assert_eq!(op.parse_errors.len(), 1);
+        assert_eq!(op.parse_errors[0].0, "");
+        assert_eq!(op.parse_errors[0].1, "");
+    }
+
+    #[test]
+    fn parse_error_interleaved_with_other_events_only_parse_errors_recorded() {
+        let sender = noop_send_output();
+        let mut output_sender = DoraOutputSender(&sender);
+        let mut op = RecordingOperator::default();
+
+        op.on_event(&Event::Stop, &mut output_sender).unwrap();
+        op.on_event(
+            &Event::InputParseError {
+                id: "x",
+                error: "oops".to_string(),
+            },
+            &mut output_sender,
+        )
+        .unwrap();
+        op.on_event(&Event::InputClosed { id: "y" }, &mut output_sender)
+            .unwrap();
+        op.on_event(
+            &Event::InputParseError {
+                id: "z",
+                error: "bad".to_string(),
+            },
+            &mut output_sender,
+        )
+        .unwrap();
+
+        assert_eq!(op.parse_errors.len(), 2);
+        assert_eq!(op.parse_errors[0].0, "x");
+        assert_eq!(op.parse_errors[1].0, "z");
+    }
+
+    #[test]
+    fn send_output_is_send_sync() {
+        // Compile-time proof that SendOutput (backed by ArcDynFn1) satisfies
+        // the Send+Sync bounds required by the operator runtime, which hands
+        // it across thread boundaries.
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<SendOutput>();
+    }
+
+    #[test]
+    fn parse_errors_accumulated_from_concurrent_event_streams() {
+        // Simulates two independent operator instances processing events
+        // concurrently — exercises the no-shared-state invariant.
+        let results: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let results2 = Arc::clone(&results);
+
+        let h1 = std::thread::spawn(move || {
+            let sender = noop_send_output();
+            let mut output_sender = DoraOutputSender(&sender);
+            let mut op = RecordingOperator::default();
+            for i in 0..100u32 {
+                op.on_event(
+                    &Event::InputParseError {
+                        id: "thread-1",
+                        error: format!("err-{i}"),
+                    },
+                    &mut output_sender,
+                )
+                .unwrap();
+            }
+            results2
+                .lock()
+                .unwrap()
+                .push(format!("t1:{}", op.parse_errors.len()));
+        });
+
+        let results3 = Arc::clone(&results);
+        let h2 = std::thread::spawn(move || {
+            let sender = noop_send_output();
+            let mut output_sender = DoraOutputSender(&sender);
+            let mut op = RecordingOperator::default();
+            for i in 0..100u32 {
+                op.on_event(
+                    &Event::InputParseError {
+                        id: "thread-2",
+                        error: format!("err-{i}"),
+                    },
+                    &mut output_sender,
+                )
+                .unwrap();
+            }
+            results3
+                .lock()
+                .unwrap()
+                .push(format!("t2:{}", op.parse_errors.len()));
+        });
+
+        h1.join().unwrap();
+        h2.join().unwrap();
+
+        let r = results.lock().unwrap();
+        assert!(r.contains(&"t1:100".to_string()));
+        assert!(r.contains(&"t2:100".to_string()));
+    }
+}

--- a/apis/rust/operator/src/lib.rs
+++ b/apis/rust/operator/src/lib.rs
@@ -222,5 +222,4 @@ mod tests {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<SendOutput>();
     }
-
 }

--- a/docs/api-cxx.md
+++ b/docs/api-cxx.md
@@ -418,13 +418,13 @@ ROS2 subscriptions add their own events to the merged stream. Use `subscription-
 
 ## Operator API (`dora-operator-api-cxx`)
 
-Operators are shared libraries loaded by the Dora runtime. The C++ side implements four functions that the CXX bridge calls into.
+Operators are shared libraries loaded by the Dora runtime. The C++ side implements five functions that the CXX bridge calls into.
 
-> **Breaking change vs. earlier dora releases:** the operator API used to require only `new_operator` + `on_input`; `Event::InputClosed` and `Event::Stop` were silently dropped on the C++ side. As of this release the bridge calls `on_input_closed` and `on_stop` instead, so existing C++ operators must add these two functions (a no-op stub returning `{ rust::String(), false }` is sufficient to restore the pre-change behavior). See [#1849](https://github.com/dora-rs/dora/pull/1849) for the rationale.
+> **Breaking change vs. earlier dora releases:** the operator API used to require only `new_operator` + `on_input`; `Event::InputClosed` and `Event::Stop` were silently dropped on the C++ side. As of dora #1849 the bridge calls `on_input_closed` and `on_stop` instead. As of dora #1879 the bridge also calls `on_input_parse_error`. Existing operators must add a no-op stub for each new function — `return { rust::String(), false };` is sufficient.
 
 ### Required C++ interface
 
-You must provide a header `operator.h` and an implementation file. The header declares an `Operator` class and four free functions:
+You must provide a header `operator.h` and an implementation file. The header declares an `Operator` class and five free functions:
 
 ```cpp
 // operator.h
@@ -448,18 +448,20 @@ DoraOnInputResult on_input(
 
 DoraOnInputResult on_input_closed(Operator& op, rust::Str id, OutputSender& output_sender);
 DoraOnInputResult on_stop(Operator& op, OutputSender& output_sender);
+DoraOnInputResult on_input_parse_error(Operator& op, rust::Str id, rust::Str error, OutputSender& output_sender);
 ```
 
 - `new_operator()` -- called once at startup; returns the operator instance.
 - `on_input()` -- called for every input event; process data and optionally send outputs.
 - `on_input_closed()` -- called when an upstream input stream closes (the daemon delivers `Event::InputClosed { id }`). Operator can log, flush per-input state, or `send_output(output_sender, ...)` to emit a final/status message in response. Set `result.stop = true` to request shutdown.
 - `on_stop()` -- called on graceful shutdown (the daemon delivers `Event::Stop`). Operator can drain output queues, persist final state, or `send_output(output_sender, ...)` to flush buffered data before returning.
+- `on_input_parse_error()` -- called when an input's Arrow data fails to deserialize (`Event::InputParseError { id, error }`). `id` identifies the affected input; `error` is the deserialization error string. Operator can log the error, surface it as health state, or request shutdown. Previously these events were silently dropped.
 
-Default implementations that simply log + return success are sufficient for operators that don't need to react to these events. The `output_sender` argument is provided so that operators which want to emit final/status outputs on close or stop can do so symmetrically to `on_input`. See `examples/c++-dataflow/operator-rust-api/operator.cc` for a minimal reference.
+Default implementations that simply log + return success are sufficient for operators that don't need to react to these events. See `examples/c++-dataflow/operator-rust-api/operator.cc` for a minimal reference.
 
 ### OutputSender (operator)
 
-Available inside `on_input()`. Sends data on a named output.
+Available inside all operator callbacks. Sends data on a named output.
 
 ```cpp
 DoraSendOutputResult send_output(

--- a/docs/api-cxx.md
+++ b/docs/api-cxx.md
@@ -477,7 +477,11 @@ struct DoraOnInputResult {
     rust::String error;  // empty on success
     bool         stop;   // true to request graceful shutdown
 };
+```
 
+> **`error` and `stop` are mutually exclusive.** If `error` is non-empty the runtime treats the result as a fatal failure regardless of the `stop` field. Use `stop = true` only when `error` is empty.
+
+```cpp
 struct DoraSendOutputResult {
     rust::String error;  // empty on success
 };

--- a/examples/c++-dataflow/operator-rust-api/operator.cc
+++ b/examples/c++-dataflow/operator-rust-api/operator.cc
@@ -39,3 +39,12 @@ DoraOnInputResult on_stop(Operator &op, OutputSender &output_sender)
     DoraOnInputResult result = {rust::String(), false};
     return result;
 }
+
+DoraOnInputResult on_input_parse_error(Operator &op, rust::Str id, rust::Str error, OutputSender &output_sender)
+{
+    (void)op;
+    (void)output_sender;
+    std::cerr << "Rust API operator: input parse error on `" << std::string(id) << "`: " << std::string(error) << std::endl;
+    DoraOnInputResult result = {rust::String(), false};
+    return result;
+}

--- a/examples/c++-dataflow/operator-rust-api/operator.h
+++ b/examples/c++-dataflow/operator-rust-api/operator.h
@@ -16,3 +16,4 @@ std::unique_ptr<Operator> new_operator();
 DoraOnInputResult on_input(Operator &op, rust::Str id, rust::Slice<const uint8_t> data, OutputSender &output_sender);
 DoraOnInputResult on_input_closed(Operator &op, rust::Str id, OutputSender &output_sender);
 DoraOnInputResult on_stop(Operator &op, OutputSender &output_sender);
+DoraOnInputResult on_input_parse_error(Operator &op, rust::Str id, rust::Str error, OutputSender &output_sender);

--- a/examples/cmake-dataflow/operator-rust-api/operator.cc
+++ b/examples/cmake-dataflow/operator-rust-api/operator.cc
@@ -39,3 +39,12 @@ DoraOnInputResult on_stop(Operator &op, OutputSender &output_sender)
     DoraOnInputResult result = {rust::String(), false};
     return result;
 }
+
+DoraOnInputResult on_input_parse_error(Operator &op, rust::Str id, rust::Str error, OutputSender &output_sender)
+{
+    (void)op;
+    (void)output_sender;
+    std::cerr << "Rust API operator: input parse error on `" << std::string(id) << "`: " << std::string(error) << std::endl;
+    DoraOnInputResult result = {rust::String(), false};
+    return result;
+}

--- a/examples/cmake-dataflow/operator-rust-api/operator.h
+++ b/examples/cmake-dataflow/operator-rust-api/operator.h
@@ -16,3 +16,4 @@ std::unique_ptr<Operator> new_operator();
 DoraOnInputResult on_input(Operator &op, rust::Str id, rust::Slice<const uint8_t> data, OutputSender &output_sender);
 DoraOnInputResult on_input_closed(Operator &op, rust::Str id, OutputSender &output_sender);
 DoraOnInputResult on_stop(Operator &op, OutputSender &output_sender);
+DoraOnInputResult on_input_parse_error(Operator &op, rust::Str id, rust::Str error, OutputSender &output_sender);

--- a/tests/cmake-find-package-operator-cxx/main.cc
+++ b/tests/cmake-find-package-operator-cxx/main.cc
@@ -38,3 +38,12 @@ DoraOnInputResult on_stop(Operator &op, OutputSender &output_sender) {
     DoraOnInputResult result = {rust::String(), false};
     return result;
 }
+
+DoraOnInputResult on_input_parse_error(Operator &op, rust::Str id, rust::Str error, OutputSender &output_sender) {
+    (void)op;
+    (void)id;
+    (void)error;
+    (void)output_sender;
+    DoraOnInputResult result = {rust::String(), false};
+    return result;
+}

--- a/tests/cmake-find-package-operator-cxx/operator.h
+++ b/tests/cmake-find-package-operator-cxx/operator.h
@@ -20,3 +20,4 @@ std::unique_ptr<Operator> new_operator();
 DoraOnInputResult on_input(Operator &op, rust::Str id, rust::Slice<const uint8_t> data, OutputSender &output_sender);
 DoraOnInputResult on_input_closed(Operator &op, rust::Str id, OutputSender &output_sender);
 DoraOnInputResult on_stop(Operator &op, OutputSender &output_sender);
+DoraOnInputResult on_input_parse_error(Operator &op, rust::Str id, rust::Str error, OutputSender &output_sender);

--- a/tests/cpp-operator-cxx-bridge.rs
+++ b/tests/cpp-operator-cxx-bridge.rs
@@ -26,8 +26,7 @@ use std::{mem, path::PathBuf, sync::Arc};
 use arrow_array::{Array, Int32Array};
 use dora_operator_api_types::{
     DoraInitResult, DoraResult, DoraStatus, Input, Metadata, OnEventResult, RawEvent, SendOutput,
-    arrow::ffi::FFI_ArrowArray,
-    safer_ffi::closure::ArcDynFn1,
+    arrow::ffi::FFI_ArrowArray, safer_ffi::closure::ArcDynFn1,
 };
 
 fn shared_lib_path() -> PathBuf {

--- a/tests/cpp-operator-cxx-bridge.rs
+++ b/tests/cpp-operator-cxx-bridge.rs
@@ -51,9 +51,7 @@ fn noop_send_output() -> SendOutput {
 fn cxx_bridge_dispatches_input_parse_error() {
     let lib_path = shared_lib_path();
     if !lib_path.exists() {
-        eprintln!(
-            "SKIP: {lib_path:?} not found — run `cargo run --example cxx-dataflow` first"
-        );
+        eprintln!("SKIP: {lib_path:?} not found — run `cargo run --example cxx-dataflow` first");
         return;
     }
 
@@ -62,11 +60,8 @@ fn cxx_bridge_dispatches_input_parse_error() {
         .unwrap_or_else(|e| panic!("failed to load {lib_path:?}: {e}"));
 
     type InitFn = unsafe extern "C" fn() -> DoraInitResult;
-    type OnEventFn = unsafe extern "C" fn(
-        &mut RawEvent,
-        &SendOutput,
-        *mut std::ffi::c_void,
-    ) -> OnEventResult;
+    type OnEventFn =
+        unsafe extern "C" fn(&mut RawEvent, &SendOutput, *mut std::ffi::c_void) -> OnEventResult;
     type DropFn = unsafe extern "C" fn(*mut std::ffi::c_void) -> DoraResult;
 
     // SAFETY: symbol names and types match the register_operator!-generated exports.
@@ -93,9 +88,8 @@ fn cxx_bridge_dispatches_input_parse_error() {
     // schema only needs to be valid in memory (not semantically matched).
     let arr = Int32Array::from(vec![1i32]);
     let arr_data = arr.to_data();
-    let (real_ffi_array, schema) =
-        dora_operator_api_types::arrow::ffi::to_ffi(&arr_data)
-            .expect("to_ffi on valid Int32Array must not fail");
+    let (real_ffi_array, schema) = dora_operator_api_types::arrow::ffi::to_ffi(&arr_data)
+        .expect("to_ffi on valid Int32Array must not fail");
     // Intentional memory leak: we forget the valid FFI_ArrowArray so its
     // release callback is not invoked.  The small tracking allocation is
     // acceptable in test context.

--- a/tests/cpp-operator-cxx-bridge.rs
+++ b/tests/cpp-operator-cxx-bridge.rs
@@ -13,11 +13,12 @@
 //! ----------------
 //! * `dora_on_event` / `dora_init_operator` / `dora_drop_operator` are
 //!   exported and loadable (catches link-time symbol regressions).
-//! * Passing a *released* `FFI_ArrowArray` (all-zero struct → `release = None`)
-//!   causes `arrow::ffi::from_ffi` to return `Err`, which
-//!   `raw::dora_on_event` converts to `Event::InputParseError` and dispatches
-//!   to `OperatorWrapper::on_event` → `ffi::on_input_parse_error` (the
-//!   cxx-bridge call site added in #1879).
+//! * Passing a structurally-valid `FFI_ArrowArray` for Int32 (n_buffers = 2,
+//!   non-null buffers pointer, length = 1) with a null values slot causes
+//!   `arrow::ffi::from_ffi` to return `Err("null buffer at position 1")`,
+//!   which `raw::dora_on_event` converts to `Event::InputParseError` and
+//!   dispatches to `OperatorWrapper::on_event` → `ffi::on_input_parse_error`
+//!   (the cxx-bridge call site added in #1879).
 //! * The C++ stub returns `{error: "", stop: false}`, so the final
 //!   `OnEventResult` is `{ result: SUCCESS, status: Continue }`.
 
@@ -81,23 +82,32 @@ fn cxx_bridge_dispatches_input_parse_error() {
         init_result.error
     );
 
-    // Construct a valid schema from a real Int32Array, then substitute a
-    // zeroed (released) FFI_ArrowArray.  arrow::ffi::from_ffi returns Err
-    // immediately when release == None, without reading the schema, so the
-    // schema only needs to be valid in memory (not semantically matched).
+    // Schema and array are independent objects in the Arrow C Data Interface;
+    // we only need the type metadata (schema) here.
     let arr = Int32Array::from(vec![1i32]);
     let arr_data = arr.to_data();
-    let (real_ffi_array, schema) = dora_operator_api_types::arrow::ffi::to_ffi(&arr_data)
+    let (_ffi_array, schema) = dora_operator_api_types::arrow::ffi::to_ffi(&arr_data)
         .expect("to_ffi on valid Int32Array must not fail");
-    // Intentional memory leak: we forget the valid FFI_ArrowArray so its
-    // release callback is not invoked.  The small tracking allocation is
-    // acceptable in test context.
-    mem::forget(real_ffi_array);
+    drop(_ffi_array);
 
-    // SAFETY: FFI_ArrowArray is repr(C); zeroed gives release = None.
-    // The Drop impl for FFI_ArrowArray only calls release when Some, so
-    // dropping this is a no-op — no dangling-pointer deref occurs.
-    let bad_array: FFI_ArrowArray = unsafe { mem::zeroed() };
+    // Construct a structurally-valid FFI_ArrowArray for Int32 that causes
+    // arrow::ffi::from_ffi to return Err rather than panic.
+    //
+    // Per Arrow C Data Interface, Int32 requires n_buffers == 2:
+    //   buffers[0] = validity bitmap — null is valid (means no nulls)
+    //   buffers[1] = values buffer  — null + non-zero byte length → Err
+    //
+    // The `buffers` field must be a non-null pointer; FFI_ArrowArray::buffer()
+    // asserts !buffers.is_null() before from_ffi can inspect the per-slot
+    // values.  length = 1 keeps the computed byte-size > 0 so from_ffi
+    // returns Err instead of Ok(empty).  Drop is a no-op when release == None.
+    let buffer_ptrs: [*const std::ffi::c_void; 2] = [std::ptr::null(), std::ptr::null()];
+    // SAFETY: FFI_ArrowArray is repr(C). We set n_buffers, buffers, and length
+    // to structurally-valid values; all other fields are zeroed (null/false/0).
+    let mut bad_array: FFI_ArrowArray = unsafe { mem::zeroed() };
+    bad_array.n_buffers = 2;
+    bad_array.buffers = buffer_ptrs.as_ptr() as *mut *const std::ffi::c_void;
+    bad_array.length = 1;
 
     let input = Input {
         id: "test-input".to_owned().into(),

--- a/tests/cpp-operator-cxx-bridge.rs
+++ b/tests/cpp-operator-cxx-bridge.rs
@@ -1,0 +1,146 @@
+//! Smoke test: exercise the cxx-bridge `on_input_parse_error` dispatch path.
+//!
+//! Loads the compiled `operator_rust_api` shared library via `libloading`,
+//! calls `dora_on_event` with a malformed Arrow FFI array, and verifies the
+//! C++ callback was invoked and returned cleanly.
+//!
+//! The test is **skipped** (not failed) when the shared library is absent so
+//! it does not break CI configurations that omit the C++ toolchain.  It is
+//! intended to run as part of the nightly / full build after
+//! `cargo run --example cxx-dataflow` has produced the artifacts.
+//!
+//! What is verified
+//! ----------------
+//! * `dora_on_event` / `dora_init_operator` / `dora_drop_operator` are
+//!   exported and loadable (catches link-time symbol regressions).
+//! * Passing a *released* `FFI_ArrowArray` (all-zero struct → `release = None`)
+//!   causes `arrow::ffi::from_ffi` to return `Err`, which
+//!   `raw::dora_on_event` converts to `Event::InputParseError` and dispatches
+//!   to `OperatorWrapper::on_event` → `ffi::on_input_parse_error` (the
+//!   cxx-bridge call site added in #1879).
+//! * The C++ stub returns `{error: "", stop: false}`, so the final
+//!   `OnEventResult` is `{ result: SUCCESS, status: Continue }`.
+
+use std::{mem, path::PathBuf, sync::Arc};
+
+use arrow_array::{Array, Int32Array};
+use dora_operator_api_types::{
+    DoraInitResult, DoraResult, DoraStatus, Input, Metadata, OnEventResult, RawEvent, SendOutput,
+    arrow::ffi::FFI_ArrowArray,
+    safer_ffi::closure::ArcDynFn1,
+};
+
+fn shared_lib_path() -> PathBuf {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let build_dir = manifest.join("examples/c++-dataflow/build");
+    build_dir.join(format!(
+        "{}operator_rust_api{}",
+        std::env::consts::DLL_PREFIX,
+        std::env::consts::DLL_SUFFIX,
+    ))
+}
+
+fn noop_send_output() -> SendOutput {
+    use dora_operator_api_types::Output;
+    SendOutput {
+        send_output: ArcDynFn1::new(Arc::new(|_: Output| DoraResult::SUCCESS)),
+    }
+}
+
+#[test]
+fn cxx_bridge_dispatches_input_parse_error() {
+    let lib_path = shared_lib_path();
+    if !lib_path.exists() {
+        eprintln!(
+            "SKIP: {lib_path:?} not found — run `cargo run --example cxx-dataflow` first"
+        );
+        return;
+    }
+
+    // SAFETY: trusted shared library produced by the cxx-dataflow example build.
+    let lib = unsafe { libloading::Library::new(&lib_path) }
+        .unwrap_or_else(|e| panic!("failed to load {lib_path:?}: {e}"));
+
+    type InitFn = unsafe extern "C" fn() -> DoraInitResult;
+    type OnEventFn = unsafe extern "C" fn(
+        &mut RawEvent,
+        &SendOutput,
+        *mut std::ffi::c_void,
+    ) -> OnEventResult;
+    type DropFn = unsafe extern "C" fn(*mut std::ffi::c_void) -> DoraResult;
+
+    // SAFETY: symbol names and types match the register_operator!-generated exports.
+    let init: libloading::Symbol<InitFn> =
+        unsafe { lib.get(b"dora_init_operator\0") }.expect("dora_init_operator not found");
+    let on_event_sym: libloading::Symbol<OnEventFn> =
+        unsafe { lib.get(b"dora_on_event\0") }.expect("dora_on_event not found");
+    let drop_op: libloading::Symbol<DropFn> =
+        unsafe { lib.get(b"dora_drop_operator\0") }.expect("dora_drop_operator not found");
+
+    let DoraInitResult {
+        result: init_result,
+        operator_context,
+    } = unsafe { init() };
+    assert!(
+        init_result.error.is_none(),
+        "dora_init_operator failed: {:?}",
+        init_result.error
+    );
+
+    // Construct a valid schema from a real Int32Array, then substitute a
+    // zeroed (released) FFI_ArrowArray.  arrow::ffi::from_ffi returns Err
+    // immediately when release == None, without reading the schema, so the
+    // schema only needs to be valid in memory (not semantically matched).
+    let arr = Int32Array::from(vec![1i32]);
+    let arr_data = arr.to_data();
+    let (real_ffi_array, schema) =
+        dora_operator_api_types::arrow::ffi::to_ffi(&arr_data)
+            .expect("to_ffi on valid Int32Array must not fail");
+    // Intentional memory leak: we forget the valid FFI_ArrowArray so its
+    // release callback is not invoked.  The small tracking allocation is
+    // acceptable in test context.
+    mem::forget(real_ffi_array);
+
+    // SAFETY: FFI_ArrowArray is repr(C); zeroed gives release = None.
+    // The Drop impl for FFI_ArrowArray only calls release when Some, so
+    // dropping this is a no-op — no dangling-pointer deref occurs.
+    let bad_array: FFI_ArrowArray = unsafe { mem::zeroed() };
+
+    let input = Input {
+        id: "test-input".to_owned().into(),
+        data_array: Some(bad_array),
+        schema,
+        metadata: Metadata {
+            open_telemetry_context: String::new().into(),
+        },
+    };
+    let mut event = RawEvent {
+        input: Some(Box::new(input).into()),
+        input_closed: None,
+        stop: false,
+        error: None,
+    };
+    let send_output = noop_send_output();
+
+    // SAFETY: operator_context is live (just returned by init), event and
+    // send_output outlive this call.
+    let OnEventResult { result, status } =
+        unsafe { on_event_sym(&mut event, &send_output, operator_context) };
+
+    assert!(
+        result.error.is_none(),
+        "on_input_parse_error returned an error: {:?}",
+        result.error
+    );
+    assert!(
+        matches!(status, DoraStatus::Continue),
+        "expected Continue after InputParseError, got {status:?}"
+    );
+
+    let drop_result = unsafe { drop_op(operator_context) };
+    assert!(
+        drop_result.error.is_none(),
+        "dora_drop_operator failed: {:?}",
+        drop_result.error
+    );
+}


### PR DESCRIPTION
Wires `Event::InputParseError` to a C++ callback. Previously silently dropped by the catch-all arm in `OperatorWrapper::on_event`.

## what changed

- `apis/c++/operator/src/lib.rs`: `on_input_parse_error(op, id, error, output_sender)` added to the cxx bridge `unsafe extern "C++"` block and dispatched in `on_event`
- `apis/rust/operator/src/lib.rs`: 7 unit tests — basic dispatch, empty strings, multiple errors in order, interleaved events, `Send+Sync` compile-time proof, two concurrency cases; clean under ASAN and TSAN
- both `c++-dataflow` and `cmake-dataflow` operator-rust-api examples updated (header + impl)
- `tests/cmake-find-package-operator-cxx`: fixture updated so the find_package compile-link smoke still passes
- `docs/api-cxx.md`: five callbacks documented; breaking-change note updated; OutputSender availability note widened

## breaking change

Same shape as #1849. Existing C++ operators must add a stub:

```cpp
DoraOnInputResult on_input_parse_error(Operator &op, rust::Str id, rust::Str error, OutputSender &output_sender) {
    (void)op; (void)id; (void)error; (void)output_sender;
    return { rust::String(), false };
}
```

## C-API parallel surface

Intentionally omitted. C operators consume raw bytes via `dora_read_data` and never hit the arrow parse path that emits this event. `operator_types.h` is auto-generated by `safer_ffi` — manual edits would be clobbered.