### PR TITLE
fix(cli): scope `dora logs --node --follow` to the requested node

### DIFF
--- a/binaries/cli/src/command/logs.rs
+++ b/binaries/cli/src/command/logs.rs
@@ -140,6 +140,7 @@ impl Executable for LogsArgs {
                 stream_logs_from_coordinator(
                     &session,
                     uuid,
+                    None,
                     &self.level,
                     self.since,
                     self.until,
@@ -569,10 +570,27 @@ fn matches_grep(msg: &LogMessage, pattern: Option<&str>) -> bool {
     false
 }
 
-/// Subscribe to coordinator log stream with time/grep filtering.
+/// Returns whether a log message should be kept given an optional node filter.
+/// `None` means no filtering (messages from every node pass); `Some(want)`
+/// keeps only messages whose node id equals `want`.
+fn matches_node_filter(msg_node: Option<&str>, want: Option<&str>) -> bool {
+    match want {
+        None => true,
+        Some(want) => msg_node == Some(want),
+    }
+}
+
+/// Subscribe to coordinator log stream with time/grep/node filtering.
+///
+/// `node`, when set, restricts the stream to messages from that single node —
+/// mirroring the node scoping already applied to the historical fetch in
+/// [`logs`]. Without this, `--node <N> --follow` would show history for `N`
+/// but then stream live logs from every node once following began.
+#[allow(clippy::too_many_arguments)]
 fn stream_logs_from_coordinator(
     session: &WsSession,
     uuid: Uuid,
+    node: Option<&NodeId>,
     level: &dora_core::build::LogLevelOrStdout,
     since: Option<std::time::Duration>,
     until: Option<std::time::Duration>,
@@ -589,6 +607,7 @@ fn stream_logs_from_coordinator(
         since.and_then(|d| chrono::TimeDelta::from_std(d).ok().map(|td| now - td));
     let until_threshold =
         until.and_then(|d| chrono::TimeDelta::from_std(d).ok().map(|td| now - td));
+    let want_node = node.map(|n| n.as_ref());
 
     let log_rx = session.subscribe_logs(
         &serde_json::to_vec(&ControlRequest::LogSubscribe {
@@ -610,6 +629,10 @@ fn stream_logs_from_coordinator(
             serde_json::from_slice(&raw).context("failed to parse log message");
         match parsed {
             Ok(log_message) => {
+                if !matches_node_filter(log_message.node_id.as_ref().map(|n| n.as_ref()), want_node)
+                {
+                    continue;
+                }
                 if let Some(threshold) = since_threshold
                     && log_message.timestamp < threshold
                 {
@@ -679,7 +702,16 @@ pub fn logs(
         return Ok(());
     }
 
-    stream_logs_from_coordinator(session, uuid, level, since, until, grep, config)
+    stream_logs_from_coordinator(
+        session,
+        uuid,
+        Some(&node),
+        level,
+        since,
+        until,
+        grep,
+        config,
+    )
 }
 
 #[cfg(test)]
@@ -902,6 +934,30 @@ mod tests {
         let now = Utc::now();
         let msg = make_msg("hello", Some("sensor"), Some("target"), now);
         assert!(!matches_grep(&msg, Some("zzz_missing")));
+    }
+
+    // --- matches_node_filter ---
+
+    #[test]
+    fn node_filter_none_passes_everything() {
+        assert!(matches_node_filter(Some("sensor"), None));
+        assert!(matches_node_filter(None, None));
+    }
+
+    #[test]
+    fn node_filter_matching_node_passes() {
+        assert!(matches_node_filter(Some("sensor"), Some("sensor")));
+    }
+
+    #[test]
+    fn node_filter_other_node_is_dropped() {
+        assert!(!matches_node_filter(Some("processor"), Some("sensor")));
+    }
+
+    #[test]
+    fn node_filter_system_message_is_dropped_when_node_requested() {
+        // System messages (no node_id) should not leak through a --node filter.
+        assert!(!matches_node_filter(None, Some("sensor")));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #2460

## Summary

`dora logs <dataflow> --node <N> --follow` correctly restricted the **historical** portion of the output to node `N`, but the **follow** portion streamed live logs from **every** node in the dataflow — the `--node` filter was silently dropped once streaming began.

## Root cause

In `binaries/cli/src/command/logs.rs`, the `--node` path's `logs()` function fetches history correctly scoped via `ControlRequest::Logs { node: node.to_string(), .. }`, but then handed off to `stream_logs_from_coordinator(session, uuid, level, since, until, grep, config)` with no `node` parameter at all. That function subscribes via `ControlRequest::LogSubscribe { dataflow_id, level }` (no node field), and its receive loop only filtered on `since`/`until`/`grep`, never on node — so messages from every node passed straight through. This was also inconsistent with the `--local` follow path (`follow_local_logs`), which stays node-scoped throughout.

## Fix

Client-side guard, as suggested in the issue (smaller change, no wire-protocol update needed):

- Added `matches_node_filter(msg_node: Option<&str>, want: Option<&str>) -> bool`, a small testable predicate mirroring the existing `matches_grep` pattern in the same file.
- `stream_logs_from_coordinator` now takes a `node: Option<&NodeId>` parameter and applies `matches_node_filter` inside the receive loop before the time/grep filters, dropping messages from other nodes.
- Updated both call sites: `logs()` now passes `Some(&node)`; the no-node-specified path passes `None`, preserving unfiltered streaming there.

Added unit tests for `matches_node_filter` covering: no filter passes everything, matching node passes, non-matching node is dropped, and system messages (`node_id: None`) are dropped when a node filter is active.

## Validation

- `cargo test -p dora-cli` — 244 passed (26 in the `logs` module, incl. 4 new)
- `cargo fmt --all -- --check`
- `cargo clippy -p dora-cli -- -D warnings`
- `cargo clippy --all --exclude dora-node-api-python --exclude dora-operator-api-python --exclude dora-ros2-bridge-python -- -D warnings`
- `cargo check --examples`

---
⚠️ **Machine-generated PR.** This change was authored by Claude (an AI agent) reviewing an automated code-review issue. It has been verified as described above but should receive human review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzhJpuL3Y3QMykwvx31Krt)_