### PR TITLE
feat(hub): dora-hub-client crate — index format, resolution, transport (P2.1+P2.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1928,6 +1928,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dora-hub-client"
+version = "1.0.0-rc1"
+dependencies = [
+ "dirs 6.0.0",
+ "dora-core",
+ "eyre",
+ "semver",
+ "serde",
+ "serde_yaml",
+ "tempfile",
+ "toml",
+]
+
+[[package]]
 name = "dora-log-utils"
 version = "1.0.0-rc1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ members = [
     "libraries/log-utils",
     "libraries/coordinator-store",
     "libraries/core",
+    "libraries/hub-client",
     "libraries/message",
     "libraries/recording",
     "binaries/replay-node",
@@ -102,6 +103,7 @@ dora-operator-api-python = { version = "1.0.0-rc1", path = "apis/python/operator
 dora-operator-api-c = { version = "1.0.0-rc1", path = "apis/c/operator" }
 dora-node-api-c = { version = "1.0.0-rc1", path = "apis/c/node" }
 dora-core = { version = "1.0.0-rc1", path = "libraries/core" }
+dora-hub-client = { version = "1.0.0-rc1", path = "libraries/hub-client" }
 dora-recording = { version = "1.0.0-rc1", path = "libraries/recording" }
 dora-arrow-convert = { version = "1.0.0-rc1", path = "libraries/arrow-convert" }
 dora-tracing = { version = "1.0.0-rc1", path = "libraries/extensions/telemetry/tracing" }

--- a/libraries/core/src/types.rs
+++ b/libraries/core/src/types.rs
@@ -692,7 +692,7 @@ impl Default for TypeRegistry {
 
 /// Simple edit distance (Levenshtein) for typo suggestions.
 /// Returns `usize::MAX` for inputs longer than 256 characters to prevent DoS.
-fn edit_distance(a: &str, b: &str) -> usize {
+pub fn edit_distance(a: &str, b: &str) -> usize {
     if a.len() > 256 || b.len() > 256 {
         return usize::MAX;
     }

--- a/libraries/hub-client/Cargo.toml
+++ b/libraries/hub-client/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "dora-hub-client"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+documentation.workspace = true
+description = "Dora Hub index client: package references, index resolution, and transport"
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+dora-core = { workspace = true }
+eyre = { workspace = true }
+semver = { workspace = true }
+serde = { workspace = true }
+serde_yaml = { workspace = true }
+toml = "0.9"
+dirs = "6"
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/libraries/hub-client/src/config.rs
+++ b/libraries/hub-client/src/config.rs
@@ -100,7 +100,9 @@ impl ResolvedConfig {
         let mut seen_aliases = BTreeMap::new();
         for (idx, index) in indexes.iter().enumerate() {
             validate_index_entry(index)?;
-            if let Some(previous) = seen_aliases.insert(index.alias.clone(), idx) {
+            // case-insensitive: aliases become cache directory names, and
+            // `acme`/`ACME` would silently share one clone on macOS/Windows
+            if let Some(previous) = seen_aliases.insert(index.alias.to_ascii_lowercase(), idx) {
                 eyre::bail!(
                     "duplicate index alias `{}` (entries {} and {idx})",
                     index.alias,
@@ -166,7 +168,7 @@ impl ResolvedConfig {
 /// Validate one `[[index]]` entry. The alias becomes a cache directory name
 /// and the git URL/path become `git` subprocess arguments — all of it is
 /// user- or repo-supplied, so each field is constrained before use.
-fn validate_index_entry(index: &IndexConfig) -> eyre::Result<()> {
+pub(crate) fn validate_index_entry(index: &IndexConfig) -> eyre::Result<()> {
     let alias_valid = index.alias.len() <= 64
         && index
             .alias

--- a/libraries/hub-client/src/config.rs
+++ b/libraries/hub-client/src/config.rs
@@ -1,0 +1,356 @@
+//! Multi-index configuration and namespace binding (spec §7.3).
+//!
+//! `~/.config/dora/hub.toml` declares `[[index]]` entries. **A namespace
+//! resolves against exactly one index**: explicit `namespaces` bindings win,
+//! the official index carries every unbound namespace, and a namespace bound
+//! by two entries is a configuration error — there is no search order to
+//! race, which makes dependency-confusion attacks structurally impossible.
+
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
+
+use eyre::Context;
+use serde::Deserialize;
+
+use crate::{OFFICIAL_INDEX_ALIAS, OFFICIAL_INDEX_GIT, OFFICIAL_INDEX_PATH};
+
+/// Parsed `hub.toml`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HubConfig {
+    #[serde(default, rename = "index")]
+    pub indexes: Vec<IndexConfig>,
+}
+
+/// One `[[index]]` entry.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct IndexConfig {
+    /// Short name; also the cache directory name for git indexes.
+    pub alias: String,
+    /// Git repository holding the catalog (remote indexes).
+    #[serde(default)]
+    pub git: Option<String>,
+    /// For git indexes: catalog directory within the repository
+    /// (default `node-index`). For local indexes: the catalog directory
+    /// itself — relative paths resolve against the config file location.
+    #[serde(default)]
+    pub path: Option<String>,
+    /// Namespaces bound exclusively to this index. Empty = this index only
+    /// serves as the official default (valid for the `official` alias).
+    #[serde(default)]
+    pub namespaces: Vec<String>,
+}
+
+impl IndexConfig {
+    /// The implicit official index entry (spec §7.3: a missing config file
+    /// means `official` only).
+    pub fn official() -> Self {
+        Self {
+            alias: OFFICIAL_INDEX_ALIAS.into(),
+            git: Some(OFFICIAL_INDEX_GIT.into()),
+            path: Some(OFFICIAL_INDEX_PATH.into()),
+            namespaces: Vec::new(),
+        }
+    }
+
+    /// Whether this entry points at a local directory instead of a git repo.
+    pub fn is_local(&self) -> bool {
+        self.git.is_none()
+    }
+
+    /// For local indexes: the catalog directory, resolved against the
+    /// directory the config file lives in.
+    pub fn local_catalog_dir(&self, config_dir: &Path) -> eyre::Result<PathBuf> {
+        let path = self
+            .path
+            .as_deref()
+            .ok_or_else(|| eyre::eyre!("index `{}` has neither `git` nor `path`", self.alias))?;
+        let path = Path::new(path);
+        Ok(if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            config_dir.join(path)
+        })
+    }
+}
+
+/// Validated configuration: every namespace maps to exactly one index.
+#[derive(Debug, Clone)]
+pub struct ResolvedConfig {
+    /// All configured indexes, official included.
+    pub indexes: Vec<IndexConfig>,
+    /// Directory the config was loaded from (base for relative `path =`).
+    pub config_dir: PathBuf,
+    bindings: BTreeMap<String, usize>,
+    default_index: usize,
+}
+
+impl ResolvedConfig {
+    /// Build from parsed entries, enforcing the binding rules.
+    pub fn new(mut indexes: Vec<IndexConfig>, config_dir: PathBuf) -> eyre::Result<Self> {
+        // the official index is always present; an explicit `official` alias
+        // entry may override its location (e.g. an enterprise mirror)
+        if !indexes.iter().any(|i| i.alias == OFFICIAL_INDEX_ALIAS) {
+            indexes.push(IndexConfig::official());
+        }
+        let mut bindings = BTreeMap::new();
+        let mut seen_aliases = BTreeMap::new();
+        for (idx, index) in indexes.iter().enumerate() {
+            validate_index_entry(index)?;
+            if let Some(previous) = seen_aliases.insert(index.alias.clone(), idx) {
+                eyre::bail!(
+                    "duplicate index alias `{}` (entries {} and {idx})",
+                    index.alias,
+                    previous
+                );
+            }
+            for namespace in &index.namespaces {
+                if let Some(previous) = bindings.insert(namespace.clone(), idx) {
+                    eyre::bail!(
+                        "namespace `{namespace}` is bound by two indexes \
+                         (`{}` and `{}`) — a namespace resolves against \
+                         exactly one index",
+                        indexes[previous].alias,
+                        index.alias
+                    );
+                }
+            }
+        }
+        let default_index = indexes
+            .iter()
+            .position(|i| i.alias == OFFICIAL_INDEX_ALIAS)
+            .expect("official index inserted above");
+        Ok(Self {
+            indexes,
+            config_dir,
+            bindings,
+            default_index,
+        })
+    }
+
+    /// Load from the conventional location (`<config_dir>/dora/hub.toml`),
+    /// falling back to official-only when the file does not exist.
+    pub fn load_default() -> eyre::Result<Self> {
+        let Some(config_dir) = dirs::config_dir() else {
+            return Self::new(Vec::new(), PathBuf::from("."));
+        };
+        Self::load_from(&config_dir.join("dora").join("hub.toml"))
+    }
+
+    /// Load from an explicit config file path (missing file = official only).
+    pub fn load_from(path: &Path) -> eyre::Result<Self> {
+        let config_dir = path.parent().unwrap_or(Path::new(".")).to_path_buf();
+        if !path.is_file() {
+            return Self::new(Vec::new(), config_dir);
+        }
+        let raw = std::fs::read_to_string(path)
+            .with_context(|| format!("failed to read `{}`", path.display()))?;
+        let config: HubConfig = toml::from_str(&raw)
+            .with_context(|| format!("invalid hub config `{}`", path.display()))?;
+        Self::new(config.indexes, config_dir)
+            .with_context(|| format!("invalid hub config `{}`", path.display()))
+    }
+
+    /// The index a namespace resolves against (spec §7.3).
+    pub fn index_for_namespace(&self, namespace: &str) -> &IndexConfig {
+        match self.bindings.get(namespace) {
+            Some(&idx) => &self.indexes[idx],
+            None => &self.indexes[self.default_index],
+        }
+    }
+}
+
+/// Validate one `[[index]]` entry. The alias becomes a cache directory name
+/// and the git URL/path become `git` subprocess arguments — all of it is
+/// user- or repo-supplied, so each field is constrained before use.
+fn validate_index_entry(index: &IndexConfig) -> eyre::Result<()> {
+    let alias_valid = index.alias.len() <= 64
+        && index
+            .alias
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_alphanumeric())
+        && index
+            .alias
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_'));
+    if !alias_valid {
+        eyre::bail!(
+            "invalid index alias `{}`: expected `[A-Za-z0-9_-]+` (max 64 chars)",
+            index
+                .alias
+                .chars()
+                .filter(|c| !c.is_control())
+                .collect::<String>()
+        );
+    }
+    match (&index.git, &index.path) {
+        (None, None) => {
+            eyre::bail!("index `{}` has neither `git` nor `path`", index.alias)
+        }
+        (Some(git), path) => {
+            crate::validate_git_url(git).with_context(|| format!("index `{}`", index.alias))?;
+            // for git indexes the path is a directory *within* the clone:
+            // it must stay relative and confined
+            if let Some(path) = path {
+                let confined = !path.is_empty()
+                    && !path.starts_with('-')
+                    && !path.starts_with('/')
+                    && !path.starts_with('\\')
+                    && !path.split(['/', '\\']).any(|c| c == "..")
+                    && !path.contains(|c: char| c.is_control());
+                if !confined {
+                    eyre::bail!(
+                        "index `{}`: `path` must be a relative directory inside \
+                         the repository (no `..`, no leading `-`)",
+                        index.alias
+                    );
+                }
+            }
+        }
+        (None, Some(path)) => {
+            if path.contains(|c: char| c.is_control()) {
+                eyre::bail!("index `{}`: invalid `path`", index.alias);
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(toml_str: &str) -> eyre::Result<ResolvedConfig> {
+        let parsed: HubConfig = toml::from_str(toml_str).unwrap();
+        ResolvedConfig::new(parsed.indexes, PathBuf::from("/cfg"))
+    }
+
+    const ACME: &str = r#"
+[[index]]
+alias = "acme"
+git = "git@github.com:acme/dora-index.git"
+namespaces = ["acme"]
+
+[[index]]
+alias = "fixtures"
+path = "./tests/fixtures/index"
+namespaces = ["test"]
+"#;
+
+    #[test]
+    fn missing_config_is_official_only() {
+        let resolved = ResolvedConfig::new(Vec::new(), PathBuf::from(".")).unwrap();
+        assert_eq!(resolved.indexes.len(), 1);
+        let index = resolved.index_for_namespace("anything");
+        assert_eq!(index.alias, "official");
+        assert_eq!(index.git.as_deref(), Some(crate::OFFICIAL_INDEX_GIT));
+    }
+
+    #[test]
+    fn explicit_bindings_win_and_official_takes_the_rest() {
+        let resolved = config(ACME).unwrap();
+        assert_eq!(resolved.index_for_namespace("acme").alias, "acme");
+        assert_eq!(resolved.index_for_namespace("test").alias, "fixtures");
+        assert_eq!(resolved.index_for_namespace("dora-rs").alias, "official");
+        assert_eq!(resolved.index_for_namespace("unbound").alias, "official");
+    }
+
+    #[test]
+    fn double_binding_is_an_error() {
+        let err = config(
+            r#"
+[[index]]
+alias = "a"
+git = "https://example.com/a"
+namespaces = ["acme"]
+
+[[index]]
+alias = "b"
+git = "https://example.com/b"
+namespaces = ["acme"]
+"#,
+        )
+        .unwrap_err();
+        assert!(format!("{err}").contains("exactly one index"), "{err}");
+    }
+
+    #[test]
+    fn duplicate_alias_is_an_error() {
+        let err = config(
+            r#"
+[[index]]
+alias = "a"
+git = "https://example.com/a"
+
+[[index]]
+alias = "a"
+git = "https://example.com/b"
+"#,
+        )
+        .unwrap_err();
+        assert!(format!("{err}").contains("duplicate index alias"), "{err}");
+    }
+
+    #[test]
+    fn official_alias_can_be_overridden() {
+        let resolved = config(
+            r#"
+[[index]]
+alias = "official"
+git = "https://git.corp.example/dora-index-mirror"
+"#,
+        )
+        .unwrap();
+        assert_eq!(resolved.indexes.len(), 1);
+        assert_eq!(
+            resolved.index_for_namespace("dora-rs").git.as_deref(),
+            Some("https://git.corp.example/dora-index-mirror")
+        );
+    }
+
+    #[test]
+    fn entry_needs_git_or_path() {
+        let err = config("[[index]]\nalias = \"x\"\n").unwrap_err();
+        assert!(format!("{err}").contains("neither"), "{err}");
+    }
+
+    #[test]
+    fn hostile_config_values_are_rejected() {
+        // alias becomes a cache directory name
+        for alias in ["", "../../evil", "a/b", "a\\b", "-x"] {
+            let err = config(&format!(
+                "[[index]]\nalias = '{alias}'\ngit = \"https://example.com/x\"\n"
+            ))
+            .unwrap_err();
+            assert!(format!("{err}").contains("alias"), "{alias}: {err}");
+        }
+        // git URLs become subprocess arguments
+        for url in ["--upload-pack=evil", "ext::sh -c evil", "host:path"] {
+            let err = config(&format!("[[index]]\nalias = \"x\"\ngit = '{url}'\n")).unwrap_err();
+            assert!(format!("{err:#}").contains("git URL"), "{url}: {err:#}");
+        }
+        // a git index's path must stay inside the clone
+        for path in ["../outside", "/abs", "-flag", "a/../../b"] {
+            let err = config(&format!(
+                "[[index]]\nalias = \"x\"\ngit = \"https://example.com/x\"\npath = '{path}'\n"
+            ))
+            .unwrap_err();
+            assert!(
+                format!("{err}").contains("relative directory"),
+                "{path}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn local_catalog_dir_resolves_relative_to_config() {
+        let resolved = config(ACME).unwrap();
+        let fixtures = resolved.index_for_namespace("test");
+        let dir = fixtures.local_catalog_dir(&resolved.config_dir).unwrap();
+        assert_eq!(dir, PathBuf::from("/cfg/tests/fixtures/index"));
+    }
+}

--- a/libraries/hub-client/src/config.rs
+++ b/libraries/hub-client/src/config.rs
@@ -14,7 +14,7 @@ use std::{
 use eyre::Context;
 use serde::Deserialize;
 
-use crate::{OFFICIAL_INDEX_ALIAS, OFFICIAL_INDEX_GIT, OFFICIAL_INDEX_PATH};
+use crate::{OFFICIAL_INDEX_ALIAS, OFFICIAL_INDEX_GIT, OFFICIAL_INDEX_PATH, OFFICIAL_NAMESPACE};
 
 /// Parsed `hub.toml`.
 #[derive(Debug, Clone, Deserialize)]
@@ -110,6 +110,17 @@ impl ResolvedConfig {
                 );
             }
             for namespace in &index.namespaces {
+                // the official namespace always resolves against the official
+                // index — a non-official entry binding it would silently shadow
+                // the official source (dependency confusion), so reject it
+                if namespace == OFFICIAL_NAMESPACE && index.alias != OFFICIAL_INDEX_ALIAS {
+                    eyre::bail!(
+                        "index `{}` cannot bind the official namespace \
+                         `{OFFICIAL_NAMESPACE}` — it always resolves against the \
+                         official index",
+                        index.alias
+                    );
+                }
                 if let Some(previous) = bindings.insert(namespace.clone(), idx) {
                     eyre::bail!(
                         "namespace `{namespace}` is bound by two indexes \
@@ -278,6 +289,20 @@ namespaces = ["acme"]
         )
         .unwrap_err();
         assert!(format!("{err}").contains("exactly one index"), "{err}");
+    }
+
+    #[test]
+    fn non_official_index_cannot_bind_the_official_namespace() {
+        let err = config(
+            r#"
+[[index]]
+alias = "evil"
+git = "https://example.com/evil"
+namespaces = ["dora-rs"]
+"#,
+        )
+        .unwrap_err();
+        assert!(format!("{err}").contains("official namespace"), "{err}");
     }
 
     #[test]

--- a/libraries/hub-client/src/index.rs
+++ b/libraries/hub-client/src/index.rs
@@ -84,13 +84,17 @@ impl SourceSpec {
         match (&self.git, &self.rev) {
             (Some(git), Some(rev)) => {
                 crate::validate_git_url(git)?;
-                // a real commit hash only: a branch or tag name here would
-                // make the "pin" mutable, defeating the audit trail and yanks
+                // a full, immutable object id only: a branch/tag name would
+                // make the "pin" mutable (defeating the audit trail and
+                // yanks), and an *abbreviated* hash can grow ambiguous as the
+                // source repo gains commits. Require a full SHA-1 (40) or
+                // SHA-256 (64) hex digest.
                 let valid_rev =
-                    (7..=64).contains(&rev.len()) && rev.chars().all(|c| c.is_ascii_hexdigit());
+                    matches!(rev.len(), 40 | 64) && rev.chars().all(|c| c.is_ascii_hexdigit());
                 if !valid_rev {
                     eyre::bail!(
-                        "index entry has an invalid commit hash (`rev` must be a hex hash)"
+                        "index entry has an invalid commit hash \
+                         (`rev` must be a full 40- or 64-char hex object id)"
                     );
                 }
                 Ok((git, rev))
@@ -241,9 +245,11 @@ impl IndexCatalog {
             .collect();
         // versions() returns ascending order; walk highest-first, skipping
         // yanked versions
+        let mut had_yanked_match = false;
         for version in matching.iter().rev() {
             let entry = self.entry(&reference.namespace, &reference.name, version)?;
             if entry.yanked {
+                had_yanked_match = true;
                 continue;
             }
             return Ok(ResolvedVersion {
@@ -251,15 +257,34 @@ impl IndexCatalog {
                 entry,
             });
         }
+        // distinguish "your range matched only yanked versions" from "no
+        // version matches your range"
+        if had_yanked_match {
+            eyre::bail!(
+                "every version of `{}` matching `{}` has been yanked",
+                reference.key(),
+                reference.requirement
+            );
+        }
+        // list only installable (non-yanked) versions as "available"
+        let available: Vec<String> = versions
+            .iter()
+            .filter(|v| {
+                self.entry(&reference.namespace, &reference.name, v)
+                    .map(|e| !e.yanked)
+                    .unwrap_or(false)
+            })
+            .map(ToString::to_string)
+            .collect();
         eyre::bail!(
             "no version of `{}` satisfies `{}` (available: {})",
             reference.key(),
             reference.requirement,
-            versions
-                .iter()
-                .map(ToString::to_string)
-                .collect::<Vec<_>>()
-                .join(", ")
+            if available.is_empty() {
+                "none".to_string()
+            } else {
+                available.join(", ")
+            }
         )
     }
 
@@ -363,9 +388,21 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let pkg = tmp.path().join("dora-rs/dora-yolo");
         std::fs::create_dir_all(&pkg).unwrap();
-        std::fs::write(pkg.join("0.5.1.yml"), entry_yaml("aaa1111", false)).unwrap();
-        std::fs::write(pkg.join("0.5.2.yml"), entry_yaml("bbb2222", false)).unwrap();
-        std::fs::write(pkg.join("0.6.0.yml"), entry_yaml("ccc3333", true)).unwrap();
+        std::fs::write(
+            pkg.join("0.5.1.yml"),
+            entry_yaml("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", false),
+        )
+        .unwrap();
+        std::fs::write(
+            pkg.join("0.5.2.yml"),
+            entry_yaml("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", false),
+        )
+        .unwrap();
+        std::fs::write(
+            pkg.join("0.6.0.yml"),
+            entry_yaml("cccccccccccccccccccccccccccccccccccccccc", true),
+        )
+        .unwrap();
         std::fs::write(
             pkg.join("package.yml"),
             "description: object detection\nowners: [haixuanTao]\n",
@@ -386,7 +423,7 @@ mod tests {
         assert_eq!(resolved.version, Version::parse("0.5.2").unwrap());
         let (git, rev) = resolved.entry.source.git_pin().unwrap();
         assert_eq!(git, "https://github.com/dora-rs/dora-hub");
-        assert_eq!(rev, "bbb2222");
+        assert_eq!(rev, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
     }
 
     #[test]
@@ -394,8 +431,16 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let pkg = tmp.path().join("dora-rs/dora-yolo");
         std::fs::create_dir_all(&pkg).unwrap();
-        std::fs::write(pkg.join("0.5.1.yml"), entry_yaml("aaa1111", false)).unwrap();
-        std::fs::write(pkg.join("0.6.0-alpha.1.yml"), entry_yaml("ddd4444", false)).unwrap();
+        std::fs::write(
+            pkg.join("0.5.1.yml"),
+            entry_yaml("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", false),
+        )
+        .unwrap();
+        std::fs::write(
+            pkg.join("0.6.0-alpha.1.yml"),
+            entry_yaml("dddddddddddddddddddddddddddddddddddddddd", false),
+        )
+        .unwrap();
         let catalog = IndexCatalog::open(tmp.path()).unwrap();
         // a plain requirement never matches a prerelease
         let resolved = catalog.resolve(&parse_ref("dora-yolo@>=0.5")).unwrap();
@@ -424,6 +469,24 @@ mod tests {
     }
 
     #[test]
+    fn git_pin_requires_a_full_object_id() {
+        let full = "a".repeat(40);
+        for (rev, ok) in [
+            (full.as_str(), true),
+            (&"b".repeat(64), true),
+            ("abc1234", false),       // abbreviated — rejected
+            (&"a".repeat(39), false), // not a full SHA-1
+            ("main", false),          // branch name
+        ] {
+            let entry: IndexEntry = serde_yaml::from_str(&format!(
+                "manifest:{MANIFEST}source:\n  git: https://example.com/r\n  rev: \"{rev}\"\n"
+            ))
+            .unwrap();
+            assert_eq!(entry.source.git_pin().is_ok(), ok, "rev `{rev}`");
+        }
+    }
+
+    #[test]
     fn yanked_versions_are_skipped() {
         let (_tmp, catalog) = fixture();
         // 0.6.0 is yanked — `*` resolves to 0.5.2 instead
@@ -432,11 +495,25 @@ mod tests {
     }
 
     #[test]
-    fn unsatisfiable_requirement_lists_available() {
+    fn unsatisfiable_requirement_lists_only_unyanked() {
         let (_tmp, catalog) = fixture();
+        // 0.6.0 is yanked — it must not appear in the "available" list
         let err = catalog.resolve(&parse_ref("dora-yolo@^2")).unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("0.5.2"), "{msg}");
+        assert!(
+            !msg.contains("0.6.0"),
+            "yanked version listed as available: {msg}"
+        );
+    }
+
+    #[test]
+    fn requirement_matching_only_yanked_says_so() {
+        let (_tmp, catalog) = fixture();
+        // 0.6.0 is the only version matching ^0.6, and it is yanked
+        let err = catalog.resolve(&parse_ref("dora-yolo@^0.6")).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("has been yanked"), "{msg}");
     }
 
     #[test]

--- a/libraries/hub-client/src/index.rs
+++ b/libraries/hub-client/src/index.rs
@@ -244,6 +244,7 @@ impl IndexCatalog {
         if !path.is_file() {
             return Ok(None);
         }
+        self.confine(&path)?;
         let raw = read_capped(&path)?;
         let meta = serde_yaml::from_str(&raw)
             .with_context(|| format!("invalid package metadata `{}`", path.display()))?;
@@ -462,18 +463,20 @@ mod tests {
         std::fs::create_dir_all(&real).unwrap();
         let rev = "a".repeat(40);
         std::fs::write(real.join("9.9.9.yml"), entry_yaml(&rev, false)).unwrap();
+        std::fs::write(real.join("package.yml"), "description: evil\n").unwrap();
         // inside the catalog, a package dir that is a symlink pointing there
         let ns = tmp.path().join("acme");
         std::fs::create_dir_all(&ns).unwrap();
         std::os::unix::fs::symlink(&real, ns.join("escape")).unwrap();
         let catalog = IndexCatalog::open(tmp.path()).unwrap();
-        // both the dir listing and the entry read must refuse to follow it
+        // dir listing, entry read, AND package metadata read must all refuse it
         assert!(catalog.versions("acme", "escape").is_err());
         assert!(
             catalog
                 .entry("acme", "escape", &Version::parse("9.9.9").unwrap())
                 .is_err()
         );
+        assert!(catalog.package_meta("acme", "escape").is_err());
     }
 
     #[test]

--- a/libraries/hub-client/src/index.rs
+++ b/libraries/hub-client/src/index.rs
@@ -84,9 +84,14 @@ impl SourceSpec {
         match (&self.git, &self.rev) {
             (Some(git), Some(rev)) => {
                 crate::validate_git_url(git)?;
-                let valid_rev = !rev.is_empty() && rev.chars().all(|c| c.is_ascii_alphanumeric());
+                // a real commit hash only: a branch or tag name here would
+                // make the "pin" mutable, defeating the audit trail and yanks
+                let valid_rev =
+                    (7..=64).contains(&rev.len()) && rev.chars().all(|c| c.is_ascii_hexdigit());
                 if !valid_rev {
-                    eyre::bail!("index entry has an invalid commit hash");
+                    eyre::bail!(
+                        "index entry has an invalid commit hash (`rev` must be a hex hash)"
+                    );
                 }
                 Ok((git, rev))
             }
@@ -139,7 +144,13 @@ impl IndexCatalog {
     fn package_dir(&self, namespace: &str, name: &str) -> eyre::Result<PathBuf> {
         for part in [namespace, name] {
             if !is_valid_key_part(part) {
-                eyre::bail!("invalid package key `{namespace}/{name}`");
+                // the key is untrusted — strip control chars before echoing
+                let shown: String = format!("{namespace}/{name}")
+                    .chars()
+                    .filter(|c| !c.is_control())
+                    .take(128)
+                    .collect();
+                eyre::bail!("invalid package key `{shown}`");
             }
         }
         Ok(self.root.join(namespace).join(name))
@@ -151,7 +162,13 @@ impl IndexCatalog {
         let mut versions = Vec::new();
         let entries = match std::fs::read_dir(&dir) {
             Ok(entries) => entries,
-            Err(_) => return Ok(versions), // unknown package = no versions
+            // unknown package = no versions; other IO errors (permissions,
+            // …) must not masquerade as package-not-found
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(versions),
+            Err(err) => {
+                return Err(err)
+                    .with_context(|| format!("failed to list versions in `{}`", dir.display()));
+            }
         };
         for entry in entries.flatten() {
             let path = entry.path();
@@ -346,9 +363,9 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let pkg = tmp.path().join("dora-rs/dora-yolo");
         std::fs::create_dir_all(&pkg).unwrap();
-        std::fs::write(pkg.join("0.5.1.yml"), entry_yaml("aaa", false)).unwrap();
-        std::fs::write(pkg.join("0.5.2.yml"), entry_yaml("bbb", false)).unwrap();
-        std::fs::write(pkg.join("0.6.0.yml"), entry_yaml("ccc", true)).unwrap();
+        std::fs::write(pkg.join("0.5.1.yml"), entry_yaml("aaa1111", false)).unwrap();
+        std::fs::write(pkg.join("0.5.2.yml"), entry_yaml("bbb2222", false)).unwrap();
+        std::fs::write(pkg.join("0.6.0.yml"), entry_yaml("ccc3333", true)).unwrap();
         std::fs::write(
             pkg.join("package.yml"),
             "description: object detection\nowners: [haixuanTao]\n",
@@ -369,7 +386,7 @@ mod tests {
         assert_eq!(resolved.version, Version::parse("0.5.2").unwrap());
         let (git, rev) = resolved.entry.source.git_pin().unwrap();
         assert_eq!(git, "https://github.com/dora-rs/dora-hub");
-        assert_eq!(rev, "bbb");
+        assert_eq!(rev, "bbb2222");
     }
 
     #[test]
@@ -377,8 +394,8 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let pkg = tmp.path().join("dora-rs/dora-yolo");
         std::fs::create_dir_all(&pkg).unwrap();
-        std::fs::write(pkg.join("0.5.1.yml"), entry_yaml("aaa", false)).unwrap();
-        std::fs::write(pkg.join("0.6.0-alpha.1.yml"), entry_yaml("pre", false)).unwrap();
+        std::fs::write(pkg.join("0.5.1.yml"), entry_yaml("aaa1111", false)).unwrap();
+        std::fs::write(pkg.join("0.6.0-alpha.1.yml"), entry_yaml("ddd4444", false)).unwrap();
         let catalog = IndexCatalog::open(tmp.path()).unwrap();
         // a plain requirement never matches a prerelease
         let resolved = catalog.resolve(&parse_ref("dora-yolo@>=0.5")).unwrap();

--- a/libraries/hub-client/src/index.rs
+++ b/libraries/hub-client/src/index.rs
@@ -1,0 +1,472 @@
+//! The on-disk index catalog format and resolution (spec §7.1/§7.2/§8.1).
+//!
+//! A catalog is a directory tree `<root>/<namespace>/<name>/<version>.yml`
+//! plus a per-package `package.yml`. Version files hold the node manifest
+//! verbatim and a source pointer; resolution picks the highest non-yanked
+//! version satisfying a requirement.
+
+use std::path::{Path, PathBuf};
+
+use dora_core::{manifest::NodeManifest, types::edit_distance};
+use eyre::Context;
+use semver::Version;
+use serde::{Deserialize, Serialize};
+
+use crate::reference::PackageRef;
+
+/// Upper bound on an index entry file. Entries hold a manifest (already
+/// capped) plus a small source stanza.
+const MAX_ENTRY_SIZE: u64 = 2 * 1024 * 1024;
+
+/// One published version: manifest snapshot + source pointer (spec §7.1).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct IndexEntry {
+    /// The node's `dora-node.yml`, copied verbatim at publish time.
+    pub manifest: NodeManifest,
+    /// Where the bytes live (spec §8.1).
+    pub source: SourceSpec,
+    /// Publish timestamp (RFC 3339), informational.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub published: Option<String>,
+    /// Yanked versions are skipped by resolution (UC10); existing lockfile
+    /// pins keep working with a warning.
+    #[serde(default)]
+    pub yanked: bool,
+    /// Reason recorded when yanking.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub yank_reason: Option<String>,
+}
+
+/// The source pointer of a published version (spec §8.1).
+///
+/// The git form is the default and the v1 source-of-record. The binary form
+/// is reserved in the schema (spec §8.2) and parses, but consuming it is
+/// deferred to P2.8.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SourceSpec {
+    /// Git repository URL holding the node's source.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub git: Option<String>,
+    /// Commit hash the version is pinned to (resolved from a tag at publish).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rev: Option<String>,
+    /// Where in the repository the node lives (monorepo support).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subdir: Option<String>,
+    /// Reserved: per-platform prebuilt artifacts (spec §8.2, P2.8).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub binary: Vec<BinaryArtifact>,
+    /// Reserved: source fallback for platforms without a prebuilt binary.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "fallback-git"
+    )]
+    pub fallback_git: Option<Box<SourceSpec>>,
+}
+
+/// Reserved binary-form artifact (spec §8.1); not consumed in v1.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BinaryArtifact {
+    pub platform: String,
+    pub url: String,
+    pub sha256: String,
+}
+
+impl SourceSpec {
+    /// The git repo + commit pin, or an error for binary-only sources
+    /// (deferred to P2.8) and malformed entries. The URL is scheme-validated
+    /// here, at the source — it ends up as a `git clone` argument.
+    pub fn git_pin(&self) -> eyre::Result<(&str, &str)> {
+        match (&self.git, &self.rev) {
+            (Some(git), Some(rev)) => {
+                crate::validate_git_url(git)?;
+                let valid_rev = !rev.is_empty() && rev.chars().all(|c| c.is_ascii_alphanumeric());
+                if !valid_rev {
+                    eyre::bail!("index entry has an invalid commit hash");
+                }
+                Ok((git, rev))
+            }
+            (None, None) if !self.binary.is_empty() => eyre::bail!(
+                "this version is published as prebuilt binaries only, which this \
+                 dora version does not support yet"
+            ),
+            _ => eyre::bail!("index entry has an incomplete git source (needs `git` + `rev`)"),
+        }
+    }
+}
+
+/// Namespace-level metadata (`package.yml`, spec §7.1/§7.4).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PackageMeta {
+    /// One-line description of the package.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// The package's primary repository.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
+    /// GitHub accounts allowed to publish (enforced by index CI).
+    #[serde(default)]
+    pub owners: Vec<String>,
+}
+
+/// A locally available catalog directory.
+#[derive(Debug, Clone)]
+pub struct IndexCatalog {
+    root: PathBuf,
+}
+
+/// A resolved package version.
+#[derive(Debug)]
+pub struct ResolvedVersion {
+    pub version: Version,
+    pub entry: IndexEntry,
+}
+
+impl IndexCatalog {
+    /// Open a catalog rooted at `root` (the `node-index/` directory).
+    pub fn open(root: impl Into<PathBuf>) -> eyre::Result<Self> {
+        let root = root.into();
+        if !root.is_dir() {
+            eyre::bail!("index catalog `{}` is not a directory", root.display());
+        }
+        Ok(Self { root })
+    }
+
+    fn package_dir(&self, namespace: &str, name: &str) -> eyre::Result<PathBuf> {
+        for part in [namespace, name] {
+            if !is_valid_key_part(part) {
+                eyre::bail!("invalid package key `{namespace}/{name}`");
+            }
+        }
+        Ok(self.root.join(namespace).join(name))
+    }
+
+    /// All published versions of a package, including yanked ones.
+    pub fn versions(&self, namespace: &str, name: &str) -> eyre::Result<Vec<Version>> {
+        let dir = self.package_dir(namespace, name)?;
+        let mut versions = Vec::new();
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(_) => return Ok(versions), // unknown package = no versions
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("yml") {
+                continue;
+            }
+            let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            if stem == "package" {
+                continue;
+            }
+            if let Ok(version) = Version::parse(stem) {
+                versions.push(version);
+            }
+        }
+        versions.sort();
+        Ok(versions)
+    }
+
+    /// Read one version's index entry.
+    ///
+    /// Note for lockfile consumers (P2.6): a *pinned* version is looked up
+    /// directly through this method even when yanked — check `entry.yanked`
+    /// and warn (UC10: existing pins keep working, with a warning).
+    pub fn entry(
+        &self,
+        namespace: &str,
+        name: &str,
+        version: &Version,
+    ) -> eyre::Result<IndexEntry> {
+        let path = self
+            .package_dir(namespace, name)?
+            .join(format!("{version}.yml"));
+        let raw = read_capped(&path)?;
+        serde_yaml::from_str(&raw)
+            .with_context(|| format!("invalid index entry `{}`", path.display()))
+    }
+
+    /// Read a package's namespace-level metadata, if present.
+    pub fn package_meta(&self, namespace: &str, name: &str) -> eyre::Result<Option<PackageMeta>> {
+        let path = self.package_dir(namespace, name)?.join("package.yml");
+        if !path.is_file() {
+            return Ok(None);
+        }
+        let raw = read_capped(&path)?;
+        let meta = serde_yaml::from_str(&raw)
+            .with_context(|| format!("invalid package metadata `{}`", path.display()))?;
+        Ok(Some(meta))
+    }
+
+    /// Resolve a reference to the highest non-yanked version satisfying its
+    /// requirement (spec §7.2).
+    pub fn resolve(&self, reference: &PackageRef) -> eyre::Result<ResolvedVersion> {
+        let versions = self.versions(&reference.namespace, &reference.name)?;
+        if versions.is_empty() {
+            eyre::bail!(
+                "package `{}` not found in the index{}",
+                reference.key(),
+                self.suggest(reference)
+                    .map(|s| format!(" — did you mean `{s}`?"))
+                    .unwrap_or_default()
+            );
+        }
+        // Note: matching follows the cargo convention — prerelease versions
+        // only match requirements that themselves carry a prerelease tag.
+        let matching: Vec<_> = versions
+            .iter()
+            .filter(|v| reference.requirement.matches(v))
+            .collect();
+        // versions() returns ascending order; walk highest-first, skipping
+        // yanked versions
+        for version in matching.iter().rev() {
+            let entry = self.entry(&reference.namespace, &reference.name, version)?;
+            if entry.yanked {
+                continue;
+            }
+            return Ok(ResolvedVersion {
+                version: (*version).clone(),
+                entry,
+            });
+        }
+        eyre::bail!(
+            "no version of `{}` satisfies `{}` (available: {})",
+            reference.key(),
+            reference.requirement,
+            versions
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    }
+
+    /// All packages in the catalog as `(namespace, name)` pairs. Directory
+    /// names outside the package-key charset are skipped — catalog content
+    /// is untrusted and these strings end up in terminal output.
+    pub fn all_packages(&self) -> Vec<(String, String)> {
+        let mut packages = Vec::new();
+        let Ok(namespaces) = std::fs::read_dir(&self.root) else {
+            return packages;
+        };
+        for ns in namespaces.flatten() {
+            if !ns.path().is_dir() {
+                continue;
+            }
+            let Some(ns_name) = ns.file_name().to_str().map(String::from) else {
+                continue;
+            };
+            if !is_valid_key_part(&ns_name) {
+                continue;
+            }
+            let Ok(names) = std::fs::read_dir(ns.path()) else {
+                continue;
+            };
+            for name in names.flatten() {
+                if !name.path().is_dir() {
+                    continue;
+                }
+                if let Some(name) = name.file_name().to_str()
+                    && is_valid_key_part(name)
+                {
+                    packages.push((ns_name.clone(), name.to_string()));
+                }
+            }
+        }
+        packages.sort();
+        packages
+    }
+
+    /// Suggest a close package name for a typo'd reference.
+    fn suggest(&self, reference: &PackageRef) -> Option<String> {
+        self.all_packages()
+            .into_iter()
+            .filter(|(ns, _)| *ns == reference.namespace)
+            .map(|(ns, name)| {
+                let dist = edit_distance(&reference.name, &name);
+                (format!("{ns}/{name}"), dist)
+            })
+            .filter(|(_, dist)| *dist <= 2)
+            .min_by_key(|(_, dist)| *dist)
+            .map(|(key, _)| key)
+    }
+}
+
+/// A valid namespace/name path segment of a package key. Keys feed into
+/// filesystem paths and terminal output, so the charset is strict.
+fn is_valid_key_part(part: &str) -> bool {
+    !part.is_empty()
+        && part.len() <= 64
+        && part
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+        && !part.starts_with('.')
+}
+
+/// Read a small catalog file, bounding the read itself (a metadata-size
+/// check would miss FIFOs/devices and growing files).
+fn read_capped(path: &Path) -> eyre::Result<String> {
+    use std::io::Read as _;
+    let file = std::fs::File::open(path)
+        .with_context(|| format!("no index entry at `{}`", path.display()))?;
+    let mut raw = String::new();
+    file.take(MAX_ENTRY_SIZE + 1)
+        .read_to_string(&mut raw)
+        .with_context(|| format!("failed to read `{}`", path.display()))?;
+    if raw.len() as u64 > MAX_ENTRY_SIZE {
+        eyre::bail!("index file `{}` too large", path.display());
+    }
+    Ok(raw)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MANIFEST: &str = r#"
+  apiVersion: 1
+  name: dora-yolo
+  namespace: dora-rs
+  runtime: python
+  entrypoint: dora-yolo
+"#;
+
+    fn entry_yaml(rev: &str, yanked: bool) -> String {
+        format!(
+            "manifest:{MANIFEST}source:\n  git: https://github.com/dora-rs/dora-hub\n  rev: {rev}\n  subdir: node-hub/dora-yolo\nyanked: {yanked}\n"
+        )
+    }
+
+    fn fixture() -> (tempfile::TempDir, IndexCatalog) {
+        let tmp = tempfile::tempdir().unwrap();
+        let pkg = tmp.path().join("dora-rs/dora-yolo");
+        std::fs::create_dir_all(&pkg).unwrap();
+        std::fs::write(pkg.join("0.5.1.yml"), entry_yaml("aaa", false)).unwrap();
+        std::fs::write(pkg.join("0.5.2.yml"), entry_yaml("bbb", false)).unwrap();
+        std::fs::write(pkg.join("0.6.0.yml"), entry_yaml("ccc", true)).unwrap();
+        std::fs::write(
+            pkg.join("package.yml"),
+            "description: object detection\nowners: [haixuanTao]\n",
+        )
+        .unwrap();
+        let catalog = IndexCatalog::open(tmp.path()).unwrap();
+        (tmp, catalog)
+    }
+
+    fn parse_ref(s: &str) -> PackageRef {
+        PackageRef::parse(s).unwrap()
+    }
+
+    #[test]
+    fn resolves_highest_matching_version() {
+        let (_tmp, catalog) = fixture();
+        let resolved = catalog.resolve(&parse_ref("dora-yolo@^0.5")).unwrap();
+        assert_eq!(resolved.version, Version::parse("0.5.2").unwrap());
+        let (git, rev) = resolved.entry.source.git_pin().unwrap();
+        assert_eq!(git, "https://github.com/dora-rs/dora-hub");
+        assert_eq!(rev, "bbb");
+    }
+
+    #[test]
+    fn prerelease_versions_follow_cargo_convention() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pkg = tmp.path().join("dora-rs/dora-yolo");
+        std::fs::create_dir_all(&pkg).unwrap();
+        std::fs::write(pkg.join("0.5.1.yml"), entry_yaml("aaa", false)).unwrap();
+        std::fs::write(pkg.join("0.6.0-alpha.1.yml"), entry_yaml("pre", false)).unwrap();
+        let catalog = IndexCatalog::open(tmp.path()).unwrap();
+        // a plain requirement never matches a prerelease
+        let resolved = catalog.resolve(&parse_ref("dora-yolo@>=0.5")).unwrap();
+        assert_eq!(resolved.version.to_string(), "0.5.1");
+        // a prerelease requirement opts in
+        let resolved = catalog
+            .resolve(&parse_ref("dora-yolo@>=0.6.0-alpha"))
+            .unwrap();
+        assert_eq!(resolved.version.to_string(), "0.6.0-alpha.1");
+    }
+
+    #[test]
+    fn git_pin_rejects_hostile_urls() {
+        for (git, rev) in [
+            ("--upload-pack=evil", "abc123"),
+            ("ext::sh -c evil", "abc123"),
+            ("https://example.com/repo", "$(evil)"),
+            ("https://example.com/repo", "--flag"),
+        ] {
+            let entry: IndexEntry = serde_yaml::from_str(&format!(
+                "manifest:{MANIFEST}source:\n  git: \"{git}\"\n  rev: \"{rev}\"\n"
+            ))
+            .unwrap();
+            assert!(entry.source.git_pin().is_err(), "{git} {rev} should fail");
+        }
+    }
+
+    #[test]
+    fn yanked_versions_are_skipped() {
+        let (_tmp, catalog) = fixture();
+        // 0.6.0 is yanked — `*` resolves to 0.5.2 instead
+        let resolved = catalog.resolve(&parse_ref("dora-yolo")).unwrap();
+        assert_eq!(resolved.version, Version::parse("0.5.2").unwrap());
+    }
+
+    #[test]
+    fn unsatisfiable_requirement_lists_available() {
+        let (_tmp, catalog) = fixture();
+        let err = catalog.resolve(&parse_ref("dora-yolo@^2")).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("0.5.2"), "{msg}");
+    }
+
+    #[test]
+    fn unknown_package_suggests_close_name() {
+        let (_tmp, catalog) = fixture();
+        let err = catalog.resolve(&parse_ref("dora-yolp@^0.5")).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("did you mean `dora-rs/dora-yolo`"), "{msg}");
+    }
+
+    #[test]
+    fn package_meta_reads() {
+        let (_tmp, catalog) = fixture();
+        let meta = catalog
+            .package_meta("dora-rs", "dora-yolo")
+            .unwrap()
+            .unwrap();
+        assert_eq!(meta.owners, vec!["haixuanTao"]);
+    }
+
+    #[test]
+    fn binary_only_source_errors_clearly() {
+        let entry: IndexEntry = serde_yaml::from_str(&format!(
+            "manifest:{MANIFEST}source:\n  binary:\n    - platform: linux-x86_64\n      url: https://example.com/x\n      sha256: \"ab\"\n"
+        ))
+        .unwrap();
+        let err = entry.source.git_pin().unwrap_err();
+        assert!(format!("{err}").contains("prebuilt binaries"), "{err}");
+    }
+
+    #[test]
+    fn traversal_keys_are_rejected() {
+        let (_tmp, catalog) = fixture();
+        for (ns, name) in [("..", "x"), ("a", "../b"), (".hidden", "x"), ("a/b", "c")] {
+            assert!(
+                catalog.versions(ns, name).is_err(),
+                "{ns}/{name} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn all_packages_lists_sorted() {
+        let (_tmp, catalog) = fixture();
+        assert_eq!(
+            catalog.all_packages(),
+            vec![("dora-rs".to_string(), "dora-yolo".to_string())]
+        );
+    }
+}

--- a/libraries/hub-client/src/index.rs
+++ b/libraries/hub-client/src/index.rs
@@ -83,7 +83,7 @@ impl SourceSpec {
     pub fn git_pin(&self) -> eyre::Result<(&str, &str)> {
         match (&self.git, &self.rev) {
             (Some(git), Some(rev)) => {
-                crate::validate_git_url(git)?;
+                crate::validate_git_url_untrusted(git)?;
                 // a full, immutable object id only: a branch/tag name would
                 // make the "pin" mutable (defeating the audit trail and
                 // yanks), and an *abbreviated* hash can grow ambiguous as the
@@ -126,6 +126,10 @@ pub struct PackageMeta {
 #[derive(Debug, Clone)]
 pub struct IndexCatalog {
     root: PathBuf,
+    /// `root` with symlinks resolved — every read is confined under this so a
+    /// malicious index repo can't ship a symlinked namespace/package/version
+    /// entry that escapes the catalog.
+    canonical_root: PathBuf,
 }
 
 /// A resolved package version.
@@ -142,7 +146,27 @@ impl IndexCatalog {
         if !root.is_dir() {
             eyre::bail!("index catalog `{}` is not a directory", root.display());
         }
-        Ok(Self { root })
+        let canonical_root = root
+            .canonicalize()
+            .with_context(|| format!("failed to resolve index catalog `{}`", root.display()))?;
+        Ok(Self {
+            root,
+            canonical_root,
+        })
+    }
+
+    /// Reject a path that, after following symlinks, resolves outside the
+    /// catalog root. A non-existent path is fine — nothing is read, and the
+    /// caller handles `NotFound`.
+    fn confine(&self, path: &Path) -> eyre::Result<()> {
+        match path.canonicalize() {
+            Ok(real) if real.starts_with(&self.canonical_root) => Ok(()),
+            Ok(_) => eyre::bail!(
+                "index path `{}` escapes the catalog root (symlink?)",
+                path.display()
+            ),
+            Err(_) => Ok(()),
+        }
     }
 
     fn package_dir(&self, namespace: &str, name: &str) -> eyre::Result<PathBuf> {
@@ -163,6 +187,7 @@ impl IndexCatalog {
     /// All published versions of a package, including yanked ones.
     pub fn versions(&self, namespace: &str, name: &str) -> eyre::Result<Vec<Version>> {
         let dir = self.package_dir(namespace, name)?;
+        self.confine(&dir)?;
         let mut versions = Vec::new();
         let entries = match std::fs::read_dir(&dir) {
             Ok(entries) => entries,
@@ -207,6 +232,7 @@ impl IndexCatalog {
         let path = self
             .package_dir(namespace, name)?
             .join(format!("{version}.yml"));
+        self.confine(&path)?;
         let raw = read_capped(&path)?;
         serde_yaml::from_str(&raw)
             .with_context(|| format!("invalid index entry `{}`", path.display()))
@@ -297,7 +323,7 @@ impl IndexCatalog {
             return packages;
         };
         for ns in namespaces.flatten() {
-            if !ns.path().is_dir() {
+            if !ns.path().is_dir() || self.confine(&ns.path()).is_err() {
                 continue;
             }
             let Some(ns_name) = ns.file_name().to_str().map(String::from) else {
@@ -310,7 +336,7 @@ impl IndexCatalog {
                 continue;
             };
             for name in names.flatten() {
-                if !name.path().is_dir() {
+                if !name.path().is_dir() || self.confine(&name.path()).is_err() {
                     continue;
                 }
                 if let Some(name) = name.file_name().to_str()
@@ -424,6 +450,30 @@ mod tests {
         let (git, rev) = resolved.entry.source.git_pin().unwrap();
         assert_eq!(git, "https://github.com/dora-rs/dora-hub");
         assert_eq!(rev, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reads_reject_symlinked_package_dir_escaping_the_catalog() {
+        let tmp = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        // a real package living OUTSIDE the catalog root
+        let real = outside.path().join("evil");
+        std::fs::create_dir_all(&real).unwrap();
+        let rev = "a".repeat(40);
+        std::fs::write(real.join("9.9.9.yml"), entry_yaml(&rev, false)).unwrap();
+        // inside the catalog, a package dir that is a symlink pointing there
+        let ns = tmp.path().join("acme");
+        std::fs::create_dir_all(&ns).unwrap();
+        std::os::unix::fs::symlink(&real, ns.join("escape")).unwrap();
+        let catalog = IndexCatalog::open(tmp.path()).unwrap();
+        // both the dir listing and the entry read must refuse to follow it
+        assert!(catalog.versions("acme", "escape").is_err());
+        assert!(
+            catalog
+                .entry("acme", "escape", &Version::parse("9.9.9").unwrap())
+                .is_err()
+        );
     }
 
     #[test]

--- a/libraries/hub-client/src/lib.rs
+++ b/libraries/hub-client/src/lib.rs
@@ -1,0 +1,46 @@
+//! Client for the Dora Hub package index (docs/plan-node-hub.md §7).
+//!
+//! The index is a git-hosted catalog mapping `namespace/name@version` to a
+//! node manifest plus a source pointer. This crate provides:
+//!
+//! - [`reference`]: parsing `[<namespace>/]<name>@<semver-req>` references,
+//! - [`index`]: the on-disk catalog format and semver/yank resolution,
+//! - [`config`]: `hub.toml` multi-index configuration with namespace binding,
+//! - [`transport`]: sparse-clone fetch and refresh of remote indexes.
+//!
+//! Everything network-facing lives in [`transport`]; the rest are pure
+//! functions over parsed data, usable against fixture directories in tests.
+
+pub mod config;
+pub mod index;
+pub mod reference;
+pub mod transport;
+
+/// The namespace bare package names resolve to (spec §7.2).
+pub const OFFICIAL_NAMESPACE: &str = "dora-rs";
+
+/// Validate a git URL before it is ever passed to a `git` subprocess.
+///
+/// URLs come from untrusted places (a public index entry's `source.git`, a
+/// user-edited `hub.toml`). Restricting to known-remote schemes rejects both
+/// argument injection (`--upload-pack=…` parsed as a flag) and command-running
+/// transports (`ext::sh -c …`).
+pub fn validate_git_url(url: &str) -> eyre::Result<()> {
+    const SCHEMES: &[&str] = &["https://", "http://", "ssh://", "git://", "file://", "git@"];
+    // absolute paths are accepted for local repositories (tests, mirrors)
+    let valid = SCHEMES.iter().any(|s| url.starts_with(s)) || url.starts_with('/');
+    if valid && !url.contains(|c: char| c.is_control()) {
+        return Ok(());
+    }
+    eyre::bail!(
+        "invalid git URL `{}`: expected a https/ssh/git/file URL or absolute path",
+        url.chars().filter(|c| !c.is_control()).collect::<String>()
+    )
+}
+
+/// The official index location (spec §7.3).
+pub const OFFICIAL_INDEX_GIT: &str = "https://github.com/dora-rs/dora-hub";
+/// Catalog directory inside the official index repository.
+pub const OFFICIAL_INDEX_PATH: &str = "node-index";
+/// Alias of the implicit official index entry.
+pub const OFFICIAL_INDEX_ALIAS: &str = "official";

--- a/libraries/hub-client/src/lib.rs
+++ b/libraries/hub-client/src/lib.rs
@@ -41,9 +41,50 @@ pub fn validate_git_url(url: &str) -> eyre::Result<()> {
     )
 }
 
+/// Validate the `source.git` of an *untrusted* index entry — stricter than
+/// [`validate_git_url`].
+///
+/// `file://` URLs and absolute paths are a supply-chain risk in a public index
+/// (a hostile entry would clone victim-local content into the build), so they
+/// are rejected for index entries unless `DORA_HUB_ALLOW_LOCAL_SOURCES` opts in
+/// (hermetic tests, air-gapped mirrors). `hub.toml` index *locations* stay on
+/// the permissive [`validate_git_url`] — that is the user's own trusted config.
+pub fn validate_git_url_untrusted(url: &str) -> eyre::Result<()> {
+    validate_git_url(url)?;
+    let is_local = url.starts_with("file://") || url.starts_with('/');
+    if is_local && std::env::var_os("DORA_HUB_ALLOW_LOCAL_SOURCES").is_none() {
+        eyre::bail!(
+            "index entry source `{}` is a local path; a public index must use an \
+             https/ssh remote (set DORA_HUB_ALLOW_LOCAL_SOURCES=1 to allow local \
+             sources for testing or mirrors)",
+            url.chars().filter(|c| !c.is_control()).collect::<String>()
+        );
+    }
+    Ok(())
+}
+
 /// The official index location (spec §7.3).
 pub const OFFICIAL_INDEX_GIT: &str = "https://github.com/dora-rs/dora-hub";
 /// Catalog directory inside the official index repository.
 pub const OFFICIAL_INDEX_PATH: &str = "node-index";
 /// Alias of the implicit official index entry.
 pub const OFFICIAL_INDEX_ALIAS: &str = "official";
+
+#[cfg(test)]
+mod tests {
+    use super::validate_git_url_untrusted;
+
+    #[test]
+    fn untrusted_index_sources_reject_local_paths() {
+        // remote transports are fine
+        assert!(validate_git_url_untrusted("https://github.com/o/r.git").is_ok());
+        assert!(validate_git_url_untrusted("ssh://git@host/o/r").is_ok());
+        assert!(validate_git_url_untrusted("git@github.com:o/r.git").is_ok());
+        // local sources would clone victim-local content into the build —
+        // rejected for untrusted index entries (no opt-in env in this test)
+        assert!(validate_git_url_untrusted("file:///tmp/repo").is_err());
+        assert!(validate_git_url_untrusted("/srv/repo").is_err());
+        // cleartext still rejected by the underlying validator
+        assert!(validate_git_url_untrusted("http://github.com/o/r").is_err());
+    }
+}

--- a/libraries/hub-client/src/lib.rs
+++ b/libraries/hub-client/src/lib.rs
@@ -26,14 +26,17 @@ pub const OFFICIAL_NAMESPACE: &str = "dora-rs";
 /// argument injection (`--upload-pack=…` parsed as a flag) and command-running
 /// transports (`ext::sh -c …`).
 pub fn validate_git_url(url: &str) -> eyre::Result<()> {
-    const SCHEMES: &[&str] = &["https://", "http://", "ssh://", "git://", "file://", "git@"];
+    // cleartext transports (http://, git://) are deliberately absent: the
+    // index is a supply-chain trust root and its fast-forward protection is
+    // meaningless against a MITM-controlled remote
+    const SCHEMES: &[&str] = &["https://", "ssh://", "file://", "git@"];
     // absolute paths are accepted for local repositories (tests, mirrors)
     let valid = SCHEMES.iter().any(|s| url.starts_with(s)) || url.starts_with('/');
     if valid && !url.contains(|c: char| c.is_control()) {
         return Ok(());
     }
     eyre::bail!(
-        "invalid git URL `{}`: expected a https/ssh/git/file URL or absolute path",
+        "invalid git URL `{}`: expected a https/ssh/file URL or absolute path",
         url.chars().filter(|c| !c.is_control()).collect::<String>()
     )
 }

--- a/libraries/hub-client/src/reference.rs
+++ b/libraries/hub-client/src/reference.rs
@@ -1,0 +1,109 @@
+//! Parsing of `hub:` package references (spec §7.2):
+//! `[<namespace>/]<name>@<semver-req>`.
+
+use semver::VersionReq;
+
+use crate::OFFICIAL_NAMESPACE;
+
+/// A parsed `hub:` reference. Bare names are official-namespace shorthand:
+/// `dora-yolo@^0.5` means exactly `dora-rs/dora-yolo@^0.5`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PackageRef {
+    /// Index namespace (`dora-rs` when the reference was written bare).
+    pub namespace: String,
+    /// Package name within the namespace.
+    pub name: String,
+    /// Requested version range.
+    pub requirement: VersionReq,
+}
+
+impl PackageRef {
+    /// Parse a reference like `dora-yolo@^0.5` or `acme/lidar-fusion@2.1`.
+    pub fn parse(reference: &str) -> eyre::Result<Self> {
+        let (path, requirement) = match reference.split_once('@') {
+            Some((path, req)) => {
+                let requirement = VersionReq::parse(req.trim()).map_err(|e| {
+                    eyre::eyre!("invalid version requirement `{}`: {e}", req.trim())
+                })?;
+                (path.trim(), requirement)
+            }
+            // a bare `hub: dora-yolo` means any version
+            None => (reference.trim(), VersionReq::STAR),
+        };
+        if path.is_empty() {
+            eyre::bail!("empty package reference");
+        }
+        let (namespace, name) = match path.split_once('/') {
+            Some((namespace, name)) => {
+                if name.contains('/') {
+                    eyre::bail!(
+                        "invalid package reference `{reference}`: \
+                         expected `[namespace/]name@version-req`"
+                    );
+                }
+                (namespace, name)
+            }
+            None => (OFFICIAL_NAMESPACE, path),
+        };
+        if namespace.is_empty() || name.is_empty() {
+            eyre::bail!("invalid package reference `{reference}`: empty namespace or name");
+        }
+        Ok(Self {
+            namespace: namespace.to_string(),
+            name: name.to_string(),
+            requirement,
+        })
+    }
+
+    /// The index key `namespace/name`.
+    pub fn key(&self) -> String {
+        format!("{}/{}", self.namespace, self.name)
+    }
+}
+
+impl std::fmt::Display for PackageRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}@{}", self.namespace, self.name, self.requirement)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bare_name_is_official_shorthand() {
+        let r = PackageRef::parse("dora-yolo@^0.5").unwrap();
+        assert_eq!(r.namespace, "dora-rs");
+        assert_eq!(r.name, "dora-yolo");
+        assert_eq!(r.requirement, VersionReq::parse("^0.5").unwrap());
+    }
+
+    #[test]
+    fn namespaced_reference() {
+        let r = PackageRef::parse("acme/lidar-fusion@2.1").unwrap();
+        assert_eq!(r.namespace, "acme");
+        assert_eq!(r.name, "lidar-fusion");
+        assert_eq!(r.key(), "acme/lidar-fusion");
+    }
+
+    #[test]
+    fn missing_requirement_means_any() {
+        let r = PackageRef::parse("dora-yolo").unwrap();
+        assert_eq!(r.requirement, VersionReq::STAR);
+    }
+
+    #[test]
+    fn full_semver_req_syntax() {
+        for req in [">=0.5, <0.7", "=1.2.3", "~0.4", "*"] {
+            PackageRef::parse(&format!("x@{req}")).unwrap_or_else(|e| panic!("{req}: {e}"));
+        }
+    }
+
+    #[test]
+    fn rejects_malformed() {
+        for bad in ["", "@1.0", "a/b/c@1", "a/@1", "/b@1", "x@not-a-req"] {
+            assert!(PackageRef::parse(bad).is_err(), "{bad:?} should fail");
+        }
+    }
+}

--- a/libraries/hub-client/src/transport.rs
+++ b/libraries/hub-client/src/transport.rs
@@ -1,0 +1,397 @@
+//! Index transport and cache (spec §7.3, P2.2).
+//!
+//! Remote indexes are cloned blobless + sparse (scoped to the catalog
+//! directory) into `~/.cache/dora/index/<alias>/`, refreshed at most once per
+//! invocation, with a fast-forward check that warns loudly on history
+//! rewrites or rollback (a stale or replayed index could otherwise hide
+//! yanks — the warning is informational; the new state is still used). The
+//! persistent clone's `HEAD` is the cross-invocation record of the last
+//! trusted index state. `--offline` skips all network access and fails
+//! loudly on a cache miss. Local `path =` indexes are read in place with no
+//! transport.
+//!
+//! Transport shells out to the `git` CLI rather than reusing dora-core's
+//! libgit2-based `GitManager`: libgit2 has no partial-clone or
+//! sparse-checkout support, which this fetch path depends on to avoid
+//! pulling the node source trees living in the same repository.
+
+use std::{
+    collections::BTreeSet,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use eyre::{Context, eyre};
+
+use crate::{OFFICIAL_INDEX_PATH, config::IndexConfig, validate_git_url};
+
+/// Fetches and caches index catalogs for one CLI invocation.
+#[derive(Debug)]
+pub struct IndexFetcher {
+    cache_root: PathBuf,
+    offline: bool,
+    refreshed: BTreeSet<String>,
+    /// Loud-but-nonfatal problems (e.g. non-fast-forward index updates);
+    /// drain and surface to the user.
+    pub warnings: Vec<String>,
+}
+
+impl IndexFetcher {
+    /// Cache under the user cache dir (`~/.cache/dora/index`).
+    pub fn new(offline: bool) -> eyre::Result<Self> {
+        let cache_root = dirs::cache_dir()
+            .ok_or_else(|| eyre!("could not determine the user cache directory"))?
+            .join("dora")
+            .join("index");
+        Ok(Self::with_cache_root(cache_root, offline))
+    }
+
+    /// Cache under an explicit root (tests, custom layouts).
+    pub fn with_cache_root(cache_root: PathBuf, offline: bool) -> Self {
+        Self {
+            cache_root,
+            offline,
+            refreshed: BTreeSet::new(),
+            warnings: Vec::new(),
+        }
+    }
+
+    /// Make the catalog of `index` locally available and return its
+    /// directory. Remote indexes are cloned/refreshed into the cache;
+    /// local indexes resolve relative to `config_dir`.
+    pub fn catalog_dir(&mut self, index: &IndexConfig, config_dir: &Path) -> eyre::Result<PathBuf> {
+        if index.is_local() {
+            let dir = index.local_catalog_dir(config_dir)?;
+            if !dir.is_dir() {
+                eyre::bail!(
+                    "local index `{}` does not exist at `{}`",
+                    index.alias,
+                    dir.display()
+                );
+            }
+            return Ok(dir);
+        }
+
+        let git_url = index.git.as_deref().expect("checked by is_local");
+        // belt-and-suspenders: configs loaded via ResolvedConfig are already
+        // validated, but IndexConfig can be constructed directly
+        validate_git_url(git_url)?;
+        let clone_dir = self.cache_root.join(&index.alias);
+        let catalog_subpath = index.path.as_deref().unwrap_or(OFFICIAL_INDEX_PATH);
+
+        if !clone_dir.join(".git").exists() {
+            if self.offline {
+                eyre::bail!(
+                    "index `{}` is not cached and `--offline` is set\n  \
+                     hint: run once with network access to populate the cache",
+                    index.alias
+                );
+            }
+            self.clone_index(git_url, &clone_dir, catalog_subpath)
+                .with_context(|| format!("failed to clone index `{}`", index.alias))?;
+            self.refreshed.insert(index.alias.clone());
+        } else if !self.offline && self.refreshed.insert(index.alias.clone()) {
+            self.refresh_index(&index.alias, &clone_dir)
+                .with_context(|| format!("failed to refresh index `{}`", index.alias))?;
+        }
+
+        let catalog = clone_dir.join(catalog_subpath);
+        if !catalog.is_dir() {
+            eyre::bail!(
+                "index `{}` has no catalog directory `{catalog_subpath}`",
+                index.alias
+            );
+        }
+        Ok(catalog)
+    }
+
+    fn clone_index(
+        &mut self,
+        git_url: &str,
+        clone_dir: &Path,
+        catalog_subpath: &str,
+    ) -> eyre::Result<()> {
+        if let Some(parent) = clone_dir.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create `{}`", parent.display()))?;
+        }
+        let clone_dir_str = clone_dir
+            .to_str()
+            .ok_or_else(|| eyre!("cache path is not valid UTF-8"))?;
+        // blobless + sparse keeps the fetch to the catalog tree, not the
+        // node sources living in the same repo; not every server supports
+        // partial clone, so degrade to a plain clone when refused
+        // `--` keeps git from ever parsing the URL or target as a flag
+        let sparse = git(
+            None,
+            &[
+                "clone",
+                "--filter=blob:none",
+                "--no-checkout",
+                "--quiet",
+                "--",
+                git_url,
+                clone_dir_str,
+            ],
+        );
+        if sparse.is_err() {
+            let _ = std::fs::remove_dir_all(clone_dir);
+            git(
+                None,
+                &[
+                    "clone",
+                    "--no-checkout",
+                    "--quiet",
+                    "--",
+                    git_url,
+                    clone_dir_str,
+                ],
+            )
+            .context("git clone failed")?;
+        }
+        // cone-mode sparse checkout of the catalog dir only; best-effort —
+        // a full checkout is correct too, just bigger
+        let _ = git(
+            Some(clone_dir),
+            &["sparse-checkout", "set", catalog_subpath],
+        );
+        git(Some(clone_dir), &["checkout", "--quiet"]).context("git checkout failed")?;
+        Ok(())
+    }
+
+    fn refresh_index(&mut self, alias: &str, clone_dir: &Path) -> eyre::Result<()> {
+        let local = git(Some(clone_dir), &["rev-parse", "HEAD"])?;
+        git(Some(clone_dir), &["fetch", "--quiet", "origin"]).context("git fetch failed")?;
+        let remote = remote_tip(clone_dir)?;
+        if remote == local {
+            return Ok(());
+        }
+        let fast_forward = git(
+            Some(clone_dir),
+            &["merge-base", "--is-ancestor", &local, &remote],
+        )
+        .is_ok();
+        if !fast_forward {
+            self.warnings.push(format!(
+                "index `{alias}` history was rewritten or rolled back \
+                 ({} -> {}) — a replayed index can hide yanked versions; \
+                 verify the index source if this is unexpected",
+                short(&local),
+                short(&remote)
+            ));
+        }
+        git(Some(clone_dir), &["reset", "--hard", "--quiet", &remote])
+            .context("git reset failed")?;
+        Ok(())
+    }
+}
+
+/// The commit the remote's default branch points at after a fetch.
+fn remote_tip(clone_dir: &Path) -> eyre::Result<String> {
+    for reference in ["refs/remotes/origin/HEAD", "origin/main", "origin/master"] {
+        if let Ok(commit) = git(Some(clone_dir), &["rev-parse", reference]) {
+            return Ok(commit);
+        }
+    }
+    eyre::bail!("could not determine the index's default branch")
+}
+
+fn short(commit: &str) -> &str {
+    &commit[..commit.len().min(12)]
+}
+
+/// Run a git command, returning trimmed stdout.
+fn git(dir: Option<&Path>, args: &[&str]) -> eyre::Result<String> {
+    let mut command = Command::new("git");
+    if let Some(dir) = dir {
+        command.current_dir(dir);
+    }
+    let output = command
+        .args(args)
+        .output()
+        .context("failed to run `git` — is git installed?")?;
+    if !output.status.success() {
+        eyre::bail!(
+            "`git {}` failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::index::IndexCatalog;
+    use crate::reference::PackageRef;
+
+    const ENTRY: &str = r#"
+manifest:
+  apiVersion: 1
+  name: dora-yolo
+  namespace: dora-rs
+  runtime: python
+  entrypoint: dora-yolo
+source:
+  git: https://github.com/dora-rs/dora-hub
+  rev: aaa111
+  subdir: node-hub/dora-yolo
+"#;
+
+    /// Create a git "remote" containing a catalog at node-index/.
+    fn make_remote(dir: &Path) {
+        std::fs::create_dir_all(dir.join("node-index/dora-rs/dora-yolo")).unwrap();
+        std::fs::write(dir.join("node-index/dora-rs/dora-yolo/0.5.1.yml"), ENTRY).unwrap();
+        run_git(dir, &["init", "--quiet", "-b", "main"]);
+        commit_all(dir, "initial");
+        // allow partial clone over the local transport
+        run_git(dir, &["config", "uploadpack.allowFilter", "true"]);
+    }
+
+    fn run_git(dir: &Path, args: &[&str]) {
+        let status = Command::new("git")
+            .current_dir(dir)
+            .args([
+                "-c",
+                "user.email=test@dora.rs",
+                "-c",
+                "user.name=test",
+                "-c",
+                "commit.gpgsign=false",
+            ])
+            .args(args)
+            .status()
+            .unwrap();
+        assert!(status.success(), "git {args:?} failed");
+    }
+
+    fn commit_all(dir: &Path, message: &str) {
+        run_git(dir, &["add", "."]);
+        run_git(dir, &["commit", "--quiet", "-m", message]);
+    }
+
+    fn remote_index(remote: &Path) -> IndexConfig {
+        IndexConfig {
+            alias: "test".into(),
+            git: Some(remote.to_str().unwrap().to_string()),
+            path: Some("node-index".into()),
+            namespaces: vec![],
+        }
+    }
+
+    #[test]
+    fn clones_resolves_and_refreshes() {
+        let remote_dir = tempfile::tempdir().unwrap();
+        let cache_dir = tempfile::tempdir().unwrap();
+        make_remote(remote_dir.path());
+        let index = remote_index(remote_dir.path());
+
+        let mut fetcher = IndexFetcher::with_cache_root(cache_dir.path().into(), false);
+        let catalog_dir = fetcher.catalog_dir(&index, Path::new(".")).unwrap();
+        let catalog = IndexCatalog::open(&catalog_dir).unwrap();
+        let resolved = catalog
+            .resolve(&PackageRef::parse("dora-yolo@^0.5").unwrap())
+            .unwrap();
+        assert_eq!(resolved.version.to_string(), "0.5.1");
+
+        // publish 0.5.2 upstream; a NEW fetcher (new invocation) sees it
+        std::fs::write(
+            remote_dir
+                .path()
+                .join("node-index/dora-rs/dora-yolo/0.5.2.yml"),
+            ENTRY,
+        )
+        .unwrap();
+        commit_all(remote_dir.path(), "publish 0.5.2");
+
+        // same fetcher: refresh-once-per-invocation means no new fetch
+        let dir_again = fetcher.catalog_dir(&index, Path::new(".")).unwrap();
+        let resolved = IndexCatalog::open(&dir_again)
+            .unwrap()
+            .resolve(&PackageRef::parse("dora-yolo@^0.5").unwrap())
+            .unwrap();
+        assert_eq!(
+            resolved.version.to_string(),
+            "0.5.1",
+            "no mid-invocation refresh"
+        );
+
+        let mut second = IndexFetcher::with_cache_root(cache_dir.path().into(), false);
+        let catalog_dir = second.catalog_dir(&index, Path::new(".")).unwrap();
+        let resolved = IndexCatalog::open(&catalog_dir)
+            .unwrap()
+            .resolve(&PackageRef::parse("dora-yolo@^0.5").unwrap())
+            .unwrap();
+        assert_eq!(resolved.version.to_string(), "0.5.2");
+        assert!(second.warnings.is_empty(), "{:?}", second.warnings);
+    }
+
+    #[test]
+    fn offline_uses_cache_and_fails_on_miss() {
+        let remote_dir = tempfile::tempdir().unwrap();
+        let cache_dir = tempfile::tempdir().unwrap();
+        make_remote(remote_dir.path());
+        let index = remote_index(remote_dir.path());
+
+        // miss: nothing cached yet
+        let mut offline = IndexFetcher::with_cache_root(cache_dir.path().into(), true);
+        let err = offline.catalog_dir(&index, Path::new(".")).unwrap_err();
+        assert!(format!("{err:#}").contains("--offline"), "{err:#}");
+
+        // populate, then offline works without touching the remote
+        let mut online = IndexFetcher::with_cache_root(cache_dir.path().into(), false);
+        online.catalog_dir(&index, Path::new(".")).unwrap();
+        std::fs::remove_dir_all(remote_dir.path()).unwrap();
+        let mut offline = IndexFetcher::with_cache_root(cache_dir.path().into(), true);
+        let catalog_dir = offline.catalog_dir(&index, Path::new(".")).unwrap();
+        assert!(catalog_dir.join("dora-rs/dora-yolo/0.5.1.yml").is_file());
+    }
+
+    #[test]
+    fn non_fast_forward_refresh_warns() {
+        let remote_dir = tempfile::tempdir().unwrap();
+        let cache_dir = tempfile::tempdir().unwrap();
+        make_remote(remote_dir.path());
+        let index = remote_index(remote_dir.path());
+
+        let mut fetcher = IndexFetcher::with_cache_root(cache_dir.path().into(), false);
+        fetcher.catalog_dir(&index, Path::new(".")).unwrap();
+
+        // rewrite remote history (amend) — a rollback/replay signature
+        std::fs::write(
+            remote_dir
+                .path()
+                .join("node-index/dora-rs/dora-yolo/0.5.1.yml"),
+            ENTRY.replace("aaa111", "evil00"),
+        )
+        .unwrap();
+        run_git(remote_dir.path(), &["add", "."]);
+        run_git(
+            remote_dir.path(),
+            &["commit", "--quiet", "--amend", "-m", "rewritten"],
+        );
+
+        let mut second = IndexFetcher::with_cache_root(cache_dir.path().into(), false);
+        second.catalog_dir(&index, Path::new(".")).unwrap();
+        assert_eq!(second.warnings.len(), 1, "{:?}", second.warnings);
+        assert!(second.warnings[0].contains("rewritten or rolled back"));
+    }
+
+    #[test]
+    fn local_index_needs_no_transport() {
+        let tmp = tempfile::tempdir().unwrap();
+        let catalog = tmp.path().join("index");
+        std::fs::create_dir_all(&catalog).unwrap();
+        let index = IndexConfig {
+            alias: "fixtures".into(),
+            git: None,
+            path: Some("index".into()),
+            namespaces: vec!["test".into()],
+        };
+        // offline does not matter for local indexes
+        let mut fetcher = IndexFetcher::with_cache_root(tmp.path().join("cache"), true);
+        let dir = fetcher.catalog_dir(&index, tmp.path()).unwrap();
+        assert_eq!(dir, catalog);
+    }
+}

--- a/libraries/hub-client/src/transport.rs
+++ b/libraries/hub-client/src/transport.rs
@@ -72,10 +72,11 @@ impl IndexFetcher {
             return Ok(dir);
         }
 
-        let git_url = index.git.as_deref().expect("checked by is_local");
         // belt-and-suspenders: configs loaded via ResolvedConfig are already
-        // validated, but IndexConfig can be constructed directly
-        validate_git_url(git_url)?;
+        // validated, but IndexConfig can be constructed directly — every
+        // field below feeds a path join or a git argument
+        crate::config::validate_index_entry(index)?;
+        let git_url = index.git.as_deref().expect("checked by is_local");
         let clone_dir = self.cache_root.join(&index.alias);
         let catalog_subpath = index.path.as_deref().unwrap_or(OFFICIAL_INDEX_PATH);
 
@@ -91,18 +92,60 @@ impl IndexFetcher {
                 .with_context(|| format!("failed to clone index `{}`", index.alias))?;
             self.refreshed.insert(index.alias.clone());
         } else if !self.offline && self.refreshed.insert(index.alias.clone()) {
-            self.refresh_index(&index.alias, &clone_dir)
-                .with_context(|| format!("failed to refresh index `{}`", index.alias))?;
+            if let Err(refresh_err) = self.refresh_index(&index.alias, &clone_dir) {
+                // self-heal a corrupt cache (e.g. a SIGKILL mid-clone left a
+                // broken .git); genuine network errors propagate so a flaky
+                // connection cannot wipe a cache that offline runs rely on
+                if git(Some(&clone_dir), &["rev-parse", "HEAD"]).is_err() {
+                    self.reclone(index, git_url, &clone_dir, catalog_subpath)?;
+                } else {
+                    return Err(refresh_err)
+                        .with_context(|| format!("failed to refresh index `{}`", index.alias));
+                }
+            }
         }
 
         let catalog = clone_dir.join(catalog_subpath);
         if !catalog.is_dir() {
-            eyre::bail!(
-                "index `{}` has no catalog directory `{catalog_subpath}`",
-                index.alias
-            );
+            // a clone whose checkout was interrupted has a valid .git but no
+            // worktree — self-heal instead of failing on every invocation
+            if self.offline {
+                eyre::bail!(
+                    "cached index `{}` is incomplete (no `{catalog_subpath}` directory) \
+                     and `--offline` is set\n  \
+                     hint: run once with network access to repair the cache",
+                    index.alias
+                );
+            }
+            self.reclone(index, git_url, &clone_dir, catalog_subpath)?;
+            if !catalog.is_dir() {
+                eyre::bail!(
+                    "index `{}` has no catalog directory `{catalog_subpath}`",
+                    index.alias
+                );
+            }
         }
         Ok(catalog)
+    }
+
+    /// Replace a corrupt or incomplete cached clone with a fresh one.
+    fn reclone(
+        &mut self,
+        index: &IndexConfig,
+        git_url: &str,
+        clone_dir: &Path,
+        catalog_subpath: &str,
+    ) -> eyre::Result<()> {
+        self.warnings.push(format!(
+            "cached index `{}` was incomplete — re-cloning",
+            index.alias
+        ));
+        std::fs::remove_dir_all(clone_dir)
+            .with_context(|| format!("failed to remove corrupt cache `{}`", clone_dir.display()))?;
+        self.clone_index(git_url, clone_dir, catalog_subpath)
+            .with_context(|| format!("failed to re-clone index `{}`", index.alias))?;
+        self.refreshed.insert(index.alias.clone());
+        Ok(())
     }
 
     fn clone_index(
@@ -162,6 +205,10 @@ impl IndexFetcher {
     fn refresh_index(&mut self, alias: &str, clone_dir: &Path) -> eyre::Result<()> {
         let local = git(Some(clone_dir), &["rev-parse", "HEAD"])?;
         git(Some(clone_dir), &["fetch", "--quiet", "origin"]).context("git fetch failed")?;
+        // `git fetch` never updates an existing refs/remotes/origin/HEAD —
+        // without this, an index repo renaming its default branch would
+        // freeze every cache on the old branch tip silently
+        let _ = git(Some(clone_dir), &["remote", "set-head", "origin", "--auto"]);
         let remote = remote_tip(clone_dir)?;
         if remote == local {
             return Ok(());
@@ -206,6 +253,8 @@ fn git(dir: Option<&Path>, args: &[&str]) -> eyre::Result<String> {
     if let Some(dir) = dir {
         command.current_dir(dir);
     }
+    // never hang on a credential prompt (e.g. a private index URL)
+    command.env("GIT_TERMINAL_PROMPT", "0");
     let output = command
         .args(args)
         .output()
@@ -376,6 +425,36 @@ source:
         second.catalog_dir(&index, Path::new(".")).unwrap();
         assert_eq!(second.warnings.len(), 1, "{:?}", second.warnings);
         assert!(second.warnings[0].contains("rewritten or rolled back"));
+    }
+
+    #[test]
+    fn wedged_cache_self_heals() {
+        let remote_dir = tempfile::tempdir().unwrap();
+        let cache_dir = tempfile::tempdir().unwrap();
+        make_remote(remote_dir.path());
+        let index = remote_index(remote_dir.path());
+
+        let mut fetcher = IndexFetcher::with_cache_root(cache_dir.path().into(), false);
+        fetcher.catalog_dir(&index, Path::new(".")).unwrap();
+
+        // simulate an interrupted checkout: valid .git, missing worktree
+        let clone_dir = cache_dir.path().join("test");
+        std::fs::remove_dir_all(clone_dir.join("node-index")).unwrap();
+
+        // offline cannot repair — fails with a repair hint
+        let mut offline = IndexFetcher::with_cache_root(cache_dir.path().into(), true);
+        let err = offline.catalog_dir(&index, Path::new(".")).unwrap_err();
+        assert!(format!("{err:#}").contains("incomplete"), "{err:#}");
+
+        // online self-heals instead of failing forever
+        let mut second = IndexFetcher::with_cache_root(cache_dir.path().into(), false);
+        let catalog = second.catalog_dir(&index, Path::new(".")).unwrap();
+        assert!(catalog.join("dora-rs/dora-yolo/0.5.1.yml").is_file());
+        assert!(
+            second.warnings.iter().any(|w| w.contains("re-cloning")),
+            "{:?}",
+            second.warnings
+        );
     }
 
     #[test]

--- a/libraries/hub-client/src/transport.rs
+++ b/libraries/hub-client/src/transport.rs
@@ -91,6 +91,20 @@ impl IndexFetcher {
             self.clone_index(git_url, &clone_dir, catalog_subpath)
                 .with_context(|| format!("failed to clone index `{}`", index.alias))?;
             self.refreshed.insert(index.alias.clone());
+        } else if cached_source_differs(&clone_dir, git_url, catalog_subpath) {
+            // the cache is keyed by alias, but `hub.toml` may have re-pointed
+            // this alias at a different URL/subpath (including an `official`
+            // mirror override) — fetching the old clone's `origin` would
+            // silently keep serving the previous source, so re-clone instead
+            if self.offline {
+                eyre::bail!(
+                    "cached index `{}` is for a different source than configured \
+                     and `--offline` is set\n  \
+                     hint: run once with network access to refresh the cache",
+                    index.alias
+                );
+            }
+            self.reclone(index, git_url, &clone_dir, catalog_subpath)?;
         } else if !self.offline
             && self.refreshed.insert(index.alias.clone())
             && let Err(refresh_err) = self.refresh_index(&index.alias, &clone_dir)
@@ -125,6 +139,20 @@ impl IndexFetcher {
                     index.alias
                 );
             }
+        }
+        // the catalog subpath comes from the index repo, which could ship it
+        // (or a parent) as a symlink pointing outside the clone — confine it
+        let real_catalog = catalog
+            .canonicalize()
+            .with_context(|| format!("failed to resolve catalog `{}`", catalog.display()))?;
+        let real_clone = clone_dir
+            .canonicalize()
+            .with_context(|| format!("failed to resolve clone `{}`", clone_dir.display()))?;
+        if !real_catalog.starts_with(&real_clone) {
+            eyre::bail!(
+                "index `{}` catalog `{catalog_subpath}` escapes the clone (symlink?)",
+                index.alias
+            );
         }
         Ok(catalog)
     }
@@ -200,6 +228,13 @@ impl IndexFetcher {
             &["sparse-checkout", "set", catalog_subpath],
         );
         git(Some(clone_dir), &["checkout", "--quiet"]).context("git checkout failed")?;
+        // record what this cache is a clone of, so a later config change that
+        // re-points the alias forces a re-clone instead of fetching the stale
+        // origin (see `cached_source_differs`)
+        let _ = std::fs::write(
+            clone_dir.join(SOURCE_MARKER),
+            format!("{git_url}\n{catalog_subpath}"),
+        );
         Ok(())
     }
 
@@ -255,6 +290,20 @@ fn remote_tip(clone_dir: &Path) -> eyre::Result<String> {
 
 fn short(commit: &str) -> &str {
     &commit[..commit.len().min(12)]
+}
+
+/// Marker file recording the `git_url` + catalog subpath a cached clone was
+/// made from, so a config change that re-points the alias is detected.
+const SOURCE_MARKER: &str = ".dora-index-source";
+
+/// Whether the cached clone was made from a different source than now
+/// configured. A missing/unreadable marker counts as "differs" so an old
+/// cache (or a tampered one) is re-cloned rather than trusted.
+fn cached_source_differs(clone_dir: &Path, git_url: &str, catalog_subpath: &str) -> bool {
+    match std::fs::read_to_string(clone_dir.join(SOURCE_MARKER)) {
+        Ok(recorded) => recorded != format!("{git_url}\n{catalog_subpath}"),
+        Err(_) => true,
+    }
 }
 
 /// Run a git command, returning trimmed stdout.

--- a/libraries/hub-client/src/transport.rs
+++ b/libraries/hub-client/src/transport.rs
@@ -23,7 +23,7 @@ use std::{
 
 use eyre::{Context, eyre};
 
-use crate::{OFFICIAL_INDEX_PATH, config::IndexConfig, validate_git_url};
+use crate::{OFFICIAL_INDEX_PATH, config::IndexConfig};
 
 /// Fetches and caches index catalogs for one CLI invocation.
 #[derive(Debug)]
@@ -91,17 +91,18 @@ impl IndexFetcher {
             self.clone_index(git_url, &clone_dir, catalog_subpath)
                 .with_context(|| format!("failed to clone index `{}`", index.alias))?;
             self.refreshed.insert(index.alias.clone());
-        } else if !self.offline && self.refreshed.insert(index.alias.clone()) {
-            if let Err(refresh_err) = self.refresh_index(&index.alias, &clone_dir) {
-                // self-heal a corrupt cache (e.g. a SIGKILL mid-clone left a
-                // broken .git); genuine network errors propagate so a flaky
-                // connection cannot wipe a cache that offline runs rely on
-                if git(Some(&clone_dir), &["rev-parse", "HEAD"]).is_err() {
-                    self.reclone(index, git_url, &clone_dir, catalog_subpath)?;
-                } else {
-                    return Err(refresh_err)
-                        .with_context(|| format!("failed to refresh index `{}`", index.alias));
-                }
+        } else if !self.offline
+            && self.refreshed.insert(index.alias.clone())
+            && let Err(refresh_err) = self.refresh_index(&index.alias, &clone_dir)
+        {
+            // self-heal a corrupt cache (e.g. a SIGKILL mid-clone left a
+            // broken .git); genuine network errors propagate so a flaky
+            // connection cannot wipe a cache that offline runs rely on
+            if git(Some(&clone_dir), &["rev-parse", "HEAD"]).is_err() {
+                self.reclone(index, git_url, &clone_dir, catalog_subpath)?;
+            } else {
+                return Err(refresh_err)
+                    .with_context(|| format!("failed to refresh index `{}`", index.alias));
             }
         }
 

--- a/libraries/hub-client/src/transport.rs
+++ b/libraries/hub-client/src/transport.rs
@@ -235,13 +235,22 @@ impl IndexFetcher {
 }
 
 /// The commit the remote's default branch points at after a fetch.
+///
+/// Resolves strictly through `refs/remotes/origin/HEAD` (populated by clone
+/// and refreshed by `git remote set-head origin --auto` in `refresh_index`).
+/// Guessing `origin/main`/`origin/master` was removed deliberately: for an
+/// index whose default branch is e.g. `develop`, a stale or coincidental
+/// `origin/main` ref would resolve against the wrong branch and produce
+/// spurious "history was rolled back" warnings or a stale tip. Better to fail
+/// loudly and have the caller re-clone than to silently track the wrong head.
 fn remote_tip(clone_dir: &Path) -> eyre::Result<String> {
-    for reference in ["refs/remotes/origin/HEAD", "origin/main", "origin/master"] {
-        if let Ok(commit) = git(Some(clone_dir), &["rev-parse", reference]) {
-            return Ok(commit);
-        }
-    }
-    eyre::bail!("could not determine the index's default branch")
+    git(Some(clone_dir), &["rev-parse", "refs/remotes/origin/HEAD"]).map_err(|_| {
+        eyre::eyre!(
+            "could not determine the index's default branch \
+             (refs/remotes/origin/HEAD is unset) — the cache may be corrupt; \
+             remove it and re-fetch"
+        )
+    })
 }
 
 fn short(commit: &str) -> &str {


### PR DESCRIPTION
Implements **P2.1 + P2.2** of the Dora Hub spec ([docs/plan-node-hub.md](https://github.com/dora-rs/dora/blob/main/docs/plan-node-hub.md) §7/§8.1, umbrella #2097): the `dora-hub-client` crate — everything needed to resolve `namespace/name@req` against a catalog, before any descriptor integration.

**Stacked on #2177** — will retarget as the stack merges.

## What's included

- **`reference`** — `[<namespace>/]<name>@<semver-req>` parsing; bare names are deterministic `dora-rs/` shorthand (§7.2); full `semver` requirement syntax.
- **`index`** — the catalog format (`<ns>/<name>/<version>.yml` = manifest snapshot + source pointer, `package.yml` owners): semver resolution picking the highest non-yanked match (cargo prerelease convention, tested), yank skipping (UC10), typo suggestions, and the **binary source form reserved in the schema** but erroring clearly on use (P2.8 deferral per §15 Q3).
- **`config`** — `hub.toml` `[[index]]` entries with **namespace↔index binding**: explicit bindings win, official carries the rest, double-binding is a hard error (no search order to race, §7.3); missing config = official only; `official` alias overridable for enterprise mirrors; local `path =` indexes for fixtures/tests (UC11).
- **`transport`** — blobless **sparse** clone of remote indexes into `~/.cache/dora/index/<alias>` (graceful fallback to plain clone when the server refuses filters), refresh at most once per invocation, **fast-forward check** that warns loudly on history rewrite/rollback (replayed indexes can hide yanks), `--offline` fails loudly on cache miss. Shells out to git deliberately — libgit2 (GitManager) has no partial-clone/sparse support.

## Security posture (self-review hardened)

This crate consumes untrusted input (public index content, user hub.toml), so:
- central `validate_git_url` rejects argument-injection (`--upload-pack=…`) and command transports (`ext::`), applied at config load, at `SourceSpec::git_pin()`, and at the transport boundary, plus `--` separators on git positionals;
- index aliases (cache dir names) and git-index `path` values are charset/confinement validated;
- package keys are charset-checked before filesystem joins; catalog listing skips out-of-charset directory names (terminal-output safety); commit hashes validated alphanumeric;
- index files are read with a bounded `take()` read.

## Verification

- 27 unit tests, including end-to-end git transport tests against local repos (clone → resolve → publish upstream → refresh-once semantics → new invocation sees the new version), offline cache-hit/miss, non-fast-forward warning, hostile config/URL rejection, prerelease semantics.
- fmt + clippy `-D warnings` + full workspace suite + qa-fast.

Part of #2097. Next: P2.5–P2.7 wire `hub:` descriptor resolution through this crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
