### PR TITLE
fix(ros2-bridge): honor array size in fixed-size string/struct defaults (#2027)

### DIFF
--- a/libraries/extensions/ros2-bridge/arrow/src/serialize/defaults.rs
+++ b/libraries/extensions/ros2-bridge/arrow/src/serialize/defaults.rs
@@ -266,7 +266,18 @@ fn list_default_values(
                     .as_slice(),
             )
             .context("Failed to concatenate default list value")?;
-            default_values.to_data()
+            // Wrap the preset elements in a single-element `List`, exactly like
+            // the no-default arm below. `ArraySerializeWrapper` /
+            // `SequenceSerializeWrapper` unwrap the column via `as_list_opt`, so
+            // returning the bare concatenated array would fail to serialize
+            // ("value is not compatible with expected array type") for an
+            // omitted field with a preset array/sequence default
+            // (dora-rs/dora#2027 review).
+            let len = default_values.len();
+            let offsets = OffsetBuffer::new(ScalarBuffer::from(vec![0, len as i32]));
+            let field = Arc::new(Field::new("item", default_values.data_type().clone(), true));
+            let list = ListArray::new(field, offsets, default_values, None);
+            list.to_data()
         }
         None => {
             let size = size.unwrap_or(1);
@@ -370,7 +381,8 @@ mod tests {
     /// Same for a preset `char[N]` default (`char[3] [0, 1, 127]`): every
     /// element must be `UInt8`. (The preset-array path returns the concatenated
     /// element array directly rather than list-wrapping it — a separate
-    /// pre-existing shape quirk vs the no-default path; assert the element type.)
+    /// no-default path) so `ArraySerializeWrapper` can unwrap it, and each
+    /// element must be `UInt8`.
     #[test]
     fn preset_char_array_default_is_uint8() {
         use dora_ros2_bridge_msg_gen::types::primitives::BasicType;
@@ -378,9 +390,55 @@ mod tests {
         member.default = Some(vec!["0".to_string(), "1".to_string(), "127".to_string()]);
         let messages = HashMap::new();
         let data = default_for_member(&member, "test_pkg", &messages).unwrap();
-        let array = make_array(data);
-        assert_eq!(array.data_type(), &arrow::datatypes::DataType::UInt8);
-        assert_eq!(array.len(), 3);
+        let list = make_array(data);
+        let list = list.as_list::<i32>();
+        assert_eq!(list.len(), 1, "preset fixed array is a single-element list");
+        let inner = list.value(0);
+        assert_eq!(inner.data_type(), &arrow::datatypes::DataType::UInt8);
+        assert_eq!(inner.len(), 3);
+    }
+
+    /// End-to-end: an Arrow input that OMITS a `char[3]` field with a preset
+    /// default must serialize using that default (it previously errored with
+    /// "value is not compatible with expected array type" because the preset
+    /// default was a bare array, not a single-element list).
+    #[test]
+    fn preset_char_array_default_serializes() {
+        use std::borrow::Cow;
+
+        use arrow::array::{ArrayRef, StructArray};
+        use byteorder::LittleEndian;
+        use dora_ros2_bridge_msg_gen::types::primitives::BasicType;
+
+        let mut member = array_member(NestableType::BasicType(BasicType::Char), 3);
+        member.name = "c".to_string();
+        member.default = Some(vec!["0".to_string(), "1".to_string(), "127".to_string()]);
+        let message = Message {
+            package: "test_pkg".to_string(),
+            name: "M".to_string(),
+            members: vec![member],
+            constants: vec![],
+        };
+        let mut package = HashMap::new();
+        package.insert("M".to_string(), message);
+        let mut messages = HashMap::new();
+        messages.insert("test_pkg".to_string(), package);
+
+        // Length-1 struct with no columns => every field uses its default.
+        let value: ArrayRef = Arc::new(StructArray::new_empty_fields(1, None));
+        let type_info = crate::TypeInfo {
+            package_name: Cow::Borrowed("test_pkg"),
+            message_name: Cow::Borrowed("M"),
+            messages: Arc::new(messages),
+        };
+        let typed = crate::serialize::TypedValue {
+            value: &value,
+            type_info: &type_info,
+        };
+        let bytes = cdr_encoding::to_vec::<_, LittleEndian>(&typed)
+            .expect("preset char[3] default must serialize");
+        // Fixed `char[3]` => 3 raw UInt8 bytes, no length prefix.
+        assert_eq!(bytes, vec![0u8, 1, 127]);
     }
 
     /// Same guard for a fixed-size array of a referenced struct type.

--- a/libraries/extensions/ros2-bridge/arrow/src/serialize/defaults.rs
+++ b/libraries/extensions/ros2-bridge/arrow/src/serialize/defaults.rs
@@ -192,7 +192,14 @@ fn preset_default_for_basic_type(t: &NestableType, preset: &str) -> Result<Array
                     .context("Could not parse preset default value")?,
             ])
             .into(),
-            BasicType::Char => StringArray::from(vec![preset]).into(),
+            // `char` is a `UInt8` on the wire (see `primitive.rs`); its preset
+            // default is the numeric byte value, not a string.
+            BasicType::Char => UInt8Array::from(vec![
+                preset
+                    .parse::<u8>()
+                    .context("Could not parse preset default value")?,
+            ])
+            .into(),
             BasicType::Byte => UInt8Array::from(preset.as_bytes().to_owned()).into(),
             BasicType::Bool => BooleanArray::from(vec![
                 preset
@@ -337,6 +344,43 @@ mod tests {
             &arrow::datatypes::DataType::UInt8,
             "char default element type must be UInt8"
         );
+    }
+
+    /// A preset `char` default (`char foo 100`) is the numeric byte value and
+    /// must produce a `UInt8` array, not a `StringArray` the serialize path
+    /// would reject (dora-rs/dora#2027 review).
+    #[test]
+    fn preset_char_default_is_uint8() {
+        use dora_ros2_bridge_msg_gen::types::primitives::BasicType;
+        let member = Member {
+            name: "c".to_string(),
+            r#type: MemberType::NestableType(NestableType::BasicType(BasicType::Char)),
+            default: Some(vec!["100".to_string()]),
+        };
+        let messages = HashMap::new();
+        let data = default_for_member(&member, "test_pkg", &messages).unwrap();
+        let array = make_array(data);
+        assert_eq!(array.data_type(), &arrow::datatypes::DataType::UInt8);
+        assert_eq!(
+            array.as_primitive::<arrow::datatypes::UInt8Type>().value(0),
+            100
+        );
+    }
+
+    /// Same for a preset `char[N]` default (`char[3] [0, 1, 127]`): every
+    /// element must be `UInt8`. (The preset-array path returns the concatenated
+    /// element array directly rather than list-wrapping it — a separate
+    /// pre-existing shape quirk vs the no-default path; assert the element type.)
+    #[test]
+    fn preset_char_array_default_is_uint8() {
+        use dora_ros2_bridge_msg_gen::types::primitives::BasicType;
+        let mut member = array_member(NestableType::BasicType(BasicType::Char), 3);
+        member.default = Some(vec!["0".to_string(), "1".to_string(), "127".to_string()]);
+        let messages = HashMap::new();
+        let data = default_for_member(&member, "test_pkg", &messages).unwrap();
+        let array = make_array(data);
+        assert_eq!(array.data_type(), &arrow::datatypes::DataType::UInt8);
+        assert_eq!(array.len(), 3);
     }
 
     /// Same guard for a fixed-size array of a referenced struct type.

--- a/libraries/extensions/ros2-bridge/arrow/src/serialize/defaults.rs
+++ b/libraries/extensions/ros2-bridge/arrow/src/serialize/defaults.rs
@@ -86,7 +86,10 @@ fn default_for_nestable_type(
             BasicType::U64 => UInt64Array::from(vec![0; size]).into(),
             BasicType::F32 => Float32Array::from(vec![0.; size]).into(),
             BasicType::F64 => Float64Array::from(vec![0.; size]).into(),
-            BasicType::Char => StringArray::from(vec![""; size]).into(),
+            // `Char` is serialized/deserialized as a `UInt8` primitive (see
+            // `array.rs` / `primitive.rs`), so its default must be a UInt8
+            // array, not a `StringArray` (which the serialize path rejects).
+            BasicType::Char => UInt8Array::from(vec![0u8; size]).into(),
             BasicType::Byte => UInt8Array::from(vec![0u8; size]).into(),
             BasicType::Bool => BooleanArray::from(vec![false; size]).into(),
         },
@@ -307,7 +310,33 @@ mod tests {
         let list = make_array(data);
         let list = list.as_list::<i32>();
         assert_eq!(list.len(), 1, "fixed array is a single-element list");
-        assert_eq!(list.value(0).len(), 3, "inner default must hold N elements");
+        let inner = list.value(0);
+        assert_eq!(inner.len(), 3, "inner default must hold N elements");
+        assert_eq!(
+            inner.data_type(),
+            &arrow::datatypes::DataType::Utf8,
+            "string default element type"
+        );
+    }
+
+    /// `char[N]` is serialized as `UInt8`, so its default element type must be
+    /// `UInt8` (not `Utf8`) — otherwise the serialize path rejects it
+    /// (dora-rs/dora#2027 review).
+    #[test]
+    fn absent_fixed_char_array_default_is_uint8() {
+        use dora_ros2_bridge_msg_gen::types::primitives::BasicType;
+        let member = array_member(NestableType::BasicType(BasicType::Char), 3);
+        let messages = HashMap::new();
+        let data = default_for_member(&member, "test_pkg", &messages).unwrap();
+        let list = make_array(data);
+        let list = list.as_list::<i32>();
+        let inner = list.value(0);
+        assert_eq!(inner.len(), 3);
+        assert_eq!(
+            inner.data_type(),
+            &arrow::datatypes::DataType::UInt8,
+            "char default element type must be UInt8"
+        );
     }
 
     /// Same guard for a fixed-size array of a referenced struct type.

--- a/libraries/extensions/ros2-bridge/arrow/src/serialize/defaults.rs
+++ b/libraries/extensions/ros2-bridge/arrow/src/serialize/defaults.rs
@@ -86,27 +86,44 @@ fn default_for_nestable_type(
             BasicType::U64 => UInt64Array::from(vec![0; size]).into(),
             BasicType::F32 => Float32Array::from(vec![0.; size]).into(),
             BasicType::F64 => Float64Array::from(vec![0.; size]).into(),
-            BasicType::Char => StringArray::from(vec![""]).into(),
+            BasicType::Char => StringArray::from(vec![""; size]).into(),
             BasicType::Byte => UInt8Array::from(vec![0u8; size]).into(),
             BasicType::Bool => BooleanArray::from(vec![false; size]).into(),
         },
-        NestableType::GenericString(_) => StringArray::from(vec![""]).into(),
+        NestableType::GenericString(_) => StringArray::from(vec![""; size]).into(),
         NestableType::NamedType(name) => {
             let referenced_message = package_messages
                 .get(&name.0)
                 .context("unknown referenced message")?;
 
-            default_for_referenced_message(referenced_message, package_name, messages)?
+            let one = default_for_referenced_message(referenced_message, package_name, messages)?;
+            repeat_default(one, size)?
         }
         NestableType::NamespacedType(t) => {
             let referenced_package_messages = messages.get(&t.package).unwrap_or(&empty);
             let referenced_message = referenced_package_messages
                 .get(&t.name)
                 .context("unknown referenced message")?;
-            default_for_referenced_message(referenced_message, &t.package, messages)?
+            let one = default_for_referenced_message(referenced_message, &t.package, messages)?;
+            repeat_default(one, size)?
         }
     };
     Ok(array)
+}
+
+/// Repeat a length-1 default `size` times so a fixed-size `T[N]` (or N-element
+/// sequence) default has a backing array of the right length. Without this,
+/// `list_default_values` builds a `[0, N]` offset over a length-1 backing and
+/// `ListArray::new` panics for `N > 1` (dora-rs/dora#2027).
+fn repeat_default(one: ArrayData, size: usize) -> Result<ArrayData> {
+    let array = make_array(one);
+    if size == 0 {
+        return Ok(arrow::array::new_empty_array(array.data_type()).to_data());
+    }
+    let copies = vec![array.as_ref(); size];
+    Ok(concat(&copies)
+        .context("failed to build repeated default value")?
+        .to_data())
 }
 
 fn preset_default_for_basic_type(t: &NestableType, preset: &str) -> Result<ArrayData> {
@@ -258,4 +275,70 @@ fn list_default_values(
     };
 
     Ok(defaults)
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow::array::AsArray;
+    use dora_ros2_bridge_msg_gen::types::{
+        Member, MemberType, Message,
+        primitives::{GenericString, NamedType, NestableType},
+        sequences::Array as ArrayType,
+    };
+
+    use super::*;
+
+    fn array_member(value_type: NestableType, size: usize) -> Member {
+        Member {
+            name: "field".to_string(),
+            r#type: MemberType::Array(ArrayType { value_type, size }),
+            default: None,
+        }
+    }
+
+    /// #2027: an absent fixed-size `string[N]` (N>1) default must not panic in
+    /// `ListArray::new` (the backing array previously had length 1 while the
+    /// list offset declared N). The default list element must hold N strings.
+    #[test]
+    fn absent_fixed_string_array_default_has_correct_length() {
+        let member = array_member(NestableType::GenericString(GenericString::String), 3);
+        let messages = HashMap::new();
+        let data = default_for_member(&member, "test_pkg", &messages).unwrap();
+        let list = make_array(data);
+        let list = list.as_list::<i32>();
+        assert_eq!(list.len(), 1, "fixed array is a single-element list");
+        assert_eq!(list.value(0).len(), 3, "inner default must hold N elements");
+    }
+
+    /// Same guard for a fixed-size array of a referenced struct type.
+    #[test]
+    fn absent_fixed_struct_array_default_has_correct_length() {
+        let inner = Message {
+            package: "test_pkg".to_string(),
+            name: "Inner".to_string(),
+            members: vec![Member {
+                name: "x".to_string(),
+                r#type: MemberType::NestableType(NestableType::BasicType(
+                    dora_ros2_bridge_msg_gen::types::primitives::BasicType::I32,
+                )),
+                default: None,
+            }],
+            constants: vec![],
+        };
+        let mut package = HashMap::new();
+        package.insert("Inner".to_string(), inner);
+        let mut messages = HashMap::new();
+        messages.insert("test_pkg".to_string(), package);
+
+        let member = array_member(NestableType::NamedType(NamedType("Inner".to_string())), 2);
+        let data = default_for_member(&member, "test_pkg", &messages).unwrap();
+        let list = make_array(data);
+        let list = list.as_list::<i32>();
+        assert_eq!(list.len(), 1);
+        assert_eq!(
+            list.value(0).len(),
+            2,
+            "inner struct default must hold N rows"
+        );
+    }
 }


