### PR TITLE
fix(ros2-bridge): skip python array test when no ROS distro is present (#2046)

### DIFF
--- a/libraries/extensions/ros2-bridge/python/src/typed/mod.rs
+++ b/libraries/extensions/ros2-bridge/python/src/typed/mod.rs
@@ -37,8 +37,32 @@ mod tests {
     use serde_assert::Deserializer;
     #[test]
     fn test_python_array_code() -> Result<()> {
+        // This test round-trips real ROS2 message types (e.g. `std_msgs::UInt8`),
+        // so it needs the `.msg` definitions discoverable at runtime via
+        // `AMENT_PREFIX_PATH` — i.e. a sourced ROS distro. The nightly "ROS2
+        // Bridge Basic Checks" job deliberately runs without one
+        // (dora-rs/dora#2046). Skip *before* building `Ros2Context`: with no
+        // distro there is nothing to test, and constructing the ros2_client DDS
+        // context can itself fail (e.g. "Could not find free ParticipantId").
+        // Release QA (`scripts/ros2dev.sh`, with a real distro) still exercises
+        // the round-trips.
+        let ament = std::env::var("AMENT_PREFIX_PATH").unwrap_or_default();
+        if ament.split(':').all(str::is_empty) {
+            eprintln!(
+                "skipping test_python_array_code: AMENT_PREFIX_PATH empty/unset \
+                 — needs a sourced ROS distro"
+            );
+            return Ok(());
+        }
+
         let context = Ros2Context::new(None).context("Could not create a context")?;
         let messages = context.messages.clone();
+        // Belt-and-suspenders: a sourced distro path that yields no messages.
+        if messages.is_empty() {
+            eprintln!("skipping test_python_array_code: no ROS2 messages resolved");
+            return Ok(());
+        }
+
         let serializer = Serializer::builder().build();
 
         Python::attach(|py| -> Result<()> {


### PR DESCRIPTION
## Summary

Closes #2046 (nightly `ros2-bridge` regression since 2026-06-05).

`test_python_array_code` round-trips real ROS2 message types (`std_msgs::UInt8`, …), which it resolves **at runtime** from `AMENT_PREFIX_PATH` — i.e. a sourced ROS distro. #2025 ("Harden nightly dynamic and ROS2 checks") dropped the `source /opt/ros/humble/setup.bash` step from the nightly "ROS2 Bridge Basic Checks" job — which now runs with **no ROS distro** by design — but kept `cargo test -p dora-ros2-bridge-python` running this test. With `AMENT_PREFIX_PATH` empty, `Ros2Context::new(None)` resolves no messages, so the test fails:

```
test typed::tests::test_python_array_code ... FAILED
Error: could not find message type std_msgs::UInt8
```

## Fix

Skip the test when no ROS2 messages resolve (empty `AMENT_PREFIX_PATH`) instead of failing — it's inherently a ROS-integration test. The no-distro nightly basics job passes; release QA (`scripts/ros2dev.sh`, with a real distro) still exercises the round-trips. It's the only test in the crate, so this unblocks the whole `cargo test -p dora-ros2-bridge-python` step.

## Verification

- [x] Reproduced the no-distro environment locally (empty `AMENT_PREFIX_PATH`): the test now **passes by skipping** (was failing on `std_msgs::UInt8`).
- [x] `cargo fmt --all -- --check` clean (rustfmt 1.92.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
