### PR TITLE
fix(node): cap fallback Arrow IPC encode to fail loudly on oversized output

### DIFF
--- a/apis/rust/node/src/node/arrow_utils.rs
+++ b/apis/rust/node/src/node/arrow_utils.rs
@@ -51,6 +51,22 @@ pub fn encode_arrow_ipc(arrow_array: &ArrayData) -> eyre::Result<Vec<u8>> {
             .finish()
             .context("failed to finish Arrow IPC stream")?;
     }
+
+    // Fail loudly at the producer instead of emitting a stream that every
+    // receive path will unconditionally reject. `decode_arrow_ipc`,
+    // `decode_arrow_ipc_zero_copy`, and the streaming `InputDecoder` all bail
+    // on payloads over `MAX_IPC_BYTES`, and the fast-path encoder refuses
+    // oversized arrays too (routing them here). Without this check an
+    // oversized array would encode successfully, get sent, and then be
+    // silently dropped as undecodable on the consumer with no error on the
+    // sending side — see the matching guard in `uint8_layout`.
+    if buf.len() > MAX_IPC_BYTES {
+        eyre::bail!(
+            "Arrow IPC payload too large: {} bytes (max {MAX_IPC_BYTES}); \
+             split the output into smaller batches",
+            buf.len()
+        );
+    }
     Ok(buf)
 }
 
@@ -162,6 +178,24 @@ mod tests {
         let encoded = encode_arrow_ipc(&data).unwrap();
         let decoded = decode_arrow_ipc(&encoded).unwrap();
         assert_eq!(data, decoded);
+    }
+
+    /// An array whose IPC stream exceeds `MAX_IPC_BYTES` must fail at encode
+    /// time. Otherwise the sender would emit a stream that every receive path
+    /// rejects, silently dropping the message with no producer-side error.
+    #[test]
+    fn ipc_encode_rejects_oversized_payload() {
+        use arrow::array::UInt8Array;
+
+        // Body just over the 256 MB cap; the framing pushes the stream over too.
+        let array = UInt8Array::from(vec![0u8; MAX_IPC_BYTES + 1]);
+        let data = array.into_data();
+        let err =
+            encode_arrow_ipc(&data).expect_err("oversized payload must be rejected by the encoder");
+        assert!(
+            err.to_string().contains("too large"),
+            "unexpected error: {err}"
+        );
     }
 
     /// Copy `bytes` into a 128-byte-aligned buffer, mirroring how Dora's


### PR DESCRIPTION
## Summary

The send and receive paths disagreed on the 256 MB `MAX_IPC_BYTES` limit, causing **silent data loss**.

- Every **receive** path rejects oversized payloads: `decode_arrow_ipc`, `decode_arrow_ipc_zero_copy`, and the streaming `InputDecoder`'s `check_ipc_size` all bail above the cap.
- The **fast-path encoder** refuses oversized arrays too — `Layout::push_buffer` returns `None`, routing them to the fallback.
- But the **fallback** `encode_arrow_ipc` (reached via `encode_ipc_to_vec` for oversized or non-fast-path arrays) had **no size check**, so `send_output`/`send_output_array` happily produced and sent a >256 MB stream.

**Result:** the send succeeds, but the consumer unconditionally rejects the payload with `"Arrow IPC payload too large"` and drops the input — silent data loss with **no error on the producer**. This is inconsistent with `send_output_raw`, whose `uint8_layout` already returns a clear producer-side error for the same size.

## Fix

Enforce `MAX_IPC_BYTES` in `encode_arrow_ipc`, so any oversized output fails at the source with an actionable message instead of being silently undecodable downstream. All callers propagate `eyre::Result`, so normal-size payloads are unaffected.

## Validation

- Adds a regression test (`ipc_encode_rejects_oversized_payload`) that **fails without the guard**.
- All 41 `arrow_utils` tests pass; `cargo clippy -p dora-node-api -- -D warnings` and `cargo fmt --all --check` pass.

---

🤖 This PR is **machine-generated by Claude** as part of an automated code-review pass. It has been compiled and tested locally, but please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014A5nJ7U2dDbXt4ZaUN8BP3)_