### PR TITLE
fix(cli): validate `dora node remove --grace` like sibling node commands

### DIFF
--- a/binaries/cli/src/command/node/remove.rs
+++ b/binaries/cli/src/command/node/remove.rs
@@ -16,9 +16,9 @@ pub struct Remove {
     #[clap(long, short = 'd', value_name = "NAME_OR_UUID")]
     dataflow: Option<String>,
     node: String,
-    /// Grace period in seconds before force-killing the node.
-    #[clap(long)]
-    grace: Option<f64>,
+    /// Grace period before force-killing the node (e.g. `30s`, `500ms`, `1m`).
+    #[clap(long, value_name = "DURATION", value_parser = crate::common::parse_duration)]
+    grace: Option<std::time::Duration>,
 }
 
 impl Executable for Remove {
@@ -37,7 +37,7 @@ impl Executable for Remove {
             &ControlRequest::RemoveNode {
                 dataflow_id,
                 node_id: node_id.clone(),
-                grace_duration: self.grace.map(std::time::Duration::from_secs_f64),
+                grace_duration: self.grace,
             },
         )?;
 


### PR DESCRIPTION
## Problem

`--grace` on `dora node remove` was parsed as a bare `f64` with clap's default parser and then passed to `Duration::from_secs_f64`, which **panics** on negative, NaN, infinite, or overflowing values:

```
dora node remove mynode --grace=-1     # panic: "value is negative"
dora node remove mynode --grace nan    # panic: "value is not finite"
dora node remove mynode --grace 1e30   # panic: "value is too big"
```

So the CLI aborted with a Rust panic/backtrace instead of a clean error.

## Fix

The sibling commands `dora node stop` and `dora node restart` already parse `--grace` with `value_parser = crate::common::parse_duration`, which rejects negatives and garbage and accepts human-friendly forms (`30s`, `500ms`, `1m`, and bare seconds like `5`). Switch `remove` to the same parser so `grace_duration` is a validated `Duration` and the three cases above become clean "invalid value" errors. This also makes the three `dora node` grace flags consistent.

## Validation

- `cargo clippy -p dora-cli -- -D warnings` (clean)
- `cargo test -p dora-cli` (pass)
- `cargo fmt --all -- --check`

---

*This PR is machine-generated by Claude (an AI agent) as part of an automated code-review pass. Please review carefully before merging.*

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcweBJR67ALrtoXpZTJk8r)_