### PR TITLE
fix(core): replace expect with contextual errors on stdout/stderr pipe capture (closes #1499)

### DIFF
--- a/libraries/core/src/build/build_command.rs
+++ b/libraries/core/src/build/build_command.rs
@@ -195,8 +195,18 @@ pub async fn prepare_managed_python_env(
             .spawn()
             .wrap_err_with(|| format!("failed to spawn `uv venv {}`", python_env_dir.display()))?;
 
-        let child_stdout = BufReader::new(child.stdout.take().expect("failed to take stdout"));
-        let child_stderr = BufReader::new(child.stderr.take().expect("failed to take stderr"));
+        let child_stdout = BufReader::new(
+            child
+                .stdout
+                .take()
+                .ok_or_else(|| eyre!("failed to take stdout pipe from uv venv child"))?,
+        );
+        let child_stderr = BufReader::new(
+            child
+                .stderr
+                .take()
+                .ok_or_else(|| eyre!("failed to take stderr pipe from uv venv child"))?,
+        );
         let stdout_tx_clone = stdout_tx.clone();
 
         tokio::spawn(async move {


### PR DESCRIPTION
Two `expect` calls in `prepare_managed_python_env` panic on missing stdout/stderr pipes instead of returning an error. Since the function already returns `eyre::Result<()>`, replace them with `ok_or_else(|| eyre!(...))` so a missing pipe propagates like any other spawn failure.

Only the two lines in `libraries/core/src/build/build_command.rs:198-199` are affected. The daemon spawn path (`binaries/daemon/src/spawn/prepared.rs`) has no equivalent issue.