### PR TITLE
refactor(operator): remove unused OutputFnRaw FFI type alias

### DIFF
--- a/apis/rust/operator/src/raw.rs
+++ b/apis/rust/operator/src/raw.rs
@@ -4,14 +4,6 @@ use dora_operator_api_types::{
 };
 use std::ffi::c_void;
 
-pub type OutputFnRaw = unsafe extern "C" fn(
-    id_start: *const u8,
-    id_len: usize,
-    data_start: *const u8,
-    data_len: usize,
-    output_context: *const c_void,
-) -> isize;
-
 pub unsafe fn dora_init_operator<O: DoraOperator>() -> DoraInitResult {
     let operator: O = Default::default();
     let ptr: *mut O = Box::leak(Box::new(operator));


### PR DESCRIPTION
> 🤖 **This PR is machine-generated by Claude** (automated dead-code sweep). Please review carefully before merging.

## Issue

`OutputFnRaw` (`apis/rust/operator/src/raw.rs`) is a `pub type` alias for a C output-callback signature:

```rust
pub type OutputFnRaw = unsafe extern "C" fn(
    id_start: *const u8, id_len: usize,
    data_start: *const u8, data_len: usize,
    output_context: *const c_void,
) -> isize;
```

It is a leftover from an older FFI output design. The live FFI path delivers operator output through `SendOutput` / `DoraOutputSender`, not this callback signature. A workspace-wide search (`rg OutputFnRaw`) returns **only the definition site** — it is referenced by nothing: not the `register_operator!` macro, not the generated `extern "C"` exports (`dora_init_operator` / `dora_drop_operator` / `dora_on_event`), and not the C/C++ headers under `apis/c++`.

## Fix

Remove the alias. The `c_void` import is retained (still used by the FFI functions in the same file). No behavior change.

## Validation

- `cargo test -p dora-operator-api --lib` — 7 passed
- `cargo clippy -p dora-operator-api --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

## Note

`OutputFnRaw` lives in the `pub mod raw` FFI module of the published `dora-operator-api` crate, so this is technically a semver-relevant public-API removal — worth noting in the next version bump. It carries no capability (it is an unreferenced type alias with no constructor/consumer), so unlike a builder/extension point there is nothing for downstream code to have depended on.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZpCopffNKVKVB1KVKgP3S)_