### PR TITLE
refactor(node-python): remove never-read generation field from recv caches

### DIFF
--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -174,7 +174,6 @@ struct RecvGpuSlot {
     gpu_va: u64,    // device VA from cudaHostGetDevicePointer, 0 if IPC path
     gpu_buf: u64,   // IPC-opened GPU DRAM pointer, 0 if GPU VA path
     host_base: u64, // original host ptr passed to cudaHostRegister
-    generation: u64,
 }
 unsafe impl Send for RecvGpuSlot {}
 unsafe impl Sync for RecvGpuSlot {}
@@ -191,7 +190,6 @@ static RECV_GPU_VA: LazyLock<std::sync::Mutex<HashMap<String, RecvGpuSlot>>> =
 struct RecvCpuSlot {
     _shmem: shared_memory_extended::Shmem,
     base: u64,
-    generation: u64,
 }
 unsafe impl Send for RecvCpuSlot {}
 unsafe impl Sync for RecvCpuSlot {}
@@ -1869,7 +1867,6 @@ impl Node {
                             cpu_cache.entry(buffer_id.clone()).or_insert(RecvCpuSlot {
                                 _shmem: shmem,
                                 base,
-                                generation: 0,
                             });
                         }
                     }
@@ -2333,7 +2330,6 @@ impl Node {
                                 gpu_va: 0,
                                 gpu_buf: gpu_ptr,
                                 host_base: shmem_ptr as u64,
-                                generation: read_gen,
                             },
                         );
                         gpu_ptr
@@ -2370,7 +2366,6 @@ impl Node {
                                 gpu_va: va,
                                 gpu_buf: 0,
                                 host_base: shmem_ptr as u64,
-                                generation: read_gen,
                             },
                         );
                         va + data_offset as u64
@@ -2391,7 +2386,6 @@ impl Node {
                         RecvCpuSlot {
                             _shmem: shmem,
                             base,
-                            generation: read_gen,
                         },
                     );
                     base + data_offset as u64


### PR DESCRIPTION
> [!NOTE]
> **This PR was generated automatically by Claude (Anthropic's Claude Code agent).** It was opened via an automated integration, so it appears under the account owner's name — the actual author is Claude. Please review accordingly.

## What

Removes the `generation: u64` field from the receiver-side DORADMA caches `RecvGpuSlot` and `RecvCpuSlot` in `apis/python/node/src/lib.rs`, along with its four construction-site assignments.

## Why

The field is **written at every insertion site but never read** (`cargo check` reports `field 'generation' is never read` for both structs).

I checked that this is genuinely dead and not a latent seqlock bug:
- The DORADMA seqlock that protects against torn reads uses **fresh volatile reads** of the shared-memory header generation word — `read_gen` (pre-read) and `read_gen2` (post-read), compared directly. It does not consult the cached struct field.
- On cache hits the code returns the cached `gpu_va` / `gpu_buf` / `base` pointers, which the surrounding comments note are *stable across data overwrites*; the per-call seqlock still validates each read.

So the cached `generation` value plays no role in correctness. The seqlock logic and its explanatory comments are left untouched.

This is not flagged by CI because `dora-node-api-python` is excluded from the `-D warnings` clippy gate (it builds with maturin/PyO3).

## Verification

- `cargo check -p dora-node-api-python` passes; the two `field 'generation' is never read` warnings are gone.
- `cargo fmt -p dora-node-api-python -- --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBPHjbS271WCrQrL3dJ97A)_