### PR TITLE
fix(ros2-bridge): drop flaky ROS2 action examples from nightly; fail-fast example

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1493,22 +1493,11 @@ jobs:
           source /opt/ros/humble/setup.bash &&
           cargo run -p dora-ros2-bridge --example rust-ros2-dataflow &&
           cargo run -p dora-ros2-bridge --example rust-ros2-dataflow-parameter
-      - name: Rust ROS2 Bridge action examples
-        # x86 is the oracle for the Rust action client/server: the macOS arm64
-        # Docker harness cannot complete the deferred get_result service round-trip
-        # (see docs/ros2-bridge.md). The action-server example is
-        # self-contained (it runs a dora action server + dora action client, both
-        # ros2-client); the action-client example drives the rclcpp minimal action
-        # server, so we install that example package first.
-        timeout-minutes: 30
-        env:
-          QT_QPA_PLATFORM: offscreen
-        run: |
-          sudo apt-get update &&
-          sudo apt-get install -y ros-humble-examples-rclcpp-minimal-action-server &&
-          source /opt/ros/humble/setup.bash &&
-          cargo run -p dora-ros2-bridge --example rust-ros2-dataflow-action-server --features ros2-examples &&
-          cargo run -p dora-ros2-bridge --example rust-ros2-dataflow-action-client --features ros2-examples
+      # ROS2 action examples (rust + cxx action-server/client) are intentionally
+      # NOT run in nightly: their deferred get_result round-trip is flaky upstream
+      # (ros2-client/rustdds) and hangs on ~20% of cold starts. They stay in the
+      # repo and in scripts/ros2dev.sh qa (release-time QA). Re-add here once the
+      # upstream flake is fixed (#1170).
       - name: Python ROS2 Bridge example
         timeout-minutes: 30
         env:
@@ -1540,18 +1529,6 @@ jobs:
           sudo apt-get install -y ros-humble-examples-rclcpp-minimal-client &&
           source /opt/ros/humble/setup.bash &&
           cargo run -p dora-ros2-bridge --example cxx-ros2-dataflow-service-server --features ros2-examples
-      - name: C++ ROS2 Bridge action-server example
-        # The dora C++ node hosts a Fibonacci action server, driven by a dora C++
-        # action client in the same dataflow (both ros2-client; a real rmw client
-        # cannot discover a ros2-client server -- ros2-client#4). Self-contained,
-        # no extra ROS2 package needed. x86 is the oracle: the deferred get_result
-        # service round-trip does not complete on the arm64 dev harness.
-        timeout-minutes: 30
-        env:
-          QT_QPA_PLATFORM: offscreen
-        run: |
-          source /opt/ros/humble/setup.bash &&
-          cargo run -p dora-ros2-bridge --example cxx-ros2-dataflow-action-server --features ros2-examples
 
   # ===== MSRV check =====
   # Restored from upstream dora CI — verifies the minimum supported

--- a/docs/testing-capabilities.md
+++ b/docs/testing-capabilities.md
@@ -190,6 +190,10 @@ Known gap: `dora self update` destructive swap path (tracked in
 > Actions, non-blocking); for local pre-release QA, run
 > `scripts/qa/ci-nightly-jobs.sh ros2-bridge` on a Linux box with ROS2 Humble.
 > Do not rely on per-PR runtime coverage for the bridge.
