### PR TITLE
ci(examples): bound C/C++ example runs with a 120s stop-after safety net (#2152)

### DIFF
--- a/examples/benchmark/run.rs
+++ b/examples/benchmark/run.rs
@@ -1,6 +1,6 @@
-use dora_cli::{BuildConfig, build, run};
+use dora_cli::{BuildConfig, Executable, RunCommand, build};
 use eyre::Context;
-use std::path::Path;
+use std::{path::Path, time::Duration};
 
 fn main() -> eyre::Result<()> {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
@@ -13,7 +13,12 @@ fn main() -> eyre::Result<()> {
         ..Default::default()
     })?;
 
-    run("dataflow.yml".to_string(), false)?;
+    // Bound the run so a wedged node fails fast via the daemon's stop
+    // escalation instead of hanging until the CI step timeout (#2152).
+    // A healthy run self-terminates quickly.
+    let mut run = RunCommand::new("dataflow.yml".to_string());
+    run.stop_after = Some(Duration::from_secs(120));
+    run.execute()?;
 
     Ok(())
 }

--- a/examples/c++-arrow-dataflow/run.rs
+++ b/examples/c++-arrow-dataflow/run.rs
@@ -1,5 +1,6 @@
+use dora_cli::{Executable, RunCommand};
 use eyre::{Context, bail};
-use std::{env::consts::EXE_SUFFIX, path::Path, process::Command};
+use std::{env::consts::EXE_SUFFIX, path::Path, process::Command, time::Duration};
 
 struct ArrowConfig {
     cflags: String,
@@ -51,7 +52,12 @@ fn main() -> eyre::Result<()> {
         ],
     )?;
 
-    dora_cli::run("dataflow.yml".to_string(), false)?;
+    // Bound the run so a wedged node fails fast via the daemon's stop
+    // escalation instead of hanging until the CI step timeout (#2152).
+    // A healthy run self-terminates quickly.
+    let mut run = RunCommand::new("dataflow.yml".to_string());
+    run.stop_after = Some(Duration::from_secs(120));
+    run.execute()?;
 
     Ok(())
 }

