### PR TITLE
feat(ros2-bridge): Python service client and server APIs (#1170)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1503,6 +1503,8 @@ jobs:
           uv pip install -e apis/python/node
           uv pip install pyarrow
           cargo run -p dora-ros2-bridge --example python-ros2-dataflow
+          cargo run -p dora-ros2-bridge --example python-ros2-dataflow-service-client
+          cargo run -p dora-ros2-bridge --example python-ros2-dataflow-service-server
       - name: C++ ROS2 Bridge example
         timeout-minutes: 30
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2253,6 +2253,7 @@ dependencies = [
  "dora-ros2-bridge-msg-gen",
  "eyre",
  "futures",
+ "futures-timer",
  "pyo3",
  "pyo3-build-config",
  "serde",

--- a/apis/python/node/dora/__init__.pyi
+++ b/apis/python/node/dora/__init__.pyi
@@ -399,6 +399,42 @@ class Ros2Node:
         )
         ```"""
 
+    def create_service_client(
+        self, service_name: str, service_type: str, qos: dora.Ros2QosPolicies
+    ) -> dora.Ros2ServiceClient:
+        """Create a ROS2 service client.
+
+        Waits (bounded) for a matching service server to become available
+        before returning. ROS2 services require **reliable** QoS.
+
+        ```python
+        client = ros2_node.create_service_client(
+        "/add_two_ints", "example_interfaces/AddTwoInts",
+        Ros2QosPolicies(reliable=True),
+        )
+        response = client.call(pa.array([{"a": 2, "b": 3}]))
+        ```"""
+
+    def create_service_server(
+        self, service_name: str, service_type: str, qos: dora.Ros2QosPolicies
+    ) -> dora.Ros2ServiceServer:
+        """Create a ROS2 service server.
+
+        Drive it by polling `take_request` and replying with `send_response`.
+        ROS2 services require **reliable** QoS.
+
+        ```python
+        server = ros2_node.create_service_server(
+        "/add_two_ints", "example_interfaces/AddTwoInts",
+        Ros2QosPolicies(reliable=True),
+        )
+        req = server.take_request(timeout_s=0.1)
+        if req is not None:
+        request_id, value = req
+        args = value[0].as_py()
+        server.send_response(request_id, pa.array([{"sum": args["a"] + args["b"]}]))
+        ```"""
+
     def __repr__(self) -> str:
         """Return repr(self)."""
 
@@ -444,6 +480,52 @@ class Ros2Publisher:
         ),
         )
         ```"""
+
+    def __repr__(self) -> str:
+        """Return repr(self)."""
+
+    def __str__(self) -> str:
+        """Return str(self)."""
+
+@typing.final
+class Ros2ServiceClient:
+    """ROS2 service client. Create via `Ros2Node.create_service_client`.
+
+    warnings:
+    - Dora ROS2 bridge functionality is considered **unstable**. It may be changed
+    at any point without it being considered a breaking change."""
+
+    def call(self, request: pyarrow.Array, timeout_s: float = None) -> pyarrow.Array:
+        """Send a request and block until the response arrives.
+
+        The request must match the service's `_Request` structure as an Arrow
+        struct (e.g. `pa.array([{"a": 2, "b": 3}])`). Returns the `_Response`
+        as a pyarrow array. Raises on timeout (default 30s)."""
+
+    def __repr__(self) -> str:
+        """Return repr(self)."""
+
+    def __str__(self) -> str:
+        """Return str(self)."""
+
+@typing.final
+class Ros2ServiceServer:
+    """ROS2 service server. Create via `Ros2Node.create_service_server`.
+
+    warnings:
+    - Dora ROS2 bridge functionality is considered **unstable**. It may be changed
+    at any point without it being considered a breaking change."""
+
+    def take_request(
+        self, timeout_s: float = None
+    ) -> typing.Optional[typing.Tuple[int, pyarrow.Array]]:
+        """Wait up to `timeout_s` (default 1s) for the next request.
+
+        Returns `(request_id, request_array)`, or `None` if no request arrived
+        within the timeout. Pass `request_id` back to `send_response`."""
+
+    def send_response(self, request_id: int, response: pyarrow.Array) -> None:
+        """Send the response for a request previously returned by `take_request`."""
 
     def __repr__(self) -> str:
         """Return repr(self)."""

--- a/binaries/ros2-bridge-node/src/main.rs
+++ b/binaries/ros2-bridge-node/src/main.rs
@@ -38,42 +38,6 @@ use dora_message::metadata::{
     REQUEST_ID,
 };
 
-/// Pick the `ros2_client::ServiceMapping` variant that matches the user's
-/// ROS2 middleware, based on `RMW_IMPLEMENTATION` (primary) and `ROS_DISTRO`
-/// (fallback). Falls back to `Enhanced` with a `tracing::warn!` if neither
-/// env var gives a usable answer — Enhanced is the historical default and
-/// keeps existing setups working when env is unset.
-///
-/// See dora-rs/dora#449 (restored from lost commit `e2c1370f`).
-fn detect_service_mapping() -> ros2_client::ServiceMapping {
-    match std::env::var("RMW_IMPLEMENTATION").ok().as_deref() {
-        Some("rmw_fastrtps_cpp") => return ros2_client::ServiceMapping::Enhanced,
-        Some("rmw_cyclonedds_cpp") => return ros2_client::ServiceMapping::Cyclone,
-        Some(other) => {
-            tracing::warn!(
-                "unknown RMW_IMPLEMENTATION `{other}`, falling back to \
-                 ServiceMapping::Enhanced (see dora-rs/dora#449)"
-            );
-            return ros2_client::ServiceMapping::Enhanced;
-        }
-        None => {}
-    }
-    match std::env::var("ROS_DISTRO").ok().as_deref() {
-        Some("humble" | "iron" | "jazzy" | "kilted" | "rolling") => {
-            ros2_client::ServiceMapping::Enhanced
-        }
-        Some("galactic") => ros2_client::ServiceMapping::Cyclone,
-        Some(other) => {
-            tracing::warn!(
-                "unknown ROS_DISTRO `{other}`, falling back to \
-                 ServiceMapping::Enhanced (see dora-rs/dora#449)"
-            );
-            ros2_client::ServiceMapping::Enhanced
-        }
-        None => ros2_client::ServiceMapping::Enhanced,
-    }
-}
-
 fn main() -> eyre::Result<()> {
     tracing_subscriber::fmt::init();
 
@@ -222,7 +186,7 @@ fn run_service_mode(
         Ros2Role::Client => {
             let client = ros_node
                 .create_client::<BridgeServiceType>(
-                    detect_service_mapping(),
+                    dora_ros2_bridge::detect_service_mapping(),
                     &ros2_client::Name::new("/", service_name.trim_start_matches('/'))
                         .map_err(|e| eyre!("failed to create service name: {e}"))?,
                     &ros2_client::ServiceTypeName::new(&package, &type_name),
@@ -239,7 +203,7 @@ fn run_service_mode(
         Ros2Role::Server => {
             let server = ros_node
                 .create_server::<BridgeServiceType>(
-                    detect_service_mapping(),
+                    dora_ros2_bridge::detect_service_mapping(),
                     &ros2_client::Name::new("/", service_name.trim_start_matches('/'))
                         .map_err(|e| eyre!("failed to create service name: {e}"))?,
                     &ros2_client::ServiceTypeName::new(&package, &type_name),
@@ -459,7 +423,7 @@ fn run_action_mode(
 
             let client = ros_node
                 .create_action_client::<BridgeActionType>(
-                    detect_service_mapping(),
+                    dora_ros2_bridge::detect_service_mapping(),
                     &action_ros2_name,
                     &action_type_name,
                     action_qos,
@@ -485,7 +449,7 @@ fn run_action_mode(
 
             let server = ros_node
                 .create_action_server::<BridgeActionType>(
-                    detect_service_mapping(),
+                    dora_ros2_bridge::detect_service_mapping(),
                     &action_ros2_name,
                     &action_type_name,
                     action_qos,

--- a/docker-compose.ros2dev.yml
+++ b/docker-compose.ros2dev.yml
@@ -1,0 +1,44 @@
+# ROS2-bridge dev environment for macOS — issue #1170, Phase 0.
+#
+# A single container that reproduces the nightly `ros2-bridge` CI job. dora and
+# all ROS2 nodes run together here, so DDS discovery stays inside one network
+# namespace (the only reliable topology on macOS — see docker/ros2dev/Dockerfile).
+#
+# Usage is via scripts/ros2dev.sh (build | shell | verify). Direct use:
+#   docker compose -f docker-compose.ros2dev.yml build
+#   docker compose -f docker-compose.ros2dev.yml run --rm ros2dev bash
+services:
+  ros2dev:
+    build:
+      context: .
+      dockerfile: docker/ros2dev/Dockerfile
+    image: dora-ros2dev:humble
+    working_dir: /work
+    # Default bridge networking is correct: everything runs in THIS container,
+    # so loopback/eth0 multicast SPDP works exactly as on the CI runner. Do not
+    # add host networking — on Docker Desktop for Mac it does not reach the Mac
+    # and is unnecessary when dora + ROS2 are co-located.
+    environment:
+      QT_QPA_PLATFORM: offscreen
+      # Do NOT set ROS_DOMAIN_ID. dora's ros2_client::Context::new() defaults to
+      # domain 0 and does not read ROS_DOMAIN_ID, while the CLI-spawned ROS2
+      # nodes (turtlesim, minimal-service) would honor it — a mismatch breaks DDS
+      # discovery. Leaving it unset keeps both sides on domain 0, matching CI.
+      # The container is isolated anyway, so domain 0 is collision-free.
+    volumes:
+      - .:/work
+      # Persist the cargo registry + build cache across runs. The target volume
+      # is mounted directly over /work/target: cargo's DEFAULT target dir then
+      # IS this named volume, so (a) the example dataflows' hardcoded
+      # `target/debug/<bin>` node paths resolve correctly, and (b) the
+      # macOS-native target/ is shadowed — no Linux/arch artifacts leak into the
+      # host repo (mixing arch fingerprints would thrash every rebuild).
+      - ros2dev-cargo-registry:/usr/local/cargo/registry
+      - ros2dev-target:/work/target
+    # Keep the container alive for `exec`-style iteration if started detached.
+    stdin_open: true
+    tty: true
+
+volumes:
+  ros2dev-cargo-registry:
+  ros2dev-target:

--- a/docker/ros2dev/Dockerfile
+++ b/docker/ros2dev/Dockerfile
@@ -25,7 +25,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential clang cmake pkg-config libssl-dev \
         curl git ca-certificates \
         ros-humble-turtlesim \
+        ros-humble-example-interfaces \
         ros-humble-examples-rclcpp-minimal-service \
+        ros-humble-examples-rclcpp-minimal-client \
+        ros-humble-examples-rclcpp-minimal-publisher \
+        ros-humble-examples-rclcpp-minimal-subscriber \
+        ros-humble-examples-rclcpp-minimal-action-server \
     && rm -rf /var/lib/apt/lists/*
 
 # Rust toolchain pinned to CI's version.

--- a/docker/ros2dev/Dockerfile
+++ b/docker/ros2dev/Dockerfile
@@ -1,0 +1,61 @@
+# ROS2-bridge development image for macOS (issue #1170, Phase 0).
+#
+# Reproduces the nightly `ros2-bridge` CI job (.github/workflows/nightly.yml)
+# locally on a Mac, where ROS2 cannot run natively. EVERYTHING — the dora
+# process AND the ROS2 nodes — runs inside THIS one container, so DDS discovery
+# happens within a single Linux network namespace exactly as on the CI runner.
+# Never split dora and ROS2 across containers: Docker Desktop for Mac has no
+# host networking to macOS and drops multicast SPDP, so discovery silently fails.
+#
+# Pins match CI: ROS2 Humble, Rust 1.92.0, Python 3.12.
+FROM ros:humble
+
+ARG RUST_VERSION=1.92.0
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    QT_QPA_PLATFORM=offscreen \
+    PATH=/usr/local/cargo/bin:/root/.local/bin:/opt/venv/bin:$PATH
+
+# System + ROS2 packages. turtlesim and examples_rclcpp_minimal_service are
+# spawned by the example harnesses via `ros2 run`; clang/cmake build the C++
+# example node; libssl/pkg-config build dora's Rust deps.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential clang cmake pkg-config libssl-dev \
+        curl git ca-certificates \
+        ros-humble-turtlesim \
+        ros-humble-examples-rclcpp-minimal-service \
+    && rm -rf /var/lib/apt/lists/*
+
+# Rust toolchain pinned to CI's version.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+        | sh -s -- -y --default-toolchain ${RUST_VERSION} --profile minimal \
+    && rustup component add clippy rustfmt
+
+# uv + a Python 3.12 interpreter (pyo3 in the workspace pins abi3-py311, so the
+# build-time interpreter must be >= 3.11). pyarrow + numpy are needed by the
+# embedded fixture that `cargo test -p dora-ros2-bridge-python` loads.
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
+    && /root/.local/bin/uv python install 3.12 \
+    && /root/.local/bin/uv venv --seed -p 3.12 /opt/venv \
+    && /root/.local/bin/uv pip install --python /opt/venv/bin/python pyarrow numpy
+
+# pyo3 build-config introspects this interpreter; the venv ships libpython +
+# headers and already has pyarrow/numpy for the test fixture.
+ENV VIRTUAL_ENV=/opt/venv \
+    PYO3_PYTHON=/opt/venv/bin/python
+
+# The embedded-interpreter test (`cargo test -p dora-ros2-bridge-python`) links
+# libpython3.12.so.1.0, which the uv standalone interpreter keeps in its own lib
+# dir. Register that dir with the dynamic loader so the test binary finds it.
+RUN PYLIB="$(/opt/venv/bin/python -c 'import sysconfig; print(sysconfig.get_config_var("LIBDIR"))')" \
+    && echo "$PYLIB" > /etc/ld.so.conf.d/uv-python.conf \
+    && ldconfig
+
+# Source ROS2 in every interactive/login shell so AMENT_PREFIX_PATH (runtime
+# message discovery) and `ros2` are available.
+RUN echo 'source /opt/ros/humble/setup.bash' >> /etc/bash.bashrc
+
+WORKDIR /work
+CMD ["bash"]

--- a/docs/plan-ros2-bridge-1170.md
+++ b/docs/plan-ros2-bridge-1170.md
@@ -1,0 +1,356 @@
+# Plan: dora GitHub Issue #1170 — "Tracking support for dora-ros2 bridge"
+
+> **Ground-truth note (corrected).** An earlier draft claimed `BridgeServiceType`/`BridgeMessage`/`TypeInfoGuard` live in the python crate's `typed` module. **That was wrong.** Verified line-by-line: `python/src/typed/mod.rs:4` is just `pub use dora_ros2_bridge_arrow::*;`. The types are *defined* in the **`dora-ros2-bridge-arrow`** crate (`arrow/src/lib.rs:71` `TypeInfoGuard`, `:112` `BridgeMessage`, `:157` `BridgeServiceType`, `:177` `BridgeActionType`), and the daemon imports them directly: `use dora_ros2_bridge_arrow::{BridgeActionType, BridgeMessage, BridgeServiceType, TypeInfo, TypeInfoGuard, ...}` (`main.rs:22-26`). The python crate **already depends on `dora-ros2-bridge-arrow` directly** (`python/Cargo.toml:11`). So the import path for the new code is settled: import from `dora_ros2_bridge_arrow`, exactly as the daemon does. Because the prior draft elevated a false premise to "verified," **every "exists / mirrors" citation below was re-checked against `arrow/src/lib.rs` and `binaries/ros2-bridge-node/src/main.rs` before this revision.** A second factual correction surfaced in that re-check and is now reflected throughout: the existing **pub/sub Python path does NOT use `BridgeMessage`/`TypeInfoGuard`** — `publish()` uses `TypedValue` + `Publisher::publish` (`lib.rs:352-362`) and `Subscription` is `Subscription<ArrayData>` driven by a `StructDeserializer` seed (`lib.rs:378,394`). The service/action path therefore introduces the `BridgeServiceType`/`BridgeMessage`/`TypeInfoGuard` mechanism into the Python crate for the first time; it mirrors the **daemon**, not the existing Python pub/sub code.
+
+## 1. Executive summary
+
+The bridge is a **pure-Rust DDS/RTPS stack** (`ros2-client 0.8` + `rustdds =0.11.4`, `libraries/extensions/ros2-bridge/Cargo.toml`) — it never links `rcl`/`rclcpp`. Two distinct surfaces exist for every ROS2 capability: (a) **codegen native APIs** (per-language, compile-time typed structs, generated in `msg-gen/`) and (b) the **dynamic-type bridge daemon** (`binaries/ros2-bridge-node/src/main.rs`, YAML-driven, language-agnostic via Arrow + thread-local `TypeInfo`). The daemon already implements service client/server AND action client/server end-to-end (`run_service_client` `main.rs:265+`, `run_service_server` `:321+`, `run_action_*` `:495+`/`:666+` — verified). So the open tracker items split cleanly:
+
+- **Python service/action surface** is *not* missing core protocol logic — it is missing the **pyo3 wrapper classes** over types that already exist in `dora-ros2-bridge-arrow` (`BridgeServiceType`, `BridgeActionType`, `BridgeMessage`, `TypeInfoGuard`). This is glue, not protocol work, and it's the highest-leverage item. **Caveat:** the glue is *not* a copy of the existing Python pub/sub code (that path uses a different serialization mechanism — see ground-truth note); it is a pyo3-shaped reimplementation of the **daemon's** service loop.
+- **Rust action server / C++ service+action server** require new **codegen** in `msg-gen/src/types/action.rs` + `service.rs` (the harder, XL-leaning work, gated by the nightly Linux+ROS2 CI).
+- **Parameter service** is "six `rcl_interfaces` services + a `/parameter_events` topic" — composable on top of the service surface once it exists in the target language.
+
+**Attack strategy:** Drive the whole tracker through the **dynamic bridge first** (cheap, language-agnostic, already battle-tested in the daemon), exposing it per-language, and only invest in codegen-native APIs where typed ergonomics are explicitly wanted. **First PR = Python service client + server pyo3 wrappers**, because all Rust machinery already exists and the reference async logic is adaptable from `main.rs`. Each subsequent item reuses the same recipe and the same macOS Docker test harness. Final gate for every item is the nightly `ros2-bridge` job (`.github/workflows/nightly.yml`, Humble/ubuntu-22.04), reproduced locally via `scripts/qa/ci-nightly-jobs.sh ros2-bridge`.
+
+The canonical **"add a feature" recipe** is:
+**codegen (`msg-gen/src/types/<feature>.rs`) → core wrapper (`ros2-bridge/src/lib.rs` over `ros2_client`) → language binding (pyo3 in `python/src/lib.rs`, or cxx in `apis/c++/node/build.rs`) → Rust example → C++/Python example → smoke entry.** For dynamic-bridge / pyo3 items the codegen step is *skipped* (dynamic `TypeInfo` replaces it).
+
+---
+
+## 2. Sub-item assessment table
+
+Difficulty: S≈1-2 days, M≈3-5 days, L≈1-2 wk, XL≈2-4 wk. "Mirrors" cites the existing code an engineer adapts.
+
+| Open sub-item | Diff | Dependencies | Leverage | Mirrors / recipe stage |
+|---|---|---|---|---|
+| **Python: service client** | **S** | None — `BridgeServiceType`/`BridgeMessage`/`TypeInfoGuard` exist in `dora-ros2-bridge-arrow`; daemon async logic exists | **Highest** — unblocks param-service client + all py service consumers | pyo3 stage only. Adapt `run_service_client` (`main.rs:265-319`) into a blocking pyo3 method |
+| **Python: service server** | **S** | Ships with client (same PR) | Highest — unblocks param-service server | Adapt `run_service_server` request-id correlation + **persisted** request stream (`main.rs:321-414`) |
+| **Python: action client** | **M** | Service-client PR (pattern only, not code) | High | pyo3 over `ros2_client::action::ActionClient<BridgeActionType>`; mirror `run_action_client` (`main.rs:495+`) |
+| **Python: action server** | **M/L** | Action-client PR; owns goal state machine/result cache | High | pyo3 over `ros2_client::action::AsyncActionServer<BridgeActionType>`; mirror `run_action_server` (`main.rs:666+`). **Genuine redesign** of daemon's single-loop into a pull API — see Risks |
+| **Parameter service** | **M** | Python (or Rust) service **server** (real code dependency) | Medium — pure composition, no transport | Compose 6 `rcl_interfaces/srv/*` service servers + publish `rcl_interfaces/msg/ParameterEvent`. No new codegen if dynamic bridge used |
+| **Rust action server** | **L** | New codegen in `action.rs` | Medium | codegen stage. Mirror existing service-server codegen `service.rs` + action-client codegen `action.rs`; add `cxx_action_server_creation_functions` sibling. Native example mirrors `service_server.rs` |
+| **C++ service server** | **L** | cxx codegen path | Medium | codegen + cxx. Service-server codegen already exists in `service.rs`; needs C++ creation fns + header export (`apis/c++/node/build.rs`). Mirror C++ action-client example |
+| **C++ action server** | **XL** | Rust action-server codegen first; cxx | Lower | codegen + cxx, hardest — 3 services + 2 topics + goal FSM exposed across FFI. Mirror C++ action-**client** (`examples/ros2-bridge/c++/action-client/`) |
+| **Examples aligned w/ ros2/examples** | **M** (incremental) | Each lands with its feature | High (CI gate) | Mirror `examples/ros2-bridge/{rust,python,c++}/turtle` + `yaml-bridge-{service,action}` + smoke entry in `tests/example-smoke.rs` |
+
+---
+
+## 3. Recommended sequencing
+
+**Phase 0 — Test harness (prereq, ~1 day).** Stand up the macOS Docker dev image (Section 5) and reproduce the *current* green nightly `ros2-bridge` job locally. No code yet; this de-risks every later PR by giving a working local ROS2 oracle.
+
+**Phase 1 — PR #1: Python service client + server (S).** *First pick — justified below.* Adds `Ros2ServiceClient`/`Ros2ServiceServer` pyo3 classes + `Ros2Node.create_service_client/server`, a `python/turtle`-style example, and a smoke entry. Unblocks the entire Python service ecosystem and the param-service.
+
+**Phase 2 — PR #2: Python action client + server (M/L).** Reuses PR #1's wrapper *pattern* (not a compile-time dependency — `ActionClient`/`AsyncActionServer` own their own service/topic machinery internally). Mirrors `run_action_*`. The **action server is a genuine redesign** of the daemon's single-loop goal FSM into a pull API (`&mut self` + persisted goal-handle map), not a mechanical copy. Closes the "Python is most behind" gap the maintainer flagged.
+
+**Phase 3 — PR #3: Parameter service (M).** Built in Python on PR #1's service-server class (**real code dependency** — correctly ordered after Phase 1): host the six `rcl_interfaces/srv/*` servers + publish `ParameterEvent`. Pure composition, validated with `ros2 param list/get/set`.
+
+**Phase 4 — PR #4: Rust action server codegen (L).** New `cxx_action_server_creation_functions` in `msg-gen/src/types/action.rs` + native example mirroring `service_server.rs`.
+
+**Phase 5 — PR #5/#6: C++ service server, then C++ action server (L → XL).** Service server first (codegen mostly exists), action server last (depends on Phase 4 + hardest cxx surface).
+
+**Why PR #1 (Python service client/server) is first:** It is the only item that is **S** difficulty with **zero new dependencies and highest leverage**. The maintainer's status comment names it highest-leverage. Concretely verified: every Rust type it wraps (`BridgeServiceType`, `BridgeMessage`, `TypeInfoGuard`) already exists and is already a direct dependency of the python crate (`python/Cargo.toml:11`); the request/response/correlation async logic already exists in `binaries/ros2-bridge-node/src/main.rs:265-414`; the pyo3 conversion primitives (PyArrow↔`ArrayData`, GIL handling, module registration) are demonstrated in `publish` / `Subscription.next`. It is the lowest-risk way to prove the per-language recipe end-to-end on the macOS harness before tackling codegen-heavy items, and it directly unblocks Phase 3. **Honest caveat:** "lowest risk" ≠ "trivial copy" — see the service-mapping and late-match risks in §7, which apply from PR #1 onward.
+
+---
+
+## 4. Detailed spec for the FIRST PR — Python service client + server
+
+### Goal
+Add Python pyo3 wrappers so a dora Python node can act as a ROS2 service **client** (`call`) and **server** (`take_request` / `send_response`) over the dynamic bridge, with no codegen and no ROS2 dependency in user code beyond pyarrow.
+
+### Verified preconditions (no new core code needed)
+- `BridgeServiceType`, `BridgeMessage`, `TypeInfoGuard`, `set_serialize_type_info`/`set_deserialize_type_info`, `TypeInfo` are defined in **`dora-ros2-bridge-arrow`** (`arrow/src/lib.rs:71/112/157`) and re-exported via `python/src/typed/mod.rs` (`pub use dora_ros2_bridge_arrow::*`). The python crate already lists `dora-ros2-bridge-arrow` as a direct dep. **Import them the way the daemon does** (see 4a).
+- `Ros2Node.node` is `ros2_client::Node`; `create_client::<BridgeServiceType>(mapping, &Name, &ServiceTypeName, qos, qos)` and `create_server::<BridgeServiceType>(...)` are exactly what `run_service_mode` (`main.rs:188-254`) calls.
+- `detect_service_mapping()` reads `RMW_IMPLEMENTATION` at **runtime** (`main.rs:48-66`, called at `:225`/`:242`). It is NOT codegen-time for this dynamic path. Mapping must match the peer's RMW or calls hang (see §7).
+- The daemon calls `wait_for_service(&client, &ros_node)` (`main.rs:235`, def `:1111`) **before** issuing client requests. The Python client must do the same (see 4c/4d) — skipping it directly exposes the late-match race.
+- QoS: `Ros2QosPolicies: Into<rustdds::QosPolicies>` exists (`python/src/qos.rs:52`), **but its default is `BestEffort`** (`qos.rs:44` `reliable: reliable.unwrap_or(false)`, `:57-64`). ROS2 services require **Reliable** QoS. We must build a Reliable+Volatile default explicitly; we cannot rely on the `Ros2QosPolicies` default.
+
+### Files to modify
+**`libraries/extensions/ros2-bridge/python/src/lib.rs`** (primary; ~250 LOC added) plus a 1-function relocation in **`libraries/extensions/ros2-bridge/src/lib.rs`** (see 4b).
+
+#### (a) New imports
+Import the service types from the arrow crate, mirroring the daemon (NOT inventing a `typed`-module path):
+```rust
+use dora_ros2_bridge_arrow::{BridgeServiceType, BridgeMessage, TypeInfo, TypeInfoGuard};
+```
+(`TypeInfo`/`TypeInfoGuard` may already be in scope via the existing `use typed::{...}`; deduplicate at edit time. The point of truth is the daemon's import block at `main.rs:22-26`.)
+
+#### (b) Shared `detect_service_mapping` (remove duplication)
+`detect_service_mapping()` currently lives only in `binaries/ros2-bridge-node/src/main.rs:48`. **Relocate it** to `libraries/extensions/ros2-bridge/src/lib.rs` as `pub fn detect_service_mapping() -> ros2_client::ServiceMapping`, and call it from both the daemon and the pyo3 crate. Surgical 1-function move; removes the duplication the dossier flagged. (Open Q resolved to "yes, relocate.")
+
+#### (c) `Ros2Node` new methods (inside `impl Ros2Node`, after `create_subscription`)
+```rust
+/// Create a ROS2 service client.
+/// :type service_name: str          # e.g. "/add_two_ints"
+/// :type service_type: str          # e.g. "example_interfaces/AddTwoInts"
+/// :type qos: dora.Ros2QosPolicies, optional   (defaults to Reliable+Volatile)
+/// :rtype: dora.Ros2ServiceClient
+#[pyo3(signature = (service_name, service_type, qos=None))]
+pub fn create_service_client(
+    &mut self,
+    service_name: &str,
+    service_type: String,
+    qos: Option<qos::Ros2QosPolicies>,
+) -> eyre::Result<Ros2ServiceClient> {
+    let (package, type_name) = parse_type(&service_type)?;   // mirror create_topic type-split
+    let (req_ti, resp_ti) = service_type_infos(&package, &type_name, &self.messages);
+    let q: rustdds::QosPolicies = match qos {
+        Some(p) => p.into(),
+        None => default_service_qos(),                        // Reliable+Volatile, built explicitly
+    };
+    let client = self.node.create_client::<BridgeServiceType>(
+        dora_ros2_bridge::detect_service_mapping(),
+        &ros2_client::Name::new("/", service_name.trim_start_matches('/'))
+            .map_err(|e| eyre!("bad service name: {e}"))?,
+        &ros2_client::ServiceTypeName::new(&package, &type_name),
+        q.clone(), q,
+    ).map_err(|e| eyre!("create_client failed: {e:?}"))?;
+    Ok(Ros2ServiceClient { client, request_type_info: req_ti, response_type_info: resp_ti,
+                            node: /* handle for wait_for_service, see note */ })
+}
+```
+**`wait_for_service` note:** `wait_for_service` needs both the client and the `ros2_client::Node`. Two viable shapes — pick one at implementation time and document it:
+1. **Auto-wait in `create_service_client`** (simplest for users): call `client.wait_for_service(&self.node)` with a bounded timeout before returning. Downside: blocks construction until the peer exists.
+2. **Explicit `Ros2ServiceClient.wait_for_service(timeout_s)` method** + document that `call` does NOT auto-wait. Requires the client to hold a way to reach the node (store a clone/handle, or have the node drive the wait).
+
+Recommendation: option 2 (explicit), defaulting examples to call it once after creation, because auto-waiting at construction can deadlock a node whose peer starts later in the same dataflow. **This is an open ergonomics question — see §7.**
+
+`create_service_server` mirrors the client signature, calling `self.node.create_server::<BridgeServiceType>(...)`, and constructs the server with its **persisted request stream** (see 4e).
+
+Helpers (file scope):
+```rust
+fn parse_type(t: &str) -> eyre::Result<(String, String)>;          // mirror create_topic type-split
+fn service_type_infos(pkg: &str, name: &str,
+    msgs: &Arc<HashMap<String, HashMap<String, Message>>>)
+    -> eyre::Result<(TypeInfo<'static>, TypeInfo<'static>)> {       // "_Request"/"_Response", mirror main.rs:200-217
+}
+fn default_service_qos() -> rustdds::QosPolicies;                   // Reliable + Volatile via QosPolicyBuilder
+```
+
+#### (d) `Ros2ServiceClient` pyclass + methods
+```rust
+#[pyclass] #[non_exhaustive]
+pub struct Ros2ServiceClient {
+    client: ros2_client::Client<BridgeServiceType>,
+    request_type_info: TypeInfo<'static>,
+    response_type_info: TypeInfo<'static>,
+    // + whatever handle the chosen wait_for_service shape requires
+}
+
+#[pymethods]
+impl Ros2ServiceClient {
+    /// Wait until a matching service server is discovered (recommended before first call).
+    /// :type timeout_s: float, optional
+    #[pyo3(signature = (timeout_s=None))]
+    pub fn wait_for_service(&self, py: Python, timeout_s: Option<f64>) -> eyre::Result<bool> { /* mirror main.rs:1111 */ }
+
+    /// Send request, block for response (default 30s timeout). Does NOT auto wait_for_service.
+    /// :type request: pyarrow.Array | pyarrow.StructScalar | dict
+    /// :type timeout_s: float, optional
+    /// :rtype: pyarrow.Array
+    #[pyo3(signature = (request, timeout_s=None))]
+    pub fn call(&self, request: Bound<'_, PyAny>, timeout_s: Option<f64>)
+        -> eyre::Result<Py<PyAny>>
+    {
+        let py = request.py();
+        let array_data = pyarrow_to_array_data(&request)?;     // EXTRACTED from publish() dict→scalar→array→ArrayData
+        let req_id = {
+            let _g = TypeInfoGuard::serialize(self.request_type_info.clone());
+            self.client.send_request(BridgeMessage(Some(array_data)))
+                .map_err(|e| eyre!("send_request: {e:?}"))?
+        };
+        let _g = TypeInfoGuard::deserialize(self.response_type_info.clone());
+        let timeout = Duration::from_secs_f64(timeout_s.unwrap_or(30.0));
+        let resp = py.allow_threads(|| futures::executor::block_on(async {  // release GIL while blocking
+            let recv = self.client.async_receive_response(req_id);
+            futures::pin_mut!(recv);
+            match futures::future::select(recv, futures_timer::Delay::new(timeout)).await {
+                Either::Left((r,_)) => r.map_err(|e| eyre!("recv response: {e:?}")),
+                Either::Right(_) => eyre::bail!("service call timed out after {timeout:?} \
+                    (check RMW_IMPLEMENTATION matches the peer; see service-mapping risk)"),
+            }
+        }))?;
+        let data = resp.0.context("service response had no data")?;  // data is ArrayData
+        Ok(data.to_pyarrow(py)?.unbind())                            // direct, no make_array round-trip
+    }
+}
+```
+**Serialization handling:** `TypeInfoGuard::serialize(req_ti)` is set *only* around `send_request`; `TypeInfoGuard::deserialize(resp_ti)` *only* around the await — exactly the daemon's discipline. `BridgeMessage::serialize` reads the thread-local set by the guard; the guard's `Drop` clears it (RAII, panic-safe — `arrow/src/lib.rs:71-110`). This is the **first** use of this mechanism in the Python crate; the existing pub/sub path uses `TypedValue`/`StructDeserializer` instead and is not a model for it.
+
+**Conversion correction:** `resp.0` is already `ArrayData`, so it goes straight to `.to_pyarrow(py)` — matching `Subscription.next` (`lib.rs:394`, where `value` is `ArrayData` and the code is `value.to_pyarrow(py)?`). No `make_array(...).to_data()` round-trip.
+
+#### (e) `Ros2ServiceServer` pyclass + methods (persisted stream — fixes per-poll bug)
+The daemon constructs `receive_request_stream()` **once** and drives it for the server's lifetime (`main.rs:328-352` via `merge_external` + `block_on_stream`). `receive_request_stream()` yields a fresh stream over the DataReader each call; constructing/dropping it per poll risks dropping requests that arrive between polls. So we **persist a `block_on_stream` iterator** as a field:
+```rust
+#[pyclass] #[non_exhaustive]
+pub struct Ros2ServiceServer {
+    // Persisted once at creation, mirroring the daemon's single-stream lifetime.
+    requests: futures::executor::BlockingStream<Pin<Box<
+        dyn Stream<Item = Result<(ros2_client::service::RmwRequestId, BridgeMessage), _>> + Send>>>,
+    server_send: /* handle to async_send_response — see note */,
+    request_type_info: TypeInfo<'static>,
+    response_type_info: TypeInfo<'static>,
+    pending: HashMap<u64, ros2_client::service::RmwRequestId>,  // request_id -> rmw id
+    next_id: u64,
+}
+```
+**Note on the borrow:** in the daemon, `receive_request_stream()` borrows `&server` and the same `&server` is used for `async_send_response`. Wrapping a self-referential (stream + server) pair in one pyclass field is awkward. Two implementation options, decided at coding time:
+1. Hold `Arc<Server<BridgeServiceType>>` (or the ros2-client server behind shared ownership) so both the persisted stream and `send_response` can reference it; OR
+2. Wrap the server in the pyclass and build the stream lazily on first `take_request`, then keep it. Either way the stream is built **once**, not per call. **This is the part of PR #1 with real implementation risk** (self-referential borrow across pyo3); flagged in §7.
+
+```rust
+#[pymethods]
+impl Ros2ServiceServer {
+    /// Block for next request. Returns (request_id, request_array) or None on stream end.
+    /// :rtype: tuple[int, pyarrow.Array] | None
+    pub fn take_request(&mut self, py: Python) -> eyre::Result<Option<(u64, Py<PyAny>)>> {
+        let _g = TypeInfoGuard::deserialize(self.request_type_info.clone());
+        let item = py.allow_threads(|| self.requests.next());      // pull from the PERSISTED iterator
+        let Some(res) = item else { return Ok(None) };
+        let (rmw_id, msg) = res.map_err(|e| eyre!("recv request: {e:?}"))?;
+        let Some(data) = msg.0 else { return Ok(None) };
+        let id = self.next_id; self.next_id += 1;
+        self.pending.insert(id, rmw_id);
+        Ok(Some((id, data.to_pyarrow(py)?.unbind())))             // data is ArrayData, direct convert
+    }
+
+    /// Send response for a previously-taken request_id.
+    /// :type request_id: int
+    /// :type response: pyarrow.Array | pyarrow.StructScalar | dict
+    pub fn send_response(&mut self, request_id: u64, response: Bound<'_, PyAny>)
+        -> eyre::Result<()>
+    {
+        let py = response.py();
+        let rmw_id = self.pending.remove(&request_id)
+            .context("unknown request_id (already answered or never taken)")?;
+        let array_data = pyarrow_to_array_data(&response)?;
+        let _g = TypeInfoGuard::serialize(self.response_type_info.clone());
+        py.allow_threads(|| futures::executor::block_on(
+            /* server */.async_send_response(rmw_id, BridgeMessage(Some(array_data)))
+        )).map_err(|e| eyre!("send_response: {e:?}"))?;
+        Ok(())
+    }
+}
+```
+**Correlation key:** the pyo3 server uses a local `u64 → RmwRequestId` map and echoes the exact `RmwRequestId` back in `send_response` — satisfying §7's "persist the full `rmw_request_id_t` until the response is produced, then echo it exactly." It deliberately does **not** reuse the daemon's String-metadata (`new_request_id()`) correlation, because the pyo3 server never round-trips through dora metadata. `u64` is the single, consistent correlation type for this class.
+
+#### (f) Extract shared PyArrow conversion
+Factor the dict→StructScalar→array→`ArrayData` logic currently inline in `publish()` (`lib.rs:337-352`) into `fn pyarrow_to_array_data(data: &Bound<'_, PyAny>) -> eyre::Result<ArrayData>`, and have `publish` call it. Surgical refactor; one source of truth for input conversion.
+
+#### (g) Register classes (`create_dora_ros2_bridge_module`)
+```rust
+m.add_class::<Ros2ServiceClient>()?;
+m.add_class::<Ros2ServiceServer>()?;
+```
+
+#### (h) Type stubs
+Add the new classes + method signatures to the python `.pyi` stub so editors/typecheckers see them.
+
+### How it reuses existing surface (summary, corrected)
+- **Conversion in:** `pyarrow_to_array_data` extracted from `publish():337-352`. **Out:** `ArrayData::to_pyarrow(py)` as in `Subscription.next:394` — `resp.0`/`msg.0` are already `ArrayData`, no `make_array`/`to_data` round-trip.
+- **Async + correlation + persisted stream + wait_for_service:** adapted from `run_service_client`/`run_service_server`/`wait_for_service` (`main.rs:265-414`, `:1111`). The daemon is the reference, NOT the Python pub/sub path.
+- **Serialization context:** `TypeInfoGuard` + `BridgeMessage` thread-local mechanism from `dora-ros2-bridge-arrow` — newly introduced into the Python crate by this PR.
+- **QoS / mapping:** `Ros2QosPolicies: Into<QosPolicies>` exists but defaults to BestEffort; we add an explicit Reliable+Volatile `default_service_qos()`. `detect_service_mapping` relocated to the shared lib.
+- **GIL:** wrap every `block_on`/blocking `next()` in `py.allow_threads` (publish is non-blocking so didn't need it; service calls block on the network and must release the GIL).
+
+### Example (lands in same PR)
+`examples/ros2-bridge/python/service/` mirroring `examples/ros2-bridge/python/turtle/`: a `dataflow.yml`, a `client_node.py` that calls `wait_for_service()` then `create_service_client("/add_two_ints","example_interfaces/AddTwoInts").call(pa.array([{"a":2,"b":3}]))`, and a `server_node.py` looping `take_request`/`send_response`. The example launch script **exports `RMW_IMPLEMENTATION=rmw_cyclonedds_cpp`** to match `detect_service_mapping()`'s Cyclone path (see §5/§7). Plus a driver entry in `libraries/extensions/ros2-bridge/Cargo.toml` mirroring the `python-ros2-dataflow` example wiring.
+
+---
+
+## 5. macOS testing & verification strategy
+
+**Decisive constraint:** the bridge's RustDDS participant does discovery via **default multicast SPDP** with no peers/interface knob. Docker Desktop for Mac has no `--network=host` to macOS and drops multicast across the bridge driver. **Therefore the dora process and the ROS2 node MUST live in the same Linux network namespace.** Never split dora-on-macOS ↔ ROS2-in-container — discovery silently fails.
+
+**Setup (Option A: one container; matches CI exactly):**
+1. **Runtime:** Colima with the vz VM type (or Docker Desktop): `colima start --vm-type=vz --cpu 6 --memory 16 --disk 60`.
+2. **Image:** `osrf/ros:humble-desktop` (native arm64, includes turtlesim + example-interfaces; **Humble** to match nightly CI). Add rustup pinned to **1.92**, Python 3.12, uv, `clang`, `cmake`, `ros-humble-example-interfaces`, and **`ros-humble-rmw-cyclonedds-cpp`** (required — see RMW default below).
+   - `network_mode: host` (= the Linux VM's host net; SPDP loops back in-namespace).
+   - Bind-mount repo to `/work`; **named volume** for `CARGO_TARGET_DIR=/cargo-target` (never share `target/` with the macOS-native build — arch fingerprints thrash); named volumes for `/root/.cargo/registry` + `/git`.
+   - `.bashrc` sources `/opt/ros/humble/setup.bash` so `AMENT_PREFIX_PATH` is set for **runtime** message loading (see build-vs-runtime note below).
+   - `QT_QPA_PLATFORM=offscreen`.
+3. **RMW default — corrected.** The compose file MUST default to **`RMW_IMPLEMENTATION=rmw_cyclonedds_cpp`** on **both** the ROS2 side and the dora process. An earlier dossier compose used `rmw_fastrtps_cpp`; with services/actions that produces a Cyclone-vs-FastDDS service-mapping mismatch and the exact "hung call" failure §7 warns about, because `detect_service_mapping()` reads `RMW_IMPLEMENTATION` at runtime and dora explicitly implements the Cyclone service mapping. Pin Cyclone everywhere, install `ros-humble-rmw-cyclonedds-cpp`, and assert the env var is set in the example launch scripts. (Topics are mapping-agnostic, so the existing pub/sub examples were unaffected — which is why the wrong default went unnoticed.)
+
+**Build-vs-runtime note (Python crate specifically) — corrected.** The python crate depends on `dora-ros2-bridge { default-features = false }` (disabling `generate-messages`) and parses `.msg`/`.srv` at **runtime** via `get_packages(AMENT_PREFIX_PATH)` (`python/src/lib.rs:68-102`). So **building the pyo3 wheel (`maturin develop`) does NOT require ROS2 message files or `AMENT_PREFIX_PATH`** — that's a runtime dependency of the *running dataflow* only. The `build.rs` codegen re-run discussion (`rerun-if-env-changed` on `AMENT_PREFIX_PATH`) applies to the **native codegen targets**, not this Python target; do not let the Docker loop assume the wheel rebuild depends on ROS2.
+
+**Build-in-container loop:**
+```bash
+docker compose -f docker-compose.ros2dev.yml up -d --build
+docker compose ... exec dora-ros2 bash -lc '
+  uv venv --seed -p 3.12 && source .venv/bin/activate &&
+  uv pip install -e apis/python/node pyarrow numpy &&
+  maturin develop -m libraries/extensions/ros2-bridge/python/Cargo.toml'   # rebuild pyo3 wheel after edits (ROS2-independent)
+```
+First build is minutes; incremental is fast on persistent volumes.
+
+**Round-trip verification against a real ROS2 node (service example):**
+```bash
+# Terminal 1 (in container): real ROS2 service server  (Cyclone RMW)
+source /opt/ros/humble/setup.bash; export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+ros2 run examples_rclpy_minimal_service service   # advertises /add_two_ints
+# Terminal 2: dora client node calls it via the new pyo3 wrapper  (same RMW)
+RMW_IMPLEMENTATION=rmw_cyclonedds_cpp dora run examples/ros2-bridge/python/service/dataflow-client.yml --uv --stop-after 10s
+#   expect node logs: sum == a+b
+
+# Reverse: dora is the SERVER, ros2 CLI is the client
+RMW_IMPLEMENTATION=rmw_cyclonedds_cpp dora run examples/ros2-bridge/python/service/dataflow-server.yml --uv &
+RMW_IMPLEMENTATION=rmw_cyclonedds_cpp ros2 service call /add_two_ints example_interfaces/srv/AddTwoInts "{a: 7, b: 5}"
+#   expect: response: example_interfaces.srv.AddTwoInts_Response(sum=12)
+```
+Explicitly test `ros2 service call` issued **immediately after** the dora server starts to exercise the late-match race (§7).
+
+**Action verification (Phase 2):**
+```bash
+ros2 action send_goal /fibonacci example_interfaces/action/Fibonacci "{order: 5}" --feedback
+# vs. dora action server; expect feedback stream + result.sequence == [0,1,1,2,3,5]
+```
+**Param verification (Phase 3):** `ros2 param list /<node>`, `ros2 param get/set` against the dora-hosted param servers; `ros2 topic echo /parameter_events`.
+
+The local CI parity check (run before every push touching the bridge): `scripts/qa/ci-nightly-jobs.sh ros2-bridge`, which sources Humble and runs `cargo test -p dora-ros2-bridge-python` + the rust/python/cxx `*-ros2-dataflow` examples — identical to the GHA job.
+
+---
+
+## 6. Plan → Spec → Implementation → Testing → Verification loop (per sub-item)
+
+1. **Plan.** Locate the recipe stage(s): codegen / core / binding (pyo3 or cxx) / example / smoke. Most Python items skip codegen. Write success criteria as the exact `ros2 service call` / `ros2 action send_goal` / `ros2 param` command that must round-trip, **with the matching `RMW_IMPLEMENTATION` set**.
+
+2. **Spec.** Enumerate files + signatures (as in Section 4). Name the existing function each new piece mirrors — for service/action items that reference is the **daemon** (`run_service_*`, `run_action_*`, `wait_for_service`), not the Python pub/sub code. Decide serialization (`_Request`/`_Response`/`_Goal`/`_Result`/`_Feedback` `TypeInfo` + `TypeInfoGuard` placement), QoS (Reliable for services), and GIL boundaries (`py.allow_threads` around every blocking call). For the action server, spec `&mut self` + a persisted goal-handle map up front.
+
+3. **Implementation (RED→GREEN→IMPROVE).**
+   - **RED — unit:** add a Rust `#[cfg(test)]` test (style of the existing Arrow↔ROS2 round-trip tests in `typed/mod.rs`) asserting request `ArrayData` → CDR → `ArrayData` round-trips through `BridgeServiceType`'s `_Request`/`_Response` `TypeInfo` with the `TypeInfoGuard` discipline. No live ROS2; runs in `cargo test -p dora-ros2-bridge-python`.
+   - **GREEN:** implement until the unit test + `maturin develop` import succeed.
+   - **IMPROVE:** `cargo clippy -p dora-ros2-bridge-python -- -D warnings`, `cargo fmt --all -- --check`, run `/review` + `/simplify`.
+
+4. **Testing tiers:**
+   - **Unit** — type/serialization round-trip, no network.
+   - **Integration** — the embedded-Python test target (`dora-ros2-bridge-python`, already run by nightly) exercising client↔server in one process over loopback DDS inside the container.
+   - **Smoke** — add entries to `tests/example-smoke.rs`: `run_smoke_test_local("ros2-service", ...)` + networked `run_smoke_test` where applicable. Register the example in `scripts/smoke-all.sh` (ros2 examples stay in the smoke SKIP list for non-ROS2 hosts; they execute only inside the container/nightly).
+
+5. **Verification.** Run the real-ROS2 round-trip commands from Section 5 inside the container, both directions, with matching RMW, including the immediately-after-start late-match probe.
+
+6. **Final gate.** `scripts/qa/ci-nightly-jobs.sh ros2-bridge` locally (Humble), then push; the **nightly `ros2-bridge` job** (ubuntu-22.04 + Humble, non-PR-blocking) is authoritative. Because bridge CI is nightly-only, schedule the merge so a nightly runs within ~24h and watch for the auto-filed `nightly-regression` issue.
+
+---
+
+## 7. Risks & open questions
+
+**Risks**
+- **Service-mapping interop (highest).** Fast-DDS (Humble default) uses RTPS `SampleIdentity` for request/reply correlation; Cyclone/RPC-style prepends a `{u64 guid, i64 seq}` body header — **mutually wire-incompatible**. `detect_service_mapping()` reads `RMW_IMPLEMENTATION` at **runtime**, so the peer's RMW must match what dora detects or the call hangs. Mitigation: pin `RMW_IMPLEMENTATION=rmw_cyclonedds_cpp` on both sides in the harness, examples, and docs; surface a clear timeout error hinting at mapping mismatch (spec'd in 4d).
+- **Late-match race.** A server may receive a request before its reply writer is matched to the client's reply reader, silently dropping the reply. Mitigation: the client calls `wait_for_service` (mirroring the daemon `main.rs:235`); explicitly test `ros2 service call` immediately after server start. **Honest uncertainty:** whether ros2-client buffers a reply across a not-yet-matched reply writer is not proven here — the immediately-after-start probe in §5 is the gate, and if it fails we add a server-side readiness wait.
+- **Self-referential server borrow in pyo3 (real PR #1 risk).** Persisting the request stream (built once) while also calling `async_send_response` on the same server is a self-referential borrow that pyo3's `#[pyclass]` (which requires owned/`Send` fields) makes awkward. The two options in 4e (shared `Arc<Server>` vs. lazy-but-persisted stream) are both plausible but **neither is verified to compile against ros2-client 0.8's `Server` API yet**. This is the single most likely place PR #1 takes longer than "S". Resolve by spiking the field layout against the real `Server` type before writing the pyclass.
+- **QoS default wrong for services.** `Ros2QosPolicies` defaults to `BestEffort` (`qos.rs:44/57`); services need Reliable. Mitigation: explicit `default_service_qos()` (Reliable+Volatile via `QosPolicyBuilder`); do not lean on the `Into` default.
+- **Blocking pyo3 API ergonomics + the `wait_for_service` shape.** `call`/`take_request` are synchronous + GIL-releasing; a user calling `call()` on the dora event-loop thread blocks that node. Acceptable for v1 (matches `Subscription.next`), but must be documented. Coupled open question: should `create_service_client` auto-wait for the service (simple, but can deadlock if the peer starts later in the same dataflow) or expose an explicit `wait_for_service(timeout)` (recommended)? **Unresolved — flagged for maintainer.**
+- **GIL deadlock** if any `block_on`/blocking `next()` is *not* wrapped in `py.allow_threads`. Enforce in review.
+- **Action server is a genuine redesign, not a copy (Phase 2).** The daemon manages goal state in a single `block_on_stream` loop (`main.rs:666+`); a pull-style pyo3 action server needs `&mut self` + a persisted `HashMap<goal_id, ExecutingGoalHandle>` and must re-implement the goal FSM, result caching (`GetResult` expiry), cancel selection (the 4 `(goal_id,stamp)` cases), and transient-local status publishing outside the loop. This is the highest-defect-surface Python item; do not budget it as mechanical.
+- **C++ action server (XL).** Goal FSM + 3 services + 2 topics re-exposed across the cxx FFI. Highest overall defect surface.
+- **macOS test fragility.** Only Option A (single container) reliably discovers; any accidental process split breaks silently. Bake the (Cyclone-defaulted) container setup into a committed `docker-compose.ros2dev.yml` so contributors can't misconfigure.
+
+**Open questions**
+1. **Native vs dynamic for Python actions:** expose only the dynamic-bridge (`BridgeActionType`) path, or also generate codegen-native typed Python? Recommend dynamic-only (no per-message codegen burden); confirm with maintainer.
+2. **`wait_for_service` ergonomics:** auto-wait in `create_service_client`, or explicit `wait_for_service(timeout)` method (recommended)? Affects whether the first `call()` can deadlock against a later-starting peer.
+3. **Server field layout vs ros2-client 0.8 `Server` API:** which of the two 4e shapes (shared `Arc<Server>` vs lazy-persisted stream) actually compiles given the `receive_request_stream`/`async_send_response` borrow signatures? Must spike before coding the pyclass.
+4. **Param service language:** implement once in Python on PR #1's server (fastest, real dependency on Phase 1), or also in Rust? Recommend Python-first.
+5. **Timeout policy:** match the daemon's 30s service / 5min result defaults, or expose per-call `timeout_s` (spec'd as optional arg, daemon values as defaults)? Recommend the latter.
+6. **Example alignment scope:** which specific upstream `ros2/examples` packages (e.g. `examples_rclpy_minimal_service`, `examples_rclpy_minimal_action_*`) are the canonical mirror targets, so example dataflow names match upstream exactly? Confirm the list.
+
+*(Resolved from the prior draft: where `BridgeServiceType`/`BridgeMessage`/`TypeInfoGuard` live — `dora-ros2-bridge-arrow`, imported as the daemon does; and whether to relocate `detect_service_mapping` — yes, to the shared `ros2-bridge/src/lib.rs`.)*

--- a/examples/ros2-bridge/python/service-client/dataflow.yml
+++ b/examples/ros2-bridge/python/service-client/dataflow.yml
@@ -1,0 +1,6 @@
+nodes:
+  - id: service-client
+    path: ./service_client_node.py
+    inputs:
+      tick: dora/timer/millis/500
+    outputs: []

--- a/examples/ros2-bridge/python/service-client/run.rs
+++ b/examples/ros2-bridge/python/service-client/run.rs
@@ -1,0 +1,46 @@
+use dora_cli::{BuildConfig, build, run as dora_run};
+use eyre::WrapErr;
+use std::path::Path;
+
+use process_wrap::std::{StdChildWrapper as ChildWrapper, StdCommandWrap as CommandWrap};
+
+fn main() -> eyre::Result<()> {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../");
+    std::env::set_current_dir(root.join(file!()).parent().unwrap())
+        .wrap_err("failed to set working dir")?;
+
+    build(BuildConfig {
+        dataflow: "dataflow.yml".to_string(),
+        uv: true,
+        force_local: true,
+        ..Default::default()
+    })?;
+
+    let dataflow_task = std::thread::spawn(|| {
+        dora_run("dataflow.yml".to_string(), true).unwrap();
+    });
+
+    let mut add_service_task = run_ros_node("examples_rclcpp_minimal_service", "service_main")?;
+
+    let dataflow_result = dataflow_task
+        .join()
+        .map_err(|_| eyre::eyre!("Failed to run dataflow"));
+
+    add_service_task.kill()?;
+
+    dataflow_result
+}
+
+fn run_ros_node(package: &str, node: &str) -> eyre::Result<Box<dyn ChildWrapper>> {
+    let mut command = CommandWrap::with_new("ros2", |cmd| {
+        cmd.arg("run");
+        cmd.arg(package).arg(node);
+    });
+    #[cfg(unix)]
+    command.wrap(process_wrap::std::ProcessGroup::leader());
+    #[cfg(windows)]
+    command.wrap(process_wrap::std::JobObject);
+    command
+        .spawn()
+        .map_err(|e| eyre::eyre!("failed to spawn ros node: {}", e))
+}

--- a/examples/ros2-bridge/python/service-client/service_client_node.py
+++ b/examples/ros2-bridge/python/service-client/service_client_node.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+"""Python ROS2 service client example.
+
+Calls the ROS2 `example_interfaces/AddTwoInts` service (provided by the
+`examples_rclcpp_minimal_service` node) from a dora Python node, using the
+`create_service_client` API of the dora ROS2 bridge.
+"""
+
+import pyarrow as pa
+from dora import Node, Ros2Context, Ros2NodeOptions, Ros2QosPolicies
+
+# Create a ROS2 context + node.
+ros2_context = Ros2Context()
+ros2_node = ros2_context.new_node(
+    "service_client",
+    "/ros2_demo",
+    Ros2NodeOptions(rosout=True),
+)
+
+# ROS2 services require reliable QoS.
+service_qos = Ros2QosPolicies(reliable=True, max_blocking_time=0.1)
+
+# Create the service client for /add_two_ints. This waits (bounded) for the
+# service to become available before returning.
+add_two_ints = ros2_node.create_service_client(
+    "/add_two_ints",
+    "example_interfaces/AddTwoInts",
+    service_qos,
+)
+
+# Drive calls from a dora timer tick.
+dora_node = Node()
+responses_received = 0
+for i in range(20):
+    event = dora_node.next()
+    if event is None:
+        break
+    if event["type"] == "INPUT" and event["id"] == "tick":
+        response = add_two_ints.call(pa.array([{"a": i, "b": 1}]))
+        result = response[0].as_py()
+        print(f"tick {i}: {i} + 1 = {result['sum']}", flush=True)
+        assert result["sum"] == i + 1, f"expected {i + 1}, got {result['sum']}"
+        responses_received += 1
+        if responses_received >= 3:
+            break
+
+assert responses_received > 0, "no service responses received"
+print("PYTHON SERVICE CLIENT OK", flush=True)

--- a/examples/ros2-bridge/python/service-server/dataflow.yml
+++ b/examples/ros2-bridge/python/service-server/dataflow.yml
@@ -1,0 +1,14 @@
+nodes:
+  # dora node that serves /add_two_ints via the ROS2 bridge.
+  - id: service-server
+    path: ./service_server_node.py
+    inputs:
+      tick: dora/timer/millis/100
+    outputs: []
+  # Reuse the service-client example node to drive the server (no external
+  # ROS2 process needed: both sides are dora nodes talking over the bridge).
+  - id: service-client
+    path: ../service-client/service_client_node.py
+    inputs:
+      tick: dora/timer/millis/500
+    outputs: []

--- a/examples/ros2-bridge/python/service-server/run.rs
+++ b/examples/ros2-bridge/python/service-server/run.rs
@@ -1,0 +1,22 @@
+use dora_cli::{BuildConfig, build, run as dora_run};
+use eyre::WrapErr;
+use std::path::Path;
+
+fn main() -> eyre::Result<()> {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../");
+    std::env::set_current_dir(root.join(file!()).parent().unwrap())
+        .wrap_err("failed to set working dir")?;
+
+    build(BuildConfig {
+        dataflow: "dataflow.yml".to_string(),
+        uv: true,
+        force_local: true,
+        ..Default::default()
+    })?;
+
+    // Self-contained: the dataflow runs both the dora service server and a dora
+    // service client that drives it, so no external ROS2 node is needed.
+    dora_run("dataflow.yml".to_string(), true)?;
+
+    Ok(())
+}

--- a/examples/ros2-bridge/python/service-server/service_server_node.py
+++ b/examples/ros2-bridge/python/service-server/service_server_node.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+"""Python ROS2 service server example.
+
+Serves the ROS2 `example_interfaces/AddTwoInts` service from a dora Python node
+using the `create_service_server` API of the dora ROS2 bridge. Requests are
+polled on each dora timer tick and answered with the sum.
+"""
+
+import pyarrow as pa
+from dora import Node, Ros2Context, Ros2NodeOptions, Ros2QosPolicies
+
+# Create a ROS2 context + node and advertise the service.
+ros2_context = Ros2Context()
+ros2_node = ros2_context.new_node(
+    "service_server",
+    "/ros2_demo",
+    Ros2NodeOptions(rosout=True),
+)
+service_qos = Ros2QosPolicies(reliable=True, max_blocking_time=0.1)
+add_two_ints = ros2_node.create_service_server(
+    "/add_two_ints",
+    "example_interfaces/AddTwoInts",
+    service_qos,
+)
+
+# Poll for requests on each dora tick and answer them.
+dora_node = Node()
+handled = 0
+for _ in range(200):
+    event = dora_node.next()
+    if event is None:
+        break
+    if event["type"] == "INPUT" and event["id"] == "tick":
+        while True:
+            req = add_two_ints.take_request(timeout_s=0.05)
+            if req is None:
+                break
+            request_id, value = req
+            args = value[0].as_py()
+            total = args["a"] + args["b"]
+            add_two_ints.send_response(request_id, pa.array([{"sum": total}]))
+            handled += 1
+            print(f"server: {args['a']} + {args['b']} = {total}", flush=True)
+    if handled >= 3:
+        break
+
+assert handled > 0, "service server handled no requests"
+print(f"PYTHON SERVICE SERVER OK ({handled} handled)", flush=True)

--- a/libraries/extensions/ros2-bridge/Cargo.toml
+++ b/libraries/extensions/ros2-bridge/Cargo.toml
@@ -75,6 +75,14 @@ name = "python-ros2-dataflow"
 path = "../../../examples/ros2-bridge/python/turtle/run.rs"
 
 [[example]]
+name = "python-ros2-dataflow-service-client"
+path = "../../../examples/ros2-bridge/python/service-client/run.rs"
+
+[[example]]
+name = "python-ros2-dataflow-service-server"
+path = "../../../examples/ros2-bridge/python/service-server/run.rs"
+
+[[example]]
 name = "cxx-ros2-dataflow"
 path = "../../../examples/ros2-bridge/c++/turtle/run.rs"
 required-features = ["ros2-examples"]

--- a/libraries/extensions/ros2-bridge/python/Cargo.toml
+++ b/libraries/extensions/ros2-bridge/python/Cargo.toml
@@ -14,6 +14,7 @@ eyre = "0.6"
 serde = "1.0.166"
 arrow = { workspace = true, features = ["pyarrow"] }
 futures = "0.3.28"
+futures-timer = "3"
 
 [build-dependencies]
 pyo3-build-config = { workspace = true }

--- a/libraries/extensions/ros2-bridge/python/src/lib.rs
+++ b/libraries/extensions/ros2-bridge/python/src/lib.rs
@@ -5,11 +5,11 @@ use std::{
     sync::Arc,
 };
 
+use ::dora_ros2_bridge::{ros2_client, rustdds};
 use arrow::{
     array::{ArrayData, make_array},
     pyarrow::{FromPyArrow, ToPyArrow},
 };
-use ::dora_ros2_bridge::{ros2_client, rustdds};
 use dora_ros2_bridge_msg_gen::types::Message;
 use eyre::{Context, ContextCompat, Result, eyre};
 use futures::{Stream, StreamExt};
@@ -18,7 +18,7 @@ use pyo3::{
     prelude::{pyclass, pymethods},
     types::{PyAnyMethods, PyDict, PyList, PyModule, PyModuleMethods},
 };
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use typed::{
     BridgeMessage, BridgeServiceType, TypeInfo, TypeInfoGuard, TypedValue,
     deserialize::StructDeserializer,
@@ -26,6 +26,13 @@ use typed::{
 
 pub mod qos;
 pub mod typed;
+
+/// Drop a taken-but-unanswered service request after this long, so a server
+/// whose handler skips `send_response` can't leak `pending` entries forever.
+/// Matches the standalone bridge daemon.
+const SERVICE_RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
+/// Hard cap on outstanding taken-but-unanswered requests. Matches the daemon.
+const MAX_PENDING_REQUESTS: usize = 64;
 
 /// ROS2 Context holding all messages definition for receiving and sending messages to ROS2.
 ///
@@ -152,7 +159,11 @@ impl Ros2Context {
             .map_err(|e| eyre::eyre!("failed to create ROS2 node: {e:?}"))?;
 
         // Start a spinner so service/discovery status events are processed.
-        let spinner_pool = futures::executor::ThreadPool::new()
+        // One worker thread is enough (the spinner is a single task); this keeps
+        // the per-node thread cost at 1 instead of one-per-CPU-core.
+        let spinner_pool = futures::executor::ThreadPool::builder()
+            .pool_size(1)
+            .create()
             .map_err(|e| eyre!("failed to create ros2 spinner pool: {e}"))?;
         let spinner = node
             .spinner()
@@ -314,6 +325,7 @@ impl Ros2Node {
     /// :rtype: dora.Ros2ServiceClient
     pub fn create_service_client(
         &mut self,
+        py: Python<'_>,
         service_name: &str,
         service_type: String,
         qos: qos::Ros2QosPolicies,
@@ -325,7 +337,7 @@ impl Ros2Node {
         let client = self
             .node
             .create_client::<BridgeServiceType>(
-                detect_service_mapping(),
+                dora_ros2_bridge::detect_service_mapping(),
                 &ros2_client::Name::new("/", service_name.trim_start_matches('/'))
                     .map_err(|e| eyre!("failed to parse service name: {e}"))?,
                 &ros2_client::ServiceTypeName::new(&package, &type_name),
@@ -335,20 +347,23 @@ impl Ros2Node {
             .map_err(|e| eyre!("failed to create service client: {e:?}"))?;
 
         // Mirror the daemon: wait for the server before returning so the first
-        // `call()` does not race service discovery.
-        let ready = async {
-            for _ in 0..10 {
-                let wait = client.wait_for_service(&self.node);
-                futures::pin_mut!(wait);
-                let timeout = futures_timer::Delay::new(Duration::from_secs(2));
-                match futures::future::select(wait, timeout).await {
-                    futures::future::Either::Left(((), _)) => return Ok(()),
-                    futures::future::Either::Right(_) => {}
+        // `call()` does not race service discovery. Release the GIL: this blocks
+        // for up to 20s and must not freeze other Python threads.
+        let node = &self.node;
+        py.detach(|| {
+            futures::executor::block_on(async {
+                for _ in 0..10 {
+                    let wait = client.wait_for_service(node);
+                    futures::pin_mut!(wait);
+                    let timeout = futures_timer::Delay::new(Duration::from_secs(2));
+                    match futures::future::select(wait, timeout).await {
+                        futures::future::Either::Left(((), _)) => return Ok(()),
+                        futures::future::Either::Right(_) => {}
+                    }
                 }
-            }
-            eyre::bail!("service `{service_name}` not available after 10 retries")
-        };
-        futures::executor::block_on(ready)?;
+                eyre::bail!("service `{service_name}` not available after 10 retries")
+            })
+        })?;
 
         Ok(Ros2ServiceClient {
             client,
@@ -395,7 +410,7 @@ impl Ros2Node {
         let server = self
             .node
             .create_server::<BridgeServiceType>(
-                detect_service_mapping(),
+                dora_ros2_bridge::detect_service_mapping(),
                 &ros2_client::Name::new("/", service_name.trim_start_matches('/'))
                     .map_err(|e| eyre!("failed to parse service name: {e}"))?,
                 &ros2_client::ServiceTypeName::new(&package, &type_name),
@@ -657,12 +672,14 @@ impl Ros2ServiceClient {
                 .map_err(|e| eyre!("failed to send service request: {e:?}"))?
         };
 
-        // NOTE: blocks holding the GIL, matching the rest of this binding
-        // (e.g. `Ros2Subscription::next`). Releasing the GIL here is a future
-        // refinement (pyo3 0.28 reworked the GIL-release API).
+        // Release the GIL while blocking on the network so other Python threads
+        // (e.g. a service server producing this very response) can run. The
+        // TypeInfoGuard lives inside the closure, which runs on the same OS
+        // thread, so the deserialize thread-local stays correct.
         let timeout = Duration::from_secs_f64(timeout_s.unwrap_or(30.0));
-        let response = {
-            let _guard = TypeInfoGuard::deserialize(self.response_type_info.clone());
+        let response_type_info = self.response_type_info.clone();
+        let response = py.detach(|| {
+            let _guard = TypeInfoGuard::deserialize(response_type_info);
             futures::executor::block_on(async {
                 let recv = self.client.async_receive_response(req_id);
                 futures::pin_mut!(recv);
@@ -675,8 +692,8 @@ impl Ros2ServiceClient {
                         eyre::bail!("service response timed out after {timeout:?}")
                     }
                 }
-            })?
-        };
+            })
+        })?;
 
         let data = response.0.context("service response contained no data")?;
         Ok(data.to_pyarrow(py)?.unbind())
@@ -694,9 +711,11 @@ pub struct Ros2ServiceServer {
     server: ros2_client::Server<BridgeServiceType>,
     request_type_info: TypeInfo<'static>,
     response_type_info: TypeInfo<'static>,
-    // Maps the integer id handed to Python back to the ROS2 request id, so
-    // `send_response` can reply to the correct (possibly out-of-order) request.
-    pending: HashMap<u64, ros2_client::service::RmwRequestId>,
+    // Maps the integer id handed to Python back to the ROS2 request id (plus the
+    // time it was taken), so `send_response` can reply to the correct (possibly
+    // out-of-order) request. The insertion time bounds the map: stale entries
+    // from requests that never got a response are evicted in `take_request`.
+    pending: HashMap<u64, (ros2_client::service::RmwRequestId, Instant)>,
     next_id: u64,
 }
 
@@ -719,8 +738,10 @@ impl Ros2ServiceServer {
 
         // Deserialize the request under the request TypeInfo (guard clears the
         // thread-local on drop). Mirrors the daemon's `run_service_server`.
-        let received = {
-            let _guard = TypeInfoGuard::deserialize(self.request_type_info.clone());
+        // Release the GIL while waiting so other Python threads can run.
+        let request_type_info = self.request_type_info.clone();
+        let received = py.detach(|| {
+            let _guard = TypeInfoGuard::deserialize(request_type_info);
             futures::executor::block_on(async {
                 let recv = self.server.async_receive_request();
                 futures::pin_mut!(recv);
@@ -731,8 +752,8 @@ impl Ros2ServiceServer {
                         .map_err(|e| eyre!("failed to receive service request: {e:?}")),
                     futures::future::Either::Right(_) => Ok(None),
                 }
-            })?
-        };
+            })
+        })?;
 
         let Some((rmw_id, message)) = received else {
             return Ok(None);
@@ -741,9 +762,28 @@ impl Ros2ServiceServer {
             return Ok(None);
         };
 
+        // Bound `pending`: drop entries whose response was never sent (timed
+        // out), then enforce a hard cap by evicting the oldest. Without this a
+        // handler that skips `send_response` would leak entries forever.
+        let now = Instant::now();
+        self.pending
+            .retain(|_, (_, taken)| now.duration_since(*taken) < SERVICE_RESPONSE_TIMEOUT);
+        while self.pending.len() >= MAX_PENDING_REQUESTS {
+            if let Some(oldest) = self
+                .pending
+                .iter()
+                .min_by_key(|(_, (_, taken))| *taken)
+                .map(|(id, _)| *id)
+            {
+                self.pending.remove(&oldest);
+            } else {
+                break;
+            }
+        }
+
         let id = self.next_id;
         self.next_id = self.next_id.wrapping_add(1);
-        self.pending.insert(id, rmw_id);
+        self.pending.insert(id, (rmw_id, now));
         Ok(Some((id, data.to_pyarrow(py)?.unbind())))
     }
 
@@ -757,17 +797,33 @@ impl Ros2ServiceServer {
         request_id: u64,
         response: Bound<'_, PyAny>,
     ) -> eyre::Result<()> {
-        let rmw_id = self.pending.remove(&request_id).with_context(|| {
+        let py = response.py();
+        let (rmw_id, _taken) = self.pending.remove(&request_id).with_context(|| {
             format!("unknown request_id {request_id} (already answered or never taken)")
         })?;
         let array_data = pyarrow_to_array_data(&response)?;
 
-        let _guard = TypeInfoGuard::serialize(self.response_type_info.clone());
-        futures::executor::block_on(
-            self.server
-                .async_send_response(rmw_id, BridgeMessage(Some(array_data))),
-        )
-        .map_err(|e| eyre!("failed to send service response: {e:?}"))?;
+        // Release the GIL while sending; bound the send with a timeout so a
+        // congested transport can't freeze the Python thread indefinitely.
+        let response_type_info = self.response_type_info.clone();
+        py.detach(|| {
+            let _guard = TypeInfoGuard::serialize(response_type_info);
+            futures::executor::block_on(async {
+                let send = self
+                    .server
+                    .async_send_response(rmw_id, BridgeMessage(Some(array_data)));
+                futures::pin_mut!(send);
+                let delay = futures_timer::Delay::new(SERVICE_RESPONSE_TIMEOUT);
+                match futures::future::select(send, delay).await {
+                    futures::future::Either::Left((result, _)) => {
+                        result.map_err(|e| eyre!("failed to send service response: {e:?}"))
+                    }
+                    futures::future::Either::Right(_) => {
+                        eyre::bail!("service response send timed out")
+                    }
+                }
+            })
+        })?;
         Ok(())
     }
 }
@@ -793,22 +849,6 @@ fn pyarrow_to_array_data(data: &Bound<'_, PyAny>) -> eyre::Result<ArrayData> {
     };
 
     Ok(ArrayData::from_pyarrow_bound(&data)?)
-}
-
-/// Pick the `ServiceMapping` matching the active ROS2 middleware, from
-/// `RMW_IMPLEMENTATION` (primary) then `ROS_DISTRO` (fallback), defaulting to
-/// `Enhanced`. Mirrors the standalone bridge daemon (see dora-rs/dora#449).
-fn detect_service_mapping() -> ros2_client::ServiceMapping {
-    use ros2_client::ServiceMapping::{Cyclone, Enhanced};
-    match std::env::var("RMW_IMPLEMENTATION").ok().as_deref() {
-        Some("rmw_cyclonedds_cpp") => return Cyclone,
-        Some(_) => return Enhanced,
-        None => {}
-    }
-    match std::env::var("ROS_DISTRO").ok().as_deref() {
-        Some("galactic") => Cyclone,
-        _ => Enhanced,
-    }
 }
 
 pub fn create_dora_ros2_bridge_module(m: &Bound<'_, PyModule>) -> PyResult<()> {

--- a/libraries/extensions/ros2-bridge/python/src/lib.rs
+++ b/libraries/extensions/ros2-bridge/python/src/lib.rs
@@ -5,11 +5,11 @@ use std::{
     sync::Arc,
 };
 
-use ::dora_ros2_bridge::{ros2_client, rustdds};
 use arrow::{
     array::{ArrayData, make_array},
     pyarrow::{FromPyArrow, ToPyArrow},
 };
+use ::dora_ros2_bridge::{ros2_client, rustdds};
 use dora_ros2_bridge_msg_gen::types::Message;
 use eyre::{Context, ContextCompat, Result, eyre};
 use futures::{Stream, StreamExt};
@@ -18,7 +18,11 @@ use pyo3::{
     prelude::{pyclass, pymethods},
     types::{PyAnyMethods, PyDict, PyList, PyModule, PyModuleMethods},
 };
-use typed::{TypeInfo, TypedValue, deserialize::StructDeserializer};
+use std::time::Duration;
+use typed::{
+    BridgeMessage, BridgeServiceType, TypeInfo, TypeInfoGuard, TypedValue,
+    deserialize::StructDeserializer,
+};
 
 pub mod qos;
 pub mod typed;
@@ -90,11 +94,24 @@ impl Ros2Context {
             .map_err(|err| eyre!(err))
             .context("failed to parse ROS2 message types")?;
 
-        let mut messages = HashMap::new();
-        for message in packages.into_iter().flat_map(|p| p.messages.into_iter()) {
-            let entry: &mut HashMap<String, Message> =
-                messages.entry(message.package.clone()).or_default();
-            entry.insert(message.name.clone(), message);
+        // Mirror the standalone bridge daemon's `load_messages`: index plain
+        // messages plus the per-service and per-action request/response/goal/
+        // result/feedback messages, so service and action types resolve too.
+        let mut messages: HashMap<String, HashMap<String, Message>> = HashMap::new();
+        for package in packages {
+            let entry = messages.entry(package.name.clone()).or_default();
+            for message in package.messages {
+                entry.insert(message.name.clone(), message);
+            }
+            for service in package.services {
+                entry.insert(service.request.name.clone(), service.request);
+                entry.insert(service.response.name.clone(), service.response);
+            }
+            for action in package.actions {
+                entry.insert(action.goal.name.clone(), action.goal);
+                entry.insert(action.result.name.clone(), action.result);
+                entry.insert(action.feedback.name.clone(), action.feedback);
+            }
         }
 
         Ok(Self {
@@ -129,12 +146,27 @@ impl Ros2Context {
     ) -> eyre::Result<Ros2Node> {
         let name = ros2_client::NodeName::new(namespace, name)
             .map_err(|err| eyre!("invalid node name: {err}"))?;
+        let mut node = self
+            .context
+            .new_node(name, options.into())
+            .map_err(|e| eyre::eyre!("failed to create ROS2 node: {e:?}"))?;
+
+        // Start a spinner so service/discovery status events are processed.
+        let spinner_pool = futures::executor::ThreadPool::new()
+            .map_err(|e| eyre!("failed to create ros2 spinner pool: {e}"))?;
+        let spinner = node
+            .spinner()
+            .map_err(|e| eyre!("failed to create ros2 spinner: {e:?}"))?;
+        spinner_pool.spawn_ok(async move {
+            if let Err(err) = spinner.spin().await {
+                eprintln!("ros2 spinner stopped: {err:?}");
+            }
+        });
+
         Ok(Ros2Node {
-            node: self
-                .context
-                .new_node(name, options.into())
-                .map_err(|e| eyre::eyre!("failed to create ROS2 node: {e:?}"))?,
+            node,
             messages: self.messages.clone(),
+            _spinner_pool: spinner_pool,
         })
     }
 }
@@ -151,6 +183,10 @@ impl Ros2Context {
 pub struct Ros2Node {
     node: ros2_client::Node,
     messages: Arc<HashMap<String, HashMap<String, Message>>>,
+    // Keeps the ROS2 spinner task alive for the node's lifetime. ros2-client
+    // requires a running spinner for service/discovery status events
+    // (`wait_for_service` panics otherwise).
+    _spinner_pool: futures::executor::ThreadPool,
 }
 
 #[pymethods]
@@ -254,6 +290,162 @@ impl Ros2Node {
             deserializer: StructDeserializer::new(Cow::Owned(topic.type_info.clone())),
         })
     }
+
+    /// Create a ROS2 service client.
+    ///
+    /// Waits (bounded) for a matching service server to become available
+    /// before returning. ROS2 services require **reliable** QoS.
+    ///
+    /// ```python
+    /// client = ros2_node.create_service_client(
+    ///     "/add_two_ints", "example_interfaces/AddTwoInts",
+    ///     Ros2QosPolicies(reliable=True),
+    /// )
+    /// response = client.call(pa.array([{"a": 2, "b": 3}]))
+    /// ```
+    ///
+    /// warnings:
+    /// - dora Ros2 bridge functionality is considered **unstable**. It may be changed
+    ///   at any point without it being considered a breaking change.
+    ///
+    /// :type service_name: str
+    /// :type service_type: str
+    /// :type qos: dora.Ros2QosPolicies
+    /// :rtype: dora.Ros2ServiceClient
+    pub fn create_service_client(
+        &mut self,
+        service_name: &str,
+        service_type: String,
+        qos: qos::Ros2QosPolicies,
+    ) -> eyre::Result<Ros2ServiceClient> {
+        let (package, type_name, request_type_info, response_type_info) =
+            service_type_infos(&service_type, &self.messages)?;
+
+        let service_qos: rustdds::QosPolicies = qos.into();
+        let client = self
+            .node
+            .create_client::<BridgeServiceType>(
+                detect_service_mapping(),
+                &ros2_client::Name::new("/", service_name.trim_start_matches('/'))
+                    .map_err(|e| eyre!("failed to parse service name: {e}"))?,
+                &ros2_client::ServiceTypeName::new(&package, &type_name),
+                service_qos.clone(),
+                service_qos,
+            )
+            .map_err(|e| eyre!("failed to create service client: {e:?}"))?;
+
+        // Mirror the daemon: wait for the server before returning so the first
+        // `call()` does not race service discovery.
+        let ready = async {
+            for _ in 0..10 {
+                let wait = client.wait_for_service(&self.node);
+                futures::pin_mut!(wait);
+                let timeout = futures_timer::Delay::new(Duration::from_secs(2));
+                match futures::future::select(wait, timeout).await {
+                    futures::future::Either::Left(((), _)) => return Ok(()),
+                    futures::future::Either::Right(_) => {}
+                }
+            }
+            eyre::bail!("service `{service_name}` not available after 10 retries")
+        };
+        futures::executor::block_on(ready)?;
+
+        Ok(Ros2ServiceClient {
+            client,
+            request_type_info,
+            response_type_info,
+        })
+    }
+
+    /// Create a ROS2 service server.
+    ///
+    /// Drive it by polling [`Ros2ServiceServer::take_request`] and replying with
+    /// [`Ros2ServiceServer::send_response`]. ROS2 services require **reliable** QoS.
+    ///
+    /// ```python
+    /// server = ros2_node.create_service_server(
+    ///     "/add_two_ints", "example_interfaces/AddTwoInts",
+    ///     Ros2QosPolicies(reliable=True),
+    /// )
+    /// req = server.take_request(timeout_s=0.1)
+    /// if req is not None:
+    ///     request_id, value = req
+    ///     args = value[0].as_py()
+    ///     server.send_response(request_id, pa.array([{"sum": args["a"] + args["b"]}]))
+    /// ```
+    ///
+    /// warnings:
+    /// - dora Ros2 bridge functionality is considered **unstable**. It may be changed
+    ///   at any point without it being considered a breaking change.
+    ///
+    /// :type service_name: str
+    /// :type service_type: str
+    /// :type qos: dora.Ros2QosPolicies
+    /// :rtype: dora.Ros2ServiceServer
+    pub fn create_service_server(
+        &mut self,
+        service_name: &str,
+        service_type: String,
+        qos: qos::Ros2QosPolicies,
+    ) -> eyre::Result<Ros2ServiceServer> {
+        let (package, type_name, request_type_info, response_type_info) =
+            service_type_infos(&service_type, &self.messages)?;
+
+        let service_qos: rustdds::QosPolicies = qos.into();
+        let server = self
+            .node
+            .create_server::<BridgeServiceType>(
+                detect_service_mapping(),
+                &ros2_client::Name::new("/", service_name.trim_start_matches('/'))
+                    .map_err(|e| eyre!("failed to parse service name: {e}"))?,
+                &ros2_client::ServiceTypeName::new(&package, &type_name),
+                service_qos.clone(),
+                service_qos,
+            )
+            .map_err(|e| eyre!("failed to create service server: {e:?}"))?;
+
+        Ok(Ros2ServiceServer {
+            server,
+            request_type_info,
+            response_type_info,
+            pending: HashMap::new(),
+            next_id: 0,
+        })
+    }
+}
+
+/// Parse a `namespace/Service` (or `namespace::Service`) type string into its
+/// package + type name and the `_Request`/`_Response` `TypeInfo`s the bridge
+/// uses to (de)serialize each side. Shared by the service client and server.
+fn service_type_infos(
+    service_type: &str,
+    messages: &Arc<HashMap<String, HashMap<String, Message>>>,
+) -> eyre::Result<(String, String, TypeInfo<'static>, TypeInfo<'static>)> {
+    let (package, type_name) = match (service_type.split_once('/'), service_type.split_once("::")) {
+        (Some(t), None) => t,
+        (None, Some(t)) => t,
+        _ => eyre::bail!(
+            "Expected service type in the format `namespace/service` or `namespace::service`, such as `example_interfaces/AddTwoInts` but got: {service_type}"
+        ),
+    };
+
+    let request_type_info = TypeInfo {
+        package_name: package.to_owned().into(),
+        message_name: format!("{type_name}_Request").into(),
+        messages: messages.clone(),
+    };
+    let response_type_info = TypeInfo {
+        package_name: package.to_owned().into(),
+        message_name: format!("{type_name}_Response").into(),
+        messages: messages.clone(),
+    };
+
+    Ok((
+        package.to_owned(),
+        type_name.to_owned(),
+        request_type_info,
+        response_type_info,
+    ))
 }
 
 /// ROS2 Node Options
@@ -332,24 +524,7 @@ impl Ros2Publisher {
     /// :rtype: None
     ///
     pub fn publish(&self, data: Bound<'_, PyAny>) -> eyre::Result<()> {
-        let pyarrow = PyModule::import(data.py(), "pyarrow")?;
-
-        let data = if data.is_instance_of::<PyDict>() {
-            // convert to arrow struct scalar
-            pyarrow.getattr("scalar")?.call1((data,))?
-        } else {
-            data
-        };
-
-        let data = if data.is_instance(&pyarrow.getattr("StructScalar")?)? {
-            // convert to arrow array
-            let list = PyList::new(data.py(), [data]).context("Failed to create Py::List")?;
-            pyarrow.getattr("array")?.call1((list,))?
-        } else {
-            data
-        };
-
-        let value = arrow::array::ArrayData::from_pyarrow_bound(&data)?;
+        let value = pyarrow_to_array_data(&data)?;
         //// add type info to ensure correct serialization (e.g. struct types
         //// and map types need to be serialized differently)
         let typed_value = TypedValue {
@@ -440,6 +615,202 @@ impl Stream for Ros2SubscriptionStream {
     }
 }
 
+/// ROS2 service client. Create via [`Ros2Node::create_service_client`].
+///
+/// warnings:
+/// - dora Ros2 bridge functionality is considered **unstable**. It may be changed
+///   at any point without it being considered a breaking change.
+#[pyclass]
+#[non_exhaustive]
+pub struct Ros2ServiceClient {
+    client: ros2_client::Client<BridgeServiceType>,
+    request_type_info: TypeInfo<'static>,
+    response_type_info: TypeInfo<'static>,
+}
+
+#[pymethods]
+impl Ros2ServiceClient {
+    /// Send a request and block until the response arrives.
+    ///
+    /// The request must match the service's `_Request` structure as an Arrow
+    /// struct (e.g. `pa.array([{"a": 2, "b": 3}])`). Returns the `_Response`
+    /// as a pyarrow array. Raises on timeout (default 30s).
+    ///
+    /// :type request: pyarrow.Array
+    /// :type timeout_s: float, optional
+    /// :rtype: pyarrow.Array
+    #[pyo3(signature = (request, timeout_s=None))]
+    pub fn call(
+        &self,
+        request: Bound<'_, PyAny>,
+        timeout_s: Option<f64>,
+    ) -> eyre::Result<Py<PyAny>> {
+        let py = request.py();
+        let array_data = pyarrow_to_array_data(&request)?;
+
+        // Serialize the request under the request TypeInfo (guard clears the
+        // thread-local on drop).
+        let req_id = {
+            let _guard = TypeInfoGuard::serialize(self.request_type_info.clone());
+            self.client
+                .send_request(BridgeMessage(Some(array_data)))
+                .map_err(|e| eyre!("failed to send service request: {e:?}"))?
+        };
+
+        // NOTE: blocks holding the GIL, matching the rest of this binding
+        // (e.g. `Ros2Subscription::next`). Releasing the GIL here is a future
+        // refinement (pyo3 0.28 reworked the GIL-release API).
+        let timeout = Duration::from_secs_f64(timeout_s.unwrap_or(30.0));
+        let response = {
+            let _guard = TypeInfoGuard::deserialize(self.response_type_info.clone());
+            futures::executor::block_on(async {
+                let recv = self.client.async_receive_response(req_id);
+                futures::pin_mut!(recv);
+                let delay = futures_timer::Delay::new(timeout);
+                match futures::future::select(recv, delay).await {
+                    futures::future::Either::Left((result, _)) => {
+                        result.map_err(|e| eyre!("failed to receive service response: {e:?}"))
+                    }
+                    futures::future::Either::Right(_) => {
+                        eyre::bail!("service response timed out after {timeout:?}")
+                    }
+                }
+            })?
+        };
+
+        let data = response.0.context("service response contained no data")?;
+        Ok(data.to_pyarrow(py)?.unbind())
+    }
+}
+
+/// ROS2 service server. Create via [`Ros2Node::create_service_server`].
+///
+/// warnings:
+/// - dora Ros2 bridge functionality is considered **unstable**. It may be changed
+///   at any point without it being considered a breaking change.
+#[pyclass]
+#[non_exhaustive]
+pub struct Ros2ServiceServer {
+    server: ros2_client::Server<BridgeServiceType>,
+    request_type_info: TypeInfo<'static>,
+    response_type_info: TypeInfo<'static>,
+    // Maps the integer id handed to Python back to the ROS2 request id, so
+    // `send_response` can reply to the correct (possibly out-of-order) request.
+    pending: HashMap<u64, ros2_client::service::RmwRequestId>,
+    next_id: u64,
+}
+
+#[pymethods]
+impl Ros2ServiceServer {
+    /// Wait up to `timeout_s` (default 1s) for the next request.
+    ///
+    /// Returns `(request_id, request_array)`, or `None` if no request arrived
+    /// within the timeout. Pass `request_id` back to `send_response`.
+    ///
+    /// :type timeout_s: float, optional
+    /// :rtype: tuple[int, pyarrow.Array] | None
+    #[pyo3(signature = (timeout_s=None))]
+    pub fn take_request(
+        &mut self,
+        py: Python<'_>,
+        timeout_s: Option<f64>,
+    ) -> eyre::Result<Option<(u64, Py<PyAny>)>> {
+        let timeout = Duration::from_secs_f64(timeout_s.unwrap_or(1.0));
+
+        // Deserialize the request under the request TypeInfo (guard clears the
+        // thread-local on drop). Mirrors the daemon's `run_service_server`.
+        let received = {
+            let _guard = TypeInfoGuard::deserialize(self.request_type_info.clone());
+            futures::executor::block_on(async {
+                let recv = self.server.async_receive_request();
+                futures::pin_mut!(recv);
+                let delay = futures_timer::Delay::new(timeout);
+                match futures::future::select(recv, delay).await {
+                    futures::future::Either::Left((result, _)) => result
+                        .map(Some)
+                        .map_err(|e| eyre!("failed to receive service request: {e:?}")),
+                    futures::future::Either::Right(_) => Ok(None),
+                }
+            })?
+        };
+
+        let Some((rmw_id, message)) = received else {
+            return Ok(None);
+        };
+        let Some(data) = message.0 else {
+            return Ok(None);
+        };
+
+        let id = self.next_id;
+        self.next_id = self.next_id.wrapping_add(1);
+        self.pending.insert(id, rmw_id);
+        Ok(Some((id, data.to_pyarrow(py)?.unbind())))
+    }
+
+    /// Send the response for a request previously returned by `take_request`.
+    ///
+    /// :type request_id: int
+    /// :type response: pyarrow.Array
+    /// :rtype: None
+    pub fn send_response(
+        &mut self,
+        request_id: u64,
+        response: Bound<'_, PyAny>,
+    ) -> eyre::Result<()> {
+        let rmw_id = self.pending.remove(&request_id).with_context(|| {
+            format!("unknown request_id {request_id} (already answered or never taken)")
+        })?;
+        let array_data = pyarrow_to_array_data(&response)?;
+
+        let _guard = TypeInfoGuard::serialize(self.response_type_info.clone());
+        futures::executor::block_on(
+            self.server
+                .async_send_response(rmw_id, BridgeMessage(Some(array_data))),
+        )
+        .map_err(|e| eyre!("failed to send service response: {e:?}"))?;
+        Ok(())
+    }
+}
+
+/// Convert a pyarrow value (dict, StructScalar, or Array) into Arrow `ArrayData`.
+/// Shared by [`Ros2Publisher::publish`] and [`Ros2ServiceClient::call`].
+fn pyarrow_to_array_data(data: &Bound<'_, PyAny>) -> eyre::Result<ArrayData> {
+    let pyarrow = PyModule::import(data.py(), "pyarrow")?;
+
+    let data = if data.is_instance_of::<PyDict>() {
+        // convert to arrow struct scalar
+        pyarrow.getattr("scalar")?.call1((data,))?
+    } else {
+        data.clone()
+    };
+
+    let data = if data.is_instance(&pyarrow.getattr("StructScalar")?)? {
+        // convert to arrow array
+        let list = PyList::new(data.py(), [data]).context("Failed to create Py::List")?;
+        pyarrow.getattr("array")?.call1((list,))?
+    } else {
+        data
+    };
+
+    Ok(ArrayData::from_pyarrow_bound(&data)?)
+}
+
+/// Pick the `ServiceMapping` matching the active ROS2 middleware, from
+/// `RMW_IMPLEMENTATION` (primary) then `ROS_DISTRO` (fallback), defaulting to
+/// `Enhanced`. Mirrors the standalone bridge daemon (see dora-rs/dora#449).
+fn detect_service_mapping() -> ros2_client::ServiceMapping {
+    use ros2_client::ServiceMapping::{Cyclone, Enhanced};
+    match std::env::var("RMW_IMPLEMENTATION").ok().as_deref() {
+        Some("rmw_cyclonedds_cpp") => return Cyclone,
+        Some(_) => return Enhanced,
+        None => {}
+    }
+    match std::env::var("ROS_DISTRO").ok().as_deref() {
+        Some("galactic") => Cyclone,
+        _ => Enhanced,
+    }
+}
+
 pub fn create_dora_ros2_bridge_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Ros2Context>()?;
     m.add_class::<Ros2Node>()?;
@@ -447,6 +818,8 @@ pub fn create_dora_ros2_bridge_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Ros2Topic>()?;
     m.add_class::<Ros2Publisher>()?;
     m.add_class::<Ros2Subscription>()?;
+    m.add_class::<Ros2ServiceClient>()?;
+    m.add_class::<Ros2ServiceServer>()?;
     m.add_class::<qos::Ros2QosPolicies>()?;
     m.add_class::<qos::Ros2Durability>()?;
     m.add_class::<qos::Ros2Liveliness>()?;

--- a/libraries/extensions/ros2-bridge/src/lib.rs
+++ b/libraries/extensions/ros2-bridge/src/lib.rs
@@ -12,6 +12,43 @@ pub mod prelude {
 
 pub use prelude::*;
 
+/// Pick the [`ros2_client::ServiceMapping`] variant that matches the user's ROS2
+/// middleware, based on `RMW_IMPLEMENTATION` (primary) and `ROS_DISTRO`
+/// (fallback). Falls back to `Enhanced` with a `tracing::warn!` if neither env
+/// var gives a usable answer — `Enhanced` is the historical default and keeps
+/// existing setups working when env is unset.
+///
+/// Shared by the standalone bridge daemon and the Python bindings so their
+/// service/action wire mapping can never drift. See dora-rs/dora#449.
+pub fn detect_service_mapping() -> ros2_client::ServiceMapping {
+    match std::env::var("RMW_IMPLEMENTATION").ok().as_deref() {
+        Some("rmw_fastrtps_cpp") => return ros2_client::ServiceMapping::Enhanced,
+        Some("rmw_cyclonedds_cpp") => return ros2_client::ServiceMapping::Cyclone,
+        Some(other) => {
+            tracing::warn!(
+                "unknown RMW_IMPLEMENTATION `{other}`, falling back to \
+                 ServiceMapping::Enhanced (see dora-rs/dora#449)"
+            );
+            return ros2_client::ServiceMapping::Enhanced;
+        }
+        None => {}
+    }
+    match std::env::var("ROS_DISTRO").ok().as_deref() {
+        Some("humble" | "iron" | "jazzy" | "kilted" | "rolling") => {
+            ros2_client::ServiceMapping::Enhanced
+        }
+        Some("galactic") => ros2_client::ServiceMapping::Cyclone,
+        Some(other) => {
+            tracing::warn!(
+                "unknown ROS_DISTRO `{other}`, falling back to \
+                 ServiceMapping::Enhanced (see dora-rs/dora#449)"
+            );
+            ros2_client::ServiceMapping::Enhanced
+        }
+        None => ros2_client::ServiceMapping::Enhanced,
+    }
+}
+
 #[cfg(feature = "generate-messages")]
 pub mod messages {
     include!(env!("MESSAGES_PATH"));

--- a/scripts/qa/ci-nightly-jobs.sh
+++ b/scripts/qa/ci-nightly-jobs.sh
@@ -1142,6 +1142,15 @@ job_ros2_bridge() {
   timeout 600s cargo test -p dora-ros2-bridge-python
   timeout 1800s env QT_QPA_PLATFORM=offscreen cargo run -p dora-ros2-bridge --example rust-ros2-dataflow
   timeout 1800s env QT_QPA_PLATFORM=offscreen cargo run -p dora-ros2-bridge --example cxx-ros2-dataflow --features ros2-examples
+
+  # Python service client/server examples need the workspace node bindings.
+  uv venv --seed -p 3.12 .venv-ros2-bridge >/dev/null
+  # shellcheck disable=SC1091
+  source .venv-ros2-bridge/bin/activate
+  uv pip install -q -e apis/python/node pyarrow
+  timeout 1800s env QT_QPA_PLATFORM=offscreen cargo run -p dora-ros2-bridge --example python-ros2-dataflow-service-client
+  timeout 1800s env QT_QPA_PLATFORM=offscreen cargo run -p dora-ros2-bridge --example python-ros2-dataflow-service-server
+  deactivate
 }
 
 # -----------------------------------------------------------------------------

--- a/scripts/ros2dev.sh
+++ b/scripts/ros2dev.sh
@@ -8,8 +8,14 @@
 #
 #   scripts/ros2dev.sh build     Build the dev image.
 #   scripts/ros2dev.sh shell      Open an interactive shell (ROS2 pre-sourced).
-#   scripts/ros2dev.sh verify     Run the full CI ros2-bridge job (test + 3 examples).
+#   scripts/ros2dev.sh verify     Mirror the nightly ros2-bridge CI job (test + 3 examples).
 #   scripts/ros2dev.sh verify --quick   Test + Rust example only (faster smoke).
+#   scripts/ros2dev.sh qa         Release-QA: smoke-test EVERY ros2 example end-to-end.
+#
+# `qa` is the pre-release gate for the ROS2 bridge: since the bridge no longer
+# runs end-to-end on every PR (extension, small user base), run this on a Linux
+# box (or Docker) with ROS2 before cutting a release. Add new example targets to
+# the EXAMPLES list below as issue #1170 items land.
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
@@ -81,8 +87,70 @@ EOF
     "${COMPOSE[@]}" run --rm -e QUICK="$quick" ros2dev bash -lc "$SCRIPT"
     ;;
 
+  qa)
+    require_daemon
+    # Release-QA: run EVERY ros2 example end-to-end and report a pass/fail
+    # summary. Each example's run.rs self-spawns the ROS2 peer it needs
+    # (turtlesim, minimal service/client/pub/sub, action server) — all are
+    # installed in the dev image.
+    read -r -d '' SCRIPT <<'EOF' || true
+set -eo pipefail
+source /opt/ros/humble/setup.bash
+echo "== ros2 release QA — distro: $ROS_DISTRO  rustc: $(rustc --version)"
+
+# Python examples need the workspace node bindings on the path.
+uv pip install -q -e apis/python/node pyarrow
+
+echo "::: cargo test -p dora-ros2-bridge-python"
+cargo test -p dora-ros2-bridge-python
+
+# Every ros2 [[example]] target (see libraries/extensions/ros2-bridge/Cargo.toml).
+# Add new examples here as issue #1170 items land (action server, C++ service
+# server, parameter service, ...). `--features ros2-examples` is required by the
+# cxx/action targets and harmless for the rest.
+EXAMPLES=(
+  rust-ros2-dataflow
+  rust-ros2-dataflow-topic-pub
+  rust-ros2-dataflow-topic-sub
+  rust-ros2-dataflow-service-client
+  rust-ros2-dataflow-service-server
+  rust-ros2-dataflow-action-client
+  python-ros2-dataflow
+  python-ros2-dataflow-service-client
+  python-ros2-dataflow-service-server
+  cxx-ros2-dataflow
+  cxx-ros2-dataflow-action-client
+)
+
+passed=()
+failed=()
+for ex in "${EXAMPLES[@]}"; do
+  echo "::: running example: $ex"
+  if QT_QPA_PLATFORM=offscreen timeout 600 \
+       cargo run -q -p dora-ros2-bridge --example "$ex" --features ros2-examples; then
+    passed+=("$ex")
+    echo "    PASS  $ex"
+  else
+    failed+=("$ex")
+    echo "    FAIL  $ex"
+  fi
+done
+
+echo
+echo "============================================================"
+echo "ros2-bridge release QA: ${#passed[@]}/${#EXAMPLES[@]} examples passed"
+if [ ${#failed[@]} -gt 0 ]; then
+  echo "FAILED:"; printf '  - %s\n' "${failed[@]}"
+  exit 1
+fi
+echo "ALL GREEN"
+EOF
+
+    "${COMPOSE[@]}" run --rm ros2dev bash -lc "$SCRIPT"
+    ;;
+
   *)
-    echo "usage: scripts/ros2dev.sh {build|shell|verify [--quick]}" >&2
+    echo "usage: scripts/ros2dev.sh {build|shell|verify [--quick]|qa}" >&2
     exit 2
     ;;
 esac

--- a/scripts/ros2dev.sh
+++ b/scripts/ros2dev.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# ROS2-bridge dev harness for macOS — issue #1170, Phase 0.
+#
+# Reproduces the nightly `ros2-bridge` CI job (.github/workflows/nightly.yml)
+# inside a single Linux+ROS2-Humble container, since ROS2 cannot run natively on
+# macOS. dora and the ROS2 nodes share one network namespace, so DDS discovery
+# behaves exactly as on the CI runner.
+#
+#   scripts/ros2dev.sh build     Build the dev image.
+#   scripts/ros2dev.sh shell      Open an interactive shell (ROS2 pre-sourced).
+#   scripts/ros2dev.sh verify     Run the full CI ros2-bridge job (test + 3 examples).
+#   scripts/ros2dev.sh verify --quick   Test + Rust example only (faster smoke).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+COMPOSE=(docker compose -f docker-compose.ros2dev.yml)
+
+require_daemon() {
+  if ! docker info >/dev/null 2>&1; then
+    echo "error: Docker daemon not reachable. Start Docker Desktop (open -a Docker) and retry." >&2
+    exit 1
+  fi
+}
+
+cmd="${1:-verify}"
+shift || true
+
+case "$cmd" in
+  build)
+    require_daemon
+    "${COMPOSE[@]}" build
+    ;;
+
+  shell)
+    require_daemon
+    "${COMPOSE[@]}" run --rm ros2dev bash
+    ;;
+
+  verify)
+    require_daemon
+    quick=false
+    [ "${1:-}" = "--quick" ] && quick=true
+
+    # The body runs INSIDE the container. Mirrors nightly.yml `ros2-bridge`
+    # step-for-step. The Rust example self-spawns turtlesim_node and
+    # examples_rclcpp_minimal_service via `ros2 run`, so no separate ROS2
+    # process is needed.
+    read -r -d '' SCRIPT <<'EOF' || true
+# No `set -u`: ROS2's setup.bash references unbound vars (AMENT_TRACE_SETUP_FILES).
+set -eo pipefail
+source /opt/ros/humble/setup.bash
+echo "== AMENT_PREFIX_PATH=${AMENT_PREFIX_PATH}"
+echo "== ros2 distro: $ROS_DISTRO  rustc: $(rustc --version)  python: $(python --version)"
+
+echo "::: [1/4] cargo test -p dora-ros2-bridge-python"
+cargo test -p dora-ros2-bridge-python
+
+echo "::: [2/4] Rust ROS2 bridge example (rust-ros2-dataflow)"
+QT_QPA_PLATFORM=offscreen cargo run -p dora-ros2-bridge --example rust-ros2-dataflow
+
+if [ "${QUICK:-false}" = "true" ]; then
+  echo "::: quick mode — skipping C++ and Python examples"
+  echo "::: ros2-bridge quick verify OK"
+  exit 0
+fi
+
+echo "::: [3/4] C++ ROS2 bridge example (cxx-ros2-dataflow)"
+QT_QPA_PLATFORM=offscreen cargo run -p dora-ros2-bridge --example cxx-ros2-dataflow --features ros2-examples
+
+echo "::: [4/4] Python ROS2 bridge examples (topic + service client/server)"
+# /opt/venv already has pyarrow; add the workspace node bindings (matches CI's
+# `uv pip install -e apis/python/node`).
+uv pip install -e apis/python/node
+QT_QPA_PLATFORM=offscreen cargo run -p dora-ros2-bridge --example python-ros2-dataflow
+QT_QPA_PLATFORM=offscreen cargo run -p dora-ros2-bridge --example python-ros2-dataflow-service-client
+QT_QPA_PLATFORM=offscreen cargo run -p dora-ros2-bridge --example python-ros2-dataflow-service-server
+
+echo "::: ros2-bridge full verify OK"
+EOF
+
+    "${COMPOSE[@]}" run --rm -e QUICK="$quick" ros2dev bash -lc "$SCRIPT"
+    ;;
+
+  *)
+    echo "usage: scripts/ros2dev.sh {build|shell|verify [--quick]}" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary

Adds the **Python service client and server** surface to the dora ROS2 bridge — the highest-leverage open item in the #1170 tracker (the Python API previously had only topic pub/sub, and this also unblocks a future Python parameter service).

New pyo3 API on the existing dynamic bridge (wraps `ros2-client` over `BridgeServiceType`, mirroring the standalone bridge daemon):

```python
client = ros2_node.create_service_client("/add_two_ints", "example_interfaces/AddTwoInts", Ros2QosPolicies(reliable=True))
response = client.call(pa.array([{"a": 2, "b": 3}]))   # -> pa.array([{"sum": 5}])

server = ros2_node.create_service_server("/add_two_ints", "example_interfaces/AddTwoInts", Ros2QosPolicies(reliable=True))
req = server.take_request(timeout_s=0.1)
if req is not None:
    request_id, value = req
    args = value[0].as_py()
    server.send_response(request_id, pa.array([{"sum": args["a"] + args["b"]}]))
```

Both reuse the daemon's serialization discipline (`TypeInfoGuard` + `BridgeMessage`, `_Request`/`_Response` `TypeInfo`s). The server uses the one-shot `async_receive_request` / `async_send_response` (both `&self`), so no persisted request stream is needed.

### Two supporting fixes the service path requires

- **Spinner**: `Ros2Node` now starts a `ros2-client` spinner (kept alive for the node's lifetime), mirroring the daemon's `create_ros_node`. Without a running spinner, `wait_for_service` panics (`status_receiver()` needs one). Topic pub/sub is unaffected.
- **Message loading**: `Ros2Context` now indexes per-service and per-action request/response/goal/result/feedback messages (mirroring the daemon's `load_messages`), so service/action types resolve. Previously only plain messages were indexed.

### Also

- Shared `pyarrow_to_array_data` helper (extracted from `publish`) and a `service_type_infos` helper.
- `detect_service_mapping` (RMW/distro -> `Enhanced`/`Cyclone`).
- Examples `examples/ros2-bridge/python/{service-client,service-server}` (the server example is a self-contained dora -> dora round-trip).
- Type stubs in `apis/python/node/dora/__init__.pyi`.
- New `futures-timer` dependency for call/request timeouts.

## Test plan

ROS2 examples run as cargo examples in the nightly `ros2-bridge` job (not `tests/example-smoke.rs`). This PR wires the two new examples into `.github/workflows/nightly.yml` and `scripts/qa/ci-nightly-jobs.sh`.

Verified locally on ROS2 Humble (Docker):

- [x] `cargo clippy -p dora-ros2-bridge-python -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test -p dora-ros2-bridge-python` passes
- [x] `python-ros2-dataflow-service-client` round-trips against a real `examples_rclcpp_minimal_service`
- [x] `python-ros2-dataflow-service-server` self-contained dora client -> server round-trip
- [x] regression: existing topic (`python-ros2-dataflow`) and client examples still pass

> [!NOTE]
> Verified on macOS/arm64 via Docker; the nightly job runs on ubuntu-22.04 + Humble. The blocking calls hold the GIL (matching the existing `Ros2Subscription::next`); releasing it is a possible follow-up (pyo3 0.28 reworked the GIL-release API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
