### PR TITLE
fix(replay-node): skip an undecodable payload instead of aborting the whole replay

### DIFF
--- a/binaries/replay-node/src/main.rs
+++ b/binaries/replay-node/src/main.rs
@@ -88,9 +88,24 @@ fn main() -> eyre::Result<()> {
                     // stream (or absent for metadata-only messages). Decode it
                     // back to an array and re-send; `send_output` re-encodes it
                     // into a fresh IPC stream on the wire.
+                    //
+                    // Skip-and-continue on a single undecodable payload rather
+                    // than aborting the whole replay, matching the bincode arm
+                    // above and the reader's own torn-record tolerance
+                    // (`RecordingReader::next_entry` stops gracefully at a torn
+                    // trailing record instead of erroring). Otherwise one corrupt
+                    // record would drop every remaining valid message.
                     let array = match &data {
-                        Some(bytes) => decode_arrow_ipc(bytes)
-                            .wrap_err("failed to decode recorded Arrow IPC payload")?,
+                        Some(bytes) => match decode_arrow_ipc(bytes) {
+                            Ok(array) => array,
+                            Err(e) => {
+                                eprintln!(
+                                    "warning: failed to decode recorded Arrow IPC payload for {}/{}: {e}",
+                                    entry.node_id, entry.output_id
+                                );
+                                continue;
+                            }
+                        },
                         None => NullArray::new(0).into(),
                     };
                     node.send_output(output_id, metadata.parameters, make_array(array))


### PR DESCRIPTION
## Summary

> ⚠️ **Machine-generated PR.** This change was written by Claude (Claude Code) as part of an automated code-review pass. Please review carefully before merging.

The replay loop in `binaries/replay-node/src/main.rs` deliberately logs-and-continues when a record's bincode `InterDaemonEvent` fails to deserialize:

```rust
let timestamped = match bincode::deserialize(&entry.event_bytes) {
    Ok(event) => event,
    Err(e) => { eprintln!("warning: failed to deserialize event ..."); continue; }
};
```

…but the *next* step decoded the inner Arrow IPC payload with `?`:

```rust
let array = match &data {
    Some(bytes) => decode_arrow_ipc(bytes).wrap_err("failed to decode ...")?, // aborts everything
    None => NullArray::new(0).into(),
};
```

So a single record whose framing and bincode survived, yet whose inner Arrow IPC body bytes are corrupt, terminated replay of **every remaining valid message**.

## Fix

Mirror the bincode arm: warn and `continue` on a decode failure, so one bad payload skips only its own message.

## Why this is the right behavior

- **Consistency with the sibling arm.** The bincode-deserialize step directly above already skips-and-continues; the IPC-decode step is the only one that aborted.
- **Consistency with the reader.** `RecordingReader::next_entry` (`libraries/recording/src/lib.rs`) goes out of its way to tolerate a torn trailing record and stop gracefully rather than error, precisely so that every fully-written record still replays. Aborting on one decodable-framing/undecodable-body record undoes that intent.

`send_output(...)?` on the next line remains a `?` — a broken daemon connection is a legitimate hard failure, unlike a single corrupt payload.

## Validation

- `cargo fmt -p dora-replay-node`, `cargo clippy -p dora-replay-node -- -D warnings` — clean.
- `cargo test -p dora-replay-node` — 4 passed.
- Reviewed against `origin/main` (`ffa6fd1`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4UYiwoYzdxW5ay5UV9kZe)_