### PR TITLE
feat(memory-pool): auto-select pinned vs pageable DMA based on tensor size

### DIFF
--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -230,6 +230,12 @@ const OFF_IPC_FLAG: usize = 24;
 const OFF_IPC_HANDLE: usize = 32;
 const OFF_WRITE_GEN: usize = 96;
 
+/// Crossover where pinned-DMA bandwidth overtakes pageable copy +
+/// cudaHostRegister/unregister fixed cost (~100 µs).  Determined by
+/// ablation study (2026-06-27): pageable faster below, pinned faster
+/// above.  Shared by `register_memory_pool` and `write_memory_pool`.
+const DMA_PIN_THRESHOLD_BYTES: usize = 25 * 1024 * 1024;
+
 /// Get (or compile) the persistent CUDA DMA helper module.
 ///
 /// Compiled once at first use and reused across all subsequent iterations.
@@ -364,12 +370,15 @@ def _ipc_close(d_ptr):
 def dma_copy(ptr, size, slot, no_dma):
     """DMA transfer from host to pre-allocated GPU buffer.
 
-    Pins source memory, copies via cudaMemcpyHtoD (DMA engine),
-    then unpins. Returns the device pointer of the pooled GPU buffer.
-
-    When no_dma=True, the pin/unpin calls are skipped so the copy uses
+    Copies via cudaMemcpyHtoD (DMA engine).  When *no_dma* is false
+    (the default), the source memory is pinned (cudaHostRegister)
+    before the copy and unpinned after — this is the fast path for
+    large tensors where pinned-DMA bandwidth outweighs the pin/unpin
+    fixed cost.  When *no_dma* is true, pin/unpin is skipped, using
     pageable memory (faster for small tensors where pin overhead
-    dominates the DMA bandwidth advantage).
+    dominates).
+
+    Returns the device pointer of the pooled GPU buffer.
     """
     if not no_dma:
         _register_host(ptr, size)
