### PR TITLE
fix(daemon): apply no-header-timeout to local_listener receive path

### DIFF
--- a/binaries/daemon/src/local_listener.rs
+++ b/binaries/daemon/src/local_listener.rs
@@ -1,4 +1,4 @@
-use crate::socket_stream_utils::{socket_stream_receive, socket_stream_send};
+use crate::socket_stream_utils::{socket_stream_receive_with_header_timeout, socket_stream_send};
 use dora_message::{
     daemon_to_node::DaemonReply,
     node_to_daemon::{DaemonRequest, DynamicNodeEvent, Timestamped},
@@ -152,7 +152,7 @@ async fn handle_connection_loop(
 async fn receive_message(
     connection: &mut TcpStream,
 ) -> eyre::Result<Option<Timestamped<DaemonRequest>>> {
-    let raw = match socket_stream_receive(connection).await {
+    let raw = match socket_stream_receive_with_header_timeout(connection, None).await {
         Ok(raw) => raw,
         Err(err) => match err.kind() {
             ErrorKind::UnexpectedEof

--- a/binaries/daemon/src/socket_stream_utils.rs
+++ b/binaries/daemon/src/socket_stream_utils.rs
@@ -25,6 +25,7 @@ pub async fn socket_stream_send(
     Ok(())
 }
 
+#[allow(dead_code)]
 pub async fn socket_stream_receive(
     connection: &mut (impl AsyncRead + Unpin),
 ) -> std::io::Result<Vec<u8>> {


### PR DESCRIPTION
Closes #2218

## Summary

PR #2126 removed the 30s TCP read-header timeout from the `path:` node communication path (`node_communication/tcp.rs`), so idle node connections aren't killed between messages. However, the parallel **dynamic-node config-fetch path** (`local_listener.rs`) was left on the old `socket_stream_receive` wrapper, which still applies `TCP_READ_TIMEOUT` to the header read.

This makes `local_listener.rs` the last remaining source of the `"TCP read header timed out"` string after #2126 — which is the exact string that PR #2199's record/replay retry classifier treats as retryable "infra noise."

## Changes

- `local_listener.rs`: switch `receive_message` to `socket_stream_receive_with_header_timeout(connection, None)` so the two daemon-side receive paths are consistent.
- `socket_stream_utils.rs`: add `#[allow(dead_code)]` to `socket_stream_receive`, which is now only called from tests (both production call sites use the explicit header-timeout form).

## Test plan

- [ ] `cargo clippy -p dora-daemon -- -D warnings` passes
- [ ] `cargo test -p dora-daemon` passes

https://claude.ai/code/session_014cjh8xB2Ju1YAmD2wMkhHC

---
_Generated by [Claude Code](https://claude.ai/code/session_014cjh8xB2Ju1YAmD2wMkhHC)_