### PR TITLE
perf(daemon): move output payload out of Arc instead of copying when uniquely owned

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -4828,9 +4828,15 @@ async fn send_output_to_local_receivers(
         dataflow.subscribe_channels.remove(id);
     }
     let data_bytes = if need_data_bytes {
-        data.as_ref().map(|arc| {
-            let DataMessage::Vec(v) = arc.as_ref();
-            v.clone()
+        // If no local receiver kept a reference (pure remote topology), the
+        // Arc is uniquely owned and the payload can be moved out instead of
+        // copied.
+        data.map(|arc| match Arc::try_unwrap(arc) {
+            Ok(DataMessage::Vec(v)) => v,
+            Err(arc) => {
+                let DataMessage::Vec(v) = arc.as_ref();
+                v.clone()
+            }
         })
     } else {
         None
@@ -5455,6 +5461,77 @@ mod fault_tolerance_tests {
         assert_eq!(events.len(), 2);
         assert!(matches_event(&events[0], "Input"));
         assert!(matches_event(&events[1], "InputRecovered"));
+    }
+
+    // -- need_data_bytes: payload must be returned for remote forwarding --
+
+    #[tokio::test]
+    async fn data_bytes_returned_with_and_without_local_receivers() {
+        let clock = test_clock();
+        let payload = [1u8, 2, 3, 4];
+        let type_info = ArrowTypeInfo {
+            data_type: DataType::UInt8,
+            len: payload.len(),
+            null_count: 0,
+            validity: None,
+            offset: 0,
+            buffer_offsets: vec![],
+            child_data: vec![],
+            field_names: None,
+            schema_hash: None,
+        };
+        let sender: NodeId = "sender".to_string().into();
+        let output: DataId = "output".to_string().into();
+
+        // Without local receivers the data Arc is uniquely owned; the payload
+        // is moved out (no copy) but must still be returned for the remote
+        // forwarding path.
+        let mut df = test_dataflow();
+        let metadata = metadata::Metadata::new(clock.new_timestamp(), type_info.clone());
+        let data = DataMessage::Vec(AVec::from_slice(128, &payload));
+        let result = send_output_to_local_receivers(
+            sender.clone(),
+            output.clone(),
+            &mut df,
+            &metadata,
+            Some(data),
+            &clock,
+            None,
+            true,
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.as_deref(), Some(&payload[..]));
+
+        // With a local receiver holding a reference, the bytes are cloned and
+        // must match the payload delivered to the receiver.
+        let mut df = test_dataflow();
+        let receiver: NodeId = "receiver".to_string().into();
+        let input: DataId = "input".to_string().into();
+        df.mappings
+            .entry(OutputId(sender.clone(), output.clone()))
+            .or_default()
+            .insert((receiver.clone(), input.clone()));
+        let (tx, mut rx) = mpsc::channel(NODE_EVENT_CHANNEL_CAPACITY);
+        df.subscribe_channels.insert(receiver.clone(), tx);
+        let metadata = metadata::Metadata::new(clock.new_timestamp(), type_info);
+        let data = DataMessage::Vec(AVec::from_slice(128, &payload));
+        let result = send_output_to_local_receivers(
+            sender,
+            output,
+            &mut df,
+            &metadata,
+            Some(data),
+            &clock,
+            None,
+            true,
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.as_deref(), Some(&payload[..]));
+        let events = drain_events(&mut rx);
+        assert_eq!(events.len(), 1);
+        assert!(matches_event(&events[0], "Input"));
     }
 
     // -- Test 8: Full circuit breaker cycle: open -> break -> recover --


### PR DESCRIPTION
> 🤖 Machine-generated PR from an automated Claude Code review session. Please review with the usual scrutiny.

## Issue

`send_output_to_local_receivers` always memcpy'd the full payload to produce the `data_bytes` returned for remote forwarding (inter-daemon Zenoh publish / debug inspection):

```rust
data.as_ref().map(|arc| {
    let DataMessage::Vec(v) = arc.as_ref();
    v.clone()   // O(payload) copy on every remotely-forwarded output
})
```

But after the local fan-out loop, the `Arc` is only shared if a local receiver's channel actually took a clone. In a **pure remote topology** — every cross-daemon output, i.e. the common case in multi-machine deployments — the refcount is 1 and the copy is avoidable. For robotics payloads (images, point clouds) that's a multi-MB memcpy per message.

## Fix

`Arc::try_unwrap` moves the payload out when uniquely owned and falls back to the previous clone only when a local receiver shares the allocation. Behavior is unchanged; an in-code comment documents why the uniqueness condition holds relative to the fan-out loop above.

## Validation

- New test `data_bytes_returned_with_and_without_local_receivers` locks the `data_bytes` contract for both paths (unique ownership → moved; shared with a local receiver → cloned, and the receiver still gets its event).
- `cargo test -p dora-daemon` green (57 unit tests incl. the new one), `cargo clippy -p dora-daemon -- -D warnings`, `cargo fmt --all -- --check`.
- Full workspace suite (110 test binaries), workspace clippy `-D warnings`, and `cargo check --examples` green on the combined diff of this session's PRs.
- All four callers checked: the two `need_data_bytes: false` callers and the bench fixture are unaffected; `send_out` (the only `true` caller) consumes the return value exactly as before.

Related: complements #2111, which hoists `Arc` allocations out of the daemon's broadcast loops — this PR addresses the remaining copy on the remote-forwarding side of the same hot path (no code overlap).

https://claude.ai/code/session_01M58UDhAkRXVWb7gwD5XBuX

---
_Generated by [Claude Code](https://claude.ai/code/session_01M58UDhAkRXVWb7gwD5XBuX)_