### PR TITLE
fix(core): don't let a concurrent session's HEAD-check delete a git clone that's still being written

### DIFF
--- a/libraries/core/src/build/git.rs
+++ b/libraries/core/src/build/git.rs
@@ -6,6 +6,7 @@ use itertools::Itertools;
 use std::{
     collections::{BTreeMap, BTreeSet},
     path::{Path, PathBuf},
+    sync::{Arc, Mutex},
 };
 use url::Url;
 
@@ -15,7 +16,31 @@ pub struct GitManager {
     pub clones_in_use: BTreeMap<PathBuf, BTreeSet<DataflowId>>,
     /// Builds that are prepared, but not done yet.
     prepared_builds: BTreeMap<SessionId, PreparedBuild>,
+    /// Clone dirs that some `GitFolder` is actively writing into right now,
+    /// process-wide, across every build session. A `NewClone`/`CopyAndFetch`/
+    /// `RenameAndFetch` claims its target dir here as soon as it's chosen and
+    /// releases it once that `GitFolder` is dropped (its clone/fetch task
+    /// finished, failed, or got cancelled). `prepared_builds` alone can't
+    /// answer "is anyone writing to this dir right now": it's scoped by
+    /// SessionId and a session's entries linger until that same session
+    /// happens to build again, which for a one-shot session never happens.
+    /// Gating the Reuse HEAD-check on that instead would let a stale dir shed
+    /// verification forever the moment any session had ever planned it (#2711).
+    clones_in_progress: Arc<Mutex<BTreeSet<PathBuf>>>,
     // reuse_for: BTreeMap<PathBuf, PathBuf>,
+}
+
+/// Releases a `clones_in_progress` claim when the owning `GitFolder` is
+/// dropped, whatever the reason (clone finished, failed, or was cancelled).
+struct InProgressClaim {
+    dir: PathBuf,
+    set: Arc<Mutex<BTreeSet<PathBuf>>>,
+}
+
+impl Drop for InProgressClaim {
+    fn drop(&mut self) {
+        self.set.lock().unwrap().remove(&self.dir);
+    }
 }
 
 #[derive(Default)]
@@ -60,21 +85,16 @@ impl GitManager {
             // So we can simply reuse the directory without doing any additional git
             // operations.
             //
-            // Only hand down a commit to verify (see the Reuse arm) when the dir was
-            // left by a prior, finished build: it's on disk but this session didn't
-            // plan it. A dir this session *did* plan is about to be filled in by a
-            // sibling node's NewClone, which may be running right now on another
-            // thread (parallel builds share one JoinSet with no per-dir lock). If I
-            // checked HEAD on that I could delete a clone that's still being written,
-            // so I skip verification and just reuse it, same as before this change.
-            let planned_this_session = self
-                .prepared_builds
-                .get(&session_id)
-                .map(|p| p.planned_clone_dirs.contains(&clone_dir))
-                .unwrap_or(false);
+            // Only hand down a commit to verify (see the Reuse arm) when nobody is
+            // actively writing to this dir right now. A dir that's still being
+            // cloned into -- by a sibling node in this session, or by an entirely
+            // different, concurrently-running session sharing this daemon's
+            // GitManager -- must never have its HEAD checked or be deleted, so I
+            // skip verification and just reuse it, same as before this change.
+            let in_progress = self.clones_in_progress.lock().unwrap().contains(&clone_dir);
             ReuseOptions::Reuse {
                 dir: clone_dir.clone(),
-                verify_commit: (!planned_this_session).then_some(commit_hash),
+                verify_commit: (!in_progress).then_some(commit_hash),
             }
         } else if let Some(previous_commit_hash) = prev_commit_hash {
             // we might be able to update a previous clone
@@ -120,9 +140,32 @@ impl GitManager {
                 commit_hash,
             }
         };
-        self.register_ready_clone_dir(session_id, clone_dir);
+        self.register_ready_clone_dir(session_id, clone_dir.clone());
 
