### PR TITLE
ci: bump pinned Rust toolchain to 1.97.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ commands:
     parameters:
       version:
         type: string
-        default: "1.92.0"
+        default: "1.97.1"
       components:
         type: string
         default: ""
@@ -55,7 +55,7 @@ commands:
     parameters:
       version:
         type: string
-        default: "1.92.0"
+        default: "1.97.1"
     steps:
       - run:
           name: Install Rust << parameters.version >>
@@ -130,7 +130,7 @@ executors:
   # Note: upgrade to xlarge if your plan supports it for faster builds.
   linux:
     docker:
-      - image: cimg/rust:1.92.0
+      - image: cimg/rust:1.97.1
     resource_class: large
     environment:
       CARGO_TERM_COLOR: always
@@ -138,7 +138,7 @@ executors:
   # Moderate compilation (clippy, bench, cross-check)
   linux-large:
     docker:
-      - image: cimg/rust:1.92.0
+      - image: cimg/rust:1.97.1
     resource_class: large
     environment:
       CARGO_TERM_COLOR: always
@@ -146,7 +146,7 @@ executors:
   # Light compilation or tool-only jobs
   linux-medium:
     docker:
-      - image: cimg/rust:1.92.0
+      - image: cimg/rust:1.97.1
     resource_class: medium
     environment:
       CARGO_TERM_COLOR: always
@@ -166,7 +166,7 @@ executors:
     resource_class: large
     environment:
       CARGO_TERM_COLOR: always
-      RUST_VERSION: "1.92.0"
+      RUST_VERSION: "1.97.1"
 
 # ────────────────────────────────────────────────────────────────────
 # Jobs
@@ -378,7 +378,7 @@ jobs:
     steps:
       - checkout
       - install-rust:
-          version: "1.92.0"
+          version: "1.97.1"
       - cargo-cache-restore:
           prefix: cargo-macos
       - run:
@@ -471,7 +471,7 @@ jobs:
     steps:
       - checkout
       - install-rust:
-          version: "1.92.0"
+          version: "1.97.1"
       - cargo-cache-restore:
           prefix: cargo-macos-examples
       - run:
@@ -519,7 +519,7 @@ jobs:
     steps:
       - checkout
       - install-rust-windows:
-          version: "1.92.0"
+          version: "1.97.1"
       - cargo-cache-restore:
           prefix: cargo-win-examples-heavy
       - run:
@@ -737,7 +737,7 @@ jobs:
     steps:
       - checkout
       - install-rust:
-          version: "1.92.0"
+          version: "1.97.1"
       - cargo-cache-restore:
           prefix: cargo-macos-cli
       - run:
@@ -952,11 +952,11 @@ jobs:
         type: string
         default: ""
     docker:
-      - image: cimg/rust:1.92.0
+      - image: cimg/rust:1.97.1
     resource_class: << parameters.resource >>
     environment:
       CARGO_TERM_COLOR: always
-      # Mirror the GHA nightly env at nightly.yml:1335. cimg/rust:1.92.0
+      # Mirror the GHA nightly env at nightly.yml:1335. cimg/rust:1.97.1
       # ships Python < 3.11, which fails pyo3-build-config 0.28+'s
       # interpreter-vs-abi3-minimum check. abi3 metadata is already
       # baked in via the workspace `abi3-py311` feature.
@@ -1000,7 +1000,7 @@ jobs:
     steps:
       - checkout
       - install-rust:
-          version: "1.92.0"
+          version: "1.97.1"
           targets: << parameters.target >>
       - cargo-cache-restore:
           prefix: cross-macos-<< parameters.target >>
@@ -1024,7 +1024,7 @@ jobs:
     resource_class: large
     environment:
       CARGO_TERM_COLOR: always
-      RUST_VERSION: "1.92.0"
+      RUST_VERSION: "1.97.1"
       # cross-rs Docker images ship Python 3.10, below our abi3-py311
       # minimum. Disable the interpreter probe (same as the GHA nightly
       # at nightly.yml:1335) AND pass the env through to the container
@@ -1035,7 +1035,7 @@ jobs:
     steps:
       - checkout
       - install-rust:
-          version: "1.92.0"
+          version: "1.97.1"
       - cargo-cache-restore:
           prefix: cross-<< parameters.target >>
       - run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  # Pin Rust to 1.92 until static_init (zenoh-shm dep) is fixed for 1.94+
