### PR TITLE
fix(daemon): gate health-check watchdog on node connection (#2937)

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -2699,22 +2699,28 @@ impl Daemon {
                     continue;
                 };
                 let last = node.last_activity.load(atomic::Ordering::Acquire);
-                if last == 0 {
-                    continue; // not yet connected
+                // The health-check watchdog only monitors *post-connection*
+                // liveness. `last_activity` is seeded to the spawn timestamp
+                // (not 0), so a node that has not yet sent its first
+                // `DaemonRequest` would be measured as silent from spawn and
+                // SIGKILLed mid-startup — e.g. a node whose cold start (Python
+                // imports + model-weight load) legitimately exceeds
+                // `health_check_timeout`. Gate the kill on the node having
+                // connected, mirroring the finish-straggler watchdog (#2937).
+                let connected = dataflow.connected_nodes.contains(node_id);
+                if !health_check_should_kill(connected, last, now_millis, timeout) {
+                    continue;
                 }
                 let elapsed_ms = now_millis.saturating_sub(last);
-                let timeout_ms = timeout.as_millis() as u64;
-                if elapsed_ms > timeout_ms {
-                    tracing::warn!(
-                        "node `{node_id}` unresponsive for {}ms (timeout: {timeout:?}), killing",
-                        elapsed_ms,
-                    );
-                    self.ft_stats
-                        .health_check_kills
-                        .fetch_add(1, atomic::Ordering::Relaxed);
-                    if let Some(process) = &node.process {
-                        process.submit(ProcessOperation::Kill);
-                    }
+                tracing::warn!(
+                    "node `{node_id}` unresponsive for {}ms (timeout: {timeout:?}), killing",
+                    elapsed_ms,
+                );
+                self.ft_stats
+                    .health_check_kills
+                    .fetch_add(1, atomic::Ordering::Relaxed);
+                if let Some(process) = &node.process {
+                    process.submit(ProcessOperation::Kill);
                 }
             }
         }
@@ -5859,6 +5865,31 @@ fn is_sigterm_like_exit(exit_status: &NodeExitStatus) -> bool {
     )
 }
 
+/// Decide whether the health-check watchdog should kill a node.
+///
+/// Returns `true` only once the node has **connected** at least once (sent its
+/// first `DaemonRequest`) and has then been silent for longer than `timeout`.
+///
+/// A node that has not yet connected is still starting up and must never be
+/// killed by this watchdog: `last_activity` is seeded to the spawn timestamp
+/// (see `spawner.rs` / `prepared.rs`), so without the `connected` gate the
+/// timeout clock would start ticking at spawn — before the node has had any
+/// chance to communicate — and a node whose legitimate cold start exceeds
+/// `health_check_timeout` would be SIGKILLed mid-startup, mirroring the trap
+/// the finish-straggler watchdog was explicitly fixed for (#2937).
+fn health_check_should_kill(
+    connected: bool,
+    last_activity_millis: u64,
+    now_millis: u64,
+    timeout: Duration,
+) -> bool {
+    if !connected {
+        return false;
+    }
+    let elapsed_ms = now_millis.saturating_sub(last_activity_millis);
+    elapsed_ms > timeout.as_millis() as u64
+}
+
 /// Grace period before the finish-straggler watchdog escalates a stuck node, or
 /// `None` if the watchdog has been explicitly **disabled**.
 ///
@@ -7861,5 +7892,57 @@ mod announce_zenoh_bind_tests {
             sock(REMOTE_COORDINATOR),
         )
         .unwrap();