--- a/examples/c++-dataflow/run.rs
+++ b/examples/c++-dataflow/run.rs
@@ -1,7 +1,9 @@
+use dora_cli::{Executable, RunCommand};
 use eyre::{Context, bail};
 use std::{
     env::consts::{DLL_PREFIX, DLL_SUFFIX, EXE_SUFFIX},
     path::Path,
+    time::Duration,
 };
 
 fn main() -> eyre::Result<()> {
@@ -92,7 +94,12 @@ fn main() -> eyre::Result<()> {
 
     build_package("dora-runtime")?;
 
-    dora_cli::run("dataflow.yml".to_string(), false)?;
+    // Bound the run so a wedged node fails fast via the daemon's stop
+    // escalation instead of hanging until the CI step timeout (#2152).
+    // A healthy run self-terminates quickly.
+    let mut run = RunCommand::new("dataflow.yml".to_string());
+    run.stop_after = Some(Duration::from_secs(120));
+    run.execute()?;
 
     Ok(())
 }

--- a/examples/c-dataflow/run.rs
+++ b/examples/c-dataflow/run.rs
@@ -1,7 +1,9 @@
+use dora_cli::{Executable, RunCommand};
 use eyre::{Context, bail};
 use std::{
     env::consts::{DLL_PREFIX, DLL_SUFFIX, EXE_SUFFIX},
     path::Path,
+    time::Duration,
 };
 
 fn main() -> eyre::Result<()> {
@@ -18,7 +20,12 @@ fn main() -> eyre::Result<()> {
     build_package("dora-operator-api-c")?;
     build_c_operator(root)?;
 
-    dora_cli::run("dataflow.yml".to_string(), false)?;
+    // Bound the run so a wedged node fails fast via the daemon's stop
+    // escalation instead of hanging until the CI step timeout (#2152).
+    // A healthy run self-terminates quickly.
+    let mut run = RunCommand::new("dataflow.yml".to_string());
+    run.stop_after = Some(Duration::from_secs(120));
+    run.execute()?;
 
     Ok(())
 }

--- a/examples/cmake-dataflow/run.rs
+++ b/examples/cmake-dataflow/run.rs
@@ -1,5 +1,6 @@
+use dora_cli::{Executable, RunCommand};
 use eyre::{Context, bail};
-use std::path::Path;
+use std::{path::Path, time::Duration};
 
 fn main() -> eyre::Result<()> {
     if cfg!(windows) {
@@ -36,7 +37,12 @@ fn main() -> eyre::Result<()> {
 
     build_package("dora-runtime")?;
 
-    dora_cli::run("dataflow.yml".to_string(), false)?;
+    // Bound the run so a wedged node fails fast via the daemon's stop
+    // escalation instead of hanging until the CI step timeout (#2152).
+    // A healthy run self-terminates quickly.
+    let mut run = RunCommand::new("dataflow.yml".to_string());
+    run.stop_after = Some(Duration::from_secs(120));
+    run.execute()?;
 
     Ok(())
 }

--- a/examples/rust-dataflow-url/run.rs
+++ b/examples/rust-dataflow-url/run.rs
@@ -1,6 +1,6 @@
-use dora_cli::{BuildConfig, build, run};
+use dora_cli::{BuildConfig, Executable, RunCommand, build};
 use eyre::Context;
-use std::path::Path;
+use std::{path::Path, time::Duration};
 
 fn main() -> eyre::Result<()> {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
@@ -13,7 +13,12 @@ fn main() -> eyre::Result<()> {
         ..Default::default()
     })?;
 
-    run("dataflow.yml".to_string(), false)?;
+    // Bound the run so a wedged node fails fast via the daemon's stop
+    // escalation instead of hanging until the CI step timeout (#2152).
+    // A healthy run self-terminates quickly.
+    let mut run = RunCommand::new("dataflow.yml".to_string());
+    run.stop_after = Some(Duration::from_secs(120));
+    run.execute()?;
 
     Ok(())
 }

--- a/examples/rust-dataflow/run.rs
+++ b/examples/rust-dataflow/run.rs
@@ -1,6 +1,6 @@
-use dora_cli::{BuildConfig, build, run};
+use dora_cli::{BuildConfig, Executable, RunCommand, build};
 use eyre::Context;
-use std::path::Path;
+use std::{path::Path, time::Duration};
 
 fn main() -> eyre::Result<()> {
     let root = Path::new(env!("CARGO_MANIFEST_DIR"));
@@ -20,7 +20,12 @@ fn main() -> eyre::Result<()> {
         ..Default::default()
     })?;
 
-    run(dataflow, false)?;
+    // Bound the run so a wedged node fails fast via the daemon's stop
+    // escalation instead of hanging until the CI step timeout (#2152).
+    // A healthy run self-terminates quickly.
+    let mut run = RunCommand::new(dataflow);
+    run.stop_after = Some(Duration::from_secs(120));
+    run.execute()?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Two consecutive nightlies hung in the Examples job until the 15-minute CI step timeout killed it, after the example's nodes had already finished their work (a wedged node kept the unbounded `dora_cli::run(dataflow, false)` alive with TCP read-timeout spam):

- 2026-06-11 nightly (https://github.com/dora-rs/dora/actions/runs/27331903367) — hung in the **c-dataflow** example (Examples, macos-latest)
- 2026-06-12 nightly (https://github.com/dora-rs/dora/actions/runs/27401997148) — hung in the **C++ Dataflow** example (Examples, ubuntu-latest)

This PR applies the bounded-run pattern from #2125 (commit 2df42101, which already fixed `rust-dataflow-git`) to every remaining example runner that still used the unbounded `run()`: switch to `RunCommand` with `stop_after = Some(Duration::from_secs(120))`. With the bound in place, the daemon's stop escalation (Stop -> 10s -> SIGTERM -> +5s -> SIGKILL) converts a wedge into a loud failure after ~2.5 minutes instead of a silent 15-minute hang. A healthy run self-terminates well before the bound and is unaffected.

This complements the daemon-side finish-straggler watchdog from #2159: that watchdog cannot fire when the wedged node never enters the drain phase — which is exactly what happened in these two hangs. The client-side `stop_after` bound covers that gap.

## Examples bounded

- `examples/c-dataflow/run.rs`
- `examples/c++-dataflow/run.rs`
- `examples/c++-arrow-dataflow/run.rs`
- `examples/cmake-dataflow/run.rs`
- `examples/benchmark/run.rs`
- `examples/rust-dataflow/run.rs`
- `examples/rust-dataflow-url/run.rs`

Not touched: `python-dataflow` / `python-operator-dataflow` (they use the `run(.., true)` uv variant, different call form), ros2 examples (not run in normal CI), `multiple-daemons` (drives coordinator/daemon directly, no `dora_cli::run`), `rust-dataflow-git` (already bounded by 2df42101).

## Test plan

- [x] `cargo check --examples` — green (compiles every touched `run.rs`)
- [x] `cargo clippy --all` (excluding Python packages) `-- -D warnings` — green
- [x] `cargo clippy --examples -- -D warnings` — green
- [x] `cargo fmt --all -- --check` — green
- [x] `typos` on the seven changed files — green
- [ ] Local `cargo run --example c-dataflow` on macOS: the C nodes built and the dataflow launched, but `runtime-node` failed to register due to a pre-existing local environment issue (a stale `dora-runtime` with message format v0.2.1 on PATH vs the workspace's v1.0.0-rc1) — unrelated to this change. Notably, the run still terminated promptly with a loud error instead of hanging, which is the behavior this PR is after. Deferring the end-to-end healthy-run verification to nightly CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
