### PR TITLE
feat(hub): consume the binary source form (P2.8, #2202)

### DIFF
--- a/binaries/cli/src/command/build/hub.rs
+++ b/binaries/cli/src/command/build/hub.rs
@@ -27,7 +27,7 @@ use dora_hub_client::{
     transport::IndexFetcher,
 };
 use dora_message::{
-    common::{GitSource, HubProvenance},
+    common::{BinaryPin, GitSource, HubProvenance},
     descriptor::Descriptor,
     id::NodeId,
 };
@@ -43,6 +43,10 @@ pub struct HubResolution {
     /// Per-node resolved git source (with subdir + hub provenance) — merged
     /// into the build's `git_sources` map and the lockfile.
     pub sources: BTreeMap<NodeId, GitSource>,
+    /// Per-node resolved prebuilt-binary pin (url + sha256 + provenance) for
+    /// nodes that resolved to a `binary` artifact — written to the lockfile so
+    /// `--locked` reproduces the exact artifact (spec §8.2).
+    pub binary_sources: BTreeMap<NodeId, BinaryPin>,
     /// Per-node local working dir for `--hub-override` substitutions (UC11):
     /// the node builds and runs from this checkout instead of a cloned commit.
     /// Threaded into the local builder so build + spawn root there.
@@ -51,7 +55,7 @@ pub struct HubResolution {
 
 impl HubResolution {
     pub fn is_empty(&self) -> bool {
-        self.sources.is_empty() && self.override_dirs.is_empty()
+        self.sources.is_empty() && self.binary_sources.is_empty() && self.override_dirs.is_empty()
     }
 }
 
@@ -99,7 +103,11 @@ fn manifest_digest(manifest: &NodeManifest) -> eyre::Result<String> {
 /// source, the default) or a prebuilt per-platform binary artifact (spec §8.2).
 enum NodeBytes {
     Git(GitSource),
-    Binary { url: String, sha256: String },
+    Binary {
+        url: String,
+        sha256: String,
+        platform: String,
+    },
 }
 
 /// Decide where a freshly-resolved entry's bytes come from (spec §8.1/§8.2):
@@ -133,6 +141,7 @@ fn resolve_node_bytes(
             return Ok(NodeBytes::Binary {
                 url: art.url.clone(),
                 sha256: art.sha256.clone(),
+                platform,
             });
         }
         // no artifact for this platform: degrade to a source build if the
@@ -149,11 +158,95 @@ fn resolve_node_bytes(
     git_bytes(git, rev, source.subdir.clone())
 }
 
+/// Resolve a node whose lockfile entry is a binary pin (`--locked`): the
+/// pinned `url`+`sha256` are used verbatim, but the manifest (entrypoint,
+/// build, contract) still comes from the mutable index entry — so the entry's
+/// artifact is cross-checked (warn on rewrite) and its manifest digest is
+/// hard-checked, mirroring the git locked path.
+fn resolve_locked_binary(
+    bpin: &BinaryPin,
+    catalog: &IndexCatalog,
+    reference: &PackageRef,
+    node_id: &NodeId,
+    resolution: &mut HubResolution,
+) -> eyre::Result<(
+    dora_hub_client::semver::Version,
+    dora_hub_client::index::IndexEntry,
+    NodeBytes,
+)> {
+    if bpin.hub.name != reference.key() {
+        eyre::bail!(
+            "node `{node_id}`: lockfile pins `{}` but the dataflow now references `{}` — \
+             regenerate with `dora build --write-lockfile`",
+            bpin.hub.name,
+            reference.key()
+        );
+    }
+    let version: dora_hub_client::semver::Version = bpin
+        .hub
+        .version
+        .parse()
+        .with_context(|| format!("node `{node_id}`: invalid version in lockfile"))?;
+    if !reference.requirement.matches(&version) {
+        eyre::bail!(
+            "node `{node_id}`: locked version {version} no longer satisfies `{}` — \
+             regenerate with `dora build --write-lockfile`",
+            reference.requirement
+        );
+    }
+    let entry = catalog
+        .entry(&reference.namespace, &reference.name, &version)
+        .with_context(|| {
+            format!(
+                "node `{node_id}`: pinned version {version} of `{}` is missing from the index",
+                reference.key()
+            )
+        })?;
+    if entry.yanked {
+        resolution.warnings.push(format!(
+            "node `{node_id}`: pinned version {version} of `{}` has been yanked — \
+             the pin keeps working, but consider updating",
+            reference.key()
+        ));
+    }
+    // the locked artifact should still match the (append-only) index entry
+    let agrees = matches!(
+        entry.source.select_binary(&bpin.platform),
+        Some(art) if art.url == bpin.url && art.sha256 == bpin.sha256
+    );
+    if !agrees {
+        resolution.warnings.push(format!(
+            "node `{node_id}`: the index entry for `{}@{version}` no longer matches the \
+             locked binary artifact for `{}` — the index may have been rewritten; \
+             the lockfile pin is used",
+            reference.key(),
+            bpin.platform
+        ));
+    }
+    if let Some(locked_digest) = &bpin.hub.manifest_digest
+        && *locked_digest != manifest_digest(&entry.manifest)?
+    {
+        eyre::bail!(
+            "node `{node_id}`: the locked index entry for `{}@{version}` changed its manifest \
+             (entrypoint, build, or contract) since the lockfile was written — \
+             regenerate with `dora build --write-lockfile`",
+            reference.key()
+        );
+    }
+    let bytes = NodeBytes::Binary {
+        url: bpin.url.clone(),
+        sha256: bpin.sha256.clone(),
+        platform: bpin.platform.clone(),
+    };
+    Ok((version, entry, bytes))
+}
+
 pub fn resolve_hub_nodes(
     dataflow: &mut Descriptor,
     registry: &mut TypeRegistry,
     offline: bool,
     pins: Option<&BTreeMap<NodeId, GitSource>>,
+    binary_pins: Option<&BTreeMap<NodeId, BinaryPin>>,
     overrides: &BTreeMap<String, PathBuf>,
 ) -> eyre::Result<HubResolution> {
     let mut resolution = HubResolution::default();
@@ -267,7 +360,8 @@ pub fn resolve_hub_nodes(
         // fail fast — *before* any index fetch — rather than hitting the
         // network (or an offline cache miss) only to bail afterwards.
         let pin = pins.and_then(|p| p.get(&node.id));
-        if pins.is_some() && pin.is_none() {
+        let binary_pin = binary_pins.and_then(|p| p.get(&node.id));
+        if pins.is_some() && pin.is_none() && binary_pin.is_none() {
             eyre::bail!(
                 "node `{}`: `hub:` reference is not in the lockfile — \
                  regenerate with `dora build --write-lockfile`",
@@ -281,144 +375,148 @@ pub fn resolve_hub_nodes(
             .with_context(|| format!("node `{}`: failed to fetch the hub index", node.id))?;
         let catalog = IndexCatalog::open(&catalog_dir)?;
 
-        let (version, entry, bytes) = match pin {
-            Some(pin) => {
-                // --locked: the pinned commit is used verbatim, no resolution
-                let valid_hash = matches!(pin.commit_hash.len(), 40 | 64)
-                    && pin.commit_hash.chars().all(|c| c.is_ascii_hexdigit());
-                if !valid_hash {
-                    eyre::bail!(
-                        "node `{}`: lockfile commit hash is not a valid hex hash",
-                        node.id
-                    );
-                }
-                let provenance = pin.hub.as_ref().with_context(|| {
-                    format!(
-                        "node `{}`: lockfile entry has no hub provenance — \
-                         regenerate with `dora build --write-lockfile`",
-                        node.id
-                    )
-                })?;
-                if provenance.name != reference.key() {
-                    eyre::bail!(
-                        "node `{}`: lockfile pins `{}` but the dataflow now references \
-                         `{}` — regenerate with `dora build --write-lockfile`",
-                        node.id,
-                        provenance.name,
-                        reference.key()
-                    );
-                }
-                let version: dora_hub_client::semver::Version = provenance
-                    .version
-                    .parse()
-                    .with_context(|| format!("node `{}`: invalid version in lockfile", node.id))?;
-                if !reference.requirement.matches(&version) {
-                    eyre::bail!(
-                        "node `{}`: locked version {version} no longer satisfies `{}` — \
-                         regenerate with `dora build --write-lockfile`",
-                        node.id,
-                        reference.requirement
-                    );
-                }
-                let entry = catalog
-                    .entry(&reference.namespace, &reference.name, &version)
-                    .with_context(|| {
+        let (version, entry, bytes) = if let Some(bpin) = binary_pin {
+            resolve_locked_binary(bpin, &catalog, &reference, &node.id, &mut resolution)?
+        } else {
+            match pin {
+                Some(pin) => {
+                    // --locked: the pinned commit is used verbatim, no resolution
+                    let valid_hash = matches!(pin.commit_hash.len(), 40 | 64)
+                        && pin.commit_hash.chars().all(|c| c.is_ascii_hexdigit());
+                    if !valid_hash {
+                        eyre::bail!(
+                            "node `{}`: lockfile commit hash is not a valid hex hash",
+                            node.id
+                        );
+                    }
+                    let provenance = pin.hub.as_ref().with_context(|| {
                         format!(
-                            "node `{}`: pinned version {version} of `{}` is missing \
-                             from the index",
-                            node.id,
-                            reference.key()
+                            "node `{}`: lockfile entry has no hub provenance — \
+                         regenerate with `dora build --write-lockfile`",
+                            node.id
                         )
                     })?;
-                if entry.yanked {
-                    resolution.warnings.push(format!(
-                        "node `{}`: pinned version {version} of `{}` has been yanked{} — \
-                         the pin keeps working, but consider updating",
-                        node.id,
-                        reference.key(),
-                        entry
-                            .yank_reason
-                            .as_deref()
-                            .map(|r| format!(
-                                " ({})",
-                                r.chars()
-                                    .filter(|c| !c.is_control())
-                                    .take(200)
-                                    .collect::<String>()
-                            ))
-                            .unwrap_or_default()
-                    ));
-                }
-                // the lockfile is authoritative for the pin, but the index
-                // entry of the pinned version should still agree — a mismatch
-                // means the append-only index was tampered with or rewritten
-                match entry.source.git_pin() {
-                    Ok((git, rev))
-                        if normalize_git_source_url(git) != pin.repo
-                            || rev != pin.commit_hash
-                            || entry.source.subdir != pin.subdir =>
-                    {
+                    if provenance.name != reference.key() {
+                        eyre::bail!(
+                            "node `{}`: lockfile pins `{}` but the dataflow now references \
+                         `{}` — regenerate with `dora build --write-lockfile`",
+                            node.id,
+                            provenance.name,
+                            reference.key()
+                        );
+                    }
+                    let version: dora_hub_client::semver::Version =
+                        provenance.version.parse().with_context(|| {
+                            format!("node `{}`: invalid version in lockfile", node.id)
+                        })?;
+                    if !reference.requirement.matches(&version) {
+                        eyre::bail!(
+                            "node `{}`: locked version {version} no longer satisfies `{}` — \
+                         regenerate with `dora build --write-lockfile`",
+                            node.id,
+                            reference.requirement
+                        );
+                    }
+                    let entry = catalog
+                        .entry(&reference.namespace, &reference.name, &version)
+                        .with_context(|| {
+                            format!(
+                                "node `{}`: pinned version {version} of `{}` is missing \
+                             from the index",
+                                node.id,
+                                reference.key()
+                            )
+                        })?;
+                    if entry.yanked {
                         resolution.warnings.push(format!(
-                            "node `{}`: the index entry for `{}@{version}` no longer matches \
+                            "node `{}`: pinned version {version} of `{}` has been yanked{} — \
+                         the pin keeps working, but consider updating",
+                            node.id,
+                            reference.key(),
+                            entry
+                                .yank_reason
+                                .as_deref()
+                                .map(|r| format!(
+                                    " ({})",
+                                    r.chars()
+                                        .filter(|c| !c.is_control())
+                                        .take(200)
+                                        .collect::<String>()
+                                ))
+                                .unwrap_or_default()
+                        ));
+                    }
+                    // the lockfile is authoritative for the pin, but the index
+                    // entry of the pinned version should still agree — a mismatch
+                    // means the append-only index was tampered with or rewritten
+                    match entry.source.git_pin() {
+                        Ok((git, rev))
+                            if normalize_git_source_url(git) != pin.repo
+                                || rev != pin.commit_hash
+                                || entry.source.subdir != pin.subdir =>
+                        {
+                            resolution.warnings.push(format!(
+                                "node `{}`: the index entry for `{}@{version}` no longer matches \
                              the lockfile pin — the index may have been rewritten; \
                              the lockfile pin is used",
-                            node.id,
-                            reference.key()
-                        ));
-                    }
-                    Err(_) => {
-                        resolution.warnings.push(format!(
-                            "node `{}`: the index entry for `{}@{version}` has a malformed \
+                                node.id,
+                                reference.key()
+                            ));
+                        }
+                        Err(_) => {
+                            resolution.warnings.push(format!(
+                                "node `{}`: the index entry for `{}@{version}` has a malformed \
                              source — the index may have been rewritten; \
                              the lockfile pin is used",
-                            node.id,
-                            reference.key()
-                        ));
+                                node.id,
+                                reference.key()
+                            ));
+                        }
+                        _ => {}
                     }
-                    _ => {}
-                }
-                // the commit hash pins the source *tree*, but the manifest
-                // (entrypoint, build command, and the typed contract) comes from
-                // the *mutable* index entry — so a rewritten entry could change
-                // any of it at a pinned version. `--locked` hard-errors if the
-                // manifest digest no longer matches what was locked. The digest
-                // doubles as the new-lockfile-format sentinel: when absent
-                // (lockfile predates this field) the check is skipped.
-                if let Some(provenance) = &pin.hub
-                    && let Some(locked_digest) = &provenance.manifest_digest
-                    && *locked_digest != manifest_digest(&entry.manifest)?
-                {
-                    eyre::bail!(
-                        "node `{}`: the locked index entry for `{}@{version}` changed its \
+                    // the commit hash pins the source *tree*, but the manifest
+                    // (entrypoint, build command, and the typed contract) comes from
+                    // the *mutable* index entry — so a rewritten entry could change
+                    // any of it at a pinned version. `--locked` hard-errors if the
+                    // manifest digest no longer matches what was locked. The digest
+                    // doubles as the new-lockfile-format sentinel: when absent
+                    // (lockfile predates this field) the check is skipped.
+                    if let Some(provenance) = &pin.hub
+                        && let Some(locked_digest) = &provenance.manifest_digest
+                        && *locked_digest != manifest_digest(&entry.manifest)?
+                    {
+                        eyre::bail!(
+                            "node `{}`: the locked index entry for `{}@{version}` changed its \
                          manifest (entrypoint, build, or contract) since the lockfile was \
                          written — regenerate with `dora build --write-lockfile`",
-                        node.id,
-                        reference.key()
-                    );
+                            node.id,
+                            reference.key()
+                        );
+                    }
+                    // Binary pins are not yet recorded in the lockfile, so a `--locked`
+                    // binary node arrives here with no pin and resolves live below.
+                    (version, entry, NodeBytes::Git(pin.clone()))
                 }
-                // Binary pins are not yet recorded in the lockfile, so a `--locked`
-                // binary node arrives here with no pin and resolves live below.
-                (version, entry, NodeBytes::Git(pin.clone()))
-            }
-            None => {
-                let resolved = catalog.resolve(&reference).with_context(|| {
-                    format!("node `{}`: failed to resolve `{raw_reference}`", node.id)
-                })?;
-                let bytes = resolve_node_bytes(
-                    &resolved.entry.source,
-                    &resolved.entry.manifest,
-                    &reference,
-                    &resolved.version,
-                )
-                .with_context(|| {
-                    format!(
-                        "node `{}`: invalid source for `{}@{}`",
-                        node.id,
-                        reference.key(),
-                        resolved.version
+                None => {
+                    let resolved = catalog.resolve(&reference).with_context(|| {
+                        format!("node `{}`: failed to resolve `{raw_reference}`", node.id)
+                    })?;
+                    let bytes = resolve_node_bytes(
+                        &resolved.entry.source,
+                        &resolved.entry.manifest,
+                        &reference,
+                        &resolved.version,
                     )
-                })?;
-                (resolved.version, resolved.entry, bytes)
+                    .with_context(|| {
+                        format!(
+                            "node `{}`: invalid source for `{}@{}`",
+                            node.id,
+                            reference.key(),
+                            resolved.version
+                        )
+                    })?;
+                    (resolved.version, resolved.entry, bytes)
+                }
             }
         };
 
@@ -507,10 +605,24 @@ pub fn resolve_hub_nodes(
                 ));
                 resolution.sources.insert(node.id.clone(), source);
             }
-            NodeBytes::Binary { url, sha256 } => {
+            NodeBytes::Binary {
+                url,
+                sha256,
+                platform,
+            } => {
                 // a prebuilt artifact: a sha256-verified URL download, no clone
-                // or build (spec §8.2). Not yet recorded in the lockfile, so a
-                // `--locked` build re-resolves it live (still hash-verified).
+                // or build (spec §8.2). Recorded in the lockfile so `--locked`
+                // reproduces this exact artifact.
+                let pin = BinaryPin {
+                    platform: platform.clone(),
+                    url: url.clone(),
+                    sha256: sha256.clone(),
+                    hub: HubProvenance {
+                        name: reference.key(),
+                        version: version.to_string(),
+                        manifest_digest: Some(manifest_digest(manifest)?),
+                    },
+                };
                 node.path = Some(url);
                 node.path_sha256 = Some(sha256);
                 node.build = None;
@@ -518,10 +630,10 @@ pub fn resolve_hub_nodes(
                 node.rev = None;
                 node.hub = None;
                 resolution.notes.push(format!(
-                    "node `{}`: resolved hub package {label} -> prebuilt binary for {}",
-                    node.id,
-                    current_platform()
+                    "node `{}`: resolved hub package {label} -> prebuilt binary for {platform}",
+                    node.id
                 ));
+                resolution.binary_sources.insert(node.id.clone(), pin);
             }
         }
     }

--- a/binaries/cli/src/command/build/hub.rs
+++ b/binaries/cli/src/command/build/hub.rs
@@ -182,6 +182,16 @@ fn resolve_locked_binary(
             reference.key()
         );
     }
+    // the lockfile holds one binary pin per node, for the platform it was
+    // generated on — a Linux pin must not download its artifact on macOS.
+    let host = current_platform();
+    if bpin.platform != host {
+        eyre::bail!(
+            "node `{node_id}`: the lockfile pins the binary artifact for `{}`, but this host is \
+             `{host}` — regenerate the lockfile on this platform (`dora build --write-lockfile`)",
+            bpin.platform
+        );
+    }
     let version: dora_hub_client::semver::Version = bpin
         .hub
         .version
@@ -755,5 +765,39 @@ mod tests {
             resolve_node_bytes(&git, &manifest, &reference, &version).unwrap(),
             NodeBytes::Git(_)
         ));
+    }
+
+    #[test]
+    fn locked_binary_rejects_platform_mismatch() {
+        use dora_hub_client::index::IndexCatalog;
+        use dora_message::common::{BinaryPin, HubProvenance};
+
+        use super::{HubResolution, PackageRef, resolve_locked_binary};
+
+        // an empty catalog is fine: the platform check fails before any lookup
+        let tmp = tempfile::tempdir().unwrap();
+        let catalog = IndexCatalog::open(tmp.path()).unwrap();
+        let reference = PackageRef::parse("dora-rs/lidar@^2").unwrap();
+        let bpin = BinaryPin {
+            platform: "some-other-platform-not-this-host".into(),
+            url: "https://example.com/x".into(),
+            sha256: "a".repeat(64),
+            hub: HubProvenance {
+                name: reference.key(),
+                version: "2.1.0".into(),
+                manifest_digest: None,
+            },
+        };
+        let mut resolution = HubResolution::default();
+        let Err(err) = resolve_locked_binary(
+            &bpin,
+            &catalog,
+            &reference,
+            &"lidar".parse().unwrap(),
+            &mut resolution,
+        ) else {
+            panic!("expected a platform-mismatch error");
+        };
+        assert!(err.to_string().contains("this host"), "{err}");
     }
 }

--- a/binaries/cli/src/command/build/hub.rs
+++ b/binaries/cli/src/command/build/hub.rs
@@ -21,7 +21,10 @@ use dora_core::{
     types::TypeRegistry,
 };
 use dora_hub_client::{
-    config::ResolvedConfig, index::IndexCatalog, reference::PackageRef, transport::IndexFetcher,
+    config::ResolvedConfig,
+    index::{IndexCatalog, current_platform},
+    reference::PackageRef,
+    transport::IndexFetcher,
 };
 use dora_message::{
     common::{GitSource, HubProvenance},
@@ -92,6 +95,60 @@ fn manifest_digest(manifest: &NodeManifest) -> eyre::Result<String> {
 /// the pinned commit is used verbatim and the index entry of the pinned
 /// version supplies the manifest. Without pins, each reference resolves to
 /// the highest non-yanked matching version.
+/// Where a resolved hub node's bytes come from: a git source (built from
+/// source, the default) or a prebuilt per-platform binary artifact (spec §8.2).
+enum NodeBytes {
+    Git(GitSource),
+    Binary { url: String, sha256: String },
+}
+
+/// Decide where a freshly-resolved entry's bytes come from (spec §8.1/§8.2):
+/// a prebuilt artifact for this platform if the entry ships one, else the
+/// `fallback-git` source build, else the plain git source.
+fn resolve_node_bytes(
+    source: &dora_hub_client::index::SourceSpec,
+    manifest: &dora_core::manifest::NodeManifest,
+    reference: &PackageRef,
+    version: &dora_hub_client::semver::Version,
+) -> eyre::Result<NodeBytes> {
+    let provenance = || -> eyre::Result<HubProvenance> {
+        Ok(HubProvenance {
+            name: reference.key(),
+            version: version.to_string(),
+            manifest_digest: Some(manifest_digest(manifest)?),
+        })
+    };
+    let git_bytes = |git: &str, rev: &str, subdir: Option<String>| -> eyre::Result<NodeBytes> {
+        Ok(NodeBytes::Git(GitSource {
+            repo: normalize_git_source_url(git),
+            commit_hash: rev.to_string(),
+            subdir,
+            hub: Some(provenance()?),
+        }))
+    };
+    if !source.binary.is_empty() {
+        let platform = current_platform();
+        if let Some(art) = source.select_binary(&platform) {
+            art.validate()?;
+            return Ok(NodeBytes::Binary {
+                url: art.url.clone(),
+                sha256: art.sha256.clone(),
+            });
+        }
+        // no artifact for this platform: degrade to a source build if the
+        // entry offers one (cargo-binstall model), else hard-fail.
+        if let Some(fallback) = &source.fallback_git {
+            let (git, rev) = fallback.git_pin()?;
+            return git_bytes(git, rev, fallback.subdir.clone());
+        }
+        eyre::bail!(
+            "no prebuilt binary for platform `{platform}` and no `fallback-git` to build from"
+        );
+    }
+    let (git, rev) = source.git_pin()?;
+    git_bytes(git, rev, source.subdir.clone())
+}
+
 pub fn resolve_hub_nodes(
     dataflow: &mut Descriptor,
     registry: &mut TypeRegistry,
@@ -224,7 +281,7 @@ pub fn resolve_hub_nodes(
             .with_context(|| format!("node `{}`: failed to fetch the hub index", node.id))?;
         let catalog = IndexCatalog::open(&catalog_dir)?;
 
-        let (version, entry, source) = match pin {
+        let (version, entry, bytes) = match pin {
             Some(pin) => {
                 // --locked: the pinned commit is used verbatim, no resolution
                 let valid_hash = matches!(pin.commit_hash.len(), 40 | 64)
@@ -339,13 +396,21 @@ pub fn resolve_hub_nodes(
                         reference.key()
                     );
                 }
-                (version, entry, pin.clone())
+                // Binary pins are not yet recorded in the lockfile, so a `--locked`
+                // binary node arrives here with no pin and resolves live below.
+                (version, entry, NodeBytes::Git(pin.clone()))
             }
             None => {
                 let resolved = catalog.resolve(&reference).with_context(|| {
                     format!("node `{}`: failed to resolve `{raw_reference}`", node.id)
                 })?;
-                let (git_url, rev) = resolved.entry.source.git_pin().with_context(|| {
+                let bytes = resolve_node_bytes(
+                    &resolved.entry.source,
+                    &resolved.entry.manifest,
+                    &reference,
+                    &resolved.version,
+                )
+                .with_context(|| {
                     format!(
                         "node `{}`: invalid source for `{}@{}`",
                         node.id,
@@ -353,21 +418,13 @@ pub fn resolve_hub_nodes(
                         resolved.version
                     )
                 })?;
-                let source = GitSource {
-                    repo: normalize_git_source_url(git_url),
-                    commit_hash: rev.to_string(),
-                    subdir: resolved.entry.source.subdir.clone(),
-                    hub: Some(HubProvenance {
-                        name: reference.key(),
-                        version: resolved.version.to_string(),
-                        manifest_digest: Some(manifest_digest(&resolved.entry.manifest)?),
-                    }),
-                };
-                (resolved.version, resolved.entry, source)
+                (resolved.version, resolved.entry, bytes)
             }
         };
 
-        if let Some(subdir) = &source.subdir {
+        if let NodeBytes::Git(git) = &bytes
+            && let Some(subdir) = &git.subdir
+        {
             validate_subdir(subdir)
                 .with_context(|| format!("node `{}`: invalid index entry", node.id))?;
         }
@@ -434,18 +491,39 @@ pub fn resolve_hub_nodes(
         }
         resolution.notes.extend(contracts.notes);
 
-        // desugar into a concrete git node
-        node.path = Some(manifest.entrypoint.replace('\\', "/"));
-        node.build = manifest.build.clone();
-        node.git = Some(source.repo.clone());
-        node.rev = Some(source.commit_hash.clone());
-        node.hub = None;
-        let short_hash: String = source.commit_hash.chars().take(12).collect();
-        resolution.notes.push(format!(
-            "node `{}`: resolved hub package {label} -> {short_hash}",
-            node.id
-        ));
-        resolution.sources.insert(node.id.clone(), source);
+        // desugar into a concrete node
+        match bytes {
+            NodeBytes::Git(source) => {
+                node.path = Some(manifest.entrypoint.replace('\\', "/"));
+                node.build = manifest.build.clone();
+                node.git = Some(source.repo.clone());
+                node.rev = Some(source.commit_hash.clone());
+                node.path_sha256 = None;
+                node.hub = None;
+                let short_hash: String = source.commit_hash.chars().take(12).collect();
+                resolution.notes.push(format!(
+                    "node `{}`: resolved hub package {label} -> {short_hash}",
+                    node.id
+                ));
+                resolution.sources.insert(node.id.clone(), source);
+            }
+            NodeBytes::Binary { url, sha256 } => {
+                // a prebuilt artifact: a sha256-verified URL download, no clone
+                // or build (spec §8.2). Not yet recorded in the lockfile, so a
+                // `--locked` build re-resolves it live (still hash-verified).
+                node.path = Some(url);
+                node.path_sha256 = Some(sha256);
+                node.build = None;
+                node.git = None;
+                node.rev = None;
+                node.hub = None;
+                resolution.notes.push(format!(
+                    "node `{}`: resolved hub package {label} -> prebuilt binary for {}",
+                    node.id,
+                    current_platform()
+                ));
+            }
+        }
     }
 
     for key in overrides.keys() {
@@ -486,5 +564,68 @@ mod tests {
         for (input, expected) in cases {
             assert_eq!(normalize_git_source_url(input), expected, "input `{input}`");
         }
+    }
+
+    #[test]
+    fn binary_source_selects_falls_back_or_errors() {
+        use dora_core::manifest::NodeManifest;
+        use dora_hub_client::index::{BinaryArtifact, SourceSpec, current_platform};
+
+        use super::{NodeBytes, PackageRef, resolve_node_bytes};
+
+        let manifest = NodeManifest::parse(
+            "apiVersion: 1\nname: dora-yolo\nnamespace: dora-rs\nruntime: python\nentrypoint: dora-yolo\n",
+        )
+        .unwrap();
+        let reference = PackageRef::parse("dora-yolo@^0.5").unwrap();
+        let version = dora_hub_client::semver::Version::parse("0.5.0").unwrap();
+        let art = |p: &str| BinaryArtifact {
+            platform: p.to_string(),
+            url: format!("https://example.com/{p}"),
+            sha256: "a".repeat(64),
+        };
+
+        // covered platform -> a prebuilt binary
+        let covered = SourceSpec {
+            binary: vec![art(&current_platform())],
+            ..Default::default()
+        };
+        assert!(matches!(
+            resolve_node_bytes(&covered, &manifest, &reference, &version).unwrap(),
+            NodeBytes::Binary { .. }
+        ));
+
+        // uncovered platform + fallback-git -> degrade to a source build
+        let fallback = SourceSpec {
+            binary: vec![art("nonexistent-arch")],
+            fallback_git: Some(Box::new(SourceSpec {
+                git: Some("https://github.com/acme/lidar".into()),
+                rev: Some("a".repeat(40)),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+        assert!(matches!(
+            resolve_node_bytes(&fallback, &manifest, &reference, &version).unwrap(),
+            NodeBytes::Git(_)
+        ));
+
+        // uncovered platform + no fallback -> hard error
+        let uncovered = SourceSpec {
+            binary: vec![art("nonexistent-arch")],
+            ..Default::default()
+        };
+        assert!(resolve_node_bytes(&uncovered, &manifest, &reference, &version).is_err());
+
+        // plain git source (no binary) -> git
+        let git = SourceSpec {
+            git: Some("https://github.com/dora-rs/dora-hub".into()),
+            rev: Some("b".repeat(40)),
+            ..Default::default()
+        };
+        assert!(matches!(
+            resolve_node_bytes(&git, &manifest, &reference, &version).unwrap(),
+            NodeBytes::Git(_)
+        ));
     }
 }

--- a/binaries/cli/src/command/build/hub.rs
+++ b/binaries/cli/src/command/build/hub.rs
@@ -233,6 +233,22 @@ fn resolve_locked_binary(
             reference.key()
         );
     }
+    // re-validate the pin's artifact shape, mirroring the git path's commit-hash
+    // re-check: a tampered lockfile must not smuggle a non-https url (which would
+    // slip past the daemon's `source_is_url` gate and skip sha256 verification)
+    // or a malformed digest.
+    if !bpin.url.starts_with("https://") {
+        eyre::bail!(
+            "node `{node_id}`: lockfile binary url for `{}` is not https",
+            bpin.platform
+        );
+    }
+    if bpin.sha256.len() != 64 || !bpin.sha256.chars().all(|c| c.is_ascii_hexdigit()) {
+        eyre::bail!(
+            "node `{node_id}`: lockfile binary sha256 for `{}` is malformed (need 64 hex chars)",
+            bpin.platform
+        );
+    }
     let bytes = NodeBytes::Binary {
         url: bpin.url.clone(),
         sha256: bpin.sha256.clone(),
@@ -493,8 +509,8 @@ pub fn resolve_hub_nodes(
                             reference.key()
                         );
                     }
-                    // Binary pins are not yet recorded in the lockfile, so a `--locked`
-                    // binary node arrives here with no pin and resolves live below.
+                    // a git pin only — binary pins take the `resolve_locked_binary`
+                    // path above, so this arm is always a git source.
                     (version, entry, NodeBytes::Git(pin.clone()))
                 }
                 None => {

--- a/binaries/cli/src/command/build/lockfile.rs
+++ b/binaries/cli/src/command/build/lockfile.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use dora_message::{
-    common::GitSource,
+    common::{BinaryPin, GitSource},
     descriptor::{GitRepoRev, NodeSource},
     id::NodeId,
 };
@@ -27,6 +27,8 @@ struct BuildLockfileView<'a> {
     version: u32,
     descriptor_fingerprint: &'a str,
     git_sources: &'a BTreeMap<NodeId, GitSource>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    binary_sources: &'a BTreeMap<NodeId, BinaryPin>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -35,6 +37,10 @@ pub struct BuildLockfile {
     #[serde(default)]
     descriptor_fingerprint: Option<String>,
     pub git_sources: BTreeMap<NodeId, GitSource>,
+    /// Per-node prebuilt-binary pins (spec §8.2). Empty/absent for plain-git
+    /// and pre-P2.8 lockfiles.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub binary_sources: BTreeMap<NodeId, BinaryPin>,
 }
 
 impl BuildLockfile {
@@ -123,14 +129,18 @@ impl BuildLockfile {
     pub fn write_git_sources(
         path: &Path,
         git_sources: &BTreeMap<NodeId, GitSource>,
+        binary_sources: &BTreeMap<NodeId, BinaryPin>,
         descriptor_fingerprint: &str,
     ) -> eyre::Result<()> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).context("failed to create lockfile directory")?;
         }
-        let has_hub_entries = git_sources
-            .values()
-            .any(|s| s.hub.is_some() || s.subdir.is_some());
+        // hub-form entries (subdir, provenance, or any binary pin) use the v3
+        // schema so an older dora fails loudly instead of dropping the fields.
+        let has_hub_entries = !binary_sources.is_empty()
+            || git_sources
+                .values()
+                .any(|s| s.hub.is_some() || s.subdir.is_some());
         let view = BuildLockfileView {
             version: if has_hub_entries {
                 LOCKFILE_VERSION
@@ -139,6 +149,7 @@ impl BuildLockfile {
             },
             descriptor_fingerprint,
             git_sources,
+            binary_sources,
         };
         let serialized = serde_yaml::to_string(&view).context("failed to serialize lockfile")?;
         // Write atomically (temp + rename in the same dir) so an interrupted
@@ -207,7 +218,13 @@ mod tests {
         let fingerprint =
             BuildLockfile::fingerprint_descriptor_git_sources(&descriptor_git_sources);
 
-        BuildLockfile::write_git_sources(&lockfile_path, &git_sources, &fingerprint).unwrap();
+        BuildLockfile::write_git_sources(
+            &lockfile_path,
+            &git_sources,
+            &BTreeMap::new(),
+            &fingerprint,
+        )
+        .unwrap();
         let loaded = BuildLockfile::read_from(&lockfile_path).unwrap();
 
         assert_eq!(loaded.version, BASE_LOCKFILE_VERSION);
@@ -232,7 +249,8 @@ mod tests {
             });
             s
         });
-        BuildLockfile::write_git_sources(&lockfile_path, &git_sources, "fp").unwrap();
+        BuildLockfile::write_git_sources(&lockfile_path, &git_sources, &BTreeMap::new(), "fp")
+            .unwrap();
         let loaded = BuildLockfile::read_from(&lockfile_path).unwrap();
         assert_eq!(loaded.version, LOCKFILE_VERSION);
         let node_id: NodeId = "detector".parse().unwrap();
@@ -245,7 +263,7 @@ mod tests {
             "node-a".parse().unwrap(),
             source("https://example.com/repo", "abc123"),
         )]);
-        BuildLockfile::write_git_sources(&lockfile_path, &plain, "fp").unwrap();
+        BuildLockfile::write_git_sources(&lockfile_path, &plain, &BTreeMap::new(), "fp").unwrap();
         let loaded = BuildLockfile::read_from(&lockfile_path).unwrap();
         assert_eq!(loaded.version, BASE_LOCKFILE_VERSION);
     }
@@ -261,6 +279,7 @@ mod tests {
             version: LOCKFILE_VERSION,
             descriptor_fingerprint: Some("abc".into()),
             git_sources,
+            binary_sources: BTreeMap::new(),
         };
 
         let err = lockfile
@@ -299,10 +318,44 @@ mod tests {
             version: 1,
             descriptor_fingerprint: None,
             git_sources: BTreeMap::new(),
+            binary_sources: BTreeMap::new(),
         };
         let err = lockfile
             .ensure_descriptor_fingerprint_matches("expected")
             .unwrap_err();
         assert!(err.to_string().contains("missing `descriptor_fingerprint`"));
+    }
+
+    #[test]
+    fn binary_sources_roundtrip_and_bump_version() {
+        use dora_message::common::HubProvenance;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let lockfile_path = tmp.path().join("bin.dora-lock.yaml");
+        let mut binary_sources = BTreeMap::new();
+        binary_sources.insert(
+            "lidar".parse().unwrap(),
+            BinaryPin {
+                platform: "linux-x86_64".into(),
+                url: "https://example.com/lidar-linux-x86_64".into(),
+                sha256: "a".repeat(64),
+                hub: HubProvenance {
+                    name: "acme/lidar".into(),
+                    version: "2.1.0".into(),
+                    manifest_digest: Some("deadbeef".into()),
+                },
+            },
+        );
+        BuildLockfile::write_git_sources(&lockfile_path, &BTreeMap::new(), &binary_sources, "fp")
+            .unwrap();
+        let loaded = BuildLockfile::read_from(&lockfile_path).unwrap();
+        // a binary pin is a hub entry -> the v3 schema, so older dora fails loud
+        assert_eq!(loaded.version, LOCKFILE_VERSION);
+        assert_eq!(loaded.binary_sources, binary_sources);
+        let node_id: NodeId = "lidar".parse().unwrap();
+        assert_eq!(
+            loaded.binary_sources[&node_id].url,
+            binary_sources[&node_id].url
+        );
     }
 }

--- a/binaries/cli/src/command/build/mod.rs
+++ b/binaries/cli/src/command/build/mod.rs
@@ -344,11 +344,13 @@ pub fn build(cfg: BuildConfig) -> eyre::Result<()> {
     // Desugar hub: nodes into concrete git nodes (spec §10.1) — after module
     // expansion, before type-checking
     let hub_pins = build_lockfile.as_ref().map(|l| l.git_sources.clone());
+    let hub_binary_pins = build_lockfile.as_ref().map(|l| l.binary_sources.clone());
     let hub_resolution = hub::resolve_hub_nodes(
         &mut dataflow_descriptor,
         &mut registry,
         offline,
         hub_pins.as_ref(),
+        hub_binary_pins.as_ref(),
         &hub_override_dirs,
     )?;
     let hub_override_node_dirs = hub_resolution.override_dirs.clone();
@@ -459,13 +461,18 @@ pub fn build(cfg: BuildConfig) -> eyre::Result<()> {
         }
     }
     if write_lockfile {
-        BuildLockfile::write_git_sources(&lockfile_path, &git_sources, &descriptor_fingerprint)
-            .with_context(|| {
-                format!(
-                    "failed to write build lockfile to `{}`",
-                    lockfile_path.display()
-                )
-            })?;
+        BuildLockfile::write_git_sources(
+            &lockfile_path,
+            &git_sources,
+            &hub_resolution.binary_sources,
+            &descriptor_fingerprint,
+        )
+        .with_context(|| {
+            format!(
+                "failed to write build lockfile to `{}`",
+                lockfile_path.display()
+            )
+        })?;
         log::info!("wrote build lockfile to {}", lockfile_path.display());
     }
 

--- a/binaries/cli/src/command/hub/fetch.rs
+++ b/binaries/cli/src/command/hub/fetch.rs
@@ -83,6 +83,12 @@ fn resolve_dataflow_pins(dataflow: &str) -> eyre::Result<Vec<GitSource>> {
     }
     let lockfile = BuildLockfile::read_from(&lockfile_path)?;
 
+    // hub nodes that resolved to a prebuilt binary — `dora hub fetch` clones git
+    // sources but does not pre-download binary artifacts yet (they are fetched +
+    // verified by the daemon at spawn time).
+    let binary_pinned: std::collections::BTreeSet<_> =
+        lockfile.binary_sources.keys().cloned().collect();
+
     // pinned hub sources from the lockfile, keyed by node id
     let pinned: std::collections::BTreeMap<_, _> = lockfile
         .git_sources
@@ -106,12 +112,19 @@ fn resolve_dataflow_pins(dataflow: &str) -> eyre::Result<Vec<GitSource>> {
         yaml_hub_nodes.insert(node.id.clone());
         let reference = PackageRef::parse(raw)
             .with_context(|| format!("node `{}`: invalid `hub:` reference", node.id))?;
-        let source = pinned.get(&node.id).ok_or_else(|| {
-            eyre::eyre!(
+        let source = match pinned.get(&node.id) {
+            Some(source) => source,
+            None if binary_pinned.contains(&node.id) => eyre::bail!(
+                "node `{}`: resolves to a prebuilt binary artifact — `dora hub fetch` does not \
+                 pre-download binary artifacts yet (the daemon fetches and verifies them at \
+                 spawn time); offline (UC7) binary prefetch is a follow-up",
+                node.id
+            ),
+            None => eyre::bail!(
                 "node `{}`: `hub:` reference is not in the lockfile — {regen}",
                 node.id
-            )
-        })?;
+            ),
+        };
         let prov = source.hub.as_ref().expect("filtered to hub sources");
         let version = dora_hub_client::semver::Version::parse(&prov.version)
             .map_err(|_| eyre::eyre!("node `{}`: invalid version in lockfile", node.id))?;
@@ -124,7 +137,11 @@ fn resolve_dataflow_pins(dataflow: &str) -> eyre::Result<Vec<GitSource>> {
         }
     }
     // the lockfile must not pin a hub node the dataflow no longer has
-    if let Some(id) = pinned.keys().find(|id| !yaml_hub_nodes.contains(*id)) {
+    if let Some(id) = pinned
+        .keys()
+        .chain(binary_pinned.iter())
+        .find(|id| !yaml_hub_nodes.contains(*id))
+    {
         eyre::bail!(
             "node `{id}`: the lockfile pins a `hub:` node the dataflow no longer has — {regen}"
         );

--- a/binaries/cli/src/command/hub/list.rs
+++ b/binaries/cli/src/command/hub/list.rs
@@ -40,6 +40,17 @@ impl Executable for List {
                 sanitize(&short)
             );
         }
+        for (node_id, pin) in &lockfile.binary_sources {
+            found = true;
+            // name/version/platform all come from the lockfile — sanitize before
+            // they reach the terminal, like the git path above.
+            println!(
+                "{node_id}: {} {} (binary {})",
+                sanitize(&pin.hub.name),
+                sanitize(&pin.hub.version),
+                sanitize(&pin.platform)
+            );
+        }
         if !found {
             println!("No hub packages pinned in {}.", lockfile_path.display());
         }

--- a/binaries/cli/src/command/hub/outdated.rs
+++ b/binaries/cli/src/command/hub/outdated.rs
@@ -35,10 +35,14 @@ impl Executable for Outdated {
         let mut checked = 0usize;
         let mut outdated = 0usize;
         let mut errored = 0usize;
-        for (node_id, source) in &lockfile.git_sources {
-            let Some(hub) = &source.hub else {
-                continue;
-            };
+        // both git-sourced and binary-sourced hub nodes carry the same hub
+        // provenance (name + version), so the upgrade check is identical.
+        let entries = lockfile
+            .git_sources
+            .iter()
+            .filter_map(|(id, s)| s.hub.as_ref().map(|h| (id, h)))
+            .chain(lockfile.binary_sources.iter().map(|(id, p)| (id, &p.hub)));
+        for (node_id, hub) in entries {
             checked += 1;
             // The node id, hub name, and version all come from the lockfile,
             // and resolve errors embed the lockfile-derived package key — none

--- a/binaries/cli/src/command/validate.rs
+++ b/binaries/cli/src/command/validate.rs
@@ -99,14 +99,14 @@ fn validate_dataflow(dataflow: &Path, strict_types: bool, offline: bool) -> eyre
     // against the index cache. Without a lockfile, fall through to live
     // resolution (same as before).
     let lockfile_path = super::build::lockfile::BuildLockfile::path_for_dataflow(dataflow, None);
-    let hub_pins = if lockfile_path.exists() {
+    let lockfile = if lockfile_path.exists() {
         match super::build::lockfile::BuildLockfile::read_from(&lockfile_path) {
             Ok(lf) => {
                 println!(
                     "  Using hub pins from lockfile `{}`",
                     lockfile_path.display()
                 );
-                Some(lf.git_sources)
+                Some(lf)
             }
             Err(e) => {
                 eprintln!(
@@ -119,6 +119,8 @@ fn validate_dataflow(dataflow: &Path, strict_types: bool, offline: bool) -> eyre
     } else {
         None
     };
+    let hub_pins = lockfile.as_ref().map(|l| l.git_sources.clone());
+    let hub_binary_pins = lockfile.as_ref().map(|l| l.binary_sources.clone());
 
     // Resolve hub: references so their contracts take part in validation
     // (spec §6.2 ordering note).
@@ -127,6 +129,7 @@ fn validate_dataflow(dataflow: &Path, strict_types: bool, offline: bool) -> eyre
         &mut registry,
         offline,
         hub_pins.as_ref(),
+        hub_binary_pins.as_ref(),
         &std::collections::BTreeMap::<String, std::path::PathBuf>::new(),
     )?;
     for note in &hub_resolution.notes {

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1973,6 +1973,7 @@ impl Daemon {
                             name: None,
                             description: None,
                             path: None,
+                            path_sha256: None,
                             args: None,
                             env: None,
                             operators: None,

--- a/binaries/daemon/src/spawn/command.rs
+++ b/binaries/daemon/src/spawn/command.rs
@@ -61,6 +61,16 @@ pub(super) async fn path_spawn_command(
                 .as_deref()
                 .filter(|_| source_is_url(source))
             {
+                // `path_sha256` is also a descriptor field, so a hand-written
+                // descriptor could set it to a traversal string. It is used as a
+                // path segment below, and `download_file` creates the target dir
+                // before verifying, so enforce the 64-hex-char shape at this
+                // trust boundary first (a valid digest has no `/`, `.`, …).
+                if expected_sha256.len() != 64
+                    || !expected_sha256.bytes().all(|b| b.is_ascii_hexdigit())
+                {
+                    eyre::bail!("invalid `path_sha256` (must be 64 hex chars)");
+                }
                 // hub binary artifact (spec §8.2): a sha256-pinned URL download.
                 // The checksum is the integrity guarantee, so this is allowed
                 // regardless of confinement / `permit_url`. `download_file`

--- a/binaries/daemon/src/spawn/command.rs
+++ b/binaries/daemon/src/spawn/command.rs
@@ -69,8 +69,11 @@ pub(super) async fn path_spawn_command(
                 // Download under the node's own working dir and return an
                 // absolute path: the spawned child's cwd is set to `working_dir`,
                 // so a relative download path (resolved against the daemon's cwd)
-                // would exec the wrong file or fail to find it.
-                let target_dir = working_dir.join("build");
+                // would exec the wrong file or fail to find it. Scope by the
+                // sha256 (content-addressed) so two nodes whose artifacts share a
+                // filename — and a `working_dir` that defaults to the shared
+                // dataflow dir — don't overwrite each other.
+                let target_dir = working_dir.join("build").join(expected_sha256);
                 let downloaded = download_file(source, &target_dir, Some(expected_sha256))
                     .await
                     .wrap_err("failed to download hub binary artifact")?;

--- a/binaries/daemon/src/spawn/command.rs
+++ b/binaries/daemon/src/spawn/command.rs
@@ -48,6 +48,14 @@ pub(super) async fn path_spawn_command(
             }
         }
         source => {
+            // a checksum only means anything for a URL download — reject a
+            // `path_sha256` on a local/PATH source rather than silently ignoring it.
+            if node.path_sha256.is_some() && !source_is_url(source) {
+                eyre::bail!(
+                    "node has `path_sha256` set but its path `{source}` is not a URL — \
+                     a download checksum only applies to URL paths"
+                );
+            }
             let resolved_path = if let Some(expected_sha256) = node
                 .path_sha256
                 .as_deref()
@@ -55,8 +63,8 @@ pub(super) async fn path_spawn_command(
             {
                 // hub binary artifact (spec §8.2): a sha256-pinned URL download.
                 // The checksum is the integrity guarantee, so this is allowed
-                // regardless of confinement / `permit_url`, and re-verified
-                // after download and on cache reuse (§8.4).
+                // regardless of confinement / `permit_url`. `download_file`
+                // re-fetches and re-verifies on every spawn (§8.4).
                 let target_dir = Path::new("build");
                 download_file(source, target_dir, Some(expected_sha256))
                     .await

--- a/binaries/daemon/src/spawn/command.rs
+++ b/binaries/daemon/src/spawn/command.rs
@@ -65,10 +65,16 @@ pub(super) async fn path_spawn_command(
                 // The checksum is the integrity guarantee, so this is allowed
                 // regardless of confinement / `permit_url`. `download_file`
                 // re-fetches and re-verifies on every spawn (§8.4).
-                let target_dir = Path::new("build");
-                download_file(source, target_dir, Some(expected_sha256))
+                //
+                // Download under the node's own working dir and return an
+                // absolute path: the spawned child's cwd is set to `working_dir`,
+                // so a relative download path (resolved against the daemon's cwd)
+                // would exec the wrong file or fail to find it.
+                let target_dir = working_dir.join("build");
+                let downloaded = download_file(source, &target_dir, Some(expected_sha256))
                     .await
-                    .wrap_err("failed to download hub binary artifact")?
+                    .wrap_err("failed to download hub binary artifact")?;
+                downloaded.canonicalize().unwrap_or(downloaded)
             } else if confined {
                 // hub-sourced node (spec §11): the entrypoint resolves only
                 // within the node's own working dir or managed env — no env

--- a/binaries/daemon/src/spawn/command.rs
+++ b/binaries/daemon/src/spawn/command.rs
@@ -48,7 +48,20 @@ pub(super) async fn path_spawn_command(
             }
         }
         source => {
-            let resolved_path = if confined {
+            let resolved_path = if let Some(expected_sha256) = node
+                .path_sha256
+                .as_deref()
+                .filter(|_| source_is_url(source))
+            {
+                // hub binary artifact (spec §8.2): a sha256-pinned URL download.
+                // The checksum is the integrity guarantee, so this is allowed
+                // regardless of confinement / `permit_url`, and re-verified
+                // after download and on cache reuse (§8.4).
+                let target_dir = Path::new("build");
+                download_file(source, target_dir, Some(expected_sha256))
+                    .await
+                    .wrap_err("failed to download hub binary artifact")?
+            } else if confined {
                 // hub-sourced node (spec §11): the entrypoint resolves only
                 // within the node's own working dir or managed env — no env
                 // expansion, no URL download, no ambient-$PATH fallback.

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -116,6 +116,7 @@ impl DescriptorExt for Descriptor {
                 } => CoreNodeKind::Custom(CustomNode {
                     path: path.clone(),
                     source,
+                    path_sha256: node.path_sha256,
                     args: node.args,
                     build: node.build,
                     send_stdout_as: node.send_stdout_as,
@@ -160,6 +161,7 @@ impl DescriptorExt for Descriptor {
                     CoreNodeKind::Custom(CustomNode {
                         path: "dora-ros2-bridge-node".to_string(),
                         source: NodeSource::Local,
+                        path_sha256: None,
                         args: node.args,
                         build: None,
                         send_stdout_as: node.send_stdout_as,

--- a/libraries/extensions/download/src/lib.rs
+++ b/libraries/extensions/download/src/lib.rs
@@ -76,7 +76,9 @@ where
     hasher.update(&bytes);
     let actual_hash = format!("{:x}", hasher.finalize());
     if let Some(expected) = expected_sha256 {
-        if actual_hash != expected {
+        // `actual_hash` is lowercase hex; a digest from an index/lockfile may be
+        // uppercase, so compare case-insensitively rather than rejecting it.
+        if !expected.eq_ignore_ascii_case(&actual_hash) {
             eyre::bail!("SHA-256 mismatch for `{url}`: expected {expected}, got {actual_hash}");
         }
     } else {

--- a/libraries/hub-client/src/index.rs
+++ b/libraries/hub-client/src/index.rs
@@ -43,7 +43,7 @@ pub struct IndexEntry {
 /// The git form is the default and the v1 source-of-record. The binary form
 /// is reserved in the schema (spec §8.2) and parses, but consuming it is
 /// deferred to P2.8.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SourceSpec {
     /// Git repository URL holding the node's source.
@@ -105,6 +105,41 @@ impl SourceSpec {
             ),
             _ => eyre::bail!("index entry has an incomplete git source (needs `git` + `rev`)"),
         }
+    }
+
+    /// The prebuilt artifact matching `platform` (e.g. `linux-x86_64`), if the
+    /// source ships one (spec §8.2). Selection is exact-match on the platform
+    /// string; the caller falls back to `fallback_git` when this returns `None`.
+    pub fn select_binary(&self, platform: &str) -> Option<&BinaryArtifact> {
+        self.binary.iter().find(|a| a.platform == platform)
+    }
+}
+
+/// The platform string for the current host, matching a binary artifact's
+/// `platform` field: `<os>-<arch>` (`linux-x86_64`, `macos-aarch64`, …),
+/// from `std::env::consts::{OS, ARCH}`.
+pub fn current_platform() -> String {
+    format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH)
+}
+
+impl BinaryArtifact {
+    /// Validate an *untrusted* index artifact before it is used: the URL is an
+    /// `https://` download (it becomes a network fetch) and the digest is a
+    /// full SHA-256 (64 hex chars, re-verified after download — §8.4).
+    pub fn validate(&self) -> eyre::Result<()> {
+        if !self.url.starts_with("https://") {
+            eyre::bail!(
+                "binary artifact for `{}` has a non-https url",
+                self.platform
+            );
+        }
+        if self.sha256.len() != 64 || !self.sha256.chars().all(|c| c.is_ascii_hexdigit()) {
+            eyre::bail!(
+                "binary artifact for `{}` has an invalid sha256 (need 64 hex chars)",
+                self.platform
+            );
+        }
+        Ok(())
     }
 }
 
@@ -636,5 +671,62 @@ mod tests {
             catalog.all_packages(),
             vec![("dora-rs".to_string(), "dora-yolo".to_string())]
         );
+    }
+
+    fn art(platform: &str) -> BinaryArtifact {
+        BinaryArtifact {
+            platform: platform.to_string(),
+            url: format!("https://example.com/{platform}"),
+            sha256: "a".repeat(64),
+        }
+    }
+
+    #[test]
+    fn current_platform_is_os_dash_arch() {
+        assert_eq!(
+            current_platform(),
+            format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH)
+        );
+    }
+
+    #[test]
+    fn select_binary_exact_matches_platform() {
+        let src = SourceSpec {
+            binary: vec![art("linux-x86_64"), art("macos-aarch64")],
+            ..SourceSpec::default()
+        };
+        assert_eq!(
+            src.select_binary("linux-x86_64").unwrap().platform,
+            "linux-x86_64"
+        );
+        assert_eq!(
+            src.select_binary("macos-aarch64").unwrap().platform,
+            "macos-aarch64"
+        );
+        // no fuzzy/substring matching — an uncovered arch returns None so the
+        // caller can fall back to `fallback-git`.
+        assert!(src.select_binary("linux-aarch64").is_none());
+        assert!(
+            SourceSpec::default()
+                .select_binary("linux-x86_64")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn binary_artifact_validate_rejects_http_and_bad_sha() {
+        assert!(art("linux-x86_64").validate().is_ok());
+        // non-https url
+        let mut a = art("linux-x86_64");
+        a.url = "http://example.com/x".into();
+        assert!(a.validate().is_err());
+        // short sha
+        let mut a = art("linux-x86_64");
+        a.sha256 = "abcd".into();
+        assert!(a.validate().is_err());
+        // non-hex sha of the right length
+        let mut a = art("linux-x86_64");
+        a.sha256 = "z".repeat(64);
+        assert!(a.validate().is_err());
     }
 }

--- a/libraries/message/src/common.rs
+++ b/libraries/message/src/common.rs
@@ -383,6 +383,22 @@ pub struct HubProvenance {
     pub manifest_digest: Option<String>,
 }
 
+/// Lockfile pin for a `hub:` node resolved to a prebuilt binary artifact
+/// (spec §8.2). Mirrors [`GitSource`] for the binary source form: the
+/// `url`+`sha256` pin the bytes (re-verified on download), and `hub` records
+/// the package/version/manifest provenance for `--locked` tamper detection.
+#[derive(Debug, serde::Deserialize, serde::Serialize, Clone, PartialEq, Eq)]
+pub struct BinaryPin {
+    /// Platform the artifact was selected for at lock time (`<os>-<arch>`).
+    pub platform: String,
+    /// Download URL of the prebuilt artifact.
+    pub url: String,
+    /// SHA-256 the download must match.
+    pub sha256: String,
+    /// Hub provenance (index key, version, manifest digest).
+    pub hub: HubProvenance,
+}
+
 // Test roundtrip serialization of LogMessage
 #[cfg(test)]
 mod tests {

--- a/libraries/message/src/descriptor.rs
+++ b/libraries/message/src/descriptor.rs
@@ -304,6 +304,12 @@ pub struct Node {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
 
+    /// SHA-256 checksum the `path` download must match, verified after fetch
+    /// and on cache reuse (spec §8.2/§8.4). Set internally when a `hub:`
+    /// reference resolves to a prebuilt binary artifact; rarely set by hand.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path_sha256: Option<String>,
+
     /// Command-line arguments passed to the executable.
     ///
     /// The command-line arguments that should be passed to the executable/script specified in `path`.
@@ -1059,6 +1065,11 @@ pub struct CustomNode {
     /// Source can match any executable in PATH.
     pub path: String,
     pub source: NodeSource,
+    /// SHA-256 the `path` download must match (set for hub binary artifacts,
+    /// spec §8.2). When present the daemon fetches `path` as a verified URL
+    /// download regardless of confinement — the checksum is the trust anchor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path_sha256: Option<String>,
     /// Args for the executable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub args: Option<String>,


### PR DESCRIPTION
Implements **Hub P2.8 — the binary source form** (closes #2202): `dora` now *acts on* an index entry's `binary` source (spec §8.1/§8.2) instead of leaving it schema-reserved.

## Behaviour

- **Covered platform** → the node resolves to its prebuilt artifact and is fetched as a **sha256-verified URL download**.
- **Uncovered platform** → degrades to a source build via **`fallback-git`** (cargo-binstall model), or hard-fails when none is offered.
- **Tampered artifact** (sha256 mismatch) → fails loudly at download.
- **`--locked`** → reproduces the exact pinned `url`+`sha256` from the lockfile.

## How it's wired (2 commits)

**1. Consume the binary source form** (`606ec8f`)
- `hub-client`: `current_platform()` (`<os>-<arch>`), `SourceSpec::select_binary()`, `BinaryArtifact::validate()` (https + 64-hex sha256).
- descriptor: a `path_sha256` field on `Node`/`CustomNode` carries the checksum from CLI resolution to the daemon.
- `resolve_hub_nodes`: a `NodeBytes::{Git,Binary}` split — binary entries desugar to a `path: <url>` node with `path_sha256`; git/`fallback-git` keep the existing source-build path.
- daemon spawn: a sha256-pinned URL is fetched + verified via `download_file`'s `expected_sha256` **regardless of confinement** (the checksum is the trust anchor); `download_file` re-fetches + re-verifies each spawn (§8.4).

**2. Lockfile binary pins** (`70131cc`)
- `BinaryPin` type (mirrors `GitSource`); a `binary_sources` map in the lockfile (v3 schema, skipped when empty).
- `--locked` resolves binary nodes via `resolve_locked_binary`: pinned `url`+`sha256` used verbatim, while still cross-checking the index entry's artifact (warn on rewrite) and hard-checking the manifest digest — mirroring the git locked path.

## Tests
- hub-client: platform string, artifact selection, artifact validation.
- cli: the covered / fallback / no-fallback / git resolution paths; lockfile binary round-trip (v3 + pins preserved).
- Full workspace compiles; `fmt --check`, `clippy`, `cargo check --examples`, and the affected-crate test suites pass.

Built on top of the four hub-hardening fixes (#2227–#2231).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
