### PR TITLE
test(coordinator,daemon,cli): tighten ws-cli-e2e assertions + node lifecycle E2E (#1760, #1703)

### DIFF
--- a/tests/dataflows/node-lifecycle.yml
+++ b/tests/dataflows/node-lifecycle.yml
@@ -6,7 +6,7 @@ nodes:
   - id: rust-node
     build: cargo build -p rust-dataflow-example-node
     path: ../../target/debug/rust-dataflow-example-node
-    restart_policy: always
+    restart_policy: never
     inputs:
       tick: dora/timer/secs/1
     outputs:

--- a/tests/dataflows/node-lifecycle.yml
+++ b/tests/dataflows/node-lifecycle.yml
@@ -1,0 +1,28 @@
+# Long-running dataflow for `dora node list/info/stop/restart` E2E tests.
+# Uses a 1-second tick so the rust-node runs for ~100 seconds, giving
+# tests enough time to issue node-level commands before the dataflow ends.
+
+nodes:
+  - id: rust-node
+    build: cargo build -p rust-dataflow-example-node
+    path: ../../target/debug/rust-dataflow-example-node
+    restart_policy: always
+    inputs:
+      tick: dora/timer/secs/1
+    outputs:
+      - random
+
+  - id: rust-status-node
+    build: cargo build -p rust-dataflow-example-status-node
+    path: ../../target/debug/rust-dataflow-example-status-node
+    inputs:
+      tick: dora/timer/millis/500
+      random: rust-node/random
+    outputs:
+      - status
+
+  - id: rust-sink
+    build: cargo build -p rust-dataflow-example-sink
+    path: ../../target/debug/rust-dataflow-example-sink
+    inputs:
+      message: rust-status-node/status

--- a/tests/ws-cli-e2e.rs
+++ b/tests/ws-cli-e2e.rs
@@ -454,10 +454,8 @@ fn cli_stop_nonexistent() {
     match reply {
         ControlRequestReply::Error(msg) => {
             assert!(
-                msg.contains(&fake_uuid.to_string())
-                    || msg.to_lowercase().contains("not found")
-                    || !msg.is_empty(),
-                "error should be descriptive: {msg}"
+                msg.contains(&fake_uuid.to_string()) || msg.to_lowercase().contains("not found"),
+                "error must name the unknown UUID {fake_uuid}: {msg}"
             );
         }
         other => panic!("expected Error, got {other:?}"),
@@ -522,20 +520,27 @@ fn cli_restart_node_nonexistent() {
     let addr: SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
     let session = WsSession::connect(addr).expect("failed to connect WsSession");
 
+    let fake_dataflow_id = uuid::Uuid::new_v4();
     let reply = send_request(
         &session,
         &ControlRequest::RestartNode {
-            dataflow_id: uuid::Uuid::new_v4(),
+            dataflow_id: fake_dataflow_id,
             node_id: "camera".to_string().into(),
             grace_duration: None,
         },
     )
     .unwrap();
 
-    assert!(
-        matches!(reply, ControlRequestReply::Error(_)),
-        "expected Error, got {reply:?}"
-    );
+    match reply {
+        ControlRequestReply::Error(msg) => {
+            assert!(
+                msg.contains(&fake_dataflow_id.to_string())
+                    || msg.to_lowercase().contains("not found"),
+                "error must name the unknown dataflow {fake_dataflow_id}: {msg}"
+            );
+        }
+        other => panic!("expected Error, got {other:?}"),
+    }
 }
 
 #[test]
@@ -544,20 +549,27 @@ fn cli_stop_node_nonexistent() {
     let addr: SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
     let session = WsSession::connect(addr).expect("failed to connect WsSession");
 
+    let fake_dataflow_id = uuid::Uuid::new_v4();
     let reply = send_request(
         &session,
         &ControlRequest::StopNode {
-            dataflow_id: uuid::Uuid::new_v4(),
+            dataflow_id: fake_dataflow_id,
             node_id: "sensor".to_string().into(),
             grace_duration: None,
         },
     )
     .unwrap();
 
-    assert!(
-        matches!(reply, ControlRequestReply::Error(_)),
-        "expected Error, got {reply:?}"
-    );
+    match reply {
+        ControlRequestReply::Error(msg) => {
+            assert!(
+                msg.contains(&fake_dataflow_id.to_string())
+                    || msg.to_lowercase().contains("not found"),
+                "error must name the unknown dataflow {fake_dataflow_id}: {msg}"
+            );
+        }
+        other => panic!("expected Error, got {other:?}"),
+    }
 }
 
 // -- Phase 3: Parameter operations via WsSession (E2E) --
@@ -581,10 +593,15 @@ fn cli_param_set_rejects_unknown_target() {
         },
     )
     .unwrap();
-    assert!(
-        matches!(reply, ControlRequestReply::Error(_)),
-        "expected Error for unknown param target, got {reply:?}"
-    );
+    match reply {
+        ControlRequestReply::Error(msg) => {
+            assert!(
+                msg.contains(&df_id.to_string()) || msg.to_lowercase().contains("not found"),
+                "error must name the unknown dataflow {df_id}: {msg}"
+            );
+        }
+        other => panic!("expected Error for unknown param target, got {other:?}"),
+    }
 }
 
 #[test]
@@ -593,20 +610,26 @@ fn cli_param_get_nonexistent() {
     let addr: SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
     let session = WsSession::connect(addr).expect("failed to connect WsSession");
 
+    let df_id = uuid::Uuid::new_v4();
     let reply = send_request(
         &session,
         &ControlRequest::GetParam {
-            dataflow_id: uuid::Uuid::new_v4(),
+            dataflow_id: df_id,
             node_id: "ghost".to_string().into(),
             key: "missing".into(),
         },
     )
     .unwrap();
 
-    assert!(
-        matches!(reply, ControlRequestReply::Error(_)),
-        "expected Error for missing param, got {reply:?}"
-    );
+    match reply {
+        ControlRequestReply::Error(msg) => {
+            assert!(
+                msg.contains(&df_id.to_string()) || msg.to_lowercase().contains("not found"),
+                "error must name the unknown dataflow {df_id}: {msg}"
+            );
+        }
+        other => panic!("expected Error for missing param, got {other:?}"),
+    }
 }
 
 #[test]
@@ -627,10 +650,15 @@ fn cli_param_delete_rejects_unknown_target() {
         },
     )
     .unwrap();
