### PR TITLE
fix(download): reject HTTP error statuses before writing the artifact

### DIFF
--- a/libraries/extensions/download/Cargo.toml
+++ b/libraries/extensions/download/Cargo.toml
@@ -19,3 +19,6 @@ reqwest = { version = "0.12.4", default-features = false, features = [
 sha2 = "0.10"
 tokio = { workspace = true, features = ["fs"] }
 tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "net", "io-util"] }

--- a/libraries/extensions/download/src/lib.rs
+++ b/libraries/extensions/download/src/lib.rs
@@ -63,6 +63,15 @@ where
         .await
         .wrap_err_with(|| format!("failed to request operator from `{url}`"))?;
 
+    // `reqwest::get` resolves to `Ok` for any completed HTTP exchange, including
+    // 4xx/5xx responses. Without this check a 404/500 error page (HTML/JSON)
+    // would be hashed, written to the build directory, and — on Unix — marked
+    // executable, then handed to `libloading`/Python, masking the real "bad URL
+    // / server error" behind a confusing downstream load failure.
+    let response = response
+        .error_for_status()
+        .wrap_err_with(|| format!("server returned an error status for `{url}`"))?;
+
     let filename = get_filename(&response).context("Could not find a filename")?;
     let bytes = response
         .bytes()
@@ -105,4 +114,47 @@ where
         .wrap_err("failed to make downloaded file executable")?;
 
     Ok(path.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    /// A 404 (or any error status) must fail the download instead of writing
+    /// the server's error page to disk as the artifact.
+    #[tokio::test]
+    async fn rejects_http_error_status() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            if let Ok((mut socket, _)) = listener.accept().await {
+                // Consume the request line/headers, then reply with a 404.
+                let mut buf = [0u8; 1024];
+                let _ = socket.read(&mut buf).await;
+                let body = "not found";
+                let resp = format!(
+                    "HTTP/1.1 404 Not Found\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len(),
+                );
+                let _ = socket.write_all(resp.as_bytes()).await;
+                let _ = socket.flush().await;
+            }
+        });
+
+        let dir = std::env::temp_dir().join(format!("dora-download-test-{}", addr.port()));
+        let url = format!("http://{addr}/model.bin");
+        let result = download_file(url.as_str(), &dir, None).await;
+
+        assert!(result.is_err(), "expected an error for a 404 response");
+        assert!(
+            !dir.join("model.bin").exists(),
+            "the error page must not be written as the artifact"
+        );
+
+        let _ = server.await;
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
 }


### PR DESCRIPTION
> 🤖 **Machine-generated PR** authored by Claude (Claude Code). Please review carefully before merging.

## Issue

`reqwest::get` resolves to `Ok` for any completed HTTP exchange, including 4xx/5xx responses, and `download_file` never called `error_for_status()`. A URL that returned a 404/500 (typo, moved artifact, captive-portal or proxy HTML) therefore had its **error-page body** hashed, written to `build/<name>`, marked executable on Unix, and handed to `libloading`/Python. The real failure was masked behind a confusing downstream *"failed to load shared library"*, and a bogus executable was left on disk. Callers pass `expected_sha256 = None`, so the integrity check does not catch this either.

## Fix

Add `response.error_for_status()?` immediately after the request, so an error status fails the download with a clear message before anything is read or written:

```rust
let response = response
    .error_for_status()
    .wrap_err_with(|| format!("server returned an error status for `{url}`"))?;
```

`error_for_status()` consumes and returns the same `Response` on success, so `get_filename(&response)` and `response.bytes()` still operate on an intact body/headers.

## Validation

- Added a regression test (`rejects_http_error_status`) that serves a local `404` from a one-shot `TcpListener` and asserts the download errors **and** writes no artifact. Confirmed it fails without the fix (the error page is otherwise written to disk) and passes with it.
- New `[dev-dependencies]` on `tokio` (`macros`, `rt`, `net`, `io-util`) for the test only.
- `cargo fmt`/`clippy -p dora-download --all-targets -- -D warnings`/`cargo test -p dora-download` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CfPhELRj2iXUrApdUF5N8r

---
_Generated by [Claude Code](https://claude.ai/code/session_01CfPhELRj2iXUrApdUF5N8r)_