### PR TITLE
fix(memory-pool): deterministic transport validation and smoke test coverage

### DIFF
--- a/examples/memory-pool/cpu2cpu.yml
+++ b/examples/memory-pool/cpu2cpu.yml
@@ -7,12 +7,14 @@ env:
   memory_pool_scenario: throughput
 nodes:
   - id: sender_node
+    build: pip install torch --index-url https://download.pytorch.org/whl/cpu numpy pyarrow
     path: sender.py
     inputs:
       next_require: receiver_node/next_require
     outputs:
       - data
   - id: receiver_node
+    build: pip install torch --index-url https://download.pytorch.org/whl/cpu pyarrow tqdm
     path: receiver.py
     inputs:
       latency: sender_node/data

--- a/examples/memory-pool/receiver.py
+++ b/examples/memory-pool/receiver.py
@@ -22,7 +22,7 @@ pbar = tqdm(total=MESSAGE_COUNT)
 velocities = []
 memory_pool_id = None
 torch_tensor = None
-prev_sum = None
+prev_counter = None
 
 for i in range(MESSAGE_COUNT):
     event = node.next()
@@ -38,14 +38,15 @@ for i in range(MESSAGE_COUNT):
     # the shmem bytes in place, so the receiver's existing tensor object
     # automatically reflects new data.  Turn-based signaling ensures the
     # sender has finished writing before the receiver accesses the tensor.
-    # Compute a cheap checksum to validate that the tensor data changed
-    # (and therefore the pooled transfer actually delivered new bytes).
-    curr_sum = int(torch_tensor[:8].sum().item())
-    if prev_sum is not None and SCENARIO != "write_after_free":
-        assert curr_sum != prev_sum, (
-            f"iteration {i}: tensor data did not change — pool write may not have propagated"
+    # Validate that the pool write propagated by checking the deterministic
+    # counter stamped into element [0] by the sender (sender sets data[0] = i).
+    curr_counter = int(torch_tensor[0].item())
+    if prev_counter is not None and SCENARIO != "write_after_free":
+        assert curr_counter == prev_counter + 1, (
+            f"iteration {i}: counter {curr_counter} != expected {prev_counter + 1}"
+            " — pool write may not have propagated"
         )
-    prev_sum = curr_sum
+    prev_counter = curr_counter
 
     t_received = time.perf_counter_ns()
     delta_t = t_received - t_send

--- a/examples/memory-pool/sender.py
+++ b/examples/memory-pool/sender.py
@@ -22,6 +22,10 @@ data_generation = np.random.default_rng()
 memory_pool_id = None
 for i in range(MESSAGE_COUNT):
     random_data = data_generation.integers(1000, size=SIZE, dtype=np.int64)
+    # Stamp the iteration counter into element [0] so the receiver can
+    # validate deterministically that the pool write propagated (avoids a
+    # probabilistically-flaky checksum over random data).
+    random_data[0] = i
     torch_tensor = torch.tensor(random_data, dtype=torch.int64, device=SENDER_DEVICE)
     t_send = time.perf_counter_ns()
     metadata = {"t_send": t_send, "scenario": SCENARIO}

--- a/scripts/smoke-all.sh
+++ b/scripts/smoke-all.sh
@@ -526,6 +526,11 @@ if [ "$RUN_PYTHON" = true ]; then
     run_local "local-python-zero-copy-send-contract" "examples/python-zero-copy-send/contract_dataflow.yml" 15
 
     echo ""
+    echo "=== Memory-pool transport (CPU-only, GPU-less CI safe) ==="
+    run_networked "memory-pool-cpu2cpu"       "examples/memory-pool/cpu2cpu.yml" 120
+    run_local     "local-memory-pool-cpu2cpu" "examples/memory-pool/cpu2cpu.yml" 120
+
+    echo ""
     echo "=== Queue/timeout regression tests (local, timing-sensitive) ==="
     run_local "local-queue-size-and-timeout"         "tests/queue_size_and_timeout_python/dataflow.yaml" 20
     run_local "local-queue-size-latest-data-python"  "tests/queue_size_latest_data_python/dataflow.yaml" 20

--- a/tests/example-smoke.rs
+++ b/tests/example-smoke.rs
@@ -747,6 +747,32 @@ fn smoke_local_streaming_example() {
 }
 
 // ---------------------------------------------------------------------------
+// Memory-pool transport (CPU-only path, GPU-less CI runner safe)
+//
+// Exercises register/write/read/free lifecycle for the pinned shared-memory
+// transport added in PR #2168. cpu2cpu.yml is the CPU-only scenario whose
+// header comment explicitly notes it was designed for GPU-less CI runners.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn smoke_memory_pool_cpu2cpu() {
+    run_smoke_test(
+        "memory-pool-cpu2cpu",
+        "examples/memory-pool/cpu2cpu.yml",
+        Duration::from_secs(120),
+    );
+}
+
+#[test]
+fn smoke_local_memory_pool_cpu2cpu() {
+    run_smoke_test_local(
+        "local-memory-pool-cpu2cpu",
+        "examples/memory-pool/cpu2cpu.yml",
+        120,
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Cross-language interoperability tests (Rust <-> Python)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes #2264.

Two concrete fixes for the memory-pool transport feature (PR #2168):

### Finding 2 — flaky assertion in `receiver.py`

The receiver validated pool writes by comparing the sum of the first 8 random `int64` elements. With a sum range of `[0, 7992]` and ~99 adjacent pairs over 100 messages, the probability of a spurious collision was on the order of a few percent per run — causing random failures even when the transport worked correctly.

**Fix:** have the sender stamp the monotonically-increasing iteration counter into element `[0]` of each tensor (`random_data[0] = i`). The receiver checks `torch_tensor[0] == prev_counter + 1` — deterministic, always unambiguous, and unaffected by the random payload in the remaining elements.

### Finding 1 — no smoke test coverage for the unsafe transport paths

The 7 unit tests in `memory-pool/src/lib.rs` cover only the pure-HashMap `MemoryPoolManager`. The unsafe shmem mapping, seqlock, bounds-check, and shutdown cleanup paths had no automated end-to-end coverage. `cpu2cpu.yml` was even designed for CI (its own header comment: *"This scenario can run on GPU-less CI runners and exercises the daemon pool path"*) but was never wired into the test harness.

**Fix:**
- Add `build: pip install torch --index-url https://download.pytorch.org/whl/cpu ...` steps to `cpu2cpu.yml` so dependencies are provisioned automatically under `--uv`
- Wire `cpu2cpu.yml` into `tests/example-smoke.rs` (both `run_smoke_test` networked and `run_smoke_test_local`)
- Wire `cpu2cpu.yml` into `scripts/smoke-all.sh`

## Test plan

- [ ] `examples/memory-pool/receiver.py` no longer has a flaky sum-comparison assertion
- [ ] `sender.py` stamps iteration counter into `data[0]`; receiver validates monotone increment
- [ ] `cargo test --test example-smoke smoke_memory_pool_cpu2cpu` passes (requires torch on PATH or `--uv`)
- [ ] `./scripts/smoke-all.sh --python-only` includes the memory-pool-cpu2cpu entries
- [ ] `cargo fmt` and `cargo clippy` pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

https://claude.ai/code/session_01Gc578USnixf6Z8mycBu3wR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gc578USnixf6Z8mycBu3wR)_