### PR TITLE
fix(daemon): bind zenoh listener on a routable address for multi-machine setups

### DIFF
--- a/binaries/cli/src/command/daemon.rs
+++ b/binaries/cli/src/command/daemon.rs
@@ -252,7 +252,7 @@ impl Executable for Daemon {
                         handle_dataflow_result(result, None)
                     }
                     None => {
-                        dora_daemon::Daemon::run(SocketAddr::new(self.coordinator_addr, self.coordinator_port), self.machine_id, self.labels.unwrap_or_default(), self.local_listen_port, self.zenoh_peer, self.zenoh_listen).await
+                        dora_daemon::Daemon::run_with_zenoh_listen(SocketAddr::new(self.coordinator_addr, self.coordinator_port), self.machine_id, self.labels.unwrap_or_default(), self.local_listen_port, self.zenoh_peer, self.zenoh_listen).await
                     }
                 }
             })

--- a/binaries/cli/src/command/daemon.rs
+++ b/binaries/cli/src/command/daemon.rs
@@ -49,6 +49,19 @@ pub struct Daemon {
     /// the `zenoh_peer` field in cluster.yml.
     #[clap(long, value_name = "ENDPOINT")]
     zenoh_peer: Option<String>,
+    /// IP address this daemon's Zenoh listener binds (e.g. `--zenoh-listen
+    /// 100.64.0.3`).
+    ///
+    /// Zenoh advertises the address it binds, and remote daemons dial exactly
+    /// that, so this is the address other daemons will use to reach this one.
+    /// By default it is derived from `--coordinator-addr`: loopback when the
+    /// coordinator is local (single-machine), otherwise the local address that
+    /// routes to the coordinator — which is the LAN address on a LAN and the
+    /// tunnel address on a mesh VPN such as Tailscale. Set this explicitly on a
+    /// multi-homed host that would otherwise advertise an interface the other
+    /// daemons cannot reach.
+    #[clap(long, value_name = "IP")]
+    zenoh_listen: Option<IpAddr>,
     /// Suppresses all log output to stdout.
     #[clap(long)]
     quiet: bool,
@@ -239,7 +252,7 @@ impl Executable for Daemon {
                         handle_dataflow_result(result, None)
                     }
                     None => {
-                        dora_daemon::Daemon::run(SocketAddr::new(self.coordinator_addr, self.coordinator_port), self.machine_id, self.labels.unwrap_or_default(), self.local_listen_port, self.zenoh_peer).await
+                        dora_daemon::Daemon::run(SocketAddr::new(self.coordinator_addr, self.coordinator_port), self.machine_id, self.labels.unwrap_or_default(), self.local_listen_port, self.zenoh_peer, self.zenoh_listen).await
                     }
                 }
             })

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -10,7 +10,8 @@ use dora_core::{
     },
     topics::{
         DORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT, LOCALHOST, open_zenoh_session_with_listen,
-        reserve_loopback_zenoh_endpoint, zenoh_daemon_control_topic, zenoh_output_publish_topic,
+        reserve_zenoh_endpoint, zenoh_bind_address_for, zenoh_daemon_control_topic,
+        zenoh_output_publish_topic,
     },
     uhlc::{self, HLC},
 };
