### PR TITLE
fix(deps): upgrade quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5514,9 +5514,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Summary

Upgrades `quinn-proto` from 0.11.14 to 0.11.15 to fix RUSTSEC-2026-0185.

**Vulnerability:** Remote memory exhaustion in quinn-proto from unbounded out-of-order stream reassembly (published 2026-06-22, CVSS 7.5 / high). A remote peer can send many out-of-order stream frames to exhaust the daemon's or coordinator's memory.

**Dependency chain:** `reqwest` → `quinn` → `quinn-proto`

**Fix:** `cargo update quinn-proto` — `quinn` 0.11 is semver-compatible with `quinn-proto` 0.11.15.

This is a Cargo.lock-only change; no code changes are required.

## Test plan

- `cargo audit` passes with quinn-proto 0.11.15 ✅
- No API changes — quinn-proto 0.11.14→0.11.15 is a patch release

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_0168S4nQPLo1Nz5tEDhKkYTB

---
_Generated by [Claude Code](https://claude.ai/code/session_0168S4nQPLo1Nz5tEDhKkYTB)_