### PR TITLE
fix(cli): improve DataflowSession error diagnostics

### DIFF
--- a/binaries/cli/src/session.rs
+++ b/binaries/cli/src/session.rs
@@ -71,12 +71,14 @@ impl DataflowSession {
     pub fn read_session(dataflow_path: &Path) -> eyre::Result<Self> {
         let session_file = session_file_path(dataflow_path)?;
         if session_file.exists() {
-            if let Ok(parsed) = deserialize(&session_file) {
-                return Ok(parsed);
-            } else {
-                tracing::warn!(
-                    "failed to read dataflow session file, regenerating (you might need to run `dora build` again)"
-                );
+            match deserialize(&session_file) {
+                Ok(parsed) => return Ok(parsed),
+                Err(err) => {
+                    tracing::warn!(
+                        "failed to read dataflow session file at {}: {err:#}, regenerating (you might need to run `dora build` again)",
+                        session_file.display()
+                    );
+                }
             }
         }
 
@@ -357,11 +359,18 @@ fn fnv1a_64_hex(bytes: &[u8]) -> String {
 }
 
 fn deserialize(session_file: &Path) -> eyre::Result<DataflowSession> {
-    std::fs::read_to_string(session_file)
-        .context("failed to read DataflowSession file")
-        .and_then(|s| {
-            serde_yaml::from_str(&s).context("failed to deserialize DataflowSession file")
-        })
+    let s = std::fs::read_to_string(session_file).with_context(|| {
+        format!(
+            "failed to read DataflowSession file at {}",
+            session_file.display()
+        )
+    })?;
+    serde_yaml::from_str(&s).with_context(|| {
+        format!(
+            "failed to deserialize DataflowSession file at {}",
+            session_file.display()
+        )
+    })
 }
 
 fn session_file_path(dataflow_path: &Path) -> eyre::Result<PathBuf> {
@@ -607,7 +616,6 @@ nodes:
 
     #[test]
     fn session_roundtrip_backward_compatible_without_field() {
-        // Sessions written before this field existed must still deserialize.
         let legacy_yaml = "build_id: null\n\
              session_id: 00000000-0000-0000-0000-000000000000\n\
              git_sources: {}\n\
@@ -615,6 +623,28 @@ nodes:
         let parsed: DataflowSession =
             serde_yaml::from_str(legacy_yaml).expect("legacy session must deserialize");
         assert!(parsed.build_fingerprint.is_none());
+    }
+
+    #[test]
+    fn read_session_corrupt_file_regenerates_with_warning() {
+        let dir = tempfile::tempdir().unwrap();
+        let dataflow_path = dir.path().join("dataflow.yml");
+        std::fs::write(&dataflow_path, "nodes: []").unwrap();
+
+        let out_dir = dir.path().join("out");
+        std::fs::create_dir_all(&out_dir).unwrap();
+        let session_path = out_dir.join("dataflow.dora-session.yaml");
+        std::fs::write(&session_path, "invalid yaml syntax: : :").unwrap();
+
+        // `read_session` should catch the deserialization error, log a warning with path and error details,
+        // and safely regenerate a default session file.
+        let session = DataflowSession::read_session(&dataflow_path).unwrap();
+        assert!(session.build_id.is_none());
+        assert!(session_path.exists());
+
+        // The session file should now contain valid regenerated YAML.
+        let re_parsed = DataflowSession::read_session(&dataflow_path).unwrap();
+        assert_eq!(session.session_id, re_parsed.session_id);
     }
 
     // ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Improve error diagnostics when reading dataflow session files by surfacing the session file path and the underlying error context instead of a generic warning.

Fixes #2830

## Root Cause

When `DataflowSession::read_session` encountered a corrupted or invalid session file, the error returned by `deserialize(&session_file)` was discarded and replaced with a generic warning:

> `failed to read dataflow session file, regenerating (you might need to run dora build again)`

This made it difficult to determine why session loading failed, as neither the session file path nor the underlying error (e.g. invalid YAML, missing fields, or I/O errors) was included in the logs. Additionally, `deserialize` used generic `context(...)` messages without indicating which file caused the failure.

## Solution

- Added file path context to `deserialize(&Path)` using `with_context(...)` for both file reading and YAML deserialization.
- Updated `DataflowSession::read_session` to:
  - match on `deserialize(&session_file)`,
  - log the session file path via `session_file.display()`, and
  - include the complete error chain using `{err:#}` before regenerating the session.
- Added a unit test (`read_session_corrupt_file_regenerates_with_warning`) to verify graceful recovery from corrupted session files.

## Testing

- ✅ `cargo fmt --all -- --check`
- ✅ Added unit test: `read_session_corrupt_file_regenerates_with_warning`

> Note: `cargo clippy --all -- -D warnings` reports existing workspace-wide Clippy warnings in unrelated crates (`dora-coordinator` and `dora-ros2-bridge-python`). These are unrelated to this change.

## Scope

This PR is intentionally limited to improving error diagnostics in `binaries/cli/src/session.rs`. No functional behavior, APIs, or unrelated files were modified.