### PR TITLE
fix(cli): reject a distributed start of a locally-built dataflow

### DIFF
--- a/binaries/cli/src/command/start/mod.rs
+++ b/binaries/cli/src/command/start/mod.rs
@@ -143,6 +143,24 @@ fn start_dataflow(
     }
     drop(resolved_for_fingerprint);
 
+    // A local `dora build` produces artifacts that only exist on this machine.
+    // A distributed (`deploy`) dataflow is started through the coordinator and
+    // runs on remote daemons that cannot see that build, so the cached id is
+    // useless there and `dora start` cannot rebuild. Refuse early with an
+    // actionable message instead of letting the daemon fail confusingly (#1955).
+    let has_deploy_nodes = dataflow_descriptor.nodes.iter().any(|n| n.deploy.is_some());
+    if local_build_blocks_distributed_start(
+        dataflow_session.local_build.is_some(),
+        has_deploy_nodes,
+    ) {
+        eyre::bail!(
+            "this dataflow was built locally, but it has `deploy` sections and is started \
+             through the coordinator — remote daemons cannot use a local build.\n\n  \
+             run `dora build` against the running coordinator (without `--local`) to build on \
+             the target machines before `dora start`"
+        );
+    }
+
     if debug {
         dataflow_descriptor.debug.enable_debug_inspection = true;
     }
@@ -238,4 +256,37 @@ fn wait_until_dataflow_started(
         }
     }
     Ok(())
+}
+
+/// Whether a cached **local** build makes a **distributed** `dora start`
+/// unusable.
+///
+/// A local `dora build` records `local_build`; its artifacts live only on this
+/// machine. A distributed dataflow (one with `deploy` sections) is started
+/// through the coordinator and runs on remote daemons that cannot see that
+/// build. The daemon resolves build metadata by id (`self.builds.get(id)`), so
+/// the local id is unknown there and behaves exactly like no build: git-source
+/// nodes fail with "no `dora build` was run yet" and other nodes silently spawn
+/// with default working dirs/env. `dora start` does not build, so it cannot
+/// recover — refuse early and tell the user to run a distributed `dora build`
+/// (#1955). Local builds for non-distributed dataflows are fine and allowed.
+fn local_build_blocks_distributed_start(has_local_build: bool, has_deploy_nodes: bool) -> bool {
+    has_local_build && has_deploy_nodes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_build_blocks_distributed_start_only_when_deployed_and_local() {
+        // local build on a `deploy` dataflow: remote daemons can't use it -> block.
+        assert!(local_build_blocks_distributed_start(true, true));
+        // distributed build (no local_build): the coordinator knows the id -> allow.
+        assert!(!local_build_blocks_distributed_start(false, true));
+        // single-machine dataflow with a local build: don't regress -> allow.
+        assert!(!local_build_blocks_distributed_start(true, false));
+        // nothing built: nothing to block -> allow.
+        assert!(!local_build_blocks_distributed_start(false, false));
+    }
 }


### PR DESCRIPTION
## What

Fixes #1955. After a local `dora build` — or a failed distributed build that left a prior local build cached (surfaced reviewing #1953) — `dora start` would send a **local-only** `build_id` to the coordinator. Remote daemons resolve build metadata by id (`self.builds.get(id)` in `daemon/src/lib.rs`), and a local build's id is unknown there, so it behaves **exactly like no build**:

- nodes with a git source fail with the misleading *"node X has git source, but no `dora build` was run yet"* (the user *did* build, just locally);
- other nodes silently spawn with default working dirs / env, ignoring the build's metadata.

`dora start` never runs build commands (by design), so it cannot recover by sending `None` either — `None` and an unknown id produce the same `build_info = None` on the daemon.

## Fix

Detect the mismatch in the CLI and **fail fast, before connecting to the coordinator**, with an actionable message: when the dataflow has `deploy` sections **and** a local build is cached (`local_build.is_some()`), refuse and tell the user to run a distributed `dora build`.

- Replaces a confusing daemon-side error (git nodes) / silent wrong-metadata start (non-git nodes) with one clear CLI error.
- Local builds for **non-distributed** dataflows are unaffected — the common single-machine `dora build` + `dora start` flow still works.
- Does not touch #1953's failure path and adds no session writes.

Decision lives in a pure predicate `local_build_blocks_distributed_start(has_local_build, has_deploy_nodes)` with a truth-table unit test.

## Why fail instead of "drop the id"

An earlier revision dropped the local id to `None`, but the daemon treats `None` and an unknown id identically (`build_id.and_then(|id| self.builds.get(&id))` → `None`), so that changed nothing — the git error and the silent non-git start both remained. Since `dora start` can't build, failing early is the correct fix (thanks to review feedback for catching this).

## Test plan

- [x] `cargo test -p dora-cli` — 176 passed, 0 failed (incl. `command::start::tests`)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p dora-cli -- -D warnings` — clean

Closes #1955.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
