### PR TITLE
ci: build the Python extension in dev profile for contract tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,6 +426,18 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request'
     timeout-minutes: 30
+    env:
+      # maturin's PEP 517 backend forces `--profile release` unless told
+      # otherwise (`ensure_release_profile` in maturin's commands/pep517.rs),
+      # so the `uv pip install -e apis/python/node` step below release-built
+      # dora-node-api-python's whole dep closure — arrow, tokio, zenoh,
+      # dora-cli — with thin LTO: 15m21s, sharing nothing with the
+      # dev-profile `shared-key: workspace` cache this job restores. Dev
+      # profile reuses that cache, and inherits the workflow-level
+      # CARGO_PROFILE_DEV_DEBUG so the fingerprints match (#2710).
+      # Caching target/release instead would cost ~1 GB against the 10 GB
+      # per-repo Actions cache cap (see the caching note in the header).
+      MATURIN_PEP517_ARGS: "--profile dev"
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master


### PR DESCRIPTION
maturin's PEP 517 backend forces `--profile release` unless told
otherwise, so `uv pip install -e apis/python/node` release-built
dora-node-api-python's entire dep closure with thin LTO on every run:
15m21s ("Prepared 3 packages in 15m 21s"), sharing nothing with the
dev-profile rust-cache the job already restores.

The step looks like it hangs on "Downloading numpy" — that's a red
herring. numpy downloads in ~1s; the silence after it is the cargo
build, which prints nothing until it finishes.

Set MATURIN_PEP517_ARGS="--profile dev" so the build reuses the
restored dev cache. Caching target/release instead would cost ~1 GB
against the repo's 10 GB Actions cache cap.

Crates whose features differ under the extension build (dora-runtime/
python, dora-cli/python, pyo3/extension-module) still rebuild; the
expected win is cache hits on the leaf tier (arrow, tokio, zenoh) plus
dropping thin LTO. The extension is now a debug build — the daemon it
drives already is, so watch contract_streaming_example and the
cross-language tests for timeout regressions.

nightly.yml has six copies of the same install; left alone pending the
measured delta here.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
