### PR TITLE
fix(coordinator): return None from state_log_delta when the log is fully drained

### DIFF
--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -5918,6 +5918,40 @@ mod tests {
     }
 
     #[test]
+    fn state_log_delta_returns_none_when_log_fully_drained() {
+        // Regression for #2601: when the log is *fully* drained (every acked
+        // daemon caught past the end) but a lagging daemon is still behind
+        // `state_log_sequence`, the empty-log branch must signal a full replay
+        // (`None`), not a misleading "up to date" `Some([])` that silently
+        // skips catch-up.
+        let dataflow_id = DataflowId::from(Uuid::new_v4());
+        let d1 = DaemonId::new(Some("m1".to_string()));
+        let node_id: dora_core::config::NodeId = "camera".to_string().into();
+
+        let mut df = test_running_dataflow(dataflow_id, d1.clone(), node_id.clone());
+        for i in 0..3 {
+            df.append_state_log(StateCatchUpOperation::SetParam {
+                node_id: node_id.clone(),
+                key: format!("key_{i}"),
+                value: serde_json::json!(i),
+            });
+        }
+
+        // d1 acked past the end -> prune drains the whole log, but
+        // state_log_sequence stays at 3.
+        df.daemon_ack_sequence.insert(d1, 3);
+        df.prune_state_log();
+        assert!(df.state_log.is_empty());
+        assert_eq!(df.state_log_sequence, 3);
+
+        // A relinked daemon with no ack entry (last_ack defaults to 0) is
+        // behind: it missed seq 1..=3, which were pruned -> full replay.
+        assert!(df.state_log_delta(0).is_none());
+        // A daemon that is genuinely up to date still gets an empty delta.
+        assert!(df.state_log_delta(3).expect("up to date").is_empty());
+    }
+
+    #[test]
     fn set_param_forward_reply_reports_daemon_rejection() {
         let reply = serde_json::to_vec(&DaemonCoordinatorReply::SetParamResult(Err(
             "node `camera` channel full".to_string(),

--- a/binaries/coordinator/src/state.rs
+++ b/binaries/coordinator/src/state.rs
@@ -393,7 +393,17 @@ impl RunningDataflow {
     /// should fall back to a full param replay).
     pub(crate) fn state_log_delta(&self, last_ack: u64) -> Option<Vec<StateCatchUpEntry>> {
         if self.state_log.is_empty() {
-            return Some(Vec::new());
+            // An empty log means either nothing was ever logged (the daemon is
+            // up to date) or the log was fully drained by `prune_state_log`. If
+            // the daemon is still behind the current sequence, the entries it
+            // missed were pruned away, so it needs a full replay -- signal that
+            // with `None` rather than a misleading "up to date" `Some([])`,
+            // which would silently skip its catch-up (#2601).
+            return if last_ack < self.state_log_sequence {
+                None
+            } else {
+                Some(Vec::new())
+            };
         }
         let oldest = self.state_log[0].sequence;
         if last_ack.saturating_add(1) < oldest {


### PR DESCRIPTION
## Summary

Fixes #2601.

`RunningDataflow::state_log_delta` returned `Some(Vec::new())` ("you're up to date") whenever the state log was empty — **even for a daemon provably behind** `state_log_sequence`. Its documented contract is to return `None` (→ full param replay) when the entries a daemon missed were pruned. The non-empty branch honored that via the `oldest` gap check; the empty-log branch did not.

## The bug

`prune_state_log` removes entries with `sequence <= min(daemon_ack_sequence.values())`. When it **fully drains** the log (every daemon *in the ack map* has acked past the end) while `state_log_sequence > 0`, a lagging daemon that is **not** represented in the ack map hit the `Some([])` branch. For the sole production caller (`binaries/coordinator/src/lib.rs`, `state_log_delta` is only called when `last_ack < state_log_sequence`), that maps to the `Some(entries) if entries.is_empty() => {}` arm — **nothing happens**, so the daemon permanently misses param mutations with no fallback replay and no log line.

This is reachable via the multi-daemon coordinator-recovery / relink / disconnect sequence in the issue: a relinked daemon is added back to `df.daemons` but never seeded into `daemon_ack_sequence`, so its `last_ack` defaults to `0` while the log has been drained out from under it.

## Fix

Make the empty-log branch prune-aware using the existing `state_log_sequence` field:

```rust
if self.state_log.is_empty() {
    return if last_ack < self.state_log_sequence {
        None            // missed entries were pruned -> full replay
    } else {
        Some(Vec::new()) // genuinely up to date
    };
}
```

This is self-contained (the `RunningDataflow` already carries `state_log_sequence`) and makes the method consistent with its documented contract for both the empty and non-empty cases.

## Tests

Added `state_log_delta_returns_none_when_log_fully_drained`, which drains the log via `prune_state_log` while `state_log_sequence` stays at 3, then asserts a behind daemon (`last_ack = 0`) gets `None` and an up-to-date daemon (`last_ack = 3`) still gets an empty delta. The existing `state_log_delta_returns_none_when_pruned` (partial prune) and `state_log_delta_returns_missed_entries` continue to pass. `cargo fmt --check` and `cargo clippy -p dora-coordinator -- -D warnings` are clean.

## Notes

The issue also suggests, as a complementary hardening, seeding `daemon_ack_sequence` for a relinked daemon in `reestablish_running_dataflow` so `prune_state_log` cannot drain the log out from under a lagging member. That is a broader change to the relink path; this PR fixes the reported logic error at its source (the sole caller now always gets the correct `None`/`Some` answer), and the seeding hardening can follow up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C79MriEbXiurvZQQ3QoCkU)_