### PR TITLE
feat(hub): hub: descriptor field with end-to-end resolution (P2.5-P2.7)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1708,6 +1708,7 @@ dependencies = [
  "dora-core",
  "dora-daemon",
  "dora-download",
+ "dora-hub-client",
  "dora-message",
  "dora-node-api-c",
  "dora-operator-api-c",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1733,6 +1733,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "sysinfo 0.36.1",
  "tabwriter",
  "tempfile",

--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -44,6 +44,7 @@ serde_yaml = { workspace = true }
 toml = "0.9"
 webbrowser = "0.8.3"
 serde_json = { workspace = true }
+sha2 = "0.10"
 termcolor = "1.1.3"
 uuid = { workspace = true }
 inquire = { workspace = true }

--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -34,6 +34,7 @@ clap_complete = "4.5.61"
 eyre = { workspace = true }
 libc = { version = "0.2", optional = true }
 dora-core = { workspace = true, features = ["zenoh"] }
+dora-hub-client = { workspace = true }
 dora-message = { workspace = true }
 dora-node-api-c = { workspace = true }
 dora-operator-api-c = { workspace = true }

--- a/binaries/cli/src/command/build/git.rs
+++ b/binaries/cli/src/command/build/git.rs
@@ -39,6 +39,8 @@ pub fn fetch_commit_hash(repo_url: String, rev: Option<GitRepoRev>) -> eyre::Res
         Some(commit_hash) => Ok(GitSource {
             repo: repo_url,
             commit_hash,
+            subdir: None,
+            hub: None,
         }),
         None => eyre::bail!("no matching commit for `{rev:?}`"),
     }

