### PR TITLE
fix(node): use wrapping_add for all inline seqlock generation increments

### DIFF
--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -1429,7 +1429,7 @@ impl Node {
         unsafe {
             let gen_ptr = shmem_ptr.add(96) as *mut u64;
             let old_gen = std::ptr::read_volatile(gen_ptr);
-            std::ptr::write_volatile(gen_ptr, old_gen + 1);
+            std::ptr::write_volatile(gen_ptr, old_gen.wrapping_add(1));
             std::sync::atomic::fence(std::sync::atomic::Ordering::Release);
         }
 
@@ -1508,7 +1508,7 @@ impl Node {
         unsafe {
             let gen_ptr = shmem_ptr.add(96) as *mut u64;
             let old_gen = std::ptr::read_volatile(gen_ptr);
-            std::ptr::write_volatile(gen_ptr, old_gen + 1);
+            std::ptr::write_volatile(gen_ptr, old_gen.wrapping_add(1));
             std::sync::atomic::fence(std::sync::atomic::Ordering::Release);
         }
 
@@ -1799,7 +1799,7 @@ impl Node {
                             // Seqlock: end write (infallible CPU copy, always advances)
                             unsafe {
                                 let old_gen = std::ptr::read_volatile(gen_ptr);
-                                std::ptr::write_volatile(gen_ptr, old_gen + 1);
+                                std::ptr::write_volatile(gen_ptr, old_gen.wrapping_add(1));
                                 std::sync::atomic::fence(std::sync::atomic::Ordering::Release);
                             }
                         }
@@ -1944,7 +1944,7 @@ impl Node {
                             // Seqlock: end write (infallible CPU copy, always advances)
                             unsafe {
                                 let old_gen = std::ptr::read_volatile(gen_ptr);
-                                std::ptr::write_volatile(gen_ptr, old_gen + 1);
+                                std::ptr::write_volatile(gen_ptr, old_gen.wrapping_add(1));
                                 std::sync::atomic::fence(std::sync::atomic::Ordering::Release);
                             }
                         }


### PR DESCRIPTION
Fixes #2890.

## Problem

PR #2866 (for issue #2865) set out to make the memory-pool seqlock generation counter in `apis/python/node/src/lib.rs` use *uniform* wrapping semantics, so that no increment of the counter can panic on overflow in debug builds while the others wrap silently. That PR only changed the `seqlock_begin_write` helper.

Four inline increments of the very same counter (`header[96]`, `gen_ptr`) were left using the non-wrapping `old_gen + 1`:

- `apis/python/node/src/lib.rs:1432` — begin-write of the top-level `write_memory_pool` path
- `apis/python/node/src/lib.rs:1511` — end-write of that same path
- `apis/python/node/src/lib.rs:1802` — inlined "end write (infallible CPU copy)" block (fast path)
- `apis/python/node/src/lib.rs:1947` — inlined "end write (infallible CPU copy)" block (slow path)

These were the only remaining non-wrapping increments of a counter whose helpers already use `wrapping_add(1)` / `wrapping_add(2)`. The issue named the two CPU-copy blocks (1802, 1947); the two begin/end increments at 1432/1511 are the same class, so this fixes all four for full consistency — which is what #2865 originally asked for.

## Fix

Replace all four `old_gen + 1` with `old_gen.wrapping_add(1)`, matching the semantics of the `seqlock_begin_write` / `seqlock_end_write` helpers.

## Severity

Low. `gen` is a `u64` advancing by 2 per write, so overflow requires ~2^63 writes and is not reachable in practice. This is a code-consistency / robustness cleanup that removes a debug-build panic divergence, not a live runtime bug.

## Verification

`cargo check -p dora-node-api-python` passes cleanly (only a pre-existing, unrelated `downcast_into` deprecation warning remains).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXQ8MhA2GNSbyzqEBam6Xx)_