### PR TITLE
refactor(coordinator): remove unused PartialEq/Eq for RunningDataflow

### DIFF
--- a/binaries/coordinator/src/state.rs
+++ b/binaries/coordinator/src/state.rs
@@ -588,14 +588,6 @@ impl From<&RunningDataflow> for ArchivedDataflow {
     }
 }
 
-impl PartialEq for RunningDataflow {
-    fn eq(&self, other: &Self) -> bool {
-        self.name == other.name && self.uuid == other.uuid && self.daemons == other.daemons
-    }
-}
-
-impl Eq for RunningDataflow {}
-
 #[cfg(test)]
 mod hub_capability_tests {
     use super::*;


### PR DESCRIPTION
> ⚠️ **Auto-generated by Claude.** This PR was produced by an automated dead-code sweep run by Claude (via Claude Code), not hand-authored by @phil-opp. Please review accordingly before merging.

## What

Remove the hand-written `impl PartialEq for RunningDataflow` and `impl Eq for RunningDataflow` from `binaries/coordinator/src/state.rs`.

## Why

`RunningDataflow` is only ever stored as a `HashMap<DataflowId, RunningDataflow>` *value*, which requires neither `PartialEq` nor `Eq`. Workspace-wide there is:

- no whole-value `RunningDataflow == RunningDataflow` comparison (every dataflow equality check compares an individual field such as `.uuid` / `.name`),
- no `HashSet<RunningDataflow>` / `BTreeSet<RunningDataflow>` / `dedup`,
- no other type that derives `PartialEq`/`Eq` while containing a `RunningDataflow`.

Both impls are therefore dead.

## Verification

- `cargo clippy -p dora-coordinator --tests -- -D warnings` — clean (the `--tests` build confirms no `#[cfg(test)]` `assert_eq!` relied on the impls)


---
_Generated by [Claude Code](https://claude.ai/code/session_014ngF9UtZM9E4Y5zn5UvtXq)_