### PR TITLE
docs(c-api): fix input-event doc/safety comments in the C node API

### DIFF
--- a/apis/c/node/src/lib.rs
+++ b/apis/c/node/src/lib.rs
@@ -161,6 +161,12 @@ pub unsafe extern "C" fn read_dora_input_id(
 /// Writes a null pointer and length `0` if the given event is not an input event
 /// or when an input event has no associated data.
 ///
+/// The raw-byte C API can only expose `UInt8` (and empty `Null`) payloads.
+/// A payload of any other Arrow type (for example an `Int32`/`Float` array
+/// from another node) also yields a null pointer and length `0` (and logs an
+/// error), so a null result is not by itself proof that the message carried no
+/// data.
+///
 /// ## Safety
 ///
 /// The `event` argument must be a dora event received through
@@ -219,9 +225,13 @@ pub unsafe extern "C" fn read_dora_input_data(
 
 /// Reads out the timestamp of the given input event from metadata.
 ///
+/// Returns `0` if the given event is not an input event.
+///
 /// ## Safety
 ///
-/// Return `0` if the given event is not an input event.
+/// The `event` argument must be a dora event received through
+/// [`dora_next_event`]. The event must be still valid, i.e., not
+/// freed yet.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn read_dora_input_timestamp(event: *const ()) -> core::ffi::c_ulonglong {
     let event: &Event = unsafe { &*event.cast() };


### PR DESCRIPTION
## Issue

Two documentation defects in the C node API (`apis/c/node/src/lib.rs`):

1. **`read_dora_input_timestamp` has a wrong `## Safety` section.** It put a return-value note under `## Safety`:

   ```rust
   /// ## Safety
   ///
   /// Return `0` if the given event is not an input event.
   pub unsafe extern "C" fn read_dora_input_timestamp(event: *const ()) -> ... {
       let event: &Event = unsafe { &*event.cast() };
   ```

   The function dereferences the caller-supplied raw pointer, so the real safety contract is the pointer-validity rule that **every** sibling accessor documents (`read_dora_input_id`, `read_dora_input_data`, `read_dora_event_type`). This one omitted it — the one piece of documentation that governs UB for the `unsafe extern "C"` function.

2. **`read_dora_input_data` doc omits the unsupported-type behavior.** The doc says null/`0` is written "if the given event is not an input event or when an input event has no associated data." But the implementation *also* writes null/`0` (and logs an error) for any Arrow payload type other than `UInt8`/`Null` (the `other =>` arm). A C caller couldn't tell "metadata-only message" from "payload exists but is an unsupported type", and the documented contract never mentioned that path.

## Fix

1. Move the return-value note into `read_dora_input_timestamp`'s description and add the standard pointer-validity safety paragraph.
2. Document that a non-`UInt8` payload also yields `(NULL, 0)` (with a logged error), so a null result is not proof of "no data".

Documentation only; no behavior change.

## Validation

- `cargo fmt -p dora-node-api-c -- --check` and `cargo clippy -p dora-node-api-c -- -D warnings` pass. The doc changes reuse the same intra-doc link style (`[dora_next_event]`) already used by the sibling functions in this file.

---
🤖 This pull request is **machine-generated by Claude** (an AI agent) as part of an automated codebase review. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyLwUdy2NmPySXpKyCxowK)_