### PR TITLE
fix(daemon): purge removed node's per-node bookkeeping on RemoveNode

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -2342,6 +2342,12 @@ impl Daemon {
                     // subscribes and could be selected mid-startup (dora#2270).
                     dataflow.connected_nodes.remove(&node_id);
                     dataflow.finish_escalated.remove(&node_id);
+                    // Purge per-node bookkeeping keyed by node id that the
+                    // routing cleanup above doesn't touch. Otherwise stale
+                    // input_deadlines/broken_inputs entries are re-scanned
+                    // every tick forever and the stderr queue leaks across
+                    // repeated dynamic add/remove cycles.
+                    dataflow.forget_node_bookkeeping(&node_id);
 
                     // Remove from stored descriptor (inverse of AddNode
                     // push) so descriptor-based lookups stay consistent.
@@ -6445,6 +6451,57 @@ mod fault_tolerance_tests {
         assert!(matches_event(&events[0], "InputClosed"));
         assert!(matches_event(&events[1], "AllInputsClosed"));
         assert!(disable_restart.load(atomic::Ordering::Acquire));
+    }
+
+    #[test]
+    fn forget_node_bookkeeping_purges_only_that_node() {
+        // Regression: RemoveNode must drop the removed node's per-node
+        // bookkeeping, otherwise stale input_deadlines/broken_inputs entries
+        // are re-scanned every tick forever and the stderr queue leaks across
+        // repeated dynamic add/remove cycles.
+        let mut df = test_dataflow();
+        let node_a: NodeId = "node_a".to_string().into();
+        let node_b: NodeId = "node_b".to_string().into();
+        let input_x: DataId = "input_x".to_string().into();
+        let timeout = Duration::from_secs(1);
+
+        for node in [&node_a, &node_b] {
+            df.input_deadlines.insert(
+                (node.clone(), input_x.clone()),
+                InputDeadline {
+                    timeout,
+                    last_received: None,
+                },
+            );
+            df.broken_inputs
+                .insert((node.clone(), input_x.clone()), timeout);
+            df.node_stderr_most_recent
+                .insert(node.clone(), Arc::new(ArrayQueue::new(4)));
+        }
+
+        df.forget_node_bookkeeping(&node_a);
+
+        // node_a's entries are gone …
+        assert!(
+            !df.input_deadlines
+                .contains_key(&(node_a.clone(), input_x.clone()))
+        );
+        assert!(
+            !df.broken_inputs
+                .contains_key(&(node_a.clone(), input_x.clone()))
+        );
+        assert!(!df.node_stderr_most_recent.contains_key(&node_a));
+
+        // … while node_b's are untouched.
+        assert!(
+            df.input_deadlines
+                .contains_key(&(node_b.clone(), input_x.clone()))
+        );
+        assert!(
+            df.broken_inputs
+                .contains_key(&(node_b.clone(), input_x.clone()))
+        );
+        assert!(df.node_stderr_most_recent.contains_key(&node_b));
     }
 
     // -- Test 3: close_input defers AllInputsClosed when broken_inputs exist --

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -299,6 +299,23 @@ impl RunningDataflow {
         }
     }
 
+    /// Drop per-node bookkeeping that is keyed by node id but not covered by
+    /// the routing-table cleanup in the `RemoveNode` handler.
+    ///
+    /// Without this, removing a node (dynamic reconfiguration) leaves stale
+    /// `input_deadlines` / `broken_inputs` entries behind. A never-armed
+    /// `input_deadlines` entry never times out, so `check_input_timeouts`
+    /// re-scans it every tick forever; a `broken_inputs` entry can never
+    /// recover once the node is gone (recovery only happens on message
+    /// receipt, which a removed node never sees). Together with the
+    /// `node_stderr_most_recent` queue this is an unbounded accumulation
+    /// across repeated add/remove cycles.
+    pub(crate) fn forget_node_bookkeeping(&mut self, node_id: &NodeId) {
+        self.input_deadlines.retain(|(n, _), _| n != node_id);
+        self.broken_inputs.retain(|(n, _), _| n != node_id);
+        self.node_stderr_most_recent.remove(node_id);
+    }
+
     pub(crate) async fn start(
         &mut self,
         events_tx: &mpsc::Sender<Timestamped<Event>>,


### PR DESCRIPTION
## Summary

The `RemoveNode` coordinator handler in `binaries/daemon/src/lib.rs` cleans up routing tables (`mappings`, `timers`, `log_subscribers`) and most per-node maps (`running_nodes`, `open_inputs`, `subscribe_channels`, `pending_messages`, `all_inputs_closed_at`, `connected_nodes`, `finish_escalated`, descriptor entry) — but leaves three maps keyed by the removed node untouched:

- `input_deadlines: HashMap<(NodeId, DataId), InputDeadline>`
- `broken_inputs: HashMap<(NodeId, DataId), Duration>`
- `node_stderr_most_recent: BTreeMap<NodeId, Arc<ArrayQueue<String>>>`

## The bug

A `input_deadlines` entry for an input that never received traffic is "not yet armed", so `InputDeadline::is_timed_out()` returns `false` and it is **never** removed (entries are only dropped when they time out, at `lib.rs:2641`). `check_input_timeouts` (`lib.rs:2607`) therefore re-scans it on **every tick** for the lifetime of the dataflow.

A `broken_inputs` entry can never recover once the node is gone — recovery only happens on message receipt (`send_output_to_local_receivers`), which a removed node never sees.

Across repeated dynamic add/remove cycles (a supported reconfiguration pattern, cf. the `#2270` comments in the same handler) these stale entries accumulate without bound, together with the dangling per-node stderr queue, wasting per-tick work indefinitely.

## The fix

Add `RunningDataflow::forget_node_bookkeeping(&mut self, node_id)` which `retain`s away the removed node's `input_deadlines`/`broken_inputs` entries and drops its `node_stderr_most_recent` queue, and call it from the `RemoveNode` cleanup block. Other nodes' entries are preserved.

## Validation

- New unit test `forget_node_bookkeeping_purges_only_that_node` populates all three maps for two nodes, removes one, and asserts only that node's entries are dropped. **Passes.**
- `cargo fmt -p dora-daemon -- --check`, `cargo clippy -p dora-daemon -- -D warnings`, `cargo test -p dora-daemon` all clean.

---

⚠️ *This PR is machine-generated by Claude (an AI assistant). Please review carefully before merging.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VatiTmTfc8dXfvVYqcGNs6

---
_Generated by [Claude Code](https://claude.ai/code/session_01VatiTmTfc8dXfvVYqcGNs6)_