### PR TITLE
perf(node): avoid per-event DataId clone in event scheduler

### DIFF
--- a/apis/rust/node/src/event_stream/scheduler.rs
+++ b/apis/rust/node/src/event_stream/scheduler.rs
@@ -248,17 +248,24 @@ impl Scheduler {
             }
         }
 
-        // Enforce queue size limit
-        let (size, queue) = self
-            .event_queues
-            .entry(event_id.clone())
-            .or_insert_with(|| {
-                tracing::warn!(
-                    "no queue config for input `{event_id}`, using default size {DEFAULT_QUEUE_SIZE}"
-                );
-                self.last_used.push_back(event_id.clone());
-                (DEFAULT_QUEUE_SIZE, Default::default())
-            });
+        // Enforce queue size limit.
+        //
+        // The queue is normally preconfigured for every input at construction
+        // (see `with_policies`), so look it up by reference first to avoid
+        // cloning the `DataId` key on every event. Only the rare unconfigured
+        // input path needs to allocate an owned key for insertion.
+        if !self.event_queues.contains_key(event_id) {
+            tracing::warn!(
+                "no queue config for input `{event_id}`, using default size {DEFAULT_QUEUE_SIZE}"
+            );
+            self.last_used.push_back(event_id.clone());
+            self.event_queues
+                .insert(event_id.clone(), (DEFAULT_QUEUE_SIZE, Default::default()));
+        }
+        let Some((size, queue)) = self.event_queues.get_mut(event_id) else {
+            // Unreachable: the entry was just inserted above when missing.
+            return;
+        };
 
         let policy = self
             .queue_policies


### PR DESCRIPTION
> 🤖 This PR is **machine-generated by Claude** (automated repository review run). Please review carefully before merging.

## Issue

`Scheduler::add_event` (`apis/rust/node/src/event_stream/scheduler.rs`) runs once per delivered input event on the node side. It looked the input's queue up with:

```rust
let (size, queue) = self
    .event_queues
    .entry(event_id.clone())   // clones a DataId (heap String) every event
    .or_insert_with(|| {
        tracing::warn!("no queue config for input `{event_id}`, using default size {DEFAULT_QUEUE_SIZE}");
        self.last_used.push_back(event_id.clone());
        (DEFAULT_QUEUE_SIZE, Default::default())
    });
```

The `entry(...)` API requires an owned key up front, so `event_id.clone()` allocates a fresh `DataId` (`String`) on **every** event — even though `event_queues` is normally preconfigured for every input at construction (`with_policies`) and the cloned key is only used as a lookup probe and then dropped. The actual insertion path (and its second clone) is the rare unconfigured-input case.

## Fix

Look the queue up by reference first, and only allocate an owned key on the rare path that actually inserts:

```rust
if !self.event_queues.contains_key(event_id) {
    tracing::warn!("no queue config for input `{event_id}`, using default size {DEFAULT_QUEUE_SIZE}");
    self.last_used.push_back(event_id.clone());
    self.event_queues
        .insert(event_id.clone(), (DEFAULT_QUEUE_SIZE, Default::default()));
}
let Some((size, queue)) = self.event_queues.get_mut(event_id) else {
    // Unreachable: the entry was just inserted above when missing.
    return;
};
```

This removes the per-event `String` allocation on the common path. The borrow checker can't return a `get_mut` reference out of a `match` whose other arm re-borrows the map, so the common path does a second by-reference lookup (no allocation) instead of the previous owned-key probe. The `last_used.push_back` / insert still happen under exactly the same condition (key absent), so behavior is unchanged.

## Validation

- `cargo test -p dora-node-api` — 107 lib tests (incl. the scheduler eviction/flush tests) + doctests passed.
- `cargo clippy -p dora-node-api -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- `scripts/qa/unwrap-budget.sh` — no new `unwrap`/`expect` (uses `let-else`, not `.unwrap()`).
- Full workspace `cargo test --all` (excluding Python/maturin/examples crates) — green.

---
_Generated by Claude (claude-code automated review). Machine-generated — please review before merging._

---
_Generated by [Claude Code](https://claude.ai/code/session_01QioZcbr99iToR63tGAPiJm)_