### PR TITLE
docs(mavlink2-bridge): add compile-checked doctest for MavlinkArrow

### DIFF
--- a/libraries/extensions/mavlink2-bridge/src/arrow_convert.rs
+++ b/libraries/extensions/mavlink2-bridge/src/arrow_convert.rs
@@ -31,6 +31,33 @@ use std::sync::Arc;
 /// [`from_record_batch`] expects; both sides carry exactly one row, and
 /// [`from_record_batch`] rejects any other row count.
 ///
+/// # Example
+///
+/// Encode a MAVLink message to a 1-row Arrow batch and decode it back:
+///
+/// ```
+/// use dora_mavlink2_bridge::MavlinkArrow;
+/// use dora_mavlink2_bridge::mavlink::common::{
+///     HEARTBEAT_DATA, MavAutopilot, MavModeFlag, MavState, MavType,
+/// };
+///
+/// let heartbeat = HEARTBEAT_DATA {
+///     custom_mode: 42,
+///     mavtype: MavType::MAV_TYPE_QUADROTOR,
+///     autopilot: MavAutopilot::MAV_AUTOPILOT_GENERIC,
+///     base_mode: MavModeFlag::MAV_MODE_FLAG_SAFETY_ARMED,
+///     system_status: MavState::MAV_STATE_ACTIVE,
+///     mavlink_version: 3,
+/// };
+///
+/// let batch = heartbeat.to_record_batch()?;
+/// assert_eq!(batch.num_rows(), 1);
+///
+/// let decoded = HEARTBEAT_DATA::from_record_batch(&batch)?;
+/// assert_eq!(decoded, heartbeat);
+/// # Ok::<(), dora_mavlink2_bridge::BridgeError>(())
+/// ```
+///
 /// [`schema`]: MavlinkArrow::schema
 /// [`to_record_batch`]: MavlinkArrow::to_record_batch
 /// [`from_record_batch`]: MavlinkArrow::from_record_batch


### PR DESCRIPTION
> 🤖 This PR is **machine-generated by Claude** (automated repository review run). Please review carefully before merging.

## Issue

`MavlinkArrow` (`libraries/extensions/mavlink2-bridge/src/arrow_convert.rs`) is the crate's primary public API (re-exported from `lib.rs`), but its encode/decode round-trip contract lived only in prose — there was no runnable, compile-checked example on the trait itself.

## Fix

Add a doctest on the trait that constructs a `HEARTBEAT` message, encodes it to a 1-row Arrow `RecordBatch`, decodes it back, and asserts equality. This documents intended usage and guards the symmetry invariant at `cargo test --doc` time.

Documentation-only change; no runtime code path is affected.

## Validation

- `cargo test -p dora-mavlink2-bridge --doc` — 1 passed.
- `cargo clippy -p dora-mavlink2-bridge -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbJBzWqUQmwFTy7gsmYmpg)_