### PR TITLE
fix(core): register the admitted TypeDef, not a body-invalid same-URN duplicate

### DIFF
--- a/libraries/core/src/manifest/inject.rs
+++ b/libraries/core/src/manifest/inject.rs
@@ -120,10 +120,17 @@ pub fn inject_adjacent_manifests(
         }
     }
     // Register the survivors into the shared registry, skipping URNs already
-    // present so preserved definitions win.
-    for &(urn, def) in &candidates {
-        if scratch.resolve(urn).is_some() && registry.resolve(urn).is_none() {
-            let _ = registry.add_user_type(urn, def.clone());
+    // present so preserved definitions win. Register the *admitted* definition
+    // from `scratch`, not the candidate's own `def`: `candidates` is not
+    // deduplicated by URN, so when two same-namespace manifests ship the same
+    // URN, `scratch.resolve(urn).is_some()` only proves that *some* body-valid
+    // definition was admitted — the first-listed candidate's `def` may be the
+    // body-invalid duplicate, which must not reach the shared registry (#2599).
+    for &(urn, _def) in &candidates {
+        if registry.resolve(urn).is_none()
+            && let Some(admitted) = scratch.resolve(urn)
+        {
+            let _ = registry.add_user_type(urn, admitted.clone());
         }
     }
 
@@ -840,6 +847,93 @@ nodes:
         assert!(registry.resolve("acme/foo/v1/Y").is_none());
         assert!(registry.resolve("acme/foo/v1/X").is_none());
         assert!(df.nodes[1].output_types.is_empty());
+    }
+
+    #[test]
+    fn duplicate_urn_registers_the_body_valid_definition() {
+        // Two same-namespace manifests ship the same URN, the body-invalid one
+        // listed first. The fixpoint admits only the body-valid definition, so
+        // the shared registry must hold *that* one — not the first-listed
+        // (invalid) candidate's body. Regression for #2599.
+        let tmp = tempfile::tempdir().unwrap();
+        // Listed first: body-invalid `X` (its field type doesn't resolve).
+        write_manifest(
+            &tmp.path().join("bad"),
+            r#"
+apiVersion: 1
+name: bad
+namespace: acme
+runtime: rust
+entrypoint: target/release/bad
+types:
+  acme/foo/v1/X:
+    arrow: Struct
+    fields:
+      - name: broken
+        type: NotARealType
+"#,
+        );
+        // Listed second: body-valid `X`, same URN.
+        write_manifest(
+            &tmp.path().join("good"),
+            r#"
+apiVersion: 1
+name: good
+namespace: acme
+runtime: rust
+entrypoint: target/release/good
+types:
+  acme/foo/v1/X:
+    arrow: Struct
+    fields:
+      - name: x
+        type: Float32
+"#,
+        );
+        write_manifest(
+            &tmp.path().join("victim"),
+            r#"
+apiVersion: 1
+name: victim
+namespace: gamma
+runtime: rust
+entrypoint: target/release/victim
+outputs:
+  out:
+    type: acme/foo/v1/X
+"#,
+        );
+        let mut df = dataflow(
+            r#"
+nodes:
+  - id: bad
+    path: bad/target/release/bad
+  - id: good
+    path: good/target/release/good
+  - id: victim
+    path: victim/target/release/victim
+    outputs: [out]
+"#,
+        );
+        let mut registry = TypeRegistry::new();
+        let _ = inject_adjacent_manifests(&mut df, tmp.path(), &mut registry);
+        // The registry holds the body-valid definition (field `x`), not the
+        // first-listed invalid one (field `broken: NotARealType`).
+        let resolved = registry
+            .resolve("acme/foo/v1/X")
+            .expect("the body-valid duplicate must register");
+        assert!(
+            resolved.fields.iter().any(|f| f.name == "x"),
+            "registry must hold the body-valid definition, got {:?}",
+            resolved.fields
+        );
+        assert!(
+            !resolved.fields.iter().any(|f| f.r#type == "NotARealType"),
+            "the body-invalid duplicate must not reach the registry, got {:?}",
+            resolved.fields
+        );
+        // The referencing node's output type materializes against the valid body.
+        assert!(!df.nodes[2].output_types.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #2599.

In `libraries/core/src/manifest/inject.rs`, the loop that registers shipped types into the **shared** registry could store a **body-invalid** definition when two matched manifests ship the same type URN.

## The bug

`candidates` is a flat `Vec<(&urn, &def)>` accumulated across **all** matched manifests and is **not** deduplicated by URN. The admission fixpoint decides, per URN, which **body-valid** definition enters the scratch registry. But the registration loop then wrote each candidate's **own** `def`, guarded only by `scratch.resolve(urn).is_some()` — which only proves that *some* definition for that URN was admitted, not that *this* candidate's `def` is the admitted one.

So with two same-namespace manifests shipping the same URN and the **body-invalid one listed first**, the loop registered the invalid `def`; the second (valid) candidate was then skipped because `registry.resolve(urn)` was already `Some`. A referencing node's port check passed against a type that can never be materialized into an Arrow schema — exactly the invariant the surrounding fixpoint and its tests exist to protect.

## Fix

Register the **admitted** definition from `scratch` rather than the candidate's own `def`:

```rust
for &(urn, _def) in &candidates {
    if registry.resolve(urn).is_none()
        && let Some(admitted) = scratch.resolve(urn)
    {
        let _ = registry.add_user_type(urn, admitted.clone());
    }
}
```

`scratch` only ever holds the body-valid definition for each URN (the fixpoint inserts nothing else), so this guarantees the shared registry receives the body-valid one regardless of candidate ordering.

## Tests

Added `duplicate_urn_registers_the_body_valid_definition`: two same-namespace manifests ship `acme/foo/v1/X`, body-invalid (`broken: NotARealType`) listed first, body-valid (`x: Float32`) second, plus a referencing node. The test asserts the registry holds the valid body (field `x`, not `NotARealType`) and the referencing node's output type materializes. It fails against the old code (which registered the invalid duplicate). All 18 `manifest::inject` tests pass; `cargo fmt --check` and `cargo clippy -p dora-core -- -D warnings` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C79MriEbXiurvZQQ3QoCkU)_