### PR TITLE
refactor(cli): remove dead pip version-check helpers

### DIFF
--- a/binaries/cli/src/lib.rs
+++ b/binaries/cli/src/lib.rs
@@ -33,72 +33,7 @@ fn get_version_info() -> clap::builder::Str {
 }
 
 fn build_version_string() -> String {
-    // Only return the CLI version for fast --version output.
-    // Python version check moved to `dora self check` to avoid spawning
-    // external processes on every --version invocation.
     env!("CARGO_PKG_VERSION").to_string()
-}
-
-/// Check if a Python dora-rs package is installed and return its version.
-#[allow(dead_code)] // used in tests; intended for future `dora self check` command
-pub(crate) fn get_python_dora_version() -> Option<String> {
-    // Try with uv first
-    if let Ok(output) = std::process::Command::new("uv")
-        .args(["pip", "show", "dora-rs"])
-        .output()
-        && output.status.success()
-        && let Some(version) = parse_version_from_pip_show(&output.stdout)
-    {
-        return Some(version);
-    }
-
-    // Try with regular pip
-    if let Ok(output) = std::process::Command::new("pip")
-        .args(["show", "dora-rs"])
-        .output()
-        && output.status.success()
-        && let Some(version) = parse_version_from_pip_show(&output.stdout)
-    {
-        return Some(version);
-    }
-
-    None
-}
-
-#[allow(dead_code)]
-pub(crate) fn parse_version_from_pip_show(output: &[u8]) -> Option<String> {
-    let output_str = String::from_utf8_lossy(output);
-    for line in output_str.lines() {
-        if line.starts_with("Version:") {
-            return line.split(':').nth(1).map(|s| s.trim().to_string());
-        }
-    }
-    None
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn pip_show_valid_output() {
-        let output = b"Name: dora-rs\nVersion: 0.1.0\nSummary: some desc\n";
-        assert_eq!(
-            parse_version_from_pip_show(output),
-            Some("0.1.0".to_string())
-        );
-    }
-
-    #[test]
-    fn pip_show_missing_version_line() {
-        let output = b"Name: dora-rs\nSummary: some desc\n";
-        assert_eq!(parse_version_from_pip_show(output), None);
-    }
-
-    #[test]
-    fn pip_show_empty() {
-        assert_eq!(parse_version_from_pip_show(b""), None);
-    }
 }
 
 #[derive(Debug, clap::Args)]


### PR DESCRIPTION
## Summary

Two functions in `binaries/cli/src/lib.rs` were unreachable in production:

- `get_python_dora_version` — annotated `#[allow(dead_code)]` with a comment "used in tests; intended for future `dora self check` command". It was **not** called anywhere (not even in tests — only its inner helper was tested directly).
- `parse_version_from_pip_show` — annotated `#[allow(dead_code)]`; its only non-test caller was `get_python_dora_version`. Removing `get_python_dora_version` made the compiler warn about `parse_version_from_pip_show` too.

The three unit tests existed solely to exercise `parse_version_from_pip_show`, which has no production callsite. They are removed along with the function.

Also removes the stale comment in `build_version_string` that referenced a non-existent `dora self check` command.

## Verification

```
cargo check -p dora-cli   → clean (0 errors, 0 warnings)
cargo fmt --all -- --check → clean
```

---

> **⚠️ Auto-generated by Claude** (claude-sonnet-4-6). This PR contains no human-authored code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uxz3khPb74iG7w9rAJWemF)_