### PR TITLE
fix(cli): show orphaned spans in `dora trace view` instead of silently dropping them

### DIFF
--- a/binaries/cli/src/command/trace/view.rs
+++ b/binaries/cli/src/command/trace/view.rs
@@ -78,7 +78,7 @@ fn print_span_tree(spans: &[TraceSpan]) {
     if partial {
         eprintln!(
             "note: trace is partial — some spans reference a parent that is absent from this \
-             snapshot or forms a cycle (shown as top-level roots)"
+             snapshot or form a cycle (shown as top-level roots)"
         );
     }
 

--- a/binaries/cli/src/command/trace/view.rs
+++ b/binaries/cli/src/command/trace/view.rs
@@ -89,7 +89,7 @@ fn print_span_tree(spans: &[TraceSpan]) {
     let present: HashSet<u64> = spans.iter().map(|s| s.span_id).collect();
     let mut roots: Vec<&TraceSpan> = spans
         .iter()
-        .filter(|s| s.parent_span_id.map_or(true, |p| !present.contains(&p)))
+        .filter(|s| s.parent_span_id.is_none_or(|p| !present.contains(&p)))
         .collect();
     roots.sort_by_key(|s| s.start_time);
 

--- a/binaries/cli/src/command/trace/view.rs
+++ b/binaries/cli/src/command/trace/view.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use clap::Args;
 use dora_message::{cli_to_coordinator::ControlRequest, coordinator_to_cli::TraceSpan};
@@ -82,14 +82,39 @@ fn print_span_tree(spans: &[TraceSpan]) {
         list.sort_by_key(|s| s.start_time);
     }
 
-    if let Some(roots) = children.get(&None) {
-        for root in roots {
-            print_span(root, &children, 0);
-        }
+    // Spans whose parent is absent from this snapshot (e.g. evicted from the
+    // ring buffer, or recorded by a different component) are "orphans".  Treat
+    // them as roots so they appear in the output rather than being silently
+    // dropped.
+    let present: HashSet<u64> = spans.iter().map(|s| s.span_id).collect();
+    let mut roots: Vec<&TraceSpan> = spans
+        .iter()
+        .filter(|s| s.parent_span_id.map_or(true, |p| !present.contains(&p)))
+        .collect();
+    roots.sort_by_key(|s| s.start_time);
+
+    if roots.iter().any(|r| r.parent_span_id.is_some()) {
+        eprintln!(
+            "note: trace is partial — some spans reference a parent not present in this \
+             snapshot (orphaned spans shown as top-level roots)"
+        );
+    }
+
+    let mut visited = HashSet::new();
+    for root in roots {
+        print_span(root, &children, 0, &mut visited);
     }
 }
 
-fn print_span(span: &TraceSpan, children: &HashMap<Option<u64>, Vec<&TraceSpan>>, depth: usize) {
+fn print_span(
+    span: &TraceSpan,
+    children: &HashMap<Option<u64>, Vec<&TraceSpan>>,
+    depth: usize,
+    visited: &mut HashSet<u64>,
+) {
+    if !visited.insert(span.span_id) {
+        return; // cycle guard: skip already-visited spans
+    }
     let indent = "  ".repeat(depth);
     let dur = format_duration_us(span.duration_us);
     let fields = if span.fields.is_empty() {
@@ -106,7 +131,7 @@ fn print_span(span: &TraceSpan, children: &HashMap<Option<u64>, Vec<&TraceSpan>>
 
     if let Some(kids) = children.get(&Some(span.span_id)) {
         for child in kids {
-            print_span(child, children, depth + 1);
+            print_span(child, children, depth + 1, visited);
         }
     }
 }

--- a/binaries/cli/src/command/trace/view.rs
+++ b/binaries/cli/src/command/trace/view.rs
@@ -73,6 +73,49 @@ fn resolve_trace_id(session: &WsSession, prefix: &str) -> eyre::Result<String> {
 }
 
 fn print_span_tree(spans: &[TraceSpan]) {
+    let DisplayPlan { rows, partial } = plan_span_tree(spans);
+
+    if partial {
+        eprintln!(
+            "note: trace is partial — some spans reference a parent that is absent from this \
+             snapshot or forms a cycle (shown as top-level roots)"
+        );
+    }
+
+    for (span, depth) in rows {
+        let indent = "  ".repeat(depth);
+        let dur = format_duration_us(span.duration_us);
+        let fields = if span.fields.is_empty() {
+            String::new()
+        } else {
+            let pairs: Vec<_> = span
+                .fields
+                .iter()
+                .map(|(k, v)| format!("{k}={v}"))
+                .collect();
+            format!(" {{{}}}", pairs.join(", "))
+        };
+        println!("{indent}{} [{} {}]{fields}", span.name, span.level, dur);
+    }
+}
+
+/// The flattened, depth-annotated render order for a span snapshot, plus a flag
+/// indicating whether the trace is incomplete (orphaned or cyclic spans).
+struct DisplayPlan<'a> {
+    rows: Vec<(&'a TraceSpan, usize)>,
+    partial: bool,
+}
+
+/// Compute the render order for `spans`, ensuring every span appears exactly
+/// once even when the snapshot is incomplete or malformed.
+///
+/// Two failure modes are handled so spans are never silently dropped:
+/// - **orphans**: a span whose parent is absent from the snapshot (ring-buffer
+///   eviction, distributed trace, missing root) is promoted to a top-level root.
+/// - **cycles**: a parent-pointer cycle whose members are *all* present (e.g.
+///   A→B→A) has no span that qualifies as a root above; such leftover spans are
+///   surfaced from their earliest member instead of being dropped.
+fn plan_span_tree(spans: &[TraceSpan]) -> DisplayPlan<'_> {
     let mut children: HashMap<Option<u64>, Vec<&TraceSpan>> = HashMap::new();
     for span in spans {
         children.entry(span.parent_span_id).or_default().push(span);
@@ -82,10 +125,6 @@ fn print_span_tree(spans: &[TraceSpan]) {
         list.sort_by_key(|s| s.start_time);
     }
 
-    // Spans whose parent is absent from this snapshot (e.g. evicted from the
-    // ring buffer, or recorded by a different component) are "orphans".  Treat
-    // them as roots so they appear in the output rather than being silently
-    // dropped.
     let present: HashSet<u64> = spans.iter().map(|s| s.span_id).collect();
     let mut roots: Vec<&TraceSpan> = spans
         .iter()
@@ -93,45 +132,122 @@ fn print_span_tree(spans: &[TraceSpan]) {
         .collect();
     roots.sort_by_key(|s| s.start_time);
 
-    if roots.iter().any(|r| r.parent_span_id.is_some()) {
-        eprintln!(
-            "note: trace is partial — some spans reference a parent not present in this \
-             snapshot (orphaned spans shown as top-level roots)"
-        );
+    let orphaned = roots.iter().any(|r| r.parent_span_id.is_some());
+
+    let mut rows = Vec::new();
+    let mut visited = HashSet::new();
+    for root in &roots {
+        collect_rows(root, &children, 0, &mut visited, &mut rows);
     }
 
-    let mut visited = HashSet::new();
-    for root in roots {
-        print_span(root, &children, 0, &mut visited);
+    // Any span still unvisited belongs to an all-present parent-pointer cycle,
+    // so it was never reached from a root above. Surface each leftover span
+    // (earliest first) rather than dropping it.
+    let mut leftover: Vec<&TraceSpan> = spans
+        .iter()
+        .filter(|s| !visited.contains(&s.span_id))
+        .collect();
+    leftover.sort_by_key(|s| s.start_time);
+    let cyclic = !leftover.is_empty();
+    for span in leftover {
+        collect_rows(span, &children, 0, &mut visited, &mut rows);
+    }
+
+    DisplayPlan {
+        rows,
+        partial: orphaned || cyclic,
     }
 }
 
-fn print_span(
-    span: &TraceSpan,
-    children: &HashMap<Option<u64>, Vec<&TraceSpan>>,
+fn collect_rows<'a>(
+    span: &'a TraceSpan,
+    children: &HashMap<Option<u64>, Vec<&'a TraceSpan>>,
     depth: usize,
     visited: &mut HashSet<u64>,
+    rows: &mut Vec<(&'a TraceSpan, usize)>,
 ) {
     if !visited.insert(span.span_id) {
         return; // cycle guard: skip already-visited spans
     }
-    let indent = "  ".repeat(depth);
-    let dur = format_duration_us(span.duration_us);
-    let fields = if span.fields.is_empty() {
-        String::new()
-    } else {
-        let pairs: Vec<_> = span
-            .fields
-            .iter()
-            .map(|(k, v)| format!("{k}={v}"))
-            .collect();
-        format!(" {{{}}}", pairs.join(", "))
-    };
-    println!("{indent}{} [{} {}]{fields}", span.name, span.level, dur,);
+    rows.push((span, depth));
 
     if let Some(kids) = children.get(&Some(span.span_id)) {
         for child in kids {
-            print_span(child, children, depth + 1, visited);
+            collect_rows(child, children, depth + 1, visited, rows);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn span(span_id: u64, parent_span_id: Option<u64>, start_time: u64) -> TraceSpan {
+        TraceSpan {
+            trace_id: "t".to_string(),
+            span_id,
+            parent_span_id,
+            name: format!("span{span_id}"),
+            target: "test".to_string(),
+            level: "INFO".to_string(),
+            start_time,
+            duration_us: 0,
+            fields: Vec::new(),
+        }
+    }
+
+    fn rendered(spans: &[TraceSpan]) -> (Vec<(u64, usize)>, bool) {
+        let plan = plan_span_tree(spans);
+        let rows = plan.rows.iter().map(|(s, d)| (s.span_id, *d)).collect();
+        (rows, plan.partial)
+    }
+
+    #[test]
+    fn nests_children_under_their_root() {
+        let spans = vec![span(1, None, 0), span(2, Some(1), 1), span(3, Some(1), 2)];
+        let (rows, partial) = rendered(&spans);
+        assert_eq!(rows, vec![(1, 0), (2, 1), (3, 1)]);
+        assert!(!partial, "a complete trace is not partial");
+    }
+
+    #[test]
+    fn promotes_orphan_whose_parent_is_absent() {
+        // Parent span 99 is not in the snapshot, so span 1 is an orphan root.
+        let spans = vec![span(1, Some(99), 0), span(2, Some(1), 1)];
+        let (rows, partial) = rendered(&spans);
+        assert_eq!(rows, vec![(1, 0), (2, 1)]);
+        assert!(partial, "an orphaned span marks the trace partial");
+    }
+
+    #[test]
+    fn surfaces_all_present_cycle_instead_of_dropping_it() {
+        // A→B→A: both present, neither qualifies as a root. Without leftover
+        // promotion the whole cycle would be silently dropped (issue #2301).
+        let spans = vec![span(1, Some(2), 0), span(2, Some(1), 1)];
+        let (rows, partial) = rendered(&spans);
+        let ids: HashSet<u64> = rows.iter().map(|(id, _)| *id).collect();
+        assert_eq!(ids, HashSet::from([1, 2]), "every cyclic span is shown");
+        assert_eq!(rows.len(), 2, "each span appears exactly once");
+        assert!(partial, "a cyclic trace marks the trace partial");
+    }
+
+    #[test]
+    fn real_tree_alongside_isolated_cycle_renders_both_once() {
+        // A normal root (1 → 2) plus a disjoint all-present cycle (3 ↔ 4).
+        // Both must appear, each span exactly once, and the trace is partial.
+        let spans = vec![
+            span(1, None, 0),
+            span(2, Some(1), 1),
+            span(3, Some(4), 2),
+            span(4, Some(3), 3),
+        ];
+        let (rows, partial) = rendered(&spans);
+        assert_eq!(rows.len(), 4, "each span appears exactly once");
+        let ids: HashSet<u64> = rows.iter().map(|(id, _)| *id).collect();
+        assert_eq!(ids, HashSet::from([1, 2, 3, 4]), "every span is shown");
+        // The real subtree keeps its nesting; cycle members surface as roots.
+        assert_eq!(rows[0], (1, 0));
+        assert_eq!(rows[1], (2, 1));
+        assert!(partial);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #2301.

`print_span_tree` in `binaries/cli/src/command/trace/view.rs` only printed spans reachable from a span with `parent_span_id == None`. Any span whose parent was absent from the snapshot — due to ring-buffer eviction, a distributed trace spanning multiple components, or the root span simply not being returned — was silently dropped. If the snapshot contained no `None`-parent span at all, `dora trace view` printed nothing despite the early `spans.is_empty()` guard having passed.

## Changes

- **Orphan promotion**: collect all present `span_id`s into a `HashSet`; treat any span whose `parent_span_id` is not in that set (or is `None`) as a root so it appears in the output rather than being silently discarded.
- **Partial-trace note**: when orphan roots are promoted, emit a one-line `note:` to stderr so users know the tree is incomplete.
- **Cycle guard**: pass a `visited: HashSet<u64>` into `print_span` so a malformed span set with a parent-pointer cycle cannot overflow the stack.

## Test plan

- `cargo check -p dora-cli` ✅
- `cargo clippy -p dora-cli -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_0168S4nQPLo1Nz5tEDhKkYTB

---
_Generated by [Claude Code](https://claude.ai/code/session_0168S4nQPLo1Nz5tEDhKkYTB)_