### PR TITLE
ci: fix test-c-cpp-libraries.yml glob escape for c++ path

### DIFF
--- a/.github/workflows/test-c-cpp-libraries.yml
+++ b/.github/workflows/test-c-cpp-libraries.yml
@@ -12,7 +12,7 @@ on:
     branches: [main]
     paths:
       - "apis/c/**"
-      - "apis/c++/**"
+      - 'apis/c\+\+/**'
       # Transitive Rust deps — the C/C++ surfaces wrap these, so an
       # ABI-breaking change here can silently regress find_package
       # consumers without touching apis/c{,++}/.
@@ -29,7 +29,7 @@ on:
   pull_request:
     paths:
       - "apis/c/**"
-      - "apis/c++/**"
+      - 'apis/c\+\+/**'
       # Transitive Rust deps — the C/C++ surfaces wrap these, so an
       # ABI-breaking change here can silently regress find_package
       # consumers without touching apis/c{,++}/.


### PR DESCRIPTION
## Summary

- **Closes #1917.** The `test-c-cpp-libraries.yml` workflow has been failing 100% of runs (100/100) since #1875 merged it on 2026-05-20. Zero jobs created per run; GitHub's UI is the only place the actual error surfaces ("This workflow file has issues") and even there it's silent on the why.
- Root cause: `apis/c++/**` in `paths:` filters. GH Actions glob treats `+` as a "one or more" quantifier; `c++` is malformed because the second `+` has no valid preceding character. The whole workflow gets rejected before matrix expansion.
- Fix: escape both `+` characters and switch the YAML quoting from double to single (double-quoted YAML rejects `\+` as an unknown escape sequence): `'apis/c\+\+/**'`.
- Diff is two lines (the `push:` and `pull_request:` `paths:` entries).

## Verification

`actionlint 1.7.7` reproduces the failure cleanly and confirms the fix:

```
# before
$ actionlint .github/workflows/test-c-cpp-libraries.yml
test-c-cpp-libraries.yml:15:17: invalid glob pattern. unexpected character '+'
  while checking special character + (one or more).  [glob]
test-c-cpp-libraries.yml:32:17: invalid glob pattern. unexpected character '+'
  while checking special character + (one or more).  [glob]

# after
$ actionlint .github/workflows/test-c-cpp-libraries.yml
# exit 0, no output
```

Swept `.github/workflows/*.yml` — no other file has `apis/c++` in a path glob. Sibling `publish-c-cpp-libraries.yml` uses `apis/c{,++}/**` in a comment only, not in an actual filter.

## Test plan

- [ ] Merge to main and observe the first run on a commit that touches `apis/c/` or `apis/c++/`. Expect 3 matrix jobs to start (ubuntu-22.04, macos-latest, windows-latest).
- [ ] Confirm subsequent `push` events to `main` no longer immediately fail with `jobs_count: 0`.
- [ ] Whether the actual smoke tests pass on first green run is a separate question — the immediate goal is to make the workflow *runnable* so we can find out.

## Follow-up (not in this PR)

Issue #1917 stretch goal: add `actionlint` as a CI step so future malformed workflows fail at PR time rather than burning runner budget for days. Worth a separate small PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)