### PR TITLE
refactor(message): remove unused DaemonId::load_or_create persistence helper

### DIFF
--- a/libraries/message/src/common.rs
+++ b/libraries/message/src/common.rs
@@ -281,22 +281,6 @@ impl DaemonId {
         }
     }
 
-    /// Load a persisted daemon ID from `<working_dir>/.daemon-id`, or create and persist a new one.
-    pub fn load_or_create(
-        working_dir: &std::path::Path,
-        machine_id: Option<String>,
-    ) -> std::io::Result<Self> {
-        let path = working_dir.join(".daemon-id");
-        if let Ok(contents) = std::fs::read_to_string(&path)
-            && let Ok(uuid) = contents.trim().parse::<Uuid>()
-        {
-            return Ok(DaemonId { machine_id, uuid });
-        }
-        let id = Self::new(machine_id);
-        std::fs::write(&path, id.uuid.to_string())?;
-        Ok(id)
-    }
-
     pub fn matches_machine_id(&self, machine_id: &str) -> bool {
         self.machine_id
             .as_ref()
@@ -527,22 +511,5 @@ mod tests {
         let id = DaemonId::new(None);
         // v7 UUIDs have version nibble = 7
         assert_eq!(id.uuid.get_version_num(), 7);
-    }
-
-    #[test]
-    fn daemon_id_load_or_create_persists() {
-        let dir = tempfile::tempdir().unwrap();
-        let id1 = DaemonId::load_or_create(dir.path(), Some("m1".into())).unwrap();
-        let id2 = DaemonId::load_or_create(dir.path(), Some("m1".into())).unwrap();
-        assert_eq!(id1.uuid, id2.uuid);
-    }
-
-    #[test]
-    fn daemon_id_load_or_create_different_dirs() {
-        let dir1 = tempfile::tempdir().unwrap();
-        let dir2 = tempfile::tempdir().unwrap();
-        let id1 = DaemonId::load_or_create(dir1.path(), None).unwrap();
-        let id2 = DaemonId::load_or_create(dir2.path(), None).unwrap();
-        assert_ne!(id1.uuid, id2.uuid);
     }
 }


### PR DESCRIPTION
> ⚠️ **Auto-generated by Claude (Claude Code).** This PR was created by an automated dead-code-removal routine, not by a human contributor. Please review accordingly and close if the analysis is wrong.

## What

Removes `DaemonId::load_or_create` from `libraries/message/src/common.rs`, along with its two unit tests (`daemon_id_load_or_create_persists`, `daemon_id_load_or_create_different_dirs`).

```rust
/// Load a persisted daemon ID from `<working_dir>/.daemon-id`, or create and persist a new one.
pub fn load_or_create(working_dir: &Path, machine_id: Option<String>) -> std::io::Result<Self>
```

## Why it's dead

- **No production caller.** A workspace-wide search (`rg 'load_or_create'`, `rg '\.daemon-id'`) finds the method only at its definition site and in its own two unit tests. Nothing reads or writes a `.daemon-id` file anywhere else.
- **The live path uses `DaemonId::new`.** The actual daemon-id is constructed via `DaemonId::new(machine_id)` (e.g. `binaries/coordinator/src/lib.rs:419`), which mints a fresh v7 UUID. The persist-to-disk variant was never wired into that path.
- This is an internal protocol type. `DaemonId` identifies daemons/coordinators on the wire; downstream node authors never construct it, so `load_or_create` is **not** a public extension point — it's an unwired internal helper.

## Verification

- `cargo clippy -p dora-message --all-targets -- -D warnings` — clean
- `cargo test -p dora-message` — passes
- `cargo fmt -p dora-message -- --check` — clean

## Note for maintainers

If persistent daemon identity across restarts is **planned** (this looks related to the daemon-reconnect work), feel free to close this — the helper would be the natural building block for that feature. As of today it has no callers, so the dead-code sweep flagged it.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjweRVzqRE2krY2a9mKJfJ)_