### PR TITLE
refactor(message): remove unused ResolvedNodeSource descriptor enum

### DIFF
--- a/libraries/message/src/descriptor.rs
+++ b/libraries/message/src/descriptor.rs
@@ -1145,13 +1145,6 @@ impl NodeSource {
 
 #[allow(missing_docs)]
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-pub enum ResolvedNodeSource {
-    Local,
-    GitCommit { repo: String, commit_hash: String },
-}
-
-#[allow(missing_docs)]
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub enum GitRepoRev {
     Branch(String),
     Tag(String),


### PR DESCRIPTION
> [!IMPORTANT]
> **🤖 Auto-generated by Claude (Claude Code).** This PR was created by an automated dead-code sweep and opened via a maintainer's account because the bot cannot author PRs directly. It has **not** been hand-reviewed by a human yet — please treat it as a suggestion and review before merging.

## What

Removes the unused `ResolvedNodeSource` enum from `dora-message`'s descriptor module:

```rust
#[allow(missing_docs)]
#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
pub enum ResolvedNodeSource {
    Local,
    GitCommit { repo: String, commit_hash: String },
}
```

## Why

`ResolvedNodeSource` has **zero references anywhere in the workspace** — a repo-wide search returns only the definition.

It looks like a "resolved" counterpart to the live [`NodeSource`](https://github.com/dora-rs/dora/blob/main/libraries/message/src/descriptor.rs) enum (branch → pinned commit), but nothing constructs it, returns it, or embeds it: it is not part of the `Descriptor` tree and — despite deriving `JsonSchema` — it is **not reachable from the schema root**, so it is absent from the checked-in `dora-schema.json`. It is orphaned scaffolding.

## Verification

- `cargo clippy --all -- -D warnings` (excluding the Python packages) ✅
- `cargo test -p dora-message` ✅
- `cargo test -p dora-core checked_in_schema_is_current` ✅ — schema unchanged
- `cargo fmt --all -- --check` ✅

## Note

`dora-message` is a published library, so this is technically a public-API change. Of the three dead-code candidates in this batch this is the least certain: if `ResolvedNodeSource` is intended as scaffolding for in-progress git-source resolution (branch-pin → commit), feel free to close and I'll leave it be. As it stands it is entirely unreferenced.

---
_Generated by [Claude Code](https://claude.ai/code/session_018wPn3gy8cweX8VPbgorn55)_