### PR TITLE
Consolidate debug info settings to workflow level

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,23 @@ env:
   CARGO_TERM_COLOR: always
   # Pin Rust to 1.92 until static_init (zenoh-shm dep) is fixed for 1.94+
   RUST_VERSION: "1.92.0"
+  # Drop full debuginfo from dev/test builds. Debug info is ~78% of every
+  # compiled artifact in this large workspace; full-debuginfo builds overrun
+  # the runner disk during `cargo test` ("No space left on device").
+  # `line-tables-only` keeps file:line in backtraces but drops the bulk.
+  #
+  # Set at the WORKFLOW level (not per-job) so the profile is identical for
+  # EVERY job that shares `shared-key: workspace` — clippy, check, test,
+  # contract-tests (#2710). Cargo's per-unit fingerprint folds the profile's
+  # debuginfo level in, so if the cache writer (`test`) and a restore-only
+  # consumer (`clippy`/`check`) disagreed, every cached dependency would be
+  # rebuilt from scratch. rust-cache also folds CARGO_*/RUST_* env vars into
+  # its key, so a shared value keeps the exact-key restore hitting too.
+  #
+  # Only affects the dev and test profiles; the release builds in e2e/bench
+  # are unaffected (their caches use separate keys).
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
+  CARGO_PROFILE_TEST_DEBUG: line-tables-only
 
 jobs:
   fmt:
@@ -162,16 +179,6 @@ jobs:
     name: Test (ubuntu-latest)
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'trunk-merge/')
-    env:
-      # Debug info is ~78% of every compiled artifact in this large
-      # workspace; full-debuginfo builds overrun the runner disk during
-      # `cargo test` ("No space left on device"). `line-tables-only`
-      # keeps file:line in test backtraces but drops the bulk. Set on
-      # both main (cache save) and PRs (restore) so the shared
-      # workspace-test rust-cache fingerprint stays coherent — this MUST
-      # match the contract-tests job, which reuses the same cache key.
-      CARGO_PROFILE_DEV_DEBUG: line-tables-only
-      CARGO_PROFILE_TEST_DEBUG: line-tables-only
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
@@ -309,11 +316,6 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'trunk-merge/')
-    env:
-      # Shrink target/ to fit the runner disk — see the `test` job note.
-      # (Release CLI build below is unaffected; only dev/test profiles.)
-      CARGO_PROFILE_DEV_DEBUG: line-tables-only
-      CARGO_PROFILE_TEST_DEBUG: line-tables-only
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
@@ -416,12 +418,6 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'trunk-merge/')
     timeout-minutes: 30
-    env:
-      # Reuses the workspace-test cache with `test`; the debuginfo
-      # settings MUST stay identical or the two jobs invalidate each
-      # other's shared cache. See the `test` job note.
-      CARGO_PROFILE_DEV_DEBUG: line-tables-only
-      CARGO_PROFILE_TEST_DEBUG: line-tables-only
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master


### PR DESCRIPTION
## Summary

Move debug info profile settings from individual job `env` sections to the workflow-level `env`, ensuring consistent Cargo fingerprints across all jobs that share the `workspace` cache key.

## Changes

- **Moved to workflow-level `env`:**
  - `CARGO_PROFILE_DEV_DEBUG: line-tables-only`
  - `CARGO_PROFILE_TEST_DEBUG: line-tables-only`
  - Added comprehensive documentation explaining the rationale and cache implications

- **Removed from job-level `env`:**
  - Deleted duplicate settings from `test` job
  - Deleted duplicate settings from `contract-tests` job  
  - Deleted duplicate settings from `e2e-tests` job

## Rationale

Debug info comprises ~78% of compiled artifacts in this large workspace. The `line-tables-only` setting reduces disk usage during `cargo test` while preserving file:line information in backtraces.

**Critical for cache coherence:** Cargo's per-unit fingerprinting includes the profile's debuginfo level. When the cache writer (`test` job) and restore-only consumers (`clippy`, `check`) use different settings, every cached dependency gets rebuilt from scratch. By setting these at the workflow level, all jobs sharing `shared-key: workspace` use identical profiles, preventing cache invalidation.

The `rust-cache` action also folds `CARGO_*/RUST_*` env vars into its cache key, so a single workflow-level value ensures the exact-key restore hits consistently.

Release builds in e2e/bench workflows remain unaffected (they use separate cache keys).

https://claude.ai/code/session_01Svyco18MAW4vZYNVLn6mBn