### PR TITLE
fix(examples): bump rust-dataflow-git pin past the Arrow IPC wire break

### DIFF
--- a/examples/rust-dataflow-git/dataflow.yml
+++ b/examples/rust-dataflow-git/dataflow.yml
@@ -3,10 +3,15 @@
 # without needing a release. Update `rev:` when a message-format-breaking
 # change lands on main — otherwise the CI job catches the mismatch and
 # signals a compatibility break, which is the whole point of this test.
+#
+# Currently pinned past #2366, which dropped the `ArrowTypeInfo` sidecar
+# from `Metadata` and took the payload wire format to v1. The previous pin
+# (1.0.0-rc1) predated that, so its nodes desynced against a current daemon
+# and died with `tag for enum is not valid` (#2742).
 nodes:
   - id: rust-node
     git: https://github.com/dora-rs/dora.git
-    rev: f40b5e7e8aa10a6faafdcebd37c7e440741722ed
+    rev: 07ed3be5f0995ace3f455ea8caff060e2f107250
     build: cargo build -p rust-dataflow-example-node
     path: target/debug/rust-dataflow-example-node
     inputs:
@@ -16,7 +21,7 @@ nodes:
 
   - id: rust-status-node
     git: https://github.com/dora-rs/dora.git
-    rev: f40b5e7e8aa10a6faafdcebd37c7e440741722ed
+    rev: 07ed3be5f0995ace3f455ea8caff060e2f107250
     build: cargo build -p rust-dataflow-example-status-node
     path: target/debug/rust-dataflow-example-status-node
     inputs:
@@ -27,7 +32,7 @@ nodes:
 
   - id: rust-sink
     git: https://github.com/dora-rs/dora.git
-    rev: f40b5e7e8aa10a6faafdcebd37c7e440741722ed
+    rev: 07ed3be5f0995ace3f455ea8caff060e2f107250
     build: cargo build -p rust-dataflow-example-sink
     path: target/debug/rust-dataflow-example-sink
     inputs:


### PR DESCRIPTION
#2366 dropped the `ArrowTypeInfo` sidecar from `Metadata` and took the
payload wire format to v1. The example still pinned 1.0.0-rc1 (May 29) —
a v0 node — so its nodes desynced against a current daemon and died with
`tag for enum is not valid, found 150`.

The example is working as designed: its header comment asks for a rev
bump when a format-breaking change lands. No commit since #2366 has
touched the wire format, so main's HEAD is format-current.

This fixes the Examples (windows-latest) nightly job, red since
2026-07-09. Worth noting the desync fires on all three platforms — but
Linux/macOS still report green, because the wedged node is killed by
SIGTERM at the grace period and the daemon treats Signal(15) during a
planned stop as clean. Windows has no signals, so the hard kill surfaces
as ExitCode(1) and fails the job.

Refs #2742

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
