### PR TITLE
fix(ci): resolve all five v1.0.0-rc.1 CI failures (fmt, typos, record-replay, redb, cpu-affinity)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -232,6 +232,8 @@ jobs:
           -p rust-dataflow-example-node
           -p rust-dataflow-example-status-node
           -p rust-dataflow-example-sink
+      - name: Build dora-record-node
+        run: cargo build -p dora-record-node
       - name: Record rust-dataflow
         run: |
           # `dora record <yaml>` instruments the dataflow and runs it;
@@ -580,6 +582,8 @@ jobs:
         run: |
           chmod +x ./cli-bin/dora
           echo "$PWD/cli-bin" >> "$GITHUB_PATH"
+      - name: Build cpu-affinity-probe
+        run: cargo build -p cpu-affinity-probe
       - name: Session 1 — write state to redb
         run: |
           STORE=/tmp/dora-redb-smoke.db

--- a/_typos.toml
+++ b/_typos.toml
@@ -4,6 +4,8 @@ extend-exclude = ["Changelog.md"]
 [default.extend-identifiers]
 # *sigh* this just isn't worth the cost of fixing
 DeviceNDArray = "DeviceNDArray"
+# YOR-robot is a GitHub repository name, not a misspelling of "YOUR"
+YOR = "YOR"
 Feedforward_2nd_Gain = "Feedforward_2nd_Gain"
 clonable_command = "clonable_command"
 

--- a/apis/c++/node/build.rs
+++ b/apis/c++/node/build.rs
@@ -74,7 +74,6 @@ fn origin_dir() -> PathBuf {
 
 #[cfg(feature = "ros2-bridge")]
 mod ros2 {
-    
     use std::{
         io::BufRead,
         path::{Component, Path, PathBuf},
@@ -175,8 +174,6 @@ mod ros2 {
     }
 
     pub fn generate_ros2_message_header(target_path: &Path) {
-        
-
         let default_target = std::env::var("CARGO_TARGET_DIR")
             .map(PathBuf::from)
             .unwrap_or_else(|_| {

--- a/examples/cpu-affinity-probe/src/main.rs
+++ b/examples/cpu-affinity-probe/src/main.rs
@@ -13,10 +13,15 @@ use eyre::Context;
 
 fn main() -> eyre::Result<()> {
     // Initialize as a dora node so the daemon can manage the process
-    // lifecycle. We don't consume events; the node prints its mask and
-    // exits on the first tick (or immediately).
-    let (_node, _events) =
+    // lifecycle. Consume the first tick event so the daemon has time to
+    // set up log forwarding before we print and exit (avoids a race where
+    // the output is lost if the process exits before the coordinator buffers it).
+    let (_node, mut events) =
         DoraNode::init_from_env().context("failed to init dora node from env")?;
+
+    // Wait for the first timer tick so our stdout is captured by the daemon
+    // log forwarder before we exit.
+    let _ = events.recv();
 
     #[cfg(target_os = "linux")]
     {

--- a/examples/cpu-affinity-probe/src/main.rs
+++ b/examples/cpu-affinity-probe/src/main.rs
@@ -12,15 +12,13 @@ use dora_node_api::DoraNode;
 use eyre::Context;
 
 fn main() -> eyre::Result<()> {
-    // Initialize as a dora node so the daemon can manage the process
-    // lifecycle. Consume the first tick event so the daemon has time to
-    // set up log forwarding before we print and exit (avoids a race where
-    // the output is lost if the process exits before the coordinator buffers it).
+    // Initialize as a dora node so the daemon can manage the process lifecycle.
     let (_node, mut events) =
         DoraNode::init_from_env().context("failed to init dora node from env")?;
 
-    // Wait for the first timer tick so our stdout is captured by the daemon
-    // log forwarder before we exit.
+    // Consume one tick before printing: avoids a race where the process exits
+    // before the daemon's async stdout forwarder buffers the log line, causing
+    // the coordinator to archive the dataflow before LogSubscribe is set up.
     let _ = events.recv();
 
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Summary

Fixes the five CI failures found on `v1.0.0-rc.1` (commit `145ccce04`).

| Job | Failure | Root cause | Fix |
|-----|---------|-----------|-----|
| **Format** (CI) | `apis/c++/node/build.rs` trailing whitespace | Two blank lines inside `mod ros2` had trailing spaces that `rustfmt` rejects | Remove trailing whitespace |
| **Typos** (CI) | `YOR` flagged as typo for `YOUR` | `YOR-robot` is an actual GitHub repo name in the consolidation plan doc | Add `YOR` to `_typos.toml` allowlist |
| **record-replay** (Nightly) | `timeout 30s dora record` exits 124 | `find_record_node_binary()` falls back to `cargo build -p dora-record-node` when binary absent — compilation exceeds 30 s budget | Pre-build `dora-record-node` in job before recording |
| **redb-backend** (Nightly) | `no running dataflow with id X` | `dora start` used on `cpu-affinity-probe` without pre-building; daemon fails to spawn missing binary, coordinator archives the dataflow, then `LogSubscribe` from `--detach` finds nothing | Pre-build `cpu-affinity-probe` before Session 1 |
| **cpu-affinity** (Nightly) | `probe did not print AFFINITY_MASK` | Probe exits immediately after `DoraNode::init_from_env()`, before daemon's async stdout forwarder can buffer the log line; coordinator archives the dataflow before `LogSubscribe` is set up | Consume one tick event before printing so the coordinator has buffered the output |

## Changes

- `apis/c++/node/build.rs` — remove 2 trailing-whitespace blank lines
- `_typos.toml` — allow `YOR` identifier
- `.github/workflows/nightly.yml` — add `cargo build -p dora-record-node` step in `record-replay` job; add `cargo build -p cpu-affinity-probe` step in `redb-backend-smoke` job
- `examples/cpu-affinity-probe/src/main.rs` — consume first tick event before printing mask

## Test plan

- [x] `cargo fmt --all -- --check` passes locally
- [x] `typos .` passes locally
- [ ] CI (Format + Typos jobs) — expect green
- [ ] Nightly (record-replay + redb-backend + cpu-affinity jobs) — expect green

Closes the blockers tracked in #1626.

🤖 Generated with [Claude Code](https://claude.com/claude-code)