### PR TITLE
test(hardening): cover verified security/framing test gaps (#2027)

### DIFF
--- a/apis/rust/node/src/daemon_connection/tcp.rs
+++ b/apis/rust/node/src/daemon_connection/tcp.rs
@@ -108,3 +108,63 @@ fn tcp_receive(connection: &mut (impl Read + Unpin)) -> std::io::Result<Vec<u8>>
     connection.read_exact(&mut reply)?;
     Ok(reply)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{tcp_receive, tcp_send};
+    use std::io::Cursor;
+
+    // Length-prefixed framing guards on the node side of the daemon<->node TCP
+    // transport (dora-rs/dora#2027 verified test gap). A malformed/hostile frame
+    // must error, not over-allocate or hang.
+
+    #[test]
+    fn framing_roundtrip() {
+        let payload = b"hello dora framing".to_vec();
+        let mut wire = Vec::new();
+        tcp_send(&mut wire, &payload).expect("send");
+        // 8-byte little-endian length prefix + payload.
+        assert_eq!(wire.len(), 8 + payload.len());
+        let got = tcp_receive(&mut Cursor::new(wire)).expect("receive");
+        assert_eq!(got, payload);
+    }
+
+    #[test]
+    fn empty_payload_roundtrips() {
+        let mut wire = Vec::new();
+        tcp_send(&mut wire, &[]).expect("send empty");
+        let got = tcp_receive(&mut Cursor::new(wire)).expect("receive empty");
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn receive_rejects_oversized_length_prefix() {
+        // A hostile peer announces a body larger than MAX_MESSAGE_BYTES. The
+        // guard must reject *before* allocating the body buffer; we therefore
+        // supply only the 8-byte header (no body).
+        let claimed = dora_message::MAX_MESSAGE_BYTES as u64 + 1;
+        let header = claimed.to_le_bytes().to_vec();
+        let err = tcp_receive(&mut Cursor::new(header)).expect_err("must reject oversized frame");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(
+            err.to_string().contains("exceeds maximum"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn receive_rejects_truncated_header() {
+        // Fewer than 8 length bytes -> EOF, not a hang or panic.
+        let err = tcp_receive(&mut Cursor::new(vec![1, 2, 3])).expect_err("truncated header");
+        assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn receive_rejects_truncated_body() {
+        // Header claims 16 bytes but only 4 follow.
+        let mut wire = 16u64.to_le_bytes().to_vec();
+        wire.extend_from_slice(&[0xAB; 4]);
+        let err = tcp_receive(&mut Cursor::new(wire)).expect_err("truncated body");
+        assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+    }
+}

--- a/apis/rust/node/src/node/arrow_utils.rs
+++ b/apis/rust/node/src/node/arrow_utils.rs
@@ -424,4 +424,53 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("depth"));
     }
+
+    // Raw-buffer round-trip beyond the offset-0 case (dora-rs/dora#2027 verified
+    // test gap): a sliced (non-zero `offset`) array and the empty-buffer
+    // early-return path.
+
+    #[test]
+    fn raw_roundtrip_preserves_nonzero_offset() {
+        // Slice the `ArrayData` so it carries a non-zero logical `offset`.
+        let data = UInt64Array::from(vec![10, 20, 30, 40, 50])
+            .into_data()
+            .slice(2, 2); // offset = 2, len = 2 -> [30, 40]
+        assert_eq!(data.offset(), 2, "precondition: array is sliced");
+
+        let mut sample = vec![0; required_data_size(&data)];
+        let type_info = copy_array_into_sample(&mut sample, &data);
+        let decoded =
+            buffer_into_arrow_array(&arrow::buffer::Buffer::from(sample), &type_info).unwrap();
+        assert_eq!(data, decoded);
+    }
+
+    #[test]
+    fn raw_roundtrip_empty_primitive_uses_empty_buffer_path() {
+        let data = UInt64Array::from(Vec::<u64>::new()).into_data();
+        let mut sample = vec![0; required_data_size(&data)];
+        let type_info = copy_array_into_sample(&mut sample, &data);
+        // An empty array yields a zero-length payload, exercising the
+        // `raw_buffer.is_empty()` early-return in `buffer_into_arrow_array`.
+        let decoded =
+            buffer_into_arrow_array(&arrow::buffer::Buffer::from(sample), &type_info).unwrap();
+        assert_eq!(decoded.len(), 0);
+        assert_eq!(decoded.data_type(), &DataType::UInt64);
+    }
+
+    #[test]
+    fn raw_roundtrip_empty_nested_struct() {
+        use arrow_schema::Field;
+        let empty_child = Arc::new(UInt64Array::from(Vec::<u64>::new())) as ArrayRef;
+        let data = StructArray::from(vec![(
+            Arc::new(Field::new("values", DataType::UInt64, false)),
+            empty_child,
+        )])
+        .into_data();
+        let mut sample = vec![0; required_data_size(&data)];
+        let type_info = copy_array_into_sample(&mut sample, &data);
+        let decoded =
+            buffer_into_arrow_array(&arrow::buffer::Buffer::from(sample), &type_info).unwrap();
+        assert_eq!(decoded.len(), 0);
+        assert!(matches!(decoded.data_type(), DataType::Struct(_)));
+    }
 }

--- a/binaries/coordinator/src/ws_server.rs
+++ b/binaries/coordinator/src/ws_server.rs
@@ -262,6 +262,68 @@ impl ShutdownTrigger {
 mod tests {
     use super::*;
 
+    // --- coordinator WebSocket auth (dora-rs/dora#2027 verified test gap) ---
+
+    fn bearer(value: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(
+            "authorization",
+            axum::http::HeaderValue::from_str(value).unwrap(),
+        );
+        h
+    }
+
+    #[test]
+    fn validate_token_ok_when_auth_disabled() {
+        // `expected = None` means auth is disabled: any (or no) token passes.
+        assert!(validate_token(&None, &None).is_ok());
+        assert!(validate_token(&None, &Some("whatever".to_string())).is_ok());
+    }
+
+    #[test]
+    fn validate_token_accepts_matching_token() {
+        let expected = Some(AuthToken::from_hex("deadbeef"));
+        assert!(validate_token(&expected, &Some("deadbeef".to_string())).is_ok());
+    }
+
+    #[test]
+    fn validate_token_rejects_wrong_missing_and_empty() {
+        let expected = Some(AuthToken::from_hex("deadbeef"));
+        assert_eq!(
+            validate_token(&expected, &Some("cafebabe".to_string())),
+            Err(StatusCode::UNAUTHORIZED)
+        );
+        assert_eq!(
+            validate_token(&expected, &None),
+            Err(StatusCode::UNAUTHORIZED)
+        );
+        assert_eq!(
+            validate_token(&expected, &Some(String::new())),
+            Err(StatusCode::UNAUTHORIZED)
+        );
+    }
+
+    #[test]
+    fn extract_token_parses_bearer() {
+        assert_eq!(
+            extract_token(&bearer("Bearer deadbeef")),
+            Some("deadbeef".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_token_none_for_missing_or_non_bearer() {
+        assert_eq!(extract_token(&HeaderMap::new()), None);
+        assert_eq!(extract_token(&bearer("Basic deadbeef")), None);
+        // The "Bearer " prefix is case-sensitive.
+        assert_eq!(extract_token(&bearer("bearer deadbeef")), None);
+    }
+
+    #[test]
+    fn extract_token_empty_after_bearer() {
+        assert_eq!(extract_token(&bearer("Bearer ")), Some(String::new()));
+    }
+
     #[test]
     fn rate_limiter_allows_within_limit() {
         let rl = IpRateLimiter::new();

--- a/binaries/daemon/Cargo.toml
+++ b/binaries/daemon/Cargo.toml
@@ -65,6 +65,9 @@ libc = "0.2"
 [dev-dependencies]
 tempfile = { workspace = true }
 criterion = { version = "0.5", features = ["html_reports"] }
+# `test-util` enables `start_paused` so the 30s TCP read-timeout guard can be
+# exercised without a real 30s wait (socket_stream_utils tests, #2027).
+tokio = { workspace = true, features = ["full", "test-util"] }
 
 [[bench]]
 name = "routing"

--- a/binaries/daemon/src/socket_stream_utils.rs
+++ b/binaries/daemon/src/socket_stream_utils.rs
@@ -60,3 +60,70 @@ pub async fn socket_stream_receive(
         })??;
     Ok(reply)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{socket_stream_receive, socket_stream_send};
+    use tokio::io::{AsyncWriteExt, duplex};
+
+    // Length-prefixed framing guards on the daemon side of the daemon<->node TCP
+    // transport (dora-rs/dora#2027 verified test gap): DoS-sized frames must be
+    // rejected before allocation, a stalled peer must time out, and well-formed
+    // frames must round-trip.
+
+    #[tokio::test]
+    async fn framing_roundtrip() {
+        let (mut a, mut b) = duplex(64 * 1024);
+        let payload = b"hello dora framing".to_vec();
+        socket_stream_send(&mut a, &payload).await.expect("send");
+        let got = socket_stream_receive(&mut b).await.expect("receive");
+        assert_eq!(got, payload);
+    }
+
+    #[tokio::test]
+    async fn empty_payload_roundtrips() {
+        let (mut a, mut b) = duplex(64);
+        socket_stream_send(&mut a, &[]).await.expect("send empty");
+        let got = socket_stream_receive(&mut b).await.expect("receive empty");
+        assert!(got.is_empty());
+    }
+
+    #[tokio::test]
+    async fn send_rejects_oversized_message() {
+        let (mut a, _b) = duplex(64);
+        let oversized = vec![0u8; dora_message::MAX_MESSAGE_BYTES + 1];
+        let err = socket_stream_send(&mut a, &oversized)
+            .await
+            .expect_err("must reject oversized outgoing message");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("exceeds maximum"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn receive_rejects_oversized_length_prefix() {
+        // Hostile peer announces a body larger than MAX_MESSAGE_BYTES. The guard
+        // must reject from the 8-byte header alone, before allocating the body.
+        let (mut a, mut b) = duplex(64);
+        let claimed = dora_message::MAX_MESSAGE_BYTES as u64 + 1;
+        a.write_all(&claimed.to_le_bytes())
+            .await
+            .expect("write hdr");
+        let err = socket_stream_receive(&mut b)
+            .await
+            .expect_err("must reject oversized frame");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("exceeds maximum"), "{err}");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn receive_times_out_on_stalled_peer() {
+        // Writer stays open but sends nothing: the header read must time out
+        // (not hang). Paused time auto-advances past TCP_READ_TIMEOUT, so the
+        // test is instant.
+        let (_writer, mut reader) = duplex(64);
+        let err = socket_stream_receive(&mut reader)
+            .await
+            .expect_err("must time out on a stalled peer");
+        assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the four **verified security/framing test gaps** from the 2026-06-04 soundness audit (`docs/audit-2026-06-04-soundness.md` §4 "Test gaps on security/framing"). Each guard was correct but untested, so a regression would ship silently. Test-only — the sole production change is one dev-dependency feature.

## Tests added (19)

- **Coordinator WebSocket auth** (`ws_server.rs`) — `validate_token`: disabled / matching / wrong / missing / empty token; `extract_token`: `Bearer` / missing header / non-`Bearer` scheme / case-sensitivity / empty-after-`Bearer`.
- **Daemon TCP framing** (`socket_stream_utils.rs`) — round-trip, empty payload, oversized-outgoing rejection, **oversized length-prefix rejection** (the DoS guard: rejects from the 8-byte header before allocating the body), and **read-timeout on a stalled peer**. The timeout test uses `#[tokio::test(start_paused = true)]` so the 30s `TCP_READ_TIMEOUT` is exercised instantly — this adds the `tokio` `test-util` dev-feature to the daemon.
- **Node TCP framing** (`daemon_connection/tcp.rs`) — round-trip, empty, oversized length-prefix rejection, truncated header, truncated body (via `Cursor`).
- **Raw-buffer Arrow round-trip** (`arrow_utils.rs`) — non-zero (sliced) `offset`, plus the empty-buffer early-return path for an empty primitive and an empty nested struct.

## Verification

- [x] `dora-coordinator` (93), `dora-daemon` (43), `dora-node-api` (93) lib suites green.
- [x] `cargo fmt --all -- --check` clean; CI-style `cargo clippy … -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
