### PR TITLE
perf(daemon): skip the metadata deep-clone for pure-remote outputs

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -5403,10 +5403,15 @@ async fn send_output_to_local_receivers(
     let empty_set = BTreeSet::new();
     let output_id = OutputId(node_id, output_id);
     let local_receivers = dataflow.mappings.get(&output_id).unwrap_or(&empty_set);
-    // Wrap in Arc once; fan-out clones are O(1) atomic ref bumps instead of O(payload_size) memcpy
-    let metadata = Arc::new(metadata.clone());
     let data = data.map(Arc::new);
     let mut closed = Vec::new();
+    // Clone the metadata into an `Arc` lazily, on the first actual delivery.
+    // Fan-out clones are then O(1) atomic ref bumps instead of O(payload_size)
+    // memcpy. For a pure-remote output topology `local_receivers` is empty (all
+    // subscribers live on other daemons), so this deep clone (a `BTreeMap` of
+    // owned `Parameter`s) is skipped entirely rather than built and dropped on
+    // every such message.
+    let mut metadata_arc = None;
     for (receiver_id, input_id) in local_receivers {
         if let Some(channel) = dataflow.subscribe_channels.get(receiver_id) {
             // Reserve headroom for control events (Stop, InputClosed, etc.)
@@ -5421,7 +5426,9 @@ async fn send_output_to_local_receivers(
             }
             let item = NodeEvent::Input {
                 id: input_id.clone(),
-                metadata: metadata.clone(),
+                metadata: metadata_arc
+                    .get_or_insert_with(|| Arc::new(metadata.clone()))
+                    .clone(),
                 data: data.clone(),
             };
             match channel.try_send(Timestamped {


### PR DESCRIPTION
## Issue

`send_output_to_local_receivers` unconditionally built `Arc::new(metadata.clone())` before fanning out to local receivers. That `Arc<Metadata>` is only consumed *inside* the fan-out loop, so when an output's subscribers all live on **other** daemons (empty `local_receivers`), the deep clone was built and immediately dropped on every message. `Metadata` owns a `BTreeMap<String, Parameter>` whose values include `String`/`Vec`, so this is a genuine heap-allocating deep clone, not a cheap copy. `send_out` still calls this function in the pure-remote case (with `need_data_bytes = true`) to move the payload bytes out.

## Fix

Build the `Arc` lazily via `get_or_insert_with`, so the clone happens once on the first actual delivery and is skipped entirely when there is no local receiver — or when every receiver is over its control-headroom capacity and is skipped anyway. The payload path was already optimal here (`Arc::try_unwrap` moves the bytes out without copying); this closes the same gap for metadata.

No new `.unwrap()` / `.expect()` is introduced (relevant because of the production unwrap-budget ratchet).

## Validation

- `cargo clippy -p dora-daemon --lib -- -D warnings` clean.
- `cargo test -p dora-daemon --lib` → 112 passed.

---

⚠️ **This PR is machine-generated by Claude (an AI assistant)** as part of an automated code-review run, and was verified against current `origin/main`. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMv79fayzGF9mDV7vPMQN7

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMv79fayzGF9mDV7vPMQN7)_