### PR TITLE
fix(coordinator): make multi-daemon stop best-effort instead of aborting on first failure

### DIFF
--- a/binaries/coordinator/src/handlers.rs
+++ b/binaries/coordinator/src/handlers.rs
@@ -275,7 +275,7 @@ pub(crate) async fn stop_dataflow<'a>(
         }
     }
 
-    if let Some((_, first)) = errors.first() {
+    if !errors.is_empty() {
         let daemon_list = errors
             .iter()
             .map(|(id, err)| format!("{id}: {err:#}"))
@@ -285,8 +285,7 @@ pub(crate) async fn stop_dataflow<'a>(
             "failed to stop dataflow `{dataflow_uuid}` on {} of {} daemon(s): {daemon_list}",
             errors.len(),
             dataflow.daemons.len(),
-        )
-        .wrap_err(format!("first failure: {first:#}")));
+        ));
     }
 
     tracing::info!("successfully send stop dataflow `{dataflow_uuid}` to all daemons");

--- a/binaries/coordinator/src/handlers.rs
+++ b/binaries/coordinator/src/handlers.rs
@@ -243,23 +243,50 @@ pub(crate) async fn stop_dataflow<'a>(
         timestamp,
     })?;
 
+    // Best-effort: attempt the stop on every daemon even if some fail, so one
+    // unreachable/erroring daemon does not orphan the nodes running on the
+    // remaining healthy daemons. Errors are aggregated and reported after all
+    // daemons have been attempted (mirrors `run::rollback_spawned_daemons`).
+    let mut errors: Vec<(DaemonId, eyre::Report)> = Vec::new();
     for daemon_id in &dataflow.daemons {
-        let daemon_connection = daemon_connections
-            .get_mut(daemon_id)
-            .wrap_err("no daemon connection")?;
+        let result: eyre::Result<()> = async {
+            let daemon_connection = daemon_connections
+                .get_mut(daemon_id)
+                .wrap_err("no daemon connection")?;
 
-        let reply_raw = daemon_connection
-            .send_and_receive(&message)
-            .await
-            .wrap_err("failed to send/receive stop message")?;
-        match serde_json::from_slice(&reply_raw)
-            .wrap_err("failed to deserialize stop reply from daemon")?
-        {
-            DaemonCoordinatorReply::StopResult(result) => result
-                .map_err(|e| eyre!(e))
-                .wrap_err("failed to stop dataflow")?,
-            other => bail!("unexpected reply after sending stop: {other:?}"),
+            let reply_raw = daemon_connection
+                .send_and_receive(&message)
+                .await
+                .wrap_err("failed to send/receive stop message")?;
+            match serde_json::from_slice(&reply_raw)
+                .wrap_err("failed to deserialize stop reply from daemon")?
+            {
+                DaemonCoordinatorReply::StopResult(result) => result
+                    .map_err(|e| eyre!(e))
+                    .wrap_err("failed to stop dataflow")?,
+                other => bail!("unexpected reply after sending stop: {other:?}"),
+            }
+            Ok(())
         }
+        .await;
+
+        if let Err(err) = result {
+            errors.push((daemon_id.clone(), err));
+        }
+    }
+
+    if let Some((_, first)) = errors.first() {
+        let daemon_list = errors
+            .iter()
+            .map(|(id, err)| format!("{id}: {err:#}"))
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Err(eyre!(
+            "failed to stop dataflow `{dataflow_uuid}` on {} of {} daemon(s): {daemon_list}",
+            errors.len(),
+            dataflow.daemons.len(),
+        )
+        .wrap_err(format!("first failure: {first:#}")));
     }
 
     tracing::info!("successfully send stop dataflow `{dataflow_uuid}` to all daemons");

--- a/binaries/coordinator/src/handlers.rs
+++ b/binaries/coordinator/src/handlers.rs
@@ -234,23 +234,50 @@ pub(crate) async fn stop_dataflow<'a>(
         timestamp,
     })?;
 
