### PR TITLE
fix(ros2-bridge): request action results explicitly

### DIFF
--- a/examples/ros2-bridge/c++/action-client/main.cc
+++ b/examples/ros2-bridge/c++/action-client/main.cc
@@ -35,6 +35,7 @@ int main()
 
     client->wait_for_action(node);
     std::unique_ptr<::rust::Box<::ActionGoalId>> goal_id;
+    bool result_requested = false;
     for(int count = 0; count < 3;) {
         auto event = merged_events.next();
         if (event.is_dora()) { // Event from Dora
@@ -47,8 +48,12 @@ int main()
                     auto goal = example_interfaces::Fibonacci_Goal{ .order = 10 + count };
                     goal_id = std::make_unique<::rust::Box<::ActionGoalId>>(
                         client->send_goal(goal));
+                    result_requested = false;
                     std::cout << "Goal have been sent" << std::endl;
+                }
+                if (!result_requested) {
                     client->request_result(*goal_id);
+                    result_requested = true;
                 }
             } else if (ty == DoraEventType::Stop || ty == DoraEventType::AllInputsClosed) {
                 std::cout << "Received stop event" << std::endl;
@@ -71,11 +76,16 @@ int main()
             if(status == ::ActionStatusEnum::Succeeded) {
                 std::cout << "Goal succeeded" << std::endl;
                 goal_id = nullptr;
+                result_requested = false;
                 count += 1;
             } else if(status == ::ActionStatusEnum::Aborted) {
                 std::cerr << "Goal aborted" << std::endl;
+                return 1;
             } else if(status == ::ActionStatusEnum::Canceled) {
                 std::cerr << "Goal canceled" << std::endl;
+                return 1;
+            } else {
+                result_requested = false;
             }
         } else if (client->matches_status(event)) { // Feedback Event from ActionClient
             std::cout << "Get status event" << std::endl;

--- a/examples/ros2-bridge/rust/action-client/run.rs
+++ b/examples/ros2-bridge/rust/action-client/run.rs
@@ -26,11 +26,16 @@ fn main() -> eyre::Result<()> {
         "action_server_member_functions",
     )?;
 
-    dataflow_task
+    let dataflow_result = dataflow_task
         .join()
-        .map_err(|e| eyre::eyre!("the dataflow thread failed: {:?}", e))?;
+        .map_err(|e| eyre::eyre!("the dataflow thread failed: {:?}", e));
 
-    ros_task.kill()?;
+    let kill_result = ros_task
+        .kill()
+        .wrap_err("failed to stop ROS2 action server");
+
+    dataflow_result?;
+    kill_result?;
 
     Ok(())
 }

--- a/examples/ros2-bridge/rust/rust-ros2-example-node/src/action_client.rs
+++ b/examples/ros2-bridge/rust/rust-ros2-example-node/src/action_client.rs
@@ -1,42 +1,17 @@
-use futures::StreamExt;
 use std::time::{Duration, Instant};
 
-use dora_node_api::{
-    self, DoraNode, Event,
-    merged::{MergeExternal, MergedEvent},
-};
+use dora_node_api::{DoraNode, Event};
 use dora_ros2_bridge::{
-    messages::{
-        self,
-        example_interfaces::action::{Fibonacci, FibonacciGoal},
-    },
+    messages::example_interfaces::action::{Fibonacci, FibonacciGoal},
     ros2_client::{
         self, ActionTypes, NodeOptions,
         action::{GoalId, GoalStatusEnum},
+        service::RmwRequestId,
     },
     rustdds::{self, policy},
 };
 use eyre::{Context, eyre};
 use futures::task::SpawnExt;
-
-#[derive(Debug)]
-enum ActionEvent<T>
-where
-    T: ActionTypes,
-{
-    Result {
-        id: GoalId,
-        result: Result<(GoalStatusEnum, T::ResultType), ros2_client::service::CallServiceError<()>>,
-    },
-    Feedback {
-        id: GoalId,
-        feedback: rustdds::dds::result::ReadResult<T::FeedbackType>,
-    },
-    Status {
-        id: GoalId,
-        status: rustdds::dds::result::ReadResult<messages::action_msgs::msg::GoalStatus>,
-    },
-}
 
 fn main() -> eyre::Result<()> {
     let mut ros_node = init_ros_node()?;
@@ -53,18 +28,13 @@ fn main() -> eyre::Result<()> {
     })
     .context("failed to spawn ros2 spinner")?;
 
-    let client = create_action_client(&mut ros_node)?; // should be after the spiner started
-    let (client_stream, mut client_stream_handle) =
-        futures_concurrency_dynamic::dynamic_merge_with_handle::<ActionEvent<Fibonacci>>();
+    let mut client = create_action_client(&mut ros_node)?; // should be after the spiner started
     let (_node, dora_events) = DoraNode::init_from_env()?;
