### PR TITLE
test(lifecycle): cover the same-id node hot-swap race, and actually run the suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,7 +396,12 @@ jobs:
           --
           --test-threads=1
           --skip lifecycle_python
-        timeout-minutes: 20
+        # 5 tests, each driving a real coordinator + daemon + node
+        # processes, plus nested `cargo build` calls for the fixtures.
+        # ~4 min on a warm dev machine; a cold 2-vCPU runner is several
+        # times that, and a step killed at the cap leaves a detached
+        # coordinator holding port 6013 for the next step.
+        timeout-minutes: 30
       # Finish-straggler watchdog regression (#2270): a deterministic wedge
       # (source exits, downstream node hangs) must be escalated/killed by the
       # watchdog rather than hanging until stop_after. Lives in `dora-examples`
@@ -500,8 +505,14 @@ jobs:
           --test-threads=1
           --nocapture
       # Python variant of the lifecycle test piggybacks on this job
-      # because it needs uv (already set up above). See the e2e job
-      # for the Rust + C++ variants.
+      # because it needs uv (already set up above). The e2e job runs
+      # every OTHER test in the file via `--skip lifecycle_python`, so
+      # the two jobs partition it by that one substring: any test in
+      # node-lifecycle-e2e.rs that needs uv MUST be named
+      # `lifecycle_python*`, or it lands in the uv-less e2e job instead.
+      # Note libtest exits 0 when a filter matches nothing, so renaming
+      # the Python test without updating this filter would make the step
+      # silently run zero tests.
       - name: Run dora node lifecycle E2E (Python)
         run: >
           cargo test -p dora-examples --test node-lifecycle-e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,18 +379,24 @@ jobs:
       # `dora node` lifecycle E2E (issue #1703). The shared test
       # binary lives under the `dora-examples` package which the bulk
       # `cargo test --all` step excludes, so it needs an explicit
-      # invocation here. Filter to the Rust + C++ variants because
-      # the Python variant requires uv (handled in `contract-tests`
-      # below where uv is already installed).
-      - name: Run dora node lifecycle E2E (Rust + C++)
-        # Cargo's TESTNAME positional is single-valued; multiple
-        # substring filters go after `--` for libtest.
+      # invocation here.
+      #
+      # Excludes rather than enumerates: the Python variant is the only
+      # test in the file this job can't run (it needs uv — handled in
+      # `contract-tests` below where uv is already installed), so
+      # `--skip` closes the file by default. The previous positive
+      # filters (`lifecycle_rust lifecycle_cxx`) silently dropped every
+      # test whose name didn't start with `lifecycle_` — including
+      # `rust_dynamic_node_readd_same_id_ignores_stale_exit`, the
+      # regression test that shipped with the #2893 stale-exit fix,
+      # which therefore never ran here.
+      - name: Run dora node lifecycle E2E (non-Python)
         run: >
           cargo test -p dora-examples --test node-lifecycle-e2e
           --
           --test-threads=1
-          lifecycle_rust lifecycle_cxx
-        timeout-minutes: 15
+          --skip lifecycle_python
+        timeout-minutes: 20
       # Finish-straggler watchdog regression (#2270): a deterministic wedge
       # (source exits, downstream node hangs) must be escalated/killed by the
       # watchdog rather than hanging until stop_after. Lives in `dora-examples`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7372,6 +7372,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "stop-delay-node"
