### PR TITLE
test(e2e): guard that SIGTERM to `dora run` tears the dataflow down

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7127,6 +7127,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sigterm-ignoring-node"
+version = "1.0.0-rc.4"
+dependencies = [
+ "dora-node-api",
+ "eyre",
+ "libc",
+]
+
+[[package]]
 name = "silent-source-node"
 version = "1.0.0-rc.4"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ members = [
     "tests/fault_tolerance/hang_after_init_node",
     "tests/fault_tolerance/input_closed_observer_node",
     "tests/fault_tolerance/reconnect_survivor_node",
+    "tests/fault_tolerance/sigterm_ignoring_node",
     "tests/fault_tolerance/silent_source_node",
     "tests/fault_tolerance/stop_delay_node",
     "tests/fault_tolerance/timed_burst_source_node",

--- a/tests/fault_tolerance/sigterm_ignoring_node/Cargo.toml
+++ b/tests/fault_tolerance/sigterm_ignoring_node/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "sigterm-ignoring-node"
+edition.workspace = true
+rust-version.workspace = true
+version.workspace = true
+description.workspace = true
+documentation.workspace = true
+license.workspace = true
+publish = false
+
+# Test-only node that honors NEITHER the cooperative `Stop` nor SIGTERM,
+# so the daemon's only remaining lever is SIGKILL. Used to prove the
+# stop ladder actually reaches its hard-kill rung before the CLI exits
+# (dora-rs/dora#2920).
+
+[[bin]]
+name = "sigterm-ignoring-node"
+path = "src/main.rs"
+
+[dependencies]
+dora-node-api = { workspace = true, default-features = false }
+eyre = { workspace = true }
+libc = "0.2"

--- a/tests/fault_tolerance/sigterm_ignoring_node/src/main.rs
+++ b/tests/fault_tolerance/sigterm_ignoring_node/src/main.rs
@@ -1,0 +1,59 @@
+//! A node that can only be stopped by SIGKILL.
+//!
+//! It ignores SIGTERM and never polls its event stream, so neither the
+//! cooperative `Stop` event nor the daemon's SIGTERM rung can end it.
+//! That makes it the only way to observe whether the stop ladder
+//! actually reaches its final SIGKILL rung: a node that dies to SIGTERM
+//! would be cleaned up either way and cannot distinguish the two
+//! (dora-rs/dora#2920).
+
+use dora_node_api::DoraNode;
+use eyre::ensure;
+use std::{thread, time::Duration};
+
+fn main() -> eyre::Result<()> {
+    // Installed BEFORE `init_from_env`, which spawns the event-stream
+    // threads, the node's tokio runtime and zenoh's threads: `signal` is
+    // only well specified in a single-threaded process.
+    //
+    // SAFETY: setting a disposition to `SIG_IGN` runs no handler, and no
+    // other thread exists yet to observe the change.
+    let previous = unsafe { libc::signal(libc::SIGTERM, libc::SIG_IGN) };
+    // Checked, because a silent failure here would leave a node that
+    // dies to SIGTERM — which still passes the test, but via the wrong
+    // rung, quietly costing the fixture the only property it has.
+    ensure!(
+        previous != libc::SIG_ERR,
+        "failed to ignore SIGTERM: {}",
+        std::io::Error::last_os_error()
+    );
+
+    let (_node, _events) = DoraNode::init_from_env()?;
+
+    // Publish our pid so the test can assert on THIS process rather than
+    // pattern-matching the process table, which would also catch a
+    // leftover from an earlier run and report a false failure.
+    //
+    // Written to a temp path and renamed, so a reader polling for the
+    // file can never observe a half-written pid and parse it as a
+    // different, valid-looking process.
+    if let Ok(path) = std::env::var("DORA_TEST_PID_FILE") {
+        let tmp = format!("{path}.tmp");
+        std::fs::write(&tmp, std::process::id().to_string())?;
+        std::fs::rename(&tmp, &path)?;
+    }
+
+    // Never read `_events`, so the cooperative Stop cannot be honored
+    // either.
+    //
+    // This MUST outlast the test's teardown deadline. Shortening it so a
+    // stranded fixture self-limits looks tidy and silently guts the
+    // test: if the node exits on its own inside the deadline, a wedged
+    // teardown becomes indistinguishable from a working one, and the
+    // mutation that should fail passes. Cleanup is the harness's job —
+    // the test kills this process group on every exit path.
+    for _ in 0..600 {
+        thread::sleep(Duration::from_millis(500));
+    }
+    Ok(())
+}

--- a/tests/node-lifecycle-e2e.rs
+++ b/tests/node-lifecycle-e2e.rs
@@ -1547,3 +1547,255 @@ fn lifecycle_cxx_dynamic_add_remove() {
         use_uv: false,
     });
 }
