### PR TITLE
docs(tracing): correct with_span_capture crate-filter description

### DIFF
--- a/libraries/extensions/telemetry/tracing/src/lib.rs
+++ b/libraries/extensions/telemetry/tracing/src/lib.rs
@@ -210,8 +210,9 @@ impl TracingBuilder {
 
     /// Add a layer that captures completed spans into the given store.
     ///
-    /// Only captures spans from `dora_*` crates at info level to avoid noise
-    /// from third-party dependencies.
+    /// Only captures spans from the `dora_coordinator` and `dora_core` crates
+    /// at info level (all other targets are filtered out) to avoid noise from
+    /// third-party dependencies.
     pub fn with_span_capture(mut self, store: span_store::SharedSpanStore) -> Self {
         let filter = EnvFilter::new("off")
             .add_directive(directive("dora_coordinator=info"))


### PR DESCRIPTION
## Issue

`TracingBuilder::with_span_capture` documented that it *"Only captures spans from `dora_*` crates"*, but its `EnvFilter` only enables `dora_coordinator=info` and `dora_core=info`:

```rust
let filter = EnvFilter::new("off")
    .add_directive(directive("dora_coordinator=info"))
    .add_directive(directive("dora_core=info"));
```

Every other target — including `dora_daemon` and `dora_node_api` — is filtered out. A reader relying on the doc to capture daemon/node spans would silently get nothing.

## Fix

Reword the doc comment to name the two crates the filter actually enables. Documentation-only change; no behavior change.

## Validation

- `cargo clippy -p dora-tracing --lib -- -D warnings` clean.

---

⚠️ **This PR is machine-generated by Claude (an AI assistant)** as part of an automated code-review run, and was verified against current `origin/main`. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMv79fayzGF9mDV7vPMQN7

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMv79fayzGF9mDV7vPMQN7)_