### PR TITLE
docs: update stale references to removed start_testing and DaemonId persistence

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -838,7 +838,7 @@ File download utility for fetching operator/node binaries from HTTP URLs. Saniti
 | `DataflowId` | `uuid::Uuid` | Assigned on dataflow start |
 | `SessionId` | `uuid::Uuid` (v7) | Per CLI session |
 | `BuildId` | `uuid::Uuid` (v7) | Per build operation |
-| `DaemonId` | `{ machine_id: Option<String>, uuid: Uuid (v7) }` | Persisted in `.daemon-id` |
+| `DaemonId` | `{ machine_id: Option<String>, uuid: Uuid (v7) }` | Created fresh on each start via `DaemonId::new(machine_id)` |
 | `NodeId` | `String` | Validated: `[a-zA-Z0-9_.-]`, non-empty |
 | `DataId` | `String` | Same validation as `NodeId` |
 | `OperatorId` | `String` | No validation |

--- a/docs/websocket-control-plane.md
+++ b/docs/websocket-control-plane.md
@@ -425,7 +425,7 @@ CLI                    WsSession              Coordinator
 
 **u128 workaround in tests**: Daemon test helpers construct WsRequest JSON strings manually via `format!()` + `serde_json::to_string()` (not `serde_json::to_value()`) to preserve `uhlc::ID` u128 values on the wire.
 
-**Test coordinator setup**: Both integration and E2E tests use `dora_coordinator::start_testing()` which binds to port 0 (OS-assigned) and accepts an empty external event stream.
+**Test coordinator setup**: Both integration and E2E tests use `dora_coordinator::start_testing_with_store()` which binds to port 0 (OS-assigned), accepts an empty external event stream, and takes an injected store (typically `Arc::new(InMemoryStore::new())`).
 
 ---
 
@@ -452,9 +452,10 @@ shutdown.shutdown(); // graceful stop
 
 ```rust
 // Binds to port 0, returns (port, future)
-let (port, future) = dora_coordinator::start_testing(
+let (port, future) = dora_coordinator::start_testing_with_store(
     "127.0.0.1:0".parse().unwrap(),
     futures::stream::empty(),
+    Arc::new(dora_coordinator::InMemoryStore::new()),
 ).await?;
 ```
 

--- a/guide/src/advanced/ws-control.md
+++ b/guide/src/advanced/ws-control.md
@@ -425,7 +425,7 @@ CLI                    WsSession              Coordinator
 
 **u128 workaround in tests**: Daemon test helpers construct WsRequest JSON strings manually via `format!()` + `serde_json::to_string()` (not `serde_json::to_value()`) to preserve `uhlc::ID` u128 values on the wire.
 
-**Test coordinator setup**: Both integration and E2E tests use `dora_coordinator::start_testing()` which binds to port 0 (OS-assigned) and accepts an empty external event stream.
+**Test coordinator setup**: Both integration and E2E tests use `dora_coordinator::start_testing_with_store()` which binds to port 0 (OS-assigned), accepts an empty external event stream, and takes an injected store (typically `Arc::new(InMemoryStore::new())`).
 
 ---
 
@@ -452,9 +452,10 @@ shutdown.shutdown(); // graceful stop
 
 ```rust
 // Binds to port 0, returns (port, future)
-let (port, future) = dora_coordinator::start_testing(
+let (port, future) = dora_coordinator::start_testing_with_store(
     "127.0.0.1:0".parse().unwrap(),
     futures::stream::empty(),
+    Arc::new(dora_coordinator::InMemoryStore::new()),
 ).await?;
 ```
 

--- a/guide/src/concepts/architecture.md
+++ b/guide/src/concepts/architecture.md
@@ -808,7 +808,7 @@ File download utility for fetching operator/node binaries from HTTP URLs. Saniti
 | `DataflowId` | `uuid::Uuid` | Assigned on dataflow start |
 | `SessionId` | `uuid::Uuid` (v7) | Per CLI session |
 | `BuildId` | `uuid::Uuid` (v7) | Per build operation |
-| `DaemonId` | `{ machine_id: Option<String>, uuid: Uuid (v7) }` | Persisted in `.daemon-id` |
+| `DaemonId` | `{ machine_id: Option<String>, uuid: Uuid (v7) }` | Created fresh on each start via `DaemonId::new(machine_id)` |
 | `NodeId` | `String` | Validated: `[a-zA-Z0-9_.-]`, non-empty |
 | `DataId` | `String` | Same validation as `NodeId` |
 | `OperatorId` | `String` | No validation |


### PR DESCRIPTION
Fixes #2399

## Summary

Two sets of doc references became stale after recent cleanup PRs:

- **`start_testing` removed in #2300**: The function was replaced by `start_testing_with_store(bind, stream, store)`, but `guide/src/advanced/ws-control.md` and `docs/websocket-control-plane.md` still showed the old two-argument signature in both prose and a Rust code sample (not a compiled doctest, so CI didn't catch it).

- **`DaemonId` persistence removed in #2310**: `DaemonId::load_or_create` (the only reader/writer of `.daemon-id`) was removed; the ID is now created fresh via `DaemonId::new(machine_id)`. Two architecture tables in `docs/architecture.md` and `guide/src/concepts/architecture.md` still said "Persisted in `.daemon-id`".

## Changes

- `guide/src/advanced/ws-control.md`: update prose and code sample to `start_testing_with_store` with `Arc::new(InMemoryStore::new())` as the store argument (matching the pattern used in `binaries/coordinator/tests/common/mod.rs`)
- `docs/websocket-control-plane.md`: same fix (mirror of the guide)
- `docs/architecture.md`: replace "Persisted in `.daemon-id`" with "Created fresh on each start via `DaemonId::new(machine_id)`"
- `guide/src/concepts/architecture.md`: same fix (mirror of the guide)

_This PR was opened automatically by [Claude Code](https://claude.ai/code) in response to the auto-generated issue above._

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQGuRD6vCHg1X8JJxDZPqo)_