### PR TITLE
fix(runtime): report the correct callback name when a shared-lib on_event fails

### DIFF
--- a/binaries/runtime/src/operator/shared_lib.rs
+++ b/binaries/runtime/src/operator/shared_lib.rs
@@ -271,7 +271,7 @@ impl SharedLibraryOperator<'_> {
                 )
             };
             match error {
-                Some(error) => bail!("on_input failed: {}", *error),
+                Some(error) => bail!("on_event failed: {}", *error),
                 None => match status {
                     DoraStatus::Continue => {}
                     DoraStatus::Stop => break StopReason::ExplicitStop,


### PR DESCRIPTION
## Issue

When a shared-library operator's `dora_on_event` FFI call returns an error, the runtime reported it as `on_input failed: ...` (`binaries/runtime/src/operator/shared_lib.rs:274`).

There is no `on_input` callback in the operator FFI — the entry points are `dora_init_operator`, `dora_drop_operator`, and `dora_on_event`. The message points users at a callback that does not exist and mislabels the one that actually failed, sending anyone grepping logs down the wrong path.

## Fix

Report `on_event failed: ...` to match the callback that was invoked. Diagnostics only; no behavior change.

## Validation

- Confirmed via grep that `dora_on_event` / `bindings.on_event.on_event` is the only call at this site and there is no real `on_input`.
- `cargo test -p dora-runtime`, `cargo clippy -p dora-runtime --all-targets -- -D warnings`, `cargo fmt --check` pass.

---

⚠️ **This is a machine-generated pull request authored by Claude (Claude Code).** It should be reviewed by a maintainer before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015PhdgdGBxVnQSk6ekLELQk)_