### PR TITLE
feat(ros2-bridge): port to ros2-client 0.10.1 and RustDDS 0.14

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1145,7 +1145,33 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        platform: [macos-latest, windows-latest]
+        include:
+          - platform: macos-latest
+            # macOS links `pnet` fine, so it keeps full ROS2 bridge coverage.
+            ros2_excludes: ""
+          - platform: windows-latest
+            # RustDDS 0.11.5+ depends unconditionally on `pnet`, and
+            # `pnet_datalink` declares `#[link(name = "Packet")]` on Windows
+            # (see its `src/bindings/winpcap.rs`). Linking therefore needs
+            # `Packet.lib` from the Npcap/WinPcap SDK, which is not installed on
+            # GitHub's Windows runners:
+            # https://github.com/Atostek/RustDDS/issues/375 (still open).
+            #
+            # `Packet.lib` is only required at *link* time, so the `cargo check`
+            # steps below are unaffected and stay unexcluded — as does the
+            # `cross-check` job's `x86_64-pc-windows-gnu` target, which also
+            # only runs `cargo check`. Just the steps that produce linked
+            # artifacts need these excludes.
+            #
+            # This is the exact set of crates that transitively pull RustDDS
+            # (`cargo tree -e normal`); `dora-ros2-bridge-msg-gen`,
+            # `dora-cli`, and `dora-daemon` do not, so Windows still covers
+            # them. `dora-ros2-bridge-python` is already excluded below.
+            ros2_excludes: >-
+              --exclude dora-ros2-bridge
+              --exclude dora-ros2-bridge-arrow
+              --exclude dora-ros2-bridge-node
+              --exclude rust-ros2-example-node
       fail-fast: false
     steps:
       - uses: actions/checkout@v6
@@ -1170,6 +1196,7 @@ jobs:
           --exclude dora-node-api-python
           --exclude dora-operator-api-python
           --exclude dora-ros2-bridge-python
+          ${{ matrix.ros2_excludes }}
       - name: Test
         run: >
           cargo test --all
@@ -1178,6 +1205,7 @@ jobs:
           --exclude dora-ros2-bridge-python
           --exclude dora-cli-api-python
           --exclude dora-examples
+          ${{ matrix.ros2_excludes }}
 
       # ===== Tier 0 CLI smoke gates =====
       # Fast per-platform checks against the 80% CLI coverage gap in #215.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1176,7 +1176,33 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        platform: [macos-latest, windows-latest]
+        include:
+          - platform: macos-latest
+            # macOS links `pnet` fine, so it keeps full ROS2 bridge coverage.
+            ros2_excludes: ""
+          - platform: windows-latest
+            # RustDDS 0.11.5+ depends unconditionally on `pnet`, and
+            # `pnet_datalink` declares `#[link(name = "Packet")]` on Windows
+            # (see its `src/bindings/winpcap.rs`). Linking therefore needs
+            # `Packet.lib` from the Npcap/WinPcap SDK, which is not installed on
+            # GitHub's Windows runners:
+            # https://github.com/Atostek/RustDDS/issues/375 (still open).
+            #
+            # `Packet.lib` is only required at *link* time, so the `cargo check`
+            # steps below are unaffected and stay unexcluded — as does the
+            # `cross-check` job's `x86_64-pc-windows-gnu` target, which also
+            # only runs `cargo check`. Just the steps that produce linked
+            # artifacts need these excludes.
+            #
+            # This is the exact set of crates that transitively pull RustDDS
+            # (`cargo tree -e normal`); `dora-ros2-bridge-msg-gen`,
+            # `dora-cli`, and `dora-daemon` do not, so Windows still covers
+            # them. `dora-ros2-bridge-python` is already excluded below.
+            ros2_excludes: >-
+              --exclude dora-ros2-bridge
+              --exclude dora-ros2-bridge-arrow
+              --exclude dora-ros2-bridge-node
+              --exclude rust-ros2-example-node
       fail-fast: false
     steps:
       - uses: actions/checkout@v6
@@ -1201,6 +1227,7 @@ jobs:
           --exclude dora-node-api-python
           --exclude dora-operator-api-python
           --exclude dora-ros2-bridge-python
+          ${{ matrix.ros2_excludes }}
       - name: Test
         run: >
           cargo test --all
@@ -1209,6 +1236,7 @@ jobs:
           --exclude dora-ros2-bridge-python
           --exclude dora-cli-api-python
           --exclude dora-examples
+          ${{ matrix.ros2_excludes }}
 
       # ===== Tier 0 CLI smoke gates =====
       # Fast per-platform checks against the 80% CLI coverage gap in #215.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1176,33 +1176,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        include:
-          - platform: macos-latest
-            # macOS links `pnet` fine, so it keeps full ROS2 bridge coverage.
-            ros2_excludes: ""
-          - platform: windows-latest
-            # RustDDS 0.11.5+ depends unconditionally on `pnet`, and
-            # `pnet_datalink` declares `#[link(name = "Packet")]` on Windows
-            # (see its `src/bindings/winpcap.rs`). Linking therefore needs
-            # `Packet.lib` from the Npcap/WinPcap SDK, which is not installed on
-            # GitHub's Windows runners:
-            # https://github.com/Atostek/RustDDS/issues/375 (still open).
-            #
-            # `Packet.lib` is only required at *link* time, so the `cargo check`
-            # steps below are unaffected and stay unexcluded — as does the
-            # `cross-check` job's `x86_64-pc-windows-gnu` target, which also
-            # only runs `cargo check`. Just the steps that produce linked
-            # artifacts need these excludes.
-            #
-            # This is the exact set of crates that transitively pull RustDDS
-            # (`cargo tree -e normal`); `dora-ros2-bridge-msg-gen`,
-            # `dora-cli`, and `dora-daemon` do not, so Windows still covers
-            # them. `dora-ros2-bridge-python` is already excluded below.
-            ros2_excludes: >-
-              --exclude dora-ros2-bridge
-              --exclude dora-ros2-bridge-arrow
-              --exclude dora-ros2-bridge-node
-              --exclude rust-ros2-example-node
+        platform: [macos-latest, windows-latest]
       fail-fast: false
     steps:
       - uses: actions/checkout@v6
@@ -1227,7 +1201,6 @@ jobs:
           --exclude dora-node-api-python
           --exclude dora-operator-api-python
           --exclude dora-ros2-bridge-python
-          ${{ matrix.ros2_excludes }}
       - name: Test
         run: >
           cargo test --all
@@ -1236,7 +1209,6 @@ jobs:
           --exclude dora-ros2-bridge-python
           --exclude dora-cli-api-python
           --exclude dora-examples
-          ${{ matrix.ros2_excludes }}
 
       # ===== Tier 0 CLI smoke gates =====
       # Fast per-platform checks against the 80% CLI coverage gap in #215.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -857,13 +857,13 @@ dependencies = [
 
 [[package]]
 name = "cdr-encoding"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f0cdb643d85bb03b1b786ab8d332747f386f0a25b19367d559b437f44f1e46"
