### PR TITLE
refactor(coordinator): remove dead ControlEvent::Error variant

### DIFF
--- a/binaries/coordinator/src/control.rs
+++ b/binaries/coordinator/src/control.rs
@@ -42,11 +42,4 @@ pub enum ControlEvent {
         subscription_id: Uuid,
         done_tx: oneshot::Sender<()>,
     },
-    Error(eyre::Report),
-}
-
-impl From<eyre::Report> for ControlEvent {
-    fn from(err: eyre::Report) -> Self {
-        ControlEvent::Error(err)
-    }
 }

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -1894,7 +1894,6 @@ async fn start_inner(
                         }
                     }
                 }
-                ControlEvent::Error(err) => tracing::error!("{err:?}"),
                 ControlEvent::LogSubscribe {
                     dataflow_id,
                     level,


### PR DESCRIPTION
> ⚠️ **Auto-generated by Claude.** This PR was produced by an automated dead-code sweep run by Claude (via Claude Code), not hand-authored by @phil-opp. Please review accordingly before merging.

## What

Remove the `ControlEvent::Error(eyre::Report)` variant (`binaries/coordinator/src/control.rs`), its sole constructor `impl From<eyre::Report> for ControlEvent`, and the now-unreachable match arm in the coordinator event loop (`lib.rs`).

## Why

The `Error` variant is constructed **only** inside the `From<eyre::Report>` impl, and that impl is never invoked anywhere in the workspace:

- No function in the crate returns `ControlEvent` as an error type (the control channel is `mpsc::Sender<Event>`, not `mpsc::Sender<ControlEvent>`), so no `?` ever converts into it.
- `rg 'ControlEvent::from|: ControlEvent =|Result<.., ControlEvent>'` → no matches.
- `rg 'ControlEvent::Error'` (whole workspace) → only the constructor inside the `From` impl and the single `tracing::error!` match arm.

So the variant is matched but never constructed — dead code. This is the task's classic "matched-but-never-constructed" case, mirroring the previously-merged `NodeMetricsExpire` cleanup.

## Verification

- `cargo clippy -p dora-coordinator -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_014ngF9UtZM9E4Y5zn5UvtXq)_