+    // Best-effort: attempt the stop on every daemon even if some fail, so one
+    // unreachable/erroring daemon does not orphan the nodes running on the
+    // remaining healthy daemons. Errors are aggregated and reported after all
+    // daemons have been attempted (mirrors `run::rollback_spawned_daemons`).
+    let mut errors: Vec<(DaemonId, eyre::Report)> = Vec::new();
     for daemon_id in &dataflow.daemons {
-        let daemon_connection = daemon_connections
-            .get_mut(daemon_id)
-            .wrap_err("no daemon connection")?;
+        let result: eyre::Result<()> = async {
+            let daemon_connection = daemon_connections
+                .get_mut(daemon_id)
+                .wrap_err("no daemon connection")?;
 
-        let reply_raw = daemon_connection
-            .send_and_receive(&message)
-            .await
-            .wrap_err("failed to send/receive stop message")?;
-        match serde_json::from_slice(&reply_raw)
-            .wrap_err("failed to deserialize stop reply from daemon")?
-        {
-            DaemonCoordinatorReply::StopResult(result) => result
-                .map_err(|e| eyre!(e))
-                .wrap_err("failed to stop dataflow")?,
-            other => bail!("unexpected reply after sending stop: {other:?}"),
+            let reply_raw = daemon_connection
+                .send_and_receive(&message)
+                .await
+                .wrap_err("failed to send/receive stop message")?;
+            match serde_json::from_slice(&reply_raw)
+                .wrap_err("failed to deserialize stop reply from daemon")?
+            {
+                DaemonCoordinatorReply::StopResult(result) => result
+                    .map_err(|e| eyre!(e))
+                    .wrap_err("failed to stop dataflow")?,
+                other => bail!("unexpected reply after sending stop: {other:?}"),
+            }
+            Ok(())
         }
+        .await;
+
+        if let Err(err) = result {
+            errors.push((daemon_id.clone(), err));
+        }
+    }
+
+    if let Some((_, first)) = errors.first() {
+        let daemon_list = errors
+            .iter()
+            .map(|(id, err)| format!("{id}: {err:#}"))
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Err(eyre!(
+            "failed to stop dataflow `{dataflow_uuid}` on {} of {} daemon(s): {daemon_list}",
+            errors.len(),
+            dataflow.daemons.len(),
+        )
+        .wrap_err(format!("first failure: {first:#}")));
     }
 
     tracing::info!("successfully send stop dataflow `{dataflow_uuid}` to all daemons");

--- a/binaries/coordinator/src/handlers.rs
+++ b/binaries/coordinator/src/handlers.rs
@@ -266,7 +266,7 @@ pub(crate) async fn stop_dataflow<'a>(
         }
     }
 
-    if let Some((_, first)) = errors.first() {
+    if !errors.is_empty() {
         let daemon_list = errors
             .iter()
             .map(|(id, err)| format!("{id}: {err:#}"))
@@ -276,8 +276,7 @@ pub(crate) async fn stop_dataflow<'a>(
             "failed to stop dataflow `{dataflow_uuid}` on {} of {} daemon(s): {daemon_list}",
             errors.len(),
             dataflow.daemons.len(),
-        )
-        .wrap_err(format!("first failure: {first:#}")));
+        ));
     }
 
     tracing::info!("successfully send stop dataflow `{dataflow_uuid}` to all daemons");

--- a/binaries/coordinator/src/handlers.rs
+++ b/binaries/coordinator/src/handlers.rs
@@ -900,4 +900,160 @@ mod tests {
             "subscriber should be evicted after 100 consecutive timeouts"
         );
     }
