### PR TITLE
feat(cli): add optional SSH `port` to cluster.yml machine config

### DIFF
--- a/binaries/cli/src/command/cluster/config.rs
+++ b/binaries/cli/src/command/cluster/config.rs
@@ -33,6 +33,9 @@ pub struct MachineConfig {
     pub host: String,
     #[serde(default)]
     pub user: Option<String>,
+    /// Custom SSH port. Defaults to the SSH client default (22).
+    #[serde(default)]
+    pub port: Option<u16>,
     /// Labels for label-based scheduling (e.g. `gpu: "true"`, `arch: arm64`).
     #[serde(default)]
     pub labels: BTreeMap<String, String>,
@@ -90,7 +93,25 @@ mod tests {
         assert_eq!(cfg.machines.len(), 1);
         assert_eq!(cfg.machines[0].id, "arm");
         assert!(cfg.machines[0].user.is_none());
+        assert!(cfg.machines[0].port.is_none());
         assert!(cfg.machines[0].labels.is_empty());
+    }
+
+    #[test]
+    fn parse_with_port() {
+        let f = write_yaml(
+            "coordinator:\n  addr: 10.0.0.1\nmachines:\n  - id: a\n    host: 10.0.0.2\n    port: 2222\n",
+        );
+        let cfg = ClusterConfig::load(f.path()).unwrap();
+        assert_eq!(cfg.machines[0].port, Some(2222));
+    }
+
+    #[test]
+    fn reject_invalid_port() {
+        let f = write_yaml(
+            "coordinator:\n  addr: 10.0.0.1\nmachines:\n  - id: a\n    host: 10.0.0.2\n    port: 99999\n",
+        );
+        assert!(ClusterConfig::load(f.path()).is_err());
     }
 
     #[test]

--- a/binaries/cli/src/command/cluster/install.rs
+++ b/binaries/cli/src/command/cluster/install.rs
@@ -62,7 +62,7 @@ WantedBy=multi-user.target
             );
 
             println!("Installing {service_name} on {} ({target})", machine.id);
