### PR TITLE
fix(cli): tighten commit-hash fallback validation to hex object ids

### DIFF
--- a/binaries/cli/src/command/build/git.rs
+++ b/binaries/cli/src/command/build/git.rs
@@ -28,11 +28,11 @@ pub fn fetch_commit_hash(repo_url: String, rev: Option<GitRepoRev>) -> eyre::Res
 
     if commit_hash.is_none()
         && let Some(GitRepoRev::Rev(rev)) = &rev
+        && looks_like_commit_hash(rev)
     {
-        // rev might be a commit hash instead of a reference
-        if rev.is_ascii() && rev.bytes().all(|b| b.is_ascii_alphanumeric()) {
-            commit_hash = Some(rev.clone());
-        }
+        // rev wasn't found among the references, but it looks like a raw
+        // commit hash, so try to use it directly.
+        commit_hash = Some(rev.clone());
     }
 
     match commit_hash {
@@ -41,5 +41,49 @@ pub fn fetch_commit_hash(repo_url: String, rev: Option<GitRepoRev>) -> eyre::Res
             commit_hash,
         }),
         None => eyre::bail!("no matching commit for `{rev:?}`"),
+    }
+}
+
+/// Returns whether `rev` could be a git object id (a short or full commit
+/// hash).
+///
+/// Git object ids are hexadecimal, between 4 (the minimum abbreviation git
+/// accepts) and 40 (a full SHA-1) characters long. Restricting to this range
+/// rejects mistyped refs like `mybranchtypo` early with the clear "no matching
+/// commit" error instead of letting them fail later with a lower-level git
+/// error.
+fn looks_like_commit_hash(rev: &str) -> bool {
+    (4..=40).contains(&rev.len()) && rev.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::looks_like_commit_hash;
+
+    #[test]
+    fn accepts_short_and_full_hashes() {
+        assert!(looks_like_commit_hash("abcd"));
+        assert!(looks_like_commit_hash("a7b8969"));
+        assert!(looks_like_commit_hash(
+            "a7b89691e0000000000000000000000000000000"
+        ));
+        assert!(looks_like_commit_hash("0123456789ABCDEF"));
+    }
+
+    #[test]
+    fn rejects_non_hex_revs() {
+        assert!(!looks_like_commit_hash("mybranchtypo"));
+        assert!(!looks_like_commit_hash("zzzzzzz"));
+        assert!(!looks_like_commit_hash("main"));
+    }
+
+    #[test]
+    fn rejects_out_of_range_lengths() {
+        assert!(!looks_like_commit_hash(""));
+        assert!(!looks_like_commit_hash("abc"));
+        // longer than a full SHA-1
+        assert!(!looks_like_commit_hash(
+            "a7b89691e00000000000000000000000000000000"
+        ));
     }
 }


### PR DESCRIPTION
`fetch_commit_hash` falls back to treating an unmatched `GitRepoRev::Rev`
as a raw commit hash. The guard accepted any ASCII alphanumeric string of
any length, so mistyped refs like `mybranchtypo` or `zzzzzzz` passed and
propagated downstream, failing later with a confusing low-level git error
instead of the clear "no matching commit" message.

Restrict the fallback to 4-40 char hexadecimal strings via a new
`looks_like_commit_hash` helper, and add unit tests.

Fixes #2084

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
