### PR TITLE
fix(core): keep a file:// drive letter out of the git clone cache path (#2742)

### DIFF
--- a/libraries/core/src/build/git.rs
+++ b/libraries/core/src/build/git.rs
@@ -217,8 +217,18 @@ impl GitManager {
         // file:// URLs (local mirrors, air-gapped setups, tests) have no
         // hostname — group their clones under a "localhost" directory
         let host = repo_url.host_str().unwrap_or("localhost");
-        let mut path = base_dir.join(host);
-        path.extend(repo_url.path_segments().context("no path in git URL")?);
+        let mut path = base_dir.join(sanitize_dir_component(host));
+        // A `file:///C:/...` URL parses with the drive letter (`C:`) as its
+        // first path segment; the colon makes that an unnameable directory on
+        // Windows (#2742). Sanitize every component so the cache path is legal
+        // on all platforms — a no-op for normal `https://host/owner/repo` URLs,
+        // whose segments carry no reserved characters.
+        path.extend(
+            repo_url
+                .path_segments()
+                .context("no path in git URL")?
+                .map(sanitize_dir_component),
+        );
         let path = path.join(commit_hash);
         Ok(dunce::simplified(&path).to_owned())
     }
@@ -496,6 +506,28 @@ fn is_full_commit_hash(s: &str) -> bool {
     matches!(s.len(), 40 | 64) && s.bytes().all(|b| b.is_ascii_hexdigit())
 }
 
+/// Map one git-URL component (host or path segment) onto a single directory
+/// name by replacing the characters Windows forbids in a path component with
+/// `_`. The one that bites in practice is the `:` of a `file:///C:/...` drive
+/// letter, which otherwise lands mid-path as an unnameable `C:` directory
+/// (#2742). This is a no-op for normal `https://host/owner/repo` URLs, whose
+/// components have no reserved characters; a collision here only means two
+/// repos share a parent cache dir, and the commit hash still keeps their
+/// clones apart. Not handled (they don't occur in real git URLs): reserved
+/// device names like `CON`/`NUL` and trailing dot/space components.
+fn sanitize_dir_component(component: &str) -> String {
+    component
+        .chars()
+        .map(|c| {
+            if c.is_control() || matches!(c, '<' | '>' | ':' | '"' | '|' | '?' | '*' | '\\' | '/') {
+                '_'
+            } else {
+                c
+            }
+        })
+        .collect()
+}
+
 fn clone_into(repo_addr: Url, clone_dir: &Path) -> eyre::Result<git2::Repository> {
     if let Some(parent) = clone_dir.parent() {
         std::fs::create_dir_all(parent)
@@ -622,6 +654,28 @@ mod tests {
         repo.commit(Some("HEAD"), &sig, &sig, "A", &tree, &[])
             .unwrap()
             .to_string()
+    }
+
+    #[test]
+    fn clone_dir_path_keeps_a_file_url_drive_letter_out_of_the_on_disk_path() {
+        // A `file://` URL to a Windows-style absolute path parses with the
+        // drive letter as its first path segment (`C:`). Colon is illegal in a
+        // Windows path component, so if it survives into the cache path the
+        // clone destination can't be created on Windows -- exactly the failure
+        // `reuse_still_verifies_a_dir_left_by_a_different_finished_session` hit
+        // on the nightly Windows runner (#2742). The check is
+        // platform-independent: `clone_dir_path` must never emit a component
+        // carrying a colon, whatever OS builds it.
+        let url = Url::parse("file:///C:/Users/runner/repo").unwrap();
+        let dir = GitManager::clone_dir_path(Path::new("base"), &url, &"a".repeat(40)).unwrap();
+        for component in dir.components() {
+            let name = component.as_os_str().to_string_lossy();
+            assert!(
+                !name.contains(':'),
+                "component `{name}` keeps a colon Windows rejects, in {}",
+                dir.display()
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
The nightly `test-cross-platform` job started failing on Windows on 2026-07-23
([run 29991190148](https://github.com/dora-rs/dora/actions/runs/29991190148)):

```
build::git::tests::reuse_still_verifies_a_dir_left_by_a_different_finished_session
  failed to clone git repo from `file:///C:/Users/RUNNER~1/.../repo`
  failed to make directory './C:Users': The directory name is invalid.
```

`GitManager::clone_dir_path` builds the on-disk clone-cache path by extending it
with the repo URL's raw path segments. A `file:///C:/...` mirror URL parses with
the drive letter `C:` as its first path segment, and the colon makes that an
unnameable directory component on Windows, so the daemon's clone destination
can't be created. The bug is latent since #2043; #2795 added the first test that
actually clones from a `file://` URL, which surfaced it. `file://` mirrors are a
supported source (local mirrors / air-gapped setups), so this also affected real
Windows builds, not just the test.

The fix sanitizes each host/path component, replacing the Windows-reserved
characters with `_`. It is a no-op for normal `https://host/owner/repo` URLs —
their components carry no reserved characters — so existing caches are
untouched. A platform-independent regression test asserts no emitted component
keeps a colon.

Refs #2742
