### PR TITLE
docs(arrow-convert): document IntoArrow semantics with a runnable example

### DIFF
--- a/libraries/arrow-convert/src/lib.rs
+++ b/libraries/arrow-convert/src/lib.rs
@@ -15,8 +15,32 @@ mod from_impls;
 mod into_impls;
 
 /// Data that can be converted to an Arrow array.
+///
+/// This is the conversion that dora node APIs use to turn plain Rust values
+/// into the [Apache Arrow](https://arrow.apache.org/) columnar format before
+/// sending them as outputs. Implementations are provided for booleans,
+/// strings, the primitive integer and float types, `Vec`s of those primitive
+/// types, and a few `chrono` date/time types. The unit type `()` converts to
+/// an empty [`NullArray`](arrow::array::NullArray), which is useful for
+/// outputs that carry only metadata.
+///
+/// For the opposite direction (reading received Arrow data back into Rust
+/// types), see the `TryFrom<&ArrowData>` implementations on [`ArrowData`].
+///
+/// # Example
+///
+/// ```
+/// use arrow::array::Array;
+/// use dora_arrow_convert::IntoArrow;
+///
+/// let array = vec![1.0_f32, 2.0, 3.0].into_arrow();
+/// assert_eq!(array.len(), 3);
+///
+/// let single = 42_u8.into_arrow();
+/// assert_eq!(single.len(), 1);
+/// ```
 pub trait IntoArrow {
-    /// The Array type that the data can be converted to.
+    /// The Arrow array type that the data converts to.
     type A: Array;
 
     /// Convert the data into an Arrow array.


### PR DESCRIPTION
## Issue

`IntoArrow` is the public trait every Rust node author hits when sending outputs, but its documentation was a single line that didn't say which types implement it, what `()` maps to, or how it relates to the receive-side `TryFrom<&ArrowData>` conversions.

## Fix

Expanded the trait docs with:
- which implementations are provided (bools, strings, primitives, `Vec`s of primitives, chrono date/time types) and that `()` → empty `NullArray` for metadata-only outputs,
- a cross-reference to the receive-side `TryFrom<&ArrowData>` impls on `ArrowData`,
- a **runnable doctest** (`vec[1.0_f32, ...].into_arrow()` / `42_u8.into_arrow()`) so the example is compile-checked in CI.

Docs-only change; no code touched. Found during a codebase audit (Documentation category).

## Validation

- `cargo test -p dora-arrow-convert` — including the new doctest (1 doc-test passed)
- `cargo fmt --check`

https://claude.ai/code/session_01L1wL2zpWyF7xvURnsUBSNw

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1wL2zpWyF7xvURnsUBSNw)_