### PR TITLE
refactor(ros2-bridge): remove vestigial ActionT/MessageT traits

### DIFF
--- a/libraries/extensions/ros2-bridge/src/_core/mod.rs
+++ b/libraries/extensions/ros2-bridge/src/_core/mod.rs
@@ -6,4 +6,4 @@ pub mod traits;
 
 pub use sequence::{FFISeq, OwnedFFISeq, RefFFISeq};
 pub use string::{FFIString, FFIWString, OwnedFFIString, OwnedFFIWString};
-pub use traits::{ActionT, FFIFromRust, FFIToRust, InternalDefault, MessageT};
+pub use traits::{FFIFromRust, FFIToRust, InternalDefault};

--- a/libraries/extensions/ros2-bridge/src/_core/traits.rs
+++ b/libraries/extensions/ros2-bridge/src/_core/traits.rs
@@ -3,20 +3,6 @@ use std::convert::TryInto;
 use super::string::U16String;
 use array_init::array_init;
 
-pub trait MessageT: Default + Send + Sync {
-    type Raw: FFIToRust<Target = Self> + Send + Sync;
-    type RawRef: FFIFromRust<From = Self>;
-}
-
-pub trait ActionT: Send {
-    type Goal: MessageT;
-    type Result: MessageT;
-    type Feedback: MessageT;
-    type SendGoal;
-    type GetResult;
-    type FeedbackMessage: MessageT;
-}
-
 // I was going to use `std::default::Default`, however generic arrays do not implement `std::default::Default`.
 pub trait InternalDefault {
     fn _default() -> Self;


### PR DESCRIPTION
> ⚠️ **Auto-generated by Claude.** This PR was produced by an automated dead-code sweep run by Claude (via Claude Code), not hand-authored by @phil-opp. Please review accordingly before merging.

## What

Remove the `_core::MessageT` and `_core::ActionT` traits from the ros2-bridge FFI runtime module (`src/_core/traits.rs`) and their re-export in `src/_core/mod.rs`.

## Why

Both traits are **dead code** — never implemented anywhere in the workspace:

- `impl MessageT for …` / `impl ActionT for …` → **zero occurrences** workspace-wide.
- `MessageT` was referenced only by `ActionT`'s associated-type bounds and the `_core/mod.rs` re-export.
- `ActionT` had no implementors at all. (The `ActionT`-looking hits elsewhere are `ros2_client::ActionTypes`, a different trait.)

The actual message/action machinery is driven by `ros2_client::Message` and `ros2_client::ActionTypes` (emitted by `msg-gen`), so these two traits are leftovers from a pre-cxx design.

The `FFIToRust` / `FFIFromRust` traits that `MessageT` referenced in its bounds are **kept** — they still have live blanket/concrete impls.

## Verification

- `cargo check -p dora-ros2-bridge` — clean
- `cargo clippy -p dora-ros2-bridge -- -D warnings` — clean

This follows the same pattern as prior accepted ros2-bridge FFI-codegen cleanups (#2292, #2389).


---
_Generated by [Claude Code](https://claude.ai/code/session_014ngF9UtZM9E4Y5zn5UvtXq)_