### PR TITLE
fix: catch operator on_event panics + stop python reload error-latch (#2027)

### DIFF
--- a/apis/rust/operator/src/lib.rs
+++ b/apis/rust/operator/src/lib.rs
@@ -215,4 +215,48 @@ mod tests {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<SendOutput>();
     }
+
+    #[derive(Default)]
+    struct PanicOperator;
+
+    impl DoraOperator for PanicOperator {
+        fn on_event(
+            &mut self,
+            _event: &Event,
+            _output_sender: &mut DoraOutputSender,
+        ) -> Result<DoraStatus, String> {
+            panic!("boom in on_event");
+        }
+    }
+
+    /// #2027: a panic in the user's `on_event` must be caught and reported as
+    /// an error (Stop), not unwind across the generated `extern "C"
+    /// dora_on_event` boundary, which would force-abort the whole process.
+    /// (A panic backtrace printed during this test is expected — the caught
+    /// unwind.)
+    #[test]
+    fn on_event_panic_is_caught_not_aborted() {
+        let sender = noop_send_output();
+        let mut op = PanicOperator;
+        let ctx: *mut std::ffi::c_void = (&mut op as *mut PanicOperator).cast();
+        // A Stop event (no input) so the panicking `on_event` is reached.
+        let mut event = types::RawEvent {
+            input: None,
+            input_closed: None,
+            stop: true,
+            error: None,
+        };
+
+        let result =
+            unsafe { crate::raw::dora_on_event::<PanicOperator>(&mut event, &sender, ctx) };
+
+        assert!(
+            result.result.error.is_some(),
+            "panic must surface as an error"
+        );
+        assert!(
+            matches!(result.status, DoraStatus::Stop),
+            "panic must stop the operator"
+        );
+    }
 }

--- a/apis/rust/operator/src/raw.rs
+++ b/apis/rust/operator/src/raw.rs
@@ -70,8 +70,16 @@ pub unsafe fn dora_on_event<O: DoraOperator>(
     };
     // Catch a panic in the user's `on_event`: this function is called directly
     // from the generated `extern "C" fn dora_on_event`, and unwinding across
-    // that boundary is a forced process abort. Convert it to a clean error +
-    // Stop so the runtime can report it (dora-rs/dora#2027).
+    // that boundary is a forced process abort. Report it as an operator error
+    // instead (dora-rs/dora#2027). The runtime treats any `error` as fatal
+    // regardless of `status`, so the `Stop` below just matches the normal
+    // error path. `AssertUnwindSafe` is sound here because the operator is torn
+    // down after an error and never re-entered.
+    //
+    // Caveats: this only protects under `panic = "unwind"` (the default) — an
+    // operator dylib built with `panic = "abort"` aborts before the unwind is
+    // caught. The default panic hook still prints to stderr in addition to the
+    // structured error returned here.
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         operator.on_event(&event_variant, &mut output_sender)
     }));

--- a/apis/rust/operator/src/raw.rs
+++ b/apis/rust/operator/src/raw.rs
@@ -68,14 +68,39 @@ pub unsafe fn dora_on_event<O: DoraOperator>(
             status: DoraStatus::Continue,
         };
     };
-    match operator.on_event(&event_variant, &mut output_sender) {
-        Ok(status) => OnEventResult {
+    // Catch a panic in the user's `on_event`: this function is called directly
+    // from the generated `extern "C" fn dora_on_event`, and unwinding across
+    // that boundary is a forced process abort. Convert it to a clean error +
+    // Stop so the runtime can report it (dora-rs/dora#2027).
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        operator.on_event(&event_variant, &mut output_sender)
+    }));
+    match result {
+        Ok(Ok(status)) => OnEventResult {
             result: DoraResult { error: None },
             status,
         },
-        Err(error) => OnEventResult {
+        Ok(Err(error)) => OnEventResult {
             result: DoraResult::from_error(error),
             status: DoraStatus::Stop,
         },
+        Err(panic) => OnEventResult {
+            result: DoraResult::from_error(format!(
+                "operator on_event panicked: {}",
+                panic_message(&*panic)
+            )),
+            status: DoraStatus::Stop,
+        },
+    }
+}
+
+/// Extract a human-readable message from a caught panic payload.
+fn panic_message(panic: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = panic.downcast_ref::<&str>() {
+        (*s).to_string()
+    } else if let Some(s) = panic.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "<non-string panic payload>".to_string()
     }
 }

--- a/binaries/runtime/src/operator/python.rs
+++ b/binaries/runtime/src/operator/python.rs
@@ -244,6 +244,13 @@ pub fn run(
                     }
                 }
             })?;
+
+            // The post-reload error leniency above applies only to the event
+            // processed in the same iteration as the reload. Reset it so a
+            // single reload doesn't permanently swallow on_event errors for all
+            // subsequent events (dora-rs/dora#2027).
+            reload = false;
+
             match status {
                 s if s == DoraStatus::Continue as i32 => {} // ok
                 s if s == DoraStatus::Stop as i32 => break StopReason::ExplicitStop,


### PR DESCRIPTION
Fixes the two remaining **runtime/operators** findings from `docs/audit-2026-06-04-soundness.md` (#2027). The cluster's other two (operator panic Debug message, `span.enter()` guards) were already done as quick wins in `3a3a1f4a`.

## 1. Operator `on_event` panic aborts the whole process

`raw::dora_on_event` is invoked directly from the generated `extern "C" fn dora_on_event` (`macros/src/lib.rs`). A panic in the user's `on_event` unwound across that `extern "C"` boundary — a **forced process abort** in current Rust (the audit's "Critical" note: defined abort, not UB). One buggy operator takes down the runtime.

Fix: wrap the user `on_event` call in `std::panic::catch_unwind` and convert a panic into a clean error + `Stop` (downcasting the payload to a readable message), so the runtime reports it like any other operator error.

Test: `on_event_panic_is_caught_not_aborted` — a panicking operator now yields `error.is_some()` + `Stop` (the call would abort the process without the guard).

## 2. Python operator hot-reload latches error leniency forever

The python operator runtime intentionally tolerates `on_event` errors right after a hot reload (dev convenience). But `reload` was set `true` on the first `Reload` event and **never reset**, so after *any* reload, *every* subsequent `on_event` error was silently swallowed (`warn!` + Continue) for the rest of the run — real errors disappeared.

Fix: reset `reload` after the `on_event` of the reload iteration, scoping leniency to that single event.

## QA
- `cargo test -p dora-operator-api` — 7 passed
- `cargo clippy -p dora-operator-api -- -D warnings` clean
- `cargo clippy -p dora-runtime --features python -- -D warnings` clean (the python operator path is feature-gated; not built by default-feature CI)
- `cargo fmt --all -- --check` + `typos` clean

The python-reload fix is in the `python`-feature path (PyO3 + a live Python operator), so it isn't covered by a unit test; it's a one-line state-machine reset, verified by construction and a `--features python` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
