### PR TITLE
fix(hub): surface yanked versions in `dora hub info` with (yanked) marker

### DIFF
--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -104,3 +104,6 @@ crate-type = ["lib", "cdylib"]
 [package.metadata.dist]
 # Enable dora-cli binary to be distributed
 dist = true
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/binaries/cli/src/command/hub/info.rs
+++ b/binaries/cli/src/command/hub/info.rs
@@ -236,4 +236,26 @@ mod tests {
             .is_err()
         );
     }
+
+    // A corrupt/unreadable matching entry must surface its parse error rather
+    // than being skipped so a lower yanked entry is shown in its place
+    // (#2275 review): the highest matching version (0.7.0) is malformed.
+    #[test]
+    fn corrupt_matching_entry_is_surfaced_not_masked_by_yanked() {
+        let tmp = tempfile::tempdir().unwrap();
+        let yolo = tmp.path().join("dora-rs/dora-yolo");
+        std::fs::create_dir_all(&yolo).unwrap();
+        write_entry(&yolo, "0.6.0", true); // readable yanked
+        // higher version, but its entry fails to parse (manifest must be a map)
+        std::fs::write(yolo.join("0.7.0.yml"), "manifest: not-a-map\n").unwrap();
+        let catalog = IndexCatalog::open(tmp.path()).unwrap();
+
+        let err = resolve_or_yanked(&catalog, &parse("dora-rs/dora-yolo"), "dora-rs/dora-yolo")
+            .expect_err("a corrupt matching entry must surface, not fall back to yanked");
+        let msg = format!("{err:#}").to_lowercase();
+        assert!(
+            msg.contains("0.7.0") || msg.contains("invalid index entry"),
+            "expected the corrupt-entry error, got: {msg}"
+        );
+    }
 }

--- a/binaries/cli/src/command/hub/info.rs
+++ b/binaries/cli/src/command/hub/info.rs
@@ -96,21 +96,25 @@ fn resolve_or_yanked(
 )> {
     match catalog.resolve(reference) {
         Ok(resolved) => Ok((resolved.version, resolved.entry)),
-        Err(resolve_err) => catalog
+        Err(resolve_err) => {
             // `versions()` is sorted ascending, so `.rev()` yields highest-first.
-            .versions(&reference.namespace, &reference.name)
-            .unwrap_or_default()
-            .into_iter()
-            .rev()
-            .filter(|v| reference.requirement.matches(v))
-            .find_map(|v| {
-                catalog
-                    .entry(&reference.namespace, &reference.name, &v)
-                    .ok()
-                    .filter(|e| e.yanked)
-                    .map(|e| (v, e))
-            })
-            .ok_or_else(|| resolve_err.wrap_err(format!("failed to resolve `{package_label}`"))),
+            // Use `?` rather than `.ok()` so that corrupt entry files surface their
+            // parse error instead of being silently skipped — otherwise a malformed
+            // non-yanked entry could be masked by a lower valid yanked result.
+            for v in catalog
+                .versions(&reference.namespace, &reference.name)
+                .unwrap_or_default()
+                .into_iter()
+                .rev()
+                .filter(|v| reference.requirement.matches(v))
+            {
+                let entry = catalog.entry(&reference.namespace, &reference.name, &v)?;
+                if entry.yanked {
+                    return Ok((v, entry));
+                }
+            }
+            Err(resolve_err.wrap_err(format!("failed to resolve `{package_label}`")))
+        }
     }
 }
 

--- a/binaries/cli/src/command/hub/info.rs
+++ b/binaries/cli/src/command/hub/info.rs
@@ -3,7 +3,6 @@
 use super::common::{HubContext, sanitize};
 use crate::command::Executable;
 use dora_hub_client::reference::PackageRef;
-use eyre::Context;
 
 /// Show details of a hub node
 #[derive(Debug, clap::Args)]
