### PR TITLE
fix(node): bound zenoh teardown below the daemon force-kill grace

### DIFF
--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -130,9 +130,25 @@ const ZENOH_OUTPUT_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 /// Poll interval while waiting for output routes to connect at startup.
 const ZENOH_OUTPUT_CONNECT_POLL_INTERVAL: Duration = Duration::from_millis(5);
 
-/// Must exceed zenoh's internal 10s session close timeout, which is not
-/// enforceable when zenoh's net runtime is wedged.
-pub(crate) const ZENOH_TEARDOWN_TIMEOUT: Duration = Duration::from_secs(15);
+/// Per-phase deadline for tearing down zenoh state on node shutdown (subscribers,
+/// liveliness tokens, and the session/publishers — see [`DoraNode::drop`] and
+/// `EventStream::drop`). Each `undeclare`/close blocks indefinitely when zenoh's net
+/// runtime is wedged (e.g. retrying an unreachable scouted peer on a headless CI
+/// runner), so it is bounded here and abandoned on timeout.
+///
+/// This MUST stay comfortably below the daemon's force-kill grace
+/// (`DEFAULT_STOP_GRACE (10s) + DEFAULT_STOP_GRACE/2 = 15s`, see
+/// `binaries/daemon/src/running_dataflow.rs`), including the worst case where all
+/// three phases wedge sequentially (`3 *` this value). Otherwise a node with a wedged
+/// net runtime is still tearing down when the daemon `TerminateProcess`es it, which on
+/// Windows surfaces as `ExitCode(1)` and reddens the nightly (dora-rs/dora#2742). The
+/// `zenoh_teardown_fits_within_daemon_force_kill_grace` test guards the invariant.
+///
+/// This deliberately no longer exceeds zenoh's internal 10s session-close timeout: a
+/// semi-wedged close that would settle at ~10s is abandoned instead, and peers fall
+/// back to liveliness expiry. That is the right trade for a *shutting-down* node —
+/// waiting out the 10s only to be force-killed anyway yields a worse (unclean) exit.
+pub(crate) const ZENOH_TEARDOWN_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// Allows sending outputs and retrieving node information.
 ///
@@ -3106,5 +3122,27 @@ mod tests {
             panic!("teardown panicked")
         });
         assert!(completed, "panicking teardown still counts as completed");
+    }
+
+    // Regression guard for dora-rs/dora#2742: the node's worst-case zenoh teardown must
+    // stay under the daemon's force-kill grace (full rationale on `ZENOH_TEARDOWN_TIMEOUT`).
+    //
+    // Teardown runs in sequential bounded phases (two in `EventStream::drop`, one in
+    // `DoraNode::drop`), so the worst case is `TEARDOWN_PHASES * ZENOH_TEARDOWN_TIMEOUT` —
+    // bump `TEARDOWN_PHASES` if you add another. The grace is `DEFAULT_STOP_GRACE +
+    // DEFAULT_STOP_GRACE/2 = 15s` (`binaries/daemon/src/running_dataflow.rs`); it lives in
+    // a binary crate that can't be imported here, hence the hard-coded copy, which the
+    // daemon const back-references so the two can't silently drift apart.
+    #[test]
+    fn zenoh_teardown_fits_within_daemon_force_kill_grace() {
+        const DAEMON_FORCE_KILL_GRACE: Duration = Duration::from_secs(15);
+        const TEARDOWN_PHASES: u32 = 3;
+        let worst_case = ZENOH_TEARDOWN_TIMEOUT * TEARDOWN_PHASES;
+        assert!(
+            worst_case < DAEMON_FORCE_KILL_GRACE,
+            "worst-case zenoh teardown ({worst_case:?}) must stay under the daemon \
+             force-kill grace ({DAEMON_FORCE_KILL_GRACE:?}); raising ZENOH_TEARDOWN_TIMEOUT \
+             reintroduces dora-rs/dora#2742"
+        );
     }
 }

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -16,7 +16,12 @@ use dora_message::{
     metadata::{self},
     node_to_daemon::Timestamped,
 };
-/// Default grace period before force-killing a stopped node.
+/// Default grace period before force-killing a stopped node. A stopped node is
+/// hard-killed at `DEFAULT_STOP_GRACE + DEFAULT_STOP_GRACE/2` (= 15s), so a node's own
+/// zenoh teardown deadline must stay under that or it gets force-killed mid-teardown
+/// (`ExitCode(1)` on Windows — dora-rs/dora#2742). Kept in sync by
+/// `ZENOH_TEARDOWN_TIMEOUT` in `apis/rust/node/src/node/mod.rs` and its
+/// `zenoh_teardown_fits_within_daemon_force_kill_grace` guard test.
 const DEFAULT_STOP_GRACE: Duration = Duration::from_millis(10_000);
 /// Default grace period before force-killing a restarting node.
 const DEFAULT_RESTART_GRACE: Duration = Duration::from_millis(5_000);


### PR DESCRIPTION
The nightly `CLI Tests (windows-latest)` job (`python-operator-dataflow`) has failed every night, distinct from the Arrow IPC wire break that #2745 already fixed in the examples job.

On shutdown a node tears down its zenoh subscribers, liveliness tokens, and session under `ZENOH_TEARDOWN_TIMEOUT` — which was **15s, exactly the daemon's `DEFAULT_STOP_GRACE * 1.5 = 15s` force-kill deadline**. When the zenoh net runtime is wedged (unreachable scouted peers on a headless CI runner), each `undeclare`/close blocks to its full deadline, so the daemon `TerminateProcess`es the node ~1s before it gives up. On Windows that surfaces as `ExitCode(1)` and reddens the job; on Unix the identical kill is masked as `Signal(15)`, which is why only Windows shows it.

Lower the timeout to **3s** so a node with a wedged runtime abandons teardown and exits cleanly before the force-kill on all platforms (three sequential teardown phases → 9s worst case, comfortably under 15s). This deliberately no longer waits out zenoh's internal 10s session-close: a semi-wedged close is abandoned and peers fall back to liveliness expiry — the right trade for a shutting-down node.

Adds a guard test asserting the worst-case teardown stays under the grace, plus a back-reference on the daemon const so the two can't silently drift.

Refs #2742.

Follow-ups intentionally out of scope: hoisting the stop-grace into a shared crate so the guard tracks the real daemon value instead of a hard-coded copy, and eliminating the zenoh teardown wedge at its source (separate issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
