### PR TITLE
fix(runtime): keep a shared-library operator's .so mapped until the event loop joins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6374,6 +6374,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-operator-teardown-example-operator"
+version = "1.0.0-rc.4"
+dependencies = [
+ "dora-operator-api",
+]
+
+[[package]]
 name = "rust-ros2-example-node"
 version = "1.0.0-rc.4"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "examples/multiple-daemons/node",
     "examples/multiple-daemons/operator",
     "examples/multiple-daemons/sink",
+    "examples/rust-operator-teardown/operator",
     "examples/cpu-affinity-probe",
     "examples/log-sink-tcp",
     "examples/log-sink-file",

--- a/binaries/runtime/src/lib.rs
+++ b/binaries/runtime/src/lib.rs
@@ -95,7 +95,12 @@ pub fn main() -> eyre::Result<()> {
     });
 
     let operator_id = operator_definition.id.clone();
-    run_operator(
+    // Keep the operator's shared library mapped until *after* the main event
+    // loop has joined below: its outputs are Arrow arrays whose FFI `release`
+    // callbacks live in the `.so`, and the loop may still hold in-flight arrays
+    // (see `run_operator` / `shared_lib::run`). Unloading it earlier dangles
+    // those callbacks and SIGSEGVs when the arrays are freed.
+    let _operator_library = run_operator(
         &node_id,
         operator_definition,
         incoming_events,
@@ -110,6 +115,9 @@ pub fn main() -> eyre::Result<()> {
         Err(panic) => std::panic::resume_unwind(panic),
     }
 
+    // `_operator_library` drops (unloads the `.so`) at end of scope here, after
+    // the main loop has joined and released every Arrow array the operator
+    // exported.
     Ok(())
 }
 

--- a/binaries/runtime/src/operator/mod.rs
+++ b/binaries/runtime/src/operator/mod.rs
@@ -12,6 +12,12 @@ pub mod channel;
 mod python;
 mod shared_lib;
 
+/// Runs the operator to completion. Returns a shared library that the caller
+/// **must keep alive until after the runtime's main event loop has joined**: a
+/// shared-library operator's outputs are Arrow arrays whose FFI `release`
+/// callbacks point into the `.so`, and the main loop (on another thread) may
+/// still hold in-flight arrays when this returns. See `shared_lib::run`. Returns
+/// `None` for operator kinds with no such library (Python).
 #[allow(unused_variables)]
 pub fn run_operator(
     node_id: &NodeId,
@@ -20,10 +26,10 @@ pub fn run_operator(
     events_tx: Sender<OperatorEvent>,
     init_done: oneshot::Sender<Result<()>>,
     dataflow_descriptor: &Descriptor,
-) -> eyre::Result<()> {
-    match &operator_definition.config.source {
+) -> eyre::Result<Option<libloading::Library>> {
+    let library = match &operator_definition.config.source {
         OperatorSource::SharedLibrary(source) => {
-            shared_lib::run(
+            let library = shared_lib::run(
                 node_id,
                 &operator_definition.id,
                 source,
@@ -37,25 +43,29 @@ pub fn run_operator(
                     operator_definition.id
                 )
             })?;
+            Some(library)
         }
         #[allow(unused_variables)]
         OperatorSource::Python(source) => {
             #[cfg(feature = "python")]
-            python::run(
-                node_id,
-                &operator_definition.id,
-                source,
-                events_tx,
-                incoming_events,
-                init_done,
-                dataflow_descriptor,
-            )
-            .wrap_err_with(|| {
-                format!(
-                    "failed to spawn Python operator for {}",
-                    operator_definition.id
+            {
+                python::run(
+                    node_id,
+                    &operator_definition.id,
+                    source,
+                    events_tx,
+                    incoming_events,
+                    init_done,
+                    dataflow_descriptor,
                 )
-            })?;
+                .wrap_err_with(|| {
+                    format!(
+                        "failed to spawn Python operator for {}",
+                        operator_definition.id
+                    )
+                })?;
+                None
+            }
             #[cfg(not(feature = "python"))]
             eyre::bail!(
                 "operator `{}` uses a Python source, but this dora-runtime was \
@@ -69,8 +79,8 @@ pub fn run_operator(
                 operator_definition.id
             );
         }
-    }
-    Ok(())
+    };
+    Ok(library)
 }
 
 #[derive(Debug)]

--- a/binaries/runtime/src/operator/shared_lib.rs
+++ b/binaries/runtime/src/operator/shared_lib.rs
@@ -29,7 +29,7 @@ pub fn run(
     events_tx: Sender<OperatorEvent>,
     incoming_events: flume::Receiver<Event>,
     init_done: oneshot::Sender<Result<()>>,
-) -> eyre::Result<()> {
+) -> eyre::Result<libloading::Library> {
     let path = if source_is_url(source) {
         let target_path = &Path::new("build");
         // try to download the shared library
@@ -82,7 +82,19 @@ pub fn run(
         }
     }
 
-    Ok(())
+    // Hand the loaded library back to the caller instead of dropping (unloading)
+    // it here. Arrow arrays produced by this operator are exported over the C
+    // data interface with a `release` callback that points *into* this `.so`
+    // (`arrow::ffi::from_ffi` imports them in `send_output_closure`). The runtime's
+    // main event loop runs on another thread and may still hold in-flight arrays
+    // when we return — the `OperatorEvent::Finished` above only guarantees the
+    // channel slot was taken, not that every prior output has been sent and
+    // dropped. Unloading the library now (dlclose on drop) would dangle those
+    // release callbacks, so freeing the arrays afterwards jumps into unmapped
+    // code (SIGSEGV, reproducible under a high output rate at shutdown). The
+    // caller keeps this alive until after the main loop has joined, by which
+    // point every exported array has been released.
+    Ok(library)
 }
 
 struct SharedLibraryOperator<'lib> {

--- a/examples/rust-operator-teardown/dataflow.yml
+++ b/examples/rust-operator-teardown/dataflow.yml
@@ -1,0 +1,20 @@
+# Regression fixture for a shared-library operator teardown SIGSEGV: a source
+# operator floods large outputs into a sink, so a burst is in flight when
+# `--stop-after` stops the dataflow. Both nodes load the same operator library.
+nodes:
+  - id: source
+    operators:
+      - id: op
+        build: cargo build -p rust-operator-teardown-example-operator
+        shared-library: ../../target/debug/rust_operator_teardown_example_operator
+        inputs:
+          tick: dora/timer/millis/5
+        outputs:
+          - data
+  - id: sink
+    operators:
+      - id: op
+        build: cargo build -p rust-operator-teardown-example-operator
+        shared-library: ../../target/debug/rust_operator_teardown_example_operator
+        inputs:
+          data: source/op/data

--- a/examples/rust-operator-teardown/operator/Cargo.toml
+++ b/examples/rust-operator-teardown/operator/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "rust-operator-teardown-example-operator"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+dora-operator-api = { workspace = true }

--- a/examples/rust-operator-teardown/operator/src/lib.rs
+++ b/examples/rust-operator-teardown/operator/src/lib.rs
@@ -1,0 +1,42 @@
+//! Regression fixture for dora-rs/dora: a shared-library operator that emits
+//! many large Arrow outputs on every tick, so a burst is in flight at
+//! `--stop-after`. The runtime used to unload the operator's `.so` as soon as
+//! its `on_event` loop returned, while the main loop (another thread) was still
+//! sending those in-flight arrays — whose Arrow FFI `release` callbacks live in
+//! the `.so`. Freeing them after `dlclose` jumped into unmapped code (SIGSEGV).
+//! Driven by `tests/example-smoke.rs::local_rust_operator_teardown_no_segfault`.
+#![warn(unsafe_op_in_unsafe_fn)]
+
+use dora_operator_api::{
+    DoraOperator, DoraOutputSender, DoraStatus, Event, IntoArrow, register_operator,
+};
+
+register_operator!(TeardownOperator);
+
+#[derive(Default)]
+struct TeardownOperator;
+
+impl DoraOperator for TeardownOperator {
+    fn on_event(
+        &mut self,
+        event: &Event,
+        output_sender: &mut DoraOutputSender,
+    ) -> Result<DoraStatus, String> {
+        match event {
+            Event::Input { id, .. } => match *id {
+                // Source: flood large outputs so many are in flight at shutdown.
+                "tick" => {
+                    for _ in 0..20 {
+                        output_sender.send("data", vec![0u8; 512 * 1024].into_arrow())?;
+                    }
+                }
+                // Sink: just consume.
+                "data" => {}
+                _ => {}
+            },
+            Event::Stop => return Ok(DoraStatus::Stop),
+            _ => {}
+        }
+        Ok(DoraStatus::Continue)
+    }
+}

--- a/tests/example-smoke.rs
+++ b/tests/example-smoke.rs
@@ -371,6 +371,23 @@ fn smoke_rust_dataflow_url() {
     );
 }
 
+/// Regression test for a shared-library operator teardown SIGSEGV: the runtime
+/// used to unload the operator's `.so` as soon as its `on_event` loop returned,
+/// while the main loop (another thread) still held in-flight Arrow arrays whose
+/// FFI `release` callbacks live in that `.so`. Freeing them after `dlclose`
+/// jumped into unmapped code (`Signal(11)`). The fixture floods large outputs so
+/// a burst is in flight at `--stop-after`; `run_smoke_test_local` asserts `dora
+/// run` exits zero, which a crashing operator node breaks. Builds the operator
+/// via the dataflow's `build:` field.
+#[test]
+fn local_rust_operator_teardown_no_segfault() {
+    run_smoke_test_local(
+        "rust-operator-teardown",
+        "examples/rust-operator-teardown/dataflow.yml",
+        3,
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Benchmark example (release build)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
A shared-library operator's outputs are Arrow arrays exported over the C data
interface; `arrow::ffi::from_ffi` (in `send_output_closure`) imports them with a
`release` callback that points **into** the operator's `.so`. The runtime
unloaded that library (dlclose on `Library` drop) as soon as the operator's
`on_event` loop returned — but the main event loop runs on another thread and can
still hold in-flight arrays at that point (`OperatorEvent::Finished` only
guarantees the channel slot was taken, not that every prior output has been sent
and dropped). Freeing those arrays after the unload jumps into unmapped code:
`Signal(11)` / SIGSEGV, reliably reproducible under a high output rate at
shutdown.

**Fix:** hand the loaded `Library` back through `run_operator` to `main`, which
holds it until *after* the main loop has joined — by which point every exported
array has been released. Deterministic; zero-copy preserved (no leak, no
per-output copy).

**Regression test:** a shared-library operator floods large outputs into a sink
so a burst is in flight at `--stop-after`; the smoke test asserts `dora run`
exits cleanly. Verified RED→GREEN — it fails with `Node source failed: exited
because of signal SIGSEGV` on the pre-fix runtime and passes with the fix.

Found while diagnosing #2742 (independent of that Windows wedge).
