### PR TITLE
fix(cli): make dora run isolated again

### DIFF
--- a/binaries/cli/src/command/daemon.rs
+++ b/binaries/cli/src/command/daemon.rs
@@ -204,7 +204,7 @@ impl Executable for Daemon {
 
                         let result = dora_daemon::Daemon::run_dataflow(&dataflow_path,
                             dataflow_session.build_id, dataflow_session.local_build, dataflow_session.session_id, false,
-                            LogDestination::Tracing, None, None, false,
+                            LogDestination::Tracing, None, None, false, None,
                         ).await?;
                         handle_dataflow_result(result, None)
                     }

--- a/binaries/cli/src/command/mod.rs
+++ b/binaries/cli/src/command/mod.rs
@@ -66,7 +66,7 @@ use validate::Validate;
 #[derive(Debug, clap::Subcommand)]
 pub enum Command {
     // -- Lifecycle --
-    /// Run a dataflow locally with embedded coordinator and daemon
+    /// Run a dataflow locally in isolation (no coordinator)
     #[clap(display_order = 1)]
     Run(Run),
     /// Start coordinator and daemon in local mode

--- a/binaries/cli/src/command/run.rs
+++ b/binaries/cli/src/command/run.rs
@@ -1,38 +1,39 @@
-//! The `dora run` command runs a dataflow locally with an embedded
-//! coordinator and daemon so that CLI monitoring commands (`dora list`,
-//! `dora stop`, `dora logs`, etc.) work during execution.
+//! The `dora run` command runs a dataflow locally in isolation: it
+//! spawns nodes in-process via `dora_daemon::Daemon::run_dataflow`
+//! without binding any coordinator port. As a result, `dora run` does
+//! NOT integrate with the CLI monitoring commands (`dora list`,
+//! `dora stop`, `dora logs`, `dora top`, ...). Use `dora up` + `dora
+//! start` instead when you need to attach those tools.
+//!
+//! Running isolated means:
+//!   - `dora run` can be invoked while `dora up` is already running
+//!     (the coordinator port is not contested).
+//!   - Multiple `dora run` calls can execute in parallel.
 
-use super::{Executable, system::status::daemon_running};
+use super::Executable;
 use crate::{
-    BuildConfig, LOCALHOST, build as build_dataflow,
-    common::{
-        canonicalize_working_dir, connect_with_retry, error_indicates_dataflow_finished,
-        handle_dataflow_result, resolve_dataflow, working_dir_or_parent, write_events_to,
-    },
+    BuildConfig, build as build_dataflow,
+    common::{handle_dataflow_result, resolve_dataflow, write_events_to},
     output::{
         LogFormat, LogOutputConfig, parse_log_filter, parse_log_level_str, print_log_message,
     },
     session::DataflowSession,
 };
-use dora_coordinator::{CoordinatorStore, InMemoryStore, SpanStore};
-use dora_core::{
-    build::LogLevelOrStdout,
-    descriptor::{Descriptor, DescriptorExt},
-    topics::DORA_COORDINATOR_PORT_WS_DEFAULT,
-};
-use dora_message::{
-    cli_to_coordinator::ControlRequest, common::LogMessage, coordinator_to_cli::ControlRequestReply,
-};
+use dora_core::build::LogLevelOrStdout;
+use dora_daemon::{Daemon, LogDestination, flume};
 use duration_str::parse as parse_duration_str;
-use eyre::{Context, bail};
-use std::{collections::BTreeMap, net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
+use eyre::Context;
+use std::{path::PathBuf, time::Duration};
 use tokio::runtime::Builder;
 
 #[derive(Debug, clap::Args)]
-/// Run a dataflow locally.
+/// Run a dataflow locally in isolation.
 ///
-/// Runs the given dataflow with an embedded coordinator and daemon so that
-/// CLI commands like `dora list`, `dora stop`, and `dora logs` work.
+/// Spawns nodes in-process without a coordinator. CLI monitoring
+/// commands (`dora list`, `dora stop`, `dora logs`, ...) do NOT attach
+/// to a `dora run` execution. Use `dora up` + `dora start` instead when
+/// you need to attach those tools or run multiple coordinated
+/// dataflows.
 pub struct Run {
     /// Path to the dataflow descriptor file
     #[clap(value_name = "PATH")]
@@ -131,12 +132,6 @@ pub fn run(dataflow: String, uv: bool) -> eyre::Result<()> {
     run.execute()
 }
 
-/// Events delivered to the main wait loop.
-enum RunEvent {
-    CtrlC,
-    StopAfterElapsed,
-}
-
 impl Executable for Run {
     fn execute(self) -> eyre::Result<()> {
         if self.allow_shell_nodes {
@@ -144,15 +139,6 @@ impl Executable for Run {
             // so there are no concurrent reads of environment variables.
             unsafe { std::env::set_var("DORA_ALLOW_SHELL_NODES", "true") };
         }
-
-        // Register ctrlc handler FIRST (before tokio runtime) so the daemon's
-        // handler gracefully skips (it already handles the "already registered" case).
-        let (event_tx, event_rx) = std::sync::mpsc::channel::<RunEvent>();
-        let ctrlc_tx = event_tx.clone();
-        ctrlc::set_handler(move || {
-            let _ = ctrlc_tx.send(RunEvent::CtrlC);
-        })
-        .context("failed to set ctrl-c handler")?;
 
         let rt = Builder::new_multi_thread()
             .enable_all()
@@ -185,203 +171,12 @@ impl Executable for Run {
             ..Default::default()
         })
         .context("failed to build dataflow before run")?;
-        let mut dataflow_session = DataflowSession::read_session(&dataflow_path)
+        let dataflow_session = DataflowSession::read_session(&dataflow_path)
             .context("failed to read DataflowSession")?;
 
-        let working_dir = working_dir_or_parent(self.working_dir.as_deref(), &dataflow_path);
-        let mut dataflow_descriptor = Descriptor::blocking_read(&dataflow_path)
-            .wrap_err_with(|| {
-                format!(
-                    "failed to read dataflow at `{}`\n\n  \
-                     hint: check the file exists and is valid YAML",
-                    dataflow_path.display()
-                )
-            })?
-            .expand(working_dir)
-            .wrap_err("failed to expand modules in dataflow descriptor")?;
-        // Defense-in-depth invalidation. The preceding `build()` call should
-        // have refreshed the fingerprint, but if any code path skips the
-        // build (e.g. future flag) the cached `build_id` must still match
-        // current build-inputs — otherwise the embedded coordinator below
-        // would start nodes from stale artifacts (#1444).
-        let resolved_for_fingerprint = dataflow_descriptor
-            .resolve_aliases_and_set_defaults()
-            .context("failed to resolve nodes for session fingerprint")?;
-        if dataflow_session.invalidate_if_build_inputs_changed(&resolved_for_fingerprint) {
-            dataflow_session
-                .write_out_for_dataflow(&dataflow_path)
-                .context("failed to persist invalidated dataflow session")?;
-        }
-        drop(resolved_for_fingerprint);
-
-        if self.debug {
-            dataflow_descriptor.debug.enable_debug_inspection = true;
-        }
-
-        // Validate: dora run doesn't support deploy keys
-        if let Some(node) = dataflow_descriptor
-            .nodes
-            .iter()
-            .find(|n| n.deploy.is_some())
-        {
-            bail!(
-                "node {} has a `deploy` section, which is not supported in `dora run`\n\n\
-                 Instead, you need to spawn a `dora coordinator` and one or more `dora daemon`\n\
-                 instances and then use `dora start`.",
-                node.id
-            );
-        }
-
-        // --- Spawn embedded coordinator ---
-        log::warn!(
-            "embedded coordinator has no authentication enabled; \
-             any local process can connect and control dataflows. \
-             For production use, run `dora up --auth` instead."
-        );
-        let bind_addr: SocketAddr = (LOCALHOST, DORA_COORDINATOR_PORT_WS_DEFAULT).into();
-        let store: Arc<dyn CoordinatorStore> = Arc::new(InMemoryStore::new());
-        #[cfg(feature = "tracing")]
-        let span_store: SpanStore = None;
-        #[cfg(not(feature = "tracing"))]
-        let span_store: SpanStore = ();
-
-        let (coordinator_port, coordinator_handle) = rt.block_on(async {
-            let (port, future) = dora_coordinator::start_embedded(
-                bind_addr,
-                futures::stream::empty(),
-                store,
-                span_store,
-            )
-            .await
-            .context("failed to start embedded coordinator")?;
-
-            let handle = tokio::spawn(future);
-            Ok::<_, eyre::Report>((port, handle))
-        })?;
-
-        let coordinator_addr: SocketAddr = (LOCALHOST, coordinator_port).into();
-
-        // --- Spawn embedded daemon ---
-        // Pass build info from the session so git-source nodes can be found.
-        let initial_builds = match (
-            dataflow_session.build_id,
-            dataflow_session.local_build.clone(),
-        ) {
-            (Some(id), Some(info)) => {
-                let mut m = BTreeMap::new();
-                m.insert(id, info);
-                m
-            }
-            _ => BTreeMap::new(),
-        };
-        let daemon_handle = rt.spawn(dora_daemon::Daemon::run_with_builds(
-            coordinator_addr,
-            None,
-            BTreeMap::new(),
-            0,
-            initial_builds,
-        ));
-
-        // --- Wait for coordinator to accept connections ---
-        let session = connect_with_retry(coordinator_addr, Duration::from_secs(10))
-            .context("failed to connect to embedded coordinator")?;
-
-        // --- Wait for daemon to connect (poll on the same session) ---
-        {
-            let deadline = std::time::Instant::now() + Duration::from_secs(10);
-            loop {
-                match daemon_running(&session) {
-                    Ok(true) => break,
-                    Ok(false) if std::time::Instant::now() < deadline => {
-                        std::thread::sleep(Duration::from_millis(100));
-                    }
-                    Ok(false) => {
-                        bail!("timed out waiting for daemon to connect to coordinator");
-                    }
-                    Err(e) => return Err(e).context("failed to check daemon status"),
-                }
-            }
-        }
-
-        // --- Start the dataflow via coordinator ---
-        let local_working_dir = Some(canonicalize_working_dir(
-            self.working_dir.as_deref(),
-            &dataflow_path,
-        )?);
-
-        let dataflow_id = {
-            let reply_raw = session
-                .request(
-                    &serde_json::to_vec(&ControlRequest::Start {
-                        build_id: dataflow_session.build_id,
-                        session_id: dataflow_session.session_id,
-                        dataflow: dataflow_descriptor.clone(),
-                        name: None,
-                        local_working_dir,
-                        uv: self.uv,
-                        write_events_to: write_events_to(),
-                    })
-                    .unwrap(),
-                )
-                .context("failed to send start dataflow message")?;
-
-            let result: ControlRequestReply =
-                serde_json::from_slice(&reply_raw).context("failed to parse reply")?;
-            match result {
-                ControlRequestReply::DataflowStartTriggered { uuid } => uuid,
-                ControlRequestReply::Error(err) => bail!("{err}"),
-                other => bail!("unexpected start dataflow reply: {other:?}"),
-            }
-        };
-
-        // --- Wait for spawn ---
-        //
-        // Sub-second dataflows race against this request: the coordinator
-        // drops the running-dataflow entry on completion, so a WaitForSpawn
-        // that arrives afterwards comes back as `Error("unknown dataflow X")`.
-        // That's not a startup failure — the DataflowStartTriggered we
-        // already received proves the coordinator accepted the spawn. Treat
-        // it as evidence the dataflow ran to completion.
-        let mut spawn_already_finished = false;
-        {
-            let reply_raw = session
-                .request(
-                    &serde_json::to_vec(&ControlRequest::WaitForSpawn { dataflow_id }).unwrap(),
-                )
-                .context("failed to send WaitForSpawn message")?;
-            let result: ControlRequestReply =
-                serde_json::from_slice(&reply_raw).context("failed to parse reply")?;
-            match result {
-                ControlRequestReply::DataflowSpawned { uuid: _ } => {}
-                ControlRequestReply::Error(err) if error_indicates_dataflow_finished(&err) => {
-                    tracing::debug!(
-                        "dataflow {dataflow_id} finished before WaitForSpawn arrived: {err}"
-                    );
-                    spawn_already_finished = true;
-                }
-                ControlRequestReply::Error(err) => bail!(
-                    "dataflow failed to start: {err}\n\n  \
-                     hint: if nodes require building, run `dora build <dataflow.yml>` first"
-                ),
-                other => bail!("unexpected WaitForSpawn reply: {other:?}"),
-            }
-        }
-
-        // --- Subscribe to logs ---
         let node_filters = match &self.log_filter {
             Some(filter) => parse_log_filter(filter).map_err(|e| eyre::eyre!(e))?,
             None => Default::default(),
-        };
-
-        let log_level = match &self.log_level {
-            LogLevelOrStdout::LogLevel(level) => match level {
-                ::log::Level::Error => ::log::LevelFilter::Error,
-                ::log::Level::Warn => ::log::LevelFilter::Warn,
-                ::log::Level::Info => ::log::LevelFilter::Info,
-                ::log::Level::Debug => ::log::LevelFilter::Debug,
-                ::log::Level::Trace => ::log::LevelFilter::Trace,
-            },
-            LogLevelOrStdout::Stdout => ::log::LevelFilter::Trace,
         };
 
         let log_config = LogOutputConfig {
@@ -392,144 +187,25 @@ impl Executable for Run {
             print_daemon_name: false,
         };
 
-        // Subscribing to logs also races against sub-second dataflows: the
-        // ack can come back with "no running dataflow with id X" even after
-        // a successful WaitForSpawn. Skip the stream (nothing to tail) but
-        // keep running so the remaining lifecycle bookkeeping still
-        // reports the dataflow exit status correctly.
-        let log_subscribe_request = serde_json::to_vec(&ControlRequest::LogSubscribe {
-            dataflow_id,
-            level: log_level,
-        })
-        .context("failed to serialize log subscribe")?;
-        let log_subscription = if spawn_already_finished {
-            None
-        } else {
-            match session.subscribe_logs(&log_subscribe_request) {
-                Ok(rx) => Some(rx),
-                Err(err) if error_indicates_dataflow_finished(&err.to_string()) => {
-                    tracing::debug!(
-                        "dataflow {dataflow_id} finished before log subscribe arrived: {err}"
-                    );
-                    None
-                }
-                Err(err) => return Err(err).context("failed to subscribe to logs"),
+        let (log_tx, log_rx) = flume::bounded(100);
+        std::thread::spawn(move || {
+            for message in log_rx {
+                print_log_message(message, &log_config);
             }
-        };
-
-        if let Some(log_rx) = log_subscription {
-            let log_event_tx = event_tx.clone();
-            std::thread::spawn(move || {
-                // Forward log messages to the print loop.
-                // When the log subscription closes (coordinator shuts down), the thread exits.
-                while let Ok(raw) = log_rx.recv() {
-                    let parsed: eyre::Result<LogMessage> = match raw {
-                        Ok(bytes) => {
-                            serde_json::from_slice(&bytes).context("failed to parse log message")
-                        }
-                        Err(err) => Err(err),
-                    };
-                    match parsed {
-                        Ok(msg) => print_log_message(msg, &log_config),
-                        Err(err) => tracing::warn!("failed to parse log message: {err:#}"),
-                    }
-                }
-                // Signal the main loop when log subscription closes (coordinator shutting down)
-                let _ = log_event_tx;
-            });
-        }
-
-        // --- Stop-after timer ---
-        if let Some(stop_after) = self.stop_after {
-            let stop_tx = event_tx;
-            std::thread::spawn(move || {
-                std::thread::sleep(stop_after);
-                let _ = stop_tx.send(RunEvent::StopAfterElapsed);
-            });
-        }
-
-        // --- Main wait loop ---
-        let mut ctrlc_count = 0u32;
-        let result = loop {
-            match event_rx.recv_timeout(Duration::from_secs(1)) {
-                Ok(RunEvent::CtrlC) => {
-                    ctrlc_count += 1;
-                    if ctrlc_count >= 2 {
-                        // Force stop
-                        let _ = session.request(
-                            &serde_json::to_vec(&ControlRequest::Stop {
-                                dataflow_uuid: dataflow_id,
-                                grace_duration: None,
-                                force: true,
-                            })
-                            .unwrap(),
-                        );
-                        break None;
-                    }
-                    // Graceful stop
-                    let _ = session.request(
-                        &serde_json::to_vec(&ControlRequest::Stop {
-                            dataflow_uuid: dataflow_id,
-                            grace_duration: None,
-                            force: false,
-                        })
-                        .unwrap(),
-                    );
-                }
-                Ok(RunEvent::StopAfterElapsed) => {
-                    let _ = session.request(
-                        &serde_json::to_vec(&ControlRequest::Stop {
-                            dataflow_uuid: dataflow_id,
-                            grace_duration: None,
-                            force: false,
-                        })
-                        .unwrap(),
-                    );
-                }
-                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-                    // Poll dataflow status
-                    let reply_raw = session.request(
-                        &serde_json::to_vec(&ControlRequest::Check {
-                            dataflow_uuid: dataflow_id,
-                        })
-                        .unwrap(),
-                    );
-                    match reply_raw {
-                        Ok(raw) => {
-                            let result: ControlRequestReply = match serde_json::from_slice(&raw) {
-                                Ok(r) => r,
-                                Err(_) => continue,
-                            };
-                            if let ControlRequestReply::DataflowStopped { uuid, result } = result {
-                                break Some((uuid, result));
-                            }
-                        }
-                        Err(_) => {
-                            // Connection lost (coordinator gone), break out
-                            break None;
-                        }
-                    }
-                }
-                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                    // All senders dropped, break out
-                    break None;
-                }
-            }
-        };
-
-        // --- Cleanup: destroy coordinator + daemon ---
-        let _ = session.request(&serde_json::to_vec(&ControlRequest::Destroy).unwrap());
-        drop(session);
-
-        // Wait for coordinator and daemon to finish
-        rt.block_on(async {
-            let _ = coordinator_handle.await;
-            let _ = daemon_handle.await;
         });
 
-        match result {
-            Some((uuid, dataflow_result)) => handle_dataflow_result(dataflow_result, Some(uuid)),
-            None => Ok(()),
-        }
+        let result = rt.block_on(Daemon::run_dataflow(
+            &dataflow_path,
+            dataflow_session.build_id,
+            dataflow_session.local_build,
+            dataflow_session.session_id,
+            self.uv,
+            LogDestination::Channel { sender: log_tx },
+            write_events_to(),
+            self.stop_after,
+            self.debug,
+            self.working_dir.clone(),
+        ))?;
+        handle_dataflow_result(result, None)
     }
 }

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -6,7 +6,7 @@ use dora_core::{
     config::{DataId, Input, InputMapping, NodeId, NodeRunConfig, OperatorId},
     descriptor::{
         CoreNodeKind, DYNAMIC_SOURCE, Descriptor, DescriptorExt, ResolvedNode, RuntimeNode,
-        read_as_descriptor,
+        read_as_descriptor, validate,
     },
     topics::{
         DORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT, LOCALHOST, open_zenoh_session_with_listen,
@@ -611,15 +611,26 @@ impl Daemon {
         write_events_to: Option<PathBuf>,
         stop_after: Option<Duration>,
         debug: bool,
+        working_dir_override: Option<PathBuf>,
     ) -> eyre::Result<DataflowResult> {
-        let working_dir = dataflow_path
-            .canonicalize()
-            .context("failed to canonicalize dataflow path")?
-            .parent()
-            .ok_or_else(|| eyre::eyre!("canonicalized dataflow path has no parent"))?
-            .to_owned();
+        let working_dir = match working_dir_override {
+            Some(p) => p
+                .canonicalize()
+                .context("failed to canonicalize working_dir override")?,
+            None => dataflow_path
+                .canonicalize()
+                .context("failed to canonicalize dataflow path")?
+                .parent()
+                .ok_or_else(|| eyre::eyre!("canonicalized dataflow path has no parent"))?
+                .to_owned(),
+        };
 
-        let mut descriptor = read_as_descriptor(dataflow_path).await?;
+        let raw_descriptor = read_as_descriptor(dataflow_path).await?;
+        // Expand module composition (must run before resolution; module
+        // nodes cause `resolve_aliases_and_set_defaults` to fail otherwise).
+        let mut descriptor = raw_descriptor
+            .expand(&working_dir)
+            .wrap_err("failed to expand modules in dataflow descriptor")?;
         if debug {
             descriptor.debug.enable_debug_inspection = true;
         }
@@ -632,7 +643,8 @@ impl Daemon {
             )
         }
 
-        descriptor.check(&working_dir)?;
+        validate::check_dataflow(&descriptor, &working_dir, None, false)
+            .wrap_err("Dataflow could not be validated.")?;
         let health_check_interval = descriptor
             .health_check_interval
             .map(Duration::from_secs_f64);

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -36,15 +36,21 @@ cd my-project
 # Build all nodes
 dora build dataflow.yml
 
-# Run the dataflow (embedded coordinator + daemon)
+# Run the dataflow in isolation
 dora run dataflow.yml
 ```
 
 Press `Ctrl+C` to stop.
 
+`dora run` is an isolated single-shot mode: it spawns nodes in-process
+without a coordinator, so CLI monitoring commands (`dora list`, `dora
+stop`, `dora logs`, `dora top`, ...) do **not** attach to it. Use `dora
+up` + `dora start` (see [Networked Mode](#networked-mode) below) when
+you want to attach those tools or run more than one dataflow at a time.
+
 ## What Just Happened?
 
-`dora run` starts an embedded coordinator and daemon, builds your nodes, and runs the dataflow defined in `dataflow.yml`:
+`dora run` builds your nodes and runs the dataflow defined in `dataflow.yml`:
 
 ```
 Timer (1Hz) --> Talker --> Listener

--- a/docs/realtime-tuning.md
+++ b/docs/realtime-tuning.md
@@ -356,9 +356,9 @@ Only if the PR touches code that could affect jitter (daemon hot path,
 send/recv loops, allocator changes).
 
 Both runs must go through an externally-started daemon so the `--rt`
-profile actually applies. `dora run` spawns its own embedded coordinator
-and daemon (see `binaries/cli/src/command/run.rs`) and will silently
-ignore the background `--rt` daemon, so use `dora start` instead.
+profile actually applies. `dora run` spawns its own in-process daemon
+(see `binaries/cli/src/command/run.rs`) and will silently ignore the
+background `--rt` daemon, so use `dora start` instead.
 
 ```bash
 # Stock run — plain daemon, no --rt

--- a/tests/example-smoke.rs
+++ b/tests/example-smoke.rs
@@ -1650,18 +1650,12 @@ fn ensure_marker_absent(marker: &std::path::Path) {
 }
 
 /// Defense in depth, narrow scope: serializes ONLY these two shell-gate
-/// tests against each other. `dora run` embeds a coordinator on the
-/// hardcoded default port `binaries/cli/src/command/run.rs:226`, so two
-/// `dora run` instances race on bind(). The lock does NOT protect
-/// against:
-///   - Other tests in this file that also invoke `dora run` (e.g.
-///     `run_smoke_test_local` callers). Those would need a file-level
-///     lock or a project-wide refactor.
-///   - Multi-process runners like `cargo nextest run` or sharded CI:
-///     the mutex is process-local. A file lock (`fs2::FileExt::lock_exclusive`
-///     or similar) would cover that case.
-/// Both are out of scope for #1702. The file is documented to run with
-/// `--test-threads=1`, which is the canonical fix.
+/// tests against each other. The file is documented to run with
+/// `--test-threads=1`, which is the canonical fix; the mutex is a
+/// last-resort guard for accidental in-process parallel invocations.
+/// It does NOT protect against multi-process runners like `cargo
+/// nextest run` or sharded CI — those would need a file lock
+/// (`fs2::FileExt::lock_exclusive` or similar).
 static SHELL_GATE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[test]

--- a/tests/fault-tolerance-e2e.rs
+++ b/tests/fault-tolerance-e2e.rs
@@ -64,6 +64,7 @@ async fn restart_recovers_from_failure() {
         None,
         Some(Duration::from_secs(30)),
         false,
+        None,
     )
     .await;
 
@@ -114,6 +115,7 @@ async fn max_restarts_limit_reached() {
         None,
         Some(Duration::from_secs(30)),
         false,
+        None,
     )
     .await;
 
@@ -181,6 +183,7 @@ async fn max_restarts_exhaustion_marks_node_failed() {
         None,
         Some(Duration::from_secs(10)),
         false,
+        None,
     )
     .await;
 
@@ -251,6 +254,7 @@ async fn restart_policy_always_restarts_on_clean_exit() {
         None,
         Some(Duration::from_secs(10)),
         false,
+        None,
     )
     .await;
 
@@ -332,6 +336,7 @@ async fn restart_window_resets_restart_counter() {
         None,
         Some(Duration::from_secs(10)),
         false,
+        None,
     )
     .await;
 
@@ -417,6 +422,7 @@ async fn input_timeout_delivers_input_closed_to_downstream() {
         // InputClosed at ~550 ms (input_timeout = 0.5 s), then exit.
         Some(Duration::from_secs(5)),
         false,
+        None,
     )
     .await;
 
@@ -505,6 +511,7 @@ async fn health_check_timeout_sigkills_unresponsive_node() {
         // the marker write races the kill).
         Some(Duration::from_secs(10)),
         false,
+        None,
     )
     .await;
 
@@ -600,6 +607,7 @@ async fn node_restarted_is_delivered_to_downstream() {
         // plus observer teardown. 5 s is generous.
         Some(Duration::from_secs(5)),
         false,
+        None,
     )
     .await;
 
@@ -677,6 +685,7 @@ async fn input_recovered_is_delivered_after_broken_input_receives_data() {
         None,
         Some(Duration::from_secs(5)),
         false,
+        None,
     )
     .await;
 
@@ -770,6 +779,7 @@ async fn health_check_timeout_exhausts_restart_budget() {
         None,
         Some(Duration::from_secs(10)),
         false,
+        None,
     )
     .await;
 
@@ -841,6 +851,7 @@ async fn planned_stop_sigterm_reports_clean() {
         // fire, short enough that the test stays fast.
         Some(Duration::from_secs(3)),
         false,
+        None,
     )
     .await;
 

--- a/tests/node-lifecycle-e2e.rs
+++ b/tests/node-lifecycle-e2e.rs
@@ -12,8 +12,7 @@
 //!
 //! Run with `cargo test --test node-lifecycle-e2e -- --test-threads=1`.
 //! Each test spawns a coordinator + daemon on the hard-coded port 6013
-//! (`binaries/cli/src/command/run.rs:226` for `dora run`,
-//! `dora_core::topics::DORA_COORDINATOR_PORT_WS_DEFAULT` for `dora up`),
+//! (`dora_core::topics::DORA_COORDINATOR_PORT_WS_DEFAULT` for `dora up`),
 //! so the in-file `LIFECYCLE_LOCK` serializes the tests within this
 //! binary and `--test-threads=1` is required for safety against other
 //! integration-test binaries that also use the default port.


### PR DESCRIPTION
The `dora run` command introduced in #6 (during the adora inclusion)
embedded a coordinator on the default port 6013 so CLI monitoring
tools (`dora list`, `dora stop`, `dora logs`, ...) could attach. That
broke two properties of the previous isolated mode:

  - `dora run` could no longer be used while `dora up` was already
    running (port 6013 race -> "Address already in use").
  - Two `dora run` invocations could not execute in parallel.

Drop the embedded coordinator and call `Daemon::run_dataflow`
directly, matching the pre-#6 behavior. CLI monitoring tools no
longer attach to a `dora run` execution; use `dora up` + `dora start`
instead when that's required. The Run subcommand help text, the
quickstart guide, and the realtime-tuning note are updated to
document this trade-off.

`Daemon::run_dataflow` gains a `working_dir_override` parameter so
`dora record`/`dora replay` (which run a rewritten tempfile against
the original source dir) keep working. Module expansion now happens
inside `Daemon::run_dataflow` too, which also unblocks the path used
by `dora daemon --run-dataflow`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


Closes #1939