### PR TITLE
fix(daemon): include debug watchers in need_data_bytes gate in send_out

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -3676,7 +3676,7 @@ impl Daemon {
             data,
             &self.clock,
             Some(&self.ft_stats),
-            remote_receivers,
+            remote_receivers || has_debug_watchers,
         )
         .await?;
 


### PR DESCRIPTION
## Summary

Fixes #2423.

`Daemon::send_out` computed `need_data_bytes` from `remote_receivers` alone, ignoring `has_debug_watchers`. When a node sends output through the daemon control-plane fallback path (no Zenoh session) and only a `dora topic echo` / debug stream is watching, `remote_receivers` is `false` while `has_debug_watchers` is `true`. This caused `send_output_to_local_receivers` to return `None` for the payload, so the frame forwarded to the watcher carried `data: None` — `dora topic echo` showed empty output even though the node sent real data.

## Root cause

```rust
// Before — data_bytes is always None when !remote_receivers
let data_bytes = send_output_to_local_receivers(
    ...
    remote_receivers,   // need_data_bytes: ignores has_debug_watchers
)
.await?;
```

## Fix

```rust
// After — payload is retained whenever anyone will consume it
let data_bytes = send_output_to_local_receivers(
    ...
    remote_receivers || has_debug_watchers,
)
.await?;
```

This matches the behaviour of the Zenoh data path (`handle_debug_topic_data`), which always includes the payload when debug watchers are present, independently of `enable_debug_inspection`.

## Verification

- `cargo test -p dora-daemon` — 89 passed, 0 failed
- `cargo clippy -p dora-daemon -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.ai/code/session_01QwbPZwQpqSXdScUcpH3VM1)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QwbPZwQpqSXdScUcpH3VM1)_