### PR TITLE
ci(nightly): enable finish-straggler watchdog to validate it (#2270 step 2)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,6 +41,14 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUST_VERSION: "1.92.0"
+  # Enable the finish-straggler watchdog (opt-in / off by default) across the
+  # nightly suite to validate it on the shutdown path it targets — most notably
+  # the macOS Examples job where dora-rs/dora#2152 reproduces. It only acts on a
+  # node still stuck 120s after the dataflow is otherwise finished, so it is a
+  # no-op for cleanly-finishing dataflows and for jobs that run no daemon. This
+  # is rollout step 2 of dora-rs/dora#2270: bake on nightly, then flip the
+  # default once it's proven to bound the hang without false-positive kills.
+  DORA_FINISH_DRAIN_GRACE_SECS: "120"
 
 jobs:
   smoke-suite:


### PR DESCRIPTION
Rollout **step 2** of #2270 (follow-up to #2271, which landed the watchdog off-by-default).

## What

Sets `DORA_FINISH_DRAIN_GRACE_SECS=120` in the nightly workflow's top-level `env:`, enabling the finish-straggler watchdog across the nightly suite.

## Why workflow-wide

The watchdog only escalates (Stop → SIGTERM → SIGKILL) a node still stuck **120s after the dataflow is otherwise finished**. So it's a no-op for:
- jobs that spawn no daemon (build-cli, cross-checks, msrv, kani — the env var is just ignored), and
- dataflows that finish cleanly (the common case).

Enabling it suite-wide is the simplest way to exercise it everywhere nightly actually runs the shutdown path — including the **macOS Examples job where #2152 reproduces**, plus smoke-suite, service/action, streaming, record-replay, and cluster jobs.

## Expected effect

Where a node currently hangs after stop (the #2152 signature), the daemon will now SIGKILL it ~120s after the dataflow is otherwise done, instead of the job sitting until its ~15-min step timeout. So a previously-flaky timeout failure should become either a clean pass or a clear `escalating stop … node X` log — better signal either way.

## Risk

Low and contained:
- Nightly is **non-blocking** — a false positive files a `nightly-regression` issue, not a PR block.
- 120s is the conservative default grace; the selector only targets a **connected, non-source, non-timer/log** node that's been quiescent past grace (sources, timer/log-fed, and still-starting nodes are excluded by construction).

## Rollout

1. ✅ Land watchdog off-by-default (#2271, merged).
2. **This PR** — bake on nightly, watch several runs for: hang bounded, no false-positive kills.
3. Flip the default (unset → enabled), after which #2270 can be resolved.

Editing `nightly.yml` triggers one nightly run on merge (the workflow's push-to-main `paths` filter), so we get immediate signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
