### PR TITLE
refactor(log-utils): remove unused formatting and aggregation helpers

### DIFF
--- a/libraries/log-utils/src/lib.rs
+++ b/libraries/log-utils/src/lib.rs
@@ -1,5 +1,4 @@
-use chrono::{DateTime, Utc};
-use dora_message::common::{LogLevel, LogLevelOrStdout, LogMessage};
+use dora_message::common::LogMessage;
 use eyre::{Context, Result, bail};
 
 /// Maximum size of a single log JSON string (64 KB).
@@ -31,24 +30,6 @@ pub fn parse_log_from_arrow(data: &dora_arrow_convert::ArrowData) -> Result<LogM
     parse_log(json)
 }
 
-/// Merge multiple log vectors into a single timeline sorted by timestamp.
-pub fn merge_by_timestamp(streams: Vec<Vec<LogMessage>>) -> Vec<LogMessage> {
-    let mut merged: Vec<LogMessage> = streams.into_iter().flatten().collect();
-    merged.sort_by_key(|m| m.timestamp);
-    merged
-}
-
-/// Filter logs that pass the given minimum level threshold.
-///
-/// Uses the same filtering logic as the daemon: a message passes if its
-/// level is at least as severe as `min_level`.
-pub fn filter_by_level<'a>(
-    logs: &'a [LogMessage],
-    min_level: &LogLevelOrStdout,
-) -> Vec<&'a LogMessage> {
-    logs.iter().filter(|m| m.level.passes(min_level)).collect()
-}
-
 /// Format a log entry as a JSON string (one line, no trailing newline).
 ///
 /// Callers writing JSONL should append `"\n"` after each call.
@@ -56,55 +37,11 @@ pub fn format_json(log: &LogMessage) -> String {
     serde_json::to_string(log).expect("LogMessage serialization is infallible")
 }
 