+
+    /// Build a minimal `RunningDataflow` running on exactly `daemons`.
+    fn dataflow_on(uuid: Uuid, daemons: impl IntoIterator<Item = DaemonId>) -> RunningDataflow {
+        let descriptor: Descriptor = serde_json::from_value(serde_json::json!({
+            "nodes": [{ "id": "sender", "outputs": ["message"] }]
+        }))
+        .expect("valid test descriptor");
+
+        RunningDataflow {
+            name: None,
+            uuid,
+            descriptor,
+            daemons: daemons.into_iter().collect(),
+            pending_daemons: BTreeSet::new(),
+            exited_before_subscribe: vec![],
+            nodes: BTreeMap::new(),
+            node_to_daemon: BTreeMap::new(),
+            node_metrics: BTreeMap::new(),
+            node_finalized: BTreeSet::new(),
+            node_stopped_at: BTreeMap::new(),
+            network_metrics: None,
+            ready_barrier_released: false,
+            spawn_result: CachedResult::default(),
+            stop_reply_senders: vec![],
+            buffered_log_messages: vec![],
+            log_subscribers: vec![],
+            topic_subscribers: BTreeMap::new(),
+            pending_spawn_results: BTreeSet::new(),
+            spawn_started_at: std::time::Instant::now(),
+            created_at: 0,
+            store_generation: 0,
+            last_recovery_attempt: BTreeMap::new(),
+            last_replay_attempt: BTreeMap::new(),
+            uv: false,
+            state_log_sequence: 0,
+            state_log: Vec::new(),
+            daemon_ack_sequence: BTreeMap::new(),
+        }
+    }
+
+    /// A connection emulating the ws_daemon handler task for a *healthy* daemon:
+    /// it records each request it receives and completes the matching
+    /// `pending_replies` oneshot with a successful `StopResult`. Returns the
+    /// connection plus the shared log of requests the daemon actually received.
+    fn healthy_daemon() -> (
+        DaemonConnection,
+        std::sync::Arc<tokio::sync::Mutex<Vec<String>>>,
+    ) {
+        let received = std::sync::Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let pending: std::sync::Arc<
+            tokio::sync::Mutex<HashMap<Uuid, tokio::sync::oneshot::Sender<String>>>,
+        > = std::sync::Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<String>(8);
+        let conn = DaemonConnection::new(tx, pending.clone(), BTreeMap::new());
+
+        let received_task = received.clone();
+        tokio::spawn(async move {
+            while let Some(msg) = rx.recv().await {
+                let value: serde_json::Value =
+                    serde_json::from_str(&msg).expect("outgoing request is JSON");
+                let id: Uuid = value["id"]
+                    .as_str()
+                    .expect("request carries an id")
+                    .parse()
+                    .expect("id is a uuid");
+                // Record receipt *before* replying, so a returned `Ok` from
+                // `send_and_receive` guarantees the request is already logged.
+                received_task.lock().await.push(msg.clone());
+                let reply = serde_json::to_string(&DaemonCoordinatorReply::StopResult(Ok(())))
+                    .expect("serialize reply");
+                if let Some(sender) = pending.lock().await.remove(&id) {
+                    let _ = sender.send(reply);
+                }
+            }
+        });
+
+        (conn, received)
+    }
+
+    /// A connection whose receiver is dropped, so the very first `send` fails —
+    /// modelling an unreachable/disconnected daemon.
+    fn broken_daemon() -> DaemonConnection {
+        let (tx, rx) = tokio::sync::mpsc::channel::<String>(1);
+        drop(rx);
+        DaemonConnection::new(
+            tx,
+            std::sync::Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            BTreeMap::new(),
+        )
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stop_dataflow_is_best_effort_when_a_daemon_fails() {
+        // A dataflow on two daemons where the one iterated *first* is
+        // unreachable. `DaemonId` orders by machine id, so `broken` (b) sorts
+        // before `healthy` (h) in `dataflow.daemons` (a `BTreeSet`): under the
+        // old first-failure `?` code the healthy daemon would never be reached
+        // and its nodes would be orphaned. Best-effort must still stop it.
+        let dataflow_uuid = Uuid::new_v4();
+        let broken = DaemonId::new(Some("broken".to_string()));
+        let healthy = DaemonId::new(Some("healthy".to_string()));
+
+        let mut daemon_connections = DaemonConnections::default();
+        daemon_connections.add(broken.clone(), broken_daemon());
+        let (healthy_conn, healthy_received) = healthy_daemon();
+        daemon_connections.add(healthy.clone(), healthy_conn);
+
+        let mut running_dataflows = HashMap::new();
+        running_dataflows.insert(
+            dataflow_uuid,
+            dataflow_on(dataflow_uuid, [broken.clone(), healthy.clone()]),
+        );
+
+        let timestamp = HLC::default().new_timestamp();
+        // `stop_dataflow`'s `Ok` is `&mut RunningDataflow` (not `Debug`), so
+        // destructure by hand rather than via `expect_err`.
+        let err = match stop_dataflow(
+            &mut running_dataflows,
+            dataflow_uuid,
+            &mut daemon_connections,
+            timestamp,
+            None,
+            false,
+        )
+        .await
+        {
+            Ok(_) => panic!("a failing daemon must surface an aggregated error"),
+            Err(err) => err,
+        };
+
+        // The core property: the healthy daemon was still told to stop even
+        // though the daemon iterated before it failed.
+        let received = healthy_received.lock().await;
+        assert_eq!(
+            received.len(),
+            1,
+            "healthy daemon must receive exactly one stop request"
+        );
+        assert!(
+            received[0].contains("StopDataflow"),
+            "healthy daemon must receive a StopDataflow, got: {}",
+            received[0]
+        );
+
+        // The error is aggregated: it reports one of two daemons failed and
+        // names the failing one (so the CLI still learns what broke).
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("1 of 2 daemon(s)"),
+            "error must aggregate the per-daemon outcome: {msg}"
+        );
+        assert!(
+            msg.contains("broken"),
+            "error must name the failed daemon: {msg}"
+        );
+    }
 }


