### PR TITLE
fix(node): bound the startup-handshake marker-thread join in DoraNode::drop

### DIFF
--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -2338,16 +2338,16 @@ pub(crate) fn teardown_with_timeout(
 
 impl Drop for DoraNode {
     fn drop(&mut self) {
-        // Stop the startup handshake first: joining its marker thread releases
-        // the thread's `Arc` clone of the publishers, so the teardown below
-        // holds the last reference and actually undeclares them.
-        let ack_subscribers = match self.startup_handshake.take() {
-            Some(mut handshake) => {
-                handshake.shutdown();
-                std::mem::take(&mut handshake.ack_subscribers)
-            }
-            None => Vec::new(),
-        };
+        // The startup handshake's marker thread holds an `Arc` clone of the
+        // publishers, so it must be stopped and joined before the publishers
+        // are dropped for the undeclare below to see the last reference. Do
+        // that join *inside* the bounded teardown: `shutdown()` sets the stop
+        // flag but cannot interrupt an in-progress `publisher.put().wait()`, so
+        // on a wedged zenoh net runtime the join could otherwise hang node
+        // shutdown (and with it the daemon, which waits for `InputClosed`) —
+        // the exact hang `teardown_with_timeout` exists to bound (#2425). The
+        // consumer side already joins its acker thread under the same deadline.
+        let startup_handshake = self.startup_handshake.take();
         // Tear down zenoh before notifying the daemon below, so that
         // daemon-signaled `InputClosed` cannot overtake in-flight zenoh data.
         let publishers = std::mem::take(&mut self.zenoh_publishers);
@@ -2356,8 +2356,10 @@ impl Drop for DoraNode {
         let session = self.zenoh_session.take();
         let runtime = self._owned_runtime.take();
         if session.is_none() && shm_provider.is_none() && publishers.is_empty() {
-            // no zenoh state (interactive/testing mode): drop inline
-            drop(ack_subscribers);
+            // no zenoh state (interactive/testing mode): drop inline. A node
+            // without a zenoh session never has a handshake, but drop it here
+            // too so this branch stays self-contained.
+            drop(startup_handshake);
             drop(runtime);
         } else {
             // A wedged zenoh net runtime stalls `Session` close beyond its
@@ -2365,12 +2367,18 @@ impl Drop for DoraNode {
             // hang node shutdown (and with it the daemon, which waits for
             // `InputClosed`). Bound the teardown with a deadline instead.
             let completed = teardown_with_timeout("zenoh", ZENOH_TEARDOWN_TIMEOUT, move || {
-                // documented drop order: subscribers and publishers (data +
-                // schema) before the session, owned runtime last so async
-                // cleanup can still run. The handshake thread was joined
-                // above, so the publishers `Arc` is the last reference and
-                // dropping it undeclares them here.
-                drop(ack_subscribers);
+                // Stop + join the marker thread first (bounded by this
+                // deadline), which releases its publishers `Arc` clone so the
+                // `drop(publishers)` below holds the last reference and
+                // undeclares them. Then the documented drop order: subscribers
+                // (dropped with the handshake) and publishers (data + schema)
+                // before the session, owned runtime last so async cleanup can
+                // still run.
+                if let Some(mut handshake) = startup_handshake {
+                    handshake.shutdown();
+                    // Undeclare the ack subscribers before the session below.
+                    drop(std::mem::take(&mut handshake.ack_subscribers));
+                }
                 drop(publishers);
                 drop(schema_publishers);
                 drop(shm_provider);


### PR DESCRIPTION
Follow-up to #2806, addressing the shutdown-robustness gap raised in that PR's latest review ([comment](https://github.com/dora-rs/dora/pull/2806#issuecomment-5074212279)).

## Problem

In `DoraNode::drop`, the startup handshake was stopped and joined *before and outside* the `teardown_with_timeout("zenoh", ZENOH_TEARDOWN_TIMEOUT, …)` block:

```rust
let ack_subscribers = match self.startup_handshake.take() {
    Some(mut handshake) => {
        handshake.shutdown();   // sets stop flag, then handle.join() on the marker thread
        std::mem::take(&mut handshake.ack_subscribers)
    }
    None => Vec::new(),
};
```

`StartupHandshake::shutdown` sets the stop flag and then unconditionally `handle.join()`s the marker thread. The marker thread's loop only checks the stop flag at the top of each iteration and then blocks in `publisher.put(&[][..]).wait()`. Setting `stop = true` cannot interrupt an in-progress `.wait()`, so on a wedged zenoh net runtime that `put().wait()` can block indefinitely and the unbounded `join()` stalls node shutdown — and with it the daemon, which waits for `InputClosed`.

This is exactly the failure mode #2425 and `teardown_with_timeout` were introduced to bound. It is reachable when a node process exits while its handshake is still in flight (route not yet proven, within the 10 s marker window) and the session is unhealthy. The consumer side already handles this correctly — `EventStream::drop` joins the `dora-startup-acker` thread *inside* `teardown_with_timeout`.

## Fix

Move the marker-thread `shutdown()`/join into the `teardown_with_timeout` closure, still before `drop(publishers)` so the join keeps its "release the last publisher `Arc` clone" property (which is what actually undeclares the publishers). The ack subscribers are undeclared immediately after, before the session, preserving the documented drop order. The producer teardown is now symmetric with the consumer side.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p dora-node-api -- -D warnings`
- `cargo test -p dora-node-api --lib` — 148 passed, 0 failed (incl. the `teardown_with_timeout_*` and `zenoh_teardown_fits_within_daemon_force_kill_grace` tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011zuVJ7ZNBcnK3cdCJ9E5vJ)_