### PR TITLE
fix: avoid bail macros in expression position

### DIFF
--- a/apis/rust/node/src/daemon_connection/interactive.rs
+++ b/apis/rust/node/src/daemon_connection/interactive.rs
@@ -83,7 +83,7 @@ impl InteractiveEvents {
             | DaemonRequest::ReadPinnedMemory { .. }
             | DaemonRequest::FreePinnedMemory { .. } => DaemonReply::Result(Ok(())),
             DaemonRequest::NodeConfig { .. } => {
-                eyre::bail!("unexpected NodeConfig in interactive mode")
+                eyre::bail!("unexpected NodeConfig in interactive mode");
             }
         };
         Ok(reply)

--- a/apis/rust/node/src/daemon_connection/json_to_arrow.rs
+++ b/apis/rust/node/src/daemon_connection/json_to_arrow.rs
@@ -13,7 +13,9 @@ pub fn read_json_bytes_as_arrow(data: &[u8]) -> eyre::Result<ArrayData> {
             // try again with quoting the input to treat it as a string
             match arrow_json::reader::infer_json_schema(wrapped_quoted(data), None) {
                 Ok((schema, _)) => read_from_json_with_schema(wrapped_quoted(data), schema),
-                Err(err) => eyre::bail!("failed to infer JSON schema: {err}"),
+                Err(err) => {
+                    eyre::bail!("failed to infer JSON schema: {err}");
+                }
             }
         }
     }

--- a/apis/rust/node/src/daemon_connection/mod.rs
+++ b/apis/rust/node/src/daemon_connection/mod.rs
@@ -53,7 +53,9 @@ impl DaemonChannel {
             DaemonReply::Result(result) => result
                 .map_err(|e| eyre!(e))
                 .wrap_err("failed to register node with dora-daemon")?,
-            other => bail!("unexpected register reply: {other:?}"),
+            other => {
+                bail!("unexpected register reply: {other:?}");
+            }
         }
         Ok(())
     }

--- a/apis/rust/node/src/daemon_connection/node_integration_testing.rs
+++ b/apis/rust/node/src/daemon_connection/node_integration_testing.rs
@@ -136,7 +136,7 @@ impl IntegrationTestingEvents {
             | DaemonRequest::ReadPinnedMemory { .. }
             | DaemonRequest::FreePinnedMemory { .. } => DaemonReply::Result(Ok(())),
             DaemonRequest::NodeConfig { .. } => {
-                eyre::bail!("unexpected NodeConfig in interactive mode")
+                eyre::bail!("unexpected NodeConfig in interactive mode");
             }
         };
         Ok(reply)

--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -623,9 +623,11 @@ impl EventStream {
         match reply {
             DaemonReply::Result(Ok(())) => {}
             DaemonReply::Result(Err(err)) => {
-                eyre::bail!("subscribe failed: {err}")
+                eyre::bail!("subscribe failed: {err}");
             }
-            other => eyre::bail!("unexpected subscribe reply: {other:?}"),
+            other => {
+                eyre::bail!("unexpected subscribe reply: {other:?}");
+            }
         }
 
         close_channel.register(dataflow_id, node_id.clone(), clock.new_timestamp())?;

--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -725,9 +725,11 @@ impl EventStream {
         match reply {
             DaemonReply::Result(Ok(())) => {}
             DaemonReply::Result(Err(err)) => {
-                eyre::bail!("subscribe failed: {err}")
+                eyre::bail!("subscribe failed: {err}");
             }
-            other => eyre::bail!("unexpected subscribe reply: {other:?}"),
+            other => {
+                eyre::bail!("unexpected subscribe reply: {other:?}");
+            }
         }
 
         close_channel.register(dataflow_id, node_id.clone(), clock.new_timestamp())?;

--- a/apis/rust/node/src/node/arrow_utils/ipc_encode.rs
+++ b/apis/rust/node/src/node/arrow_utils/ipc_encode.rs
@@ -832,7 +832,7 @@ fn decode_one_batch(
             bail!("IPC batch decoder made no progress on a partial/corrupt message");
         }
     }
-    bail!("IPC batch message yielded no record batch")
+    bail!("IPC batch message yielded no record batch");
 }
 
 #[cfg(test)]

--- a/apis/rust/node/src/node/control_channel.rs
+++ b/apis/rust/node/src/node/control_channel.rs
@@ -70,7 +70,9 @@ impl ControlChannel {
             DaemonReply::Result(result) => result
                 .map_err(|e| eyre!(e))
                 .wrap_err("failed to report outputs done event to dora-daemon")?,
-            other => bail!("unexpected outputs done reply: {other:?}"),
+            other => {
+                bail!("unexpected outputs done reply: {other:?}");
+            }
         }
         Ok(())
     }
@@ -87,7 +89,9 @@ impl ControlChannel {
             DaemonReply::Result(result) => result
                 .map_err(|e| eyre!(e))
                 .wrap_err("failed to receive closed outputs reply from dora-daemon")?,
-            other => bail!("unexpected closed outputs reply: {other:?}"),
+            other => {
+                bail!("unexpected closed outputs reply: {other:?}");
+            }
         }
         Ok(())
     }
@@ -112,7 +116,9 @@ impl ControlChannel {
             .wrap_err("failed to send SendMessage request to dora-daemon")?;
         match reply {
             DaemonReply::Empty => Ok(()),
-            other => bail!("unexpected SendMessage reply: {other:?}"),
+            other => {
+                bail!("unexpected SendMessage reply: {other:?}");
+            }
         }
     }
 
@@ -134,7 +140,9 @@ impl ControlChannel {
             .wrap_err("failed to send OutputSent request to dora-daemon")?;
         match reply {
             DaemonReply::Empty => Ok(()),
-            other => bail!("unexpected OutputSent reply: {other:?}"),
+            other => {
+                bail!("unexpected OutputSent reply: {other:?}");
+            }
         }
     }
 
@@ -156,8 +164,12 @@ impl ControlChannel {
             .wrap_err("failed to send RegisterPinnedMemory request to dora-daemon")?;
         match reply {
             DaemonReply::Result(Ok(())) => Ok(()),
-            DaemonReply::Result(Err(e)) => bail!("{e}"),
-            other => bail!("unexpected RegisterPinnedMemory reply: {other:?}"),
+            DaemonReply::Result(Err(e)) => {
+                bail!("{e}");
+            }
+            other => {
+                bail!("unexpected RegisterPinnedMemory reply: {other:?}");
+            }
         }
     }
 
@@ -179,8 +191,12 @@ impl ControlChannel {
             .wrap_err("failed to send ReadPinnedMemory request to dora-daemon")?;
         match reply {
             DaemonReply::PinnedMemoryMetadata { metadata } => Ok(metadata),
-            DaemonReply::Result(Err(e)) => bail!("{e}"),
-            other => bail!("unexpected ReadPinnedMemory reply: {other:?}"),
+            DaemonReply::Result(Err(e)) => {
+                bail!("{e}");
+            }
+            other => {
+                bail!("unexpected ReadPinnedMemory reply: {other:?}");
+            }
         }
     }
 
@@ -195,8 +211,12 @@ impl ControlChannel {
             .wrap_err("failed to send FreePinnedMemory request to dora-daemon")?;
         match reply {
             DaemonReply::Result(Ok(())) => Ok(()),
-            DaemonReply::Result(Err(e)) => bail!("{e}"),
-            other => bail!("unexpected FreePinnedMemory reply: {other:?}"),
+            DaemonReply::Result(Err(e)) => {
+                bail!("{e}");
+            }
+            other => {
+                bail!("unexpected FreePinnedMemory reply: {other:?}");
+            }
         }
     }
 }

--- a/binaries/cli/src/command/build/distributed.rs
+++ b/binaries/cli/src/command/build/distributed.rs
@@ -78,6 +78,8 @@ pub fn wait_until_dataflow_built(
             println!("dataflow build finished successfully");
             Ok(build_id)
         }
-        Err(err) => bail!("{err}"),
+        Err(err) => {
+            bail!("{err}");
+        }
     }
 }

--- a/binaries/cli/src/command/build/git.rs
+++ b/binaries/cli/src/command/build/git.rs
@@ -42,7 +42,9 @@ pub fn fetch_commit_hash(repo_url: String, rev: Option<GitRepoRev>) -> eyre::Res
             subdir: None,
             hub: None,
         }),
-        None => eyre::bail!("no matching commit for `{rev:?}`"),
+        None => {
+            eyre::bail!("no matching commit for `{rev:?}`");
+        }
     }
 }
 

--- a/binaries/cli/src/command/build/mod.rs
+++ b/binaries/cli/src/command/build/mod.rs
@@ -627,9 +627,11 @@ fn select_distributed_working_dir(
             let canonical = canonicalize_working_dir(Some(override_), dataflow_path)?;
             Ok(Some(canonical))
         }
-        (Some(_), None) => eyre::bail!(
-            "`working_dir_override` can only be used for single-machine coordinator builds where CLI and daemon run on the same machine"
-        ),
+        (Some(_), None) => {
+            eyre::bail!(
+                "`working_dir_override` can only be used for single-machine coordinator builds where CLI and daemon run on the same machine"
+            );
+        }
         (None, inferred) => Ok(inferred),
     }
 }

--- a/binaries/cli/src/command/cluster/install.rs
+++ b/binaries/cli/src/command/cluster/install.rs
@@ -89,7 +89,7 @@ WantedBy=multi-user.target
                 "install failed on {}/{} machine(s)",
                 failures.len(),
                 config.machines.len()
-            )
+            );
         }
     }
 }

--- a/binaries/cli/src/command/cluster/uninstall.rs
+++ b/binaries/cli/src/command/cluster/uninstall.rs
@@ -59,7 +59,7 @@ impl Executable for Uninstall {
                 "uninstall failed on {}/{} machine(s)",
                 failures.len(),
                 config.machines.len()
-            )
+            );
         }
     }
 }

--- a/binaries/cli/src/command/cluster/up.rs
+++ b/binaries/cli/src/command/cluster/up.rs
@@ -162,7 +162,7 @@ impl Executable for Up {
                 "cluster up incomplete: {} ssh failure(s), {} daemon(s) did not register",
                 ssh_failures.len(),
                 missing_daemons.len()
-            )
+            );
         }
     }
 }

--- a/binaries/cli/src/command/cluster/upgrade.rs
+++ b/binaries/cli/src/command/cluster/upgrade.rs
@@ -129,7 +129,7 @@ impl Executable for Upgrade {
                 "upgrade failed on {}/{} machine(s)",
                 failures.len(),
                 config.machines.len()
-            )
+            );
         }
     }
 }