@@ -21,14 +20,41 @@ impl Executable for Info {
         let reference = PackageRef::parse(&self.package)?;
         let mut ctx = HubContext::load(self.offline)?;
         let catalog = ctx.catalog_for_namespace(&reference.namespace)?;
-        let resolved = catalog
-            .resolve(&reference)
-            .with_context(|| format!("failed to resolve `{}`", self.package))?;
+
+        // resolve() only returns non-yanked entries. If it fails (e.g. every
+        // matching version is yanked), fall back to the highest yanked match so
+        // `info` can surface the (yanked) marker instead of an opaque error.
+        let (version, entry) = match catalog.resolve(&reference) {
+            Ok(resolved) => (resolved.version, resolved.entry),
+            Err(resolve_err) => {
+                let yanked_match = catalog
+                    .versions(&reference.namespace, &reference.name)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .rev()
+                    .filter(|v| reference.requirement.matches(v))
+                    .find_map(|v| {
+                        catalog
+                            .entry(&reference.namespace, &reference.name, &v)
+                            .ok()
+                            .filter(|e| e.yanked)
+                            .map(|e| (v, e))
+                    });
+                match yanked_match {
+                    Some(pair) => pair,
+                    None => {
+                        return Err(
+                            resolve_err.wrap_err(format!("failed to resolve `{}`", self.package))
+                        );
+                    }
+                }
+            }
+        };
         ctx.drain_warnings();
 
-        let m = &resolved.entry.manifest;
-        println!("{} {}", reference.key(), resolved.version);
-        if resolved.entry.yanked {
+        let m = &entry.manifest;
+        println!("{} {}", reference.key(), version);
+        if entry.yanked {
             println!("  (yanked)");
         }
         if let Some(desc) = &m.description {

--- a/binaries/cli/src/command/hub/info.rs
+++ b/binaries/cli/src/command/hub/info.rs
@@ -21,35 +21,7 @@ impl Executable for Info {
         let mut ctx = HubContext::load(self.offline)?;
         let catalog = ctx.catalog_for_namespace(&reference.namespace)?;
 
-        // resolve() only returns non-yanked entries. If it fails (e.g. every
-        // matching version is yanked), fall back to the highest yanked match so
-        // `info` can surface the (yanked) marker instead of an opaque error.
-        let (version, entry) = match catalog.resolve(&reference) {
-            Ok(resolved) => (resolved.version, resolved.entry),
-            Err(resolve_err) => {
-                let yanked_match = catalog
-                    .versions(&reference.namespace, &reference.name)
-                    .unwrap_or_default()
-                    .into_iter()
-                    .rev()
-                    .filter(|v| reference.requirement.matches(v))
-                    .find_map(|v| {
-                        catalog
-                            .entry(&reference.namespace, &reference.name, &v)
-                            .ok()
-                            .filter(|e| e.yanked)
-                            .map(|e| (v, e))
-                    });
-                match yanked_match {
-                    Some(pair) => pair,
-                    None => {
-                        return Err(
-                            resolve_err.wrap_err(format!("failed to resolve `{}`", self.package))
-                        );
-                    }
-                }
-            }
-        };
+        let (version, entry) = resolve_or_yanked(&catalog, &reference, &self.package)?;
         ctx.drain_warnings();
 
         let m = &entry.manifest;
@@ -106,6 +78,42 @@ impl Executable for Info {
     }
 }
 
+/// Resolve `reference`, falling back to the highest **yanked** version that
+/// matches when `resolve()` fails because every matching version is yanked.
+///
+/// `resolve()` only returns non-yanked entries, so without this an explicit (or
+/// all-yanked) lookup errors instead of surfacing the package with its
+/// `(yanked)` marker — the marker branch in `info` would be dead code
+/// (dora-rs/dora#2275). When no matching version exists at all, the original
+/// resolve error is re-raised unchanged.
+fn resolve_or_yanked(
+    catalog: &dora_hub_client::index::IndexCatalog,
+    reference: &PackageRef,
+    package_label: &str,
+) -> eyre::Result<(
+    dora_hub_client::semver::Version,
+    dora_hub_client::index::IndexEntry,
+)> {
+    match catalog.resolve(reference) {
+        Ok(resolved) => Ok((resolved.version, resolved.entry)),
+        Err(resolve_err) => catalog
+            // `versions()` is sorted ascending, so `.rev()` yields highest-first.
+            .versions(&reference.namespace, &reference.name)
+            .unwrap_or_default()
+            .into_iter()
+            .rev()
+            .filter(|v| reference.requirement.matches(v))
+            .find_map(|v| {
+                catalog
+                    .entry(&reference.namespace, &reference.name, &v)
+                    .ok()
+                    .filter(|e| e.yanked)
+                    .map(|e| (v, e))
+            })
+            .ok_or_else(|| resolve_err.wrap_err(format!("failed to resolve `{package_label}`"))),
+    }
+}
+
 fn print_ports(
     label: &str,
     ports: &std::collections::BTreeMap<String, dora_core::manifest::PortDef>,
@@ -121,5 +129,107 @@ fn print_ports(
             .map(|t| format!(": {}", sanitize(t)))
             .unwrap_or_else(|| ": (untyped)".into());
         println!("    {}{ty}", sanitize(name));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Regression coverage for dora-rs/dora#2275: `info`'s `(yanked)` marker
+    //! was unreachable because `resolve()` never returns yanked entries.
+    use super::resolve_or_yanked;
+    use dora_hub_client::index::IndexCatalog;
+    use dora_hub_client::reference::PackageRef;
+
+    fn entry_yaml(yanked: bool) -> String {
+        format!(
+            "manifest:\n  apiVersion: 1\n  name: dora-yolo\n  namespace: dora-rs\n  \
+             runtime: python\n  entrypoint: dora-yolo\nsource:\n  \
+             git: https://github.com/dora-rs/dora-hub\n  \
+             rev: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n  \
+             subdir: node-hub/dora-yolo\nyanked: {yanked}\n"
+        )
+    }
+
+    fn write_entry(dir: &std::path::Path, version: &str, yanked: bool) {
+        std::fs::write(dir.join(format!("{version}.yml")), entry_yaml(yanked)).unwrap();
+    }
+
+    /// Catalog with `dora-rs/dora-yolo` (0.5.1 + 0.5.2 live, 0.6.0 yanked) and
+    /// `dora-rs/legacy` (only version 0.1.0, yanked).
+    fn fixture() -> (tempfile::TempDir, IndexCatalog) {
+        let tmp = tempfile::tempdir().unwrap();
+        let yolo = tmp.path().join("dora-rs/dora-yolo");
+        std::fs::create_dir_all(&yolo).unwrap();
+        write_entry(&yolo, "0.5.1", false);
+        write_entry(&yolo, "0.5.2", false);
+        write_entry(&yolo, "0.6.0", true);
+        std::fs::write(yolo.join("package.yml"), "description: yolo\nowners: [x]\n").unwrap();
+
+        let legacy = tmp.path().join("dora-rs/legacy");
+        std::fs::create_dir_all(&legacy).unwrap();
+        write_entry(&legacy, "0.1.0", true);
+        std::fs::write(
+            legacy.join("package.yml"),
+            "description: legacy\nowners: [x]\n",
+        )
+        .unwrap();
+
+        let catalog = IndexCatalog::open(tmp.path()).unwrap();
+        (tmp, catalog)
+    }
+
+    fn parse(s: &str) -> PackageRef {
+        PackageRef::parse(s).unwrap()
+    }
+
+    // The core fix: an explicitly requested yanked version is surfaced with its
+    // entry (so the `(yanked)` branch is reachable), not an error.
+    #[test]
+    fn surfaces_explicitly_requested_yanked_version() {
+        let (_tmp, catalog) = fixture();
+        let (version, entry) = resolve_or_yanked(
+            &catalog,
+            &parse("dora-rs/dora-yolo@0.6.0"),
+            "dora-rs/dora-yolo@0.6.0",
+        )
+        .unwrap();
+        assert_eq!(version.to_string(), "0.6.0");
+        assert!(entry.yanked, "the (yanked) marker branch must be reachable");
+    }
+
+    // A bare reference still resolves to the highest non-yanked version,
+    // skipping the yanked 0.6.0 — the fallback must not change this.
+    #[test]
+    fn bare_reference_resolves_highest_non_yanked() {
+        let (_tmp, catalog) = fixture();
+        let (version, entry) =
+            resolve_or_yanked(&catalog, &parse("dora-rs/dora-yolo"), "dora-rs/dora-yolo").unwrap();
+        assert_eq!(version.to_string(), "0.5.2");
+        assert!(!entry.yanked);
+    }
+
+    // A bare reference whose every matching version is yanked surfaces the
+    // yanked entry instead of erroring.
+    #[test]
+    fn bare_reference_surfaces_yanked_when_all_yanked() {
+        let (_tmp, catalog) = fixture();
+        let (version, entry) =
+            resolve_or_yanked(&catalog, &parse("dora-rs/legacy"), "dora-rs/legacy").unwrap();
+        assert_eq!(version.to_string(), "0.1.0");
+        assert!(entry.yanked);
+    }
+
+    // No matching version at all → the original resolve error is re-raised.
+    #[test]
+    fn errors_when_no_version_matches() {
+        let (_tmp, catalog) = fixture();
+        assert!(
+            resolve_or_yanked(
+                &catalog,
+                &parse("dora-rs/nonexistent"),
+                "dora-rs/nonexistent"
+            )
+            .is_err()
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #2275.

`resolve()` only returns non-yanked index entries, making the existing `if resolved.entry.yanked` branch in `info.rs` dead code. When a user explicitly requests a yanked version (`dora hub info pkg@0.6.0` where `0.6.0` is yanked), `resolve()` fails with an opaque "every version … has been yanked" error rather than showing the package info marked `(yanked)`.

**Fix:** when `resolve()` fails, fall back to the highest yanked version matching the requirement (via `catalog.versions()` + `catalog.entry()`). If a yanked match is found, display it with the `(yanked)` marker as originally intended. If no matching version exists at all, re-raise the original resolve error unchanged.

This makes the `(yanked)` branch reachable and aligns `dora hub info` with the user expectation implied by the branch: explicit version lookups surface yanked status instead of returning an error.

## Test plan

- [ ] `dora hub info pkg@<non-yanked>` still resolves and displays normally
- [ ] `dora hub info pkg@<yanked>` now shows the entry with `(yanked)` instead of an error
- [ ] `dora hub info pkg` (bare, all versions yanked) surfaces the yanked entry with `(yanked)`
- [ ] `dora hub info nonexistent` still returns an error (no yanked fallback found)
- [ ] `cargo clippy` and `cargo fmt` pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

https://claude.ai/code/session_01Gc578USnixf6Z8mycBu3wR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gc578USnixf6Z8mycBu3wR)_