### PR TITLE
docs(core): document `source_is_url` with a compile-checked doctest

### DIFF
--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -342,6 +342,26 @@ fn node_kind_mut(node: &mut Node) -> eyre::Result<NodeKindMut<'_>> {
     }
 }
 
+/// Returns `true` if `source` is an `http://` or `https://` URL.
+///
+/// This is the trust boundary that decides whether a node `path` is fetched as
+/// a remote download (and, for hub artifacts, checksum-verified) versus
+/// resolved as a local filesystem path. The match is on the literal scheme
+/// prefix and is **case-sensitive**: an upper-cased scheme such as `HTTPS://`
+/// is treated as a path, not a URL. Schemes other than HTTP(S) (e.g. `ftp://`,
+/// `s3://`, `file://`) are likewise not considered URLs here.
+///
+/// ```
+/// use dora_core::descriptor::source_is_url;
+///
+/// assert!(source_is_url("https://example.com/node"));
+/// assert!(source_is_url("http://example.com/node"));
+///
+/// assert!(!source_is_url("./build/my_node"));
+/// assert!(!source_is_url("/usr/bin/my_node"));
+/// assert!(!source_is_url("s3://bucket/key"));
+/// assert!(!source_is_url("HTTPS://example.com/node")); // case-sensitive
+/// ```
 pub fn source_is_url(source: &str) -> bool {
     source.starts_with("https://") || source.starts_with("http://")
 }


### PR DESCRIPTION
> 🤖 This PR is machine-generated by Claude (automated repository review run). Please review before merging.

## Issue

`dora_core::descriptor::source_is_url` is a `pub` function used across the daemon, runtime, and CLI (`binaries/daemon/src/spawn/command.rs`, `binaries/runtime/src/operator/*`, `binaries/cli/src/common.rs`, and within `dora-core` itself). It is the trust boundary that decides whether a node `path` is fetched as a remote download — and, for hub artifacts, checksum-verified — versus resolved as a local filesystem path:

```rust
pub fn source_is_url(source: &str) -> bool {
    source.starts_with("https://") || source.starts_with("http://")
}
```

Despite gating security-relevant behavior, it had no doc comment. Two of its properties are easy to overlook: the match is **case-sensitive** (so `HTTPS://…` is treated as a local path, not a URL), and only HTTP(S) counts (not `s3://`, `file://`, etc.).

## Fix

Add a doc comment plus a **compile-checked doctest** that pins the accepted schemes and the case-sensitivity. Documentation only; no behavior change.

```rust
/// use dora_core::descriptor::source_is_url;
/// assert!(source_is_url("https://example.com/node"));
/// assert!(!source_is_url("s3://bucket/key"));
/// assert!(!source_is_url("HTTPS://example.com/node")); // case-sensitive
```

## Validation

- `cargo test -p dora-core --doc source_is_url` passes (doctest compiles and runs).
- `cargo clippy -p dora-core -- -D warnings`, `cargo fmt --all -- --check` green. Full workspace suite run on the combined review diff.

---
_Generated by Claude Code. Machine-generated; please review before merging._

---
_Generated by [Claude Code](https://claude.ai/code/session_013E9DFdCzXco92HGKE7UcBr)_