### PR TITLE
fix(daemon): drop per-dataflow node results on finish to bound memory

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -4210,6 +4210,11 @@ impl Daemon {
             let _ = df.listener_shutdown_tx.send(true);
         }
         self.running.remove(&dataflow_id);
+        // Reclaim the per-node result entries for this dataflow. They were
+        // already consumed into `result` above and have no reader once the
+        // dataflow is no longer running, so keeping them would leak one entry
+        // per node for every dataflow a long-lived daemon ever runs.
+        self.dataflow_node_results.remove(&dataflow_id);
 
         Ok(())
     }


### PR DESCRIPTION
## Issue

`Daemon::dataflow_node_results` (`binaries/daemon/src/lib.rs`) accumulates one entry per node for every dataflow the daemon runs, but `finish_dataflow` only removed the dataflow from `self.running` — never from this map. The entries were reclaimed solely by the wholesale `mem::take` on daemon exit/reconnect, so a **long-lived daemon** that services many short dataflows (e.g. repeated `dora run` against a persistent daemon) grows this map without bound.

## Fix

`finish_dataflow` already clones the entry into the `DataflowDaemonResult` it reports to the coordinator **before** any cleanup, and nothing reads the map for a dataflow once it has finished. Remove the entry alongside `self.running`:

```rust
self.running.remove(&dataflow_id);
self.dataflow_node_results.remove(&dataflow_id);
```

UUID keys are unique, so there is no stale-lookup hazard.

## Validation

- `cargo test -p dora-daemon` — all lib tests pass.
- `cargo clippy -p dora-daemon -- -D warnings` and `cargo fmt --all -- --check` clean.

---
🤖 This PR was generated by Claude (an AI agent) in an automated code-review session. **Machine-generated change — please review carefully before merging.** It has been reviewed by the agent before submission but warrants human review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxqZqpep1HtBrYurEGRpJw)_