-  RUST_VERSION: "1.92.0"
+  RUST_VERSION: "1.97.1"
   # Drop full debuginfo from dev/test builds. Debug info is ~78% of every
   # compiled artifact in this large workspace; full-debuginfo builds overrun
   # the runner disk during `cargo test` ("No space left on device").

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,7 +51,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: "1.92.0"
+  RUST_VERSION: "1.97.1"
   # The finish-straggler watchdog (dora-rs/dora#2270) is now on by default, so
   # the explicit DORA_FINISH_DRAIN_GRACE_SECS override added for the step-2
   # nightly bake is no longer needed — nightly now exercises the default-on

--- a/.github/workflows/pip-release.yml
+++ b/.github/workflows/pip-release.yml
@@ -29,8 +29,8 @@ on:
       - "trunk-merge/**"
 
 env:
-  RUST_VERSION: "1.92.0"
-  RUST_TOOLCHAIN_DIR: "1.92.0-x86_64-unknown-linux-gnu"
+  RUST_VERSION: "1.97.1"
+  RUST_TOOLCHAIN_DIR: "1.97.1-x86_64-unknown-linux-gnu"
   # The workspace pins PyO3's abi3 floor to Python 3.11.
   PYTHON_VERSION: "3.11"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  # Pin Rust to 1.92 until static_init (zenoh-shm dep) is fixed for 1.94+
