### PR TITLE
refactor(coordinator): remove unused start_embedded entry point

### DIFF
--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -196,25 +196,6 @@ pub async fn start_with_auth(
 }
 
 /// Like [`start`] but without registering a ctrl-c handler.
-/// For embedding the coordinator in another process (e.g., `dora run`).
-pub async fn start_embedded(
-    bind: SocketAddr,
-    external_events: impl Stream<Item = Event> + Unpin,
-    store: Arc<dyn CoordinatorStore>,
-    span_store: SpanStore,
-) -> Result<(u16, impl Future<Output = eyre::Result<()>>), eyre::ErrReport> {
-    start_with_events(
-        bind,
-        external_events,
-        futures::stream::empty(),
-        store,
-        None,
-        span_store,
-    )
-    .await
-}
-
-/// Like [`start`] but without registering a ctrl-c handler.
 /// Useful for tests that run multiple coordinators in the same process.
 /// Testing-only entry point. Starts coordinator without auth.
 /// Do NOT use in production.


### PR DESCRIPTION
> 🤖 **Machine-generated PR from an automated Claude Code session.** Authored by Claude, not the account that pushed it. Please review with the usual scrutiny.

## Issue

`start_embedded` in `dora-coordinator` is a `pub async fn` wrapper over `start_with_events`:

```rust
/// Like [`start`] but without registering a ctrl-c handler.
/// For embedding the coordinator in another process (e.g., `dora run`).
pub async fn start_embedded(
    bind: SocketAddr,
    external_events: impl Stream<Item = Event> + Unpin,
    store: Arc<dyn CoordinatorStore>,
    span_store: SpanStore,
) -> Result<(u16, impl Future<Output = eyre::Result<()>>), eyre::ErrReport> {
    start_with_events(bind, external_events, futures::stream::empty(), store, None, span_store).await
}
```

It has **zero callers anywhere in the workspace** — no production code, no tests, no examples:

```
$ rg -n 'start_embedded' -g '!**/target/**'
binaries/coordinator/src/lib.rs:200:pub async fn start_embedded(
```

`dora-coordinator` is a **binary crate**, not a published library, so its `pub` items are not a public API surface — an unreferenced `pub fn` here is dead code. The role its doc comment describes (embedding the coordinator without a ctrl-c handler) is actually filled by the entry points that *are* wired up: `start`, `start_with_auth`, and the `#[doc(hidden)]` `start_testing` / `start_testing_with_store`.

## Fix

Delete the function. No behavior change; `start_with_events` and all live entry points are untouched.

## Validation

- `cargo clippy -p dora-coordinator -- -D warnings` — green (no newly-unused imports; `futures::stream::empty()` is still used by `start_testing_with_store`).
- `cargo test -p dora-coordinator` — green.
- `cargo fmt --all -- --check` — green.
- `cargo check --all` (excluding Python packages) on the base — green; this PR only deletes an unreferenced item.

---
_Generated by [Claude Code](https://claude.ai/code). The commit is authored as `Claude <noreply@anthropic.com>`; it was pushed via the repository owner's credentials because PR authorship is tied to the push account._

---
_Generated by [Claude Code](https://claude.ai/code/session_011C31FPkrcx3dhZEuPZhmip)_