### PR TITLE
fix(ci): resync dora-schema.json + stop schema-PR spam

### DIFF
--- a/.github/workflows/regenerate-schemas.yml
+++ b/.github/workflows/regenerate-schemas.yml
@@ -21,20 +21,27 @@ jobs:
 
       - name: Update Schema
         run: cargo run -p dora-core --bin generate_schema
-      - name: Create if changed
+      - name: Create or update the schema-sync PR if changed
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if git diff --exit-code -- libraries/core/dora-schema.json libraries/core/dora-node-schema.json; then
-              echo "Schema file was not changed"
+              echo "Schema file is up to date"
           else
-              git switch -c schema-update-for-${{ github.sha }}
+              # Reuse ONE branch + PR: force-push so an already-open sync PR is
+              # updated in place instead of opening a fresh PR on every push to
+              # main (which otherwise piles up dozens of duplicates while the
+              # schema stays drifted).
+              git checkout -B auto/schema-update
               git add libraries/core/dora-schema.json libraries/core/dora-node-schema.json
               git config user.email "dora-bot@phil-opp.com"
               git config user.name "Dora Bot"
-              git commit -m "Update JSON schema for ${{ github.sha }}"
-              git push -u origin HEAD
-              git fetch origin main
-              gh pr create --title "Update JSON schema for \`dora-core\`" --body "Update JSON schema for ${{ github.sha }}"
+              git commit -m "Update JSON schema (${{ github.sha }})"
+              git push -f -u origin auto/schema-update
+              if [ -z "$(gh pr list --head auto/schema-update --state open --json number --jq '.[].number')" ]; then
+                  gh pr create --head auto/schema-update --base main \
+                    --title "Update JSON schema for \`dora-core\`" \
+                    --body "The committed JSON schema drifted from \`cargo run -p dora-core --bin generate_schema\`. Merge to resync. This PR is force-updated in place on every push to main, so there is only ever one open."
+              fi
           fi
-          
+

--- a/libraries/core/dora-schema.json
+++ b/libraries/core/dora-schema.json
@@ -176,6 +176,13 @@
           "description": "Path of the source code\n\nIf you want to use a specific `conda` environment.\nProvide the python path within the source.\n\nsource: /home/peter/miniconda3/bin/python\n\nargs: some_node.py\n\nSource can match any executable in PATH.",
           "type": "string"
         },
+        "path_sha256": {
+          "description": "SHA-256 the `path` download must match (set for hub binary artifacts,\nspec §8.2). When present the daemon fetches `path` as a verified URL\ndownload regardless of confinement — the checksum is the trust anchor.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "restart_delay": {
           "description": "Initial delay in seconds before restarting (exponential backoff).",
           "type": [
@@ -649,6 +656,13 @@
         },
         "path": {
           "description": "Path to executable or script that should be run.\n\nSpecifies the path of the executable or script that Dora should run when starting the\ndataflow.\nThis can point to a normal executable (e.g. when using a compiled language such as Rust) or\na Python script.\n\nDora will automatically append a `.exe` extension on Windows systems when the specified\nfile name has no extension.\n\n## Example\n\n```yaml\nnodes:\n  - id: rust-example\n    path: target/release/rust-node\n  - id: python-example\n    path: ./receive_data.py\n```\n\n## URL as Path\n\nThe `path` field can also point to a URL instead of a local path.\nIn this case, Dora will download the given file when starting the dataflow.\n\nNote that this is quite an old feature and using this functionality is **not recommended**\nanymore. Instead, we recommend using a [`git`][Self::git] and/or [`build`](Self::build)\nkey.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "path_sha256": {
+          "description": "SHA-256 checksum the `path` download must match, verified after fetch\nand on cache reuse (spec §8.2/§8.4). Set internally when a `hub:`\nreference resolves to a prebuilt binary artifact; rarely set by hand.",
           "type": [
             "string",
             "null"


### PR DESCRIPTION
The committed `libraries/core/dora-schema.json` was stale (missing `path_sha256` from the P2.8 hub binary-source work). The `regenerate-schemas` workflow runs on every push to main, regenerates the schema, sees the drift, and opens a **new `schema-update-for-<sha>` PR each time** — so **15 duplicate PRs** piled up (#2239–#2259), plus a stale Cargo.lock bump (#2232).

## Fix
1. **Resync the schema** — regenerate `dora-schema.json` (adds the two `path_sha256` blocks). Once committed == generated, the workflow produces no diff and stops opening PRs. Verified identical to the canonical bot regen (#2259).
2. **Tidy the workflow** — reuse one `auto/schema-update` branch with a force-push, and only `gh pr create` when no sync PR is already open. Future drift updates a single PR in place instead of spawning a new one per push.

The 15 stale auto-PRs (#2232, #2239–#2258) are closed as superseded; #2259 is superseded by this PR.

Docs-adjacent / CI-only Rust-wise (schema JSON + workflow); no production code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)