### PR TITLE
perf(record-node): encode recorded payloads via the 1-copy Arrow IPC fast path

### DIFF
--- a/binaries/record-node/src/main.rs
+++ b/binaries/record-node/src/main.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, fs::File, time::SystemTime};
 
-use aligned_vec::AVec;
+use aligned_vec::{AVec, ConstAlign};
 use dora_message::{
     common::Timestamped,
     daemon_to_daemon::InterDaemonEvent,
@@ -65,23 +65,47 @@ fn main() -> eyre::Result<()> {
                 // Record the payload as a self-describing Arrow IPC stream so
                 // replay can reconstruct the array without a type sidecar.
                 let arrow_data = data.to_data();
-                let raw_data =
-                    if matches!(arrow_data.data_type(), DataType::Null) && arrow_data.is_empty() {
-                        // Exactly the unit array that replay rebuilds from an absent
-                        // payload (`NullArray::new(0)`) — record `None` to skip the
-                        // IPC framing.
-                        None
-                    } else {
-                        // Encode every other array — including a zero-length *typed*
-                        // array (e.g. an empty `Float32Array`) and a non-empty
-                        // `NullArray` — as a self-describing IPC stream, so replay
-                        // preserves the declared type and length instead of
-                        // collapsing it to `NullArray::new(0)`. (The deleted
-                        // `type_info` sidecar used to preserve this; #2027/#2083.)
-                        let ipc_bytes = arrow_utils::encode_arrow_ipc(&arrow_data)
-                            .wrap_err("failed to Arrow-IPC-encode recorded output")?;
-                        Some(AVec::from_slice(128, &ipc_bytes))
-                    };
+                let raw_data = if matches!(arrow_data.data_type(), DataType::Null)
+                    && arrow_data.is_empty()
+                {
+                    // Exactly the unit array that replay rebuilds from an absent
+                    // payload (`NullArray::new(0)`) — record `None` to skip the
+                    // IPC framing.
+                    None
+                } else {
+                    // Encode every other array — including a zero-length *typed*
+                    // array (e.g. an empty `Float32Array`) and a non-empty
+                    // `NullArray` — as a self-describing IPC stream, so replay
+                    // preserves the declared type and length instead of
+                    // collapsing it to `NullArray::new(0)`. (The deleted
+                    // `type_info` sidecar used to preserve this; #2027/#2083.)
+                    //
+                    // Use the hand-rolled 1-copy fast path when the array type
+                    // is eligible — it copies each buffer straight into the
+                    // aligned target — falling back to the official writer
+                    // otherwise, mirroring `DoraNode::send_output_array`. The
+                    // previous code always went through the official writer
+                    // (which stages the body in an internal `Vec`, ~2 payload
+                    // copies) and then copied the result a third time into the
+                    // `AVec`, on every recorded message.
+                    let encoded: AVec<u8, ConstAlign<128>> =
+                        match arrow_utils::ipc_encode::ipc_fast_path_len(&arrow_data) {
+                            Some(len) => {
+                                let mut buf: AVec<u8, ConstAlign<128>> =
+                                    AVec::__from_elem(128, 0, len);
+                                arrow_utils::ipc_encode::encode_ipc_into(&arrow_data, &mut buf)
+                                    .wrap_err("failed to Arrow-IPC-encode recorded output")?;
+                                buf
+                            }
+                            None => {
+                                let ipc_bytes =
+                                    arrow_utils::ipc_encode::encode_ipc_to_vec(&arrow_data)
+                                        .wrap_err("failed to Arrow-IPC-encode recorded output")?;
+                                AVec::from_slice(128, &ipc_bytes)
+                            }
+                        };
+                    Some(encoded)
+                };
 
                 let timestamp = metadata.timestamp();
                 let inter_event = InterDaemonEvent::Output {


### PR DESCRIPTION
## Summary

> ⚠️ **Machine-generated PR.** This change was written by Claude (Claude Code) as part of an automated code-review pass. Please review carefully before merging.

Every recorded message in `binaries/record-node/src/main.rs` was Arrow-IPC-encoded through the official writer (`encode_arrow_ipc`), which stages the record-batch body in an internal `Vec` — at least two payload copies — and the result was then copied a **third** time into the aligned `AVec`:

```rust
let ipc_bytes = arrow_utils::encode_arrow_ipc(&arrow_data)?; // official writer, ~2 copies
Some(AVec::from_slice(128, &ipc_bytes))                       // + a 3rd copy
```

This runs on **every recorded message** (e.g. every camera frame), so the extra copies add up on high-rate recordings.

## Fix

Use the hand-rolled 1-copy fast path (`ipc_fast_path_len` + `encode_ipc_into`) when the array type is eligible — it copies each buffer straight into the aligned target — and fall back to the official writer only for non-fast-path types (dictionary / `*View` / union / map):

```rust
let encoded: AVec<u8, ConstAlign<128>> =
    match arrow_utils::ipc_encode::ipc_fast_path_len(&arrow_data) {
        Some(len) => {
            let mut buf = AVec::__from_elem(128, 0, len);
            arrow_utils::ipc_encode::encode_ipc_into(&arrow_data, &mut buf)?;
            buf
        }
        None => AVec::from_slice(128, &arrow_utils::ipc_encode::encode_ipc_to_vec(&arrow_data)?),
    };
```

This mirrors `DoraNode::send_output_array`, which already uses exactly this fast-path/fallback dispatch on the live send path.

## Wire format is unchanged

The fast path emits a normal Arrow IPC stream. Its `ipc_encode` test suite proves round-trip equality against both the official `StreamReader` and the zero-copy decoder, and `replay-node` decodes recorded payloads via the same official `decode_arrow_ipc` path — so recordings written by the new code decode identically. Non-eligible types still go through the official writer, so nothing regresses for them.

## Validation

- `cargo fmt -p dora-record-node`, `cargo clippy -p dora-record-node -- -D warnings` — clean.
- `cargo test -p dora-record-node` — builds (thin binary, no unit tests).
- Full workspace test suite run on the combined review branch.
- Reviewed against `origin/main` (`ffa6fd1`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4UYiwoYzdxW5ay5UV9kZe)_