### PR TITLE
fix(ci,runtime): repair the tag-release pipeline's Python and publish failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,36 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUST_VERSION: "1.97.1"
+  # The workspace pins PyO3's abi3 floor to Python 3.11 (see pip-release.yml).
+  PYTHON_VERSION: "3.11"
 
 jobs:
+  # ── 0. Fail fast if the tag doesn't match the workspace version ──────────
+  # Guards against tag/version skew (the v1.0.0-rc.3 tag shipped rc.2
+  # artifacts). Only the publish jobs gate on this — build jobs have no
+  # irreversible side effects, so they start immediately.
+  check-version:
+    name: Verify tag matches workspace version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Compare tag with workspace version
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          # dora-cli inherits [workspace.package].version, so it stands in
+          # for the workspace version here.
+          crate_version=$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.name == "dora-cli") | .version')
+          if [ "$tag_version" != "$crate_version" ]; then
+            echo "::error::tag v$tag_version does not match workspace version $crate_version — bump [workspace.package].version before tagging"
+            exit 1
+          fi
+          echo "tag v$tag_version matches workspace version"
+
   # ── 1. Publish Rust crates to crates.io ──────────────────────────────────
   publish-crates:
     name: Publish crates
+    needs: check-version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -71,22 +96,35 @@ jobs:
           )
           # `cargo publish` blocks until the crate is available in the
           # index, so no propagation sleep is needed. Tolerate only
-          # already-published versions (idempotent re-runs); any other
-          # failure must fail the job instead of silently producing a
-          # partial release.
+          # already-published versions (idempotent re-runs) and retry on
+          # crates.io's new-crate rate limit (429, refills ~1 new crate per
+          # 10 min after the initial burst); any other failure must fail the
+          # job instead of silently producing a partial release.
+          max_attempts=4
+          backoff=630 # rate-limit window is 10 min, plus 30s slack
           for crate in "${CRATES[@]}"; do
             echo "::group::Publishing $crate"
-            if ! output=$(cargo publish -p "$crate" --no-verify 2>&1); then
+            for attempt in $(seq 1 "$max_attempts"); do
+              if output=$(cargo publish -p "$crate" --no-verify 2>&1); then
+                echo "$output" | tail -5
+                break
+              fi
               echo "$output"
               if echo "$output" | grep -qi "already uploaded\|is already uploaded\|already exists"; then
                 echo "::warning::$crate already published, skipping"
+                break
+              elif echo "$output" | grep -qi "429 Too Many Requests"; then
+                if [ "$attempt" -eq "$max_attempts" ]; then
+                  echo "::error::still rate limited publishing $crate after $attempt attempts"
+                  exit 1
+                fi
+                echo "::warning::crates.io rate limit hit for $crate; retrying in ${backoff}s (attempt $attempt)"
+                sleep "$backoff"
               else
                 echo "::error::failed to publish $crate"
                 exit 1
               fi
-            else
-              echo "$output" | tail -5
-            fi
+            done
             echo "::endgroup::"
           done
 
@@ -113,7 +151,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: ${{ env.PYTHON_VERSION }}
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -140,7 +178,7 @@ jobs:
   # ── 3. Publish wheels to PyPI ─────────────────────────────────────────────
   publish-pypi:
     name: Publish to PyPI
-    needs: build-wheels
+    needs: [build-wheels, check-version]
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -151,8 +189,14 @@ jobs:
           pattern: dora-rs*
           merge-multiple: true
           path: dist/
+      # Authenticate with the PYPI_PASS API token (same mechanism as
+      # pip-release.yml). Keyless trusted publishing needs a publisher
+      # registered on PyPI first — to switch later, register one on
+      # https://pypi.org/manage/project/dora-rs/settings/publishing/ with
+      # workflow `release.yml` and environment `pypi`, then drop `password`.
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          password: ${{ secrets.PYPI_PASS }}
           packages-dir: dist/
           skip-existing: true
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "action-example-client"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "arrow",
  "dora-node-api",
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "action-example-server"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "arrow",
  "dora-node-api",
