### PR TITLE
ci: trigger merge-queue checks on push to trunk-merge branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,16 @@
 #     These gate the merge itself. Running them only on Trunk's
 #     batched queue branch means 5 PRs share one expensive CI run.
 #
-# Detection of merge-queue runs relies on Trunk's draft-PR queue
-# mode: the queue branch is named `trunk-merge/...` and the
-# `pull_request` event fires with `github.head_ref` pointing at it.
+# Merge-queue runs are push-triggered: Trunk pushes a `trunk-merge/...`
+# batch branch and the `push` trigger below picks it up, so the expensive
+# tier gates on `github.event_name != 'pull_request'` alone. Checks attach
+# to the batch head SHA, which is what Trunk reads — pip-release.yml has
+# relied on exactly this since it went push-only, and `pip-release all
+# green` is a required status today.
+#
+# This reports correctly whether or not Trunk also opens a draft PR per
+# batch, so the two can overlap during a cutover — see .trunk/trunk.yaml
+# for that setting and why it stays off.
 #
 # Moved to .github/workflows/nightly.yml (runs once daily, ~3-4h):
 #   - test on macos + windows
@@ -62,7 +69,8 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    # Do not add a `paths:` filter — see .trunk/trunk.yaml.
+    branches: [main, "trunk-merge/**"]
   pull_request:
     branches: [main]
     # GitHub's default `pull_request` activity types are
@@ -178,7 +186,7 @@ jobs:
     # Trunk merge-queue batches, and manual workflow_dispatch.
     name: Test (ubuntu-latest)
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'trunk-merge/')
+    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
@@ -315,7 +323,7 @@ jobs:
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'trunk-merge/')
+    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
@@ -416,7 +424,7 @@ jobs:
   contract-tests:
     name: Semantic contract tests
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'trunk-merge/')
+    if: github.event_name != 'pull_request'
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -493,7 +501,7 @@ jobs:
   bench:
     name: Benchmark regression check
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'trunk-merge/')
+    if: github.event_name != 'pull_request'
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/test-c-cpp-libraries.yml
+++ b/.github/workflows/test-c-cpp-libraries.yml
@@ -16,6 +16,10 @@ name: Test C/C++ find_package
 #   covers a batch of up to 5 PRs, and quiet batches cost one short runner.
 #   Manual dispatch always runs it.
 #
+#   The queue is push-triggered, so a batch arrives as a push to a
+#   `trunk-merge/**` branch. See the `changes` job for why that has to be
+#   diffed against `main` rather than against `github.event.before`.
+#
 #   `find_package smoke all green` is a merge-queue required status
 #   (.trunk/trunk.yaml). That is why there is no workflow-level `paths:`
 #   filter: a workflow skipped by path filtering emits *no* check run at
@@ -27,7 +31,7 @@ name: Test C/C++ find_package
 
 on:
   push:
-    branches: [main]
+    branches: [main, "trunk-merge/**"]
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -37,8 +41,12 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  # The `changes` job diffs the batch branch against main via the
+  # compare REST API.
   contents: read
-  # The `changes` job lists the PR's changed files via the REST API.
+  # Only for the dev-PR path of `changes`, which lists the PR's changed
+  # files via the pulls REST API. Batches arrive as pushes and never use
+  # it; the path is kept so the workflow still reports on dev PRs.
   pull-requests: read
 
 jobs:
@@ -61,6 +69,7 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           BEFORE: ${{ github.event.before }}
+          REF_NAME: ${{ github.ref_name }}
           SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
@@ -110,14 +119,30 @@ jobs:
               ;;
             push)
               CAP=300  # compare caps .files at 300 and will not paginate it.
