### PR TITLE
fix(daemon): remove trailing newline from Indent log formatter

### DIFF
--- a/binaries/daemon/src/log.rs
+++ b/binaries/daemon/src/log.rs
@@ -532,8 +532,13 @@ struct Indent<'a>(&'a str);
 
 impl std::fmt::Display for Indent<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for line in self.0.lines() {
-            writeln!(f, "   {line}")?;
+        let mut lines = self.0.lines().peekable();
+        while let Some(line) = lines.next() {
+            if lines.peek().is_some() {
+                writeln!(f, "   {line}")?;
+            } else {
+                write!(f, "   {line}")?;
+            }
         }
         Ok(())
     }
@@ -700,13 +705,15 @@ mod tests {
     #[test]
     fn indent_preserves_newlines_between_lines() {
         let out = Indent("line1\nline2\nline3").to_string();
-        assert_eq!(out, "   line1\n   line2\n   line3\n");
+        // No trailing newline: tracing adds its own per-event newline.
+        assert_eq!(out, "   line1\n   line2\n   line3");
     }
 
     #[test]
-    fn indent_single_line_gets_newline() {
+    fn indent_single_line_no_trailing_newline() {
         let out = Indent("hello").to_string();
-        assert_eq!(out, "   hello\n");
+        // No trailing newline: tracing adds its own per-event newline.
+        assert_eq!(out, "   hello");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #2382.

PR #2336 fixed multi-line log message rendering by switching from `write!` to `writeln!` inside `Indent::fmt`. However `writeln!` also terminates the **last** line, and because the tracing formatter appends its own per-event `\n`, every log message ended with a spurious blank line.

### Root cause

```rust
// binaries/daemon/src/log.rs — before
impl std::fmt::Display for Indent<'_> {
    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
        for line in self.0.lines() {
            writeln!(f, "   {line}")?;  // trailing \n on every line, incl. last
        }
        Ok(())
    }
}
```

The tracing compact/full formatter terminates each event with its own `\n`, so a single-line message `"hello"` produced `"   hello\n\n"` — one blank line per log message.

### Fix

Use a `Peekable` iterator to distinguish the last line and call `write!` (no newline) instead of `writeln!` for it:

```rust
impl std::fmt::Display for Indent<'_> {
    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
        let mut lines = self.0.lines().peekable();
        while let Some(line) = lines.next() {
            if lines.peek().is_some() {
                writeln!(f, "   {line}")?;
            } else {
                write!(f, "   {line}")?;
            }
        }
        Ok(())
    }
}
```

Two unit tests are updated to assert the corrected (no-trailing-newline) output; `indent_single_line_gets_newline` is renamed to `indent_single_line_no_trailing_newline` to reflect the fix.

🤖 Generated with [Claude Code](https://claude.ai/code/session_011M2xjArXh256K9iuc3pPD9)

---
_Generated by [Claude Code](https://claude.ai/code/session_011M2xjArXh256K9iuc3pPD9)_