### PR TITLE
refactor(ros2-bridge): remove dead MessageT::from_raw/to_raw_ref defaults

### DIFF
--- a/libraries/extensions/ros2-bridge/src/_core/traits.rs
+++ b/libraries/extensions/ros2-bridge/src/_core/traits.rs
@@ -6,14 +6,6 @@ use array_init::array_init;
 pub trait MessageT: Default + Send + Sync {
     type Raw: FFIToRust<Target = Self> + Send + Sync;
     type RawRef: FFIFromRust<From = Self>;
-
-    unsafe fn from_raw(from: &Self::Raw) -> Self {
-        unsafe { from.to_rust() }
-    }
-
-    unsafe fn to_raw_ref(&self) -> Self::RawRef {
-        unsafe { Self::RawRef::from_rust(self) }
-    }
 }
 
 pub trait ActionT: Send {


### PR DESCRIPTION
> [!IMPORTANT]
> **🤖 Auto-generated by Claude (Claude Code).** This PR was created by an automated dead-code sweep and opened via a maintainer's account because the bot cannot author PRs directly. It has **not** been hand-reviewed by a human yet — please treat it as a suggestion and review before merging.

## What

Removes two provided (default) methods from the `MessageT` trait:

```rust
unsafe fn from_raw(from: &Self::Raw) -> Self {
    unsafe { from.to_rust() }
}
unsafe fn to_raw_ref(&self) -> Self::RawRef {
    unsafe { Self::RawRef::from_rust(self) }
}
```

## Why

Both are default methods that just forward to `FFIToRust::to_rust` / `FFIFromRust::from_rust`. They are:

- **never overridden** by any impl (the `msg-gen` codegen never emits them), and
- **never called** anywhere in the workspace — verified across the generated message code, the Python bridge, examples, and tests. The only other `from_raw` matches in the repo are unrelated std calls (`CString::from_raw`, `U16CString::from_raw`).

The `MessageT` trait stays alive via its associated types (`Raw`/`RawRef`) and the sibling `to_rust`/`from_rust` conversions, which provide the same raw round-trip — so this is not a capability regression.

## Verification

- `cargo clippy -p dora-ros2-bridge -- -D warnings` ✅
- `cargo test -p dora-ros2-bridge` ✅
- `cargo fmt -p dora-ros2-bridge -- --check` ✅

## Note

`dora-ros2-bridge` is a published library and `MessageT` is part of its FFI surface, so removing these two `unsafe fn`s is a public-API change. They are pure convenience wrappers over the already-exposed `to_rust`/`from_rust`, but if you consider them part of the intended symmetric FFI contract, feel free to close — flagging the call explicitly for a maintainer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Feut1TvNKPGU439BfP4ymS)_