### PR TITLE
fix(cli): emit `dora node list --format json` as a single JSON array (#2922)

### DIFF
--- a/binaries/cli/src/command/node/list.rs
+++ b/binaries/cli/src/command/node/list.rs
@@ -23,7 +23,7 @@ use dora_message::{cli_to_coordinator::ControlRequest, coordinator_to_cli::NodeI
 /// List nodes in a specific dataflow:
 ///   dora node list --dataflow my-dataflow
 ///
-/// List nodes as JSON:
+/// List nodes as a JSON array (parses as a single JSON document):
 ///   dora node list --format json
 #[derive(Debug, Args)]
 #[clap(verbatim_doc_comment)]
@@ -188,11 +188,55 @@ fn list(
             tw.flush()?;
         }
         OutputFormat::Json => {
-            for entry in entries {
-                println!("{}", serde_json::to_string(&entry)?);
-            }
+            // Emit a single JSON document (an array) rather than JSON Lines, so
+            // callers can parse the whole output with one `json.loads` — the
+            // common `--format json` contract, and consistent with sibling
+            // `dora node info --format json`. An empty result prints `[]`.
+            println!("{}", serde_json::to_string_pretty(&entries)?);
         }
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OutputEntry;
+
+    fn entry(node: &str) -> OutputEntry {
+        OutputEntry {
+            node: node.to_string(),
+            status: "Running".to_string(),
+            pid: "42".to_string(),
+            cpu: "1.0%".to_string(),
+            memory: "10 MB".to_string(),
+            restarts: "0".to_string(),
+            dataflow: None,
+        }
+    }
+
+    #[test]
+    fn json_output_is_a_single_array_document() {
+        // Regression for #2922: `--format json` used to emit JSON Lines (one
+        // object per line), which does not parse with a single `json.loads`.
+        // The whole output must now be one JSON document — an array.
+        let entries = vec![entry("a"), entry("b")];
+        let rendered = serde_json::to_string_pretty(&entries).unwrap();
+
+        let parsed: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+        let arr = parsed
+            .as_array()
+            .expect("output must parse as a JSON array");
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["node"], "a");
+        assert_eq!(arr[1]["node"], "b");
+    }
+
+    #[test]
+    fn empty_json_output_is_an_empty_array() {
+        let entries: Vec<OutputEntry> = Vec::new();
+        let rendered = serde_json::to_string_pretty(&entries).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+        assert_eq!(parsed.as_array().map(|a| a.len()), Some(0));
+    }
 }


### PR DESCRIPTION
Fixes #2922.

## Problem

`dora node list --format json` printed one JSON object per line (JSON Lines),
not a single JSON document. Callers that reasonably expect `--format json` to
mean "the output parses as one JSON document" (a common convention) fail with a
single `json.loads`.

## Fix

Emit the entries as a single pretty-printed JSON **array**, matching the sibling
`dora node info --format json` (which already serializes its whole output as one
document via `serde_json::to_string_pretty`). An empty result now prints `[]`
rather than nothing, so the output always parses. The command help is updated to
state the array contract explicitly.

## Tests

Added unit tests asserting the JSON output parses as a single JSON array (and
round-trips the entries), and that an empty result serializes to `[]`.

Both pass; `cargo clippy -p dora-cli -- -D warnings` and `cargo fmt` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PLCvVNoinZn72SBVekMYS

---
_Generated by [Claude Code](https://claude.ai/code/session_012PLCvVNoinZn72SBVekMYS)_