### PR TITLE
feat(hub): dora hub outdated — locked hub pins behind the index (P3.2)

### DIFF
--- a/binaries/cli/src/command/hub/mod.rs
+++ b/binaries/cli/src/command/hub/mod.rs
@@ -11,6 +11,7 @@ mod info;
 mod init;
 mod install;
 mod list;
+mod outdated;
 mod publish;
 mod search;
 mod yank;
@@ -26,6 +27,7 @@ pub enum Hub {
     Install(install::Install),
     Publish(publish::Publish),
     Yank(yank::Yank),
+    Outdated(outdated::Outdated),
 }
 
 impl Executable for Hub {
@@ -39,6 +41,7 @@ impl Executable for Hub {
             Hub::Install(cmd) => cmd.execute(),
             Hub::Publish(cmd) => cmd.execute(),
             Hub::Yank(cmd) => cmd.execute(),
+            Hub::Outdated(cmd) => cmd.execute(),
         }
     }
 }

--- a/binaries/cli/src/command/hub/outdated.rs
+++ b/binaries/cli/src/command/hub/outdated.rs
@@ -34,6 +34,7 @@ impl Executable for Outdated {
 
         let mut checked = 0usize;
         let mut outdated = 0usize;
+        let mut errored = 0usize;
         for (node_id, source) in &lockfile.git_sources {
             let Some(hub) = &source.hub else {
                 continue;
@@ -44,6 +45,7 @@ impl Executable for Outdated {
             // before echoing, and treat a malformed pin as "can't check".
             let Some((namespace, name)) = hub.name.split_once('/') else {
                 println!("{node_id}: malformed hub name `{}`", sanitize(&hub.name));
+                errored += 1;
                 continue;
             };
             let pinned = match hub.version.parse::<dora_hub_client::semver::Version>() {
@@ -53,6 +55,7 @@ impl Executable for Outdated {
                         "{node_id}: malformed pinned version `{}`",
                         sanitize(&hub.version)
                     );
+                    errored += 1;
                     continue;
                 }
             };
@@ -65,6 +68,7 @@ impl Executable for Outdated {
                         sanitize(namespace),
                         sanitize(name)
                     );
+                    errored += 1;
                     continue;
                 }
             };
@@ -86,24 +90,32 @@ impl Executable for Outdated {
                     );
                 }
                 Ok(_) => {} // up to date
-                Err(err) => println!(
-                    "{node_id}: {}/{} {pinned} — {err:#}",
-                    sanitize(namespace),
-                    sanitize(name)
-                ),
+                Err(err) => {
+                    println!(
+                        "{node_id}: {}/{} {pinned} — {err:#}",
+                        sanitize(namespace),
+                        sanitize(name)
+                    );
+                    errored += 1;
+                }
             }
         }
         ctx.drain_warnings();
 
         if checked == 0 {
             println!("No hub packages pinned in {}.", lockfile_path.display());
-        } else if outdated == 0 {
-            println!("All {checked} hub package(s) are up to date.");
-        } else {
+        } else if outdated > 0 {
             println!(
                 "{outdated} of {checked} hub package(s) are outdated — \
                  update the `hub:` range and rebuild to upgrade."
             );
+        } else if errored == 0 {
+            println!("All {checked} hub package(s) are up to date.");
+        }
+        // A check that couldn't complete must not read as "up to date": report
+        // it and exit non-zero so a human or CI can tell the report is partial.
+        if errored > 0 {
+            eyre::bail!("{errored} of {checked} hub package(s) could not be checked (see above)");
         }
         Ok(())
     }

