### PR TITLE
fix(qa): enforce semver gate post-1.0 + count unwraps after inline cfg(test) (#2002)

### DIFF
--- a/scripts/qa/semver.sh
+++ b/scripts/qa/semver.sh
@@ -41,8 +41,20 @@ done
 
 if [[ "$FAILED" == "1" ]]; then
   echo
-  echo "SemVer check found breaking changes."
-  echo "During 0.x this is a warning. After 1.0 this will be a hard fail."
-  # Soft warning during 0.x — exit 0 even on breaks
-  exit 0
+  # Soft warning during 0.x; hard gate once the workspace hits 1.0 (API
+  # stability is the 1.0 promise). Read the workspace version from the root
+  # Cargo.toml ([workspace.package] version).
+  WORKSPACE_VERSION=$(awk -F'"' '/^version = /{print $2; exit}' Cargo.toml)
+  echo "SemVer check found breaking changes (workspace version: ${WORKSPACE_VERSION:-unknown})."
+  case "$WORKSPACE_VERSION" in
+    0.*|"")
+      echo "During 0.x this is a soft warning (exit 0)."
+      exit 0
+      ;;
+    *)
+      echo "Post-1.0: breaking changes are a hard failure. Bump the major"
+      echo "version or revert the breaking change."
+      exit 1
+      ;;
+  esac
 fi

--- a/scripts/qa/unwrap-budget.sh
+++ b/scripts/qa/unwrap-budget.sh
@@ -49,27 +49,34 @@ count_unwraps() {
       */tests.rs) continue ;;
     esac
     # Rule 3: skip each #[cfg(test)] block, count unwrap/expect in the rest.
