### PR TITLE
refactor(node-cxx): remove unreachable MergedEvents::merge

### DIFF
--- a/apis/c++/node/src/lib.rs
+++ b/apis/c++/node/src/lib.rs
@@ -12,7 +12,7 @@ use dora_node_api::{
     self, Event, EventStream, Metadata as DoraMetadata,
     MetadataParameters as DoraMetadataParameters, Parameter as DoraParameter, TryRecvError,
     arrow::array::{AsArray, UInt8Array},
-    merged::{MergeExternal, MergedEvent},
+    merged::MergedEvent,
 };
 use eyre::{Result as EyreResult, bail, eyre};
 use serde::Serialize;
@@ -365,7 +365,6 @@ fn dora_events_into_combined(events: Box<Events>) -> ffi::CombinedEvents {
     ffi::CombinedEvents {
         events: Box::new(MergedEvents {
             events: Some(Box::new(events)),
-            next_id: 1,
         }),
     }
 }
@@ -374,7 +373,6 @@ fn empty_combined_events() -> ffi::CombinedEvents {
     ffi::CombinedEvents {
         events: Box::new(MergedEvents {
             events: Some(Box::new(stream::empty())),
-            next_id: 1,
         }),
     }
 }
@@ -904,7 +902,6 @@ fn send_output_internal(
 
 pub struct MergedEvents {
     events: Option<Box<dyn Stream<Item = MergedEvent<ExternalEvent>> + Unpin>>,
-    next_id: u32,
 }
 
 fn new_metadata() -> Box<Metadata> {
@@ -980,22 +977,6 @@ impl MergedEvents {
     fn next(&mut self) -> MergedDoraEvent {
         let event = futures_lite::future::block_on(self.events.as_mut().unwrap().next());
         MergedDoraEvent(event)
-    }
-
-    pub fn merge(&mut self, events: impl Stream<Item = Box<dyn Any>> + Unpin + 'static) -> u32 {
-        let id = self.next_id;
-        self.next_id += 1;
-        let events = Box::pin(events.map(move |event| ExternalEvent { event, id }));
-
-        let inner = self.events.take().unwrap();
-        let merged: Box<dyn Stream<Item = _> + Unpin + 'static> =
-            Box::new(inner.merge_external(events).map(|event| match event {
-                MergedEvent::Dora(event) => MergedEvent::Dora(event),
-                MergedEvent::External(event) => MergedEvent::External(event.flatten()),
-            }));
-        self.events = Some(merged);
-
-        id
     }
 }
 


### PR DESCRIPTION
> 🤖 **Auto-generated by Claude.** This PR was created by an automated dead-code sweep run via Claude Code. It is opened under the maintainer's GitHub account only because the automation authenticates with that token — the change itself was written by Claude. Please review before merging.

## What

Removes `MergedEvents::merge` from `dora-node-api-cxx`, plus the now-dead private `next_id` field (and its two initializers) and the now-unused `MergeExternal` import.

## Why it's unreachable

`merge` is `pub`, but nothing can call it:

- It is **not** exported in the `#[cxx::bridge]` `extern "Rust"` block (lines 108–249), so it is not part of the C++ API surface. Its signature `impl Stream<Item = Box<dyn Any>>` could not cross the cxx FFI boundary in any case, so no C++ node can reach it.
- A whole-workspace `rg "\.merge\(" / "MergedEvents::merge"` finds no Rust caller — only the definition.

It's leftover plumbing from an external-stream-merging path that was never wired into the C++ node API. The live event path — `dora_events_into_combined` → `CombinedEvents::next` → `downcast_dora` — never goes through it; every item the stream produces is a `MergedEvent::Dora`.

Once `merge` is gone, `next_id` is only ever written (never read) and would trip `-D warnings`, so it is removed along with `MergeExternal`.

## Scope note (deliberately minimal)

The surrounding `MergedEvent` / `ExternalEvent` stream scaffolding is **left in place** — it is the event stream's type structure and is a plausible host for a future *bridged* merge API. Fully unwinding it (re-typing the stream to drop the `MergedEvent` wrapper) would be a larger refactor and a feature-level decision; this PR is a pure, low-risk deletion of the unreachable method only.

## Caveat for reviewers

`dora-node-api-cxx` does not set `publish = false`, so `merge` is technically part of the crate's published Rust surface. In practice the crate exists only to generate the C++ bridge and is not consumed as a Rust library, and this method is unreachable through the bridge — but flagging it so the API call is yours to make.

## Verification

- `cargo fmt -p dora-node-api-cxx -- --check` — clean
- `cargo clippy -p dora-node-api-cxx -- -D warnings` — clean
- `cargo test -p dora-node-api-cxx` — passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01WRvTzEb58Xi7bm9DE5twsB)_