### PR TITLE
refactor(ros2-bridge): remove unused as_slice FFI sequence accessors

### DIFF
--- a/libraries/extensions/ros2-bridge/src/_core/sequence.rs
+++ b/libraries/extensions/ros2-bridge/src/_core/sequence.rs
@@ -11,11 +11,6 @@ pub struct FFISeq<T> {
 }
 
 impl<T> FFISeq<T> {
-    /// Extracts a slice.
-    pub fn as_slice(&self) -> &[T] {
-        self
-    }
-
     /// Returns the length of the sequence.
     pub const fn len(&self) -> usize {
         self.size
@@ -88,11 +83,6 @@ pub struct OwnedFFISeq<T> {
 }
 
 impl<T> OwnedFFISeq<T> {
-    /// Extracts a slice.
-    pub fn as_slice(&self) -> &[T] {
-        unsafe { std::slice::from_raw_parts(self.data, self.len()) }
-    }
-
     /// Returns the length of the sequence.
     pub const fn len(&self) -> usize {
         self.size
@@ -150,11 +140,6 @@ pub struct RefFFISeq<T> {
 }
 
 impl<T> RefFFISeq<T> {
-    /// Extracts a slice.
-    pub fn as_slice(&self) -> &[T] {
-        unsafe { std::slice::from_raw_parts(self.data, self.len()) }
-    }
-
     /// Returns the length of the sequence.
     pub const fn len(&self) -> usize {
         self.size


### PR DESCRIPTION
> ⚠️ **Auto-generated by Claude.** This PR was produced by an automated dead-code sweep run by Claude (via Claude Code), not hand-authored by @phil-opp. Please review accordingly before merging.

## What

Remove `FFISeq::as_slice`, `OwnedFFISeq::as_slice`, and `RefFFISeq::as_slice` from the ros2-bridge `_core` FFI runtime module (`src/_core/sequence.rs`).

## Why

None of the three `as_slice` methods have any caller in the workspace. The only `.as_slice()` call sites inside the crate are on `Vec` values (`build.rs`, `arrow/src/serialize/defaults.rs`), not on these FFI sequence types.

`FFISeq` additionally already exposes the exact same slice view via its `Deref<Target = [T]>` and `AsRef<[T]>` impls, so its `as_slice` was doubly redundant. Those impls are retained.

The `len` / `is_empty` companion methods on each type are **kept** unchanged.

## Verification

- `cargo check -p dora-ros2-bridge` — clean
- `cargo clippy -p dora-ros2-bridge -- -D warnings` — clean (no `len_without_is_empty`, since `is_empty` remains)


---
_Generated by [Claude Code](https://claude.ai/code/session_014ngF9UtZM9E4Y5zn5UvtXq)_