### PR TITLE
refactor(node-api): remove never-constructed NodeError::Connection variant

### DIFF
--- a/apis/rust/node/src/error.rs
+++ b/apis/rust/node/src/error.rs
@@ -6,9 +6,6 @@ pub enum NodeError {
     /// Initialization failed (config parsing, env vars, daemon handshake).
     #[error("initialization failed: {0}")]
     Init(String),
-    /// Could not connect to the daemon or lost connection.
-    #[error("connection error: {0}")]
-    Connection(String),
     /// Sending an output or closing outputs failed.
     #[error("output error: {0}")]
     Output(String),


### PR DESCRIPTION
> [!IMPORTANT]
> **🤖 Auto-generated by Claude (Claude Code).** This PR was created by an automated dead-code sweep and is opened under a maintainer's account only because the automation authenticates with that token — the change was written by Claude, not by the account owner. It has **not** been hand-reviewed by a human. Please review before merging, and close it if the variant is being reserved for planned work (see the note below).

## What

Removes the `Connection(String)` variant from `NodeError` in `apis/rust/node` (crate `dora-node-api`):

```rust
/// Could not connect to the daemon or lost connection.
#[error("connection error: {0}")]
Connection(String),
```

## Why it's dead

`NodeError::Connection` has **no construction site anywhere in the workspace** — the library never returns it. A workspace-wide search finds only the definition:

```
$ rg -n 'NodeError::Connection' --glob '!target'
apis/rust/node/src/error.rs:11:    Connection(String),   # definition only
```

Every other variant is actually produced: `Init` (config/env/daemon handshake, ~12 sites), `Output` (~8 sites), `Data` (descriptor/allocation), and `Internal` via the `#[from] eyre::Report]` blanket `?` conversion. The connection-failure paths that exist today surface as `Init(..)` during the daemon handshake or as `Internal(..)`.

Error-enum variants are **produced by the library and matched by consumers** — they are not something a downstream user *calls*. Because the crate never constructs `Connection`, no consumer can ever observe or match it, so removing it drops no capability. This is unlike the maintainer-rejected removals of callable extension points (`TracingBuilder::add_layer`, `HEADER_OPERATOR_API`); it's closer to the already-merged orphaned-scaffolding removals (#2296 `PythonOperatorConfig`, #2297 `ResolvedNodeSource`).

## Note for maintainers

`dora-node-api` is published and `NodeError` is not `#[non_exhaustive]`, so dropping a variant is technically a semver-breaking change — worth folding into the next version bump. It cannot break any consumer at runtime, since the variant is never produced. **If `Connection` is intentionally reserved for the daemon-reconnect work** (a dedicated connection-lost error would be its natural home), feel free to close this — as it stands it is entirely unconstructed.

## Verification

- `cargo fmt -p dora-node-api -- --check` — clean
- `cargo build -p dora-node-api` + `cargo clippy -p dora-node-api --lib -- -D warnings` — clean
- Diff is a 3-line deletion in `error.rs` only.

Pure deletion; no behavior change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KFp6v3cwJhCDFEQtPV1dNc) — automated dead-code sweep. No human has verified this; please double-check before merging._

---
_Generated by [Claude Code](https://claude.ai/code/session_01KFp6v3cwJhCDFEQtPV1dNc)_