### PR TITLE
fix(coordinator): guard DaemonExit against stale connection from daemon reconnect race

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,8 +200,9 @@ out/
 # MacOS DS_Store
 .DS_Store
 
-# Claude Code local settings (machine-specific)
+# Claude Code local settings and temporary agent worktrees (machine-specific)
 .claude/settings.local.json
+.claude/worktrees/
 
 # macOS debug symbol bundles
 *.dSYM/

--- a/binaries/coordinator/src/events.rs
+++ b/binaries/coordinator/src/events.rs
@@ -33,6 +33,10 @@ pub enum Event {
     Log(LogMessage),
     DaemonExit {
         daemon_id: DaemonId,
+        /// Connection-instance ID stamped at registration time. Used to guard
+        /// against a stale connection's exit evicting a freshly re-registered
+        /// connection that reused the same `DaemonId` (#2392).
+        connection_id: Uuid,
     },
     DataflowBuildResult {
         build_id: BuildId,

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -2196,32 +2196,47 @@ async fn start_inner(
                         .await;
                 }
             }
-            Event::DaemonExit { daemon_id } => {
-                tracing::info!("Daemon `{daemon_id}` exited");
-                daemon_connections.remove(&daemon_id);
-                if let Err(e) = store.unregister_daemon(&daemon_id) {
-                    tracing::warn!("failed to persist daemon unregistration: {e}");
+            Event::DaemonExit {
+                daemon_id,
+                connection_id,
+            } => {
+                // Only act on the exit if the connection_id matches the
+                // currently-registered connection. A named daemon that
+                // reconnects before the old connection's handler task
+                // delivers its DaemonExit must NOT evict the new connection
+                // or trigger spurious dataflow cleanup (#2392).
+                if daemon_connections.connection_id_of(&daemon_id) == Some(connection_id) {
+                    tracing::info!("Daemon `{daemon_id}` exited");
+                    daemon_connections.remove(&daemon_id);
+                    if let Err(e) = store.unregister_daemon(&daemon_id) {
+                        tracing::warn!("failed to persist daemon unregistration: {e}");
+                    }
+                    let disconnected = BTreeSet::from([daemon_id]);
+                    let disconnect_actions = cleanup_disconnected_daemons_from_running_dataflows(
+                        &mut running_dataflows,
+                        &disconnected,
+                        &mut pending_restarts,
+                    );
+                    apply_disconnect_actions(
+                        disconnect_actions,
+                        &mut running_dataflows,
+                        &mut daemon_connections,
+                        &store,
+                        &clock,
+                    )
+                    .await?;
+                    notify_daemons_about_disconnected_peers(
+                        &disconnected,
+                        &mut daemon_connections,
+                        &clock,
+                    )
+                    .await?;
+                } else {
+                    tracing::debug!(
+                        "ignoring stale DaemonExit for `{daemon_id}` \
+                         (connection replaced by reconnect)"
+                    );
                 }
-                let disconnected = BTreeSet::from([daemon_id]);
-                let disconnect_actions = cleanup_disconnected_daemons_from_running_dataflows(
-                    &mut running_dataflows,
-                    &disconnected,
-                    &mut pending_restarts,
-                );
-                apply_disconnect_actions(
-                    disconnect_actions,
-                    &mut running_dataflows,
-                    &mut daemon_connections,
-                    &store,
-                    &clock,
-                )
-                .await?;
-                notify_daemons_about_disconnected_peers(
-                    &disconnected,
-                    &mut daemon_connections,
-                    &clock,
-                )
-                .await?;
             }
             Event::NodeMetrics {
                 dataflow_id,

--- a/binaries/coordinator/src/state.rs
+++ b/binaries/coordinator/src/state.rs
@@ -71,6 +71,12 @@ impl DaemonConnections {
         self.daemons.remove(daemon_id)
     }
 
+    /// Returns the `connection_id` of the currently-registered connection for
+    /// `daemon_id`, or `None` if the daemon is not connected.
+    pub(crate) fn connection_id_of(&self, daemon_id: &DaemonId) -> Option<Uuid> {
+        self.daemons.get(daemon_id).map(|c| c.connection_id)
+    }
+
     pub(crate) fn unnamed(&self) -> impl Iterator<Item = &DaemonId> {
         self.daemons.keys().filter(|id| id.machine_id().is_none())
     }
@@ -101,6 +107,10 @@ pub(crate) struct DaemonConnection {
     /// for a daemon too old to advertise it, so the coordinator can refuse to
     /// route a hub node to it with a clear error.
     pub(crate) supports_hub_sources: bool,
+    /// Unique ID for this connection instance. Used to distinguish a stale
+    /// connection's `DaemonExit` from a freshly re-registered connection
+    /// that reused the same `DaemonId` (daemon reconnect race, #2392).
+    pub(crate) connection_id: Uuid,
 }
 
 impl DaemonConnection {
@@ -118,6 +128,7 @@ impl DaemonConnection {
             // set from the register request at the real registration site;
             // conservative default keeps non-registration constructors safe
             supports_hub_sources: false,
+            connection_id: Uuid::new_v4(),
         }
     }
 

--- a/binaries/coordinator/src/ws_daemon.rs
+++ b/binaries/coordinator/src/ws_daemon.rs
@@ -30,8 +30,9 @@ pub(crate) async fn handle_daemon_ws(
     let pending_replies: Arc<Mutex<HashMap<Uuid, oneshot::Sender<String>>>> =
         Arc::new(Mutex::new(HashMap::new()));
 
-    // Track daemon_id from incoming events for cleanup on disconnect
+    // Track daemon_id and connection_id from incoming events for cleanup on disconnect
     let mut tracked_daemon_id: Option<DaemonId> = None;
+    let mut tracked_connection_id: Option<Uuid> = None;
 
     loop {
         tokio::select! {
@@ -72,6 +73,7 @@ pub(crate) async fn handle_daemon_ws(
                         &cmd_tx,
                         &pending_replies,
                         &mut tracked_daemon_id,
+                        &mut tracked_connection_id,
                     ).await {
                         break;
                     }
@@ -89,10 +91,17 @@ pub(crate) async fn handle_daemon_ws(
         }
     }
 
-    // Emit DaemonExit on WS close for immediate cleanup
-    if let Some(daemon_id) = tracked_daemon_id {
+    // Emit DaemonExit on WS close for immediate cleanup.
+    // Only emit if we also have a connection_id — they are always set together,
+    // but this guards against a half-initialized state.
+    if let (Some(daemon_id), Some(connection_id)) = (tracked_daemon_id, tracked_connection_id) {
         tracing::info!("daemon WS connection closed for `{daemon_id}`");
-        let _ = event_tx.send(Event::DaemonExit { daemon_id }).await;
+        let _ = event_tx
+            .send(Event::DaemonExit {
+                daemon_id,
+                connection_id,
+            })
+            .await;
     }
 }
 
@@ -114,6 +123,7 @@ async fn handle_daemon_request(
     cmd_tx: &mpsc::Sender<String>,
     pending_replies: &Arc<Mutex<HashMap<Uuid, oneshot::Sender<String>>>>,
     tracked_daemon_id: &mut Option<DaemonId>,
+    tracked_connection_id: &mut Option<Uuid>,
 ) -> bool {
     let parsed: DaemonWsRequestRaw = match serde_json::from_str(raw_text) {
         Ok(m) => m,
@@ -153,6 +163,8 @@ async fn handle_daemon_request(
             let mut connection =
                 DaemonConnection::new(cmd_tx.clone(), pending_replies.clone(), labels.clone());
             connection.supports_hub_sources = supports_hub_sources;
+            // Capture the connection_id before moving `connection` into the event.
+            let connection_id = connection.connection_id;
             let (daemon_id_tx, daemon_id_rx) = oneshot::channel();
             let event = DaemonRequest::Register {
                 connection,
@@ -164,9 +176,10 @@ async fn handle_daemon_request(
             if event_tx.send(Event::Daemon(event)).await.is_err() {
                 return false;
             }
-            // Capture the assigned daemon_id for cleanup on disconnect
+            // Capture the assigned daemon_id and connection_id for cleanup on disconnect
             if let Ok(daemon_id) = daemon_id_rx.await {
                 *tracked_daemon_id = Some(daemon_id);
+                *tracked_connection_id = Some(connection_id);
             }
             true
         }
@@ -180,7 +193,11 @@ async fn handle_daemon_request(
                 );
                 return false;
             }
-            if let Some(coordinator_event) = translate_daemon_event(daemon_id, event) {
+            // Use the tracked connection_id (set at registration); fall back to a fresh
+            // UUID if somehow called before registration (shouldn't happen in practice).
+            let connection_id = tracked_connection_id.unwrap_or_else(Uuid::new_v4);
+            if let Some(coordinator_event) = translate_daemon_event(daemon_id, event, connection_id)
+            {
                 event_tx.send(coordinator_event).await.is_ok()
             } else {
                 true
@@ -189,7 +206,11 @@ async fn handle_daemon_request(
     }
 }
 
-fn translate_daemon_event(daemon_id: DaemonId, event: DaemonEvent) -> Option<Event> {
+fn translate_daemon_event(
+    daemon_id: DaemonId,
+    event: DaemonEvent,
+    connection_id: Uuid,
+) -> Option<Event> {
     match event {
         DaemonEvent::AllNodesReady {
             dataflow_id,
@@ -213,7 +234,10 @@ fn translate_daemon_event(daemon_id: DaemonId, event: DaemonEvent) -> Option<Eve
             ft_stats,
         }),
         DaemonEvent::Log(message) => Some(Event::Log(message)),
-        DaemonEvent::Exit => Some(Event::DaemonExit { daemon_id }),
+        DaemonEvent::Exit => Some(Event::DaemonExit {
+            daemon_id,
+            connection_id,
+        }),
         DaemonEvent::NodeMetrics {
             dataflow_id,
             metrics,


### PR DESCRIPTION
Fixes #2392

## Summary

When a named daemon reconnects, the coordinator reuses its `DaemonId` and `DaemonConnections::add` replaces the old connection entry with the new one. The old connection's handler task still emits `Event::DaemonExit { daemon_id }` when it detects the socket close. If this stale `DaemonExit` is processed *after* the new connection has registered, the handler calls `daemon_connections.remove(&daemon_id)` — removing the freshly registered healthy connection — and then runs disconnect cleanup against the new connection's dataflows.

## Fix

Assign a unique `connection_id: Uuid` to each `DaemonConnection` at creation time. Include `connection_id` in `Event::DaemonExit`. In the `DaemonExit` handler, only proceed with removal and cleanup when the stored `connection_id` matches the current registration — a stale exit from a replaced connection is silently dropped with a `debug!` log.

## Changes

- **`state.rs`**: Add `connection_id: Uuid` to `DaemonConnection` (generated via `Uuid::new_v4()` in `new()`); add `DaemonConnections::connection_id_of()` lookup
- **`events.rs`**: Add `connection_id: Uuid` field to `Event::DaemonExit`
- **`ws_daemon.rs`**: Track `tracked_connection_id` alongside `tracked_daemon_id`; capture `connection.connection_id` before moving `connection` into the `Register` event; pass `connection_id` through both the WS-close and explicit `DaemonEvent::Exit` paths
- **`lib.rs`**: Check `connection_id_of(&daemon_id) == Some(connection_id)` before removing; skip cleanup with a `debug!` log on mismatch

All coordinator tests pass. Also includes `.gitignore` update to ignore `.claude/worktrees/` (temporary agent working directories).

_This PR was opened automatically by [Claude Code](https://claude.ai/code) in response to the auto-generated issue above._

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQGuRD6vCHg1X8JJxDZPqo)_