### PR TITLE
chore(deps): bump stabby off yanked 72.1.1 -> 72.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6747,12 +6747,12 @@ dependencies = [
 
 [[package]]
 name = "stabby"
-version = "72.1.1"
+version = "72.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976399a0c48ea769ef7f5dc303bb88240ab8d84008647a6b2303eced3dab3945"
+checksum = "ec9e9da673d4db1d470fa36cf4483ad5b1fdea349a392d400fea5d3673a9c5ca"
 dependencies = [
  "rustversion",
- "stabby-abi 72.1.1",
+ "stabby-abi 72.1.2",
 ]
 
 [[package]]
@@ -6769,14 +6769,14 @@ dependencies = [
 
 [[package]]
 name = "stabby-abi"
-version = "72.1.1"
+version = "72.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b54832a9a1f92a0e55e74a5c0332744426edc515bb3fbad82f10b874a87f0d"
+checksum = "10a281b17b3cf11531b7dc4e5f1c6be27db86a06e19c477e7a88fa4ee1b6daf3"
 dependencies = [
  "rustc_version",
  "rustversion",
  "sha2-const-stable",
- "stabby-macros 72.1.1",
+ "stabby-macros 72.1.2",
 ]
 
 [[package]]
@@ -6794,9 +6794,9 @@ dependencies = [
 
 [[package]]
 name = "stabby-macros"
-version = "72.1.1"
+version = "72.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a768b1e51e4dbfa4fa52ae5c01241c0a41e2938fdffbb84add0c8238092f9091"
+checksum = "605b39114a0c132d77ffdd7d179491323dbaa8369e7dcbcdf3da09d0b43c13cf"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -9198,7 +9198,7 @@ dependencies = [
  "git-version",
  "libloading 0.8.9",
  "serde",
- "stabby 72.1.1",
+ "stabby 72.1.2",
  "tracing",
  "zenoh-config",
  "zenoh-keyexpr",
@@ -9262,7 +9262,7 @@ dependencies = [
  "nix 0.29.0",
  "num-traits",
  "rand 0.8.6",
- "stabby 72.1.1",
+ "stabby 72.1.2",
  "static_assertions",
  "static_init",
  "talc",


### PR DESCRIPTION
## Summary

`stabby 72.1.1` (with `stabby-abi` / `stabby-macros`) was yanked from crates.io. The supply-chain gate (`deny.toml` → `[advisories] yanked = "deny"`) treats a yanked crate in `Cargo.lock` as a hard failure, so `cargo deny check` (`scripts/qa/audit.sh`, the `Audit` job) started failing on **`main` and every open PR** once CI refreshed its crates.io index — even on PRs that touch no dependencies.

stabby is a transitive dependency of `zenoh-shm`.

## Fix

`cargo update -p stabby@72.1.1` → moves to the non-yanked **72.1.2** patch release. Lock-only change, 3 packages (`stabby`, `stabby-abi`, `stabby-macros`).

## Verification

- [x] `scripts/qa/audit.sh` (cargo-audit + cargo-deny) green: `advisories ok, bans ok, licenses ok, sources ok`.
- [x] `cargo check -p dora-daemon` (the `zenoh → zenoh-shm → stabby` path) builds.

Unblocks the audit gate for all open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
