### PR TITLE
fix(daemon,cli): report true on-wire size in `dora topic info`

### DIFF
--- a/binaries/cli/src/command/topic/info.rs
+++ b/binaries/cli/src/command/topic/info.rs
@@ -178,19 +178,14 @@ fn info(
                     };
                     match event.inner {
                         InterDaemonEvent::Output { data, metadata, .. } => {
-                            // Prefer the daemon-stamped on-wire size: the debug
-                            // frame's `data` is a rebuilt self-describing stream
-                            // with the schema prepended to every frame, but a
-                            // schema-once output ships that schema only once, so
-                            // `data.len()` over-reports bandwidth. Fall back to the
-                            // buffer length when the size isn't present (#2584).
-                            let data_size = dora_message::metadata::get_integer_param(
+                            // Charge the real on-wire size, not the rebuilt
+                            // self-describing `data` (which re-prepends the schema
+                            // a schema-once output ships only once) — see
+                            // `debug_frame_wire_size` (#2584).
+                            let data_size = dora_message::metadata::debug_frame_wire_size(
                                 &metadata.parameters,
-                                dora_message::metadata::WIRE_SIZE,
-                            )
-                            .and_then(|n| usize::try_from(n).ok())
-                            .or_else(|| data.as_ref().map(|d| d.len()))
-                            .unwrap_or(0);
+                                data.as_deref(),
+                            );
                             // The payload is a self-describing Arrow IPC stream;
                             // read its data type from the decoded array (best
                             // effort — a malformed stream just leaves it unknown).

--- a/binaries/cli/src/command/topic/info.rs
+++ b/binaries/cli/src/command/topic/info.rs
@@ -177,8 +177,20 @@ fn info(
                         }
                     };
                     match event.inner {
-                        InterDaemonEvent::Output { data, .. } => {
-                            let data_size = data.as_ref().map(|d| d.len()).unwrap_or(0);
+                        InterDaemonEvent::Output { data, metadata, .. } => {
+                            // Prefer the daemon-stamped on-wire size: the debug
+                            // frame's `data` is a rebuilt self-describing stream
+                            // with the schema prepended to every frame, but a
+                            // schema-once output ships that schema only once, so
+                            // `data.len()` over-reports bandwidth. Fall back to the
+                            // buffer length when the size isn't present (#2584).
+                            let data_size = dora_message::metadata::get_integer_param(
+                                &metadata.parameters,
+                                dora_message::metadata::WIRE_SIZE,
+                            )
+                            .and_then(|n| usize::try_from(n).ok())
+                            .or_else(|| data.as_ref().map(|d| d.len()))
+                            .unwrap_or(0);
                             // The payload is a self-describing Arrow IPC stream;
                             // read its data type from the decoded array (best
                             // effort — a malformed stream just leaves it unknown).

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -5697,7 +5697,10 @@ fn rebuild_debug_topic_stream(
 #[cfg(test)]
 mod debug_topic_tests {
     use super::rebuild_debug_topic_stream;
-    use dora_message::metadata::{MetadataParameters, Parameter, SCHEMA_HASH, fnv1a};
+    use dora_message::metadata::{
+        MetadataParameters, Parameter, SCHEMA_HASH, WIRE_SIZE, debug_frame_wire_size, fnv1a,
+        get_integer_param, strip_internal_parameters,
+    };
 
     fn params_with_schema_hash(hash: u64) -> MetadataParameters {
         let mut params = MetadataParameters::default();
@@ -5740,36 +5743,56 @@ mod debug_topic_tests {
         assert_eq!(out, Some(expected));
     }
 
-    /// The true on-wire size stamped for `dora topic info` (the data-sample
-    /// `payload.len()`) must exclude the schema block that `rebuild_*` prepends
-    /// for inspection — otherwise bandwidth is over-reported by the schema size
-    /// on every schema-once frame, and by the most for the small/frequent
-    /// primitive outputs the schema-once optimization targets (#2584). For a
-    /// full self-describing frame the wire size equals the rebuilt length.
+    /// End-to-end guard for the `dora topic info` bandwidth fix, mirroring the
+    /// daemon debug path (the topic subscriber in `Daemon::spawn_dataflow`):
+    /// rebuild the inspection stream, strip the internal wire keys, then stamp
+    /// the *input* payload length under `WIRE_SIZE`. The CLI reader
+    /// ([`debug_frame_wire_size`]) must then charge the schema-less on-wire
+    /// size, not the rebuilt stream — otherwise bandwidth is over-reported by
+    /// the prepended schema on every schema-once frame, worst for the
+    /// small/frequent primitives the schema-once optimization targets (#2584).
+    /// Keep this in sync with the stamp site in `spawn_dataflow`.
     #[test]
     fn on_wire_size_excludes_prepended_schema() {
+        // --- schema-once frame: rebuilt = schema ++ batch, only batch on-wire.
         let schema = b"SCHEMA-BLOCK".to_vec();
         let hash = fnv1a(&schema);
         let batch = b"schema-less-batch".to_vec();
         let mut cache = vec![(hash, schema.clone())];
+        let mut params = params_with_schema_hash(hash);
 
-        // schema-once: rebuilt = schema ++ batch, but only `batch` is on-wire.
         let rebuilt =
-            rebuild_debug_topic_stream(&mut cache, &params_with_schema_hash(hash), &batch)
-                .expect("schema cached");
-        let wire_size = batch.len();
-        assert_eq!(rebuilt.len(), schema.len() + wire_size);
+            rebuild_debug_topic_stream(&mut cache, &params, &batch).expect("schema cached");
+        assert_eq!(rebuilt.len(), schema.len() + batch.len());
+
+        // Replicate the daemon stamp: strip wire keys, record the input length.
+        strip_internal_parameters(&mut params);
         assert!(
-            wire_size < rebuilt.len(),
-            "schema-once wire size must exclude the prepended schema"
+            get_integer_param(&params, SCHEMA_HASH).is_none(),
+            "internal wire keys must be stripped before stamping"
+        );
+        params.insert(
+            WIRE_SIZE.to_string(),
+            Parameter::Integer(batch.len() as i64),
         );
 
-        // full stream: rebuilt == payload, so the wire size is the full length.
+        // The CLI reader charges the schema-less size, not the rebuilt stream.
+        let charged = debug_frame_wire_size(&params, Some(&rebuilt));
+        assert_eq!(charged, batch.len());
+        assert!(
+            charged < rebuilt.len(),
+            "schema-once accounting must exclude the prepended schema"
+        );
+
+        // --- full self-describing frame: rebuilt == payload, charge full len.
         let full = b"self-describing-stream".to_vec();
-        let out =
-            rebuild_debug_topic_stream(&mut Vec::new(), &MetadataParameters::default(), &full)
-                .expect("full stream forwarded");
+        let mut full_params = MetadataParameters::default();
+        let out = rebuild_debug_topic_stream(&mut Vec::new(), &full_params, &full)
+            .expect("full stream forwarded");
         assert_eq!(out.len(), full.len());
+        strip_internal_parameters(&mut full_params);
+        full_params.insert(WIRE_SIZE.to_string(), Parameter::Integer(full.len() as i64));
+        assert_eq!(debug_frame_wire_size(&full_params, Some(&out)), full.len());
     }
 
     #[test]

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -2999,6 +2999,20 @@ impl Daemon {
                                     dora_message::metadata::strip_internal_parameters(
                                         &mut metadata.parameters,
                                     );
+                                    // Record the true on-wire size so `dora topic
+                                    // info` measures the schema-less batch that
+                                    // actually travelled, not the rebuilt stream
+                                    // (which prepends the schema to every frame even
+                                    // though it ships once). For a full
+                                    // self-describing frame this equals `data.len()`;
+                                    // for a schema-once batch it excludes the
+                                    // prepended schema block (dora-rs/dora#2584).
+                                    metadata.parameters.insert(
+                                        dora_message::metadata::WIRE_SIZE.to_string(),
+                                        dora_message::metadata::Parameter::Integer(
+                                            payload.len() as i64
+                                        ),
+                                    );
                                     let event = Event::DebugTopicData {
                                         dataflow_id,
                                         output_id: OutputId(node_id.clone(), output_id.clone()),
@@ -5724,6 +5738,38 @@ mod debug_topic_tests {
         let mut expected = schema;
         expected.extend_from_slice(&batch);
         assert_eq!(out, Some(expected));
+    }
+
+    /// The true on-wire size stamped for `dora topic info` (the data-sample
+    /// `payload.len()`) must exclude the schema block that `rebuild_*` prepends
+    /// for inspection — otherwise bandwidth is over-reported by the schema size
+    /// on every schema-once frame, and by the most for the small/frequent
+    /// primitive outputs the schema-once optimization targets (#2584). For a
+    /// full self-describing frame the wire size equals the rebuilt length.
+    #[test]
+    fn on_wire_size_excludes_prepended_schema() {
+        let schema = b"SCHEMA-BLOCK".to_vec();
+        let hash = fnv1a(&schema);
+        let batch = b"schema-less-batch".to_vec();
+        let mut cache = vec![(hash, schema.clone())];
+
+        // schema-once: rebuilt = schema ++ batch, but only `batch` is on-wire.
+        let rebuilt =
+            rebuild_debug_topic_stream(&mut cache, &params_with_schema_hash(hash), &batch)
+                .expect("schema cached");
+        let wire_size = batch.len();
+        assert_eq!(rebuilt.len(), schema.len() + wire_size);
+        assert!(
+            wire_size < rebuilt.len(),
+            "schema-once wire size must exclude the prepended schema"
+        );
+
+        // full stream: rebuilt == payload, so the wire size is the full length.
+        let full = b"self-describing-stream".to_vec();
+        let out =
+            rebuild_debug_topic_stream(&mut Vec::new(), &MetadataParameters::default(), &full)
+                .expect("full stream forwarded");
+        assert_eq!(out.len(), full.len());
     }
 
     #[test]

--- a/libraries/message/src/metadata.rs
+++ b/libraries/message/src/metadata.rs
@@ -167,6 +167,24 @@ pub const SCHEMA_HASH: &str = "_schema_hash";
 /// Debug/inspection path only — never set on real node→node outputs.
 pub const WIRE_SIZE: &str = "_wire_size";
 
+/// Byte size to charge for a `dora topic` debug frame when accounting bandwidth.
+///
+/// Prefers the daemon-stamped [`WIRE_SIZE`] (the real on-wire data-sample
+/// length): the `data` the CLI receives is a rebuilt self-describing stream
+/// whose schema was re-prepended for inspection, so for a schema-once output
+/// `data.len()` over-reports what actually travelled. Falls back to the buffer
+/// length when the key is absent — an older daemon, or a non-debug frame that
+/// never carried it (dora-rs/dora#2584). A present-but-out-of-range stamp (a
+/// negative `i64` that can't be a byte count) also falls back rather than
+/// silently counting zero. Keep this the single reader of [`WIRE_SIZE`] so the
+/// daemon stamp and the CLI accounting can never disagree on the fallback rule.
+pub fn debug_frame_wire_size(params: &MetadataParameters, data: Option<&[u8]>) -> usize {
+    get_integer_param(params, WIRE_SIZE)
+        .and_then(|n| usize::try_from(n).ok())
+        .or_else(|| data.map(|d| d.len()))
+        .unwrap_or(0)
+}
+
 /// Returns `true` if the given parameters carry any pattern-correlation key
 /// ([`REQUEST_ID`], [`GOAL_ID`], or [`GOAL_STATUS`]).
 ///
@@ -333,5 +351,37 @@ mod tests {
         let mut params = MetadataParameters::default();
         params.insert("n".to_string(), Parameter::Integer(1));
         assert_eq!(get_bool_param(&params, "n"), None);
+    }
+
+    #[test]
+    fn debug_frame_wire_size_prefers_stamped_value() {
+        // The stamped size wins over the (larger, schema-inflated) buffer: a
+        // schema-once frame's rebuilt `data` is bigger than what travelled.
+        let mut params = MetadataParameters::default();
+        params.insert(WIRE_SIZE.to_string(), Parameter::Integer(17));
+        assert_eq!(debug_frame_wire_size(&params, Some(&[0u8; 42])), 17);
+    }
+
+    #[test]
+    fn debug_frame_wire_size_falls_back_to_buffer_len() {
+        // No stamp (older daemon / non-debug frame) ⇒ use the buffer length.
+        let params = MetadataParameters::default();
+        assert_eq!(debug_frame_wire_size(&params, Some(&[0u8; 42])), 42);
+    }
+
+    #[test]
+    fn debug_frame_wire_size_falls_back_on_out_of_range_stamp() {
+        // A negative i64 can't be a byte count; fall back rather than count 0.
+        let mut params = MetadataParameters::default();
+        params.insert(WIRE_SIZE.to_string(), Parameter::Integer(-1));
+        assert_eq!(debug_frame_wire_size(&params, Some(&[0u8; 42])), 42);
+    }
+
+    #[test]
+    fn debug_frame_wire_size_zero_without_stamp_or_buffer() {
+        assert_eq!(
+            debug_frame_wire_size(&MetadataParameters::default(), None),
+            0
+        );
     }
 }

--- a/libraries/message/src/metadata.rs
+++ b/libraries/message/src/metadata.rs
@@ -153,6 +153,20 @@ pub const FRAMING_ARROW_IPC: &str = "arrow-ipc";
 /// stream (large/SHM and daemon-path payloads).
 pub const SCHEMA_HASH: &str = "_schema_hash";
 
+/// Metadata key carrying the true on-wire byte size (as an `i64`) of a
+/// `dora topic` debug frame's data sample.
+///
+/// The daemon rebuilds a self-describing Arrow IPC stream for inspection by
+/// prepending the retained schema block to each schema-once batch, so the
+/// rebuilt stream the CLI receives is larger than what actually travelled on
+/// the wire (the schema-less batch — the schema is published only once on the
+/// `@schema` subtopic). To keep `dora topic info`'s bandwidth accounting
+/// accurate, the daemon stamps the original data-sample length here; the CLI
+/// measures this instead of the rebuilt stream length (dora-rs/dora#2584).
+///
+/// Debug/inspection path only — never set on real node→node outputs.
+pub const WIRE_SIZE: &str = "_wire_size";
+
 /// Returns `true` if the given parameters carry any pattern-correlation key
 /// ([`REQUEST_ID`], [`GOAL_ID`], or [`GOAL_STATUS`]).
 ///


### PR DESCRIPTION
## Summary

Fixes #2584.

After the Arrow IPC data plane (#2366), `dora topic info` over-reports bandwidth and total-bytes for schema-once (small/primitive) outputs. The daemon rebuilds a self-describing Arrow IPC stream for inspection by prepending the retained schema block to **every** debug frame (`rebuild_debug_topic_stream`), but on the wire that schema block travels only **once** (published on the `@schema` subtopic); each data sample carries only the schema-less record batch. `dora topic info` measured the length of the *rebuilt* stream, so the ~200+ B schema was counted on every message — reported bandwidth / total bytes came out several-to-many× the true network usage for exactly the small, frequent primitive messages the schema-once optimization matters most for. Under the pre-#2366 raw-buffer format the measured size was ≈ the payload bytes, so this is an accuracy regression.

## Change

Measure the real on-wire size instead of the rebuilt stream:

- **daemon**: stamps the original data-sample length on the debug frame's metadata under a new debug-only `_wire_size` key (`dora_message::metadata::WIRE_SIZE`). For a full self-describing frame this equals `data.len()`; for a schema-once batch it excludes the prepended schema block.
- **cli**: `dora topic info` records `_wire_size` when present, falling back to the buffer length otherwise (robust to older daemons / non-debug frames).

The size is carried in **metadata** (set only on the inspection path) rather than added as a field to the shared `InterDaemonEvent::Output` wire struct — so the real data-forwarding hot path gains **no** per-message overhead, and the change stays confined to the debug/inspection path.

## Testing

- New `dora-daemon` test `on_wire_size_excludes_prepended_schema` — asserts the stamped wire size (the data-sample `payload.len()`) excludes the schema block prepended by `rebuild_debug_topic_stream` for a schema-once frame, and equals the full length for a self-describing frame.
- `cargo test -p dora-daemon --lib debug_topic_tests` (8 passed), `cargo clippy -p dora-message -p dora-cli -- -D warnings`, `cargo fmt --all -- --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0113jYVAS47BoeJZ9qQ1Q2Yz)_