### PR TITLE
fix(daemon): bind dynamic-node listener once, not per reconnect (#1999)

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -535,6 +535,19 @@ impl Daemon {
         // permanently gone -> exit instead of orphaning (dora-rs/dora#1996).
         let mut connected_once = false;
 
+        // Dynamic-node listener: bind once for the daemon's lifetime, not once
+        // per reconnect. Rebinding on every reconnect leaked the listener task
+        // and hit AddrInUse on the second bind, silently dropping dynamic-node
+        // support (dora-rs/dora#1999). Keep `dynamic_node_events_rx` alive for
+        // the whole loop so the channel stays open across reconnect gaps; each
+        // iteration streams a clone of it.
+        let (dynamic_node_events_tx, dynamic_node_events_rx) = flume::bounded(10);
+        let _listen_port = local_listener::spawn_listener_loop(
+            (LOCALHOST, local_listen_port).into(),
+            dynamic_node_events_tx,
+        )
+        .await?;
+
         loop {
             // Sized for bursts of inter-daemon events
             let (remote_daemon_events_tx, remote_daemon_events_rx) = flume::bounded(100);
@@ -546,7 +559,7 @@ impl Daemon {
                     labels.clone(),
                     &clock,
                     remote_daemon_events_rx,
-                    local_listen_port,
+                    dynamic_node_events_rx.clone(),
                 );
 
                 // Bound reconnects (but not the initial connect) so a
@@ -4398,8 +4411,10 @@ async fn set_up_event_stream(
     labels: BTreeMap<String, String>,
     clock: &Arc<HLC>,
     remote_daemon_events_rx: flume::Receiver<eyre::Result<Timestamped<InterDaemonEvent>>>,
-    // used for dynamic nodes
-    local_listen_port: u16,
+    // Events from the dynamic-node listener. The listener is bound once by the
+    // caller (for the daemon's lifetime) and its receiver passed in, rather than
+    // rebinding the port on every reconnect (dora-rs/dora#1999).
+    dynamic_node_events_rx: flume::Receiver<Timestamped<DynamicNodeEventWrapper>>,
 ) -> eyre::Result<(
     DaemonId,
     coordinator::CoordinatorSender,
@@ -4433,11 +4448,7 @@ async fn set_up_event_stream(
             timestamp,
         },
     );
-    let (events_tx, events_rx) = flume::bounded(10);
-    let _listen_port =
-        local_listener::spawn_listener_loop((LOCALHOST, local_listen_port).into(), events_tx)
-            .await?;
-    let dynamic_node_events = events_rx.into_stream().map(|e| Timestamped {
+    let dynamic_node_events = dynamic_node_events_rx.into_stream().map(|e| Timestamped {
         inner: Event::DynamicNode(e.inner),
         timestamp: e.timestamp,
     });


### PR DESCRIPTION
## Problem

Closes #1999.

`Daemon::run()` calls `set_up_event_stream` on every (re)connect, and that function bound the dynamic-node listener on `local_listen_port` each time. On a reconnect:

- The listener task from the previous connection is still running and still holds the port (it's a detached `tokio::spawn`, never aborted) — leaked.
- The rebind hits `AddrInUse`, so `spawn_listener_loop` returns `Ok(None)` (`local_listener.rs`) and the daemon **silently runs without a dynamic-node listener** for the rest of its life.

So after the first reconnect, dynamic nodes can no longer connect to the daemon, and every additional flap leaks another listener task. Static nodes are unaffected (ephemeral ports). Found during the #1998 review.

## Fix

Bind the dynamic-node listener **once**, before the reconnect loop, for the daemon's lifetime:

- `run()` binds the listener once and holds `dynamic_node_events_rx` for the whole loop, so the flume channel stays open across reconnect gaps.
- Each loop iteration streams a `clone()` of that receiver into the merged event stream (flume is MPMC; only the active clone-stream is polled, so dynamic-node events route to the current connection).
- `set_up_event_stream` now takes the receiver instead of a port and no longer binds.

The one-shot `run_dataflow` path (`dora daemon --run-dataflow`) binds its own listener once and has no reconnect loop, so it's unchanged.

## Verification (local, behavioral)

Forced a coordinator reconnect (kill + restart within the window):

| Check | Result |
|---|---|
| Daemon re-registers after reconnect | ✅ |
| `"listen port already in use"` warnings (the leak symptom) | **0** (previously logged on every reconnect) |

Plus: `cargo fmt --all --check`, `cargo clippy --all -- -D warnings`, `cargo test --all` (excl. Python), `cargo check --examples` all pass.

Note: a full dynamic-node-across-reconnect e2e isn't part of the smoke suite (would need a dynamic-node harness); the leak symptom is eliminated and reconnection verified, and the listener is now bound for the daemon's lifetime so dynamic nodes survive reconnects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
