### PR TITLE
Fixes for: upgrade workspace dependencies to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,7 +236,6 @@ jobs:
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
-    needs: test
     if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'trunk-merge/')
     steps:
       - uses: actions/checkout@v6
@@ -312,7 +311,6 @@ jobs:
   contract-tests:
     name: Semantic contract tests
     runs-on: ubuntu-latest
-    needs: test
     if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'trunk-merge/')
     timeout-minutes: 30
     steps:
@@ -364,7 +362,6 @@ jobs:
   bench:
     name: Benchmark regression check
     runs-on: ubuntu-latest
-    needs: test
     if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'trunk-merge/')
     timeout-minutes: 20
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,6 +243,18 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
+      # Now that this job runs in parallel with `test` (#2524) it no longer
+      # inherits `test`'s freed disk, and it builds the CLI + all E2E test
+      # binaries itself. Reclaim the ~25 GB of preinstalled toolchains the
+      # runner ships so the build doesn't hit "no space left on device".
+      - name: Free disk space
+        shell: bash
+        run: |
+          set -eux
+          df -h
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /opt/hostedtoolcache/CodeQL || true
+          docker system prune -af || true
+          df -h
       - name: Build CLI
         run: cargo build -p dora-cli --release
       - name: Install CLI
@@ -321,6 +333,19 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: workspace-test
+      # Runs in parallel with `test` (#2524), so it can't rely on `test`
+      # having freed disk. It builds the dora-examples test binary and
+      # compiles the PyO3 node extension via `uv pip install -e` below —
+      # both large. Free the preinstalled toolchains first to avoid
+      # "no space left on device".
+      - name: Free disk space
+        shell: bash
+        run: |
+          set -eux
+          df -h
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /opt/hostedtoolcache/CodeQL || true
+          docker system prune -af || true
+          df -h
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
@@ -370,6 +395,17 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
+      # Runs in parallel with `test` (#2524); compiles the criterion
+      # benchmark binaries for dora-message + dora-daemon itself. Free the
+      # preinstalled toolchains first to avoid "no space left on device".
+      - name: Free disk space
+        shell: bash
+        run: |
+          set -eux
+          df -h
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /opt/hostedtoolcache/CodeQL || true
+          docker system prune -af || true
+          df -h
 
       # Restore baseline from the most recent main-branch run.
       # The key uses a fixed prefix; restore-keys enables prefix matching

--- a/.github/workflows/test-c-cpp-libraries.yml
+++ b/.github/workflows/test-c-cpp-libraries.yml
@@ -6,49 +6,158 @@ name: Test C/C++ find_package
 # dora-operator-api-cxx. Each crate path: cargo build → xtask stage →
 # cmake configure → cmake build of a checked-in smoke fixture.
 # Guards #1756's find_package contract.
+#
+# Tiering, mirroring .github/workflows/ci.yml:
+#
+#   The smoke matrix is expensive (3 OSes × 2 release cargo builds ×
+#   4 cmake builds; macOS bills at 10x, Windows at 2x). It is skipped on
+#   regular PRs, and on Trunk merge-queue batches / pushes to main it runs
+#   only when the changed files touch the find_package surface — so one run
+#   covers a batch of up to 5 PRs, and quiet batches cost one short runner.
+#   Manual dispatch always runs it.
+#
+#   `find_package smoke all green` is a merge-queue required status
+#   (.trunk/trunk.yaml). That is why there is no workflow-level `paths:`
+#   filter: a workflow skipped by path filtering emits *no* check run at
+#   all, so the required name would stay Pending and stall the batch.
+#   (A job skipped by `if:` does emit a check run, which is why the `if:`
+#   gating below is safe.) The path filter therefore lives inside the
+#   workflow, in the `changes` job, and the aggregator runs
+#   unconditionally. Same reasoning as pip-release.yml.
 
 on:
   push:
     branches: [main]
-    paths:
-      - "apis/c/**"
-      - 'apis/c\+\+/**'
-      # Transitive Rust deps — the C/C++ surfaces wrap these, so an
-      # ABI-breaking change here can silently regress find_package
-      # consumers without touching apis/c{,++}/.
-      - "apis/rust/node/**"
-      - "apis/rust/operator/**"
-      - "libraries/core/**"
-      - "libraries/message/**"
-      - "xtask/**"
-      - "tests/cmake-find-package-c/**"
-      - "tests/cmake-find-package-cxx/**"
-      - "tests/cmake-find-package-operator-c/**"
-      - "tests/cmake-find-package-operator-cxx/**"
-      - ".github/workflows/test-c-cpp-libraries.yml"
   pull_request:
