### PR TITLE
feat(hub): node manifest parsing, JSON schema, and validation (P1.1+P1.3)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,11 +115,16 @@ commands:
           command: |
             uv venv --seed -p 3.12
             echo "export VIRTUAL_ENV=$PWD/.venv" >> "$BASH_ENV"
+            # Dora's example nodes spawn `uv run python` from nested
+            # directories; pin uv to the CI venv that contains the editable
+            # dora package instead of relying on cwd-based discovery.
+            echo "export UV_PYTHON=$PWD/.venv/bin/python" >> "$BASH_ENV"
             echo "export PATH=$PWD/.venv/bin:\$PATH" >> "$BASH_ENV"
             source "$BASH_ENV"
             uv pip install pyarrow
             uv pip install -e apis/python/node
             uv pip install ruff pytest
+            uv run python -c "import dora; print(dora.__file__)"
 
 # ────────────────────────────────────────────────────────────────────
 # Executors

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,10 +115,6 @@ commands:
           command: |
             uv venv --seed -p 3.12
             echo "export VIRTUAL_ENV=$PWD/.venv" >> "$BASH_ENV"
-            # Dora's example nodes spawn `uv run python` from nested
-            # directories; pin uv to the CI venv that contains the editable
-            # dora package instead of relying on cwd-based discovery.
-            echo "export UV_PYTHON=$PWD/.venv/bin/python" >> "$BASH_ENV"
             echo "export PATH=$PWD/.venv/bin:\$PATH" >> "$BASH_ENV"
             source "$BASH_ENV"
             uv pip install pyarrow
@@ -857,6 +853,16 @@ jobs:
             cp target/debug/dora ~/.cargo/bin/dora
             chmod +x ~/.cargo/bin/dora
       - setup-python-uv
+      - run:
+          name: Pin uv to the CI venv for the contract examples
+          # The contract examples spawn `uv run python` from nested example
+          # dirs; pin uv to the venv that holds the editable dora package
+          # rather than cwd-based discovery. Scoped to this job on purpose —
+          # cli-python's template-project nodes need their own per-project env
+          # resolution and break under a global UV_PYTHON pin.
+          command: |
+            echo "export UV_PYTHON=$PWD/.venv/bin/python" >> "$BASH_ENV"
+            source "$BASH_ENV"
       - run:
           name: Run semantic contract tests
           command: >

--- a/.github/workflows/regenerate-schemas.yml
+++ b/.github/workflows/regenerate-schemas.yml
@@ -25,11 +25,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if git diff --exit-code -- libraries/core/dora-schema.json; then
+          if git diff --exit-code -- libraries/core/dora-schema.json libraries/core/dora-node-schema.json; then
               echo "Schema file was not changed"
           else
               git switch -c schema-update-for-${{ github.sha }}
-              git add libraries/core/dora-schema.json
+              git add libraries/core/dora-schema.json libraries/core/dora-node-schema.json
               git config user.email "dora-bot@phil-opp.com"
               git config user.name "Dora Bot"
               git commit -m "Update JSON schema for ${{ github.sha }}"

--- a/.gitignore
+++ b/.gitignore
@@ -68,7 +68,9 @@ share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
-MANIFEST
+# (the distutils `MANIFEST` pattern was removed here: nothing in this repo
+# produces one, and on case-insensitive filesystems it silently hides Rust
+# `manifest/` module directories from git)
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1822,6 +1822,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "schemars 1.2.1",
+ "semver",
  "serde",
  "serde-with-expand-env",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,7 @@ git2 = { version = "0.20.4", features = ["vendored-openssl"] }
 serde_yaml = "0.9.33"
 zenoh = { version = "~1.8", default-features = false, features = ["shared-memory", "unstable", "transport_tcp", "transport_udp", "transport_unixsock-stream"] }
 serde_json = "1.0.145"
+semver = { version = "1.0.23", features = ["serde"] }
 thiserror = "2.0"
 colored = "3.0.0"
 inquire = { version = "0.7.5", default-features = false }

--- a/binaries/cli/src/command/mod.rs
+++ b/binaries/cli/src/command/mod.rs
@@ -388,6 +388,21 @@ mod tests {
     }
 
     #[test]
+    fn parse_validate_node_manifest() {
+        parse_ok(&["dora", "validate", "--node-manifest", "dora-node.yml"]);
+        // a dataflow and --node-manifest are mutually exclusive
+        parse_err(&[
+            "dora",
+            "validate",
+            "dataflow.yml",
+            "--node-manifest",
+            "dora-node.yml",
+        ]);
+        // one of the two is required
+        parse_err(&["dora", "validate"]);
+    }
+
+    #[test]
     fn parse_new() {
         parse_ok(&["dora", "new", "test"]);
     }

--- a/binaries/cli/src/command/mod.rs
+++ b/binaries/cli/src/command/mod.rs
@@ -400,6 +400,14 @@ mod tests {
         ]);
         // one of the two is required
         parse_err(&["dora", "validate"]);
+        // --strict-types is dataflow-only
+        parse_err(&[
+            "dora",
+            "validate",
+            "--node-manifest",
+            "dora-node.yml",
+            "--strict-types",
+        ]);
     }
 
     #[test]

--- a/binaries/cli/src/command/validate.rs
+++ b/binaries/cli/src/command/validate.rs
@@ -11,7 +11,7 @@ use eyre::{Context, bail};
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, clap::Args)]
-/// Validate a dataflow YAML file and check type annotations
+/// Validate a dataflow YAML file (or a node manifest) and check type annotations
 pub struct Validate {
     /// Path to the dataflow descriptor file
     #[clap(
@@ -22,7 +22,7 @@ pub struct Validate {
     )]
     dataflow: Option<PathBuf>,
     /// Treat type warnings as errors (non-zero exit code)
-    #[clap(long, action)]
+    #[clap(long, action, conflicts_with = "node_manifest")]
     strict_types: bool,
     /// Validate a node manifest (dora-node.yml) instead of a dataflow
     #[clap(long, value_name = "PATH", value_hint = clap::ValueHint::FilePath)]

--- a/binaries/cli/src/command/validate.rs
+++ b/binaries/cli/src/command/validate.rs
@@ -4,87 +4,118 @@ use dora_core::{
         Descriptor, DescriptorExt,
         validate::{check_type_annotations_full, check_wiring},
     },
+    manifest::NodeManifest,
     types::TypeRegistry,
 };
 use eyre::{Context, bail};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, clap::Args)]
 /// Validate a dataflow YAML file and check type annotations
 pub struct Validate {
     /// Path to the dataflow descriptor file
-    #[clap(value_name = "PATH", value_hint = clap::ValueHint::FilePath)]
-    dataflow: PathBuf,
+    #[clap(
+        value_name = "PATH",
+        value_hint = clap::ValueHint::FilePath,
+        required_unless_present = "node_manifest",
+        conflicts_with = "node_manifest"
+    )]
+    dataflow: Option<PathBuf>,
     /// Treat type warnings as errors (non-zero exit code)
     #[clap(long, action)]
     strict_types: bool,
+    /// Validate a node manifest (dora-node.yml) instead of a dataflow
+    #[clap(long, value_name = "PATH", value_hint = clap::ValueHint::FilePath)]
+    node_manifest: Option<PathBuf>,
 }
 
 impl Executable for Validate {
     fn execute(self) -> eyre::Result<()> {
-        let working_dir = self
+        if let Some(manifest_path) = &self.node_manifest {
+            return validate_node_manifest(manifest_path);
+        }
+        let dataflow = self
             .dataflow
-            .parent()
-            .filter(|p| !p.as_os_str().is_empty())
-            .unwrap_or_else(|| std::path::Path::new("."));
-
-        println!("Validating {}...", self.dataflow.display());
-
-        // Parse and expand modules (no runtime needed)
-        let descriptor = Descriptor::blocking_read(&self.dataflow)
-            .with_context(|| {
-                format!(
-                    "failed to read dataflow at `{}`\n\n  \
-                     hint: check the file exists and is valid YAML",
-                    self.dataflow.display()
-                )
-            })?
-            .expand(working_dir)
-            .context("failed to expand modules in dataflow descriptor")?;
-
-        // Check input/output wiring (no build required)
-        check_wiring(&descriptor).context("wiring check failed")?;
-        println!("Input/output wiring OK.");
-
-        let strict = self.strict_types || descriptor.strict_types.unwrap_or(false);
-
-        // Load user types if a types/ directory exists
-        let mut registry = TypeRegistry::new();
-        let types_dir = working_dir.join("types");
-        if types_dir.is_dir() {
-            match registry.load_from_dir(&types_dir) {
-                Ok(count) if count > 0 => {
-                    println!("Loaded {count} user-defined type(s) from types/");
-                }
-                Err(e) => {
-                    bail!("failed to load user types: {e}");
-                }
-                _ => {}
-            }
-        }
-
-        // Run type annotation checks
-        let result = check_type_annotations_full(&descriptor, &registry, strict);
-
-        // Print inferences
-        for inf in &result.inferences {
-            println!("  {inf}");
-        }
-
-        if result.warnings.is_empty() {
-            println!("All type annotations OK.");
-        } else {
-            println!("Type warnings:");
-            for w in &result.warnings {
-                println!("  - {w}");
-            }
-            let count = result.warnings.len();
-            println!("{count} type warning(s) found.");
-            if strict {
-                bail!("{count} type warning(s) found (--strict mode)");
-            }
-        }
-
-        Ok(())
+            .expect("clap guarantees dataflow when --node-manifest is absent");
+        validate_dataflow(&dataflow, self.strict_types)
     }
+}
+
+fn validate_node_manifest(path: &Path) -> eyre::Result<()> {
+    println!("Validating node manifest {}...", path.display());
+    let manifest = NodeManifest::read(path)?;
+
+    // Built-in std/ types only; types shipped in the manifest's `types:`
+    // block are resolved by validate() against the manifest itself.
+    let registry = TypeRegistry::new();
+    manifest.validate_strict(&registry)?;
+
+    println!("Node manifest OK.");
+    Ok(())
+}
+
+fn validate_dataflow(dataflow: &Path, strict_types: bool) -> eyre::Result<()> {
+    let working_dir = dataflow
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| std::path::Path::new("."));
+
+    println!("Validating {}...", dataflow.display());
+
+    // Parse and expand modules (no runtime needed)
+    let descriptor = Descriptor::blocking_read(dataflow)
+        .with_context(|| {
+            format!(
+                "failed to read dataflow at `{}`\n\n  \
+                     hint: check the file exists and is valid YAML",
+                dataflow.display()
+            )
+        })?
+        .expand(working_dir)
+        .context("failed to expand modules in dataflow descriptor")?;
+
+    // Check input/output wiring (no build required)
+    check_wiring(&descriptor).context("wiring check failed")?;
+    println!("Input/output wiring OK.");
+
+    let strict = strict_types || descriptor.strict_types.unwrap_or(false);
+
+    // Load user types if a types/ directory exists
+    let mut registry = TypeRegistry::new();
+    let types_dir = working_dir.join("types");
+    if types_dir.is_dir() {
+        match registry.load_from_dir(&types_dir) {
+            Ok(count) if count > 0 => {
+                println!("Loaded {count} user-defined type(s) from types/");
+            }
+            Err(e) => {
+                bail!("failed to load user types: {e}");
+            }
+            _ => {}
+        }
+    }
+
+    // Run type annotation checks
+    let result = check_type_annotations_full(&descriptor, &registry, strict);
+
+    // Print inferences
+    for inf in &result.inferences {
+        println!("  {inf}");
+    }
+
+    if result.warnings.is_empty() {
+        println!("All type annotations OK.");
+    } else {
+        println!("Type warnings:");
+        for w in &result.warnings {
+            println!("  - {w}");
+        }
+        let count = result.warnings.len();
+        println!("{count} type warning(s) found.");
+        if strict {
+            bail!("{count} type warning(s) found (--strict mode)");
+        }
+    }
+
+    Ok(())
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1055,16 +1055,19 @@ dora graph dataflow.yml --mermaid
 
 #### `dora validate`
 
