### PR TITLE
feat(daemon,core): allow opting out of zenoh multicast scouting

### DIFF
--- a/binaries/cli/src/command/daemon.rs
+++ b/binaries/cli/src/command/daemon.rs
@@ -62,6 +62,26 @@ pub struct Daemon {
     /// the `zenoh_peer` field in cluster.yml.
     #[clap(long, value_name = "ENDPOINT")]
     zenoh_peer: Option<String>,
+    /// Open zenoh sessions without multicast scouting, for this daemon and the
+    /// nodes it spawns.
+    ///
+    /// Discovery then relies entirely on explicit endpoints — which is already
+    /// how the daemon reaches its nodes (it injects `DORA_ZENOH_CONNECT` into
+    /// each one) and, with `--zenoh-peer`, how daemons reach each other. Use it
+    /// where the scouting socket itself is the problem: a busy DDS/ROS2
+    /// multicast graph can keep zenoh from binding its scouting group, which
+    /// fails session startup outright.
+    ///
+    /// Not for multi-daemon setups without `--zenoh-peer`: those discover each
+    /// other *by* multicast, and this would leave them unable to.
+    ///
+    /// Dynamic nodes need care too. They are started outside the daemon, so
+    /// they inherit neither its environment nor a `DORA_ZENOH_CONNECT`, and
+    /// scouting is symmetric — a dynamic node still scouting finds nothing once
+    /// the daemon has stopped answering. Export `DORA_ZENOH_CONNECT` (the
+    /// daemon's listen endpoint) for them yourself when using this flag.
+    #[clap(long)]
+    zenoh_no_multicast: bool,
     /// IP address this daemon's Zenoh listener binds (e.g. `--zenoh-listen
     /// 100.64.0.3`).
     ///
@@ -265,7 +285,7 @@ impl Executable for Daemon {
                         handle_dataflow_result(result, None)
                     }
                     None => {
-                        dora_daemon::Daemon::run_with_zenoh_listen(SocketAddr::new(self.coordinator_addr, self.coordinator_port), self.machine_id, self.labels.unwrap_or_default(), self.local_listen_port, self.zenoh_peer, self.zenoh_listen).await
+                        dora_daemon::Daemon::run_with_zenoh_listen(SocketAddr::new(self.coordinator_addr, self.coordinator_port), self.machine_id, self.labels.unwrap_or_default(), self.local_listen_port, self.zenoh_peer, self.zenoh_listen, self.zenoh_no_multicast).await
                     }
                 }
             })

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -9,9 +9,9 @@ use dora_core::{
         read_as_descriptor, validate,
     },
     topics::{
-        DORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT, LOCALHOST, open_zenoh_session_with_listen,
-        reserve_zenoh_endpoint, validate_zenoh_listen, zenoh_bind_address_for,
-        zenoh_daemon_control_topic, zenoh_output_publish_topic,
+        DORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT, LOCALHOST, MulticastScouting,
+        open_zenoh_session_with_listen, reserve_zenoh_endpoint, validate_zenoh_listen,
+        zenoh_bind_address_for, zenoh_daemon_control_topic, zenoh_output_publish_topic,
     },
     uhlc::{self, HLC},
 };
