### PR TITLE
refactor(tracing): remove deprecated unused jaeger compatibility shims

### DIFF
--- a/libraries/extensions/telemetry/tracing/src/lib.rs
+++ b/libraries/extensions/telemetry/tracing/src/lib.rs
@@ -208,12 +208,6 @@ impl TracingBuilder {
         Ok(self)
     }
 
-    /// Legacy method name for backward compatibility.
-    #[deprecated(since = "0.1.0", note = "Use `with_otlp_tracing` instead")]
-    pub fn with_jaeger_tracing(self) -> eyre::Result<Self> {
-        self.with_otlp_tracing()
-    }
-
     /// Add a layer that captures completed spans into the given store.
     ///
     /// Only captures spans from `dora_*` crates at info level to avoid noise

--- a/libraries/extensions/telemetry/tracing/src/telemetry.rs
+++ b/libraries/extensions/telemetry/tracing/src/telemetry.rs
@@ -52,15 +52,6 @@ pub fn init_tracing(_name: &str, endpoint: &str) -> eyre::Result<sdktrace::SdkTr
         .build())
 }
 
-/// Legacy function name for backward compatibility
-#[deprecated(since = "0.1.0", note = "Use `init_tracing` instead")]
-pub fn init_jaeger_tracing(
-    name: &str,
-    endpoint: &str,
-) -> eyre::Result<sdktrace::SdkTracerProvider> {
-    init_tracing(name, endpoint)
-}
-
 /// Serialize the trace context (trace ID, span ID) into a compact string.
 /// Only W3C TraceContext keys (`traceparent`, `tracestate`) are included.
 /// OTel Baggage keys are stripped to prevent sensitive data from leaking


### PR DESCRIPTION
> 🤖 **Machine-generated PR from an automated Claude Code session.** Authored by Claude, not the account that pushed it. Please review with the usual scrutiny.

## Issue

`dora-tracing` carries two `#[deprecated]` jaeger-named backward-compatibility shims, each of which merely delegates to its modern replacement:

```rust
// telemetry.rs
#[deprecated(since = "0.1.0", note = "Use `init_tracing` instead")]
pub fn init_jaeger_tracing(name: &str, endpoint: &str) -> eyre::Result<sdktrace::SdkTracerProvider> {
    init_tracing(name, endpoint)
}

// lib.rs — TracingBuilder
#[deprecated(since = "0.1.0", note = "Use `with_otlp_tracing` instead")]
pub fn with_jaeger_tracing(self) -> eyre::Result<Self> {
    self.with_otlp_tracing()
}
```

Both have **zero references anywhere in the workspace** — production code, tests, and examples:

```
$ rg -n 'init_jaeger_tracing|with_jaeger_tracing' -g '!**/target/**'
(no matches outside their own definitions)
```

They carry no unique logic; the live entry points (`init_tracing` / `with_otlp_tracing`) fully supersede them. Note that `with_otlp_tracing` already reads the legacy `DORA_JAEGER_TRACING` environment variable for backward compatibility, so the deprecated method *names* add nothing on top of that.

## Why this is safe to remove now

- Both are explicitly `#[deprecated]` — the author already flagged them for eventual removal.
- They are pure delegating shims with no callers.
- dora is at **`1.0.0-rc1`** — pruning already-deprecated, unused API before the 1.0 stability freeze is exactly the right time.

While these are technically `pub` (and `dora-tracing` is reachable via `dora-node-api`'s optional `tracing` feature), they are deprecated zero-use shims rather than active public API.

## Fix

Delete both functions (and their `#[deprecated]` attributes / doc comments). No behavior change.

## Validation

- `cargo clippy -p dora-tracing --all-features -- -D warnings` — green.
- `cargo test -p dora-tracing --all-features` — green (incl. doctests).
- `cargo fmt --all -- --check` — green.
- `rg` confirms zero remaining references to either symbol across the workspace.

---
_Generated by [Claude Code](https://claude.ai/code). The commit is authored as `Claude <noreply@anthropic.com>`; it was pushed via the repository owner's credentials because PR authorship is tied to the push account._

---
_Generated by [Claude Code](https://claude.ai/code/session_011C31FPkrcx3dhZEuPZhmip)_