### PR TITLE
fix(memory-pool): unregister host with host_base, not device VA, in broadcast-free cleanup (#2934)

### DIFF
--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -1287,9 +1287,15 @@ impl Node {
                             let _ = bound.call_method1("_ipc_close", (slot.gpu_buf,));
                         }
                     } else if slot.gpu_va != 0 {
+                        // Host-registered mapping (effective_as_cuda branch):
+                        // must cudaHostUnregister before munmap.  _unregister_host
+                        // requires the original host pointer (shmem base), not the
+                        // device VA returned by cudaHostGetDevicePointer — passing
+                        // the device VA makes cudaHostUnregister fail and leaks the
+                        // pin over an address range that then gets munmap'd.
                         if let Ok(helpers) = get_cuda_helpers(py) {
                             let bound = helpers.bind(py);
-                            let _ = bound.call_method1("_unregister_host", (slot.gpu_va,));
+                            let _ = bound.call_method1("_unregister_host", (slot.host_base,));
                         }
                     }
                     // Drop slot → munmap
@@ -2074,11 +2080,13 @@ impl Node {
                     dtoh_copy_ok = false;
                 }
                 if !dtoh_copy_ok {
-                    if !is_pinned {
-                        if let Ok(helpers) = get_cuda_helpers(py) {
-                            let bound = helpers.bind(py);
-                            let _ = bound.call_method1("_unregister_host", (shmem_ptr as u64,));
-                        }
+                    // The matching `_register_host` above is unconditional (it
+                    // runs whenever `!receiver_is_cuda`), so the unregister must
+                    // be too — gating it on `!is_pinned` would leak the pin if
+                    // `should_pin` is ever tuned to pin CUDA sources.
+                    if let Ok(helpers) = get_cuda_helpers(py) {
+                        let bound = helpers.bind(py);
+                        let _ = bound.call_method1("_unregister_host", (shmem_ptr as u64,));
                     }
                     shmem.set_owner(true);
                     eyre::bail!(


### PR DESCRIPTION
Fixes #2934.

## Problem

The cross-process cleanup path added in #2619 (`process_pending_memory_pool_frees`,
the handler for the daemon-broadcast `NodeEvent::FreeMemoryPool`) called
`cudaHostUnregister` (`_unregister_host`) with the **device virtual address**
(`slot.gpu_va`) instead of the **original host pointer** (`slot.host_base`) that
was registered with `cudaHostRegister`.

`cudaHostUnregister` then fails with `cudaErrorHostMemoryNotRegistered`, the
error is swallowed by `let _ = …`, and the slot drops — `munmap`ping memory
that is still pinned in the CUDA driver. The result is a pinned-memory leak
plus a dangling pinned registration over an address range that can be reused.
On UVA systems where `gpu_va == host_base` this is coincidentally masked, so the
failure is intermittent and hardware-dependent.

The sibling cleanup in `free_memory_pool` does this correctly (passes
`slot.host_base`) and even carries a comment describing exactly this pitfall;
the broadcast-free path diverged.

## Fix

- Pass `slot.host_base` in the broadcast-free path, mirroring the correct
  sibling, with the same explanatory comment.
- Related latent fix flagged in the report: in `register_memory_pool`, the
  DtoH-failure cleanup gated `_unregister_host` on `!is_pinned` while the
  corresponding `_register_host` call is unconditional. The unregister is now
  unconditional to match, so a future change to `should_pin` (to pin CUDA
  sources) cannot leak a pin on a large-tensor DtoH failure.

## Testing

The GPU memory-pool paths are `#[ignore]`-gated (require CUDA hardware), so this
is a targeted correctness fix verified against the working sibling path; no new
automated test exercises the CUDA branch in CI. `cargo check -p
dora-node-api-python` compiles cleanly (the pre-existing warnings are unrelated
to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PLCvVNoinZn72SBVekMYS

---
_Generated by [Claude Code](https://claude.ai/code/session_012PLCvVNoinZn72SBVekMYS)_