--- a/binaries/cli/src/command/coordinator.rs
+++ b/binaries/cli/src/command/coordinator.rs
@@ -137,7 +137,9 @@ fn create_store(spec: &str) -> eyre::Result<Arc<dyn CoordinatorStore>> {
             )
         }
 
-        other => eyre::bail!("unknown store backend: `{other}` (expected `memory` or `redb`)"),
+        other => {
+            eyre::bail!("unknown store backend: `{other}` (expected `memory` or `redb`)");
+        }
     }
 }
 

--- a/binaries/cli/src/command/hub/fetch.rs
+++ b/binaries/cli/src/command/hub/fetch.rs
@@ -114,16 +114,20 @@ fn resolve_dataflow_pins(dataflow: &str) -> eyre::Result<Vec<GitSource>> {
             .with_context(|| format!("node `{}`: invalid `hub:` reference", node.id))?;
         let source = match pinned.get(&node.id) {
             Some(source) => source,
-            None if binary_pinned.contains(&node.id) => eyre::bail!(
-                "node `{}`: resolves to a prebuilt binary artifact — `dora hub fetch` does not \
-                 pre-download binary artifacts yet (the daemon fetches and verifies them at \
-                 spawn time); offline (UC7) binary prefetch is a follow-up",
-                node.id
-            ),
-            None => eyre::bail!(
-                "node `{}`: `hub:` reference is not in the lockfile — {regen}",
-                node.id
-            ),
+            None if binary_pinned.contains(&node.id) => {
+                eyre::bail!(
+                    "node `{}`: resolves to a prebuilt binary artifact — `dora hub fetch` does not \
+                     pre-download binary artifacts yet (the daemon fetches and verifies them at \
+                     spawn time); offline (UC7) binary prefetch is a follow-up",
+                    node.id
+                );
+            }
+            None => {
+                eyre::bail!(
+                    "node `{}`: `hub:` reference is not in the lockfile — {regen}",
+                    node.id
+                );
+            }
         };
         let prov = source.hub.as_ref().expect("filtered to hub sources");
         let version = dora_hub_client::semver::Version::parse(&prov.version)

--- a/binaries/cli/src/command/hub/install.rs
+++ b/binaries/cli/src/command/hub/install.rs
@@ -19,6 +19,6 @@ impl Executable for Install {
              - id: my-node\n      hub: <name>@<version-req>\n\n  \
              then `dora build dataflow.yml` fetches and builds it.\n  \
              To pre-populate caches for offline use, see `dora hub fetch` (planned)."
-        )
+        );
     }
 }

--- a/binaries/cli/src/command/hub/publish.rs
+++ b/binaries/cli/src/command/hub/publish.rs
@@ -208,11 +208,13 @@ impl Executable for Publish {
                 .open(&dest)
             {
                 Ok(file) => file,
-                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => bail!(
-                    "version {version} of `{namespace}/{name}` already exists at `{}` — \
-                     the index is append-only; bump the version to publish a new one",
-                    dest.display()
-                ),
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                    bail!(
+                        "version {version} of `{namespace}/{name}` already exists at `{}` — \
+                         the index is append-only; bump the version to publish a new one",
+                        dest.display()
+                    );
+                }
                 Err(e) => {
                     return Err(e).with_context(|| format!("failed to write `{}`", dest.display()));
                 }

--- a/binaries/cli/src/command/node/add.rs
+++ b/binaries/cli/src/command/node/add.rs
@@ -36,8 +36,12 @@ impl Executable for Add {
             ControlRequestReply::NodeAdded { node_id, .. } => {
                 println!("Node `{node_id}` added to dataflow {dataflow_id}");
             }
-            ControlRequestReply::Error(err) => bail!("failed to add node: {err}"),
-            other => bail!("unexpected reply: {other:?}"),
+            ControlRequestReply::Error(err) => {
+                bail!("failed to add node: {err}");
+            }
+            other => {
+                bail!("unexpected reply: {other:?}");
+            }
         }
         Ok(())
     }

--- a/binaries/cli/src/command/node/connect.rs
+++ b/binaries/cli/src/command/node/connect.rs
@@ -48,8 +48,12 @@ impl Executable for Connect {
             ControlRequestReply::MappingAdded { .. } => {
                 println!("{source_node}/{source_output} -> {target_node}/{target_input}");
             }
-            ControlRequestReply::Error(err) => bail!("failed to connect: {err}"),
-            other => bail!("unexpected reply: {other:?}"),
+            ControlRequestReply::Error(err) => {
+                bail!("failed to connect: {err}");
+            }
+            other => {
+                bail!("unexpected reply: {other:?}");
+            }
         }
         Ok(())
     }

--- a/binaries/cli/src/command/node/disconnect.rs
+++ b/binaries/cli/src/command/node/disconnect.rs
@@ -48,8 +48,12 @@ impl Executable for Disconnect {
             ControlRequestReply::MappingRemoved { .. } => {
                 println!("{source_node}/{source_output} -x- {target_node}/{target_input}");
             }
-            ControlRequestReply::Error(err) => bail!("failed to disconnect: {err}"),
-            other => bail!("unexpected reply: {other:?}"),
+            ControlRequestReply::Error(err) => {
+                bail!("failed to disconnect: {err}");
+            }
+            other => {
+                bail!("unexpected reply: {other:?}");
+            }
         }
         Ok(())
     }

--- a/binaries/cli/src/command/node/remove.rs
+++ b/binaries/cli/src/command/node/remove.rs
@@ -45,8 +45,12 @@ impl Executable for Remove {
             ControlRequestReply::NodeRemoved { node_id, .. } => {
                 println!("Node `{node_id}` removed from dataflow {dataflow_id}");
             }
-            ControlRequestReply::Error(err) => bail!("failed to remove node: {err}"),
-            other => bail!("unexpected reply: {other:?}"),
+            ControlRequestReply::Error(err) => {
+                bail!("failed to remove node: {err}");
+            }
+            other => {
+                bail!("unexpected reply: {other:?}");
+            }
         }
         Ok(())
     }

--- a/binaries/cli/src/command/node/replace.rs
+++ b/binaries/cli/src/command/node/replace.rs
@@ -82,8 +82,12 @@ impl Executable for Replace {
             ControlRequestReply::NodeReplaced { node_id, .. } => {
                 println!("Node `{node_id}` replaced in dataflow {dataflow_id}");
             }
-            ControlRequestReply::Error(err) => bail!("failed to replace node: {err}"),
-            other => bail!("unexpected reply: {other:?}"),
+            ControlRequestReply::Error(err) => {
+                bail!("failed to replace node: {err}");
+            }
+            other => {
+                bail!("unexpected reply: {other:?}");
+            }
         }
         Ok(())
     }

--- a/binaries/cli/src/command/node/restart.rs
+++ b/binaries/cli/src/command/node/restart.rs
@@ -69,8 +69,12 @@ impl Executable for Restart {
                 println!("Node `{node_id}` restart initiated");
                 Ok(())
             }
-            ControlRequestReply::Error(err) => bail!("{err}"),
-            other => bail!("unexpected reply: {other:?}"),
+            ControlRequestReply::Error(err) => {
+                bail!("{err}");
+            }
+            other => {
+                bail!("unexpected reply: {other:?}");
+            }
         }
     }
 }

--- a/binaries/cli/src/command/node/stop.rs
+++ b/binaries/cli/src/command/node/stop.rs
@@ -70,8 +70,12 @@ impl Executable for Stop {
                 println!("Node `{node_id}` stopped");
                 Ok(())
             }
-            ControlRequestReply::Error(err) => bail!("{err}"),
-            other => bail!("unexpected reply: {other:?}"),
+            ControlRequestReply::Error(err) => {
+                bail!("{err}");
+            }
+            other => {
+                bail!("unexpected reply: {other:?}");
+            }
         }
     }
 }

--- a/binaries/cli/src/command/node_binary.rs
+++ b/binaries/cli/src/command/node_binary.rs
@@ -31,11 +31,15 @@ pub fn find(binary_name: &str, crate_name: &str) -> eyre::Result<PathBuf> {
         .status();
     match status {
         Ok(s) if s.success() => {}
-        Ok(s) => bail!("failed to install {crate_name} (exit code: {s})"),
-        Err(e) => bail!(
-            "could not find `{binary_name}` and installation failed: {e}\n\
-             Install it manually with: cargo install {crate_name}"
-        ),
+        Ok(s) => {
+            bail!("failed to install {crate_name} (exit code: {s})");
+        }
+        Err(e) => {
+            bail!(
+                "could not find `{binary_name}` and installation failed: {e}\n\
+                 Install it manually with: cargo install {crate_name}"
+            );
+        }
     }
 
     search(binary_name).ok_or_else(|| {

--- a/binaries/cli/src/command/param/delete.rs
+++ b/binaries/cli/src/command/param/delete.rs
@@ -63,8 +63,12 @@ impl Executable for Delete {
                 println!("Deleted `{}` from node `{}`", self.key, self.node);
                 Ok(())
             }
-            ControlRequestReply::Error(err) => bail!("{err}"),
-            other => bail!("unexpected reply: {other:?}"),
+            ControlRequestReply::Error(err) => {
+                bail!("{err}");
+            }
+            other => {
+                bail!("unexpected reply: {other:?}");
+            }
         }
     }
 }

--- a/binaries/cli/src/command/param/get.rs
+++ b/binaries/cli/src/command/param/get.rs
@@ -63,8 +63,12 @@ impl Executable for Get {
                 println!("{value}");
                 Ok(())
             }
-            ControlRequestReply::Error(err) => bail!("{err}"),
-            other => bail!("unexpected reply: {other:?}"),
+            ControlRequestReply::Error(err) => {
+                bail!("{err}");
+            }
+            other => {
+                bail!("unexpected reply: {other:?}");
+            }
         }
     }
 }

--- a/binaries/cli/src/command/param/list.rs
+++ b/binaries/cli/src/command/param/list.rs
@@ -79,8 +79,12 @@ impl Executable for List {
                 }
                 Ok(())
             }
-            ControlRequestReply::Error(err) => bail!("{err}"),
-            other => bail!("unexpected reply: {other:?}"),
+            ControlRequestReply::Error(err) => {
+                bail!("{err}");
+            }
+            other => {
+                bail!("unexpected reply: {other:?}");
+            }
         }
     }
 }

--- a/binaries/cli/src/command/param/list.rs
+++ b/binaries/cli/src/command/param/list.rs
@@ -77,8 +77,12 @@ impl Executable for List {
                 }
                 Ok(())
             }
