### PR TITLE
fix(ros2-bridge-arrow): cap element count when deserializing a wstring field

### DIFF
--- a/libraries/extensions/ros2-bridge/arrow/src/deserialize/sequence.rs
+++ b/libraries/extensions/ros2-bridge/arrow/src/deserialize/sequence.rs
@@ -17,7 +17,7 @@ use super::{StructDeserializer, error};
 /// Maximum number of elements allowed in a deserialized sequence.
 /// This prevents unbounded allocations from malformed CDR packets.
 /// 16 million elements is ~128 MB for f64 or ~16 MB for u8.
-const MAX_SEQUENCE_ELEMENTS: usize = 16_000_000;
+pub(super) const MAX_SEQUENCE_ELEMENTS: usize = 16_000_000;
 
 pub struct SequenceDeserializer<'a> {
     pub item_type: &'a NestableType,

--- a/libraries/extensions/ros2-bridge/arrow/src/deserialize/string.rs
+++ b/libraries/extensions/ros2-bridge/arrow/src/deserialize/string.rs
@@ -75,11 +75,72 @@ impl<'de> serde::de::Visitor<'de> for WStringVisitor {
     {
         let mut u16_buf: Vec<u16> = Vec::new();
         while let Some(value) = seq.next_element::<u16>()? {
+            // Bound the element count so a malformed CDR length prefix cannot
+            // drive an unbounded allocation. Mirrors every sequence path in
+            // `sequence.rs`, which the single-`wstring` field path previously
+            // omitted.
+            if u16_buf.len() >= super::sequence::MAX_SEQUENCE_ELEMENTS {
+                return Err(serde::de::Error::custom(format!(
+                    "wstring exceeds maximum of {} code units",
+                    super::sequence::MAX_SEQUENCE_ELEMENTS
+                )));
+            }
             u16_buf.push(value);
         }
         let utf8 = String::from_utf16(&u16_buf).map_err(serde::de::Error::custom)?;
         let mut array = StringBuilder::new();
         array.append_value(utf8);
         Ok(array.finish().into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Array, StringArray};
+    use serde::de::value::{Error as ValueError, U16Deserializer};
+    use serde::de::{DeserializeSeed, SeqAccess, Visitor};
+
+    /// A minimal, lazy `SeqAccess` yielding `u16` values from an iterator, so
+    /// the oversized case doesn't need to materialize a huge buffer up front.
+    struct U16Seq<I>(I);
+
+    impl<'de, I: Iterator<Item = u16>> SeqAccess<'de> for U16Seq<I> {
+        type Error = ValueError;
+
+        fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
+        where
+            T: DeserializeSeed<'de>,
+        {
+            match self.0.next() {
+                Some(v) => seed.deserialize(U16Deserializer::new(v)).map(Some),
+                None => Ok(None),
+            }
+        }
+    }
+
+    #[test]
+    fn wstring_roundtrips() {
+        // UTF-16 code units for "hi".
+        let seq = U16Seq([104u16, 105].into_iter());
+        let data = WStringVisitor.visit_seq(seq).expect("valid wstring");
+        let array = StringArray::from(data);
+        assert_eq!(array.len(), 1);
+        assert_eq!(array.value(0), "hi");
+    }
+
+    #[test]
+    fn wstring_rejects_oversized() {
+        use super::super::sequence::MAX_SEQUENCE_ELEMENTS;
+        // One code unit past the cap; the iterator is lazy so nothing is
+        // allocated beyond the cap before the guard fires.
+        let seq = U16Seq(std::iter::repeat_n(b'a' as u16, MAX_SEQUENCE_ELEMENTS + 1));
+        let err = WStringVisitor
+            .visit_seq(seq)
+            .expect_err("wstring past the element cap must be rejected");
+        assert!(
+            err.to_string().contains("maximum"),
+            "unexpected error: {err}"
+        );
     }
 }


### PR DESCRIPTION
> 🤖 **This PR is machine-generated by Claude (an AI agent)** as part of an automated code-review pass, and reviewed for correctness. Please review carefully before merging.

## Issue

Every sequence path in `libraries/extensions/ros2-bridge/arrow/src/deserialize/sequence.rs` bounds its element count at `MAX_SEQUENCE_ELEMENTS` (16M) to stop a malformed CDR length prefix from driving an unbounded allocation — e.g. the bool, string, wstring-in-sequence, struct, and primitive paths all count elements and bail past the cap.

The single-`wstring` field deserializer in `deserialize/string.rs` (`WStringVisitor::visit_seq`) was the one path missing that guard:

```rust
let mut u16_buf: Vec<u16> = Vec::new();
while let Some(value) = seq.next_element::<u16>()? {
    u16_buf.push(value);   // unbounded
}
```

So a single `wstring`/`wstring<=N>` field could grow `u16_buf` without the cap that every neighbouring collection path enforces — a defense-in-depth inconsistency against untrusted ROS2 wire data.

## Fix

Apply the same element-count cap in `WStringVisitor::visit_seq`, sharing the existing constant (promoted from module-private to `pub(super)`) so the two paths cannot diverge. A wstring past the cap is rejected with a clear error instead of allocating without bound.

## Validation

- Added regression tests: a normal round-trip (`"hi"`) and an oversized case driven by a lazy iterator, so the guard fires without allocating past the cap.
- `cargo test -p dora-ros2-bridge-arrow --lib deserialize::string`, `cargo clippy -p dora-ros2-bridge-arrow --lib --tests -- -D warnings`, and `cargo fmt --check` all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_012FTmfPDhBkaQbVFprNnTmk)_