### PR TITLE
fix(hub): skip yanked versions in `dora hub search` results

### DIFF
--- a/binaries/cli/src/command/hub/search.rs
+++ b/binaries/cli/src/command/hub/search.rs
@@ -30,11 +30,22 @@ impl Executable for Search {
         let mut hits = Vec::new();
         for (_alias, catalog) in ctx.all_catalogs() {
             for (namespace, name) in catalog.all_packages() {
-                let Some(version) = catalog.versions(&namespace, &name)?.into_iter().next_back()
+                // Skip yanked versions — find the highest non-yanked version.
+                // versions() returns all versions including yanked ones, so we
+                // must filter here to match the behavior of resolve() and
+                // `dora hub info` / `dora hub outdated`.
+                let Some((version, entry)) = catalog
+                    .versions(&namespace, &name)?
+                    .into_iter()
+                    .rev()
+                    .find_map(|v| {
+                        catalog
+                            .entry(&namespace, &name, &v)
+                            .ok()
+                            .filter(|e| !e.yanked)
+                            .map(|e| (v, e))
+                    })
                 else {
-                    continue;
-                };
-                let Ok(entry) = catalog.entry(&namespace, &name, &version) else {
                     continue;
                 };
                 let m = &entry.manifest;


### PR DESCRIPTION
## Summary

Fixes #2274.

`dora hub search` used `versions().into_iter().next_back()` to pick the headline version for each package, which takes the highest version regardless of its `yanked` flag. This could surface a yanked version as the installable headline version in search results — with no `(yanked)` marker — contradicting yank semantics and the behavior of `resolve()`, `dora hub info`, and `dora hub outdated` which all skip yanked versions.

**Fix:** replace `next_back()` with a `find_map` that walks versions highest-first and returns the first entry whose `yanked` flag is `false`. Packages with no non-yanked version are omitted from search results (same behavior as `resolve()`).

**Before:** `dora hub search` with package `0.5.1` (ok) + `0.6.0` (yanked) → shows `0.6.0` as headline  
**After:** same package → shows `0.5.1` as headline

## Test plan

- [ ] `dora hub search` with a package whose highest version is yanked shows the latest non-yanked version
- [ ] `dora hub search` with a package where all versions are yanked omits that package entirely
- [ ] `dora hub search` with only non-yanked versions behaves identically to before
- [ ] `cargo clippy` and `cargo fmt` pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

https://claude.ai/code/session_01Gc578USnixf6Z8mycBu3wR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gc578USnixf6Z8mycBu3wR)_