### PR TITLE
docs(message): fix DataId try_from guidance

### DIFF
--- a/libraries/message/src/id.rs
+++ b/libraries/message/src/id.rs
@@ -181,8 +181,15 @@ impl From<DataId> for String {
 
 /// # Panics
 ///
-/// Panics if `id` contains invalid characters. Prefer `id.parse::<DataId>()`
-/// or `DataId::try_from(s)` when handling untrusted input.
+/// Panics if `id` contains invalid characters (not in `[a-zA-Z0-9_./-]`).
+///
+/// **For untrusted input, use `id.parse::<DataId>()`** which calls
+/// `FromStr::from_str` and returns `Result<Self, InvalidId>`.
+///
+/// Do NOT use `DataId::try_from(s)`: `TryFrom<String>` is the
+/// auto-derived blanket impl that delegates to this `From` impl, so it
+/// panics exactly like `.into()`. Only `parse::<DataId>()` / `from_str`
+/// is fallible.
 impl From<String> for DataId {
     fn from(id: String) -> Self {
         if let Err(e) = validate_data_id(&id) {


### PR DESCRIPTION
## Summary

Fixes #2195.

The `DataId` docs suggested `DataId::try_from(s)` for untrusted input, but that resolves to the standard blanket `TryFrom<String>` impl and delegates to the panicking `From<String>` implementation. This updates the guidance to recommend the fallible `parse::<DataId>()` / `FromStr` path, matching the existing `NodeId` warning.

## Changes

- Clarify the `From<String> for DataId` panic docs.
- Explicitly warn that `DataId::try_from(s)` is not the fallible path here.

## Testing

- `cargo test -p dora-message data_id_parse_rejects_invalid`
- `cargo test -p dora-message id::tests`
- `cargo fmt --all -- --check`
- `cargo clippy -p dora-message -- -D warnings`
- `git diff --check`

Note: Codex helped with issue scouting and local review; I reviewed the final diff and ran the listed checks locally.
