### PR TITLE
fix(python): decode string tuples in operator metadata as ListString

### DIFF
--- a/apis/python/operator/src/lib.rs
+++ b/apis/python/operator/src/lib.rs
@@ -291,7 +291,7 @@ pub fn pydict_to_metadata(dict: Option<Bound<'_, PyDict>>) -> Result<MetadataPar
             {
                 let list: Vec<f64> = value.extract()?;
                 parameters.insert(key, Parameter::ListFloat(list))
-            } else if value.is_instance_of::<PyList>()
+            } else if (value.is_instance_of::<PyTuple>() || value.is_instance_of::<PyList>())
                 && value.len()? > 0
                 && value.get_item(0)?.is_exact_instance_of::<PyString>()
             {


### PR DESCRIPTION
## Problem

`pydict_to_metadata` inspects each metadata value to pick a `Parameter` variant. The integer- and float-list branches both accept a `PyTuple` *or* a `PyList`, but the string-list branch checked `PyList` only. As a result a tuple of strings fell through to the catch-all and was coerced to its string repr:

```python
{"names": ("a", "b")}   ->   Parameter::String("('a', 'b')")
```

instead of `Parameter::ListString(["a", "b"])`, while `["a", "b"]`, `(1, 2)`, and `(1.0, 2.0)` all converted correctly. This silently corrupted the value and was inconsistent with the sibling branches.

## Fix

Accept `PyTuple` in the string-list branch too, matching the int/float branches directly above it (one-line change).

## Validation

The crate is a PyO3 extension module whose metadata path needs a live Python interpreter, so it is not exercised by `cargo test`; verified with `cargo check -p dora-operator-api-python` (clean) and `cargo fmt --all -- --check`.

---

*This PR is machine-generated by Claude (an AI agent) as part of an automated code-review pass. Please review carefully before merging.*

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcweBJR67ALrtoXpZTJk8r)_