### PR TITLE
ci: drop full debuginfo in workspace-build jobs to avoid disk exhaustion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,12 @@ jobs:
         run: |
           set -eux
           df -h
-          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /opt/hostedtoolcache/CodeQL || true
+          # None of these toolchains are used by any dora CI job. Not the
+          # whole /opt/hostedtoolcache — contract-tests' setup-python reads
+          # /opt/hostedtoolcache/Python (only the CodeQL bundle is removed).
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
+            /usr/local/.ghcup /usr/local/share/boost /usr/lib/jvm \
+            /opt/hostedtoolcache/CodeQL || true
           docker system prune -af || true
           df -h
       - name: Build (excluding Python packages)
@@ -291,7 +296,12 @@ jobs:
         run: |
           set -eux
           df -h
-          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /opt/hostedtoolcache/CodeQL || true
+          # None of these toolchains are used by any dora CI job. Not the
+          # whole /opt/hostedtoolcache — contract-tests' setup-python reads
+          # /opt/hostedtoolcache/Python (only the CodeQL bundle is removed).
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
+            /usr/local/.ghcup /usr/local/share/boost /usr/lib/jvm \
+            /opt/hostedtoolcache/CodeQL || true
           docker system prune -af || true
           df -h
       - name: Build CLI
@@ -390,7 +400,12 @@ jobs:
         run: |
           set -eux
           df -h
-          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /opt/hostedtoolcache/CodeQL || true
+          # None of these toolchains are used by any dora CI job. Not the
+          # whole /opt/hostedtoolcache — contract-tests' setup-python reads
+          # /opt/hostedtoolcache/Python (only the CodeQL bundle is removed).
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
+            /usr/local/.ghcup /usr/local/share/boost /usr/lib/jvm \
+            /opt/hostedtoolcache/CodeQL || true
           docker system prune -af || true
           df -h
       - uses: actions/setup-python@v6
@@ -453,7 +468,12 @@ jobs:
         run: |
           set -eux
           df -h
-          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /opt/hostedtoolcache/CodeQL || true
+          # None of these toolchains are used by any dora CI job. Not the
+          # whole /opt/hostedtoolcache — contract-tests' setup-python reads
+          # /opt/hostedtoolcache/Python (only the CodeQL bundle is removed).
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
+            /usr/local/.ghcup /usr/local/share/boost /usr/lib/jvm \
+            /opt/hostedtoolcache/CodeQL || true
           docker system prune -af || true
           df -h
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,16 @@ jobs:
     name: Test (ubuntu-latest)
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'trunk-merge/')
+    env:
+      # Debug info is ~78% of every compiled artifact in this large
+      # workspace; full-debuginfo builds overrun the runner disk during
+      # `cargo test` ("No space left on device"). `line-tables-only`
+      # keeps file:line in test backtraces but drops the bulk. Set on
+      # both main (cache save) and PRs (restore) so the shared
+      # workspace-test rust-cache fingerprint stays coherent — this MUST
+      # match the contract-tests job, which reuses the same cache key.
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
+      CARGO_PROFILE_TEST_DEBUG: line-tables-only
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
@@ -258,6 +268,11 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'trunk-merge/')
+    env:
+      # Shrink target/ to fit the runner disk — see the `test` job note.
+      # (Release CLI build below is unaffected; only dev/test profiles.)
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
+      CARGO_PROFILE_TEST_DEBUG: line-tables-only
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
@@ -349,6 +364,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'trunk-merge/')
     timeout-minutes: 30
+    env:
+      # Reuses the workspace-test cache with `test`; the debuginfo
+      # settings MUST stay identical or the two jobs invalidate each
+      # other's shared cache. See the `test` job note.
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
+      CARGO_PROFILE_TEST_DEBUG: line-tables-only
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master


### PR DESCRIPTION
The Test/E2E/contract-tests jobs build the whole workspace in the
dev/test profile with default full debug info. Measured on a workspace
artifact, debug info is ~78% of each binary (781 MB -> 175 MB after
`strip --strip-debug`), so `cargo build` + `cargo test` overrun the
runner disk even after the existing "Free disk space" step, failing
with "No space left on device".

Set CARGO_PROFILE_DEV_DEBUG / CARGO_PROFILE_TEST_DEBUG to
`line-tables-only` on those three jobs. This keeps file:line in test
backtraces while dropping the bulk of target/. The env is applied on
both main (cache save) and PRs (restore) so the shared workspace-test
rust-cache fingerprint stays coherent, and identically on `test` and
`contract-tests`, which reuse the same cache key.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
