### PR TITLE
fix(c-node): accept the (NULL, 0) empty-payload idiom in dora_send_output

### DIFF
--- a/apis/c/node/src/lib.rs
+++ b/apis/c/node/src/lib.rs
@@ -284,18 +284,42 @@ unsafe fn try_send_output(
     data_ptr: *const u8,
     data_len: usize,
 ) -> eyre::Result<()> {
-    if context.is_null() || id_ptr.is_null() || data_ptr.is_null() {
+    if context.is_null() || id_ptr.is_null() {
         eyre::bail!("null pointer passed to dora_send_output");
     }
     let context: &mut DoraContext = unsafe { &mut *context.cast() };
     let id = std::str::from_utf8(unsafe { slice::from_raw_parts(id_ptr, id_len) })?;
     let output_id = id.to_owned().into();
-    let data = unsafe { slice::from_raw_parts(data_ptr, data_len) };
+    let data = unsafe { data_slice(data_ptr, data_len) }?;
     Ok(context
         .node
         .send_output_raw(output_id, Default::default(), data.len(), |out| {
             out.copy_from_slice(data);
         })?)
+}
+
+/// Resolve a C `(ptr, len)` payload pair into a slice, accepting the standard
+/// `(NULL, 0)` idiom for an empty message.
+///
+/// `slice::from_raw_parts` is UB when the pointer is null even for length 0
+/// (the pointer must be non-null and well-aligned regardless of length), so an
+/// empty payload must be handled without dereferencing the pointer. This
+/// mirrors the operator FFI (`dora_send_operator_output`), which already
+/// accepts `(NULL, 0)`; previously a C node emitting an empty output via the
+/// idiomatic `dora_send_output(ctx, id, id_len, NULL, 0)` was rejected.
+///
+/// # Safety
+///
+/// When `data_len > 0`, `data_ptr` must point to `data_len` initialized bytes
+/// valid for the duration of the returned borrow.
+unsafe fn data_slice<'a>(data_ptr: *const u8, data_len: usize) -> eyre::Result<&'a [u8]> {
+    if data_len == 0 {
+        Ok(&[])
+    } else if data_ptr.is_null() {
+        eyre::bail!("dora_send_output: data_ptr is null with non-zero data_len");
+    } else {
+        Ok(unsafe { slice::from_raw_parts(data_ptr, data_len) })
+    }
 }
 
 /// Sends a structured log message from a C node.
@@ -384,5 +408,28 @@ mod tests {
             "expected null out_ptr for non-UInt8 input"
         );
         assert_eq!(out_len, 0, "expected zero out_len for non-UInt8 input");
+    }
+
+    #[test]
+    fn data_slice_accepts_null_zero_idiom() {
+        // A C node sending an empty output: `dora_send_output(.., NULL, 0)`.
+        let data =
+            unsafe { data_slice(std::ptr::null(), 0) }.expect("(NULL, 0) is a valid empty payload");
+        assert!(data.is_empty());
+    }
+
+    #[test]
+    fn data_slice_rejects_null_with_nonzero_len() {
+        let err = unsafe { data_slice(std::ptr::null(), 4) }
+            .expect_err("null pointer with a non-zero length must be rejected");
+        assert!(err.to_string().contains("null"), "got: {err}");
+    }
+
+    #[test]
+    fn data_slice_reads_valid_pointer() {
+        let buf = [1u8, 2, 3, 4];
+        let data =
+            unsafe { data_slice(buf.as_ptr(), buf.len()) }.expect("valid pointer yields a slice");
+        assert_eq!(data, &buf);
     }
 }


### PR DESCRIPTION
## Summary

`dora_send_output`'s `try_send_output` rejected any null `data_ptr` unconditionally, so a C node emitting a zero-length output with the standard idiom `dora_send_output(ctx, id, id_len, NULL, 0)` got `-1`. The parallel operator FFI `dora_send_operator_output` already accepts `(NULL, 0)` (it branches on `data_len == 0` first), so the node surface was inconsistent and empty/tick-style outputs from C nodes were impossible via the natural call.

## Fix

Extract a `data_slice` helper that:
- treats `data_len == 0` as an empty slice (accepting the `(NULL, 0)` idiom),
- rejects a null pointer only with a **non-zero** length,
- otherwise builds the slice.

This also avoids `slice::from_raw_parts(NULL, 0)`, which is UB in Rust even for length 0 (the pointer must be non-null and aligned regardless of length).

## Validation

- Adds 3 unit tests: `(NULL, 0)` accepted, null-with-length rejected, valid pointer read.
- `cargo test -p dora-node-api-c`, `cargo clippy -p dora-node-api-c -- -D warnings`, `cargo fmt --all --check` all pass.

---

🤖 This PR is **machine-generated by Claude** as part of an automated code-review pass. It has been compiled and tested locally, but please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014A5nJ7U2dDbXt4ZaUN8BP3)_