### PR TITLE
fix(message): reject invalid ids in user input mappings instead of panicking

### DIFF
--- a/libraries/message/src/config.rs
+++ b/libraries/message/src/config.rs
@@ -320,10 +320,16 @@ impl FromStr for InputMapping {
                 }),
                 None => return Err("dora input has invalid format".into()),
             },
-            _ => Self::User(UserInputMapping {
-                source: source.to_owned().into(),
-                output: output.to_owned().into(),
-            }),
+            _ => {
+                // Validate the source/output segments instead of using the
+                // panicking `From<String>` impls (`.into()`): an input mapping
+                // string comes straight from user-authored descriptor YAML, so an
+                // invalid identifier (e.g. containing a space) must surface as a
+                // clean deserialization error rather than panicking the parser.
+                let source = source.parse::<NodeId>().map_err(|e| e.to_string())?;
+                let output = output.parse::<DataId>().map_err(|e| e.to_string())?;
+                Self::User(UserInputMapping { source, output })
+            }
         };
 
         Ok(mapping)
@@ -621,6 +627,23 @@ mod tests {
         let input: Input = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(input.queue_size, Some(5));
         assert_eq!(input.queue_policy, None);
+    }
+
+    #[test]
+    fn parse_user_mapping_rejects_invalid_ids() {
+        // A source node id with a space is not a valid `NodeId` and must be
+        // rejected with a clean error rather than panicking the parser via the
+        // `From<String>` impl.
+        let result: Result<InputMapping, _> = "bad node/output".parse();
+        assert!(result.is_err(), "invalid source node id must be rejected");
+
+        // An output data id with an invalid character must likewise be rejected.
+        let result: Result<InputMapping, _> = "node_a/bad output".parse();
+        assert!(result.is_err(), "invalid output data id must be rejected");
+
+        // A valid mapping still parses successfully.
+        let mapping: InputMapping = "node_a/output_1".parse().unwrap();
+        assert!(matches!(mapping, InputMapping::User(_)));
     }
 
     #[test]


### PR DESCRIPTION
## Issue

`InputMapping::from_str` (`libraries/message/src/config.rs`) builds the `User` variant's source `NodeId` and output `DataId` with `.into()`:

```rust
_ => Self::User(UserInputMapping {
    source: source.to_owned().into(),
    output: output.to_owned().into(),
}),
```

`From<String> for NodeId` / `From<String> for DataId` are documented as **panicking** on invalid identifiers (they call `validate_*_id` and `panic!` on failure). Input mappings are parsed straight from user-authored descriptor YAML — `InputMapping::deserialize` calls `string.parse()` — so a descriptor input like:

```yaml
inputs:
  x: "bad node/output"   # space is not allowed in a NodeId
```

aborts descriptor parsing with a **panic** instead of returning a clean deserialization error.

## Fix

Validate the segments with the fallible `str::parse::<NodeId>()` / `parse::<DataId>()` and map the error into `FromStr`'s existing `String` error type:

```rust
let source = source.parse::<NodeId>().map_err(|e| e.to_string())?;
let output = output.parse::<DataId>().map_err(|e| e.to_string())?;
Self::User(UserInputMapping { source, output })
```

This mirrors how the open PR #2373 hardens the sibling `dora/logs` node-filter branch; that PR fixes line ~298 (the `Logs` branch), this one fixes the distinct `User` branch (line ~323) which previously *panicked* rather than silently mis-parsing.

## Validation

- Added regression test `parse_user_mapping_rejects_invalid_ids`. Verified it **panics** against the pre-fix code and **passes** with the fix.
- `cargo fmt --all -- --check`, `cargo clippy -p dora-message -- -D warnings`, `cargo test -p dora-message` (116 + 5 + 1 doctest, all green).

---

🤖 This is a machine-generated PR authored by Claude (Claude Code). Please review carefully before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A43PRFZVJLmyW77ZMdYcXd)_