### PR TITLE
fix(node): bound zenoh subscriber teardown to prevent node shutdown hang (#2425)

### DIFF
--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -28,6 +28,7 @@ use crate::{
     DaemonCommunicationWrapper, PatternError,
     daemon_connection::{DaemonChannel, node_integration_testing::convert_output_to_json},
     event_stream::data_conversion::RawData,
+    node::{ZENOH_TEARDOWN_TIMEOUT, teardown_with_timeout},
 };
 use dora_core::{
     config::{Input, NodeId},
@@ -75,9 +76,11 @@ pub struct EventStream {
     receiver: tokio::sync::mpsc::Receiver<EventItem>,
     _thread_handle: EventStreamThreadHandle,
     /// Callback subscribers — kept alive for the lifetime of the
-    /// EventStream. Dropping a subscriber stops further callbacks; the
-    /// callback itself will see `blocking_send` return Err once the
-    /// `receiver` (declared above) is dropped.
+    /// EventStream. Dropping a subscriber undeclares it and stops further
+    /// callbacks. The callbacks use `try_send` (never block), so undeclaring
+    /// does not depend on `receiver` being dropped first. `EventStream::drop`
+    /// explicitly tears these down under a deadline (see there); by the time
+    /// this field drops it is already empty.
     _zenoh_subscribers: Vec<zenoh::pubsub::Subscriber<()>>,
     close_channel: DaemonChannel,
     clock: Arc<uhlc::HLC>,
@@ -1356,6 +1359,30 @@ impl Stream for EventStream {
 
 impl Drop for EventStream {
     fn drop(&mut self) {
+        // Tear down the per-input zenoh callback subscribers under a deadline.
+        // `Subscriber::drop` undeclares the subscription on the shared zenoh
+        // session, which blocks indefinitely when zenoh's net runtime is
+        // wedged (e.g. stuck retrying an unreachable scouted peer). Left
+        // unbounded, that hangs the whole node in `EventStream`'s field-drop
+        // sequence — before `DoraNode::Drop` (which already bounds its own
+        // session teardown) even runs — so the daemon never sees the node
+        // finish and the dataflow stalls until an outer timeout (dora-rs/dora#2425).
+        // The callbacks use `try_send`, so undeclaring before `receiver` drops
+        // cannot deadlock on a blocked callback.
+        let subscribers = std::mem::take(&mut self._zenoh_subscribers);
+        if !subscribers.is_empty() {
+            let completed =
+                teardown_with_timeout("zenoh-subscribers", ZENOH_TEARDOWN_TIMEOUT, move || {
+                    drop(subscribers);
+                });
+            if !completed {
+                tracing::warn!(
+                    "zenoh subscriber teardown timed out after {}s; continuing node shutdown",
+                    ZENOH_TEARDOWN_TIMEOUT.as_secs()
+                );
+            }
+        }
+
         let request = Timestamped {
             inner: DaemonRequest::EventStreamDropped,
             timestamp: self.clock.new_timestamp(),

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -104,7 +104,7 @@ const ZENOH_FIRST_PUBLISH_MATCH_POLL_INTERVAL: Duration = Duration::from_millis(
 
 /// Must exceed zenoh's internal 10s session close timeout, which is not
 /// enforceable when zenoh's net runtime is wedged.
-const ZENOH_TEARDOWN_TIMEOUT: Duration = Duration::from_secs(15);
+pub(crate) const ZENOH_TEARDOWN_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Allows sending outputs and retrieving node information.
 ///
@@ -1540,7 +1540,7 @@ impl DoraNodeBuilder {
 /// until process exit. That is acceptable for nodes dropped right before
 /// exit; long-lived hosts (e.g. a Python interpreter dropping a node during
 /// GC) inherit only the bounded delay instead of a permanent hang.
-fn teardown_with_timeout(
+pub(crate) fn teardown_with_timeout(
     label: &str,
     timeout: Duration,
     teardown: impl FnOnce() + Send + 'static,


### PR DESCRIPTION
A node with user-mapped inputs declares a per-input zenoh callback
subscriber on the shared session. `EventStream`'s `_zenoh_subscribers`
field dropped these inline, and `Subscriber::drop` (undeclare) blocks
indefinitely when zenoh's net runtime is wedged (e.g. stuck retrying an
unreachable scouted peer). Because that field drops before
`DoraNode::Drop` — which already bounds its own session teardown — a
wedged runtime hangs the whole node in the field-drop sequence, so the
daemon never sees the node finish and the dataflow stalls until an outer
timeout. This surfaced as the intermittent nightly hangs in #2425
(record-replay: `dora record` never returns; multiple-daemons: "dataflow
not finished after 101 retries").

Tear the subscribers down inside `EventStream::Drop` under the existing
`teardown_with_timeout` / `ZENOH_TEARDOWN_TIMEOUT` guard, mirroring the
`DoraNode` session teardown. The callbacks use `try_send`, so undeclaring
before `receiver` drops cannot deadlock on a blocked callback.

Reproduced locally (~10-20% of `dora record` runs hung before the fix;
0/60 after). Nodes without user-mapped inputs (timer-only) were never
affected because they declare no subscribers.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
