### PR TITLE
perf(daemon): drop per-log-line env read and content clones in the log path

### DIFF
--- a/binaries/daemon/src/spawn/prepared.rs
+++ b/binaries/daemon/src/spawn/prepared.rs
@@ -662,14 +662,17 @@ impl PreparedNode {
                     }
                 };
                 truncate_log_line(&mut content);
-                let sent = stdout_tx
+                // Move `content` into the `LogLine`; on the rare closed-channel
+                // error, recover it from the returned `SendError` for the
+                // warning instead of cloning on every line.
+                if let Err(mpsc::error::SendError(unsent)) = stdout_tx
                     .send(LogLine {
-                        content: content.clone(),
+                        content,
                         stream: LogStream::Stdout,
                     })
-                    .await;
-                if sent.is_err() {
-                    tracing::warn!("Could not log: {content}");
+                    .await
+                {
+                    tracing::warn!("Could not log: {}", unsent.content);
                 }
             }
         });
@@ -719,14 +722,17 @@ impl PreparedNode {
                 // Store the truncated line in the crash-diagnostics ring buffer
                 // so a single over-long line cannot be retained in full here.
                 self.node_stderr_most_recent.force_push(content.clone());
-                let sent = stderr_tx
+                // Move `content` into the `LogLine` (the ring-buffer clone above
+                // is the only copy kept); recover it from `SendError` on the rare
+                // closed-channel error rather than cloning again per line.
+                if let Err(mpsc::error::SendError(unsent)) = stderr_tx
                     .send(LogLine {
-                        content: content.clone(),
+                        content,
                         stream: LogStream::Stderr,
                     })
-                    .await;
-                if sent.is_err() {
-                    tracing::warn!("Could not log: {content}");
+                    .await
+                {
+                    tracing::warn!("Could not log: {}", unsent.content);
                 }
             }
         });
@@ -801,6 +807,10 @@ impl PreparedNode {
         let working_dir_c = self.node_working_dir.clone();
         let uhlc = self.clock.clone();
         let mut logger_c = logger.try_clone().await?;
+        // Read `DORA_QUIET` once instead of on every log line: the env var
+        // cannot change during this task's lifetime, and `std::env::var` takes
+        // the process-global environment lock (and allocates) on each call.
+        let quiet = std::env::var_os("DORA_QUIET").is_some();
         // Log to file stream.
         tokio::spawn(async move {
             let mut bytes_written: u64 = 0;
@@ -999,7 +1009,7 @@ impl PreparedNode {
                 }
 
                 // Forward to channel/coordinator for live display
-                if std::env::var("DORA_QUIET").is_err() {
+                if !quiet {
                     cloned_logger.log(log_message).await;
                 }
 


### PR DESCRIPTION
## Issue

The per-node stdout/stderr logging pipeline in `binaries/daemon/src/spawn/prepared.rs` does redundant work on every log line — the hot path for any chatty node:

1. **Per-line `std::env::var("DORA_QUIET")`.** The file-logging loop (`while let Some(log_line) = rx.recv().await`) called `std::env::var("DORA_QUIET")` on every forwarded line. `std::env::var` takes the process-global environment lock and allocates a `String` on each call — and the value cannot change during the task's lifetime. (Ironic given the adjacent comment that deliberately avoids per-line `fsync` for the same reason.)

2. **Per-line `content.clone()` in both reader tasks.** The stdout and stderr reader tasks each cloned `content` on every line solely so the original stayed available for a `tracing::warn!("Could not log: …")` that only fires when the log channel is already closed (a rare, terminal condition).

## Fix

1. Read `DORA_QUIET` once before the loop: `let quiet = std::env::var_os("DORA_QUIET").is_some();` (`var_os` also skips UTF-8 validation/allocation), and test the captured `quiet` bool in the loop.

2. Move `content` into the `LogLine` instead of cloning; on the rare `SendError` (closed channel), recover the value from the returned `mpsc::error::SendError` for the warning. The stderr path keeps its single, unavoidable clone for the crash-diagnostics ring buffer (`force_push`).

No behavior change on the success path.

## Validation

- `cargo fmt -p dora-daemon -- --check`, `cargo clippy -p dora-daemon -- -D warnings`, and `cargo test -p dora-daemon --lib` (106 tests) all pass.

---
🤖 This pull request is **machine-generated by Claude** (an AI agent) as part of an automated codebase review. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyLwUdy2NmPySXpKyCxowK)_