### PR TITLE
fix(ros2-bridge): enforce byte limit for BoundedString and UTF-16 limit for BoundedWString

### DIFF
--- a/libraries/extensions/ros2-bridge/msg-gen/src/parser/literal.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/parser/literal.rs
@@ -114,7 +114,7 @@ pub fn get_string_literal_parser(
     match string_type {
         GenericString::String | GenericString::WString => Box::new(string_literal),
         GenericString::BoundedString(max_size) | GenericString::BoundedWString(max_size) => {
-            Box::new(move |s| verify(string_literal, |s: &str| s.len() <= max_size)(s))
+            Box::new(move |s| verify(string_literal, |s: &str| s.chars().count() <= max_size)(s))
         }
     }
 }
@@ -270,6 +270,24 @@ mod test {
         assert_eq!(string_literal(r#""aaa\"aaa" "#)?.1, r#"aaa"aaa"#);
         assert_eq!(string_literal(r#"'aaa\'aaa' "#)?.1, "aaa'aaa");
         Ok(())
+    }
+
+    #[test]
+    fn bounded_string_uses_char_count_not_byte_length() {
+        use crate::types::primitives::GenericString;
+        // "€€€" is 3 chars but 9 UTF-8 bytes; a bound of 4 should accept it.
+        let parser = get_string_literal_parser(GenericString::BoundedString(4));
+        // Wrap in a Box<dyn FnMut> as returned by get_string_literal_parser.
+        let mut p = parser;
+        assert!(
+            p("€€€").is_ok(),
+            "3-char multi-byte string rejected by bound of 4 — byte length wrongly used"
+        );
+        // A 5-char string should be rejected by a bound of 4.
+        assert!(
+            p("hello").is_err(),
+            "5-char string should be rejected by bound of 4"
+        );
     }
 
     #[test]

--- a/libraries/extensions/ros2-bridge/msg-gen/src/parser/literal.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/parser/literal.rs
@@ -113,9 +113,16 @@ pub fn get_string_literal_parser(
 ) -> Box<dyn FnMut(&str) -> IResult<&str, String>> {
     match string_type {
         GenericString::String | GenericString::WString => Box::new(string_literal),
-        GenericString::BoundedString(max_size) | GenericString::BoundedWString(max_size) => {
-            Box::new(move |s| verify(string_literal, |s: &str| s.chars().count() <= max_size)(s))
+        // ROS 2 spec: string<=N bound is in UTF-8 bytes; wstring<=N bound is in UTF-16 code units.
+        // Keep these separate so the parser metric matches the codegen validator in value_tokens().
+        GenericString::BoundedString(max_size) => {
+            Box::new(move |s| verify(string_literal, move |s: &str| s.len() <= max_size)(s))
         }
+        GenericString::BoundedWString(max_size) => Box::new(move |s| {
+            verify(string_literal, move |s: &str| {
+                s.encode_utf16().count() <= max_size
+            })(s)
+        }),
     }
 }
 
@@ -273,20 +280,52 @@ mod test {
     }
 
     #[test]
-    fn bounded_string_uses_char_count_not_byte_length() {
+    fn bounded_string_enforces_byte_limit_per_ros2_spec() {
         use crate::types::primitives::GenericString;
-        // "€€€" is 3 chars but 9 UTF-8 bytes; a bound of 4 should accept it.
-        let parser = get_string_literal_parser(GenericString::BoundedString(4));
-        // Wrap in a Box<dyn FnMut> as returned by get_string_literal_parser.
-        let mut p = parser;
+        // ROS 2 spec: string<=N is a byte limit, not a character limit.
+        // "hi" is 2 bytes, accepted under bound 4.
+        let mut p = get_string_literal_parser(GenericString::BoundedString(4));
         assert!(
-            p("€€€").is_ok(),
-            "3-char multi-byte string rejected by bound of 4 — byte length wrongly used"
+            p("hi").is_ok(),
+            "2-byte string should be accepted by byte bound of 4"
         );
-        // A 5-char string should be rejected by a bound of 4.
+        // "hello" is 5 bytes, rejected under bound 4.
         assert!(
             p("hello").is_err(),
-            "5-char string should be rejected by bound of 4"
+            "5-byte string should be rejected by byte bound of 4"
+        );
+        // "€€€" is 9 UTF-8 bytes (3 chars), rejected under bound 4.
+        assert!(
+            p("€€€").is_err(),
+            "9-byte string should be rejected by byte bound of 4"
+        );
+    }
+
+    #[test]
+    fn bounded_wstring_enforces_utf16_code_unit_limit_per_ros2_spec() {
+        use crate::types::primitives::GenericString;
+        // ROS 2 spec: wstring<=N is a UTF-16 code-unit limit.
+        // "hi" is 2 UTF-16 code units, accepted under bound 4.
+        let mut p = get_string_literal_parser(GenericString::BoundedWString(4));
+        assert!(
+            p("hi").is_ok(),
+            "2-code-unit string should be accepted by UTF-16 bound of 4"
+        );
+        // "hello" is 5 UTF-16 code units, rejected under bound 4.
+        assert!(
+            p("hello").is_err(),
+            "5-code-unit string should be rejected by UTF-16 bound of 4"
+        );
+        // "€€€" is 3 UTF-16 code units (U+20AC × 3, all in BMP), accepted under bound 4.
+        assert!(
+            p("€€€").is_ok(),
+            "3-code-unit string should be accepted by UTF-16 bound of 4"
+        );
+        // An astral character like 😀 (U+1F600) takes 2 UTF-16 code units.
+        // "😀😀😀" = 6 code units, rejected under bound 4.
+        assert!(
+            p("😀😀😀").is_err(),
+            "6-code-unit astral string should be rejected by UTF-16 bound of 4"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes #2363.

`get_string_literal_parser` in `literal.rs` used a single shared arm for `BoundedString` and `BoundedWString`, both validating via `s.len()` (UTF-8 bytes). This was wrong for `BoundedWString`, which per the ROS 2 spec should be validated in UTF-16 code units.

Per the [ROS 2 IDL spec](https://design.ros2.org/articles/wide_strings.html):
- `string<=N` bound is in **UTF-8 bytes**
- `wstring<=N` bound is in **UTF-16 code units**

## Fix

Split the shared `BoundedString | BoundedWString` match arm into two separate arms:

- `BoundedString(max)` → `s.len() <= max` (UTF-8 byte count, matches spec and the existing codegen validator in `value_tokens()`)
- `BoundedWString(max)` → `s.encode_utf16().count() <= max` (UTF-16 code units, matches spec and the existing codegen validator in `value_tokens()`)

## Tests

Two new tests validate spec-correct behavior:

**`bounded_string_enforces_byte_limit_per_ros2_spec`**:
- `"hi"` (2 bytes) accepted under bound 4 ✓
- `"hello"` (5 bytes) rejected under bound 4 ✓
- `"€€€"` (9 UTF-8 bytes, 3 chars) rejected under bound 4 ✓

**`bounded_wstring_enforces_utf16_code_unit_limit_per_ros2_spec`**:
- `"hi"` (2 UTF-16 code units) accepted under bound 4 ✓
- `"hello"` (5 UTF-16 code units) rejected under bound 4 ✓
- `"€€€"` (3 UTF-16 code units, U+20AC × 3 all in BMP) accepted under bound 4 ✓
- `"😀😀😀"` (6 UTF-16 code units, 2 per astral char) rejected under bound 4 ✓

## Validation

- `cargo test -p dora-ros2-bridge-msg-gen --lib` — 70 passed
- `cargo clippy -p dora-ros2-bridge-msg-gen -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01YV34LCDzQGUNEzAKCbCAMW)_