### PR TITLE
docs: drop "autonomous AI agents" overstatement, keep "agentic engineering" framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 [**User Guide**](https://dora-rs.ai/dora/) | [**用户指南 (中文)**](https://dora-rs.ai/dora/zh-CN/)
 
-> Built and maintained with **agentic engineering** -- code generation, reviews, refactoring, testing, and commits are driven by autonomous AI agents.
+> Built and maintained with **agentic engineering** -- AI agents do the heavy lifting on code generation, reviews, refactoring, and testing; humans set direction and gate every merge.
 
 ---
 
@@ -653,9 +653,9 @@ For non-trivial work, discuss the approach in a GitHub issue, discussion, or Dis
 - [Discord](https://discord.gg/6eMGGutkfE)
 - [GitHub Discussions](https://github.com/orgs/dora-rs/discussions)
 
-## AI-Assisted Development
+## Agentic Engineering
 
-This repository is maintained with AI-assisted agentic engineering. Code generation, reviews, refactoring, testing, and commits are driven by autonomous AI agents -- enabling faster iteration and higher code quality at scale.
+This repository is built with agentic engineering. AI agents collaborate on day-to-day work -- code generation, reviews, refactoring, testing, drafting PR comments, triaging nightly regressions -- while maintainers set direction, review judgments, and authorize what ships. The two roles compound: AI agents move fast on mechanical work; humans catch the things that matter.
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -30,7 +30,7 @@
 
 [**User Guide**](https://dora-rs.ai/dora/) | [**用户指南 (中文)**](https://dora-rs.ai/dora/zh-CN/)
 
-> 通过**智能体工程（agentic engineering）**方式构建和维护 -- 代码生成、审查、重构、测试和提交均由自主 AI 智能体驱动。
+> 通过**智能体工程（agentic engineering）**方式构建和维护 -- AI 智能体主要承担代码生成、审查、重构和测试工作；维护者把控方向，每次合并均需人工授权。
 
 ---
 
@@ -515,9 +515,9 @@ cargo run --example benchmark --release
 - [Discord](https://discord.gg/6eMGGutkfE)
 - [GitHub Discussions](https://github.com/orgs/dora-rs/discussions)
 
-## AI 辅助开发
+## 智能体工程（Agentic Engineering）
 
-本仓库通过 AI 辅助的智能体工程方式维护。代码生成、审查、重构、测试和提交均由自主 AI 智能体驱动 -- 实现更快的迭代速度和更高的大规模代码质量。
+本仓库采用智能体工程方式构建。AI 智能体在日常工作中协同推进 -- 代码生成、审查、重构、测试、撰写 PR 评论、分析每日构建回归 -- 维护者负责设定方向、审核判断、并把控发布内容。两种角色相辅相成：AI 智能体在机械性工作上效率更高；真正关键的细节则由人类把关。
 
 ## 许可证
 


### PR DESCRIPTION
## Summary

The pre-existing README wording promised more than this repo actually delivers:

> Built and maintained with **agentic engineering** -- code generation, reviews, refactoring, testing, and commits are driven by autonomous AI agents.

In practice every merge in this repo flows through a maintainer's explicit authorization (admin-merge or trunk merge queue), every non-trivial decision is human-directed, and AI agents execute under maintainer supervision rather than autonomously. The "autonomous" framing also contradicts the older "AI-Assisted Development" section further down in the same file (the two mentions said different things about the same workflow).

## What changed

- Dropped the "autonomous AI agents" claim from the line-33 tagline.
- Kept **agentic engineering** as the headline term — it's a legitimate methodology label and the framing is worth claiming.
- Renamed the body section `## AI-Assisted Development` → `## Agentic Engineering` so the two mentions stay aligned.
- New body text describes the actual role split: AI agents on mechanical work (code generation, reviews, refactoring, testing, PR comment drafting, nightly regression triage); maintainers on direction, judgment, and merge authorization.
- Mirrored the same change in `README.zh-CN.md`.

## Diff

**Line 33 (tagline):**

Before:
```
> Built and maintained with **agentic engineering** -- code generation, reviews, refactoring, testing, and commits are driven by autonomous AI agents.
```

After:
```
> Built and maintained with **agentic engineering** -- AI agents do the heavy lifting on code generation, reviews, refactoring, and testing; humans set direction and gate every merge.
```

**Section ~656 (body):**

Before:
```
## AI-Assisted Development

This repository is maintained with AI-assisted agentic engineering. Code generation, reviews, refactoring, testing, and commits are driven by autonomous AI agents -- enabling faster iteration and higher code quality at scale.
```

After:
```
## Agentic Engineering

This repository is built with agentic engineering. AI agents collaborate on day-to-day work -- code generation, reviews, refactoring, testing, drafting PR comments, triaging nightly regressions -- while maintainers set direction, review judgments, and authorize what ships. The two roles compound: AI agents move fast on mechanical work; humans catch the things that matter.
```

## Why this matters

"Humans set direction and gate every merge" is verifiable from `git log --merges` + admin-merge history; the previous "autonomous AI agents" claim was not. Lower-promise/higher-defense wording reduces the risk of being called out for AI-washing and signals confidence in the methodology rather than the buzzword.

## Risk

Docs-only. No runtime behavior change.

## Validation

- `typos README.md README.zh-CN.md` — no diffs
- Side-by-side review of both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
