### PR TITLE
perf(runtime): drop per-message input-id clone in the operator dispatch loop

### DIFF
--- a/binaries/runtime/src/lib.rs
+++ b/binaries/runtime/src/lib.rs
@@ -293,13 +293,16 @@ async fn run(
 
                 if let Err(err) = operator_channel
                     .send_async(Event::Input {
-                        id: input_id.clone(),
+                        id: input_id,
                         metadata,
                         data,
                     })
                     .await
                     .wrap_err_with(|| {
-                        format!("failed to send input `{input_id}` to operator `{operator_id}`")
+                        // `id` is the full `operator/input` DataId; use it (and the
+                        // still-owned `operator_id`) here so `input_id` can be moved
+                        // into the event above without a per-message clone.
+                        format!("failed to send input `{id}` to operator `{operator_id}`")
                     })
                 {
                     tracing::warn!("{err}");


### PR DESCRIPTION
## Issue

The runtime's input-forwarding arm cloned `input_id` on **every** input message:

```rust
operator_channel.send_async(Event::Input {
    id: input_id.clone(),   // <-- per-message heap allocation
    metadata,
    data,
})
.await
.wrap_err_with(|| {
    format!("failed to send input `{input_id}` to operator `{operator_id}`")
})
```

The clone existed only so `input_id` could still be referenced in the `wrap_err_with` closure — a closure that runs **only on the rare channel-send failure**. `DataId` is a newtype over `String`, so this paid a heap allocation on the steady-state per-message dispatch path to serve a cold error path.

## Fix

Move `input_id` into the event and have the error closure use the already-owned `id` (the full `operator/input` `DataId`) and `operator_id`. Behavior is unchanged on success; the error message is equally informative (arguably more so — it now names the full input path).

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p dora-runtime -- -D warnings` — clean
- `cargo test -p dora-runtime` — pass

---

🤖 This PR is **machine-generated by Claude** (an AI agent) as part of an automated code-review pass. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9EsyZqeYbHZjjgpdMazTu

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9EsyZqeYbHZjjgpdMazTu)_