### PR TITLE
refactor(core): remove always-None TypeSuggestion.line dead code

### DIFF
--- a/libraries/core/src/inference.rs
+++ b/libraries/core/src/inference.rs
@@ -19,25 +19,15 @@ pub struct TypeSuggestion {
     pub suggested_urn: String,
     /// Source file path
     pub file: String,
-    /// Line number in source (None if unavailable)
-    pub line: Option<usize>,
 }
 
 impl std::fmt::Display for TypeSuggestion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(line) = self.line {
-            write!(
-                f,
-                "suggest: node \"{}\" output \"{}\" -> {} (from {}:{})",
-                self.node_id, self.output_id, self.suggested_urn, self.file, line,
-            )
-        } else {
-            write!(
-                f,
-                "suggest: node \"{}\" output \"{}\" -> {} (from {})",
-                self.node_id, self.output_id, self.suggested_urn, self.file,
-            )
-        }
+        write!(
+            f,
+            "suggest: node \"{}\" output \"{}\" -> {} (from {})",
+            self.node_id, self.output_id, self.suggested_urn, self.file,
+        )
     }
 }
 
@@ -80,7 +70,6 @@ impl<'ast> Visit<'ast> for TypeInferenceVisitor {
                         output_id,
                         suggested_urn: urn,
                         file: self.file_name.clone(),
-                        line: None,
                     });
                 }
             }


### PR DESCRIPTION
## Issue

`TypeSuggestion.line` (in `libraries/core/src/inference.rs`) is a public `Option<usize>`, and the `Display` impl had a dedicated `Some(line)` branch printing `file:line`. But the only construction site hardcodes `line: None`. The field is therefore never populated: the `Some` branch is unreachable and the field always reads `None`, implying a source-line feature that does not exist.

## Fix

Remove the dead `line` field and collapse `Display` to the single reachable form. `TypeSuggestion` and `infer_types_from_source` are used only within this module (and its tests) — `grep` confirms no external reference to `TypeSuggestion.line` — so no caller is affected.

## Validation

- `cargo test -p dora-core --features type-inference inference::` → 11 passed (unchanged).
- `cargo fmt`/`clippy --features type-inference` clean.

---
*This is a machine-generated pull request authored by Claude (an AI agent). It has been verified against current `origin/main`, but please review carefully before merging.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Li8Us8Czain6HcimZJiedm)_