### PR TITLE
fix(daemon): accept-loop backoff + reset health clock on respawn (#2027)

### DIFF
--- a/binaries/daemon/src/local_listener.rs
+++ b/binaries/daemon/src/local_listener.rs
@@ -50,28 +50,40 @@ async fn listener_loop(
     listener: TcpListener,
     events_tx: flume::Sender<Timestamped<DynamicNodeEventWrapper>>,
 ) {
-    // Exponential backoff for repeated `accept()` failures. A persistent error
-    // (e.g. `EMFILE` — too many open files) would otherwise busy-spin the loop
-    // at 100% CPU and flood the logs with no pause (dora-rs/dora#2027).
+    // Exponential backoff for repeated resource-exhaustion `accept()` failures.
+    // A persistent error (e.g. `EMFILE` — too many open files) would otherwise
+    // busy-spin the loop at 100% CPU and flood the logs (dora-rs/dora#2027).
+    // Per-connection errors (a peer that reset before `accept` completed) are
+    // transient and retried immediately, matching the standard accept-loop
+    // idiom — only resource exhaustion warrants the pause.
     const ACCEPT_BACKOFF_MAX: Duration = Duration::from_secs(1);
     let mut backoff: Option<Duration> = None;
     loop {
-        match listener
-            .accept()
-            .await
-            .wrap_err("failed to accept new connection")
-        {
+        match listener.accept().await {
+            Ok((connection, _)) => {
+                backoff = None;
+                tokio::spawn(handle_connection_loop(connection, events_tx.clone()));
+            }
+            Err(err)
+                if matches!(
+                    err.kind(),
+                    ErrorKind::ConnectionAborted
+                        | ErrorKind::ConnectionReset
+                        | ErrorKind::Interrupted
+                ) =>
+            {
+                // Transient: the offending connection is already gone, so the
+                // next `accept` makes progress. Retry without a penalty.
+                tracing::warn!("failed to accept new connection: {err}");
+                backoff = None;
+            }
             Err(err) => {
                 let delay = backoff
                     .map_or(Duration::from_millis(10), |d| d * 2)
                     .min(ACCEPT_BACKOFF_MAX);
                 backoff = Some(delay);
-                tracing::warn!("{err} (retrying in {delay:?})");
+                tracing::warn!("failed to accept new connection: {err} (retrying in {delay:?})");
                 tokio::time::sleep(delay).await;
-            }
-            Ok((connection, _)) => {
-                backoff = None;
-                tokio::spawn(handle_connection_loop(connection, events_tx.clone()));
             }
         }
     }

--- a/binaries/daemon/src/local_listener.rs
+++ b/binaries/daemon/src/local_listener.rs
@@ -4,7 +4,7 @@ use dora_message::{
     node_to_daemon::{DaemonRequest, DynamicNodeEvent, Timestamped},
 };
 use eyre::Context;
-use std::{io::ErrorKind, net::SocketAddr};
+use std::{io::ErrorKind, net::SocketAddr, time::Duration};
 use tokio::{
     net::{TcpListener, TcpStream},
     sync::oneshot,
@@ -50,6 +50,11 @@ async fn listener_loop(
     listener: TcpListener,
     events_tx: flume::Sender<Timestamped<DynamicNodeEventWrapper>>,
 ) {
+    // Exponential backoff for repeated `accept()` failures. A persistent error
+    // (e.g. `EMFILE` — too many open files) would otherwise busy-spin the loop
+    // at 100% CPU and flood the logs with no pause (dora-rs/dora#2027).
+    const ACCEPT_BACKOFF_MAX: Duration = Duration::from_secs(1);
+    let mut backoff: Option<Duration> = None;
     loop {
         match listener
             .accept()
@@ -57,9 +62,15 @@ async fn listener_loop(
             .wrap_err("failed to accept new connection")
         {
             Err(err) => {
-                tracing::warn!("{err}");
+                let delay = backoff
+                    .map_or(Duration::from_millis(10), |d| d * 2)
+                    .min(ACCEPT_BACKOFF_MAX);
+                backoff = Some(delay);
+                tracing::warn!("{err} (retrying in {delay:?})");
+                tokio::time::sleep(delay).await;
             }
             Ok((connection, _)) => {
+                backoff = None;
                 tokio::spawn(handle_connection_loop(connection, events_tx.clone()));
             }
         }

--- a/binaries/daemon/src/spawn/prepared.rs
+++ b/binaries/daemon/src/spawn/prepared.rs
@@ -343,6 +343,18 @@ impl PreparedNode {
                         )
                         .await;
                 }
+                // Reset the health-check clock for the new incarnation.
+                // `last_activity` is a shared `Arc` reused across restarts, so
+                // it still holds the pre-crash timestamp here; without this the
+                // watchdog (`check_node_health`) can see a stale `last_activity`
+                // and kill the freshly restarted process before it reconnects
+                // and reports any activity. Matches the initial-spawn init in
+                // `spawner.rs` (dora-rs/dora#2027).
+                self.last_activity.store(
+                    crate::node_communication::current_millis(),
+                    atomic::Ordering::Release,
+                );
+
                 // Fresh `(op_tx, op_rx)` per incarnation so any
                 // grace-kill task holding an older `op_tx` cannot
                 // reach the new process — closes the race in


### PR DESCRIPTION
Addresses two of the five **daemon-resilience** findings from `docs/audit-2026-06-04-soundness.md` (#2027) — the two that are clean, low-risk resilience bugs. The other three are deferred with reasoning (below).

## 1. Dynamic-node listener busy-spins on persistent `accept()` errors

`local_listener::listener_loop` logged and immediately retried on every `accept()` error with no pause:
```rust
Err(err) => { tracing::warn!("{err}"); }   // then loop again immediately
```
A persistent failure (classically `EMFILE` — too many open files) spins the loop at 100% CPU and floods the logs. Added exponential backoff (10ms doubling to a 1s cap), reset on a successful accept. Mirrors the resilience posture of `node_communication/tcp.rs`.

## 2. Restarted node killed by the health-check watchdog before it reconnects

`last_activity` is a shared `Arc<AtomicU64>` reused across restarts. On respawn it still holds the **pre-crash** timestamp, so the watchdog (`check_node_health`, lib.rs:2241) sees `now - last_activity > timeout` and kills the freshly restarted process before it has a chance to reconnect and report activity:
```rust
let last = node.last_activity.load(Acquire);
if last == 0 { continue; }                 // "not yet connected" sentinel
if now_millis.saturating_sub(last) > timeout_ms { /* kill */ }
```
Reset `last_activity` to `now` on each respawn in `restart_loop`, granting the new incarnation a fresh grace window — matching the initial-spawn init in `spawner.rs:147`.

## Deferred (with reasoning)
- **Coordinator WS channel stall** (`coordinator.rs`, blocking send on bounded(64)) — auditor-reported (`verified:false`); switching protocol-critical coordinator sends to `try_send`+drop risks dropping heartbeats/ready/result frames, and a writer-timeout variant is a behavior change in the comms path that needs verification first.
- **`dora run` silently drops dynamic-node support on port-in-use** (`#1999` unfixed half) — the two listener binds (lib.rs:582 daemon-lifetime/unconditional and lib.rs:806 dynamic-guarded) share one fixed port and interact; a correct `bail!` is per-callsite and risks breaking legit multi-daemon-same-machine. Needs its own focused change. It's a misleading-success, not a hang (per the verifier).
- **Cross-daemon `OutputClosed` dropped on the lossy zenoh path** — this is Deeper-Investment #6 (a reliable zenoh control channel), architectural.

## QA
- `cargo test -p dora-daemon` — 43 passed
- `cargo clippy -p dora-daemon -- -D warnings` clean
- `cargo fmt --all -- --check` clean

Both changes are infra/timing behaviors, validated by construction + the full daemon suite. A crash-restart + tight `health_check_timeout` integration test would be the ideal gate for (2) but is disproportionate to the one-line reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
