### PR TITLE
fix(zenoh): restore reliable node links and large cross-host messages under zenoh 1.9

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1941,6 +1941,7 @@ impl Daemon {
                         ft_stats: self.ft_stats.clone(),
                         shutdown: dataflow.listener_shutdown_rx.clone(),
                         zenoh_connect_endpoint: self.zenoh_listen_endpoint.clone(),
+                        zenoh_peering: dataflow.zenoh_peering.clone(),
                     };
                     let mut logger = self
                         .logger
@@ -2780,11 +2781,20 @@ impl Daemon {
             .try_clone()
             .await
             .context("failed to clone logger")?;
-        let dataflow = RunningDataflow::new(
+        let mut dataflow = RunningDataflow::new(
             dataflow_id,
             self.daemon_id.clone(),
             dataflow_descriptor.clone(),
         );
+        // Decide who dials whom before anything spawns: zenoh 1.9 peers do not
+        // relay, so a producer/consumer pair that never forms a direct link can
+        // never exchange data. Assign the links explicitly instead of leaving
+        // them to gossip's best-effort autoconnect.
+        dataflow.zenoh_peering = Arc::new(crate::spawn::plan_zenoh_peering(
+            &nodes,
+            &spawn_nodes,
+            self.zenoh_listen_endpoint.as_deref(),
+        ));
         let dataflow = match self.running.entry(dataflow_id) {
             std::collections::hash_map::Entry::Vacant(entry) => {
                 self.working_dir
@@ -3032,6 +3042,7 @@ impl Daemon {
             ft_stats: self.ft_stats.clone(),
             shutdown: dataflow.listener_shutdown_rx.clone(),
             zenoh_connect_endpoint: self.zenoh_listen_endpoint.clone(),
+            zenoh_peering: dataflow.zenoh_peering.clone(),
         };
 
         let mut tasks = Vec::new();

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -183,6 +183,10 @@ pub struct LogSubscriber {
 pub struct RunningDataflow {
     pub(crate) id: uuid::Uuid,
     pub(crate) descriptor: Descriptor,
+    /// Per-node zenoh listener + dial-list, so the node↔node links this dataflow
+    /// needs are established deterministically rather than left to gossip.
+    /// Populated when the dataflow is spawned; see `plan_zenoh_peering`.
+    pub(crate) zenoh_peering: Arc<BTreeMap<NodeId, crate::spawn::NodeZenohPeering>>,
     pub(crate) pending_nodes: PendingNodes,
     pub(crate) dataflow_started: bool,
     pub(crate) subscribe_channels: HashMap<NodeId, Sender<Timestamped<NodeEvent>>>,
@@ -257,6 +261,7 @@ impl RunningDataflow {
         let (listener_shutdown_tx, listener_shutdown_rx) = tokio::sync::watch::channel(false);
         Self {
             id: dataflow_id,
+            zenoh_peering: Arc::new(BTreeMap::new()),
             pending_nodes: PendingNodes::new(dataflow_id, daemon_id),
             dataflow_started: false,
             subscribe_channels: HashMap::new(),

--- a/binaries/daemon/src/spawn/mod.rs
+++ b/binaries/daemon/src/spawn/mod.rs
@@ -1,5 +1,5 @@
 pub use prepared::PreparedNode;
-pub use spawner::Spawner;
+pub use spawner::{NodeZenohPeering, Spawner, plan_zenoh_peering};
 
 mod command;
 mod prepared;

--- a/binaries/daemon/src/spawn/spawner.rs
+++ b/binaries/daemon/src/spawn/spawner.rs
@@ -116,17 +116,20 @@ pub struct NodeZenohPeering {
 /// Assign every node a loopback listener and dial-list so the links the dataflow
 /// needs are established *by construction*.
 ///
-/// Since zenoh 1.9 peers no longer relay for each other (`routing.peer` and
-/// `peers_failover_brokering` were both removed): a peer-to-peer region has to be
-/// a clique, and a producer/consumer pair that never forms a direct link simply
-/// cannot exchange data — there is no relay to fall back on and no amount of
-/// waiting helps. Leaving those links to gossip's best-effort autoconnect made
-/// them racy, which measured as a ~25% chance of some route never coming up.
+/// Zenoh 1.9's `peer` hat hardcodes `full_linkstate: false` (its release notes
+/// list "Disable `full_linkstate` in `peer::Hat::Network`" under Bug fixes),
+/// where 1.8's `linkstate_peer` hat still honored `routing.peer.mode`. So peers
+/// no longer relay for each other: a producer/consumer pair that never forms a
+/// direct link cannot exchange data at all — there is no relay to fall back on
+/// and no amount of waiting helps. Leaving those links to gossip's best-effort
+/// autoconnect made them racy, measuring 5 failures in 20 runs of
+/// `examples/rust-dataflow`; with this planning it is 0 in 20.
 ///
 /// The nodes this daemon spawns are all on this machine, hence all
-/// loopback-addressable, so we can just say who dials whom. Each node dials only the nodes it *consumes from*: a zenoh
-/// transport is bidirectional, so the consumer's dial is what carries the
-/// producer's data back. That is `|edges|` links rather than `N^2`, and it is
+/// loopback-addressable, so we can just say who dials whom. Each node dials only
+/// the nodes it *consumes from*: a zenoh transport is bidirectional, so the
+/// consumer's dial is what carries the producer's data back. That is `|edges|`
+/// links rather than `N^2`, and it is
 /// exactly the set the dataflow requires.
 ///
 /// Dynamic nodes are omitted: they are not in the descriptor's spawn set and join

--- a/binaries/daemon/src/spawn/spawner.rs
+++ b/binaries/daemon/src/spawn/spawner.rs
@@ -8,9 +8,12 @@ use clonable_command::{Command, Stdio};
 use crossbeam::queue::ArrayQueue;
 use dora_core::{
     build::{managed_python_bin_dir, managed_python_interpreter},
-    descriptor::{Descriptor, OperatorDefinition, OperatorSource, PythonSource, ResolvedNode},
+    config::{Input, InputMapping, NodeId},
+    descriptor::{
+        CoreNodeKind, Descriptor, OperatorDefinition, OperatorSource, PythonSource, ResolvedNode,
+    },
     get_python_path,
-    topics::DORA_ZENOH_CONNECT_ENV,
+    topics::{DORA_ZENOH_CONNECT_ENV, DORA_ZENOH_LISTEN_ENV},
     uhlc::HLC,
 };
 use dora_message::{
@@ -22,7 +25,7 @@ use dora_message::{
 };
 use eyre::{ContextCompat, WrapErr, bail};
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     ffi::OsString,
     future::Future,
     path::{Path, PathBuf},
@@ -100,6 +103,126 @@ fn apply_managed_python_runtime_env(
         .env("PATH", new_path))
 }
 
+/// Where a single node's zenoh session should listen, and which peers it must
+/// dial. See [`plan_zenoh_peering`].
+#[derive(Clone, Debug)]
+pub struct NodeZenohPeering {
+    /// Loopback endpoint this node listens on, so its consumers can dial it.
+    pub listen: String,
+    /// Endpoints this node dials: the daemon, plus each node it consumes from.
+    pub connect: Vec<String>,
+}
+
+/// Assign every node a loopback listener and dial-list so the links the dataflow
+/// needs are established *by construction*.
+///
+/// Since zenoh 1.9 peers no longer relay for each other (`routing.peer` and
+/// `peers_failover_brokering` were both removed): a peer-to-peer region has to be
+/// a clique, and a producer/consumer pair that never forms a direct link simply
+/// cannot exchange data — there is no relay to fall back on and no amount of
+/// waiting helps. Leaving those links to gossip's best-effort autoconnect made
+/// them racy, which measured as a ~25% chance of some route never coming up.
+///
+/// The nodes this daemon spawns are all on this machine, hence all
+/// loopback-addressable, so we can just say who dials whom. Each node dials only the nodes it *consumes from*: a zenoh
+/// transport is bidirectional, so the consumer's dial is what carries the
+/// producer's data back. That is `|edges|` links rather than `N^2`, and it is
+/// exactly the set the dataflow requires.
+///
+/// Dynamic nodes are omitted: they are not in the descriptor's spawn set and join
+/// at arbitrary times, so they keep the daemon-endpoint-only behavior.
+///
+/// Only *local* nodes are planned. `nodes` spans the whole dataflow including
+/// nodes on other daemons, whose endpoints are not on this host's loopback, so a
+/// local consumer of a remote producer gets no dial for it and keeps the existing
+/// cross-machine behavior. Multi-machine/NAT deployments supply their own zenoh
+/// config via `ZENOH_CONFIG_PATH`, which bypasses this path entirely and can put
+/// a real router (which *does* still relay) in between.
+pub fn plan_zenoh_peering(
+    nodes: &BTreeMap<NodeId, ResolvedNode>,
+    local_nodes: &BTreeSet<NodeId>,
+    daemon_endpoint: Option<&str>,
+) -> BTreeMap<NodeId, NodeZenohPeering> {
+    // Reserve a listener per node first, so the dial-lists below can reference
+    // every node regardless of spawn order.
+    //
+    // Only nodes this daemon spawns get one: the endpoints are *loopback*, so
+    // handing a local consumer the "endpoint" of a node running on another
+    // machine would point it at this host's 127.0.0.1 — either a failed dial or,
+    // worse, an unrelated local process. A local consumer of a remote producer
+    // therefore gets no dial for it and keeps the existing cross-machine
+    // behavior (see the `ZENOH_CONFIG_PATH` note above).
+    let mut listeners: BTreeMap<NodeId, String> = BTreeMap::new();
+    for (node_id, node) in nodes {
+        if node.kind.dynamic() || !local_nodes.contains(node_id) {
+            continue;
+        }
+        match dora_core::topics::reserve_loopback_zenoh_endpoint() {
+            Ok(ep) => {
+                listeners.insert(node_id.clone(), ep);
+            }
+            Err(err) => {
+                // Fall back to gossip for this node rather than failing the
+                // dataflow; it just loses the determinism guarantee.
+                tracing::warn!(
+                    node = %node_id,
+                    "failed to reserve a zenoh listen endpoint ({err}); \
+                     falling back to gossip discovery for this node"
+                );
+            }
+        }
+    }
+
+    let mut plan = BTreeMap::new();
+    for (node_id, node) in nodes {
+        let Some(listen) = listeners.get(node_id) else {
+            continue;
+        };
+        let mut connect: Vec<String> = Vec::new();
+        if let Some(ep) = daemon_endpoint {
+            connect.push(ep.to_string());
+        }
+        for source in input_sources(node) {
+            // A node may consume from itself only via a timer/log mapping, which
+            // `input_sources` already filters out.
+            if &source == node_id {
+                continue;
+            }
+            if let Some(ep) = listeners.get(&source) {
+                connect.push(ep.clone());
+            }
+        }
+        connect.dedup();
+        plan.insert(
+            node_id.clone(),
+            NodeZenohPeering {
+                listen: listen.clone(),
+                connect,
+            },
+        );
+    }
+    plan
+}
+
+/// The nodes whose outputs `node` subscribes to (deduplicated).
+fn input_sources(node: &ResolvedNode) -> BTreeSet<NodeId> {
+    let inputs: Vec<&Input> = match &node.kind {
+        CoreNodeKind::Custom(n) => n.run_config.inputs.values().collect(),
+        CoreNodeKind::Runtime(n) => n
+            .operators
+            .iter()
+            .flat_map(|op| op.config.inputs.values())
+            .collect(),
+    };
+    inputs
+        .iter()
+        .filter_map(|input| match &input.mapping {
+            InputMapping::User(mapping) => Some(mapping.source.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
 #[derive(Clone)]
 pub struct Spawner {
     pub dataflow_id: DataflowId,
@@ -115,13 +238,29 @@ pub struct Spawner {
     /// nodes via `DORA_ZENOH_CONNECT` so the >=4 KiB zenoh data path works
     /// without multicast scouting (#1778).
     pub zenoh_connect_endpoint: Option<String>,
+    /// Per-node listener + dial-list, so the node↔node links the dataflow needs
+    /// are established deterministically. See [`plan_zenoh_peering`].
+    pub zenoh_peering: Arc<BTreeMap<NodeId, NodeZenohPeering>>,
 }
 
 impl Spawner {
-    fn maybe_inject_zenoh_connect(&self, command: Command) -> Command {
-        match &self.zenoh_connect_endpoint {
-            Some(ep) => command.env(DORA_ZENOH_CONNECT_ENV, ep),
-            None => command,
+    fn maybe_inject_zenoh_connect(&self, command: Command, node_id: &NodeId) -> Command {
+        match self.zenoh_peering.get(node_id) {
+            Some(peering) => {
+                let command = command.env(DORA_ZENOH_LISTEN_ENV, &peering.listen);
+                if peering.connect.is_empty() {
+                    command
+                } else {
+                    command.env(DORA_ZENOH_CONNECT_ENV, peering.connect.join(","))
+                }
+            }
+            // No plan for this node (dynamic node, or endpoint reservation
+            // failed): fall back to dialing just the daemon and letting gossip
+            // discover the rest.
+            None => match &self.zenoh_connect_endpoint {
+                Some(ep) => command.env(DORA_ZENOH_CONNECT_ENV, ep),
+                None => command,
+            },
         }
     }
 
@@ -229,7 +368,7 @@ impl Spawner {
                         serde_yaml::to_string(&node_config.clone())
                             .wrap_err("failed to serialize node config")?,
                     );
-                    command = self.maybe_inject_zenoh_connect(command);
+                    command = self.maybe_inject_zenoh_connect(command, &node.id);
                     // Injecting the env variable defined in the `yaml` into
                     // the node runtime.
                     if let Some(envs) = &node.env {
@@ -436,7 +575,7 @@ impl Spawner {
                         serde_yaml::to_string(&runtime_config)
                             .wrap_err("failed to serialize runtime config")?,
                     );
-                    command = self.maybe_inject_zenoh_connect(command);
+                    command = self.maybe_inject_zenoh_connect(command, &node.id);
                     // Injecting the env variable defined in the `yaml` into
                     // the node runtime.
                     if let Some(envs) = &node.env {
@@ -485,5 +624,181 @@ impl Spawner {
             last_activity,
             ft_stats: self.ft_stats,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dora_core::descriptor::DescriptorExt;
+
+    fn plan_for(yaml: &str, daemon: Option<&str>) -> BTreeMap<NodeId, NodeZenohPeering> {
+        let descriptor: Descriptor = serde_yaml::from_str(yaml).expect("parse descriptor");
+        let nodes = descriptor
+            .resolve_aliases_and_set_defaults()
+            .expect("resolve nodes");
+        // Default: every node is local to this daemon.
+        let local: BTreeSet<NodeId> = nodes.keys().cloned().collect();
+        plan_zenoh_peering(&nodes, &local, daemon)
+    }
+
+    fn plan_for_local(
+        yaml: &str,
+        local: &[&str],
+        daemon: Option<&str>,
+    ) -> BTreeMap<NodeId, NodeZenohPeering> {
+        let descriptor: Descriptor = serde_yaml::from_str(yaml).expect("parse descriptor");
+        let nodes = descriptor
+            .resolve_aliases_and_set_defaults()
+            .expect("resolve nodes");
+        let local: BTreeSet<NodeId> = local.iter().map(|id| node(id)).collect();
+        plan_zenoh_peering(&nodes, &local, daemon)
+    }
+
+    fn node(id: &str) -> NodeId {
+        NodeId::from(id.to_string())
+    }
+
+    /// Since zenoh 1.9 peers don't relay, a consumer that never dials its
+    /// producer can never receive its data. So every consumer must dial exactly
+    /// its producers — that link set is the whole point of the plan.
+    #[test]
+    fn each_consumer_dials_its_producers_and_nothing_else() {
+        let plan = plan_for(
+            r#"
+nodes:
+  - id: source
+    path: source
+    inputs:
+      tick: dora/timer/millis/10
+    outputs:
+      - value
+  - id: transform
+    path: transform
+    inputs:
+      value: source/value
+    outputs:
+      - doubled
+  - id: sink
+    path: sink
+    inputs:
+      doubled: transform/doubled
+"#,
+            Some("tcp/127.0.0.1:1"),
+        );
+
+        let listen_of = |id: &str| plan[&node(id)].listen.clone();
+
+        // A pure source has no `User` inputs, so it dials only the daemon: a
+        // timer mapping is not a peer.
+        assert_eq!(plan[&node("source")].connect, vec!["tcp/127.0.0.1:1"]);
+
+        // Each consumer dials the daemon plus its own producer's listener.
+        assert_eq!(
+            plan[&node("transform")].connect,
+            vec!["tcp/127.0.0.1:1".to_string(), listen_of("source")]
+        );
+        assert_eq!(
+            plan[&node("sink")].connect,
+            vec!["tcp/127.0.0.1:1".to_string(), listen_of("transform")]
+        );
+
+        // `sink` does not consume from `source`, so it must not dial it —
+        // otherwise the plan degenerates toward N^2.
+        assert!(!plan[&node("sink")].connect.contains(&listen_of("source")));
+
+        // Listeners must be distinct, or two nodes would fight for a port.
+        let listeners: BTreeSet<_> = plan.values().map(|p| p.listen.clone()).collect();
+        assert_eq!(listeners.len(), 3, "each node needs its own listener");
+    }
+
+    /// A cycle must still produce a plan: every node is assigned a listener
+    /// before any dial-list is built, so `a -> b -> a` resolves rather than
+    /// leaving one side unable to reference the other.
+    #[test]
+    fn cyclic_dataflow_links_both_directions() {
+        let plan = plan_for(
+            r#"
+nodes:
+  - id: a
+    path: a
+    inputs:
+      from_b: b/out_b
+    outputs:
+      - out_a
+  - id: b
+    path: b
+    inputs:
+      from_a: a/out_a
+    outputs:
+      - out_b
+"#,
+            None,
+        );
+        assert_eq!(
+            plan[&node("a")].connect,
+            vec![plan[&node("b")].listen.clone()]
+        );
+        assert_eq!(
+            plan[&node("b")].connect,
+            vec![plan[&node("a")].listen.clone()]
+        );
+    }
+
+    /// `nodes` spans the whole dataflow, including nodes owned by other daemons.
+    /// Their listeners would be on *this* host's loopback, so dialing one would hit
+    /// nothing (or an unrelated local process). A local consumer of a remote
+    /// producer must therefore get no dial for it.
+    #[test]
+    fn remote_nodes_are_never_dialled_on_local_loopback() {
+        let yaml = r#"
+nodes:
+  - id: remote_source
+    path: remote_source
+    outputs:
+      - value
+  - id: local_sink
+    path: local_sink
+    inputs:
+      v: remote_source/value
+"#;
+        // Only `local_sink` runs on this daemon.
+        let plan = plan_for_local(yaml, &["local_sink"], Some("tcp/127.0.0.1:1"));
+
+        assert!(
+            !plan.contains_key(&node("remote_source")),
+            "a node on another daemon must not be assigned a local loopback listener"
+        );
+        // The local consumer dials only the daemon: there is no local endpoint
+        // for its remote producer, and inventing one would be worse than none.
+        assert_eq!(plan[&node("local_sink")].connect, vec!["tcp/127.0.0.1:1"]);
+    }
+
+    /// Dynamic nodes join at arbitrary times and aren't part of the spawn set,
+    /// so they get no plan (and fall back to daemon-only + gossip). A static
+    /// consumer of a dynamic node must not end up with a dangling dial.
+    #[test]
+    fn dynamic_nodes_are_excluded_from_the_plan() {
+        let plan = plan_for(
+            r#"
+nodes:
+  - id: dyn_source
+    path: dynamic
+    outputs:
+      - value
+  - id: static_sink
+    path: static_sink
+    inputs:
+      v: dyn_source/value
+"#,
+            Some("tcp/127.0.0.1:1"),
+        );
+        assert!(
+            !plan.contains_key(&node("dyn_source")),
+            "dynamic node must not be assigned a listener"
+        );
+        // The static consumer still gets a plan, but only dials the daemon:
+        // there is no endpoint to dial for a node that hasn't joined yet.
+        assert_eq!(plan[&node("static_sink")].connect, vec!["tcp/127.0.0.1:1"]);
     }
 }

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -98,14 +98,15 @@ pub async fn open_zenoh_session_with_listen(
             let mut zenoh_config = zenoh::Config::default();
             // NOTE: we used to set `routing/peer: { mode: "linkstate" }` here so
             // that peers would relay for each other (e.g. two daemons on separate
-            // networks reaching each other through a public one). Zenoh 1.9
-            // *removed* peer routing modes — "routing.peer is removed, all peers
-            // now operate in peer-to-peer mode" — so the setting became a silent
-            // no-op (`insert_json5` still returns `Ok`, and only zenoh logs a
-            // deprecation warning). It is deleted rather than ported because
-            // there is no 1.9 equivalent for peers: peer regions must now form a
-            // clique, and `peers_failover_brokering` was removed too. Only
-            // *routers* still do linkstate routing.
+            // networks reaching each other through a public one). In zenoh 1.8 that
+            // worked: its `linkstate_peer` hat derived
+            // `peer_full_linkstate = routing.peer.mode == "linkstate"`. Zenoh 1.9
+            // dropped that hat; its `peer` hat hardcodes `full_linkstate: false`
+            // (release notes, under Bug fixes: "Disable `full_linkstate` in
+            // `peer::Hat::Network`"), so peers no longer relay. The setting became a
+            // silent no-op — `insert_json5` still returns `Ok`, so our own error
+            // branch never fired, and only zenoh's deprecation log hinted at it.
+            // Deleted rather than ported: there is no peer-side equivalent in 1.9.
             //
             // Consequences, and why this is not a regression here:
             //   * Same-machine nodes are all loopback-addressable, so the links
@@ -116,28 +117,38 @@ pub async fn open_zenoh_session_with_listen(
             //     serve, supply their own config via `ZENOH_CONFIG_PATH` (handled
             //     in the branch above) and can put a real router in the path.
             //
-            // Dora's data plane favors per-message latency over Zenoh's
-            // default adaptive batching path. Publishers also set
-            // `express(true)`, but low-latency unicast lets peer transports
-            // skip the universal batching/priority queues entirely when both
-            // ends use Dora's default config. Zenoh's low-latency transport is
-            // negotiated without QoS, so disable QoS together with it instead
-            // of falling back during session open.
+            // NOTE: we used to set `transport/unicast/lowlatency: true` here (and
+            // `qos/enabled: false` with it, since the low-latency transport is
+            // negotiated without QoS) to skip zenoh's batching/priority queues.
+            // Both are gone, because low-latency cannot fragment: a message has to
+            // fit one batch, and `batch_size` is capped at 64 KiB
+            // (`pub type BatchSize = u16`, so 65535 is the max, not just the
+            // default). Shared memory hid that — an SHM payload travels as a
+            // ~16-byte descriptor and never fragments — but SHM is per-host, so it
+            // cannot negotiate between machines. A >64 KiB message to another host
+            // therefore had *no* working path: the sender writes it with a 4-byte
+            // length prefix and no size check, `put()` returns `Ok`, and the peer
+            // rejects the frame ("Batch len is invalid") — silent loss, with the
+            // publisher believing it succeeded.
+            //
+            // Dropping both is not a latency regression — measured against the old
+            // config (release, `examples/benchmark`), p50 is neutral-to-better
+            // (64 B 65->55 µs, 512 B 66->58 µs, 16 KB 73->63 µs; only 8 B is ~7 µs
+            // worse) and throughput is up (4 KB +51%, 16 KB +41%), since bypassing
+            // batching cost a syscall per message.
+            //
+            // The two settings must be removed *together*: dropping `lowlatency`
+            // while leaving `qos/enabled: false` did cost ~25 µs p50 on small
+            // messages. Restoring QoS recovers it, because the publishers'
+            // `Priority::RealTime` finally takes effect — it was silently inert
+            // while QoS was off. Publishers also still set `express(true)`, which is
+            // what actually carries small-message latency here.
             //
             // We rely on zenoh's SHM transport (`transport/shared_memory/enabled`)
             // being enabled, which is its default — do NOT set it to `false`: the
             // API keeps working, but SHM buffers silently get serialized as plain
             // bytes onto the wire (i.e. copied) instead of sent as a ~16-byte
-            // descriptor. Worse, `lowlatency` cannot fragment (message must stay
-            // under `batch_size`, 64 KiB), so without SHM a payload above that has
-            // no working path at all — zenoh's "fallback to network mode" is not
-            // transparent under this config.
-            zenoh_config
-                .insert_json5("transport/unicast/lowlatency", "true")
-                .unwrap();
-            zenoh_config
-                .insert_json5("transport/unicast/qos/enabled", "false")
-                .unwrap();
+            // descriptor.
 
             // Build the connect-endpoint list from two sources:
             //   1. DORA_ZENOH_CONNECT env var — daemon-bootstrapped local

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -71,26 +71,42 @@ pub async fn open_zenoh_session_with_listen(
         }
         Err(std::env::VarError::NotPresent) => {
             let mut zenoh_config = zenoh::Config::default();
-            // Linkstate make it possible to connect two daemons on different network through a public daemon
-            // TODO: There is currently a CI/CD Error in windows linkstate.
-            if cfg!(not(target_os = "windows"))
-                && let Err(err) =
-                    zenoh_config.insert_json5("routing/peer", r#"{ mode: "linkstate" }"#)
-            {
-                warn!("failed to set zenoh routing/peer to linkstate: {err}");
-            }
-
+            // NOTE: we used to set `routing/peer: { mode: "linkstate" }` here so
+            // that peers would relay for each other (e.g. two daemons on separate
+            // networks reaching each other through a public one). Zenoh 1.9
+            // *removed* peer routing modes — "routing.peer is removed, all peers
+            // now operate in peer-to-peer mode" — so the setting became a silent
+            // no-op (`insert_json5` still returns `Ok`, and only zenoh logs a
+            // deprecation warning). It is deleted rather than ported because
+            // there is no 1.9 equivalent for peers: peer regions must now form a
+            // clique, and `peers_failover_brokering` was removed too. Only
+            // *routers* still do linkstate routing.
+            //
+            // Consequences, and why this is not a regression here:
+            //   * Same-machine nodes are all loopback-addressable, so the links
+            //     the dataflow needs are established explicitly via
+            //     `connect/endpoints` below (see `DORA_ZENOH_CONNECT`) instead of
+            //     being left to gossip's best-effort autoconnect.
+            //   * Multi-machine/NAT setups, which is what linkstate was meant to
+            //     serve, supply their own config via `ZENOH_CONFIG_PATH` (handled
+            //     in the branch above) and can put a real router in the path.
+            //
             // Dora's data plane favors per-message latency over Zenoh's
             // default adaptive batching path. Publishers also set
             // `express(true)`, but low-latency unicast lets peer transports
             // skip the universal batching/priority queues entirely when both
             // ends use Dora's default config. Zenoh's low-latency transport is
             // negotiated without QoS, so disable QoS together with it instead
-            // of falling back during session open. We deliberately do NOT enable
-            // Zenoh's inter-peer SHM transport (`transport/shared_memory/enabled`):
-            // Dora nodes select Zenoh SHM per payload, while small payloads
-            // stay heap-buffered because page-aligned SHM setup does not pay
-            // off below the zero-copy threshold.
+            // of falling back during session open.
+            //
+            // We rely on zenoh's SHM transport (`transport/shared_memory/enabled`)
+            // being enabled, which is its default — do NOT set it to `false`: the
+            // API keeps working, but SHM buffers silently get serialized as plain
+            // bytes onto the wire (i.e. copied) instead of sent as a ~16-byte
+            // descriptor. Worse, `lowlatency` cannot fragment (message must stay
+            // under `batch_size`, 64 KiB), so without SHM a payload above that has
+            // no working path at all — zenoh's "fallback to network mode" is not
+            // transparent under this config.
             zenoh_config
                 .insert_json5("transport/unicast/lowlatency", "true")
                 .unwrap();

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -6,10 +6,35 @@ pub const DORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT: u16 = 53291;
 pub const DORA_DAEMON_LOCAL_LISTEN_PORT_ENV: &str = "DORA_DAEMON_LOCAL_LISTEN_PORT";
 pub const DORA_COORDINATOR_PORT_WS_DEFAULT: u16 = 6013;
 
-/// Env var injected by the daemon into spawned nodes that points at the
-/// daemon's loopback zenoh listener. Lets nodes bootstrap zenoh peer discovery
-/// without multicast (dev containers, locked-down hosts, many CI runners).
+/// Comma-separated zenoh endpoints a spawned node should connect to, injected by
+/// the daemon: the daemon's own loopback listener plus the listeners of the nodes
+/// this one consumes from (see [`DORA_ZENOH_LISTEN_ENV`]).
+///
+/// Lets nodes bootstrap zenoh peer discovery without multicast (dev containers,
+/// locked-down hosts, many CI runners), and — since zenoh 1.9 removed peer
+/// relaying — establishes the node↔node links the dataflow needs *explicitly*
+/// rather than leaving them to gossip's best-effort autoconnect.
 pub const DORA_ZENOH_CONNECT_ENV: &str = "DORA_ZENOH_CONNECT";
+
+/// Loopback zenoh endpoint a spawned node should listen on, injected by the
+/// daemon so this node's consumers can dial it directly (they receive it via
+/// their [`DORA_ZENOH_CONNECT_ENV`]).
+///
+/// Peers in zenoh 1.9 do not relay for each other, so a producer and consumer
+/// that never form a direct link simply cannot exchange data — no amount of
+/// waiting fixes it. Assigning each node a known listener makes those links
+/// deterministic instead of racy.
+pub const DORA_ZENOH_LISTEN_ENV: &str = "DORA_ZENOH_LISTEN";
+
+/// Split a comma-separated endpoint list env var, ignoring empty entries.
+#[cfg(feature = "zenoh")]
+fn split_endpoints(value: &str) -> impl Iterator<Item = String> + '_ {
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+}
 
 #[cfg(feature = "zenoh")]
 pub async fn open_zenoh_session(coordinator_addr: Option<IpAddr>) -> eyre::Result<zenoh::Session> {
@@ -125,8 +150,8 @@ pub async fn open_zenoh_session_with_listen(
             // disable multicast scouting so we don't end up with mixed
             // discovery modes.
             let mut connect_eps: Vec<String> = Vec::new();
-            if let Ok(ep) = std::env::var(DORA_ZENOH_CONNECT_ENV) {
-                connect_eps.push(ep);
+            if let Ok(eps) = std::env::var(DORA_ZENOH_CONNECT_ENV) {
+                connect_eps.extend(split_endpoints(&eps));
             }
             if let Some(peer) = inter_daemon_peer {
                 connect_eps.push(peer.to_string());
@@ -178,6 +203,14 @@ pub async fn open_zenoh_session_with_listen(
             // daemon proceed even if some don't bind — e.g. the second
             // daemon to start on the same host with the same rendezvous
             // port falls through to connect-only.
+            // A spawned node gets its listener from the daemon via
+            // `DORA_ZENOH_LISTEN` (the daemon itself passes `listen_endpoint`
+            // directly). Without a known listener a node cannot be dialled, and
+            // since zenoh 1.9 peers do not relay, a consumer that cannot dial its
+            // producer never receives its data at all.
+            let env_listen_endpoint = std::env::var(DORA_ZENOH_LISTEN_ENV).ok();
+            let listen_endpoint = listen_endpoint.or(env_listen_endpoint.as_deref());
+
             let mut listen_eps: Vec<String> = Vec::new();
             if let Some(ep) = listen_endpoint {
                 listen_eps.push(ep.to_string());


### PR DESCRIPTION
Addresses part of #2715. Three independent zenoh-1.9 defects, all silent, all found while investigating startup message loss (#2666).

> **Correction to an earlier revision of this description and of #2715:** it quoted release notes claiming *"routing.peer is removed—all peers now operate in peer-to-peer mode"* and that `peers_failover_brokering` was removed. **That quote is not in the 1.9.0 release notes and should be disregarded** — it came from an unverified source. The conclusion is unchanged, but the evidence below is now first-hand. The "must form a clique" claim is likewise withdrawn pending verification.

## 1. `routing/peer: linkstate` became a silent no-op → node links are racy

| source | evidence |
|---|---|
| [1.8.0 `linkstate_peer/mod.rs`](https://github.com/eclipse-zenoh/zenoh/blob/1.8.0/zenoh/src/net/routing/hat/linkstate_peer/mod.rs) | `peer_full_linkstate = unwrap_or_default!(config.routing().peer().mode()) == *"linkstate"` — our setting **worked** |
| [1.9.0 `peer/mod.rs`](https://github.com/eclipse-zenoh/zenoh/blob/1.9.0/zenoh/src/net/routing/hat/peer/mod.rs) | the `linkstate_peer` hat is gone; the `peer` hat passes **`full_linkstate: false`**, hardcoded |
| [1.9.0 release notes](https://github.com/eclipse-zenoh/zenoh/releases/tag/1.9.0) | *"Disable `full_linkstate` in `peer::Hat::Network`"* — listed under **Bug fixes**, not breaking changes |
| runtime | `routing.peer.mode` and `routing.peer.linkstate` are deprecated and have no effect` on every session open |

`insert_json5` still returns `Ok`, so our own `warn!` branch never fired. We lost transitive peer routing and nothing told us.

Consequence: node↔node links depend entirely on gossip's autoconnect, which is asynchronous and best-effort. When it loses, there is no relay to fall back on — delivery for that pair is permanently zero, not degraded, which is why it's per-pair independent.

Measured on `examples/rust-dataflow` (dev container, no multicast — the explicit-endpoint path, representative of CI):

| | route failures |
|---|---|
| before (gossip autoconnect) | **5 / 20** |
| after | **0 / 20** |

In a failing run `rust-node/random` published 2066 samples over 10s and its consumer received **zero**, while another pair in the same run delivered 1949/1949.

**Fix:** the nodes a daemon spawns are all on one machine and therefore loopback-addressable, so we say who dials whom instead of hoping discovery converges. The daemon reserves a listener per local node before spawning and injects `DORA_ZENOH_LISTEN`, plus a `DORA_ZENOH_CONNECT` list naming the daemon and the nodes this one consumes from.

Each consumer dials only its **producers** — a zenoh transport is bidirectional, so the consumer's dial carries the producer's data back. That is `|edges|` links rather than `N²`, and exactly the set the dataflow requires. Traffic stays direct peer-to-peer: **no relay hop, no change to zero-copy**.

## 2. `lowlatency` made >64 KiB cross-host messages undeliverable, silently

LowLatency cannot fragment, so a message must fit one batch — and `batch_size` is capped at 64 KiB by `pub type BatchSize = u16` (65535 is the *maximum*, not just the default; no feature widens it).

Shared memory hid this: an SHM payload travels as a ~16-byte descriptor and never fragments. But **SHM is per-host by construction, so it cannot negotiate between machines** — meaning a >64 KiB message to another host had no working path at all. Not "if SHM fails"; for cross-host it is guaranteed.

The failure is silent and misattributed: [`lowlatency/link.rs`](https://github.com/eclipse-zenoh/zenoh/blob/1.9.0/io/zenoh-transport/src/unicast/lowlatency/link.rs) writes a 4-byte u32 length prefix with **no size check on TX**, so `put()` returns `Ok` and the bytes reach the socket; the receiver's buffer is bounded by the u16 `batch_size` and rejects the frame with `Batch len is invalid`. The publisher believes it succeeded.

Reproduced on `examples/benchmark` (release, ascending sizes, otherwise identical runs), forcing SHM off to stand in for cross-host:

| condition | 40KB | 400KB | 3MB |
|---|---|---|---|
| SHM on + lowlatency on (old default) | ok | ok | ok |
| SHM **off** + lowlatency **on** | ok | **LOST** | **LOST** |
| SHM **off** + lowlatency **off** | ok | ok | ok |
| **SHM off + this PR** | ok | **ok** | **ok** |

Row 3 isolates the cause; row 1 shows why we never saw it. With the fix the SHM-off case delivers 400KB and 3MB again (**2 of 2, from 0 of 2**) at 255 µs and 1.7 ms — i.e. genuinely fragmented rather than riding a descriptor.

**Fix:** drop `transport/unicast/lowlatency`. `qos/enabled: false` goes with it — it existed *only* because the low-latency transport is negotiated without QoS.

Not a latency regression (release, `examples/benchmark`, vs the old config):

| size | p50 before | p50 after | throughput |
|---|---|---|---|
| 64B | 65µs | **55µs** | −28% |
| 512B | 66µs | **58µs** | +8% |
| 4KB | 72µs | **62µs** | **+51%** |
| 16KB | 73µs | **63µs** | **+41%** |
| 400KB | 69µs | **62µs** | +7% |

The two must be removed **together**: dropping `lowlatency` alone cost ~25 µs p50 on small messages, and restoring QoS is what recovers it — the publishers' `Priority::RealTime` was silently inert the whole time QoS was disabled. `express(true)` on publishers is untouched; that is the setting actually carrying small-message latency.

## 3. The shared-memory comment was inverted

It claimed we *"deliberately do NOT enable"* `transport/shared_memory/enabled`. That setting **defaults to `true`** ([defaults.rs](https://github.com/eclipse-zenoh/zenoh/blob/1.9.0/commons/zenoh-config/src/defaults.rs), so `Config::default()` agrees — not just the shipped file), and has since 1.0. We get zero-copy *by default*, not by opting out. Anyone "correcting" the code to match the comment would silently turn every SHM buffer into a copy.

## Scope

- **Only local nodes are planned.** `nodes` spans the whole dataflow including other daemons' nodes, whose endpoints are not on this host's loopback — dialing one would hit nothing, or an unrelated local process. A local consumer of a remote producer gets no dial for it and keeps existing cross-machine behavior. Covered by a regression test.
- **Dynamic nodes** keep daemon-endpoint-only + gossip, since they join at arbitrary times and aren't in the spawn set.
- **Multi-machine/NAT is untouched** — those deployments inject their own config via `ZENOH_CONFIG_PATH`, which bypasses this path entirely.

## Still open in #2715

- **daemon↔daemon across networks.** `inter_daemon_peer`'s hub only provides *discovery*; peers no longer relay, so two daemons behind NAT can discover each other and still not exchange data. Needs a router or 1.9 regions.
- **Dynamic nodes** remain exposed to the gossip race.
- The upstream transport bug itself: `put()` returning `Ok` for a message the peer must reject is zenoh's to fix.

## Verification

- 4 unit tests for the peering plan: graph mapping, cycle (`a→b→a`), dynamic-node exclusion, remote-node exclusion.
- 20-run before/after route measurement; 3-condition (+fix) large-message matrix; release latency/throughput comparison — all above.
- Full workspace tests, clippy `-D warnings`, `cargo fmt --check`, `cargo check --examples`, example dataflow end-to-end.

**Caveat on the numbers:** measured in a shared dev container, one run per condition for the benchmark. Directions are consistent and the deltas large, but the exact percentages want confirmation on quiet hardware. The route-failure rate (5/20) is specific to a no-multicast environment — representative of CI and dev containers, though the fix removes the race rather than tuning it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
