### PR TITLE
Remove `needs: test` to run tests in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,6 @@ jobs:
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
-    needs: test
     if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'trunk-merge/')
     steps:
       - uses: actions/checkout@v6
@@ -312,7 +311,6 @@ jobs:
   contract-tests:
     name: Semantic contract tests
     runs-on: ubuntu-latest
-    needs: test
     if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'trunk-merge/')
     timeout-minutes: 30
     steps:
@@ -364,7 +362,6 @@ jobs:
   bench:
     name: Benchmark regression check
     runs-on: ubuntu-latest
-    needs: test
     if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'trunk-merge/')
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
They only run on trunk merge and we want to be quick then