-            ControlRequestReply::Error(err) => bail!("{err}"),
-            other => bail!("unexpected reply: {other:?}"),
+            ControlRequestReply::Error(err) => {
+                bail!("{err}");
+            }
+            other => {
+                bail!("unexpected reply: {other:?}");
+            }
         }
     }
 }

--- a/binaries/cli/src/command/param/set.rs
+++ b/binaries/cli/src/command/param/set.rs
@@ -77,8 +77,12 @@ impl Executable for Set {
                 println!("Set `{}` = {} on node `{}`", self.key, value, self.node);
                 Ok(())
             }
-            ControlRequestReply::Error(err) => bail!("{err}"),
-            other => bail!("unexpected reply: {other:?}"),
+            ControlRequestReply::Error(err) => {
+                bail!("{err}");
+            }
+            other => {
+                bail!("unexpected reply: {other:?}");
+            }
         }
     }
 }

--- a/binaries/cli/src/command/record.rs
+++ b/binaries/cli/src/command/record.rs
@@ -135,10 +135,12 @@ fn run_record(args: Record) -> eyre::Result<()> {
                 Some(input_id) => {
                     filtered.insert(requested.clone(), input_id.clone());
                 }
-                None => bail!(
-                    "topic `{requested}` not found in descriptor. Available: {}",
-                    all_topics.keys().cloned().collect::<Vec<_>>().join(", ")
-                ),
+                None => {
+                    bail!(
+                        "topic `{requested}` not found in descriptor. Available: {}",
+                        all_topics.keys().cloned().collect::<Vec<_>>().join(", ")
+                    );
+                }
             }
         }
         filtered
@@ -348,7 +350,9 @@ fn run_record_proxy(args: Record) -> eyre::Result<()> {
         dora_message::coordinator_to_cli::ControlRequestReply::DataflowList(list) => {
             list.get_active()
         }
-        _ => bail!("unexpected reply to List"),
+        _ => {
+            bail!("unexpected reply to List");
+        }
     };
 
     if active_ids.is_empty() {
@@ -552,10 +556,12 @@ fn select_dataflow(
             .filter(|d| d.name.as_deref() == Some(name))
             .collect();
         return match matched.len() {
-            0 => bail!(
-                "no running dataflow named `{name}`. \
-                 Run `dora list` to see the names of running dataflows."
-            ),
+            0 => {
+                bail!(
+                    "no running dataflow named `{name}`. \
+                     Run `dora list` to see the names of running dataflows."
+                );
+            }
             1 => Ok(Selection::One(matched.remove(0))),
             _ => Ok(Selection::Many(matched)),
         };

--- a/binaries/cli/src/command/record.rs
+++ b/binaries/cli/src/command/record.rs
@@ -135,10 +135,12 @@ fn run_record(args: Record) -> eyre::Result<()> {
                 Some(input_id) => {
                     filtered.insert(requested.clone(), input_id.clone());
                 }
-                None => bail!(
-                    "topic `{requested}` not found in descriptor. Available: {}",
-                    all_topics.keys().cloned().collect::<Vec<_>>().join(", ")
-                ),
+                None => {
+                    bail!(
+                        "topic `{requested}` not found in descriptor. Available: {}",
+                        all_topics.keys().cloned().collect::<Vec<_>>().join(", ")
+                    );
+                }
             }
         }
         filtered
@@ -323,7 +325,9 @@ fn run_record_proxy(args: Record) -> eyre::Result<()> {
         dora_message::coordinator_to_cli::ControlRequestReply::DataflowList(list) => {
             list.get_active()
         }
-        _ => bail!("unexpected reply to List"),
+        _ => {
+            bail!("unexpected reply to List");
+        }
     };
 
     if active_ids.is_empty() {
@@ -487,10 +491,12 @@ fn select_dataflow(
             .filter(|d| d.name.as_deref() == Some(name))
             .collect();
         return match matched.len() {
-            0 => bail!(
-                "no running dataflow named `{name}`. \
-                 Run `dora list` to see the names of running dataflows."
-            ),
+            0 => {
+                bail!(
+                    "no running dataflow named `{name}`. \
+                     Run `dora list` to see the names of running dataflows."
+                );
+            }
             1 => Ok(Selection::One(matched.remove(0))),
             _ => Ok(Selection::Many(matched)),
         };

--- a/binaries/cli/src/command/restart.rs
+++ b/binaries/cli/src/command/restart.rs
@@ -98,8 +98,12 @@ fn restart_dataflow(
             println!("dataflow restarted: {old_uuid} -> {new_uuid}");
             Ok(())
         }
-        ControlRequestReply::Error(err) => bail!("{err}"),
-        other => bail!("unexpected restart dataflow reply: {other:?}"),
+        ControlRequestReply::Error(err) => {
+            bail!("{err}");
+        }
+        other => {
+            bail!("unexpected restart dataflow reply: {other:?}");
+        }
     }
 }
 
@@ -126,7 +130,11 @@ fn restart_dataflow_by_name(
             println!("dataflow restarted: {old_uuid} -> {new_uuid}");
             Ok(())
         }
-        ControlRequestReply::Error(err) => bail!("{err}"),
-        other => bail!("unexpected restart dataflow reply: {other:?}"),
+        ControlRequestReply::Error(err) => {
+            bail!("{err}");
+        }
+        other => {
+            bail!("unexpected restart dataflow reply: {other:?}");
+        }
     }
 }

--- a/binaries/cli/src/command/self_.rs
+++ b/binaries/cli/src/command/self_.rs
@@ -70,7 +70,9 @@ impl Executable for SelfSubCommand {
                                 );
                             }
                         }
-                        Err(e) => bail!("failed to check for updates: {e}"),
+                        Err(e) => {
+                            bail!("failed to check for updates: {e}");
+                        }
                     }
                 } else {
                     // Perform the actual update
@@ -83,7 +85,9 @@ impl Executable for SelfSubCommand {
                                 println!("Successfully updated Dora CLI to version: {version}");
                             }
                         },
-                        Err(e) => bail!("failed to update: {e}"),
+                        Err(e) => {
+                            bail!("failed to update: {e}");
+                        }
                     }
                 }
             }

--- a/binaries/cli/src/command/topic/pub_.rs
+++ b/binaries/cli/src/command/topic/pub_.rs
@@ -139,7 +139,11 @@ fn publish(
 
     match reply {
         ControlRequestReply::TopicPublished => Ok(()),
-        ControlRequestReply::Error(err) => bail!("{err}"),
-        other => bail!("unexpected reply: {other:?}"),
+        ControlRequestReply::Error(err) => {
+            bail!("{err}");
+        }
+        other => {
+            bail!("unexpected reply: {other:?}");
+        }
     }
 }

--- a/binaries/cli/src/command/topic/selector.rs
+++ b/binaries/cli/src/command/topic/selector.rs
@@ -39,8 +39,12 @@ impl DataflowSelector {
             serde_json::from_slice(&reply_raw).wrap_err("failed to parse reply")?;
         match reply {
             ControlRequestReply::DataflowInfo { descriptor, .. } => Ok((dataflow_id, descriptor)),
-            ControlRequestReply::Error(err) => bail!("{err}"),
-            other => bail!("unexpected list dataflow reply: {other:?}"),
+            ControlRequestReply::Error(err) => {
+                bail!("{err}");
+            }
+            other => {
+                bail!("unexpected list dataflow reply: {other:?}");
+            }
         }
     }
 }
@@ -147,9 +151,11 @@ impl TopicSelector {
                     }
                 }
                 Ok(_) => {
-                    bail!("Reserved input mapping cannot be inspected")
+                    bail!("Reserved input mapping cannot be inspected");
                 }
-                Err(e) => bail!("Invalid output id `{s}`: {e}"),
+                Err(e) => {
+                    bail!("Invalid output id `{s}`: {e}");
+                }
             }
         }
 

--- a/binaries/cli/src/command/trace/view.rs
+++ b/binaries/cli/src/command/trace/view.rs
@@ -66,9 +66,13 @@ fn resolve_trace_id(session: &WsSession, prefix: &str) -> eyre::Result<String> {
         .collect();
 
     match matches.len() {
-        0 => bail!("no trace found matching prefix `{prefix}`"),
+        0 => {
+            bail!("no trace found matching prefix `{prefix}`");
+        }
         1 => Ok(matches[0].trace_id.clone()),
-        n => bail!("prefix `{prefix}` is ambiguous ({n} matches). Use a longer prefix."),
+        n => {
+            bail!("prefix `{prefix}` is ambiguous ({n} matches). Use a longer prefix.");
+        }
     }
 }
 

--- a/binaries/cli/src/command/up.rs
+++ b/binaries/cli/src/command/up.rs
@@ -379,7 +379,7 @@ fn available_backup_path(path: &Path) -> eyre::Result<PathBuf> {
             return Ok(candidate);
         }
     }
-    bail!("could not find an available coordinator store backup path")
+    bail!("could not find an available coordinator store backup path");
 }
 
 /// Whether `dora down` may destroy the coordinator it just connected to.

