### PR TITLE
docs(hub): user-facing documentation for the Dora Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ See the [Distributed Deployment Guide](docs/distributed-deployment.md) for clust
 | `dora hub publish [PATH]` | Validate + add a pinned index entry (`--dry-run`) |
 | `dora hub yank <pkg>@<ver>` | Yank/restore a published version (`--undo`) |
 | `dora hub list/outdated/update <dataflow>` | Inspect, check, and refresh lockfile pins |
-| `dora hub fetch <target>` | Mirror pinned sources for offline builds |
+| `dora hub fetch <target>` | Mirror pinned sources locally (inspection / CI / transfer) |
 
 Reference a node with one line of YAML -- `hub: dora-yolo@^0.5` -- and `dora build` resolves, pins, and type-checks it. See the [Hub guide](guide/src/hub/overview.md).
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@
 
 - **Communication patterns** -- built-in [service (request/reply)](docs/patterns.md#2-service-requestreply), [action (goal/feedback/result)](docs/patterns.md#3-action-goalfeedbackresult), and [streaming (session/segment/chunk)](docs/patterns.md#4-streaming-sessionsegmentchunk) patterns via well-known metadata keys; no daemon or YAML changes required
 - **ROS2 bridge** -- bidirectional interop with ROS2 topics, services, and actions; QoS mapping; Arrow-native type conversion
-- **Pre-packaged nodes** -- [node hub](https://github.com/dora-rs/dora-hub/) with ready-made nodes for cameras, YOLO, LLMs, TTS, and more
+- **Node Hub (package manager)** -- pull a reusable node into a dataflow with one line -- `hub: dora-yolo@^0.5` -- with cargo-style versioned resolution, reproducible lockfiles (`--locked`), and typed contracts checked at build time; backed by a git-based [public catalog](https://github.com/dora-rs/dora-hub/) of ready-made nodes for cameras, YOLO, LLMs, TTS, and more. See the [Hub guide](guide/src/hub/overview.md) *(unstable)*
 - **In-process operators** -- lightweight functions that run inside a shared runtime, avoiding per-node process overhead for simple transformations
 
 ## Installation
@@ -302,6 +302,20 @@ See the [Distributed Deployment Guide](docs/distributed-deployment.md) for clust
 | `dora system` | System management (daemon/coordinator control) |
 | `dora completion <SHELL>` | Generate shell completions |
 | `dora self update` | Update dora CLI |
+
+### Node Hub (unstable)
+
+| Command | Description |
+|---------|-------------|
+| `dora hub search <query>` | Find nodes by name, keyword, or category |
+| `dora hub info <pkg>[@<ver>]` | Show a package's typed contracts + example |
+| `dora hub init [PATH]` | Scaffold a `dora-node.yml` manifest |
+| `dora hub publish [PATH]` | Validate + add a pinned index entry (`--dry-run`) |
+| `dora hub yank <pkg>@<ver>` | Yank/restore a published version (`--undo`) |
+| `dora hub list/outdated/update <dataflow>` | Inspect, check, and refresh lockfile pins |
+| `dora hub fetch <target>` | Mirror pinned sources for offline builds |
+
+Reference a node with one line of YAML -- `hub: dora-yolo@^0.5` -- and `dora build` resolves, pins, and type-checks it. See the [Hub guide](guide/src/hub/overview.md).
 
 For full CLI documentation, see [docs/cli.md](docs/cli.md). For distributed deployment, see [docs/distributed-deployment.md](docs/distributed-deployment.md).
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1164,7 +1164,7 @@ version (the index is append-only). For a git-backed index it prints the entry
 and where to add it; automated PR-opening against the official `node-index`
 lands with the index bootstrap.
 
-`search`/`info`/`fetch` accept `--offline` to use only the cached index.
+`search`/`info`/`outdated`/`update` accept `--offline` to use only the cached index.
 Indexes are configured in `~/.config/dora/hub.toml`; a namespace resolves
 against exactly one index (see the plan §7.3). `hub:` nodes in a dataflow are
 resolved by `dora build` — there is deliberately no `dora hub install` (hub

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1101,17 +1101,19 @@ See the [Type Annotations Guide](types.md) for the full type library and usage d
 
 #### `dora hub` (unstable)
 
-Package, discover, and use dora nodes (see
-[the Dora Hub plan](plan-node-hub.md)):
+Package, discover, and use dora nodes. For the full walkthrough see the
+[Hub guide](../guide/src/hub/overview.md); the design spec is
+[the Dora Hub plan](plan-node-hub.md).
 
 ```
 dora hub init [PATH]                       # scaffold a dora-node.yml manifest
 dora hub search <query> [--category C]     # find nodes by name/keyword/category
-                        [--platform P]
-dora hub info <pkg>[@<ver>]                # contracts + example for a package
+                        [--platform P] [--offline]
+dora hub info <pkg>[@<ver>] [--offline]    # contracts + example for a package
 dora hub list <dataflow.yml>               # hub packages pinned in the lockfile
 dora hub fetch <dataflow.yml | pkg@ver>    # warm the index cache + mirror sources
                [--target-dir DIR]
+dora hub install                           # (stub) prints how to add a hub: node
 dora hub publish [PATH] [--dry-run]        # validate + add a pinned index entry
                  [--rev REF] [--repo URL]
                  [--version SEMVER] [--index ALIAS]

--- a/docs/yaml-spec.md
+++ b/docs/yaml-spec.md
@@ -57,7 +57,7 @@ Every node requires an `id`. All other fields are optional (though most nodes ne
 
 ### Source
 
-A node's executable comes from a local path, a git repository, a module reference, or is implicit (operator/ROS2 nodes).
+A node's executable comes from a local path, a git repository, a hub package, a module reference, or is implicit (operator/ROS2 nodes).
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -67,6 +67,7 @@ A node's executable comes from a local path, a git repository, a module referenc
 | `branch` | string | Branch to checkout (requires `git`, mutually exclusive with `tag`/`rev`) |
 | `tag` | string | Tag to checkout (requires `git`, mutually exclusive with `branch`/`rev`) |
 | `rev` | string | Commit hash to checkout (requires `git`, mutually exclusive with `branch`/`tag`) |
+| `hub` | string | A Hub package reference `[<namespace>/]<name>@<version-req>` (mutually exclusive with `path`/`git`/`build`). `dora build` resolves it to a pinned commit (or binary) and injects its typed contracts. **Unstable.** See [Hub guide](../guide/src/hub/overview.md) |
 | `build` | string | Build commands run during `dora build`. Each line runs separately. With `--uv`, `pip`/`pip3` lines use `uv pip` and Python nodes get a dedicated managed venv at `<working-dir>/.dora/python-envs/<node-id>/` that the runtime reuses at spawn time. See [CLI reference](cli.md#dora-build) for details. |
 | `args` | string | Command-line arguments (space-separated) |
 
@@ -78,6 +79,17 @@ Example with git source:
   branch: main
   build: cargo build -p example-node --release
   path: target/release/example-node
+```
+
+Example with a hub source (resolution provides the build + path):
+
+```yaml
+- id: detector
+  hub: dora-yolo@^0.5        # [namespace/]name@semver-req; bare name = dora-rs/
+  inputs:
+    image: camera/image
+  outputs:
+    - bbox
 ```
 
 ### Data I/O

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -41,7 +41,12 @@
 
 # Node Packaging (Dora Hub)
 
+- [Overview](hub/overview.md)
+- [Using Hub Nodes](hub/using-nodes.md)
 - [Writing a Node Manifest](hub/node-manifest.md)
+- [Reproducible Builds](hub/reproducible-builds.md)
+- [Publishing a Node](hub/publishing.md)
+- [Custom & Enterprise Indexes](hub/indexes.md)
 
 # Development
 

--- a/guide/src/hub/indexes.md
+++ b/guide/src/hub/indexes.md
@@ -1,0 +1,126 @@
+# Custom & Enterprise Indexes
+
+By default the Hub resolves every namespace from the public catalog at
+[`dora-rs/dora-hub`](https://github.com/dora-rs/dora-hub). With **no config at
+all**, that is the only index. A `hub.toml` lets you add private or mirrored
+catalogs and bind namespaces to them — for an internal node registry, an
+air-gapped mirror, or an enterprise fork.
+
+## `hub.toml`
+
+Config lives at `~/.config/dora/hub.toml` (override the path with the
+`DORA_HUB_CONFIG` environment variable). It is a list of `[[index]]` entries:
+
+```toml
+# An internal git-backed catalog for the `acme` namespace.
+[[index]]
+alias = "acme"
+git = "https://git.acme.internal/dora-index"
+namespaces = ["acme", "acme-labs"]
+
+# A local on-disk catalog (useful for testing or air-gapped setups).
+[[index]]
+alias = "local"
+path = "/srv/dora-index"
+namespaces = ["sandbox"]
+```
+
+Each `[[index]]` has:
+
+| Key | Meaning |
+|---|---|
+| `alias` | required; unique (case-insensitive); also the cache directory name |
+| `git` | the catalog's git remote URL … |
+| `path` | … **or** a local catalog directory (a subpath within a git clone defaults to `node-index`) |
+| `namespaces` | the namespaces this index exclusively serves |
+
+## Namespace binding (no dependency confusion)
+
+Resolution is **not** a search order — it's an exclusive mapping, which is what
+prevents dependency-confusion attacks:
+
+- A namespace listed under an index resolves **only** there.
+- Any namespace **not** bound to a custom index resolves from the official
+  catalog.
+- Binding the same namespace to two indexes is a **config error**.
+- The official `dora-rs` namespace always resolves to the official catalog; a
+  custom index cannot claim it.
+
+So `hub: acme/lidar` in the config above resolves from the `acme` index, while
+`hub: dora-yolo` still resolves from the official catalog — there is exactly one
+place each can come from.
+
+### Mirroring the official index
+
+Point the reserved `official` alias at an internal mirror to serve even the
+`dora-rs` namespace from your own infrastructure:
+
+```toml
+[[index]]
+alias = "official"
+git = "https://git.acme.internal/dora-hub-mirror"
+```
+
+## Binary distribution
+
+A published node can ship a **prebuilt binary** for a platform instead of
+requiring every consumer to compile from source — the cargo-binstall model. The
+index entry's source gains a `binary` list:
+
+```yaml
+source:
+  binary:
+    - platform: linux-x86_64
+      url: https://artifacts.acme.internal/lidar-2.1-linux-x86_64.tar.gz
+      sha256: <64-hex>
+  fallback-git:          # optional: build from source where no binary matches
+    git: https://git.acme.internal/lidar
+    rev: <full-commit-hash>
+    subdir: nodes/lidar
+```
+
+At resolution time:
+
+- if the entry ships a binary for the **current** platform (`<os>-<arch>`, exact
+  match), the node becomes a sha256-verified URL download — **no clone, no
+  build**;
+- else if a `fallback-git` source is present, the node builds from that;
+- else resolution fails with a clear "no binary for this platform" error.
+
+The artifact `url` must be `https://` and the `sha256` (64 hex chars) is
+re-verified after download. A binary pin is recorded in the lockfile so
+`--locked` reproduces the exact artifact, and the **daemon** fetches and verifies
+it at node spawn time.
+
+> `dora hub fetch` mirrors git sources but **not** binary artifacts. For an
+> air-gapped binary node, host the artifact `url` somewhere the target can reach.
+
+## Catalog layout
+
+A catalog (the official one or your own) is a directory tree:
+
+```
+node-index/
+  <namespace>/
+    <name>/
+      package.yml        # description, repo, owners
+      <version>.yml      # one immutable entry per published version
+```
+
+Each `<version>.yml` holds the node's manifest verbatim plus its `source`
+(git pin or binary), `published` timestamp, and `yanked` flag. The catalog is
+append-only — the only permitted mutation to a published version is the `yanked`
+flag. See [Publishing a Node](publishing.md) for adding entries.
+
+## Security notes
+
+The Hub treats index entries as untrusted input:
+
+- git source URLs are scheme-validated (`https`/`ssh`/`file`/`git@`) before any
+  `git` subprocess runs; cleartext `git://` is rejected. Untrusted index entries
+  may not point at local paths unless `DORA_HUB_ALLOW_LOCAL_SOURCES=1`.
+- a `rev` must be a full 40/64-char hex commit — no branches, tags, or
+  abbreviations (those are mutable).
+- an entry's declared `namespace` must match the namespace it was fetched under,
+  and catalog reads/writes are confined to the catalog root (no symlink escapes).
+- binary artifacts are sha256-verified after download.

--- a/guide/src/hub/overview.md
+++ b/guide/src/hub/overview.md
@@ -67,7 +67,7 @@ satisfies it. See [Using Hub Nodes](using-nodes.md) for the full syntax.
 - **[Writing a Node Manifest](node-manifest.md)** — turn your own code into a
   node others can use with one line.
 - **[Reproducible Builds](reproducible-builds.md)** — lockfiles, `--locked`,
-  checking for and applying updates, offline and air-gapped builds.
+  checking for and applying updates, offline builds, and mirroring sources.
 - **[Publishing a Node](publishing.md)** — add your node to a catalog, manage
   versions, and the namespace/ownership model.
 - **[Custom & Enterprise Indexes](indexes.md)** — private/mirrored catalogs via

--- a/guide/src/hub/overview.md
+++ b/guide/src/hub/overview.md
@@ -1,0 +1,82 @@
+# Overview
+
+The **Dora Hub** lets you use a reusable node in a dataflow with one line of
+YAML, instead of vendoring its source or hand-writing a `path:`/`git:` entry:
+
+```yaml
+nodes:
+  - id: detector
+    hub: dora-yolo@^0.5      # ← resolved from the Hub, pinned, contract-checked
+    inputs:
+      image: camera/image
+    outputs:
+      - bbox
+```
+
+`dora build` resolves `dora-yolo@^0.5` to a specific published version, pins it
+to an exact commit, injects its typed input/output contracts into validation,
+and builds it — the same way `cargo` or `npm` resolve a dependency.
+
+> The `hub:` feature is **unstable**: its behaviour may change in a future
+> release. The node manifest format itself (`apiVersion: 1`) is stable and
+> useful without the Hub — see [Writing a Node Manifest](node-manifest.md).
+
+## The model
+
+The Hub is a **package manager for dora nodes**, deliberately cargo-style:
+
+- **Per-dataflow resolution, no global install.** There is no `dora hub install`
+  that mutates a machine. A node is a dependency of *a dataflow*; you add `hub:`
+  to the YAML and `dora build` resolves it. (`dora hub install` exists only to
+  point you at this.)
+- **A git-backed index, not an artifact upload.** Publishing adds a small
+  *index entry* that points at a git commit of the node's source; it does not
+  upload a tarball. The default index is the public catalog at
+  [`dora-rs/dora-hub`](https://github.com/dora-rs/dora-hub).
+- **Source-distributed by default.** A resolved node is cloned at its pinned
+  commit and built on the machine that runs it. A node may *optionally* ship a
+  prebuilt binary for a platform (see [Custom & Enterprise
+  Indexes](indexes.md#binary-distribution)).
+- **Reproducible.** `dora build --write-lockfile` records the exact commits;
+  `dora build --locked` rebuilds them byte-for-byte. See [Reproducible
+  Builds](reproducible-builds.md).
+- **Typed end-to-end.** A published node carries its dora input/output contracts
+  in its manifest, so wiring it wrong fails at `dora build`/`dora validate` time,
+  before anything runs.
+
+## A package reference
+
+A `hub:` value is `[<namespace>/]<name>@<version-requirement>`:
+
+```yaml
+hub: dora-yolo@^0.5          # official namespace (dora-rs) — bare name
+hub: dora-rs/dora-yolo@^0.5  # the same, written out
+hub: acme/lidar@~2.1         # a third-party namespace
+hub: dora-vad                # no @req → any version (the latest non-yanked)
+```
+
+A **bare name** is shorthand for the official `dora-rs/` namespace. The version
+requirement is a standard semver/Cargo range (`^0.5`, `~2.1`, `>=0.5, <0.7`,
+`=1.2.3`, `*`); resolution picks the **highest non-yanked** version that
+satisfies it. See [Using Hub Nodes](using-nodes.md) for the full syntax.
+
+## What this section covers
+
+- **[Using Hub Nodes](using-nodes.md)** — reference a node, search the catalog,
+  inspect a package's contracts.
+- **[Writing a Node Manifest](node-manifest.md)** — turn your own code into a
+  node others can use with one line.
+- **[Reproducible Builds](reproducible-builds.md)** — lockfiles, `--locked`,
+  checking for and applying updates, offline and air-gapped builds.
+- **[Publishing a Node](publishing.md)** — add your node to a catalog, manage
+  versions, and the namespace/ownership model.
+- **[Custom & Enterprise Indexes](indexes.md)** — private/mirrored catalogs via
+  `hub.toml`, namespace binding, and binary distribution.
+
+## How it relates to `path:` and `git:`
+
+`hub:` is a fourth node source, mutually exclusive with `path:`, `git:`, and
+`build:` on the same node. Under the hood the Hub **desugars** a `hub:` node into
+an ordinary pinned `git:` node (or a verified binary download) before the build
+runs — so everything you know about git nodes still applies. The Hub's job is the
+*resolution* (name + version → commit + contracts), nothing more.

--- a/guide/src/hub/publishing.md
+++ b/guide/src/hub/publishing.md
@@ -8,9 +8,11 @@ manifest."
 
 ## Prerequisites
 
-1. A committed [`dora-node.yml`](node-manifest.md) at your node's root, with a
-   `namespace`, `name`, and version (the version is read from
-   `[package].version` / `[project].version` at the pinned commit).
+1. A committed [`dora-node.yml`](node-manifest.md) at your node's root with a
+   `namespace` and `name`. The **version is not part of the manifest** — it is
+   read from `[package].version` (Cargo) / `[project].version` (pyproject) at the
+   pinned commit, or supplied with `--version`. (Adding `version:` to the
+   manifest is rejected — it uses `deny_unknown_fields`.)
 2. The node's source pushed to a git remote (the index entry points at it).
 3. Your `namespace` matches a GitHub org or user you control (see
    [Namespaces & ownership](#namespaces--ownership)).

--- a/guide/src/hub/publishing.md
+++ b/guide/src/hub/publishing.md
@@ -103,5 +103,5 @@ dora hub init                      # scaffold dora-node.yml (if you haven't)
 dora validate --node-manifest dora-node.yml   # manifest is well-formed
 # commit dora-node.yml + the version bump, push
 dora hub publish --dry-run         # preview the exact entry
-dora hub publish                   # open the PR (or append, for a local index)
+dora hub publish                   # print the entry + PR instructions (or append, for a local index)
 ```

--- a/guide/src/hub/publishing.md
+++ b/guide/src/hub/publishing.md
@@ -1,0 +1,107 @@
+# Publishing a Node
+
+Publishing makes your node installable with `hub: <namespace>/<name>@<version>`.
+It does **not** upload code: it adds a small, append-only *index entry* that
+points at a git commit of your node's source. The source stays in your repo; the
+index just records "version `X` of this node lives at commit `Y`, and here is its
+manifest."
+
+## Prerequisites
+
+1. A committed [`dora-node.yml`](node-manifest.md) at your node's root, with a
+   `namespace`, `name`, and version (the version is read from
+   `[package].version` / `[project].version` at the pinned commit).
+2. The node's source pushed to a git remote (the index entry points at it).
+3. Your `namespace` matches a GitHub org or user you control (see
+   [Namespaces & ownership](#namespaces--ownership)).
+
+## Preview the entry
+
+```bash
+cd my-node
+dora hub publish --dry-run
+```
+
+This resolves the commit, reads and strictly validates the manifest as committed,
+and prints the exact `<namespace>/<name>/<version>.yml` index entry it would add —
+without writing anything or opening a PR. Run this first.
+
+Useful flags:
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--rev <ref>` | `HEAD` | the git commit/ref to pin |
+| `--repo <url>` | the `origin` remote | the source repo URL recorded in the entry |
+| `--version <semver>` | the native manifest's version at the commit | override the published version |
+| `--index <alias>` | the index bound to your namespace | target a specific `hub.toml` index |
+| `--dry-run` | — | validate + print, don't write |
+
+The version, name, and manifest are all read **at the pinned commit** (via
+`git show <commit>:…`), not from your working tree — so an uncommitted manifest
+or version bump is an error, not a silently-published entry. Commit first.
+
+## Publishing to the official catalog
+
+The default index is the public catalog at
+[`dora-rs/dora-hub`](https://github.com/dora-rs/dora-hub), a git repo. Because
+it is git-backed, publishing to it is a **pull request**:
+
+```bash
+dora hub publish        # prints the entry + PR instructions for a git index
+```
+
+`dora hub publish` against a git-backed index prints the entry and the steps to
+open a PR that adds it under `node-index/<namespace>/<name>/<version>.yml`. The
+catalog's CI then validates the entry (schema, full-commit pin, path/namespace
+consistency, append-only), and a conformant publish by a namespace **owner**
+auto-merges — the publishing latency is just CI latency, the winget/conda-forge
+model.
+
+## Versioning and yanking
+
+Published version files are **immutable** — the index is append-only. To release
+a new version, publish a new entry; to mark a bad version, **yank** it:
+
+```bash
+dora hub yank dora-yolo@0.5.1 --reason "panics on empty input"
+dora hub yank dora-yolo@0.5.1 --undo        # restore it
+```
+
+Yanking flips the one mutable flag on an entry. A yanked version is **skipped by
+new resolution** (so `^0.5` picks the next-highest good version), but a lockfile
+that already pinned it keeps working with a warning — so yanking never breaks
+existing reproducible builds, it just stops new ones from selecting it. Like
+publishing, yanking a git-backed index is a small flag-flip PR.
+
+## Namespaces & ownership
+
+- A **namespace** is a GitHub org or user (`dora-rs`, `acme`). The index key is
+  `namespace/name`.
+- A namespace resolves against **exactly one** index (no search order, so no
+  dependency-confusion). The official `dora-rs` namespace always resolves to the
+  official catalog.
+- Each package carries an **owners** list (`package.yml`). The catalog's
+  auto-merge only applies to a routine publish authored by an owner of the
+  package's namespace; a new namespace, an owners change, or a yank by a
+  non-owner is held for human review. A newly-claimed namespace must also match
+  the claiming author's GitHub identity (their login, or an org they belong to) —
+  claiming someone else's username is rejected.
+- The `std` namespace and a short reserved list (`dora`, `dora-rs`, `dora-hub`,
+  `hub`, `official`, …) are reserved.
+
+## Local indexes
+
+For testing or a private catalog on disk, `dora hub publish` against a
+**local** (`path =`) index appends the entry directly (atomically, refusing to
+overwrite an existing version) instead of printing PR instructions. See
+[Custom & Enterprise Indexes](indexes.md) for configuring one.
+
+## Checklist
+
+```bash
+dora hub init                      # scaffold dora-node.yml (if you haven't)
+dora validate --node-manifest dora-node.yml   # manifest is well-formed
+# commit dora-node.yml + the version bump, push
+dora hub publish --dry-run         # preview the exact entry
+dora hub publish                   # open the PR (or append, for a local index)
+```

--- a/guide/src/hub/reproducible-builds.md
+++ b/guide/src/hub/reproducible-builds.md
@@ -89,18 +89,21 @@ lockfile — but compiles nothing. It produces a lockfile byte-identical to
 contract/type checks too), just without the build. Review the lockfile diff and
 commit it.
 
-All of these accept `--offline` to use only the cached index.
+`outdated` and `update` accept `--offline` to use only the cached index; `list`
+reads the local lockfile and needs no network.
 
-## Offline and air-gapped builds
+## Offline builds and source mirroring
 
-Two independent "offline" mechanisms:
+Two independent mechanisms for working with limited or no network:
 
-- **`--offline`** (on `build`, `validate`, and the `hub` query commands) skips
-  the network index refresh and uses the local cache, failing loudly on a cache
-  miss instead of silently going stale.
+- **`--offline`** (on `dora build`, `dora validate`, and `dora hub
+  search`/`info`/`outdated`/`update`) skips the network index refresh and uses
+  the local cache, failing loudly on a cache miss instead of silently going
+  stale.
 
-- **`dora hub fetch`** mirrors the pinned *sources* into a directory so a machine
-  with no network (or no git access to the source repos) can still build:
+- **`dora hub fetch`** mirrors the pinned *sources* into a directory — a
+  verifiable local copy of each pinned commit, for inspection, auditing, CI
+  source-caching, or manual transfer to another machine:
 
   ```bash
   dora hub fetch dataflow.yml                      # mirror the lockfile's pins
@@ -112,10 +115,13 @@ Two independent "offline" mechanisms:
   YAML, like `--locked`); a bare `name@version` resolves live against the index.
   Sources are blobless-cloned at their pinned commit into `<dir>/<commit>`.
 
-  > `fetch` mirrors **git** sources. Binary-node artifacts are **not**
-  > pre-downloaded — the daemon fetches and sha256-verifies them at spawn time.
-  > For a fully air-gapped binary node, host the artifact `url` somewhere the
-  > target can reach.
+  > **Not yet a turnkey air-gapped build.** `dora build` still fetches git
+  > sources through its own build cache and does **not** reuse this mirror yet
+  > (full air-gapped source reuse is a follow-up). Today `fetch` guarantees a
+  > verifiable local copy; consuming it from a fully offline build is manual.
+  > `fetch` also mirrors **git** sources only — binary-node artifacts are
+  > fetched and sha256-verified by the daemon at spawn time, so host a binary
+  > node's `url` somewhere the target can reach.
 
 ## Recommended workflow
 

--- a/guide/src/hub/reproducible-builds.md
+++ b/guide/src/hub/reproducible-builds.md
@@ -1,0 +1,127 @@
+# Reproducible Builds
+
+A `hub:` requirement like `^0.5` is a *range*. Without pinning, each `dora build`
+re-resolves it to the latest matching version, so two builds can differ. A
+**lockfile** records the exact commit (and, for binary nodes, the exact
+artifact) each node resolved to, so a build is reproducible across machines and
+over time — the same model as `Cargo.lock` or `package-lock.json`.
+
+## Writing a lockfile
+
+```bash
+dora build dataflow.yml --write-lockfile
+```
+
+This resolves every `hub:` (and `git:`) node, builds the dataflow, and writes a
+lockfile next to the dataflow named `<dataflow-stem>.dora-lock.yaml`. Commit it
+alongside the dataflow.
+
+The lockfile stores, per node:
+
+- the resolved **git source** — repo, exact `commit_hash`, and `subdir`; plus
+  the hub **provenance** (package `name`, resolved `version`, and a
+  `manifest_digest`), or
+- the resolved **binary source** — `platform`, `url`, and `sha256` — for a node
+  that shipped a prebuilt artifact.
+
+It also records a `descriptor_fingerprint` of the dataflow's source graph, used
+to detect when the YAML changed out from under the lockfile.
+
+## Building from the lockfile
+
+```bash
+dora build dataflow.yml --locked
+```
+
+`--locked` is **strict**: every `hub:` node must be present in the lockfile and
+still valid, or the build fails rather than resolving live. It rebuilds the exact
+pinned commits/artifacts. Use it in CI and on deploy targets so what you ship is
+what you tested.
+
+`--locked` also re-checks integrity:
+
+- the dataflow's fingerprint must match the lockfile (the YAML hasn't drifted);
+- a binary node's artifact is re-verified against its `sha256`;
+- if a published index entry's manifest was rewritten since you locked
+  (its `manifest_digest` no longer matches), `--locked` **fails** — the
+  contract you locked against changed. (A rewritten *source pin* warns and uses
+  the lockfile pin.)
+
+> `dora validate` is **best-effort**, not strict: when a lockfile exists it uses
+> its pins, but a missing or stale pin falls back to live resolution with a note
+> instead of failing — so validating a half-updated dataflow never fails harder
+> than building it without `--locked`. Reproducibility is enforced by
+> `build --locked`, not by `validate`.
+
+## Inspecting and updating pins
+
+### What's pinned
+
+```bash
+dora hub list dataflow.yml
+```
+
+Lists each hub package pinned in the lockfile with its version and short commit
+(or `binary <platform>` for a binary pin). Errors if there is no lockfile,
+pointing you at `--write-lockfile`.
+
+### What's outdated
+
+```bash
+dora hub outdated dataflow.yml
+```
+
+Compares each locked pin against the latest **non-yanked** version in the index
+(ignoring the YAML range) and reports `node: ns/name <pinned> -> <latest>
+(newer available)`. It exits non-zero if any package couldn't be checked, so it
+composes in CI.
+
+### Apply updates
+
+```bash
+dora hub update dataflow.yml            # re-resolve + rewrite the lockfile
+dora hub update dataflow.yml --dry-run  # show what would change, write nothing
+```
+
+`update` re-resolves every node within its YAML requirement and rewrites the
+lockfile — but compiles nothing. It produces a lockfile byte-identical to
+`dora build --write-lockfile` (it re-resolves non-hub git refs and runs the
+contract/type checks too), just without the build. Review the lockfile diff and
+commit it.
+
+All of these accept `--offline` to use only the cached index.
+
+## Offline and air-gapped builds
+
+Two independent "offline" mechanisms:
+
+- **`--offline`** (on `build`, `validate`, and the `hub` query commands) skips
+  the network index refresh and uses the local cache, failing loudly on a cache
+  miss instead of silently going stale.
+
+- **`dora hub fetch`** mirrors the pinned *sources* into a directory so a machine
+  with no network (or no git access to the source repos) can still build:
+
+  ```bash
+  dora hub fetch dataflow.yml                      # mirror the lockfile's pins
+  dora hub fetch dataflow.yml --target-dir vendor  # into ./vendor
+  dora hub fetch dora-yolo@0.5.2                    # mirror one package, live-resolved
+  ```
+
+  A dataflow target reads pins from the lockfile (validated against the current
+  YAML, like `--locked`); a bare `name@version` resolves live against the index.
+  Sources are blobless-cloned at their pinned commit into `<dir>/<commit>`.
+
+  > `fetch` mirrors **git** sources. Binary-node artifacts are **not**
+  > pre-downloaded — the daemon fetches and sha256-verifies them at spawn time.
+  > For a fully air-gapped binary node, host the artifact `url` somewhere the
+  > target can reach.
+
+## Recommended workflow
+
+1. Develop with plain `dora build` (live resolution within your `^`/`~` ranges).
+2. Before sharing or deploying: `dora build --write-lockfile`, commit the
+   `*.dora-lock.yaml`.
+3. In CI and on deploy targets: `dora build --locked` (and `--offline` if the
+   index cache is pre-warmed).
+4. Periodically: `dora hub outdated`, then `dora hub update` + review the diff.

--- a/guide/src/hub/using-nodes.md
+++ b/guide/src/hub/using-nodes.md
@@ -1,0 +1,143 @@
+# Using Hub Nodes
+
+This chapter is the consumer side: finding a node, wiring it into a dataflow, and
+understanding how the version you wrote resolves to the version you run. To
+*author* a node, see [Writing a Node Manifest](node-manifest.md).
+
+## Referencing a node
+
+Add a `hub:` field to a node instead of `path:` or `git:`:
+
+```yaml
+nodes:
+  - id: detector
+    hub: dora-yolo@^0.5
+    inputs:
+      image: camera/image
+    outputs:
+      - bbox
+
+  - id: camera
+    hub: opencv-video-capture@^0.3
+    outputs:
+      - image
+```
+
+`hub:` is mutually exclusive with `path:`, `git:`, `build:`, and the
+`branch`/`tag`/`rev` fields on the same node — the Hub provides all of those.
+You still write the node's `inputs`/`outputs` wiring as usual; the *types* of
+those ports come from the published manifest.
+
+### The reference syntax
+
+```
+[<namespace>/]<name>@<version-requirement>
+```
+
+| Form | Meaning |
+|---|---|
+| `dora-yolo@^0.5` | name in the **official** `dora-rs` namespace |
+| `dora-rs/dora-yolo@^0.5` | the same, fully qualified |
+| `acme/lidar@~2.1` | a third-party namespace |
+| `dora-vad` | no `@` → `*`, any version (the latest non-yanked) |
+
+A bare name (no `namespace/`) means the official `dora-rs` namespace. A namespace
+maps to a GitHub org or user and resolves against exactly one index (see
+[Custom & Enterprise Indexes](indexes.md)).
+
+### Version requirements
+
+The part after `@` is a standard semver/Cargo version requirement:
+
+| Requirement | Matches |
+|---|---|
+| `^0.5` | `>=0.5.0, <0.6.0` (caret; `0.x` treats minor as breaking) |
+| `^1.2` | `>=1.2.0, <2.0.0` |
+| `~2.1` | `>=2.1.0, <2.2.0` |
+| `>=0.5, <0.7` | an explicit range |
+| `=1.2.3` | exactly that version |
+| `*` (or omitted) | any version |
+
+Resolution picks the **highest non-yanked** version that satisfies the
+requirement. Pre-release versions (e.g. `0.6.0-rc1`) are only matched by a
+requirement that itself names a pre-release, following the Cargo convention.
+
+Pin your requirement, then lock it for reproducibility — see [Reproducible
+Builds](reproducible-builds.md). Without a lockfile, each `dora build`
+re-resolves to the latest matching version.
+
+## Finding nodes
+
+### Search the catalog
+
+```bash
+dora hub search yolo                    # name / description / keyword match
+dora hub search --category ml-inference # browse a category
+dora hub search lidar --platform linux-x86_64
+dora hub search                         # list everything
+```
+
+Search spans every configured index and prints `namespace/name version —
+description (categories)`, using each package's latest version.
+
+### Inspect a package
+
+`dora hub info` shows a package's typed contracts, configuration, and a ready-to-
+paste example — read this before wiring a node so you know its ports and types:
+
+```bash
+dora hub info dora-yolo            # latest version
+dora hub info dora-yolo@0.5.2      # a specific version
+dora hub info acme/lidar@^2        # a requirement
+```
+
+It prints the version (and a `(yanked)` marker if applicable), description,
+categories, supported platforms, runtime, the **typed inputs and outputs**, env
+vars, and the example snippet.
+
+Add `--offline` to any of these to use only the local cache without hitting the
+network.
+
+## Building and validating
+
+Resolution happens at `dora build` / `dora validate` / `dora run` time — there is
+no separate fetch step:
+
+```bash
+dora validate dataflow.yml   # resolve hub nodes, check wiring + types, no build
+dora build dataflow.yml      # resolve, pin, and build every node
+dora run dataflow.yml        # build + run (local)
+```
+
+Because a published node ships its input/output **types** in its manifest, the
+normal type-checking pipeline applies to it: wiring a `BoundingBox` output into
+an input that expects an `Image` fails at compose time with the producer/consumer
+URNs, before any process starts. Your own annotations in the dataflow always take
+precedence over the manifest's.
+
+## What gets built
+
+A `hub:` node desugars to a pinned `git:` node: the resolver clones the node's
+source at the exact published commit and runs its `build` command (e.g.
+`pip install .`, `cargo build --release`) on the machine that builds it. For a
+node that ships a prebuilt binary for your platform, the resolver downloads and
+sha256-verifies that artifact instead of cloning — see [Binary
+distribution](indexes.md#binary-distribution).
+
+Heavy builds run wherever the node runs, so on constrained devices prefer
+build-on-a-host-and-ship (see the manifest chapter's [build-location
+guidance](node-manifest.md#build-location-guidance) and the offline
+[`dora hub fetch`](reproducible-builds.md#offline-and-air-gapped-builds) flow).
+
+## Overriding a node locally
+
+While iterating on a node you consume, point a single package at a local checkout
+without editing the YAML or publishing anything:
+
+```bash
+dora build dataflow.yml --hub-override dora-yolo=../my-fork/dora-yolo
+```
+
+This is a local-build-only inner-loop tool (it cannot combine with
+`--write-lockfile` or distributed builds). See [Reproducible
+Builds](reproducible-builds.md) for the lockfile interactions.

--- a/guide/src/hub/using-nodes.md
+++ b/guide/src/hub/using-nodes.md
@@ -126,8 +126,9 @@ distribution](indexes.md#binary-distribution).
 
 Heavy builds run wherever the node runs, so on constrained devices prefer
 build-on-a-host-and-ship (see the manifest chapter's [build-location
-guidance](node-manifest.md#build-location-guidance) and the offline
-[`dora hub fetch`](reproducible-builds.md#offline-and-air-gapped-builds) flow).
+guidance](node-manifest.md#build-location-guidance) and
+[`dora hub fetch`](reproducible-builds.md#offline-builds-and-source-mirroring) for
+mirroring sources).
 
 ## Overriding a node locally
 


### PR DESCRIPTION
Audits and fills the dora-repo documentation for the Dora Hub feature, which until now had only one user-facing chapter (the node manifest) despite being a large, mostly-landed feature.

## Audit findings

| Surface | Before | After |
|---|---|---|
| `guide/` (mdBook) — main user docs | 1 chapter (*Writing a Node Manifest*, authoring only) | 6-chapter section covering the full user journey |
| `README.md` | Hub shown only as a *node collection* link | Presented as a **package manager** (`hub: …@^0.5`, lockfiles, typed contracts) + a CLI command table |
| `docs/yaml-spec.md` | `hub:` field unspecified | Added to the node **Source** table with an example |
| `docs/cli.md` | `dora hub` block linked only the internal plan | Links the new user guide; added `--offline` flags + the `install` stub |

## New guide chapters (`guide/src/hub/`)

Follow the consumer → author → operator journey:

1. **Overview** — what the Hub is, the cargo-style model (per-dataflow resolution, git-backed index, source-distributed, reproducible, typed), the package-reference syntax.
2. **Using Hub Nodes** — `hub:` syntax, semver/version-requirement semantics, `search`/`info`, building/validating, `--hub-override`.
3. **Writing a Node Manifest** *(existing, unchanged)*.
4. **Reproducible Builds** — lockfiles, `--write-lockfile`/`--locked`, `list`/`outdated`/`update`, offline + `dora hub fetch`.
5. **Publishing a Node** — `publish`/`yank`, the append-only catalog, the PR/auto-merge flow, namespaces & ownership.
6. **Custom & Enterprise Indexes** — `hub.toml`, namespace binding (no dependency confusion), binary distribution, security model.

## Accuracy

Every command, flag, syntax form, and behavior was extracted fresh from the code (clap definitions, the descriptor `hub:` field, the lockfile module, the manifest struct, the hub-client index/config) — including the **"unstable"** marker that the CLI itself prints. No behavior is documented that the code doesn't implement.

## Verification

- [x] `mdbook build guide` — clean (all SUMMARY entries resolve, no broken file links)
- [x] `typos` — clean on all new/changed docs
- [x] Internal cross-references + anchors checked
- [x] Docs-only change — no code touched

Note: the Hub is marked **unstable** throughout, matching the CLI. Follow-ups (separate): the dora-hub repo README/CONTRIBUTING and the dora-rs.ai website.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
