### PR TITLE
Separate Zenoh topics for node output and daemon control

### DIFF
--- a/binaries/coordinator/src/ws_control.rs
+++ b/binaries/coordinator/src/ws_control.rs
@@ -410,7 +410,7 @@ pub(crate) async fn handle_control_ws(
     }
 }
 
-/// Publish JSON data to a Zenoh topic as a serialized `InterDaemonEvent::Output`.
+/// Publish JSON data as a serialized `InterDaemonEvent::Output`.
 ///
 /// The JSON string is stored as raw UTF-8 bytes in a UInt8 Arrow array.
 async fn publish_topic(
@@ -421,7 +421,7 @@ async fn publish_topic(
     clock: &dora_core::uhlc::HLC,
     session: &mut Option<zenoh::Session>,
 ) -> Result<(), String> {
-    let topic = dora_core::topics::zenoh_output_publish_topic(dataflow_id, node_id, output_id);
+    let topic = dora_core::topics::zenoh_daemon_control_topic(dataflow_id, node_id, output_id);
 
     // Store JSON as raw UTF-8 bytes in a UInt8 array
     let data_bytes = data_json.as_bytes();

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -10,7 +10,7 @@ use dora_core::{
     },
     topics::{
         DORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT, LOCALHOST, open_zenoh_session_with_listen,
-        reserve_loopback_zenoh_endpoint, zenoh_output_publish_topic,
+        reserve_loopback_zenoh_endpoint, zenoh_daemon_control_topic, zenoh_output_publish_topic,
     },
     uhlc::{self, HLC},
 };
@@ -2726,8 +2726,8 @@ impl Daemon {
                         .wrap_err("no remote_daemon_events_tx channel")?;
                     let mut finished_rx = dataflow.finished_tx.subscribe();
                     let subscribe_topic =
-                        zenoh_output_publish_topic(dataflow.id, &output_id.0, &output_id.1);
-                    tracing::debug!("declaring subscriber on {subscribe_topic}");
+                        zenoh_daemon_control_topic(dataflow.id, &output_id.0, &output_id.1);
+                    tracing::debug!("declaring control subscriber on {subscribe_topic}");
                     let subscriber = self
                         .zenoh_session
                         .declare_subscriber(subscribe_topic)
@@ -2760,30 +2760,13 @@ impl Daemon {
                                     finished = f;
                                     match sample {
                                         Ok(s) => {
-                                            // Count telemetry for every received sample. Use the
-                                            // cheap length accessor so we don't materialize the
-                                            // payload (`to_bytes()` copies for multi-region buffers)
-                                            // for the samples we skip below.
+                                            // Count telemetry for every received control sample.
                                             net_bytes_rx.fetch_add(
                                                 s.payload().len() as u64,
                                                 std::sync::atomic::Ordering::Relaxed,
                                             );
                                             net_msgs_rx
                                                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                            // dora #1992: since #1787 moved data routing off the
-                                            // daemon, nodes publish their raw output directly to
-                                            // this same Zenoh key (raw payload + bincode Metadata
-                                            // in the Zenoh ATTACHMENT) and the consumer node reads
-                                            // it directly (apis/rust/node/src/event_stream/mod.rs).
-                                            // Such samples carry an attachment; daemon-emitted
-                                            // InterDaemonEvent frames (Output fallback /
-                                            // OutputClosed in send_to_remote_receivers) NEVER set
-                                            // one. Skip attachment-bearing samples here so the
-                                            // daemon does not bincode-decode node raw output (which
-                                            // fails with "failed to deserialize InterDaemonEvent").
-                                            if s.attachment().is_some() {
-                                                continue;
-                                            }
                                             let bytes = s.payload().to_bytes();
                                             let event =
                                                 Timestamped::deserialize_inter_daemon_event(&bytes)
@@ -3267,8 +3250,8 @@ impl Daemon {
             std::collections::btree_map::Entry::Occupied(e) => e.get().clone(),
             std::collections::btree_map::Entry::Vacant(e) => {
                 let publish_topic =
-                    zenoh_output_publish_topic(dataflow.id, &output_id.0, &output_id.1);
-                tracing::debug!("declaring publisher on {publish_topic}");
+                    zenoh_daemon_control_topic(dataflow.id, &output_id.0, &output_id.1);
+                tracing::debug!("declaring control publisher on {publish_topic}");
                 let publisher = self
                     .zenoh_session
                     .declare_publisher(publish_topic)

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -370,4 +370,33 @@ mod tests {
             .expect("endpoint has a numeric port");
         assert!(port > 0, "kernel must hand out a non-zero ephemeral port");
     }
+
+    // Node raw output and daemon control frames MUST live on distinct Zenoh
+    // keys: they share neither format nor consumer, and merging them caused the
+    // #1992 crossover (daemon bincode-decoding node output). Guard the split.
+    #[cfg(feature = "zenoh")]
+    #[test]
+    fn output_and_control_topics_are_distinct() {
+        use dora_message::id::{DataId, NodeId};
+
+        let dataflow_id = uuid::Uuid::nil();
+        let node = NodeId::from("node".to_string());
+        let output = DataId::from("out".to_string());
+
+        let output_topic = zenoh_output_publish_topic(dataflow_id, &node, &output);
+        let control_topic = zenoh_daemon_control_topic(dataflow_id, &node, &output);
+
+        assert!(
+            output_topic.contains("/output/"),
+            "node output key must contain `/output/`, got {output_topic}"
+        );
+        assert!(
+            control_topic.contains("/control/"),
+            "daemon control key must contain `/control/`, got {control_topic}"
+        );
+        assert_ne!(
+            output_topic, control_topic,
+            "node output and daemon control must not share a Zenoh key (dora #1992/#2008)"
+        );
+    }
 }

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -319,17 +319,12 @@ pub fn reserve_loopback_zenoh_endpoint() -> std::io::Result<String> {
     Ok(format!("tcp/127.0.0.1:{port}"))
 }
 
-/// Zenoh key for a node output. Two message classes share this key, and the
-/// **Zenoh attachment distinguishes them** (a load-bearing contract relied on by
-/// both the daemon and the consumer node — see dora #1992):
-/// - **attachment present** => a node's raw output publish (raw payload + bincode
-///   `Metadata` in the attachment). Read directly by the consumer node; the daemon
-///   ignores it (data routing moved off the daemon in #1787).
-/// - **attachment absent** => a bincode `Timestamped<InterDaemonEvent>` frame
-///   emitted by the daemon (Output fallback / OutputClosed) or coordinator.
+/// Zenoh key for node output data.
 ///
-/// A new publisher to this key MUST follow this rule: raw output sets an
-/// attachment, daemon/coordinator frames never do.
+/// Payload format: raw Arrow bytes with bincode `Metadata` in the Zenoh
+/// attachment. This topic is published by nodes and consumed directly by
+/// downstream nodes (plus debug-inspection subscribers). Daemon control frames
+/// must not be published here; use [`zenoh_daemon_control_topic`] instead.
 #[cfg(feature = "zenoh")]
 pub fn zenoh_output_publish_topic(
     dataflow_id: uuid::Uuid,
@@ -338,6 +333,23 @@ pub fn zenoh_output_publish_topic(
 ) -> String {
     let network_id = "default";
     format!("dora/{network_id}/{dataflow_id}/output/{node_id}/{output_id}")
+}
+
+/// Zenoh key for control frames associated with a node output.
+///
+/// Payload format: bincode `Timestamped<InterDaemonEvent>` with no Zenoh
+/// attachment. Published by daemons for inter-daemon control (for example
+/// `OutputClosed`) and by the coordinator for explicit topic injection. Keeping
+/// this separate from [`zenoh_output_publish_topic`] avoids mixing control frames
+/// with raw node output payloads on the same key.
+#[cfg(feature = "zenoh")]
+pub fn zenoh_daemon_control_topic(
+    dataflow_id: uuid::Uuid,
+    node_id: &dora_message::id::NodeId,
+    output_id: &dora_message::id::DataId,
+) -> String {
+    let network_id = "default";
+    format!("dora/{network_id}/{dataflow_id}/control/{node_id}/{output_id}")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- add a dedicated Zenoh daemon control topic for serialized Timestamped InterDaemonEvent frames
- keep the existing output publish topic for raw node output payloads with metadata attachments
- move daemon control subscribers/publishers and coordinator topic injection to the control topic
- remove the attachment-based daemon skip heuristic

Fixes #2008.

## Validation

- cargo check -p dora-core --features zenoh
- cargo check -p dora-daemon
- cargo check -p dora-coordinator
- cargo fmt --all -- --check
- git diff --check
- cargo run --example multiple-daemons