### PR TITLE
fix(examples): bump rust-dataflow-git pin past the node-register format break (#2742)

### DIFF
--- a/examples/rust-dataflow-git/dataflow.yml
+++ b/examples/rust-dataflow-git/dataflow.yml
@@ -4,14 +4,15 @@
 # change lands on main — otherwise the CI job catches the mismatch and
 # signals a compatibility break, which is the whole point of this test.
 #
-# Currently pinned past #2366, which dropped the `ArrowTypeInfo` sidecar
-# from `Metadata` and took the payload wire format to v1. The previous pin
-# (1.0.0-rc1) predated that, so its nodes desynced against a current daemon
-# and died with `tag for enum is not valid` (#2742).
+# Currently pinned past #2774, which added a `metadata_version` field to
+# `NodeRegisterRequest` to reject metadata-format skew at registration. The
+# previous pin (07ed3be, from #2745) predated that, so its nodes failed to
+# register against a current daemon with `unexpected end of file` (#2742).
+# (#2745 had likewise moved the pin past #2366's payload-format v1 break.)
 nodes:
   - id: rust-node
     git: https://github.com/dora-rs/dora.git
-    rev: 07ed3be5f0995ace3f455ea8caff060e2f107250
+    rev: c9a3699209f6bb771952e365df044788d1347626
     build: cargo build -p rust-dataflow-example-node
     path: target/debug/rust-dataflow-example-node
     inputs:
@@ -21,7 +22,7 @@ nodes:
 
   - id: rust-status-node
     git: https://github.com/dora-rs/dora.git
-    rev: 07ed3be5f0995ace3f455ea8caff060e2f107250
+    rev: c9a3699209f6bb771952e365df044788d1347626
     build: cargo build -p rust-dataflow-example-status-node
     path: target/debug/rust-dataflow-example-status-node
     inputs:
@@ -32,7 +33,7 @@ nodes:
 
   - id: rust-sink
     git: https://github.com/dora-rs/dora.git
-    rev: 07ed3be5f0995ace3f455ea8caff060e2f107250
+    rev: c9a3699209f6bb771952e365df044788d1347626
     build: cargo build -p rust-dataflow-example-sink
     path: target/debug/rust-dataflow-example-sink
     inputs:


### PR DESCRIPTION
The `Examples` job fails on all three platforms — the git-pinned `rust-dataflow-git` nodes can't register against a current daemon: `failed to deserialize DaemonRequest: unexpected end of file`.

Cause: #2774 added a `metadata_version` field to `NodeRegisterRequest` (to reject metadata-format skew at registration) — a change to the register wire format. The example's pin was still `07ed3be` (set by #2745, predates #2774), so the pinned nodes send a register request without the new field and the daemon fails to deserialize it. #2775's backstop guard then makes the run fail loudly on every platform instead of silently.

Bumps the pin to `c9a3699` (current `main`, format-current) across all three nodes. Same operation #2745 performed for #2366's earlier payload-format break — the example working as designed (bump `rev:` when a message-format break lands on main).

Refs #2742.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
