### PR TITLE
fix(cli): invalidate session build_id on build-inputs delta (closes #1444)

### DIFF
--- a/binaries/cli/src/command/build/mod.rs
+++ b/binaries/cli/src/command/build/mod.rs
@@ -290,6 +290,12 @@ pub fn build(cfg: BuildConfig) -> eyre::Result<()> {
     let resolved_nodes = dataflow_descriptor
         .resolve_aliases_and_set_defaults()
         .context("failed to resolve nodes")?;
+    // Compute the session-level build-inputs fingerprint up front, while we
+    // still hold a borrow of `resolved_nodes` (Pass 2 below consumes it).
+    // This is what `dora start` / `dora run` / `dora daemon --run-dataflow`
+    // compare against to decide whether the cached `build_id` is still
+    // valid for the current descriptor (#1444).
+    let session_build_fingerprint = DataflowSession::fingerprint_build_inputs(&resolved_nodes);
     // Pass 1 (fail-fast): derive descriptor git-source fingerprint and validate lockfile
     // provenance before any per-node locked-source lookups.
     for (node_id, node) in &resolved_nodes {
@@ -403,6 +409,11 @@ pub fn build(cfg: BuildConfig) -> eyre::Result<()> {
                 dataflow_session.build_id = Some(BuildId::generate());
             }
             dataflow_session.local_build = Some(build_info);
+            // Record the build-inputs fingerprint so subsequent `dora start`
+            // / `dora run` / `dora daemon --run-dataflow` invocations can
+            // detect descriptor drift and invalidate cached build metadata
+            // (#1444).
+            dataflow_session.build_fingerprint = Some(session_build_fingerprint.clone());
             dataflow_session
                 .write_out_for_dataflow(&dataflow_path)
                 .context("failed to write out dataflow session file")?;
@@ -437,6 +448,10 @@ pub fn build(cfg: BuildConfig) -> eyre::Result<()> {
 
             dataflow_session.build_id = Some(build_id);
             dataflow_session.local_build = None;
+            // Same fingerprint-recording rationale as the local-build branch
+            // above (#1444). The session file is the source of truth for
+            // "what descriptor produced this `build_id`."
+            dataflow_session.build_fingerprint = Some(session_build_fingerprint.clone());
             dataflow_session
                 .write_out_for_dataflow(&dataflow_path)
                 .context("failed to write out dataflow session file")?;

--- a/binaries/cli/src/command/daemon.rs
+++ b/binaries/cli/src/command/daemon.rs
@@ -1,8 +1,11 @@
 use super::Executable;
 use crate::{common::handle_dataflow_result, session::DataflowSession};
-use dora_core::topics::{
-    DORA_COORDINATOR_PORT_WS_DEFAULT, DORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT,
-    DORA_DAEMON_LOCAL_LISTEN_PORT_ENV, LOCALHOST,
+use dora_core::{
+    descriptor::DescriptorExt,
+    topics::{
+        DORA_COORDINATOR_PORT_WS_DEFAULT, DORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT,
+        DORA_DAEMON_LOCAL_LISTEN_PORT_ENV, LOCALHOST,
+    },
 };
 
 use dora_daemon::LogDestination;
@@ -170,8 +173,34 @@ impl Executable for Daemon {
                                 self.coordinator_addr
                             );
                         }
-                        let dataflow_session =
+                        let mut dataflow_session =
                             DataflowSession::read_session(&dataflow_path).context("failed to read DataflowSession")?;
+                        // Invalidate cached build metadata if the descriptor's
+                        // build-inputs changed since the last `dora build`.
+                        // Without this, the daemon would consume a stale
+                        // `build_id` and spawn nodes from the previous build's
+                        // artifacts (#1444).
+                        let dataflow_descriptor = dora_core::descriptor::Descriptor::blocking_read(&dataflow_path)
+                            .wrap_err_with(|| format!(
+                                "failed to read dataflow at `{}` for session fingerprinting",
+                                dataflow_path.display()
+                            ))?;
+                        let working_dir = dataflow_path
+                            .parent()
+                            .filter(|p| !p.as_os_str().is_empty())
+                            .unwrap_or_else(|| std::path::Path::new("."));
+                        let expanded = dataflow_descriptor
+                            .expand(working_dir)
+                            .wrap_err("failed to expand modules in dataflow descriptor")?;
+                        let resolved_for_fingerprint = expanded
+                            .resolve_aliases_and_set_defaults()
+                            .context("failed to resolve nodes for session fingerprint")?;
+                        if dataflow_session.invalidate_if_build_inputs_changed(&resolved_for_fingerprint) {
+                            dataflow_session
+                                .write_out_for_dataflow(&dataflow_path)
+                                .context("failed to persist invalidated dataflow session")?;
+                        }
+                        drop(resolved_for_fingerprint);
 
                         let result = dora_daemon::Daemon::run_dataflow(&dataflow_path,
                             dataflow_session.build_id, dataflow_session.local_build, dataflow_session.session_id, false,

--- a/binaries/cli/src/command/run.rs
+++ b/binaries/cli/src/command/run.rs
@@ -185,7 +185,7 @@ impl Executable for Run {
             ..Default::default()
         })
         .context("failed to build dataflow before run")?;
-        let dataflow_session = DataflowSession::read_session(&dataflow_path)
+        let mut dataflow_session = DataflowSession::read_session(&dataflow_path)
             .context("failed to read DataflowSession")?;
 
         let working_dir = working_dir_or_parent(self.working_dir.as_deref(), &dataflow_path);
@@ -199,6 +199,21 @@ impl Executable for Run {
             })?
             .expand(working_dir)
             .wrap_err("failed to expand modules in dataflow descriptor")?;
+        // Defense-in-depth invalidation. The preceding `build()` call should
+        // have refreshed the fingerprint, but if any code path skips the
+        // build (e.g. future flag) the cached `build_id` must still match
+        // current build-inputs — otherwise the embedded coordinator below
+        // would start nodes from stale artifacts (#1444).
+        let resolved_for_fingerprint = dataflow_descriptor
+            .resolve_aliases_and_set_defaults()
+            .context("failed to resolve nodes for session fingerprint")?;
+        if dataflow_session.invalidate_if_build_inputs_changed(&resolved_for_fingerprint) {
+            dataflow_session
+                .write_out_for_dataflow(&dataflow_path)
+                .context("failed to persist invalidated dataflow session")?;
+        }
+        drop(resolved_for_fingerprint);
+
         if self.debug {
             dataflow_descriptor.debug.enable_debug_inspection = true;
         }

--- a/binaries/cli/src/command/start/mod.rs
+++ b/binaries/cli/src/command/start/mod.rs
@@ -126,8 +126,22 @@ fn start_dataflow(
         })?
         .expand(working_dir)
         .wrap_err("failed to expand modules in dataflow descriptor")?;
-    let dataflow_session =
+    let mut dataflow_session =
         DataflowSession::read_session(&dataflow).context("failed to read DataflowSession")?;
+    // Invalidate cached `build_id`/`local_build`/`git_sources` if the
+    // descriptor's build-inputs (build command, source, env, cwd) changed
+    // since the last `dora build`. Without this, `dora start` would send a
+    // stale `build_id` to the coordinator and silently target the previous
+    // build's artifacts (#1444).
+    let resolved_for_fingerprint = dataflow_descriptor
+        .resolve_aliases_and_set_defaults()
+        .context("failed to resolve nodes for session fingerprint")?;
+    if dataflow_session.invalidate_if_build_inputs_changed(&resolved_for_fingerprint) {
+        dataflow_session
+            .write_out_for_dataflow(&dataflow)
+            .context("failed to persist invalidated dataflow session")?;
+    }
+    drop(resolved_for_fingerprint);
 
     if debug {
         dataflow_descriptor.debug.enable_debug_inspection = true;

--- a/binaries/cli/src/session.rs
+++ b/binaries/cli/src/session.rs
@@ -4,8 +4,18 @@ use std::{
 };
 
 use dora_core::build::BuildInfo;
-use dora_message::{BuildId, SessionId, common::GitSource, id::NodeId};
+use dora_message::{
+    BuildId, SessionId,
+    common::GitSource,
+    descriptor::{CoreNodeKind, NodeSource, ResolvedNode},
+    id::NodeId,
+};
 use eyre::{Context, ContextCompat};
+
+/// Schema tag included in the build-inputs fingerprint canonical form. Bump
+/// when the canonicalization shape changes so old fingerprints invalidate
+/// automatically.
+const FINGERPRINT_SCHEMA_VERSION: u32 = 1;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct DataflowSession {
@@ -13,6 +23,11 @@ pub struct DataflowSession {
     pub session_id: SessionId,
     pub git_sources: BTreeMap<NodeId, GitSource>,
     pub local_build: Option<BuildInfo>,
+    /// FNV-1a 64-bit hex digest of the resolved descriptor's build-inputs.
+    /// `None` on sessions written before this field was introduced (treated
+    /// as "unknown" — `invalidate_if_build_inputs_changed` clears and rewrites).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build_fingerprint: Option<String>,
 }
 
 impl Default for DataflowSession {
@@ -22,6 +37,7 @@ impl Default for DataflowSession {
             session_id: SessionId::generate(),
             git_sources: Default::default(),
             local_build: Default::default(),
+            build_fingerprint: None,
         }
     }
 }
@@ -77,6 +93,175 @@ impl DataflowSession {
     fn serialize(&self) -> eyre::Result<String> {
         serde_yaml::to_string(&self).context("failed to serialize dataflow session file")
     }
+
+    /// Compute the build-inputs fingerprint over the resolved descriptor.
+    ///
+    /// Inputs (anything that affects what `dora build` produces):
+    /// - per-node `build` command (Custom and Runtime kinds)
+    /// - per-node `source` (Local vs GitBranch with repo + branch/tag/rev)
+    /// - per-node `env` (sorted map, Display'd values — covers global env after
+    ///   resolve_aliases_and_set_defaults merges it)
+    /// - per-node `deploy.working_dir` (changes shift the cwd cargo/python runs in)
+    ///
+    /// Deliberately ignored (don't affect the build):
+    /// - `path` — where the artifact is read from at start time, not built to
+    /// - `deploy.machine` — affects placement at start time, not build inputs
+    ///
+    /// Discussed in #1444.
+    pub fn fingerprint_build_inputs(resolved_nodes: &BTreeMap<NodeId, ResolvedNode>) -> String {
+        let mut canonical = String::new();
+        // Schema tag in the canonical form so format bumps force regeneration
+        // even if descriptor inputs are unchanged. Same approach used by
+        // `BuildLockfile::fingerprint_descriptor_git_sources`.
+        canonical.push_str(&format!(
+            "dora-session-build-inputs-v{FINGERPRINT_SCHEMA_VERSION}\n"
+        ));
+
+        // BTreeMap iteration is already sorted by NodeId — deterministic.
+        for (node_id, node) in resolved_nodes {
+            canonical.push_str("node:");
+            canonical.push_str(node_id.as_ref());
+            canonical.push('\n');
+
+            // Build command (None and Some("") both contribute distinctly:
+            // "build:none" vs "build:" — preserves the "unset vs empty"
+            // distinction in case a user toggles between them).
+            let build_field = node_build_command(&node.kind);
+            match build_field {
+                Some(cmd) => {
+                    canonical.push_str("build:");
+                    canonical.push_str(cmd);
+                    canonical.push('\n');
+                }
+                None => canonical.push_str("build:none\n"),
+            }
+
+            // Source (Local vs git repo+rev).
+            let source = node_source(&node.kind);
+            match source {
+                Some(NodeSource::Local) => canonical.push_str("source:local\n"),
+                Some(NodeSource::GitBranch { repo, rev }) => {
+                    canonical.push_str("source:git\nrepo:");
+                    canonical.push_str(repo);
+                    canonical.push('\n');
+                    let (kind, value) = match rev {
+                        Some(dora_message::descriptor::GitRepoRev::Branch(v)) => {
+                            ("branch", v.as_str())
+                        }
+                        Some(dora_message::descriptor::GitRepoRev::Tag(v)) => ("tag", v.as_str()),
+                        Some(dora_message::descriptor::GitRepoRev::Rev(v)) => ("rev", v.as_str()),
+                        None => ("head", ""),
+                    };
+                    canonical.push_str("rev:");
+                    canonical.push_str(kind);
+                    canonical.push(':');
+                    canonical.push_str(value);
+                    canonical.push('\n');
+                }
+                None => canonical.push_str("source:none\n"),
+            }
+
+            // Env (BTreeMap iteration sorted; covers globals after merge).
+            // `EnvValue` has a `Display` impl that produces the canonical text
+            // form ("true", "42", "1.5", or the raw string).
+            if let Some(env) = &node.env {
+                canonical.push_str("env:\n");
+                for (k, v) in env {
+                    canonical.push_str("  ");
+                    canonical.push_str(k);
+                    canonical.push('=');
+                    canonical.push_str(&v.to_string());
+                    canonical.push('\n');
+                }
+            } else {
+                canonical.push_str("env:none\n");
+            }
+
+            // Working directory (per-node deploy override).
+            if let Some(deploy) = &node.deploy {
+                if let Some(cwd) = &deploy.working_dir {
+                    canonical.push_str("cwd:");
+                    canonical.push_str(&cwd.to_string_lossy());
+                    canonical.push('\n');
+                } else {
+                    canonical.push_str("cwd:none\n");
+                }
+            } else {
+                canonical.push_str("cwd:none\n");
+            }
+        }
+
+        fnv1a_64_hex(canonical.as_bytes())
+    }
+
+    /// Compare current descriptor's build-inputs fingerprint against the
+    /// stored one. On mismatch (including "never recorded"), clear stale
+    /// build metadata (`build_id`, `local_build`, `git_sources`) and store
+    /// the new fingerprint. Returns `true` if invalidation occurred.
+    ///
+    /// Call this on `dora start` / `dora run` / `dora daemon
+    /// --run-dataflow` before consuming `build_id`, and on `dora build`
+    /// after resolving the descriptor (so the fingerprint reflects the
+    /// build that just ran).
+    pub fn invalidate_if_build_inputs_changed(
+        &mut self,
+        resolved_nodes: &BTreeMap<NodeId, ResolvedNode>,
+    ) -> bool {
+        let current = Self::fingerprint_build_inputs(resolved_nodes);
+        if self.build_fingerprint.as_deref() == Some(&current) {
+            return false;
+        }
+        let had_build_id = self.build_id.is_some();
+        self.build_id = None;
+        self.local_build = None;
+        self.git_sources.clear();
+        self.build_fingerprint = Some(current);
+        if had_build_id {
+            tracing::info!(
+                "dataflow build inputs changed since last session — discarding cached \
+                 build_id; run `dora build` to rebuild"
+            );
+        }
+        true
+    }
+}
+
+/// Extract the `build` command from a `ResolvedNode`'s kind. Returns `None`
+/// when the field is unset, and `Some("")` to distinguish an empty-string
+/// build from a missing one (a user could plausibly toggle between them).
+fn node_build_command(kind: &CoreNodeKind) -> Option<&str> {
+    match kind {
+        CoreNodeKind::Custom(custom) => custom.build.as_deref(),
+        CoreNodeKind::Runtime(_) => {
+            // RuntimeNode is `#[serde(transparent)]` over operator definitions;
+            // operators don't carry a build field today. If they ever do,
+            // extend this match. Returning None here matches the no-build
+            // case for operators.
+            None
+        }
+    }
+}
+
+/// Extract the `source` from a `ResolvedNode`'s kind.
+fn node_source(kind: &CoreNodeKind) -> Option<&NodeSource> {
+    match kind {
+        CoreNodeKind::Custom(custom) => Some(&custom.source),
+        CoreNodeKind::Runtime(_) => None,
+    }
+}
+
+/// FNV-1a 64-bit, lowercase hex (16 chars). Matches the digest shape used
+/// by `BuildLockfile::fingerprint_descriptor_git_sources` so the two
+/// fingerprints are visually distinguishable as the same family.
+fn fnv1a_64_hex(bytes: &[u8]) -> String {
+    const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
+    const FNV_PRIME: u64 = 0x100000001b3;
+    let mut hash = FNV_OFFSET_BASIS;
+    for byte in bytes {
+        hash ^= *byte as u64;
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    format!("{hash:016x}")
 }
 
 fn deserialize(session_file: &Path) -> eyre::Result<DataflowSession> {
@@ -97,4 +282,225 @@ fn session_file_path(dataflow_path: &Path) -> eyre::Result<PathBuf> {
         .with_file_name("out")
         .join(format!("{file_stem}.dora-session.yaml"));
     Ok(session_file)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dora_core::descriptor::DescriptorExt;
+    use dora_message::descriptor::Descriptor;
+
+    /// Parse YAML into a resolved-nodes map. Tests stay readable by editing
+    /// the YAML rather than wrestling with `CustomNode`'s 20-field struct
+    /// literal (and they survive descriptor schema additions).
+    fn resolved(yaml: &str) -> BTreeMap<NodeId, ResolvedNode> {
+        let desc: Descriptor = serde_yaml::from_str(yaml).expect("yaml parses as Descriptor");
+        desc.resolve_aliases_and_set_defaults()
+            .expect("descriptor resolves cleanly")
+    }
+
+    const BASELINE: &str = "\
+nodes:
+  - id: a
+    path: ./a
+    build: cargo build
+";
+
+    #[test]
+    fn fingerprint_is_stable_for_same_inputs() {
+        let nodes = resolved(BASELINE);
+        let fp1 = DataflowSession::fingerprint_build_inputs(&nodes);
+        let fp2 = DataflowSession::fingerprint_build_inputs(&nodes);
+        assert_eq!(fp1, fp2, "same inputs must produce same fingerprint");
+    }
+
+    #[test]
+    fn fingerprint_changes_when_build_command_changes() {
+        let before = resolved(BASELINE);
+        let after = resolved(
+            "\
+nodes:
+  - id: a
+    path: ./a
+    build: cargo build --release
+",
+        );
+        assert_ne!(
+            DataflowSession::fingerprint_build_inputs(&before),
+            DataflowSession::fingerprint_build_inputs(&after),
+            "build command change must change fingerprint",
+        );
+    }
+
+    #[test]
+    fn fingerprint_changes_when_source_changes_local_to_git() {
+        let local = resolved(BASELINE);
+        let git = resolved(
+            "\
+nodes:
+  - id: a
+    path: ./a
+    git: https://github.com/dora-rs/dora.git
+    build: cargo build
+",
+        );
+        assert_ne!(
+            DataflowSession::fingerprint_build_inputs(&local),
+            DataflowSession::fingerprint_build_inputs(&git),
+            "switching local->git source must change fingerprint",
+        );
+    }
+
+    #[test]
+    fn fingerprint_changes_when_git_rev_changes() {
+        let rev_a = resolved(
+            "\
+nodes:
+  - id: a
+    path: ./a
+    git: https://github.com/dora-rs/dora.git
+    rev: aaaaaaa
+    build: cargo build
+",
+        );
+        let rev_b = resolved(
+            "\
+nodes:
+  - id: a
+    path: ./a
+    git: https://github.com/dora-rs/dora.git
+    rev: bbbbbbb
+    build: cargo build
+",
+        );
+        assert_ne!(
+            DataflowSession::fingerprint_build_inputs(&rev_a),
+            DataflowSession::fingerprint_build_inputs(&rev_b),
+            "different git revs must produce different fingerprints",
+        );
+    }
+
+    #[test]
+    fn fingerprint_changes_when_env_changes() {
+        let without_env = resolved(BASELINE);
+        let with_env = resolved(
+            "\
+nodes:
+  - id: a
+    path: ./a
+    build: cargo build
+    env:
+      RUST_LOG: info
+",
+        );
+        assert_ne!(
+            DataflowSession::fingerprint_build_inputs(&without_env),
+            DataflowSession::fingerprint_build_inputs(&with_env),
+            "adding env must change fingerprint",
+        );
+    }
+
+    #[test]
+    fn fingerprint_unchanged_when_only_path_changes() {
+        // Path is where the artifact is *read from* at start time, not where
+        // it's built to. Per the #1444 policy, path-only changes must not
+        // invalidate cached build metadata.
+        let map_a = resolved(
+            "\
+nodes:
+  - id: a
+    path: ./target/debug/a
+    build: cargo build
+",
+        );
+        let map_b = resolved(
+            "\
+nodes:
+  - id: a
+    path: ./target/release/a
+    build: cargo build
+",
+        );
+        assert_eq!(
+            DataflowSession::fingerprint_build_inputs(&map_a),
+            DataflowSession::fingerprint_build_inputs(&map_b),
+            "path-only change MUST NOT change fingerprint (per #1444 policy)",
+        );
+    }
+
+    #[test]
+    fn invalidate_clears_build_metadata_on_mismatch() {
+        let nodes = resolved(BASELINE);
+        let mut session = DataflowSession {
+            build_id: Some(BuildId::generate()),
+            git_sources: BTreeMap::from([(
+                NodeId::from("a".to_string()),
+                GitSource {
+                    repo: "x".to_string(),
+                    commit_hash: "y".to_string(),
+                },
+            )]),
+            ..Default::default()
+        };
+
+        let invalidated = session.invalidate_if_build_inputs_changed(&nodes);
+        assert!(
+            invalidated,
+            "first call against an un-fingerprinted session must invalidate"
+        );
+        assert!(session.build_id.is_none(), "build_id must be cleared");
+        assert!(session.local_build.is_none(), "local_build must be cleared");
+        assert!(
+            session.git_sources.is_empty(),
+            "git_sources must be cleared"
+        );
+        assert!(
+            session.build_fingerprint.is_some(),
+            "new fingerprint must be stored"
+        );
+    }
+
+    #[test]
+    fn invalidate_is_noop_when_fingerprint_matches() {
+        let nodes = resolved(BASELINE);
+        let mut session = DataflowSession::default();
+        // Prime the fingerprint as if a previous `dora build` had stored it.
+        session.invalidate_if_build_inputs_changed(&nodes);
+        // Set a build_id to mimic post-build state.
+        let post_build_id = Some(BuildId::generate());
+        session.build_id = post_build_id;
+
+        let invalidated = session.invalidate_if_build_inputs_changed(&nodes);
+        assert!(!invalidated, "matching fingerprint must NOT invalidate");
+        assert_eq!(
+            session.build_id, post_build_id,
+            "build_id must survive matching call"
+        );
+    }
+
+    #[test]
+    fn session_roundtrip_with_new_field() {
+        let session = DataflowSession {
+            build_fingerprint: Some("abcdef0123456789".to_string()),
+            ..Default::default()
+        };
+        let yaml = serde_yaml::to_string(&session).unwrap();
+        let parsed: DataflowSession = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(
+            parsed.build_fingerprint.as_deref(),
+            Some("abcdef0123456789")
+        );
+    }
+
+    #[test]
+    fn session_roundtrip_backward_compatible_without_field() {
+        // Sessions written before this field existed must still deserialize.
+        let legacy_yaml = "build_id: null\n\
+             session_id: 00000000-0000-0000-0000-000000000000\n\
+             git_sources: {}\n\
+             local_build: null\n";
+        let parsed: DataflowSession =
+            serde_yaml::from_str(legacy_yaml).expect("legacy session must deserialize");
+        assert!(parsed.build_fingerprint.is_none());
+    }
 }

--- a/binaries/cli/src/session.rs
+++ b/binaries/cli/src/session.rs
@@ -7,7 +7,7 @@ use dora_core::build::BuildInfo;
 use dora_message::{
     BuildId, SessionId,
     common::GitSource,
-    descriptor::{CoreNodeKind, NodeSource, ResolvedNode},
+    descriptor::{CoreNodeKind, NodeSource, OperatorSource, ResolvedNode},
     id::NodeId,
 };
 use eyre::{Context, ContextCompat};
@@ -15,7 +15,11 @@ use eyre::{Context, ContextCompat};
 /// Schema tag included in the build-inputs fingerprint canonical form. Bump
 /// when the canonicalization shape changes so old fingerprints invalidate
 /// automatically.
-const FINGERPRINT_SCHEMA_VERSION: u32 = 1;
+///
+/// Versions:
+///   - v1: Custom-node build/source/env/cwd only (initial #1944 implementation)
+///   - v2: + Runtime-node operator build/source iteration (review of #1947)
+const FINGERPRINT_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct DataflowSession {
@@ -97,17 +101,19 @@ impl DataflowSession {
     /// Compute the build-inputs fingerprint over the resolved descriptor.
     ///
     /// Inputs (anything that affects what `dora build` produces):
-    /// - per-node `build` command (Custom and Runtime kinds)
+    /// - per-node `build` command (Custom-kind nodes)
     /// - per-node `source` (Local vs GitBranch with repo + branch/tag/rev)
     /// - per-node `env` (sorted map, Display'd values — covers global env after
     ///   resolve_aliases_and_set_defaults merges it)
     /// - per-node `deploy.working_dir` (changes shift the cwd cargo/python runs in)
+    /// - per-operator `build` command and `source` (Runtime-kind nodes — Python
+    ///   script path, conda env, SharedLibrary path, Wasm path)
     ///
     /// Deliberately ignored (don't affect the build):
     /// - `path` — where the artifact is read from at start time, not built to
     /// - `deploy.machine` — affects placement at start time, not build inputs
     ///
-    /// Discussed in #1444.
+    /// Discussed in #1444 + extended in #1947 review.
     pub fn fingerprint_build_inputs(resolved_nodes: &BTreeMap<NodeId, ResolvedNode>) -> String {
         let mut canonical = String::new();
         // Schema tag in the canonical form so format bumps force regeneration
@@ -189,6 +195,63 @@ impl DataflowSession {
             } else {
                 canonical.push_str("cwd:none\n");
             }
+
+            // Operator-level build commands and sources (Runtime node only).
+            // Each operator can carry its own `build:` and `source` (Python /
+            // SharedLibrary / Wasm). The schema-v1 fingerprint missed these
+            // entirely, so changing an operator's build silently reused the
+            // cached `build_id` — see #1947 self-review.
+            //
+            // `OperatorDefinition.id` is sorted within the Vec because
+            // `resolve_aliases_and_set_defaults` preserves user-declared order
+            // rather than sorting. Sort by id here so reordering operators in
+            // YAML doesn't churn the fingerprint.
+            if let CoreNodeKind::Runtime(runtime) = &node.kind {
+                let mut by_id: Vec<_> = runtime.operators.iter().collect();
+                by_id.sort_by_key(|op| op.id.as_ref());
+                if by_id.is_empty() {
+                    canonical.push_str("operators:none\n");
+                } else {
+                    canonical.push_str("operators:\n");
+                    for op in by_id {
+                        canonical.push_str("  op:");
+                        canonical.push_str(op.id.as_ref());
+                        canonical.push('\n');
+                        match op.config.build.as_deref() {
+                            Some(cmd) => {
+                                canonical.push_str("    build:");
+                                canonical.push_str(cmd);
+                                canonical.push('\n');
+                            }
+                            None => canonical.push_str("    build:none\n"),
+                        }
+                        match &op.config.source {
+                            OperatorSource::SharedLibrary(path) => {
+                                canonical.push_str("    source:shared-library\n    path:");
+                                canonical.push_str(path);
+                                canonical.push('\n');
+                            }
+                            OperatorSource::Python(py) => {
+                                canonical.push_str("    source:python\n    script:");
+                                canonical.push_str(&py.source);
+                                canonical.push('\n');
+                                if let Some(conda) = &py.conda_env {
+                                    canonical.push_str("    conda_env:");
+                                    canonical.push_str(conda);
+                                    canonical.push('\n');
+                                } else {
+                                    canonical.push_str("    conda_env:none\n");
+                                }
+                            }
+                            OperatorSource::Wasm(path) => {
+                                canonical.push_str("    source:wasm\n    path:");
+                                canonical.push_str(path);
+                                canonical.push('\n');
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         fnv1a_64_hex(canonical.as_bytes())
@@ -229,16 +292,14 @@ impl DataflowSession {
 /// Extract the `build` command from a `ResolvedNode`'s kind. Returns `None`
 /// when the field is unset, and `Some("")` to distinguish an empty-string
 /// build from a missing one (a user could plausibly toggle between them).
+///
+/// Runtime-kind nodes (operator runtime) return `None` here; their
+/// operator-level builds are folded into the canonical form separately
+/// by `fingerprint_build_inputs`.
 fn node_build_command(kind: &CoreNodeKind) -> Option<&str> {
     match kind {
         CoreNodeKind::Custom(custom) => custom.build.as_deref(),
-        CoreNodeKind::Runtime(_) => {
-            // RuntimeNode is `#[serde(transparent)]` over operator definitions;
-            // operators don't carry a build field today. If they ever do,
-            // extend this match. Returning None here matches the no-build
-            // case for operators.
-            None
-        }
+        CoreNodeKind::Runtime(_) => None,
     }
 }
 
@@ -502,5 +563,283 @@ nodes:
         let parsed: DataflowSession =
             serde_yaml::from_str(legacy_yaml).expect("legacy session must deserialize");
         assert!(parsed.build_fingerprint.is_none());
+    }
+
+    // ---------------------------------------------------------------------
+    // Coverage added during /pr-review of #1947. The initial 10 tests
+    // exercised only single-node Custom-kind dataflows, leaving the policy
+    // partially unverified for operators, multi-node ordering, env
+    // mutation, and deploy.machine ignore. These tests close those gaps.
+    // ---------------------------------------------------------------------
+
+    /// `deploy.machine` is a placement input, not a build input — per the
+    /// #1444 narrower policy, changing it MUST NOT invalidate the session.
+    /// The original test suite only verified path-only changes; this
+    /// closes the symmetric gap.
+    #[test]
+    fn fingerprint_unchanged_when_only_deploy_machine_changes() {
+        let on_m1 = resolved(
+            "\
+nodes:
+  - id: a
+    path: ./a
+    build: cargo build
+    _unstable_deploy:
+      machine: machine-1
+",
+        );
+        let on_m2 = resolved(
+            "\
+nodes:
+  - id: a
+    path: ./a
+    build: cargo build
+    _unstable_deploy:
+      machine: machine-2
+",
+        );
+        assert_eq!(
+            DataflowSession::fingerprint_build_inputs(&on_m1),
+            DataflowSession::fingerprint_build_inputs(&on_m2),
+            "deploy.machine-only change MUST NOT change fingerprint (per #1444 policy)",
+        );
+    }
+
+    /// `deploy.working_dir` is a build input — the cargo/python invocation
+    /// runs from there. Per policy, changing it MUST invalidate.
+    #[test]
+    fn fingerprint_changes_when_deploy_working_dir_changes() {
+        let cwd_a = resolved(
+            "\
+nodes:
+  - id: a
+    path: ./a
+    build: cargo build
+    _unstable_deploy:
+      working_dir: /tmp/a
+",
+        );
+        let cwd_b = resolved(
+            "\
+nodes:
+  - id: a
+    path: ./a
+    build: cargo build
+    _unstable_deploy:
+      working_dir: /tmp/b
+",
+        );
+        assert_ne!(
+            DataflowSession::fingerprint_build_inputs(&cwd_a),
+            DataflowSession::fingerprint_build_inputs(&cwd_b),
+            "deploy.working_dir change must change fingerprint",
+        );
+    }
+
+    /// Env removal and value-mutation are both forms of env change. The
+    /// original test suite only covered env *addition*; this verifies the
+    /// fingerprint detects the other two shapes.
+    #[test]
+    fn fingerprint_changes_when_env_value_mutates() {
+        let info = resolved(
+            "\
+nodes:
+  - id: a
+    path: ./a
+    build: cargo build
+    env:
+      RUST_LOG: info
+",
+        );
+        let debug = resolved(
+            "\
+nodes:
+  - id: a
+    path: ./a
+    build: cargo build
+    env:
+      RUST_LOG: debug
+",
+        );
+        assert_ne!(
+            DataflowSession::fingerprint_build_inputs(&info),
+            DataflowSession::fingerprint_build_inputs(&debug),
+            "mutating an env value must change fingerprint",
+        );
+    }
+
+    #[test]
+    fn fingerprint_changes_when_env_key_removed() {
+        let two_keys = resolved(
+            "\
+nodes:
+  - id: a
+    path: ./a
+    build: cargo build
+    env:
+      RUST_LOG: info
+      FEATURE: x
+",
+        );
+        let one_key = resolved(
+            "\
+nodes:
+  - id: a
+    path: ./a
+    build: cargo build
+    env:
+      RUST_LOG: info
+",
+        );
+        assert_ne!(
+            DataflowSession::fingerprint_build_inputs(&two_keys),
+            DataflowSession::fingerprint_build_inputs(&one_key),
+            "removing an env key must change fingerprint",
+        );
+    }
+
+    /// Multi-node ordering: BTreeMap iteration is sorted by NodeId, so
+    /// reordering nodes in YAML must not change the fingerprint. The
+    /// original test suite never exercised more than one node, so this
+    /// pins the determinism guarantee.
+    #[test]
+    fn fingerprint_unchanged_when_only_node_yaml_order_changes() {
+        let ab = resolved(
+            "\
+nodes:
+  - id: a
+    path: ./a
+    build: cargo build
+  - id: b
+    path: ./b
+    build: make
+",
+        );
+        let ba = resolved(
+            "\
+nodes:
+  - id: b
+    path: ./b
+    build: make
+  - id: a
+    path: ./a
+    build: cargo build
+",
+        );
+        assert_eq!(
+            DataflowSession::fingerprint_build_inputs(&ab),
+            DataflowSession::fingerprint_build_inputs(&ba),
+            "node YAML ordering must not affect fingerprint (BTreeMap sorts by id)",
+        );
+    }
+
+    /// Operator-level build commands DO affect what gets built and MUST
+    /// invalidate. This is the P1 from /pr-review of #1947 — the v1
+    /// fingerprint silently ignored Runtime nodes, so changing an
+    /// operator's `pip install` build silently kept the cached `build_id`.
+    #[test]
+    fn fingerprint_changes_when_operator_build_changes() {
+        let pandas_v2 = resolved(
+            "\
+nodes:
+  - id: foo
+    operators:
+      - id: op
+        python: ./op.py
+        build: pip install pandas==2.0
+        inputs: {}
+        outputs: []
+",
+        );
+        let pandas_v2_1 = resolved(
+            "\
+nodes:
+  - id: foo
+    operators:
+      - id: op
+        python: ./op.py
+        build: pip install pandas==2.1
+        inputs: {}
+        outputs: []
+",
+        );
+        assert_ne!(
+            DataflowSession::fingerprint_build_inputs(&pandas_v2),
+            DataflowSession::fingerprint_build_inputs(&pandas_v2_1),
+            "operator-level build change must change fingerprint",
+        );
+    }
+
+    #[test]
+    fn fingerprint_changes_when_operator_source_changes() {
+        let py_a = resolved(
+            "\
+nodes:
+  - id: foo
+    operators:
+      - id: op
+        python: ./op_a.py
+        inputs: {}
+        outputs: []
+",
+        );
+        let py_b = resolved(
+            "\
+nodes:
+  - id: foo
+    operators:
+      - id: op
+        python: ./op_b.py
+        inputs: {}
+        outputs: []
+",
+        );
+        assert_ne!(
+            DataflowSession::fingerprint_build_inputs(&py_a),
+            DataflowSession::fingerprint_build_inputs(&py_b),
+            "operator-level Python source change must change fingerprint",
+        );
+    }
+
+    #[test]
+    fn fingerprint_unchanged_when_only_operator_yaml_order_changes() {
+        // Operators within a node are stored in a Vec (not a BTreeMap), so
+        // the fingerprint code sorts them by `id` before canonicalizing.
+        // Verify reordering in YAML doesn't churn the fingerprint.
+        let ab = resolved(
+            "\
+nodes:
+  - id: foo
+    operators:
+      - id: a
+        python: ./a.py
+        inputs: {}
+        outputs: []
+      - id: b
+        python: ./b.py
+        inputs: {}
+        outputs: []
+",
+        );
+        let ba = resolved(
+            "\
+nodes:
+  - id: foo
+    operators:
+      - id: b
+        python: ./b.py
+        inputs: {}
+        outputs: []
+      - id: a
+        python: ./a.py
+        inputs: {}
+        outputs: []
+",
+        );
+        assert_eq!(
+            DataflowSession::fingerprint_build_inputs(&ab),
+            DataflowSession::fingerprint_build_inputs(&ba),
+            "operator YAML ordering within a node must not affect fingerprint",
+        );
     }
 }

--- a/binaries/cli/src/session.rs
+++ b/binaries/cli/src/session.rs
@@ -17,9 +17,15 @@ use eyre::{Context, ContextCompat};
 /// automatically.
 ///
 /// Versions:
-///   - v1: Custom-node build/source/env/cwd only (initial #1944 implementation)
-///   - v2: + Runtime-node operator build/source iteration (review of #1947)
-const FINGERPRINT_SCHEMA_VERSION: u32 = 2;
+/// - v1: Custom-node build/source/env/cwd only (initial #1444 implementation).
+/// - v2: + Runtime-node operator build + source-including-paths (first
+///   self-review fix of #1947, later flagged as over-broad).
+/// - v3: Drop operator runtime paths (python script path / shared-lib path /
+///   wasm path / conda_env) from the canonical form. They are runtime
+///   artifact locations, not build inputs — symmetric to `path` on Custom
+///   nodes which the #1444 policy explicitly excludes. Keep operator `build`
+///   and source-kind tag; those still flip the fingerprint correctly.
+const FINGERPRINT_SCHEMA_VERSION: u32 = 3;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct DataflowSession {
@@ -106,11 +112,15 @@ impl DataflowSession {
     /// - per-node `env` (sorted map, Display'd values — covers global env after
     ///   resolve_aliases_and_set_defaults merges it)
     /// - per-node `deploy.working_dir` (changes shift the cwd cargo/python runs in)
-    /// - per-operator `build` command and `source` (Runtime-kind nodes — Python
-    ///   script path, conda env, SharedLibrary path, Wasm path)
+    /// - per-operator `build` command and source-kind tag (Runtime-kind
+    ///   nodes — distinguishes Python vs SharedLibrary vs Wasm because
+    ///   switching kinds is a build-system change)
     ///
     /// Deliberately ignored (don't affect the build):
     /// - `path` — where the artifact is read from at start time, not built to
+    /// - operator `python:` / `shared-library:` / `wasm:` path values, and
+    ///   `conda_env` — runtime artifact pointers, symmetric to `path` on
+    ///   Custom nodes
     /// - `deploy.machine` — affects placement at start time, not build inputs
     ///
     /// Discussed in #1444 + extended in #1947 review.
@@ -225,30 +235,25 @@ impl DataflowSession {
                             }
                             None => canonical.push_str("    build:none\n"),
                         }
-                        match &op.config.source {
-                            OperatorSource::SharedLibrary(path) => {
-                                canonical.push_str("    source:shared-library\n    path:");
-                                canonical.push_str(path);
-                                canonical.push('\n');
-                            }
-                            OperatorSource::Python(py) => {
-                                canonical.push_str("    source:python\n    script:");
-                                canonical.push_str(&py.source);
-                                canonical.push('\n');
-                                if let Some(conda) = &py.conda_env {
-                                    canonical.push_str("    conda_env:");
-                                    canonical.push_str(conda);
-                                    canonical.push('\n');
-                                } else {
-                                    canonical.push_str("    conda_env:none\n");
-                                }
-                            }
-                            OperatorSource::Wasm(path) => {
-                                canonical.push_str("    source:wasm\n    path:");
-                                canonical.push_str(path);
-                                canonical.push('\n');
-                            }
-                        }
+                        // Operator source: include only the KIND tag, not the
+                        // path/script/conda_env inside. Those are runtime
+                        // artifact locations — symmetric to `path` on Custom
+                        // nodes, which the #1444 policy explicitly excludes.
+                        // Swapping `python: ./op_a.py` for `./op_b.py` is a
+                        // runtime-pointer change, not a build-input change,
+                        // and should NOT invalidate `build_id` for unrelated
+                        // built/git nodes in a mixed dataflow (#1947 review).
+                        //
+                        // Kind tag still flips when switching kinds (Python ->
+                        // SharedLibrary etc.), which IS a build-system change.
+                        let kind_tag = match &op.config.source {
+                            OperatorSource::SharedLibrary(_) => "shared-library",
+                            OperatorSource::Python(_) => "python",
+                            OperatorSource::Wasm(_) => "wasm",
+                        };
+                        canonical.push_str("    source-kind:");
+                        canonical.push_str(kind_tag);
+                        canonical.push('\n');
                     }
                 }
             }
@@ -770,8 +775,14 @@ nodes:
         );
     }
 
+    /// Operator runtime paths (`python:` script, `shared-library:` path,
+    /// `wasm:` path) are artifact-location fields, not build inputs.
+    /// Symmetric to `path` on Custom nodes. Swapping the script must NOT
+    /// invalidate `build_id` for unrelated built/git nodes in the same
+    /// dataflow. This was over-invalidating in the initial fix
+    /// (#1947 round-2 review).
     #[test]
-    fn fingerprint_changes_when_operator_source_changes() {
+    fn fingerprint_unchanged_when_only_operator_python_path_changes() {
         let py_a = resolved(
             "\
 nodes:
@@ -794,10 +805,45 @@ nodes:
         outputs: []
 ",
         );
-        assert_ne!(
+        assert_eq!(
             DataflowSession::fingerprint_build_inputs(&py_a),
             DataflowSession::fingerprint_build_inputs(&py_b),
-            "operator-level Python source change must change fingerprint",
+            "operator script path-only change MUST NOT change fingerprint \
+             (symmetric to Custom `path` exclusion in #1444)",
+        );
+    }
+
+    /// Switching operator KIND (Python -> SharedLibrary, etc.) IS a
+    /// build-system change. The fingerprint tracks the kind tag separately
+    /// from the path within each kind, so this still flips.
+    #[test]
+    fn fingerprint_changes_when_operator_kind_changes() {
+        let python = resolved(
+            "\
+nodes:
+  - id: foo
+    operators:
+      - id: op
+        python: ./op.py
+        inputs: {}
+        outputs: []
+",
+        );
+        let shared_lib = resolved(
+            "\
+nodes:
+  - id: foo
+    operators:
+      - id: op
+        shared-library: ./op
+        inputs: {}
+        outputs: []
+",
+        );
+        assert_ne!(
+            DataflowSession::fingerprint_build_inputs(&python),
+            DataflowSession::fingerprint_build_inputs(&shared_lib),
+            "switching operator kind (Python -> SharedLibrary) must change fingerprint",
         );
     }
 


### PR DESCRIPTION
## Summary

- **Closes #1444.** Implements the narrower invalidation policy phil-opp scoped in the [2026-04-07 comment](https://github.com/dora-rs/dora/issues/1444#issuecomment-) plus @Bhanudahiyaa's `env` addition from 2026-04-08.
- `DataflowSession` gains a `build_fingerprint` field; mismatches against the current descriptor clear `build_id` / `local_build` / `git_sources`.
- Backward-compatible — sessions written by earlier dora versions deserialize cleanly (field defaults to `None`, first invalidation call rewrites with a fresh fingerprint).

## What invalidates the session

Per the #1444 agreement:

| Input | Triggers invalidation? |
|---|---|
| per-node `build` command | ✅ |
| per-node source (Local vs git repo+rev) | ✅ |
| per-node `env` (sorted, includes globals after resolve) | ✅ |
| per-node `deploy.working_dir` | ✅ |
| per-node `path` | ❌ (artifact path at start time, not build input) |
| per-node `deploy.machine` | ❌ (placement at start time, not build input) |

## Implementation shape

```rust
pub struct DataflowSession {
    pub build_id: Option<BuildId>,
    pub session_id: SessionId,
    pub git_sources: BTreeMap<NodeId, GitSource>,
    pub local_build: Option<BuildInfo>,
    #[serde(default, skip_serializing_if = "Option::is_none")]
    pub build_fingerprint: Option<String>,
}

impl DataflowSession {
    pub fn fingerprint_build_inputs(
        resolved_nodes: &BTreeMap<NodeId, ResolvedNode>,
    ) -> String { /* FNV-1a 64-bit over canonical text */ }

    pub fn invalidate_if_build_inputs_changed(
        &mut self,
        resolved_nodes: &BTreeMap<NodeId, ResolvedNode>,
    ) -> bool { /* clears build metadata on mismatch */ }
}
```

Same FNV-1a digest shape as `BuildLockfile::fingerprint_descriptor_git_sources` — visually distinguishable as the same family of fingerprints, no new crypto crate.

## Wired into 4 call sites

| Site | Behavior |
|---|---|
| `dora build` | Records the fingerprint after a successful build, both local and through-coordinator branches |
| `dora start` | Reads session → resolves descriptor → invalidates if mismatched → persists session → consumes `build_id` |
| `dora run` | Same defense-in-depth (preceding `build()` call should leave a fresh fingerprint, but the check catches any code path that skips it) |
| `dora daemon --run-dataflow` | Same — the hidden local-dataflow path the original issue explicitly called out |

## Test coverage

10 new unit tests in `session::tests`, all YAML-driven so they survive descriptor schema additions:

- `fingerprint_is_stable_for_same_inputs`
- `fingerprint_changes_when_build_command_changes`
- `fingerprint_changes_when_source_changes_local_to_git`
- `fingerprint_changes_when_git_rev_changes`
- `fingerprint_changes_when_env_changes`
- `fingerprint_unchanged_when_only_path_changes` — per-policy
- `invalidate_clears_build_metadata_on_mismatch`
- `invalidate_is_noop_when_fingerprint_matches`
- `session_roundtrip_with_new_field`
- `session_roundtrip_backward_compatible_without_field`

Local gates all clean:

```bash
cargo fmt --all -- --check                                            # clean
cargo clippy --all --exclude dora-{node,operator,ros2-bridge}-api-python \
  -- -D warnings                                                       # clean
cargo test -p dora-cli --lib                                          # 164 passed, 0 failed
```

## What about @Bhanudahiyaa's prior PRs?

#1445 ("fix(cli): invalidate stale build session on dataflow changes") and #1449 ("feat(cli): enforce --locked validation for start and run") were the original broader-scope attempts. They're not used as a base here — the 2026-04-07 narrowing agreement happened after they were written, so the policy in this PR diverges from what those branches implemented. Fresh implementation tracks the agreed policy directly.

## Test plan

- [ ] Existing `cargo test -p dora-cli` suite stays green
- [ ] Manually verify: edit a node's `build:` field after a `dora build`, then run `dora start` → expect `tracing::info!` line about discarded `build_id`
- [ ] Manually verify: edit a node's `path:` field only → no invalidation, `build_id` reused
- [ ] Smoke test the migration: an existing session file from current main deserializes, then gets invalidated on first run (expected — no `build_fingerprint` field stored yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
