### PR TITLE
fix(node-api): return error on send_output_bytes data_len mismatch

### DIFF
--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -907,6 +907,16 @@ impl DoraNode {
         if !self.validate_output(&output_id) {
             return Ok(());
         };
+        // `send_output_raw` allocates a `data_len`-byte sample and the closure
+        // below copies `data` into it. A mismatch would otherwise panic deep
+        // inside `copy_from_slice` ("source slice length .. does not match
+        // destination slice length .."); return a clear error instead.
+        if data.len() != data_len {
+            return Err(NodeError::Output(format!(
+                "send_output_bytes: data_len ({data_len}) does not match data.len() ({})",
+                data.len()
+            )));
+        }
         self.send_output_raw(output_id, parameters, data_len, |sample| {
             sample.copy_from_slice(data)
         })
@@ -1959,6 +1969,25 @@ mod tests {
         let outputs: Vec<_> = rx.try_iter().collect();
         assert_eq!(outputs.len(), 1);
         assert_eq!(outputs[0]["id"], "response");
+    }
+
+    /// `send_output_bytes` must reject a `data_len` that disagrees with
+    /// `data.len()` with a clear error instead of panicking inside
+    /// `copy_from_slice` deep in `send_output_raw`.
+    #[test]
+    fn send_output_bytes_rejects_len_mismatch() {
+        let (mut node, events, _rx) = test_node();
+
+        let result = node.send_output_bytes("out".into(), Default::default(), 8, &[1, 2, 3, 4]);
+
+        let err = result.expect_err("mismatched data_len must error, not panic");
+        assert!(
+            err.to_string().contains("does not match"),
+            "unexpected error message: {err}"
+        );
+
+        drop(node);
+        drop(events);
     }
 
     // ---- dora-rs/adora#150: pattern polymorphism exemption ----


### PR DESCRIPTION
## Issue

`DoraNode::send_output_bytes` ([`apis/rust/node/src/node/mod.rs`](https://github.com/dora-rs/dora/blob/main/apis/rust/node/src/node/mod.rs#L900)) takes **both** a `data_len: usize` and a `data: &[u8]`:

```rust
pub fn send_output_bytes(&mut self, output_id: DataId, parameters: MetadataParameters,
                         data_len: usize, data: &[u8]) -> NodeResult<()> {
    if !self.validate_output(&output_id) { return Ok(()); };
    self.send_output_raw(output_id, parameters, data_len, |sample| {
        sample.copy_from_slice(data)   // <-- panics if data.len() != data_len
    })
}
```

`send_output_raw` allocates a `data_len`-byte sample, then the closure copies `data` into it. If the caller passes a `data_len` that doesn't match `data.len()`, `copy_from_slice` **panics** ("source slice length .. does not match destination slice length ..") deep inside `send_output_raw`, taking the whole node down on a simple caller mistake.

Every other misuse on the public node API surface (unknown output, encode failure, …) is reported as a recoverable `NodeError`, so a panic here is inconsistent and hard to diagnose.

## Fix

Validate the lengths up front and return a clear `NodeError::Output` instead of letting `copy_from_slice` panic:

```rust
if data.len() != data_len {
    return Err(NodeError::Output(format!(
        "send_output_bytes: data_len ({data_len}) does not match data.len() ({})",
        data.len()
    )));
}
```

## Validation

- Added regression test `send_output_bytes_rejects_len_mismatch`.
- `cargo fmt --all -- --check` ✅
- `cargo clippy -p dora-node-api -- -D warnings` ✅
- `cargo test -p dora-node-api` ✅

> Note: the `Audit (cargo-audit + cargo-deny)` CI job is failing repo-wide on pre-existing RUSTSEC advisories (e.g. unmaintained `paste`/`proc-macro-error2`, and the advisory addressed by #2305); it is unrelated to this dependency-free change.

---

🤖 This PR was generated by Claude, an AI agent. The diff is machine-generated and was verified locally as described above; a human should still review before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RrWzN9zDS9okB4FBH49dF9)_