### PR TITLE
feat(cli): add optional `daemon_port` to cluster.yml machine config

### DIFF
--- a/binaries/cli/src/command/cluster/config.rs
+++ b/binaries/cli/src/command/cluster/config.rs
@@ -71,6 +71,12 @@ impl ClusterConfig {
             if m.host.is_empty() {
                 bail!("machine `{}` host must not be empty", m.id);
             }
+            // Reject daemon_port = 0: the daemon would bind an ephemeral port
+            // but exports DORA_DAEMON_LOCAL_LISTEN_PORT=0 to spawned nodes
+            // (binaries/cli/src/command/daemon.rs), so they fail to connect.
+            if m.daemon_port == Some(0) {
+                bail!("machine `{}` daemon_port must not be 0", m.id);
+            }
         }
         Ok(())
     }
@@ -118,6 +124,15 @@ mod tests {
             "coordinator:\n  addr: 10.0.0.1\nmachines:\n  - id: a\n    host: 10.0.0.2\n    daemon_port: 99999\n",
         );
         assert!(ClusterConfig::load(f.path()).is_err());
+    }
+
+    #[test]
+    fn reject_zero_daemon_port() {
+        let f = write_yaml(
+            "coordinator:\n  addr: 10.0.0.1\nmachines:\n  - id: a\n    host: 10.0.0.2\n    daemon_port: 0\n",
+        );
+        let err = ClusterConfig::load(f.path()).unwrap_err();
+        assert!(err.to_string().contains("daemon_port must not be 0"));
     }
 
     #[test]

