### PR TITLE
perf(daemon): skip per-message key clones in note_output_sent when maps empty

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -5289,7 +5289,13 @@ fn note_output_sent_to_local_receivers(
             .subscribe_channels
             .get(receiver_id)
             .is_some_and(|channel| channel.capacity() >= CONTROL_EVENT_HEADROOM);
+        // Looking up these maps requires cloning the `(NodeId, DataId)` key (the
+        // tuple key type can't borrow). Both maps are empty unless input
+        // deadlines or circuit breakers are configured, so skip the per-message
+        // key clone + hash in the common case — mirroring
+        // `send_output_to_local_receivers`.
         if receiver_keeping_up
+            && !dataflow.input_deadlines.is_empty()
             && let Some(deadline) = dataflow
                 .input_deadlines
                 .get_mut(&(receiver_id.clone(), input_id.clone()))
@@ -5310,6 +5316,12 @@ fn note_output_sent_to_local_receivers(
             continue;
         }
 
+        // `broken_inputs` is empty unless circuit breakers are configured, so
+        // skip the per-message `(NodeId, DataId)` key clone + hash + remove in
+        // the common case — mirroring `send_output_to_local_receivers`.
+        if dataflow.broken_inputs.is_empty() {
+            continue;
+        }
         let Some(timeout) = dataflow
             .broken_inputs
             .remove(&(receiver_id.clone(), input_id.clone()))


### PR DESCRIPTION
> **Machine-generated PR.** This change was written by Claude (an AI agent) as part of an automated code-review pass. Please review carefully before merging.

## Issue

`note_output_sent_to_local_receivers` runs once per local receiver per `OutputSent` event — a hot path. For every receiver it built a `(NodeId, DataId)` tuple key — cloning two `String`-backed ids — to probe `input_deadlines` (via `get_mut`) and `broken_inputs` (via `remove`):

```rust
if receiver_keeping_up
    && let Some(deadline) = dataflow.input_deadlines
        .get_mut(&(receiver_id.clone(), input_id.clone())) { ... }

let Some(timeout) = dataflow.broken_inputs
    .remove(&(receiver_id.clone(), input_id.clone())) else { continue; };
```

Both maps are empty unless input-timeout deadlines or circuit breakers are configured (the uncommon case), so these clones are pure waste in the common configuration.

## Fix

Guard both lookups with `!map.is_empty()`, so the common case pays no per-message clone or hash:

```rust
if receiver_keeping_up
    && !dataflow.input_deadlines.is_empty()
    && let Some(deadline) = ... { ... }

if dataflow.broken_inputs.is_empty() { continue; }
let Some(timeout) = ... .remove(...) else { continue; };
```

This mirrors the guards the sibling `send_output_to_local_receivers` already applies (and documents) for the same two maps. Behavior is unchanged: when a map is non-empty, the identical lookup runs.

## Validation

- `cargo clippy -p dora-daemon -- -D warnings` — clean.
- `cargo test -p dora-daemon --lib` — 100 passed (includes the circuit-breaker / input-deadline coverage).
- `cargo fmt` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUCqQZRYLeDFJYK8UkBLca)_