### PR TITLE
fix(cli): scale char_sum by 255.0 in word_to_color

### DIFF
--- a/binaries/cli/src/output.rs
+++ b/binaries/cli/src/output.rs
@@ -282,10 +282,11 @@ pub fn word_to_color(word: &str) -> Color {
 
     // Adjust colors based on word features for similarity
     // Similar abbreviations will have similar features
-    let r = (base_r as f32 * 0.5 + repeat_ratio * 255.0 * 0.2 + char_sum * 0.3) as u8;
+    let r = (base_r as f32 * 0.5 + repeat_ratio * 255.0 * 0.2 + char_sum * 255.0 * 0.3) as u8;
     let g = (base_g as f32 * 0.5 + diversity * 255.0 * 0.25 + length_factor * 255.0 * 0.25) as u8;
-    let b =
-        (base_b as f32 * 0.5 + (1.0 - repeat_ratio) * 255.0 * 0.3 + (1.0 - char_sum) * 0.2) as u8;
+    let b = (base_b as f32 * 0.5
+        + (1.0 - repeat_ratio) * 255.0 * 0.3
+        + (1.0 - char_sum) * 255.0 * 0.2) as u8;
 
     Color::TrueColor { r, g, b }
 }
@@ -515,5 +516,29 @@ mod tests {
             Some("other"),
             &config,
         ));
+    }
+
+    // --- word_to_color ---
+
+    #[test]
+    fn word_to_color_returns_true_color() {
+        // Smoke test: function does not panic and returns TrueColor
+        assert!(matches!(word_to_color("stt"), Color::TrueColor { .. }));
+        assert!(matches!(word_to_color("vlm"), Color::TrueColor { .. }));
+    }
+
+    #[test]
+    fn word_to_color_char_sum_affects_output() {
+        // "aaa" has char_sum ≈ 1/26 (low); "zzz" has char_sum = 1.0 (high).
+        // After the fix (char_sum * 255.0 * weight), the two words must
+        // produce different colors. Before the fix both terms rounded to 0
+        // and the colors could be identical despite a 26x difference in
+        // char_sum.
+        let low = word_to_color("aaa");
+        let high = word_to_color("zzz");
+        assert_ne!(
+            low, high,
+            "char_sum should influence color: 'aaa' and 'zzz' must differ"
+        );
     }
 }


### PR DESCRIPTION
Closes #2189

## Summary

The `word_to_color()` function in `binaries/cli/src/output.rs` uses four normalized [0,1] features to blend a deterministic terminal color for each node label. Three features (`repeat_ratio`, `diversity`, `length_factor`) were correctly scaled by `× 255.0` before applying weights, but the two `char_sum` terms were missing this scale factor:

**Before (buggy):**
```rust
let r = (base_r as f32 * 0.5 + repeat_ratio * 255.0 * 0.2 + char_sum * 0.3) as u8;
let b = (base_b as f32 * 0.5 + (1.0 - repeat_ratio) * 255.0 * 0.3 + (1.0 - char_sum) * 0.2) as u8;
```

`char_sum * 0.3` contributes at most 0.3 out of 255 — below `as u8` rounding threshold, so the feature had no visible effect. The R and B channels were also systematically darker than G since their weights didn't sum to 1.0.

**After (fixed):**
```rust
let r = (base_r as f32 * 0.5 + repeat_ratio * 255.0 * 0.2 + char_sum * 255.0 * 0.3) as u8;
let b = (base_b as f32 * 0.5 + (1.0 - repeat_ratio) * 255.0 * 0.3 + (1.0 - char_sum) * 255.0 * 0.2) as u8;
```

Channel weights now balance (R: 0.5+0.2+0.3=1.0, G: 0.5+0.25+0.25=1.0, B: 0.5+0.3+0.2=1.0).

## Tests added

- `word_to_color_returns_true_color` — smoke test confirming no panic
- `word_to_color_char_sum_affects_output` — regression test asserting `"aaa"` and `"zzz"` produce different colors (would have failed before this fix since `char_sum` was rounded to 0)

## Verification

- `cargo fmt -p dora-cli -- --check` ✓
- `cargo clippy -p dora-cli -- -D warnings` ✓
- `cargo test -p dora-cli --lib` — 216 tests pass ✓

---
_Generated by [Claude Code](https://claude.ai/code/session_01SjmbDSV9GfWdiUovySqHTB)_