### PR TITLE
fix(hub): enforce shipped-type namespace rule on untrusted index entries (P2.12)

### DIFF
--- a/binaries/cli/src/command/build/hub.rs
+++ b/binaries/cli/src/command/build/hub.rs
@@ -297,7 +297,10 @@ pub fn resolve_hub_nodes(
                 node.id,
                 type_issues
                     .iter()
-                    .map(|i| format!("{}: {}", i.field, i.message))
+                    // route through `ManifestIssue`'s Display, which strips
+                    // control chars — `i.message` can embed an unvalidated
+                    // field `type:` string from a hostile manifest
+                    .map(|i| i.to_string())
                     .collect::<Vec<_>>()
                     .join("\n  - ")
             );

--- a/binaries/cli/src/command/build/hub.rs
+++ b/binaries/cli/src/command/build/hub.rs
@@ -284,6 +284,24 @@ pub fn resolve_hub_nodes(
         let manifest = &entry.manifest;
         let label = format!("{}@{version}", reference.key());
 
+        // The index entry is an untrusted input: validate its shipped types
+        // (namespace ownership, materializable bodies) before loading them, so
+        // a rewritten entry can't register a `std/` override or a
+        // cross-namespace type that a consumer's port check would resolve
+        // (spec §6.3, P2.12).
+        let type_issues = manifest.shipped_type_issues(registry);
+        if !type_issues.is_empty() {
+            eyre::bail!(
+                "node `{}`: the `{label}` package ships invalid custom types — \
+                 the index entry may be malformed or rewritten:\n  - {}",
+                node.id,
+                type_issues
+                    .iter()
+                    .map(|i| format!("{}: {}", i.field, i.message))
+                    .collect::<Vec<_>>()
+                    .join("\n  - ")
+            );
+        }
         // register the package's shipped types, then inject contracts and
         // check the dataflow's wiring against the declared ports
         for (urn, def) in &manifest.types {

--- a/libraries/core/src/manifest/validate.rs
+++ b/libraries/core/src/manifest/validate.rs
@@ -110,36 +110,11 @@ impl NodeManifest {
             issue("dora", format!("`{req}` is not a valid semver requirement"));
         }
 
-        // Validate shipped type bodies against a registry that includes the
-        // manifest's own types, so that a port referencing a shipped type is
-        // backed by a type that can actually be materialized (the P1.3 gate
-        // must reject unresolvable field types, not just unknown URN keys).
-        let mut local_registry = registry.clone();
-        for (urn, def) in &self.types {
-            local_registry.insert_type(urn.clone(), def.clone());
-        }
-        for (urn, def) in &self.types {
-            if let Some(problem) = check_shipped_type_urn(urn, &self.namespace) {
-                issue(&format!("types.{urn}"), problem);
-                continue;
-            }
-            // the `arrow:` discriminant must be a type dora can materialize —
-            // otherwise a port referencing this shipped type resolves (the URN
-            // exists) yet fails to build into an Arrow schema later
-            if !crate::types::is_known_arrow_type(&def.arrow) {
-                issue(
-                    &format!("types.{urn}.arrow"),
-                    format!("unknown arrow type `{}`", def.arrow),
-                );
-            }
-            for field in &def.fields {
-                if !local_registry.field_type_resolves(&field.r#type) {
-                    issue(
-                        &format!("types.{urn}.fields.{}", field.name),
-                        format!("unknown field type `{}`", field.r#type),
-                    );
-                }
-            }
+        // Validate shipped type bodies (namespace ownership + materializable
+        // bodies). Factored out because the hub resolver runs the same gate on
+        // an *untrusted* index entry before loading its types (spec §6.3, P2.12).
+        for problem in self.shipped_type_issues(registry) {
+            issue(&problem.field, problem.message);
         }
 
         for (direction, ports) in [("inputs", &self.inputs), ("outputs", &self.outputs)] {
@@ -184,6 +159,53 @@ impl NodeManifest {
             issue("example", "is not valid YAML".into());
         }
 
+        issues
+    }
+
+    /// Validate only the manifest's shipped `types:` — namespace ownership
+    /// (no `std/`, no cross-namespace, no `.`/`..` segments), a materializable
+    /// `arrow:` discriminant, and field types that resolve.
+    ///
+    /// Used both by full [`validate`](Self::validate) and by the hub resolver,
+    /// which loads an *untrusted* index entry's shipped types into the
+    /// dataflow's `TypeRegistry`. A rewritten or malformed entry must not be
+    /// able to register a `std/` override or a cross-namespace type that a
+    /// consumer's port check would then resolve (spec §6.3, P2.12).
+    pub fn shipped_type_issues(&self, registry: &TypeRegistry) -> Vec<ManifestIssue> {
+        let mut issues = Vec::new();
+        // Resolve field types against a registry that includes the manifest's
+        // own sibling types, so a type referencing another type it ships
+        // resolves, but an unresolvable field is still rejected.
+        let mut local_registry = registry.clone();
+        for (urn, def) in &self.types {
+            local_registry.insert_type(urn.clone(), def.clone());
+        }
+        for (urn, def) in &self.types {
+            if let Some(problem) = check_shipped_type_urn(urn, &self.namespace) {
+                issues.push(ManifestIssue {
+                    field: format!("types.{urn}"),
+                    message: problem,
+                });
+                continue;
+            }
+            // the `arrow:` discriminant must be a type dora can materialize —
+            // otherwise a port referencing this shipped type resolves (the URN
+            // exists) yet fails to build into an Arrow schema later
+            if !crate::types::is_known_arrow_type(&def.arrow) {
+                issues.push(ManifestIssue {
+                    field: format!("types.{urn}.arrow"),
+                    message: format!("unknown arrow type `{}`", def.arrow),
+                });
+            }
+            for field in &def.fields {
+                if !local_registry.field_type_resolves(&field.r#type) {
+                    issues.push(ManifestIssue {
+                        field: format!("types.{urn}.fields.{}", field.name),
+                        message: format!("unknown field type `{}`", field.r#type),
+                    });
+                }
+            }
+        }
         issues
     }
 
@@ -652,6 +674,42 @@ outputs:
                 "`{bad}` should be rejected for traversal: {issues:?}"
             );
         }
+    }
+
+    #[test]
+    fn shipped_type_issues_gates_untrusted_entries() {
+        // This is the gate the hub resolver runs on an untrusted index entry
+        // (P2.12). A `std/` override and a cross-namespace type must both be
+        // rejected; a well-formed own-namespace type passes.
+        let reg = TypeRegistry::new();
+
+        let std_override = minimal(
+            "types:\n  std/core/v1/Float32:\n    arrow: Struct\n    \
+             fields:\n      - name: x\n        type: Float32\n",
+        );
+        let issues = std_override.shipped_type_issues(&reg);
+        assert!(
+            issues.iter().any(|i| i.message.contains("std/")),
+            "a `std/` shipped type must be rejected: {issues:?}"
+        );
+
+        let cross_ns = minimal(
+            "types:\n  acme/lidar/v1/PointCloud:\n    arrow: Struct\n    \
+             fields:\n      - name: x\n        type: Float32\n",
+        );
+        assert!(
+            cross_ns
+                .shipped_type_issues(&reg)
+                .iter()
+                .any(|i| i.message.contains("namespace")),
+            "a cross-namespace shipped type must be rejected"
+        );
+
+        let ok = minimal(
+            "types:\n  dora-rs/lidar/v1/PointCloud:\n    arrow: Struct\n    \
+             fields:\n      - name: x\n        type: Float32\n",
+        );
+        assert_eq!(ok.shipped_type_issues(&reg), vec![]);
     }
 
     #[test]

--- a/tests/hub-smoke.rs
+++ b/tests/hub-smoke.rs
@@ -331,6 +331,49 @@ fn hub_end_to_end() {
     );
 }
 
+/// The hub resolver loads a package's shipped `types:` into the dataflow's
+/// type registry. The index entry is untrusted, so a rewritten entry that
+/// ships a `std/` override (or a cross-namespace type) must be rejected at
+/// resolve time — before the type can back a consumer's port check (P2.12).
+#[test]
+fn hub_rejects_invalid_shipped_type() {
+    if Command::new("git").arg("--version").output().is_err() {
+        eprintln!("git not available — skipping hub shipped-type test");
+        return;
+    }
+    let fixture = build_fixture();
+
+    // Rewrite the entry's manifest to ship a `std/` type — the namespace rule
+    // forbids it, and the resolver must enforce that on the untrusted entry.
+    let entry_path = fixture.root.join("index/test/hub-smoke-hello/0.1.0.yml");
+    let entry = std::fs::read_to_string(&entry_path).unwrap();
+    let tampered = entry.replace(
+        "  build: cargo build --release\nsource:",
+        "  build: cargo build --release\n  types:\n    std/core/v1/Hijack:\n      arrow: Struct\nsource:",
+    );
+    assert_ne!(entry, tampered, "expected the types injection to apply");
+    std::fs::write(&entry_path, &tampered).unwrap();
+
+    write(
+        &fixture.root.join("flow/dataflow.yml"),
+        "nodes:\n  - id: hello\n    hub: test/hub-smoke-hello@^0.1\n",
+    );
+    let flow = fixture.root.join("flow/dataflow.yml");
+    let out = dora(&fixture)
+        .args(["build", flow.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "build must reject a package shipping a `std/` type"
+    );
+    assert!(
+        stderr(&out).contains("invalid custom types") || stderr(&out).contains("std/"),
+        "expected a shipped-type rejection, got: {}",
+        stderr(&out)
+    );
+}
+
 fn stderr(out: &std::process::Output) -> String {
     String::from_utf8_lossy(&out.stderr).into_owned()
 }


### PR DESCRIPTION
## P2.12 — enforce shipped-type namespace rule at hub resolve

Closes #2205.

The hub resolver loads a resolved package's shipped `types:` into the dataflow's `TypeRegistry` so a consumer's port check can resolve them. The index entry is an **untrusted trust boundary** (spec §11), but resolution called `add_user_type` directly — skipping the namespace rule that `NodeManifest::validate` already enforces. A rewritten/malformed entry could register a `std/` override or a cross-namespace type a consumer then resolves.

### Change
- Factor the shipped-type checks out of `NodeManifest::validate` into a public `NodeManifest::shipped_type_issues` (namespace ownership, no `std/`, no traversal, materializable `arrow:`, resolvable fields).
- Run it in `resolve_hub_nodes` before loading any types; bail with the offending URNs.

The in-memory `add_user_type` registration already gives the compose-time resolution the spec's cache-dir load path (§6.3) was one way to achieve, so no separate cache materialization is needed.

### Tests
- [x] unit: `shipped_type_issues` rejects `std/` + cross-namespace, accepts own-namespace
- [x] hub-smoke: `dora build` rejects a package whose entry ships a `std/` type
- [x] `cargo fmt --check` + clippy clean; full `dora-core` manifest suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
