### PR TITLE
fix(coordinator): don't disconnect a live daemon on a heartbeat-send backpressure timeout

### DIFF
--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -293,6 +293,40 @@ async fn start_with_events(
     Ok((port, future))
 }
 
+/// Outcome of the coordinator's periodic heartbeat send to one daemon.
+///
+/// The heartbeat is written to the daemon's bounded command channel — the
+/// *same* channel that carries every coordinator→daemon command (spawn, stop,
+/// add/remove node, …), not a dedicated heartbeat channel. That makes the two
+/// failure shapes mean very different things, and the disconnect decision must
+/// tell them apart (see [`HeartbeatSendOutcome::should_disconnect`]).
+enum HeartbeatSendOutcome {
+    /// The heartbeat was enqueued for delivery.
+    Delivered,
+    /// `send()` returned an error, i.e. the daemon's WS writer task has
+    /// dropped its receiver. The connection is genuinely gone.
+    ChannelClosed,
+    /// The send did not complete within the timeout: the bounded command
+    /// channel is momentarily full (backpressure from a large spawn or a
+    /// burst of control commands), *not* a dead daemon.
+    TimedOut,
+}
+
+impl HeartbeatSendOutcome {
+    /// Whether this outcome should tear the daemon down.
+    ///
+    /// Only a closed channel does. A [`TimedOut`](Self::TimedOut) send means
+    /// the command channel is backed up, which says nothing about daemon
+    /// liveness — the daemon reports its own health through *inbound*
+    /// heartbeats (`last_heartbeat`), and the 30 s inbound threshold already
+    /// catches a genuinely dead daemon. Treating a transient send timeout as
+    /// death would let one slow WS write burst falsely disconnect a live
+    /// daemon and tear down all of its dataflows.
+    fn should_disconnect(&self) -> bool {
+        matches!(self, HeartbeatSendOutcome::ChannelClosed)
+    }
+}
+
 async fn start_inner(
     events: impl Stream<Item = Event> + Unpin,
     clock: Arc<HLC>,
@@ -2026,18 +2060,38 @@ async fn start_inner(
                         disconnected.insert(machine_id.clone());
                         continue;
                     }
-                    let result: eyre::Result<()> = tokio::time::timeout(
+                    let outcome = match tokio::time::timeout(
                         Duration::from_millis(500),
                         send_heartbeat_message(connection, clock.new_timestamp()),
                     )
                     .await
-                    .wrap_err("timeout")
-                    .and_then(|r| r)
-                    .wrap_err_with(|| {
-                        format!("failed to send heartbeat message to daemon at `{machine_id}`")
-                    });
-                    if let Err(err) = result {
-                        tracing::warn!("{err:?}");
+                    {
+                        Ok(Ok(())) => HeartbeatSendOutcome::Delivered,
+                        Ok(Err(err)) => {
+                            tracing::warn!(
+                                "heartbeat send channel to daemon at `{machine_id}` is closed: {err:?}"
+                            );
+                            HeartbeatSendOutcome::ChannelClosed
+                        }
+                        Err(_elapsed) => {
+                            // The 500 ms budget elapsed while the *bounded*
+                            // command channel was full — backpressure from a
+                            // large spawn or a burst of control commands, not a
+                            // dead daemon. Do not tear the daemon down: it is
+                            // proven alive by its recent inbound heartbeat
+                            // (checked just above against the 30 s threshold),
+                            // and disconnecting here would fail all of its
+                            // dataflows over transient congestion.
+                            tracing::warn!(
+                                "heartbeat send to daemon at `{machine_id}` timed out \
+                                 (command channel full); not disconnecting a live daemon \
+                                 (last inbound heartbeat {:?} ago)",
+                                connection.last_heartbeat.elapsed()
+                            );
+                            HeartbeatSendOutcome::TimedOut
+                        }
+                    };
+                    if outcome.should_disconnect() {
                         disconnected.insert(machine_id.clone());
                     }
                 }
@@ -4706,6 +4760,29 @@ mod tests {
     use std::collections::HashMap;
     use tokio::time::{Duration as TokioDuration, timeout};
     use uuid::Uuid;
+
+    // A heartbeat that could not be delivered because the *bounded command
+    // channel* was momentarily full (a `TimedOut` outcome) must NOT disconnect
+    // the daemon: the daemon reports its own liveness through inbound
+    // heartbeats, and the 30 s inbound threshold already catches a genuinely
+    // dead one. Only a closed send channel is a real death signal. Regression
+    // for a transient control-command burst falsely tearing down a live
+    // daemon's dataflows.
+    #[test]
+    fn heartbeat_timeout_does_not_disconnect_a_live_daemon() {
+        assert!(
+            HeartbeatSendOutcome::ChannelClosed.should_disconnect(),
+            "a closed heartbeat send channel must disconnect the daemon"
+        );
+        assert!(
+            !HeartbeatSendOutcome::TimedOut.should_disconnect(),
+            "a transient command-channel backpressure timeout must not disconnect a live daemon"
+        );
+        assert!(
+            !HeartbeatSendOutcome::Delivered.should_disconnect(),
+            "a delivered heartbeat must not disconnect the daemon"
+        );
+    }
 
     fn test_running_dataflow(
         dataflow_id: DataflowId,

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -2193,9 +2193,8 @@ async fn start_inner(
                         clock.new_timestamp(),
                     ));
                 }
-                for (machine_id, result) in join_all(heartbeats).await {
-                    if let Err(err) = result {
-                        tracing::warn!("{err:?}");
+                for (machine_id, disconnect) in join_all(heartbeats).await {
+                    if disconnect {
                         disconnected.insert(machine_id);
                     }
                 }
@@ -3339,23 +3338,110 @@ fn handle_spawn_result_ok(
     }
 }
 
-/// Send one heartbeat to `connection` with a 500 ms deadline, tagging the
-/// result with `machine_id` so the watchdog can act on failures after awaiting
-/// many of these concurrently via `join_all`.
+/// Consecutive heartbeat-send timeouts after which a daemon is disconnected.
+///
+/// A heartbeat send is a write to the daemon's *bounded* command channel — the
+/// same channel every coordinator→daemon command uses. A single send timeout is
+/// transient backpressure (a large spawn, a burst of control commands) and must
+/// not disconnect a daemon that is otherwise alive and still sending its own
+/// inbound heartbeats; disconnecting on one timeout tears down all of its
+/// dataflows over momentary congestion.
+///
+/// This backstop bounds only the **no-traffic** wedge: a daemon whose command
+/// channel stays full while *no* command is routed to it is disconnected after
+/// this many consecutive heartbeat ticks (~30 s at the 3 s interval, matching
+/// the 30 s inbound-heartbeat liveness horizon). It does **not** bound the case
+/// where a command *is* routed to a wedged daemon first: `send_and_receive`
+/// awaits the same channel with no timeout, so that send blocks the
+/// single-threaded coordinator event loop before any further heartbeat tick can
+/// advance this counter. Bounding that enqueue is a separate change (it alters
+/// command-dispatch failure semantics); see the PR discussion.
+const MAX_CONSECUTIVE_HEARTBEAT_SEND_TIMEOUTS: u32 = 10;
+
+/// Classification of one heartbeat-send attempt.
+enum HeartbeatSendOutcome {
+    /// The heartbeat was enqueued for delivery.
+    Delivered,
+    /// The send returned an error: the command channel's receiver has been
+    /// dropped (the daemon's WS writer task is gone) or — cosmetically — the
+    /// heartbeat could not be serialized. Either way the send cannot succeed,
+    /// so disconnect immediately.
+    SendFailed,
+    /// The 500 ms deadline elapsed while the bounded command channel was full
+    /// (backpressure), which does not by itself mean the daemon is dead.
+    TimedOut,
+}
+
+/// Fold a heartbeat-send outcome and the running count of consecutive timeouts
+/// into the next count and whether to disconnect the daemon.
+///
+/// - `Delivered` clears the timeout streak and keeps the daemon.
+/// - `SendFailed` disconnects immediately and clears the streak.
+/// - `TimedOut` increments the streak and disconnects only once it reaches
+///   [`MAX_CONSECUTIVE_HEARTBEAT_SEND_TIMEOUTS`], so transient backpressure is
+///   tolerated while a persistently wedged channel is still torn down.
+fn heartbeat_disconnect_decision(
+    outcome: HeartbeatSendOutcome,
+    consecutive_timeouts: u32,
+) -> (u32, bool) {
+    match outcome {
+        HeartbeatSendOutcome::Delivered => (0, false),
+        HeartbeatSendOutcome::SendFailed => (0, true),
+        HeartbeatSendOutcome::TimedOut => {
+            let streak = consecutive_timeouts.saturating_add(1);
+            (streak, streak >= MAX_CONSECUTIVE_HEARTBEAT_SEND_TIMEOUTS)
+        }
+    }
+}
+
+/// Send one heartbeat to `connection` with a 500 ms deadline and return, tagged
+/// with `machine_id`, whether the watchdog should disconnect the daemon.
+///
+/// A send *timeout* means the bounded command channel is momentarily full, not
+/// that the daemon is dead — so a single timeout no longer disconnects a live
+/// daemon (which would fail all of its dataflows over transient congestion).
+/// Only a failed send disconnects immediately; a persistent timeout streak
+/// escalates via [`heartbeat_disconnect_decision`]. The counter lives on
+/// `connection`, and each future here holds a distinct `&mut` (one per daemon),
+/// so updating it from inside the concurrent `join_all` is sound.
 async fn send_heartbeat_with_timeout(
     machine_id: DaemonId,
     connection: &mut crate::state::DaemonConnection,
     timestamp: dora_core::uhlc::Timestamp,
-) -> (DaemonId, eyre::Result<()>) {
-    let result = tokio::time::timeout(
+) -> (DaemonId, bool) {
+    let outcome = match tokio::time::timeout(
         Duration::from_millis(500),
         send_heartbeat_message(connection, timestamp),
     )
     .await
-    .wrap_err("timeout")
-    .and_then(|r| r)
-    .wrap_err_with(|| format!("failed to send heartbeat message to daemon at `{machine_id}`"));
-    (machine_id, result)
+    {
+        Ok(Ok(())) => HeartbeatSendOutcome::Delivered,
+        Ok(Err(err)) => {
+            tracing::warn!("heartbeat send to daemon at `{machine_id}` failed: {err:?}");
+            HeartbeatSendOutcome::SendFailed
+        }
+        Err(_elapsed) => HeartbeatSendOutcome::TimedOut,
+    };
+    let (streak, disconnect) =
+        heartbeat_disconnect_decision(outcome, connection.consecutive_heartbeat_send_timeouts);
+    connection.consecutive_heartbeat_send_timeouts = streak;
+    // `streak > 0` only for a `TimedOut` outcome.
+    if streak > 0 {
+        if disconnect {
+            tracing::error!(
+                "heartbeat send to daemon at `{machine_id}` timed out {streak} times in a row \
+                 (command channel persistently full); disconnecting"
+            );
+        } else {
+            tracing::warn!(
+                "heartbeat send to daemon at `{machine_id}` timed out (command channel full, \
+                 streak {streak}/{MAX_CONSECUTIVE_HEARTBEAT_SEND_TIMEOUTS}); not disconnecting a \
+                 live daemon (last inbound heartbeat {:?} ago)",
+                connection.last_heartbeat.elapsed()
+            );
+        }
+    }
+    (machine_id, disconnect)
 }
 
 /// Handle the failure arm of `Event::DataflowSpawnResult`.
@@ -5520,6 +5606,108 @@ mod tests {
     use std::collections::HashMap;
     use tokio::time::{Duration as TokioDuration, timeout};
     use uuid::Uuid;
+
+    // ---- heartbeat-send backpressure classification (#2886) ----
+
+    // A failed send disconnects immediately; a delivered heartbeat never does
+    // and clears any timeout streak.
+    #[test]
+    fn heartbeat_send_failed_disconnects_delivered_resets() {
+        assert_eq!(
+            heartbeat_disconnect_decision(HeartbeatSendOutcome::SendFailed, 0),
+            (0, true),
+            "a failed heartbeat send must disconnect the daemon"
+        );
+        assert_eq!(
+            heartbeat_disconnect_decision(HeartbeatSendOutcome::Delivered, 7),
+            (0, false),
+            "a delivered heartbeat must not disconnect and must clear the timeout streak"
+        );
+    }
+
+    // A *transient* command-channel backpressure timeout must NOT disconnect a
+    // live daemon (regression for a control-command burst tearing down a live
+    // daemon's dataflows), but a *persistent* streak must escalate.
+    #[test]
+    fn heartbeat_timeout_tolerates_transient_but_escalates_persistent() {
+        assert_eq!(
+            heartbeat_disconnect_decision(HeartbeatSendOutcome::TimedOut, 0),
+            (1, false),
+            "a single timeout must not disconnect a live daemon"
+        );
+        assert_eq!(
+            heartbeat_disconnect_decision(
+                HeartbeatSendOutcome::TimedOut,
+                MAX_CONSECUTIVE_HEARTBEAT_SEND_TIMEOUTS - 2,
+            ),
+            (MAX_CONSECUTIVE_HEARTBEAT_SEND_TIMEOUTS - 1, false),
+            "timeouts below the threshold must not disconnect"
+        );
+        let (streak, disconnect) = heartbeat_disconnect_decision(
+            HeartbeatSendOutcome::TimedOut,
+            MAX_CONSECUTIVE_HEARTBEAT_SEND_TIMEOUTS - 1,
+        );
+        assert_eq!(streak, MAX_CONSECUTIVE_HEARTBEAT_SEND_TIMEOUTS);
+        assert!(
+            disconnect,
+            "a persistently full command channel must escalate to a disconnect"
+        );
+    }
+
+    // Wiring guard: `send_heartbeat_with_timeout` must map a closed send channel
+    // (dropped receiver) to an immediate disconnect, so re-flattening the
+    // outcome back into "disconnect on any failure" is the only green state.
+    #[tokio::test(flavor = "current_thread")]
+    async fn send_heartbeat_with_timeout_disconnects_on_closed_channel() {
+        let (tx, rx) = tokio::sync::mpsc::channel::<String>(1);
+        drop(rx); // closing the channel makes every send return Err immediately
+        let pending_replies = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let mut connection =
+            crate::state::DaemonConnection::new(tx, pending_replies, BTreeMap::new());
+
+        let (_id, disconnect) = send_heartbeat_with_timeout(
+            DaemonId::new(Some("dead".to_string())),
+            &mut connection,
+            HLC::default().new_timestamp(),
+        )
+        .await;
+
+        assert!(
+            disconnect,
+            "a closed send channel must disconnect the daemon"
+        );
+    }
+
+    // Wiring guard: `send_heartbeat_with_timeout` must map a full command
+    // channel (send never completes) to a *non*-disconnecting timeout that only
+    // bumps the streak. `start_paused` auto-advances through the 500 ms deadline
+    // without real delay (mirrors the topic-frame timeout test in handlers.rs).
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn send_heartbeat_with_timeout_tolerates_a_full_channel() {
+        // Capacity 1, pre-filled, receiver kept alive (so the channel is full,
+        // not closed) and never drained => the heartbeat send blocks and times out.
+        let (tx, _rx_never_drained) = tokio::sync::mpsc::channel::<String>(1);
+        tx.send("prefill".to_string()).await.unwrap();
+        let pending_replies = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let mut connection =
+            crate::state::DaemonConnection::new(tx, pending_replies, BTreeMap::new());
+
+        let (_id, disconnect) = send_heartbeat_with_timeout(
+            DaemonId::new(Some("wedged".to_string())),
+            &mut connection,
+            HLC::default().new_timestamp(),
+        )
+        .await;
+
+        assert!(
+            !disconnect,
+            "a single backpressure timeout must not disconnect a live daemon"
+        );
+        assert_eq!(
+            connection.consecutive_heartbeat_send_timeouts, 1,
+            "the timeout must advance the consecutive-timeout streak"
+        );
+    }
 
     /// The single input mapping of a resolved custom node.
     fn only_input_mapping(

--- a/binaries/coordinator/src/state.rs
+++ b/binaries/coordinator/src/state.rs
@@ -148,6 +148,12 @@ pub(crate) struct DaemonConnection {
     /// the connection: a daemon that dropped must not keep being advertised,
     /// and a restarted one replaces its own stale entry on re-register.
     pub(crate) zenoh_listen_endpoint: Option<String>,
+    /// Consecutive coordinator→daemon heartbeat-send timeouts (the bounded
+    /// command channel was full when the 500 ms heartbeat deadline elapsed).
+    /// Reset to 0 on any completed send. A transient streak is tolerated as
+    /// backpressure; a persistent one escalates to a disconnect (see
+    /// `MAX_CONSECUTIVE_HEARTBEAT_SEND_TIMEOUTS`).
+    pub(crate) consecutive_heartbeat_send_timeouts: u32,
 }
 
 /// The envelope `handle_daemon_response` (see `ws_daemon.rs`) produces when a
@@ -177,6 +183,7 @@ impl DaemonConnection {
             supports_hub_sources: false,
             connection_id: Uuid::new_v4(),
             zenoh_listen_endpoint: None,
+            consecutive_heartbeat_send_timeouts: 0,
         }
     }
 


### PR DESCRIPTION
## Issue

The per-daemon heartbeat is written to the daemon's **bounded command channel** — the same channel every coordinator→daemon command (spawn, stop, add/remove node, …) uses. `send_heartbeat_with_timeout` wraps the send in a 500 ms `timeout`, and the watchdog disconnected the daemon on **any** error, including that timeout:

```rust
let result = tokio::time::timeout(Duration::from_millis(500), send_heartbeat_message(..))
    .await.wrap_err("timeout").and_then(|r| r) ...;
// caller:
if let Err(err) = result { disconnected.insert(machine_id); }
```

A disconnected daemon is removed, unregistered from the store, and **all of its running dataflows are torn down**. A `timeout` here only means the bounded command channel was momentarily full — backpressure from a large spawn or a burst of control commands — while the daemon is provably alive (its *inbound* heartbeat was checked against the 30 s threshold immediately above). So a single slow WS-write burst could falsely disconnect a healthy daemon and fail all of its dataflows.

## Fix

Classify the send outcome (`Delivered` / `SendFailed` / `TimedOut`) and only disconnect *immediately* on `SendFailed`. A transient timeout is tolerated; a persistent streak escalates to a disconnect after `MAX_CONSECUTIVE_HEARTBEAT_SEND_TIMEOUTS` (10 ≈ 30 s at the 3 s interval). A genuinely dead daemon is still caught by (a) the next send returning `Err` once the WS writer's receiver drops, and (b) the existing 30 s inbound-heartbeat threshold.

## Scope of the escalation backstop (reviewer-raised, important)

The escalation bounds only the **no-traffic wedge**: a daemon whose command channel stays full while *no* command is routed to it is disconnected after ~30 s of heartbeat ticks. It does **not** bound the case where a command is routed to a wedged daemon first — `DaemonConnection::send_and_receive` awaits the same channel with **no** timeout, so that send blocks the single-threaded coordinator event loop before any further heartbeat tick can advance the counter. Pre-fix, one 500 ms timeout disconnected the daemon and stopped routing there, so this change narrows that immediate backstop. Fully closing it means bounding the `send_and_receive` enqueue, which changes command-dispatch failure semantics and is left as a **separate follow-up** (see thread). The const's doc and the code comments state this limitation explicitly rather than claiming the backstop is unconditional.

Net effect: the common, impactful failure (a transient spawn burst tearing down all of a live daemon's dataflows) is fixed; the rare wedged-daemon-plus-routed-command head-of-line window is documented and left to the follow-up.

## Validation

- `heartbeat_disconnect_decision` is a pure helper with unit tests (tolerate transient → escalate persistent → reset on delivery → disconnect on `SendFailed`).
- `send_heartbeat_with_timeout` is covered by two **wiring** tests so re-flattening the outcome back into "disconnect on any error" can't pass silently: a dropped-receiver channel → disconnect; a full capacity-1 channel under `#[tokio::test(start_paused = true)]` → a tolerated timeout that only bumps the streak.
- `cargo test -p dora-coordinator` (148 passed), `clippy --all-targets -D warnings`, and `fmt --check` all green on rustc 1.97.1, rebased on current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeK3nXPz84sLjc8eTKPnbb