+checksum = "7cd0f96619d833f771daff46c9755785f6fdea3d9ff67ec329f52f66936b0d6d"
 dependencies = [
  "byteorder",
  "log",
- "paste",
+ "pastey",
  "serde",
  "serde_repr",
  "static_assertions",
@@ -3708,9 +3708,9 @@ dependencies = [
 
 [[package]]
 name = "if-addrs"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+checksum = "bf39cc0423ee66021dc5eccface85580e4a001e0c5288bae8bea7ecb69225e90"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -4554,9 +4554,9 @@ dependencies = [
 
 [[package]]
 name = "md5"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
 
 [[package]]
 name = "memchr"
@@ -5266,6 +5266,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5530,6 +5536,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pnet"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "682396b533413cc2e009fbb48aadf93619a149d3e57defba19ff50ce0201bd0d"
+dependencies = [
+ "ipnetwork",
+ "pnet_base",
+ "pnet_datalink",
+ "pnet_packet",
+ "pnet_sys",
+ "pnet_transport",
+]
+
+[[package]]
 name = "pnet_base"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5552,6 +5572,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "pnet_macros"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13325ac86ee1a80a480b0bc8e3d30c25d133616112bb16e86f712dcf8a71c863"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "pnet_macros_support"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed67a952585d509dd0003049b1fc56b982ac665c8299b124b90ea2bdb3134ab"
+dependencies = [
+ "pnet_base",
+]
+
+[[package]]
+name = "pnet_packet"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c96ebadfab635fcc23036ba30a7d33a80c39e8461b8bd7dc7bb186acb96560f"
+dependencies = [
+ "glob",
+ "pnet_base",
+ "pnet_macros",
+ "pnet_macros_support",
+]
+
+[[package]]
 name = "pnet_sys"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5559,6 +5612,18 @@ checksum = "7d4643d3d4db6b08741050c2f3afa9a892c4244c085a72fcda93c9c2c9a00f4b"
 dependencies = [
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "pnet_transport"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f604d98bc2a6591cf719b58d3203fd882bdd6bf1db696c4ac97978e9f4776bf"
+dependencies = [
+ "libc",
+ "pnet_base",
+ "pnet_packet",
+ "pnet_sys",
 ]
 
 [[package]]
@@ -6315,9 +6380,9 @@ dependencies = [
 
 [[package]]
 name = "ros2-client"
-version = "0.8.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15b491a0c37fb42f0e6cdcee24b2aa427acb298658576073920f4b8529f7012"
+checksum = "2465ff4307d2c74e86ff2ae1f1219d03e1d764d94c553e303dc790c5d8ff6748"
 dependencies = [
  "async-channel",
  "bstr",
@@ -6464,9 +6529,9 @@ dependencies = [
 
 [[package]]
 name = "rustdds"
-version = "0.11.4"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f3fe51148e1490a88b20d2148ceb14d5a35fc96732c147bde23f01dffa6ebe"
+checksum = "679e56ae1ec6eb11214e965875e732ef5fd265e63d82200f4aa7cd7f43b1c1d5"
 dependencies = [
  "bit-vec 0.8.0",
  "byteorder",
@@ -6484,13 +6549,16 @@ dependencies = [
  "mio 0.6.23",
  "mio 0.8.11",
  "mio-extras",
+ "nix 0.29.0",
  "num-derive",
  "num-traits",
- "paste",
+ "pastey",
+ "pnet",
+ "pnet_sys",
  "rand 0.9.5",
  "serde",
  "serde_repr",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "socketpair",
  "speedy",
  "static_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,6 +725,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-vec"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5727b15fa97d4f4fee0a3b7c3d550ed0269f54329207b86388de918604e31269"
+dependencies = [
+ "borsh",
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,6 +774,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "borsh"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases 0.2.2",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f347189c62a579b8cd5f80714efa178f52e461dc2e6d701d264f5ff22e566c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1591,36 +1625,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.119",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1638,22 +1648,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.119",
 ]
@@ -1750,37 +1749,6 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
-dependencies = [
- "derive_builder_core",
  "syn 2.0.119",
 ]
 
@@ -1896,6 +1864,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "dlopen2"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4"
+dependencies = [
+ "libc",
+ "once_cell",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3267,17 +3246,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getset"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "git-version"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3707,16 +3675,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "if-addrs"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf39cc0423ee66021dc5eccface85580e4a001e0c5288bae8bea7ecb69225e90"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3823,7 +3781,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "indoc",
  "proc-macro2",
  "quote",
@@ -3840,16 +3798,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-extras"
-version = "0.18.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
-dependencies = [
- "io-lifetimes",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "io-kit-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3858,12 +3806,6 @@ dependencies = [
  "core-foundation-sys",
  "mach2",
 ]
-
-[[package]]
-name = "io-lifetimes"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
 name = "iovec"
@@ -4346,17 +4288,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
-name = "local-ip-address"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa08fb2b1ec3ea84575e94b489d06d4ce0cbf052d12acd515838f50e3c3d63e3"
-dependencies = [
- "libc",
- "neli",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4426,6 +4357,12 @@ checksum = "8b8c72594ac26bfd34f2d99dfced2edfaddfe8a476e3ff2ca0eb293d925c4f83"
 dependencies = [
  "twox-hash",
 ]
+
+[[package]]
+name = "mac-addr"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d25b0e0b648a86960ac23b7ad4abb9717601dec6f66c165f5b037f3f03065f"
 
 [[package]]
 name = "mac_address"
@@ -4622,18 +4559,6 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "mio"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
@@ -4710,35 +4635,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
-name = "neli"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f9786d56d972959e1408b6a93be6af13b9c1392036c5c1fafa08a1b0c6ee87"
-dependencies = [
- "bitflags 2.13.1",
- "byteorder",
- "derive_builder",
- "getset",
- "libc",
- "log",
- "neli-proc-macros",
- "parking_lot",
-]
-
-[[package]]
-name = "neli-proc-macros"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d8d08c6e98f20a62417478ebf7be8e1425ec9acecc6f63e22da633f6b71609"
-dependencies = [
- "either",
- "proc-macro2",
- "quote",
- "serde",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "net2"
 version = "0.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4747,6 +4643,63 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "netdev"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "569dfbdd2efd771b24ec9bb57f956e04d4fbfc72f62b2f11961723f9b3f4b020"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "dlopen2",
+ "ipnet",
+ "libc",
+ "mac-addr",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-sys",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-wlan",
+ "objc2-foundation",
+ "objc2-system-configuration",
+ "once_cell",
+ "plist",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "netlink-packet-core"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b897d7bd4f0af82e68d40d0344cf37e97f9c97ddf74a098de3e4da05e96ca395"
+dependencies = [
+ "paste",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2288fcb784eb3defd5fb16f4c4160d5f477de192eac730f43e1d11c24d9a007"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
+ "log",
+ "netlink-packet-core",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
+dependencies = [
+ "bytes",
+ "libc",
+ "log",
 ]
 
 [[package]]
@@ -4783,6 +4736,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "cfg_aliases 0.2.2",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -4989,8 +4943,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.13.1",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
+]
+
+[[package]]
+name = "objc2-core-wlan"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e34919aba0d701380d911702455038a8a3587467fe0141d6a71501e7ffe48"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-security",
+ "objc2-security-foundation",
 ]
 
 [[package]]
@@ -5006,7 +4976,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.1",
+ "block2",
+ "libc",
  "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -5028,6 +5001,35 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-security"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-security-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef76382e9cedd18123099f17638715cc3d81dba3637d4c0d39ab69df2ef345a5"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -5508,6 +5510,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "plist"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
+dependencies = [
+ "base64",
+ "indexmap 2.14.0",
+ "quick-xml 0.41.0",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5536,20 +5551,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pnet"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "682396b533413cc2e009fbb48aadf93619a149d3e57defba19ff50ce0201bd0d"
-dependencies = [
- "ipnetwork",
- "pnet_base",
- "pnet_datalink",
- "pnet_packet",
- "pnet_sys",
- "pnet_transport",
-]
-
-[[package]]
 name = "pnet_base"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5572,39 +5573,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pnet_macros"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13325ac86ee1a80a480b0bc8e3d30c25d133616112bb16e86f712dcf8a71c863"
-dependencies = [
- "proc-macro2",
- "quote",
- "regex",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "pnet_macros_support"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed67a952585d509dd0003049b1fc56b982ac665c8299b124b90ea2bdb3134ab"
-dependencies = [
- "pnet_base",
-]
-
-[[package]]
-name = "pnet_packet"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c96ebadfab635fcc23036ba30a7d33a80c39e8461b8bd7dc7bb186acb96560f"
-dependencies = [
- "glob",
- "pnet_base",
- "pnet_macros",
- "pnet_macros_support",
-]
-
-[[package]]
 name = "pnet_sys"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5612,18 +5580,6 @@ checksum = "7d4643d3d4db6b08741050c2f3afa9a892c4244c085a72fcda93c9c2c9a00f4b"
 dependencies = [
  "libc",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "pnet_transport"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f604d98bc2a6591cf719b58d3203fd882bdd6bf1db696c4ac97978e9f4776bf"
-dependencies = [
- "libc",
- "pnet_base",
- "pnet_packet",
- "pnet_sys",
 ]
 
 [[package]]
@@ -6380,9 +6336,9 @@ dependencies = [
 
 [[package]]
 name = "ros2-client"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2465ff4307d2c74e86ff2ae1f1219d03e1d764d94c553e303dc790c5d8ff6748"
+checksum = "3eac908ed717bbd6aab755b45d9002593514907a48ccef8b7d480e63d4f2422c"
 dependencies = [
  "async-channel",
  "bstr",
@@ -6391,7 +6347,7 @@ dependencies = [
  "chrono",
  "clap",
  "futures",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "lazy_static",
  "libc",
  "log",
@@ -6529,11 +6485,11 @@ dependencies = [
 
 [[package]]
 name = "rustdds"
-version = "0.13.1"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "679e56ae1ec6eb11214e965875e732ef5fd265e63d82200f4aa7cd7f43b1c1d5"
+checksum = "3d287a6d1381823ac83093b3d66a503ac34cd103e9fdf38d5f6862b940d6a736"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec 0.10.1",
  "byteorder",
  "bytes",
  "cdr-encoding",
@@ -6541,25 +6497,19 @@ dependencies = [
  "chrono",
  "enumflags2",
  "futures",
- "if-addrs",
- "io-extras",
- "local-ip-address",
  "log",
  "md5",
  "mio 0.6.23",
- "mio 0.8.11",
  "mio-extras",
- "nix 0.29.0",
+ "netdev",
+ "nix 0.31.3",
  "num-derive",
  "num-traits",
  "pastey",
- "pnet",
- "pnet_sys",
  "rand 0.9.5",
  "serde",
  "serde_repr",
  "socket2 0.6.5",
- "socketpair",
  "speedy",
  "static_assertions",
  "thiserror 2.0.19",
@@ -7038,7 +6988,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -7304,19 +7254,6 @@ checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "socketpair"
-version = "0.19.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20296a054f6fb573c1f73e49b0e3afd1efcc643548928fc9c21144f5ecf4f7e3"
-dependencies = [
- "io-extras",
- "io-lifetimes",
- "rustix",
- "uuid",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9110,27 +9047,9 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -9151,21 +9070,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -9221,12 +9125,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -9245,12 +9143,6 @@ checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -9266,12 +9158,6 @@ name = "windows_i686_gnu"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9305,12 +9191,6 @@ checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -9329,12 +9209,6 @@ checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
@@ -9344,12 +9218,6 @@ name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -9368,12 +9236,6 @@ name = "windows_x86_64_msvc"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -857,13 +857,13 @@ dependencies = [
 
 [[package]]
 name = "cdr-encoding"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f0cdb643d85bb03b1b786ab8d332747f386f0a25b19367d559b437f44f1e46"
+checksum = "7cd0f96619d833f771daff46c9755785f6fdea3d9ff67ec329f52f66936b0d6d"
 dependencies = [
  "byteorder",
  "log",
- "paste",
+ "pastey",
  "serde",
  "serde_repr",
  "static_assertions",
@@ -3687,9 +3687,9 @@ dependencies = [
 
 [[package]]
 name = "if-addrs"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+checksum = "bf39cc0423ee66021dc5eccface85580e4a001e0c5288bae8bea7ecb69225e90"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -4525,9 +4525,9 @@ dependencies = [
 
 [[package]]
 name = "md5"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
 
 [[package]]
 name = "memchr"
@@ -5224,6 +5224,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5488,6 +5494,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pnet"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "682396b533413cc2e009fbb48aadf93619a149d3e57defba19ff50ce0201bd0d"
+dependencies = [
+ "ipnetwork",
+ "pnet_base",
+ "pnet_datalink",
+ "pnet_packet",
+ "pnet_sys",
+ "pnet_transport",
+]
+
+[[package]]
 name = "pnet_base"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5510,6 +5530,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "pnet_macros"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13325ac86ee1a80a480b0bc8e3d30c25d133616112bb16e86f712dcf8a71c863"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "pnet_macros_support"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed67a952585d509dd0003049b1fc56b982ac665c8299b124b90ea2bdb3134ab"
+dependencies = [
+ "pnet_base",
+]
+
+[[package]]
+name = "pnet_packet"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c96ebadfab635fcc23036ba30a7d33a80c39e8461b8bd7dc7bb186acb96560f"
+dependencies = [
+ "glob",
+ "pnet_base",
+ "pnet_macros",
+ "pnet_macros_support",
+]
+
+[[package]]
 name = "pnet_sys"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5517,6 +5570,18 @@ checksum = "7d4643d3d4db6b08741050c2f3afa9a892c4244c085a72fcda93c9c2c9a00f4b"
 dependencies = [
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "pnet_transport"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f604d98bc2a6591cf719b58d3203fd882bdd6bf1db696c4ac97978e9f4776bf"
+dependencies = [
+ "libc",
+ "pnet_base",
+ "pnet_packet",
+ "pnet_sys",
 ]
 
 [[package]]
@@ -6273,9 +6338,9 @@ dependencies = [
 
 [[package]]
 name = "ros2-client"
-version = "0.8.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15b491a0c37fb42f0e6cdcee24b2aa427acb298658576073920f4b8529f7012"
+checksum = "2465ff4307d2c74e86ff2ae1f1219d03e1d764d94c553e303dc790c5d8ff6748"
 dependencies = [
  "async-channel",
  "bstr",
@@ -6415,9 +6480,9 @@ dependencies = [
 
 [[package]]
 name = "rustdds"
-version = "0.11.4"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f3fe51148e1490a88b20d2148ceb14d5a35fc96732c147bde23f01dffa6ebe"
+checksum = "679e56ae1ec6eb11214e965875e732ef5fd265e63d82200f4aa7cd7f43b1c1d5"
 dependencies = [
  "bit-vec 0.8.0",
  "byteorder",
@@ -6435,13 +6500,16 @@ dependencies = [
  "mio 0.6.23",
  "mio 0.8.11",
  "mio-extras",
+ "nix 0.29.0",
  "num-derive",
  "num-traits",
- "paste",
+ "pastey",
+ "pnet",
+ "pnet_sys",
  "rand 0.9.5",
  "serde",
  "serde_repr",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "socketpair",
  "speedy",
  "static_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,18 @@ dora-ros2-bridge-python = { path = "libraries/extensions/ros2-bridge/python" }
 dora-mavlink2-bridge = { version = "1.0.0-rc.4", path = "libraries/extensions/mavlink2-bridge" }
 dora-memory-pool = { version = "1.0.0-rc.4", path = "libraries/extensions/memory-pool" }
 dora-message = { version = "1.0.0-rc.4", path = "libraries/message" }
+# Declared here so `dora-ros2-bridge` and `dora-ros2-bridge-arrow` cannot drift
+# apart on the ROS distro. `humble` selects the 24-byte `Gid` layout used by
+# `rmw_dds_common` graph discovery (see `ros2-client`'s `src/gid.rs`), matching
+# the distro our ROS2 harness runs (`scripts/ros2dev.sh`). Distro selection
+# became an explicit Cargo feature in 0.10; 0.8 only had a `pre-iron-gid`
+# opt-out. Changing this changes graph-discovery wire compatibility.
+ros2-client = { version = "0.10.0", default-features = false, features = [
+    "humble",
+] }
+# Kept in step with the `cdr-encoding` that `rustdds` depends on, so the
+# workspace resolves a single copy.
+cdr-encoding = "0.11"
 arrow = { version = "59", default-features = false }
 arrow-schema = { version = "59" }
 arrow-data = { version = "59" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,11 +136,10 @@ dora-message = { version = "1.0.0-rc.4", path = "libraries/message" }
 # apart on the ROS distro. `humble` selects the 24-byte `Gid` layout used by
 # `rmw_dds_common` graph discovery (see `ros2-client`'s `src/gid.rs`), matching
 # the distro our ROS2 harness runs (`scripts/ros2dev.sh`). Distro selection
-# became an explicit Cargo feature in 0.10; 0.8 only had a `pre-iron-gid`
-# opt-out. Changing this changes graph-discovery wire compatibility.
-ros2-client = { version = "0.10.0", default-features = false, features = [
-    "humble",
-] }
+# became an explicit Cargo feature in 0.10 (default `jazzy`, i.e. 16-byte Gid);
+# 0.8 only had a `pre-iron-gid` opt-out. Changing this changes graph-discovery
+# wire compatibility.
+ros2-client = { version = "0.10.1", default-features = false, features = ["humble"] }
 # Kept in step with the `cdr-encoding` that `rustdds` depends on, so the
 # workspace resolves a single copy.
 cdr-encoding = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,18 @@ dora-ros2-bridge-python = { path = "libraries/extensions/ros2-bridge/python" }
 dora-mavlink2-bridge = { version = "1.0.0-rc.4", path = "libraries/extensions/mavlink2-bridge" }
 dora-memory-pool = { version = "1.0.0-rc.4", path = "libraries/extensions/memory-pool" }
 dora-message = { version = "1.0.0-rc.4", path = "libraries/message" }
+# Declared here so `dora-ros2-bridge` and `dora-ros2-bridge-arrow` cannot drift
+# apart on the ROS distro. `humble` selects the 24-byte `Gid` layout used by
+# `rmw_dds_common` graph discovery (see `ros2-client`'s `src/gid.rs`), matching
+# the distro our ROS2 harness runs (`scripts/ros2dev.sh`). Distro selection
+# became an explicit Cargo feature in 0.10; 0.8 only had a `pre-iron-gid`
+# opt-out. Changing this changes graph-discovery wire compatibility.
+ros2-client = { version = "0.10.0", default-features = false, features = [
+    "humble",
+] }
+# Kept in step with the `cdr-encoding` that `rustdds` depends on, so the
+# workspace resolves a single copy.
+cdr-encoding = "0.11"
 arrow = { version = "59", default-features = false }
 arrow-schema = { version = "59" }
 arrow-data = { version = "59" }

--- a/docs/ros2-bridge.md
+++ b/docs/ros2-bridge.md
@@ -1043,9 +1043,9 @@ have their own notes under [Discovery & RMW notes](#discovery--rmw-notes-native-
 - **Max 8 concurrent action goals**: Additional goals receive `Aborted` status when the limit is reached.
 - **Max 64 pending service requests (server)**: Requests are dropped when the queue is full.
 
-### Platform and distro constraints
+### Distro constraint
 
-These apply to **all** bridge surfaces (YAML and native code APIs).
+This applies to **all** bridge surfaces (YAML and native code APIs).
 
 - **Built for ROS 2 Humble**: The bridge enables `ros2-client`'s `humble`
   distro feature, which selects the **24-byte `Gid`** used by
@@ -1053,14 +1053,6 @@ These apply to **all** bridge surfaces (YAML and native code APIs).
   between Humble and Iron, so graph *discovery* against an Iron-or-newer stack
   will not match. Topic, service, and action **payloads are unaffected** --
   those are ordinary CDR and interoperate across distros regardless.
-- **Not built or tested on Windows**: `rustdds` 0.11.5+ depends unconditionally
-  on `pnet`, whose `pnet_datalink` links `Packet.lib` on Windows
-  ([RustDDS#375](https://github.com/Atostek/RustDDS/issues/375), still open).
-  Building the bridge on Windows requires the
-  [Npcap SDK](https://npcap.com/#download) on the linker path. The bridge
-  crates are therefore excluded from dora's Windows CI build/test steps;
-  Linux and macOS are unaffected. `cargo check` works on Windows without the
-  SDK, since `Packet.lib` is only needed at link time.
 
 ---
 

--- a/docs/ros2-bridge.md
+++ b/docs/ros2-bridge.md
@@ -1043,6 +1043,25 @@ have their own notes under [Discovery & RMW notes](#discovery--rmw-notes-native-
 - **Max 8 concurrent action goals**: Additional goals receive `Aborted` status when the limit is reached.
 - **Max 64 pending service requests (server)**: Requests are dropped when the queue is full.
 
+### Platform and distro constraints
+
+These apply to **all** bridge surfaces (YAML and native code APIs).
+
+- **Built for ROS 2 Humble**: The bridge enables `ros2-client`'s `humble`
+  distro feature, which selects the **24-byte `Gid`** used by
+  `rmw_dds_common` graph discovery. ROS 2 changed `Gid` from 24 to 16 bytes
+  between Humble and Iron, so graph *discovery* against an Iron-or-newer stack
+  will not match. Topic, service, and action **payloads are unaffected** --
+  those are ordinary CDR and interoperate across distros regardless.
+- **Not built or tested on Windows**: `rustdds` 0.11.5+ depends unconditionally
+  on `pnet`, whose `pnet_datalink` links `Packet.lib` on Windows
+  ([RustDDS#375](https://github.com/Atostek/RustDDS/issues/375), still open).
+  Building the bridge on Windows requires the
+  [Npcap SDK](https://npcap.com/#download) on the linker path. The bridge
+  crates are therefore excluded from dora's Windows CI build/test steps;
+  Linux and macOS are unaffected. `cargo check` works on Windows without the
+  SDK, since `Packet.lib` is only needed at link time.
+
 ---
 
 ## Best Practices

--- a/docs/superpowers/specs/2026-07-26-ros2-client-0.10-port-design.md
+++ b/docs/superpowers/specs/2026-07-26-ros2-client-0.10-port-design.md
@@ -1,212 +1,140 @@
-# Port to ros2-client 0.10.0 / RustDDS 0.13.1
+# Port to ros2-client 0.10 / RustDDS 0.14
 
-Date: 2026-07-26
+**PR:** [dora-rs/dora#2854](https://github.com/dora-rs/dora/pull/2854)
+**Status:** Implemented
+**Date:** 2026-07-26 (revised 2026-08-11 for the RustDDS 0.14 release)
 
 ## Goal
 
 Move `dora-ros2-bridge` from `ros2-client 0.8.0` / `rustdds =0.11.4` to
-`ros2-client 0.10.0` / `rustdds 0.13.1`, removing the `=` pin on RustDDS.
+`ros2-client 0.10.1` / `rustdds 0.14`, removing the `=` pin on RustDDS.
 
-The two halves of the request are one upgrade: `ros2-client 0.10.0` declares
-`rustdds = "0.13"`, so resolving RustDDS to >= 0.13.1 follows from the
-ros2-client bump rather than being an independent change.
+The two halves are one upgrade: `ros2-client 0.10.1` declares
+`rustdds = "0.14"`, so the RustDDS version follows from the ros2-client bump
+rather than being an independent choice.
 
-## Why the pin existed
+## Why the pin existed, and why it no longer needs to
 
-`libraries/extensions/ros2-bridge/Cargo.toml:28` pinned `rustdds` to exactly
-`0.11.4` and pointed at [RustDDS#375](https://github.com/Atostek/RustDDS/issues/375).
-That issue reports that RustDDS 0.11.5 added a **mandatory `pnet` dependency**,
-which breaks Windows linking with `cannot open input file 'Packet.lib'`.
+`libraries/extensions/ros2-bridge/Cargo.toml` pinned `rustdds` to exactly
+`0.11.4` and pointed at [RustDDS#375](https://github.com/Atostek/RustDDS/issues/375):
+RustDDS 0.11.5 added a mandatory `pnet` dependency, whose `pnet_datalink`
+declares `#[link(name = "Packet")]` under `#[cfg(windows)]`, so Windows linking
+fails with `cannot open input file 'Packet.lib'` unless the Npcap SDK is on the
+linker path. RustDDS needed `pnet` for a single `pnet::datalink::interfaces()`
+call.
 
-The issue is **still open**, and 0.13.1 still has the dependency:
+That is fixed upstream. RustDDS commit `92c9b117c` (2026-07-04, *"Rewrite
+network interface enumeration to reduce dependencies"*) replaced `pnet` with
+`netdev`, which on Windows uses `windows-sys` and requires no SDK. It shipped in
+**rustdds 0.14.0** (2026-08-04), #375 is closed, and **ros2-client 0.10.1**
+(requiring `rustdds ^0.14`) followed.
 
-- `rustdds-0.13.1/Cargo.toml` -> `pnet 0.35`, not optional, features `std` +
-  `pnet_datalink`
-- `pnet_datalink-0.35.0/src/bindings/winpcap.rs:357` -> `#[link(name = "Packet")]`
-  under `#[cfg(windows)]`
-- RustDDS uses exactly one item from it: `pnet::datalink::interfaces()` in
-  `src/network/util.rs:61` (interface enumeration)
+Consequence for this port: **no Windows CI exclusions and no Windows caveat in
+the docs.** An earlier revision of this PR carried both, because at the time the
+only versions satisfying `ros2-client 0.10.0` were RustDDS 0.13.x, which still
+had `pnet`. Waiting for the upstream release removed the workaround entirely.
 
-So the pin was load-bearing, and lifting it requires an explicit Windows
-decision rather than just a version edit.
+Verified rather than assumed: `cargo tree -e normal --workspace --target
+x86_64-pc-windows-msvc` resolves **zero `pnet*` crates**.
 
 ## Decisions
-
-### Windows: exclude the affected crates from Windows CI
-
-Chosen over installing the Npcap SDK in CI (which would push a build-env
-requirement onto every Windows developer building the bridge) and over forking
-RustDDS to make `pnet` optional (which would add a fork to maintain).
-
-Consequence: Windows loses compile/test coverage of the bridge crates. Accepted
-deliberately.
 
 ### ROS distro: build against `humble`
 
 `ros2-client 0.10` makes the ROS-distro choice explicit via Cargo features
 (`default = [jazzy]`, plus `galactic`/`humble`/`iron`/`kilted`/`lyrical`);
-0.8 had no such concept, only a `pre-iron-gid` opt-out.
+0.8 had no such concept, only a `pre-iron-gid` opt-out. 0.10.1 keeps the same
+feature set.
 
-The features gate `Gid` width (`ros2-client-0.10.0/src/gid.rs:9-12`):
+The features gate `Gid` width (`ros2-client`'s `src/gid.rs`):
 
 | Build | `GID_LENGTH` |
 |---|---|
-| 0.8 as dora ships it (`pre-iron-gid` off) | 16 |
+| 0.8 as dora shipped it (`pre-iron-gid` off) | 16 |
 | 0.10 with `default = [jazzy]` (jazzy > iron) | 16 |
 | 0.10 with `humble` | 24 |
 
-dora's own ROS2 harness runs humble (`scripts/ros2dev.sh:57`,
-`scripts/ros2-zenoh-interop.sh`), so today's build emits iron-era 16-byte Gids
-while being tested against a 24-byte-Gid distro. Selecting `humble` aligns the
-build with the harness.
+dora's own ROS2 harness runs humble (`scripts/ros2dev.sh`,
+`scripts/ros2-zenoh-interop.sh`), so the pre-port build emitted iron-era 16-byte
+Gids while being tested against a 24-byte-Gid distro. Selecting `humble` aligns
+the build with the harness.
 
 **This is a deliberate wire-format change**, not a mechanical port. It affects
 `rmw_dds_common` graph-discovery messages only; topic, service, and action
-payloads are unaffected.
+payloads are ordinary CDR and interoperate across distros either way.
 
-## Changes
+### Dependency declaration
 
-### Manifests
-
-`ros2-client` and `cdr-encoding` go in the root `[workspace.dependencies]`, so
+`ros2-client` and `cdr-encoding` live in the root `[workspace.dependencies]`, so
 `dora-ros2-bridge` and `dora-ros2-bridge-arrow` cannot drift apart on the ROS
-distro:
+distro. `rustdds` stays local to `dora-ros2-bridge`, its only direct consumer.
 
-```toml
-ros2-client = { version = "0.10.0", default-features = false, features = ["humble"] }
-cdr-encoding = "0.11"
-```
+`cdr-encoding` 0.10.2 -> 0.11 matches what RustDDS depends on, leaving a single
+copy in the lockfile. Its only API change tightens `from_bytes` to `&'de [u8]`;
+every dora call site deserializes owned types.
 
-Both bridge crates then use `{ workspace = true }`. `rustdds = "0.13.1"` stays
-local to `dora-ros2-bridge`, which is its only direct consumer.
+## Source changes
 
-An earlier draft declared the full `ros2-client` spec in both crates and carried
-a "keep the distro feature in sync" comment. That comment was the tell: a
-manual-sync requirement where the workspace already had a mechanism to remove
-it. Verified after the change with `cargo tree -e features`, which shows
-`ros2-client` resolving with `humble` and `galactic` but **not** `iron` -- i.e.
-the 24-byte `Gid` -- and a single `cdr-encoding` copy in `Cargo.lock`.
-
-`cdr-encoding` 0.10.2 -> 0.11.0 changes only `from_bytes` / `from_bytes_with`,
-tightening the input to `&'de [u8]`. Every dora call site deserializes owned
-types, so this is a no-op that removes a duplicate dependency (RustDDS 0.13
-depends on `cdr-encoding 0.11`).
-
-### Source
-
-Expected to be minimal. Every `ros2-client` symbol dora uses (~60 items:
-`Node`, `Context`, `Name`, `ServiceMapping`, `action::*`, `ParameterValue`, ...)
-survives 0.8 -> 0.10; the diff of the public surface is additions only
-(`distributions`, `pub use rustdds`, `Node::stop_spinner`).
-
-Removed APIs that dora does not use: `QosPolicyBuilder::property()`, and the
-`rustdds::CdrEncodingSize` re-export (msg-gen does not reference it).
-
-Confirmed by compiling, not by assertion.
-
-### Windows CI
-
-Crates that transitively pull `rustdds` (verified via `cargo tree -e normal`):
-
-| Crate | Pulls rustdds | Action |
-|---|---|---|
-| `dora-ros2-bridge` | yes | exclude (test targets link) |
-| `dora-ros2-bridge-arrow` | yes | exclude (test targets link) |
-| `dora-ros2-bridge-node` | yes | exclude (bin links) |
-| `rust-ros2-example-node` | yes | exclude (bin links) |
-| `dora-ros2-bridge-msg-gen` | no | keep - Windows coverage retained |
-| `dora-cli`, `dora-daemon` | no | keep |
-| `dora-ros2-bridge-python`, `dora-node-api-python` | yes | already excluded |
-
-`Packet.lib` is a link-time symbol, so only steps that produce linked artifacts
-break. That is exactly `nightly.yml`'s `test-cross-platform` job, steps
-`cargo build --all` and `cargo test --all`.
-
-Unaffected, and therefore unchanged:
-
-- `test-cross-platform`'s `cargo check --all` and `cargo check --examples`
-- the `cross-check` job (`nightly.yml:1713-1726`) including its
-  `x86_64-pc-windows-gnu` target - it runs `cargo check` only
-
-Because that job's matrix covers macOS and Windows through shared steps, the
-excludes are carried in a per-platform matrix variable (empty on macOS) so
-macOS retains full bridge coverage.
+**None required.** Every `ros2-client` symbol dora uses (~60 items: `Node`,
+`Context`, `Name`, `ServiceMapping`, `action::*`, `ParameterValue`, ...)
+survives 0.8 -> 0.10.1; the public-surface diff is additions only
+(`distributions`, `pub use rustdds`, `Node::stop_spinner`). The removed APIs,
+`QosPolicyBuilder::property()` and the `rustdds::CdrEncodingSize` re-export,
+were never referenced here. RustDDS 0.14 additionally gates its mio-0.8
+integration behind an opt-in `mio_08` feature; nothing in dora or ros2-client
+uses it (ros2-client is on mio 0.6).
 
 ## Verification
 
-Local, against the real `/opt/ros/humble`:
+Re-run on this revision (Linux, no ROS distro installed):
 
-- `cargo fmt --all -- --check`
-- `cargo clippy -- -D warnings` on the bridge crates
-- `cargo test` on the bridge crates
-- a `generate-messages` build (default features) against humble
-- live interop: ROS2 humble talker against a dora bridge subscriber, to
-  exercise the 24-byte Gid on the wire
-
-Baseline before any edit is green: `cargo check -p dora-ros2-bridge` passes both
-with and without default features, so breakage is attributable.
-
-Supply-chain gates (`cargo-deny`, `cargo-audit`, `cargo-lichking`) are run
-because `pnet` is a new transitive dependency.
-
-**Not verified here:** the Windows link failure and the CI exclusion that avoids
-it. No Windows host is available. This needs a nightly run to confirm.
-
-### Results
-
-Source changes required by the port: **none**. The manifests were the only edit
-needed; `cargo check`, `clippy -D warnings`, and `cargo check --examples` all
-pass unmodified.
-
-- `cargo fmt --all -- --check`: clean
-- `clippy --lib --bins --tests -- -D warnings` on all five bridge crates: clean
-- bridge tests: **110 passed, 0 failed** (`dora-ros2-bridge` 18,
-  `dora-ros2-bridge-arrow` 15, `dora-ros2-bridge-msg-gen` 77)
-- full workspace `cargo test --all` (per CLAUDE.md's exclude list):
-  **1543 passed, 0 failed** across 126 test binaries
-- `cargo check --examples`: clean
-- `cargo build --example` links successfully against RustDDS 0.13.1 on Linux,
-  so the port is proven to *link*, not merely typecheck
+- `cargo tree -e normal --workspace --target x86_64-pc-windows-msvc`:
+  **0 `pnet*` crates**; single copies of `rustdds 0.14.1`, `ros2-client 0.10.1`,
+  `netdev 0.45.0`, `cdr-encoding 0.11.0`
+- `cargo check` on `dora-ros2-bridge`, `dora-ros2-bridge-arrow`,
+  `dora-ros2-bridge-node`: clean
+- `cargo check --target x86_64-pc-windows-gnu` on the bridge and bridge node:
+  clean, so the Windows compile path (including `netdev`'s) builds
+- `cargo test -p dora-ros2-bridge -p dora-ros2-bridge-arrow`: 18 + 19 passed,
+  0 failed
 - `cargo deny check licenses advisories bans sources`: all ok
+- `Cargo.lock` shrinks by 70 lines net -- the `netdev` tree is smaller than
+  `pnet`'s, and `mio_08`/`socketpair` leave the graph
 
-Live interop against `ros2 run demo_nodes_cpp talker` on ROS 2 Humble, using a
-throwaway probe node built on the bridge's ros2-client stack (subscribing to
-`/chatter`, `std_msgs/String`). A counterfactual run with the `jazzy` default
-isolates what the distro feature actually buys:
+Carried over from the original port validation (ros2-client 0.10.0 /
+rustdds 0.13.1, run against a real `/opt/ros/humble`), **not re-run** on
+0.10.1 / 0.14.1:
 
-| Build | `ros2 node list` sees the dora node | Payload interop |
-|---|---|---|
-| `humble` (24-byte Gid) | **yes** - `/dora_interop_probe` listed | 3/3 messages |
-| `jazzy` (16-byte Gid) | **no** - only `/talker` listed | 3/3 messages |
+- full workspace `cargo test --all` (CLAUDE.md exclude list): 1543 passed
+- live interop against `ros2 run demo_nodes_cpp talker` with a throwaway probe
+  node on the bridge's ros2-client stack. The `humble` build was listed by
+  `ros2 node list` and `ros2 topic info -v /chatter` attributed the subscription
+  to it with a 24-octet GID; the counterfactual `jazzy` build was invisible to
+  graph introspection while still exchanging 3/3 payloads. This is what
+  establishes that Gid width governs graph discovery and nothing else.
 
-`ros2 topic info -v /chatter` on the humble build reports the dora subscription
-attributed to node `dora_interop_probe` with a 24-octet GID matching the
-talker's format.
+The distro feature set is identical between 0.10.0 and 0.10.1, so the Gid
+result carries; the version bump does not re-open it.
 
-This confirms the prediction in "Decisions" exactly: the Gid width governs
-`rmw_dds_common` **graph discovery** and nothing else. Topic payloads
-interoperate across distros either way, so the `humble` selection is what makes
-a dora bridge node visible to `ros2 node list` on a Humble stack.
-
-The probe was temporary scaffolding and is not part of the change.
+**Not verified anywhere:** an actual Windows *link*. No Windows host was
+available, and `cargo check` does not link. The known blocker is now
+structurally absent (no `#[link(name = "Packet")]` anywhere in the graph) and
+the nightly `test-cross-platform` job builds and tests the bridge on Windows,
+so a nightly run is the confirmation.
 
 ## Risks
 
-**The Gid change is the real behavior change.** 24-byte versus 16-byte Gid.
-Scoped to `rmw_dds_common` graph discovery, but anyone interoperating with an
-iron-or-newer stack is affected.
+**The Gid change is the real behavior change.** 24-byte versus 16-byte Gid,
+scoped to `rmw_dds_common` graph discovery. Anyone doing graph introspection
+against an iron-or-newer stack is affected.
 
-**`pnet` is new on Linux and macOS too**, not only Windows. The lockfile gains
-exactly six crates: `pnet`, `pnet_macros`, `pnet_macros_support`, `pnet_packet`,
-`pnet_transport`, and `pastey`. (`pnet_datalink`, `pnet_sys`, `ipnetwork`, and
-`winapi` were already in `Cargo.lock` before this change.) `cargo deny check
-licenses advisories bans sources` passes on the new tree.
+`mio 0.6.23` remains a non-optional transitive dependency (via `mio_06` in
+rustdds 0.14 and `mio-extras`), so the `[profile.dev.package."mio:0.6.23"]`
+debug-assertions workaround from #3092 is still required and still load-bearing
+for Windows bridge tests.
 
 ## Follow-ups (out of scope)
 
-- Upstream a PR to RustDDS making the single `pnet::datalink::interfaces()`
-  call optional, which would close #375 and restore Windows support for
-  everyone. This is the durable fix; excluding Windows is the cheap one.
 - Decide whether the bridge should expose distro selection as a dora-level
   feature passthrough (`ros-humble` / `ros-jazzy` / ...) rather than hardcoding
   one distro.

--- a/docs/superpowers/specs/2026-07-26-ros2-client-0.10-port-design.md
+++ b/docs/superpowers/specs/2026-07-26-ros2-client-0.10-port-design.md
@@ -1,0 +1,212 @@
+# Port to ros2-client 0.10.0 / RustDDS 0.13.1
+
+Date: 2026-07-26
+
+## Goal
+
+Move `dora-ros2-bridge` from `ros2-client 0.8.0` / `rustdds =0.11.4` to
+`ros2-client 0.10.0` / `rustdds 0.13.1`, removing the `=` pin on RustDDS.
+
+The two halves of the request are one upgrade: `ros2-client 0.10.0` declares
+`rustdds = "0.13"`, so resolving RustDDS to >= 0.13.1 follows from the
+ros2-client bump rather than being an independent change.
+
+## Why the pin existed
+
+`libraries/extensions/ros2-bridge/Cargo.toml:28` pinned `rustdds` to exactly
+`0.11.4` and pointed at [RustDDS#375](https://github.com/Atostek/RustDDS/issues/375).
+That issue reports that RustDDS 0.11.5 added a **mandatory `pnet` dependency**,
+which breaks Windows linking with `cannot open input file 'Packet.lib'`.
+
+The issue is **still open**, and 0.13.1 still has the dependency:
+
+- `rustdds-0.13.1/Cargo.toml` -> `pnet 0.35`, not optional, features `std` +
+  `pnet_datalink`
+- `pnet_datalink-0.35.0/src/bindings/winpcap.rs:357` -> `#[link(name = "Packet")]`
+  under `#[cfg(windows)]`
+- RustDDS uses exactly one item from it: `pnet::datalink::interfaces()` in
+  `src/network/util.rs:61` (interface enumeration)
+
+So the pin was load-bearing, and lifting it requires an explicit Windows
+decision rather than just a version edit.
+
+## Decisions
+
+### Windows: exclude the affected crates from Windows CI
+
+Chosen over installing the Npcap SDK in CI (which would push a build-env
+requirement onto every Windows developer building the bridge) and over forking
+RustDDS to make `pnet` optional (which would add a fork to maintain).
+
+Consequence: Windows loses compile/test coverage of the bridge crates. Accepted
+deliberately.
+
+### ROS distro: build against `humble`
+
+`ros2-client 0.10` makes the ROS-distro choice explicit via Cargo features
+(`default = [jazzy]`, plus `galactic`/`humble`/`iron`/`kilted`/`lyrical`);
+0.8 had no such concept, only a `pre-iron-gid` opt-out.
+
+The features gate `Gid` width (`ros2-client-0.10.0/src/gid.rs:9-12`):
+
+| Build | `GID_LENGTH` |
+|---|---|
+| 0.8 as dora ships it (`pre-iron-gid` off) | 16 |
+| 0.10 with `default = [jazzy]` (jazzy > iron) | 16 |
+| 0.10 with `humble` | 24 |
+
+dora's own ROS2 harness runs humble (`scripts/ros2dev.sh:57`,
+`scripts/ros2-zenoh-interop.sh`), so today's build emits iron-era 16-byte Gids
+while being tested against a 24-byte-Gid distro. Selecting `humble` aligns the
+build with the harness.
+
+**This is a deliberate wire-format change**, not a mechanical port. It affects
+`rmw_dds_common` graph-discovery messages only; topic, service, and action
+payloads are unaffected.
+
+## Changes
+
+### Manifests
+
+`ros2-client` and `cdr-encoding` go in the root `[workspace.dependencies]`, so
+`dora-ros2-bridge` and `dora-ros2-bridge-arrow` cannot drift apart on the ROS
+distro:
+
+```toml
+ros2-client = { version = "0.10.0", default-features = false, features = ["humble"] }
+cdr-encoding = "0.11"
+```
+
+Both bridge crates then use `{ workspace = true }`. `rustdds = "0.13.1"` stays
+local to `dora-ros2-bridge`, which is its only direct consumer.
+
+An earlier draft declared the full `ros2-client` spec in both crates and carried
+a "keep the distro feature in sync" comment. That comment was the tell: a
+manual-sync requirement where the workspace already had a mechanism to remove
+it. Verified after the change with `cargo tree -e features`, which shows
+`ros2-client` resolving with `humble` and `galactic` but **not** `iron` -- i.e.
+the 24-byte `Gid` -- and a single `cdr-encoding` copy in `Cargo.lock`.
+
+`cdr-encoding` 0.10.2 -> 0.11.0 changes only `from_bytes` / `from_bytes_with`,
+tightening the input to `&'de [u8]`. Every dora call site deserializes owned
+types, so this is a no-op that removes a duplicate dependency (RustDDS 0.13
+depends on `cdr-encoding 0.11`).
+
+### Source
+
+Expected to be minimal. Every `ros2-client` symbol dora uses (~60 items:
+`Node`, `Context`, `Name`, `ServiceMapping`, `action::*`, `ParameterValue`, ...)
+survives 0.8 -> 0.10; the diff of the public surface is additions only
+(`distributions`, `pub use rustdds`, `Node::stop_spinner`).
+
+Removed APIs that dora does not use: `QosPolicyBuilder::property()`, and the
+`rustdds::CdrEncodingSize` re-export (msg-gen does not reference it).
+
+Confirmed by compiling, not by assertion.
+
+### Windows CI
+
+Crates that transitively pull `rustdds` (verified via `cargo tree -e normal`):
+
+| Crate | Pulls rustdds | Action |
+|---|---|---|
+| `dora-ros2-bridge` | yes | exclude (test targets link) |
+| `dora-ros2-bridge-arrow` | yes | exclude (test targets link) |
+| `dora-ros2-bridge-node` | yes | exclude (bin links) |
+| `rust-ros2-example-node` | yes | exclude (bin links) |
+| `dora-ros2-bridge-msg-gen` | no | keep - Windows coverage retained |
+| `dora-cli`, `dora-daemon` | no | keep |
+| `dora-ros2-bridge-python`, `dora-node-api-python` | yes | already excluded |
+
+`Packet.lib` is a link-time symbol, so only steps that produce linked artifacts
+break. That is exactly `nightly.yml`'s `test-cross-platform` job, steps
+`cargo build --all` and `cargo test --all`.
+
+Unaffected, and therefore unchanged:
+
+- `test-cross-platform`'s `cargo check --all` and `cargo check --examples`
+- the `cross-check` job (`nightly.yml:1713-1726`) including its
+  `x86_64-pc-windows-gnu` target - it runs `cargo check` only
+
+Because that job's matrix covers macOS and Windows through shared steps, the
+excludes are carried in a per-platform matrix variable (empty on macOS) so
+macOS retains full bridge coverage.
+
+## Verification
+
+Local, against the real `/opt/ros/humble`:
+
+- `cargo fmt --all -- --check`
+- `cargo clippy -- -D warnings` on the bridge crates
+- `cargo test` on the bridge crates
+- a `generate-messages` build (default features) against humble
+- live interop: ROS2 humble talker against a dora bridge subscriber, to
+  exercise the 24-byte Gid on the wire
+
+Baseline before any edit is green: `cargo check -p dora-ros2-bridge` passes both
+with and without default features, so breakage is attributable.
+
+Supply-chain gates (`cargo-deny`, `cargo-audit`, `cargo-lichking`) are run
+because `pnet` is a new transitive dependency.
+
+**Not verified here:** the Windows link failure and the CI exclusion that avoids
+it. No Windows host is available. This needs a nightly run to confirm.
+
+### Results
+
+Source changes required by the port: **none**. The manifests were the only edit
+needed; `cargo check`, `clippy -D warnings`, and `cargo check --examples` all
+pass unmodified.
+
+- `cargo fmt --all -- --check`: clean
+- `clippy --lib --bins --tests -- -D warnings` on all five bridge crates: clean
+- bridge tests: **110 passed, 0 failed** (`dora-ros2-bridge` 18,
+  `dora-ros2-bridge-arrow` 15, `dora-ros2-bridge-msg-gen` 77)
+- full workspace `cargo test --all` (per CLAUDE.md's exclude list):
+  **1543 passed, 0 failed** across 126 test binaries
+- `cargo check --examples`: clean
+- `cargo build --example` links successfully against RustDDS 0.13.1 on Linux,
+  so the port is proven to *link*, not merely typecheck
+- `cargo deny check licenses advisories bans sources`: all ok
+
+Live interop against `ros2 run demo_nodes_cpp talker` on ROS 2 Humble, using a
+throwaway probe node built on the bridge's ros2-client stack (subscribing to
+`/chatter`, `std_msgs/String`). A counterfactual run with the `jazzy` default
+isolates what the distro feature actually buys:
+
+| Build | `ros2 node list` sees the dora node | Payload interop |
+|---|---|---|
+| `humble` (24-byte Gid) | **yes** - `/dora_interop_probe` listed | 3/3 messages |
+| `jazzy` (16-byte Gid) | **no** - only `/talker` listed | 3/3 messages |
+
+`ros2 topic info -v /chatter` on the humble build reports the dora subscription
+attributed to node `dora_interop_probe` with a 24-octet GID matching the
+talker's format.
+
+This confirms the prediction in "Decisions" exactly: the Gid width governs
+`rmw_dds_common` **graph discovery** and nothing else. Topic payloads
+interoperate across distros either way, so the `humble` selection is what makes
+a dora bridge node visible to `ros2 node list` on a Humble stack.
+
+The probe was temporary scaffolding and is not part of the change.
+
+## Risks
+
+**The Gid change is the real behavior change.** 24-byte versus 16-byte Gid.
+Scoped to `rmw_dds_common` graph discovery, but anyone interoperating with an
+iron-or-newer stack is affected.
+
+**`pnet` is new on Linux and macOS too**, not only Windows. The lockfile gains
+exactly six crates: `pnet`, `pnet_macros`, `pnet_macros_support`, `pnet_packet`,
+`pnet_transport`, and `pastey`. (`pnet_datalink`, `pnet_sys`, `ipnetwork`, and
+`winapi` were already in `Cargo.lock` before this change.) `cargo deny check
+licenses advisories bans sources` passes on the new tree.
+
+## Follow-ups (out of scope)
+
+- Upstream a PR to RustDDS making the single `pnet::datalink::interfaces()`
+  call optional, which would close #375 and restore Windows support for
+  everyone. This is the durable fix; excluding Windows is the cheap one.
+- Decide whether the bridge should expose distro selection as a dora-level
+  feature passthrough (`ros-humble` / `ros-jazzy` / ...) rather than hardcoding
+  one distro.

--- a/libraries/extensions/ros2-bridge/Cargo.toml
+++ b/libraries/extensions/ros2-bridge/Cargo.toml
@@ -24,8 +24,16 @@ dora-ros2-bridge-msg-gen = { workspace = true }
 serde = { workspace = true }
 serde-big-array = "0.5.1"
 widestring = "1.2.1"
-ros2-client = "0.8.0"
-rustdds = "=0.11.4" # pinned because of https://github.com/Atostek/RustDDS/issues/375
+# Version + ROS distro feature are set in `[workspace.dependencies]`.
+ros2-client = { workspace = true }
+# No longer pinned to `=0.11.4`. RustDDS 0.11.5+ depends unconditionally on
+# `pnet`, whose `pnet_datalink` links `Packet.lib` on Windows, so Windows builds
+# need the Npcap SDK: https://github.com/Atostek/RustDDS/issues/375 (still open
+# as of this bump). Instead of pinning, the crates that pull RustDDS are
+# excluded from the Windows build/test steps in `.github/workflows/nightly.yml`.
+# RustDDS needs `pnet` for a single `pnet::datalink::interfaces()` call, so the
+# durable fix is upstreaming an optional-`pnet` feature.
+rustdds = "0.13.1"
 eyre = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = "0.3.23"
@@ -33,7 +41,7 @@ flume = "0.12.0"
 futures = { workspace = true, features = ["thread-pool"] }
 futures-timer = "3.0.4"
 thiserror = { workspace = true }
-cdr-encoding = "=0.10.2"
+cdr-encoding = { workspace = true }
 byteorder = "1"
 zenoh = { workspace = true, optional = true }
 zenoh-ext = { workspace = true, optional = true }

--- a/libraries/extensions/ros2-bridge/Cargo.toml
+++ b/libraries/extensions/ros2-bridge/Cargo.toml
@@ -26,14 +26,12 @@ serde-big-array = "0.5.1"
 widestring = "1.2.1"
 # Version + ROS distro feature are set in `[workspace.dependencies]`.
 ros2-client = { workspace = true }
-# No longer pinned to `=0.11.4`. RustDDS 0.11.5+ depends unconditionally on
-# `pnet`, whose `pnet_datalink` links `Packet.lib` on Windows, so Windows builds
-# need the Npcap SDK: https://github.com/Atostek/RustDDS/issues/375 (still open
-# as of this bump). Instead of pinning, the crates that pull RustDDS are
-# excluded from the Windows build/test steps in `.github/workflows/nightly.yml`.
-# RustDDS needs `pnet` for a single `pnet::datalink::interfaces()` call, so the
-# durable fix is upstreaming an optional-`pnet` feature.
-rustdds = "0.13.1"
+# No longer pinned to `=0.11.4`. That pin existed because rustdds 0.11.5-0.13.x
+# depended unconditionally on `pnet`, whose `pnet_datalink` links `Packet.lib`
+# on Windows (https://github.com/Atostek/RustDDS/issues/375). 0.14 replaced
+# `pnet` with `netdev`, which uses `windows-sys` and needs no npcap SDK, so the
+# issue is closed and Windows builds the bridge again.
+rustdds = "0.14"
 eyre = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = "0.3.23"

--- a/libraries/extensions/ros2-bridge/arrow/Cargo.toml
+++ b/libraries/extensions/ros2-bridge/arrow/Cargo.toml
@@ -11,11 +11,11 @@ repository.workspace = true
 dora-ros2-bridge-msg-gen = { workspace = true }
 arrow = { workspace = true }
 eyre = { workspace = true }
-ros2-client = "0.8"
+ros2-client = { workspace = true }
 serde = { workspace = true }
-cdr-encoding = "=0.10.2"
+cdr-encoding = { workspace = true }
 byteorder = "1"
 
 [dev-dependencies]
-# CDR codec used by ros2-client 0.8 on the wire; used in tests to verify the
+# CDR codec used by ros2-client 0.10 on the wire; used in tests to verify the
 # real CDR byte layout (length prefixes, alignment) rather than just serde shape.


### PR DESCRIPTION
Ports `dora-ros2-bridge` from **ros2-client 0.8.0 / rustdds `=0.11.4`** to
**ros2-client 0.10.1 / rustdds 0.14**, removing the `=` pin on RustDDS. One
upgrade, not two: ros2-client 0.10.1 declares `rustdds = "0.14"`.

No source changes were required. Every ros2-client symbol the bridge uses (~60
items) survives 0.8 → 0.10.1 — the public-surface diff is additions only
(`distributions`, `pub use rustdds`, `Node::stop_spinner`). The APIs that *were*
removed, `QosPolicyBuilder::property()` and the `rustdds::CdrEncodingSize`
re-export, were never referenced here.

`ros2-client` and `cdr-encoding` move into `[workspace.dependencies]` so the
bridge and its arrow helper cannot drift apart on the ROS distro.
`cdr-encoding` goes 0.10.2 → 0.11 to match what RustDDS depends on, leaving a
single copy in the lockfile.

Kept as two commits: the first is the original port (ros2-client 0.10.0 /
rustdds 0.13.1, with a Windows CI exclusion); the second moves it to
rustdds 0.14 and deletes that exclusion. Read the second commit alone to see
what changed.

### No Windows workaround needed

The `=0.11.4` pin was load-bearing: rustdds 0.11.5–0.13.x depended
unconditionally on `pnet`, whose `pnet_datalink` declares
`#[link(name = "Packet")]` under `#[cfg(windows)]`, so Windows linking needed
`Packet.lib` from the Npcap SDK ([RustDDS#375](https://github.com/Atostek/RustDDS/issues/375)).

That is fixed upstream. RustDDS [`92c9b117c`](https://github.com/Atostek/RustDDS/commit/92c9b117c)
replaced `pnet` with `netdev` (which uses `windows-sys` and needs no SDK); it
shipped in **rustdds 0.14.0**, #375 is closed, and **ros2-client 0.10.1**
followed with `rustdds ^0.14`. So this PR needs no CI exclusions and no Windows
caveat in the docs — `cargo tree -e normal --workspace --target
x86_64-pc-windows-msvc` resolves **zero `pnet*` crates**. That matters beyond
tidiness: excluding the bridge from Windows would have cancelled out #3092, the
`mio 0.6.23` debug-assertions fix that stopped the bridge test binary aborting
there.

### Needs review attention: the ROS distro is now explicit, and this picks `humble`

0.10 gained distro Cargo features (`default = [jazzy]`, plus
`galactic`/`humble`/`iron`/`kilted`/`lyrical`); 0.8 only had a `pre-iron-gid`
opt-out. These select `Gid` width in `ros2-client`'s `src/gid.rs`:

| Build | `GID_LENGTH` |
|---|---|
| 0.8 as we shipped it (`pre-iron-gid` off) | 16 |
| 0.10 with `default = [jazzy]` (jazzy ⊃ iron) | 16 |
| **0.10 with `humble` (this PR)** | **24** |

This aligns the build with the distro our own harness runs
(`scripts/ros2dev.sh`, `scripts/ros2-zenoh-interop.sh`). Previously we emitted
iron-era 16-byte Gids while testing against a 24-byte-Gid distro.

**It is a deliberate wire-format change.** It affects `rmw_dds_common` graph
discovery only — topic, service, and action payloads are ordinary CDR and
interoperate across distros either way. Anyone doing graph introspection
against an iron-or-newer stack is affected. Happy to split it out or switch to
a feature passthrough (`ros-humble` / `ros-jazzy` / …) if you'd rather.

### Verification

On Linux, no ROS distro installed:

- `cargo fmt --all -- --check` — clean
- `cargo clippy --lib --bins --tests -- -D warnings` on the four bridge crates — clean
- `cargo check --examples` — clean
- `cargo check --target x86_64-pc-windows-gnu` on the bridge and bridge node — clean, so the Windows compile path (including `netdev`'s) builds
- bridge tests — 18 + 19 passed, 0 failed
- full workspace `cargo test --all` (CLAUDE.md exclude list) — see comment below
- `cargo deny check licenses advisories bans sources` — all ok
- `Cargo.lock` shrinks by 70 lines net: the `netdev` tree is smaller than `pnet`'s, and `mio_08`/`socketpair` leave the graph

Carried over from the earlier revision of this PR (validated at ros2-client
0.10.0 / rustdds 0.13.1 against a real `/opt/ros/humble`), **not re-run** on
0.10.1 / 0.14.1: live interop against `ros2 run demo_nodes_cpp talker`, where
the `humble` build was listed by `ros2 node list` with a 24-octet GID and the
counterfactual `jazzy` build was invisible to graph introspection while still
exchanging 3/3 payloads. The distro feature set is identical between 0.10.0 and
0.10.1, so that result carries.

**Not verified:** an actual Windows *link* — no Windows host available, and
`cargo check` does not link. The known blocker is structurally absent now, and
the nightly `test-cross-platform` job builds and tests the bridge on Windows,
so a nightly run is the confirmation.

`docs/superpowers/specs/2026-07-26-ros2-client-0.10-port-design.md` records the
investigation and the alternatives that the upstream release made unnecessary.