+              # A merge-queue batch branch is main plus the batched PRs, so
+              # always diff it against main: `base...head` merge-base
+              # semantics then yield exactly the changes the batch carries.
+              # Keyed on the ref name rather than on `before` because the
+              # two disagree on a re-pushed batch. A fresh batch branch has
+              # an all-zero `before` and nothing to diff against; a retried
+              # or bisected one has a real `before`, and diffing against
+              # that would narrow the filter to the delta between attempts
+              # and skip the matrix on a batch that does touch the
+              # find_package surface. Without either, every batch would
+              # fail open and run the 3-OS matrix — the cost this job
+              # exists to avoid.
+              case "$REF_NAME" in
+                trunk-merge/*) BASE=main ;;
+                *)             BASE="$BEFORE" ;;
+              esac
               # All-zero SHA => branch creation, nothing to compare against.
-              if [ -z "${BEFORE//0/}" ]; then
+              if [ -z "${BASE//0/}" ]; then
                 decided true "No base commit for this push; running the smoke matrix."
               fi
               # No --paginate: it pages .commits and would re-emit .files.
-              gh api "repos/$REPO/compare/$BEFORE...$SHA" \
+              gh api "repos/$REPO/compare/$BASE...$SHA" \
                 --jq '.files[].filename' > changed.txt \
-                || decided true "::warning::Could not compare $BEFORE...$SHA; running the smoke matrix."
+                || decided true "::warning::Could not compare $BASE...$SHA; running the smoke matrix."
               ;;
             *)
               decided true "Event is $EVENT_NAME; running the smoke matrix."
@@ -157,7 +182,7 @@ jobs:
     needs: changes
     if: >-
       needs.changes.outputs.relevant == 'true' &&
-      (github.event_name != 'pull_request' || startsWith(github.head_ref, 'trunk-merge/'))
+      github.event_name != 'pull_request'
     strategy:
       fail-fast: false
       matrix:

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -10,10 +10,19 @@ version: 0.1
 # these are the names it waits on before merging. Names must match the
 # GitHub Actions check names exactly.
 #
+# These statuses are produced by `push: trunk-merge/**` triggers on the
+# batch branch, not by a draft PR. Whether Trunk *also* opens a draft PR
+# per batch is the dashboard's "Draft Pull Request Creation" setting
+# (Settings > Repositories > dora-rs/dora > Merge Queue); the workflows
+# report either way, so the setting is a noise choice rather than a
+# correctness one. Leaving it on puts a draft PR in the PR list for every
+# batch, retry, and bisection, and double-runs the cheap tier on each
+# batch SHA — which is why it should stay off.
+#
 # Two tiers, mirroring `.github/workflows/ci.yml`:
 #   - Cheap checks run on every PR (gate queue entry via branch protection).
-#   - Expensive checks are guarded by `if: ... startsWith(github.head_ref,
-#     'trunk-merge/')` and run only on the batch branch.
+#   - Expensive checks are guarded by `if: github.event_name !=
+#     'pull_request'` and so run on the batch branch, not on dev PRs.
 #
 # A required check must be produced on *every* batch branch, or the queue
 # waits forever on a name that never reports. That rules out workflow-level


### PR DESCRIPTION
Trunk's queue currently runs in draft-PR mode, so every batch, retry and
bisection opens a draft PR against main. Over the last two weeks that was
289 draft PRs across 133 source PRs — 33% of them bisection branches.

Point the required checks at the batch branch itself instead. Trunk pushes
`trunk-merge/...`, the push trigger picks it up, and the checks attach to
the batch head SHA, which is what the queue reads. pip-release.yml has
worked this way since it went push-only and `pip-release all green` is a
required status, so the mechanism is already proven on this repo.

The expensive tier now gates on `github.event_name != 'pull_request'`
alone; the `startsWith(github.head_ref, 'trunk-merge/')` half only existed
to catch the draft-PR event. This reports correctly in either mode, so it
can merge before the dashboard setting is flipped.

`test-c-cpp-libraries.yml` needs more care: its path filter diffs against
`github.event.before`, which is the all-zero SHA on a freshly pushed batch
branch and a real SHA on a re-pushed one. The first fails open and would
run the 3-OS matrix on every batch; the second narrows the diff to the
delta between attempts and would wrongly skip it. Batch branches are now
keyed on the ref name and diffed against main, which is correct for both.

Requires flipping Draft Pull Request Creation to Disabled in the Trunk
dashboard after this lands.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
