### PR TITLE
fix(daemon): don't poison the shared metrics System on serialization error

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -499,11 +499,11 @@ async fn collect_and_send_metrics_bg(
                 // Skip this dataflow's batch rather than `?`-returning: an early
                 // return here would bypass the `System` restore below, leaving
                 // the shared metrics `System` (moved out via `mem::take`) empty
-                // for the rest of the process and degrading every later CPU
-                // reading. `serde_json` rejects non-finite floats, and
-                // `cpu_usage` is an `f32` from sysinfo, so one NaN must not
-                // poison collection permanently. Matches the `send_event`
-                // failure handling just below.
+                // until the next successful collection repopulates it.
+                // Serialization of this structure is effectively infallible, so
+                // this is defense-in-depth — `continue` just keeps the cleanup
+                // path unconditional against any future error here. Matches the
+                // `send_event` failure handling just below.
                 Err(e) => {
                     tracing::warn!("failed to serialize metrics for dataflow: {e}");
                     continue;

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -484,7 +484,7 @@ async fn collect_and_send_metrics_bg(
                     None
                 }
             };
-            let msg = serde_json::to_vec(&Timestamped {
+            let msg = match serde_json::to_vec(&Timestamped {
                 inner: CoordinatorRequest::Event {
                     daemon_id: daemon_id.clone(),
                     event: DaemonEvent::NodeMetrics {
@@ -494,7 +494,21 @@ async fn collect_and_send_metrics_bg(
                     },
                 },
                 timestamp: clock.new_timestamp(),
-            })?;
+            }) {
+                Ok(msg) => msg,
+                // Skip this dataflow's batch rather than `?`-returning: an early
+                // return here would bypass the `System` restore below, leaving
+                // the shared metrics `System` (moved out via `mem::take`) empty
+                // for the rest of the process and degrading every later CPU
+                // reading. `serde_json` rejects non-finite floats, and
+                // `cpu_usage` is an `f32` from sysinfo, so one NaN must not
+                // poison collection permanently. Matches the `send_event`
+                // failure handling just below.
+                Err(e) => {
+                    tracing::warn!("failed to serialize metrics for dataflow: {e}");
+                    continue;
+                }
+            };
             if let Err(e) = sender.send_event(&msg).await {
                 tracing::warn!("failed to send metrics for dataflow: {e}");
                 continue;


### PR DESCRIPTION
> **Machine-generated PR.** This change was written by Claude (an AI agent) as part of an automated code-review pass. Please review carefully before merging.

## Context

`collect_and_send_metrics_bg` moves the shared sysinfo `System` out of its mutex with `mem::take` (leaving a default-empty one behind), refreshes it on a blocking thread, and restores it to the mutex **only after** the per-dataflow send loop:

```rust
let sys = std::mem::take(&mut *guard);   // shared System now empty
// ... refresh ...
for df in &dataflows {
    let msg = serde_json::to_vec(&Timestamped { ... })?;   // <-- early return skips restore
    // ...
}
// restore sys to the mutex   <-- bypassed if the `?` fires
```

The `?` inside the loop early-returns on a serialization error, bypassing the restore below and leaving the shared `System` empty. Every subsequent collection would then refresh a fresh `System`, losing the CPU-usage baseline until the mutex is repopulated.

## Fix

Handle the serialization error with `continue` (matching the `send_event` failure immediately below it) so the loop always runs to completion and the `System` is returned to the mutex.

## Note on severity

This is **defense-in-depth, not a live bug**. Serializing this structure is effectively infallible: all fields are scalars/strings/vecs, the map keys are `String` (via `NodeId`), and `to_vec` writes to a `Vec` with no I/O-error path. In particular `serde_json` encodes non-finite floats (`NaN`/`Inf`) as `null` rather than erroring, so a bad `cpu_usage` value cannot trigger this. The `?` here effectively never fires today — but propagating it would skip the `System` restore, and any future `?` added to this loop would reintroduce the same hazard, so making the cleanup path unconditional is worthwhile.

## Validation

- `cargo clippy -p dora-daemon -- -D warnings` — clean.
- `cargo test -p dora-daemon --lib` — 100 passed.
- `cargo fmt` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUCqQZRYLeDFJYK8UkBLca)_
