### PR TITLE
fix(daemon): skip node raw output publishes in inter-daemon-event subscriber (#1992)

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -2709,19 +2709,47 @@ impl Daemon {
                                 },
                                 future::Either::Right((sample, f)) => {
                                     finished = f;
-                                    let event = sample.map_err(|e| eyre!(e)).and_then(|s| {
-                                        let bytes = s.payload().to_bytes();
-                                        net_bytes_rx.fetch_add(
-                                            bytes.len() as u64,
-                                            std::sync::atomic::Ordering::Relaxed,
-                                        );
-                                        net_msgs_rx
-                                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                        Timestamped::deserialize_inter_daemon_event(&bytes)
-                                    });
-                                    if tx.send_async(event).await.is_err() {
-                                        // daemon finished
-                                        break;
+                                    match sample {
+                                        Ok(s) => {
+                                            // Count telemetry for every received sample. Use the
+                                            // cheap length accessor so we don't materialize the
+                                            // payload (`to_bytes()` copies for multi-region buffers)
+                                            // for the samples we skip below.
+                                            net_bytes_rx.fetch_add(
+                                                s.payload().len() as u64,
+                                                std::sync::atomic::Ordering::Relaxed,
+                                            );
+                                            net_msgs_rx
+                                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                            // dora #1992: since #1787 moved data routing off the
+                                            // daemon, nodes publish their raw output directly to
+                                            // this same Zenoh key (raw payload + bincode Metadata
+                                            // in the Zenoh ATTACHMENT) and the consumer node reads
+                                            // it directly (apis/rust/node/src/event_stream/mod.rs).
+                                            // Such samples carry an attachment; daemon-emitted
+                                            // InterDaemonEvent frames (Output fallback /
+                                            // OutputClosed in send_to_remote_receivers) NEVER set
+                                            // one. Skip attachment-bearing samples here so the
+                                            // daemon does not bincode-decode node raw output (which
+                                            // fails with "failed to deserialize InterDaemonEvent").
+                                            if s.attachment().is_some() {
+                                                continue;
+                                            }
+                                            let bytes = s.payload().to_bytes();
+                                            let event =
+                                                Timestamped::deserialize_inter_daemon_event(&bytes)
+                                                    .map_err(|e| eyre!(e));
+                                            if tx.send_async(event).await.is_err() {
+                                                // daemon finished
+                                                break;
+                                            }
+                                        }
+                                        Err(e) => {
+                                            if tx.send_async(Err(eyre!(e))).await.is_err() {
+                                                // daemon finished
+                                                break;
+                                            }
+                                        }
                                     }
                                 }
                             }

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -319,6 +319,17 @@ pub fn reserve_loopback_zenoh_endpoint() -> std::io::Result<String> {
     Ok(format!("tcp/127.0.0.1:{port}"))
 }
 
+/// Zenoh key for a node output. Two message classes share this key, and the
+/// **Zenoh attachment distinguishes them** (a load-bearing contract relied on by
+/// both the daemon and the consumer node — see dora #1992):
+/// - **attachment present** => a node's raw output publish (raw payload + bincode
+///   `Metadata` in the attachment). Read directly by the consumer node; the daemon
+///   ignores it (data routing moved off the daemon in #1787).
+/// - **attachment absent** => a bincode `Timestamped<InterDaemonEvent>` frame
+///   emitted by the daemon (Output fallback / OutputClosed) or coordinator.
+///
+/// A new publisher to this key MUST follow this rule: raw output sets an
+/// attachment, daemon/coordinator frames never do.
 #[cfg(feature = "zenoh")]
 pub fn zenoh_output_publish_topic(
     dataflow_id: uuid::Uuid,


### PR DESCRIPTION
Fixes #1992.

## Problem

In distributed (multi-daemon) mode, the daemon's per-output inter-daemon-event Zenoh subscriber bincode-decodes **every** sample on `zenoh_output_publish_topic` as a `Timestamped<InterDaemonEvent>`. Since #1787 moved data routing off the daemon, nodes publish their raw output **directly** to that same key (raw payload + bincode `Metadata` in the Zenoh **attachment**), and the consuming node reads it directly (`apis/rust/node/src/event_stream/mod.rs`). The daemon chokes on those raw publishes:

```
failed to deserialize InterDaemonEvent
    UUID parsing failed: invalid length: expected 16 bytes, found 63   (also 64)
```

(The misread "length" is just the raw payload's own size byte, interpreted as the `DataflowId` Uuid's bincode length prefix.) This floods errors and intermittently prevents the `multiple-daemons` dataflow from finishing in time — the nightly `Examples (ubuntu-latest)` flake `Error: dataflow not finished after 101 retries`.

## Topology (3 publishers to the same key)

| Publisher | Format | Attachment? |
|---|---|---|
| Node raw output (`node/mod.rs:1041`, post-#1787 data plane) | raw payload + bincode `Metadata` | **yes** |
| Daemon `InterDaemonEvent::Output` (no-Zenoh-session fallback) | bincode | no |
| Daemon `InterDaemonEvent::OutputClosed` | bincode | no |

The subscriber is **not** vestigial — it legitimately handles the two daemon-emitted (attachment-less) frames. The attachment cleanly distinguishes node-raw from daemon-events.

## Fix

In the subscriber's `Either::Right` arm (`binaries/daemon/src/lib.rs`), **skip samples that carry a Zenoh attachment** — they are node raw output, already delivered to the consumer over Zenoh, so the daemon must not decode them. Attachment-less samples decode and forward exactly as before. `finished = f` reassignment, telemetry counters, and the `Err` recv path are all preserved.

```rust
if s.attachment().is_some() {
    continue; // node raw output (#1787); consumer reads it directly
}
let event = Timestamped::deserialize_inter_daemon_event(&bytes).map_err(|e| eyre!(e));
```

No data loss: the daemon doesn't route this data post-#1787; the consumer node already receives it (and itself requires the attachment, dropping samples without one).

## Validation

`cargo run --example multiple-daemons`:

| | deserialize errors | finished | sink received data |
|---|---|---|---|
| baseline (pre-fix) | **100** | ✓ | — |
| 3 runs (post-fix) | **0 / 0 / 0** | ✓ ✓ ✓ | ✓ (100 / 104 / 100 msgs) |

`cargo check`, `cargo clippy -p dora-daemon -- -D warnings`, and `cargo fmt --all -- --check` all pass.

## Scope note

This eliminates the **deserialize-crossover flood** (the documented #1992 root cause). During verification I also observed a **separate, pre-existing** intermittent startup race in `multiple-daemons` (WS "connection reset" / `rust-sink` `Signal(9)` → "101 retries") that occurs with **0** deserialize errors — a different issue, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
