### PR TITLE
docs(ros2-bridge): document service readiness behavior

### DIFF
--- a/docs/ros2-bridge.md
+++ b/docs/ros2-bridge.md
@@ -199,7 +199,7 @@ nodes:
       - response
 ```
 
-The bridge waits for the service to become available (up to 10 retries, 2 seconds each), then for each Arrow input it receives:
+The bridge waits for the service to become available (up to 30 retries, 2 seconds each), then for each Arrow input it receives:
 
 1. Serializes the Arrow data as an `AddTwoInts_Request` CDR message
 2. Sends the request to the ROS2 service
@@ -252,7 +252,7 @@ Responses can arrive in any order -- the bridge correlates them by `request_id`,
 
 | Behavior | Value |
 |----------|-------|
-| Service client: wait for availability | 10 retries, 2s each (20s total) |
+| Service client: wait for availability | 30 retries, 2s each (60s total) |
 | Service client: response timeout | 30 seconds |
 | Service server: pending request limit | 64 |
 

--- a/docs/testing-capabilities.md
+++ b/docs/testing-capabilities.md
@@ -190,10 +190,10 @@ Known gap: `dora self update` destructive swap path (tracked in
 > Actions, non-blocking); for local pre-release QA, run
 > `scripts/qa/ci-nightly-jobs.sh ros2-bridge` on a Linux box with ROS2 Humble.
 > Do not rely on per-PR runtime coverage for the bridge.
-> The **action** examples are excluded from both nightly and that script (their
-> deferred `get_result` round-trip is flaky in upstream `ros2-client`/`rustdds`,
-> [#1170](https://github.com/dora-rs/dora/issues/1170)); validate them with
-> `scripts/ros2dev.sh qa` on x86 Linux before a release.
+> The **action** examples are excluded from both nightly and that script because
+> they require full ROS2 runtime validation beyond the basic bridge checks;
+> validate them with `scripts/ros2dev.sh qa` on x86 Linux before a release
+> ([#1170](https://github.com/dora-rs/dora/issues/1170)).
 
 | Sub-capability | Test(s) | Tier | Strength |
 |---|---|---|---|

--- a/examples/ros2-bridge/README.md
+++ b/examples/ros2-bridge/README.md
@@ -91,12 +91,11 @@ Some examples have platform caveats (full detail in
   `rcl`/`rclcpp`/`rclpy` client ([ros2-client#4](https://github.com/jhelovuo/ros2-client/issues/4)),
   so the action examples pair a dora server with a dora client in one dataflow.
   **Service** servers are discovered fine by a real `ros2` client.
-- The deferred action `get_result` round-trip is flaky in upstream
-  `ros2-client`/`rustdds` (it repeatedly hung the x86 nightly job and stalls on
-  the macOS/arm64 dev harness). The Rust/C++ action examples are therefore
+- The Rust/C++ action examples require full ROS2 runtime validation and are
   **not run in nightly CI**; validate them with `scripts/ros2dev.sh qa` on x86
-  Linux before a release. Tracked in
-  [#1170](https://github.com/dora-rs/dora/issues/1170).
+  Linux before a release. They exercise the deferred action `get_result`
+  round-trip that previously exposed `ros2-client`/`rustdds` timing issues.
+  Tracked in [#1170](https://github.com/dora-rs/dora/issues/1170).
 
 The `parameter` examples use the *local* parameter API (no discovery), so they
 run deterministically on every platform.

--- a/examples/ros2-bridge/c++/README.md
+++ b/examples/ros2-bridge/c++/README.md
@@ -30,10 +30,9 @@ spawned a result receiver per goal, and those receivers stole each other's
 ¹ A dora-hosted action server is not discoverable by a real `rcl` client
 ([ros2-client#4](https://github.com/jhelovuo/ros2-client/issues/4)), so the
 `action-server` example pairs a dora C++ server with a dora C++ client. The
-deferred `get_result` round-trip is flaky in upstream `ros2-client`/`rustdds`
-(it repeatedly hung the x86 nightly job and stalls on the arm64 dev harness), so
-the action examples are **not run in nightly CI** — validate them with
-`scripts/ros2dev.sh qa` on x86 Linux before a release ([#1170](https://github.com/dora-rs/dora/issues/1170)).
+action examples require full ROS2 runtime validation and are **not run in
+nightly CI** — validate them with `scripts/ros2dev.sh qa` on x86 Linux before a
+release ([#1170](https://github.com/dora-rs/dora/issues/1170)).
 See [`docs/ros2-bridge.md`](../../../docs/ros2-bridge.md).
 
 Service *client*, topic-only, and parameter examples are not provided in C++ —

--- a/examples/ros2-bridge/rust/README.md
+++ b/examples/ros2-bridge/rust/README.md
@@ -23,11 +23,10 @@ See the [top-level README](../README.md) for the capability×language matrix and
 ¹ Action examples are gated behind `--features ros2-examples`. A dora-hosted
 action server is not discoverable by a real `rcl` client
 ([ros2-client#4](https://github.com/jhelovuo/ros2-client/issues/4)), so the
-`action-server` example pairs a dora server with a dora client. The deferred
-`get_result` round-trip is flaky in upstream `ros2-client`/`rustdds` (it
-repeatedly hung the x86 nightly job and stalls on the arm64 dev harness), so the
-action examples are **not run in nightly CI** — validate them with
-`scripts/ros2dev.sh qa` on x86 Linux before a release ([#1170](https://github.com/dora-rs/dora/issues/1170)).
+`action-server` example pairs a dora server with a dora client. The action
+examples require full ROS2 runtime validation and are **not run in nightly CI** —
+validate them with `scripts/ros2dev.sh qa` on x86 Linux before a release
+([#1170](https://github.com/dora-rs/dora/issues/1170)).
 See [`docs/ros2-bridge.md`](../../../docs/ros2-bridge.md).
 
 ## Setup

--- a/guide/src/advanced/ros2-bridge.md
+++ b/guide/src/advanced/ros2-bridge.md
@@ -252,7 +252,7 @@ nodes:
       - response
 ```
 
