### PR TITLE
refactor(daemon): use DEFAULT_STOP_GRACE in stop_all grace path

### DIFF
--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -403,7 +403,7 @@ impl RunningDataflow {
         } else {
             let grace_duration_kills = self.grace_duration_kills.clone();
             tokio::spawn(async move {
-                let duration = grace_duration.unwrap_or(Duration::from_millis(10000));
+                let duration = grace_duration.unwrap_or(DEFAULT_STOP_GRACE);
                 tokio::time::sleep(duration).await;
 
                 for (node, proc) in &running_processes {


### PR DESCRIPTION
## Issue

`stop_all` (`binaries/daemon/src/running_dataflow.rs`) hardcoded `Duration::from_millis(10000)` for the default stop grace:

```rust
let duration = grace_duration.unwrap_or(Duration::from_millis(10000));
```

The same module defines `const DEFAULT_STOP_GRACE: Duration = Duration::from_millis(10_000)` (line 20) and `stop_single_node` correctly threads it through `send_stop_and_schedule_kill`. The values are identical today, but the duplicated literal means a maintainer tuning `DEFAULT_STOP_GRACE` would silently leave the whole-dataflow stop path on the old 10 s grace — diverging from the single-node path.

## Fix

Use the existing `DEFAULT_STOP_GRACE` constant in `stop_all` so both stop paths share one source of truth. No behavior change (the literal already equals the constant).

## Validation

- `cargo clippy -p dora-daemon -- -D warnings` and `cargo fmt --all -- --check` pass; full workspace `cargo test` passes on the combined branch.

---
🤖 This pull request was generated by Claude (an AI assistant) as part of an automated code-review pass. It is **machine-generated** and should be reviewed carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkeKgBFLZeS6iM6cJT745E)_