### PR TITLE
fix(cli): avoid Instant underflow panic in `dora topic hz`

### DIFF
--- a/binaries/cli/src/command/topic/hz.rs
+++ b/binaries/cli/src/command/topic/hz.rs
@@ -185,12 +185,19 @@ impl HzStats {
     fn record(&self, now: Instant) {
         let mut timestamps = self.timestamps.lock().unwrap_or_else(|e| e.into_inner());
         timestamps.push_back(now);
-        let cutoff = now - self.window_duration;
-        while let Some(&first) = timestamps.front() {
-            if first < cutoff {
-                timestamps.pop_front();
-            } else {
-                break;
+        // `now - window_duration` panics ("overflow when subtracting duration
+        // from instant") when the window exceeds the monotonic-clock value --
+        // reachable via a large `--window` (which `parse_window` leaves
+        // unbounded) or within `window` seconds of the monotonic epoch. When
+        // the cutoff would predate the epoch, every timestamp is within the
+        // window, so there is nothing to prune. Mirrors `info::calculate_hz`.
+        if let Some(cutoff) = now.checked_sub(self.window_duration) {
+            while let Some(&first) = timestamps.front() {
+                if first < cutoff {
+                    timestamps.pop_front();
+                } else {
+                    break;
+                }
             }
         }
     }
@@ -332,12 +339,14 @@ fn run_hz(
 
     loop {
         let now = Instant::now();
+        // `None` when the 1 s sub-window predates the monotonic epoch (only in
+        // the first second of uptime); then every timestamp counts as recent.
+        let cutoff = now.checked_sub(sub_window);
         for (i, (_topic, s)) in stats.iter().enumerate() {
-            let cutoff = now - sub_window;
             let mut count = 0usize;
             let ts = s.timestamps.lock().unwrap_or_else(|e| e.into_inner());
             for &t in ts.iter().rev() {
-                if t < cutoff {
+                if cutoff.is_some_and(|c| t < c) {
                     break;
                 }
                 count += 1;
@@ -600,5 +609,19 @@ mod tests {
     #[test]
     fn parse_window_non_numeric() {
         assert!(parse_window("abc").is_err());
+    }
+
+    // A huge window (`parse_window` imposes no upper bound) must not panic in
+    // `record`: `now - window_duration` would otherwise overflow the monotonic
+    // clock. Regression for the `dora topic hz --window <huge>` panic.
+    #[test]
+    fn record_does_not_underflow_on_huge_window() {
+        let stats = HzStats::new(u32::MAX as usize);
+        // Would panic with "overflow when subtracting duration from instant"
+        // before the `checked_sub` guard.
+        stats.record(Instant::now());
+        stats.record(Instant::now());
+        // Nothing pruned: the cutoff predates the epoch, so both are kept.
+        assert_eq!(stats.timestamps.lock().unwrap().len(), 2);
     }
 }


### PR DESCRIPTION
## Issue

`HzStats::record` computed the sliding-window cutoff as `now - self.window_duration`. `Instant - Duration` **panics** with `"overflow when subtracting duration from instant"` whenever `window_duration` exceeds the current monotonic-clock value.

This is reachable from unvalidated CLI input: `parse_window` only rejects `0`, imposing no upper bound. So:

```
dora topic hz --window 100000000000 -d <flow>
```

builds a multi-thousand-year window and panics on the **first received message**. Because the panic happens while the `timestamps` mutex guard is held, the mutex is poisoned and the interactive UI/reader threads then panic on their own `.lock().unwrap()`. The default 10 s window is also affected within the first 10 seconds of monotonic uptime (freshly-booted host / container).

The sibling `dora topic info` path (`info::calculate_hz`) already guards this exact case with `Instant::checked_sub` and an explanatory comment — `hz.rs` was simply not given the same treatment.

## Fix

Apply `Instant::checked_sub` to both cutoff computations in `hz.rs`:

- the per-message prune in `record`, and
- the fixed 1 s sub-window in the interactive UI loop (`run_hz`).

When the cutoff would predate the monotonic epoch, every recorded timestamp is within the window, so all are kept/counted.

## Validation

- Added `record_does_not_underflow_on_huge_window` — panics before the fix, passes after.
- `cargo test -p dora-cli` (`command::topic::hz`), `cargo fmt --all -- --check`, and `cargo clippy -p dora-cli -- -D warnings` pass. On a combined branch with all three sibling PRs, `dora-core` + `dora-cli` + `dora-coordinator` suites pass together (0 failures) and a high-effort `/code-review` of the combined diff surfaced no correctness findings.
- Note: a full `cargo test --all` in the review sandbox could not complete — it exhausted the fixed per-session disk allowance during linking (ENOSPC in crates unrelated to this change). No real compile/test failures were observed, and this PR changes no public API or signatures, so downstream crates are unaffected. CI runs the full matrix.

---

🤖 This pull request was generated by Claude (an AI agent) running an automated code-review task. The change was verified against `origin/main`, but please review carefully before merging — it is machine-generated.