### PR TITLE
fix(node): preserve length of zero-footprint arrays (e.g. NullArray) in raw path

### DIFF
--- a/apis/rust/node/src/event_stream/data_conversion.rs
+++ b/apis/rust/node/src/event_stream/data_conversion.rs
@@ -22,7 +22,14 @@ impl RawData {
         }
 
         let raw_buffer = match self {
-            RawData::Empty => return Ok(().into_arrow().into()),
+            // An empty payload still carries a meaningful `type_info`. Rebuild
+            // from it with an empty backing buffer so the declared length is
+            // preserved (e.g. `NullArray::new(n)` keeps length `n` instead of
+            // collapsing to a `NullArray(0)`, dora-rs/dora#2083).
+            RawData::Empty => {
+                let empty = arrow::buffer::Buffer::from_vec(Vec::<u8>::new());
+                return buffer_into_arrow_array(&empty, type_info);
+            }
             RawData::Vec(data) => {
                 let ptr = NonNull::new(data.as_ptr() as *mut _).unwrap();
                 let len = data.len();

--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -1085,26 +1085,32 @@ fn zenoh_payload_to_arrow_array(
     ) == Some(dora_message::metadata::FRAMING_ARROW_IPC);
 
     if payload.is_empty() {
-        // Mirror the daemon raw path (`arrow_utils::buffer_into_arrow_array`,
-        // which returns `ArrayData::new_empty(&type_info.data_type)` for an
-        // empty buffer): an empty payload becomes a length-0 array of the
-        // declared type, NOT a `NullArray`. A genuine unit/timer output has
-        // `type_info.data_type == Null`, so it still yields a `NullArray`; a
-        // zero-length *typed* array stays typed — matching the daemon path and
-        // avoiding a downstream `as_primitive` panic on the zenoh transport
-        // (cross-transport non-determinism, dora-rs/dora#2027).
+        // Mirror the daemon raw path (`arrow_utils::buffer_into_arrow_array`):
+        // an empty payload still carries a meaningful `type_info`, so rebuild
+        // the array from it with an empty backing buffer. This preserves both
+        // the declared type (a zero-length *typed* array stays typed, avoiding
+        // a downstream `as_primitive` panic — cross-transport non-determinism,
+        // dora-rs/dora#2027) AND the declared length (a `NullArray::new(n)` or
+        // struct-of-nulls keeps its length `n` instead of collapsing to 0 —
+        // dora-rs/dora#2083).
         //
         // `data_type` is peer-controlled (bincode-decoded from the zenoh
-        // attachment). `new_empty` (-> `new_null`) panics on a few malformed
-        // types (empty `Union` fields, `Dictionary` with a non-integer key), so
-        // catch the unwind and surface a clean error instead of letting a buggy
-        // or malicious peer crash the node (#2027 anti-panic).
-        let data_type = &metadata.type_info.data_type;
-        let data = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            arrow::array::ArrayData::new_empty(data_type)
+        // attachment). `ArrayData::try_new` is meant to validate and return an
+        // error rather than panic, but some malformed types (e.g. empty `Union`
+        // fields, a `Dictionary` with a non-integer key) can still abort inside
+        // Arrow. Keep the unwind guard so a buggy or malicious peer can't crash
+        // the node with an empty payload (#2027 anti-panic, dora-rs/dora#2083).
+        let empty = arrow::buffer::Buffer::from_vec(Vec::<u8>::new());
+        let array = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            buffer_into_arrow_array(&empty, &metadata.type_info)
         }))
