### PR TITLE
fix(cli): escalate `dora record` on a repeated Ctrl-C

### DIFF
--- a/binaries/cli/src/command/record.rs
+++ b/binaries/cli/src/command/record.rs
@@ -414,15 +414,26 @@ fn run_record_proxy(args: Record) -> eyre::Result<()> {
     // Set up Ctrl-C handler.
     //
     // The first Ctrl-C requests a graceful stop (finalize the recording and
-    // exit). Escalate on a repeated signal — mirroring the daemon, coordinator,
-    // and `dora start` attach handlers — so an operator is never stuck: the
+    // exit). Escalate on a repeated signal — as the daemon, coordinator, and
+    // `dora start` attach handlers all do — so an operator is never stuck: the
     // recording loop does blocking file I/O between poll ticks, and a write that
     // wedges (full disk, stalled network mount, a large flush) would otherwise
     // swallow every subsequent Ctrl-C with no way out but SIGKILL from another
     // terminal. The second signal exits immediately with the conventional SIGINT
     // status; the partial file is left in place, but the message warns that it
-    // may be truncated so `dora replay` is not handed a half-written file
-    // silently.
+    // may be truncated so the operator knows `dora replay` will get a short
+    // recording (a missing footer is tolerated by `RecordingReader`, and the
+    // flush before `finish()` below bounds the loss to the footer).
+    //
+    // Two deliberate departures from those siblings, both because what wedges
+    // here is our own teardown rather than a child process:
+    //   * `process::exit` rather than the daemon's unwinding `bail!` — the
+    //     thing being escaped IS `writer.finish()`, so unwinding through it
+    //     would re-enter the wedge. Nothing here owns child processes to
+    //     orphan.
+    //   * exit 130 (128 + SIGINT) rather than the attach handler's 1, so a
+    //     supervisor can tell an operator abort from a recording error. This
+    //     is the only place in the CLI that returns it; see docs/cli.md.
     let (stop_tx, stop_rx) = std::sync::mpsc::channel();
     let mut signalled = false;
     ctrlc::set_handler(move || match record_ctrlc_action(&mut signalled) {
@@ -482,6 +493,17 @@ fn run_record_proxy(args: Record) -> eyre::Result<()> {
             Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
         }
     }
+
+    // Flush before the blocking finalize, not as part of it. `finish()` writes
+    // the buffered tail AND the footer, and it is the call most likely to wedge
+    // (full disk, stalled network mount) — which is exactly when an operator
+    // reaches for the second Ctrl-C. Escalating out of an unflushed `finish()`
+    // discards every entry since the last 100-message flush: with fewer than
+    // 100 messages recorded that is the whole file, and `dora replay` then
+    // fails with "failed to read recording header" rather than replaying a
+    // short recording. Flushing here bounds what escalation can cost to the
+    // 24-byte footer, which readers already tolerate.
+    writer.flush()?;
 
     let footer = writer.finish()?;
     eprintln!(

--- a/binaries/cli/src/command/record.rs
+++ b/binaries/cli/src/command/record.rs
@@ -386,9 +386,26 @@ fn run_record_proxy(args: Record) -> eyre::Result<()> {
 
     eprintln!("Recording... (press Ctrl-C to stop)");
 
-    // Set up Ctrl-C handler
+    // Set up Ctrl-C handler.
+    //
+    // The first Ctrl-C requests a graceful stop (finalize the recording and
+    // exit). Escalate on a repeated signal — mirroring the daemon, coordinator,
+    // and `dora start` attach handlers — so an operator is never stuck: the
+    // recording loop does blocking file I/O between poll ticks, and a write that
+    // wedges (full disk, stalled network mount, a large flush) would otherwise
+    // swallow every subsequent Ctrl-C with no way out but SIGKILL from another
+    // terminal. The second signal exits immediately with the conventional SIGINT
+    // status; the partial file is left in place, but the message warns that it
+    // may be truncated so `dora replay` is not handed a half-written file
+    // silently.
     let (stop_tx, stop_rx) = std::sync::mpsc::channel();
+    let mut signalled = false;
     ctrlc::set_handler(move || {
+        if signalled {
+            eprintln!("received second Ctrl-C -> exiting immediately (recording may be truncated)");
+            std::process::exit(130);
+        }
+        signalled = true;
         let _ = stop_tx.send(());
     })
     .wrap_err("failed to set ctrl-c handler")?;

--- a/binaries/cli/src/command/record.rs
+++ b/binaries/cli/src/command/record.rs
@@ -253,6 +253,31 @@ fn run_record(args: Record) -> eyre::Result<()> {
         .execute()
 }
 
+/// What a Ctrl-C on the recording loop should do, given whether one was already
+/// seen. Split out from the signal handler so the escalation state machine is
+/// unit-testable without delivering a real signal (which also exits the process
+/// via `process::exit`, and races the handler-installation window).
+#[derive(Debug, PartialEq, Eq)]
+enum CtrlCAction {
+    /// First Ctrl-C: request a graceful stop (finalize the recording).
+    RequestStop,
+    /// Repeated Ctrl-C: give up and exit immediately, even if a write is wedged.
+    ExitImmediately,
+}
+
+/// Advance the Ctrl-C escalation state: the first call requests a stop, every
+/// later call escalates. Taking `&mut bool` is deliberate — the handler owns
+/// the flag across invocations, so dropping the `mut` there would fail to
+/// compile rather than silently disabling escalation.
+fn record_ctrlc_action(signalled: &mut bool) -> CtrlCAction {
+    if *signalled {
+        CtrlCAction::ExitImmediately
+    } else {
+        *signalled = true;
+        CtrlCAction::RequestStop
+    }
+}
+
 fn run_record_proxy(args: Record) -> eyre::Result<()> {
     let yaml_bytes =
         std::fs::read(&args.file).wrap_err_with(|| format!("failed to read {}", args.file))?;
@@ -400,13 +425,14 @@ fn run_record_proxy(args: Record) -> eyre::Result<()> {
     // silently.
     let (stop_tx, stop_rx) = std::sync::mpsc::channel();
     let mut signalled = false;
-    ctrlc::set_handler(move || {
-        if signalled {
+    ctrlc::set_handler(move || match record_ctrlc_action(&mut signalled) {
+        CtrlCAction::RequestStop => {
+            let _ = stop_tx.send(());
+        }
+        CtrlCAction::ExitImmediately => {
             eprintln!("received second Ctrl-C -> exiting immediately (recording may be truncated)");
             std::process::exit(130);
         }
-        signalled = true;
-        let _ = stop_tx.send(());
     })
     .wrap_err("failed to set ctrl-c handler")?;
 
@@ -538,6 +564,27 @@ mod tests {
             uuid: Uuid::new_v4(),
             name: name.map(str::to_string),
         }
+    }
+
+    #[test]
+    fn ctrlc_requests_stop_first_then_escalates() {
+        // The recording loop's Ctrl-C handler must ask for a graceful stop on
+        // the first signal and escalate to an immediate exit on every one
+        // after — so a wedged write can't swallow repeated Ctrl-C. Pins the
+        // state machine without a real signal (#2952).
+        let mut signalled = false;
+        assert_eq!(
+            record_ctrlc_action(&mut signalled),
+            CtrlCAction::RequestStop
+        );
+        assert_eq!(
+            record_ctrlc_action(&mut signalled),
+            CtrlCAction::ExitImmediately
+        );
+        assert_eq!(
+            record_ctrlc_action(&mut signalled),
+            CtrlCAction::ExitImmediately
+        );
     }
 
     #[test]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -462,6 +462,8 @@ dora record <DATAFLOW_YAML> [OPTIONS]
 
 Default mode injects a record node into the dataflow. `--proxy` mode requires a running dataflow and `enable_debug_inspection: true`.
 
+**Ctrl-C in `--proxy` mode:** the first press stops the recording and finalizes the file. A second press exits immediately with status `130`, for the case where finalizing is itself stuck (a full disk or a stalled network mount). The recording is flushed before finalizing, so an escalated exit costs only the file's footer — `dora replay` still reads it, as a recording that ends early.
+
 #### `dora replay`
 
 Replay a recorded `.drec` file by replacing source nodes with replay nodes. See [Debugging Guide](debugging.md#replaying-a-recording) for full workflows.


### PR DESCRIPTION
## Summary

Fixes #2952.

`dora record`'s SIGINT handler (`binaries/cli/src/command/record.rs`) only sent a stop request and then swallowed every subsequent Ctrl-C:

```rust
ctrlc::set_handler(move || {
    let _ = stop_tx.send(());
})
```

The poll loop checks the stop channel every 100 ms, so the happy path is responsive — but the work between polls is blocking file I/O (`write_entry`, `flush`, `finish`). If a write wedges (full disk, stalled network mount, a very large flush), the loop never reaches the next poll and there is no second-signal path to break out. Because the handler stays installed for the life of the process, the default "SIGINT terminates" disposition is gone too, so repeated Ctrl-C does nothing at all and the only escape is SIGKILL from another terminal.

Every other signal handler in the tree already escalates on a repeated signal:

| Handler | Escalation |
|---|---|
| `binaries/daemon/src/lib.rs` `set_up_ctrlc_handler` | 2nd → `SecondCtrlC`, 3rd → `abort()` |
| `binaries/coordinator/src/events.rs` `set_up_ctrlc_handler` | 2nd → `abort()` |
| `binaries/cli/src/command/start/attach.rs` | 2nd → force-stop + `exit(1)` |
| `binaries/cli/src/command/record.rs` | **none** (this PR) |

## Change

Count signals in the closure and escalate. The second Ctrl-C exits immediately with the conventional SIGINT status (`130`) and prints a message warning that the recording may be truncated — so a partial `.drec` is not handed to `dora replay` silently.

`exit(130)` rather than `abort()`: a truncated recording is a legitimate outcome of an impatient operator, and 130 is the conventional SIGINT status. The partial file is left in place (removing it from inside the async-unsafe handler would be riskier than the visible warning).

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p dora-cli -- -D warnings` (clean)

A signal handler that ends in `process::exit` isn't unit-testable in-process; the change mirrors the already-established, exercised pattern in the daemon/coordinator/attach handlers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpwSeg7gZkeNEWq11apYNF)_