### PR TITLE
refactor(core): remove unused `run` process-spawn helper

### DIFF
--- a/libraries/core/src/lib.rs
+++ b/libraries/core/src/lib.rs
@@ -1,7 +1,6 @@
 use eyre::{Context, bail, eyre};
 use std::{
     env::consts::{DLL_PREFIX, DLL_SUFFIX},
-    ffi::OsStr,
     path::Path,
 };
 
@@ -118,21 +117,4 @@ fn is_python2(python_path: &std::path::Path) -> bool {
 pub fn get_uv_path() -> Result<std::path::PathBuf, eyre::ErrReport> {
     which::which("uv")
         .context("failed to find `uv`. Make sure to install it using: https://docs.astral.sh/uv/getting-started/installation/")
-}
-
-// Helper function to run a program
-pub async fn run<S>(program: S, args: &[&str], pwd: Option<&Path>) -> eyre::Result<()>
-where
-    S: AsRef<OsStr>,
-{
-    let mut run = tokio::process::Command::new(program);
-    run.args(args);
-
-    if let Some(pwd) = pwd {
-        run.current_dir(pwd);
-    }
-    if !run.status().await?.success() {
-        eyre::bail!("failed to run {args:?}");
-    };
-    Ok(())
 }


### PR DESCRIPTION
> 🤖 **Auto-generated by Claude.** This PR was created by an automated dead-code sweep run via Claude Code. It is opened under the maintainer's GitHub account only because the automation authenticates with that token — the change itself was written by Claude, not by the account owner. Please review before merging.

## What

Removes the unused generic helper `dora_core::run` from `libraries/core/src/lib.rs`:

```rust
pub async fn run<S>(program: S, args: &[&str], pwd: Option<&Path>) -> eyre::Result<()>
where S: AsRef<OsStr> { ... }
```

and the `std::ffi::OsStr` import that only this function needed.

## Why

The helper spawned a process via `tokio::process::Command` and bailed on a non-zero exit, but **nothing in the workspace calls it**: a grep for `dora_core::run` / `core::run` returns no hits, and every component that spawns subprocesses (daemon spawner, CLI, runtime) builds its own `Command` directly.

This follows the recent cleanup of unused public helpers (e.g. #2187 `get_pip_path`, #2291 `infer_types_from_file`, #2331 `socket_stream_receive`).

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p dora-core --all-features -- -D warnings` — clean
- `cargo test -p dora-core --all-features` — 269 tests + doctests pass

Pure deletion; no behavior change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPhxJigtSTpZiDEr9VmahR)_