### PR TITLE
chore(deps): bump git2 0.20.4 -> 0.21 (fixes RUSTSEC-2026-0183)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2991,9 +2991,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.20.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
  "bitflags 2.13.0",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,7 +133,10 @@ pyo3 = { version = "0.28", features = [
 ] }
 pythonize = "0.28"
 pyo3-build-config = { version = "0.28", features = ["resolve-config", "abi3-py311"] }
-git2 = { version = "0.20.4", features = ["vendored-openssl"] }
+# git2 0.21 dropped `https`/`ssh` from its default features (0.20 had
+# `default = ["ssh", "https"]`), so request them explicitly — otherwise
+# libgit2 ships without a TLS transport ("no TLS stream available").
+git2 = { version = "0.21", features = ["vendored-openssl", "https", "ssh"] }
 serde_yaml = "0.9.33"
 zenoh = { version = "~1.8", default-features = false, features = ["shared-memory", "unstable", "transport_tcp", "transport_udp", "transport_unixsock-stream"] }
 serde_json = "1.0.145"


### PR DESCRIPTION
## What

Bump the workspace `git2` dependency `0.20.4 → 0.21` to fix **RUSTSEC-2026-0183**.

## Why

git2 `< 0.21.0` passes a null pointer to `slice::from_raw_parts()` in `Remote::list()` when a remote advertises no references — undefined behaviour (the advisory is **INFO / unsound**). The only patched release is **`>= 0.21.0`**, so a bump is the only fix (no 0.20.x patch exists).

The advisory blocks the **supply-chain audit gate (`cargo-audit` + `cargo-deny`)** on every open PR, so this unblocks them all.

## Verification

`git2` is a direct workspace dependency (used by `dora-core`, `dora-cli`, `dora-daemon`). 0.21.0 is a clean upgrade:

- `cargo check --workspace` (excl. Python) builds; `dora-core`/`dora-cli`/`dora-daemon` compile **unchanged** (no API breaks).
- `cargo deny check advisories` → **advisories ok**; `cargo audit` → **no vulnerabilities** (only pre-existing allowed warnings).
- The git2 clone path still works at runtime: `tests/hub-smoke.rs::hub_end_to_end` passes.
- Single `git2 0.21.0` in `Cargo.lock` (no duplicate versions).

Diff is `Cargo.toml` (one line) + `Cargo.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
