### PR TITLE
fix(cli): reject `dora daemon --worker-threads 0` instead of panicking

### DIFF
--- a/binaries/cli/src/command/daemon.rs
+++ b/binaries/cli/src/command/daemon.rs
@@ -18,6 +18,19 @@ use std::{
 use tokio::runtime::Builder;
 use tracing::level_filters::LevelFilter;
 
+/// Parse `--worker-threads`, rejecting 0.
+///
+/// `tokio::runtime::Builder::worker_threads` asserts `val > 0` and would
+/// otherwise abort the daemon with a raw panic ("Worker threads cannot be set
+/// to 0"). Validating here turns that into a normal clap usage error.
+fn parse_worker_threads(s: &str) -> Result<usize, String> {
+    match s.parse::<usize>() {
+        Ok(0) => Err("worker threads must be at least 1".to_string()),
+        Ok(n) => Ok(n),
+        Err(err) => Err(err.to_string()),
+    }
+}
+
 #[derive(Debug, clap::Args)]
 /// Run daemon
 pub struct Daemon {
@@ -72,7 +85,7 @@ pub struct Daemon {
     #[clap(long)]
     allow_shell_nodes: bool,
     /// Number of tokio worker threads (default: number of CPU cores).
-    #[clap(long)]
+    #[clap(long, value_parser = parse_worker_threads)]
     worker_threads: Option<usize>,
     /// Enable real-time profile: mlockall + SCHED_FIFO priority.
     /// Requires CAP_SYS_NICE + CAP_IPC_LOCK capabilities.

--- a/binaries/cli/src/command/mod.rs
+++ b/binaries/cli/src/command/mod.rs
@@ -317,6 +317,20 @@ mod tests {
     }
 
     #[test]
+    fn parse_daemon_worker_threads() {
+        parse_ok(&["dora", "daemon", "--worker-threads", "4"]);
+        parse_ok(&["dora", "daemon", "--worker-threads", "1"]);
+    }
+
+    #[test]
+    fn reject_daemon_worker_threads_zero() {
+        // `tokio::runtime::Builder::worker_threads` asserts `val > 0`, so
+        // `--worker-threads 0` used to abort the daemon with a raw panic.
+        // clap must reject it with a normal usage error instead.
+        parse_err(&["dora", "daemon", "--worker-threads", "0"]);
+    }
+
+    #[test]
     fn parse_logs_dataflow_node_flag() {
         parse_ok(&["dora", "logs", "my-dataflow", "--node", "sensor"]);
     }


### PR DESCRIPTION
## Issue

`dora daemon --worker-threads 0` aborts the daemon with a raw Rust panic:

```
if let Some(threads) = self.worker_threads {
    builder.worker_threads(threads);   // tokio asserts val > 0
}
```

`tokio::runtime::Builder::worker_threads` does `assert!(val > 0, "Worker threads cannot be set to 0")`, so a user typo produces an ugly panic + backtrace instead of a clean CLI usage error. The flag had no range validation, unlike every other bounded numeric flag in the CLI (`--refresh-interval`, `--duration`, `--count`, …), which consistently use `range(1..)`.

## Fix

`usize` is not one of the ranged integer types clap's `value_parser!` macro supports (the sibling flags use `u64`/`u32`), so `.range(1..)` doesn't compile for it. This adds a small `parse_worker_threads` value parser that rejects `0` with a normal usage error and keeps the field type `usize`, so the downstream `builder.worker_threads(threads)` call is unchanged.

```
fn parse_worker_threads(s: &str) -> Result<usize, String> {
    match s.parse::<usize>() {
        Ok(0) => Err("worker threads must be at least 1".to_string()),
        Ok(n) => Ok(n),
        Err(err) => Err(err.to_string()),
    }
}
```

## Validation

- Added parser tests: `--worker-threads 4` / `1` parse; `--worker-threads 0` is rejected.
- `cargo test -p dora-cli --lib` — 253 passed.
- `cargo clippy -p dora-cli --lib -- -D warnings` — clean. `cargo fmt --all -- --check` — clean.

---
🤖 This pull request is **machine-generated by Claude** (an AI agent) as part of an automated code-review pass. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qagXwFeCr5pUYHFS3KukQ

---
_Generated by [Claude Code](https://claude.ai/code/session_013qagXwFeCr5pUYHFS3KukQ)_