### PR TITLE
fix(core): reject `~` and `@{` rev-specs when checking out a git pin

### DIFF
--- a/libraries/core/src/build/git.rs
+++ b/libraries/core/src/build/git.rs
@@ -464,8 +464,19 @@ async fn fetch_changes(
 }
 
 fn checkout_tree(repository: &git2::Repository, commit_hash: &str) -> eyre::Result<()> {
-    // Reject arbitrary rev-spec expressions; only allow hex commit hashes and branch/tag names.
-    if commit_hash.contains("..") || commit_hash.contains(':') || commit_hash.contains('^') {
+    // Reject arbitrary rev-spec expressions; only allow hex commit hashes and
+    // branch/tag names. `..` (ranges), `:` (`<rev>:<path>`), `^` and `~`
+    // (ancestor navigation, e.g. `HEAD~3`), and `@{` (reflog / date specs,
+    // e.g. `HEAD@{1}`, `main@{yesterday}`) all resolve to a computed commit
+    // other than the one named, defeating the "pin to a reviewed commit"
+    // intent. None of these can appear in a valid git ref name, so blocking
+    // them never rejects a legitimate branch/tag.
+    if commit_hash.contains("..")
+        || commit_hash.contains(':')
+        || commit_hash.contains('^')
+        || commit_hash.contains('~')
+        || commit_hash.contains("@{")
+    {
         eyre::bail!(
             "invalid commit reference '{commit_hash}': rev-spec expressions are not allowed"
         );
@@ -640,5 +651,40 @@ mod tests {
         };
         assert_eq!(folder.prepare(&mut TestLogger).await.unwrap(), dir);
         assert!(dir.exists(), "a sibling-owned clone must never be deleted");
+    }
+
+    #[test]
+    fn checkout_tree_rejects_revspec_expressions() {
+        let base = tempfile::tempdir().unwrap();
+        init_repo_with_commit(base.path());
+        let repo = git2::Repository::open(base.path()).unwrap();
+
+        // Each of these resolves to a commit *other* than the one named,
+        // defeating commit pinning. The string guard must reject them before
+        // `revparse_ext` ever gets to interpret them.
+        for spec in [
+            "a..b",             // range
+            "HEAD:file.txt",    // <rev>:<path>
+            "HEAD^",            // first parent
+            "HEAD~1",           // ancestor
+            "main~3",           // ancestor of a branch
+            "HEAD@{0}",         // reflog
+            "main@{yesterday}", // date spec
+        ] {
+            let err = checkout_tree(&repo, spec).unwrap_err();
+            assert!(
+                err.to_string()
+                    .contains("rev-spec expressions are not allowed"),
+                "expected rejection for {spec:?}, got: {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn checkout_tree_accepts_plain_commit_hash() {
+        let base = tempfile::tempdir().unwrap();
+        let commit = init_repo_with_commit(base.path());
+        let repo = git2::Repository::open(base.path()).unwrap();
+        checkout_tree(&repo, &commit).expect("a plain commit hash must check out");
     }
 }


### PR DESCRIPTION
## Issue

`checkout_tree` (used when materializing a `git:` / `rev:` source pin in a dataflow) rejects arbitrary git rev-spec expressions so a pin can only name a hex commit hash or a branch/tag — the "pin to a specific, reviewed commit" property:

```rust
if commit_hash.contains("..") || commit_hash.contains(':') || commit_hash.contains('^') {
    eyre::bail!("invalid commit reference '{commit_hash}': rev-spec expressions are not allowed");
}
```

The blocklist misses two rev-spec escapes:

- **`~`** — ancestor navigation, the direct sibling of the already-blocked `^` (e.g. `rev: HEAD~3`, `rev: main~2`).
- **`@{`** — reflog / date specs (e.g. `rev: "HEAD@{1}"`, `rev: "main@{yesterday}"`).

Both fall through to `git2::revparse_ext`, which resolves them to a **computed** commit other than the one named, defeating the pin.

## Fix

Add `~` and `@{` to the blocklist. Neither can appear in a valid git ref name (`git check-ref-format` forbids `~`, `^`, `:`, and the `@{` sequence), so blocking them never rejects a legitimate branch/tag.

## Validation

- Added `checkout_tree_rejects_revspec_expressions`: `a..b`, `HEAD:file.txt`, `HEAD^`, `HEAD~1`, `main~3`, `HEAD@{0}`, `main@{yesterday}` are all rejected with the "rev-spec expressions are not allowed" error before resolution.
- Added `checkout_tree_accepts_plain_commit_hash`: a real commit hash still checks out.
- `cargo test -p dora-core --features build` — 277 passed.
- `cargo clippy -p dora-core --features build --all-targets -- -D warnings` — clean. `cargo fmt --all -- --check` — clean.

---
🤖 This pull request is **machine-generated by Claude** (an AI agent) as part of an automated code-review pass. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qagXwFeCr5pUYHFS3KukQ

---
_Generated by [Claude Code](https://claude.ai/code/session_013qagXwFeCr5pUYHFS3KukQ)_