### PR TITLE
fix(run): bound tokio runtime shutdown to prevent macOS hang (#2287)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5514,9 +5514,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/binaries/cli/src/command/run.rs
+++ b/binaries/cli/src/command/run.rs
@@ -240,6 +240,11 @@ impl Executable for Run {
         let result = rt
             .block_on(handle)
             .context("dora-run daemon task panicked")??;
+        // Bound runtime shutdown to prevent hanging on blocking Drop impls
+        // (e.g. zenoh::Session::drop blocks tokio workers on macOS during
+        // TCP teardown). Without this, `rt` drops implicitly at end of scope
+        // and waits indefinitely for all worker threads to exit (#2287).
+        rt.shutdown_timeout(Duration::from_secs(10));
         handle_dataflow_result(result, None)
     }
 }


### PR DESCRIPTION
## Summary

Fixes the macOS shutdown hang reported in #2287 where `dora run` hangs indefinitely after a dataflow completes.

- On macOS, `zenoh::Session::drop` blocks a tokio worker thread during TCP teardown
- After `run_dataflow` returns and `Daemon` drops, the implicit `rt` drop in `RunCommand::execute` waits forever for that blocked thread
- The stop-after background task fires correctly but its channel receiver is already gone, so it has no effect on the hang
- Replace the implicit runtime drop with `rt.shutdown_timeout(Duration::from_secs(10))` so the runtime forcibly exits worker threads after the deadline

## Change

`binaries/cli/src/command/run.rs`: call `rt.shutdown_timeout(10s)` after `block_on` returns instead of relying on the implicit `Drop`.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p dora-cli -- -D warnings` — clean
- [ ] Full macOS nightly run needed to confirm the C++ Dataflow example no longer times out (cannot reproduce locally without a macOS runner)

Closes #2287

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018W9vTuaNRRA3ypxqwotcjo

---
_Generated by [Claude Code](https://claude.ai/code/session_018W9vTuaNRRA3ypxqwotcjo)_