+> The **action** examples are excluded from both nightly and that script (their
+> deferred `get_result` round-trip is flaky in upstream `ros2-client`/`rustdds`,
+> [#1170](https://github.com/dora-rs/dora/issues/1170)); validate them with
+> `scripts/ros2dev.sh qa` on x86 Linux before a release.
 
 | Sub-capability | Test(s) | Tier | Strength |
 |---|---|---|---|

--- a/examples/ros2-bridge/README.md
+++ b/examples/ros2-bridge/README.md
@@ -74,10 +74,10 @@ Some examples have platform caveats (full detail in
   so the action examples pair a dora server with a dora client in one dataflow.
   **Service** servers are discovered fine by a real `ros2` client.
 - The deferred action `get_result` round-trip is flaky in upstream
-  `ros2-client`/`rustdds` (~20% of cold starts never return on x86, and it does
-  not complete at all on the macOS/arm64 dev harness). The Rust/C++ action
-  examples are therefore **not run in nightly CI**; validate them with
-  `scripts/ros2dev.sh qa` on x86 Linux before a release. Tracked in
+  `ros2-client`/`rustdds` (it repeatedly hung the x86 nightly job and stalls on
+  the macOS/arm64 dev harness). The Rust/C++ action examples are therefore
+  **not run in nightly CI**; validate them with `scripts/ros2dev.sh qa` on x86
+  Linux before a release. Tracked in
   [#1170](https://github.com/dora-rs/dora/issues/1170).
 
 The `parameter` examples use the *local* parameter API (no discovery), so they

--- a/examples/ros2-bridge/README.md
+++ b/examples/ros2-bridge/README.md
@@ -66,16 +66,19 @@ prerequisites.
 
 ## Platform notes
 
-Some examples cannot complete on the macOS/arm64 Docker dev harness and rely on
-the x86 nightly `ros2-bridge` CI job as the oracle (full detail in
+Some examples have platform caveats (full detail in
 [`docs/ros2-bridge.md`](../../docs/ros2-bridge.md)):
 
 - A dora-hosted **action** server is not discoverable by a real
   `rcl`/`rclcpp`/`rclpy` client ([ros2-client#4](https://github.com/jhelovuo/ros2-client/issues/4)),
   so the action examples pair a dora server with a dora client in one dataflow.
   **Service** servers are discovered fine by a real `ros2` client.
-- The deferred action `get_result` service round-trip stalls on the arm64
-  harness, so the Rust/C++ action examples are verified on x86 nightly.
+- The deferred action `get_result` round-trip is flaky in upstream
+  `ros2-client`/`rustdds` (~20% of cold starts never return on x86, and it does
+  not complete at all on the macOS/arm64 dev harness). The Rust/C++ action
+  examples are therefore **not run in nightly CI**; validate them with
+  `scripts/ros2dev.sh qa` on x86 Linux before a release. Tracked in
+  [#1170](https://github.com/dora-rs/dora/issues/1170).
 
 The `parameter` examples use the *local* parameter API (no discovery), so they
 run deterministically on every platform.

--- a/examples/ros2-bridge/c++/README.md
+++ b/examples/ros2-bridge/c++/README.md
@@ -24,9 +24,9 @@ All C++ examples are gated behind `--features ros2-examples`.
 ([ros2-client#4](https://github.com/jhelovuo/ros2-client/issues/4)), so the
 `action-server` example pairs a dora C++ server with a dora C++ client. The
 deferred `get_result` round-trip is flaky in upstream `ros2-client`/`rustdds`
-(~20% of cold starts never return on x86; does not complete on the arm64 dev
-harness), so the action examples are **not run in nightly CI** — validate them
-with `scripts/ros2dev.sh qa` on x86 Linux before a release ([#1170](https://github.com/dora-rs/dora/issues/1170)).
+(it repeatedly hung the x86 nightly job and stalls on the arm64 dev harness), so
+the action examples are **not run in nightly CI** — validate them with
+`scripts/ros2dev.sh qa` on x86 Linux before a release ([#1170](https://github.com/dora-rs/dora/issues/1170)).
 See [`docs/ros2-bridge.md`](../../../docs/ros2-bridge.md).
 
 Service *client*, topic-only, and parameter examples are not provided in C++ —

--- a/examples/ros2-bridge/c++/README.md
+++ b/examples/ros2-bridge/c++/README.md
@@ -22,9 +22,12 @@ All C++ examples are gated behind `--features ros2-examples`.
 
 ¹ A dora-hosted action server is not discoverable by a real `rcl` client
 ([ros2-client#4](https://github.com/jhelovuo/ros2-client/issues/4)), so the
-`action-server` example pairs a dora C++ server with a dora C++ client; x86
-nightly CI is the oracle (the deferred `get_result` round-trip stalls on the
-arm64 dev harness). See [`docs/ros2-bridge.md`](../../../docs/ros2-bridge.md).
+`action-server` example pairs a dora C++ server with a dora C++ client. The
+deferred `get_result` round-trip is flaky in upstream `ros2-client`/`rustdds`
+(~20% of cold starts never return on x86; does not complete on the arm64 dev
+harness), so the action examples are **not run in nightly CI** — validate them
+with `scripts/ros2dev.sh qa` on x86 Linux before a release ([#1170](https://github.com/dora-rs/dora/issues/1170)).
+See [`docs/ros2-bridge.md`](../../../docs/ros2-bridge.md).
 
 Service *client*, topic-only, and parameter examples are not provided in C++ —
 those surfaces are covered by the Rust and Python examples (see the matrix).

--- a/examples/ros2-bridge/rust/README.md
+++ b/examples/ros2-bridge/rust/README.md
@@ -24,9 +24,9 @@ See the [top-level README](../README.md) for the capability×language matrix and
 action server is not discoverable by a real `rcl` client
 ([ros2-client#4](https://github.com/jhelovuo/ros2-client/issues/4)), so the
 `action-server` example pairs a dora server with a dora client. The deferred
-`get_result` round-trip is flaky in upstream `ros2-client`/`rustdds` (~20% of
-cold starts never return on x86; does not complete on the arm64 dev harness), so
-the action examples are **not run in nightly CI** — validate them with
+`get_result` round-trip is flaky in upstream `ros2-client`/`rustdds` (it
+repeatedly hung the x86 nightly job and stalls on the arm64 dev harness), so the
+action examples are **not run in nightly CI** — validate them with
 `scripts/ros2dev.sh qa` on x86 Linux before a release ([#1170](https://github.com/dora-rs/dora/issues/1170)).
 See [`docs/ros2-bridge.md`](../../../docs/ros2-bridge.md).
 

--- a/examples/ros2-bridge/rust/README.md
+++ b/examples/ros2-bridge/rust/README.md
@@ -23,9 +23,12 @@ See the [top-level README](../README.md) for the capability×language matrix and
 ¹ Action examples are gated behind `--features ros2-examples`. A dora-hosted
 action server is not discoverable by a real `rcl` client
 ([ros2-client#4](https://github.com/jhelovuo/ros2-client/issues/4)), so the
-`action-server` example pairs a dora server with a dora client; x86 nightly CI
-is the oracle (the deferred `get_result` round-trip stalls on the arm64 dev
-harness). See [`docs/ros2-bridge.md`](../../../docs/ros2-bridge.md).
+`action-server` example pairs a dora server with a dora client. The deferred
+`get_result` round-trip is flaky in upstream `ros2-client`/`rustdds` (~20% of
+cold starts never return on x86; does not complete on the arm64 dev harness), so
+the action examples are **not run in nightly CI** — validate them with
+`scripts/ros2dev.sh qa` on x86 Linux before a release ([#1170](https://github.com/dora-rs/dora/issues/1170)).
+See [`docs/ros2-bridge.md`](../../../docs/ros2-bridge.md).
 
 ## Setup
 

--- a/examples/ros2-bridge/rust/rust-ros2-example-node/src/action_client.rs
+++ b/examples/ros2-bridge/rust/rust-ros2-example-node/src/action_client.rs
@@ -1,5 +1,5 @@
 use futures::StreamExt;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use dora_node_api::{
     self, DoraNode, Event,
@@ -60,8 +60,15 @@ fn main() -> eyre::Result<()> {
     let merged_events = dora_events.merge_external(Box::pin(client_stream));
     let mut events = futures::executor::block_on_stream(merged_events);
 
+    // Fail fast instead of hanging: the upstream get_result round-trip can wedge
+    // the node forever (it never returns on ~20% of cold starts). The dora timer
+    // ticks at 2 Hz, so this loop always wakes to check the deadline.
+    let deadline = Instant::now() + Duration::from_secs(60);
     let mut sent = false;
     loop {
+        if Instant::now() >= deadline {
+            eyre::bail!("timed out waiting for a terminal Fibonacci action result");
+        }
         let event = match events.next() {
             Some(input) => input,
             None => break,
@@ -112,17 +119,17 @@ fn main() -> eyre::Result<()> {
                 other => eprintln!("Received unexpected input: {other:?}"),
             },
             MergedEvent::External(action_event) => match action_event {
-                ActionEvent::Result { id, result } => {
-                    if let Ok((status, result)) = result {
-                        if status == GoalStatusEnum::Unknown {
-                            client_stream_handle.push(result_stream(&client, id));
-                            // there are tons of unknown status :(
-                        } else {
-                            println!("status: {:?}", result);
-                            break;
-                        }
+                ActionEvent::Result { id, result } => match result {
+                    Ok((GoalStatusEnum::Unknown, _)) => {
+                        // there are tons of unknown status :(
+                        client_stream_handle.push(result_stream(&client, id));
                     }
-                }
+                    Ok((_, result)) => {
+                        println!("status: {:?}", result);
+                        break;
+                    }
+                    Err(err) => eyre::bail!("get_result service call failed: {err:?}"),
+                },
                 other => {
                     println!("{:?}", other);
                 }

--- a/scripts/qa/ci-nightly-jobs.sh
+++ b/scripts/qa/ci-nightly-jobs.sh
@@ -1170,10 +1170,10 @@ job_ros2_bridge() {
   # Note: the Rust action client/server AND the C++ action examples are NOT
   # mirrored here, and as of PR #1988 are no longer in nightly.yml either --
   # their deferred get_result round-trip is flaky in upstream ros2-client/rustdds
-  # (~20% of cold starts never return on x86; does not complete at all on
-  # arm64/Docker, which this local driver runs on). Validate them via
-  # `scripts/ros2dev.sh qa` on x86 Linux at release time (tracked in #1170). The
-  # C++ *service* server above is mirrored because it completes reliably.
+  # (it repeatedly hung the x86 nightly job and stalls on arm64/Docker, which
+  # this local driver runs on). Validate them via `scripts/ros2dev.sh qa` on x86
+  # Linux at release time (tracked in #1170). The C++ *service* server above is
+  # mirrored because it completes reliably.
 
   # Python service client/server examples need the workspace node bindings.
   uv venv --seed -p 3.12 .venv-ros2-bridge >/dev/null

--- a/scripts/qa/ci-nightly-jobs.sh
+++ b/scripts/qa/ci-nightly-jobs.sh
@@ -1167,12 +1167,13 @@ job_ros2_bridge() {
     echo "SKIP cxx-ros2-dataflow-service-server: examples_rclcpp_minimal_client not installed (apt-get install ros-humble-examples-rclcpp-minimal-client)"
     SKIPPED+=("ros2-bridge: cxx-service-server (examples_rclcpp_minimal_client missing)")
   fi
-  # Note: the Rust action client/server AND the C++ action-server example
-  # (cxx-ros2-dataflow-action-server) are in nightly.yml but are intentionally
-  # NOT mirrored here -- their deferred get_result service round-trip does not
-  # complete on arm64/Docker (this local driver runs on arm64 too), so they
-  # would hang to the timeout. They are x86-nightly-only. (The C++ *service*
-  # server above is mirrored because it completes on arm64.)
+  # Note: the Rust action client/server AND the C++ action examples are NOT
+  # mirrored here, and as of PR #1988 are no longer in nightly.yml either --
+  # their deferred get_result round-trip is flaky in upstream ros2-client/rustdds
+  # (~20% of cold starts never return on x86; does not complete at all on
+  # arm64/Docker, which this local driver runs on). Validate them via
+  # `scripts/ros2dev.sh qa` on x86 Linux at release time (tracked in #1170). The
+  # C++ *service* server above is mirrored because it completes reliably.
 
   # Python service client/server examples need the workspace node bindings.
   uv venv --seed -p 3.12 .venv-ros2-bridge >/dev/null


### PR DESCRIPTION
## Problem

The `Nightly Regression` workflow has failed every run since 2026-06-01. The failing job is **ROS2 Bridge Examples**, specifically the "Rust ROS2 Bridge action examples" step, which **hung for the full 30-minute timeout**:

```
WARN dora_daemon::node_communication: failed to receive DaemonRequest
  Caused by:
    1: TCP read header timed out
  Location: binaries/daemon/src/node_communication/tcp.rs:78
##[error] The action 'Rust ROS2 Bridge action examples' has timed out after 30 minutes.
```

This step was **added** in #1170 (commit `b29f9d68`) — it's a newly-exposed latent flake, not a regression in previously-green code.

## Root cause

The deferred **`get_result`** service round-trip in upstream **`ros2-client` 0.8.1 / `rustdds` 0.11.4** is flaky: on ~20% of cold starts the result reply never arrives, so the action example's event loop never breaks, the node never exits, and the dataflow wedges until the CI watchdog kills it.

Reproduced in `scripts/ros2dev.sh`:

| approach | result |
|---|---|
| baseline | 7–8/10 pass, rest hang at the watchdog |
| retry `get_result` every 3s | still hung — re-requesting doesn't recover a lost reply |
| wait for the result service to match first | still hung, with `discovery_retries=0` (service reports *matched*, reply still never comes) |

This is **not** a CDR/deserialization bug — the `int32[]` Fibonacci sequences decode correctly in every run (`Fibonacci_Result { sequence: [0,1,1,2,3,5,8,13,21,34,55] }`); the `sequence size exceeds remaining buffer` log line is benign FastDDS noise present in *passing* runs too. The failure is in service-reply delivery, upstream, and not fixable at the example level.

## Changes

ROS2 is an optional feature whose examples run **only in nightly** (not PR CI), so:

- **`.github/workflows/nightly.yml`** — remove the rust + cxx action-server example steps (action-client was already excluded in the first commit). All three share the same flaky `get_result` mechanism. They remain in the repo and in `scripts/ros2dev.sh qa` for release-time QA; re-add to nightly once the upstream flake is fixed (#1170). The **parameter, service, and topic** examples (different, reliable mechanisms) are kept.
- **`examples/ros2-bridge/rust/rust-ros2-example-node/src/action_client.rs`** — harden the example so it fails fast wherever it runs (release-QA harness, manual): add a 60s in-loop deadline (the dora timer ticks at 2 Hz, so the loop always wakes to check it), and `bail!` on a previously **silently-swallowed** `get_result` `Err`.

## Verification

- `cargo fmt --all -- --check` ✅
- `nightly.yml` valid YAML ✅; remaining ROS2 example runs: topic + parameter + service (rust/python/cxx), no action examples
- Example builds + green-path run succeeds in the ROS2 Docker harness ✅
- Fail-fast verified: a hung run now exits in ~60s with `timed out waiting for a terminal Fibonacci action result` instead of the 30-minute timeout

## Note on coverage

The ROS2 action examples are now validated only by `scripts/ros2dev.sh qa`, which must be run on **x86 Linux** before a release — the deferred `get_result` round-trip does not complete on the macOS arm64 dev harness (documented limitation). Until the upstream flake is fixed, the #1170 action codegen has no automated nightly coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
