### PR TITLE
fix(daemon): re-check disable_restart before respawn on every path

### DIFF
--- a/binaries/daemon/src/spawn/prepared.rs
+++ b/binaries/daemon/src/spawn/prepared.rs
@@ -329,18 +329,28 @@ impl PreparedNode {
                         )
                         .await;
                     tokio::time::sleep(backoff).await;
+                }
 
-                    // Re-check disable_restart after sleep (may have changed)
-                    if disable_restart.load(atomic::Ordering::Acquire) {
-                        logger
-                            .log(
-                                LogLevel::Info,
-                                Some("daemon".into()),
-                                "restart cancelled: inputs closed during backoff wait".to_string(),
-                            )
-                            .await;
-                        break;
-                    }
+                // Re-check `disable_restart` before committing to a respawn. It
+                // may have flipped to `true` after the `load` at the top of this
+                // iteration: emitting the `SpawnedNodeResult` event and any
+                // backoff sleep above are `.await` points, and a concurrent
+                // `StopDataflow` (`RunningDataflow::stop_all`) sets
+                // `disable_restart` on every node. Keeping this gate inside the
+                // `restart_delay.is_some()` branch above meant that a node with
+                // the default (unset) `restart_delay` had no final check, so a
+                // stop racing an in-progress restart was ignored and the node
+                // respawned *after* the stop — an orphan process that `stop_all`
+                // has already passed over.
+                if disable_restart.load(atomic::Ordering::Acquire) {
+                    logger
+                        .log(
+                            LogLevel::Info,
+                            Some("daemon".into()),
+                            "restart cancelled: inputs closed before respawn".to_string(),
+                        )
+                        .await;
+                    break;
                 }
 
                 restart_count += 1;


### PR DESCRIPTION
## Summary

`restart_loop` in `binaries/daemon/src/spawn/prepared.rs` can respawn a node **after** an explicit stop, leaving an orphan process that survives `dora stop`.

## The issue

Each loop iteration reads `disable_restart` once, near the top (`prepared.rs:247`), and then:
1. emits the `SpawnedNodeResult` event via `daemon_tx.send(event).await` (an `.await` point), and
2. optionally sleeps for the restart backoff (`tokio::time::sleep(backoff).await`, another `.await` point),

before actually calling `spawn_inner` to respawn. During those await points a concurrent `StopDataflow` runs `RunningDataflow::stop_all`, which sets `disable_restart = true` on **every** node.

The guard that re-checks `disable_restart` after the wait lived **inside** the `if let Some(base_delay) = config.restart_delay { … }` block. But `restart_delay` defaults to `None` (`restart_config`, `prepared.rs:194`), so a node using the default configuration had **no** final gate. A stop that races an in-progress restart was therefore ignored, and the node was respawned after the stop.

Nothing reaps the respawned process: `stop_all` already ran and had nothing to kill for this node (its process slot was empty because it had just exited), and `finish_stragglers` is gated on `stop_sent`. The result is an orphan process that outlives `dora stop`.

### Failing scenario
1. A node with `restart_policy: Always` and no `restart_delay` exits.
2. `restart_loop` decides `restart = true` and awaits on the event send / logging.
3. Concurrently the coordinator delivers `StopDataflow`; `stop_all` sets `disable_restart = true` for the node (whose slot is already empty).
4. `restart_loop` resumes. With `restart_delay == None` the re-check is skipped, so it respawns the node — after the stop.

## The fix

Move the `disable_restart` re-check out of the `restart_delay.is_some()` branch so it runs **unconditionally**, immediately before committing to the respawn — on both the delayed and the immediate (default) restart paths. This is a one-line control-flow change plus the relocated guard; the `break` was already the behavior used by the old delay-branch check, so no new exit path is introduced.

## Validation

- `cargo fmt -p dora-daemon -- --check` ✓
- `cargo clippy -p dora-daemon -- -D warnings` ✓ (matches CI invocation)
- `cargo test -p dora-daemon` ✓ (96 passed)

`restart_loop` takes a fully-constructed `PreparedNode` plus live spawn machinery, so there is no isolated seam to unit-test the race directly; the fix is a minimal, self-contained control-flow correction.

---

🤖 This is a **machine-generated** pull request proposed by Claude (an AI agent) as part of an automated code-review pass. It has been verified locally as described above, but a human should review it carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYwkkfs2mPg1Gj4s26HB1q

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYwkkfs2mPg1Gj4s26HB1q)_