### PR TITLE
fix(daemon): increment pending counter when propagating NodeFailed downstream

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -4963,32 +4963,7 @@ impl Daemon {
                     if let Err(e) = &node_result
                         && let Some(dataflow) = self.running.get(&dataflow_id)
                     {
-                        let error_msg = e.to_string();
-                        let mut affected_by_receiver: BTreeMap<NodeId, Vec<DataId>> =
-                            BTreeMap::new();
-                        for (output_id, receivers) in &dataflow.mappings {
-                            if output_id.0 == node_id {
-                                for (recv_id, input_id) in receivers {
-                                    affected_by_receiver
-                                        .entry(recv_id.clone())
-                                        .or_default()
-                                        .push(input_id.clone());
-                                }
-                            }
-                        }
-                        for (recv_id, affected_ids) in affected_by_receiver {
-                            if let Some(channel) = dataflow.subscribe_channels.get(&recv_id) {
-                                let _ = send_with_timestamp(
-                                    channel,
-                                    NodeEvent::NodeFailed {
-                                        affected_input_ids: affected_ids,
-                                        error: error_msg.clone(),
-                                        source_node_id: node_id.clone(),
-                                    },
-                                    &self.clock,
-                                );
-                            }
-                        }
+                        dataflow.propagate_node_failed(&node_id, &e.to_string(), &self.clock);
                     }
 
                     let exit_clean = node_result.is_ok();

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -634,6 +634,47 @@ impl RunningDataflow {
         }
     }
 
+    /// Propagate a `NodeFailed` event to every downstream subscriber of the
+    /// failed node's outputs.
+    ///
+    /// Each successful enqueue is paired with `inc_pending`, mirroring every
+    /// other delivery site: the `Listener` unconditionally decrements a node's
+    /// `pending_messages` counter for every event it drains (`NodeFailed`
+    /// included), so an enqueue without the matching increment would leave the
+    /// reported count one too low — and underflow it to `u64::MAX` when the
+    /// receiver's channel was already empty (dora-rs/dora#2827).
+    pub(crate) fn propagate_node_failed(&self, failed_node: &NodeId, error_msg: &str, clock: &HLC) {
+        let mut affected_by_receiver: BTreeMap<NodeId, Vec<DataId>> = BTreeMap::new();
+        for (output_id, receivers) in &self.mappings {
+            if output_id.0 == *failed_node {
+                for (recv_id, input_id) in receivers {
+                    affected_by_receiver
+                        .entry(recv_id.clone())
+                        .or_default()
+                        .push(input_id.clone());
+                }
+            }
+        }
+        for (recv_id, affected_ids) in affected_by_receiver {
+            if let Some(channel) = self.subscribe_channels.get(&recv_id) {
+                let delivered = send_with_timestamp(
+                    channel,
+                    NodeEvent::NodeFailed {
+                        affected_input_ids: affected_ids,
+                        error: error_msg.to_string(),
+                        source_node_id: failed_node.clone(),
+                    },
+                    clock,
+                )
+                .ok()
+                    == Some(true);
+                if delivered {
+                    self.inc_pending(&recv_id);
+                }
+            }
+        }
+    }
+
     pub(crate) fn open_inputs(&self, node_id: &NodeId) -> &BTreeSet<DataId> {
         self.open_inputs.get(node_id).unwrap_or(&self.empty_set)
     }
