### PR TITLE
fix(daemon): collapse stray whitespace in `--zenoh-listen` error message

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -700,7 +700,8 @@ impl Daemon {
         let zenoh_bind = match zenoh_listen_addr {
             Some(addr) => {
                 validate_zenoh_listen(addr).wrap_err(
-                    "invalid --zenoh-listen address (omit the flag to derive it                      from --coordinator-addr)",
+                    "invalid --zenoh-listen address (omit the flag to derive it \
+                     from --coordinator-addr)",
                 )?;
                 ZenohBind::Explicit(addr)
             }


### PR DESCRIPTION
## Summary

Fixes #2753.

The operator-facing error wrapped around `validate_zenoh_listen` (`binaries/daemon/src/lib.rs`, added by #2722) contained a run of ~22 spaces in the middle of the sentence — a hard-wrapped source line joined without collapsing its leading indentation — so it rendered as:

> invalid --zenoh-listen address (omit the flag to derive it&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; from --coordinator-addr)

## Change

Use a `\`-continuation in the string literal so the source can still wrap across two lines while the compiler strips the newline and the following line's leading whitespace. The message now renders single-spaced:

> invalid --zenoh-listen address (omit the flag to derive it from --coordinator-addr)

Purely cosmetic; no functional effect. `cargo fmt` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYmpFfw3ZcSyeo5XBAS7EE)_