### PR TITLE
fix(ros2-bridge): bound FFIWString::to_rust read by size

### DIFF
--- a/libraries/extensions/ros2-bridge/src/_core/string.rs
+++ b/libraries/extensions/ros2-bridge/src/_core/string.rs
@@ -4,7 +4,7 @@ use std::{
     os::raw::c_char,
 };
 
-use widestring::{U16CStr, U16CString};
+use widestring::U16CString;
 
 use super::traits::{FFIFromRust, FFIToRust};
 
@@ -177,7 +177,12 @@ impl FFIToRust for FFIWString {
         if self.is_empty() {
             Self::Target::new()
         } else {
-            U16String(unsafe { U16CStr::from_ptr_str(self.data).to_ustring() })
+            // Use `size` to bound the read instead of `U16CStr::from_ptr_str`,
+            // which scans for a NUL terminator: that truncates wstrings with an
+            // embedded U+0000 and reads past the buffer if it isn't
+            // NUL-terminated. Mirrors the hardened 8-bit `FFIString::to_str`.
+            let slice = unsafe { std::slice::from_raw_parts(self.data, self.size) };
+            U16String(widestring::U16String::from_vec(slice.to_vec()))
         }
     }
 }
@@ -252,5 +257,27 @@ mod test {
         };
 
         assert_eq!(wstring, unsafe { native_wstring.to_rust() });
+    }
+
+    #[test]
+    fn ffi_wstring_preserves_embedded_nul() {
+        // A ROS2 wstring can legitimately contain an embedded U+0000. The
+        // rosidl C representation stores data + size + capacity precisely so
+        // that interior NULs are representable. `to_rust` must bound the read
+        // by `size` rather than scanning for a terminator, or the payload is
+        // silently truncated at the first NUL.
+        //
+        // Build the buffer directly: `OwnedFFIWString::from_rust` can't
+        // produce this case because `U16CString` rejects interior NULs.
+        let mut data: Vec<u16> = vec![0x0041, 0x0000, 0x0042]; // 'A', NUL, 'B'
+        let native = FFIWString {
+            data: data.as_mut_ptr(),
+            size: data.len(),
+            capacity: data.len(),
+        };
+        // `FFIWString` has no `Drop`, so it only borrows `data`; `to_rust`
+        // copies out before `data` is freed at end of scope.
+        let rust = unsafe { native.to_rust() };
+        assert_eq!(rust, U16String::from(vec![0x0041u16, 0x0000, 0x0042]));
     }
 }


### PR DESCRIPTION
## Summary

`FFIWString::to_rust` in `libraries/extensions/ros2-bridge/src/_core/string.rs` determined the wide-string length by scanning for a NUL terminator via `U16CStr::from_ptr_str`, **ignoring the `size` field the struct already carries**. Its 8-bit sibling `FFIString::to_str` was deliberately hardened to bound the read by `size` (with a comment explaining why), so the two conversion paths were inconsistent and the wide path carried two hazards:

- **Silent truncation of valid data.** A ROS2 wstring / `U16String` can legitimately contain an embedded `U+0000` — the rosidl C representation stores `data + size + capacity` precisely so interior NULs are representable. `from_ptr_str` stops at the first NUL, so any wstring with an embedded `U+0000` is silently truncated on the C++ → Rust conversion.
- **Unbounded read risk.** If a producer ever hands over a buffer that isn't NUL-terminated, `from_ptr_str` reads past the end of the buffer — exactly the hazard the `FFIString` hardening comment calls out, in `unsafe` code.

## Fix

Bound the read by `size`, building the `U16String` from a size-bounded slice, mirroring the hardened 8-bit path:

```rust
let slice = unsafe { std::slice::from_raw_parts(self.data, self.size) };
U16String(widestring::U16String::from_vec(slice.to_vec()))
```

This preserves embedded NULs and never reads beyond `size` elements. Also drops the now-unused `U16CStr` import.

## Test

Adds `ffi_wstring_preserves_embedded_nul`, which round-trips an `['A', NUL, 'B']` buffer constructed directly (`OwnedFFIWString::from_rust` can't produce this case — `U16CString` rejects interior NULs). The existing test only covered a NUL-free string.

## Verification

- New test **fails against the old `from_ptr_str` code** (`left: "A"` vs `right: "A\0B"` — the truncation) and passes with the fix, so it genuinely guards the regression.
- `cargo test -p dora-ros2-bridge --lib _core::string` — 3/3 pass.
- `cargo fmt --all -- --check` ✓
- `cargo clippy -p dora-ros2-bridge --lib` ✓ (only environmental `AMENT_PREFIX_PATH` build-script warnings).

Found by a scheduled automated code-review check on the `ros2-bridge` component. The change strictly matches the already-accepted `FFIString` hardening; a reviewer may still want to confirm the rosidl wstring contract (that `size` counts code units excluding the terminator and interior NULs are valid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)