### PR TITLE
ci: wall-clock cap on contract-tests steps to surface the hang (#2064)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -872,16 +872,18 @@ jobs:
           # last `test contract_… ` line without a following result names the
           # hung test. Normal runtime is well under 28m (full job ~22m).
           command: |
+            # `|| rc=$?` (not a bare `rc=$?`): CircleCI runs steps under
+            # `bash -eo pipefail`, so a bare timeout failure would trip errexit
+            # and exit before the diagnostic branch. `|| ` marks it checked.
+            rc=0
             timeout --kill-after=30s 1680s \
               cargo test -p dora-examples --test example-smoke contract_ \
-              -- --test-threads=1 --nocapture
-            rc=$?
+              -- --test-threads=1 --nocapture || rc=$?
             if [ "$rc" = 124 ] || [ "$rc" = 137 ]; then
               echo "ERROR (dora#2064): contract tests hit the 28m wall-clock cap."
               echo "The hung test is the last 'test contract_…' line above with no 'ok'/'FAILED' after it."
-              exit 1
             fi
-            exit $rc
+            exit "$rc"
           no_output_timeout: 30m
       # Python variant of the lifecycle test piggybacks on this
       # job because it needs uv (already set up via setup-python-uv
@@ -890,15 +892,17 @@ jobs:
           name: Run dora node lifecycle E2E (Python)
           # Wall-clock cap, same rationale as the contract step above (#2064).
           command: |
+            # `|| rc=$?`: checked so the wall-clock failure doesn't trip
+            # errexit before the diagnostic branch (CircleCI runs `bash -eo
+            # pipefail`).
+            rc=0
             timeout --kill-after=30s 840s \
               cargo test -p dora-examples --test node-lifecycle-e2e \
-              -- --test-threads=1 lifecycle_python
-            rc=$?
+              -- --test-threads=1 lifecycle_python || rc=$?
             if [ "$rc" = 124 ] || [ "$rc" = 137 ]; then
               echo "ERROR (dora#2064): lifecycle_python hit the 14m wall-clock cap (hung --uv dataflow)."
-              exit 1
             fi
-            exit $rc
+            exit "$rc"
           no_output_timeout: 15m
       - cargo-cache-save
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -865,22 +865,40 @@ jobs:
             source "$BASH_ENV"
       - run:
           name: Run semantic contract tests
-          command: >
-            cargo test -p dora-examples --test example-smoke contract_
-            --
-            --test-threads=1
-            --nocapture
+          # Wall-clock cap (dora-rs/dora#2064): a hung `--uv` dataflow keeps
+          # emitting log output, so CircleCI's output-based `no_output_timeout`
+          # never fires and the job runs ~50min–2h to the hard wall. `timeout`
+          # fires regardless of output. With `--test-threads=1 --nocapture` the
+          # last `test contract_… ` line without a following result names the
+          # hung test. Normal runtime is well under 28m (full job ~22m).
+          command: |
+            timeout --kill-after=30s 1680s \
+              cargo test -p dora-examples --test example-smoke contract_ \
+              -- --test-threads=1 --nocapture
+            rc=$?
+            if [ "$rc" = 124 ] || [ "$rc" = 137 ]; then
+              echo "ERROR (dora#2064): contract tests hit the 28m wall-clock cap."
+              echo "The hung test is the last 'test contract_…' line above with no 'ok'/'FAILED' after it."
+              exit 1
+            fi
+            exit $rc
           no_output_timeout: 30m
       # Python variant of the lifecycle test piggybacks on this
       # job because it needs uv (already set up via setup-python-uv
       # above). Rust + C++ variants run in the `e2e` job.
       - run:
           name: Run dora node lifecycle E2E (Python)
-          command: >
-            cargo test -p dora-examples --test node-lifecycle-e2e
-            --
-            --test-threads=1
-            lifecycle_python
+          # Wall-clock cap, same rationale as the contract step above (#2064).
+          command: |
+            timeout --kill-after=30s 840s \
+              cargo test -p dora-examples --test node-lifecycle-e2e \
+              -- --test-threads=1 lifecycle_python
+            rc=$?
+            if [ "$rc" = 124 ] || [ "$rc" = 137 ]; then
+              echo "ERROR (dora#2064): lifecycle_python hit the 14m wall-clock cap (hung --uv dataflow)."
+              exit 1
+            fi
+            exit $rc
           no_output_timeout: 15m
       - cargo-cache-save
 


### PR DESCRIPTION
Towards #2064 — makes the contract-tests hang self-identify and fail fast. Does **not** close it (this is a diagnostic, not a fix for the underlying hung dataflow).

## Problem

`ci/circleci: contract-tests` intermittently hangs ~50 min–2 h on PRs touching nothing in its surface (#2064), forcing admin-merges. CircleCI's `no_output_timeout` doesn't catch it: a hung `--uv` dataflow keeps emitting log output, so the *output*-based timeout never fires and the job runs to the hard wall. Evidence on #2064 — the ~50 min hang recurred as recently as 06-16/06-17, even after the venv/`UV_PYTHON` fix (#2174) that addressed the suspected root cause.

## Change

Wrap the two `--uv` steps (`contract_` and `lifecycle_python`) in a **wall-clock** `timeout` that fires regardless of output:

- `contract_`: 28 m cap (full job normally ~22 m, so ample margin)
- `lifecycle_python`: 14 m cap

On a hit, the step prints an explicit `dora#2064` message and exits 1. Combined with the existing `--test-threads=1 --nocapture`, the **last `test contract_… ` line with no `ok`/`FAILED` after it names the hung test** — so the next occurrence self-identifies in the log instead of a silent 50 min+ hang.

## Risk

Low: caps are well above normal runtime, so no new false failures; `no_output_timeout` is kept as a secondary backstop above the wall-clock so the shell `timeout` (with the helpful message) fires first. `timeout` is GNU coreutils, present on the Ubuntu linux executor.

## Follow-up

Once a hang names itself, we can gate/fix the specific dataflow and close #2064.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