-            let result = run_ssh(&target, &cmd);
+            let result = run_ssh(&target, machine.port, &cmd);
             record_ssh_result(
                 &mut failures,
                 &machine.id,

--- a/binaries/cli/src/command/cluster/mod.rs
+++ b/binaries/cli/src/command/cluster/mod.rs
@@ -73,18 +73,21 @@ pub(super) fn format_labels_arg(labels: &BTreeMap<String, String>) -> String {
 }
 
 /// Run a command on a remote machine via SSH. Returns whether it succeeded.
-pub(super) fn run_ssh(target: &str, cmd: &str) -> eyre::Result<bool> {
-    let status = std::process::Command::new("ssh")
-        .args([
-            "-o",
-            "BatchMode=yes",
-            "-o",
-            "ConnectTimeout=10",
-            "-o",
-            "StrictHostKeyChecking=accept-new",
-            target,
-            cmd,
-        ])
+pub(super) fn run_ssh(target: &str, port: Option<u16>, cmd: &str) -> eyre::Result<bool> {
+    let mut command = std::process::Command::new("ssh");
+    command.args([
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "ConnectTimeout=10",
+        "-o",
+        "StrictHostKeyChecking=accept-new",
+    ]);
+    if let Some(p) = port {
+        command.args(["-p", &p.to_string()]);
+    }
+    command.args([target, cmd]);
+    let status = command
         .status()
         .with_context(|| format!("failed to run ssh to {target}"))?;
     Ok(status.success())

--- a/binaries/cli/src/command/cluster/uninstall.rs
+++ b/binaries/cli/src/command/cluster/uninstall.rs
@@ -41,7 +41,7 @@ impl Executable for Uninstall {
             );
 
             println!("Uninstalling {service_name} from {} ({target})", machine.id);
-            let result = run_ssh(&target, &cmd);
+            let result = run_ssh(&target, machine.port, &cmd);
             record_ssh_result(
                 &mut failures,
                 &machine.id,

--- a/binaries/cli/src/command/cluster/up.rs
+++ b/binaries/cli/src/command/cluster/up.rs
@@ -70,7 +70,7 @@ impl Executable for Up {
             );
 
             println!("Starting daemon on {} ({})", machine.id, target);
-            match run_ssh(&target, &remote_cmd) {
+            match run_ssh(&target, machine.port, &remote_cmd) {
                 Ok(true) => {}
                 Ok(false) => {
                     let msg = "ssh command failed".to_string();

--- a/binaries/cli/src/command/cluster/upgrade.rs
+++ b/binaries/cli/src/command/cluster/upgrade.rs
@@ -49,18 +49,17 @@ impl Executable for Upgrade {
             println!("Upgrading {} ({target})...", machine.id);
 
             // 1. SCP binary
-            let scp_status = std::process::Command::new("scp")
-                .args([
-                    "-o",
-                    "BatchMode=yes",
-                    "-o",
-                    "ConnectTimeout=10",
-                    local_binary
-                        .to_str()
-                        .ok_or_else(|| eyre::eyre!("local binary path is not valid UTF-8"))?,
-                    &format!("{target}:/usr/local/bin/dora"),
-                ])
-                .status();
+            let local_binary_str = local_binary
+                .to_str()
+                .ok_or_else(|| eyre::eyre!("local binary path is not valid UTF-8"))?;
+            let mut scp = std::process::Command::new("scp");
+            scp.args(["-o", "BatchMode=yes", "-o", "ConnectTimeout=10"]);
+            if let Some(p) = machine.port {
+                // scp uses `-P` (capital) for the port; `-p` means "preserve mtimes"
+                scp.args(["-P", &p.to_string()]);
+            }
+            scp.args([local_binary_str, &format!("{target}:/usr/local/bin/dora")]);
+            let scp_status = scp.status();
 
             match scp_status {
                 Ok(s) if s.success() => {}
@@ -80,7 +79,7 @@ impl Executable for Upgrade {
 
             // 2. Restart systemd service
             let restart_cmd = format!("sudo systemctl restart {service_name}");
-            match run_ssh(&target, &restart_cmd) {
+            match run_ssh(&target, machine.port, &restart_cmd) {
                 Ok(true) => {}
                 _ => {
                     let msg = "systemctl restart failed".to_string();

--- a/docs/distributed-deployment.md
+++ b/docs/distributed-deployment.md
@@ -124,6 +124,7 @@ machines:
   - id: edge-01              # Unique machine identifier (required)
     host: 10.0.0.2           # SSH-reachable hostname or IP (required)
     user: ubuntu              # SSH user (optional, defaults to current user)
+    port: 2222                # SSH port (optional, defaults to 22)
     labels:                   # Key-value labels for scheduling (optional)
       gpu: "true"
       arch: arm64
@@ -150,6 +151,7 @@ machines:
 | `id` | string | (required) | Unique machine identifier, used in `_unstable_deploy.machine` |
 | `host` | string | (required) | SSH-reachable hostname or IP address |
 | `user` | string | current user | SSH username |
+| `port` | u16 | `22` | SSH port. Set when sshd listens on a non-standard port (e.g., containerized or hardened deployments). Applied to both `ssh` (`-p`) and `scp` (`-P`). |
 | `labels` | map | empty | Key-value pairs for label-based scheduling |
 
 ### Validation Rules


### PR DESCRIPTION
Adds an optional `port: u16` field to `MachineConfig`, threaded into the `ssh` (`-p`) and `scp` (`-P`) invocations used by `dora cluster up`, `install`, `uninstall`, and `upgrade`. Configs without `port:` continue to use the SSH client default (22) — fully backward compatible.

Motivated by sshd on non-standard ports (containerized / hardened deployments) and as a prerequisite for an upcoming cluster end-to-end test that runs sshd on a non-22 port on a CI runner.