### PR TITLE
refactor(memory-pool): remove unused MemoryPoolManager::get_all_entries

### DIFF
--- a/libraries/extensions/memory-pool/src/lib.rs
+++ b/libraries/extensions/memory-pool/src/lib.rs
@@ -209,15 +209,6 @@ impl MemoryPoolManager {
         }
     }
 
-    /// Get all memory pool entries for cleanup on shutdown.
-    pub fn get_all_entries(&self) -> Vec<(MemoryPoolId, MemoryPoolEntry)> {
-        let table = self.lock_table();
-        table
-            .iter()
-            .map(|(id, entry)| (id.clone(), entry.clone()))
-            .collect()
-    }
-
     /// Sweep orphaned shared-memory segments from a previous crash or
     /// SIGKILL of the same dataflow.
     ///


### PR DESCRIPTION
> ⚠️ **Auto-generated by Claude Code.** This PR was created and pushed by an automated agent (it appears under a maintainer's account only because of how the API authenticates — no human wrote or reviewed it before submission). Please review accordingly.

## What

Removes the unused `MemoryPoolManager::get_all_entries` method from `dora-memory-pool`.

## Why

`get_all_entries` was introduced in #2168 with the doc comment *"Get all memory pool entries for cleanup on shutdown"*, but it has **no callers anywhere in the workspace** and **no test coverage**:

- The daemon — the only crate depending on `dora-memory-pool` — performs shutdown cleanup via [`cleanup_all()`](https://github.com/dora-rs/dora/blob/main/binaries/daemon/src/lib.rs) (`binaries/daemon/src/lib.rs:1486`), which iterates the pool table and frees each segment internally. It does not need a separate accessor that clones every entry out.
- A repo-wide search for `get_all_entries` finds only the definition site.

So the intended shutdown-cleanup role is already fully covered by `cleanup_all()`, leaving this method dead.

`MemoryPoolEntry` is still used internally (it's the pool table's value type), so this change only drops the unused accessor.

## Verification

- `cargo fmt -p dora-memory-pool -- --check` ✅
- `cargo clippy -p dora-memory-pool -p dora-daemon -- -D warnings` ✅
- `cargo test -p dora-memory-pool` ✅ (7 passed)

---
_Generated by [Claude Code](https://claude.ai/code) — automated dead-code sweep._

---
_Generated by [Claude Code](https://claude.ai/code/session_016PuZqHMRr5LGCoe6KRLniQ)_