### PR TITLE
refactor(node-api): use logical && instead of bitwise & in EventStream::is_empty

### DIFF
--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -599,7 +599,7 @@ impl EventStream {
     /// Check if there are any buffered events in the scheduler, the
     /// receiver, or the passthrough buffer used by pattern-aware helpers.
     pub fn is_empty(&self) -> bool {
-        self.pending_passthrough.is_empty() & self.scheduler.is_empty() & self.receiver.is_empty()
+        self.pending_passthrough.is_empty() && self.scheduler.is_empty() && self.receiver.is_empty()
     }
 
     /// Returns and resets the accumulated drop counts per input ID.


### PR DESCRIPTION
## Issue

`EventStream::is_empty()` combined its three checks with the bitwise `&` operator instead of logical `&&`:

```rust
self.pending_passthrough.is_empty() & self.scheduler.is_empty() & self.receiver.is_empty()
```

On `bool` this is well-defined and produces the same result, but it is non-idiomatic, evaluates all three operands unconditionally (no short-circuiting — `scheduler.is_empty()` iterates every input queue), and reads like a typo to reviewers.

## Fix

One-line change to `&&`. Behaviorally identical (all three operands are pure); the later checks are now skipped when an earlier one is already `false`. Found during a codebase audit (Simplification category).

## Validation

- `cargo clippy -p dora-node-api -- -D warnings`, `cargo test -p dora-node-api`, `cargo fmt --check`

https://claude.ai/code/session_01L1wL2zpWyF7xvURnsUBSNw

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1wL2zpWyF7xvURnsUBSNw)_