### PR TITLE
docs(cli): update --stop-after doc examples to match duration-str grammar

### DIFF
--- a/binaries/cli/src/command/run.rs
+++ b/binaries/cli/src/command/run.rs
@@ -47,6 +47,7 @@ pub struct Run {
     /// similar to pressing Ctrl-C. This gracefully stops all nodes in the dataflow.
     ///
     /// Examples:
+    ///   --stop-after 30      # 30 seconds (a bare number is seconds)
     ///   --stop-after 10s     # 10 seconds
     ///   --stop-after 5m      # 5 minutes
     ///   --stop-after 1h30m   # 1 hour 30 minutes

--- a/binaries/cli/src/command/run.rs
+++ b/binaries/cli/src/command/run.rs
@@ -47,9 +47,10 @@ pub struct Run {
     /// similar to pressing Ctrl-C. This gracefully stops all nodes in the dataflow.
     ///
     /// Examples:
-    ///   --stop-after 30      # 30 seconds
-    ///   --stop-after 30s     # 30 seconds
+    ///   --stop-after 10s     # 10 seconds
     ///   --stop-after 5m      # 5 minutes
+    ///   --stop-after 1h30m   # 1 hour 30 minutes
+    ///   --stop-after 500ms   # 500 milliseconds
     #[clap(long, value_name = "DURATION", verbatim_doc_comment)]
     #[arg(value_parser = parse_duration)]
     pub stop_after: Option<Duration>,


### PR DESCRIPTION
## Summary

Update the `--stop-after` CLI help examples to match the duration formats accepted by the `duration-str` parser.

Fixes #2867 

## Root Cause

The help text for the `--stop-after` option in `binaries/cli/src/command/run.rs` did not fully reflect the duration formats supported by the parser. In particular, examples for compound durations (e.g. `1h30m`) and sub-second durations (e.g. `500ms`) were missing, making the CLI documentation less representative of the accepted syntax.

## Solution

- Updated the `--stop-after` documentation examples to use valid `duration-str` formats.
- Added examples covering:
  - `10s`
  - `5m`
  - `1h30m`
  - `500ms`

This aligns the CLI help text with the formats accepted by `common::parse_duration`.

## Testing

- ✅ `cargo fmt --all -- --check`
- ✅ `cargo check -p dora-cli`

## Scope

This PR is intentionally limited to documentation updates in `binaries/cli/src/command/run.rs`. No parser behavior, runtime logic, or public APIs were modified.