### PR TITLE
perf(runtime): reuse the held GIL token in the operator on_event path

### DIFF
--- a/binaries/runtime/src/operator/python.rs
+++ b/binaries/runtime/src/operator/python.rs
@@ -228,9 +228,15 @@ pub fn run(
                     .map_err(traceback);
                 match status_enum {
                     Ok(status_enum) => {
-                        let status_val = Python::attach(|py| status_enum.getattr(py, "value"))
+                        // Already inside the outer `Python::attach` (the `py`
+                        // token is in scope), so reuse it instead of re-entering
+                        // the GIL twice per event on the operator's steady-state
+                        // path.
+                        let status_val = status_enum
+                            .getattr(py, "value")
                             .wrap_err("on_event must have enum return value")?;
-                        Python::attach(|py| status_val.extract(py))
+                        status_val
+                            .extract(py)
                             .wrap_err("on_event has invalid return value")
                     }
                     Err(err) => {


### PR DESCRIPTION
## Summary

In the Python operator's per-event path, the return-value handling re-entered
`Python::attach` twice (once for `getattr("value")`, once for `extract`) even
though the surrounding `Python::attach` already provided a valid `py` token in
scope.

## Issue

`binaries/runtime/src/operator/python.rs` runs the operator's `on_event` inside
an outer `Python::attach(|py| ...)`. Within that closure, the success arm did:

```rust
let status_val = Python::attach(|py| status_enum.getattr(py, "value"))?;
Python::attach(|py| status_val.extract(py))
```

Each `Python::attach` re-entry is redundant GIL/thread-state bookkeeping,
executed once per input event on the operator's steady-state path.

## Fix

Reuse the outer `py` token directly:

```rust
let status_val = status_enum.getattr(py, "value")?;
status_val.extract(py)
```

Behavior is unchanged — this only removes the redundant re-attach.

## Validation

`cargo clippy -p dora-runtime --features python -- -D warnings` and
`cargo fmt --check` pass. Behavior-preserving refactor of the GIL handling.

---
🤖 This PR is machine-generated (Claude, automated code review). Please review
carefully before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_0149wVfgvHjBbrm8ib8tWZrh)_