### PR TITLE
fix(memory-pool): include OS error details during orphan cleanup

### DIFF
--- a/libraries/extensions/memory-pool/src/lib.rs
+++ b/libraries/extensions/memory-pool/src/lib.rs
@@ -225,16 +225,27 @@ impl MemoryPoolManager {
         #[cfg(target_os = "linux")]
         {
             let prefix = format!("dora_pool_{}_", dataflow_id);
-            if let Ok(entries) = std::fs::read_dir("/dev/shm") {
-                for entry in entries.flatten() {
-                    let name = entry.file_name();
-                    let name = name.to_string_lossy();
-                    if name.starts_with(&prefix)
-                        && let Err(err) = std::fs::remove_file(entry.path())
-                        && err.kind() != std::io::ErrorKind::NotFound
-                    {
-                        tracing::debug!("Orphan sweep: could not unlink {}: {}", name, err);
+            match std::fs::read_dir("/dev/shm") {
+                Ok(entries) => {
+                    for entry in entries.flatten() {
+                        let name = entry.file_name();
+                        let name = name.to_string_lossy();
+                        if name.starts_with(&prefix)
+                            && let Err(err) = std::fs::remove_file(entry.path())
+                            && err.kind() != std::io::ErrorKind::NotFound
+                        {
+                            tracing::debug!(
+                                "Orphan sweep: could not unlink {} at {}: {}",
+                                name,
+                                entry.path().display(),
+                                err
+                            );
+                        }
                     }
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) => {
+                    tracing::debug!("Orphan sweep: failed to read /dev/shm directory: {}", err);
                 }
             }
         }
@@ -482,5 +493,11 @@ mod tests {
             // Guard held; drop it before testing further operations.
         }
         assert_eq!(mgr.table_size(), 0);
+    }
+
+    #[test]
+    fn cleanup_orphans_runs_without_panic() {
+        // Sweep should run cleanly without panicking regardless of platform.
+        MemoryPoolManager::cleanup_orphans("test-dataflow-uuid");
     }
 }


### PR DESCRIPTION
## Summary

Improve orphan cleanup diagnostics by surfacing `/dev/shm` directory read failures and providing additional file path context when shared memory cleanup encounters OS errors.

Fixes #2831

## Root Cause

`MemoryPoolManager::cleanup_orphans` previously used `if let Ok(entries) = std::fs::read_dir("/dev/shm")`. If reading the shared memory directory failed (e.g. due to permission or filesystem errors), the failure was silently ignored.

Additionally, when removing orphaned shared memory files failed, the debug log only included the shared memory object name and the OS error, making it harder to identify the affected file.

## Solution

- Replaced `if let Ok(...)` with `match std::fs::read_dir("/dev/shm")` to explicitly handle and log directory enumeration failures.
- Enhanced orphan cleanup logging to include the full file path (`entry.path().display()`) together with the shared memory object name and the underlying OS error.
- Added a unit test (`cleanup_orphans_runs_without_panic`) to verify cleanup executes safely without panicking.

## Testing

- ✅ `cargo fmt --all -- --check`
- ✅ `cargo check -p dora-memory-pool`
- ✅ `cargo test -p dora-memory-pool` (10 tests passed)

## Scope

This PR is intentionally limited to improving diagnostics in `libraries/extensions/memory-pool/src/lib.rs`. No functional behavior, public APIs, or cleanup logic were modified.