### PR TITLE
perf(core): look up wiring source node by key instead of scanning all nodes

### DIFF
--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -445,7 +445,12 @@ fn check_input(
     match &input.mapping {
         InputMapping::Timer { interval: _ } | InputMapping::Logs(_) => {}
         InputMapping::User(UserInputMapping { source, output }) => {
-            let source_node = nodes.values().find(|n| &n.id == source).ok_or_else(|| {
+            // `nodes` is keyed by each node's own id (see
+            // `resolve_aliases_and_set_defaults`), so look the source up
+            // directly instead of scanning every node — this runs once per
+            // input of every node, so a linear scan makes wiring validation
+            // quadratic in the node count.
+            let source_node = nodes.get(source).ok_or_else(|| {
                 eyre!("source node `{source}` mapped to input `{input_id_str}` does not exist",)
             })?;
             match &source_node.kind {


### PR DESCRIPTION
## Issue

In `libraries/core/src/descriptor/validate.rs`, `check_input` resolved an input's source node with a linear scan:

```rust
let source_node = nodes.values().find(|n| &n.id == source).ok_or_else(...)?;
```

But `nodes` is a `BTreeMap<NodeId, ResolvedNode>` **keyed by exactly that `NodeId`** — `resolve_aliases_and_set_defaults` inserts each node under its own id (`resolved.insert(node.id.clone(), ResolvedNode { id: node.id, ... })`). `check_wiring` calls `check_input` once for every input of every node, so the scan makes wiring validation **O(nodes × inputs × nodes)** — quadratic in the node count. For a large dataflow this is wasted work on every `dora start`/build validation.

## Fix

Replace the scan with the O(log N) map lookup:

```rust
let source_node = nodes.get(source).ok_or_else(...)?;
```

This is behavior-preserving because the map key is the node's own id, so `get(source)` returns exactly the node the scan found (and produces the same "source node does not exist" error when absent).

## Validation

- `cargo fmt -p dora-core -- --check`, `cargo clippy -p dora-core -- -D warnings`, and `cargo test -p dora-core` all pass (89 `descriptor::validate` tests green, covering the wiring-validation paths that exercise this lookup, including the missing-source-node error case).

---
🤖 This pull request is **machine-generated by Claude** (an AI agent) as part of an automated codebase review. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyLwUdy2NmPySXpKyCxowK)_