### PR TITLE
fix(cli): apply the log level filter before --tail, not after

### DIFF
--- a/binaries/cli/src/command/logs.rs
+++ b/binaries/cli/src/command/logs.rs
@@ -12,8 +12,8 @@ use crate::{
         send_control_request,
     },
     output::{
-        LogFormat, LogOutputConfig, parse_jsonl_line, parse_log_filter, parse_log_level_str,
-        print_log_message,
+        LogFormat, LogOutputConfig, level_filter_is_active, message_passes_level_filter,
+        parse_jsonl_line, parse_log_filter, parse_log_level_str, print_log_message,
     },
     ws_client::WsSession,
 };
@@ -249,7 +249,8 @@ fn read_local_logs(args: &LogsArgs) -> Result<()> {
     all_messages.sort_by_key(|a| a.timestamp);
     let filtered = apply_time_filters(all_messages, args.since, args.until, now);
     let grepped = apply_grep(filtered, args.grep.as_deref());
-    let display = apply_tail(grepped, args.tail);
+    let leveled = apply_level_filter(grepped, &config);
+    let display = apply_tail(leveled, args.tail);
 
     for msg in display {
         print_log_message(msg, &config);
@@ -294,7 +295,8 @@ fn follow_local_logs(args: &LogsArgs) -> Result<()> {
     all_messages.sort_by_key(|a| a.timestamp);
     let filtered = apply_time_filters(all_messages, args.since, args.until, now);
     let grepped = apply_grep(filtered, args.grep.as_deref());
-    let display = apply_tail(grepped, args.tail);
+    let leveled = apply_level_filter(grepped, &config);
+    let display = apply_tail(leveled, args.tail);
 
     for msg in display {
         print_log_message(msg, &config);
@@ -577,6 +579,18 @@ fn apply_grep(messages: Vec<LogMessage>, pattern: Option<&str>) -> Vec<LogMessag
         .collect()
 }
 
+/// Drop messages that the configured minimum-level / per-node level filters
+/// would suppress. This must run *before* `apply_tail` so that `--tail N`
+/// counts only lines that will actually be displayed; otherwise `print_log_message`
+/// applies the level filter after tailing and the visible output can be shorter
+/// than `N` (or empty), even when far more matching lines exist.
+fn apply_level_filter(messages: Vec<LogMessage>, config: &LogOutputConfig) -> Vec<LogMessage> {
+    messages
+        .into_iter()
+        .filter(|msg| message_passes_level_filter(msg, config))
+        .collect()
+}
+
 fn apply_tail(messages: Vec<LogMessage>, tail: Option<usize>) -> Vec<LogMessage> {
     match tail {
         Some(n) => messages
@@ -686,7 +700,8 @@ fn all_nodes_logs_from_coordinator(
     let now = Utc::now();
     let filtered = apply_time_filters(messages, args.since, args.until, now);
     let grepped = apply_grep(filtered, args.grep.as_deref());
-    let display = apply_tail(grepped, args.tail);
+    let leveled = apply_level_filter(grepped, config);
+    let display = apply_tail(leveled, args.tail);
     for msg in display {
         print_log_message(msg, config);
     }
@@ -799,8 +814,16 @@ pub fn logs(
                 uuid: Some(uuid),
                 name: None,
                 node: node.to_string(),
-                tail: if since.is_some() || until.is_some() || grep.is_some() {
-                    // Fetch all logs when filtering client-side, apply tail after
+                tail: if since.is_some()
+                    || until.is_some()
+                    || grep.is_some()
+                    || level_filter_is_active(config)
+                {
+                    // Fetch all logs when filtering client-side, apply tail after.
+                    // The level filter counts here too: pre-tailing at the
+                    // coordinator would trim older matching lines before the
+                    // level filter runs, so `--tail N --level error` could show
+                    // fewer than N (or zero) errors even when many exist.
                     None
                 } else {
                     tail
@@ -816,7 +839,8 @@ pub fn logs(
     let messages: Vec<LogMessage> = content.lines().filter_map(parse_jsonl_line).collect();
     let filtered = apply_time_filters(messages, since, until, now);
     let grepped = apply_grep(filtered, grep);
-    let display = apply_tail(grepped, tail);
+    let leveled = apply_level_filter(grepped, config);
+    let display = apply_tail(leveled, tail);
     for msg in display {
         print_log_message(msg, config);
     }
@@ -1210,5 +1234,57 @@ mod tests {
         assert_eq!(msgs[0].message, "ok");
         // The dangling partial byte is left unconsumed.
         assert_eq!(new_pos, complete.len() as u64);
+    }
+
+    // --- level filter is applied before tail ---
+
+    fn msg_with_level(message: &str, level: log::Level, ts_secs: i64) -> LogMessage {
+        let mut m = make_msg(
+            message,
+            Some("n"),
+            None,
+            DateTime::from_timestamp(ts_secs, 0).unwrap(),
+        );
+        m.level = LogLevelOrStdout::LogLevel(level);
+        m
+    }
+
+    #[test]
+    fn tail_counts_only_level_filtered_lines() {
+        // A few early errors, then many later info lines — the classic case
+        // where a naive "tail then filter" drops every error.
+        let mut messages = vec![
+            msg_with_level("err1", log::Level::Error, 1),
+            msg_with_level("err2", log::Level::Error, 2),
+        ];
+        for i in 0..20 {
+            messages.push(msg_with_level("info", log::Level::Info, 100 + i));
+        }
+
+        let config = LogOutputConfig {
+            min_level: LogLevelOrStdout::LogLevel(log::Level::Error),
+            ..Default::default()
+        };
+
+        // Correct order: filter by level first, then tail.
+        let leveled = apply_level_filter(messages.clone(), &config);
+        let shown = apply_tail(leveled, Some(5));
+        let shown_msgs: Vec<_> = shown.iter().map(|m| m.message.as_str()).collect();
+        assert_eq!(shown_msgs, vec!["err1", "err2"]);
+
+        // The buggy order (tail before filter) would have shown nothing.
+        let tailed_first = apply_tail(messages, Some(5));
+        let then_leveled = apply_level_filter(tailed_first, &config);
+        assert!(then_leveled.is_empty());
+    }
+
+    #[test]
+    fn level_filter_active_predicate() {
+        assert!(!level_filter_is_active(&LogOutputConfig::default()));
+        let restrictive = LogOutputConfig {
+            min_level: LogLevelOrStdout::LogLevel(log::Level::Error),
+            ..Default::default()
+        };
+        assert!(level_filter_is_active(&restrictive));
     }
 }

--- a/binaries/cli/src/command/logs.rs
+++ b/binaries/cli/src/command/logs.rs
@@ -247,10 +247,15 @@ fn read_local_logs(args: &LogsArgs) -> Result<()> {
         all_messages.extend(read_log_file(path)?);
     }
     all_messages.sort_by_key(|a| a.timestamp);
-    let filtered = apply_time_filters(all_messages, args.since, args.until, now);
-    let grepped = apply_grep(filtered, args.grep.as_deref());
-    let leveled = apply_level_filter(grepped, &config);
-    let display = apply_tail(leveled, args.tail);
+    let display = filter_and_tail(
+        all_messages,
+        args.since,
+        args.until,
+        args.grep.as_deref(),
+        &config,
+        args.tail,
+        now,
+    );
 
     for msg in display {
         print_log_message(msg, &config);
@@ -293,10 +298,15 @@ fn follow_local_logs(args: &LogsArgs) -> Result<()> {
         all_messages.extend(read_log_file(path)?);
     }
     all_messages.sort_by_key(|a| a.timestamp);
-    let filtered = apply_time_filters(all_messages, args.since, args.until, now);
-    let grepped = apply_grep(filtered, args.grep.as_deref());
-    let leveled = apply_level_filter(grepped, &config);
-    let display = apply_tail(leveled, args.tail);
+    let display = filter_and_tail(
+        all_messages,
+        args.since,
+        args.until,
+        args.grep.as_deref(),
+        &config,
+        args.tail,
+        now,
+    );
 
     for msg in display {
         print_log_message(msg, &config);
@@ -605,6 +615,29 @@ fn apply_tail(messages: Vec<LogMessage>, tail: Option<usize>) -> Vec<LogMessage>
     }
 }
 
+/// The shared client-side display pipeline used by every non-follow log path:
+/// time filter → grep → level filter → tail, in that order.
+///
+/// `apply_level_filter` MUST come before `apply_tail` so that `--tail N` counts
+/// only lines that will actually be displayed (otherwise the level filter, which
+/// `print_log_message` applies last, can shrink the output below `N` or to
+/// nothing). Routing all four call sites through this single helper keeps that
+/// ordering from drifting apart between them.
+fn filter_and_tail(
+    messages: Vec<LogMessage>,
+    since: Option<std::time::Duration>,
+    until: Option<std::time::Duration>,
+    grep: Option<&str>,
+    config: &LogOutputConfig,
+    tail: Option<usize>,
+    now: DateTime<Utc>,
+) -> Vec<LogMessage> {
+    let filtered = apply_time_filters(messages, since, until, now);
+    let grepped = apply_grep(filtered, grep);
+    let leveled = apply_level_filter(grepped, config);
+    apply_tail(leveled, tail)
+}
+
 fn matches_grep(msg: &LogMessage, pattern: Option<&str>) -> bool {
     let Some(pattern) = pattern else { return true };
     let pattern_lower = pattern.to_lowercase();
@@ -698,10 +731,15 @@ fn all_nodes_logs_from_coordinator(
     messages.sort_by_key(|msg| msg.timestamp);
 
     let now = Utc::now();
-    let filtered = apply_time_filters(messages, args.since, args.until, now);
-    let grepped = apply_grep(filtered, args.grep.as_deref());
-    let leveled = apply_level_filter(grepped, config);
-    let display = apply_tail(leveled, args.tail);
+    let display = filter_and_tail(
+        messages,
+        args.since,
+        args.until,
+        args.grep.as_deref(),
+        config,
+        args.tail,
+        now,
+    );
     for msg in display {
         print_log_message(msg, config);
     }
@@ -837,10 +875,7 @@ pub fn logs(
     let now = Utc::now();
     let content = String::from_utf8_lossy(&logs);
     let messages: Vec<LogMessage> = content.lines().filter_map(parse_jsonl_line).collect();
-    let filtered = apply_time_filters(messages, since, until, now);
-    let grepped = apply_grep(filtered, grep);
-    let leveled = apply_level_filter(grepped, config);
-    let display = apply_tail(leveled, tail);
+    let display = filter_and_tail(messages, since, until, grep, config, tail, now);
     for msg in display {
         print_log_message(msg, config);
     }
@@ -1266,16 +1301,14 @@ mod tests {
             ..Default::default()
         };
 
-        // Correct order: filter by level first, then tail.
-        let leveled = apply_level_filter(messages.clone(), &config);
-        let shown = apply_tail(leveled, Some(5));
+        // Drive the *production* pipeline that all four log paths route through.
+        // If the level filter ran after the tail (the bug), `--tail 5` over these
+        // 22 lines — whose last 5 are all `info` — would display nothing. The two
+        // errors survive only because `filter_and_tail` levels before it tails, so
+        // this asserts the real ordering rather than an isolated composition.
+        let shown = filter_and_tail(messages, None, None, None, &config, Some(5), Utc::now());
         let shown_msgs: Vec<_> = shown.iter().map(|m| m.message.as_str()).collect();
         assert_eq!(shown_msgs, vec!["err1", "err2"]);
-
-        // The buggy order (tail before filter) would have shown nothing.
-        let tailed_first = apply_tail(messages, Some(5));
-        let then_leveled = apply_level_filter(tailed_first, &config);
-        assert!(then_leveled.is_empty());
     }
 
     #[test]

--- a/binaries/cli/src/output.rs
+++ b/binaries/cli/src/output.rs
@@ -46,6 +46,22 @@ fn should_display(
     msg_level.passes(effective_level)
 }
 
+/// Returns whether `msg` passes the configured minimum-level / per-node level
+/// filters. Exposed so the `logs` command can drop filtered-out messages
+/// *before* applying `--tail`, so tail counts only lines that will be shown.
+pub(crate) fn message_passes_level_filter(msg: &LogMessage, config: &LogOutputConfig) -> bool {
+    let node_id_str = msg.node_id.as_ref().map(|n| n.to_string());
+    should_display(&msg.level, node_id_str.as_deref(), config)
+}
+
+/// Returns whether the configured level filters can drop any message. When
+/// this is true, `--tail` must be applied client-side (after filtering) rather
+/// than pre-tailed at the coordinator, otherwise older matching lines are
+/// trimmed away before the level filter ever sees them.
+pub(crate) fn level_filter_is_active(config: &LogOutputConfig) -> bool {
+    !matches!(config.min_level, LogLevelOrStdout::Stdout) || !config.node_filters.is_empty()
+}
+
 pub fn print_log_message(log_message: LogMessage, config: &LogOutputConfig) {
     let node_id_str = log_message.node_id.as_ref().map(|n| n.to_string());
     if !should_display(&log_message.level, node_id_str.as_deref(), config) {


### PR DESCRIPTION
> [!NOTE]
> This PR is **machine-generated by Claude** (an AI agent) as part of an automated code-review pass. Please review carefully before merging.

## Issue

`dora logs --tail N` trimmed to the last `N` lines **before** the minimum-level (`--level`) and per-node (`--log-filter`) filters ran. Those filters are only enforced inside `print_log_message` → `should_display`, which executes *after* `apply_tail`.

As a result, `dora logs --tail 20 --level error` could display **zero** lines even when many error lines exist: `apply_tail` kept the last 20 lines of *all* levels (mostly stdout/info in a healthy run), and the level filter then dropped them all. The local (`--local`), all-nodes, and follow-initial-batch paths had the same defect.

The single-node coordinator path was worse: the level filter was not part of the "fetch everything and tail client-side" decision, so the coordinator itself was asked to pre-tail — discarding older matching lines before the CLI ever saw them.

## Fix

- Add `apply_level_filter` and drop level-filtered messages **before** `apply_tail` in all four log paths (local, follow-local initial batch, all-nodes, single-node).
- Treat an active level filter like the other client-side filters (`since`/`until`/`grep`) when deciding whether to fetch all logs from the coordinator, via a new `level_filter_is_active` helper (`min_level != Stdout` or per-node filters set; the default level is `stdout`, which drops nothing).

## Validation

- New unit tests: `tail_counts_only_level_filtered_lines` (the early-errors-then-many-infos case) and `level_filter_active_predicate`.
- `cargo test -p dora-cli`, `cargo clippy -p dora-cli -- -D warnings`, `cargo fmt --all -- --check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kn2dEu5y7DbjVNyjCK85pP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kn2dEu5y7DbjVNyjCK85pP)_