### PR TITLE
ci(examples): bound rust-dataflow-git run with a 120s stop-after safety net

### DIFF
--- a/examples/rust-dataflow-git/run.rs
+++ b/examples/rust-dataflow-git/run.rs
@@ -1,6 +1,6 @@
-use dora_cli::{BuildConfig, build, run};
+use dora_cli::{BuildConfig, Executable, RunCommand, build};
 use eyre::Context;
-use std::path::Path;
+use std::{path::Path, time::Duration};
 
 fn main() -> eyre::Result<()> {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
@@ -20,7 +20,13 @@ fn main() -> eyre::Result<()> {
         ..Default::default()
     })?;
 
-    run(dataflow, false)?;
+    // The node binaries are pinned to a fixed git rev, so node-API fixes
+    // don't reach this example until the rev is bumped. Bound the run so
+    // a wedged dataflow fails fast instead of hanging until the CI step
+    // timeout (#2089). A healthy run self-terminates in ~2s.
+    let mut run = RunCommand::new(dataflow);
+    run.stop_after = Some(Duration::from_secs(120));
+    run.execute()?;
 
     Ok(())
 }


### PR DESCRIPTION
The rust-dataflow-git example pins its node binaries to rev f40b5e7e, so node-API fixes don't reach it until a rev bump — when a pinned node wedges, the runner's unbounded `run(dataflow, false)` call hangs until the GHA step timeout, as in the 2026-06-09 nightly (run 27190356408, 30 minutes of warn spam, auto-filed on #2089). This switches the runner to `RunCommand` with `stop_after = 120s` so the daemon's stop escalation (Stop -> 10s grace -> SoftKill -> +5s -> Kill) kills wedged nodes and the step fails in ~2.5 minutes with a clear error; a healthy run self-terminates in ~2s, so the bound only fires on a wedge.

Refs #2089

🤖 Generated with [Claude Code](https://claude.com/claude-code)
