### PR TITLE
fix(node): freeze un-acked outputs at the startup grace boundary (#2891)

### DIFF
--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -121,11 +121,16 @@ pub struct EventStream {
 /// (node, input) in the attachment. The producer switches the output from the
 /// lossless daemon path to direct zenoh once all its required consumers acked.
 ///
-/// The thread acks *every* marker for the stream's whole lifetime: markers
-/// keep coming until the producer has this ack, so ack-route establishment
-/// races self-heal, and late producers (dynamic nodes, restarts) get their
-/// acks whenever they run their handshake. It exits when the data subscribers
-/// (the only senders) are dropped.
+/// The thread acks *every* marker for the stream's whole lifetime, so late
+/// producers (dynamic nodes, restarts) get their acks whenever they run their
+/// handshake. Note that the producer's markers are **not** unbounded: it stops
+/// marking an output at its startup grace boundary and pins any still-un-acked
+/// output to the daemon path for the rest of its run (dora-rs/dora#2891). So
+/// acking promptly is what preserves the fast path — an ack-route race that
+/// outlasts the producer's grace does not self-heal, and a dropped ack (the
+/// bounded-queue `try_send` fallback below) costs that output direct zenoh for
+/// the producer's whole run. The thread exits when the data subscribers (the
+/// only senders) are dropped.
 fn spawn_startup_acker(
     node_id: NodeId,
     ack_publishers: HashMap<DataId, zenoh::pubsub::Publisher<'static>>,

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -147,31 +147,32 @@ const LARGE_SEND_DIAG_LIMIT: u32 = 3;
 /// How often a starting node re-publishes its startup route-probe markers.
 ///
 /// See [`StartupHandshake`]. Markers stop per output as soon as that output's
-/// required acks have arrived (or the deadline froze it on the daemon path),
-/// so this rate only applies while the handshake is in flight.
+/// required acks have arrived (or the grace boundary froze it on the daemon
+/// path), so this rate only applies while the handshake is in flight.
 const ZENOH_STARTUP_MARKER_INTERVAL: Duration = Duration::from_millis(5);
 
-/// How long a producer keeps publishing markers for an un-acked output before
-/// freezing it on the reliable daemon path.
+/// The whole budget the startup handshake gets, measured from the daemon's
+/// "all nodes ready" barrier: `init` waits this long for the handshake, and
+/// whatever is still un-acked at the end is frozen on the daemon path for the
+/// run (see [`wait_for_grace`] for why the freeze is unconditional).
 ///
-/// Armed only once the daemon's "all nodes ready" barrier has released — i.e.
-/// once every static consumer has declared its subscribers and ack publishers
-/// — so a consumer that is merely slow to *start* (a Python node importing
-/// heavy libraries for a minute) cannot burn the deadline. From arming, this
-/// long with 5 ms markers and no ack means the route is genuinely broken, not
-/// slow. Nothing fails on the deadline: the output just keeps riding the
-/// lossless daemon path.
-const ZENOH_STARTUP_ACK_TIMEOUT: Duration = Duration::from_secs(10);
-
-/// How long `init` waits after the barrier for the handshake to complete
-/// before returning control to user code.
+/// The window starts at the barrier, not at spawn: by then every static
+/// consumer has declared its subscribers and ack publishers, so a consumer
+/// that is merely slow to *start* (a Python node importing heavy libraries for
+/// a minute) cannot burn it. The healthy case completes in one marker→ack
+/// round-trip (single-digit milliseconds); half a second of 5 ms markers with
+/// no ack means the route is broken, not slow. Nothing fails at the boundary —
+/// a frozen output just keeps riding the lossless daemon path, trading the
+/// fast path for ordering. This is the single knob for that trade: raising it
+/// gives slow-to-establish routes more chance at direct zenoh, at the cost of
+/// delaying every node whose routes are genuinely broken.
 ///
-/// The healthy case completes in one marker→ack round-trip (single-digit
-/// milliseconds), which makes switch-before-first-send the overwhelmingly
-/// common case — messages then never straddle the daemon→zenoh path switch,
-/// so cross-path reordering cannot occur. When a route is genuinely broken
-/// this costs half a second once and the affected outputs keep riding the
-/// daemon path (still upgrading later if acks arrive before the deadline).
+/// For a **dynamic or restarted** producer the barrier releases immediately —
+/// its consumers have long been running — so this window instead starts a few
+/// milliseconds after the zenoh session opens, while the peer links it needs
+/// may still be dialing. Such a producer is therefore the most likely to end
+/// up frozen on the daemon path; if that shows up as a measurable regression,
+/// this constant (not a late upgrade) is the thing to raise.
 const ZENOH_STARTUP_GRACE: Duration = Duration::from_millis(500);
 
 /// Poll interval for the post-barrier grace wait.
@@ -182,8 +183,9 @@ struct DirectOutput {
     publisher: zenoh::pubsub::Publisher<'static>,
     /// `false` until the startup handshake proves this output's routes — every
     /// required consumer acked one of its markers (see [`StartupHandshake`]).
-    /// The send path consults this per message and takes the reliable daemon
-    /// path while it is `false`.
+    /// Settled by [`wait_for_grace`] before `init` returns and immutable from
+    /// then on, so every send of a given output takes the same path: direct
+    /// zenoh when `true`, the reliable daemon path when `false`.
     ready: Arc<AtomicBool>,
 }
 
@@ -274,7 +276,7 @@ fn declare_output_publishers(
 ///
 /// Shared between the output's ack-subscriber callback (which records incoming
 /// acks) and the [`StartupHandshake`] thread (which publishes markers until
-/// completion and checks the deadline).
+/// completion or the freeze).
 struct AckState {
     output_id: DataId,
     /// The (consumer node, input) identities that must ack before the output
@@ -284,8 +286,12 @@ struct AckState {
     /// Identities that have acked so far.
     received: Mutex<BTreeSet<(String, String)>>,
     /// The same flag as the output's [`DirectOutput::ready`]; flipped exactly
-    /// once, when `received` covers `required`.
+    /// once, when `received` covers `required` before the freeze.
     ready: Arc<AtomicBool>,
+    /// Set once the grace boundary passed with this output still un-acked: the
+    /// output is pinned to the daemon path and can never upgrade (see
+    /// [`Self::freeze`]).
+    frozen: AtomicBool,
 }
 
 impl AckState {
@@ -302,33 +308,70 @@ impl AckState {
                 .collect(),
             received: Mutex::new(BTreeSet::new()),
             ready,
+            frozen: AtomicBool::new(false),
         }
+    }
+
+    /// The ack lock, recovered from poisoning: a panicking callback leaves the
+    /// set intact and losing acks would silently cost the fast path.
+    ///
+    /// Holding this guard is what makes [`Self::record`] and [`Self::freeze`]
+    /// atomic against each other, so every method that touches `received` or
+    /// `frozen` goes through here.
+    fn received(&self) -> std::sync::MutexGuard<'_, BTreeSet<(String, String)>> {
+        self.received
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
     /// Records one ack. Identities outside the required set — a dynamic or
     /// debug consumer may ack too — are ignored; they must never count toward
-    /// completion. Flips `ready` once the required set is covered.
+    /// completion. Flips `ready` once the required set is covered, unless the
+    /// output was already frozen on the daemon path.
     fn record(&self, consumer_node: &str, input_id: &str) {
         let identity = (consumer_node.to_owned(), input_id.to_owned());
         if !self.required.contains(&identity) {
             return;
         }
-        let mut received = self
-            .received
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut received = self.received();
+        // Read under the same lock `freeze` takes, so the two can't interleave
+        // into a `ready` flip that outlives the freeze.
+        if self.frozen.load(Ordering::Relaxed) {
+            return;
+        }
         received.insert(identity);
         if received.len() == self.required.len() {
             self.ready.store(true, Ordering::Relaxed);
         }
     }
 
-    /// The required identities that have not acked (for the deadline warning).
+    /// Pins this output to the daemon path for the rest of the run: no later
+    /// ack may flip `ready`. Called once, at the grace boundary — see
+    /// [`wait_for_grace`].
+    ///
+    /// Returns whether the output was actually frozen — `false` means it had
+    /// already completed its handshake and keeps the direct-zenoh path. The
+    /// `received` lock makes that decision atomic against a concurrent
+    /// [`Self::record`]: either the ack completed the set before the freeze, or
+    /// it is ignored.
+    fn freeze(&self) -> bool {
+        let _guard = self.received();
+        if self.ready.load(Ordering::Relaxed) {
+            return false;
+        }
+        self.frozen.store(true, Ordering::Relaxed);
+        true
+    }
+
+    /// Whether this output was frozen on the daemon path (marker-thread view;
+    /// no lock needed, a stale `false` just costs one more marker).
+    fn is_frozen(&self) -> bool {
+        self.frozen.load(Ordering::Relaxed)
+    }
+
+    /// The required identities that have not acked (for the freeze warning).
     fn missing(&self) -> Vec<String> {
-        let received = self
-            .received
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let received = self.received();
         self.required
             .difference(&received)
             .map(|(node, input)| format!("{node}/{input}"))
@@ -406,7 +449,10 @@ fn declare_ack_subscribers(
 /// consumer's ack rides the output's `@ack` topic back — an arrived ack is
 /// evidence that the route pair carries data. Until then every send takes the
 /// daemon path, so nothing is ever lost; a route that never proves itself only
-/// costs the fast path, never correctness ([`ZENOH_STARTUP_ACK_TIMEOUT`]).
+/// costs the fast path, never correctness ([`ZENOH_STARTUP_GRACE`]).
+///
+/// The handshake is over by the time `init` returns: [`Self::settle`] either
+/// sees an output acked or freezes it on the daemon path.
 ///
 /// Runs on its own thread because the node blocks inside the daemon's "all
 /// nodes ready" barrier while markers must already be flowing: consumers ack
@@ -422,10 +468,6 @@ fn declare_ack_subscribers(
 /// (their ack publishers answer markers for the consumer's whole lifetime).
 struct StartupHandshake {
     stop: Arc<AtomicBool>,
-    /// Deadline for un-acked outputs; unset until armed post-barrier (see
-    /// [`Self::arm_deadline`]). Written exactly once, hence a lock-free
-    /// `OnceLock` rather than a mutex.
-    deadline: Arc<std::sync::OnceLock<Instant>>,
     /// The outputs whose handshake is (or was) in flight.
     ack_states: Vec<Arc<AckState>>,
     handle: Option<std::thread::JoinHandle<()>>,
@@ -446,7 +488,6 @@ impl StartupHandshake {
         use zenoh::Wait;
 
         let stop = Arc::new(AtomicBool::new(false));
-        let deadline = Arc::new(std::sync::OnceLock::new());
         let ack_subscribers =
             declare_ack_subscribers(session, dataflow_id, node_id, &mut ack_states);
         if ack_states.is_empty() {
@@ -454,7 +495,6 @@ impl StartupHandshake {
             // failed): no markers to publish, nothing to stop.
             return Self {
                 stop,
-                deadline,
                 ack_states,
                 handle: None,
                 ack_subscribers,
@@ -462,7 +502,6 @@ impl StartupHandshake {
         }
 
         let thread_stop = stop.clone();
-        let thread_deadline = deadline.clone();
         let thread_states = ack_states.clone();
         let thread_publishers = publishers.clone();
         let handle = std::thread::Builder::new()
@@ -472,27 +511,12 @@ impl StartupHandshake {
                     if thread_stop.load(Ordering::Relaxed) {
                         return;
                     }
-                    let deadline_passed = thread_deadline
-                        .get()
-                        .is_some_and(|deadline| Instant::now() >= *deadline);
                     let mut awaiting = false;
                     for state in &thread_states {
-                        if state.ready.load(Ordering::Relaxed) {
-                            continue;
-                        }
-                        if deadline_passed {
-                            // Freeze: no more markers and no late upgrade — a
-                            // route that produced no ack in 10s of 5ms markers
-                            // after every consumer subscribed is broken, and
-                            // upgrading minutes in would trade a working
-                            // (slower) path for a mid-run reorder.
-                            warn!(
-                                output = %state.output_id,
-                                missing = ?state.missing(),
-                                "startup handshake incomplete after {}s; \
-                                 output stays on the reliable daemon path",
-                                ZENOH_STARTUP_ACK_TIMEOUT.as_secs()
-                            );
+                        // A frozen output can never upgrade, so its markers can
+                        // only cost bandwidth; `wait_for_grace` already logged
+                        // why it stays on the daemon path.
+                        if state.ready.load(Ordering::Relaxed) || state.is_frozen() {
                             continue;
                         }
                         awaiting = true;
@@ -527,7 +551,6 @@ impl StartupHandshake {
         match handle {
             Ok(handle) => Self {
                 stop,
-                deadline,
                 ack_states,
                 handle: Some(handle),
                 ack_subscribers,
@@ -541,7 +564,6 @@ impl StartupHandshake {
                 );
                 Self {
                     stop,
-                    deadline,
                     ack_states,
                     handle: None,
                     ack_subscribers,
@@ -550,54 +572,15 @@ impl StartupHandshake {
         }
     }
 
-    /// Arm the handshake deadline.
+    /// Settle every output's transport: wait out `grace`, then freeze whatever
+    /// has not proven its routes. See [`wait_for_grace`].
     ///
-    /// Called once `EventStream::init` has returned, i.e. once the daemon's
-    /// "all nodes ready" barrier has released: from that point every static
-    /// consumer has declared its subscribers and ack publishers, so a bounded
-    /// wait is meaningful. (For a dynamic or restarted producer the barrier
-    /// releases immediately — its consumers have long been running.)
-    fn arm_deadline(&self) {
-        let _ = self
-            .deadline
-            .set(Instant::now() + ZENOH_STARTUP_ACK_TIMEOUT);
-    }
-
-    /// Post-barrier grace wait: give the handshake a moment to complete before
-    /// user code runs, so outputs switch to the direct zenoh path *before*
-    /// their first real send and no message straddles the daemon→zenoh switch.
-    /// Returns as soon as every awaited output is ready; bounded by
-    /// [`ZENOH_STARTUP_GRACE`].
-    fn wait_for_grace(&self) {
-        if self.ack_states.is_empty() {
-            return;
-        }
-        let grace_deadline = Instant::now() + ZENOH_STARTUP_GRACE;
-        loop {
-            if self
-                .ack_states
-                .iter()
-                .all(|state| state.ready.load(Ordering::Relaxed))
-            {
-                return;
-            }
-            if Instant::now() >= grace_deadline {
-                let pending: Vec<_> = self
-                    .ack_states
-                    .iter()
-                    .filter(|state| !state.ready.load(Ordering::Relaxed))
-                    .map(|state| state.output_id.to_string())
-                    .collect();
-                debug!(
-                    outputs = ?pending,
-                    "startup handshake still in flight after the {}ms grace; \
-                     these outputs start on the daemon path and upgrade when acked",
-                    ZENOH_STARTUP_GRACE.as_millis()
-                );
-                return;
-            }
-            std::thread::sleep(ZENOH_STARTUP_GRACE_POLL_INTERVAL);
-        }
+    /// `DoraNode::init` **must** call this before returning to user code —
+    /// that is what makes an output's path constant for the run
+    /// (dora-rs/dora#2891). It is a method (rather than only the free function
+    /// the tests drive) so the requirement is discoverable from the type.
+    fn settle(&self, grace: Duration) {
+        wait_for_grace(&self.ack_states, grace);
     }
 
     /// Signal the handshake thread to stop and wait for it to exit, so its
@@ -616,6 +599,57 @@ impl Drop for StartupHandshake {
         // a failed `EventStream::init`). Without this the handshake thread
         // would keep publishing and keep the publishers (and session) alive.
         self.shutdown();
+    }
+}
+
+/// Post-barrier grace wait: give the handshake `grace` to complete, then freeze
+/// whatever is left. This is the boundary that settles every output's transport
+/// before user code runs.
+///
+/// Returns as soon as every awaited output is ready. Anything still un-acked
+/// when `grace` expires is pinned to the daemon path for the rest of the run
+/// ([`AckState::freeze`]) rather than left to upgrade later. Upgrading later is
+/// the bug in dora-rs/dora#2891: user code sends from the moment this returns,
+/// so *any* subsequent upgrade is mid-stream, and the direct-zenoh path has
+/// fewer hops than the daemon-relay path — a message sent just after the switch
+/// can overtake an earlier one still in flight on the daemon path, which the
+/// consumer merges into a single arrival-ordered channel with no cross-path
+/// resequencing. Freezing keeps a topic's per-input FIFO order unconditional;
+/// the cost is the fast path for routes that fail to establish within `grace`.
+///
+/// A free function taking the states (rather than a `StartupHandshake` method)
+/// so tests can exercise the boundary without zenoh, with a `grace` shorter
+/// than [`ZENOH_STARTUP_GRACE`].
+fn wait_for_grace(ack_states: &[Arc<AckState>], grace: Duration) {
+    let grace_deadline = Instant::now() + grace;
+    loop {
+        // Vacuously true when nothing awaits acks (no consumers, or every ack
+        // subscriber failed to declare): there is nothing to wait for.
+        if ack_states
+            .iter()
+            .all(|state| state.ready.load(Ordering::Relaxed))
+        {
+            return;
+        }
+        if Instant::now() >= grace_deadline {
+            break;
+        }
+        std::thread::sleep(ZENOH_STARTUP_GRACE_POLL_INTERVAL);
+    }
+
+    for state in ack_states {
+        // `freeze` re-checks readiness under the ack lock, so an ack landing
+        // right now either completes the handshake or is ignored — never a
+        // half-applied upgrade.
+        if state.freeze() {
+            warn!(
+                output = %state.output_id,
+                missing = ?state.missing(),
+                "startup handshake incomplete after {}ms; output stays on the \
+                 reliable daemon path for the rest of the run",
+                grace.as_millis()
+            );
+        }
     }
 }
 
@@ -1291,12 +1325,11 @@ impl DoraNode {
         .wrap_err("failed to init event stream")?;
 
         // The barrier has released: every static consumer is subscribed and
-        // acking. Arm the bounded handshake deadline and give the handshake a
-        // moment to complete, so outputs switch to direct zenoh before the
-        // first real send.
+        // acking, so the handshake now gets its bounded window. This settles
+        // every output's transport — acked onto direct zenoh, or frozen on the
+        // daemon path — before user code sends its first message.
         if let Some(handshake) = &startup_handshake {
-            handshake.arm_deadline();
-            handshake.wait_for_grace();
+            handshake.settle(ZENOH_STARTUP_GRACE);
         }
         let control_channel =
             ControlChannel::init(dataflow_id, &node_id, &daemon_communication, clock.clone())
@@ -1659,8 +1692,9 @@ impl DoraNode {
         // `StartupHandshake`). Everything else takes the reliable daemon path:
         // no zenoh session (interactive/testing mode), an output the daemon
         // pinned there (a consumer on another daemon needs inter-daemon
-        // forwarding, which only daemon-path sends feed — #2738), or a
-        // handshake still in flight or frozen. An SHM-backed sample is moved
+        // forwarding, which only daemon-path sends feed — #2738), or an output
+        // whose handshake did not complete before `init` returned and is
+        // therefore frozen there for the run. An SHM-backed sample is moved
         // straight into zenoh's `put` (no extra copy); only the daemon path
         // copies it out into a `DataMessage::Vec`.
         let delivery = match finalized {
@@ -1779,7 +1813,9 @@ impl DoraNode {
 
     /// Whether `output_id` may take the direct zenoh path: its publisher exists
     /// (declared at init, not pinned to the daemon path) and the startup
-    /// handshake has proven its routes — see [`StartupHandshake`].
+    /// handshake proved its routes — see [`StartupHandshake`].
+    ///
+    /// Constant for the node's lifetime — see [`wait_for_grace`].
     fn output_direct_ready(&self, output_id: &DataId) -> bool {
         self.zenoh_publishers
             .get(output_id)
@@ -3026,6 +3062,15 @@ mod tests {
         }
     }
 
+    /// A not-yet-ready `AckState` for `output` awaiting a single `acker`.
+    fn test_ack_state(output: &str, acker: (&str, &str)) -> Arc<AckState> {
+        Arc::new(AckState::new(
+            DataId::from(output.to_string()),
+            &BTreeSet::from([required_acker(acker.0, acker.1)]),
+            Arc::new(AtomicBool::new(false)),
+        ))
+    }
+
     #[test]
     fn ack_state_completes_only_when_required_set_is_covered() {
         let ready = Arc::new(AtomicBool::new(false));
@@ -3066,6 +3111,82 @@ mod tests {
 
         state.record("sink", "camera");
         assert!(ready.load(Ordering::Relaxed));
+    }
+
+    // Regression guard for dora-rs/dora#2891: a frozen output must never
+    // upgrade. Before the fix an ack arriving after the grace (but before the
+    // old 10s deadline) flipped `ready` while user code was already sending,
+    // so a message on the shorter direct-zenoh path could overtake an earlier
+    // one still relaying through the daemon.
+    #[test]
+    fn ack_state_freeze_blocks_a_late_upgrade() {
+        let state = test_ack_state("image", ("sink", "camera"));
+
+        assert!(state.freeze(), "an un-acked output is frozen");
+        assert!(state.is_frozen());
+
+        // The consumer's ack arrives late — it must not move the output onto
+        // the direct path mid-stream.
+        state.record("sink", "camera");
+        assert!(
+            !state.ready.load(Ordering::Relaxed),
+            "a frozen output must stay on the daemon path for the rest of the run"
+        );
+        assert_eq!(state.missing(), vec!["sink/camera".to_string()]);
+    }
+
+    #[test]
+    fn ack_state_freeze_spares_an_output_that_acked_in_time() {
+        let state = test_ack_state("image", ("sink", "camera"));
+
+        state.record("sink", "camera");
+        assert!(!state.freeze(), "a ready output is not frozen");
+        assert!(!state.is_frozen());
+        assert!(
+            state.ready.load(Ordering::Relaxed),
+            "an output that proved its routes keeps the direct zenoh path"
+        );
+    }
+
+    // dora-rs/dora#2891: whatever has not proven its routes when the grace
+    // expires is pinned to the daemon path, so every output's transport is
+    // decided before user code sends its first message.
+    #[test]
+    fn grace_boundary_freezes_unacked_outputs_only() {
+        let acked = test_ack_state("image", ("sink", "camera"));
+        let unacked = test_ack_state("status", ("sink", "state"));
+        acked.record("sink", "camera");
+
+        wait_for_grace(&[acked.clone(), unacked.clone()], Duration::from_millis(20));
+
+        assert!(acked.ready.load(Ordering::Relaxed));
+        assert!(!acked.is_frozen());
+        assert!(unacked.is_frozen());
+
+        // The straggler's ack lands after the boundary and is ignored.
+        unacked.record("sink", "state");
+        assert!(!unacked.ready.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn grace_returns_early_once_every_output_is_acked() {
+        // Also covers the no-awaited-outputs case (no consumers, or every ack
+        // subscriber failed to declare): `all` is vacuously true on an empty
+        // slice, so there is nothing to wait for and nothing to freeze.
+        let state = test_ack_state("image", ("sink", "camera"));
+        state.record("sink", "camera");
+
+        let start = Instant::now();
+        wait_for_grace(&[state.clone()], Duration::from_secs(30));
+        wait_for_grace(&[], Duration::from_secs(30));
+
+        assert!(!state.is_frozen());
+        assert!(state.ready.load(Ordering::Relaxed));
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "a completed handshake must not wait out the grace, took {:?}",
+            start.elapsed()
+        );
     }
 
     #[test]

--- a/binaries/daemon/src/output_routing.rs
+++ b/binaries/daemon/src/output_routing.rs
@@ -16,7 +16,11 @@
 //!   reached through forwarding.
 //! - a **local static** consumer becomes a required acker: the producer keeps
 //!   the output on the lossless daemon path until this consumer's startup ack
-//!   proves the direct zenoh route end-to-end.
+//!   proves the direct zenoh route end-to-end. The producer gives that proof a
+//!   bounded startup window and pins the output to the daemon path for the run
+//!   if it does not arrive in time, so adding a required acker that is slow to
+//!   answer costs the fast path rather than reordering a live topic
+//!   (dora-rs/dora#2891).
 //! - **local dynamic** consumers are neither: they join at arbitrary times (or
 //!   never), so nothing may wait on them, and their pre-join messages are
 //!   inherently out of scope.

--- a/libraries/message/src/daemon_to_node.rs
+++ b/libraries/message/src/daemon_to_node.rs
@@ -62,6 +62,10 @@ pub struct OutputRouting {
     /// the direct node-to-node zenoh path. Dynamic consumers are never
     /// required: they join at arbitrary times (or never), and nothing may wait
     /// on them.
+    ///
+    /// The producer only collects these during a bounded startup window; an
+    /// acker that is slow to answer costs this output the fast path for the
+    /// whole run rather than upgrading it mid-stream (dora-rs/dora#2891).
     #[serde(default)]
     pub required_ackers: BTreeSet<RequiredAcker>,
 }

--- a/libraries/message/src/metadata.rs
+++ b/libraries/message/src/metadata.rs
@@ -116,8 +116,11 @@ impl Metadata {
 /// marker with an ack (see [`STARTUP_ACK_PARAM`]): an ack arriving back at the
 /// producer is end-to-end proof that the route pair carries data. The producer
 /// stops marking an output — and switches it to the direct zenoh path — once
-/// all its required consumers have acked; a route that never proves itself
-/// just keeps the output on the daemon path.
+/// all its required consumers have acked, but only within a bounded startup
+/// window: an output still un-acked when the window closes is pinned to the
+/// daemon path for the rest of the run, so a topic's messages never straddle a
+/// path switch (dora-rs/dora#2891). A route that never proves itself just keeps
+/// the output on the daemon path.
 ///
 /// The `__dora_` prefix is reserved; user parameters must not use it. Receivers
 /// filter markers before decoding the payload, so they never reach user code.
@@ -131,9 +134,11 @@ pub const STARTUP_MARKER_PARAM: &str = "__dora_startup_marker";
 /// output's dedicated `@ack` topic. An ack arriving back at the producer is
 /// end-to-end proof that the route works in *both* directions; once every
 /// required consumer of an output has acked, the producer switches that output
-/// from the reliable daemon path to the direct node-to-node zenoh path. A
-/// missing ack never fails anything — the output simply stays on the daemon
-/// path.
+/// from the reliable daemon path to the direct node-to-node zenoh path. Ack
+/// timing is load-bearing: the switch can only happen inside the producer's
+/// bounded startup window (see [`STARTUP_MARKER_PARAM`]), so a consumer that
+/// acks late costs that output the fast path for the whole run. A missing or
+/// late ack never fails anything — the output simply stays on the daemon path.
 ///
 /// Acks travel as an empty-payload message whose attachment carries this flag
 /// plus the acking consumer's identity under [`STARTUP_ACK_CONSUMER_PARAM`] and


### PR DESCRIPTION
Implements **option 1** of #2891.

## The bug

The startup route handshake (#2806) picks an output's transport *per message*, gated only on its `ready` flag, and `ready` could flip at any point up to the 10 s `ZENOH_STARTUP_ACK_TIMEOUT`. But `init()` returns to user code after only the 500 ms grace, so an output that acked late upgraded from the daemon path to direct zenoh **mid-stream**.

The direct-zenoh path has fewer hops than the daemon relay, and the consumer merges both into one arrival-ordered channel with no cross-path resequencing — so a message sent just after the switch can overtake an earlier one still in flight, silently breaking the per-input FIFO ordering that topic consumers rely on.

The code already recognised this hazard at the 10 s deadline:

> `// Freeze: … upgrading minutes in would trade a working (slower) path for a mid-run reorder.`

…yet the identical hazard was open across the whole 0.5 s → 10 s window, because user code has been sending since the grace expired.

## The fix

Move the freeze to the **grace boundary**: whatever has not proven its routes when `wait_for_grace` returns is pinned to the daemon path for the rest of the run. Each output's transport is then settled *before* user code sends its first message and never changes, so no message can straddle a path switch and FIFO order holds unconditionally.

- `AckState` gains a `frozen` flag. `record` reads it under the same `received` lock that `freeze` takes, so an ack landing exactly at the boundary either completes the handshake or is ignored — never a half-applied upgrade.
- The marker thread skips frozen outputs, so on a broken route it retires ~9.5 s earlier instead of publishing 5 ms markers until the deadline.
- `ZENOH_STARTUP_ACK_TIMEOUT` (and `arm_deadline`) are removed — the grace now *is* the whole handshake window, and `ZENOH_STARTUP_GRACE` is the single knob for the trade-off.
- `wait_for_grace` is a free function over the ack states, so the boundary is testable without a zenoh session.

**The cost, stated plainly:** a route that fails to establish within 500 ms now loses the direct-zenoh fast path for the whole run, where it previously had until 10 s to upgrade. That is the deliberate trade in option 1 — correctness of ordering over the fast path for slow-to-establish routes. Dynamic/restarted producers are most exposed (their barrier releases immediately, so the window starts a few ms after the zenoh session opens); this is now called out on the constant, and raising `ZENOH_STARTUP_GRACE` is the intended remedy if it shows up as a regression.

## Docs corrected

The protocol docs described the upgrade as unconditional on ack arrival, with no mention of a window — now false. Updated `STARTUP_MARKER_PARAM`, `STARTUP_ACK_PARAM`, `OutputRouting::required_ackers`, the daemon's routing policy, and the consumer-side acker (which claimed ack-route races "self-heal" because markers keep coming — they no longer do past the grace). This subsumes option 3 of the issue.

## Tests

New unit tests in `apis/rust/node/src/node/mod.rs`:

- `ack_state_freeze_blocks_a_late_upgrade` — the direct #2891 regression guard: a frozen output ignores a late ack and `ready` stays `false`.
- `ack_state_freeze_spares_an_output_that_acked_in_time` — an output that completed its handshake keeps direct zenoh.
- `grace_boundary_freezes_unacked_outputs_only` — end-to-end over the boundary: the acked output is untouched, the un-acked one is frozen, and its straggler ack is ignored.
- `grace_returns_early_once_every_output_is_acked` — a completed handshake does not wait out the grace (also covers the empty-states case).

## Validation

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --all …` (CI-equivalent, `-D warnings`) | pass |
| `cargo test -p dora-node-api -p dora-message` | pass (158 + 140 + 5 + 1) |
| `cargo test -p dora-daemon` | pass (133) |
| `cargo check --examples` | pass |

Two notes on validation, so the gaps are explicit:

- `dora-node-api --test zenoh_schema_cache` fails in my sandbox (`Address family not supported by protocol` binding `tcp/[::]:0` — no IPv6). Verified it fails identically on the unmodified baseline commit, so it is environmental and unrelated to this change.
- The full `cargo test --all` did not complete: the workspace build exceeded this environment's disk allowance. The affected crates were tested individually instead; CI should be treated as the authority for the rest.

## Follow-up considered but not taken

Option 2 of the issue (latch the transport per output at its *first send*, rather than globally at the grace boundary) is strictly less restrictive — it would keep the fast path for outputs first published long after startup, e.g. a `metrics` output first sent 30 s in, whose route needed 600 ms. It gives the same unconditional FIFO guarantee. The issue named option 1 as the most defensible and that is what this PR implements; option 2 is a reasonable follow-up if the lost fast path proves to matter.

Closes #2891

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbpiNTgsFoQmL6BWeeN8f7

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbpiNTgsFoQmL6BWeeN8f7)_