### PR TITLE
fix(coordinator): reject daemon events sent before Register

### DIFF
--- a/binaries/coordinator/src/ws_daemon.rs
+++ b/binaries/coordinator/src/ws_daemon.rs
@@ -171,14 +171,18 @@ async fn handle_daemon_request(
             true
         }
         CoordinatorRequest::Event { daemon_id, event } => {
-            // Verify daemon_id matches the registered one (prevent impersonation)
-            if let Some(tracked) = tracked_daemon_id
-                && *tracked != daemon_id
-            {
-                tracing::warn!(
-                    "daemon sent event with mismatched id: expected `{tracked}`, got `{daemon_id}` — closing connection"
-                );
-                return false;
+            match tracked_daemon_id {
+                None => {
+                    tracing::warn!("daemon sent event before registering — closing connection");
+                    return false;
+                }
+                Some(tracked) if *tracked != daemon_id => {
+                    tracing::warn!(
+                        "daemon sent event with mismatched id: expected `{tracked}`, got `{daemon_id}` — closing connection"
+                    );
+                    return false;
+                }
+                Some(_) => {}
             }
             if let Some(coordinator_event) = translate_daemon_event(daemon_id, event) {
                 event_tx.send(coordinator_event).await.is_ok()


### PR DESCRIPTION
Fixes #2390

## Summary

The `/api/daemon` WebSocket handler verified that `daemon_id` in an incoming `CoordinatorRequest::Event` matched the registered identity — but only when `tracked_daemon_id` was `Some`. Before a `Register` message (`tracked_daemon_id == None`), the guard was an `if let Some(..)` that evaluated to false, so the entire identity check was skipped. Any client that could open the `/api/daemon` socket could then inject arbitrary events (e.g. `DaemonExit` for a legitimate daemon, `AllNodesFinished` for a running dataflow) without registering first.

## Change

Replace the `if let Some(tracked) = tracked_daemon_id && *tracked != daemon_id` guard with a `match` on `tracked_daemon_id` that explicitly handles:
- `None` → log a warning and close the connection ("daemon sent event before registering")
- `Some(tracked) if *tracked != daemon_id` → log a warning and close (existing mismatch path)
- `Some(_)` → forward the event normally

All 124 coordinator tests pass.

_This PR was opened automatically by [Claude Code](https://claude.ai/code) in response to the auto-generated issue above._

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQGuRD6vCHg1X8JJxDZPqo)_