### PR TITLE
fix(python): install the logging `basicConfig` wrapper only once per process

### DIFF
--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -83,6 +83,15 @@ fn host_log<'py>(record: Bound<'py, PyAny>) -> PyResult<()> {
 /// delivered to `crate::host_log`, which will send them to `tracing::event!`.
 pub fn setup_logging(py: Python) -> PyResult<()> {
     let logging = py.import("logging")?;
+    // `setup_logging` runs on every `Node` construction. Installing the
+    // `basicConfig` wrapper a second time would wrap the wrapper (the new
+    // `oldBasicConfig` would be the first wrapper), so every `basicConfig`
+    // call would attach one `HostHandler` per `Node` ever created in this
+    // process and emit duplicate log records. `oldBasicConfig` only exists
+    // once the wrapper is installed, so use it as the install marker.
+    if logging.hasattr("oldBasicConfig")? {
+        return Ok(());
+    }
     logging.setattr("host_log", wrap_pyfunction!(host_log, &logging)?)?;
     py.run(
         cr#"


### PR DESCRIPTION
> 🤖 This PR is machine-generated by Claude (automated repository review run). Please review before merging.

## Issue

`setup_logging` (`apis/python/node/src/lib.rs`) runs on **every** `dora.Node` construction. The wrapper it installs resolves `oldBasicConfig` from the logging module dict *at call time*, so a second `Node()` in the same interpreter — notebooks, pytest suites, sequential dynamic-node sessions — rebinds `oldBasicConfig` to wrapper #1. Wrapper #1 then calls itself through that same lookup:

- every subsequent `logging.basicConfig()` — **including the implicit one inside `logging.info(...)`** — dies with `RecursionError`;
- `logging.__all__` accumulates duplicate `"HostHandler"` entries.

## Fix

Guard the install with the `oldBasicConfig` attribute, which exists exactly when the wrapper has already been installed (no new sentinel needed — the marker *is* the invariant being protected).

## Validation

Validated against a locally built debug wheel (`maturin develop`) using the daemon-free `DORA_TEST_WITH_INPUTS` integration-test mode, constructing two `Node`s in one interpreter and then calling `logging.basicConfig(level=INFO)`:

- **before** this change: `RecursionError` (reproduced);
- **after**: succeeds, with exactly one `HostHandler` attached.

Also: `cargo check -p dora-node-api-python`, `cargo fmt --check`, typos, and the full workspace fmt + clippy + test gates on the combined review diff. (The crate is a cdylib excluded from workspace tests, hence the wheel-based runtime validation.)

https://claude.ai/code/session_01SNdKeGorC4iubLKedo2CSw

---
_Generated by [Claude Code](https://claude.ai/code/session_01SNdKeGorC4iubLKedo2CSw)_