### PR TITLE
fix(core): reject invalid operator ids instead of panicking during resolve

### DIFF
--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -106,6 +106,21 @@ fn node_is_dynamic(node: &ResolvedNode) -> bool {
         if matches!(n.source, NodeSource::Local) && n.path == DYNAMIC_SOURCE)
 }
 
+/// Build the fully-qualified output id `"{operator}/{output}"` for an input
+/// mapping that references a single-operator node.
+///
+/// `OperatorId` is not charset-validated on construction (unlike `NodeId` and
+/// `DataId`), so an operator `id` may contain characters that are illegal in a
+/// `DataId`. Parsing the concatenation fallibly turns such an id into a clean
+/// validation error instead of a panic — `DataId::from(String)` would
+/// otherwise abort descriptor validation (`dora check`, `dora run`, `dora
+/// graph`, ...) on well-formed-but-invalid YAML.
+fn qualified_operator_output(op_name: &OperatorId, output: &DataId) -> Result<DataId> {
+    format!("{op_name}/{output}").parse::<DataId>().wrap_err_with(|| {
+        format!("operator id `{op_name}` is not a valid data-id component (referenced in an input mapping as `{op_name}/{output}`)")
+    })
+}
+
 impl DescriptorExt for Descriptor {
     fn resolve_aliases_and_set_defaults(&self) -> eyre::Result<BTreeMap<NodeId, ResolvedNode>> {
         let default_op_id = OperatorId::from(SINGLE_OPERATOR_DEFAULT_ID.to_string());
@@ -128,7 +143,7 @@ impl DescriptorExt for Descriptor {
                     if let InputMapping::User(m) = &mut input.mapping
                         && let Some(op_name) = single_operator_nodes.get(&m.source).copied()
                     {
-                        m.output = DataId::from(format!("{op_name}/{}", m.output));
+                        m.output = qualified_operator_output(op_name, &m.output)?;
                     }
                 }
             }
@@ -154,7 +169,7 @@ impl DescriptorExt for Descriptor {
                 })
             {
                 if let Some(op_name) = single_operator_nodes.get(&mapping.source).copied() {
-                    mapping.output = DataId::from(format!("{op_name}/{}", mapping.output));
+                    mapping.output = qualified_operator_output(op_name, &mapping.output)?;
                 }
             }
 
@@ -767,6 +782,39 @@ nodes:
         assert_eq!(
             b_env.get("OTEL_ENDPOINT"),
             Some(&EnvValue::String("http://collector:4317".into()))
+        );
+    }
+
+    #[test]
+    fn resolve_rejects_operator_id_that_is_invalid_in_a_data_id() {
+        // Regression: `OperatorId` is not charset-validated, so an operator
+        // `id` may contain characters (e.g. a space) that are illegal in a
+        // `DataId`. When such an operator's output is referenced by another
+        // node, the alias resolver builds `"{op_id}/{output}"` as a `DataId`.
+        // Previously that used the panicking `DataId::from(String)`, so
+        // resolving/validating this (well-formed but invalid) YAML aborted the
+        // process instead of returning a clean error.
+        let yaml = r#"
+nodes:
+  - id: producer
+    operator:
+      id: "bad id"
+      python: op.py
+      outputs:
+        - out
+  - id: consumer
+    path: ./consumer
+    inputs:
+      x: producer/out
+"#;
+        let desc: Descriptor = serde_yaml::from_str(yaml).expect("parse");
+        let err = desc
+            .resolve_aliases_and_set_defaults()
+            .expect_err("invalid operator id must be a clean error, not a panic");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("bad id"),
+            "error should name the offending operator id, got: {msg}"
         );
     }
 


### PR DESCRIPTION
> **Machine-generated PR.** This change was written by Claude (an AI agent) as part of an automated code-review pass. Please review carefully before merging.

## Issue

`resolve_aliases_and_set_defaults` rewrites an input mapping that targets a single-operator node to the fully-qualified output `"{operator_id}/{output}"`, built via `DataId::from(String)`:

```rust
mapping.output = DataId::from(format!("{op_name}/{}", mapping.output));
```

Unlike `NodeId` and `DataId`, `OperatorId` performs **no charset validation** on construction (`FromStr` is `Infallible`, `Deserialize` is derived), so an operator `id` may contain characters that are illegal in a `DataId` (e.g. a space, or an empty id producing a leading slash). Because `DataId::from(String)` **panics** on an invalid id, resolving such a well-formed-but-invalid descriptor aborts the process instead of returning an error.

This is reachable from every validation entry point that calls `resolve_aliases_and_set_defaults` — `check_wiring`, `check_dataflow` (`dora check` / `dora run`), and `visualize` (`dora graph`). Example that panics today:

```yaml
nodes:
  - id: producer
    operator:
      id: "bad id"          # legal OperatorId, illegal DataId component
      python: op.py
      outputs: [out]
  - id: consumer
    path: ./consumer
    inputs:
      x: producer/out
```

→ `panicked at id.rs: invalid DataId 'bad id/out'`.

## Fix

Parse the concatenation fallibly via a small `qualified_operator_output` helper and propagate a descriptive `eyre` error (the function already returns `Result`):

```rust
fn qualified_operator_output(op_name: &OperatorId, output: &DataId) -> Result<DataId> {
    format!("{op_name}/{output}").parse::<DataId>().wrap_err_with(|| { ... })
}
```

## Validation

- New regression test `resolve_rejects_operator_id_that_is_invalid_in_a_data_id`. I confirmed it **panics** on the pre-fix code (`invalid DataId 'bad id/out'`) and returns a clean `Err` with the fix.
- `cargo test -p dora-core` — passes (one unrelated pre-existing failure, `topics::tests::ipv6_endpoints_are_bracketed`, is environmental — the sandbox has no IPv6 and it does not touch this diff).
- `cargo clippy -p dora-core -- -D warnings` and `cargo fmt` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUCqQZRYLeDFJYK8UkBLca)_