### PR TITLE
fix(hub): tighten --locked commit hash validation to require full SHA

### DIFF
--- a/binaries/cli/src/command/build/hub.rs
+++ b/binaries/cli/src/command/build/hub.rs
@@ -227,7 +227,7 @@ pub fn resolve_hub_nodes(
         let (version, entry, source) = match pin {
             Some(pin) => {
                 // --locked: the pinned commit is used verbatim, no resolution
-                let valid_hash = (7..=64).contains(&pin.commit_hash.len())
+                let valid_hash = matches!(pin.commit_hash.len(), 40 | 64)
                     && pin.commit_hash.chars().all(|c| c.is_ascii_hexdigit());
                 if !valid_hash {
                     eyre::bail!(

--- a/binaries/cli/src/command/hub/fetch.rs
+++ b/binaries/cli/src/command/hub/fetch.rs
@@ -153,7 +153,7 @@ fn resolve_single(reference: &str, ctx: &mut HubContext) -> eyre::Result<GitSour
 fn clone_pinned(source: &GitSource, target_dir: &std::path::Path) -> eyre::Result<()> {
     // re-validate the hash at the API boundary — `GitSource.commit_hash` is a
     // plain string and a future caller might not have run it through git_pin
-    let valid_hash = (7..=64).contains(&source.commit_hash.len())
+    let valid_hash = matches!(source.commit_hash.len(), 40 | 64)
         && source.commit_hash.chars().all(|c| c.is_ascii_hexdigit());
     if !valid_hash {
         eyre::bail!("invalid commit hash for `{}`", source.repo);


### PR DESCRIPTION
Closes #2224

## Summary

The `--locked` build path validated a lockfile's hub `commit_hash` as 7–64 hex chars, while the index-entry path (`SourceSpec::git_pin`, `index.rs:93`) deliberately requires a **full** 40- or 64-char SHA to prevent abbreviated hashes from becoming ambiguous as the source repo grows.

This meant a lockfile with an abbreviated hash passed the locked-build check and was fed to the git checkout — reintroducing exactly the ambiguity the index validation was written to forbid.

## Changes

Both validation sites now use `matches!(len, 40 | 64)`, consistent with the check already in `libraries/hub-client/src/index.rs:93`:

- `binaries/cli/src/command/build/hub.rs:230` — `--locked` pin validation
- `binaries/cli/src/command/hub/fetch.rs:156` — `dora hub fetch` clone validation

## Test plan

- [ ] `cargo clippy -p dora-cli -- -D warnings` passes
- [ ] `cargo test -p dora-cli --lib` passes (214 tests)

https://claude.ai/code/session_014cjh8xB2Ju1YAmD2wMkhHC

---
_Generated by [Claude Code](https://claude.ai/code/session_014cjh8xB2Ju1YAmD2wMkhHC)_