### PR TITLE
fix(node): JSON-escape bare-string input in read_json_bytes_as_arrow

### DIFF
--- a/apis/rust/node/src/daemon_connection/json_to_arrow.rs
+++ b/apis/rust/node/src/daemon_connection/json_to_arrow.rs
@@ -39,10 +39,56 @@ fn wrapped(data: impl BufRead) -> impl BufRead {
     "{ \"inner\":".as_bytes().chain(data).chain("}".as_bytes())
 }
 
-// wrap data into JSON object to also allow bare JSON values
-fn wrapped_quoted(data: impl BufRead) -> impl BufRead {
-    let quoted = "\"".as_bytes().chain(data).chain("\"".as_bytes());
-    wrapped(quoted)
+// wrap data into a JSON object, treating the input as a bare string value.
+//
+// The raw bytes are JSON-encoded (not merely surrounded by quotes) so that
+// strings containing `"`, `\`, newlines, or other control characters still
+// yield *valid* JSON. Previously the bytes were wrapped in literal quotes
+// without escaping, so any such character produced malformed JSON and made
+// schema inference fail — meaning the advertised "bare string" input path
+// only worked for strings with no JSON-special characters.
+fn wrapped_quoted(data: &[u8]) -> impl BufRead {
+    // `from_utf8_lossy` keeps non-UTF-8 input producing valid JSON (via the
+    // replacement character) instead of failing outright. `to_string` on a
+    // string value cannot fail, but fall back defensively just in case.
+    let s = String::from_utf8_lossy(data);
+    let escaped = serde_json::to_string(s.as_ref()).unwrap_or_else(|_| "\"\"".to_string());
+    wrapped(std::io::Cursor::new(escaped.into_bytes()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::read_json_bytes_as_arrow;
+    use arrow::array::{Array, StringArray};
+
+    fn parse_string(input: &str) -> String {
+        let data = read_json_bytes_as_arrow(input.as_bytes())
+            .unwrap_or_else(|e| panic!("failed to parse {input:?}: {e}"));
+        let array = arrow::array::make_array(data);
+        let strings = array
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("expected a string array for bare-string input");
+        assert_eq!(strings.len(), 1);
+        strings.value(0).to_string()
+    }
+
+    #[test]
+    fn bare_string_with_embedded_quotes() {
+        // Regression: the string fallback used to wrap the raw bytes in literal
+        // quotes without escaping, so any embedded `"` produced invalid JSON.
+        assert_eq!(parse_string(r#"he said "hi""#), r#"he said "hi""#);
+    }
+
+    #[test]
+    fn bare_string_with_backslash_and_newline() {
+        assert_eq!(parse_string("a\\b\nc"), "a\\b\nc");
+    }
+
+    #[test]
+    fn plain_string_still_works() {
+        assert_eq!(parse_string("hello"), "hello");
+    }
 }
 
 /// convert the given JSON object to the closed arrow representation


### PR DESCRIPTION
> [!NOTE]
> This PR is **machine-generated by Claude** (an AI agent) as part of an automated code-review pass. Please review carefully before merging.

## Issue

`read_json_bytes_as_arrow` (`apis/rust/node/src/daemon_connection/json_to_arrow.rs`) has a string fallback used when the raw input is not valid JSON: it wraps the input bytes in literal double quotes and re-tries schema inference. The old `wrapped_quoted` did this **without JSON-escaping** the bytes:

```rust
fn wrapped_quoted(data: impl BufRead) -> impl BufRead {
    let quoted = "\"".as_bytes().chain(data).chain("\"".as_bytes());
    wrapped(quoted)
}
```

Any input containing a `"`, `\`, a newline, or another control character therefore produced **malformed JSON**, so `infer_json_schema` failed and the whole call bailed.

This is the path that backs the interactive `Data` prompt's advertised bare-string input. Typing `he said "hi"` produced the wrapper `{ "inner":"he said "hi""}` (invalid JSON), so the input was silently rejected. Same for any multi-line paste. The bare-string path only worked for strings with no JSON-special characters.

## Fix

JSON-encode the bytes as a proper string value instead of raw-quoting them:

```rust
fn wrapped_quoted(data: &[u8]) -> impl BufRead {
    let s = String::from_utf8_lossy(data);
    let escaped = serde_json::to_string(s.as_ref()).unwrap_or_else(|_| "\"\"".to_string());
    wrapped(std::io::Cursor::new(escaped.into_bytes()))
}
```

`from_utf8_lossy` keeps non-UTF-8 input producing valid JSON rather than failing outright.

## Validation

- New regression tests cover embedded quotes, backslash + newline, and a plain string (round-trip through `read_json_bytes_as_arrow` to a `StringArray`).
- `cargo test -p dora-node-api`, `cargo clippy -p dora-node-api -- -D warnings`, `cargo fmt --all -- --check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kn2dEu5y7DbjVNyjCK85pP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kn2dEu5y7DbjVNyjCK85pP)_