### PR TITLE
fix(cli): correct byte-offset tracking in `dora logs --follow`

### DIFF
--- a/binaries/cli/src/command/logs.rs
+++ b/binaries/cli/src/command/logs.rs
@@ -313,16 +313,9 @@ fn follow_local_logs(args: &LogsArgs) -> Result<()> {
             if current_size <= pos {
                 continue;
             }
-            let mut file = std::fs::File::open(path)?;
-            file.seek(std::io::SeekFrom::Start(pos))?;
-            let mut buf = String::new();
-            file.read_to_string(&mut buf)?;
-            for line in buf.lines() {
-                if let Some(msg) = parse_jsonl_line(line) {
-                    new_messages.push(msg);
-                }
-            }
-            file_positions.insert(path.clone(), current_size);
+            let (msgs, new_pos) = read_appended_log_lines(path, pos)?;
+            new_messages.extend(msgs);
+            file_positions.insert(path.clone(), new_pos);
         }
 
         new_messages.sort_by_key(|a| a.timestamp);
@@ -332,6 +325,30 @@ fn follow_local_logs(args: &LogsArgs) -> Result<()> {
             }
         }
     }
+}
+
+/// Read log lines appended to `path` after byte offset `pos`, returning the
+/// parsed messages and the new byte offset.
+///
+/// Only *complete* (newline-terminated) lines are consumed. A trailing partial
+/// line — the daemon may be mid-write — is left unconsumed so it is re-read once
+/// completed, rather than being parsed as a broken JSON line and dropped. The
+/// returned offset advances only past the bytes actually consumed, never past
+/// the (racily larger) file size, so nothing is re-read and duplicated on the
+/// next poll. Bytes are decoded lossily so a read that ends inside a multibyte
+/// UTF-8 sequence cannot abort the follow session.
+fn read_appended_log_lines(path: &Path, pos: u64) -> Result<(Vec<LogMessage>, u64)> {
+    let mut file = std::fs::File::open(path)?;
+    file.seek(std::io::SeekFrom::Start(pos))?;
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf)?;
+    let consumed = match buf.iter().rposition(|&b| b == b'\n') {
+        Some(idx) => idx + 1,
+        None => return Ok((Vec::new(), pos)),
+    };
+    let text = String::from_utf8_lossy(&buf[..consumed]);
+    let messages = text.lines().filter_map(parse_jsonl_line).collect();
+    Ok((messages, pos + consumed as u64))
 }
 
 fn find_dataflow_dir(out_dir: &Path, dataflow_id: Option<&str>) -> Result<PathBuf> {
@@ -918,5 +935,91 @@ mod tests {
 
         assert_eq!(files.len(), 1);
         assert!(files[0].file_name().unwrap() == "log_cam.jsonl");
+    }
+
+    // --- read_appended_log_lines (follow-mode offset tracking) ---
+
+    fn jsonl(message: &str) -> String {
+        let mut line = serde_json::to_string(&make_msg(message, None, None, Utc::now())).unwrap();
+        line.push('\n');
+        line
+    }
+
+    #[test]
+    fn read_appended_reads_complete_lines_and_advances_to_end() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("log.jsonl");
+        let content = format!("{}{}", jsonl("a"), jsonl("b"));
+        std::fs::write(&path, &content).unwrap();
+
+        let (msgs, new_pos) = read_appended_log_lines(&path, 0).unwrap();
+        assert_eq!(msgs.len(), 2);
+        assert_eq!(msgs[0].message, "a");
+        assert_eq!(msgs[1].message, "b");
+        // Offset advances to exactly the bytes consumed (whole file here).
+        assert_eq!(new_pos, content.len() as u64);
+
+        // A follow-up read from the returned offset yields nothing and does not
+        // move the offset (no duplication).
+        let (msgs, pos2) = read_appended_log_lines(&path, new_pos).unwrap();
+        assert!(msgs.is_empty());
+        assert_eq!(pos2, new_pos);
+    }
+
+    #[test]
+    fn read_appended_leaves_trailing_partial_line_for_next_poll() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("log.jsonl");
+
+        // First line complete, second line still being written (no newline).
+        let complete = jsonl("first");
+        let partial = {
+            let mut p = complete.clone();
+            let second =
+                serde_json::to_string(&make_msg("second", None, None, Utc::now())).unwrap();
+            p.push_str(&second); // no trailing '\n' yet
+            p
+        };
+        std::fs::write(&path, &partial).unwrap();
+
+        let (msgs, new_pos) = read_appended_log_lines(&path, 0).unwrap();
+        assert_eq!(msgs.len(), 1, "partial line must not be parsed/emitted");
+        assert_eq!(msgs[0].message, "first");
+        // Offset stops at the last newline, not the (larger) file size.
+        assert_eq!(new_pos, complete.len() as u64);
+
+        // Daemon finishes the second line; re-reading from the saved offset now
+        // yields exactly that line — the first line is not duplicated.
+        std::fs::write(&path, format!("{complete}{}", jsonl("second"))).unwrap();
+        let (msgs, _pos) = read_appended_log_lines(&path, new_pos).unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].message, "second");
+    }
+
+    #[test]
+    fn read_appended_does_not_abort_on_split_multibyte_utf8() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("log.jsonl");
+
+        // One complete line, then a lone leading byte of a multibyte UTF-8
+        // sequence with no newline (a write caught mid-flush). `read_to_string`
+        // would return an InvalidData error here; the lossy path must not.
+        let complete = jsonl("ok");
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(complete.as_bytes()).unwrap();
+        f.write_all(&[0xE2]).unwrap(); // first byte of a 3-byte char, no newline
+        drop(f);
+
+        let (msgs, new_pos) = read_appended_log_lines(&path, 0).unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].message, "ok");
+        // The dangling partial byte is left unconsumed.
+        assert_eq!(new_pos, complete.len() as u64);
     }
 }


