### PR TITLE
chore: bump workspace version to 1.0.0-rc1 (closes #1924, closes #1925)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "action-example-client"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "arrow",
  "dora-node-api",
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "action-example-server"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "arrow",
  "dora-node-api",
@@ -87,7 +87,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "always-crash-node"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -556,7 +556,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "benchmark-example-node"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "benchmark-example-sink"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -926,7 +926,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clean-exit-node"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1084,7 +1084,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpu-affinity-probe"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "cross-language-rust-receiver"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "cross-language-rust-sender"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1472,7 +1472,7 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "delayed-crash-node"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1660,7 +1660,7 @@ dependencies = [
 
 [[package]]
 name = "dora-arrow-convert"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "arrow",
  "chrono",
@@ -1671,7 +1671,7 @@ dependencies = [
 
 [[package]]
 name = "dora-cli"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "arrow",
  "arrow-json",
@@ -1727,7 +1727,7 @@ dependencies = [
 
 [[package]]
 name = "dora-cli-api-python"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-cli",
  "dora-download",
@@ -1741,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "dora-coordinator"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "axum",
  "bincode 1.3.3",
@@ -1773,7 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "dora-coordinator-store"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "bincode 2.0.1",
  "dora-message",
@@ -1787,7 +1787,7 @@ dependencies = [
 
 [[package]]
 name = "dora-core"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "dora-daemon"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "aligned-vec",
  "bincode 1.3.3",
@@ -1865,7 +1865,7 @@ dependencies = [
 
 [[package]]
 name = "dora-download"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "eyre",
  "reqwest",
@@ -1904,7 +1904,7 @@ dependencies = [
 
 [[package]]
 name = "dora-log-utils"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "arrow",
  "chrono",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "dora-mavlink2-bridge"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "arrow",
  "eyre",
@@ -1931,7 +1931,7 @@ dependencies = [
 
 [[package]]
 name = "dora-mavlink2-bridge-node"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "arrow",
  "dora-mavlink2-bridge",
@@ -1948,7 +1948,7 @@ dependencies = [
 
 [[package]]
 name = "dora-message"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "aligned-vec",
  "arrow-data",
@@ -1976,7 +1976,7 @@ dependencies = [
 
 [[package]]
 name = "dora-metrics"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "eyre",
  "opentelemetry",
@@ -1987,7 +1987,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -2020,7 +2020,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-c"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "arrow-array",
  "dora-node-api",
@@ -2030,7 +2030,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-cxx"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "arrow",
  "chrono",
@@ -2050,7 +2050,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-python"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "arrow",
  "chrono",
@@ -2074,7 +2074,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-arrow-convert",
  "dora-operator-api-macros",
@@ -2083,14 +2083,14 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-c"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-operator-api-types",
 ]
 
 [[package]]
 name = "dora-operator-api-cxx"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -2099,7 +2099,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-macros"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2108,7 +2108,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-python"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -2128,7 +2128,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-types"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "arrow",
  "dora-arrow-convert",
@@ -2137,7 +2137,7 @@ dependencies = [
 
 [[package]]
 name = "dora-record-node"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "aligned-vec",
  "dora-message",
@@ -2150,7 +2150,7 @@ dependencies = [
 
 [[package]]
 name = "dora-recording"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "eyre",
  "tempfile",
@@ -2159,7 +2159,7 @@ dependencies = [
 
 [[package]]
 name = "dora-replay-node"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "bincode 1.3.3",
  "dora-message",
@@ -2170,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "dora-ros2-bridge"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "array-init",
  "dora-cli",
@@ -2196,7 +2196,7 @@ dependencies = [
 
 [[package]]
 name = "dora-ros2-bridge-arrow"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "arrow",
  "dora-ros2-bridge-msg-gen",
@@ -2207,7 +2207,7 @@ dependencies = [
 
 [[package]]
 name = "dora-ros2-bridge-msg-gen"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "anyhow",
  "glob",
@@ -2225,7 +2225,7 @@ dependencies = [
 
 [[package]]
 name = "dora-ros2-bridge-node"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "arrow",
  "dora-message",
@@ -2245,7 +2245,7 @@ dependencies = [
 
 [[package]]
 name = "dora-ros2-bridge-python"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "arrow",
  "dora-ros2-bridge",
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "dora-runtime"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -2290,7 +2290,7 @@ dependencies = [
 
 [[package]]
 name = "dora-tracing"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "eyre",
  "opentelemetry",
@@ -2485,7 +2485,7 @@ dependencies = [
 
 [[package]]
 name = "event-log-observer-node"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -2593,7 +2593,7 @@ checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
 
 [[package]]
 name = "fire-and-forget-source-node"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -2992,7 +2992,7 @@ dependencies = [
 
 [[package]]
 name = "hang-after-init-node"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "input-closed-observer-node"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -3979,7 +3979,7 @@ dependencies = [
 
 [[package]]
 name = "log-sink-alert"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-arrow-convert",
  "dora-log-utils",
@@ -3990,7 +3990,7 @@ dependencies = [
 
 [[package]]
 name = "log-sink-file"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-log-utils",
  "dora-node-api",
@@ -3999,7 +3999,7 @@ dependencies = [
 
 [[package]]
 name = "log-sink-tcp"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-log-utils",
  "dora-node-api",
@@ -4124,7 +4124,7 @@ dependencies = [
 
 [[package]]
 name = "mavlink2-bridge-example-heartbeat-emitter"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "arrow",
  "dora-mavlink2-bridge",
@@ -4135,7 +4135,7 @@ dependencies = [
 
 [[package]]
 name = "mavlink2-bridge-example-mavlink-sim"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-mavlink2-bridge",
  "dora-node-api",
@@ -4147,7 +4147,7 @@ dependencies = [
 
 [[package]]
 name = "mavlink2-bridge-example-telemetry-printer-rust"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "arrow",
  "dora-mavlink2-bridge",
@@ -4273,7 +4273,7 @@ dependencies = [
 
 [[package]]
 name = "multiple-daemons-example-node"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4284,14 +4284,14 @@ dependencies = [
 
 [[package]]
 name = "multiple-daemons-example-operator"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-operator-api",
 ]
 
 [[package]]
 name = "multiple-daemons-example-sink"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -5668,7 +5668,7 @@ dependencies = [
 
 [[package]]
 name = "receive_data"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "chrono",
  "dora-node-api",
@@ -5874,7 +5874,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-node"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -5887,7 +5887,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-sink"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -5895,7 +5895,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-sink-dynamic"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -5903,7 +5903,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-status-node"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -5912,7 +5912,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dynamic-add-remove-filter"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -5920,7 +5920,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dynamic-add-remove-receiver"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -5928,7 +5928,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dynamic-add-remove-sender"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -5947,7 +5947,7 @@ dependencies = [
 
 [[package]]
 name = "rust-ros2-example-node"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-node-api",
  "dora-ros2-bridge",
@@ -6462,7 +6462,7 @@ dependencies = [
 
 [[package]]
 name = "service-example-client"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "arrow",
  "dora-node-api",
@@ -6471,7 +6471,7 @@ dependencies = [
 
 [[package]]
 name = "service-example-server"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "arrow",
  "dora-node-api",
@@ -6605,7 +6605,7 @@ dependencies = [
 
 [[package]]
 name = "silent-source-node"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -7163,7 +7163,7 @@ dependencies = [
 
 [[package]]
 name = "timed-burst-source-node"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -7783,7 +7783,7 @@ dependencies = [
 
 [[package]]
 name = "validated-pipeline-sink"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -7791,7 +7791,7 @@ dependencies = [
 
 [[package]]
 name = "validated-pipeline-source"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -7799,7 +7799,7 @@ dependencies = [
 
 [[package]]
 name = "validated-pipeline-transform"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -8856,7 +8856,7 @@ dependencies = [
 
 [[package]]
 name = "yaml-bridge-action-goal"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "arrow",
  "dora-node-api",
@@ -8865,7 +8865,7 @@ dependencies = [
 
 [[package]]
 name = "yaml-bridge-action-server-handler"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "arrow",
  "dora-node-api",
@@ -8874,7 +8874,7 @@ dependencies = [
 
 [[package]]
 name = "yaml-bridge-service-handler"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "arrow",
  "dora-node-api",
@@ -8883,7 +8883,7 @@ dependencies = [
 
 [[package]]
 name = "yaml-bridge-service-requester"
-version = "0.2.1"
+version = "1.0.0-rc1"
 dependencies = [
  "arrow",
  "dora-node-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ members = [
 edition = "2024"
 rust-version = "1.88.0"
 # Python packages derive version from CARGO_PKG_VERSION automatically.
-version = "0.2.1"
+version = "1.0.0-rc1"
 description = "`dora` goal is to be a low latency, composable, and distributed data flow."
 documentation = "https://dora-rs.ai"
 readme = "./README.md"
@@ -92,31 +92,31 @@ license = "Apache-2.0"
 repository = "https://github.com/dora-rs/dora/"
 
 [workspace.dependencies]
-dora-node-api = { version = "0.2.0", path = "apis/rust/node", default-features = false }
-dora-node-api-python = { version = "0.2.0", path = "apis/python/node", default-features = false }
-dora-operator-api = { version = "0.2.0", path = "apis/rust/operator", default-features = false }
-dora-operator-api-macros = { version = "0.2.0", path = "apis/rust/operator/macros" }
-dora-operator-api-types = { version = "0.2.0", path = "apis/rust/operator/types" }
-dora-operator-api-python = { version = "0.2.0", path = "apis/python/operator" }
-dora-operator-api-c = { version = "0.2.0", path = "apis/c/operator" }
-dora-node-api-c = { version = "0.2.0", path = "apis/c/node" }
-dora-core = { version = "0.2.0", path = "libraries/core" }
-dora-recording = { version = "0.2.0", path = "libraries/recording" }
-dora-arrow-convert = { version = "0.2.0", path = "libraries/arrow-convert" }
-dora-tracing = { version = "0.2.0", path = "libraries/extensions/telemetry/tracing" }
-dora-metrics = { version = "0.2.0", path = "libraries/extensions/telemetry/metrics" }
-dora-download = { version = "0.2.0", path = "libraries/extensions/download" }
-dora-log-utils = { version = "0.2.0", path = "libraries/log-utils" }
-dora-coordinator-store = { version = "0.2.0", path = "libraries/coordinator-store" }
-dora-cli = { version = "0.2.0", path = "binaries/cli" }
-dora-runtime = { version = "0.2.0", path = "binaries/runtime" }
-dora-daemon = { version = "0.2.0", path = "binaries/daemon" }
-dora-coordinator = { version = "0.2.0", path = "binaries/coordinator" }
-dora-ros2-bridge = { version = "0.2.0", path = "libraries/extensions/ros2-bridge" }
-dora-ros2-bridge-msg-gen = { version = "0.2.0", path = "libraries/extensions/ros2-bridge/msg-gen" }
+dora-node-api = { version = "1.0.0-rc1", path = "apis/rust/node", default-features = false }
+dora-node-api-python = { version = "1.0.0-rc1", path = "apis/python/node", default-features = false }
+dora-operator-api = { version = "1.0.0-rc1", path = "apis/rust/operator", default-features = false }
+dora-operator-api-macros = { version = "1.0.0-rc1", path = "apis/rust/operator/macros" }
+dora-operator-api-types = { version = "1.0.0-rc1", path = "apis/rust/operator/types" }
+dora-operator-api-python = { version = "1.0.0-rc1", path = "apis/python/operator" }
+dora-operator-api-c = { version = "1.0.0-rc1", path = "apis/c/operator" }
+dora-node-api-c = { version = "1.0.0-rc1", path = "apis/c/node" }
+dora-core = { version = "1.0.0-rc1", path = "libraries/core" }
+dora-recording = { version = "1.0.0-rc1", path = "libraries/recording" }
+dora-arrow-convert = { version = "1.0.0-rc1", path = "libraries/arrow-convert" }
+dora-tracing = { version = "1.0.0-rc1", path = "libraries/extensions/telemetry/tracing" }
+dora-metrics = { version = "1.0.0-rc1", path = "libraries/extensions/telemetry/metrics" }
+dora-download = { version = "1.0.0-rc1", path = "libraries/extensions/download" }
+dora-log-utils = { version = "1.0.0-rc1", path = "libraries/log-utils" }
+dora-coordinator-store = { version = "1.0.0-rc1", path = "libraries/coordinator-store" }
+dora-cli = { version = "1.0.0-rc1", path = "binaries/cli" }
+dora-runtime = { version = "1.0.0-rc1", path = "binaries/runtime" }
+dora-daemon = { version = "1.0.0-rc1", path = "binaries/daemon" }
+dora-coordinator = { version = "1.0.0-rc1", path = "binaries/coordinator" }
+dora-ros2-bridge = { version = "1.0.0-rc1", path = "libraries/extensions/ros2-bridge" }
+dora-ros2-bridge-msg-gen = { version = "1.0.0-rc1", path = "libraries/extensions/ros2-bridge/msg-gen" }
 dora-ros2-bridge-python = { path = "libraries/extensions/ros2-bridge/python" }
-dora-mavlink2-bridge = { version = "0.2.0", path = "libraries/extensions/mavlink2-bridge" }
-dora-message = { version = "0.2.0", path = "libraries/message" }
+dora-mavlink2-bridge = { version = "1.0.0-rc1", path = "libraries/extensions/mavlink2-bridge" }
+dora-message = { version = "1.0.0-rc1", path = "libraries/message" }
 arrow = { version = "58", default-features = false }
 arrow-schema = { version = "58" }
 arrow-data = { version = "58" }


### PR DESCRIPTION
## What

Bump the workspace version strings to **`1.0.0-rc1`** — closes #1924 and #1925.

The repo has been carrying adora-era version strings since the dora ↔ adora merge ([`145ccce0`](https://github.com/dora-rs/dora/commit/145ccce0)): the workspace was pinned at `0.2.1` while the public release line had moved to `0.4.5`, and every internal `[workspace.dependencies]` pin was `0.2.0`. This PR normalizes both.

## Diff (one file's worth of source mechanics, no logic)

| Change | Detail |
|---|---|
| `[workspace.package].version` | `"0.2.1"` → `"1.0.0-rc1"` (closes #1924) |
| `[workspace.dependencies]` internal `dora-*` pins (×24) | `"0.2.0"` → `"1.0.0-rc1"` (closes #1925) |
| `Cargo.lock` | auto-regenerated via `cargo check --all` |

The **81 crates that inherit via `version.workspace = true`** pick up the new version automatically. The handful of crates that pin their own version (per `CLAUDE.md`: `apis/rust/operator/types`, `examples/error-propagation/*`) are left alone — that's a separate, deliberate independence.

## This is **not** a release

To be very explicit:

- ❌ no git tag
- ❌ no `CHANGELOG.md` entry
- ❌ no `crates.io` publish
- ❌ no PyPI publish
- ❌ no GitHub release

The intent is to **stop carrying stale 0.2.x version strings** and **mark the codebase as being on the 1.0 release-candidate track**. A formal `1.0.0-rc1` release (tag + CHANGELOG + publish) is a separate, deliberate process the maintainers will do when ready.

## Verification

- `cargo check --all` → all crates build as `v1.0.0-rc1` (logs show `dora-record-node v1.0.0-rc1`, `dora-mavlink2-bridge-node v1.0.0-rc1`, …)
- `cargo fmt --all -- --check` → clean
- `cargo clippy --all --exclude dora-node-api-python --exclude dora-operator-api-python --exclude dora-ros2-bridge-python -- -D warnings` → clean (only pre-existing AMENT_PREFIX_PATH warnings from ROS2 not being set, unrelated to this PR)

Closes #1924, closes #1925.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
