### PR TITLE
fix(daemon,core): correct misleading zenoh bind-failure warning and document per-node advertise-before-bind race (#2762)

### DIFF
--- a/binaries/daemon/src/spawn/spawner.rs
+++ b/binaries/daemon/src/spawn/spawner.rs
@@ -135,6 +135,24 @@ pub struct NodeZenohPeering {
 /// Dynamic nodes are omitted: they are not in the descriptor's spawn set and join
 /// at arbitrary times, so they keep the daemon-endpoint-only behavior.
 ///
+/// # Caveat: per-node endpoints are advertised before they bind (#2762)
+///
+/// This reserves each local node's loopback port with
+/// `dora_core::topics::reserve_loopback_zenoh_endpoint`
+/// — which binds `127.0.0.1:0`, reads the port, and drops the socket — and commits
+/// that port into every *consumer's* dial list here at plan time, i.e. **before the
+/// producing node process has bound it**. Unlike the daemon's own listener, these
+/// per-node endpoints are therefore *not* covered by the bind-verification in
+/// `open_zenoh_session_with_listen` (#1858): the node opens with
+/// `listen/exit_on_failure: false` and discards its own `effective_listen_endpoint`,
+/// so a lost reserve→bind race (another process grabs the port in the window) leaves
+/// the producer listener-less while its consumers hold a dead endpoint. Because those
+/// consumers also have explicit `connect/endpoints`, multicast scouting is disabled
+/// for them, so there is no fallback and that edge is silently partitioned. The
+/// probability is low (the OS keeps handing out fresh ephemeral ports) but the impact
+/// is silent data loss; closing the window fully requires holding each reservation
+/// until the child binds, or verifying the per-node bind and re-planning on failure.
+///
 /// Only *local* nodes are planned. `nodes` spans the whole dataflow including
 /// nodes on other daemons, whose endpoints are not on this host's loopback, so a
 /// local consumer of a remote producer gets no dial for it and keeps the existing

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -330,11 +330,31 @@ pub async fn open_zenoh_session_with_listen(
                             .any(|l| l.split(['?', '#']).next() == Some(requested.as_str()));
                         if bound {
                             effective_listen_endpoint = Some(requested);
+                        } else if connect_inserted {
+                            // We set explicit `connect/endpoints` above, so
+                            // multicast scouting was disabled for this session
+                            // (#1856). There is therefore NO discovery fallback:
+                            // peers already told to dial `{requested}` (e.g. via
+                            // the per-node `DORA_ZENOH_CONNECT` plan from #2716)
+                            // cannot reach this now-listener-less session, and it
+                            // cannot be scouted either — that edge is silently
+                            // partitioned. Do not claim "multicast scouting only"
+                            // here; that fallback does not exist in this mode and
+                            // the old message pointed debuggers the wrong way
+                            // (#2762).
+                            warn!(
+                                "zenoh session opened but listener for `{requested}` \
+                                 did not bind (actually bound: {bound_locators:?}); \
+                                 multicast scouting is disabled for this session \
+                                 (explicit connect endpoints are set), so peers told \
+                                 to dial `{requested}` have no fallback path to reach \
+                                 it (#2762)"
+                            );
                         } else {
                             warn!(
                                 "zenoh session opened but listener for `{requested}` \
                                  did not bind (actually bound: {bound_locators:?}); \
-                                 spawned nodes will use multicast scouting only"
+                                 falling back to multicast scouting for discovery"
                             );
                         }
                     }


### PR DESCRIPTION
Fixes the "at minimum" part of #2762.

## Background

The per-node zenoh listener mechanism added in #2716 (`plan_zenoh_peering` + `DORA_ZENOH_LISTEN`/`DORA_ZENOH_CONNECT`) reserves each local node's loopback port with `reserve_loopback_zenoh_endpoint()` (bind `127.0.0.1:0`, read the port, drop the socket) and commits that port into every **consumer's** dial list at plan time — **before the producing node process binds it**. Those consumers also set explicit `connect/endpoints`, which disables multicast scouting. If the reserve→bind window is lost (another process grabs the port), the producer runs listener-less, the consumers hold a dead endpoint, and there is **no multicast fallback** — that edge is silently partitioned.

Unlike the daemon's own listener, this path is **not** covered by the #1858 bind-verification: the node opens with `listen/exit_on_failure: false` and `open_zenoh_session` discards its own `effective_listen_endpoint`, so nothing propagates the failed bind back to the consumers that were already told to dial it.

## What this PR changes

This is the low-risk, explicitly-endorsed "at minimum" fix from the issue (suggested fix #3). It does **not** attempt to close the race itself.

- **`libraries/core/src/topics.rs`** — the bind-verification warning claimed *"spawned nodes will use multicast scouting only"* unconditionally. But when explicit `connect/endpoints` are set (`connect_inserted`), multicast scouting was just disabled, so that fallback does **not** exist. The old message pointed a debugger the wrong way when the race actually fired. The warning is now split:
  - explicit connect endpoints set → no fallback path; the message says so and references #2762;
  - otherwise → genuinely falls back to multicast scouting.

- **`binaries/daemon/src/spawn/spawner.rs`** — document on `plan_zenoh_peering` that the per-node endpoints are advertised to consumers **before** the node binds, and are therefore **not** covered by the #1858 daemon-listener bind verification, so future readers don't assume they are.

## Deliberately out of scope (needs maintainer design input)

The two structural fixes from the issue — (1) holding each port reservation until the child confirms its bind, or (2) propagating each node's `effective_listen_endpoint` back to the daemon and re-planning/keeping multicast on failure — are larger changes to the fault-tolerance-sensitive spawn path and are left for maintainer direction. The race probability is low (fresh ephemeral ports each call); the value here is removing the misleading diagnostic and recording the gap.

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p dora-core -p dora-daemon -- -D warnings` — clean
- `cargo test -p dora-core -p dora-daemon` — pass (105 tests)

Changes are a logging-message refactor and a doc comment; no control-flow logic changed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VVAiDbEZ7Uuy3K4yH7vwJz)_