### PR TITLE
fix(message): reject zero-length hz timer intervals

### DIFF
--- a/libraries/message/src/config.rs
+++ b/libraries/message/src/config.rs
@@ -280,9 +280,22 @@ impl FromStr for InputMapping {
                                     "hz must be a positive finite number (got `{value}`)"
                                 ));
                             }
-                            Duration::try_from_secs_f64(1.0 / hz).map_err(|e| {
+                            let interval = Duration::try_from_secs_f64(1.0 / hz).map_err(|e| {
                                 format!("hz `{value}` produces an out-of-range interval: {e}")
-                            })?
+                            })?;
+                            // A very large hz makes `1/hz` round below 1ns, so
+                            // `try_from_secs_f64` returns `Ok(Duration::ZERO)`
+                            // rather than an error. A zero-length interval means
+                            // the timer fires continuously (busy loop), so reject
+                            // it explicitly -- mirroring the tiny-hz overflow guard
+                            // above.
+                            if interval.is_zero() {
+                                return Err(format!(
+                                    "hz `{value}` is too large: it produces a zero-length \
+                                     timer interval"
+                                ));
+                            }
+                            interval
                         }
                         other => {
                             return Err(format!(
@@ -746,6 +759,23 @@ mod tests {
             .parse::<InputMapping>()
             .unwrap_err();
         assert!(err.contains("hz"), "error should mention hz: {err}");
+    }
+
+    #[test]
+    fn parse_timer_hz_rejects_zero_interval() {
+        // A pathologically large hz makes 1/hz round below 1ns, so
+        // `try_from_secs_f64` returns `Ok(Duration::ZERO)` instead of an
+        // error. That would be a zero-length (busy-loop) timer, so parsing
+        // must reject it rather than silently accept it.
+        let err = "dora/timer/hz/1000000000000"
+            .parse::<InputMapping>()
+            .unwrap_err();
+        assert!(err.contains("hz"), "error should mention hz: {err}");
+        // Sanity check: the raw conversion really does round to zero here.
+        assert_eq!(
+            Duration::try_from_secs_f64(1.0 / 1_000_000_000_000.0),
+            Ok(Duration::ZERO)
+        );
     }
 
     /// Regression test for dora-rs#2031: the `Display` impl previously emitted

--- a/libraries/message/src/config.rs
+++ b/libraries/message/src/config.rs
@@ -280,22 +280,13 @@ impl FromStr for InputMapping {
                                     "hz must be a positive finite number (got `{value}`)"
                                 ));
                             }
-                            let interval = Duration::try_from_secs_f64(1.0 / hz).map_err(|e| {
-                                format!("hz `{value}` produces an out-of-range interval: {e}")
-                            })?;
                             // A very large hz makes `1/hz` round below 1ns, so
-                            // `try_from_secs_f64` returns `Ok(Duration::ZERO)`
-                            // rather than an error. A zero-length interval means
-                            // the timer fires continuously (busy loop), so reject
-                            // it explicitly -- mirroring the tiny-hz overflow guard
-                            // above.
-                            if interval.is_zero() {
-                                return Err(format!(
-                                    "hz `{value}` is too large: it produces a zero-length \
-                                     timer interval"
-                                ));
-                            }
-                            interval
+                            // `try_from_secs_f64` returns `Ok(Duration::ZERO)`;
+                            // that zero interval is caught by the shared guard
+                            // after this `match`, together with `<unit>/0`.
+                            Duration::try_from_secs_f64(1.0 / hz).map_err(|e| {
+                                format!("hz `{value}` produces an out-of-range interval: {e}")
+                            })?
                         }
                         other => {
                             return Err(format!(
@@ -303,6 +294,19 @@ impl FromStr for InputMapping {
                             ));
                         }
                     };