--- a/binaries/cli/src/command/hub/outdated.rs
+++ b/binaries/cli/src/command/hub/outdated.rs
@@ -1,0 +1,110 @@
+//! `dora hub outdated` (spec §9): compare a dataflow's locked hub pins against
+//! the latest non-yanked version available in the index.
+
+use std::path::PathBuf;
+
+use dora_hub_client::{reference::PackageRef, semver::VersionReq};
+
+use super::common::{HubContext, sanitize};
+use crate::command::{Executable, build::lockfile::BuildLockfile};
+
+/// Show hub packages whose lockfile pin is behind the index.
+#[derive(Debug, clap::Args)]
+pub struct Outdated {
+    /// Dataflow whose lockfile to check.
+    #[clap(value_name = "DATAFLOW")]
+    dataflow: PathBuf,
+    /// Do not refresh the index over the network; use only the cached copy.
+    #[clap(long, action)]
+    offline: bool,
+}
+
+impl Executable for Outdated {
+    fn execute(self) -> eyre::Result<()> {
+        let lockfile_path = BuildLockfile::path_for_dataflow(&self.dataflow, None);
+        if !lockfile_path.exists() {
+            eyre::bail!(
+                "no lockfile at `{}` — run `dora build --write-lockfile {}` first",
+                lockfile_path.display(),
+                self.dataflow.display()
+            );
+        }
+        let lockfile = BuildLockfile::read_from(&lockfile_path)?;
+        let mut ctx = HubContext::load(self.offline)?;
+
+        let mut checked = 0usize;
+        let mut outdated = 0usize;
+        for (node_id, source) in &lockfile.git_sources {
+            let Some(hub) = &source.hub else {
+                continue;
+            };
+            checked += 1;
+            // `hub.name` is `namespace/name`; `hub.version` the pinned version.
+            // Both come from the lockfile (not charset-validated) — sanitize
+            // before echoing, and treat a malformed pin as "can't check".
+            let Some((namespace, name)) = hub.name.split_once('/') else {
+                println!("{node_id}: malformed hub name `{}`", sanitize(&hub.name));
+                continue;
+            };
+            let pinned = match hub.version.parse::<dora_hub_client::semver::Version>() {
+                Ok(v) => v,
+                Err(_) => {
+                    println!(
+                        "{node_id}: malformed pinned version `{}`",
+                        sanitize(&hub.version)
+                    );
+                    continue;
+                }
+            };
+
+            let catalog = match ctx.catalog_for_namespace(namespace) {
+                Ok(catalog) => catalog,
+                Err(err) => {
+                    println!(
+                        "{node_id}: {}/{} — could not read index ({err:#})",
+                        sanitize(namespace),
+                        sanitize(name)
+                    );
+                    continue;
+                }
+            };
+            // the highest *non-yanked* version (ignoring the dataflow's range,
+            // so a major bump still shows as available to upgrade to).
+            let reference = PackageRef {
+                namespace: namespace.to_string(),
+                name: name.to_string(),
+                requirement: VersionReq::STAR,
+            };
+            match catalog.resolve(&reference) {
+                Ok(latest) if latest.version > pinned => {
+                    outdated += 1;
+                    println!(
+                        "{node_id}: {}/{} {pinned} -> {} (newer available)",
+                        sanitize(namespace),
+                        sanitize(name),
+                        latest.version
+                    );
+                }
+                Ok(_) => {} // up to date
+                Err(err) => println!(
+                    "{node_id}: {}/{} {pinned} — {err:#}",
+                    sanitize(namespace),
+                    sanitize(name)
+                ),
+            }
+        }
+        ctx.drain_warnings();
+
+        if checked == 0 {
+            println!("No hub packages pinned in {}.", lockfile_path.display());
+        } else if outdated == 0 {
+            println!("All {checked} hub package(s) are up to date.");
+        } else {
+            println!(
+                "{outdated} of {checked} hub package(s) are outdated — \
+                 update the `hub:` range and rebuild to upgrade."
+            );
+        }
+        Ok(())
+    }
+}

--- a/binaries/cli/src/command/hub/outdated.rs
+++ b/binaries/cli/src/command/hub/outdated.rs
@@ -40,11 +40,14 @@ impl Executable for Outdated {
                 continue;
             };
             checked += 1;
-            // `hub.name` is `namespace/name`; `hub.version` the pinned version.
-            // Both come from the lockfile (not charset-validated) — sanitize
-            // before echoing, and treat a malformed pin as "can't check".
+            // The node id, hub name, and version all come from the lockfile,
+            // and resolve errors embed the lockfile-derived package key — none
+            // are charset-validated, so sanitize every one before echoing (a
+            // hostile entry could otherwise inject terminal escapes). Treat a
+            // malformed pin as "can't check".
+            let node = sanitize(node_id.as_ref());
             let Some((namespace, name)) = hub.name.split_once('/') else {
-                println!("{node_id}: malformed hub name `{}`", sanitize(&hub.name));
+                println!("{node}: malformed hub name `{}`", sanitize(&hub.name));
                 errored += 1;
                 continue;
             };
