### PR TITLE
fix(examples): make c-api consumer node tolerant of stream end (fixes flaky Windows nightly)

### DIFF
--- a/examples/c++-dataflow/node-c-api/main.cc
+++ b/examples/c++-dataflow/node-c-api/main.cc
@@ -10,13 +10,15 @@ int run(void *dora_context)
 {
     unsigned char counter = 0;
 
-    for (int i = 0; i < 20; i++)
+    while (true)
     {
         void *event = dora_next_event(dora_context);
         if (event == NULL)
         {
-            printf("[c node] ERROR: unexpected end of event\n");
-            return -1;
+            // Stream exhausted (all inputs closed) -- the normal end of the
+            // dataflow, not an error. Don't assume a fixed input count: pub/sub
+            // discovery can drop early messages before subscriptions match.
+            break;
         }
 
         enum DoraEventType ty = read_dora_event_type(event);


### PR DESCRIPTION
## Problem

The nightly `Examples (windows-latest)` job intermittently fails (~2/10 runs; e.g. 2026-06-01 and 2026-06-02) on the `cxx-dataflow` example:

```
cxx-node-c-api: [c node] ERROR: unexpected end of event
ERROR node_failure: node exited with error: ExitCode(-1) node_id=cxx-node-c-api
Error: Dataflow failed: Node `cxx-node-c-api` failed: exited with code -1
error: process didn't exit successfully: `target\debug\examples\cxx-dataflow.exe` (exit code: 1)
```

It's a flake, not a hard regression — the same commit passes on the next run.

## Root cause

`examples/c++-dataflow/node-c-api/main.cc` hard-looped **exactly 20 events** and treated an early `dora_next_event() == NULL` as a fatal error (`return -1`). Its input is the upstream producer's output (`cxx-node-rust-api/counter`). The producer sends ~20 counters then exits. On Windows, Zenoh pub/sub discovery drops the first message(s) before the subscription is matched, so the consumer can't reach 20 inputs before the producer finishes and the stream closes → `NULL` → `-1`. Early-message loss before pub/sub discovery settles is inherent to Zenoh/DDS/ROS, so the real bug is the consumer assuming exact delivery.

## Fix

Process events until the stream is cleanly exhausted instead of demanding a fixed count:

```c
while (true) {
    void *event = dora_next_event(dora_context);
    if (event == NULL) { break; }  // all inputs closed = normal end
    ...
}
return 0;
```

`dora_next_event` returns `NULL` only when the event stream is cleanly exhausted (`events.recv()` → `None`, `apis/c/node/src/lib.rs:78`); genuine upstream failures arrive as a separate `Error` event, **not** `NULL` — so this does not mask real failures. The producer's bounded loop closes the consumer's input, so the unbounded loop terminates (no hang). This matches the canonical consumer idiom in `examples/c-dataflow/sink.c`.

### Scope: c++-dataflow only

This is intentionally **not** applied to `cmake-dataflow/node-c-api`. Although the C code is identical, the wiring differs: cmake-dataflow's `node-c-api` reads a **direct timer** (`dora/timer/millis/300`) that never closes, so it relies on the finite `for i < 20` bound to terminate — an unbounded loop there would hang until the CI timeout. It's also timer-driven (daemon-local), so it isn't subject to the cross-node Zenoh discovery-drop flake this fix addresses. It keeps its finite bound.

## Cross-platform impact

- **Windows:** fixes the recurring `cxx-dataflow` flake.
- **Linux/macOS:** removes the same latent fragility for `cxx-dataflow` (could break under slow/loaded discovery), gives cleaner failure reporting (no spurious `-1` masking the real cause), and aligns with the idiomatic event-loop pattern. No happy-path behavior change; no perf change.

## Validation

- Builds cleanly; ran a stripped two-node dataflow matching c++-dataflow's wiring (producer → this consumer) via the workspace CLI → exit 0, clean shutdown (`InputClosed` → `stop` → `GOODBYE`), no "unexpected end of event".
- `cargo check -p dora-daemon` green.

> Note: the underlying Zenoh startup message-loss is not addressed here (it's inherent to pub/sub; the correct layer to fix is the consumer being tolerant). A separate, unrelated Linux `multiple-daemons` flake was root-caused and filed as #1992.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
