### PR TITLE
fix(daemon): exit when coordinator is permanently gone (#1996)

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -197,6 +197,13 @@ const METRICS_INTERVAL_SECS: f64 = METRICS_INTERVAL.as_secs_f64();
 /// Capacity of the Zenoh publish drain channel. Large enough for burst
 /// patterns; messages are dropped with a warning when full.
 const ZENOH_PUBLISH_CHANNEL_CAPACITY: usize = 256;
+/// How long the daemon keeps trying to (re)connect to the coordinator before
+/// giving up and exiting. Bounds the orphan-daemon window when the coordinator
+/// is permanently gone (dora-rs/dora#1996); a reachable coordinator connects
+/// well within this, so transient outages and reconnects are unaffected.
+const COORDINATOR_RECONNECT_TIMEOUT: Duration = Duration::from_secs(90);
+/// Pause between losing the coordinator connection and attempting to reconnect.
+const COORDINATOR_RECONNECT_BACKOFF: Duration = Duration::from_secs(1);
 
 fn deliver_param_update_strict(
     dataflow: &RunningDataflow,
@@ -521,7 +528,12 @@ impl Daemon {
     ) -> eyre::Result<()> {
         let clock = Arc::new(HLC::default());
         let mut ctrlc_events = set_up_ctrlc_handler(clock.clone())?;
-        let mut reconnect_attempt = 0u32;
+        // Tracks whether we've ever connected to the coordinator. The initial
+        // connect is left to set_up_event_stream's own retry loop (the
+        // coordinator may simply not be up yet at startup), but once connected,
+        // a coordinator gone past the reconnect timeout is treated as
+        // permanently gone -> exit instead of orphaning (dora-rs/dora#1996).
+        let mut connected_once = false;
 
         loop {
             // Sized for bursts of inter-daemon events
@@ -537,19 +549,38 @@ impl Daemon {
                     local_listen_port,
                 );
 
+                // Bound reconnects (but not the initial connect) so a
+                // permanently gone coordinator makes the daemon exit rather than
+                // orphan; see `connected_once` above. A reachable coordinator
+                // reconnects well within the timeout, so legitimate reconnection
+                // (e.g. the daemon-reconnect test) is unaffected.
+                let connect = async move {
+                    if connected_once {
+                        tokio::time::timeout(COORDINATOR_RECONNECT_TIMEOUT, incoming_events).await
+                    } else {
+                        Ok(incoming_events.await)
+                    }
+                };
+
                 let ctrl_c = pin!(ctrlc_events.recv());
-                match futures::future::select(ctrl_c, pin!(incoming_events)).await {
+                match futures::future::select(ctrl_c, pin!(connect)).await {
                     future::Either::Left((_ctrl_c, _)) => {
                         tracing::info!("received ctrl-c signal -> stopping daemon");
                         return Ok(());
                     }
-                    future::Either::Right((events, _)) => events,
+                    future::Either::Right((Ok(events), _)) => events,
+                    future::Either::Right((Err(_elapsed), _)) => {
+                        return Err(eyre::eyre!(
+                            "coordinator unreachable after \
+                             {COORDINATOR_RECONNECT_TIMEOUT:?}; daemon exiting"
+                        ));
+                    }
                 }
             };
 
             match connect_result {
                 Ok((daemon_id, coordinator_sender, incoming_events)) => {
-                    reconnect_attempt = 0;
+                    connected_once = true;
                     let log_destination = LogDestination::Coordinator {
                         sender: coordinator_sender.clone(),
                     };
@@ -589,18 +620,23 @@ impl Daemon {
                     }
                 }
                 Err(e) => {
-                    tracing::warn!(
-                        attempt = reconnect_attempt,
-                        "failed to connect to coordinator: {e:#}"
-                    );
+                    if connected_once {
+                        // Connected before, can't reconnect -> coordinator gone;
+                        // exit rather than orphan (see `connected_once` above).
+                        return Err(eyre::eyre!(
+                            "failed to reconnect to coordinator: {e:#}; daemon exiting"
+                        ));
+                    }
+                    // Still waiting for the initial connect: keep retrying, the
+                    // coordinator may not be up yet.
+                    tracing::warn!("waiting for coordinator: {e:#}");
                 }
             }
 
-            // Exponential backoff: 1s, 2s, 4s, 8s, 16s, 30s, 30s...
-            let delay = Duration::from_secs((1u64 << reconnect_attempt.min(5)).min(30));
-            reconnect_attempt += 1;
-            tracing::info!("reconnecting in {delay:?}...");
-            tokio::time::sleep(delay).await;
+            // Reached while waiting for the initial connect, or after a mid-run
+            // disconnect (to reconnect). Pause briefly before the next attempt.
+            tracing::info!("retrying in {COORDINATOR_RECONNECT_BACKOFF:?}...");
+            tokio::time::sleep(COORDINATOR_RECONNECT_BACKOFF).await;
         }
     }
 


### PR DESCRIPTION
## Problem

Closes #1996.

A daemon that lost its coordinator connection retry-reconnected **forever**, leaving orphaned `dora daemon` processes when the coordinator was permanently gone.

The clean shutdown path already works: on a `DaemonCoordinatorEvent::Destroy` the daemon exits. But a daemon that had **already lost its connection** when the coordinator shut down never receives `Destroy`, and the reconnect loop in `Daemon::run()` was unbounded — `reconnect_attempt` only fed the backoff delay, never an exit condition. So it looped against a dead coordinator indefinitely. This is the lingering-daemon behavior behind the flaky `multiple-daemons` example (the example-side workaround was #1997).

## Fix

Bound reconnection. Once the daemon has connected at least once (`connected_once`), a coordinator unreachable past `COORDINATOR_RECONNECT_TIMEOUT` (90s) is treated as permanently gone: the daemon returns `Err` from `run()` and the process exits instead of looping.

- **Initial connect is left unbounded** (the coordinator may simply not be up yet at startup), so startup ordering is unaffected — the daemon keeps retrying until the coordinator appears.
- **Legitimate reconnection is preserved**: a coordinator that stays reachable reconnects well within the timeout. The Linux-only `daemon-reconnect` nightly test only freezes the *daemon* (coordinator stays up), so on resume it reconnects immediately.
- The exponential-backoff `reconnect_attempt: u32` counter — which only existed to pace the infinite retry — is replaced by a single `connected_once` flag and a fixed 1s pre-reconnect pause.

## Why 90s

Chosen for prompt orphan cleanup while staying generous for transient outages. The bound applies **only to reconnects**, never to the initial connect, so a daemon started before its coordinator (incl. distributed deploys with slow coordinator boot) is unaffected.

## Verification (local, behavioral)

| Scenario | Result |
|---|---|
| Connected, then coordinator killed | daemon exits **~94s** later (`coordinator unreachable after 90s; daemon exiting`) |
| Coordinator restarts within the window | daemon **reconnects** and re-registers |
| No coordinator ever started | daemon **keeps retrying** — no false startup exit |

Plus: `cargo fmt --all --check`, `cargo clippy --all -- -D warnings`, `cargo test --all` (excl. Python), `cargo check --examples`, and 32 `dora-daemon` unit tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
