### PR TITLE
ci(examples): bump rust-dataflow-git pin to current main (closes #1945)

### DIFF
--- a/examples/rust-dataflow-git/dataflow.yml
+++ b/examples/rust-dataflow-git/dataflow.yml
@@ -6,7 +6,7 @@
 nodes:
   - id: rust-node
     git: https://github.com/dora-rs/dora.git
-    rev: 10cf7fe9c082caaa90679bcca48c873cdc16311b
+    rev: 9f4242b69720dd6c4da44260cc4102541dcf7d70
     build: cargo build -p rust-dataflow-example-node
     path: target/debug/rust-dataflow-example-node
     inputs:
@@ -16,7 +16,7 @@ nodes:
 
   - id: rust-status-node
     git: https://github.com/dora-rs/dora.git
-    rev: 10cf7fe9c082caaa90679bcca48c873cdc16311b
+    rev: 9f4242b69720dd6c4da44260cc4102541dcf7d70
     build: cargo build -p rust-dataflow-example-status-node
     path: target/debug/rust-dataflow-example-status-node
     inputs:
@@ -27,7 +27,7 @@ nodes:
 
   - id: rust-sink
     git: https://github.com/dora-rs/dora.git
-    rev: 10cf7fe9c082caaa90679bcca48c873cdc16311b
+    rev: 9f4242b69720dd6c4da44260cc4102541dcf7d70
     build: cargo build -p rust-dataflow-example-sink
     path: target/debug/rust-dataflow-example-sink
     inputs:


### PR DESCRIPTION
## Summary

- **Closes #1945.** Bumps the `rev:` pin in `examples/rust-dataflow-git/dataflow.yml` from `10cf7fe9` (2026-04-28, 74 commits stale) to `9f4242b6` (current main HEAD).
- Unblocks `ci/circleci: examples-windows` + `examples-linux`, which have been failing on every main commit since 2026-05-26 (9 reds in a row) at the "Rust Git Dataflow example" step.
- This is exactly the scenario the dataflow.yml comment was written to catch:
  > Update `rev:` when a message-format-breaking change lands on main — otherwise the CI job catches the mismatch and signals a compatibility break, **which is the whole point of this test**.

The job did its job. Bumping the pin restores 1:1 protocol parity between the example's git-sourced nodes and the CLI they're invoked from.

## Why this is a one-line YAML change

The example pins each node to a specific dora commit so the nodes are built from that source tree, then invoked by the current dora-cli. When the CLI-side protocol drifts past the pinned commit's protocol, the nodes don't understand what the CLI is saying — they hang.

The 74-commit drift between `10cf7fe9` and current main includes substantial node-to-daemon protocol churn:

| Area | Lines changed |
|---|---|
| `libraries/message/` | 1598+/349- |
| `apis/rust/node/src/` | (large, included #1787 zenoh-routing rewrite) |
| `binaries/daemon/src/spawn/` | substantial spawner/lifecycle changes |

The simplest fix is "pick up the latest." Future contributors who break the protocol will see this example go red again — that's working as designed.

## Validation

Locally I started the example with the new pin and watched it build the pinned dora source tree (rust-sink: `Compiling dora-message v0.2.1 (.../9f4242b69720dd6c4da44260cc4102541dcf7d70/libraries/message)`). Full execution takes 20+ min (mostly the dependency build), so the conclusive smoke is in CI on this PR.

If CI's examples-windows + examples-linux still hit a timeout at the same step with the new pin, that signals the regression isn't purely message-format drift and there's a real bug — but I expect the bump alone is sufficient.

## Test plan

- [ ] `examples-windows` ✅ on this PR (currently 9/9 red on main)
- [ ] `examples-linux` ✅ on this PR
- [ ] After merge, the first main commit after this lands shows both jobs ✅

## Out of scope

The medium-term recurrence prevention (add the example to required checks, scheduled auto-bump, or `CONTRIBUTING.md` snippet) — discussed in #1945 — is deferred to a separate decision. This PR is the short-term unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