-Validate a dataflow YAML file and check type annotations.
+Validate a dataflow YAML file and check type annotations, or validate a node
+manifest (`dora-node.yml`).
 
 ```
 dora validate <PATH> [OPTIONS]
+dora validate --node-manifest <PATH>
 ```
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `<PATH>` | required | Dataflow descriptor path |
+| `<PATH>` | required unless `--node-manifest` | Dataflow descriptor path |
 | `--strict-types` | false | Treat warnings as errors (non-zero exit code for CI) |
+| `--node-manifest <PATH>` | — | Validate a node manifest instead of a dataflow (schema, entrypoint confinement, env deny-list, type URNs) |
 
 Checks:
 1. **Key existence**: `output_types`/`input_types` keys exist in the corresponding `outputs`/`inputs` lists
@@ -1084,6 +1087,9 @@ dora validate dataflow.yml
 
 # Strict mode for CI (exit 1 on warnings)
 dora validate --strict-types dataflow.yml
+
+# Validate a node manifest (always strict)
+dora validate --node-manifest dora-node.yml
 ```
 
 See the [Type Annotations Guide](types.md) for the full type library and usage details.

--- a/docs/plan-node-hub.md
+++ b/docs/plan-node-hub.md
@@ -318,8 +318,9 @@ env:                          # configuration surface, documented + typed.
     type: float
     default: 0.4
 
-types: []                     # optional: custom type defs shipped with the
-                              # node, loaded into the TypeRegistry (§6.3)
+types: {}                     # optional: custom type defs shipped with the
+                              # node (a map of URN -> def), loaded into the
+                              # TypeRegistry (§6.3)
 
 requirements:                 # informational: surfaced by `hub info` and at
   hardware: []                # build start. v1 actively probes only `cuda`;

--- a/libraries/core/Cargo.toml
+++ b/libraries/core/Cargo.toml
@@ -29,6 +29,7 @@ serde-with-expand-env = "1.1.0"
 tokio = { workspace = true, features = ["fs", "io-util", "macros", "process", "sync", "rt"] }
 tokio-stream = { workspace = true, features = ["io-util"] }
 schemars = "1.0.4"
+semver = { workspace = true }
 serde_json = { workspace = true }
 log = { version = "0.4.21", features = ["serde"] }
 dunce = "1.0.5"

--- a/libraries/core/dora-node-schema.json
+++ b/libraries/core/dora-node-schema.json
@@ -1,0 +1,368 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "NodeManifest",
+  "description": "A node manifest (`dora-node.yml`).\n\nHolds only what native package manifests *cannot*: dora contracts and dora\nwiring. Name, version, license, and dependencies are read from\n`pyproject.toml`/`Cargo.toml` at publish time where possible.",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "Manifest schema version. Currently always `1`.",
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0
+    },
+    "categories": {
+      "description": "Categories from the fixed list (spec §7.6); drive search facets.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Category"
+      }
+    },
+    "description": {
+      "description": "One-line description, shown by `dora hub search`/`info`.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "dora": {
+      "description": "Supported dora version range (semver requirement, e.g. `>=0.4`).",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "entrypoint": {
+      "description": "What to run, relative to the node's working dir.\n\nPython: a console script on the managed-env PATH (e.g. `dora-yolo`).\nRust/C/C++: the build output, e.g. `target/release/dora-yolo`.\nMust be a relative path without `..` components.",
+      "type": "string"
+    },
+    "env": {
+      "description": "Documented + typed configuration surface (environment variables).\nSecurity-sensitive names (`PATH`, `PYTHONPATH`, `LD_*`, `DYLD_*`) are\nrejected at validation.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/EnvVarDef"
+      }
+    },
+    "example": {
+      "description": "Example dataflow snippet shown by `dora hub info` (YAML node list).",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "inputs": {
+      "description": "Typed input ports. May be empty (source nodes).",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/PortDef"
+      }
+    },
+    "keywords": {
+      "description": "Free-form search keywords.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "name": {
+      "description": "Package name. Defaults to `[project].name` / `[package].name` of the\nnative manifest at publish time; required for standalone validation.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "namespace": {
+      "description": "Index namespace the package publishes under (a GitHub org or user).",
+      "type": "string"
+    },
+    "outputs": {
+      "description": "Typed output ports. May be empty (sink nodes).",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/PortDef"
+      }
+    },
+    "platforms": {
+      "description": "Optional platform allowlist, e.g. `[linux-x86_64, macos-aarch64]`.\nEmpty means all platforms.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "requirements": {
+      "description": "Informational hardware/system requirements; surfaced by `dora hub\ninfo` and at build start, never auto-installed.",
+      "$ref": "#/$defs/Requirements"
+    },
+    "runtime": {
+      "description": "Language runtime of the node.",
+      "$ref": "#/$defs/Runtime"
+    },
+    "types": {
+      "description": "Custom type definitions shipped with the node, keyed by full URN\n(e.g. `acme/lidar/v1/PointCloud`). Must live under the package's\nnamespace; `std/` is rejected.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/TypeDef"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "apiVersion",
+    "namespace",
+    "runtime",
+    "entrypoint"
+  ],
+  "$defs": {
+    "Category": {
+      "description": "Fixed category list (spec §7.6). Extended by index PR + discussion.",
+      "type": "string",
+      "enum": [
+        "sensor",
+        "actuator",
+        "robot",
+        "transform",
+        "filter",
+        "ml-inference",
+        "llm",
+        "speech",
+        "communication",
+        "recorder",
+        "visualization",
+        "simulator",
+        "debug"
+      ]
+    },
+    "EnvValue": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "type": "number",
+          "format": "double"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "EnvVarDef": {
+      "description": "A documented environment variable.",
+      "type": "object",
+      "properties": {
+        "default": {
+          "description": "Default value used when the variable is not set in the dataflow.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EnvValue"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "description": {
+          "description": "Human-readable description.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type": {
+          "description": "Value type: `string` (default), `int`, `float`, or `bool`.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EnvVarType"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "EnvVarType": {
+      "description": "Declared value type of an environment variable.",
+      "type": "string",
+      "enum": [
+        "string",
+        "int",
+        "float",
+        "bool"
+      ]
+    },
+    "FieldDef": {
+      "description": "A field definition within a struct type.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Field name",
+          "type": "string"
+        },
+        "nullable": {
+          "description": "Whether the field is nullable (default: true)",
+          "type": "boolean",
+          "default": true
+        },
+        "type": {
+          "description": "Arrow type name or URN reference",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "type"
+      ]
+    },
+    "MetadataDef": {
+      "description": "Metadata key required on outputs of a given type.",
+      "type": "object",
+      "properties": {
+        "description": {
+          "description": "Description of the metadata key",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "key": {
+          "description": "Key name that must be present in message metadata",
+          "type": "string"
+        }
+      },
+      "required": [
+        "key"
+      ]
+    },
+    "PortDef": {
+      "description": "A typed input or output port.",
+      "type": "object",
+      "properties": {
+        "description": {
+          "description": "Human-readable description of the port.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "required": {
+          "description": "Whether a dataflow must wire this input (defaults to `true`; only\nmeaningful on inputs — validation rejects it on outputs).",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "type": {
+          "description": "Type URN (e.g. `std/media/v1/Image`). Omitted = untyped; validation\nskips the port.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "Requirements": {
+      "description": "Informational hardware/system requirements (spec §5): documentation\nsurfaced by `dora hub info`, never auto-installed.",
+      "type": "object",
+      "properties": {
+        "hardware": {
+          "description": "Hardware requirements, e.g. `[cuda]`. v1 actively probes only `cuda`.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "system": {
+          "description": "System package requirements, keyed by package manager or platform.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "Runtime": {
+      "description": "Language runtime of a node.",
+      "type": "string",
+      "enum": [
+        "python",
+        "rust",
+        "c",
+        "cpp"
+      ]
+    },
+    "TypeDef": {
+      "description": "A single type definition from the standard type library.",
+      "type": "object",
+      "properties": {
+        "arrow": {
+          "description": "Arrow data type name (e.g. \"Float32\", \"Struct\", \"LargeBinary\")",
+          "type": "string"
+        },
+        "description": {
+          "description": "Human-readable description",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "fields": {
+          "description": "Struct field definitions (only for Struct arrow types)",
+          "type": "array",
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/FieldDef"
+          }
+        },
+        "metadata": {
+          "description": "Required metadata keys",
+          "type": "array",
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/MetadataDef"
+          }
+        },
+        "params": {
+          "description": "Type parameters (e.g. sample_type for AudioFrame)",
+          "type": "array",
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/TypeParam"
+          }
+        }
+      },
+      "required": [
+        "arrow"
+      ]
+    },
+    "TypeParam": {
+      "description": "A type parameter declaration (e.g. `sample_type` on AudioFrame).",
+      "type": "object",
+      "properties": {
+        "default": {
+          "description": "Default value (used when parameter is not specified)",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "name": {
+          "description": "Parameter name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    }
+  }
+}

--- a/libraries/core/dora-node-schema.json
+++ b/libraries/core/dora-node-schema.json
@@ -131,7 +131,8 @@
         "debug"
       ]
     },
-    "EnvValue": {
+    "EnvDefault": {
+      "description": "A literal env default value.\n\nDeliberately *not* the descriptor's `EnvValue`: that type expands `$VAR`\nreferences against the local environment at deserialization time, which is\nright for a dataflow being deployed but wrong for a manifest — manifests\nare published verbatim into an index, so defaults must stay literal and\nparse identically on every machine.",
       "anyOf": [
         {
           "type": "boolean"
@@ -157,7 +158,7 @@
           "description": "Default value used when the variable is not set in the dataflow.",
           "anyOf": [
             {
-              "$ref": "#/$defs/EnvValue"
+              "$ref": "#/$defs/EnvDefault"
             },
             {
               "type": "null"
@@ -311,13 +312,11 @@
           "type": [
             "string",
             "null"
-          ],
-          "default": null
+          ]
         },
         "fields": {
           "description": "Struct field definitions (only for Struct arrow types)",
           "type": "array",
-          "default": [],
           "items": {
             "$ref": "#/$defs/FieldDef"
           }
@@ -325,7 +324,6 @@
         "metadata": {
           "description": "Required metadata keys",
           "type": "array",
-          "default": [],
           "items": {
             "$ref": "#/$defs/MetadataDef"
           }
@@ -333,7 +331,6 @@
         "params": {
           "description": "Type parameters (e.g. sample_type for AudioFrame)",
           "type": "array",
-          "default": [],
           "items": {
             "$ref": "#/$defs/TypeParam"
           }

--- a/libraries/core/src/bin/generate_schema.rs
+++ b/libraries/core/src/bin/generate_schema.rs
@@ -1,5 +1,6 @@
 use std::{env, path::Path};
 
+use dora_core::manifest::NodeManifest;
 use dora_message::descriptor::Descriptor;
 use schemars::schema_for;
 
@@ -39,4 +40,12 @@ fn main() {
 
     // write to file
     std::fs::write(new_file_path, raw_schema).expect("Could not write schema to file");
+
+    // Node manifest schema (dora-node.yml, see docs/plan-node-hub.md §5)
+    let node_schema = schema_for!(NodeManifest);
+    let raw_node_schema = serde_json::to_string_pretty(&node_schema)
+        .expect("Could not serialize node manifest schema to json");
+    let node_schema_path = Path::new(&manifest_dir).join("dora-node-schema.json");
+    std::fs::write(node_schema_path, raw_node_schema)
+        .expect("Could not write node manifest schema to file");
 }

--- a/libraries/core/src/lib.rs
+++ b/libraries/core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod build;
 pub mod descriptor;
 #[cfg(feature = "type-inference")]
 pub mod inference;
+pub mod manifest;
 pub mod metadata;
 pub mod topics;
 pub mod types;

--- a/libraries/core/src/manifest/mod.rs
+++ b/libraries/core/src/manifest/mod.rs
@@ -1,0 +1,380 @@
+//! Node manifest (`dora-node.yml`) — the typed, dora-specific description of
+//! a node: contracts, entry point, env/config surface.
+//!
+//! See `docs/plan-node-hub.md` §5 for the format specification. The manifest
+//! lives next to the node's native package manifest (`pyproject.toml` /
+//! `Cargo.toml`) and is copied verbatim into a hub index entry at publish
+//! time, so discovery never needs to fetch source.
+
+pub mod validate;
+
+use std::{collections::BTreeMap, path::Path};
+
+use eyre::Context;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::types::TypeDef;
+use dora_message::descriptor::EnvValue;
+
+/// Conventional file name of a node manifest.
+pub const MANIFEST_FILENAME: &str = "dora-node.yml";
+
+/// The manifest schema version this library reads and writes.
+pub const MANIFEST_API_VERSION: u64 = 1;
+
+/// A node manifest (`dora-node.yml`).
+///
+/// Holds only what native package manifests *cannot*: dora contracts and dora
+/// wiring. Name, version, license, and dependencies are read from
+/// `pyproject.toml`/`Cargo.toml` at publish time where possible.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct NodeManifest {
+    /// Manifest schema version. Currently always `1`.
+    #[serde(rename = "apiVersion")]
+    pub api_version: u64,
+
+    /// Package name. Defaults to `[project].name` / `[package].name` of the
+    /// native manifest at publish time; required for standalone validation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    /// Index namespace the package publishes under (a GitHub org or user).
+    pub namespace: String,
+
+    /// One-line description, shown by `dora hub search`/`info`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// Categories from the fixed list (spec §7.6); drive search facets.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub categories: Vec<Category>,
+
+    /// Free-form search keywords.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub keywords: Vec<String>,
+
+    /// Language runtime of the node.
+    pub runtime: Runtime,
+
+    /// What to run, relative to the node's working dir.
+    ///
+    /// Python: a console script on the managed-env PATH (e.g. `dora-yolo`).
+    /// Rust/C/C++: the build output, e.g. `target/release/dora-yolo`.
+    /// Must be a relative path without `..` components.
+    pub entrypoint: String,
+
+    /// Optional platform allowlist, e.g. `[linux-x86_64, macos-aarch64]`.
+    /// Empty means all platforms.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub platforms: Vec<String>,
+
+    /// Supported dora version range (semver requirement, e.g. `>=0.4`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dora: Option<String>,
+
+    /// Typed input ports. May be empty (source nodes).
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub inputs: BTreeMap<String, PortDef>,
+
+    /// Typed output ports. May be empty (sink nodes).
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub outputs: BTreeMap<String, PortDef>,
+
+    /// Documented + typed configuration surface (environment variables).
+    /// Security-sensitive names (`PATH`, `PYTHONPATH`, `LD_*`, `DYLD_*`) are
+    /// rejected at validation.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub env: BTreeMap<String, EnvVarDef>,
+
+    /// Custom type definitions shipped with the node, keyed by full URN
+    /// (e.g. `acme/lidar/v1/PointCloud`). Must live under the package's
+    /// namespace; `std/` is rejected.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub types: BTreeMap<String, TypeDef>,
+
+    /// Informational hardware/system requirements; surfaced by `dora hub
+    /// info` and at build start, never auto-installed.
+    #[serde(default, skip_serializing_if = "Requirements::is_empty")]
+    pub requirements: Requirements,
+
+    /// Example dataflow snippet shown by `dora hub info` (YAML node list).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub example: Option<String>,
+}
+
+/// Language runtime of a node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum Runtime {
+    Python,
+    Rust,
+    C,
+    Cpp,
+}
+
+/// Fixed category list (spec §7.6). Extended by index PR + discussion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum Category {
+    Sensor,
+    Actuator,
+    Robot,
+    Transform,
+    Filter,
+    MlInference,
+    Llm,
+    Speech,
+    Communication,
+    Recorder,
+    Visualization,
+    Simulator,
+    Debug,
+}
+
+/// A typed input or output port.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct PortDef {
+    /// Type URN (e.g. `std/media/v1/Image`). Omitted = untyped; validation
+    /// skips the port.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<String>,
+
+    /// Whether a dataflow must wire this input (defaults to `true`; only
+    /// meaningful on inputs — validation rejects it on outputs).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub required: Option<bool>,
+
+    /// Human-readable description of the port.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+impl PortDef {
+    /// Whether a dataflow must wire this input (defaults to `true`).
+    pub fn is_required(&self) -> bool {
+        self.required.unwrap_or(true)
+    }
+}
+
+/// A documented environment variable.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct EnvVarDef {
+    /// Value type: `string` (default), `int`, `float`, or `bool`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<EnvVarType>,
+
+    /// Default value used when the variable is not set in the dataflow.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default: Option<EnvValue>,
+
+    /// Human-readable description.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// Declared value type of an environment variable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum EnvVarType {
+    String,
+    Int,
+    Float,
+    Bool,
+}
+
+/// Informational hardware/system requirements (spec §5): documentation
+/// surfaced by `dora hub info`, never auto-installed.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct Requirements {
+    /// Hardware requirements, e.g. `[cuda]`. v1 actively probes only `cuda`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub hardware: Vec<String>,
+
+    /// System package requirements, keyed by package manager or platform.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub system: BTreeMap<String, String>,
+}
+
+impl Requirements {
+    fn is_empty(&self) -> bool {
+        self.hardware.is_empty() && self.system.is_empty()
+    }
+}
+
+/// Upper bound on manifest size. Manifests are small by construction; the cap
+/// bounds memory for the YAML parse of untrusted index content.
+pub const MAX_MANIFEST_SIZE: usize = 1024 * 1024;
+
+impl NodeManifest {
+    /// Parse a manifest from YAML.
+    pub fn parse(yaml: &str) -> eyre::Result<Self> {
+        if yaml.len() > MAX_MANIFEST_SIZE {
+            eyre::bail!(
+                "node manifest too large ({} bytes, max {MAX_MANIFEST_SIZE})",
+                yaml.len()
+            );
+        }
+        serde_yaml::from_str(yaml).context("failed to parse node manifest")
+    }
+
+    /// Read and parse a manifest file.
+    pub fn read(path: &Path) -> eyre::Result<Self> {
+        // check the size before reading so the cap also bounds the read
+        let len = std::fs::metadata(path)
+            .with_context(|| format!("failed to read node manifest at `{}`", path.display()))?
+            .len();
+        if len > MAX_MANIFEST_SIZE as u64 {
+            eyre::bail!(
+                "node manifest at `{}` too large ({len} bytes, max {MAX_MANIFEST_SIZE})",
+                path.display()
+            );
+        }
+        let content = std::fs::read_to_string(path)
+            .with_context(|| format!("failed to read node manifest at `{}`", path.display()))?;
+        Self::parse(&content)
+            .with_context(|| format!("invalid node manifest at `{}`", path.display()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The full example manifest from spec §5.
+    const SPEC_EXAMPLE: &str = r#"
+apiVersion: 1
+name: dora-yolo
+namespace: dora-rs
+description: YOLO object detection on camera frames
+categories: [ml-inference]
+keywords: [vision, detection, yolo]
+
+runtime: python
+entrypoint: dora-yolo
+platforms: []
+dora: ">=0.4"
+
+inputs:
+  image:
+    type: std/media/v1/Image
+    required: true
+    description: BGR frame to run detection on
+outputs:
+  bbox:
+    type: std/vision/v1/BBox2D
+    description: detected bounding boxes
+
+env:
+  MODEL:
+    default: yolov8n.pt
+    description: model weights file or hub id
+  CONFIDENCE:
+    type: float
+    default: 0.4
+
+requirements:
+  hardware: []
+  system: {}
+
+example: |
+  - id: detector
+    hub: dora-yolo@^0.5
+    inputs:
+      image: camera/image
+    outputs:
+      - bbox
+"#;
+
+    #[test]
+    fn parses_spec_example() {
+        let m = NodeManifest::parse(SPEC_EXAMPLE).unwrap();
+        assert_eq!(m.api_version, 1);
+        assert_eq!(m.name.as_deref(), Some("dora-yolo"));
+        assert_eq!(m.namespace, "dora-rs");
+        assert_eq!(m.runtime, Runtime::Python);
+        assert_eq!(m.entrypoint, "dora-yolo");
+        assert_eq!(m.categories, vec![Category::MlInference]);
+        assert_eq!(
+            m.inputs["image"].r#type.as_deref(),
+            Some("std/media/v1/Image")
+        );
+        assert!(m.inputs["image"].is_required());
+        assert_eq!(
+            m.outputs["bbox"].r#type.as_deref(),
+            Some("std/vision/v1/BBox2D")
+        );
+        assert_eq!(m.env["CONFIDENCE"].r#type, Some(EnvVarType::Float));
+        assert!(m.example.is_some());
+    }
+
+    #[test]
+    fn ports_may_be_empty() {
+        // sinks have no outputs; sources no inputs (spec D9)
+        let m = NodeManifest::parse(
+            r#"
+apiVersion: 1
+name: dora-recorder
+namespace: dora-rs
+runtime: rust
+entrypoint: target/release/dora-recorder
+inputs:
+  data:
+    type: std/core/v1/Bytes
+"#,
+        )
+        .unwrap();
+        assert!(m.outputs.is_empty());
+        assert_eq!(m.inputs.len(), 1);
+    }
+
+    #[test]
+    fn unknown_fields_rejected() {
+        let err = NodeManifest::parse(
+            r#"
+apiVersion: 1
+name: x
+namespace: y
+runtime: python
+entrypoint: x
+no_such_field: true
+"#,
+        )
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("no_such_field"), "{err:#}");
+    }
+
+    #[test]
+    fn checked_in_schema_is_current() {
+        let schema = schemars::schema_for!(NodeManifest);
+        let expected = serde_json::to_value(&schema).unwrap();
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("dora-node-schema.json");
+        let on_disk: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(
+            on_disk, expected,
+            "dora-node-schema.json is stale — run `cargo run -p dora-core --bin generate_schema`"
+        );
+    }
+
+    #[test]
+    fn rejects_oversized_manifest() {
+        let huge = format!("apiVersion: 1\n# {}", "x".repeat(MAX_MANIFEST_SIZE));
+        let err = NodeManifest::parse(&huge).unwrap_err();
+        assert!(format!("{err:#}").contains("too large"), "{err:#}");
+    }
+
+    #[test]
+    fn roundtrips_through_serde() {
+        let m = NodeManifest::parse(SPEC_EXAMPLE).unwrap();
+        let yaml = serde_yaml::to_string(&m).unwrap();
+        let again = NodeManifest::parse(&yaml).unwrap();
+        assert_eq!(again.name, m.name);
+        assert_eq!(again.inputs.len(), m.inputs.len());
+        assert_eq!(again.env.len(), m.env.len());
+    }
+}

--- a/libraries/core/src/manifest/mod.rs
+++ b/libraries/core/src/manifest/mod.rs
@@ -15,7 +15,6 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::types::TypeDef;
-use dora_message::descriptor::EnvValue;
 
 /// Conventional file name of a node manifest.
 pub const MANIFEST_FILENAME: &str = "dora-node.yml";
@@ -169,11 +168,27 @@ pub struct EnvVarDef {
 
     /// Default value used when the variable is not set in the dataflow.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub default: Option<EnvValue>,
+    pub default: Option<EnvDefault>,
 
     /// Human-readable description.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+}
+
+/// A literal env default value.
+///
+/// Deliberately *not* the descriptor's `EnvValue`: that type expands `$VAR`
+/// references against the local environment at deserialization time, which is
+/// right for a dataflow being deployed but wrong for a manifest — manifests
+/// are published verbatim into an index, so defaults must stay literal and
+/// parse identically on every machine.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum EnvDefault {
+    Bool(bool),
+    Integer(i64),
+    Float(f64),
+    String(String),
 }
 
 /// Declared value type of an environment variable.
@@ -184,6 +199,18 @@ pub enum EnvVarType {
     Int,
     Float,
     Bool,
+}
+
+impl EnvVarType {
+    /// The lowercase name as written in manifests.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            EnvVarType::String => "string",
+            EnvVarType::Int => "int",
+            EnvVarType::Float => "float",
+            EnvVarType::Bool => "bool",
+        }
+    }
 }
 
 /// Informational hardware/system requirements (spec §5): documentation
@@ -224,17 +251,14 @@ impl NodeManifest {
 
     /// Read and parse a manifest file.
     pub fn read(path: &Path) -> eyre::Result<Self> {
-        // check the size before reading so the cap also bounds the read
-        let len = std::fs::metadata(path)
-            .with_context(|| format!("failed to read node manifest at `{}`", path.display()))?
-            .len();
-        if len > MAX_MANIFEST_SIZE as u64 {
-            eyre::bail!(
-                "node manifest at `{}` too large ({len} bytes, max {MAX_MANIFEST_SIZE})",
-                path.display()
-            );
-        }
-        let content = std::fs::read_to_string(path)
+        use std::io::Read as _;
+        // bound the read itself (not just the parse) — a size check on
+        // metadata alone would miss FIFOs/devices and growing files
+        let file = std::fs::File::open(path)
+            .with_context(|| format!("failed to read node manifest at `{}`", path.display()))?;
+        let mut content = String::new();
+        file.take(MAX_MANIFEST_SIZE as u64 + 1)
+            .read_to_string(&mut content)
             .with_context(|| format!("failed to read node manifest at `{}`", path.display()))?;
         Self::parse(&content)
             .with_context(|| format!("invalid node manifest at `{}`", path.display()))
@@ -346,6 +370,30 @@ no_such_field: true
         )
         .unwrap_err();
         assert!(format!("{err:#}").contains("no_such_field"), "{err:#}");
+    }
+
+    #[test]
+    fn env_defaults_stay_literal() {
+        // EnvDefault must NOT expand `$VAR` against the local environment —
+        // manifests are published verbatim and must parse identically on
+        // every machine (the descriptor's EnvValue would expand here)
+        let m = NodeManifest::parse(
+            r#"
+apiVersion: 1
+name: x
+namespace: y
+runtime: python
+entrypoint: x
+env:
+  MODEL_PATH:
+    default: $HOME/weights.pt
+"#,
+        )
+        .unwrap();
+        assert_eq!(
+            m.env["MODEL_PATH"].default,
+            Some(EnvDefault::String("$HOME/weights.pt".into()))
+        );
     }
 
     #[test]

--- a/libraries/core/src/manifest/validate.rs
+++ b/libraries/core/src/manifest/validate.rs
@@ -51,7 +51,7 @@ const ENV_DENY_EXACT: &[&str] = &[
     "ENV",
     "IFS",
 ];
-const ENV_DENY_PREFIX: &[&str] = &["LD_", "DYLD_"];
+const ENV_DENY_PREFIX: &[&str] = &["LD_", "DYLD_", "DORA_"];
 
 /// Platform identifiers accepted in `platforms:` (spec §5).
 const KNOWN_OS: &[&str] = &["linux", "macos", "windows"];
@@ -326,6 +326,17 @@ fn check_shipped_type_urn(urn: &str, namespace: &str) -> Option<String> {
             "type URN `{urn}` may only contain alphanumerics and `_ - . /`"
         ));
     }