### PR DESCRIPTION
> 🤖 **Machine-generated PR.** Opened by Claude (Anthropic) during an automated code-review pass of the repository. Please review carefully before merging.

## Issue

`stop_dataflow` (`binaries/coordinator/src/handlers.rs`) iterates over `dataflow.daemons` and uses `?` on each step — the connection lookup, `send_and_receive`, and the reply match. The first daemon that errors returns `Err` from the whole function; the CLI `Stop` / `StopByName` handlers just forward that error and do nothing else. **Daemons later in iteration never receive `StopDataflow`.**

### Failure scenario

A 3-daemon dataflow on daemons `A < B < C` (`dataflow.daemons` is a sorted `BTreeSet`). Daemon `B` disconnects. User runs `dora stop`:

1. `A` gets `StopDataflow` and stops its nodes.
2. At `B`, `daemon_connections.get_mut(B)` returns `None` → `bail!` → function returns early.
3. Healthy daemon `C` **never gets the stop** — its nodes keep running as orphans, consuming resources, until `C` independently disconnects.

The CLI only sees the error about `B`.

## Fix

Make the loop best-effort: attempt the stop on **every** daemon, collect per-daemon failures, and return an aggregated error only after all daemons have been attempted. This mirrors the established pattern already used by `run::rollback_spawned_daemons`, whose comment explicitly states "one daemon's failure must not abort rollback for the remaining daemons."

The success path is unchanged (all daemons succeed → same `Ok`); only the failure path changes from short-circuit to best-effort with an aggregated error listing each failing daemon.

## Known limitation — restart widens the blast radius (follow-up)

Best-effort stop interacts with the restart path (`initiate_restart`, `binaries/coordinator/src/lib.rs`). Step 2 of a restart stops the old dataflow and, on `Err` from `stop_dataflow`, replies with the error and returns **without** registering a `PendingRestart`. With best-effort stop, a `dora restart` across daemons `A, B, C` where `B` is unreachable now actively stops `A` and `C` and then abandons the restart — leaving the dataflow half-dead, where the old first-failure abort touched fewer daemons before giving up. Same failure class, wider reach.

This is a pre-existing restart-under-partial-failure semantics question (should a partial stop still proceed to a `PendingRestart`, or roll forward?), not something this PR should decide unilaterally — flagging it here for a maintainer call / follow-up rather than changing restart behavior in a stop-teardown fix. Thanks to @phil-opp for catching this.

## Validation

- **New regression test** `stop_dataflow_is_best_effort_when_a_daemon_fails` (`handlers.rs`): two daemons where the one iterated first is unreachable; asserts the healthy daemon still receives a `StopDataflow` and that the error aggregates the per-daemon outcome. RED under the old `?` code (the healthy daemon is never reached).
- `cargo test -p dora-coordinator` — all pass (incl. the new test).
- `cargo clippy -p dora-coordinator --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.