### PR TITLE
fix(cli): compute dora topic info bandwidth over actual collection window

### DIFF
--- a/binaries/cli/src/command/topic/info.rs
+++ b/binaries/cli/src/command/topic/info.rs
@@ -193,6 +193,12 @@ fn info(
     .join()
     .map_err(|_| eyre::eyre!("stats collection thread panicked"))?;
 
+    // Use the actual collection time rather than the configured window: the
+    // loop breaks early when the publisher closes (`OutputClosed`), so dividing
+    // by the full `duration_secs` would under-report the bandwidth of a topic
+    // that stops mid-window.
+    let elapsed_secs = start_time.elapsed().as_secs_f64();
+
     // Display the information
     let message_count = *stats
         .message_count
@@ -240,14 +246,26 @@ fn info(
     // Statistics
     println!("Statistics:");
     println!("  Total messages: {}", message_count);
-    if duration_secs > 0 {
-        let bandwidth_mbps = (total_bytes as f64 * 8.0) / (duration_secs as f64 * 1_000_000.0);
-        println!("  Bandwidth: {:.2} Mbps", bandwidth_mbps);
-    } else {
-        println!("  Bandwidth: <unknown>");
+    match bandwidth_mbps(total_bytes, message_count, elapsed_secs) {
+        Some(mbps) => println!("  Bandwidth: {:.2} Mbps", mbps),
+        None => println!("  Bandwidth: <unknown>"),
     }
 
     Ok(())
+}
+
+/// Compute the average bandwidth in Mbps over the actual collection window.
+///
+/// Returns `None` when no messages were observed or the elapsed time is
+/// non-positive, so the caller can render `<unknown>` instead of a misleading
+/// `0.00` or a division-by-zero result.
+fn bandwidth_mbps(total_bytes: u64, message_count: u64, elapsed_secs: f64) -> Option<f64> {
+    // `elapsed_secs` comes from `Duration::as_secs_f64`, so it is finite and
+    // non-negative; `<= 0.0` only rejects a zero window.
+    if message_count == 0 || elapsed_secs <= 0.0 {
+        return None;
+    }
+    Some((total_bytes as f64 * 8.0) / (elapsed_secs * 1_000_000.0))
 }
 
 fn format_arrow_type(data_type: &DataType) -> String {
@@ -358,5 +376,20 @@ mod tests {
         // so a finite positive rate is returned instead of a panic.
         let hz = hz.expect("expected a frequency from two timestamps");
         assert!(hz.is_finite() && hz > 0.0, "unexpected hz: {hz}");
+    }
+
+    #[test]
+    fn bandwidth_uses_actual_elapsed_window() {
+        // 1_000_000 bytes over 1 s = 8 Mbps. A publisher that closed after 1 s
+        // of a 10 s window must report 8 Mbps (over the actual elapsed time),
+        // not 0.8 Mbps (over the full configured window).
+        let mbps = bandwidth_mbps(1_000_000, 5, 1.0).expect("some bandwidth");
+        assert!((mbps - 8.0).abs() < 1e-9, "expected 8 Mbps, got {mbps}");
+    }
+
+    #[test]
+    fn bandwidth_unknown_without_messages_or_time() {
+        assert_eq!(bandwidth_mbps(0, 0, 5.0), None, "no messages -> unknown");
+        assert_eq!(bandwidth_mbps(100, 1, 0.0), None, "no elapsed -> unknown");
     }
 }


### PR DESCRIPTION
> 🤖 This PR is **machine-generated by Claude** (automated repository review run). Please review carefully before merging.

## Issue

`dora topic info` (`binaries/cli/src/command/topic/info.rs`) collects stats in a thread that **breaks early** when the publisher closes (`InterDaemonEvent::OutputClosed => break`), but always divided the byte total by the full configured `--duration`:

```rust
let bandwidth_mbps = (total_bytes as f64 * 8.0) / (duration_secs as f64 * 1_000_000.0);
```

So a topic that stopped publishing partway through reported a bandwidth that was too low — e.g. ~10× low for a topic that closed after 1 s of a 10 s window. The trailing `else` branch was also dead: `duration` is parsed with `value_parser(range(1..))`, so `duration_secs > 0` is always true.

## Fix

Divide by the **actual** elapsed collection time (`start_time.elapsed()` captured after the thread joins), and extract the computation into a small pure `bandwidth_mbps` helper that returns `None` (rendered `<unknown>`) when no messages were observed or the window is zero. (The `hz` figure already uses inter-message intervals, so it was unaffected.)

## Validation

- New unit tests `bandwidth_uses_actual_elapsed_window` and `bandwidth_unknown_without_messages_or_time`.
- `cargo test -p dora-cli --lib bandwidth` — 2 passed.
- `cargo clippy -p dora-cli -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbJBzWqUQmwFTy7gsmYmpg)_