### PR TITLE
fix(daemon): start the dataflow when a node death completes the startup barrier (#2967)

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -4655,7 +4655,7 @@ impl Daemon {
             ),
         };
 
-        dataflow
+        let status = dataflow
             .pending_nodes
             .handle_node_stop(
                 node_id,
@@ -4665,6 +4665,25 @@ impl Daemon {
                 &mut logger,
             )
             .await?;
+
+        // If this death completed the startup barrier (the dying node was the
+        // last cohort member yet to subscribe), the barrier resolves to
+        // `AllNodesReady` just as a final subscribe or a `RemoveNode` would —
+        // and both of those callers start the dataflow here. Do the same, so a
+        // non-cohort survivor that was answered `Ok(())` (since #2933) isn't
+        // left parked on a dataflow that never starts and never tears down
+        // (#2967). `start()` is idempotent and guarded by `dataflow_started`.
+        if matches!(status, DataflowStatus::AllNodesReady) && !dataflow.dataflow_started {
+            logger
+                .log(
+                    LogLevel::Info,
+                    None,
+                    Some("daemon".into()),
+                    "startup barrier completed by a node exit, starting dataflow",
+                )
+                .await;
+            dataflow.start(&self.events_tx, &self.clock).await?;
+        }
 
         // node only reaches here if it will not be restarted
         let might_restart = false;

--- a/binaries/daemon/src/pending.rs
+++ b/binaries/daemon/src/pending.rs
@@ -142,7 +142,7 @@ impl PendingNodes {
         clock: &HLC,
         cascading_errors: &mut CascadingErrorCauses,
         logger: &mut DataflowLogger<'_>,
-    ) -> eyre::Result<()> {
+    ) -> eyre::Result<DataflowStatus> {
         if self.local_nodes.remove(node_id) {
             logger
                 .log(
@@ -153,10 +153,19 @@ impl PendingNodes {
                 )
                 .await;
             self.exited_before_subscribe.push(node_id.clone());
-            self.update_dataflow_status(coordinator_sender, clock, cascading_errors, logger)
-                .await?;
+            // Return the barrier status so the caller can drive the same
+            // start-or-teardown transition that `Subscribe` and `RemoveNode`
+            // do. A death can complete the barrier just as a subscribe can;
+            // dropping the status here left a non-cohort survivor (answered
+            // `Ok(())` since #2933) parked on a dataflow that never starts
+            // and never tears down (#2967).
+            return self
+                .update_dataflow_status(coordinator_sender, clock, cascading_errors, logger)
+                .await;
         }
-        Ok(())
+        // The dying node was not a pending cohort member (it had already
+        // subscribed), so the barrier state is unchanged.
+        Ok(DataflowStatus::Pending)
     }
 
     pub async fn handle_dataflow_stop(
@@ -603,6 +612,70 @@ mod tests {
             reply_of(&mut rx),
             Ok(()),
             "the parked non-cohort node inherited a cohort member's death"
+        );
+    }
+
+    /// #2967: when a death is the *final* transition that completes the
+    /// startup barrier, `handle_node_stop` must report `AllNodesReady` — the
+    /// signal the daemon acts on to call `dataflow.start()`. Dropping it left
+    /// a non-cohort survivor parked on a dataflow that never started.
+    #[tokio::test]
+    async fn death_completing_the_barrier_reports_all_nodes_ready() {
+        let (last, survivor) = (node("last"), node("survivor"));
+        let mut p = pending();
+        // `last` is the only cohort member still pending; `survivor` joined
+        // later (not enrolled) and is parked waiting to run.
+        p.insert(last.clone());
+        let mut rx = park(&mut p, &survivor);
+
+        let mut daemon_logger = test_logger();
+        let status = p
+            .handle_node_stop(
+                &last,
+                &mut None,
+                &HLC::default(),
+                &mut CascadingErrorCauses::default(),
+                &mut daemon_logger.for_dataflow(uuid::Uuid::nil()),
+            )
+            .await
+            .expect("stop should succeed");
+
+        assert!(
+            matches!(status, DataflowStatus::AllNodesReady),
+            "a death that empties the cohort must report the barrier ready so \
+             the dataflow can start"
+        );
+        assert_eq!(
+            reply_of(&mut rx),
+            Ok(()),
+            "the non-cohort survivor should be released, not stranded"
+        );
+    }
+
+    /// A death that does *not* complete the barrier (other members still
+    /// pending) leaves it `Pending`, so the daemon does not start early.
+    #[tokio::test]
+    async fn death_leaving_the_barrier_incomplete_stays_pending() {
+        let (dead, still_pending) = (node("dead"), node("still-pending"));
+        let mut p = pending();
+        p.insert(dead.clone());
+        p.insert(still_pending.clone());
+
+        let mut daemon_logger = test_logger();
+        let status = p
+            .handle_node_stop(
+                &dead,
+                &mut None,
+                &HLC::default(),
+                &mut CascadingErrorCauses::default(),
+                &mut daemon_logger.for_dataflow(uuid::Uuid::nil()),
+            )
+            .await
+            .expect("stop should succeed");
+
+        assert!(
+            matches!(status, DataflowStatus::Pending),
+            "the barrier must stay pending while a cohort member has not resolved"
         );
     }
 


### PR DESCRIPTION
Fixes #2967.

## Problem

`PendingNodes::handle_node_stop` discarded the `DataflowStatus` returned by `update_dataflow_status`, whereas the two other callers of the startup barrier act on it and call `dataflow.start()` on `AllNodesReady`:

- `Subscribe` path — `lib.rs` `DataflowStatus::AllNodesReady if !dataflow.dataflow_started => { … dataflow.start(…) }`
- `RemoveNode` path (added in #2933) — same handling.

So when the barrier's **final** transition was a cohort member **dying before subscribing** (rather than subscribing), `start()` was never called.

Since #2933, a non-cohort subscriber is answered `Ok(())` even when the cohort fails (to avoid the #2917 cross-talk). A **non-dynamic** node added via `dora node add` during the pre-`dataflow_started` window is exactly such a survivor. Combined with the discarded status, it could end up subscribed-and-alive on a dataflow that:

- never starts — `dataflow_started` stays `false`, so timers never spawn, and
- never tears down — `should_finish` requires all remaining nodes to be dynamic, and the survivor is non-dynamic.

### Event sequence

1. Cohort `{A, B}`, neither subscribed, `dataflow_started == false`.
2. `dora node add X` (non-dynamic, not enrolled in the cohort); `X` subscribes → parked as a non-cohort waiter.
3. `A` dies before subscribing → barrier still `Pending` (status discarded).
4. `B` dies before subscribing → barrier completes; `X` is answered `Ok(())`; the resulting `AllNodesReady` is **discarded**, so `start()` is never called.
5. `X` sits subscribed, receives nothing, and the dataflow neither starts nor tears down.

## Fix

`handle_node_stop` now **returns** the barrier `DataflowStatus`, and `handle_node_stop_inner` drives the same start transition as the other two callers — starting the dataflow on `AllNodesReady` while `!dataflow_started`. `start()` only spawns timer tasks and sets the flag; it is idempotent and guarded by `dataflow_started`, so this is a no-op on the common path.

This is suggestion #1 in the issue ("make `handle_node_stop` act on the barrier status the way `handle_node_removal` and `Subscribe` do"), and makes all three barrier callers consistent.

## Tests

Fills the coverage gap the issue names ("no test drives barrier-completed-by-a-death with a non-cohort survivor parked"):

- `death_completing_the_barrier_reports_all_nodes_ready` — a death that empties the cohort reports `AllNodesReady` and releases a parked non-cohort survivor.
- `death_leaving_the_barrier_incomplete_stays_pending` — a death with another member still pending stays `Pending` (no early start).

Existing `pending` suite (13 tests) passes; `cargo fmt --all -- --check` and `cargo clippy -p dora-daemon -- -D warnings` are clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NSmdswXU8QEnQjskE8Tf45)_