### PR DESCRIPTION
## Summary

`dora logs --follow` (the local `follow_local_logs` loop in `binaries/cli/src/command/logs.rs`) tracks how far it has read into each log file with a byte offset, but advances that offset incorrectly. This causes duplicated output, can abort the whole follow session on non-ASCII logs, and can silently drop lines.

## The issue

Each poll:
1. samples the file size with `metadata()` — call it `current_size` (time T1),
2. reads from the saved offset to EOF with `read_to_string` (time T2 ≥ T1),
3. stores the offset as **`current_size`** (the T1 size), not the number of bytes actually read.

Three defects follow:

1. **Duplicated output.** Under active logging the file grows between T1 and T2, so `read_to_string` consumes past `current_size` and prints those bytes — but the offset only advances to `current_size`. On the next poll the reader seeks back and re-reads/re-prints every byte written in the (T1, T2) window.
2. **Follow session aborts on non-ASCII logs.** `read_to_string` returns `InvalidData` if the byte range ends inside a multibyte UTF-8 sequence (any `é`, CJK char, emoji written across two flushes). The `?` propagates out of `follow_local_logs`, terminating the whole `dora logs --follow` command with *"stream did not contain valid UTF-8"*.
3. **Silent log loss.** A line split across two flushes is parsed as a broken JSON line, dropped, and the offset still advances past it, so the completed line is never re-read.

## The fix

Extract the read into a small, testable helper `read_appended_log_lines(path, pos) -> (Vec<LogMessage>, u64)` that:

- reads raw bytes (`read_to_end`) instead of `read_to_string`,
- consumes only **through the last newline**, leaving any trailing partial line for the next poll,
- decodes lossily (`from_utf8_lossy`) so a read ending mid-multibyte-char can never abort the session,
- advances the offset by exactly the **bytes consumed** (`pos + consumed`), never by the racily-larger file size.

The caller's cheap `current_size <= pos` early-out is preserved. Behavior for the common ASCII, newline-terminated case is unchanged aside from removing the duplication.

## Validation

- `cargo fmt --all -- --check` ✓
- `cargo clippy -p dora-cli -- -D warnings` ✓ (matches CI invocation)
- `cargo test -p dora-cli` ✓ (251 passed, incl. 3 new regression tests)

New unit tests cover: complete-lines read + no re-read on the next poll (duplication guard), a trailing partial line left for the next poll, and a read ending on a split multibyte UTF-8 byte not aborting.

---

🤖 This is a **machine-generated** pull request proposed by Claude (an AI agent) as part of an automated code-review pass. It has been verified locally as described above, but a human should review it carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYwkkfs2mPg1Gj4s26HB1q

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYwkkfs2mPg1Gj4s26HB1q)_