### PR TITLE
refactor(node): delegate scheduler correlation check to the canonical predicate

### DIFF
--- a/apis/rust/node/src/event_stream/scheduler.rs
+++ b/apis/rust/node/src/event_stream/scheduler.rs
@@ -7,7 +7,7 @@ use dora_message::{
     config::{DEFAULT_QUEUE_SIZE, QueuePolicy},
     daemon_to_node::NodeEvent,
     id::DataId,
-    metadata::{GOAL_ID, GOAL_STATUS, REQUEST_ID, get_string_param},
+    metadata::{GOAL_ID, GOAL_STATUS, REQUEST_ID, carries_pattern_correlation, get_string_param},
 };
 
 use super::thread::EventItem;
@@ -28,9 +28,13 @@ fn is_correlated(event: &EventItem) -> bool {
         EventItem::ZenohInput { metadata, .. } => &metadata.parameters,
         _ => return false,
     };
-    params.contains_key(REQUEST_ID)
-        || params.contains_key(GOAL_ID)
-        || params.contains_key(GOAL_STATUS)
+    // Delegate to the canonical definition in `dora_message` so the scheduler's
+    // eviction guard can never disagree with the send-side / receive-side /
+    // daemon-debug layers about which keys mark a message as pattern-correlated
+    // (see `carries_pattern_correlation`). Duplicating the key list here risked
+    // silently dropping service/action messages if a new correlation key were
+    // added to only one copy.
+    carries_pattern_correlation(params)
 }
 
 /// Outcome of `select_eviction`.


### PR DESCRIPTION
## Issue

The event-stream scheduler's `is_correlated` inlined the same three-key check (`request_id` / `goal_id` / `goal_status`) that `dora_message` already exposes as `carries_pattern_correlation`. That canonical function's own doc explicitly asks callers to keep it the single definition, so the send-side, node-receive-side, and daemon-debug layers can never disagree on what "pattern-correlated" means.

The scheduler is the one place that had drifted into a private copy. The two are identical today, so there is **no active bug** — but if a fourth correlation key were ever added to `carries_pattern_correlation`, the scheduler would keep treating those messages as non-correlated and could evict them under queue pressure, silently breaking the service/action request-response contract this eviction logic exists to protect (dora-rs/adora#145).

## Fix

Delegate `is_correlated` to `carries_pattern_correlation` and drop the duplicated key list. `REQUEST_ID`/`GOAL_ID`/`GOAL_STATUS` remain imported for the per-key structured fields in `log_correlation_drop`.

## Validation

- `cargo test -p dora-node-api` passes, including the existing scheduler eviction tests.
- `cargo clippy ... -D warnings` and `cargo fmt --all --check` pass.

---

⚠️ **This PR is machine-generated by Claude (Claude Code), an AI assistant.** Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2eu6P1CvTvoKdK9fK3ZSd

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2eu6P1CvTvoKdK9fK3ZSd)_