### PR TITLE
fix: correct signal-name mapping for signals 22 and 23 in NodeError Display

### DIFF
--- a/libraries/message/src/common.rs
+++ b/libraries/message/src/common.rs
@@ -140,8 +140,8 @@ impl std::fmt::Display for NodeError {
                     13 => "SIGPIPE".into(),
                     14 => "SIGALRM".into(),
                     15 => "SIGTERM".into(),
-                    22 => "SIGABRT".into(),
-                    23 => "NSIG".into(),
+                    22 => "SIGTTOU".into(),
+                    23 => "SIGURG".into(),
                     other => other.to_string().into(),
                 };
                 if matches!(self.cause, NodeErrorCause::GraceDuration) {
@@ -387,6 +387,35 @@ pub struct BinaryPin {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn node_error_with_signal(signal: i32) -> NodeError {
+        NodeError {
+            timestamp: uhlc::HLC::default().new_timestamp(),
+            cause: NodeErrorCause::Other {
+                stderr: String::new(),
+            },
+            exit_status: NodeExitStatus::Signal(signal),
+        }
+    }
+
+    #[test]
+    fn node_error_signal_display_uses_linux_signal_names() {
+        for (signal, name) in [(6, "SIGABRT"), (22, "SIGTTOU"), (23, "SIGURG")] {
+            assert_eq!(
+                node_error_with_signal(signal).to_string(),
+                format!("exited because of signal {name}")
+            );
+        }
+    }
+
+    #[test]
+    fn node_error_signal_display_falls_back_to_signal_number() {
+        assert_eq!(
+            node_error_with_signal(40).to_string(),
+            "exited because of signal 40"
+        );
+    }
+
     #[test]
     fn test_log_message_serialization() {
         let log_message = LogMessage {


### PR DESCRIPTION
## Summary
Edit the `NodeExitStatus::Signal` match arm in `impl std::fmt::Display for NodeError` in libraries/message/src/common.rs (lines 143-144), changing `22 => "SIGABRT".into()` to `22 => "SIGTTOU".into()` and `23 => "NSIG".into()` to `23 => "SIGURG".into()`, matching the Linux signal numbering used by the rest of the table. Keep the change minimal per the issue's "at minimum" guidance - do not expand the table to other signal numbers or introduce platform-conditional mapping, since the maintainer flagged those as optional extras. Add unit tests in the existing `mod tests` block at the bottom of the same file asserting the Display output for `NodeExitStatus::Signal(22)`, `Signal(23)`, and an unmapped number.

## Why this matters
The `Display` implementation for `NodeError` in `libraries/message/src/common.rs` contains a signal-number to signal-name lookup table used when a dora node is killed by a signal. Two entries are wrong: signal 22 is mapped to "SIGABRT" (which is actually signal 6, already correctly mapped) and signal 23 is mapped to "NSIG" (a libc count constant, not a deliverable signal). On Linux, signal 22 is SIGTTOU and signal 23 is SIGURG, so users debugging a node crash see a misleading signal name. The issue was filed by the repo's primary maintainer (phil-opp) with the exact fix spelled out, has bug/rust/daemon labels, no assignee, no comments, and no prior PR attempts.

See https://github.com/dora-rs/dora/issues/2459.

## Testing
- Display of a NodeError with `NodeExitStatus::Signal(22)` contains "SIGTTOU" (happy path for the first fixed entry). - Display of a NodeError with `NodeExitStatus::Signal(23)` contains "SIGURG" (happy path for the second fixed entry). - Display of a NodeError with `NodeExitStatus::Signal(6)` still contains "SIGABRT" (regression guard: the correct entry is untouched and no longer duplicated). - Display of a NodeError with an unmapped signal number (e.g.

Fixes #2459
