### PR TITLE
fix(daemon): cancel a timer task when RemoveNode drains its last subscriber

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -2314,9 +2314,9 @@ impl Daemon {
                     // both to stop delivering to a removed node and so a re-added
                     // ID is classified by its own inputs, not stale timer/log
                     // state (which would mark it never-finishing forever, #2270).
-                    for receivers in dataflow.timers.values_mut() {
-                        receivers.retain(|(nid, _)| nid != &node_id);
-                    }
+                    // Cancels the timer task of any interval left with no
+                    // subscribers (#2585); see the method for details.
+                    dataflow.unsubscribe_node_from_timers(&node_id);
                     dataflow
                         .log_subscribers
                         .retain(|sub| sub.node_id != node_id);
@@ -6168,6 +6168,52 @@ mod fault_tolerance_tests {
         assert!(df._timer_handles.contains_key(&first));
         assert!(df._timer_handles.contains_key(&second));
         assert_eq!(df._timer_handles.len(), 2);
+    }
+
+    // dora-rs/dora: removing the last subscriber of a timer interval (via
+    // `RemoveNode`) must cancel that interval's timer task and forget the
+    // entry, so it doesn't keep ticking to an empty subscriber set for the
+    // rest of the dataflow's life (#2585). An interval that still has other
+    // subscribers must be left running.
+    #[tokio::test]
+    async fn unsubscribe_last_subscriber_cancels_timer_task() {
+        let mut df = test_dataflow();
+        let clock = Arc::new(HLC::default());
+        let (events_tx, _events_rx) = mpsc::channel(8);
+
+        let node_a = NodeId::from("a".to_string());
+        let node_b = NodeId::from("b".to_string());
+        let solo = Duration::from_millis(100); // only `a` subscribes
+        let shared = Duration::from_millis(250); // `a` and `b` subscribe
+
+        df.timers
+            .entry(solo)
+            .or_default()
+            .insert((node_a.clone(), DataId::from("t".to_string())));
+        df.timers
+            .entry(shared)
+            .or_default()
+            .insert((node_a.clone(), DataId::from("t".to_string())));
+        df.timers
+            .entry(shared)
+            .or_default()
+            .insert((node_b.clone(), DataId::from("t".to_string())));
+        df.start(&events_tx, &clock).await.unwrap();
+        assert!(df._timer_handles.contains_key(&solo));
+        assert!(df._timer_handles.contains_key(&shared));
+
+        df.unsubscribe_node_from_timers(&node_a);
+
+        // `solo` lost its only subscriber: entry and task both gone.
+        assert!(!df.timers.contains_key(&solo));
+        assert!(!df._timer_handles.contains_key(&solo));
+        // `shared` still has `b`: it keeps its subscriber set and its task.
+        assert_eq!(
+            df.timers.get(&shared).map(|s| s.len()),
+            Some(1),
+            "shared interval must keep its remaining subscriber"
+        );
+        assert!(df._timer_handles.contains_key(&shared));
     }
 
     // dora-rs/dora: the `AddNode` handler guards its re-invocation of

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -397,6 +397,36 @@ impl RunningDataflow {
         Ok(())
     }
 
+    /// Drop `node_id` from every timer subscriber set, and for any interval it
+    /// was the *last* subscriber of, cancel that interval's timer task and
+    /// forget the now-empty entry.
+    ///
+    /// Without the cancellation, the per-interval task spawned by [`start`]
+    /// keeps ticking and dispatching `DoraEvent::Timer`s to an empty subscriber
+    /// set for the remaining life of the dataflow — a bounded but pointless
+    /// stream of wakeups after the last consumer of that interval is removed
+    /// via `RemoveNode` (#2585). Dropping the [`RemoteHandle`] stored in
+    /// `_timer_handles` cancels the spawned future. A later `AddNode` that
+    /// re-subscribes to the same interval re-spawns the task through `start`,
+    /// whose `_timer_handles.contains_key` guard makes that safe.
+    ///
+    /// [`start`]: RunningDataflow::start
+    /// [`RemoteHandle`]: futures::future::RemoteHandle
+    pub(crate) fn unsubscribe_node_from_timers(&mut self, node_id: &NodeId) {
+        let mut drained_intervals = Vec::new();
+        for (interval, receivers) in self.timers.iter_mut() {
+            receivers.retain(|(nid, _)| nid != node_id);
+            if receivers.is_empty() {
+                drained_intervals.push(*interval);
+            }
+        }
+        for interval in drained_intervals {
+            self.timers.remove(&interval);
+            // Dropping the RemoteHandle cancels the spawned timer task.
+            self._timer_handles.remove(&interval);
+        }
+    }
+
     pub(crate) async fn stop_all(
         &mut self,
         coordinator_sender: &mut Option<coordinator::CoordinatorSender>,


### PR DESCRIPTION
## Summary

Addresses the lower-severity observation in #2585.

The **primary** bug in #2585 (a node added via `AddNode` to a running dataflow never receiving ticks for a brand-new interval) was already fixed on `main` by #2474, which re-invokes `dataflow.start()` from the `AddNode` handler. This PR closes out the issue's remaining, explicitly-noted **secondary** observation.

`RemoveNode` removed the departing node from every `timers` subscriber set but never touched `_timer_handles`. When the removed node was the *last* subscriber to an interval, that interval's per-interval task kept ticking and dispatching `DoraEvent::Timer`s to an empty subscriber set for the remaining life of the dataflow — a bounded but pointless stream of wakeups.

## Fix

Extract the timer-unsubscribe logic into `RunningDataflow::unsubscribe_node_from_timers`, which:
- drops the node from each interval's subscriber set, and
- for any interval left with no subscribers, cancels its timer task (dropping the `futures::future::RemoteHandle` stored in `_timer_handles` cancels the spawned future) and forgets the now-empty `timers` entry.

A later `AddNode` re-subscribing to the same interval re-spawns the task via the idempotent `start()` (its `_timer_handles.contains_key` guard makes re-invocation safe), so behavior for the re-subscribe case is preserved.

## Tests

`unsubscribe_last_subscriber_cancels_timer_task` — with one interval subscribed only by node `a` and another shared by `a` and `b`, removing `a` drops the solo interval's entry *and* its task, while the shared interval keeps its remaining subscriber and its task.

`cargo fmt --all -- --check` is clean and `cargo clippy -p dora-daemon --lib -- -D warnings` passes. (An unrelated pre-existing `match_like_matches_macro` lint in the `matches_event` test helper is untouched, per the repo's "don't fix unrelated warnings" convention.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYVWUwXULA9QoNbYJcLsF4)_