+version = "1.0.0-rc.4"
+dependencies = [
+ "dora-node-api",
+ "eyre",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ members = [
     "tests/fault_tolerance/input_closed_observer_node",
     "tests/fault_tolerance/reconnect_survivor_node",
     "tests/fault_tolerance/silent_source_node",
+    "tests/fault_tolerance/stop_delay_node",
     "tests/fault_tolerance/timed_burst_source_node",
     "xtask",
 ]

--- a/tests/fault_tolerance/stop_delay_node/Cargo.toml
+++ b/tests/fault_tolerance/stop_delay_node/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "stop-delay-node"
+edition.workspace = true
+rust-version.workspace = true
+version.workspace = true
+description.workspace = true
+documentation.workspace = true
+license.workspace = true
+publish = false
+
+# Test-only node with a configurable shutdown: it honors the
+# cooperative `Event::Stop`, then sleeps `DORA_TEST_STOP_DELAY_MS`
+# before exiting with `DORA_TEST_STOP_EXIT_CODE`. Both knobs exist to
+# place a removed incarnation's exit deterministically on either side
+# of a same-id `dora node add` (dora-rs/dora#2916), which decides
+# whether the daemon's stale-exit guard sees a re-added node or an
+# absent one. Lives here alongside the other test-only node crates
+# (`fire-and-forget-source-node` is likewise shared with
+# tests/node-lifecycle-e2e.rs).
+
+[[bin]]
+name = "stop-delay-node"
+path = "src/main.rs"
+
+[dependencies]
+dora-node-api = { workspace = true, default-features = false }
+eyre = { workspace = true }

--- a/tests/fault_tolerance/stop_delay_node/src/main.rs
+++ b/tests/fault_tolerance/stop_delay_node/src/main.rs
@@ -15,26 +15,49 @@
 //! * `DORA_TEST_STOP_EXIT_CODE` (default 0) — the exit status, so a test
 //!   can distinguish a clean shutdown from a node that fails on its way
 //!   out.
+//! * `DORA_TEST_MARKER_FILE` (optional) — path to write the resolved
+//!   exit code to, immediately before exiting. Lets a test assert that
+//!   this fixture really did exit the way the test's premise assumes,
+//!   rather than inferring it from daemon-side state that a removed
+//!   node no longer has (`dora node list` drops the row on removal).
+//!   Same marker-file convention as `clean_exit_node` and
+//!   `delayed_crash_node`.
 //!
 //! Declares no inputs, so `events.recv()` blocks until the daemon sends
 //! `Stop` — the node stays alive until the test removes it.
 
 use dora_node_api::{DoraNode, Event};
 use eyre::Context;
-use std::{thread, time::Duration};
+use std::{io::Write, thread, time::Duration};
+
+/// Absolute lifetime cap. Nothing in the test path should reach this —
+/// the node exits on `Stop` — but an orphaned incarnation (killed
+/// daemon, timed-out CI step, severed connection that never yields
+/// `None`) would otherwise sit resident forever holding its
+/// shared-memory pool. `fire-and-forget-source-node` bounds itself the
+/// same way, at 100s of wall-clock work.
+const MAX_LIFETIME: Duration = Duration::from_secs(300);
 
 fn main() -> eyre::Result<()> {
     let (_node, mut events) =
         DoraNode::init_from_env().context("failed to init dora node from env")?;
 
-    // Unset means "default"; set-but-unparseable is a fixture bug and
-    // must fail loudly rather than silently fall back to the default.
+    // Unset (or set to non-UTF8) means "default"; a set-but-unparseable
+    // value is a fixture bug and fails loudly rather than silently
+    // falling back.
     let delay_ms: u64 = std::env::var("DORA_TEST_STOP_DELAY_MS")
         .map_or(Ok(0), |raw| raw.parse())
         .context("DORA_TEST_STOP_DELAY_MS must be a u64")?;
     let exit_code: i32 = std::env::var("DORA_TEST_STOP_EXIT_CODE")
         .map_or(Ok(0), |raw| raw.parse())
         .context("DORA_TEST_STOP_EXIT_CODE must be an i32")?;
+    let marker = std::env::var("DORA_TEST_MARKER_FILE").ok();
+
+    thread::spawn(|| {
+        thread::sleep(MAX_LIFETIME);
+        eprintln!("stop-delay-node: lifetime cap reached, exiting");
+        std::process::exit(0);
+    });
 
     while let Some(event) = events.recv() {
         if matches!(event, Event::Stop(_)) {
@@ -43,6 +66,17 @@ fn main() -> eyre::Result<()> {
     }
 
     thread::sleep(Duration::from_millis(delay_ms));
+
+    if let Some(path) = marker {
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .with_context(|| format!("failed to open marker file {path:?}"))?;
+        writeln!(file, "{exit_code}").context("failed to write exit marker")?;
+        file.flush().context("failed to flush exit marker")?;
+    }
+
     // `process::exit` rather than returning: the exit status has to be
     // exactly what the fixture asked for, with no destructor-driven
     // handshake changing the timing the test is pinning.

--- a/tests/fault_tolerance/stop_delay_node/src/main.rs
+++ b/tests/fault_tolerance/stop_delay_node/src/main.rs
@@ -1,0 +1,50 @@
+//! Test-only node that honors `Event::Stop` but controls *when* and
+//! *how* it exits.
+//!
+//! A `dora node remove` immediately followed by a `dora node add` of the
+//! same id (dora-rs/dora#2916) races the removed process's exit against
+//! the new incarnation's spawn. Which side of the re-add that exit lands
+//! on decides which daemon code path accounts it, so a test that wants
+//! to pin one ordering needs a node whose shutdown latency it controls:
+//!
+//! * `DORA_TEST_STOP_DELAY_MS` (default 0) — how long to linger after
+//!   `Stop` before exiting. Large enough and the exit lands *after* the
+//!   re-add (the shape the issue reported, where a Python node's
+//!   interpreter teardown outlived the CLI round trip); zero and it
+//!   lands *before*.
+//! * `DORA_TEST_STOP_EXIT_CODE` (default 0) — the exit status, so a test
+//!   can distinguish a clean shutdown from a node that fails on its way
+//!   out.
+//!
+//! Declares no inputs, so `events.recv()` blocks until the daemon sends
+//! `Stop` — the node stays alive until the test removes it.
+
+use dora_node_api::{DoraNode, Event};
+use eyre::Context;
+use std::{thread, time::Duration};
+
+fn main() -> eyre::Result<()> {
+    let (_node, mut events) =
+        DoraNode::init_from_env().context("failed to init dora node from env")?;
+
+    // Unset means "default"; set-but-unparseable is a fixture bug and
+    // must fail loudly rather than silently fall back to the default.
+    let delay_ms: u64 = std::env::var("DORA_TEST_STOP_DELAY_MS")
+        .map_or(Ok(0), |raw| raw.parse())
+        .context("DORA_TEST_STOP_DELAY_MS must be a u64")?;
+    let exit_code: i32 = std::env::var("DORA_TEST_STOP_EXIT_CODE")
+        .map_or(Ok(0), |raw| raw.parse())
+        .context("DORA_TEST_STOP_EXIT_CODE must be an i32")?;
+
+    while let Some(event) = events.recv() {
+        if matches!(event, Event::Stop(_)) {
+            break;
+        }
+    }
+
+    thread::sleep(Duration::from_millis(delay_ms));
+    // `process::exit` rather than returning: the exit status has to be
+    // exactly what the fixture asked for, with no destructor-driven
+    // handshake changing the timing the test is pinning.
+    std::process::exit(exit_code);
+}

--- a/tests/node-lifecycle-e2e.rs
+++ b/tests/node-lifecycle-e2e.rs
@@ -723,6 +723,239 @@ fn rust_dynamic_node_readd_same_id_ignores_stale_exit() {
     );
 }
 
+static BUILD_STOP_DELAY: Once = Once::new();
+
+/// Build the `stop-delay-node` fixture used by the #2916 hot-swap
+/// tests. Same rationale as `ensure_rust_filter_built`: `dora node add`
+/// never runs a `build:` field, so the binary has to exist beforehand.
+fn ensure_stop_delay_built() {
+    BUILD_STOP_DELAY.call_once(|| {
+        let dora_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let status = Command::new("cargo")
+            .args(["build", "-p", "stop-delay-node"])
+            .arg("--target-dir")
+            .arg(dora_root.join("target"))
+            .status()
+            .expect("failed to run cargo build for stop-delay-node");
+        assert!(status.success(), "failed to build stop-delay-node");
+    });
+}
+
+/// Write a `dora node add --from-yaml` spec for the `stop-delay-node`
+/// fixture, wiring its two shutdown knobs through the descriptor's
+/// `env:` block.
+fn write_stop_delay_yml(file_stem: &str, delay_ms: u64, exit_code: i32) -> std::path::PathBuf {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let path = std::env::temp_dir().join(format!(
+        "dora-stop-delay-{file_stem}-{}.yml",
+        std::process::id()
+    ));
+    fs::write(
+        &path,
+        format!(
+            "id: filter\n\
+             path: {manifest_dir}/target/debug/stop-delay-node\n\
+             env:\n  \
+               DORA_TEST_STOP_DELAY_MS: {delay_ms}\n  \
+               DORA_TEST_STOP_EXIT_CODE: {exit_code}\n\
+             outputs:\n  - value\n"
+        ),
+    )
+    .expect("failed to write stop-delay node spec");
+    path
+}
+
+/// Add the `filter` node from `spec`, then wait for it to report
+/// `Running` and return its pid.
+fn add_filter_and_wait(dora: &str, name: &str, spec: &Path, label: &str) -> String {
+    let (ok, _, stderr) = run_capture(
+        Command::new(dora).args([
+            "node",
+            "add",
+            "--dataflow",
+            name,
+            "--from-yaml",
+            spec.to_str().unwrap(),
+        ]),
+        label,
+    );
+    assert!(ok, "{label} failed.\nstderr:\n{stderr}");
+    let list_out = wait_for_list(dora, name, Duration::from_secs(10), |m| {
+        m.get("filter").is_some_and(|(s, _, _)| s == "Running")
+    });
+    parse_node_list(&list_out)
+        .get("filter")
+        .cloned()
+        .filter(|(s, _, _)| s == "Running")
+        .unwrap_or_else(|| panic!("filter did not reach Running after {label}; list:\n{list_out}"))
+        .1
+}
+
+/// Shared setup for the #2916 hot-swap tests: bring up the rust
+/// dynamic-add-remove dataflow, with the `stop-delay-node` fixture
+/// built and ready to be added as `filter`. The caller owns the
+/// returned `dora` path so it can attach its own `CleanupGuard`.
+fn start_hot_swap_fixture(name: &str) -> String {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let dataflow = Path::new(manifest_dir).join("examples/rust-dynamic-add-remove/dataflow.yml");
+    let filter_yml =
+        Path::new(manifest_dir).join("examples/rust-dynamic-add-remove/filter-node.yml");
+    ensure_stop_delay_built();
+    let fixture = LifecycleFixture {
+        dataflow_path: &dataflow,
+        filter_yml_path: &filter_yml,
+        name,
+        sender_path_marker: "rust-dynamic-add-remove-sender",
+        use_uv: false,
+    };
+    start_lifecycle(&fixture).dora
+}
+
+/// Hot-swap regression guard for dora-rs/dora#2916: the predecessor's
+/// exit lands *after* the same-id re-add.
+///
+/// This is the ordering the issue reported. The removed Python node's
+/// interpreter teardown outlived the CLI's `node add` round trip, so by
+/// the time its exit reached the daemon, `running_nodes["filter"]` had
+/// already been replaced by the new incarnation. Every lifecycle
+/// bookkeeping path is keyed by node id alone, so the dead
+/// predecessor's exit was accounted against the live successor:
+/// `handle_node_stop` removed the *new* `running_nodes` entry, whose
+/// `ProcessHandle::drop` SIGKILLed the new process ("process was killed
+/// on drop because it was still running"), and the resulting `Signal(9)`
+/// was recorded under the same id so `dora stop` failed the dataflow.
+///
+/// `DORA_TEST_STOP_DELAY_MS` pins the ordering rather than relying on a
+/// language runtime happening to be slow: 1500ms comfortably outlasts
+/// the `node add` round trip while staying well inside the 10s stop
+/// grace, so the predecessor exits cleanly on its own rather than being
+/// SIGTERMed (which is the shape
+/// `rust_dynamic_node_readd_same_id_ignores_stale_exit` already covers).
+///
+/// No sleep between remove and add — the gap is the bug, and the
+/// workaround the issue reports shipping (sleep ~2s) is exactly what
+/// this must not need.
+#[test]
+fn hot_swap_survives_predecessor_exit_after_readd() {
+    let _guard = LIFECYCLE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let name = "rustlc-swap-late";
+    let spec = write_stop_delay_yml("late", 1500, 0);
+    let dora = start_hot_swap_fixture(name);
+    let _cleanup = CleanupGuard { dora: &dora };
+
+    let old_pid = add_filter_and_wait(&dora, name, &spec, "dora node add filter");
+
+    // --- the hot swap: remove immediately followed by add ---------------
+    let (ok, _, stderr) = run_capture(
+        Command::new(&dora).args(["node", "remove", "--dataflow", name, "filter"]),
+        "dora node remove filter",
+    );
+    assert!(ok, "dora node remove failed.\nstderr:\n{stderr}");
+    let new_pid = add_filter_and_wait(&dora, name, &spec, "dora node re-add filter");
+    assert_ne!(
+        new_pid, old_pid,
+        "re-added filter should be a new process; the daemon reused pid {old_pid}"
+    );
+
+    // Outlast the predecessor's 1500ms shutdown delay, then confirm its
+    // exit did not take the successor down with it.
+    std::thread::sleep(Duration::from_secs(5));
+    let (ok, list_out, stderr) = run_capture(
+        Command::new(&dora).args(["node", "list", "--dataflow", name, "--format", "json"]),
+        "dora node list after swap",
+    );
+    assert!(ok, "dora node list failed.\nstderr:\n{stderr}");
+    let filter_state = parse_node_list(&list_out).get("filter").cloned();
+    assert!(
+        matches!(&filter_state, Some((s, pid, _)) if s == "Running" && pid == &new_pid),
+        "the re-added filter (pid {new_pid}) must still be Running after the \
+         predecessor's exit is accounted; got {filter_state:?}\nlist:\n{list_out}"
+    );
+
+    // The predecessor's exit must not poison the dataflow result either:
+    // `dora stop` fails with "Dataflow <uuid> failed: Node filter failed:
+    // exited because of signal SIGKILL" when it does.
+    let (ok, stdout, stderr) = run_capture(
+        Command::new(&dora).args(["stop", "--name", name, "--grace-duration", "5s"]),
+        "dora stop",
+    );
+    assert!(
+        ok,
+        "dora stop reported the dataflow as failed after a hot swap.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+/// The other ordering in dora-rs/dora#2916: the predecessor's exit
+/// lands *before* the same-id re-add.
+///
+/// The daemon's stale-exit guard compares the exiting pid against
+/// `running_nodes[node_id]`, so it can only fire once the successor is
+/// installed. Here there is nothing to compare against — `RemoveNode`
+/// took the entry out and `AddNode` has not arrived yet — so the
+/// removed incarnation's failure *is* recorded under the bare node id
+/// (`dataflow_node_results[node_id] = Err`), and nothing clears it when
+/// the id is re-added. What keeps this benign today is incidental: the
+/// successor's own clean exit overwrites that map entry at teardown.
+/// The assertion pins the survivable outcome so a future change to how
+/// node results are keyed or aggregated can't quietly turn it into the
+/// contradiction the issue reports — `dora node list` saying `filter`
+/// is Running while `dora stop` blames `filter` for a dead
+/// predecessor's exit code.
+///
+/// Modelled on the workflow the issue describes: swap a node that fails
+/// on the way out for a fixed build. The predecessor exits 1 the
+/// instant it sees `Stop` (`DORA_TEST_STOP_DELAY_MS: 0`), comfortably
+/// ahead of the next CLI round trip; the replacement exits cleanly, so
+/// the only failure in the dataflow's history belongs to an incarnation
+/// the operator explicitly removed.
+#[test]
+fn hot_swap_survives_predecessor_exit_before_readd() {
+    let _guard = LIFECYCLE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let name = "rustlc-swap-early";
+    let broken = write_stop_delay_yml("early-broken", 0, 1);
+    let fixed = write_stop_delay_yml("early-fixed", 0, 0);
+    let dora = start_hot_swap_fixture(name);
+    let _cleanup = CleanupGuard { dora: &dora };
+
+    let old_pid = add_filter_and_wait(&dora, name, &broken, "dora node add filter (broken)");
+
+    // --- the hot swap: remove the broken build, add the fixed one -------
+    let (ok, _, stderr) = run_capture(
+        Command::new(&dora).args(["node", "remove", "--dataflow", name, "filter"]),
+        "dora node remove filter",
+    );
+    assert!(ok, "dora node remove failed.\nstderr:\n{stderr}");
+    let new_pid = add_filter_and_wait(&dora, name, &fixed, "dora node re-add filter (fixed)");
+    assert_ne!(
+        new_pid, old_pid,
+        "re-added filter should be a new process; the daemon reused pid {old_pid}"
+    );
+
+    std::thread::sleep(Duration::from_secs(3));
+    let (ok, list_out, stderr) = run_capture(
+        Command::new(&dora).args(["node", "list", "--dataflow", name, "--format", "json"]),
+        "dora node list after swap",
+    );
+    assert!(ok, "dora node list failed.\nstderr:\n{stderr}");
+    let filter_state = parse_node_list(&list_out).get("filter").cloned();
+    assert!(
+        matches!(&filter_state, Some((s, pid, _)) if s == "Running" && pid == &new_pid),
+        "the re-added filter (pid {new_pid}) must be Running; got {filter_state:?}\nlist:\n{list_out}"
+    );
+
+    // The removed incarnation's exit code must not be attributed to the
+    // healthy successor that now owns the id.
+    let (ok, stdout, stderr) = run_capture(
+        Command::new(&dora).args(["stop", "--name", name, "--grace-duration", "5s"]),
+        "dora stop",
+    );
+    assert!(
+        ok,
+        "`dora node list` reports filter Running, but `dora stop` blames it for \
+         the removed incarnation's exit.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
 #[test]
 // C++ fixture is deliberately Unix-only: the existing cmake-dataflow
 // example in this repo explicitly skips Windows

--- a/tests/node-lifecycle-e2e.rs
+++ b/tests/node-lifecycle-e2e.rs
@@ -819,6 +819,26 @@ fn process_alive(pid: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Block until `pid` is gone, panicking if it outlives `timeout`.
+///
+/// `dora node remove` returns once the daemon has scheduled `Stop`, not
+/// once the process is reaped, so a test that needs the predecessor's
+/// exit to be accounted *before* its next CLI call has to wait for it
+/// explicitly. `dora node list` is no help: the row disappears the
+/// moment the node is removed and never reappears to report the later
+/// exit, so process liveness is the observable.
+#[cfg(unix)]
+fn wait_for_process_exit(pid: &str, timeout: Duration) {
+    let deadline = std::time::Instant::now() + timeout;
+    while process_alive(pid) {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "predecessor pid {pid} was still alive {timeout:?} after `node remove`"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
 /// Shared setup for the #2916 hot-swap tests: bring up the rust
 /// dynamic-add-remove dataflow, with the `stop-delay-node` fixture
 /// built and ready to be added as `filter`. The caller owns the
@@ -954,10 +974,11 @@ fn hot_swap_survives_predecessor_exit_after_readd() {
 ///
 /// Modelled on the workflow the issue describes: swap a node that fails
 /// on the way out for a fixed build. The predecessor exits 1 the
-/// instant it sees `Stop` (`DORA_TEST_STOP_DELAY_MS: 0`), comfortably
-/// ahead of the next CLI round trip; the replacement exits cleanly, so
-/// the only failure in the dataflow's history belongs to an incarnation
-/// the operator explicitly removed.
+/// instant it sees `Stop` (`DORA_TEST_STOP_DELAY_MS: 0`) and the test
+/// waits for that exit before re-adding, so the ordering is enforced
+/// rather than assumed; the replacement exits cleanly, so the only
+/// failure in the dataflow's history belongs to an incarnation the
+/// operator explicitly removed.
 #[test]
 fn hot_swap_survives_predecessor_exit_before_readd() {
     let _guard = LIFECYCLE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
@@ -975,6 +996,18 @@ fn hot_swap_survives_predecessor_exit_before_readd() {
         "dora node remove filter",
     );
     assert!(ok, "dora node remove failed.\nstderr:\n{stderr}");
+
+    // `node remove` returns once `Stop` is scheduled, not once the
+    // process is gone, so re-adding immediately would leave the
+    // ordering to chance: if the daemon handled `AddNode` first, the
+    // pid guard would discard the predecessor's failure and this test
+    // would silently re-run the sibling test's ordering instead of the
+    // one it documents. Waiting for the process to exit rules that out
+    // — the exit event is queued before the replacement's CLI round
+    // trip even begins, and a slower runner only widens that margin.
+    #[cfg(unix)]
+    wait_for_process_exit(&old_pid, Duration::from_secs(10));
+
     let new_pid = add_filter_and_wait(&dora, name, &fixed, "dora node re-add filter (fixed)");
     assert_ne!(
         new_pid, old_pid,

--- a/tests/node-lifecycle-e2e.rs
+++ b/tests/node-lifecycle-e2e.rs
@@ -765,9 +765,11 @@ fn write_stop_delay_yml(file_stem: &str, delay_ms: u64, exit_code: i32) -> std::
     path
 }
 
-/// Add the `filter` node from `spec`, then wait for it to report
-/// `Running` and return its pid.
-fn add_filter_and_wait(dora: &str, name: &str, spec: &Path, label: &str) -> String {
+/// Run `dora node add` for the `filter` node from `spec`. Returns once
+/// the CLI call completes, without waiting for the node to come up, so
+/// a caller can observe state that is only true in the moments right
+/// after the add.
+fn add_filter(dora: &str, name: &str, spec: &Path, label: &str) {
     let (ok, _, stderr) = run_capture(
         Command::new(dora).args([
             "node",
@@ -780,6 +782,10 @@ fn add_filter_and_wait(dora: &str, name: &str, spec: &Path, label: &str) -> Stri
         label,
     );
     assert!(ok, "{label} failed.\nstderr:\n{stderr}");
+}
+
+/// Wait for `filter` to report `Running` and return its pid.
+fn wait_for_filter_pid(dora: &str, name: &str, label: &str) -> String {
     let list_out = wait_for_list(dora, name, Duration::from_secs(10), |m| {
         m.get("filter").is_some_and(|(s, _, _)| s == "Running")
     });
@@ -789,6 +795,28 @@ fn add_filter_and_wait(dora: &str, name: &str, spec: &Path, label: &str) -> Stri
         .filter(|(s, _, _)| s == "Running")
         .unwrap_or_else(|| panic!("filter did not reach Running after {label}; list:\n{list_out}"))
         .1
+}
+
+/// Add the `filter` node from `spec`, then wait for it to report
+/// `Running` and return its pid.
+fn add_filter_and_wait(dora: &str, name: &str, spec: &Path, label: &str) -> String {
+    add_filter(dora, name, spec, label);
+    wait_for_filter_pid(dora, name, label)
+}
+
+/// Whether `pid` still names a live process.
+///
+/// Used to prove a test actually entered the window it claims to
+/// cover, rather than passing because the race never happened.
+#[cfg(unix)]
+fn process_alive(pid: &str) -> bool {
+    Command::new("kill")
+        .args(["-0", pid])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
 }
 
 /// Shared setup for the #2916 hot-swap tests: bring up the rust
@@ -826,10 +854,12 @@ fn start_hot_swap_fixture(name: &str) -> String {
 /// was recorded under the same id so `dora stop` failed the dataflow.
 ///
 /// `DORA_TEST_STOP_DELAY_MS` pins the ordering rather than relying on a
-/// language runtime happening to be slow: 1500ms comfortably outlasts
-/// the `node add` round trip while staying well inside the 10s stop
-/// grace, so the predecessor exits cleanly on its own rather than being
-/// SIGTERMed (which is the shape
+/// language runtime happening to be slow, and the test asserts the
+/// predecessor was still alive when the re-add returned — so a runner
+/// slow enough to close the window fails the test instead of passing it
+/// vacuously. The delay stays well inside the 10s stop grace, so the
+/// predecessor exits cleanly on its own rather than being SIGTERMed
+/// (which is the shape
 /// `rust_dynamic_node_readd_same_id_ignores_stale_exit` already covers).
 ///
 /// No sleep between remove and add — the gap is the bug, and the
@@ -839,7 +869,10 @@ fn start_hot_swap_fixture(name: &str) -> String {
 fn hot_swap_survives_predecessor_exit_after_readd() {
     let _guard = LIFECYCLE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
     let name = "rustlc-swap-late";
-    let spec = write_stop_delay_yml("late", 1500, 0);
+    // 4s of margin over the `node add` round trip: generous for a
+    // loaded CI runner, still far inside the 10s stop grace so the
+    // predecessor exits on its own rather than being SIGTERMed.
+    let spec = write_stop_delay_yml("late", 4000, 0);
     let dora = start_hot_swap_fixture(name);
     let _cleanup = CleanupGuard { dora: &dora };
 
@@ -851,14 +884,31 @@ fn hot_swap_survives_predecessor_exit_after_readd() {
         "dora node remove filter",
     );
     assert!(ok, "dora node remove failed.\nstderr:\n{stderr}");
-    let new_pid = add_filter_and_wait(&dora, name, &spec, "dora node re-add filter");
+    add_filter(&dora, name, &spec, "dora node re-add filter");
+
+    // Prove the window this test exists to cover was actually open: the
+    // predecessor must still be alive at the moment the re-add returns,
+    // so its exit is necessarily accounted *after* the successor was
+    // installed. Without this the test would pass vacuously on a runner
+    // slow enough that `node add` outlasts the fixture's shutdown delay
+    // — it would then be exercising the pre-add ordering, which the
+    // sibling test already covers.
+    #[cfg(unix)]
+    assert!(
+        process_alive(&old_pid),
+        "predecessor pid {old_pid} already exited before `node add` returned, so this \
+         run did not exercise the exit-after-re-add ordering; raise \
+         DORA_TEST_STOP_DELAY_MS in the fixture spec"
+    );
+
+    let new_pid = wait_for_filter_pid(&dora, name, "dora node re-add filter");
     assert_ne!(
         new_pid, old_pid,
         "re-added filter should be a new process; the daemon reused pid {old_pid}"
     );
 
-    // Outlast the predecessor's 1500ms shutdown delay, then confirm its
-    // exit did not take the successor down with it.
+    // Outlast the predecessor's shutdown delay, then confirm its exit
+    // did not take the successor down with it.
     std::thread::sleep(Duration::from_secs(5));
     let (ok, list_out, stderr) = run_capture(
         Command::new(&dora).args(["node", "list", "--dataflow", name, "--format", "json"]),

--- a/tests/node-lifecycle-e2e.rs
+++ b/tests/node-lifecycle-e2e.rs
@@ -741,28 +741,58 @@ fn ensure_stop_delay_built() {
     });
 }
 
+/// A `stop-delay-node` spec plus the marker file its incarnation writes
+/// its exit code to.
+struct StopDelaySpec {
+    yml: std::path::PathBuf,
+    marker: std::path::PathBuf,
+}
+
+impl StopDelaySpec {
+    /// The exit codes recorded by every incarnation spawned from this
+    /// spec, oldest first. Empty until one actually exits.
+    fn recorded_exits(&self) -> Vec<String> {
+        fs::read_to_string(&self.marker)
+            .unwrap_or_default()
+            .lines()
+            .map(|l| l.trim().to_string())
+            .filter(|l| !l.is_empty())
+            .collect()
+    }
+}
+
 /// Write a `dora node add --from-yaml` spec for the `stop-delay-node`
-/// fixture, wiring its two shutdown knobs through the descriptor's
-/// `env:` block.
-fn write_stop_delay_yml(file_stem: &str, delay_ms: u64, exit_code: i32) -> std::path::PathBuf {
+/// fixture, wiring its shutdown knobs through the descriptor's `env:`
+/// block.
+///
+/// Artifacts land under `target/` rather than the system temp dir: the
+/// tests never delete them (a failed run's spec is worth keeping), and
+/// `target/` is both gitignored and cleaned by `cargo clean`, so they
+/// don't accumulate in `/tmp` run after run.
+fn write_stop_delay_yml(file_stem: &str, delay_ms: u64, exit_code: i32) -> StopDelaySpec {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    let path = std::env::temp_dir().join(format!(
-        "dora-stop-delay-{file_stem}-{}.yml",
-        std::process::id()
-    ));
+    let dir = Path::new(manifest_dir).join("target");
+    let stem = format!("dora-stop-delay-{file_stem}-{}", std::process::id());
+    let yml = dir.join(format!("{stem}.yml"));
+    let marker = dir.join(format!("{stem}.exits"));
+    // A rerun in the same process would otherwise append to the
+    // previous run's exit records.
+    let _ = fs::remove_file(&marker);
     fs::write(
-        &path,
+        &yml,
         format!(
             "id: filter\n\
              path: {manifest_dir}/target/debug/stop-delay-node\n\
              env:\n  \
                DORA_TEST_STOP_DELAY_MS: {delay_ms}\n  \
-               DORA_TEST_STOP_EXIT_CODE: {exit_code}\n\
-             outputs:\n  - value\n"
+               DORA_TEST_STOP_EXIT_CODE: {exit_code}\n  \
+               DORA_TEST_MARKER_FILE: {marker}\n\
+             outputs:\n  - value\n",
+            marker = marker.display()
         ),
     )
     .expect("failed to write stop-delay node spec");
-    path
+    StopDelaySpec { yml, marker }
 }
 
 /// Run `dora node add` for the `filter` node from `spec`. Returns once
@@ -806,17 +836,31 @@ fn add_filter_and_wait(dora: &str, name: &str, spec: &Path, label: &str) -> Stri
 
 /// Whether `pid` still names a live process.
 ///
-/// Used to prove a test actually entered the window it claims to
-/// cover, rather than passing because the race never happened.
+/// Used to prove a test actually entered the window it claims to cover,
+/// rather than passing because the race never happened.
+///
+/// Deliberately NOT `kill -0`: that succeeds for a zombie — a process
+/// that has already exited but whose parent (here the daemon) hasn't
+/// reaped it yet. Under load the daemon's reaping task is exactly what
+/// falls behind, so `kill -0` would report a dead predecessor as alive
+/// and let a test claim a window it never had. `ps -o state=` reports
+/// `Z` for that case, which is what makes this check honest.
+///
+/// A failure to run `ps` at all panics rather than reading as "dead" —
+/// silently degrading the liveness check to a no-op would turn the
+/// anti-vacuity guards below back into the thing they exist to prevent.
 #[cfg(unix)]
 fn process_alive(pid: &str) -> bool {
-    Command::new("kill")
-        .args(["-0", pid])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
+    let out = Command::new("ps")
+        .args(["-o", "state=", "-p", pid])
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run `ps -o state= -p {pid}`: {e}"));
+    if !out.status.success() {
+        return false; // no such process
+    }
+    let state = String::from_utf8_lossy(&out.stdout);
+    let state = state.trim();
+    !state.is_empty() && !state.starts_with('Z')
 }
 
 /// Block until `pid` is gone, panicking if it outlives `timeout`.
@@ -846,12 +890,17 @@ fn wait_for_process_exit(pid: &str, timeout: Duration) {
 fn start_hot_swap_fixture(name: &str) -> String {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let dataflow = Path::new(manifest_dir).join("examples/rust-dynamic-add-remove/dataflow.yml");
-    let filter_yml =
+    // `start_lifecycle` reads neither `filter_yml_path` nor
+    // `sender_path_marker` (only `run_lifecycle` does), so this path is
+    // a placeholder to satisfy the struct — the hot-swap tests add
+    // their own `stop-delay-node` spec instead, and the example's
+    // filter binary is never built or spawned here.
+    let unused_filter_yml =
         Path::new(manifest_dir).join("examples/rust-dynamic-add-remove/filter-node.yml");
     ensure_stop_delay_built();
     let fixture = LifecycleFixture {
         dataflow_path: &dataflow,
-        filter_yml_path: &filter_yml,
+        filter_yml_path: &unused_filter_yml,
         name,
         sender_path_marker: "rust-dynamic-add-remove-sender",
         use_uv: false,
@@ -877,34 +926,45 @@ fn start_hot_swap_fixture(name: &str) -> String {
 /// language runtime happening to be slow, and the test asserts the
 /// predecessor was still alive when the re-add returned — so a runner
 /// slow enough to close the window fails the test instead of passing it
-/// vacuously. The delay stays well inside the 10s stop grace, so the
-/// predecessor exits cleanly on its own rather than being SIGTERMed
-/// (which is the shape
+/// vacuously. An explicit long `--grace` on the remove decouples that
+/// window from `DEFAULT_STOP_GRACE`, so the delay can carry real margin
+/// over a slow CLI round trip while the predecessor still exits on its
+/// own rather than being SIGTERMed (which is the shape
 /// `rust_dynamic_node_readd_same_id_ignores_stale_exit` already covers).
 ///
 /// No sleep between remove and add — the gap is the bug, and the
 /// workaround the issue reports shipping (sleep ~2s) is exactly what
 /// this must not need.
 #[test]
+#[cfg(unix)]
 fn hot_swap_survives_predecessor_exit_after_readd() {
     let _guard = LIFECYCLE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
     let name = "rustlc-swap-late";
-    // 4s of margin over the `node add` round trip: generous for a
-    // loaded CI runner, still far inside the 10s stop grace so the
-    // predecessor exits on its own rather than being SIGTERMed.
-    let spec = write_stop_delay_yml("late", 4000, 0);
+    // The predecessor must outlive the `node add` round trip (two debug
+    // CLI process lifecycles plus a daemon spawn the daemon awaits
+    // before replying). 10s is generous for a cold 2-vCPU runner; the
+    // `--grace 60` below keeps it well clear of the kill escalation.
+    let spec = write_stop_delay_yml("late", 10_000, 0);
     let dora = start_hot_swap_fixture(name);
     let _cleanup = CleanupGuard { dora: &dora };
 
-    let old_pid = add_filter_and_wait(&dora, name, &spec, "dora node add filter");
+    let old_pid = add_filter_and_wait(&dora, name, &spec.yml, "dora node add filter");
 
     // --- the hot swap: remove immediately followed by add ---------------
     let (ok, _, stderr) = run_capture(
-        Command::new(&dora).args(["node", "remove", "--dataflow", name, "filter"]),
+        Command::new(&dora).args([
+            "node",
+            "remove",
+            "--dataflow",
+            name,
+            "--grace",
+            "60",
+            "filter",
+        ]),
         "dora node remove filter",
     );
     assert!(ok, "dora node remove failed.\nstderr:\n{stderr}");
-    add_filter(&dora, name, &spec, "dora node re-add filter");
+    add_filter(&dora, name, &spec.yml, "dora node re-add filter");
 
     // Prove the window this test exists to cover was actually open: the
     // predecessor must still be alive at the moment the re-add returns,
@@ -913,7 +973,6 @@ fn hot_swap_survives_predecessor_exit_after_readd() {
     // slow enough that `node add` outlasts the fixture's shutdown delay
     // — it would then be exercising the pre-add ordering, which the
     // sibling test already covers.
-    #[cfg(unix)]
     assert!(
         process_alive(&old_pid),
         "predecessor pid {old_pid} already exited before `node add` returned, so this \
@@ -927,9 +986,23 @@ fn hot_swap_survives_predecessor_exit_after_readd() {
         "re-added filter should be a new process; the daemon reused pid {old_pid}"
     );
 
-    // Outlast the predecessor's shutdown delay, then confirm its exit
-    // did not take the successor down with it.
-    std::thread::sleep(Duration::from_secs(5));
+    // Wait for the predecessor to actually exit rather than sleeping
+    // past its configured delay and hoping. A blind sleep would assert
+    // the successor survived an exit that may not have happened yet,
+    // which is the same vacuous pass the liveness check above exists to
+    // prevent. `process_alive` returns false once the daemon has reaped
+    // it, which is exactly when the exit event reaches the event loop.
+    wait_for_process_exit(&old_pid, Duration::from_secs(60));
+    assert_eq!(
+        spec.recorded_exits(),
+        vec!["0"],
+        "the predecessor should have exited 0 exactly once; \
+         marker file {:?} says otherwise",
+        spec.marker
+    );
+    // Settle: let the daemon account the exit (and, if the pid guard
+    // regressed, kill the successor) before observing.
+    std::thread::sleep(Duration::from_secs(2));
     let (ok, list_out, stderr) = run_capture(
         Command::new(&dora).args(["node", "list", "--dataflow", name, "--format", "json"]),
         "dora node list after swap",
@@ -980,6 +1053,7 @@ fn hot_swap_survives_predecessor_exit_after_readd() {
 /// failure in the dataflow's history belongs to an incarnation the
 /// operator explicitly removed.
 #[test]
+#[cfg(unix)]
 fn hot_swap_survives_predecessor_exit_before_readd() {
     let _guard = LIFECYCLE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
     let name = "rustlc-swap-early";
@@ -988,7 +1062,7 @@ fn hot_swap_survives_predecessor_exit_before_readd() {
     let dora = start_hot_swap_fixture(name);
     let _cleanup = CleanupGuard { dora: &dora };
 
-    let old_pid = add_filter_and_wait(&dora, name, &broken, "dora node add filter (broken)");
+    let old_pid = add_filter_and_wait(&dora, name, &broken.yml, "dora node add filter (broken)");
 
     // --- the hot swap: remove the broken build, add the fixed one -------
     let (ok, _, stderr) = run_capture(
@@ -1005,10 +1079,24 @@ fn hot_swap_survives_predecessor_exit_before_readd() {
     // one it documents. Waiting for the process to exit rules that out
     // — the exit event is queued before the replacement's CLI round
     // trip even begins, and a slower runner only widens that margin.
-    #[cfg(unix)]
-    wait_for_process_exit(&old_pid, Duration::from_secs(10));
+    wait_for_process_exit(&old_pid, Duration::from_secs(30));
 
-    let new_pid = add_filter_and_wait(&dora, name, &fixed, "dora node re-add filter (fixed)");
+    // Pin the premise: this test is only meaningful if the removed
+    // incarnation exited NON-ZERO, i.e. there is a real failure that
+    // could be misattributed to the successor. Without this the
+    // scenario degrades silently into a plain remove/add — the
+    // `DORA_TEST_STOP_EXIT_CODE` knob getting dropped (env denylisted,
+    // renamed, typo'd) would leave every other assertion below
+    // unchanged and still green.
+    assert_eq!(
+        broken.recorded_exits(),
+        vec!["1"],
+        "the removed incarnation must have exited 1 for this test to mean \
+         anything; marker file {:?} says otherwise",
+        broken.marker
+    );
+
+    let new_pid = add_filter_and_wait(&dora, name, &fixed.yml, "dora node re-add filter (fixed)");
     assert_ne!(
         new_pid, old_pid,
         "re-added filter should be a new process; the daemon reused pid {old_pid}"


### PR DESCRIPTION
## What

Regression coverage for the `dora node remove` → `dora node add` (same id) race reported in dora-rs/dora#2916, plus a CI fix without which none of it — or the existing coverage — runs.

No daemon changes: the reported bug is already fixed on `main`.

## Why

The reporter built from `7eb4a5f8b` (Jul 26). The stale-exit pid guard in dora-rs/dora#2893 landed Jul 30, four days later, and addresses it.

While confirming that, two things turned up:

**1. The reported ordering was untested.** `rust_dynamic_node_readd_same_id_ignores_stale_exit` covers a node that ignores `Stop` and dies to the grace SIGTERM seconds after the re-add. The issue's node honored `Stop` and exited on its own — just slowly enough (Python interpreter teardown) that the exit still landed *after* the re-add. That is the window where the exit gets accounted against the live successor: `handle_node_stop` removes the new `running_nodes` entry, and dropping its `ProcessHandle` SIGKILLs the fresh process.

My first attempt at this test used the existing `filter` fixture and **passed with the pid guard reverted** — it never entered the race, because that node exits ~1 ms after `Stop`, always ahead of the next CLI round trip. Hence the new fixture: `stop-delay-node` takes its shutdown latency and exit code from the descriptor's `env:` block, so the ordering is pinned explicitly instead of inherited from how slow a language runtime happens to be.

**2. The existing regression test never runs in CI.** The e2e job filtered by name (`lifecycle_rust lifecycle_cxx`), which silently drops every test not starting with `lifecycle_` — including the one #2893 shipped with its own fix. Inverting to `--skip lifecycle_python` takes selection from 2 tests to 5 and closes the file by default.

## Test plan

- [x] `hot_swap_survives_predecessor_exit_after_readd` verified **RED** with #2893's pid guard reverted — the re-added node goes `Failed` immediately, matching the reported log — and green with it restored.
- [x] `hot_swap_survives_predecessor_exit_before_readd` passes on unmodified `main`. Noted inline that it holds only incidentally: the removed incarnation's failure *is* recorded under the bare node id and stays there until the successor's own clean exit overwrites it. The assertion guards against that becoming a real contradiction.
- [x] `cargo test -p dora-examples --test node-lifecycle-e2e -- --test-threads=1 --skip lifecycle_python` — the newly selected set passes locally except `lifecycle_cxx_dynamic_add_remove`, which needs a cmake toolchain this machine lacks and was already in CI's selection before this PR.
- [x] `cargo fmt --all -- --check`, `cargo clippy` on the new fixture and test target.
- [x] `lifecycle_python_dynamic_add_remove` fails on this machine, but identically on clean `main` with these changes stashed — pre-existing and environmental, and unaffected by this PR (that test runs in the contract-tests job).

## Notes for reviewers

Two id-keyed paths I traced but did not touch, neither reproducing today:

- `ProcessHandleReplaced` is still keyed by node id alone, so a restart loop from a dead incarnation can overwrite — and thereby drop, hence kill — a live successor's process handle.
- The stale `dataflow_node_results[node_id]` entry above survives if the successor never reports its own result, e.g. a dynamic-node successor.

Happy to file either separately if they're worth tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
