### PR TITLE
perf(daemon): skip per-message metadata clone when output has no local receiver

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -5372,8 +5372,15 @@ async fn send_output_to_local_receivers(
     let empty_set = BTreeSet::new();
     let output_id = OutputId(node_id, output_id);
     let local_receivers = dataflow.mappings.get(&output_id).unwrap_or(&empty_set);
-    // Wrap in Arc once; fan-out clones are O(1) atomic ref bumps instead of O(payload_size) memcpy
-    let metadata = Arc::new(metadata.clone());
+    // Wrap in Arc once; fan-out clones are O(1) atomic ref bumps instead of O(payload_size) memcpy.
+    // Only clone the metadata when there is at least one local receiver to hand
+    // it to: for outputs consumed only across daemons — or while debug
+    // inspection forces `need_data_bytes` with no local subscriber — the loop
+    // below never runs, so this per-message `Metadata` deep-clone + allocation
+    // would otherwise be pure waste. (`data` still wraps unconditionally: the
+    // `need_data_bytes` move-out below expects an `Arc`, and a uniquely-owned
+    // one is moved out rather than copied.)
+    let metadata = (!local_receivers.is_empty()).then(|| Arc::new(metadata.clone()));
     let data = data.map(Arc::new);
     let mut closed = Vec::new();
     for (receiver_id, input_id) in local_receivers {
@@ -5390,7 +5397,11 @@ async fn send_output_to_local_receivers(
             }
             let item = NodeEvent::Input {
                 id: input_id.clone(),
-                metadata: metadata.clone(),
+                // `metadata` is `Some` whenever `local_receivers` is non-empty,
+                // which is the only way we reach this loop body.
+                metadata: metadata
+                    .clone()
+                    .expect("metadata is set when there are local receivers"),
                 data: data.clone(),
             };
             match channel.try_send(Timestamped {
@@ -6699,7 +6710,17 @@ mod fault_tolerance_tests {
         assert_eq!(result.as_deref(), Some(&payload[..]));
         let events = drain_events(&mut rx);
         assert_eq!(events.len(), 1);
-        assert!(matches_event(&events[0], "Input"));
+        match &events[0] {
+            NodeEvent::Input {
+                metadata: delivered,
+                ..
+            } => {
+                // The metadata is only Arc-wrapped when there is a local
+                // receiver; make sure the receiver still gets the original.
+                assert_eq!(delivered.timestamp(), metadata.timestamp());
+            }
+            other => panic!("expected Input event, got {other:?}"),
+        }
     }
 
     // -- Test 8: Full circuit breaker cycle: open -> break -> recover --


### PR DESCRIPTION
## Summary

`send_output_to_local_receivers` (`binaries/daemon/src/lib.rs`) is on the per-message output hot path. It unconditionally built an Arc-wrapped copy of the message metadata:

```rust
let local_receivers = dataflow.mappings.get(&output_id).unwrap_or(&empty_set);
let metadata = Arc::new(metadata.clone());   // always runs
```

but that Arc is only ever consumed inside the `for (receiver_id, input_id) in local_receivers` fan-out loop.

## The waste

When an output has **no local receiver** — a purely cross-daemon output, or any output while `enable_debug_inspection` forces `need_data_bytes = true` with no local subscriber — the loop body never executes, yet the full `Metadata` deep-clone (including its `parameters: BTreeMap<String, Parameter>`) plus an `Arc` allocation was performed and immediately dropped, **on every message**. The remote-forwarding path uses the original `&metadata` (moved into `InterDaemonEvent` by the caller), not this clone.

## The fix

Wrap the metadata only when there is at least one local receiver:

```rust
let metadata = (!local_receivers.is_empty()).then(|| Arc::new(metadata.clone()));
```

and unwrap it inside the loop (reached only when `local_receivers` is non-empty). `data` is left wrapped unconditionally on purpose — the `need_data_bytes` path below moves the payload out of a uniquely-owned `Arc` without copying, which is the existing zero-copy remote optimization.

## Validation

- The existing `data_bytes_returned_with_and_without_local_receivers` test already exercises both the no-receiver path (returns the payload, now with `metadata = None`) and the with-receiver path (delivers an `Input` event). Extended its with-receiver branch to assert the delivered metadata timestamp still matches the input — guarding metadata delivery through the `Option`/`expect` refactor.
- `cargo fmt -p dora-daemon -- --check`, `cargo clippy -p dora-daemon -- -D warnings`, `cargo test -p dora-daemon` (103 tests) all pass.

---

⚠️ *This PR is machine-generated by Claude (an AI assistant). Please review carefully before merging.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VatiTmTfc8dXfvVYqcGNs6

---
_Generated by [Claude Code](https://claude.ai/code/session_01VatiTmTfc8dXfvVYqcGNs6)_