--- a/binaries/cli/src/common.rs
+++ b/binaries/cli/src/common.rs
@@ -159,10 +159,12 @@ pub(crate) fn resolve_dataflow_identifier_interactive(
         return Ok(dataflow.uuid);
     }
     Ok(match &active[..] {
-        [] => bail!(
-            "no dataflows are running\n\n  \
-             hint: start a dataflow with `dora start` or `dora run`"
-        ),
+        [] => {
+            bail!(
+                "no dataflows are running\n\n  \
+                 hint: start a dataflow with `dora start` or `dora run`"
+            );
+        }
         [entry] => entry.uuid,
         _ => {
             if !std::io::stdin().is_terminal() {

--- a/binaries/cli/src/env_overrides.rs
+++ b/binaries/cli/src/env_overrides.rs
@@ -100,19 +100,23 @@ fn ensure_wire_safe(key: &str, value: &str) -> Result<()> {
         .with_context(|| format!("failed to encode --env `{key}`"))?;
     match serde_json::from_str::<EnvValue>(&encoded) {
         Ok(decoded) if decoded.to_string() == value => Ok(()),
-        Ok(decoded) => bail!(
-            "--env `{key}={value}` would not survive the dataflow descriptor's \
-             encoding: nodes would receive `{decoded}` instead.\n\n  \
-             hint: numeric-looking values are coerced (`1.10` -> `1.1`, \
-             `01234` -> `1234`). Set this one in the node's `env:` block in \
-             the dataflow YAML instead."
-        ),
-        Err(err) => bail!(
-            "--env `{key}={value}` cannot be represented in the dataflow \
-             descriptor: {err}.\n\n  \
-             hint: set this one in the node's `env:` block in the dataflow \
-             YAML instead."
-        ),
+        Ok(decoded) => {
+            bail!(
+                "--env `{key}={value}` would not survive the dataflow descriptor's \
+                 encoding: nodes would receive `{decoded}` instead.\n\n  \
+                 hint: numeric-looking values are coerced (`1.10` -> `1.1`, \
+                 `01234` -> `1234`). Set this one in the node's `env:` block in \
+                 the dataflow YAML instead."
+            );
+        }
+        Err(err) => {
+            bail!(
+                "--env `{key}={value}` cannot be represented in the dataflow \
+                 descriptor: {err}.\n\n  \
+                 hint: set this one in the node's `env:` block in the dataflow \
+                 YAML instead."
+            );
+        }
     }
 }
 

--- a/binaries/coordinator/src/handlers.rs
+++ b/binaries/coordinator/src/handlers.rs
@@ -231,7 +231,7 @@ pub(crate) async fn stop_dataflow<'a>(
     force: bool,
 ) -> eyre::Result<&'a mut RunningDataflow> {
     let Some(dataflow) = running_dataflows.get_mut(&dataflow_uuid) else {
-        bail!("no known running dataflow found with UUID `{dataflow_uuid}`")
+        bail!("no known running dataflow found with UUID `{dataflow_uuid}`");
     };
 
     let message = serde_json::to_vec(&Timestamped {
@@ -258,7 +258,9 @@ pub(crate) async fn stop_dataflow<'a>(
             DaemonCoordinatorReply::StopResult(result) => result
                 .map_err(|e| eyre!(e))
                 .wrap_err("failed to stop dataflow")?,
-            other => bail!("unexpected reply after sending stop: {other:?}"),
+            other => {
+                bail!("unexpected reply after sending stop: {other:?}");
+            }
         }
     }
 
@@ -276,7 +278,7 @@ pub(crate) async fn reload_dataflow(
     timestamp: uhlc::Timestamp,
 ) -> eyre::Result<()> {
     let Some(dataflow) = running_dataflows.get(&dataflow_id) else {
-        bail!("No running dataflow found with UUID `{dataflow_id}`")
+        bail!("No running dataflow found with UUID `{dataflow_id}`");
     };
     let message = serde_json::to_vec(&Timestamped {
         inner: DaemonCoordinatorEvent::ReloadDataflow {
@@ -302,7 +304,9 @@ pub(crate) async fn reload_dataflow(
             DaemonCoordinatorReply::ReloadResult(result) => result
                 .map_err(|e| eyre!(e))
                 .wrap_err("failed to reload dataflow")?,
-            other => bail!("unexpected reply after sending reload: {other:?}"),
+            other => {
+                bail!("unexpected reply after sending reload: {other:?}");
+            }
         }
     }
     tracing::info!("successfully reloaded dataflow `{dataflow_id}`");
@@ -321,7 +325,7 @@ async fn dispatch_node_command(
     action: &str,
 ) -> eyre::Result<DaemonCoordinatorReply> {
     let Some(dataflow) = running_dataflows.get(&dataflow_id) else {
-        bail!("No running dataflow found with UUID `{dataflow_id}`")
+        bail!("No running dataflow found with UUID `{dataflow_id}`");
     };
     let daemon_id = dataflow
         .node_to_daemon
@@ -370,7 +374,9 @@ pub(crate) async fn restart_node(
         DaemonCoordinatorReply::RestartNodeResult(result) => result
             .map_err(|e| eyre!(e))
             .wrap_err("failed to restart node")?,
-        other => bail!("unexpected reply after sending restart node: {other:?}"),
+        other => {
+            bail!("unexpected reply after sending restart node: {other:?}");
+        }
     }
     tracing::info!("successfully restarted node `{node_id}` in dataflow `{dataflow_id}`");
     Ok(())
@@ -402,7 +408,9 @@ pub(crate) async fn stop_node(
         DaemonCoordinatorReply::StopNodeResult(result) => result
             .map_err(|e| eyre!(e))
             .wrap_err("failed to stop node")?,
-        other => bail!("unexpected reply after sending stop node: {other:?}"),
+        other => {
+            bail!("unexpected reply after sending stop node: {other:?}");
+        }
     }
     tracing::info!("successfully stopped node `{node_id}` in dataflow `{dataflow_id}`");
     Ok(())
@@ -438,12 +446,16 @@ fn resolve_log_daemon_id(
 
         let machine_id = match &machine_ids[..] {
             [machine_id] => machine_id.clone(),
-            [] => bail!("No machine contains {}/{}", dataflow_id, node_id),
-            _ => bail!(
-                "More than one machine contains {}/{}. However, it should only be present on one.",
-                dataflow_id,
-                node_id
-            ),
+            [] => {
+                bail!("No machine contains {}/{}", dataflow_id, node_id);
+            }
+            _ => {
+                bail!(
+                    "More than one machine contains {}/{}. However, it should only be present on one.",
+                    dataflow_id,
+                    node_id
+                );
+            }
         };
 
         let daemon_ids: Vec<_> = match &machine_id {
@@ -455,15 +467,19 @@ fn resolve_log_daemon_id(
         };
         match &daemon_ids[..] {
             [id] => Ok((*id).clone()),
-            [] => bail!("no matching daemon connections for machine ID `{machine_id:?}`"),
-            _ => bail!("multiple matching daemon connections for machine ID `{machine_id:?}`"),
+            [] => {
+                bail!("no matching daemon connections for machine ID `{machine_id:?}`");
+            }
+            _ => {
+                bail!("multiple matching daemon connections for machine ID `{machine_id:?}`");
+            }
         }
     } else if let Some(node_to_daemon) = running_node_to_daemon {
         node_to_daemon.get(node_id).cloned().ok_or_else(|| {
             eyre!("node `{node_id}` is not part of running dataflow `{dataflow_id}`")
         })
     } else {
-        bail!("No dataflow found with UUID `{dataflow_id}`")
+        bail!("No dataflow found with UUID `{dataflow_id}`");
     }
 }
 
@@ -507,7 +523,9 @@ pub(crate) async fn retrieve_logs(
         .wrap_err("failed to deserialize logs reply from daemon")?
     {
         DaemonCoordinatorReply::Logs(logs) => logs,
-        other => bail!("unexpected reply after sending logs: {other:?}"),
+        other => {
+            bail!("unexpected reply after sending logs: {other:?}");
+        }
     };
     tracing::info!("successfully retrieved logs for `{dataflow_id}/{node_id}`");
 
@@ -609,7 +627,9 @@ pub(crate) async fn build_dataflow(
             DaemonCoordinatorReply::TriggerBuildResult(result) => result
                 .map_err(|e| eyre!(e))
                 .wrap_err("daemon returned an error")?,
-            _ => bail!("unexpected reply"),
+            _ => {
+                bail!("unexpected reply");
+            }
         }
 
         daemons.insert(daemon_id.clone());
@@ -718,7 +738,9 @@ async fn destroy_daemon(
         DaemonCoordinatorReply::DestroyResult { result, .. } => result
             .map_err(|e| eyre!(e))
             .wrap_err("failed to destroy dataflow")?,
-        other => bail!("unexpected reply after sending `destroy`: {other:?}"),
+        other => {
+            bail!("unexpected reply after sending `destroy`: {other:?}");
+        }
     }
 
     tracing::info!("successfully destroyed daemon `{daemon_id}`");

--- a/binaries/coordinator/src/handlers.rs
+++ b/binaries/coordinator/src/handlers.rs
@@ -222,7 +222,7 @@ pub(crate) async fn stop_dataflow<'a>(
     force: bool,
 ) -> eyre::Result<&'a mut RunningDataflow> {
     let Some(dataflow) = running_dataflows.get_mut(&dataflow_uuid) else {
-        bail!("no known running dataflow found with UUID `{dataflow_uuid}`")
+        bail!("no known running dataflow found with UUID `{dataflow_uuid}`");
     };
 
     let message = serde_json::to_vec(&Timestamped {
@@ -249,7 +249,9 @@ pub(crate) async fn stop_dataflow<'a>(
             DaemonCoordinatorReply::StopResult(result) => result
                 .map_err(|e| eyre!(e))
                 .wrap_err("failed to stop dataflow")?,
-            other => bail!("unexpected reply after sending stop: {other:?}"),
+            other => {
+                bail!("unexpected reply after sending stop: {other:?}");
+            }
         }
     }
 
@@ -267,7 +269,7 @@ pub(crate) async fn reload_dataflow(
     timestamp: uhlc::Timestamp,
 ) -> eyre::Result<()> {
     let Some(dataflow) = running_dataflows.get(&dataflow_id) else {
-        bail!("No running dataflow found with UUID `{dataflow_id}`")
+        bail!("No running dataflow found with UUID `{dataflow_id}`");
     };
     let message = serde_json::to_vec(&Timestamped {
         inner: DaemonCoordinatorEvent::ReloadDataflow {
@@ -293,7 +295,9 @@ pub(crate) async fn reload_dataflow(
             DaemonCoordinatorReply::ReloadResult(result) => result
                 .map_err(|e| eyre!(e))
                 .wrap_err("failed to reload dataflow")?,
-            other => bail!("unexpected reply after sending reload: {other:?}"),
+            other => {
+                bail!("unexpected reply after sending reload: {other:?}");
+            }
         }
     }
     tracing::info!("successfully reloaded dataflow `{dataflow_id}`");
@@ -312,7 +316,7 @@ async fn dispatch_node_command(
     action: &str,
 ) -> eyre::Result<DaemonCoordinatorReply> {
     let Some(dataflow) = running_dataflows.get(&dataflow_id) else {
-        bail!("No running dataflow found with UUID `{dataflow_id}`")
+        bail!("No running dataflow found with UUID `{dataflow_id}`");
     };
     let daemon_id = dataflow
         .node_to_daemon
@@ -361,7 +365,9 @@ pub(crate) async fn restart_node(
         DaemonCoordinatorReply::RestartNodeResult(result) => result
             .map_err(|e| eyre!(e))
             .wrap_err("failed to restart node")?,
-        other => bail!("unexpected reply after sending restart node: {other:?}"),
+        other => {
+            bail!("unexpected reply after sending restart node: {other:?}");
+        }
     }
     tracing::info!("successfully restarted node `{node_id}` in dataflow `{dataflow_id}`");
     Ok(())
@@ -393,7 +399,9 @@ pub(crate) async fn stop_node(
         DaemonCoordinatorReply::StopNodeResult(result) => result
             .map_err(|e| eyre!(e))
             .wrap_err("failed to stop node")?,
-        other => bail!("unexpected reply after sending stop node: {other:?}"),
+        other => {
+            bail!("unexpected reply after sending stop node: {other:?}");
+        }
     }
     tracing::info!("successfully stopped node `{node_id}` in dataflow `{dataflow_id}`");
     Ok(())
@@ -429,12 +437,16 @@ fn resolve_log_daemon_id(
 
         let machine_id = match &machine_ids[..] {
             [machine_id] => machine_id.clone(),
-            [] => bail!("No machine contains {}/{}", dataflow_id, node_id),
-            _ => bail!(
-                "More than one machine contains {}/{}. However, it should only be present on one.",
-                dataflow_id,
-                node_id
-            ),
+            [] => {
+                bail!("No machine contains {}/{}", dataflow_id, node_id);
+            }
+            _ => {
+                bail!(
+                    "More than one machine contains {}/{}. However, it should only be present on one.",
+                    dataflow_id,
+                    node_id
+                );
+            }
         };
 
         let daemon_ids: Vec<_> = match &machine_id {
@@ -446,15 +458,19 @@ fn resolve_log_daemon_id(
         };
         match &daemon_ids[..] {
             [id] => Ok((*id).clone()),
-            [] => bail!("no matching daemon connections for machine ID `{machine_id:?}`"),
-            _ => bail!("multiple matching daemon connections for machine ID `{machine_id:?}`"),
+            [] => {
+                bail!("no matching daemon connections for machine ID `{machine_id:?}`");
+            }
+            _ => {
+                bail!("multiple matching daemon connections for machine ID `{machine_id:?}`");
+            }
         }
     } else if let Some(node_to_daemon) = running_node_to_daemon {
         node_to_daemon.get(node_id).cloned().ok_or_else(|| {
             eyre!("node `{node_id}` is not part of running dataflow `{dataflow_id}`")
         })
     } else {
-        bail!("No dataflow found with UUID `{dataflow_id}`")
+        bail!("No dataflow found with UUID `{dataflow_id}`");
     }
 }
 
@@ -498,7 +514,9 @@ pub(crate) async fn retrieve_logs(
         .wrap_err("failed to deserialize logs reply from daemon")?
     {
         DaemonCoordinatorReply::Logs(logs) => logs,
-        other => bail!("unexpected reply after sending logs: {other:?}"),
+        other => {
+            bail!("unexpected reply after sending logs: {other:?}");
+        }
     };
     tracing::info!("successfully retrieved logs for `{dataflow_id}/{node_id}`");
 
@@ -600,7 +618,9 @@ pub(crate) async fn build_dataflow(
             DaemonCoordinatorReply::TriggerBuildResult(result) => result
                 .map_err(|e| eyre!(e))
                 .wrap_err("daemon returned an error")?,
-            _ => bail!("unexpected reply"),
+            _ => {
+                bail!("unexpected reply");
+            }
         }
 
         daemons.insert(daemon_id.clone());
@@ -708,7 +728,9 @@ async fn destroy_daemon(
         DaemonCoordinatorReply::DestroyResult { result, .. } => result
             .map_err(|e| eyre!(e))
             .wrap_err("failed to destroy dataflow")?,
-        other => bail!("unexpected reply after sending `destroy`: {other:?}"),
+        other => {
+            bail!("unexpected reply after sending `destroy`: {other:?}");
+        }
     }
 
     tracing::info!("successfully destroyed daemon `{daemon_id}`");

--- a/binaries/coordinator/src/run/mod.rs
+++ b/binaries/coordinator/src/run/mod.rs
@@ -79,7 +79,9 @@ pub(super) async fn spawn_dataflow(
                 DaemonCoordinatorReply::TriggerSpawnResult(result) => result
                     .map_err(|e| eyre!(e))
                     .wrap_err("daemon returned an error")?,
-                _ => bail!("unexpected reply"),
+                _ => {
+                    bail!("unexpected reply");
+                }
             }
             Ok(())
         }
@@ -237,7 +239,9 @@ async fn rollback_spawned_daemons(
                 DaemonCoordinatorReply::StopResult(r) => {
                     r.map_err(|e| eyre!(e)).wrap_err("daemon stop failed")?;
                 }
-                other => bail!("unexpected reply during rollback: {other:?}"),
+                other => {
+                    bail!("unexpected reply during rollback: {other:?}");
+                }
             }
             Ok(())
         }

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -967,7 +967,7 @@ impl Daemon {
                 Instead, you need to spawn a `dora coordinator` and one or more `dora daemon`
                 instances and then use `dora start`.",
                 node.id
-            )
+            );
         }
 
         validate::check_dataflow(&descriptor, &working_dir)
@@ -1066,7 +1066,7 @@ impl Daemon {
             None,
             if let Some(local_build) = local_build {
                 let Some(build_id) = build_id else {
-                    bail!("no build_id, but local_build set")
+                    bail!("no build_id, but local_build set");
                 };
                 let mut builds = BTreeMap::new();
                 builds.insert(build_id, local_build);
@@ -1455,7 +1455,7 @@ impl Daemon {
                             // running nodes and their `ProcessHandle`s survive,
                             // and the next reconnect re-adopts them
                             // (dora-rs/dora#2029).
-                            bail!("coordinator heartbeat timeout (20s)")
+                            bail!("coordinator heartbeat timeout (20s)");
                         }
                     }
                 }
@@ -2979,7 +2979,7 @@ impl Daemon {
                 entry.insert(dataflow)
             }
             std::collections::hash_map::Entry::Occupied(_) => {
-                bail!("there is already a running dataflow with ID `{dataflow_id}`")
+                bail!("there is already a running dataflow with ID `{dataflow_id}`");
             }
         };
 
@@ -2999,7 +2999,7 @@ impl Daemon {
                     nodes with a `git` field must be built using `dora build` before starting the \
                     dataflow",
                 git_node.id
-            )
+            );
         }
         // Reuse build-time metadata so runtime spawn can follow the same
         // working-directory and managed-env decisions.
@@ -3263,7 +3263,7 @@ impl Daemon {
                         "node {} has git source, but no git clone directory was found for it\n\n\
                         try running `dora build` again",
                         node.id
-                    )
+                    );
                 }
                 let node_working_dir = configured_node_working_dir
                     .or_else(|| {
@@ -4314,9 +4314,11 @@ impl Daemon {
                 );
                 return Ok(());
             }
-            None => eyre::bail!(
-                "failed to get downstream nodes: no running dataflow with ID `{dataflow_id}`"
-            ),
+            None => {
+                eyre::bail!(
+                    "failed to get downstream nodes: no running dataflow with ID `{dataflow_id}`"
+                );
+            }
         };
 
         dataflow
@@ -5051,7 +5053,7 @@ impl Daemon {
                     bail!(
                         "working directory does not exist: {}",
                         working_dir.display(),
-                    )
+                    );
                 }
             }
             None => {

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -3109,10 +3109,10 @@ impl Daemon {
                         match current_edges.remove(input_id) {
                             Some(mapping) if mapping == input.mapping => {}
                             Some(_) => {
-                                eyre::bail!("replacement remaps input `{input_id}`; {EDGE_HINT}")
+                                eyre::bail!("replacement remaps input `{input_id}`; {EDGE_HINT}");
                             }
                             None => {
-                                eyre::bail!("replacement adds input `{input_id}`; {EDGE_HINT}")
+                                eyre::bail!("replacement adds input `{input_id}`; {EDGE_HINT}");
                             }
                         }
                     }

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1310,7 +1310,7 @@ impl Daemon {
                 Instead, you need to spawn a `dora coordinator` and one or more `dora daemon`
                 instances and then use `dora start`.",
                 node.id
-            )
+            );
         }
 
         validate::check_dataflow(&descriptor, &working_dir)
