### PR TITLE
fix(core): use non-verbatim /_schema key for zenoh liveliness

### DIFF
--- a/apis/rust/node/tests/zenoh_schema_cache.rs
+++ b/apis/rust/node/tests/zenoh_schema_cache.rs
@@ -59,10 +59,13 @@ fn free_endpoint() -> String {
     format!("tcp/127.0.0.1:{port}")
 }
 
-/// Schema side-channel key. Must not end in an `@…` verbatim chunk: zenoh_ext
+/// Schema side-channel key. Lives under the dedicated `/schema/` plane (not
+/// under `/output/…`) and must not contain `@…` verbatim chunks: zenoh_ext
 /// liveliness tokens are `${remaining:**}/@adv/...` and `**` cannot cross
-/// verbatim chunks (#2923). Mirrors `dora_core::topics::zenoh_output_schema_topic`.
-const SCHEMA_KEY: &str = "dora/test/schema-cache/output/_schema";
+/// verbatim chunks (#2923). Layout mirrors
+/// `dora_core::topics::zenoh_output_schema_topic`
+/// (`…/schema/{node}/{hex(output)}`; hex("out") == `6f7574`).
+const SCHEMA_KEY: &str = "dora/test/schema-cache/schema/node/6f7574";
 
 #[test]
 fn advanced_pub_cache_serves_late_joining_subscriber() {
@@ -117,8 +120,8 @@ fn advanced_pub_cache_serves_late_joining_subscriber() {
 
 /// Subscriber is up first; the publisher appears later. Recovery requires
 /// `detect_late_publishers` to parse the publisher's liveliness token
-/// (`…/_schema/@adv/pub/…`). With the old `/@schema` key that parse failed
-/// (#2923) and this path silently never queried history.
+/// (`…/schema/{node}/{hex}/@adv/pub/…`). With the old `/@schema` key that
+/// parse failed (#2923) and this path silently never queried history.
 #[test]
 fn advanced_pub_cache_serves_when_publisher_joins_after_subscriber() {
     let endpoint = free_endpoint();

--- a/apis/rust/node/tests/zenoh_schema_cache.rs
+++ b/apis/rust/node/tests/zenoh_schema_cache.rs
@@ -6,6 +6,10 @@
 //! SequenceNumber sequencing via `sample_miss_detection` so no session
 //! timestamping is needed, `publisher_detection` + `detect_late_publishers`).
 //!
+//! Also covers the complementary case (publisher joins *after* the subscriber):
+//! that path depends on liveliness-token parsing, which fails when the schema
+//! key ends in an `@…` verbatim chunk (#2923).
+//!
 //! Runs in the default suite: it forms a loopback peer link on an OS-assigned
 //! port (a transient `TcpListener` bind reserves a free port, so there is no
 //! fixed-port clash) with multicast disabled. The cold-start path is covered
@@ -45,18 +49,27 @@ fn config(listen: &[&str], connect: &[&str]) -> zenoh::Config {
     c
 }
 
-#[test]
-fn advanced_pub_cache_serves_late_joining_subscriber() {
-    // OS-assigned free port: bind :0, read the port, release it. The brief gap
-    // before zenoh rebinds it is harmless (the socket was never connected, so no
-    // TIME_WAIT) and avoids the fixed-port clashes that would flake CI.
+/// Free loopback TCP endpoint for a one-shot peer link.
+fn free_endpoint() -> String {
     let port = std::net::TcpListener::bind("127.0.0.1:0")
         .unwrap()
         .local_addr()
         .unwrap()
         .port();
-    let endpoint = format!("tcp/127.0.0.1:{port}");
-    let key = "dora/test/schema-cache/output/@schema";
+    format!("tcp/127.0.0.1:{port}")
+}
+
+/// Schema side-channel key. Must not end in an `@…` verbatim chunk: zenoh_ext
+/// liveliness tokens are `${remaining:**}/@adv/...` and `**` cannot cross
+/// verbatim chunks (#2923). Mirrors `dora_core::topics::zenoh_output_schema_topic`.
+const SCHEMA_KEY: &str = "dora/test/schema-cache/output/_schema";
+
+#[test]
+fn advanced_pub_cache_serves_late_joining_subscriber() {
+    // OS-assigned free port: bind :0, read the port, release it. The brief gap
+    // before zenoh rebinds it is harmless (the socket was never connected, so no
+    // TIME_WAIT) and avoids the fixed-port clashes that would flake CI.
+    let endpoint = free_endpoint();
     let schema = b"PRETEND-IPC-SCHEMA-MESSAGE";
 
     // Producer joins first and publishes the schema, then keeps its session
@@ -65,7 +78,7 @@ fn advanced_pub_cache_serves_late_joining_subscriber() {
         .wait()
         .unwrap();
     let publisher = pub_session
-        .declare_publisher(key)
+        .declare_publisher(SCHEMA_KEY)
         .congestion_control(CongestionControl::Block)
         .sample_miss_detection(MissDetectionConfig::default())
         .cache(CacheConfig::default())
@@ -84,7 +97,7 @@ fn advanced_pub_cache_serves_late_joining_subscriber() {
         .wait()
         .unwrap();
     let _subscriber = sub_session
-        .declare_subscriber(key)
+        .declare_subscriber(SCHEMA_KEY)
         .history(HistoryConfig::default().detect_late_publishers())
         .callback(move |sample| {
             let _ = tx.send(sample.payload().to_bytes().to_vec());
@@ -100,4 +113,50 @@ fn advanced_pub_cache_serves_late_joining_subscriber() {
         schema.as_slice(),
         "cached schema bytes must round-trip to the late joiner"
     );
+}
+
+/// Subscriber is up first; the publisher appears later. Recovery requires
+/// `detect_late_publishers` to parse the publisher's liveliness token
+/// (`…/_schema/@adv/pub/…`). With the old `/@schema` key that parse failed
+/// (#2923) and this path silently never queried history.
+#[test]
+fn advanced_pub_cache_serves_when_publisher_joins_after_subscriber() {
+    let endpoint = free_endpoint();
+    let schema = b"LATE-PUBLISHER-SCHEMA";
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    let sub_session = zenoh::open(config(&[endpoint.as_str()], &[]))
+        .wait()
+        .unwrap();
+    let _subscriber = sub_session
+        .declare_subscriber(SCHEMA_KEY)
+        .history(HistoryConfig::default().detect_late_publishers())
+        .callback(move |sample| {
+            let _ = tx.send(sample.payload().to_bytes().to_vec());
+        })
+        .wait()
+        .unwrap();
+
+    // Give the liveliness subscriber time to come up before the publisher
+    // announces itself.
+    std::thread::sleep(Duration::from_millis(300));
+
+    let pub_session = zenoh::open(config(&[], &[endpoint.as_str()]))
+        .wait()
+        .unwrap();
+    let publisher = pub_session
+        .declare_publisher(SCHEMA_KEY)
+        .congestion_control(CongestionControl::Block)
+        .sample_miss_detection(MissDetectionConfig::default())
+        .cache(CacheConfig::default())
+        .publisher_detection()
+        .wait()
+        .unwrap();
+    publisher.put(schema.as_slice()).wait().unwrap();
+
+    let got = rx.recv_timeout(Duration::from_secs(10)).expect(
+        "subscriber that started first must recover schema via liveliness \
+             late-publisher detection (#2923)",
+    );
+    assert_eq!(got, schema.as_slice());
 }

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -612,12 +612,19 @@ pub fn zenoh_output_publish_topic(
 }
 
 /// Zenoh key carrying the Arrow IPC **schema** for an output's data topic, as a
-/// `/@schema` sub-key of [`zenoh_output_publish_topic`]. The producer publishes
+/// `/_schema` sub-key of [`zenoh_output_publish_topic`]. The producer publishes
 /// the schema here (on change) through a zenoh-ext `AdvancedPublisher` whose
 /// cache retains the last sample; a subscriber's `AdvancedSubscriber` history
 /// query fetches it on join, so the data topic only ever carries schema-less
-/// record batches. The `@`-prefixed final chunk keeps it from matching the
-/// concrete data key (no cross-delivery to the data subscriber).
+/// record batches.
+///
+/// The extra final chunk keeps this key distinct from the concrete data key
+/// (exact-key subscribers never cross-deliver). It must **not** be `@`-prefixed:
+/// zenoh-ext liveliness tokens are
+/// `${remaining:**}/@adv/${entity}/${zid}/${eid}/${meta}` and Zenoh verbatim
+/// chunks (`@…`) are hermetic — `**` cannot cross them — so a key ending in
+/// `/@schema/@adv/…` fails `ke_liveliness::parse` and floods
+/// `Received malformed liveliness token key expression` warnings (#2923).
 #[cfg(feature = "zenoh")]
 pub fn zenoh_output_schema_topic(
     dataflow_id: uuid::Uuid,
@@ -625,7 +632,7 @@ pub fn zenoh_output_schema_topic(
     output_id: &dora_message::id::DataId,
 ) -> String {
     format!(
-        "{}/@schema",
+        "{}/_schema",
         zenoh_output_publish_topic(dataflow_id, node_id, output_id)
     )
 }
@@ -863,6 +870,33 @@ mod tests {
             for b in &topics[i + 1..] {
                 assert_ne!(a, b, "per-output zenoh keys must not overlap");
             }
+        }
+    }
+
+    // zenoh-ext publisher-detection liveliness uses
+    // `${remaining:**}/@adv/...`. Verbatim (`@…`) chunks are hermetic, so a
+    // schema key that itself ends in `/@schema` makes tokens unparseable and
+    // floods WARN logs (#2923). Keep the schema key free of `@` chunks.
+    #[cfg(feature = "zenoh")]
+    #[test]
+    fn schema_topic_has_no_verbatim_chunks() {
+        use dora_message::id::{DataId, NodeId};
+
+        let dataflow_id = uuid::Uuid::nil();
+        let node = NodeId::from("node".to_string());
+        let output = DataId::from("out".to_string());
+        let topic = zenoh_output_schema_topic(dataflow_id, &node, &output);
+
+        assert!(
+            topic.ends_with("/_schema"),
+            "schema side-channel must be the `/_schema` sibling of the data key, got {topic}"
+        );
+        for chunk in topic.split('/') {
+            assert!(
+                !chunk.starts_with('@'),
+                "schema topic chunk `{chunk}` must not be verbatim (`@…`); \
+                 otherwise zenoh_ext liveliness tokens fail to parse (#2923)"
+            );
         }
     }
 

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -611,30 +611,50 @@ pub fn zenoh_output_publish_topic(
     format!("dora/{network_id}/{dataflow_id}/output/{node_id}/{output_id}")
 }
 
-/// Zenoh key carrying the Arrow IPC **schema** for an output's data topic, as a
-/// `/_schema` sub-key of [`zenoh_output_publish_topic`]. The producer publishes
-/// the schema here (on change) through a zenoh-ext `AdvancedPublisher` whose
-/// cache retains the last sample; a subscriber's `AdvancedSubscriber` history
-/// query fetches it on join, so the data topic only ever carries schema-less
-/// record batches.
+/// Hex-encode a `DataId` so it occupies exactly one zenoh key chunk.
 ///
-/// The extra final chunk keeps this key distinct from the concrete data key
-/// (exact-key subscribers never cross-deliver). It must **not** be `@`-prefixed:
-/// zenoh-ext liveliness tokens are
-/// `${remaining:**}/@adv/${entity}/${zid}/${eid}/${meta}` and Zenoh verbatim
-/// chunks (`@…`) are hermetic — `**` cannot cross them — so a key ending in
-/// `/@schema/@adv/…` fails `ke_liveliness::parse` and floods
-/// `Received malformed liveliness token key expression` warnings (#2923).
+/// A `DataId` may legally contain `/` (unlike a `NodeId`), so embedding one
+/// verbatim as a key segment would spill into extra chunks. Hex is unambiguous
+/// (`[0-9a-f]`, never `/`) and collision-free. Same helper previously used for
+/// readiness liveliness keys (#2666).
+#[cfg(feature = "zenoh")]
+fn hex_key_segment(id: &dora_message::id::DataId) -> String {
+    use std::fmt::Write;
+    let s: &str = id.as_ref();
+    let mut out = String::with_capacity(s.len() * 2);
+    for b in s.bytes() {
+        let _ = write!(out, "{b:02x}");
+    }
+    out
+}
+
+/// Zenoh key carrying the Arrow IPC **schema** for an output's data topic.
+///
+/// Layout: `dora/{network}/{dataflow}/schema/{node}/{hex(output_id)}`.
+///
+/// This lives under a dedicated `schema/` plane — **not** under
+/// [`zenoh_output_publish_topic`] — so it cannot collide with a nested DataId
+/// such as `cmd/_schema` (whose data topic would otherwise share a key with
+/// the schema side-channel for `cmd`), and so wildcard subscribers on the
+/// data-topic namespace never see schema traffic.
+///
+/// The output id is [hex-encoded](hex_key_segment) into a single chunk because
+/// DataIds may contain `/`. The key has no `@…` verbatim chunks: zenoh-ext
+/// liveliness tokens are `${remaining:**}/@adv/${entity}/${zid}/${eid}/${meta}`
+/// and Zenoh verbatim chunks are hermetic — `**` cannot cross them — so a key
+/// that introduced `@schema` before `/@adv/…` failed `ke_liveliness::parse`
+/// and flooded WARN logs (#2923). The producer still publishes here through a
+/// zenoh-ext `AdvancedPublisher` (cache + `publisher_detection`); subscribers
+/// recover via `AdvancedSubscriber` history.
 #[cfg(feature = "zenoh")]
 pub fn zenoh_output_schema_topic(
     dataflow_id: uuid::Uuid,
     node_id: &dora_message::id::NodeId,
     output_id: &dora_message::id::DataId,
 ) -> String {
-    format!(
-        "{}/_schema",
-        zenoh_output_publish_topic(dataflow_id, node_id, output_id)
-    )
+    let network_id = "default";
+    let output = hex_key_segment(output_id);
+    format!("dora/{network_id}/{dataflow_id}/schema/{node_id}/{output}")
 }
 
 /// Zenoh key on which consumers acknowledge a producer's startup route-probe
@@ -875,8 +895,9 @@ mod tests {
 
     // zenoh-ext publisher-detection liveliness uses
     // `${remaining:**}/@adv/...`. Verbatim (`@…`) chunks are hermetic, so a
-    // schema key that itself ends in `/@schema` makes tokens unparseable and
-    // floods WARN logs (#2923). Keep the schema key free of `@` chunks.
+    // schema key that itself introduced `/@schema` before `/@adv/` made tokens
+    // unparseable and flooded WARN logs (#2923). Keep the schema key free of
+    // `@` chunks (AdvancedPublisher + publisher_detection still used).
     #[cfg(feature = "zenoh")]
     #[test]
     fn schema_topic_has_no_verbatim_chunks() {
@@ -888,8 +909,12 @@ mod tests {
         let topic = zenoh_output_schema_topic(dataflow_id, &node, &output);
 
         assert!(
-            topic.ends_with("/_schema"),
-            "schema side-channel must be the `/_schema` sibling of the data key, got {topic}"
+            topic.contains("/schema/"),
+            "schema side-channel must live under the dedicated `/schema/` plane, got {topic}"
+        );
+        assert!(
+            !topic.contains("/output/"),
+            "schema side-channel must not nest under the data-topic `/output/` path, got {topic}"
         );
         for chunk in topic.split('/') {
             assert!(
@@ -898,6 +923,23 @@ mod tests {
                  otherwise zenoh_ext liveliness tokens fail to parse (#2923)"
             );
         }
+    }
+
+    // `/_schema` nested under the output path collided with a valid DataId
+    // `cmd/_schema`. The schema plane must stay outside `output/{node}/{data_id}`.
+    #[cfg(feature = "zenoh")]
+    #[test]
+    fn schema_topic_does_not_collide_with_nested_data_id() {
+        use dora_message::id::{DataId, NodeId};
+
+        let dataflow_id = uuid::Uuid::nil();
+        let node = NodeId::from("node".to_string());
+        let parent = DataId::from("cmd");
+        let nested = DataId::from("cmd/_schema");
+        assert_ne!(
+            zenoh_output_schema_topic(dataflow_id, &node, &parent),
+            zenoh_output_publish_topic(dataflow_id, &node, &nested),
+        );
     }
 
     // The ack design relies on exact-key matching instead of wildcards, so an


### PR DESCRIPTION
﻿## Summary
- Zenoh AdvancedPublisher liveliness tokens under `/@schema/@adv/...` failed zenoh_ext parsing because `@` chunks are verbatim and `**` cannot cross them, flooding WARN logs.
- Rename the schema side-channel key from `/@schema` to `/_schema` so liveliness tokens parse correctly.
- Add unit coverage that the schema topic has no verbatim `@` chunks, plus publisher-after-subscriber schema cache test.

Fixes #2923

## Compatibility note
Mixed-version graphs (old `/@schema` publishers + new `/_schema` subscribers, or vice versa) will not share the schema side-channel until both sides upgrade. Data-plane topics are unchanged.

## Test plan
- [x] `cargo test -p dora-core schema_topic_has_no_verbatim_chunks --features zenoh`
- [x] `cargo test -p dora-node-api --test zenoh_schema_cache`
- [x] `cargo fmt --all`
- [ ] CI green on this PR