--- a/binaries/cli/src/command/build/hub.rs
+++ b/binaries/cli/src/command/build/hub.rs
@@ -96,9 +96,26 @@ pub fn resolve_hub_nodes(
         let catalog = IndexCatalog::open(&catalog_dir)?;
 
         let pin = pins.and_then(|p| p.get(&node.id));
+        // under `--locked` (pins present), a node with no lockfile entry must
+        // fail fast rather than silently resolving from the network
+        if pins.is_some() && pin.is_none() {
+            eyre::bail!(
+                "node `{}`: `hub:` reference is not in the lockfile — \
+                 regenerate with `dora build --write-lockfile`",
+                node.id
+            );
+        }
         let (version, entry, source) = match pin {
             Some(pin) => {
                 // --locked: the pinned commit is used verbatim, no resolution
+                let valid_hash = (7..=64).contains(&pin.commit_hash.len())
+                    && pin.commit_hash.chars().all(|c| c.is_ascii_hexdigit());
+                if !valid_hash {
+                    eyre::bail!(
+                        "node `{}`: lockfile commit hash is not a valid hex hash",
+                        node.id
+                    );
+                }
                 let provenance = pin.hub.as_ref().with_context(|| {
                     format!(
                         "node `{}`: lockfile entry has no hub provenance — \
@@ -148,9 +165,28 @@ pub fn resolve_hub_nodes(
                             .as_deref()
                             .map(|r| format!(
                                 " ({})",
-                                r.chars().filter(|c| !c.is_control()).collect::<String>()
+                                r.chars()
+                                    .filter(|c| !c.is_control())
+                                    .take(200)
+                                    .collect::<String>()
                             ))
                             .unwrap_or_default()
+                    ));
+                }
+                // the lockfile is authoritative for the pin, but the index
+                // entry of the pinned version should still agree — a mismatch
+                // means the append-only index was tampered with or rewritten
+                if let Ok((git, rev)) = entry.source.git_pin()
+                    && (git != pin.repo
+                        || rev != pin.commit_hash
+                        || entry.source.subdir != pin.subdir)
+                {
+                    resolution.warnings.push(format!(
+                        "node `{}`: the index entry for `{}@{version}` no longer matches \
+                         the lockfile pin — the index may have been rewritten; \
+                         the lockfile pin is used",
+                        node.id,
+                        reference.key()
                     ));
                 }
                 (version, entry, pin.clone())
@@ -214,10 +250,10 @@ pub fn resolve_hub_nodes(
         node.git = Some(source.repo.clone());
         node.rev = Some(source.commit_hash.clone());
         node.hub = None;
+        let short_hash: String = source.commit_hash.chars().take(12).collect();
         resolution.notes.push(format!(
-            "node `{}`: resolved hub package {label} -> {}",
-            node.id,
-            &source.commit_hash[..source.commit_hash.len().min(12)]
+            "node `{}`: resolved hub package {label} -> {short_hash}",
+            node.id
         ));
         resolution.sources.insert(node.id.clone(), source);
     }

--- a/binaries/cli/src/command/build/hub.rs
+++ b/binaries/cli/src/command/build/hub.rs
@@ -1,0 +1,227 @@
+//! `hub:` reference resolution — the desugar step (spec §10.1, P2.5/P2.7).
+//!
+//! The CLI rewrites every `hub:` node into a concrete git-sourced node
+//! *before dispatch*: the index entry supplies the pinned commit (and
+//! optional `subdir`), the package manifest supplies the entrypoint, build
+//! command, and typed contracts. Downstream — coordinator, daemons, the
+//! lockfile — sees an ordinary git node carrying the optional `subdir` and
+//! hub provenance marker on its [`GitSource`].
+
+use std::collections::BTreeMap;
+
+use dora_core::{
+    build::validate_subdir,
+    manifest::inject::{InjectionResult, apply_manifest_contracts},
+    types::TypeRegistry,
+};
+use dora_hub_client::{
+    config::ResolvedConfig, index::IndexCatalog, reference::PackageRef, transport::IndexFetcher,
+};
+use dora_message::{
+    common::{GitSource, HubProvenance},
+    descriptor::Descriptor,
+    id::NodeId,
+};
+use eyre::{Context, ContextCompat};
+
+/// Outcome of resolving the `hub:` nodes of a dataflow.
+#[derive(Debug, Default)]
+pub struct HubResolution {
+    /// Progress/info lines for the user.
+    pub notes: Vec<String>,
+    /// Non-fatal problems (yanked pins, index rollback warnings).
+    pub warnings: Vec<String>,
+    /// Per-node resolved git source (with subdir + hub provenance) — merged
+    /// into the build's `git_sources` map and the lockfile.
+    pub sources: BTreeMap<NodeId, GitSource>,
+}
+
+impl HubResolution {
+    pub fn is_empty(&self) -> bool {
+        self.sources.is_empty()
+    }
+}
+
+/// Resolve and desugar every `hub:` node in `dataflow`.
+///
+/// With `pins` (from a lockfile, `--locked`), no index resolution happens:
+/// the pinned commit is used verbatim and the index entry of the pinned
+/// version supplies the manifest. Without pins, each reference resolves to
+/// the highest non-yanked matching version.
+pub fn resolve_hub_nodes(
+    dataflow: &mut Descriptor,
+    registry: &mut TypeRegistry,
+    offline: bool,
+    pins: Option<&BTreeMap<NodeId, GitSource>>,
+) -> eyre::Result<HubResolution> {
+    let mut resolution = HubResolution::default();
+    if !dataflow.nodes.iter().any(|n| n.hub.is_some()) {
+        return Ok(resolution);
+    }
+    resolution
+        .notes
+        .push("`hub:` is an unstable feature — its behavior may change in future releases".into());
+
+    let config = ResolvedConfig::load_default().context("failed to load hub configuration")?;
+    let mut fetcher = IndexFetcher::new(offline)?;
+
+    for node in &mut dataflow.nodes {
+        let Some(raw_reference) = node.hub.clone() else {
+            continue;
+        };
+        // the index entry supplies source and build (spec §10.1)
+        if node.path.is_some()
+            || node.git.is_some()
+            || node.build.is_some()
+            || node.branch.is_some()
+            || node.tag.is_some()
+            || node.rev.is_some()
+            || node.operators.is_some()
+            || node.operator.is_some()
+            || node.ros2.is_some()
+        {
+            eyre::bail!(
+                "node `{}`: `hub:` is mutually exclusive with `path`, `git`, \
+                 `build`, and operator fields — the hub package supplies them",
+                node.id
+            );
+        }
+
+        let reference = PackageRef::parse(&raw_reference)
+            .with_context(|| format!("node `{}`: invalid `hub:` reference", node.id))?;
+        let index_config = config.index_for_namespace(&reference.namespace);
+        let catalog_dir = fetcher
+            .catalog_dir(index_config, &config.config_dir)
+            .with_context(|| format!("node `{}`: failed to fetch the hub index", node.id))?;
+        let catalog = IndexCatalog::open(&catalog_dir)?;
+
+        let pin = pins.and_then(|p| p.get(&node.id));
+        let (version, entry, source) = match pin {
+            Some(pin) => {
+                // --locked: the pinned commit is used verbatim, no resolution
+                let provenance = pin.hub.as_ref().with_context(|| {
+                    format!(
+                        "node `{}`: lockfile entry has no hub provenance — \
+                         regenerate with `dora build --write-lockfile`",
+                        node.id
+                    )
+                })?;
+                if provenance.name != reference.key() {
+                    eyre::bail!(
+                        "node `{}`: lockfile pins `{}` but the dataflow now references \
+                         `{}` — regenerate with `dora build --write-lockfile`",
+                        node.id,
+                        provenance.name,
+                        reference.key()
+                    );
+                }
+                let version: dora_hub_client::semver::Version = provenance
+                    .version
+                    .parse()
+                    .with_context(|| format!("node `{}`: invalid version in lockfile", node.id))?;
+                if !reference.requirement.matches(&version) {
+                    eyre::bail!(
+                        "node `{}`: locked version {version} no longer satisfies `{}` — \
+                         regenerate with `dora build --write-lockfile`",
+                        node.id,
+                        reference.requirement
+                    );
+                }
+                let entry = catalog
+                    .entry(&reference.namespace, &reference.name, &version)
+                    .with_context(|| {
+                        format!(
+                            "node `{}`: pinned version {version} of `{}` is missing \
+                             from the index",
+                            node.id,
+                            reference.key()
+                        )
+                    })?;
+                if entry.yanked {
+                    resolution.warnings.push(format!(
+                        "node `{}`: pinned version {version} of `{}` has been yanked{} — \
+                         the pin keeps working, but consider updating",
+                        node.id,
+                        reference.key(),
+                        entry
+                            .yank_reason
+                            .as_deref()
+                            .map(|r| format!(
+                                " ({})",
+                                r.chars().filter(|c| !c.is_control()).collect::<String>()
+                            ))
+                            .unwrap_or_default()
+                    ));
+                }
+                (version, entry, pin.clone())
+            }
+            None => {
+                let resolved = catalog.resolve(&reference).with_context(|| {
+                    format!("node `{}`: failed to resolve `{raw_reference}`", node.id)
+                })?;
+                let (git_url, rev) = resolved.entry.source.git_pin().with_context(|| {
+                    format!(
+                        "node `{}`: invalid source for `{}@{}`",
+                        node.id,
+                        reference.key(),
+                        resolved.version
+                    )
+                })?;
+                let source = GitSource {
+                    repo: git_url.to_string(),
+                    commit_hash: rev.to_string(),
+                    subdir: resolved.entry.source.subdir.clone(),
+                    hub: Some(HubProvenance {
+                        name: reference.key(),
+                        version: resolved.version.to_string(),
+                    }),
+                };
+                (resolved.version, resolved.entry, source)
+            }
+        };
+
+        if let Some(subdir) = &source.subdir {
+            validate_subdir(subdir)
+                .with_context(|| format!("node `{}`: invalid index entry", node.id))?;
+        }
+
+        let manifest = &entry.manifest;
+        let label = format!("{}@{version}", reference.key());
+
+        // register the package's shipped types, then inject contracts and
+        // check the dataflow's wiring against the declared ports
+        for (urn, def) in &manifest.types {
+            if registry.resolve(urn).is_none() {
+                let _ = registry.add_user_type(urn, def.clone());
+            }
+        }
+        let mut contracts = InjectionResult::default();
+        apply_manifest_contracts(node, manifest, &label, registry, &mut contracts);
+        if !contracts.warnings.is_empty() {
+            // for hub packages the manifest is the contract — violations are
+            // errors, not warnings (spec §10.1)
+            eyre::bail!(
+                "node `{}`: does not match the `{label}` package contract:\n  - {}",
+                node.id,
+                contracts.warnings.join("\n  - ")
+            );
+        }
+        resolution.notes.extend(contracts.notes);
+
+        // desugar into a concrete git node
+        node.path = Some(manifest.entrypoint.replace('\\', "/"));
+        node.build = manifest.build.clone();
+        node.git = Some(source.repo.clone());
+        node.rev = Some(source.commit_hash.clone());
+        node.hub = None;
+        resolution.notes.push(format!(
+            "node `{}`: resolved hub package {label} -> {}",
+            node.id,
+            &source.commit_hash[..source.commit_hash.len().min(12)]
+        ));
+        resolution.sources.insert(node.id.clone(), source);
+    }
+
+    resolution.warnings.append(&mut fetcher.warnings);
+    Ok(resolution)
+}

--- a/binaries/cli/src/command/build/hub.rs
+++ b/binaries/cli/src/command/build/hub.rs
@@ -11,7 +11,10 @@ use std::collections::BTreeMap;
 
 use dora_core::{
     build::validate_subdir,
-    manifest::inject::{InjectionResult, apply_manifest_contracts},
+    manifest::{
+        NodeManifest,
+        inject::{InjectionResult, apply_manifest_contracts},
+    },
     types::TypeRegistry,
 };
 use dora_hub_client::{
@@ -63,6 +66,19 @@ fn normalize_git_source_url(url: &str) -> String {
     url.to_string()
 }
 
+/// A stable SHA-256 digest of an index entry's manifest, recorded in the
+/// lockfile so `--locked` can detect a rewritten index entry (entrypoint,
+/// build command, or typed contract). `serde_json` sorts the manifest's
+/// `BTreeMap` fields, so the serialization — and the digest — is canonical.
+fn manifest_digest(manifest: &NodeManifest) -> String {
+    use sha2::{Digest, Sha256};
+    let bytes = serde_json::to_vec(manifest).unwrap_or_default();
+    Sha256::digest(&bytes)
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
+}
+
 /// Resolve and desugar every `hub:` node in `dataflow`.
 ///
 /// With `pins` (from a lockfile, `--locked`), no index resolution happens:
@@ -110,15 +126,11 @@ pub fn resolve_hub_nodes(
 
         let reference = PackageRef::parse(&raw_reference)
             .with_context(|| format!("node `{}`: invalid `hub:` reference", node.id))?;
-        let index_config = config.index_for_namespace(&reference.namespace);
-        let catalog_dir = fetcher
-            .catalog_dir(index_config, &config.config_dir)
-            .with_context(|| format!("node `{}`: failed to fetch the hub index", node.id))?;
-        let catalog = IndexCatalog::open(&catalog_dir)?;
 
-        let pin = pins.and_then(|p| p.get(&node.id));
         // under `--locked` (pins present), a node with no lockfile entry must
-        // fail fast rather than silently resolving from the network
+        // fail fast — *before* any index fetch — rather than hitting the
+        // network (or an offline cache miss) only to bail afterwards.
+        let pin = pins.and_then(|p| p.get(&node.id));
         if pins.is_some() && pin.is_none() {
             eyre::bail!(
                 "node `{}`: `hub:` reference is not in the lockfile — \
@@ -126,6 +138,13 @@ pub fn resolve_hub_nodes(
                 node.id
             );
         }
+
+        let index_config = config.index_for_namespace(&reference.namespace);
+        let catalog_dir = fetcher
+            .catalog_dir(index_config, &config.config_dir)
+            .with_context(|| format!("node `{}`: failed to fetch the hub index", node.id))?;
+        let catalog = IndexCatalog::open(&catalog_dir)?;
+
         let (version, entry, source) = match pin {
             Some(pin) => {
                 // --locked: the pinned commit is used verbatim, no resolution
@@ -210,35 +229,24 @@ pub fn resolve_hub_nodes(
                         reference.key()
                     ));
                 }
-                // the commit hash pins the source *tree*, but the entrypoint and
-                // build command come from the (mutable) index entry — so a
-                // rewritten index could inject an arbitrary build command at a
-                // pinned version. `--locked` hard-errors if they changed. The
-                // `entrypoint` field doubles as the new-lockfile-format sentinel:
-                // when absent (lockfile predates this field) the check is skipped.
+                // the commit hash pins the source *tree*, but the manifest
+                // (entrypoint, build command, and the typed contract) comes from
+                // the *mutable* index entry — so a rewritten entry could change
+                // any of it at a pinned version. `--locked` hard-errors if the
+                // manifest digest no longer matches what was locked. The digest
+                // doubles as the new-lockfile-format sentinel: when absent
+                // (lockfile predates this field) the check is skipped.
                 if let Some(provenance) = &pin.hub
-                    && let Some(locked_entrypoint) = &provenance.entrypoint
+                    && let Some(locked_digest) = &provenance.manifest_digest
+                    && *locked_digest != manifest_digest(&entry.manifest)
                 {
-                    if *locked_entrypoint != entry.manifest.entrypoint {
-                        eyre::bail!(
-                            "node `{}`: the locked index entry for `{}@{version}` changed \
-                             its entrypoint since the lockfile was written \
-                             (`{locked_entrypoint}` -> `{}`) — regenerate with \
-                             `dora build --write-lockfile`",
-                            node.id,
-                            entry.manifest.entrypoint,
-                            reference.key()
-                        );
-                    }
-                    if provenance.build != entry.manifest.build {
-                        eyre::bail!(
-                            "node `{}`: the locked index entry for `{}@{version}` changed \
-                             its build command since the lockfile was written — \
-                             regenerate with `dora build --write-lockfile`",
-                            node.id,
-                            reference.key()
-                        );
-                    }
+                    eyre::bail!(
+                        "node `{}`: the locked index entry for `{}@{version}` changed its \
+                         manifest (entrypoint, build, or contract) since the lockfile was \
+                         written — regenerate with `dora build --write-lockfile`",
+                        node.id,
+                        reference.key()
+                    );
                 }
                 (version, entry, pin.clone())
             }
@@ -261,8 +269,7 @@ pub fn resolve_hub_nodes(
                     hub: Some(HubProvenance {
                         name: reference.key(),
                         version: resolved.version.to_string(),
-                        entrypoint: Some(resolved.entry.manifest.entrypoint.clone()),
-                        build: resolved.entry.manifest.build.clone(),
+                        manifest_digest: Some(manifest_digest(&resolved.entry.manifest)),
                     }),
                 };
                 (resolved.version, resolved.entry, source)

--- a/binaries/cli/src/command/build/hub.rs
+++ b/binaries/cli/src/command/build/hub.rs
@@ -42,6 +42,27 @@ impl HubResolution {
     }
 }
 
+/// Normalize an index `source.git` into a form the build's `GitManager` can
+/// consume. `validate_git_url` accepts two scheme-less forms — scp-style
+/// `git@host:path` and absolute local paths — but `GitManager::choose_clone_dir`
+/// parses the URL with `url::Url`, which rejects both. Rewrite them into the
+/// equivalent `ssh://` / `file://` URLs git treats identically, so a source
+/// that resolves also clones instead of failing late during the build.
+fn normalize_git_source_url(url: &str) -> String {
+    if url.contains("://") {
+        return url.to_string();
+    }
+    if let Some(rest) = url.strip_prefix("git@")
+        && let Some((host, path)) = rest.split_once(':')
+    {
+        return format!("ssh://git@{host}/{}", path.trim_start_matches('/'));
+    }
+    if url.starts_with('/') {
+        return format!("file://{url}");
+    }
+    url.to_string()
+}
+
 /// Resolve and desugar every `hub:` node in `dataflow`.
 ///
 /// With `pins` (from a lockfile, `--locked`), no index resolution happens:
@@ -177,7 +198,7 @@ pub fn resolve_hub_nodes(
                 // entry of the pinned version should still agree — a mismatch
                 // means the append-only index was tampered with or rewritten
                 if let Ok((git, rev)) = entry.source.git_pin()
-                    && (git != pin.repo
+                    && (normalize_git_source_url(git) != pin.repo
                         || rev != pin.commit_hash
                         || entry.source.subdir != pin.subdir)
                 {
@@ -204,7 +225,7 @@ pub fn resolve_hub_nodes(
                     )
                 })?;
                 let source = GitSource {
-                    repo: git_url.to_string(),
+                    repo: normalize_git_source_url(git_url),
                     commit_hash: rev.to_string(),
                     subdir: resolved.entry.source.subdir.clone(),
                     hub: Some(HubProvenance {
@@ -260,4 +281,33 @@ pub fn resolve_hub_nodes(
 
     resolution.warnings.append(&mut fetcher.warnings);
     Ok(resolution)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_git_source_url;
+
+    #[test]
+    fn normalizes_scp_and_path_sources_to_parseable_urls() {
+        // every `expected` is a scheme-prefixed URL `url::Url::parse` accepts,
+        // which is exactly what GitManager::choose_clone_dir needs.
+        let cases = [
+            // scp-style → ssh://
+            (
+                "git@github.com:org/repo.git",
+                "ssh://git@github.com/org/repo.git",
+            ),
+            ("/srv/mirrors/repo", "file:///srv/mirrors/repo"),
+            // already-parseable forms are left untouched
+            (
+                "https://github.com/org/repo.git",
+                "https://github.com/org/repo.git",
+            ),
+            ("ssh://git@host/org/repo", "ssh://git@host/org/repo"),
+            ("file:///local/repo", "file:///local/repo"),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(normalize_git_source_url(input), expected, "input `{input}`");
+        }
+    }
 }

--- a/binaries/cli/src/command/build/hub.rs
+++ b/binaries/cli/src/command/build/hub.rs
@@ -210,6 +210,36 @@ pub fn resolve_hub_nodes(
                         reference.key()
                     ));
                 }
+                // the commit hash pins the source *tree*, but the entrypoint and
+                // build command come from the (mutable) index entry — so a
+                // rewritten index could inject an arbitrary build command at a
+                // pinned version. `--locked` hard-errors if they changed. The
+                // `entrypoint` field doubles as the new-lockfile-format sentinel:
+                // when absent (lockfile predates this field) the check is skipped.
+                if let Some(provenance) = &pin.hub
+                    && let Some(locked_entrypoint) = &provenance.entrypoint
+                {
+                    if *locked_entrypoint != entry.manifest.entrypoint {
+                        eyre::bail!(
+                            "node `{}`: the locked index entry for `{}@{version}` changed \
+                             its entrypoint since the lockfile was written \
+                             (`{locked_entrypoint}` -> `{}`) — regenerate with \
+                             `dora build --write-lockfile`",
+                            node.id,
+                            entry.manifest.entrypoint,
+                            reference.key()
+                        );
+                    }
+                    if provenance.build != entry.manifest.build {
+                        eyre::bail!(
+                            "node `{}`: the locked index entry for `{}@{version}` changed \
+                             its build command since the lockfile was written — \
+                             regenerate with `dora build --write-lockfile`",
+                            node.id,
+                            reference.key()
+                        );
+                    }
+                }
                 (version, entry, pin.clone())
             }
             None => {
@@ -231,6 +261,8 @@ pub fn resolve_hub_nodes(
                     hub: Some(HubProvenance {
                         name: reference.key(),
                         version: resolved.version.to_string(),
+                        entrypoint: Some(resolved.entry.manifest.entrypoint.clone()),
+                        build: resolved.entry.manifest.build.clone(),
                     }),
                 };
                 (resolved.version, resolved.entry, source)

--- a/binaries/cli/src/command/build/local.rs
+++ b/binaries/cli/src/command/build/local.rs
@@ -56,7 +56,11 @@ async fn build_dataflow(
         let git_source = git_sources.get(&node_id).cloned();
         let prev_git_source = prev_git_sources.get(&node_id).cloned();
         let prev_git = prev_git_source.map(|prev_source| PrevGitSource {
-            still_needed_for_this_build: git_sources.values().any(|s| s == &prev_source),
+            // compare clone identity (repo + commit) only: hub provenance and
+            // subdir don't change which directory the clone occupies
+            still_needed_for_this_build: git_sources
+                .values()
+                .any(|s| s.repo == prev_source.repo && s.commit_hash == prev_source.commit_hash),
             git_source: prev_source,
         });
 
@@ -79,6 +83,12 @@ async fn build_dataflow(
     let mut info = BuildInfo {
         node_working_dirs: Default::default(),
         python_env_dirs: Default::default(),
+        // hub-sourced nodes are spawned with confined path resolution
+        confined_nodes: git_sources
+            .iter()
+            .filter(|(_, source)| source.hub.is_some())
+            .map(|(node_id, _)| node_id.clone())
+            .collect(),
     };
 
     if parallel && tasks.len() > 1 {

--- a/binaries/cli/src/command/build/lockfile.rs
+++ b/binaries/cli/src/command/build/lockfile.rs
@@ -221,6 +221,8 @@ mod tests {
             s.hub = Some(dora_message::common::HubProvenance {
                 name: "dora-rs/dora-yolo".into(),
                 version: "0.5.2".into(),
+                entrypoint: Some("target/release/dora-yolo".into()),
+                build: Some("cargo build --release".into()),
             });
             s
         });

--- a/binaries/cli/src/command/build/lockfile.rs
+++ b/binaries/cli/src/command/build/lockfile.rs
@@ -10,8 +10,17 @@ use dora_message::{
 };
 use eyre::{Context, ContextCompat};
 
-const LOCKFILE_VERSION: u32 = 2;
+const LOCKFILE_VERSION: u32 = 3;
 const MIN_SUPPORTED_LOCKFILE_VERSION: u32 = 1;
+/// Version written when no entry carries hub provenance or a subdir. Writing
+/// the lower version keeps plain-git lockfiles byte-compatible with older
+/// dora; hub-carrying lockfiles get v3 so an older dora fails loudly instead
+/// of silently ignoring the extra fields (and rooting the build in the wrong directory).
+const BASE_LOCKFILE_VERSION: u32 = 2;
+/// Schema tag hashed into the descriptor fingerprint. Deliberately decoupled
+/// from `LOCKFILE_VERSION`: bumping the file version for hub support must not
+/// invalidate every existing v2 lockfile.
+const FINGERPRINT_SCHEMA_VERSION: u32 = 2;
 
 #[derive(serde::Serialize)]
 struct BuildLockfileView<'a> {
@@ -58,9 +67,9 @@ impl BuildLockfile {
         descriptor_git_sources: &BTreeMap<NodeId, NodeSource>,
     ) -> String {
         let mut canonical = String::new();
-        // Intentional: include schema version in canonical content so lockfile format
-        // bumps force regeneration even if descriptor sources are unchanged.
-        canonical.push_str(&format!("dora-lockfile-v{LOCKFILE_VERSION}\n"));
+        // Intentional: include schema version in canonical content so fingerprint
+        // schema bumps force regeneration even if descriptor sources are unchanged.
+        canonical.push_str(&format!("dora-lockfile-v{FINGERPRINT_SCHEMA_VERSION}\n"));
 
         for (node_id, source) in descriptor_git_sources {
             let NodeSource::GitBranch { repo, rev } = source else {
@@ -119,8 +128,15 @@ impl BuildLockfile {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).context("failed to create lockfile directory")?;
         }
+        let has_hub_entries = git_sources
+            .values()
+            .any(|s| s.hub.is_some() || s.subdir.is_some());
         let view = BuildLockfileView {
-            version: LOCKFILE_VERSION,
+            version: if has_hub_entries {
+                LOCKFILE_VERSION
+            } else {
+                BASE_LOCKFILE_VERSION
+            },
             descriptor_fingerprint,
             git_sources,
         };
@@ -153,6 +169,8 @@ mod tests {
         GitSource {
             repo: repo.to_owned(),
             commit_hash: commit_hash.to_owned(),
+            subdir: None,
+            hub: None,
         }
     }
 
@@ -185,11 +203,43 @@ mod tests {
         BuildLockfile::write_git_sources(&lockfile_path, &git_sources, &fingerprint).unwrap();
         let loaded = BuildLockfile::read_from(&lockfile_path).unwrap();
 
-        assert_eq!(loaded.version, LOCKFILE_VERSION);
+        assert_eq!(loaded.version, BASE_LOCKFILE_VERSION);
         assert_eq!(loaded.git_sources, git_sources);
         loaded
             .ensure_descriptor_fingerprint_matches(&fingerprint)
             .unwrap();
+    }
+
+    #[test]
+    fn hub_entries_bump_lockfile_version() {
+        let tmp = tempfile::tempdir().unwrap();
+        let lockfile_path = tmp.path().join("hub.dora-lock.yaml");
+        let mut git_sources = BTreeMap::new();
+        git_sources.insert("detector".parse().unwrap(), {
+            let mut s = source("https://example.com/hub", "abc1234");
+            s.subdir = Some("node-hub/dora-yolo".into());
+            s.hub = Some(dora_message::common::HubProvenance {
+                name: "dora-rs/dora-yolo".into(),
+                version: "0.5.2".into(),
+            });
+            s
+        });
+        BuildLockfile::write_git_sources(&lockfile_path, &git_sources, "fp").unwrap();
+        let loaded = BuildLockfile::read_from(&lockfile_path).unwrap();
+        assert_eq!(loaded.version, LOCKFILE_VERSION);
+        let node_id: NodeId = "detector".parse().unwrap();
+        assert_eq!(
+            loaded.git_sources[&node_id].hub.as_ref().unwrap().version,
+            "0.5.2"
+        );
+        // plain-git lockfiles keep the old version for compatibility
+        let plain: BTreeMap<NodeId, GitSource> = BTreeMap::from([(
+            "node-a".parse().unwrap(),
+            source("https://example.com/repo", "abc123"),
+        )]);
+        BuildLockfile::write_git_sources(&lockfile_path, &plain, "fp").unwrap();
+        let loaded = BuildLockfile::read_from(&lockfile_path).unwrap();
+        assert_eq!(loaded.version, BASE_LOCKFILE_VERSION);
     }
 
     #[test]

--- a/binaries/cli/src/command/build/lockfile.rs
+++ b/binaries/cli/src/command/build/lockfile.rs
@@ -221,8 +221,7 @@ mod tests {
             s.hub = Some(dora_message::common::HubProvenance {
                 name: "dora-rs/dora-yolo".into(),
                 version: "0.5.2".into(),
-                entrypoint: Some("target/release/dora-yolo".into()),
-                build: Some("cargo build --release".into()),
+                manifest_digest: Some("deadbeef".into()),
             });
             s
         });

--- a/binaries/cli/src/command/build/mod.rs
+++ b/binaries/cli/src/command/build/mod.rs
@@ -241,6 +241,14 @@ pub fn build(cfg: BuildConfig) -> eyre::Result<()> {
         .expand(working_dir)
         .wrap_err("failed to expand modules in dataflow descriptor")?;
 
+    // Digest the expanded descriptor before hub desugaring so `dora start` /
+    // `dora daemon --run-dataflow` can detect on-disk edits to a hub dataflow
+    // (whose unresolved `hub:` references can't be re-fingerprinted directly).
+    let has_hub_nodes = dataflow_descriptor.nodes.iter().any(|n| n.hub.is_some());
+    let source_fingerprint = has_hub_nodes
+        .then(|| DataflowSession::fingerprint_source(&dataflow_descriptor))
+        .flatten();
+
     // --- Type checking (Phase 1) ---
     let strict = strict_types || dataflow_descriptor.strict_types.unwrap_or(false);
     let mut registry = TypeRegistry::new();
@@ -461,6 +469,7 @@ pub fn build(cfg: BuildConfig) -> eyre::Result<()> {
             // hub: nodes were desugared in memory — `dora start`/`dora run`
             // re-read the YAML from disk and need the resolved form
             dataflow_session.resolved_dataflow = resolved_dataflow_for_session.clone();
+            dataflow_session.source_fingerprint = source_fingerprint.clone();
             dataflow_session
                 .write_out_for_dataflow(&dataflow_path)
                 .context("failed to write out dataflow session file")?;
@@ -489,6 +498,7 @@ pub fn build(cfg: BuildConfig) -> eyre::Result<()> {
                 wait_until_dataflow_built(build_id, &coordinator_session, log::LevelFilter::Info);
 
             dataflow_session.resolved_dataflow = resolved_dataflow_for_session.clone();
+            dataflow_session.source_fingerprint = source_fingerprint.clone();
             finalize_distributed_build_session(
                 &mut dataflow_session,
                 &dataflow_path,

--- a/binaries/cli/src/command/build/mod.rs
+++ b/binaries/cli/src/command/build/mod.rs
@@ -77,6 +77,7 @@ use lockfile::BuildLockfile;
 
 mod distributed;
 mod git;
+pub mod hub;
 mod local;
 mod lockfile;
 
@@ -113,6 +114,10 @@ pub struct Build {
     /// Build nodes concurrently (faster on multi-core machines).
     #[clap(long, action)]
     parallel: bool,
+    /// Do not access the network for hub index refreshes; fail loudly on
+    /// cache misses.
+    #[clap(long, action)]
+    offline: bool,
 }
 
 impl Executable for Build {
@@ -129,6 +134,7 @@ impl Executable for Build {
             write_lockfile: self.write_lockfile,
             lockfile_override: self.lockfile,
             parallel: self.parallel,
+            offline: self.offline,
             ..Default::default()
         })
     }
@@ -157,6 +163,8 @@ pub struct BuildConfig {
     pub write_lockfile: bool,
     pub lockfile_override: Option<PathBuf>,
     pub parallel: bool,
+    /// Skip network access for hub index refreshes (cache only).
+    pub offline: bool,
     /// Overrides the working directory for cargo invocations and
     /// module expansion. Needed when the dataflow path points at a
     /// rewritten copy (e.g. a tempfile) whose parent can't resolve the
@@ -205,6 +213,7 @@ pub fn build(cfg: BuildConfig) -> eyre::Result<()> {
         write_lockfile,
         lockfile_override,
         parallel,
+        offline,
         working_dir_override,
     } = cfg;
     // `BuildConfig` derives `Default` so `..Default::default()` works at
@@ -247,6 +256,36 @@ pub fn build(cfg: BuildConfig) -> eyre::Result<()> {
             _ => {}
         }
     }
+    // The lockfile is read before hub resolution: under `--locked`, hub
+    // references use the pinned commits verbatim, no index resolution.
+    let lockfile_path = BuildLockfile::path_for_dataflow(&dataflow_path, lockfile_override);
+    let build_lockfile = if locked {
+        Some(BuildLockfile::read_from(&lockfile_path).with_context(|| {
+            format!(
+                "failed to read build lockfile at `{}`",
+                lockfile_path.display()
+            )
+        })?)
+    } else {
+        None
+    };
+    // Desugar hub: nodes into concrete git nodes (spec §10.1) — after module
+    // expansion, before type-checking
+    let hub_pins = build_lockfile.as_ref().map(|l| l.git_sources.clone());
+    let hub_resolution = hub::resolve_hub_nodes(
+        &mut dataflow_descriptor,
+        &mut registry,
+        offline,
+        hub_pins.as_ref(),
+    )?;
+    for note in &hub_resolution.notes {
+        println!("  {note}");
+    }
+    for warning in &hub_resolution.warnings {
+        eprintln!("  warning: {warning}");
+    }
+    let resolved_dataflow_for_session =
+        (!hub_resolution.is_empty()).then(|| dataflow_descriptor.clone());
     // Inject contracts from node manifests adjacent to path: nodes (§6.2)
     let injection = dora_core::manifest::inject::inject_adjacent_manifests(
         &mut dataflow_descriptor,
@@ -284,18 +323,6 @@ pub fn build(cfg: BuildConfig) -> eyre::Result<()> {
 
     let mut dataflow_session =
         DataflowSession::read_session(&dataflow_path).context("failed to read DataflowSession")?;
-
-    let lockfile_path = BuildLockfile::path_for_dataflow(&dataflow_path, lockfile_override);
-    let build_lockfile = if locked {
-        Some(BuildLockfile::read_from(&lockfile_path).with_context(|| {
-            format!(
-                "failed to read build lockfile at `{}`",
-                lockfile_path.display()
-            )
-        })?)
-    } else {
-        None
-    };
 
     let mut git_sources = BTreeMap::new();
     let mut descriptor_git_sources = BTreeMap::new();
@@ -345,12 +372,17 @@ pub fn build(cfg: BuildConfig) -> eyre::Result<()> {
             ..
         }) = node.kind
         {
-            let source = match &build_lockfile {
-                Some(lockfile) => lockfile
-                    .get_source(&node_id, &repo)
-                    .with_context(|| format!("failed to resolve locked git source `{node_id}`"))?,
-                None => git::fetch_commit_hash(repo, rev)
-                    .with_context(|| format!("failed to find commit hash for `{node_id}`"))?,
+            // hub-desugared nodes are already pinned to a commit (and carry
+            // subdir + provenance) — no ref resolution needed
+            let source = match hub_resolution.sources.get(&node_id) {
+                Some(source) => source.clone(),
+                None => match &build_lockfile {
+                    Some(lockfile) => lockfile.get_source(&node_id, &repo).with_context(|| {
+                        format!("failed to resolve locked git source `{node_id}`")
+                    })?,
+                    None => git::fetch_commit_hash(repo, rev)
+                        .with_context(|| format!("failed to find commit hash for `{node_id}`"))?,
+                },
             };
             git_sources.insert(node_id, source);
         }
@@ -426,6 +458,9 @@ pub fn build(cfg: BuildConfig) -> eyre::Result<()> {
             // detect descriptor drift and invalidate cached build metadata
             // (#1444).
             dataflow_session.build_fingerprint = Some(session_build_fingerprint.clone());
+            // hub: nodes were desugared in memory — `dora start`/`dora run`
+            // re-read the YAML from disk and need the resolved form
+            dataflow_session.resolved_dataflow = resolved_dataflow_for_session.clone();
             dataflow_session
                 .write_out_for_dataflow(&dataflow_path)
                 .context("failed to write out dataflow session file")?;
@@ -453,6 +488,7 @@ pub fn build(cfg: BuildConfig) -> eyre::Result<()> {
             let build_result =
                 wait_until_dataflow_built(build_id, &coordinator_session, log::LevelFilter::Info);
 
+            dataflow_session.resolved_dataflow = resolved_dataflow_for_session.clone();
             finalize_distributed_build_session(
                 &mut dataflow_session,
                 &dataflow_path,
@@ -629,6 +665,8 @@ mod tests {
         GitSource {
             repo: repo.to_owned(),
             commit_hash: commit_hash.to_owned(),
+            subdir: None,
+            hub: None,
         }
     }
 

--- a/binaries/cli/src/command/daemon.rs
+++ b/binaries/cli/src/command/daemon.rs
@@ -215,6 +215,7 @@ impl Executable for Daemon {
                         let result = dora_daemon::Daemon::run_dataflow(&dataflow_path,
                             dataflow_session.build_id, dataflow_session.local_build, dataflow_session.session_id, false,
                             LogDestination::Tracing, None, None, false, None,
+                            dataflow_session.resolved_dataflow,
                         ).await?;
                         handle_dataflow_result(result, None)
                     }

--- a/binaries/cli/src/command/daemon.rs
+++ b/binaries/cli/src/command/daemon.rs
@@ -205,7 +205,11 @@ impl Executable for Daemon {
                         // `hub:` references are unresolved on disk; fingerprinting
                         // resolves nodes, which rejects unresolved hub refs. Verify
                         // the build is current and use its desugared descriptor.
-                        let expanded = if expanded.nodes.iter().any(|n| n.hub.is_some()) {
+                        // Only a hub dataflow uses the desugared descriptor override,
+                        // and only then is the source-fingerprint staleness gate
+                        // meaningful — keep the two conditions aligned so a non-hub
+                        // file can never be run against a stale resolved descriptor.
+                        let (expanded, descriptor_override) = if expanded.nodes.iter().any(|n| n.hub.is_some()) {
                             let resolved = dataflow_session.resolved_dataflow.clone().ok_or_else(|| {
                                 eyre::eyre!("this dataflow uses `hub:` nodes — run `dora build` first")
                             })?;
@@ -213,9 +217,9 @@ impl Executable for Daemon {
                             if current.is_none() || current != dataflow_session.source_fingerprint {
                                 eyre::bail!("this dataflow changed since the last `dora build` — run `dora build` again");
                             }
-                            resolved
+                            (resolved.clone(), Some(resolved))
                         } else {
-                            expanded
+                            (expanded, None)
                         };
                         let resolved_for_fingerprint = expanded
                             .resolve_aliases_and_set_defaults()
@@ -230,7 +234,7 @@ impl Executable for Daemon {
                         let result = dora_daemon::Daemon::run_dataflow(&dataflow_path,
                             dataflow_session.build_id, dataflow_session.local_build, dataflow_session.session_id, false,
                             LogDestination::Tracing, None, None, false, None,
-                            dataflow_session.resolved_dataflow,
+                            descriptor_override,
                         ).await?;
                         handle_dataflow_result(result, None)
                     }

--- a/binaries/cli/src/command/daemon.rs
+++ b/binaries/cli/src/command/daemon.rs
@@ -202,6 +202,21 @@ impl Executable for Daemon {
                         let expanded = dataflow_descriptor
                             .expand(working_dir)
                             .wrap_err("failed to expand modules in dataflow descriptor")?;
+                        // `hub:` references are unresolved on disk; fingerprinting
+                        // resolves nodes, which rejects unresolved hub refs. Verify
+                        // the build is current and use its desugared descriptor.
+                        let expanded = if expanded.nodes.iter().any(|n| n.hub.is_some()) {
+                            let resolved = dataflow_session.resolved_dataflow.clone().ok_or_else(|| {
+                                eyre::eyre!("this dataflow uses `hub:` nodes — run `dora build` first")
+                            })?;
+                            let current = DataflowSession::fingerprint_source(&expanded);
+                            if current.is_none() || current != dataflow_session.source_fingerprint {
+                                eyre::bail!("this dataflow changed since the last `dora build` — run `dora build` again");
+                            }
+                            resolved
+                        } else {
+                            expanded
+                        };
                         let resolved_for_fingerprint = expanded
                             .resolve_aliases_and_set_defaults()
                             .context("failed to resolve nodes for session fingerprint")?;

--- a/binaries/cli/src/command/mod.rs
+++ b/binaries/cli/src/command/mod.rs
@@ -422,6 +422,14 @@ mod tests {
     }
 
     #[test]
+    fn parse_offline() {
+        parse_ok(&["dora", "build", "dataflow.yml", "--offline"]);
+        parse_ok(&["dora", "validate", "dataflow.yml", "--offline"]);
+        // --offline is meaningless for standalone manifest validation
+        parse_err(&["dora", "validate", "--node-manifest", "x.yml", "--offline"]);
+    }
+
+    #[test]
     fn parse_hub() {
         parse_ok(&["dora", "hub", "init"]);
         parse_ok(&["dora", "hub", "init", "path/to/node"]);

--- a/binaries/cli/src/command/run.rs
+++ b/binaries/cli/src/command/run.rs
@@ -224,6 +224,9 @@ impl Executable for Run {
                 stop_after,
                 debug,
                 working_dir_override,
+                // hub: dataflows run from the desugared descriptor stored at
+                // build time (the on-disk YAML has unresolved references)
+                dataflow_session.resolved_dataflow,
             )
             .await
         });

--- a/binaries/cli/src/command/start/mod.rs
+++ b/binaries/cli/src/command/start/mod.rs
@@ -130,35 +130,20 @@ fn start_dataflow(
         DataflowSession::read_session(&dataflow).context("failed to read DataflowSession")?;
     // `hub:` references are desugared by `dora build`, which stores the
     // resolved descriptor in the session — `dora start` requires that prior
-    // build, exactly like git sources require a prior clone. Verify the
-    // on-disk references still match what was built before substituting.
+    // build, exactly like git sources require a prior clone. Compare the
+    // expanded descriptor against the digest taken at build time so *any*
+    // on-disk edit (hub or not) since the build is caught, then substitute
+    // the resolved form.
     if dataflow_descriptor.nodes.iter().any(|n| n.hub.is_some()) {
         let resolved = dataflow_session.resolved_dataflow.clone().ok_or_else(|| {
             eyre::eyre!("this dataflow uses `hub:` nodes — run `dora build` first")
         })?;
-        for node in &dataflow_descriptor.nodes {
-            let Some(raw_reference) = &node.hub else {
-                continue;
-            };
-            let reference = dora_hub_client::reference::PackageRef::parse(raw_reference)
-                .with_context(|| format!("node `{}`: invalid `hub:` reference", node.id))?;
-            let built = dataflow_session
-                .git_sources
-                .get(&node.id)
-                .and_then(|s| s.hub.as_ref());
-            let matches_build = built.is_some_and(|p| {
-                p.name == reference.key()
-                    && p.version
-                        .parse()
-                        .is_ok_and(|v| reference.requirement.matches(&v))
-            });
-            if !matches_build {
-                eyre::bail!(
-                    "node `{}`: the `hub:` reference changed since the last build \
-                     (or the cached build is stale) — run `dora build` again",
-                    node.id
-                );
-            }
+        let current = DataflowSession::fingerprint_source(&dataflow_descriptor);
+        if current.is_none() || current != dataflow_session.source_fingerprint {
+            eyre::bail!(
+                "this dataflow changed since the last `dora build` — run `dora build` again \
+                 (`dora start` cannot re-resolve `hub:` references)"
+            );
         }
         dataflow_descriptor = resolved;
     }

--- a/binaries/cli/src/command/start/mod.rs
+++ b/binaries/cli/src/command/start/mod.rs
@@ -128,6 +128,40 @@ fn start_dataflow(
         .wrap_err("failed to expand modules in dataflow descriptor")?;
     let mut dataflow_session =
         DataflowSession::read_session(&dataflow).context("failed to read DataflowSession")?;
+    // `hub:` references are desugared by `dora build`, which stores the
+    // resolved descriptor in the session — `dora start` requires that prior
+    // build, exactly like git sources require a prior clone. Verify the
+    // on-disk references still match what was built before substituting.
+    if dataflow_descriptor.nodes.iter().any(|n| n.hub.is_some()) {
+        let resolved = dataflow_session.resolved_dataflow.clone().ok_or_else(|| {
+            eyre::eyre!("this dataflow uses `hub:` nodes — run `dora build` first")
+        })?;
+        for node in &dataflow_descriptor.nodes {
+            let Some(raw_reference) = &node.hub else {
+                continue;
+            };
+            let reference = dora_hub_client::reference::PackageRef::parse(raw_reference)
+                .with_context(|| format!("node `{}`: invalid `hub:` reference", node.id))?;
+            let built = dataflow_session
+                .git_sources
+                .get(&node.id)
+                .and_then(|s| s.hub.as_ref());
+            let matches_build = built.is_some_and(|p| {
+                p.name == reference.key()
+                    && p.version
+                        .parse()
+                        .is_ok_and(|v| reference.requirement.matches(&v))
+            });
+            if !matches_build {
+                eyre::bail!(
+                    "node `{}`: the `hub:` reference changed since the last build \
+                     (or the cached build is stale) — run `dora build` again",
+                    node.id
+                );
+            }
+        }
+        dataflow_descriptor = resolved;
+    }
     // Invalidate cached `build_id`/`local_build`/`git_sources` if the
     // descriptor's build-inputs (build command, source, env, cwd) changed
     // since the last `dora build`. Without this, `dora start` would send a

--- a/binaries/cli/src/command/validate.rs
+++ b/binaries/cli/src/command/validate.rs
@@ -27,6 +27,9 @@ pub struct Validate {
     /// Validate a node manifest (dora-node.yml) instead of a dataflow
     #[clap(long, value_name = "PATH", value_hint = clap::ValueHint::FilePath)]
     node_manifest: Option<PathBuf>,
+    /// Do not access the network for hub index refreshes (cache only)
+    #[clap(long, action, conflicts_with = "node_manifest")]
+    offline: bool,
 }
 
 impl Executable for Validate {
@@ -37,7 +40,7 @@ impl Executable for Validate {
         let dataflow = self
             .dataflow
             .expect("clap guarantees dataflow when --node-manifest is absent");
-        validate_dataflow(&dataflow, self.strict_types)
+        validate_dataflow(&dataflow, self.strict_types, self.offline)
     }
 }
 
@@ -54,7 +57,7 @@ fn validate_node_manifest(path: &Path) -> eyre::Result<()> {
     Ok(())
 }
 
-fn validate_dataflow(dataflow: &Path, strict_types: bool) -> eyre::Result<()> {
+fn validate_dataflow(dataflow: &Path, strict_types: bool, offline: bool) -> eyre::Result<()> {
     let working_dir = dataflow
         .parent()
         .filter(|p| !p.as_os_str().is_empty())
@@ -74,10 +77,6 @@ fn validate_dataflow(dataflow: &Path, strict_types: bool) -> eyre::Result<()> {
         .expand(working_dir)
         .context("failed to expand modules in dataflow descriptor")?;
 
-    // Check input/output wiring (no build required)
-    check_wiring(&descriptor).context("wiring check failed")?;
-    println!("Input/output wiring OK.");
-
     let strict = strict_types || descriptor.strict_types.unwrap_or(false);
 
     // Load user types if a types/ directory exists
@@ -95,6 +94,18 @@ fn validate_dataflow(dataflow: &Path, strict_types: bool) -> eyre::Result<()> {
         }
     }
 
+    // Resolve hub: references against the (cached) index so their contracts
+    // take part in validation (spec §6.2 ordering note)
+    let hub_resolution =
+        super::build::hub::resolve_hub_nodes(&mut descriptor, &mut registry, offline, None)?;
+    for note in &hub_resolution.notes {
+        println!("  {note}");
+    }
+
+    // Check input/output wiring (no build required)
+    check_wiring(&descriptor).context("wiring check failed")?;
+    println!("Input/output wiring OK.");
+
     // Inject contracts from node manifests adjacent to path: nodes (§6.2)
     let injection = inject_adjacent_manifests(&mut descriptor, working_dir, &mut registry);
     for note in &injection.notes {
@@ -109,11 +120,14 @@ fn validate_dataflow(dataflow: &Path, strict_types: bool) -> eyre::Result<()> {
         println!("  {inf}");
     }
 
-    let count = injection.warnings.len() + result.warnings.len();
+    let count = hub_resolution.warnings.len() + injection.warnings.len() + result.warnings.len();
     if count == 0 {
         println!("All type annotations OK.");
     } else {
         println!("Type warnings:");
+        for w in &hub_resolution.warnings {
+            println!("  - {w}");
+        }
         for w in &injection.warnings {
             println!("  - {w}");
         }

--- a/binaries/cli/src/session.rs
+++ b/binaries/cli/src/session.rs
@@ -44,6 +44,13 @@ pub struct DataflowSession {
     /// resolved form instead. `None` when the dataflow has no hub nodes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolved_dataflow: Option<dora_message::descriptor::Descriptor>,
+    /// FNV-1a digest of the expanded (pre-desugar) descriptor as built. For a
+    /// hub dataflow the on-disk YAML can't be re-fingerprinted directly (its
+    /// `hub:` references are unresolved, so `kind()` rejects them), so
+    /// `dora start` / `dora daemon --run-dataflow` compare this instead to
+    /// detect any on-disk edit since the build. `None` for non-hub dataflows.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_fingerprint: Option<String>,
 }
 
 impl Default for DataflowSession {
@@ -55,6 +62,7 @@ impl Default for DataflowSession {
             local_build: Default::default(),
             build_fingerprint: None,
             resolved_dataflow: None,
+            source_fingerprint: None,
         }
     }
 }
@@ -109,6 +117,15 @@ impl DataflowSession {
 
     fn serialize(&self) -> eyre::Result<String> {
         serde_yaml::to_string(&self).context("failed to serialize dataflow session file")
+    }
+
+    /// Digest of the expanded (pre-desugar) descriptor. Used to detect any
+    /// on-disk edit to a hub dataflow since its build, since the on-disk YAML
+    /// can't be re-fingerprinted via `fingerprint_build_inputs` (its `hub:`
+    /// references are unresolved). Returns `None` if serialization fails.
+    pub fn fingerprint_source(descriptor: &dora_message::descriptor::Descriptor) -> Option<String> {
+        let yaml = serde_yaml::to_string(descriptor).ok()?;
+        Some(format!("src-v1-{}", fnv1a_64_hex(yaml.as_bytes())))
     }
 
     /// Compute the build-inputs fingerprint over the resolved descriptor.
@@ -380,6 +397,25 @@ nodes:
     path: ./a
     build: cargo build
 ";
+
+    #[test]
+    fn source_fingerprint_changes_with_any_edit() {
+        // the hub staleness check relies on this catching ANY descriptor
+        // edit, not just build-inputs (unlike fingerprint_build_inputs)
+        let base: Descriptor =
+            serde_yaml::from_str("nodes:\n  - id: a\n    hub: test/x@^0.1\n").unwrap();
+        let fp = DataflowSession::fingerprint_source(&base);
+        assert!(fp.is_some());
+        let edited: Descriptor = serde_yaml::from_str(
+            "nodes:\n  - id: a\n    hub: test/x@^0.1\n  - id: b\n    path: ./b\n",
+        )
+        .unwrap();
+        assert_ne!(fp, DataflowSession::fingerprint_source(&edited));
+        // identical descriptors hash identically
+        let same: Descriptor =
+            serde_yaml::from_str("nodes:\n  - id: a\n    hub: test/x@^0.1\n").unwrap();
+        assert_eq!(fp, DataflowSession::fingerprint_source(&same));
+    }
 
     #[test]
     fn fingerprint_is_stable_for_same_inputs() {

--- a/binaries/cli/src/session.rs
+++ b/binaries/cli/src/session.rs
@@ -38,6 +38,12 @@ pub struct DataflowSession {
     /// as "unknown" — `invalidate_if_build_inputs_changed` clears and rewrites).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub build_fingerprint: Option<String>,
+    /// The dataflow descriptor with `hub:` references desugared into concrete
+    /// git nodes, as built. `dora start` / `dora run` re-read the YAML from
+    /// disk, which still contains unresolved `hub:` fields — they use this
+    /// resolved form instead. `None` when the dataflow has no hub nodes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_dataflow: Option<dora_message::descriptor::Descriptor>,
 }
 
 impl Default for DataflowSession {
@@ -48,6 +54,7 @@ impl Default for DataflowSession {
             git_sources: Default::default(),
             local_build: Default::default(),
             build_fingerprint: None,
+            resolved_dataflow: None,
         }
     }
 }
@@ -283,6 +290,8 @@ impl DataflowSession {
         self.build_id = None;
         self.local_build = None;
         self.git_sources.clear();
+        // the desugared hub descriptor was produced by the invalidated build
+        self.resolved_dataflow = None;
         self.build_fingerprint = Some(current);
         if had_build_id {
             tracing::info!(
@@ -502,6 +511,8 @@ nodes:
             git_sources: BTreeMap::from([(
                 NodeId::from("a".to_string()),
                 GitSource {
+                    subdir: None,
+                    hub: None,
                     repo: "x".to_string(),
                     commit_hash: "y".to_string(),
                 },

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -748,7 +748,6 @@ impl Daemon {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[allow(clippy::too_many_arguments)]
     pub async fn run_dataflow(
         dataflow_path: &Path,
         build_id: Option<BuildId>,

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -748,6 +748,7 @@ impl Daemon {
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     pub async fn run_dataflow(
         dataflow_path: &Path,
         build_id: Option<BuildId>,
@@ -759,6 +760,7 @@ impl Daemon {
         stop_after: Option<Duration>,
         debug: bool,
         working_dir_override: Option<PathBuf>,
+        descriptor_override: Option<Descriptor>,
     ) -> eyre::Result<DataflowResult> {
         let working_dir = match working_dir_override {
             Some(p) => p
@@ -772,7 +774,13 @@ impl Daemon {
                 .to_owned(),
         };
 
-        let raw_descriptor = read_as_descriptor(dataflow_path).await?;
+        // `hub:` dataflows are desugared in memory by `dora build` — the
+        // on-disk YAML still contains unresolved references, so the caller
+        // passes the resolved descriptor from the dataflow session instead
+        let raw_descriptor = match descriptor_override {
+            Some(descriptor) => descriptor,
+            None => read_as_descriptor(dataflow_path).await?,
+        };
         // Expand module composition (must run before resolution; module
         // nodes cause `resolve_aliases_and_set_defaults` to fail otherwise).
         let mut descriptor = raw_descriptor
@@ -1880,6 +1888,7 @@ impl Daemon {
                             node.clone(),
                             base_working_dir,
                             python_env_dir,
+                            false,
                             node_stderr,
                             None,
                             &mut logger,
@@ -1986,6 +1995,7 @@ impl Daemon {
                             max_rotated_files: None,
                             build: None,
                             git: None,
+                            hub: None,
                             branch: None,
                             tag: None,
                             rev: None,
@@ -2573,7 +2583,11 @@ impl Daemon {
             let git_source = git_sources.get(&node_id).cloned();
             let prev_git_source = prev_git_sources.get(&node_id).cloned();
             let prev_git = prev_git_source.map(|prev_source| PrevGitSource {
-                still_needed_for_this_build: git_sources.values().any(|s| s == &prev_source),
+                // compare clone identity (repo + commit) only: hub provenance
+                // and subdir don't change which directory the clone occupies
+                still_needed_for_this_build: git_sources.values().any(|s| {
+                    s.repo == prev_source.repo && s.commit_hash == prev_source.commit_hash
+                }),
                 git_source: prev_source,
             });
 
@@ -2614,10 +2628,18 @@ impl Daemon {
             }
         }
 
+        // hub-sourced nodes (recognized by the provenance marker on their
+        // git source) are spawned with confined path resolution (spec §11)
+        let confined_nodes: BTreeSet<NodeId> = git_sources
+            .iter()
+            .filter(|(_, source)| source.hub.is_some())
+            .map(|(node_id, _)| node_id.clone())
+            .collect();
         let task = async move {
             let mut info = BuildInfo {
                 node_working_dirs: Default::default(),
                 python_env_dirs: Default::default(),
+                confined_nodes,
             };
             for task in tasks {
                 let NodeBuildTask {
@@ -2694,8 +2716,14 @@ impl Daemon {
         }
         // Reuse build-time metadata so runtime spawn can follow the same
         // working-directory and managed-env decisions.
-        let (node_working_dirs, python_env_dirs) = build_info
-            .map(|info| (info.node_working_dirs.clone(), info.python_env_dirs.clone()))
+        let (node_working_dirs, python_env_dirs, confined_nodes) = build_info
+            .map(|info| {
+                (
+                    info.node_working_dirs.clone(),
+                    info.python_env_dirs.clone(),
+                    info.confined_nodes.clone(),
+                )
+            })
             .unwrap_or_default();
 
         // calculate info about mappings
@@ -2910,6 +2938,7 @@ impl Daemon {
                         node,
                         node_working_dir,
                         configured_python_env_dir,
+                        confined_nodes.contains(&node_id),
                         node_stderr_most_recent,
                         node_write_events_to,
                         &mut logger,

--- a/binaries/daemon/src/spawn/command.rs
+++ b/binaries/daemon/src/spawn/command.rs
@@ -2,7 +2,9 @@ use crate::log::NodeLogger;
 use clonable_command::Command;
 use dora_core::{
     build::managed_python_interpreter,
-    descriptor::{DYNAMIC_SOURCE, SHELL_SOURCE, resolve_path, source_is_url},
+    descriptor::{
+        DYNAMIC_SOURCE, SHELL_SOURCE, resolve_path, resolve_path_confined, source_is_url,
+    },
     get_python_path,
 };
 use dora_download::download_file;
@@ -10,10 +12,12 @@ use dora_message::common::LogLevel;
 use eyre::WrapErr;
 use std::path::Path;
 
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn path_spawn_command(
     working_dir: &Path,
     uv: bool,
     python_env_dir: Option<&Path>,
+    confined: bool,
     logger: &mut NodeLogger<'_>,
     node: &dora_core::descriptor::CustomNode,
     permit_url: bool,
@@ -44,7 +48,17 @@ pub(super) async fn path_spawn_command(
             }
         }
         source => {
-            let resolved_path = if source_is_url(source) {
+            let resolved_path = if confined {
+                // hub-sourced node (spec §11): the entrypoint resolves only
+                // within the node's own working dir or managed env — no env
+                // expansion, no URL download, no ambient-$PATH fallback.
+                // (The *interpreter* for a script-only `.py` entrypoint still
+                // comes from `uv run` like any non-hub script node — hub
+                // Python nodes are expected to ship a `build:` so they get a
+                // managed env, spec §15 Q4.)
+                resolve_path_confined(source, working_dir, python_env_dir)
+                    .wrap_err_with(|| format!("failed to resolve hub entrypoint `{source}`"))?
+            } else if source_is_url(source) {
                 if !permit_url {
                     eyre::bail!("URL paths are not supported in this case");
                 }

--- a/binaries/daemon/src/spawn/spawner.rs
+++ b/binaries/daemon/src/spawn/spawner.rs
@@ -125,11 +125,13 @@ impl Spawner {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn spawn_node(
         self,
         node: ResolvedNode,
         node_working_dir: PathBuf,
         python_env_dir: Option<PathBuf>,
+        confined: bool,
         node_stderr_most_recent: Arc<ArrayQueue<String>>,
         write_events_to: Option<PathBuf>,
         logger: &mut NodeLogger<'_>,
@@ -177,6 +179,7 @@ impl Spawner {
                 node,
                 node_working_dir,
                 python_env_dir,
+                confined,
                 &mut logger,
                 dataflow_id,
                 node_config,
@@ -194,6 +197,7 @@ impl Spawner {
         node: ResolvedNode,
         node_working_dir: PathBuf,
         python_env_dir: Option<PathBuf>,
+        confined: bool,
         logger: &mut NodeLogger<'_>,
         dataflow_id: uuid::Uuid,
         node_config: NodeConfig,
@@ -208,6 +212,7 @@ impl Spawner {
                     &node_working_dir,
                     self.uv,
                     python_env_dir.as_deref(),
+                    confined,
                     logger,
                     n,
                     true,

--- a/libraries/core/dora-node-schema.json
+++ b/libraries/core/dora-node-schema.json
@@ -10,6 +10,13 @@
       "format": "uint64",
       "minimum": 0
     },
+    "build": {
+      "description": "Build command run in the node's working dir when the package is\ninstalled (e.g. `pip install .`, `cargo build --release`). Arbitrary\ncode by design, like any `build:` — `--locked` binds it to the\nreviewed, commit-pinned source (spec §11).",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "categories": {
       "description": "Categories from the fixed list (spec §7.6); drive search facets.",
       "type": "array",

--- a/libraries/core/dora-schema.json
+++ b/libraries/core/dora-schema.json
@@ -507,6 +507,13 @@
           ],
           "format": "double"
         },
+        "hub": {
+          "description": "Hub package reference (unstable).\n\nReferences a node published in the Dora Hub index:\n`[<namespace>/]<name>@<semver-requirement>`. A bare name is shorthand\nfor the official `dora-rs/` namespace.\n\n`dora build` resolves the reference against the index to a pinned\ncommit and the node is fetched/built through the same machinery as a\n[`git`](Self::git) node; the package manifest supplies the\nentrypoint, build command, and typed contracts. Mutually exclusive\nwith `path`, `git`, and `build`.\n\n## Example\n\n```yaml\nnodes:\n  - id: detector\n    hub: dora-yolo@^0.5\n    inputs:\n      image: camera/image\n    outputs:\n      - bbox\n```",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "id": {
           "description": "Unique node identifier. Must not contain `/` characters.\n\nNode IDs can be arbitrary strings with the following limitations:\n\n- They must not contain any `/` characters (slashes).\n- We do not recommend using whitespace characters (e.g. spaces) in IDs\n\nEach node must have an ID field.\n\n## Example\n\n```yaml\nnodes:\n  - id: camera_node\n  - id: some_other_node\n```",
           "$ref": "#/$defs/NodeId"

--- a/libraries/core/src/build/git.rs
+++ b/libraries/core/src/build/git.rs
@@ -132,7 +132,10 @@ impl GitManager {
         repo_url: &Url,
         commit_hash: &String,
     ) -> eyre::Result<PathBuf> {
-        let mut path = base_dir.join(repo_url.host_str().context("git URL has no hostname")?);
+        // file:// URLs (local mirrors, air-gapped setups, tests) have no
+        // hostname — group their clones under a "localhost" directory
+        let host = repo_url.host_str().unwrap_or("localhost");
+        let mut path = base_dir.join(host);
         path.extend(repo_url.path_segments().context("no path in git URL")?);
         let path = path.join(commit_hash);
         Ok(dunce::simplified(&path).to_owned())

--- a/libraries/core/src/build/mod.rs
+++ b/libraries/core/src/build/mod.rs
@@ -89,16 +89,7 @@ impl Builder {
                         match subdir {
                             // monorepo node: build, env prep, and spawn root
                             // at `<clone>/<subdir>` (validated above)
-                            Some(subdir) => {
-                                let dir = clone_dir.join(&subdir);
-                                if !dir.is_dir() {
-                                    eyre::bail!(
-                                        "git source has no `{subdir}` directory in `{}`",
-                                        clone_dir.display()
-                                    );
-                                }
-                                dir
-                            }
+                            Some(subdir) => confine_subdir(&clone_dir, &subdir)?,
                             None => clone_dir,
                         }
                     }
@@ -292,6 +283,33 @@ pub fn validate_subdir(subdir: &str) -> eyre::Result<()> {
                 .collect::<String>()
         )
     }
+}
+
+/// Resolve `<clone_dir>/<subdir>` and confine it to the clone, returning the
+/// real (canonical) directory.
+///
+/// [`validate_subdir`] is lexical only; `is_dir()` follows in-repo symlinks, so
+/// a package shipping `node-hub/x -> /etc` could otherwise root the build (and
+/// the entrypoint `confine` check) outside the clone. Requiring the canonical
+/// path to stay under the canonical clone closes that escape.
+fn confine_subdir(clone_dir: &Path, subdir: &str) -> eyre::Result<PathBuf> {
+    let dir = clone_dir.join(subdir);
+    if !dir.is_dir() {
+        eyre::bail!(
+            "git source has no `{subdir}` directory in `{}`",
+            clone_dir.display()
+        );
+    }
+    let real = dir
+        .canonicalize()
+        .with_context(|| format!("failed to resolve git source subdir `{subdir}`"))?;
+    let real_clone = clone_dir
+        .canonicalize()
+        .context("failed to resolve git clone directory")?;
+    if !real.starts_with(&real_clone) {
+        eyre::bail!("git source subdir `{subdir}` escapes the repository (symlink?)");
+    }
+    Ok(real)
 }
 
 /// Computes the managed Python env directory for `node`, if it needs one.
@@ -539,5 +557,22 @@ mod tests {
         ] {
             assert!(validate_subdir(bad).is_err(), "{bad:?} should be invalid");
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn confine_subdir_rejects_symlink_escape() {
+        let clone = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        // a real in-repo subdir resolves to itself
+        std::fs::create_dir(clone.path().join("src")).unwrap();
+        assert!(super::confine_subdir(clone.path(), "src").is_ok());
+        // an in-repo symlink pointing outside the clone (`escape -> <outside>`)
+        // passes `validate_subdir` (no `..`/absolute) and `is_dir()`, but must
+        // be rejected by the canonical-containment check
+        std::os::unix::fs::symlink(outside.path(), clone.path().join("escape")).unwrap();
+        assert!(validate_subdir("escape").is_ok());
+        let err = super::confine_subdir(clone.path(), "escape").unwrap_err();
+        assert!(err.to_string().contains("escapes the repository"), "{err}");
     }
 }

--- a/libraries/core/src/build/mod.rs
+++ b/libraries/core/src/build/mod.rs
@@ -42,7 +42,16 @@ impl Builder {
     where
         L: BuildLogger,
     {
-        let prepared_git = if let Some(GitSource { repo, commit_hash }) = git {
+        let prepared_git = if let Some(GitSource {
+            repo,
+            commit_hash,
+            subdir,
+            hub: _,
+        }) = git
+        {
+            if let Some(subdir) = &subdir {
+                validate_subdir(subdir)?;
+            }
             let target_dir = self.base_working_dir.join("git");
             let git_folder = git_manager.choose_clone_dir(
                 self.session_id,
@@ -51,7 +60,7 @@ impl Builder {
                 prev_git,
                 &target_dir,
             )?;
-            Some(git_folder)
+            Some((git_folder, subdir))
         } else {
             None
         };
@@ -64,20 +73,34 @@ impl Builder {
         self,
         node: ResolvedNode,
         logger: &mut impl BuildLogger,
-        git_folder: Option<GitFolder>,
+        git_folder: Option<(GitFolder, Option<String>)>,
     ) -> eyre::Result<BuiltNode> {
         logger.log_message(LogLevel::Debug, "building node").await;
         let python_env_dir;
         let node_working_dir = match &node.kind {
             CoreNodeKind::Custom(n) => {
                 let node_working_dir = match git_folder {
-                    Some(git_folder) => {
+                    Some((git_folder, subdir)) => {
                         let clone_dir = git_folder.prepare(logger).await?;
                         tracing::warn!(
                             "using git clone directory as working dir: \
                             this behavior is unstable and might change"
                         );
-                        clone_dir
+                        match subdir {
+                            // monorepo node: build, env prep, and spawn root
+                            // at `<clone>/<subdir>` (validated above)
+                            Some(subdir) => {
+                                let dir = clone_dir.join(&subdir);
+                                if !dir.is_dir() {
+                                    eyre::bail!(
+                                        "git source has no `{subdir}` directory in `{}`",
+                                        clone_dir.display()
+                                    );
+                                }
+                                dir
+                            }
+                            None => clone_dir,
+                        }
                     }
                     None => self.base_working_dir,
                 };
@@ -242,6 +265,33 @@ pub struct BuildInfo {
     pub node_working_dirs: BTreeMap<NodeId, PathBuf>,
     #[serde(default)]
     pub python_env_dirs: BTreeMap<NodeId, PathBuf>,
+    /// Nodes that must be spawned with confined path resolution (no ambient
+    /// `$PATH` fallback) — set for hub-sourced nodes (spec §11).
+    #[serde(default)]
+    pub confined_nodes: std::collections::BTreeSet<NodeId>,
+}
+
+/// Validate a git source `subdir`: a relative path confined to the clone
+/// (no absolute, no `..`, no leading `-`, printable characters only). The
+/// value can come from an untrusted hub index entry.
+pub fn validate_subdir(subdir: &str) -> eyre::Result<()> {
+    let confined = !subdir.is_empty()
+        && !subdir.starts_with(['/', '\\', '-', '~'])
+        && !subdir.split(['/', '\\']).any(|c| c == "..")
+        && !subdir.contains(|c: char| c.is_control())
+        && (subdir.len() < 2 || subdir.as_bytes()[1] != b':');
+    if confined {
+        Ok(())
+    } else {
+        eyre::bail!(
+            "invalid git source subdir `{}`: must be a relative path inside \
+             the repository",
+            subdir
+                .chars()
+                .filter(|c| !c.is_control())
+                .collect::<String>()
+        )
+    }
 }
 
 /// Computes the managed Python env directory for `node`, if it needs one.
@@ -331,7 +381,9 @@ pub struct PrevGitSource {
 
 #[cfg(test)]
 mod tests {
-    use super::{managed_python_bin_dir, managed_python_env_dir, managed_python_interpreter};
+    use super::{
+        managed_python_bin_dir, managed_python_env_dir, managed_python_interpreter, validate_subdir,
+    };
     use crate::descriptor::ResolvedNode;
     use std::path::PathBuf;
 
@@ -466,5 +518,26 @@ mod tests {
 
         assert_eq!(managed_python_bin_dir(&env_dir), expected_bin_dir);
         assert_eq!(managed_python_interpreter(&env_dir), expected_interpreter);
+    }
+
+    #[test]
+    fn subdir_validation_confines_to_the_clone() {
+        for good in ["node-hub/dora-yolo", "src", "a/b/c", "a.b"] {
+            assert!(validate_subdir(good).is_ok(), "{good} should be valid");
+        }
+        for bad in [
+            "",
+            "/abs",
+            "\\abs",
+            "../outside",
+            "a/../../b",
+            "a\\..\\b",
+            "-flag",
+            "~home",
+            "C:\\windows",
+            "a\x07b",
+        ] {
+            assert!(validate_subdir(bad).is_err(), "{bad:?} should be invalid");
+        }
     }
 }

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -366,6 +366,70 @@ pub fn resolve_path(source: &str, working_dir: &Path) -> Result<PathBuf> {
     }
 }
 
+/// Resolve a hub node's entrypoint under **confined** rules (spec §11): the
+/// executable may only come from the node's own working directory
+/// (`<clone>/<subdir>`) or its managed Python environment. There is no
+/// ambient-`$PATH` fallback — a typo or missing console script fails loudly
+/// instead of silently running a host binary — and the resolved path is
+/// canonicalized and checked to stay inside those roots, so a symlink
+/// escaping the working dir is rejected rather than followed.
+pub fn resolve_path_confined(
+    source: &str,
+    working_dir: &Path,
+    python_env_dir: Option<&Path>,
+) -> Result<PathBuf> {
+    let path = Path::new(&source);
+    let path = if path.extension().is_none() {
+        path.with_extension(EXE_EXTENSION)
+    } else {
+        path.to_owned()
+    };
+
+    // a console script installed into the node's managed env
+    if let Some(env_dir) = python_env_dir {
+        let bin_dir = env_dir.join(if cfg!(windows) { "Scripts" } else { "bin" });
+        let candidate = bin_dir.join(&path);
+        if candidate.is_file() {
+            return confine(&candidate, &bin_dir);
+        }
+    }
+
+    // a file within the node's working dir (e.g. target/release/<bin>)
+    let candidate = working_dir.join(&path);
+    if candidate.exists() {
+        return confine(&candidate, working_dir);
+    }
+
+    bail!(
+        "could not find `{}` in the node's working directory `{}`{} — \
+         hub nodes resolve only within their own package (no $PATH fallback)",
+        path.display(),
+        working_dir.display(),
+        python_env_dir
+            .map(|env| format!(" or its managed environment `{}`", env.display()))
+            .unwrap_or_default(),
+    )
+}
+
+/// Canonicalize `candidate` and require it to stay under `root`.
+fn confine(candidate: &Path, root: &Path) -> Result<PathBuf> {
+    let resolved = candidate
+        .canonicalize()
+        .with_context(|| format!("failed to canonicalize `{}`", candidate.display()))?;
+    let root = root
+        .canonicalize()
+        .with_context(|| format!("failed to canonicalize `{}`", root.display()))?;
+    if !resolved.starts_with(&root) {
+        bail!(
+            "entrypoint `{}` resolves outside the node's directory `{}` \
+             (symlink escape?) — refusing to run it",
+            resolved.display(),
+            root.display()
+        );
+    }
+    Ok(resolved)
+}
+
 /// Resolve `path` against the `uv`-managed environment by running
 /// `uv run which <path>`, returning an absolute path.
 ///
@@ -403,6 +467,17 @@ pub trait NodeExt {
 
 impl NodeExt for Node {
     fn kind(&self) -> eyre::Result<NodeKind<'_>> {
+        if self.hub.is_some() && self.path.is_none() {
+            // `hub:` is desugared into a concrete git node by `dora build` /
+            // `dora run` / `dora validate` before any kind dispatch — an
+            // unresolved reference reaching this point means a flow that
+            // skipped resolution
+            eyre::bail!(
+                "node `{}` uses an unresolved `hub:` reference — run `dora build` \
+                 first (`dora start` requires a prior build for hub nodes)",
+                self.id
+            );
+        }
         match (
             &self.path,
             &self.operators,
@@ -558,6 +633,60 @@ nodes:
             result.is_err(),
             "expected Err for a binary that exists nowhere, got {result:?}"
         );
+    }
+
+    #[test]
+    fn resolve_path_confined_has_no_path_fallback() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // `sh` exists on $PATH everywhere on unix — confined resolution must
+        // NOT find it (spec §11: a typo or missing console script fails, it
+        // never silently runs a host binary)
+        let result = resolve_path_confined("sh", tmp.path(), None);
+        assert!(result.is_err(), "expected Err, got {result:?}");
+
+        // a real file in the working dir resolves
+        let exe = if cfg!(windows) {
+            "node.exe"
+        } else {
+            "node.bin"
+        };
+        std::fs::write(tmp.path().join(exe), b"x").unwrap();
+        let resolved = resolve_path_confined(exe, tmp.path(), None).unwrap();
+        assert!(resolved.is_absolute());
+
+        // a managed-env console script resolves through the env's bin dir
+        let env_dir = tmp.path().join("env");
+        let bin_dir = env_dir.join(if cfg!(windows) { "Scripts" } else { "bin" });
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        std::fs::write(bin_dir.join(exe), b"x").unwrap();
+        let resolved =
+            resolve_path_confined(exe, tmp.path().join("empty").as_path(), Some(&env_dir));
+        assert!(resolved.is_ok(), "{resolved:?}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_path_confined_rejects_symlink_escape() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let working_dir = tmp.path().join("work");
+        std::fs::create_dir_all(&working_dir).unwrap();
+        let outside = tmp.path().join("outside.bin");
+        std::fs::write(&outside, b"x").unwrap();
+        std::os::unix::fs::symlink(&outside, working_dir.join("escape.bin")).unwrap();
+        let result = resolve_path_confined("escape.bin", &working_dir, None);
+        assert!(
+            result.is_err(),
+            "a symlink pointing outside the working dir must be rejected, got {result:?}"
+        );
+        let msg = format!("{:#}", result.unwrap_err());
+        assert!(msg.contains("outside"), "{msg}");
+    }
+
+    #[test]
+    fn unresolved_hub_node_has_clear_kind_error() {
+        let node: Node = serde_yaml::from_str("id: x\nhub: dora-yolo@^0.5\n").unwrap();
+        let err = node.kind().unwrap_err();
+        assert!(format!("{err}").contains("dora build"), "{err}");
     }
 
     #[test]

--- a/libraries/core/src/manifest/inject.rs
+++ b/libraries/core/src/manifest/inject.rs
@@ -129,10 +129,10 @@ pub fn inject_adjacent_manifests(
 
     // Pass 2: validate each manifest against the full registry and inject.
     for (idx, (manifest_path, manifest)) in matched {
-        apply_manifest(
+        apply_manifest_contracts(
             &mut dataflow.nodes[idx],
             &manifest,
-            &manifest_path,
+            &manifest_path.display().to_string(),
             registry,
             &mut result,
         );
@@ -242,10 +242,15 @@ fn normalize(path: &Path) -> PathBuf {
     out
 }
 
-fn apply_manifest(
+/// Apply a manifest's contracts to a descriptor node: validate the
+/// manifest, check the dataflow's wiring against the declared ports, and
+/// inject port types (the dataflow author's own annotations win).
+/// `source_label` names where the manifest came from in messages (a file
+/// path for adjacent manifests, a `namespace/name@version` for hub packages).
+pub fn apply_manifest_contracts(
     node: &mut dora_message::descriptor::Node,
     manifest: &NodeManifest,
-    manifest_path: &Path,
+    source_label: &str,
     registry: &TypeRegistry,
     result: &mut InjectionResult,
 ) {
@@ -254,7 +259,7 @@ fn apply_manifest(
         result.warnings.push(sanitize(&format!(
             "node \"{}\": {} has {} problem(s) — contracts not injected (first: {})",
             node.id,
-            manifest_path.display(),
+            source_label,
             issues.len(),
             issues[0]
         )));
@@ -266,8 +271,7 @@ fn apply_manifest(
         if !manifest.inputs.contains_key(input.as_str()) {
             result.warnings.push(sanitize(&format!(
                 "node \"{}\": input `{input}` is not declared in {}",
-                node.id,
-                manifest_path.display()
+                node.id, source_label
             )));
         }
     }
@@ -275,8 +279,7 @@ fn apply_manifest(
         if !manifest.outputs.contains_key(output.as_str()) {
             result.warnings.push(sanitize(&format!(
                 "node \"{}\": output `{output}` is not declared in {}",
-                node.id,
-                manifest_path.display()
+                node.id, source_label
             )));
         }
     }
@@ -313,8 +316,7 @@ fn apply_manifest(
     if injected > 0 {
         result.notes.push(sanitize(&format!(
             "node \"{}\": injected {injected} contract type(s) from {}",
-            node.id,
-            manifest_path.display()
+            node.id, source_label
         )));
     }
 }

--- a/libraries/core/src/manifest/mod.rs
+++ b/libraries/core/src/manifest/mod.rs
@@ -65,6 +65,13 @@ pub struct NodeManifest {
     /// Must be a relative path without `..` components.
     pub entrypoint: String,
 
+    /// Build command run in the node's working dir when the package is
+    /// installed (e.g. `pip install .`, `cargo build --release`). Arbitrary
+    /// code by design, like any `build:` — `--locked` binds it to the
+    /// reviewed, commit-pinned source (spec §11).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build: Option<String>,
+
     /// Optional platform allowlist, e.g. `[linux-x86_64, macos-aarch64]`.
     /// Empty means all platforms.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/libraries/core/src/manifest/validate.rs
+++ b/libraries/core/src/manifest/validate.rs
@@ -288,6 +288,11 @@ fn check_entrypoint(entrypoint: &str) -> Option<String> {
     if entrypoint.is_empty() {
         return Some("must not be empty".into());
     }
+    // these resolve to the dynamic-node and shell-node sentinels at spawn,
+    // which bypass confined resolution — a hub package must not become one
+    if entrypoint == "dynamic" || entrypoint == "shell" {
+        return Some(format!("`{entrypoint}` is a reserved node source name"));
+    }
     let valid_char =
         |c: char| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-' | '/' | '\\');
     if !entrypoint.chars().all(valid_char) {
@@ -520,6 +525,10 @@ outputs:
         // shell metacharacters, whitespace, control chars are out of charset
         for bad in ["foo; rm -rf x", "foo bar", "a|b", "a$(b)", "a\x1b[2Jb"] {
             assert!(check_entrypoint(bad).is_some(), "{bad:?} should be invalid");
+        }
+        // the dynamic/shell spawn sentinels would bypass confined resolution
+        for bad in ["dynamic", "shell"] {
+            assert!(check_entrypoint(bad).is_some(), "{bad} should be reserved");
         }
     }
 

--- a/libraries/hub-client/src/config.rs
+++ b/libraries/hub-client/src/config.rs
@@ -145,8 +145,13 @@ impl ResolvedConfig {
     }
 
     /// Load from the conventional location (`<config_dir>/dora/hub.toml`),
-    /// falling back to official-only when the file does not exist.
+    /// falling back to official-only when the file does not exist. The
+    /// `DORA_HUB_CONFIG` environment variable overrides the location
+    /// (integration tests, hermetic CI).
     pub fn load_default() -> eyre::Result<Self> {
+        if let Ok(path) = std::env::var("DORA_HUB_CONFIG") {
+            return Self::load_from(Path::new(&path));
+        }
         let Some(config_dir) = dirs::config_dir() else {
             return Self::new(Vec::new(), PathBuf::from("."));
         };

--- a/libraries/hub-client/src/lib.rs
+++ b/libraries/hub-client/src/lib.rs
@@ -16,6 +16,9 @@ pub mod index;
 pub mod reference;
 pub mod transport;
 
+// re-exported so consumers can name version types without a separate dep
+pub use semver;
+
 /// The namespace bare package names resolve to (spec §7.2).
 pub const OFFICIAL_NAMESPACE: &str = "dora-rs";
 

--- a/libraries/message/src/common.rs
+++ b/libraries/message/src/common.rs
@@ -373,6 +373,16 @@ pub struct HubProvenance {
     pub name: String,
     /// Resolved version.
     pub version: String,
+    /// The pinned entrypoint at lock time. The commit hash pins the *source
+    /// tree*, but the entrypoint + build command live in the (mutable) index
+    /// entry, so they are recorded here too — `--locked` hard-errors if the
+    /// index entry no longer matches. `Option` for back-compat with lockfiles
+    /// written before this field existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entrypoint: Option<String>,
+    /// The pinned build command at lock time (see `entrypoint`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build: Option<String>,
 }
 
 // Test roundtrip serialization of LogMessage

--- a/libraries/message/src/common.rs
+++ b/libraries/message/src/common.rs
@@ -354,6 +354,25 @@ impl std::fmt::Display for DaemonId {
 pub struct GitSource {
     pub repo: String,
     pub commit_hash: String,
+    /// Subdirectory of the repository the node lives in (monorepo support).
+    /// Build, env preparation, and spawn are rooted at `<clone>/<subdir>`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subdir: Option<String>,
+    /// Hub provenance marker. Set when this git source was desugared from a
+    /// `hub:` reference — it tells the daemon to use confined path
+    /// resolution (no ambient `$PATH` fallback) for the node, and feeds the
+    /// lockfile and `dora hub` commands.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hub: Option<HubProvenance>,
+}
+
+/// Identity of the hub package a git source was resolved from.
+#[derive(Debug, serde::Deserialize, serde::Serialize, Clone, PartialEq, Eq)]
+pub struct HubProvenance {
+    /// Index key (`namespace/name`).
+    pub name: String,
+    /// Resolved version.
+    pub version: String,
 }
 
 // Test roundtrip serialization of LogMessage

--- a/libraries/message/src/common.rs
+++ b/libraries/message/src/common.rs
@@ -373,16 +373,14 @@ pub struct HubProvenance {
     pub name: String,
     /// Resolved version.
     pub version: String,
-    /// The pinned entrypoint at lock time. The commit hash pins the *source
-    /// tree*, but the entrypoint + build command live in the (mutable) index
-    /// entry, so they are recorded here too — `--locked` hard-errors if the
-    /// index entry no longer matches. `Option` for back-compat with lockfiles
-    /// written before this field existed.
+    /// Digest of the index entry's manifest at lock time. The commit hash pins
+    /// the *source tree*, but the entrypoint, build command, and typed contract
+    /// (inputs/outputs/types) all live in the (mutable) index entry — so a
+    /// rewritten entry could change any of them for an already-pinned version.
+    /// `--locked` hard-errors if this digest no longer matches. `Option` for
+    /// back-compat with lockfiles written before this field existed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub entrypoint: Option<String>,
-    /// The pinned build command at lock time (see `entrypoint`).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub build: Option<String>,
+    pub manifest_digest: Option<String>,
 }
 
 // Test roundtrip serialization of LogMessage

--- a/libraries/message/src/descriptor.rs
+++ b/libraries/message/src/descriptor.rs
@@ -648,6 +648,32 @@ pub struct Node {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub git: Option<String>,
 
+    /// Hub package reference (unstable).
+    ///
+    /// References a node published in the Dora Hub index:
+    /// `[<namespace>/]<name>@<semver-requirement>`. A bare name is shorthand
+    /// for the official `dora-rs/` namespace.
+    ///
+    /// `dora build` resolves the reference against the index to a pinned
+    /// commit and the node is fetched/built through the same machinery as a
+    /// [`git`](Self::git) node; the package manifest supplies the
+    /// entrypoint, build command, and typed contracts. Mutually exclusive
+    /// with `path`, `git`, and `build`.
+    ///
+    /// ## Example
+    ///
+    /// ```yaml
+    /// nodes:
+    ///   - id: detector
+    ///     hub: dora-yolo@^0.5
+    ///     inputs:
+    ///       image: camera/image
+    ///     outputs:
+    ///       - bbox
+    /// ```
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hub: Option<String>,
+
     /// Git branch to checkout after cloning.
     ///
     /// The `branch` field is only allowed in combination with the [`git`](#git) field.

--- a/tests/fault-tolerance-e2e.rs
+++ b/tests/fault-tolerance-e2e.rs
@@ -65,6 +65,7 @@ async fn restart_recovers_from_failure() {
         Some(Duration::from_secs(30)),
         false,
         None,
+        None,
     )
     .await;
 
@@ -115,6 +116,7 @@ async fn max_restarts_limit_reached() {
         None,
         Some(Duration::from_secs(30)),
         false,
+        None,
         None,
     )
     .await;
@@ -183,6 +185,7 @@ async fn max_restarts_exhaustion_marks_node_failed() {
         None,
         Some(Duration::from_secs(10)),
         false,
+        None,
         None,
     )
     .await;
@@ -254,6 +257,7 @@ async fn restart_policy_always_restarts_on_clean_exit() {
         None,
         Some(Duration::from_secs(10)),
         false,
+        None,
         None,
     )
     .await;
@@ -336,6 +340,7 @@ async fn restart_window_resets_restart_counter() {
         None,
         Some(Duration::from_secs(10)),
         false,
+        None,
         None,
     )
     .await;
@@ -422,6 +427,7 @@ async fn input_timeout_delivers_input_closed_to_downstream() {
         // InputClosed at ~550 ms (input_timeout = 0.5 s), then exit.
         Some(Duration::from_secs(5)),
         false,
+        None,
         None,
     )
     .await;
@@ -511,6 +517,7 @@ async fn health_check_timeout_sigkills_unresponsive_node() {
         // the marker write races the kill).
         Some(Duration::from_secs(10)),
         false,
+        None,
         None,
     )
     .await;
@@ -608,6 +615,7 @@ async fn node_restarted_is_delivered_to_downstream() {
         Some(Duration::from_secs(5)),
         false,
         None,
+        None,
     )
     .await;
 
@@ -685,6 +693,7 @@ async fn input_recovered_is_delivered_after_broken_input_receives_data() {
         None,
         Some(Duration::from_secs(5)),
         false,
+        None,
         None,
     )
     .await;
@@ -780,6 +789,7 @@ async fn health_check_timeout_exhausts_restart_budget() {
         Some(Duration::from_secs(10)),
         false,
         None,
+        None,
     )
     .await;
 
@@ -851,6 +861,7 @@ async fn planned_stop_sigterm_reports_clean() {
         // fire, short enough that the test stays fast.
         Some(Duration::from_secs(3)),
         false,
+        None,
         None,
     )
     .await;


### PR DESCRIPTION
Implements **P2.5 + P2.6 + P2.7** of the Dora Hub spec ([docs/plan-node-hub.md](https://github.com/dora-rs/dora/blob/main/docs/plan-node-hub.md) §10/§11, umbrella #2097): the `hub:` field works end-to-end — `dora build`, `dora run`, `dora validate`, `--locked`, `--offline`.

**Stacked on #2178** — will retarget as the stack merges.

## The mechanism (spec §10.1)

The CLI desugars `hub:` into a concrete git node **before dispatch**: the index entry supplies the pinned commit + `subdir`, the manifest supplies the entrypoint, `build:` command, and typed contracts (injected through the shared `apply_manifest_contracts`; contract violations are hard errors for hub nodes — the manifest is the contract). Downstream, coordinator/daemons/lockfile see an ordinary git node whose `GitSource` carries two new optional wire bits: `subdir` and the `hub` provenance marker.

- **`subdir` (P2.7a)**: build, env prep, and spawn root at `<clone>/<subdir>` — independently useful for plain `git:` monorepo nodes. Validated (relative, no `..`, charset) at desugar *and* at build consumption.
- **Confined resolution (P2.7b)**: daemons recognize hub nodes by the provenance marker (recorded as `BuildInfo.confined_nodes`) and spawn through `resolve_path_confined`: working dir or managed env only, **no ambient-`$PATH` fallback**, and the resolved path is canonicalized + prefix-checked, so a package shipping `bin/run -> /bin/sh` fails loudly instead of escaping (closes the symlink-escape residual flagged in the P1 reviews).
- **Lockfile (P2.6)**: hub provenance rides the existing `git_sources` map (the pinned commit *is* the lock). Files carrying hub entries are written as **v3** so older dora fails loudly instead of silently ignoring `subdir` and mis-rooting builds; plain-git lockfiles stay byte-compatible v2, and the fingerprint schema tag is deliberately decoupled so existing lockfiles aren't invalidated. `--locked` uses pins verbatim (no resolution), verifies name/range still match, and warns on yanked pins (UC10).
- **`dora start`/`dora run`**: both re-read YAML from disk, which still contains unresolved `hub:` — the desugared descriptor is stored in the dataflow session at build time; `start` verifies the on-disk references still match the built provenance before substituting, `run` passes it to the daemon as a descriptor override. An unresolved `hub:` reaching `kind()` errors with "run `dora build` first".
- Plus: manifest `build:` field (spec §10.1 requires it; §5 omitted it), `--offline` on build/validate, `DORA_HUB_CONFIG` env override for hermetic tests, and `file://` git URLs in GitManager (local mirrors/air-gapped, host falls back to `localhost`).

## Live-tested end-to-end

Hermetic fixture (local catalog + `file://` monorepo source repo, `namespaces = ["test"]` binding):
- `dora build --write-lockfile` → resolution note, clone at the pinned commit, `cargo build` running **in `<clone>/node-hub/hello`**, v3 lockfile with `subdir` + `hub: {name, version}`.
- `dora run` → `hello from the hub node` through confined spawn.
- `dora build --locked` → pin used verbatim, no resolution.
- `dora validate` → resolution + contracts + wiring, all OK.
- Negative: a version whose entrypoint is `sh` **fails** with "hub nodes resolve only within their own package (no $PATH fallback)" instead of running the host shell.

## Self-review round (pre-open)

Fixed from review: session invalidation now clears `resolved_dataflow` (stale-error trap after non-hub edits); clone-reuse compares repo+commit identity only (provenance fields would have broken `still_needed_for_this_build` and forced re-clones); lockfile version assertions; script-only Python interpreter caveat documented (hub Python nodes are expected to ship `build:` for a managed env, spec §15 Q4).

## Verification

- New unit tests: subdir confinement, confined resolution (no-PATH + symlink-escape rejection), unresolved-hub kind() error, lockfile v2/v3 selection + hub roundtrip, `--offline` parse tests.
- fmt + clippy `-D warnings` (workspace) + full test suite + `cargo check --examples` + qa-fast.

Part of #2097. Next: P2.4/P2.11 (`dora hub search/info/fetch`, `--hub-override`, fixture-index smoke tests, `examples/hub-dataflow`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
