### PR TITLE
fix(node): guard JSON-to-Arrow decoders against a zero-column record batch

### DIFF
--- a/apis/rust/node/src/daemon_connection/json_to_arrow.rs
+++ b/apis/rust/node/src/daemon_connection/json_to_arrow.rs
@@ -31,6 +31,9 @@ fn read_from_json_with_schema(
         .context("no record batch in JSON")?
         .context("failed to read record batch")?;
 
+    if batch.num_columns() == 0 {
+        eyre::bail!("JSON record batch has no columns");
+    }
     Ok(batch.column(0).to_data())
 }
 
@@ -60,5 +63,24 @@ pub fn read_json_value_as_arrow(
         .flush()
         .context("failed to read record batch")?
         .context("no record batch in JSON")?;
+    if batch.num_columns() == 0 {
+        eyre::bail!("JSON record batch has no columns");
+    }
     Ok(batch.column(0).to_data())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_schema::Schema;
+
+    #[test]
+    fn empty_field_schema_errors_instead_of_panicking() {
+        // A caller-supplied schema with no fields yields a zero-column record
+        // batch; `column(0)` would otherwise index out of bounds and panic.
+        let schema = Arc::new(Schema::empty());
+        let values = [serde_json::json!({})];
+        let result = read_json_value_as_arrow(&values, schema);
+        assert!(result.is_err());
+    }
 }

--- a/apis/rust/node/src/daemon_connection/json_to_arrow.rs
+++ b/apis/rust/node/src/daemon_connection/json_to_arrow.rs
@@ -36,6 +36,9 @@ fn read_from_json_with_schema(
         .context("no record batch in JSON")?
         .context("failed to read record batch")?;
 
+    if batch.num_columns() == 0 {
+        eyre::bail!("JSON record batch has no columns");
+    }
     Ok(batch.column(0).to_data())
 }
 
@@ -67,6 +70,9 @@ pub fn read_json_value_as_arrow(
         .flush()
         .context("failed to read record batch")?
         .context("no record batch in JSON")?;
+    if batch.num_columns() == 0 {
+        eyre::bail!("JSON record batch has no columns");
+    }
     Ok(batch.column(0).to_data())
 }
 
@@ -74,6 +80,7 @@ pub fn read_json_value_as_arrow(
 mod tests {
     use super::*;
     use arrow::array::{StringArray, make_array};
+    use arrow_schema::Schema;
 
     fn as_single_string(data: ArrayData) -> String {
         let array = make_array(data);
@@ -83,6 +90,16 @@ mod tests {
             .expect("expected a string array");
         assert_eq!(strings.len(), 1);
         strings.value(0).to_owned()
+    }
+
+    #[test]
+    fn empty_field_schema_errors_instead_of_panicking() {
+        // A caller-supplied schema with no fields yields a zero-column record
+        // batch; `column(0)` would otherwise index out of bounds and panic.
+        let schema = Arc::new(Schema::empty());
+        let values = [serde_json::json!({})];
+        let result = read_json_value_as_arrow(&values, schema);
+        assert!(result.is_err());
     }
 
     #[test]


### PR DESCRIPTION
> 🤖 **Machine-generated PR.** Opened by Claude (Anthropic) during an automated code-review pass of the repository. Please review carefully before merging.

## Issue

In `apis/rust/node/src/daemon_connection/json_to_arrow.rs`, both `read_from_json_with_schema` and `read_json_value_as_arrow` end with `batch.column(0).to_data()` with no column-count check.

`read_json_value_as_arrow` takes a **caller-supplied** `Arc<Schema>` (used e.g. from `node_integration_testing.rs`). An empty-field schema produces a record batch with 0 columns, and `batch.column(0)` then indexes out of bounds → **panic**.

The sibling IPC decoders in this crate (`decode_arrow_ipc`, `ipc_encode::decode_one_batch`) already guard the column count before indexing; these two JSON paths did not.

## Fix

Add a `num_columns() == 0` check before `column(0)` in both functions, returning a descriptive error instead of panicking — consistent with the IPC decoders:

```rust
if batch.num_columns() == 0 {
    eyre::bail!("JSON record batch has no columns");
}
Ok(batch.column(0).to_data())
```

A regression test constructs an empty-field schema and asserts the function returns `Err` rather than panicking.

## Validation

- `cargo test -p dora-node-api --lib json_to_arrow` — new test passes
- `cargo clippy -p dora-node-api -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

Severity is low (the reachable path is cold — interactive/test schema input), but it removes a real panic and aligns the JSON decoders with the crate's existing IPC guards.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CCyEn8YqaYQYwh3RLjEZ7B)_