### PR TITLE
fix(core): reject zero `health_check_interval` before it panics the daemon

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1375,13 +1375,19 @@ impl Daemon {
         });
 
         let health_check_clock = self.clock.clone();
-        let health_check_interval = tokio_stream::wrappers::IntervalStream::new(
-            tokio::time::interval(health_check_interval_duration.unwrap_or(Duration::from_secs(5))),
-        )
-        .map(move |_| Timestamped {
-            inner: Event::NodeHealthCheckInterval,
-            timestamp: health_check_clock.new_timestamp(),
-        });
+        // `tokio::time::interval` panics on a zero period. Descriptor validation
+        // already rejects a zero `health_check_interval` (see `check_dataflow`),
+        // but guard here as well so a stray `Duration::ZERO` falls back to the
+        // default rather than crashing the daemon (defense-in-depth for #2752).
+        let health_check_period = health_check_interval_duration
+            .filter(|d| !d.is_zero())
+            .unwrap_or(Duration::from_secs(5));
+        let health_check_interval =
+            tokio_stream::wrappers::IntervalStream::new(tokio::time::interval(health_check_period))
+                .map(move |_| Timestamped {
+                    inner: Event::NodeHealthCheckInterval,
+                    timestamp: health_check_clock.new_timestamp(),
+                });
 
         let mut events = (
             external_events,

--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -81,15 +81,19 @@ pub fn check_dataflow_static(dataflow: &Descriptor) -> eyre::Result<()> {
                 &format!("input `{input_id}` of node `{}`", node.id),
                 "input_timeout",
                 input.input_timeout,
+                true,
             )?;
         }
     }
     // dataflow-level `health_check_interval` reaches `Duration::from_secs_f64`
-    // in the same way (`binaries/daemon/src/lib.rs`).
+    // in the same way (`binaries/daemon/src/lib.rs`). A zero interval must also
+    // be rejected: it is fed to `tokio::time::interval`, which panics on a zero
+    // period.
     check_seconds_field(
         "dataflow",
         "health_check_interval",
         dataflow.health_check_interval,
+        false,
     )?;
 
     // check that all inputs mappings point to an existing output
@@ -208,7 +212,7 @@ fn check_timing_fields(
         ("max_restart_delay", custom.max_restart_delay),
         ("restart_window", custom.restart_window),
     ] {
-        check_seconds_field(&owner, field, value)?;
+        check_seconds_field(&owner, field, value, true)?;
     }
     Ok(())
 }
