### PR TITLE
refactor(core): remove unused MANUAL_STOP topic constant

### DIFF
--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -11,8 +11,6 @@ pub const DORA_COORDINATOR_PORT_WS_DEFAULT: u16 = 6013;
 /// without multicast (dev containers, locked-down hosts, many CI runners).
 pub const DORA_ZENOH_CONNECT_ENV: &str = "DORA_ZENOH_CONNECT";
 
-pub const MANUAL_STOP: &str = "dora/stop";
-
 #[cfg(feature = "zenoh")]
 pub async fn open_zenoh_session(coordinator_addr: Option<IpAddr>) -> eyre::Result<zenoh::Session> {
     let (session, _) = open_zenoh_session_with_listen(coordinator_addr, None, None).await?;


### PR DESCRIPTION
> [!NOTE]
> **This PR was generated automatically by Claude (Anthropic's Claude Code agent).** It was opened via an automated integration, so it appears under the account owner's name — the actual author is Claude. Please review accordingly.

## What

Removes the unused `MANUAL_STOP` constant from `dora-core`'s topics module:

```rust
pub const MANUAL_STOP: &str = "dora/stop";
```

## Why

`MANUAL_STOP` (and its string value `"dora/stop"`) has **no references anywhere in the workspace** — not in any crate, example, test, or doc. Manual stop is implemented through the daemon's `trigger_manual_stop` / `send_stop_and_schedule_kill` code paths, which do not use this topic string. The constant is dead code.

This continues the ongoing dead-code cleanup effort (e.g. #2295 which removed the unused `WS_PING_INTERVAL` constant).

## Verification

- Confirmed zero references repo-wide (`grep -rn 'MANUAL_STOP\|dora/stop'` returns only the definition line).
- `cargo check -p dora-core` passes.
- `cargo fmt -p dora-core -- --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBPHjbS271WCrQrL3dJ97A)_