### PR TITLE
ci(examples): split examples-windows; gate heavy half to release tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -534,6 +534,28 @@ jobs:
       - cargo-cache-save:
           prefix: cargo-macos-examples
 
+  # `examples-windows` was a single job covering Build + 5 examples
+  # (~65m total post-#1946). CircleCI Windows jobs cap at a 60-minute
+  # wall, so the cumulative runtime tripped the wall during "Multiple
+  # Daemons example" — even though the per-step `no_output_timeout`
+  # values are well above 60m. Split into two cooperating jobs:
+  #
+  #   examples-windows       — Build + Rust Dataflow + Rust Git Dataflow (~42m).
+  #                            Runs on every main push as a fast informational
+  #                            signal — exercises runtime + CLI + git source path.
+  #   examples-windows-heavy — Build + Multiple Daemons + C + C++ (~47m).
+  #                            Runs ONLY on release tags (see workflow filter).
+  #                            Dora has few Windows users; paying double Windows
+  #                            compute on every main push to catch regressions
+  #                            that mostly matter at tag time isn't worth the
+  #                            spend. Multi-daemon cluster + C/C++ FFI are
+  #                            release-time confidence checks.
+  #
+  # Both jobs do their own `cargo build --examples` because Windows
+  # runners don't share workspaces with each other today (no Windows
+  # job uses `persist_to_workspace`). Linux examples remain in a single
+  # `examples-linux` job — Linux is fast enough that the cumulative
+  # runtime stays under 50m.
   examples-windows:
     executor: win/default
     environment:
@@ -565,6 +587,29 @@ jobs:
           shell: bash.exe
           command: cargo run --example rust-dataflow-git
           no_output_timeout: 30m
+      - cargo-cache-save:
+          prefix: cargo-win-examples
+
+  examples-windows-heavy:
+    executor: win/default
+    environment:
+      CARGO_TERM_COLOR: always
+      PYO3_NO_PYTHON: "1"
+    steps:
+      - checkout
+      - install-rust-windows:
+          version: "1.92.0"
+      # Separate cache prefix from `examples-windows` so the two jobs
+      # never trip on each other's incremental compilation state.
+      - cargo-cache-restore:
+          prefix: cargo-win-examples-heavy
+      - run:
+          name: Build examples + CLI binary
+          shell: bash.exe
+          command: |
+            cargo build --examples
+            cargo build -p dora-cli
+          no_output_timeout: 30m
       - run:
           name: Multiple Daemons example
           shell: bash.exe
@@ -581,7 +626,7 @@ jobs:
           command: cargo run --example cxx-dataflow
           no_output_timeout: 15m
       - cargo-cache-save:
-          prefix: cargo-win-examples
+          prefix: cargo-win-examples-heavy
 
   # ===== CLI integration tests =====
   # Split into Rust-only and Python sub-jobs for parallelism.
@@ -1326,11 +1371,30 @@ workflows:
       - examples-macos
       - cli-macos
 
-      # ── Windows integration (main branch only -- 2x slower) ──
+      # ── Windows integration (slow runners, narrow user surface) ──
+      #
+      # `examples-windows` runs on every main push as a fast informational
+      # signal (Rust Dataflow + Rust Git Dataflow exercise the runtime +
+      # CLI + git-source paths — where most "did anything obvious break
+      # on Windows" lives).
+      #
+      # `examples-windows-heavy` runs ONLY on release tags. Multiple
+      # Daemons cluster + C/C++ FFI examples are release-time confidence
+      # checks, not per-commit signal. Dora's Windows user surface is
+      # narrow; paying double Windows CI compute on every main push to
+      # catch regressions that mostly matter at tag time isn't worth the
+      # spend. Trade-off accepted: a Windows-heavy regression landing
+      # mid-cycle won't surface until the next `v*` tag.
       - examples-windows:
           filters:
             branches:
               only: main
+      - examples-windows-heavy:
+          filters:
+            tags:
+              only: /^v[0-9]+\.[0-9]+.*/
+            branches:
+              ignore: /.*/
       - cli-windows:
           filters:
             branches:


