### PR TITLE
fix(hub): harden manifest_digest, git_pin tamper warning, and URL host validation

### DIFF
--- a/binaries/cli/src/command/build/hub.rs
+++ b/binaries/cli/src/command/build/hub.rs
@@ -77,13 +77,13 @@ fn normalize_git_source_url(url: &str) -> String {
 /// lockfile so `--locked` can detect a rewritten index entry (entrypoint,
 /// build command, or typed contract). `serde_json` sorts the manifest's
 /// `BTreeMap` fields, so the serialization — and the digest — is canonical.
-fn manifest_digest(manifest: &NodeManifest) -> String {
+fn manifest_digest(manifest: &NodeManifest) -> eyre::Result<String> {
     use sha2::{Digest, Sha256};
-    let bytes = serde_json::to_vec(manifest).unwrap_or_default();
-    Sha256::digest(&bytes)
+    let bytes = serde_json::to_vec(manifest).context("failed to serialize node manifest")?;
+    Ok(Sha256::digest(&bytes)
         .iter()
         .map(|b| format!("{b:02x}"))
-        .collect()
+        .collect())
 }
 
 /// Resolve and desugar every `hub:` node in `dataflow`.
@@ -295,18 +295,30 @@ pub fn resolve_hub_nodes(
                 // the lockfile is authoritative for the pin, but the index
                 // entry of the pinned version should still agree — a mismatch
                 // means the append-only index was tampered with or rewritten
-                if let Ok((git, rev)) = entry.source.git_pin()
-                    && (normalize_git_source_url(git) != pin.repo
-                        || rev != pin.commit_hash
-                        || entry.source.subdir != pin.subdir)
-                {
-                    resolution.warnings.push(format!(
-                        "node `{}`: the index entry for `{}@{version}` no longer matches \
-                         the lockfile pin — the index may have been rewritten; \
-                         the lockfile pin is used",
-                        node.id,
-                        reference.key()
-                    ));
+                match entry.source.git_pin() {
+                    Ok((git, rev))
+                        if normalize_git_source_url(git) != pin.repo
+                            || rev != pin.commit_hash
+                            || entry.source.subdir != pin.subdir =>
+                    {
+                        resolution.warnings.push(format!(
+                            "node `{}`: the index entry for `{}@{version}` no longer matches \
+                             the lockfile pin — the index may have been rewritten; \
+                             the lockfile pin is used",
+                            node.id,
+                            reference.key()
+                        ));
+                    }
+                    Err(_) => {
+                        resolution.warnings.push(format!(
+                            "node `{}`: the index entry for `{}@{version}` has a malformed \
+                             source — the index may have been rewritten; \
+                             the lockfile pin is used",
+                            node.id,
+                            reference.key()
+                        ));
+                    }
+                    _ => {}
                 }
                 // the commit hash pins the source *tree*, but the manifest
                 // (entrypoint, build command, and the typed contract) comes from
@@ -317,7 +329,7 @@ pub fn resolve_hub_nodes(
                 // (lockfile predates this field) the check is skipped.
                 if let Some(provenance) = &pin.hub
                     && let Some(locked_digest) = &provenance.manifest_digest
-                    && *locked_digest != manifest_digest(&entry.manifest)
+                    && *locked_digest != manifest_digest(&entry.manifest)?
                 {
                     eyre::bail!(
                         "node `{}`: the locked index entry for `{}@{version}` changed its \
@@ -348,7 +360,7 @@ pub fn resolve_hub_nodes(
                     hub: Some(HubProvenance {
                         name: reference.key(),
                         version: resolved.version.to_string(),
-                        manifest_digest: Some(manifest_digest(&resolved.entry.manifest)),
+                        manifest_digest: Some(manifest_digest(&resolved.entry.manifest)?),
                     }),
                 };
                 (resolved.version, resolved.entry, source)

--- a/libraries/hub-client/src/lib.rs
+++ b/libraries/hub-client/src/lib.rs
@@ -35,13 +35,38 @@ pub fn validate_git_url(url: &str) -> eyre::Result<()> {
     const SCHEMES: &[&str] = &["https://", "ssh://", "file://", "git@"];
     // absolute paths are accepted for local repositories (tests, mirrors)
     let valid = SCHEMES.iter().any(|s| url.starts_with(s)) || url.starts_with('/');
-    if valid && !url.contains(|c: char| c.is_control()) {
-        return Ok(());
+    if !valid || url.contains(|c: char| c.is_control()) {
+        eyre::bail!(
+            "invalid git URL `{}`: expected a https/ssh/file URL or absolute path",
+            url.chars().filter(|c| !c.is_control()).collect::<String>()
+        );
     }
-    eyre::bail!(
-        "invalid git URL `{}`: expected a https/ssh/file URL or absolute path",
-        url.chars().filter(|c| !c.is_control()).collect::<String>()
-    )
+    // Defense-in-depth: reject a leading '-' in the host component.
+    // ssh://-oProxyCommand=... or git@-... passes the scheme check above but
+    // would look like an option flag to a bare `git` subprocess. All current
+    // callers use libgit2 or a `--` separator, but the validator is documented
+    // as the single pre-subprocess chokepoint (CVE-2017-1000117 shape).
+    let host = if let Some(rest) = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("ssh://"))
+        .or_else(|| url.strip_prefix("file://"))
+    {
+        // authority = everything before the first '/'; strip optional userinfo
+        let authority = rest.split('/').next().unwrap_or(rest);
+        let after_at = authority.rsplit('@').next().unwrap_or(authority);
+        after_at.split(':').next().unwrap_or(after_at)
+    } else if let Some(rest) = url.strip_prefix("git@") {
+        rest.split(':').next().unwrap_or(rest)
+    } else {
+        ""
+    };
+    if host.starts_with('-') {
+        eyre::bail!(
+            "invalid git URL `{}`: host component starts with '-' (option injection risk)",
+            url.chars().filter(|c| !c.is_control()).collect::<String>()
+        );
+    }
+    Ok(())
 }
 
 /// Validate the `source.git` of an *untrusted* index entry — stricter than
@@ -75,7 +100,7 @@ pub const OFFICIAL_INDEX_ALIAS: &str = "official";
 
 #[cfg(test)]
 mod tests {
-    use super::validate_git_url_untrusted;
+    use super::{validate_git_url, validate_git_url_untrusted};
 
     #[test]
     fn untrusted_index_sources_reject_local_paths() {
@@ -89,5 +114,19 @@ mod tests {
         assert!(validate_git_url_untrusted("/srv/repo").is_err());
         // cleartext still rejected by the underlying validator
         assert!(validate_git_url_untrusted("http://github.com/o/r").is_err());
+    }
+
+    #[test]
+    fn rejects_leading_dash_in_host() {
+        // ssh://-oProxyCommand=... / git@-... are the classic option-injection
+        // shapes (CVE-2017-1000117); they pass the scheme check but have a
+        // leading '-' in the host component.
+        assert!(validate_git_url("ssh://-oProxyCommand=touch /tmp/x/path").is_err());
+        assert!(validate_git_url("https://-evil.example.com/r").is_err());
+        assert!(validate_git_url("git@-evil.example.com:o/r.git").is_err());
+        // normal URLs are unaffected
+        assert!(validate_git_url("ssh://git@github.com/o/r").is_ok());
+        assert!(validate_git_url("https://github.com/o/r.git").is_ok());
+        assert!(validate_git_url("git@github.com:o/r.git").is_ok());
     }
 }


### PR DESCRIPTION
Closes #2220

## Summary

Three hardening fixes in the hub trust-boundary code:

### 1. `manifest_digest()` — propagate serialization error (primary fix)

`binaries/cli/src/command/build/hub.rs:82` used `serde_json::to_vec(manifest).unwrap_or_default()`. If serialization ever fails, the previous code digested an empty byte slice — every non-serializable manifest would hash to the same constant, making the `--locked` tamper check ineffective. The function now returns `eyre::Result<String>` and propagates the error with `?`.

### 2. Swallowed `git_pin()` error in the `--locked` index-agreement check

`build/hub.rs:298` used `if let Ok((git, rev)) = entry.source.git_pin()`, silently dropping the tamper warning when the index entry's source was malformed. A malformed source is itself a suspicious signal. The check is now a `match` that emits a warning in the `Err` arm too.

### 3. `validate_git_url()` — reject leading-dash hosts

`ssh://-oProxyCommand=...`, `https://-evil.com/r`, and `git@-evil.com:...` all pass the scheme check but have a leading `-` in the host, making them look like option flags to a bare `git` subprocess (CVE-2017-1000117 shape). All current callers use libgit2 or a `--` separator, but `validate_git_url` is documented as the single pre-subprocess chokepoint. Three new tests cover all leading-dash variants.

## Test plan

- [ ] `cargo test -p dora-hub-client --lib` — 35 tests pass, including new `rejects_leading_dash_in_host`
- [ ] `cargo test -p dora-cli --lib` — 214 tests pass
- [ ] `cargo clippy -p dora-cli -p dora-hub-client -- -D warnings` passes

https://claude.ai/code/session_014cjh8xB2Ju1YAmD2wMkhHC

---
_Generated by [Claude Code](https://claude.ai/code/session_014cjh8xB2Ju1YAmD2wMkhHC)_