### PR TITLE
refactor(runtime): remove unused OperatorEvent::AllocateOutputSample variant

### DIFF
--- a/binaries/runtime/src/lib.rs
+++ b/binaries/runtime/src/lib.rs
@@ -213,14 +213,6 @@ async fn run(
                         break;
                     }
                 }
-                OperatorEvent::AllocateOutputSample { len, sample: tx } => {
-                    let sample = node.allocate_data_sample(len).map_err(eyre::Report::from);
-                    if tx.send(sample).is_err() {
-                        tracing::warn!(
-                            "output sample requested, but operator {operator_id} exited already"
-                        );
-                    }
-                }
                 OperatorEvent::Output {
                     output_id,
                     parameters,

--- a/binaries/runtime/src/operator/mod.rs
+++ b/binaries/runtime/src/operator/mod.rs
@@ -2,7 +2,7 @@ use dora_core::{
     config::{DataId, NodeId},
     descriptor::{Descriptor, OperatorDefinition, OperatorSource},
 };
-use dora_node_api::{DataSample, Event, MetadataParameters, arrow::array::ArrayData};
+use dora_node_api::{Event, MetadataParameters, arrow::array::ArrayData};
 use eyre::{Context, Result};
 use std::any::Any;
 use tokio::sync::{mpsc::Sender, oneshot};
@@ -69,12 +69,8 @@ pub fn run_operator(
 }
 
 #[derive(Debug)]
-#[allow(dead_code, clippy::large_enum_variant)]
+#[allow(clippy::large_enum_variant)]
 pub enum OperatorEvent {
-    AllocateOutputSample {
-        len: usize,
-        sample: oneshot::Sender<eyre::Result<DataSample>>,
-    },
     Output {
         output_id: DataId,
         parameters: MetadataParameters,


### PR DESCRIPTION
> [!IMPORTANT]
> **🤖 Auto-generated by Claude (Claude Code).** This PR was created by an automated dead-code sweep and is opened under a maintainer's account only because the automation authenticates with that token — the change was written by Claude, not by the account owner. It has **not** been hand-reviewed by a human. Please review before merging.

## What

Removes the `AllocateOutputSample` variant from `OperatorEvent` in `binaries/runtime` (crate `dora-runtime`):

```rust
AllocateOutputSample {
    len: usize,
    sample: oneshot::Sender<eyre::Result<DataSample>>,
},
```

## Why it's dead

The variant has **no construction site anywhere in the workspace** — nothing ever sends `OperatorEvent::AllocateOutputSample`, so the match arm handling it in the runtime event loop (`binaries/runtime/src/lib.rs`) was unreachable. A workspace-wide search for the variant returns only its definition and that single unreachable consumer:

```
$ rg -n 'AllocateOutputSample' --glob '!target'
binaries/runtime/src/operator/mod.rs:74:    AllocateOutputSample {          # definition
binaries/runtime/src/lib.rs:216:   OperatorEvent::AllocateOutputSample ...  # unreachable arm
```

The deadness was masked by the `#[allow(dead_code, clippy::large_enum_variant)]` on the enum. The other variants are all live — `Output` (operator output), `Error`, `Panic`, and `Finished` are constructed in `python.rs` / `shared_lib.rs`. Output-sample allocation is **not** routed through this event; the live path allocates directly via `DoraNode::allocate_data_sample`.

`dora-runtime` is a binary crate, so `OperatorEvent` is not a published-library API surface.

## Changes (cascade)

- Delete the `AllocateOutputSample` variant (`operator/mod.rs`)
- Delete the unreachable match arm (`lib.rs`) — required, since matching a non-existent variant won't compile
- Drop the now-unused `DataSample` import (it was referenced only by the removed field)
- Drop the `dead_code` portion of the enum's `#[allow(...)]`, keeping `clippy::large_enum_variant`

`DoraNode::allocate_data_sample` in `dora-node-api` is left untouched (it's public node API, used directly by node authors).

## Verification

- `cargo fmt -p dora-runtime -- --check` — clean
- `cargo clippy -p dora-runtime -- -D warnings` — clean (no orphaned imports; `oneshot` is still used by `run_operator`'s `init_done` param)
- `cargo test -p dora-runtime` — passes

Pure deletion; no behavior change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KFp6v3cwJhCDFEQtPV1dNc) — automated dead-code sweep. No human has verified this; please double-check before merging._

---
_Generated by [Claude Code](https://claude.ai/code/session_01KFp6v3cwJhCDFEQtPV1dNc)_