### PR TITLE
fix(cli): validate node name in `dora new --kind node`

### DIFF
--- a/binaries/cli/src/template/python/mod.rs
+++ b/binaries/cli/src/template/python/mod.rs
@@ -39,6 +39,16 @@ fn create_custom_node(
     path: Option<PathBuf>,
     main: &str,
 ) -> Result<(), eyre::ErrReport> {
+    // Reject names that would turn into path separators or non-ASCII module
+    // directories, mirroring the validation in `create_dataflow`. Spaces are
+    // fine — they are normalized to `-`/`_` below.
+    if name.contains('/') {
+        bail!("node name must not contain `/` separators");
+    }
+    if !name.is_ascii() {
+        bail!("node name must be ASCII");
+    }
+
     // create directories
     let root = path.unwrap_or_else(|| PathBuf::from(name.replace(" ", "-")));
     let module_path = root.join(name.replace(" ", "_").replace("-", "_"));


### PR DESCRIPTION
## Issue

`create_dataflow` rejects names containing `/` or non-ASCII characters, but the `--kind node` path (`create_custom_node`) had no such guard. It built directories straight from the raw name via the non-recursive `fs::create_dir`, so:

```
dora new --lang python --kind node a/b
```

failed with a confusing "failed to create root directory" (or, if `a` already existed, silently created a nested path the user didn't intend). Non-ASCII names were likewise unvalidated.

## Fix

Apply the same `contains('/')` / `is_ascii()` checks that `create_dataflow` already uses, with clear error messages. Spaces remain allowed — they're normalized to `-`/`_` — so the internal `create_dataflow` callers (`"talker 1"`, `"listener 1"`, …) are unaffected.

## Validation

- `cargo build -p dora-cli`, `cargo clippy ... -D warnings`, and `cargo fmt --all --check` pass.
- The `dora new --kind dataflow` template path still generates its custom nodes (its calls use space-separated ASCII names, which pass validation).

---

⚠️ **This PR is machine-generated by Claude (Claude Code), an AI assistant.** Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2eu6P1CvTvoKdK9fK3ZSd

---
_Generated by [Claude Code](https://claude.ai/code/session_01D2eu6P1CvTvoKdK9fK3ZSd)_