### PR TITLE
fix(daemon): harden node stdout/stderr log readers

### DIFF
--- a/binaries/daemon/src/spawn/prepared.rs
+++ b/binaries/daemon/src/spawn/prepared.rs
@@ -588,10 +588,15 @@ impl PreparedNode {
                     Ok(0) => true,
                     Ok(_) => false,
                     Err(err) => {
+                        // Terminate the reader on a persistent read error
+                        // instead of re-entering the loop: a broken stdout fd
+                        // keeps returning the same (non-`WouldBlock`) error, so
+                        // `finished = false` would busy-spin at 100% CPU while
+                        // flooding logs. Mirrors the stderr reader below.
                         logger_c
                             .log(LogLevel::Warn, Some("daemon".into()), format!("{err:?}"))
                             .await;
-                        false
+                        true
                     }
                 };
 
@@ -671,7 +676,14 @@ impl PreparedNode {
 
                 buffer.push_str(&new);
 
-                self.node_stderr_most_recent.force_push(new);
+                // Truncate before retaining: `node_stderr_most_recent` keeps up
+                // to `STDERR_LOG_LINES_MAX` lines alive (drained on node
+                // failure), so pushing the untruncated line here would bypass
+                // the per-line `MAX_LOG_LINE_BYTES` heap-exhaustion guard that
+                // `truncate_log_line` exists to enforce.
+                let mut recent = new;
+                truncate_log_line(&mut recent);
+                self.node_stderr_most_recent.force_push(recent);
 
                 let mut content = std::mem::take(&mut buffer);
                 truncate_log_line(&mut content);


### PR DESCRIPTION
## Problem

Two independent robustness issues in the per-node log readers spawned by `PreparedNode` (`binaries/daemon/src/spawn/prepared.rs`):

1. **stdout reader busy-loops on a persistent read error.** On a non-EOF read error the stdout task set `finished = false` and re-entered the loop. A broken/errored stdout fd keeps returning the same (non-`WouldBlock`) error, so the reader spins at 100% CPU, emitting a warning and pushing a `LogLine` every iteration for the rest of the node's life. The sibling stderr reader already terminates on error (`finished = true`) — the two were inconsistent.

2. **stderr "most recent" ring retained untruncated lines.** Each stderr line was `force_push`ed into `node_stderr_most_recent` (a bounded ring of `STDERR_LOG_LINES_MAX = 500` lines, drained on node failure by `extract_err_from_stderr`) *before* truncation; only the copy sent to the log channel passed through `truncate_log_line`. That bypasses the per-line `MAX_LOG_LINE_BYTES` (1 MiB) guard whose documented purpose is to stop "a malicious or buggy node from causing heap exhaustion via a single multi-GB stdout/stderr line" — up to ~500 multi-MB/GB lines could be retained at once.

## Fix

1. Make the stdout `Err` arm terminate the reader (`finished = true`), mirroring the stderr reader.
2. Truncate the stderr line before pushing it into `node_stderr_most_recent`.

Both are small and align the two readers' behavior; comments explain the intent at each site.

## Validation

- `cargo clippy -p dora-daemon -- -D warnings` (clean)
- `cargo test -p dora-daemon` (96 passed)
- `cargo fmt --all -- --check`

---

*This PR is machine-generated by Claude (an AI agent) as part of an automated code-review pass. Please review carefully before merging.*

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcweBJR67ALrtoXpZTJk8r)_