@@ -1411,7 +1411,7 @@ impl Daemon {
             None,
             if let Some(local_build) = local_build {
                 let Some(build_id) = build_id else {
-                    bail!("no build_id, but local_build set")
+                    bail!("no build_id, but local_build set");
                 };
                 let mut builds = BTreeMap::new();
                 builds.insert(build_id, local_build);
@@ -1881,7 +1881,7 @@ impl Daemon {
                             // running nodes and their `ProcessHandle`s survive,
                             // and the next reconnect re-adopts them
                             // (dora-rs/dora#2029).
-                            bail!("coordinator heartbeat timeout (20s)")
+                            bail!("coordinator heartbeat timeout (20s)");
                         }
                     }
                 }
@@ -3950,7 +3950,7 @@ impl Daemon {
                 entry.insert(dataflow)
             }
             std::collections::hash_map::Entry::Occupied(_) => {
-                bail!("there is already a running dataflow with ID `{dataflow_id}`")
+                bail!("there is already a running dataflow with ID `{dataflow_id}`");
             }
         };
 
@@ -3970,7 +3970,7 @@ impl Daemon {
                     nodes with a `git` field must be built using `dora build` before starting the \
                     dataflow",
                 git_node.id
-            )
+            );
         }
         // Reuse build-time metadata so runtime spawn can follow the same
         // working-directory and managed-env decisions.
@@ -4262,7 +4262,7 @@ impl Daemon {
                         "node {} has git source, but no git clone directory was found for it\n\n\
                         try running `dora build` again",
                         node.id
-                    )
+                    );
                 }
                 let node_working_dir = configured_node_working_dir
                     .or_else(|| {
@@ -6222,7 +6222,7 @@ impl Daemon {
                     bail!(
                         "working directory does not exist: {}",
                         working_dir.display(),
-                    )
+                    );
                 }
             }
             None => {

--- a/binaries/runtime/src/lib.rs
+++ b/binaries/runtime/src/lib.rs
@@ -256,7 +256,7 @@ async fn run(
                     bail!(err.wrap_err(format!(
                         "operator {}/{operator_id} raised an error",
                         node.id()
-                    )))
+                    )));
                 }
                 OperatorEvent::Panic(payload) => {
                     let message = payload
@@ -408,7 +408,9 @@ async fn run(
                     }
                 }
             }
-            RuntimeEvent::Event(Event::Error(err)) => eyre::bail!("received error event: {err}"),
+            RuntimeEvent::Event(Event::Error(err)) => {
+                eyre::bail!("received error event: {err}");
+            }
             RuntimeEvent::Event(other) => {
                 tracing::warn!("received unknown event `{other:?}`");
             }

--- a/binaries/runtime/src/lib.rs
+++ b/binaries/runtime/src/lib.rs
@@ -189,7 +189,7 @@ async fn run(
                     bail!(err.wrap_err(format!(
                         "operator {}/{operator_id} raised an error",
                         node.id()
-                    )))
+                    )));
                 }
                 OperatorEvent::Panic(payload) => {
                     let message = payload
@@ -336,7 +336,9 @@ async fn run(
                     }
                 }
             }
