### PR TITLE
perf(node-api): avoid per-call allocations in event scheduler hot path

### DIFF
--- a/apis/rust/node/src/event_stream/scheduler.rs
+++ b/apis/rust/node/src/event_stream/scheduler.rs
@@ -1,4 +1,7 @@
-use std::collections::{HashMap, VecDeque};
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::LazyLock,
+};
 
 use dora_message::{
     config::{DEFAULT_QUEUE_SIZE, QueuePolicy},
@@ -84,6 +87,11 @@ fn log_correlation_drop(event_id: &DataId, dropped: &EventItem) {
     );
 }
 pub(crate) const NON_INPUT_EVENT: &str = "dora.non_input_event";
+
+/// Shared [`DataId`] for [`NON_INPUT_EVENT`], so the hot `add_event`/`next`
+/// paths don't have to allocate a fresh `String` on every call.
+static NON_INPUT_EVENT_ID: LazyLock<DataId> =
+    LazyLock::new(|| DataId::from(NON_INPUT_EVENT.to_string()));
 
 /// This scheduler will make sure that there is fairness between inputs.
 ///
@@ -176,7 +184,7 @@ impl Scheduler {
         let topic = VecDeque::from_iter(
             event_queues
                 .keys()
-                .filter(|t| **t != DataId::from(NON_INPUT_EVENT.to_string()))
+                .filter(|t| **t != *NON_INPUT_EVENT_ID)
                 .cloned(),
         );
         Self {
@@ -211,7 +219,7 @@ impl Scheduler {
                 ) == Some(true);
                 (id, flush)
             }
-            _ => (&DataId::from(NON_INPUT_EVENT.to_string()), false),
+            _ => (&*NON_INPUT_EVENT_ID, false),
         };
 
         // Flush older queued messages when flush=true is present.
@@ -290,22 +298,22 @@ impl Scheduler {
 
     pub(crate) fn next(&mut self) -> Option<EventItem> {
         // Retrieve message from the non input event first that have priority over input message.
-        if let Some((_size, queue)) = self
-            .event_queues
-            .get_mut(&DataId::from(NON_INPUT_EVENT.to_string()))
+        if let Some((_size, queue)) = self.event_queues.get_mut(&*NON_INPUT_EVENT_ID)
             && let Some(event) = queue.pop_front()
         {
             return Some(event);
         }
 
         // Process the ID with the oldest timestamp using BTreeMap Ordering
-        for (index, id) in self.last_used.clone().iter().enumerate() {
+        for index in 0..self.last_used.len() {
+            let id = &self.last_used[index];
             if let Some((_size, queue)) = self.event_queues.get_mut(id)
                 && let Some(event) = queue.pop_front()
             {
                 // Put last used at last
-                self.last_used.remove(index);
-                self.last_used.push_back(id.clone());
+                if let Some(id) = self.last_used.remove(index) {
+                    self.last_used.push_back(id);
+                }
                 return Some(event);
             }
         }


### PR DESCRIPTION
## Issue

`Scheduler::next()` runs once per yielded event — the hottest path of the node event stream — and performed two avoidable allocations on every call:

1. `self.last_used.clone()` copied the entire `VecDeque<DataId>` (one `String` allocation per input ID) just to iterate it, even though the loop returns immediately after the first mutation.
2. `DataId::from(NON_INPUT_EVENT.to_string())` allocated a fresh `String` for the non-input-event sentinel on every `next()` call, and again on every `add_event()` call for non-input events.

## Fix

- Iterate `last_used` by index instead of cloning it. The loop `return`s immediately after `remove(index)` + `push_back(id)`, so no iteration ever continues over the mutated deque, and the removed element is moved (not cloned) to the back.
- Introduce a `LazyLock<DataId>` for the `NON_INPUT_EVENT` sentinel and use it in `add_event`, `next`, and `with_policies`, removing the per-call `String` allocations.

No behavior change; scheduling order is identical. Found during a codebase audit (Optimization category).

## Validation

- `cargo test -p dora-node-api` — 96 unit + 5 integration tests pass (includes the scheduler fairness/eviction/flush test suite)
- `cargo clippy -p dora-node-api -- -D warnings`, `cargo fmt --check`

https://claude.ai/code/session_01L1wL2zpWyF7xvURnsUBSNw

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1wL2zpWyF7xvURnsUBSNw)_