### PR TITLE
fix(core): enforce ROS2 structural name rules in validate_ros2_name

### DIFF
--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -645,8 +645,21 @@ fn validate_ros2_qos(
     Ok(())
 }
 
-/// Validate a ROS2 name (topic, service, or action) contains only valid characters.
-/// ROS2 names allow: ASCII alphanumeric, underscore, and forward slash.
+/// Validate a ROS2 name (topic, service, or action).
+///
+/// Enforces both the allowed character set (ASCII alphanumeric, underscore, and
+/// forward slash) and ROS2's structural naming rules, so that a malformed name
+/// fails at `dora check` time with a clear message instead of being rejected by
+/// `rmw` only when the bridge tries to create the publisher/subscriber.
+///
+/// Structural rules enforced (see <https://design.ros2.org/articles/topic_and_service_names.html>):
+/// * must not contain repeated forward slashes (`//`);
+/// * must not end with a forward slash, and must not be a bare `/`;
+/// * each `/`-delimited segment must not start with a digit.
+///
+/// Note: a leading underscore is intentionally *allowed* — ROS2 treats names
+/// whose segments start with `_` as valid "hidden" topics/services, so the rule
+/// is "must not start with a digit", not "must start with a letter".
 fn validate_ros2_name(node_id: &NodeId, field: &str, name: &str) -> eyre::Result<()> {
     if name.is_empty() {
         bail!("node `{node_id}`: `{field}` must not be empty");
@@ -659,6 +672,30 @@ fn validate_ros2_name(node_id: &NodeId, field: &str, name: &str) -> eyre::Result
             "node `{node_id}`: invalid `{field}` name `{name}`, \
              only ASCII alphanumeric, underscore, and '/' characters allowed"
         );
+    }
+    if name.contains("//") {
+        bail!(
+            "node `{node_id}`: invalid `{field}` name `{name}`, \
+             consecutive '/' separators are not allowed"
+        );
+    }
+    if name == "/" {
+        bail!("node `{node_id}`: invalid `{field}` name `{name}`, must not be a bare '/'");
+    }
+    if name.ends_with('/') {
+        bail!("node `{node_id}`: invalid `{field}` name `{name}`, must not end with '/'");
+    }
+    // A leading '/' yields an empty first segment (absolute name), which is
+    // fine; `//` and a trailing '/' are already rejected above, so the only
+    // empty segment that can reach here is that leading one. An empty segment
+    // never starts with a digit, so it passes the check naturally.
+    for segment in name.split('/') {
+        if segment.starts_with(|c: char| c.is_ascii_digit()) {
+            bail!(
+                "node `{node_id}`: invalid `{field}` name `{name}`, \
+                 name segment `{segment}` must not start with a digit"
+            );
+        }
     }
     Ok(())
 }
@@ -1481,6 +1518,53 @@ mod tests {
         let err = validate_ros2_config(&NodeId::from("n".to_owned()), &config, &inputs, &outputs)
             .unwrap_err();
         assert!(err.to_string().contains("keep_last"));
+    }
+
+    // --- ROS2 name validation tests ---
+
+    #[test]
+    fn validate_ros2_name_accepts_valid() {
+        let node = NodeId::from("n".to_owned());
+        // relative, absolute, nested, underscores, hidden (leading '_'),
+        // digits inside a segment.
+        for name in [
+            "topic",
+            "/topic",
+            "/topic/sub",
+            "my_topic",
+            "/ns/my_topic_2",
+            "/_hidden",
+            "/ns/_internal/foo",
+            "cmd_vel0",
+        ] {
+            validate_ros2_name(&node, "topic", name)
+                .unwrap_or_else(|e| panic!("`{name}` should be valid, got: {e}"));
+        }
+    }
+
+    #[test]
+    fn validate_ros2_name_rejects_structural_violations() {
+        let node = NodeId::from("n".to_owned());
+        // (name, substring expected in the error)
+        let cases = [
+            ("", "must not be empty"),
+            ("bad name", "alphanumeric"),
+            ("//topic", "consecutive"),
+            ("topic//sub", "consecutive"),
+            ("topic/", "must not end with"),
+            ("/", "bare '/'"),
+            ("9topic", "must not start with a digit"),
+            ("/topic/9sub", "must not start with a digit"),
+        ];
+        for (name, expected) in cases {
+            let err = validate_ros2_name(&node, "topic", name)
+                .unwrap_err()
+                .to_string();
+            assert!(
+                err.contains(expected),
+                "`{name}` should be rejected with `{expected}`, got: {err}"
+            );
+        }
     }
 
     // --- Type annotation tests ---


### PR DESCRIPTION
## Summary

`validate_ros2_name` (`libraries/core/src/descriptor/validate.rs`) only checked that each character belongs to the allowed set (`[a-zA-Z0-9_/]`); it did not enforce ROS2's structural naming rules. Several invalid names passed `dora check` and were only rejected at runtime by `rmw` when the bridge tried to create the publisher/subscriber — a confusing runtime error instead of a clear validation-time one.

Names that passed validation before this change:

| Name | Why invalid |
|------|-------------|
| `//topic` | double leading slash |
| `topic/` | trailing slash |
| `topic//sub` | consecutive interior slashes |
| `/` | bare slash, no content |
| `9topic` | segment starts with a digit |

## Fix

Add structural checks to `validate_ros2_name`:
- reject consecutive slashes (`//`);
- reject a trailing slash and a bare `/`;
- reject any `/`-delimited segment that starts with a digit.

## Note on the underscore rule

The originating issue suggested "each token must start with a letter" and listed leading-underscore names (e.g. `___`) as invalid. That is **inaccurate** for ROS2: names whose segments start with `_` are valid *hidden* topics/services (e.g. `/_internal/foo`, per [the ROS2 naming design doc](https://design.ros2.org/articles/topic_and_service_names.html)). Enforcing "must start with a letter" would reject legitimate hidden names. The correct, non-over-restrictive rule — and the one implemented here — is **"a segment must not start with a digit"**, which still rejects `9topic` / `/topic/9sub` while allowing `/_hidden`.

I deliberately did *not* add a "repeated underscores" check: it is not reliably enforced by `rmw_validate_topic_name`, and adding it risks false-rejecting names that work today.

## Tests

- `validate_ros2_name_accepts_valid` — relative, absolute, nested, underscore/hidden, and digit-inside-segment names.
- `validate_ros2_name_rejects_structural_violations` — empty, bad charset, `//`, interior `//`, trailing `/`, bare `/`, and digit-leading segments, each asserting the specific error substring.

## Verification

- `cargo test -p dora-core` — 154 tests pass (152 prior + 2 new).
- `cargo fmt --all -- --check` ✓
- `cargo clippy -p dora-core --lib --tests -- -D warnings` ✓

Found by a scheduled automated code-review check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)