### PR TITLE
docs(core): add a compile-checked doctest for parse_urn

### DIFF
--- a/libraries/core/src/types.rs
+++ b/libraries/core/src/types.rs
@@ -197,6 +197,30 @@ pub struct ParsedUrn {
 /// - `std/core/v1/Float32` (no params)
 /// - `std/media/v1/AudioFrame[sample_type=f32]` (with params)
 /// - `std/media/v1/AudioFrame[sample_type=f32,channels=2]` (multiple params)
+///
+/// Returns `None` for malformed input: a `[` with no closing `]`, empty
+/// brackets `[]`, or an empty parameter key or value.
+///
+/// ```
+/// use dora_core::types::parse_urn;
+///
+/// // With parameters:
+/// let parsed = parse_urn("std/media/v1/AudioFrame[sample_type=f32,channels=2]").unwrap();
+/// assert_eq!(parsed.base, "std/media/v1/AudioFrame");
+/// assert_eq!(parsed.params.get("sample_type"), Some(&"f32".to_string()));
+/// assert_eq!(parsed.params.get("channels"), Some(&"2".to_string()));
+///
+/// // No-param URN parses with an empty parameter map:
+/// let plain = parse_urn("std/core/v1/Float32").unwrap();
+/// assert_eq!(plain.base, "std/core/v1/Float32");
+/// assert!(plain.params.is_empty());
+///
+/// // Malformed inputs return None:
+/// assert!(parse_urn("std/media/v1/AudioFrame[").is_none()); // no closing ]
+/// assert!(parse_urn("std/media/v1/AudioFrame[]").is_none()); // empty brackets
+/// assert!(parse_urn("std/media/v1/AudioFrame[=f32]").is_none()); // empty key
+/// assert!(parse_urn("").is_none());
+/// ```
 pub fn parse_urn(urn: &str) -> Option<ParsedUrn> {
     if urn.is_empty() {
         return None;

--- a/libraries/core/src/types.rs
+++ b/libraries/core/src/types.rs
@@ -205,13 +205,14 @@ pub struct ParsedUrn {
 /// use dora_core::types::parse_urn;
 ///
 /// // With parameters:
-/// let parsed = parse_urn("std/media/v1/AudioFrame[sample_type=f32,channels=2]").unwrap();
+/// let Some(parsed) = parse_urn("std/media/v1/AudioFrame[sample_type=f32,channels=2]")
+/// else { unreachable!() };
 /// assert_eq!(parsed.base, "std/media/v1/AudioFrame");
 /// assert_eq!(parsed.params.get("sample_type"), Some(&"f32".to_string()));
 /// assert_eq!(parsed.params.get("channels"), Some(&"2".to_string()));
 ///
 /// // No-param URN parses with an empty parameter map:
-/// let plain = parse_urn("std/core/v1/Float32").unwrap();
+/// let Some(plain) = parse_urn("std/core/v1/Float32") else { unreachable!() };
 /// assert_eq!(plain.base, "std/core/v1/Float32");
 /// assert!(plain.params.is_empty());
 ///


### PR DESCRIPTION
## Summary

> ⚠️ **Machine-generated PR.** This change was written by Claude (Claude Code) as part of an automated code-review pass. Please review carefully before merging.

`dora_core::types::parse_urn` parses a non-obvious `Type[k=v,k2=v2]` parameter syntax and silently returns `None` for several malformed shapes — a `[` with no closing `]`, empty brackets `[]`, and an empty parameter key or value — which a caller can easily get wrong. The prose docs described the *accepted* formats but never demonstrated the rejection cases, and there was no runnable example.

## Change

Add a compile-checked doctest that pins both the success shape (base + parameter map) and the `None` failure modes, plus a short prose note enumerating the malformed inputs. Being a doctest, it is compiled and run as part of the test suite, so the documented behavior can't drift from the implementation.

```rust
use dora_core::types::parse_urn;

let parsed = parse_urn("std/media/v1/AudioFrame[sample_type=f32,channels=2]").unwrap();
assert_eq!(parsed.base, "std/media/v1/AudioFrame");
assert_eq!(parsed.params.get("channels"), Some(&"2".to_string()));

assert!(parse_urn("std/media/v1/AudioFrame[").is_none()); // no closing ]
assert!(parse_urn("std/media/v1/AudioFrame[]").is_none()); // empty brackets
assert!(parse_urn("std/media/v1/AudioFrame[=f32]").is_none()); // empty key
assert!(parse_urn("").is_none());
```

Docs-only; no runtime behavior changes.

## Validation

- `cargo test -p dora-core --doc types::parse_urn` — 1 passed.
- `cargo fmt -p dora-core`, `cargo clippy -p dora-core -- -D warnings` — clean.
- Reviewed against `origin/main` (`ffa6fd1`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4UYiwoYzdxW5ay5UV9kZe)_