### PR TITLE
fix(core): don't fail ipv6_endpoints_are_bracketed on IPv6-less hosts

### DIFF
--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -656,12 +656,23 @@ mod tests {
     // (`tcp/::1:7447` is ambiguous).
     #[test]
     fn ipv6_endpoints_are_bracketed() {
-        let endpoint = reserve_zenoh_endpoint(IpAddr::V6(std::net::Ipv6Addr::LOCALHOST))
-            .expect("reservation on ::1 succeeds");
-        assert!(
-            endpoint.starts_with("tcp/[::1]:"),
-            "expected a bracketed IPv6 endpoint, got {endpoint}"
-        );
+        match reserve_zenoh_endpoint(IpAddr::V6(std::net::Ipv6Addr::LOCALHOST)) {
+            Ok(endpoint) => assert!(
+                endpoint.starts_with("tcp/[::1]:"),
+                "expected a bracketed IPv6 endpoint, got {endpoint}"
+            ),
+            // Many CI runners, Docker containers, and locked-down hosts have no
+            // IPv6 address on `lo`, so binding `::1` fails with EAFNOSUPPORT
+            // (`Unsupported`) or `AddrNotAvailable`. That is a property of the
+            // host, not of the endpoint formatting under test, so skip rather
+            // than fail — the production path never binds `::1` on such hosts.
+            Err(e)
+                if matches!(
+                    e.kind(),
+                    std::io::ErrorKind::AddrNotAvailable | std::io::ErrorKind::Unsupported
+                ) || e.raw_os_error() == Some(97) => {}
+            Err(e) => panic!("unexpected error reserving ::1 endpoint: {e}"),
+        }
     }
 
     // The filter behind the routing lookup, tested directly rather than through


### PR DESCRIPTION
Fixes #2737

## Problem

The unit test `topics::tests::ipv6_endpoints_are_bracketed`, added in #2722, unconditionally `.expect()`s that reserving an endpoint on `::1` succeeds:

```rust
let endpoint = reserve_zenoh_endpoint(IpAddr::V6(std::net::Ipv6Addr::LOCALHOST))
    .expect("reservation on ::1 succeeds");   // <-- panics when ::1 can't be bound
```

`reserve_zenoh_endpoint` calls `TcpListener::bind((bind, 0))`, which requires the OS to actually support binding `::1`. On any host whose loopback has no IPv6 address (many Docker containers, CI runners, `sysctl net.ipv6.conf.all.disable_ipv6=1` hosts), the bind fails with `EAFNOSUPPORT` (errno 97) and the test panics before it even reaches the assertion it cares about. This breaks `cargo test -p dora-core` and the CI `cargo test --all` gate on IPv6-disabled hosts — a false negative unrelated to any contributor's change. It slips past GitHub's `ubuntu-latest` runners because they *do* have `::1` on `lo`.

The production data path is **not** affected (the loopback case binds IPv4, and an explicit `--zenoh-listen ::1` is caught by the up-front bindability probe), so this is a test-portability regression only.

## Fix

Tolerate a host that cannot bind `::1` by matching on the result: assert the `tcp/[::1]:` bracketing whenever `::1` is bindable, and skip (rather than panic) when the bind fails with `AddrNotAvailable` / `Unsupported` / errno 97. Any other error still fails the test.

Local `cargo test -p dora-core --lib ipv6_endpoints_are_bracketed`, `cargo clippy -p dora-core -- -D warnings`, and `cargo fmt` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USWzvYEFrYJvCAJ13DALfF

---
_Generated by [Claude Code](https://claude.ai/code/session_01USWzvYEFrYJvCAJ13DALfF)_