### PR TITLE
fix(message): validate node filter in dora/logs input parsing

### DIFF
--- a/libraries/message/src/config.rs
+++ b/libraries/message/src/config.rs
@@ -295,7 +295,17 @@ impl FromStr for InputMapping {
                 Some(("logs", rest)) => {
                     // dora/logs/{level} or dora/logs/{level}/{node_id}
                     let (level_str, node_filter) = match rest.split_once('/') {
-                        Some((level, node)) => (Some(level), Some(NodeId(node.to_owned()))),
+                        Some((level, node)) => {
+                            // Validate the node segment instead of constructing a
+                            // `NodeId` directly: `rest.split_once('/')` keeps every
+                            // slash after the first inside `node`, so an input such
+                            // as `dora/logs/info/a/b` would otherwise build a NodeId
+                            // containing `/` -- a value `validate_node_id` forbids and
+                            // that no real node id can ever equal, silently producing
+                            // a filter that never matches.
+                            let node_id = node.parse::<NodeId>().map_err(|e| e.to_string())?;
+                            (Some(level), Some(node_id))
+                        }
                         None => {
                             if rest.is_empty() {
                                 (None, None)
@@ -864,6 +874,19 @@ mod tests {
     fn parse_logs_invalid_level() {
         let result: Result<InputMapping, _> = "dora/logs/banana".parse();
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_logs_rejects_invalid_node_filter() {
+        // A node segment with an extra `/` (kept by `split_once`) is not a valid
+        // NodeId and must be rejected rather than silently yielding a filter that
+        // can never match a real (validated) node id.
+        let result: Result<InputMapping, _> = "dora/logs/info/a/b".parse();
+        assert!(result.is_err(), "node filter `a/b` must be rejected");
+
+        // A node segment containing a space is likewise invalid.
+        let result: Result<InputMapping, _> = "dora/logs/info/bad node".parse();
+        assert!(result.is_err(), "node filter `bad node` must be rejected");
     }
 
     #[test]


### PR DESCRIPTION
> 🤖 This PR is **machine-generated by Claude** (automated repository review run). Please review carefully before merging.

## Issue

`InputMapping::from_str` parses `dora/logs/{level}/{node_id}` filters in `libraries/message/src/config.rs`, but constructed the node id directly:

```rust
Some((level, node)) => (Some(level), Some(NodeId(node.to_owned()))),
```

This bypasses `validate_node_id` (`libraries/message/src/id.rs`), which every other `NodeId` construction path enforces. Because `rest.split_once('/')` keeps **every slash after the first** inside `node`, an input such as `dora/logs/info/a/b` produced a `NodeId` containing `/` — a character the NodeId invariant explicitly forbids ("NodeIds must NOT contain `/`"). Spaces and other invalid characters were likewise accepted.

Such a filter can never equal a real, validated node id, so instead of erroring it silently matched **nothing** (the daemon compares it by equality against each `log_message.node_id` at `binaries/daemon/src/lib.rs:4355`). A user typo became a silent no-op rather than a clear error.

## Fix

Parse the node segment through `NodeId::from_str` so invalid filters are rejected at parse time:

```rust
let node_id = node.parse::<NodeId>().map_err(|e| e.to_string())?;
(Some(level), Some(node_id))
```

## Validation

- New regression test `parse_logs_rejects_invalid_node_filter` (rejects `a/b` and `bad node`).
- `cargo test -p dora-message --lib config::` — 43 passed.
- `cargo clippy -p dora-message -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbJBzWqUQmwFTy7gsmYmpg)_