--- a/binaries/cli/src/command/cluster/config.rs
+++ b/binaries/cli/src/command/cluster/config.rs
@@ -36,6 +36,11 @@ pub struct MachineConfig {
     /// Custom SSH port. Defaults to the SSH client default (22).
     #[serde(default)]
     pub port: Option<u16>,
+    /// Custom daemon local-listen port. Defaults to 53291.
+    /// Set when running multiple daemons on the same host
+    /// (see `examples/multiple-daemons`).
+    #[serde(default)]
+    pub daemon_port: Option<u16>,
     /// Labels for label-based scheduling (e.g. `gpu: "true"`, `arch: arm64`).
     #[serde(default)]
     pub labels: BTreeMap<String, String>,
@@ -94,7 +99,25 @@ mod tests {
         assert_eq!(cfg.machines[0].id, "arm");
         assert!(cfg.machines[0].user.is_none());
         assert!(cfg.machines[0].port.is_none());
+        assert!(cfg.machines[0].daemon_port.is_none());
         assert!(cfg.machines[0].labels.is_empty());
+    }
+
+    #[test]
+    fn parse_with_daemon_port() {
+        let f = write_yaml(
+            "coordinator:\n  addr: 10.0.0.1\nmachines:\n  - id: a\n    host: 10.0.0.2\n    daemon_port: 53292\n",
+        );
+        let cfg = ClusterConfig::load(f.path()).unwrap();
+        assert_eq!(cfg.machines[0].daemon_port, Some(53292));
+    }
+
+    #[test]
+    fn reject_invalid_daemon_port() {
+        let f = write_yaml(
+            "coordinator:\n  addr: 10.0.0.1\nmachines:\n  - id: a\n    host: 10.0.0.2\n    daemon_port: 99999\n",
+        );
+        assert!(ClusterConfig::load(f.path()).is_err());
     }
 
     #[test]

--- a/binaries/cli/src/command/cluster/install.rs
+++ b/binaries/cli/src/command/cluster/install.rs
@@ -5,7 +5,10 @@ use clap::Args;
 use crate::command::{Executable, default_tracing};
 
 use super::config::ClusterConfig;
-use super::{format_labels_arg, print_summary, record_ssh_result, run_ssh, ssh_target};
+use super::{
+    format_daemon_port_arg, format_labels_arg, print_summary, record_ssh_result, run_ssh,
+    ssh_target,
+};
 
 /// Install dora-daemon as a systemd service on each machine.
 ///
@@ -32,6 +35,7 @@ impl Executable for Install {
         for machine in &config.machines {
             let target = ssh_target(machine);
             let labels_arg = format_labels_arg(&machine.labels);
+            let daemon_port_arg = format_daemon_port_arg(machine.daemon_port);
             let service_name = format!("dora-daemon-{}", machine.id);
 
             let unit = format!(
@@ -42,7 +46,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-ExecStart=dora daemon --machine-id {id} --coordinator-addr {addr} --coordinator-port {port}{labels} --quiet
+ExecStart=dora daemon --machine-id {id} --coordinator-addr {addr} --coordinator-port {port}{daemon_port_arg}{labels} --quiet
 Restart=on-failure
 RestartSec=5
 

--- a/binaries/cli/src/command/cluster/mod.rs
+++ b/binaries/cli/src/command/cluster/mod.rs
@@ -72,6 +72,14 @@ pub(super) fn format_labels_arg(labels: &BTreeMap<String, String>) -> String {
     }
 }
 
+/// Format the `--local-listen-port <p>` argument string.
+pub(super) fn format_daemon_port_arg(daemon_port: Option<u16>) -> String {
+    match daemon_port {
+        Some(p) => format!(" --local-listen-port {p}"),
+        None => String::new(),
+    }
+}
+
 /// Run a command on a remote machine via SSH. Returns whether it succeeded.
 pub(super) fn run_ssh(target: &str, port: Option<u16>, cmd: &str) -> eyre::Result<bool> {
     let mut command = std::process::Command::new("ssh");

--- a/binaries/cli/src/command/cluster/up.rs
+++ b/binaries/cli/src/command/cluster/up.rs
@@ -17,7 +17,9 @@ use crate::{
 };
 
 use super::config::ClusterConfig;
-use super::{format_labels_arg, query_connected_daemons, run_ssh, ssh_target};
+use super::{
+    format_daemon_port_arg, format_labels_arg, query_connected_daemons, run_ssh, ssh_target,
+};
 
 /// Bring up a multi-machine cluster from a cluster.yml file.
 ///
@@ -61,8 +63,9 @@ impl Executable for Up {
         for machine in &config.machines {
             let target = ssh_target(machine);
             let labels_arg = format_labels_arg(&machine.labels);
+            let daemon_port_arg = format_daemon_port_arg(machine.daemon_port);
             let remote_cmd = format!(
-                "nohup dora daemon --machine-id {id} --coordinator-addr {addr} --coordinator-port {port}{labels} --quiet > /tmp/dora-daemon-{id}.log 2>&1 &",
+                "nohup dora daemon --machine-id {id} --coordinator-addr {addr} --coordinator-port {port}{daemon_port_arg}{labels} --quiet > /tmp/dora-daemon-{id}.log 2>&1 &",
                 id = machine.id,
                 addr = config.coordinator.addr,
                 port = config.coordinator.port,

--- a/docs/distributed-deployment.md
+++ b/docs/distributed-deployment.md
@@ -125,6 +125,7 @@ machines:
     host: 10.0.0.2           # SSH-reachable hostname or IP (required)
     user: ubuntu              # SSH user (optional, defaults to current user)
     port: 2222                # SSH port (optional, defaults to 22)
+    daemon_port: 53291        # Daemon local-listen port (optional, defaults to 53291)
     labels:                   # Key-value labels for scheduling (optional)
       gpu: "true"
       arch: arm64
@@ -152,6 +153,7 @@ machines:
 | `host` | string | (required) | SSH-reachable hostname or IP address |
 | `user` | string | current user | SSH username |
 | `port` | u16 | `22` | SSH port. Set when sshd listens on a non-standard port (e.g., containerized or hardened deployments). Applied to both `ssh` (`-p`) and `scp` (`-P`). |
+| `daemon_port` | u16 | `53291` | Daemon local-listen port (passed to `dora daemon --local-listen-port`). Set when running multiple `dora daemon` instances on the same host so each daemon binds a unique port. See [`examples/multiple-daemons/`](../examples/multiple-daemons/). |
 | `labels` | map | empty | Key-value pairs for label-based scheduling |
 
 ### Validation Rules


### PR DESCRIPTION

Adds an optional `daemon_port: u16` field to `MachineConfig`, passed as `dora daemon --local-listen-port` from both `dora cluster up` and `dora cluster install`. Configs without `daemon_port:` keep the existing default of 53291 — fully backward compatible.

Required when running multiple `dora daemon` instances on the same host. The existing [`examples/multiple-daemons/`](examples/multiple-daemons/) example already demonstrates the manual form of the same pattern. Also a prerequisite for an upcoming cluster end-to-end test that points three machines at the same loopback host with distinct daemon ports.