### PR TITLE
fix(message): clamp DropOldest queue capacity to at least 1

### DIFF
--- a/libraries/message/src/config.rs
+++ b/libraries/message/src/config.rs
@@ -38,11 +38,17 @@ pub enum QueuePolicy {
 impl QueuePolicy {
     /// Returns the effective capacity for a given configured queue size.
     ///
-    /// - `DropOldest`: returns `queue_size` as-is.
+    /// - `DropOldest`: returns `queue_size`, but never less than 1.
     /// - `Backpressure`: returns `10 * queue_size` (min 100) as a hard safety cap.
+    ///
+    /// A `DropOldest` cap of 0 would drop 100% of the input's events — the
+    /// runtime operator channel sets the just-queued event to `None` on every
+    /// `add_event`, so the operator never receives a single message and the
+    /// dataflow silently hangs. Clamp `queue_size: 0` to 1 (latest-only)
+    /// instead of turning the input into a dead port.
     pub fn effective_cap(&self, queue_size: usize) -> usize {
         match self {
-            Self::DropOldest => queue_size,
+            Self::DropOldest => queue_size.max(1),
             Self::Backpressure => queue_size.saturating_mul(10).max(100),
         }
     }
@@ -637,6 +643,23 @@ mod tests {
         let input: Input = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(input.queue_size, Some(5));
         assert_eq!(input.queue_policy, None);
+    }
+
+    #[test]
+    fn drop_oldest_cap_is_never_zero() {
+        // A `queue_size: 0` DropOldest input must keep at least the latest
+        // message; a cap of 0 would starve the operator entirely.
+        assert_eq!(QueuePolicy::DropOldest.effective_cap(0), 1);
+        // Non-zero sizes are unchanged.
+        assert_eq!(QueuePolicy::DropOldest.effective_cap(1), 1);
+        assert_eq!(QueuePolicy::DropOldest.effective_cap(5), 5);
+    }
+
+    #[test]
+    fn backpressure_cap_has_floor() {
+        assert_eq!(QueuePolicy::Backpressure.effective_cap(0), 100);
+        assert_eq!(QueuePolicy::Backpressure.effective_cap(5), 100);
+        assert_eq!(QueuePolicy::Backpressure.effective_cap(20), 200);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`QueuePolicy::DropOldest::effective_cap` returned `queue_size` verbatim, so an input configured with `queue_size: 0` yielded an effective cap of **0**. In the runtime operator channel's `drop_oldest_inputs`, the newest event (iterated first) then matches the `Some(0)` arm and is set to `None` on **every** `add_event` — the operator never receives a single message for that input and the dataflow **silently hangs**, with only a generic "dropped … queue too full" warning. The node event-stream scheduler is likewise degraded (constant dropping, and a `cap == 0` would run eviction against an empty queue).

No descriptor validation rejects `queue_size: 0`, so this is reachable from user config.

## Fix

Clamp the `DropOldest` cap to `queue_size.max(1)`, so a zero size behaves as **latest-only** instead of a dead port. `Backpressure` already had a floor of 100 and is unchanged.

## Validation

- Adds unit tests for both policies' cap flooring (`drop_oldest_cap_is_never_zero`, `backpressure_cap_has_floor`).
- `cargo test -p dora-message`, `cargo clippy -p dora-message -- -D warnings`, `cargo fmt --all --check` all pass.

---

🤖 This PR is **machine-generated by Claude** as part of an automated code-review pass. It has been compiled and tested locally, but please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014A5nJ7U2dDbXt4ZaUN8BP3)_