### PR TITLE
refactor(daemon): drop dead Vec<LogMessage> return from handle_dataflow_stop

### DIFF
--- a/binaries/daemon/src/pending.rs
+++ b/binaries/daemon/src/pending.rs
@@ -7,7 +7,7 @@ use dora_core::{
 use dora_message::{
     DataflowId,
     common::DaemonId,
-    daemon_to_coordinator::{CoordinatorRequest, DaemonEvent, LogLevel, LogMessage, Timestamped},
+    daemon_to_coordinator::{CoordinatorRequest, DaemonEvent, LogLevel, Timestamped},
     daemon_to_node::DaemonReply,
 };
 use eyre::{Context, bail};
@@ -111,7 +111,7 @@ impl PendingNodes {
         cascading_errors: &mut CascadingErrorCauses,
         dynamic_nodes: &BTreeSet<NodeId>,
         logger: &mut DataflowLogger<'_>,
-    ) -> eyre::Result<Vec<LogMessage>> {
+    ) -> eyre::Result<()> {
         // remove all local dynamic nodes that are not yet started
         for node_id in dynamic_nodes {
             if self.local_nodes.remove(node_id) {
@@ -120,7 +120,7 @@ impl PendingNodes {
             }
         }
 
-        Ok(Vec::new())
+        Ok(())
     }
 
     pub async fn handle_external_all_nodes_ready(


### PR DESCRIPTION
> 🤖 This PR is **machine-generated by Claude** (automated repository review run). Please review before merging.

## Issue

`PendingNodes::handle_dataflow_stop` (`binaries/daemon/src/pending.rs`) declared a return type of `eyre::Result<Vec<LogMessage>>` but unconditionally returned `Ok(Vec::new())` — it never pushed anything. Its sole caller, `RunningDataflow::stop_all` (`running_dataflow.rs`), discarded the value with `.await?`. The `Vec<LogMessage>` was dead surface.

## Fix

Change the signature to `eyre::Result<()>`, return `Ok(())`, and drop the now-unused `LogMessage` import. No behavior change.

## Validation

- `cargo clippy -p dora-daemon -- -D warnings` — clean (confirms no remaining use of the dropped import)
- `cargo test -p dora-daemon --lib --no-run` — compiles
- `cargo fmt --all -- --check` — clean
- Full workspace test + combined `/review` + `/simplify` gates run on the combined review-run diff.

https://claude.ai/code/session_019Vpkwsx8NPyHPg9LmtMhdD

---
_Generated by [Claude Code](https://claude.ai/code/session_019Vpkwsx8NPyHPg9LmtMhdD)_