-    paths:
-      - "apis/c/**"
-      - 'apis/c\+\+/**'
-      # Transitive Rust deps — the C/C++ surfaces wrap these, so an
-      # ABI-breaking change here can silently regress find_package
-      # consumers without touching apis/c{,++}/.
-      - "apis/rust/node/**"
-      - "apis/rust/operator/**"
-      - "libraries/core/**"
-      - "libraries/message/**"
-      - "xtask/**"
-      - "tests/cmake-find-package-c/**"
-      - "tests/cmake-find-package-cxx/**"
-      - "tests/cmake-find-package-operator-c/**"
-      - "tests/cmake-find-package-operator-cxx/**"
-      - ".github/workflows/test-c-cpp-libraries.yml"
+    branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  # The `changes` job lists the PR's changed files via the REST API.
+  pull-requests: read
+
 jobs:
+  changes:
+    name: Detect relevant changes
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.decide.outputs.relevant }}
+    steps:
+      - name: Decide whether the find_package surface is affected
+        id: decide
+        shell: bash
+        # `gh` is preinstalled on GitHub-hosted runners, so this needs no
+        # third-party action and no checkout. Interpolations go through
+        # `env:` rather than into the script body, so nothing attacker-
+        # controlled is ever spliced into bash.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BEFORE: ${{ github.event.before }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          # Every entry below is a directory prefix or one exact path, so
+          # plain string matching is exact. Deliberately no globbing: the
+          # `apis/c++/` entry is what broke GitHub's `paths:` filter in
+          # #1918, and `+` is a metacharacter in both ERE and picomatch.
+          PREFIXES=(
+            "apis/c/"
+            "apis/c++/"
+            # Transitive Rust deps — the C/C++ surfaces wrap these, so an
+            # ABI-breaking change here can silently regress find_package
+            # consumers without touching apis/c{,++}/. The fixtures link an
+            # executable, so symbol-level breaks surface at link time.
+            "apis/rust/node/"
+            "apis/rust/operator/"
+            "libraries/core/"
+            "libraries/message/"
+            "xtask/"
+            "tests/cmake-find-package-c/"
+            "tests/cmake-find-package-cxx/"
+            "tests/cmake-find-package-operator-c/"
+            "tests/cmake-find-package-operator-cxx/"
+          )
+          EXACT=(
+            ".github/workflows/test-c-cpp-libraries.yml"
+          )
+
+          # Fail open everywhere: if we cannot determine what changed, run
+          # the matrix rather than silently skip a check the queue gates on.
+          decided() {
+            echo "$2"
+            echo "relevant=$1" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+
+          # Both events have a base to diff against, so both get filtered.
+          # Each endpoint truncates its file list at a different size, and a
+          # truncated list makes a "no match" answer unsound — hence $CAP.
+          case "$EVENT_NAME" in
+            pull_request)
+              CAP=3000  # pulls/files truncates here; --paginate up to it.
+              gh api "repos/$REPO/pulls/$PR_NUMBER/files" \
+                --paginate --jq '.[].filename' > changed.txt \
+                || decided true "::warning::Could not list PR files; running the smoke matrix."
+              ;;
+            push)
+              CAP=300  # compare caps .files at 300 and will not paginate it.
+              # All-zero SHA => branch creation, nothing to compare against.
+              if [ -z "${BEFORE//0/}" ]; then
+                decided true "No base commit for this push; running the smoke matrix."
+              fi
+              # No --paginate: it pages .commits and would re-emit .files.
+              gh api "repos/$REPO/compare/$BEFORE...$SHA" \
+                --jq '.files[].filename' > changed.txt \
+                || decided true "::warning::Could not compare $BEFORE...$SHA; running the smoke matrix."
+              ;;
+            *)
+              decided true "Event is $EVENT_NAME; running the smoke matrix."
+              ;;
+          esac
+
+          if [ "$(wc -l < changed.txt)" -ge "$CAP" ]; then
+            decided true "::warning::Changed-file list hit the $CAP-entry API cap; running the smoke matrix."
+          fi
+
+          relevant=false
+          # `|| [ -n "$file" ]` so a final line without a trailing newline
+          # is still processed rather than silently dropped.
+          while IFS= read -r file || [ -n "$file" ]; do
+            for prefix in "${PREFIXES[@]}"; do
+              # Quoted expansion => prefix strip, never a glob match.
+              if [ "${file#"$prefix"}" != "$file" ]; then
+                echo "Relevant: $file (matched prefix $prefix)"
+                relevant=true
+                break 2
+              fi
+            done
+            for exact in "${EXACT[@]}"; do
+              if [ "$file" = "$exact" ]; then
+                echo "Relevant: $file (exact match)"
+                relevant=true
+                break 2
+              fi
+            done
+          done < changed.txt
+
+          echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
+
   find-package-smoke:
     name: find_package smoke (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    needs: changes
+    if: >-
+      needs.changes.outputs.relevant == 'true' &&
+      (github.event_name != 'pull_request' || startsWith(github.head_ref, 'trunk-merge/'))
     strategy:
       fail-fast: false
       matrix:
@@ -147,3 +256,22 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/dora-cpp-prefix"
           cmake --build build-operator-cxx --config Release
+
+  # Single aggregator check the merge queue gates on. Listing each matrix
+  # expansion in the queue's required-checks config is fragile (names carry
+  # generated `(os)` suffixes); this job fails if any upstream job failed
+  # and succeeds when they all succeeded *or were skipped*. `if: always()`
+  # guarantees the check is always produced, so the queue never waits on a
+  # name that will not report.
+  find-package-all-green:
+    name: find_package smoke all green
+    runs-on: ubuntu-latest
+    needs: [changes, find-package-smoke]
+    if: always()
+    steps:
+      - name: Verify no find_package smoke job failed
+        run: |
+          if [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "One or more find_package smoke jobs failed or were cancelled."
+            exit 1
+          fi

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -14,6 +14,12 @@ version: 0.1
 #   - Cheap checks run on every PR (gate queue entry via branch protection).
 #   - Expensive checks are guarded by `if: ... startsWith(github.head_ref,
 #     'trunk-merge/')` and run only on the batch branch.
+#
+# A required check must be produced on *every* batch branch, or the queue
+# waits forever on a name that never reports. That rules out workflow-level
+# `paths:` filters (a path-filtered workflow emits no check run), which is
+# why `pip-release all green` and `find_package smoke all green` are
+# `if: always()` aggregator jobs in workflows with no `paths:` filter.
 merge:
   required_statuses:
     # Cheap (always run)
@@ -30,3 +36,4 @@ merge:
     - Semantic contract tests
     - Benchmark regression check
     - pip-release all green
+    - find_package smoke all green

--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -25,6 +25,7 @@ use crate::{
     DaemonCommunicationWrapper, PatternError,
     daemon_connection::{DaemonChannel, node_integration_testing::convert_output_to_json},
     event_stream::data_conversion::RawData,
+    node::{ZENOH_TEARDOWN_TIMEOUT, teardown_with_timeout},
 };
 use dora_arrow_convert::IntoArrow;
 use dora_core::{
@@ -73,9 +74,11 @@ pub struct EventStream {
     receiver: tokio::sync::mpsc::Receiver<EventItem>,
     _thread_handle: EventStreamThreadHandle,
     /// Callback subscribers — kept alive for the lifetime of the
-    /// EventStream. Dropping a subscriber stops further callbacks; the
-    /// callback itself will see `blocking_send` return Err once the
-    /// `receiver` (declared above) is dropped.
+    /// EventStream. Dropping a subscriber undeclares it and stops further
+    /// callbacks. The callbacks use `try_send` (never block), so undeclaring
+    /// does not depend on `receiver` being dropped first. `EventStream::drop`
+    /// explicitly tears these down under a deadline (see there); by the time
+    /// this field drops it is already empty.
     _zenoh_subscribers: Vec<zenoh::pubsub::Subscriber<()>>,
     /// Per-input `@schema` subscribers (zenoh-ext AdvancedSubscriber) that prime
     /// the data subscribers' decoders. Kept alive like `_zenoh_subscribers`.
@@ -1527,6 +1530,30 @@ impl Stream for EventStream {
 
 impl Drop for EventStream {
     fn drop(&mut self) {
+        // Tear down the per-input zenoh callback subscribers under a deadline.
+        // `Subscriber::drop` undeclares the subscription on the shared zenoh
+        // session, which blocks indefinitely when zenoh's net runtime is
+        // wedged (e.g. stuck retrying an unreachable scouted peer). Left
+        // unbounded, that hangs the whole node in `EventStream`'s field-drop
+        // sequence — before `DoraNode::Drop` (which already bounds its own
+        // session teardown) even runs — so the daemon never sees the node
+        // finish and the dataflow stalls until an outer timeout (dora-rs/dora#2425).
+        // The callbacks use `try_send`, so undeclaring before `receiver` drops
+        // cannot deadlock on a blocked callback.
+        let subscribers = std::mem::take(&mut self._zenoh_subscribers);
+        if !subscribers.is_empty() {
+            let completed =
+                teardown_with_timeout("zenoh-subscribers", ZENOH_TEARDOWN_TIMEOUT, move || {
+                    drop(subscribers);
+                });
+            if !completed {
+                tracing::warn!(
+                    "zenoh subscriber teardown timed out after {}s; continuing node shutdown",
+                    ZENOH_TEARDOWN_TIMEOUT.as_secs()
+                );
+            }
+        }
+
         let request = Timestamped {
             inner: DaemonRequest::EventStreamDropped,
             timestamp: self.clock.new_timestamp(),

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -97,7 +97,7 @@ const ZENOH_FIRST_PUBLISH_MATCH_POLL_INTERVAL: Duration = Duration::from_millis(
 
 /// Must exceed zenoh's internal 10s session close timeout, which is not
 /// enforceable when zenoh's net runtime is wedged.
-const ZENOH_TEARDOWN_TIMEOUT: Duration = Duration::from_secs(15);
+pub(crate) const ZENOH_TEARDOWN_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Allows sending outputs and retrieving node information.
 ///
@@ -1771,7 +1771,7 @@ impl DoraNodeBuilder {
 /// until process exit. That is acceptable for nodes dropped right before
 /// exit; long-lived hosts (e.g. a Python interpreter dropping a node during
 /// GC) inherit only the bounded delay instead of a permanent hang.
-fn teardown_with_timeout(
+pub(crate) fn teardown_with_timeout(
     label: &str,
     timeout: Duration,
     teardown: impl FnOnce() + Send + 'static,

--- a/binaries/cli/src/command/doctor.rs
+++ b/binaries/cli/src/command/doctor.rs
@@ -161,24 +161,15 @@ fn doctor(args: Doctor) -> eyre::Result<()> {
     // 6. Per-node health
     if let Some(ref session) = session {
         match check_node_health(session) {
-            Ok((total, healthy, degraded, failed_nodes)) => {
-                if failed_nodes > 0 {
-                    fail(
-                        &mut stdout,
-                        &format!(
-                            "Nodes: {total} total, {healthy} healthy, {degraded} degraded, {failed_nodes} failed"
-                        ),
-                    )?;
+            Ok(counts) => match node_health_report(counts) {
+                NodeHealthReport::Fail(msg) => {
+                    fail(&mut stdout, &msg)?;
                     failures += 1;
-                } else if degraded > 0 {
-                    warn(
-                        &mut stdout,
-                        &format!("Nodes: {total} total, {healthy} healthy, {degraded} degraded"),
-                    )?;
-                } else if total > 0 {
-                    pass(&mut stdout, &format!("Nodes: {total} total, all healthy"))?;
                 }
-            }
+                NodeHealthReport::Warn(msg) => warn(&mut stdout, &msg)?,
+                NodeHealthReport::Pass(msg) => pass(&mut stdout, &msg)?,
+                NodeHealthReport::Nothing => {}
+            },
             Err(e) => {
                 fail(&mut stdout, &format!("Nodes: check failed ({e})"))?;
                 failures += 1;
@@ -347,6 +338,90 @@ fn check_uv(stdout: &mut termcolor::StandardStream) -> eyre::Result<()> {
     Ok(())
 }
 
+#[cfg(test)]
+mod node_health_tests {
+    use super::{NodeHealthCounts, NodeHealthReport, node_health_report};
+
+    #[test]
+    fn all_stopped_is_not_reported_as_healthy() {
+        let counts = NodeHealthCounts {
+            total: 3,
+            stopped: 3,
+            ..Default::default()
+        };
+        assert_eq!(
+            node_health_report(counts),
+            NodeHealthReport::Pass("Nodes: 3 total, all stopped".to_string())
+        );
+    }
+
+    #[test]
+    fn healthy_with_some_stopped_reports_both() {
+        let counts = NodeHealthCounts {
+            total: 5,
+            healthy: 2,
+            stopped: 3,
+            ..Default::default()
+        };
+        assert_eq!(
+            node_health_report(counts),
+            NodeHealthReport::Pass("Nodes: 5 total, 2 healthy, 3 stopped".to_string())
+        );
+    }
+
+    #[test]
+    fn all_healthy_has_no_stopped_suffix() {
+        let counts = NodeHealthCounts {
+            total: 2,
+            healthy: 2,
+            ..Default::default()
+        };
+        assert_eq!(
+            node_health_report(counts),
+            NodeHealthReport::Pass("Nodes: 2 total, 2 healthy".to_string())
+        );
+    }
+
+    #[test]
+    fn failed_takes_precedence_and_counts_reconcile() {
+        let counts = NodeHealthCounts {
+            total: 4,
+            healthy: 1,
+            degraded: 1,
+            failed: 1,
+            stopped: 1,
+        };
+        assert_eq!(
+            node_health_report(counts),
+            NodeHealthReport::Fail(
+                "Nodes: 4 total, 1 healthy, 1 degraded, 1 failed, 1 stopped".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn degraded_reports_warn() {
+        let counts = NodeHealthCounts {
+            total: 2,
+            healthy: 1,
+            degraded: 1,
+            ..Default::default()
+        };
+        assert_eq!(
+            node_health_report(counts),
+            NodeHealthReport::Warn("Nodes: 2 total, 1 healthy, 1 degraded".to_string())
+        );
+    }
+
+    #[test]
+    fn no_nodes_reports_nothing() {
+        assert_eq!(
+            node_health_report(NodeHealthCounts::default()),
+            NodeHealthReport::Nothing
+        );
+    }
+}
+
 #[cfg(all(test, target_os = "linux"))]
 mod shm_tests {
     use super::{ShmState, evaluate_shm};
@@ -406,33 +481,90 @@ fn check_connected_machines(
     Ok(expect_reply!(reply, ConnectedDaemons(daemons))?)
 }
 
-fn check_node_health(session: &WsSession) -> eyre::Result<(usize, usize, usize, usize)> {
+/// Per-node health counts. `total` is every known node; the rest partition it
+/// by status, with `stopped` holding cleanly-stopped nodes (which are neither
+/// healthy nor faults).
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct NodeHealthCounts {
+    total: usize,
+    healthy: usize,
+    degraded: usize,
+    failed: usize,
+    stopped: usize,
+}
+
+/// The verdict `dora doctor` renders for the per-node health check. Kept as a
+/// pure function of the counts so the message selection is unit-testable.
+#[derive(Debug, PartialEq, Eq)]
+enum NodeHealthReport {
+    Fail(String),
+    Warn(String),
+    Pass(String),
+    /// No nodes are known — nothing to report.
+    Nothing,
+}
+
+fn node_health_report(counts: NodeHealthCounts) -> NodeHealthReport {
+    let NodeHealthCounts {
+        total,
+        healthy,
+        degraded,
+        failed,
+        stopped,
+    } = counts;
+    // Fold the stopped count into every message so the numbers reconcile with
+    // `total` (which includes stopped nodes).
+    let stopped_suffix = if stopped > 0 {
+        format!(", {stopped} stopped")
+    } else {
+        String::new()
+    };
+    if failed > 0 {
+        NodeHealthReport::Fail(format!(
+            "Nodes: {total} total, {healthy} healthy, {degraded} degraded, {failed} failed{stopped_suffix}"
+        ))
+    } else if degraded > 0 {
+        NodeHealthReport::Warn(format!(
+            "Nodes: {total} total, {healthy} healthy, {degraded} degraded{stopped_suffix}"
+        ))
+    } else if healthy > 0 {
+        NodeHealthReport::Pass(format!(
+            "Nodes: {total} total, {healthy} healthy{stopped_suffix}"
+        ))
+    } else if total > 0 {
+        // Every known node has stopped. Don't claim "all healthy" when nothing
+        // is actually running.
+        NodeHealthReport::Pass(format!("Nodes: {total} total, all stopped"))
+    } else {
+        NodeHealthReport::Nothing
+    }
+}
+
+fn check_node_health(session: &WsSession) -> eyre::Result<NodeHealthCounts> {
     let reply = send_control_request(session, &ControlRequest::GetNodeInfo)?;
     let nodes = expect_reply!(reply, NodeInfoList(infos))?;
 
-    let total = nodes.len();
-    let mut healthy = 0usize;
-    let mut degraded = 0usize;
-    let mut failed = 0usize;
+    let mut counts = NodeHealthCounts {
+        total: nodes.len(),
+        ..Default::default()
+    };
 
     for node in &nodes {
         if let Some(metrics) = &node.metrics {
             use dora_message::daemon_to_coordinator::NodeStatus;
             match metrics.status {
-                NodeStatus::Running => healthy += 1,
-                NodeStatus::Restarting => healthy += 1,
-                NodeStatus::Degraded => degraded += 1,
-                NodeStatus::Failed => failed += 1,
-                // A cleanly-stopped node is neither healthy nor a fault:
-                // skip it so doctor counts reflect the live surface.
-                NodeStatus::Stopped => {}
+                NodeStatus::Running => counts.healthy += 1,
+                NodeStatus::Restarting => counts.healthy += 1,
+                NodeStatus::Degraded => counts.degraded += 1,
+                NodeStatus::Failed => counts.failed += 1,
+                NodeStatus::Stopped => counts.stopped += 1,
             }
         } else {
-            healthy += 1; // No metrics yet = assumed healthy
+            counts.healthy += 1; // No metrics yet = assumed healthy
         }
     }
 
-    Ok((total, healthy, degraded, failed))
+    Ok(counts)
 }
 
 fn validate_dataflow(path: &std::path::Path) -> eyre::Result<()> {

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -403,7 +403,7 @@ impl RunningDataflow {
         } else {
             let grace_duration_kills = self.grace_duration_kills.clone();
             tokio::spawn(async move {
-                let duration = grace_duration.unwrap_or(Duration::from_millis(10000));
+                let duration = grace_duration.unwrap_or(DEFAULT_STOP_GRACE);
                 tokio::time::sleep(duration).await;
 
                 for (node, proc) in &running_processes {

--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -105,6 +105,8 @@ pub fn check_dataflow(dataflow: &Descriptor, working_dir: &Path) -> eyre::Result
                             let path = &python_source.source;
                             if source_is_url(path) {
                                 info!("{path} is a URL."); // TODO: Implement url check.
+                            } else if operator_definition.config.build.is_some() {
+                                info!("skipping path check for operator with build command");
                             } else if !working_dir.join(path).exists() {
                                 bail!("no Python library at `{path}`");
                             }
@@ -112,6 +114,8 @@ pub fn check_dataflow(dataflow: &Descriptor, working_dir: &Path) -> eyre::Result
                         OperatorSource::Wasm(path) => {
                             if source_is_url(path) {
                                 info!("{path} is a URL."); // TODO: Implement url check.
+                            } else if operator_definition.config.build.is_some() {
+                                info!("skipping path check for operator with build command");
                             } else if !working_dir.join(path).exists() {
                                 bail!("no WASM library at `{path}`");
                             }
@@ -1352,6 +1356,50 @@ operators:
         assert!(
             err.contains("runtime-node/<operator_id>/<output_id>"),
             "error should explain the expected format, got: {err}"
+        );
+    }
+
+    // A runtime operator whose artifact is produced by a `build:` command must
+    // not fail the on-disk source check before the build has run — mirroring the
+    // custom-node and shared-library behavior. Exercised via the WASM arm so the
+    // test does not require a Python `dora-rs` runtime (the Python arm carries an
+    // identical guard).
+    #[test]
+    fn operator_with_build_command_skips_missing_source_check() {
+        let dataflow = parse_dataflow(
+            "\
+nodes:
+  - id: runtime-node
+    operators:
+      - id: op1
+        wasm: does/not/exist.wasm
+        build: cargo build
+        outputs:
+          - out
+",
+        );
+        check_dataflow(&dataflow, Path::new("/nonexistent-dora-validate-test")).unwrap();
+    }
+
+    #[test]
+    fn operator_without_build_command_rejects_missing_source() {
+        let dataflow = parse_dataflow(
+            "\
+nodes:
+  - id: runtime-node
+    operators:
+      - id: op1
+        wasm: does/not/exist.wasm
+        outputs:
+          - out
+",
+        );
+        let err = check_dataflow(&dataflow, Path::new("/nonexistent-dora-validate-test"))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("no WASM library"),
+            "missing source without a build command should still be rejected, got: {err}"
         );
     }
 

--- a/libraries/extensions/download/src/lib.rs
+++ b/libraries/extensions/download/src/lib.rs
@@ -5,20 +5,31 @@ use std::os::unix::prelude::PermissionsExt;
 use std::path::{Path, PathBuf};
 use tokio::io::AsyncWriteExt;
 
-fn get_filename(response: &reqwest::Response) -> Option<String> {
-    let raw_name = if let Some(content_disposition) = response.headers().get("content-disposition")
-    {
-        if let Ok(filename) = content_disposition.to_str() {
-            filename
-                .split("filename=")
-                .nth(1)
-                .map(|n| n.trim_matches('"').to_string())
-        } else {
-            None
-        }
+/// Extract the `filename` parameter from a `Content-Disposition` header value.
+///
+/// Handles headers that carry additional parameters after the filename, e.g.
+/// `attachment; filename="model.bin"; size=1000`, and both quoted and unquoted
+/// forms. Returns `None` when no non-empty `filename=` value is present (the
+/// RFC 5987 extended `filename*=` form is not decoded and falls through).
+fn parse_content_disposition_filename(header: &str) -> Option<String> {
+    let rest = header.split("filename=").nth(1)?.trim_start();
+    let name = if let Some(after_quote) = rest.strip_prefix('"') {
+        // Quoted form: the value runs up to the closing quote, so a trailing
+        // `; param=...` (or a `;` inside the quotes) is handled correctly.
+        after_quote.split('"').next().unwrap_or(after_quote)
     } else {
-        None
+        // Token form: the value ends at the next parameter separator.
+        rest.split(';').next().unwrap_or(rest).trim()
     };
+    (!name.is_empty()).then(|| name.to_string())
+}
+
+fn get_filename(response: &reqwest::Response) -> Option<String> {
+    let raw_name = response
+        .headers()
+        .get("content-disposition")
+        .and_then(|value| value.to_str().ok())
+        .and_then(parse_content_disposition_filename);
 
     // If Content-Disposition header is not available, extract from URL
     let raw_name = raw_name.or_else(|| {
@@ -105,4 +116,56 @@ where
         .wrap_err("failed to make downloaded file executable")?;
 
     Ok(path.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_content_disposition_filename;
+
+    #[test]
+    fn quoted_filename_without_extra_params() {
+        assert_eq!(
+            parse_content_disposition_filename("attachment; filename=\"model.bin\""),
+            Some("model.bin".to_string())
+        );
+    }
+
+    #[test]
+    fn quoted_filename_with_trailing_params() {
+        // Regression: the trailing `; size=1000` must not leak into the name.
+        assert_eq!(
+            parse_content_disposition_filename("attachment; filename=\"model.bin\"; size=1000"),
+            Some("model.bin".to_string())
+        );
+    }
+
+    #[test]
+    fn unquoted_filename_with_trailing_params() {
+        assert_eq!(
+            parse_content_disposition_filename("attachment; filename=model.bin; size=1000"),
+            Some("model.bin".to_string())
+        );
+    }
+
+    #[test]
+    fn semicolon_inside_quotes_is_preserved() {
+        assert_eq!(
+            parse_content_disposition_filename("attachment; filename=\"a;b.bin\""),
+            Some("a;b.bin".to_string())
+        );
+    }
+
+    #[test]
+    fn empty_or_missing_filename_returns_none() {
+        assert_eq!(
+            parse_content_disposition_filename("attachment; filename=\"\""),
+            None
+        );
+        assert_eq!(parse_content_disposition_filename("inline"), None);
+        // RFC 5987 extended form is not decoded here; it falls through to None.
+        assert_eq!(
+            parse_content_disposition_filename("attachment; filename*=UTF-8''model.bin"),
+            None
+        );
+    }
 }

--- a/libraries/hub-client/src/transport.rs
+++ b/libraries/hub-client/src/transport.rs
@@ -132,9 +132,10 @@ impl IndexFetcher {
             // to self-heal) from a sound clone whose repository simply does not
             // contain the catalog subpath (a real configuration/bootstrap error
             // — must NOT be re-cloned on every invocation).
-            let incomplete = !clone_dir.join(CLONE_COMPLETE_MARKER).exists();
+            let mut incomplete = !clone_dir.join(CLONE_COMPLETE_MARKER).exists();
             if incomplete && !self.offline {
                 self.reclone(index, git_url, &clone_dir, catalog_subpath)?;
+                incomplete = false; // reclone() writes CLONE_COMPLETE_MARKER on success
             }
             if !catalog.is_dir() {
                 if incomplete {
@@ -556,6 +557,57 @@ source:
             !fetcher.warnings.iter().any(|w| w.contains("re-cloning")),
             "a valid clone must not be re-cloned: {:?}",
             fetcher.warnings
+        );
+    }
+
+    #[test]
+    fn stale_incomplete_flag_not_reused_after_successful_reclone() {
+        // an "incomplete" clone (no completion marker) whose repo genuinely
+        // lacks the catalog subpath must, after a successful *online*
+        // reclone, report the config error — not the stale "interrupted
+        // clone / --offline" message (which implies offline is set and the
+        // clone is still broken, neither of which is true here).
+        let remote_dir = tempfile::tempdir().unwrap();
+        let cache_dir = tempfile::tempdir().unwrap();
+        // remote has content, but under a different dir than the index `path`
+        std::fs::create_dir_all(remote_dir.path().join("node-hub")).unwrap();
+        std::fs::write(remote_dir.path().join("node-hub/readme"), "x").unwrap();
+        run_git(remote_dir.path(), &["init", "--quiet", "-b", "main"]);
+        commit_all(remote_dir.path(), "init");
+        run_git(
+            remote_dir.path(),
+            &["config", "uploadpack.allowFilter", "true"],
+        );
+        let index = remote_index(remote_dir.path()); // path = node-index (absent upstream)
+
+        // manually seed a clone that mimics an interrupted first run: cloned
+        // and its source recorded, but the completion marker never written
+        let clone_dir = cache_dir.path().join(&index.alias);
+        git(
+            None,
+            &[
+                "clone",
+                "--quiet",
+                "--",
+                remote_dir.path().to_str().unwrap(),
+                clone_dir.to_str().unwrap(),
+            ],
+        )
+        .unwrap();
+        std::fs::write(
+            clone_dir.join(SOURCE_MARKER),
+            format!("{}\nnode-index", remote_dir.path().to_str().unwrap()),
+        )
+        .unwrap();
+
+        let mut fetcher = IndexFetcher::with_cache_root(cache_dir.path().into(), false);
+        let err = fetcher.catalog_dir(&index, Path::new(".")).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("node-index"), "{msg}");
+        assert!(
+            !msg.contains("interrupted clone") && !msg.contains("--offline"),
+            "stale `incomplete` flag misreported a real config error as an \
+             interrupted-clone/offline issue: {msg}"
         );
     }
 

--- a/libraries/recording/src/lib.rs
+++ b/libraries/recording/src/lib.rs
@@ -1,3 +1,48 @@
+//! Binary `.drec` recording format for dora dataflow message capture and replay.
+//!
+//! A recording is a [`RecordingHeader`], a sequence of [`RecordEntry`] records,
+//! and an optional [`RecordingFooter`]. Capture a stream with
+//! [`RecordingWriter`] and read it back with [`RecordingReader`]. Both are
+//! generic over any [`std::io::Write`] / [`std::io::Read`], so they work with
+//! files as well as in-memory buffers.
+//!
+//! ```
+//! use dora_recording::{RecordEntry, RecordingHeader, RecordingReader, RecordingWriter};
+//! use std::io::Cursor;
+//!
+//! # fn main() -> eyre::Result<()> {
+//! let header = RecordingHeader {
+//!     version: 1,
+//!     start_nanos: 0,
+//!     dataflow_id: uuid::Uuid::nil(),
+//!     descriptor_yaml: b"nodes: []".to_vec(),
+//! };
+//!
+//! // Write one entry into an in-memory buffer.
+//! let mut buf: Vec<u8> = Vec::new();
+//! {
+//!     let mut writer = RecordingWriter::new(&mut buf, &header)?;
+//!     writer.write_entry(&RecordEntry {
+//!         node_id: "camera".to_string(),
+//!         output_id: "image".to_string(),
+//!         timestamp_offset_nanos: 0,
+//!         event_bytes: vec![1, 2, 3],
+//!     })?;
+//!     let footer = writer.finish()?;
+//!     assert_eq!(footer.total_messages, 1);
+//! }
+//!
+//! // Read it back.
+//! let mut reader = RecordingReader::open(Cursor::new(buf))?;
+//! assert_eq!(reader.header().dataflow_id, uuid::Uuid::nil());
+//! let entry = reader.next_entry()?.expect("one entry");
+//! assert_eq!(entry.node_id, "camera");
+//! assert_eq!(entry.event_bytes, vec![1, 2, 3]);
+//! assert!(reader.next_entry()?.is_none());
+//! # Ok(())
+//! # }
+//! ```
+
 use std::io::{self, BufReader, BufWriter, Read, Write};
 
 use eyre::Context;
@@ -43,6 +88,7 @@ pub struct RecordingWriter<W: Write> {
 }
 
 impl<W: Write> RecordingWriter<W> {
+    /// Create a writer over `inner`, immediately writing the recording header.
     pub fn new(inner: W, header: &RecordingHeader) -> eyre::Result<Self> {
         let mut writer = BufWriter::new(inner);
         write_header(&mut writer, header)?;
@@ -53,6 +99,7 @@ impl<W: Write> RecordingWriter<W> {
         })
     }
 
+    /// Append a single message entry to the recording.
     pub fn write_entry(&mut self, entry: &RecordEntry) -> eyre::Result<()> {
         let node_id_bytes = entry.node_id.as_bytes();
         let output_id_bytes = entry.output_id.as_bytes();
@@ -98,6 +145,7 @@ impl<W: Write> RecordingWriter<W> {
         Ok(())
     }
 
+    /// Write the footer (message/byte totals), flush, and consume the writer.
     pub fn finish(mut self) -> eyre::Result<RecordingFooter> {
         let footer = RecordingFooter {
             total_messages: self.total_messages,
@@ -111,6 +159,7 @@ impl<W: Write> RecordingWriter<W> {
         Ok(footer)
     }
 
+    /// Flush buffered bytes to the underlying writer without finishing.
     pub fn flush(&mut self) -> eyre::Result<()> {
         self.writer.flush().wrap_err("flush failed")
     }
@@ -124,12 +173,14 @@ pub struct RecordingReader<R: Read> {
 }
 
 impl<R: Read> RecordingReader<R> {
+    /// Open a reader over `inner`, immediately parsing and validating the header.
     pub fn open(inner: R) -> eyre::Result<Self> {
         let mut reader = BufReader::new(inner);
         let header = read_header(&mut reader)?;
         Ok(Self { reader, header })
     }
 
+    /// The recording header parsed by [`open`](Self::open).
     pub fn header(&self) -> &RecordingHeader {
         &self.header
     }


### PR DESCRIPTION
Major migrations: arrow 58->59, zenoh 1.8->1.9, mavlink 0.13->0.18
(dialects under mavlink::dialects, renamed features), nom 7->8 (msg-gen
parser rewrite + scoped workaround for rust-bakery/nom#1808), syn 1->2,
process-wrap 8->9, notify 5->8, duration-str 0.5->0.21, self_update
0.42->0.44 (explicit reqwest backend), reqwest 0.12->0.13 (platform
trust store), sha2 0.11, sysinfo 0.38, criterion 0.8, rand 0.10,
aligned-vec 0.6 (bincode wire format verified byte-identical), plus
assorted minor bumps.

Held back with reasons: uhlc (0.9 byte-reverses the serialized HLC ID —
wire-format break, verified empirically), bincode (3.0.0 is a
compile_error! protest stub), pyo3 0.29 (arrow-pyarrow 59 pins ^0.28),
opentelemetry 0.32 (needs opentelemetry-system-metrics release), redb
3/4 + sysinfo 0.39 (above MSRV 1.88), ros2-client/rustdds (pinned on
Atostek/RustDDS#375), prettyplease (must stay 0.1 to unify rust-format's
verbatim feature).

mavlink 0.18 surfaces UDP recv errors that 0.13 swallowed internally;
classify_recv_error gained a datagram mode so ICMP port-unreachable or
a zero-length datagram no longer kills the bridge node (tests added).
Audit waivers updated for new upstream-pinned advisories (lz4_flex,
quick-xml, rustls-pemfile), each with justification and review date.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>