### PR TITLE
fix(coordinator): surface daemon WS errors instead of an undeserializable envelope

### DIFF
--- a/binaries/coordinator/src/state.rs
+++ b/binaries/coordinator/src/state.rs
@@ -113,6 +113,15 @@ pub(crate) struct DaemonConnection {
     pub(crate) connection_id: Uuid,
 }
 
+/// The envelope `handle_daemon_response` (see `ws_daemon.rs`) produces when a
+/// daemon replies with a WS-level `error` instead of a result. `deny_unknown_fields`
+/// keeps it from ever matching a real `DaemonCoordinatorReply` payload.
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WsErrorEnvelope {
+    ws_error: String,
+}
+
 impl DaemonConnection {
     pub(crate) fn new(
         sender: mpsc::Sender<String>,
@@ -179,6 +188,18 @@ impl DaemonConnection {
                     return Err(eyre!("timeout waiting for daemon WS reply"));
                 }
             };
+
+        // A WS-level failure on the daemon side arrives as a `{"ws_error": ...}`
+        // envelope (see `handle_daemon_response` in `ws_daemon.rs`). It matches
+        // no `DaemonCoordinatorReply` variant, so returning it verbatim would
+        // make every caller fail with an opaque "failed to deserialize ... reply"
+        // and drop the daemon's real error text (it would survive only in a log
+        // line). Surface it as an `Err` carrying that text instead.
+        if let Ok(WsErrorEnvelope { ws_error }) =
+            serde_json::from_str::<WsErrorEnvelope>(&response_json)
+        {
+            return Err(eyre!("daemon returned error: {ws_error}"));
+        }
 
         Ok(response_json.into_bytes())
     }
@@ -645,6 +666,46 @@ mod send_and_receive_tests {
         assert!(
             pending.lock().await.is_empty(),
             "pending reply leaked after send failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn ws_error_envelope_surfaces_as_err() {
+        // The daemon-side WS error path delivers a `{"ws_error": ...}` string to
+        // the pending reply (see `handle_daemon_response` in `ws_daemon.rs`).
+        // `send_and_receive` must turn that into an `Err` carrying the daemon's
+        // text — not return an envelope its callers cannot deserialize, which
+        // would surface as an opaque "failed to deserialize ... reply".
+        let (tx, mut rx) = mpsc::channel::<String>(1);
+        let pending: Arc<Mutex<HashMap<Uuid, oneshot::Sender<String>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let conn = DaemonConnection::new(tx, pending.clone(), BTreeMap::new());
+
+        let pending_bg = pending.clone();
+        tokio::spawn(async move {
+            let outgoing = rx.recv().await.expect("request should be sent");
+            let value: serde_json::Value =
+                serde_json::from_str(&outgoing).expect("outgoing request is JSON");
+            let id: Uuid = value["id"]
+                .as_str()
+                .expect("request carries an id")
+                .parse()
+                .expect("id is a UUID");
+            let sender = pending_bg
+                .lock()
+                .await
+                .remove(&id)
+                .expect("pending reply is registered before the send");
+            let _ = sender.send(r#"{"ws_error":"daemon blew up"}"#.to_string());
+        });
+
+        let err = conn
+            .send_and_receive(b"{}")
+            .await
+            .expect_err("ws_error envelope must be surfaced as an error");
+        assert!(
+            err.to_string().contains("daemon blew up"),
+            "error should carry the daemon's message, got: {err}"
         );
     }
 }


### PR DESCRIPTION
## Issue

When a daemon replies with a WS-level `error`, `handle_daemon_response` (`binaries/coordinator/src/ws_daemon.rs`) flattens it into a JSON string and pushes it through the pending-reply channel:

```rust
} else if let Some(err) = response.error {
    tracing::warn!("daemon returned error for request {}: {err}", response.id);
    serde_json::json!({"ws_error": err}).to_string()
```

`DaemonConnection::send_and_receive` returned those bytes as `Ok(...)`, and every caller (`stop_dataflow`, `reload_dataflow`, `build_dataflow`, node commands, logs, destroy) then does `serde_json::from_slice::<DaemonCoordinatorReply>(&reply_raw)`. A `{"ws_error": "..."}` object matches **no** `DaemonCoordinatorReply` variant, so the caller fails with a generic *"failed to deserialize \<op\> reply from daemon"* and the daemon's real error text is dropped from the returned error chain — it survives only in a `warn!` log line. The operator running `dora stop`/`reload`/`build` sees an opaque deserialization message instead of the actual cause.

This is reachable today: the daemon emits `WsResponse::err(request_id, …)` when it fails to serialize a reply (`binaries/daemon/src/coordinator.rs`).

## Fix

Detect the `{"ws_error": ...}` envelope in `send_and_receive` and return it as an `Err` carrying the daemon's text, so **all** callers propagate the real cause. A dedicated `#[serde(deny_unknown_fields)]` single-field struct makes the match exact, so it can never collide with a real `DaemonCoordinatorReply` payload (whose variants serialize with their own tags). The success path is unchanged — the raw JSON bytes still flow through (preserving the u128-fidelity rationale for raw-JSON passthrough).

### Note on depth

A deeper fix would change the pending-reply channel payload from `oneshot::Sender<String>` to `Result<String, String>`, carrying the error *as* an error across the boundary and removing the need for the sentinel envelope entirely. That change threads through `state.rs`, `ws_daemon.rs`, `run/mod.rs`, and ~15 test construction sites, so it's left as a follow-up; this localized fix is behavior-safe and self-contained.

## Validation

- Added `ws_error_envelope_surfaces_as_err`, which drives the full `send_and_receive` path with an injected `ws_error` reply and asserts the returned error carries the daemon's message.
- `cargo fmt -p dora-coordinator -- --check`, `cargo clippy -p dora-coordinator -- -D warnings`, and `cargo test -p dora-coordinator` (incl. the new test) all pass.

---
🤖 This pull request is **machine-generated by Claude** (an AI agent) as part of an automated codebase review. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SyLwUdy2NmPySXpKyCxowK)_