### PR TITLE
fix(core): reject ancestry and reflog git rev-specs in checkout_tree

### DIFF
--- a/libraries/core/src/build/git.rs
+++ b/libraries/core/src/build/git.rs
@@ -350,9 +350,31 @@ async fn fetch_changes(
     Ok(repository)
 }
 
+/// Returns `true` if `commit_hash` contains git rev-spec *navigation* syntax.
+///
+/// A pinned commit reference is only meant to be a hex commit hash or a plain
+/// branch/tag name. Rev-spec operators instead resolve to a *different* commit
+/// than any literal ref, defeating the reproducibility of the pin:
+///
+/// * `a..b` / `a...b` — commit range
+/// * `ref:path`       — `<tree-ish>:<path>` blob/tree lookup
+/// * `ref^`, `ref^2`  — parent navigation
+/// * `ref~5`          — ancestor navigation
+/// * `ref@{...}`      — reflog / date lookup (e.g. `HEAD@{yesterday}`)
+///
+/// A legitimate git ref name can never contain `~`, `^`, `:`, `..`, or `@{`
+/// (see `git-check-ref-format`), so rejecting them cannot block a valid pin.
+fn contains_revspec_navigation(commit_hash: &str) -> bool {
+    commit_hash.contains("..")
+        || commit_hash.contains(':')
+        || commit_hash.contains('^')
+        || commit_hash.contains('~')
+        || commit_hash.contains("@{")
+}
+
 fn checkout_tree(repository: &git2::Repository, commit_hash: &str) -> eyre::Result<()> {
     // Reject arbitrary rev-spec expressions; only allow hex commit hashes and branch/tag names.
-    if commit_hash.contains("..") || commit_hash.contains(':') || commit_hash.contains('^') {
+    if contains_revspec_navigation(commit_hash) {
         eyre::bail!(
             "invalid commit reference '{commit_hash}': rev-spec expressions are not allowed"
         );
@@ -373,4 +395,44 @@ fn checkout_tree(repository: &git2::Repository, commit_hash: &str) -> eyre::Resu
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::contains_revspec_navigation;
+
+    #[test]
+    fn plain_refs_and_hashes_are_allowed() {
+        for ok in [
+            "main",
+            "release-1.2",
+            "v1.0.0",
+            "feature/foo",
+            "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0",
+            "HEAD",
+        ] {
+            assert!(
+                !contains_revspec_navigation(ok),
+                "`{ok}` should be accepted as a plain ref/hash"
+            );
+        }
+    }
+
+    #[test]
+    fn revspec_navigation_is_rejected() {
+        for bad in [
+            "main~5",           // ancestor navigation
+            "HEAD@{yesterday}", // reflog / date lookup
+            "HEAD@{1}",
+            "v1.0..v2.0", // commit range
+            "tag^2",      // parent navigation
+            "main^",
+            "HEAD:src/main.rs", // <tree-ish>:<path>
+        ] {
+            assert!(
+                contains_revspec_navigation(bad),
+                "`{bad}` should be rejected as a rev-spec expression"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Issue

`checkout_tree` (in `libraries/core/src/build/git.rs`) guards a git-source pin against rev-spec expressions so it resolves only to a literal commit hash or branch/tag name. The denylist covered `..`, `:`, and `^`, but not the `~` (ancestor) or `@{...}` (reflog / date) navigation operators:

```rust
if commit_hash.contains("..") || commit_hash.contains(':') || commit_hash.contains('^') { ... }
```

So a descriptor with `commit_hash: "main~5"` or `"HEAD@{yesterday}"` passed validation, and `revparse_ext` resolved it to a **different** commit than any literal ref — defeating the reproducibility the guard is meant to enforce.

## Fix

Extract the check into `contains_revspec_navigation` and add `~` and `@{` to the rejected set. A valid git ref name can never contain `~`, `^`, `:`, `..`, or `@{` (per `git-check-ref-format`), and neither can a hex commit hash, so no legitimate pin is newly rejected. All three `checkout_tree` call sites pass a user-supplied `commit_hash`, so every path is hardened uniformly.

## Validation

- New unit tests: `plain_refs_and_hashes_are_allowed` (main, `release-1.2`, `v1.0.0`, `feature/foo`, a 40-char hash, `HEAD`) and `revspec_navigation_is_rejected` (`main~5`, `HEAD@{yesterday}`, `HEAD@{1}`, `v1.0..v2.0`, `tag^2`, `main^`, `HEAD:src/main.rs`).
- `cargo test -p dora-core --features build build::git::tests` → 2 passed; `cargo fmt`/`clippy --features build` clean.

---
*This is a machine-generated pull request authored by Claude (an AI agent). It has been verified against current `origin/main`, but please review carefully before merging.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Li8Us8Czain6HcimZJiedm)_