### PR TITLE
fix(ros2-bridge): reject null single-element scalar/string fields on serialize

### DIFF
--- a/libraries/extensions/ros2-bridge/arrow/src/serialize/mod.rs
+++ b/libraries/extensions/ros2-bridge/arrow/src/serialize/mod.rs
@@ -147,12 +147,14 @@ impl TypedValue<'_> {
                     GenericString::String | GenericString::BoundedString(_) => {
                         let string = if let Some(string_array) = column.as_string_opt::<i32>() {
                             check_single_element(string_array.len(), "StringArray")?;
+                            check_not_null(string_array, "StringArray")?;
                             string_array.value(0)
                         } else {
                             let string_array = column
                                 .as_string_opt::<i64>()
                                 .ok_or_else(|| error("expected string array"))?;
                             check_single_element(string_array.len(), "LargeStringArray")?;
+                            check_not_null(string_array, "LargeStringArray")?;
                             string_array.value(0)
                         };
                         if let GenericString::BoundedString(max) = t
@@ -169,12 +171,14 @@ impl TypedValue<'_> {
                     GenericString::WString | GenericString::BoundedWString(_) => {
                         let string = if let Some(string_array) = column.as_string_opt::<i32>() {
                             check_single_element(string_array.len(), "StringArray (WString)")?;
+                            check_not_null(string_array, "StringArray (WString)")?;
                             string_array.value(0)
                         } else {
                             let string_array = column
                                 .as_string_opt::<i64>()
                                 .ok_or_else(|| error("expected string array for WString"))?;
                             check_single_element(string_array.len(), "LargeStringArray (WString)")?;
+                            check_not_null(string_array, "LargeStringArray (WString)")?;
                             string_array.value(0)
                         };
                         if let GenericString::BoundedWString(max) = t {
@@ -236,6 +240,27 @@ fn check_single_element<E: serde::ser::Error>(len: usize, type_name: &str) -> Re
     Ok(())
 }
 
+/// Reject a null in a single-element scalar/string field column.
+///
+/// ROS2 messages (and the CDR wire format) have no null concept, but
+/// `Array::value(0)` returns the physical buffer slot regardless of the
+/// validity bit — for a null it silently yields a default (`0`/`false`/`""`).
+/// Serializing that would invent a value the producer never sent, so reject it
+/// instead, matching the sibling `arrow-convert` and `mavlink2-bridge` layers
+/// which also refuse nulls rather than substitute a default. Callers must have
+/// already checked that the column has exactly one element.
+fn check_not_null<E: serde::ser::Error>(
+    array: &dyn arrow::array::Array,
+    type_name: &str,
+) -> Result<(), E> {
+    if array.is_null(0) {
+        return Err(serde::ser::Error::custom(format!(
+            "{type_name} field is null at row 0, but ROS2 messages cannot represent null"
+        )));
+    }
+    Ok(())
+}
+
 /// Guard for fixed-size array fields: a ROS2 `T[N]` array has no length prefix
 /// on the CDR wire, so the Arrow column must have exactly `expected` elements.
 /// A mismatch would otherwise emit the wrong element count into a fixed tuple
@@ -247,4 +272,107 @@ fn check_array_len<E: serde::ser::Error>(actual: usize, expected: usize) -> Resu
         )));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, sync::Arc};
