### PR TITLE
fix(node): add zenoh data-plane readiness barrier to stop startup message loss

### DIFF
--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -83,6 +83,12 @@ pub struct EventStream {
     /// Per-input `@schema` subscribers (zenoh-ext AdvancedSubscriber) that prime
     /// the data subscribers' decoders. Kept alive like `_zenoh_subscribers`.
     _zenoh_schema_subscribers: Vec<zenoh_ext::AdvancedSubscriber<()>>,
+    /// Per-input liveliness tokens announcing "my data subscriber is declared"
+    /// so producers can count subscribers and only switch an output to the direct
+    /// zenoh data plane once every subscriber is wired (startup no-loss barrier;
+    /// see [`dora_core::topics::zenoh_input_ready_liveliness_topic`]). Kept alive
+    /// for the EventStream's lifetime; dropping a token undeclares it.
+    _zenoh_liveliness_tokens: Vec<zenoh::liveliness::LivelinessToken>,
     close_channel: DaemonChannel,
     clock: Arc<uhlc::HLC>,
     scheduler: Scheduler,
@@ -119,6 +125,7 @@ impl EventStream {
         clock: Arc<uhlc::HLC>,
         write_events_to: Option<PathBuf>,
         zenoh_session: Option<&zenoh::Session>,
+        dynamic: bool,
     ) -> eyre::Result<Self> {
         let channel = match daemon_communication {
             DaemonCommunicationWrapper::Standard(daemon_communication) => {
@@ -263,6 +270,7 @@ impl EventStream {
             total_queue_capacity,
             zenoh_session,
             &input_config,
+            dynamic,
         )
     }
 
@@ -279,6 +287,7 @@ impl EventStream {
         channel_capacity: usize,
         zenoh_session: Option<&zenoh::Session>,
         input_config: &BTreeMap<DataId, Input>,
+        dynamic: bool,
     ) -> eyre::Result<Self> {
         channel.register(dataflow_id, node_id.clone(), clock.new_timestamp())?;
         let (tx, rx) = tokio::sync::mpsc::channel(channel_capacity);
@@ -300,6 +309,7 @@ impl EventStream {
         // them in `_zenoh_subscribers` and drop them after `receiver`.
         let mut zenoh_subscribers = Vec::new();
         let mut zenoh_schema_subscribers = Vec::new();
+        let mut zenoh_liveliness_tokens = Vec::new();
         if let Some(session) = zenoh_session {
             use zenoh::Wait;
             for (input_id, input) in input_config {
@@ -559,6 +569,37 @@ impl EventStream {
                         Ok(s) => {
                             tracing::debug!(input = %input_id, %topic, "zenoh subscriber declared (callback)");
                             zenoh_subscribers.push(s);
+
+                            // Announce readiness for this link so the producer
+                            // counts us before switching the output to the direct
+                            // zenoh data plane. Declared only after a *successful*
+                            // data subscriber (so a counted token always implies
+                            // the subscription is in flight) and never for dynamic
+                            // nodes — they connect at arbitrary times and are not
+                            // part of the startup barrier (the producer reaches
+                            // them via normal matching once they join). A failure
+                            // here is non-fatal: the producer just keeps this
+                            // output on the reliable daemon path.
+                            if !dynamic {
+                                let ready_key =
+                                    dora_core::topics::zenoh_input_ready_liveliness_topic(
+                                        dataflow_id,
+                                        source_node,
+                                        source_output,
+                                        node_id,
+                                        input_id,
+                                    );
+                                match session.liveliness().declare_token(ready_key).wait() {
+                                    Ok(token) => zenoh_liveliness_tokens.push(token),
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            input = %input_id,
+                                            "failed to declare zenoh readiness token ({e}); \
+                                             producer will keep this output on the daemon path"
+                                        );
+                                    }
+                                }
+                            }
                         }
                         Err(e) => {
                             tracing::warn!(
@@ -597,6 +638,7 @@ impl EventStream {
             _thread_handle: thread_handle,
             _zenoh_subscribers: zenoh_subscribers,
             _zenoh_schema_subscribers: zenoh_schema_subscribers,
+            _zenoh_liveliness_tokens: zenoh_liveliness_tokens,
             close_channel,
             start_timestamp: clock.new_timestamp(),
             clock,
@@ -1553,6 +1595,26 @@ impl Drop for EventStream {
             if !completed {
                 tracing::warn!(
                     "zenoh subscriber teardown timed out after {}s; continuing node shutdown",
+                    ZENOH_TEARDOWN_TIMEOUT.as_secs()
+                );
+            }
+        }
+
+        // Undeclare readiness tokens under the same deadline: like subscriber
+        // teardown, `LivelinessToken::drop` undeclares on the shared session and
+        // can block if zenoh's net runtime is wedged (dora-rs/dora#2425).
+        let tokens = std::mem::take(&mut self._zenoh_liveliness_tokens);
+        if !tokens.is_empty() {
+            let completed = teardown_with_timeout(
+                "zenoh-liveliness-tokens",
+                ZENOH_TEARDOWN_TIMEOUT,
+                move || {
+                    drop(tokens);
+                },
+            );
+            if !completed {
+                tracing::warn!(
+                    "zenoh readiness-token teardown timed out after {}s; continuing node shutdown",
                     ZENOH_TEARDOWN_TIMEOUT.as_secs()
                 );
             }

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -13,7 +13,7 @@ use arrow::array::{Array, ArrayData};
 use colored::Colorize;
 use dora_core::{
     config::{DataId, NodeId, NodeRunConfig},
-    descriptor::Descriptor,
+    descriptor::{Descriptor, DescriptorExt},
     topics::{DORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT, DORA_DAEMON_LOCAL_LISTEN_PORT_ENV, LOCALHOST},
     types::TypeRegistry,
     uhlc,
@@ -92,8 +92,43 @@ impl RuntimeTypeCheck {
 /// TCP.
 pub const ZERO_COPY_THRESHOLD: usize = 4096;
 
-const ZENOH_FIRST_PUBLISH_MATCH_TIMEOUT: Duration = Duration::from_millis(200);
-const ZENOH_FIRST_PUBLISH_MATCH_POLL_INTERVAL: Duration = Duration::from_millis(5);
+/// Per-output data-plane readiness for the startup no-loss barrier.
+///
+/// The zenoh data plane is direct node-to-node pub/sub, so a producer that
+/// starts publishing before a consumer's subscription has propagated drops those
+/// early samples. Until every expected subscriber has announced its subscription
+/// (via a liveliness readiness token — see
+/// [`dora_core::topics::zenoh_input_ready_liveliness_topic`]), the producer keeps
+/// delivering over the reliable daemon path and only switches this output to the
+/// fast zenoh path once all subscribers are confirmed wired. Over-counting keeps
+/// an output on the (lossless) daemon path; it never drops messages.
+struct ZenohOutputReadiness {
+    /// Number of subscriber input-links this output has in the dataflow.
+    expected: usize,
+    /// Latches `true` once all expected subscribers are confirmed wired. Never
+    /// reverts — once switched to the fast path we stay on it.
+    ready: bool,
+    /// Distinct readiness-token key expressions currently seen for this output
+    /// (deduped). Maintained by the liveliness subscriber callback.
+    alive: Arc<std::sync::Mutex<std::collections::HashSet<String>>>,
+    /// Liveliness subscriber counting readiness tokens for this output. Kept
+    /// alive so its callback keeps `alive` current; dropped with the node.
+    _liveliness_sub: zenoh::pubsub::Subscriber<()>,
+}
+
+/// How long [`DoraNode::init`] waits for the direct-zenoh routes of this node's
+/// outputs to connect before handing control to user code.
+///
+/// The daemon "all nodes ready" barrier already guarantees every subscriber is
+/// *declared* before any node runs; this only waits out the residual zenoh
+/// propagation between two already-declared endpoints, so it is normally
+/// sub-second. On timeout (e.g. a zenoh data plane that can't connect while the
+/// control plane can) the un-connected outputs simply start on the reliable
+/// daemon path and upgrade to direct zenoh once their subscribers appear — the
+/// dataflow is never blocked, and nothing is dropped.
+const ZENOH_OUTPUT_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+/// Poll interval while waiting for output routes to connect at startup.
+const ZENOH_OUTPUT_CONNECT_POLL_INTERVAL: Duration = Duration::from_millis(5);
 
 /// Must exceed zenoh's internal 10s session close timeout, which is not
 /// enforceable when zenoh's net runtime is wedged.
@@ -132,6 +167,9 @@ pub struct DoraNode {
     zenoh_schema_state: HashMap<DataId, SchemaOnceState>,
     /// Threshold for using zenoh SHM vs inline bytes (default 4096).
     zenoh_zero_copy_threshold: usize,
+    /// Per-output startup readiness for the direct zenoh data plane (lazily
+    /// created on first send). See [`ZenohOutputReadiness`].
+    zenoh_output_readiness: HashMap<DataId, ZenohOutputReadiness>,
 
     dataflow_descriptor: serde_yaml::Result<Descriptor>,
     warned_unknown_output: BTreeSet<DataId>,
@@ -660,6 +698,7 @@ impl DoraNode {
             clock.clone(),
             write_events_to,
             zenoh_session.as_ref(),
+            dynamic,
         )
         .wrap_err("failed to init event stream")?;
         let control_channel =
@@ -692,7 +731,7 @@ impl DoraNode {
             }
         };
 
-        let node = Self {
+        let mut node = Self {
             id: node_id,
             dataflow_id,
             node_config: run_config.clone(),
@@ -704,6 +743,7 @@ impl DoraNode {
             zenoh_schema_publishers: HashMap::new(),
             zenoh_schema_state: HashMap::new(),
             zenoh_zero_copy_threshold,
+            zenoh_output_readiness: HashMap::new(),
             dataflow_descriptor: serde_yaml::from_value(dataflow_descriptor),
             warned_unknown_output: BTreeSet::new(),
             interactive: false,
@@ -739,6 +779,14 @@ impl DoraNode {
                 }
             }
         }
+
+        // Warm up the direct-zenoh data plane before handing control to user
+        // code: declare output publishers and wait (bounded) until their
+        // subscribers are wired, so the first `send_output` on a connected output
+        // hits an established route. Fail-safe — un-connected outputs start on the
+        // daemon path and upgrade later (see `warm_up_direct_outputs`).
+        node.warm_up_direct_outputs();
+
         Ok((node, event_stream))
     }
 
@@ -1092,14 +1140,276 @@ impl DoraNode {
         Ok(())
     }
 
+    /// Whether the direct zenoh data plane is safe to use for `output_id` — i.e.
+    /// every subscriber this output has in the dataflow has announced its
+    /// subscription. Returns `false` while any expected subscriber is still
+    /// missing, so the caller keeps using the reliable daemon path (no message is
+    /// dropped during the startup subscription-establishment window).
+    ///
+    /// Lazily declares the per-output liveliness counter on first use. Once all
+    /// subscribers are confirmed the result latches `true` and later calls are a
+    /// cheap map lookup. If readiness tracking cannot be set up (no zenoh session
+    /// or an invalid key) this returns `true` so the data plane is not stalled.
+    fn ensure_output_ready(&mut self, output_id: &DataId) -> bool {
+        use zenoh::Wait;
+
+        if self
+            .zenoh_output_readiness
+            .get(output_id)
+            .is_some_and(|r| r.ready)
+        {
+            return true;
+        }
+
+        if !self.zenoh_output_readiness.contains_key(output_id) {
+            match self.declare_output_readiness(output_id) {
+                Some(readiness) => {
+                    self.zenoh_output_readiness
+                        .insert(output_id.clone(), readiness);
+                }
+                // Tracking unavailable — don't stall the data plane.
+                None => return true,
+            }
+        }
+
+        let (expected, count) = {
+            let readiness = self
+                .zenoh_output_readiness
+                .get(output_id)
+                .expect("readiness entry just ensured");
+            let count = readiness.alive.lock().map(|alive| alive.len()).unwrap_or(0);
+            (readiness.expected, count)
+        };
+
+        // No subscribers to wait for: nothing can be lost, use the fast path.
+        if expected == 0 {
+            self.mark_output_ready(output_id);
+            return true;
+        }
+
+        if count < expected {
+            return false;
+        }
+
+        // Every readiness token is visible (all subscribers declared their
+        // subscriptions). Confirm zenoh has actually forwarded a matching
+        // subscription to this publisher before switching, so the very first
+        // zenoh sample isn't published into a not-yet-wired route.
+        let matched = self
+            .zenoh_publishers
+            .get(output_id)
+            .and_then(|publisher| publisher.matching_status().wait().ok())
+            .is_some_and(|status| status.matching());
+        if matched {
+            self.mark_output_ready(output_id);
+            return true;
+        }
+
+        false
+    }
+
+    /// Latch the output's data plane as ready (idempotent).
+    fn mark_output_ready(&mut self, output_id: &DataId) {
+        if let Some(readiness) = self.zenoh_output_readiness.get_mut(output_id) {
+            if !readiness.ready {
+                tracing::debug!(
+                    output = %output_id,
+                    subscribers = readiness.expected,
+                    "all subscribers wired; switching output to direct zenoh data plane"
+                );
+            }
+            readiness.ready = true;
+        }
+    }
+
+    /// Build the per-output readiness counter: resolve how many subscribers the
+    /// output has (from the dataflow descriptor) and declare a liveliness
+    /// subscriber that counts their readiness tokens. Returns `None` if there is
+    /// no zenoh session or the counting subscription could not be declared.
+    fn declare_output_readiness(&self, output_id: &DataId) -> Option<ZenohOutputReadiness> {
+        use zenoh::Wait;
+
+        let session = self.zenoh_session.as_ref()?;
+
+        // Expected subscriber count from the global topology. A descriptor that
+        // failed to parse (never the case for a daemon-spawned node) yields 0,
+        // which just means "no barrier" — the pre-existing behaviour.
+        let expected = match &self.dataflow_descriptor {
+            Ok(descriptor) => descriptor
+                .output_subscriber_count(&self.id, output_id)
+                .unwrap_or_else(|e| {
+                    tracing::warn!(
+                        output = %output_id,
+                        "failed to count subscribers ({e}); not gating the zenoh data plane"
+                    );
+                    0
+                }),
+            Err(_) => 0,
+        };
+
+        let prefix = dora_core::topics::zenoh_output_ready_liveliness_prefix(
+            self.dataflow_id,
+            &self.id,
+            output_id,
+        );
+        let key_expr = match zenoh::key_expr::KeyExpr::new(prefix) {
+            Ok(key) => key.into_owned(),
+            Err(e) => {
+                tracing::warn!(output = %output_id, "invalid readiness key ({e}); not gating the zenoh data plane");
+                return None;
+            }
+        };
+
+        let alive = Arc::new(std::sync::Mutex::new(std::collections::HashSet::new()));
+        let alive_cb = alive.clone();
+        // `history(true)` replays tokens that were declared before this
+        // subscriber, so subscribers that wired up early are still counted.
+        let subscriber = session
+            .liveliness()
+            .declare_subscriber(key_expr)
+            .history(true)
+            .callback(move |sample| {
+                let key = sample.key_expr().as_str().to_string();
+                if let Ok(mut alive) = alive_cb.lock() {
+                    match sample.kind() {
+                        zenoh::sample::SampleKind::Put => {
+                            alive.insert(key);
+                        }
+                        zenoh::sample::SampleKind::Delete => {
+                            alive.remove(&key);
+                        }
+                    }
+                }
+            })
+            .wait();
+
+        match subscriber {
+            Ok(subscriber) => Some(ZenohOutputReadiness {
+                expected,
+                ready: false,
+                alive,
+                _liveliness_sub: subscriber,
+            }),
+            Err(e) => {
+                tracing::warn!(output = %output_id, "failed to declare readiness subscriber ({e}); not gating the zenoh data plane");
+                None
+            }
+        }
+    }
+
+    /// Ensure a direct-zenoh data publisher is declared for `output_id`.
+    ///
+    /// Idempotent: returns `true` if a publisher exists after the call (already
+    /// present or freshly declared), `false` if there is no zenoh session or the
+    /// declaration failed (the caller then falls back to the daemon path).
+    ///
+    /// QoS is configured at declare time so it applies to every put:
+    /// `express(true)` bypasses zenoh's adaptive batch timer (the single biggest
+    /// small-message latency win — without it, per-put delivery on the bare local
+    /// config collapses to a few msg/s), `Priority::RealTime` keeps data-plane
+    /// messages off the bulk-data queues, and `CongestionControl::Drop` prevents a
+    /// stalled subscriber from back-pressuring the publishing node.
+    fn ensure_zenoh_publisher(&mut self, output_id: &DataId) -> bool {
+        use zenoh::Wait;
+        use zenoh::qos::{CongestionControl, Priority};
+
+        if self.zenoh_publishers.contains_key(output_id) {
+            return true;
+        }
+        let Some(session) = self.zenoh_session.as_ref() else {
+            return false;
+        };
+        let topic =
+            dora_core::topics::zenoh_output_publish_topic(self.dataflow_id, &self.id, output_id);
+        let key_expr = match zenoh::key_expr::KeyExpr::new(topic) {
+            Ok(key) => key.into_owned(),
+            Err(e) => {
+                tracing::warn!(output = %output_id, "invalid zenoh key ({e}); falling back to daemon path");
+                return false;
+            }
+        };
+        let publisher = match session
+            .declare_publisher(key_expr)
+            .congestion_control(CongestionControl::Drop)
+            .express(true)
+            .priority(Priority::RealTime)
+            .wait()
+        {
+            Ok(publisher) => publisher,
+            Err(e) => {
+                tracing::warn!(output = %output_id, "failed to declare zenoh publisher ({e}); falling back to daemon path");
+                return false;
+            }
+        };
+        self.zenoh_publishers.insert(output_id.clone(), publisher);
+        true
+    }
+
+    /// Eagerly declare this node's direct-zenoh output publishers and readiness
+    /// counters, then wait (bounded) until every output's subscribers are wired
+    /// up — so the user's first `send_output` on a connected output is guaranteed
+    /// to hit an established route rather than dropping startup samples.
+    ///
+    /// Runs once, at the end of [`Self::init`], *after* the daemon "all nodes
+    /// ready" barrier. By then every subscriber in the dataflow has already
+    /// declared its data subscriber and readiness token (the barrier releases
+    /// only once all nodes have subscribed), so this merely waits out zenoh route
+    /// propagation between already-declared endpoints — normally milliseconds.
+    ///
+    /// Fail-safe: outputs that don't connect within
+    /// [`ZENOH_OUTPUT_CONNECT_TIMEOUT`] (an unreachable remote subscriber, or a
+    /// zenoh data plane that can't connect while the control plane can) are left
+    /// on the reliable daemon path and upgrade to direct zenoh on a later send
+    /// once their subscribers appear. The dataflow is never blocked from starting
+    /// and nothing is dropped.
+    fn warm_up_direct_outputs(&mut self) {
+        if self.zenoh_session.is_none() {
+            return;
+        }
+        let outputs: Vec<DataId> = self.node_config.outputs.iter().cloned().collect();
+        if outputs.is_empty() {
+            return;
+        }
+
+        // Declare publishers up front so zenoh starts wiring routes immediately
+        // and `ensure_output_ready` (which reads `matching_status`) can observe
+        // them. `ensure_output_ready` lazily declares the readiness counter.
+        for output_id in &outputs {
+            self.ensure_zenoh_publisher(output_id);
+        }
+
+        let deadline = Instant::now() + ZENOH_OUTPUT_CONNECT_TIMEOUT;
+        loop {
+            let all_ready = outputs
+                .iter()
+                .all(|output_id| self.ensure_output_ready(output_id));
+            if all_ready {
+                break;
+            }
+            if Instant::now() >= deadline {
+                let pending: Vec<&str> = outputs
+                    .iter()
+                    .filter(|o| !self.ensure_output_ready(o))
+                    .map(|o| o.as_str())
+                    .collect();
+                tracing::debug!(
+                    outputs = ?pending,
+                    "direct-zenoh routes not confirmed within {}s; these outputs start on the daemon path and upgrade when their subscribers connect",
+                    ZENOH_OUTPUT_CONNECT_TIMEOUT.as_secs()
+                );
+                break;
+            }
+            std::thread::sleep(ZENOH_OUTPUT_CONNECT_POLL_INTERVAL);
+        }
+    }
+
     /// Publish data directly via zenoh (node-to-node, bypassing daemon for data).
     /// Uses SHM for zero-copy when possible, falls back to heap buffer.
     ///
-    /// The publisher is declared with `express(true)` to bypass zenoh's adaptive
-    /// batch timer (the single biggest small-message latency win — without it,
-    /// per-put delivery on the bare local config collapses to a few msg/s) and
-    /// with `Priority::RealTime` so data-plane messages don't share queues with
-    /// bulk traffic.
+    /// The publisher is declared (see [`Self::ensure_zenoh_publisher`]) with
+    /// `express(true)` to bypass zenoh's adaptive batch timer and with
+    /// `Priority::RealTime` so data-plane messages don't share queues with bulk
+    /// traffic.
     fn zenoh_publish(
         &mut self,
         output_id: &DataId,
@@ -1107,85 +1417,37 @@ impl DoraNode {
         finalized: FinalizedSample,
     ) -> eyre::Result<PublishOutcome> {
         use zenoh::Wait;
-        use zenoh::qos::{CongestionControl, Priority};
 
         // Every failure *before* the payload is moved into `put` returns the
         // sample as `NotPublished` so the caller can still deliver it via the
         // daemon. Only a failed `put` of an SHM buffer (which consumes it)
         // returns `Err` — that is the single non-recoverable case.
-        let Some(session) = self.zenoh_session.as_ref() else {
+        //
+        // Get or create the publisher for this output. Normally it was already
+        // declared eagerly at startup (see [`Self::warm_up_direct_outputs`]);
+        // this covers outputs sent that weren't declared then. A missing
+        // session or a declaration failure falls back to the daemon path.
+        if !self.ensure_zenoh_publisher(output_id) {
             return Ok(PublishOutcome::NotPublished(finalized));
-        };
+        }
 
-        // Get or create publisher for this output. QoS is configured at
-        // declare time so it applies to every put: `express(true)` bypasses
-        // zenoh's adaptive batch timer (the single biggest small-message
-        // latency win — without it, per-put delivery on the bare local config
-        // collapses to a few msg/s), and `Priority::RealTime` keeps data-plane
-        // messages off the bulk-data queues. `CongestionControl::Drop`
-        // prevents a stalled subscriber from back-pressuring the publishing
-        // node.
-        let declared_publisher = if !self.zenoh_publishers.contains_key(output_id) {
-            let topic = dora_core::topics::zenoh_output_publish_topic(
-                self.dataflow_id,
-                &self.id,
-                output_id,
-            );
-            let key_expr = match zenoh::key_expr::KeyExpr::new(topic) {
-                Ok(key) => key.into_owned(),
-                Err(e) => {
-                    tracing::warn!(output = %output_id, "invalid zenoh key ({e}); falling back to daemon path");
-                    return Ok(PublishOutcome::NotPublished(finalized));
-                }
-            };
-            let publisher = match session
-                .declare_publisher(key_expr)
-                .congestion_control(CongestionControl::Drop)
-                .express(true)
-                .priority(Priority::RealTime)
-                .wait()
-            {
-                Ok(publisher) => publisher,
-                Err(e) => {
-                    tracing::warn!(output = %output_id, "failed to declare zenoh publisher ({e}); falling back to daemon path");
-                    return Ok(PublishOutcome::NotPublished(finalized));
-                }
-            };
-            self.zenoh_publishers.insert(output_id.clone(), publisher);
-            true
-        } else {
-            false
-        };
+        // Startup no-loss barrier: until every subscriber for this output has
+        // wired up its zenoh subscription, deliver over the reliable daemon path
+        // rather than dropping early samples on the not-yet-established data
+        // plane. Once all subscribers are confirmed this latches ready and every
+        // subsequent send takes the fast zenoh path.
+        if !self.ensure_output_ready(output_id) {
+            return Ok(PublishOutcome::NotPublished(finalized));
+        }
+
         let Some(publisher) = self.zenoh_publishers.get(output_id) else {
             tracing::warn!(output = %output_id, "zenoh publisher missing; falling back to daemon path");
             return Ok(PublishOutcome::NotPublished(finalized));
         };
-
-        if declared_publisher {
-            let wait_until = Instant::now() + ZENOH_FIRST_PUBLISH_MATCH_TIMEOUT;
-            loop {
-                match publisher.matching_status().wait() {
-                    Ok(status) if status.matching() => break,
-                    Ok(_) if Instant::now() < wait_until => {
-                        std::thread::sleep(ZENOH_FIRST_PUBLISH_MATCH_POLL_INTERVAL);
-                    }
-                    Ok(_) => {
-                        tracing::debug!(
-                            output = %output_id,
-                            "no matching zenoh subscriber before first publish timeout"
-                        );
-                        return Ok(PublishOutcome::NotPublished(finalized));
-                    }
-                    Err(err) => {
-                        tracing::warn!(
-                            output = %output_id,
-                            "failed to query zenoh matching status before first publish: {err}"
-                        );
-                        return Ok(PublishOutcome::NotPublished(finalized));
-                    }
-                }
-            }
-        }
+        let session = self
+            .zenoh_session
+            .as_ref()
+            .expect("zenoh session presence checked above");
 
         // Serialize metadata as zenoh attachment.
         let metadata_bytes = match bincode::serialize(metadata) {
@@ -1808,6 +2070,9 @@ impl Drop for DoraNode {
         // daemon-signaled `InputClosed` cannot overtake in-flight zenoh data.
         let publishers = std::mem::take(&mut self.zenoh_publishers);
         let schema_publishers = std::mem::take(&mut self.zenoh_schema_publishers);
+        // Per-output readiness counters hold liveliness subscribers on the shared
+        // session; drop them before the session (same reasoning as publishers).
+        let readiness = std::mem::take(&mut self.zenoh_output_readiness);
         let shm_provider = self.zenoh_shm_provider.take();
         let session = self.zenoh_session.take();
         let runtime = self._owned_runtime.take();
@@ -1820,10 +2085,12 @@ impl Drop for DoraNode {
             // hang node shutdown (and with it the daemon, which waits for
             // `InputClosed`). Bound the teardown with a deadline instead.
             let completed = teardown_with_timeout("zenoh", ZENOH_TEARDOWN_TIMEOUT, move || {
-                // documented drop order: publishers (data + schema) before the
-                // session, owned runtime last so async cleanup can still run
+                // documented drop order: publishers (data + schema) and readiness
+                // subscribers before the session, owned runtime last so async
+                // cleanup can still run
                 drop(publishers);
                 drop(schema_publishers);
+                drop(readiness);
                 drop(shm_provider);
                 drop(session);
                 drop(runtime);

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -31,6 +31,51 @@ pub use expand::{
 
 pub trait DescriptorExt {
     fn resolve_aliases_and_set_defaults(&self) -> eyre::Result<BTreeMap<NodeId, ResolvedNode>>;
+    /// Number of subscriber input-links for the output `source_node/source_output`
+    /// across the whole (resolved) dataflow — i.e. how many `(node, input)` pairs
+    /// map to it, counting each operator input of a runtime node separately.
+    ///
+    /// This is the count of zenoh data-plane subscribers a producer must see wired
+    /// up before it is safe to switch that output from the reliable daemon path to
+    /// the direct zenoh path without dropping startup messages (see
+    /// [`crate::topics::zenoh_input_ready_liveliness_topic`]). It is a global
+    /// topology count, so it correctly includes subscribers on other daemons.
+    ///
+    /// Provided in terms of [`resolve_aliases_and_set_defaults`](Self::resolve_aliases_and_set_defaults).
+    fn output_subscriber_count(
+        &self,
+        source_node: &NodeId,
+        source_output: &DataId,
+    ) -> eyre::Result<usize> {
+        let resolved = self.resolve_aliases_and_set_defaults()?;
+        let mut count = 0;
+        for node in resolved.values() {
+            // Dynamic nodes connect at arbitrary times (or never), so the startup
+            // barrier must not wait for them: they receive over zenoh via normal
+            // publisher/subscriber matching once they connect, and excluding them
+            // cannot lose a message to an already-connected static subscriber.
+            if node_is_dynamic(node) {
+                continue;
+            }
+            let inputs: Vec<&Input> = match &node.kind {
+                CoreNodeKind::Custom(n) => n.run_config.inputs.values().collect(),
+                CoreNodeKind::Runtime(n) => n
+                    .operators
+                    .iter()
+                    .flat_map(|op| op.config.inputs.values())
+                    .collect(),
+            };
+            for input in inputs {
+                if let InputMapping::User(m) = &input.mapping
+                    && &m.source == source_node
+                    && &m.output == source_output
+                {
+                    count += 1;
+                }
+            }
+        }
+        Ok(count)
+    }
     fn visualize_as_mermaid_with_boundaries(
         &self,
         boundaries: &ModuleBoundaries,
@@ -53,6 +98,13 @@ pub trait DescriptorExt {
 }
 
 pub const SINGLE_OPERATOR_DEFAULT_ID: &str = "op";
+
+/// Whether a resolved node is a dynamic node (spawned/connected at runtime rather
+/// than at dataflow launch). Mirrors the daemon's classification.
+fn node_is_dynamic(node: &ResolvedNode) -> bool {
+    matches!(&node.kind, CoreNodeKind::Custom(n)
+        if matches!(n.source, NodeSource::Local) && n.path == DYNAMIC_SOURCE)
+}
 
 impl DescriptorExt for Descriptor {
     fn resolve_aliases_and_set_defaults(&self) -> eyre::Result<BTreeMap<NodeId, ResolvedNode>> {
@@ -597,6 +649,81 @@ mod tests {
         assert_eq!(merged.get("A"), Some(&EnvValue::String("node".into())));
         assert_eq!(merged.get("B"), Some(&EnvValue::String("global".into())));
         assert_eq!(merged.get("C"), Some(&EnvValue::String("node".into())));
+    }
+
+    #[test]
+    fn output_subscriber_count_counts_fanout_and_ignores_non_subscribers() {
+        // `source/value` fans out to `transform` and `recorder` (2); the
+        // `transform/doubled` output feeds only `sink` (1). Timer inputs and
+        // subscriptions to other outputs must not be counted. This count is what
+        // a producer waits for before switching an output to the direct zenoh
+        // data plane, so an undercount here would drop startup messages.
+        let yaml = r#"
+nodes:
+  - id: source
+    path: source
+    inputs:
+      tick: dora/timer/millis/50
+    outputs:
+      - value
+  - id: transform
+    path: transform
+    inputs:
+      value: source/value
+    outputs:
+      - doubled
+  - id: recorder
+    path: recorder
+    inputs:
+      rec_in: source/value
+  - id: sink
+    path: sink
+    inputs:
+      doubled: transform/doubled
+"#;
+        let desc: Descriptor = serde_yaml::from_str(yaml).expect("parse");
+        let source = NodeId::from("source".to_string());
+        let transform = NodeId::from("transform".to_string());
+        let sink = NodeId::from("sink".to_string());
+        let value = DataId::from("value".to_string());
+        let doubled = DataId::from("doubled".to_string());
+        let missing = DataId::from("nonexistent".to_string());
+
+        assert_eq!(desc.output_subscriber_count(&source, &value).unwrap(), 2);
+        assert_eq!(
+            desc.output_subscriber_count(&transform, &doubled).unwrap(),
+            1
+        );
+        // Output nobody subscribes to.
+        assert_eq!(desc.output_subscriber_count(&source, &missing).unwrap(), 0);
+        // `sink` produces nothing.
+        assert_eq!(desc.output_subscriber_count(&sink, &value).unwrap(), 0);
+    }
+
+    #[test]
+    fn output_subscriber_count_excludes_dynamic_subscribers() {
+        // A dynamic subscriber connects at runtime, so it must not be counted in
+        // the startup barrier — otherwise the producer would stall on the daemon
+        // path waiting for a node that may connect late or never.
+        let yaml = r#"
+nodes:
+  - id: source
+    path: source
+    outputs:
+      - value
+  - id: static_sub
+    path: static_sub
+    inputs:
+      v: source/value
+  - id: dyn_sub
+    path: dynamic
+    inputs:
+      v: source/value
+"#;
+        let desc: Descriptor = serde_yaml::from_str(yaml).expect("parse");
+        let source = NodeId::from("source".to_string());
+        let value = DataId::from("value".to_string());
+        assert_eq!(desc.output_subscriber_count(&source, &value).unwrap(), 1);
     }
 
     #[test]

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -369,6 +369,80 @@ pub fn zenoh_daemon_control_topic(
     format!("dora/{network_id}/{dataflow_id}/control/{node_id}/{output_id}")
 }
 
+/// Hex-encode a `DataId` so it occupies exactly one zenoh key chunk.
+///
+/// A `DataId` may legally contain `/` (unlike a `NodeId`), so embedding one
+/// verbatim as a key segment would spill into extra chunks and let a producer's
+/// wildcard readiness subscription collide across outputs whose names nest —
+/// e.g. output `cmd` would over-count tokens belonging to output `cmd/vel`,
+/// which in the startup barrier could switch `cmd` to the direct path before all
+/// of *its* subscribers are wired and drop messages. Hex is unambiguous
+/// (`[0-9a-f]`, never `/`), collision-free, and computed identically by the
+/// subscriber (declaring the token) and the producer (matching it).
+#[cfg(feature = "zenoh")]
+fn hex_key_segment(id: &dora_message::id::DataId) -> String {
+    use std::fmt::Write;
+    let s: &str = id.as_ref();
+    let mut out = String::with_capacity(s.len() * 2);
+    for b in s.bytes() {
+        let _ = write!(out, "{b:02x}");
+    }
+    out
+}
+
+/// Zenoh **liveliness** key a subscriber declares once it has wired up its
+/// data-plane subscriber for `source_node`'s `source_output`.
+///
+/// The data plane is direct node-to-node zenoh pub/sub, so a producer that
+/// starts publishing before a consumer's subscription has propagated would drop
+/// those early samples (zenoh does not buffer for not-yet-declared subscribers).
+/// Each subscriber therefore declares a liveliness token here right after
+/// declaring its data subscriber; the producer counts these tokens (via
+/// [`zenoh_output_ready_liveliness_prefix`]) and keeps delivering over the
+/// reliable daemon path until every expected subscriber is present, only then
+/// switching to the fast zenoh path. This gives startup a lossless barrier that
+/// the daemon control-plane "all nodes ready" gate cannot (it does not observe
+/// the zenoh data plane). The `<subscriber_node>/<subscriber_input>` suffix makes
+/// each link's token unique so producers can count distinct subscribers.
+///
+/// `source_output` is [hex-encoded](hex_key_segment) into a single chunk so it
+/// cannot collide with a differently-named output whose key would nest under the
+/// producer's wildcard subscription.
+#[cfg(feature = "zenoh")]
+pub fn zenoh_input_ready_liveliness_topic(
+    dataflow_id: uuid::Uuid,
+    source_node: &dora_message::id::NodeId,
+    source_output: &dora_message::id::DataId,
+    subscriber_node: &dora_message::id::NodeId,
+    subscriber_input: &dora_message::id::DataId,
+) -> String {
+    let network_id = "default";
+    let output = hex_key_segment(source_output);
+    let input = hex_key_segment(subscriber_input);
+    format!(
+        "dora/{network_id}/{dataflow_id}/ready/{source_node}/{output}/{subscriber_node}/{input}"
+    )
+}
+
+/// Wildcard liveliness key matching every subscriber-ready token for
+/// `source_node`'s `source_output` (see [`zenoh_input_ready_liveliness_topic`]).
+/// The producer subscribes to / queries this to count how many subscribers have
+/// wired up their data-plane subscription.
+#[cfg(feature = "zenoh")]
+pub fn zenoh_output_ready_liveliness_prefix(
+    dataflow_id: uuid::Uuid,
+    source_node: &dora_message::id::NodeId,
+    source_output: &dora_message::id::DataId,
+) -> String {
+    let network_id = "default";
+    let output = hex_key_segment(source_output);
+    // `source_output` is hex-encoded to a single chunk (see
+    // `zenoh_input_ready_liveliness_topic`), so `**` matches exactly the
+    // `<subscriber_node>/<subscriber_input>` suffix of tokens for *this* output
+    // and nothing from a nested-named output.
+    format!("dora/{network_id}/{dataflow_id}/ready/{source_node}/{output}/**")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -414,6 +488,49 @@ mod tests {
         assert_ne!(
             output_topic, control_topic,
             "node output and daemon control must not share a Zenoh key (dora #1992/#2008)"
+        );
+    }
+
+    // The readiness barrier counts a producer's subscriber tokens via a wildcard
+    // key. Because a `DataId` may contain `/`, a naive `.../{output}/**` prefix
+    // would also match tokens of a nested-named output (`cmd` matching
+    // `cmd/vel`), over-counting and letting the producer switch `cmd` to the
+    // direct path before all of *its* subscribers are wired — dropping startup
+    // messages. Hex-encoding the output segment must prevent that collision while
+    // still matching the output's own tokens (incl. slash-containing inputs).
+    #[cfg(feature = "zenoh")]
+    #[test]
+    fn ready_prefix_isolates_nested_output_names() {
+        use dora_message::id::{DataId, NodeId};
+        use zenoh::key_expr::KeyExpr;
+
+        let df = uuid::Uuid::nil();
+        let source = NodeId::from("source".to_string());
+        let sub_node = NodeId::from("sink".to_string());
+        let cmd = DataId::from("cmd".to_string());
+        let cmd_vel = DataId::from("cmd/vel".to_string());
+        // A namespaced runtime-node input (`operator/input`) exercises a
+        // slash-containing subscriber input on the token side.
+        let sub_input = DataId::from("op/in".to_string());
+
+        let cmd_prefix =
+            KeyExpr::new(zenoh_output_ready_liveliness_prefix(df, &source, &cmd)).unwrap();
+        let cmd_token = KeyExpr::new(zenoh_input_ready_liveliness_topic(
+            df, &source, &cmd, &sub_node, &sub_input,
+        ))
+        .unwrap();
+        let cmd_vel_token = KeyExpr::new(zenoh_input_ready_liveliness_topic(
+            df, &source, &cmd_vel, &sub_node, &sub_input,
+        ))
+        .unwrap();
+
+        assert!(
+            cmd_prefix.intersects(&cmd_token),
+            "producer of `cmd` must count its own subscriber's token (even with a `/`-containing input)"
+        );
+        assert!(
+            !cmd_prefix.intersects(&cmd_vel_token),
+            "producer of `cmd` must NOT count a token of the nested output `cmd/vel`"
         );
     }
 }


### PR DESCRIPTION
Since #1787 node outputs are published directly node-to-node over zenoh, bypassing the daemon. The daemon's "all nodes ready" barrier only synchronizes the control plane: it guarantees every subscriber is *declared* before any node runs, but not that each subscription has *propagated across zenoh to the producer's session*. A fast producer — e.g. a `dora/timer`-driven source — could start publishing before that route was established, and zenoh drops samples for a not-yet-wired subscriber. Those early messages were silently lost, which made the record/replay and validated-pipeline contract tests flaky (`sink got only 0 messages`; the recorder captured 10 messages instead of 20).

Each subscriber now declares a zenoh liveliness token once its data subscriber is wired (dynamic nodes excluded — they connect at arbitrary times). At startup, after the daemon barrier and before handing control to user code, each producer eagerly declares its output publishers and waits (bounded) until every expected subscriber for an output is present — counted from the descriptor via `DescriptorExt::output_subscriber_count` — and zenoh reports a matching subscription. Only then is that output on the direct zenoh path, so the first `send_output` is guaranteed to hit an established route. The wait runs after the barrier, so all tokens are already declared and it only waits out route propagation (normally milliseconds); it cannot deadlock, since a producer only ever waits on its subscribers, never on another producer's wait.

Fail-safe: an output whose subscribers don't connect within the timeout (an unreachable remote subscriber, or a zenoh data plane that can't connect while the control plane can) starts on the reliable daemon path and upgrades to direct zenoh on a later send once its subscribers appear — the dataflow is never blocked from starting and nothing is dropped.

The readiness liveliness key hex-encodes the output name so a producer's wildcard subscription cannot collide across nested output names (an output `cmd` must not count tokens of a distinct output `cmd/vel`, which would otherwise let `cmd` switch to the direct path before all of its own subscribers were wired).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
