### PR TITLE
test(mavlink2-bridge): cover write-path Arrow round-trips

### DIFF
--- a/libraries/extensions/mavlink2-bridge/tests/arrow_roundtrip.rs
+++ b/libraries/extensions/mavlink2-bridge/tests/arrow_roundtrip.rs
@@ -7,9 +7,11 @@ use dora_mavlink2_bridge::MavlinkArrow;
 use dora_mavlink2_bridge::mavlink::common::{
     ATTITUDE_DATA, ATTITUDE_QUATERNION_DATA, COMMAND_ACK_DATA, COMMAND_LONG_DATA,
     GLOBAL_POSITION_INT_DATA, GPS_RAW_INT_DATA, GpsFixType, HEARTBEAT_DATA,
-    LOCAL_POSITION_NED_DATA, MISSION_CURRENT_DATA, MavAutopilot, MavCmd, MavModeFlag, MavResult,
-    MavState, MavSysStatusSensor, MavType, RC_CHANNELS_DATA, SERVO_OUTPUT_RAW_DATA,
-    SYS_STATUS_DATA, SYSTEM_TIME_DATA,
+    LOCAL_POSITION_NED_DATA, MISSION_CURRENT_DATA, MavAutopilot, MavCmd, MavFrame, MavMode,
+    MavModeFlag, MavResult, MavState, MavSysStatusSensor, MavType, PositionTargetTypemask,
+    RC_CHANNELS_DATA, RC_CHANNELS_OVERRIDE_DATA, SERVO_OUTPUT_RAW_DATA, SET_MODE_DATA,
+    SET_POSITION_TARGET_GLOBAL_INT_DATA, SET_POSITION_TARGET_LOCAL_NED_DATA, SYS_STATUS_DATA,
+    SYSTEM_TIME_DATA,
 };
 
 #[test]
