### PR TITLE
fix(coordinator-store): reject null-byte param keys in shared validator

### DIFF
--- a/libraries/coordinator-store/src/in_memory.rs
+++ b/libraries/coordinator-store/src/in_memory.rs
@@ -340,6 +340,17 @@ mod tests {
         assert_eq!(store.list_node_params(&df, &node).unwrap().len(), 1);
     }
 
+    /// A `\0`-containing param key must be rejected here just as the redb
+    /// backend rejects it (it reserves `\0` as a composite-key separator), so
+    /// the two backends agree on which input is valid.
+    #[test]
+    fn param_key_with_null_byte_is_rejected() {
+        let store = InMemoryStore::new();
+        let df = Uuid::new_v4();
+        let node: NodeId = "sensor".to_string().into();
+        assert!(store.put_node_param(&df, &node, "a\0b", b"v").is_err());
+    }
+
     /// `delete_dataflow` must remove every node param tied to that
     /// dataflow so `dora clean` doesn't leak orphan rows. Params for
     /// other dataflows must survive untouched.

--- a/libraries/coordinator-store/src/lib.rs
+++ b/libraries/coordinator-store/src/lib.rs
@@ -10,10 +10,20 @@ pub const MAX_PARAM_KEY_BYTES: usize = 256;
 /// Maximum allowed size for a serialized param value (bytes).
 pub const MAX_PARAM_VALUE_BYTES: usize = 65_536;
 
-/// Validate param key and value size limits.
+/// Validate param key and value limits.
+///
+/// This is the single source of truth shared by every [`CoordinatorStore`]
+/// backend, so all backends accept or reject identical input. In particular
+/// the null byte is rejected here because the redb backend uses it as an
+/// internal composite-key separator (see `redb_store::KEY_SEPARATOR`); without
+/// this check `put_node_param` with a `\0`-containing key would succeed on the
+/// in-memory backend but fail on redb.
 pub fn validate_param_limits(key: &str, value: &[u8]) -> Result<()> {
     if key.len() > MAX_PARAM_KEY_BYTES {
         eyre::bail!("param key too long (max {MAX_PARAM_KEY_BYTES} bytes)");
+    }
+    if key.contains('\0') {
+        eyre::bail!("param key must not contain null bytes");
     }
     if value.len() > MAX_PARAM_VALUE_BYTES {
         eyre::bail!("param value too large (max {MAX_PARAM_VALUE_BYTES} bytes)");


### PR DESCRIPTION
## Summary

The two `CoordinatorStore` backends disagreed on which param keys they accept:

- `RedbStore::put_node_param` builds a composite string key using `\0` as a separator (`KEY_SEPARATOR`) and rejects any key containing `\0` via `make_param_key`/`check_no_separator`.
- `InMemoryStore::put_node_param` stores the key in a tuple `BTreeMap` and only checked length.

So the same `put_node_param(..., "a\0b", ...)` call returned `Err` on the redb backend but `Ok` on the in-memory backend — a latent inconsistency that would surface if the coordinator switched backends.

## Fix

Move the null-byte rejection into the shared `validate_param_limits`, which both backends already call, so they now accept/reject identical input. The redb-side `check_no_separator` stays as defense in depth. Added an in-memory regression test mirroring the existing redb one (`param_key_with_null_byte_is_rejected`).

## Validation

- `cargo test -p dora-coordinator-store` and `... --features redb-backend` — both new tests pass, all 34 redb tests pass ✅
- `cargo clippy -p dora-coordinator-store --features redb-backend -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅

---

⚠️ **Machine-generated PR.** Authored by Claude (an AI agent) during an automated codebase review. Verified as described but should receive human review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N42W9zv3r7PXcEuox4Wqx1)_