### PR TITLE
ci: stop cache thrashing (gate rust-cache to main, kill sccache flood)

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,44 @@
+# Delete a PR's Actions caches when the PR closes.
+#
+# GitHub's Actions cache is capped at 10 GB per repo and LRU-evicts once
+# full. Caches created on a PR branch (`refs/pull/<n>/merge`) are scoped
+# to that PR and unusable by anyone else, so once the PR closes they are
+# pure dead weight competing with the shared `main` caches. The main
+# workflows already gate their saves to `main` (see ci.yml), so most PR
+# runs no longer create large caches — but anything that slips through
+# (a step without the gate, a fork's own runs) is reclaimed here.
+#
+# Companion to delete-buildjet-cache.yml, which only handles the manual
+# BuildJet path.
+name: Cleanup PR caches
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete caches for the closed PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge
+        run: |
+          set -euo pipefail
+          gh extension install actions/gh-actions-cache || true
+          echo "Reclaiming caches scoped to $BRANCH"
+          # Loop because `gh actions-cache list` pages at 100 entries.
+          while :; do
+            keys=$(gh actions-cache list -R "$REPO" -B "$BRANCH" -L 100 | cut -f1)
+            [ -z "$keys" ] && break
+            for k in $keys; do
+              gh actions-cache delete "$k" -R "$REPO" -B "$BRANCH" --confirm || true
+            done
+          done
+          echo "Done."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,18 @@
 # nightly schedule to surface platform-specific regressions.
 #
 # Repo-wide workflows: all upstream workflows present plus guide.yml.
+#
+# Caching: every `Swatinem/rust-cache` step below sets
+# `save-if: github.ref == 'refs/heads/main'`. GitHub's Actions cache is
+# capped at 10 GB per repo and LRU-evicts once full. Without the gate,
+# each PR run *saved* a fresh ~800 MB workspace cache scoped to its own
+# ref (unusable by other PRs) and pushed the shared `main` caches out of
+# the budget — so `check`/`clippy`/`test` kept starting cold and
+# recompiling the whole dependency graph. With the gate, only `main`
+# refreshes the shared caches and every PR restores from them. Keep new
+# cache steps gated the same way, and do NOT enable the sccache backend
+# in any workflow (it writes one cache entry per object and floods the
+# same 10 GB budget — see pip-release.yml).
 name: CI
 
 on:
@@ -76,6 +88,11 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
           components: clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          # Only `main` refreshes the shared cache. PRs restore it but
+          # never save, so per-PR runs don't churn the 10 GB repo budget
+          # and evict each other's caches (see header note on caching).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: >
           cargo clippy --all
           --exclude dora-node-api-python
@@ -97,6 +114,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: workspace-check
+          # Save only on `main`; PRs restore-only (see clippy job note).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Check
         run: cargo check --all
       # `cargo check --all` does NOT build `[[example]]` targets, so
@@ -123,6 +142,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: workspace-test
+          # Save only on `main`; PRs restore-only (see clippy job note).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Free disk space
         shell: bash
         run: |
@@ -243,6 +264,9 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
+        with:
+          # Save only on `main`; PRs/merge-queue restore-only (see clippy job note).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       # Now that this job runs in parallel with `test` (#2524) it no longer
       # inherits `test`'s freed disk, and it builds the CLI + all E2E test
       # binaries itself. Reclaim the ~25 GB of preinstalled toolchains the
@@ -333,6 +357,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: workspace-test
+          # Save only on `main`; PRs restore-only (see clippy job note).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       # Runs in parallel with `test` (#2524), so it can't rely on `test`
       # having freed disk. It builds the dora-examples test binary and
       # compiles the PyO3 node extension via `uv pip install -e` below —
@@ -395,6 +421,9 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
+        with:
+          # Save only on `main`; PRs/merge-queue restore-only (see clippy job note).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       # Runs in parallel with `test` (#2524); compiles the criterion
       # benchmark binaries for dora-message + dora-daemon itself. Free the
       # preinstalled toolchains first to avoid "no space left on device".
@@ -496,6 +525,9 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
+        with:
+          # Save only on `main`; PRs restore-only (see clippy job note).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo install cargo-lichking
       - name: Check dependency licenses
         run: cargo lichking check

--- a/.github/workflows/pip-release.yml
+++ b/.github/workflows/pip-release.yml
@@ -83,6 +83,12 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --zig
           manylinux: manylinux_2_28
+          # sccache's GitHub-cache backend writes one entry per compiled
+          # object, flooding the 10 GB repo-wide cache with thousands of
+          # micro-entries that evict the workspace caches PR CI relies on.
+          # These release cross-builds don't help the PR loop, so keep it
+          # off. rust-cache above already caches deps (via BuildJet).
+          sccache: "false"
           working-directory: ${{ matrix.repository.path }}
           before-script-linux: |
             sudo apt-get update
@@ -204,7 +210,10 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist -i ${{ env.PYTHON_VERSION }}
-          sccache: "true"
+          # Was "true" — sccache floods the 10 GB repo cache with
+          # per-object entries that evict PR CI's workspace caches. See
+          # the linux job above for the full rationale.
+          sccache: "false"
           working-directory: ${{ matrix.repository.path }}
       - name: Upload wheels
         if: github.event_name == 'release'
@@ -236,6 +245,9 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist -i ${{ env.PYTHON_VERSION }}
+          # Explicit: never enable the sccache GitHub-cache backend here
+          # (floods the 10 GB repo cache). See the linux job for details.
+          sccache: "false"
           working-directory: ${{ matrix.repository.path }}
       - name: Upload wheels
         if: github.event_name == 'release'

--- a/.github/workflows/test-c-cpp-libraries.yml
+++ b/.github/workflows/test-c-cpp-libraries.yml
@@ -180,6 +180,11 @@ jobs:
 
       - name: Cache cargo target
         uses: Swatinem/rust-cache@v2
+        with:
+          # Save only on `main` so PR runs restore the shared cache but
+          # never write their own ~1.2 GB per-target copies, which would
+          # churn the 10 GB repo-wide cache budget. See ci.yml header.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # ============================================================
       # C API: node + operator


### PR DESCRIPTION
The repo Actions cache sat at ~12 GB / 2,660 entries against GitHub's
10 GB cap, so GitHub continuously LRU-evicted the shared main-branch
workspace caches that check/clippy/test restore from — every PR started
cold and recompiled the whole dependency graph.

- Gate every Swatinem/rust-cache save in ci.yml and test-c-cpp to
  `main` (save-if). PRs restore the shared cache but no longer write
  per-PR ~800 MB / ~1.2 GB copies that churn the budget and evict each
  other. Matches the pattern already used in pip-release/release.
- Disable the sccache backend in pip-release.yml. Its per-object GitHub
  cache entries were 2,648 of the 2,660 caches (~4 GB) and give the PR
  loop no benefit.
- Add cache-cleanup.yml to drop a PR's caches when it closes.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
