### PR TITLE
fix(ros2-bridge): wait for service readiness in turtle examples

### DIFF
--- a/examples/ros2-bridge/c++/turtle/run.rs
+++ b/examples/ros2-bridge/c++/turtle/run.rs
@@ -1,5 +1,5 @@
 use eyre::{Context, bail};
-use std::{env::consts::EXE_SUFFIX, path::Path};
+use std::{env::consts::EXE_SUFFIX, path::Path, process::Command, time::Duration};
 
 use process_wrap::std::{StdChildWrapper as ChildWrapper, StdCommandWrap as CommandWrap};
 
@@ -47,21 +47,33 @@ fn main() -> eyre::Result<()> {
         ],
     )?;
 
-    let dataflow_task = std::thread::spawn(|| {
-        dora_cli::run("dataflow.yml".to_string(), false).unwrap();
-    });
-
     let mut add_service_task = run_ros_node("examples_rclcpp_minimal_service", "service_main")?;
     let mut turtle_task = run_ros_node("turtlesim", "turtlesim_node")?;
 
-    let dataflow_result = dataflow_task
-        .join()
-        .map_err(|_| eyre::eyre!("Failed to run dataflow"));
+    let service_wait_result = wait_for_ros_service("/add_two_ints");
 
-    add_service_task.kill()?;
-    turtle_task.kill()?;
+    let dataflow_result = if service_wait_result.is_ok() {
+        let dataflow_task = std::thread::spawn(|| {
+            dora_cli::run("dataflow.yml".to_string(), false).unwrap();
+        });
+        dataflow_task
+            .join()
+            .map_err(|_| eyre::eyre!("Failed to run dataflow"))
+    } else {
+        Ok(())
+    };
 
