### PR TITLE
refactor(coordinator): remove unused start_testing entry point

### DIFF
--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -195,20 +195,10 @@ pub async fn start_with_auth(
     .await
 }
 
-/// Like [`start`] but without registering a ctrl-c handler.
+/// Testing-only entry point. Starts the coordinator without auth and without
+/// registering a ctrl-c handler, allowing a custom store to be injected.
 /// Useful for tests that run multiple coordinators in the same process.
-/// Testing-only entry point. Starts coordinator without auth.
 /// Do NOT use in production.
-#[doc(hidden)]
-pub async fn start_testing(
-    bind: SocketAddr,
-    external_events: impl Stream<Item = Event> + Unpin,
-) -> Result<(u16, impl Future<Output = eyre::Result<()>>), eyre::ErrReport> {
-    let store: Arc<dyn CoordinatorStore> = Arc::new(InMemoryStore::new());
-    start_testing_with_store(bind, external_events, store).await
-}
-
-/// Like [`start_testing`], but allows injecting a custom store.
 #[doc(hidden)]
 pub async fn start_testing_with_store(
     bind: SocketAddr,


### PR DESCRIPTION
> 🤖 **Auto-generated by Claude.** This PR was created by an automated dead-code sweep run via Claude Code. The commit is authored as `Claude <noreply@anthropic.com>`; the PR is opened under the maintainer's account only because PR authorship is tied to the push token. Please review before merging.

## What

Removes the unused `start_testing` entry point from `dora-coordinator`:

```rust
#[doc(hidden)]
pub async fn start_testing(
    bind: SocketAddr,
    external_events: impl Stream<Item = Event> + Unpin,
) -> Result<(u16, impl Future<Output = eyre::Result<()>>), eyre::ErrReport> {
    let store: Arc<dyn CoordinatorStore> = Arc::new(InMemoryStore::new());
    start_testing_with_store(bind, external_events, store).await
}
```

## Why

`start_testing` is a `#[doc(hidden)]` testing-only wrapper that builds an `InMemoryStore` and delegates to `start_testing_with_store`. It has **zero callers anywhere in the workspace** — production code, tests, and examples:

```
$ rg -n 'start_testing\b' -g '*.rs' -g '!target'
binaries/coordinator/src/lib.rs:203:pub async fn start_testing(          # definition
binaries/coordinator/src/lib.rs:211:/// Like [`start_testing`], but ...  # doc link
```

Every test constructs its store explicitly and calls `start_testing_with_store` directly:

- `tests/ws-cli-e2e.rs:50`
- `binaries/coordinator/tests/common/mod.rs:32`

`dora-coordinator` is a **binary crate**, not a published library, so its `pub` items are not a public API surface — an unreferenced `pub fn` here is dead code. This mirrors the earlier removal of the unused `start_embedded` entry point (#2155).

The `start_testing_with_store` doc comment, which previously linked to the removed function via `[start_testing]`, is reworded so it no longer references a deleted item (avoiding a broken intra-doc link).

## Validation

- `cargo fmt -p dora-coordinator -- --check` ✓
- `cargo clippy -p dora-coordinator -- -D warnings` ✓ (no newly-unused imports — `InMemoryStore`, `Stream`, `Future` all remain in use)
- `cargo test -p dora-coordinator` ✓ (98 lib unit tests + 4 integration tests pass)
- `rg` confirms no remaining references to `start_testing`.

Pure deletion; no behavior change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NeGwBECf5efgt4TCzZ3Nx2)_