-        Ok(GitFolder { reuse })
+        // Claim the dir as in-progress for every arm that's about to write
+        // into it, so a concurrent Reuse elsewhere skips verification instead
+        // of racing the write.
+        let claim = matches!(
+            reuse,
+            ReuseOptions::NewClone { .. }
+                | ReuseOptions::CopyAndFetch { .. }
+                | ReuseOptions::RenameAndFetch { .. }
+        )
+        .then(|| {
+            self.clones_in_progress
+                .lock()
+                .unwrap()
+                .insert(clone_dir.clone());
+            InProgressClaim {
+                dir: clone_dir,
+                set: self.clones_in_progress.clone(),
+            }
+        });
+
+        Ok(GitFolder {
+            reuse,
+            _claim: claim,
+        })
     }
 
     pub fn clone_dir_ready(&self, session_id: SessionId, dir: &Path) -> bool {
@@ -163,11 +206,15 @@ impl GitManager {
 pub struct GitFolder {
     /// Specifies whether an existing repo should be reused.
     reuse: ReuseOptions,
+    /// Held for as long as this `GitFolder` is writing to its clone dir;
+    /// releases the `clones_in_progress` claim on drop. `None` for the Reuse
+    /// arm, which never writes.
+    _claim: Option<InProgressClaim>,
 }
 
 impl GitFolder {
     pub async fn prepare(self, logger: &mut impl BuildLogger) -> eyre::Result<PathBuf> {
-        let GitFolder { reuse } = self;
+        let GitFolder { reuse, _claim } = self;
 
         tracing::info!("reuse: {reuse:?}");
         let clone_dir = match reuse {
@@ -540,6 +587,7 @@ mod tests {
                 // 40 hex chars, but we never get that far: the fetch blows up first.
                 commit_hash: "deadbeef".repeat(5),
             },
+            _claim: None,
         };
         assert!(folder.prepare(&mut TestLogger).await.is_err());
         assert!(
@@ -561,6 +609,7 @@ mod tests {
                 target_dir: target.clone(),
                 commit_hash: "deadbeef".repeat(5),
             },
+            _claim: None,
         };
         assert!(folder.prepare(&mut TestLogger).await.is_err());
         assert!(
@@ -581,6 +630,7 @@ mod tests {
                 // Well-formed full hash that is definitely not commit A.
                 verify_commit: Some("0".repeat(40)),
             },
+            _claim: None,
         };
         assert!(folder.prepare(&mut TestLogger).await.is_err());
         assert!(
@@ -600,6 +650,7 @@ mod tests {
                 dir: dir.clone(),
                 verify_commit: Some(oid),
             },
+            _claim: None,
         };
         assert_eq!(folder.prepare(&mut TestLogger).await.unwrap(), dir);
         assert!(dir.exists());
@@ -617,8 +668,146 @@ mod tests {
                 dir: dir.clone(),
                 verify_commit: Some("main".into()),
             },
+            _claim: None,
         };
         assert!(folder.prepare(&mut TestLogger).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn reuse_does_not_verify_a_dir_a_concurrent_session_is_cloning_into() {
+        // Regression test for #2711. The daemon shares one GitManager across
+        // concurrently-spawned build sessions (binaries/daemon/src/lib.rs:290,
+        // :1562). The old guard only skipped verification for a dir *this
+        // session's own* planned_clone_dirs contains, so it couldn't see a
+        // different, concurrently-running session's in-flight NewClone. Two
+        // sessions building the same repo@commit at the same time would let
+        // the second session's HEAD check run against a directory the first
+        // is still writing, fail to resolve HEAD, and delete it out from
+        // under the first session's clone.
+        let repo_dir = tempfile::tempdir().unwrap();
+        let repo_path = repo_dir.path().join("repo");
+        let commit = init_repo_with_commit(&repo_path);
+        let repo_url_str = format!("file://{}", repo_path.display());
+        let target_dir = tempfile::tempdir().unwrap();
+
+        let mut manager = GitManager::default();
+
+        // Session A picks NewClone for repo@commit; its GitFolder claims the
+        // dir as in-progress even though it hasn't cloned into it yet.
+        let session_a = SessionId::generate();
+        let folder_a = manager
+            .choose_clone_dir(
+                session_a,
+                repo_url_str.clone(),
+                commit.clone(),
+                None,
+                target_dir.path(),
+            )
+            .unwrap();
+        assert!(matches!(folder_a.reuse, ReuseOptions::NewClone { .. }));
+
+        // The directory now exists on disk mid-clone (libgit2 creates it
+        // before it's a valid, HEAD-resolvable repo). Session B must see
+        // this as owned by an in-flight build, not as a finished clone to
+        // verify.
+        let parsed = Url::parse(&repo_url_str).unwrap();
+        let clone_dir = GitManager::clone_dir_path(target_dir.path(), &parsed, &commit).unwrap();
+        std::fs::create_dir_all(&clone_dir).unwrap();
+
+        let session_b = SessionId::generate();
+        let folder_b = manager
+            .choose_clone_dir(session_b, repo_url_str, commit, None, target_dir.path())
+            .unwrap();
+        assert!(
+            matches!(
+                &folder_b.reuse,
+                ReuseOptions::Reuse {
+                    verify_commit: None,
+                    ..
+                }
+            ),
+            "a dir a concurrent session is still cloning into must be reused without verification"
+        );
+
+        // folder_a is still alive, holding its in-progress claim. Dropping it
+        // now releases the claim, same as when its real clone finishes.
+        drop(folder_a);
+    }
+
+    #[tokio::test]
+    async fn reuse_still_verifies_a_dir_left_by_a_different_finished_session() {
+        // Regression test for #2711. `prepared_builds` entries are keyed by
+        // SessionId and only ever get cleared at the top of *that same
+        // session's* next build (see `clear_planned_builds`). A one-shot
+        // session -- the normal case, one SessionId per `dora start` -- never
+        // calls `build_dataflow` again, so its `planned_clone_dirs` entry
+        // sits in `GitManager` forever. A verify_commit gate keyed on "did
+        // any session ever plan this dir" would then permanently skip the
+        // HEAD check for that dir the moment a second session touches it,
+        // silently reusing a stale wrong-commit clone -- exactly what #2482
+        // was written to stop. The gate has to track dirs that are actually
+        // being written *right now*, not dirs some session once planned.
+        let repo_dir = tempfile::tempdir().unwrap();
+        let repo_path = repo_dir.path().join("repo");
+        let old_commit = init_repo_with_commit(&repo_path);
+        let repo_url = format!("file://{}", repo_path.display());
+
+        let target_dir = tempfile::tempdir().unwrap();
+        let mut manager = GitManager::default();
+
+        // Session A clones the repo and finishes. Nobody ever calls
+        // clear_planned_builds(session_a) again, matching a real one-shot
+        // daemon session.
+        let session_a = SessionId::generate();
+        let folder_a = manager
+            .choose_clone_dir(
+                session_a,
+                repo_url.clone(),
+                old_commit.clone(),
+                None,
+                target_dir.path(),
+            )
+            .unwrap();
+        let clone_dir = folder_a.prepare(&mut TestLogger).await.unwrap();
+
+        // The clone on disk drifts to a different commit -- a stale leftover,
+        // exactly the case the #2482 HEAD check exists to catch.
+        std::fs::write(clone_dir.join("file.txt"), b"B").unwrap();
+        let repo = git2::Repository::open(&clone_dir).unwrap();
+        let parent = repo.head().unwrap().peel_to_commit().unwrap();
+        let mut index = repo.index().unwrap();
+        index.add_path(Path::new("file.txt")).unwrap();
+        index.write().unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        let sig = git2::Signature::now("t", "t@t").unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "B", &tree, &[&parent])
+            .unwrap();
+
+        // Session B (a fresh SessionId -- a second, unrelated `dora start`)
+        // asks for the same old commit and is handed the same dir. Session
+        // A's planned entry is still sitting in `prepared_builds`, but
+        // nothing is actively cloning into this dir right now, so
+        // verification must still run and catch the mismatch.
+        let session_b = SessionId::generate();
+        let folder_b = manager
+            .choose_clone_dir(session_b, repo_url, old_commit, None, target_dir.path())
+            .unwrap();
+        assert!(
+            matches!(
+                &folder_b.reuse,
+                ReuseOptions::Reuse {
+                    verify_commit: Some(_),
+                    ..
+                }
+            ),
+            "a dir left by a different, finished session must still be verified, not silently reused"
+        );
+        assert!(folder_b.prepare(&mut TestLogger).await.is_err());
+        assert!(
+            !clone_dir.exists(),
+            "the stale wrong-commit clone must be removed"
+        );
     }
 
     #[tokio::test]
@@ -637,6 +826,7 @@ mod tests {
                 dir: dir.clone(),
                 verify_commit: None,
             },
+            _claim: None,
         };
         assert_eq!(folder.prepare(&mut TestLogger).await.unwrap(), dir);
         assert!(dir.exists(), "a sibling-owned clone must never be deleted");

--- a/libraries/core/src/build/git.rs
+++ b/libraries/core/src/build/git.rs
@@ -39,8 +39,20 @@ struct InProgressClaim {
 
 impl Drop for InProgressClaim {
     fn drop(&mut self) {
-        self.set.lock().unwrap().remove(&self.dir);
+        lock_in_progress(&self.set).remove(&self.dir);
     }
+}
+
+/// Locks `clones_in_progress`, recovering from poisoning instead of
+/// panicking. A panic elsewhere while this lock was held must not leave the
+/// set stuck: `InProgressClaim::drop` runs during unwinding, where a panic
+/// here would abort the process, and any panic-on-poison here would also
+/// leave the dir's claim permanently unreleased, exempting it from
+/// verification forever.
+fn lock_in_progress(
+    set: &Mutex<BTreeSet<PathBuf>>,
+) -> std::sync::MutexGuard<'_, BTreeSet<PathBuf>> {
+    set.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 #[derive(Default)]
@@ -91,7 +103,7 @@ impl GitManager {
             // different, concurrently-running session sharing this daemon's
             // GitManager -- must never have its HEAD checked or be deleted, so I
             // skip verification and just reuse it, same as before this change.
-            let in_progress = self.clones_in_progress.lock().unwrap().contains(&clone_dir);
+            let in_progress = lock_in_progress(&self.clones_in_progress).contains(&clone_dir);
             ReuseOptions::Reuse {
                 dir: clone_dir.clone(),
                 verify_commit: (!in_progress).then_some(commit_hash),
@@ -152,10 +164,7 @@ impl GitManager {
                 | ReuseOptions::RenameAndFetch { .. }
         )
         .then(|| {
-            self.clones_in_progress
-                .lock()
-                .unwrap()
-                .insert(clone_dir.clone());
+            lock_in_progress(&self.clones_in_progress).insert(clone_dir.clone());
             InProgressClaim {
                 dir: clone_dir,
                 set: self.clones_in_progress.clone(),
@@ -368,18 +377,32 @@ impl GitFolder {
                     .await
                     .context("HEAD read task panicked")?;
 
-                    let on_right_commit =
-                        matches!(&head, Ok(h) if h.eq_ignore_ascii_case(&commit_hash));
-                    if !on_right_commit {
-                        // Drop the stale clone so the next build re-clones from
-                        // scratch, then fail loudly instead of quietly building the
-                        // old source.
-                        cleanup_failed_clone(logger, &dir).await;
-                        bail!(
-                            "clone dir {} is not on the requested commit {commit_hash} \
-                             (found {head:?}); I removed it, please rebuild",
+                    match head {
+                        // A valid repo sitting on the commit we asked for.
+                        Ok(h) if h.eq_ignore_ascii_case(&commit_hash) => {}
+                        // A valid repo concretely on some *other* commit, so a
+                        // genuine stale leftover. Drop it so the next build
+                        // re-clones from scratch, then fail loudly instead of
+                        // quietly building the old source.
+                        Ok(h) => {
+                            cleanup_failed_clone(logger, &dir).await;
+                            bail!(
+                                "clone dir {} is not on the requested commit {commit_hash} \
+                                 (found {h}); I removed it, please rebuild",
+                                dir.display()
+                            );
+                        }
+                        // HEAD didn't resolve, so I can't tell a broken leftover
+                        // from a clone another process is still writing. My
+                        // in-progress set only covers one GitManager and the CLI
+                        // builds with its own, so deleting here is how #2711
+                        // wipes out a live build. Fail loudly, leave the dir.
+                        Err(err) => bail!(
+                            "couldn't verify clone dir {} is on commit {commit_hash}: {err:?}; \
+                             leaving it in place in case another build is writing it, \
+                             please retry",
                             dir.display()
-                        );
+                        ),
                     }
                 }
 
@@ -654,6 +677,35 @@ mod tests {
         };
         assert_eq!(folder.prepare(&mut TestLogger).await.unwrap(), dir);
         assert!(dir.exists());
+    }
+
+    #[tokio::test]
+    async fn reuse_leaves_the_dir_alone_when_head_wont_resolve() {
+        // My in-progress set only covers one GitManager, and the CLI builds
+        // with its own, so it can't see a clone another process is writing.
+        // That clone isn't a valid repo yet, so HEAD won't resolve, and if I
+        // treat that as a wrong commit I delete a live build's work all over
+        // again (#2711). Only a HEAD that resolves to a different commit is
+        // safe to delete.
+        let base = tempfile::tempdir().unwrap();
+        let dir = base.path().join("clone");
+        // Exists but isn't a repo, so Repository::open fails the same way it
+        // would against a half-written clone.
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("partial.txt"), b"mid-clone").unwrap();
+
+        let folder = GitFolder {
+            reuse: ReuseOptions::Reuse {
+                dir: dir.clone(),
+                verify_commit: Some("0".repeat(40)),
+            },
+            _claim: None,
+        };
+        assert!(folder.prepare(&mut TestLogger).await.is_err());
+        assert!(
+            dir.exists(),
+            "an unresolvable HEAD must not delete the dir, another build may be writing it"
+        );
     }
 
     #[tokio::test]

--- a/libraries/core/src/build/git.rs
+++ b/libraries/core/src/build/git.rs
@@ -17,16 +17,22 @@ pub struct GitManager {
     /// Builds that are prepared, but not done yet.
     prepared_builds: BTreeMap<SessionId, PreparedBuild>,
     /// Clone dirs that some `GitFolder` is actively writing into right now,
-    /// process-wide, across every build session. A `NewClone`/`CopyAndFetch`/
-    /// `RenameAndFetch` claims its target dir here as soon as it's chosen and
-    /// releases it once that `GitFolder` is dropped (its clone/fetch task
-    /// finished, failed, or got cancelled). `prepared_builds` alone can't
-    /// answer "is anyone writing to this dir right now": it's scoped by
-    /// SessionId and a session's entries linger until that same session
-    /// happens to build again, which for a one-shot session never happens.
-    /// Gating the Reuse HEAD-check on that instead would let a stale dir shed
-    /// verification forever the moment any session had ever planned it (#2711).
-    clones_in_progress: Arc<Mutex<BTreeSet<PathBuf>>>,
+    /// process-wide, across every build session, with a count of how many
+    /// writers claimed each dir. A `NewClone`/`CopyAndFetch`/`RenameAndFetch`
+    /// claims its target dir here as soon as it's chosen and releases it once
+    /// that `GitFolder` is dropped (its clone/fetch task finished, failed, or
+    /// got cancelled). `prepared_builds` alone can't answer "is anyone
+    /// writing to this dir right now": it's scoped by SessionId and a
+    /// session's entries linger until that same session happens to build
+    /// again, which for a one-shot session never happens. Gating the Reuse
+    /// HEAD-check on that instead would let a stale dir shed verification
+    /// forever the moment any session had ever planned it (#2711).
+    ///
+    /// This counts instead of tracking membership because two sessions can
+    /// both choose a writing arm for the same dir before it exists on disk;
+    /// with a plain set the first claim to drop would strip the protection
+    /// while the second writer is still going.
+    clones_in_progress: Arc<Mutex<BTreeMap<PathBuf, usize>>>,
     // reuse_for: BTreeMap<PathBuf, PathBuf>,
 }
 
@@ -34,25 +40,33 @@ pub struct GitManager {
 /// dropped, whatever the reason (clone finished, failed, or was cancelled).
 struct InProgressClaim {
     dir: PathBuf,
-    set: Arc<Mutex<BTreeSet<PathBuf>>>,
+    claims: Arc<Mutex<BTreeMap<PathBuf, usize>>>,
 }
 
 impl Drop for InProgressClaim {
     fn drop(&mut self) {
-        lock_in_progress(&self.set).remove(&self.dir);
+        let mut claims = lock_in_progress(&self.claims);
+        if let Some(count) = claims.get_mut(&self.dir) {
+            *count -= 1;
+            if *count == 0 {
+                claims.remove(&self.dir);
+            }
+        }
     }
 }
 
 /// Locks `clones_in_progress`, recovering from poisoning instead of
 /// panicking. A panic elsewhere while this lock was held must not leave the
-/// set stuck: `InProgressClaim::drop` runs during unwinding, where a panic
+/// map stuck: `InProgressClaim::drop` runs during unwinding, where a panic
 /// here would abort the process, and any panic-on-poison here would also
 /// leave the dir's claim permanently unreleased, exempting it from
 /// verification forever.
 fn lock_in_progress(
-    set: &Mutex<BTreeSet<PathBuf>>,
-) -> std::sync::MutexGuard<'_, BTreeSet<PathBuf>> {
-    set.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+    claims: &Mutex<BTreeMap<PathBuf, usize>>,
+) -> std::sync::MutexGuard<'_, BTreeMap<PathBuf, usize>> {
+    claims
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
 #[derive(Default)]
@@ -103,7 +117,7 @@ impl GitManager {
             // different, concurrently-running session sharing this daemon's
             // GitManager -- must never have its HEAD checked or be deleted, so I
             // skip verification and just reuse it, same as before this change.
-            let in_progress = lock_in_progress(&self.clones_in_progress).contains(&clone_dir);
+            let in_progress = lock_in_progress(&self.clones_in_progress).contains_key(&clone_dir);
             ReuseOptions::Reuse {
                 dir: clone_dir.clone(),
                 verify_commit: (!in_progress).then_some(commit_hash),
@@ -164,10 +178,12 @@ impl GitManager {
                 | ReuseOptions::RenameAndFetch { .. }
         )
         .then(|| {
-            lock_in_progress(&self.clones_in_progress).insert(clone_dir.clone());
+            *lock_in_progress(&self.clones_in_progress)
+                .entry(clone_dir.clone())
+                .or_insert(0) += 1;
             InProgressClaim {
                 dir: clone_dir,
-                set: self.clones_in_progress.clone(),
+                claims: self.clones_in_progress.clone(),
             }
         });
 
@@ -784,6 +800,98 @@ mod tests {
         // folder_a is still alive, holding its in-progress claim. Dropping it
         // now releases the claim, same as when its real clone finishes.
         drop(folder_a);
+    }
+
+    #[tokio::test]
+    async fn a_dir_stays_protected_while_any_overlapping_claim_is_alive() {
+        // Two sessions can both pick a writing arm for the same dir: the
+        // daemon's choose phase is synchronous in the event loop while the
+        // prepare tasks are spawned, so B's choose can run before A's clone
+        // has created the dir on disk. With plain set membership the two
+        // claims collapse into one entry, and whichever drops first strips
+        // the protection while the other is still writing. The claims have
+        // to count.
+        let repo_dir = tempfile::tempdir().unwrap();
+        let repo_path = repo_dir.path().join("repo");
+        let commit = init_repo_with_commit(&repo_path);
+        let repo_url_str = format!("file://{}", repo_path.display());
+        let target_dir = tempfile::tempdir().unwrap();
+
+        let mut manager = GitManager::default();
+
+        // A and B both choose before the dir exists, so both get NewClone
+        // and both claim it.
+        let folder_a = manager
+            .choose_clone_dir(
+                SessionId::generate(),
+                repo_url_str.clone(),
+                commit.clone(),
+                None,
+                target_dir.path(),
+            )
+            .unwrap();
+        let folder_b = manager
+            .choose_clone_dir(
+                SessionId::generate(),
+                repo_url_str.clone(),
+                commit.clone(),
+                None,
+                target_dir.path(),
+            )
+            .unwrap();
+        assert!(matches!(folder_a.reuse, ReuseOptions::NewClone { .. }));
+        assert!(matches!(folder_b.reuse, ReuseOptions::NewClone { .. }));
+
+        // The dir shows up on disk, then A finishes and drops its claim.
+        // B is still writing, so a third session must not get a commit to
+        // verify.
+        let parsed = Url::parse(&repo_url_str).unwrap();
+        let clone_dir = GitManager::clone_dir_path(target_dir.path(), &parsed, &commit).unwrap();
+        std::fs::create_dir_all(&clone_dir).unwrap();
+        drop(folder_a);
+
+        let folder_c = manager
+            .choose_clone_dir(
+                SessionId::generate(),
+                repo_url_str.clone(),
+                commit.clone(),
+                None,
+                target_dir.path(),
+            )
+            .unwrap();
+        assert!(
+            matches!(
+                &folder_c.reuse,
+                ReuseOptions::Reuse {
+                    verify_commit: None,
+                    ..
+                }
+            ),
+            "dropping one of two overlapping claims must not expose the dir to verification"
+        );
+
+        // Once B drops too, the next session verifies again as normal.
+        drop(folder_b);
+        drop(folder_c);
+        let folder_d = manager
+            .choose_clone_dir(
+                SessionId::generate(),
+                repo_url_str,
+                commit,
+                None,
+                target_dir.path(),
+            )
+            .unwrap();
+        assert!(
+            matches!(
+                &folder_d.reuse,
+                ReuseOptions::Reuse {
+                    verify_commit: Some(_),
+                    ..
+                }
+            ),
+            "once every claim is gone the dir must be verified again"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

#2482 added a HEAD-verification step to the `Reuse` arm that deletes a clone when its HEAD isn't at the pinned commit. It gated that check on `planned_this_session`, which only looks at the current session's own planned clone dirs. The daemon shares one `GitManager` across concurrently spawned build sessions, so a second session building the same repo@commit at the same time as a first could get handed `verify_commit: Some(hash)` for a dir the first session is still cloning into. Its HEAD check then fails to resolve HEAD on a half-written repo, reads that as a wrong-commit mismatch, and deletes the directory out from under the first session's in-flight clone.

I replaced the session-scoped guard with a process-wide `clones_in_progress` set on `GitManager`. Every `NewClone`, `CopyAndFetch`, and `RenameAndFetch` claims its target dir the moment it's chosen and releases it through an RAII guard when its `GitFolder` is dropped, whether the clone finished, failed, or got cancelled. The `Reuse` arm now skips verification only while a dir is actually being written, not because some session once planned it.

That distinction matters on its own. A session's planned-dir bookkeeping is never cleared until that same session builds again, and for a one-shot session (the normal case, one `SessionId` per `dora start`) that never happens. Keying the skip off "any session ever planned this dir," instead of "this dir is being written right now," would silently exempt a stale wrong-commit dir from verification forever, the first time any session touched it. That's the exact bug #2482 was written to close, reopened.

## Testing

- `reuse_does_not_verify_a_dir_a_concurrent_session_is_cloning_into`: two overlapping sessions against the same repo@commit; the second reuses without verification while the first is still cloning.
- `reuse_still_verifies_a_dir_left_by_a_different_finished_session`: a stale wrong-commit dir left by a different, already finished session still gets verified and cleaned up.
- Existing `Reuse` tests (wrong-commit delete, HEAD-match reuse, branch-ref skip, sibling-clone untouched) still pass.
- `cargo fmt --all -- --check`, `cargo clippy --all -- -D warnings`, a full `cargo test --all` (excluding the Python packages), and `cargo check --examples` all pass locally.

## Note on #2756

#2756 is already open against this issue and takes a different approach: it widens the per-session planned-dirs check to look across every session in `prepared_builds`. I think that reopens the same gap under a different name, for the same reason described above: a session's planned dirs never expire on their own, so the widened check ends up permanently skipping verification for a dir the first time any session plans it. This PR claims and releases dirs based on whether a clone is actually in flight, which sidesteps that.

Fixes #2711.