### PR TITLE
fix(ros2-bridge): parse byte preset default as u8 instead of ASCII bytes

### DIFF
--- a/libraries/extensions/ros2-bridge/arrow/src/serialize/defaults.rs
+++ b/libraries/extensions/ros2-bridge/arrow/src/serialize/defaults.rs
@@ -200,7 +200,12 @@ fn preset_default_for_basic_type(t: &NestableType, preset: &str) -> Result<Array
                     .context("Could not parse preset default value")?,
             ])
             .into(),
-            BasicType::Byte => UInt8Array::from(preset.as_bytes().to_owned()).into(),
+            BasicType::Byte => UInt8Array::from(vec![
+                preset
+                    .parse::<u8>()
+                    .context("Could not parse preset default value")?,
+            ])
+            .into(),
             BasicType::Bool => BooleanArray::from(vec![
                 preset
                     .parse::<bool>()


### PR DESCRIPTION
Fixes #2400

## Summary

In `libraries/extensions/ros2-bridge/arrow/src/serialize/defaults.rs`, the `BasicType::Byte` arm in `preset_default_for_basic_type` used `preset.as_bytes().to_owned()` instead of parsing the string as a `u8`.

This caused two classes of bugs:
- **Single-digit defaults (0–9):** silent value corruption — `byte b 5` produced `[0x35]` (decimal 53) instead of `[5]`
- **Multi-digit defaults (10–255):** hard serialization failure — `byte b 66` produced a 2-element array `[0x36, 0x36]` which fails the scalar-field length check

The `U8` and `Char` arms already use `preset.parse::<u8>()` correctly; this fixes `Byte` to match.

## Change

`libraries/extensions/ros2-bridge/arrow/src/serialize/defaults.rs` — change `BasicType::Byte` arm from `UInt8Array::from(preset.as_bytes().to_owned()).into()` to the same `parse::<u8>()` pattern used by `Char`/`U8`.

All 10 existing `dora-ros2-bridge-arrow` tests pass.

_This PR was opened automatically by [Claude Code](https://claude.ai/code) in response to the auto-generated issue above._

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQGuRD6vCHg1X8JJxDZPqo)_