### PR TITLE
fix(message): reject node ids starting with '.' to prevent path traversal

### DIFF
--- a/libraries/core/src/build/mod.rs
+++ b/libraries/core/src/build/mod.rs
@@ -337,10 +337,18 @@ fn confine_subdir(clone_dir: &Path, subdir: &str) -> eyre::Result<PathBuf> {
 /// directory and silently clobber each other's envs.
 pub fn managed_python_env_dir(node: &ResolvedNode, node_working_dir: &Path) -> Option<PathBuf> {
     node_requires_managed_python_env(node).then(|| {
-        node_working_dir
-            .join(".dora")
-            .join("python-envs")
-            .join(node.id.as_ref())
+        let envs_base = node_working_dir.join(".dora").join("python-envs");
+        let env_dir = envs_base.join(node.id.as_ref());
+        // Defense-in-depth: the node id must not escape the python-envs/ directory.
+        // validate_node_id already rejects leading-dot ids (`.`, `..`, `.hidden`),
+        // so this assertion should never fire in practice — it guards against future
+        // callers that bypass validation.
+        debug_assert!(
+            env_dir.components().count() > envs_base.components().count(),
+            "node id '{id}' escaped python-envs directory (env_dir={env_dir:?}, base={envs_base:?})",
+            id = node.id,
+        );
+        env_dir
     })
 }
 

--- a/libraries/message/src/id.rs
+++ b/libraries/message/src/id.rs
@@ -3,13 +3,26 @@ use std::{borrow::Borrow, convert::Infallible, str::FromStr};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-/// Validate that a node identifier contains only safe characters: `[a-zA-Z0-9_.-]`.
+/// Validate that a node identifier contains only safe characters: `[a-zA-Z0-9_.-]`,
+/// does not start with `.`, and is not empty.
 ///
 /// NodeIds must NOT contain `/` because `/` is the separator between
 /// `<node_id>/<output_id>` in input mapping syntax.
+///
+/// Leading dots are rejected because the node id is joined into filesystem paths
+/// (e.g. `managed_python_env_dir` appends `node.id` under `.dora/python-envs/`).
+/// A node id of `..` or `.` would resolve to a parent directory, and
+/// `uv venv --clear` would then wipe that directory — destroying sibling envs.
+/// This mirrors the `is_valid_key_part` guard in the hub-client index.
 fn validate_node_id(id: &str) -> Result<(), InvalidId> {
     if id.is_empty() {
         return Err(InvalidId("identifier must not be empty".into()));
+    }
+    if id.starts_with('.') {
+        return Err(InvalidId(format!(
+            "identifier '{id}' must not start with '.' \
+             (dot-segments such as '.' and '..' can traverse parent directories)"
+        )));
     }
     if let Some(ch) = id
         .chars()
@@ -267,6 +280,31 @@ mod tests {
         assert!(validate_node_id("node name").is_err());
         assert!(validate_node_id("node;rm").is_err());
         assert!(validate_node_id("node\0").is_err());
+    }
+
+    #[test]
+    fn node_id_rejects_dot_segments() {
+        // Dot-only ids resolve to parent directory when joined into filesystem paths
+        assert!(validate_node_id(".").is_err(), ". must be rejected");
+        assert!(validate_node_id("..").is_err(), ".. must be rejected");
+        // Any leading dot is rejected (mirrors hub-client is_valid_key_part)
+        assert!(
+            validate_node_id(".hidden").is_err(),
+            ".hidden must be rejected"
+        );
+        assert!(
+            validate_node_id(".config").is_err(),
+            ".config must be rejected"
+        );
+        // Embedded dots are still fine
+        assert!(
+            validate_node_id("node.v2").is_ok(),
+            "embedded dot is allowed"
+        );
+        assert!(
+            validate_node_id("a.b.c").is_ok(),
+            "multiple embedded dots are allowed"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #2293

## Summary

A node `id` of `.` or `..` passed `validate_node_id` because only the empty string and disallowed characters were checked. The id was then joined **unsanitized** into `.dora/python-envs/<node-id>`, so `uv venv --clear` silently destroyed sibling python envs or the entire `.dora/` directory.

## Changes

### `libraries/message/src/id.rs`

Added a `starts_with('.')` guard to `validate_node_id`, mirroring the same check already present in `hub-client`'s `is_valid_key_part`:

```rust
if id.starts_with('.') {
    return Err(InvalidId(format!(
        "identifier '{id}' must not start with '.' \
         (dot-segments such as '.' and '..' can traverse parent directories)"
    )));
}
```

This rejects `.`, `..`, and any dotfile-style id (e.g. `.hidden`). Embedded dots (`node.v2`, `a.b.c`) are still allowed.

Added regression tests:
- `.` and `..` are rejected
- `.hidden`, `.config` are rejected  
- `node.v2`, `a.b.c` still pass

### `libraries/core/src/build/mod.rs`

Added a `debug_assert` containment check in `managed_python_env_dir` as defense-in-depth: the joined path must have more components than the `python-envs/` base. This assertion guards against future callers that bypass `validate_node_id`.

## Verification

- `cargo test -p dora-message --lib -- id::tests` — 12 passed ✅
- `cargo clippy -p dora-message -p dora-core -- -D warnings` — clean ✅
- `cargo fmt --all -- --check` — clean ✅


---
_Generated by [Claude Code](https://claude.ai/code/session_01GvxT3tKqQE9kW2PAJDLpkx)_