### PR TITLE
refactor(daemon): remove unused Daemon::run / run_with_builds entry points

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -615,27 +615,7 @@ impl ZenohBind {
 }
 
 impl Daemon {
-    /// Derives the zenoh listen address from `coordinator_ws_addr`; see
-    /// [`Daemon::run_with_zenoh_listen`] to override it.
-    pub async fn run(
-        coordinator_ws_addr: SocketAddr,
-        machine_id: Option<String>,
-        labels: BTreeMap<String, String>,
-        local_listen_port: u16,
-        inter_daemon_peer: Option<String>,
-    ) -> eyre::Result<()> {
-        Self::run_with_zenoh_listen(
-            coordinator_ws_addr,
-            machine_id,
-            labels,
-            local_listen_port,
-            inter_daemon_peer,
-            None,
-        )
-        .await
-    }
-
-    /// Like [`Daemon::run`], but `zenoh_listen_addr` overrides the address this
+    /// Runs the daemon. `zenoh_listen_addr` overrides the address this
     /// daemon's zenoh listener binds, and therefore the locator its peers are
     /// told to dial.
     ///
@@ -661,28 +641,6 @@ impl Daemon {
             inter_daemon_peer,
             zenoh_listen_addr,
             Default::default(),
-        )
-        .await
-    }
-
-    /// Derives the zenoh listen address from `coordinator_ws_addr`; see
-    /// [`Daemon::run_with_zenoh_listen`] to override it.
-    pub async fn run_with_builds(
-        coordinator_ws_addr: SocketAddr,
-        machine_id: Option<String>,
-        labels: BTreeMap<String, String>,
-        local_listen_port: u16,
-        inter_daemon_peer: Option<String>,
-        initial_builds: BTreeMap<BuildId, BuildInfo>,
-    ) -> eyre::Result<()> {
-        Self::run_inner_with_builds(
-            coordinator_ws_addr,
-            machine_id,
-            labels,
-            local_listen_port,
-            inter_daemon_peer,
-            None,
-            initial_builds,
         )
         .await
     }
@@ -1155,7 +1113,7 @@ impl Daemon {
     ) -> eyre::Result<DaemonRunResult> {
         // Single-shot path (`dora run`): build the daemon and run one event
         // loop. The reconnecting daemon binary instead builds the daemon once
-        // and reuses it across reconnects (see `run_with_builds`), so that node
+        // and reuses it across reconnects (see `run_inner_with_builds`), so that node
         // processes are not killed when the coordinator connection drops.
         // `dora run` is single-machine by construction: the daemon, its nodes
         // and the in-process coordinator all live on this host, so loopback is
@@ -1477,7 +1435,7 @@ impl Daemon {
 
                         if self.last_coordinator_heartbeat.elapsed() > Duration::from_secs(20) {
                             // Return error to trigger the reconnection loop in
-                            // `run_with_builds`. Because `run_inner` borrows
+                            // `run_inner_with_builds`. Because `run_inner` borrows
                             // `&mut self`, this error does NOT drop the daemon:
                             // running nodes and their `ProcessHandle`s survive,
                             // and the next reconnect re-adopts them


### PR DESCRIPTION
> ⚠️ **Auto-generated by Claude.** This PR was produced by an automated dead-code sweep run by Claude (via Claude Code), not hand-authored by @phil-opp. Please review accordingly before merging.

## What

Remove two unused public entry-point wrappers on `Daemon` (`binaries/daemon/src/lib.rs`):

- `Daemon::run` — forwards to `run_with_zenoh_listen(.., None)`
- `Daemon::run_with_builds` — forwards to `run_inner_with_builds(.., None, initial_builds)`

## Why

Neither wrapper is called anywhere in the workspace (src, tests, benches, examples):

- `rg 'Daemon::run\b|Self::run\b'` → only a doc-comment reference.
- `rg 'run_with_builds'` → only the definition plus two explanatory comments.

The daemon binary and `dora run` both start the daemon via `run_with_zenoh_listen` (`binaries/cli/src/command/daemon.rs`), and the reconnect loop with build reuse lives in `run_inner_with_builds`. Both removed wrappers only delegated to those still-used inner functions, so behavior is unchanged.

Two stale references that pointed at the removed functions (an intra-doc link on `run_with_zenoh_listen` and two `// see run_with_builds` comments) are updated to point at the surviving functions.

This mirrors the previously-merged removal of the coordinator's unused `start_testing` entry point.

## Verification

- `cargo clippy -p dora-daemon -- -D warnings` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_014ngF9UtZM9E4Y5zn5UvtXq)_