+    }
+}
+
+#[cfg(test)]
+mod health_check_tests {
+    use super::health_check_should_kill;
+    use std::time::Duration;
+
+    const TIMEOUT: Duration = Duration::from_secs(5);
+
+    #[test]
+    fn not_connected_is_never_killed_even_when_long_silent() {
+        // Regression for #2937: `last_activity` is seeded to the spawn
+        // timestamp, so a node in a slow cold start (imports + model-weight
+        // load) reads as long-silent well before it ever connects. The
+        // watchdog must not kill it while it is still starting up — even if
+        // the elapsed time since spawn already exceeds the timeout.
+        let spawn = 1_000u64;
+        let now = spawn + 10_000; // 10s after spawn, timeout is 5s
+        assert!(!health_check_should_kill(false, spawn, now, TIMEOUT));
+    }
+
+    #[test]
+    fn connected_and_silent_past_timeout_is_killed() {
+        let last = 1_000u64;
+        let now = last + 6_000; // 6s of post-connection silence, timeout 5s
+        assert!(health_check_should_kill(true, last, now, TIMEOUT));
+    }
+
+    #[test]
+    fn connected_and_recently_active_is_not_killed() {
+        let last = 1_000u64;
+        let now = last + 4_000; // 4s < 5s timeout
+        assert!(!health_check_should_kill(true, last, now, TIMEOUT));
+    }
+
+    #[test]
+    fn exactly_at_timeout_is_not_killed() {
+        // The comparison is strictly greater-than, so a node silent for
+        // exactly the timeout is given the benefit of the doubt.
+        let last = 1_000u64;
+        let now = last + 5_000;
+        assert!(!health_check_should_kill(true, last, now, TIMEOUT));
+    }
+
+    #[test]
+    fn clock_skew_does_not_underflow() {
+        // `now` before `last` (clock went backwards) must not panic via
+        // subtraction underflow, and must not be treated as elapsed time.
+        let last = 10_000u64;
+        let now = 1_000u64;
+        assert!(!health_check_should_kill(true, last, now, TIMEOUT));
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -614,7 +614,7 @@ pub enum RestartPolicy {
 - `restart_delay` — initial backoff in seconds (doubles each attempt)
 - `max_restart_delay` — caps exponential backoff
 - `restart_window` — reset counter after N seconds (enables "N restarts per M seconds")
-- `health_check_timeout` — kill node if no activity within this duration
+- `health_check_timeout` — kill node if no activity within this duration, measured only after the node connects (post-connection liveness, not a startup deadline)
 
 ### Health Monitoring
 

--- a/docs/fault-tolerance.md
+++ b/docs/fault-tolerance.md
@@ -139,11 +139,31 @@ Each `RunningNode` has a `last_activity: Arc<AtomicU64>` field storing the times
 The health check function (`check_node_health`) iterates all running nodes:
 
 1. Skip nodes without `health_check_timeout` set
-2. Skip nodes with `last_activity == 0` (not yet connected)
+2. Skip nodes that have not connected yet (not in `connected_nodes`)
 3. Compute `elapsed_ms = now - last_activity`
 4. If `elapsed_ms > timeout_ms`, log a warning and **kill** the node process
 
 After killing, the normal exit handling runs, which evaluates the restart policy. This means `health_check_timeout` combined with `restart_policy: on-failure` automatically recovers hung nodes.
+
+### Post-Connection Liveness Only
+
+Step 2 above means `health_check_timeout` bounds **post-connection** liveness, not
+total startup time. A node joins `connected_nodes` when it first subscribes to
+events (inside `Node::init` / `DoraNode::init_from_env`), and the timeout clock is
+only consulted from that point on.
+
+This is deliberate: `last_activity` is seeded to the spawn timestamp, so without
+the connection gate a node whose legitimate cold start (Python imports,
+model-weight loading) exceeds `health_check_timeout` would be SIGKILLed
+mid-startup -- and under `restart_policy: always`/`on-failure` that becomes an
+unescapable restart loop.
+
+The tradeoff is that a node that hangs **before** it ever subscribes -- a
+deadlock in import or init code that never reaches `Node::init` -- is not
+reaped by this watchdog, and the dataflow stays in its pending state waiting
+for that node. Slow-but-legitimate startup and hung startup are
+indistinguishable before the node connects, so bounding them needs a separate
+startup deadline rather than this timeout.
 
 ### What Counts as "Activity"
 

--- a/docs/yaml-spec.md
+++ b/docs/yaml-spec.md
@@ -272,7 +272,7 @@ For a complete guide to all logging features, see [Logging](logging.md).
 | `restart_delay` | float | -- | Initial backoff in seconds. Doubles each attempt |
 | `max_restart_delay` | float | -- | Cap for exponential backoff |
 | `restart_window` | float | -- | Time window for counting restarts. The counter resets after this many seconds since the first restart in the current window. Enables "N restarts per M seconds" semantics with `max_restarts` |
-| `health_check_timeout` | float | -- | If the node does not communicate with the daemon (send outputs, subscribe, etc.) for this many seconds, the daemon kills the process and evaluates the `restart_policy` |
+| `health_check_timeout` | float | -- | Once the node has connected (subscribed to events), if it then does not communicate with the daemon (send outputs, acknowledge ticks, etc.) for this many seconds, the daemon kills the process and evaluates the `restart_policy`. Covers **post-connection** liveness only -- it does not bound startup time, so a node that hangs before it ever subscribes is not killed |
 
 Restart policies:
 

--- a/guide/src/operations/fault-tolerance.md
+++ b/guide/src/operations/fault-tolerance.md
@@ -139,11 +139,31 @@ Each `RunningNode` has a `last_activity: Arc<AtomicU64>` field storing the times
 The health check function (`check_node_health`) iterates all running nodes:
 
 1. Skip nodes without `health_check_timeout` set
-2. Skip nodes with `last_activity == 0` (not yet connected)
+2. Skip nodes that have not connected yet (not in `connected_nodes`)
 3. Compute `elapsed_ms = now - last_activity`
 4. If `elapsed_ms > timeout_ms`, log a warning and **kill** the node process
 
 After killing, the normal exit handling runs, which evaluates the restart policy. This means `health_check_timeout` combined with `restart_policy: on-failure` automatically recovers hung nodes.
+
+### Post-Connection Liveness Only
+
+Step 2 above means `health_check_timeout` bounds **post-connection** liveness, not
+total startup time. A node joins `connected_nodes` when it first subscribes to
+events (inside `Node::init` / `DoraNode::init_from_env`), and the timeout clock is
+only consulted from that point on.
+
+This is deliberate: `last_activity` is seeded to the spawn timestamp, so without
+the connection gate a node whose legitimate cold start (Python imports,
+model-weight loading) exceeds `health_check_timeout` would be SIGKILLed
+mid-startup -- and under `restart_policy: always`/`on-failure` that becomes an
+unescapable restart loop.
+
+The tradeoff is that a node that hangs **before** it ever subscribes -- a
+deadlock in import or init code that never reaches `Node::init` -- is not
+reaped by this watchdog, and the dataflow stays in its pending state waiting
+for that node. Slow-but-legitimate startup and hung startup are
+indistinguishable before the node connects, so bounding them needs a separate
+startup deadline rather than this timeout.
 
 ### What Counts as "Activity"
 

--- a/libraries/message/src/descriptor.rs
+++ b/libraries/message/src/descriptor.rs
@@ -785,9 +785,15 @@ pub struct Node {
 
     /// Health check timeout in seconds.
     ///
-    /// When set, the daemon monitors this node for activity. If the node does not
-    /// communicate with the daemon within this timeout, it is killed and the restart
-    /// policy is evaluated.
+    /// When set, the daemon monitors this node for activity **once it has
+    /// connected** (i.e. subscribed to events during `Node::init`). If the
+    /// connected node then does not communicate with the daemon within this
+    /// timeout, it is killed and the restart policy is evaluated.
+    ///
+    /// This bounds post-connection liveness only, not startup time: a node
+    /// still in a slow cold start has not connected yet and is never killed by
+    /// this watchdog. A node that hangs before it ever subscribes is therefore
+    /// not reaped here either.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub health_check_timeout: Option<f64>,
 
@@ -1117,9 +1123,15 @@ pub struct CustomNode {
 
     /// Health check timeout in seconds.
     ///
-    /// When set, the daemon monitors this node for activity. If the node does not
-    /// communicate with the daemon within this timeout, it is killed and the restart
-    /// policy is evaluated.
+    /// When set, the daemon monitors this node for activity **once it has
+    /// connected** (i.e. subscribed to events during `Node::init`). If the
+    /// connected node then does not communicate with the daemon within this
+    /// timeout, it is killed and the restart policy is evaluated.
+    ///
+    /// This bounds post-connection liveness only, not startup time: a node
+    /// still in a slow cold start has not connected yet and is never killed by
+    /// this watchdog. A node that hangs before it ever subscribes is therefore
+    /// not reaped here either.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub health_check_timeout: Option<f64>,
 

--- a/tests/fault_tolerance/hang_after_init_node/src/main.rs
+++ b/tests/fault_tolerance/hang_after_init_node/src/main.rs
@@ -1,13 +1,14 @@
 //! Register as a dora node, pull one event to advance the daemon's
-//! `last_activity` past its unarmed-zero state, write an incarnation
-//! marker, then block without draining further events.
+//! `last_activity`, write an incarnation marker, then block without
+//! draining further events.
 //!
-//! The daemon's health check skips nodes whose `last_activity == 0`
-//! ("not yet connected" — binaries/daemon/src/lib.rs:1925), so a node
-//! that registers and immediately hangs is invisible to the health
-//! check. Pumping one event first guarantees `last_activity` holds a
-//! real timestamp, after which the watchdog clock can legitimately
-//! fire when we go silent.
+//! The daemon's health check only monitors nodes that have **connected**
+//! — i.e. subscribed to events (`health_check_should_kill`,
+//! binaries/daemon/src/lib.rs) — so a node that hangs before it ever
+//! subscribes is invisible to the health check. Subscribing and pumping
+//! one event first puts this node in `connected_nodes` and gives
+//! `last_activity` a real post-connection timestamp, after which the
+//! watchdog clock can legitimately fire when we go silent.
 //!
 //! Each incarnation writes a new marker line, so the test can count
 //! how many times the daemon had to kill-and-respawn the node.


### PR DESCRIPTION
Fixes #2937.

## Problem

`Daemon::check_node_health` kills any node whose `last_activity` is older than
its configured `health_check_timeout`. Its only startup guard was
`if last == 0 { continue }` — but `last_activity` is seeded to the spawn
timestamp (`current_millis()`), never `0`, so that guard was dead code. There
was no `connected` check, so the timeout clock started ticking at **spawn**,
before the node had any chance to communicate. A node whose legitimate cold
start (e.g. Python imports + model-weight load) exceeds `health_check_timeout`
was SIGKILLed mid-startup — and under `restart_policy: Always`/`OnFailure` this
became an unescapable restart→kill→restart loop.

This was asymmetric with the sibling finish-straggler watchdog
(`running_dataflow.rs`), which reads the same `last_activity` and was
explicitly given a `connected` gate for exactly this seed-at-spawn trap.

## Fix

Gate the kill on the node having connected (`dataflow.connected_nodes`),
mirroring the straggler watchdog, and drop the dead `last == 0` check. The
decision is extracted into a pure `health_check_should_kill(connected,
last_activity, now, timeout)` helper so it can be unit-tested without a full
`Daemon`. `health_check_timeout` now covers **post-connection** liveness, which
matches the "monitors this node for activity" field wording.

## Tests

Added `health_check_tests` covering: a not-yet-connected node is never killed
even when long-silent past the timeout; a connected+silent node past the
timeout is killed; a connected+recently-active node is not; the boundary
(exactly-at-timeout) is not killed; and clock skew does not underflow.

All 5 pass; `cargo clippy -p dora-daemon -- -D warnings` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PLCvVNoinZn72SBVekMYS

---
_Generated by [Claude Code](https://claude.ai/code/session_012PLCvVNoinZn72SBVekMYS)_