### PR TITLE
docs(operator): document Event enum and DoraOperator trait with a compile-checked doctest

### DIFF
--- a/apis/rust/operator/src/lib.rs
+++ b/apis/rust/operator/src/lib.rs
@@ -29,25 +29,93 @@ use types::{
 
 pub mod raw;
 
+/// An event delivered to an operator's [`DoraOperator::on_event`] callback.
+///
+/// The dataflow runtime dispatches one `Event` per occurrence: a received
+/// input, a failed input decode, an input that will produce no more data, or a
+/// request to shut down. The enum is `#[non_exhaustive]`, so implementations
+/// must include a catch-all arm to stay forward-compatible with future variants.
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum Event<'a> {
+    /// A new input arrived on one of the operator's declared inputs.
     Input {
+        /// The input id, as declared in the dataflow YAML.
         id: &'a str,
+        /// Metadata associated with this input (e.g. OpenTelemetry context).
         metadata: &'a types::Metadata,
+        /// The Arrow-encoded payload.
         data: ArrowData,
     },
+    /// The payload for an input could not be decoded into an Arrow array.
+    ///
+    /// The input id and a human-readable description are provided so the
+    /// operator can log or surface the failure.
     InputParseError {
+        /// The input id whose payload failed to decode.
         id: &'a str,
+        /// A human-readable description of the decode failure.
         error: String,
     },
+    /// An input was closed: its source finished, so no further `Input` events
+    /// will be delivered for this id.
     InputClosed {
+        /// The input id that was closed.
         id: &'a str,
     },
+    /// The runtime requested a graceful shutdown. The operator should finish
+    /// any pending work and return [`DoraStatus::Stop`].
     Stop,
 }
 
+/// Trait implemented by every dora operator.
+///
+/// An operator is driven by the dataflow runtime: it is constructed via
+/// [`Default`] and then receives a stream of [`Event`]s through
+/// [`on_event`](DoraOperator::on_event), sending outputs back through the
+/// [`DoraOutputSender`]. Register your implementation with the
+/// [`register_operator!`](crate::register_operator) macro so the runtime can
+/// load it.
+///
+/// # Example
+///
+/// ```
+/// use dora_operator_api::{DoraOperator, DoraOutputSender, DoraStatus, Event, IntoArrow};
+///
+/// #[derive(Default)]
+/// struct ExampleOperator {
+///     ticks: u64,
+/// }
+///
+/// impl DoraOperator for ExampleOperator {
+///     fn on_event(
+///         &mut self,
+///         event: &Event,
+///         output_sender: &mut DoraOutputSender,
+///     ) -> Result<DoraStatus, String> {
+///         match event {
+///             Event::Input { id, .. } if *id == "tick" => {
+///                 self.ticks += 1;
+///                 output_sender.send("count", self.ticks.into_arrow())?;
+///                 Ok(DoraStatus::Continue)
+///             }
+///             Event::InputParseError { id, error } => {
+///                 Err(format!("failed to parse input `{id}`: {error}"))
+///             }
+///             Event::Stop => Ok(DoraStatus::Stop),
+///             // Ignore other inputs, input-closed notifications, and any
+///             // future (non_exhaustive) variants.
+///             _ => Ok(DoraStatus::Continue),
+///         }
+///     }
+/// }
+/// ```
 pub trait DoraOperator: Default {
+    /// Handle a single [`Event`].
+    ///
+    /// Return [`DoraStatus::Continue`] to keep running or [`DoraStatus::Stop`]
+    /// to shut the operator down. Returning `Err` reports a fatal error to the
+    /// runtime and stops the operator.
     #[allow(clippy::result_unit_err)] // we use a () error type only for testing
     fn on_event(
         &mut self,


### PR DESCRIPTION
## Summary

The two central public items of the operator API — the `Event` enum that operators pattern-match on and the `DoraOperator` trait they implement — had **no doc comments**. New users implementing an operator had to infer:

- the meaning of each event variant (e.g. `InputParseError` vs `InputClosed`),
- when `Stop` fires,
- the contract of `on_event`'s return value (`Continue`/`Stop`/`Err`),
- that the enum is `#[non_exhaustive]` and therefore needs a catch-all arm.

This PR documents the enum, each variant, the trait, and its method, and adds a **compile-checked doctest** showing a minimal operator implementation (with a catch-all arm and an `output_sender.send(...)` call via `IntoArrow`).

## Issue

`apis/rust/operator/src/lib.rs` is the recommended entry point for writing dora operators (the crate-level docs even say "It is the recommended way of using `dora`"), yet its two key public types carried zero item-level documentation.

## Fix

- Doc comments on `Event` and each of its fields/variants.
- Doc comments on `DoraOperator` and `on_event`, including the return-value contract.
- A `///` doctest demonstrating a complete `impl DoraOperator`.

No behavior change — documentation only.

## Validation

Run against the affected crate:

- `cargo test -p dora-operator-api --doc` → the new doctest (`DoraOperator (line 82)`) passes.
- `cargo clippy -p dora-operator-api -- -D warnings` → clean.
- `cargo fmt --all -- --check` → clean.

---

⚠️ **Disclaimer:** This pull request was generated by Claude (an AI agent) and is **machine-generated**. It has been verified locally (fmt, clippy, doctest) but should be reviewed by a human before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MykPCxNT1WK3ekBaVyM6ig)_