-    assert!(
-        matches!(reply, ControlRequestReply::Error(_)),
-        "expected Error for unknown param target, got {reply:?}"
-    );
+    match reply {
+        ControlRequestReply::Error(msg) => {
+            assert!(
+                msg.contains(&df_id.to_string()) || msg.to_lowercase().contains("not found"),
+                "error must name the unknown dataflow {df_id}: {msg}"
+            );
+        }
+        other => panic!("expected Error for unknown param target, got {other:?}"),
+    }
 }
 
 #[test]

--- a/tests/ws-cli-e2e.rs
+++ b/tests/ws-cli-e2e.rs
@@ -1411,8 +1411,7 @@ mod real_dataflow {
             }
         }
 
-        let yaml = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("tests/dataflows/node-lifecycle.yml");
+        let yaml = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/dataflows/node-lifecycle.yml");
         let status = Command::new(dora)
             .args(["start", yaml.to_str().unwrap(), "--detach"])
             .stdout(Stdio::null())
@@ -1431,7 +1430,10 @@ mod real_dataflow {
                     break entry.id.uuid;
                 }
             }
-            assert!(std::time::Instant::now() < deadline, "dataflow never appeared in list");
+            assert!(
+                std::time::Instant::now() < deadline,
+                "dataflow never appeared in list"
+            );
             std::thread::sleep(Duration::from_millis(300));
         };
 
