### PR TITLE
fix(ros2-bridge): avoid null-pointer slice UB in Owned/RefFFISeq::as_slice

### DIFF
--- a/libraries/extensions/ros2-bridge/src/_core/sequence.rs
+++ b/libraries/extensions/ros2-bridge/src/_core/sequence.rs
@@ -90,6 +90,12 @@ pub struct OwnedFFISeq<T> {
 impl<T> OwnedFFISeq<T> {
     /// Extracts a slice.
     pub fn as_slice(&self) -> &[T] {
+        // `from_rust` stores a null `data` pointer for an empty sequence, and
+        // `slice::from_raw_parts` is UB with a null pointer even for length 0.
+        // Guard the empty case, mirroring `FFISeq::deref`.
+        if self.size == 0 {
+            return &[];
+        }
         unsafe { std::slice::from_raw_parts(self.data, self.len()) }
     }
 
@@ -152,6 +158,12 @@ pub struct RefFFISeq<T> {
 impl<T> RefFFISeq<T> {
     /// Extracts a slice.
     pub fn as_slice(&self) -> &[T] {
+        // `from_rust` stores a null `data` pointer for an empty sequence, and
+        // `slice::from_raw_parts` is UB with a null pointer even for length 0.
+        // Guard the empty case, mirroring `FFISeq::deref`.
+        if self.size == 0 {
+            return &[];
+        }
         unsafe { std::slice::from_raw_parts(self.data, self.len()) }
     }
 
@@ -183,5 +195,52 @@ impl<T> FFIFromRust for RefFFISeq<T> {
                 capacity: vec.len(),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // `from_rust` deliberately stores a null `data` pointer for an empty
+    // sequence (see the `vec.is_empty()` branches). `slice::from_raw_parts`
+    // is undefined behavior when given a null pointer even for a zero
+    // length, so `as_slice` must special-case the empty sequence — exactly
+    // as `FFISeq::deref` already does. These tests exercise the empty and
+    // non-empty paths of that guard.
+    //
+    // `RefFFISeq` is used because it borrows (no `Drop`) and its `from_rust`
+    // is unconstrained in `T`, so the empty case can be built safely.
+
+    #[test]
+    fn ref_seq_as_slice_empty_is_safe() {
+        let empty: Vec<i32> = Vec::new();
+        let seq = unsafe { RefFFISeq::from_rust(&empty) };
+        assert!(seq.is_empty());
+        assert_eq!(seq.as_slice(), &[] as &[i32]);
+    }
+
+    #[test]
+    fn ref_seq_as_slice_non_empty_roundtrips() {
+        let data = vec![1_i32, 2, 3];
+        let seq = unsafe { RefFFISeq::from_rust(&data) };
+        assert_eq!(seq.as_slice(), data.as_slice());
+    }
+
+    #[test]
+    fn owned_seq_as_slice_empty_is_safe() {
+        // Build the empty representation `from_rust` produces (null data,
+        // size 0) directly, since `OwnedFFISeq::from_rust` requires
+        // `T: FFIFromRust`. `forget` avoids the unrelated `Drop` path
+        // (`Vec::from_raw_parts` on the null pointer); this test only
+        // covers the `as_slice` empty-guard.
+        let seq: OwnedFFISeq<i32> = OwnedFFISeq {
+            data: std::ptr::null_mut(),
+            size: 0,
+            capacity: 0,
+        };
+        assert!(seq.is_empty());
+        assert_eq!(seq.as_slice(), &[] as &[i32]);
+        std::mem::forget(seq);
     }
 }

--- a/libraries/extensions/ros2-bridge/src/_core/sequence.rs
+++ b/libraries/extensions/ros2-bridge/src/_core/sequence.rs
@@ -142,6 +142,14 @@ where
 
 impl<T> Drop for OwnedFFISeq<T> {
     fn drop(&mut self) {
+        // `from_rust` stores a null `data` pointer for an empty sequence (as
+        // rosidl requires). `Vec::from_raw_parts(null, 0, 0)` is undefined
+        // behavior — it feeds the null pointer to `Unique::new_unchecked`,
+        // which aborts under debug assertions — so skip reconstruction when
+        // there is nothing to free. Mirrors the `as_slice` empty-case guard.
+        if self.data.is_null() {
+            return;
+        }
         unsafe { Vec::from_raw_parts(self.data, self.size, self.capacity) };
     }
 }
@@ -231,9 +239,9 @@ mod tests {
     fn owned_seq_as_slice_empty_is_safe() {
         // Build the empty representation `from_rust` produces (null data,
         // size 0) directly, since `OwnedFFISeq::from_rust` requires
-        // `T: FFIFromRust`. `forget` avoids the unrelated `Drop` path
-        // (`Vec::from_raw_parts` on the null pointer); this test only
-        // covers the `as_slice` empty-guard.
+        // `T: FFIFromRust`. Letting it drop at end of scope also exercises the
+        // `Drop` guard (`Vec::from_raw_parts` must not run on the null
+        // pointer), so no `mem::forget` is needed.
         let seq: OwnedFFISeq<i32> = OwnedFFISeq {
             data: std::ptr::null_mut(),
             size: 0,
@@ -241,6 +249,36 @@ mod tests {
         };
         assert!(seq.is_empty());
         assert_eq!(seq.as_slice(), &[] as &[i32]);
-        std::mem::forget(seq);
+    }
+
+    #[test]
+    fn owned_seq_empty_drop_is_safe() {
+        // `from_rust` stores a null `data` pointer for an empty sequence.
+        // `Drop` must not feed it to `Vec::from_raw_parts`, which reaches
+        // `Unique::new_unchecked(null)` and aborts under debug assertions.
+        // Building the empty representation and dropping it exercises the
+        // guard directly (this is the more reachable case: `OwnedFFISeq` is
+        // what msg-gen emits for every non-primitive sequence field).
+        let seq: OwnedFFISeq<i32> = OwnedFFISeq {
+            data: std::ptr::null_mut(),
+            size: 0,
+            capacity: 0,
+        };
+        drop(seq);
+    }
+
+    #[test]
+    fn owned_seq_non_empty_drop_frees() {
+        // The guard only skips the null/empty case: a non-null sequence must
+        // still be reconstructed and freed. Build one from a leaked `Vec`
+        // (matching what `from_rust` stores) and let it drop; miri/ASan would
+        // flag a leak or double-free if the guard were too broad.
+        let mut v = ManuallyDrop::new(vec![1_i32, 2, 3]);
+        let seq: OwnedFFISeq<i32> = OwnedFFISeq {
+            data: v.as_mut_ptr(),
+            size: v.len(),
+            capacity: v.capacity(),
+        };
+        drop(seq);
     }
 }


### PR DESCRIPTION
> 🤖 **This PR is machine-generated by Claude (an AI agent)** as part of an automated code-review pass, and reviewed for correctness. Please review carefully before merging.

## Issue

For an **empty** sequence, `FFIFromRust::from_rust` deliberately stores a **null** `data` pointer (the `vec.is_empty()` branches set `data: std::ptr::null_mut()`, as the rosidl C ABI requires). Two code paths in `libraries/extensions/ros2-bridge/src/_core/sequence.rs` then use that null pointer in ways that are undefined behavior:

1. **`OwnedFFISeq::as_slice` and `RefFFISeq::as_slice`** build a slice unconditionally:

   ```rust
   pub fn as_slice(&self) -> &[T] {
       unsafe { std::slice::from_raw_parts(self.data, self.len()) }
   }
   ```

   `std::slice::from_raw_parts` requires a non-null, aligned pointer *even for a zero length*, so passing the null `data` pointer is UB. The sibling `FFISeq::deref` in the same file already guards exactly this case (`if self.size == 0 { return &[]; }`); the two `as_slice` accessors simply omitted the same guard.

2. **`OwnedFFISeq::drop`** reconstructs a `Vec` unconditionally:

   ```rust
   fn drop(&mut self) {
       unsafe { Vec::from_raw_parts(self.data, self.size, self.capacity) };
   }
   ```

   `Vec::from_raw_parts(null, 0, 0)` feeds the null pointer to `Unique::new_unchecked`, which aborts under debug assertions (and is UB in release). This is the same empty-sequence null-pointer path, and `OwnedFFISeq` is what msg-gen emits for every non-primitive sequence field.

## Fix

- Add the `size == 0` early-return to both `OwnedFFISeq::as_slice` and `RefFFISeq::as_slice`, mirroring `FFISeq::deref`.
- Add a `data.is_null()` early-return to `OwnedFFISeq::drop`, so an empty (null) sequence is not reconstructed.

Both are minimal soundness fixes on the same empty-sequence path. Neither changes the FFI representation — `from_rust` still stores a null pointer for the empty case.

## Validation

- Added regression tests covering the empty and non-empty paths of both `as_slice` and `Drop`. `RefFFISeq` is used for the empty `as_slice` case because it borrows (no `Drop`) and its `from_rust` is unconstrained in `T`, so the null-data representation can be built safely; the `OwnedFFISeq` empty representation is built directly to also exercise the `Drop` guard.
- `cargo test -p dora-ros2-bridge --lib sequence`, `cargo clippy -p dora-ros2-bridge --lib`, and `cargo fmt --check` all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_012FTmfPDhBkaQbVFprNnTmk)_
