### PR TITLE
fix(memory-pool): don't log cleanup success when frees failed

### DIFF
--- a/libraries/extensions/memory-pool/src/lib.rs
+++ b/libraries/extensions/memory-pool/src/lib.rs
@@ -263,19 +263,26 @@ impl MemoryPoolManager {
             }
         }
 
-        if unreleased_count > 0 {
-            tracing::info!(
-                "Successfully released {} unreleased memory pools!",
-                unreleased_count
-            );
-        }
+        let released_count = unreleased_count - errors.len();
 
         if errors.is_empty() {
+            if unreleased_count > 0 {
+                tracing::info!(
+                    "Successfully released {} unreleased memory pools!",
+                    released_count
+                );
+            }
             Ok(CleanupSummary {
                 unreleased_count,
-                released_count: unreleased_count,
+                released_count,
             })
         } else {
+            tracing::warn!(
+                "Released {} of {} unreleased memory pools; {} failed",
+                released_count,
+                unreleased_count,
+                errors.len()
+            );
             Err(errors)
         }
     }
@@ -390,7 +397,29 @@ mod tests {
 
         let summary = mgr.cleanup_all().unwrap();
         assert_eq!(summary.unreleased_count, 3);
+        assert_eq!(summary.released_count, 3);
         assert_eq!(mgr.table_size(), 0);
+    }
+
+    #[test]
+    fn cleanup_all_reports_partial_release_on_failure() {
+        let mgr = MemoryPoolManager::new();
+
+        // One entry frees cleanly (no backing shmem name)...
+        mgr.register_memory_pool(make_id("ok"), make_metadata(), "node_a".into())
+            .unwrap();
+        // ...and one whose shared_memory_name fails the `dora_pool_` validation
+        // in `free_shared_memory`, so its release errors.
+        let mut bad_meta = make_metadata();
+        bad_meta.shared_memory_name = Some("invalid_name".to_string());
+        mgr.register_memory_pool(make_id("bad"), bad_meta, "node_a".into())
+            .unwrap();
+
+        // cleanup_all must surface the failure (rather than silently claiming
+        // "Successfully released") and still drain every entry from the table.
+        let errors = mgr.cleanup_all().unwrap_err();
+        assert_eq!(errors.len(), 1, "exactly one free should have failed");
+        assert_eq!(mgr.table_size(), 0, "all entries must be removed");
     }
 
     #[test]


### PR DESCRIPTION
> 🤖 This PR is **machine-generated by Claude** (automated repository review run). Please review carefully before merging.

## Issue

`MemoryPoolManager::cleanup_all` (`libraries/extensions/memory-pool/src/lib.rs`) logged success unconditionally, **before** checking whether any frees failed:

```rust
for id in &ids { /* ... collect errors from free_shared_memory ... */ }

if unreleased_count > 0 {
    tracing::info!("Successfully released {} unreleased memory pools!", unreleased_count);
}

if errors.is_empty() { Ok(..) } else { Err(errors) }
```

When one or more `free_shared_memory` calls failed, a shutdown printed a "Successfully released N" line **and** returned `Err` — contradictory — and the count was the number *attempted*, not released. That misleading message appears in exactly the failure case the log exists to surface.

## Fix

Move the success log into the `errors.is_empty()` branch, report the accurate `released_count` (attempted − failed), and emit a `warn` summarizing the partial release on the failure path. `CleanupSummary.released_count` is now exact.

`released_count = unreleased_count - errors.len()` cannot underflow: `ids` are unique table keys and the loop pushes at most one error per id, so `errors.len() <= unreleased_count`.

## Validation

- New regression test `cleanup_all_reports_partial_release_on_failure` (one entry with an invalid `shared_memory_name` fails to free; asserts `Err` with one error and the table fully drained), plus a `released_count == 3` assertion added to the existing all-success test.
- `cargo test -p dora-memory-pool --lib` — passes.
- `cargo clippy -p dora-memory-pool -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbJBzWqUQmwFTy7gsmYmpg)_