### PR TITLE
ci: add `timeout --kill-after` to bounded CI call sites

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -382,7 +382,7 @@ jobs:
           # #1674 for record). (Historically the workspace root also had
           # a types/ dir that replay wrongly loaded as user types; it moved
           # to libraries/core/types/ but the placement rule stands.)
-          timeout 300s dora record examples/rust-dataflow/dataflow.yml \
+          timeout -k 30s 300s dora record examples/rust-dataflow/dataflow.yml \
             -o examples/rust-dataflow/run.drec
           test -f examples/rust-dataflow/run.drec || { echo "record did not produce run.drec"; exit 1; }
           echo "recording size: $(wc -c < examples/rust-dataflow/run.drec) bytes"
@@ -656,7 +656,7 @@ jobs:
         # update is available. Catches regressions in CLI flag parsing,
         # the self_update crate integration, and the API-response contract.
         run: |
-          out=$(timeout 30 dora self update --check-only 2>&1) || exit_code=$?
+          out=$(timeout -k 30s 30 dora self update --check-only 2>&1) || exit_code=$?
           echo "$out"
           # Must always print the entry banner — if this is missing, the
           # command didn't even start the check path.
@@ -715,7 +715,7 @@ jobs:
           # Tests the CLI-side WebSocket subscription path end-to-end (#238).
           # Fixture emits at 10 Hz, so 5 frames arrive in ~500ms — generous
           # 15s timeout protects against daemon startup delay.
-          timeout 15 dora topic echo -d tui-smoke ticker/count --count 5 --format json \
+          timeout -k 30s 15 dora topic echo -d tui-smoke ticker/count --count 5 --format json \
             2>&1 | tee echo.out
           lines=$(grep -c '"name":"ticker/count"' echo.out || echo 0)
           if [ "$lines" -lt 5 ]; then

--- a/scripts/qa/ci-nightly-jobs.sh
+++ b/scripts/qa/ci-nightly-jobs.sh
@@ -196,7 +196,12 @@ if ! command -v timeout > /dev/null 2>&1; then
     echo "      Jobs will run UNBOUNDED until they complete or you Ctrl-C."
     echo
     timeout() {
-      # Silently drop the duration arg and run the command unbounded.
+      # Silently drop the leading duration args and run the command unbounded.
+      # Handle the optional `-k <kill-after>` prefix the call sites use, so the
+      # kill-after flag isn't left in place and executed as a command.
+      if [ "$1" = "-k" ]; then
+        shift 2
+      fi
       shift
       "$@"
     }
