### PR TITLE
fix(cli): surface coordinator startup stderr in dora up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2150,6 +2150,7 @@ dependencies = [
  "eyre",
  "futures",
  "libloading 0.9.0",
+ "redb",
  "serde_json",
  "serde_yaml",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,6 +203,7 @@ tracing = { workspace = true }
 futures = { workspace = true }
 tokio-stream = "0.1.18"
 tempfile = { workspace = true }
+redb = "2"
 assert2 = "0.4.0"
 tokio-tungstenite = "0.29"
 libloading = "0.9"

--- a/binaries/cli/src/command/up.rs
+++ b/binaries/cli/src/command/up.rs
@@ -10,6 +10,7 @@ use eyre::{Context, ContextCompat, bail};
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::{fs, net::SocketAddr, path::Path, process::Command, time::Duration};
+use uuid::Uuid;
 
 #[derive(Debug, clap::Args)]
 /// Spawn coordinator and daemon in local mode (with default config)
@@ -54,15 +55,8 @@ pub(crate) fn up(config_path: Option<&Path>, auth: bool) -> eyre::Result<()> {
             session
         }
         Err(_) => {
-            start_coordinator(auth).wrap_err("failed to start dora-coordinator")?;
-
-            connect_with_retry(coordinator_addr, Duration::from_secs(10)).map_err(|err| {
-                eyre::eyre!(
-                    "timed out waiting for coordinator to start at {coordinator_addr}: {err}\n\n  \
-                     hint: is port {port} already in use? Check with `dora status`\n  \
-                     or stop the existing coordinator with `dora down`"
-                )
-            })?
+            let startup = start_coordinator(auth)?;
+            wait_for_coordinator_start(coordinator_addr, port, startup)?
         }
     };
 
@@ -87,6 +81,61 @@ pub(crate) fn up(config_path: Option<&Path>, auth: bool) -> eyre::Result<()> {
     }
 
     Ok(())
+}
+
+struct CoordinatorStartup {
+    stderr_path: std::path::PathBuf,
+    child: std::process::Child,
+}
+
+fn wait_for_coordinator_start(
+    coordinator_addr: SocketAddr,
+    port: u16,
+    mut startup: CoordinatorStartup,
+) -> eyre::Result<crate::ws_client::WsSession> {
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Some(status) = startup
+            .child
+            .try_wait()
+            .wrap_err("failed to poll coordinator")?
+        {
+            let stderr = captured_stderr(&startup.stderr_path);
+            let _ = fs::remove_file(&startup.stderr_path);
+            if stderr.is_empty() {
+                eyre::bail!("coordinator exited before it became ready: {status}");
+            }
+            eyre::bail!("coordinator exited before it became ready: {status}\n{stderr}");
+        }
+        match connect_to_coordinator(coordinator_addr) {
+            Ok(session) => {
+                let _ = fs::remove_file(&startup.stderr_path);
+                return Ok(session);
+            }
+            Err(_) if std::time::Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(err) => {
+                let stderr = captured_stderr(&startup.stderr_path);
+                let _ = fs::remove_file(&startup.stderr_path);
+                if stderr.is_empty() {
+                    eyre::bail!(
+                        "timed out waiting for coordinator to start at {coordinator_addr}: {err}\n\n  hint: is port {port} already in use? Check with `dora status`\n  or stop the existing coordinator with `dora down`"
+                    );
+                }
+                eyre::bail!(
+                    "timed out waiting for coordinator to start at {coordinator_addr}: {err}\n\n  coordinator stderr:\n{stderr}\n\n  hint: is port {port} already in use? Check with `dora status`\n  or stop the existing coordinator with `dora down`"
+                );
+            }
+        }
+    }
+}
+
+fn captured_stderr(path: &Path) -> String {
+    fs::read_to_string(path)
+        .unwrap_or_default()
+        .trim()
+        .to_owned()
 }
 
 pub(crate) fn down(
@@ -156,7 +205,7 @@ pub(crate) fn detach_process(cmd: &mut Command) {
     }
 }
 