+
+/// dora-rs/dora#2920: SIGTERM to `dora run` must actually tear the
+/// dataflow down and let the CLI exit, even when the node cooperates
+/// with nothing.
+///
+/// The teardown chain is: signal -> the ctrl-c ladder -> `stop_all` ->
+/// `Stop`, then SIGTERM after the grace period, then SIGKILL after
+/// another half-grace. Each node is a process-group leader, so a kill is
+/// a `killpg` over its whole group, and the daemon's per-node
+/// `child.wait()` reaps that group before reporting the node finished.
+///
+/// Because `run_dataflow` returns only once every node has reported, the
+/// CLI cannot exit while a node is still alive. That makes the realistic
+/// failure mode a WEDGE rather than an orphan: if teardown breaks, the
+/// run never returns, and this test fails on its exit deadline.
+///
+/// Note on what a single-rung mutation proves here, which is less than
+/// it looks: `stop_all` moves the `ProcessHandle`s into the ladder task
+/// (`n.process.take()`), so when that task ends they drop and
+/// `ProcessHandle::drop` submits one more `Kill`. That is a second kill
+/// in the SAME task, not an independent path — disabling only the
+/// ladder's SIGKILL rung still leaves the drop-kill, and the test
+/// passes. Disabling both is what fails it.
+///
+/// The fixture ignores BOTH the cooperative `Stop` and SIGTERM, so only
+/// a SIGKILL can end it; a node that died to SIGTERM would be cleaned up
+/// either way and could not tell a working ladder from a broken one.
+///
+/// Unix-only: it signals the CLI and inspects process state.
+#[test]
+#[cfg(unix)]
+fn run_killed_by_sigterm_terminates_nodes_and_exits() {
+    // Not for port 6013 (`dora run` binds none) but for CPU: this test
+    // builds a fixture and then sits through a 15s teardown, and the
+    // liveness windows in sibling tests are tuned for an unloaded runner.
+    let _guard = LIFECYCLE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+    ensure_cli_built();
+    let dora = dora_bin();
+    let target = Path::new(env!("CARGO_MANIFEST_DIR")).join("target");
+    // `--target-dir` pinned for the same reason as the sibling helpers:
+    // the descriptor below hard-codes the workspace-relative path, so a
+    // `CARGO_TARGET_DIR` override would build the fixture somewhere the
+    // daemon will not look, and the failure would surface later as a
+    // misleading "node never reported its pid".
+    let status = Command::new("cargo")
+        .args(["build", "-p", "sigterm-ignoring-node"])
+        .arg("--target-dir")
+        .arg(&target)
+        .status()
+        .expect("failed to run cargo build for sigterm-ignoring-node");
+    assert!(status.success(), "failed to build sigterm-ignoring-node");
+
+    // Sweep artifacts from earlier runs, as the sibling tests do.
+    if let Ok(entries) = fs::read_dir(&target) {
+        for entry in entries.flatten() {
+            if entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with("dora-2920-orphan-")
+            {
+                let _ = fs::remove_file(entry.path());
+            }
+        }
+    }
+    let pid_file = target.join(format!("dora-2920-orphan-{}.pid", std::process::id()));
+    let yaml = target.join(format!("dora-2920-orphan-{}.yml", std::process::id()));
+    fs::write(
+        &yaml,
+        format!(
+            "nodes:\n  \
+             - id: stubborn\n    \
+               path: \"{node}\"\n    \
+               env:\n      \
+                 DORA_TEST_PID_FILE: \"{pid_file}\"\n    \
+               inputs:\n      \
+                 tick: dora/timer/millis/100\n",
+            node = target.join("debug/sigterm-ignoring-node").display(),
+            pid_file = pid_file.display(),
+        ),
+    )
+    .expect("failed to write dataflow yaml");
+
+    let log = target.join(format!("dora-2920-orphan-{}.log", std::process::id()));
+    let log_file = fs::File::create(&log).expect("failed to create log file");
+    let mut run = Command::new(&dora)
+        .args(["run", yaml.to_str().unwrap()])
+        .stdout(Stdio::null())
+        // Captured, not discarded: the failure this test exists to catch
+        // is a wedge on a remote runner, where the log is the only
+        // forensic artifact.
+        .stderr(Stdio::from(log_file))
+        .spawn()
+        .expect("failed to spawn dora run");
+
+    // RAII so every panic path below tears down the CLI *and* the node.
+    // The node ignores SIGTERM and outlives this test by design, so a
+    // bail-out that only kills the CLI would strand it on the runner for
+    // the rest of the suite.
+    struct Teardown {
+        cli_pid: u32,
+        /// Set once `try_wait` has reaped the CLI. After that its pid is
+        /// free for reuse and must never be signalled again.
+        cli_reaped: bool,
+        node_pid: Option<u32>,
+        files: Vec<std::path::PathBuf>,
+    }
+    impl Drop for Teardown {
+        fn drop(&mut self) {
+            // Signal the CLI only while it is UNREAPED: an unreaped child
+            // is a zombie at worst, so the kernel still holds its pid and
+            // it cannot have been recycled. Once reaped the pid is free,
+            // and a blind `kill` here would eventually hit a stranger.
+            if !self.cli_reaped {
+                let _ = Command::new("kill")
+                    .args(["-KILL", &self.cli_pid.to_string()])
+                    .status();
+            }
+            // The node is the daemon's child, never ours, so we can never
+            // reap it and cannot lean on the rule above. Confirm identity
+            // instead -- and note the target is a process GROUP, so a
+            // recycled pgid would take out an unrelated group, not just a
+            // stray process.
+            if let Some(pid) = self.node_pid
+                && still_our_fixture(pid)
+            {
+                let _ = Command::new("kill")
+                    .args(["-KILL", &format!("-{pid}")])
+                    .status();
+            }
+            for f in &self.files {
+                let _ = fs::remove_file(f);
+            }
+        }
+    }
+    let mut teardown = Teardown {
+        cli_pid: run.id(),
+        cli_reaped: false,
+        node_pid: None,
+        files: vec![yaml.clone(), pid_file.clone(), log.clone()],
+    };
+
+    let tail = |path: &std::path::Path| -> String {
+        fs::read_to_string(path)
+            .map(|s| s.lines().rev().take(20).collect::<Vec<_>>().join("\n"))
+            .unwrap_or_else(|e| format!("<could not read {}: {e}>", path.display()))
+    };
+
+    // Wait for the node to actually be up before signalling; otherwise we
+    // could tear down before it ever spawned and prove nothing.
+    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    let node_pid = loop {
+        // If the CLI already died, say so with its status and stderr
+        // rather than blaming the pid file 60s from now.
+        if let Some(status) = run.try_wait().expect("try_wait failed") {
+            teardown.cli_reaped = true;
+            panic!(
+                "`dora run` exited early with {status} before the node reported \
+                 its pid.\nstderr tail:\n{}",
+                tail(&log)
+            );
+        }
+        if let Ok(contents) = fs::read_to_string(&pid_file)
+            && let Ok(pid) = contents.trim().parse::<u32>()
+        {
+            break pid;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "node never reported its pid to {}\nstderr tail:\n{}",
+            pid_file.display(),
+            tail(&log)
+        );
+        std::thread::sleep(Duration::from_millis(200));
+    };
+    teardown.node_pid = Some(node_pid);
+    assert!(
+        node_is_fixture(node_pid),
+        "precondition: node {node_pid} should be running our fixture before we signal"
+    );
+
+    let signalled = Command::new("kill")
+        .args(["-TERM", &run.id().to_string()])
+        .status()
+        .expect("failed to run `kill`");
+    // Checked: an undelivered signal would make the wait below time out
+    // and report a teardown wedge that never actually happened.
+    assert!(signalled.success(), "failed to SIGTERM `dora run`");
+
+    // The default ladder hard-kills at grace + grace/2 = 15s; measured
+    // end-to-end teardown is ~18s. 60s leaves headroom for a cold runner
+    // while still bounding the ladder, so a regression that merely
+    // inflates teardown is caught rather than passing silently.
+    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    let status = loop {
+        match run.try_wait().expect("try_wait failed") {
+            Some(status) => {
+                teardown.cli_reaped = true;
+                break status;
+            }
+            None if std::time::Instant::now() >= deadline => panic!(
+                "`dora run` did not exit within 60s of SIGTERM — teardown \
+                 wedged, so the run never returns (#2920)\nstderr tail:\n{}",
+                tail(&log)
+            ),
+            None => std::thread::sleep(Duration::from_millis(250)),
+        }
+    };
+
+    // Identity-checked: a bare pid could have been recycled between the
+    // node's death and this check, which would both report a false orphan
+    // and SIGKILL an unrelated process.
+    assert!(
+        !node_is_fixture(node_pid),
+        "node {node_pid} survived `dora run` exiting with {status}: the stop \
+         ladder never reached its SIGKILL rung, so killing the CLI strands \
+         nodes (#2920)"
+    );
+}
+
+/// Whether `pid` is alive AND is our fixture, so a recycled pid is not
+/// mistaken for a surviving node.
+#[cfg(unix)]
+fn node_is_fixture(pid: u32) -> bool {
+    if !process_alive(&pid.to_string()) {
+        return false;
+    }
+    let out = Command::new("ps")
+        .args(["-o", "comm=", "-p", &pid.to_string()])
+        .output()
+        .expect("failed to run `ps -o comm=`");
+    String::from_utf8_lossy(&out.stdout).contains("sigterm-ignoring-node")
+}
+
+/// Same question, but safe to ask from a `Drop`: never panics.
+///
+/// `node_is_fixture` and `process_alive` both `expect` on `ps`. Calling
+/// either while unwinding from a failed assertion would panic inside a
+/// panic and abort the process, replacing the real diagnostic with
+/// nothing. Returning false on any doubt is the safe default -- it skips
+/// a kill rather than risking one against the wrong target.
+#[cfg(unix)]
+fn still_our_fixture(pid: u32) -> bool {
+    Command::new("ps")
+        .args(["-o", "comm=", "-p", &pid.to_string()])
+        .output()
+        .map(|out| {
+            out.status.success()
+                && String::from_utf8_lossy(&out.stdout).contains("sigterm-ignoring-node")
+        })
+        .unwrap_or(false)
+}


