### PR TITLE
refactor(mavlink2-bridge): remove never-constructed BridgeError::Transport variant

### DIFF
--- a/libraries/extensions/mavlink2-bridge/src/error.rs
+++ b/libraries/extensions/mavlink2-bridge/src/error.rs
@@ -5,9 +5,6 @@ pub enum BridgeError {
     #[error("Arrow error: {0}")]
     Arrow(#[from] arrow::error::ArrowError),
 
-    #[error("transport error: {0}")]
-    Transport(#[from] std::io::Error),
-
     #[error("config error: {0}")]
     Config(String),
 


### PR DESCRIPTION
> [!IMPORTANT]
> **🤖 Auto-generated by Claude (Claude Code).** This PR was created by an automated dead-code sweep and opened via a maintainer's account only because the bot cannot author PRs directly (the commit itself is authored as `Claude <noreply@anthropic.com>`). It has **not** been hand-reviewed by a human yet — please treat it as a suggestion and review before merging.

## What

Removes the never-constructed `Transport` variant (and its `From<std::io::Error>` impl) from `BridgeError` in `libraries/extensions/mavlink2-bridge/src/error.rs`:

```rust
#[error("transport error: {0}")]
Transport(#[from] std::io::Error),
```

## Why

`BridgeError::Transport` has **no constructor anywhere in the workspace**, and its `#[from] std::io::Error` conversion is **never triggered** — there is no `?`-on-`io::Error` call site in a `BridgeResult` context.

The transport layer deliberately maps connection/parse failures to `BridgeError::Config` with added context rather than surfacing a bare `io::Error`, e.g.:

```rust
// transport.rs
.map_err(|e| BridgeError::Config(format!("failed to connect mavlink to '{addr}': {e}")))?;
```

So the `Transport` variant and its auto-derived `From` impl are dead code. The only other repo-wide match for the identifier is an unrelated doc-comment mentioning "Transport builders" (the `transport` module), not the variant.

The sibling variants stay live: `Arrow` (constructed via `#[from]` on `?` in `arrow_convert.rs`), `Config`, and `Mavlink`.

## Verification

- `cargo fmt -p dora-mavlink2-bridge -- --check` ✅
- `cargo clippy -p dora-mavlink2-bridge --all-targets -- -D warnings` ✅ (confirms no now-orphaned imports)
- `cargo test -p dora-mavlink2-bridge -p dora-mavlink2-bridge-node` ✅ (16 tests + doctest pass)

## Note

`dora-mavlink2-bridge` inherits the workspace version and is publishable (no `publish = false`), so removing a public error-enum variant is technically a semver-relevant change — worth catching in the next version bump. If the `Transport` variant is intentionally reserved as part of the public error surface (e.g. for a planned code path that surfaces raw I/O errors instead of wrapping them in `Config`), feel free to close — as it stands it is entirely unconstructed. This is in the same spirit as the in-flight #2626 (removing the never-constructed `NodeError::Connection` variant).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDEwG8vQcrctgi9YkYS7CU)_