### PR TITLE
feat(hub): dora hub publish — validate + add a pinned index entry (P3.1)

### DIFF
--- a/binaries/cli/src/command/hub/mod.rs
+++ b/binaries/cli/src/command/hub/mod.rs
@@ -11,6 +11,7 @@ mod info;
 mod init;
 mod install;
 mod list;
+mod publish;
 mod search;
 
 /// Package, discover, and use dora nodes (unstable)
@@ -22,6 +23,7 @@ pub enum Hub {
     List(list::List),
     Fetch(fetch::Fetch),
     Install(install::Install),
+    Publish(publish::Publish),
 }
 
 impl Executable for Hub {
@@ -33,6 +35,7 @@ impl Executable for Hub {
             Hub::List(cmd) => cmd.execute(),
             Hub::Fetch(cmd) => cmd.execute(),
             Hub::Install(cmd) => cmd.execute(),
+            Hub::Publish(cmd) => cmd.execute(),
         }
     }
 }

--- a/binaries/cli/src/command/hub/publish.rs
+++ b/binaries/cli/src/command/hub/publish.rs
@@ -1,0 +1,229 @@
+//! `dora hub publish` (spec §9.1, P3.1).
+//!
+//! Publishing is just *adding an index entry that points at your source* —
+//! there is no upload, because the bytes already live in a git repo. This
+//! command validates the node manifest, resolves the source pin (git repo +
+//! commit + subdir) and the package version, and produces the index version
+//! file `<namespace>/<name>/<version>.yml`.
+//!
+//! With `--dry-run` it validates and prints the entry. Otherwise it writes the
+//! entry into a **local** index (the `path =` form — enterprise/private indexes
+//! and the integration fixtures, UC8/UC11). For a git-backed index it prints
+//! the entry and the path to add, since automated PR-opening against the
+//! official `node-index` lands with the index bootstrap (P2.3).
+
+use std::path::{Path, PathBuf};
+
+use dora_core::{
+    manifest::{MANIFEST_FILENAME, NodeManifest},
+    types::TypeRegistry,
+};
+use dora_hub_client::{
+    config::ResolvedConfig,
+    index::{IndexEntry, SourceSpec},
+    semver,
+};
+use eyre::{Context, ContextCompat, bail};
+
+use crate::command::Executable;
+
+#[derive(Debug, clap::Args)]
+/// Publish a node: validate its manifest and add a pinned index entry.
+pub struct Publish {
+    /// Directory holding the node's `dora-node.yml` (and `Cargo.toml` /
+    /// `pyproject.toml`). Defaults to the current directory.
+    #[clap(value_name = "PATH", default_value = ".")]
+    path: PathBuf,
+    /// Validate and print the index entry without writing it or opening a PR.
+    #[clap(long, action)]
+    dry_run: bool,
+    /// Git ref (tag, branch, or commit) to pin as the source. Defaults to the
+    /// current `HEAD`.
+    #[clap(long, value_name = "REF")]
+    rev: Option<String>,
+    /// Source git repository URL. Defaults to the `origin` remote of the
+    /// node's directory.
+    #[clap(long, value_name = "URL")]
+    repo: Option<String>,
+    /// Package version (semver). Defaults to `[package].version` (Cargo) or
+    /// `[project].version` (pyproject).
+    #[clap(long, value_name = "SEMVER")]
+    version: Option<String>,
+    /// Index to publish into (by `hub.toml` alias). Defaults to the index
+    /// bound to the manifest's namespace.
+    #[clap(long, value_name = "ALIAS")]
+    index: Option<String>,
+}
+
+impl Executable for Publish {
+    fn execute(self) -> eyre::Result<()> {
+        let dir = self.path.as_path();
+
+        // 1. Read and validate the manifest (spec §9.1 step 1).
+        let manifest_path = dir.join(MANIFEST_FILENAME);
+        let manifest = NodeManifest::read(&manifest_path).with_context(|| {
+            format!(
+                "failed to read {MANIFEST_FILENAME} at `{}`",
+                manifest_path.display()
+            )
+        })?;
+        manifest
+            .validate_strict(&TypeRegistry::new())
+            .context("the node manifest is invalid — fix it before publishing")?;
+        // `validate_strict` guarantees `name`/`namespace` are present and valid.
+        let name = manifest
+            .name
+            .clone()
+            .context("manifest is missing `name`")?;
+        let namespace = manifest.namespace.clone();
+
+        // 2. Version (read from the native manifest unless overridden).
+        let version_str = match &self.version {
+            Some(v) => v.clone(),
+            None => read_native_version(dir).context(
+                "could not determine the package version — pass `--version`, or set \
+                 `[package].version` (Cargo) / `[project].version` (pyproject)",
+            )?,
+        };
+        let version = semver::Version::parse(version_str.trim())
+            .with_context(|| format!("version `{version_str}` is not valid semver"))?;
+
+        // 3. Resolve the source pin (spec §9.1 step 2): repo + commit + subdir.
+        let repo = match &self.repo {
+            Some(r) => r.trim().to_string(),
+            None => git_in(dir, &["remote", "get-url", "origin"]).context(
+                "no `--repo` given and the directory has no `origin` remote — \
+                 pass `--repo <url>`",
+            )?,
+        };
+        let rev_arg = self.rev.as_deref().unwrap_or("HEAD");
+        let commit = git_in(dir, &["rev-parse", &format!("{rev_arg}^{{commit}}")])
+            .with_context(|| format!("failed to resolve git ref `{rev_arg}` to a commit"))?;
+        if commit.len() != 40 || !commit.chars().all(|c| c.is_ascii_hexdigit()) {
+            bail!("resolved commit `{commit}` is not a full 40-char hash");
+        }
+        // subdir = the node directory's path within the repo (empty at root).
+        let subdir = git_in(dir, &["rev-parse", "--show-prefix"])
+            .ok()
+            .map(|p| p.trim_end_matches('/').to_string())
+            .filter(|p| !p.is_empty());
+
+        // 4. Construct the index entry.
+        let entry = IndexEntry {
+            manifest: manifest.clone(),
+            source: SourceSpec {
+                git: Some(repo.clone()),
+                rev: Some(commit.clone()),
+                subdir: subdir.clone(),
+                binary: Vec::new(),
+                fallback_git: None,
+            },
+            published: Some(chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)),
+            yanked: false,
+            yank_reason: None,
+        };
+        let entry_yaml =
+            serde_yaml::to_string(&entry).context("failed to serialize index entry")?;
+        let rel_path = format!("{namespace}/{name}/{version}.yml");
+
+        // 5a. Dry run: validate + preview only.
+        if self.dry_run {
+            println!("# {rel_path}");
+            print!("{entry_yaml}");
+            println!(
+                "\nvalidated `{namespace}/{name}` v{version} @ {} (subdir: {})",
+                &commit[..12],
+                subdir.as_deref().unwrap_or(".")
+            );
+            return Ok(());
+        }
+
+        // 5b. Resolve the target index and publish.
+        let config = ResolvedConfig::load_default().context("failed to load hub configuration")?;
+        let index = match &self.index {
+            Some(alias) => config
+                .indexes
+                .iter()
+                .find(|i| i.alias.eq_ignore_ascii_case(alias))
+                .with_context(|| format!("no index with alias `{alias}` in hub.toml"))?,
+            None => config.index_for_namespace(&namespace),
+        };
+
+        if index.is_local() {
+            let catalog = index.local_catalog_dir(&config.config_dir)?;
+            let dest = catalog.join(&rel_path);
+            // append-only: never overwrite a published version (spec §7.5).
+            if dest.exists() {
+                bail!(
+                    "version {version} of `{namespace}/{name}` already exists at `{}` — \
+                     the index is append-only; bump the version to publish a new one",
+                    dest.display()
+                );
+            }
+            if let Some(parent) = dest.parent() {
+                std::fs::create_dir_all(parent)
+                    .with_context(|| format!("failed to create `{}`", parent.display()))?;
+            }
+            std::fs::write(&dest, &entry_yaml)
+                .with_context(|| format!("failed to write `{}`", dest.display()))?;
+            println!(
+                "published `{namespace}/{name}` v{version} -> {}",
+                dest.display()
+            );
+        } else {
+            // git-backed index: PR-opening needs the bootstrapped node-index
+            // repo + CI (P2.3). Print the entry and where it goes.
+            println!("# add this as `{rel_path}` in the index repo:");
+            println!("{entry_yaml}");
+            println!(
+                "the `{}` index is git-backed ({}). Commit the entry above at `{rel_path}` and \
+                 open a PR. Automated `dora hub publish` PR-opening lands with the node-index \
+                 bootstrap (P2.3).",
+                index.alias,
+                index.git.as_deref().unwrap_or("?")
+            );
+        }
+        Ok(())
+    }
+}
+
+/// Run `git <args>` in `dir`, returning trimmed stdout or an error on failure.
+fn git_in(dir: &Path, args: &[&str]) -> eyre::Result<String> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .context("failed to run git")?;
+    if !output.status.success() {
+        bail!(
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Read the package version from `Cargo.toml` (`[package].version`) or
+/// `pyproject.toml` (`[project].version`), returning the first one found.
+fn read_native_version(dir: &Path) -> Option<String> {
+    if let Ok(raw) = std::fs::read_to_string(dir.join("Cargo.toml"))
+        && let Ok(t) = raw.parse::<toml::Table>()
+        && let Some(v) = t
+            .get("package")
+            .and_then(|p| p.get("version"))
+            .and_then(|v| v.as_str())
+    {
+        return Some(v.to_string());
+    }
+    if let Ok(raw) = std::fs::read_to_string(dir.join("pyproject.toml"))
+        && let Ok(t) = raw.parse::<toml::Table>()
+        && let Some(v) = t
+            .get("project")
+            .and_then(|p| p.get("version"))
+            .and_then(|v| v.as_str())
+    {
+        return Some(v.to_string());
+    }
+    None
+}

--- a/binaries/cli/src/command/hub/publish.rs
+++ b/binaries/cli/src/command/hub/publish.rs
@@ -59,36 +59,12 @@ impl Executable for Publish {
     fn execute(self) -> eyre::Result<()> {
         let dir = self.path.as_path();
 
-        // 1. Read and validate the manifest (spec §9.1 step 1).
-        let manifest_path = dir.join(MANIFEST_FILENAME);
-        let manifest = NodeManifest::read(&manifest_path).with_context(|| {
-            format!(
-                "failed to read {MANIFEST_FILENAME} at `{}`",
-                manifest_path.display()
-            )
-        })?;
-        manifest
-            .validate_strict(&TypeRegistry::new())
-            .context("the node manifest is invalid — fix it before publishing")?;
-        // `validate_strict` guarantees `name`/`namespace` are present and valid.
-        let name = manifest
-            .name
-            .clone()
-            .context("manifest is missing `name`")?;
-        let namespace = manifest.namespace.clone();
-
-        // 2. Version (read from the native manifest unless overridden).
-        let version_str = match &self.version {
-            Some(v) => v.clone(),
-            None => read_native_version(dir).context(
-                "could not determine the package version — pass `--version`, or set \
-                 `[package].version` (Cargo) / `[project].version` (pyproject)",
-            )?,
-        };
-        let version = semver::Version::parse(version_str.trim())
-            .with_context(|| format!("version `{version_str}` is not valid semver"))?;
-
-        // 3. Resolve the source pin (spec §9.1 step 2): repo + commit + subdir.
+        // 1. Resolve the source pin (spec §9.1 step 2): repo + commit + subdir.
+        // The manifest and version are then read from that *commit*, not the
+        // working tree — a published entry is immutable, so it must never
+        // describe files that aren't committed at `source.rev` (a dirty tree
+        // would otherwise append an entry whose manifest/version don't exist at
+        // the pin, and consumers would clone the old commit while trusting it).
         let repo = match &self.repo {
             Some(r) => r.trim().to_string(),
             None => git_in(dir, &["remote", "get-url", "origin"]).context(
@@ -111,11 +87,48 @@ impl Executable for Publish {
         if !matches!(commit.len(), 40 | 64) || !commit.chars().all(|c| c.is_ascii_hexdigit()) {
             bail!("resolved commit `{commit}` is not a full git hash (40 or 64 hex chars)");
         }
-        // subdir = the node directory's path within the repo (empty at root).
-        let subdir = git_in(dir, &["rev-parse", "--show-prefix"])
-            .ok()
-            .map(|p| p.trim_end_matches('/').to_string())
-            .filter(|p| !p.is_empty());
+        // `--show-prefix` is the node directory's repo-relative path (forward
+        // slashes, trailing slash, empty at the repo root). It both locates the
+        // committed files (`<commit>:<prefix><file>`) and becomes `source.subdir`.
+        let prefix = git_in(dir, &["rev-parse", "--show-prefix"])
+            .context("`dora hub publish` must be run inside the node's git repository")?;
+        let subdir = Some(prefix.trim_end_matches('/').to_string()).filter(|p| !p.is_empty());
+
+        // 2. Read + validate the manifest as committed at `commit`.
+        let manifest_yaml = git_in(
+            dir,
+            &["show", &format!("{commit}:{prefix}{MANIFEST_FILENAME}")],
+        )
+        .with_context(|| {
+            format!(
+                "{MANIFEST_FILENAME} is not committed at {} — commit it (and any \
+                     version bump) before publishing, or pass `--rev <commit>` that \
+                     contains it",
+                &commit[..12]
+            )
+        })?;
+        let manifest = NodeManifest::parse(&manifest_yaml)
+            .with_context(|| format!("invalid {MANIFEST_FILENAME} at commit {}", &commit[..12]))?;
+        manifest
+            .validate_strict(&TypeRegistry::new())
+            .context("the node manifest is invalid — fix it before publishing")?;
+        // `validate_strict` guarantees `name`/`namespace` are present and valid.
+        let name = manifest
+            .name
+            .clone()
+            .context("manifest is missing `name`")?;
+        let namespace = manifest.namespace.clone();
+
+        // 3. Version: `--version`, else read from the native manifest at `commit`.
+        let version_str = match &self.version {
+            Some(v) => v.clone(),
+            None => read_committed_version(dir, &commit, &prefix).context(
+                "could not determine the package version — pass `--version`, or commit \
+                 `[package].version` (Cargo) / `[project].version` (pyproject)",
+            )?,
+        };
+        let version = semver::Version::parse(version_str.trim())
+            .with_context(|| format!("version `{version_str}` is not valid semver"))?;
 
         // 4. Construct the index entry.
         let entry = IndexEntry {
@@ -245,9 +258,12 @@ fn git_in(dir: &Path, args: &[&str]) -> eyre::Result<String> {
 }
 
 /// Read the package version from `Cargo.toml` (`[package].version`) or
-/// `pyproject.toml` (`[project].version`), returning the first one found.
-fn read_native_version(dir: &Path) -> Option<String> {
-    if let Ok(raw) = std::fs::read_to_string(dir.join("Cargo.toml"))
+/// `pyproject.toml` (`[project].version`) **as committed at `commit`**,
+/// returning the first one found. `prefix` is the node directory's
+/// repo-relative path (forward slashes, trailing slash, empty at the root).
+fn read_committed_version(dir: &Path, commit: &str, prefix: &str) -> Option<String> {
+    let read = |file: &str| git_in(dir, &["show", &format!("{commit}:{prefix}{file}")]).ok();
+    if let Some(raw) = read("Cargo.toml")
         && let Ok(t) = raw.parse::<toml::Table>()
         && let Some(v) = t
             .get("package")
@@ -256,7 +272,7 @@ fn read_native_version(dir: &Path) -> Option<String> {
     {
         return Some(v.to_string());
     }
-    if let Ok(raw) = std::fs::read_to_string(dir.join("pyproject.toml"))
+    if let Some(raw) = read("pyproject.toml")
         && let Ok(t) = raw.parse::<toml::Table>()
         && let Some(v) = t
             .get("project")

--- a/binaries/cli/src/command/hub/publish.rs
+++ b/binaries/cli/src/command/hub/publish.rs
@@ -106,8 +106,10 @@ impl Executable for Publish {
         let rev_arg = self.rev.as_deref().unwrap_or("HEAD");
         let commit = git_in(dir, &["rev-parse", &format!("{rev_arg}^{{commit}}")])
             .with_context(|| format!("failed to resolve git ref `{rev_arg}` to a commit"))?;
-        if commit.len() != 40 || !commit.chars().all(|c| c.is_ascii_hexdigit()) {
-            bail!("resolved commit `{commit}` is not a full 40-char hash");
+        // Accept SHA-1 (40) or SHA-256 (64) hashes — the index resolver
+        // (`git_pin`) takes both, so publish must not be stricter.
+        if !matches!(commit.len(), 40 | 64) || !commit.chars().all(|c| c.is_ascii_hexdigit()) {
+            bail!("resolved commit `{commit}` is not a full git hash (40 or 64 hex chars)");
         }
         // subdir = the node directory's path within the repo (empty at root).
         let subdir = git_in(dir, &["rev-parse", "--show-prefix"])
@@ -133,19 +135,10 @@ impl Executable for Publish {
             serde_yaml::to_string(&entry).context("failed to serialize index entry")?;
         let rel_path = format!("{namespace}/{name}/{version}.yml");
 
-        // 5a. Dry run: validate + preview only.
-        if self.dry_run {
-            println!("# {rel_path}");
-            print!("{entry_yaml}");
-            println!(
-                "\nvalidated `{namespace}/{name}` v{version} @ {} (subdir: {})",
-                &commit[..12],
-                subdir.as_deref().unwrap_or(".")
-            );
-            return Ok(());
-        }
-
-        // 5b. Resolve the target index and publish.
+        // 5. Resolve the target index up-front so `--dry-run` validates the same
+        // `--index`/namespace binding a real publish would, and previews where
+        // the entry lands. `load_default` falls back to the official index when
+        // no hub.toml is present, so dry-run still works without a config.
         let config = ResolvedConfig::load_default().context("failed to load hub configuration")?;
         let index = match &self.index {
             Some(alias) => {
@@ -174,6 +167,19 @@ impl Executable for Publish {
             None => config.index_for_namespace(&namespace),
         };
 
+        // 5a. Dry run: validate + preview only.
+        if self.dry_run {
+            println!("# {rel_path} (index: {})", index.alias);
+            print!("{entry_yaml}");
+            println!(
+                "\nvalidated `{namespace}/{name}` v{version} @ {} (subdir: {})",
+                &commit[..12],
+                subdir.as_deref().unwrap_or(".")
+            );
+            return Ok(());
+        }
+
+        // 5b. Publish into the resolved index.
         if index.is_local() {
             let catalog = index.local_catalog_dir(&config.config_dir)?;
             let dest = catalog.join(&rel_path);

--- a/binaries/cli/src/command/hub/publish.rs
+++ b/binaries/cli/src/command/hub/publish.rs
@@ -96,6 +96,13 @@ impl Executable for Publish {
                  pass `--repo <url>`",
             )?,
         };
+        // The repo URL is consumed by others as an untrusted index source, and
+        // the resolver only accepts https/ssh/file/scp-style/abs-path forms.
+        // Validate it now so a cleartext-http or otherwise-unresolvable `origin`
+        // fails on the publisher, not silently on every later consumer.
+        dora_hub_client::validate_git_url_untrusted(&repo).with_context(|| {
+            format!("source repo `{repo}` is not a usable index source — pass a valid `--repo`")
+        })?;
         let rev_arg = self.rev.as_deref().unwrap_or("HEAD");
         let commit = git_in(dir, &["rev-parse", &format!("{rev_arg}^{{commit}}")])
             .with_context(|| format!("failed to resolve git ref `{rev_arg}` to a commit"))?;
@@ -141,30 +148,57 @@ impl Executable for Publish {
         // 5b. Resolve the target index and publish.
         let config = ResolvedConfig::load_default().context("failed to load hub configuration")?;
         let index = match &self.index {
-            Some(alias) => config
-                .indexes
-                .iter()
-                .find(|i| i.alias.eq_ignore_ascii_case(alias))
-                .with_context(|| format!("no index with alias `{alias}` in hub.toml"))?,
+            Some(alias) => {
+                let target = config
+                    .indexes
+                    .iter()
+                    .find(|i| i.alias.eq_ignore_ascii_case(alias))
+                    .with_context(|| format!("no index with alias `{alias}` in hub.toml"))?;
+                // A namespace resolves against exactly one index (spec §7.3).
+                // Refuse to seed a namespace into an index it isn't bound to —
+                // otherwise `--index` would let a `dora-rs/*` entry be written
+                // into any local index, defeating namespace binding.
+                let bound = config.index_for_namespace(&namespace);
+                if !bound.alias.eq_ignore_ascii_case(&target.alias) {
+                    bail!(
+                        "namespace `{namespace}` is bound to index `{}`, not `{}` — publish \
+                         into `{}`, or bind the namespace to `{}` in hub.toml",
+                        bound.alias,
+                        target.alias,
+                        bound.alias,
+                        target.alias
+                    );
+                }
+                target
+            }
             None => config.index_for_namespace(&namespace),
         };
 
         if index.is_local() {
             let catalog = index.local_catalog_dir(&config.config_dir)?;
             let dest = catalog.join(&rel_path);
-            // append-only: never overwrite a published version (spec §7.5).
-            if dest.exists() {
-                bail!(
-                    "version {version} of `{namespace}/{name}` already exists at `{}` — \
-                     the index is append-only; bump the version to publish a new one",
-                    dest.display()
-                );
-            }
             if let Some(parent) = dest.parent() {
                 std::fs::create_dir_all(parent)
                     .with_context(|| format!("failed to create `{}`", parent.display()))?;
             }
-            std::fs::write(&dest, &entry_yaml)
+            // append-only: create exclusively (O_EXCL) so a published version is
+            // never overwritten, even under a concurrent publish (spec §7.5).
+            let mut file = match std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&dest)
+            {
+                Ok(file) => file,
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => bail!(
+                    "version {version} of `{namespace}/{name}` already exists at `{}` — \
+                     the index is append-only; bump the version to publish a new one",
+                    dest.display()
+                ),
+                Err(e) => {
+                    return Err(e).with_context(|| format!("failed to write `{}`", dest.display()));
+                }
+            };
+            std::io::Write::write_all(&mut file, entry_yaml.as_bytes())
                 .with_context(|| format!("failed to write `{}`", dest.display()))?;
             println!(
                 "published `{namespace}/{name}` v{version} -> {}",

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1112,12 +1112,26 @@ dora hub info <pkg>[@<ver>]                # contracts + example for a package
 dora hub list <dataflow.yml>               # hub packages pinned in the lockfile
 dora hub fetch <dataflow.yml | pkg@ver>    # warm the index cache + mirror sources
                [--target-dir DIR]
+dora hub publish [PATH] [--dry-run]        # validate + add a pinned index entry
+                 [--rev REF] [--repo URL]
+                 [--version SEMVER] [--index ALIAS]
 ```
 
 `init` pre-fills the name, runtime, and entrypoint from `pyproject.toml` /
 `Cargo.toml` when present and the namespace from the `origin` git remote;
 typed inputs/outputs are left as commented examples. Check the result with
 `dora validate --node-manifest dora-node.yml`.
+
+`publish` validates the manifest, reads the version from `[package].version`
+(Cargo) / `[project].version` (pyproject), resolves the source pin (the
+`origin` remote or `--repo`, the `--rev`/`HEAD` commit, and the directory's
+subdir within the repo), and produces the index entry
+`<namespace>/<name>/<version>.yml`. `--dry-run` prints the entry without
+writing it. Otherwise it writes into a **local** (`path =`) index — the
+enterprise/private and fixture form — and refuses to overwrite an existing
+version (the index is append-only). For a git-backed index it prints the entry
+and where to add it; automated PR-opening against the official `node-index`
+lands with the index bootstrap.
 
 `search`/`info`/`fetch` accept `--offline` to use only the cached index.
 Indexes are configured in `~/.config/dora/hub.toml`; a namespace resolves

--- a/tests/hub-smoke.rs
+++ b/tests/hub-smoke.rs
@@ -738,6 +738,41 @@ fn hub_publish_then_build_resolves() {
     );
 }
 
+/// `--index` must not let a namespace be seeded into an index it isn't bound to
+/// (spec §7.3). The `test` namespace is bound to the local `smoke` index, so
+/// publishing it into the `official` index is rejected.
+#[test]
+fn hub_publish_rejects_index_not_bound_to_namespace() {
+    if Command::new("git").arg("--version").output().is_err() {
+        eprintln!("git not available — skipping hub publish wrong-index test");
+        return;
+    }
+    let fixture = build_fixture();
+    let src = fixture.root.join("source");
+    let checkout = src.join("node-hub/hello");
+    let out = dora(&fixture)
+        .args([
+            "hub",
+            "publish",
+            checkout.to_str().unwrap(),
+            "--repo",
+            &format!("file://{}", src.display()),
+            "--index",
+            "official",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "publishing into an unbound index must fail"
+    );
+    assert!(
+        stderr(&out).contains("is bound to index"),
+        "expected a namespace-binding rejection, got: {}",
+        stderr(&out)
+    );
+}
+
 fn stderr(out: &std::process::Output) -> String {
     String::from_utf8_lossy(&out.stderr).into_owned()
 }

--- a/tests/hub-smoke.rs
+++ b/tests/hub-smoke.rs
@@ -614,6 +614,130 @@ fn hub_override_rejects_remote_coordinator_even_if_unmatched() {
     );
 }
 
+/// `dora hub publish --dry-run` validates the manifest and previews the index
+/// entry (the version from Cargo.toml, the resolved git pin + subdir) without
+/// writing anything (P3.1).
+#[test]
+fn hub_publish_dry_run_previews_entry() {
+    if Command::new("git").arg("--version").output().is_err() {
+        eprintln!("git not available — skipping hub publish dry-run test");
+        return;
+    }
+    let fixture = build_fixture();
+    let src = fixture.root.join("source");
+    let checkout = src.join("node-hub/hello");
+    let out = dora(&fixture)
+        .args([
+            "hub",
+            "publish",
+            checkout.to_str().unwrap(),
+            "--dry-run",
+            "--repo",
+            &format!("file://{}", src.display()),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "publish --dry-run failed: {}",
+        stderr(&out)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // version 0.1.0 from Cargo.toml; subdir from the repo layout; name/namespace
+    assert!(
+        stdout.contains("test/hub-smoke-hello/0.1.0.yml"),
+        "expected the entry path in the preview:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("subdir: node-hub/hello"),
+        "expected the resolved subdir in the preview:\n{stdout}"
+    );
+    // dry run must not have written anything into the index
+    assert!(
+        !fixture
+            .root
+            .join("index/test/hub-smoke-hello/0.2.0.yml")
+            .exists(),
+        "dry-run must not write entries"
+    );
+}
+
+/// End-to-end: `dora hub publish` writes a pinned index entry that `dora build`
+/// then resolves and builds — the publish→consume loop, fully local (P3.1).
+#[test]
+fn hub_publish_then_build_resolves() {
+    if Command::new("git").arg("--version").output().is_err() {
+        eprintln!("git not available — skipping hub publish→build test");
+        return;
+    }
+    let fixture = build_fixture();
+    let src = fixture.root.join("source");
+    let checkout = src.join("node-hub/hello");
+
+    // remove the fixture's pre-written entry so `publish` creates it fresh
+    let entry = fixture.root.join("index/test/hub-smoke-hello/0.1.0.yml");
+    std::fs::remove_file(&entry).unwrap();
+
+    let out = dora(&fixture)
+        .args([
+            "hub",
+            "publish",
+            checkout.to_str().unwrap(),
+            "--repo",
+            &format!("file://{}", src.display()),
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "publish failed: {}", stderr(&out));
+    assert!(entry.exists(), "publish did not write the index entry");
+    let written = std::fs::read_to_string(&entry).unwrap();
+    assert!(
+        written.contains("subdir: node-hub/hello"),
+        "entry: {written}"
+    );
+    assert!(
+        written.contains("name: hub-smoke-hello"),
+        "entry must hold the manifest: {written}"
+    );
+
+    // append-only: re-publishing the same version is refused
+    let out = dora(&fixture)
+        .args([
+            "hub",
+            "publish",
+            checkout.to_str().unwrap(),
+            "--repo",
+            &format!("file://{}", src.display()),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "re-publishing same version must fail"
+    );
+    assert!(
+        stderr(&out).contains("already exists"),
+        "expected append-only rejection, got: {}",
+        stderr(&out)
+    );
+
+    // the published entry resolves end-to-end through `dora build`
+    write(
+        &fixture.root.join("flow/dataflow.yml"),
+        "nodes:\n  - id: hello\n    hub: test/hub-smoke-hello@^0.1\n",
+    );
+    let flow = fixture.root.join("flow/dataflow.yml");
+    let out = dora(&fixture)
+        .args(["build", flow.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "build of a freshly-published package failed: {}",
+        stderr(&out)
+    );
+}
+
 fn stderr(out: &std::process::Output) -> String {
     String::from_utf8_lossy(&out.stderr).into_owned()
 }

--- a/tests/hub-smoke.rs
+++ b/tests/hub-smoke.rs
@@ -738,6 +738,57 @@ fn hub_publish_then_build_resolves() {
     );
 }
 
+/// `dora hub publish` reads the manifest and version from the *committed*
+/// source at `source.rev`, not the working tree. A dirty version bump must not
+/// produce an immutable entry whose version doesn't exist at the pinned commit.
+#[test]
+fn hub_publish_reads_committed_source_not_worktree() {
+    if Command::new("git").arg("--version").output().is_err() {
+        eprintln!("git not available — skipping hub publish dirty-tree test");
+        return;
+    }
+    let fixture = build_fixture();
+    let src = fixture.root.join("source");
+    let checkout = src.join("node-hub/hello");
+
+    // free the committed version's slot so publish can write it fresh
+    std::fs::remove_file(fixture.root.join("index/test/hub-smoke-hello/0.1.0.yml")).unwrap();
+
+    // bump the version in the working tree WITHOUT committing it
+    write(
+        &checkout.join("Cargo.toml"),
+        "[package]\nname = \"hub-smoke-hello\"\nversion = \"0.9.9\"\nedition = \"2021\"\n\
+         \n[[bin]]\nname = \"hub-smoke-hello\"\npath = \"src/main.rs\"\n\n[workspace]\n",
+    );
+
+    let out = dora(&fixture)
+        .args([
+            "hub",
+            "publish",
+            checkout.to_str().unwrap(),
+            "--repo",
+            &format!("file://{}", src.display()),
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "publish failed: {}", stderr(&out));
+    // the committed 0.1.0 is published; the uncommitted 0.9.9 is ignored
+    assert!(
+        fixture
+            .root
+            .join("index/test/hub-smoke-hello/0.1.0.yml")
+            .exists(),
+        "publish must use the committed version (0.1.0)"
+    );
+    assert!(
+        !fixture
+            .root
+            .join("index/test/hub-smoke-hello/0.9.9.yml")
+            .exists(),
+        "publish must not embed the uncommitted working-tree version (0.9.9)"
+    );
+}
+
 /// `--index` must not let a namespace be seeded into an index it isn't bound to
 /// (spec §7.3). The `test` namespace is bound to the local `smoke` index, so
 /// publishing it into the `official` index is rejected.


### PR DESCRIPTION
## P3.1 — `dora hub publish`

First Phase 3 (publishing) deliverable. Publishing is just *adding an index entry that points at your source* — no upload, since the bytes already live in git (spec §9.1).

`dora hub publish [PATH]`:
1. reads + validates the node manifest (same gate as `dora validate --node-manifest`);
2. reads the version from `[package].version` (Cargo) / `[project].version` (pyproject), or `--version`;
3. resolves the source pin: repo (`origin` remote or `--repo`), the `--rev`/`HEAD` commit, and the directory's subdir within the repo;
4. constructs the index entry `<namespace>/<name>/<version>.yml`.

- `--dry-run` validates + prints the entry (no write).
- Writes into a **local** (`path =`) index — the enterprise/private and fixture form (UC8/UC11) — and refuses to overwrite an existing version (**append-only**, §7.5).
- For a git-backed index, prints the entry + where to add it. Automated PR-opening against the official `node-index` lands with the index bootstrap (P2.3, which lives in the `dora-rs/dora-hub` repo, tracked by #2201).

### Tests
- [x] `hub_publish_dry_run_previews_entry` — validates + previews, writes nothing
- [x] `hub_publish_then_build_resolves` — **full publish→build loop**: `dora hub publish` writes a pinned entry, `dora build` resolves and builds it; plus the append-only re-publish rejection
- [x] fmt + clippy clean, `cargo check --examples` green

### Scope note
P3.2 (`yank`/`outdated`/`update`) follows next. P3.3 (62-node migration) and P3.4 (index CI) are `dora-rs/dora-hub` repo work. Part of umbrella #2097.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
