### PR TITLE
fix(core): fall back to non-multicast zenoh discovery when scouting bind fails

### DIFF
--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -342,12 +342,29 @@ pub async fn open_zenoh_session_with_listen(
                 }
                 Err(err) => {
                     warn!(
-                        "failed to open tuned zenoh session ({err}), retrying with default config"
+                        "failed to open tuned zenoh session ({err}), retrying with \
+                         multicast scouting disabled"
                     );
                     // Default fallback has no listener; `effective_listen_endpoint`
                     // stays `None` so peers don't try to reach a bind that isn't
                     // there (#1856).
-                    let zenoh_config = zenoh::Config::default();
+                    //
+                    // Disable multicast scouting on the retry. The most common open
+                    // failure is the scouting socket failing to bind its multicast
+                    // group (`224.0.0.224:7446`) — e.g. when a busy DDS/ROS2
+                    // multicast graph (a full TurtleBot3 / nav2 stack) saturates the
+                    // multicast networking. A plain `Config::default()` retry keeps
+                    // multicast enabled, re-attempts the same failing bind, and takes
+                    // the whole dataflow down. Gossip + explicit connect endpoints
+                    // still cover discovery for co-located and connect-configured
+                    // setups, so degrading to non-multicast here keeps dora running
+                    // where it would otherwise fail outright.
+                    let mut zenoh_config = zenoh::Config::default();
+                    if let Err(err) =
+                        zenoh_config.insert_json5("scouting/multicast/enabled", "false")
+                    {
+                        warn!("failed to disable zenoh scouting/multicast on fallback: {err}");
+                    }
                     zenoh::open(zenoh_config)
                         .await
                         .map_err(|e| eyre!(e))


### PR DESCRIPTION
## Summary

`open_zenoh_session_with_listen` (`libraries/core/src/topics.rs`, called from the
daemon at `binaries/daemon/src/lib.rs:1225`) opens the tuned zenoh session and,
on failure, retried with a plain `zenoh::Config::default()`. The default keeps
**multicast scouting enabled**, so when the failure's *cause* is the scouting
socket failing to bind its multicast group (`224.0.0.224:7446`), the retry
re-attempts the identical bind, fails again, and the dataflow aborts at startup.

This bites when dora shares one network namespace with a busy DDS/ROS 2 multicast
graph — i.e. **dev containers / CI / any co-located `docker`-netns setup** (the
existing comment in `topics.rs` already notes multicast scouting is "broken in
dev containers and many CI environments"). Reproduced in `docker/ros2dev` (dora +
ROS 2 in one netns) alongside a ~25-participant DDS graph.

## Fix

Disable multicast scouting on the **fallback retry** only. Gossip + explicit
connect endpoints (`DORA_ZENOH_CONNECT`) still cover discovery for co-located and
connect-configured setups, so degrading to non-multicast keeps dora running where
it would otherwise fail outright. The **primary open is unchanged** — normal
(uncontended) environments still get multicast by default and the fallback never
triggers. It's strictly safer than today: the fallback runs only *after* the
primary already failed to bind multicast, so a multicast-dependent setup wasn't
getting multicast on that attempt anyway.

## Scope — what this does and does NOT fix

This is the **dora daemon zenoh-transport** layer only. It does **not** touch the
ROS 2 bridge's DDS path (`Ros2Transport::Dds` / `Ros2Context` default), which
opens no zenoh session at all.

There is a **separate** discovery bug with a confusingly similar ~50% rate: the
ROS 2 bridge's **RustDDS discovery** going silently empty under DDS domain
contention (process healthy, subscription just receives nothing — no bind error,
no daemon required). **This PR does not address that**; it lives at the
`ros2_client`/`rustdds` layer, not in dora's zenoh session. The two share an
environmental cause (multicast contention) but are distinct code paths.

Host deployments where dora and ROS 2 do **not** share a netns are not exposed to
the failure this PR fixes (measured: 10/10 dataflow starts with and without
`ZENOH_CONFIG` against a live 32-node graph, zero bind errors) — for those, the
DDS-layer bug above is the relevant one.

## Validation

`rust-ros2-dataflow` bridge example vs a ~25-participant DDS graph, 12 runs each,
in `docker/ros2dev` (dora + ROS 2 share one netns):

| Condition | Dataflow starts |
|---|---|
| clean graph, multicast on (main) | 11/12 |
| **busy graph, multicast on (main)** | **0/12** — all fail on `224.0.0.224:7446 Address already in use` |
| **busy graph, this PR** | **12/12** — primary fails, fallback logs `retrying with multicast scouting disabled`, dataflow finishes |
| clean graph, this PR | unchanged (fallback never triggers) |

`cargo fmt` / `cargo clippy -p dora-core -- -D warnings` clean.

A deterministic unit test isn't practical (triggering the fallback needs a
contended-multicast environment where the primary bind fails), so this is
validated by the reproduction above.

## Workaround (no rebuild)

Set `ZENOH_CONFIG` to a config with `scouting: { multicast: { enabled: false } }`,
or set `DORA_ZENOH_CONNECT`, to opt out of multicast scouting directly.