### PR TITLE
fix(core): enforce ROS2 structural naming rules in validate_ros2_name

### DIFF
--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -647,8 +647,12 @@ fn validate_ros2_qos(
     Ok(())
 }
 
-/// Validate a ROS2 name (topic, service, or action) contains only valid characters.
-/// ROS2 names allow: ASCII alphanumeric, underscore, and forward slash.
+/// Validate a ROS2 name (topic, service, or action) follows ROS2 naming rules.
+///
+/// ROS2 names allow ASCII alphanumeric, underscore, and forward slash characters,
+/// and must additionally be structurally valid: no consecutive slashes, no trailing
+/// slash, not a bare `/`, and each `/`-delimited token must start with an ASCII letter.
+/// See <https://design.ros2.org/articles/topic_and_service_names.html>.
 fn validate_ros2_name(node_id: &NodeId, field: &str, name: &str) -> eyre::Result<()> {
     if name.is_empty() {
         bail!("node `{node_id}`: `{field}` must not be empty");
@@ -661,6 +665,34 @@ fn validate_ros2_name(node_id: &NodeId, field: &str, name: &str) -> eyre::Result
             "node `{node_id}`: invalid `{field}` name `{name}`, \
              only ASCII alphanumeric, underscore, and '/' characters allowed"
         );
+    }
+    if name == "/" {
+        bail!("node `{node_id}`: invalid `{field}` name, must not be a bare '/'");
+    }
+    if name.contains("//") {
+        bail!(
+            "node `{node_id}`: invalid `{field}` name `{name}`, \
+             consecutive slashes ('//') are not allowed"
+        );
+    }
+    if name.ends_with('/') {
+        bail!(
+            "node `{node_id}`: invalid `{field}` name `{name}`, \
+             name must not end with '/'"
+        );
+    }
+    // Each '/'-delimited token must start with an ASCII letter. A leading '/'
+    // (absolute name) produces an empty first token, which is allowed and skipped.
+    for (i, token) in name.split('/').enumerate() {
+        if i == 0 && token.is_empty() {
+            continue;
+        }
+        if !token.starts_with(|c: char| c.is_ascii_alphabetic()) {
+            bail!(
+                "node `{node_id}`: invalid `{field}` name `{name}`, \
+                 each token must start with an ASCII letter (offending token `{token}`)"
+            );
+        }
     }
     Ok(())
 }
@@ -1441,6 +1473,64 @@ mod tests {
         let err = validate_ros2_config(&NodeId::from("n".to_owned()), &config, &inputs, &outputs)
             .unwrap_err();
         assert!(err.to_string().contains("alphanumeric"));
+    }
+
+    #[test]
+    fn ros2_name_accepts_valid() {
+        let node = NodeId::from("n".to_owned());
+        for name in [
+            "topic",
+            "/topic",
+            "/a/b/c",
+            "/add_two_ints",
+            "ns/sub_topic",
+            "/navigate",
+        ] {
+            validate_ros2_name(&node, "topic", name)
+                .unwrap_or_else(|e| panic!("`{name}` should be valid: {e}"));
+        }
+    }
+
+    #[test]
+    fn ros2_name_rejects_double_leading_slash() {
+        let node = NodeId::from("n".to_owned());
+        let err = validate_ros2_name(&node, "topic", "//topic").unwrap_err();
+        assert!(err.to_string().contains("consecutive slashes"));
+    }
+
+    #[test]
+    fn ros2_name_rejects_trailing_slash() {
+        let node = NodeId::from("n".to_owned());
+        let err = validate_ros2_name(&node, "topic", "topic/").unwrap_err();
+        assert!(err.to_string().contains("end with"));
+    }
+
+    #[test]
+    fn ros2_name_rejects_consecutive_interior_slashes() {
+        let node = NodeId::from("n".to_owned());
+        let err = validate_ros2_name(&node, "topic", "topic//sub").unwrap_err();
+        assert!(err.to_string().contains("consecutive slashes"));
+    }
+
+    #[test]
+    fn ros2_name_rejects_bare_slash() {
+        let node = NodeId::from("n".to_owned());
+        let err = validate_ros2_name(&node, "topic", "/").unwrap_err();
+        assert!(err.to_string().contains("bare"));
+    }
+
+    #[test]
+    fn ros2_name_rejects_leading_underscore() {
+        let node = NodeId::from("n".to_owned());
+        let err = validate_ros2_name(&node, "topic", "___").unwrap_err();
+        assert!(err.to_string().contains("ASCII letter"));
+    }
+
+    #[test]
+    fn ros2_name_rejects_token_starting_with_digit() {
+        let node = NodeId::from("n".to_owned());
+        let err = validate_ros2_name(&node, "topic", "/2bad").unwrap_err();
+        assert!(err.to_string().contains("ASCII letter"));
     }
 
     #[test]


### PR DESCRIPTION
`validate_ros2_name` only checked the allowed character set, so
structurally invalid ROS2 names (`//topic`, `topic/`, `topic//sub`,
a bare `/`, leading-underscore tokens like `___`) passed `dora check`
and only failed later at runtime when the bridge created the
publisher/subscriber.

Add structural checks: reject a bare `/`, consecutive slashes, a
trailing slash, and require each `/`-delimited token to start with an
ASCII letter (a leading `/` for absolute names is allowed).

Closes #2017

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
