### PR TITLE
fix(node-api): make close_outputs atomic on unknown output id

### DIFF
--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -1031,10 +1031,18 @@ impl DoraNode {
     ///
     /// Closing outputs early can be helpful to receivers.
     pub fn close_outputs(&mut self, outputs_ids: Vec<DataId>) -> NodeResult<()> {
+        // Validate the whole batch before mutating any local state. Removing
+        // outputs eagerly would leave the node's local output set out of sync
+        // with the daemon if a later id is unknown: the early ones would be
+        // gone locally, yet `report_closed_outputs` is skipped on error so the
+        // daemon never learns about them.
         for output_id in &outputs_ids {
-            if !self.node_config.outputs.remove(output_id) {
+            if !self.node_config.outputs.contains(output_id) {
                 return Err(NodeError::Output(format!("unknown output {output_id}")));
             }
+        }
+        for output_id in &outputs_ids {
+            self.node_config.outputs.remove(output_id);
         }
 
         self.control_channel
@@ -1984,6 +1992,32 @@ mod tests {
         assert!(
             err.to_string().contains("does not match"),
             "unexpected error message: {err}"
+        );
+
+        drop(node);
+        drop(events);
+    }
+
+    /// `close_outputs` must be atomic: if any id in the batch is unknown, the
+    /// call fails *without* removing the valid ids from the local output set.
+    /// Otherwise the daemon (never notified, because `report_closed_outputs` is
+    /// skipped on error) and the node disagree about which outputs are open, and
+    /// the node would silently drop subsequent sends to a still-open output.
+    #[test]
+    fn close_outputs_is_atomic_on_unknown_id() {
+        let (mut node, events, _rx) = test_node();
+        let valid: DataId = "valid".into();
+        node.node_config.outputs.insert(valid.clone());
+
+        let result = node.close_outputs(vec![valid.clone(), "unknown".into()]);
+
+        assert!(
+            result.is_err(),
+            "closing a batch containing an unknown output must fail"
+        );
+        assert!(
+            node.node_config.outputs.contains(&valid),
+            "a failed close_outputs must not remove the valid output from local state"
         );
 
         drop(node);


### PR DESCRIPTION
## Issue

`DoraNode::close_outputs` ([`apis/rust/node/src/node/mod.rs`](https://github.com/dora-rs/dora/blob/main/apis/rust/node/src/node/mod.rs#L1023)) iterated over the requested ids and **removed each one from the local output set as it went**, bailing out on the first unknown id:

```rust
for output_id in &outputs_ids {
    if !self.node_config.outputs.remove(output_id) {   // mutates, then maybe errors
        return Err(NodeError::Output(format!("unknown output {output_id}")));
    }
}
self.control_channel.report_closed_outputs(outputs_ids)?;  // only on success
```

The daemon is notified **only on the success path** (`report_closed_outputs`). So for a batch like `[valid, unknown]`:

1. `valid` is removed from the node's local `outputs` set.
2. `unknown` triggers the early `return Err(...)`.
3. `report_closed_outputs` is **never called**.

The node now believes `valid` is closed while the daemon still believes it is open — and because the local set drives `validate_output`, any later `send_output(valid, ...)` is **silently dropped** instead of delivered.

## Fix

Validate the entire batch before mutating any state, making the operation atomic — it either closes every id and notifies the daemon, or fails leaving local state untouched:

```rust
for output_id in &outputs_ids {
    if !self.node_config.outputs.contains(output_id) {
        return Err(NodeError::Output(format!("unknown output {output_id}")));
    }
}
for output_id in &outputs_ids {
    self.node_config.outputs.remove(output_id);
}
self.control_channel.report_closed_outputs(outputs_ids)?;
```

## Validation

- Added regression test `close_outputs_is_atomic_on_unknown_id` exercising the partial-failure path (fails on the old code, passes on the new code).
- `cargo fmt --all -- --check` ✅
- `cargo clippy -p dora-node-api -- -D warnings` ✅
- `cargo test -p dora-node-api` ✅

---

🤖 This PR was generated by Claude, an AI agent. The diff is machine-generated and was verified locally as described above; a human should still review before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RrWzN9zDS9okB4FBH49dF9)_