### PR TITLE
fix(cli): restore `uv run ruff/pytest` in dora-new python template (follow-up to #1906)

### DIFF
--- a/binaries/cli/src/template/python/mod.rs
+++ b/binaries/cli/src/template/python/mod.rs
@@ -129,12 +129,20 @@ fn create_dataflow(
         .with_context(|| format!("failed to write `{}`", readme_path.display()))?;
 
     let pyproject_path = root.join("pyproject.toml");
-    let mut pyproject = WORKSPACE_PYPROJECT.replace("___name___", &name);
-    if use_path_deps {
-        pyproject.push_str(
-            "\n[tool.uv.sources]\ndora-rs = { path = \"../apis/python/node\", editable = true }\n",
-        );
-    }
+    // `___DORA_RS_PATH_SOURCE___` is the placeholder inside the
+    // existing `[tool.uv.sources]` block — replace it with the
+    // path-pinned line in CI mode, drop it otherwise. We cannot append
+    // a second `[tool.uv.sources]` header at the end of the file
+    // (duplicate section = TOML parse error), so this stays an in-place
+    // substitution rather than a `push_str`.
+    let dora_rs_source = if use_path_deps {
+        "dora-rs = { path = \"../apis/python/node\", editable = true }"
+    } else {
+        ""
+    };
+    let pyproject = WORKSPACE_PYPROJECT
+        .replace("___name___", &name)
+        .replace("___DORA_RS_PATH_SOURCE___", dora_rs_source);
     fs::write(&pyproject_path, pyproject)
         .with_context(|| format!("failed to write `{}`", pyproject_path.display()))?;
 

--- a/binaries/cli/src/template/python/workspace-pyproject-template.toml
+++ b/binaries/cli/src/template/python/workspace-pyproject-template.toml
@@ -2,6 +2,32 @@
 name = "___name___"
 version = "0.0.0"
 requires-python = ">=3.11"
+# Depend on the workspace members so `uv run` (which syncs the
+# workspace-root `.venv` before executing) installs each node package
+# AND its transitive deps (`dora-rs` → `pyarrow`, `numpy`, `pyyaml`)
+# into the env. Without this, `uv run pytest` fails with
+# `ModuleNotFoundError: No module named 'pyarrow'` because the test
+# stubs do `import pyarrow as pa` but uv only installs the root
+# project's own deps, not member deps.
+dependencies = ["talker-1", "talker-2", "listener-1"]
 
 [tool.uv.workspace]
 members = ["talker-1", "talker-2", "listener-1"]
+
+# Tell uv to resolve the named workspace members from the local
+# directories (not from PyPI) when satisfying `dependencies` above.
+[tool.uv.sources]
+talker-1 = { workspace = true }
+talker-2 = { workspace = true }
+listener-1 = { workspace = true }
+___DORA_RS_PATH_SOURCE___
+
+# Dev tools must live in the workspace-root pyproject (not just the
+# per-node ones) because `uv run` resolves against the workspace root.
+# Without this, `uv run ruff` / `uv run pytest` from the project
+# directory fail with "Failed to spawn: ruff / No such file or
+# directory" — `uv` creates a fresh `.venv` for the workspace and
+# doesn't install per-node `[dependency-groups] dev` into it.
+# Matches the versions pinned in the per-node template.
+[dependency-groups]
+dev = ["pytest >=8.1.1", "ruff >=0.9.1"]


### PR DESCRIPTION
Follow-up to #1906. Restores `uv run ruff` / `uv run pytest` in the `dora new --lang python` template, which the nightly CLI Tests step exercises.

## Symptom

Nightly run `26274087660` (2026-05-22, against post-#1906/#1909 main) — **all three** `CLI Tests` jobs (macOS, Windows, Ubuntu) failed at:

```
error: Failed to spawn: `ruff`
  Caused by: No such file or directory (os error 2)
##[error]Process completed with exit code 2.
```

Caught while checking whether #1909 cleared the macOS `--stop-after` regression — the job died at this step before reaching `python-dataflow --stop-after`.

## Root cause

PR #1906 added `[tool.uv.workspace] members = [...]` to the generated workspace-root `pyproject.toml`. With that pyproject in place, `uv run` resolves against the workspace root and creates a fresh `.venv` in the project directory, ignoring the `VIRTUAL_ENV` set up by CI's `setup-python-uv` command. The workspace root pyproject only had `[tool.uv.workspace]` declared — no `dependencies`, no dev-tools — so the fresh `.venv` was empty:

- `uv run ruff check .` → ruff not installed → spawn error (what CI hit)
- `uv run pytest` → pytest spawn worked, but test stubs `import pyarrow as pa` and pyarrow wasn't installed either (pyarrow is transitively pulled by `dora-rs`, which the workspace root didn't depend on)

## Fix

Two changes to `binaries/cli/src/template/python/workspace-pyproject-template.toml`:

1. List the three workspace members as `dependencies` and declare each via `[tool.uv.sources] X = { workspace = true }`. This makes `uv sync` install each member's prod deps (`dora-rs` → `pyarrow`, `numpy`, `pyyaml`) into the workspace `.venv`.

2. Add `[dependency-groups] dev = ["pytest >=8.1.1", "ruff >=0.9.1"]`. Dev tools live where `uv run` looks for them. Versions match the per-node template.

Plumbing in `binaries/cli/src/template/python/mod.rs`: the path-deps `dora-rs = { path = ..., editable = true }` line used to be appended at end of file under its own `[tool.uv.sources]` header. With the new members-sources block living in the template, a second `[tool.uv.sources]` header would produce a TOML duplicate-section parse error. Switched to a `___DORA_RS_PATH_SOURCE___` placeholder inside the existing block; `mod.rs` substitutes the path-pinned line (or empty string) via `String::replace`, matching the existing `___name___` substitution pattern.

## Verification

Locally, from the dora workspace root with the workspace `.venv` prepared per `setup-python-uv`:

```
dora new test_python_project_repro --lang python --internal-create-with-path-dependencies
cd test_python_project_repro
dora build dataflow.yml --uv
uv run ruff check .   # All checks passed!
uv run pytest         # 6 passed in 4.15s
```

Plus:
- `cargo fmt --all -- --check` ✓
- `cargo clippy -p dora-cli -- -D warnings` ✓
- `cargo test -p dora-cli --lib` ✓ 146/146

## Risk

The new `dependencies` listing makes user-facing `dora new` projects pull all three nodes into a workspace `.venv` on first `uv run`. That's the desired uv-workspace idiom and is what users would expect, but it's a slight footprint increase vs. the pre-PR-#1906 behavior (which used per-node venvs only). The pre-existing per-node `.dora/python-envs/<node>/` venvs are unchanged; this only affects the workspace-level `.venv` for tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
