### PR TITLE
fix(tracing): don't truncate trace-context values at the second colon

### DIFF
--- a/libraries/extensions/telemetry/tracing/src/telemetry.rs
+++ b/libraries/extensions/telemetry/tracing/src/telemetry.rs
@@ -79,10 +79,34 @@ pub fn deserialize_context(string_context: &str) -> Context {
 pub fn deserialize_to_hashmap(string_context: &str) -> HashMap<&str, &str> {
     let mut map = HashMap::new();
     for s in string_context.split(';') {
-        let mut values = s.split(':');
+        // Split on the FIRST ':' only. The value (e.g. a W3C `tracestate`
+        // like `vendor=a:b`) may legitimately contain ':', and a plain
+        // `split(':')` would drop everything after the second colon, silently
+        // corrupting the propagated context.
+        let mut values = s.splitn(2, ':');
         let key = values.next().unwrap();
         let value = values.next().unwrap_or("");
         map.insert(key, value);
     }
     map
+}
+
+#[cfg(test)]
+mod tests {
+    use super::deserialize_to_hashmap;
+
+    #[test]
+    fn deserialize_keeps_colons_in_value() {
+        // A W3C `tracestate` value may contain ':'. It must survive
+        // deserialization intact rather than being truncated at the 2nd colon.
+        let map = deserialize_to_hashmap("tracestate:vendor=a:b:c;");
+        assert_eq!(map.get("tracestate"), Some(&"vendor=a:b:c"));
+    }
+
+    #[test]
+    fn deserialize_plain_traceparent_round_trips() {
+        // The common case: `traceparent` has no ':' in its value.
+        let map = deserialize_to_hashmap("traceparent:00-abc-def-01;");
+        assert_eq!(map.get("traceparent"), Some(&"00-abc-def-01"));
+    }
 }


### PR DESCRIPTION
## Issue

`deserialize_to_hashmap` reconstructs the propagated OpenTelemetry trace context on the receiving node. It parsed each `key:value` entry like this:

```rust
for s in string_context.split(';') {
    let mut values = s.split(':');
    let key = values.next().unwrap();
    let value = values.next().unwrap_or("");   // everything after the 2nd ':' is dropped
    map.insert(key, value);
}
```

`serialize_context` only ever emits the W3C keys `traceparent` and `tracestate`. `traceparent` values contain no `:`, so the common path is fine — but a **`tracestate`** value may legitimately contain `:` (the W3C spec allows 0x20–0x7E except `,` and `=`). For a value like `vendor=a:b`, deserialization kept only `vendor=a`, silently corrupting the propagated sampling/vendor state across node boundaries.

## Fix

Split on the **first** `:` only:

```rust
let mut values = s.splitn(2, ':');
```

The value now retains everything after the first colon. `traceparent` is unaffected. This is backward-compatible: previously-serialized contexts without problematic characters parse identically (and ones *with* them were already broken).

## Validation

- Added `deserialize_keeps_colons_in_value` (a colon-bearing `tracestate` round-trips intact) and `deserialize_plain_traceparent_round_trips`.
- `cargo test -p dora-tracing --lib` — 5 passed.
- `cargo clippy -p dora-tracing --all-targets -- -D warnings` — clean. `cargo fmt --all -- --check` — clean.

### Note on remaining scope

This fixes the `:`-in-value truncation, the realistic case. The entry delimiter is still `;`, which is also technically allowed in a `tracestate` value; a fully delimiter-safe encoding (percent-encoding/JSON) would be a larger, wire-format-changing change and is deliberately out of scope here.

---
🤖 This pull request is **machine-generated by Claude** (an AI agent) as part of an automated code-review pass. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qagXwFeCr5pUYHFS3KukQ

---
_Generated by [Claude Code](https://claude.ai/code/session_013qagXwFeCr5pUYHFS3KukQ)_