### PR TITLE
refactor(daemon): dedup all-inputs-closed tail of close_input/break_input

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -5516,35 +5516,50 @@ fn close_input(
         return;
     }
 
-    if let Some(channel) = dataflow.subscribe_channels.get(receiver_id) {
-        if was_open
-            && send_with_timestamp(
-                channel,
-                NodeEvent::InputClosed {
-                    id: input_id.clone(),
-                },
-                clock,
-            )
-            .ok()
-                == Some(true)
-        {
-            dataflow.inc_pending(receiver_id);
-        }
+    if let Some(channel) = dataflow.subscribe_channels.get(receiver_id)
+        && was_open
+        && send_with_timestamp(
+            channel,
+            NodeEvent::InputClosed {
+                id: input_id.clone(),
+            },
+            clock,
+        )
+        .ok()
+            == Some(true)
+    {
+        dataflow.inc_pending(receiver_id);
+    }
 
-        let has_broken = dataflow
-            .broken_inputs
-            .keys()
-            .any(|(nid, _)| nid == receiver_id);
-        if dataflow.open_inputs(receiver_id).is_empty() && !has_broken {
-            if let Some(node) = dataflow.running_nodes.get_mut(receiver_id) {
-                node.disable_restart();
-            }
-            if send_with_timestamp(channel, NodeEvent::AllInputsClosed, clock).ok() == Some(true) {
-                dataflow.inc_pending(receiver_id);
-                dataflow
-                    .all_inputs_closed_at
-                    .insert(receiver_id.clone(), Instant::now());
-            }
+    signal_all_inputs_closed_if_drained(dataflow, receiver_id, clock);
+}
+
+/// If `receiver_id` has no remaining open inputs (and none are circuit-broken),
+/// disable its restart policy and notify it that all inputs are closed.
+///
+/// Shared drain-completion tail of [`close_input`] and [`break_input`]; a
+/// no-op if the node still has open/broken inputs or has no subscribe channel.
+fn signal_all_inputs_closed_if_drained(
+    dataflow: &mut RunningDataflow,
+    receiver_id: &NodeId,
+    clock: &HLC,
+) {
+    let Some(channel) = dataflow.subscribe_channels.get(receiver_id) else {
+        return;
+    };
+    let has_broken = dataflow
+        .broken_inputs
+        .keys()
+        .any(|(nid, _)| nid == receiver_id);
+    if dataflow.open_inputs(receiver_id).is_empty() && !has_broken {
+        if let Some(node) = dataflow.running_nodes.get_mut(receiver_id) {
+            node.disable_restart();
+        }
+        if send_with_timestamp(channel, NodeEvent::AllInputsClosed, clock).ok() == Some(true) {
+            dataflow.inc_pending(receiver_id);
+            dataflow
+                .all_inputs_closed_at
+                .insert(receiver_id.clone(), Instant::now());
         }
     }
 }
@@ -5562,8 +5577,8 @@ fn break_input(
     {
         return;
     }
-    if let Some(channel) = dataflow.subscribe_channels.get(receiver_id) {
-        if send_with_timestamp(
+    if let Some(channel) = dataflow.subscribe_channels.get(receiver_id)
+        && send_with_timestamp(
             channel,
             NodeEvent::InputClosed {
                 id: input_id.clone(),
@@ -5572,26 +5587,11 @@ fn break_input(
         )
         .ok()
             == Some(true)
-        {
-            dataflow.inc_pending(receiver_id);
-        }
-
-        let has_broken = dataflow
-            .broken_inputs
-            .keys()
-            .any(|(nid, _)| nid == receiver_id);
-        if dataflow.open_inputs(receiver_id).is_empty() && !has_broken {
-            if let Some(node) = dataflow.running_nodes.get_mut(receiver_id) {
-                node.disable_restart();
-            }
-            if send_with_timestamp(channel, NodeEvent::AllInputsClosed, clock).ok() == Some(true) {
-                dataflow.inc_pending(receiver_id);
-                dataflow
-                    .all_inputs_closed_at
-                    .insert(receiver_id.clone(), Instant::now());
-            }
-        }
+    {
+        dataflow.inc_pending(receiver_id);
     }
+
+    signal_all_inputs_closed_if_drained(dataflow, receiver_id, clock);
 }
 
 /// Grace period used when the finish-straggler watchdog is enabled but


### PR DESCRIPTION
## Summary

`close_input` and `break_input` in `binaries/daemon/src/lib.rs` each contained a byte-for-byte identical ~15-line block: recompute whether any input is still circuit-broken and, if the node has no remaining open inputs, disable its restart policy, send `AllInputsClosed`, bump the pending counter, and record `all_inputs_closed_at`. Two copies had to be kept in sync manually.

## Fix

Extract the shared block into `signal_all_inputs_closed_if_drained(dataflow, receiver_id, clock)`.

Behavior is preserved exactly:
- The helper opens with `let Some(channel) = dataflow.subscribe_channels.get(...) else { return; }`, so `disable_restart` + `AllInputsClosed` still only run when the node has a subscribe channel (the drain logic previously lived inside the `if let Some(channel)` guard in both callers).
- `close_input` keeps its `was_open` guard on the `InputClosed` send; `break_input` still has none — unchanged.
- `has_broken` timing is unchanged (`break_input`'s input is moved into `broken_inputs` before the call, so the helper correctly suppresses `AllInputsClosed`).

## Validation

- `cargo test -p dora-daemon` — 89 tests pass, incl. the circuit-breaker / close-input cases ✅
- `cargo clippy -p dora-daemon -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅

---

⚠️ **Machine-generated PR.** Authored by Claude (an AI agent) during an automated codebase review. Verified as described but should receive human review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N42W9zv3r7PXcEuox4Wqx1)_