### PR TITLE
docs(apis): fix DoraEvent alias doc and document DoraOutputSender

### DIFF
--- a/apis/rust/node/src/lib.rs
+++ b/apis/rust/node/src/lib.rs
@@ -128,8 +128,8 @@ mod node;
 
 pub use error::{NodeError, NodeResult, PatternError};
 
-/// Backward-compatible alias so code using the old `DoraNode` name still compiles.
-/// Backward-compatible alias for [`Event`].
+/// Backward-compatible alias for [`Event`], so code using the old `DoraEvent`
+/// name still compiles.
 pub use Event as DoraEvent;
 
 #[derive(Debug)]

--- a/apis/rust/operator/src/lib.rs
+++ b/apis/rust/operator/src/lib.rs
@@ -124,6 +124,12 @@ pub trait DoraOperator: Default {
     ) -> Result<DoraStatus, String>;
 }
 
+/// Handle passed to [`DoraOperator::on_event`] for emitting outputs back
+/// into the dataflow.
+///
+/// Call [`DoraOutputSender::send`] with an `output_id` declared in your
+/// dataflow YAML and the data to publish. See the crate-level example for
+/// a full operator implementation.
 pub struct DoraOutputSender<'a>(&'a SendOutput);
 
 impl DoraOutputSender<'_> {


### PR DESCRIPTION
## Summary

Two public-API rustdoc gaps in the Rust node/operator APIs.

### 1. `DoraEvent` alias has a wrong doc line (`apis/rust/node/src/lib.rs`)

```rust
/// Backward-compatible alias so code using the old `DoraNode` name still compiles.
/// Backward-compatible alias for [`Event`].
pub use Event as DoraEvent;
```

The first line is a copy-paste error — this alias is for `Event`, not `DoraNode`. Because the crate enables `#[warn(missing_docs)]`, the contradictory text ships in the generated rustdoc for a public re-export. Collapsed to a single correct line.

### 2. `DoraOutputSender` is undocumented (`apis/rust/operator/src/lib.rs`)

`DoraOutputSender` is the sole handle operators use to emit outputs — it appears in `DoraOperator::on_event`'s signature and in the crate-level example — yet it had no doc comment (this crate does not set `#[warn(missing_docs)]`, so the gap went uncaught and it renders with an empty description on docs.rs). Added a doc comment linking to `on_event` and `send`.

## Validation

- `cargo fmt -p dora-node-api -p dora-operator-api -- --check` clean.
- `cargo doc -p dora-node-api -p dora-operator-api --no-deps` builds; the new intra-doc links (`[\`Event\`]`, `[\`DoraOperator::on_event\`]`, `[\`DoraOutputSender::send\`]`) resolve with no new warnings. The 4 remaining warnings (`StreamDecoder`, `batch_slice`, `Buffer`×2) are pre-existing in untouched files and left alone per the repo convention "don't fix unrelated warnings in PRs".

Docs-only; no runtime behavior changes.

---

⚠️ *This PR is machine-generated by Claude (an AI assistant). Please review carefully before merging.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VatiTmTfc8dXfvVYqcGNs6

---
_Generated by [Claude Code](https://claude.ai/code/session_01VatiTmTfc8dXfvVYqcGNs6)_