### PR TITLE
refactor(message): remove unused WS_PING_INTERVAL constant

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -816,7 +816,6 @@ File download utility for fetching operator/node binaries from HTTP URLs. Saniti
 | `MAX_MESSAGE_BYTES` | 64 MiB | Max TCP/bincode message |
 | `MAX_CONTROL_MESSAGE_BYTES` | 1 MiB | Max control plane JSON message |
 | `TCP_READ_TIMEOUT` | 30 seconds | Socket read timeout |
-| `WS_PING_INTERVAL` | 10 seconds | WebSocket keepalive |
 | `MAX_WS_CONNECTIONS` | 256 | Concurrent WebSocket limit |
 | `MAX_CONNECTIONS_PER_IP` | 20 / 60s | Rate limiting |
 | `MAX_TOPICS_PER_SUBSCRIBE` | 64 | Topic batch limit |

--- a/guide/src/concepts/architecture.md
+++ b/guide/src/concepts/architecture.md
@@ -786,7 +786,6 @@ File download utility for fetching operator/node binaries from HTTP URLs. Saniti
 | `MAX_MESSAGE_BYTES` | 64 MiB | Max TCP/bincode message |
 | `MAX_CONTROL_MESSAGE_BYTES` | 1 MiB | Max control plane JSON message |
 | `TCP_READ_TIMEOUT` | 30 seconds | Socket read timeout |
-| `WS_PING_INTERVAL` | 10 seconds | WebSocket keepalive |
 | `MAX_WS_CONNECTIONS` | 256 | Concurrent WebSocket limit |
 | `MAX_CONNECTIONS_PER_IP` | 20 / 60s | Rate limiting |
 | `MAX_TOPICS_PER_SUBSCRIBE` | 64 | Topic batch limit |

--- a/libraries/message/src/lib.rs
+++ b/libraries/message/src/lib.rs
@@ -15,9 +15,6 @@ pub const MAX_MESSAGE_BYTES: usize = 64 * 1024 * 1024;
 /// Read timeout for TCP/socket connections (30 seconds).
 pub const TCP_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
-/// WebSocket ping interval for keepalive (10 seconds).
-pub const WS_PING_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
-
 pub mod auth;
 pub mod common;
 pub mod config;


### PR DESCRIPTION
> [!IMPORTANT]
> **🤖 Auto-generated by Claude (Claude Code).** This PR was created by an automated dead-code sweep and opened via a maintainer's account because the bot cannot author PRs directly. It has **not** been hand-reviewed by a human yet — please treat it as a suggestion and review before merging.

## What

Removes the unused `WS_PING_INTERVAL` constant from `dora-message`:

```rust
/// WebSocket ping interval for keepalive (10 seconds).
pub const WS_PING_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
```

## Why

`WS_PING_INTERVAL` has **zero references anywhere in the workspace** — a repo-wide search for the identifier returns only the definition site.

The coordinator's WebSocket handlers (`ws_control.rs`, `ws_daemon.rs`) only *respond* to inbound `Message::Ping(..)` frames with a pong; nothing sends interval-based keepalive pings, so this constant is never read. Its siblings in the same module — `MAX_MESSAGE_BYTES` and `TCP_READ_TIMEOUT` — are both actively used; `WS_PING_INTERVAL` is the odd one out.

This is a plain magic-number constant, not an extension point: anyone who needs a 10s interval can write `Duration::from_secs(10)` directly, so removing it is not a capability regression.

## Verification

- `cargo clippy -p dora-message -- -D warnings` ✅
- `cargo test -p dora-message` ✅
- `cargo check --all` (excluding the Python packages) ✅ — nothing else references it
- `cargo fmt --all -- --check` ✅

## Note

`dora-message` is a published library, so this is technically a public-API change. If interval-based WS keepalive is planned and this constant was reserved for it, feel free to close — but as it stands it is unreferenced.

---
_Generated by [Claude Code](https://claude.ai/code/session_018wPn3gy8cweX8VPbgorn55)_