### PR TITLE
fix(ros2-bridge): length-check fixed-size string/wstring/struct arrays (#2027)

### DIFF
--- a/libraries/extensions/ros2-bridge/arrow/src/serialize/array.rs
+++ b/libraries/extensions/ros2-bridge/arrow/src/serialize/array.rs
@@ -357,7 +357,7 @@ mod tests {
     }
 
     /// #2027: a fixed-size `string[3]` field given the wrong number of elements
-    /// must error rather than silently emit a mis-sized (length-prefix-less)
+    /// must error rather than silently emit a wrong-sized (length-prefix-less)
     /// CDR tuple.
     #[test]
     fn fixed_string_array_length_is_checked() {

--- a/libraries/extensions/ros2-bridge/arrow/src/serialize/array.rs
+++ b/libraries/extensions/ros2-bridge/arrow/src/serialize/array.rs
@@ -12,7 +12,7 @@ use serde::ser::SerializeTuple;
 
 use crate::TypeInfo;
 
-use super::{TypedValue, error};
+use super::{TypedValue, check_array_len, error};
 
 /// Serialize an array with known size as tuple.
 pub struct ArraySerializeWrapper<'a> {
@@ -120,6 +120,7 @@ impl serde::Serialize for ArraySerializeWrapper<'_> {
                 let array = entry
                     .as_struct_opt()
                     .ok_or_else(|| error("not a struct array"))?;
+                check_array_len(array.len(), self.array_info.size)?;
                 let mut seq = serializer.serialize_tuple(self.array_info.size)?;
                 for i in 0..array.len() {
                     let row = array.slice(i, 1);
@@ -144,6 +145,7 @@ impl serde::Serialize for ArraySerializeWrapper<'_> {
                 let array = entry
                     .as_struct_opt()
                     .ok_or_else(|| error("not a struct array"))?;
+                check_array_len(array.len(), self.array_info.size)?;
                 let mut seq = serializer.serialize_tuple(self.array_info.size)?;
                 for i in 0..array.len() {
                     let row = array.slice(i, 1);
@@ -211,13 +213,7 @@ where
             .value
             .as_primitive_opt()
             .ok_or_else(|| error(format!("not a primitive {} array", type_name::<T>())))?;
-        if array.len() != self.len {
-            return Err(error(format!(
-                "expected array with length {}, got length {}",
-                self.len,
-                array.len()
-            )));
-        }
+        check_array_len(array.len(), self.len)?;
 
         for value in array.values() {
             seq.serialize_element(value)?;
@@ -242,13 +238,7 @@ impl serde::Serialize for BoolArrayAsTuple<'_> {
             .value
             .as_boolean_opt()
             .ok_or_else(|| error("not a boolean array"))?;
-        if array.len() != self.len {
-            return Err(error(format!(
-                "expected array with length {}, got length {}",
-                self.len,
-                array.len()
-            )));
-        }
+        check_array_len(array.len(), self.len)?;
 
         for value in array.values() {
             seq.serialize_element(&value)?;
@@ -267,6 +257,7 @@ where
     S: serde::Serializer,
     O: OffsetSizeTrait,
 {
+    check_array_len(array.len(), array_len)?;
     let mut seq = serializer.serialize_tuple(array_len)?;
     for s in array.iter() {
         seq.serialize_element(s.unwrap_or_default())?;
@@ -283,10 +274,115 @@ where
     S: serde::Serializer,
     O: OffsetSizeTrait,
 {
+    check_array_len(array.len(), array_len)?;
     let mut seq = serializer.serialize_tuple(array_len)?;
     for s in array.iter() {
         let utf16: Vec<u16> = s.unwrap_or_default().encode_utf16().collect();
         seq.serialize_element(&utf16)?;
     }
     seq.end()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{borrow::Cow, collections::HashMap, sync::Arc};
+
+    use arrow::{
+        array::{ArrayRef, ListArray, StringArray, StructArray},
+        buffer::OffsetBuffer,
+        datatypes::{DataType, Field},
+    };
+    use byteorder::LittleEndian;
+    use dora_ros2_bridge_msg_gen::types::{
+        Member, MemberType, Message,
+        primitives::{GenericString, NestableType},
+        sequences::Array as ArrayType,
+    };
+
+    use super::*;
+    use crate::TypeInfo;
+
+    /// A message with a single fixed-size `<field_type>[3]` array field.
+    fn fixed_array_message(
+        field_type: NestableType,
+    ) -> Arc<HashMap<String, HashMap<String, Message>>> {
+        let message = Message {
+            package: "test_msgs".to_string(),
+            name: "ArrMsg".to_string(),
+            members: vec![Member {
+                name: "names".to_string(),
+                r#type: MemberType::Array(ArrayType {
+                    value_type: field_type,
+                    size: 3,
+                }),
+                default: None,
+            }],
+            constants: vec![],
+        };
+        let mut package = HashMap::new();
+        package.insert("ArrMsg".to_string(), message);
+        let mut messages = HashMap::new();
+        messages.insert("test_msgs".to_string(), package);
+        Arc::new(messages)
+    }
+
+    fn serializes_ok(
+        messages: &Arc<HashMap<String, HashMap<String, Message>>>,
+        names: &[&str],
+    ) -> bool {
+        // An array field's column is a single-element `List` whose inner value
+        // holds the array elements (mirrors how dora wraps message fields).
+        let item = Arc::new(Field::new("item", DataType::Utf8, true));
+        let list = ListArray::new(
+            item.clone(),
+            OffsetBuffer::from_lengths([names.len()]),
+            Arc::new(StringArray::from(names.to_vec())),
+            None,
+        );
+        let struct_array = StructArray::from(vec![(
+            Arc::new(Field::new("names", DataType::List(item), false)),
+            Arc::new(list) as ArrayRef,
+        )]);
+        let value = Arc::new(struct_array) as ArrayRef;
+        let type_info = TypeInfo {
+            package_name: Cow::Borrowed("test_msgs"),
+            message_name: Cow::Borrowed("ArrMsg"),
+            messages: messages.clone(),
+        };
+        let typed = TypedValue {
+            value: &value,
+            type_info: &type_info,
+        };
+        cdr_encoding::to_vec::<_, LittleEndian>(&typed).is_ok()
+    }
+
+    /// #2027: a fixed-size `string[3]` field given the wrong number of elements
+    /// must error rather than silently emit a mis-sized (length-prefix-less)
+    /// CDR tuple.
+    #[test]
+    fn fixed_string_array_length_is_checked() {
+        let messages = fixed_array_message(NestableType::GenericString(GenericString::String));
+        assert!(
+            !serializes_ok(&messages, &["a", "b"]),
+            "size-3 field with 2 elements must error"
+        );
+        assert!(
+            serializes_ok(&messages, &["a", "b", "c"]),
+            "size-3 field with 3 elements must serialize"
+        );
+    }
+
+    /// Same guard on the `wstring[N]` path.
+    #[test]
+    fn fixed_wstring_array_length_is_checked() {
+        let messages = fixed_array_message(NestableType::GenericString(GenericString::WString));
+        assert!(
+            !serializes_ok(&messages, &["a", "b", "c", "d"]),
+            "size-3 field with 4 elements must error"
+        );
+        assert!(
+            serializes_ok(&messages, &["a", "b", "c"]),
+            "size-3 field with 3 elements must serialize"
+        );
+    }
 }

--- a/libraries/extensions/ros2-bridge/arrow/src/serialize/mod.rs
+++ b/libraries/extensions/ros2-bridge/arrow/src/serialize/mod.rs
@@ -235,3 +235,16 @@ fn check_single_element<E: serde::ser::Error>(len: usize, type_name: &str) -> Re
     }
     Ok(())
 }
+
+/// Guard for fixed-size array fields: a ROS2 `T[N]` array has no length prefix
+/// on the CDR wire, so the Arrow column must have exactly `expected` elements.
+/// A mismatch would otherwise emit the wrong element count into a fixed tuple
+/// and silently corrupt the message (dora-rs/dora#2027).
+fn check_array_len<E: serde::ser::Error>(actual: usize, expected: usize) -> Result<(), E> {
+    if actual != expected {
+        return Err(serde::ser::Error::custom(format!(
+            "expected array with length {expected}, got length {actual}"
+        )));
+    }
+    Ok(())
+}


### PR DESCRIPTION
Fixes the fixed-size-array length-check finding from `docs/audit-2026-06-04-soundness.md` (#2027). The cluster's other items are done or scoped: `Name::new().unwrap()` → `?` (#2065), scalar WString cap (#2041), and the service-side client-pending eviction.

## The bug

A ROS2 `T[N]` fixed-size array has **no length prefix** on the CDR wire — the deserializer reads exactly `N` elements. The serializer's primitive and bool paths already guard `array.len() == N` (`BasicArrayAsTuple` / `BoolArrayAsTuple`), but three paths did not:

- `serialize_arrow_string` / `serialize_arrow_wstring` — declared `serialize_tuple(array_len)` then iterated `array.iter()` (the actual column);
- the struct paths (`NestableType::NamedType` / `NamespacedType`) — declared `serialize_tuple(array_info.size)` then looped `0..array.len()`.

So a `string[3]` / `Pose[3]` field handed an Arrow column of length 2 or 4 silently emitted the wrong element count into the fixed tuple, corrupting that field and **everything after it** in the message.

## The fix

A shared `check_array_len(actual, expected)` helper (next to `check_single_element`), applied on all the fixed-array paths. The two pre-existing inline checks are refactored to use it too, so all six paths share one guard and one error message.

## Tests
- `fixed_string_array_length_is_checked` — a `string[3]` field with 2 elements errors; with 3 serializes.
- `fixed_wstring_array_length_is_checked` — same on the `wstring[N]` path (4 elements error, 3 serialize).

Both fail against the prior code (the wrong-length case used to serialize silently). The struct paths use the identical `check_array_len` guard.

## Deferred (same cluster)
The **action-client `pending` request set** still lacks the 30s-timeout eviction the service side has (it's removed only on a matching GetResult response, so a never-answered result leaks). That's a codegen (`quote!`) change in the recently-reworked result demux (#1972/#1995), untestable without a ROS2 runtime — better as a focused follow-up with a `syn` parse-test (like #2065) than bolted onto this serialization fix.

## QA
- `cargo test -p dora-ros2-bridge-arrow` — 4 passed
- `cargo clippy -p dora-ros2-bridge-arrow -- -D warnings` clean
- `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
