### PR TITLE
perf(daemon): drop per-event Box/clone overhead in NextEvent handling

### DIFF
--- a/binaries/daemon/src/node_communication/mod.rs
+++ b/binaries/daemon/src/node_communication/mod.rs
@@ -80,7 +80,7 @@ struct Listener {
     daemon_tx: mpsc::Sender<Timestamped<Event>>,
     subscribed_events: Option<Receiver<Timestamped<NodeEvent>>>,
     pending_counter: Option<Arc<AtomicU64>>,
-    queue: VecDeque<Box<Option<Timestamped<NodeEvent>>>>,
+    queue: VecDeque<Timestamped<NodeEvent>>,
     clock: Arc<uhlc::HLC>,
     last_activity: Arc<AtomicU64>,
 }
@@ -180,7 +180,7 @@ impl Listener {
                     future::Either::Right((message, _)) => break message,
                 };
 
-                self.queue.push_back(Box::new(Some(event)));
+                self.queue.push_back(event);
                 self.handle_events().await?;
             };
 
@@ -207,7 +207,7 @@ impl Listener {
                 if let Some(counter) = &self.pending_counter {
                     counter.fetch_sub(1, Ordering::Relaxed);
                 }
-                self.queue.push_back(Box::new(Some(event)));
+                self.queue.push_back(event);
             }
         }
         Ok(())
@@ -300,10 +300,7 @@ impl Listener {
             }
             DaemonRequest::NextEvent => {
                 // try to take the queued events first
-                let queued_events: Vec<_> = mem::take(&mut self.queue)
-                    .into_iter()
-                    .filter_map(|e| *e)
-                    .collect();
+                let queued_events: Vec<_> = mem::take(&mut self.queue).into_iter().collect();
                 let reply = if queued_events.is_empty() {
                     match self.subscribed_events.as_mut() {
                         // wait for next event
@@ -326,9 +323,9 @@ impl Listener {
                     DaemonReply::NextEvents(queued_events)
                 };
 
-                self.send_reply(reply.clone(), connection)
+                self.send_reply(reply, connection)
                     .await
-                    .wrap_err_with(|| format!("failed to send NextEvent reply: {reply:?}"))?;
+                    .wrap_err("failed to send NextEvent reply")?;
             }
             DaemonRequest::EventStreamDropped => {
                 let (reply_sender, reply) = oneshot::channel();


### PR DESCRIPTION
> 🤖 This PR is **machine-generated by Claude** (automated repository review run). Please review carefully before merging.

## Issue

The per-node `Listener` in `binaries/daemon/src/node_communication/mod.rs` buffers pending daemon→node events in a queue, and the daemon serves them on every `DaemonRequest::NextEvent`. Two avoidable per-event costs live on that hot path:

1. **Per-event heap allocation + a dead `Option`.** The queue was typed `VecDeque<Box<Option<Timestamped<NodeEvent>>>>`. Both push sites used `Box::new(Some(event))` — `None` was never inserted anywhere — and the drain unwrapped it again with `filter_map(|e| *e)`. So every event paid a `Box` heap allocation, and the `Option` was pure dead weight.

   ```rust
   queue: VecDeque<Box<Option<Timestamped<NodeEvent>>>>,
   // ...
   self.queue.push_back(Box::new(Some(event)));      // ×2 sites, never None
   // ...
   let queued_events: Vec<_> = mem::take(&mut self.queue)
       .into_iter()
       .filter_map(|e| *e)   // unwraps the Box+Option that was always Some
       .collect();
   ```

2. **Cloning the whole reply for an error string.** `NextEvent` cloned the entire reply before sending it, solely so the post-move error context could `{reply:?}` it:

   ```rust
   self.send_reply(reply.clone(), connection)
       .await
       .wrap_err_with(|| format!("failed to send NextEvent reply: {reply:?}"))?;
   ```

   `DaemonReply::NextEvents` carries the whole queued-event `Vec`, so this cloned every queued event on a path taken once per consumed event.

## Fix

- Store events inline as `VecDeque<Timestamped<NodeEvent>>`; push `event` directly; drain with a plain `.into_iter().collect()`. This removes the per-event `Box` allocation and the dead `Option`/`filter_map`.
- Move `reply` into `send_reply` instead of cloning, and drop the payload from the error context. `send_reply` already tags its error with the node id (`failed to send reply to node {node_id}`), so no diagnostic context is lost.

Behavior-preserving: `None` was never stored, so removing the `Option` cannot change results; the reply is unused after the send.

## Validation

- `cargo test -p dora-daemon` — 89 passed, 0 failed.
- `cargo clippy -p dora-daemon -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- Full workspace `cargo test --all` (excluding Python/maturin/examples crates) — green.

---
_Generated by Claude (claude-code automated review). Machine-generated — please review before merging._

---
_Generated by [Claude Code](https://claude.ai/code/session_01QioZcbr99iToR63tGAPiJm)_