-/// Format a log entry as a compact single-line string.
-///
-/// Format: `<timestamp> <node> <LEVEL>: <message>`
-pub fn format_compact(log: &LogMessage) -> String {
-    let ts = format_timestamp(&log.timestamp);
-    let node = log
-        .node_id
-        .as_ref()
-        .map(|n| n.to_string())
-        .unwrap_or_default();
-    let level = format_level(&log.level);
-    format!("{ts} {node} {level}: {}", log.message)
-}
-
-/// Format a log entry as a pretty human-readable string.
-///
-/// Format: `[<timestamp>][<LEVEL>][<node>] <message>`
-pub fn format_pretty(log: &LogMessage) -> String {
-    let ts = format_timestamp(&log.timestamp);
-    let node = log
-        .node_id
-        .as_ref()
-        .map(|n| n.to_string())
-        .unwrap_or_default();
-    let level = format_level(&log.level);
-    format!("[{ts}][{level:6}][{node}] {}", log.message)
-}
-
-fn format_timestamp(ts: &DateTime<Utc>) -> String {
-    ts.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string()
-}
-
-fn format_level(level: &LogLevelOrStdout) -> &'static str {
-    match level {
-        LogLevelOrStdout::Stdout => "STDOUT",
-        LogLevelOrStdout::LogLevel(l) => match *l {
-            LogLevel::Error => "ERROR",
-            LogLevel::Warn => "WARN",
-            LogLevel::Info => "INFO",
-            LogLevel::Debug => "DEBUG",
-            LogLevel::Trace => "TRACE",
-        },
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use chrono::Utc;
+    use dora_message::common::{LogLevel, LogLevelOrStdout};
 
     fn make_log(level: LogLevelOrStdout, msg: &str, node: &str) -> LogMessage {
         LogMessage {
@@ -142,94 +79,11 @@ mod tests {
     }
 
     #[test]
-    fn merge_sorts_by_timestamp() {
-        let now = Utc::now();
-        let early = now - chrono::Duration::seconds(10);
-        let late = now + chrono::Duration::seconds(10);
-
-        let mut log1 = make_log(LogLevelOrStdout::LogLevel(LogLevel::Info), "late", "a");
-        log1.timestamp = late;
-
-        let mut log2 = make_log(LogLevelOrStdout::LogLevel(LogLevel::Info), "early", "b");
-        log2.timestamp = early;
-
-        let merged = merge_by_timestamp(vec![vec![log1], vec![log2]]);
-        assert_eq!(merged[0].message, "early");
-        assert_eq!(merged[1].message, "late");
-    }
-
-    #[test]
-    fn filter_by_level_filters_correctly() {
-        let error = make_log(LogLevelOrStdout::LogLevel(LogLevel::Error), "err", "a");
-        let info = make_log(LogLevelOrStdout::LogLevel(LogLevel::Info), "info", "b");
-        let debug = make_log(LogLevelOrStdout::LogLevel(LogLevel::Debug), "dbg", "c");
-
-        let logs = vec![error, info, debug];
-        let min = LogLevelOrStdout::LogLevel(LogLevel::Info);
-        let filtered = filter_by_level(&logs, &min);
-        assert_eq!(filtered.len(), 2);
-        assert_eq!(filtered[0].message, "err");
-        assert_eq!(filtered[1].message, "info");
-    }
-
-    #[test]
-    fn format_compact_output() {
-        let log = make_log(
-            LogLevelOrStdout::LogLevel(LogLevel::Warn),
-            "overheating",
-            "motor",
-        );
-        let out = format_compact(&log);
-        assert!(out.contains("motor"));
-        assert!(out.contains("WARN"));
-        assert!(out.contains("overheating"));
-    }
-
-    #[test]
-    fn format_pretty_output() {
-        let log = make_log(
-            LogLevelOrStdout::LogLevel(LogLevel::Error),
-            "failure",
-            "sensor",
-        );
-        let out = format_pretty(&log);
-        assert!(out.contains("[ERROR ]"));
-        assert!(out.contains("[sensor]"));
-        assert!(out.contains("failure"));
-    }
-
-    #[test]
-    fn format_pretty_stdout_alignment() {
-        let log = make_log(LogLevelOrStdout::Stdout, "raw line", "cam");
-        let out = format_pretty(&log);
-        assert!(out.contains("[STDOUT]"));
-        assert!(out.contains("[cam]"));
-    }
-
-    #[test]
     fn format_json_roundtrip() {
         let log = make_log(LogLevelOrStdout::LogLevel(LogLevel::Info), "test", "node1");
         let json = format_json(&log);
         let parsed: LogMessage = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.message, "test");
-    }
-
-    #[test]
-    fn merge_empty_streams() {
-        let merged = merge_by_timestamp(vec![]);
-        assert!(merged.is_empty());
-    }
-
-    #[test]
-    fn merge_single_stream() {
-        let now = Utc::now();
-        let mut a = make_log(LogLevelOrStdout::LogLevel(LogLevel::Info), "a", "n");
-        a.timestamp = now;
-        let mut b = make_log(LogLevelOrStdout::LogLevel(LogLevel::Info), "b", "n");
-        b.timestamp = now + chrono::Duration::seconds(1);
-        let merged = merge_by_timestamp(vec![vec![b, a]]);
-        assert_eq!(merged[0].message, "a");
-        assert_eq!(merged[1].message, "b");
     }
 
     #[test]


### PR DESCRIPTION
> 🤖 **Auto-generated by Claude.** This PR was created by an automated dead-code sweep run via Claude Code. It is opened under the maintainer's GitHub account only because the automation authenticates with that token — the change itself was written by Claude. Please review before merging.

## What

Removes six helpers from `dora-log-utils` that have **no caller** anywhere in the workspace (only their own unit tests reference them):

| Function | Visibility | Purpose |
|----------|-----------|---------|
| `format_compact` | `pub` | render a log entry as `<ts> <node> <LEVEL>: <msg>` |
| `format_pretty` | `pub` | render a log entry as `[<ts>][<LEVEL>][<node>] <msg>` |
| `format_timestamp` | private | helper used only by the two formatters above |
| `format_level` | private | helper used only by the two formatters above |
| `merge_by_timestamp` | `pub` | merge multiple log vectors into a sorted timeline |
| `filter_by_level` | `pub` | filter logs by a minimum severity threshold |

## Why

`dora-log-utils` is `publish = false` (workspace-internal — it is **not** part of any published public API), so a `pub` item with zero in-workspace callers is genuinely dead rather than an external extension point. A whole-workspace `rg` for each name finds only the definition and its own `#[cfg(test)]` tests; nothing in any node, operator, example, or CLI command calls them.

The crate's actively-used surface is **retained**:
- `parse_log`, `parse_log_from_arrow` — used by the `log-sink-alert` / `log-sink-tcp` / `log-sink-file` examples
- `format_json` — used by the same examples

## Note for reviewers

The crate is recent (added in #2090), so if any of these helpers are earmarked for an imminent consumer (e.g. a `dora logs` aggregator that would format/merge/filter), feel free to close this — they're easy to restore from history. As of now they are unreachable.

## Verification

- `cargo fmt -p dora-log-utils -- --check` — clean
- `cargo clippy -p dora-log-utils -- -D warnings` — clean
- `cargo test -p dora-log-utils` — 4 tests pass
- `cargo check -p log-sink-alert -p log-sink-tcp -p log-sink-file` — the dependent examples still build

Pure deletion; no behavior change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WRvTzEb58Xi7bm9DE5twsB)_