### PR TITLE
fix(ros2-bridge): clean up topic subscriber example

### DIFF
--- a/examples/ros2-bridge/rust/rust-ros2-example-node/src/topic_sub.rs
+++ b/examples/ros2-bridge/rust/rust-ros2-example-node/src/topic_sub.rs
@@ -28,10 +28,10 @@ fn main() -> eyre::Result<()> {
     let (_node, dora_events) = DoraNode::init_from_env()?;
 
     let merged_events = dora_events.merge_external(Box::pin(subscriber.async_stream()));
-    let mut events = futures::executor::block_on_stream(merged_events);
+    let events = futures::executor::block_on_stream(merged_events);
 
     let mut count = 0usize;
-    while let Some(event) = events.next() {
+    for event in events {
         match event {
             MergedEvent::Dora(event) => match event {
                 Event::Input {


### PR DESCRIPTION
## Issue

The Rust ROS2 topic subscriber example used:

```rust
let mut events = futures::executor::block_on_stream(merged_events);

while let Some(event) = events.next() {
    ...
}

block_on_stream returns an iterator-like stream wrapper that can be consumed directly. The manual while let Some(event) = events.next() pattern requires events to be mutable and triggers clippy's while_let_on_iterator warning. With -D warnings, this warning fails the ROS2 example clippy gate even though the example behavior is otherwise unchanged.

This matters because the ROS2 example crate is validated with:
cargo clippy -p rust-ros2-example-node --features ros2 --bins -- -D warnings
so style warnings in examples are CI-blocking for this validation path.


Fix

Replace the manual while let Some(event) = events.next() loop with a direct for event in events loop.
Remove the unnecessary mut from the events binding.
Preserve the existing event handling behavior unchanged.
Validation

Ran:
cargo check -p rust-ros2-example-node --features ros2 --bins
cargo clippy -p rust-ros2-example-node --features ros2 --bins -- -D warnings
cargo fmt --all -- --check


