### PR TITLE
fix(cli): avoid Instant underflow panic in `dora topic info` hz calc

### DIFF
--- a/binaries/cli/src/command/topic/info.rs
+++ b/binaries/cli/src/command/topic/info.rs
@@ -87,12 +87,20 @@ impl TopicStats {
         }
 
         let now = Instant::now();
-        let cutoff = now - window;
-        let recent: Vec<_> = timestamps
-            .iter()
-            .filter(|&&t| t >= cutoff)
-            .copied()
-            .collect();
+        // `now - window` would panic ("overflow when subtracting duration from
+        // instant") when `window` exceeds the monotonic clock value -- reachable
+        // via a large `--duration` (the flag accepts any `u64`) when the topic
+        // closes early, so the full window never elapses before this runs. When
+        // the cutoff predates the monotonic epoch, every recorded timestamp is
+        // within the window, so keep them all.
+        let recent: Vec<_> = match now.checked_sub(window) {
+            Some(cutoff) => timestamps
+                .iter()
+                .filter(|&&t| t >= cutoff)
+                .copied()
+                .collect(),
+            None => timestamps.iter().copied().collect(),
+        };
 
         if recent.len() < 2 {
             return None;
@@ -324,5 +332,31 @@ fn format_arrow_type(data_type: &DataType) -> String {
             )
         }
         _ => format!("{:?}", data_type),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn calculate_hz_does_not_panic_on_oversized_window() {
+        // Regression: a large `--duration` (the flag accepts any u64) made
+        // `now - window` underflow the monotonic clock and panic with
+        // "overflow when subtracting duration from instant". This is reachable
+        // when the topic closes early so the full window never elapses.
+        let stats = TopicStats::default();
+        let now = Instant::now();
+        {
+            let mut ts = stats.timestamps.lock().unwrap();
+            ts.push(now);
+            ts.push(now + Duration::from_millis(100));
+        }
+        // A window far larger than any plausible monotonic-clock value.
+        let hz = stats.calculate_hz(Duration::from_secs(u64::MAX));
+        // With the cutoff before the monotonic epoch, every timestamp counts,
+        // so a finite positive rate is returned instead of a panic.
+        let hz = hz.expect("expected a frequency from two timestamps");
+        assert!(hz.is_finite() && hz > 0.0, "unexpected hz: {hz}");
     }
 }


### PR DESCRIPTION
> 🤖 This PR is machine-generated by Claude (automated repository review run). Please review before merging.

## Issue

`TopicStats::calculate_hz` in `binaries/cli/src/command/topic/info.rs` computed the window cutoff as:

```rust
let now = Instant::now();
let cutoff = now - window;
```

`Instant - Duration` panics (`"overflow when subtracting duration from instant"`) when `window` exceeds the monotonic-clock value. This is reachable from user input:

- The `--duration` flag is `#[clap(... value_parser = clap::value_parser!(u64).range(1..))]`, so it accepts any `u64` up to `u64::MAX` seconds.
- The collection thread breaks early on `OutputClosed`/`Disconnected` (a node that emits a few outputs then stops), so the full window need **not** elapse before `calculate_hz` runs.

So `dora topic info <topic> --duration <very-large>` against a topic that closes early reaches `now - Duration::from_secs(very_large)` and crashes the command instead of printing stats. (A sufficiently large value such as near `u64::MAX` overflows the `Instant` arithmetic on any machine; smaller-but-large values reach it on a freshly-booted machine where uptime is below the window.)

## Fix

Guard the subtraction with `Instant::checked_sub`. When the cutoff would predate the monotonic epoch, every recorded timestamp is necessarily within the window, so all are kept:

```rust
let recent: Vec<_> = match now.checked_sub(window) {
    Some(cutoff) => timestamps.iter().filter(|&&t| t >= cutoff).copied().collect(),
    None => timestamps.iter().copied().collect(),
};
```

## Validation

- New regression test `calculate_hz_does_not_panic_on_oversized_window` (records two timestamps, calls `calculate_hz(Duration::from_secs(u64::MAX))`, asserts a finite positive rate instead of a panic). It panics on `main`, passes here.
- `cargo test -p dora-cli --lib` (passes), `cargo clippy -p dora-cli -- -D warnings`, `cargo fmt --all -- --check` all green. Full workspace fmt/clippy/test run on the combined review diff.

---
_Generated by Claude Code. Machine-generated; please review before merging._

---
_Generated by [Claude Code](https://claude.ai/code/session_013E9DFdCzXco92HGKE7UcBr)_