### PR TITLE
ci: smoke-test the uncovered CLI subcommands (#1800 A2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
           set -e
           for sub in run up down build start stop restart list logs top \
                      topic node param record replay trace doctor status \
-                     new graph expand validate; do
+                     new graph expand validate completion inspect self; do
             cargo run --quiet -p dora-cli -- "$sub" --help > /dev/null
           done
           cargo run --quiet -p dora-cli -- --help > /dev/null
@@ -220,6 +220,14 @@ jobs:
             echo "$out" | grep -q "$id" \
               || { echo "ERROR: graph output missing node '$id'"; exit 1; }
           done
+      # Offline shell-completion generation must emit a non-empty script.
+      # Guards against clap_complete wiring regressions (#1800 A2).
+      - name: CLI smoke — dora completion
+        shell: bash
+        run: |
+          out=$(cargo run --quiet -p dora-cli -- completion bash)
+          echo "$out" | grep -q '_dora' \
+            || { echo "ERROR: dora completion bash produced no completion script"; exit 1; }
 
   e2e:
     name: E2E Tests

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -546,6 +546,42 @@ jobs:
           dora topic pub -d tui-smoke ticker/count '42' --count 3 2>&1 | tee pub.out
           # `topic pub` prints "Published message N/3" on success.
           grep -q 'Published message 3/3' pub.out || { echo "ERROR: pub didn't emit all 3 messages"; exit 1; }
+      # CLI subcommand coverage (#1800 A2) — exercise the live commands that
+      # need a running coordinator + dataflow, reusing the tui-smoke fixture.
+      - name: dora doctor (coordinator reachable)
+        run: |
+          # doctor probes CLI/uv/coordinator/daemon/dataflow health. With the
+          # network up and a dataflow running, the coordinator check must pass.
+          # `tee` masks doctor's exit code, so the grep is the real assertion.
+          dora doctor 2>&1 | tee doctor.out || true
+          grep -q 'PASS  Coordinator' doctor.out \
+            || { echo "ERROR: doctor didn't report coordinator reachable"; cat doctor.out; exit 1; }
+      - name: dora inspect top --once (top alias)
+        run: |
+          # `inspect top` is the canonical path behind `dora top`; assert the
+          # alias produces the same JSON-array snapshot.
+          out=$(dora inspect top --once)
+          echo "$out" | grep -qE '^\[' \
+            || { echo "ERROR: inspect top --once didn't produce JSON array"; exit 1; }
+      - name: dora param list (running node)
+        run: |
+          # ticker declares no params; `param list` must still succeed and
+          # report the empty state (exercises the param-store query path).
+          dora param list ticker -d tui-smoke 2>&1 | tee param.out
+          grep -qi 'parameter' param.out \
+            || { echo "ERROR: param list produced no recognizable output"; cat param.out; exit 1; }
+      - name: dora logs (running dataflow)
+        run: |
+          # Smoke the log-retrieval path end-to-end. ticker may have no stdout
+          # yet, so the assertion is that the command succeeds (exit 0).
+          dora logs tui-smoke --node ticker
+      - name: dora restart (stop + re-start with stored descriptor)
+        run: |
+          # Disruptive (re-IDs the dataflow) — keep last among the live steps.
+          # Asserts the restart round-trips and reports the new dataflow id.
+          dora restart --name tui-smoke 2>&1 | tee restart.out
+          grep -q 'restarted' restart.out \
+            || { echo "ERROR: restart didn't report success"; cat restart.out; exit 1; }
       - name: Stop dataflow + tear down
         if: always()
         run: |


### PR DESCRIPTION
## What

Addresses the **A2** item of the #1800 CI-coverage umbrella — smoke coverage for the six CLI subcommands it listed as uncovered: `completion`, `doctor`, `inspect`, `param`, `logs`, `restart`. (`expand`/`validate`/`graph`/`self` were already covered.)

## Changes

**Offline — `ci.yml` CLI-semantic job (PR gate, fast):**
- New `CLI smoke — dora completion` step: `dora completion bash` must emit a completion script (asserts `_dora`).
- Added `completion`, `inspect`, `self` to the `argparse & help text` loop — they were missing from it.

**Live — `nightly.yml` "Topic & top inspection smoke" job** (reuses the already-running `tui-smoke` debug fixture, so no new job/runner cost):
- `dora doctor` → asserts `PASS  Coordinator` (coordinator reachable with the network up)
- `dora inspect top --once` → asserts the JSON-array snapshot (the alias behind `dora top`)
- `dora param list ticker` → asserts the empty-param state message (exercises the param-store query path)
- `dora logs tui-smoke --node ticker` → asserts the command succeeds (logs may be empty)
- `dora restart --name tui-smoke` → asserts `restarted` (kept **last** — it re-IDs the dataflow)

## Verification

Every assertion was run locally against the built CLI with a live `tui-smoke` dataflow:

```
doctor            → exit 0, "PASS  Coordinator: reachable at 127.0.0.1:6013"
inspect top --once→ exit 0, JSON array
param list ticker → exit 0, "No parameters set for node `ticker`"
logs --node ticker→ exit 0
restart --name    → exit 0, "dataflow restarted: <old> -> <new>"
completion bash   → exit 0, emits `_dora()`
```

Both workflow files parse (`yaml.safe_load`); `restart` is ordered before the teardown step.

## Scope

Completes **A2** only. Does **not** close #1800 — `B1` (stitched cluster+record+replay E2E), `C9` (`--rt` smoke), `C12` (container smoke), `A1` (coverage matrix) remain, and `B2` stays blocked on #1799.

Refs #1800.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
