### PR TITLE
refactor(node-python): remove unused DORADMA header offset constants

### DIFF
--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -217,13 +217,6 @@ static RECV_CPU_SHMEM: LazyLock<std::sync::Mutex<HashMap<String, RecvCpuSlot>>> 
 const DORADMA_HEADER_SIZE: usize = 256;
 const DORADMA_MAGIC: &[u8; 8] = b"DORADMA\x00";
 const DORADMA_METADATA_ALIGN: usize = 256;
-// Header field offsets
-const OFF_MAGIC: usize = 0;
-const OFF_JSON_LEN: usize = 8;
-const OFF_DATA_OFF: usize = 16;
-const OFF_IPC_FLAG: usize = 24;
-const OFF_IPC_HANDLE: usize = 32;
-const OFF_WRITE_GEN: usize = 96;
 
 /// Get (or compile) the persistent CUDA DMA helper module.
 ///


### PR DESCRIPTION
> [!NOTE]
> **This PR was generated automatically by Claude (Anthropic's Claude Code agent).** It was opened via an automated integration, so it appears under the account owner's name — the actual author is Claude. Please review accordingly.

## What

Removes six unused constants from `apis/python/node/src/lib.rs`:

```rust
// Header field offsets
const OFF_MAGIC: usize = 0;
const OFF_JSON_LEN: usize = 8;
const OFF_DATA_OFF: usize = 16;
const OFF_IPC_FLAG: usize = 24;
const OFF_IPC_HANDLE: usize = 32;
const OFF_WRITE_GEN: usize = 96;
```

## Why

These were declared as named "header field offsets" for the DORADMA shared-memory layout, but **none of them is referenced anywhere**. The DORADMA read/write paths use `DORADMA_HEADER_SIZE`, `DORADMA_MAGIC`, and explicit offsets directly, so the named constants are dead code.

They are not flagged by CI because `dora-node-api-python` is excluded from the `-D warnings` clippy gate (it builds with maturin/PyO3). A local `cargo check -p dora-node-api-python` reports them as `dead_code` warnings.

The descriptive header-layout doc comment above the constants is **retained** — it documents the on-wire format, which is still in use.

## Verification

- `cargo check -p dora-node-api-python` passes; the `OFF_*` `dead_code` warnings are gone afterward.
- `cargo fmt -p dora-node-api-python -- --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBPHjbS271WCrQrL3dJ97A)_