### PR TITLE
fix(c/c++-node): reject invalid output ids instead of aborting the node

### DIFF
--- a/apis/c++/node/src/lib.rs
+++ b/apis/c++/node/src/lib.rs
@@ -474,26 +474,29 @@ fn event_as_node_failed(event: Box<DoraEvent>) -> eyre::Result<ffi::DoraNodeFail
     })
 }
 
+/// Parse a caller-supplied output id via `FromStr` instead of the panicking
+/// `From<String>`.
+///
+/// `DataId::from(String)` is documented as panicking on invalid characters
+/// (see `libraries/message/src/id.rs`, `# Panics`). Calling it on a
+/// caller-supplied string would mean a typo in a C++ string literal aborts
+/// the whole node by unwinding across the `cxx::bridge`. Returning the error
+/// as a `DoraResult.error` instead lets the C++ caller handle it.
+fn parse_output_id(id: &str) -> Result<dora_node_api::dora_core::config::DataId, ffi::DoraResult> {
+    id.parse().map_err(|e| ffi::DoraResult {
+        error: format!("invalid output id '{id}': {e}"),
+    })
+}
+
 fn close_outputs(
     output_sender: &mut Box<OutputSender>,
     output_ids: Vec<String>,
 ) -> ffi::DoraResult {
-    // Parse via `FromStr` instead of `From<String>` so invalid IDs
-    // surface as a `DoraResult.error` rather than panicking across
-    // the cxx::bridge. `DataId::from(String)` is documented as
-    // panicking on invalid characters (see
-    // `libraries/message/src/id.rs:186`, `# Panics`); calling it on
-    // caller-supplied input would mean a typo in a C++ string literal
-    // aborts the whole node.
     let mut ids = Vec::with_capacity(output_ids.len());
     for id in output_ids {
-        match id.parse::<dora_node_api::dora_core::config::DataId>() {
+        match parse_output_id(&id) {
             Ok(parsed) => ids.push(parsed),
-            Err(e) => {
-                return ffi::DoraResult {
-                    error: format!("invalid output id '{id}': {e}"),
-                };
-            }
+            Err(err) => return err,
         }
     }
     match output_sender.0.close_outputs(ids) {
@@ -911,9 +914,13 @@ fn send_output_internal(
     data: &[u8],
     metadata: DoraMetadataParameters,
 ) -> ffi::DoraResult {
+    let output_id = match parse_output_id(&id) {
+        Ok(parsed) => parsed,
+        Err(err) => return err,
+    };
     let result = sender
         .0
-        .send_output_raw(id.into(), metadata, data.len(), |out| {
+        .send_output_raw(output_id, metadata, data.len(), |out| {
             out.copy_from_slice(data)
         });
     let error = match result {
@@ -982,7 +989,11 @@ unsafe fn send_arrow_output_impl(
                 .as_ref()
                 .map(|metadata| metadata.parameters.clone())
                 .unwrap_or_default();
-            let result = sender.0.send_output(id.into(), parameters, arrow_array);
+            let output_id = match parse_output_id(&id) {
+                Ok(parsed) => parsed,
+                Err(err) => return err,
+            };
+            let result = sender.0.send_output(output_id, parameters, arrow_array);
             match result {
                 Ok(()) => ffi::DoraResult {
                     error: String::new(),
@@ -1102,6 +1113,27 @@ mod tests {
         }
         seen.sort_unstable();
         assert_eq!(seen, vec![1, 2]);
+    }
+
+    /// Regression test: a caller-supplied output id with invalid characters
+    /// (e.g. a typo containing a space) must surface as a `DoraResult.error`
+    /// rather than panicking across the `cxx::bridge` and aborting the node.
+    /// The `send_output`/`send_arrow_output`/`close_outputs` paths all route
+    /// through `parse_output_id`.
+    #[test]
+    fn parse_output_id_rejects_invalid_without_panicking() {
+        let ok = parse_output_id("cmd_vel");
+        assert!(ok.is_ok(), "a valid id must parse");
+
+        for bad in ["cmd vel", "cmd!", "señal"] {
+            let err = parse_output_id(bad).expect_err("invalid id must return an error");
+            assert!(
+                err.error.contains("invalid output id"),
+                "error must describe the failure, got {:?}",
+                err.error
+            );
+            assert!(!err.error.is_empty());
+        }
     }
 
     /// Regression test: `set_timestamp` must accept and correctly represent

--- a/apis/c/node/src/lib.rs
+++ b/apis/c/node/src/lib.rs
@@ -289,7 +289,14 @@ unsafe fn try_send_output(
     }
     let context: &mut DoraContext = unsafe { &mut *context.cast() };
     let id = std::str::from_utf8(unsafe { slice::from_raw_parts(id_ptr, id_len) })?;
-    let output_id = id.to_owned().into();
+    // Parse via `FromStr` instead of the panicking `From<String>`: an invalid
+    // id (e.g. a typo containing a space) must surface as a `-1` return, not
+    // unwind across the `extern "C"` boundary and abort the node process.
+    // `DataId::from(String)` is documented as panicking on invalid characters
+    // (see `libraries/message/src/id.rs`, `# Panics`).
+    let output_id = id
+        .parse::<dora_node_api::dora_core::config::DataId>()
+        .map_err(|e| eyre::eyre!("invalid output id `{id}`: {e}"))?;
     let data = unsafe { data_slice(data_ptr, data_len) }?;
     Ok(context
         .node


### PR DESCRIPTION
## Issue

`DoraNode::send_output*` output ids reach `DataId` through the panicking `From<String>` / `From<&str>` conversion, which is documented to **panic** on any character outside `[a-zA-Z0-9_./-]` (`libraries/message/src/id.rs`). On the C and C++ FFI **send** paths the id is caller-supplied, so a typo in a string literal (e.g. `"cmd vel"`, `"cmd!"`) triggers a panic that unwinds across the `extern "C"` / `cxx::bridge` boundary and **aborts the whole node process** instead of returning an error.

The `close_outputs` path was already hardened against exactly this (it parses via `FromStr` and returns a `DoraResult` error), with a comment explicitly noting that "a typo in a C++ string literal aborts the whole node." The send paths were left unhardened:

- `apis/c/node/src/lib.rs` — `try_send_output` used `id.to_owned().into()`.
- `apis/c++/node/src/lib.rs` — `send_output_internal` (`send_output_raw(id.into(), …)`) and `send_arrow_output_impl` (`send_output(id.into(), …)`). These return `ffi::DoraResult`, not a cxx `Result`, so cxx does not catch the panic — it aborts.

## Fix

Extend the `close_outputs` treatment to the send paths:

- C `try_send_output` now parses via `FromStr` and returns `-1` on an invalid id.
- C++ `send_output_internal` and `send_arrow_output_impl` route the id through a new shared `parse_output_id` helper (also adopted by `close_outputs`, removing three inline copies of the parse/error-map logic) that returns a `DoraResult.error`.

## Validation

- Added `parse_output_id_rejects_invalid_without_panicking` regression test (valid id parses; `"cmd vel"`, `"cmd!"`, `"señal"` return an error rather than panicking).
- `cargo fmt --all -- --check`, `cargo clippy -p dora-node-api-c -p dora-node-api-cxx -- -D warnings`, and `cargo test -p dora-node-api-c -p dora-node-api-cxx` all pass.

---

⚠️ **This is a machine-generated pull request** authored by Claude Code as part of an automated codebase review. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SmcdjzPaLtnNqfFw4mMSdn

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmcdjzPaLtnNqfFw4mMSdn)_