### PR TITLE
feat(daemon): enable finish-straggler watchdog by default (#2270 step 3)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,14 +41,10 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUST_VERSION: "1.92.0"
-  # Enable the finish-straggler watchdog (opt-in / off by default) across the
-  # nightly suite to validate it on the shutdown path it targets — most notably
-  # the macOS Examples job where dora-rs/dora#2152 reproduces. It only acts on a
-  # node still stuck 120s after the dataflow is otherwise finished, so it is a
-  # no-op for cleanly-finishing dataflows and for jobs that run no daemon. This
-  # is rollout step 2 of dora-rs/dora#2270: bake on nightly, then flip the
-  # default once it's proven to bound the hang without false-positive kills.
-  DORA_FINISH_DRAIN_GRACE_SECS: "120"
+  # The finish-straggler watchdog (dora-rs/dora#2270) is now on by default, so
+  # the explicit DORA_FINISH_DRAIN_GRACE_SECS override added for the step-2
+  # nightly bake is no longer needed — nightly now exercises the default-on
+  # path, same as production.
 
 jobs:
   smoke-suite:

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -5335,15 +5335,15 @@ fn break_input(
 const DEFAULT_FINISH_DRAIN_GRACE: Duration = Duration::from_secs(120);
 
 /// Grace period before the finish-straggler watchdog escalates a stuck node, or
-/// `None` if the watchdog is **disabled**.
+/// `None` if the watchdog has been explicitly **disabled**.
 ///
-/// The watchdog is opt-in and ships dark: with `DORA_FINISH_DRAIN_GRACE_SECS`
-/// unset it does nothing, so the SIGKILL-on-stuck-node behaviour can be enabled
-/// per-deployment and validated on real workloads before becoming default —
-/// this path is exercised only at shutdown and is not reproducible locally
-/// (dora-rs/dora#2152, #2270). Set the var to a whole number of seconds to
-/// enable it; a set-but-garbage value enables it at the default grace (the user
-/// clearly intended it on).
+/// The watchdog is **on by default** (dora-rs/dora#2270): a node still stuck
+/// past the grace once its dataflow is otherwise finished is escalated rather
+/// than hanging until an external timeout. `DORA_FINISH_DRAIN_GRACE_SECS` tunes
+/// it — a whole number of seconds sets the grace; `off`/`disabled` opts out
+/// entirely (the escape hatch for a deployment that hits a false positive). It
+/// shipped dark first and was validated on nightly + a deterministic e2e
+/// (#2271, #2276, #2280) before this default flip.
 fn finish_drain_grace() -> Option<Duration> {
     parse_finish_drain_grace(
         std::env::var("DORA_FINISH_DRAIN_GRACE_SECS")
@@ -5353,7 +5353,14 @@ fn finish_drain_grace() -> Option<Duration> {
 }
 
 fn parse_finish_drain_grace(value: Option<&str>) -> Option<Duration> {
-    let value = value?;
+    let Some(value) = value else {
+        // unset → enabled at the conservative default grace (on by default)
+        return Some(DEFAULT_FINISH_DRAIN_GRACE);
+    };
+    // explicit opt-out escape hatch for a deployment that hits a false positive
+    if value.eq_ignore_ascii_case("off") || value.eq_ignore_ascii_case("disabled") {
+        return None;
+    }
     match value.parse::<u64>() {
         Ok(secs) => Some(Duration::from_secs(secs)),
         Err(_) => {
@@ -5362,7 +5369,7 @@ fn parse_finish_drain_grace(value: Option<&str>) -> Option<Duration> {
             if !WARNED.swap(true, atomic::Ordering::Relaxed) {
                 tracing::warn!(
                     "invalid DORA_FINISH_DRAIN_GRACE_SECS value `{value}` \
-                     (expected whole seconds); using the default of {}s",
+                     (expected whole seconds or `off`); using the default of {}s",
                     DEFAULT_FINISH_DRAIN_GRACE.as_secs()
                 );
             }
@@ -5899,9 +5906,16 @@ mod fault_tolerance_tests {
     }
 
     #[test]
-    fn finish_drain_grace_is_opt_in() {
-        // unset → watchdog disabled (ships dark)
-        assert_eq!(parse_finish_drain_grace(None), None);
+    fn finish_drain_grace_defaults_on_with_opt_out() {
+        // unset → enabled at the default grace (on by default, dora#2270 step 3)
+        assert_eq!(
+            parse_finish_drain_grace(None),
+            Some(DEFAULT_FINISH_DRAIN_GRACE)
+        );
+        // explicit opt-out escape hatch → disabled
+        assert_eq!(parse_finish_drain_grace(Some("off")), None);
+        assert_eq!(parse_finish_drain_grace(Some("disabled")), None);
+        assert_eq!(parse_finish_drain_grace(Some("OFF")), None);
         // set → enabled at the given grace
         assert_eq!(
             parse_finish_drain_grace(Some("30")),

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -2363,8 +2363,8 @@ impl Daemon {
     /// ladder used by explicit stops — after capturing a stack sample of
     /// the stuck process so the hang itself stays diagnosable.
     fn check_finish_stragglers(&mut self) {
-        // Opt-in: with DORA_FINISH_DRAIN_GRACE_SECS unset the watchdog is
-        // disabled and never escalates (ships dark; see `finish_drain_grace`).
+        // On by default; only DORA_FINISH_DRAIN_GRACE_SECS=off/disabled turns
+        // escalation off entirely (see `finish_drain_grace`).
         let Some(grace) = finish_drain_grace() else {
             return;
         };


### PR DESCRIPTION
Final rollout step for #2270 — flips the finish-straggler watchdog **on by default**.

## The change

`finish_drain_grace()` semantics for `DORA_FINISH_DRAIN_GRACE_SECS`:

| value | before | **after** |
|---|---|---|
| unset | disabled | **enabled @ 120s default** |
| `N` (seconds) | enabled @ N | enabled @ N |
| `off` / `disabled` | (n/a) | **disabled (escape hatch)** |
| garbage | enabled @ default | enabled @ default |

So a node still stuck past the grace once its dataflow is otherwise finished is now escalated (Stop → SIGTERM → SIGKILL) by default, bounding the #2152 hang instead of running to an external timeout.

Also drops the now-redundant `DORA_FINISH_DRAIN_GRACE_SECS=120` override from `nightly.yml` (added in #2276) so nightly exercises the default-on path, same as production.

## Why now — the rollout is complete

| Step | PR | Evidence |
|---|---|---|
| 1. Land dark | #2271 | merged, off by default |
| 2. Bake on nightly | #2276 | merged; nightly `27802599843` green, **no false-positive kills** |
| 3. Flip default | **this PR** | — |
| Regression test | #2280 | deterministic e2e: wedge escalated in ~14s, not the 40s net |

We have both real-suite validation (nightly bake) and deterministic validation (e2e), which is stronger than the original "wait for the flake" plan.

## Escape hatch

Because this turns a force-kill on by default, `DORA_FINISH_DRAIN_GRACE_SECS=off` disables it entirely for any deployment that hits a false positive — no code change needed to back out.

## Sequencing note

Recommend landing **#2280 (the deterministic e2e regression test) first or together** with this, so the default-on behavior is guarded by a test in the same window.

## Verification

- `cargo test -p dora-daemon --lib` → 79 passed (incl. updated `finish_drain_grace_defaults_on_with_opt_out`)
- `cargo test --test fault-tolerance-e2e` → **11 passed** with the watchdog now active (no regression; the 120s grace is well above those tests' durations)
- fmt + clippy (`-D warnings`) clean; nightly.yml YAML validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

Closes #2270.
