### PR TITLE
fix(daemon): bound and diagnose nodes that block an otherwise-finished dataflow (#2152)

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1203,6 +1203,7 @@ impl Daemon {
                 Event::Dora(event) => self.handle_dora_event(event).await?,
                 Event::DynamicNode(event) => self.handle_dynamic_node_event(event).await?,
                 Event::HeartbeatInterval => {
+                    self.check_finish_stragglers();
                     if let Some(sender) = &self.coordinator_sender {
                         let msg = serde_json::to_vec(&Timestamped {
                             inner: CoordinatorRequest::Event {
@@ -2236,6 +2237,46 @@ impl Daemon {
             }
         };
         Ok(status)
+    }
+
+    /// Watchdog for nodes that block an otherwise-finished dataflow
+    /// (dora-rs/dora#2152).
+    ///
+    /// The natural-finish path sends `AllInputsClosed` and waits for nodes
+    /// to exit voluntarily; unlike explicit stops it had no deadline, so a
+    /// stuck node hung `dora run` (and CI) until an external timeout. Once
+    /// every running node of a dataflow has been draining for longer than
+    /// the grace period, escalate through the same Stop → SIGTERM → SIGKILL
+    /// ladder used by explicit stops — after capturing a stack sample of
+    /// the stuck process so the hang itself stays diagnosable.
+    fn check_finish_stragglers(&mut self) {
+        let grace = finish_drain_grace();
+        for (dataflow_id, dataflow) in self.running.iter_mut() {
+            for node_id in dataflow.finish_stragglers(grace) {
+                let drained_for_secs = dataflow
+                    .all_inputs_closed_at
+                    .get(&node_id)
+                    .map(|since| since.elapsed().as_secs())
+                    .unwrap_or_default();
+                let pid = dataflow
+                    .running_nodes
+                    .get(&node_id)
+                    .and_then(|node| node.pid.as_ref())
+                    .map(|pid| pid.load(atomic::Ordering::Relaxed));
+                tracing::warn!(
+                    "dataflow {dataflow_id} is finished except node `{node_id}` \
+                     (AllInputsClosed sent {drained_for_secs}s ago) — escalating stop \
+                     (set DORA_FINISH_DRAIN_GRACE_SECS to adjust the grace period)"
+                );
+                spawn_stack_sample_capture(node_id.clone(), pid);
+                dataflow.finish_escalated.insert(node_id.clone());
+                if let Err(err) = dataflow.stop_single_node(&node_id, &self.clock, None) {
+                    tracing::warn!(
+                        "failed to escalate stop for finish straggler `{node_id}`: {err:?}"
+                    );
+                }
+            }
+        }
     }
 
     fn check_node_health(&self) {
@@ -3619,6 +3660,9 @@ impl Daemon {
                     == Some(true)
                 {
                     dataflow.inc_pending(&node_id);
+                    dataflow
+                        .all_inputs_closed_at
+                        .insert(node_id.clone(), Instant::now());
                 }
             }
         }
@@ -4892,6 +4936,9 @@ fn close_input(
             }
             if send_with_timestamp(channel, NodeEvent::AllInputsClosed, clock).ok() == Some(true) {
                 dataflow.inc_pending(receiver_id);
+                dataflow
+                    .all_inputs_closed_at
+                    .insert(receiver_id.clone(), Instant::now());
             }
         }
     }
@@ -4934,9 +4981,79 @@ fn break_input(
             }
             if send_with_timestamp(channel, NodeEvent::AllInputsClosed, clock).ok() == Some(true) {
                 dataflow.inc_pending(receiver_id);
+                dataflow
+                    .all_inputs_closed_at
+                    .insert(receiver_id.clone(), Instant::now());
             }
         }
     }
+}
+
+/// Grace period before the finish-straggler watchdog escalates
+/// (dora-rs/dora#2152). Conservative by default: a sink may legitimately
+/// keep working for a while after its inputs close (flushing recordings,
+/// final writes). Override with `DORA_FINISH_DRAIN_GRACE_SECS`.
+const DEFAULT_FINISH_DRAIN_GRACE: Duration = Duration::from_secs(120);
+
+fn finish_drain_grace() -> Duration {
+    static GRACE: std::sync::OnceLock<Duration> = std::sync::OnceLock::new();
+    *GRACE.get_or_init(|| {
+        std::env::var("DORA_FINISH_DRAIN_GRACE_SECS")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .map(Duration::from_secs)
+            .unwrap_or(DEFAULT_FINISH_DRAIN_GRACE)
+    })
+}
+
+/// Best-effort stack capture of a stuck node before it is killed, so the
+/// "why didn't it exit" half of dora-rs/dora#2152 stays answerable from
+/// logs. macOS ships `sample`; other platforms have no portable
+/// unprivileged stack tool, so only the escalation log is emitted there.
+/// Runs as a background task — the kill ladder's grace period (10 s before
+/// SIGTERM) leaves ample time for the capture to finish first.
+fn spawn_stack_sample_capture(node_id: NodeId, pid: Option<u32>) {
+    let Some(pid) = pid.filter(|pid| *pid != 0) else {
+        tracing::warn!("no pid recorded for stuck node `{node_id}`; skipping stack sample");
+        return;
+    };
+    if !cfg!(target_os = "macos") {
+        tracing::info!(
+            "stack sample capture is not supported on this platform \
+             (stuck node `{node_id}`, pid {pid})"
+        );
+        return;
+    }
+    tokio::spawn(async move {
+        match tokio::process::Command::new("sample")
+            .args([&pid.to_string(), "1"])
+            .output()
+            .await
+        {
+            Ok(output) if output.status.success() => {
+                let mut text = String::from_utf8_lossy(&output.stdout).into_owned();
+                const MAX_SAMPLE_BYTES: usize = 64 * 1024;
+                if text.len() > MAX_SAMPLE_BYTES {
+                    let mut cut = MAX_SAMPLE_BYTES;
+                    while !text.is_char_boundary(cut) {
+                        cut -= 1;
+                    }
+                    text.truncate(cut);
+                    text.push_str("\n…(truncated)");
+                }
+                tracing::warn!("stack sample of stuck node `{node_id}` (pid {pid}):\n{text}");
+            }
+            Ok(output) => {
+                tracing::warn!(
+                    "`sample {pid}` failed for stuck node `{node_id}`: {}",
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
+            Err(err) => {
+                tracing::warn!("failed to run `sample` for stuck node `{node_id}`: {err}");
+            }
+        }
+    });
 }
 
 // RunningDataflow and related types are in running_dataflow.rs

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1203,7 +1203,6 @@ impl Daemon {
                 Event::Dora(event) => self.handle_dora_event(event).await?,
                 Event::DynamicNode(event) => self.handle_dynamic_node_event(event).await?,
                 Event::HeartbeatInterval => {
-                    self.check_finish_stragglers();
                     if let Some(sender) = &self.coordinator_sender {
                         let msg = serde_json::to_vec(&Timestamped {
                             inner: CoordinatorRequest::Event {
@@ -1241,6 +1240,7 @@ impl Daemon {
                 Event::NodeHealthCheckInterval => {
                     self.check_node_health();
                     self.check_input_timeouts();
+                    self.check_finish_stragglers();
                     if self.ft_stats.any_nonzero() {
                         tracing::info!(
                             restarts = self.ft_stats.restarts.load(atomic::Ordering::Relaxed),
@@ -2062,6 +2062,8 @@ impl Daemon {
                     dataflow.open_inputs.remove(&node_id);
                     dataflow.subscribe_channels.remove(&node_id);
                     dataflow.pending_messages.remove(&node_id);
+                    dataflow.all_inputs_closed_at.remove(&node_id);
+                    dataflow.finish_escalated.remove(&node_id);
 
                     // Remove from stored descriptor (inverse of AddNode
                     // push) so descriptor-based lookups stay consistent.
@@ -2263,18 +2265,25 @@ impl Daemon {
                     .get(&node_id)
                     .and_then(|node| node.pid.as_ref())
                     .map(|pid| pid.load(atomic::Ordering::Relaxed));
+                // Escalate first: if the node exited naturally between
+                // selection and now, this fails benignly and nothing
+                // should be logged or sampled.
+                if dataflow
+                    .stop_single_node(&node_id, &self.clock, None)
+                    .is_err()
+                {
+                    tracing::debug!(
+                        "finish straggler `{node_id}` exited before escalation; skipping"
+                    );
+                    continue;
+                }
+                dataflow.finish_escalated.insert(node_id.clone());
                 tracing::warn!(
                     "dataflow {dataflow_id} is finished except node `{node_id}` \
                      (AllInputsClosed sent {drained_for_secs}s ago) — escalating stop \
                      (set DORA_FINISH_DRAIN_GRACE_SECS to adjust the grace period)"
                 );
-                spawn_stack_sample_capture(node_id.clone(), pid);
-                dataflow.finish_escalated.insert(node_id.clone());
-                if let Err(err) = dataflow.stop_single_node(&node_id, &self.clock, None) {
-                    tracing::warn!(
-                        "failed to escalate stop for finish straggler `{node_id}`: {err:?}"
-                    );
-                }
+                spawn_stack_sample_capture(node_id, pid);
             }
         }
     }
@@ -4126,6 +4135,20 @@ impl Daemon {
                         let grace_duration_kill = dataflow
                             .map(|d| d.grace_duration_kills.contains(&node_id))
                             .unwrap_or_default();
+                        // Killed by the finish-straggler watchdog
+                        // (dora-rs/dora#2152): the node blocked an
+                        // otherwise-finished dataflow past the drain grace
+                        // period. Unlike an operator-initiated stop this
+                        // must NOT classify as clean — a node that needed
+                        // force-killing during natural finish is a shutdown
+                        // bug, and reporting success would hide every
+                        // recurrence behind a green run. (A straggler that
+                        // exits 0 on the escalation's Stop event takes the
+                        // `Success` arm above and stays clean: it finished
+                        // its work and responded to stop, just late.)
+                        let finish_escalated = dataflow
+                            .map(|d| d.finish_escalated.contains(&node_id))
+                            .unwrap_or_default();
                         // The daemon explicitly sent SoftKill (SIGTERM)
                         // to this node as part of an operator-initiated
                         // stop (`dora stop`, `dora destroy`, `dora run
@@ -4177,7 +4200,11 @@ impl Daemon {
                                 | NodeExitStatus::ExitCode(143)
                                 | NodeExitStatus::ExitCode(130)
                         );
-                        if caused_by_node.is_none() && grace_duration_kill && is_sigterm_like {
+                        if caused_by_node.is_none()
+                            && grace_duration_kill
+                            && is_sigterm_like
+                            && !finish_escalated
+                        {
                             logger
                                 .log(
                                     LogLevel::Info,
@@ -4201,7 +4228,9 @@ impl Daemon {
 
                                     NodeErrorCause::Cascading { caused_by_node }
                                 }
-                                None if grace_duration_kill => NodeErrorCause::GraceDuration,
+                                None if grace_duration_kill || finish_escalated => {
+                                    NodeErrorCause::GraceDuration
+                                }
                                 None => {
                                     let cause = dataflow
                                         .and_then(|d| d.node_stderr_most_recent.get(&node_id))
@@ -4237,9 +4266,13 @@ impl Daemon {
                 // unrelated 143 exit from the restarted process would
                 // still see `grace_duration_kill=true` and be
                 // misreported as `Ok(())`. The marker has done its job
-                // for this exit — drop it.
-                if let Some(dataflow) = self.running.get(&dataflow_id) {
+                // for this exit — drop it. Same for the finish-straggler
+                // drain state: a respawned or re-added node under the
+                // same id must start with a fresh drain clock.
+                if let Some(dataflow) = self.running.get_mut(&dataflow_id) {
                     dataflow.grace_duration_kills.remove(&node_id);
+                    dataflow.all_inputs_closed_at.remove(&node_id);
+                    dataflow.finish_escalated.remove(&node_id);
                 }
 
                 logger
@@ -4996,14 +5029,24 @@ fn break_input(
 const DEFAULT_FINISH_DRAIN_GRACE: Duration = Duration::from_secs(120);
 
 fn finish_drain_grace() -> Duration {
-    static GRACE: std::sync::OnceLock<Duration> = std::sync::OnceLock::new();
-    *GRACE.get_or_init(|| {
-        std::env::var("DORA_FINISH_DRAIN_GRACE_SECS")
-            .ok()
-            .and_then(|value| value.parse::<u64>().ok())
-            .map(Duration::from_secs)
-            .unwrap_or(DEFAULT_FINISH_DRAIN_GRACE)
-    })
+    match std::env::var("DORA_FINISH_DRAIN_GRACE_SECS") {
+        Ok(value) => match value.parse::<u64>() {
+            Ok(secs) => Duration::from_secs(secs),
+            Err(_) => {
+                static WARNED: std::sync::atomic::AtomicBool =
+                    std::sync::atomic::AtomicBool::new(false);
+                if !WARNED.swap(true, atomic::Ordering::Relaxed) {
+                    tracing::warn!(
+                        "invalid DORA_FINISH_DRAIN_GRACE_SECS value `{value}` \
+                         (expected whole seconds); using the default of {}s",
+                        DEFAULT_FINISH_DRAIN_GRACE.as_secs()
+                    );
+                }
+                DEFAULT_FINISH_DRAIN_GRACE
+            }
+        },
+        Err(_) => DEFAULT_FINISH_DRAIN_GRACE,
+    }
 }
 
 /// Best-effort stack capture of a stuck node before it is killed, so the

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -3758,7 +3758,9 @@ impl Daemon {
     /// the `clean_stop` flag sent to the coordinator: clean_stop = true
     /// → `NodeStatus::Stopped` (auto-expires from `dora node list` after
     /// the 60s grace), clean_stop = false → `NodeStatus::Failed` (stays
-    /// visible so `dora doctor` keeps reporting it).
+    /// visible so `dora doctor` keeps reporting it). A finish-straggler
+    /// escalation (dora-rs/dora#2152) forces clean_stop = false unless
+    /// the node still exited 0.
     async fn handle_node_stop_inner(
         &mut self,
         dataflow_id: Uuid,
@@ -3809,6 +3811,13 @@ impl Daemon {
         //   - crash / panic / restart_policy=Never with non-zero exit:
         //     neither bit is set → clean_stop=false → `Failed`, so the
         //     row sticks around and `dora doctor` keeps reporting it.
+        //   - finish-straggler escalation (dora-rs/dora#2152): the
+        //     watchdog also goes through stop_single_node, so
+        //     restarts_disabled is set — but a force-killed straggler is
+        //     a node FAILURE and must not auto-expire from `dora node
+        //     list` as a clean stop. `finish_escalated` overrides
+        //     restarts_disabled (an escalated node that still exited 0
+        //     keeps exit_clean=true and stays clean).
         let (should_finish, clean_stop) = {
             let dataflow = self.running.get_mut(&dataflow_id).wrap_err_with(|| {
                 format!(
@@ -3820,7 +3829,9 @@ impl Daemon {
                 .get(node_id)
                 .map(|n| n.restarts_disabled())
                 .unwrap_or(false);
-            let clean_stop = exit_clean || restarts_disabled;
+            let finish_escalated = dataflow.finish_escalated.remove(node_id);
+            dataflow.all_inputs_closed_at.remove(node_id);
+            let clean_stop = exit_clean || (restarts_disabled && !finish_escalated);
             dataflow.running_nodes.remove(node_id);
             // Check if all remaining nodes are dynamic (won't send SpawnedNodeResult)
             let should_finish = !dataflow.pending_nodes.local_nodes_pending()
@@ -4266,13 +4277,16 @@ impl Daemon {
                 // unrelated 143 exit from the restarted process would
                 // still see `grace_duration_kill=true` and be
                 // misreported as `Ok(())`. The marker has done its job
-                // for this exit — drop it. Same for the finish-straggler
-                // drain state: a respawned or re-added node under the
-                // same id must start with a fresh drain clock.
+                // for this exit — drop it. Same for the drain clock: a
+                // respawned node under the same id must start fresh.
+                // (`finish_escalated` is NOT cleared here — it is read
+                // and consumed by `handle_node_stop_inner` below to keep
+                // the coordinator-facing `clean_stop` flag honest; an
+                // escalated node never restarts, so it cannot leak into
+                // a next incarnation.)
                 if let Some(dataflow) = self.running.get_mut(&dataflow_id) {
                     dataflow.grace_duration_kills.remove(&node_id);
                     dataflow.all_inputs_closed_at.remove(&node_id);
-                    dataflow.finish_escalated.remove(&node_id);
                 }
 
                 logger

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -195,6 +195,12 @@ pub struct RunningDataflow {
     pub(crate) dynamic_nodes: BTreeSet<NodeId>,
     pub(crate) open_external_mappings: BTreeSet<OutputId>,
     pub(crate) _timer_handles: BTreeMap<Duration, futures::future::RemoteHandle<()>>,
+    /// When the daemon sent `AllInputsClosed` to each node — the start of
+    /// that node's drain phase. Drives the finish-straggler watchdog
+    /// (dora-rs/dora#2152).
+    pub(crate) all_inputs_closed_at: HashMap<NodeId, Instant>,
+    /// Nodes already escalated by the finish-straggler watchdog (one-shot).
+    pub(crate) finish_escalated: BTreeSet<NodeId>,
     pub(crate) stop_sent: bool,
     pub(crate) empty_set: BTreeSet<DataId>,
     pub(crate) cascading_error_causes: CascadingErrorCauses,
@@ -255,6 +261,8 @@ impl RunningDataflow {
             dynamic_nodes: BTreeSet::new(),
             open_external_mappings: Default::default(),
             _timer_handles: BTreeMap::new(),
+            all_inputs_closed_at: HashMap::new(),
+            finish_escalated: BTreeSet::new(),
             stop_sent: false,
             empty_set: BTreeSet::new(),
             cascading_error_causes: Default::default(),
@@ -566,11 +574,154 @@ impl RunningDataflow {
     pub(crate) fn open_inputs(&self, node_id: &NodeId) -> &BTreeSet<DataId> {
         self.open_inputs.get(node_id).unwrap_or(&self.empty_set)
     }
+
+    /// Nodes blocking an otherwise-finished dataflow (dora-rs/dora#2152).
+    ///
+    /// Returns nodes that have been draining (received `AllInputsClosed`)
+    /// for longer than `grace`, but only once *every* running non-dynamic
+    /// node of the dataflow is draining — a running source (which never
+    /// receives `AllInputsClosed`) means the dataflow is still producing
+    /// and nothing is escalated. Explicitly stopped dataflows are excluded:
+    /// `stop_all` runs its own kill escalation.
+    pub(crate) fn finish_stragglers(&self, grace: Duration) -> Vec<NodeId> {
+        if self.stop_sent {
+            return Vec::new();
+        }
+        select_finish_stragglers(
+            self.running_nodes
+                .iter()
+                .map(|(id, node)| (id, node.node_config.dynamic)),
+            &self.all_inputs_closed_at,
+            &self.finish_escalated,
+            grace,
+        )
+    }
+}
+
+/// Pure core of [`RunningDataflow::finish_stragglers`].
+fn select_finish_stragglers<'a>(
+    running_nodes: impl Iterator<Item = (&'a NodeId, bool)>,
+    all_inputs_closed_at: &HashMap<NodeId, Instant>,
+    already_escalated: &BTreeSet<NodeId>,
+    grace: Duration,
+) -> Vec<NodeId> {
+    let mut stragglers = Vec::new();
+    for (node_id, dynamic) in running_nodes {
+        if dynamic {
+            continue;
+        }
+        let Some(drain_started) = all_inputs_closed_at.get(node_id) else {
+            // A running node that is not draining (e.g. a source) means the
+            // dataflow is not "otherwise finished".
+            return Vec::new();
+        };
+        if drain_started.elapsed() >= grace && !already_escalated.contains(node_id) {
+            stragglers.push(node_id.clone());
+        }
+    }
+    stragglers
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---- dora-rs/dora#2152: finish-straggler selection ----
+
+    fn node_id(name: &str) -> NodeId {
+        NodeId::from(name.to_string())
+    }
+
+    fn drained_since(entries: &[(&str, Duration)]) -> HashMap<NodeId, Instant> {
+        entries
+            .iter()
+            .map(|(name, age)| (node_id(name), Instant::now() - *age))
+            .collect()
+    }
+
+    #[test]
+    fn straggler_past_grace_is_selected() {
+        let running = [(node_id("sink"), false)];
+        let drained = drained_since(&[("sink", Duration::from_secs(100))]);
+        let selected = select_finish_stragglers(
+            running.iter().map(|(id, d)| (id, *d)),
+            &drained,
+            &BTreeSet::new(),
+            Duration::from_secs(60),
+        );
+        assert_eq!(selected, vec![node_id("sink")]);
+    }
+
+    #[test]
+    fn straggler_within_grace_is_not_selected() {
+        let running = [(node_id("sink"), false)];
+        let drained = drained_since(&[("sink", Duration::from_secs(5))]);
+        let selected = select_finish_stragglers(
+            running.iter().map(|(id, d)| (id, *d)),
+            &drained,
+            &BTreeSet::new(),
+            Duration::from_secs(60),
+        );
+        assert!(selected.is_empty());
+    }
+
+    #[test]
+    fn running_source_blocks_escalation_of_drained_nodes() {
+        // `source` never receives AllInputsClosed; while it runs, the
+        // dataflow is not "otherwise finished" and nothing escalates.
+        let running = [(node_id("source"), false), (node_id("sink"), false)];
+        let drained = drained_since(&[("sink", Duration::from_secs(100))]);
+        let selected = select_finish_stragglers(
+            running.iter().map(|(id, d)| (id, *d)),
+            &drained,
+            &BTreeSet::new(),
+            Duration::from_secs(60),
+        );
+        assert!(selected.is_empty());
+    }
+
+    #[test]
+    fn dynamic_nodes_neither_block_nor_escalate() {
+        let running = [(node_id("dynamic"), true), (node_id("sink"), false)];
+        let drained = drained_since(&[("sink", Duration::from_secs(100))]);
+        let selected = select_finish_stragglers(
+            running.iter().map(|(id, d)| (id, *d)),
+            &drained,
+            &BTreeSet::new(),
+            Duration::from_secs(60),
+        );
+        assert_eq!(selected, vec![node_id("sink")]);
+    }
+
+    #[test]
+    fn already_escalated_nodes_are_not_reselected() {
+        let running = [(node_id("sink"), false)];
+        let drained = drained_since(&[("sink", Duration::from_secs(100))]);
+        let escalated: BTreeSet<_> = [node_id("sink")].into();
+        let selected = select_finish_stragglers(
+            running.iter().map(|(id, d)| (id, *d)),
+            &drained,
+            &escalated,
+            Duration::from_secs(60),
+        );
+        assert!(selected.is_empty());
+    }
+
+    #[test]
+    fn multiple_drained_stragglers_are_all_selected() {
+        let running = [(node_id("a"), false), (node_id("b"), false)];
+        let drained = drained_since(&[
+            ("a", Duration::from_secs(100)),
+            ("b", Duration::from_secs(90)),
+        ]);
+        let selected = select_finish_stragglers(
+            running.iter().map(|(id, d)| (id, *d)),
+            &drained,
+            &BTreeSet::new(),
+            Duration::from_secs(60),
+        );
+        assert_eq!(selected, vec![node_id("a"), node_id("b")]);
+    }
 
     // ---- dora-rs/adora#149: InputDeadline::is_timed_out ----
 

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -513,6 +513,11 @@ impl RunningDataflow {
         // promise that `dora node restart` "re-spawns it".
         node.force_restart_next
             .store(true, atomic::Ordering::Release);
+        // A fresh incarnation starts with a clean drain state: a stale
+        // AllInputsClosed timestamp from the previous incarnation must not
+        // trip the finish-straggler watchdog on the restarted node.
+        self.all_inputs_closed_at.remove(node_id);
+        self.finish_escalated.remove(node_id);
         self.send_stop_and_schedule_kill(
             node_id,
             process,
@@ -582,9 +587,12 @@ impl RunningDataflow {
     /// node of the dataflow is draining — a running source (which never
     /// receives `AllInputsClosed`) means the dataflow is still producing
     /// and nothing is escalated. Explicitly stopped dataflows are excluded:
-    /// `stop_all` runs its own kill escalation.
+    /// `stop_all` runs its own kill escalation. Dataflows with open
+    /// cross-daemon output mappings are also excluded — a local node that
+    /// looks like a straggler may still be flushing outputs to consumers
+    /// on other daemons, which this daemon cannot see.
     pub(crate) fn finish_stragglers(&self, grace: Duration) -> Vec<NodeId> {
-        if self.stop_sent {
+        if self.stop_sent || !self.open_external_mappings.is_empty() {
             return Vec::new();
         }
         select_finish_stragglers(
@@ -605,21 +613,27 @@ fn select_finish_stragglers<'a>(
     already_escalated: &BTreeSet<NodeId>,
     grace: Duration,
 ) -> Vec<NodeId> {
-    let mut stragglers = Vec::new();
+    // Gate first: every running non-dynamic node must be draining,
+    // otherwise the dataflow is not "otherwise finished" (e.g. a running
+    // source) and nothing may be escalated.
+    let mut draining = Vec::new();
     for (node_id, dynamic) in running_nodes {
         if dynamic {
             continue;
         }
-        let Some(drain_started) = all_inputs_closed_at.get(node_id) else {
-            // A running node that is not draining (e.g. a source) means the
-            // dataflow is not "otherwise finished".
-            return Vec::new();
-        };
-        if drain_started.elapsed() >= grace && !already_escalated.contains(node_id) {
-            stragglers.push(node_id.clone());
+        match all_inputs_closed_at.get(node_id) {
+            Some(drain_started) => draining.push((node_id, drain_started)),
+            None => return Vec::new(),
         }
     }
-    stragglers
+
+    draining
+        .into_iter()
+        .filter(|(node_id, drain_started)| {
+            drain_started.elapsed() >= grace && !already_escalated.contains(*node_id)
+        })
+        .map(|(node_id, _)| node_id.clone())
+        .collect()
 }
 
 #[cfg(test)]
@@ -632,6 +646,9 @@ mod tests {
         NodeId::from(name.to_string())
     }
 
+    /// Backdates are kept tiny (≤2s): on Windows, `Instant` is anchored at
+    /// boot and larger subtractions underflow on fresh CI runners — the
+    /// exact panic class fixed in dora-rs/dora#2088.
     fn drained_since(entries: &[(&str, Duration)]) -> HashMap<NodeId, Instant> {
         entries
             .iter()
@@ -639,15 +656,18 @@ mod tests {
             .collect()
     }
 
+    const TEST_GRACE: Duration = Duration::from_millis(100);
+    const PAST_GRACE: Duration = Duration::from_secs(2);
+
     #[test]
     fn straggler_past_grace_is_selected() {
         let running = [(node_id("sink"), false)];
-        let drained = drained_since(&[("sink", Duration::from_secs(100))]);
+        let drained = drained_since(&[("sink", PAST_GRACE)]);
         let selected = select_finish_stragglers(
             running.iter().map(|(id, d)| (id, *d)),
             &drained,
             &BTreeSet::new(),
-            Duration::from_secs(60),
+            TEST_GRACE,
         );
         assert_eq!(selected, vec![node_id("sink")]);
     }
@@ -655,12 +675,12 @@ mod tests {
     #[test]
     fn straggler_within_grace_is_not_selected() {
         let running = [(node_id("sink"), false)];
-        let drained = drained_since(&[("sink", Duration::from_secs(5))]);
+        let drained = drained_since(&[("sink", Duration::ZERO)]);
         let selected = select_finish_stragglers(
             running.iter().map(|(id, d)| (id, *d)),
             &drained,
             &BTreeSet::new(),
-            Duration::from_secs(60),
+            TEST_GRACE,
         );
         assert!(selected.is_empty());
     }
@@ -670,12 +690,12 @@ mod tests {
         // `source` never receives AllInputsClosed; while it runs, the
         // dataflow is not "otherwise finished" and nothing escalates.
         let running = [(node_id("source"), false), (node_id("sink"), false)];
-        let drained = drained_since(&[("sink", Duration::from_secs(100))]);
+        let drained = drained_since(&[("sink", PAST_GRACE)]);
         let selected = select_finish_stragglers(
             running.iter().map(|(id, d)| (id, *d)),
             &drained,
             &BTreeSet::new(),
-            Duration::from_secs(60),
+            TEST_GRACE,
         );
         assert!(selected.is_empty());
     }
@@ -683,12 +703,12 @@ mod tests {
     #[test]
     fn dynamic_nodes_neither_block_nor_escalate() {
         let running = [(node_id("dynamic"), true), (node_id("sink"), false)];
-        let drained = drained_since(&[("sink", Duration::from_secs(100))]);
+        let drained = drained_since(&[("sink", PAST_GRACE)]);
         let selected = select_finish_stragglers(
             running.iter().map(|(id, d)| (id, *d)),
             &drained,
             &BTreeSet::new(),
-            Duration::from_secs(60),
+            TEST_GRACE,
         );
         assert_eq!(selected, vec![node_id("sink")]);
     }
@@ -696,13 +716,13 @@ mod tests {
     #[test]
     fn already_escalated_nodes_are_not_reselected() {
         let running = [(node_id("sink"), false)];
-        let drained = drained_since(&[("sink", Duration::from_secs(100))]);
+        let drained = drained_since(&[("sink", PAST_GRACE)]);
         let escalated: BTreeSet<_> = [node_id("sink")].into();
         let selected = select_finish_stragglers(
             running.iter().map(|(id, d)| (id, *d)),
             &drained,
             &escalated,
-            Duration::from_secs(60),
+            TEST_GRACE,
         );
         assert!(selected.is_empty());
     }
@@ -710,15 +730,12 @@ mod tests {
     #[test]
     fn multiple_drained_stragglers_are_all_selected() {
         let running = [(node_id("a"), false), (node_id("b"), false)];
-        let drained = drained_since(&[
-            ("a", Duration::from_secs(100)),
-            ("b", Duration::from_secs(90)),
-        ]);
+        let drained = drained_since(&[("a", PAST_GRACE), ("b", PAST_GRACE)]);
         let selected = select_finish_stragglers(
             running.iter().map(|(id, d)| (id, *d)),
             &drained,
             &BTreeSet::new(),
-            Duration::from_secs(60),
+            TEST_GRACE,
         );
         assert_eq!(selected, vec![node_id("a"), node_id("b")]);
     }


### PR DESCRIPTION
## Summary

Implements both fixes proposed in #2152 (analysis [here](https://github.com/dora-rs/dora/issues/2152#issuecomment-4686174951)): the nightly macOS `examples` job has flaked twice with a node failing to exit after the dataflow finished its work, hanging the daemon — and CI — until the 15-minute step timeout, with nothing in the logs but TCP read-timeout spam.

**Root cause**: the natural-finish path sends `AllInputsClosed` and waits forever; only explicit stops had a Stop → SIGTERM → SIGKILL escalation ladder. Startup has a watchdog; shutdown had none.

## What this adds

**1. Finish-straggler watchdog** (bounded damage): the daemon records when each node's drain phase starts (`AllInputsClosed` sent). On the existing health-check tick, once *every* running non-dynamic node of a dataflow is draining and a node has been draining longer than the grace period (default 120 s, `DORA_FINISH_DRAIN_GRACE_SECS` to override), it is escalated through the **same `stop_single_node` ladder** explicit stops use (Stop event → 10 s → SIGTERM → +5 s → SIGKILL).

**2. Stack capture** (diagnosability): just before escalation, the daemon captures a stack sample of the stuck process into the logs (macOS `sample` — the platform where #2152 manifests), so the *why didn't it exit* question is answerable from the next CI occurrence instead of requiring a live repro. This subsumes the originally-proposed CI `timeout` wrapper: with the watchdog bounding the hang, a step-level wrapper would never fire — the daemon now produces the diagnostic itself, in CI and locally alike.

## Semantics (deliberate choices)

- **An escalated straggler that has to be killed is a node FAILURE** (`GraceDuration`: "killed by dora because it didn't react to a stop message in time"). Bounded *and* loud — a green run would hide every recurrence of the shutdown bug. A straggler that exits 0 on the escalation's Stop event stays clean (work done, responded to stop, just late).
- **A running source vetoes escalation**: sources never receive `AllInputsClosed`, so a dataflow with a live source is never "otherwise finished". A stuck *source* therefore still hangs (documented limitation; different bug class).
- **Cross-daemon conservatism**: dataflows with open external output mappings skip escalation — a local "straggler" may be flushing to consumers on other daemons this daemon can't see.
- Drain state is cleared on node exit, `RemoveNode`, and `restart_single_node`, so restarted/re-added nodes under the same id get a fresh clock.

## Verification

- 6 new unit tests on the selection logic (gating on non-draining nodes, grace boundary, dynamic nodes, one-shot escalation, multi-straggler); 62 daemon tests pass. Test backdates kept ≤2 s (the `Instant` underflow class from #2088).
- **E2E with a deliberately hanging Python node** (`DORA_FINISH_DRAIN_GRACE_SECS=5`): warn at +7 s naming the straggler, stack sample captured (full `sample` process analysis in the log), SIGTERM at +16 s, run exits **1** with `Node 'hang' failed: node was killed by dora because it didn't react to a stop message in time` — ~20 s bounded instead of forever.
- Control runs (`examples/rust-dataflow`, with and without the change): exit 0, zero escalations.
- `make qa-fast`, clippy `-D warnings`, fmt all green. Adversarially reviewed (3 finder angles, 12 findings); review revisions are the second commit.

## Effect on #2152

Fixes the hang-forever half: the nightly flake becomes a ~2-minute bounded failure with the culprit named and its stack in the log. The underlying node-exit race stays open in #2152, now self-diagnosing — the next occurrence hands us the stuck stack directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
