### PR TITLE
refactor(message): remove unused InputMapping::source accessor

### DIFF
--- a/libraries/message/src/config.rs
+++ b/libraries/message/src/config.rs
@@ -7,7 +7,6 @@ use std::{
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::sync::OnceLock;
 
 use crate::descriptor;
 pub use crate::id::{DataId, NodeId, OperatorId};
@@ -207,19 +206,6 @@ pub enum InputMapping {
     /// Syntax: `dora/logs`, `dora/logs/{level}`, `dora/logs/{level}/{node_id}`
     Logs(LogSubscriptionFilter),
     User(UserInputMapping),
-}
-
-impl InputMapping {
-    pub fn source(&self) -> &NodeId {
-        static DORA_NODE_ID: OnceLock<NodeId> = OnceLock::new();
-
-        match self {
-            InputMapping::User(mapping) => &mapping.source,
-            InputMapping::Timer { .. } | InputMapping::Logs(_) => {
-                DORA_NODE_ID.get_or_init(|| NodeId("dora".to_string()))
-            }
-        }
-    }
 }
 
 impl fmt::Display for InputMapping {
@@ -896,12 +882,6 @@ mod tests {
     fn display_roundtrip_logs_with_level_and_node() {
         let mapping: InputMapping = "dora/logs/debug/camera".parse().unwrap();
         assert_eq!(mapping.to_string(), "dora/logs/debug/camera");
-    }
-
-    #[test]
-    fn logs_source_is_dora() {
-        let mapping: InputMapping = "dora/logs".parse().unwrap();
-        assert_eq!(mapping.source().to_string(), "dora");
     }
 
     #[test]


### PR DESCRIPTION
> 🤖 **This PR is machine-generated by Claude** (automated dead-code sweep). Please review carefully before merging.

## Issue

`InputMapping::source` (`libraries/message/src/config.rs`) returns the source `NodeId` for a mapping, synthesizing a `"dora"` node id for the `Timer`/`Logs` variants:

```rust
impl InputMapping {
    pub fn source(&self) -> &NodeId {
        static DORA_NODE_ID: OnceLock<NodeId> = OnceLock::new();
        match self {
            InputMapping::User(mapping) => &mapping.source,
            InputMapping::Timer { .. } | InputMapping::Logs(_) => {
                DORA_NODE_ID.get_or_init(|| NodeId("dora".to_string()))
            }
        }
    }
}
```

`InputMapping` is widely re-exported (as `dora_core::config::InputMapping`) and consumed across the CLI and daemon, but every consumer pattern-matches the enum directly and reads the `UserInputMapping::source` **field** — none call the `.source()` **method**. A workspace-wide search (`rg '\.source\(\)'`) finds the method used only by one in-crate unit test (`logs_source_is_dora`), so the `dead_code` lint stays silent.

## Fix

Remove the method, the now-unused `OnceLock` import, and the single test that exercised it. No behavior change (the `NodeId` import stays — still used elsewhere in the file).

## Validation

- `cargo test -p dora-message --lib config` — 44 passed
- `cargo clippy -p dora-message --all-targets -- -D warnings` — clean (confirms no orphaned `OnceLock`/`NodeId` import)
- `cargo fmt --all -- --check` — clean

## Note

`dora-message` publishes to crates.io, so removing this `pub fn` is technically a minor semver-breaking change — worth catching in the next version bump, consistent with the earlier dead-code-sweep PRs (#2186, #2187, #2188).

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZpCopffNKVKVB1KVKgP3S)_