### PR TITLE
fix(telemetry): propagate OTLP metric-exporter build failures instead of panicking

### DIFF
--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -242,7 +242,7 @@ async fn start_with_events(
     // Start WS server
     #[cfg(feature = "metrics")]
     let _meter_provider = {
-        let provider = dora_metrics::init_metrics();
+        let provider = dora_metrics::init_metrics()?;
         opentelemetry::global::set_meter_provider(provider.clone());
         provider
     };

--- a/libraries/extensions/telemetry/metrics/src/lib.rs
+++ b/libraries/extensions/telemetry/metrics/src/lib.rs
@@ -10,7 +10,7 @@
 //! [`sysinfo`]: https://github.com/GuillaumeGomez/sysinfo
 //! [`opentelemetry-rust`]: https://github.com/open-telemetry/opentelemetry-rust
 
-use eyre::Result;
+use eyre::{Result, WrapErr};
 use opentelemetry::{InstrumentationScope, global};
 use opentelemetry_otlp::MetricExporter;
 use opentelemetry_sdk::metrics::SdkMeterProvider;
@@ -20,19 +20,19 @@ use opentelemetry_system_metrics::init_process_observer;
 /// Use the default Opentelemetry exporter with default config
 /// TODO: Make Opentelemetry configurable
 ///
-pub fn init_metrics() -> SdkMeterProvider {
+pub fn init_metrics() -> Result<SdkMeterProvider> {
     let exporter = MetricExporter::builder()
         .with_tonic()
         .build()
-        .expect("Failed to create metric exporter");
+        .wrap_err("failed to create metric exporter")?;
 
-    SdkMeterProvider::builder()
+    Ok(SdkMeterProvider::builder()
         .with_periodic_exporter(exporter)
-        .build()
+        .build())
 }
 
 pub async fn run_metrics_monitor(meter_id: String) -> Result<()> {
-    let meter_provider = init_metrics();
+    let meter_provider = init_metrics()?;
     global::set_meter_provider(meter_provider.clone());
     let scope = InstrumentationScope::builder(meter_id)
         .with_version("1.0")

--- a/libraries/extensions/telemetry/tracing/src/lib.rs
+++ b/libraries/extensions/telemetry/tracing/src/lib.rs
@@ -181,7 +181,8 @@ impl TracingBuilder {
         // Initialize OTLP tracing - this returns a tracer and sets the global provider
         let sdk_tracer_provider = crate::telemetry::init_tracing(&self.name, &endpoint)
             .wrap_err("failed to initialize OTLP tracing exporter")?;
-        let meter_provider = metrics::init_meter_provider(&endpoint);
+        let meter_provider = metrics::init_meter_provider(&endpoint)
+            .wrap_err("failed to initialize OTLP metrics exporter")?;
 
         // TODO: Maybe this needs to be removed in favor of application level global.
         // global::set_meter_provider(meter_provider.clone());

--- a/libraries/extensions/telemetry/tracing/src/metrics.rs
+++ b/libraries/extensions/telemetry/tracing/src/metrics.rs
@@ -1,3 +1,4 @@
+use eyre::WrapErr;
 use opentelemetry_otlp::{MetricExporter, WithExportConfig};
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 
@@ -10,14 +11,14 @@ use opentelemetry_sdk::metrics::SdkMeterProvider;
 /// where the metric exporter ignored `DORA_OTLP_ENDPOINT` and always fell back
 /// to the OTLP gRPC default (`http://localhost:4317`), silently diverging from
 /// the trace exporter when a remote collector was configured.
-pub fn init_meter_provider(endpoint: &str) -> SdkMeterProvider {
+pub fn init_meter_provider(endpoint: &str) -> eyre::Result<SdkMeterProvider> {
     let exporter = MetricExporter::builder()
         .with_tonic()
         .with_endpoint(endpoint)
         .build()
-        .expect("Failed to create metric exporter");
+        .wrap_err("failed to create metric exporter")?;
 
-    SdkMeterProvider::builder()
+    Ok(SdkMeterProvider::builder()
         .with_periodic_exporter(exporter)
-        .build()
+        .build())
 }


### PR DESCRIPTION
## Issue

`dora-tracing`'s `init_meter_provider` and `dora-metrics`'s `init_metrics` returned a bare `SdkMeterProvider` and `.expect()`ed on the fallible exporter build:

```rust
let exporter = MetricExporter::builder()
    .with_tonic()
    .build()
    .expect("Failed to create metric exporter");
```

`MetricExporter::builder().with_tonic().build()` genuinely returns a `Result` and can fail — e.g. an invalid endpoint derived from `DORA_OTLP_ENDPOINT`, or TLS/transport setup failure.

Both functions are only reachable from public APIs that **already return `eyre::Result` and carefully wrap every other fallible step**:
- `TracingBuilder::with_otlp_tracing` (wraps `init_tracing`, the endpoint lookup, …)
- `run_metrics_monitor`
- the coordinator's `#[cfg(feature = "metrics")]` init block

So a build failure aborted the whole node/coordinator process via panic instead of surfacing as a normal error.

## Fix

Return `eyre::Result<SdkMeterProvider>` from both functions (`.wrap_err(...)?`) and propagate at the three call sites.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p dora-tracing -p dora-metrics -p dora-coordinator --features metrics -- -D warnings` — clean
- `cargo test -p dora-tracing -p dora-metrics` — pass (incl. doctests)
- `cargo test -p dora-coordinator --features metrics` — pass
- Confirmed all three call sites (the only callers in the workspace) are updated.

---

🤖 This PR is **machine-generated by Claude** (an AI agent) as part of an automated code-review pass. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9EsyZqeYbHZjjgpdMazTu

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9EsyZqeYbHZjjgpdMazTu)_