### PR TITLE
fix(arrow-convert): reject arrays with nulls in into_vec

### DIFF
--- a/libraries/arrow-convert/src/lib.rs
+++ b/libraries/arrow-convert/src/lib.rs
@@ -44,6 +44,9 @@ impl DerefMut for ArrowData {
 macro_rules! register_array_handlers {
     ($(($variant:path, $array_type:ty, $type_name:expr)),* $(,)?) => {
         /// Tries to convert the given Arrow array into a `Vec` of integers or floats.
+        ///
+        /// Returns an error if the array contains any null values, consistent
+        /// with every other [`TryFrom<&ArrowData>`] impl in this crate.
         pub fn into_vec<T>(data: &ArrowData) -> Result<Vec<T>>
         where
             T: Copy + NumCast + 'static,
@@ -55,6 +58,10 @@ macro_rules! register_array_handlers {
                             .as_any()
                             .downcast_ref()
                             .context(concat!("series is not ", $type_name))?;
+
+                        if buffer.null_count() != 0 {
+                            eyre::bail!("array has nulls");
+                        }
 
                         let mut result = Vec::with_capacity(buffer.len());
                         for &v in buffer.values() {

--- a/libraries/arrow-convert/tests/conversion_test.rs
+++ b/libraries/arrow-convert/tests/conversion_test.rs
@@ -1,5 +1,5 @@
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
-use dora_arrow_convert::{ArrowData, IntoArrow};
+use dora_arrow_convert::{ArrowData, IntoArrow, into_vec};
 use half::f16;
 use std::sync::Arc;
 
@@ -263,6 +263,33 @@ mod tests {
         let data: ArrowData = ArrowData(Arc::new(arrow_array));
         let result_naivetime: NaiveTime = TryFrom::try_from(&data)?;
         assert_eq!(value_naivetime, result_naivetime);
+        Ok(())
+    }
+
+    #[test]
+    fn test_into_vec_rejects_nulls() -> Result<(), Report> {
+        use arrow::array::{Array, Int32Array};
+        // [10, null, 30] — null slots must be rejected, not silently converted to 0
+        let array = Int32Array::from(vec![Some(10), None, Some(30)]);
+        assert_eq!(array.null_count(), 1);
+        let data = ArrowData(Arc::new(array));
+        let result: Result<Vec<i32>, eyre::Report> = into_vec(&data);
+        assert!(
+            result.is_err(),
+            "into_vec must reject arrays with nulls, but got {result:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_into_vec_accepts_no_nulls() -> Result<(), Report> {
+        use arrow::array::{Array, Int32Array};
+        // [10, 20, 30] — no nulls, must succeed
+        let array = Int32Array::from(vec![Some(10), Some(20), Some(30)]);
+        assert_eq!(array.null_count(), 0);
+        let data = ArrowData(Arc::new(array));
+        let v: Vec<i32> = into_vec(&data)?;
+        assert_eq!(v, vec![10, 20, 30]);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

`dora_arrow_convert::into_vec<T>()` silently ignores the null bitmap,
turning null slots into backing values (e.g. `0`) instead of reporting an
error.  This is the **only** conversion path in the crate that does not
check for nulls — every `TryFrom<&ArrowData>` impl in `from_impls.rs`
bails with `"array has nulls"` when `null_count() != 0`.

## Reproduction

```rust
use arrow::array::Int32Array;
use dora_arrow_convert::{into_vec, ArrowData};

// [10, null, 30]
let data = ArrowData(Arc::new(Int32Array::from(vec![Some(10), None, Some(30)])));
let v: Vec<i32> = into_vec(&data).unwrap();
assert_eq!(v, vec![10, 0, 30]); // null → 0, silently
```

## Root Cause

The register_array_handlers! macro (lib.rs:59-64) iterates
buffer.values() unconditionally without checking null_count().

## Fix

Add a null_count() check before the value iteration, consistent with
the rest of the crate:
```rust
if buffer.null_count() != 0 {
    eyre::bail!("array has nulls");
}
```

## Changes

| File                                              | Change                                            |
|---------------------------------------------------|---------------------------------------------------|
| libraries/arrow-convert/src/lib.rs                | +6 lines — null check in register_array_handlers! |
| libraries/arrow-convert/tests/conversion_test.rs  | +29 lines — two regression tests                  |

## Tests added

- test_into_vec_rejects_nulls — [10, null, 30] → error
- test_into_vec_accepts_no_nulls — [10, 20, 30] → Ok(vec![10, 20, 30])

## Validation

cargo test -p dora-arrow-convert                       # 29 passed, 0 failed
cargo clippy -p dora-arrow-convert -- -D warnings      # clean
cargo fmt --all -- --check                             # clean

Closes #2081
