### PR TITLE
feat(hub): inject node manifest contracts into path: nodes (P1.4)

### DIFF
--- a/binaries/cli/src/command/build/mod.rs
+++ b/binaries/cli/src/command/build/mod.rs
@@ -221,7 +221,7 @@ pub fn build(cfg: BuildConfig) -> eyre::Result<()> {
         eyre::bail!("`--lockfile` requires either `--locked` or `--write-lockfile`");
     }
     let working_dir = working_dir_or_parent(working_dir_override.as_deref(), &dataflow_path);
-    let dataflow_descriptor = Descriptor::blocking_read(&dataflow_path)
+    let mut dataflow_descriptor = Descriptor::blocking_read(&dataflow_path)
         .wrap_err_with(|| {
             format!(
                 "failed to read dataflow at `{}`\n\n  \
@@ -247,6 +247,15 @@ pub fn build(cfg: BuildConfig) -> eyre::Result<()> {
             _ => {}
         }
     }
+    // Inject contracts from node manifests adjacent to path: nodes (§6.2)
+    let injection = dora_core::manifest::inject::inject_adjacent_manifests(
+        &mut dataflow_descriptor,
+        working_dir,
+        &mut registry,
+    );
+    for note in &injection.notes {
+        println!("  {note}");
+    }
     let type_result = dora_core::descriptor::validate::check_type_annotations_full(
         &dataflow_descriptor,
         &registry,
@@ -255,16 +264,19 @@ pub fn build(cfg: BuildConfig) -> eyre::Result<()> {
     for inf in &type_result.inferences {
         println!("  {inf}");
     }
-    if !type_result.warnings.is_empty() {
+    let warning_count = injection.warnings.len() + type_result.warnings.len();
+    if warning_count > 0 {
+        for w in &injection.warnings {
+            eprintln!("  warning: {w}");
+        }
         for w in &type_result.warnings {
             eprintln!("  warning: {w}");
         }
-        let count = type_result.warnings.len();
         if strict {
-            eyre::bail!("{count} type error(s) found (strict mode)");
+            eyre::bail!("{warning_count} type error(s) found (strict mode)");
         } else {
             eprintln!(
-                "{count} type warning(s) found.\n  \
+                "{warning_count} type warning(s) found.\n  \
                  hint: use --strict-types to fail on type warnings"
             );
         }

--- a/binaries/cli/src/command/validate.rs
+++ b/binaries/cli/src/command/validate.rs
@@ -4,7 +4,7 @@ use dora_core::{
         Descriptor, DescriptorExt,
         validate::{check_type_annotations_full, check_wiring},
     },
-    manifest::NodeManifest,
+    manifest::{NodeManifest, inject::inject_adjacent_manifests},
     types::TypeRegistry,
 };
 use eyre::{Context, bail};
@@ -63,7 +63,7 @@ fn validate_dataflow(dataflow: &Path, strict_types: bool) -> eyre::Result<()> {
     println!("Validating {}...", dataflow.display());
 
     // Parse and expand modules (no runtime needed)
-    let descriptor = Descriptor::blocking_read(dataflow)
+    let mut descriptor = Descriptor::blocking_read(dataflow)
         .with_context(|| {
             format!(
                 "failed to read dataflow at `{}`\n\n  \
@@ -95,6 +95,12 @@ fn validate_dataflow(dataflow: &Path, strict_types: bool) -> eyre::Result<()> {
         }
     }
 
+    // Inject contracts from node manifests adjacent to path: nodes (§6.2)
+    let injection = inject_adjacent_manifests(&mut descriptor, working_dir, &mut registry);
+    for note in &injection.notes {
+        println!("  {note}");
+    }
+
     // Run type annotation checks
     let result = check_type_annotations_full(&descriptor, &registry, strict);
 
@@ -103,14 +109,17 @@ fn validate_dataflow(dataflow: &Path, strict_types: bool) -> eyre::Result<()> {
         println!("  {inf}");
     }
 
-    if result.warnings.is_empty() {
+    let count = injection.warnings.len() + result.warnings.len();
+    if count == 0 {
         println!("All type annotations OK.");
     } else {
         println!("Type warnings:");
+        for w in &injection.warnings {
+            println!("  - {w}");
+        }
         for w in &result.warnings {
             println!("  - {w}");
         }
-        let count = result.warnings.len();
         println!("{count} type warning(s) found.");
         if strict {
             bail!("{count} type warning(s) found (--strict mode)");

--- a/libraries/core/src/manifest/inject.rs
+++ b/libraries/core/src/manifest/inject.rs
@@ -6,6 +6,11 @@
 //! own annotations win), its custom types are registered, and the dataflow's
 //! wiring is checked against the declared ports. Local development thereby
 //! gets the same contract validation as hub consumption (UC11).
+//!
+//! Scope (P1.4): injection runs in `dora build` and `dora validate` only —
+//! compose-time checking. The injected annotations do not reach the runtime
+//! first-message type check or `dora graph`, which read the descriptor
+//! through paths that don't inject (deliberate for now; see plan §6.2).
 
 use std::path::{Component, Path, PathBuf};
 
@@ -62,10 +67,14 @@ pub fn inject_adjacent_manifests(
     // manifest referencing a type shipped by another node resolves regardless
     // of node order. URN policy violations (namespace, charset) are reported
     // by each manifest's validation in pass 2; only the `std/` override guard
-    // is load-bearing here.
+    // is load-bearing here. Already-registered URNs are left untouched: types
+    // the dataflow author defined in `types/` win over manifest-shipped ones,
+    // and two nodes sharing one manifest re-ship identical definitions.
     for (_, (_, manifest)) in &matched {
         for (urn, def) in &manifest.types {
-            let _ = registry.add_user_type(urn, def.clone());
+            if registry.resolve(urn).is_none() {
+                let _ = registry.add_user_type(urn, def.clone());
+            }
         }
     }
 
@@ -98,13 +107,13 @@ fn find_manifest_for(
         // on-disk node directory to search
         return None;
     }
-    let working_dir = normalize(working_dir);
-    let full = normalize(&working_dir.join(path));
-    if !full.starts_with(&working_dir) {
+    let Some((full, working_dir)) = containment_roots(path, working_dir) else {
         // absolute or `..`-escaping paths point outside the dataflow tree —
-        // never walk unrelated directories looking for a manifest
+        // never walk unrelated directories looking for a manifest. (Env-var
+        // paths like `$HOME/bin/node` also land here or miss below: the
+        // daemon expands them at spawn time, injection does not.)
         return None;
-    }
+    };
     for dir in full.parent()?.ancestors() {
         if !dir.starts_with(&working_dir) {
             break;
@@ -137,6 +146,29 @@ fn find_manifest_for(
         }
     }
     None
+}
+
+/// Compute the normalized executable path and working-dir root used for the
+/// manifest walk, or `None` if the node path escapes the working directory.
+///
+/// The working dir is absolutized first: a relative working dir like `.`
+/// (the default when the dataflow sits in the invocation directory) would
+/// otherwise normalize to an empty prefix, which trivially "contains" every
+/// path — including absolute ones — and lets leading `..` components be
+/// silently dropped instead of detected as escapes.
+fn containment_roots(path: &str, working_dir: &Path) -> Option<(PathBuf, PathBuf)> {
+    let working_dir = if working_dir.is_absolute() {
+        normalize(working_dir)
+    } else {
+        let cwd = std::env::current_dir().ok()?;
+        normalize(&cwd.join(working_dir))
+    };
+    let full = normalize(&working_dir.join(path));
+    if full.starts_with(&working_dir) {
+        Some((full, working_dir))
+    } else {
+        None
+    }
 }
 
 /// Lexically normalize a path (collapse `.` and resolve `..`) without
@@ -480,6 +512,24 @@ nodes:
         assert_eq!(result.notes, Vec::<String>::new());
         assert_eq!(result.warnings, Vec::<String>::new());
         assert!(df.nodes.iter().all(|n| n.input_types.is_empty()));
+    }
+
+    #[test]
+    fn relative_working_dir_does_not_collapse_containment() {
+        // `dora build dataflow.yml` run inside the dataflow's directory uses
+        // working_dir = "." — which must NOT normalize to an empty prefix
+        // that trivially contains absolute paths or eats leading `..`
+        assert!(
+            containment_roots("/opt/builds/some-node", Path::new(".")).is_none(),
+            "absolute path must not be contained by a relative working dir"
+        );
+        assert!(
+            containment_roots("../outside/target/release/bin", Path::new(".")).is_none(),
+            "`..`-escaping path must be detected, not remapped"
+        );
+        let (full, wd) = containment_roots("yolo/target/release/bin", Path::new(".")).unwrap();
+        assert!(wd.is_absolute());
+        assert!(full.starts_with(&wd));
     }
 
     #[test]

--- a/libraries/core/src/manifest/inject.rs
+++ b/libraries/core/src/manifest/inject.rs
@@ -1,0 +1,588 @@
+//! Manifest → descriptor contract injection (spec §6.2, P1.4).
+//!
+//! A `dora-node.yml` sitting next to a plain `path:` node is picked up at
+//! validate/build time: the manifest's typed ports surface as the node's
+//! `input_types`/`output_types` descriptor annotations (the dataflow author's
+//! own annotations win), its custom types are registered, and the dataflow's
+//! wiring is checked against the declared ports. Local development thereby
+//! gets the same contract validation as hub consumption (UC11).
+
+use std::path::{Component, Path, PathBuf};
+
+use dora_message::{descriptor::Descriptor, id::NodeId};
+
+use super::{MANIFEST_FILENAME, NodeManifest, validate::sanitize};
+use crate::{descriptor::source_is_url, types::TypeRegistry};
+
+/// Outcome of scanning a dataflow for adjacent node manifests.
+#[derive(Debug, Default)]
+pub struct InjectionResult {
+    /// Human-readable notes about applied injections.
+    pub notes: Vec<String>,
+    /// Problems found; callers treat these like type warnings
+    /// (printed, and fatal under `strict_types`).
+    pub warnings: Vec<String>,
+}
+
+/// Scan a dataflow for `path:` nodes with an adjacent `dora-node.yml` and
+/// inject the manifest contracts into the descriptor (spec §6.2).
+///
+/// Custom types shipped by matched manifests are registered into `registry`
+/// so the subsequent type check can resolve them.
+pub fn inject_adjacent_manifests(
+    dataflow: &mut Descriptor,
+    working_dir: &Path,
+    registry: &mut TypeRegistry,
+) -> InjectionResult {
+    let mut result = InjectionResult::default();
+
+    // Pass 1: locate each node's manifest.
+    let mut matched = Vec::new();
+    for (idx, node) in dataflow.nodes.iter().enumerate() {
+        // Only plain local-path nodes: URL paths are downloaded artifacts,
+        // git sources are not cloned yet at this stage, and runtime/operator/
+        // ros2 nodes have no node-level executable.
+        let Some(path) = node.path.as_deref() else {
+            continue;
+        };
+        if source_is_url(path)
+            || node.git.is_some()
+            || node.operators.is_some()
+            || node.operator.is_some()
+            || node.ros2.is_some()
+        {
+            continue;
+        }
+        if let Some(found) = find_manifest_for(path, working_dir, &node.id, &mut result) {
+            matched.push((idx, found));
+        }
+    }
+
+    // Register every shipped type before validating any manifest, so that a
+    // manifest referencing a type shipped by another node resolves regardless
+    // of node order. URN policy violations (namespace, charset) are reported
+    // by each manifest's validation in pass 2; only the `std/` override guard
+    // is load-bearing here.
+    for (_, (_, manifest)) in &matched {
+        for (urn, def) in &manifest.types {
+            let _ = registry.add_user_type(urn, def.clone());
+        }
+    }
+
+    // Pass 2: validate each manifest against the full registry and inject.
+    for (idx, (manifest_path, manifest)) in matched {
+        apply_manifest(
+            &mut dataflow.nodes[idx],
+            &manifest,
+            &manifest_path,
+            registry,
+            &mut result,
+        );
+    }
+    result
+}
+
+/// Find the manifest governing `path` by walking up from the executable's
+/// directory. A manifest applies iff its `entrypoint` names the same file —
+/// `<manifest dir>/<entrypoint> == <working_dir>/<path>` — which makes the
+/// association exact for build outputs like `target/release/<bin>` where the
+/// manifest sits at the node's source root, not next to the binary.
+fn find_manifest_for(
+    path: &str,
+    working_dir: &Path,
+    node_id: &NodeId,
+    result: &mut InjectionResult,
+) -> Option<(PathBuf, NodeManifest)> {
+    if !path.contains('/') && !path.contains('\\') {
+        // bare command name (e.g. an installed console script) — there is no
+        // on-disk node directory to search
+        return None;
+    }
+    let working_dir = normalize(working_dir);
+    let full = normalize(&working_dir.join(path));
+    if !full.starts_with(&working_dir) {
+        // absolute or `..`-escaping paths point outside the dataflow tree —
+        // never walk unrelated directories looking for a manifest
+        return None;
+    }
+    for dir in full.parent()?.ancestors() {
+        if !dir.starts_with(&working_dir) {
+            break;
+        }
+        let candidate = dir.join(MANIFEST_FILENAME);
+        if candidate.is_file() {
+            let manifest = match NodeManifest::read(&candidate) {
+                Ok(manifest) => manifest,
+                Err(err) => {
+                    result.warnings.push(sanitize(&format!(
+                        "node \"{node_id}\": failed to read {}: {err:#}",
+                        candidate.display()
+                    )));
+                    return None;
+                }
+            };
+            // manifests are written once and consumed on any platform —
+            // treat `\` in the entrypoint as a separator everywhere
+            let entrypoint = manifest.entrypoint.replace('\\', "/");
+            if normalize(&dir.join(entrypoint)) == full {
+                return Some((candidate, manifest));
+            }
+            result.warnings.push(sanitize(&format!(
+                "node \"{node_id}\": {} has entrypoint `{}`, which does not name \
+                 the node's path `{path}` — contracts not injected",
+                candidate.display(),
+                manifest.entrypoint,
+            )));
+            return None;
+        }
+    }
+    None
+}
+
+/// Lexically normalize a path (collapse `.` and resolve `..`) without
+/// touching the filesystem — the executable may not be built yet.
+fn normalize(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                out.pop();
+            }
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+fn apply_manifest(
+    node: &mut dora_message::descriptor::Node,
+    manifest: &NodeManifest,
+    manifest_path: &Path,
+    registry: &TypeRegistry,
+    result: &mut InjectionResult,
+) {
+    let issues = manifest.validate(registry);
+    if !issues.is_empty() {
+        result.warnings.push(sanitize(&format!(
+            "node \"{}\": {} has {} problem(s) — contracts not injected (first: {})",
+            node.id,
+            manifest_path.display(),
+            issues.len(),
+            issues[0]
+        )));
+        return;
+    }
+
+    // the dataflow's wiring must stay within the declared ports (spec §10.1)
+    for input in node.inputs.keys() {
+        if !manifest.inputs.contains_key(input.as_str()) {
+            result.warnings.push(sanitize(&format!(
+                "node \"{}\": input `{input}` is not declared in {}",
+                node.id,
+                manifest_path.display()
+            )));
+        }
+    }
+    for output in &node.outputs {
+        if !manifest.outputs.contains_key(output.as_str()) {
+            result.warnings.push(sanitize(&format!(
+                "node \"{}\": output `{output}` is not declared in {}",
+                node.id,
+                manifest_path.display()
+            )));
+        }
+    }
+    for (name, def) in &manifest.inputs {
+        if def.is_required() && !node.inputs.keys().any(|k| k.as_str() == name) {
+            result.warnings.push(sanitize(&format!(
+                "node \"{}\": required input `{name}` is not wired",
+                node.id
+            )));
+        }
+    }
+
+    // inject contract types; the dataflow author's own annotations win
+    let mut injected = 0;
+    let port_sets = [
+        (&manifest.inputs, &mut node.input_types),
+        (&manifest.outputs, &mut node.output_types),
+    ];
+    for (ports, annotations) in port_sets {
+        for (name, def) in ports {
+            let Some(urn) = &def.r#type else {
+                continue;
+            };
+            // manifest validation guarantees port names parse as DataId
+            let Ok(id) = name.parse() else {
+                continue;
+            };
+            if let std::collections::btree_map::Entry::Vacant(entry) = annotations.entry(id) {
+                entry.insert(urn.clone());
+                injected += 1;
+            }
+        }
+    }
+    if injected > 0 {
+        result.notes.push(sanitize(&format!(
+            "node \"{}\": injected {injected} contract type(s) from {}",
+            node.id,
+            manifest_path.display()
+        )));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MANIFEST: &str = r#"
+apiVersion: 1
+name: dora-yolo
+namespace: dora-rs
+runtime: rust
+entrypoint: target/release/dora-yolo
+inputs:
+  image:
+    type: std/media/v1/Image
+outputs:
+  bbox:
+    type: std/vision/v1/BoundingBox
+"#;
+
+    fn dataflow(yaml: &str) -> Descriptor {
+        serde_yaml::from_str(yaml).unwrap()
+    }
+
+    fn write_manifest(dir: &Path, content: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(dir.join(MANIFEST_FILENAME), content).unwrap();
+    }
+
+    #[test]
+    fn injects_types_from_adjacent_manifest() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(&tmp.path().join("yolo"), MANIFEST);
+        let mut df = dataflow(
+            r#"
+nodes:
+  - id: camera
+    path: cam
+    outputs: [image]
+  - id: detector
+    path: yolo/target/release/dora-yolo
+    inputs:
+      image: camera/image
+    outputs: [bbox]
+"#,
+        );
+        let mut registry = TypeRegistry::new();
+        let result = inject_adjacent_manifests(&mut df, tmp.path(), &mut registry);
+        assert_eq!(result.warnings, Vec::<String>::new());
+        assert_eq!(result.notes.len(), 1);
+        let detector = &df.nodes[1];
+        assert_eq!(
+            detector
+                .input_types
+                .get(&"image".parse::<dora_message::id::DataId>().unwrap()),
+            Some(&"std/media/v1/Image".to_string())
+        );
+        assert_eq!(
+            detector
+                .output_types
+                .get(&"bbox".parse::<dora_message::id::DataId>().unwrap()),
+            Some(&"std/vision/v1/BoundingBox".to_string())
+        );
+    }
+
+    #[test]
+    fn author_annotations_win() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(&tmp.path().join("yolo"), MANIFEST);
+        let mut df = dataflow(
+            r#"
+nodes:
+  - id: detector
+    path: yolo/target/release/dora-yolo
+    inputs:
+      image: other/image
+    input_types:
+      image: std/core/v1/Bytes
+    outputs: [bbox]
+"#,
+        );
+        let mut registry = TypeRegistry::new();
+        inject_adjacent_manifests(&mut df, tmp.path(), &mut registry);
+        assert_eq!(
+            df.nodes[0]
+                .input_types
+                .get(&"image".parse::<dora_message::id::DataId>().unwrap()),
+            Some(&"std/core/v1/Bytes".to_string()),
+            "explicit dataflow annotation must not be overwritten"
+        );
+    }
+
+    #[test]
+    fn entrypoint_mismatch_warns_and_skips() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(&tmp.path().join("yolo"), MANIFEST);
+        let mut df = dataflow(
+            r#"
+nodes:
+  - id: detector
+    path: yolo/other-binary
+    inputs:
+      image: camera/image
+"#,
+        );
+        let mut registry = TypeRegistry::new();
+        let result = inject_adjacent_manifests(&mut df, tmp.path(), &mut registry);
+        assert_eq!(result.warnings.len(), 1);
+        assert!(result.warnings[0].contains("does not name"), "{result:?}");
+        assert!(df.nodes[0].input_types.is_empty());
+    }
+
+    #[test]
+    fn undeclared_wiring_and_missing_required_input_warn() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(&tmp.path().join("yolo"), MANIFEST);
+        let mut df = dataflow(
+            r#"
+nodes:
+  - id: detector
+    path: yolo/target/release/dora-yolo
+    inputs:
+      depth: camera/depth
+    outputs: [points]
+"#,
+        );
+        let mut registry = TypeRegistry::new();
+        let result = inject_adjacent_manifests(&mut df, tmp.path(), &mut registry);
+        let all = result.warnings.join("\n");
+        assert!(all.contains("input `depth` is not declared"), "{all}");
+        assert!(all.contains("output `points` is not declared"), "{all}");
+        assert!(all.contains("required input `image` is not wired"), "{all}");
+    }
+
+    #[test]
+    fn custom_types_are_registered() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(
+            &tmp.path().join("lidar"),
+            r#"
+apiVersion: 1
+name: lidar
+namespace: acme
+runtime: rust
+entrypoint: target/release/lidar
+outputs:
+  cloud:
+    type: acme/lidar/v1/PointCloud
+types:
+  acme/lidar/v1/PointCloud:
+    arrow: Struct
+    fields:
+      - name: x
+        type: Float32
+"#,
+        );
+        let mut df = dataflow(
+            r#"
+nodes:
+  - id: lidar
+    path: lidar/target/release/lidar
+    outputs: [cloud]
+"#,
+        );
+        let mut registry = TypeRegistry::new();
+        let result = inject_adjacent_manifests(&mut df, tmp.path(), &mut registry);
+        assert_eq!(result.warnings, Vec::<String>::new());
+        assert!(registry.resolve("acme/lidar/v1/PointCloud").is_some());
+        assert_eq!(
+            df.nodes[0]
+                .output_types
+                .get(&"cloud".parse::<dora_message::id::DataId>().unwrap()),
+            Some(&"acme/lidar/v1/PointCloud".to_string())
+        );
+    }
+
+    #[test]
+    fn invalid_manifest_warns_and_skips() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(
+            &tmp.path().join("bad"),
+            r#"
+apiVersion: 1
+name: bad
+namespace: dora-rs
+runtime: rust
+entrypoint: run
+env:
+  LD_PRELOAD:
+    default: x
+"#,
+        );
+        let mut df = dataflow(
+            r#"
+nodes:
+  - id: bad
+    path: bad/run
+"#,
+        );
+        let mut registry = TypeRegistry::new();
+        let result = inject_adjacent_manifests(&mut df, tmp.path(), &mut registry);
+        assert_eq!(result.warnings.len(), 1);
+        assert!(
+            result.warnings[0].contains("contracts not injected"),
+            "{result:?}"
+        );
+    }
+
+    #[test]
+    fn bare_command_and_url_and_git_nodes_are_skipped() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(tmp.path(), MANIFEST);
+        let mut df = dataflow(
+            r#"
+nodes:
+  - id: console-script
+    path: dora-yolo
+  - id: url
+    path: https://example.com/node
+  - id: git-node
+    path: target/release/dora-yolo
+    git: https://github.com/x/y
+"#,
+        );
+        let mut registry = TypeRegistry::new();
+        let result = inject_adjacent_manifests(&mut df, tmp.path(), &mut registry);
+        assert_eq!(result.notes, Vec::<String>::new());
+        assert_eq!(result.warnings, Vec::<String>::new());
+    }
+
+    #[test]
+    fn paths_outside_working_dir_are_skipped() {
+        let tmp = tempfile::tempdir().unwrap();
+        // a manifest exists at the working dir root, but escaping paths must
+        // never be associated with anything
+        write_manifest(tmp.path(), MANIFEST);
+        let mut df = dataflow(
+            r#"
+nodes:
+  - id: absolute
+    path: /opt/builds/some-node
+  - id: escaping
+    path: ../outside/target/release/dora-yolo
+"#,
+        );
+        let mut registry = TypeRegistry::new();
+        let result = inject_adjacent_manifests(&mut df, tmp.path(), &mut registry);
+        assert_eq!(result.notes, Vec::<String>::new());
+        assert_eq!(result.warnings, Vec::<String>::new());
+        assert!(df.nodes.iter().all(|n| n.input_types.is_empty()));
+    }
+
+    #[test]
+    fn cross_manifest_types_resolve_regardless_of_node_order() {
+        let tmp = tempfile::tempdir().unwrap();
+        // `consumer` (listed first) references a type shipped by `lidar`
+        // (listed second) — pass-1 registration makes this order-independent
+        write_manifest(
+            &tmp.path().join("consumer"),
+            r#"
+apiVersion: 1
+name: consumer
+namespace: beta
+runtime: rust
+entrypoint: target/release/consumer
+inputs:
+  cloud:
+    type: acme/lidar/v1/PointCloud
+    required: false
+"#,
+        );
+        write_manifest(
+            &tmp.path().join("lidar"),
+            r#"
+apiVersion: 1
+name: lidar
+namespace: acme
+runtime: rust
+entrypoint: target/release/lidar
+outputs:
+  cloud:
+    type: acme/lidar/v1/PointCloud
+types:
+  acme/lidar/v1/PointCloud:
+    arrow: Struct
+    fields:
+      - name: x
+        type: Float32
+"#,
+        );
+        let mut df = dataflow(
+            r#"
+nodes:
+  - id: consumer
+    path: consumer/target/release/consumer
+    inputs:
+      cloud: lidar/cloud
+  - id: lidar
+    path: lidar/target/release/lidar
+    outputs: [cloud]
+"#,
+        );
+        let mut registry = TypeRegistry::new();
+        let result = inject_adjacent_manifests(&mut df, tmp.path(), &mut registry);
+        assert_eq!(result.warnings, Vec::<String>::new());
+        assert_eq!(result.notes.len(), 2, "{result:?}");
+    }
+
+    #[test]
+    fn backslash_entrypoint_matches_cross_platform() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(
+            &tmp.path().join("yolo"),
+            r#"
+apiVersion: 1
+name: dora-yolo
+namespace: dora-rs
+runtime: rust
+entrypoint: target\release\dora-yolo
+outputs:
+  bbox:
+    type: std/vision/v1/BoundingBox
+"#,
+        );
+        let mut df = dataflow(
+            r#"
+nodes:
+  - id: detector
+    path: yolo/target/release/dora-yolo
+    outputs: [bbox]
+"#,
+        );
+        let mut registry = TypeRegistry::new();
+        let result = inject_adjacent_manifests(&mut df, tmp.path(), &mut registry);
+        assert_eq!(result.notes.len(), 1, "{result:?}");
+    }
+
+    #[test]
+    fn dot_segments_in_path_still_match() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(&tmp.path().join("yolo"), MANIFEST);
+        let mut df = dataflow(
+            r#"
+nodes:
+  - id: detector
+    path: ./yolo/target/release/dora-yolo
+    inputs:
+      image: camera/image
+    outputs: [bbox]
+"#,
+        );
+        let mut registry = TypeRegistry::new();
+        let result = inject_adjacent_manifests(&mut df, tmp.path(), &mut registry);
+        assert_eq!(result.notes.len(), 1, "{result:?}");
+    }
+}

