### PR TITLE
refactor(daemon): remove unused socket_stream_receive production helper

### DIFF
--- a/binaries/daemon/src/socket_stream_utils.rs
+++ b/binaries/daemon/src/socket_stream_utils.rs
@@ -25,16 +25,9 @@ pub async fn socket_stream_send(
     Ok(())
 }
 
-#[allow(dead_code)]
-pub async fn socket_stream_receive(
-    connection: &mut (impl AsyncRead + Unpin),
-) -> std::io::Result<Vec<u8>> {
-    socket_stream_receive_with_header_timeout(connection, Some(dora_message::TCP_READ_TIMEOUT))
-        .await
-}
-
-/// Like [`socket_stream_receive`], but with a configurable timeout for the
-/// header read. Pass `None` for connections that may legitimately stay idle
+/// Receive a length-prefixed frame, with a configurable timeout for the header
+/// read. Pass `Some(dora_message::TCP_READ_TIMEOUT)` for request/response
+/// connections, or `None` for connections that may legitimately stay idle
 /// between requests; the body read always uses
 /// [`dora_message::TCP_READ_TIMEOUT`] because a mid-frame stall is a fault.
 pub async fn socket_stream_receive_with_header_timeout(
@@ -87,10 +80,17 @@ pub async fn socket_stream_receive_with_header_timeout(
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        socket_stream_receive, socket_stream_receive_with_header_timeout, socket_stream_send,
-    };
+    use super::{socket_stream_receive_with_header_timeout, socket_stream_send};
     use tokio::io::{AsyncWriteExt, duplex};
+
+    /// Receive a frame using the default header timeout, mirroring the
+    /// production request/response call sites.
+    async fn socket_stream_receive(
+        connection: &mut (impl tokio::io::AsyncRead + Unpin),
+    ) -> std::io::Result<Vec<u8>> {
+        socket_stream_receive_with_header_timeout(connection, Some(dora_message::TCP_READ_TIMEOUT))
+            .await
+    }
 
     // Length-prefixed framing guards on the daemon side of the daemon<->node TCP
     // transport (dora-rs/dora#2027 verified test gap): DoS-sized frames must be


### PR DESCRIPTION
> [!IMPORTANT]
> **🤖 Auto-generated by Claude (Claude Code).** This PR was created by an automated dead-code sweep, not by a human contributor, and is opened under a maintainer's account only because the bot cannot author PRs directly. The commit itself is authored as `Claude <noreply@anthropic.com>`. Please review before merging and close if the analysis is wrong.

## What

Removes the unused `socket_stream_receive` function from `binaries/daemon/src/socket_stream_utils.rs`:

```rust
#[allow(dead_code)]
pub async fn socket_stream_receive(
    connection: &mut (impl AsyncRead + Unpin),
) -> std::io::Result<Vec<u8>> {
    socket_stream_receive_with_header_timeout(connection, Some(dora_message::TCP_READ_TIMEOUT)).await
}
```

## Why it's dead

- **No production caller.** A whole-workspace search (`rg 'socket_stream_receive\b'`) finds the function only at its definition site and in the framing unit tests in the same file — the four tests that exercise the wrapper itself. Nothing in the daemon, node, or any other crate calls it.
- **The live paths use the timeout-aware variant directly.** Every request/response call site constructs the receiver via `socket_stream_receive_with_header_timeout(.., Some(..))` (or `None` for idle-tolerant connections). The thin default-timeout wrapper was never wired into them.
- It is already annotated `#[allow(dead_code)]`. `dora-daemon` is a binary crate, so a `pub` item here is **not** a public API surface — an unreferenced `pub fn` is genuinely dead, not an external extension point.

## Scope note (coverage preserved)

The four framing tests (`framing_roundtrip`, `empty_payload_roundtrips`, `receive_rejects_oversized_length_prefix`, `receive_times_out_on_stalled_peer`) verify real round-trip / DoS-guard / stalled-peer behavior, so rather than delete them, the default-timeout wrapper is moved into the test module as a private helper. `socket_stream_receive(conn)` is exactly `socket_stream_receive_with_header_timeout(conn, Some(TCP_READ_TIMEOUT))`, so the tests keep identical coverage while the production surface drops the dead `pub` function.

## Verification

- `cargo fmt -p dora-daemon -- --check` — clean
- `cargo clippy -p dora-daemon -- -D warnings` — clean
- `cargo test -p dora-daemon --lib socket_stream` — 7 tests pass

Pure deletion of an unreferenced helper; no behavior change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7t8s2sEiaRrJ3BporBxL5)_