### PR TITLE
ci: run cargo fmt after clippy --fix in the autofix workflow

### DIFF
--- a/.github/workflows/cargo-update.yml
+++ b/.github/workflows/cargo-update.yml
@@ -64,6 +64,14 @@ jobs:
         if: steps.check_pr.outputs.exists == 'false'
         run: cargo clippy --fix --allow-dirty --allow-staged --workspace --exclude rust-ros2-example-node --exclude dora-ros2-bridge --exclude dora-ros2-bridge-msg-gen --exclude dora-ros2-bridge-python --all-targets --all-features
 
+      # `clippy --fix` rewrites code structurally but does not run rustfmt, so its
+      # output can fail the required Format check (trailing whitespace, un-reindented
+      # blocks). Format here so the generated PR is fmt-clean (#1957). Same scope as
+      # CI's `cargo fmt --all -- --check`.
+      - name: Format clippy fixes
+        if: steps.check_pr.outputs.exists == 'false'
+        run: cargo fmt --all
+
       - name: Configure git
         if: steps.check_pr.outputs.exists == 'false'
         run: |


### PR DESCRIPTION
## What

Fixes #1957. The weekly clippy-autofix job in `.github/workflows/cargo-update.yml` ran `cargo clippy --fix` and committed the result without formatting. `clippy --fix` rewrites code structurally (derive macros, collapsing `if let` into let-chains) but does not run rustfmt, so its `chore: Fix clippy warnings` PRs repeatedly failed the required **Format** check and sat blocked until a human hand-formatted them (most recently #1936).

## Fix

Add a `cargo fmt --all` step in the `cargo-clippy-fix` job, between the clippy-fix step and the commit:

```yaml
      - name: Run cargo clippy fix
        ...

      - name: Format clippy fixes        # new
        if: steps.check_pr.outputs.exists == 'false'
        run: cargo fmt --all

      - name: Configure git
        ...
```

- Same scope as CI's `cargo fmt --all -- --check`, so the generated PR is fmt-clean by construction.
- The existing `git diff --quiet` guard still skips PR creation when there are no net changes.

## Test plan

Workflow-only change (no Rust touched). Verified:
- [x] YAML parses; step order is `clippy-fix → fmt → configure-git → commit`, with the same `if: steps.check_pr.outputs.exists == 'false'` guard as its siblings.

Effect will be observable on the next scheduled run (Tuesdays 08:00 UTC) or via `workflow_dispatch`.

Closes #1957.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