+    // reject path-traversal / empty segments: shipped types are materialized
+    // into cache paths (spec §6.3, P2.12), so a URN like `acme/../../std/x`
+    // must not pass even though it carries the namespace prefix.
+    if urn
+        .split('/')
+        .any(|seg| seg.is_empty() || seg == "." || seg == "..")
+    {
+        return Some(format!(
+            "type URN `{urn}` must not contain empty or `.`/`..` path segments"
+        ));
+    }
     if urn.starts_with("std/") || urn == "std" {
         return Some("shipped types cannot use the `std/` prefix".into());
     }
@@ -538,6 +549,12 @@ outputs:
             "IFS",
             "LD_PRELOAD",
             "DYLD_INSERT_LIBRARIES",
+            // reserved framework control vars (the daemon sets these; a
+            // manifest must not advertise them as its config surface)
+            "DORA_NODE_CONFIG",
+            "DORA_RUNTIME_CONFIG",
+            "DORA_AUTH_TOKEN",
+            "dora_node_config",
         ] {
             let issues = validate(&format!("env:\n  {bad}:\n    default: x\n"));
             assert_eq!(issues.len(), 1, "{bad} should be rejected: {issues:?}");
@@ -591,6 +608,29 @@ outputs:
 "#,
         );
         assert_eq!(issues, vec![]);
