### PR TITLE
perf(daemon): early-out in note_output_sent_to_local_receivers when no deadlines/breakers

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -5287,6 +5287,15 @@ fn note_output_sent_to_local_receivers(
     clock: &HLC,
     ft_stats: Option<&FaultToleranceStats>,
 ) {
+    // Both side effects below are gated on a non-empty `input_deadlines`
+    // (deadline refresh) or `broken_inputs` (circuit-breaker recovery). When
+    // neither feature is configured — the common case — the whole loop is a
+    // no-op, so skip it entirely rather than paying a clock read plus a
+    // `subscribe_channels` lookup per receiver on every `OutputSent`.
+    if dataflow.input_deadlines.is_empty() && dataflow.broken_inputs.is_empty() {
+        return;
+    }
+
     let empty_set = BTreeSet::new();
     let output_id = OutputId(node_id, output_id);
     let local_receivers = dataflow.mappings.get(&output_id).unwrap_or(&empty_set);


### PR DESCRIPTION
## Issue

`note_output_sent_to_local_receivers` runs on **every** `OutputSent` message (the per-output notification). Its per-receiver loop has two possible effects:

- refreshing an input deadline — only when `input_deadlines` is non-empty, and
- circuit-breaker recovery — only when `broken_inputs` is non-empty.

Both inner branches already guard on those maps being non-empty. But in the common case where neither `input_timeout` deadlines nor circuit breakers are configured, the whole loop is a no-op — yet the function still did an `Instant::now()` clock read and, for every receiver, a `subscribe_channels` lookup plus a channel-capacity check, on every message.

## Fix

Add a single early return at the top of the function when both `input_deadlines` and `broken_inputs` are empty, skipping the clock read and the entire loop. Behavior is unchanged: the loop had no observable effect in that case.

## Validation

- `cargo test -p dora-daemon` passes, including the existing `note_output_sent` recovery tests — those configure `broken_inputs`, so they still exercise the loop past the new guard.
- `cargo clippy ... -D warnings` and `cargo fmt --all --check` pass.

---

⚠️ **This PR is machine-generated by Claude (Claude Code), an AI assistant.** Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2eu6P1CvTvoKdK9fK3ZSd

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2eu6P1CvTvoKdK9fK3ZSd)_