--- a/libraries/core/src/manifest/inject.rs
+++ b/libraries/core/src/manifest/inject.rs
@@ -97,11 +97,16 @@ pub fn inject_adjacent_manifests(
             if check_shipped_type_urn(urn, &manifest.namespace).is_some() {
                 continue;
             }
-            let body_resolves = def
-                .fields
-                .iter()
-                .all(|f| scratch.field_type_resolves(&f.r#type));
-            if body_resolves && registry.resolve(urn).is_none() {
+            // body-valid = a known `arrow:` discriminant AND every field type
+            // resolves; matches `NodeManifest::validate` so an invalid sibling
+            // can't slip a type into the shared registry that a referencing
+            // node then resolves but can never materialize.
+            let body_valid = crate::types::is_known_arrow_type(&def.arrow)
+                && def
+                    .fields
+                    .iter()
+                    .all(|f| scratch.field_type_resolves(&f.r#type));
+            if body_valid && registry.resolve(urn).is_none() {
                 let _ = registry.add_user_type(urn, def.clone());
             }
         }
@@ -131,11 +136,11 @@ fn find_manifest_for(
     node_id: &NodeId,
     result: &mut InjectionResult,
 ) -> Option<(PathBuf, NodeManifest)> {
-    if !path.contains('/') && !path.contains('\\') {
-        // bare command name (e.g. an installed console script) — there is no
-        // on-disk node directory to search
-        return None;
-    }
+    // A bare `path:` (no separator) is still a local file the daemon resolves
+    // as `working_dir/<path>` (a console script or a local executable next to
+    // `dora-node.yml`), so it is not skipped: `containment_roots` roots it at
+    // the working dir and the walk below matches an adjacent manifest whose
+    // entrypoint names it. A path that escapes the working dir returns `None`.
     let Some((full, working_dir)) = containment_roots(path, working_dir) else {
         // absolute or `..`-escaping paths point outside the dataflow tree —
         // never walk unrelated directories looking for a manifest. (Env-var
@@ -165,12 +170,18 @@ fn find_manifest_for(
             if normalize(&dir.join(entrypoint)) == full {
                 return Some((candidate, manifest));
             }
-            result.warnings.push(sanitize(&format!(
-                "node \"{node_id}\": {} has entrypoint `{}`, which does not name \
-                 the node's path `{path}` — contracts not injected",
-                candidate.display(),
-                manifest.entrypoint,
-            )));
+            // A bare `path:` (console script) commonly shares its working dir
+            // with an unrelated node's manifest, so a mismatch there is not a
+            // mistake — warn only when the path has a directory component that
+            // strongly associates it with the manifest it sits under.
+            if path.contains('/') || path.contains('\\') {
+                result.warnings.push(sanitize(&format!(
+                    "node \"{node_id}\": {} has entrypoint `{}`, which does not name \
+                     the node's path `{path}` — contracts not injected",
+                    candidate.display(),
+                    manifest.entrypoint,
+                )));
+            }
             return None;
         }
     }
@@ -728,6 +739,53 @@ nodes:
         // port check correctly fails to resolve it
         assert!(registry.resolve("acme/foo/v1/X").is_none());
         assert!(df.nodes[1].output_types.is_empty());
+    }
+
+    #[test]
+    fn unknown_arrow_sibling_cannot_contaminate_the_registry() {
+        let tmp = tempfile::tempdir().unwrap();
+        // valid fields but a bogus `arrow:` — still unmaterializable, so it
+        // must not register where a sibling could resolve it
+        write_manifest(
+            &tmp.path().join("bad"),
+            "apiVersion: 1\nname: bad\nnamespace: acme\nruntime: rust\n\
+             entrypoint: target/release/bad\ntypes:\n  acme/foo/v1/X:\n    arrow: NotAnArrowType\n",
+        );
+        write_manifest(
+            &tmp.path().join("victim"),
+            "apiVersion: 1\nname: victim\nnamespace: gamma\nruntime: rust\n\
+             entrypoint: target/release/victim\noutputs:\n  out:\n    type: acme/foo/v1/X\n",
+        );
+        let mut df = dataflow(
+            "nodes:\n  - id: bad\n    path: bad/target/release/bad\n  \
+             - id: victim\n    path: victim/target/release/victim\n    outputs: [out]\n",
+        );
+        let mut registry = TypeRegistry::new();
+        let _ = inject_adjacent_manifests(&mut df, tmp.path(), &mut registry);
+        assert!(registry.resolve("acme/foo/v1/X").is_none());
+        assert!(df.nodes[1].output_types.is_empty());
+    }
+
+    #[test]
+    fn bare_path_with_adjacent_manifest_is_injected() {
+        // a console-script / bare local-exe `path:` next to its manifest must
+        // still get its contracts injected (the entrypoint names the bare path)
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(
+            tmp.path(),
+            "apiVersion: 1\nname: dora-yolo\nnamespace: acme\nruntime: python\n\
+             entrypoint: dora-yolo\noutputs:\n  bbox:\n    type: std/vision/v1/BoundingBox\n",
+        );
+        let mut df =
+            dataflow("nodes:\n  - id: detector\n    path: dora-yolo\n    outputs: [bbox]\n");
+        let mut registry = TypeRegistry::new();
+        inject_adjacent_manifests(&mut df, tmp.path(), &mut registry);
+        assert_eq!(
+            df.nodes[0]
+                .output_types
+                .get(&"bbox".parse::<dora_message::id::DataId>().unwrap()),
+            Some(&"std/vision/v1/BoundingBox".to_string())
+        );
     }
 
     #[test]

--- a/libraries/core/src/manifest/inject.rs
+++ b/libraries/core/src/manifest/inject.rs
@@ -79,36 +79,51 @@ pub fn inject_adjacent_manifests(
     //    *referencing* node's port check pass against a type that can never be
     //    materialized into an Arrow schema.
     // Field bodies may reference *other* shipped types, so resolvability is
-    // checked against a scratch registry holding all namespace-owned
-    // candidates. Already-registered URNs are left untouched: `types/`
-    // definitions and same-manifest re-ships win.
+    // checked against a scratch registry. Admission is a *fixpoint*: a
+    // candidate enters `scratch` only once its `arrow:` discriminant is known
+    // and every field type resolves against what is already admitted. A type
+    // referencing a body-invalid sibling is therefore never admitted, and a
+    // third type referencing *it* can't be admitted either — the gate is
+    // transitively tight (a plain "insert every candidate first" pass would
+    // let `field_type_resolves` see a body-invalid sibling by key presence and
+    // wrongly admit its referent). Already-present URNs are left untouched:
+    // `types/` definitions and same-manifest re-ships win.
     let mut scratch = registry.clone();
+    let mut candidates = Vec::new();
     for (_, (_, manifest)) in &matched {
         for (urn, def) in &manifest.types {
-            if check_shipped_type_urn(urn, &manifest.namespace).is_none()
-                && scratch.resolve(urn).is_none()
-            {
-                scratch.insert_type(urn.clone(), def.clone());
+            if check_shipped_type_urn(urn, &manifest.namespace).is_none() {
+                candidates.push((urn, def));
             }
         }
     }
-    for (_, (_, manifest)) in &matched {
-        for (urn, def) in &manifest.types {
-            if check_shipped_type_urn(urn, &manifest.namespace).is_some() {
+    loop {
+        let mut admitted = false;
+        for &(urn, def) in &candidates {
+            if scratch.resolve(urn).is_some() {
                 continue;
             }
             // body-valid = a known `arrow:` discriminant AND every field type
-            // resolves; matches `NodeManifest::validate` so an invalid sibling
-            // can't slip a type into the shared registry that a referencing
-            // node then resolves but can never materialize.
+            // resolves; matches `NodeManifest::validate`.
             let body_valid = crate::types::is_known_arrow_type(&def.arrow)
                 && def
                     .fields
                     .iter()
                     .all(|f| scratch.field_type_resolves(&f.r#type));
-            if body_valid && registry.resolve(urn).is_none() {
-                let _ = registry.add_user_type(urn, def.clone());
+            if body_valid {
+                scratch.insert_type(urn.clone(), def.clone());
+                admitted = true;
             }
+        }
+        if !admitted {
+            break;
+        }
+    }
+    // Register the survivors into the shared registry, skipping URNs already
+    // present so preserved definitions win.
+    for &(urn, def) in &candidates {
+        if scratch.resolve(urn).is_some() && registry.resolve(urn).is_none() {
+            let _ = registry.add_user_type(urn, def.clone());
         }
     }
 
@@ -762,6 +777,65 @@ nodes:
         );
         let mut registry = TypeRegistry::new();
         let _ = inject_adjacent_manifests(&mut df, tmp.path(), &mut registry);
+        assert!(registry.resolve("acme/foo/v1/X").is_none());
+        assert!(df.nodes[1].output_types.is_empty());
+    }
+
+    #[test]
+    fn type_referencing_a_body_invalid_sibling_is_not_registered() {
+        let tmp = tempfile::tempdir().unwrap();
+        // `bad` ships two own-namespace types: `Y` is body-invalid (its field
+        // type doesn't resolve), and `X` references `Y`. `X`'s body is only
+        // "resolvable" if `Y` is treated as present — but `Y` can never
+        // materialize, so neither may reach the shared registry. The fixpoint
+        // admission must reject `X` transitively, not just `Y`.
+        write_manifest(
+            &tmp.path().join("bad"),
+            r#"
+apiVersion: 1
+name: bad
+namespace: acme
+runtime: rust
+entrypoint: target/release/bad
+types:
+  acme/foo/v1/Y:
+    arrow: Struct
+    fields:
+      - name: y
+        type: NotARealType
+  acme/foo/v1/X:
+    arrow: Struct
+    fields:
+      - name: inner
+        type: acme/foo/v1/Y
+"#,
+        );
+        write_manifest(
+            &tmp.path().join("victim"),
+            r#"
+apiVersion: 1
+name: victim
+namespace: gamma
+runtime: rust
+entrypoint: target/release/victim
+outputs:
+  out:
+    type: acme/foo/v1/X
+"#,
+        );
+        let mut df = dataflow(
+            r#"
+nodes:
+  - id: bad
+    path: bad/target/release/bad
+  - id: victim
+    path: victim/target/release/victim
+    outputs: [out]
+"#,
+        );
+        let mut registry = TypeRegistry::new();
+        let _ = inject_adjacent_manifests(&mut df, tmp.path(), &mut registry);
+        assert!(registry.resolve("acme/foo/v1/Y").is_none());
         assert!(registry.resolve("acme/foo/v1/X").is_none());
         assert!(df.nodes[1].output_types.is_empty());
     }

--- a/libraries/core/src/manifest/inject.rs
+++ b/libraries/core/src/manifest/inject.rs
@@ -69,20 +69,39 @@ pub fn inject_adjacent_manifests(
     // Register shipped types before validating ports, so a manifest can
     // reference a type shipped by another node regardless of node order.
     //
-    // Registration is what makes a type visible to *sibling* manifests' port
-    // checks, so the namespace-ownership gate must run *before* registration —
-    // otherwise an invalid manifest (e.g. an `acme` node shipping a `beta/…`
-    // URN) could grant a definition a different node then relies on. Ownership
-    // is intrinsic (no sibling types needed), so checking it here is safe;
-    // other per-manifest errors are reported in pass 2 and merely suppress
-    // that manifest's own injection. Already-registered URNs are left
-    // untouched: `types/` definitions and same-manifest re-ships win.
+    // Two gates must pass before a type reaches the *shared* registry, where a
+    // sibling node's port check can rely on it:
+    //  - namespace ownership — an invalid manifest (e.g. an `acme` node
+    //    shipping a `beta/…` URN) must not grant a definition another node
+    //    relies on; ownership is intrinsic, so it is safe to check up front.
+    //  - body-resolvability — every field type must resolve, so a sibling that
+    //    ships `acme/foo/v1/X` with an unresolvable field can't make a
+    //    *referencing* node's port check pass against a type that can never be
+    //    materialized into an Arrow schema.
+    // Field bodies may reference *other* shipped types, so resolvability is
+    // checked against a scratch registry holding all namespace-owned
+    // candidates. Already-registered URNs are left untouched: `types/`
+    // definitions and same-manifest re-ships win.
+    let mut scratch = registry.clone();
+    for (_, (_, manifest)) in &matched {
+        for (urn, def) in &manifest.types {
+            if check_shipped_type_urn(urn, &manifest.namespace).is_none()
+                && scratch.resolve(urn).is_none()
+            {
+                scratch.insert_type(urn.clone(), def.clone());
+            }
+        }
+    }
     for (_, (_, manifest)) in &matched {
         for (urn, def) in &manifest.types {
             if check_shipped_type_urn(urn, &manifest.namespace).is_some() {
                 continue;
             }
-            if registry.resolve(urn).is_none() {
+            let body_resolves = def
+                .fields
+                .iter()
+                .all(|f| scratch.field_type_resolves(&f.r#type));
+            if body_resolves && registry.resolve(urn).is_none() {
                 let _ = registry.add_user_type(urn, def.clone());
             }
         }
@@ -655,6 +674,59 @@ nodes:
             all.contains("victim") && all.contains("contracts not injected"),
             "{result:?}"
         );
+        assert!(df.nodes[1].output_types.is_empty());
+    }
+
+    #[test]
+    fn unresolvable_sibling_body_cannot_contaminate_the_registry() {
+        let tmp = tempfile::tempdir().unwrap();
+        // `bad` owns its namespace but ships a type whose field type does not
+        // resolve — it must not register, or a referencing node's port check
+        // would pass against a type that can never be materialized.
+        write_manifest(
+            &tmp.path().join("bad"),
+            r#"
+apiVersion: 1
+name: bad
+namespace: acme
+runtime: rust
+entrypoint: target/release/bad
+types:
+  acme/foo/v1/X:
+    arrow: Struct
+    fields:
+      - name: x
+        type: NotARealType
+"#,
+        );
+        write_manifest(
+            &tmp.path().join("victim"),
+            r#"
+apiVersion: 1
+name: victim
+namespace: gamma
+runtime: rust
+entrypoint: target/release/victim
+outputs:
+  out:
+    type: acme/foo/v1/X
+"#,
+        );
+        let mut df = dataflow(
+            r#"
+nodes:
+  - id: bad
+    path: bad/target/release/bad
+  - id: victim
+    path: victim/target/release/victim
+    outputs: [out]
+"#,
+        );
+        let mut registry = TypeRegistry::new();
+        let _ = inject_adjacent_manifests(&mut df, tmp.path(), &mut registry);
+        // the type with an unresolvable body was never registered, so victim's
+        // port check correctly fails to resolve it
+        assert!(registry.resolve("acme/foo/v1/X").is_none());
         assert!(df.nodes[1].output_types.is_empty());
     }
 

--- a/libraries/core/src/manifest/inject.rs
+++ b/libraries/core/src/manifest/inject.rs
@@ -16,7 +16,10 @@ use std::path::{Component, Path, PathBuf};
 
 use dora_message::{descriptor::Descriptor, id::NodeId};
 
-use super::{MANIFEST_FILENAME, NodeManifest, validate::sanitize};
+use super::{
+    MANIFEST_FILENAME, NodeManifest,
+    validate::{check_shipped_type_urn, sanitize},
+};
 use crate::{descriptor::source_is_url, types::TypeRegistry};
 
 /// Outcome of scanning a dataflow for adjacent node manifests.
@@ -63,15 +66,22 @@ pub fn inject_adjacent_manifests(
         }
     }
 
-    // Register every shipped type before validating any manifest, so that a
-    // manifest referencing a type shipped by another node resolves regardless
-    // of node order. URN policy violations (namespace, charset) are reported
-    // by each manifest's validation in pass 2; only the `std/` override guard
-    // is load-bearing here. Already-registered URNs are left untouched: types
-    // the dataflow author defined in `types/` win over manifest-shipped ones,
-    // and two nodes sharing one manifest re-ship identical definitions.
+    // Register shipped types before validating ports, so a manifest can
+    // reference a type shipped by another node regardless of node order.
+    //
+    // Registration is what makes a type visible to *sibling* manifests' port
+    // checks, so the namespace-ownership gate must run *before* registration —
+    // otherwise an invalid manifest (e.g. an `acme` node shipping a `beta/…`
+    // URN) could grant a definition a different node then relies on. Ownership
+    // is intrinsic (no sibling types needed), so checking it here is safe;
+    // other per-manifest errors are reported in pass 2 and merely suppress
+    // that manifest's own injection. Already-registered URNs are left
+    // untouched: `types/` definitions and same-manifest re-ships win.
     for (_, (_, manifest)) in &matched {
         for (urn, def) in &manifest.types {
+            if check_shipped_type_urn(urn, &manifest.namespace).is_some() {
+                continue;
+            }
             if registry.resolve(urn).is_none() {
                 let _ = registry.add_user_type(urn, def.clone());
             }
@@ -586,6 +596,66 @@ nodes:
         let result = inject_adjacent_manifests(&mut df, tmp.path(), &mut registry);
         assert_eq!(result.warnings, Vec::<String>::new());
         assert_eq!(result.notes.len(), 2, "{result:?}");
+    }
+
+    #[test]
+    fn invalid_sibling_cannot_contaminate_the_registry() {
+        let tmp = tempfile::tempdir().unwrap();
+        // `bad` (namespace acme) ships a type under the *beta* namespace —
+        // a violation. It must not be registered, so the unrelated `victim`
+        // node referencing it must NOT validate against a definition `bad`
+        // was never entitled to ship.
+        write_manifest(
+            &tmp.path().join("bad"),
+            r#"
+apiVersion: 1
+name: bad
+namespace: acme
+runtime: rust
+entrypoint: target/release/bad
+types:
+  beta/foo/v1/X:
+    arrow: Struct
+    fields:
+      - name: x
+        type: Float32
+"#,
+        );
+        write_manifest(
+            &tmp.path().join("victim"),
+            r#"
+apiVersion: 1
+name: victim
+namespace: gamma
+runtime: rust
+entrypoint: target/release/victim
+outputs:
+  out:
+    type: beta/foo/v1/X
+"#,
+        );
+        let mut df = dataflow(
+            r#"
+nodes:
+  - id: bad
+    path: bad/target/release/bad
+  - id: victim
+    path: victim/target/release/victim
+    outputs: [out]
+"#,
+        );
+        let mut registry = TypeRegistry::new();
+        let result = inject_adjacent_manifests(&mut df, tmp.path(), &mut registry);
+        // the out-of-namespace type was never registered
+        assert!(registry.resolve("beta/foo/v1/X").is_none());
+        // victim's port type does not resolve → its manifest fails validation
+        // and contributes no injection
+        let all = result.warnings.join("\n");
+        assert!(
+            all.contains("victim") && all.contains("contracts not injected"),
+            "{result:?}"
+        );
+        assert!(df.nodes[1].output_types.is_empty());
     }
 
     #[test]

--- a/libraries/core/src/manifest/mod.rs
+++ b/libraries/core/src/manifest/mod.rs
@@ -6,6 +6,7 @@
 //! `Cargo.toml`) and is copied verbatim into a hub index entry at publish
 //! time, so discovery never needs to fetch source.
 
+pub mod inject;
 pub mod validate;
 
 use std::{collections::BTreeMap, path::Path};

--- a/libraries/core/src/manifest/validate.rs
+++ b/libraries/core/src/manifest/validate.rs
@@ -329,8 +329,9 @@ fn check_platform(platform: &str) -> Option<String> {
 }
 
 /// Shipped custom types must live under the package's namespace (spec §6.3),
-/// be declared without parameters, and use the URN character set.
-fn check_shipped_type_urn(urn: &str, namespace: &str) -> Option<String> {
+/// be declared without parameters, and use the URN character set. Returns the
+/// problem, or `None` if the manifest is entitled to ship this URN.
+pub(crate) fn check_shipped_type_urn(urn: &str, namespace: &str) -> Option<String> {
     let valid_char = |c: char| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | '/');
     if !urn.chars().all(valid_char) {
         return Some(format!(

--- a/libraries/core/src/manifest/validate.rs
+++ b/libraries/core/src/manifest/validate.rs
@@ -29,12 +29,14 @@ impl std::fmt::Display for ManifestIssue {
 }
 
 fn write_sanitized(f: &mut std::fmt::Formatter<'_>, s: &str) -> std::fmt::Result {
-    // newlines are stripped too: no issue message is legitimately multi-line,
-    // and an embedded `\n` would let a manifest spoof additional output lines
-    for c in s.chars().filter(|c| !c.is_control()) {
-        std::fmt::Write::write_char(f, c)?;
-    }
-    Ok(())
+    f.write_str(&sanitize(s))
+}
+
+/// Strip control characters from untrusted content destined for terminal
+/// output. Newlines are stripped too: no message is legitimately multi-line,
+/// and an embedded `\n` would let a manifest spoof additional output lines.
+pub(crate) fn sanitize(s: &str) -> String {
+    s.chars().filter(|c| !c.is_control()).collect()
 }
 
 /// Environment variable names that could hijack the loader, the interpreter,

--- a/libraries/core/src/types.rs
+++ b/libraries/core/src/types.rs
@@ -613,6 +613,16 @@ impl TypeRegistry {
         Ok(count)
     }
 
+    /// Register a single user-defined type at the given URN (e.g. one shipped
+    /// in a node manifest, spec §6.3). The `std/` prefix is reserved.
+    pub fn add_user_type(&mut self, urn: &str, def: TypeDef) -> Result<(), String> {
+        if urn.starts_with("std/") || urn == "std" {
+            return Err(format!("user types cannot use the \"std/\" prefix: {urn}"));
+        }
+        self.types.insert(urn.to_string(), def);
+        Ok(())
+    }
+
     /// Suggest the closest URN for a typo. Returns `None` if no close match.
     /// Prefers matches in the same package prefix (e.g. `std/media/v1`).
     pub fn suggest(&self, urn: &str) -> Option<&str> {

--- a/libraries/core/src/types.rs
+++ b/libraries/core/src/types.rs
@@ -619,6 +619,16 @@ impl TypeRegistry {
         if urn.starts_with("std/") || urn == "std" {
             return Err(format!("user types cannot use the \"std/\" prefix: {urn}"));
         }
+        // reject control characters and other unexpected bytes so a registered
+        // URN can be safely echoed and used as a map key (namespace ownership
+        // remains the caller's responsibility — the registry has no namespace)
+        let valid_char = |c: char| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | '/');
+        if urn.is_empty() || !urn.chars().all(valid_char) {
+            return Err(format!(
+                "invalid type URN `{}`",
+                urn.chars().filter(|c| !c.is_control()).collect::<String>()
+            ));
+        }
         self.types.insert(urn.to_string(), def);
         Ok(())
     }


### PR DESCRIPTION
Implements **P1.4** of the Dora Hub spec ([docs/plan-node-hub.md](https://github.com/dora-rs/dora/blob/main/docs/plan-node-hub.md) §6.2, umbrella #2097): a `dora-node.yml` sitting next to a plain `path:` node is picked up by `dora validate` and `dora build`, so local development gets the same compose-time contract checking that hub consumption will get (UC11, UC2).

**Stacked on #2174** (needs the manifest module) — base is `feat/hub-node-manifest`; will retarget to `main` once that merges.

## How it works

- For each plain local-`path:` node, the injector walks up from the executable's path looking for a `dora-node.yml`. A manifest applies **iff** `<manifest dir>/<entrypoint> == <working dir>/<path>` — exact association even when the manifest sits at the node's source root and the binary is at `target/release/<bin>`. The walk never leaves the dataflow's working directory; absolute and `..`-escaping paths are skipped entirely.
- A matched manifest's typed ports are injected as the node's `input_types`/`output_types` annotations (the dataflow author's own annotations win); from there the existing validation pipeline applies unchanged — edge compatibility, field-level struct diffs, inference, `strict_types`.
- The dataflow's wiring is checked against the declared ports (§10.1): undeclared inputs/outputs and unwired required inputs are warnings, fatal under `--strict-types`.
- Custom types shipped in manifests (`types:`) are registered into the `TypeRegistry` in a first pass over all matched manifests, so cross-manifest type references resolve regardless of node order.

Live-tested (UC2): a manifest-typed `bbox` output wired into a consumer expecting `std/media/v1/Image` fails at compose time with the producer/consumer URNs and the field-level diff, before anything runs.

## Hardening (from self-review)

- Walk containment: a hostile or accidental `dora-node.yml` outside the working dir can never be associated with a node.
- All injection notes/warnings are control-character-sanitized (they embed manifest/path content and are printed by the CLI).
- Manifest entrypoints using `\` separators match on every platform.
- Entrypoint mismatch warns rather than silently skipping, so a typo'd `entrypoint` is visible.

## Verification

- 11 new unit tests in `manifest/inject.rs` (injection, author-override, mismatch, containment, cross-manifest types, backslash entrypoints, invalid-manifest skip).
- fmt + clippy `-D warnings` + full workspace tests + `cargo check --examples`.
- Live: `dora validate` and `dora build` on a fixture dataflow — injection note printed, downstream mismatch caught, `--strict-types` exits 1.

Part of #2097.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