-            RuntimeEvent::Event(Event::Error(err)) => eyre::bail!("received error event: {err}"),
+            RuntimeEvent::Event(Event::Error(err)) => {
+                eyre::bail!("received error event: {err}");
+            }
             RuntimeEvent::Event(other) => {
                 tracing::warn!("received unknown event `{other:?}`");
             }

--- a/binaries/runtime/src/operator/shared_lib.rs
+++ b/binaries/runtime/src/operator/shared_lib.rs
@@ -119,7 +119,7 @@ impl SharedLibraryOperator<'_> {
             let raw = match result.error {
                 Some(error) => {
                     let _ = init_done.send(Err(eyre!(error.to_string())));
-                    bail!("init_operator failed: {}", *error)
+                    bail!("init_operator failed: {}", *error);
                 }
                 None => operator_context,
             };
@@ -273,7 +273,9 @@ impl SharedLibraryOperator<'_> {
                 )
             };
             match error {
-                Some(error) => bail!("on_input failed: {}", *error),
+                Some(error) => {
+                    bail!("on_input failed: {}", *error);
+                }
                 None => match status {
                     DoraStatus::Continue => {}
                     DoraStatus::Stop => break StopReason::ExplicitStop,

--- a/binaries/runtime/src/operator/shared_lib.rs
+++ b/binaries/runtime/src/operator/shared_lib.rs
@@ -102,7 +102,7 @@ impl SharedLibraryOperator<'_> {
             let raw = match result.error {
                 Some(error) => {
                     let _ = init_done.send(Err(eyre!(error.to_string())));
-                    bail!("init_operator failed: {}", *error)
+                    bail!("init_operator failed: {}", *error);
                 }
                 None => operator_context,
             };
@@ -254,7 +254,9 @@ impl SharedLibraryOperator<'_> {
                 )
             };
             match error {
-                Some(error) => bail!("on_input failed: {}", *error),
+                Some(error) => {
+                    bail!("on_input failed: {}", *error);
+                }
                 None => match status {
                     DoraStatus::Continue => {}
                     DoraStatus::Stop => break StopReason::ExplicitStop,

--- a/libraries/core/src/build/git.rs
+++ b/libraries/core/src/build/git.rs
@@ -103,7 +103,7 @@ impl GitManager {
                 "the build directory is still in use by the following \
                     dataflows, please stop them before rebuilding: {}",
                 using.iter().join(", ")
-            );
+            )
         }
 
         let reuse = if self.clone_dir_ready(session_id, &clone_dir) {
@@ -293,7 +293,7 @@ impl GitFolder {
                             .log_message(LogLevel::Error, format!("{err:?}"))
                             .await;
                         cleanup_failed_clone(logger, &target_dir).await;
-                        bail!(err);
+                        bail!(err)
                     }
                 }
             }
@@ -345,7 +345,7 @@ impl GitFolder {
                     Ok(()) => target_dir,
                     Err(err) => {
                         cleanup_failed_clone(logger, &target_dir).await;
-                        bail!(err);
+                        bail!(err)
                     }
                 }
             }
@@ -379,7 +379,7 @@ impl GitFolder {
                     Ok(()) => target_dir,
                     Err(err) => {
                         cleanup_failed_clone(logger, &target_dir).await;
-                        bail!(err);
+                        bail!(err)
                     }
                 }
             }
@@ -432,14 +432,12 @@ impl GitFolder {
                         // in-progress set only covers one GitManager and the CLI
                         // builds with its own, so deleting here is how #2711
                         // wipes out a live build. Fail loudly, leave the dir.
-                        Err(err) => {
-                            bail!(
-                                "couldn't verify clone dir {} is on commit {commit_hash}: {err:?}; \
-                                 leaving it in place in case another build is writing it, \
-                                 please retry",
-                                dir.display()
-                            );
-                        }
+                        Err(err) => bail!(
+                            "couldn't verify clone dir {} is on commit {commit_hash}: {err:?}; \
+                             leaving it in place in case another build is writing it, \
+                             please retry",
+                            dir.display()
+                        ),
                     }
                 }
 

--- a/libraries/core/src/build/git.rs
+++ b/libraries/core/src/build/git.rs
@@ -103,7 +103,7 @@ impl GitManager {
                 "the build directory is still in use by the following \
                     dataflows, please stop them before rebuilding: {}",
                 using.iter().join(", ")
-            )
+            );
         }
 
         let reuse = if self.clone_dir_ready(session_id, &clone_dir) {
@@ -284,7 +284,7 @@ impl GitFolder {
                             .log_message(LogLevel::Error, format!("{err:?}"))
                             .await;
                         cleanup_failed_clone(logger, &target_dir).await;
-                        bail!(err)
+                        bail!(err);
                     }
                 }
             }
@@ -336,7 +336,7 @@ impl GitFolder {
                     Ok(()) => target_dir,
                     Err(err) => {
                         cleanup_failed_clone(logger, &target_dir).await;
-                        bail!(err)
+                        bail!(err);
                     }
                 }
             }
@@ -370,7 +370,7 @@ impl GitFolder {
                     Ok(()) => target_dir,
                     Err(err) => {
                         cleanup_failed_clone(logger, &target_dir).await;
-                        bail!(err)
+                        bail!(err);
                     }
                 }
             }
@@ -423,12 +423,14 @@ impl GitFolder {
                         // in-progress set only covers one GitManager and the CLI
                         // builds with its own, so deleting here is how #2711
                         // wipes out a live build. Fail loudly, leave the dir.
-                        Err(err) => bail!(
-                            "couldn't verify clone dir {} is on commit {commit_hash}: {err:?}; \
-                             leaving it in place in case another build is writing it, \
-                             please retry",
-                            dir.display()
-                        ),
+                        Err(err) => {
+                            bail!(
+                                "couldn't verify clone dir {} is on commit {commit_hash}: {err:?}; \
+                                 leaving it in place in case another build is writing it, \
+                                 please retry",
+                                dir.display()
+                            );
+                        }
                     }
                 }
 

--- a/libraries/core/src/build/git.rs
+++ b/libraries/core/src/build/git.rs
@@ -103,7 +103,7 @@ impl GitManager {
                 "the build directory is still in use by the following \
                     dataflows, please stop them before rebuilding: {}",
                 using.iter().join(", ")
-            )
+            );
         }
 
         let reuse = if self.clone_dir_ready(session_id, &clone_dir) {
@@ -293,7 +293,7 @@ impl GitFolder {
                             .log_message(LogLevel::Error, format!("{err:?}"))
                             .await;
                         cleanup_failed_clone(logger, &target_dir).await;
-                        bail!(err)
+                        bail!(err);
                     }
                 }
             }
@@ -345,7 +345,7 @@ impl GitFolder {
                     Ok(()) => target_dir,
                     Err(err) => {
                         cleanup_failed_clone(logger, &target_dir).await;
-                        bail!(err)
+                        bail!(err);
                     }
                 }
             }
@@ -379,7 +379,7 @@ impl GitFolder {
                     Ok(()) => target_dir,
                     Err(err) => {
                         cleanup_failed_clone(logger, &target_dir).await;
-                        bail!(err)
+                        bail!(err);
                     }
                 }
             }
@@ -432,12 +432,14 @@ impl GitFolder {
                         // in-progress set only covers one GitManager and the CLI
                         // builds with its own, so deleting here is how #2711
                         // wipes out a live build. Fail loudly, leave the dir.
-                        Err(err) => bail!(
-                            "couldn't verify clone dir {} is on commit {commit_hash}: {err:?}; \
-                             leaving it in place in case another build is writing it, \
-                             please retry",
-                            dir.display()
-                        ),
+                        Err(err) => {
+                            bail!(
+                                "couldn't verify clone dir {} is on commit {commit_hash}: {err:?}; \
+                                 leaving it in place in case another build is writing it, \
+                                 please retry",
+                                dir.display()
+                            );
+                        }
                     }
                 }
 

--- a/libraries/core/src/build/mod.rs
+++ b/libraries/core/src/build/mod.rs
@@ -281,7 +281,7 @@ pub fn validate_subdir(subdir: &str) -> eyre::Result<()> {
                 .chars()
                 .filter(|c| !c.is_control())
                 .collect::<String>()
-        )
+        );
     }
 }
 

--- a/libraries/core/src/descriptor/expand.rs
+++ b/libraries/core/src/descriptor/expand.rs
@@ -628,10 +628,12 @@ fn rewrite_module_input(
                         }))
                     }
                     None if optional_inputs.contains(&port_name) => Ok(None),
-                    None => bail!(
-                        "module input reference `_mod/{}` not found in module node inputs",
-                        port_name,
-                    ),
+                    None => {
+                        bail!(
+                            "module input reference `_mod/{}` not found in module node inputs",
+                            port_name,
+                        );
+                    }
                 }
             } else if inner_node_ids.contains(&source_str) {
                 // Internal cross-reference: prefix with module_id

--- a/libraries/core/src/descriptor/expand.rs
+++ b/libraries/core/src/descriptor/expand.rs
@@ -693,12 +693,10 @@ fn rewrite_module_input(
                         }))
                     }
                     None if optional_inputs.contains(&port_name) => Ok(None),
-                    None => {
-                        bail!(
-                            "module input reference `_mod/{}` not found in module node inputs",
-                            port_name,
-                        );
-                    }
+                    None => bail!(
+                        "module input reference `_mod/{}` not found in module node inputs",
+                        port_name,
+                    ),
                 }
             } else if inner_node_ids.contains(&source_str) {
                 // Internal cross-reference: prefix with module_id

--- a/libraries/core/src/descriptor/expand.rs
+++ b/libraries/core/src/descriptor/expand.rs
@@ -693,10 +693,12 @@ fn rewrite_module_input(
                         }))
                     }
                     None if optional_inputs.contains(&port_name) => Ok(None),
-                    None => bail!(
-                        "module input reference `_mod/{}` not found in module node inputs",
-                        port_name,
-                    ),
+                    None => {
+                        bail!(
+                            "module input reference `_mod/{}` not found in module node inputs",
+                            port_name,
+                        );
+                    }
                 }
             } else if inner_node_ids.contains(&source_str) {
                 // Internal cross-reference: prefix with module_id

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -355,7 +355,7 @@ fn node_kind_mut(node: &mut Node) -> eyre::Result<NodeKindMut<'_>> {
                 "module node `{}` must be expanded before resolution — \
                  call expand_modules() first",
                 node.id
-            )
+            );
         }
         NodeKind::Standard(_) => {
             let source = match (&node.git, &node.branch, &node.tag, &node.rev) {
@@ -369,7 +369,7 @@ fn node_kind_mut(node: &mut Node) -> eyre::Result<NodeKindMut<'_>> {
                         other @ (_, _, _) => {
                             eyre::bail!(
                                 "only one of `branch`, `tag`, and `rev` are allowed (got {other:?})"
-                            )
+                            );
                         }
                     };
                     NodeSource::GitBranch {
@@ -378,7 +378,7 @@ fn node_kind_mut(node: &mut Node) -> eyre::Result<NodeKindMut<'_>> {
                     }
                 }
                 (None, _, _, _) => {
-                    eyre::bail!("`git` source required when using branch, tag, or rev")
+                    eyre::bail!("`git` source required when using branch, tag, or rev");
                 }
             };
 
