### PR TITLE
fix(core): drop invalid uv flags from local wheel build (#2003)

### DIFF
--- a/libraries/core/src/build/build_command.rs
+++ b/libraries/core/src/build/build_command.rs
@@ -419,8 +419,10 @@ async fn ensure_local_dora_python_wheel(
     let mut cmd = Command::new("uv");
     cmd.arg("build");
     cmd.arg("--wheel");
-    cmd.arg("--clear");
-    cmd.arg("--no-create-gitignore");
+    // NOTE: `--clear` and `--no-create-gitignore` are NOT valid for `uv build`
+    // (current uv, 0.8.x) -- `--clear` belongs to `uv venv`. Passing them makes
+    // `uv build` exit 2 ("unexpected argument '--clear'"), which broke `dora
+    // build` for every node using a managed Python env. See dora-rs/dora#2003.
     cmd.arg("--out-dir");
     cmd.arg(&wheel_dir);
     cmd.arg(&source.package_dir);


### PR DESCRIPTION
## Problem

Closes #2003.

The local Dora Python wheel build (the managed-env feature from #1820/#1829) in `libraries/core/src/build/build_command.rs` invokes `uv build` with `--clear` and `--no-create-gitignore`. Neither is a valid `uv build` flag in current uv (0.8.x) — `--clear` is a `uv venv` flag (used correctly elsewhere in the same file). uv exits `2` (`unexpected argument '--clear'`), so `dora build` fails for every node that uses a managed Python env:

```
failed to build node `receive_data_with_sleep`
  managed Python env preparation failed
  local Dora Python wheel build `apis/python/node` returned exit status: 2
```

Masked in CI: the nightly example harness installs `-e apis/python/node` itself, bypassing dora's own wheel-build path, so the broken path is never exercised.

## Fix

Drop the two invalid flags from the `uv build` invocation (keep `--clear` on `uv venv`).

## Verification

```
$ uv build --wheel --out-dir /tmp/wheeltest apis/python/node
Successfully built /tmp/wheeltest/dora_rs-1.0.0rc1-cp311-abi3-macosx_11_0_arm64.whl
```

After this fix, `dora build --uv` succeeds for managed-env examples (python-async, python-drain, python-zero-copy-send, …) and they run via `dora run --uv`. `cargo fmt`, `cargo clippy --all -- -D warnings`, and `dora-core` tests pass.

Found while auditing `scripts/smoke-all.sh` coverage for 1.0.0-rc1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)