### PR TITLE
refactor(core): remove unused visualize_as_mermaid / visualize_nodes helpers

### DIFF
--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -31,7 +31,6 @@ pub use expand::{
 
 pub trait DescriptorExt {
     fn resolve_aliases_and_set_defaults(&self) -> eyre::Result<BTreeMap<NodeId, ResolvedNode>>;
-    fn visualize_as_mermaid(&self) -> eyre::Result<String>;
     fn visualize_as_mermaid_with_boundaries(
         &self,
         boundaries: &ModuleBoundaries,
@@ -215,12 +214,6 @@ impl DescriptorExt for Descriptor {
         }
 
         Ok(resolved)
-    }
-
-    fn visualize_as_mermaid(&self) -> eyre::Result<String> {
-        let resolved = self.resolve_aliases_and_set_defaults()?;
-        let flowchart = visualize::visualize_nodes(&resolved);
-        Ok(flowchart)
     }
 
     fn visualize_as_mermaid_with_boundaries(

--- a/libraries/core/src/descriptor/visualize.rs
+++ b/libraries/core/src/descriptor/visualize.rs
@@ -11,10 +11,6 @@ use std::{
     time::Duration,
 };
 
-pub fn visualize_nodes(nodes: &BTreeMap<NodeId, ResolvedNode>) -> String {
-    visualize_nodes_with_boundaries(nodes, &ModuleBoundaries::default())
-}
-
 pub fn visualize_nodes_with_boundaries(
     nodes: &BTreeMap<NodeId, ResolvedNode>,
     boundaries: &ModuleBoundaries,


### PR DESCRIPTION
> 🤖 **This PR is machine-generated by Claude** (automated dead-code sweep). It was authored without human review — please verify the reasoning below before merging.

## Issue

The no-boundaries variant of the mermaid visualizer is dead code:

- **`DescriptorExt::visualize_as_mermaid`** (`libraries/core/src/descriptor/mod.rs`, trait decl + impl) has **zero call sites** anywhere in the workspace. A workspace-wide search for `.visualize_as_mermaid()` returns nothing. The only textual matches for the name are a *different* function — the CLI-local free function `pub fn visualize_as_mermaid(dataflow: &Path)` in `binaries/cli/src/command/graph.rs`, which has a distinct signature and internally builds its output through `expand_with_boundaries(...)` + `.visualize_as_mermaid_with_boundaries(...)`. The trait's no-arg method is superseded by that `_with_boundaries` sibling and is never invoked.

- **`visualize_nodes`** (`libraries/core/src/descriptor/visualize.rs`) is a thin wrapper that just calls `visualize_nodes_with_boundaries(nodes, &ModuleBoundaries::default())`. Its **only** caller is the dead `visualize_as_mermaid` method above, so the two form a self-contained removal unit. The module is declared `mod visualize;` (private) and only `collect_dora_timers` is re-exported — `visualize_nodes` is not reachable from outside the crate.

## Fix

Remove the `visualize_as_mermaid` trait method (declaration + impl) and the `visualize_nodes` wrapper. The live paths are untouched:

- `visualize_as_mermaid_with_boundaries` — used by the CLI `graph` command
- `visualize_nodes_with_boundaries` — the real flowchart builder
- `collect_dora_timers` — the only public re-export from the `visualize` module

Net: 11 lines deleted across 2 files, no behavior change.

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p dora-core --all-targets -- -D warnings` — clean (no orphaned imports; `ModuleBoundaries` is still used by the `_with_boundaries` signature)
- `cargo test -p dora-core` — passes
- `cargo check -p dora-cli` — builds (confirms the CLI's `_with_boundaries` consumer is unaffected)

## Note

`dora-core` publishes to crates.io, and `DescriptorExt` is a public extension trait, so removing this trait method is technically a minor semver-breaking change — worth folding into the next version bump, consistent with the earlier dead-code-sweep PRs (#2186, #2187, #2188, #2358). `visualize_nodes` itself lives in a private module and is not part of the public surface.

---
_Generated by [Claude Code](https://claude.ai/code) — automated dead-code sweep. No human has verified these findings; please double-check before merging._

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5KVit4cM46bFW2hAsPP6k)_