### PR TITLE
ci(nightly): give the Windows Multiple Daemons example more build headroom (#2742)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1265,7 +1265,10 @@ jobs:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
-    timeout-minutes: 90
+    # Raised alongside the Multiple Daemons step bump (30->45 min) so the whole
+    # sequence of from-scratch example builds still fits under the job cap on a
+    # cold Windows runner (#2742).
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
@@ -1311,7 +1314,12 @@ jobs:
         timeout-minutes: 30
         run: cargo run --example rust-dataflow-git
       - name: Multiple Daemons example
-        timeout-minutes: 30
+        # `dora build` recompiles the node/operator crates (zenoh, arrow,
+        # rustls, quinn) from scratch in release, which on a cold Windows
+        # runner can outrun a 30-min step budget — the 2026-07-23 nightly was
+        # still compiling zenoh when the step was force-killed (#2742). 45 min
+        # gives the release build margin without masking a genuine hang.
+        timeout-minutes: 45
         run: cargo run --example multiple-daemons
       - name: C Dataflow example
         timeout-minutes: 15


### PR DESCRIPTION
The nightly `Examples (windows-latest)` job failed on 2026-07-23
([run 29991190148](https://github.com/dora-rs/dora/actions/runs/29991190148))
when the "Multiple Daemons example" step hit its 30-minute timeout while still
compiling zenoh:

```
error: process didn't exit successfully: `...\dora.exe build dataflow.yml`
  (exit code: 0xc000013a, STATUS_CONTROL_C_EXIT)
The action 'Multiple Daemons example' has timed out after 30 minutes.
```

`cargo run --example multiple-daemons` triggers `dora build`, which recompiles
the node/operator crates (zenoh, arrow, rustls, quinn) from scratch in release.
On a cold Windows runner that occasionally runs past 30 minutes — the step was
force-killed mid-compile (`STATUS_CONTROL_C_EXIT` is the timeout killing the
process tree, not a logic error). The step was green on the 2026-07-22 nightly.

This raises the step budget to 45 minutes and the job cap 90 → 120 so the
from-scratch build sequence fits under both, without masking a genuine hang.

Refs #2742
