### PR TITLE
fix(node): bound the emitted Arrow IPC stream length at the producer

### DIFF
--- a/apis/rust/node/src/node/arrow_utils/ipc_encode.rs
+++ b/apis/rust/node/src/node/arrow_utils/ipc_encode.rs
@@ -853,11 +853,14 @@ impl InputDecoder {
     }
 }
 
-/// Reject an IPC payload larger than [`super::MAX_IPC_BYTES`] before decoding.
-/// Defense-in-depth against an oversized peer-controlled zenoh payload, mirroring
-/// the guard in [`decode_arrow_ipc_zero_copy`](super::decode_arrow_ipc_zero_copy)
-/// (the persistent-decoder paths receive the same untrusted bytes).
-fn check_ipc_size(len: usize) -> eyre::Result<()> {
+/// Reject an IPC stream larger than [`super::MAX_IPC_BYTES`].
+///
+/// Used on both sides so the encode and decode limits agree: as a producer-side
+/// guard (so a stream the producer emits is always decodable by every receiver,
+/// rather than silently dropped — see #2586) and as defense-in-depth on decode
+/// against an oversized peer-controlled zenoh payload, mirroring the guard in
+/// [`decode_arrow_ipc_zero_copy`](super::decode_arrow_ipc_zero_copy).
+pub(crate) fn check_ipc_size(len: usize) -> eyre::Result<()> {
     if len > super::MAX_IPC_BYTES {
         bail!(
             "Arrow IPC payload too large: {len} bytes (max {})",
@@ -1460,6 +1463,24 @@ mod tests {
         let decoded = decode_arrow_ipc_zero_copy(buffer).unwrap();
         assert_eq!(decoded.data_type(), &DataType::UInt8);
         assert_eq!(decoded.len(), 0);
+    }
+
+    /// A `UInt8` payload whose *encoded stream* would exceed `MAX_IPC_BYTES`
+    /// must be rejected at encode time even though `data_len` itself is within
+    /// the limit: the validity bitmap, alignment padding, and message blocks
+    /// make the stream larger, and every receiver bounds the whole stream. The
+    /// producer must fail loudly rather than emit a stream that is silently
+    /// dropped on the zenoh path. Regression for #2586.
+    #[test]
+    fn uint8_ipc_len_rejects_oversized_stream() {
+        // `data_len == MAX_IPC_BYTES` clears a naive `data_len` check, but the
+        // ~1.125x stream overhead pushes the emitted stream over the cap.
+        let err = uint8_ipc_len(super::super::MAX_IPC_BYTES)
+            .expect_err("stream exceeding MAX_IPC_BYTES must be rejected")
+            .to_string();
+        assert!(err.contains("too large"), "unexpected error: {err}");
+        // A comfortably-small payload still encodes to an in-bounds stream.
+        assert!(uint8_ipc_len(1024).unwrap() <= super::super::MAX_IPC_BYTES);
     }
 
     /// The schema-once receive path must decode a 0-row (empty) batch, not drop

--- a/apis/rust/node/src/node/arrow_utils/ipc_encode.rs
+++ b/apis/rust/node/src/node/arrow_utils/ipc_encode.rs
@@ -756,11 +756,14 @@ impl InputDecoder {
     }
 }
 
-/// Reject an IPC payload larger than [`super::MAX_IPC_BYTES`] before decoding.
-/// Defense-in-depth against an oversized peer-controlled zenoh payload, mirroring
-/// the guard in [`decode_arrow_ipc_zero_copy`](super::decode_arrow_ipc_zero_copy)
-/// (the persistent-decoder paths receive the same untrusted bytes).
-fn check_ipc_size(len: usize) -> eyre::Result<()> {
+/// Reject an IPC stream larger than [`super::MAX_IPC_BYTES`].
+///
+/// Used on both sides so the encode and decode limits agree: as a producer-side
+/// guard (so a stream the producer emits is always decodable by every receiver,
+/// rather than silently dropped — see #2586) and as defense-in-depth on decode
+/// against an oversized peer-controlled zenoh payload, mirroring the guard in
+/// [`decode_arrow_ipc_zero_copy`](super::decode_arrow_ipc_zero_copy).
+pub(crate) fn check_ipc_size(len: usize) -> eyre::Result<()> {
     if len > super::MAX_IPC_BYTES {
         bail!(
             "Arrow IPC payload too large: {len} bytes (max {})",
@@ -1363,6 +1366,24 @@ mod tests {
         let decoded = decode_arrow_ipc_zero_copy(buffer).unwrap();
         assert_eq!(decoded.data_type(), &DataType::UInt8);
         assert_eq!(decoded.len(), 0);
+    }
+
+    /// A `UInt8` payload whose *encoded stream* would exceed `MAX_IPC_BYTES`
+    /// must be rejected at encode time even though `data_len` itself is within
+    /// the limit: the validity bitmap, alignment padding, and message blocks
+    /// make the stream larger, and every receiver bounds the whole stream. The
+    /// producer must fail loudly rather than emit a stream that is silently
+    /// dropped on the zenoh path. Regression for #2586.
+    #[test]
+    fn uint8_ipc_len_rejects_oversized_stream() {
+        // `data_len == MAX_IPC_BYTES` clears a naive `data_len` check, but the
+        // ~1.125x stream overhead pushes the emitted stream over the cap.
+        let err = uint8_ipc_len(super::super::MAX_IPC_BYTES)
+            .expect_err("stream exceeding MAX_IPC_BYTES must be rejected")
+            .to_string();
+        assert!(err.contains("too large"), "unexpected error: {err}");
+        // A comfortably-small payload still encodes to an in-bounds stream.
+        assert!(uint8_ipc_len(1024).unwrap() <= super::super::MAX_IPC_BYTES);
     }
 
     /// The schema-once receive path must decode a 0-row (empty) batch, not drop

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -2712,6 +2712,11 @@ impl SampleAllocator {
     pub fn encode_arrow(&self, array: &ArrayData) -> NodeResult<EncodedSample> {
         let sample = match ipc_encode::PreparedIpc::new(array) {
             Some(prepared) => {
+                // Reject a stream larger than every receiver will accept before
+                // emitting it, rather than sending an undecodable payload that
+                // is silently dropped on the zenoh path (#2586).
+                ipc_encode::check_ipc_size(prepared.byte_len())
+                    .map_err(|e| NodeError::Output(format!("Arrow IPC encode: {e}")))?;
                 // Prepare once: size the sample from the prepared layout, then
                 // encode into it — avoids rebuilding the layout + IPC headers.
                 let mut sample = self.allocate(prepared.byte_len())?;
@@ -2722,6 +2727,8 @@ impl SampleAllocator {
             }
             None => {
                 let bytes = ipc_encode::encode_ipc_to_vec(array)
+                    .map_err(|e| NodeError::Output(format!("Arrow IPC encode: {e}")))?;
+                ipc_encode::check_ipc_size(bytes.len())
                     .map_err(|e| NodeError::Output(format!("Arrow IPC encode: {e}")))?;
                 let mut sample = self.allocate(bytes.len())?;
                 sample.copy_from_slice(&bytes);

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -1000,6 +1000,11 @@ impl DoraNode {
 
         let sample = match ipc_encode::ipc_fast_path_len(&arrow_array) {
             Some(len) => {
+                // Reject a stream larger than every receiver will accept before
+                // emitting it, rather than sending an undecodable payload that
+                // is silently dropped on the zenoh path (#2586).
+                ipc_encode::check_ipc_size(len)
+                    .map_err(|e| NodeError::Output(format!("Arrow IPC encode: {e}")))?;
                 let mut s = self.allocate_data_sample(len)?;
                 ipc_encode::encode_ipc_into(&arrow_array, &mut s)
                     .map_err(|e| NodeError::Output(format!("Arrow IPC encode: {e}")))?;
@@ -1007,6 +1012,8 @@ impl DoraNode {
             }
             None => {
                 let bytes = ipc_encode::encode_ipc_to_vec(&arrow_array)
+                    .map_err(|e| NodeError::Output(format!("Arrow IPC encode: {e}")))?;
+                ipc_encode::check_ipc_size(bytes.len())
                     .map_err(|e| NodeError::Output(format!("Arrow IPC encode: {e}")))?;
                 let mut s = self.allocate_data_sample(bytes.len())?;
                 s.copy_from_slice(&bytes);


### PR DESCRIPTION
## Summary

Fixes #2586.

The Arrow IPC data plane (#2366) guarded the **input** length against `MAX_IPC_BYTES` at encode time, but the emitted IPC stream is ~1.125× larger (validity bitmap `data_len/8`, 64-byte alignment padding, and the schema + record-batch message blocks). Every **receiver** bounds the **whole stream** against the same `MAX_IPC_BYTES`. So a payload whose input length sits just under the cap (roughly `(227.5 MiB, 256 MiB]` for `UInt8`) could pass the encode guard and be sent, then be rejected by all receivers — a **silent drop** on the zenoh receive path.

## Changes

Guard the *resulting stream length* instead, so anything the producer accepts is decodable by every receiver (or it fails loudly at the producer):

- **`uint8_layout`** (`ipc_encode.rs`): now bounds the computed `total` stream length, not just `data_len`. Covers the `send_output_raw` UInt8 construct-in-place path — including the Python bindings (`apis/python/node/.../sample_handler.rs`) and `send_output_bytes` (`mod.rs`), both of which go through `uint8_ipc_len` / `encode_uint8_ipc_header`. The pre-existing `data_len > MAX_IPC_BYTES` check is kept as an overflow-safety bound before `total` is computed.
- **`send_output_array`** (`mod.rs`): runs `check_ipc_size` on the fast-path length and on the fallback stream length before allocating the sample, so the general array path (both the zero-copy fast path and the official-writer fallback) also fails loudly rather than emitting an undecodable stream.
- **`check_ipc_size`** is promoted to `pub(crate)` and its doc updated to note the dual producer/decode role.

## Tests

Added `uint8_ipc_len_rejects_oversized_stream`: `data_len == MAX_IPC_BYTES` clears a naive `data_len` check but the stream overhead pushes the emitted stream over the cap, so it must be rejected; a small payload still encodes to an in-bounds stream. Full `ipc_encode` suite (33 tests) passes; `cargo fmt --check` and `cargo clippy -p dora-node-api -- -D warnings` are clean.

## Notes

The receiver-side guards are unchanged — this only tightens the producer side so the encode and decode limits agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C79MriEbXiurvZQQ3QoCkU)_