### PR TITLE
fix(ros2-bridge): propagate Name::new errors in generated create fns (#2027)

### DIFF
--- a/libraries/extensions/ros2-bridge/msg-gen/src/types/action.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/types/action.rs
@@ -399,7 +399,8 @@ impl Action {
 
                 let client = node.node.create_action_client::< action :: #self_name >(
                     crate::ros2_client::ServiceMapping:: #ros_service_mapping,
-                    &crate::ros2_client::Name::new(name_space, base_name).unwrap(),
+                    &crate::ros2_client::Name::new(name_space, base_name)
+                        .map_err(|e| eyre::eyre!("invalid ROS2 name/namespace: {e:?}"))?,
                     &crate::ros2_client::ActionTypeName::new(#package_name, #self_name_str),
                     qos.into(),
                 ).map_err(|e| eyre::eyre!("{e:?}"))?;
@@ -879,7 +880,8 @@ impl Action {
                 let q: crate::rustdds::QosPolicies = qos.into();
                 let server = node.node.create_action_server::< action :: #self_name >(
                     crate::ros2_client::ServiceMapping:: #ros_service_mapping,
-                    &crate::ros2_client::Name::new(name_space, base_name).unwrap(),
+                    &crate::ros2_client::Name::new(name_space, base_name)
+                        .map_err(|e| eyre::eyre!("invalid ROS2 name/namespace: {e:?}"))?,
                     &crate::ros2_client::ActionTypeName::new(#package_name, #self_name_str),
                     crate::ros2_client::action::ActionServerQosPolicies {
                         goal_service: q.clone(),
@@ -1201,5 +1203,46 @@ fn goal_id_type() -> Member {
         }
         .into(),
         default: None,
+    }
+}
+
+#[cfg(test)]
+mod codegen_tests {
+    use super::*;
+
+    fn empty_msg(name: &str) -> Message {
+        Message {
+            package: "test_pkg".to_string(),
+            name: name.to_string(),
+            members: vec![],
+            constants: vec![],
+        }
+    }
+
+    fn format_valid_rust(tokens: impl ToTokens) -> String {
+        use rust_format::Formatter;
+        rust_format::PrettyPlease::default()
+            .format_tokens(tokens.into_token_stream())
+            .expect("generated ROS2 action code must parse as valid Rust")
+    }
+
+    // #2027: the generated action client/server `create` fns used to
+    // `Name::new(..).unwrap()`; they now propagate via `?`. Guard that the
+    // generated code (a) still parses and (b) routes the `Name::new` error
+    // through `map_err` rather than panic.
+    #[test]
+    fn action_creation_functions_propagate_name_errors() {
+        let action = Action {
+            package: "test_pkg".to_string(),
+            name: "Fibonacci".to_string(),
+            goal: empty_msg("Fibonacci_Goal"),
+            result: empty_msg("Fibonacci_Result"),
+            feedback: empty_msg("Fibonacci_Feedback"),
+        };
+        let needle = "invalid ROS2 name/namespace"; // must propagate via `?`, not panic
+        let (_decl, imp) = action.cxx_action_creation_functions("test_pkg");
+        assert!(format_valid_rust(imp).contains(needle), "client create fn");
+        let (_decl, imp) = action.cxx_action_server_creation_functions("test_pkg");
+        assert!(format_valid_rust(imp).contains(needle), "server create fn");
     }
 }

--- a/libraries/extensions/ros2-bridge/msg-gen/src/types/service.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/types/service.rs
@@ -134,7 +134,8 @@ impl Service {
 
                 let client = node.node.create_client::< service :: #self_name >(
                     crate::ros2_client::ServiceMapping:: #ros_service_mapping,
-                    &crate::ros2_client::Name::new(name_space, base_name).unwrap(),
+                    &crate::ros2_client::Name::new(name_space, base_name)
+                        .map_err(|e| eyre::eyre!("invalid ROS2 name/namespace: {e:?}"))?,
                     &crate::ros2_client::ServiceTypeName::new(#package_name, #self_name_str),
                     qos.clone().into(),
                     qos.into(),
@@ -351,7 +352,8 @@ impl Service {
 
                 let server = node.node.create_server::< service :: #self_name >(
                     crate::ros2_client::ServiceMapping:: #ros_service_mapping,
-                    &crate::ros2_client::Name::new(name_space, base_name).unwrap(),
+                    &crate::ros2_client::Name::new(name_space, base_name)
+                        .map_err(|e| eyre::eyre!("invalid ROS2 name/namespace: {e:?}"))?,
                     &crate::ros2_client::ServiceTypeName::new(#package_name, #self_name_str),
                     qos.clone().into(),
                     qos.into(),
@@ -545,5 +547,45 @@ impl Service {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod codegen_tests {
+    use super::*;
+
+    fn empty_msg(name: &str) -> Message {
+        Message {
+            package: "test_pkg".to_string(),
+            name: name.to_string(),
+            members: vec![],
+            constants: vec![],
+        }
+    }
+
+    fn format_valid_rust(tokens: impl ToTokens) -> String {
+        use rust_format::Formatter;
+        rust_format::PrettyPlease::default()
+            .format_tokens(tokens.into_token_stream())
+            .expect("generated ROS2 service code must parse as valid Rust")
+    }
+
+    // #2027: the generated client/server `create` fns used to
+    // `Name::new(..).unwrap()` (a node-abort panic on a bad name/namespace);
+    // they now propagate via `?`. Guard that the generated code (a) still parses
+    // and (b) routes the `Name::new` error through `map_err` rather than panic.
+    #[test]
+    fn service_creation_functions_propagate_name_errors() {
+        let svc = Service {
+            package: "test_pkg".to_string(),
+            name: "AddTwoInts".to_string(),
+            request: empty_msg("AddTwoInts_Request"),
+            response: empty_msg("AddTwoInts_Response"),
+        };
+        let needle = "invalid ROS2 name/namespace"; // must propagate via `?`, not panic
+        let (_decl, imp) = svc.cxx_service_creation_functions("test_pkg");
+        assert!(format_valid_rust(imp).contains(needle), "client create fn");
+        let (_decl, imp) = svc.cxx_service_server_creation_functions("test_pkg");
+        assert!(format_valid_rust(imp).contains(needle), "server create fn");
     }
 }


### PR DESCRIPTION
## Summary

Quick Win #3 from the 2026-06-04 soundness audit (`docs/audit-2026-06-04-soundness.md` §5). Closes 4 node-abort panics in the ROS2 codegen.

The generated service/action client+server `create` functions emitted:
```rust
&crate::ros2_client::Name::new(name_space, base_name).unwrap(),
```
so an invalid user-supplied name/namespace **panics the node**. The graceful path (`message.rs`) already uses `?`.

## Fix

Replace all four `.unwrap()`s (`service.rs:137,354`, `action.rs:402,882`) with:
```rust
&crate::ros2_client::Name::new(name_space, base_name)
    .map_err(|e| eyre::eyre!("invalid ROS2 name/namespace: {e:?}"))?,
```
The enclosing generated fns already return `eyre::Result<Box<…>>` and already wrap the `create_*` call with the identical `.map_err(…)?` — so this is mechanical and matches existing precedent on the same line.

## Tests

Added the **first tests to exercise the service/action codegen output**: each generates the four create fns and asserts (via `rust_format`/prettyplease, already a dependency) that the output (a) **parses as valid Rust** and (b) **routes `Name::new` through `map_err`** (the formatted source contains `invalid ROS2 name/namespace`), so the panic can't silently come back. Verified the gate fails when the fix is reverted to `.unwrap()`.

## Verification

- [x] `cargo test -p dora-ros2-bridge-msg-gen` green (66).
- [x] `cargo fmt --all -- --check` clean; clippy clean. No unrelated churn (diff is the 4 replacements + 2 test modules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
