### PR TITLE
fix(ros2-bridge-arrow): give the msg-gen path dep a version for publishing

### DIFF
--- a/libraries/extensions/ros2-bridge/arrow/Cargo.toml
+++ b/libraries/extensions/ros2-bridge/arrow/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-dora-ros2-bridge-msg-gen = { path = "../msg-gen" }
+dora-ros2-bridge-msg-gen = { workspace = true }
 arrow = { workspace = true }
 eyre = { workspace = true }
 ros2-client = "0.8"


### PR DESCRIPTION
Follow-up to #2719, found by dry-running `cargo package` for all 26 crates in the release publish list before cutting v1.0.0-rc.2.

`dora-ros2-bridge-arrow` declared `dora-ros2-bridge-msg-gen = { path = "../msg-gen" }` without a version, which `cargo package` rejects outright:

```
error: failed to verify manifest ...
  all dependencies must have a version requirement specified when packaging.
  dependency `dora-ros2-bridge-msg-gen` does not specify a version
```

So this crate (last in the publish order) would have failed the release publish step. Switching to the workspace dependency (version + path) fixes it; all 26 crates now package cleanly:

```
OK  dora-message ... OK  dora-operator-api-cxx
OK  dora-ros2-bridge-arrow   <- was FAIL
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)