### PR TITLE
fix: correct debug_assert in managed_python_env_dir to detect .. path traversal

### DIFF
--- a/libraries/core/src/build/mod.rs
+++ b/libraries/core/src/build/mod.rs
@@ -344,8 +344,8 @@ pub fn managed_python_env_dir(node: &ResolvedNode, node_working_dir: &Path) -> O
         // so this assertion should never fire in practice — it guards against future
         // callers that bypass validation.
         debug_assert!(
-            env_dir.components().count() > envs_base.components().count(),
-            "node id '{id}' escaped python-envs directory (env_dir={env_dir:?}, base={envs_base:?})",
+            !env_dir.components().any(|c| matches!(c, std::path::Component::ParentDir)),
+            "node id '{id}' contains a parent-dir segment (env_dir={env_dir:?})",
             id = node.id,
         );
         env_dir

--- a/libraries/core/src/build/mod.rs
+++ b/libraries/core/src/build/mod.rs
@@ -344,7 +344,9 @@ pub fn managed_python_env_dir(node: &ResolvedNode, node_working_dir: &Path) -> O
         // so this assertion should never fire in practice — it guards against future
         // callers that bypass validation.
         debug_assert!(
-            !env_dir.components().any(|c| matches!(c, std::path::Component::ParentDir)),
+            !env_dir
+                .components()
+                .any(|c| matches!(c, std::path::Component::ParentDir)),
             "node id '{id}' contains a parent-dir segment (env_dir={env_dir:?})",
             id = node.id,
         );

--- a/libraries/core/src/build/mod.rs
+++ b/libraries/core/src/build/mod.rs
@@ -344,10 +344,10 @@ pub fn managed_python_env_dir(node: &ResolvedNode, node_working_dir: &Path) -> O
         // so this assertion should never fire in practice — it guards against future
         // callers that bypass validation.
         debug_assert!(
-            !env_dir
+            !Path::new(node.id.as_ref())
                 .components()
                 .any(|c| matches!(c, std::path::Component::ParentDir)),
-            "node id '{id}' contains a parent-dir segment (env_dir={env_dir:?})",
+            "node id '{id}' contains a parent-dir segment",
             id = node.id,
         );
         env_dir


### PR DESCRIPTION
Fixes #2332

The `debug_assert!` in `managed_python_env_dir` used `components().count()` to detect `..` path traversal, but this is ineffective — `..` adds a `ParentDir` component, increasing the count and causing the assertion to pass silently for the dangerous case while firing for the harmless `.` case.

Fix: replace the count check with an explicit `ParentDir` check using `.any()`.