### PR TITLE
fix(download): match Content-Disposition `filename` on a parameter boundary

### DIFF
--- a/libraries/extensions/download/src/lib.rs
+++ b/libraries/extensions/download/src/lib.rs
@@ -11,24 +11,51 @@ use tokio::io::AsyncWriteExt;
 /// `attachment; filename="model.bin"; size=1000`, and both quoted and unquoted
 /// forms. Per RFC 6266 / RFC 2616 the parameter name is case-insensitive, so
 /// `Filename`, `FILENAME`, etc. are matched too. Returns `None` when no
-/// non-empty `filename=` value is present (the RFC 5987 extended `filename*=`
-/// form is not decoded and falls through — searching for the literal
-/// `filename=` skips it, since `filename*=` does not contain that substring).
+/// non-empty `filename` value is present.
+///
+/// The `filename` parameter is matched on a real parameter boundary — the
+/// name before its `=`, compared case-insensitively to exactly `filename` —
+/// not by a substring search. That distinguishes it from the RFC 5987 extended
+/// `filename*=` form (which this does not decode) and from an unrelated longer
+/// token such as `xfilename=` that merely ends in `filename`.
 fn parse_content_disposition_filename(header: &str) -> Option<String> {
-    // RFC 6266: parameter names are case-insensitive. Lower-casing only maps
-    // ASCII bytes 1:1, so byte offsets stay valid indices into `header`.
-    let lower = header.to_ascii_lowercase();
-    let start = lower.find("filename=")? + "filename=".len();
-    let rest = header[start..].trim_start();
-    let name = if let Some(after_quote) = rest.strip_prefix('"') {
-        // Quoted form: the value runs up to the closing quote, so a trailing
-        // `; param=...` (or a `;` inside the quotes) is handled correctly.
-        after_quote.split('"').next().unwrap_or(after_quote)
-    } else {
-        // Token form: the value ends at the next parameter separator.
-        rest.split(';').next().unwrap_or(rest).trim()
-    };
-    (!name.is_empty()).then(|| name.to_string())
+    split_disposition_params(header).find_map(|param| {
+        let (name, value) = param.split_once('=')?;
+        // RFC 6266: parameter names are case-insensitive. `filename*` (extended
+        // form) and tokens like `xfilename` do not compare equal to `filename`.
+        if !name.trim().eq_ignore_ascii_case("filename") {
+            return None;
+        }
+        let value = value.trim();
+        let name = if let Some(after_quote) = value.strip_prefix('"') {
+            // Quoted form: the value runs up to the closing quote.
+            after_quote.split('"').next().unwrap_or(after_quote)
+        } else {
+            value
+        };
+        (!name.is_empty()).then(|| name.to_string())
+    })
+}
+
+/// Split a `Content-Disposition` header value into its `;`-separated
+/// parameters, treating a `;` inside a double-quoted value as literal so that
+/// `filename="a;b.bin"` stays a single parameter.
+fn split_disposition_params(header: &str) -> impl Iterator<Item = &str> {
+    let mut params = Vec::new();
+    let mut start = 0;
+    let mut in_quotes = false;
+    for (i, c) in header.char_indices() {
+        match c {
+            '"' => in_quotes = !in_quotes,
+            ';' if !in_quotes => {
+                params.push(&header[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    params.push(&header[start..]);
+    params.into_iter()
 }
 
 /// Derive a candidate filename from the *last path segment* of a URL.
@@ -244,6 +271,24 @@ mod tests {
                 "attachment; filename*=UTF-8''extended.bin; filename=\"plain.bin\""
             ),
             Some("plain.bin".to_string())
+        );
+    }
+
+    #[test]
+    fn longer_token_ending_in_filename_is_not_matched() {
+        // Regression: a substring search for `filename=` would false-match the
+        // `xfilename=` parameter and return `evil`. The real `filename`
+        // parameter must be the one that is used.
+        assert_eq!(
+            parse_content_disposition_filename(
+                "attachment; xfilename=\"evil\"; filename=\"good.bin\""
+            ),
+            Some("good.bin".to_string())
+        );
+        // With no genuine `filename` parameter, a look-alike token yields None.
+        assert_eq!(
+            parse_content_disposition_filename("attachment; xfilename=\"evil\""),
+            None
         );
     }
 


### PR DESCRIPTION
## Issue

`libraries/extensions/download/src/lib.rs::parse_content_disposition_filename` found the filename with a raw substring search:

```rust
let start = lower.find("filename=")? + "filename=".len();
```

`find("filename=")` matches the literal `filename=` **anywhere** in the header, including inside a longer parameter token. So a header like:

```
attachment; xfilename="evil"; filename="good.bin"
```

resolved to `evil` — the value of the unrelated `xfilename` parameter — instead of the genuine `filename` parameter's `good.bin`. (The RFC 5987 extended `filename*=` form was already skipped, but only incidentally: it happens to contain a `*` before the `=`.)

This is on the download path used to fetch node/operator binaries. It requires an unusual or adversarial header, so severity is low, but the result is picking the wrong filename off an attacker-influenced header.

## Fix

Parse the header into its `;`-separated parameters and match the parameter whose **name before `=`** equals `filename` case-insensitively — a real parameter boundary rather than a substring:

- Splitting is **quote-aware**, so a `;` inside `filename="a;b.bin"` still yields a single parameter (preserving the existing behavior).
- `filename*` (extended form) and look-alikes such as `xfilename` no longer compare equal to `filename`.

All prior behaviors are retained: quoted and unquoted forms, trailing-parameter stripping, case-insensitive parameter name, semicolon-inside-quotes, `filename*=`/plain coexistence, and empty→`None`.

## Validation

- `cargo fmt -p dora-download -- --check` — clean
- `cargo clippy -p dora-download --all-targets -- -D warnings` — clean
- `cargo test -p dora-download` — 12 passed, 0 failed (adds a regression test asserting `xfilename="evil"; filename="good.bin"` → `good.bin`, and a bare `xfilename` → `None`)

---

⚠️ **This is a machine-generated pull request** authored by Claude (Anthropic's Claude Code) as part of an automated code-review pass. A human should review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SiJuCLqpZ4o7nMK2FN18UX)_