### PR TITLE
test(runtime): guard the #2483 compact() fix with an integration-level test

### DIFF
--- a/binaries/runtime/src/operator/channel.rs
+++ b/binaries/runtime/src/operator/channel.rs
@@ -160,10 +160,22 @@ impl InputBuffer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrow::array::new_empty_array;
+    use arrow::datatypes::DataType;
+    use dora_message::metadata::Metadata;
+    use dora_node_api::ArrowData;
 
     fn closed_event(id: &str) -> Event {
         Event::InputClosed {
             id: DataId::from(id.to_string()),
+        }
+    }
+
+    fn input_event(id: &str) -> Event {
+        Event::Input {
+            id: DataId::from(id.to_string()),
+            metadata: Metadata::new(dora_core::uhlc::HLC::default().new_timestamp()),
+            data: ArrowData(new_empty_array(&DataType::Null)),
         }
     }
 
@@ -206,6 +218,45 @@ mod tests {
             ids,
             ["a", "b"],
             "surviving events must keep their FIFO order"
+        );
+    }
+
+    // Integration-level guard for the fix in #2483: driving the *real* path
+    // (`add_event` -> `drop_oldest_inputs` -> `compact`) under a stalled
+    // consumer must keep the deque physically bounded, not just cap the number
+    // of live `Some` events. The stall is modelled by never draining the queue
+    // (no `send_next_queued`/`pop_front`), which is exactly when the tombstones
+    // would otherwise accumulate. Unlike `compact_removes_tombstones_preserving_order`,
+    // this routes through the fix site, so deleting the `self.compact();` call
+    // in `drop_oldest_inputs` makes the length assertion fail (regression test
+    // for #2680 — the previous test left that call site unguarded/mutable).
+    #[test]
+    fn drop_oldest_inputs_keeps_deque_bounded_under_stall() {
+        let cap = 2usize;
+        let mut caps = BTreeMap::new();
+        caps.insert(
+            DataId::from("x".to_string()),
+            (cap, QueuePolicy::DropOldest),
+        );
+        let mut buffer = InputBuffer::new(caps);
+
+        // Feed far more inputs than the cap without ever draining the queue.
+        let total = 50;
+        for _ in 0..total {
+            buffer.add_event(input_event("x"));
+        }
+
+        // With `compact()`, the deque holds only the `cap` live events and no
+        // tombstones. Without it, every drop past the cap would leave a `None`
+        // behind, growing the deque roughly linearly with `total`.
+        assert_eq!(
+            buffer.queue.len(),
+            cap,
+            "stalled consumer must not accumulate tombstones (deque must stay bounded to the cap)"
+        );
+        assert!(
+            buffer.queue.iter().all(Option::is_some),
+            "no `None` tombstones may remain after compaction"
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #2680.

PR #2483 fixed a real unbounded-memory leak in `binaries/runtime/src/operator/channel.rs`: when a downstream operator stalls, `drop_oldest_inputs` converts over-cap inputs to `None` tombstones that are only cleared by `pop_front` in `send_next_queued` — which never runs while the outgoing rendezvous send is pending. The fix adds `compact()` (`queue.retain(Option::is_some)`) and calls it from `drop_oldest_inputs`.

The accompanying regression test `compact_removes_tombstones_preserving_order` only exercises `compact()` **in isolation** — it assigns `buffer.queue` directly and calls `compact()`, never routing through `add_event` → `drop_oldest_inputs`. As the issue notes, deleting the `self.compact();` call at the fix site therefore has **no effect** on that test — a surviving mutant on the exact line that bounds queue memory.

## Fix

Add `drop_oldest_inputs_keeps_deque_bounded_under_stall`, which drives the real path:
- feeds 50 inputs for a `DropOldest`-capped id (cap 2) via `add_event`, never draining the queue (models a stalled consumer — exactly when tombstones would otherwise accumulate);
- asserts the deque stays bounded to the cap and holds no `None` tombstones.

With `compact()` present the deque length is `cap`; without it, every drop past the cap leaves a `None` behind and the length grows roughly linearly with the input count.

## Verification

- `cargo test -p dora-runtime --lib operator::channel::tests` — both tests pass.
- Temporarily removed the `self.compact();` call and confirmed the new test **FAILS** (`0 passed; 1 failed`), then restored it. The previous isolated test stayed green under the same mutation.
- `cargo clippy -p dora-runtime` and `cargo fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ao7aPbNLtWogf4xxZ61fQw)_