### PR TITLE
fix(cli): drive dora run daemon on a tokio worker thread (regression from #1962)

### DIFF
--- a/binaries/cli/src/command/run.rs
+++ b/binaries/cli/src/command/run.rs
@@ -194,18 +194,42 @@ impl Executable for Run {
             }
         });
 
-        let result = rt.block_on(Daemon::run_dataflow(
-            &dataflow_path,
-            dataflow_session.build_id,
-            dataflow_session.local_build,
-            dataflow_session.session_id,
-            self.uv,
-            LogDestination::Channel { sender: log_tx },
-            write_events_to(),
-            self.stop_after,
-            self.debug,
-            self.working_dir.clone(),
-        ))?;
+        // Drive `Daemon::run_dataflow` on a tokio worker thread, not the
+        // calling main thread. On Windows the main thread's default stack
+        // is 1 MiB, which the daemon's deeply-nested async state machine
+        // (zenoh + arrow + flume + coordinator I/O) overflows in debug
+        // builds — `target\debug\examples\rust-dataflow.exe` crashed with
+        // STATUS_STACK_OVERFLOW in the 05-28 nightly (#1964). tokio worker
+        // threads default to 2 MiB, which clears the overflow. Linux and
+        // macOS were unaffected because their main-thread stacks are
+        // multi-MiB by default. Regression from #1962.
+        //
+        // `run_dataflow` takes `&Path`, so the returned future borrows
+        // non-`'static`; move an owned `PathBuf` (plus the other Run
+        // fields) into the spawned task so the future is `'static`.
+        let dataflow_path_for_daemon = dataflow_path.clone();
+        let uv = self.uv;
+        let stop_after = self.stop_after;
+        let debug = self.debug;
+        let working_dir_override = self.working_dir.clone();
+        let handle = rt.spawn(async move {
+            Daemon::run_dataflow(
+                &dataflow_path_for_daemon,
+                dataflow_session.build_id,
+                dataflow_session.local_build,
+                dataflow_session.session_id,
+                uv,
+                LogDestination::Channel { sender: log_tx },
+                write_events_to(),
+                stop_after,
+                debug,
+                working_dir_override,
+            )
+            .await
+        });
+        let result = rt
+            .block_on(handle)
+            .context("dora-run daemon task panicked")??;
         handle_dataflow_result(result, None)
     }
 }


### PR DESCRIPTION
## What

Hot-fix for the 2026-05-28 nightly: `Examples (windows-latest)` failed with `STATUS_STACK_OVERFLOW` in `target\debug\examples\rust-dataflow.exe`. Refs #1964. Regression from #1962.

## Root cause

#1962 simplified `dora run` to call `rt.block_on(Daemon::run_dataflow(...))` directly in `binaries/cli/src/command/run.rs:197`. Because `block_on` drives the polled future on the **calling thread**, the daemon's deeply-nested async state machine (zenoh + arrow + flume + coordinator I/O) now runs on the **main thread**.

- Windows main-thread default stack: **1 MiB**.
- tokio worker thread default stack: **2 MiB**.
- Linux/macOS main-thread default stack: multi-MiB.

The daemon future does not fit in 1 MiB in debug builds. CI log:

```
thread 'main' (8976) has overflowed its stack
error: process didn't exit successfully: `target\debug\examples\rust-dataflow.exe`
  (exit code: 0xc00000fd, STATUS_STACK_OVERFLOW)
```

Evidence the fault is platform-specific to Windows:
- 05-28 nightly: `Examples (windows-latest)` ❌, `Examples (ubuntu-latest)` ✅, `Examples (macos-latest)` ✅.
- 05-27 nightly (pre-#1962): `Examples (windows-latest)` ✅.
- The only commit in the range that touches `dora run` is #1962.

## Fix

Spawn the daemon future onto a tokio worker (2 MiB stack) and have the main thread `block_on` the resulting JoinHandle (tiny):

```rust
// Before (binaries/cli/src/command/run.rs:197):
let result = rt.block_on(Daemon::run_dataflow(&dataflow_path, /* … */))?;

// After:
let dataflow_path_for_daemon = dataflow_path.clone();
// …extract owned/Copy field values from `self`…
let handle = rt.spawn(async move {
    Daemon::run_dataflow(&dataflow_path_for_daemon, /* … */).await
});
let result = rt.block_on(handle)
    .context("dora-run daemon task panicked")??;
```

`Daemon::run_dataflow` takes `&Path`, so the future borrows non-`'static`. The fix moves an owned `PathBuf` (plus the small `Run` field copies) into an `async move` block to satisfy `spawn`'s `Send + 'static` bound.

## Test plan

- [x] `cargo check -p dora-cli` — clean
- [x] `cargo test -p dora-cli` — 176 passed, 0 failed
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p dora-cli -- -D warnings` — clean
- [ ] Windows-specific repro can only be verified in CI (the next push-to-main / nightly run). I'm on macOS — main-thread stack is generous enough that the regression doesn't fire locally.

Refs #1964.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