@@ -454,7 +454,7 @@ pub fn resolve_path(source: &str, working_dir: &Path) -> Result<PathBuf> {
     } else if let Ok(abs_path) = which::which(&path) {
         Ok(abs_path)
     } else {
-        bail!("Could not find source path {}", path.display())
+        bail!("Could not find source path {}", path.display());
     }
 }
 
@@ -500,7 +500,7 @@ pub fn resolve_path_confined(
         python_env_dir
             .map(|env| format!(" or its managed environment `{}`", env.display()))
             .unwrap_or_default(),
-    )
+    );
 }
 
 /// Canonicalize `candidate` and require it to stay under `root`.
@@ -605,7 +605,7 @@ impl NodeExt for Node {
                 eyre::bail!(
                     "node `{}` requires a `path`, `custom`, `operators`, `ros2`, or `module` field",
                     self.id
-                )
+                );
             }
             (None, None, None, Some(operator), None, None) => Ok(NodeKind::Operator(operator)),
             (None, None, Some(custom), None, None, None) => Ok(NodeKind::Custom(custom)),
@@ -617,7 +617,7 @@ impl NodeExt for Node {
                 eyre::bail!(
                     "node `{}` has multiple exclusive fields set, only one of `path`, `custom`, `operators`, `operator`, `ros2`, and `module` is allowed",
                     self.id
-                )
+                );
             }
         }
     }

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -360,7 +360,7 @@ fn node_kind_mut(node: &mut Node) -> eyre::Result<NodeKindMut<'_>> {
                 "module node `{}` must be expanded before resolution — \
                  call expand_modules() first",
                 node.id
-            )
+            );
         }
         NodeKind::Standard(_) => {
             let source = match (&node.git, &node.branch, &node.tag, &node.rev) {
@@ -374,7 +374,7 @@ fn node_kind_mut(node: &mut Node) -> eyre::Result<NodeKindMut<'_>> {
                         other @ (_, _, _) => {
                             eyre::bail!(
                                 "only one of `branch`, `tag`, and `rev` are allowed (got {other:?})"
-                            )
+                            );
                         }
                     };
                     NodeSource::GitBranch {
@@ -383,7 +383,7 @@ fn node_kind_mut(node: &mut Node) -> eyre::Result<NodeKindMut<'_>> {
                     }
                 }
                 (None, _, _, _) => {
-                    eyre::bail!("`git` source required when using branch, tag, or rev")
+                    eyre::bail!("`git` source required when using branch, tag, or rev");
                 }
             };
 
@@ -458,7 +458,7 @@ pub fn resolve_path(source: &str, working_dir: &Path) -> Result<PathBuf> {
     } else if let Ok(abs_path) = which::which(&path) {
         Ok(abs_path)
     } else {
-        bail!("Could not find source path {}", path.display())
+        bail!("Could not find source path {}", path.display());
     }
 }
 
@@ -504,7 +504,7 @@ pub fn resolve_path_confined(
         python_env_dir
             .map(|env| format!(" or its managed environment `{}`", env.display()))
             .unwrap_or_default(),
-    )
+    );
 }
 
 /// Canonicalize `candidate` and require it to stay under `root`.
@@ -586,7 +586,7 @@ impl NodeExt for Node {
                 eyre::bail!(
                     "node `{}` requires a `path`, `custom`, `operators`, `ros2`, or `module` field",
                     self.id
-                )
+                );
             }
             (None, None, None, Some(operator), None, None) => Ok(NodeKind::Operator(operator)),
             (None, None, Some(custom), None, None, None) => Ok(NodeKind::Custom(custom)),
@@ -598,7 +598,7 @@ impl NodeExt for Node {
                 eyre::bail!(
                     "node `{}` has multiple exclusive fields set, only one of `path`, `custom`, `operators`, `operator`, `ros2`, and `module` is allowed",
                     self.id
-                )
+                );
             }
         }
     }

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -355,7 +355,7 @@ fn node_kind_mut(node: &mut Node) -> eyre::Result<NodeKindMut<'_>> {
                 "module node `{}` must be expanded before resolution — \
                  call expand_modules() first",
                 node.id
-            );
+            )
         }
         NodeKind::Standard(_) => {
             let source = match (&node.git, &node.branch, &node.tag, &node.rev) {
@@ -369,7 +369,7 @@ fn node_kind_mut(node: &mut Node) -> eyre::Result<NodeKindMut<'_>> {
                         other @ (_, _, _) => {
                             eyre::bail!(
                                 "only one of `branch`, `tag`, and `rev` are allowed (got {other:?})"
-                            );
+                            )
                         }
                     };
                     NodeSource::GitBranch {
@@ -378,7 +378,7 @@ fn node_kind_mut(node: &mut Node) -> eyre::Result<NodeKindMut<'_>> {
                     }
                 }
                 (None, _, _, _) => {
-                    eyre::bail!("`git` source required when using branch, tag, or rev");
+                    eyre::bail!("`git` source required when using branch, tag, or rev")
                 }
             };
 
@@ -454,7 +454,7 @@ pub fn resolve_path(source: &str, working_dir: &Path) -> Result<PathBuf> {
     } else if let Ok(abs_path) = which::which(&path) {
         Ok(abs_path)
     } else {
-        bail!("Could not find source path {}", path.display());
+        bail!("Could not find source path {}", path.display())
     }
 }
 
@@ -500,7 +500,7 @@ pub fn resolve_path_confined(
         python_env_dir
             .map(|env| format!(" or its managed environment `{}`", env.display()))
             .unwrap_or_default(),
-    );
+    )
 }
 
 /// Canonicalize `candidate` and require it to stay under `root`.
@@ -605,7 +605,7 @@ impl NodeExt for Node {
                 eyre::bail!(
                     "node `{}` requires a `path`, `custom`, `operators`, `ros2`, or `module` field",
                     self.id
-                );
+                )
             }
             (None, None, None, Some(operator), None, None) => Ok(NodeKind::Operator(operator)),
             (None, None, Some(custom), None, None, None) => Ok(NodeKind::Custom(custom)),
@@ -617,7 +617,7 @@ impl NodeExt for Node {
                 eyre::bail!(
                     "node `{}` has multiple exclusive fields set, only one of `path`, `custom`, `operators`, `operator`, `ros2`, and `module` is allowed",
                     self.id
-                );
+                )
             }
         }
     }

--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -425,9 +425,7 @@ fn parse_byte_size(s: &str) -> eyre::Result<u64> {
         "KB" | "K" => 1024,
         "MB" | "M" => 1024 * 1024,
         "GB" | "G" => 1024 * 1024 * 1024,
-        _ => {
-            bail!("unknown byte size unit: '{unit}', expected B, KB, MB, or GB");
-        }
+        _ => bail!("unknown byte size unit: '{unit}', expected B, KB, MB, or GB"),
     };
     // Use integer parse when possible to avoid float rounding
     if let Ok(num) = num_str.parse::<u64>() {
@@ -474,11 +472,9 @@ fn parse_log_level(s: &str) -> eyre::Result<dora_message::common::LogLevelOrStdo
             log::Level::Trace,
         )),
         "stdout" => Ok(dora_message::common::LogLevelOrStdout::Stdout),
-        _ => {
-            bail!(
-                "invalid min_log_level: '{s}', expected one of: error, warn, info, debug, trace, stdout"
-            );
-        }
+        _ => bail!(
+            "invalid min_log_level: '{s}', expected one of: error, warn, info, debug, trace, stdout"
+        ),
     }
 }
 
@@ -569,7 +565,7 @@ assert dora.__version__=='{VERSION}',  'Python dora-rs should be {VERSION}, but 
         .wrap_err("Could not get exit status when checking python dora-rs")?;
 
     if !status.success() {
-        bail!("Something went wrong with Python dora-rs. {reinstall_command}");
+        bail!("Something went wrong with Python dora-rs. {reinstall_command}")
     }
 
     Ok(())
@@ -761,23 +757,19 @@ fn validate_ros2_qos(
     if let Some(d) = &qos.durability {
         match d.as_str() {
             "volatile" | "transient_local" => {}
-            _ => {
-                bail!(
-                    "node `{node_id}`: invalid QoS durability `{d}`, \
-                     expected \"volatile\" or \"transient_local\""
-                );
-            }
+            _ => bail!(
+                "node `{node_id}`: invalid QoS durability `{d}`, \
+                 expected \"volatile\" or \"transient_local\""
+            ),
         }
     }
     if let Some(l) = &qos.liveliness {
         match l.as_str() {
             "automatic" | "manual_by_participant" | "manual_by_topic" => {}
-            _ => {
-                bail!(
-                    "node `{node_id}`: invalid QoS liveliness `{l}`, \
-                     expected \"automatic\", \"manual_by_participant\", or \"manual_by_topic\""
-                );
-            }
+            _ => bail!(
+                "node `{node_id}`: invalid QoS liveliness `{l}`, \
+                 expected \"automatic\", \"manual_by_participant\", or \"manual_by_topic\""
+            ),
         }
     }
     if let Some(depth) = qos.keep_last

--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -407,7 +407,9 @@ fn parse_byte_size(s: &str) -> eyre::Result<u64> {
         "KB" | "K" => 1024,
         "MB" | "M" => 1024 * 1024,
         "GB" | "G" => 1024 * 1024 * 1024,
-        _ => bail!("unknown byte size unit: '{unit}', expected B, KB, MB, or GB"),
+        _ => {
+            bail!("unknown byte size unit: '{unit}', expected B, KB, MB, or GB");
+        }
     };
     // Use integer parse when possible to avoid float rounding
     if let Ok(num) = num_str.parse::<u64>() {
@@ -454,9 +456,11 @@ fn parse_log_level(s: &str) -> eyre::Result<dora_message::common::LogLevelOrStdo
             log::Level::Trace,
         )),
         "stdout" => Ok(dora_message::common::LogLevelOrStdout::Stdout),
-        _ => bail!(
-            "invalid min_log_level: '{s}', expected one of: error, warn, info, debug, trace, stdout"
-        ),
+        _ => {
+            bail!(
+                "invalid min_log_level: '{s}', expected one of: error, warn, info, debug, trace, stdout"
+            );
+        }
     }
 }
 