@@ -412,7 +417,7 @@ job_record_replay() {
   # record-replay job (.github/workflows/nightly.yml:261, tuned in
   # #1705 for cold-cache rebuild variance). Replay is normally ~2s;
   # 120s is generous but still bounded.
-  if ! timeout 300s dora record examples/rust-dataflow/dataflow.yml -o "$DREC"; then
+  if ! timeout -k 30s 300s dora record examples/rust-dataflow/dataflow.yml -o "$DREC"; then
     echo "ERROR: dora record failed or exceeded 300s"
     return 1
   fi
@@ -422,7 +427,7 @@ job_record_replay() {
   fi
   echo "OK: recording size: $(wc -c < "$DREC") bytes"
 
-  if ! timeout 120s dora replay "$DREC"; then
+  if ! timeout -k 30s 120s dora replay "$DREC"; then
     echo "ERROR: dora replay failed or exceeded 120s"
     rm -f "$DREC"
     return 1
@@ -1173,7 +1178,7 @@ EOF
   # $WORK/out/.
   echo "=== dora replay $DREC (local single-daemon run) ==="
   rm -rf "$WORK/out"
-  if ! timeout 120s dora replay "$DREC" --speed 0; then
+  if ! timeout -k 30s 120s dora replay "$DREC" --speed 0; then
     echo "ERROR: dora replay failed or exceeded 120s"
     rm -rf "$WORK"
     return 1
@@ -1294,7 +1299,7 @@ job_topic_and_top() {
     || { echo "ERROR: trace view missing prefix-error message"; return 1; }
 
   # self update --check-only read path
-  out=$(timeout 30 dora self update --check-only 2>&1) || true
+  out=$(timeout -k 30s 30 dora self update --check-only 2>&1) || true
   echo "$out" | grep -q "Checking for updates" \
     || { echo "ERROR: --check-only didn't enter update-check path"; return 1; }
   # "up to date" covers the #2512 reworded up-to-date message.
@@ -1335,7 +1340,7 @@ assert any(r.get('node') == 'ticker' and r.get('name') == 'count' for r in rows)
 
   # topic echo --count 5
   local echo_out
-  echo_out=$(timeout 15 dora topic echo -d tui-smoke ticker/count --count 5 --format json 2>&1)
+  echo_out=$(timeout -k 30s 15 dora topic echo -d tui-smoke ticker/count --count 5 --format json 2>&1)
   local lines
   lines=$(echo "$echo_out" | grep -c '"name":"ticker/count"' || echo 0)
   if [ "$lines" -lt 5 ]; then
@@ -1636,9 +1641,9 @@ job_examples() {
   # would end up at target/debug/dora, which `terminate_our_dora_children`
   # (scoped to $CLI_ROOT/bin/dora via pgrep) can't see -> leaked procs.
 
-  timeout 600s cargo run --example rust-dataflow
-  timeout 600s cargo run --example rust-dataflow-git
-  timeout 600s cargo run --example multiple-daemons
+  timeout -k 30s 600s cargo run --example rust-dataflow
+  timeout -k 30s 600s cargo run --example rust-dataflow-git
+  timeout -k 30s 600s cargo run --example multiple-daemons
 
   case "$OS" in
     MINGW*|CYGWIN*|MSYS*|Windows_NT)
@@ -1647,14 +1652,14 @@ job_examples() {
       ;;
     *)
       # C / C++ examples need a working C/C++ toolchain reachable by cargo.
-      timeout 600s cargo run --example c-dataflow
-      timeout 600s cargo run --example cxx-dataflow
+      timeout -k 30s 600s cargo run --example c-dataflow
+      timeout -k 30s 600s cargo run --example cxx-dataflow
 
       # Arrow C++ library: detect via pkg-config or brew. Skip if neither.
       if command -v pkg-config > /dev/null 2>&1 && pkg-config --exists arrow 2>/dev/null; then
-        timeout 600s cargo run --example cxx-arrow-dataflow
+        timeout -k 30s 600s cargo run --example cxx-arrow-dataflow
       elif [ "$OS" = "Darwin" ] && command -v brew > /dev/null 2>&1 && brew list apache-arrow > /dev/null 2>&1; then
-        timeout 600s cargo run --example cxx-arrow-dataflow
+        timeout -k 30s 600s cargo run --example cxx-arrow-dataflow
       else
         echo "SKIP cxx-arrow-dataflow: arrow C++ library not found (install libarrow-dev or 'brew install apache-arrow')"
         SKIPPED+=("examples: cxx-arrow-dataflow (arrow C++ missing)")
@@ -1663,7 +1668,7 @@ job_examples() {
   esac
 
   if [ "$OS" = "Linux" ]; then
-    timeout 600s cargo run --example cmake-dataflow
+    timeout -k 30s 600s cargo run --example cmake-dataflow
   else
     echo "SKIP cmake-dataflow: GHA runs this on Linux only"
     SKIPPED+=("examples: cmake-dataflow (non-Linux)")
@@ -1691,7 +1696,7 @@ job_cli_tests() {
     dora new test_rust_project --internal-create-with-path-dependencies
     cd test_rust_project
     cargo build --all
-    timeout 120s dora run dataflow.yml --stop-after 10s
+    timeout -k 30s 120s dora run dataflow.yml --stop-after 10s
     # Assert no per-node failures hid behind dora-run's 10s timer (#1863).
     assert_clean_dataflow_run "out"
   )
@@ -1727,7 +1732,7 @@ job_cli_tests() {
   # Error Event Example
   dora build examples/error-propagation/dataflow.yml
   local err_out
-  err_out=$(timeout 60s dora run examples/error-propagation/dataflow.yml 2>&1 || true)
+  err_out=$(timeout -k 30s 60s dora run examples/error-propagation/dataflow.yml 2>&1 || true)
   echo "$err_out" | grep -q "Received error from node" \
     || { echo "ERROR: error-propagation did not receive NodeFailed event"; return 1; }
 
@@ -1762,7 +1767,7 @@ job_cli_tests() {
       uv run pytest
       export OPERATING_MODE=SAVE
       dora build dataflow.yml --uv
-      timeout 120s dora run dataflow.yml --uv --stop-after 10s
+      timeout -k 30s 120s dora run dataflow.yml --uv --stop-after 10s
       # Assert no per-node failures hid behind dora-run's 10s timer (#1863).
       assert_clean_dataflow_run "out"
     )
@@ -1774,7 +1779,7 @@ job_cli_tests() {
     # this invocation's per-node behavior (#1863).
     rm -rf examples/python-dataflow/out
     dora build examples/python-dataflow/dataflow.yml --uv
-    timeout 60s dora run examples/python-dataflow/dataflow.yml --uv --stop-after 10s
+    timeout -k 30s 60s dora run examples/python-dataflow/dataflow.yml --uv --stop-after 10s
     assert_clean_dataflow_run examples/python-dataflow/out
 
     # Python Dynamic Node example
@@ -1785,7 +1790,7 @@ job_cli_tests() {
     dora up
     sleep 2
     dora start examples/python-dataflow/dataflow_dynamic.yml --name ci-python-dynamic --detach --uv
-    timeout 60s uv run opencv-plot || true
+    timeout -k 30s 60s uv run opencv-plot || true
     sleep 10
     dora stop --name ci-python-dynamic --grace-duration 30s 2>/dev/null || true
     dora destroy 2>/dev/null || true
@@ -1795,13 +1800,13 @@ job_cli_tests() {
     rm -rf examples/python-operator-dataflow/out
     dora build examples/python-operator-dataflow/dataflow.yml --uv
     uv pip install --quiet -e apis/python/node
-    timeout 120s dora run examples/python-operator-dataflow/dataflow.yml --uv --stop-after 20s
+    timeout -k 30s 120s dora run examples/python-operator-dataflow/dataflow.yml --uv --stop-after 20s
     assert_clean_dataflow_run examples/python-operator-dataflow/out
 
     # Python Multiple Arrays
     rm -rf examples/python-multiple-arrays/out
     dora build examples/python-multiple-arrays/dataflow.yml --uv
-    timeout 120s dora run examples/python-multiple-arrays/dataflow.yml --uv --stop-after 30s
+    timeout -k 30s 120s dora run examples/python-multiple-arrays/dataflow.yml --uv --stop-after 30s
     assert_clean_dataflow_run examples/python-multiple-arrays/out
 
     # Python Async example (5-min run; skipped on Windows per GHA)
@@ -1811,12 +1816,12 @@ job_cli_tests() {
         SKIPPED+=("cli-tests: python-async on Windows")
         ;;
       *)
-        timeout 360s dora run examples/python-async/dataflow.yaml --uv --stop-after 5m
+        timeout -k 30s 360s dora run examples/python-async/dataflow.yaml --uv --stop-after 5m
         ;;
     esac
 
     # Python Drain example
-    OTEL_SDK_DISABLED=true timeout 120s dora run examples/python-drain/dataflow.yaml --uv
+    OTEL_SDK_DISABLED=true timeout -k 30s 120s dora run examples/python-drain/dataflow.yaml --uv
 
     # Python Dataflow Builder API (YAML generation contract test)
     # `simple_example.py` itself can't run here -- its build: directives
@@ -1824,17 +1829,17 @@ job_cli_tests() {
     # which pull PyPI `dora-rs` 0.5.0 and clobber the local workspace version.
     # Exercise the builder API itself via the hub-package-free YAML
     # generation contract test (matches GHA's #1654 approach).
-    timeout 60s uv run --with PyYAML python examples/python-dataflow-builder/test_builder_api.py
+    timeout -k 30s 60s uv run --with PyYAML python examples/python-dataflow-builder/test_builder_api.py
 
     # Python Queue Latency Test
-    timeout 120s dora run tests/queue_size_latest_data_python/dataflow.yaml --uv
+    timeout -k 30s 120s dora run tests/queue_size_latest_data_python/dataflow.yaml --uv
 
     # Python Queue Latency + Timeout Test
-    timeout 120s dora run tests/queue_size_and_timeout_python/dataflow.yaml --uv
+    timeout -k 30s 120s dora run tests/queue_size_and_timeout_python/dataflow.yaml --uv
 
     # Rust Queue Latency Test
     dora build tests/queue_size_latest_data_rust/dataflow.yaml --uv
-    timeout 120s dora run tests/queue_size_latest_data_rust/dataflow.yaml --uv
+    timeout -k 30s 120s dora run tests/queue_size_latest_data_rust/dataflow.yaml --uv
 
     deactivate 2>/dev/null || true
     rm -rf "$venv_dir"
@@ -1851,7 +1856,7 @@ job_cli_tests() {
       cmake -B build
       cmake --build build
       cmake --install build
-      timeout 120s dora run dataflow.yml --stop-after 10s
+      timeout -k 30s 120s dora run dataflow.yml --stop-after 10s
     )
     rm -rf "$tmpd3"
 
@@ -1864,7 +1869,7 @@ job_cli_tests() {
       cmake -B build
       cmake --build build
       cmake --install build
-      timeout 120s dora run dataflow.yml --stop-after 10s
+      timeout -k 30s 120s dora run dataflow.yml --stop-after 10s
     )
     rm -rf "$tmpd4"
   else
@@ -1878,7 +1883,7 @@ job_cli_tests() {
 # Mirrors nightly.yml `bench-example`.
 # -----------------------------------------------------------------------------
 job_bench_example() {
-  timeout 2700s cargo run --example benchmark --release
+  timeout -k 30s 2700s cargo run --example benchmark --release
 }
 
 # -----------------------------------------------------------------------------
@@ -1979,8 +1984,8 @@ job_ros2_bridge() {
     return 0
   fi
   # Basic checks -- mirror nightly.yml `ros2-bridge` (no ROS distro required).
-  timeout 600s cargo check -p dora-ros2-bridge --no-default-features
-  timeout 600s cargo test -p dora-ros2-bridge-msg-gen
+  timeout -k 30s 600s cargo check -p dora-ros2-bridge --no-default-features
+  timeout -k 30s 600s cargo test -p dora-ros2-bridge-msg-gen
   # dora-ros2-bridge-python's test_utils.py imports numpy + pyarrow. The
   # workflow installs them (`pip install pyarrow numpy`); do the same here in a
   # throwaway venv so this runs cleanly on a Linux box without ROS2 instead of
@@ -1991,7 +1996,7 @@ job_ros2_bridge() {
   # shellcheck disable=SC1091
   source "$ros2_basic_venv/bin/activate"
   uv pip install --quiet pyarrow numpy
-  timeout 600s cargo test -p dora-ros2-bridge-python
+  timeout -k 30s 600s cargo test -p dora-ros2-bridge-python
   deactivate 2>/dev/null || true
   rm -rf "$ros2_basic_venv"
 
@@ -2003,11 +2008,11 @@ job_ros2_bridge() {
   fi
   # shellcheck disable=SC1091
   source /opt/ros/humble/setup.bash
-  timeout 1800s env QT_QPA_PLATFORM=offscreen cargo run -p dora-ros2-bridge --example rust-ros2-dataflow
+  timeout -k 30s 1800s env QT_QPA_PLATFORM=offscreen cargo run -p dora-ros2-bridge --example rust-ros2-dataflow
   # Self-contained parameter example: declares + exercises ROS2 parameters via
   # the local API (no discovery), so it runs on every platform incl. arm64.
-  timeout 1800s env QT_QPA_PLATFORM=offscreen cargo run -p dora-ros2-bridge --example rust-ros2-dataflow-parameter
-  timeout 1800s env QT_QPA_PLATFORM=offscreen cargo run -p dora-ros2-bridge --example cxx-ros2-dataflow --features ros2-examples
+  timeout -k 30s 1800s env QT_QPA_PLATFORM=offscreen cargo run -p dora-ros2-bridge --example rust-ros2-dataflow-parameter
+  timeout -k 30s 1800s env QT_QPA_PLATFORM=offscreen cargo run -p dora-ros2-bridge --example cxx-ros2-dataflow --features ros2-examples
 
   # C++ service server, driven by the rclcpp minimal client. Mirrors the
   # nightly.yml "C++ ROS2 Bridge service-server example" step. The example peer
@@ -2025,7 +2030,7 @@ job_ros2_bridge() {
     fi
   fi
   if ros2 pkg executables examples_rclcpp_minimal_client 2>/dev/null | grep -q client_main; then
-    timeout 1800s env QT_QPA_PLATFORM=offscreen cargo run -p dora-ros2-bridge --example cxx-ros2-dataflow-service-server --features ros2-examples
+    timeout -k 30s 1800s env QT_QPA_PLATFORM=offscreen cargo run -p dora-ros2-bridge --example cxx-ros2-dataflow-service-server --features ros2-examples
   else
     echo "SKIP cxx-ros2-dataflow-service-server: examples_rclcpp_minimal_client not installed (apt-get install ros-humble-examples-rclcpp-minimal-client)"
     SKIPPED+=("ros2-bridge: cxx-service-server (examples_rclcpp_minimal_client missing)")
@@ -2043,17 +2048,17 @@ job_ros2_bridge() {
   # shellcheck disable=SC1091
   source .venv-ros2-bridge/bin/activate
   uv pip install -q -e apis/python/node pyarrow
-  timeout 1800s env QT_QPA_PLATFORM=offscreen cargo run -p dora-ros2-bridge --example python-ros2-dataflow-service-client
-  timeout 1800s env QT_QPA_PLATFORM=offscreen cargo run -p dora-ros2-bridge --example python-ros2-dataflow-service-server
+  timeout -k 30s 1800s env QT_QPA_PLATFORM=offscreen cargo run -p dora-ros2-bridge --example python-ros2-dataflow-service-client
+  timeout -k 30s 1800s env QT_QPA_PLATFORM=offscreen cargo run -p dora-ros2-bridge --example python-ros2-dataflow-service-server
   deactivate
 }
 
 job_ros2_zenoh_humble() {
-  timeout 3600s scripts/ros2-zenoh-interop.sh humble all
+  timeout -k 30s 3600s scripts/ros2-zenoh-interop.sh humble all
 }
 
 job_ros2_zenoh_kilted() {
-  timeout 3600s scripts/ros2-zenoh-interop.sh kilted all
+  timeout -k 30s 3600s scripts/ros2-zenoh-interop.sh kilted all
 }
 
 # -----------------------------------------------------------------------------

--- a/scripts/ros2-zenoh-interop.sh
+++ b/scripts/ros2-zenoh-interop.sh
@@ -23,7 +23,7 @@ cleanup() { "${compose[@]}" down --volumes --remove-orphans >/dev/null 2>&1 || t
 trap cleanup EXIT INT TERM
 
 "${compose[@]}" up -d "$service"
-timeout 180 bash -c 'until [[ $(docker inspect -f "{{.State.Health.Status}}" "$1" 2>/dev/null) == healthy ]]; do sleep 2; done' _ "${PROJECT}-${service}-1"
+timeout -k 30s 180 bash -c 'until [[ $(docker inspect -f "{{.State.Health.Status}}" "$1" 2>/dev/null) == healthy ]]; do sleep 2; done' _ "${PROJECT}-${service}-1"
 "${compose[@]}" exec -T "$service" bash -lc \
   "source /opt/ros/$DISTRO/setup.bash; dpkg-query -W 'ros-${DISTRO}-rmw-zenoh-cpp'; ros2 pkg executables rmw_zenoh_cpp"
 

--- a/scripts/ros2dev.sh
+++ b/scripts/ros2dev.sh
@@ -138,7 +138,7 @@ passed=()
 failed=()
 for ex in "${EXAMPLES[@]}"; do
   echo "::: running example: $ex"
-  if QT_QPA_PLATFORM=offscreen timeout 600 \
+  if QT_QPA_PLATFORM=offscreen timeout -k 30s 600 \
        cargo run -q -p dora-ros2-bridge --example "$ex" --features ros2-examples; then
     passed+=("$ex")
     echo "    PASS  $ex"

--- a/tests/ros2-zenoh/fixtures/run-case.sh
+++ b/tests/ros2-zenoh/fixtures/run-case.sh
@@ -23,17 +23,17 @@ case "$CASE" in
 esac
 
 log="$DORA_ROS2_ZENOH_ARTIFACTS/${CASE}-rclpy.log"
-timeout 60 "${compose[@]}" exec -T "$SERVICE" bash -lc \
+timeout -k 30s 60 "${compose[@]}" exec -T "$SERVICE" bash -lc \
   "source /opt/ros/$DISTRO/setup.bash && python3 /workspace/tests/ros2-zenoh/peers/$peer" \
   >"$log" 2>&1 &
 peer_pid=$!
 trap 'kill "$peer_pid" 2>/dev/null || true' EXIT
-timeout 20 bash -c 'until grep -q '"'"'"event": "READY"'"'"' "$1"; do kill -0 "$2" 2>/dev/null || exit 1; sleep .2; done' _ "$log" "$peer_pid"
+timeout -k 30s 20 bash -c 'until grep -q '"'"'"event": "READY"'"'"' "$1"; do kill -0 "$2" 2>/dev/null || exit 1; sleep .2; done' _ "$log" "$peer_pid"
 
 profile=rep2016
 [[ "$DISTRO" == humble ]] && profile=humble
 PYTHONPATH="$DORA_ROS2_ZENOH_PYTHON" AMENT_PREFIX_PATH="$DORA_ROS2_ZENOH_AMENT" \
-  timeout 60 "$DORA_ROS2_ZENOH_PYTHON_EXECUTABLE" \
+  timeout -k 30s 60 "$DORA_ROS2_ZENOH_PYTHON_EXECUTABLE" \
     "$ROOT/tests/ros2-zenoh/peers/dora_peer.py" "$CASE" \
     --profile "$profile" --ament "$DORA_ROS2_ZENOH_AMENT" \
     --config "$ROOT/tests/ros2-zenoh/fixtures/zenoh-client.json5"


### PR DESCRIPTION
## Summary

Fixes #2951.

`timeout N cmd` sends SIGTERM and then **waits indefinitely** for the child to die — without `-k`, the stated bound is only honored by processes that choose to honor SIGTERM. A `grep` for `timeout -k` / `--kill-after` across `.github/workflows/` and `scripts/` previously returned **zero hits** across ~45 bare `timeout` call sites.

### Why it matters

Several dora entry points install SIGINT handlers via `ctrlc`, and whether they should also catch SIGTERM is live (#2920 asks for it so that killing `dora run` stops leaking node processes). The moment any of them starts handling SIGTERM, every one of these call sites becomes a soft bound: a wedged teardown turns a `timeout 300s` into a hang that runs to the GitHub Actions job cap instead of failing at 300s with exit 124. `dora record` is the sharpest example (its handler had no escalation either — see #2952 / #2953). This isn't broken on `main` today — SIGTERM is still fatal — but the CI's only defence against a hang is a bound that stops working the instant the product becomes better-behaved about SIGTERM.

## Change

- Add `-k 30s` to every bounded `timeout` call site across five files:
  - `.github/workflows/nightly.yml` (3)
  - `scripts/qa/ci-nightly-jobs.sh` (40)
  - `scripts/ros2dev.sh` (1)
  - `scripts/ros2-zenoh-interop.sh` (1)
  - `tests/ros2-zenoh/fixtures/run-case.sh` (3) — the callee invoked by `ros2-zenoh-interop.sh:57`, so the bound the caller guarantees is not re-softened one level down. Line 36 there runs a dora Python node, exactly the SIGTERM-handling class this issue is about. (Added after review — thanks @heyong4725.)

  30s clears the daemon's stop ladder (10s grace → SIGTERM → 5s → SIGKILL) while still guaranteeing the process dies. Done as one uniform sweep rather than per-site/per-file judgement, as the issue requested.
- Teach the portable `timeout` fallback shim in `ci-nightly-jobs.sh` (used on hosts without coreutils `timeout`/`gtimeout`) to strip an optional `-k <dur>` prefix, so the kill-after flag isn't left in place and executed as a command.

The substitution used a negative lookbehind so `--timeout`, `gtimeout`, and path substrings like `queue_size_and_timeout_python` are untouched — only the leading coreutils `timeout` command gets the flag.

## Testing

- No bare `timeout <digit>` sites remain **in the five files touched** (all now carry `-k 30s`).
- `bash -n` clean on all four scripts; `nightly.yml` parses as valid YAML.
- Functional test of the fallback shim: it correctly strips both `-k 30s 300s cmd` and `300s cmd` down to `cmd`.

`timeout -k` is GNU coreutils and is supported by BSD/macOS `timeout` too, so it stays portable across the runners in use.