### PR TITLE
fix(mavlink2-bridge): reject multi-row command batches instead of silently truncating to row 0

### DIFF
--- a/libraries/extensions/mavlink2-bridge/src/arrow_convert.rs
+++ b/libraries/extensions/mavlink2-bridge/src/arrow_convert.rs
@@ -3,7 +3,7 @@
 //! Arrow-side conventions used by every impl:
 //!
 //! * One row per call. `to_record_batch` returns a 1-row `RecordBatch`;
-//!   `from_record_batch` reads row 0.
+//!   `from_record_batch` requires exactly one row and rejects anything else.
 //! * All MAVLink enums (regardless of wire width) are stored as `UInt32`
 //!   to match the Rust `repr(u32)` of the generated enum types.
 //! * Bitflag fields are stored at their bitflag's natural width
@@ -28,7 +28,8 @@ use std::sync::Arc;
 /// Bidirectional conversion between a MAVLink 2 message struct and a 1-row
 /// Apache Arrow `RecordBatch`. Each impl is symmetric: the schema returned
 /// by [`schema`] is what [`to_record_batch`] emits and what
-/// [`from_record_batch`] expects.
+/// [`from_record_batch`] expects; both sides carry exactly one row, and
+/// [`from_record_batch`] rejects any other row count.
 ///
 /// [`schema`]: MavlinkArrow::schema
 /// [`to_record_batch`]: MavlinkArrow::to_record_batch
@@ -62,6 +63,9 @@ fn build(fields: Vec<Field>, columns: Vec<ArrayRef>) -> BridgeResult<RecordBatch
 //   * wrong column dtype  → `as_primitive` would panic; downcast_ref
 //     returns None and we return a `BridgeError::Mavlink` instead.
 //   * zero-row batch      → `value(0)` would panic on out-of-bounds.
+//   * multi-row batch     → `value(0)` would silently drop every row
+//     after the first (e.g. the LAND in a [TAKEOFF, LAND] command
+//     batch); reject the whole batch instead.
 //   * null at row 0       → `value(0)` returns the slot but ignores the
 //     null bit, which silently invents a value; reject it.
 //
@@ -83,9 +87,11 @@ where
                 col.data_type()
             ))
         })?;
-    if arr.is_empty() {
+    let len = arr.len();
+    if len != 1 {
         return Err(BridgeError::Mavlink(format!(
-            "column '{name}' has zero rows; expected ≥1 row"
+            "column '{name}' has {len} rows; expected exactly 1 (one MAVLink message \
+             per batch — multi-row command batches are not supported)"
         )));
     }
     if arr.is_null(0) {

--- a/libraries/extensions/mavlink2-bridge/tests/arrow_malformed.rs
+++ b/libraries/extensions/mavlink2-bridge/tests/arrow_malformed.rs
@@ -81,7 +81,40 @@ fn rejects_zero_row_batch() {
 
     let err = COMMAND_LONG_DATA::from_record_batch(&batch).expect_err("expected decode error");
     let msg = err.to_string();
-    assert!(msg.contains("zero rows"), "unexpected error: {msg}");
+    assert!(
+        msg.contains("has 0 rows") && msg.contains("exactly 1"),
+        "unexpected error: {msg}"
+    );
+}
+
+#[test]
+fn rejects_multi_row_batch() {
+    // Two commands in one batch: row 0 is TAKEOFF, row 1 is LAND. Reading
+    // only row 0 would silently drop the LAND command — safety-relevant
+    // data loss — so the whole batch must be rejected.
+    let schema = COMMAND_LONG_DATA::schema();
+    let cols: Vec<arrow::array::ArrayRef> = vec![
+        Arc::new(Float32Array::from(vec![1.0, 101.0])),
+        Arc::new(Float32Array::from(vec![2.0, 102.0])),
+        Arc::new(Float32Array::from(vec![3.0, 103.0])),
+        Arc::new(Float32Array::from(vec![4.0, 104.0])),
+        Arc::new(Float32Array::from(vec![5.0, 105.0])),
+        Arc::new(Float32Array::from(vec![6.0, 106.0])),
+        Arc::new(Float32Array::from(vec![7.0, 107.0])),
+        // MAV_CMD_NAV_TAKEOFF, MAV_CMD_NAV_LAND
+        Arc::new(UInt32Array::from(vec![22u32, 21u32])),
+        Arc::new(UInt8Array::from(vec![1u8, 1u8])),
+        Arc::new(UInt8Array::from(vec![1u8, 1u8])),
+        Arc::new(UInt8Array::from(vec![0u8, 0u8])),
+    ];
+    let batch = RecordBatch::try_new(Arc::new(schema), cols).expect("build batch");
+
+    let err = COMMAND_LONG_DATA::from_record_batch(&batch).expect_err("expected decode error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("has 2 rows") && msg.contains("exactly 1"),
+        "unexpected error: {msg}"
+    );
 }
 
 #[test]

--- a/libraries/extensions/mavlink2-bridge/tests/arrow_roundtrip.rs
+++ b/libraries/extensions/mavlink2-bridge/tests/arrow_roundtrip.rs
@@ -451,7 +451,8 @@ fn set_position_target_local_ned_arrow_roundtrip() {
 /// must emit exactly the `schema()` it advertises (same field names, order,
 /// dtypes, and nullability) and exactly one row. This catches an impl whose
 /// column-builder list drifts in width or dtype from its schema list, and
-/// guards the decode contract that `from_record_batch` reads row 0.
+/// guards the decode contract that `from_record_batch` requires exactly
+/// one row.
 #[test]
 fn encode_matches_declared_schema() {
     fn check<T: MavlinkArrow + Default>() {


### PR DESCRIPTION
`from_record_batch` read only row 0 of an incoming RecordBatch, so a producer publishing a multi-row command batch (e.g. `[TAKEOFF, LAND]` on `command_long_cmd`) had every row after the first silently dropped on the dora-to-vehicle path — safety-relevant silent data loss. `read_primitive`, the single decode chokepoint all `MavlinkArrow` impls funnel through, now requires exactly one row and returns a `BridgeError` otherwise; the bridge node logs the decode error and keeps running.

Behavior change: out-of-tree producers that were sending multi-row batches (and silently losing rows 1..N) now get the whole message rejected with an error log — fail-closed instead of partial delivery. The encode side already emits exactly one row per batch (locked by `encode_matches_declared_schema`), so telemetry output is unaffected.

Closes #2075

🤖 Generated with [Claude Code](https://claude.com/claude-code)
