### PR TITLE
refactor(daemon): remove dead `experienced_cascading_error` method

### DIFF
--- a/binaries/daemon/src/fault_tolerance.rs
+++ b/binaries/daemon/src/fault_tolerance.rs
@@ -34,11 +34,6 @@ pub struct CascadingErrorCauses {
 }
 
 impl CascadingErrorCauses {
-    #[allow(dead_code)]
-    pub fn experienced_cascading_error(&self, node: &NodeId) -> bool {
-        self.caused_by.contains_key(node)
-    }
-
     /// Return the ID of the node that caused a cascading error for the given node, if any.
     pub fn error_caused_by(&self, node: &NodeId) -> Option<&NodeId> {
         self.caused_by.get(node)


### PR DESCRIPTION
## Summary

`CascadingErrorCauses::experienced_cascading_error` was annotated `#[allow(dead_code)]` and had **zero callers** anywhere in the codebase. The same predicate is already covered by `error_caused_by`, which returns `Option<&NodeId>` and is actively used.

- Remove the `experienced_cascading_error` method and its `#[allow(dead_code)]` attribute from `binaries/daemon/src/fault_tolerance.rs`

## Verification

```
cargo check -p dora-daemon   → clean (0 errors, 0 warnings)
cargo fmt --all -- --check   → clean
```

---

> **⚠️ Auto-generated by Claude** (claude-sonnet-4-6). This PR contains no human-authored code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uxz3khPb74iG7w9rAJWemF)_