### PR TITLE
fix(node-api-cxx): correct pre-epoch timestamps in Metadata::set_timestamp

### DIFF
--- a/apis/c++/node/src/lib.rs
+++ b/apis/c++/node/src/lib.rs
@@ -770,9 +770,18 @@ impl Metadata {
     }
 
     pub fn set_timestamp(&mut self, key: &str, value: i64) -> EyreResult<()> {
-        // Convert nanoseconds since Unix epoch to chrono::DateTime<Utc>
-        let secs = value / 1_000_000_000;
-        let subsec_nanos = (value % 1_000_000_000) as u32;
+        // Convert nanoseconds since Unix epoch to chrono::DateTime<Utc>.
+        //
+        // Use Euclidean division so pre-epoch (negative) timestamps split
+        // correctly. Plain `/` and `%` truncate toward zero, yielding a
+        // *negative* remainder for negative inputs; casting that to `u32`
+        // wraps it to a huge value and makes `from_timestamp` reject the
+        // (otherwise valid) instant. `div_euclid`/`rem_euclid` keep the
+        // remainder in `0..1_000_000_000`, matching how `from_timestamp`
+        // interprets `(secs, subsec_nanos)` and round-tripping with
+        // `get_timestamp` for negative values.
+        let secs = value.div_euclid(1_000_000_000);
+        let subsec_nanos = value.rem_euclid(1_000_000_000) as u32;
 
         let dt = DateTime::from_timestamp(secs, subsec_nanos)
             .ok_or_else(|| eyre!("Invalid timestamp: out of range (nanos: {value})"))?;
@@ -1044,5 +1053,32 @@ mod tests {
 
         let result = event_as_input(event);
         assert!(result.is_err(), "expected Err for non-UInt8 input, got Ok");
+    }
+
+    /// Regression test: `set_timestamp` must accept and correctly represent
+    /// pre-epoch (negative) nanosecond timestamps. The previous truncating
+    /// `value % 1_000_000_000` produced a negative remainder that wrapped when
+    /// cast to `u32`, making `from_timestamp` reject valid instants. The value
+    /// must also round-trip through `get_timestamp`.
+    #[test]
+    fn set_timestamp_roundtrips_negative_values() {
+        for value in [
+            -1_i64,
+            -500_000_000,
+            -1_000_000_000,
+            -1_500_000_000,
+            -1_000_000_001,
+            0,
+            1,
+            1_500_000_000,
+        ] {
+            let mut meta = Metadata::empty();
+            meta.set_timestamp("ts", value)
+                .unwrap_or_else(|e| panic!("set_timestamp({value}) failed: {e}"));
+            let got = meta
+                .get_timestamp("ts")
+                .unwrap_or_else(|e| panic!("get_timestamp after set({value}) failed: {e}"));
+            assert_eq!(got, value, "timestamp {value} did not round-trip");
+        }
     }
 }


### PR DESCRIPTION
> 🤖 **This PR is machine-generated by Claude (an AI agent)** as part of an automated code-review pass, and reviewed for correctness. Please review carefully before merging.

## Issue

`Metadata::set_timestamp` in `apis/c++/node/src/lib.rs` splits an `i64` nanosecond value using truncating division:

```rust
let secs = value / 1_000_000_000;
let subsec_nanos = (value % 1_000_000_000) as u32;
```

For any **negative** `value` (an instant before the Unix epoch), `value % 1_000_000_000` is a *negative* remainder, and casting it to `u32` wraps it to a huge number. `DateTime::from_timestamp(secs, subsec_nanos)` then interprets `subsec_nanos` as an out-of-range nanosecond count and returns `None`, so:

- `set_timestamp(key, -500_000_000)` — a perfectly valid instant 0.5 s before the epoch — **fails** with "Invalid timestamp: out of range".
- Every pre-epoch instant is unrepresentable, and values in `-1_000_000_000 < value < 0` are silently corrupted.

This does not round-trip with `get_timestamp`, which reads the value back via `DateTime::timestamp_nanos_opt`.

## Fix

Use Euclidean division/remainder so the subsecond part stays in `0..1_000_000_000`, matching how `from_timestamp` interprets the `(secs, subsec_nanos)` pair:

```rust
let secs = value.div_euclid(1_000_000_000);
let subsec_nanos = value.rem_euclid(1_000_000_000) as u32;
```

For example, `-500_000_000` now becomes `secs = -1, subsec_nanos = 500_000_000` → `-1e9 + 0.5e9 = -0.5e9`, which round-trips back to `-500_000_000`.

## Validation

- Added `set_timestamp_roundtrips_negative_values`, asserting `set_timestamp` → `get_timestamp` round-trips for negative, epoch-boundary, and positive nanosecond values. The test fails on `main` and passes with this change.
- `cargo test -p dora-node-api-cxx`, `cargo clippy -p dora-node-api-cxx -- -D warnings`, and `cargo fmt --check` all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_012FTmfPDhBkaQbVFprNnTmk)_