### PR DESCRIPTION
Test-only. Covers a gap in the second half of #2920: killing `dora run` already tears its nodes down, but nothing verified it.

## What already works

The teardown chain exists, assembled from several pieces that all have to stay in step:

| Piece | Where |
|---|---|
| Nodes spawned as process-group leaders | `spawn/prepared.rs:587` |
| `ProcessOperation::Kill` is a `killpg` over the whole group | via `process_wrap` |
| Group reaped before the node reports finished | `spawn/prepared.rs:761` → `782` |
| `run_dataflow` returns only once every node reported | `lib.rs:1680` / `1827` |
| SIGTERM/SIGHUP routed into that chain | #2949 |

Measured on a node that ignores both `Stop` and SIGTERM: `dora run` exits after ~15s (`grace + grace/2`), node gone, nothing stranded.

## What this adds

A regression test, plus a fixture that honors **neither** the cooperative `Stop` **nor** SIGTERM — so only the ladder's final SIGKILL rung can end it. A node that dies to SIGTERM gets cleaned up whether or not that rung ever runs, and so cannot tell a working ladder from a broken one.

## What it catches, and how I know

**A teardown wedge, not an orphan.** Because the CLI waits for every node to report, it *cannot* exit while a node is still alive — so broken teardown surfaces as a run that never returns, which is the original shape of the complaint in #2920.

