### PR TITLE
fix(core): reject duplicate node IDs in plain dataflows

### DIFF
--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -188,6 +188,12 @@ impl DescriptorExt for Descriptor {
                 }
             };
 
+            if resolved.contains_key(&node.id) {
+                eyre::bail!(
+                    "duplicate node ID `{}` — each node must have a unique `id`",
+                    node.id
+                );
+            }
             resolved.insert(
                 node.id.clone(),
                 ResolvedNode {
@@ -733,5 +739,27 @@ nodes:
         );
         let b = resolved.get(&NodeId::from("b".to_string())).unwrap();
         assert!(b.env.is_none(), "node b has no env anywhere");
+    }
+
+    #[test]
+    fn duplicate_node_id_is_rejected() {
+        // Regression for #2393: a plain dataflow with two nodes sharing the
+        // same `id` must return an error instead of silently discarding one.
+        let yaml = r#"
+nodes:
+  - id: my-node
+    path: ./a
+  - id: my-node
+    path: ./b
+"#;
+        let desc: Descriptor = serde_yaml::from_str(yaml).expect("parse");
+        let err = desc
+            .resolve_aliases_and_set_defaults()
+            .expect_err("duplicate node ID must be rejected");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("duplicate node ID") && msg.contains("my-node"),
+            "unexpected error message: {msg}"
+        );
     }
 }


### PR DESCRIPTION
Fixes #2393

## Summary

A plain dataflow YAML (no `module:` nodes) with two `nodes:` entries sharing the same `id` was silently accepted: the second entry would overwrite the first in the `BTreeMap` inside `resolve_aliases_and_set_defaults`, causing one node to disappear without any error.

The duplicate-check in `expand.rs` only runs when the dataflow contains module nodes, and returns early otherwise, so plain dataflows were unprotected.

## Changes

**`libraries/core/src/descriptor/mod.rs`**
- Added a `contains_key` guard before `resolved.insert(...)` in `resolve_aliases_and_set_defaults`
- On duplicate, returns `eyre::bail!("duplicate node ID \`{}\` — each node must have a unique \`id\`", node.id)`, consistent with the message style in `expand.rs`

**Test added**: `duplicate_node_id_is_rejected` — parses a YAML with two nodes both named `my-node` and asserts the error is returned (233 tests pass including the new one).

_This PR was opened automatically by [Claude Code](https://claude.ai/code) in response to the auto-generated issue above._

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQGuRD6vCHg1X8JJxDZPqo)_