### PR TITLE
perf(daemon): build LogBroadcast metadata once instead of per subscriber

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -4596,6 +4596,23 @@ impl Daemon {
                     aligned_vec::AVec::from_slice(128, &ipc_bytes);
                 let data = Arc::new(DataMessage::Vec(sample));
 
+                // Build the metadata once and share the `Arc` across subscribers.
+                // It is identical for every delivery (only the `arrow-ipc`
+                // framing parameter), so rebuilding it (and re-allocating the
+                // `Arc`) per subscriber was wasted work — mirror the Timer/Logs
+                // broadcast loops, which build the `Arc<Metadata>` once.
+                let mut params = MetadataParameters::new();
+                params.insert(
+                    dora_message::metadata::FRAMING.to_string(),
+                    dora_message::metadata::Parameter::String(
+                        dora_message::metadata::FRAMING_ARROW_IPC.to_string(),
+                    ),
+                );
+                let metadata = Arc::new(metadata::Metadata::from_parameters(
+                    self.clock.new_timestamp(),
+                    params,
+                ));
+
                 let mut closed = Vec::new();
                 for sub in &dataflow.log_subscribers {
                     // Apply level filter
@@ -4619,21 +4636,11 @@ impl Daemon {
                         continue;
                     };
 
-                    let mut params = MetadataParameters::new();
-                    params.insert(
-                        dora_message::metadata::FRAMING.to_string(),
-                        dora_message::metadata::Parameter::String(
-                            dora_message::metadata::FRAMING_ARROW_IPC.to_string(),
-                        ),
-                    );
-                    let metadata =
-                        metadata::Metadata::from_parameters(self.clock.new_timestamp(), params);
-
                     let send_result = send_with_timestamp(
                         channel,
                         NodeEvent::Input {
                             id: sub.input_id.clone(),
-                            metadata: Arc::new(metadata),
+                            metadata: metadata.clone(),
                             data: Some(data.clone()),
                         },
                         &self.clock,


### PR DESCRIPTION
> **Machine-generated PR.** This change was written by Claude (an AI agent) as part of an automated code-review pass. Please review carefully before merging.

## Issue

The `DoraEvent::LogBroadcast` handler rebuilt an identical `MetadataParameters` map, `Metadata`, and `Arc` **inside** the per-subscriber delivery loop:

```rust
for sub in &dataflow.log_subscribers {
    // ... filters ...
    let mut params = MetadataParameters::new();
    params.insert(FRAMING, FRAMING_ARROW_IPC);
    let metadata = metadata::Metadata::from_parameters(self.clock.new_timestamp(), params);
    send_with_timestamp(channel, NodeEvent::Input { metadata: Arc::new(metadata), ... }, ...);
}
```

The metadata carries only the constant `arrow-ipc` framing parameter and is the same for every subscriber, so this reallocated a map + `Metadata` + `Arc` for each one.

## Fix

Hoist the construction above the loop and clone the shared `Arc<Metadata>` per delivery — matching the sibling **Timer** and **Logs** broadcast loops in the same function, which already build the `Arc<Metadata>` once. (The Arrow-IPC `data` sample was already shared this way.)

The handler already early-returns when `log_subscribers.is_empty()`, so the single build only runs when there is at least one subscriber. The only behavioral difference is that all subscribers now observe one broadcast timestamp — exactly as the Timer/Logs loops already do.

## Validation

- `cargo clippy -p dora-daemon -- -D warnings` — clean.
- `cargo test -p dora-daemon --lib` — 100 passed.
- `cargo fmt` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUCqQZRYLeDFJYK8UkBLca)_