### PR TITLE
fix(examples): bump rust-dataflow-git pinned rev to 1.0.0-rc1 (unbreaks examples-linux)

### DIFF
--- a/examples/rust-dataflow-git/dataflow.yml
+++ b/examples/rust-dataflow-git/dataflow.yml
@@ -6,7 +6,7 @@
 nodes:
   - id: rust-node
     git: https://github.com/dora-rs/dora.git
-    rev: 9f4242b69720dd6c4da44260cc4102541dcf7d70
+    rev: f40b5e7e8aa10a6faafdcebd37c7e440741722ed
     build: cargo build -p rust-dataflow-example-node
     path: target/debug/rust-dataflow-example-node
     inputs:
@@ -16,7 +16,7 @@ nodes:
 
   - id: rust-status-node
     git: https://github.com/dora-rs/dora.git
-    rev: 9f4242b69720dd6c4da44260cc4102541dcf7d70
+    rev: f40b5e7e8aa10a6faafdcebd37c7e440741722ed
     build: cargo build -p rust-dataflow-example-status-node
     path: target/debug/rust-dataflow-example-status-node
     inputs:
@@ -27,7 +27,7 @@ nodes:
 
   - id: rust-sink
     git: https://github.com/dora-rs/dora.git
-    rev: 9f4242b69720dd6c4da44260cc4102541dcf7d70
+    rev: f40b5e7e8aa10a6faafdcebd37c7e440741722ed
     build: cargo build -p rust-dataflow-example-sink
     path: target/debug/rust-dataflow-example-sink
     inputs:


### PR DESCRIPTION
## Summary

Fixes the `examples-linux` / `examples-macos` CI failures that have been red since **#1968** (the "bump to 1.0.0-rc1" commit) — affecting **every PR branched after it**.

## Root cause

#1968 bumped the workspace **0.2.1 → 1.0.0-rc1** (Cargo.toml + Cargo.lock only). But the `rust-dataflow-git` example pins its git-sourced nodes to commit **`9f4242b6`** — which is still at **v0.2.1**:

```yaml
rev: 9f4242b69720dd6c4da44260cc4102541dcf7d70   # dora v0.2.1
```

dora's node↔daemon handshake **gates on version compatibility**:
- node embeds `CARGO_PKG_VERSION` (`libraries/message/src/node_to_daemon.rs:77`)
- daemon calls `register_request.check_version()` on registration (`binaries/daemon/src/node_communication/mod.rs:118`)
- `versions_compatible(1.0.0-rc1, 0.2.1)` (`libraries/message/src/lib.rs:105`): `^1.0.0-rc1` doesn't match `0.2.1`, and `^0.2.1` doesn't match `1.0.0-rc1` → **incompatible**

So the v0.2.1 git-sourced nodes are **rejected** by the v1.0.0-rc1 local daemon → `rust-dataflow-git` fails → `examples-linux`/`examples-macos` go red.

The example's own `dataflow.yml` comment documents exactly this failure mode:

> *"Update `rev:` when a message-format-breaking change lands on main — otherwise the CI job catches the mismatch."*

The version bump **was** that change, and #1968 missed the `rev:` update.

## Fix

Pin the `rev:` (3 nodes) to **`f40b5e7e`** — the #1968 commit itself, the first commit at v1.0.0-rc1. The git-sourced nodes then embed v1.0.0-rc1 and match the daemon. One-line change per node; the `git/` cache is gitignored so the diff is just the 3 `rev:` lines.

## Verification

- Root cause confirmed in code (the version-check path above).
- **End-to-end is verified by this PR's own `examples-linux` / `examples-macos` (x86)** — the authoritative environment.
- Local arm64 (Docker) reproduction got past disk limits but is then blocked by an **unrelated `rustix`-on-aarch64 compile error** in the sink node's dependency tree (`console` → `rustix 1.1.4`). That's not the version fix and not present on x86: #1968 didn't touch `rustix`/`console`, and the prior rev `9f4242b6` (same non-dora deps) built fine on x86 when `examples-linux` was green. So x86 CI is unaffected by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