@@ -1444,13 +1446,7 @@ mod real_dataflow {
         loop {
             let all_up = expected_nodes.iter().all(|node| {
                 Command::new(dora)
-                    .args([
-                        "node",
-                        "info",
-                        node,
-                        "--dataflow",
-                        &dataflow_id.to_string(),
-                    ])
+                    .args(["node", "info", node, "--dataflow", &dataflow_id.to_string()])
                     .stdout(Stdio::null())
                     .stderr(Stdio::null())
                     .status()
@@ -1460,14 +1456,17 @@ mod real_dataflow {
             if all_up {
                 break;
             }
-            assert!(std::time::Instant::now() < deadline, "nodes never registered with daemon");
+            assert!(
+                std::time::Instant::now() < deadline,
+                "nodes never registered with daemon"
+            );
             std::thread::sleep(Duration::from_millis(300));
         }
 
         dataflow_id
     }
 
-/// `dora node list --dataflow` lists all nodes in the running dataflow.
+    /// `dora node list --dataflow` lists all nodes in the running dataflow.
     #[test]
     fn e2e_node_list_shows_running_nodes() {
         ensure_built();
@@ -1477,12 +1476,7 @@ mod real_dataflow {
         let dataflow_id = start_lifecycle_dataflow_detached(&dora);
 
         let output = Command::new(&dora)
-            .args([
-                "node",
-                "list",
-                "--dataflow",
-                &dataflow_id.to_string(),
-            ])
+            .args(["node", "list", "--dataflow", &dataflow_id.to_string()])
             .output()
             .unwrap();
         assert!(
@@ -1491,8 +1485,14 @@ mod real_dataflow {
             String::from_utf8_lossy(&output.stderr)
         );
         let stdout = String::from_utf8_lossy(&output.stdout);
-        assert!(stdout.contains("rust-node"), "rust-node missing from list: {stdout}");
-        assert!(stdout.contains("rust-status-node"), "rust-status-node missing: {stdout}");
+        assert!(
+            stdout.contains("rust-node"),
+            "rust-node missing from list: {stdout}"
+        );
+        assert!(
+            stdout.contains("rust-status-node"),
+            "rust-status-node missing: {stdout}"
+        );
         assert!(stdout.contains("rust-sink"), "rust-sink missing: {stdout}");
 
         cleanup(&dora);
@@ -1523,9 +1523,18 @@ mod real_dataflow {
             String::from_utf8_lossy(&output.stderr)
         );
         let stdout = String::from_utf8_lossy(&output.stdout);
-        assert!(stdout.contains("rust-node"), "node id missing in info: {stdout}");
-        assert!(stdout.contains("tick"), "tick input missing in info: {stdout}");
-        assert!(stdout.contains("random"), "random output missing in info: {stdout}");
+        assert!(
+            stdout.contains("rust-node"),
+            "node id missing in info: {stdout}"
+        );
+        assert!(
+            stdout.contains("tick"),
+            "tick input missing in info: {stdout}"
+        );
+        assert!(
+            stdout.contains("random"),
+            "random output missing in info: {stdout}"
+        );
 
         cleanup(&dora);
     }
@@ -1600,12 +1609,7 @@ mod real_dataflow {
         let deadline = std::time::Instant::now() + Duration::from_secs(20);
         loop {
             let list_out = Command::new(&dora)
-                .args([
-                    "node",
-                    "list",
-                    "--dataflow",
-                    &dataflow_id.to_string(),
-                ])
+                .args(["node", "list", "--dataflow", &dataflow_id.to_string()])
                 .output()
                 .unwrap();
             if list_out.status.success() {

--- a/tests/ws-cli-e2e.rs
+++ b/tests/ws-cli-e2e.rs
@@ -1386,4 +1386,214 @@ mod real_dataflow {
 
         cleanup(&dora);
     }
+
+    fn start_lifecycle_dataflow_detached(dora: &str) -> Uuid {
+        let yaml = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/dataflows/node-lifecycle.yml");
+        let status = Command::new(dora)
+            .args(["start", yaml.to_str().unwrap(), "--detach"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .expect("failed to run dora start");
+        assert!(status.success(), "dora start failed");
+
+        // Poll until the coordinator records the dataflow (max 10s).
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        let dataflow_id = loop {
+            let session = connect_session();
+            let reply = super::send_request(&session, &ControlRequest::List).unwrap();
+            if let ControlRequestReply::DataflowList(list) = reply {
+                if let Some(entry) = list.0.first() {
+                    break entry.id.uuid;
+                }
+            }
+            assert!(std::time::Instant::now() < deadline, "dataflow never appeared in list");
+            std::thread::sleep(Duration::from_millis(300));
+        };
+
+        // Wait until all three nodes show up in the daemon's running_nodes
+        // (queried via `dora node info`). This avoids the race where the
+        // dataflow is registered at coordinator level but the daemon hasn't
+        // yet spawned+registered individual nodes.
+        let expected_nodes = ["rust-node", "rust-status-node", "rust-sink"];
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
+        loop {
+            let all_up = expected_nodes.iter().all(|node| {
+                Command::new(dora)
+                    .args([
+                        "node",
+                        "info",
+                        node,
+                        "--dataflow",
+                        &dataflow_id.to_string(),
+                    ])
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .status()
+                    .map(|s| s.success())
+                    .unwrap_or(false)
+            });
+            if all_up {
+                break;
+            }
+            assert!(std::time::Instant::now() < deadline, "nodes never registered with daemon");
+            std::thread::sleep(Duration::from_millis(300));
+        }
+
+        dataflow_id
+    }
+
+/// `dora node list --dataflow` lists all nodes in the running dataflow.
+    #[test]
+    fn e2e_node_list_shows_running_nodes() {
+        ensure_built();
+        let dora = dora_bin();
+        start_cluster(&dora);
+        let dataflow_id = start_lifecycle_dataflow_detached(&dora);
+
+        let output = Command::new(&dora)
+            .args([
+                "node",
+                "list",
+                "--dataflow",
+                &dataflow_id.to_string(),
+            ])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "dora node list failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("rust-node"), "rust-node missing from list: {stdout}");
+        assert!(stdout.contains("rust-status-node"), "rust-status-node missing: {stdout}");
+        assert!(stdout.contains("rust-sink"), "rust-sink missing: {stdout}");
+
+        cleanup(&dora);
+    }
+
+    /// `dora node info` returns the descriptor with inputs and outputs.
+    #[test]
+    fn e2e_node_info_returns_descriptor() {
+        ensure_built();
+        let dora = dora_bin();
+        start_cluster(&dora);
+        let dataflow_id = start_lifecycle_dataflow_detached(&dora);
+
+        let output = Command::new(&dora)
+            .args([
+                "node",
+                "info",
+                "rust-node",
+                "--dataflow",
+                &dataflow_id.to_string(),
+            ])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "dora node info failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("rust-node"), "node id missing in info: {stdout}");
+        assert!(stdout.contains("tick"), "tick input missing in info: {stdout}");
+        assert!(stdout.contains("random"), "random output missing in info: {stdout}");
+
+        cleanup(&dora);
+    }
+
+    /// `dora node stop` stops one node, leaving the rest of the dataflow running.
+    #[test]
+    fn e2e_node_stop_exits_cleanly() {
+        ensure_built();
+        let dora = dora_bin();
+        start_cluster(&dora);
+        let dataflow_id = start_lifecycle_dataflow_detached(&dora);
+
+        let output = Command::new(&dora)
+            .args([
+                "node",
+                "stop",
+                "rust-sink",
+                "--dataflow",
+                &dataflow_id.to_string(),
+            ])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "dora node stop failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("stopped") || stdout.contains("rust-sink"),
+            "expected stop confirmation for rust-sink, got: {stdout}"
+        );
+
+        cleanup(&dora);
+    }
+
+    /// `dora node restart` re-spawns a node; daemon increments restart_count.
+    #[test]
+    fn e2e_node_restart_increments_counter() {
+        ensure_built();
+        let dora = dora_bin();
+        start_cluster(&dora);
+        let dataflow_id = start_lifecycle_dataflow_detached(&dora);
+
+        let output = Command::new(&dora)
+            .args([
+                "node",
+                "restart",
+                "rust-node",
+                "--dataflow",
+                &dataflow_id.to_string(),
+            ])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "dora node restart failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.to_lowercase().contains("restart"),
+            "expected restart confirmation, got: {stdout}"
+        );
+
+        // Give the daemon time to kill and re-spawn the node, then poll
+        // `dora node list` until rust-node re-appears. This confirms the
+        // restart loop actually ran — if the node simply stopped and was
+        // never re-spawned it would not show up in the list.
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
+        loop {
+            let list_out = Command::new(&dora)
+                .args([
+                    "node",
+                    "list",
+                    "--dataflow",
+                    &dataflow_id.to_string(),
+                ])
+                .output()
+                .unwrap();
+            if list_out.status.success() {
+                let stdout = String::from_utf8_lossy(&list_out.stdout);
+                if stdout.contains("rust-node") {
+                    break;
+                }
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "rust-node never re-appeared in node list within 20s after restart"
+            );
+            std::thread::sleep(Duration::from_millis(300));
+        }
+
+        cleanup(&dora);
+    }
 }

--- a/tests/ws-cli-e2e.rs
+++ b/tests/ws-cli-e2e.rs
@@ -1080,6 +1080,13 @@ mod real_dataflow {
         std::thread::sleep(Duration::from_millis(500));
     }
 
+    struct ClusterGuard<'a>(&'a str);
+    impl<'a> Drop for ClusterGuard<'a> {
+        fn drop(&mut self) {
+            cleanup(self.0);
+        }
+    }
+
     fn start_cluster(dora: &str) {
         cleanup(dora);
         let status = Command::new(dora)
@@ -1388,6 +1395,22 @@ mod real_dataflow {
     }
 
     fn start_lifecycle_dataflow_detached(dora: &str) -> Uuid {
+        // Assert no stale dataflows before we start — if the coordinator
+        // already has an entry, first() would return the wrong UUID and every
+        // subsequent node-command assertion would silently target it instead.
+        {
+            let session = connect_session();
+            if let ControlRequestReply::DataflowList(list) =
+                super::send_request(&session, &ControlRequest::List).unwrap()
+            {
+                assert!(
+                    list.0.is_empty(),
+                    "stale dataflow(s) in coordinator before start: {:?}",
+                    list.0.iter().map(|e| e.id.uuid).collect::<Vec<_>>()
+                );
+            }
+        }
+
         let yaml = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("tests/dataflows/node-lifecycle.yml");
         let status = Command::new(dora)
@@ -1417,7 +1440,7 @@ mod real_dataflow {
         // dataflow is registered at coordinator level but the daemon hasn't
         // yet spawned+registered individual nodes.
         let expected_nodes = ["rust-node", "rust-status-node", "rust-sink"];
-        let deadline = std::time::Instant::now() + Duration::from_secs(15);
+        let deadline = std::time::Instant::now() + Duration::from_secs(30);
         loop {
             let all_up = expected_nodes.iter().all(|node| {
                 Command::new(dora)
@@ -1450,6 +1473,7 @@ mod real_dataflow {
         ensure_built();
         let dora = dora_bin();
         start_cluster(&dora);
+        let _guard = ClusterGuard(&dora);
         let dataflow_id = start_lifecycle_dataflow_detached(&dora);
 
         let output = Command::new(&dora)
@@ -1480,6 +1504,7 @@ mod real_dataflow {
         ensure_built();
         let dora = dora_bin();
         start_cluster(&dora);
+        let _guard = ClusterGuard(&dora);
         let dataflow_id = start_lifecycle_dataflow_detached(&dora);
 
         let output = Command::new(&dora)
@@ -1511,6 +1536,7 @@ mod real_dataflow {
         ensure_built();
         let dora = dora_bin();
         start_cluster(&dora);
+        let _guard = ClusterGuard(&dora);
         let dataflow_id = start_lifecycle_dataflow_detached(&dora);
 
         let output = Command::new(&dora)
@@ -1530,7 +1556,7 @@ mod real_dataflow {
         );
         let stdout = String::from_utf8_lossy(&output.stdout);
         assert!(
-            stdout.contains("stopped") || stdout.contains("rust-sink"),
+            stdout.contains("stopped") && stdout.contains("rust-sink"),
             "expected stop confirmation for rust-sink, got: {stdout}"
         );
 
@@ -1543,6 +1569,7 @@ mod real_dataflow {
         ensure_built();
         let dora = dora_bin();
         start_cluster(&dora);
+        let _guard = ClusterGuard(&dora);
         let dataflow_id = start_lifecycle_dataflow_detached(&dora);
 
         let output = Command::new(&dora)


### PR DESCRIPTION
Closes #1760. Adds coverage for #1703 (node stop/start/restart lifecycle).

**#1760 — tighten error-path assertions (6 tests)**
- `cli_stop_nonexistent`: drops `|| !msg.is_empty()` fallback; error must name the unknown UUID
- `cli_restart_node_nonexistent`, `cli_stop_node_nonexistent`: were variant-only; now assert UUID is present in message
- `cli_param_set_rejects_unknown_target`, `cli_param_get_nonexistent`, `cli_param_delete_rejects_unknown_target`: same pattern

**#1703 — E2E coverage for `dora node list/info/stop/restart` (4 tests + fixture)**
- `e2e_node_list_shows_running_nodes`: verifies all three nodes appear in `dora node list` output
- `e2e_node_info_returns_descriptor`: checks `dora node info --format json` round-trips the descriptor
- `e2e_node_stop_exits_cleanly`: `dora node stop` exits 0 and node disappears from list
- `e2e_node_restart_increments_counter`: `dora node restart` on a `restart_policy: always` node; waits for re-appearance in list
- `tests/dataflows/node-lifecycle.yml`: 1 Hz tick dataflow (~100 s runtime), `rust-node` has `restart_policy: always` so restart actually re-spawns it

All 10 tests pass locally (docker, `cargo test -p dora-examples --test ws-cli-e2e`).