### PR TITLE
fix(coordinator): avoid Instant underflow panic in build-timeout tests on Windows (#2082)

### DIFF
--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -2042,7 +2042,13 @@ async fn start_inner(
                 // that would otherwise hang on the client-side RPC deadline
                 // when a daemon participating in `dora build` disconnects
                 // or otherwise never reports its `build_result`. #1465.
-                check_build_timeouts(&mut running_builds, &mut finished_builds, &clock).await;
+                check_build_timeouts(
+                    &mut running_builds,
+                    &mut finished_builds,
+                    &clock,
+                    build_result_timeout(),
+                )
+                .await;
 
                 // Recovery timeout: transition stale Recovering dataflows to Failed.
                 // Dataflows are marked Recovering on coordinator startup and should
@@ -3536,8 +3542,8 @@ async fn check_build_timeouts(
     running_builds: &mut HashMap<BuildId, RunningBuild>,
     finished_builds: &mut IndexMap<BuildId, CachedResult>,
     clock: &HLC,
+    timeout_threshold: Duration,
 ) {
-    let timeout_threshold = build_result_timeout();
     let stuck: Vec<(BuildId, usize)> = running_builds
         .iter()
         .filter_map(|(id, build)| {
@@ -7544,6 +7550,15 @@ mod tests {
     // dataflow_results synthesis — just release waiters and move the entry
     // from `running_builds` to `finished_builds`.
 
+    // Small, cross-platform-safe watchdog timeout for the unit tests. The
+    // tests pass this to `check_build_timeouts` instead of the 20-min
+    // production `build_result_timeout()`, so `test_running_build` only has to
+    // backdate `build_started_at` by ~2s. Backdating by the production timeout
+    // computes `Instant::now() - 20min`, which underflows and panics on
+    // Windows runners whose monotonic-clock epoch is younger than 20 min
+    // (dora-rs/dora#2082).
+    const TEST_BUILD_TIMEOUT: Duration = Duration::from_secs(1);
+
     fn test_running_build(daemon_id: DaemonId, backdate: bool) -> RunningBuild {
         let mut pending = BTreeSet::new();
         pending.insert(daemon_id);
@@ -7554,7 +7569,7 @@ mod tests {
             log_subscribers: Vec::new(),
             pending_build_results: pending,
             build_started_at: if backdate {
-                Instant::now() - build_result_timeout() - Duration::from_secs(1)
+                Instant::now() - TEST_BUILD_TIMEOUT - Duration::from_secs(1)
             } else {
                 Instant::now()
             },
@@ -7577,7 +7592,13 @@ mod tests {
         running_builds.insert(build_id, build);
         let mut finished_builds: IndexMap<BuildId, CachedResult> = IndexMap::new();
 
-        check_build_timeouts(&mut running_builds, &mut finished_builds, &clock).await;
+        check_build_timeouts(
+            &mut running_builds,
+            &mut finished_builds,
+            &clock,
+            TEST_BUILD_TIMEOUT,
+        )
+        .await;
 
         // Waiter resolved with an error.
         let reply = timeout(TokioDuration::from_secs(1), rx)
@@ -7617,7 +7638,13 @@ mod tests {
         running_builds.insert(build_id, build);
         let mut finished_builds: IndexMap<BuildId, CachedResult> = IndexMap::new();
 
-        check_build_timeouts(&mut running_builds, &mut finished_builds, &clock).await;
+        check_build_timeouts(
+            &mut running_builds,
+            &mut finished_builds,
+            &clock,
+            TEST_BUILD_TIMEOUT,
+        )
+        .await;
 
         // Waiter still pending.
         let polled = tokio::time::timeout(TokioDuration::from_millis(50), rx).await;
@@ -7653,7 +7680,13 @@ mod tests {
         running_builds.insert(build_id, build);
         let mut finished_builds: IndexMap<BuildId, CachedResult> = IndexMap::new();
 
-        check_build_timeouts(&mut running_builds, &mut finished_builds, &clock).await;
+        check_build_timeouts(
+            &mut running_builds,
+            &mut finished_builds,
+            &clock,
+            TEST_BUILD_TIMEOUT,
+        )
+        .await;
 
         let build = running_builds.get_mut(&build_id).expect(
             "Cached(Ok) build must stay in running_builds — only is_pending() \
@@ -7695,7 +7728,13 @@ mod tests {
         running_builds.insert(build_id, build);
         let mut finished_builds: IndexMap<BuildId, CachedResult> = IndexMap::new();
 
-        check_build_timeouts(&mut running_builds, &mut finished_builds, &clock).await;
+        check_build_timeouts(
+            &mut running_builds,
+            &mut finished_builds,
+            &clock,
+            TEST_BUILD_TIMEOUT,
+        )
+        .await;
 
         // Build was moved to finished_builds with a Cached Err.
         let cached = finished_builds


### PR DESCRIPTION
## Problem

The nightly `test-cross-platform` (Windows) job in #2082 fails intermittently with three `dora-coordinator` unit tests panicking:

```
---- tests::check_build_timeouts_fires_error_when_pending_past_deadline stdout ----
thread '…' panicked at library\std\src\time.rs:446:33:
---- tests::check_build_timeouts_late_wait_for_build_gets_cached_error stdout ----
thread '…' panicked at library\std\src\time.rs:446:33:
---- tests::check_build_timeouts_idempotent_on_already_cached_result stdout ----
thread '…' panicked at library\std\src\time.rs:446:33:
test result: FAILED. 92 passed; 3 failed; …
```

(See https://github.com/dora-rs/dora/actions/runs/27123358401.)

## Root cause

`time.rs:446` is the `"overflow when subtracting duration from instant"` panic. The watchdog tests backdate `build_started_at` so the deadline has already passed:

```rust
build_started_at: Instant::now() - build_result_timeout() - Duration::from_secs(1)
```

`build_result_timeout()` defaults to **20 minutes** (`BUILD_RESULT_TIMEOUT_DEFAULT`). On Windows, `Instant` is backed by `QueryPerformanceCounter` with a monotonic epoch at **system boot**, so `Instant::now() - 20min` underflows and panics whenever the runner's uptime is under ~20 minutes. That's plausible on a GitHub-hosted Windows VM with a warm build cache, which explains the intermittent failure.

The sibling spawn-watchdog tests use the same idiom but backdate by only `spawn_result_timeout()` (60s) + 1s, so they don't realistically underflow — which is exactly why **only the build tests** fail, and only on Windows.

## Fix

Dependency-inject the timeout threshold into `check_build_timeouts` rather than reading the 20-min global inside it:

- Production call site passes `build_result_timeout()` — **behavior unchanged**.
- The unit tests pass a 1s `TEST_BUILD_TIMEOUT`, so the helper only backdates `build_started_at` by ~2s — well within any runner's uptime and safe on every platform.

No production behavior change; this is a test-determinism fix.

## Testing

- `cargo test -p dora-coordinator --lib` — 95 passed, 0 failed (macOS).
- `cargo clippy -p dora-coordinator --all-targets -- -D warnings` — clean.
- `cargo fmt -p dora-coordinator -- --check` — clean.

The underflow only reproduces on a low-uptime Windows runner, so the real confirmation is a green nightly `test-cross-platform` on Windows.

## Scope

`Refs #2082`. This addresses **only** the Windows unit-test panic. #2082 also bundles a cluster-e2e Zenoh restart race + a macOS Python-operator build timeout (both targeted by #2085) and a separate macOS `python-operator-dataflow` cold-start flake (`object_detection exited before connecting`) that remains open. #2082 should not be auto-closed by any single one of these.

### Knowingly left unfixed

The same `Instant::now() - <Duration>` idiom exists in the `check_spawn_timeouts` and `NODE_STOPPED_GRACE` tests, but those backdate only 61s (vs the build path's 20 min). 61s cannot underflow in practice — compiling `dora-coordinator` + deps on a Windows runner takes minutes, so uptime is always well above 61s by the time the tests run. Left surgical to keep the diff scoped to the actual failure; can be hardened with the same DI pattern later if a spawn/grace timeout is ever bumped to a large value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

