### PR TITLE
fix(cli): make dora validate use lockfile pins for hub: resolution

### DIFF
--- a/binaries/cli/src/command/validate.rs
+++ b/binaries/cli/src/command/validate.rs
@@ -94,13 +94,39 @@ fn validate_dataflow(dataflow: &Path, strict_types: bool, offline: bool) -> eyre
         }
     }
 
-    // Resolve hub: references against the (cached) index so their contracts
-    // take part in validation (spec §6.2 ordering note)
+    // If a lockfile exists, use its pins for hub: resolution so validate
+    // reflects the same versions a --locked build would use and works offline
+    // against the index cache. Without a lockfile, fall through to live
+    // resolution (same as before).
+    let lockfile_path = super::build::lockfile::BuildLockfile::path_for_dataflow(dataflow, None);
+    let hub_pins = if lockfile_path.exists() {
+        match super::build::lockfile::BuildLockfile::read_from(&lockfile_path) {
+            Ok(lf) => {
+                println!(
+                    "  Using hub pins from lockfile `{}`",
+                    lockfile_path.display()
+                );
+                Some(lf.git_sources)
+            }
+            Err(e) => {
+                eprintln!(
+                    "  warning: could not read lockfile `{}`: {e} — resolving hub: nodes live",
+                    lockfile_path.display()
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    // Resolve hub: references so their contracts take part in validation
+    // (spec §6.2 ordering note).
     let hub_resolution = super::build::hub::resolve_hub_nodes(
         &mut descriptor,
         &mut registry,
         offline,
-        None,
+        hub_pins.as_ref(),
         &std::collections::BTreeMap::<String, std::path::PathBuf>::new(),
     )?;
     for note in &hub_resolution.notes {


### PR DESCRIPTION
Closes #2219

## Summary

`dora validate` on a dataflow with `hub:` nodes always resolved against the live hub index, even when a `.dora-lock.yaml` existed. This caused two problems:

1. **Offline failure**: `dora validate` failed without network access even when a lockfile + cached index fully pinned the versions (the `--offline` flag was the only workaround).
2. **Version skew**: validate could resolve a *different* index version than what a prior `--locked` build pinned, making validation results inconsistent with the actual build.

## Fix

Mirror the build command's pattern: if a `.dora-lock.yaml` exists next to the dataflow, read its `git_sources` and pass them as `pins` to `resolve_hub_nodes`. If the lockfile is missing or unreadable, fall through to live resolution (previous behavior) with a warning.

The change is limited to `binaries/cli/src/command/validate.rs` — no new flags or options needed.

## Test plan

- [ ] `cargo clippy -p dora-cli -- -D warnings` passes
- [ ] `cargo test -p dora-cli --lib` passes

https://claude.ai/code/session_014cjh8xB2Ju1YAmD2wMkhHC

---
_Generated by [Claude Code](https://claude.ai/code/session_014cjh8xB2Ju1YAmD2wMkhHC)_