### PR TITLE
fix(node): bound _zenoh_schema_subscribers teardown on shutdown

### DIFF
--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -1540,11 +1540,20 @@ impl Drop for EventStream {
         // finish and the dataflow stalls until an outer timeout (dora-rs/dora#2425).
         // The callbacks use `try_send`, so undeclaring before `receiver` drops
         // cannot deadlock on a blocked callback.
+        //
+        // The `@schema` `AdvancedSubscriber`s (added with the Arrow IPC data
+        // plane in #2366) undeclare on the same shared session and can wedge
+        // the same way, so they must be torn down under the same deadline —
+        // mirroring `DoraNode::Drop`, which drops both publisher maps inside
+        // one guard. Left out, they would otherwise drop unbounded in the
+        // implicit field-drop phase after this `Drop` body returns (#2583).
         let subscribers = std::mem::take(&mut self._zenoh_subscribers);
-        if !subscribers.is_empty() {
+        let schema_subscribers = std::mem::take(&mut self._zenoh_schema_subscribers);
+        if !subscribers.is_empty() || !schema_subscribers.is_empty() {
             let completed =
                 teardown_with_timeout("zenoh-subscribers", ZENOH_TEARDOWN_TIMEOUT, move || {
                     drop(subscribers);
+                    drop(schema_subscribers);
                 });
             if !completed {
                 tracing::warn!(


### PR DESCRIPTION
## Summary

Fixes #2583.

The node-shutdown-hang guard added in #2439 only wrapped `_zenoh_subscribers` in `EventStream::Drop`. The Arrow IPC data plane (#2366) then added a **second** per-input zenoh entity on the shared session — `_zenoh_schema_subscribers` (the `@schema` `AdvancedSubscriber`s) — which was left **outside** the `teardown_with_timeout` deadline. It was dropped inline during Rust's implicit field-drop phase, after the `Drop` body returns. Its `undeclare` on the shared session blocks indefinitely when zenoh's net runtime is wedged (stuck retrying an unreachable scouted peer), reopening the exact node-shutdown hang #2439 set out to fix — the #2425 signature (record-replay `dora record` never returns; multi-daemon "dataflow not finished after N retries").

This was inconsistent with the **publisher** side, which #2366 got right: `DoraNode::Drop` takes *both* publisher maps and drops them together inside one guard.

## Change

Take both subscriber vectors and drop them together inside a single `teardown_with_timeout("zenoh-subscribers", ...)` closure in `EventStream::Drop`, mirroring the publisher side. `std::mem::take` leaves empty `Vec`s behind, so the later implicit field-drop is a no-op and there is no double-undeclare.

## Testing

- `cargo check -p dora-node-api`
- `cargo clippy -p dora-node-api -- -D warnings`
- `cargo fmt --all -- --check`

Nodes with only timer inputs declare no subscribers and are unaffected (the guard is skipped when both vectors are empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0113jYVAS47BoeJZ9qQ1Q2Yz)_