### PR TITLE
fix(core): reject byte sizes that overflow u64 in parse_byte_size

### DIFF
--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -322,7 +322,17 @@ fn parse_byte_size(s: &str) -> eyre::Result<u64> {
     if !num.is_finite() || num < 0.0 {
         bail!("byte size must be a non-negative, finite number: '{s}'");
     }
-    Ok((num * multiplier as f64) as u64)
+    let bytes = num * multiplier as f64;
+    // A finite product can still exceed u64::MAX (e.g. "99999999999999999999GB"),
+    // and casting an out-of-range f64 to u64 saturates to u64::MAX instead of
+    // erroring, silently turning an absurd limit into the maximum. `u64::MAX as
+    // f64` rounds up to 2^64 and no f64 values exist between u64::MAX and 2^64,
+    // so `>=` rejects exactly the products that overflow u64. Mirrors the guard
+    // in `ByteSize::from_str` (dora-message).
+    if bytes >= u64::MAX as f64 {
+        bail!("byte size '{s}' overflows u64");
+    }
+    Ok(bytes as u64)
 }
 
 fn parse_log_level(s: &str) -> eyre::Result<dora_message::common::LogLevelOrStdout> {
@@ -2226,6 +2236,17 @@ nodes:
         // (debug) or silently wrap (release).
         assert!(parse_byte_size("20000000000GB").is_err());
         assert!(parse_byte_size("18446744073709551615GB").is_err());
+    }
+
+    #[test]
+    fn parse_byte_size_rejects_float_overflow() {
+        // num does not fit in u64 (so it takes the f64 path) and is finite and
+        // positive, but num * multiplier exceeds u64::MAX. Casting the result
+        // to u64 saturates to u64::MAX instead of erroring, so it must be
+        // rejected up front rather than silently clamped.
+        assert!(parse_byte_size("99999999999999999999GB").is_err());
+        assert!(parse_byte_size("99999999999999999999.0GB").is_err());
+        assert!(parse_byte_size("184467440737095516160B").is_err());
     }
 
     #[test]


### PR DESCRIPTION
> 🤖 This PR is **machine-generated by Claude** (automated repository review run). Please review before merging.

## Issue

`parse_byte_size` in `libraries/core/src/descriptor/validate.rs` has an integer fast-path (which uses `checked_mul`) and an f64 fallback for numeric parts that don't fit in `u64`. The f64 branch guarded negative and non-finite inputs but **not** finite-but-overflowing positive values:

```rust
if !num.is_finite() || num < 0.0 { bail!(...); }
Ok((num * multiplier as f64) as u64)   // <- saturates on overflow
```

Casting an out-of-range positive `f64` to `u64` **saturates to `u64::MAX`** instead of erroring. So an absurd value like `max_log_size: "99999999999999999999GB"` (20 digits — too large for `u64`, so it takes the f64 path) was silently clamped to the maximum rather than rejected.

The sibling `ByteSize::from_str` in `dora-message` (`libraries/message/src/config.rs`) already has this exact guard (`bytes >= usize::MAX as f64`) with a regression test (`byte_size_rejects_overflow`); `validate.rs` was simply missing the matching check. The existing `parse_byte_size_rejects_integer_overflow` test only exercises the integer path.

## Fix

Add the `bytes >= u64::MAX as f64` guard before the cast. `u64::MAX as f64` rounds up to 2^64 and no f64 values exist between `u64::MAX` and 2^64, so `>=` rejects exactly the products that overflow `u64` without falsely rejecting any in-range value. A new `parse_byte_size_rejects_float_overflow` test covers the GB-multiplier and bare-`B` overflow cases.

## Validation

- `cargo test -p dora-core --lib parse_byte_size` — 14 passed (incl. the new test)
- `cargo clippy -p dora-core -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- Full workspace test + combined `/review` + `/simplify` gates run on the combined review-run diff.

https://claude.ai/code/session_019Vpkwsx8NPyHPg9LmtMhdD

---
_Generated by [Claude Code](https://claude.ai/code/session_019Vpkwsx8NPyHPg9LmtMhdD)_