### PR TITLE
chore: waive RUSTSEC-2026-0176/0177 (pyo3 0.28) pending 0.29 upgrade

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,13 @@
+# cargo-audit configuration. Keep ignore entries in sync with deny.toml
+# (cargo-deny enforces the same policy; both run in `make qa-audit`).
+[advisories]
+ignore = [
+    # pyo3 0.28 OOB read in PyList/PyTuple iterator nth/nth_back. The
+    # affected APIs are not used in this workspace; the pyo3 0.29 upgrade
+    # is tracked in https://github.com/dora-rs/dora/issues/2157.
+    # Review: 2026-07.
+    "RUSTSEC-2026-0176",
+    # pyo3 0.28 missing Sync bound on PyCFunction::new_closure — unused
+    # in this workspace; same upgrade tracked in #2157.
+    "RUSTSEC-2026-0177",
+]

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 .cargo/*
 # Project-wide cargo-mutants config must be tracked.
 !.cargo/mutants.toml
+# Project-wide cargo-audit ignore policy must be tracked (kept in sync
+# with deny.toml).
+!.cargo/audit.toml
 
 # Generated coverage artifacts (make qa-coverage)
 /lcov.info

--- a/deny.toml
+++ b/deny.toml
@@ -22,6 +22,9 @@ ignore = [
     "RUSTSEC-2025-0057",  # fxhash: transitive, waiting for upstream. Review: 2026-07.
     "RUSTSEC-2025-0119",  # number_prefix: transitive, low risk. Review: 2026-07.
     "RUSTSEC-2024-0436",  # paste: transitive (safer_ffi / macro_rules_attribute). Low risk. Review: 2026-07.
+    # --- Temporary vulnerability waivers ---
+    "RUSTSEC-2026-0176",  # pyo3 0.28 OOB read in PyList/PyTuple iterator nth/nth_back. Affected APIs unused in this workspace; upgrade to 0.29 tracked in #2157. Review: 2026-07.
+    "RUSTSEC-2026-0177",  # pyo3 0.28 missing Sync bound on PyCFunction::new_closure. API unused in this workspace; upgrade to 0.29 tracked in #2157. Review: 2026-07.
 ]
 
 # ----- Licenses -----


### PR DESCRIPTION
Two pyo3 0.28 advisories published today (2026-06-11) fail `make qa-audit` — and therefore the PR CI audit gate — for every branch: [RUSTSEC-2026-0176](https://rustsec.org/advisories/RUSTSEC-2026-0176) (OOB read in `PyList`/`PyTuple` iterator `nth`/`nth_back`) and [RUSTSEC-2026-0177](https://rustsec.org/advisories/RUSTSEC-2026-0177) (missing `Sync` bound on `PyCFunction::new_closure`). Both are fixed in pyo3 0.29.

**Neither affected API is used in this workspace** (verified by grep; the only `nth` call is on a str-split iterator). Temporary waivers added to `deny.toml` and a new tracked `.cargo/audit.toml` (cargo-audit previously ran bare with no ignore mechanism; .gitignore gains the tracked-file exception). The real fix — the pyo3 0.29 workspace upgrade — is tracked in #2157 with a 2026-07 review date.

Note: `cargo deny` warns `advisory-not-detected` for the two new IDs when its local advisory DB predates today's publication; CI fetches fresh DBs where both match. `make qa-audit` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)