### PR TITLE
fix(daemon): record force-stopped nodes in grace_duration_kills

### DIFF
--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -400,9 +400,17 @@ impl RunningDataflow {
             .map(|(id, n)| (id.clone(), n.process.take()))
             .collect();
         if force {
-            for (_, proc) in &running_processes {
-                if let Some(proc) = proc {
-                    proc.submit(ProcessOperation::Kill);
+            for (node, proc) in &running_processes {
+                if let Some(proc) = proc
+                    && proc.submit(ProcessOperation::Kill)
+                {
+                    // Record the daemon-initiated kill so a node that ignores
+                    // the pre-kill `Stop` and gets SIGKILLed is classified as
+                    // a planned `GraceDuration` stop rather than a genuine node
+                    // failure. Mirrors the graceful branch below; exit
+                    // classification keys "the daemon asked this node to stop"
+                    // off `grace_duration_kills` (see lib.rs exit handling).
+                    self.grace_duration_kills.insert(node.clone());
                 }
             }
         } else {


### PR DESCRIPTION
## Summary

`RunningDataflow::stop_all(force = true)` (`binaries/daemon/src/running_dataflow.rs`) sends `ProcessOperation::Kill` to every node but, unlike the graceful (`else`) branch, never inserts the killed node into `grace_duration_kills`.

## The bug

Exit classification in `Daemon::handle_node_stop` (`lib.rs`, ~line 4687) uses `grace_duration_kills` as the discriminant for "the daemon asked this node to stop":

```rust
let grace_duration_kill = dataflow
    .map(|d| d.grace_duration_kills.contains(&node_id))
    .unwrap_or_default();
```

When a node ignores the pre-kill `Stop` event and is therefore SIGKILLed under `dora stop --force` / `dora destroy`, it gets `grace_duration_kill = false` and falls through to `NodeErrorCause::Other { stderr }` — reported as a genuine node failure. The same node under a *graceful* stop is correctly reported as `GraceDuration`. So forced teardown surfaces spurious per-node failures for nodes that simply didn't drain in time.

The in-code comment at `lib.rs` even states the intended contract: *"`grace_duration_kills` is only populated by the daemon's own SoftKill/Kill submission path (`running_dataflow.rs::stop_all` and `::send_stop_and_schedule_kill`), so it accurately encodes 'daemon asked this node to stop.'"* — the `force` branch was the one place that path failed to hold up its end.

## The fix

Record each successfully-submitted force kill in `grace_duration_kills`, mirroring the graceful branch. After the fix, a force-killed node's non-success exit classifies as `NodeErrorCause::GraceDuration` instead of `Other`.

## Validation

- `cargo fmt -p dora-daemon -- --check`, `cargo clippy -p dora-daemon -- -D warnings`, `cargo test -p dora-daemon` (103 tests) all pass.
- The force-kill path drives live child processes and is exercised by the fault-tolerance e2e suite rather than a unit test; this change is a direct mirror of the already-present graceful-branch logic (which is likewise covered by e2e, not unit tests).

---

⚠️ *This PR is machine-generated by Claude (an AI assistant). Please review carefully before merging.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VatiTmTfc8dXfvVYqcGNs6

---
_Generated by [Claude Code](https://claude.ai/code/session_01VatiTmTfc8dXfvVYqcGNs6)_