### PR DESCRIPTION
Fixes a crash surfaced in the adversarial review of #2073 (a pre-existing bug, not in the original audit list).

## The bug

`default_for_member` builds the default value for a message field the user omitted from their Arrow input. For a fixed-size array field it calls `list_default_values`, which builds a single-element `List` with offsets `[0, N]` over an inner "default element" array, and that inner array must have `N` elements.

But `default_for_nestable_type(t, …, size)` only honored `size` for the numeric basic types (`vec![…; size]`). For:
- `GenericString` (line 93) and `BasicType::Char` (line 89) — it always returned a length-1 `StringArray`;
- `NamedType` / `NamespacedType` (lines 94-107) — `default_for_referenced_message` always returns a single struct row.

So for an absent `string[N>1]` / `char[N>1]` / `Struct[N>1]` field, `list_default_values` built `[0, N]` offsets over a length-1 backing and `ListArray::new` **panicked**:

```
Max offset of N exceeds length of values 1
```

before serialization even began — a hard crash on a valid message that merely omits a fixed-size array field. (`int32[3]` etc. worked, because numeric types honored `size`.)

## The fix

Honor `size` in those arms:
- `GenericString` / `Char` → `StringArray::from(vec![""; size])`;
- `NamedType` / `NamespacedType` → a new `repeat_default` helper that `concat`s the length-1 struct default `size` times (and returns a length-0 array for `size == 0`).

The `size == 1` scalar-field callers are unchanged (`vec![""; 1]` == `vec![""]`; repeat 1× == the single struct).

## Tests
- `absent_fixed_string_array_default_has_correct_length` — an omitted `string[3]` now yields a list whose element holds 3 strings.
- `absent_fixed_struct_array_default_has_correct_length` — an omitted `Inner[2]` (referenced struct) yields a list whose element holds 2 struct rows.

Both **panicked** against the prior code.

## QA
- `cargo test -p dora-ros2-bridge-arrow` — 6 passed
- `cargo clippy -p dora-ros2-bridge-arrow -- -D warnings` clean
- `cargo fmt --all -- --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
