### PR TITLE
test(daemon): deterministic e2e for the finish-straggler watchdog (#2270)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,6 +280,15 @@ jobs:
           --test-threads=1
           lifecycle_rust lifecycle_cxx
         timeout-minutes: 15
+      # Finish-straggler watchdog regression (#2270): a deterministic wedge
+      # (source exits, downstream node hangs) must be escalated/killed by the
+      # watchdog rather than hanging until stop_after. Lives in `dora-examples`
+      # (excluded from the bulk `cargo test --all` step), so it needs an
+      # explicit invocation; the test sets DORA_FINISH_DRAIN_GRACE_SECS itself.
+      - name: Run finish-straggler watchdog E2E
+        run: >
+          cargo test -p dora-examples --test finish-straggler-e2e -- --test-threads=1
+        timeout-minutes: 10
 
   # Semantic contract tests — promoted from nightly per #1632.
   #

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2422,6 +2422,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
+name = "emit-then-exit-source-node"
+version = "1.0.0-rc1"
+dependencies = [
+ "dora-node-api",
+ "eyre",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ members = [
     "tests/fault_tolerance/always_crash_node",
     "tests/fault_tolerance/clean_exit_node",
     "tests/fault_tolerance/delayed_crash_node",
+    "tests/fault_tolerance/emit_then_exit_source_node",
     "tests/fault_tolerance/event_log_observer_node",
     "tests/fault_tolerance/fire_and_forget_source_node",
     "tests/fault_tolerance/hang_after_init_node",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -267,6 +267,10 @@ path = "tests/example-smoke.rs"
 name = "hub-smoke"
 path = "tests/hub-smoke.rs"
 
+[[test]]
+name = "finish-straggler-e2e"
+path = "tests/finish-straggler-e2e.rs"
+
 [profile.release]
 lto = "thin"
 

--- a/tests/dataflows/finish-straggler-escalation.yml
+++ b/tests/dataflows/finish-straggler-escalation.yml
@@ -1,0 +1,35 @@
+# Validates the finish-straggler watchdog (dora-rs/dora#2270).
+#
+# `source` emits one value on its first tick, then exits. Once it exits the
+# daemon closes its output, so `wedge`'s only input closes while `wedge` is
+# still alive — the dataflow is now "otherwise finished" except for `wedge`,
+# which subscribed (so it is a connected candidate) then dropped its event
+# stream and sleeps forever.
+#
+# With DORA_FINISH_DRAIN_GRACE_SECS set (by the test process) the watchdog
+# escalates `wedge` (Stop -> SIGTERM -> SIGKILL) once it has been quiescent
+# past the grace, so the dataflow terminates instead of hanging until
+# stop_after. `health_check_interval` is the tick that drives the watchdog
+# (check_finish_stragglers); shorten it so the check fires promptly.
+health_check_interval: 0.1
+
+nodes:
+  - id: source
+    build: cargo build -p emit-then-exit-source-node
+    path: ../../target/debug/emit-then-exit-source-node
+    inputs:
+      tick: dora/timer/millis/100
+    outputs:
+      - value
+
+  - id: wedge
+    build: cargo build -p hang-after-init-node
+    path: ../../target/debug/hang-after-init-node
+    # restart_policy: never keeps the assertion on the escalation kill itself.
+    restart_policy: never
+    env:
+      DORA_TEST_MARKER_FILE: /tmp/dora-finish-straggler-marker.log
+    # A plain user input (no timer/logs) so `wedge` is a finishing,
+    # non-source node — eligible for finish-straggler escalation.
+    inputs:
+      value: source/value

--- a/tests/fault_tolerance/emit_then_exit_source_node/Cargo.toml
+++ b/tests/fault_tolerance/emit_then_exit_source_node/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "emit-then-exit-source-node"
+edition.workspace = true
+rust-version.workspace = true
+version.workspace = true
+description.workspace = true
+documentation.workspace = true
+license.workspace = true
+publish = false
+
+# Test-only node: emits a single `value` output on the first tick, then
+# exits. Once it exits the daemon closes its output, so a downstream
+# node's input closes while that node is still alive — the setup for the
+# finish-straggler watchdog (dora-rs/dora#2270).
+
+[[bin]]
+name = "emit-then-exit-source-node"
+path = "src/main.rs"
+
+[dependencies]
+dora-node-api = { workspace = true, default-features = false }
+eyre = { workspace = true }

--- a/tests/fault_tolerance/emit_then_exit_source_node/src/main.rs
+++ b/tests/fault_tolerance/emit_then_exit_source_node/src/main.rs
@@ -1,0 +1,31 @@
+//! Emit one `value` output on the first tick, then exit.
+//!
+//! Once this node exits the daemon closes its output, so a downstream
+//! node's input closes while that downstream is still alive. That is the
+//! setup for the finish-straggler watchdog (dora-rs/dora#2270): the
+//! dataflow becomes "otherwise finished" except for any node that won't
+//! exit, which the watchdog then escalates.
+
+use dora_node_api::{DoraNode, Event, IntoArrow, dora_core::config::DataId};
+use eyre::Context;
+
+fn main() -> eyre::Result<()> {
+    let (mut node, mut events) =
+        DoraNode::init_from_env().context("failed to init dora node from env")?;
+    let output = DataId::from("value".to_owned());
+
+    while let Some(event) = events.recv() {
+        match event {
+            Event::Input { id, metadata, .. } if id.as_str() == "tick" => {
+                node.send_output(output.clone(), metadata.parameters, 42i64.into_arrow())
+                    .context("failed to send value")?;
+                // Exit after the first emit; the daemon closing our output
+                // is what drains the downstream node.
+                break;
+            }
+            Event::Stop(_) => break,
+            _ => {}
+        }
+    }
+    Ok(())
+}

--- a/tests/finish-straggler-e2e.rs
+++ b/tests/finish-straggler-e2e.rs
@@ -10,6 +10,11 @@
 //! ladder instead of hanging until `stop_after`. This is the behaviour the
 //! nightly only exercises when the #2152 flake happens to fire; here it is
 //! forced every run.
+//!
+//! This is a plain `#[test]` (not `#[tokio::test]`) because it mutates the
+//! process environment: under Rust 2024 `std::env::set_var` is only sound
+//! while the process is single-threaded, so the var must be set before any
+//! runtime threads exist. The test sets it first, then builds the runtime.
 
 use std::path::Path;
 use std::time::{Duration, Instant};
@@ -17,8 +22,14 @@ use std::time::{Duration, Instant};
 use dora_daemon::{Daemon, LogDestination};
 use dora_message::SessionId;
 
-#[tokio::test(flavor = "multi_thread")]
-async fn finish_straggler_watchdog_escalates_wedged_node() {
+#[test]
+fn finish_straggler_watchdog_escalates_wedged_node() {
+    // Enable the opt-in watchdog for this daemon. Set BEFORE any runtime or
+    // other thread exists so the env mutation is single-threaded.
+    // SAFETY: the process is still single-threaded here — no runtime has been
+    // built and `cargo build` below only spawns separate child processes.
+    unsafe { std::env::set_var("DORA_FINISH_DRAIN_GRACE_SECS", "2") };
+
     for pkg in ["emit-then-exit-source-node", "hang-after-init-node"] {
         let status = std::process::Command::new("cargo")
             .args(["build", "-p", pkg])
@@ -27,12 +38,14 @@ async fn finish_straggler_watchdog_escalates_wedged_node() {
         assert!(status.success(), "failed to build {pkg}");
     }
 
-    // Enable the opt-in watchdog for this daemon. This is the daemon's own
-    // process env (run_dataflow runs in-process); set here because the test
-    // owns this dedicated test binary, so no other test races the var.
-    // SAFETY: single-threaded set before any daemon thread reads it.
-    unsafe { std::env::set_var("DORA_FINISH_DRAIN_GRACE_SECS", "2") };
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("failed to build tokio runtime");
+    runtime.block_on(run());
+}
 
+async fn run() {
     let marker = Path::new("/tmp/dora-finish-straggler-marker.log");
     let _ = std::fs::remove_file(marker);
 

--- a/tests/finish-straggler-e2e.rs
+++ b/tests/finish-straggler-e2e.rs
@@ -1,0 +1,109 @@
+//! End-to-end validation of the finish-straggler watchdog (dora-rs/dora#2270).
+//!
+//! Deterministic stand-in for the flaky #2152 macOS hang: a `source` that
+//! emits once and exits, plus a `wedge` that subscribes, drops its event
+//! stream, and sleeps forever. Once `source` exits the dataflow is
+//! "otherwise finished" except `wedge`, which never exits on its own.
+//!
+//! With the watchdog enabled (`DORA_FINISH_DRAIN_GRACE_SECS`), the daemon
+//! escalates `wedge` and the dataflow terminates within the grace + kill
+//! ladder instead of hanging until `stop_after`. This is the behaviour the
+//! nightly only exercises when the #2152 flake happens to fire; here it is
+//! forced every run.
+
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use dora_daemon::{Daemon, LogDestination};
+use dora_message::SessionId;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn finish_straggler_watchdog_escalates_wedged_node() {
+    for pkg in ["emit-then-exit-source-node", "hang-after-init-node"] {
+        let status = std::process::Command::new("cargo")
+            .args(["build", "-p", pkg])
+            .status()
+            .expect("failed to run cargo build");
+        assert!(status.success(), "failed to build {pkg}");
+    }
+
+    // Enable the opt-in watchdog for this daemon. This is the daemon's own
+    // process env (run_dataflow runs in-process); set here because the test
+    // owns this dedicated test binary, so no other test races the var.
+    // SAFETY: single-threaded set before any daemon thread reads it.
+    unsafe { std::env::set_var("DORA_FINISH_DRAIN_GRACE_SECS", "2") };
+
+    let marker = Path::new("/tmp/dora-finish-straggler-marker.log");
+    let _ = std::fs::remove_file(marker);
+
+    let dataflow_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/dataflows/finish-straggler-escalation.yml");
+
+    let started = Instant::now();
+    let result = Daemon::run_dataflow(
+        &dataflow_path,
+        None,
+        None,
+        SessionId::generate(),
+        false,
+        LogDestination::Tracing,
+        None,
+        // Generous safety net, far above the ~2 s grace + kill ladder, so a
+        // working watchdog finishes well before this and a broken one is
+        // caught by the elapsed-time assertion below rather than hanging CI.
+        Some(Duration::from_secs(40)),
+        false,
+        None,
+        None,
+    )
+    .await;
+    let elapsed = started.elapsed();
+
+    let dr = result.expect("dataflow should complete");
+    eprintln!(
+        "dataflow completed in {elapsed:?} with {} node results",
+        dr.node_results.len()
+    );
+    for (id, r) in &dr.node_results {
+        eprintln!("  {id}: {r:?}");
+    }
+
+    // The marker confirms `wedge` actually reached its post-init hang, so a
+    // non-escalation completion can't be "the node never ran".
+    let contents = std::fs::read_to_string(marker)
+        .expect("wedge marker should exist — hang-after-init writes it at startup");
+    let _ = std::fs::remove_file(marker);
+    assert!(
+        contents.contains("incarnation"),
+        "wedge never reached the post-init hang — unrelated regression"
+    );
+
+    // Core contract: the watchdog bounded the hang. A working watchdog
+    // escalates `wedge` ~2 s after the dataflow is otherwise finished (plus
+    // the kill ladder); a disabled/broken one would hang until the 40 s
+    // stop_after net.
+    assert!(
+        elapsed < Duration::from_secs(30),
+        "dataflow took {elapsed:?} — the watchdog did not bound the hang \
+         (a broken watchdog runs to the 40 s stop_after)"
+    );
+
+    // `wedge` was force-terminated by the escalation ladder (a signal exit),
+    // not a clean voluntary exit.
+    let wedge = dr
+        .node_results
+        .get(&"wedge".to_string().into())
+        .expect("wedge should be in node_results");
+    let err = wedge
+        .as_ref()
+        .expect_err("wedge should have errored — escalation kill is a failure exit");
+    use dora_message::common::NodeExitStatus;
+    assert!(
+        matches!(
+            err.exit_status,
+            NodeExitStatus::Signal(15) | NodeExitStatus::Signal(9)
+        ),
+        "expected SIGTERM(15)/SIGKILL(9) from finish-straggler escalation, got {:?}",
+        err.exit_status
+    );
+}


### PR DESCRIPTION
Towards #2270 (does not close it). Follow-up to #2271 (watchdog) and #2276 (nightly enablement).

## What

A deterministic end-to-end test for the finish-straggler watchdog, so we no longer depend on the flaky #2152 macOS hang actually occurring to validate it.

- New fixture `emit-then-exit-source-node`: emits one value, then exits.
- Reuses the existing `hang-after-init-node` (subscribes → drops its event stream → sleeps forever).
- `tests/dataflows/finish-straggler-escalation.yml` wires them: once `source` exits, the dataflow is "otherwise finished" except `wedge`, which never exits on its own.
- `tests/finish-straggler-e2e.rs` runs it in-process with `DORA_FINISH_DRAIN_GRACE_SECS=2` and asserts the watchdog bounds the hang.

## Why this is the deterministic version

The hang in #2152 is a ~2/3-of-runs macOS flake, so nightly only *sometimes* exercises the escalation. This forces the exact wedge condition every run: `source` exits, `wedge` stays alive and silent, and the watchdog must escalate it.

## Observed result

```
dataflow completed in 14.43s with 2 node results
  source: Ok(())
  wedge:  Err(NodeError { cause: GraceDuration, exit_status: Signal(15) })
```

The wedge is escalated and killed (~2s grace + ~10s kill ladder ≈ 14s) instead of hanging until the 40s `stop_after` net. The test asserts:
1. completion well under `stop_after` (a disabled/broken watchdog runs to 40s → fails the `< 30s` bound), and
2. the wedge exited via signal (SIGTERM/SIGKILL from the escalation ladder).

The `< 30s` bound is the load-bearing assertion: both the watchdog and `stop_after` produce a signal exit, so timing is what distinguishes "watchdog fired at ~14s" from "hung to the 40s net."

## Relationship to the #2270 rollout

This strengthens step 2→3: we now have a permanent, deterministic regression test for the escalation, rather than waiting to catch the nightly flake. (Default stays off; flipping it remains a separate step.)

Notes:
- Lives in its own test binary so its `DORA_FINISH_DRAIN_GRACE_SECS` set doesn't affect other tests' daemons.
- `cargo test --test finish-straggler-e2e` → 1 passed (~15s); fmt + clippy (`-D warnings`) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
