### PR TITLE
fix(arrow-convert): correct copy-pasted error context in NaiveDateTime conversion

### DIFF
--- a/libraries/arrow-convert/src/from_impls.rs
+++ b/libraries/arrow-convert/src/from_impls.rs
@@ -240,7 +240,7 @@ impl TryFrom<&ArrowData> for NaiveDateTime {
         }
         let array = value
             .as_primitive_opt::<arrow::datatypes::TimestampNanosecondType>()
-            .context("not any of the primitive Time arrays")?;
+            .context("not any of the primitive Timestamp arrays")?;
         if check_single_datetime(array) {
             eyre::bail!("Not a valid array");
         }


### PR DESCRIPTION
## Issue

The `TryFrom<&ArrowData> for NaiveDateTime` fallback downcasts to `TimestampNanosecondType`, but its error context read:

```rust
.context("not any of the primitive Time arrays")?;
```

That string was copied verbatim from the sibling `NaiveTime` impl. A caller passing, e.g., a `Float64Array` where a `NaiveDateTime` is expected got an error mentioning **"Time arrays"**, which is misleading (the impl handles `Timestamp*` arrays).

## Fix

Correct the message to "not any of the primitive **Timestamp** arrays". Error-path only; no logic change.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p dora-arrow-convert --all-targets -- -D warnings` — clean
- `cargo test -p dora-arrow-convert` — pass

---

🤖 This PR is **machine-generated by Claude** (an AI agent) as part of an automated code-review pass. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9EsyZqeYbHZjjgpdMazTu

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9EsyZqeYbHZjjgpdMazTu)_