### PR TITLE
docs: fix all broken intra-doc links in published crate docs

### DIFF
--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -47,7 +47,7 @@ mod thread;
 /// Asynchronous iterator over the incoming [`Event`]s destined for this node.
 ///
 /// This struct [implements](#impl-Stream-for-EventStream) the [`Stream`] trait,
-/// so you can use methods of the [`StreamExt`] trait
+/// so you can use methods of the [`StreamExt`](futures::StreamExt) trait
 /// on this struct. A common pattern is `while let Some(event) = event_stream.next().await`.
 ///
 /// Nodes should iterate over this event stream and react to events that they are interested in.
@@ -448,7 +448,7 @@ impl EventStream {
     /// documentation of the [`EventScheduler`] struct.
     ///
     /// If you want to receive the events in their original chronological order, use the
-    /// asynchronous [`StreamExt::next`] method instead ([`EventStream`] implements the
+    /// asynchronous [`StreamExt::next`](futures::StreamExt::next) method instead ([`EventStream`] implements the
     /// [`Stream`] trait).
     pub fn recv(&mut self) -> Option<Event> {
         futures::executor::block_on(self.recv_async())
@@ -470,7 +470,7 @@ impl EventStream {
     /// documentation of the [`EventScheduler`] struct.
     ///
     /// If you want to receive the events in their original chronological order, use the
-    /// asynchronous [`StreamExt::next`] method instead ([`EventStream`] implements the
+    /// asynchronous [`StreamExt::next`](futures::StreamExt::next) method instead ([`EventStream`] implements the
     /// [`Stream`] trait).
     pub fn recv_timeout(&mut self, dur: Duration) -> Option<Event> {
         futures::executor::block_on(self.recv_async_timeout(dur))
@@ -487,7 +487,7 @@ impl EventStream {
     /// documentation of the [`EventScheduler`] struct.
     ///
     /// If you want to receive the events in their original chronological order, use the
-    /// [`StreamExt::next`] method with a custom timeout future instead
+    /// [`StreamExt::next`](futures::StreamExt::next) method with a custom timeout future instead
     /// ([`EventStream`] implements the [`Stream`] trait).
     pub async fn recv_async(&mut self) -> Option<Event> {
         // Drain any events that were stashed by pattern-aware helpers
@@ -737,7 +737,7 @@ impl EventStream {
     /// documentation of the [`EventScheduler`] struct.
     ///
     /// If you want to receive the events in their original chronological order, use the
-    /// [`StreamExt::next`] method with a custom timeout future instead
+    /// [`StreamExt::next`](futures::StreamExt::next) method with a custom timeout future instead
     /// ([`EventStream`] implements the [`Stream`] trait).
     pub fn try_recv(&mut self) -> Result<Event, TryRecvError> {
         match self.recv_async().now_or_never() {
@@ -787,7 +787,7 @@ impl EventStream {
     /// documentation of the [`EventScheduler`] struct.
     ///
     /// If you want to receive the events in their original chronological order, use the
-    /// [`StreamExt::next`] method with a custom timeout future instead
+    /// [`StreamExt::next`](futures::StreamExt::next) method with a custom timeout future instead
     /// ([`EventStream`] implements the [`Stream`] trait).
     pub async fn recv_async_timeout(&mut self, dur: Duration) -> Option<Event> {
         match select(Delay::new(dur), pin!(self.recv_async())).await {

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -1376,7 +1376,7 @@ impl DoraNode {
     /// Allocates a [`DataSample`] of the specified size.
     ///
     /// Zero-copy transport for large messages is handled by the zenoh SHM
-    /// provider inside [`send_output`]; this allocation itself is a heap
+    /// provider inside [`send_output`](Self::send_output); this allocation itself is a heap
     /// buffer.
     pub fn allocate_data_sample(&mut self, data_len: usize) -> NodeResult<DataSample> {
         let avec: AVec<u8, ConstAlign<128>> = AVec::__from_elem(128, 0, data_len);

--- a/libraries/core/src/lib.rs
+++ b/libraries/core/src/lib.rs
@@ -20,7 +20,7 @@ pub mod types;
 ///
 /// Takes a base path (without platform-specific prefix and extension) and returns
 /// a path with the appropriate shared library naming conventions using
-/// [`DLL_PREFIX`](std::env::consts::DLL_PREFIX) and [`DLL_SUFFIX`](std::env::consts::DLL_SUFFIX).
+/// [`DLL_PREFIX`] and [`DLL_SUFFIX`].
 ///
 /// # Errors
 ///

--- a/libraries/message/src/cli_to_coordinator.rs
+++ b/libraries/message/src/cli_to_coordinator.rs
@@ -106,7 +106,7 @@ pub enum ControlRequest {
     /// otherwise sit in redb forever and never become reachable for
     /// `dora clean`. If the persisted-store enumeration itself
     /// errors, the entire request fails with
-    /// [`ControlRequestReply::Error`] and no in-memory state is
+    /// [`ControlRequestReply::Error`](crate::coordinator_to_cli::ControlRequestReply::Error) and no in-memory state is
     /// mutated — degrading silently to in-memory-only would let the
     /// CLI claim "nothing to clean" while historical rows are still
     /// sitting on disk.
@@ -114,7 +114,7 @@ pub enum ControlRequest {
     /// For each cleaned dataflow the coordinator removes its persisted
     /// record first and only then mutates in-memory state, so the reply
     /// reflects what was actually persisted. The response is
-    /// [`ControlRequestReply::CleanResult`] carrying two separate
+    /// [`ControlRequestReply::CleanResult`](crate::coordinator_to_cli::ControlRequestReply::CleanResult) carrying two separate
     /// lists: `cleaned` for dataflows whose redb row (and every
     /// `dora param` row owned by it — the persisted-store delete
     /// cascades) is gone, and `failed` for dataflows whose
@@ -235,8 +235,8 @@ pub enum ControlRequest {
     /// (dora-rs/adora#151).
     ///
     /// The coordinator replies with either
-    /// [`ControlRequestReply::HelloOk`] carrying its own crate version,
-    /// or [`ControlRequestReply::Error`] with a human-readable mismatch
+    /// [`ControlRequestReply::HelloOk`](crate::coordinator_to_cli::ControlRequestReply::HelloOk) carrying its own crate version,
+    /// or [`ControlRequestReply::Error`](crate::coordinator_to_cli::ControlRequestReply::Error) with a human-readable mismatch
     /// message.
     Hello {
         dora_version: semver::Version,

--- a/libraries/message/src/common.rs
+++ b/libraries/message/src/common.rs
@@ -308,7 +308,7 @@ impl DaemonId {
         self.machine_id.as_deref()
     }
 
-    /// Reverse of [`Display`]: parse `"{machine_id}-{uuid}"`, or a bare
+    /// Reverse of [`Display`](std::fmt::Display): parse `"{machine_id}-{uuid}"`, or a bare
     /// `"{uuid}"` when there is no machine id.
     ///
     /// Both the machine id (hostnames) and the canonical UUID contain `-`, so

--- a/libraries/message/src/integration_testing_format.rs
+++ b/libraries/message/src/integration_testing_format.rs
@@ -82,8 +82,8 @@ pub struct IntegrationTestInput {
     /// Environment variables for node builds and execution.
     ///
     /// Key-value map of environment variables that should be set for both the
-    /// [`build`](Self::build) operation and the node execution (i.e. when the node is spawned
-    /// through [`path`](Self::path)).
+    /// [`build`](crate::descriptor::Node::build) operation and the node execution (i.e. when the node is spawned
+    /// through [`path`](crate::descriptor::Node::path)).
     ///
     /// Supports strings, numbers, and booleans.
     ///


### PR DESCRIPTION
> 🤖 This PR is machine-generated by Claude (automated repository review run). Please review before merging.

## Issue

`cargo doc --no-deps` reported 16 warnings across the published API docs; each renders as a dead link on docs.rs:

- **dora-node-api**: `StreamExt` / `StreamExt::next` (6 links — the futures trait isn't in scope) and a `send_output` link missing its `Self::` target
- **dora-message**: `Display` (needs `std::fmt`), four `ControlRequestReply::*` links written from `cli_to_coordinator.rs` but pointing at items in `coordinator_to_cli`, and `Self::build` / `Self::path` on `IntegrationTestInput` referring to fields that actually live on `descriptor::Node`
- **dora-core**: two redundant explicit link targets for `DLL_PREFIX` / `DLL_SUFFIX`

## Fix

Point each link at the real item (`futures::StreamExt`, `Self::send_output`, `std::fmt::Display`, `crate::coordinator_to_cli::ControlRequestReply::*`, `crate::descriptor::Node::{build,path}`); drop the redundant targets in dora-core. Doc comments only — no code changes.

## Validation

`cargo doc -p dora-node-api -p dora-message -p dora-core --no-deps` is now warning-free (was 16 warnings). All link targets verified to exist and be public. `cargo fmt --check` green; full workspace fmt + clippy + test gates run on the combined review diff.

https://claude.ai/code/session_01SNdKeGorC4iubLKedo2CSw

---
_Generated by [Claude Code](https://claude.ai/code/session_01SNdKeGorC4iubLKedo2CSw)_