### PR TITLE
chore(deps): move off yanked spin 0.9.8/0.10.0 to 0.9.9/0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,7 +700,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7913f22349ffcfc6ca0ca9a656ec26cfbba538ed49c31a273dff2c5d1ea83d9"
 dependencies = [
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -2747,7 +2747,7 @@ dependencies = [
  "futures-sink",
  "nanorand",
  "pin-project",
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -2759,7 +2759,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "nanorand",
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -6852,18 +6852,18 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spki"
@@ -7788,7 +7788,7 @@ dependencies = [
  "lazy_static",
  "log",
  "serde",
- "spin 0.9.8",
+ "spin 0.9.9",
  "uuid",
 ]
 
@@ -7803,7 +7803,7 @@ dependencies = [
  "log",
  "rand 0.8.6",
  "serde",
- "spin 0.10.0",
+ "spin 0.10.1",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`spin` **0.9.8** and **0.10.0** (transitive dependencies via the zenoh / ring stack) have been **yanked** from crates.io. `deny.toml` sets `yanked = "deny"`, so `cargo deny check advisories` — the supply-chain **`audit`** CI job — now fails on **every branch, including `main`**, independent of the diff under test. This is currently blocking the Trunk merge queue for all in-flight PRs.

This is not caused by any code change — it's a live-advisory-DB gate reacting to an upstream yank.

## Change

Bump both to their non-yanked patch successors — the remedy `cargo deny` itself suggests (`try cargo update -p spin`):

- `spin 0.9.8 → 0.9.9`
- `spin 0.10.0 → 0.10.1`

**`Cargo.lock` only** — no manifest or source changes, and no transitive cascade (the other 193 locked dependencies are unchanged).

## Verification

- `cargo deny check` → **advisories ok, bans ok, licenses ok, sources ok**
- `cargo check -p dora-daemon -p dora-cli` → builds clean

## Notes

Kept deliberately separate from the feature PRs (#2588, #2589) so their scope stays clean. Merging this unblocks the `audit` gate for those and any other open PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0113jYVAS47BoeJZ9qQ1Q2Yz)_