### PR TITLE
test(coordinator): cover pending-restart cleanup on daemon disconnect (#2131)

### DIFF
--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -5017,6 +5017,66 @@ mod tests {
         );
     }
 
+    // Regression test for #2131 (Problem 1): if a daemon disconnects while a
+    // two-phase restart is parked in `pending_restarts`, that daemon will never
+    // send `DataflowFinishedOnDaemon`, so the deferred restart can never
+    // complete. The disconnect cleanup must evict the stale entry and reply
+    // `Err` so the restart caller (CLI) gets a clear error instead of hanging
+    // forever. This locks in the cleanup path added for the inline TODO.
+    #[test]
+    fn disconnect_drains_pending_restart_and_replies_err() {
+        let dataflow_id = DataflowId::from(Uuid::new_v4());
+        let daemon_id = DaemonId::new(Some("gone".to_string()));
+        let node_id: dora_core::config::NodeId = "sender".to_string().into();
+
+        let mut df = test_running_dataflow(dataflow_id, daemon_id.clone(), node_id);
+        df.spawn_result
+            .set_result(Ok(ControlRequestReply::DataflowSpawned {
+                uuid: dataflow_id,
+            }));
+
+        let mut running_dataflows = HashMap::new();
+        running_dataflows.insert(dataflow_id, df);
+
+        // Park a deferred restart with the caller's reply channel.
+        let descriptor: Descriptor =
+            serde_json::from_value(serde_json::json!({"nodes": [{"id": "sender"}]}))
+                .expect("valid descriptor");
+        let (reply_tx, mut reply_rx) = tokio::sync::oneshot::channel();
+        let mut pending_restarts = HashMap::new();
+        pending_restarts.insert(
+            dataflow_id,
+            PendingRestart {
+                descriptor,
+                name: None,
+                uv: false,
+                reply_sender: reply_tx,
+            },
+        );
+
+        let disconnected = BTreeSet::from([daemon_id]);
+        cleanup_disconnected_daemons_from_running_dataflows(
+            &mut running_dataflows,
+            &disconnected,
+            &mut pending_restarts,
+        );
+
+        // The stale entry must be evicted so it cannot leak/hang.
+        assert!(
+            pending_restarts.is_empty(),
+            "pending restart for the disconnected daemon must be drained"
+        );
+        // The caller must be woken with an error, not left hanging.
+        let reply = reply_rx
+            .try_recv()
+            .expect("restart caller must receive a reply (not be left hanging)");
+        let err = reply.expect_err("restart must be reported as failed on disconnect");
+        assert!(
+            format!("{err:?}").contains("daemon disconnected while restart was pending"),
+            "error must explain the restart was cancelled by a disconnect, got: {err:?}"
+        );
+    }
+
     #[test]
     fn resolve_param_target_returns_running_daemon_for_active_node() {
         let store: Arc<dyn CoordinatorStore> = Arc::new(InMemoryStore::new());


### PR DESCRIPTION
## Summary

Refs #2131.

While investigating #2131, I found that **Problem 1** (caller hangs forever if a daemon dies mid-restart) and **Problem 2** (double-restart guard running after `StopDataflow`) are already fixed on `main`:

- `cleanup_disconnected_daemons_from_running_dataflows` now drains matching `pending_restarts` entries and replies `Err` when a daemon disconnects (`binaries/coordinator/src/lib.rs`), resolving the inline TODO that Problem 1 quoted.
- `initiate_restart` now checks the `pending_restarts.contains_key(...)` duplicate guard **first**, before extracting the descriptor or calling `stop_dataflow`.

What was still missing is **Problem 3** for the Problem-1 cleanup path: the existing tests cover the duplicate-restart guard (`initiate_restart_rejects_duplicate_request`) and orphan reclaim (`disconnect_reclaims_orphaned_running_dataflow`), but nothing asserts that a disconnect **drains a parked restart and unblocks its caller with an error**. Without coverage, that cleanup could silently regress back into the original hang.

## Change

Adds `disconnect_drains_pending_restart_and_replies_err`:
- parks a `PendingRestart` (with the caller's reply channel) for a running dataflow;
- runs `cleanup_disconnected_daemons_from_running_dataflows` with the dataflow's daemon in the disconnected set;
- asserts `pending_restarts` is drained and the caller receives an `Err` mentioning "daemon disconnected while restart was pending" (rather than being left hanging).

Test-only change; no production behavior is modified.

## Verification

- `cargo test -p dora-coordinator --lib disconnect_drains_pending_restart_and_replies_err` — passes.
- Temporarily removed the drain loop and confirmed the test **FAILS** (`0 passed; 1 failed`), then restored it.
- `cargo clippy -p dora-coordinator` and `cargo fmt --all -- --check` — clean.

Once merged, this closes the remaining Problem 3 gap; the primary fixes for Problems 1 & 2 are already on `main`, so #2131 can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ao7aPbNLtWogf4xxZ61fQw)_