+
+    use arrow::{
+        array::{ArrayRef, Int32Array, StringArray, StructArray},
+        datatypes::{DataType, Field},
+    };
+    use byteorder::LittleEndian;
+    use dora_ros2_bridge_msg_gen::types::{
+        Member, MemberType, Message,
+        primitives::{BasicType, GenericString, NestableType},
+    };
+
+    use super::*;
+
+    /// A one-field message whose single member has the given name/type.
+    fn single_field_message(
+        field: &str,
+        ty: NestableType,
+    ) -> Arc<HashMap<String, HashMap<String, Message>>> {
+        let message = Message {
+            package: "test_msgs".to_string(),
+            name: "OneField".to_string(),
+            members: vec![Member {
+                name: field.to_string(),
+                r#type: MemberType::NestableType(ty),
+                default: None,
+            }],
+            constants: vec![],
+        };
+        let mut package = HashMap::new();
+        package.insert("OneField".to_string(), message);
+        let mut messages = HashMap::new();
+        messages.insert("test_msgs".to_string(), package);
+        Arc::new(messages)
+    }
+
+    fn struct_of(field: &str, data_type: DataType, column: ArrayRef) -> ArrayRef {
+        Arc::new(StructArray::from(vec![(
+            Arc::new(Field::new(field, data_type, true)),
+            column,
+        )])) as ArrayRef
+    }
+
+    fn serialize(
+        messages: &Arc<HashMap<String, HashMap<String, Message>>>,
+        value: &ArrayRef,
+    ) -> Result<Vec<u8>, String> {
+        let type_info = TypeInfo {
+            package_name: Cow::Borrowed("test_msgs"),
+            message_name: Cow::Borrowed("OneField"),
+            messages: messages.clone(),
+        };
+        let typed = TypedValue {
+            value,
+            type_info: &type_info,
+        };
+        cdr_encoding::to_vec::<_, LittleEndian>(&typed).map_err(|e| e.to_string())
+    }
+
+    #[test]
+    fn null_scalar_field_is_rejected() {
+        let messages = single_field_message("x", NestableType::BasicType(BasicType::I32));
+        // A present value serializes fine...
+        let ok = struct_of(
+            "x",
+            DataType::Int32,
+            Arc::new(Int32Array::from(vec![Some(7)])),
+        );
+        assert!(serialize(&messages, &ok).is_ok());
+        // ...but a null must be rejected rather than silently encoded as 0.
+        let null = struct_of("x", DataType::Int32, Arc::new(Int32Array::from(vec![None])));
+        let err = serialize(&messages, &null).unwrap_err();
+        assert!(
+            err.to_string().contains("null"),
+            "expected a null-rejection error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn null_string_field_is_rejected() {
+        let messages =
+            single_field_message("s", NestableType::GenericString(GenericString::String));
+        let ok = struct_of(
+            "s",
+            DataType::Utf8,
+            Arc::new(StringArray::from(vec![Some("hi")])),
+        );
+        assert!(serialize(&messages, &ok).is_ok());
+        let null = struct_of(
+            "s",
+            DataType::Utf8,
+            Arc::new(StringArray::from(vec![Option::<&str>::None])),
+        );
+        let err = serialize(&messages, &null).unwrap_err();
+        assert!(
+            err.to_string().contains("null"),
+            "expected a null-rejection error, got: {err}"
+        );
+    }
 }

--- a/libraries/extensions/ros2-bridge/arrow/src/serialize/primitive.rs
+++ b/libraries/extensions/ros2-bridge/arrow/src/serialize/primitive.rs
@@ -58,6 +58,7 @@ impl serde::Serialize for SerializeWrapper<'_> {
                         array.len()
                     )));
                 }
+                super::check_not_null(array, "BooleanArray")?;
                 let field_value = array.value(0);
                 serializer.serialize_bool(field_value)
             }
@@ -83,6 +84,7 @@ where
             array.len()
         )));
     }
+    super::check_not_null(array, std::any::type_name::<T::Native>())?;
     let number = array.value(0);
     Ok(number)
 }


### PR DESCRIPTION
## Issue

The Arrow→CDR serializers for single-element **scalar** and **string** ROS2 message fields validate the element count but never check the Arrow **null validity bit**:

- `libraries/extensions/ros2-bridge/arrow/src/serialize/primitive.rs` — `as_single_primitive` (`array.value(0)`) and the `Bool` arm (`array.value(0)`)
- `libraries/extensions/ros2-bridge/arrow/src/serialize/mod.rs` — the `String`/`WString` single-field paths (`string_array.value(0)`)

`PrimitiveArray::value(0)` / `BooleanArray::value(0)` / `GenericStringArray::value(0)` return the physical buffer slot **regardless of the validity bit**. So a single-element field column built with a null — e.g. `Int32Array::from(vec[None])`, or a nullable bool/string — was serialized to CDR as `0` / `false` / `""`, silently inventing a value the producing node never sent.

This is inconsistent with the two sibling conversion layers in this repo, which were explicitly hardened for exactly this case:
- `arrow-convert` rejects nulls (`if array.null_count() != 0 { bail!(...) }`).
- `mavlink2-bridge`'s `read_primitive` rejects `is_null(0)` with the comment that `value` "returns the slot but ignores the null bit, which silently invents a value; reject it."

## Fix

Add a shared `check_not_null` guard (alongside the existing `check_single_element`) and apply it after the length check in `as_single_primitive`, the `Bool` arm, and the `String`/`WString` single-element paths. ROS2/CDR has no null concept, so a null field is now a clear serialization error instead of a substituted default. A null-free column (`null_count == 0`) is unaffected, and missing fields still fall back to computed defaults as before.

**Scope:** this covers the single-element scalar/string field paths. Null handling for `sequence<T>` / fixed-array **element** columns is a broader change and is intentionally left out of this PR.

## Validation

- `cargo fmt -p dora-ros2-bridge-arrow -- --check` — clean
- `cargo clippy -p dora-ros2-bridge-arrow --all-targets -- -D warnings` — clean
- `cargo test -p dora-ros2-bridge-arrow` — 15 passed, 0 failed (existing CDR round-trip tests still green; adds message-level tests that a null `int32` and a null `string` are rejected, with non-null positive controls)

---

⚠️ **This is a machine-generated pull request** authored by Claude (Anthropic's Claude Code) as part of an automated code-review pass. A human should review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SiJuCLqpZ4o7nMK2FN18UX)_