### PR TITLE
fix(smoke): restore graceful skip gate for memory-pool suite on air-gapped machines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5514,9 +5514,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/scripts/smoke-all.sh
+++ b/scripts/smoke-all.sh
@@ -532,14 +532,26 @@ if [ "$RUN_PYTHON" = true ]; then
 
     echo ""
     echo "=== Memory-pool CPU transport ==="
-    # Dependencies (torch, numpy, tqdm) are provisioned by per-node
-    # `build:` steps in each YAML — no host-side gate needed.
-    run_networked "memory-pool-cpu2cpu"            "examples/memory-pool/cpu2cpu.yml" 60
-    run_local     "local-memory-pool-cpu2cpu"      "examples/memory-pool/cpu2cpu.yml" 60
-    run_local     "local-memory-pool-auto-cleanup" "examples/memory-pool/auto_cleanup.yml" 10
-    run_local     "local-memory-pool-duplicate-free"    "examples/memory-pool/duplicate_free.yml" 10
-    run_local     "local-memory-pool-read-after-free"   "examples/memory-pool/read_after_free.yml" 10
-    run_local     "local-memory-pool-write-after-free"  "examples/memory-pool/write_after_free.yml" 10
+    # Dependencies (torch, numpy, tqdm) are provisioned by per-node `build:`
+    # steps that pip-install from download.pytorch.org/whl/cpu.  Skip
+    # gracefully on air-gapped / network-restricted machines where that index
+    # is unreachable; the gate is a lightweight TCP probe, not an import check.
+    if python3 -c "
+import urllib.request, sys
+try:
+    urllib.request.urlopen('https://download.pytorch.org/whl/cpu/', timeout=5)
+except Exception:
+    sys.exit(1)
+" 2>/dev/null; then
+        run_networked "memory-pool-cpu2cpu"            "examples/memory-pool/cpu2cpu.yml" 60
+        run_local     "local-memory-pool-cpu2cpu"      "examples/memory-pool/cpu2cpu.yml" 60
+        run_local     "local-memory-pool-auto-cleanup" "examples/memory-pool/auto_cleanup.yml" 10
+        run_local     "local-memory-pool-duplicate-free"    "examples/memory-pool/duplicate_free.yml" 10
+        run_local     "local-memory-pool-read-after-free"   "examples/memory-pool/read_after_free.yml" 10
+        run_local     "local-memory-pool-write-after-free"  "examples/memory-pool/write_after_free.yml" 10
+    else
+        log_skip "memory-pool" "download.pytorch.org unreachable (run on a machine with PyPI access to exercise this suite)"
+    fi
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/example-smoke.rs
+++ b/tests/example-smoke.rs
@@ -1889,7 +1889,8 @@ fn smoke_shell_node_blocked_without_flag() {
 // Requires `torch` and `tqdm` — not installed in standard PR CI. Run
 // explicitly on machines with torch available:
 //   cargo test --test example-smoke -- --ignored smoke_memory_pool
-// or via `scripts/smoke-all.sh` which gates on `python3 -c "import torch"`.
+// or via `scripts/smoke-all.sh` (skips gracefully when download.pytorch.org
+// is unreachable; torch is installed by per-node `build:` steps).
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -1977,7 +1978,8 @@ fn smoke_local_memory_pool_write_after_free() {
 // |                           | smoke_local_memory_pool_{cpu2cpu, auto_cleanup,      |          |
 // |                           | duplicate_free, read_after_free, write_after_free}   |          |
 // |                           | (#[ignore], run when torch+tqdm available);          |          |
-// |                           | smoke-all.sh gates on `import torch`.                 |          |
+// |                           | smoke-all.sh skips when download.pytorch.org is      |          |
+// |                           | unreachable (torch installed via per-node build:);   |          |
 // |                           | cuda2cpu/cpu2cuda/etc blocked: needs NVIDIA CUDA.     |          |
 // | cuda-benchmark            | blocker: needs NVIDIA CUDA toolkit                   | —        |
 // | dynamic-add-remove        | blocker: `dora node add` times out +                 | #1682    |


### PR DESCRIPTION
## Summary

Fixes #2302 (Findings 2 and 3).

PR #2268 replaced the `python3 -c "import torch"` host-side skip guard with unconditional per-node `build:` pip-install steps, but left two stale comments in `tests/example-smoke.rs` that still claimed the old gate was active. Running `scripts/smoke-all.sh` (or `make qa-examples`) on a machine without network access to `download.pytorch.org` now fails every memory-pool entry on the pip-install build step — previously they were simply skipped.

## Changes

- **`tests/example-smoke.rs`**: fix two stale comments (lines 1892, 1980) that said `smoke-all.sh` gates on `import torch` — the gate was removed in #2268.
- **`scripts/smoke-all.sh`**: restore a graceful skip for the memory-pool block. A lightweight TCP probe to `download.pytorch.org/whl/cpu/` checks reachability before running the suite; if the index is unreachable the suite logs `SKIP` instead of failing (matching the existing pattern used for the hub-dataflow block).

## What is not addressed

**Finding 1** (the 6 `#[ignore]` tests still don't run in any CI workflow because neither PR CI nor nightly passes `--ignored`) requires a dedicated CI step that installs torch and runs `cargo test --test example-smoke -- --ignored smoke_memory_pool`. That's a separate CI infrastructure decision left for maintainers to make.

## Test plan

- `cargo fmt --all -- --check` ✅
- Shell syntax: `bash -n scripts/smoke-all.sh` ✅

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_0168S4nQPLo1Nz5tEDhKkYTB

---
_Generated by [Claude Code](https://claude.ai/code/session_0168S4nQPLo1Nz5tEDhKkYTB)_