### PR TITLE
ci(nightly): raise CLI Tests timeout to 100 min for Windows cache-save overhang

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1206,7 +1206,13 @@ jobs:
       fail-fast: false
     # Windows builds + Python Dynamic Node tests are slower than other
     # platforms; 60 min is not enough when the runner is under load.
-    timeout-minutes: 90
+    # 100 min: on 2026-06-11 (first run with the #2145 wheel cache) Windows
+    # finished all test steps at ~88 min but was killed at 90 during the
+    # post-job rust-cache save. The structural per-step rebuild creep is
+    # fixed (#2143); this covers the remaining fixed cost (23 min CLI build
+    # + 19 min venv setup) plus the cache save. Do not raise further —
+    # investigate per-step times instead (see #2143).
+    timeout-minutes: 100
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master


### PR DESCRIPTION
## Summary

Closes out the Windows residual from #2143. On the [2026-06-11 nightly](https://github.com/dora-rs/dora/actions/runs/27331903367) — the first run with the #2145 wheel cache — `CLI Tests (windows-latest)` **passed every test step** at ~88 min but was killed at the 90-min limit during the post-job rust-cache save. macOS and Linux finished in 72/57 min.

The structural per-step rebuild creep is fixed (the wheel cache works on Windows too: `Test Python Multiple Arrays` took 37 s vs ~10 min pre-fix). The remaining Windows cost is fixed overhead — 23 min CLI build + 19 min venv setup — so a 10-minute bump covers the cache save without masking future creep. The workflow comment documents this and says not to raise further; per-step times are the next lever if it creeps again.

YAML-only change; `timeout-minutes: 90 → 100` on the `cli-tests` job plus an explanatory comment.

## Test plan
- [x] YAML parses
- [ ] Next nightly: `CLI Tests (windows-latest)` green end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)