### PR TITLE
refactor(cli): remove dead `dataflow_id` field from `NodeStats` in `dora top`

### DIFF
--- a/binaries/cli/src/command/inspect/top.rs
+++ b/binaries/cli/src/command/inspect/top.rs
@@ -3,6 +3,9 @@ use std::{
     time::{Duration, Instant},
 };
 
+use crate::common::{
+    CoordinatorOptions, connect_to_coordinator, expect_reply, send_control_request,
+};
 use clap::Args;
 use crossterm::{
     event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind},
@@ -17,11 +20,6 @@ use ratatui::{
     layout::{Constraint, Layout},
     style::{Color, Modifier, Style},
     widgets::{Block, Borders, Cell, Row, Table, TableState},
-};
-use uuid::Uuid;
-
-use crate::common::{
-    CoordinatorOptions, connect_to_coordinator, expect_reply, send_control_request,
 };
 
 use super::super::{Executable, default_tracing};
@@ -103,8 +101,6 @@ struct App {
 
 #[derive(Debug, Clone)]
 struct NodeStats {
-    #[allow(dead_code)]
-    dataflow_id: Uuid,
     dataflow_name: String,
     node_id: NodeId,
     pid: Option<u32>,
@@ -252,7 +248,6 @@ impl App {
                 .unwrap_or((0, 0));
 
             self.node_stats.push(NodeStats {
-                dataflow_id: node_info.dataflow_id,
                 dataflow_name: node_info
                     .dataflow_name
                     .unwrap_or_else(|| "<unnamed>".to_string()),


### PR DESCRIPTION
## Summary

`NodeStats::dataflow_id` in `binaries/cli/src/command/inspect/top.rs` was annotated `#[allow(dead_code)]` and:

- Populated from `node_info.dataflow_id` when building `NodeStats`
- **Never read** — not in the table renderer, not in any sort comparator, not anywhere else

Removing it also eliminates the now-unused `use uuid::Uuid` import.

## Changes

- `binaries/cli/src/command/inspect/top.rs`: drop `dataflow_id: Uuid` field, its constructor assignment, `#[allow(dead_code)]`, and the `uuid::Uuid` import

## Verification

```
cargo check -p dora-cli   → clean (0 errors, 0 warnings)
cargo fmt --all -- --check → clean
```

---

> **⚠️ Auto-generated by Claude** (claude-sonnet-4-6). This PR contains no human-authored code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uxz3khPb74iG7w9rAJWemF)_