### PR TITLE
fix(core): trim field-type strings in resolve_field_type to match the admission gate

### DIFF
--- a/libraries/core/src/types.rs
+++ b/libraries/core/src/types.rs
@@ -133,6 +133,13 @@ fn resolve_field_type(type_str: &str, registry: &TypeRegistry, depth: u8) -> Opt
         return None;
     }
 
+    // Trim surrounding whitespace so a padded field type (e.g. a quoted
+    // `"Float32 "` in YAML) resolves the same way here as in
+    // `TypeRegistry::field_type_resolves`, which already trims. Without this,
+    // the admission gate would accept the type but this materializer would
+    // return `None`, silently skipping the schema-compatibility check.
+    let type_str = type_str.trim();
+
     // 1. Try primitive Arrow type
     if let Some(dt) = arrow_type_from_name(type_str) {
         return Some(dt);
@@ -1363,5 +1370,49 @@ mod tests {
         // rejected (return false), not overflow the stack
         let deep = format!("{}Float32{}", "List<".repeat(100_000), ">".repeat(100_000));
         assert!(!reg.field_type_resolves(&deep));
+    }
+
+    #[test]
+    fn padded_field_type_gate_and_schema_agree() {
+        // Regression: `field_type_resolves` trims but `resolve_field_type` did
+        // not, so a whitespace-padded field type (e.g. a quoted `"Float32 "`
+        // in YAML) passed the admission gate yet failed to materialize into a
+        // schema — silently skipping the schema-compatibility check. Both must
+        // now agree.
+        let reg = TypeRegistry::new();
+
+        // The gate accepts the padded primitive and its padded `List<…>` form.
+        assert!(reg.field_type_resolves("Float32 "));
+        assert!(reg.field_type_resolves(" List<Float32> "));
+
+        let def = TypeDef {
+            arrow: "Struct".to_string(),
+            description: None,
+            params: vec![],
+            fields: vec![
+                FieldDef {
+                    name: "x".to_string(),
+                    r#type: "Float32 ".to_string(),
+                    nullable: true,
+                },
+                FieldDef {
+                    name: "xs".to_string(),
+                    r#type: " List<Float32> ".to_string(),
+                    nullable: true,
+                },
+            ],
+            metadata: vec![],
+        };
+
+        // …and the materializer now builds the same fields rather than None.
+        let schema = def
+            .to_arrow_schema_with_registry(&reg)
+            .expect("padded field types should build a schema, matching the gate");
+        assert_eq!(schema.fields().len(), 2);
+        assert_eq!(schema.fields()[0].data_type(), &DataType::Float32);
+        assert!(matches!(
+            schema.fields()[1].data_type(),
+            DataType::LargeList(_)
+        ));
     }
 }


### PR DESCRIPTION
## Summary

Two functions in `libraries/core/src/types.rs` are meant to agree on which struct field types are valid, but disagree on whitespace:

- `TypeRegistry::field_type_resolves` — the **admission gate** — trims its input at every level (`let t = type_str.trim();`).
- `resolve_field_type` — the **materializer** that builds the Arrow schema — only trimmed the *inner* type of `List<…>` (via `.map(str::trim)`), never its top-level argument. `arrow_type_from_name` and the registry lookups require an exact match.

## The bug

A whitespace-padded field type — e.g. a quoted `type: "Float32 "` (trailing space) in a type manifest — slips through the mismatch:

1. `field_type_resolves("Float32 ")` trims → `"Float32"` → `true`, so `NodeManifest::validate` / the manifest-injection admission fixpoint **accept and register** the type.
2. Later, `TypeDef::to_arrow_schema_with_registry` → `resolve_field_type("Float32 ", …)`: no top-level trim, `arrow_type_from_name("Float32 ") = None`, no `List<` prefix, registry lookup of `"Float32 " = None` → returns `None`.
3. The schema silently fails to build, so `check_schema_compat` gets `None` and **skips** the schema-compatibility check for edges using that type — the malformed type is quietly ignored rather than reported.

This is precisely the "resolves (URN exists) yet fails to build into a schema later" case the `field_type_resolves` gate was added to prevent.

## The fix

Add a top-level `let type_str = type_str.trim();` in `resolve_field_type` so it agrees with `field_type_resolves`. Low-severity (requires an unusually quoted YAML value, and the effect is a lost validation *warning*, not runtime corruption) but a clear-cut consistency bug with a one-line fix.

## Validation

- New regression test `padded_field_type_gate_and_schema_agree` asserts both the gate accepts and the materializer builds a schema for padded `"Float32 "` and `" List<Float32> "`. **Passes** (and fails without the fix — the materializer previously returned `None`).
- `cargo fmt -p dora-core -- --check`, `cargo clippy -p dora-core -- -D warnings`, `cargo test -p dora-core` all clean.

---

⚠️ *This PR is machine-generated by Claude (an AI assistant). Please review carefully before merging.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VatiTmTfc8dXfvVYqcGNs6

---
_Generated by [Claude Code](https://claude.ai/code/session_01VatiTmTfc8dXfvVYqcGNs6)_