### PR TITLE
perf(runtime): build the shared-lib SendOutput wrapper once, not per event

### DIFF
--- a/binaries/runtime/src/operator/shared_lib.rs
+++ b/binaries/runtime/src/operator/shared_lib.rs
@@ -151,6 +151,14 @@ impl SharedLibraryOperator<'_> {
             }
         });
 
+        // `send_output_closure` is invariant across events, so build the FFI
+        // `SendOutput` wrapper once and reuse it by reference each iteration
+        // rather than cloning the `Arc` and reconstructing an `ArcDynFn1` per
+        // event.
+        let send_output = SendOutput {
+            send_output: ArcDynFn1::new(send_output_closure),
+        };
+
         let reason = loop {
             #[allow(unused_mut)]
             let Ok(mut event) = self.incoming_events.recv() else {
@@ -240,9 +248,6 @@ impl SharedLibraryOperator<'_> {
                 }
             };
 
-            let send_output = SendOutput {
-                send_output: ArcDynFn1::new(send_output_closure.clone()),
-            };
             let OnEventResult {
                 result: DoraResult { error },
                 status,


### PR DESCRIPTION
## Issue

The shared-library operator loop rebuilt the FFI `SendOutput` wrapper on **every** incoming event:

```rust
let send_output = SendOutput {
    send_output: ArcDynFn1::new(send_output_closure.clone()),
};
```

`send_output_closure` is created once before the loop and never changes, so this paid an `Arc` clone (atomic refcount traffic) plus an `ArcDynFn1` construction per event, purely to hand the same invariant callback to the FFI `on_event`.

## Fix

Construct the `SendOutput` once before the loop and pass `&send_output` each iteration. Behavior is identical; the per-event refcount churn and allocation are gone.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p dora-runtime -- -D warnings` — clean
- `cargo test -p dora-runtime` — pass

---

🤖 This PR is **machine-generated by Claude** (an AI agent) as part of an automated code-review pass. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9EsyZqeYbHZjjgpdMazTu

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9EsyZqeYbHZjjgpdMazTu)_