@@ -867,6 +908,68 @@ mod tests {
 
         let outputs = node_output_ids(&mappings, &open_external_mappings, &node_id("source"));
         assert!(outputs.is_empty());
+    }
+
+    // ---- dora-rs/dora#2827: NodeFailed propagation must not underflow the
+    //      receiver's pending_messages counter ----
+
+    fn empty_descriptor() -> Descriptor {
+        use dora_message::{config::CommunicationConfig, descriptor::Debug as DescriptorDebug};
+        Descriptor {
+            nodes: vec![],
+            communication: CommunicationConfig::default(),
+            deploy: None,
+            debug: DescriptorDebug::default(),
+            health_check_interval: None,
+            strict_types: None,
+            type_rules: vec![],
+            env: None,
+        }
+    }
+
+    #[test]
+    fn propagate_node_failed_keeps_idle_receiver_counter_consistent() {
+        let mut df =
+            RunningDataflow::new(uuid::Uuid::nil(), DaemonId::new(None), empty_descriptor());
+        let failed = node_id("source");
+        let receiver = node_id("sink");
+
+        // `source/out` is consumed by `sink/in`.
+        df.mappings.insert(
+            OutputId(failed.clone(), data_id("out")),
+            BTreeSet::from([(receiver.clone(), data_id("in"))]),
+        );
+
+        // The receiver is subscribed and idle: its pending counter starts at 0.
+        let (tx, mut rx) = mpsc::channel(16);
+        df.subscribe_channels.insert(receiver.clone(), tx);
+        let counter = Arc::new(AtomicU64::new(0));
+        df.pending_messages
+            .insert(receiver.clone(), counter.clone());
+
+        let clock = HLC::default();
+        df.propagate_node_failed(&failed, "boom", &clock);
+
+        // The successful enqueue must have incremented the counter to match the
+        // in-flight event.
+        assert_eq!(counter.load(atomic::Ordering::Relaxed), 1);
+
+        // Drain the event exactly as the Listener does: one unconditional
+        // decrement per drained event. With the matching increment in place the
+        // counter returns to 0; without it, this decrement would wrap to
+        // `u64::MAX`.
+        let mut drained = 0;
+        while let Ok(event) = rx.try_recv() {
+            counter.fetch_sub(1, atomic::Ordering::Relaxed);
+            assert!(matches!(event.inner, NodeEvent::NodeFailed { .. }));
+            drained += 1;
+        }
+        assert_eq!(drained, 1, "receiver should get exactly one NodeFailed");
+        assert_eq!(
+            counter.load(atomic::Ordering::Relaxed),
+            0,
+            "pending counter must stay consistent (no u64::MAX underflow)"
+        );
     }
 
     const TEST_GRACE: Duration = Duration::from_millis(100);


### PR DESCRIPTION
## Summary

Fixes #2827.

When an upstream node exits with a non-zero code, the daemon propagates a `NodeEvent::NodeFailed` to each downstream (subscriber) node. It enqueued that event into the subscriber's channel **without** the matching `inc_pending()` that every other delivery site performs. The per-node `pending_messages` counter (an `Arc<AtomicU64>`) is still decremented unconditionally by the `Listener` when it drains the event, so the counter ended up one lower than the true in-flight count — and if the subscriber's channel was already empty (counter `== 0`), the `fetch_sub(1)` **wrapped to `u64::MAX`**. The bogus value was then reported to the coordinator (metrics / `dora node list`) until the node re-subscribed.

## Change

- Extract the `NodeFailed` propagation loop out of the `SpawnedNodeResult` handler in `lib.rs` into a new `RunningDataflow::propagate_node_failed(failed_node, error_msg, clock)` method.
- The method pairs each successful enqueue (`send_with_timestamp(...).ok() == Some(true)`) with `inc_pending(&recv_id)`, mirroring every other delivery site in the daemon.
- Add a regression test (`propagate_node_failed_keeps_idle_receiver_counter_consistent`) that drives a `source → sink` mapping with an idle receiver, propagates a `NodeFailed`, then drains the event the way the `Listener` does (one unconditional `fetch_sub`) and asserts the counter returns to `0` rather than underflowing to `u64::MAX`.

## Testing

- `cargo test -p dora-daemon` — all 113 tests pass, including the new one.
- `cargo fmt -p dora-daemon -- --check` and `cargo clippy -p dora-daemon -- -D warnings` are clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQi7Jq6ewwkjjskR7nmNgK)_