### PR TITLE
refactor(message): remove unused remove_token auth helper

### DIFF
--- a/libraries/message/src/auth.rs
+++ b/libraries/message/src/auth.rs
@@ -167,14 +167,6 @@ fn read_token_from_path(path: &Path) -> std::io::Result<Option<AuthToken>> {
     }
 }
 
-/// Remove the token file if it exists (from both working dir and config dir).
-pub fn remove_token(working_dir: &Path) {
-    let _ = fs::remove_file(token_path(working_dir));
-    if let Some(config_path) = config_token_path() {
-        let _ = fs::remove_file(config_path);
-    }
-}
-
 /// Attempt to read the auth token from (in order):
 /// 1. `DORA_AUTH_TOKEN` environment variable
 /// 2. `<cwd>/.dora-token` file
@@ -264,9 +256,6 @@ mod tests {
 
         let read_back = read_token(dir.path()).unwrap().unwrap();
         assert_eq!(token.as_hex(), read_back.as_hex());
-
-        remove_token(dir.path());
-        assert!(read_token(dir.path()).unwrap().is_none());
     }
 
     #[test]


### PR DESCRIPTION
> 🤖 **This PR is machine-generated by Claude** (automated dead-code sweep). Please review carefully before merging.

## Issue

`auth::remove_token` (`libraries/message/src/auth.rs`) deletes the auth token file from both the working dir and the config dir:

```rust
pub fn remove_token(working_dir: &Path) {
    let _ = fs::remove_file(token_path(working_dir));
    if let Some(config_path) = config_token_path() {
        let _ = fs::remove_file(config_path);
    }
}
```

But it was never wired into any shutdown or cleanup path. A workspace-wide search (`rg remove_token`) returns only the definition and a single in-crate unit test — no production caller anywhere in the coordinator, daemon, or CLI. Its sibling token helpers (`write_token`, `read_token`, `token_path`, `discover_token`, `config_token_path`) all have real production callers; `remove_token` is the only orphan in the set, so the `dead_code` lint stays silent (the test counts as a use).

## Fix

Remove the function and the one test line that exercised it (`write_and_read_token` keeps its write→read assertions). No behavior change.

## Validation

- `cargo test -p dora-message --lib auth` — 6 passed
- `cargo clippy -p dora-message --all-targets -- -D warnings` — clean (confirms no orphaned `fs`/`Path` import)
- `cargo fmt --all -- --check` — clean

## Note

`dora-message` publishes to crates.io, so removing this `pub fn` is technically a minor semver-breaking change — worth catching in the next version bump, consistent with the earlier dead-code-sweep PRs (#2186, #2187, #2188).

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZpCopffNKVKVB1KVKgP3S)_