### PR TITLE
fix(validate): make hub: pin resolution best-effort, not strict-locked

### DIFF
--- a/binaries/cli/src/command/build/hub.rs
+++ b/binaries/cli/src/command/build/hub.rs
@@ -92,11 +92,20 @@ fn manifest_digest(manifest: &NodeManifest) -> eyre::Result<String> {
 /// the pinned commit is used verbatim and the index entry of the pinned
 /// version supplies the manifest. Without pins, each reference resolves to
 /// the highest non-yanked matching version.
+///
+/// `strict_pins` controls what happens when `pins` is `Some` but a hub node
+/// has no entry in the pins map:
+/// - `true` (used by `dora build --locked`): hard-fail immediately — the
+///   caller demanded every hub node be pinned.
+/// - `false` (used by `dora validate`): fall back to live resolution for
+///   the unpinned node rather than erroring; pinned nodes still use their
+///   lockfile entry.
 pub fn resolve_hub_nodes(
     dataflow: &mut Descriptor,
     registry: &mut TypeRegistry,
     offline: bool,
     pins: Option<&BTreeMap<NodeId, GitSource>>,
+    strict_pins: bool,
     overrides: &BTreeMap<String, PathBuf>,
 ) -> eyre::Result<HubResolution> {
     let mut resolution = HubResolution::default();
@@ -206,11 +215,17 @@ pub fn resolve_hub_nodes(
             continue;
         }
 
-        // under `--locked` (pins present), a node with no lockfile entry must
-        // fail fast — *before* any index fetch — rather than hitting the
-        // network (or an offline cache miss) only to bail afterwards.
+        // under `--locked` (pins present, strict_pins=true), a node with no
+        // lockfile entry must fail fast — *before* any index fetch — rather
+        // than hitting the network (or an offline cache miss) only to bail
+        // afterwards.
+        //
+        // When strict_pins=false (e.g. `dora validate` with a lockfile), a
+        // missing pin is not an error: the node is resolved live so that
+        // `dora validate` never fails harder than `dora build` (without
+        // `--locked`) would on the same dataflow.
         let pin = pins.and_then(|p| p.get(&node.id));
-        if pins.is_some() && pin.is_none() {
+        if strict_pins && pins.is_some() && pin.is_none() {
             eyre::bail!(
                 "node `{}`: `hub:` reference is not in the lockfile — \
                  regenerate with `dora build --write-lockfile`",

--- a/binaries/cli/src/command/build/mod.rs
+++ b/binaries/cli/src/command/build/mod.rs
@@ -349,6 +349,9 @@ pub fn build(cfg: BuildConfig) -> eyre::Result<()> {
         &mut registry,
         offline,
         hub_pins.as_ref(),
+        // `--locked` (build_lockfile.is_some()) means every hub node must have
+        // a lockfile pin; no fallback to live resolution.
+        build_lockfile.is_some(),
         &hub_override_dirs,
     )?;
     let hub_override_node_dirs = hub_resolution.override_dirs.clone();

--- a/binaries/cli/src/command/validate.rs
+++ b/binaries/cli/src/command/validate.rs
@@ -122,11 +122,17 @@ fn validate_dataflow(dataflow: &Path, strict_types: bool, offline: bool) -> eyre
 
     // Resolve hub: references so their contracts take part in validation
     // (spec §6.2 ordering note).
+    //
+    // Use best-effort pins (strict_pins=false): nodes present in the lockfile
+    // use their pinned version; nodes absent from the lockfile fall back to
+    // live resolution rather than hard-failing. This keeps `dora validate` no
+    // stricter than `dora build` (without `--locked`) on the same dataflow.
     let hub_resolution = super::build::hub::resolve_hub_nodes(
         &mut descriptor,
         &mut registry,
         offline,
         hub_pins.as_ref(),
+        false,
         &std::collections::BTreeMap::<String, std::path::PathBuf>::new(),
     )?;
     for note in &hub_resolution.notes {


### PR DESCRIPTION
Closes #2234

## Summary

PR #2229 made `dora validate` pass lockfile pins to `resolve_hub_nodes` whenever a `.dora-lock.yaml` exists — but `resolve_hub_nodes` treats any non-`None` `pins` as all-or-nothing strict-locked mode, hard-failing for any hub node not present in the lockfile. This made `dora validate` stricter than `dora build` (without `--locked`) on the same dataflow.

**Concrete regression:** add a new hub node `C` to a dataflow that already has a lockfile for nodes `A` and `B` → `dora validate` fails with *"node `C`: `hub:` reference is not in the lockfile"* even though `dora build` and `dora run` both resolve `C` live and succeed.

## Fix

Add a `strict_pins: bool` parameter to `resolve_hub_nodes`:

- **`strict_pins: true`** (used by `dora build --locked`) — existing behaviour: all hub nodes must be pinned, hard-fail otherwise.
- **`strict_pins: false`** (used by `dora validate`) — best-effort: use a pin when present, fall through to live resolution otherwise. A stale or partial lockfile warns but doesn't block validation.

Changed files:
- `binaries/cli/src/command/build/hub.rs` — adds `strict_pins` param; the bail is now guarded by `strict_pins`.
- `binaries/cli/src/command/build/mod.rs` — passes `strict_pins: build_lockfile.is_some()` (preserves existing locked build behaviour).
- `binaries/cli/src/command/validate.rs` — passes `strict_pins: false`.

## Test plan

- [x] `cargo fmt -p dora-cli -- --check`
- [x] `cargo clippy -p dora-cli -- -D warnings`
- [x] `cargo test -p dora-cli` — all 214 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code/session_011W4GgG3pYa7AhaGiy5m54b)

---
_Generated by [Claude Code](https://claude.ai/code/session_011W4GgG3pYa7AhaGiy5m54b)_