+    }
+
+    #[test]
+    fn shipped_type_urn_rejects_path_traversal() {
+        // a `..` segment escapes the namespace even though the URN still
+        // carries the `acme/` prefix — must be rejected before P2.12 ever
+        // turns the URN into a cache path
+        // `minimal` ships namespace `dora-rs`, so traversal URNs keep that
+        // prefix (passing the namespace check) yet must still be rejected.
+        for bad in [
+            "dora-rs/../../std/core/v1/Float32",
+            "dora-rs/lidar/v1/../../../etc/passwd",
+            "dora-rs//lidar/v1/Foo",
+            "dora-rs/./lidar/v1/Foo",
+        ] {
+            let issues = validate(&format!(
+                "types:\n  {bad}:\n    arrow: Struct\n    fields:\n      - name: x\n        type: Float32\n"
+            ));
+            assert!(
+                issues.iter().any(|i| i.message.contains("path segments")),
+                "`{bad}` should be rejected for traversal: {issues:?}"
+            );
+        }
     }
 
     #[test]

--- a/libraries/core/src/manifest/validate.rs
+++ b/libraries/core/src/manifest/validate.rs
@@ -1,0 +1,594 @@
+//! Static validation of node manifests (spec §5/§11).
+//!
+//! This is the core of `dora hub publish --dry-run` and
+//! `dora validate --node-manifest <file>`: schema sanity, entrypoint path
+//! confinement rules, the env-var deny-list, and type-URN resolution.
+
+use semver::VersionReq;
+
+use super::NodeManifest;
+use crate::types::{TypeRegistry, parse_urn};
+
+/// A single validation problem, referencing the manifest field it concerns.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManifestIssue {
+    /// Manifest field the issue concerns (e.g. `entrypoint`, `inputs.image.type`).
+    pub field: String,
+    /// Human-readable problem description.
+    pub message: String,
+}
+
+impl std::fmt::Display for ManifestIssue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // field/message embed untrusted manifest content — strip control
+        // characters so a hostile manifest cannot inject terminal escapes
+        write_sanitized(f, &self.field)?;
+        f.write_str(": ")?;
+        write_sanitized(f, &self.message)
+    }
+}
+
+fn write_sanitized(f: &mut std::fmt::Formatter<'_>, s: &str) -> std::fmt::Result {
+    for c in s.chars().filter(|c| !c.is_control() || *c == '\n') {
+        std::fmt::Write::write_char(f, c)?;
+    }
+    Ok(())
+}
+
+/// Environment variable names that could hijack the loader, the interpreter,
+/// or the shell of the spawned node (spec §11). Compared case-insensitively.
+const ENV_DENY_EXACT: &[&str] = &[
+    "PATH",
+    "PYTHONPATH",
+    "PYTHONHOME",
+    "PYTHONSTARTUP",
+    "PYTHONEXECUTABLE",
+    "PYTHONBREAKPOINT",
+    "VIRTUAL_ENV",
+    "BASH_ENV",
+    "ENV",
+    "IFS",
+];
+const ENV_DENY_PREFIX: &[&str] = &["LD_", "DYLD_"];
+
+/// Platform identifiers accepted in `platforms:` (spec §5).
+const KNOWN_OS: &[&str] = &["linux", "macos", "windows"];
+const KNOWN_ARCH: &[&str] = &["x86_64", "aarch64", "armv7"];
+
+impl NodeManifest {
+    /// Validate the manifest against the schema rules and the given type
+    /// registry. Returns all problems found; an empty vec means valid.
+    pub fn validate(&self, registry: &TypeRegistry) -> Vec<ManifestIssue> {
+        let mut issues = Vec::new();
+        let mut issue = |field: &str, message: String| {
+            issues.push(ManifestIssue {
+                field: field.to_string(),
+                message,
+            });
+        };
+
+        if self.api_version != super::MANIFEST_API_VERSION {
+            issue(
+                "apiVersion",
+                format!(
+                    "unsupported manifest version {} (this dora supports {})",
+                    self.api_version,
+                    super::MANIFEST_API_VERSION
+                ),
+            );
+        }
+
+        match &self.name {
+            None => issue("name", "missing (required)".into()),
+            Some(name) => {
+                if let Some(problem) = check_package_name(name) {
+                    issue("name", problem);
+                }
+            }
+        }
+        if let Some(problem) = check_namespace(&self.namespace) {
+            issue("namespace", problem);
+        }
+
+        if let Some(problem) = check_entrypoint(&self.entrypoint) {
+            issue("entrypoint", problem);
+        }
+
+        for platform in &self.platforms {
+            if let Some(problem) = check_platform(platform) {
+                issue("platforms", problem);
+            }
+        }
+
+        if let Some(req) = &self.dora
+            && VersionReq::parse(req).is_err()
+        {
+            issue("dora", format!("`{req}` is not a valid semver requirement"));
+        }
+
+        for urn in self.types.keys() {
+            if let Some(problem) = check_shipped_type_urn(urn, &self.namespace) {
+                issue(&format!("types.{urn}"), problem);
+            }
+        }
+
+        for (direction, ports) in [("inputs", &self.inputs), ("outputs", &self.outputs)] {
+            for (port, def) in ports {
+                if let Some(problem) = check_port_name(port) {
+                    issue(&format!("{direction}.{port}"), problem);
+                }
+                if let Some(urn) = &def.r#type
+                    && let Some(problem) = self.check_port_type(urn, registry)
+                {
+                    issue(&format!("{direction}.{port}.type"), problem);
+                }
+                if direction == "outputs" && def.required.is_some() {
+                    issue(
+                        &format!("outputs.{port}.required"),
+                        "`required` is only meaningful on inputs".into(),
+                    );
+                }
+            }
+        }
+
+        for name in self.env.keys() {
+            if let Some(problem) = check_env_name(name) {
+                issue(&format!("env.{name}"), problem);
+            }
+        }
+
+        if let Some(example) = &self.example
+            && serde_yaml::from_str::<serde_yaml::Value>(example).is_err()
+        {
+            issue("example", "is not valid YAML".into());
+        }
+
+        issues
+    }
+
+    /// Like [`validate`](Self::validate), but returns an error listing all
+    /// problems if any were found.
+    pub fn validate_strict(&self, registry: &TypeRegistry) -> eyre::Result<()> {
+        let issues = self.validate(registry);
+        if issues.is_empty() {
+            return Ok(());
+        }
+        let list = issues
+            .iter()
+            .map(|i| format!("  - {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        eyre::bail!(
+            "node manifest validation failed ({} problem(s)):\n{list}",
+            issues.len()
+        );
+    }
+
+    /// Check that a port type URN resolves: against the registry, or against
+    /// the custom types shipped in this manifest.
+    fn check_port_type(&self, urn: &str, registry: &TypeRegistry) -> Option<String> {
+        if registry.resolve(urn).is_some() {
+            return None;
+        }
+        let base = parse_urn(urn)
+            .map(|p| p.base)
+            .unwrap_or_else(|| urn.to_string());
+        if self.types.contains_key(&base) {
+            return None;
+        }
+        if has_namespace_prefix(&base, &self.namespace) {
+            return Some(format!(
+                "unknown type `{urn}` — declare it under `types:` in this manifest"
+            ));
+        }
+        match registry.suggest(urn) {
+            Some(suggestion) => Some(format!(
+                "unknown type `{urn}` — did you mean `{suggestion}`?"
+            )),
+            None => Some(format!("unknown type `{urn}`")),
+        }
+    }
+}
+
+/// Package names: lowercase alphanumeric plus `-`, `_`, `.`; must start and
+/// end alphanumeric (PEP 503-normalized names satisfy this).
+fn check_package_name(name: &str) -> Option<String> {
+    if name.is_empty() {
+        return Some("must not be empty".into());
+    }
+    if name.len() > 64 {
+        return Some("must be at most 64 characters".into());
+    }
+    let valid_char = |c: char| c.is_ascii_lowercase() || c.is_ascii_digit() || "-_.".contains(c);
+    if !name.chars().all(valid_char) {
+        return Some(format!(
+            "`{name}` may only contain lowercase letters, digits, `-`, `_`, `.`"
+        ));
+    }
+    let first = name.chars().next().unwrap();
+    let last = name.chars().last().unwrap();
+    if !first.is_ascii_alphanumeric() || !last.is_ascii_alphanumeric() {
+        return Some(format!("`{name}` must start and end alphanumeric"));
+    }
+    None
+}
+
+/// Namespaces are GitHub orgs/users: lowercase alphanumeric plus `-`, no
+/// leading/trailing/double hyphen, at most 39 characters.
+fn check_namespace(ns: &str) -> Option<String> {
+    if ns.is_empty() {
+        return Some("must not be empty".into());
+    }
+    if ns.len() > 39 {
+        return Some("must be at most 39 characters (GitHub limit)".into());
+    }
+    let valid_char = |c: char| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-';
+    if !ns.chars().all(valid_char) {
+        return Some(format!(
+            "`{ns}` may only contain lowercase letters, digits, and `-`"
+        ));
+    }
+    if ns.starts_with('-') || ns.ends_with('-') || ns.contains("--") {
+        return Some(format!("`{ns}` has invalid hyphen placement"));
+    }
+    if ns == "std" {
+        return Some("`std` is reserved for the built-in type library".into());
+    }
+    None
+}
+
+/// Entrypoints must be relative paths confined to the node's working dir:
+/// no absolute paths, no `..` components (spec §11). The character set is
+/// deliberately conservative — console scripts and build outputs only need
+/// alphanumerics plus `. _ - / \`; rejecting everything else (whitespace,
+/// shell metacharacters, control characters, `~`, drive letters) keeps the
+/// entrypoint a single unambiguous path token for the spawn side.
+fn check_entrypoint(entrypoint: &str) -> Option<String> {
+    if entrypoint.is_empty() {
+        return Some("must not be empty".into());
+    }
+    let valid_char =
+        |c: char| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-' | '/' | '\\');
+    if !entrypoint.chars().all(valid_char) {
+        return Some(format!(
+            "`{entrypoint}` may only contain alphanumerics and `. _ - / \\`"
+        ));
+    }
+    if entrypoint.starts_with('/') || entrypoint.starts_with('\\') {
+        return Some(format!("`{entrypoint}` must be a relative path"));
+    }
+    // Split on both separators regardless of host platform: a manifest is
+    // validated once but may run anywhere, so `..` must be caught whether
+    // the consuming platform treats `\` as a separator or not.
+    if entrypoint.split(['/', '\\']).any(|c| c == "..") {
+        return Some(format!("`{entrypoint}` must not contain `..` components"));
+    }
+    None
+}
+
+fn check_platform(platform: &str) -> Option<String> {
+    let Some((os, arch)) = platform.split_once('-') else {
+        return Some(format!(
+            "`{platform}` is not of the form `<os>-<arch>` (e.g. `linux-x86_64`)"
+        ));
+    };
+    if !KNOWN_OS.contains(&os) {
+        return Some(format!(
+            "unknown OS `{os}` in `{platform}` (known: {})",
+            KNOWN_OS.join(", ")
+        ));
+    }
+    if !KNOWN_ARCH.contains(&arch) {
+        return Some(format!(
+            "unknown architecture `{arch}` in `{platform}` (known: {})",
+            KNOWN_ARCH.join(", ")
+        ));
+    }
+    None
+}
+
+/// Shipped custom types must live under the package's namespace (spec §6.3).
+fn check_shipped_type_urn(urn: &str, namespace: &str) -> Option<String> {
+    if urn.starts_with("std/") || urn == "std" {
+        return Some("shipped types cannot use the `std/` prefix".into());
+    }
+    if !has_namespace_prefix(urn, namespace) {
+        return Some(format!(
+            "shipped types must live under this package's namespace (`{namespace}/…`)"
+        ));
+    }
+    None
+}
+
+/// Whether `urn` starts with `<namespace>/`.
+fn has_namespace_prefix(urn: &str, namespace: &str) -> bool {
+    urn.strip_prefix(namespace)
+        .is_some_and(|rest| rest.starts_with('/'))
+}
+
+/// Port names must be valid dataflow `DataId`s (the runtime's own rule),
+/// minus `/`, which the descriptor syntax uses as a separator.
+fn check_port_name(name: &str) -> Option<String> {
+    if let Err(err) = name.parse::<dora_message::id::DataId>() {
+        return Some(format!("port name `{name}` is invalid: {err}"));
+    }
+    if name.contains('/') {
+        return Some(format!("port name `{name}` must not contain `/`"));
+    }
+    None
+}
+
+/// Reject environment variables that could hijack the dynamic loader or the
+/// Python interpreter of the spawned node (spec §11). Names must be valid
+/// environment variable identifiers — this also closes whitespace-padding
+/// tricks like `" PATH "` slipping past the deny-list.
+fn check_env_name(name: &str) -> Option<String> {
+    let mut chars = name.chars();
+    let valid_first = chars
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_');
+    if !valid_first || !chars.all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        return Some(format!(
+            "`{name}` is not a valid environment variable name \
+             (expected `[A-Za-z_][A-Za-z0-9_]*`)"
+        ));
+    }
+    let upper = name.to_ascii_uppercase();
+    if ENV_DENY_EXACT.contains(&upper.as_str())
+        || ENV_DENY_PREFIX.iter().any(|p| upper.starts_with(p))
+    {
+        return Some(format!(
+            "`{name}` is security-sensitive and cannot be declared by a node manifest"
+        ));
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::NodeManifest;
+
+    fn minimal(extra: &str) -> NodeManifest {
+        NodeManifest::parse(&format!(
+            r#"
+apiVersion: 1
+name: dora-test
+namespace: dora-rs
+runtime: python
+entrypoint: dora-test
+{extra}"#,
+        ))
+        .unwrap()
+    }
+
+    fn validate(extra: &str) -> Vec<ManifestIssue> {
+        minimal(extra).validate(&TypeRegistry::new())
+    }
+
+    #[test]
+    fn minimal_manifest_is_valid() {
+        assert_eq!(validate(""), vec![]);
+    }
+
+    #[test]
+    fn spec_example_is_valid() {
+        // BBox2D from the spec text doesn't exist in std/vision/v1 — use the
+        // real BoundingBox type.
+        let issues = validate(
+            r#"
+dora: ">=0.4"
+inputs:
+  image:
+    type: std/media/v1/Image
+outputs:
+  bbox:
+    type: std/vision/v1/BoundingBox
+"#,
+        );
+        assert_eq!(issues, vec![]);
+    }
+
+    #[test]
+    fn rejects_wrong_api_version() {
+        let mut m = minimal("");
+        m.api_version = 99;
+        let issues = m.validate(&TypeRegistry::new());
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].field, "apiVersion");
+    }
+
+    #[test]
+    fn rejects_missing_name() {
+        let mut m = minimal("");
+        m.name = None;
+        let issues = m.validate(&TypeRegistry::new());
+        assert!(issues.iter().any(|i| i.field == "name"));
+    }
+
+    #[test]
+    fn rejects_bad_names() {
+        for bad in ["UPPER", "-leading", "trailing-", "has space", "ünicode"] {
+            assert!(check_package_name(bad).is_some(), "{bad} should be invalid");
+        }
+        for good in ["dora-yolo", "lidar_driver", "node.v2", "x"] {
+            assert!(check_package_name(good).is_none(), "{good} should be valid");
+        }
+    }
+
+    #[test]
+    fn rejects_bad_namespaces() {
+        for bad in ["", "-acme", "acme-", "ac--me", "Acme", "a.b"] {
+            assert!(check_namespace(bad).is_some(), "{bad:?} should be invalid");
+        }
+        for good in ["acme", "dora-rs", "a1"] {
+            assert!(check_namespace(good).is_none(), "{good} should be valid");
+        }
+    }
+
+    #[test]
+    fn rejects_escaping_entrypoints() {
+        for bad in [
+            "/usr/bin/sh",
+            "../outside",
+            "foo/../../bin",
+            "C:\\windows\\evil.exe",
+            "\\\\server\\share",
+            "~/x",
+            "",
+        ] {
+            assert!(check_entrypoint(bad).is_some(), "{bad:?} should be invalid");
+        }
+        for good in ["dora-yolo", "target/release/node", "build/lidar", "a.py"] {
+            assert!(check_entrypoint(good).is_none(), "{good} should be valid");
+        }
+        // shell metacharacters, whitespace, control chars are out of charset
+        for bad in ["foo; rm -rf x", "foo bar", "a|b", "a$(b)", "a\x1b[2Jb"] {
+            assert!(check_entrypoint(bad).is_some(), "{bad:?} should be invalid");
+        }
+    }
+
+    #[test]
+    fn rejects_required_on_outputs() {
+        let issues = validate("outputs:\n  bbox:\n    required: true\n");
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].field, "outputs.bbox.required");
+    }
+
+    #[test]
+    fn rejects_std_namespace() {
+        assert!(check_namespace("std").is_some());
+    }
+
+    #[test]
+    fn display_strips_control_characters() {
+        let issue = ManifestIssue {
+            field: "name".into(),
+            message: "`\x1b[2Jevil\x07` is bad".into(),
+        };
+        let rendered = issue.to_string();
+        assert!(!rendered.contains('\x1b'), "{rendered:?}");
+        assert!(!rendered.contains('\x07'), "{rendered:?}");
+        assert!(rendered.contains("evil"), "{rendered:?}");
+    }
+
+    #[test]
+    fn rejects_denied_env_vars() {
+        for bad in [
+            "PATH",
+            "path",
+            "PaTh",
+            "PYTHONPATH",
+            "pYtHoNpAtH",
+            "PYTHONSTARTUP",
+            "VIRTUAL_ENV",
+            "BASH_ENV",
+            "IFS",
+            "LD_PRELOAD",
+            "DYLD_INSERT_LIBRARIES",
+        ] {
+            let issues = validate(&format!("env:\n  {bad}:\n    default: x\n"));
+            assert_eq!(issues.len(), 1, "{bad} should be rejected: {issues:?}");
+        }
+        let issues = validate("env:\n  MODEL:\n    default: x\n");
+        assert_eq!(issues, vec![]);
+    }
+
+    #[test]
+    fn rejects_malformed_env_names() {
+        // whitespace padding must not slip the deny-list
+        for bad in ["\" PATH \"", "\"PATH\\t\"", "\"A B\"", "\"1LEADING\""] {
+            let issues = validate(&format!("env:\n  {bad}:\n    default: x\n"));
+            assert_eq!(issues.len(), 1, "{bad} should be rejected: {issues:?}");
+        }
+    }
+
+    #[test]
+    fn unknown_type_gets_suggestion() {
+        let issues = validate("inputs:\n  image:\n    type: std/media/v1/Imag\n");
+        assert_eq!(issues.len(), 1);
+        assert!(issues[0].message.contains("did you mean"), "{issues:?}");
+    }
+
+    #[test]
+    fn custom_type_must_match_namespace() {
+        let issues = validate(
+            r#"
+types:
+  other-ns/lidar/v1/PointCloud:
+    arrow: Struct
+    fields:
+      - name: x
+        type: Float32
+"#,
+        );
+        assert_eq!(issues.len(), 1);
+        assert!(issues[0].message.contains("namespace"), "{issues:?}");
+
+        let issues = validate(
+            r#"
+types:
+  dora-rs/lidar/v1/PointCloud:
+    arrow: Struct
+    fields:
+      - name: x
+        type: Float32
+outputs:
+  cloud:
+    type: dora-rs/lidar/v1/PointCloud
+"#,
+        );
+        assert_eq!(issues, vec![]);
+    }
+
+    #[test]
+    fn std_shipped_type_rejected() {
+        let issues = validate(
+            r#"
+types:
+  std/lidar/v1/PointCloud:
+    arrow: Struct
+"#,
+        );
+        assert_eq!(issues.len(), 1);
+        assert!(issues[0].message.contains("std/"), "{issues:?}");
+    }
+
+    #[test]
+    fn own_namespace_type_without_declaration_hints_types_block() {
+        let issues = validate("outputs:\n  cloud:\n    type: dora-rs/lidar/v1/PointCloud\n");
+        assert_eq!(issues.len(), 1);
+        assert!(issues[0].message.contains("types:"), "{issues:?}");
+    }
+
+    #[test]
+    fn rejects_bad_platform_and_semver() {
+        let issues = validate("platforms: [linux-x86_64, freebsd-x86_64]\ndora: \"not-a-req\"\n");
+        assert_eq!(issues.len(), 2, "{issues:?}");
+    }
+
+    #[test]
+    fn rejects_bad_port_names() {
+        let issues = validate("outputs:\n  \"a/b\": {}\n");
+        assert_eq!(issues.len(), 1);
+        assert!(issues[0].message.contains("/"), "{issues:?}");
+    }
+
+    #[test]
+    fn rejects_invalid_example_yaml() {
+        let issues = validate("example: \"- id: [unclosed\"\n");
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].field, "example");
+    }
+
+    #[test]
+    fn validate_strict_lists_all_problems() {
+        let mut m = minimal("");
+        m.api_version = 2;
+        m.entrypoint = "../evil".into();
+        let err = m.validate_strict(&TypeRegistry::new()).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("apiVersion"), "{msg}");
+        assert!(msg.contains("entrypoint"), "{msg}");
+    }
+}

