### PR TITLE
fix(arrow-convert): support UInt64 and Float16 in into_vec (#2080)

### DIFF
--- a/libraries/arrow-convert/src/lib.rs
+++ b/libraries/arrow-convert/src/lib.rs
@@ -3,8 +3,8 @@
 #![warn(missing_docs)]
 
 use arrow::array::{
-    Array, Float32Array, Float64Array, Int8Array, Int16Array, Int32Array, Int64Array, UInt8Array,
-    UInt16Array, UInt32Array,
+    Array, Float16Array, Float32Array, Float64Array, Int8Array, Int16Array, Int32Array, Int64Array,
+    UInt8Array, UInt16Array, UInt32Array, UInt64Array,
 };
 use arrow::datatypes::DataType;
 use eyre::{ContextCompat, Result, eyre};
@@ -89,4 +89,73 @@ register_array_handlers! {
     (DataType::UInt8, UInt8Array, "uint8"),
     (DataType::UInt16, UInt16Array, "uint16"),
     (DataType::UInt32, UInt32Array, "uint32"),
+    (DataType::UInt64, UInt64Array, "uint64"),
+    (DataType::Float16, Float16Array, "float16"),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::ArrayRef;
+    use half::f16;
+    use std::sync::Arc;
+
+    /// Round-trips every type registered in `register_array_handlers!` so a
+    /// future macro entry that gets dropped (the original cause of #2080) is
+    /// caught by a failing test rather than a silent runtime error.
+    #[test]
+    fn into_vec_supports_all_registered_types() {
+        macro_rules! assert_round_trip {
+            ($array_type:ty, $rust_type:ty, $values:expr) => {{
+                let values: Vec<$rust_type> = $values;
+                let array: ArrayRef = Arc::new(<$array_type>::from(values.clone()));
+                let data = ArrowData(array);
+                let result: Vec<$rust_type> = into_vec(&data).unwrap();
+                assert_eq!(result, values);
+            }};
+        }
+
+        assert_round_trip!(Float32Array, f32, vec![1.0, 2.5, -3.0]);
+        assert_round_trip!(Float64Array, f64, vec![1.0, 2.5, -3.0]);
+        assert_round_trip!(Int8Array, i8, vec![-1, 2, 3]);
+        assert_round_trip!(Int16Array, i16, vec![-1, 2, 3]);
+        assert_round_trip!(Int32Array, i32, vec![-1, 2, 3]);
+        assert_round_trip!(Int64Array, i64, vec![-1, 2, 3]);
+        assert_round_trip!(UInt8Array, u8, vec![1, 2, 3]);
+        assert_round_trip!(UInt16Array, u16, vec![1, 2, 3]);
+        assert_round_trip!(UInt32Array, u32, vec![1, 2, 3]);
+        assert_round_trip!(UInt64Array, u64, vec![1, 2, 3]);
+
+        // Float16 needs explicit f16 construction; round-trip back to f16.
+        let values = vec![f16::from_f32(1.0), f16::from_f32(2.5), f16::from_f32(-3.0)];
+        let array: ArrayRef = Arc::new(Float16Array::from(values.clone()));
+        let data = ArrowData(array);
+        let result: Vec<f16> = into_vec(&data).unwrap();
+        assert_eq!(result, values);
+    }
+
+    /// The case from the issue: a `UInt64` array previously errored with
+    /// "Unsupported data type for conversion: UInt64".
+    #[test]
+    fn into_vec_handles_uint64() {
+        let data = ArrowData(Arc::new(UInt64Array::from(vec![1u64, 2, 3])));
+        let res: Vec<u64> = into_vec(&data).unwrap();
+        assert_eq!(res, vec![1u64, 2, 3]);
+    }
+
+    #[test]
+    fn into_vec_rejects_arrays_with_nulls() {
+        let array: ArrayRef = Arc::new(UInt64Array::from(vec![Some(1u64), None, Some(3)]));
+        let data = ArrowData(array);
+        let res: Result<Vec<u64>> = into_vec(&data);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn into_vec_rejects_unsupported_type() {
+        let array: ArrayRef = Arc::new(arrow::array::BooleanArray::from(vec![true, false]));
+        let data = ArrowData(array);
+        let res: Result<Vec<u8>> = into_vec(&data);
+        assert!(res.is_err());
+    }
 }


### PR DESCRIPTION
The `register_array_handlers!` invocation omitted `UInt64`/`Float16`,
so `into_vec` returned "Unsupported data type for conversion" for
arrays whose element type is fully supported elsewhere in the crate
via `IntoArrow` and `TryFrom`. U64 (timestamps, counters, IDs) is
common in robotics, so this was a real usability gap.

Register both types and add `into_vec` round-trip tests covering every
registered type — existing tests only exercised `into_vec` with i32,
which is how the gap slipped through.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
