### PR TITLE
fix(coordinator): don't treat a partially-finished multi-daemon dataflow as stopped

### DIFF
--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -893,7 +893,18 @@ async fn start_inner(
                             grace_duration,
                             force,
                         } => {
-                            if let Some(result) = dataflow_results.get(&dataflow_uuid) {
+                            // `dataflow_results` is filled incrementally, one
+                            // entry per daemon, while a multi-daemon dataflow is
+                            // still running on the others (see
+                            // `DataflowFinishedOnDaemon`). Only take the
+                            // already-stopped fast path when the dataflow is
+                            // truly gone from `running_dataflows`; otherwise fall
+                            // through to `stop_dataflow` so the daemons that are
+                            // still running actually get told to stop. Mirrors
+                            // the `Clean` handler's guard.
+                            if !running_dataflows.contains_key(&dataflow_uuid)
+                                && let Some(result) = dataflow_results.get(&dataflow_uuid)
+                            {
                                 let reply = ControlRequestReply::DataflowStopped {
                                     uuid: dataflow_uuid,
                                     result: dataflow_result(result, dataflow_uuid, &clock),
@@ -935,7 +946,13 @@ async fn start_inner(
                             force,
                         } => match resolve_name(name, &running_dataflows, &archived_dataflows) {
                             Ok(dataflow_uuid) => {
-                                if let Some(result) = dataflow_results.get(&dataflow_uuid) {
+                                // Same partial-completion guard as `Stop`: a
+                                // still-running multi-daemon dataflow has a
+                                // partial `dataflow_results` entry, but must
+                                // still be stopped rather than reported done.
+                                if !running_dataflows.contains_key(&dataflow_uuid)
+                                    && let Some(result) = dataflow_results.get(&dataflow_uuid)
+                                {
                                     let reply = ControlRequestReply::DataflowStopped {
                                         uuid: dataflow_uuid,
                                         result: dataflow_result(result, dataflow_uuid, &clock),
@@ -1090,8 +1107,16 @@ async fn start_inner(
                                 },
                                 status: DataflowStatus::Running,
                             });
-                            let finished_failed =
-                                dataflow_results.iter().map(|(&uuid, results)| {
+                            // Skip uuids still in `running_dataflows`: a
+                            // partially-finished multi-daemon dataflow has a
+                            // partial `dataflow_results` entry while it keeps
+                            // running, and would otherwise be listed twice (once
+                            // Running, once Finished/Failed) with contradictory
+                            // statuses. It is already yielded above as Running.
+                            let finished_failed = dataflow_results
+                                .iter()
+                                .filter(|(uuid, _)| !running_dataflows.contains_key(uuid))
+                                .map(|(&uuid, results)| {
                                     let name =
                                         archived_dataflows.get(&uuid).and_then(|d| d.name.clone());
                                     let id = DataflowIdAndName { uuid, name };
@@ -7292,6 +7317,57 @@ mod tests {
             "Stop handler's dataflow_results early-return must fire for \
              watchdog-failed dataflows (otherwise stop_dataflow bails \
              with 'no known running dataflow')"
+        );
+    }
+
+    /// A partially-finished multi-daemon dataflow is present in BOTH
+    /// `running_dataflows` (still running on the remaining daemons) and
+    /// `dataflow_results` (a partial, per-daemon entry). The Stop/StopByName
+    /// early-return and the List `finished_failed` projection both consult
+    /// `dataflow_results`; without a `running_dataflows` guard, Stop no-ops
+    /// (leaving the still-running daemons' nodes alive) and List shows the
+    /// dataflow twice with contradictory statuses. This exercises the guard
+    /// predicate shared by all three handlers.
+    #[test]
+    fn partial_multi_daemon_dataflow_is_not_stopped_early_or_listed_twice() {
+        let partial = DataflowId::from(Uuid::new_v4()); // running + partial results
+        let finished = DataflowId::from(Uuid::new_v4()); // fully done, results only
+
+        let daemon_id = DaemonId::new(Some("m1".to_string()));
+        let mut running_dataflows: HashMap<DataflowId, RunningDataflow> = HashMap::new();
+        running_dataflows.insert(
+            partial,
+            test_running_dataflow(partial, daemon_id.clone(), "sender".to_string().into()),
+        );
+
+        let mut dataflow_results: IndexMap<DataflowId, BTreeMap<DaemonId, DataflowDaemonResult>> =
+            IndexMap::new();
+        dataflow_results.insert(partial, BTreeMap::new());
+        dataflow_results.insert(finished, BTreeMap::new());
+
+        // Stop/StopByName fast path: only the fully-finished dataflow may take it.
+        let stop_fast_path = |uuid: &DataflowId| {
+            !running_dataflows.contains_key(uuid) && dataflow_results.contains_key(uuid)
+        };
+        assert!(
+            !stop_fast_path(&partial),
+            "partial dataflow must fall through to stop_dataflow, not report DataflowStopped"
+        );
+        assert!(
+            stop_fast_path(&finished),
+            "fully finished dataflow keeps the DataflowStopped fast path"
+        );
+
+        // List: only the fully-finished dataflow is a finished_failed row.
+        let finished_failed: Vec<_> = dataflow_results
+            .iter()
+            .filter(|(uuid, _)| !running_dataflows.contains_key(uuid))
+            .map(|(&uuid, _)| uuid)
+            .collect();
+        assert_eq!(
+            finished_failed,
+            vec![finished],
+            "the still-running partial dataflow must not also appear as finished/failed"
         );
     }
 


### PR DESCRIPTION
## Issue

`dataflow_results` is filled **incrementally — one entry per daemon** — as each daemon reports `DataflowFinishedOnDaemon`, while the dataflow stays in `running_dataflows` until *every* daemon has finished. The `Clean` handler already accounts for this (it skips uuids still in `running_dataflows`, with a comment explaining why), but three other consumers of `dataflow_results` did not:

- **`Stop` / `StopByName`** early-returned `DataflowStopped` on *any* `dataflow_results` entry. On a multi-daemon dataflow where one daemon has finished but others are still running, `dora stop <uuid>` / `--name <name>` replied `"stopped"` and **skipped `stop_dataflow` entirely** — so the still-running daemons' nodes were never told to stop and kept running until they exited on their own.
- **`List`** yielded every `dataflow_results` entry as `Finished`/`Failed` with no `running_dataflows` filter, so a partially-finished dataflow appeared **twice** in `dora list` — once `Running`, once `Finished`/`Failed` — with contradictory statuses.

### Failure scenario

Two-daemon dataflow on A and B. A's nodes all exit → `DataflowFinishedOnDaemon(A)` inserts a partial `dataflow_results[uuid] = {A: ...}` and removes A from `dataflow.daemons`; the dataflow is still running on B. `dora stop <uuid>` finds the partial entry, replies `DataflowStopped`, and `continue`s — B's nodes are never stopped.

## Fix

Gate all three consumers on the dataflow being truly absent from `running_dataflows`, mirroring the `Clean` handler:

```rust
if !running_dataflows.contains_key(&dataflow_uuid)
    && let Some(result) = dataflow_results.get(&dataflow_uuid)
{ /* fast path */ }
```

and, in `List`, `.filter(|(uuid, _)| !running_dataflows.contains_key(uuid))`.

Fully-finished single- and multi-daemon dataflows keep the existing fast paths unchanged.

## Validation

- Added `partial_multi_daemon_dataflow_is_not_stopped_early_or_listed_twice`, exercising the shared guard predicate for both the Stop fast path and the List projection (partial dataflow falls through; fully-finished keeps the fast path and appears once).
- `cargo test -p dora-coordinator`, `cargo fmt --all -- --check`, and `cargo clippy -p dora-coordinator -- -D warnings` pass. On a combined branch with all three sibling PRs, `dora-core` + `dora-cli` + `dora-coordinator` suites pass together (0 failures) and a high-effort `/code-review` of the combined diff surfaced no correctness findings.
- Note: a full `cargo test --all` in the review sandbox could not complete — it exhausted the fixed per-session disk allowance during linking (ENOSPC in crates unrelated to this change). No real compile/test failures were observed, and this PR changes no public API or signatures, so downstream crates are unaffected. CI runs the full matrix.

---

🤖 This pull request was generated by Claude (an AI agent) running an automated code-review task. The change was verified against `origin/main`, but please review carefully before merging — it is machine-generated.