--- a/libraries/core/src/manifest/validate.rs
+++ b/libraries/core/src/manifest/validate.rs
@@ -6,7 +6,7 @@
 
 use semver::VersionReq;
 
-use super::NodeManifest;
+use super::{EnvDefault, EnvVarType, NodeManifest};
 use crate::types::{TypeRegistry, parse_urn};
 
 /// A single validation problem, referencing the manifest field it concerns.
@@ -29,7 +29,9 @@ impl std::fmt::Display for ManifestIssue {
 }
 
 fn write_sanitized(f: &mut std::fmt::Formatter<'_>, s: &str) -> std::fmt::Result {
-    for c in s.chars().filter(|c| !c.is_control() || *c == '\n') {
+    // newlines are stripped too: no issue message is legitimately multi-line,
+    // and an embedded `\n` would let a manifest spoof additional output lines
+    for c in s.chars().filter(|c| !c.is_control()) {
         std::fmt::Write::write_char(f, c)?;
     }
     Ok(())
@@ -131,9 +133,20 @@ impl NodeManifest {
             }
         }
 
-        for name in self.env.keys() {
+        for (name, def) in &self.env {
             if let Some(problem) = check_env_name(name) {
                 issue(&format!("env.{name}"), problem);
+            }
+            if let (Some(declared), Some(default)) = (def.r#type, &def.default)
+                && !env_default_matches(declared, default)
+            {
+                issue(
+                    &format!("env.{name}.default"),
+                    format!(
+                        "default value does not match declared type `{}`",
+                        declared.as_str()
+                    ),
+                );
             }
         }
 
@@ -287,8 +300,15 @@ fn check_platform(platform: &str) -> Option<String> {
     None
 }
 
-/// Shipped custom types must live under the package's namespace (spec §6.3).
+/// Shipped custom types must live under the package's namespace (spec §6.3),
+/// be declared without parameters, and use the URN character set.
 fn check_shipped_type_urn(urn: &str, namespace: &str) -> Option<String> {
+    let valid_char = |c: char| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | '/');
+    if !urn.chars().all(valid_char) {
+        return Some(format!(
+            "type URN `{urn}` may only contain alphanumerics and `_ - . /`"
+        ));
+    }
     if urn.starts_with("std/") || urn == "std" {
         return Some("shipped types cannot use the `std/` prefix".into());
     }
@@ -298,6 +318,17 @@ fn check_shipped_type_urn(urn: &str, namespace: &str) -> Option<String> {
         ));
     }
     None
+}
+
+/// Whether a declared env default value is of the declared type. An integer
+/// default satisfies a `float` declaration (YAML `0` parses as an integer).
+fn env_default_matches(declared: EnvVarType, default: &EnvDefault) -> bool {
+    match declared {
+        EnvVarType::String => matches!(default, EnvDefault::String(_)),
+        EnvVarType::Int => matches!(default, EnvDefault::Integer(_)),
+        EnvVarType::Float => matches!(default, EnvDefault::Float(_) | EnvDefault::Integer(_)),
+        EnvVarType::Bool => matches!(default, EnvDefault::Bool(_)),
+    }
 }
 
 /// Whether `urn` starts with `<namespace>/`.
