### PR TITLE
fix(nightly): repair cli-tests ruff isort and Windows git clone-dir test

### DIFF
--- a/binaries/cli/src/template/python/__node-name__/tests/test___node_name__.py
+++ b/binaries/cli/src/template/python/__node-name__/tests/test___node_name__.py
@@ -2,7 +2,6 @@
 
 import pyarrow as pa
 import pytest
-
 from dora.testing import MockNode
 
 

--- a/libraries/core/src/build/git.rs
+++ b/libraries/core/src/build/git.rs
@@ -997,18 +997,24 @@ mod tests {
         let clone_dir = folder_a.prepare(&mut TestLogger).await.unwrap();
 
         // The clone on disk drifts to a different commit -- a stale leftover,
-        // exactly the case the #2482 HEAD check exists to catch.
+        // exactly the case the #2482 HEAD check exists to catch. Scope every
+        // git2 handle to this block so they're all dropped before prepare()
+        // tries to delete the dir: on Windows an open repo handle keeps a lock
+        // on the .git files and blocks remove_dir_all, leaving the stale clone
+        // behind and failing the assertion below.
         std::fs::write(clone_dir.join("file.txt"), b"B").unwrap();
-        let repo = git2::Repository::open(&clone_dir).unwrap();
-        let parent = repo.head().unwrap().peel_to_commit().unwrap();
-        let mut index = repo.index().unwrap();
-        index.add_path(Path::new("file.txt")).unwrap();
-        index.write().unwrap();
-        let tree_id = index.write_tree().unwrap();
-        let tree = repo.find_tree(tree_id).unwrap();
-        let sig = git2::Signature::now("t", "t@t").unwrap();
-        repo.commit(Some("HEAD"), &sig, &sig, "B", &tree, &[&parent])
-            .unwrap();
+        {
+            let repo = git2::Repository::open(&clone_dir).unwrap();
+            let parent = repo.head().unwrap().peel_to_commit().unwrap();
+            let mut index = repo.index().unwrap();
+            index.add_path(Path::new("file.txt")).unwrap();
+            index.write().unwrap();
+            let tree_id = index.write_tree().unwrap();
+            let tree = repo.find_tree(tree_id).unwrap();
+            let sig = git2::Signature::now("t", "t@t").unwrap();
+            repo.commit(Some("HEAD"), &sig, &sig, "B", &tree, &[&parent])
+                .unwrap();
+        }
 
         // Session B (a fresh SessionId -- a second, unrelated `dora start`)
         // asks for the same old commit and is handed the same dir. Session


### PR DESCRIPTION
## Summary

Fixes two independent nightly regressions reported in #2742 (2026-07-25 run).

### `cli-tests` — ruff isort failure in generated projects

The generated Python node template
(`binaries/cli/src/template/python/__node-name__/tests/test___node_name__.py`)
put a blank line between the third-party imports:

```python
import pyarrow as pa
import pytest

from dora.testing import MockNode
```

ruff's isort (`I001`) treats `pyarrow`, `pytest`, and `dora` all as
third-party and wants them in a single block with no blank line, so
`ruff check` failed on every generated project (`listener-1`, `talker-1`,
`talker-2`). Removing the blank line makes the template pass ruff.

### `test-cross-platform` — Windows git clone-dir test failure

`build::git::tests::reuse_still_verifies_a_dir_left_by_a_different_finished_session`
kept a `git2::Repository` handle open into the clone dir while `prepare()`
tried to `remove_dir_all` it. On Windows an open repo handle locks the
`.git` files and blocks the deletion, so the stale clone survived and the
`!clone_dir.exists()` assertion failed. The sibling test
`reuse_bails_and_removes_dir_on_head_mismatch` passes because
`init_repo_with_commit` drops its handle before returning — this test was
the only one holding a handle across `prepare()`. Scoping the git2 handles
into a block so they drop before `prepare()` runs mirrors that pattern and
fixes the Windows failure. Test-only change; no production behavior changes.

## Testing

- `ruff check --select I binaries/cli/src/template/python/` → all checks passed
- `cargo test -p dora-core --lib --features build reuse_still_verifies` → 1 passed
- `cargo fmt --all -- --check` and `cargo clippy -p dora-core --features build --tests` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgwVoUt93c9Z1h6R2nQf3V)_