### PR TITLE
ci(nightly): accept the reworded "up to date" self-update message

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -662,10 +662,11 @@ jobs:
           # command didn't even start the check path.
           echo "$out" | grep -q "Checking for updates" \
             || { echo "ERROR: --check-only didn't enter update-check path"; exit 1; }
-          # One of the two valid outcomes must print. If neither appears,
-          # either GitHub rate-limited us (tolerated) or the output format
-          # regressed (fail).
-          if echo "$out" | grep -qE "latest version|update is available"; then
+          # One of the valid outcomes must print — "up to date" / "update is
+          # available" (#2512 reworded the up-to-date line to "Dora CLI is up to
+          # date (current: X, latest release: Y)"). If none appears, either
+          # GitHub rate-limited us (tolerated) or the output format regressed.
+          if echo "$out" | grep -qE "up to date|latest version|update is available"; then
             echo "OK: check-only produced a valid outcome message"
           elif echo "$out" | grep -qE "rate limit|403|429"; then
             echo "WARN: GitHub API rate-limited on shared runner IP — skipping outcome assertion"

--- a/scripts/qa/ci-nightly-jobs.sh
+++ b/scripts/qa/ci-nightly-jobs.sh
@@ -1295,7 +1295,8 @@ job_topic_and_top() {
   out=$(timeout 30 dora self update --check-only 2>&1) || true
   echo "$out" | grep -q "Checking for updates" \
     || { echo "ERROR: --check-only didn't enter update-check path"; return 1; }
-  if echo "$out" | grep -qE "latest version|update is available"; then
+  # "up to date" covers the #2512 reworded up-to-date message.
+  if echo "$out" | grep -qE "up to date|latest version|update is available"; then
     :
   elif echo "$out" | grep -qE "rate limit|403|429"; then
     echo "WARN: GitHub API rate-limited -- skipping outcome assertion"


### PR DESCRIPTION
#2512 reworded `dora self update --check-only`'s up-to-date output to "Dora CLI is up to date (current: X, latest release: Y)", but the topic-and-top-smoke assertion still only accepted "latest version" / "update is available". The new wording matched neither, so it fell through to `ERROR: --check-only produced no recognized outcome message` and failed the nightly deterministically whenever the GitHub releases API was reachable (surfaced once #2742's Examples fix let the run reach this job).

Add "up to date" to the valid-outcome grep in both the workflow step (.github/workflows/nightly.yml) and the local repro (scripts/qa/ci-nightly-jobs.sh). Verified the exact failing CI output now matches.

Caught in https://github.com/dora-rs/dora/issues/2742#issuecomment-5044526458