### PR TITLE
fix(daemon): restore newlines in Indent log formatter for multi-line messages

### DIFF
--- a/binaries/daemon/src/log.rs
+++ b/binaries/daemon/src/log.rs
@@ -533,7 +533,7 @@ struct Indent<'a>(&'a str);
 impl std::fmt::Display for Indent<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for line in self.0.lines() {
-            write!(f, "   {line}")?;
+            writeln!(f, "   {line}")?;
         }
         Ok(())
     }
@@ -695,5 +695,23 @@ mod tests {
 
         // Should not error even with no files
         rotate_log_files(tmp.path(), &uuid, &node, 5).unwrap();
+    }
+
+    #[test]
+    fn indent_preserves_newlines_between_lines() {
+        let out = Indent("line1\nline2\nline3").to_string();
+        assert_eq!(out, "   line1\n   line2\n   line3\n");
+    }
+
+    #[test]
+    fn indent_single_line_gets_newline() {
+        let out = Indent("hello").to_string();
+        assert_eq!(out, "   hello\n");
+    }
+
+    #[test]
+    fn indent_empty_string_produces_empty() {
+        let out = Indent("").to_string();
+        assert_eq!(out, "");
     }
 }


### PR DESCRIPTION
Closes #2312

## Summary

The `Indent` `Display` adapter in `binaries/daemon/src/log.rs` used `write!` (no trailing newline) for each line from `str::lines()`. Since `lines()` strips line terminators, the loop wrote all lines back-to-back with no separator, collapsing multi-line messages into a single unreadable line.

This affected all node log messages routed to the `Tracing` destination, which wraps every message in `Indent(...)`. Python tracebacks (the most common multi-line messages) were the most visibly impacted.

**Fix:** Change `write!(f, "   {line}")` to `writeln!(f, "   {line}")` so each line is indented and properly terminated.

## Changes

- `binaries/daemon/src/log.rs`: `Indent::fmt` — use `writeln!` instead of `write!`
- Add unit tests: multi-line, single-line, and empty-string cases

## Test

```
cargo test -p dora-daemon indent
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01UJwUkUpoFFHCfLCqXuYB5N)_