### PR TITLE
fix(download): match Content-Disposition filename case-insensitively

### DIFF
--- a/libraries/extensions/download/src/lib.rs
+++ b/libraries/extensions/download/src/lib.rs
@@ -9,10 +9,17 @@ use tokio::io::AsyncWriteExt;
 ///
 /// Handles headers that carry additional parameters after the filename, e.g.
 /// `attachment; filename="model.bin"; size=1000`, and both quoted and unquoted
-/// forms. Returns `None` when no non-empty `filename=` value is present (the
-/// RFC 5987 extended `filename*=` form is not decoded and falls through).
+/// forms. Per RFC 6266 / RFC 2616 the parameter name is case-insensitive, so
+/// `Filename`, `FILENAME`, etc. are matched too. Returns `None` when no
+/// non-empty `filename=` value is present (the RFC 5987 extended `filename*=`
+/// form is not decoded and falls through — searching for the literal
+/// `filename=` skips it, since `filename*=` does not contain that substring).
 fn parse_content_disposition_filename(header: &str) -> Option<String> {
-    let rest = header.split("filename=").nth(1)?.trim_start();
+    // RFC 6266: parameter names are case-insensitive. Lower-casing only maps
+    // ASCII bytes 1:1, so byte offsets stay valid indices into `header`.
+    let lower = header.to_ascii_lowercase();
+    let start = lower.find("filename=")? + "filename=".len();
+    let rest = header[start..].trim_start();
     let name = if let Some(after_quote) = rest.strip_prefix('"') {
         // Quoted form: the value runs up to the closing quote, so a trailing
         // `; param=...` (or a `;` inside the quotes) is handled correctly.
@@ -156,6 +163,37 @@ mod tests {
         assert_eq!(
             parse_content_disposition_filename("attachment; filename=\"a;b.bin\""),
             Some("a;b.bin".to_string())
+        );
+    }
+
+    #[test]
+    fn filename_parameter_name_is_case_insensitive() {
+        // RFC 6266: `Content-Disposition` parameter names are case-insensitive,
+        // so a spec-compliant server sending a non-lowercase `filename` must not
+        // have its filename silently dropped.
+        for header in [
+            "attachment; Filename=\"model.bin\"",
+            "attachment; FILENAME=\"model.bin\"",
+            "attachment; FileName=model.bin",
+        ] {
+            assert_eq!(
+                parse_content_disposition_filename(header),
+                Some("model.bin".to_string()),
+                "header {header:?} should parse case-insensitively"
+            );
+        }
+    }
+
+    #[test]
+    fn extended_form_before_plain_filename_is_skipped() {
+        // A header may carry both the RFC 5987 extended form and a plain one;
+        // the plain `filename=` value must still be found (and the `filename*=`
+        // form skipped, not mistaken for it).
+        assert_eq!(
+            parse_content_disposition_filename(
+                "attachment; filename*=UTF-8''extended.bin; filename=\"plain.bin\""
+            ),
+            Some("plain.bin".to_string())
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes #2609.

`parse_content_disposition_filename` in `dora-download` matched the header parameter name with a **case-sensitive** `split("filename=")`. Per [RFC 6266](https://www.rfc-editor.org/rfc/rfc6266) / RFC 2616, `Content-Disposition` parameter names are **case-insensitive**, so a spec-compliant server sending `filename` in any other case (`Filename`, `FILENAME`, `FileName` — common from some Java/.NET/IIS stacks) had its filename **silently ignored**. The download then fell through to the URL-derived fallback path (which has its own bug, #2600), so the two together could produce a wrong on-disk name or an outright `Could not find a filename` error even though the server told us the correct name. Because URL nodes are dispatched by extension in the daemon spawn path, a wrong name can also break `.py`/native detection.

## Fix

Match the parameter name case-insensitively via an ASCII-lowercased copy of the header. `to_ascii_lowercase` maps only ASCII bytes 1:1 and preserves byte length, so the found offset stays a valid index into the original `header` (the value bytes are returned unchanged, preserving case). The RFC 5987 extended `filename*=` form is still skipped, because searching for the literal `filename=` (with the `=`) does not match `filename*=`.

```rust
let lower = header.to_ascii_lowercase();
let start = lower.find("filename=")? + "filename=".len();
let rest = header[start..].trim_start();
```

The escaped-quote (`\"`) unescaping noted as a secondary nit in the issue is intentionally left as an independent follow-up to keep this change focused on the reported case-sensitivity bug.

## Tests

- `filename_parameter_name_is_case_insensitive` — `Filename=`, `FILENAME=`, and `FileName=` all parse to `model.bin`.
- `extended_form_before_plain_filename_is_skipped` — a header carrying both `filename*=…` and a plain `filename="plain.bin"` still resolves the plain value.
- All pre-existing tests (lowercase, trailing params, unquoted, `;`-in-quotes, empty/missing, `filename*=`-only) continue to pass.

## Validation

- `cargo test -p dora-download` — 7 passed ✅
- `cargo clippy -p dora-download -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅

---

⚠️ **Machine-generated PR.** Authored by Claude (an AI agent) while working through automatically-filed code-review issues. Verified as described, but please review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019gSmVnGaEqXnzMScnFXdxV)_