### PR TITLE
fix(coordinator): don't double-list partially-finished multi-daemon dataflows

### DIFF
--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -1090,8 +1090,20 @@ async fn start_inner(
                                 },
                                 status: DataflowStatus::Running,
                             });
-                            let finished_failed =
-                                dataflow_results.iter().map(|(&uuid, results)| {
+                            let finished_failed = dataflow_results
+                                .iter()
+                                // A multi-daemon dataflow appears in
+                                // `dataflow_results` as soon as its *first*
+                                // daemon finishes, while it stays in
+                                // `running_dataflows` until the last daemon is
+                                // gone. Skip those still-running entries so a
+                                // partially-finished dataflow isn't listed
+                                // twice (once Running, once Finished/Failed) —
+                                // and isn't reported Finished while other
+                                // daemons are still executing it. Mirrors the
+                                // guard in the `Clean` handler below.
+                                .filter(|(uuid, _)| !running_dataflows.contains_key(*uuid))
+                                .map(|(&uuid, results)| {
                                     let name =
                                         archived_dataflows.get(&uuid).and_then(|d| d.name.clone());
                                     let id = DataflowIdAndName { uuid, name };


### PR DESCRIPTION
> **Machine-generated PR.** This change was written by Claude (an AI agent) as part of an automated code-review pass. Please review carefully before merging.

## Issue

The `ControlRequest::List` handler builds one entry per `running_dataflows` value **and** one per `dataflow_results` key, with no dedup between them:

```rust
let running = dataflows.into_iter().map(...);          // from running_dataflows
let finished_failed = dataflow_results.iter().map(...); // from dataflow_results
running.chain(finished_failed).collect()
```

For a multi-daemon dataflow, `dataflow_results` gains an entry as soon as its **first** daemon reports `DataflowFinishedOnDaemon`, while the dataflow stays in `running_dataflows` until the **last** daemon is gone. During that window `dora list` shows the dataflow **twice**: once as `Running` and once as `Finished`/`Failed`.

Worse: if the first daemon exited cleanly, `results.values().all(is_ok)` is `true`, so the dataflow is reported **`Finished` while it is still actively running** on the other daemons.

## Fix

Filter the `finished_failed` iterator to skip entries still present in `running_dataflows`:

```rust
.filter(|(uuid, _)| !running_dataflows.contains_key(*uuid))
```

This mirrors the guard the sibling `ControlRequest::Clean` handler already applies (and documents in detail) for exactly this partially-finished situation — the `List` path simply lacked the same guard.

## Validation

- `cargo clippy -p dora-coordinator -- -D warnings` — clean.
- `cargo test -p dora-coordinator --test ws_control_tests` — 22 passed (incl. `control_list_empty`).
- `cargo fmt` — clean.

A dedicated regression test would require standing up a two-daemon dataflow and pausing between daemon completions; the fix is a one-line guard that restores symmetry with the already-tested `Clean` handler, so I relied on that coverage plus the existing List tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUCqQZRYLeDFJYK8UkBLca)_