### PR TITLE
fix(cli): propagate errors instead of panicking; dedup workspace-path resolution in templates

### DIFF
--- a/binaries/cli/src/common.rs
+++ b/binaries/cli/src/common.rs
@@ -59,8 +59,10 @@ pub(crate) fn send_control_request(
     session: &WsSession,
     request: &ControlRequest,
 ) -> eyre::Result<ControlRequestReply> {
+    let request_bytes =
+        serde_json::to_vec(request).wrap_err("failed to serialize control request")?;
     let reply_raw = session
-        .request(&serde_json::to_vec(request).unwrap())
+        .request(&request_bytes)
         .wrap_err("failed to send control request")?;
     let reply: ControlRequestReply =
         serde_json::from_slice(&reply_raw).wrap_err("failed to parse reply")?;

--- a/binaries/cli/src/template/c/mod.rs
+++ b/binaries/cli/src/template/c/mod.rs
@@ -1,5 +1,5 @@
 use dora_node_api_c::HEADER_NODE_API;
-use eyre::{Context, ContextCompat, bail};
+use eyre::{Context, bail};
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -80,13 +80,7 @@ fn create_cmakefile(root: PathBuf, use_path_deps: bool) -> Result<(), eyre::ErrR
     const CMAKEFILE: &str = include_str!("cmake-template.txt");
 
     let cmake_file = if use_path_deps {
-        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-        let workspace_dir = manifest_dir
-            .parent()
-            .context("Could not get manifest parent folder")?
-            .parent()
-            .context("Could not get manifest grandparent folder")?;
-        CMAKEFILE.replace("__DORA_PATH__", workspace_dir.to_str().unwrap())
+        CMAKEFILE.replace("__DORA_PATH__", super::workspace_dir()?)
     } else {
         CMAKEFILE.replace("__DORA_PATH__", "")
     };
@@ -140,15 +134,9 @@ fn create_node_cmakefile(
     use_path_deps: bool,
 ) -> Result<(), eyre::ErrReport> {
     let cmake_content = if use_path_deps {
-        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-        let workspace_dir = manifest_dir
-            .parent()
-            .context("Could not get manifest parent folder")?
-            .parent()
-            .context("Could not get manifest grandparent folder")?;
         NODE_CMAKE
             .replace("___name___", name)
-            .replace("__DORA_PATH__", workspace_dir.to_str().unwrap())
+            .replace("__DORA_PATH__", super::workspace_dir()?)
     } else {
         NODE_CMAKE
             .replace("___name___", name)

--- a/binaries/cli/src/template/cxx/mod.rs
+++ b/binaries/cli/src/template/cxx/mod.rs
@@ -1,4 +1,4 @@
-use eyre::{Context, ContextCompat, bail};
+use eyre::{Context, bail};
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -79,13 +79,7 @@ fn create_cmakefile(root: PathBuf, use_path_deps: bool) -> Result<(), eyre::ErrR
     const CMAKEFILE: &str = include_str!("cmake-template.txt");
 
     let cmake_file = if use_path_deps {
-        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-        let workspace_dir = manifest_dir
-            .parent()
-            .context("Could not get manifest parent folder")?
-            .parent()
-            .context("Could not get manifest grandparent folder")?;
-        CMAKEFILE.replace("__DORA_PATH__", workspace_dir.to_str().unwrap())
+        CMAKEFILE.replace("__DORA_PATH__", super::workspace_dir()?)
     } else {
         CMAKEFILE.replace("__DORA_PATH__", "")
     };
@@ -136,15 +130,9 @@ fn create_node_cmakefile(
     use_path_deps: bool,
 ) -> Result<(), eyre::ErrReport> {
     let cmake_content = if use_path_deps {
-        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-        let workspace_dir = manifest_dir
-            .parent()
-            .context("Could not get manifest parent folder")?
-            .parent()
-            .context("Could not get manifest grandparent folder")?;
         NODE_CMAKE
             .replace("___name___", name)
-            .replace("__DORA_PATH__", workspace_dir.to_str().unwrap())
+            .replace("__DORA_PATH__", super::workspace_dir()?)
     } else {
         NODE_CMAKE
             .replace("___name___", name)

--- a/binaries/cli/src/template/mod.rs
+++ b/binaries/cli/src/template/mod.rs
@@ -1,7 +1,23 @@
+use eyre::ContextCompat;
+use std::path::Path;
+
 mod c;
 mod cxx;
 mod python;
 mod rust;
+
+/// Path to the dora workspace root (two levels above the CLI crate
+/// manifest), used by the C/C++ templates to reference dora via path
+/// dependencies when `use_path_deps` is set.
+fn workspace_dir() -> eyre::Result<&'static str> {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .context("Could not get manifest parent folder")?
+        .parent()
+        .context("Could not get manifest grandparent folder")?
+        .to_str()
+        .context("dora workspace path is not valid UTF-8")
+}
 
 pub fn create(args: crate::CommandNew, use_path_deps: bool) -> eyre::Result<()> {
     match args.lang {


### PR DESCRIPTION
## Issue

Two avoidable panic paths in user-facing CLI code, plus a 4× code duplication:

1. **`dora new` C/C++ templates**: `workspace_dir.to_str().unwrap()` panicked if the dora checkout path contains non-UTF-8 bytes. The unwrap appeared in four identical copies of the manifest→workspace path-resolution block (`create_cmakefile` and `create_node_cmakefile` in both `template/c/mod.rs` and `template/cxx/mod.rs`).
2. **`send_control_request`**: `serde_json::to_vec(request).unwrap()` panicked instead of returning `Err` from a function that already returns `eyre::Result` and is the funnel for every CLI→coordinator request.

## Fix

- Extracted the duplicated path-resolution block into a single `template::workspace_dir()` helper that returns a proper error (`"dora workspace path is not valid UTF-8"`) instead of panicking. Net −6 lines despite the added doc comment.
- Serialization errors in `send_control_request` are now propagated with context instead of panicking.

Both changes also reduce the production unwrap count tracked by the CI unwrap-budget ratchet. Found during a codebase audit (Correctness + Simplification categories).

## Validation

- `cargo test -p dora-cli` passes
- `cargo clippy -p dora-cli -- -D warnings`, `cargo fmt --check`
- `cargo check --examples` (gates `dora_cli` API surface, #1680)

https://claude.ai/code/session_01L1wL2zpWyF7xvURnsUBSNw

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1wL2zpWyF7xvURnsUBSNw)_