### PR TITLE
refactor(operator-c): remove unused HEADER_OPERATOR_API/HEADER_OPERATOR_TYPES consts

### DIFF
--- a/apis/c/operator/src/lib.rs
+++ b/apis/c/operator/src/lib.rs
@@ -1,4 +1,1 @@
-pub const HEADER_OPERATOR_API: &str = include_str!("../operator_api.h");
-pub const HEADER_OPERATOR_TYPES: &str = include_str!("../operator_types.h");
-
 pub use dora_operator_api_types;


### PR DESCRIPTION
> 🤖 **Auto-generated by Claude.** This PR was created by an automated dead-code sweep run via Claude Code. It is opened under the maintainer's GitHub account only because the automation authenticates with that token — the change itself was written by Claude, not by the account owner. Please review before merging.

## What

Removes two unused `pub const`s from `dora-operator-api-c` (`apis/c/operator/src/lib.rs`):

- `HEADER_OPERATOR_API` — `include_str!("../operator_api.h")`
- `HEADER_OPERATOR_TYPES` — `include_str!("../operator_types.h")`

## Why

Both embed the crate's C header files as Rust string constants, but **nothing in the workspace reads either one** (`grep` for both identifiers across the repo returns only their definitions).

`dora-operator-api-c` is consumed only as a **staticlib** (for linking C operators) and via its **on-disk header files** — `build.rs` copies `operator_api.h` / `operator_types.h`, and the CLI's C/C++ templates `#include` them by path. No Rust code imports `dora_operator_api_c::HEADER_*`.

Contrast with the node-side analog `dora_node_api_c::HEADER_NODE_API`, which **is** wired into the CLI's C-node template generator (`binaries/cli/src/template/c/mod.rs:1,118`). The operator equivalents were never wired into any generator, so they are leftover convenience constants with zero consumers.

This follows the recent cleanup of unused public helpers/constants (e.g. #2295, #2360, #2361).

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p dora-operator-api-c -- -D warnings` — clean
- `cargo test -p dora-operator-api-c` — passes

Pure deletion; the `.h` files and `build.rs` behavior are untouched, so the C/C++ operator build path is unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPhxJigtSTpZiDEr9VmahR)_