### PR TITLE
fix(tracing): truncate span field values at UTF-8 char boundary

### DIFF
--- a/libraries/extensions/telemetry/tracing/src/span_store.rs
+++ b/libraries/extensions/telemetry/tracing/src/span_store.rs
@@ -86,7 +86,11 @@ impl FieldVisitor {
             return;
         }
         if value.len() > MAX_FIELD_VALUE_BYTES {
-            value.truncate(MAX_FIELD_VALUE_BYTES);
+            let mut end = MAX_FIELD_VALUE_BYTES;
+            while !value.is_char_boundary(end) {
+                end -= 1;
+            }
+            value.truncate(end);
             value.push_str("...");
         }
         self.0.push((name.to_string(), value));
@@ -217,6 +221,23 @@ where
 mod tests {
     use super::*;
     use tracing_subscriber::{Registry, layer::SubscriberExt};
+
+    #[test]
+    fn field_visitor_truncates_at_char_boundary() {
+        // A 4-byte emoji straddles byte 4096 — raw truncate would panic.
+        let mut value = "a".repeat(4095);
+        value.push('😀'); // occupies bytes 4095..4099
+        assert!(!value.is_char_boundary(4096));
+
+        let mut visitor = FieldVisitor(Vec::new());
+        visitor.push_field("key", value);
+
+        let (_, stored) = &visitor.0[0];
+        assert!(stored.ends_with("..."));
+        assert!(stored.is_char_boundary(stored.len()));
+        // Stored value must be valid UTF-8 (would panic on display otherwise)
+        let _ = stored.len();
+    }
 
     #[test]
     fn span_store_evicts_oldest() {


### PR DESCRIPTION
## Summary

Fixes the panic reported in #2263.

`FieldVisitor::push_field` in `libraries/extensions/telemetry/tracing/src/span_store.rs` called `String::truncate(MAX_FIELD_VALUE_BYTES)` where `MAX_FIELD_VALUE_BYTES = 4096`. `String::truncate` panics if the byte index does not fall on a UTF-8 character boundary. Any span field carrying non-ASCII content (paths, JSON blobs, emoji) that exceeded 4096 bytes and had a multi-byte character straddling byte 4096 would panic inside the `tracing` subscriber layer — propagating out of the code that emitted the span and potentially aborting a node or the daemon.

## Fix

Walk backwards from `MAX_FIELD_VALUE_BYTES` to find the nearest valid char boundary before truncating:

```rust
let mut end = MAX_FIELD_VALUE_BYTES;
while !value.is_char_boundary(end) {
    end -= 1;
}
value.truncate(end);
value.push_str("...");
```

## Tests

Added a regression test (`field_visitor_truncates_at_char_boundary`) that constructs a string where a 4-byte emoji (`😀`) straddles byte 4096 — the exact case that previously panicked — and asserts the stored value is valid UTF-8 ending with `"..."`.

All 3 `dora-tracing` unit tests pass; clippy and fmt clean.

Closes #2263

---
_Generated by [Claude Code](https://claude.ai/code/session_01QheETdNcNiZ6JZa8oz5sRK)_