### PR TITLE
perf(arrow-convert): drop per-element error-string allocation in into_vec

### DIFF
--- a/libraries/arrow-convert/src/lib.rs
+++ b/libraries/arrow-convert/src/lib.rs
@@ -89,7 +89,13 @@ macro_rules! register_array_handlers {
 
                         let mut result = Vec::with_capacity(buffer.len());
                         for &v in buffer.values() {
-                            let converted = NumCast::from(v).context(format!("Failed to cast value from {} to target type",$type_name))?;
+                            // `with_context` defers the `format!` to the error
+                            // path: `context(format!(...))` would heap-allocate a
+                            // fresh error String on every element even on the
+                            // (overwhelmingly common) success path.
+                            let converted = NumCast::from(v).with_context(|| {
+                                format!("Failed to cast value from {} to target type", $type_name)
+                            })?;
                             result.push(converted);
                         }
                         Ok(result)


### PR DESCRIPTION
## Issue

`into_vec` (the public Arrow-array → `Vec<T>` conversion, registered for every numeric Arrow type) casts element by element:

```rust
let mut result = Vec::with_capacity(buffer.len());
for &v in buffer.values() {
    let converted = NumCast::from(v)
        .context(format!("Failed to cast value from {} to target type", $type_name))?;
    result.push(converted);
}
```

`eyre`'s `ContextCompat::context` takes the context **by value**, so the `format!(...)` is evaluated on **every iteration** — even when the cast succeeds, which is the overwhelmingly common case. `$type_name` is a `&str` literal, so each iteration heap-allocates a fresh `String` that is immediately dropped. Converting a 1,000,000-element `Float64Array` performs ~1,000,000 pointless allocations.

## Fix

Use the closure form `with_context(|| format!(...))`, which only builds the message on the error path:

```rust
let converted = NumCast::from(v).with_context(|| {
    format!("Failed to cast value from {} to target type", $type_name)
})?;
```

`with_context` is provided by the same `eyre::ContextCompat` trait already imported. No behavior change — the error message is byte-for-byte identical on the failure path. This was the only per-element context site in the crate (the rest already use static `concat!`/`wrap_err`).

## Validation

- `cargo test -p dora-arrow-convert` — 29 tests + doctest pass (round-trip and null-rejection coverage for `into_vec` is unchanged).
- `cargo clippy -p dora-arrow-convert --all-targets -- -D warnings` — clean. `cargo fmt --all -- --check` — clean.

---
🤖 This pull request is **machine-generated by Claude** (an AI agent) as part of an automated code-review pass. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qagXwFeCr5pUYHFS3KukQ

---
_Generated by [Claude Code](https://claude.ai/code/session_013qagXwFeCr5pUYHFS3KukQ)_