### PR TITLE
refactor(mavlink2-bridge): remove unused BridgeError::Transport variant

### DIFF
--- a/libraries/extensions/mavlink2-bridge/src/error.rs
+++ b/libraries/extensions/mavlink2-bridge/src/error.rs
@@ -5,9 +5,6 @@ pub enum BridgeError {
     #[error("Arrow error: {0}")]
     Arrow(#[from] arrow::error::ArrowError),
 
-    #[error("transport error: {0}")]
-    Transport(#[from] std::io::Error),
-
     #[error("config error: {0}")]
     Config(String),
 


### PR DESCRIPTION
> [!IMPORTANT]
> **🤖 Auto-generated by Claude (Claude Code).** This PR was created by an automated dead-code sweep and is opened under a maintainer's account only because the automation authenticates with that token — the change was written by Claude, **not** by the account owner. It has **not** been hand-reviewed by a human. Please review before merging.

## What

Removes the `Transport` variant from `BridgeError` in `dora-mavlink2-bridge` (`libraries/extensions/mavlink2-bridge/src/error.rs`):

```rust
#[error("transport error: {0}")]
Transport(#[from] std::io::Error),
```

## Why it's dead

The variant is **never constructed anywhere in the workspace**, and its auto-generated `From<std::io::Error>` impl is never triggered either:

- Nothing produces `BridgeError::Transport(..)` explicitly. A workspace-wide search for `Transport` in the bridge lib + node crate finds only the definition and an unrelated doc-comment ("Transport builders for TCP, UDP, and serial links").
- The `#[from] std::io::Error` conversion has no implicit call site. Every fallible path in the crate maps I/O failures to `BridgeError::Config` instead. In `transport.rs`, `open_mavlink` wraps `mavlink::connect(..)`'s error via `.map_err(|e| BridgeError::Config(..))`, and the other `connect_*` helpers only ever return `BridgeError::Config`. No function returning `BridgeResult` uses `?` on a `std::io::Error`, so the `From` impl is unreachable.

The live variants — `Arrow` (`#[from] ArrowError`), `Config`, and `Mavlink` — are all still constructed and are left untouched.

## Note

`dora-mavlink2-bridge` is a `1.0.0-rc1` crate without `publish = false`, so removing a `pub` enum variant is technically a pre-1.0 public-API change. It is an internal error-representation variant (not an external extension point), and pruning an impossible-to-construct error before the 1.0 freeze seems like the right time — but flagging it so the call is yours.

## Verification

- `cargo fmt -p dora-mavlink2-bridge -- --check` — clean
- `cargo clippy -p dora-mavlink2-bridge -p dora-mavlink2-bridge-node --all-targets -- -D warnings` — clean
- `cargo test -p dora-mavlink2-bridge -p dora-mavlink2-bridge-node` — all pass, including the TCP/UDP loopback transport tests that exercise the real connect path

Pure deletion; no behavior change.

---
_Generated by [Claude Code](https://claude.ai/code). Commit authored as `Claude <noreply@anthropic.com>`._

---
_Generated by [Claude Code](https://claude.ai/code/session_01X6EQTcEpBcx1pMHbEhD1kb)_