### PR TITLE
docs(mavlink2-bridge): describe the implemented crate surface, not a scaffold

### DIFF
--- a/libraries/extensions/mavlink2-bridge/src/lib.rs
+++ b/libraries/extensions/mavlink2-bridge/src/lib.rs
@@ -1,8 +1,16 @@
 //! MAVLink 2 ↔ Apache Arrow bridge for the dora dataflow runtime.
 //!
-//! This crate is the scaffold for a MAVLink 2 bridge that mirrors the
-//! `dora-ros2-bridge` extension. Subsequent PRs add Arrow conversion,
-//! transport adapters, and the daemon-spawnable bridge node.
+//! This crate mirrors the `dora-ros2-bridge` extension for MAVLink 2. It
+//! provides:
+//!
+//! - Arrow conversion for common-dialect messages via the [`MavlinkArrow`]
+//!   trait.
+//! - Transport builders for TCP, UDP, and serial links (see [`transport`]).
+//! - [`MAVLINK_VERSION`], a compile-time guarantee that the bridge targets
+//!   MAVLink 2.
+//!
+//! The daemon-spawnable bridge node built on top of this crate lives in the
+//! `dora-mavlink2-bridge-node` binary.
 //!
 //! See <https://github.com/dora-rs/dora/issues/1786> for the design RFC.
 


### PR DESCRIPTION
## Issue

The crate-level doc in `libraries/extensions/mavlink2-bridge/src/lib.rs` still described `dora-mavlink2-bridge` as "the scaffold for a MAVLink 2 bridge" whose Arrow conversion, transport adapters, and daemon-spawnable node would be added by "subsequent PRs". All three already exist:

- the `MavlinkArrow` Arrow-conversion trait,
- the `transport` module (TCP/UDP/serial builders via `transport::connect`),
- the `dora-mavlink2-bridge-node` binary.

The doc misrepresented the crate's current state to rustdoc readers.

## Fix

Replace the stale module doc with an accurate summary of the implemented surface (Arrow conversion, transport builders, `MAVLINK_VERSION`, and a pointer to the bridge-node binary). Intra-doc links reference only public items.

## Validation

- `cargo build -p dora-mavlink2-bridge` clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p dora-mavlink2-bridge --no-deps` — no warnings/broken links.
- `cargo fmt --all -- --check` clean.

---
🤖 This PR was generated by Claude (an AI agent) in an automated code-review session. **Machine-generated change — please review carefully before merging.** It has been reviewed by the agent before submission but warrants human review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxqZqpep1HtBrYurEGRpJw)_