### PR TITLE
fix(hub): bind shipped-type namespace gate to requested reference.namespace

### DIFF
--- a/binaries/cli/src/command/build/hub.rs
+++ b/binaries/cli/src/command/build/hub.rs
@@ -363,11 +363,29 @@ pub fn resolve_hub_nodes(
         let manifest = &entry.manifest;
         let label = format!("{}@{version}", reference.key());
 
-        // The index entry is an untrusted input: validate its shipped types
-        // (namespace ownership, materializable bodies) before loading them, so
-        // a rewritten entry can't register a `std/` override or a
-        // cross-namespace type that a consumer's port check would resolve
-        // (spec §6.3, P2.12).
+        // The index entry is untrusted. Its self-declared `namespace` must
+        // match the namespace the entry was actually fetched under
+        // (`reference.namespace`): `shipped_type_issues` gates URNs against
+        // `manifest.namespace`, so an entry that sets `namespace: victim` and
+        // ships `victim/...` types would bypass the cross-namespace guard if we
+        // didn't bind it to the requested namespace first (spec §6.3, P2.12).
+        if manifest.namespace != reference.namespace {
+            eyre::bail!(
+                "node `{}`: the index entry for `{}` declares namespace `{}` \
+                 but was fetched under namespace `{}` — the index may have been tampered with",
+                node.id,
+                reference.key(),
+                manifest
+                    .namespace
+                    .chars()
+                    .filter(|c| !c.is_control())
+                    .collect::<String>(),
+                reference.namespace
+            );
+        }
+
+        // With the namespace now verified, validate shipped types
+        // (materializable bodies, no `std/` override, no cross-namespace URN).
         let type_issues = manifest.shipped_type_issues(registry);
         if !type_issues.is_empty() {
             eyre::bail!(

--- a/libraries/core/src/manifest/validate.rs
+++ b/libraries/core/src/manifest/validate.rs
@@ -710,6 +710,28 @@ outputs:
              fields:\n      - name: x\n        type: Float32\n",
         );
         assert_eq!(ok.shipped_type_issues(&reg), vec![]);
+
+        // Document the gap that the namespace-consistency check in hub.rs closes:
+        // an entry can self-declare `namespace: victim` and ship `victim/…` types
+        // that pass `shipped_type_issues` (which validates URNs against self.namespace).
+        // The hub resolver must compare manifest.namespace against the *requested*
+        // reference.namespace *before* calling this function, so this circular
+        // self-attestation cannot be exploited.
+        let attacker_namespace = "victim";
+        let attacker = NodeManifest {
+            namespace: attacker_namespace.to_string(),
+            ..minimal(
+                "types:\n  victim/sensor/v1/Image:\n    arrow: Struct\n    \
+                 fields:\n      - name: x\n        type: Float32\n",
+            )
+        };
+        // shipped_type_issues alone is NOT sufficient to catch this; it passes:
+        assert_eq!(
+            attacker.shipped_type_issues(&reg),
+            vec![],
+            "shipped_type_issues alone cannot reject a self-consistent attacker manifest \
+             (namespace binding in hub.rs is the guard)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #2222

## Summary

The shipped-type namespace gate (spec §6.3, P2.12, introduced in #2206) validated type URN prefixes against `manifest.namespace` — a field that comes from the **same untrusted index entry** being validated. This is circular: an attacker controlling an index entry could:

1. Set `namespace: victim` in the manifest
2. Ship `victim/sensor/v1/Image` (a valid `victim/…` type)
3. `shipped_type_issues` checks the URN against `self.namespace` = `"victim"` → **passes**
4. The bogus type is registered into the shared `TypeRegistry`
5. Legitimate `victim/…` types from other packages get skipped (already resolved) → **type confusion**

## Fix

Before calling `shipped_type_issues`, assert that `manifest.namespace == reference.namespace` — the namespace the **user actually requested** (from the `hub:` field in the dataflow YAML), not the one the entry self-declares. A mismatch is treated as a tamper signal and the build fails with a clear error.

The check is in `binaries/cli/src/command/build/hub.rs` right before the existing type gate:

```rust
if manifest.namespace != reference.namespace {
    eyre::bail!(
        "node `{}`: the index entry for `{}` declares namespace `{}` \
         but was fetched under namespace `{}` — the index may have been tampered with",
        ...
    );
}
```

## Documentation of the gap

A comment-test was added to `libraries/core/src/manifest/validate.rs` documenting that `shipped_type_issues` alone cannot catch this class of attack (it's self-referential), and that the namespace binding check in `hub.rs` is the necessary guard. The test verifies the gap exists so it cannot be accidentally closed at the wrong level.

## Test plan

- [ ] `cargo test -p dora-core -p dora-cli --lib` passes (247 tests)
- [ ] `cargo clippy -p dora-cli -p dora-core -- -D warnings` passes

https://claude.ai/code/session_014cjh8xB2Ju1YAmD2wMkhHC

---
_Generated by [Claude Code](https://claude.ai/code/session_014cjh8xB2Ju1YAmD2wMkhHC)_