### PR TITLE
fix(ros2-bridge): saturate seconds decrement in builtin_interfaces__Time conversion

### DIFF
--- a/libraries/extensions/ros2-bridge/msg-gen/src/types/message.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/types/message.rs
@@ -215,7 +215,16 @@ impl Message {
                             // * -1.0           sec = -1 sec and 0 nanosec
                             // * -1.00000000001 sec = -2 sec and 999_999_999 nanosec
                             Self {
-                                sec: quot_sat - 1, // note -1
+                                // Borrow one second for the negative fractional
+                                // part. Saturate the decrement: when `quot_sat`
+                                // is already `i32::MIN` (either `quot == i32::MIN`
+                                // or the underflow branch above clamped it), a
+                                // plain `- 1` computes `i32::MIN - 1`, which
+                                // panics in debug builds and wraps to `i32::MAX`
+                                // (a sign flip) in release builds. `saturating_sub`
+                                // keeps the value pinned at `i32::MIN`, preserving
+                                // the saturation guarantee.
+                                sec: quot_sat.saturating_sub(1),
                                 nanosec: (1_000_000_000 + rem) as u32,
                             }
                         }


### PR DESCRIPTION
## Summary

Fixes #2798.

The generated `From<Time> for ffi::builtin_interfaces__Time` conversion in `libraries/extensions/ros2-bridge/msg-gen/src/types/message.rs` carefully saturates the whole-seconds value to `i32::MIN`, but the negative sub-second branch then decremented it unconditionally:

```rust
sec: quot_sat - 1, // note -1
```

When `quot_sat == i32::MIN` (whenever `quot <= i32::MIN`), this evaluates `i32::MIN - 1`:

- **Debug builds:** panic with `attempt to subtract with overflow`.
- **Release builds:** wrap to `i32::MAX`, corrupting the timestamp — a `~-2.15e9`-second time is reported as `~+2.15e9` seconds (sign flip).

This bug is emitted into every generated ROS2 bridge build.

## Fix

Use `saturating_sub(1)` so the value stays pinned at `i32::MIN`, preserving the saturation guarantee the surrounding branches already establish. One-token behavioral change plus an explanatory comment.

## Trigger

Any `Time` whose `to_nanos()` value `t` satisfies both `t / 1_000_000_000 <= i32::MIN` (≈ 68 years before the epoch, well within `i64` range) and a non-zero negative sub-second remainder.

## Validation

- `cargo check -p dora-ros2-bridge-msg-gen` ✅
- `cargo clippy -p dora-ros2-bridge-msg-gen -- -D warnings` ✅
- `cargo fmt --all -- --check` ✅

The changed code is inside a `quote! { ... }` codegen macro (it is emitted into the generated bridge crate rather than compiled here), so there is no in-crate unit test to add; the fix is a localized saturation change verified by inspection against the sibling `rem >= 0` saturation branch.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V54sCK4Gp5JR4dwv7KvNRE)_