### PR TITLE
refactor(tracing): remove unused TracingBuilder::add_layer/with_layers

### DIFF
--- a/libraries/extensions/telemetry/tracing/src/lib.rs
+++ b/libraries/extensions/telemetry/tracing/src/lib.rs
@@ -221,25 +221,6 @@ impl TracingBuilder {
         self
     }
 
-    pub fn add_layer<L>(mut self, layer: L) -> Self
-    where
-        L: Layer<Registry> + Send + Sync + 'static,
-    {
-        self.layers.push(layer.boxed());
-        self
-    }
-
-    pub fn with_layers<I, L>(mut self, layers: I) -> Self
-    where
-        I: IntoIterator<Item = L>,
-        L: Layer<Registry> + Send + Sync + 'static,
-    {
-        for layer in layers {
-            self.layers.push(layer.boxed());
-        }
-        self
-    }
-
     pub fn build(self) -> eyre::Result<()> {
         let registry = Registry::default().with(self.layers);
 


### PR DESCRIPTION
> 🤖 **Auto-generated by Claude.** This PR was created by an automated dead-code sweep run via Claude Code. It is opened under the maintainer's GitHub account only because the automation authenticates with that token — the change itself was written by Claude. Please review before merging.

## What

Removes two unused generic layer-injection helpers from `TracingBuilder` in `dora-tracing`:

- `TracingBuilder::add_layer<L>(self, layer: L) -> Self`
- `TracingBuilder::with_layers<I, L>(self, layers: I) -> Self`

## Why

Both are escape-hatch builder methods that push arbitrary `Layer`s onto the builder, but **nothing in the workspace calls either one**. Every layer that the codebase actually installs goes through a purpose-built method:

- `with_node_stdout`
- `with_stdout`
- `with_file`
- `with_otlp_tracing`
- `with_span_capture`

Neither `add_layer` nor `with_layers` is documented or exercised by a test. This follows the recent cleanup of unused public builder/introspection helpers (e.g. #2188, #2186).

## Verification

- `cargo clippy -p dora-tracing -- -D warnings` — clean
- `cargo fmt -p dora-tracing -- --check` — clean
- `cargo test -p dora-tracing` — all tests + doctests pass

Pure deletion; no behavior change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SjmqFXAn8idhNcv6Yyavdo)_