-fn start_coordinator(auth: bool) -> eyre::Result<()> {
+fn start_coordinator(auth: bool) -> eyre::Result<CoordinatorStartup> {
     let path = dora_executable_path()?;
     let mut cmd = Command::new(path);
     cmd.arg("coordinator");
@@ -164,15 +213,26 @@ fn start_coordinator(auth: bool) -> eyre::Result<()> {
     if auth {
         cmd.arg("--auth");
     }
-    detach_process(&mut cmd);
-    cmd.spawn().wrap_err(
+    let stderr_path =
+        std::env::temp_dir().join(format!("dora-coordinator-{}.stderr", Uuid::new_v4()));
+    let stderr_file =
+        fs::File::create(&stderr_path).wrap_err("failed to create coordinator stderr capture")?;
+    cmd.stdin(Stdio::null());
+    cmd.stdout(Stdio::null());
+    cmd.stderr(stderr_file);
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        cmd.process_group(0);
+    }
+    let child = cmd.spawn().wrap_err(
         "failed to run `dora coordinator`\n\n  \
          hint: ensure the `dora` binary is in your PATH",
     )?;
 
     println!("started dora coordinator");
 
-    Ok(())
+    Ok(CoordinatorStartup { stderr_path, child })
 }
 
 fn start_daemon() -> eyre::Result<()> {

--- a/tests/ws-cli-e2e.rs
+++ b/tests/ws-cli-e2e.rs
@@ -1016,11 +1016,13 @@ mod real_dataflow {
     use dora_message::{
         cli_to_coordinator::ControlRequest, coordinator_to_cli::ControlRequestReply,
     };
+    use redb::{Database, TableDefinition};
     use std::net::SocketAddr;
     use std::path::Path;
     use std::process::{Command, Stdio};
     use std::sync::Once;
     use std::time::Duration;
+    use tempfile::tempdir;
     use uuid::Uuid;
 
     static BUILD: Once = Once::new();
@@ -1063,6 +1065,69 @@ mod real_dataflow {
                 .expect("failed to build");
             assert!(status.success());
         });
+    }
+
+    fn write_legacy_coordinator_redb(home: &Path) {
+        let path = home.join(".dora").join("coordinator.redb");
+        std::fs::create_dir_all(path.parent().unwrap()).expect("create .dora dir");
+        let db = Database::create(&path).expect("create redb file");
+        let txn = db.begin_write().expect("begin redb write");
+        {
+            let mut meta: redb::Table<'_, &str, u32> = txn
+                .open_table(TableDefinition::new("meta"))
+                .expect("open meta table");
+            meta.insert("schema_version", 2u32)
+                .expect("write legacy schema version");
+        }
+        txn.commit().expect("commit redb fixture");
+    }
+
+    fn allocate_port() -> u16 {
+        std::net::TcpListener::bind(("127.0.0.1", 0))
+            .expect("bind ephemeral port")
+            .local_addr()
+            .expect("local addr")
+            .port()
+    }
+
+    fn run_dora_with_home(
+        dora: &str,
+        home: &Path,
+        port: u16,
+        args: &[&str],
+    ) -> (std::process::ExitStatus, String, String) {
+        let mut cmd = Command::new(dora);
+        cmd.args(args);
+        cmd.env("HOME", home);
+        cmd.env("DORA_COORDINATOR_PORT", port.to_string());
+        let out = cmd
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .expect("failed to spawn dora");
+        let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+        let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+        (out.status, stdout, stderr)
+    }
+
+    #[test]
+    fn e2e_up_reports_redb_schema_mismatch_from_coordinator() {
+        ensure_built();
+        let dora = dora_bin();
+        let home = tempdir().expect("temp home");
+        write_legacy_coordinator_redb(home.path());
+        let port = allocate_port();
+
+        let (status, stdout, stderr) = run_dora_with_home(&dora, home.path(), port, &["up"]);
+        assert!(
+            !status.success(),
+            "dora up should fail with a legacy redb file; stdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("redb schema version mismatch")
+                || stdout.contains("redb schema version mismatch"),
+            "startup error should expose the coordinator crash cause, got stdout:\n{stdout}\nstderr:\n{stderr}"
+        );
     }
 
     fn cleanup(dora: &str) {


### PR DESCRIPTION
## Issue

`dora up` could hide the real coordinator startup failure when a persisted coordinator redb file was incompatible with the current binary.

The coordinator redb backend intentionally rejects old schema versions at startup. For example, a user upgrading from older rc builds can still have `~/.dora/coordinator.redb` stamped with schema v2, while the current binary expects schema v3. In that case `dora coordinator` exits immediately with `redb schema version mismatch`.

Before this change, `dora up` spawned the coordinator as a detached child with stderr redirected to null. The child could exit with the actionable schema mismatch error, but the parent CLI only kept retrying the WebSocket connection until it timed out. Users then saw a generic “timed out waiting for coordinator to start” message instead of the real reason.

## Fix

- Capture `dora coordinator` stderr in a temporary file while `dora up` waits for the coordinator to become ready.
- Poll the coordinator child process during startup so an early exit is detected directly.
- Include captured coordinator stderr when the coordinator exits before readiness.
- Include captured coordinator stderr on startup timeout if the child produced any output.
- Remove the temporary stderr capture file on success, early exit, and timeout paths.
- Keep the daemon startup path unchanged.
- Add a regression test that creates an isolated HOME with a legacy v2 `coordinator.redb` and verifies `dora up` reports `redb schema version mismatch`.

## Validation

- Reproduced the issue with:
  - `cargo test --test ws-cli-e2e e2e_up_reports_redb_schema_mismatch_from_coordinator -- --test-threads=1 --nocapture`
- Verified the fix with:
  - `cargo test --test ws-cli-e2e e2e_up_reports_redb_schema_mismatch_from_coordinator -- --test-threads=1 --nocapture`
  - `cargo fmt --all -- --check`
  - `cargo clippy -p dora-cli -- -D warnings`
  - `cargo test --test node-lifecycle-e2e lifecycle_rust_dynamic_add_remove -- --test-threads=1 --nocapture` with isolated `HOME`
