### PR TITLE
fix(core): validate health_check_interval and input_timeout as seconds

### DIFF
--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -132,7 +132,24 @@ pub fn check_dataflow(dataflow: &Descriptor, working_dir: &Path) -> eyre::Result
         if let descriptor::CoreNodeKind::Custom(custom) = &node.kind {
             check_timing_fields(&node.id, custom)?;
         }
+        // `input_timeout` is a second-valued `f64` that the daemon also feeds
+        // to `Duration::from_secs_f64`, on both the initial-spawn and the
+        // reconnect paths.
+        for (input_id, input) in node_inputs(node) {
+            check_seconds_field(
+                &format!("input `{input_id}` of node `{}`", node.id),
+                "input_timeout",
+                input.input_timeout,
+            )?;
+        }
     }
+    // dataflow-level `health_check_interval` reaches `Duration::from_secs_f64`
+    // in the same way (`binaries/daemon/src/lib.rs`).
+    check_seconds_field(
+        "dataflow",
+        "health_check_interval",
+        dataflow.health_check_interval,
+    )?;
 
     // check that all inputs mappings point to an existing output
     check_wiring(dataflow)?;
@@ -167,6 +184,7 @@ fn check_timing_fields(
     node_id: &NodeId,
     custom: &dora_message::descriptor::CustomNode,
 ) -> eyre::Result<()> {
+    let owner = format!("node `{node_id}`");
     for (field, value) in [
         ("finish_grace_secs", custom.finish_grace_secs),
         ("health_check_timeout", custom.health_check_timeout),
@@ -174,16 +192,36 @@ fn check_timing_fields(
         ("max_restart_delay", custom.max_restart_delay),
         ("restart_window", custom.restart_window),
     ] {
-        if let Some(value) = value
-            && (!value.is_finite() || value < 0.0)
-        {
-            bail!(
-                "node `{node_id}` has invalid `{field}`: {value} \
-                 (must be a finite, non-negative number of seconds)"
-            );
-        }
+        check_seconds_field(&owner, field, value)?;
     }
     Ok(())
+}
+
+/// Reject a negative / non-finite second-valued field before it reaches the
+/// daemon, where `Duration::from_secs_f64` would panic on such input.
+fn check_seconds_field(owner: &str, field: &str, value: Option<f64>) -> eyre::Result<()> {
+    if let Some(value) = value
+        && (!value.is_finite() || value < 0.0)
+    {
+        bail!(
+            "{owner} has invalid `{field}`: {value} \
+             (must be a finite, non-negative number of seconds)"
+        );
+    }
+    Ok(())
+}
+
+/// All `(input_id, input)` pairs declared on a resolved node: a custom node's
+/// own inputs, or the merged inputs of every operator of a runtime node.
+fn node_inputs(node: &ResolvedNode) -> Vec<(&DataId, &Input)> {
+    match &node.kind {
+        CoreNodeKind::Custom(custom) => custom.run_config.inputs.iter().collect(),
+        CoreNodeKind::Runtime(runtime) => runtime
+            .operators
+            .iter()
+            .flat_map(|op| op.config.inputs.iter())
+            .collect(),
+    }
 }
 
 pub trait ResolvedNodeExt {
@@ -1322,6 +1360,104 @@ operators:
                 "non-finite {bad} should be rejected, got: {err}"
             );
         }
