### PR TITLE
docs(coordinator): fix misplaced/incorrect MAX_PENDING_REPLIES doc

### DIFF
--- a/binaries/coordinator/src/state.rs
+++ b/binaries/coordinator/src/state.rs
@@ -121,17 +121,17 @@ impl DaemonConnection {
         }
     }
 
+    /// Maximum number of in-flight requests per daemon WebSocket connection.
+    ///
+    /// `pending_replies` is an `Arc<Mutex<_>>` shared by every
+    /// `DaemonConnection` clone, so this cap is enforced globally across all
+    /// clones of one connection rather than independently per clone.
+    const MAX_PENDING_REPLIES: usize = 256;
+
     /// Send a message to the daemon and wait for a reply.
     ///
     /// Embeds raw JSON bytes directly to preserve u128 fidelity
     /// for uhlc::ID inside timestamps.
-    /// Maximum number of in-flight requests per `DaemonConnection` clone.
-    ///
-    /// `DaemonConnection` is cloneable and each clone keeps an independent
-    /// pending-reply map, so this cap is enforced per clone rather than
-    /// globally per WebSocket connection.
-    const MAX_PENDING_REPLIES: usize = 256;
-
     pub(crate) async fn send_and_receive(&self, message: &[u8]) -> eyre::Result<Vec<u8>> {
         let id = Uuid::new_v4();
         let params_str =


### PR DESCRIPTION
> 🤖 This PR is machine-generated by Claude (automated repository review run). Please review before merging.

## Issue

In `binaries/coordinator/src/state.rs`, the doc block above `const MAX_PENDING_REPLIES` had two problems:

```rust
/// Send a message to the daemon and wait for a reply.
///
/// Embeds raw JSON bytes directly to preserve u128 fidelity
/// for uhlc::ID inside timestamps.
/// Maximum number of in-flight requests per `DaemonConnection` clone.
///
/// `DaemonConnection` is cloneable and each clone keeps an independent
/// pending-reply map, so this cap is enforced per clone rather than
/// globally per WebSocket connection.
const MAX_PENDING_REPLIES: usize = 256;

pub(crate) async fn send_and_receive(&self, message: &[u8]) -> eyre::Result<Vec<u8>> {
```

1. **Misattributed method doc.** The first two sentences ("Send a message to the daemon and wait for a reply" / "Embeds raw JSON bytes…") describe `send_and_receive`, but they are attached to the `MAX_PENDING_REPLIES` const that sits between them and the method.
2. **Factually wrong concurrency claim.** It states "each clone keeps an independent pending-reply map, so this cap is enforced per clone". But `pending_replies` is an `Arc<Mutex<HashMap<…>>>` (line 94) that is **shared** by every `DaemonConnection` clone, so the cap is enforced *globally across a connection's clones*, not independently per clone. The cap check at `send_and_receive` operates on that shared map.

## Fix

Move the method doc back onto `send_and_receive`, and rewrite the const's doc to describe the actual shared-`Arc` semantics. Documentation only; no behavior change.

## Validation

- `cargo clippy -p dora-coordinator -- -D warnings`, `cargo fmt --all -- --check` green. Full workspace suite run on the combined review diff.

---
_Generated by Claude Code. Machine-generated; please review before merging._

---
_Generated by [Claude Code](https://claude.ai/code/session_013E9DFdCzXco92HGKE7UcBr)_