### PR TITLE
fix(guide): drop unused --sidebar-non-existant from dora.css (Typos)

### DIFF
--- a/guide/theme/dora.css
+++ b/guide/theme/dora.css
@@ -15,7 +15,6 @@
   --sidebar-bg: #1A1D29;
   --sidebar-fg: #B5BACC;
   --sidebar-active: #2fc78a;
-  --sidebar-non-existant: #585d72;
   --sidebar-spacer: #2f3346;
   --links: #1d9e6b;
   --inline-code-color: #cc8f2a;
@@ -45,7 +44,6 @@ html.ayu, html.navy, html.coal, .ayu, .navy, .coal {
   --sidebar-bg: #1a1d29;
   --sidebar-fg: #8a91ab;
   --sidebar-active: #2fc78a;
-  --sidebar-non-existant: #585d72;
   --sidebar-spacer: #262b3a;
   --links: #5b73ff;
   --inline-code-color: #f2b33d;


### PR DESCRIPTION
Hot-fix for the Typos CI failure on main after #1966 (`78239dd7`).

The variable name was mirrored from mdBook's upstream stock CSS (which has the typo too), but never referenced by any of my own selectors. Drop the two defensive definitions; mdBook's stock CSS continues to set the variable with its own default. No visual change.

```
error: `existant` should be `existent`
error: `existant` should be `existent`
##[error]Process completed with exit code 2.
```

Refs the Typos failure in run [26590938018](https://github.com/dora-rs/dora/actions/runs/26590938018).