+    }
+
+    #[test]
+    fn seconds_field_accepts_none_zero_and_positive() {
+        check_seconds_field("owner", "field", None).unwrap();
+        check_seconds_field("owner", "field", Some(0.0)).unwrap();
+        check_seconds_field("owner", "field", Some(3600.0)).unwrap();
+    }
+
+    #[test]
+    fn seconds_field_rejects_negative_and_non_finite() {
+        for bad in [-1.0, f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let err = check_seconds_field("owner", "field", Some(bad))
+                .unwrap_err()
+                .to_string();
+            assert!(
+                err.contains("field") && err.contains("non-negative"),
+                "{bad} should be rejected with a field/constraint message, got: {err}"
+            );
+        }
+    }
+
+    // `health_check_interval` (dataflow-level) reaches `Duration::from_secs_f64`
+    // in the daemon just like the per-node timing fields, so `check_dataflow`
+    // must reject a non-finite / negative value rather than let the daemon panic.
+    #[test]
+    fn check_dataflow_rejects_negative_health_check_interval() {
+        let dataflow = parse_dataflow(
+            "\
+health_check_interval: -1.0
+nodes:
+  - id: a
+    path: node_a
+    build: cargo build
+    outputs:
+      - out
+",
+        );
+        let err = check_dataflow(&dataflow, Path::new("/nonexistent-dora-validate-test"))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("health_check_interval") && err.contains("non-negative"),
+            "error should name the field and constraint, got: {err}"
+        );
+    }
+
+    // Same guarantee for the per-input `input_timeout`, which the daemon feeds
+    // to `Duration::from_secs_f64` on both the spawn and reconnect paths.
+    #[test]
+    fn check_dataflow_rejects_non_finite_input_timeout() {
+        let dataflow = parse_dataflow(
+            "\
+nodes:
+  - id: a
+    path: node_a
+    build: cargo build
+    outputs:
+      - out
+  - id: b
+    path: node_b
+    build: cargo build
+    inputs:
+      x:
+        source: a/out
+        input_timeout: .inf
+",
+        );
+        let err = check_dataflow(&dataflow, Path::new("/nonexistent-dora-validate-test"))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("input_timeout") && err.contains('x'),
+            "error should name the offending input and field, got: {err}"
+        );
+    }
+
+    #[test]
+    fn check_dataflow_accepts_valid_interval_and_timeout() {
+        let dataflow = parse_dataflow(
+            "\
+health_check_interval: 2.5
+nodes:
+  - id: a
+    path: node_a
+    build: cargo build
+    outputs:
+      - out
+  - id: b
+    path: node_b
+    build: cargo build
+    inputs:
+      x:
+        source: a/out
+        input_timeout: 0.5
+",
+        );
+        check_dataflow(&dataflow, Path::new("/nonexistent-dora-validate-test")).unwrap();
     }
 
     fn user_input(source: &str, output: &str) -> Input {


### PR DESCRIPTION
## Issue

The daemon converts several second-valued `f64` descriptor fields to `Duration` via `Duration::from_secs_f64`, which **panics** on a negative, NaN, or infinite input.

`check_dataflow` (in `libraries/core`) already guards the per-node timing fields — `finish_grace_secs`, `health_check_timeout`, `restart_delay`, `max_restart_delay`, `restart_window` — for exactly this reason (`check_timing_fields`). But two more fields fed to the same conversion were missed:

- **dataflow-level `health_check_interval`** — `binaries/daemon/src/lib.rs`: `descriptor.health_check_interval.map(Duration::from_secs_f64)`, converted right after `check_dataflow` runs.
- **per-input `input_timeout`** — `binaries/daemon/src/lib.rs`: `Duration::from_secs_f64(timeout)` on both the initial-spawn and the reconnect paths.

A descriptor such as:

```yaml
health_check_interval: -1.0
# or an input with:
#   input_timeout: .inf
```

passes `dora validate` and then **crashes the daemon** the moment the dataflow is started, instead of surfacing a clean descriptor error.

## Fix

- Extract the shared bound check into `check_seconds_field(owner, field, value)`.
- Reuse it from `check_timing_fields` (same error message, no behavior change).
- Apply it to `input_timeout` for every node's inputs (custom **and** runtime operators, via a new `node_inputs` helper) and to the dataflow-level `health_check_interval`.

## Validation

- New unit tests for `check_seconds_field` (accepts `None`/`0`/positive; rejects negative + NaN + ±inf).
- New `check_dataflow` tests: negative `health_check_interval` and non-finite `input_timeout` are rejected with a clear message; valid values are accepted.
- `cargo test -p dora-core`, `cargo fmt --all -- --check`, and `cargo clippy -p dora-core -- -D warnings` pass. On a combined branch with all three sibling PRs, `dora-core` + `dora-cli` + `dora-coordinator` suites pass together (0 failures) and a high-effort `/code-review` of the combined diff surfaced no correctness findings.
- Note: a full `cargo test --all` in the review sandbox could not complete — it exhausted the fixed per-session disk allowance during linking (ENOSPC in crates unrelated to this change). No real compile/test failures were observed, and this PR changes no public API or signatures, so downstream crates are unaffected. CI runs the full matrix.

---

🤖 This pull request was generated by Claude (an AI agent) running an automated code-review task. The change was verified against `origin/main`, but please review carefully before merging — it is machine-generated.