-    let merged_events = dora_events.merge_external(Box::pin(client_stream));
-    let mut events = futures::executor::block_on_stream(merged_events);
+    let mut events = futures::executor::block_on_stream(dora_events);
 
-    // Fail fast instead of hanging: the upstream get_result round-trip can wedge
-    // the node forever (it never returns on ~20% of cold starts). The dora timer
-    // ticks at 2 Hz, so this loop always wakes to check the deadline.
     let deadline = Instant::now() + Duration::from_secs(60);
-    let mut sent = false;
+    let mut sent_goal: Option<GoalId> = None;
+    let mut pending_results: Vec<RmwRequestId> = Vec::new();
     loop {
         if Instant::now() >= deadline {
             eyre::bail!("timed out waiting for a terminal Fibonacci action result");
@@ -75,87 +45,92 @@ fn main() -> eyre::Result<()> {
         };
 
         match event {
-            MergedEvent::Dora(event) => match event {
-                Event::Input {
-                    id,
-                    metadata: _,
-                    data: _,
-                } => match id.as_str() {
-                    "tick" => {
-                        if !sent {
-                            let goal = FibonacciGoal { order: 10 };
-                            futures::executor::block_on(async {
-                                if let Ok((goal_id, goal_resp)) = client.async_send_goal(goal).await
-                                {
-                                    println!("goal_resp: {:?}", goal_resp);
-                                    if goal_resp.accepted {
-                                        let feedback_stream =
-                                            client.feedback_stream(goal_id).map(move |feedback| {
-                                                ActionEvent::Feedback {
-                                                    id: goal_id,
-                                                    feedback,
-                                                }
-                                            });
-                                        let status_stream =
-                                            client.status_stream(goal_id).map(move |status| {
-                                                ActionEvent::Status {
-                                                    id: goal_id,
-                                                    status: status.map(|status| status.into()),
-                                                }
-                                            });
-
-                                        client_stream_handle.push(feedback_stream);
-                                        client_stream_handle.push(result_stream(&client, goal_id));
-                                        client_stream_handle.push(status_stream);
-                                        sent = true;
-                                    }
-                                }
-                            });
+            Event::Input {
+                id,
+                metadata: _,
+                data: _,
+            } => match id.as_str() {
+                "tick" => {
+                    if sent_goal.is_none() {
+                        let goal = FibonacciGoal { order: 10 };
+                        let (goal_id, goal_resp) = futures::executor::block_on(
+                            client.async_send_goal(goal),
+                        )
+                        .map_err(|err| eyre::eyre!("failed to send Fibonacci goal: {err:?}"))?;
+                        println!("goal_resp: {:?}", goal_resp);
+                        if !goal_resp.accepted {
+                            eyre::bail!("Fibonacci goal was rejected by the action server");
                         }
+                        sent_goal = Some(goal_id);
                     }
-                    other => eprintln!("Ignoring unexpected input `{other}`"),
-                },
-                Event::Stop(_) => println!("Received stop"),
-                other => eprintln!("Received unexpected input: {other:?}"),
-            },
-            MergedEvent::External(action_event) => match action_event {
-                ActionEvent::Result { id, result } => match result {
-                    Ok((GoalStatusEnum::Unknown, _)) => {
-                        // there are tons of unknown status :(
-                        client_stream_handle.push(result_stream(&client, id));
+
+                    if let Some(goal_id) = sent_goal
+                        && pending_results.is_empty()
+                    {
+                        pending_results.push(request_result(&client, goal_id)?);
                     }
-                    Ok((_, result)) => {
-                        println!("status: {:?}", result);
-                        break;
+
+                    match receive_result(&mut client, &mut pending_results)? {
+                        Some((GoalStatusEnum::Unknown, _)) => {}
+                        Some((GoalStatusEnum::Succeeded, result)) => {
+                            println!("status: {:?}", result);
+                            break;
+                        }
+                        Some((GoalStatusEnum::Canceled, _)) => {
+                            eyre::bail!("Fibonacci goal was canceled");
+                        }
+                        Some((GoalStatusEnum::Aborted, _)) => {
+                            eyre::bail!("Fibonacci goal was aborted");
+                        }
+                        Some((status, _)) => {
+                            println!("Fibonacci goal still running with status: {status:?}");
+                        }
+                        None => {}
                     }
-                    Err(err) => eyre::bail!("get_result service call failed: {err:?}"),
-                },
-                other => {
-                    println!("{:?}", other);
                 }
+                other => eprintln!("Ignoring unexpected input `{other}`"),
             },
+            Event::Stop(_) => println!("Received stop"),
+            other => eprintln!("Received unexpected input: {other:?}"),
         }
     }
 
     Ok(())
 }
 
-fn result_stream<T>(
+fn request_result<T>(
     client: &ros2_client::action::ActionClient<T>,
     goal_id: GoalId,
-) -> impl futures::stream::Stream<Item = ActionEvent<T>>
+) -> eyre::Result<RmwRequestId>
 where
     T: ActionTypes,
     <T as ActionTypes>::ResultType: 'static,
 {
-    let fut = client.async_request_result(goal_id);
-    futures::stream::once(async move {
-        ActionEvent::Result {
-            id: goal_id,
-            result: fut.await,
+    client
+        .request_result(goal_id)
+        .map_err(|err| eyre::eyre!("failed to request Fibonacci result: {err:?}"))
+}
+
+fn receive_result<T>(
+    client: &mut ros2_client::action::ActionClient<T>,
+    pending_results: &mut Vec<RmwRequestId>,
+) -> eyre::Result<Option<(GoalStatusEnum, T::ResultType)>>
+where
+    T: ActionTypes,
+    <T as ActionTypes>::ResultType: 'static,
+{
+    loop {
+        match client.result_client().receive_response() {
+            Ok(Some((incoming_req_id, response))) => {
+                if let Some(pos) = pending_results.iter().position(|id| *id == incoming_req_id) {
+                    pending_results.remove(pos);
+                    break Ok(Some((response.status, response.result)));
+                }
+            }
+            Ok(None) => break Ok(None),
+            Err(err) => eyre::bail!("failed to receive Fibonacci result: {err:?}"),
         }
-    })
-    .fuse()
+    }
 }
 
 fn init_ros_node() -> eyre::Result<ros2_client::Node> {
@@ -201,7 +176,7 @@ fn create_action_client(
     println!("wait for fibonacci action server");
     let server_ready = async {
         for _ in 0..10 {
-            let ready = fib_client.goal_client().wait_for_service(&ros_node);
+            let ready = fib_client.goal_client().wait_for_service(ros_node);
             futures::pin_mut!(ready);
             let timeout = futures_timer::Delay::new(Duration::from_secs(2));
             match futures::future::select(ready, timeout).await {


### PR DESCRIPTION
## Issue

The native ROS2 action-client examples could hang while waiting for a terminal Fibonacci result.

In the Rust example, result handling used `async_request_result` through a dynamically merged external stream. On cold starts this result future could wedge and never yield, so the node kept running until the outer timeout instead of making progress through Dora timer ticks. The old code also merged feedback/status/result streams into the Dora event stream, which made the example harder to reason about and harder to fail fast when the action server returned a terminal non-success status.

In the C++ example, result requests were tied to goal submission in a way that did not reliably retry/poll result reception. If a result status was not terminal-success, the loop could keep running with the same `goal_id` and no useful state transition. Aborted or canceled goals were logged but did not fail the example, so the runner could continue waiting instead of reporting the real terminal action state.

The Rust action-client runner also killed the ROS2 action server only after the dataflow thread joined successfully. If the dataflow returned an error, cleanup could be skipped or the original error could be obscured by cleanup behavior.

## Fix

- Rework the Rust action-client example to drive action progress from Dora timer ticks instead of merging ROS action streams into the Dora event stream.
- Send one Fibonacci goal, store the accepted `GoalId`, and request the result explicitly with `request_result`.
- Track pending result request IDs and poll `result_client().receive_response()` so unrelated responses are ignored.
- Treat terminal states explicitly:
  - `Succeeded` prints the result and exits the loop.
  - `Canceled` and `Aborted` return errors.
  - `Unknown` and other non-terminal statuses keep polling.
- Preserve the 60-second fail-fast timeout so the example does not hang indefinitely.
- Update the C++ action-client example to:
  - track whether a result request is already outstanding,
  - request results after goal submission,
  - reset result-request state after completion,
  - fail immediately on aborted/canceled terminal states.
- Make the Rust runner collect the dataflow result and ROS cleanup result separately so the action server is still stopped and cleanup errors remain visible.

## Validation

- Ran:
  - `cargo check -p rust-ros2-example-node --features ros2 --bins`
  - `cargo clippy -p rust-ros2-example-node --features ros2 --bins -- -D warnings`
  - `cargo fmt --all -- --check`
- Also covered by the full branch validation run:
  - `cargo clippy --all --exclude dora-node-api-python --exclude dora-operator-api-python --exclude dora-ros2-bridge-python -- -D warnings`
  - `cargo test --all --exclude dora-node-api-python --exclude dora-operator-api-python --exclude dora-ros2-bridge-python --exclude dora-cli-api-python --exclude dora-examples`
  - `cargo check --examples`
