### PR TITLE
fix(node): accept off/0/false as disable spellings for DORA_RUNTIME_TYPE_CHECK

### DIFF
--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -61,11 +61,19 @@ enum RuntimeTypeCheck {
 
 impl RuntimeTypeCheck {
     fn from_env() -> Self {
-        match std::env::var("DORA_RUNTIME_TYPE_CHECK").as_deref() {
-            Ok("error") => Self::Error,
-            Ok("1" | "warn" | "true") => Self::Warn,
-            Ok("") | Err(_) => Self::Off,
-            Ok(other) => {
+        Self::from_value(std::env::var("DORA_RUNTIME_TYPE_CHECK").ok().as_deref())
+    }
+
+    /// Parse the `DORA_RUNTIME_TYPE_CHECK` value (`None` when the var is unset).
+    fn from_value(value: Option<&str>) -> Self {
+        match value {
+            Some("error") => Self::Error,
+            Some("1" | "warn" | "true" | "on") => Self::Warn,
+            // Accept the natural "disable" spellings without a warning: a user
+            // who sets `=0`/`=false`/`=off` to turn the feature off means to
+            // disable it, not to type an unrecognized value.
+            Some("" | "0" | "false" | "off") | None => Self::Off,
+            Some(other) => {
                 tracing::warn!(
                     "unknown DORA_RUNTIME_TYPE_CHECK value \"{other}\", \
                      expected \"warn\" or \"error\"; disabling runtime type check"
@@ -73,6 +81,41 @@ impl RuntimeTypeCheck {
                 Self::Off
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod runtime_type_check_tests {
+    use super::RuntimeTypeCheck;
+
+    #[test]
+    fn parses_enable_spellings() {
+        for v in ["1", "warn", "true", "on"] {
+            assert_eq!(
+                RuntimeTypeCheck::from_value(Some(v)),
+                RuntimeTypeCheck::Warn
+            );
+        }
+        assert_eq!(
+            RuntimeTypeCheck::from_value(Some("error")),
+            RuntimeTypeCheck::Error
+        );
+    }
+
+    #[test]
+    fn disable_spellings_and_unset_are_off() {
+        for v in ["", "0", "false", "off"] {
+            assert_eq!(RuntimeTypeCheck::from_value(Some(v)), RuntimeTypeCheck::Off);
+        }
+        assert_eq!(RuntimeTypeCheck::from_value(None), RuntimeTypeCheck::Off);
+    }
+
+    #[test]
+    fn unknown_value_falls_back_to_off() {
+        assert_eq!(
+            RuntimeTypeCheck::from_value(Some("maybe")),
+            RuntimeTypeCheck::Off
+        );
     }
 }
 


### PR DESCRIPTION
## Issue

`RuntimeTypeCheck::from_env` accepted `1`/`warn`/`true` (→ warn) and `error`, and treated the empty string / unset as `Off`. But the natural "disable" spellings `0`, `false`, and `off` fell into the unknown-value arm, logging:

```
unknown DORA_RUNTIME_TYPE_CHECK value "false", expected "warn" or "error"; disabling runtime type check
```

So a user who set `DORA_RUNTIME_TYPE_CHECK=false` to turn the feature off got a warning implying they had mistyped — even though the resulting behavior (disabled) was exactly what they asked for.

## Fix

Treat `` / `0` / `false` / `off` as `Off` without a warning, and accept `on` alongside the existing enable spellings for symmetry. Genuinely unrecognized values still warn and disable, as before.

The env read is split into a pure `from_value(Option<&str>)` helper so parsing is unit-testable without mutating process-global env state.

## Validation

- Added unit tests covering enable spellings, disable spellings, unset (`None`), and an unknown value.
- `cargo test -p dora-node-api`, `cargo clippy ... -D warnings`, and `cargo fmt --all --check` pass.

---

⚠️ **This PR is machine-generated by Claude (Claude Code), an AI assistant.** Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2eu6P1CvTvoKdK9fK3ZSd

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2eu6P1CvTvoKdK9fK3ZSd)_