### PR TITLE
fix(core): bound the module-file read to prevent unbounded reads

### DIFF
--- a/libraries/core/src/descriptor/expand.rs
+++ b/libraries/core/src/descriptor/expand.rs
@@ -818,18 +818,27 @@ fn rewrite_inputs_map(
 }
 
 fn load_module_file(path: &Path) -> eyre::Result<ModuleFile> {
-    let metadata = std::fs::metadata(path)
-        .with_context(|| format!("failed to stat module file: {}", path.display()))?;
-    if metadata.len() > MAX_MODULE_FILE_SIZE {
+    use std::io::Read as _;
+    // Bound the read itself, not just a `metadata().len()` pre-check: that
+    // check reports 0 for FIFOs/character devices (e.g. `/dev/zero`) and is
+    // racy against a file being appended to, so it would sail past the cap and
+    // then `std::fs::read` unboundedly — exactly the "infinite files" DoS the
+    // limit is meant to prevent. `take(MAX + 1)` caps the read regardless of
+    // what the file claims its size is; if we hit the cap we reject. Mirrors
+    // the manifest loader in `crate::manifest`.
+    let file = std::fs::File::open(path)
+        .with_context(|| format!("failed to read module file: {}", path.display()))?;
+    let mut buf = Vec::new();
+    file.take(MAX_MODULE_FILE_SIZE + 1)
+        .read_to_end(&mut buf)
+        .with_context(|| format!("failed to read module file: {}", path.display()))?;
+    if buf.len() as u64 > MAX_MODULE_FILE_SIZE {
         bail!(
-            "module file too large ({} bytes, limit {}): {}",
-            metadata.len(),
+            "module file too large (limit {} bytes): {}",
             MAX_MODULE_FILE_SIZE,
             path.display()
         );
     }
-    let buf = std::fs::read(path)
-        .with_context(|| format!("failed to read module file: {}", path.display()))?;
     serde_yaml::from_slice(&buf)
         .with_context(|| format!("failed to parse module file: {}", path.display()))
 }
@@ -852,6 +861,36 @@ mod tests {
 
     fn parse_descriptor(yaml: &str) -> Descriptor {
         serde_yaml::from_str(yaml).unwrap()
+    }
+
+    #[test]
+    fn load_module_file_rejects_oversized_file() {
+        let tmp = TempDir::new().unwrap();
+        // A valid module prefix followed by padding that pushes the file just
+        // over the cap. The read is bounded, so this is rejected before the
+        // whole (potentially unbounded) file is pulled into memory.
+        let mut content = String::from("module:\n  name: big\n  outputs: [x]\nnodes: []\n");
+        content.push_str("# ");
+        content.push_str(&"a".repeat((MAX_MODULE_FILE_SIZE + 16) as usize));
+        let path = write_file(tmp.path(), "big_module.yml", &content);
+
+        let err = load_module_file(&path).unwrap_err().to_string();
+        assert!(err.contains("too large"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn load_module_file_accepts_file_at_limit() {
+        let tmp = TempDir::new().unwrap();
+        // Exactly the cap (padding the comment out to MAX_MODULE_FILE_SIZE
+        // bytes total) must still load — the `+ 1` in `take` is what makes the
+        // boundary inclusive.
+        let prefix = "module:\n  name: ok\n  outputs: [x]\nnodes: []\n# ";
+        let pad = (MAX_MODULE_FILE_SIZE as usize) - prefix.len();
+        let content = format!("{prefix}{}", "a".repeat(pad));
+        assert_eq!(content.len() as u64, MAX_MODULE_FILE_SIZE);
+        let path = write_file(tmp.path(), "ok_module.yml", &content);
+
+        assert!(load_module_file(&path).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Issue

`load_module_file` (`libraries/core/src/descriptor/expand.rs`) guarded oversized module files with a `std::fs::metadata().len()` pre-check, then read the file with an **unbounded** `std::fs::read`:

```rust
let metadata = std::fs::metadata(path)?;
if metadata.len() > MAX_MODULE_FILE_SIZE { bail!(...) }
let buf = std::fs::read(path)?; // unbounded
```

The `MAX_MODULE_FILE_SIZE` doc comment states this *"prevents DoS from huge or infinite files"*, but the metadata pre-check does not achieve that:

- **FIFOs / character devices** (e.g. `/dev/zero`) report a length of `0`, so the check passes and the unbounded read then never terminates — exactly the "infinite files" case the limit claims to prevent.
- The check is **racy** (TOCTOU): a file appended to between the `stat` and the `read` bypasses the cap.

The sibling manifest loader (`libraries/core/src/manifest/mod.rs::read`) was already hardened against this class of bug, with a comment noting *"a size check on metadata alone would miss FIFOs/devices and growing files."*

## Fix

Bound the read itself with `take(MAX_MODULE_FILE_SIZE + 1)` and reject when the cap is hit, mirroring the manifest loader. This drops the separate `stat` syscall (a single open+read instead of stat-then-read).

## Validation

- Added regression tests for the just-over-cap (rejected) and exactly-at-cap (accepted) boundaries.
- `cargo test -p dora-core`, `cargo clippy -p dora-core -- -D warnings`, `cargo fmt --check` all pass.

---

⚠️ **This is a machine-generated pull request authored by Claude (Claude Code).** It should be reviewed by a maintainer before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015PhdgdGBxVnQSk6ekLELQk)_