### PR TITLE
fix(coordinator): continue destroy_daemons even when a dataflow stop fails

### DIFF
--- a/binaries/coordinator/src/handlers.rs
+++ b/binaries/coordinator/src/handlers.rs
@@ -174,7 +174,7 @@ pub(crate) async fn handle_destroy(
         }
     }
     for dataflow_uuid in running_dataflows.keys().cloned().collect::<Vec<_>>() {
-        let _ = stop_dataflow(
+        if let Err(e) = stop_dataflow(
             running_dataflows,
             dataflow_uuid,
             daemon_connections,
@@ -182,7 +182,10 @@ pub(crate) async fn handle_destroy(
             None,
             false,
         )
-        .await?;
+        .await
+        {
+            tracing::warn!("failed to stop dataflow {dataflow_uuid} during destroy: {e:#}");
+        }
     }
 
     destroy_daemons(daemon_connections, clock.new_timestamp()).await?;


### PR DESCRIPTION
Fixes #2391

## Summary

In `handle_destroy` (`binaries/coordinator/src/handlers.rs`), each running dataflow was stopped with `.await?`. The `?` caused early return on the first stop failure, so `destroy_daemons` — which tells daemons to shut down and drains `daemon_connections` — was never reached when any dataflow stop errored. The result: live daemons were left running after `dora destroy` if any dataflow's stop failed (e.g. because its daemon had already disconnected).

## Change

Replace `let _ = stop_dataflow(...).await?` with `if let Err(e) = ... { tracing::warn!(...) }` so failures are logged and the loop continues. `destroy_daemons` is now always called regardless of individual stop results.

All 124 coordinator tests pass.

_This PR was opened automatically by [Claude Code](https://claude.ai/code) in response to the auto-generated issue above._

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQGuRD6vCHg1X8JJxDZPqo)_