### PR TITLE
refactor(message): remove unused PythonOperatorConfig descriptor struct

### DIFF
--- a/libraries/message/src/descriptor.rs
+++ b/libraries/message/src/descriptor.rs
@@ -1,7 +1,7 @@
 #![warn(missing_docs)]
 
 use crate::{
-    config::{ByteSize, CommunicationConfig, Input, InputMapping, NodeRunConfig},
+    config::{ByteSize, CommunicationConfig, Input, NodeRunConfig},
     id::{DataId, NodeId, OperatorId},
 };
 use schemars::JsonSchema;
@@ -1034,20 +1034,6 @@ impl From<PythonSourceDef> for PythonSource {
             PythonSourceDef::WithOptions { source, conda_env } => Self { source, conda_env },
         }
     }
-}
-
-#[allow(missing_docs)]
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(deny_unknown_fields)]
-pub struct PythonOperatorConfig {
-    pub path: PathBuf,
-    #[serde(default)]
-    pub inputs: BTreeMap<DataId, InputMapping>,
-    #[serde(default)]
-    pub outputs: BTreeSet<DataId>,
-    /// Per-output framing overrides (default: Raw for all).
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub output_framing: BTreeMap<DataId, OutputFraming>,
 }
 
 #[allow(missing_docs)]


### PR DESCRIPTION
> [!IMPORTANT]
> **🤖 Auto-generated by Claude (Claude Code).** This PR was created by an automated dead-code sweep and opened via a maintainer's account because the bot cannot author PRs directly. It has **not** been hand-reviewed by a human yet — please treat it as a suggestion and review before merging.

## What

Removes the unused `PythonOperatorConfig` struct from `dora-message`'s descriptor module (plus the now-unused `InputMapping` import):

```rust
#[allow(missing_docs)]
#[derive(Debug, Serialize, Deserialize, Clone)]
#[serde(deny_unknown_fields)]
pub struct PythonOperatorConfig {
    pub path: PathBuf,
    pub inputs: BTreeMap<DataId, InputMapping>,
    pub outputs: BTreeSet<DataId>,
    pub output_framing: BTreeMap<DataId, OutputFraming>,
}
```

## Why

`PythonOperatorConfig` has **zero references anywhere in the workspace** — a repo-wide search returns only the definition.

The actual operator descriptor types use a different config struct: `OperatorDefinition` and `SingleOperatorDefinition` both carry an [`OperatorConfig`](https://github.com/dora-rs/dora/blob/main/libraries/message/src/descriptor.rs) (which holds an `OperatorSource`). `PythonOperatorConfig` is **not** embedded in the `Descriptor` tree, is **not** reachable from the JSON schema (it doesn't even derive `JsonSchema`, and it's absent from `dora-schema.json`), and cannot be deserialized from any real dataflow YAML. It's orphaned leftover scaffolding.

## Verification

- `cargo clippy --all -- -D warnings` (excluding the Python packages) ✅
- `cargo test -p dora-message` ✅
- `cargo check --all` (excluding the Python packages) ✅ — nothing else references it
- `cargo test -p dora-core checked_in_schema_is_current` ✅ — schema unchanged
- `cargo fmt --all -- --check` ✅

## Note

`dora-message` is a published library, so this is technically a public-API change. If `PythonOperatorConfig` is reserved for a planned python-operator descriptor path that isn't wired up yet, feel free to close — but as it stands it is entirely unreferenced and unreachable.

---
_Generated by [Claude Code](https://claude.ai/code/session_018wPn3gy8cweX8VPbgorn55)_