### PR TITLE
docs(message): add a compile-checked doctest for format_duration

### DIFF
--- a/libraries/message/src/config.rs
+++ b/libraries/message/src/config.rs
@@ -436,6 +436,31 @@ fn format_log_level(level: &crate::common::LogLevelOrStdout) -> &'static str {
     }
 }
 
+/// A [`Duration`] wrapper whose [`Display`](fmt::Display) renders a timer
+/// interval as `<unit>/<count>`, choosing the coarsest unit that represents the
+/// interval *exactly*.
+///
+/// This is the inverse of how a `dora/timer/<unit>/<count>` input is parsed, so
+/// the rendered string round-trips back to the same `Duration`. Picking the
+/// coarsest exact unit matters: rendering a sub-millisecond interval as
+/// `millis/0` would parse back to a zero-length (busy-loop) timer
+/// (dora-rs#2031).
+///
+/// Usually constructed via [`format_duration`].
+///
+/// ```
+/// use std::time::Duration;
+/// use dora_message::config::format_duration;
+///
+/// // Coarsest exact unit is chosen: whole seconds render as `secs`.
+/// assert_eq!(format_duration(Duration::from_secs(2)).to_string(), "secs/2");
+/// assert_eq!(format_duration(Duration::from_millis(100)).to_string(), "millis/100");
+/// // 1500 ms is not a whole number of seconds, so it stays in `millis`.
+/// assert_eq!(format_duration(Duration::from_millis(1500)).to_string(), "millis/1500");
+/// // Sub-millisecond intervals keep their precision instead of truncating to 0.
+/// assert_eq!(format_duration(Duration::from_micros(500)).to_string(), "micros/500");
+/// assert_eq!(format_duration(Duration::from_nanos(333_333)).to_string(), "nanos/333333");
+/// ```
 pub struct FormattedDuration(pub Duration);
 
 impl fmt::Display for FormattedDuration {
@@ -457,6 +482,9 @@ impl fmt::Display for FormattedDuration {
     }
 }
 
+/// Wrap a [`Duration`] so it renders as a `dora/timer`-style `<unit>/<count>`
+/// string. See [`FormattedDuration`] for the exact formatting rules and a
+/// round-trip example.
 pub fn format_duration(interval: Duration) -> FormattedDuration {
     FormattedDuration(interval)
 }


### PR DESCRIPTION
## Issue

`FormattedDuration` and `format_duration` (`libraries/message/src/config.rs`) are public API but carried no doc comments, despite implementing the non-obvious "coarsest exact unit" rule that keeps a timer interval round-tripping through the `dora/timer/<unit>/<count>` parser (the fix for #2031). Rendering a sub-millisecond interval as `millis/0` would parse back to a zero-length busy-loop timer.

## Fix

Document both items and add a compile-checked doctest that pins the contract:

- whole seconds render as `secs`
- `1500ms` stays in `millis` (not a whole number of seconds)
- sub-millisecond intervals keep their precision (`micros` / `nanos`) instead of truncating to zero

Documentation only; no behavior change.

## Validation

- `cargo test -p dora-message --doc` — the new `config::FormattedDuration` doctest compiles and passes alongside the existing ones.
- `cargo clippy -p dora-message -- -D warnings`, `cargo fmt --check` pass.

---

⚠️ **This is a machine-generated pull request authored by Claude (Claude Code).** It should be reviewed by a maintainer before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015PhdgdGBxVnQSk6ekLELQk)_