-    dataflow_result
+    let service_kill_result = add_service_task
+        .kill()
+        .wrap_err("failed to stop ROS2 add_two_ints service");
+    let turtle_kill_result = turtle_task.kill().wrap_err("failed to stop turtlesim node");
+
+    service_wait_result?;
+    dataflow_result?;
+    service_kill_result?;
+    turtle_kill_result?;
+
+    Ok(())
 }
 
 fn run_ros_node(package: &str, node: &str) -> eyre::Result<Box<dyn ChildWrapper>> {
@@ -76,6 +88,31 @@ fn run_ros_node(package: &str, node: &str) -> eyre::Result<Box<dyn ChildWrapper>
     command
         .spawn()
         .map_err(|e| eyre::eyre!("failed to spawn ros node: {}", e))
+}
+
+fn wait_for_ros_service(service: &str) -> eyre::Result<()> {
+    for _ in 0..30 {
+        let output = Command::new("ros2")
+            .arg("service")
+            .arg("list")
+            .output()
+            .wrap_err("failed to list ROS2 services")?;
+        if !output.status.success() {
+            return Err(eyre::eyre!(
+                "ros2 service list failed with status {}",
+                output.status
+            ));
+        }
+        if String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .any(|line| line == service)
+        {
+            return Ok(());
+        }
+        std::thread::sleep(Duration::from_secs(1));
+    }
+
+    Err(eyre::eyre!("ROS2 service {service} not available"))
 }
 
 fn build_package(package: &str, features: &[&str]) -> eyre::Result<()> {

--- a/examples/ros2-bridge/rust/rust-ros2-example-node/src/service_client.rs
+++ b/examples/ros2-bridge/rust/rust-ros2-example-node/src/service_client.rs
@@ -104,8 +104,8 @@ fn create_service_client(
 
     println!("wait for add_two_ints service");
     let service_ready = async {
-        for _ in 0..10 {
-            let ready = add_client.wait_for_service(&ros_node);
+        for _ in 0..30 {
+            let ready = add_client.wait_for_service(ros_node);
             futures::pin_mut!(ready);
             let timeout = futures_timer::Delay::new(Duration::from_secs(2));
             match futures::future::select(ready, timeout).await {

--- a/examples/ros2-bridge/rust/rust-ros2-example-node/src/turtle.rs
+++ b/examples/ros2-bridge/rust/rust-ros2-example-node/src/turtle.rs
@@ -17,6 +17,8 @@ use dora_ros2_bridge::{
 use eyre::{Context, eyre};
 use futures::task::SpawnExt;
 
+const ADD_SERVICE_DISCOVERY_POLL_TIMEOUT: Duration = Duration::from_millis(100);
+
 fn main() -> eyre::Result<()> {
     let mut ros_node = init_ros_node()?;
     let turtle_vel_publisher = create_vel_publisher(&mut ros_node)?;
@@ -51,27 +53,8 @@ fn main() -> eyre::Result<()> {
         service_qos.clone(),
     )?;
 
-    // wait until the service server is ready
-    println!("wait for add_two_ints service");
-    let service_ready = async {
-        for _ in 0..10 {
-            let ready = add_client.wait_for_service(&ros_node);
-            futures::pin_mut!(ready);
-            let timeout = futures_timer::Delay::new(Duration::from_secs(2));
-            match futures::future::select(ready, timeout).await {
-                futures::future::Either::Left(((), _)) => {
-                    println!("add_two_ints service is ready");
-                    return Ok(());
-                }
-                futures::future::Either::Right(_) => {
-                    println!("timeout while waiting for add_two_ints service, retrying");
-                }
-            }
-        }
-        eyre::bail!("add_two_ints service not available");
-    };
-    futures::executor::block_on(service_ready)?;
-
+    let mut add_service_ready = false;
+    let add_service_deadline = std::time::Instant::now() + Duration::from_secs(60);
     let output = DataId::from("pose".to_owned());
 
     let (mut node, dora_events) = DoraNode::init_from_env()?;
@@ -107,13 +90,27 @@ fn main() -> eyre::Result<()> {
                         turtle_vel_publisher.publish(direction).unwrap();
                     }
                     "service_timer" => {
-                        let a = rand::random();
-                        let b = rand::random();
-                        let service_result = add_two_ints_request(&add_client, a, b);
-                        let sum = futures::executor::block_on(service_result)
-                            .context("failed to send service request")?;
-                        if sum != a.wrapping_add(b) {
-                            eyre::bail!("unexpected addition result: expected {}, got {sum}", a + b)
+                        if !add_service_ready {
+                            add_service_ready = add_two_ints_service_ready(&add_client, &ros_node);
+                            if add_service_ready {
+                                println!("add_two_ints service is ready");
+                            } else if std::time::Instant::now() >= add_service_deadline {
+                                eyre::bail!("add_two_ints service not available");
+                            }
+                        }
+
+                        if add_service_ready {
+                            let a: i64 = rand::random();
+                            let b: i64 = rand::random();
+                            let expected = a.wrapping_add(b);
+                            let service_result = add_two_ints_request(&add_client, a, b);
+                            let sum = futures::executor::block_on(service_result)
+                                .context("failed to send service request")?;
+                            if sum != expected {
+                                eyre::bail!(
+                                    "unexpected addition result: expected {expected}, got {sum}"
+                                )
+                            }
                         }
                     }
                     other => eprintln!("Ignoring unexpected input `{other}`"),
@@ -140,6 +137,19 @@ fn main() -> eyre::Result<()> {
     }
 
     Ok(())
+}
+
+fn add_two_ints_service_ready(
+    add_client: &ros2_client::Client<AddTwoInts>,
+    ros_node: &ros2_client::Node,
+) -> bool {
+    let ready = add_client.wait_for_service(ros_node);
+    futures::pin_mut!(ready);
+    let timeout = futures_timer::Delay::new(ADD_SERVICE_DISCOVERY_POLL_TIMEOUT);
+    matches!(
+        futures::executor::block_on(futures::future::select(ready, timeout)),
+        futures::future::Either::Left(((), _))
+    )
 }
 
 async fn add_two_ints_request(

--- a/examples/ros2-bridge/rust/turtle/run.rs
+++ b/examples/ros2-bridge/rust/turtle/run.rs
@@ -1,6 +1,6 @@
 use dora_cli::{BuildConfig, build, run};
 use eyre::Context;
-use std::path::Path;
+use std::{path::Path, process::Command, time::Duration};
 
 use process_wrap::std::{StdChildWrapper as ChildWrapper, StdCommandWrap as CommandWrap};
 
@@ -15,21 +15,33 @@ fn main() -> eyre::Result<()> {
         ..Default::default()
     })?;
 
-    let dataflow_task = std::thread::spawn(|| {
-        run("dataflow.yml".to_string(), false).unwrap();
-    });
-
     let mut add_service_task = run_ros_node("examples_rclcpp_minimal_service", "service_main")?;
     let mut turtle_task = run_ros_node("turtlesim", "turtlesim_node")?;
 
-    let dataflow_result = dataflow_task
-        .join()
-        .map_err(|_| eyre::eyre!("Failed to run dataflow"));
+    let service_wait_result = wait_for_ros_service("/add_two_ints");
 
-    add_service_task.kill()?;
-    turtle_task.kill()?;
+    let dataflow_result = if service_wait_result.is_ok() {
+        let dataflow_task = std::thread::spawn(|| {
+            run("dataflow.yml".to_string(), false).unwrap();
+        });
+        dataflow_task
+            .join()
+            .map_err(|_| eyre::eyre!("Failed to run dataflow"))
+    } else {
+        Ok(())
+    };
 
-    dataflow_result
+    let service_kill_result = add_service_task
+        .kill()
+        .wrap_err("failed to stop ROS2 add_two_ints service");
+    let turtle_kill_result = turtle_task.kill().wrap_err("failed to stop turtlesim node");
+
+    service_wait_result?;
+    dataflow_result?;
+    service_kill_result?;
+    turtle_kill_result?;
+
+    Ok(())
 }
 
 fn run_ros_node(package: &str, node: &str) -> eyre::Result<Box<dyn ChildWrapper>> {
@@ -44,4 +56,29 @@ fn run_ros_node(package: &str, node: &str) -> eyre::Result<Box<dyn ChildWrapper>
     command
         .spawn()
         .map_err(|e| eyre::eyre!("failed to spawn ros node: {}", e))
+}
+
+fn wait_for_ros_service(service: &str) -> eyre::Result<()> {
+    for _ in 0..30 {
+        let output = Command::new("ros2")
+            .arg("service")
+            .arg("list")
+            .output()
+            .wrap_err("failed to list ROS2 services")?;
+        if !output.status.success() {
+            return Err(eyre::eyre!(
+                "ros2 service list failed with status {}",
+                output.status
+            ));
+        }
+        if String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .any(|line| line == service)
+        {
+            return Ok(());
+        }
+        std::thread::sleep(Duration::from_secs(1));
+    }
+
+    Err(eyre::eyre!("ROS2 service {service} not available"))
 }

--- a/libraries/extensions/ros2-bridge/msg-gen/src/types/service.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/types/service.rs
@@ -216,7 +216,7 @@ impl Service {
                 #[allow(non_snake_case)]
                 fn #wait_for_service(self: &mut #client_name, node: &Box<Ros2Node>) -> eyre::Result<()> {
                     let service_ready = async {
-                        for _ in 0..10 {
+                        for _ in 0..30 {
                             let ready = self.client.wait_for_service(&node.node);
                             futures::pin_mut!(ready);
                             let timeout = futures_timer::Delay::new(std::time::Duration::from_secs(2));


### PR DESCRIPTION
## Issue

The ROS2 turtle/service examples had discovery races around `/add_two_ints`.

The C++ and Rust turtle runners started `dora run` immediately after spawning the ROS2 `examples_rclcpp_minimal_service` process. ROS2 service discovery is asynchronous, so the service process can be running while `/add_two_ints` is not yet visible to clients. In that window, the Dora dataflow starts, the turtle node begins sending service requests, and the example can fail or hang depending on discovery timing.

Inside the Rust turtle node, service readiness was checked up front with a blocking wait. That made startup fragile because Dora input processing was blocked while waiting for ROS2 discovery. It also meant a slow service discovery path could prevent the node from handling normal Dora events until the wait completed or failed.

The generated C++ service client wait loop also only retried 10 times. On slower ROS2 environments this can be too short, producing intermittent failures even though the service eventually appears.

There was an additional compile-time issue in the Rust turtle node: the code referenced `add_two_ints_service_ready` without defining it, and `rand::random()` did not infer the intended `i64` type reliably in the service request path.

## Fix

- Update both turtle runners to wait for `/add_two_ints` to appear in `ros2 service list` before starting the Dora dataflow.
- Keep ROS child cleanup explicit:
  - collect the service wait result,
  - collect the dataflow result,
  - kill the ROS service and turtlesim processes,
  - then report any wait/dataflow/cleanup errors.
- Change the Rust turtle node to poll service readiness from the `service_timer` input path with a short timeout instead of blocking startup.
- Add `add_two_ints_service_ready` using `wait_for_service` plus a 100 ms timeout.
- Add a 60-second service discovery deadline so the example fails with `add_two_ints service not available` instead of hanging indefinitely.
- Explicitly type generated service operands as `i64` and compare against `wrapping_add`.
- Increase generated C++ service-client readiness retries from 10 to 30.

## Validation

- Reproduced the compile failure with:
  - `cargo check -p rust-ros2-example-node --features ros2 --bin rust-ros2-example-node-turtle`
- Verified the fix with:
  - `cargo check -p rust-ros2-example-node --features ros2 --bins`
  - `cargo check -p dora-ros2-bridge-msg-gen`
  - `cargo clippy -p rust-ros2-example-node --features ros2 --bins -- -D warnings`
  - `cargo clippy -p dora-ros2-bridge-msg-gen -- -D warnings`
  - `cargo test -p dora-ros2-bridge-msg-gen`
  - `cargo fmt --all -- --check`
