### PR TITLE
fix(coordinator-store): reject over-limit records at write time to prevent silent data loss

### DIFF
--- a/libraries/coordinator-store/src/redb_store.rs
+++ b/libraries/coordinator-store/src/redb_store.rs
@@ -109,18 +109,30 @@ impl RedbStore {
 // Serialisation helpers
 // ---------------------------------------------------------------------------
 
+/// Maximum size of a single serialized record. `decode` refuses to *read*
+/// beyond this (capping allocation from a malformed varint length prefix), and
+/// `encode` refuses to *write* beyond it. The two limits must match: a record
+/// that encodes larger than `decode` will accept is silently unreadable —
+/// `put_dataflow` would persist it, but every later `get_dataflow` returns a
+/// decode error and `list_dataflows` skips it as "corrupt" (dora-rs/dora#2027),
+/// dropping a perfectly valid dataflow from startup recovery. Guarding at write
+/// time turns that silent data loss into an explicit error at the source.
+const MAX_RECORD_BYTES: usize = 64 * 1024 * 1024;
+
 fn encode<T: serde::Serialize>(value: &T) -> Result<Vec<u8>> {
-    bincode::serde::encode_to_vec(value, bincode::config::standard())
-        .map_err(|e| eyre!("encode error: {e}"))
+    let bytes = bincode::serde::encode_to_vec(value, bincode::config::standard())
+        .map_err(|e| eyre!("encode error: {e}"))?;
+    if bytes.len() > MAX_RECORD_BYTES {
+        eyre::bail!(
+            "record too large to store: {} bytes exceeds the {MAX_RECORD_BYTES}-byte limit",
+            bytes.len()
+        );
+    }
+    Ok(bytes)
 }
 
-/// Decode uses a separate config with a 64 MiB limit that `encode` intentionally
-/// omits: encoding our own data needs no guard, but decoding potentially corrupt
-/// data must cap allocation sizes to prevent OOM from malformed varint length
-/// prefixes. The limit type is a const generic in bincode 2.x, so it cannot
-/// share a single `const` with the unlimited encode config.
 fn decode<T: serde::de::DeserializeOwned>(bytes: &[u8]) -> Result<T> {
-    let config = bincode::config::standard().with_limit::<{ 64 * 1024 * 1024 }>();
+    let config = bincode::config::standard().with_limit::<{ MAX_RECORD_BYTES }>();
     let (val, _) =
         bincode::serde::decode_from_slice(bytes, config).map_err(|e| eyre!("decode error: {e}"))?;
     Ok(val)
@@ -420,6 +432,28 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let store = RedbStore::open(&dir.path().join("test.redb")).unwrap();
         (store, dir)
+    }
+
+    /// A record that serializes beyond `MAX_RECORD_BYTES` is rejected at write
+    /// time (`encode`) rather than persisted and then silently skipped as
+    /// "corrupt" by the `list_*` recovery paths. Write and read limits must
+    /// stay symmetric — see the `MAX_RECORD_BYTES` doc (dora-rs/dora#2027).
+    #[test]
+    fn encode_rejects_record_larger_than_decode_limit() {
+        // Serializes to just over the limit (raw bytes + a small length prefix),
+        // exactly the size `decode`'s `with_limit` would refuse to read back.
+        let oversized = vec![0u8; MAX_RECORD_BYTES + 1];
+        let err = encode(&oversized).unwrap_err();
+        assert!(
+            err.to_string().contains("too large"),
+            "expected 'too large' error, got: {err}"
+        );
+
+        // A normal-sized record still encodes and round-trips.
+        let small = vec![1u8, 2, 3];
+        let bytes = encode(&small).unwrap();
+        let decoded: Vec<u8> = decode(&bytes).unwrap();
+        assert_eq!(decoded, small);
     }
 
     #[test]


### PR DESCRIPTION
## Issue

`RedbStore::decode` deliberately caps deserialization at 64 MiB (to bound allocation from a malformed varint length prefix):

```rust
let config = bincode::config::standard().with_limit::<{ 64 * 1024 * 1024 }>();
```

…but `encode` and the `put_*` write paths had **no matching bound**. The two limits were asymmetric, so a `put` → `get` round-trip was not guaranteed to be lossless for the store's own data:

- A `DataflowRecord` whose `descriptor_json` / `node_to_daemon` map serialized to more than 64 MiB was accepted by `put_dataflow` and written to disk.
- Every later `get_dataflow` then returned a decode error, and `list_dataflows` treated that as a **corrupt row and silently skipped it** (the skip logic added for #2027).
- After a coordinator restart, the dataflow silently vanished from recovery even though its on-disk bytes were perfectly valid — a write that can never be read back, mislabeled as corruption.

## Fix

Share a single `MAX_RECORD_BYTES` constant between `decode`'s `with_limit` and a new length check in `encode`, so an over-limit record is rejected **loudly at write time** with a clear error instead of becoming silently unreadable. This also removes the duplicated `64 * 1024 * 1024` literal.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p dora-coordinator-store --all-targets -- -D warnings` — clean
- `cargo test -p dora-coordinator-store --features redb-backend` — 34 pass, including a new regression test `encode_rejects_record_larger_than_decode_limit`.

---

🤖 This PR is **machine-generated by Claude** (an AI agent) as part of an automated code-review pass. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9EsyZqeYbHZjjgpdMazTu

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9EsyZqeYbHZjjgpdMazTu)_