### PR TITLE
refactor(core): remove dead remote-skip validation plumbing

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -790,7 +790,7 @@ impl Daemon {
             )
         }
 
-        validate::check_dataflow(&descriptor, &working_dir, None, false)
+        validate::check_dataflow(&descriptor, &working_dir)
             .wrap_err("Dataflow could not be validated.")?;
         let health_check_interval = descriptor
             .health_check_interval

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -39,7 +39,6 @@ pub trait DescriptorExt {
     fn blocking_read(path: &Path) -> eyre::Result<Descriptor>;
     fn parse(buf: Vec<u8>) -> eyre::Result<Descriptor>;
     fn check(&self, working_dir: &Path) -> eyre::Result<()>;
-    fn check_in_daemon(&self, working_dir: &Path, coordinator_is_remote: bool) -> eyre::Result<()>;
     /// Expand all module references into flat nodes.
     ///
     /// Module nodes are replaced by the inner nodes defined in their module
@@ -234,13 +233,7 @@ impl DescriptorExt for Descriptor {
 
     fn check(&self, working_dir: &Path) -> eyre::Result<()> {
         let expanded = self.expand(working_dir)?;
-        validate::check_dataflow(&expanded, working_dir, None, false)
-            .wrap_err("Dataflow could not be validated.")
-    }
-
-    fn check_in_daemon(&self, working_dir: &Path, coordinator_is_remote: bool) -> eyre::Result<()> {
-        let expanded = self.expand(working_dir)?;
-        validate::check_dataflow(&expanded, working_dir, None, coordinator_is_remote)
+        validate::check_dataflow(&expanded, working_dir)
             .wrap_err("Dataflow could not be validated.")
     }
 

--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -51,12 +51,7 @@ pub fn check_wiring(dataflow: &Descriptor) -> eyre::Result<()> {
     Ok(())
 }
 
-pub fn check_dataflow(
-    dataflow: &Descriptor,
-    working_dir: &Path,
-    remote_daemon_id: Option<&[&str]>,
-    coordinator_is_remote: bool,
-) -> eyre::Result<()> {
+pub fn check_dataflow(dataflow: &Descriptor, working_dir: &Path) -> eyre::Result<()> {
     // validate ROS2 bridge configs before resolution
     for node in &dataflow.nodes {
         if let Some(ros2) = &node.ros2 {
@@ -77,14 +72,6 @@ pub fn check_dataflow(
                     source => {
                         if source_is_url(source) {
                             info!("{source} is a URL."); // TODO: Implement url check.
-                        } else if let Some(remote_daemon_id) = remote_daemon_id {
-                            if let Some(deploy) = &node.deploy
-                                && let Some(machine) = &deploy.machine
-                                && (remote_daemon_id.contains(&machine.as_str())
-                                    || coordinator_is_remote)
-                            {
-                                info!("skipping path check for remote node `{}`", node.id);
-                            }
                         } else if custom.build.is_some() {
                             info!("skipping path check for node with build command");
                         } else {


### PR DESCRIPTION
`check_dataflow`'s `remote_daemon_id` and `coordinator_is_remote`
params were inert: every caller passed `None`/`false`, and
`coordinator_is_remote` was only read inside the never-taken
`Some(remote_daemon_id)` branch (which only emitted an info! log).
The `check_in_daemon` trait method that threaded these through had
no callers. Remove all three.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Fixes #2098
Alternative to #2099 
