### PR TITLE
fix(core): propagate outer module build through nested module expansion

### DIFF
--- a/libraries/core/src/descriptor/expand.rs
+++ b/libraries/core/src/descriptor/expand.rs
@@ -424,8 +424,20 @@ fn expand_module_node(
     for inner_node in prefixed_nodes {
         if inner_node.module.is_some() {
             let nested_id = inner_node.id.to_string();
-            let (nested, nested_omap) =
+            let accumulated_build = inner_node.build.clone();
+            let (mut nested, nested_omap) =
                 expand_module_node(&inner_node, module_dir, canonical_base, depth + 1, seen)?;
+            // Propagate the outer module's accumulated build to each nested leaf node,
+            // mirroring how `deploy` is propagated through recursion.
+            if let Some(ref outer_build) = accumulated_build {
+                for nested_node in &mut nested {
+                    let inner_build = nested_node.build.take();
+                    nested_node.build = Some(match inner_build {
+                        Some(existing) => format!("{outer_build}\n{existing}"),
+                        None => outer_build.clone(),
+                    });
+                }
+            }
             nested_output_maps.insert(nested_id, nested_omap);
             final_nodes.extend(nested);
         } else {
@@ -1712,6 +1724,75 @@ nodes:
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(msg.contains("duplicate node ID"), "got: {msg}");
+    }
+
+    #[test]
+    fn expand_nested_module_build_propagated() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+
+        write_file(
+            base,
+            "leaf_module.yml",
+            r#"
+module:
+  name: leaf
+  inputs: [x]
+  outputs: [y]
+
+nodes:
+  - id: worker
+    path: worker.py
+    inputs:
+      x: _mod/x
+    outputs:
+      - y
+"#,
+        );
+
+        write_file(
+            base,
+            "outer_module.yml",
+            r#"
+module:
+  name: outer
+  inputs: [x]
+  outputs: [y]
+
+build: pip install outer-deps
+
+nodes:
+  - id: inner
+    module: leaf_module.yml
+    inputs:
+      x: _mod/x
+"#,
+        );
+
+        let desc = parse_descriptor(
+            r#"
+nodes:
+  - id: src
+    path: src.py
+    outputs: [val]
+  - id: top
+    module: outer_module.yml
+    inputs:
+      x: src/val
+"#,
+        );
+
+        let expanded = expand_modules(&desc, base).unwrap();
+        let worker = expanded
+            .nodes
+            .iter()
+            .find(|n| n.id.to_string() == "top.inner.worker")
+            .unwrap();
+        let build = worker.build.as_deref().unwrap();
+        assert!(
+            build.contains("pip install outer-deps"),
+            "outer module build must propagate through nested modules; got: {build}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #2311

## Summary

When a module file references a nested module, the outer module's `build:` command was silently dropped for the resulting leaf nodes.

**Root cause:** In `expand_module_node`, phase 1 correctly prepends the outer module's `build` to every inner node (including nested-module reference nodes). But in phase 2, when a nested-module node is recursively expanded, the function only passes `inner_node` to the recursive call. The recursive call constructs fresh leaf nodes from the nested module file and never reads `inner_node.build`. The accumulated outer build is thrown away.

`deploy` did not have this bug because it is re-applied inside the recursion (propagated down at lines 398–400, which run again in the nested call).

**Fix:** After the recursive `expand_module_node` returns `nested` nodes, prepend `inner_node.build` (the accumulated outer build) to each returned node's `build` — mirroring how `deploy` flows through recursion.

## Changes

- `libraries/core/src/descriptor/expand.rs`: propagate `accumulated_build` from the outer module-reference node to each leaf node returned by the recursive expansion
- Add regression test `expand_nested_module_build_propagated`

## Test

```
cargo test -p dora-core -- expand_nested_module_build_propagated
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01UJwUkUpoFFHCfLCqXuYB5N)_