@@ -536,6 +567,39 @@ types:
 outputs:
   cloud:
     type: dora-rs/lidar/v1/PointCloud
+"#,
+        );
+        assert_eq!(issues, vec![]);
+    }
+
+    #[test]
+    fn env_default_must_match_declared_type() {
+        let issues = validate("env:\n  CONFIDENCE:\n    type: float\n    default: not-a-number\n");
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].field, "env.CONFIDENCE.default");
+
+        // integer default satisfies a float declaration
+        let issues = validate("env:\n  CONFIDENCE:\n    type: float\n    default: 1\n");
+        assert_eq!(issues, vec![]);
+    }
+
+    #[test]
+    fn shipped_type_keys_are_format_checked() {
+        // parameterized keys can never be referenced (the port checker strips
+        // params before lookup) — reject them at declaration
+        let issues = validate("types:\n  \"dora-rs/lidar/v1/PC[res=high]\":\n    arrow: Struct\n");
+        assert_eq!(issues.len(), 1, "{issues:?}");
+        assert!(issues[0].field.starts_with("types."), "{issues:?}");
+
+        // parameterized *references* to a declared base type resolve fine
+        let issues = validate(
+            r#"
+types:
+  dora-rs/lidar/v1/PC:
+    arrow: Struct
+outputs:
+  cloud:
+    type: "dora-rs/lidar/v1/PC[res=high]"
 "#,
         );
         assert_eq!(issues, vec![]);

--- a/libraries/core/src/manifest/validate.rs
+++ b/libraries/core/src/manifest/validate.rs
@@ -108,9 +108,26 @@ impl NodeManifest {
             issue("dora", format!("`{req}` is not a valid semver requirement"));
         }
 
-        for urn in self.types.keys() {
+        // Validate shipped type bodies against a registry that includes the
+        // manifest's own types, so that a port referencing a shipped type is
+        // backed by a type that can actually be materialized (the P1.3 gate
+        // must reject unresolvable field types, not just unknown URN keys).
+        let mut local_registry = registry.clone();
+        for (urn, def) in &self.types {
+            local_registry.insert_type(urn.clone(), def.clone());
+        }
+        for (urn, def) in &self.types {
             if let Some(problem) = check_shipped_type_urn(urn, &self.namespace) {
                 issue(&format!("types.{urn}"), problem);
+                continue;
+            }
+            for field in &def.fields {
+                if !local_registry.field_type_resolves(&field.r#type) {
+                    issue(
+                        &format!("types.{urn}.fields.{}", field.name),
+                        format!("unknown field type `{}`", field.r#type),
+                    );
+                }
             }
         }
 
@@ -324,7 +341,11 @@ fn check_shipped_type_urn(urn: &str, namespace: &str) -> Option<String> {
 /// default satisfies a `float` declaration (YAML `0` parses as an integer).
 fn env_default_matches(declared: EnvVarType, default: &EnvDefault) -> bool {
     match declared {
-        EnvVarType::String => matches!(default, EnvDefault::String(_)),
+        // any scalar is a valid string default: a `type: string` var with an
+        // unquoted YAML scalar (`default: true`, `default: 8080`) deserializes
+        // to Bool/Integer, but the publisher means the literal string — don't
+        // force them to quote it
+        EnvVarType::String => true,
         EnvVarType::Int => matches!(default, EnvDefault::Integer(_)),
         EnvVarType::Float => matches!(default, EnvDefault::Float(_) | EnvDefault::Integer(_)),
         EnvVarType::Bool => matches!(default, EnvDefault::Bool(_)),
@@ -580,6 +601,69 @@ outputs:
 
         // integer default satisfies a float declaration
         let issues = validate("env:\n  CONFIDENCE:\n    type: float\n    default: 1\n");
+        assert_eq!(issues, vec![]);
+
+        // any scalar is a valid `type: string` default — `true`/`8080` are
+        // unquoted YAML scalars the publisher means as strings
+        for default in ["true", "8080", "1.5", "\"hello\""] {
+            let issues = validate(&format!(
+                "env:\n  V:\n    type: string\n    default: {default}\n"
+            ));
+            assert_eq!(
+                issues,
+                vec![],
+                "string default `{default}` should be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn shipped_type_bodies_are_validated() {
+        // a shipped type referencing an unresolvable field type is rejected
+        let issues = validate(
+            r#"
+types:
+  dora-rs/lidar/v1/Bad:
+    arrow: Struct
+    fields:
+      - name: x
+        type: DefinitelyNotAType
+outputs:
+  cloud:
+    type: dora-rs/lidar/v1/Bad
+"#,
+        );
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.field == "types.dora-rs/lidar/v1/Bad.fields.x"),
+            "{issues:?}"
+        );
+
+        // fields referencing primitives, std types, and sibling shipped types
+        // all resolve
+        let issues = validate(
+            r#"
+types:
+  dora-rs/lidar/v1/Point:
+    arrow: Struct
+    fields:
+      - name: x
+        type: Float32
+  dora-rs/lidar/v1/Cloud:
+    arrow: Struct
+    fields:
+      - name: first
+        type: dora-rs/lidar/v1/Point
+      - name: raw
+        type: std/core/v1/Bytes
+      - name: points
+        type: List<dora-rs/lidar/v1/Point>
+outputs:
+  cloud:
+    type: dora-rs/lidar/v1/Cloud
+"#,
+        );
         assert_eq!(issues, vec![]);
     }
 

--- a/libraries/core/src/manifest/validate.rs
+++ b/libraries/core/src/manifest/validate.rs
@@ -121,6 +121,15 @@ impl NodeManifest {
                 issue(&format!("types.{urn}"), problem);
                 continue;
             }
+            // the `arrow:` discriminant must be a type dora can materialize —
+            // otherwise a port referencing this shipped type resolves (the URN
+            // exists) yet fails to build into an Arrow schema later
+            if !crate::types::is_known_arrow_type(&def.arrow) {
+                issue(
+                    &format!("types.{urn}.arrow"),
+                    format!("unknown arrow type `{}`", def.arrow),
+                );
+            }
             for field in &def.fields {
                 if !local_registry.field_type_resolves(&field.r#type) {
                     issue(
@@ -705,6 +714,38 @@ outputs:
 "#,
         );
         assert_eq!(issues, vec![]);
+    }
+
+    #[test]
+    fn shipped_type_arrow_discriminant_is_validated() {
+        // an unknown `arrow:` value resolves (the URN exists) but can never be
+        // materialized — reject it at validation
+        let issues = validate(
+            r#"
+types:
+  dora-rs/lidar/v1/Bad:
+    arrow: NotAnArrowType
+outputs:
+  cloud:
+    type: dora-rs/lidar/v1/Bad
+"#,
+        );
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.field == "types.dora-rs/lidar/v1/Bad.arrow"),
+            "{issues:?}"
+        );
+        // primitives and `Struct` are accepted
+        for arrow in ["Float32", "Utf8", "Boolean", "Struct"] {
+            let issues = validate(&format!("types:\n  dora-rs/x/v1/T:\n    arrow: {arrow}\n"));
+            assert!(
+                !issues
+                    .iter()
+                    .any(|i| i.field == "types.dora-rs/x/v1/T.arrow"),
+                "`{arrow}` should be accepted: {issues:?}"
+            );
+        }
     }
 
     #[test]

--- a/libraries/core/src/types.rs
+++ b/libraries/core/src/types.rs
@@ -1,11 +1,12 @@
 use arrow_schema::{DataType, Field, Fields, Schema};
-use serde::Deserialize;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::Path;
 use std::sync::Arc;
 
 /// A field definition within a struct type.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct FieldDef {
     /// Field name
     pub name: String,
@@ -21,7 +22,7 @@ fn default_true() -> bool {
 }
 
 /// A type parameter declaration (e.g. `sample_type` on AudioFrame).
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct TypeParam {
     /// Parameter name
     pub name: String,
@@ -31,7 +32,7 @@ pub struct TypeParam {
 }
 
 /// Metadata key required on outputs of a given type.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct MetadataDef {
     /// Key name that must be present in message metadata
     pub key: String,
@@ -41,7 +42,7 @@ pub struct MetadataDef {
 }
 
 /// A single type definition from the standard type library.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct TypeDef {
     /// Arrow data type name (e.g. "Float32", "Struct", "LargeBinary")
     pub arrow: String,

--- a/libraries/core/src/types.rs
+++ b/libraries/core/src/types.rs
@@ -506,12 +506,23 @@ impl TypeRegistry {
     /// here. Lenient by design — it accepts primitive-backed std types (e.g.
     /// `std/core/v1/Bytes`) and only rejects genuinely-unknown names.
     pub fn field_type_resolves(&self, type_str: &str) -> bool {
+        self.field_type_resolves_depth(type_str, 0)
+    }
+
+    fn field_type_resolves_depth(&self, type_str: &str, depth: u8) -> bool {
+        // bound the `List<…>` recursion: this runs on untrusted shipped-type
+        // field bodies (only the URN key is charset-checked), and a 1 MiB
+        // manifest can nest `List<` deep enough to overflow the stack. Match
+        // the cap `resolve_field_type` uses — anything deeper doesn't resolve.
+        if depth > MAX_TYPE_DEPTH {
+            return false;
+        }
         let t = type_str.trim();
         if arrow_type_from_name(t).is_some() {
             return true;
         }
         if let Some(inner) = t.strip_prefix("List<").and_then(|s| s.strip_suffix('>')) {
-            return self.field_type_resolves(inner);
+            return self.field_type_resolves_depth(inner, depth + 1);
         }
         self.resolve(t).is_some() || self.resolve_short_name(t).is_some()
     }
@@ -1335,5 +1346,16 @@ mod tests {
             .unwrap();
         let schema = def.to_arrow_schema_with_registry(&reg).unwrap();
         assert_eq!(schema.fields().len(), 3); // sample_rate, channels, data
+    }
+
+    #[test]
+    fn field_type_resolves_bounds_list_nesting() {
+        let reg = TypeRegistry::new();
+        // shallow nesting still resolves
+        assert!(reg.field_type_resolves("List<List<Float32>>"));
+        // a pathologically deep `List<…>` from an untrusted manifest must be
+        // rejected (return false), not overflow the stack
+        let deep = format!("{}Float32{}", "List<".repeat(100_000), ">".repeat(100_000));
+        assert!(!reg.field_type_resolves(&deep));
     }
 }

--- a/libraries/core/src/types.rs
+++ b/libraries/core/src/types.rs
@@ -119,6 +119,14 @@ fn arrow_type_from_name(name: &str) -> Option<DataType> {
     }
 }
 
+/// Whether `name` is an arrow discriminant dora recognizes for a shipped type's
+/// `arrow:` field: a known primitive, or `Struct` (whose shape is its fields).
+/// Anything else cannot be materialized into a schema, so it must be rejected
+/// at manifest validation rather than silently failing later at build time.
+pub fn is_known_arrow_type(name: &str) -> bool {
+    arrow_type_from_name(name).is_some() || name == "Struct"
+}
+
 const MAX_TYPE_DEPTH: u8 = 8;
 
 /// Resolve a field type string to an Arrow `DataType`, supporting:

--- a/libraries/core/src/types.rs
+++ b/libraries/core/src/types.rs
@@ -47,16 +47,16 @@ pub struct TypeDef {
     /// Arrow data type name (e.g. "Float32", "Struct", "LargeBinary")
     pub arrow: String,
     /// Human-readable description
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// Type parameters (e.g. sample_type for AudioFrame)
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub params: Vec<TypeParam>,
     /// Struct field definitions (only for Struct arrow types)
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub fields: Vec<FieldDef>,
     /// Required metadata keys
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub metadata: Vec<MetadataDef>,
 }
 

--- a/libraries/core/src/types.rs
+++ b/libraries/core/src/types.rs
@@ -452,6 +452,7 @@ pub fn pattern_metadata_keys(pattern: &str) -> Option<&'static [&'static str]> {
 /// Registry of known type URNs, loaded from embedded YAML files.
 ///
 /// URN format: `std/<category>/v<version>/<TypeName>`
+#[derive(Clone)]
 pub struct TypeRegistry {
     types: BTreeMap<String, TypeDef>,
 }
@@ -492,6 +493,27 @@ impl TypeRegistry {
             }
         }
         Self { types }
+    }
+
+    /// Register a single type definition at the given URN, overwriting any
+    /// existing entry. Used to load manifest-shipped types for validation.
+    pub fn insert_type(&mut self, urn: impl Into<String>, def: TypeDef) {
+        self.types.insert(urn.into(), def);
+    }
+
+    /// Whether a struct field's type string is known: a primitive Arrow type,
+    /// `List<T>` of a known type, or any type (URN or short name) registered
+    /// here. Lenient by design — it accepts primitive-backed std types (e.g.
+    /// `std/core/v1/Bytes`) and only rejects genuinely-unknown names.
+    pub fn field_type_resolves(&self, type_str: &str) -> bool {
+        let t = type_str.trim();
+        if arrow_type_from_name(t).is_some() {
+            return true;
+        }
+        if let Some(inner) = t.strip_prefix("List<").and_then(|s| s.strip_suffix('>')) {
+            return self.field_type_resolves(inner);
+        }
+        self.resolve(t).is_some() || self.resolve_short_name(t).is_some()
     }
 
     /// Resolve a type URN to its definition.

--- a/libraries/message/Cargo.toml
+++ b/libraries/message/Cargo.toml
@@ -20,7 +20,7 @@ tokio = { workspace = true, features = ["sync"] }
 uuid = { workspace = true }
 log = { version = "0.4.21", features = ["serde"] }
 aligned-vec = { version = "0.5.0", features = ["serde"] }
-semver = { version = "1.0.23", features = ["serde"] }
+semver = { workspace = true }
 schemars = "1.0.4"
 uhlc = "0.5.1"
 serde_yaml = { workspace = true }


### PR DESCRIPTION
Implements **P1.1 + P1.3** of the Dora Hub spec ([docs/plan-node-hub.md](https://github.com/dora-rs/dora/blob/main/docs/plan-node-hub.md), umbrella #2097): the node manifest (`dora-node.yml`) parsing/validation layer that `dora hub publish --dry-run` (P3.1) and manifest→descriptor contract injection (P1.4) will build on. No network, no index — immediately useful standalone.

## What's included

- **`dora_core::manifest`** — `NodeManifest` serde types matching spec §5 (contracts, entrypoint, env surface, shipped custom types, requirements, example snippet), with a 1 MiB input cap for untrusted index content.
- **Validation (spec §5/§11)** — returns all problems with field paths:
  - entrypoint: relative-path confinement (no absolute, no `..`, no `~`/drive letters) via a conservative charset that also excludes whitespace/shell metacharacters/control chars;
  - env deny-list: `PATH`, `PYTHONPATH`/`PYTHONHOME`/`PYTHONSTARTUP`/`PYTHONEXECUTABLE`/`PYTHONBREAKPOINT`, `VIRTUAL_ENV`, `BASH_ENV`, `ENV`, `IFS`, and `LD_*`/`DYLD_*` prefixes, case-insensitive; names must be valid env identifiers (closes whitespace-padding bypasses);
  - type URNs resolve against the `TypeRegistry` or the manifest's own `types:` block, with typo suggestions; shipped types must live under the package namespace, `std/` rejected;
  - port names validated with the runtime's own `DataId` rules; `required` rejected on outputs; platform/semver/example checks;
  - issue rendering strips control characters (hostile manifests can't inject terminal escapes).
- **JSON Schema** — `dora-node-schema.json` generated alongside `dora-schema.json`; a unit test fails if the checked-in schema drifts from the types, and the regenerate-schemas workflow now covers both files.
- **CLI** — `dora validate --node-manifest <file>` (mutually exclusive with the dataflow argument).
- `semver` promoted to a workspace dependency (spec §7.2 note).
- `.gitignore`: dropped the distutils `MANIFEST` pattern — on case-insensitive filesystems it silently hides Rust `manifest/` module dirs from git, and nothing in this repo produces a distutils `MANIFEST`.

## Verification

- `cargo test -p dora-core manifest` — 26 tests (parsing, validation rules, bypass attempts, schema drift).
- `dora validate --node-manifest` live-tested against a clean manifest (OK, exit 0) and a hostile one (4 errors incl. typo suggestion, exit 1).
- fmt + clippy `-D warnings` + full workspace test suite + `cargo check --examples`.

## Notes for reviewers

- Lexical entrypoint validation deliberately does **not** claim to stop symlink escapes — that requires canonicalization at spawn time, which is the confined-resolution work in P2.7 (tracked in the spec §10.1/§11).
- The validate-once-run-anywhere stance means `..` is rejected with either separator regardless of host platform; a Unix file literally named `a\..\b` is conservatively rejected.

Part of #2097.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
