### PR TITLE
fix(scheduler): log correlation drop for ZenohInput

### DIFF
--- a/apis/rust/node/src/event_stream/scheduler.rs
+++ b/apis/rust/node/src/event_stream/scheduler.rs
@@ -64,14 +64,14 @@ fn select_eviction(queue: &VecDeque<EventItem>, incoming: &EventItem) -> Evictio
 /// everything in the queue is also correlated. Identifies the correlation
 /// keys so operators can trace the affected request/goal.
 fn log_correlation_drop(event_id: &DataId, dropped: &EventItem) {
-    let EventItem::NodeEvent {
-        event: NodeEvent::Input { metadata, .. },
-        ..
-    } = dropped
-    else {
-        return;
+    let params = match dropped {
+        EventItem::NodeEvent {
+            event: NodeEvent::Input { metadata, .. },
+            ..
+        } => &metadata.parameters,
+        EventItem::ZenohInput { metadata, .. } => &metadata.parameters,
+        _ => return,
     };
-    let params = &metadata.parameters;
     let request_id = get_string_param(params, REQUEST_ID);
     let goal_id = get_string_param(params, GOAL_ID);
     let goal_status = get_string_param(params, GOAL_STATUS);
@@ -688,5 +688,77 @@ mod tests {
         // Zero drops
         let counts = sched.drain_drop_counts();
         assert!(counts.is_empty());
+    }
+
+    // ---- issue #2212: log_correlation_drop must also fire for ZenohInput ----
+
+    fn make_zenoh_input(id: &str, params: MetadataParameters) -> EventItem {
+        let type_info = ArrowTypeInfo {
+            data_type: DataType::Null,
+            len: 0,
+            null_count: 0,
+            validity: None,
+            offset: 0,
+            buffer_offsets: vec![],
+            child_data: vec![],
+            field_names: None,
+            schema_hash: None,
+        };
+        let ts = uhlc::HLC::default().new_timestamp();
+        let metadata = Metadata::from_parameters(ts, type_info, params);
+        EventItem::ZenohInput {
+            id: DataId::from(id.to_string()),
+            metadata: std::sync::Arc::new(metadata),
+            payload: zenoh::bytes::ZBytes::default(),
+        }
+    }
+
+    /// Helper: extract request_id from a ZenohInput event's metadata, if any.
+    fn request_id_of_zenoh(event: &EventItem) -> Option<String> {
+        let EventItem::ZenohInput { metadata, .. } = event else {
+            return None;
+        };
+        get_string_param(&metadata.parameters, REQUEST_ID).map(|s| s.to_string())
+    }
+
+    #[test]
+    fn zenoh_drop_oldest_drops_front_loudly_when_both_queue_and_incoming_are_correlated() {
+        // Mirrors `drop_oldest_drops_front_loudly_when_both_queue_and_incoming_are_correlated`
+        // but uses ZenohInput items, exercising the second match arm of
+        // `log_correlation_drop` (issue #2212).
+        //
+        // Queue: [req-1, req-2] (both ZenohInput + correlated). Incoming is req-3.
+        // Unavoidable drop — the oldest correlation (req-1) is evicted.
+        let (mut sched, id) = make_scheduler(2);
+
+        sched.add_event(make_zenoh_input("audio", with_request_id("req-1")));
+        sched.add_event(make_zenoh_input("audio", with_request_id("req-2")));
+        sched.add_event(make_zenoh_input("audio", with_request_id("req-3")));
+
+        let queue = &sched.event_queues[&id].1;
+        assert_eq!(queue.len(), 2);
+        let ids: Vec<_> = queue.iter().filter_map(request_id_of_zenoh).collect();
+        assert_eq!(ids, vec!["req-2".to_string(), "req-3".to_string()]);
+    }
+
+    #[test]
+    fn zenoh_drop_oldest_preserves_correlated_when_non_correlated_present() {
+        // ZenohInput mirror of `drop_oldest_preserves_correlated_when_non_correlated_present`.
+        // A correlated ZenohInput must not be evicted when non-correlated items are available.
+        let (mut sched, id) = make_scheduler(3);
+
+        sched.add_event(make_zenoh_input("audio", with_request_id("req-1")));
+        sched.add_event(make_zenoh_input("audio", MetadataParameters::new()));
+        sched.add_event(make_zenoh_input("audio", MetadataParameters::new()));
+        sched.add_event(make_zenoh_input("audio", MetadataParameters::new()));
+
+        let queue = &sched.event_queues[&id].1;
+        assert_eq!(queue.len(), 3);
+        assert!(
+            queue
+                .iter()
+                .any(|e| request_id_of_zenoh(e).as_deref() == Some("req-1")),
+            "correlated ZenohInput was dropped even though non-correlated events were available"
+        );
     }
 }


### PR DESCRIPTION
Closes #2212

## Summary

`log_correlation_drop` in `apis/rust/node/src/event_stream/scheduler.rs` silently returned early for `EventItem::ZenohInput`, even though `is_correlated` correctly treats `ZenohInput` as correlation-bearing. This meant that when a correlated Zenoh message (service response / action result) was evicted via `DropFrontLoud`, the error log — which exists to surface broken request/response contracts — never fired.

This was especially harmful for distributed dataflows where Zenoh is the transport and correlation breakage is hardest to diagnose.

## Root Cause

The original `log_correlation_drop` used a `let-else` guard that only destructured `NodeEvent::Input`:

```rust
fn log_correlation_drop(event_id: &DataId, dropped: &EventItem) {
    let EventItem::NodeEvent {
        event: NodeEvent::Input { metadata, .. },
        ..
    } = dropped
    else {
        return;  // ZenohInput falls through here — no error logged
    };
    ...
}
```

## Fix

Replace the guard with a `match` that extracts `&metadata.parameters` from both variants, mirroring the pattern already in `is_correlated`:

```rust
fn log_correlation_drop(event_id: &DataId, dropped: &EventItem) {
    let params = match dropped {
        EventItem::NodeEvent {
            event: NodeEvent::Input { metadata, .. },
            ..
        } => &metadata.parameters,
        EventItem::ZenohInput { metadata, .. } => &metadata.parameters,
        _ => return,
    };
    ...
}
```

## Tests Added

- `zenoh_drop_oldest_drops_front_loudly_when_both_queue_and_incoming_are_correlated` — when a full queue of correlated `ZenohInput` items receives another correlated one, the oldest is evicted and the two newest survive
- `zenoh_drop_oldest_preserves_correlated_when_non_correlated_present` — a correlated `ZenohInput` is not evicted when non-correlated items are available to drop instead

## Verification

- `cargo fmt -p dora-node-api -- --check` ✓
- `cargo clippy -p dora-node-api -- -D warnings` ✓
- `cargo test -p dora-node-api` — 103 tests pass ✓

---
_Generated by [Claude Code](https://claude.ai/code/session_01SjmbDSV9GfWdiUovySqHTB)_