### PR TITLE
fix(cli): don't drop compact JSONL log lines that omit the `level` key

### DIFF
--- a/binaries/cli/src/output.rs
+++ b/binaries/cli/src/output.rs
@@ -183,7 +183,11 @@ pub fn parse_jsonl_line(line: &str) -> Option<LogMessage> {
     let v: serde_json::Value = serde_json::from_str(line).ok()?;
     let ts = v.get("ts")?.as_str()?;
     let timestamp = chrono::DateTime::parse_from_rfc3339(ts).ok()?.to_utc();
-    let level_str = v.get("level")?.as_str().unwrap_or("stdout");
+    // A missing `level` key defaults to stdout-level rather than dropping the
+    // line. The previous `v.get("level")?` short-circuited the whole function
+    // to `None` when the key was absent, which both discarded the line and made
+    // the trailing `.unwrap_or("stdout")` dead code.
+    let level_str = v.get("level").and_then(|l| l.as_str()).unwrap_or("stdout");
     let level = match level_str {
         "error" => LogLevelOrStdout::LogLevel(log::Level::Error),
         "warn" => LogLevelOrStdout::LogLevel(log::Level::Warn),
@@ -450,6 +454,17 @@ mod tests {
             LogLevelOrStdout::LogLevel(log::Level::Info)
         ));
         assert_eq!(msg.node_id.unwrap().to_string(), "sensor");
+    }
+
+    #[test]
+    fn parse_jsonl_compact_without_level_defaults_to_stdout() {
+        // A compact line missing the `level` key must still be parsed and
+        // default to stdout-level, not be silently dropped (the `?` on
+        // `v.get("level")` previously discarded the whole line).
+        let line = r#"{"ts":"2025-01-01T00:00:00Z","node":"sensor","msg":"plain line"}"#;
+        let msg = parse_jsonl_line(line).expect("line without `level` must not be dropped");
+        assert_eq!(msg.message, "plain line");
+        assert!(matches!(msg.level, LogLevelOrStdout::Stdout));
     }
 
     #[test]


### PR DESCRIPTION
## Issue

`parse_jsonl_line` in `binaries/cli/src/output.rs` read a compact log line's level with:

```rust
let level_str = v.get("level")?.as_str().unwrap_or("stdout");
```

The `?` short-circuits the **whole function** to `None` when the `level` key is absent, so a compact log line carrying `ts` + `msg` but no `level` was silently **discarded** instead of shown. That also made the trailing `.unwrap_or("stdout")` dead code — it can only ever run when the key is present but non-string, never for the missing-key case the default was clearly written to cover.

The first-party daemon writer currently always emits `level`, so this is latent for dora's own logs, but it bites any legacy / hand-written / third-party compact JSONL the CLI is asked to read, and the intent of the code (default to stdout) was already contradicted by its own control flow.

## Fix

Read the key without the short-circuit:

```rust
let level_str = v.get("level").and_then(|l| l.as_str()).unwrap_or("stdout");
```

so a missing (or non-string) level falls back to stdout-level, matching the intent and the `.get().and_then()` shape already used for the adjacent `node` / `msg` / `target` fields.

## Validation

- Added regression test `parse_jsonl_compact_without_level_defaults_to_stdout`, asserting a compact line without `level` is parsed (not dropped) and defaults to `Stdout`.
- `cargo test -p dora-cli`, `cargo clippy -p dora-cli --all-targets -- -D warnings`, and `cargo fmt --all -- --check` all pass.

---

🤖 This is a machine-generated pull request opened by Claude Code. A human maintainer should review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142J7B2578ixrh77kNDNJry

---
_Generated by [Claude Code](https://claude.ai/code/session_0142J7B2578ixrh77kNDNJry)_