### PR TITLE
fix(daemon): escalate a node that wedges before draining (#2270)

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -2156,6 +2156,10 @@ impl Daemon {
                     dataflow.subscribe_channels.remove(&node_id);
                     dataflow.pending_messages.remove(&node_id);
                     dataflow.all_inputs_closed_at.remove(&node_id);
+                    // clear the connected marker too, else a re-added node ID
+                    // would look already-connected before its new incarnation
+                    // subscribes and could be selected mid-startup (dora#2270).
+                    dataflow.connected_nodes.remove(&node_id);
                     dataflow.finish_escalated.remove(&node_id);
 
                     // Remove from stored descriptor (inverse of AddNode
@@ -2345,7 +2349,11 @@ impl Daemon {
     /// ladder used by explicit stops — after capturing a stack sample of
     /// the stuck process so the hang itself stays diagnosable.
     fn check_finish_stragglers(&mut self) {
-        let grace = finish_drain_grace();
+        // Opt-in: with DORA_FINISH_DRAIN_GRACE_SECS unset the watchdog is
+        // disabled and never escalates (ships dark; see `finish_drain_grace`).
+        let Some(grace) = finish_drain_grace() else {
+            return;
+        };
         let now_millis = node_communication::current_millis();
         for (dataflow_id, dataflow) in self.running.iter_mut() {
             for node_id in dataflow.finish_stragglers(grace, now_millis) {
@@ -3882,6 +3890,10 @@ impl Daemon {
         event_sender: mpsc::Sender<Timestamped<NodeEvent>>,
         clock: &HLC,
     ) {
+        // record that this node has connected — it stays a finish-straggler
+        // candidate even if it later drops its event stream (dora#2270).
+        dataflow.connected_nodes.insert(node_id.clone());
+
         // some inputs might have been closed already -> report those events
         let closed_inputs = dataflow
             .mappings
@@ -5298,30 +5310,46 @@ fn break_input(
     }
 }
 
-/// Grace period before the finish-straggler watchdog escalates
-/// (dora-rs/dora#2152). Conservative by default: a sink may legitimately
-/// keep working for a while after its inputs close (flushing recordings,
-/// final writes). Override with `DORA_FINISH_DRAIN_GRACE_SECS`.
+/// Grace period used when the finish-straggler watchdog is enabled but
+/// `DORA_FINISH_DRAIN_GRACE_SECS` is set to an unparseable value. Conservative:
+/// a sink may legitimately keep working for a while after its inputs close
+/// (flushing recordings, final writes).
 const DEFAULT_FINISH_DRAIN_GRACE: Duration = Duration::from_secs(120);
 
-fn finish_drain_grace() -> Duration {
-    match std::env::var("DORA_FINISH_DRAIN_GRACE_SECS") {
-        Ok(value) => match value.parse::<u64>() {
-            Ok(secs) => Duration::from_secs(secs),
-            Err(_) => {
-                static WARNED: std::sync::atomic::AtomicBool =
-                    std::sync::atomic::AtomicBool::new(false);
-                if !WARNED.swap(true, atomic::Ordering::Relaxed) {
-                    tracing::warn!(
-                        "invalid DORA_FINISH_DRAIN_GRACE_SECS value `{value}` \
-                         (expected whole seconds); using the default of {}s",
-                        DEFAULT_FINISH_DRAIN_GRACE.as_secs()
-                    );
-                }
-                DEFAULT_FINISH_DRAIN_GRACE
+/// Grace period before the finish-straggler watchdog escalates a stuck node, or
+/// `None` if the watchdog is **disabled**.
+///
+/// The watchdog is opt-in and ships dark: with `DORA_FINISH_DRAIN_GRACE_SECS`
+/// unset it does nothing, so the SIGKILL-on-stuck-node behaviour can be enabled
+/// per-deployment and validated on real workloads before becoming default —
+/// this path is exercised only at shutdown and is not reproducible locally
+/// (dora-rs/dora#2152, #2270). Set the var to a whole number of seconds to
+/// enable it; a set-but-garbage value enables it at the default grace (the user
+/// clearly intended it on).
+fn finish_drain_grace() -> Option<Duration> {
+    parse_finish_drain_grace(
+        std::env::var("DORA_FINISH_DRAIN_GRACE_SECS")
+            .ok()
+            .as_deref(),
+    )
+}
+
+fn parse_finish_drain_grace(value: Option<&str>) -> Option<Duration> {
+    let value = value?;
+    match value.parse::<u64>() {
+        Ok(secs) => Some(Duration::from_secs(secs)),
+        Err(_) => {
+            static WARNED: std::sync::atomic::AtomicBool =
+                std::sync::atomic::AtomicBool::new(false);
+            if !WARNED.swap(true, atomic::Ordering::Relaxed) {
+                tracing::warn!(
+                    "invalid DORA_FINISH_DRAIN_GRACE_SECS value `{value}` \
+                     (expected whole seconds); using the default of {}s",
+                    DEFAULT_FINISH_DRAIN_GRACE.as_secs()
+                );
             }
-        },
-        Err(_) => DEFAULT_FINISH_DRAIN_GRACE,
+            Some(DEFAULT_FINISH_DRAIN_GRACE)
+        }
     }
 }
 
@@ -5655,8 +5683,8 @@ mod fault_tolerance_tests {
 
     // -- dora#2270: finish-straggler watchdog must spare timer/log-fed nodes --
 
-    /// Insert a connected (subscribed) node that has been silent since the
-    /// epoch, so `finish_stragglers` sees it as long-idle regardless of grace.
+    /// Insert a connected node that has been silent since the epoch, so
+    /// `finish_stragglers` sees it as long-idle regardless of grace.
     fn insert_silent_node(df: &mut RunningDataflow, node: &NodeId) {
         let running = test_running_node();
         running.last_activity.store(1, atomic::Ordering::Release);
@@ -5664,6 +5692,7 @@ mod fault_tolerance_tests {
         // a real running node has subscribed (can receive finish events)
         let (tx, _rx) = mpsc::channel(NODE_EVENT_CHANNEL_CAPACITY);
         df.subscribe_channels.insert(node.clone(), tx);
+        df.connected_nodes.insert(node.clone());
     }
 
     #[test]
@@ -5717,6 +5746,66 @@ mod fault_tolerance_tests {
         assert!(
             selected.is_empty(),
             "a node that has not subscribed must not be escalated: {selected:?}"
+        );
+    }
+
+    #[test]
+    fn dropped_stream_node_is_still_a_finish_straggler() {
+        // A node that connected, then dropped its event stream (channel removed)
+        // but kept its process alive, is still a wedge candidate — `connected`
+        // tracks `connected_nodes`, not current channel presence (#2270 review).
+        let mut df = test_dataflow();
+        let stuck: NodeId = "stuck".to_string().into();
+        let running = test_running_node();
+        running.last_activity.store(1, atomic::Ordering::Release);
+        df.running_nodes.insert(stuck.clone(), running);
+        df.connected_nodes.insert(stuck.clone());
+        // NOTE: no subscribe_channels entry — the event stream was dropped.
+
+        let now = node_communication::current_millis();
+        let selected = df.finish_stragglers(Duration::from_millis(1), now);
+        assert_eq!(selected, vec![stuck]);
+    }
+
+    #[test]
+    fn removed_node_id_is_not_connected_on_reuse() {
+        // RemoveNode clears connected_nodes, so a re-added node ID starts fresh:
+        // its slow-starting new incarnation must not be selected before it
+        // subscribes, even though the previous incarnation had connected.
+        let mut df = test_dataflow();
+        let node_a: NodeId = "node_a".to_string().into();
+        df.connected_nodes.insert(node_a.clone());
+        df.connected_nodes.remove(&node_a); // (the RemoveNode cleanup line)
+
+        let running = test_running_node();
+        running.last_activity.store(1, atomic::Ordering::Release);
+        df.running_nodes.insert(node_a.clone(), running);
+
+        let now = node_communication::current_millis();
+        let selected = df.finish_stragglers(Duration::from_millis(1), now);
+        assert!(
+            selected.is_empty(),
+            "a re-added node ID must not be selected before its new incarnation subscribes"
+        );
+    }
+
+    #[test]
+    fn finish_drain_grace_is_opt_in() {
+        // unset → watchdog disabled (ships dark)
+        assert_eq!(parse_finish_drain_grace(None), None);
+        // set → enabled at the given grace
+        assert_eq!(
+            parse_finish_drain_grace(Some("30")),
+            Some(Duration::from_secs(30))
+        );
+        assert_eq!(
+            parse_finish_drain_grace(Some("0")),
+            Some(Duration::from_secs(0))
+        );
+        // set-but-garbage → enabled at the default (the user meant to turn it on)
+        assert_eq!(
+            parse_finish_drain_grace(Some("not-a-number")),
+            Some(DEFAULT_FINISH_DRAIN_GRACE)
         );
     }
 

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -2149,6 +2149,16 @@ impl Daemon {
                     for receivers in dataflow.mappings.values_mut() {
                         receivers.retain(|(nid, _)| nid != &node_id);
                     }
+                    // Drop this node's timer/log virtual-input subscriptions —
+                    // both to stop delivering to a removed node and so a re-added
+                    // ID is classified by its own inputs, not stale timer/log
+                    // state (which would mark it never-finishing forever, #2270).
+                    for receivers in dataflow.timers.values_mut() {
+                        receivers.retain(|(nid, _)| nid != &node_id);
+                    }
+                    dataflow
+                        .log_subscribers
+                        .retain(|sub| sub.node_id != node_id);
 
                     // Clean up remaining state for this node.
                     dataflow.running_nodes.remove(&node_id);
@@ -2198,6 +2208,10 @@ impl Daemon {
                         .entry(output_id)
                         .or_default()
                         .insert((target_node.clone(), target_input.clone()));
+                    // Reopening an input ends any drain: clear the stale clock so
+                    // the selector does not treat the node as drained-and-eligible
+                    // on a timestamp from before the mapping was re-added (#2270).
+                    dataflow.all_inputs_closed_at.remove(&target_node);
                     dataflow
                         .open_inputs
                         .entry(target_node)
@@ -5790,6 +5804,71 @@ mod fault_tolerance_tests {
         assert!(
             selected.is_empty(),
             "a re-added node ID must not be selected before its new incarnation subscribes"
+        );
+    }
+
+    #[test]
+    fn cleared_timer_state_makes_reused_id_escalatable() {
+        // A timer-fed node is never-finishing (vetoed). RemoveNode clears its
+        // timer subscription, so a re-added user-input node under the same ID is
+        // classified by its own inputs and can be escalated (#2270 review).
+        let mut df = test_dataflow();
+        let node: NodeId = "reused".to_string().into();
+        insert_silent_node(&mut df, &node);
+        df.timers
+            .entry(Duration::from_millis(100))
+            .or_default()
+            .insert((node.clone(), "tick".to_string().into()));
+
+        let now = node_communication::current_millis();
+        // as a timer node → vetoed
+        assert!(
+            df.finish_stragglers(Duration::from_millis(1), now)
+                .is_empty(),
+            "timer-fed node must be vetoed"
+        );
+
+        // RemoveNode clears the timer subscription
+        for receivers in df.timers.values_mut() {
+            receivers.retain(|(nid, _)| nid != &node);
+        }
+        assert_eq!(
+            df.finish_stragglers(Duration::from_millis(1), now),
+            vec![node],
+            "once its timer state is cleared the node is classified by its own inputs"
+        );
+    }
+
+    #[test]
+    fn reopened_input_clears_stale_drain_timestamp() {
+        // A node drained long ago is eligible via the drained arm. Reopening a
+        // mapping must clear that timestamp so the node — now actively receiving
+        // again, not silent — is not force-stopped on a stale drain (#2270 review).
+        let mut df = test_dataflow();
+        let node: NodeId = "node_a".to_string().into();
+        let running = test_running_node();
+        // recent activity → not silent (only a stale drain clock could select it)
+        running.last_activity.store(
+            node_communication::current_millis(),
+            atomic::Ordering::Release,
+        );
+        df.running_nodes.insert(node.clone(), running);
+        df.connected_nodes.insert(node.clone());
+        df.all_inputs_closed_at.insert(
+            node.clone(),
+            std::time::Instant::now() - Duration::from_secs(1),
+        );
+
+        let grace = Duration::from_millis(500);
+        let now = node_communication::current_millis();
+        // drained past grace → selected
+        assert_eq!(df.finish_stragglers(grace, now), vec![node.clone()]);
+
+        // AddMapping reopen clears the drain clock
+        df.all_inputs_closed_at.remove(&node);
+        assert!(
+            df.finish_stragglers(grace, now).is_empty(),
+            "an active node with a reopened input must not be selected on a stale drain"
         );
     }
 

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -4555,6 +4555,10 @@ impl Daemon {
                 if let Some(dataflow) = self.running.get_mut(&dataflow_id) {
                     dataflow.grace_duration_kills.remove(&node_id);
                     dataflow.all_inputs_closed_at.remove(&node_id);
+                    // a respawned node must re-subscribe before it counts as
+                    // connected, else a slow restart could be silence-escalated
+                    // mid-startup (dora-rs/dora#2270).
+                    dataflow.connected_nodes.remove(&node_id);
                 }
 
                 logger
@@ -5786,6 +5790,32 @@ mod fault_tolerance_tests {
         assert!(
             selected.is_empty(),
             "a re-added node ID must not be selected before its new incarnation subscribes"
+        );
+    }
+
+    #[tokio::test]
+    async fn restart_clears_connected_marker() {
+        // A restarting node keeps its ID but is a new incarnation: clear the
+        // connected marker so the restarting process isn't silence-escalatable
+        // before it re-subscribes (a slow restart / model reload) — #2270 review.
+        use crate::running_dataflow::{ProcessHandle, ProcessOperation};
+        let mut df = test_dataflow();
+        let clock = test_clock();
+        let node_a: NodeId = "node_a".to_string().into();
+
+        let mut running = test_running_node();
+        let (op_tx, _op_rx) = flume::unbounded::<ProcessOperation>();
+        running.process = Some(ProcessHandle::new(op_tx));
+        df.running_nodes.insert(node_a.clone(), running);
+        df.connected_nodes.insert(node_a.clone());
+        df.all_inputs_closed_at
+            .insert(node_a.clone(), std::time::Instant::now());
+
+        df.restart_single_node(&node_a, &clock, None).unwrap();
+
+        assert!(
+            !df.connected_nodes.contains(&node_a),
+            "restart must clear the connected marker so the new incarnation re-subscribes"
         );
     }
 

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -5653,6 +5653,50 @@ mod fault_tolerance_tests {
         assert!(matches_event(&events[0], "InputClosed"));
     }
 
+    // -- dora#2270: finish-straggler watchdog must spare timer/log-fed nodes --
+
+    /// Mark `node` silent since the epoch so `finish_stragglers` sees it as
+    /// long-idle regardless of the grace.
+    fn insert_silent_node(df: &mut RunningDataflow, node: &NodeId) {
+        let running = test_running_node();
+        running.last_activity.store(1, atomic::Ordering::Release);
+        df.running_nodes.insert(node.clone(), running);
+    }
+
+    #[test]
+    fn timer_fed_node_is_not_a_finish_straggler() {
+        // A long-running timer-only node never drains and sends no daemon
+        // traffic, so it looks "silent + never drained" exactly like a wedge —
+        // but it is alive by design and must NOT be force-killed (#2270).
+        let mut df = test_dataflow();
+        let timer_node: NodeId = "timer_node".to_string().into();
+        insert_silent_node(&mut df, &timer_node);
+        df.timers
+            .entry(Duration::from_millis(100))
+            .or_default()
+            .insert((timer_node.clone(), "tick".to_string().into()));
+
+        let now = node_communication::current_millis();
+        let selected = df.finish_stragglers(Duration::from_millis(1), now);
+        assert!(
+            selected.is_empty(),
+            "timer-fed node must not be escalated: {selected:?}"
+        );
+    }
+
+    #[test]
+    fn wedged_user_input_node_is_a_finish_straggler() {
+        // A node with no timer/log input that has gone silent past grace while
+        // the rest of the dataflow finished IS a straggler and is escalated.
+        let mut df = test_dataflow();
+        let stuck: NodeId = "stuck".to_string().into();
+        insert_silent_node(&mut df, &stuck);
+
+        let now = node_communication::current_millis();
+        let selected = df.finish_stragglers(Duration::from_millis(1), now);
+        assert_eq!(selected, vec![stuck]);
+    }
+
     // -- Test 2: close_input sends AllInputsClosed + disable_restart on last input --
 
     #[test]

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -5655,12 +5655,15 @@ mod fault_tolerance_tests {
 
     // -- dora#2270: finish-straggler watchdog must spare timer/log-fed nodes --
 
-    /// Mark `node` silent since the epoch so `finish_stragglers` sees it as
-    /// long-idle regardless of the grace.
+    /// Insert a connected (subscribed) node that has been silent since the
+    /// epoch, so `finish_stragglers` sees it as long-idle regardless of grace.
     fn insert_silent_node(df: &mut RunningDataflow, node: &NodeId) {
         let running = test_running_node();
         running.last_activity.store(1, atomic::Ordering::Release);
         df.running_nodes.insert(node.clone(), running);
+        // a real running node has subscribed (can receive finish events)
+        let (tx, _rx) = mpsc::channel(NODE_EVENT_CHANNEL_CAPACITY);
+        df.subscribe_channels.insert(node.clone(), tx);
     }
 
     #[test]
@@ -5686,8 +5689,8 @@ mod fault_tolerance_tests {
 
     #[test]
     fn wedged_user_input_node_is_a_finish_straggler() {
-        // A node with no timer/log input that has gone silent past grace while
-        // the rest of the dataflow finished IS a straggler and is escalated.
+        // A connected node with no timer/log input that has gone silent past
+        // grace while the rest of the dataflow finished IS a straggler.
         let mut df = test_dataflow();
         let stuck: NodeId = "stuck".to_string().into();
         insert_silent_node(&mut df, &stuck);
@@ -5695,6 +5698,26 @@ mod fault_tolerance_tests {
         let now = node_communication::current_millis();
         let selected = df.finish_stragglers(Duration::from_millis(1), now);
         assert_eq!(selected, vec![stuck]);
+    }
+
+    #[test]
+    fn unconnected_slow_starting_node_is_not_a_finish_straggler() {
+        // `last_activity` is seeded at spawn, so a node that has not subscribed
+        // yet looks long-silent — but it is still starting up (e.g. loading a
+        // model) and must not be force-killed (#2270 review).
+        let mut df = test_dataflow();
+        let starting: NodeId = "slow_loader".to_string().into();
+        let running = test_running_node();
+        running.last_activity.store(1, atomic::Ordering::Release);
+        df.running_nodes.insert(starting.clone(), running);
+        // NOTE: deliberately NOT added to subscribe_channels (not connected).
+
+        let now = node_communication::current_millis();
+        let selected = df.finish_stragglers(Duration::from_millis(1), now);
+        assert!(
+            selected.is_empty(),
+            "a node that has not subscribed must not be escalated: {selected:?}"
+        );
     }
 
     // -- Test 2: close_input sends AllInputsClosed + disable_restart on last input --

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -2346,8 +2346,9 @@ impl Daemon {
     /// the stuck process so the hang itself stays diagnosable.
     fn check_finish_stragglers(&mut self) {
         let grace = finish_drain_grace();
+        let now_millis = node_communication::current_millis();
         for (dataflow_id, dataflow) in self.running.iter_mut() {
-            for node_id in dataflow.finish_stragglers(grace) {
+            for node_id in dataflow.finish_stragglers(grace, now_millis) {
                 let drained_for_secs = dataflow
                     .all_inputs_closed_at
                     .get(&node_id)

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -199,6 +199,12 @@ pub struct RunningDataflow {
     /// that node's drain phase. Drives the finish-straggler watchdog
     /// (dora-rs/dora#2152).
     pub(crate) all_inputs_closed_at: HashMap<NodeId, Instant>,
+    /// Nodes that have subscribed at least once. Distinguishes a node that has
+    /// connected (and may since have dropped its event stream) from one still
+    /// starting up — only the former is a finish-straggler candidate. Set on
+    /// subscribe, cleared on node removal so a re-added node ID starts a fresh
+    /// incarnation rather than looking already-connected (dora-rs/dora#2270).
+    pub(crate) connected_nodes: BTreeSet<NodeId>,
     /// Nodes already escalated by the finish-straggler watchdog (one-shot).
     pub(crate) finish_escalated: BTreeSet<NodeId>,
     pub(crate) stop_sent: bool,
@@ -262,6 +268,7 @@ impl RunningDataflow {
             open_external_mappings: Default::default(),
             _timer_handles: BTreeMap::new(),
             all_inputs_closed_at: HashMap::new(),
+            connected_nodes: BTreeSet::new(),
             finish_escalated: BTreeSet::new(),
             stop_sent: false,
             empty_set: BTreeSet::new(),
@@ -613,11 +620,14 @@ impl RunningDataflow {
                     dynamic: node.node_config.dynamic,
                     never_finishes: self.node_never_finishes(id),
                     // A node is only a silence candidate once it has subscribed
-                    // — i.e. can actually receive AllInputsClosed/Stop. Until
-                    // then it is still starting (a slow model-load node), not a
-                    // wedge, even though `last_activity` is seeded at spawn time
-                    // and would otherwise read as long-silent (dora#2270 review).
-                    connected: self.subscribe_channels.contains_key(id),
+                    // — i.e. has connected and can receive AllInputsClosed/Stop.
+                    // Until then it is still starting (a slow model-load node),
+                    // not a wedge, even though `last_activity` is seeded at spawn
+                    // time and would otherwise read as long-silent. Uses the
+                    // sticky `connected_nodes` rather than current channel
+                    // presence so a node that dropped its event stream but is
+                    // still alive remains a candidate (dora#2270 review).
+                    connected: self.connected_nodes.contains(id),
                     drained_for: self.all_inputs_closed_at.get(id).map(Instant::elapsed),
                     silent_for: Duration::from_millis(now_millis.saturating_sub(last)),
                 }

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -522,8 +522,12 @@ impl RunningDataflow {
             .store(true, atomic::Ordering::Release);
         // A fresh incarnation starts with a clean drain state: a stale
         // AllInputsClosed timestamp from the previous incarnation must not
-        // trip the finish-straggler watchdog on the restarted node.
+        // trip the finish-straggler watchdog on the restarted node. The
+        // connected marker is cleared too, so the restarting process is not
+        // treated as connected (and silence-escalatable) before it re-subscribes
+        // (dora-rs/dora#2270).
         self.all_inputs_closed_at.remove(node_id);
+        self.connected_nodes.remove(node_id);
         self.finish_escalated.remove(node_id);
         self.send_stop_and_schedule_kill(
             node_id,

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -582,57 +582,111 @@ impl RunningDataflow {
 
     /// Nodes blocking an otherwise-finished dataflow (dora-rs/dora#2152).
     ///
-    /// Returns nodes that have been draining (received `AllInputsClosed`)
-    /// for longer than `grace`, but only once *every* running non-dynamic
-    /// node of the dataflow is draining — a running source (which never
-    /// receives `AllInputsClosed`) means the dataflow is still producing
-    /// and nothing is escalated. Explicitly stopped dataflows are excluded:
-    /// `stop_all` runs its own kill escalation. Dataflows with open
-    /// cross-daemon output mappings are also excluded — a local node that
-    /// looks like a straggler may still be flushing outputs to consumers
-    /// on other daemons, which this daemon cannot see.
-    pub(crate) fn finish_stragglers(&self, grace: Duration) -> Vec<NodeId> {
+    /// Returns nodes that should be force-stopped because the dataflow is
+    /// "otherwise finished" — every running non-dynamic node is quiescent —
+    /// but they have not exited. A node is quiescent once it has either been
+    /// draining (received `AllInputsClosed`) past `grace`, or — never having
+    /// reached the drain state — gone silent (no daemon traffic) past `grace`.
+    /// The second arm catches a node that wedges *before* draining (dora#2152:
+    /// the operator runtime stuck after stop), which the drain-only gate let
+    /// hang indefinitely.
+    ///
+    /// A running source (no inputs, never drains) means the dataflow is still
+    /// producing, so nothing escalates; likewise an active non-source node
+    /// (recent traffic) means work is still in progress. Explicitly stopped
+    /// dataflows are excluded (`stop_all` runs its own kill escalation), as are
+    /// dataflows with open cross-daemon output mappings — a local node that
+    /// looks like a straggler may still be flushing outputs to consumers on
+    /// other daemons, which this daemon cannot see.
+    ///
+    /// `now_millis` is the current `node_communication::current_millis()`, the
+    /// clock `RunningNode::last_activity` is stamped against.
+    pub(crate) fn finish_stragglers(&self, grace: Duration, now_millis: u64) -> Vec<NodeId> {
         if self.stop_sent || !self.open_external_mappings.is_empty() {
             return Vec::new();
         }
         select_finish_stragglers(
-            self.running_nodes
-                .iter()
-                .map(|(id, node)| (id, node.node_config.dynamic)),
-            &self.all_inputs_closed_at,
+            self.running_nodes.iter().map(|(id, node)| {
+                let is_source = self
+                    .descriptor
+                    .nodes
+                    .iter()
+                    .find(|n| &n.id == id)
+                    .is_some_and(|n| n.inputs.is_empty());
+                let last = node.last_activity.load(atomic::Ordering::Acquire);
+                // last == 0 means never connected; treat as active so a
+                // node that has not started is not mistaken for a wedge.
+                let silent_for = if last == 0 {
+                    Duration::ZERO
+                } else {
+                    Duration::from_millis(now_millis.saturating_sub(last))
+                };
+                StragglerNode {
+                    id,
+                    dynamic: node.node_config.dynamic,
+                    is_source,
+                    drained_for: self.all_inputs_closed_at.get(id).map(Instant::elapsed),
+                    silent_for,
+                }
+            }),
             &self.finish_escalated,
             grace,
         )
     }
 }
 
+/// One running node's view for [`select_finish_stragglers`].
+struct StragglerNode<'a> {
+    id: &'a NodeId,
+    dynamic: bool,
+    /// No inputs in the descriptor — a source that never drains.
+    is_source: bool,
+    /// Time since `AllInputsClosed`, or `None` if it never reached drain.
+    drained_for: Option<Duration>,
+    /// Time since the last daemon-bound message from this node.
+    silent_for: Duration,
+}
+
 /// Pure core of [`RunningDataflow::finish_stragglers`].
 fn select_finish_stragglers<'a>(
-    running_nodes: impl Iterator<Item = (&'a NodeId, bool)>,
-    all_inputs_closed_at: &HashMap<NodeId, Instant>,
+    running_nodes: impl Iterator<Item = StragglerNode<'a>>,
     already_escalated: &BTreeSet<NodeId>,
     grace: Duration,
 ) -> Vec<NodeId> {
-    // Gate first: every running non-dynamic node must be draining,
-    // otherwise the dataflow is not "otherwise finished" (e.g. a running
-    // source) and nothing may be escalated.
-    let mut draining = Vec::new();
-    for (node_id, dynamic) in running_nodes {
-        if dynamic {
+    // Gate first: every running non-dynamic node must be quiescent (drained or
+    // silent past grace), otherwise the dataflow is not "otherwise finished"
+    // (a running source, or a node still producing) and nothing may escalate.
+    let mut eligible = Vec::new();
+    for node in running_nodes {
+        if node.dynamic {
             continue;
         }
-        match all_inputs_closed_at.get(node_id) {
-            Some(drain_started) => draining.push((node_id, drain_started)),
-            None => return Vec::new(),
+        if node.is_source {
+            // a live source keeps the dataflow producing
+            return Vec::new();
+        }
+        match node.drained_for {
+            // draining: ready past grace; still within grace it is progressing
+            // toward exit and does not veto, but is not escalated yet
+            Some(drained_for) => {
+                if drained_for >= grace {
+                    eligible.push(node.id.clone());
+                }
+            }
+            // never drained: only "finished" if it has wedged silent past grace
+            None => {
+                if node.silent_for >= grace {
+                    eligible.push(node.id.clone());
+                } else {
+                    return Vec::new();
+                }
+            }
         }
     }
 
-    draining
+    eligible
         .into_iter()
-        .filter(|(node_id, drain_started)| {
-            drain_started.elapsed() >= grace && !already_escalated.contains(*node_id)
-        })
-        .map(|(node_id, _)| node_id.clone())
+        .filter(|node_id| !already_escalated.contains(node_id))
         .collect()
 }
 
@@ -646,26 +700,37 @@ mod tests {
         NodeId::from(name.to_string())
     }
 
-    /// Backdates are kept tiny (≤2s): on Windows, `Instant` is anchored at
-    /// boot and larger subtractions underflow on fresh CI runners — the
-    /// exact panic class fixed in dora-rs/dora#2088.
-    fn drained_since(entries: &[(&str, Duration)]) -> HashMap<NodeId, Instant> {
-        entries
-            .iter()
-            .map(|(name, age)| (node_id(name), Instant::now() - *age))
-            .collect()
-    }
-
     const TEST_GRACE: Duration = Duration::from_millis(100);
     const PAST_GRACE: Duration = Duration::from_secs(2);
+    const WITHIN_GRACE: Duration = Duration::ZERO;
+
+    /// A non-source node draining for `age` (received `AllInputsClosed`).
+    fn drained<'a>(id: &'a NodeId, age: Duration) -> StragglerNode<'a> {
+        StragglerNode {
+            id,
+            dynamic: false,
+            is_source: false,
+            drained_for: Some(age),
+            silent_for: Duration::ZERO,
+        }
+    }
+
+    /// A non-source node that never drained, silent for `silent_for`.
+    fn never_drained<'a>(id: &'a NodeId, silent_for: Duration) -> StragglerNode<'a> {
+        StragglerNode {
+            id,
+            dynamic: false,
+            is_source: false,
+            drained_for: None,
+            silent_for,
+        }
+    }
 
     #[test]
     fn straggler_past_grace_is_selected() {
-        let running = [(node_id("sink"), false)];
-        let drained = drained_since(&[("sink", PAST_GRACE)]);
+        let sink = node_id("sink");
         let selected = select_finish_stragglers(
-            running.iter().map(|(id, d)| (id, *d)),
-            &drained,
+            [drained(&sink, PAST_GRACE)].into_iter(),
             &BTreeSet::new(),
             TEST_GRACE,
         );
@@ -674,11 +739,9 @@ mod tests {
 
     #[test]
     fn straggler_within_grace_is_not_selected() {
-        let running = [(node_id("sink"), false)];
-        let drained = drained_since(&[("sink", Duration::ZERO)]);
+        let sink = node_id("sink");
         let selected = select_finish_stragglers(
-            running.iter().map(|(id, d)| (id, *d)),
-            &drained,
+            [drained(&sink, WITHIN_GRACE)].into_iter(),
             &BTreeSet::new(),
             TEST_GRACE,
         );
@@ -689,11 +752,17 @@ mod tests {
     fn running_source_blocks_escalation_of_drained_nodes() {
         // `source` never receives AllInputsClosed; while it runs, the
         // dataflow is not "otherwise finished" and nothing escalates.
-        let running = [(node_id("source"), false), (node_id("sink"), false)];
-        let drained = drained_since(&[("sink", PAST_GRACE)]);
+        let source = node_id("source");
+        let sink = node_id("sink");
+        let source_node = StragglerNode {
+            id: &source,
+            dynamic: false,
+            is_source: true,
+            drained_for: None,
+            silent_for: PAST_GRACE,
+        };
         let selected = select_finish_stragglers(
-            running.iter().map(|(id, d)| (id, *d)),
-            &drained,
+            [source_node, drained(&sink, PAST_GRACE)].into_iter(),
             &BTreeSet::new(),
             TEST_GRACE,
         );
@@ -702,11 +771,17 @@ mod tests {
 
     #[test]
     fn dynamic_nodes_neither_block_nor_escalate() {
-        let running = [(node_id("dynamic"), true), (node_id("sink"), false)];
-        let drained = drained_since(&[("sink", PAST_GRACE)]);
+        let dynamic = node_id("dynamic");
+        let sink = node_id("sink");
+        let dynamic_node = StragglerNode {
+            id: &dynamic,
+            dynamic: true,
+            is_source: false,
+            drained_for: None,
+            silent_for: WITHIN_GRACE,
+        };
         let selected = select_finish_stragglers(
-            running.iter().map(|(id, d)| (id, *d)),
-            &drained,
+            [dynamic_node, drained(&sink, PAST_GRACE)].into_iter(),
             &BTreeSet::new(),
             TEST_GRACE,
         );
@@ -715,12 +790,10 @@ mod tests {
 
     #[test]
     fn already_escalated_nodes_are_not_reselected() {
-        let running = [(node_id("sink"), false)];
-        let drained = drained_since(&[("sink", PAST_GRACE)]);
+        let sink = node_id("sink");
         let escalated: BTreeSet<_> = [node_id("sink")].into();
         let selected = select_finish_stragglers(
-            running.iter().map(|(id, d)| (id, *d)),
-            &drained,
+            [drained(&sink, PAST_GRACE)].into_iter(),
             &escalated,
             TEST_GRACE,
         );
@@ -729,15 +802,80 @@ mod tests {
 
     #[test]
     fn multiple_drained_stragglers_are_all_selected() {
-        let running = [(node_id("a"), false), (node_id("b"), false)];
-        let drained = drained_since(&[("a", PAST_GRACE), ("b", PAST_GRACE)]);
+        let a = node_id("a");
+        let b = node_id("b");
         let selected = select_finish_stragglers(
-            running.iter().map(|(id, d)| (id, *d)),
-            &drained,
+            [drained(&a, PAST_GRACE), drained(&b, PAST_GRACE)].into_iter(),
             &BTreeSet::new(),
             TEST_GRACE,
         );
         assert_eq!(selected, vec![node_id("a"), node_id("b")]);
+    }
+
+    // ---- dora-rs/dora#2270: wedge-before-drain escalation ----
+
+    #[test]
+    fn non_source_wedged_silent_past_grace_is_escalated() {
+        // the #2152/#2270 case: a node that never reached the drain state but
+        // has gone silent past grace while the rest of the dataflow finished.
+        let stuck = node_id("runtime");
+        let selected = select_finish_stragglers(
+            [never_drained(&stuck, PAST_GRACE)].into_iter(),
+            &BTreeSet::new(),
+            TEST_GRACE,
+        );
+        assert_eq!(selected, vec![node_id("runtime")]);
+    }
+
+    #[test]
+    fn non_source_active_without_drain_blocks_escalation() {
+        // a non-source node still sending daemon traffic means work is in
+        // progress — the dataflow is not otherwise finished.
+        let active = node_id("active");
+        let sink = node_id("sink");
+        let selected = select_finish_stragglers(
+            [
+                never_drained(&active, WITHIN_GRACE),
+                drained(&sink, PAST_GRACE),
+            ]
+            .into_iter(),
+            &BTreeSet::new(),
+            TEST_GRACE,
+        );
+        assert!(selected.is_empty());
+    }
+
+    #[test]
+    fn silent_source_is_never_escalated() {
+        // a source has no inputs and is stopped via the explicit-stop path,
+        // never via finish-straggler escalation — even when silent past grace.
+        let source = node_id("source");
+        let source_node = StragglerNode {
+            id: &source,
+            dynamic: false,
+            is_source: true,
+            drained_for: None,
+            silent_for: PAST_GRACE,
+        };
+        let selected =
+            select_finish_stragglers([source_node].into_iter(), &BTreeSet::new(), TEST_GRACE);
+        assert!(selected.is_empty());
+    }
+
+    #[test]
+    fn drained_and_wedged_stragglers_escalate_together() {
+        let sink = node_id("sink");
+        let stuck = node_id("runtime");
+        let selected = select_finish_stragglers(
+            [
+                drained(&sink, PAST_GRACE),
+                never_drained(&stuck, PAST_GRACE),
+            ]
+            .into_iter(),
+            &BTreeSet::new(),
+            TEST_GRACE,
+        );
+        assert_eq!(selected, vec![node_id("sink"), node_id("runtime")]);
     }
 
     // ---- dora-rs/adora#149: InputDeadline::is_timed_out ----

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -607,12 +607,6 @@ impl RunningDataflow {
         }
         select_finish_stragglers(
             self.running_nodes.iter().map(|(id, node)| {
-                let is_source = self
-                    .descriptor
-                    .nodes
-                    .iter()
-                    .find(|n| &n.id == id)
-                    .is_some_and(|n| n.inputs.is_empty());
                 let last = node.last_activity.load(atomic::Ordering::Acquire);
                 // last == 0 means never connected; treat as active so a
                 // node that has not started is not mistaken for a wedge.
@@ -624,7 +618,7 @@ impl RunningDataflow {
                 StragglerNode {
                     id,
                     dynamic: node.node_config.dynamic,
-                    is_source,
+                    never_finishes: self.node_never_finishes(id),
                     drained_for: self.all_inputs_closed_at.get(id).map(Instant::elapsed),
                     silent_for,
                 }
@@ -633,14 +627,41 @@ impl RunningDataflow {
             grace,
         )
     }
+
+    /// Whether a node can never reach natural finish, so the finish-straggler
+    /// watchdog must leave it alone (it is stopped only via the explicit-stop
+    /// path). True for a source (no inputs) and — crucially — for any node fed
+    /// by a `Timer` or `Logs` input: those virtual inputs never close, so the
+    /// node never receives `AllInputsClosed`, and timer/log delivery is
+    /// daemon-to-node so it never refreshes `last_activity`. Such a node looks
+    /// "silent and never drained" exactly like a wedge, but is alive by design
+    /// (dora-rs/dora#2270) — e.g. a long-running timer-only side-effect node.
+    fn node_never_finishes(&self, node_id: &NodeId) -> bool {
+        let is_source = self
+            .descriptor
+            .nodes
+            .iter()
+            .find(|n| &n.id == node_id)
+            .is_some_and(|n| n.inputs.is_empty());
+        let has_timer = self
+            .timers
+            .values()
+            .any(|receivers| receivers.iter().any(|(id, _)| id == node_id));
+        let has_logs = self
+            .log_subscribers
+            .iter()
+            .any(|sub| &sub.node_id == node_id);
+        is_source || has_timer || has_logs
+    }
 }
 
 /// One running node's view for [`select_finish_stragglers`].
 struct StragglerNode<'a> {
     id: &'a NodeId,
     dynamic: bool,
-    /// No inputs in the descriptor — a source that never drains.
-    is_source: bool,
+    /// Node that never reaches natural finish — a source, or one kept alive by
+    /// a `Timer`/`Logs` input (see [`RunningDataflow::node_never_finishes`]).
+    never_finishes: bool,
     /// Time since `AllInputsClosed`, or `None` if it never reached drain.
     drained_for: Option<Duration>,
     /// Time since the last daemon-bound message from this node.
@@ -661,8 +682,9 @@ fn select_finish_stragglers<'a>(
         if node.dynamic {
             continue;
         }
-        if node.is_source {
-            // a live source keeps the dataflow producing
+        if node.never_finishes {
+            // a live source (or timer/log-fed node) keeps the dataflow running;
+            // it is stopped only via the explicit-stop path, never escalated here
             return Vec::new();
         }
         match node.drained_for {
@@ -704,23 +726,23 @@ mod tests {
     const PAST_GRACE: Duration = Duration::from_secs(2);
     const WITHIN_GRACE: Duration = Duration::ZERO;
 
-    /// A non-source node draining for `age` (received `AllInputsClosed`).
+    /// A finishing (non-source, no timer/log) node draining for `age`.
     fn drained<'a>(id: &'a NodeId, age: Duration) -> StragglerNode<'a> {
         StragglerNode {
             id,
             dynamic: false,
-            is_source: false,
+            never_finishes: false,
             drained_for: Some(age),
             silent_for: Duration::ZERO,
         }
     }
 
-    /// A non-source node that never drained, silent for `silent_for`.
+    /// A finishing node that never drained, silent for `silent_for`.
     fn never_drained<'a>(id: &'a NodeId, silent_for: Duration) -> StragglerNode<'a> {
         StragglerNode {
             id,
             dynamic: false,
-            is_source: false,
+            never_finishes: false,
             drained_for: None,
             silent_for,
         }
@@ -757,7 +779,7 @@ mod tests {
         let source_node = StragglerNode {
             id: &source,
             dynamic: false,
-            is_source: true,
+            never_finishes: true,
             drained_for: None,
             silent_for: PAST_GRACE,
         };
@@ -776,7 +798,7 @@ mod tests {
         let dynamic_node = StragglerNode {
             id: &dynamic,
             dynamic: true,
-            is_source: false,
+            never_finishes: false,
             drained_for: None,
             silent_for: WITHIN_GRACE,
         };
@@ -846,19 +868,20 @@ mod tests {
     }
 
     #[test]
-    fn silent_source_is_never_escalated() {
-        // a source has no inputs and is stopped via the explicit-stop path,
+    fn never_finishing_node_is_not_escalated_when_silent() {
+        // a source or timer/log-fed node is stopped via the explicit-stop path,
         // never via finish-straggler escalation — even when silent past grace.
-        let source = node_id("source");
-        let source_node = StragglerNode {
-            id: &source,
+        // Guards the dora#2270 regression where a long-running timer-only node
+        // (silent, never drained) was force-killed after the grace period.
+        let perpetual = node_id("timer_node");
+        let node = StragglerNode {
+            id: &perpetual,
             dynamic: false,
-            is_source: true,
+            never_finishes: true,
             drained_for: None,
             silent_for: PAST_GRACE,
         };
-        let selected =
-            select_finish_stragglers([source_node].into_iter(), &BTreeSet::new(), TEST_GRACE);
+        let selected = select_finish_stragglers([node].into_iter(), &BTreeSet::new(), TEST_GRACE);
         assert!(selected.is_empty());
     }
 

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -608,19 +608,18 @@ impl RunningDataflow {
         select_finish_stragglers(
             self.running_nodes.iter().map(|(id, node)| {
                 let last = node.last_activity.load(atomic::Ordering::Acquire);
-                // last == 0 means never connected; treat as active so a
-                // node that has not started is not mistaken for a wedge.
-                let silent_for = if last == 0 {
-                    Duration::ZERO
-                } else {
-                    Duration::from_millis(now_millis.saturating_sub(last))
-                };
                 StragglerNode {
                     id,
                     dynamic: node.node_config.dynamic,
                     never_finishes: self.node_never_finishes(id),
+                    // A node is only a silence candidate once it has subscribed
+                    // — i.e. can actually receive AllInputsClosed/Stop. Until
+                    // then it is still starting (a slow model-load node), not a
+                    // wedge, even though `last_activity` is seeded at spawn time
+                    // and would otherwise read as long-silent (dora#2270 review).
+                    connected: self.subscribe_channels.contains_key(id),
                     drained_for: self.all_inputs_closed_at.get(id).map(Instant::elapsed),
-                    silent_for,
+                    silent_for: Duration::from_millis(now_millis.saturating_sub(last)),
                 }
             }),
             &self.finish_escalated,
@@ -662,9 +661,13 @@ struct StragglerNode<'a> {
     /// Node that never reaches natural finish — a source, or one kept alive by
     /// a `Timer`/`Logs` input (see [`RunningDataflow::node_never_finishes`]).
     never_finishes: bool,
+    /// Whether the node has subscribed and can receive finish events. A node
+    /// that has not connected yet is still starting up, not wedged.
+    connected: bool,
     /// Time since `AllInputsClosed`, or `None` if it never reached drain.
     drained_for: Option<Duration>,
-    /// Time since the last daemon-bound message from this node.
+    /// Time since the last daemon-bound message from this node. Only meaningful
+    /// once `connected` — `last_activity` is seeded at spawn time.
     silent_for: Duration,
 }
 
@@ -695,9 +698,12 @@ fn select_finish_stragglers<'a>(
                     eligible.push(node.id.clone());
                 }
             }
-            // never drained: only "finished" if it has wedged silent past grace
+            // never drained: only "finished" if a connected node has wedged
+            // silent past grace. An unconnected node is still starting up (so
+            // the dataflow is not otherwise finished); a connected but active
+            // node still has work in progress — both veto.
             None => {
-                if node.silent_for >= grace {
+                if node.connected && node.silent_for >= grace {
                     eligible.push(node.id.clone());
                 } else {
                     return Vec::new();
@@ -726,23 +732,25 @@ mod tests {
     const PAST_GRACE: Duration = Duration::from_secs(2);
     const WITHIN_GRACE: Duration = Duration::ZERO;
 
-    /// A finishing (non-source, no timer/log) node draining for `age`.
+    /// A finishing (non-source, no timer/log), connected node draining for `age`.
     fn drained<'a>(id: &'a NodeId, age: Duration) -> StragglerNode<'a> {
         StragglerNode {
             id,
             dynamic: false,
             never_finishes: false,
+            connected: true,
             drained_for: Some(age),
             silent_for: Duration::ZERO,
         }
     }
 
-    /// A finishing node that never drained, silent for `silent_for`.
+    /// A finishing, connected node that never drained, silent for `silent_for`.
     fn never_drained<'a>(id: &'a NodeId, silent_for: Duration) -> StragglerNode<'a> {
         StragglerNode {
             id,
             dynamic: false,
             never_finishes: false,
+            connected: true,
             drained_for: None,
             silent_for,
         }
@@ -780,6 +788,7 @@ mod tests {
             id: &source,
             dynamic: false,
             never_finishes: true,
+            connected: true,
             drained_for: None,
             silent_for: PAST_GRACE,
         };
@@ -799,6 +808,7 @@ mod tests {
             id: &dynamic,
             dynamic: true,
             never_finishes: false,
+            connected: true,
             drained_for: None,
             silent_for: WITHIN_GRACE,
         };
@@ -850,6 +860,24 @@ mod tests {
     }
 
     #[test]
+    fn unconnected_node_silent_past_grace_is_not_escalated() {
+        // `last_activity` is seeded at spawn, so a slow-starting node that has
+        // not subscribed yet reads as long-silent — but it is still coming up,
+        // not wedged, and must not be killed (dora#2270 review regression).
+        let starting = node_id("slow_loader");
+        let node = StragglerNode {
+            id: &starting,
+            dynamic: false,
+            never_finishes: false,
+            connected: false,
+            drained_for: None,
+            silent_for: PAST_GRACE,
+        };
+        let selected = select_finish_stragglers([node].into_iter(), &BTreeSet::new(), TEST_GRACE);
+        assert!(selected.is_empty());
+    }
+
+    #[test]
     fn non_source_active_without_drain_blocks_escalation() {
         // a non-source node still sending daemon traffic means work is in
         // progress — the dataflow is not otherwise finished.
@@ -878,6 +906,7 @@ mod tests {
             id: &perpetual,
             dynamic: false,
             never_finishes: true,
+            connected: true,
             drained_for: None,
             silent_for: PAST_GRACE,
         };


### PR DESCRIPTION
Towards #2270 — **does not auto-close it** (the watchdog ships disabled by default; see Rollout). Supersedes the drain-clock alternative in #2272.

## Why the liveness approach (not drain-clock)

#2270's acceptance case is "all nodes finished except one **wedged node that never entered the AllInputsClosed drain**." The drain-clock alternative (#2272) only arms when a node's `open_inputs` actually empties, so it can't cover a node that never drains — structurally partial. The liveness approach escalates on **silence past grace** regardless of drain state, so it covers the outside-drain case the issue requires.

## What it does

The finish-straggler watchdog escalates (Stop → SIGTERM → SIGKILL, with a pre-kill stack sample) a node blocking an otherwise-finished dataflow. `select_finish_stragglers`:

- **dynamic** → skip
- **never-finishes** (source, or fed by a `Timer`/`Logs` input) → veto
- **drained** (`AllInputsClosed`) past grace → escalate
- **never drained but silent** past grace **and connected** → escalate (the #2270 wedge)
- never drained, silent < grace, or not connected → veto

## Edge cases handled (surfaced across both approaches' reviews)

- **sources / timer-log nodes** never escalate.
- **slow-start nodes**: gated on a sticky **`connected_nodes`** signal (set on subscribe).
- **dropped-stream nodes**: `connected_nodes` is not tied to current channel presence, so a node that dropped its stream but stayed alive is still a candidate (SIGKILL signals the process).
- **node-ID reuse / restart**: `connected_nodes` is cleared on `RemoveNode`, on `restart_single_node`, and on node exit, so a re-added/respawned ID must re-subscribe before counting as connected.

## Rollout (why this leaves #2270 open)

This escalates to SIGKILL on a shutdown-only path that **isn't reproducible locally**, so it ships **dark**: gated on `DORA_FINISH_DRAIN_GRACE_SECS` (unset → disabled, current default). Plan:

1. **This PR**: land the mechanism, disabled by default. No behavior change for anyone.
2. **Validate**: enable it on nightly (`DORA_FINISH_DRAIN_GRACE_SECS=120` in the nightly jobs that exercise the #2152/#2270 shutdown path) and confirm it bounds the hang without false-positive kills over several runs.
3. **Flip the default**: once proven, make unset → enabled (one-line change), after which #2270 can be closed.

So #2270 stays open until step 3. Step 2 is a separate, reviewable change (it turns a force-kill heuristic on in CI), not bundled here.

## Tests

Pure-core selector cases + daemon-level: timer-fed spared, wedged-user escalated, unconnected slow-start spared, dropped-stream escalated, reused-ID spared pre-subscribe, restart clears the connected marker, opt-in parse.

`cargo test -p dora-daemon --lib` → 77 passed; fmt + clippy (`-D warnings`) clean.

Companion to #2152 (root cause of *why* a node fails to exit stays separately tracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