### PR DESCRIPTION
## Summary

Splits `examples-windows` into two cooperating jobs with **different triggers**:

| Job | Trigger | When it runs |
|---|---|---|
| `examples-windows` | `branches: only: main` | Every main push (fast informational signal: ~42m) |
| **`examples-windows-heavy`** (new) | **`tags: only: /^v[0-9]+\.[0-9]+.*/`** | **Only on release tags (`v*`) — release-time confidence check** |

This solves two problems at once:
1. The 60-minute Windows job wall (post-#1946, cumulative steps exceed it on a single job).
2. The poor CI-cost-vs-risk trade-off — dora has few Windows users; paying double Windows compute on every main push to catch regressions that mostly matter at tag time isn't worth the spend.

## Problem

After #1946 bumped the `rust-dataflow-git` pin, `examples-windows` started reliably failing at the **Multiple Daemons example** step on main. Per-step `no_output_timeout` values are all ≥ 30m, so this is the job-level CircleCI 60-min wall, not a step timeout. Concrete step timing on `b5c6db99`:

```
[success ]  19.7m  Build examples + CLI binary
[success ]  10.4m  Rust Dataflow example
[success ]  11.4m  Rust Git Dataflow example    ← #1946's fix landed here
[timedout]  17.4m  Multiple Daemons example     ← cumulative wall fires here
[skipped ]   ----  C Dataflow example
[skipped ]   ----  C++ Dataflow example
[timedout]   0.0m  Build timed out
```

`19.7 + 10.4 + 11.4 + 17.4 ≈ 59m`. Adding C + C++ pushes any single Windows job past 60m.

## Why surfaced now

Pre-#1887 (the original regression bisect point), the Rust Git Dataflow step exited fast on cached older-protocol nodes. With #1946 restoring proper protocol parity, every step now takes its honest time — cumulative exceeds 60m.

## Fix

### Light job (`examples-windows`)

Build + Rust Dataflow + Rust Git Dataflow. Runs on every main push. ~42m. Covers the most common "did anything break on Windows" signal: runtime + CLI + git-source path.

### Heavy job (`examples-windows-heavy`)

Build + Multiple Daemons + C Dataflow + C++ Dataflow. Runs **only on release tags** matching `/^v[0-9]+\.[0-9]+.*/`. ~47m. Multi-daemon cluster + C/C++ FFI are release-time confidence checks.

Filter:
```yaml
- examples-windows-heavy:
    filters:
      tags:
        only: /^v[0-9]+\.[0-9]+.*/
      branches:
        ignore: /.*/
```

## Trade-offs

- ✅ **CI cost on main pushes drops** — only the light job runs (~42m), no double-build.
- ✅ **Release-time confidence preserved** — heavy job still runs on every `v*` tag.
- ⚠️ **A Windows-heavy regression landing mid-cycle won't surface until the next release tag.** Acceptable given the narrow Windows user surface.
- **No test loss** — all 5 examples still run, just on different cadences.

## Why not other approaches

- **Run heavy on every main push** (the original PR draft) — pays double Windows compute every push for marginal incremental signal.
- **Move "Multiple Daemons" to Linux-only** — examples-windows is informational; users who need multi-daemon-on-Windows confidence lose that signal entirely.
- **persist_to_workspace cross-Windows-job** — adds upload-from-Windows-runner latency (notoriously slow) and complexity. Worth doing only if compute cost becomes a real concern.

## Test plan

- [ ] On this PR's CI: only `examples-windows` runs (this PR is not a release tag) — heavy job correctly absent
- [ ] After merge to main: `examples-windows` ✅, `examples-windows-heavy` not invoked
- [ ] Next release tag (`v*`): `examples-windows-heavy` invoked and ✅
- [ ] `examples-linux` job untouched, still ✅

## Related

- #1945: rust-dataflow-git pin staleness (fixed by #1946) — this PR is the second-order fix that surfaces the time-wall as a separate concern
- #1947: session-fingerprint invalidation self-review (where this thread started)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
