### PR TITLE
fix(download): match Content-Disposition filename param case-insensitively

### DIFF
--- a/libraries/extensions/download/src/lib.rs
+++ b/libraries/extensions/download/src/lib.rs
@@ -9,19 +9,37 @@ use tokio::io::AsyncWriteExt;
 ///
 /// Handles headers that carry additional parameters after the filename, e.g.
 /// `attachment; filename="model.bin"; size=1000`, and both quoted and unquoted
-/// forms. Returns `None` when no non-empty `filename=` value is present (the
-/// RFC 5987 extended `filename*=` form is not decoded and falls through).
+/// forms. Per RFC 6266 the parameter name is matched case-insensitively, so
+/// `Filename=`/`FILENAME=` are accepted too. Returns `None` when no non-empty
+/// `filename=` value is present (the RFC 5987 extended `filename*=` form is not
+/// decoded and falls through — the literal `filename=` substring never matches
+/// the `filename*=` spelling, so it is skipped automatically).
 fn parse_content_disposition_filename(header: &str) -> Option<String> {
-    let rest = header.split("filename=").nth(1)?.trim_start();
+    // RFC 6266: parameter names are case-insensitive. Locate `filename=`
+    // regardless of case without copying the value bytes.
+    let lower = header.to_ascii_lowercase();
+    let value_start = lower.find("filename=")? + "filename=".len();
+    let rest = header[value_start..].trim_start();
+
     let name = if let Some(after_quote) = rest.strip_prefix('"') {
-        // Quoted form: the value runs up to the closing quote, so a trailing
-        // `; param=...` (or a `;` inside the quotes) is handled correctly.
-        after_quote.split('"').next().unwrap_or(after_quote)
+        // Quoted form: read up to the closing quote, honoring RFC 6266
+        // `\`-escapes (`filename="a\"b"` -> `a"b`), so a trailing
+        // `; param=...` (or a `;`/`"` inside the quotes) is handled correctly.
+        let mut name = String::new();
+        let mut chars = after_quote.chars();
+        while let Some(c) = chars.next() {
+            match c {
+                '"' => break,
+                '\\' => name.extend(chars.next()),
+                _ => name.push(c),
+            }
+        }
+        name
     } else {
         // Token form: the value ends at the next parameter separator.
-        rest.split(';').next().unwrap_or(rest).trim()
+        rest.split(';').next().unwrap_or(rest).trim().to_string()
     };
-    (!name.is_empty()).then(|| name.to_string())
+    (!name.is_empty()).then_some(name)
 }
 
 fn get_filename(response: &reqwest::Response) -> Option<String> {
@@ -156,6 +174,33 @@ mod tests {
         assert_eq!(
             parse_content_disposition_filename("attachment; filename=\"a;b.bin\""),
             Some("a;b.bin".to_string())
+        );
+    }
+
+    #[test]
+    fn parameter_name_is_case_insensitive() {
+        // RFC 6266 parameter names are case-insensitive; a non-lowercase
+        // `filename` (common from Java/.NET/IIS stacks) must still be honored.
+        assert_eq!(
+            parse_content_disposition_filename("attachment; Filename=\"model.bin\""),
+            Some("model.bin".to_string())
+        );
+        assert_eq!(
+            parse_content_disposition_filename("attachment; FILENAME=model.bin"),
+            Some("model.bin".to_string())
+        );
+        assert_eq!(
+            parse_content_disposition_filename("inline; FileName=node.py"),
+            Some("node.py".to_string())
+        );
+    }
+
+    #[test]
+    fn escaped_quote_inside_quoted_value() {
+        // RFC 6266 quoted-string: a `\"` is a literal quote, not the terminator.
+        assert_eq!(
+            parse_content_disposition_filename("attachment; filename=\"a\\\"b.bin\""),
+            Some("a\"b.bin".to_string())
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes #2609.

`parse_content_disposition_filename` in `dora-download` matched the header parameter name with a **case-sensitive** `split("filename=")`. Per [RFC 6266](https://www.rfc-editor.org/rfc/rfc6266), `Content-Disposition` parameter names are **case-insensitive**, so a spec-compliant server sending `filename` in any other case (`Filename`, `FILENAME`, `FileName` — common from some Java/.NET/IIS stacks) had its filename **silently dropped**. The download then fell through to the URL-derived fallback path (which has its own separate issue, #2600), producing a wrong on-disk name or an outright `"Could not find a filename"` error even though the server supplied the correct name.

## Changes

- Match the `filename=` parameter name **case-insensitively** by locating it in an ASCII-lowercased copy of the header, then slicing the value from the original (case-preserving) header.
- The literal `filename=` substring never matches the RFC 5987 extended `filename*=` spelling, so that form is still skipped and falls through to `None` (existing behavior, covered by an existing test).
- Honor `\`-escaped quotes inside the quoted-string form (RFC 6266 quoted-string), so `filename="a\"b.bin"` yields `a"b.bin` instead of truncating at the escaped quote.

## Tests

Added two regression tests in the existing `#[cfg(test)]` block:
- `parameter_name_is_case_insensitive` — `Filename=`, `FILENAME=`, `FileName=` all parse.
- `escaped_quote_inside_quoted_value` — `filename="a\"b.bin"` → `a"b.bin`.

All 7 unit tests pass; the pre-existing cases (quoted/unquoted, trailing params, semicolon-inside-quotes, empty/`filename*=` → `None`) are unchanged. `cargo fmt --check` and `cargo clippy -p dora-download -- -D warnings` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C79MriEbXiurvZQQ3QoCkU)_