@@ -542,7 +546,7 @@ assert dora.__version__=='{VERSION}',  'Python dora-rs should be {VERSION}, but 
         .wrap_err("Could not get exit status when checking python dora-rs")?;
 
     if !status.success() {
-        bail!("Something went wrong with Python dora-rs. {reinstall_command}")
+        bail!("Something went wrong with Python dora-rs. {reinstall_command}");
     }
 
     Ok(())
@@ -734,19 +738,23 @@ fn validate_ros2_qos(
     if let Some(d) = &qos.durability {
         match d.as_str() {
             "volatile" | "transient_local" => {}
-            _ => bail!(
-                "node `{node_id}`: invalid QoS durability `{d}`, \
-                 expected \"volatile\" or \"transient_local\""
-            ),
+            _ => {
+                bail!(
+                    "node `{node_id}`: invalid QoS durability `{d}`, \
+                     expected \"volatile\" or \"transient_local\""
+                );
+            }
         }
     }
     if let Some(l) = &qos.liveliness {
         match l.as_str() {
             "automatic" | "manual_by_participant" | "manual_by_topic" => {}
-            _ => bail!(
-                "node `{node_id}`: invalid QoS liveliness `{l}`, \
-                 expected \"automatic\", \"manual_by_participant\", or \"manual_by_topic\""
-            ),
+            _ => {
+                bail!(
+                    "node `{node_id}`: invalid QoS liveliness `{l}`, \
+                     expected \"automatic\", \"manual_by_participant\", or \"manual_by_topic\""
+                );
+            }
         }
     }
     if let Some(depth) = qos.keep_last

--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -425,7 +425,9 @@ fn parse_byte_size(s: &str) -> eyre::Result<u64> {
         "KB" | "K" => 1024,
         "MB" | "M" => 1024 * 1024,
         "GB" | "G" => 1024 * 1024 * 1024,
-        _ => bail!("unknown byte size unit: '{unit}', expected B, KB, MB, or GB"),
+        _ => {
+            bail!("unknown byte size unit: '{unit}', expected B, KB, MB, or GB");
+        }
     };
     // Use integer parse when possible to avoid float rounding
     if let Ok(num) = num_str.parse::<u64>() {
@@ -472,9 +474,11 @@ fn parse_log_level(s: &str) -> eyre::Result<dora_message::common::LogLevelOrStdo
             log::Level::Trace,
         )),
         "stdout" => Ok(dora_message::common::LogLevelOrStdout::Stdout),
-        _ => bail!(
-            "invalid min_log_level: '{s}', expected one of: error, warn, info, debug, trace, stdout"
-        ),
+        _ => {
+            bail!(
+                "invalid min_log_level: '{s}', expected one of: error, warn, info, debug, trace, stdout"
+            );
+        }
     }
 }
 
@@ -565,7 +569,7 @@ assert dora.__version__=='{VERSION}',  'Python dora-rs should be {VERSION}, but 
         .wrap_err("Could not get exit status when checking python dora-rs")?;
 
     if !status.success() {
-        bail!("Something went wrong with Python dora-rs. {reinstall_command}")
+        bail!("Something went wrong with Python dora-rs. {reinstall_command}");
     }
 
     Ok(())
@@ -757,19 +761,23 @@ fn validate_ros2_qos(
     if let Some(d) = &qos.durability {
         match d.as_str() {
             "volatile" | "transient_local" => {}
-            _ => bail!(
-                "node `{node_id}`: invalid QoS durability `{d}`, \
-                 expected \"volatile\" or \"transient_local\""
-            ),
+            _ => {
+                bail!(
+                    "node `{node_id}`: invalid QoS durability `{d}`, \
+                     expected \"volatile\" or \"transient_local\""
+                );
+            }
         }
     }
     if let Some(l) = &qos.liveliness {
         match l.as_str() {
             "automatic" | "manual_by_participant" | "manual_by_topic" => {}
-            _ => bail!(
-                "node `{node_id}`: invalid QoS liveliness `{l}`, \
-                 expected \"automatic\", \"manual_by_participant\", or \"manual_by_topic\""
-            ),
+            _ => {
+                bail!(
+                    "node `{node_id}`: invalid QoS liveliness `{l}`, \
+                     expected \"automatic\", \"manual_by_participant\", or \"manual_by_topic\""
+                );
+            }
         }
     }
     if let Some(depth) = qos.keep_last

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -355,10 +355,12 @@ pub async fn open_zenoh_session_with_listen(
                 }
             }
         }
-        Err(std::env::VarError::NotUnicode(_)) => eyre::bail!(
-            "{} env variable is not valid unicode",
-            zenoh::Config::DEFAULT_CONFIG_PATH_ENV
-        ),
+        Err(std::env::VarError::NotUnicode(_)) => {
+            eyre::bail!(
+                "{} env variable is not valid unicode",
+                zenoh::Config::DEFAULT_CONFIG_PATH_ENV
+            );
+        }
     };
     Ok((zenoh_session, effective_listen_endpoint))
 }

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -507,10 +507,12 @@ pub async fn open_zenoh_session_with_listen(
                 }
             }
         }
-        Err(std::env::VarError::NotUnicode(_)) => eyre::bail!(
-            "{} env variable is not valid unicode",
-            zenoh::Config::DEFAULT_CONFIG_PATH_ENV
-        ),
+        Err(std::env::VarError::NotUnicode(_)) => {
+            eyre::bail!(
+                "{} env variable is not valid unicode",
+                zenoh::Config::DEFAULT_CONFIG_PATH_ENV
+            );
+        }
     };
     Ok((zenoh_session, effective_listen_endpoint))
 }

--- a/libraries/hub-client/src/config.rs
+++ b/libraries/hub-client/src/config.rs
@@ -207,7 +207,7 @@ pub(crate) fn validate_index_entry(index: &IndexConfig) -> eyre::Result<()> {
     }
     match (&index.git, &index.path) {
         (None, None) => {
-            eyre::bail!("index `{}` has neither `git` nor `path`", index.alias)
+            eyre::bail!("index `{}` has neither `git` nor `path`", index.alias);
         }
         (Some(git), path) => {
             crate::validate_git_url(git).with_context(|| format!("index `{}`", index.alias))?;

--- a/libraries/hub-client/src/index.rs
+++ b/libraries/hub-client/src/index.rs
@@ -99,11 +99,15 @@ impl SourceSpec {
                 }
                 Ok((git, rev))
             }
-            (None, None) if !self.binary.is_empty() => eyre::bail!(
-                "this version is published as prebuilt binaries only, which this \
-                 dora version does not support yet"
-            ),
-            _ => eyre::bail!("index entry has an incomplete git source (needs `git` + `rev`)"),
+            (None, None) if !self.binary.is_empty() => {
+                eyre::bail!(
+                    "this version is published as prebuilt binaries only, which this \
+                     dora version does not support yet"
+                );
+            }
+            _ => {
+                eyre::bail!("index entry has an incomplete git source (needs `git` + `rev`)");
+            }
         }
     }
 
@@ -196,10 +200,12 @@ impl IndexCatalog {
     fn confine(&self, path: &Path) -> eyre::Result<()> {
         match path.canonicalize() {
             Ok(real) if real.starts_with(&self.canonical_root) => Ok(()),
-            Ok(_) => eyre::bail!(
-                "index path `{}` escapes the catalog root (symlink?)",
-                path.display()
-            ),
+            Ok(_) => {
+                eyre::bail!(
+                    "index path `{}` escapes the catalog root (symlink?)",
+                    path.display()
+                );
+            }
             Err(_) => Ok(()),
         }
     }
@@ -363,7 +369,7 @@ impl IndexCatalog {
             } else {
                 available.join(", ")
             }
-        )
+        );
     }
 
     /// All packages in the catalog as `(namespace, name)` pairs. Directory

--- a/libraries/hub-client/src/index.rs
+++ b/libraries/hub-client/src/index.rs
@@ -99,11 +99,15 @@ impl SourceSpec {
                 }
                 Ok((git, rev))
             }
-            (None, None) if !self.binary.is_empty() => eyre::bail!(
-                "this version is published as prebuilt binaries only, which this \
-                 dora version does not support yet"
-            ),
-            _ => eyre::bail!("index entry has an incomplete git source (needs `git` + `rev`)"),
+            (None, None) if !self.binary.is_empty() => {
+                eyre::bail!(
+                    "this version is published as prebuilt binaries only, which this \
+                     dora version does not support yet"
+                );
+            }
+            _ => {
+                eyre::bail!("index entry has an incomplete git source (needs `git` + `rev`)");
+            }
         }
     }
 
@@ -401,7 +405,7 @@ impl IndexCatalog {
             } else {
                 available.join(", ")
             }
-        )
+        );
     }
 
     /// All packages in the catalog as `(namespace, name)` pairs. Directory


### PR DESCRIPTION
## Summary

Fixes `bail!` and `eyre::bail!` macro invocations that are used in expression position and trigger `semicolon_in_expressions_from_macros` on recent nightly Rust.

This lint is denied through `future_incompatible`, so recent nightly toolchains fail when checking or building `dora-cli`.

Closes #2835

## Background

This follows up on the reopened issue comment: https://github.com/dora-rs/dora/issues/2835#issuecomment-5082795113

There are two separate problems involved:

1. A rustc nightly ICE can occur while compiling `tokio` at higher release optimization levels.
2. Once the build proceeds past `tokio`, Dora still hits the original `bail!` macro compilation error.

This PR only addresses the Dora-specific `bail!` / `eyre::bail!` error. The `tokio` ICE appears to be a separate rustc nightly issue and is intentionally left out of scope.

## Validation

Tested locally on Windows MSVC:

- `cargo +nightly-2026-07-13 check -p dora-cli` on `main`: passes
- `cargo +nightly check -p dora-cli` on `main` with `rustc 1.99.0-nightly (da86f4d07 2026-07-24)`: fails with `semicolon_in_expressions_from_macros`
- `cargo +nightly check -p dora-cli` on this branch: passes
- `cargo +nightly check -p dora-cli --release` on this branch: passes
- `cargo +stable check -p dora-cli`: passes
- `cargo fmt --all -- --check`: passes
- `git diff --check`: passes

Additional note:

- `cargo +nightly build --release -p dora-cli` with `rustc 1.99.0-nightly (da86f4d07 2026-07-24)` still triggers a rustc ICE while compiling `tokio v1.53.1`.
- The same full release build passes with `nightly-2026-07-13`.
- This supports treating the `tokio` ICE as unrelated to this PR.