### PR TITLE
refactor(core): remove redundant test-only check_type_annotations wrapper

### DIFF
--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -797,7 +797,9 @@ pub struct TypeCheckResult {
 /// Timer nodes auto-inject this type.
 const TIMER_TYPE: &str = "std/core/v1/UInt64";
 
-/// Check type annotations in a dataflow.
+/// Check type annotations in a dataflow, with strict mode support.
+///
+/// Returns the collected warnings plus any inferred edge types.
 ///
 /// Checks:
 /// 1. `output_types` keys exist in `outputs`
@@ -808,14 +810,6 @@ const TIMER_TYPE: &str = "std/core/v1/UInt64";
 /// 6. Metadata annotation validation (Phase 5)
 /// 7. Arrow schema validation (Phase 6)
 /// 8. Strict mode: warn on unannotated ports connected to annotated ports
-pub fn check_type_annotations(
-    dataflow: &super::Descriptor,
-    registry: &crate::types::TypeRegistry,
-) -> Vec<TypeWarning> {
-    check_type_annotations_full(dataflow, registry, false).warnings
-}
-
-/// Full type checking with strict mode support. Returns warnings + inferences.
 pub fn check_type_annotations_full(
     dataflow: &super::Descriptor,
     registry: &crate::types::TypeRegistry,
@@ -1752,7 +1746,7 @@ operators:
     fn type_check_no_annotations_no_warnings() {
         let dataflow = parse_dataflow("nodes:\n  - id: a\n");
         let reg = TypeRegistry::new();
-        let warnings = check_type_annotations(&dataflow, &reg);
+        let warnings = check_type_annotations_full(&dataflow, &reg, false).warnings;
         assert!(warnings.is_empty());
     }
 
@@ -1762,7 +1756,7 @@ operators:
             "nodes:\n  - id: camera\n    outputs:\n      - image\n    output_types:\n      image: std/media/v1/Image\n",
         );
         let reg = TypeRegistry::new();
-        let warnings = check_type_annotations(&dataflow, &reg);
+        let warnings = check_type_annotations_full(&dataflow, &reg, false).warnings;
         assert!(warnings.is_empty());
     }
 
@@ -1772,7 +1766,7 @@ operators:
             "nodes:\n  - id: camera\n    output_types:\n      image: std/media/v1/Image\n",
         );
         let reg = TypeRegistry::new();
-        let warnings = check_type_annotations(&dataflow, &reg);
+        let warnings = check_type_annotations_full(&dataflow, &reg, false).warnings;
         assert_eq!(warnings.len(), 1);
         assert!(warnings[0].message.contains("not found in outputs"));
     }
@@ -1783,7 +1777,7 @@ operators:
             "nodes:\n  - id: camera\n    outputs:\n      - image\n    output_types:\n      image: std/media/v1/Imag\n",
         );
         let reg = TypeRegistry::new();
-        let warnings = check_type_annotations(&dataflow, &reg);
+        let warnings = check_type_annotations_full(&dataflow, &reg, false).warnings;
         assert_eq!(warnings.len(), 1);
         assert!(warnings[0].message.contains("unknown type"));
         assert!(warnings[0].message.contains("did you mean"));
@@ -1807,7 +1801,7 @@ nodes:
 ",
         );
         let reg = TypeRegistry::new();
-        let warnings = check_type_annotations(&dataflow, &reg);
+        let warnings = check_type_annotations_full(&dataflow, &reg, false).warnings;
         assert!(warnings.is_empty());
     }
 
@@ -1829,7 +1823,7 @@ nodes:
 ",
         );
         let reg = TypeRegistry::new();
-        let warnings = check_type_annotations(&dataflow, &reg);
+        let warnings = check_type_annotations_full(&dataflow, &reg, false).warnings;
         assert_eq!(warnings.len(), 1);
         assert!(warnings[0].message.contains("type mismatch"));
         assert!(warnings[0].message.contains("Float32"));
@@ -1970,7 +1964,7 @@ nodes:
 ",
         );
         let reg = TypeRegistry::new();
-        let warnings = check_type_annotations(&dataflow, &reg);
+        let warnings = check_type_annotations_full(&dataflow, &reg, false).warnings;
         assert!(warnings.is_empty(), "UInt8 -> UInt32 should be compatible");
     }
 
@@ -1992,7 +1986,7 @@ nodes:
 ",
         );
         let reg = TypeRegistry::new();
