### PR TITLE
chore(runtime,examples): diagnostics to pin the Windows operator stop-wedge (#2742)

### DIFF
--- a/binaries/runtime/src/lib.rs
+++ b/binaries/runtime/src/lib.rs
@@ -15,6 +15,8 @@ use operator::{OperatorEvent, StopReason, run_operator};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     mem,
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
 };
 use tokio::{
     runtime::Builder,
@@ -179,7 +181,48 @@ async fn run(
         .map(|(id, config)| (id, config.inputs.keys().collect()))
         .collect();
 
-    while let Some(event) = events.next().await {
+    // Diagnostic watchdog (dora-rs/dora#2742): warn when the main loop stops
+    // making progress *while handling* an event, naming the stuck event. On
+    // Windows a wedged operator can't be soft-killed (`CTRL_BREAK_EVENT` cannot
+    // interrupt native code the way Unix `SIGTERM` does), so the only symptom is
+    // a silent grace-period force-kill with no clue where it parked.
+    let activity = Arc::new(Mutex::new(LoopActivity::Idle));
+    {
+        let activity = activity.clone();
+        let node_id = node.id().to_string();
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(Duration::from_secs(2));
+            ticker.tick().await; // first tick fires immediately
+            loop {
+                ticker.tick().await;
+                let stalled = match &*lock(&activity) {
+                    LoopActivity::Handling { since, what }
+                        if since.elapsed() > Duration::from_secs(3) =>
+                    {
+                        Some((since.elapsed(), *what))
+                    }
+                    _ => None,
+                };
+                if let Some((elapsed, what)) = stalled {
+                    tracing::warn!(
+                        "runtime `{node_id}` main loop stalled for {:.0}s while handling {what} \
+                         (dora-rs/dora#2742 diagnostic)",
+                        elapsed.as_secs_f32()
+                    );
+                }
+            }
+        });
+    }
+
+    loop {
+        *lock(&activity) = LoopActivity::Idle;
+        let Some(event) = events.next().await else {
+            break;
+        };
+        *lock(&activity) = LoopActivity::Handling {
+            since: Instant::now(),
+            what: describe_runtime_event(&event),
+        };
         match event {
             RuntimeEvent::Operator {
                 id: operator_id,
@@ -250,9 +293,25 @@ async fn run(
                 }
             },
             RuntimeEvent::Event(Event::Stop(cause)) => {
+                // Diagnostic (dora-rs/dora#2742): trace Stop delivery so a
+                // Windows nightly shows whether the runtime received Stop and
+                // whether each per-operator forward *completed*. A logged
+                // "received Stop" with no matching "forwarded Stop" means the
+                // forward blocked on a full operator channel — i.e. the operator
+                // is parked in its own `on_event` and never draining.
+                // `warn!` (not `info!`) so it survives the runtime's default
+                // stdout filter (`with_stdout("warn", …)`) and reaches the
+                // nightly log.
+                tracing::warn!(
+                    "runtime received Stop; forwarding to {} operator(s) (dora-rs/dora#2742 diagnostic)",
+                    operator_channels.len()
+                );
                 // forward stop event to all operators and close the event channels
-                for (_, channel) in operator_channels.drain() {
+                for (id, channel) in operator_channels.drain() {
                     let _ = channel.send_async(Event::Stop(cause.clone())).await;
+                    tracing::warn!(
+                        "forwarded Stop to operator `{id}` (dora-rs/dora#2742 diagnostic)"
+                    );
                 }
             }
             RuntimeEvent::Event(Event::Reload {
@@ -359,4 +418,46 @@ enum RuntimeEvent {
         event: OperatorEvent,
     },
     Event(Event),
+}
+
+/// What the runtime's main loop is currently doing, for the stall watchdog.
+///
+/// Diagnostic for dora-rs/dora#2742: on Windows a wedged operator cannot be
+/// interrupted by the daemon's soft-kill (`CTRL_BREAK_EVENT`, unlike Unix
+/// `SIGTERM`), so the node runs to the force-kill and the failure shows up only
+/// as a grace-period kill with no clue where it parked. The watchdog names the
+/// event whose handling has stopped making progress.
+enum LoopActivity {
+    Idle,
+    Handling { since: Instant, what: &'static str },
+}
+
+/// Which *kind* of runtime event the main loop is handling, for the stall
+/// watchdog. Returns a `&'static str` (no per-event allocation on the hot path);
+/// the kind alone distinguishes the two wedge sites that matter — a stalled
+/// `an operator output` is a blocked daemon send, a stalled `an operator input`
+/// is a blocked forward to a parked operator.
+fn describe_runtime_event(event: &RuntimeEvent) -> &'static str {
+    match event {
+        RuntimeEvent::Operator { event, .. } => match event {
+            OperatorEvent::Output { .. } => "an operator output",
+            _ => "an operator lifecycle event",
+        },
+        RuntimeEvent::Event(event) => match event {
+            Event::Input { .. } => "an operator input",
+            Event::InputClosed { .. } => "an input-closed event",
+            Event::Stop(_) => "a stop event",
+            Event::Reload { .. } => "a reload event",
+            _ => "an event",
+        },
+    }
+}
+
+/// Lock a mutex, recovering the guard even if a previous holder panicked. The
+/// watchdog state is pure diagnostics, so a poisoned lock must not take the
+/// runtime down with it.
+fn lock<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }

--- a/examples/python-operator-dataflow/webcam.py
+++ b/examples/python-operator-dataflow/webcam.py
@@ -75,13 +75,39 @@ class Operator:
             # camera, read() above is skipped, keeping the operator responsive.
             headless = frame is None
             if headless:
+                # Diagnostic (dora-rs/dora#2742): the Windows nightly wedges the
+                # webcam operator without ever reaching STOP. These flushed
+                # prints pin *which* call parks on the stuck tick — the native
+                # frame build (`cv2.putText`), the pyarrow encode, or dora's
+                # `send_output` (a blocked daemon-path TCP write). Gated on
+                # `headless` so a real-camera run is unaffected; remove once
+                # #2742 is understood.
+                print(
+                    f"webcam-diag: t={time.time() - self.start_time:.2f}s building placeholder",
+                    flush=True,
+                )
                 frame = self._placeholder_frame()
+                print(
+                    f"webcam-diag: t={time.time() - self.start_time:.2f}s encoding pa.array",
+                    flush=True,
+                )
 
+            payload = pa.array(frame.ravel())
+            if headless:
+                print(
+                    f"webcam-diag: t={time.time() - self.start_time:.2f}s send_output START",
+                    flush=True,
+                )
             send_output(
                 "image",
-                pa.array(frame.ravel()),
+                payload,
                 dora_event["metadata"],
             )
+            if headless:
+                print(
+                    f"webcam-diag: t={time.time() - self.start_time:.2f}s send_output DONE",
+                    flush=True,
+                )
 
             # Stop promptly under CI when there is no real camera, so the node
             # exits well inside the daemon's `--stop-after`/grace instead of
@@ -93,7 +119,9 @@ class Operator:
             ):
                 return DoraStatus.STOP
         elif event_type == "STOP":
-            print("received stop")
+            # `flush=True` so this is never lost in a buffer if the process is
+            # force-killed shortly after (dora-rs/dora#2742 diagnostic).
+            print("received stop", flush=True)
             return DoraStatus.STOP
         else:
             print("received unexpected event:", event_type)


### PR DESCRIPTION
Diagnostics to pin the Windows `cli-tests` wedge in #2742, where the
`python-operator-dataflow` `webcam` source parks without ever receiving Stop
and is force-killed at the grace period (`ExitCode(1)`).

The wedge does not reproduce on Linux: a Rust flood-operator reproducing
webcam's exact backpressure (900 KB output every tick, "dropped operator
inputs" warnings and all) receives Stop and shuts down cleanly. On Unix the
daemon's soft-kill (SIGTERM) terminates a parked process cleanly (`Signal(15)`);
on Windows `CTRL_BREAK_EVENT` cannot interrupt native code, so the parked node
runs to the hard-kill. Since it only fails on Windows and we have no Windows
repro, these diagnostics make the next nightly reveal the exact hop:

- **runtime** — a main-loop stall watchdog warns (naming the stuck activity)
  when handling an event stalls >3s, plus warn-level `received Stop` /
  `forwarded Stop to operator` logs. Together: did the runtime get Stop, did it
  deliver it to the operator, and did the loop wedge in the daemon send vs. an
  input forward.
- **webcam.py** — flushed prints (gated on `headless`, so real cameras are
  unaffected) bracket every native call on the stuck tick; the last line pins
  whether it parked in `cv2`, `pyarrow`, or dora's `send_output`.

Temporary — to be reverted once the wedge is understood. Verified on Linux: no
false stall warnings on healthy runs; the Stop-delivery chain logs as expected.

Refs #2742
