### PR TITLE
fix(memory-pool): replace flaky sum-based assertion with monotonic counter check

### DIFF
--- a/examples/memory-pool/receiver.py
+++ b/examples/memory-pool/receiver.py
@@ -22,7 +22,6 @@ pbar = tqdm(total=MESSAGE_COUNT)
 velocities = []
 memory_pool_id = None
 torch_tensor = None
-prev_sum = None
 
 for i in range(MESSAGE_COUNT):
     event = node.next()
@@ -38,14 +37,14 @@ for i in range(MESSAGE_COUNT):
     # the shmem bytes in place, so the receiver's existing tensor object
     # automatically reflects new data.  Turn-based signaling ensures the
     # sender has finished writing before the receiver accesses the tensor.
-    # Compute a cheap checksum to validate that the tensor data changed
-    # (and therefore the pooled transfer actually delivered new bytes).
-    curr_sum = int(torch_tensor[:8].sum().item())
-    if prev_sum is not None and SCENARIO != "write_after_free":
-        assert curr_sum != prev_sum, (
-            f"iteration {i}: tensor data did not change — pool write may not have propagated"
+    # The sender stamps element[0] with the iteration counter so we can
+    # verify propagation deterministically (sum-of-8 had ~3% collision rate).
+    if SCENARIO != "write_after_free":
+        actual = int(torch_tensor[0].item())
+        assert actual == i, (
+            f"iteration {i}: tensor[0] expected {i}, got {actual}"
+            " — pool write may not have propagated"
         )
-    prev_sum = curr_sum
 
     t_received = time.perf_counter_ns()
     delta_t = t_received - t_send

--- a/examples/memory-pool/sender.py
+++ b/examples/memory-pool/sender.py
@@ -22,6 +22,7 @@ data_generation = np.random.default_rng()
 memory_pool_id = None
 for i in range(MESSAGE_COUNT):
     random_data = data_generation.integers(1000, size=SIZE, dtype=np.int64)
+    random_data[0] = i  # monotonic counter lets receiver detect change without collision risk
     torch_tensor = torch.tensor(random_data, dtype=torch.int64, device=SENDER_DEVICE)
     t_send = time.perf_counter_ns()
     metadata = {"t_send": t_send, "scenario": SCENARIO}

--- a/scripts/smoke-all.sh
+++ b/scripts/smoke-all.sh
@@ -501,6 +501,15 @@ if [ "$RUN_PYTHON" = true ]; then
     echo "=== Queue/timeout regression tests (local, timing-sensitive) ==="
     run_local "local-queue-size-and-timeout"         "tests/queue_size_and_timeout_python/dataflow.yaml" 20
     run_local "local-queue-size-latest-data-python"  "tests/queue_size_latest_data_python/dataflow.yaml" 20
+
+    echo ""
+    echo "=== Memory-pool CPU transport (requires torch) ==="
+    if python3 -c "import torch, tqdm" 2>/dev/null; then
+        run_networked "memory-pool-cpu2cpu"       "examples/memory-pool/cpu2cpu.yml" 60
+        run_local     "local-memory-pool-cpu2cpu" "examples/memory-pool/cpu2cpu.yml" 60
+    else
+        log_skip "memory-pool-cpu2cpu" "requires torch + tqdm (pip install torch tqdm)"
+    fi
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/example-smoke.rs
+++ b/tests/example-smoke.rs
@@ -1884,6 +1884,35 @@ fn smoke_shell_node_blocked_without_flag() {
 }
 
 // ---------------------------------------------------------------------------
+// Memory-pool CPU transport (#2168)
+//
+// Requires `torch` and `tqdm` — not installed in standard PR CI. Run
+// explicitly on machines with torch available:
+//   cargo test --test example-smoke -- --ignored smoke_memory_pool
+// or via `scripts/smoke-all.sh` which gates on `python3 -c "import torch"`.
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires `torch` and `tqdm` (not in standard CI)"]
+fn smoke_memory_pool_cpu2cpu() {
+    run_smoke_test(
+        "memory-pool-cpu2cpu",
+        "examples/memory-pool/cpu2cpu.yml",
+        Duration::from_secs(60),
+    );
+}
+
+#[test]
+#[ignore = "requires `torch` and `tqdm` (not in standard CI)"]
+fn smoke_local_memory_pool_cpu2cpu() {
+    run_smoke_test_local(
+        "local-memory-pool-cpu2cpu",
+        "examples/memory-pool/cpu2cpu.yml",
+        60,
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Examples under `examples/` that do NOT have a corresponding `smoke_*` or
 // `contract_*` test in this file. Some are blocked (filed issue or external
 // dep); others are intentionally covered by a DIFFERENT CI job. Keep this
@@ -1903,6 +1932,11 @@ fn smoke_shell_node_blocked_without_flag() {
 //
 // | Example                   | Where it's tested / blocker                          | Tracking |
 // |---------------------------|------------------------------------------------------|----------|
+// | memory-pool               | covered: smoke_memory_pool_cpu2cpu /                 | #2264    |
+// |                           | smoke_local_memory_pool_cpu2cpu (#[ignore],           |          |
+// |                           | run when torch+tqdm available); smoke-all.sh          |          |
+// |                           | gates on `python3 -c "import torch"`.                 |          |
+// |                           | cuda2cpu/cpu2cuda/etc blocked: needs NVIDIA CUDA.     |          |
 // | cuda-benchmark            | blocker: needs NVIDIA CUDA toolkit                   | —        |
 // | dynamic-add-remove        | blocker: `dora node add` times out +                 | #1682    |
 // |                           | corrupts dataflow state                              |          |


### PR DESCRIPTION
## Summary

Addresses the two concrete findings in #2264.

### Finding 2 fix: eliminate the ~3% spurious failure rate in `receiver.py`

The old assertion summed the first 8 `int64` elements (each in `[0, 1000)`) of two consecutive random tensors and asserted they differed. With a sum range of `[0, 7992]` and ~99 comparisons per run, two adjacent draws had a ~1/3000 collision probability, giving roughly **3% spurious test failure per run** even when the transport worked perfectly.

Fix: stamp element `[0]` with the iteration counter `i` in the sender, and assert `tensor[0] == i` in the receiver. Zero collision probability.

**sender.py:**
```python
random_data[0] = i  # monotonic counter lets receiver detect change without collision risk
```

**receiver.py:**
```python
if SCENARIO != "write_after_free":
    actual = int(torch_tensor[0].item())
    assert actual == i, f"iteration {i}: tensor[0] expected {i}, got {actual}"
```

### Finding 1 (partial): wire `cpu2cpu.yml` into the test harness

`cpu2cpu.yml` is the only GPU-free scenario in the memory-pool suite. Added:
- `tests/example-smoke.rs`: two `#[ignore]` smoke tests (torch is not installed in standard PR CI; run explicitly with `cargo test --test example-smoke -- --ignored smoke_memory_pool`)
- `scripts/smoke-all.sh`: conditional block that runs `cpu2cpu.yml` when `python3 -c "import torch, tqdm"` succeeds, skips otherwise
- Coverage audit table updated

The CUDA-dependent scenarios (`cpu2cuda`, `cuda2cpu`) remain blocked by the need for NVIDIA hardware.

Closes #2264

---
_Generated by [Claude Code](https://claude.ai/code/session_01QheETdNcNiZ6JZa8oz5sRK)_