### PR TITLE
perf(cxx-node): drop redundant ArrayData clone in arrow input export

### DIFF
--- a/apis/c++/node/src/lib.rs
+++ b/apis/c++/node/src/lib.rs
@@ -536,7 +536,7 @@ unsafe fn event_as_arrow_input(
 
     let array_data = data.to_data();
 
-    match arrow::ffi::to_ffi(&array_data.clone()) {
+    match arrow::ffi::to_ffi(&array_data) {
         Ok((ffi_array, ffi_schema)) => {
             unsafe {
                 std::ptr::write(out_array, ffi_array);


### PR DESCRIPTION
> 🤖 Machine-generated PR from an automated Claude Code review session. Please review with the usual scrutiny.

## Issue

`event_as_arrow_input` in the C++ node API cloned the `ArrayData` just to pass a reference to `arrow::ffi::to_ffi`, which only borrows its argument:

```rust
let array_data = data.to_data();
match arrow::ffi::to_ffi(&array_data.clone()) {
```

The clone duplicates the buffer/child-data vecs and bumps every buffer `Arc` on **every typed input event** crossing the C++ FFI boundary — pure waste, since `array_data` is dropped right after the call either way.

## Fix

One-line change: pass `&array_data` directly.

## Validation

- `cargo test -p dora-node-api-cxx`, `cargo clippy -p dora-node-api-cxx -- -D warnings`, `cargo fmt --all -- --check` — green.
- Full workspace suite (110 test binaries), workspace clippy `-D warnings`, and `cargo check --examples` green on the combined diff of this session's PRs.
- Verified `array_data` has no use after the `to_ffi` call, and that the sibling `event_as_arrow_input_with_info` path doesn't have the same redundancy.

https://claude.ai/code/session_01M58UDhAkRXVWb7gwD5XBuX

---
_Generated by [Claude Code](https://claude.ai/code/session_01M58UDhAkRXVWb7gwD5XBuX)_