### PR TITLE
fix(ros2-bridge): don't panic in parse_message_string on space-free lines

### DIFF
--- a/libraries/extensions/ros2-bridge/msg-gen/src/parser/message.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/parser/message.rs
@@ -41,9 +41,12 @@ pub fn parse_message_string(
 
         let (_, rest) = split_once(line, ' ');
 
-        match rest.unwrap().find('=') {
-            Some(_) => constants.push(constant_def(line)?),
-            None => members.push(member_def(line)?),
+        // rest is None when the line has no space (e.g. tab-separated or single-token);
+        // treat absence of '=' as a member definition rather than panicking.
+        if rest.is_some_and(|r| r.contains('=')) {
+            constants.push(constant_def(line)?);
+        } else {
+            members.push(member_def(line)?);
         }
     }
 
@@ -156,5 +159,22 @@ mod test {
     fn parse_wstrings() -> Result<()> {
         let _result = parse_msg_def("WStrings")?;
         Ok(())
+    }
+
+    #[test]
+    fn parse_message_string_tab_separated_field() -> Result<()> {
+        // Tab-separated lines must produce a member, not panic.
+        let msg = parse_message_string("pkg", "Msg", "int8\tfoo")?;
+        assert_eq!(msg.members.len(), 1);
+        assert_eq!(msg.members[0].name, "foo");
+        Ok(())
+    }
+
+    #[test]
+    fn parse_message_string_single_token_line_returns_error() {
+        // A single-token line with no space is malformed and must return an
+        // error, not a panic.
+        let result = parse_message_string("pkg", "Msg", "garbage");
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Summary

Fixes #2362.

`parse_message_string` called `rest.unwrap()` where `rest: Option<&str>` is `None` for any non-empty, non-comment line that contains no ASCII space character. Two real inputs hit this:

- **Tab-separated field** (`int8\tfoo`) — valid for the downstream `member_def` parser (which uses nom's `space1`), but the pre-split panicked before reaching it.
- **Malformed single-token line** (`garbage`) — should produce a clean parse error with context, instead panicked.

Because `parse_message_file` discovers interface files via glob over `AMENT_PREFIX_PATH`, a single tab-using or slightly malformed file anywhere in the search path caused the entire build to abort with a panic rather than a contextual error.

## Fix

Replace `rest.unwrap().find('=')` with `rest.is_some_and(|r| r.contains('='))`. A line with no space has no `=` in the "rest" part, so it routes to `member_def`, which produces a proper `Err` for truly malformed input and correctly parses tab-separated fields.

## Tests

Two new regression tests:

- `parse_message_string_tab_separated_field` — `"int8\tfoo"` produces a member named `foo` (no panic)
- `parse_message_string_single_token_line_returns_error` — `"garbage"` returns `Err`, not a panic

## Validation

- `cargo test -p dora-ros2-bridge-msg-gen --lib` — 16 passed (all existing + 2 new)
- `cargo clippy -p dora-ros2-bridge-msg-gen -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01YV34LCDzQGUNEzAKCbCAMW)_