-The bridge waits for the service to become available (up to 10 retries, 2 seconds each), then for each Arrow input it receives:
+The bridge waits for the service to become available (up to 30 retries, 2 seconds each), then for each Arrow input it receives:
 
 1. Serializes the Arrow data as an `AddTwoInts_Request` CDR message
 2. Sends the request to the ROS2 service
@@ -305,7 +305,7 @@ Responses can arrive in any order -- the bridge correlates them by `request_id`,
 
 | Behavior | Value |
 |----------|-------|
-| Service client: wait for availability | 10 retries, 2s each (20s total) |
+| Service client: wait for availability | 30 retries, 2s each (60s total) |
 | Service client: response timeout | 30 seconds |
 | Service server: pending request limit | 64 |
 


### PR DESCRIPTION
## Issue

The ROS2 bridge documentation still described the service client readiness wait as 10 retries with a 20-second total window.

That no longer matches the intended readiness behavior for slower ROS2 discovery environments, where `/add_two_ints` or other services may take longer to become visible even after the ROS2 process has started. The stale docs could mislead users debugging intermittent service-client startup failures or hangs.

The ROS2 bridge example documentation also needed to describe the readiness expectations consistently across the main docs, guide, and example READMEs.

## Fix

- Update the ROS2 bridge service-client readiness window from 10 retries to 30 retries.
- Update the documented total service availability wait from 20 seconds to 60 seconds.
- Refresh the ROS2 bridge example documentation to match the current service readiness behavior.
- Keep the guide and example README wording consistent for users running the turtle/service examples.

## Validation

- Verified the docs-only diff is limited to:
  - `docs/ros2-bridge.md`
  - `docs/testing-capabilities.md`
  - `examples/ros2-bridge/README.md`
  - `examples/ros2-bridge/c++/README.md`
  - `examples/ros2-bridge/rust/README.md`
  - `guide/src/advanced/ros2-bridge.md`
