### PR TITLE
fix(core): don't resolve symlinks in node paths, so venv interpreters keep their venv

### DIFF
--- a/binaries/cli/src/command/start/attach.rs
+++ b/binaries/cli/src/command/start/attach.rs
@@ -51,6 +51,15 @@ pub fn attach_dataflow(
                             .wrap_err_with(|| {
                                 format!("failed to resolve node source `{}`", python_source.source)
                             })?;
+                        // Canonicalize for the WATCH MAP only: `notify`
+                        // backends (FSEvents in particular) report real
+                        // paths, and the lookup below is a plain `==` on
+                        // the event path. Since #2918 `resolve_path` no
+                        // longer canonicalizes (exec must preserve venv
+                        // symlinks), so a symlinked or `..`-containing
+                        // source would silently never match its own
+                        // modification events without this.
+                        let path = path.canonicalize().unwrap_or(path);
                         node_path_lookup
                             .insert(path, (dataflow_id, node.id.clone(), Some(op.id.clone())));
                     }

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -396,9 +396,17 @@ pub fn resolve_path(source: &str, working_dir: &Path) -> Result<PathBuf> {
         path.to_owned()
     };
 
-    // Search path within current working directory
-    if let Ok(abs_path) = working_dir.join(&path).canonicalize() {
-        Ok(abs_path)
+    // Search path within current working directory. Deliberately NOT
+    // `canonicalize()`: that follows symlinks, and a virtualenv's
+    // `bin/python` is a symlink whose *location* is what CPython uses to
+    // discover `pyvenv.cfg`. Resolving it before exec runs the base
+    // interpreter with no venv, so imports that work in a shell fail
+    // under dora (dora-rs/dora#2918). `path::absolute` only prepends the
+    // cwd and drops `.` components; symlinks and `..` are left for the
+    // kernel to resolve at exec time, which matches shell behavior.
+    let joined = working_dir.join(&path);
+    if joined.exists() {
+        std::path::absolute(&joined).map_err(Into::into)
     // Otherwise resolve against the `uv`-managed environment first (when `uv`
     // is available), then fall back to the system `$PATH`.
     } else if which::which("uv").is_ok() {
@@ -702,6 +710,44 @@ nodes:
         assert!(
             result.is_err(),
             "expected Err for a binary that exists nowhere, got {result:?}"
+        );
+    }
+
+    /// dora-rs/dora#2918: resolving a node path must NOT follow symlinks.
+    ///
+    /// A virtualenv's `bin/python` is a symlink to the base interpreter,
+    /// and CPython's venv discovery hinges on that: it looks for
+    /// `pyvenv.cfg` relative to the path it was *invoked* as, not the
+    /// symlink's target. Canonicalizing before exec therefore runs the
+    /// base interpreter with no venv — imports that work in a shell
+    /// (`.venv/bin/python -c "import numpy"`) fail under dora with
+    /// `ModuleNotFoundError`.
+    #[test]
+    #[cfg(unix)]
+    fn resolve_path_preserves_symlinks() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let target = tmp.path().join("base-interpreter.bin");
+        std::fs::write(&target, b"x").unwrap();
+        let link = tmp.path().join("venv-python.bin");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        // relative source resolved against the working dir
+        let resolved = resolve_path("venv-python.bin", tmp.path()).unwrap();
+        assert!(resolved.is_absolute());
+        assert!(
+            resolved.ends_with("venv-python.bin"),
+            "resolve_path followed the symlink: {} — venv discovery \
+             (pyvenv.cfg) is keyed off the symlink location, so execing \
+             the target bypasses the venv",
+            resolved.display()
+        );
+
+        // absolute source (the shape from the issue: `path: /…/.venv/bin/python`)
+        let resolved = resolve_path(link.to_str().unwrap(), Path::new("/")).unwrap();
+        assert!(
+            resolved.ends_with("venv-python.bin"),
+            "absolute symlink path was canonicalized: {}",
+            resolved.display()
         );
     }
 

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -396,17 +396,10 @@ pub fn resolve_path(source: &str, working_dir: &Path) -> Result<PathBuf> {
         path.to_owned()
     };
 
