### PR TITLE
fix(ros2-bridge): don't panic on zero-field message types (std_msgs/Empty)

### DIFF
--- a/libraries/extensions/ros2-bridge/arrow/src/deserialize/mod.rs
+++ b/libraries/extensions/ros2-bridge/arrow/src/deserialize/mod.rs
@@ -217,7 +217,15 @@ impl<'de> serde::de::Visitor<'de> for StructVisitor<'_> {
             ));
         }
 
-        let struct_array: StructArray = fields.into();
+        // A message type with zero fields (e.g. `std_msgs/msg/Empty`) yields an
+        // empty `fields` vec. `StructArray::from(Vec<..>)` panics on an empty vec
+        // because the array length is ambiguous, so build a length-1 empty-fields
+        // struct explicitly instead.
+        let struct_array: StructArray = if fields.is_empty() {
+            StructArray::new_empty_fields(1, None)
+        } else {
+            fields.into()
+        };
 
         Ok(struct_array.into())
     }
@@ -329,5 +337,44 @@ mod tests {
         // ...but the child type is the correct `Point` struct.
         assert!(matches!(inner.data_type(), DataType::Struct(fields)
             if fields.len() == 1 && fields[0].name() == "x"));
+    }
+
+    /// Regression test for #2804: a message type with zero fields (e.g.
+    /// `std_msgs/msg/Empty`) must not panic the deserializer. Previously
+    /// `StructArray::from(Vec<..>)` panicked on the empty field vec because the
+    /// array length was ambiguous, which poisoned the DDS cache lock held on the
+    /// take path and killed the whole participant.
+    #[test]
+    fn empty_message_deserializes() {
+        let empty = Message {
+            package: "test_pkg".to_string(),
+            name: "Empty".to_string(),
+            members: vec![],
+            constants: vec![],
+        };
+        let mut package = HashMap::new();
+        package.insert("Empty".to_string(), empty);
+        let mut messages = HashMap::new();
+        messages.insert("test_pkg".to_string(), package);
+
+        let type_info = TypeInfo {
+            package_name: Cow::Borrowed("test_pkg"),
+            message_name: Cow::Borrowed("Empty"),
+            messages: Arc::new(messages),
+        };
+
+        // An empty message has no fields, so the CDR body is empty.
+        let bytes: Vec<u8> = Vec::new();
+
+        let seed = StructDeserializer::new(Cow::Owned(type_info));
+        let mut deserializer = cdr_encoding::CdrDeserializer::<LittleEndian>::new(&bytes);
+        let data = serde::de::DeserializeSeed::deserialize(seed, &mut deserializer)
+            .expect("empty message must deserialize successfully");
+
+        let array = make_array(data);
+        let empty = array.as_struct();
+        // One struct row with no columns.
+        assert_eq!(empty.len(), 1);
+        assert_eq!(empty.num_columns(), 0);
     }
 }

--- a/libraries/extensions/ros2-bridge/arrow/src/serialize/defaults.rs
+++ b/libraries/extensions/ros2-bridge/arrow/src/serialize/defaults.rs
@@ -241,7 +241,15 @@ fn default_for_referenced_message(
         })
         .collect::<Result<_, _>>()?;
 
-    let struct_array: StructArray = fields.into();
+    // A referenced message with zero fields (e.g. `std_msgs/msg/Empty`) yields an
+    // empty `fields` vec. `StructArray::from(Vec<..>)` panics on an empty vec
+    // because the array length is ambiguous, so build a length-1 empty-fields
+    // struct explicitly instead.
+    let struct_array: StructArray = if fields.is_empty() {
+        StructArray::new_empty_fields(1, None)
+    } else {
+        fields.into()
+    };
     Ok(struct_array.into())
 }
 


### PR DESCRIPTION
## Summary

Fixes #2804.

Deserializing a ROS 2 message type with **zero fields** (e.g. `std_msgs/msg/Empty`) panicked in the ros2-bridge CDR→Arrow conversion:

```
called `Result::unwrap()` on an `Err` value: InvalidArgumentError("use StructArray::try_new_with_length or StructArray::new_empty_fields to create a struct array with no fields so that the length can be set correctly")
```

`StructArray::from(Vec<..>)` panics on an empty field vec because the array length is ambiguous with no columns. Since the deserializer runs inside the subscription take path **while a RustDDS cache lock is held**, the panic poisoned the DDS cache mutex and then killed the participant event loop — silently taking down *every* subscription on the participant (0 Hz on all topics) after a single stray `Empty` message.

## Changes

- `deserialize/mod.rs` (the take path) and `serialize/defaults.rs` (default-value construction) now build a length‑1 empty‑fields struct via `StructArray::new_empty_fields(1, None)` when there are no fields, instead of `fields.into()`. This mirrors the pattern already used in the crate's default-value test code.
- Added a regression test `empty_message_deserializes` that deserializes a zero‑field message and asserts it produces a single struct row with no columns.

## Testing

- `cargo test -p dora-ros2-bridge-arrow` — 16 passed, incl. the new regression test
- `cargo clippy -p dora-ros2-bridge-arrow -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpY25UTvkyfgyTaJYcAQ7v)_