@@ -97,7 +97,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "always-crash-node"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -639,7 +639,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "benchmark-example-node"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "benchmark-example-sink"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1042,7 +1042,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clean-exit-node"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1243,7 +1243,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpu-affinity-probe"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1362,7 +1362,7 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "cross-language-rust-receiver"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1370,7 +1370,7 @@ dependencies = [
 
 [[package]]
 name = "cross-language-rust-sender"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "delayed-crash-node"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1924,7 +1924,7 @@ dependencies = [
 
 [[package]]
 name = "dora-arrow-convert"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "arrow",
  "chrono",
@@ -1936,7 +1936,7 @@ dependencies = [
 
 [[package]]
 name = "dora-cli"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "arrow",
  "arrow-json",
@@ -1995,7 +1995,7 @@ dependencies = [
 
 [[package]]
 name = "dora-cli-api-python"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-cli",
  "dora-download",
@@ -2009,7 +2009,7 @@ dependencies = [
 
 [[package]]
 name = "dora-coordinator"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "arrow",
  "axum",
@@ -2042,7 +2042,7 @@ dependencies = [
 
 [[package]]
 name = "dora-coordinator-store"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "bincode 2.0.1",
  "dora-message",
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "dora-core"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -2088,7 +2088,7 @@ dependencies = [
 
 [[package]]
 name = "dora-daemon"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "aligned-vec",
  "bincode 1.3.3",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "dora-download"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "eyre",
  "reqwest",
@@ -2177,7 +2177,7 @@ dependencies = [
 
 [[package]]
 name = "dora-hub-client"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dirs 6.0.0",
  "dora-core",
@@ -2191,7 +2191,7 @@ dependencies = [
 
 [[package]]
 name = "dora-log-utils"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "arrow",
  "chrono",
@@ -2203,7 +2203,7 @@ dependencies = [
 
 [[package]]
 name = "dora-mavlink2-bridge"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "arrow",
  "eyre",
@@ -2218,7 +2218,7 @@ dependencies = [
 
 [[package]]
 name = "dora-mavlink2-bridge-node"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "arrow",
  "dora-mavlink2-bridge",
@@ -2235,14 +2235,14 @@ dependencies = [
 
 [[package]]
 name = "dora-memory-pool"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "dora-message"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "aligned-vec",
  "arrow-data",
@@ -2270,7 +2270,7 @@ dependencies = [
 
 [[package]]
 name = "dora-metrics"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "eyre",
  "opentelemetry",
@@ -2281,7 +2281,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -2317,7 +2317,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-c"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "arrow-array",
  "dora-node-api",
@@ -2327,7 +2327,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-cxx"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "arrow",
  "chrono",
@@ -2347,7 +2347,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-python"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "arrow",
  "chrono",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-arrow-convert",
  "dora-operator-api-macros",
@@ -2382,14 +2382,14 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-c"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-operator-api-types",
 ]
 
 [[package]]
 name = "dora-operator-api-cxx"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -2398,7 +2398,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-macros"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-python"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -2428,7 +2428,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-types"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "arrow",
  "dora-arrow-convert",
@@ -2437,7 +2437,7 @@ dependencies = [
 
 [[package]]
 name = "dora-record-node"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "aligned-vec",
  "dora-message",
@@ -2450,7 +2450,7 @@ dependencies = [
 
 [[package]]
 name = "dora-recording"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "eyre",
  "tempfile",
@@ -2459,7 +2459,7 @@ dependencies = [
 
 [[package]]
 name = "dora-replay-node"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "bincode 1.3.3",
  "dora-message",
@@ -2470,7 +2470,7 @@ dependencies = [
 
 [[package]]
 name = "dora-ros2-bridge"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "array-init",
  "dora-cli",
@@ -2496,7 +2496,7 @@ dependencies = [
 
 [[package]]
 name = "dora-ros2-bridge-arrow"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "arrow",
  "byteorder",
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "dora-ros2-bridge-msg-gen"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "anyhow",
  "glob",
@@ -2527,7 +2527,7 @@ dependencies = [
 
 [[package]]
 name = "dora-ros2-bridge-node"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "arrow",
  "dora-message",
@@ -2547,7 +2547,7 @@ dependencies = [
 
 [[package]]
 name = "dora-ros2-bridge-python"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "arrow",
  "dora-ros2-bridge",
@@ -2564,7 +2564,7 @@ dependencies = [
 
 [[package]]
 name = "dora-runtime"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "aligned-vec",
  "arrow",
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "dora-tracing"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "eyre",
  "opentelemetry",
@@ -2670,7 +2670,7 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "emit-then-exit-source-node"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -2819,7 +2819,7 @@ dependencies = [
 
 [[package]]
 name = "event-log-observer-node"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -2948,7 +2948,7 @@ checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
 
 [[package]]
 name = "fire-and-forget-source-node"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -3334,7 +3334,7 @@ dependencies = [
 
 [[package]]
 name = "hang-after-init-node"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -3781,7 +3781,7 @@ dependencies = [
 
 [[package]]
 name = "input-closed-observer-node"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4351,7 +4351,7 @@ dependencies = [
 
 [[package]]
 name = "log-sink-alert"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-arrow-convert",
  "dora-log-utils",
@@ -4362,7 +4362,7 @@ dependencies = [
 
 [[package]]
 name = "log-sink-file"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-log-utils",
  "dora-node-api",
@@ -4371,7 +4371,7 @@ dependencies = [
 
 [[package]]
 name = "log-sink-tcp"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-log-utils",
  "dora-node-api",
@@ -4496,7 +4496,7 @@ dependencies = [
 
 [[package]]
 name = "mavlink2-bridge-example-heartbeat-emitter"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "arrow",
  "dora-mavlink2-bridge",
@@ -4507,7 +4507,7 @@ dependencies = [
 
 [[package]]
 name = "mavlink2-bridge-example-mavlink-sim"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-mavlink2-bridge",
  "dora-node-api",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "mavlink2-bridge-example-telemetry-printer-rust"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "arrow",
  "dora-mavlink2-bridge",
@@ -4645,7 +4645,7 @@ dependencies = [
 
 [[package]]
 name = "multiple-daemons-example-node"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4656,14 +4656,14 @@ dependencies = [
 
 [[package]]
 name = "multiple-daemons-example-operator"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-operator-api",
 ]
 
 [[package]]
 name = "multiple-daemons-example-sink"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -6099,7 +6099,7 @@ dependencies = [
 
 [[package]]
 name = "receive_data"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "chrono",
  "dora-node-api",
@@ -6108,7 +6108,7 @@ dependencies = [
 
 [[package]]
 name = "reconnect-survivor-node"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -6312,7 +6312,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-node"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -6325,7 +6325,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-sink"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -6333,7 +6333,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-sink-dynamic"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -6341,7 +6341,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-status-node"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -6350,7 +6350,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dynamic-add-remove-filter"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -6358,7 +6358,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dynamic-add-remove-receiver"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -6366,7 +6366,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dynamic-add-remove-sender"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -6385,7 +6385,7 @@ dependencies = [
 
 [[package]]
 name = "rust-ros2-example-node"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-node-api",
  "dora-ros2-bridge",
@@ -6970,7 +6970,7 @@ dependencies = [
 
 [[package]]
 name = "service-example-client"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "arrow",
  "dora-node-api",
@@ -6979,7 +6979,7 @@ dependencies = [
 
 [[package]]
 name = "service-example-server"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "arrow",
  "dora-node-api",
@@ -7124,7 +7124,7 @@ dependencies = [
 
 [[package]]
 name = "silent-source-node"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -7726,7 +7726,7 @@ dependencies = [
 
 [[package]]
 name = "timed-burst-source-node"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -8405,7 +8405,7 @@ dependencies = [
 
 [[package]]
 name = "validated-pipeline-sink"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -8413,7 +8413,7 @@ dependencies = [
 
 [[package]]
 name = "validated-pipeline-source"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -8421,7 +8421,7 @@ dependencies = [
 
 [[package]]
 name = "validated-pipeline-transform"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -9352,7 +9352,7 @@ dependencies = [
 
 [[package]]
 name = "yaml-bridge-action-goal"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "arrow",
  "dora-node-api",
@@ -9361,7 +9361,7 @@ dependencies = [
 
 [[package]]
 name = "yaml-bridge-action-server-handler"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "arrow",
  "dora-node-api",
@@ -9370,7 +9370,7 @@ dependencies = [
 
 [[package]]
 name = "yaml-bridge-service-handler"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "arrow",
  "dora-node-api",
@@ -9379,7 +9379,7 @@ dependencies = [
 
 [[package]]
 name = "yaml-bridge-service-requester"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 dependencies = [
  "arrow",
  "dora-node-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ members = [
 edition = "2024"
 rust-version = "1.88.0"
 # Python packages derive version from CARGO_PKG_VERSION automatically.
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.4"
 description = "`dora` goal is to be a low latency, composable, and distributed data flow."
 documentation = "https://dora-rs.ai"
 readme = "./README.md"
@@ -96,33 +96,33 @@ license = "Apache-2.0"
 repository = "https://github.com/dora-rs/dora/"
 
 [workspace.dependencies]
-dora-node-api = { version = "1.0.0-rc.2", path = "apis/rust/node", default-features = false }
-dora-node-api-python = { version = "1.0.0-rc.2", path = "apis/python/node", default-features = false }
-dora-operator-api = { version = "1.0.0-rc.2", path = "apis/rust/operator", default-features = false }
-dora-operator-api-macros = { version = "1.0.0-rc.2", path = "apis/rust/operator/macros" }
-dora-operator-api-types = { version = "1.0.0-rc.2", path = "apis/rust/operator/types" }
-dora-operator-api-python = { version = "1.0.0-rc.2", path = "apis/python/operator" }
-dora-operator-api-c = { version = "1.0.0-rc.2", path = "apis/c/operator" }
-dora-node-api-c = { version = "1.0.0-rc.2", path = "apis/c/node" }
-dora-core = { version = "1.0.0-rc.2", path = "libraries/core" }
-dora-hub-client = { version = "1.0.0-rc.2", path = "libraries/hub-client" }
-dora-recording = { version = "1.0.0-rc.2", path = "libraries/recording" }
-dora-arrow-convert = { version = "1.0.0-rc.2", path = "libraries/arrow-convert" }
-dora-tracing = { version = "1.0.0-rc.2", path = "libraries/extensions/telemetry/tracing" }
-dora-metrics = { version = "1.0.0-rc.2", path = "libraries/extensions/telemetry/metrics" }
-dora-download = { version = "1.0.0-rc.2", path = "libraries/extensions/download" }
-dora-log-utils = { version = "1.0.0-rc.2", path = "libraries/log-utils" }
-dora-coordinator-store = { version = "1.0.0-rc.2", path = "libraries/coordinator-store" }
-dora-cli = { version = "1.0.0-rc.2", path = "binaries/cli" }
-dora-runtime = { version = "1.0.0-rc.2", path = "binaries/runtime" }
-dora-daemon = { version = "1.0.0-rc.2", path = "binaries/daemon" }
-dora-coordinator = { version = "1.0.0-rc.2", path = "binaries/coordinator" }
-dora-ros2-bridge = { version = "1.0.0-rc.2", path = "libraries/extensions/ros2-bridge" }
-dora-ros2-bridge-msg-gen = { version = "1.0.0-rc.2", path = "libraries/extensions/ros2-bridge/msg-gen" }
+dora-node-api = { version = "1.0.0-rc.4", path = "apis/rust/node", default-features = false }
+dora-node-api-python = { version = "1.0.0-rc.4", path = "apis/python/node", default-features = false }
+dora-operator-api = { version = "1.0.0-rc.4", path = "apis/rust/operator", default-features = false }
+dora-operator-api-macros = { version = "1.0.0-rc.4", path = "apis/rust/operator/macros" }
+dora-operator-api-types = { version = "1.0.0-rc.4", path = "apis/rust/operator/types" }
+dora-operator-api-python = { version = "1.0.0-rc.4", path = "apis/python/operator" }
+dora-operator-api-c = { version = "1.0.0-rc.4", path = "apis/c/operator" }
+dora-node-api-c = { version = "1.0.0-rc.4", path = "apis/c/node" }
+dora-core = { version = "1.0.0-rc.4", path = "libraries/core" }
+dora-hub-client = { version = "1.0.0-rc.4", path = "libraries/hub-client" }
+dora-recording = { version = "1.0.0-rc.4", path = "libraries/recording" }
+dora-arrow-convert = { version = "1.0.0-rc.4", path = "libraries/arrow-convert" }
+dora-tracing = { version = "1.0.0-rc.4", path = "libraries/extensions/telemetry/tracing" }
+dora-metrics = { version = "1.0.0-rc.4", path = "libraries/extensions/telemetry/metrics" }
+dora-download = { version = "1.0.0-rc.4", path = "libraries/extensions/download" }
+dora-log-utils = { version = "1.0.0-rc.4", path = "libraries/log-utils" }
+dora-coordinator-store = { version = "1.0.0-rc.4", path = "libraries/coordinator-store" }
+dora-cli = { version = "1.0.0-rc.4", path = "binaries/cli" }
+dora-runtime = { version = "1.0.0-rc.4", path = "binaries/runtime" }
+dora-daemon = { version = "1.0.0-rc.4", path = "binaries/daemon" }
+dora-coordinator = { version = "1.0.0-rc.4", path = "binaries/coordinator" }
+dora-ros2-bridge = { version = "1.0.0-rc.4", path = "libraries/extensions/ros2-bridge" }
+dora-ros2-bridge-msg-gen = { version = "1.0.0-rc.4", path = "libraries/extensions/ros2-bridge/msg-gen" }
 dora-ros2-bridge-python = { path = "libraries/extensions/ros2-bridge/python" }
-dora-mavlink2-bridge = { version = "1.0.0-rc.2", path = "libraries/extensions/mavlink2-bridge" }
-dora-memory-pool = { version = "1.0.0-rc.2", path = "libraries/extensions/memory-pool" }
-dora-message = { version = "1.0.0-rc.2", path = "libraries/message" }
+dora-mavlink2-bridge = { version = "1.0.0-rc.4", path = "libraries/extensions/mavlink2-bridge" }
+dora-memory-pool = { version = "1.0.0-rc.4", path = "libraries/extensions/memory-pool" }
+dora-message = { version = "1.0.0-rc.4", path = "libraries/message" }
 arrow = { version = "59", default-features = false }
 arrow-schema = { version = "59" }
 arrow-data = { version = "59" }

--- a/binaries/runtime/Cargo.toml
+++ b/binaries/runtime/Cargo.toml
@@ -37,11 +37,21 @@ arrow = { workspace = true, features = ["ffi"] }
 aligned-vec = "0.6.4"
 
 [build-dependencies]
-pyo3-build-config = { workspace = true }
+# Optional: pyo3-build-config's own build script (resolve-config feature)
+# probes the Python interpreter and fails when it's older than the
+# workspace abi3-py311 floor, which broke plain `cargo build -p dora-cli`
+# on systems with Python <= 3.10. Only pull it in when Python is wanted.
+pyo3-build-config = { workspace = true, optional = true }
 
 [features]
 default = ["tracing", "metrics"]
 tracing = ["dora-tracing"]
 telemetry = ["tracing", "tracing-opentelemetry"]
 metrics = ["dora-metrics"]
-python = ["pyo3", "dora-operator-api-python", "pythonize", "arrow/pyarrow"]
+python = [
+    "pyo3",
+    "dora-operator-api-python",
+    "pythonize",
+    "arrow/pyarrow",
+    "dep:pyo3-build-config",
+]

--- a/binaries/runtime/build.rs
+++ b/binaries/runtime/build.rs
@@ -4,8 +4,10 @@ fn main() {
     // without each contributor rediscovering this setup. See
     // apis/python/node/build.rs for context; #1833 hit this issue first.
     //
-    // `pyo3` is an optional dependency on this crate (`python` feature), but
-    // `pyo3-build-config::use_pyo3_cfgs()` is a no-op when there's no Python
-    // discoverable, so it's safe to call unconditionally.
+    // pyo3-build-config is an optional build-dependency tied to the `python`
+    // feature: its own build script probes the Python interpreter and fails
+    // on systems older than the workspace `abi3-py311` floor (e.g. Python
+    // 3.10 on ubuntu-22.04), which broke non-Python `cargo build -p dora-cli`.
+    #[cfg(feature = "python")]
     pyo3_build_config::use_pyo3_cfgs();
 }


### PR DESCRIPTION
## Problem

The `v1.0.0-rc.3` tag release run ([29585371901](https://github.com/dora-rs/dora/actions/runs/29585371901)) failed in three independent ways:

1. **Publish to PyPI** — the trusted-publishing token exchange was rejected with `invalid-publisher`: no trusted publisher is registered on PyPI for `release.yml` + environment `pypi`. (Releases through v0.5.0 worked because `pip-release.yml` used the `PYPI_PASS` API token.)
2. **Build CLI binaries (both Linux targets)** — `failed to run custom build command for pyo3-build-config v0.28.3`: its build script (via the `resolve-config` feature) probes the Python interpreter and errors when it is older than the workspace `abi3-py311` floor. ubuntu-22.04 ships Python 3.10. This also breaks `cargo install dora-cli` for end users on such systems — the CLI build doesn't use Python at all, yet `dora-runtime` unconditionally pulled the probe in as a build-dependency.
3. **Publish crates** — crates.io's new-crate rate limit (429, refills ~1 new crate per 10 min) killed the job at `dora-operator-api-cxx`; the loop treated 429 as fatal.

Additionally, the rc.3 tag was pushed while the workspace was still versioned `1.0.0-rc.2`, so the run half-published rc.2 artifacts.

## Fixes

- **PyPI**: authenticate with the existing `PYPI_PASS` secret. A comment documents the path back to keyless trusted publishing (register the publisher on PyPI, then drop `password`).
- **pyo3 probe**: `pyo3-build-config` is now an optional build-dependency of `dora-runtime`, enabled by the `python` feature; `build.rs` gates the `use_pyo3_cfgs()` call on `#[cfg(feature = "python")]`. Verified: with the feature off the crate is absent from the `dora-cli` graph entirely; with it on, the build script still emits all `Py_3_N` cfgs unchanged.
- **429**: retry up to 4 attempts with a 630 s backoff, still failing loudly on exhaustion or any other error, and still tolerating already-published versions for idempotent re-runs.
- **Version guard**: a new `check-version` job fails fast when the tag doesn't match `[workspace.package].version`. Only the publish jobs gate on it — wheel/binary builds have no irreversible side effects and start immediately.

## Validation

- `cargo check -p dora-runtime` and `--features python` both pass; `-vv` build confirms the `Py_3_N` cfg emission with the feature on
- `cargo clippy -p dora-runtime --features python -- -D warnings` clean
- `cargo fmt --all -- --check` clean

## Notes / follow-ups

- Before the next tag: bump `[workspace.package].version` (rc.3 is burned — next should be `v1.0.0-rc.4`), and double-check the `PYPI_PASS` secret is still valid (last used successfully for v0.5.0).
- `cargo-release.yml` carries a duplicate crate-publish loop (triggered on `release: published`) without the 429 retry; extracting a shared `scripts/publish-crates.sh` for both workflows would be a good follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)