### PR TITLE
ci(nightly): pre-warm python-operator example to fix macOS cold-start flake (#2089)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1351,6 +1351,17 @@ jobs:
           curl -fL --retry 10 --retry-delay 10 --retry-all-errors \
             -o examples/python-operator-dataflow/yolov8n.pt \
             https://github.com/ultralytics/assets/releases/download/v8.4.0/yolov8n.pt
+          # Pre-warm object_detection's env so the one-time matplotlib font-cache
+          # build and Ultralytics settings creation happen BEFORE the timed run.
+          # On a cold runner those can exceed the 20s --stop-after window, so the
+          # node gets SIGTERM'd mid-init and never connects to dora (#2089). Both
+          # caches live under $HOME, so warming the node's built venv (reusing the
+          # deps `dora build` already installed) warms the subsequent run. Best
+          # effort: non-Windows only (Scripts/ vs bin/), never fail the job.
+          if [ "$RUNNER_OS" != "Windows" ]; then
+            examples/python-operator-dataflow/.dora/python-envs/object_detection/bin/python -c \
+              "import matplotlib.pyplot; from ultralytics import YOLO; YOLO('examples/python-operator-dataflow/yolov8n.pt')" || true
+          fi
           dora run examples/python-operator-dataflow/dataflow.yml --uv --stop-after 20s
 
       - name: Test Python Multiple Arrays

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1357,10 +1357,19 @@ jobs:
           # node gets SIGTERM'd mid-init and never connects to dora (#2089). Both
           # caches live under $HOME, so warming the node's built venv (reusing the
           # deps `dora build` already installed) warms the subsequent run. Best
-          # effort: non-Windows only (Scripts/ vs bin/), never fail the job.
+          # effort: non-Windows only (Scripts/ vs bin/), never fail the job. The
+          # explicit markers mean a future change to the managed-venv layout shows
+          # up in the log instead of silently no-op'ing the warm-up.
           if [ "$RUNNER_OS" != "Windows" ]; then
-            examples/python-operator-dataflow/.dora/python-envs/object_detection/bin/python -c \
-              "import matplotlib.pyplot; from ultralytics import YOLO; YOLO('examples/python-operator-dataflow/yolov8n.pt')" || true
+            prewarm_py=examples/python-operator-dataflow/.dora/python-envs/object_detection/bin/python
+            if [ -x "$prewarm_py" ]; then
+              "$prewarm_py" -c \
+                "import matplotlib.pyplot; from ultralytics import YOLO; YOLO('examples/python-operator-dataflow/yolov8n.pt')" \
+                && echo "[prewarm] object_detection env warmed" \
+                || echo "[prewarm] warm command failed — continuing (#2089)"
+            else
+              echo "[prewarm] interpreter not found at $prewarm_py — venv layout may have changed (#2089)"
+            fi
           fi
           dora run examples/python-operator-dataflow/dataflow.yml --uv --stop-after 20s
 


### PR DESCRIPTION
## Problem

Fixes the macOS cold-start flake tracked in #2089 (split out from #2082).

The nightly **CLI Tests (macOS)** job intermittently fails on `python-operator-dataflow`. From the 2026-06-08 run (https://github.com/dora-rs/dora/actions/runs/27123358401):

```
object_detection:  Creating new Ultralytics Settings v0.0.6 file ✅
object_detection:  Matplotlib is building the font cache; this may take a minute
dora_daemon: stop-after timeout reached (20s) -> stopping dataflow
dora_daemon::spawn::prepared: node exited with error: Signal(15) node_id=object_detection
Node `plot` failed: ... node `object_detection` exited before connecting to dora.
```

`object_detection.py` imports `torch` + `ultralytics` and constructs `YOLO("yolov8n.pt")` at module load. On a cold runner this triggers two one-time setup costs **before the operator connects to dora**: creating the Ultralytics settings file and building the matplotlib font cache. When that cold init exceeds the **20 s** `--stop-after` window, the daemon SIGTERMs the graph mid-init, so `object_detection` never connects and `plot` dies with a cascading SIGTERM. (`yolov8n.pt` is already pre-fetched on `main`, so the model download is not the cause.)

## Fix

Pre-warm `object_detection`'s built venv before the timed run:

```bash
if [ "$RUNNER_OS" != "Windows" ]; then
  examples/python-operator-dataflow/.dora/python-envs/object_detection/bin/python -c \
    "import matplotlib.pyplot; from ultralytics import YOLO; YOLO('examples/python-operator-dataflow/yolov8n.pt')" || true
fi
```

Both the matplotlib font cache and the Ultralytics settings live under `$HOME`, so paying those one-time costs once ahead of `dora run` leaves the timed run warm. Properties:

- **No extra install** — reuses the venv `dora build --uv` already created (`.dora/python-envs/object_detection`, path per `libraries/core/src/build/mod.rs:270`).
- **Best-effort** — `|| true`, never fails the job.
- **Non-Windows only** — Windows uses `Scripts/` not `bin/`, and the flake isn't observed there.

This is option 1 (the preferred fix) from #2089.

## Testing

CI-only change for a cold-runner flake; can't be reproduced locally once matplotlib/ultralytics caches are warm. YAML validated (`yaml.safe_load`). Real confirmation is a green nightly **CLI Tests (macOS)** run.

`Refs #2089` rather than `Closes` — leave the issue open until a nightly confirms the flake is gone, since the fix can't be verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
