### PR TITLE
perf(daemon): skip per-message key clone for empty deadline/circuit-breaker maps

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -5136,16 +5136,22 @@ async fn send_output_to_local_receivers(
             }) {
                 Ok(()) => {
                     dataflow.inc_pending(receiver_id);
-                    if let Some(deadline) = dataflow
-                        .input_deadlines
-                        .get_mut(&(receiver_id.clone(), input_id.clone()))
+                    // Looking up these maps requires cloning the `(NodeId, DataId)`
+                    // key (the tuple key type can't borrow). Both maps are empty
+                    // unless input deadlines or circuit breakers are configured, so
+                    // skip the per-message key clone + hash in the common case.
+                    if !dataflow.input_deadlines.is_empty()
+                        && let Some(deadline) = dataflow
+                            .input_deadlines
+                            .get_mut(&(receiver_id.clone(), input_id.clone()))
                     {
                         deadline.last_received = Some(Instant::now());
                     }
                     // Circuit breaker recovery: re-open broken input
-                    if let Some(timeout) = dataflow
-                        .broken_inputs
-                        .remove(&(receiver_id.clone(), input_id.clone()))
+                    if !dataflow.broken_inputs.is_empty()
+                        && let Some(timeout) = dataflow
+                            .broken_inputs
+                            .remove(&(receiver_id.clone(), input_id.clone()))
                     {
                         tracing::info!(
                             "input `{receiver_id}/{input_id}` recovered, \


### PR DESCRIPTION
## Issue

`send_output_to_local_receivers` (`binaries/daemon/src/lib.rs`) runs on the per-message local delivery path. On every successfully delivered message it performs two map lookups:

```rust
if let Some(deadline) = dataflow
    .input_deadlines
    .get_mut(&(receiver_id.clone(), input_id.clone()))
{ ... }

if let Some(timeout) = dataflow
    .broken_inputs
    .remove(&(receiver_id.clone(), input_id.clone()))
{ ... }
```

Both maps are keyed by `(NodeId, DataId)` — a tuple key that cannot be borrowed for lookup — so each probe **clones both `String` ids** to build the key, hashes it, and (in the common case) finds nothing.

`input_deadlines` is only populated when an input declares a `deadline`, and `broken_inputs` is only populated after a circuit breaker trips. For the common dataflow that configures neither, these clones+hashes are pure per-message overhead.

## Fix

Guard each lookup with `is_empty()` so the key clone and hash are skipped when the map is empty:

```rust
if !dataflow.input_deadlines.is_empty()
    && let Some(deadline) = dataflow.input_deadlines.get_mut(&(receiver_id.clone(), input_id.clone()))
{ ... }
```

This is behavior-preserving — a lookup into an empty map always returns `None` — and adds only a cheap length check when the maps *are* in use.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p dora-daemon -- -D warnings` (clean)
- `cargo test -p dora-daemon` (85 passed, 0 failed)

---

🤖 This is a machine-generated PR authored by Claude (Claude Code). Please review carefully before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A43PRFZVJLmyW77ZMdYcXd)_