Both directions are checked:

- clean tree → passes
- **both** kill submissions disabled → fails on the exit deadline
- **only** the ladder's SIGKILL rung disabled → still passes

That last line is stated rather than hidden, because someone will try it. `stop_all` moves the `ProcessHandle`s into the ladder task (`n.process.take()`), so when that task ends they drop and `ProcessHandle::drop` submits one more `Kill`. It is a second kill in the **same task**, not an independent path — so a single-rung mutation is uninformative here. An earlier revision of this PR described that as "defence in depth"; it isn't, and the code comment now says so.

## One thing worth knowing before editing the fixture

Its 300s lifetime is **load-bearing**. Shortening it so a stranded process self-limits looks tidier and silently guts the test: once the node can exit on its own inside the deadline, a wedged teardown completes anyway and the mutation that should fail passes. An earlier revision of this PR did exactly that, and the mutation went green.

Cleanup is the harness's job instead — an RAII guard kills the CLI and the node's process group on every exit path, so no failure strands a process the suite cannot signal away.

## Robustness

- `--target-dir` pinned on the fixture build, matching the sibling helpers; the descriptor hard-codes the workspace-relative path, so a `CARGO_TARGET_DIR` override would otherwise build it where the daemon never looks and fail 60s later with the wrong diagnosis.
- `kill` and `libc::signal` results are checked: an undelivered signal would blame production for a wedge that never happened, and a failed `SIG_IGN` install would leave a node that dies to SIGTERM — still green, but never exercising the rung under test.
- the surviving-node check confirms identity with `ps -o comm=`, so a recycled pid cannot report a false orphan or get an unrelated process SIGKILLed.
- deadline 120s → 60s, so a regression that merely inflates teardown is caught rather than passing silently.
- stderr captured and tailed into every failure message; the wedge this guards would otherwise be reported with no evidence on a remote runner.
- takes `LIFECYCLE_LOCK` like every sibling, sweeps stale artifacts by prefix, writes the pid file atomically, quotes interpolated paths.

## Scope

Marginal CI cost is ~18-20s, and the job that runs this file is merge-queue-only, so PR turnaround is unaffected.

A genuine orphan needs the CLI itself to be SIGKILLed, which is unhandleable in-process and would need parent-death signals (`PR_SET_PDEATHSIG` on Linux, a kqueue watcher on macOS). Deliberately out of scope; the surviving-node assertion is kept as a cheap backstop.

No production change.

Refs #2920

🤖 Generated with [Claude Code](https://claude.com/claude-code)
