### PR TITLE
feat(hub): dora build --hub-override for local package substitution (P2.11, UC11)

### DIFF
--- a/binaries/cli/src/command/build/hub.rs
+++ b/binaries/cli/src/command/build/hub.rs
@@ -7,12 +7,15 @@
 //! lockfile — sees an ordinary git node carrying the optional `subdir` and
 //! hub provenance marker on its [`GitSource`].
 
-use std::collections::BTreeMap;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::PathBuf,
+};
 
 use dora_core::{
     build::validate_subdir,
     manifest::{
-        NodeManifest,
+        MANIFEST_FILENAME, NodeManifest,
         inject::{InjectionResult, apply_manifest_contracts},
     },
     types::TypeRegistry,
@@ -37,11 +40,15 @@ pub struct HubResolution {
     /// Per-node resolved git source (with subdir + hub provenance) — merged
     /// into the build's `git_sources` map and the lockfile.
     pub sources: BTreeMap<NodeId, GitSource>,
+    /// Per-node local working dir for `--hub-override` substitutions (UC11):
+    /// the node builds and runs from this checkout instead of a cloned commit.
+    /// Threaded into the local builder so build + spawn root there.
+    pub override_dirs: BTreeMap<NodeId, PathBuf>,
 }
 
 impl HubResolution {
     pub fn is_empty(&self) -> bool {
-        self.sources.is_empty()
+        self.sources.is_empty() && self.override_dirs.is_empty()
     }
 }
 
@@ -90,11 +97,13 @@ pub fn resolve_hub_nodes(
     registry: &mut TypeRegistry,
     offline: bool,
     pins: Option<&BTreeMap<NodeId, GitSource>>,
+    overrides: &BTreeMap<String, PathBuf>,
 ) -> eyre::Result<HubResolution> {
     let mut resolution = HubResolution::default();
     if !dataflow.nodes.iter().any(|n| n.hub.is_some()) {
         return Ok(resolution);
     }
+    let mut used_overrides = BTreeSet::new();
     resolution
         .notes
         .push("`hub:` is an unstable feature — its behavior may change in future releases".into());
@@ -126,6 +135,68 @@ pub fn resolve_hub_nodes(
 
         let reference = PackageRef::parse(&raw_reference)
             .with_context(|| format!("node `{}`: invalid `hub:` reference", node.id))?;
+
+        // `--hub-override`: substitute a local checkout for this package (UC11
+        // inner loop). The manifest is read from the checkout, contracts are
+        // still validated, and the node builds + runs from local source — no
+        // index resolution, no lockfile pin (it's an ephemeral dev override).
+        if let Some(local_dir) = overrides.get(&reference.key()) {
+            used_overrides.insert(reference.key());
+            let manifest_path = local_dir.join(MANIFEST_FILENAME);
+            let manifest = NodeManifest::read(&manifest_path).with_context(|| {
+                format!(
+                    "node `{}`: --hub-override for `{}` has no readable {MANIFEST_FILENAME} at `{}`",
+                    node.id,
+                    reference.key(),
+                    manifest_path.display()
+                )
+            })?;
+            // the local manifest is the developer's own input — validate it in
+            // full (this includes the shipped-type namespace rule, §6.3)
+            let issues = manifest.validate(registry);
+            if !issues.is_empty() {
+                eyre::bail!(
+                    "node `{}`: overridden manifest `{}` is invalid:\n  - {}",
+                    node.id,
+                    manifest_path.display(),
+                    issues
+                        .iter()
+                        .map(|i| format!("{}: {}", i.field, i.message))
+                        .collect::<Vec<_>>()
+                        .join("\n  - ")
+                );
+            }
+            for (urn, def) in &manifest.types {
+                if registry.resolve(urn).is_none() {
+                    let _ = registry.add_user_type(urn, def.clone());
+                }
+            }
+            let label = format!("{} (local override)", reference.key());
+            let mut contracts = InjectionResult::default();
+            apply_manifest_contracts(node, &manifest, &label, registry, &mut contracts);
+            if !contracts.warnings.is_empty() {
+                eyre::bail!(
+                    "node `{}`: does not match the `{label}` package contract:\n  - {}",
+                    node.id,
+                    contracts.warnings.join("\n  - ")
+                );
+            }
+            resolution.notes.extend(contracts.notes);
+            // desugar to a local path node; the checkout is the build/run dir
+            node.path = Some(manifest.entrypoint.replace('\\', "/"));
+            node.build = manifest.build.clone();
+            node.hub = None;
+            resolution.notes.push(format!(
+                "node `{}`: overriding hub package {} with local checkout `{}`",
+                node.id,
+                reference.key(),
+                local_dir.display()
+            ));
+            resolution
+                .override_dirs
+                .insert(node.id.clone(), local_dir.clone());
+            continue;
+        }
 
         // under `--locked` (pins present), a node with no lockfile entry must
         // fail fast — *before* any index fetch — rather than hitting the
@@ -337,6 +408,14 @@ pub fn resolve_hub_nodes(
             node.id
         ));
         resolution.sources.insert(node.id.clone(), source);
+    }
+
+    for key in overrides.keys() {
+        if !used_overrides.contains(key) {
+            resolution.warnings.push(format!(
+                "--hub-override `{key}` did not match any hub node in the dataflow"
+            ));
+        }
     }
 
     resolution.warnings.append(&mut fetcher.warnings);

--- a/binaries/cli/src/command/build/hub.rs
+++ b/binaries/cli/src/command/build/hub.rs
@@ -101,6 +101,13 @@ pub fn resolve_hub_nodes(
 ) -> eyre::Result<HubResolution> {
     let mut resolution = HubResolution::default();
     if !dataflow.nodes.iter().any(|n| n.hub.is_some()) {
+        // No hub nodes — but if `--hub-override`s were given they match nothing,
+        // so surface that rather than silently ignoring the flags.
+        for key in overrides.keys() {
+            resolution.warnings.push(format!(
+                "--hub-override `{key}` did not match any hub node in the dataflow"
+            ));
+        }
         return Ok(resolution);
     }
     let mut used_overrides = BTreeSet::new();
@@ -187,7 +194,8 @@ pub fn resolve_hub_nodes(
             node.build = manifest.build.clone();
             node.hub = None;
             resolution.notes.push(format!(
-                "node `{}`: overriding hub package {} with local checkout `{}`",
+                "node `{}`: overriding hub package {} with local checkout `{}` \
+                 (local source is trusted: spawned without hub `$PATH` confinement)",
                 node.id,
                 reference.key(),
                 local_dir.display()

--- a/binaries/cli/src/command/build/local.rs
+++ b/binaries/cli/src/command/build/local.rs
@@ -17,6 +17,7 @@ pub fn build_dataflow_locally(
     working_dir: PathBuf,
     uv: bool,
     parallel: bool,
+    node_working_dir_overrides: &BTreeMap<NodeId, PathBuf>,
 ) -> eyre::Result<BuildInfo> {
     let runtime = tokio::runtime::Runtime::new()?;
 
@@ -27,6 +28,7 @@ pub fn build_dataflow_locally(
         working_dir,
         uv,
         parallel,
+        node_working_dir_overrides,
     ))
 }
 
@@ -37,6 +39,7 @@ async fn build_dataflow(
     base_working_dir: PathBuf,
     uv: bool,
     parallel: bool,
+    node_working_dir_overrides: &BTreeMap<NodeId, PathBuf>,
 ) -> eyre::Result<BuildInfo> {
     let builder = Builder {
         session_id: dataflow_session.session_id,
@@ -64,8 +67,15 @@ async fn build_dataflow(
             git_source: prev_source,
         });
 
-        let task = builder
-            .clone()
+        // `--hub-override` roots this node's build (and, via the recorded
+        // working dir, its spawn) at a local checkout instead of the dataflow
+        // dir or a git clone.
+        let mut node_builder = builder.clone();
+        if let Some(override_dir) = node_working_dir_overrides.get(&node_id) {
+            node_builder.base_working_dir = override_dir.clone();
+        }
+
+        let task = node_builder
             .build_node(
                 node,
                 git_source,

--- a/binaries/cli/src/command/build/mod.rs
+++ b/binaries/cli/src/command/build/mod.rs
@@ -438,15 +438,24 @@ pub fn build(cfg: BuildConfig) -> eyre::Result<()> {
     let session = || connect_to_coordinator_with_defaults(coordinator_addr, coordinator_port);
 
     // `--hub-override` substitutes a checkout that only exists on this machine,
-    // so it is a local-only feature. Reject mixing it with an explicit remote
-    // coordinator rather than silently ignoring the override.
-    if !hub_override_node_dirs.is_empty()
-        && (coordinator_addr.is_some() || coordinator_port.is_some())
-    {
-        eyre::bail!(
-            "`--hub-override` is a local build feature and cannot be combined with a remote \
-             coordinator (`--coordinator-addr`/`--coordinator-port`)"
-        );
+    // so it is a local-only feature. Reject combining it with a distributed
+    // build rather than silently forcing everything local: an explicit remote
+    // coordinator, or a `deploy:`-driven distributed build (unless the caller
+    // already forced local, e.g. `dora run`, where local is the only mode).
+    if !hub_override_node_dirs.is_empty() {
+        if coordinator_addr.is_some() || coordinator_port.is_some() {
+            eyre::bail!(
+                "`--hub-override` is a local build feature and cannot be combined with a remote \
+                 coordinator (`--coordinator-addr`/`--coordinator-port`)"
+            );
+        }
+        if !force_local && dataflow_descriptor.nodes.iter().any(|n| n.deploy.is_some()) {
+            eyre::bail!(
+                "`--hub-override` is a local build feature and cannot be used with a distributed \
+                 (`deploy:`) dataflow — the local checkout only exists on this machine. Use \
+                 `--local` to force a fully local build if that is what you want."
+            );
+        }
     }
     let build_kind = if !hub_override_node_dirs.is_empty() {
         log::info!("Building locally because `--hub-override` was given");

--- a/binaries/cli/src/command/build/mod.rs
+++ b/binaries/cli/src/command/build/mod.rs
@@ -118,6 +118,13 @@ pub struct Build {
     /// cache misses.
     #[clap(long, action)]
     offline: bool,
+    /// Substitute a local checkout for a hub package (UC11 inner loop):
+    /// `--hub-override <namespace>/<name>=<path>`. The manifest is read from
+    /// the checkout, contracts are still validated, and the node builds + runs
+    /// from local source — no index resolution for that package. Repeatable;
+    /// local builds only.
+    #[clap(long = "hub-override", value_name = "PKG=PATH")]
+    hub_override: Vec<String>,
 }
 
 impl Executable for Build {
@@ -135,6 +142,7 @@ impl Executable for Build {
             lockfile_override: self.lockfile,
             parallel: self.parallel,
             offline: self.offline,
+            hub_overrides: self.hub_override,
             ..Default::default()
         })
     }
@@ -165,6 +173,9 @@ pub struct BuildConfig {
     pub parallel: bool,
     /// Skip network access for hub index refreshes (cache only).
     pub offline: bool,
+    /// `--hub-override <namespace>/<name>=<path>` entries (UC11): substitute a
+    /// local checkout for a hub package. Parsed and validated in [`build`].
+    pub hub_overrides: Vec<String>,
     /// Overrides the working directory for cargo invocations and
     /// module expansion. Needed when the dataflow path points at a
     /// rewritten copy (e.g. a tempfile) whose parent can't resolve the
@@ -214,8 +225,24 @@ pub fn build(cfg: BuildConfig) -> eyre::Result<()> {
         lockfile_override,
         parallel,
         offline,
+        hub_overrides,
         working_dir_override,
     } = cfg;
+    // Parse `--hub-override <namespace>/<name>=<path>` into key -> canonical
+    // local dir. The key matches a node's resolved `hub:` reference key.
+    let mut hub_override_dirs: BTreeMap<String, PathBuf> = BTreeMap::new();
+    for spec in &hub_overrides {
+        let (pkg, path) = spec.split_once('=').ok_or_else(|| {
+            eyre::eyre!("invalid --hub-override `{spec}`: expected `<namespace>/<name>=<path>`")
+        })?;
+        let key = dora_hub_client::reference::PackageRef::parse(pkg.trim())
+            .with_context(|| format!("invalid --hub-override package `{pkg}`"))?
+            .key();
+        let dir = std::fs::canonicalize(path.trim()).with_context(|| {
+            format!("invalid --hub-override path `{}` for `{pkg}`", path.trim())
+        })?;
+        hub_override_dirs.insert(key, dir);
+    }
     // `BuildConfig` derives `Default` so `..Default::default()` works at
     // call sites, but that gives `dataflow: String::new()` which would
     // fail late with a confusing "failed to read ``" error. Catch it up
@@ -285,7 +312,9 @@ pub fn build(cfg: BuildConfig) -> eyre::Result<()> {
         &mut registry,
         offline,
         hub_pins.as_ref(),
+        &hub_override_dirs,
     )?;
+    let hub_override_node_dirs = hub_resolution.override_dirs.clone();
     for note in &hub_resolution.notes {
         println!("  {note}");
     }
@@ -408,7 +437,21 @@ pub fn build(cfg: BuildConfig) -> eyre::Result<()> {
 
     let session = || connect_to_coordinator_with_defaults(coordinator_addr, coordinator_port);
 
-    let build_kind = if force_local {
+    // `--hub-override` substitutes a checkout that only exists on this machine,
+    // so it is a local-only feature. Reject mixing it with an explicit remote
+    // coordinator rather than silently ignoring the override.
+    if !hub_override_node_dirs.is_empty()
+        && (coordinator_addr.is_some() || coordinator_port.is_some())
+    {
+        eyre::bail!(
+            "`--hub-override` is a local build feature and cannot be combined with a remote \
+             coordinator (`--coordinator-addr`/`--coordinator-port`)"
+        );
+    }
+    let build_kind = if !hub_override_node_dirs.is_empty() {
+        log::info!("Building locally because `--hub-override` was given");
+        BuildKind::Local
+    } else if force_local {
         log::info!("Building locally, as requested through `--force-local`");
         BuildKind::Local
     } else if dataflow_descriptor.nodes.iter().all(|n| n.deploy.is_none()) {
@@ -449,6 +492,7 @@ pub fn build(cfg: BuildConfig) -> eyre::Result<()> {
                 local_working_dir,
                 uv,
                 parallel,
+                &hub_override_node_dirs,
             )?;
 
             dataflow_session.git_sources = git_sources;

--- a/binaries/cli/src/command/build/mod.rs
+++ b/binaries/cli/src/command/build/mod.rs
@@ -268,6 +268,36 @@ pub fn build(cfg: BuildConfig) -> eyre::Result<()> {
         .expand(working_dir)
         .wrap_err("failed to expand modules in dataflow descriptor")?;
 
+    // `--hub-override` is a local-only inner-loop feature (the checkout exists
+    // only on this machine). If it was *requested* at all, reject combining it
+    // with a distributed build or with lockfile generation here — before any
+    // index resolution or lockfile write. Keyed on the requested overrides, not
+    // the ones that matched a node, so a typo'd package name can't silently
+    // fall through to a distributed build or clobber the lockfile.
+    if !hub_override_dirs.is_empty() {
+        if coordinator_addr.is_some() || coordinator_port.is_some() {
+            eyre::bail!(
+                "`--hub-override` is a local build feature and cannot be combined with a remote \
+                 coordinator (`--coordinator-addr`/`--coordinator-port`)"
+            );
+        }
+        if !force_local && dataflow_descriptor.nodes.iter().any(|n| n.deploy.is_some()) {
+            eyre::bail!(
+                "`--hub-override` is a local build feature and cannot be used with a distributed \
+                 (`deploy:`) dataflow — the local checkout only exists on this machine. Use \
+                 `--local` to force a fully local build if that is what you want."
+            );
+        }
+        if write_lockfile {
+            eyre::bail!(
+                "`--hub-override` cannot be combined with `--write-lockfile`: the override \
+                 substitutes local source for a hub node, so the regenerated lockfile would drop \
+                 that node's hub pin. Drop `--write-lockfile` (or the override) when refreshing \
+                 the lockfile."
+            );
+        }
+    }
+
     // Digest the expanded descriptor before hub desugaring so `dora start` /
     // `dora daemon --run-dataflow` can detect on-disk edits to a hub dataflow
     // (whose unresolved `hub:` references can't be re-fingerprinted directly).
@@ -437,27 +467,10 @@ pub fn build(cfg: BuildConfig) -> eyre::Result<()> {
 
     let session = || connect_to_coordinator_with_defaults(coordinator_addr, coordinator_port);
 
-    // `--hub-override` substitutes a checkout that only exists on this machine,
-    // so it is a local-only feature. Reject combining it with a distributed
-    // build rather than silently forcing everything local: an explicit remote
-    // coordinator, or a `deploy:`-driven distributed build (unless the caller
-    // already forced local, e.g. `dora run`, where local is the only mode).
-    if !hub_override_node_dirs.is_empty() {
-        if coordinator_addr.is_some() || coordinator_port.is_some() {
-            eyre::bail!(
-                "`--hub-override` is a local build feature and cannot be combined with a remote \
-                 coordinator (`--coordinator-addr`/`--coordinator-port`)"
-            );
-        }
-        if !force_local && dataflow_descriptor.nodes.iter().any(|n| n.deploy.is_some()) {
-            eyre::bail!(
-                "`--hub-override` is a local build feature and cannot be used with a distributed \
-                 (`deploy:`) dataflow — the local checkout only exists on this machine. Use \
-                 `--local` to force a fully local build if that is what you want."
-            );
-        }
-    }
-    let build_kind = if !hub_override_node_dirs.is_empty() {
+    // `--hub-override` implies a local build (validated above). Force it even
+    // when the override matched no node: the override-vs-distributed conflict
+    // was already rejected, so the remaining cases are safe to build locally.
+    let build_kind = if !hub_override_dirs.is_empty() {
         log::info!("Building locally because `--hub-override` was given");
         BuildKind::Local
     } else if force_local {

--- a/binaries/cli/src/command/run.rs
+++ b/binaries/cli/src/command/run.rs
@@ -100,6 +100,11 @@ pub struct Run {
     /// can't resolve the original `build:` / relative-path references.
     #[clap(skip)]
     pub working_dir: Option<PathBuf>,
+    /// Substitute a local checkout for a hub package (UC11 inner loop):
+    /// `--hub-override <namespace>/<name>=<path>`. Same as `dora build
+    /// --hub-override`; `dora run` is always local, so it applies directly.
+    #[clap(long = "hub-override", value_name = "PKG=PATH")]
+    pub hub_override: Vec<String>,
 }
 
 impl Run {
@@ -117,6 +122,7 @@ impl Run {
             write_lockfile: false,
             lockfile: None,
             working_dir: None,
+            hub_override: Vec::new(),
         }
     }
 
@@ -168,6 +174,7 @@ impl Executable for Run {
             write_lockfile: self.write_lockfile,
             lockfile_override: self.lockfile.clone(),
             working_dir_override: self.working_dir.clone(),
+            hub_overrides: self.hub_override.clone(),
             ..Default::default()
         })
         .context("failed to build dataflow before run")?;

--- a/binaries/cli/src/command/validate.rs
+++ b/binaries/cli/src/command/validate.rs
@@ -96,8 +96,13 @@ fn validate_dataflow(dataflow: &Path, strict_types: bool, offline: bool) -> eyre
 
     // Resolve hub: references against the (cached) index so their contracts
     // take part in validation (spec §6.2 ordering note)
-    let hub_resolution =
-        super::build::hub::resolve_hub_nodes(&mut descriptor, &mut registry, offline, None)?;
+    let hub_resolution = super::build::hub::resolve_hub_nodes(
+        &mut descriptor,
+        &mut registry,
+        offline,
+        None,
+        &std::collections::BTreeMap::<String, std::path::PathBuf>::new(),
+    )?;
     for note in &hub_resolution.notes {
         println!("  {note}");
     }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -346,6 +346,11 @@ dora build <PATH> [OPTIONS]
 | `--uv` | false | Use `uv` for Python builds |
 | `--local` | false | Force local build (skip coordinator) |
 | `--strict-types` | false | Treat type warnings as errors (non-zero exit code) |
+| `--locked` | false | Use pinned hub/git commits from the lockfile (no resolution) |
+| `--offline` | false | Do not refresh the hub index over the network; cache only |
+| `--hub-override <PKG=PATH>` | — | Substitute a local checkout for a hub package (repeatable; local builds only) |
+
+**`--hub-override`:** for the node author's inner loop (UC11) — test a local checkout against a consumer dataflow without publishing. `--hub-override <namespace>/<name>=<path>` reads the manifest from `<path>`, still validates contracts, and builds + runs the node from local source instead of resolving and cloning the index pin. It implies a local build (the checkout only exists on this machine).
 
 **Type checking:** After expanding modules, `build` runs the same type checks as `validate`. Warnings are printed by default; use `--strict-types` (or set `strict_types: true` in the YAML) to fail the build on type mismatches. User-defined types in a `types/` directory next to the dataflow are loaded automatically.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -350,7 +350,7 @@ dora build <PATH> [OPTIONS]
 | `--offline` | false | Do not refresh the hub index over the network; cache only |
 | `--hub-override <PKG=PATH>` | — | Substitute a local checkout for a hub package (repeatable; local builds only) |
 
-**`--hub-override`:** for the node author's inner loop (UC11) — test a local checkout against a consumer dataflow without publishing. `--hub-override <namespace>/<name>=<path>` reads the manifest from `<path>`, still validates contracts, and builds + runs the node from local source instead of resolving and cloning the index pin. It implies a local build (the checkout only exists on this machine).
+**`--hub-override`:** for the node author's inner loop (UC11) — test a local checkout against a consumer dataflow without publishing. `--hub-override <namespace>/<name>=<path>` reads the manifest from `<path>`, still validates contracts, and builds + runs the node from local source instead of resolving and cloning the index pin. The same flag is accepted by `dora run`. It implies a local build (the checkout only exists on this machine), so it is rejected when combined with a remote coordinator or a distributed (`deploy:`) dataflow. Pair `dora build --hub-override …` with `dora start`, or use `dora run --hub-override …` directly.
 
 **Type checking:** After expanding modules, `build` runs the same type checks as `validate`. Warnings are printed by default; use `--strict-types` (or set `strict_types: true` in the YAML) to fail the build on type mismatches. User-defined types in a `types/` directory next to the dataflow are loaded automatically.
 

--- a/tests/hub-smoke.rs
+++ b/tests/hub-smoke.rs
@@ -460,6 +460,38 @@ fn hub_override_unused_is_warned() {
     );
 }
 
+/// An override is also surfaced when the dataflow has *no* hub nodes at all —
+/// the resolver early-returns in that case, so the warning must fire there too.
+#[test]
+fn hub_override_warns_when_no_hub_nodes() {
+    if Command::new("git").arg("--version").output().is_err() {
+        eprintln!("git not available — skipping hub override no-hub-node test");
+        return;
+    }
+    let fixture = build_fixture();
+    let checkout = fixture.root.join("source/node-hub/hello"); // any existing dir
+    // a dataflow with only a non-hub (dynamic) node — nothing to build
+    write(
+        &fixture.root.join("flow/dataflow.yml"),
+        "nodes:\n  - id: plain\n    path: dynamic\n",
+    );
+    let flow = fixture.root.join("flow/dataflow.yml");
+    let out = dora(&fixture)
+        .args([
+            "build",
+            flow.to_str().unwrap(),
+            "--hub-override",
+            &format!("test/ghost={}", checkout.display()),
+        ])
+        .output()
+        .unwrap();
+    let combined = format!("{}{}", String::from_utf8_lossy(&out.stdout), stderr(&out));
+    assert!(
+        combined.contains("did not match any hub node"),
+        "expected an unused-override warning even with no hub nodes, got:\n{combined}"
+    );
+}
+
 fn stderr(out: &std::process::Output) -> String {
     String::from_utf8_lossy(&out.stderr).into_owned()
 }

--- a/tests/hub-smoke.rs
+++ b/tests/hub-smoke.rs
@@ -539,6 +539,81 @@ fn hub_override_warns_when_no_hub_nodes() {
     );
 }
 
+/// `--hub-override` + `--write-lockfile` is rejected: the override substitutes
+/// local source, so a regenerated lockfile would silently drop the hub pin.
+#[test]
+fn hub_override_rejects_write_lockfile() {
+    if Command::new("git").arg("--version").output().is_err() {
+        eprintln!("git not available — skipping hub override write-lockfile test");
+        return;
+    }
+    let fixture = build_fixture();
+    let checkout = fixture.root.join("source/node-hub/hello");
+    write(
+        &fixture.root.join("flow/dataflow.yml"),
+        "nodes:\n  - id: hello\n    hub: test/hub-smoke-hello@^0.1\n",
+    );
+    let flow = fixture.root.join("flow/dataflow.yml");
+    let out = dora(&fixture)
+        .args([
+            "build",
+            flow.to_str().unwrap(),
+            "--write-lockfile",
+            "--hub-override",
+            &format!("test/hub-smoke-hello={}", checkout.display()),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "must reject --hub-override + --write-lockfile"
+    );
+    assert!(
+        stderr(&out).contains("write-lockfile"),
+        "expected a write-lockfile rejection, got: {}",
+        stderr(&out)
+    );
+}
+
+/// `--hub-override` is rejected with a remote coordinator even when the
+/// override package matches NO node (a typo must not silently fall through to
+/// a distributed build).
+#[test]
+fn hub_override_rejects_remote_coordinator_even_if_unmatched() {
+    if Command::new("git").arg("--version").output().is_err() {
+        eprintln!("git not available — skipping hub override coordinator test");
+        return;
+    }
+    let fixture = build_fixture();
+    let checkout = fixture.root.join("source/node-hub/hello");
+    write(
+        &fixture.root.join("flow/dataflow.yml"),
+        "nodes:\n  - id: hello\n    hub: test/hub-smoke-hello@^0.1\n",
+    );
+    let flow = fixture.root.join("flow/dataflow.yml");
+    let out = dora(&fixture)
+        .args([
+            "build",
+            flow.to_str().unwrap(),
+            "--coordinator-addr",
+            "127.0.0.1",
+            // a package that matches no node in the dataflow
+            "--hub-override",
+            &format!("test/not-a-node={}", checkout.display()),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "must reject --hub-override + remote coordinator regardless of match"
+    );
+    assert!(
+        stderr(&out).contains("remote") && stderr(&out).contains("coordinator"),
+        "expected a remote-coordinator rejection, got: {}",
+        stderr(&out)
+    );
+}
+
 fn stderr(out: &std::process::Output) -> String {
     String::from_utf8_lossy(&out.stderr).into_owned()
 }

--- a/tests/hub-smoke.rs
+++ b/tests/hub-smoke.rs
@@ -374,6 +374,92 @@ fn hub_rejects_invalid_shipped_type() {
     );
 }
 
+/// `dora build --hub-override <pkg>=<path>` substitutes a local checkout for a
+/// hub package (UC11): the manifest is read from the checkout, contracts are
+/// validated, and the node builds from local source — no index resolution, no
+/// clone. We assert the build roots at the checkout (its `target/` appears) and
+/// that the override is reported.
+#[test]
+fn hub_override_builds_from_local_checkout() {
+    if Command::new("git").arg("--version").output().is_err() {
+        eprintln!("git not available — skipping hub override test");
+        return;
+    }
+    let fixture = build_fixture();
+
+    // the local checkout is the node's source dir inside the fixture repo
+    let checkout = fixture.root.join("source/node-hub/hello");
+    assert!(checkout.join("dora-node.yml").is_file(), "fixture checkout");
+
+    write(
+        &fixture.root.join("flow/dataflow.yml"),
+        "nodes:\n  - id: hello\n    hub: test/hub-smoke-hello@^0.1\n",
+    );
+    let flow = fixture.root.join("flow/dataflow.yml");
+
+    let out = dora(&fixture)
+        .args([
+            "build",
+            flow.to_str().unwrap(),
+            "--hub-override",
+            &format!("test/hub-smoke-hello={}", checkout.display()),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "override build failed: {}",
+        stderr(&out)
+    );
+    let combined = format!("{}{}", String::from_utf8_lossy(&out.stdout), stderr(&out));
+    assert!(
+        combined.contains("overriding hub package test/hub-smoke-hello"),
+        "expected an override note, got:\n{combined}"
+    );
+    // the node built from local source: the binary lands in the checkout's
+    // own target dir, not a clone under the hub cache
+    let built = checkout.join("target/release/hub-smoke-hello");
+    assert!(
+        built.exists(),
+        "override did not build in the local checkout (missing {})",
+        built.display()
+    );
+}
+
+/// An override that names no node in the dataflow is reported, not silently
+/// ignored.
+#[test]
+fn hub_override_unused_is_warned() {
+    if Command::new("git").arg("--version").output().is_err() {
+        eprintln!("git not available — skipping hub override-warn test");
+        return;
+    }
+    let fixture = build_fixture();
+    let checkout = fixture.root.join("source/node-hub/hello");
+    write(
+        &fixture.root.join("flow/dataflow.yml"),
+        "nodes:\n  - id: hello\n    hub: test/hub-smoke-hello@^0.1\n",
+    );
+    let flow = fixture.root.join("flow/dataflow.yml");
+    let out = dora(&fixture)
+        .args([
+            "build",
+            flow.to_str().unwrap(),
+            "--hub-override",
+            &format!("test/not-a-node={}", checkout.display()),
+        ])
+        .output()
+        .unwrap();
+    // resolution still proceeds against the index for the real node; the unused
+    // override is surfaced as a warning
+    assert!(
+        stderr(&out).contains("did not match any hub node")
+            || String::from_utf8_lossy(&out.stdout).contains("did not match any hub node"),
+        "expected an unused-override warning, got:\n{}",
+        stderr(&out)
+    );
+}
+
 fn stderr(out: &std::process::Output) -> String {
     String::from_utf8_lossy(&out.stderr).into_owned()
 }

--- a/tests/hub-smoke.rs
+++ b/tests/hub-smoke.rs
@@ -426,6 +426,53 @@ fn hub_override_builds_from_local_checkout() {
     );
 }
 
+/// `dora run --hub-override` must build AND run the LOCAL checkout, not the
+/// published/committed source. We modify the checkout's source (uncommitted)
+/// to print a unique marker; if the override truly uses local source, that
+/// marker — not the index-pinned version — appears at run time (UC11).
+#[test]
+fn hub_run_override_executes_local_source() {
+    if Command::new("git").arg("--version").output().is_err() {
+        eprintln!("git not available — skipping hub run-override test");
+        return;
+    }
+    let fixture = build_fixture();
+    let checkout = fixture.root.join("source/node-hub/hello");
+
+    // edit the checkout's source WITHOUT committing — the index pin still
+    // points at the original commit, so only a local override sees this.
+    let marker = "LOCAL-OVERRIDE-MARKER-9173";
+    write(
+        &checkout.join("src/main.rs"),
+        &format!("fn main() {{ println!(\"{marker}\"); }}\n"),
+    );
+
+    write(
+        &fixture.root.join("flow/dataflow.yml"),
+        "nodes:\n  - id: hello\n    hub: test/hub-smoke-hello@^0.1\n",
+    );
+    let flow = fixture.root.join("flow/dataflow.yml");
+    let out = dora(&fixture)
+        .args([
+            "run",
+            flow.to_str().unwrap(),
+            "--hub-override",
+            &format!("test/hub-smoke-hello={}", checkout.display()),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "run --hub-override failed: {}",
+        stderr(&out)
+    );
+    let combined = format!("{}{}", String::from_utf8_lossy(&out.stdout), stderr(&out));
+    assert!(
+        combined.contains(marker),
+        "run did not execute the local checkout (marker absent):\n{combined}"
+    );
+}
+
 /// An override that names no node in the dataflow is reported, not silently
 /// ignored.
 #[test]


### PR DESCRIPTION
## P2.11 — `dora build --hub-override` (UC11 inner loop)

Closes #2204.

Lets a node author test a local checkout against a consumer dataflow **without publishing**:

```bash
dora build consumer.yml --hub-override dora-rs/dora-yolo=../dora-yolo
```

The manifest is read from `../dora-yolo`, contracts are still validated against the consumer wiring, and the node **builds + runs from local source** — no index resolution, no clone, no lockfile pin. Repeatable.

### Design
- The resolver desugars an overridden `hub:` node into a `path:` node and records its checkout dir.
- The **local** builder roots that node build at the checkout, so its recorded working dir also drives spawn.
- `--hub-override` is **local-only** (the checkout exists only on this machine): it forces a local build and errors if combined with a remote coordinator.
- An override that matches no hub node is **warned**, not silently ignored.

Deliberately avoids the `_unstable_deploy.working_dir` field (setting `deploy` flips the build to distributed dispatch) and needs **no daemon protocol change**.

### Scope
Wired for `dora build` (the UC11 command). `dora run`/`dora validate` pass an empty override map for now — a follow-up can thread the same flag.

### Tests
- [x] `hub_override_builds_from_local_checkout` — asserts the build lands in the checkout `target/`
- [x] `hub_override_unused_is_warned`
- [x] fmt + clippy clean; `cargo check --examples` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
