### PR TITLE
docs(node-api): fix stale scheduler comment referencing a nonexistent BTreeMap

### DIFF
--- a/apis/rust/node/src/event_stream/scheduler.rs
+++ b/apis/rust/node/src/event_stream/scheduler.rs
@@ -311,7 +311,9 @@ impl Scheduler {
             return Some(event);
         }
 
-        // Process the ID with the oldest timestamp using BTreeMap Ordering
+        // Yield from the first non-empty input queue in least-recently-used
+        // order: `last_used` is a VecDeque of input IDs, and the ID we serve
+        // from is rotated to the back below so the others get a turn next.
         for index in 0..self.last_used.len() {
             let id = &self.last_used[index];
             if let Some((_size, queue)) = self.event_queues.get_mut(id)


### PR DESCRIPTION
## Issue

In `apis/rust/node/src/event_stream/scheduler.rs`, the round-robin loop in `Scheduler::next` carries a comment that describes a data structure and ordering the code does not have:

```rust
// Process the ID with the oldest timestamp using BTreeMap Ordering
for index in 0..self.last_used.len() {
    let id = &self.last_used[index];
    ...
}
```

`Scheduler` has no `BTreeMap` and does no timestamp comparison. Its fields are:

```rust
last_used: VecDeque<DataId>,
event_queues: HashMap<DataId, (usize, VecDeque<EventItem>)>,
```

The loop walks `last_used` (a `VecDeque`), serves the first ID with a non-empty queue, and rotates that ID to the back — a plain **least-recently-used rotation**. The comment is a stale leftover from an earlier implementation and misleads anyone reasoning about the fairness/ordering of the node receive path.

## Fix

Replace the comment with one that describes the actual LRU-rotation behavior. Comment-only change — no behavior change.

## Validation

- `cargo fmt -p dora-node-api -- --check` — clean
- `cargo clippy -p dora-node-api -- -D warnings` — clean
- `cargo test -p dora-node-api` scheduler tests — 17 passed, 0 failed

---

⚠️ **This is a machine-generated pull request** authored by Claude (Anthropic's Claude Code) as part of an automated code-review pass. A human should review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SiJuCLqpZ4o7nMK2FN18UX)_