-  RUST_VERSION: "1.92.0"
+  RUST_VERSION: "1.97.1"
 
 jobs:
   # ── 1. Publish Rust crates to crates.io ──────────────────────────────────

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,7 +184,7 @@ The deeper QA gates — `make qa-full`, `make qa-deep`, `make qa-nightly`, `make
 - Supply-chain audit (`cargo-audit` + `cargo-deny`)
 - Unwrap-budget check (production `.unwrap()` / `.expect(` ratchet)
 - License check (`cargo-lichking`)
-- Rust toolchain pinned to 1.92 (see `.github/workflows/ci.yml`)
+- Rust toolchain pinned to 1.97.1 (see `.github/workflows/ci.yml`)
 
 **Nightly CI (`.github/workflows/nightly.yml`, ~3-4h, daily 06:40 UTC):** Broader coverage, does NOT block PRs. Auto-files an issue on failure (`nightly-regression` label).
 - Test on macOS + Windows

--- a/apis/rust/node/src/daemon_connection/json_to_arrow.rs
+++ b/apis/rust/node/src/daemon_connection/json_to_arrow.rs
@@ -41,7 +41,7 @@ fn wrapped(data: impl BufRead) -> impl BufRead {
 
 // wrap data into JSON object to also allow bare JSON values
 fn wrapped_quoted(data: impl BufRead) -> impl BufRead {
-    let quoted = [b'"'].chain(data).chain([b'"'].as_slice());
+    let quoted = "\"".as_bytes().chain(data).chain("\"".as_bytes());
     wrapped(quoted)
 }
 

--- a/binaries/cli/src/command/hub/fetch.rs
+++ b/binaries/cli/src/command/hub/fetch.rs
@@ -225,7 +225,7 @@ fn clone_pinned(source: &GitSource, target_dir: &std::path::Path) -> eyre::Resul
     run_git_in(&dest, &["checkout", "--quiet", &source.commit_hash])
         .with_context(|| format!("failed to checkout `{}`", source.commit_hash))?;
     let _ = std::fs::write(&marker, b"");
-    println!("  {} @ {}", source.repo, &source.commit_hash);
+    println!("  {} @ {}", source.repo, source.commit_hash);
     Ok(())
 }
 

--- a/binaries/cli/src/template/python/mod.rs
+++ b/binaries/cli/src/template/python/mod.rs
@@ -43,13 +43,13 @@ fn create_custom_node(
     let root = path.unwrap_or_else(|| PathBuf::from(name.replace(" ", "-")));
     let module_path = root.join(name.replace(" ", "_").replace("-", "_"));
     fs::create_dir(&root)
-        .with_context(|| format!("failed to create root directory `{}`", &root.display()))?;
+        .with_context(|| format!("failed to create root directory `{}`", root.display()))?;
 
     fs::create_dir(&module_path)
-        .with_context(|| format!("failed to create module directory `{}`", &root.display()))?;
+        .with_context(|| format!("failed to create module directory `{}`", root.display()))?;
 
     fs::create_dir(root.join("tests"))
-        .with_context(|| format!("failed to create tests directory `{}`", &root.display()))?;
+        .with_context(|| format!("failed to create tests directory `{}`", root.display()))?;
 
     // PYPROJECT.toml
     let node_path = root.join("pyproject.toml");

--- a/binaries/daemon/src/spawn/command.rs
+++ b/binaries/daemon/src/spawn/command.rs
@@ -184,7 +184,7 @@ pub(super) async fn path_spawn_command(
                             .log(
                                 LogLevel::Info,
                                 Some("spawner".into()),
-                                format!("spawning: {:?} -u {}", &python, resolved_path.display()),
+                                format!("spawning: {python:?} -u {}", resolved_path.display()),
                             )
                             .await;
 

--- a/docker/ros2dev/Dockerfile
+++ b/docker/ros2dev/Dockerfile
@@ -7,10 +7,10 @@
 # Never split dora and ROS2 across containers: Docker Desktop for Mac has no
 # host networking to macOS and drops multicast SPDP, so discovery silently fails.
 #
-# Pins match CI: ROS2 Humble, Rust 1.92.0, Python 3.12.
+# Pins match CI: ROS2 Humble, Rust 1.97.1, Python 3.12.
 FROM ros:humble
 
-ARG RUST_VERSION=1.92.0
+ARG RUST_VERSION=1.97.1
 
 ENV DEBIAN_FRONTEND=noninteractive \
     RUSTUP_HOME=/usr/local/rustup \

--- a/examples/rust-dynamic-add-remove/sender/src/main.rs
+++ b/examples/rust-dynamic-add-remove/sender/src/main.rs
@@ -12,12 +12,7 @@ fn main() -> eyre::Result<()> {
 
     while let Some(event) = events.recv() {
         match event {
-            Event::Input {
-                id,
-                metadata,
-                data: _,
-                ..
-            } if id.as_str() == "tick" => {
+            Event::Input { id, metadata, .. } if id.as_str() == "tick" => {
                 let payload = counter.into_arrow();
                 node.send_output(output.clone(), metadata.parameters, payload)?;
                 counter = counter.wrapping_add(1);

--- a/libraries/extensions/ros2-bridge/arrow/src/serialize/mod.rs
+++ b/libraries/extensions/ros2-bridge/arrow/src/serialize/mod.rs
@@ -52,13 +52,13 @@ impl serde::Serialize for TypedValue<'_> {
         })?;
         for column_name in input.column_names() {
             if !message.members.iter().any(|m| m.name == column_name) {
-                return Err(error(format!(
+                Err(error(format!(
                     "given struct has unknown field {column_name}"
                 )))?;
             }
         }
         if input.len() > 1 {
-            return Err(error(format!(
+            Err(error(format!(
                 "expected single struct instance, got struct array with {} entries",
                 input.len()
             )))?;


### PR DESCRIPTION
Bumps the pinned Rust toolchain from 1.92.0 to 1.97.1 (current stable) across the four GitHub workflows, `.circleci/config.yml`, and `docker/ros2dev/Dockerfile`.

The pin was held by a comment reading "Pin Rust to 1.92 until static_init (zenoh-shm dep) is fixed for 1.94+". That described the `static_init` 1.0.3 bug; it was fixed in 1.0.4, which `Cargo.lock` already carries. Verified locally: `static_init` 1.0.4 and `zenoh-shm` 1.9.0 both build (full codegen, not just `check`) on 1.97.1, so the pin and its now-misleading comment are removed rather than carried forward.

The jump surfaced four lints that 1.97's clippy newly flags under `-D warnings` — `useless_borrows_in_formatting`, `needless_return_with_question_mark`, `unneeded_wildcard_pattern`, and `byte_char_slices` — fixed mechanically across six files with no behavior change. In `json_to_arrow.rs` the byte-slice literal is written as `"\"".as_bytes()` to match the idiom on the adjacent line rather than clippy's suggestion, which needs parens to compile.

MSRV (`rust-version = "1.88.0"`) is deliberately unchanged, so downstream users on older compilers are unaffected; every edit is well within it.

Green locally on 1.97.1: `clippy --all -- -D warnings` (`--keep-going`, exit 0), `fmt --all --check`, `cargo check --examples`, and `cargo test --all` (1363 passed / 117 suites / 0 failed).

`docs/qa-baseline-2026-04-07.md` still reads "CI toolchain | 1.92" — left as-is, since it is a dated point-in-time snapshot rather than live config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
