### PR TITLE
fix(core): normalize inner-node path before containment check to block `..` traversal

### DIFF
--- a/libraries/core/src/descriptor/expand.rs
+++ b/libraries/core/src/descriptor/expand.rs
@@ -7,8 +7,24 @@ use eyre::{Context, bail};
 use serde::Deserialize;
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
 };
+
+/// Lexically normalize a path (collapse `.` and resolve `..`) without touching
+/// the filesystem — the executable may not be built yet when this is called.
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                out.pop();
+            }
+            other => out.push(other),
+        }
+    }
+    out
+}
 
 /// Check if a path string is absolute on any platform.
 /// On Windows, `Path::is_absolute()` returns false for Unix-style `/foo` paths,
@@ -376,12 +392,15 @@ fn expand_module_node(
         }
         inner_node.inputs = new_inputs;
 
-        // Resolve relative paths: make inner node paths relative to base_dir
+        // Resolve relative paths: make inner node paths relative to base_dir.
+        // Normalize lexically (collapse `..`) before the containment check so
+        // that paths like `../../evil` are detected even though the binary may
+        // not exist yet (ruling out filesystem canonicalize).
         if let Some(ref path) = inner_node.path
             && !super::source_is_url(path)
             && !Path::new(path).is_absolute()
         {
-            let resolved = module_dir.join(path);
+            let resolved = normalize_path(&module_dir.join(path));
             let relative = resolved.strip_prefix(canonical_base).map_err(|_| {
                 eyre::eyre!(
                     "module node `{}` path `{}` resolves outside the project \
@@ -1631,6 +1650,45 @@ nodes:
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(msg.contains("escapes"), "got: {msg}");
+    }
+
+    #[test]
+    fn reject_inner_node_path_traversal_via_dotdot() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+
+        // Module file that declares an inner node with a `..`-escaping path.
+        // The binary doesn't need to exist — the check is purely lexical.
+        write_file(
+            base,
+            "escape_node_module.yml",
+            r#"
+module:
+  name: escape_node
+  inputs: []
+  outputs: []
+
+nodes:
+  - id: evil
+    path: ../../etc/evil-binary
+"#,
+        );
+
+        let desc = parse_descriptor(
+            r#"
+nodes:
+  - id: m
+    module: escape_node_module.yml
+"#,
+        );
+
+        let result = expand_modules(&desc, base);
+        assert!(result.is_err(), "expected error but got success");
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("resolves outside the project directory"),
+            "got: {msg}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #2333

## Summary

The `strip_prefix` containment guard in `expand_module_node` was purely lexical and did not collapse `..` path components. A module inner node with `path: ../../etc/evil-binary` would pass the check even though it resolves outside the project root — the exact condition the check claims to prevent.

**Root cause:** `module_dir.join(path)` is a lexical join. `Path::strip_prefix` is also component-based and lexical, so it succeeds whenever the path *starts* with the prefix components regardless of any `..` that follow. For example, `/project/sub/../../etc/evil` does strip `/project` prefix successfully, returning `sub/../../etc/evil`.

**Fix:** Normalize the joined path lexically (collapse `.` and resolve `..` without touching the filesystem) before `strip_prefix`. Uses the same approach as `libraries/core/src/manifest/inject.rs::normalize`. Filesystem `canonicalize()` is intentionally avoided because the binary may not exist yet at expansion time.

## Changes

- `libraries/core/src/descriptor/expand.rs`: add `normalize_path` helper; apply it to `resolved` before the `strip_prefix` containment check
- Add regression test `reject_inner_node_path_traversal_via_dotdot`

## Test

```
cargo test -p dora-core -- reject_inner_node_path_traversal_via_dotdot
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01UJwUkUpoFFHCfLCqXuYB5N)_