### PR TITLE
perf(record-node): serialize arrow payload directly into aligned buffer

### DIFF
--- a/binaries/record-node/src/main.rs
+++ b/binaries/record-node/src/main.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, fs::File, time::SystemTime};
 
-use aligned_vec::AVec;
+use aligned_vec::{AVec, ConstAlign};
 use dora_message::{
     common::Timestamped,
     daemon_to_daemon::InterDaemonEvent,
@@ -65,9 +65,13 @@ fn main() -> eyre::Result<()> {
                 let arrow_data = data.to_data();
                 let data_size = arrow_utils::required_data_size(&arrow_data);
                 let raw_data = if data_size > 0 {
-                    let mut buf = vec![0u8; data_size];
+                    // Serialize the arrow buffers straight into the aligned
+                    // target buffer. Going through a temporary `Vec<u8>` and
+                    // then `AVec::from_slice` would allocate and memcpy the
+                    // whole payload a second time on every recorded message.
+                    let mut buf: AVec<u8, ConstAlign<128>> = AVec::__from_elem(128, 0, data_size);
                     arrow_utils::copy_array_into_sample(&mut buf, &arrow_data);
-                    Some(AVec::from_slice(128, &buf))
+                    Some(buf)
                 } else {
                     None
                 };


### PR DESCRIPTION
## Summary

The per-message record path in `binaries/record-node/src/main.rs` allocated and copied the arrow payload **twice**:

```rust
let mut buf = vec[0u8; data_size];                 // alloc #1
arrow_utils::copy_array_into_sample(&mut buf, ...); // copy #1
Some(AVec::from_slice(128, &buf))                   // alloc #2 + copy #2
```

`AVec::from_slice` allocates a new 128-byte-aligned buffer and memcpys `buf` into it, so every recorded message paid for two allocations and two payload-sized copies where one of each suffices.

## Fix

Allocate the aligned `AVec` once (zeroed) and serialize the arrow buffers straight into it, matching the idiom already used in the daemon (`lib.rs`) and runtime:

```rust
let mut buf: AVec<u8, ConstAlign<128>> = AVec::__from_elem(128, 0, data_size);
arrow_utils::copy_array_into_sample(&mut buf, &arrow_data);
Some(buf)
```

Same result type as before. The zeroing is retained because `copy_array_into_sample` leaves alignment-padding gaps between buffers unwritten.

## Validation

- `cargo test -p dora-record-node` ✅
- `cargo clippy -p dora-record-node -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅

---

⚠️ **Machine-generated PR.** Authored by Claude (an AI agent) during an automated codebase review. Verified as described but should receive human review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N42W9zv3r7PXcEuox4Wqx1)_