### PR TITLE
fix(daemon): correct misleading coordinator-reconnect comment and pin kill-on-disconnect behavior

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1070,8 +1070,16 @@ impl Daemon {
                             .wrap_err("failed to send watchdog message to dora-coordinator")?;
 
                         if self.last_coordinator_heartbeat.elapsed() > Duration::from_secs(20) {
-                            // Return error to trigger reconnection loop in run().
-                            // Running dataflows continue — nodes are separate processes.
+                            // Returning `Err` propagates up to the reconnect loop in
+                            // `run_with_builds`, which drops this by-value `Daemon` and
+                            // rebuilds a fresh one. Dropping the `Daemon` drops every
+                            // `RunningNode`, whose `ProcessHandle::drop` submits a
+                            // `ProcessOperation::Kill` — so running nodes ARE terminated
+                            // on a coordinator heartbeat timeout, not preserved. This is
+                            // consistent with the coordinator tearing down / releasing a
+                            // disconnected daemon's dataflows (#2028). Transparent graceful
+                            // degradation (preserving running dataflows across a coordinator
+                            // reconnect) is future work tracked by #1799 — not implemented here.
                             bail!("coordinator heartbeat timeout (20s)")
                         }
                     }

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -648,4 +648,28 @@ mod tests {
             "kill from the previous incarnation must not reach the replacement process"
         );
     }
+
+    // ---- #2029: a dropped ProcessHandle kills its node ----
+    //
+    // Pins the documented coordinator-reconnect behavior (lib.rs heartbeat
+    // timeout): when the by-value `Daemon` is dropped, each `RunningNode`'s
+    // `ProcessHandle::drop` submits a `Kill` to the still-alive wait task, so
+    // running nodes ARE terminated on coordinator disconnect. If anyone makes
+    // `Drop` stop killing (e.g. to "preserve nodes"), this test fails, forcing
+    // the lib.rs comment to be revisited rather than silently drifting.
+    #[test]
+    fn dropping_process_handle_submits_kill() {
+        let (tx, rx) = flume::bounded::<ProcessOperation>(2);
+        let handle = ProcessHandle::new(tx);
+        // Dropping the handle stands in for the `Daemon` (and thus the
+        // `RunningNode`) being dropped on the reconnect path.
+        drop(handle);
+        let op = rx
+            .try_recv()
+            .expect("dropping a ProcessHandle must enqueue an operation for the wait task");
+        assert!(
+            matches!(op, ProcessOperation::Kill),
+            "ProcessHandle::drop must submit Kill, terminating the node on disconnect"
+        );
+    }
 }


### PR DESCRIPTION
The daemon's heartbeat-timeout comment claimed running dataflows continue on coordinator disconnect, but dropping the by-value `Daemon` drops each `RunningNode` whose `ProcessHandle::drop` submits a `Kill`, so nodes are actually terminated — consistent with the coordinator tearing down a disconnected daemon's dataflows (#2028). This corrects the comment to document the real teardown behavior and adds a regression test pinning that `ProcessHandle::drop` submits a `Kill`. Transparent graceful degradation across reconnect remains future work tracked by #1799.

Closes #2029.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
