### PR TITLE
refactor(core): remove unused infer_types_from_file helper

### DIFF
--- a/libraries/core/src/inference.rs
+++ b/libraries/core/src/inference.rs
@@ -6,8 +6,6 @@
 //!
 //! Feature-gated behind `type-inference`.
 
-use std::path::Path;
-
 use syn::{Expr, ExprMethodCall, visit::Visit};
 
 /// A suggested type annotation inferred from source code.
@@ -41,16 +39,6 @@ impl std::fmt::Display for TypeSuggestion {
             )
         }
     }
-}
-
-/// Scan a Rust source file for type hints. Returns suggestions.
-pub fn infer_types_from_file(
-    source_path: &Path,
-    node_id: &str,
-) -> Result<Vec<TypeSuggestion>, String> {
-    let content = std::fs::read_to_string(source_path)
-        .map_err(|e| format!("{}: {e}", source_path.display()))?;
-    infer_types_from_source(&content, source_path.to_string_lossy().as_ref(), node_id)
 }
 
 /// Scan Rust source text for type hints.


### PR DESCRIPTION
> [!IMPORTANT]
> **🤖 Auto-generated by Claude (Claude Code).** This PR was created by an automated dead-code sweep and opened via a maintainer's account because the bot cannot author PRs directly. It has **not** been hand-reviewed by a human yet — please treat it as a suggestion and review before merging.

## What

Removes the unused `infer_types_from_file` helper from the `type-inference`-gated `inference` module (and its now-unused `std::path::Path` import):

```rust
pub fn infer_types_from_file(source_path: &Path, node_id: &str) -> Result<Vec<TypeSuggestion>, String> {
    let content = std::fs::read_to_string(source_path)...?;
    infer_types_from_source(&content, source_path.to_string_lossy().as_ref(), node_id)
}
```

## Why

`infer_types_from_file` was a thin wrapper that read a file and delegated to `infer_types_from_source`. It has **zero call sites anywhere in the workspace** — not in production, and not even in the module's own unit tests, which all drive `infer_types_from_source` directly with in-memory source strings. The `type-inference` feature is not enabled by any crate, so nothing reaches this wrapper.

The actual entry point, `infer_types_from_source`, is **kept** — so any caller that needs file-based inference can still read the file and call it. This is not an irreplaceable extension point; it's a convenience wrapper with no users.

## Verification

- `cargo clippy -p dora-core --features type-inference -- -D warnings` ✅
- `cargo test -p dora-core --features type-inference inference` ✅ (14 passed)
- `cargo check -p dora-core` (feature off) ✅
- `cargo fmt -p dora-core -- --check` ✅

## Note

`dora-core` is a published library. If `infer_types_from_file` was intended as the future public entry point for CLI/build wiring, feel free to close this — but as it stands it is unreferenced including by tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Feut1TvNKPGU439BfP4ymS)_