-    # The block ends at a `}` DEDENTED to the attribute's indentation. We use
-    # dedent (not raw brace counting) because counting `{`/`}` would miscount
-    # braces inside string literals and `format!("{}")` macros that pepper test
-    # code; the block-closing brace is the only `}` back at the attribute indent.
+    # A MULTI-LINE block opener ends with `{` (rustfmt puts the opening brace
+    # last); its matching close is the only `}` DEDENTED back to the attribute
+    # indent. We key off dedent + the trailing-`{`, not raw brace counting,
+    # because counting `{`/`}` miscounts braces inside string literals and
+    # `format!("{}")` macros that pepper test code. A SELF-CONTAINED one-line
+    # item (`#[cfg(test)] fn helper() {}` or a `mod tests;` decl) is fully on
+    # one line and is skipped without entering block mode, so production code
+    # after it is still counted.
     local n
     n=$(awk '
-      # Inside a test block: ends when a `}` dedents to the attribute indent.
+      # Inside a multi-line test block: ends at a `}` dedented to its indent.
       in_test {
         if ($0 ~ ("^" ind "[}]")) in_test = 0
         next
       }
-      # Saw #[cfg(test)]; skip the items signature lines until its opening `{`
-      # (block, e.g. mod/fn/impl) or a `;` terminator (one-line decl).
+      # Saw #[cfg(test)] with the item on later line(s): skip signature lines
+      # until the opener ends with `{` (enter block), or the item resolves on a
+      # single line (one-line `{...}` body, or a `;`-terminated decl).
       awaiting {
-        if ($0 ~ /[{]/) { awaiting = 0; in_test = 1 }
-        else if ($0 ~ /;[[:space:]]*$/) awaiting = 0
+        if ($0 ~ /\{[[:space:]]*$/) { awaiting = 0; in_test = 1 }
+        else if ($0 ~ /[{};]/) awaiting = 0
         next
       }
       /^[[:space:]]*#\[cfg\(test\)\]/ {
         ind = $0; sub(/[^ \t].*/, "", ind)   # leading whitespace = indent
-        if ($0 ~ /[{]/) in_test = 1; else awaiting = 1
+        if ($0 ~ /\{[[:space:]]*$/) in_test = 1      # multi-line block opener
+        else if ($0 !~ /[{]/) awaiting = 1           # brace is on a later line
+        # else: self-contained one-line `{...}` item -> skip just this line
         next
       }
       {

--- a/scripts/qa/unwrap-budget.sh
+++ b/scripts/qa/unwrap-budget.sh
@@ -12,14 +12,16 @@
 #      `#[cfg(test)] mod tests;` from a sibling source file — the file
 #      content does not carry the cfg(test) attribute but the whole
 #      file is test-only)
-#   3. Content after the first `#[cfg(test)]` line in any remaining
-#      source file (inline `mod tests {}` blocks at the bottom of a
-#      source file — dora's convention)
+#   3. Each `#[cfg(test)]`-attributed item (the brace-balanced `mod`/`fn`/
+#      `impl` block that follows the attribute) — inline test modules and
+#      test helpers anywhere in a source file, not just at EOF.
 #
-# Rule 3 uses simple line-based truncation, which works because dora
-# consistently places `#[cfg(test)]` only at the top of a test module
-# and only at the end of source files. Verified 2026-04-08 by grep —
-# if this convention changes, this script must be updated.
+# Rule 3 brace-balances each `#[cfg(test)]` block instead of truncating to
+# EOF, so production code that follows an interspersed test block (e.g. a
+# `#[cfg(test)]` helper fn before more production fns, as in
+# binaries/cli/src/output.rs) is still counted. All `#[cfg(test)]` items in
+# the counted source are brace blocks (mod/fn/impl); brace-less attributed
+# items (`#[cfg(test)] use ...;`) do not occur and are not handled.
 
 set -euo pipefail
 
@@ -36,8 +38,8 @@ fi
 # Count unwrap/expect in non-test source code. Three steps:
 # 1. Enumerate candidate .rs files (excluding tests/, examples/, build.rs)
 # 2. Drop files named tests.rs (submodule test files)
-# 3. For each remaining file, strip content from the first #[cfg(test)]
-#    line to EOF, then count .unwrap() / .expect( occurrences.
+# 3. For each remaining file, skip each #[cfg(test)] brace-balanced block
+#    (mod/fn/impl) and count .unwrap() / .expect( in the rest.
 count_unwraps() {
   local total=0
   local file
@@ -46,10 +48,30 @@ count_unwraps() {
     case "$file" in
       */tests.rs) continue ;;
     esac
-    # Rule 3: truncate at first #[cfg(test)] line, count unwraps in head
+    # Rule 3: skip each #[cfg(test)] block, count unwrap/expect in the rest.
+    # The block ends at a `}` DEDENTED to the attribute's indentation. We use
+    # dedent (not raw brace counting) because counting `{`/`}` would miscount
+    # braces inside string literals and `format!("{}")` macros that pepper test
+    # code; the block-closing brace is the only `}` back at the attribute indent.
     local n
     n=$(awk '
-      /^[[:space:]]*#\[cfg\(test\)\]/ { exit }
+      # Inside a test block: ends when a `}` dedents to the attribute indent.
+      in_test {
+        if ($0 ~ ("^" ind "[}]")) in_test = 0
+        next
+      }
+      # Saw #[cfg(test)]; skip the items signature lines until its opening `{`
+      # (block, e.g. mod/fn/impl) or a `;` terminator (one-line decl).
+      awaiting {
+        if ($0 ~ /[{]/) { awaiting = 0; in_test = 1 }
+        else if ($0 ~ /;[[:space:]]*$/) awaiting = 0
+        next
+      }
+      /^[[:space:]]*#\[cfg\(test\)\]/ {
+        ind = $0; sub(/[^ \t].*/, "", ind)   # leading whitespace = indent
+        if ($0 ~ /[{]/) in_test = 1; else awaiting = 1
+        next
+      }
       {
         n = gsub(/\.unwrap\(\)|\.expect\(/, "&")
         if (n > 0) count += n


### PR DESCRIPTION
## Summary

Closes #2002. Two release-QA gates report "green" while under-checking.

## 1. `scripts/qa/semver.sh` — never failed on breaking changes (post-1.0)

The script's header promised a post-1.0 hard gate, but the code unconditionally `exit 0`'d on breakage. The workspace is now `1.0.0-rc1`, so the documented gate never engaged — `make qa-deep`/`qa-release-gate` would print "found breaking changes" and pass.

**Fix:** read the workspace version from `Cargo.toml` (`[workspace.package] version`) and hard-fail (`exit 1`) on breakage when it's ≥ 1.0; keep the soft warning for `0.x` (and as a safe fallback if the version can't be read).

```
1.0.0-rc1 -> HARD (exit 1)    0.5.0 -> SOFT (exit 0)
1.2.3     -> HARD (exit 1)    0.3.13 -> SOFT (exit 0)
```

(`cargo-semver-checks` compares against a git-tag baseline and is version-aware, so the intentional 0.x→1.0 major bump is *not* flagged — the hard gate only trips on changes that violate the current version's contract.)

## 2. `scripts/qa/unwrap-budget.sh` — Rule 3 hid production code after inline `#[cfg(test)]`

The awk truncated each file at the **first** `#[cfg(test)]` line to EOF, so `.unwrap()`/`.expect(` in production code *after* an interspersed test block were excluded from the ratchet. Example: `binaries/cli/src/output.rs` has a `#[cfg(test)]` helper fn, then production `calculate_char_sum`, then the real `mod tests`. Any unwrap added to that middle region was silently uncounted — a latent ratchet defeat.

**Fix:** skip each `#[cfg(test)]` block by **dedent** (the block-closing `}` back at the attribute's indentation) and count the rest, instead of truncating to EOF.

- Dedent, **not** raw brace-counting: `{`/`}` inside string literals and `format!("{}")` macros that pepper test code make brace balance unreliable (my first attempt over-counted test unwraps for exactly this reason). The block-closing brace is the only `}` back at the attribute's indent.
- All `#[cfg(test)]` items in the counted source are brace blocks (`mod`/`fn`/`impl`, verified across 73 occurrences); brace-less attributed items don't occur.

**Verified:** count is **unchanged at 163** on current `main` (old-awk and new-awk agree, no per-file diffs) — the previously-hidden regions happen to have zero unwraps today — but new production unwraps in those regions will now be caught. The budget (185) is untouched; the gate passes.

`bash -n` clean on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