+                    // A zero-length interval is invalid for every unit: the timer
+                    // task builds `tokio::time::interval(interval)`, which panics
+                    // (`period` must be non-zero). Reject it at parse time for all
+                    // units -- `secs/0`, `millis/0`, `micros/0`, `nanos/0`, and a
+                    // huge `hz` that rounds `1/hz` below 1ns -- so a bad descriptor
+                    // fails at load with a clear message instead of panicking a
+                    // daemon task later.
+                    if interval.is_zero() {
+                        return Err(format!(
+                            "timer interval must be non-zero (`{unit}/{value}` \
+                             produces a zero-length interval)"
+                        ));
+                    }
                     Self::Timer { interval }
                 }
                 Some(("logs", rest)) => {
@@ -762,16 +766,27 @@ mod tests {
     }
 
     #[test]
-    fn parse_timer_hz_rejects_zero_interval() {
-        // A pathologically large hz makes 1/hz round below 1ns, so
-        // `try_from_secs_f64` returns `Ok(Duration::ZERO)` instead of an
-        // error. That would be a zero-length (busy-loop) timer, so parsing
-        // must reject it rather than silently accept it.
-        let err = "dora/timer/hz/1000000000000"
-            .parse::<InputMapping>()
-            .unwrap_err();
-        assert!(err.contains("hz"), "error should mention hz: {err}");
-        // Sanity check: the raw conversion really does round to zero here.
+    fn parse_timer_rejects_zero_interval_for_every_unit() {
+        // A zero-length interval panics `tokio::time::interval` in the timer
+        // task (`period` must be non-zero), so every unit that can express it
+        // must be rejected at parse time -- not just `hz`. `<unit>/0` is the
+        // obvious case; a huge `hz` reaches the same zero interval because
+        // `1/hz` rounds below 1ns.
+        let cases = [
+            "dora/timer/secs/0",
+            "dora/timer/millis/0",
+            "dora/timer/micros/0",
+            "dora/timer/nanos/0",
+            "dora/timer/hz/1000000000000",
+        ];
+        for case in cases {
+            let err = case.parse::<InputMapping>().unwrap_err();
+            assert!(
+                err.contains("non-zero"),
+                "`{case}` should be rejected as a zero-length interval, got: {err}"
+            );
+        }
+        // Sanity check: the huge-hz conversion really does round to zero.
         assert_eq!(
             Duration::try_from_secs_f64(1.0 / 1_000_000_000_000.0),
             Ok(Duration::ZERO)


### PR DESCRIPTION
## Issue

The per-interval timer task builds `tokio::time::interval(interval)` (`binaries/daemon/src/running_dataflow.rs:315`), which **panics** on a zero-length interval (`` `period` must be non-zero ``). Several descriptor inputs parsed to a zero interval and reached that panic:

- `dora/timer/hz/<huge>` — for a very large `hz`, `1/hz` rounds below 1 ns and `Duration::try_from_secs_f64` returns `Ok(Duration::ZERO)`.
- `dora/timer/secs/0`, `millis/0`, `micros/0`, `nanos/0` — `Duration::from_*(0).is_zero()` is `true`.

Parsing accepted all of these, so a bad descriptor panicked a daemon task at runtime instead of failing at load.

## Fix

Hoist a single `interval.is_zero()` guard to just after the `match unit { … }` block, so **all five units** are covered in one place, and simplify the `hz` arm. A zero interval now fails at parse time with a clear message (surfaced at YAML load via `Deserialize for InputMapping`) instead of panicking the daemon later.

## Compatibility

Not a compat break for previously-valid input: `dora/timer/hz/0` was already rejected on `main` by the existing `hz <= 0.0` guard. The only newly-rejected inputs are `<unit>/0` and `hz` values large enough to round `1/hz` below 1 ns — all of which previously produced a zero interval that panicked the daemon. This trades a runtime panic for a parse-time error. No in-repo dataflow uses a zero-interval timer.

## Validation

- `parse_timer_rejects_zero_interval_for_every_unit` covers `secs/0`, `millis/0`, `micros/0`, `nanos/0`, and the huge-`hz` case.
- `cargo test -p dora-message --lib config::tests::parse_timer` → 8 passed; `cargo fmt`/`clippy` clean.

---
*This is a machine-generated pull request authored by Claude (an AI agent), updated to address review feedback. Please review carefully before merging.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)