@@ -1166,12 +1175,10 @@ impl Node {
         let is_cuda = tensor_device.starts_with("cuda");
         let receiver_is_cuda = device.starts_with("cuda");
         let cpu_mode = !receiver_is_cuda;
-        // Auto-select pinning strategy: for CPU→CUDA transfers, pin only
-        // when tensor > 25 MiB (where pinned DMA bandwidth outweighs the
-        // per-frame cudaHostRegister overhead).  Below 25 MiB, pageable
-        // cudaMemcpy is faster because pin/unpin fixed cost (~100 µs)
-        // dominates the transfer time.
-        let is_pinned = !cpu_mode && size > 25 * 1024 * 1024;
+        // Auto-select pinning: key off the source device — pinning only
+        // matters when the source is CPU (cudaHostRegister on device memory
+        // is a no-op).  Use the 25 MiB crossover from the ablation study.
+        let is_pinned = !is_cuda && size > DMA_PIN_THRESHOLD_BYTES;
         let pinned_type = if cpu_mode { "cpu" } else { "cuda" };
 
         if ptr_val == 0 {
@@ -1444,12 +1451,9 @@ impl Node {
             }
         }
 
-        // Auto-select pinning: for CPU→CUDA transfers, pin only when
-        // tensor > 25 MiB (matching the threshold in register_memory_pool).
-        // The sender-side is_cuda guards this: pinning only matters when the
-        // source is CPU (cudaHostRegister on CUDA memory is a no-op).
-        // Used by both fast-path (cache-miss) and slow-path below.
-        let auto_pin = !is_cuda && size > 25 * 1024 * 1024;
+        // Pin-decision guard shared by cache-miss PoolSlot construction and
+        // slow-path dma_copy (cache-hit reuses the slot's stored is_pinned).
+        let auto_pin = !is_cuda && size > DMA_PIN_THRESHOLD_BYTES;
 
         // Fast path: pool_ format -> DORADMA
         if buffer_id.starts_with("pool_") {

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -236,6 +236,60 @@ const OFF_WRITE_GEN: usize = 96;
 /// above.  Shared by `register_memory_pool` and `write_memory_pool`.
 const DMA_PIN_THRESHOLD_BYTES: usize = 25 * 1024 * 1024;
 
+/// Returns `true` when the source tensor should be pinned before DMA.
+///
+/// Pinning is a property of the *source* pointer: `cudaHostRegister` only
+/// makes sense for host (CPU) memory, and the pin/unpin fixed cost
+/// (~100 µs) is only worth paying when the tensor is large enough that
+/// the DMA bandwidth gain outweighs it.
+///
+/// # Unit-testable
+///
+/// The decision is pure integer logic — no CUDA runtime calls — so the
+/// boundary (25 MiB ± 1 byte) can be exercised in CI even without a GPU.
+#[inline]
+const fn should_pin(is_cuda: bool, size: usize) -> bool {
+    !is_cuda && size > DMA_PIN_THRESHOLD_BYTES
+}
+
+#[cfg(test)]
+mod pin_tests {
+    use super::*;
+
+    #[test]
+    fn pin_cpu_source_above_threshold() {
+        // CPU source, 25 MiB + 1 byte → should pin
+        assert!(should_pin(false, 25 * 1024 * 1024 + 1));
+        // CPU source, 100 MiB → should pin
+        assert!(should_pin(false, 100 * 1024 * 1024));
+    }
+
+    #[test]
+    fn pin_cpu_source_below_threshold() {
+        // CPU source, exactly at threshold → should NOT pin (> not >=)
+        assert!(!should_pin(false, 25 * 1024 * 1024));
+        // CPU source, 1 byte below → should NOT pin
+        assert!(!should_pin(false, 25 * 1024 * 1024 - 1));
+        // CPU source, tiny → should NOT pin
+        assert!(!should_pin(false, 1));
+    }
+
+    #[test]
+    fn pin_cuda_source_never_pins() {
+        // CUDA source regardless of size → never pin
+        assert!(!should_pin(true, 0));
+        assert!(!should_pin(true, 25 * 1024 * 1024));
+        assert!(!should_pin(true, 100 * 1024 * 1024));
+        assert!(!should_pin(true, 1024 * 1024 * 1024));
+    }
+
+    #[test]
+    fn pin_zero_size_cpu() {
+        // Zero-size CPU tensor → below threshold, don't pin
+        assert!(!should_pin(false, 0));
+    }
+}
+
 /// Get (or compile) the persistent CUDA DMA helper module.
 ///
 /// Compiled once at first use and reused across all subsequent iterations.
@@ -1178,7 +1232,7 @@ impl Node {
         // Auto-select pinning: key off the source device — pinning only
         // matters when the source is CPU (cudaHostRegister would raise on a
         // device pointer; prevented by the !is_cuda guard above).
-        let is_pinned = !is_cuda && size > DMA_PIN_THRESHOLD_BYTES;
+        let is_pinned = should_pin(is_cuda, size);
         let pinned_type = if cpu_mode { "cpu" } else { "cuda" };
 
         if ptr_val == 0 {
@@ -1453,7 +1507,7 @@ impl Node {
 
         // Pin-decision guard shared by cache-miss PoolSlot construction and
         // slow-path dma_copy (cache-hit reuses the slot's stored is_pinned).
-        let auto_pin = !is_cuda && size > DMA_PIN_THRESHOLD_BYTES;
+        let auto_pin = should_pin(is_cuda, size);
 
         // Fast path: pool_ format -> DORADMA
         if buffer_id.starts_with("pool_") {

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -161,8 +161,6 @@ struct PoolSlot {
     /// tensor size: true for >25 MiB (where pinned bandwidth wins),
     /// false for smaller (where pin overhead dominates DMA gain).
     is_pinned: bool,
-    /// "cpu" or "cuda" — the receiver device type.
-    pinned_type: String,
 }
 
 unsafe impl Send for PoolSlot {}
@@ -1326,7 +1324,6 @@ impl Node {
                     base: shmem_ptr as u64,
                     size: total_size,
                     is_pinned,
-                    pinned_type: pinned_type.to_string(),
                 },
             );
         }
@@ -1489,7 +1486,6 @@ impl Node {
                                     base,
                                     size: cap,
                                     is_pinned: false,
-                                    pinned_type: "cuda".to_string(),
                                 };
                                 (base as *mut u8, cap, Some(slot), false)
                             }

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -1176,8 +1176,8 @@ impl Node {
         let receiver_is_cuda = device.starts_with("cuda");
         let cpu_mode = !receiver_is_cuda;
         // Auto-select pinning: key off the source device — pinning only
-        // matters when the source is CPU (cudaHostRegister on device memory
-        // is a no-op).  Use the 25 MiB crossover from the ablation study.
+        // matters when the source is CPU (cudaHostRegister would raise on a
+        // device pointer; prevented by the !is_cuda guard above).
         let is_pinned = !is_cuda && size > DMA_PIN_THRESHOLD_BYTES;
         let pinned_type = if cpu_mode { "cpu" } else { "cuda" };
 

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -1444,6 +1444,13 @@ impl Node {
             }
         }
 
+        // Auto-select pinning: for CPU→CUDA transfers, pin only when
+        // tensor > 25 MiB (matching the threshold in register_memory_pool).
+        // The sender-side is_cuda guards this: pinning only matters when the
+        // source is CPU (cudaHostRegister on CUDA memory is a no-op).
+        // Used by both fast-path (cache-miss) and slow-path below.
+        let auto_pin = !is_cuda && size > 25 * 1024 * 1024;
+
         // Fast path: pool_ format -> DORADMA
         if buffer_id.starts_with("pool_") {
             // Extract counter from the last underscore segment — node_id
@@ -1485,9 +1492,9 @@ impl Node {
                                     _shmem: shmem,
                                     base,
                                     size: cap,
-                                    is_pinned: false,
+                                    is_pinned: auto_pin,
                                 };
-                                (base as *mut u8, cap, Some(slot), false)
+                                (base as *mut u8, cap, Some(slot), auto_pin)
                             }
                             Err(_) => (std::ptr::null_mut(), 0, None, false),
                         }
@@ -1674,12 +1681,16 @@ impl Node {
                                 std::ptr::write_volatile(gen_ptr, old_gen + 1);
                                 std::sync::atomic::fence(std::sync::atomic::Ordering::Release);
                             }
-                            // Slow path: default to pinned DMA (no_dma=false).
-                            // The fast path is the primary code path; the slow
-                            // path is a rare daemon-mediated fallback.
+                            // Slow path: daemon-mediated fallback (rare).
+                            // Respect the same 25 MiB auto-pin threshold as the
+                            // fast path and register_memory_pool.  no_dma=true
+                            // skips cudaHostRegister for small pageable tensors
+                            // where pin overhead dominates DMA gain.
+                            let slow_no_dma = !auto_pin;
                             if let (Ok(helpers), Some(c)) = (get_cuda_helpers(py), slow_counter) {
                                 let bound = helpers.bind(py);
-                                let _ = bound.call_method1("dma_copy", (ptr_val, size, c, false));
+                                let _ =
+                                    bound.call_method1("dma_copy", (ptr_val, size, c, slow_no_dma));
                             }
                             // Seqlock: end write
                             unsafe {

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -156,6 +156,13 @@ struct PoolSlot {
     _shmem: shared_memory_extended::Shmem,
     base: u64,
     size: usize,
+    /// Whether the source tensor should be pinned (cudaHostRegister)
+    /// before DMA transfer.  Auto-set in register_memory_pool based on
+    /// tensor size: true for >25 MiB (where pinned bandwidth wins),
+    /// false for smaller (where pin overhead dominates DMA gain).
+    is_pinned: bool,
+    /// "cpu" or "cuda" — the receiver device type.
+    pinned_type: String,
 }
 
 unsafe impl Send for PoolSlot {}
@@ -356,13 +363,18 @@ def _ipc_close(d_ptr):
     if err != 0:
         raise RuntimeError(f'cudaIpcCloseMemHandle(0x{d_ptr:x}) failed: {err}')
 
-def dma_copy(ptr, size, slot):
+def dma_copy(ptr, size, slot, no_dma):
     """DMA transfer from host to pre-allocated GPU buffer.
 
     Pins source memory, copies via cudaMemcpyHtoD (DMA engine),
     then unpins. Returns the device pointer of the pooled GPU buffer.
+
+    When no_dma=True, the pin/unpin calls are skipped so the copy uses
+    pageable memory (faster for small tensors where pin overhead
+    dominates the DMA bandwidth advantage).
     """
-    _register_host(ptr, size)
+    if not no_dma:
+        _register_host(ptr, size)
     try:
         d_ptr = _get_gpu_buf(slot, size)
         err = _lib.cudaMemcpy(
@@ -375,7 +387,8 @@ def dma_copy(ptr, size, slot):
             raise RuntimeError(f'cudaMemcpy failed: {err}')
         _lib.cudaDeviceSynchronize()
     finally:
-        _unregister_host(ptr)
+        if not no_dma:
+            _unregister_host(ptr)
     return d_ptr
 
 "#;
@@ -1155,6 +1168,13 @@ impl Node {
         let is_cuda = tensor_device.starts_with("cuda");
         let receiver_is_cuda = device.starts_with("cuda");
         let cpu_mode = !receiver_is_cuda;
+        // Auto-select pinning strategy: for CPU→CUDA transfers, pin only
+        // when tensor > 25 MiB (where pinned DMA bandwidth outweighs the
+        // per-frame cudaHostRegister overhead).  Below 25 MiB, pageable
+        // cudaMemcpy is faster because pin/unpin fixed cost (~100 µs)
+        // dominates the transfer time.
+        let is_pinned = !cpu_mode && size > 25 * 1024 * 1024;
+        let pinned_type = if cpu_mode { "cpu" } else { "cuda" };
 
         if ptr_val == 0 {
             eyre::bail!("Invalid source pointer (NULL)");
@@ -1184,7 +1204,7 @@ impl Node {
         header_meta.set_item("size", size)?;
         header_meta.set_item("dtype", &dtype)?;
         header_meta.set_item("shape", shape_list.clone())?;
-        header_meta.set_item("pinned_type", if cpu_mode { "cpu" } else { "cuda" })?;
+        header_meta.set_item("pinned_type", pinned_type)?;
 
         let json_bytes = py
             .import("json")
@@ -1272,7 +1292,7 @@ impl Node {
         if receiver_is_cuda && let Ok(helpers) = get_cuda_helpers(py) {
             let bound = helpers.bind(py);
             if let Ok(gpu_ptr) = bound
-                .call_method1("dma_copy", (ptr_val, size, pool_counter))
+                .call_method1("dma_copy", (ptr_val, size, pool_counter, !is_pinned))
                 .and_then(|r| r.extract::<u64>())
                 && let Ok(handle) = bound
                     .call_method1("_ipc_export", (gpu_ptr,))
@@ -1305,6 +1325,8 @@ impl Node {
                     _shmem: shmem,
                     base: shmem_ptr as u64,
                     size: total_size,
+                    is_pinned,
+                    pinned_type: pinned_type.to_string(),
                 },
             );
         }
@@ -1336,15 +1358,11 @@ impl Node {
             );
             params.insert(
                 "is_pinned".to_string(),
-                dora_node_api::Parameter::Bool(true),
+                dora_node_api::Parameter::Bool(is_pinned),
             );
             params.insert(
                 "pinned_type".to_string(),
-                dora_node_api::Parameter::String(if cpu_mode {
-                    "cpu".to_string()
-                } else {
-                    "cuda".to_string()
-                }),
+                dora_node_api::Parameter::String(pinned_type.to_string()),
             );
             params.insert(
                 "buffer_id".to_string(),
@@ -1449,31 +1467,35 @@ impl Node {
                 // Both cache-hit and cache-miss produce a PoolSlot that is
                 // stored back into PINNED_POOL after the write — this keeps
                 // the shmem mapping alive for the duration of the data copy.
-                let (shmem_ptr, shmem_capacity, store_back) = if let Some(slot_data) = pool_slot {
-                    // Cache hit: reuse the persistent mapping (no mmap)
-                    let cap = slot_data.size;
-                    (slot_data.base as *mut u8, cap, Some(slot_data))
-                } else {
-                    // Cache miss: open via ShmemConf, wrap immediately
-                    // so the mapping stays alive until post-write re-insert.
-                    let shmem_name = format!(
-                        "dora_pool_{}_{}_{}",
-                        self.dataflow_id, self.node_id, counter
-                    );
-                    match ShmemConf::new().os_id(&shmem_name).open() {
-                        Ok(shmem) => {
-                            let cap = shmem.len();
-                            let base = shmem.as_ptr() as u64;
-                            let slot = PoolSlot {
-                                _shmem: shmem,
-                                base,
-                                size: cap,
-                            };
-                            (base as *mut u8, cap, Some(slot))
+                let (shmem_ptr, shmem_capacity, store_back, is_pinned) =
+                    if let Some(slot_data) = pool_slot {
+                        // Cache hit: reuse the persistent mapping (no mmap)
+                        let cap = slot_data.size;
+                        let pinned = slot_data.is_pinned;
+                        (slot_data.base as *mut u8, cap, Some(slot_data), pinned)
+                    } else {
+                        // Cache miss: open via ShmemConf, wrap immediately
+                        // so the mapping stays alive until post-write re-insert.
+                        let shmem_name = format!(
+                            "dora_pool_{}_{}_{}",
+                            self.dataflow_id, self.node_id, counter
+                        );
+                        match ShmemConf::new().os_id(&shmem_name).open() {
+                            Ok(shmem) => {
+                                let cap = shmem.len();
+                                let base = shmem.as_ptr() as u64;
+                                let slot = PoolSlot {
+                                    _shmem: shmem,
+                                    base,
+                                    size: cap,
+                                    is_pinned: false,
+                                    pinned_type: "cuda".to_string(),
+                                };
+                                (base as *mut u8, cap, Some(slot), false)
+                            }
+                            Err(_) => (std::ptr::null_mut(), 0, None, false),
                         }
-                        Err(_) => (std::ptr::null_mut(), 0, None),
-                    }
-                };
+                    };
 
                 if !shmem_ptr.is_null() {
                     // Guard against truncated segments before any
@@ -1522,10 +1544,14 @@ impl Node {
                                 std::ptr::write_volatile(gen_ptr, old_gen + 1);
                                 std::sync::atomic::fence(std::sync::atomic::Ordering::Release);
                             }
-                            // DMA: source CPU data -> GPU pool buffer via DMA engine
+                            // DMA: source CPU data -> GPU pool buffer via DMA engine.
+                            // When is_pinned=false, dma_copy skips cudaHostRegister/
+                            // cudaHostUnregister — pageable cudaMemcpy is faster for
+                            // small tensors where pin overhead dominates.
                             if let Ok(helpers) = get_cuda_helpers(py) {
                                 let bound = helpers.bind(py);
-                                let _ = bound.call_method1("dma_copy", (ptr_val, size, counter));
+                                let _ = bound
+                                    .call_method1("dma_copy", (ptr_val, size, counter, !is_pinned));
                             }
                             // Seqlock: end write
                             unsafe {
@@ -1652,9 +1678,12 @@ impl Node {
                                 std::ptr::write_volatile(gen_ptr, old_gen + 1);
                                 std::sync::atomic::fence(std::sync::atomic::Ordering::Release);
                             }
+                            // Slow path: default to pinned DMA (no_dma=false).
+                            // The fast path is the primary code path; the slow
+                            // path is a rare daemon-mediated fallback.
                             if let (Ok(helpers), Some(c)) = (get_cuda_helpers(py), slow_counter) {
                                 let bound = helpers.bind(py);
-                                let _ = bound.call_method1("dma_copy", (ptr_val, size, c));
+                                let _ = bound.call_method1("dma_copy", (ptr_val, size, c, false));
                             }
                             // Seqlock: end write
                             unsafe {


### PR DESCRIPTION
register_memory_pool now sets is_pinned based on a 25 MiB threshold:
- >25 MiB: pinned DMA (bandwidth advantage outweighs pin overhead)
- <25 MiB: pageable DMA (pin/unpin fixed cost dominates)

PoolSlot stores is_pinned so write_memory_pool fast path reads it directly from the local cache (no env var, no daemon query).

Inline Python dma_copy accepts no_dma parameter: when true, skips cudaHostRegister/cudaHostUnregister — cudaMemcpy uses pageable source.

Ablation finding: crossover at ~25 MiB where pinned DMA bandwidth overtakes pageable + pin overhead.