-    // Search path within current working directory. Deliberately NOT
-    // `canonicalize()`: that follows symlinks, and a virtualenv's
-    // `bin/python` is a symlink whose *location* is what CPython uses to
-    // discover `pyvenv.cfg`. Resolving it before exec runs the base
-    // interpreter with no venv, so imports that work in a shell fail
-    // under dora (dora-rs/dora#2918). `path::absolute` only prepends the
-    // cwd and drops `.` components; symlinks and `..` are left for the
-    // kernel to resolve at exec time, which matches shell behavior.
+    // Search path within current working directory.
     let joined = working_dir.join(&path);
     if joined.exists() {
-        std::path::absolute(&joined).map_err(Into::into)
+        absolutize_preserving_symlinks(&joined)
     // Otherwise resolve against the `uv`-managed environment first (when `uv`
     // is available), then fall back to the system `$PATH`.
     } else if which::which("uv").is_ok() {
@@ -482,13 +475,37 @@ fn confine(candidate: &Path, root: &Path) -> Result<PathBuf> {
     Ok(resolved)
 }
 
+/// Make an existing executable path absolute WITHOUT following symlinks.
+///
+/// Deliberately not `canonicalize()`: that resolves symlinks, and a
+/// virtualenv's `bin/python` is a symlink whose *location* is what
+/// CPython uses to discover `pyvenv.cfg`. Resolving it before exec runs
+/// the base interpreter with no venv, so imports that work in a shell
+/// fail under dora (dora-rs/dora#2918). `path::absolute` only prepends
+/// the cwd and drops `.` components; symlinks and `..` are left for the
+/// kernel to resolve at exec time, which matches shell behavior.
+///
+/// Errors if the path does not exist (`exists()` traverses symlinks, so
+/// a dangling link counts as missing — same outcome canonicalize gave).
+/// Shared by every [`resolve_path`] branch so the no-symlink-resolution
+/// contract cannot regress in one branch while the tests exercise
+/// another.
+fn absolutize_preserving_symlinks(path: &Path) -> Result<PathBuf> {
+    if !path.exists() {
+        bail!("path {} does not exist", path.display());
+    }
+    std::path::absolute(path)
+        .with_context(|| format!("failed to make path {} absolute", path.display()))
+}
+
 /// Resolve `path` against the `uv`-managed environment by running
 /// `uv run which <path>`, returning an absolute path.
 ///
 /// Unlike a fire-and-forget spawn, this waits for the child, checks its
-/// exit status (so a missing binary surfaces as an error), and canonicalizes
-/// the captured location so the result matches the absolute-path contract of
-/// the other [`resolve_path`] branches.
+/// exit status (so a missing binary surfaces as an error), and verifies
+/// the captured location exists — without resolving symlinks, which
+/// would reintroduce the venv bypass fixed for the working-dir branch
+/// (dora-rs/dora#2918).
 fn resolve_path_via_uv(path: &Path) -> Result<PathBuf> {
     let which = if cfg!(windows) { "where" } else { "which" };
     let output = Command::new("uv")
@@ -508,9 +525,8 @@ fn resolve_path_via_uv(path: &Path) -> Result<PathBuf> {
         .map(str::trim)
         .find(|line| !line.is_empty())
         .ok_or_else(|| eyre::eyre!("`uv run {which} {}` produced no output", path.display()))?;
-    PathBuf::from(resolved)
-        .canonicalize()
-        .with_context(|| format!("failed to canonicalize uv-resolved path {resolved}"))
+    absolutize_preserving_symlinks(Path::new(resolved))
+        .with_context(|| format!("uv-resolved path {resolved} is not usable"))
 }
 
 pub trait NodeExt {
@@ -748,6 +764,39 @@ nodes:
             resolved.ends_with("venv-python.bin"),
             "absolute symlink path was canonicalized: {}",
             resolved.display()
+        );
+
+        // `..` components survive too: they are resolved by the kernel at
+        // exec time, AFTER any symlinked directories — which is the
+        // shell-matching semantic. A lexical "cleanup" that collapses
+        // them would resolve differently through symlinked dirs.
+        std::fs::create_dir(tmp.path().join("sub")).unwrap();
+        let resolved = resolve_path("sub/../venv-python.bin", tmp.path()).unwrap();
+        assert!(
+            resolved.ends_with("sub/../venv-python.bin"),
+            "`..` was normalized away: {}",
+            resolved.display()
+        );
+    }
+
+    /// A dangling symlink is "missing": `exists()` traverses the link, so
+    /// resolution falls through to the uv/$PATH branches and ultimately
+    /// errors — the same outcome the old `canonicalize()` failure gave.
+    /// Pins the branch boundary so a switch to `symlink_metadata()`
+    /// (which would treat the dangling link as present and exec a
+    /// guaranteed-ENOENT path) doesn't slip in silently.
+    #[test]
+    #[cfg(unix)]
+    fn resolve_path_treats_dangling_symlink_as_missing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let link = tmp.path().join("dangling-2918-regression.bin");
+        std::os::unix::fs::symlink(tmp.path().join("no-such-target"), &link).unwrap();
+
+        let result = resolve_path("dangling-2918-regression.bin", tmp.path());
+        assert!(
+            result.is_err(),
+            "a dangling symlink must not resolve (nothing on uv/$PATH matches \
+             this name either), got {result:?}"
         );
     }
 

