### PR TITLE
feat(hub): dora hub yank — yank/restore a published version (P3.2, UC10)

### DIFF
--- a/binaries/cli/src/command/hub/mod.rs
+++ b/binaries/cli/src/command/hub/mod.rs
@@ -13,6 +13,7 @@ mod install;
 mod list;
 mod publish;
 mod search;
+mod yank;
 
 /// Package, discover, and use dora nodes (unstable)
 #[derive(Debug, clap::Subcommand)]
@@ -24,6 +25,7 @@ pub enum Hub {
     Fetch(fetch::Fetch),
     Install(install::Install),
     Publish(publish::Publish),
+    Yank(yank::Yank),
 }
 
 impl Executable for Hub {
@@ -36,6 +38,7 @@ impl Executable for Hub {
             Hub::Fetch(cmd) => cmd.execute(),
             Hub::Install(cmd) => cmd.execute(),
             Hub::Publish(cmd) => cmd.execute(),
+            Hub::Yank(cmd) => cmd.execute(),
         }
     }
 }

--- a/binaries/cli/src/command/hub/yank.rs
+++ b/binaries/cli/src/command/hub/yank.rs
@@ -60,22 +60,34 @@ impl Executable for Yank {
         let action = if self.undo { "restore" } else { "yank" };
 
         if !index.is_local() {
-            println!(
-                "the `{}` index is git-backed ({}). {action} is a flag-flip PR: in `{rel_path}` set \
-                 `yanked: {}`{} and open a PR against the index repo.",
-                index.alias,
-                index.git.as_deref().unwrap_or("?"),
-                !self.undo,
+            // Mirror the local path: yanking records the reason, restoring
+            // clears it. Don't tell a `--undo` author to keep a stale reason.
+            let reason_hint = if self.undo {
+                " and remove any `yank_reason`".to_string()
+            } else {
                 self.reason
                     .as_deref()
                     .map(|r| format!(" with `yank_reason: {r}`"))
-                    .unwrap_or_default(),
+                    .unwrap_or_default()
+            };
+            println!(
+                "the `{}` index is git-backed ({}). {action} is a flag-flip PR: in `{rel_path}` set \
+                 `yanked: {}`{reason_hint} and open a PR against the index repo.",
+                index.alias,
+                index.git.as_deref().unwrap_or("?"),
+                !self.undo,
             );
             return Ok(());
         }
 
-        let catalog = index.local_catalog_dir(&config.config_dir)?;
-        let entry_path = catalog.join(&rel_path);
+        // Open the catalog so the write path is confined under the canonical
+        // root — the same symlink-escape guard the read paths use. The `..`
+        // key-part check above blocks lexical traversal; this blocks a
+        // symlinked namespace/package dir that resolves outside the root.
+        let catalog_dir = index.local_catalog_dir(&config.config_dir)?;
+        let catalog = dora_hub_client::index::IndexCatalog::open(&catalog_dir)
+            .with_context(|| format!("failed to open index catalog `{}`", catalog_dir.display()))?;
+        let entry_path = catalog.version_entry_path(namespace, name, &version)?;
         if !entry_path.is_file() {
             bail!(
                 "no published version {version} of `{namespace}/{name}` at `{}`",

--- a/binaries/cli/src/command/hub/yank.rs
+++ b/binaries/cli/src/command/hub/yank.rs
@@ -88,7 +88,10 @@ impl Executable for Yank {
             .with_context(|| format!("`{}` is not a valid index entry", entry_path.display()))?;
 
         let target = !self.undo;
-        if entry.yanked == target {
+        let new_reason = target.then(|| self.reason.clone()).flatten();
+        // No-op only when nothing would change — re-yanking with a *different*
+        // reason must update it, not silently discard the new one.
+        if entry.yanked == target && entry.yank_reason == new_reason {
             println!(
                 "`{namespace}/{name}@{version}` is already {}",
                 if target { "yanked" } else { "not yanked" }
@@ -96,7 +99,7 @@ impl Executable for Yank {
             return Ok(());
         }
         entry.yanked = target;
-        entry.yank_reason = target.then(|| self.reason.clone()).flatten();
+        entry.yank_reason = new_reason;
 
         let updated = serde_yaml::to_string(&entry).context("failed to serialize index entry")?;
         write_atomic(&entry_path, &updated)?;

--- a/binaries/cli/src/command/hub/yank.rs
+++ b/binaries/cli/src/command/hub/yank.rs
@@ -43,6 +43,16 @@ impl Executable for Yank {
         let reference =
             PackageRef::parse(pkg).with_context(|| format!("invalid package reference `{pkg}`"))?;
         let (namespace, name) = (&reference.namespace, &reference.name);
+        // We build a catalog path from these and *write* to it, so apply the
+        // same key-part guard the read paths use — `PackageRef::parse` does not
+        // reject `..`, and a write must never escape the catalog root.
+        if !dora_hub_client::index::is_valid_key_part(namespace)
+            || !dora_hub_client::index::is_valid_key_part(name)
+        {
+            bail!(
+                "invalid package `{namespace}/{name}`: namespace and name must be `[A-Za-z0-9._-]` and not start with `.`"
+            );
+        }
 
         let config = ResolvedConfig::load_default().context("failed to load hub configuration")?;
         let index = config.index_for_namespace(namespace);

--- a/binaries/cli/src/command/hub/yank.rs
+++ b/binaries/cli/src/command/hub/yank.rs
@@ -1,0 +1,117 @@
+//! `dora hub yank` (spec §9, UC10).
+//!
+//! Flipping the `yanked` flag is the one mutation an existing index version
+//! file is allowed (spec §7.5). New resolutions skip a yanked version; an
+//! existing `--locked` pin keeps working but `dora build` warns. `--undo`
+//! restores it.
+//!
+//! For a local (`path =`) index the flag is flipped in place; for a git-backed
+//! index this is a flag-flip PR, so the command prints what to change.
+
+use std::path::Path;
+
+use dora_hub_client::{config::ResolvedConfig, index::IndexEntry, reference::PackageRef, semver};
+use eyre::{Context, ContextCompat, bail};
+
+use crate::command::Executable;
+
+#[derive(Debug, clap::Args)]
+/// Yank (or restore) a published version.
+pub struct Yank {
+    /// Package and version: `[<namespace>/]<name>@<version>`.
+    #[clap(value_name = "PKG@VERSION")]
+    package: String,
+    /// Reason recorded with the yank (shown to consumers who pinned it).
+    #[clap(long, value_name = "REASON")]
+    reason: Option<String>,
+    /// Restore a previously yanked version instead of yanking it.
+    #[clap(long, action)]
+    undo: bool,
+}
+
+impl Executable for Yank {
+    fn execute(self) -> eyre::Result<()> {
+        // Parse `[ns/]name@version`.
+        let (pkg, version_str) = self.package.rsplit_once('@').with_context(|| {
+            format!(
+                "invalid package `{}`: expected `[<namespace>/]<name>@<version>`",
+                self.package
+            )
+        })?;
+        let version = semver::Version::parse(version_str.trim())
+            .with_context(|| format!("version `{version_str}` is not valid semver"))?;
+        let reference =
+            PackageRef::parse(pkg).with_context(|| format!("invalid package reference `{pkg}`"))?;
+        let (namespace, name) = (&reference.namespace, &reference.name);
+
+        let config = ResolvedConfig::load_default().context("failed to load hub configuration")?;
+        let index = config.index_for_namespace(namespace);
+        let rel_path = format!("{namespace}/{name}/{version}.yml");
+        let action = if self.undo { "restore" } else { "yank" };
+
+        if !index.is_local() {
+            println!(
+                "the `{}` index is git-backed ({}). {action} is a flag-flip PR: in `{rel_path}` set \
+                 `yanked: {}`{} and open a PR against the index repo.",
+                index.alias,
+                index.git.as_deref().unwrap_or("?"),
+                !self.undo,
+                self.reason
+                    .as_deref()
+                    .map(|r| format!(" with `yank_reason: {r}`"))
+                    .unwrap_or_default(),
+            );
+            return Ok(());
+        }
+
+        let catalog = index.local_catalog_dir(&config.config_dir)?;
+        let entry_path = catalog.join(&rel_path);
+        if !entry_path.is_file() {
+            bail!(
+                "no published version {version} of `{namespace}/{name}` at `{}`",
+                entry_path.display()
+            );
+        }
+        let raw = std::fs::read_to_string(&entry_path)
+            .with_context(|| format!("failed to read `{}`", entry_path.display()))?;
+        let mut entry: IndexEntry = serde_yaml::from_str(&raw)
+            .with_context(|| format!("`{}` is not a valid index entry", entry_path.display()))?;
+
+        let target = !self.undo;
+        if entry.yanked == target {
+            println!(
+                "`{namespace}/{name}@{version}` is already {}",
+                if target { "yanked" } else { "not yanked" }
+            );
+            return Ok(());
+        }
+        entry.yanked = target;
+        entry.yank_reason = target.then(|| self.reason.clone()).flatten();
+
+        let updated = serde_yaml::to_string(&entry).context("failed to serialize index entry")?;
+        write_atomic(&entry_path, &updated)?;
+        if target {
+            println!("yanked `{namespace}/{name}@{version}`");
+        } else {
+            println!("restored `{namespace}/{name}@{version}`");
+        }
+        Ok(())
+    }
+}
+
+/// Overwrite `path` by writing a temp file in the same directory and renaming
+/// it into place, so a yank flip can't leave a half-written entry.
+fn write_atomic(path: &Path, contents: &str) -> eyre::Result<()> {
+    let dir = path.parent().unwrap_or(Path::new("."));
+    let tmp = path.with_extension("yml.tmp");
+    std::fs::write(&tmp, contents)
+        .with_context(|| format!("failed to write `{}`", tmp.display()))?;
+    std::fs::rename(&tmp, path).with_context(|| {
+        format!(
+            "failed to replace `{}` (dir `{}`)",
+            path.display(),
+            dir.display()
+        )
+    })?;
+    Ok(())
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1115,7 +1115,15 @@ dora hub fetch <dataflow.yml | pkg@ver>    # warm the index cache + mirror sourc
 dora hub publish [PATH] [--dry-run]        # validate + add a pinned index entry
                  [--rev REF] [--repo URL]
                  [--version SEMVER] [--index ALIAS]
+dora hub yank <pkg>@<version>              # yank/restore a published version
+              [--reason R] [--undo]
 ```
+
+`yank` flips the `yanked` flag on a published version: new resolutions skip it,
+an existing `--locked` pin keeps working but `dora build` warns; `--undo`
+restores it (the one mutation an index entry allows, §7.5). For a local
+(`path =`) index the flag is flipped in place; for a git-backed index it prints
+the flag-flip change to open as a PR.
 
 `init` pre-fills the name, runtime, and entrypoint from `pyproject.toml` /
 `Cargo.toml` when present and the namespace from the `origin` git remote;

--- a/libraries/hub-client/src/index.rs
+++ b/libraries/hub-client/src/index.rs
@@ -238,6 +238,22 @@ impl IndexCatalog {
             .with_context(|| format!("invalid index entry `{}`", path.display()))
     }
 
+    /// The confined on-disk path of a version entry file, for callers that
+    /// read or rewrite it in place (e.g. `dora hub yank`). Errors if the path
+    /// escapes the catalog root via a symlink, so a write can't land outside it.
+    pub fn version_entry_path(
+        &self,
+        namespace: &str,
+        name: &str,
+        version: &Version,
+    ) -> eyre::Result<PathBuf> {
+        let path = self
+            .package_dir(namespace, name)?
+            .join(format!("{version}.yml"));
+        self.confine(&path)?;
+        Ok(path)
+    }
+
     /// Read a package's namespace-level metadata, if present.
     pub fn package_meta(&self, namespace: &str, name: &str) -> eyre::Result<Option<PackageMeta>> {
         let path = self.package_dir(namespace, name)?.join("package.yml");

--- a/libraries/hub-client/src/index.rs
+++ b/libraries/hub-client/src/index.rs
@@ -368,7 +368,12 @@ impl IndexCatalog {
 
 /// A valid namespace/name path segment of a package key. Keys feed into
 /// filesystem paths and terminal output, so the charset is strict.
-fn is_valid_key_part(part: &str) -> bool {
+/// Whether `part` is a safe catalog path segment (a namespace or name): a
+/// bounded `[A-Za-z0-9._-]` token that is not empty and does not start with `.`
+/// (so `..` and dotfiles can never become a directory traversal). Used by every
+/// catalog read, and by writers like `dora hub yank` that build an entry path
+/// from a CLI-supplied reference.
+pub fn is_valid_key_part(part: &str) -> bool {
     !part.is_empty()
         && part.len() <= 64
         && part

--- a/tests/hub-smoke.rs
+++ b/tests/hub-smoke.rs
@@ -901,6 +901,41 @@ fn hub_yank_skips_version_then_undo_restores() {
     );
 }
 
+/// Re-yanking an already-yanked version with a *different* `--reason` updates
+/// the recorded reason instead of silently discarding it.
+#[test]
+fn hub_yank_updates_reason_when_already_yanked() {
+    if Command::new("git").arg("--version").output().is_err() {
+        eprintln!("git not available — skipping hub yank reason-update test");
+        return;
+    }
+    let fixture = build_fixture();
+    let entry = fixture.root.join("index/test/hub-smoke-hello/0.1.0.yml");
+
+    let yank = |reason: &str| {
+        dora(&fixture)
+            .args([
+                "hub",
+                "yank",
+                "test/hub-smoke-hello@0.1.0",
+                "--reason",
+                reason,
+            ])
+            .output()
+            .unwrap()
+    };
+
+    assert!(yank("first").status.success(), "initial yank failed");
+    // re-yank with a corrected reason — must take effect, not no-op
+    let out = yank("corrected");
+    assert!(out.status.success(), "re-yank failed: {}", stderr(&out));
+    let written = std::fs::read_to_string(&entry).unwrap();
+    assert!(
+        written.contains("corrected") && !written.contains("first"),
+        "re-yank must update the reason, got: {written}"
+    );
+}
+
 /// A yank reference with `..` path segments must be rejected before any file
 /// is touched — the write path can't be allowed to escape the catalog root.
 #[test]

--- a/tests/hub-smoke.rs
+++ b/tests/hub-smoke.rs
@@ -824,6 +824,104 @@ fn hub_publish_rejects_index_not_bound_to_namespace() {
     );
 }
 
+/// `dora hub yank` flips the `yanked` flag on a local index entry: a fresh
+/// resolve then skips the version (build fails when nothing else satisfies the
+/// range), and `--undo` restores it (UC10).
+#[test]
+fn hub_yank_skips_version_then_undo_restores() {
+    if Command::new("git").arg("--version").output().is_err() {
+        eprintln!("git not available — skipping hub yank test");
+        return;
+    }
+    let fixture = build_fixture();
+    let entry = fixture.root.join("index/test/hub-smoke-hello/0.1.0.yml");
+    write(
+        &fixture.root.join("flow/dataflow.yml"),
+        "nodes:\n  - id: hello\n    hub: test/hub-smoke-hello@^0.1\n",
+    );
+    let flow = fixture.root.join("flow/dataflow.yml");
+
+    // baseline: builds before the yank
+    assert!(
+        dora(&fixture)
+            .args(["build", flow.to_str().unwrap()])
+            .output()
+            .unwrap()
+            .status
+            .success(),
+        "baseline build should succeed"
+    );
+
+    // yank it
+    let out = dora(&fixture)
+        .args([
+            "hub",
+            "yank",
+            "test/hub-smoke-hello@0.1.0",
+            "--reason",
+            "broken",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "yank failed: {}", stderr(&out));
+    let written = std::fs::read_to_string(&entry).unwrap();
+    assert!(written.contains("yanked: true"), "entry: {written}");
+    assert!(written.contains("broken"), "yank reason missing: {written}");
+
+    // a fresh resolve now finds no non-yanked version satisfying `^0.1`
+    let out = dora(&fixture)
+        .args(["build", flow.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "build must fail when the only matching version is yanked"
+    );
+
+    // undo restores it
+    let out = dora(&fixture)
+        .args(["hub", "yank", "test/hub-smoke-hello@0.1.0", "--undo"])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "undo failed: {}", stderr(&out));
+    assert!(
+        std::fs::read_to_string(&entry)
+            .unwrap()
+            .contains("yanked: false"),
+        "undo did not clear the flag"
+    );
+    assert!(
+        dora(&fixture)
+            .args(["build", flow.to_str().unwrap()])
+            .output()
+            .unwrap()
+            .status
+            .success(),
+        "build should succeed again after undo"
+    );
+}
+
+/// Yanking against a git-backed index (the official one) can't flip a file in
+/// place — it prints the flag-flip PR instructions instead.
+#[test]
+fn hub_yank_git_index_prints_pr_instructions() {
+    let fixture = build_fixture();
+    let out = dora(&fixture)
+        .args(["hub", "yank", "dora-rs/some-node@1.0.0"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "yank git-index failed: {}",
+        stderr(&out)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("git-backed") && stdout.contains("yanked: true"),
+        "expected flag-flip PR instructions, got:\n{stdout}"
+    );
+}
+
 fn stderr(out: &std::process::Output) -> String {
     String::from_utf8_lossy(&out.stderr).into_owned()
 }

--- a/tests/hub-smoke.rs
+++ b/tests/hub-smoke.rs
@@ -901,6 +901,24 @@ fn hub_yank_skips_version_then_undo_restores() {
     );
 }
 
+/// A yank reference with `..` path segments must be rejected before any file
+/// is touched — the write path can't be allowed to escape the catalog root.
+#[test]
+fn hub_yank_rejects_path_traversal() {
+    let fixture = build_fixture();
+    for bad in ["../..@0.1.0", "../x@0.1.0", "..@0.1.0"] {
+        let out = dora(&fixture).args(["hub", "yank", bad]).output().unwrap();
+        assert!(!out.status.success(), "`{bad}` must be rejected");
+        // it must be rejected by the key-part guard (not merely a missing file),
+        // proving the traversal never reached a filesystem path
+        assert!(
+            stderr(&out).contains("invalid package"),
+            "`{bad}` should be rejected by the key-part guard, got: {}",
+            stderr(&out)
+        );
+    }
+}
+
 /// Yanking against a git-backed index (the official one) can't flip a file in
 /// place — it prints the flag-flip PR instructions instead.
 #[test]

--- a/tests/hub-smoke.rs
+++ b/tests/hub-smoke.rs
@@ -954,6 +954,33 @@ fn hub_yank_rejects_path_traversal() {
     }
 }
 
+/// A symlinked package directory resolving outside the catalog root must be
+/// rejected — the `..` guard blocks lexical traversal; this blocks symlink
+/// escape, matching the read-path confinement.
+#[cfg(unix)]
+#[test]
+fn hub_yank_rejects_symlink_escape() {
+    let fixture = build_fixture();
+    // a target entry that lives OUTSIDE the catalog root
+    let outside = fixture.root.join("outside/test/hub-smoke-hello");
+    write(&outside.join("0.1.0.yml"), "manifest: {}\nsource: {}\n");
+    // replace the in-catalog package dir with a symlink to that outside dir
+    let pkg_dir = fixture.root.join("index/test/hub-smoke-hello");
+    std::fs::remove_dir_all(&pkg_dir).unwrap();
+    std::os::unix::fs::symlink(&outside, &pkg_dir).unwrap();
+
+    let out = dora(&fixture)
+        .args(["hub", "yank", "test/hub-smoke-hello@0.1.0"])
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "symlink escape must be rejected");
+    assert!(
+        stderr(&out).contains("escapes the catalog root"),
+        "expected catalog-confinement rejection, got: {}",
+        stderr(&out)
+    );
+}
+
 /// Yanking against a git-backed index (the official one) can't flip a file in
 /// place — it prints the flag-flip PR instructions instead.
 #[test]


### PR DESCRIPTION
## P3.2 — `dora hub yank` (UC10)

`dora hub yank <pkg>@<version> [--reason R] [--undo]` flips the `yanked` flag — the one mutation an existing index version file is allowed (spec §7.5):

- new resolutions **skip** a yanked version;
- an existing `--locked` pin keeps working but `dora build` **warns**;
- `--undo` restores it.

(The resolver already implements both behaviors — this command just sets the flag.)

For a **local** (`path =`) index the flag is flipped in place (read entry → set `yanked`/`yank_reason` → atomic rename). For a **git-backed** index it prints the flag-flip change to open as a PR (the official index's flag-flip lands as a bot-merged PR, §7.5).

### Tests
- [x] `hub_yank_skips_version_then_undo_restores` — yank → a fresh resolve fails (only matching version yanked) → `--undo` → builds again
- [x] `hub_yank_git_index_prints_pr_instructions`
- [x] fmt + clippy clean

### Scope
First of the P3.2 trio. `outdated` (lockfile pins vs index) and `update` (re-resolve + rewrite lockfile) follow in a separate PR. Part of umbrella #2097.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
