### PR TITLE
fix(ci): avoid SIGPIPE in the dora completion smoke step (main red since #1959)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,11 +222,15 @@ jobs:
           done
       # Offline shell-completion generation must emit a non-empty script.
       # Guards against clap_complete wiring regressions (#1800 A2).
+      # Use a here-string instead of `echo "$out" | grep -q`: under
+      # `set -eo pipefail`, `grep -q` exits as soon as it matches (line 1 of
+      # the 3712-line completion script), closing the pipe; `echo` is still
+      # writing, gets SIGPIPE, and `pipefail` fails the whole step.
       - name: CLI smoke — dora completion
         shell: bash
         run: |
           out=$(cargo run --quiet -p dora-cli -- completion bash)
-          echo "$out" | grep -q '_dora' \
+          grep -q '_dora' <<<"$out" \
             || { echo "ERROR: dora completion bash produced no completion script"; exit 1; }
 
   e2e:


### PR DESCRIPTION
## What

Hot-fix: **main has been red since #1959** because the `CLI smoke — dora completion` step (`.github/workflows/ci.yml:225`) hits `SIGPIPE` under CI's `set -eo pipefail` shell.

## Root cause

```bash
out=$(cargo run --quiet -p dora-cli -- completion bash)   # 3712-line script
echo "$out" | grep -q '_dora'                              # ← the bug
```

`grep -q` exits the **instant** it matches (`_dora` is on line 1 of the completion script), closing the pipe. `echo` is still writing the rest of the 3712 lines, gets `SIGPIPE`, returns non-zero, and `pipefail` propagates → step fails.

CI log shows it verbatim:
```
echo: write error: Broken pipe
ERROR: dora completion bash produced no completion script
##[error]Process completed with exit code 1.
```

Worked on macOS during local verification because that shell didn't have `pipefail` enabled.

## Fix

Replace the pipe with a here-string — no pipe, no SIGPIPE:

```bash
out=$(cargo run --quiet -p dora-cli -- completion bash)
grep -q '_dora' <<<"$out" \
  || { echo "ERROR: dora completion bash produced no completion script"; exit 1; }
```

## Verification

Reproduced and confirmed locally with the **exact CI shell** (`bash -eo pipefail`):
- Old form (`echo | grep -q`): fails with `echo: write error: Broken pipe`, exit 1.
- New form (`grep -q <<<"$out"`): passes, exit 0.

## Note for adjacent smokes

The existing validate / expand / graph semantic smokes use the same `echo "$out" | grep -q ...` pattern, but with **small** outputs (a YAML or a Mermaid graph), so `echo` finishes writing before `grep -q` exits and there's no SIGPIPE. Only the completion smoke triggers it because the captured output is enormous. Out of scope here; could be hardened later for consistency.

Part of #1800.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
