### PR TITLE
fix(ros2-bridge): emit CDR length prefix for variable-length bool sequences

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,6 +2199,8 @@ name = "dora-ros2-bridge-arrow"
 version = "1.0.0-rc1"
 dependencies = [
  "arrow",
+ "byteorder",
+ "cdr-encoding",
  "dora-ros2-bridge-msg-gen",
  "eyre",
  "ros2-client",

--- a/libraries/extensions/ros2-bridge/arrow/Cargo.toml
+++ b/libraries/extensions/ros2-bridge/arrow/Cargo.toml
@@ -13,3 +13,9 @@ arrow = { workspace = true }
 eyre = { workspace = true }
 ros2-client = "0.8"
 serde = { workspace = true }
+
+[dev-dependencies]
+# CDR codec used by ros2-client 0.8 on the wire; used in tests to verify the
+# real CDR byte layout (length prefixes, alignment) rather than just serde shape.
+cdr-encoding = "0.10"
+byteorder = "1"

--- a/libraries/extensions/ros2-bridge/arrow/src/serialize/sequence.rs
+++ b/libraries/extensions/ros2-bridge/arrow/src/serialize/sequence.rs
@@ -396,7 +396,7 @@ mod tests {
 
     /// Regression test for #2032: a variable-length `sequence<bool>` must be
     /// CDR-encoded with a u32 length prefix. Without it, an actual CDR reader
-    /// mis-parses both the sequence and every following field.
+    /// misparses both the sequence and every following field.
     #[test]
     fn bool_sequence_round_trips_through_real_cdr() {
         // Choose flags whose first element is `true` so that, under the buggy

--- a/libraries/extensions/ros2-bridge/arrow/src/serialize/sequence.rs
+++ b/libraries/extensions/ros2-bridge/arrow/src/serialize/sequence.rs
@@ -5,7 +5,7 @@ use arrow::{
     datatypes::{self, ArrowPrimitiveType, UInt8Type},
 };
 use dora_ros2_bridge_msg_gen::types::primitives::{BasicType, GenericString, NestableType};
-use serde::ser::{SerializeSeq, SerializeTuple};
+use serde::ser::SerializeSeq;
 
 use crate::TypeInfo;
 
@@ -308,12 +308,134 @@ impl serde::Serialize for BoolArray<'_> {
             .value
             .as_boolean_opt()
             .ok_or_else(|| error("not a boolean array"))?;
-        let mut seq = serializer.serialize_tuple(array.len())?;
+        // Variable-length `sequence<bool>` / `bool[]` must be encoded with a
+        // serde sequence so the CDR codec emits the mandatory u32 length
+        // prefix. Using `serialize_tuple` here omits that prefix, which makes
+        // the deserializer (and every field after it) decode garbage.
+        let mut seq = serializer.serialize_seq(Some(array.len()))?;
 
         for value in array.values() {
             seq.serialize_element(&value)?;
         }
 
         seq.end()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use arrow::{
+        array::{ArrayRef, BooleanArray, Int32Array, ListArray, StructArray},
+        buffer::OffsetBuffer,
+        datatypes::{DataType, Field},
+    };
+    use byteorder::LittleEndian;
+    use dora_ros2_bridge_msg_gen::types::{
+        Member, MemberType, Message,
+        primitives::{BasicType, NestableType},
+        sequences::Sequence,
+    };
+
+    use super::*;
+
+    /// Builds a message type with a `sequence<bool>` field followed by an
+    /// `int32` field, so we can verify the trailing field survives.
+    fn bool_seq_then_int32_message() -> Arc<HashMap<String, HashMap<String, Message>>> {
+        let message = Message {
+            package: "test_msgs".to_string(),
+            name: "BoolSeqMsg".to_string(),
+            members: vec![
+                Member {
+                    name: "flags".to_string(),
+                    r#type: MemberType::Sequence(Sequence {
+                        value_type: NestableType::BasicType(BasicType::Bool),
+                    }),
+                    default: None,
+                },
+                Member {
+                    name: "tail".to_string(),
+                    r#type: MemberType::NestableType(NestableType::BasicType(BasicType::I32)),
+                    default: None,
+                },
+            ],
+            constants: vec![],
+        };
+        let mut package = HashMap::new();
+        package.insert("BoolSeqMsg".to_string(), message);
+        let mut messages = HashMap::new();
+        messages.insert("test_msgs".to_string(), package);
+        Arc::new(messages)
+    }
+
+    fn build_value(flags: &[bool], tail: i32) -> ArrayRef {
+        let bool_array = BooleanArray::from(flags.to_vec());
+        let list = ListArray::new(
+            Arc::new(Field::new("item", DataType::Boolean, true)),
+            OffsetBuffer::from_lengths([flags.len()]),
+            Arc::new(bool_array),
+            None,
+        );
+        let struct_array = StructArray::from(vec![
+            (
+                Arc::new(Field::new(
+                    "flags",
+                    DataType::List(Arc::new(Field::new("item", DataType::Boolean, true))),
+                    false,
+                )),
+                Arc::new(list) as ArrayRef,
+            ),
+            (
+                Arc::new(Field::new("tail", DataType::Int32, false)),
+                Arc::new(Int32Array::from(vec![tail])) as ArrayRef,
+            ),
+        ]);
+        Arc::new(struct_array) as ArrayRef
+    }
+
+    /// Regression test for #2032: a variable-length `sequence<bool>` must be
+    /// CDR-encoded with a u32 length prefix. Without it, an actual CDR reader
+    /// mis-parses both the sequence and every following field.
+    #[test]
+    fn bool_sequence_round_trips_through_real_cdr() {
+        // Choose flags whose first element is `true` so that, under the buggy
+        // (no length prefix) encoding, the reader would interpret the leading
+        // `0x01` byte as a length of 1 and stop after a single element.
+        let flags = vec![true, false, true, true];
+        let tail = 0x1234_5678_i32;
+
+        let messages = bool_seq_then_int32_message();
+        let type_info = TypeInfo {
+            package_name: Cow::Borrowed("test_msgs"),
+            message_name: Cow::Borrowed("BoolSeqMsg"),
+            messages,
+        };
+        let value = build_value(&flags, tail);
+        let typed = TypedValue {
+            value: &value,
+            type_info: &type_info,
+        };
+
+        let bytes = cdr_encoding::to_vec::<_, LittleEndian>(&typed).expect("serialize to CDR");
+
+        // The first 4 bytes must be the little-endian u32 sequence length.
+        let prefix = u32::from_le_bytes(bytes[..4].try_into().unwrap());
+        assert_eq!(
+            prefix,
+            flags.len() as u32,
+            "missing/incorrect CDR length prefix for sequence<bool>"
+        );
+
+        // Decode with a real CDR reader as `(Vec<bool>, i32)` and confirm both
+        // the sequence values and the trailing field are intact.
+        let (decoded, _consumed): ((Vec<bool>, i32), _) =
+            cdr_encoding::from_bytes::<(Vec<bool>, i32), LittleEndian>(&bytes)
+                .expect("deserialize from CDR");
+        assert_eq!(decoded.0, flags, "bool sequence values corrupted");
+        assert_eq!(
+            decoded.1, tail,
+            "trailing field after bool sequence corrupted"
+        );
     }
 }


### PR DESCRIPTION
The variable-length `bool` sequence path in the Arrow→ROS2 serializer used `serialize_tuple`, which omits the mandatory u32 CDR length prefix that the deserializer reads, so `sequence<bool>` / `bool[]` values and every field after them decoded as garbage. The fix routes that path through `serialize_seq(Some(len))` (matching the deserializer's `deserialize_seq`), leaving genuinely fixed-size bool arrays in `array.rs` on `serialize_tuple`.

Closes #2032.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