@@ -282,6 +282,10 @@ pub struct Daemon {
     /// peer without multicast (#1778). `None` when the OS rejected the
     /// reservation; nodes then fall back to multicast scouting.
     pub(crate) zenoh_listen_endpoint: Option<String>,
+    /// Whether this daemon opened its zenoh session without multicast
+    /// scouting. Forwarded to spawned nodes so they discover the same way the
+    /// daemon does (see `DORA_ZENOH_MULTICAST`).
+    pub(crate) disable_multicast: bool,
     pub(crate) zenoh_publish_tx: mpsc::Sender<ZenohOutbound>,
     pub(crate) remote_daemon_events_tx:
         Option<flume::Sender<eyre::Result<Timestamped<InterDaemonEvent>>>>,
@@ -646,6 +650,7 @@ impl Daemon {
         local_listen_port: u16,
         inter_daemon_peer: Option<String>,
         zenoh_listen_addr: Option<IpAddr>,
+        disable_multicast: bool,
     ) -> eyre::Result<()> {
         Self::run_inner_with_builds(
             coordinator_ws_addr,
@@ -654,6 +659,7 @@ impl Daemon {
             local_listen_port,
             inter_daemon_peer,
             zenoh_listen_addr,
+            disable_multicast,
             Default::default(),
         )
         .await
@@ -667,6 +673,7 @@ impl Daemon {
         local_listen_port: u16,
         inter_daemon_peer: Option<String>,
         zenoh_listen_addr: Option<IpAddr>,
+        disable_multicast: bool,
         initial_builds: BTreeMap<BuildId, BuildInfo>,
     ) -> eyre::Result<()> {
         let zenoh_bind = match zenoh_listen_addr {
@@ -832,6 +839,7 @@ impl Daemon {
                                 log_destination,
                                 inter_daemon_peer.clone(),
                                 zenoh_bind,
+                                disable_multicast,
                             )
                             .await?;
                             daemon = Some(built);
@@ -978,10 +986,10 @@ impl Daemon {
         let nodes = descriptor.resolve_aliases_and_set_defaults()?;
 
         let (events_tx, events_rx) = flume::bounded(10);
-        if nodes
+        let has_dynamic_nodes = nodes
             .iter()
-            .any(|(_n, resolved_nodes)| resolved_nodes.kind.dynamic())
-        {
+            .any(|(_n, resolved_nodes)| resolved_nodes.kind.dynamic());
+        if has_dynamic_nodes {
             // Spawn local listener for dynamic nodes
             let _listen_port = local_listener::spawn_listener_loop(
                 (LOCALHOST, DORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT).into(),
@@ -1079,6 +1087,17 @@ impl Daemon {
             // Local dataflow runs (one daemon, no cluster) never need
             // cross-daemon Zenoh discovery; the rendezvous is irrelevant.
             None,
+            // `dora run` is single-machine by construction, and every node it
+            // spawns is handed `DORA_ZENOH_CONNECT`, so all links are explicit
+            // and multicast scouting buys nothing — while still exposing us to
+            // a scouting bind that fails on a busy DDS/ROS2 network.
+            //
+            // Dynamic nodes are the exception: they are started by the user in
+            // a separate process, inherit none of the daemon's environment, and
+            // so have no endpoint to dial. Multicast is the only way they and
+            // the daemon find each other, so keep it on when the descriptor
+            // declares any.
+            !has_dynamic_nodes,
         );
 
         let spawn_result = reply_rx
@@ -1125,6 +1144,7 @@ impl Daemon {
         log_destination: LogDestination,
         health_check_interval_duration: Option<Duration>,
         inter_daemon_peer: Option<String>,
+        disable_multicast: bool,
     ) -> eyre::Result<DaemonRunResult> {
         // Single-shot path (`dora run`): build the daemon and run one event
         // loop. The reconnecting daemon binary instead builds the daemon once
@@ -1143,6 +1163,7 @@ impl Daemon {
             log_destination,
             inter_daemon_peer,
             ZenohBind::Derived(LOCALHOST),
+            disable_multicast,
         )
         .await?;
         daemon
@@ -1174,6 +1195,7 @@ impl Daemon {
         log_destination: LogDestination,
         inter_daemon_peer: Option<String>,
         zenoh_bind: ZenohBind,
+        disable_multicast: bool,
     ) -> eyre::Result<(Self, mpsc::Receiver<Timestamped<Event>>)> {
         // Reserve a port and have zenoh listen on it. The endpoint is injected
         // into spawned nodes via `DORA_ZENOH_CONNECT` so peer discovery works
@@ -1226,6 +1248,11 @@ impl Daemon {
             None,
             requested_listen_endpoint.as_deref(),
             inter_daemon_peer.as_deref(),
+            if disable_multicast {
+                MulticastScouting::Disabled
+            } else {
+                MulticastScouting::Allowed
+            },
         )
         .await
         .wrap_err("failed to open zenoh session")?;
@@ -1291,6 +1318,7 @@ impl Daemon {
             ft_stats: Default::default(),
             zenoh_session,
             zenoh_listen_endpoint,
+            disable_multicast,
             zenoh_publish_tx,
             remote_daemon_events_tx,
             git_manager: Default::default(),
@@ -2096,6 +2124,7 @@ impl Daemon {
                         shutdown: dataflow.listener_shutdown_rx.clone(),
                         zenoh_connect_endpoint: self.zenoh_listen_endpoint.clone(),
                         zenoh_peering: dataflow.zenoh_peering.clone(),
+                        disable_multicast: self.disable_multicast,
                     };
                     let mut logger = self
                         .logger
@@ -3234,6 +3263,7 @@ impl Daemon {
             shutdown: dataflow.listener_shutdown_rx.clone(),
             zenoh_connect_endpoint: self.zenoh_listen_endpoint.clone(),
             zenoh_peering: dataflow.zenoh_peering.clone(),
+            disable_multicast: self.disable_multicast,
         };
 
         let mut tasks = Vec::new();

--- a/binaries/daemon/src/spawn/spawner.rs
+++ b/binaries/daemon/src/spawn/spawner.rs
@@ -13,7 +13,7 @@ use dora_core::{
         CoreNodeKind, Descriptor, OperatorDefinition, OperatorSource, PythonSource, ResolvedNode,
     },
     get_python_path,
-    topics::{DORA_ZENOH_CONNECT_ENV, DORA_ZENOH_LISTEN_ENV},
+    topics::{DORA_ZENOH_CONNECT_ENV, DORA_ZENOH_LISTEN_ENV, DORA_ZENOH_MULTICAST_ENV},
     uhlc::HLC,
 };
 use dora_message::{
@@ -249,11 +249,15 @@ pub struct Spawner {
     /// Per-node listener + dial-list, so the node↔node links the dataflow needs
     /// are established deterministically. See [`plan_zenoh_peering`].
     pub zenoh_peering: Arc<BTreeMap<NodeId, NodeZenohPeering>>,
+    /// Whether this daemon runs without multicast scouting, so spawned nodes
+    /// should too (see [`DORA_ZENOH_MULTICAST_ENV`]). Mixing modes leaves a
+    /// node scouting for a daemon that no longer answers.
+    pub disable_multicast: bool,
 }
 
 impl Spawner {
     fn maybe_inject_zenoh_connect(&self, command: Command, node_id: &NodeId) -> Command {
-        match self.zenoh_peering.get(node_id) {
+        let command = match self.zenoh_peering.get(node_id) {
             Some(peering) => {
                 let command = command.env(DORA_ZENOH_LISTEN_ENV, &peering.listen);
                 if peering.connect.is_empty() {
@@ -269,6 +273,16 @@ impl Spawner {
                 Some(ep) => command.env(DORA_ZENOH_CONNECT_ENV, ep),
                 None => command,
             },
+        };
+        // Forward the daemon's multicast decision unconditionally: it is a
+        // request, and `open_zenoh_session_with_listen` ignores it for a node
+        // that ended up with neither an endpoint to dial nor a listener to be
+        // dialled on. Re-deriving that condition here would duplicate the
+        // #1856 guard against the code that owns it.
+        if self.disable_multicast {
+            command.env(DORA_ZENOH_MULTICAST_ENV, "off")
+        } else {
+            command
         }
     }
 
@@ -639,6 +653,54 @@ impl Spawner {
 mod tests {
     use super::*;
     use dora_core::descriptor::DescriptorExt;
+    use std::ffi::{OsStr, OsString};
+
+    fn spawner_for(daemon_endpoint: Option<&str>, disable_multicast: bool) -> Spawner {
+        let (daemon_tx, _rx) = mpsc::channel(1);
+        let (_shutdown_tx, shutdown) = tokio::sync::watch::channel(false);
+        Spawner {
+            dataflow_id: uuid::Uuid::nil(),
+            daemon_tx,
+            dataflow_descriptor: serde_yaml::from_str("nodes: []").expect("parse descriptor"),
+            clock: Arc::new(HLC::default()),
+            uv: false,
+            ft_stats: Arc::new(crate::FaultToleranceStats::default()),
+            shutdown,
+            zenoh_connect_endpoint: daemon_endpoint.map(String::from),
+            // Empty: exercises the daemon-endpoint fallback arm, which is the
+            // one a node without its own peering plan takes.
+            zenoh_peering: Arc::new(BTreeMap::new()),
+            disable_multicast,
+        }
+    }
+
+    fn injected_multicast(spawner: &Spawner) -> Option<OsString> {
+        let command = spawner.maybe_inject_zenoh_connect(Command::new("true"), &node("sink"));
+        command
+            .environment
+            .get(&OsString::from(DORA_ZENOH_MULTICAST_ENV))
+            .cloned()
+            .flatten()
+    }
+
+    /// A node must discover the same way the daemon does: a node left scouting
+    /// for a daemon that has stopped scouting finds nothing. Whether the
+    /// request is honored is `open_zenoh_session_with_listen`'s call (it keeps
+    /// scouting for a node with no endpoint and no listener, per #1856), so the
+    /// spawner forwards it and does not re-derive that condition.
+    #[test]
+    fn the_daemons_multicast_decision_is_forwarded_to_spawned_nodes() {
+        assert_eq!(
+            injected_multicast(&spawner_for(Some("tcp/127.0.0.1:7447"), true)).as_deref(),
+            Some(OsStr::new("off")),
+            "a daemon off multicast must tell its nodes"
+        );
+        assert_eq!(
+            injected_multicast(&spawner_for(Some("tcp/127.0.0.1:7447"), false)),
+            None,
+            "a daemon still scouting must not disable it for its nodes"
+        );
+    }
 
     fn plan_for(yaml: &str, daemon: Option<&str>) -> BTreeMap<NodeId, NodeZenohPeering> {
         let descriptor: Descriptor = serde_yaml::from_str(yaml).expect("parse descriptor");

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -31,6 +31,60 @@ pub const DORA_ZENOH_CONNECT_ENV: &str = "DORA_ZENOH_CONNECT";
 /// deterministic instead of racy.
 pub const DORA_ZENOH_LISTEN_ENV: &str = "DORA_ZENOH_LISTEN";
 
+/// Opt out of zenoh multicast scouting for this process, regardless of whether
+/// explicit connect endpoints replaced it.
+///
+/// Set to `off`, `0`, `false`, or `no` to disable. Any other value (including
+/// unset) leaves the default behaviour, where multicast is dropped only once
+/// [`DORA_ZENOH_CONNECT_ENV`] gives the session something to dial instead.
+///
+/// Exists for networks where the scouting socket itself is the problem: a busy
+/// DDS/ROS2 multicast graph can keep zenoh from binding its scouting group,
+/// which fails `zenoh::open` outright. Disabling scouting sidesteps that bind
+/// entirely — but it removes a discovery mechanism, so a session that has no
+/// connect endpoints *and* no multicast can reach nobody. Set it only where
+/// every link is established explicitly (the daemon injects
+/// [`DORA_ZENOH_CONNECT_ENV`] into the nodes it spawns, so those are covered).
+///
+/// The daemon sets this on the nodes it spawns when started with
+/// `--zenoh-no-multicast`, so a single flag covers the whole process tree.
+pub const DORA_ZENOH_MULTICAST_ENV: &str = "DORA_ZENOH_MULTICAST";
+
+/// Whether a session may discover peers by multicast scouting.
+///
+/// Spelled as an enum rather than a bool because the concept flips polarity at
+/// every hop it crosses — `--zenoh-no-multicast`, `DORA_ZENOH_MULTICAST=off`,
+/// `scouting/multicast/enabled=false` — and an inverted bool would not fail a
+/// test, it would silently partition the dataflow.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MulticastScouting {
+    /// Scout unless explicit connect endpoints replace it. The default
+    /// everywhere; [`DORA_ZENOH_MULTICAST_ENV`] can still turn it off.
+    #[default]
+    Allowed,
+    /// The caller establishes every link explicitly and wants no scouting.
+    Disabled,
+}
+
+/// Whether [`DORA_ZENOH_MULTICAST_ENV`] asks for multicast scouting to be off.
+#[cfg(feature = "zenoh")]
+fn multicast_disabled_by_env() -> bool {
+    multicast_disabled_by_value(std::env::var(DORA_ZENOH_MULTICAST_ENV).ok().as_deref())
+}
+
+/// Parse a [`DORA_ZENOH_MULTICAST_ENV`] value (`None` when the var is unset).
+///
+/// Split from [`multicast_disabled_by_env`] so it is testable without mutating
+/// the process environment, which is `unsafe` in edition 2024 and racy against
+/// other tests in the same binary.
+#[cfg(feature = "zenoh")]
+fn multicast_disabled_by_value(value: Option<&str>) -> bool {
+    matches!(
+        value.map(|v| v.trim().to_ascii_lowercase()).as_deref(),
+        Some("off" | "0" | "false" | "no")
+    )
+}
+
 /// Split a comma-separated endpoint list env var, ignoring empty entries.
 #[cfg(feature = "zenoh")]
 fn split_endpoints(value: &str) -> impl Iterator<Item = String> + '_ {
@@ -43,7 +97,11 @@ fn split_endpoints(value: &str) -> impl Iterator<Item = String> + '_ {
 
 #[cfg(feature = "zenoh")]
 pub async fn open_zenoh_session(coordinator_addr: Option<IpAddr>) -> eyre::Result<zenoh::Session> {
-    let (session, _) = open_zenoh_session_with_listen(coordinator_addr, None, None).await?;
+    // Nodes and the coordinator have no in-process way to know, so
+    // [`DORA_ZENOH_MULTICAST_ENV`] (honored inside) is their only channel.
+    let (session, _) =
+        open_zenoh_session_with_listen(coordinator_addr, None, None, MulticastScouting::Allowed)
+            .await?;
     Ok(session)
 }
 
@@ -76,11 +134,17 @@ pub async fn open_zenoh_session(coordinator_addr: Option<IpAddr>) -> eyre::Resul
 /// part of the returned endpoint — it is cluster-wide configuration
 /// shared by the caller (e.g. `dora cluster up`), not per-daemon
 /// state to advertise back to nodes.
+///
+/// `multicast` lets a caller that establishes every link explicitly opt out of
+/// scouting — see [`DORA_ZENOH_MULTICAST_ENV`], honored in addition to this
+/// argument. It is a request, not a command: it is ignored unless this session
+/// ends up reachable some other way (see the `#1856` guard below).
 #[cfg(feature = "zenoh")]
 pub async fn open_zenoh_session_with_listen(
     coordinator_addr: Option<IpAddr>,
     listen_endpoint: Option<&str>,
     inter_daemon_peer: Option<&str>,
+    multicast: MulticastScouting,
 ) -> eyre::Result<(zenoh::Session, Option<String>)> {
     use eyre::{Context, eyre};
     use tracing::warn;
@@ -192,15 +256,6 @@ pub async fn open_zenoh_session_with_listen(
                     }
                 }
             }
-            // Only disable multicast scouting if we successfully replaced
-            // it with explicit connect endpoints — otherwise we'd end up
-            // with no discovery at all (#1856).
-            if connect_inserted
-                && let Err(err) = zenoh_config.insert_json5("scouting/multicast/enabled", "false")
-            {
-                warn!("failed to disable zenoh scouting/multicast: {err}");
-            }
-
             // Track whether listen/endpoints was accepted into THIS config.
             // We don't promote it to `effective_listen_endpoint` until the
             // configured open succeeds — the fallback default-config path
@@ -212,6 +267,10 @@ pub async fn open_zenoh_session_with_listen(
             // wrong (nodes would try to reach it through what may be a
             // remote address, defeating the loopback shortcut).
             let mut listen_inserted_into_configured: Option<String> = None;
+            // Any accepted listener, including the cluster-wide rendezvous that
+            // is deliberately absent from `listen_inserted_into_configured`.
+            // Reachability, not advertisability, is what the #1856 guard needs.
+            let mut listen_configured = false;
 
             // Build the listen-endpoint list (loopback for spawned nodes +
             // optional inter-daemon rendezvous). With multiple entries,
@@ -247,6 +306,7 @@ pub async fn open_zenoh_session_with_listen(
                 let listen_inserted = match zenoh_config.insert_json5("listen/endpoints", &json) {
                     Ok(()) => {
                         listen_inserted_into_configured = listen_endpoint.map(String::from);
+                        listen_configured = true;
                         true
                     }
                     Err(err) => {
@@ -264,6 +324,29 @@ pub async fn open_zenoh_session_with_listen(
                 {
                     warn!("failed to set zenoh listen/exit_on_failure: {err}");
                 }
+            }
+
+            // Drop multicast scouting only once this session is reachable some
+            // other way — otherwise it has no endpoints to dial and no way to
+            // be found, which is the silent partition #1856 exists to prevent.
+            //
+            // Two things make it reachable. `connect_inserted`: explicit
+            // endpoints replaced scouting (the pre-existing rule). Or an
+            // accepted listener plus a caller that asked to stop scouting —
+            // `dora run` without dynamic nodes, or `--zenoh-no-multicast` on a
+            // network where the scouting bind itself fails; a listener means
+            // peers that hold the endpoint can dial in.
+            //
+            // Deliberately *not* honoring the request when neither holds: the
+            // reservation-failure paths in `build_daemon` log "falling back to
+            // multicast scouting only" and mean it. Treating the request as
+            // absolute would disarm that recovery and strand the daemon.
+            let requested_off =
+                matches!(multicast, MulticastScouting::Disabled) || multicast_disabled_by_env();
+            if (connect_inserted || (requested_off && listen_configured))
+                && let Err(err) = zenoh_config.insert_json5("scouting/multicast/enabled", "false")
+            {
+                warn!("failed to disable zenoh scouting/multicast: {err}");
             }
 
             if let Some(addr) = coordinator_addr
@@ -621,6 +704,32 @@ pub fn zenoh_output_ready_liveliness_prefix(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(feature = "zenoh")]
+    #[test]
+    fn multicast_disable_spellings_are_recognized() {
+        for value in ["off", "0", "false", "no", "OFF", "False", "  off  "] {
+            assert!(
+                multicast_disabled_by_value(Some(value)),
+                "{value:?} should disable multicast scouting"
+            );
+        }
+    }
+
+    #[cfg(feature = "zenoh")]
+    #[test]
+    fn unset_or_unrecognized_multicast_value_keeps_default() {
+        // Anything that is not an explicit disable spelling must leave the
+        // default behaviour: silently dropping discovery because of a typo
+        // would be a partition with no error to point at (#1856).
+        assert!(!multicast_disabled_by_value(None));
+        for value in ["on", "1", "true", "yes", "", "maybe"] {
+            assert!(
+                !multicast_disabled_by_value(Some(value)),
+                "{value:?} must not disable multicast scouting"
+            );
+        }
+    }
 
     #[test]
     fn reserve_loopback_endpoint_returns_loopback_tcp() {


### PR DESCRIPTION
A busy DDS/ROS2 multicast graph can keep zenoh from binding its scouting group, which fails `zenoh::open` outright and takes the dataflow with it. There was no way to ask dora not to scout: multicast was dropped only as a side effect of explicit `connect/endpoints` being accepted.

Add `dora daemon --zenoh-no-multicast` and the `DORA_ZENOH_MULTICAST` env var (`off`/`0`/`false`/`no`), which the daemon forwards to the nodes it spawns so one flag covers the process tree. `dora run` opts out on its own: it is single-machine by construction and hands every node it spawns a `DORA_ZENOH_CONNECT`, so scouting buys nothing there — except when the descriptor declares dynamic nodes, which are started outside the daemon, inherit no endpoint, and have multicast as their only way to find it.

The request is not absolute. `open_zenoh_session_with_listen` honors it only once the session is reachable some other way — explicit connect endpoints, or an accepted listener peers can dial. Without that it keeps scouting, so the reservation-failure paths in `build_daemon` that log "falling back to multicast scouting only" still mean it, rather than being silently disarmed into the no-discovery-at-all state #1856 exists to prevent.

Alternative to https://github.com/dora-rs/dora/pull/2850