### PR TITLE
fix(coordinator): treat a fully-drained state log as pruned for a lagging daemon

### DIFF
--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -5928,6 +5928,42 @@ mod tests {
     }
 
     #[test]
+    fn state_log_delta_returns_none_when_log_fully_drained_but_daemon_behind() {
+        // Regression for #2601: a relinked daemon that was never seeded into
+        // `daemon_ack_sequence` queries with last_ack == 0. If peers have
+        // acked and `prune_state_log` drained the log entirely (while
+        // `state_log_sequence` stays > 0), the empty-log branch must return
+        // `None` (→ full param replay), not `Some([])` ("up to date").
+        let dataflow_id = DataflowId::from(Uuid::new_v4());
+        let d1 = DaemonId::new(Some("m1".to_string()));
+        let node_id: dora_core::config::NodeId = "camera".to_string().into();
+
+        let mut df = test_running_dataflow(dataflow_id, d1.clone(), node_id.clone());
+        for i in 0..3 {
+            df.append_state_log(StateCatchUpOperation::SetParam {
+                node_id: node_id.clone(),
+                key: format!("key_{i}"),
+                value: serde_json::json!(i),
+            });
+        }
+
+        // d1 (the only member in the ack map) acks all 3 → prune drains the
+        // whole log, but state_log_sequence stays at 3.
+        df.daemon_ack_sequence.insert(d1, 3);
+        df.prune_state_log();
+        assert!(df.state_log.is_empty());
+        assert_eq!(df.state_log_sequence, 3);
+
+        // A relinked daemon not in the ack map is provably behind (0 < 3) yet
+        // sees an empty log → must get the None fallback, not Some([]).
+        assert!(df.state_log_delta(0).is_none());
+
+        // A member already at the head is genuinely up to date → empty, non-None.
+        let delta = df.state_log_delta(3).expect("head daemon is up to date");
+        assert!(delta.is_empty());
+    }
+
+    #[test]
     fn set_param_forward_reply_reports_daemon_rejection() {
         let reply = serde_json::to_vec(&DaemonCoordinatorReply::SetParamResult(Err(
             "node `camera` channel full".to_string(),

--- a/binaries/coordinator/src/state.rs
+++ b/binaries/coordinator/src/state.rs
@@ -393,6 +393,17 @@ impl RunningDataflow {
     /// should fall back to a full param replay).
     pub(crate) fn state_log_delta(&self, last_ack: u64) -> Option<Vec<StateCatchUpEntry>> {
         if self.state_log.is_empty() {
+            // An empty log only means "up to date" when nothing newer than
+            // `last_ack` ever existed. If `last_ack < state_log_sequence`, the
+            // entries the daemon still needs (`last_ack+1..=state_log_sequence`)
+            // were pruned away — the daemon must fall back to a full replay,
+            // not be told it is current. This happens on relink: a daemon that
+            // was never seeded into `daemon_ack_sequence` queries with
+            // `last_ack == 0` after peers acked and drained the log
+            // (dora-rs/dora#2601).
+            if last_ack < self.state_log_sequence {
+                return None;
+            }
             return Some(Vec::new());
         }
         let oldest = self.state_log[0].sequence;


### PR DESCRIPTION
## Summary

Fixes #2601.

`RunningDataflow::state_log_delta` returned `Some(Vec::new())` ("you're up to date") whenever the state log was empty — even when the querying daemon was provably behind. Its documented contract is to return `None` (→ full param replay) when the log has been pruned past `last_ack`; only the *non-empty* branch honored that via the `oldest` gap check.

The sole production caller (`binaries/coordinator/src/lib.rs`) only calls `state_log_delta` when `last_ack < state_log_sequence`, so an empty log in that state always means the entries the daemon still needs (`last_ack+1..=state_log_sequence`) were pruned away. As written, that daemon got the `Some([])` → `entries.is_empty() => {}` arm and silently missed every param mutation — no fallback replay, no log line.

### Reachability

On multi-daemon coordinator restart, a relinked daemon is re-added to `df.daemons` but never seeded into `daemon_ack_sequence` (the ack map is only seeded at construction and updated on ack). So it queries with `last_ack == 0` (`unwrap_or(0)`), while its peers ack and `prune_state_log` drains the log entirely (`state_log_sequence` stays > 0). It then permanently misses param mutations.

## Fix

Make the empty-log branch prune-aware: return `None` when `last_ack < self.state_log_sequence`, and `Some(vec[])` only when the daemon is genuinely current. No signature change — the method already has `self.state_log_sequence`. Adds a regression test (`state_log_delta_returns_none_when_log_fully_drained_but_daemon_behind`) exercising the fully-drained case the existing `..._returns_none_when_pruned` test (partial prune) never covered.

## Validation

- `cargo test -p dora-coordinator state_log` — 5 tests incl. new regression ✅
- `cargo clippy -p dora-coordinator -- -D warnings` ✅
- `cargo fmt -p dora-coordinator -- --check` ✅

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUUqcrfqFNECPmtAy9ZX43)_