### PR TITLE
refactor(operator-types): remove unused DoraResult::error accessor

### DIFF
--- a/apis/rust/operator/types/src/lib.rs
+++ b/apis/rust/operator/types/src/lib.rs
@@ -16,7 +16,7 @@ use safer_ffi::{
     closure::ArcDynFn1,
     derive_ReprC, ffi_export,
 };
-use std::{ops::Deref, path::Path};
+use std::path::Path;
 
 #[derive_ReprC]
 #[ffi_export]
@@ -55,10 +55,6 @@ impl DoraResult {
         Self {
             error: Some(Box::new(safer_ffi::String::from(error)).into()),
         }
-    }
-
-    pub fn error(&self) -> Option<&str> {
-        self.error.as_deref().map(|s| s.deref())
     }
 
     pub fn into_result(self) -> Result<(), String> {


### PR DESCRIPTION
> 🤖 **This PR is machine-generated by Claude** (automated dead-code sweep). Please review carefully before merging.

## Issue

`DoraResult::error` (`apis/rust/operator/types/src/lib.rs`) returns the error message as a borrowed `Option<&str>`:

```rust
pub fn error(&self) -> Option<&str> {
    self.error.as_deref().map(|s| s.deref())
}
```

A workspace-wide search (`rg '\.error\(\)'`) finds **zero callers**. Every consumer either reads the public `error` **field** directly (the `#[repr(C)]` FFI struct and the C++ side) or uses `into_result()`. The sibling helpers `SUCCESS`, `from_error`, and `into_result` are all used in production (`apis/rust/operator/src/lib.rs`, `raw.rs`); only the `error()` accessor method is orphaned, which is why the `dead_code` lint stays silent across the FFI types.

## Fix

Remove the method and the now-unused `Deref` import. The `error` field, the FFI export, and all sibling helpers are untouched. No behavior change.

## Validation

- `cargo clippy -p dora-operator-api-types --all-targets -- -D warnings` — clean (confirms the `Deref` import is no longer needed)
- `cargo clippy -p dora-operator-api --all-targets -- -D warnings` — clean (dependent crate unaffected)
- `cargo build -p dora-operator-api-types` — ok
- `cargo fmt --all -- --check` — clean

## Note

`dora-operator-api-types` publishes to crates.io, so removing this `pub fn` is technically a minor semver-breaking change — worth catching in the next version bump. The accessor carries no capability that the public `error` field and `into_result()` don't already provide.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZpCopffNKVKVB1KVKgP3S)_