--- a/tests/node-lifecycle-e2e.rs
+++ b/tests/node-lifecycle-e2e.rs
@@ -1332,6 +1332,26 @@ fn venv_interpreter_path_runs_inside_the_venv() {
     let target = Path::new(manifest_dir).join("target");
     let stem = format!("dora-venv-2918-{}", std::process::id());
 
+    // The artifacts are pid-suffixed, so a previous run's venv (a few MB)
+    // is never reused — reclaim any stale ones instead of accumulating
+    // one per invocation until `cargo clean`.
+    if let Ok(entries) = fs::read_dir(&target) {
+        for entry in entries.flatten() {
+            if entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with("dora-venv-2918-")
+            {
+                let path = entry.path();
+                let _ = if path.is_dir() {
+                    fs::remove_dir_all(&path)
+                } else {
+                    fs::remove_file(&path)
+                };
+            }
+        }
+    }
+
     let venv = target.join(format!("{stem}-venv"));
     let status = Command::new("python3")
         .args(["-m", "venv", "--without-pip"])
@@ -1384,7 +1404,7 @@ fn venv_interpreter_path_runs_inside_the_venv() {
     let _cleanup = CleanupGuard { dora: &dora };
     add_node(&dora, name, &spec, "dora node add venvprobe");
 
-    let deadline = std::time::Instant::now() + Duration::from_secs(20);
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
     while !marker.exists() {
         assert!(
             std::time::Instant::now() < deadline,

--- a/tests/node-lifecycle-e2e.rs
+++ b/tests/node-lifecycle-e2e.rs
@@ -1307,6 +1307,107 @@ fn crash_before_subscribe_does_not_kill_the_startup_cohort() {
     );
 }
 
+/// dora-rs/dora#2918: a node whose `path:` is a virtualenv interpreter
+/// must actually run inside that venv.
+///
+/// A venv's `bin/python` is a symlink, and CPython finds `pyvenv.cfg`
+/// relative to the path it was *invoked* as — that is the entire venv
+/// mechanism. `resolve_path` used to `canonicalize()` before exec, which
+/// resolved the symlink and ran the base interpreter instead: imports
+/// that worked in a shell (`.venv/bin/python -c "import numpy"`) failed
+/// under dora with `ModuleNotFoundError`, and the documented escape
+/// hatch for giving a dynamic node an explicit environment didn't work.
+///
+/// The probe is not a dora node (that would need dora-rs installed into
+/// the scratch venv — network, plus the PyPI/workspace drift from
+/// #1710). It writes `sys.prefix` to a marker and exits; the daemon
+/// marks it Failed, which post-#2933 harms nothing, and the marker tells
+/// us which interpreter really ran. The venv is created with
+/// `--without-pip`, so this needs only a bare `python3`.
+#[test]
+#[cfg(unix)]
+fn venv_interpreter_path_runs_inside_the_venv() {
+    let _guard = LIFECYCLE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let target = Path::new(manifest_dir).join("target");
+    let stem = format!("dora-venv-2918-{}", std::process::id());
+
+    let venv = target.join(format!("{stem}-venv"));
+    let status = Command::new("python3")
+        .args(["-m", "venv", "--without-pip"])
+        .arg(&venv)
+        .status()
+        .expect("failed to run python3 -m venv");
+    assert!(status.success(), "python3 -m venv failed");
+    let venv_python = venv.join("bin/python");
+    assert!(
+        venv_python
+            .symlink_metadata()
+            .expect("venv python missing")
+            .file_type()
+            .is_symlink(),
+        "test premise: {} should be a symlink (venvs on unix)",
+        venv_python.display()
+    );
+
+    let probe = target.join(format!("{stem}-probe.py"));
+    let marker = target.join(format!("{stem}-prefix.txt"));
+    let _ = fs::remove_file(&marker);
+    fs::write(
+        &probe,
+        "import sys, os\nopen(os.environ['PROBE_OUT'], 'w').write(sys.prefix)\n",
+    )
+    .expect("failed to write probe script");
+
+    // The probe interpreter itself is not a `.py` path, so the yaml's
+    // `path:` is the venv python and the script rides in `args:` —
+    // exactly the shape from the issue report.
+    let spec = target.join(format!("{stem}.yml"));
+    fs::write(
+        &spec,
+        format!(
+            "id: venvprobe\n\
+             path: {python}\n\
+             args: {probe}\n\
+             env:\n  \
+               PROBE_OUT: {marker}\n\
+             outputs:\n  - value\n",
+            python = venv_python.display(),
+            probe = probe.display(),
+            marker = marker.display(),
+        ),
+    )
+    .expect("failed to write node spec");
+
+    let name = "rustlc-venv";
+    let dora = start_hot_swap_fixture(name);
+    let _cleanup = CleanupGuard { dora: &dora };
+    add_node(&dora, name, &spec, "dora node add venvprobe");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
+    while !marker.exists() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "probe never ran — check `dora logs {name} --node venvprobe`"
+        );
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    let prefix = fs::read_to_string(&marker).expect("failed to read marker");
+    // Compare on canonicalized forms: sys.prefix reflects how CPython
+    // resolved the venv dir, which may differ from our path in /tmp
+    // symlinkage (e.g. /tmp vs /private/tmp on macOS).
+    let got = Path::new(prefix.trim())
+        .canonicalize()
+        .unwrap_or_else(|_| std::path::PathBuf::from(prefix.trim()));
+    let want = venv.canonicalize().expect("venv path should canonicalize");
+    assert_eq!(
+        got, want,
+        "the spawned node ran OUTSIDE its venv: sys.prefix is {got:?} instead of the \
+         venv — the interpreter symlink was resolved before exec, bypassing pyvenv.cfg \
+         discovery (#2918)"
+    );
+}
+
 /// Removing a node that has not yet subscribed must release the startup
 /// barrier — the `RemoveNode` wiring, which no other test covers.
 ///


### PR DESCRIPTION
## What

`resolve_path` canonicalized the node executable path before exec. A virtualenv's `bin/python` is a symlink, and CPython finds `pyvenv.cfg` relative to the path it was *invoked* as — that indirection is the entire venv mechanism. Canonicalizing resolved the symlink and ran the base interpreter with no venv, so `path: .venv/bin/python` silently lost its environment:

```
$ .venv/bin/python -c "import numpy"          # works in a shell
# under dora:  ModuleNotFoundError: No module named 'numpy'
```

Addresses the second ask in #2918 (no closing keyword — the first ask is discussed below and the reporter should confirm on their pipeline before closing). Not specific to dynamic adds: every spawn goes through `resolve_path`, so a *static* node pointing at a venv interpreter was equally broken.

## The fix

`std::path::absolute` instead of `canonicalize()`: prepends the cwd, strips `.`, and leaves symlinks and `..` for the kernel to resolve at exec time — how a shell would invoke the same path. The existence check gating the fall-through to uv/`$PATH` resolution is preserved.

Deliberately untouched: `resolve_path_confined` (hub nodes), where canonicalization is a security measure against symlink escapes; and the post-download `canonicalize()` calls, where no venv symlink semantics exist.

## On the issue's first ask (`--uv` inheritance)

Traced and partially disproved: the coordinator already forwards the dataflow's `--uv` flag on `AddNode` (`uv: dataflow.uv`), and did at the reporter's rev. What remains true is that a build-less dynamic `.py` node gets `uv run python` resolved from the dataflow working directory, which is not necessarily the environment its static peers use — there is no single "dataflow env" to inherit, since managed envs are per-node (keyed by `build:`). The reliable way to hand a dynamic node a specific environment is exactly `path: <venv>/bin/python` — which this PR makes work.

## Test plan

Both tests verified in both directions by stashing only the `dora-core` change:

| Test | Without fix | With fix |
|---|---|---|
| `resolve_path_preserves_symlinks` (unit, relative + absolute shapes) | FAILED | ok |
| `venv_interpreter_path_runs_inside_the_venv` (e2e, real daemon spawn) | `sys.prefix is "/opt/anaconda3/envs/aisle"` | ok |

The e2e creates a scratch venv with `python3 -m venv --without-pip` (no network, no pip), adds a node whose `path:` is the venv symlink with the script in `args:` — the exact shape from the issue — and asserts the marker file the probe writes contains the venv's `sys.prefix`. The probe is deliberately not a dora node (that would need dora-rs installed into the venv, hitting the #1710 PyPI/workspace drift); post-#2933 a pre-register exit is harmless to the dataflow.

- [x] `cargo test -p dora-core` — 264 passed
- [x] `node-lifecycle-e2e --skip lifecycle_python` — 8/9 (`lifecycle_cxx` at its cmake step, pre-existing macOS linker issue)
- [x] `fault-tolerance-e2e` — 11/11 (spawn-heavy, exercises the changed path on every node)
- [x] fmt + clippy clean

## Behavior note

Spawn log lines may now show un-normalized paths (`examples/foo/../../target/debug/bin`) where they previously showed the canonical form. Exec behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
