### PR TITLE
fix(python): GIL-safe merge_external_events + metadata empty-list/log fixes (#2027)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2125,6 +2125,7 @@ dependencies = [
  "pythonize",
  "serde_json",
  "serde_yaml",
+ "tracing",
 ]
 
 [[package]]

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -734,7 +734,11 @@ impl Node {
     ///
     /// :type subscription: dora.Ros2Subscription
     /// :rtype: None
-    pub fn merge_external_events(&self, subscription: &mut Ros2Subscription) -> eyre::Result<()> {
+    pub fn merge_external_events(
+        &self,
+        py: Python,
+        subscription: &mut Ros2Subscription,
+    ) -> eyre::Result<()> {
         let subscription = subscription.into_stream()?;
         let stream = futures::stream::poll_fn(move |cx| {
             let s = subscription.as_stream().map(|item| {
@@ -753,14 +757,22 @@ impl Node {
             s.poll_next_unpin(cx)
         });
 
-        // take out the event stream and temporarily replace it with a dummy
-        let mut inner = self.events.inner.blocking_lock();
-        let events = std::mem::replace(
-            &mut *inner,
-            EventsInner::Merged(Box::new(futures::stream::empty())),
-        );
-        // update self.events with the merged stream
-        *inner = EventsInner::Merged(events.merge_external_send(Box::pin(stream)));
+        // Release the GIL while blocking on the node's event mutex. Holding the
+        // GIL across `blocking_lock()` can deadlock against a suspended
+        // `recv_async` task that holds the same lock (`inner.lock().await`) and
+        // needs the GIL to make progress (dora-rs/dora#2027). Clone the `Arc` so
+        // the closure doesn't capture `&self` (keeping the `Ungil` bound clean).
+        let inner = self.events.inner.clone();
+        py.detach(move || {
+            // take out the event stream and temporarily replace it with a dummy
+            let mut guard = inner.blocking_lock();
+            let events = std::mem::replace(
+                &mut *guard,
+                EventsInner::Merged(Box::new(futures::stream::empty())),
+            );
+            // update the stream with the merged one
+            *guard = EventsInner::Merged(events.merge_external_send(Box::pin(stream)));
+        });
 
         Ok(())
     }

--- a/apis/python/operator/Cargo.toml
+++ b/apis/python/operator/Cargo.toml
@@ -25,6 +25,7 @@ futures-concurrency = "7.3.0"
 chrono = { version = "0.4", features = ["serde"] }
 pythonize = { workspace = true }
 serde_json = { workspace = true }
+tracing = { workspace = true }
 
 [build-dependencies]
 pyo3-build-config = { workspace = true }

--- a/apis/python/operator/src/lib.rs
+++ b/apis/python/operator/src/lib.rs
@@ -273,6 +273,13 @@ pub fn pydict_to_metadata(dict: Option<Bound<'_, PyDict>>) -> Result<MetadataPar
             } else if value.is_instance_of::<PyString>() {
                 parameters.insert(key, Parameter::String(value.extract()?))
             } else if (value.is_instance_of::<PyTuple>() || value.is_instance_of::<PyList>())
+                && value.len()? == 0
+            {
+                // Empty list/tuple: no element type to infer. Preserve
+                // list-ness with an empty list (round-trips to `[]`) instead of
+                // coercing to the string "[]" (dora-rs/dora#2027).
+                parameters.insert(key, Parameter::ListString(vec![]))
+            } else if (value.is_instance_of::<PyTuple>() || value.is_instance_of::<PyList>())
                 && value.len()? > 0
                 && value.get_item(0)?.is_exact_instance_of::<PyInt>()
             {
@@ -320,7 +327,10 @@ pub fn pydict_to_metadata(dict: Option<Bound<'_, PyDict>>) -> Result<MetadataPar
 
                     parameters.insert(key, Parameter::Timestamp(dt))
                 } else {
-                    println!("could not convert type {value}");
+                    tracing::warn!(
+                        "unsupported metadata value type for key `{key}`; \
+                         coercing to its string representation: {value}"
+                    );
                     parameters.insert(key, Parameter::String(value.str()?.to_string()))
                 }
             };


### PR DESCRIPTION
Addresses two of the five **Python/C node + operator API** findings from `docs/audit-2026-06-04-soundness.md` (#2027) — the two that are clean and compile-verifiable without changing event-delivery semantics. The other three are deferred with reasoning (below).

## 1. GIL deadlock in `Node::merge_external_events`

`merge_external_events` acquired the node's event mutex with `self.events.inner.blocking_lock()` **while holding the GIL**. A suspended `recv_async` task holds the same lock across its `inner.lock().await` and needs the GIL to make progress — so the blocking acquisition can deadlock the two against each other.

Fix: release the GIL around the lock with `py.detach(...)` (PyO3 0.28's `allow_threads`). The `Arc<Mutex<_>>` is cloned so the closure doesn't capture `&self`, keeping the `Ungil` bound satisfied. The stream's `Python::attach` runs later when the stream is polled, not under the lock, so nothing inside the detached closure touches Python.

## 2. Empty-list metadata coerced to the string "[]" + `println!` spam

In `pydict_to_metadata` (operator API), every list branch requires `value.len()? > 0`, so an empty Python list/tuple `[]` fell through to the string fallback and became `Parameter::String("[]")` — losing its list-ness (it round-trips back as the string `"[]"`, not `[]`).

Fix: an explicit empty-list/tuple branch maps to `Parameter::ListString(vec![])`, which `metadata_to_pydict` turns back into an empty list `[]` (verified: `Parameter::ListString(l) => dict.set_item(k, l)`). Also replaced the `println!("could not convert type ...")` log spam on an unsupported value type with `tracing::warn!` (adds the `tracing` workspace dep to the crate).

## Deferred (with reasoning)
- **`try_recv`/`drain` no-op on merged event streams** — they currently return `Empty`/`[]` by design (documented; recoverable via blocking `recv`). Making them poll the merged stream non-blockingly is an event-delivery semantics change that needs maturin integration tests this Rust suite can't run.
- **`drain` inserts an empty `{}` on a per-event conversion failure** (silent data loss; `next` propagates) — the fix (propagate vs error-marker dict) is a consumer-facing schema decision that also needs Python tests.
- **`dora_read_data` collapses 3 failure modes to `None`** — `apis/rust/operator/types` is a deliberately minimal C-FFI types crate with no `eyre`/`tracing` deps; adding a logging dep for two rare branches is disproportionate. (The companion C-operator example buffer leak was already fixed in `3a3a1f4a`.)

## QA
- `cargo check -p dora-node-api-python -p dora-operator-api-python` clean
- `cargo clippy -p dora-node-api-python -p dora-operator-api-python` clean
- `cargo fmt --all -- --check` clean

The PyO3 packages are built with maturin and excluded from `cargo test`, so these changes are compile/clippy-verified rather than covered by the Rust test suite. Neither alters event-delivery data semantics; #2's round-trip is verified by reading `metadata_to_pydict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
