### PR TITLE
fix(ros2-bridge): reject string-array constants with a mismatched element count

### DIFF
--- a/libraries/extensions/ros2-bridge/msg-gen/src/parser/constant.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/parser/constant.rs
@@ -39,6 +39,8 @@ fn validate_value(r#type: ConstantType, value: &str) -> Result<Vec<String>> {
                 let (rest, values) = literal::string_literal_sequence(value)
                     .map_err(|_| RclMsgError::ParseDefaultValueError(value.into()))?;
                 ensure!(rest.is_empty());
+                ensure!(values.len() == array_t.size);
+
                 Ok(values)
             }
         },
@@ -82,5 +84,31 @@ mod test {
         assert_eq!(result.r#type, BasicType::I32.into());
         assert_eq!(result.value, vec!["30"]);
         Ok(())
+    }
+
+    #[test]
+    fn parse_string_array_constant_matching_size() -> Result<()> {
+        let result = constant_def(r#"string[3] NAMES=["a", "b", "c"]"#)?;
+        assert_eq!(result.name, "NAMES");
+        assert_eq!(result.value, vec!["a", "b", "c"]);
+        // The declared size matches the literal count, so codegen must not panic.
+        let _ = result.r#type.value_tokens(&result.value);
+        Ok(())
+    }
+
+    #[test]
+    fn string_array_constant_with_wrong_element_count_errors() {
+        // A fixed-size string-array constant whose literal element count does not
+        // match the declared size must be rejected at parse time with a clean
+        // error, mirroring the basic-type array branch — not accepted here and
+        // then panicked on later in `ConstantType::value_tokens`.
+        assert!(constant_def(r#"string[3] NAMES=["a", "b"]"#).is_err());
+        assert!(constant_def(r#"string[1] NAMES=["a", "b"]"#).is_err());
+    }
+
+    #[test]
+    fn basic_type_array_constant_with_wrong_element_count_errors() {
+        // Regression guard for the already-correct basic-type branch.
+        assert!(constant_def("uint8[3] NUMS=[1, 2]").is_err());
     }
 }


### PR DESCRIPTION
## Summary

Fixes #2826.

In the ROS2 message-definition parser (`libraries/extensions/ros2-bridge/msg-gen`), a fixed-size **string-array** constant (`string[N] NAME=[...]`) whose literal element count did not match the declared size `N` was accepted at parse time and then **panicked later during code generation** via `assert_eq!(values.len(), t.size)` in `ConstantType::value_tokens`.

The analogous **basic-type** array branch (`uint8[N] NAME=[...]`) already validated the element count with `ensure!(values.len() == array_t.size)` and returned a clean `RclMsgError`. Only the `GenericUnboundedString` branch of `validate_value` skipped the check.

## Change

- Add `ensure!(values.len() == array_t.size);` to the string-array branch of `validate_value`, mirroring the basic-type branch, so a mismatched count yields a graceful `RclMsgError` instead of a codegen panic.
- Add regression tests: a `string[N]` constant with the wrong element count now errors (matching the basic-type behavior), and a correctly-sized `string[N]` constant still parses and generates tokens without panicking.

## Testing

- `cargo test -p dora-ros2-bridge-msg-gen` — all 73 tests pass, including the new ones.
- `cargo fmt -p dora-ros2-bridge-msg-gen -- --check` and `cargo clippy -p dora-ros2-bridge-msg-gen -- -D warnings` are clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQi7Jq6ewwkjjskR7nmNgK)_