### PR TITLE
refactor(memory-pool): drain the table in cleanup_all instead of cloning keys

### DIFF
--- a/libraries/extensions/memory-pool/src/lib.rs
+++ b/libraries/extensions/memory-pool/src/lib.rs
@@ -247,8 +247,12 @@ impl MemoryPoolManager {
     /// Cleanup all memory pools on shutdown.
     pub fn cleanup_all(&self) -> Result<CleanupSummary, Vec<String>> {
         let mut table = self.lock_table();
-        let ids: Vec<MemoryPoolId> = table.keys().cloned().collect();
-        let unreleased_count = ids.len();
+        // Drain the table in one move instead of cloning every key into a
+        // `Vec` only to look each one back up and remove it. The guard is held
+        // for the rest of the function (matching the previous locking window);
+        // `free_shared_memory` does not re-enter the table.
+        let drained = std::mem::take(&mut *table);
+        let unreleased_count = drained.len();
         let mut errors = Vec::new();
 
         if unreleased_count > 0 {
@@ -258,9 +262,8 @@ impl MemoryPoolManager {
             );
         }
 
-        for id in &ids {
-            if let Some(entry) = table.remove(id)
-                && let Some(shm_name) = &entry.metadata.shared_memory_name
+        for (_id, entry) in drained {
+            if let Some(shm_name) = &entry.metadata.shared_memory_name
                 && !shm_name.is_empty()
                 && let Err(err) = self.free_shared_memory(shm_name)
             {


### PR DESCRIPTION
## Issue

`MemoryPoolManager::cleanup_all` collected every `MemoryPoolId` key into a throwaway `Vec` (cloning two `String`s per entry) only to look each id back up and `remove` it one at a time:

```rust
let ids: Vec<MemoryPoolId> = table.keys().cloned().collect();
...
for id in &ids {
    if let Some(entry) = table.remove(id) ...
}
```

## Fix

Replace that with a single `std::mem::take(&mut *table)` move and iterate the drained map directly, dropping the key clones and the redundant per-id re-lookup.

Behavior is unchanged:
- the guard is still held for the whole function (`free_shared_memory` never re-enters the table, so this can't deadlock — the original relied on the same fact);
- the table still ends empty;
- the `unreleased_count` / `released_count` accounting is identical.

## Validation

- `cargo clippy -p dora-memory-pool --all-targets -- -D warnings` clean.
- `cargo test -p dora-memory-pool --lib` → 9 passed, including `cleanup_all_tracks_counts` and `cleanup_all_reports_partial_release_on_failure`.

---

⚠️ **This PR is machine-generated by Claude (an AI assistant)** as part of an automated code-review run, and was verified against current `origin/main`. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMv79fayzGF9mDV7vPMQN7

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMv79fayzGF9mDV7vPMQN7)_