### PR TITLE
fix(core): resolve module outputs produced by operator/custom inner nodes

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -151,7 +151,7 @@ Parameters are also injected as environment variables (`PARAM_SPEED`, `PARAM_MOD
 2. Prefix all internal node IDs with `{module_id}.` (e.g., `nav_stack.planner`)
 3. Replace `_mod/port_name` references with the actual sources from the parent's input map
 4. Rewrite internal cross-references (e.g., `planner/path` becomes `nav_stack.planner/path`)
-5. Map module-declared outputs to internal node outputs, so `nav_stack/cmd_vel` resolves to `nav_stack.controller/cmd_vel`
+5. Map module-declared outputs to internal node outputs, so `nav_stack/cmd_vel` resolves to `nav_stack.controller/cmd_vel`. An inner node may produce a declared output from its node-level `outputs:`, from an `operator:`/`operators:` block, or from a legacy `custom:` block. For an output produced by one operator of a multi-operator `operators:` node, the resolved reference keeps the operator segment that runtime nodes require: `nav_stack/cmd_vel` resolves to `nav_stack.runtime/controller/cmd_vel`
 6. Replace the module node with the expanded flat nodes
 7. Substitute `params:` values in `args:` fields and inject as env vars
 
@@ -231,6 +231,7 @@ This checks:
 - Valid YAML structure
 - Module header is present with `name`, `inputs`, `outputs`
 - All `_mod/` references correspond to declared inputs or optional inputs
+- Every declared output is produced by some inner node (counting `operator:`/`operators:` and legacy `custom:` outputs)
 - No duplicate node IDs
 - Internal wiring is consistent
 

--- a/libraries/core/src/descriptor/expand.rs
+++ b/libraries/core/src/descriptor/expand.rs
@@ -46,6 +46,12 @@ const MAX_MODULE_FILE_SIZE: u64 = 1_048_576;
 /// Usage in module YAML: `_mod/port_name`
 const MODULE_INPUT_SOURCE: &str = "_mod";
 
+/// Where the outputs a module declares end up after expansion: maps each
+/// declared output name to the mapping a consumer must use to read it — the
+/// prefixed inner node ID plus the output name as that node addresses it
+/// (see [`node_output_refs`]).
+type ModuleOutputMap = BTreeMap<String, UserInputMapping>;
+
 /// Header section of a module definition file.
 #[derive(Debug, Clone, Deserialize)]
 struct ModuleHeader {
@@ -112,7 +118,7 @@ pub fn expand_modules_with_boundaries(
         .with_context(|| format!("failed to resolve base directory: {}", base_dir.display()))?;
     let mut seen = HashSet::new();
     let mut flat_nodes = Vec::new();
-    let mut output_maps: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
+    let mut output_maps: BTreeMap<String, ModuleOutputMap> = BTreeMap::new();
     let mut boundaries = ModuleBoundaries::default();
 
     for node in &descriptor.nodes {
@@ -196,11 +202,14 @@ pub fn check_module_file(module_path: &Path) -> eyre::Result<()> {
 
     // Check outputs: each declared output should be produced by some inner node.
     // For nested module children, recursively load their declared outputs.
+    // Runtime (operator) and legacy custom nodes declare their outputs in
+    // config.outputs / run_config.outputs rather than the node-level `outputs`
+    // set, so `node_output_refs` collects those too (see #2817).
     let mut inner_outputs: BTreeSet<String> = module_file
         .nodes
         .iter()
         .filter(|n| n.module.is_none())
-        .flat_map(|n| n.outputs.iter().map(|o| o.to_string()))
+        .flat_map(|n| node_output_refs(n).into_iter().map(|(name, _)| name))
         .collect();
 
     // Check nested module files exist and collect their declared outputs
@@ -329,17 +338,54 @@ fn node_input_maps_mut(node: &mut Node) -> Vec<&mut BTreeMap<DataId, Input>> {
     maps
 }
 
+/// Every output an inner node produces, as `(output_name, output_ref)` pairs
+/// where `output_ref` is how a consumer addresses that output on this node.
+///
+/// The two differ only for multi-operator runtime nodes: their outputs live in
+/// `operators[].config.outputs` and must be referenced as
+/// `<operator_id>/<output>`. Node-level `outputs`, legacy `custom:`
+/// `run_config.outputs`, and single `operator:` outputs are all referenced by
+/// their bare name — for `operator:` the `op/` prefix is injected later by
+/// `resolve_aliases_and_set_defaults`, so adding it here would double it up.
+///
+/// Output-side counterpart of [`node_input_maps`]: centralizes the node-kind
+/// enumeration so module output resolution stays in sync as node kinds are
+/// added or change (see #2817).
+fn node_output_refs(node: &Node) -> Vec<(String, String)> {
+    fn bare(outputs: &BTreeSet<DataId>) -> impl Iterator<Item = (String, String)> {
+        outputs.iter().map(|o| (o.to_string(), o.to_string()))
+    }
+
+    let mut refs: Vec<(String, String)> = bare(&node.outputs).collect();
+    if let Some(ref operators) = node.operators {
+        for op in &operators.operators {
+            refs.extend(
+                op.config
+                    .outputs
+                    .iter()
+                    .map(|o| (o.to_string(), format!("{}/{o}", op.id))),
+            );
+        }
+    }
+    if let Some(ref operator) = node.operator {
+        refs.extend(bare(&operator.config.outputs));
+    }
+    if let Some(ref custom) = node.custom {
+        refs.extend(bare(&custom.run_config.outputs));
+    }
+    refs
+}
+
 /// Expand a single module node into its constituent flat nodes.
 ///
-/// Returns `(expanded_nodes, output_map)` where output_map maps each declared
-/// module output name to the prefixed inner node ID that produces it.
+/// Returns `(expanded_nodes, output_map)`; see [`ModuleOutputMap`].
 fn expand_module_node(
     node: &Node,
     base_dir: &Path,
     canonical_base: &Path,
     depth: u8,
     seen: &mut HashSet<PathBuf>,
-) -> eyre::Result<(Vec<Node>, BTreeMap<String, String>)> {
+) -> eyre::Result<(Vec<Node>, ModuleOutputMap)> {
     if depth >= MAX_MODULE_DEPTH {
         bail!(
             "module nesting exceeds depth limit of {MAX_MODULE_DEPTH} \
@@ -519,7 +565,7 @@ fn expand_module_node(
     // Phase 2: recursively expand nested modules (before building output map)
     // Collect nested output maps so sibling nodes can reference nested module
     // outputs correctly via rewrite_external_refs.
-    let mut nested_output_maps: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
+    let mut nested_output_maps: BTreeMap<String, ModuleOutputMap> = BTreeMap::new();
     let mut final_nodes = Vec::new();
     for inner_node in prefixed_nodes {
         if inner_node.module.is_some() {
@@ -550,12 +596,24 @@ fn expand_module_node(
         rewrite_external_refs(&mut final_nodes, &nested_output_maps)?;
     }
 
-    // Phase 3: build output map from fully-expanded flat nodes
-    let mut output_map: BTreeMap<String, String> = BTreeMap::new();
+    // Phase 3: build output map from fully-expanded flat nodes. A producer may
+    // be a plain node, a runtime node's operator, or a legacy custom node, so
+    // the lookup goes through `node_output_refs` — which also yields the form
+    // consumers must use to address the output (see #2817).
+    let mut output_map = ModuleOutputMap::new();
     for declared_output in &module_file.module.outputs {
-        let producer = final_nodes
+        let declared = declared_output.to_string();
+        let target = final_nodes
             .iter()
-            .find(|n| n.outputs.contains(declared_output))
+            .find_map(|n| {
+                node_output_refs(n)
+                    .into_iter()
+                    .find(|(name, _)| *name == declared)
+                    .map(|(_, output_ref)| UserInputMapping {
+                        source: n.id.clone(),
+                        output: output_ref.into(),
+                    })
+            })
             .ok_or_else(|| {
                 eyre::eyre!(
                     "module `{}` declares output `{}` but no inner node produces it",
@@ -563,7 +621,7 @@ fn expand_module_node(
                     declared_output,
                 )
             })?;
-        output_map.insert(declared_output.to_string(), producer.id.to_string());
+        output_map.insert(declared, target);
     }
 
     // Remove from seen so the same module file can be used in different
@@ -688,10 +746,12 @@ fn rewrite_module_inputs_map(
 ///
 /// If node X has input `nav_stack/cmd_vel` and `nav_stack` was a module whose
 /// output `cmd_vel` is produced by inner node `controller`, rewrite to
-/// `nav_stack.controller/cmd_vel`.
+/// `nav_stack.controller/cmd_vel`. If the producer is an operator of a runtime
+/// node, the rewritten output keeps the operator segment the runtime node
+/// requires: `nav_stack.runtime/controller_op/cmd_vel`.
 fn rewrite_external_refs(
     nodes: &mut [Node],
-    output_maps: &BTreeMap<String, BTreeMap<String, String>>,
+    output_maps: &BTreeMap<String, ModuleOutputMap>,
 ) -> eyre::Result<()> {
     if output_maps.is_empty() {
         return Ok(());
@@ -717,7 +777,7 @@ fn rewrite_external_refs(
 
 fn rewrite_inputs_map(
     inputs: &mut BTreeMap<DataId, Input>,
-    output_maps: &BTreeMap<String, BTreeMap<String, String>>,
+    output_maps: &BTreeMap<String, ModuleOutputMap>,
     node_id: &NodeId,
 ) -> eyre::Result<()> {
     let mut new_inputs = BTreeMap::new();
@@ -727,12 +787,9 @@ fn rewrite_inputs_map(
                 let source_str = user_mapping.source.to_string();
                 if let Some(omap) = output_maps.get(&source_str) {
                     let output_str = user_mapping.output.to_string();
-                    if let Some(prefixed_node) = omap.get(&output_str) {
+                    if let Some(target) = omap.get(&output_str) {
                         Input {
-                            mapping: InputMapping::User(UserInputMapping {
-                                source: prefixed_node.clone().into(),
-                                output: user_mapping.output.clone(),
-                            }),
+                            mapping: InputMapping::User(target.clone()),
                             queue_size: input.queue_size,
                             input_timeout: input.input_timeout,
                             queue_policy: input.queue_policy,
@@ -2295,5 +2352,203 @@ nodes:
             }
             _ => panic!("expected user mapping"),
         }
+    }
+
+    /// Expand a dataflow whose single module node `m` re-exports `result`, and
+    /// return the mapping the downstream `sink` node ends up with. Also asserts
+    /// that the expanded dataflow passes wiring validation, which is what
+    /// catches a producer reference that is syntactically plausible but wrong
+    /// for the producer's node kind (e.g. a missing operator segment).
+    fn expand_and_resolve_sink_input(base: &Path) -> UserInputMapping {
+        let desc = parse_descriptor(
+            r#"
+nodes:
+  - id: src
+    path: src.py
+    outputs: [val]
+  - id: m
+    module: mod.yml
+    inputs:
+      data: src/val
+  - id: sink
+    path: sink.py
+    inputs:
+      r: m/result
+"#,
+        );
+
+        let expanded = expand_modules(&desc, base).unwrap();
+        crate::descriptor::validate::check_wiring(&expanded).unwrap();
+
+        let sink = expanded
+            .nodes
+            .iter()
+            .find(|n| n.id.to_string() == "sink")
+            .unwrap();
+        match &sink.inputs[&DataId::from("r".to_string())].mapping {
+            InputMapping::User(m) => m.clone(),
+            _ => panic!("expected user mapping"),
+        }
+    }
+
+    /// Regression test for #2817: a module output produced by an operator of a
+    /// multi-operator runtime node must resolve. Consumers of a runtime node
+    /// address outputs as `<node>/<operator>/<output>`, so the rewritten
+    /// reference has to keep the `proc/` segment.
+    #[test]
+    fn expand_resolves_operator_produced_module_output() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+
+        write_file(
+            base,
+            "mod.yml",
+            r#"
+module:
+  name: rt
+  inputs: [data]
+  outputs: [result]
+
+nodes:
+  - id: runtime
+    operators:
+      - id: proc
+        shared-library: proc.so
+        inputs:
+          x: _mod/data
+        outputs:
+          - result
+"#,
+        );
+
+        let mapping = expand_and_resolve_sink_input(base);
+        assert_eq!(mapping.source.to_string(), "m.runtime");
+        assert_eq!(mapping.output.to_string(), "proc/result");
+    }
+
+    /// Regression test for #2817: same for a single `operator:` node. Here the
+    /// output stays bare — `resolve_aliases_and_set_defaults` injects the `op/`
+    /// prefix afterwards, so adding it during expansion would double it up.
+    #[test]
+    fn expand_resolves_single_operator_produced_module_output() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+
+        write_file(
+            base,
+            "mod.yml",
+            r#"
+module:
+  name: rt
+  inputs: [data]
+  outputs: [result]
+
+nodes:
+  - id: runtime
+    operator:
+      shared-library: proc.so
+      inputs:
+        x: _mod/data
+      outputs:
+        - result
+"#,
+        );
+
+        let mapping = expand_and_resolve_sink_input(base);
+        assert_eq!(mapping.source.to_string(), "m.runtime");
+        assert_eq!(mapping.output.to_string(), "result");
+    }
+
+    /// Regression test for #2817: same for a legacy `custom:` inner node, whose
+    /// outputs live in `run_config.outputs`.
+    #[test]
+    fn expand_resolves_custom_produced_module_output() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+
+        write_file(
+            base,
+            "mod.yml",
+            r#"
+module:
+  name: legacy
+  inputs: [data]
+  outputs: [result]
+
+nodes:
+  - id: runner
+    custom:
+      path: node.py
+      source: Local
+      inputs:
+        x: _mod/data
+      outputs:
+        - result
+"#,
+        );
+
+        let mapping = expand_and_resolve_sink_input(base);
+        assert_eq!(mapping.source.to_string(), "m.runner");
+        assert_eq!(mapping.output.to_string(), "result");
+    }
+
+    /// Regression test for #2817: `check_module_file` must accept a declared
+    /// output produced by an operator or legacy custom inner node, and still
+    /// reject one nothing produces.
+    #[test]
+    fn check_module_file_accepts_operator_and_custom_produced_outputs() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+
+        let path = write_file(
+            base,
+            "mixed_module.yml",
+            r#"
+module:
+  name: mixed
+  inputs: [data]
+  outputs: [from_operator, from_custom]
+
+nodes:
+  - id: runtime
+    operators:
+      - id: proc
+        shared-library: proc.so
+        inputs:
+          x: _mod/data
+        outputs:
+          - from_operator
+
+  - id: runner
+    custom:
+      path: node.py
+      source: Local
+      inputs:
+        y: _mod/data
+      outputs:
+        - from_custom
+"#,
+        );
+        check_module_file(&path).unwrap();
+
+        let missing = write_file(
+            base,
+            "missing_module.yml",
+            r#"
+module:
+  name: missing
+  outputs: [nobody_produces_this]
+
+nodes:
+  - id: runtime
+    operators:
+      - id: proc
+        shared-library: proc.so
+        outputs:
+          - something_else
+"#,
+        );
+        let err = check_module_file(&missing).unwrap_err().to_string();
+        assert!(err.contains("no inner node produces it"), "{err}");
     }
 }


### PR DESCRIPTION
## Summary

Fixes #2817.

Module output resolution in `expand_module_node` and `check_module_file` only consulted `Node::outputs`, the node-level output set. A runtime node (`operators:` / `operator:`) or a legacy `custom:` inner node declares its outputs in `OperatorConfig::outputs` / `NodeRunConfig::outputs` instead, which stays empty at the node level. A module whose declared output came from one of these was rejected with "no inner node produces it," and any downstream node wiring that output then failed to resolve too.

This is the output-side counterpart of #2441, which fixed the same gap on the input side by routing operator/custom `config.inputs` through `node_input_maps`.

## Changes

- Add `node_output_refs(node)`, mirroring `node_input_maps`, returning `(output_name, output_ref)` pairs for every output a node produces across all its forms.
- Use it in the Phase-3 producer lookup in `expand_module_node`, and in `check_module_file`'s output-declaration check.
- `docs/modules.md`: document that an inner node can produce a declared output from node-level `outputs:`, an `operator:`/`operators:` block, or a legacy `custom:` block.

## Why not just node id -> output name

An earlier attempt at this fix (#2818) maps `declared_output -> producer_node_id` and always uses the bare declared name as the consumer-facing reference. That works for a plain node or a single `operator:` node, but not for a multi-operator `operators:` node: `check_wiring` requires those to be addressed as `<node>/<operator_id>/<output_id>`, and a map with no operator id can't distinguish two operators on the same node that happen to produce differently-scoped outputs. Verified this concretely — building #2818's own `operators:` test case and running `check_wiring` on the result fails with:

```
input `sink/y` references output `result` of node `m.runtime`, which is a runtime
node; runtime node outputs must include the operator id (expected format:
`m.runtime/<operator_id>/<output_id>`)
```

`node_output_refs` avoids this by keeping the `<operator_id>/` segment in the `output_ref` for each `operators:` entry, while leaving node-level, `custom:`, and single-`operator:` outputs bare (matching how `resolve_aliases_and_set_defaults` injects the `op/` prefix for the single-operator case afterward).

## Tests

- `expand_resolves_operator_produced_module_output` — multi-operator `operators:` producer; asserts the consumer's rewritten reference is `<node>/<operator_id>/<output>` and passes `check_wiring`.
- `expand_resolves_single_operator_produced_module_output` — single `operator:` producer; reference stays bare.
- `expand_resolves_custom_produced_module_output` — legacy `custom:` producer.
- `check_module_file_accepts_operator_and_custom_produced_outputs` — the isolated linter accepts outputs from both, and still rejects a declared output nothing produces.

`cargo test -p dora-core` (36 tests in the `descriptor::expand` module), `cargo clippy -p dora-core -- -D warnings`, and `cargo fmt --all -- --check` all pass.