### PR TITLE
fix(daemon): send OutputClosed for remote-only outputs on node finish

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -4035,13 +4035,12 @@ impl Daemon {
             .get_mut(&dataflow_id)
             .ok_or_else(|| eyre!("no running dataflow with ID `{dataflow_id}`"))?;
 
-        let outputs = dataflow
-            .mappings
-            .keys()
-            .filter(|m| &m.0 == node_id)
-            .map(|m| &m.1)
-            .cloned()
-            .collect();
+        // Include outputs consumed only by nodes on other daemons
+        // (`open_external_mappings`), not just those with a local consumer
+        // (`mappings`). Otherwise a remote-only output never triggers an
+        // `OutputClosed` event when the producing node finishes, leaving the
+        // remote consumer's input open until it is force-killed.
+        let outputs = dataflow.node_output_ids(node_id).into_iter().collect();
 
         if might_restart {
             self.logger

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -592,6 +592,18 @@ impl RunningDataflow {
         self.open_inputs.get(node_id).unwrap_or(&self.empty_set)
     }
 
+    /// All output ids produced by `node_id`, whether they are consumed by a
+    /// local node (recorded in `mappings`) or only by nodes on another daemon
+    /// (recorded in `open_external_mappings`).
+    ///
+    /// Deriving the set from `mappings` alone misses outputs that have no local
+    /// consumer, so their remote consumers would never receive the
+    /// `OutputClosed` event when the producing node finishes (dora-rs/dora#2152
+    /// region — graceful cross-daemon shutdown).
+    pub(crate) fn node_output_ids(&self, node_id: &NodeId) -> BTreeSet<DataId> {
+        node_output_ids(&self.mappings, &self.open_external_mappings, node_id)
+    }
+
     /// Nodes blocking an otherwise-finished dataflow (dora-rs/dora#2152).
     ///
     /// Returns nodes that should be force-stopped because the dataflow is
@@ -691,6 +703,23 @@ struct StragglerNode<'a> {
     node_grace: Option<Duration>,
 }
 
+/// Pure core of [`RunningDataflow::node_output_ids`].
+///
+/// Unions the output ids of `node_id` across both the locally-consumed
+/// `mappings` and the remote-only `open_external_mappings`.
+fn node_output_ids(
+    mappings: &HashMap<OutputId, BTreeSet<(NodeId, DataId)>>,
+    open_external_mappings: &BTreeSet<OutputId>,
+    node_id: &NodeId,
+) -> BTreeSet<DataId> {
+    mappings
+        .keys()
+        .chain(open_external_mappings.iter())
+        .filter(|output| &output.0 == node_id)
+        .map(|output| output.1.clone())
+        .collect()
+}
+
 /// Pure core of [`RunningDataflow::finish_stragglers`].
 fn select_finish_stragglers<'a>(
     running_nodes: impl Iterator<Item = StragglerNode<'a>>,
@@ -750,6 +779,48 @@ mod tests {
 
     fn node_id(name: &str) -> NodeId {
         NodeId::from(name.to_string())
+    }
+
+    fn data_id(name: &str) -> DataId {
+        DataId::from(name.to_string())
+    }
+
+    // ---- node_output_ids: remote-only outputs must be included ----
+
+    #[test]
+    fn node_output_ids_unions_local_and_remote_outputs() {
+        let source = node_id("source");
+        let mut mappings: HashMap<OutputId, BTreeSet<(NodeId, DataId)>> = HashMap::new();
+        // `source/local_out` is consumed by a local node.
+        mappings.insert(
+            OutputId(source.clone(), data_id("local_out")),
+            BTreeSet::from([(node_id("sink"), data_id("in"))]),
+        );
+        // `source/remote_out` is consumed only by a node on another daemon.
+        let open_external_mappings =
+            BTreeSet::from([OutputId(source.clone(), data_id("remote_out"))]);
+
+        let outputs = node_output_ids(&mappings, &open_external_mappings, &source);
+
+        // Both the locally-consumed and the remote-only output must appear, so
+        // the remote consumer receives an `OutputClosed` when `source` finishes.
+        assert_eq!(
+            outputs,
+            BTreeSet::from([data_id("local_out"), data_id("remote_out")]),
+        );
+    }
+
+    #[test]
+    fn node_output_ids_ignores_other_producers() {
+        let mut mappings: HashMap<OutputId, BTreeSet<(NodeId, DataId)>> = HashMap::new();
+        mappings.insert(
+            OutputId(node_id("other"), data_id("x")),
+            BTreeSet::from([(node_id("sink"), data_id("in"))]),
+        );
+        let open_external_mappings = BTreeSet::from([OutputId(node_id("other"), data_id("y"))]);
+
+        let outputs = node_output_ids(&mappings, &open_external_mappings, &node_id("source"));
+        assert!(outputs.is_empty());
     }
 
     const TEST_GRACE: Duration = Duration::from_millis(100);


### PR DESCRIPTION
## Summary

When a node finishes, the daemon's `handle_outputs_done` derived the set of
closed outputs solely from `dataflow.mappings`, which only records outputs that
have a **local** consumer. Outputs consumed exclusively by a node on another
daemon live in `open_external_mappings` and were therefore omitted, so
`send_output_closed_events` never emitted the `InterDaemonEvent::OutputClosed`
for them.

## Issue

Consider a distributed dataflow where daemon **A** runs a source node `sensor`
whose output `frame` is consumed **only** by node `proc` on daemon **B**
(nothing on A subscribes to `sensor/frame`):

- `sensor/frame` is registered in B's `mappings` (local consumer `proc`) and in
  A's `open_external_mappings` (remote consumer), but **not** in A's `mappings`.
- When `sensor` finishes, A calls `handle_outputs_done`, which collects
  `outputs` from `mappings` only → `sensor/frame` is missing.
- `send_output_closed_events` filters the remote-close list by
  `outputs.contains(&output_id.1)`, so it never sends `OutputClosed` to B.
- On B, the `OutputClosed` handler that would `close_input` for `proc` never
  fires. `proc`'s input stays open forever: it never receives
  `InputClosed`/`AllInputsClosed`, never drains cleanly, and is ultimately
  SIGKILLed by the finish-straggler watchdog after the grace period instead of
  shutting down gracefully.

The explicit `CloseOutputs` path is unaffected — there the node supplies its own
output list — so only the implicit finish path (`OutputsDone`) was broken.

## Fix

Add `RunningDataflow::node_output_ids`, which unions a node's outputs across both
`mappings` and `open_external_mappings`, and use it in `handle_outputs_done`.

## Validation

- New unit tests on the pure helper (`node_output_ids_unions_local_and_remote_outputs`,
  `node_output_ids_ignores_other_producers`).
- `cargo test -p dora-daemon`, `cargo clippy -p dora-daemon -- -D warnings`, and
  `cargo fmt --check` all pass.
- The change is `pub(crate)`-internal (no public API change). CI will exercise
  the full multi-daemon E2E suite.

---
🤖 This PR is machine-generated (Claude, automated code review). Please review
carefully before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_0149wVfgvHjBbrm8ib8tWZrh)_