### PR TITLE
fix(core): register the admitted type body for a duplicated manifest URN

### DIFF
--- a/libraries/core/src/manifest/inject.rs
+++ b/libraries/core/src/manifest/inject.rs
@@ -120,10 +120,19 @@ pub fn inject_adjacent_manifests(
         }
     }
     // Register the survivors into the shared registry, skipping URNs already
-    // present so preserved definitions win.
-    for &(urn, def) in &candidates {
-        if scratch.resolve(urn).is_some() && registry.resolve(urn).is_none() {
-            let _ = registry.add_user_type(urn, def.clone());
+    // present so preserved definitions win. `candidates` is a flat list across
+    // all manifests and is NOT deduplicated by URN, so two matched manifests
+    // may ship the same URN with differing bodies. Register the *admitted*
+    // definition from `scratch` — the body-valid one the fixpoint chose — not
+    // this candidate's own `def`, which may be a body-invalid duplicate listed
+    // first. Registering `def` here would write an unmaterializable definition
+    // into the shared registry and let a referencing node's port check pass
+    // against a type that can never become an Arrow schema (dora-rs/dora#2599).
+    for &(urn, _def) in &candidates {
+        if registry.resolve(urn).is_none()
+            && let Some(admitted) = scratch.resolve(urn)
+        {
+            let _ = registry.add_user_type(urn, admitted.clone());
         }
     }
 
@@ -840,6 +849,70 @@ nodes:
         assert!(registry.resolve("acme/foo/v1/Y").is_none());
         assert!(registry.resolve("acme/foo/v1/X").is_none());
         assert!(df.nodes[1].output_types.is_empty());
+    }
+
+    #[test]
+    fn duplicate_urn_registers_the_body_valid_definition_not_the_first_listed() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Two same-namespace manifests ship the SAME urn `acme/foo/v1/X` with
+        // differing bodies. `bad` (listed first) is body-invalid — its field
+        // type does not resolve; `good` (listed second) is body-valid. The
+        // fixpoint admits only the valid body into `scratch`, and the shared
+        // registry must end up holding THAT definition — not the first-listed
+        // invalid candidate, which would let a referencing node's port check
+        // pass against a type that can never materialize (dora-rs/dora#2599).
+        write_manifest(
+            &tmp.path().join("bad"),
+            r#"
+apiVersion: 1
+name: bad
+namespace: acme
+runtime: rust
+entrypoint: target/release/bad
+types:
+  acme/foo/v1/X:
+    arrow: Struct
+    fields:
+      - name: bad
+        type: NotARealType
+"#,
+        );
+        write_manifest(
+            &tmp.path().join("good"),
+            r#"
+apiVersion: 1
+name: good
+namespace: acme
+runtime: rust
+entrypoint: target/release/good
+types:
+  acme/foo/v1/X:
+    arrow: Struct
+    fields:
+      - name: x
+        type: Float32
+"#,
+        );
+        let mut df = dataflow(
+            r#"
+nodes:
+  - id: bad
+    path: bad/target/release/bad
+  - id: good
+    path: good/target/release/good
+"#,
+        );
+        let mut registry = TypeRegistry::new();
+        let _ = inject_adjacent_manifests(&mut df, tmp.path(), &mut registry);
+        // The URN is registered (a body-valid definition exists for it)...
+        let def = registry
+            .resolve("acme/foo/v1/X")
+            .expect("a body-valid duplicate should register the type");
+        // ...and it is the body-valid one (field `x: Float32`), never the
+        // body-invalid first-listed candidate (field `bad: NotARealType`).
+        assert_eq!(def.fields.len(), 1, "{def:?}");
+        assert_eq!(def.fields[0].name, "x", "{def:?}");
+        assert_eq!(def.fields[0].r#type, "Float32", "{def:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #2599.

In `libraries/core/src/manifest/inject.rs`, the loop that registers shipped types into the **shared** registry could write a *body-invalid* definition when two matched manifests ship the same type URN.

`candidates` is a flat `Vec<(&urn, &def)>` accumulated across all matched manifests and is **not** deduplicated by URN. The admission fixpoint decides admission *per URN* into `scratch`, inserting only a body-valid definition. But the registration loop then wrote each candidate's own `def`, guarded only by `scratch.resolve(urn).is_some()` — which proves *some* definition for that URN was admitted, **not** that *this* candidate's `def` is the admitted one. So when a body-invalid duplicate is listed first, the registry ended up holding the body-invalid definition, and a referencing node's port check passed against a type that can never be materialized into an Arrow schema — defeating the body-resolvability invariant the module documents and its tests protect.

### Failure scenario

Two same-namespace `path:` nodes ship `acme/foo/v1/X`, the invalid one first:
- Node A (listed first) ships `X` with field `bad: NotARealType` → body-invalid.
- Node B (listed second) ships `X` with field `x: Float32` → body-valid.

The fixpoint admits B into `scratch`, but the registration loop's first iteration `(X, A_invalid)` sees `scratch.resolve(X).is_some()` (from B) and registers **A_invalid** into the shared registry.

## Fix

Register the *admitted* definition from `scratch` (the body-valid one the fixpoint chose) rather than the candidate's own `def`:

```rust
for &(urn, _def) in &candidates {
    if registry.resolve(urn).is_none()
        && let Some(admitted) = scratch.resolve(urn)
    {
        let _ = registry.add_user_type(urn, admitted.clone());
    }
}
```

Adds a regression test (`duplicate_urn_registers_the_body_valid_definition_not_the_first_listed`) with two same-namespace manifests shipping the same URN, body-invalid first. Verified it **fails** against the old code and passes with the fix.

## Validation

- `cargo test -p dora-core --lib manifest::inject` — 18 tests incl. new regression ✅ (confirmed red without the fix)
- `cargo clippy -p dora-core -- -D warnings` ✅
- `cargo fmt -p dora-core -- --check` ✅

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUUqcrfqFNECPmtAy9ZX43)_