@@ -44,7 +45,7 @@ use std::{
     env::current_dir,
     future::Future,
     io,
-    net::SocketAddr,
+    net::{IpAddr, SocketAddr},
     path::{Path, PathBuf},
     pin::pin,
     sync::{
@@ -591,6 +592,7 @@ impl Daemon {
         labels: BTreeMap<String, String>,
         local_listen_port: u16,
         inter_daemon_peer: Option<String>,
+        zenoh_listen_addr: Option<IpAddr>,
     ) -> eyre::Result<()> {
         Self::run_with_builds(
             coordinator_ws_addr,
@@ -598,19 +600,64 @@ impl Daemon {
             labels,
             local_listen_port,
             inter_daemon_peer,
+            zenoh_listen_addr,
             Default::default(),
         )
         .await
     }
 
+    /// `zenoh_listen_addr` overrides the address this daemon's zenoh listener
+    /// binds, and therefore the locator its peers are told to dial. Leave it
+    /// `None` to derive it from `coordinator_ws_addr`, which is correct
+    /// whenever the daemons reach each other over the same network they reach
+    /// the coordinator over — a LAN, or a mesh VPN. Set it explicitly on a
+    /// multi-homed host that would otherwise advertise the wrong interface.
+    #[allow(clippy::too_many_arguments)]
     pub async fn run_with_builds(
         coordinator_ws_addr: SocketAddr,
         machine_id: Option<String>,
         labels: BTreeMap<String, String>,
         local_listen_port: u16,
         inter_daemon_peer: Option<String>,
+        zenoh_listen_addr: Option<IpAddr>,
         initial_builds: BTreeMap<BuildId, BuildInfo>,
     ) -> eyre::Result<()> {
+        // A wildcard cannot be advertised: zenoh would bind every interface but
+        // report a concrete address, which then fails the listener verification
+        // in `open_zenoh_session_with_listen` and silently drops the
+        // `DORA_ZENOH_CONNECT` injection that local nodes rely on. Reject it
+        // loudly instead of degrading quietly.
+        if let Some(addr) = zenoh_listen_addr
+            && addr.is_unspecified()
+        {
+            eyre::bail!(
+                "--zenoh-listen must be a concrete address, not the wildcard `{addr}`. \
+                 Zenoh advertises the address it binds and remote daemons dial exactly \
+                 that, so a wildcard has nothing to advertise. Pass the address other \
+                 daemons should use to reach this host (e.g. its LAN or VPN address), \
+                 or omit the flag to derive it from --coordinator-addr."
+            );
+        }
+        let zenoh_bind =
+            zenoh_listen_addr.unwrap_or_else(|| zenoh_bind_address_for(coordinator_ws_addr));
+        if zenoh_bind.is_loopback() && !coordinator_ws_addr.ip().is_loopback() {
+            // The coordinator is remote, so other daemons are expected, but we
+            // have no address to offer them. Binding loopback anyway means
+            // advertising `127.0.0.1` to peers, who dial their own loopback and
+            // reach nothing — and since zenoh 1.9 peers do not relay, that pair
+            // is dead with no fallback. Say so: this is the silent failure the
+            // routable bind exists to prevent.
+            tracing::warn!(
+                "coordinator at {coordinator_ws_addr} is remote, but no routable local \
+                 address toward it was found; zenoh will bind loopback and other daemons \
+                 will not be able to reach this one. Pass --zenoh-listen <IP> explicitly."
+            );
+        } else if !zenoh_bind.is_loopback() {
+            tracing::info!(
+                "zenoh listener binding {zenoh_bind} (derived from coordinator address \
+                 {coordinator_ws_addr}); this port accepts connections from other hosts"
+            );
+        }
         let clock = Arc::new(HLC::default());
         let mut ctrlc_events = set_up_ctrlc_handler(clock.clone())?;
         // Tracks whether we've ever connected to the coordinator. The initial
@@ -722,6 +769,7 @@ impl Daemon {
                                 initial_builds.clone(),
                                 log_destination,
                                 inter_daemon_peer.clone(),
+                                zenoh_bind,
                             )
                             .await?;
                             daemon = Some(built);
@@ -1020,6 +1068,9 @@ impl Daemon {
         // loop. The reconnecting daemon binary instead builds the daemon once
         // and reuses it across reconnects (see `run_with_builds`), so that node
         // processes are not killed when the coordinator connection drops.
+        // `dora run` is single-machine by construction: the daemon, its nodes
+        // and the in-process coordinator all live on this host, so loopback is
+        // both sufficient and the least exposed choice.
         let (mut daemon, mut dora_events_rx) = Self::build_daemon(
             coordinator_sender,
             daemon_id,
@@ -1029,6 +1080,7 @@ impl Daemon {
             builds,
             log_destination,
             inter_daemon_peer,
+            LOCALHOST,
         )
         .await?;
         daemon
@@ -1059,15 +1111,25 @@ impl Daemon {
         builds: BTreeMap<BuildId, BuildInfo>,
         log_destination: LogDestination,
         inter_daemon_peer: Option<String>,
+        zenoh_bind: IpAddr,
     ) -> eyre::Result<(Self, mpsc::Receiver<Timestamped<Event>>)> {
-        // Reserve a loopback port and have zenoh listen on it. The endpoint is
-        // injected into spawned nodes via `DORA_ZENOH_CONNECT` so peer
-        // discovery works without multicast (#1778).
-        let requested_listen_endpoint = match reserve_loopback_zenoh_endpoint() {
+        // Reserve a port and have zenoh listen on it. The endpoint is injected
+        // into spawned nodes via `DORA_ZENOH_CONNECT` so peer discovery works
+        // without multicast (#1778).
+        //
+        // `zenoh_bind` is loopback for single-machine deployments and an
+        // address on the coordinator's network otherwise. It is not merely a
+        // question of which interface accepts connections: zenoh advertises the
+        // address it bound as its locator, and remote daemons dial exactly
+        // that. A daemon bound to loopback therefore tells its peers to dial
+        // `127.0.0.1` — their own loopback — where they reach nothing. Since
+        // zenoh 1.9 peers do not relay for each other, such a pair has no
+        // fallback path and simply never exchanges data.
+        let requested_listen_endpoint = match reserve_zenoh_endpoint(zenoh_bind) {
             Ok(ep) => Some(ep),
             Err(err) => {
                 tracing::warn!(
-                    "failed to reserve loopback zenoh listen endpoint: {err}; \
+                    "failed to reserve zenoh listen endpoint on {zenoh_bind}: {err}; \
                      falling back to multicast scouting only"
                 );
                 None

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -10,8 +10,8 @@ use dora_core::{
     },
     topics::{
         DORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT, LOCALHOST, open_zenoh_session_with_listen,
-        reserve_zenoh_endpoint, zenoh_bind_address_for, zenoh_daemon_control_topic,
-        zenoh_output_publish_topic,
+        reserve_zenoh_endpoint, validate_zenoh_listen, zenoh_bind_address_for,
+        zenoh_daemon_control_topic, zenoh_output_publish_topic,
     },
     uhlc::{self, HLC},
 };
@@ -585,8 +585,67 @@ fn pool_metadata_from_params(params: &MetadataParameters) -> MemoryPoolMetadata 
     }
 }
 
+/// Where the daemon's zenoh listen address came from, which decides what a bind
+/// failure means.
+///
+/// A derived address is a best guess, so failing to bind it may fall back to
+/// multicast scouting. An address the operator *named* must bind or the daemon
+/// must exit: they are on a network where they had to say the address out loud,
+/// which is precisely a network where multicast is not going to rescue us — and
+/// a daemon with no listener is undialable and silently dead, which is the
+/// failure this whole mechanism exists to prevent.
+#[derive(Debug, Clone, Copy)]
+enum ZenohBind {
+    /// Derived from the coordinator address; a bind failure can fall back.
+    Derived(IpAddr),
+    /// Named via `--zenoh-listen`; a bind failure is fatal.
+    Explicit(IpAddr),
+}
+
+impl ZenohBind {
+    fn addr(self) -> IpAddr {
+        match self {
+            Self::Derived(addr) | Self::Explicit(addr) => addr,
+        }
+    }
+
+    fn is_explicit(self) -> bool {
+        matches!(self, Self::Explicit(_))
+    }
+}
+
 impl Daemon {
+    /// Derives the zenoh listen address from `coordinator_ws_addr`; see
+    /// [`Daemon::run_with_zenoh_listen`] to override it.
     pub async fn run(
+        coordinator_ws_addr: SocketAddr,
+        machine_id: Option<String>,
+        labels: BTreeMap<String, String>,
+        local_listen_port: u16,
+        inter_daemon_peer: Option<String>,
+    ) -> eyre::Result<()> {
+        Self::run_with_zenoh_listen(
+            coordinator_ws_addr,
+            machine_id,
+            labels,
+            local_listen_port,
+            inter_daemon_peer,
+            None,
+        )
+        .await
+    }
+
+    /// Like [`Daemon::run`], but `zenoh_listen_addr` overrides the address this
+    /// daemon's zenoh listener binds, and therefore the locator its peers are
+    /// told to dial.
+    ///
+    /// Leave it `None` to derive it from `coordinator_ws_addr`, which is correct
+    /// whenever the daemons reach each other over the same network they reach
+    /// the coordinator over — a LAN, or a mesh VPN. Set it explicitly on a
+    /// multi-homed host that would otherwise advertise the wrong interface. An
+    /// address given here must bind: unlike the derived one, failing to bind it
+    /// is fatal rather than a fallback.
+    pub async fn run_with_zenoh_listen(
         coordinator_ws_addr: SocketAddr,
         machine_id: Option<String>,
         labels: BTreeMap<String, String>,
@@ -594,7 +653,7 @@ impl Daemon {
         inter_daemon_peer: Option<String>,
         zenoh_listen_addr: Option<IpAddr>,
     ) -> eyre::Result<()> {
-        Self::run_with_builds(
+        Self::run_inner_with_builds(
             coordinator_ws_addr,
             machine_id,
             labels,
@@ -606,14 +665,30 @@ impl Daemon {
         .await
     }
 
-    /// `zenoh_listen_addr` overrides the address this daemon's zenoh listener
-    /// binds, and therefore the locator its peers are told to dial. Leave it
-    /// `None` to derive it from `coordinator_ws_addr`, which is correct
-    /// whenever the daemons reach each other over the same network they reach
-    /// the coordinator over — a LAN, or a mesh VPN. Set it explicitly on a
-    /// multi-homed host that would otherwise advertise the wrong interface.
-    #[allow(clippy::too_many_arguments)]
+    /// Derives the zenoh listen address from `coordinator_ws_addr`; see
+    /// [`Daemon::run_with_zenoh_listen`] to override it.
     pub async fn run_with_builds(
+        coordinator_ws_addr: SocketAddr,
+        machine_id: Option<String>,
+        labels: BTreeMap<String, String>,
+        local_listen_port: u16,
+        inter_daemon_peer: Option<String>,
+        initial_builds: BTreeMap<BuildId, BuildInfo>,
+    ) -> eyre::Result<()> {
+        Self::run_inner_with_builds(
+            coordinator_ws_addr,
+            machine_id,
+            labels,
+            local_listen_port,
+            inter_daemon_peer,
+            None,
+            initial_builds,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn run_inner_with_builds(
         coordinator_ws_addr: SocketAddr,
         machine_id: Option<String>,
         labels: BTreeMap<String, String>,
@@ -622,25 +697,33 @@ impl Daemon {
         zenoh_listen_addr: Option<IpAddr>,
         initial_builds: BTreeMap<BuildId, BuildInfo>,
     ) -> eyre::Result<()> {
-        // A wildcard cannot be advertised: zenoh would bind every interface but
-        // report a concrete address, which then fails the listener verification
-        // in `open_zenoh_session_with_listen` and silently drops the
-        // `DORA_ZENOH_CONNECT` injection that local nodes rely on. Reject it
-        // loudly instead of degrading quietly.
-        if let Some(addr) = zenoh_listen_addr
-            && addr.is_unspecified()
-        {
-            eyre::bail!(
-                "--zenoh-listen must be a concrete address, not the wildcard `{addr}`. \
-                 Zenoh advertises the address it binds and remote daemons dial exactly \
-                 that, so a wildcard has nothing to advertise. Pass the address other \
-                 daemons should use to reach this host (e.g. its LAN or VPN address), \
-                 or omit the flag to derive it from --coordinator-addr."
-            );
+        let zenoh_bind = match zenoh_listen_addr {
+            Some(addr) => {
+                validate_zenoh_listen(addr).wrap_err(
+                    "invalid --zenoh-listen address (omit the flag to derive it                      from --coordinator-addr)",
+                )?;
+                ZenohBind::Explicit(addr)
+            }
+            None => ZenohBind::Derived(zenoh_bind_address_for(coordinator_ws_addr)),
+        };
+        // Fail fast on an address that does not exist on this host (a typo'd
+        // digit gives EADDRNOTAVAIL). The reservation in `build_daemon` is the
+        // real guard, but that only runs once the coordinator connects — which
+        // may be many retries away, or never — so without this probe a typo
+        // looks like a connectivity problem for minutes before it looks like a
+        // typo. Whether the address exists is not racy, so checking it early
+        // costs nothing but a bind and a drop.
+        if let ZenohBind::Explicit(addr) = zenoh_bind {
+            std::net::TcpListener::bind((addr, 0))
+                .map(drop)
+                .wrap_err_with(|| {
+                    format!(
+                        "cannot bind the zenoh listen address {addr} given via \
+                         --zenoh-listen; it does not appear to exist on this host"
+                    )
+                })?;
         }
-        let zenoh_bind =
-            zenoh_listen_addr.unwrap_or_else(|| zenoh_bind_address_for(coordinator_ws_addr));
-        if zenoh_bind.is_loopback() && !coordinator_ws_addr.ip().is_loopback() {
+        if zenoh_bind.addr().is_loopback() && !coordinator_ws_addr.ip().is_loopback() {
             // The coordinator is remote, so other daemons are expected, but we
             // have no address to offer them. Binding loopback anyway means
             // advertising `127.0.0.1` to peers, who dial their own loopback and
@@ -652,10 +735,16 @@ impl Daemon {
                  address toward it was found; zenoh will bind loopback and other daemons \
                  will not be able to reach this one. Pass --zenoh-listen <IP> explicitly."
             );
-        } else if !zenoh_bind.is_loopback() {
+        } else if !zenoh_bind.addr().is_loopback() {
             tracing::info!(
-                "zenoh listener binding {zenoh_bind} (derived from coordinator address \
-                 {coordinator_ws_addr}); this port accepts connections from other hosts"
+                "zenoh listener binding {} ({}); this port accepts connections from \
+                 other hosts",
+                zenoh_bind.addr(),
+                match zenoh_bind {
+                    ZenohBind::Explicit(_) => "given via --zenoh-listen".to_string(),
+                    ZenohBind::Derived(_) =>
+                        format!("derived from coordinator address {coordinator_ws_addr}"),
+                }
             );
         }
         let clock = Arc::new(HLC::default());
@@ -1080,7 +1169,7 @@ impl Daemon {
             builds,
             log_destination,
             inter_daemon_peer,
-            LOCALHOST,
+            ZenohBind::Derived(LOCALHOST),
         )
         .await?;
         daemon
@@ -1111,7 +1200,7 @@ impl Daemon {
         builds: BTreeMap<BuildId, BuildInfo>,
         log_destination: LogDestination,
         inter_daemon_peer: Option<String>,
-        zenoh_bind: IpAddr,
+        zenoh_bind: ZenohBind,
     ) -> eyre::Result<(Self, mpsc::Receiver<Timestamped<Event>>)> {
         // Reserve a port and have zenoh listen on it. The endpoint is injected
         // into spawned nodes via `DORA_ZENOH_CONNECT` so peer discovery works
@@ -1125,12 +1214,32 @@ impl Daemon {
         // `127.0.0.1` — their own loopback — where they reach nothing. Since
         // zenoh 1.9 peers do not relay for each other, such a pair has no
         // fallback path and simply never exchanges data.
-        let requested_listen_endpoint = match reserve_zenoh_endpoint(zenoh_bind) {
+        //
+        // Falling back to multicast when the reservation fails is only defensible
+        // for a *derived* address: loopback always exists, so the error was
+        // effectively unreachable. An operator-supplied address can genuinely
+        // fail — a typo'd digit gives EADDRNOTAVAIL — and continuing would leave
+        // the daemon with no listener at all: undialable, silently dead, which is
+        // the exact failure this code exists to prevent. Someone who named an
+        // address explicitly is also, almost by definition, on a network where
+        // multicast will not save them. So: fatal when explicit.
+        let requested_listen_endpoint = match reserve_zenoh_endpoint(zenoh_bind.addr()) {
             Ok(ep) => Some(ep),
+            Err(err) if zenoh_bind.is_explicit() => {
+                return Err(err).wrap_err_with(|| {
+                    format!(
+                        "failed to bind the zenoh listen address {} given via \
+                         --zenoh-listen; other daemons would have no way to reach this \
+                         one. Check that this address exists on this host",
+                        zenoh_bind.addr()
+                    )
+                });
+            }
             Err(err) => {
                 tracing::warn!(
-                    "failed to reserve zenoh listen endpoint on {zenoh_bind}: {err}; \
-                     falling back to multicast scouting only"
+                    "failed to reserve zenoh listen endpoint on {}: {err}; \
+                     falling back to multicast scouting only",
+                    zenoh_bind.addr()
                 );
                 None
             }
@@ -1148,6 +1257,16 @@ impl Daemon {
         .await
         .wrap_err("failed to open zenoh session")?;
         if requested_listen_endpoint.is_some() && zenoh_listen_endpoint.is_none() {
+            // Same argument as the reservation above: an address the operator
+            // named must actually be listening, or this daemon is unreachable
+            // and nothing will tell them.
+            if zenoh_bind.is_explicit() {
+                eyre::bail!(
+                    "zenoh did not bind the listen address {} given via --zenoh-listen; \
+                     other daemons would have no way to reach this one",
+                    zenoh_bind.addr()
+                );
+            }
             tracing::warn!(
                 "requested zenoh listener but zenoh did not bind it; \
                  spawned nodes will use multicast scouting only"

--- a/binaries/daemon/src/spawn/spawner.rs
+++ b/binaries/daemon/src/spawn/spawner.rs
@@ -237,9 +237,14 @@ pub struct Spawner {
     pub ft_stats: Arc<crate::FaultToleranceStats>,
     /// Signals listener loops to shut down when the dataflow finishes.
     pub shutdown: tokio::sync::watch::Receiver<bool>,
-    /// Loopback endpoint of the daemon's zenoh listener. Forwarded to spawned
-    /// nodes via `DORA_ZENOH_CONNECT` so the >=4 KiB zenoh data path works
-    /// without multicast scouting (#1778).
+    /// Endpoint of the daemon's zenoh listener. Forwarded to spawned nodes via
+    /// `DORA_ZENOH_CONNECT` so the >=4 KiB zenoh data path works without
+    /// multicast scouting (#1778).
+    ///
+    /// Loopback for a single-machine deployment, but possibly a routable address
+    /// for a daemon in a cluster. Either way it is on the node's own host, so
+    /// the node can reach it. Node listeners themselves stay on loopback: node
+    /// output crosses machines by daemon-level forwarding, not node-to-node.
     pub zenoh_connect_endpoint: Option<String>,
     /// Per-node listener + dial-list, so the node↔node links the dataflow needs
     /// are established deterministically. See [`plan_zenoh_peering`].

--- a/docs/distributed-deployment.md
+++ b/docs/distributed-deployment.md
@@ -148,6 +148,22 @@ machines:
 | `zenoh_peer` | string | none | Shared Zenoh peer endpoint that all daemons use as a rendezvous for cross-daemon discovery (e.g., `tcp/192.168.1.1:5456`). `dora cluster up` passes it to every daemon via `dora daemon --zenoh-peer <ep>`. The first daemon to bind serves as the gossip hub; the rest fall through to connect-only. **Set this when your network lacks multicast** (dev containers, hardened deployments, many CI runners) — otherwise daemons can't find each other and cross-daemon dataflows hang. |
 | `machines` | array | (required) | Machine list (see below) |
 
+> **Every daemon must be dialable by every other daemon.** Zenoh advertises the
+> address a daemon binds, and remote daemons dial exactly that; since zenoh 1.9
+> peers do not relay for each other, a pair that cannot form a direct link has no
+> fallback and silently exchanges nothing. By default a daemon binds the local
+> address that routes toward `coordinator.addr` — the LAN address on a LAN, the
+> tunnel address on a mesh VPN such as Tailscale — which is correct without
+> configuration. On a multi-homed machine that would otherwise advertise an
+> interface the other daemons cannot reach, override it with
+> `dora daemon --zenoh-listen <IP>`. A daemon whose coordinator is loopback stays
+> on loopback and is not reachable from the network at all.
+>
+> `--zenoh-listen` must be a concrete address: a wildcard (`0.0.0.0`) is rejected
+> because zenoh would bind every interface but advertise a concrete one. An
+> address given explicitly must bind, or the daemon exits rather than starting
+> without a listener.
+
 **coordinator**
 
 | Field | Type | Default | Description |

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -7,8 +7,13 @@ pub const DORA_DAEMON_LOCAL_LISTEN_PORT_ENV: &str = "DORA_DAEMON_LOCAL_LISTEN_PO
 pub const DORA_COORDINATOR_PORT_WS_DEFAULT: u16 = 6013;
 
 /// Comma-separated zenoh endpoints a spawned node should connect to, injected by
-/// the daemon: the daemon's own loopback listener plus the listeners of the nodes
-/// this one consumes from (see [`DORA_ZENOH_LISTEN_ENV`]).
+/// the daemon: the daemon's own listener plus the listeners of the nodes this one
+/// consumes from (see [`DORA_ZENOH_LISTEN_ENV`]).
+///
+/// The daemon's listener is loopback for a single-machine deployment, but may be
+/// a routable address when the daemon is part of a cluster (see
+/// [`zenoh_bind_address_for`]). Either way it is on this node's own host, so the
+/// node can always reach it.
 ///
 /// Lets nodes bootstrap zenoh peer discovery without multicast (dev containers,
 /// locked-down hosts, many CI runners), and — since zenoh 1.9 removed peer
@@ -43,9 +48,10 @@ pub async fn open_zenoh_session(coordinator_addr: Option<IpAddr>) -> eyre::Resul
 }
 
 /// Like [`open_zenoh_session`], but also configures the session to listen on
-/// the given loopback endpoint (e.g. `tcp/127.0.0.1:43217`). The daemon uses
-/// this so spawned nodes can connect via `DORA_ZENOH_CONNECT` without
-/// multicast scouting.
+/// the given endpoint (e.g. `tcp/127.0.0.1:43217`, or a routable address such as
+/// `tcp/10.0.2.100:43217` for a daemon in a cluster). The daemon uses this so
+/// spawned nodes can connect via `DORA_ZENOH_CONNECT` without multicast
+/// scouting, and so that other daemons can dial it.
 ///
 /// `inter_daemon_peer` is an optional shared endpoint used as the
 /// rendezvous for daemon-to-daemon discovery when multicast isn't
@@ -199,7 +205,7 @@ pub async fn open_zenoh_session_with_listen(
             // We don't promote it to `effective_listen_endpoint` until the
             // configured open succeeds — the fallback default-config path
             // below has no listener and must not advertise one (#1856).
-            // We only track `listen_endpoint` (the per-daemon loopback that
+            // We only track `listen_endpoint` (the per-daemon listener that
             // gets advertised to spawned nodes), NOT `inter_daemon_peer`
             // which is cluster-wide config — daemons that bind it act as
             // the rendezvous, but advertising it back to nodes would be
@@ -436,6 +442,43 @@ pub fn zenoh_bind_address_for(coordinator_addr: SocketAddr) -> IpAddr {
     local_address_toward(coordinator_addr).unwrap_or(LOCALHOST)
 }
 
+/// Reject a zenoh listen address that cannot be advertised to peers.
+///
+/// Only the wildcard is rejected here, and only because it is *structurally*
+/// unadvertisable: zenoh would bind every interface but report a concrete
+/// locator, so the listener verification in [`open_zenoh_session_with_listen`]
+/// could never match it, and the daemon would silently stop advertising an
+/// endpoint to its nodes. Whether a concrete address actually exists on this
+/// host is not knowable here — that surfaces as a bind error from
+/// [`reserve_zenoh_endpoint`], which callers must treat as fatal when the
+/// operator named the address explicitly.
+pub fn validate_zenoh_listen(bind: IpAddr) -> eyre::Result<()> {
+    if bind.is_unspecified() {
+        eyre::bail!(
+            "zenoh listen address must be concrete, not the wildcard `{bind}`. \
+             Zenoh advertises the address it binds and remote daemons dial exactly \
+             that, so a wildcard has nothing to advertise. Pass the address other \
+             daemons should use to reach this host (e.g. its LAN or VPN address)."
+        );
+    }
+    Ok(())
+}
+
+/// Whether a source address the routing table handed back can be advertised to
+/// peers as a locator.
+///
+/// The unspecified address is not a real source, and a loopback source for a
+/// *remote* target means the routing table told us nothing usable (there is no
+/// route, or the target resolved back to this host). Advertising either would
+/// point peers at nothing, so both mean "we learned nothing" and the caller
+/// should fall back rather than guess.
+fn usable_source(local: IpAddr) -> Option<IpAddr> {
+    if local.is_unspecified() || local.is_loopback() {
+        return None;
+    }
+    Some(local)
+}
+
 fn local_address_toward(target: SocketAddr) -> Option<IpAddr> {
     // Bind the wildcard of the same family as the target, then `connect` to
     // consult the routing table. UDP `connect` is local-only: no traffic.
@@ -446,13 +489,7 @@ fn local_address_toward(target: SocketAddr) -> Option<IpAddr> {
     };
     let socket = std::net::UdpSocket::bind(bind).ok()?;
     socket.connect(target).ok()?;
-    let local = socket.local_addr().ok()?.ip();
-    // A routing table that hands back an unspecified or loopback source for a
-    // remote target tells us nothing usable; treat it as "no route".
-    if local.is_unspecified() || local.is_loopback() {
-        return None;
-    }
-    Some(local)
+    usable_source(socket.local_addr().ok()?.ip())
 }
 
 /// Zenoh key for node output data.
@@ -600,18 +637,6 @@ mod tests {
         assert!(port > 0, "kernel must hand out a non-zero ephemeral port");
     }
 
-    // `reserve_loopback_zenoh_endpoint` must stay exactly the loopback case of
-    // the generalized helper: single-machine deployments keep binding loopback
-    // only, so this change adds no network exposure for them.
-    #[test]
-    fn reserve_loopback_is_the_loopback_case_of_reserve() {
-        let endpoint = reserve_zenoh_endpoint(LOCALHOST).expect("reservation succeeds");
-        assert!(
-            endpoint.starts_with("tcp/127.0.0.1:"),
-            "expected loopback tcp endpoint, got {endpoint}"
-        );
-    }
-
     // A local coordinator means every zenoh peer is on this host, so we must
     // keep binding loopback — a single-machine daemon should not start
     // listening on the network just because this code path exists.
@@ -639,20 +664,61 @@ mod tests {
         );
     }
 
-    // The routing lookup is best-effort: it must never panic, and must never
-    // hand back an address that cannot be advertised (unspecified/loopback for
-    // a remote target both mean "we learned nothing").
+    // The filter behind the routing lookup, tested directly rather than through
+    // the runner's routing table (which would make the assertion depend on the
+    // machine and, for a remote target, be satisfiable by either branch).
     #[test]
-    fn bind_address_for_remote_coordinator_is_advertisable_or_loopback() {
-        let addr: SocketAddr = "203.0.113.1:6013".parse().unwrap();
-        let picked = zenoh_bind_address_for(addr);
-        assert!(
-            !picked.is_unspecified(),
-            "never advertise a wildcard as a locator, got {picked}"
-        );
-        // Either the host has a route to the outside (any concrete address), or
-        // it does not and we fall back to loopback. Both are acceptable; a
-        // wildcard or a panic are not.
+    fn only_concrete_routable_sources_are_advertisable() {
+        // Real interface addresses are what we want to advertise.
+        for ok in ["10.0.2.100", "192.168.1.7", "100.64.0.3"] {
+            let addr: IpAddr = ok.parse().unwrap();
+            assert_eq!(
+                usable_source(addr),
+                Some(addr),
+                "{ok} is a concrete routable address and must be advertisable"
+            );
+        }
+        // A wildcard is not a source at all, and a loopback source for a remote
+        // target means the routing table told us nothing — advertising either
+        // points peers at nothing.
+        for rejected in ["0.0.0.0", "127.0.0.1", "::", "::1"] {
+            let addr: IpAddr = rejected.parse().unwrap();
+            assert_eq!(
+                usable_source(addr),
+                None,
+                "{rejected} must never be advertised to peers as a locator"
+            );
+        }
+    }
+
+    // The wildcard cannot be advertised: zenoh binds every interface but reports
+    // a concrete locator, so the listener check can never match it and the
+    // daemon would silently stop advertising an endpoint to its nodes —
+    // reintroducing the gossip race #2716 removed. Reject it up front instead.
+    #[test]
+    fn wildcard_zenoh_listen_is_rejected() {
+        for wildcard in ["0.0.0.0", "::"] {
+            let addr: IpAddr = wildcard.parse().unwrap();
+            let err = validate_zenoh_listen(addr)
+                .expect_err("wildcard listen address must be rejected, not accepted");
+            assert!(
+                err.to_string().contains("concrete"),
+                "error should tell the operator to pass a concrete address, got: {err}"
+            );
+        }
+    }
+
+    // Concrete addresses pass validation whether or not they exist on this host:
+    // existence is not knowable here and surfaces as a bind error instead.
+    #[test]
+    fn concrete_zenoh_listen_addresses_are_accepted() {
+        for ok in ["127.0.0.1", "10.0.2.100", "::1"] {
+            let addr: IpAddr = ok.parse().unwrap();
+            assert!(
+                validate_zenoh_listen(addr).is_ok(),
+                "{ok} is concrete and must pass validation"
+            );
+        }
     }
 
     // Node raw output and daemon control frames MUST live on distinct Zenoh

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -1,4 +1,4 @@
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 pub const LOCALHOST: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
 pub const DORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT: u16 = 53291;
@@ -307,12 +307,18 @@ pub async fn open_zenoh_session_with_listen(
                         // false-positive on port-prefix collisions (e.g.
                         // requested `:5000` matching bound `:50000`), which
                         // is exactly the mismatch this check exists to
-                        // catch. NOTE: the comparison is by canonical
-                        // `tcp/127.0.0.1:<port>` form; callers passing
-                        // non-canonical loopback forms (`localhost`, IPv6
-                        // mapped) won't match — `reserve_loopback_zenoh_
-                        // endpoint` only emits the canonical form, so this
-                        // is fine for the daemon's only call site.
+                        // catch. NOTE: the comparison is against the
+                        // requested string verbatim, so a caller must request
+                        // the same canonical `tcp/<addr>:<port>` form that
+                        // zenoh reports back. `reserve_zenoh_endpoint` emits
+                        // that form, but only for a *concrete* address: a
+                        // wildcard request (`tcp/0.0.0.0:<port>`) can never
+                        // match, because zenoh binds every interface and
+                        // reports the concrete one. Callers must therefore
+                        // reject wildcards up front (the daemon does) rather
+                        // than reach this check, which would read the mismatch
+                        // as "the listener did not bind" and silently fall back
+                        // to multicast scouting.
                         let bound = bound_locators
                             .iter()
                             .any(|l| l.split(['?', '#']).next() == Some(requested.as_str()));
@@ -351,9 +357,20 @@ pub async fn open_zenoh_session_with_listen(
     Ok((zenoh_session, effective_listen_endpoint))
 }
 
-/// Reserve an unused TCP port on `127.0.0.1` for use as a zenoh listen
-/// endpoint. Returns a string suitable for the zenoh `listen/endpoints`
-/// config (e.g. `tcp/127.0.0.1:43217`).
+/// Reserve an unused TCP port on `bind` for use as a zenoh listen endpoint.
+/// Returns a string suitable for the zenoh `listen/endpoints` config
+/// (e.g. `tcp/127.0.0.1:43217`, or `tcp/[::1]:43217` for IPv6).
+///
+/// The bind address matters beyond which interface accepts connections:
+/// zenoh advertises the address it bound as its locator, and remote peers
+/// dial exactly that. A daemon that binds loopback is therefore not merely
+/// unreachable from another machine — it actively tells remote daemons to
+/// dial `127.0.0.1`, i.e. their own loopback, where they find nothing (or an
+/// unrelated local process). Since zenoh 1.9 peers do not relay for each
+/// other, such a pair has no fallback path and is silently dead. Multi-machine
+/// deployments must therefore reserve on an address the other machines can
+/// actually reach; see [`reserve_loopback_zenoh_endpoint`] for the
+/// single-machine case.
 ///
 /// There is a small race window between dropping the reservation socket
 /// and zenoh's own bind. `open_zenoh_session_with_listen` defends against
@@ -370,11 +387,72 @@ pub async fn open_zenoh_session_with_listen(
 ///
 /// In practice the OS keeps allocating fresh ephemeral ports each call,
 /// so collisions remain vanishingly rare.
-pub fn reserve_loopback_zenoh_endpoint() -> std::io::Result<String> {
-    let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))?;
+///
+/// Note that the locator check in (2) compares the requested `addr:port`
+/// literally, so reserving on the unspecified address (`0.0.0.0`) will not
+/// match the concrete interface address zenoh reports back. Pass the address
+/// you want advertised, not a wildcard.
+pub fn reserve_zenoh_endpoint(bind: IpAddr) -> std::io::Result<String> {
+    let listener = std::net::TcpListener::bind((bind, 0))?;
     let port = listener.local_addr()?.port();
     drop(listener);
-    Ok(format!("tcp/127.0.0.1:{port}"))
+    // `SocketAddr`'s Display brackets IPv6 for us, which is also zenoh's
+    // endpoint syntax (`tcp/[::1]:7447`).
+    Ok(format!("tcp/{}", SocketAddr::new(bind, port)))
+}
+
+/// Loopback case of [`reserve_zenoh_endpoint`] — the right choice when every
+/// zenoh peer that needs this listener is on the same host, which is what a
+/// single-machine deployment looks like.
+pub fn reserve_loopback_zenoh_endpoint() -> std::io::Result<String> {
+    reserve_zenoh_endpoint(LOCALHOST)
+}
+
+/// Pick the address a daemon's zenoh listener should bind so that the other
+/// daemons in the deployment can dial it.
+///
+/// Returns [`LOCALHOST`] when the coordinator is itself local: everything that
+/// needs this listener is then on this host, and binding loopback keeps the
+/// daemon's zenoh unreachable from the network — which is the status quo for
+/// single-machine users, and worth preserving.
+///
+/// Otherwise the daemon is part of a multi-machine deployment, and we return
+/// the local address the kernel would use to reach `coordinator_addr`. That is
+/// the correct choice without anyone configuring anything: on a LAN it is the
+/// LAN address, and on a mesh VPN (Tailscale/WireGuard) — where the
+/// coordinator is reached over the tunnel — it is the tunnel address, which is
+/// exactly the one remote daemons can dial. A multi-homed host that picks the
+/// wrong interface can be overridden explicitly by the caller.
+///
+/// The lookup `connect()`s a UDP socket, which sends no packets: it only asks
+/// the routing table which source address applies. If there is no route (or
+/// the lookup otherwise fails) we fall back to [`LOCALHOST`] rather than
+/// guessing, since a wrong address is advertised to peers and fails silently,
+/// whereas loopback at least keeps same-host behavior working.
+pub fn zenoh_bind_address_for(coordinator_addr: SocketAddr) -> IpAddr {
+    if coordinator_addr.ip().is_loopback() {
+        return LOCALHOST;
+    }
+    local_address_toward(coordinator_addr).unwrap_or(LOCALHOST)
+}
+
+fn local_address_toward(target: SocketAddr) -> Option<IpAddr> {
+    // Bind the wildcard of the same family as the target, then `connect` to
+    // consult the routing table. UDP `connect` is local-only: no traffic.
+    let bind: SocketAddr = if target.is_ipv4() {
+        (Ipv4Addr::UNSPECIFIED, 0).into()
+    } else {
+        (std::net::Ipv6Addr::UNSPECIFIED, 0).into()
+    };
+    let socket = std::net::UdpSocket::bind(bind).ok()?;
+    socket.connect(target).ok()?;
+    let local = socket.local_addr().ok()?.ip();
+    // A routing table that hands back an unspecified or loopback source for a
+    // remote target tells us nothing usable; treat it as "no route".
+    if local.is_unspecified() || local.is_loopback() {
+        return None;
+    }
+    Some(local)
 }
 
 /// Zenoh key for node output data.
@@ -520,6 +598,61 @@ mod tests {
             .and_then(|p| p.parse().ok())
             .expect("endpoint has a numeric port");
         assert!(port > 0, "kernel must hand out a non-zero ephemeral port");
+    }
+
+    // `reserve_loopback_zenoh_endpoint` must stay exactly the loopback case of
+    // the generalized helper: single-machine deployments keep binding loopback
+    // only, so this change adds no network exposure for them.
+    #[test]
+    fn reserve_loopback_is_the_loopback_case_of_reserve() {
+        let endpoint = reserve_zenoh_endpoint(LOCALHOST).expect("reservation succeeds");
+        assert!(
+            endpoint.starts_with("tcp/127.0.0.1:"),
+            "expected loopback tcp endpoint, got {endpoint}"
+        );
+    }
+
+    // A local coordinator means every zenoh peer is on this host, so we must
+    // keep binding loopback — a single-machine daemon should not start
+    // listening on the network just because this code path exists.
+    #[test]
+    fn local_coordinator_keeps_the_listener_on_loopback() {
+        for addr in ["127.0.0.1:6013", "[::1]:6013"] {
+            let addr: SocketAddr = addr.parse().unwrap();
+            assert_eq!(
+                zenoh_bind_address_for(addr),
+                LOCALHOST,
+                "a loopback coordinator at {addr} must not move the listener off loopback"
+            );
+        }
+    }
+
+    // IPv6 endpoints must be bracketed or zenoh cannot parse the port back off
+    // (`tcp/::1:7447` is ambiguous).
+    #[test]
+    fn ipv6_endpoints_are_bracketed() {
+        let endpoint = reserve_zenoh_endpoint(IpAddr::V6(std::net::Ipv6Addr::LOCALHOST))
+            .expect("reservation on ::1 succeeds");
+        assert!(
+            endpoint.starts_with("tcp/[::1]:"),
+            "expected a bracketed IPv6 endpoint, got {endpoint}"
+        );
+    }
+
+    // The routing lookup is best-effort: it must never panic, and must never
+    // hand back an address that cannot be advertised (unspecified/loopback for
+    // a remote target both mean "we learned nothing").
+    #[test]
+    fn bind_address_for_remote_coordinator_is_advertisable_or_loopback() {
+        let addr: SocketAddr = "203.0.113.1:6013".parse().unwrap();
+        let picked = zenoh_bind_address_for(addr);
+        assert!(
+            !picked.is_unspecified(),
+            "never advertise a wildcard as a locator, got {picked}"
+        );
+        // Either the host has a route to the outside (any concrete address), or
+        // it does not and we fall back to loopback. Both are acceptable; a
+        // wildcard or a panic are not.
     }
 
     // Node raw output and daemon control frames MUST live on distinct Zenoh


### PR DESCRIPTION
The daemon reserved its zenoh listener on `127.0.0.1` unconditionally. Zenoh advertises the address it binds and remote peers dial exactly that — so a daemon wasn't merely unreachable from another machine, it actively told remote daemons to dial `127.0.0.1`, i.e. their own loopback, where they reach nothing or an unrelated local process. Since 1.9 removed peer relaying (#2715, #2716), such a pair has no fallback and is silently dead.

Kernel-level evidence that this is what we bind today:

```
reserve_loopback_zenoh_endpoint() -> tcp/127.0.0.1:39469
  session.info().locators():  tcp/127.0.0.1:39469
  kernel: LISTEN 127.0.0.1:39469        <-- loopback only

listen tcp/0.0.0.0:17899                <-- for contrast
  session.info().locators():  tcp/10.0.2.100:17899
  kernel: LISTEN 0.0.0.0:17899
```

Note zenoh's own default for a peer is `tcp/[::]:0` — all interfaces. Our explicit loopback endpoint *narrows* that; we aren't falling back to a wildcard, we're overriding one.

## What this does

Derive the bind address from `--coordinator-addr`:

- **Coordinator loopback** → loopback bind, exactly as today. Note this is precisely "is the coordinator address loopback", *not* "is it one of my interfaces": `--coordinator-addr <this box's LAN IP>` on a single machine now binds that LAN address where it used to bind loopback. That's deliberate — tightening it to "is this a local interface?" would break the common layout where the coordinator is co-located with a daemon that genuinely needs a routable bind — but it does mean the no-new-exposure guarantee is scoped to a loopback coordinator, not to single-machine setups generally.
- **Coordinator remote** → the local address the kernel routes toward it. Correct with no configuration: the LAN address on a LAN, and the tunnel address on a mesh VPN such as Tailscale — which is exactly the address remote daemons can dial. The lookup `connect()`s a UDP socket, which sends no packets; it only consults the routing table.
- `--zenoh-listen <IP>` overrides it for a multi-homed host that would otherwise advertise the wrong interface.

An explicitly given `--zenoh-listen` **must bind, or the daemon exits.** A derived address may still fall back to multicast scouting, but an operator who names an address is on a network where multicast will not rescue them, and a daemon with no listener is undialable and silently dead — the exact failure this PR exists to prevent. A wildcard is rejected for a related reason: zenoh binds every interface but reports a concrete locator, which fails the #1858 listener verification and silently drops the `DORA_ZENOH_CONNECT` injection local nodes depend on. Bindability is probed at startup so a typo'd address fails immediately rather than after the coordinator retry loop. A remote coordinator that yields no routable address warns instead of quietly binding loopback.

## Measured (zenoh 1.9.0)

NAT simulated by giving leaves no listen endpoints — an unlistening session is undialable, which is precisely a NAT'd daemon's property. 5 messages, leaf A → leaf B through a hub:

| hub | leaves | gateway | delivered |
|---|---|---|---|
| peer | peer | none — **dora today** | **0/5** |
| **router** | peer | none | **0/5** |
| peer | client | none | 5/5 |
| **peer** | peer | 2 subregions | **5/5** |
| router | peer | 1 subregion | 0/5 |

**Why the breakage starts at 3 machines.** With `--zenoh-peer`, the rendezvous endpoint goes into *both* the hub's listen and connect lists, so the hub daemon already advertised a routable locator — 2-daemon setups worked. The spokes only ever had loopback locators, so spoke↔spoke links could never form, and with peer relaying gone in 1.9 there is no hub to fall back through. So the failure is invisible at 2 machines and appears at 3.

Worth flagging: **a router does not fix this** — 1.9 removed peer failover brokering, so peers under a router in one region relay nothing. `examples/multiple-daemons/README.md` currently recommends exactly that for the NAT case; it's wrong there and needs a separate fix. The discriminator is the subregion split, not the hub's mode.

Once leaves are dialable — what this PR makes true — the relay is unnecessary and the clique forms: gossip-only **10/10**, explicit mesh **10/10** over 10 rounds each.

## Scope

Makes daemons **dialable**. Does not change how they **discover** each other: multicast on a LAN, or the `--zenoh-peer` rendezvous.

Daemon↔daemon links are the right layer to fix, and nodes correctly stay on loopback (`spawner.rs`): node output crosses machines by daemon-level application forwarding — `send_out` serializes an `InterDaemonEvent::Output` onto `zenoh_daemon_control_topic`, and the peer daemon subscribes and fans out locally. That is one daemon↔daemon hop, which needs no relaying. Zenoh rejects `connect/endpoints` updates on an open session (`updating config is only supported for keys starting with 'plugins/'`), so a daemon's peer set is fixed at session open and cannot be distributed by the coordinator at spawn time — which rules out the tidier design and leaves gossip as the only dynamic mechanism today.

Known gaps, deliberately not addressed here:

- **Gossip is still best-effort.** #2716 measured it failing 5/20 at the node tier and chose explicit dialing instead; my 10/10 daemon probe doesn't refute that at a 10-sample size with a generous settle. Whether the daemon tier needs the same explicit treatment (a `cluster.yml` peer list, requiring a known port per machine) wants measurement first.
- **The 3-machine claim has a mechanism but no end-to-end test.** It rests on a code fact (the listener binds `Ipv4Addr::LOCALHOST`), a measurement (undialable leaves under a peer hub deliver 0/5), and the hub/spoke asymmetry above. Three real machines would close it.
- **`cluster.yml` cannot set `--zenoh-listen`.** `dora cluster up`/`install` build the daemon command line with `--zenoh-peer` only, so a multi-homed cluster machine has no override short of editing the systemd unit. `machines[].host` is by construction an address the operator can reach that machine on, so it's the natural value — deferred to the follow-up that adds the explicit peer list, where the host/port surface gets designed once rather than twice.
- CLAUDE.md wants a smoke test for a new CLI flag; `--zenoh-listen` has unit tests on the extracted helpers but nothing driving it through the daemon, since a meaningful test needs two machines.

## Verification

`cargo fmt --check`, `cargo clippy --all -D warnings`, full workspace tests (117 suites, 0 failures), `cargo check --examples`. Unit tests in `dora-core` cover the wildcard rejection and the source-address filter directly. Against the built CLI: a wildcard and a typo'd address (`10.0.0.99`) each fail immediately with the OS error attached; a valid local address starts and logs the bind; a loopback coordinator is unchanged.

`Daemon::run` and `run_with_builds` keep their published signatures as delegating wrappers, with `run_with_zenoh_listen` added alongside — no semver break.

Follows #2716. Part of #2715.
