### PR TITLE
fix(cli): recover from stale coordinator store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2150,6 +2150,7 @@ dependencies = [
  "eyre",
  "futures",
  "libloading 0.9.0",
+ "redb",
  "serde_json",
  "serde_yaml",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1947,6 +1947,7 @@ dependencies = [
  "duration-str",
  "env_logger",
  "eyre",
+ "fs2",
  "futures",
  "git2",
  "inquire",
@@ -2148,6 +2149,7 @@ dependencies = [
  "dora-tracing",
  "dunce",
  "eyre",
+ "fs2",
  "futures",
  "libloading 0.9.0",
  "redb",
@@ -3039,6 +3041,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,6 +206,7 @@ tracing = { workspace = true }
 futures = { workspace = true }
 tokio-stream = "0.1.18"
 tempfile = { workspace = true }
+redb = "2"
 assert2 = "0.4.0"
 tokio-tungstenite = "0.29"
 libloading = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,6 +165,7 @@ tracing = "0.1.44"
 uuid = { version = "1.23", features = ["serde", "v7"] }
 futures = { version = "0.3.32", default-features = false, features = ["std", "async-await"] }
 fs2 = "0.4.3"
+redb = "2"
 bincode = "1.3.3"
 flume = "0.12.0"
 tempfile = "3.27.0"
@@ -207,7 +208,7 @@ tracing = { workspace = true }
 futures = { workspace = true }
 tokio-stream = "0.1.18"
 tempfile = { workspace = true }
-redb = "2"
+redb = { workspace = true }
 fs2 = { workspace = true }
 assert2 = "0.4.0"
 tokio-tungstenite = "0.29"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,6 +164,7 @@ serde = { version = "1", features = ["derive"] }
 tracing = "0.1.44"
 uuid = { version = "1.23", features = ["serde", "v7"] }
 futures = { version = "0.3.32", default-features = false, features = ["std", "async-await"] }
+fs2 = "0.4.3"
 bincode = "1.3.3"
 flume = "0.12.0"
 tempfile = "3.27.0"
@@ -207,6 +208,7 @@ futures = { workspace = true }
 tokio-stream = "0.1.18"
 tempfile = { workspace = true }
 redb = "2"
+fs2 = { workspace = true }
 assert2 = "0.4.0"
 tokio-tungstenite = "0.29"
 libloading = "0.9"

--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -24,7 +24,7 @@ python = ["pyo3"]
 # This suppresses Python library linking, which is correct for cdylib targets
 # loaded into Python but breaks standalone binary and test builds.
 python-extension-module = ["python", "pyo3/extension-module"]
-redb-backend = ["dora-coordinator/redb-backend", "dep:libc"]
+redb-backend = ["dora-coordinator/redb-backend", "dep:fs2", "dep:libc"]
 
 [dependencies]
 arrow = { workspace = true, features = ["ipc"] }
@@ -32,6 +32,7 @@ arrow-schema = { workspace = true }
 clap = { version = "4.6.1", features = ["derive", "string", "env"] }
 clap_complete = "4.6.7"
 eyre = { workspace = true }
+fs2 = { workspace = true, optional = true }
 libc = { version = "0.2", optional = true }
 dora-core = { workspace = true, features = ["zenoh"] }
 dora-hub-client = { workspace = true }

--- a/binaries/cli/src/command/coordinator.rs
+++ b/binaries/cli/src/command/coordinator.rs
@@ -141,12 +141,18 @@ fn create_store(spec: &str) -> eyre::Result<Arc<dyn CoordinatorStore>> {
     }
 }
 
-#[cfg(feature = "redb-backend")]
-pub(crate) fn default_redb_path() -> eyre::Result<std::path::PathBuf> {
+/// `~/.dora` (HOME, falling back to USERPROFILE, then `.`). Path derivation
+/// only — callers create the directory with the permissions they need.
+pub(crate) fn dora_dir() -> std::path::PathBuf {
     let home = std::env::var("HOME")
         .or_else(|_| std::env::var("USERPROFILE"))
         .unwrap_or_else(|_| ".".into());
-    let dir = std::path::PathBuf::from(home).join(".dora");
+    std::path::PathBuf::from(home).join(".dora")
+}
+
+#[cfg(feature = "redb-backend")]
+pub(crate) fn default_redb_path() -> eyre::Result<std::path::PathBuf> {
+    let dir = dora_dir();
     // Set restrictive umask before creating directory to close the TOCTOU window
     // between creation and set_permissions.
     #[cfg(unix)]

--- a/binaries/cli/src/command/coordinator.rs
+++ b/binaries/cli/src/command/coordinator.rs
@@ -142,7 +142,7 @@ fn create_store(spec: &str) -> eyre::Result<Arc<dyn CoordinatorStore>> {
 }
 
 #[cfg(feature = "redb-backend")]
-fn default_redb_path() -> eyre::Result<std::path::PathBuf> {
+pub(crate) fn default_redb_path() -> eyre::Result<std::path::PathBuf> {
     let home = std::env::var("HOME")
         .or_else(|_| std::env::var("USERPROFILE"))
         .unwrap_or_else(|_| ".".into());

--- a/binaries/cli/src/command/mod.rs
+++ b/binaries/cli/src/command/mod.rs
@@ -269,6 +269,7 @@ mod tests {
     #[test]
     fn parse_up() {
         parse_ok(&["dora", "up"]);
+        parse_ok(&["dora", "up", "--recreate-store"]);
     }
 
     #[test]

--- a/binaries/cli/src/command/up.rs
+++ b/binaries/cli/src/command/up.rs
@@ -55,22 +55,27 @@ pub(crate) fn up(config_path: Option<&Path>, auth: bool, recreate_store: bool) -
         .and_then(|s| s.parse().ok())
         .unwrap_or(DORA_COORDINATOR_PORT_WS_DEFAULT);
     let coordinator_addr = (addr, port).into();
+    if recreate_store && !addr.is_loopback() {
+        bail!(
+            "--recreate-store only applies to the local default coordinator store, \
+             but DORA_COORDINATOR_ADDR is set to the non-loopback address {addr}\n\n  \
+             hint: unset DORA_COORDINATOR_ADDR, or run this command on the machine \
+             that hosts the coordinator store"
+        );
+    }
     // Keep the lock through daemon readiness so overlapping recreation commands
     // cannot race either the fresh coordinator or its daemon startup.
     let mut _recreation_lock = None;
     let session = match connect_to_coordinator(coordinator_addr) {
-        Ok(session) => {
-            println!("coordinator already running on {coordinator_addr}");
-            session
-        }
+        Ok(session) => attach_to_running_coordinator(session, coordinator_addr, recreate_store),
         Err(_) if recreate_store => {
             _recreation_lock = Some(lock_default_coordinator_store_recreation()?);
             match connect_to_coordinator(coordinator_addr) {
                 Ok(session) => {
-                    println!("coordinator already running on {coordinator_addr}");
-                    session
+                    attach_to_running_coordinator(session, coordinator_addr, recreate_store)
                 }
-                Err(_) => {
+                Err(err) => {
+                    ensure_no_listener_before_archive(coordinator_addr, err)?;
                     archive_default_coordinator_store()?;
                     start_and_wait_for_coordinator(coordinator_addr, port, auth)?
                 }
@@ -102,9 +107,46 @@ pub(crate) fn up(config_path: Option<&Path>, auth: bool, recreate_store: bool) -
     Ok(())
 }
 
+fn attach_to_running_coordinator(
+    session: crate::ws_client::WsSession,
+    coordinator_addr: SocketAddr,
+    recreate_store: bool,
+) -> crate::ws_client::WsSession {
+    println!("coordinator already running on {coordinator_addr}");
+    if recreate_store {
+        println!(
+            "--recreate-store skipped: the running coordinator holds the store; \
+             run `dora down` first, then rerun `dora up --recreate-store`"
+        );
+    }
+    session
+}
+
+/// A failed WebSocket connect only proves the coordinator is absent when
+/// nothing is listening on the port at all. If a process is listening but the
+/// handshake failed (stale auth token, protocol mismatch), archiving would
+/// rename the store out from under a live coordinator, silently diverting all
+/// further writes into the backup file.
+fn ensure_no_listener_before_archive(
+    coordinator_addr: SocketAddr,
+    connect_err: eyre::Report,
+) -> eyre::Result<()> {
+    if std::net::TcpStream::connect_timeout(&coordinator_addr, Duration::from_secs(1)).is_ok() {
+        return Err(connect_err.wrap_err(format!(
+            "refusing to archive the coordinator store: a process is listening on \
+             {coordinator_addr} but the connection failed\n\n  \
+             hint: resolve the connection error below (e.g. an auth token mismatch), \
+             or stop the coordinator with `dora down` before recreating the store"
+        )));
+    }
+    Ok(())
+}
+
 struct CoordinatorStartup {
     child: std::process::Child,
-    stderr: fs::File,
+    /// `None` when the capture file could not be created; startup proceeds
+    /// without stderr in error reports rather than failing.
+    stderr: Option<fs::File>,
 }
 
 fn start_and_wait_for_coordinator(
@@ -128,13 +170,23 @@ fn wait_for_coordinator_start(
             .try_wait()
             .wrap_err("failed to poll dora-coordinator")?
         {
-            let stderr = captured_stderr(&mut startup.stderr)?;
+            // A concurrent `dora up` may have won the port race, in which case
+            // our child exits with a bind error while a healthy coordinator is
+            // accepting connections. Attach to the winner instead of failing,
+            // keeping `dora up` idempotent under concurrent invocation.
+            if let Ok(session) = connect_to_coordinator(coordinator_addr) {
+                println!("coordinator already running on {coordinator_addr}");
+                return Ok(session);
+            }
+            // Degrades to an empty capture on read failure: the exit status is
+            // the primary diagnostic and must not be lost to capture plumbing.
+            let stderr = captured_stderr(startup.stderr.as_mut());
             let mut message = format!("coordinator exited before it became ready: {status}");
             if !stderr.is_empty() {
                 message.push('\n');
                 message.push_str(&stderr);
             }
-            if stderr.contains("redb schema version mismatch") {
+            if stderr.contains(dora_coordinator::dora_coordinator_store::SCHEMA_MISMATCH_MARKER) {
                 message.push_str(
                     "\n\n  hint: run `dora up --recreate-store` to archive the incompatible \
                      store and create a fresh one",
@@ -149,6 +201,12 @@ fn wait_for_coordinator_start(
                 std::thread::sleep(Duration::from_millis(50));
             }
             Err(err) => {
+                // Don't leave a detached child racing the failure we are about
+                // to report: it could bind the port seconds after the user was
+                // told startup failed (and, with --recreate-store, after the
+                // recreation lock has been released).
+                let _ = startup.child.kill();
+                let _ = startup.child.wait();
                 bail!(
                     "timed out waiting for coordinator to start at {coordinator_addr}: {err}\n\n  \
                      hint: is port {port} already in use? Check with `dora status`\n  \
@@ -159,46 +217,94 @@ fn wait_for_coordinator_start(
     }
 }
 
-fn captured_stderr(file: &mut fs::File) -> eyre::Result<String> {
-    file.rewind()
-        .wrap_err("failed to rewind coordinator stderr capture")?;
+/// Best-effort read of the coordinator stderr capture; empty on any failure.
+fn captured_stderr(file: Option<&mut fs::File>) -> String {
+    let Some(file) = file else {
+        return String::new();
+    };
     let mut bytes = Vec::new();
-    file.read_to_end(&mut bytes)
-        .wrap_err("failed to read coordinator stderr capture")?;
-    Ok(String::from_utf8_lossy(&bytes).trim().to_owned())
+    if file.rewind().is_err() || file.read_to_end(&mut bytes).is_err() {
+        return String::new();
+    }
+    String::from_utf8_lossy(&bytes).trim().to_owned()
 }
+
+/// Open `~/.dora/coordinator-stderr.log` (truncated on each start) to capture
+/// the spawned coordinator's stderr. A named file keeps post-startup panics
+/// inspectable — an unlinked tempfile would be held invisibly by the detached
+/// coordinator for its entire lifetime. Returns `None` (capture disabled)
+/// instead of failing startup when the file cannot be created.
+fn open_coordinator_stderr_capture() -> Option<fs::File> {
+    let dir = super::coordinator::dora_dir();
+    fs::create_dir_all(&dir).ok()?;
+    fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(dir.join("coordinator-stderr.log"))
+        .ok()
+}
+
+#[cfg(not(feature = "redb-backend"))]
+const RECREATE_STORE_REQUIRES_REDB: &str = "--recreate-store requires the `redb-backend` feature";
 
 fn archive_default_coordinator_store() -> eyre::Result<()> {
     #[cfg(feature = "redb-backend")]
     {
         let path = super::coordinator::default_redb_path()?;
-        if !path.exists() {
-            println!(
-                "no coordinator store at `{}`; nothing to archive",
-                path.display()
-            );
-            return Ok(());
-        }
-
-        let backup = available_backup_path(&path)?;
-        fs::rename(&path, &backup).with_context(|| {
-            format!(
-                "failed to archive coordinator store `{}` as `{}`",
-                path.display(),
-                backup.display()
-            )
-        })?;
-        println!(
-            "archived coordinator store `{}` as `{}`",
-            path.display(),
-            backup.display()
-        );
-        Ok(())
+        archive_coordinator_store(&path)
     }
     #[cfg(not(feature = "redb-backend"))]
     {
-        bail!("--recreate-store requires the `redb-backend` feature")
+        bail!(RECREATE_STORE_REQUIRES_REDB)
     }
+}
+
+#[cfg(feature = "redb-backend")]
+fn archive_coordinator_store(path: &Path) -> eyre::Result<()> {
+    use fs2::FileExt as _;
+
+    if !path.exists() {
+        println!(
+            "no coordinator store at `{}`; nothing to archive",
+            path.display()
+        );
+        return Ok(());
+    }
+
+    // redb holds an exclusive OS lock on every open database. Trying that
+    // lock checks the actual invariant — "no live process has this store
+    // open" — which the TCP probe cannot: a coordinator on a non-default
+    // port, or one still in its pre-listen window, holds the file without
+    // answering the default address. Hold the lock across the rename so no
+    // opener can slip in between check and archive.
+    let store_file = fs::File::open(path)
+        .with_context(|| format!("failed to open coordinator store `{}`", path.display()))?;
+    if store_file.try_lock_exclusive().is_err() {
+        bail!(
+            "refusing to archive coordinator store `{}`: another process still \
+             has it open\n\n  \
+             hint: stop the coordinator with `dora down`, then rerun \
+             `dora up --recreate-store`",
+            path.display()
+        );
+    }
+
+    let backup = available_backup_path(path)?;
+    fs::rename(path, &backup).with_context(|| {
+        format!(
+            "failed to archive coordinator store `{}` as `{}`",
+            path.display(),
+            backup.display()
+        )
+    })?;
+    println!(
+        "archived coordinator store `{}` as `{}`",
+        path.display(),
+        backup.display()
+    );
+    Ok(())
 }
 
 fn lock_default_coordinator_store_recreation() -> eyre::Result<fs::File> {
@@ -209,7 +315,7 @@ fn lock_default_coordinator_store_recreation() -> eyre::Result<fs::File> {
     }
     #[cfg(not(feature = "redb-backend"))]
     {
-        bail!("--recreate-store requires the `redb-backend` feature")
+        bail!(RECREATE_STORE_REQUIRES_REDB)
     }
 }
 
@@ -234,12 +340,18 @@ fn lock_coordinator_store_recreation(path: &Path) -> eyre::Result<fs::File> {
                 lock_path.display()
             )
         })?;
-    lock.lock_exclusive().with_context(|| {
-        format!(
-            "failed to lock coordinator store recreation at `{}`",
-            lock_path.display()
-        )
-    })?;
+    // Announce contention before blocking: the holder keeps the lock through
+    // coordinator + daemon startup, so the wait is seconds in the normal case
+    // and would otherwise look like a silent hang.
+    if lock.try_lock_exclusive().is_err() {
+        println!("waiting for another `dora up --recreate-store` to finish...");
+        lock.lock_exclusive().with_context(|| {
+            format!(
+                "failed to lock coordinator store recreation at `{}`",
+                lock_path.display()
+            )
+        })?;
+    }
     Ok(lock)
 }
 
@@ -346,10 +458,12 @@ fn start_coordinator(auth: bool) -> eyre::Result<CoordinatorStartup> {
     if auth {
         cmd.arg("--auth");
     }
-    let stderr = tempfile::tempfile().wrap_err("failed to create coordinator stderr capture")?;
+    let stderr = open_coordinator_stderr_capture();
     let child_stderr = stderr
-        .try_clone()
-        .wrap_err("failed to clone coordinator stderr capture")?;
+        .as_ref()
+        .and_then(|file| file.try_clone().ok())
+        .map(Into::into)
+        .unwrap_or_else(Stdio::null);
     detach_process_with_stderr(&mut cmd, child_stderr);
     let child = cmd.spawn().wrap_err(
         "failed to run `dora coordinator`\n\n  \
@@ -377,11 +491,61 @@ fn start_daemon() -> eyre::Result<()> {
     Ok(())
 }
 
-#[cfg(all(test, feature = "redb-backend"))]
+#[cfg(test)]
+#[cfg(feature = "redb-backend")]
 mod tests {
-    use super::{available_backup_path, lock_coordinator_store_recreation};
+    use super::{
+        archive_coordinator_store, available_backup_path, ensure_no_listener_before_archive,
+        lock_coordinator_store_recreation,
+    };
     use std::sync::mpsc;
     use std::time::Duration;
+
+    #[test]
+    fn archive_refused_while_store_file_is_locked() {
+        use fs2::FileExt as _;
+
+        let dir = tempfile::tempdir().expect("create temporary store directory");
+        let store = dir.path().join("coordinator.redb");
+        std::fs::write(&store, [1u8]).expect("create store file");
+        let holder = std::fs::File::open(&store).expect("open store file");
+        holder
+            .try_lock_exclusive()
+            .expect("lock store file like an open database would");
+
+        let err = archive_coordinator_store(&store)
+            .expect_err("archive must be refused while the store file is locked");
+        assert!(
+            format!("{err:#}").contains("refusing to archive"),
+            "unexpected error: {err:#}"
+        );
+        assert!(store.exists(), "locked store must not be renamed");
+
+        fs2::FileExt::unlock(&holder).expect("release store lock");
+        archive_coordinator_store(&store).expect("archive must succeed once the lock is free");
+        assert!(!store.exists(), "store was not renamed");
+        assert!(
+            dir.path().join("coordinator.redb.backup").exists(),
+            "backup was not created"
+        );
+    }
+
+    #[test]
+    fn recreate_store_archive_refused_while_port_is_listening() {
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind listener");
+        let addr = listener.local_addr().expect("listener addr");
+
+        let err = ensure_no_listener_before_archive(addr, eyre::eyre!("handshake failed"))
+            .expect_err("archive must be refused while a listener holds the port");
+        assert!(
+            format!("{err:#}").contains("refusing to archive"),
+            "unexpected error: {err:#}"
+        );
+
+        drop(listener);
+        ensure_no_listener_before_archive(addr, eyre::eyre!("connection refused"))
+            .expect("archive must be allowed when nothing is listening");
+    }
 
     #[test]
     fn coordinator_store_backup_path_skips_existing_backups() {

--- a/binaries/cli/src/command/up.rs
+++ b/binaries/cli/src/command/up.rs
@@ -7,6 +7,7 @@ use crate::{
 use dora_core::topics::DORA_COORDINATOR_PORT_WS_DEFAULT;
 use dora_message::{cli_to_coordinator::ControlRequest, coordinator_to_cli::ControlRequestReply};
 use eyre::{Context, ContextCompat, bail};
+use std::io::{Read, Seek};
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::{fs, net::SocketAddr, path::Path, process::Command, time::Duration};
@@ -24,12 +25,18 @@ pub struct Up {
     /// this token to connect.
     #[clap(long)]
     auth: bool,
+    /// Archive the default coordinator store before starting a fresh coordinator.
+    ///
+    /// Use this after an upgrade when the on-disk schema is incompatible.
+    /// The previous store is preserved next to the new one as a `.backup` file.
+    #[clap(long)]
+    recreate_store: bool,
 }
 
 impl Executable for Up {
     fn execute(self) -> eyre::Result<()> {
         default_tracing()?;
-        up(self.config.as_deref(), self.auth)
+        up(self.config.as_deref(), self.auth, self.recreate_store)
     }
 }
 
@@ -37,7 +44,7 @@ impl Executable for Up {
 #[serde(deny_unknown_fields)]
 struct UpConfig {}
 
-pub(crate) fn up(config_path: Option<&Path>, auth: bool) -> eyre::Result<()> {
+pub(crate) fn up(config_path: Option<&Path>, auth: bool, recreate_store: bool) -> eyre::Result<()> {
     let UpConfig {} = parse_dora_config(config_path)?;
     let addr: std::net::IpAddr = std::env::var("DORA_COORDINATOR_ADDR")
         .ok()
@@ -54,15 +61,10 @@ pub(crate) fn up(config_path: Option<&Path>, auth: bool) -> eyre::Result<()> {
             session
         }
         Err(_) => {
-            start_coordinator(auth).wrap_err("failed to start dora-coordinator")?;
-
-            connect_with_retry(coordinator_addr, Duration::from_secs(10)).map_err(|err| {
-                eyre::eyre!(
-                    "timed out waiting for coordinator to start at {coordinator_addr}: {err}\n\n  \
-                     hint: is port {port} already in use? Check with `dora status`\n  \
-                     or stop the existing coordinator with `dora down`"
-                )
-            })?
+            if recreate_store {
+                archive_default_coordinator_store()?;
+            }
+            start_and_wait_for_coordinator(coordinator_addr, port, auth)?
         }
     };
 
@@ -87,6 +89,129 @@ pub(crate) fn up(config_path: Option<&Path>, auth: bool) -> eyre::Result<()> {
     }
 
     Ok(())
+}
+
+struct CoordinatorStartup {
+    child: std::process::Child,
+    stderr: fs::File,
+}
+
+fn start_and_wait_for_coordinator(
+    coordinator_addr: SocketAddr,
+    port: u16,
+    auth: bool,
+) -> eyre::Result<crate::ws_client::WsSession> {
+    let startup = start_coordinator(auth).wrap_err("failed to start dora-coordinator")?;
+    wait_for_coordinator_start(coordinator_addr, port, startup)
+}
+
+fn wait_for_coordinator_start(
+    coordinator_addr: SocketAddr,
+    port: u16,
+    mut startup: CoordinatorStartup,
+) -> eyre::Result<crate::ws_client::WsSession> {
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Some(status) = startup
+            .child
+            .try_wait()
+            .wrap_err("failed to poll dora-coordinator")?
+        {
+            let stderr = captured_stderr(&mut startup.stderr)?;
+            let mut message = format!("coordinator exited before it became ready: {status}");
+            if !stderr.is_empty() {
+                message.push('\n');
+                message.push_str(&stderr);
+            }
+            if stderr.contains("redb schema version mismatch") {
+                message.push_str(
+                    "\n\n  hint: run `dora up --recreate-store` to archive the incompatible \
+                     store and create a fresh one",
+                );
+            }
+            bail!(message);
+        }
+
+        match connect_to_coordinator(coordinator_addr) {
+            Ok(session) => return Ok(session),
+            Err(_) if std::time::Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(err) => {
+                bail!(
+                    "timed out waiting for coordinator to start at {coordinator_addr}: {err}\n\n  \
+                     hint: is port {port} already in use? Check with `dora status`\n  \
+                     or stop the existing coordinator with `dora down`"
+                );
+            }
+        }
+    }
+}
+
+fn captured_stderr(file: &mut fs::File) -> eyre::Result<String> {
+    file.rewind()
+        .wrap_err("failed to rewind coordinator stderr capture")?;
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)
+        .wrap_err("failed to read coordinator stderr capture")?;
+    Ok(String::from_utf8_lossy(&bytes).trim().to_owned())
+}
+
+fn archive_default_coordinator_store() -> eyre::Result<()> {
+    #[cfg(feature = "redb-backend")]
+    {
+        let path = super::coordinator::default_redb_path()?;
+        if !path.exists() {
+            println!(
+                "no coordinator store at `{}`; nothing to archive",
+                path.display()
+            );
+            return Ok(());
+        }
+
+        let backup = available_backup_path(&path)?;
+        fs::rename(&path, &backup).with_context(|| {
+            format!(
+                "failed to archive coordinator store `{}` as `{}`",
+                path.display(),
+                backup.display()
+            )
+        })?;
+        println!(
+            "archived coordinator store `{}` as `{}`",
+            path.display(),
+            backup.display()
+        );
+        Ok(())
+    }
+    #[cfg(not(feature = "redb-backend"))]
+    {
+        bail!("--recreate-store requires the `redb-backend` feature")
+    }
+}
+
+#[cfg(feature = "redb-backend")]
+fn available_backup_path(path: &Path) -> eyre::Result<PathBuf> {
+    let file_name = path
+        .file_name()
+        .context("coordinator store path has no file name")?
+        .to_string_lossy();
+    let parent = path
+        .parent()
+        .context("coordinator store path has no parent directory")?;
+
+    for suffix in 0..u32::MAX {
+        let backup_name = if suffix == 0 {
+            format!("{file_name}.backup")
+        } else {
+            format!("{file_name}.backup.{suffix}")
+        };
+        let candidate = parent.join(backup_name);
+        if !candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+    bail!("could not find an available coordinator store backup path")
 }
 
 pub(crate) fn down(
@@ -146,9 +271,13 @@ pub(crate) fn dora_executable_path() -> eyre::Result<std::ffi::OsString> {
 /// - null stdio prevents broken-pipe crashes when the parent's terminal closes
 /// - new process group prevents terminal signals (SIGHUP/SIGINT) from propagating
 pub(crate) fn detach_process(cmd: &mut Command) {
+    detach_process_with_stderr(cmd, Stdio::null());
+}
+
+fn detach_process_with_stderr(cmd: &mut Command, stderr: impl Into<Stdio>) {
     cmd.stdin(Stdio::null());
     cmd.stdout(Stdio::null());
-    cmd.stderr(Stdio::null());
+    cmd.stderr(stderr);
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;
@@ -156,7 +285,7 @@ pub(crate) fn detach_process(cmd: &mut Command) {
     }
 }
 
-fn start_coordinator(auth: bool) -> eyre::Result<()> {
+fn start_coordinator(auth: bool) -> eyre::Result<CoordinatorStartup> {
     let path = dora_executable_path()?;
     let mut cmd = Command::new(path);
     cmd.arg("coordinator");
@@ -164,15 +293,19 @@ fn start_coordinator(auth: bool) -> eyre::Result<()> {
     if auth {
         cmd.arg("--auth");
     }
-    detach_process(&mut cmd);
-    cmd.spawn().wrap_err(
+    let stderr = tempfile::tempfile().wrap_err("failed to create coordinator stderr capture")?;
+    let child_stderr = stderr
+        .try_clone()
+        .wrap_err("failed to clone coordinator stderr capture")?;
+    detach_process_with_stderr(&mut cmd, child_stderr);
+    let child = cmd.spawn().wrap_err(
         "failed to run `dora coordinator`\n\n  \
          hint: ensure the `dora` binary is in your PATH",
     )?;
 
     println!("started dora coordinator");
 
-    Ok(())
+    Ok(CoordinatorStartup { child, stderr })
 }
 
 fn start_daemon() -> eyre::Result<()> {

--- a/binaries/cli/src/command/up.rs
+++ b/binaries/cli/src/command/up.rs
@@ -55,17 +55,28 @@ pub(crate) fn up(config_path: Option<&Path>, auth: bool, recreate_store: bool) -
         .and_then(|s| s.parse().ok())
         .unwrap_or(DORA_COORDINATOR_PORT_WS_DEFAULT);
     let coordinator_addr = (addr, port).into();
+    // Keep the lock through daemon readiness so overlapping recreation commands
+    // cannot race either the fresh coordinator or its daemon startup.
+    let mut _recreation_lock = None;
     let session = match connect_to_coordinator(coordinator_addr) {
         Ok(session) => {
             println!("coordinator already running on {coordinator_addr}");
             session
         }
-        Err(_) => {
-            if recreate_store {
-                archive_default_coordinator_store()?;
+        Err(_) if recreate_store => {
+            _recreation_lock = Some(lock_default_coordinator_store_recreation()?);
+            match connect_to_coordinator(coordinator_addr) {
+                Ok(session) => {
+                    println!("coordinator already running on {coordinator_addr}");
+                    session
+                }
+                Err(_) => {
+                    archive_default_coordinator_store()?;
+                    start_and_wait_for_coordinator(coordinator_addr, port, auth)?
+                }
             }
-            start_and_wait_for_coordinator(coordinator_addr, port, auth)?
         }
+        Err(_) => start_and_wait_for_coordinator(coordinator_addr, port, auth)?,
     };
 
     if !daemon_running(&session)? {
@@ -188,6 +199,48 @@ fn archive_default_coordinator_store() -> eyre::Result<()> {
     {
         bail!("--recreate-store requires the `redb-backend` feature")
     }
+}
+
+fn lock_default_coordinator_store_recreation() -> eyre::Result<fs::File> {
+    #[cfg(feature = "redb-backend")]
+    {
+        let path = super::coordinator::default_redb_path()?;
+        lock_coordinator_store_recreation(&path)
+    }
+    #[cfg(not(feature = "redb-backend"))]
+    {
+        bail!("--recreate-store requires the `redb-backend` feature")
+    }
+}
+
+#[cfg(feature = "redb-backend")]
+fn lock_coordinator_store_recreation(path: &Path) -> eyre::Result<fs::File> {
+    use fs2::FileExt as _;
+
+    let file_name = path
+        .file_name()
+        .context("coordinator store path has no file name")?
+        .to_string_lossy();
+    let lock_path = path.with_file_name(format!("{file_name}.recreate.lock"));
+    let lock = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .with_context(|| {
+            format!(
+                "failed to open coordinator store recreation lock `{}`",
+                lock_path.display()
+            )
+        })?;
+    lock.lock_exclusive().with_context(|| {
+        format!(
+            "failed to lock coordinator store recreation at `{}`",
+            lock_path.display()
+        )
+    })?;
+    Ok(lock)
 }
 
 #[cfg(feature = "redb-backend")]
@@ -322,4 +375,48 @@ fn start_daemon() -> eyre::Result<()> {
     println!("started dora daemon");
 
     Ok(())
+}
+
+#[cfg(all(test, feature = "redb-backend"))]
+mod tests {
+    use super::{available_backup_path, lock_coordinator_store_recreation};
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    #[test]
+    fn coordinator_store_backup_path_skips_existing_backups() {
+        let dir = tempfile::tempdir().expect("create temporary store directory");
+        let store = dir.path().join("coordinator.redb");
+        std::fs::write(dir.path().join("coordinator.redb.backup"), []).expect("create backup");
+        std::fs::write(dir.path().join("coordinator.redb.backup.1"), [])
+            .expect("create numbered backup");
+
+        let backup = available_backup_path(&store).expect("select available backup path");
+
+        assert_eq!(backup, dir.path().join("coordinator.redb.backup.2"));
+    }
+
+    #[test]
+    fn coordinator_store_recreation_lock_serializes_callers() {
+        let dir = tempfile::tempdir().expect("create temporary store directory");
+        let store = dir.path().join("coordinator.redb");
+        let first = lock_coordinator_store_recreation(&store).expect("acquire first lock");
+        let (tx, rx) = mpsc::channel();
+
+        let waiter = std::thread::spawn(move || {
+            let second = lock_coordinator_store_recreation(&store).expect("acquire second lock");
+            tx.send(second).expect("report acquired lock");
+        });
+
+        assert!(
+            rx.recv_timeout(Duration::from_millis(100)).is_err(),
+            "second recreation acquired the lock before the first released it"
+        );
+        drop(first);
+        let second = rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("second recreation did not acquire the released lock");
+        drop(second);
+        waiter.join().expect("join lock waiter");
+    }
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -313,9 +313,17 @@ Start coordinator and daemon in local mode.
 
 ```
 dora up
+dora up --recreate-store
 ```
 
 Spawns `dora coordinator` and `dora daemon` as background processes. Waits for both to be ready before returning. Idempotent: if already running, does nothing.
+
+| Flag | Description |
+|------|-------------|
+| `--auth` | Enable token authentication for the coordinator |
+| `--recreate-store` | Archive `~/.dora/coordinator.redb` and start with a fresh persistent store |
+
+If the coordinator cannot start, `dora up` reports its startup error directly. After an upgrade reports an incompatible redb schema, rerun with `--recreate-store`. The old store is preserved alongside the new one as `coordinator.redb.backup` (or a numbered variant).
 
 When running the daemon directly (e.g., for distributed deployments), additional flags are available:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -325,6 +325,8 @@ Spawns `dora coordinator` and `dora daemon` as background processes. Waits for b
 
 If the coordinator cannot start, `dora up` reports its startup error directly. After an upgrade reports an incompatible redb schema, rerun with `--recreate-store`. The old store is preserved alongside the new one as `coordinator.redb.backup` (or a numbered variant).
 
+The spawned coordinator's stderr is captured to `~/.dora/coordinator-stderr.log` (truncated on each `dora up`) so post-startup errors stay inspectable. `--recreate-store` only operates on the local default store: it is refused when `DORA_COORDINATOR_ADDR` points at a non-loopback address, skipped (with a notice) when a coordinator is already running, and aborted when a process is listening on the coordinator port but the connection fails (e.g. an auth token mismatch) — so a live coordinator's store is never archived out from under it.
+
 When running the daemon directly (e.g., for distributed deployments), additional flags are available:
 
 | Flag | Default | Description |

--- a/guide/src/operations/cli.md
+++ b/guide/src/operations/cli.md
@@ -336,6 +336,8 @@ Spawns `dora coordinator` and `dora daemon` as background processes. Waits for b
 
 If the coordinator cannot start, `dora up` reports its startup error directly. After an upgrade reports an incompatible redb schema, rerun with `--recreate-store`. The old store is preserved alongside the new one as `coordinator.redb.backup` (or a numbered variant).
 
+The spawned coordinator's stderr is captured to `~/.dora/coordinator-stderr.log` (truncated on each `dora up`) so post-startup errors stay inspectable. `--recreate-store` only operates on the local default store: it is refused when `DORA_COORDINATOR_ADDR` points at a non-loopback address, skipped (with a notice) when a coordinator is already running, and aborted when a process is listening on the coordinator port but the connection fails (e.g. an auth token mismatch) — so a live coordinator's store is never archived out from under it.
+
 #### `dora down` (alias: `dora destroy`)
 
 Tear down coordinator and daemon. Stops all running dataflows first.

--- a/guide/src/operations/cli.md
+++ b/guide/src/operations/cli.md
@@ -324,9 +324,17 @@ Start coordinator and daemon in local mode.
 
 ```
 dora up
+dora up --recreate-store
 ```
 
 Spawns `dora coordinator` and `dora daemon` as background processes. Waits for both to be ready before returning. Idempotent: if already running, does nothing.
+
+| Flag | Description |
+|------|-------------|
+| `--auth` | Enable token authentication for the coordinator |
+| `--recreate-store` | Archive `~/.dora/coordinator.redb` and start with a fresh persistent store |
+
+If the coordinator cannot start, `dora up` reports its startup error directly. After an upgrade reports an incompatible redb schema, rerun with `--recreate-store`. The old store is preserved alongside the new one as `coordinator.redb.backup` (or a numbered variant).
 
 #### `dora down` (alias: `dora destroy`)
 

--- a/libraries/coordinator-store/Cargo.toml
+++ b/libraries/coordinator-store/Cargo.toml
@@ -17,7 +17,7 @@ dora-message = { workspace = true }
 bincode = { version = "2.0", features = ["serde"], optional = true }
 eyre = { workspace = true }
 libc = { version = "0.2", optional = true }
-redb = { version = "2", optional = true }
+redb = { workspace = true, optional = true }
 serde = { workspace = true }
 tracing = { workspace = true, optional = true }
 uuid = { workspace = true }

--- a/libraries/coordinator-store/src/lib.rs
+++ b/libraries/coordinator-store/src/lib.rs
@@ -5,6 +5,13 @@ mod redb_store;
 
 pub use in_memory::InMemoryStore;
 
+/// Marker prefix of the error produced by `RedbStore::open` on a schema
+/// version mismatch. The CLI (`dora up`) matches coordinator stderr against
+/// this exact string to decide whether to suggest `--recreate-store`, so any
+/// rewording must update both sites together (covered end-to-end by
+/// `tests/ws-cli-e2e.rs::e2e_up_reports_incompatible_coordinator_store`).
+pub const SCHEMA_MISMATCH_MARKER: &str = "redb schema version mismatch";
+
 /// Maximum allowed length for a param key (bytes).
 pub const MAX_PARAM_KEY_BYTES: usize = 256;
 /// Maximum allowed size for a serialized param value (bytes).

--- a/libraries/coordinator-store/src/redb_store.rs
+++ b/libraries/coordinator-store/src/redb_store.rs
@@ -88,11 +88,12 @@ impl RedbStore {
             match stored {
                 Some(v) if v != SCHEMA_VERSION => {
                     return Err(eyre!(
-                        "redb schema version mismatch: database at `{}` has v{v}, \
+                        "{marker}: database at `{path}` has v{v}, \
                          but this binary expects v{SCHEMA_VERSION}. \
                          Delete the file and restart to create a fresh database, \
                          or use `--store memory` to bypass persistence.",
-                        path.display()
+                        marker = crate::SCHEMA_MISMATCH_MARKER,
+                        path = path.display()
                     ));
                 }
                 Some(_) => {} // version matches

--- a/libraries/coordinator-store/src/redb_store.rs
+++ b/libraries/coordinator-store/src/redb_store.rs
@@ -91,7 +91,6 @@ impl RedbStore {
                         "redb schema version mismatch: database at `{}` has v{v}, \
                          but this binary expects v{SCHEMA_VERSION}. \
                          Delete the file and restart to create a fresh database, \
-                         run `dora up --recreate-store` to archive it first, \
                          or use `--store memory` to bypass persistence.",
                         path.display()
                     ));
@@ -794,6 +793,10 @@ mod tests {
                 assert!(
                     msg.contains("schema version mismatch"),
                     "expected schema version mismatch error, got: {msg}"
+                );
+                assert!(
+                    !msg.contains("dora up --recreate-store"),
+                    "custom redb paths must not receive default-store recovery advice: {msg}"
                 );
             }
         }

--- a/libraries/coordinator-store/src/redb_store.rs
+++ b/libraries/coordinator-store/src/redb_store.rs
@@ -91,6 +91,7 @@ impl RedbStore {
                         "redb schema version mismatch: database at `{}` has v{v}, \
                          but this binary expects v{SCHEMA_VERSION}. \
                          Delete the file and restart to create a fresh database, \
+                         run `dora up --recreate-store` to archive it first, \
                          or use `--store memory` to bypass persistence.",
                         path.display()
                     ));

--- a/tests/ws-cli-e2e.rs
+++ b/tests/ws-cli-e2e.rs
@@ -1016,12 +1016,13 @@ mod real_dataflow {
     use dora_message::{
         cli_to_coordinator::ControlRequest, coordinator_to_cli::ControlRequestReply,
     };
+    use fs2::FileExt as _;
     use redb::{Database, TableDefinition};
     use std::net::SocketAddr;
     use std::path::Path;
     use std::process::{Command, Stdio};
     use std::sync::Once;
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
     use tempfile::tempdir;
     use uuid::Uuid;
 
@@ -1097,21 +1098,54 @@ mod real_dataflow {
         port: u16,
         args: &[&str],
     ) -> (std::process::ExitStatus, String, String) {
+        let capture_name = args.join("-");
+        let (child, stdout_path, stderr_path) =
+            spawn_dora_isolated(dora, home, port, args, &capture_name);
+        wait_for_dora_isolated(child, stdout_path, stderr_path)
+    }
+
+    fn spawn_dora_isolated(
+        dora: &str,
+        home: &Path,
+        port: u16,
+        args: &[&str],
+        capture_name: &str,
+    ) -> (std::process::Child, std::path::PathBuf, std::path::PathBuf) {
         // Files avoid waiting for pipe EOF on Windows when a detached child
         // inherits a standard-stream handle from `dora up`.
-        let stdout_path = home.join(format!("{}-stdout.txt", args.join("-")));
-        let stderr_path = home.join(format!("{}-stderr.txt", args.join("-")));
+        let stdout_path = home.join(format!("{capture_name}-stdout.txt"));
+        let stderr_path = home.join(format!("{capture_name}-stderr.txt"));
         let stdout = std::fs::File::create(&stdout_path).expect("create stdout capture");
         let stderr = std::fs::File::create(&stderr_path).expect("create stderr capture");
-        let status = Command::new(dora)
+        let child = Command::new(dora)
             .args(args)
             .env("HOME", home)
             .env("USERPROFILE", home)
             .env("DORA_COORDINATOR_PORT", port.to_string())
             .stdout(stdout)
             .stderr(stderr)
-            .status()
-            .expect("run isolated dora command");
+            .spawn()
+            .expect("spawn isolated dora command");
+        (child, stdout_path, stderr_path)
+    }
+
+    fn wait_for_dora_isolated(
+        mut child: std::process::Child,
+        stdout_path: std::path::PathBuf,
+        stderr_path: std::path::PathBuf,
+    ) -> (std::process::ExitStatus, String, String) {
+        let deadline = Instant::now() + Duration::from_secs(15);
+        let status = loop {
+            if let Some(status) = child.try_wait().expect("poll isolated dora command") {
+                break status;
+            }
+            if Instant::now() >= deadline {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("isolated dora command did not exit within 15 seconds");
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        };
         let stdout = std::fs::read_to_string(stdout_path).unwrap_or_default();
         let stderr = std::fs::read_to_string(stderr_path).unwrap_or_default();
         (status, stdout, stderr)
@@ -1180,6 +1214,102 @@ mod real_dataflow {
         assert!(
             store_dir.join("coordinator.redb").exists(),
             "fresh coordinator store was not created"
+        );
+    }
+
+    #[test]
+    fn e2e_concurrent_up_recreate_store_preserves_original_backup() {
+        ensure_built();
+        let dora = dora_bin();
+        let home = tempdir().expect("create isolated home");
+        write_incompatible_coordinator_store(home.path());
+        let port = unused_port();
+        let store_dir = home.path().join(".dora");
+        let lock_path = store_dir.join("coordinator.redb.recreate.lock");
+        let lock = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(lock_path)
+            .expect("open recreation lock");
+        lock.lock_exclusive().expect("hold recreation lock");
+
+        let (mut first, first_stdout, first_stderr) = spawn_dora_isolated(
+            &dora,
+            home.path(),
+            port,
+            &["up", "--recreate-store"],
+            "first-recreate",
+        );
+        let (mut second, second_stdout, second_stderr) = spawn_dora_isolated(
+            &dora,
+            home.path(),
+            port,
+            &["up", "--recreate-store"],
+            "second-recreate",
+        );
+        std::thread::sleep(Duration::from_millis(200));
+        assert!(
+            first.try_wait().expect("poll first recreation").is_none(),
+            "first recreation ignored the held store lock"
+        );
+        assert!(
+            second.try_wait().expect("poll second recreation").is_none(),
+            "second recreation ignored the held store lock"
+        );
+        fs2::FileExt::unlock(&lock).expect("release recreation lock");
+
+        let (first_status, first_stdout, first_stderr) =
+            wait_for_dora_isolated(first, first_stdout, first_stderr);
+        let (second_status, second_stdout, second_stderr) =
+            wait_for_dora_isolated(second, second_stdout, second_stderr);
+        let (down_status, down_stdout, down_stderr) =
+            run_dora_isolated(&dora, home.path(), port, &["down"]);
+
+        assert!(
+            first_status.success(),
+            "first recreation failed; stdout:\n{first_stdout}\nstderr:\n{first_stderr}"
+        );
+        assert!(
+            second_status.success(),
+            "second recreation failed; stdout:\n{second_stdout}\nstderr:\n{second_stderr}"
+        );
+        assert!(
+            down_status.success(),
+            "failed to stop isolated coordinator; stdout:\n{down_stdout}\nstderr:\n{down_stderr}"
+        );
+
+        let backups: Vec<_> = std::fs::read_dir(&store_dir)
+            .expect("read store directory")
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.file_name().is_some_and(|name| {
+                    name.to_string_lossy()
+                        .starts_with("coordinator.redb.backup")
+                })
+            })
+            .collect();
+        assert_eq!(
+            backups.len(),
+            1,
+            "concurrent recreation should archive the original store exactly once"
+        );
+        let backup = Database::open(&backups[0]).expect("open archived store");
+        let txn = backup.begin_read().expect("read archived store");
+        let meta = txn
+            .open_table::<&str, u32>(TableDefinition::new("meta"))
+            .expect("open archived metadata table");
+        let archived_version = meta
+            .get("schema_version")
+            .expect("read archived schema version")
+            .expect("archived schema version exists")
+            .value();
+        assert_eq!(
+            archived_version,
+            u32::MAX,
+            "the original incompatible store backup was overwritten"
         );
     }
 

--- a/tests/ws-cli-e2e.rs
+++ b/tests/ws-cli-e2e.rs
@@ -1122,11 +1122,41 @@ mod real_dataflow {
             .env("HOME", home)
             .env("USERPROFILE", home)
             .env("DORA_COORDINATOR_PORT", port.to_string())
+            // Complete the isolation: an inherited coordinator address would
+            // make these tests poll a foreign host after mutating the store.
+            .env_remove("DORA_COORDINATOR_ADDR")
+            .env_remove("DORA_COORDINATOR_INTERFACE")
             .stdout(stdout)
             .stderr(stderr)
             .spawn()
             .expect("spawn isolated dora command");
         (child, stdout_path, stderr_path)
+    }
+
+    /// Kills the wrapped `dora` CLI process on drop so assertion failures
+    /// cannot leak children blocked on the recreation lock — once the test's
+    /// lock is released by the panic, such a child would spawn a detached
+    /// coordinator + daemon pointing at the already-deleted temp HOME and
+    /// pollute the rest of the serially-run suite.
+    struct KillOnDrop(Option<std::process::Child>);
+
+    impl KillOnDrop {
+        fn child(&mut self) -> &mut std::process::Child {
+            self.0.as_mut().expect("child already taken")
+        }
+
+        fn into_inner(mut self) -> std::process::Child {
+            self.0.take().expect("child already taken")
+        }
+    }
+
+    impl Drop for KillOnDrop {
+        fn drop(&mut self) {
+            if let Some(mut child) = self.0.take() {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+        }
     }
 
     fn wait_for_dora_isolated(
@@ -1201,20 +1231,30 @@ mod real_dataflow {
             "store archive was not announced; stdout:\n{stdout}\nstderr:\n{stderr}"
         );
         let store_dir = home.path().join(".dora");
-        let has_backup = std::fs::read_dir(&store_dir)
-            .expect("read store directory")
-            .filter_map(Result::ok)
-            .any(|entry| {
-                entry
-                    .file_name()
-                    .to_string_lossy()
-                    .starts_with("coordinator.redb.backup")
-            });
-        assert!(has_backup, "incompatible store was not archived");
+        assert!(
+            !backup_files(&store_dir).is_empty(),
+            "incompatible store was not archived"
+        );
         assert!(
             store_dir.join("coordinator.redb").exists(),
             "fresh coordinator store was not created"
         );
+    }
+
+    /// All `coordinator.redb.backup*` files in the store directory (the
+    /// naming scheme of `available_backup_path` in dora-cli).
+    fn backup_files(store_dir: &Path) -> Vec<std::path::PathBuf> {
+        std::fs::read_dir(store_dir)
+            .expect("read store directory")
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.file_name().is_some_and(|name| {
+                    name.to_string_lossy()
+                        .starts_with("coordinator.redb.backup")
+                })
+            })
+            .collect()
     }
 
     #[test]
@@ -1235,35 +1275,57 @@ mod real_dataflow {
             .expect("open recreation lock");
         lock.lock_exclusive().expect("hold recreation lock");
 
-        let (mut first, first_stdout, first_stderr) = spawn_dora_isolated(
+        let (first, first_stdout, first_stderr) = spawn_dora_isolated(
             &dora,
             home.path(),
             port,
             &["up", "--recreate-store"],
             "first-recreate",
         );
-        let (mut second, second_stdout, second_stderr) = spawn_dora_isolated(
+        let mut first = KillOnDrop(Some(first));
+        let (second, second_stdout, second_stderr) = spawn_dora_isolated(
             &dora,
             home.path(),
             port,
             &["up", "--recreate-store"],
             "second-recreate",
         );
+        let mut second = KillOnDrop(Some(second));
         std::thread::sleep(Duration::from_millis(200));
         assert!(
-            first.try_wait().expect("poll first recreation").is_none(),
+            first
+                .child()
+                .try_wait()
+                .expect("poll first recreation")
+                .is_none(),
             "first recreation ignored the held store lock"
         );
         assert!(
-            second.try_wait().expect("poll second recreation").is_none(),
+            second
+                .child()
+                .try_wait()
+                .expect("poll second recreation")
+                .is_none(),
             "second recreation ignored the held store lock"
+        );
+        // Neither invocation may touch the store before holding the lock; if
+        // the lock acquisition is ever removed from `up()`, these assertions
+        // fail deterministically (the liveness checks above pass either way,
+        // and the final single-backup count is reachable without locking).
+        assert!(
+            store_dir.join("coordinator.redb").exists(),
+            "a recreation archived the store without holding the lock"
+        );
+        assert!(
+            backup_files(&store_dir).is_empty(),
+            "backup created while the external lock was held"
         );
         fs2::FileExt::unlock(&lock).expect("release recreation lock");
 
         let (first_status, first_stdout, first_stderr) =
-            wait_for_dora_isolated(first, first_stdout, first_stderr);
+            wait_for_dora_isolated(first.into_inner(), first_stdout, first_stderr);
         let (second_status, second_stdout, second_stderr) =
-            wait_for_dora_isolated(second, second_stdout, second_stderr);
+            wait_for_dora_isolated(second.into_inner(), second_stdout, second_stderr);
         let (down_status, down_stdout, down_stderr) =
             run_dora_isolated(&dora, home.path(), port, &["down"]);
 
@@ -1280,17 +1342,7 @@ mod real_dataflow {
             "failed to stop isolated coordinator; stdout:\n{down_stdout}\nstderr:\n{down_stderr}"
         );
 
-        let backups: Vec<_> = std::fs::read_dir(&store_dir)
-            .expect("read store directory")
-            .filter_map(Result::ok)
-            .map(|entry| entry.path())
-            .filter(|path| {
-                path.file_name().is_some_and(|name| {
-                    name.to_string_lossy()
-                        .starts_with("coordinator.redb.backup")
-                })
-            })
-            .collect();
+        let backups = backup_files(&store_dir);
         assert_eq!(
             backups.len(),
             1,
@@ -1310,6 +1362,82 @@ mod real_dataflow {
             archived_version,
             u32::MAX,
             "the original incompatible store backup was overwritten"
+        );
+    }
+
+    #[test]
+    fn e2e_up_recreate_store_skips_archive_when_coordinator_running() {
+        ensure_built();
+        let dora = dora_bin();
+        let home = tempdir().expect("create isolated home");
+        let port = unused_port();
+
+        let (up_status, up_stdout, up_stderr) =
+            run_dora_isolated(&dora, home.path(), port, &["up"]);
+        let (status, stdout, stderr) =
+            run_dora_isolated(&dora, home.path(), port, &["up", "--recreate-store"]);
+        let (down_status, down_stdout, down_stderr) =
+            run_dora_isolated(&dora, home.path(), port, &["down"]);
+
+        assert!(
+            up_status.success(),
+            "initial dora up failed; stdout:\n{up_stdout}\nstderr:\n{up_stderr}"
+        );
+        assert!(
+            status.success(),
+            "recreate against a running coordinator failed; stdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+        assert!(
+            down_status.success(),
+            "failed to stop isolated coordinator; stdout:\n{down_stdout}\nstderr:\n{down_stderr}"
+        );
+        assert!(
+            stdout.contains("--recreate-store skipped"),
+            "skip notice was not printed; stdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+        let store_dir = home.path().join(".dora");
+        assert!(
+            backup_files(&store_dir).is_empty(),
+            "live store was archived despite a running coordinator"
+        );
+        assert!(
+            store_dir.join("coordinator.redb").exists(),
+            "live coordinator store went missing"
+        );
+    }
+
+    #[test]
+    fn e2e_up_recreate_store_with_no_existing_store_succeeds() {
+        ensure_built();
+        let dora = dora_bin();
+        let home = tempdir().expect("create isolated home");
+        let port = unused_port();
+
+        let (status, stdout, stderr) =
+            run_dora_isolated(&dora, home.path(), port, &["up", "--recreate-store"]);
+        let (down_status, down_stdout, down_stderr) =
+            run_dora_isolated(&dora, home.path(), port, &["down"]);
+
+        assert!(
+            status.success(),
+            "dora up --recreate-store failed on an empty home; stdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+        assert!(
+            down_status.success(),
+            "failed to stop isolated coordinator; stdout:\n{down_stdout}\nstderr:\n{down_stderr}"
+        );
+        assert!(
+            stdout.contains("nothing to archive"),
+            "missing-store notice was not printed; stdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+        let store_dir = home.path().join(".dora");
+        assert!(
+            backup_files(&store_dir).is_empty(),
+            "backup created although no store existed"
+        );
+        assert!(
+            store_dir.join("coordinator.redb").exists(),
+            "fresh coordinator store was not created"
         );
     }
 

--- a/tests/ws-cli-e2e.rs
+++ b/tests/ws-cli-e2e.rs
@@ -1016,11 +1016,13 @@ mod real_dataflow {
     use dora_message::{
         cli_to_coordinator::ControlRequest, coordinator_to_cli::ControlRequestReply,
     };
+    use redb::{Database, TableDefinition};
     use std::net::SocketAddr;
     use std::path::Path;
     use std::process::{Command, Stdio};
     use std::sync::Once;
     use std::time::Duration;
+    use tempfile::tempdir;
     use uuid::Uuid;
 
     static BUILD: Once = Once::new();
@@ -1063,6 +1065,122 @@ mod real_dataflow {
                 .expect("failed to build");
             assert!(status.success());
         });
+    }
+
+    fn write_incompatible_coordinator_store(home: &Path) {
+        let path = home.join(".dora").join("coordinator.redb");
+        std::fs::create_dir_all(path.parent().expect("store parent"))
+            .expect("create store directory");
+        let db = Database::create(path).expect("create redb store");
+        let txn = db.begin_write().expect("begin redb transaction");
+        {
+            let mut meta: redb::Table<'_, &str, u32> = txn
+                .open_table(TableDefinition::new("meta"))
+                .expect("open metadata table");
+            meta.insert("schema_version", u32::MAX)
+                .expect("write incompatible schema version");
+        }
+        txn.commit().expect("commit incompatible store");
+    }
+
+    fn unused_port() -> u16 {
+        std::net::TcpListener::bind(("127.0.0.1", 0))
+            .expect("bind ephemeral port")
+            .local_addr()
+            .expect("read ephemeral port")
+            .port()
+    }
+
+    fn run_dora_isolated(
+        dora: &str,
+        home: &Path,
+        port: u16,
+        args: &[&str],
+    ) -> (std::process::ExitStatus, String, String) {
+        // Files avoid waiting for pipe EOF on Windows when a detached child
+        // inherits a standard-stream handle from `dora up`.
+        let stdout_path = home.join(format!("{}-stdout.txt", args.join("-")));
+        let stderr_path = home.join(format!("{}-stderr.txt", args.join("-")));
+        let stdout = std::fs::File::create(&stdout_path).expect("create stdout capture");
+        let stderr = std::fs::File::create(&stderr_path).expect("create stderr capture");
+        let status = Command::new(dora)
+            .args(args)
+            .env("HOME", home)
+            .env("USERPROFILE", home)
+            .env("DORA_COORDINATOR_PORT", port.to_string())
+            .stdout(stdout)
+            .stderr(stderr)
+            .status()
+            .expect("run isolated dora command");
+        let stdout = std::fs::read_to_string(stdout_path).unwrap_or_default();
+        let stderr = std::fs::read_to_string(stderr_path).unwrap_or_default();
+        (status, stdout, stderr)
+    }
+
+    #[test]
+    fn e2e_up_reports_incompatible_coordinator_store() {
+        ensure_built();
+        let dora = dora_bin();
+        let home = tempdir().expect("create isolated home");
+        write_incompatible_coordinator_store(home.path());
+
+        let (status, stdout, stderr) =
+            run_dora_isolated(&dora, home.path(), unused_port(), &["up"]);
+
+        assert!(
+            !status.success(),
+            "dora up unexpectedly succeeded; stdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("redb schema version mismatch"),
+            "coordinator startup error was not surfaced; stdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("dora up --recreate-store"),
+            "recovery hint was not surfaced; stdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+    }
+
+    #[test]
+    fn e2e_up_recreate_store_archives_incompatible_store() {
+        ensure_built();
+        let dora = dora_bin();
+        let home = tempdir().expect("create isolated home");
+        write_incompatible_coordinator_store(home.path());
+        let port = unused_port();
+
+        let (status, stdout, stderr) =
+            run_dora_isolated(&dora, home.path(), port, &["up", "--recreate-store"]);
+        let (down_status, down_stdout, down_stderr) =
+            run_dora_isolated(&dora, home.path(), port, &["down"]);
+
+        assert!(
+            status.success(),
+            "dora up --recreate-store failed; stdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+        assert!(
+            down_status.success(),
+            "failed to stop isolated coordinator; stdout:\n{down_stdout}\nstderr:\n{down_stderr}"
+        );
+        assert!(
+            stdout.contains("archived coordinator store"),
+            "store archive was not announced; stdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+        let store_dir = home.path().join(".dora");
+        let has_backup = std::fs::read_dir(&store_dir)
+            .expect("read store directory")
+            .filter_map(Result::ok)
+            .any(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with("coordinator.redb.backup")
+            });
+        assert!(has_backup, "incompatible store was not archived");
+        assert!(
+            store_dir.join("coordinator.redb").exists(),
+            "fresh coordinator store was not created"
+        );
     }
 
     fn cleanup(dora: &str) {


### PR DESCRIPTION
## Summary

- capture coordinator stderr during `dora up` startup and report early process exits directly
- add `dora up --recreate-store` to archive the default redb store before starting fresh
- serialize recreation with an OS file lock and recheck coordinator state after acquiring it, preventing overlapping commands from overwriting the original backup
- keep the recreate hint in the default-store `dora up` path so custom `redb:/path` backends receive valid recovery guidance
- preserve prior stores as `coordinator.redb.backup` or a numbered variant instead of deleting persisted state
- document the recovery flow and add unit and full-stack regression coverage

Automatic deletion is intentionally avoided because the coordinator store contains persisted dataflow, build, and daemon records.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all --exclude dora-node-api-python --exclude dora-operator-api-python --exclude dora-ros2-bridge-python -- -D warnings`
- `cargo test --all --exclude dora-node-api-python --exclude dora-operator-api-python --exclude dora-ros2-bridge-python --exclude dora-cli-api-python --exclude dora-examples`
- `cargo check --examples`
- `cargo test -p dora-cli --lib coordinator_store_backup_path_skips_existing_backups`
- targeted `ws-cli-e2e` coverage for stale-store reporting, recreation, and concurrent recreation

Related: #2892
Closes #2921