@@ -294,4 +296,190 @@ fn mission_current_arrow_roundtrip() {
     let batch = original.to_record_batch().expect("encode");
     let decoded = MISSION_CURRENT_DATA::from_record_batch(&batch).expect("decode");
     assert_eq!(decoded.seq, original.seq);
+}
+
+// -----------------------------------------------------------------------------
+// Write-path (dora -> MAVLink) round-trips.
+//
+// These are the messages that arm and move a vehicle, so they get stricter
+// coverage than the telemetry tests above: every field gets a *distinct*
+// sentinel value and every field is asserted. The schema list and the
+// column-builder list in each impl are two parallel, manually-ordered lists;
+// transposing two same-Arrow-type fields between them is not a compile error
+// and not caught by `RecordBatch::try_new` (the dtypes still match). Distinct
+// per-field sentinels are what make such a swap actually fail the assert —
+// reusing the same value for adjacent same-type fields (e.g. the long runs of
+// Float32 in the SET_POSITION_TARGET messages) would silently pass.
+// -----------------------------------------------------------------------------
+
+#[test]
+fn set_mode_arrow_roundtrip() {
+    let original = SET_MODE_DATA {
+        custom_mode: 42,
+        target_system: 7,
+        // Must be one of mavlink-rust 0.13's strict MavMode variants
+        // (see the SET_MODE limitation note in arrow_convert.rs); a raw
+        // ArduPilot custom-mode base_mode would not round-trip.
+        base_mode: MavMode::MAV_MODE_GUIDED_ARMED,
+    };
+    let batch = original.to_record_batch().expect("encode");
+    assert_eq!(batch.num_rows(), 1);
+    let decoded = SET_MODE_DATA::from_record_batch(&batch).expect("decode");
+    assert_eq!(decoded.custom_mode, original.custom_mode);
+    assert_eq!(decoded.target_system, original.target_system);
+    assert_eq!(decoded.base_mode, original.base_mode);
+}
+
+#[test]
+fn rc_channels_override_arrow_roundtrip() {
+    let original = RC_CHANNELS_OVERRIDE_DATA {
+        target_system: 9,
+        target_component: 11,
+        chan1_raw: 1001,
+        chan2_raw: 1002,
+        chan3_raw: 1003,
+        chan4_raw: 1004,
+        chan5_raw: 1005,
+        chan6_raw: 1006,
+        chan7_raw: 1007,
+        chan8_raw: 1008,
+    };
+    let batch = original.to_record_batch().expect("encode");
+    assert_eq!(batch.num_rows(), 1);
+    let decoded = RC_CHANNELS_OVERRIDE_DATA::from_record_batch(&batch).expect("decode");
+    assert_eq!(decoded.target_system, original.target_system);
+    assert_eq!(decoded.target_component, original.target_component);
+    assert_eq!(decoded.chan1_raw, original.chan1_raw);
+    assert_eq!(decoded.chan2_raw, original.chan2_raw);
+    assert_eq!(decoded.chan3_raw, original.chan3_raw);
+    assert_eq!(decoded.chan4_raw, original.chan4_raw);
+    assert_eq!(decoded.chan5_raw, original.chan5_raw);
+    assert_eq!(decoded.chan6_raw, original.chan6_raw);
+    assert_eq!(decoded.chan7_raw, original.chan7_raw);
+    assert_eq!(decoded.chan8_raw, original.chan8_raw);
+}
+
+#[test]
+fn set_position_target_global_int_arrow_roundtrip() {
+    let original = SET_POSITION_TARGET_GLOBAL_INT_DATA {
+        time_boot_ms: 8000,
+        lat_int: 379_000_000,
+        lon_int: -1_223_000_000,
+        // Distinct value per Float32 slot so a transposition anywhere in
+        // the 9-field alt..yaw_rate run is caught.
+        alt: 100.0,
+        vx: 1.0,
+        vy: 2.0,
+        vz: 3.0,
+        afx: 4.0,
+        afy: 5.0,
+        afz: 6.0,
+        yaw: 7.0,
+        yaw_rate: 8.0,
+        type_mask: PositionTargetTypemask::POSITION_TARGET_TYPEMASK_AX_IGNORE
+            | PositionTargetTypemask::POSITION_TARGET_TYPEMASK_YAW_IGNORE,
+        target_system: 3,
+        target_component: 4,
+        coordinate_frame: MavFrame::MAV_FRAME_GLOBAL_INT,
+    };
+    let batch = original.to_record_batch().expect("encode");
+    assert_eq!(batch.num_rows(), 1);
+    let decoded = SET_POSITION_TARGET_GLOBAL_INT_DATA::from_record_batch(&batch).expect("decode");
+    assert_eq!(decoded.time_boot_ms, original.time_boot_ms);
+    assert_eq!(decoded.lat_int, original.lat_int);
+    assert_eq!(decoded.lon_int, original.lon_int);
+    assert_eq!(decoded.alt, original.alt);
+    assert_eq!(decoded.vx, original.vx);
+    assert_eq!(decoded.vy, original.vy);
+    assert_eq!(decoded.vz, original.vz);
+    assert_eq!(decoded.afx, original.afx);
+    assert_eq!(decoded.afy, original.afy);
+    assert_eq!(decoded.afz, original.afz);
+    assert_eq!(decoded.yaw, original.yaw);
+    assert_eq!(decoded.yaw_rate, original.yaw_rate);
+    assert_eq!(decoded.type_mask, original.type_mask);
+    assert_eq!(decoded.target_system, original.target_system);
+    assert_eq!(decoded.target_component, original.target_component);
+    assert_eq!(decoded.coordinate_frame, original.coordinate_frame);
+}
+
+#[test]
+fn set_position_target_local_ned_arrow_roundtrip() {
+    let original = SET_POSITION_TARGET_LOCAL_NED_DATA {
+        time_boot_ms: 5000,
+        // 11 adjacent Float32 fields — the worst case for a silent
+        // transposition. Each gets a distinct sentinel.
+        x: 1.0,
+        y: 2.0,
+        z: 3.0,
+        vx: 4.0,
+        vy: 5.0,
+        vz: 6.0,
+        afx: 7.0,
+        afy: 8.0,
+        afz: 9.0,
+        yaw: 10.0,
+        yaw_rate: 11.0,
+        type_mask: PositionTargetTypemask::POSITION_TARGET_TYPEMASK_VX_IGNORE
+            | PositionTargetTypemask::POSITION_TARGET_TYPEMASK_AZ_IGNORE,
+        target_system: 1,
+        target_component: 2,
+        coordinate_frame: MavFrame::MAV_FRAME_LOCAL_NED,
+    };
+    let batch = original.to_record_batch().expect("encode");
+    assert_eq!(batch.num_rows(), 1);
+    let decoded = SET_POSITION_TARGET_LOCAL_NED_DATA::from_record_batch(&batch).expect("decode");
+    assert_eq!(decoded.time_boot_ms, original.time_boot_ms);
+    assert_eq!(decoded.x, original.x);
+    assert_eq!(decoded.y, original.y);
+    assert_eq!(decoded.z, original.z);
+    assert_eq!(decoded.vx, original.vx);
+    assert_eq!(decoded.vy, original.vy);
+    assert_eq!(decoded.vz, original.vz);
+    assert_eq!(decoded.afx, original.afx);
+    assert_eq!(decoded.afy, original.afy);
+    assert_eq!(decoded.afz, original.afz);
+    assert_eq!(decoded.yaw, original.yaw);
+    assert_eq!(decoded.yaw_rate, original.yaw_rate);
+    assert_eq!(decoded.type_mask, original.type_mask);
+    assert_eq!(decoded.target_system, original.target_system);
+    assert_eq!(decoded.target_component, original.target_component);
+    assert_eq!(decoded.coordinate_frame, original.coordinate_frame);
+}
+
+/// Lock every impl's encode side to its declared schema: `to_record_batch`
+/// must emit exactly the `schema()` it advertises (same field names, order,
+/// dtypes, and nullability) and exactly one row. This catches an impl whose
+/// column-builder list drifts in width or dtype from its schema list, and
+/// guards the decode contract that `from_record_batch` reads row 0.
+#[test]
+fn encode_matches_declared_schema() {
+    fn check<T: MavlinkArrow + Default>() {
+        let batch = T::default().to_record_batch().expect("encode default");
+        assert_eq!(batch.num_rows(), 1, "expected exactly one row");
+        assert_eq!(
+            batch.schema().as_ref(),
+            &T::schema(),
+            "to_record_batch() schema drifted from schema()"
+        );
+    }
+
+    check::<HEARTBEAT_DATA>();
+    check::<SYS_STATUS_DATA>();
+    check::<SYSTEM_TIME_DATA>();
+    check::<ATTITUDE_DATA>();
+    check::<ATTITUDE_QUATERNION_DATA>();
+    check::<LOCAL_POSITION_NED_DATA>();
+    check::<GLOBAL_POSITION_INT_DATA>();
+    check::<GPS_RAW_INT_DATA>();
+    check::<RC_CHANNELS_DATA>();
+    check::<SERVO_OUTPUT_RAW_DATA>();
+    check::<COMMAND_LONG_DATA>();
+    check::<COMMAND_ACK_DATA>();
+    check::<MISSION_CURRENT_DATA>();
+    // write path
+    check::<SET_MODE_DATA>();
+    check::<RC_CHANNELS_OVERRIDE_DATA>();
+    check::<SET_POSITION_TARGET_GLOBAL_INT_DATA>();
+    check::<SET_POSITION_TARGET_LOCAL_NED_DATA>();
 }


