### PR TITLE
fix(core): normalize an empty merged env to None in merge_env

### DIFF
--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -275,23 +275,28 @@ impl DescriptorExt for Descriptor {
 }
 
 /// Merge dataflow-level `env` into a node's `env`, with per-node keys winning
-/// on conflict. Returns `None` when both inputs are empty so the resolved
-/// node serializes cleanly when no env vars are set anywhere.
+/// on conflict. Returns `None` when the merged result is empty so the resolved
+/// node serializes cleanly (no empty `env: {}` map) whenever no env vars are
+/// effectively set — regardless of whether the emptiness comes from the global
+/// map, the node map, or both (e.g. a node that declares `env: {}` with no
+/// dataflow-level env).
 fn merge_env(
     global: Option<&BTreeMap<String, EnvValue>>,
     node: Option<BTreeMap<String, EnvValue>>,
 ) -> Option<BTreeMap<String, EnvValue>> {
-    match (global, node) {
-        (None, node) => node,
-        (Some(global), None) if global.is_empty() => None,
-        (Some(global), None) => Some(global.clone()),
+    let merged = match (global, node) {
+        (None, None) => return None,
+        (None, Some(node)) => node,
+        (Some(global), None) => global.clone(),
         (Some(global), Some(node)) => {
             let mut merged = global.clone();
             // Per-node entries override global ones on key conflict.
             merged.extend(node);
-            Some(merged)
+            merged
         }
-    }
+    };
+    // Normalize an empty result to `None` regardless of which side was empty.
+    (!merged.is_empty()).then_some(merged)
 }
 
 pub async fn read_as_descriptor(path: &Path) -> eyre::Result<Descriptor> {
@@ -608,6 +613,21 @@ mod tests {
         let global = env(&[("A", "1")]);
         let merged = merge_env(Some(&global), None).unwrap();
         assert_eq!(merged, global);
+    }
+
+    #[test]
+    fn merge_env_normalizes_empty_node_map_to_none() {
+        // A node that declares `env: {}` with no dataflow-level env must
+        // resolve to `None`, not `Some({})`, matching the documented contract
+        // (and the `(Some(empty), None)` arm) so the resolved node serializes
+        // without an empty `env:` map.
+        assert!(merge_env(None, Some(env(&[]))).is_none());
+    }
+
+    #[test]
+    fn merge_env_normalizes_empty_global_and_node_maps_to_none() {
+        assert!(merge_env(Some(&env(&[])), Some(env(&[]))).is_none());
+        assert!(merge_env(Some(&env(&[])), None).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Issue

`merge_env` documents that it returns `None` when no env vars are effectively set, so a resolved node serializes cleanly without an empty `env: {}` map. Two input combinations violated that contract:

- `(None, Some(empty))` — a node declaring `env: {}` with no dataflow-level env — returned `Some(empty)`.
- `(Some(empty), Some(empty))` — returned `Some(empty)`.

…while the analogous `(Some(empty), None)` arm correctly returned `None`. So the "empty → None" normalization was applied inconsistently depending on which side was empty.

## Fix

Build the merged map first, then normalize an empty result to `None` uniformly (`(!merged.is_empty()).then_some(merged)`), so the contract holds regardless of which side is empty. This also drops the special-case guard arm.

This is behavior-preserving for every caller: all consumers of `ResolvedNode.env` use `if let Some(env) = …` / `.as_ref()`, so iterating an empty map and skipping `None` are equivalent — no caller relied on `Some(empty)` meaning "env was explicitly declared". The only observable effect is cleaner serialization.

## Validation

- New unit tests `merge_env_normalizes_empty_node_map_to_none` and `merge_env_normalizes_empty_global_and_node_maps_to_none`; existing `merge_env` tests still pass.
- `cargo test -p dora-core`, `cargo clippy -p dora-core -- -D warnings`, `cargo fmt --check` all pass.

---

🤖 This is a machine-generated pull request opened by Claude Code as part of an automated codebase review. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeK3nXPz84sLjc8eTKPnbb

---
_Generated by [Claude Code](https://claude.ai/code/session_01DeK3nXPz84sLjc8eTKPnbb)_