### PR TITLE
fix(test): build rust-dynamic-add-remove-filter before lifecycle e2e (unblocks ci/circleci: e2e)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1878,6 +1878,7 @@ dependencies = [
 name = "dora-examples"
 version = "0.0.0"
 dependencies = [
+ "arrow-array",
  "assert2",
  "dora-cli",
  "dora-coordinator",
@@ -1885,10 +1886,12 @@ dependencies = [
  "dora-daemon",
  "dora-download",
  "dora-message",
+ "dora-operator-api-types",
  "dora-tracing",
  "dunce",
  "eyre",
  "futures",
+ "libloading 0.8.9",
  "serde_json",
  "serde_yaml",
  "tempfile",

--- a/tests/node-lifecycle-e2e.rs
+++ b/tests/node-lifecycle-e2e.rs
@@ -63,6 +63,38 @@ fn ensure_cli_built() {
     });
 }
 
+static BUILD_RUST_FILTER: Once = Once::new();
+
+/// Build the `rust-dynamic-add-remove-filter` workspace binary that
+/// `lifecycle_rust_dynamic_add_remove` adds via `dora node add
+/// --from-yaml filter-node.yml`. Unlike `sender`/`receiver`, the
+/// filter is NOT listed in `dataflow.yml` — `dora build` never sees
+/// it — and `dora node add` only reads the descriptor + dispatches
+/// `AddNode`; it does NOT execute the `build:` field. Without this
+/// helper the test panics on `dora node add filter` with `No such
+/// file or directory` for `target/debug/rust-dynamic-add-remove-filter`.
+///
+/// `--target-dir` is pinned to the workspace-relative `target/` to
+/// match `filter-node.yml`'s `path: ../../target/debug/...`, so a
+/// `CARGO_TARGET_DIR` override on the test invocation can't desync
+/// the build location from where the daemon will look at spawn time.
+fn ensure_rust_filter_built() {
+    BUILD_RUST_FILTER.call_once(|| {
+        let dora_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let target_dir = dora_root.join("target");
+        let status = Command::new("cargo")
+            .args(["build", "-p", "rust-dynamic-add-remove-filter"])
+            .arg("--target-dir")
+            .arg(&target_dir)
+            .status()
+            .expect("failed to run cargo build for rust-dynamic-add-remove-filter");
+        assert!(
+            status.success(),
+            "failed to build rust-dynamic-add-remove-filter"
+        );
+    });
+}
+
 #[cfg(not(windows))]
 static BUILD_CXX: Once = Once::new();
 
@@ -561,6 +593,12 @@ fn lifecycle_rust_dynamic_add_remove() {
     // mod.rs) automatically appends `EXE_EXTENSION` (.exe) on Windows
     // when the YAML path has no extension, so the same fixture works
     // cross-platform without per-OS YAML.
+    //
+    // Build the filter binary before run_lifecycle — `dora node add`
+    // does not honor `build:` in the dynamic-node yaml, so unlike
+    // sender/receiver (built by `dora build dataflow.yml`) the filter
+    // has to be compiled explicitly. Mirrors `ensure_cxx_built`.
+    ensure_rust_filter_built();
     run_lifecycle(LifecycleFixture {
         dataflow_path: &dataflow,
         filter_yml_path: &filter_yml,


### PR DESCRIPTION
## Summary

- **Unblocks `ci/circleci: e2e`** which has been red on `main` for ~30 consecutive commits since PR #1903 merged on 2026-05-21. Every PR opened since then (mine included) shows a red `e2e` check unrelated to its actual diff.
- Root cause: `lifecycle_rust_dynamic_add_remove` in `tests/node-lifecycle-e2e.rs` assumes `target/debug/rust-dynamic-add-remove-filter` exists, but nothing in the test setup actually builds it.
- The C++ variant has `ensure_cxx_built()` for exactly this reason. This PR adds the analogous `ensure_rust_filter_built()` helper, mirroring the existing pattern.

## Why `dora build` didn't catch it

The dynamic filter lives in a separate `filter-node.yml`, not in the main `dataflow.yml`:

```
examples/rust-dynamic-add-remove/
├── dataflow.yml         # sender + receiver (built by `dora build`)
├── filter-node.yml      # filter (added at runtime via `dora node add`)
└── filter/Cargo.toml    # the workspace crate
```

`dora build dataflow.yml` builds sender + receiver via their `build:` directives. The filter is never built by `dora build` because it isn't in `dataflow.yml`.

When the test later runs:

```
dora node add --dataflow rustlc --from-yaml filter-node.yml
```

`dora node add` reads the YAML and dispatches `ControlRequest::AddNode` to the coordinator (`binaries/cli/src/command/node/add.rs:33`). **It does not execute the `build:` field.** The daemon then tries to spawn `target/debug/rust-dynamic-add-remove-filter`, which doesn't exist on a cold CI runner.

## Why the PR that introduced this test (#1903) passed

The author almost certainly had a previously-compiled `rust-dynamic-add-remove-filter` binary sitting in their local `target/` tree from earlier development. Locally everything worked. CI's clean filesystem hits the cold-start path and exposes the gap.

## Reproduction

```bash
pkill -9 -f rust-dynamic-add-remove  # ensure cold start
rm -f target/debug/rust-dynamic-add-remove-filter

PYO3_NO_PYTHON=1 cargo test -p dora-examples \
  --test node-lifecycle-e2e -- --test-threads=1 \
  lifecycle_rust lifecycle_cxx
```

### Before this PR

```
thread 'lifecycle_rust_dynamic_add_remove' panicked at tests/node-lifecycle-e2e.rs:340:5:
dora node add failed.
stderr:
[ERROR]
daemon failed to add node `filter`: failed to spawn node

Caused by:
   0: failed to run `../../target/debug/rust-dynamic-add-remove-filter` with args ``
   1: No such file or directory (os error 2)

test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 1 filtered out
```

### After this PR

```
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 53.52s
```

## Implementation

Mirrors `ensure_cxx_built()` directly above it in the same file:

- `BUILD_RUST_FILTER: Once` static — guarantees a single build per test-binary lifetime.
- `ensure_rust_filter_built()` — `cargo build -p rust-dynamic-add-remove-filter --target-dir <workspace>/target`.
- Called from `lifecycle_rust_dynamic_add_remove` before `run_lifecycle()`.

`--target-dir` is pinned to the workspace-relative `target/` to match what `filter-node.yml` expects (`path: ../../target/debug/...`). This way a `CARGO_TARGET_DIR` override on the test invocation can't desync the build location from where the daemon will look at spawn time — same defense the existing `dataflow.yml` uses for sender/receiver via `--target-dir ../../target`.

## Test plan

- [ ] CI's `ci/circleci: e2e` job passes on this PR (currently red on every other open PR).
- [ ] After merge, the next PR opened against main shows a green `e2e`.
- [ ] No regression in `lifecycle_cxx_dynamic_add_remove` (the cxx side was already correct via `ensure_cxx_built()`).

## Why not fix `dora node add` to honor `build:`?

That would be a bigger, more invasive change with security implications (spawning arbitrary shell commands from a CLI subcommand) and timing/streaming considerations. Worth a separate design discussion; until that lands, the test simply needs to compile its own fixture, same as the C++ variant does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