### PR DESCRIPTION
## Summary

The four command/write-path `MavlinkArrow` impls — the side that arms and moves a vehicle — had **zero** round-trip test coverage, while every telemetry message was tested:

- `SET_MODE_DATA`
- `RC_CHANNELS_OVERRIDE_DATA`
- `SET_POSITION_TARGET_GLOBAL_INT_DATA`
- `SET_POSITION_TARGET_LOCAL_NED_DATA`

This is a **latent footgun, not a live bug** (the impls are consistent today). Each impl maintains the schema field list and the column-builder list as two parallel, manually-ordered lists. Transposing two same-Arrow-type fields between them is **not** a compile error and is **not** caught by `RecordBatch::try_new` (the dtypes still match), so a future copy-paste/reorder edit could silently send e.g. a velocity into an acceleration slot, or swap x↔y. The `SET_POSITION_TARGET` messages are the worst case — 9 and 11 adjacent `Float32` fields.

## Changes (test-only, no production code change)

- Round-trip tests for all four write-path impls, asserting **every** field with a **distinct sentinel value per field** so a transposition actually fails the assert (reusing one value across the adjacent `Float32` runs would let a swap pass silently).
- `encode_matches_declared_schema`: locks **every** impl's `to_record_batch()` to its declared `schema()` (field names, order, dtypes, nullability) and to exactly one row.

## Verification

- Confirmed the tests are effective: a temporary `afx`↔`afy` swap in the source made the local-NED round-trip fail (`left: 8.0, right: 7.0`); reverting restored green.
- `cargo fmt --all -- --check` ✓
- `cargo clippy -p dora-mavlink2-bridge --tests -- -D warnings` ✓
- `cargo test -p dora-mavlink2-bridge` ✓ (18 round-trip tests pass)

## Related issue

Closes #2023.

This implements the two test-based remediations from #2023: (1) round-trip tests for all four write-path impls with distinct per-field sentinels, and (3) a per-impl `to_record_batch().schema() == schema()` + single-row lock. The dangerous gap — a safety-relevant write path with zero coverage where a silent same-type transposition could ship undetected — is now closed and the tests are verified to catch it.

The issue's optional remediation (2) — eliminating the parallel schema-list / builder-list fragility structurally by deriving both from a single source of truth — is **deferred**. With the regression now caught by tests and no live bug today, the structural refactor is a separate, non-urgent follow-up.

Found by a scheduled automated code-review check on the `mavlink2-bridge` component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