@@ -221,13 +225,27 @@ fn check_timing_fields(
 /// values too large to fit in a `Duration` (> `Duration::MAX`, ≈ 1.8e19 s). We
 /// probe the exact same boundary with its non-panicking twin
 /// `try_from_secs_f64`, so a value accepted here can never panic the daemon.
-fn check_seconds_field(owner: &str, field: &str, value: Option<f64>) -> eyre::Result<()> {
+///
+/// When `allow_zero` is `false`, `0.0` is also rejected. This is required for
+/// fields that reach `tokio::time::interval` (e.g. `health_check_interval`),
+/// which panics on a zero period.
+fn check_seconds_field(
+    owner: &str,
+    field: &str,
+    value: Option<f64>,
+    allow_zero: bool,
+) -> eyre::Result<()> {
     if let Some(value) = value
-        && std::time::Duration::try_from_secs_f64(value).is_err()
+        && (std::time::Duration::try_from_secs_f64(value).is_err() || (!allow_zero && value == 0.0))
     {
+        let requirement = if allow_zero {
+            "non-negative"
+        } else {
+            "positive"
+        };
         bail!(
             "{owner} has invalid `{field}`: {value} \
-             (must be a finite, non-negative number of seconds smaller than {})",
+             (must be a finite, {requirement} number of seconds smaller than {})",
             std::time::Duration::MAX.as_secs_f64()
         );
     }
@@ -1413,15 +1431,15 @@ operators:
 
     #[test]
     fn seconds_field_accepts_none_zero_and_positive() {
-        check_seconds_field("owner", "field", None).unwrap();
-        check_seconds_field("owner", "field", Some(0.0)).unwrap();
-        check_seconds_field("owner", "field", Some(3600.0)).unwrap();
+        check_seconds_field("owner", "field", None, true).unwrap();
+        check_seconds_field("owner", "field", Some(0.0), true).unwrap();
+        check_seconds_field("owner", "field", Some(3600.0), true).unwrap();
     }
 
     #[test]
     fn seconds_field_rejects_negative_and_non_finite() {
         for bad in [-1.0, f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
-            let err = check_seconds_field("owner", "field", Some(bad))
+            let err = check_seconds_field("owner", "field", Some(bad), true)
                 .unwrap_err()
                 .to_string();
             assert!(
@@ -1441,7 +1459,7 @@ operators:
         for bad in [1e20, Duration::MAX.as_secs_f64()] {
             // Confirms the value genuinely trips the daemon's conversion.
             assert!(Duration::try_from_secs_f64(bad).is_err());
-            let err = check_seconds_field("owner", "field", Some(bad))
+            let err = check_seconds_field("owner", "field", Some(bad), true)
                 .unwrap_err()
                 .to_string();
             assert!(
@@ -1455,12 +1473,32 @@ operators:
     #[test]
     fn seconds_field_accepts_large_representable_value() {
         assert!(Duration::try_from_secs_f64(1e18).is_ok());
-        check_seconds_field("owner", "field", Some(1e18)).unwrap();
+        check_seconds_field("owner", "field", Some(1e18), true).unwrap();
+    }
+
+    // With `allow_zero: false`, `0.0` must be rejected (in addition to the
+    // negative / non-finite cases) because such a field reaches
+    // `tokio::time::interval`, which panics on a zero period.
+    #[test]
+    fn seconds_field_rejects_zero_when_positive_required() {
+        check_seconds_field("owner", "field", None, false).unwrap();
+        check_seconds_field("owner", "field", Some(3600.0), false).unwrap();
+        for bad in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            let err = check_seconds_field("owner", "field", Some(bad), false)
+                .unwrap_err()
+                .to_string();
+            assert!(
+                err.contains("field") && err.contains("positive"),
+                "{bad} should be rejected with a field/constraint message, got: {err}"
+            );
+        }
     }
 
     // `health_check_interval` (dataflow-level) reaches `Duration::from_secs_f64`
-    // in the daemon just like the per-node timing fields, so `check_dataflow`
-    // must reject a non-finite / negative value rather than let the daemon panic.
+    // and then `tokio::time::interval` in the daemon, so `check_dataflow` must
+    // reject a non-finite / negative / zero value rather than let the daemon
+    // panic. A zero interval additionally panics `tokio::time::interval`, so it
+    // is rejected with a `positive` constraint.
     #[test]
     fn check_dataflow_rejects_negative_health_check_interval() {
         let dataflow = parse_dataflow(
@@ -1478,7 +1516,32 @@ nodes:
             .unwrap_err()
             .to_string();
         assert!(
-            err.contains("health_check_interval") && err.contains("non-negative"),
+            err.contains("health_check_interval") && err.contains("positive"),
+            "error should name the field and constraint, got: {err}"
+        );
+    }
+
+    // A zero `health_check_interval` passes `Duration::from_secs_f64` (yielding
+    // `Duration::ZERO`) but then panics `tokio::time::interval`, so it must be
+    // rejected up front (regression test for #2752).
+    #[test]
+    fn check_dataflow_rejects_zero_health_check_interval() {
+        let dataflow = parse_dataflow(
+            "\
+health_check_interval: 0.0
+nodes:
+  - id: a
+    path: node_a
+    build: cargo build
+    outputs:
+      - out
+",
+        );
+        let err = check_dataflow(&dataflow, Path::new("/nonexistent-dora-validate-test"))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("health_check_interval") && err.contains("positive"),
             "error should name the field and constraint, got: {err}"
         );
     }


### PR DESCRIPTION
## Summary

Fixes #2752.

A dataflow descriptor with `health_check_interval: 0.0` passed `dora validate` and then **panicked the daemon** the moment the dataflow started. The value is fed to `tokio::time::interval`, which panics with *"`interval` called with a period of zero"* on a `Duration::ZERO`. The validation added in #2612 (`check_seconds_field`) only rejected negative / non-finite values, so `0.0` slipped through, and the daemon's `unwrap_or(Duration::from_secs(5))` default only guarded the `None` case — `Some(Duration::ZERO)` sailed through.

## Changes

- **`libraries/core/src/descriptor/validate.rs`**: added an `allow_zero` parameter to `check_seconds_field`. `health_check_interval` now requires a strictly positive value; fields that tolerate zero (`input_timeout`, `finish_grace_secs`, `restart_*`, …) keep `allow_zero: true`. The rejection message reads `positive` vs. `non-negative` accordingly.
- **`binaries/daemon/src/lib.rs`**: defense-in-depth — the health-check interval construction now falls back to the 5 s default when the configured duration is zero, so a stray `Duration::ZERO` can never panic the daemon.

## Tests

- New `seconds_field_rejects_zero_when_positive_required` unit test.
- New `check_dataflow_rejects_zero_health_check_interval` regression test.
- Updated `check_dataflow_rejects_negative_health_check_interval` for the `positive` constraint wording.

Local `cargo test -p dora-core`, `cargo fmt --all -- --check`, and `cargo clippy -p dora-core -p dora-daemon -- -D warnings` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYmpFfw3ZcSyeo5XBAS7EE)_