### PR TITLE
fix(python): use wrapping_add(1) in seqlock_begin_write for overflow consistency

### DIFF
--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -526,7 +526,7 @@ fn warn_missing_memory_pool(node_id: &NodeId, action: &str, buffer_id: &str) {
 unsafe fn seqlock_begin_write(gen_ptr: *mut u64) -> u64 {
     unsafe {
         let pre_write_gen = std::ptr::read_volatile(gen_ptr);
-        std::ptr::write_volatile(gen_ptr, pre_write_gen + 1);
+        std::ptr::write_volatile(gen_ptr, pre_write_gen.wrapping_add(1));
         std::sync::atomic::fence(std::sync::atomic::Ordering::Release);
         pre_write_gen
     }


### PR DESCRIPTION
## Summary

Use `wrapping_add(1)` in `seqlock_begin_write` to provide consistent overflow handling for the seqlock generation counter.

Fixes #2865

## Root Cause

In `apis/python/node/src/lib.rs`, `seqlock_begin_write` incremented the generation counter using `pre_write_gen + 1`, while `seqlock_end_write` already used `pre_write_gen.wrapping_add(2)`.

Using normal integer addition can panic on `u64` overflow in debug builds or when overflow checks are enabled, resulting in inconsistent overflow behavior between the begin and end write paths.

## Solution

- Replaced `pre_write_gen + 1` with `pre_write_gen.wrapping_add(1)` in `seqlock_begin_write`.
- Align the overflow behavior with `seqlock_end_write`, ensuring the generation counter wraps consistently without panicking.

## Testing

- ✅ `cargo fmt --all -- --check`
- ✅ `cargo check -p dora-node-api-python`

## Scope

This PR is intentionally limited to `apis/python/node/src/lib.rs` and changes a single arithmetic operation to ensure consistent overflow handling. No functional APIs or runtime behavior were otherwise modified.