### PR TITLE
docs(coordinator-store): add a compile-checked doctest for validate_param_limits

### DIFF
--- a/libraries/coordinator-store/src/lib.rs
+++ b/libraries/coordinator-store/src/lib.rs
@@ -18,6 +18,23 @@ pub const MAX_PARAM_VALUE_BYTES: usize = 65_536;
 /// internal composite-key separator (see `redb_store::KEY_SEPARATOR`); without
 /// this check `put_node_param` with a `\0`-containing key would succeed on the
 /// in-memory backend but fail on redb.
+///
+/// # Examples
+///
+/// ```
+/// use dora_coordinator_store::{validate_param_limits, MAX_PARAM_KEY_BYTES};
+///
+/// // Ordinary keys and values are accepted.
+/// assert!(validate_param_limits("robot_pose", b"{...}").is_ok());
+///
+/// // A key exactly at the limit is fine; one byte over is rejected.
+/// assert!(validate_param_limits(&"k".repeat(MAX_PARAM_KEY_BYTES), b"v").is_ok());
+/// assert!(validate_param_limits(&"k".repeat(MAX_PARAM_KEY_BYTES + 1), b"v").is_err());
+///
+/// // A null byte in the key is rejected so every backend behaves identically
+/// // (redb uses `\0` as a composite-key separator).
+/// assert!(validate_param_limits("a\0b", b"v").is_err());
+/// ```
 pub fn validate_param_limits(key: &str, value: &[u8]) -> Result<()> {
     if key.len() > MAX_PARAM_KEY_BYTES {
         eyre::bail!("param key too long (max {MAX_PARAM_KEY_BYTES} bytes)");


### PR DESCRIPTION
> 🤖 **Machine-generated PR.** Opened by Claude (Anthropic) during an automated code-review pass of the repository. Please review carefully before merging.

## Issue

`validate_param_limits` (`libraries/coordinator-store/src/lib.rs`) is the single source of truth both store backends (in-memory + redb) rely on for param key/value size limits and the subtle null-byte rejection rule (redb uses `\0` as an internal composite-key separator). It had only prose docs; its accept/reject contract was pinned only by `#[cfg(test)]` backend tests, not a compile-checked example on the exported function itself.

## Fix

Add a runnable `# Examples` doctest covering the function's contract:

- an ordinary key/value is accepted;
- a key exactly at `MAX_PARAM_KEY_BYTES` is accepted, one byte over is rejected;
- a key containing a null byte is rejected.

Pure documentation addition — no code behavior changes.

## Validation

- `cargo test -p dora-coordinator-store --doc` — the new doctest passes.
- `cargo fmt --all -- --check` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CCyEn8YqaYQYwh3RLjEZ7B)_