### PR TITLE
test(scripts): smoke-all.sh coverage + robustness for 1.0.0-rc1

### DIFF
--- a/scripts/ros2dev.sh
+++ b/scripts/ros2dev.sh
@@ -108,6 +108,10 @@ cargo test -p dora-ros2-bridge-python
 # Add new examples here as issue #1170 items land (action server, C++ service
 # server, parameter service, ...). `--features ros2-examples` is required by the
 # cxx/action targets and harmless for the rest.
+# Keep in sync with the [[example]] targets in
+# libraries/extensions/ros2-bridge/Cargo.toml -- every shipped ros2-bridge
+# example should be exercised by the release QA gate, or the gate reports
+# "all green" while real surfaces go untested.
 EXAMPLES=(
   rust-ros2-dataflow
   rust-ros2-dataflow-topic-pub
@@ -115,6 +119,8 @@ EXAMPLES=(
   rust-ros2-dataflow-service-client
   rust-ros2-dataflow-service-server
   rust-ros2-dataflow-action-client
+  rust-ros2-dataflow-action-server
+  rust-ros2-dataflow-parameter
   python-ros2-dataflow
   python-ros2-dataflow-service-client
   python-ros2-dataflow-service-server
@@ -125,6 +131,7 @@ EXAMPLES=(
   cxx-ros2-dataflow-action-client
   cxx-ros2-dataflow-action-client-concurrent
   cxx-ros2-dataflow-service-server
+  cxx-ros2-dataflow-action-server
 )
 
 passed=()

--- a/scripts/smoke-all.sh
+++ b/scripts/smoke-all.sh
@@ -5,7 +5,13 @@
 #
 # Networked lifecycle:
 #   dora up -> dora build -> dora start --detach -> poll dora list
-#   -> dora stop -> dora destroy -> dora down
+#   -> dora stop -> dora down
+#
+# What PASS means: the dataflow ran without crashing (no "Failed" state /
+# nonzero exit) for the smoke window. It does NOT assert correct OUTPUT --
+# the semantic contract assertions live in the Rust suite
+# (`cargo test --test example-smoke`, the contract_* tests). Treat a green
+# smoke-all.sh as "nothing blew up", not "output verified".
 #
 # Usage:
 #   ./scripts/smoke-all.sh               # Run all examples
@@ -13,10 +19,20 @@
 #   ./scripts/smoke-all.sh --python-only # Python examples only
 #   ./scripts/smoke-all.sh --verbose     # Stream dora stdout/stderr live
 #
-# Prerequisites: cargo, Python 3 with pyarrow + numpy installed.
+# Prerequisites: cargo. For Python examples also `uv` and `maturin` -- the
+# script builds the WORKSPACE Python bindings into target/smoke-venv so dep-less
+# Python nodes (which run in the ambient env, not a per-node managed env) use the
+# workspace dora instead of whatever `dora-rs` is otherwise installed. If uv or
+# maturin is missing, Python examples are still attempted but may fail.
 # Skips examples that need webcam, CUDA, ROS2, C/C++ toolchain, etc.
 
 set -euo pipefail
+
+# Surface the failing line if a build/setup step aborts the run (set -e).
+# Example pass/fail is handled explicitly via log_fail; this only fires on an
+# unguarded failure such as a broken cargo build, which would otherwise abort
+# with no summary and no obvious cause.
+trap 'rc=$?; echo; echo "smoke-all.sh: aborted (exit $rc) near line $LINENO -- likely a build/setup failure above"; exit $rc' ERR
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -108,8 +124,21 @@ dump_tail() {
 
 cleanup_stale() {
     "$DORA" stop --all > /dev/null 2>&1 || true
-    "$DORA" destroy > /dev/null 2>&1 || true
+    # `destroy` is just an alias for `down`; one call is enough.
     "$DORA" down > /dev/null 2>&1 || true
+    # Backstop: a daemon does not always self-exit the instant its coordinator
+    # goes away (see dora-rs/dora#1996), so reap any repo-local coordinator/daemon
+    # stragglers. Otherwise they hold port 6013 or leave stale "Running" entries
+    # that contaminate the next example's verdict.
+    pkill -f "$ROOT/target/debug/dora .*(coordinator|daemon)" > /dev/null 2>&1 || true
+    pkill -f "$ROOT/target/debug/dora-(coordinator|daemon|runtime)" > /dev/null 2>&1 || true
+    # Reap orphan example nodes that bind a FIXED port -- e.g. the MAVLink bridge
+    # on udp:14550. If one lingers (hard-killed local run, or not self-exiting on
+    # coordinator loss), the next mavlink example dies with "Address already in
+    # use". These patterns only match the mavlink example binaries, so they're
+    # no-ops for every other example.
+    pkill -f "$ROOT/target/(debug|release)/dora-mavlink2-bridge-node" > /dev/null 2>&1 || true
+    pkill -f "$ROOT/target/(debug|release)/mavlink2-bridge-example" > /dev/null 2>&1 || true
     sleep 0.5
 }
 
@@ -124,6 +153,54 @@ sys.exit(0 if ".py" in content or "pip install" in content else 1)
 PY
 }
 
+# Python examples must run against the WORKSPACE dora bindings. Under `--uv`,
+# dora only builds a per-node managed env (with the workspace dora wheel) for
+# nodes that declare pip/build deps; a dep-less Python node instead runs in the
+# AMBIENT Python env. So those nodes pick up whatever `dora-rs` happens to be
+# installed there -- a stale editable install, nothing, or the PyPI package --
+# none of which matches a workspace-built daemon, e.g. "version mismatch:
+# message format vX.Y.Z is not compatible with v1.0.0-rc1" (or
+# ModuleNotFoundError if dora isn't installed at all).
+# Fix: build + activate a venv with the workspace `-e apis/python/node` so the
+# ambient env those nodes resolve has the workspace bindings. Mirrors
+# scripts/qa/ci-nightly-jobs.sh. Idempotent.
+PY_BINDINGS_READY=false
+PY_BINDINGS_OK=false
+ensure_python_bindings() {
+    [ "$PY_BINDINGS_READY" = true ] && return 0
+    PY_BINDINGS_READY=true
+    if ! command -v uv > /dev/null 2>&1; then
+        echo "  WARN: uv not found -- Python examples use the ambient dora-rs, which may"
+        echo "        version-mismatch the workspace daemon (install uv to fix)."
+        return 0
+    fi
+    if ! command -v maturin > /dev/null 2>&1; then
+        echo "  WARN: maturin not found -- cannot build workspace Python bindings;"
+        echo "        Python examples may fail with a version mismatch (pip install maturin)."
+        return 0
+    fi
+    local venv="$ROOT/target/smoke-venv"
+    echo "Setting up workspace Python bindings in target/smoke-venv (maturin build, first time ~1-3 min)..."
+    uv venv --seed -p 3.12 "$venv" > /dev/null 2>&1 || uv venv --seed "$venv" > /dev/null 2>&1
+    # shellcheck disable=SC1091
+    source "$venv/bin/activate"
+    uv pip install -q pyarrow numpy > /dev/null 2>&1 || true
+    if uv pip install -q -e "$ROOT/apis/python/node" > /dev/null 2>&1; then
+        PY_BINDINGS_OK=true
+        echo "  workspace dora-rs: $(python -c 'import dora; print(dora.__version__)' 2>/dev/null || echo '?')"
+    else
+        echo "  WARN: failed to build workspace Python bindings; Python examples may version-mismatch."
+    fi
+}
+
+# Re-pin the workspace bindings into the active venv. Some examples' build deps
+# pull dora-rs from PyPI and clobber the local version, so call this after a
+# Python example's `dora build` and before its `dora start`/`run`.
+repin_python_bindings() {
+    [ "$PY_BINDINGS_OK" = true ] || return 0
+    uv pip install -q -e "$ROOT/apis/python/node" > /dev/null 2>&1 || true
+}
+
 # Run a dataflow through the full up/start/stop/down lifecycle (networked).
 run_networked() {
     local name="$1" yaml="$2" timeout="${3:-30}"
@@ -133,6 +210,7 @@ run_networked() {
     local uv_args=()
     if needs_uv "$full_yaml"; then
         uv_args=(--uv)
+        ensure_python_bindings
     fi
 
     local logfile
@@ -158,6 +236,8 @@ run_networked() {
         cleanup_stale
         return
     fi
+    # The build may have pulled PyPI dora-rs; re-pin the workspace bindings.
+    [ ${#uv_args[@]} -gt 0 ] && repin_python_bindings
     printf ' ok |  start'
 
     if ! run_dora_step "$logfile" start "$full_yaml" --detach ${uv_args[@]+"${uv_args[@]}"}; then
@@ -179,14 +259,16 @@ run_networked() {
         elapsed=$((elapsed + 2))
         printf '\r  up ok |  build ok |  start ok | running %ds/%ds ' "$elapsed" "$timeout"
         local list_out
-        list_out=$("$DORA" list --json 2>/dev/null || echo "")
-        if [ -z "$list_out" ]; then
-            break
-        fi
+        # NOTE: `dora list --json` exits non-zero (2) even on success when there
+        # are no dataflows, so the exit code is NOT a reliable failure signal --
+        # parse stdout only, matching the authoritative Rust suite
+        # (tests/example-smoke.rs, which uses .output().ok() and ignores status).
+        list_out=$("$DORA" list --json 2>/dev/null || true)
         if echo "$list_out" | grep -q "Failed"; then
             failed=true
             break
         fi
+        # Nothing left Running (empty list or all Finished) -> done.
         if ! echo "$list_out" | grep -q "Running"; then
             break
         fi
@@ -213,6 +295,7 @@ run_local() {
     local uv_args=()
     if needs_uv "$full_yaml"; then
         uv_args=(--uv)
+        ensure_python_bindings
     fi
     echo "=> $name (local, ${timeout}s, hard-kill ${hard_timeout}s)"
 
@@ -220,19 +303,26 @@ run_local() {
     logfile=$(mktemp -t "smoke-${name}.XXXXXX")
     trap 'rm -f "$logfile"' RETURN
 
-    if [ "$VERBOSE" = true ]; then
-        "$DORA" run "$full_yaml" --stop-after "${timeout}s" \
-            ${uv_args[@]+"${uv_args[@]}"} 2>&1 | tee "$logfile" &
-    else
-        "$DORA" run "$full_yaml" --stop-after "${timeout}s" \
-            ${uv_args[@]+"${uv_args[@]}"} > "$logfile" 2>&1 &
-    fi
+    # Always run dora directly into the logfile in the background so $pid is
+    # dora's PID. Piping to `tee` would make $pid the tee PID, so `wait` would
+    # return tee's (always-0) status and mask a node-level failure as PASS, and
+    # the hard-kill would target tee, orphaning dora. In verbose mode, stream
+    # the log live with a separate `tail -f`.
+    "$DORA" run "$full_yaml" --stop-after "${timeout}s" \
+        ${uv_args[@]+"${uv_args[@]}"} > "$logfile" 2>&1 &
     local pid=$!
+    local tail_pid=""
+    if [ "$VERBOSE" = true ]; then
+        tail -f "$logfile" &
+        tail_pid=$!
+    fi
     local elapsed=0
     while kill -0 "$pid" 2>/dev/null; do
         if [ "$elapsed" -ge "$hard_timeout" ]; then
+            pkill -9 -P "$pid" 2>/dev/null || true   # reap spawned nodes/daemon
             kill -9 "$pid" 2>/dev/null || true
             wait "$pid" 2>/dev/null || true
+            [ -n "$tail_pid" ] && kill "$tail_pid" 2>/dev/null || true
             echo ""
             dump_tail "$logfile"
             log_fail "$name (hard-killed after ${hard_timeout}s)"
@@ -245,8 +335,13 @@ run_local() {
         fi
     done
     [ "$VERBOSE" != true ] && echo ""
-    wait "$pid" 2>/dev/null
-    if [ $? -eq 0 ]; then
+    # Guarded wait: capture dora's real exit status without letting `set -e`
+    # abort the whole script when one example exits nonzero (which would kill
+    # the run mid-way with no FAIL line and no summary).
+    local rc=0
+    wait "$pid" 2>/dev/null || rc=$?
+    [ -n "$tail_pid" ] && kill "$tail_pid" 2>/dev/null || true
+    if [ "$rc" -eq 0 ]; then
         [ "$SHOW_OUTPUT" = true ] && dump_tail "$logfile" 15
         log_pass "$name"
     else
@@ -379,6 +474,11 @@ if [ "$RUN_PYTHON" = true ]; then
     run_networked "typed-dataflow"          "examples/typed-dataflow/dataflow.yml" 15
     run_networked "streaming-example"       "examples/streaming-example/dataflow.yml" 15
     run_networked "python-recv-async"      "examples/python-recv-async/dataflow.yml" 30
+    # Zero-copy send_output_raw -- the API backing dora's zero-copy guarantee.
+    # contract_dataflow.yml self-checks the buffer-protocol safety contract and
+    # exits nonzero on violation (validated by the run_local exit-code check).
+    run_networked "python-zero-copy-send"          "examples/python-zero-copy-send/dataflow.yml" 30
+    run_networked "python-zero-copy-send-contract" "examples/python-zero-copy-send/contract_dataflow.yml" 30
 
     echo ""
     echo "=== Python examples (local) ==="
@@ -394,6 +494,8 @@ if [ "$RUN_PYTHON" = true ]; then
     run_local "local-typed-dataflow"          "examples/typed-dataflow/dataflow.yml" 10
     run_local "local-streaming-example"       "examples/streaming-example/dataflow.yml" 10
     run_local "local-python-recv-async"    "examples/python-recv-async/dataflow.yml" 15
+    run_local "local-python-zero-copy-send"          "examples/python-zero-copy-send/dataflow.yml" 15
+    run_local "local-python-zero-copy-send-contract" "examples/python-zero-copy-send/contract_dataflow.yml" 15
 
     echo ""
     echo "=== Queue/timeout regression tests (local, timing-sensitive) ==="
@@ -469,7 +571,15 @@ log_skip "cmake-dataflow" "CMake + C++"
 log_skip "python-dataflow-builder" "no YAML (API-based)"
 log_skip "dynamic-add-remove" "interactive dynamic topology CLI"
 log_skip "dynamic-agent-tools" "interactive dynamic topology CLI"
+log_skip "rust-dynamic-add-remove" "dynamic topology lifecycle (covered by node-lifecycle-e2e)"
+log_skip "cxx-dynamic-add-remove" "C++/CMake + dynamic topology (covered by node-lifecycle-e2e)"
 log_skip "mavlink2-bridge-cxx" "C++ + Arrow C++ libs (covered by cxx examples job)"
+log_skip "cpu-affinity-probe" "Linux-only cpu_affinity (covered by example-smoke.rs + nightly)"
+log_skip "error-propagation" "deliberate node failure demo (success == nonzero exit)"
+log_skip "python-parquet-recorder" "webcam + opencv"
+log_skip "python-yolo-detection" "webcam + YOLO + torch"
+log_skip "mavlink2-bridge-sitl-mission" "external ArduPilot SITL on udp:14550"
+log_skip "ros2-comparison" "ROS2 rclpy comparison (and dataflow.yml node paths are stale, see #issue)"
 
 # ---------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
Audit-driven hardening of `scripts/smoke-all.sh` (the human smoke runner) ahead of 1.0.0-rc1, plus a coverage fix to `scripts/ros2dev.sh`. Found via a multi-agent audit + repeated local runs.

## Why

The current `smoke-all.sh` could **report a false green or abort mid-run with no summary**, and its Python half didn't reliably test the *workspace* bindings. Concretely, before this PR a single failing local example aborted the whole run (no FAIL line, every later example skipped), and dep-less Python nodes ran against whatever `dora-rs` happened to be in the ambient env, version-mismatching the rc1 workspace daemon.

## Robustness fixes

- **`run_local` `set -e` abort** — guard `wait` (`wait "$pid" || rc=$?`) so a failing example logs FAIL and the run continues. Previously one bad example killed the run with no summary.
- **`run_local --verbose`** — run dora directly in the background instead of `| tee` (so `$pid` is dora's, not tee's; `wait` was returning tee's always-0 status and masking node failures, and the hard-kill hit tee, orphaning dora).
- **`run_networked`** — parse `dora list --json` stdout only; it exits non-zero (2) even on success, so the exit code is not a failure signal (matches the authoritative `tests/example-smoke.rs`).
- **`cleanup_stale`** — reap orphan repo-local coordinator/daemon and the fixed-port MAVLink bridge/sim nodes between examples (a lingering daemon holds port 6013, the bridge holds `udp:14550` → "address already in use" in the next example). Drop the redundant `destroy` (it's an alias of `down`).
- **Build/setup failures** — abort with a clear line + the failing output instead of `| tail -1` (which hid the error and died with no summary).

## Coverage fixes

- **Workspace Python bindings** — build + activate a venv with `-e apis/python/node` (uv + maturin) and run Python examples against it. Under `--uv`, dora only builds a per-node managed env (with the workspace dora wheel) for nodes that declare pip/build deps; a **dep-less Python node runs in the ambient Python env** and resolves whatever `dora-rs` is installed there — a stale editable install, nothing, or the PyPI package — none of which matches a 1.0.0-rc1 daemon (e.g. `message format vX.Y.Z is not compatible with v1.0.0-rc1`, or `ModuleNotFoundError`). The venv makes that ambient env carry the workspace bindings. Mirrors `scripts/qa/ci-nightly-jobs.sh`. (Verified in a clean venv: nodes that declare deps get a managed env with the workspace wheel automatically; dep-less nodes are the ones that need this venv.)
- **python-zero-copy-send** + its self-checking contract added — the zero-copy `send_output_raw` API was entirely unsmoked.
- **Explicit skips** for every remaining example dir (cpu-affinity-probe, error-propagation, rust/cxx-dynamic-add-remove, python-parquet-recorder, python-yolo-detection, mavlink2-bridge-sitl-mission, ros2-comparison) → **0 silently-uncovered examples** (was 9).
- Header now documents that PASS means "ran without crashing", not "output verified" (semantic assertions live in `cargo test --test example-smoke`).

**`scripts/ros2dev.sh`**: add the 3 ros2-bridge `[[example]]` targets missing from the release QA gate (rust + cxx action-server, rust parameter) so it can't report all-green while shipped examples go unexercised.

## Local run result

After these script fixes the runner completes reliably with a trustworthy summary. With a current `uv` and a clean ambient env, the only genuine product bug it surfaces is **#2004** — networked `dora build --uv` + `dora start --uv` loses the managed-env recording ("no managed env was recorded during build"); `dora run --uv` (local) works. Verified against the latest uv (0.11.18), so it's a real handoff bug, not a tooling artifact.

It also surfaced #2001 (ros2-comparison broken YAML) and #2002 (semver.sh / unwrap-budget.sh QA-gate logic).

Note: an earlier draft of this PR referenced a `dora build` "invalid uv flag" bug — that was a false alarm from a stale local uv (0.8.3) and has been retracted (#2003 closed). `smoke-all.sh` does not pass any `uv build` flags and is unaffected.

`bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
