### PR TITLE
fix(core): reject module param keys that collide case-insensitively

### DIFF
--- a/libraries/core/src/descriptor/expand.rs
+++ b/libraries/core/src/descriptor/expand.rs
@@ -352,6 +352,7 @@ fn expand_module_node(
         .collect();
 
     // Validate and collect params
+    let mut seen_upper: BTreeMap<String, &String> = BTreeMap::new();
     for key in node.params.keys() {
         if !key.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') || key.is_empty() {
             bail!(
@@ -359,6 +360,22 @@ fn expand_module_node(
                  contain only [A-Za-z0-9_]",
                 key,
                 node.id
+            );
+        }
+        // Params are injected into the node env as `PARAM_<KEY>` with the key
+        // upper-cased (see `substitute_params_in_node`). Two keys that differ
+        // only in case (e.g. `mode` and `Mode`) would both map to `PARAM_MODE`,
+        // so one would silently overwrite the other. Reject the collision
+        // instead of dropping a param.
+        let upper = key.to_uppercase();
+        if let Some(existing) = seen_upper.insert(upper.clone(), key) {
+            bail!(
+                "param keys `{}` and `{}` in node `{}` collide: both map to the \
+                 env var `PARAM_{}`. Param keys must be unique case-insensitively.",
+                existing,
+                key,
+                node.id,
+                upper
             );
         }
     }
@@ -1744,6 +1761,52 @@ nodes:
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(msg.contains("invalid param key"), "got: {msg}");
+    }
+
+    #[test]
+    fn reject_case_colliding_param_keys() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+
+        write_file(
+            base,
+            "param_mod.yml",
+            r#"
+module:
+  name: p
+  inputs: [x]
+  outputs: [y]
+
+nodes:
+  - id: n
+    path: n.py
+    inputs:
+      x: _mod/x
+    outputs: [y]
+"#,
+        );
+
+        // `mode` and `Mode` are both valid keys but both map to `PARAM_MODE`,
+        // so one would silently overwrite the other in the node env.
+        let desc = parse_descriptor(
+            r#"
+nodes:
+  - id: src
+    path: src.py
+    outputs: [v]
+  - id: m
+    module: param_mod.yml
+    inputs:
+      x: src/v
+    params:
+      mode: safe
+      Mode: turbo
+"#,
+        );
+        let result = expand_modules(&desc, base);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("PARAM_MODE"), "got: {msg}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Module `params` keys that differ only in case (e.g. `mode` and `Mode`) both map
to the same `PARAM_<KEY>` env var, so one silently overwrote the other. This PR
rejects such collisions with a clear error.

## Issue

`expand_module_node` injects each module param into the inner node's env as
`PARAM_<KEY>` with the key upper-cased (`substitute_params_in_node`). The key
validation only enforced `[A-Za-z0-9_]`, so `mode`, `Mode`, and `MODE` are all
valid, distinct param keys that all collapse to `PARAM_MODE`. Because the env
map is built by inserting in `BTreeMap` iteration order, only one survives — the
rest are silently dropped, with the winner determined by ASCII sort order.

```yaml
params:
  mode: safe
  Mode: turbo
```

injects only `PARAM_MODE` = `safe` (`Mode` sorts before `mode`, then `mode`
overwrites), silently losing `turbo`.

## Fix

During param validation, track the upper-cased form of each key and `bail!` on a
collision, naming both keys and the colliding env var. A param can no longer be
silently dropped.

## Validation

- New unit test `reject_case_colliding_param_keys`; existing
  `reject_invalid_param_key` still passes.
- `cargo test -p dora-core`, `cargo clippy -p dora-core -- -D warnings`, and
  `cargo fmt --check` all pass.

---
🤖 This PR is machine-generated (Claude, automated code review). Please review
carefully before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_0149wVfgvHjBbrm8ib8tWZrh)_