### PR TITLE
fix(core): don't re-panic the build when a git clone/checkout task panics

### DIFF
--- a/libraries/core/src/build/git.rs
+++ b/libraries/core/src/build/git.rs
@@ -268,14 +268,23 @@ impl GitFolder {
                     )
                     .await;
                 let clone_target = target_dir.clone();
-                let checkout_result = tokio::task::spawn_blocking(move || {
+                let checkout_result = match tokio::task::spawn_blocking(move || {
                     let repository = clone_into(repo_url.clone(), &clone_target)
                         .with_context(|| format!("failed to clone git repo from `{repo_url}`"))?;
                     checkout_tree(&repository, &commit_hash)
                         .with_context(|| format!("failed to checkout commit `{commit_hash}`"))
                 })
                 .await
-                .unwrap();
+                {
+                    Ok(result) => result,
+                    // A panic in the blocking clone/checkout task must not abort the
+                    // whole build: route it through the same cleanup + `bail!` arm as
+                    // an ordinary clone error so we don't leave a half-written clone
+                    // behind for the next build to reuse (#2480).
+                    Err(join_err) => {
+                        Err(eyre::Report::new(join_err)).context("git clone/checkout task panicked")
+                    }
+                };
 
                 match checkout_result {
                     Ok(()) => target_dir,


### PR DESCRIPTION
## Issue

In `libraries/core/src/build/git.rs`, the `NewClone` arm of `reuse_or_clone` ran the blocking git clone + checkout like this:

```rust
let checkout_result = tokio::task::spawn_blocking(move || { ... })
    .await
    .unwrap();   // <-- unwraps the JoinError
```

If the blocking task **panics** (e.g. a panic bubbling out of the `git2` FFI) or is aborted, the `JoinError` returned by `.await` is `.unwrap()`ed and **re-panics the whole build process**. That bypasses the `cleanup_failed_clone(...)` + `bail!` recovery arm immediately below it, leaving a half-written clone directory on disk that a later build could mistake for a good clone — the exact hazard that #2480 guards against for the copy-and-fetch path.

This arm is also the *only* `spawn_blocking` in the file that unwraps its join result. Every sibling propagates the `JoinError` cleanly (`.await??` at lines 320 and 580, `.await.context(...)?` at 403, `task.await??` in `build/mod.rs`).

## Fix

Convert a task panic into an `eyre` error and route it through the **same** cleanup + `bail!` arm as an ordinary clone/checkout failure, instead of unwrapping:

```rust
let checkout_result = match tokio::task::spawn_blocking(move || { ... }).await {
    Ok(result) => result,
    Err(join_err) => Err(eyre::Report::new(join_err))
        .context("git clone/checkout task panicked"),
};
```

Now a panicked clone/checkout task produces a clean build error *and* runs `cleanup_failed_clone`, so no half-written clone is left behind.

## Validation

- `cargo build -p dora-core --features build`
- `cargo clippy -p dora-core --features build -- -D warnings` — clean
- `cargo fmt -p dora-core -- --check` — clean
- `cargo test -p dora-core --features build` — 295 passed, 0 failed (plus doctests)

Note: the `git` module is behind the `build` feature, so verification requires `--features build`.

---

⚠️ **This is a machine-generated pull request** authored by Claude (Anthropic's Claude Code) as part of an automated code-review pass. A human should review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SiJuCLqpZ4o7nMK2FN18UX)_