### PR TITLE
docs(ros2-bridge): align examples with a capability matrix + Rust parameter example

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1491,7 +1491,8 @@ jobs:
           QT_QPA_PLATFORM: offscreen
         run: |
           source /opt/ros/humble/setup.bash &&
-          cargo run -p dora-ros2-bridge --example rust-ros2-dataflow
+          cargo run -p dora-ros2-bridge --example rust-ros2-dataflow &&
+          cargo run -p dora-ros2-bridge --example rust-ros2-dataflow-parameter
       - name: Rust ROS2 Bridge action examples
         # x86 is the oracle for the Rust action client/server: the macOS arm64
         # Docker harness cannot complete the deferred get_result service round-trip

--- a/examples/ros2-bridge/README.md
+++ b/examples/ros2-bridge/README.md
@@ -1,0 +1,81 @@
+# `ros2-bridge` examples
+
+These examples show how to bridge between ROS2 and dora. dora speaks the ROS2
+wire protocol directly over a pure-Rust DDS stack (`ros2-client` + `rustdds`) and
+never links `rcl`/`rclcpp`/`rclpy`, so a sourced ROS2 install is only needed for
+the examples that talk to a *real* ROS2 node (e.g. `turtlesim`, or an `rclcpp`
+peer).
+
+For the full feature reference (architecture, the two bridge surfaces, and the
+known limitations) see [`docs/ros2-bridge.md`](../../docs/ros2-bridge.md), also
+published in the guide under *Advanced → ROS2 bridge*.
+
+## Two surfaces
+
+1. **Native code APIs** — generated Rust/C++ types (from the ROS2 message
+   definitions) plus the Python bindings. You write a dora node that constructs
+   a `ros2-client` node and publishes/subscribes/calls services/actions. The
+   per-language subdirectories below demonstrate this surface.
+2. **YAML / dynamic bridge** — no codegen: a daemon-spawnable bridge node mapping
+   ROS2 topics/services/actions to dora inputs/outputs via the dataflow YAML. See
+   the `yaml-bridge*` directories.
+
+## Capability × language matrix (native APIs)
+
+| Capability      | Rust                       | Python              | C++              |
+| --------------- | -------------------------- | ------------------- | ---------------- |
+| topic pub/sub   | `topic-pub`, `topic-sub`   | (in `turtle`)       | (in `turtle`)    |
+| service client  | `service-client`           | `service-client`    | —                |
+| service server  | `service-server`           | `service-server`    | `service-server` |
+| action client   | `action-client`            | `action-client`     | `action-client`  |
+| action server   | `action-server`            | `action-server`     | `action-server`  |
+| parameters      | `parameter`                | `parameter`         | —                |
+| turtlesim demo  | `turtle`                   | `turtle`            | `turtle`         |
+
+Empty cells are intentional, not missing work: each protocol surface is
+demonstrated in at least one language, and the C++ examples focus on the
+codegen surfaces delivered for [#1170](https://github.com/dora-rs/dora/issues/1170)
+(service/action servers + an action client). Topic pub/sub and parameters are
+covered by the Rust and Python examples.
+
+## Running
+
+Each example is wired as a Cargo `[[example]]` of the `dora-ros2-bridge` crate
+(its `run.rs` builds the dataflow and launches it, spawning any ROS2 peer it
+needs). Run them by name:
+
+```bash
+# self-contained (no ROS2 install needed): pure-Rust DDS only
+cargo run -p dora-ros2-bridge --example rust-ros2-dataflow-parameter
+
+# talks to a real ROS2 node / rclcpp peer: source ROS2 first
+source /opt/ros/humble/setup.bash
+cargo run -p dora-ros2-bridge --example rust-ros2-dataflow            # turtlesim
+cargo run -p dora-ros2-bridge --example python-ros2-dataflow-service-server
+```
+
+Examples that require a sourced ROS2 install and an example message package are
+gated behind the `ros2-examples` feature, e.g.:
+
+```bash
+cargo run -p dora-ros2-bridge --example cxx-ros2-dataflow-action-server --features ros2-examples
+```
+
+See each language subdirectory's `README.md` for the per-example commands and
+prerequisites.
+
+## Platform notes
+
+Some examples cannot complete on the macOS/arm64 Docker dev harness and rely on
+the x86 nightly `ros2-bridge` CI job as the oracle (full detail in
+[`docs/ros2-bridge.md`](../../docs/ros2-bridge.md)):
+
+- A dora-hosted **action** server is not discoverable by a real
+  `rcl`/`rclcpp`/`rclpy` client ([ros2-client#4](https://github.com/jhelovuo/ros2-client/issues/4)),
+  so the action examples pair a dora server with a dora client in one dataflow.
+  **Service** servers are discovered fine by a real `ros2` client.
+- The deferred action `get_result` service round-trip stalls on the arm64
+  harness, so the Rust/C++ action examples are verified on x86 nightly.
+
+The `parameter` examples use the *local* parameter API (no discovery), so they
+run deterministically on every platform.

--- a/examples/ros2-bridge/c++/README.md
+++ b/examples/ros2-bridge/c++/README.md
@@ -1,0 +1,44 @@
+# `ros2-bridge` C++ examples
+
+These examples show how to interact between ROS2 and dora from C++, using the
+generated `cxx` bridge headers (`ros2-bridge/...`). They focus on the codegen
+surfaces delivered for
+[#1170](https://github.com/dora-rs/dora/issues/1170): service/action servers and
+an action client, plus a turtlesim demo (topic pub/sub).
+
+See the [top-level README](../README.md) for the capability×language matrix and
+[`docs/ros2-bridge.md`](../../../docs/ros2-bridge.md) for the full reference.
+
+## Examples
+
+| Directory        | `--example` name                   | Needs sourced ROS2 / peer    |
+| ---------------- | ---------------------------------- | ---------------------------- |
+| `service-server` | `cxx-ros2-dataflow-service-server` | yes (rclcpp minimal client)  |
+| `action-client`  | `cxx-ros2-dataflow-action-client`  | yes (rclcpp action server)¹  |
+| `action-server`  | `cxx-ros2-dataflow-action-server`  | no (dora server + client)¹   |
+| `turtle`         | `cxx-ros2-dataflow`                | yes (`turtlesim`)            |
+
+All C++ examples are gated behind `--features ros2-examples`.
+
+¹ A dora-hosted action server is not discoverable by a real `rcl` client
+([ros2-client#4](https://github.com/jhelovuo/ros2-client/issues/4)), so the
+`action-server` example pairs a dora C++ server with a dora C++ client; x86
+nightly CI is the oracle (the deferred `get_result` round-trip stalls on the
+arm64 dev harness). See [`docs/ros2-bridge.md`](../../../docs/ros2-bridge.md).
+
+Service *client*, topic-only, and parameter examples are not provided in C++ —
+those surfaces are covered by the Rust and Python examples (see the matrix).
+
+## Setup
+
+A sourced ROS2 installation plus a working C++ toolchain and CMake are required.
+Some examples need an example message package, e.g.
+`ros-humble-examples-rclcpp-minimal-client`.
+
+## Running
+
+```bash
+source /opt/ros/humble/setup.bash
+cargo run -p dora-ros2-bridge --example cxx-ros2-dataflow-service-server --features ros2-examples
+cargo run -p dora-ros2-bridge --example cxx-ros2-dataflow-action-server --features ros2-examples
+```

--- a/examples/ros2-bridge/python/README.md
+++ b/examples/ros2-bridge/python/README.md
@@ -1,0 +1,50 @@
+# `ros2-bridge` Python examples
+
+These examples show how to interact between ROS2 and dora from Python, using the
+`dora` package's ROS2 bindings (`Ros2Context`, `Ros2Node`, …). They cover service
+client/server, action client/server, parameters, and a turtlesim demo (topic
+pub/sub).
+
+See the [top-level README](../README.md) for the capability×language matrix and
+[`docs/ros2-bridge.md`](../../../docs/ros2-bridge.md) for the full reference.
+
+## Examples
+
+| Directory        | `--example` name                      | Needs sourced ROS2 / peer   |
+| ---------------- | ------------------------------------- | --------------------------- |
+| `parameter`      | `python-ros2-dataflow-parameter`      | no (local parameter API)    |
+| `service-client` | `python-ros2-dataflow-service-client` | yes (rclcpp service server) |
+| `service-server` | `python-ros2-dataflow-service-server` | yes (rclcpp minimal client) |
+| `action-client`  | `python-ros2-dataflow-action-client`  | yes (rclcpp action server)  |
+| `action-server`  | `python-ros2-dataflow-action-server`  | no (dora server + client)¹  |
+| `turtle`         | `python-ros2-dataflow`                | yes (`turtlesim`)           |
+
+¹ A dora-hosted action server is not discoverable by a real `rcl` client
+([ros2-client#4](https://github.com/jhelovuo/ros2-client/issues/4)), so the
+`action-server` example pairs a dora server with a dora client. The Python
+action client/server *do* support cancellation. See
+[`docs/ros2-bridge.md`](../../../docs/ros2-bridge.md).
+
+## Setup
+
+```bash
+uv venv --seed -p 3.12
+source .venv/bin/activate
+uv pip install -e ../../../apis/python/node   # workspace dora bindings
+uv pip install pyarrow
+```
+
+Examples that talk to a real ROS2 node also need a sourced ROS2 install and the
+matching example message package. The `parameter` example is self-contained
+(local parameter API, no discovery) and needs no ROS2 install.
+
+## Running
+
+```bash
+# self-contained
+cargo run -p dora-ros2-bridge --example python-ros2-dataflow-parameter
+
+# against a real ROS2 node (source ROS2 first)
+source /opt/ros/humble/setup.bash
+cargo run -p dora-ros2-bridge --example python-ros2-dataflow          # turtlesim
+```

--- a/examples/ros2-bridge/rust/README.md
+++ b/examples/ros2-bridge/rust/README.md
@@ -1,17 +1,55 @@
-# `ros2-bridge` Rust Examples
+# `ros2-bridge` Rust examples
 
-These examples show how to interact between ROS2 and Dora with Rust, including topic pub/sub service client/server and action client/server.
-The dataflow consists of the [ROS2's examples package](https://index.ros.org/r/examples/).
+These examples show how to interact between ROS2 and dora from Rust, using the
+generated message types and a `ros2-client` node. They cover topic pub/sub,
+service client/server, action client/server, and parameters.
+
+See the [top-level README](../README.md) for the capability×language matrix and
+[`docs/ros2-bridge.md`](../../../docs/ros2-bridge.md) for the full reference.
+
+## Examples
+
+| Directory        | `--example` name                    | Needs sourced ROS2 / peer    |
+| ---------------- | ----------------------------------- | ---------------------------- |
+| `parameter`      | `rust-ros2-dataflow-parameter`      | no (local parameter API)     |
+| `topic-pub`      | `rust-ros2-dataflow-topic-pub`      | yes (publishes to ROS2)      |
+| `topic-sub`      | `rust-ros2-dataflow-topic-sub`      | yes (subscribes from ROS2)   |
+| `service-client` | `rust-ros2-dataflow-service-client` | yes (rclcpp service server)  |
+| `service-server` | `rust-ros2-dataflow-service-server` | yes (rclcpp minimal client)  |
+| `action-client`  | `rust-ros2-dataflow-action-client`  | yes (rclcpp action server)¹  |
+| `action-server`  | `rust-ros2-dataflow-action-server`  | no (dora server + client)¹   |
+| `turtle`         | `rust-ros2-dataflow`                | yes (`turtlesim`)            |
+
+¹ Action examples are gated behind `--features ros2-examples`. A dora-hosted
+action server is not discoverable by a real `rcl` client
+([ros2-client#4](https://github.com/jhelovuo/ros2-client/issues/4)), so the
+`action-server` example pairs a dora server with a dora client; x86 nightly CI
+is the oracle (the deferred `get_result` round-trip stalls on the arm64 dev
+harness). See [`docs/ros2-bridge.md`](../../../docs/ros2-bridge.md).
 
 ## Setup
 
-These examples requires a sourced ROS2 installation.
+The examples that talk to a real ROS2 node require a sourced ROS2 installation
+and the matching example message package:
 
-- To set up ROS2, follow the [ROS2 installation](https://docs.ros.org/en/iron/Installation.html) guide.
-- Don't forget to [source the ROS2 setup files](https://docs.ros.org/en/iron/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.html#source-the-setup-files)
-- Install the corresponding ROS2 examples package
+- [Install ROS2](https://docs.ros.org/en/iron/Installation.html) and
+  [source the setup files](https://docs.ros.org/en/iron/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.html#source-the-setup-files).
+- Install the corresponding ROS2 examples package (e.g.
+  `ros-humble-examples-rclcpp-minimal-client`).
+
+The `parameter` example is self-contained (pure-Rust DDS, local parameter API)
+and needs no ROS2 install.
 
 ## Running
 
-- Run the corresponding ROS2 node.
-- Run the Dora dataflow.
+```bash
+# self-contained
+cargo run -p dora-ros2-bridge --example rust-ros2-dataflow-parameter
+
+# against a real ROS2 node (source ROS2 first)
+source /opt/ros/humble/setup.bash
+cargo run -p dora-ros2-bridge --example rust-ros2-dataflow            # turtlesim
+
+# action examples need the ros2-examples feature
+cargo run -p dora-ros2-bridge --example rust-ros2-dataflow-action-server --features ros2-examples
+```

--- a/examples/ros2-bridge/rust/parameter/dataflow.yml
+++ b/examples/ros2-bridge/rust/parameter/dataflow.yml
@@ -1,0 +1,10 @@
+nodes:
+    # dora node exposing ROS2 parameters on /demo_params. The rcl_interfaces
+    # parameter services are hosted natively by ros2-client (driven by the node
+    # spinner); this node declares + exercises them via the local parameter API.
+    - id: parameter-server
+      build: cargo build -p rust-ros2-example-node --bin rust-ros2-example-node-parameter --features ros2
+      path: ../../../../target/debug/rust-ros2-example-node-parameter
+      inputs:
+          tick: dora/timer/millis/100
+      outputs: []

--- a/examples/ros2-bridge/rust/parameter/run.rs
+++ b/examples/ros2-bridge/rust/parameter/run.rs
@@ -1,0 +1,20 @@
+use dora_cli::{BuildConfig, build, run};
+use eyre::Context;
+use std::path::Path;
+
+fn main() -> eyre::Result<()> {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    std::env::set_current_dir(root.join("../../../").join(file!()).parent().unwrap())
+        .wrap_err("failed to set working dir")?;
+
+    build(BuildConfig {
+        dataflow: "dataflow.yml".to_string(),
+        force_local: true,
+        ..Default::default()
+    })?;
+
+    // The parameter example is self-contained: the node declares and exercises
+    // its parameters via the local API and exits, so there is no external ROS2
+    // client to pair with.
+    run("dataflow.yml".to_string(), false)
+}

--- a/examples/ros2-bridge/rust/rust-ros2-example-node/Cargo.toml
+++ b/examples/ros2-bridge/rust/rust-ros2-example-node/Cargo.toml
@@ -46,6 +46,11 @@ name = "rust-ros2-example-node-action-server"
 path = "src/action_server.rs"
 required-features = ["ros2"]
 
+[[bin]]
+name = "rust-ros2-example-node-parameter"
+path = "src/parameter.rs"
+required-features = ["ros2"]
+
 [dependencies]
 dora-node-api = { workspace = true, features = ["tracing"] }
 eyre = { workspace = true }

--- a/examples/ros2-bridge/rust/rust-ros2-example-node/src/parameter.rs
+++ b/examples/ros2-bridge/rust/rust-ros2-example-node/src/parameter.rs
@@ -1,0 +1,134 @@
+//! dora node exposing ROS2 parameters via the bridge.
+//!
+//! Declares parameters on the ROS2 node `/demo_params` and exercises the
+//! parameter API. The six rcl_interfaces parameter services are hosted natively
+//! by ros2-client (driven by the node spinner), so `ros2 param` / rclpy clients
+//! can query them over DDS (subject to ros2-client#4 discoverability); this node
+//! uses the local get/set/list API, which needs no discovery and is therefore
+//! deterministic on every platform. This mirrors the Python `parameter` example.
+
+use std::{
+    collections::HashMap,
+    mem::{Discriminant, discriminant},
+};
+
+use dora_node_api::{self, DoraNode, Event};
+use dora_ros2_bridge::ros2_client::{self, NodeOptions, ParameterValue};
+use eyre::{Context, eyre};
+use futures::task::SpawnExt;
+
+fn main() -> eyre::Result<()> {
+    // Connect to the dora daemon first (before the slower ROS2 setup), so the
+    // daemon does not kill this node for not initializing its connection in time.
+    let (_node, mut dora_events) = DoraNode::init_from_env()?;
+
+    // Initial parameters to declare on the node, covering the ParameterValue
+    // kinds exercised here (scalar int/float/str plus float and bool arrays).
+    let declared: Vec<(&str, ParameterValue)> = vec![
+        ("speed", ParameterValue::Double(1.5)),
+        ("name", ParameterValue::String("robot".to_string())),
+        ("gain", ParameterValue::Integer(7)),
+        (
+            "waypoints",
+            ParameterValue::DoubleArray(vec![1.0, 2.0, 3.0]),
+        ),
+        ("flags", ParameterValue::BooleanArray(vec![true, false])),
+    ];
+
+    // Record each declared parameter's value type so the validator can enforce
+    // type stability on *every* set path (the local `set_parameter` and any
+    // remote `ros2 param set`).
+    let declared_types: HashMap<String, Discriminant<ParameterValue>> = declared
+        .iter()
+        .map(|(name, value)| (name.to_string(), discriminant(value)))
+        .collect();
+
+    let mut node_options = NodeOptions::new().enable_rosout(true);
+    for (name, value) in &declared {
+        node_options = node_options.declare_parameter(name, value.clone());
+    }
+    // Type-stability validator: reject a set whose value type differs from the
+    // declared one. ros2-client invokes this on both the local and the
+    // service-served set paths.
+    node_options =
+        node_options.parameter_validator(Box::new(move |name: &str, value: &ParameterValue| {
+            match declared_types.get(name) {
+                Some(declared) if *declared != discriminant(value) => Err(format!(
+                    "parameter `{name}` is type-stable; cannot change its declared type"
+                )),
+                _ => Ok(()),
+            }
+        }));
+
+    let ros_context =
+        ros2_client::Context::new().map_err(|e| eyre!("failed to create ROS2 context: {e:?}"))?;
+    let mut ros_node = ros_context
+        .new_node(
+            ros2_client::NodeName::new("/", "demo_params")
+                .map_err(|e| eyre!("failed to create ROS2 node name: {e}"))?,
+            node_options,
+        )
+        .map_err(|e| eyre!("failed to create ros2 node: {e:?}"))?;
+
+    // Background spinner: hosts the parameter services over DDS so an external
+    // `ros2 param` / rclpy client could query them. The local API below does not
+    // depend on it, but a "parameter server" example should keep it running.
+    let pool = futures::executor::ThreadPool::new()?;
+    let spinner = ros_node
+        .spinner()
+        .map_err(|e| eyre!("failed to create spinner: {e:?}"))?;
+    pool.spawn(async move {
+        if let Err(err) = spinner.spin().await {
+            eprintln!("ros2 spinner failed: {err:?}");
+        }
+    })
+    .context("failed to spawn ros2 spinner")?;
+
+    // Local parameter API (no cross-node discovery needed). `ParameterValue`
+    // does not implement `PartialEq`, so assert by matching the variant.
+    println!("list_parameters: {:?}", ros_node.list_parameters());
+    assert!(ros_node.has_parameter("speed"));
+    assert!(matches!(ros_node.get_parameter("speed"), Some(ParameterValue::Double(v)) if v == 1.5));
+    assert!(
+        matches!(ros_node.get_parameter("name"), Some(ParameterValue::String(s)) if s == "robot")
+    );
+    assert!(matches!(
+        ros_node.get_parameter("gain"),
+        Some(ParameterValue::Integer(7))
+    ));
+    assert!(
+        matches!(ros_node.get_parameter("waypoints"), Some(ParameterValue::DoubleArray(v)) if v == [1.0, 2.0, 3.0])
+    );
+    assert!(
+        matches!(ros_node.get_parameter("flags"), Some(ParameterValue::BooleanArray(v)) if v == [true, false])
+    );
+    assert!(ros_node.get_parameter("missing").is_none());
+
+    // Update a parameter (same type) and read it back.
+    ros_node
+        .set_parameter("speed", ParameterValue::Double(2.0))
+        .map_err(|e| eyre!("failed to set `speed`: {e}"))?;
+    assert!(matches!(ros_node.get_parameter("speed"), Some(ParameterValue::Double(v)) if v == 2.0));
+
+    // Changing a declared parameter's type is rejected (type-stable contract,
+    // enforced by the validator on every set path).
+    assert!(
+        ros_node
+            .set_parameter("gain", ParameterValue::String("not an int".to_string()))
+            .is_err(),
+        "expected a type-change rejection for `gain`"
+    );
+
+    println!("PARAM API OK");
+
+    // Keep the node (and its parameter services) alive briefly so an external
+    // ROS2 client could query it; the asserts above are the smoke contract.
+    for _ in 0..50 {
+        match dora_events.recv() {
+            Some(Event::Stop(_)) | None => break,
+            _ => {}
+        }
+    }
+
+    Ok(())
+}

--- a/libraries/extensions/ros2-bridge/Cargo.toml
+++ b/libraries/extensions/ros2-bridge/Cargo.toml
@@ -76,6 +76,10 @@ path = "../../../examples/ros2-bridge/rust/action-server/run.rs"
 required-features = ["ros2-examples"]
 
 [[example]]
+name = "rust-ros2-dataflow-parameter"
+path = "../../../examples/ros2-bridge/rust/parameter/run.rs"
+
+[[example]]
 name = "python-ros2-dataflow"
 path = "../../../examples/ros2-bridge/python/turtle/run.rs"
 

--- a/scripts/qa/ci-nightly-jobs.sh
+++ b/scripts/qa/ci-nightly-jobs.sh
@@ -1141,6 +1141,9 @@ job_ros2_bridge() {
   source /opt/ros/humble/setup.bash
   timeout 600s cargo test -p dora-ros2-bridge-python
   timeout 1800s env QT_QPA_PLATFORM=offscreen cargo run -p dora-ros2-bridge --example rust-ros2-dataflow
+  # Self-contained parameter example: declares + exercises ROS2 parameters via
+  # the local API (no discovery), so it runs on every platform incl. arm64.
+  timeout 1800s env QT_QPA_PLATFORM=offscreen cargo run -p dora-ros2-bridge --example rust-ros2-dataflow-parameter
   timeout 1800s env QT_QPA_PLATFORM=offscreen cargo run -p dora-ros2-bridge --example cxx-ros2-dataflow --features ros2-examples
 
   # C++ service server, driven by the rclcpp minimal client. Mirrors the


### PR DESCRIPTION
## Summary

Follow-up alignment item from the #1170 arc: the ROS2 bridge examples had grown asymmetric and under-documented after every protocol surface landed. This brings them into a documented, consistent matrix and fills the one safe coverage gap.

- **Top-level `examples/ros2-bridge/README.md`** — capability×language matrix, run instructions (self-contained vs. needs-sourced-ROS2), the two-surfaces overview (native code APIs vs. YAML/dynamic bridge), and the arm64 / [ros2-client#4](https://github.com/jhelovuo/ros2-client/issues/4) platform notes.
- **Per-language READMEs** — refreshed the stale `rust/README.md`; added brief `python/` and `c++/` READMEs. Each lists its examples, `--example` names, and prerequisites. Empty matrix cells are documented as intentional (each surface is covered in at least one language; C++ focuses on the #1170 codegen server/client surfaces).
- **New Rust `parameter` example** — mirrors the Python one (declare scalars + arrays, get/set/list, type-stability rejection via the validator). Uses the local parameter API (no discovery), so it is self-contained and runs on every platform.
- **CI** — wired into `nightly.yml` and `scripts/qa/ci-nightly-jobs.sh` next to the other Rust ros2 examples.

No repo-root README.md change — ros2 is not a core feature.

## Capability × language matrix (after this PR)

| Capability | Rust | Python | C++ |
|---|---|---|---|
| topic pub/sub | yes | (turtle) | (turtle) |
| service client | yes | yes | — |
| service server | yes | yes | yes |
| action client | yes | yes | yes |
| action server | yes | yes | yes |
| parameters | yes (new) | yes | — |
| turtlesim | yes | yes | yes |

## Test plan

- [x] `cargo build -p rust-ros2-example-node --bin rust-ros2-example-node-parameter --features ros2`
- [x] `cargo run -p dora-ros2-bridge --example rust-ros2-dataflow-parameter` produces `PARAM API OK`, exit 0 (verified locally on macOS/arm64; self-contained, no ROS2 install)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p rust-ros2-example-node --bin rust-ros2-example-node-parameter --features ros2 -- -D warnings`
- [x] `cargo check --examples` (example-target gate)
- [x] `typos` on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
