### PR TITLE
fix(cli): render sub-millisecond timer inputs correctly in `dora node info`

### DIFF
--- a/binaries/cli/src/command/node/info.rs
+++ b/binaries/cli/src/command/node/info.rs
@@ -230,18 +230,16 @@ fn build_input_info(node_desc: &dora_message::descriptor::Node) -> Vec<InputInfo
     node_desc
         .inputs
         .iter()
-        .map(|(input_id, input)| {
-            let source = match &input.mapping {
-                InputMapping::User(user) => format!("{}/{}", user.source, user.output),
-                InputMapping::Timer { interval } => {
-                    format!("dora/timer/millis/{}", interval.as_millis())
-                }
-                mapping @ InputMapping::Logs(_) => mapping.to_string(),
-            };
-            InputInfo {
-                id: input_id.to_string(),
-                source,
-            }
+        .map(|(input_id, input)| InputInfo {
+            id: input_id.to_string(),
+            // Use `InputMapping`'s canonical `Display` rather than re-deriving the
+            // source string here. The previous hand-rolled
+            // `dora/timer/millis/{interval.as_millis()}` truncated any
+            // sub-millisecond timer (e.g. a `dora/timer/hz/2000` = 500µs input)
+            // to `dora/timer/millis/0`, a nonsensical zero-interval source;
+            // `Display` picks the coarsest exact unit and round-trips through the
+            // descriptor parser.
+            source: input.mapping.to_string(),
         })
         .collect()
 }


### PR DESCRIPTION
## Issue

`build_input_info` in `binaries/cli/src/command/node/info.rs` reconstructed every timer input source by hand as `dora/timer/millis/{interval.as_millis()}`.

`Duration::as_millis()` floors to `0` for any sub-millisecond interval, so a valid high-rate timer input such as `dora/timer/hz/2000` (500 µs) was displayed by `dora node info` as `dora/timer/millis/0` — a nonsensical zero-interval source that no longer round-trips through the descriptor parser. Whole-Hz timers like `dora/timer/hz/3` (~333 ms) were also rendered lossily as `millis/333`.

## Fix

Use `InputMapping`'s canonical `Display` impl (`libraries/message/src/config.rs`) instead of re-deriving the source string. `Display` already selects the coarsest exact unit (`secs`/`millis`/`micros`/`nanos`) and is the form the descriptor round-trips through. The `User` and `Logs` arms of the old hand-rolled `match` rendered identically to `Display` anyway, so this also removes a small reimplementation of the trait — `build_input_info` now just calls `input.mapping.to_string()`.

## Validation

- New unit tests were unnecessary: the sub-millisecond round-trip is already covered by dora-message's existing `timer_subms_interval_roundtrips` test, which guarantees `Display` never truncates.
- `cargo test -p dora-cli`, `cargo clippy -p dora-cli --all-targets -- -D warnings`, and `cargo fmt --all -- --check` all pass.
- Full workspace test suite green except for pre-existing zenoh/ros2 networking tests that require IPv6 (unavailable in the CI sandbox) — unrelated to this CLI-only change.

---

🤖 This is a machine-generated pull request opened by Claude Code. A human maintainer should review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142J7B2578ixrh77kNDNJry

---
_Generated by [Claude Code](https://claude.ai/code/session_0142J7B2578ixrh77kNDNJry)_