### PR TITLE
refactor(recording): remove unused RecordingWriter::stats accessor

### DIFF
--- a/libraries/recording/src/lib.rs
+++ b/libraries/recording/src/lib.rs
@@ -114,10 +114,6 @@ impl<W: Write> RecordingWriter<W> {
     pub fn flush(&mut self) -> eyre::Result<()> {
         self.writer.flush().wrap_err("flush failed")
     }
-
-    pub fn stats(&self) -> (u64, u64) {
-        (self.total_messages, self.total_bytes)
-    }
 }
 
 /// Reads recording entries from disk.


### PR DESCRIPTION
> [!IMPORTANT]
> **🤖 Auto-generated by Claude (Claude Code).** This PR was created by an automated dead-code sweep and opened via a maintainer's account because the bot cannot author PRs directly. It has **not** been hand-reviewed by a human yet — please treat it as a suggestion and review before merging.

## What

Removes the unused `RecordingWriter::stats` accessor:

```rust
pub fn stats(&self) -> (u64, u64) {
    (self.total_messages, self.total_bytes)
}
```

## Why

`stats` has **zero call sites anywhere in the workspace** — not in production code, the `record-node` binary, the CLI `record`/`replay` commands, nor in the `dora-recording` crate's own tests. A repo-wide search for `.stats()` on this type returns only the definition.

The two counters it exposed (`total_messages`, `total_bytes`) are still written by `write_entry` and consumed by `finish` (returned via `RecordingFooter`), so this only drops the dead accessor — no behavior change.

This mirrors the already-merged #2186 (*remove unused `GitManager::in_use` accessor*).

## Verification

- `cargo clippy -p dora-recording -- -D warnings` ✅
- `cargo test -p dora-recording` ✅ (14 passed)
- `cargo fmt -p dora-recording -- --check` ✅

## Note

`dora-recording` is a published library, so this is technically a public-API change. The method is a leftover internal-counter accessor with no callers (including tests), so the risk is low — but flagging for a deliberate version bump if needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Feut1TvNKPGU439BfP4ymS)_