### PR TITLE
fix(message): reject metadata wire-format skew at node register

### DIFF
--- a/libraries/message/src/node_to_daemon.rs
+++ b/libraries/message/src/node_to_daemon.rs
@@ -84,6 +84,17 @@ pub struct NodeRegisterRequest {
     pub dataflow_id: DataflowId,
     pub node_id: NodeId,
     dora_version: semver::Version,
+    /// The metadata wire-format version this node was built against
+    /// ([`Metadata::CURRENT_VERSION`]).
+    ///
+    /// The `dora_version` semver check above is too coarse to catch a
+    /// message-format break within a release series: two builds that both
+    /// report `1.0.0-rc` are "compatible" by semver even when the payload
+    /// layout differs (as it did across #2366). Carrying the format version
+    /// explicitly lets the daemon reject an incompatible peer at register with
+    /// a clear message, instead of the node desyncing mid-stream into a
+    /// cryptic `tag for enum is not valid` bincode error (#2742).
+    metadata_version: u16,
 }
 
 impl NodeRegisterRequest {
@@ -92,6 +103,7 @@ impl NodeRegisterRequest {
             dataflow_id,
             node_id,
             dora_version: semver::Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
+            metadata_version: Metadata::CURRENT_VERSION,
         }
     }
 
@@ -99,19 +111,72 @@ impl NodeRegisterRequest {
         let crate_version = current_crate_version();
         let specified_version = &self.dora_version;
 
-        if versions_compatible(&crate_version, specified_version)? {
-            Ok(())
-        } else {
-            Err(format!(
+        if !versions_compatible(&crate_version, specified_version)? {
+            return Err(format!(
                 "version mismatch: message format v{} is not compatible \
                 with expected message format v{crate_version}",
                 self.dora_version
-            ))
+            ));
         }
+
+        // Even when the semver check passes, the payload wire format can still
+        // differ within a release series (#2366 dropped a `Metadata` field
+        // without changing the version). Reject that here so the failure is a
+        // legible register-time error rather than a mid-stream desync (#2742).
+        if self.metadata_version != Metadata::CURRENT_VERSION {
+            return Err(format!(
+                "message wire-format mismatch: node speaks metadata format v{} \
+                but this daemon speaks v{}. The node and daemon were built from \
+                dora revisions with incompatible message formats; rebuild both \
+                from the same revision.",
+                self.metadata_version,
+                Metadata::CURRENT_VERSION
+            ));
+        }
+
+        Ok(())
     }
 }
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub enum DynamicNodeEvent {
     NodeConfig { node_id: NodeId },
+}
+
+#[cfg(test)]
+mod register_version_tests {
+    use super::*;
+
+    fn request() -> NodeRegisterRequest {
+        NodeRegisterRequest::new(uuid::Uuid::nil(), NodeId::from("test-node".to_string()))
+    }
+
+    #[test]
+    fn new_stamps_current_metadata_version() {
+        assert_eq!(request().metadata_version, Metadata::CURRENT_VERSION);
+    }
+
+    #[test]
+    fn check_version_accepts_a_matching_request() {
+        // A request built by this same crate version passes both the semver
+        // and the wire-format gate.
+        request().check_version().unwrap();
+    }
+
+    #[test]
+    fn check_version_rejects_a_wire_format_mismatch() {
+        // A peer built from a dora revision with a different metadata wire
+        // format — same semver, incompatible bytes. This is the #2366 / #2742
+        // shape: it must be rejected at register with a legible message rather
+        // than desyncing mid-stream into a cryptic bincode error.
+        let mut req = request();
+        req.metadata_version = Metadata::CURRENT_VERSION.wrapping_add(1);
+        let err = req
+            .check_version()
+            .expect_err("mismatched metadata wire version must be rejected");
+        assert!(
+            err.contains("wire-format") && err.contains(&Metadata::CURRENT_VERSION.to_string()),
+            "error should name the wire-format mismatch and the expected version, got: {err}"
+        );
+    }
 }


### PR DESCRIPTION
The `dora_version` semver check on `NodeRegisterRequest` is too coarse to catch a message-format break within a release series: two builds that both report `1.0.0-rc` pass as compatible even when the payload layout differs. #2366 dropped a `Metadata` field without a semver bump, so a stale git-pinned node registered successfully and only desynced later, mid-stream, with a cryptic `tag for enum is not valid` bincode error (#2742).

Carry the node's `Metadata::CURRENT_VERSION` in the register request and reject a mismatch against the daemon's own version with a legible message naming both sides. The check rides inside the existing `check_version()`, so no daemon change is needed.

Note the wire-format tradeoff, acceptable at 1.0.0-rc: appending the field is itself a one-time break of the register message. A node built before this change registering against a newer daemon fails to deserialize ("unexpected end of file") rather than getting the new legible error — the clean message only appears once both ends carry the field. From here on, every future format break that bumps CURRENT_VERSION is caught at register.

Refs #2742