-        let warnings = check_type_annotations(&dataflow, &reg);
+        let warnings = check_type_annotations_full(&dataflow, &reg, false).warnings;
         assert!(
             warnings.is_empty(),
             "anything -> Bytes should be compatible"
@@ -2020,7 +2014,7 @@ nodes:
 ",
         );
         let reg = TypeRegistry::new();
-        let warnings = check_type_annotations(&dataflow, &reg);
+        let warnings = check_type_annotations_full(&dataflow, &reg, false).warnings;
         assert!(
             warnings.is_empty(),
             "user-defined rule should make this compatible"
@@ -2041,7 +2035,7 @@ nodes:
 ",
         );
         let reg = TypeRegistry::new();
-        let warnings = check_type_annotations(&dataflow, &reg);
+        let warnings = check_type_annotations_full(&dataflow, &reg, false).warnings;
         assert!(warnings.is_empty());
     }
 
@@ -2057,7 +2051,7 @@ nodes:
 ",
         );
         let reg = TypeRegistry::new();
-        let warnings = check_type_annotations(&dataflow, &reg);
+        let warnings = check_type_annotations_full(&dataflow, &reg, false).warnings;
         assert_eq!(warnings.len(), 1);
         assert!(warnings[0].message.contains("unknown pattern"));
     }
@@ -2075,7 +2069,7 @@ nodes:
 ",
         );
         let reg = TypeRegistry::new();
-        let warnings = check_type_annotations(&dataflow, &reg);
+        let warnings = check_type_annotations_full(&dataflow, &reg, false).warnings;
         assert_eq!(warnings.len(), 1);
         assert!(warnings[0].message.contains("output_metadata key"));
     }
@@ -2095,7 +2089,7 @@ nodes:
 ",
         );
         let reg = TypeRegistry::new();
-        let warnings = check_type_annotations(&dataflow, &reg);
+        let warnings = check_type_annotations_full(&dataflow, &reg, false).warnings;
         assert!(!warnings.is_empty());
         assert!(warnings[0].message.contains("type mismatch"));
     }


### PR DESCRIPTION
> 🤖 **Auto-generated by Claude.** This PR was created by an automated dead-code sweep run via Claude Code. It is opened under the maintainer's GitHub account only because the automation authenticates with that token — the change itself was written by Claude, not by the account owner. Please review before merging.

## What

Removes the thin `pub fn check_type_annotations` wrapper from `dora-core` (`libraries/core/src/descriptor/validate.rs`):

```rust
pub fn check_type_annotations(
    dataflow: &super::Descriptor,
    registry: &crate::types::TypeRegistry,
) -> Vec<TypeWarning> {
    check_type_annotations_full(dataflow, registry, false).warnings
}
```

The wrapper did nothing but call `check_type_annotations_full(.., false)` and discard everything except `.warnings`.

## Why

Every **production** consumer already calls `check_type_annotations_full` directly:

- `binaries/cli/src/command/build/mod.rs:376`
- `binaries/cli/src/command/validate.rs:153`

The wrapper's **only** callers were this module's own unit tests (13 call sites, all inside `#[cfg(test)] mod tests`). A repo-wide `git grep "check_type_annotations\b"` (excluding the `_full` variant) confirms zero non-test references anywhere in the workspace, and nothing outside `*.rs` references it either.

It is `pub` but not re-exported from `descriptor/mod.rs`, and `check_type_annotations_full` is the strictly-more-capable public entry point (it returns the full `TypeCheckResult { warnings, inferences }` and exposes `strict` mode). So this removes a redundant, superseded helper rather than a downstream capability — a caller wanting warnings-only writes `check_type_annotations_full(.., false).warnings`, exactly what the wrapper did.

> Note: it is `pub`, so if you'd rather keep the warnings-only convenience signature as a stable public entry point, that's a reasonable call — feel free to close. The 8-point checklist doc comment is preserved either way (folded onto `_full`).

## Changes

- Delete `check_type_annotations`; fold its checklist doc comment onto `check_type_annotations_full` so no documentation is lost.
- Migrate the 13 unit-test call sites to `check_type_annotations_full(.., false).warnings`.

Net: `+16 / -22`, one file.

## Verification

- `cargo fmt -p dora-core -- --check` — clean
- `cargo clippy -p dora-core -- -D warnings` — clean (confirms no remaining references)
- `cargo test -p dora-core --lib` — 236 passed, 0 failed

No behavior change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9MPpfnHWWw72as7SKYyZq)_