@@ -52,7 +55,7 @@ impl Executable for Outdated {
                 Ok(v) => v,
                 Err(_) => {
                     println!(
-                        "{node_id}: malformed pinned version `{}`",
+                        "{node}: malformed pinned version `{}`",
                         sanitize(&hub.version)
                     );
                     errored += 1;
@@ -64,9 +67,10 @@ impl Executable for Outdated {
                 Ok(catalog) => catalog,
                 Err(err) => {
                     println!(
-                        "{node_id}: {}/{} — could not read index ({err:#})",
+                        "{node}: {}/{} — could not read index ({})",
                         sanitize(namespace),
-                        sanitize(name)
+                        sanitize(name),
+                        sanitize(&format!("{err:#}"))
                     );
                     errored += 1;
                     continue;
@@ -83,7 +87,7 @@ impl Executable for Outdated {
                 Ok(latest) if latest.version > pinned => {
                     outdated += 1;
                     println!(
-                        "{node_id}: {}/{} {pinned} -> {} (newer available)",
+                        "{node}: {}/{} {pinned} -> {} (newer available)",
                         sanitize(namespace),
                         sanitize(name),
                         latest.version
@@ -92,9 +96,10 @@ impl Executable for Outdated {
                 Ok(_) => {} // up to date
                 Err(err) => {
                     println!(
-                        "{node_id}: {}/{} {pinned} — {err:#}",
+                        "{node}: {}/{} {pinned} — {}",
                         sanitize(namespace),
-                        sanitize(name)
+                        sanitize(name),
+                        sanitize(&format!("{err:#}"))
                     );
                     errored += 1;
                 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1117,6 +1117,8 @@ dora hub publish [PATH] [--dry-run]        # validate + add a pinned index entry
                  [--version SEMVER] [--index ALIAS]
 dora hub yank <pkg>@<version>              # yank/restore a published version
               [--reason R] [--undo]
+dora hub outdated <dataflow.yml>           # locked hub pins behind the index
+                  [--offline]
 ```
 
 `yank` flips the `yanked` flag on a published version: new resolutions skip it,
@@ -1124,6 +1126,11 @@ an existing `--locked` pin keeps working but `dora build` warns; `--undo`
 restores it (the one mutation an index entry allows, §7.5). For a local
 (`path =`) index the flag is flipped in place; for a git-backed index it prints
 the flag-flip change to open as a PR.
+
+`outdated` reads a dataflow's lockfile and, for each pinned hub package,
+compares the pin against the latest non-yanked version in the index (ignoring
+the dataflow's range, so a major/minor bump still shows up). Update the `hub:`
+range and rebuild to upgrade.
 
 `init` pre-fills the name, runtime, and entrypoint from `pyproject.toml` /
 `Cargo.toml` when present and the namespace from the `origin` git remote;

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1128,9 +1128,10 @@ restores it (the one mutation an index entry allows, §7.5). For a local
 the flag-flip change to open as a PR.
 
 `outdated` reads a dataflow's lockfile and, for each pinned hub package,
-compares the pin against the latest non-yanked version in the index (ignoring
-the dataflow's range, so a major/minor bump still shows up). Update the `hub:`
-range and rebuild to upgrade.
+compares the pin against the latest non-yanked **stable** version in the index
+(ignoring the dataflow's range, so a major/minor bump still shows up;
+pre-releases are not reported, matching resolution). Update the `hub:` range and
+rebuild to upgrade. Exits non-zero if any package could not be checked.
 
 `init` pre-fills the name, runtime, and entrypoint from `pyproject.toml` /
 `Cargo.toml` when present and the namespace from the `origin` git remote;

--- a/tests/hub-smoke.rs
+++ b/tests/hub-smoke.rs
@@ -1002,6 +1002,60 @@ fn hub_yank_git_index_prints_pr_instructions() {
     );
 }
 
+/// `dora hub outdated` reports a hub pin that is behind the index's latest
+/// non-yanked version, and says nothing when up to date (P3.2).
+#[test]
+fn hub_outdated_reports_newer_version() {
+    if Command::new("git").arg("--version").output().is_err() {
+        eprintln!("git not available — skipping hub outdated test");
+        return;
+    }
+    let fixture = build_fixture();
+    write(
+        &fixture.root.join("flow/dataflow.yml"),
+        "nodes:\n  - id: hello\n    hub: test/hub-smoke-hello@^0.1\n",
+    );
+    let flow = fixture.root.join("flow/dataflow.yml");
+    // pin 0.1.0 in the lockfile
+    assert!(
+        dora(&fixture)
+            .args(["build", flow.to_str().unwrap(), "--write-lockfile"])
+            .output()
+            .unwrap()
+            .status
+            .success(),
+        "build --write-lockfile should succeed"
+    );
+
+    // only 0.1.0 exists -> up to date
+    let out = dora(&fixture)
+        .args(["hub", "outdated", flow.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "outdated failed: {}", stderr(&out));
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("up to date"),
+        "expected up-to-date, got:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+
+    // add a newer version into the index (copy the 0.1.0 entry to 0.2.0)
+    let entry_010 = fixture.root.join("index/test/hub-smoke-hello/0.1.0.yml");
+    let entry_020 = fixture.root.join("index/test/hub-smoke-hello/0.2.0.yml");
+    std::fs::copy(&entry_010, &entry_020).unwrap();
+
+    let out = dora(&fixture)
+        .args(["hub", "outdated", flow.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "outdated failed: {}", stderr(&out));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("0.1.0 -> 0.2.0") && stdout.contains("newer available"),
+        "expected an outdated report, got:\n{stdout}"
+    );
+}
+
 fn stderr(out: &std::process::Output) -> String {
     String::from_utf8_lossy(&out.stderr).into_owned()
 }

--- a/tests/hub-smoke.rs
+++ b/tests/hub-smoke.rs
@@ -1056,6 +1056,45 @@ fn hub_outdated_reports_newer_version() {
     );
 }
 
+/// A check that can't complete (the pinned package is gone from the index) must
+/// exit non-zero and must NOT be summarized as "up to date" (P3.2).
+#[test]
+fn hub_outdated_errors_when_pin_unresolvable() {
+    if Command::new("git").arg("--version").output().is_err() {
+        eprintln!("git not available — skipping hub outdated error test");
+        return;
+    }
+    let fixture = build_fixture();
+    write(
+        &fixture.root.join("flow/dataflow.yml"),
+        "nodes:\n  - id: hello\n    hub: test/hub-smoke-hello@^0.1\n",
+    );
+    let flow = fixture.root.join("flow/dataflow.yml");
+    assert!(
+        dora(&fixture)
+            .args(["build", flow.to_str().unwrap(), "--write-lockfile"])
+            .output()
+            .unwrap()
+            .status
+            .success(),
+        "build --write-lockfile should succeed"
+    );
+
+    // remove the index entry so the pin can no longer be resolved
+    std::fs::remove_file(fixture.root.join("index/test/hub-smoke-hello/0.1.0.yml")).unwrap();
+
+    let out = dora(&fixture)
+        .args(["hub", "outdated", flow.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(!out.status.success(), "a failed check must exit non-zero");
+    assert!(
+        !String::from_utf8_lossy(&out.stdout).contains("up to date"),
+        "a failed check must not be summarized as up to date:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+}
+
 fn stderr(out: &std::process::Output) -> String {
     String::from_utf8_lossy(&out.stderr).into_owned()
 }


### PR DESCRIPTION
## P3.2 — `dora hub outdated`

`dora hub outdated <dataflow>` reads the dataflow's lockfile and, for each pinned hub package, compares the pin against the **latest non-yanked version** in the index (`IndexCatalog::resolve` with a `*` requirement, so a major/minor bump still surfaces — not just in-range patches). Reports each outdated pin as `pinned -> latest`, or "all up to date".

- `--offline` uses only the cached index.
- Index/lockfile strings are sanitized before printing (an untrusted entry can't inject terminal escapes).
- A malformed pin or unreadable index degrades to a per-node note, not a whole-command failure.

### Test
- [x] `hub_outdated_reports_newer_version` — build pins `0.1.0` (reports up to date) → add `0.2.0` to the index → reports `0.1.0 -> 0.2.0 (newer available)`
- [x] fmt + clippy clean

### Scope
Completes the read-side of P3.2. `dora hub update` (re-resolve + rewrite the lockfile without building) is the remaining piece — it overlaps `dora build --write-lockfile` and wants a "resolve-and-lock, no build" mode, so it's a focused follow-up. With `publish` (#2215) + `yank` (#2216) + this, the hub publishing CLI is nearly complete. Part of umbrella #2097.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
