### PR TITLE
docs(node): fix comments/test name that contradict the implementation

### DIFF
--- a/apis/rust/node/src/event_stream/scheduler.rs
+++ b/apis/rust/node/src/event_stream/scheduler.rs
@@ -311,7 +311,10 @@ impl Scheduler {
             return Some(event);
         }
 
-        // Process the ID with the oldest timestamp using BTreeMap Ordering
+        // Return the next event from the least-recently-used input queue:
+        // scan `last_used` (a `VecDeque` in LRU order), pop from the first
+        // non-empty queue, and move that id to the back so other inputs get a
+        // turn. There is no timestamp comparison or `BTreeMap` involved.
         for index in 0..self.last_used.len() {
             let id = &self.last_used[index];
             if let Some((_size, queue)) = self.event_queues.get_mut(id)

--- a/apis/rust/node/src/node/arrow_utils.rs
+++ b/apis/rust/node/src/node/arrow_utils.rs
@@ -529,12 +529,15 @@ mod tests {
     }
 
     #[test]
-    fn raw_roundtrip_empty_primitive_uses_empty_buffer_path() {
+    fn raw_roundtrip_empty_primitive_via_general_path() {
         let data = UInt64Array::from(Vec::<u64>::new()).into_data();
         let mut sample = vec![0; required_data_size(&data)];
         let type_info = copy_array_into_sample(&mut sample, &data);
-        // An empty array yields a zero-length payload, exercising the
-        // `raw_buffer.is_empty()` early-return in `buffer_into_arrow_array`.
+        // An empty array yields a zero-length payload. There is deliberately no
+        // `raw_buffer.is_empty()` early-return (see the NOTE in
+        // `buffer_into_arrow_array`, dora-rs/dora#2083); this goes through the
+        // general `ArrayData::try_new` path, which happens to also produce a
+        // length-0 array here because `type_info.len` is 0.
         let decoded =
             buffer_into_arrow_array(&arrow::buffer::Buffer::from(sample), &type_info).unwrap();
         assert_eq!(decoded.len(), 0);


### PR DESCRIPTION
## Issue

Two comments in `dora-node-api` described code that does not exist, both of which could mislead a future maintainer:

1. **`apis/rust/node/src/node/arrow_utils.rs`** — the test `raw_roundtrip_empty_primitive_uses_empty_buffer_path` and its comment claimed to exercise a `raw_buffer.is_empty()` early-return in `buffer_into_arrow_array`. No such early-return exists: the `NOTE` in that function explicitly documents that the empty-buffer case is deliberately *not* special-cased, because doing so discarded the array's declared length and reintroduced dora-rs/dora#2083. The misleading name actively invites "restoring" exactly the bug the `NOTE` warns against.

2. **`apis/rust/node/src/event_stream/scheduler.rs`** — the comment *"Process the ID with the oldest timestamp using BTreeMap Ordering"* describes an algorithm that isn't there. `next()` scans `last_used` (a `VecDeque` in least-recently-used order); there is no timestamp comparison and no `BTreeMap`. The struct field is already documented correctly (*"Tracks the last-used event ID"*).

## Fix

- Rename the test to `raw_roundtrip_empty_primitive_via_general_path` and correct its comment to state that the empty case goes through the general `ArrayData::try_new` path (no early-return), per the `NOTE`.
- Rewrite the scheduler comment to describe the actual LRU-over-`VecDeque` behavior.

Comments / test name only — no behavior change.

## Validation

`cargo fmt`, `cargo clippy -D warnings`, and the full `dora-node-api` test suite pass.

---
🤖 This is a machine-generated change (Claude, automated code review). A human should review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017LDuSGyp9tcaQpackgPPnp)_