### PR TITLE
refactor(ros2-bridge): remove unused Package::message_structs codegen helper

### DIFF
--- a/libraries/extensions/ros2-bridge/msg-gen/src/types/package.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/types/package.rs
@@ -32,27 +32,6 @@ impl Package {
         self.messages.is_empty() && self.services.is_empty() && self.actions.is_empty()
     }
 
-    pub fn message_structs(&self, gen_cxx_bridge: bool) -> (impl ToTokens, impl ToTokens) {
-        if self.messages.is_empty() {
-            // empty msg
-            (quote! {}, quote! {})
-        } else {
-            let items = self
-                .messages
-                .iter()
-                .map(|v| v.struct_token_stream(&self.name, gen_cxx_bridge));
-            let defs = items.clone().map(|(def, _)| def);
-            let impls = items.clone().map(|(_, im)| im);
-            let def_tokens = quote! {
-                #(#defs)*
-            };
-            let impl_tokens = quote! {
-                #(#impls)*
-            };
-            (def_tokens, impl_tokens)
-        }
-    }
-
     fn message_aliases(&self, package_name: &Ident) -> impl ToTokens {
         if self.messages.is_empty() {
             quote! {


### PR DESCRIPTION
> 🤖 **Auto-generated by Claude.** This PR was created by an automated dead-code sweep run via Claude Code. It is opened under the maintainer's GitHub account only because the automation authenticates with that token — the change itself was written by Claude. Please review before merging.

## What

Removes the unused `Package::message_structs` method from `dora-ros2-bridge-msg-gen`:

```rust
pub fn message_structs(&self, gen_cxx_bridge: bool) -> (impl ToTokens, impl ToTokens)
```

## Why

This method builds the message struct definitions/impls token streams for a package, but **nothing in the workspace calls it**. The actual code generator in `msg-gen/src/lib.rs` produces message structs directly by iterating `package.messages` and calling `Message::struct_token_stream(...)` inline:

```rust
for message in &package.messages {
    let (def, imp) = message.struct_token_stream(&package.name, create_cxx_bridge);
    shared_type_defs.push(def);
    message_struct_impls.push(imp);
    // ...
}
```

So `message_structs` is dead, duplicated logic. (The sibling alias/service/action helpers on `Package` are all still used and untouched.)

## Verification

- `cargo clippy -p dora-ros2-bridge-msg-gen -- -D warnings` — clean
- `cargo fmt -p dora-ros2-bridge-msg-gen -- --check` — clean
- `cargo test -p dora-ros2-bridge-msg-gen` — 66 tests pass

Pure deletion; generated ROS 2 bindings are unaffected (no call site existed).

---
_Generated by [Claude Code](https://claude.ai/code/session_01SjmqFXAn8idhNcv6Yyavdo)_