-        .map_err(|_| eyre!("cannot build an empty array for declared type {data_type:?}"))?;
-        return Ok(arrow::array::make_array(data));
+        .map_err(|_| {
+            eyre!(
+                "cannot build an empty array for declared type {:?}",
+                metadata.type_info.data_type
+            )
+        })??;
+        return Ok(arrow::array::make_array(array));
     }
 
     if is_ipc {
@@ -2109,61 +2115,76 @@ mod tests {
         assert!(events.recv().is_none(), "stream must close after the input");
     }
 
-    /// #2027: an empty payload over the zenoh transport must become a length-0
-    /// array of the DECLARED type, matching the daemon path
-    /// (`buffer_into_arrow_array` -> `new_empty(type_info.data_type)`). A
-    /// zero-length typed array previously degraded to `NullArray` only on the
-    /// zenoh path, so a downstream `as_primitive` would panic on one transport
-    /// but not the other. A genuine unit/timer output (Null type) still yields
-    /// a `NullArray`.
+    /// #2027 + #2083: an empty payload over the zenoh transport must round-trip
+    /// through the array's real `type_info` (as produced by the send side),
+    /// preserving both the DECLARED type and the DECLARED length.
+    ///
+    /// #2027: a zero-length typed array stays typed (it previously degraded to
+    /// `NullArray` only on the zenoh path, so a downstream `as_primitive` would
+    /// panic on one transport but not the other).
+    ///
+    /// #2083: a zero-footprint array with a non-zero length (e.g.
+    /// `NullArray::new(n)`) keeps its length instead of collapsing to 0.
     #[test]
-    fn zenoh_empty_payload_preserves_declared_type() {
-        use dora_message::metadata::{ArrowTypeInfo, Metadata};
+    fn zenoh_empty_payload_preserves_declared_type_and_length() {
+        use crate::arrow_utils::{copy_array_into_sample, required_data_size};
+        use arrow::array::{Array, Int32Array, NullArray};
+        use dora_message::metadata::Metadata;
 
-        fn type_info(dt: arrow_schema::DataType) -> ArrowTypeInfo {
-            ArrowTypeInfo {
-                data_type: dt,
-                len: 0,
-                null_count: 0,
-                validity: None,
-                offset: 0,
-                buffer_offsets: vec![],
-                child_data: vec![],
-                field_names: None,
-                schema_hash: None,
-            }
-        }
-        fn meta(dt: arrow_schema::DataType) -> Metadata {
-            Metadata::new(
-                dora_core::uhlc::HLC::default().new_timestamp(),
-                type_info(dt),
-            )
+        // Build the real `type_info` the send side would record for `array`.
+        // (Hand-built `type_info` would not match the serialized layout — e.g. a
+        // typed array always records a zero-length data-buffer offset.)
+        fn meta_for(array: &dyn Array) -> Metadata {
+            let data = array.to_data();
+            let mut sample = vec![0; required_data_size(&data)];
+            assert!(sample.is_empty(), "expected a zero-footprint array");
+            let type_info = copy_array_into_sample(&mut sample, &data);
+            Metadata::new(dora_core::uhlc::HLC::default().new_timestamp(), type_info)
         }
 
         let empty = zenoh::bytes::ZBytes::new();
 
-        // Zero-length typed array stays typed.
-        let typed =
-            zenoh_payload_to_arrow_array(empty.clone(), &meta(arrow_schema::DataType::Int32))
-                .unwrap();
+        // #2027: zero-length typed array stays typed.
+        let typed = zenoh_payload_to_arrow_array(
+            empty.clone(),
+            &meta_for(&Int32Array::from(Vec::<i32>::new())),
+        )
+        .unwrap();
         assert_eq!(typed.data_type(), &arrow_schema::DataType::Int32);
         assert_eq!(typed.len(), 0);
 
-        // Genuine unit/timer output stays a NullArray.
-        let null =
-            zenoh_payload_to_arrow_array(empty, &meta(arrow_schema::DataType::Null)).unwrap();
+        // #2083: a NullArray with a non-zero length keeps its length.
+        let null = zenoh_payload_to_arrow_array(empty, &meta_for(&NullArray::new(5))).unwrap();
         assert_eq!(null.data_type(), &arrow_schema::DataType::Null);
-
-        // #2027 review (P2): `data_type` is peer-controlled, and `new_empty`
-        // panics on a few malformed types. A `Dictionary` with a non-integer
-        // key reaches `k.primitive_width().unwrap()` -> panic; the empty-payload
-        // path must surface that as `Err`, not crash the node. (A panic trace
-        // printed during this test is expected — it is the caught unwind.)
-        let malformed = arrow_schema::DataType::Dictionary(
-            Box::new(arrow_schema::DataType::Utf8),
-            Box::new(arrow_schema::DataType::Int32),
+        assert_eq!(
+            null.len(),
+            5,
+            "NullArray length must survive the zenoh path"
         );
-        let result = zenoh_payload_to_arrow_array(zenoh::bytes::ZBytes::new(), &meta(malformed));
+
+        // #2027 review (P2): `data_type` is peer-controlled. A malformed type
+        // (`Dictionary` with a non-integer key) must surface as `Err`, not crash
+        // the node — the `catch_unwind` guard on the empty-payload path turns any
+        // panic inside Arrow into a clean error. (A panic trace printed during
+        // this test is expected — it is the caught unwind.)
+        let malformed = dora_message::metadata::ArrowTypeInfo {
+            data_type: arrow_schema::DataType::Dictionary(
+                Box::new(arrow_schema::DataType::Utf8),
+                Box::new(arrow_schema::DataType::Int32),
+            ),
+            len: 0,
+            null_count: 0,
+            validity: None,
+            offset: 0,
+            buffer_offsets: vec![],
+            child_data: vec![],
+            field_names: None,
+            schema_hash: None,
+        };
+        let result = zenoh_payload_to_arrow_array(
+            zenoh::bytes::ZBytes::new(),
+            &Metadata::new(dora_core::uhlc::HLC::default().new_timestamp(), malformed),
+        );
         assert!(
             result.is_err(),
             "malformed peer type must produce Err, not panic"

--- a/apis/rust/node/src/node/arrow_utils.rs
+++ b/apis/rust/node/src/node/arrow_utils.rs
@@ -136,6 +136,15 @@ pub fn buffer_into_arrow_array(
     buffer_into_arrow_array_inner(raw_buffer, type_info, 0)
 }
 
+/// A zero-length Arrow buffer that is aligned for any fixed-width type.
+///
+/// `MutableBuffer` allocates with Arrow's 64-byte alignment, so the resulting
+/// (empty) buffer satisfies the alignment checks `ArrayData::try_new` performs
+/// even for length-0 buffers — unlike a buffer sliced out of an empty payload.
+fn aligned_empty_buffer() -> arrow::buffer::Buffer {
+    arrow::buffer::MutableBuffer::new(0).into()
+}
+
 fn buffer_into_arrow_array_inner(
     raw_buffer: &arrow::buffer::Buffer,
     type_info: &ArrowTypeInfo,
@@ -145,9 +154,14 @@ fn buffer_into_arrow_array_inner(
         eyre::bail!("Arrow type nesting depth exceeds maximum ({MAX_TYPE_DEPTH})");
     }
 
-    if raw_buffer.is_empty() {
-        return Ok(arrow::array::ArrayData::new_empty(&type_info.data_type));
-    }
+    // NOTE: do not special-case an empty `raw_buffer` here. A zero-footprint
+    // array (e.g. `NullArray::new(n)`, a struct whose only fields are
+    // `Null`-typed, or a zero-length typed array) serializes to an empty
+    // payload while still carrying a meaningful `type_info.len`. Falling back
+    // to `ArrayData::new_empty` would discard that length (and `offset`,
+    // `validity`, `child_data`), silently truncating the array to length 0
+    // (dora-rs/dora#2083). The general path below honors all of them by
+    // rebuilding through `ArrayData::try_new`, which keeps the declared length.
 
     if type_info.buffer_offsets.len() > MAX_ENTRIES {
         eyre::bail!(
@@ -164,6 +178,16 @@ fn buffer_into_arrow_array_inner(
 
     let mut buffers = Vec::new();
     for BufferOffset { offset, len } in &type_info.buffer_offsets {
+        if *len == 0 {
+            // A zero-length buffer carries no data; slicing it out of the
+            // payload risks producing an under-aligned pointer (the payload
+            // base may be empty/dangling), which `ArrayData::try_new` rejects
+            // for SIMD-aligned types. Substitute a freshly allocated, properly
+            // aligned empty buffer instead. This is what lets a zero-footprint
+            // array round-trip with its true length (dora-rs/dora#2083).
+            buffers.push(aligned_empty_buffer());
+            continue;
+        }
         // Use checked_add to guard against malicious/buggy peers sending
         // `offset` or `len` values that would overflow `usize` on addition
         // and bypass the bounds check below.
@@ -455,6 +479,46 @@ mod tests {
             buffer_into_arrow_array(&arrow::buffer::Buffer::from(sample), &type_info).unwrap();
         assert_eq!(decoded.len(), 0);
         assert_eq!(decoded.data_type(), &DataType::UInt64);
+    }
+
+    #[test]
+    fn raw_roundtrip_preserves_nullarray_length() {
+        // dora-rs/dora#2083: a `NullArray::new(n>0)` has no data buffers and no
+        // validity, so its serialized footprint is empty — but its logical
+        // length must survive the raw round-trip instead of collapsing to 0.
+        use arrow::array::NullArray;
+        let data = NullArray::new(5).into_data();
+        assert_eq!(data.len(), 5);
+        let mut sample = vec![0; required_data_size(&data)];
+        assert!(sample.is_empty(), "precondition: zero-footprint payload");
+        let type_info = copy_array_into_sample(&mut sample, &data);
+        assert_eq!(type_info.len, 5);
+        let decoded =
+            buffer_into_arrow_array(&arrow::buffer::Buffer::from(sample), &type_info).unwrap();
+        assert_eq!(decoded.len(), 5, "NullArray length must be preserved");
+        assert_eq!(decoded.data_type(), &DataType::Null);
+    }
+
+    #[test]
+    fn raw_roundtrip_preserves_struct_of_nulls_length() {
+        // dora-rs/dora#2083: a struct whose only field is `Null`-typed also has
+        // a zero-byte footprint while carrying a non-zero length.
+        use arrow::array::NullArray;
+        use arrow_schema::Field;
+        let child = Arc::new(NullArray::new(3)) as ArrayRef;
+        let data = StructArray::from(vec![(
+            Arc::new(Field::new("nulls", DataType::Null, true)),
+            child,
+        )])
+        .into_data();
+        assert_eq!(data.len(), 3);
+        let mut sample = vec![0; required_data_size(&data)];
+        assert!(sample.is_empty(), "precondition: zero-footprint payload");
+        let type_info = copy_array_into_sample(&mut sample, &data);
+        let decoded =
+            buffer_into_arrow_array(&arrow::buffer::Buffer::from(sample), &type_info).unwrap();
+        assert_eq!(decoded.len(), 3, "struct-of-nulls length must be preserved");
+        assert_eq!(decoded.child_data()[0].len(), 3);
     }
 
     #[test]

--- a/binaries/cli/src/command/topic/echo.rs
+++ b/binaries/cli/src/command/topic/echo.rs
@@ -272,12 +272,32 @@ fn buffer_into_arrow_array(
     raw_buffer: &arrow::buffer::Buffer,
     type_info: &ArrowTypeInfo,
 ) -> eyre::Result<arrow::array::ArrayData> {
-    if raw_buffer.is_empty() {
-        return Ok(arrow::array::ArrayData::new_empty(&type_info.data_type));
-    }
-
+    // A zero-footprint array (e.g. `NullArray::new(n)`) serializes to an empty
+    // payload but still carries a meaningful `type_info.len`. Reconstructing via
+    // `ArrayData::new_empty` would discard that length and silently truncate the
+    // array to 0; the general path below honors it (dora-rs/dora#2083).
     let mut buffers = Vec::new();
     for BufferOffset { offset, len } in &type_info.buffer_offsets {
+        if *len == 0 {
+            // Slicing a zero-length buffer out of an empty payload can yield an
+            // under-aligned pointer that `try_new` rejects; use a freshly
+            // aligned empty buffer instead (dora-rs/dora#2083).
+            buffers.push(arrow::buffer::MutableBuffer::new(0).into());
+            continue;
+        }
+        // `type_info` is peer-controlled, so validate the offset before slicing.
+        // `checked_add` guards against an `offset`/`len` that would overflow
+        // `usize` and bypass the bounds check; both prevent a panic inside
+        // `slice_with_length` on a malformed event (dora-rs/dora#2083).
+        let end = offset
+            .checked_add(*len)
+            .ok_or_else(|| eyre!("buffer offset overflow: offset={offset}, len={len}"))?;
+        if end > raw_buffer.len() {
+            return Err(eyre!(
+                "buffer offset out of bounds: offset={offset}, len={len}, buffer_len={}",
+                raw_buffer.len()
+            ));
+        }
         buffers.push(raw_buffer.slice_with_length(*offset, *len));
     }
 
@@ -298,4 +318,71 @@ fn buffer_into_arrow_array(
         child_data,
     )
     .map_err(|e| eyre!("Error creating Arrow array: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Array, NullArray};
+
+    fn type_info(
+        data_type: arrow::datatypes::DataType,
+        buffer_offsets: Vec<BufferOffset>,
+    ) -> ArrowTypeInfo {
+        ArrowTypeInfo {
+            data_type,
+            len: 0,
+            null_count: 0,
+            validity: None,
+            offset: 0,
+            buffer_offsets,
+            child_data: vec![],
+            field_names: None,
+            schema_hash: None,
+        }
+    }
+
+    #[test]
+    fn empty_payload_preserves_nullarray_length() {
+        // dora-rs/dora#2083: a `NullArray::new(n)` has an empty footprint but a
+        // non-zero length that must survive `dora topic echo`'s decode.
+        let mut info = type_info(arrow::datatypes::DataType::Null, vec![]);
+        info.len = 5;
+        let decoded =
+            buffer_into_arrow_array(&arrow::buffer::Buffer::from(Vec::<u8>::new()), &info).unwrap();
+        assert_eq!(decoded.len(), 5);
+        assert_eq!(decoded.data_type(), &arrow::datatypes::DataType::Null);
+        assert_eq!(NullArray::from(decoded).len(), 5);
+    }
+
+    #[test]
+    fn malformed_offset_is_rejected_not_panicked() {
+        // dora-rs/dora#2083: `type_info` is peer-controlled. An empty payload
+        // with `offset = usize::MAX` would overflow `offset + len` and bypass the
+        // bounds check, panicking inside `slice_with_length`. It must surface as
+        // an error instead.
+        let info = type_info(
+            arrow::datatypes::DataType::UInt8,
+            vec![BufferOffset {
+                offset: usize::MAX,
+                len: 1,
+            }],
+        );
+        let err = buffer_into_arrow_array(&arrow::buffer::Buffer::from(Vec::<u8>::new()), &info)
+            .unwrap_err();
+        assert!(err.to_string().contains("overflow"), "got: {err}");
+    }
+
+    #[test]
+    fn out_of_bounds_offset_is_rejected() {
+        // A non-overflowing but out-of-range offset must also be reported, not
+        // panic in `slice_with_length`.
+        let info = type_info(
+            arrow::datatypes::DataType::UInt8,
+            vec![BufferOffset { offset: 0, len: 8 }],
+        );
+        let err =
+            buffer_into_arrow_array(&arrow::buffer::Buffer::from(vec![0u8; 4]), &info).unwrap_err();
+        assert!(err.to_string().contains("out of bounds"), "got: {err}");
+    }
 }


### PR DESCRIPTION
An Arrow array whose entire serialized footprint is zero bytes but whose
logical length is non-zero (most commonly `NullArray::new(n)`, but also a
struct of `Null`-typed children) was silently rebuilt with length 0 on the
raw (non-IPC) reconstruction path. The receive side early-returned
`ArrayData::new_empty(data_type)` for an empty buffer, discarding
`type_info.len` (and offset/validity/child_data).

Drop the empty-buffer special case in the shared `buffer_into_arrow_array`
and let the general `try_new` path honor the declared length. A zero-length
buffer sliced out of an empty payload can be under-aligned, which arrow
rejects for SIMD types, so substitute a freshly aligned empty buffer for any
zero-length buffer offset. Apply the same fix to the zenoh path and the
`dora topic echo` hand-rolled copy, and route `RawData::Empty` through the
shared function so it preserves length too. The peer-controlled zenoh path
keeps its `catch_unwind` guard against malformed types.

Regression tests cover `NullArray::new(n>0)` and a struct-of-nulls round-trip
on both the raw and zenoh paths.

Fixes #2083

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
