### PR TITLE
fix(runtime): enter Python tracing span after parent context setup

### DIFF
--- a/binaries/runtime/src/operator/python.rs
+++ b/binaries/runtime/src/operator/python.rs
@@ -189,7 +189,6 @@ pub fn run(
 
             let status = Python::attach(|py| -> Result<i32> {
                 let span = span!(tracing::Level::TRACE, "on_event", input_id = field::Empty);
-                let _enter = span.enter();
 
                 // Add metadata context if we have a tracer and
                 // incoming input has some metadata.
@@ -216,6 +215,7 @@ pub fn run(
                         Parameter::String(string_cx),
                     );
                 }
+                let _enter = span.enter();
 
                 let py_event = PyEvent {
                     event: MergedEvent::Dora(event),


### PR DESCRIPTION
## Summary

Ensure Python operator tracing spans are entered only after the OpenTelemetry parent context has been established, preserving the correct tracing context during `on_event` callback execution.

Fixes #2862

## Root Cause

In `binaries/runtime/src/operator/python.rs`, the tracing span was entered before the incoming OpenTelemetry parent context was attached via `span.set_parent(cx)`.

As a result, the span became active without the correct parent context, causing Python operator execution to be detached from the intended trace hierarchy.

## Solution

- Move `let _enter = span.enter();` to execute after the `#[cfg(feature = "telemetry")]` block sets the parent context.
- Preserve the entered span for the entire lifetime of the Python `on_event` callback by keeping the guard alive until the callback completes.

## Testing

- ✅ `cargo fmt --all -- --check`
- ✅ `cargo check -p dora-runtime`

## Scope

This PR is intentionally limited to `binaries/runtime/src/operator/python.rs` and only changes the ordering of tracing span entry relative to parent context initialization. No functional behavior or public APIs were modified.