### PR TITLE
perf(daemon): hoist Arc allocations out of event broadcast loops

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -3887,6 +3887,7 @@ impl Daemon {
                     return Ok(());
                 };
 
+                let metadata = Arc::new(metadata);
                 let mut closed = Vec::new();
                 for (receiver_id, input_id) in subscribers {
                     let Some(channel) = dataflow.subscribe_channels.get(receiver_id) else {
@@ -3897,7 +3898,7 @@ impl Daemon {
                         channel,
                         NodeEvent::Input {
                             id: input_id.clone(),
-                            metadata: Arc::new(metadata.clone()),
+                            metadata: metadata.clone(),
                             data: None,
                         },
                         &self.clock,
@@ -3936,6 +3937,8 @@ impl Daemon {
                     return Ok(());
                 };
 
+                let metadata = Arc::new(metadata);
+                let message = Arc::new(message);
                 let mut closed = Vec::new();
                 for (receiver_id, input_id) in subscribers {
                     let Some(channel) = dataflow.subscribe_channels.get(receiver_id) else {
@@ -3947,8 +3950,8 @@ impl Daemon {
                         channel,
                         NodeEvent::Input {
                             id: input_id.clone(),
-                            metadata: Arc::new(metadata.clone()),
-                            data: Some(Arc::new(message.clone())),
+                            metadata: metadata.clone(),
+                            data: Some(message.clone()),
                         },
                         &self.clock,
                     );
@@ -3996,6 +3999,7 @@ impl Daemon {
                     aligned_vec::AVec::__from_elem(128, 0, total_len);
                 let type_info =
                     dora_node_api::arrow_utils::copy_array_into_sample(&mut sample, &array);
+                let data = Arc::new(DataMessage::Vec(sample));
 
                 let mut closed = Vec::new();
                 for sub in &dataflow.log_subscribers {
@@ -4028,7 +4032,7 @@ impl Daemon {
                         NodeEvent::Input {
                             id: sub.input_id.clone(),
                             metadata: Arc::new(metadata),
-                            data: Some(Arc::new(DataMessage::Vec(sample.clone()))),
+                            data: Some(data.clone()),
                         },
                         &self.clock,
                     );


### PR DESCRIPTION
## Issue

Three broadcast loops in `Daemon::handle_dora_event` re-allocated identical data once per subscriber instead of sharing it:

- **`DoraEvent::Timer`**: `Arc::new(metadata.clone())` inside the subscriber loop — a full `Metadata` clone + `Arc` allocation per timer subscriber, on every tick.
- **`DoraEvent::Logs`**: same per-subscriber `Arc::new(metadata.clone())`, plus `Arc::new(message.clone())` which copies the whole message payload per subscriber.
- **`DoraEvent::LogBroadcast`**: `Arc::new(DataMessage::Vec(sample.clone()))` copied the entire serialized log sample per subscriber — despite the comment directly above saying "Convert to Arrow once, share the sample across subscribers".

The codebase already uses the correct pattern elsewhere (e.g. the output-dispatch loop around line 4730): wrap in `Arc` once before the loop, bump the refcount inside.

## Fix

Hoist the `Arc::new(...)` out of all three loops. In `Timer`/`Logs` the event owns `metadata`/`message`, so the values are moved into the `Arc` — the original clone is eliminated entirely, not just amortized. In `LogBroadcast`, the per-subscriber `Metadata` is left as-is (it carries a fresh timestamp per subscriber by design); only the payload sample is shared.

No consumer relies on `Arc` uniqueness (`get_mut`/`try_unwrap`/`into_inner` are not used on these in the node API, daemon, or runtime), so sharing one allocation is observationally equivalent. Found during a codebase audit (Optimization category).

## Validation

- `cargo test -p dora-daemon` — 56 tests pass
- `cargo clippy -p dora-daemon -- -D warnings`, `cargo fmt --check`

https://claude.ai/code/session_01L1wL2zpWyF7xvURnsUBSNw

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1wL2zpWyF7xvURnsUBSNw)_