### PR TITLE
fix(node): migrate TestingOutput::ToChannel from flume to tokio mpsc (#2956)

### DIFF
--- a/apis/rust/node/src/daemon_connection/node_integration_testing.rs
+++ b/apis/rust/node/src/daemon_connection/node_integration_testing.rs
@@ -166,8 +166,12 @@ impl IntegrationTestingEvents {
                 writeln!(writer.as_mut()).context("failed to write newline to output file")?;
             }
             OutputWriter::Channel(sender) => {
+                // The testing daemon simulation runs on a dedicated
+                // `std::thread` outside any tokio runtime (see
+                // `DoraNode::init_testing`), so `blocking_send` is safe here
+                // and gives flume's original blocking-on-full semantics.
                 sender
-                    .send(output)
+                    .blocking_send(output)
                     .context("failed to send output to channel")?;
             }
         }
@@ -234,7 +238,7 @@ impl IntegrationTestingEvents {
 
 enum OutputWriter {
     Writer(Box<dyn Write + Send>),
-    Channel(flume::Sender<serde_json::Map<String, serde_json::Value>>),
+    Channel(tokio::sync::mpsc::Sender<serde_json::Map<String, serde_json::Value>>),
 }
 
 pub fn convert_output_to_json(

--- a/apis/rust/node/src/daemon_connection/node_integration_testing.rs
+++ b/apis/rust/node/src/daemon_connection/node_integration_testing.rs
@@ -166,12 +166,9 @@ impl IntegrationTestingEvents {
                 writeln!(writer.as_mut()).context("failed to write newline to output file")?;
             }
             OutputWriter::Channel(sender) => {
-                // The testing daemon simulation runs on a dedicated
-                // `std::thread` outside any tokio runtime (see
-                // `DoraNode::init_testing`), so `blocking_send` is safe here
-                // and gives flume's original blocking-on-full semantics.
+                // Must not block: the node is waiting for this request's reply.
                 sender
-                    .blocking_send(output)
+                    .send(output)
                     .context("failed to send output to channel")?;
             }
         }
@@ -238,7 +235,7 @@ impl IntegrationTestingEvents {
 
 enum OutputWriter {
     Writer(Box<dyn Write + Send>),
-    Channel(tokio::sync::mpsc::Sender<serde_json::Map<String, serde_json::Value>>),
+    Channel(tokio::sync::mpsc::UnboundedSender<serde_json::Map<String, serde_json::Value>>),
 }
 
 pub fn convert_output_to_json(

--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -2314,12 +2314,54 @@ mod tests {
             "test-node".parse().unwrap(),
             events,
         ));
-        let (tx, _rx) = flume::unbounded();
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
         let outputs = TestingOutput::ToChannel(tx);
         let options = TestingOptions {
             skip_output_time_offsets: true,
         };
         crate::DoraNode::init_testing(inputs, outputs, options).unwrap()
+    }
+
+    /// #2956: an output sent through `TestingOutput::ToChannel` must actually
+    /// arrive on the receiver. This is the end-to-end path that the flume →
+    /// `tokio::sync::mpsc` migration touched (`handle_output`'s
+    /// `blocking_send`). Plain `#[test]` on purpose: the testing daemon
+    /// bridge uses `blocking_send`/`blocking_recv`, which panic inside a tokio
+    /// runtime.
+    #[test]
+    fn to_channel_delivers_outputs() {
+        use arrow::array::Int32Array;
+
+        let events = vec![TimedIncomingEvent {
+            time_offset_secs: 0.0,
+            event: IncomingEvent::Stop,
+        }];
+        let inputs = TestingInput::Input(IntegrationTestInput::new(
+            "test-node".parse().unwrap(),
+            events,
+        ));
+        let (tx, mut rx) = tokio::sync::mpsc::channel(16);
+        let outputs = TestingOutput::ToChannel(tx);
+        let options = TestingOptions {
+            skip_output_time_offsets: true,
+        };
+        let (mut node, _events) = crate::DoraNode::init_testing(inputs, outputs, options).unwrap();
+
+        node.send_output(
+            "out".parse().unwrap(),
+            Default::default(),
+            Int32Array::from(vec![1, 2, 3]),
+        )
+        .unwrap();
+
+        let received = rx
+            .try_recv()
+            .expect("output should have been delivered to the tokio mpsc channel");
+        assert_eq!(
+            received.get("id").and_then(|v| v.as_str()),
+            Some("out"),
+            "delivered output should carry the sent output id"
+        );
     }
 
     #[test]
@@ -2430,7 +2472,7 @@ mod tests {
             "test-node".parse().unwrap(),
             events,
         ));
-        let (tx, _rx) = flume::unbounded();
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
         let outputs = TestingOutput::ToChannel(tx);
         let options = TestingOptions {
             skip_output_time_offsets: true,
@@ -2497,7 +2539,7 @@ mod tests {
             "test-node".parse().unwrap(),
             events,
         ));
-        let (tx, _rx) = flume::unbounded();
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
         let outputs = TestingOutput::ToChannel(tx);
         let options = TestingOptions {
             skip_output_time_offsets: true,

--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -2314,7 +2314,7 @@ mod tests {
             "test-node".parse().unwrap(),
             events,
         ));
-        let (tx, _rx) = tokio::sync::mpsc::channel(16);
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         let outputs = TestingOutput::ToChannel(tx);
         let options = TestingOptions {
             skip_output_time_offsets: true,
@@ -2322,14 +2322,16 @@ mod tests {
         crate::DoraNode::init_testing(inputs, outputs, options).unwrap()
     }
 
-    /// #2956: an output sent through `TestingOutput::ToChannel` must actually
-    /// arrive on the receiver. This is the end-to-end path that the flume →
-    /// `tokio::sync::mpsc` migration touched (`handle_output`'s
-    /// `blocking_send`). Plain `#[test]` on purpose: the testing daemon
-    /// bridge uses `blocking_send`/`blocking_recv`, which panic inside a tokio
-    /// runtime.
+    /// #2956: outputs sent through `TestingOutput::ToChannel` must reach the
+    /// receiver, in order, when drained after the node has finished — the
+    /// documented usage pattern, and previously untested (every other
+    /// `ToChannel` test here drops the receiver).
+    ///
+    /// Plain `#[test]` on purpose: the testing bridge uses
+    /// `blocking_send`/`blocking_recv` on the request channel, which panic
+    /// inside a tokio runtime.
     #[test]
-    fn to_channel_delivers_outputs() {
+    fn to_channel_delivers_outputs_in_order() {
         use arrow::array::Int32Array;
 
         let events = vec![TimedIncomingEvent {
@@ -2340,28 +2342,33 @@ mod tests {
             "test-node".parse().unwrap(),
             events,
         ));
-        let (tx, mut rx) = tokio::sync::mpsc::channel(16);
+        let (tx, mut rx) = crate::integration_testing::unbounded_channel();
         let outputs = TestingOutput::ToChannel(tx);
         let options = TestingOptions {
             skip_output_time_offsets: true,
         };
         let (mut node, _events) = crate::DoraNode::init_testing(inputs, outputs, options).unwrap();
 
-        node.send_output(
-            "out".parse().unwrap(),
-            Default::default(),
-            Int32Array::from(vec![1, 2, 3]),
-        )
-        .unwrap();
+        for i in 0..3 {
+            node.send_output(
+                "out".parse().unwrap(),
+                Default::default(),
+                Int32Array::from(vec![i]),
+            )
+            .unwrap();
+        }
 
-        let received = rx
-            .try_recv()
-            .expect("output should have been delivered to the tokio mpsc channel");
-        assert_eq!(
-            received.get("id").and_then(|v| v.as_str()),
-            Some("out"),
-            "delivered output should carry the sent output id"
-        );
+        let received = crate::integration_testing::drain_outputs(&mut rx);
+
+        assert_eq!(received.len(), 3, "every sent output should be delivered");
+        for (i, output) in received.iter().enumerate() {
+            assert_eq!(output.get("id").and_then(|v| v.as_str()), Some("out"));
+            assert_eq!(
+                output.get("data"),
+                Some(&serde_json::json!([i as i32])),
+                "outputs should arrive in send order"
+            );
+        }
     }
 
     #[test]
@@ -2472,7 +2479,7 @@ mod tests {
             "test-node".parse().unwrap(),
             events,
         ));
-        let (tx, _rx) = tokio::sync::mpsc::channel(16);
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         let outputs = TestingOutput::ToChannel(tx);
         let options = TestingOptions {
             skip_output_time_offsets: true,
@@ -2539,7 +2546,7 @@ mod tests {
             "test-node".parse().unwrap(),
             events,
         ));
-        let (tx, _rx) = tokio::sync::mpsc::channel(16);
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
         let outputs = TestingOutput::ToChannel(tx);
         let options = TestingOptions {
             skip_output_time_offsets: true,

--- a/apis/rust/node/src/integration_testing.rs
+++ b/apis/rust/node/src/integration_testing.rs
@@ -49,7 +49,7 @@
 //!    );
 //!
 //!    // send the node's outputs to a channel so we can verify them later
-//!    let (tx, rx) = flume::unbounded();
+//!    let (tx, mut rx) = tokio::sync::mpsc::channel(16);
 //!    let outputs = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
 //!
 //!    // don't include time offsets in the outputs to make them deterministic
@@ -65,7 +65,10 @@
 //!     crate::main()?;
 //!
 //!     // collect the nodes's outputs and compare them
-//!     let outputs = rx.try_iter().collect::<Vec<_>>();
+//!     let mut outputs = Vec::new();
+//!     while let Ok(output) = rx.try_recv() {
+//!         outputs.push(output);
+//!     }
 //!     assert_eq!(outputs, expected_outputs);
 //!
 //!     Ok(())
@@ -266,10 +269,11 @@ pub enum TestingOutput {
     ToFile(std::path::PathBuf),
     /// Writes the output as JSONL file to the given writer.
     ToWriter(Box<dyn std::io::Write + Send>),
-    /// Sends each output as a JSON object to the given [`flume::Receiver`].
+    /// Sends each output as a JSON object to the given
+    /// [`tokio::sync::mpsc::Receiver`].
     ///
-    /// Note: When using a bounded channel, the node may block when the channel is full.
-    ToChannel(flume::Sender<serde_json::Map<String, serde_json::Value>>),
+    /// Note: the channel is bounded, so the node may block when it is full.
+    ToChannel(tokio::sync::mpsc::Sender<serde_json::Map<String, serde_json::Value>>),
 }
 
 /// Options for integration testing.

--- a/apis/rust/node/src/integration_testing.rs
+++ b/apis/rust/node/src/integration_testing.rs
@@ -49,7 +49,7 @@
 //!    );
 //!
 //!    // send the node's outputs to a channel so we can verify them later
-//!    let (tx, mut rx) = tokio::sync::mpsc::channel(16);
+//!    let (tx, mut rx) = dora_node_api::integration_testing::unbounded_channel();
 //!    let outputs = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
 //!
 //!    // don't include time offsets in the outputs to make them deterministic
@@ -65,10 +65,7 @@
 //!     crate::main()?;
 //!
 //!     // collect the nodes's outputs and compare them
-//!     let mut outputs = Vec::new();
-//!     while let Ok(output) = rx.try_recv() {
-//!         outputs.push(output);
-//!     }
+//!     let outputs = dora_node_api::integration_testing::drain_outputs(&mut rx);
 //!     assert_eq!(outputs, expected_outputs);
 //!
 //!     Ok(())
@@ -170,6 +167,22 @@ use std::cell::Cell;
 
 pub use dora_message::integration_testing_format::{self, IntegrationTestInput};
 
+/// Re-exported so tests can build the [`TestingOutput::ToChannel`] pair without
+/// taking their own `tokio` dependency. Only the unbounded API is re-exported —
+/// see [`TestingOutput::ToChannel`] for why a bounded channel is not usable here.
+pub use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
+
+/// A single node output, encoded as a JSON object.
+pub type OutputJson = serde_json::Map<String, serde_json::Value>;
+
+/// Collects every output queued on a [`TestingOutput::ToChannel`] receiver
+/// without blocking.
+///
+/// Call this once the node has finished; anything it sent is already queued.
+pub fn drain_outputs(rx: &mut UnboundedReceiver<OutputJson>) -> Vec<OutputJson> {
+    std::iter::from_fn(|| rx.try_recv().ok()).collect()
+}
+
 thread_local! {
     static TESTING_ENV: Cell<Option<Box<TestingCommunication>>> = const { Cell::new(None) };
 }
@@ -269,11 +282,17 @@ pub enum TestingOutput {
     ToFile(std::path::PathBuf),
     /// Writes the output as JSONL file to the given writer.
     ToWriter(Box<dyn std::io::Write + Send>),
-    /// Sends each output as a JSON object to the given
-    /// [`tokio::sync::mpsc::Receiver`].
+    /// Sends each output as a JSON object to the given [`UnboundedReceiver`].
     ///
-    /// Note: the channel is bounded, so the node may block when it is full.
-    ToChannel(tokio::sync::mpsc::Sender<serde_json::Map<String, serde_json::Value>>),
+    /// Create the pair with [`unbounded_channel`] and read it with
+    /// [`drain_outputs`] once the node has finished.
+    ///
+    /// The channel is unbounded because nothing consumes it while the node
+    /// runs. A bounded channel would deadlock as soon as a node emitted more
+    /// outputs than its capacity: the node blocks waiting for the daemon's
+    /// reply to that very output, and the reply cannot be produced until the
+    /// output is accepted.
+    ToChannel(UnboundedSender<OutputJson>),
 }
 
 /// Options for integration testing.

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -3275,24 +3275,10 @@ mod tests {
         drop(events);
     }
 
-    /// Drain everything currently queued on a testing output channel.
-    /// Replaces flume's `rx.try_iter().collect()` for the tokio mpsc receiver.
-    fn drain_channel(
-        rx: &mut tokio::sync::mpsc::Receiver<serde_json::Map<String, serde_json::Value>>,
-    ) -> Vec<serde_json::Map<String, serde_json::Value>> {
-        let mut outputs = Vec::new();
-        while let Ok(output) = rx.try_recv() {
-            outputs.push(output);
-        }
-        outputs
-    }
+    use crate::integration_testing::{OutputJson, UnboundedReceiver, drain_outputs};
 
     /// Helper: create a minimal test node with a channel output.
-    fn test_node() -> (
-        DoraNode,
-        crate::EventStream,
-        tokio::sync::mpsc::Receiver<serde_json::Map<String, serde_json::Value>>,
-    ) {
+    fn test_node() -> (DoraNode, crate::EventStream, UnboundedReceiver<OutputJson>) {
         let events = vec![TimedIncomingEvent {
             time_offset_secs: 0.1,
             event: IncomingEvent::Stop,
@@ -3301,10 +3287,7 @@ mod tests {
             "test-node".parse().unwrap(),
             events,
         ));
-        // Bounded (the enum requires a bounded `Sender`); large enough that no
-        // test fills it before draining, so the simulation thread's
-        // `blocking_send` never stalls.
-        let (tx, rx) = tokio::sync::mpsc::channel(1024);
+        let (tx, rx) = crate::integration_testing::unbounded_channel();
         let outputs = TestingOutput::ToChannel(tx);
         let options = TestingOptions {
             skip_output_time_offsets: true,
@@ -3327,7 +3310,7 @@ mod tests {
         // Output should have been sent to the channel
         drop(node);
         drop(events);
-        let outputs = drain_channel(&mut rx);
+        let outputs = drain_outputs(&mut rx);
         assert_eq!(outputs.len(), 1);
         assert_eq!(outputs[0]["id"], "request");
     }
@@ -3364,7 +3347,7 @@ mod tests {
 
         drop(node);
         drop(events);
-        let outputs = drain_channel(&mut rx);
+        let outputs = drain_outputs(&mut rx);
         assert_eq!(outputs.len(), 1);
         assert_eq!(outputs[0]["id"], "response");
     }
@@ -3700,7 +3683,7 @@ mod tests {
 
         drop(node);
         drop(events);
-        let outputs = drain_channel(&mut rx);
+        let outputs = drain_outputs(&mut rx);
         assert_eq!(outputs.len(), 1);
         assert_eq!(outputs[0]["id"], "audio");
     }

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -3275,11 +3275,23 @@ mod tests {
         drop(events);
     }
 
+    /// Drain everything currently queued on a testing output channel.
+    /// Replaces flume's `rx.try_iter().collect()` for the tokio mpsc receiver.
+    fn drain_channel(
+        rx: &mut tokio::sync::mpsc::Receiver<serde_json::Map<String, serde_json::Value>>,
+    ) -> Vec<serde_json::Map<String, serde_json::Value>> {
+        let mut outputs = Vec::new();
+        while let Ok(output) = rx.try_recv() {
+            outputs.push(output);
+        }
+        outputs
+    }
+
     /// Helper: create a minimal test node with a channel output.
     fn test_node() -> (
         DoraNode,
         crate::EventStream,
-        flume::Receiver<serde_json::Map<String, serde_json::Value>>,
+        tokio::sync::mpsc::Receiver<serde_json::Map<String, serde_json::Value>>,
     ) {
         let events = vec![TimedIncomingEvent {
             time_offset_secs: 0.1,
@@ -3289,7 +3301,10 @@ mod tests {
             "test-node".parse().unwrap(),
             events,
         ));
-        let (tx, rx) = flume::unbounded();
+        // Bounded (the enum requires a bounded `Sender`); large enough that no
+        // test fills it before draining, so the simulation thread's
+        // `blocking_send` never stalls.
+        let (tx, rx) = tokio::sync::mpsc::channel(1024);
         let outputs = TestingOutput::ToChannel(tx);
         let options = TestingOptions {
             skip_output_time_offsets: true,
@@ -3300,7 +3315,7 @@ mod tests {
 
     #[test]
     fn send_service_request_returns_valid_id_and_sends_output() {
-        let (mut node, events, rx) = test_node();
+        let (mut node, events, mut rx) = test_node();
 
         let request_id = node
             .send_service_request("request".into(), Default::default(), NullArray::new(0))
@@ -3312,7 +3327,7 @@ mod tests {
         // Output should have been sent to the channel
         drop(node);
         drop(events);
-        let outputs: Vec<_> = rx.try_iter().collect();
+        let outputs = drain_channel(&mut rx);
         assert_eq!(outputs.len(), 1);
         assert_eq!(outputs[0]["id"], "request");
     }
@@ -3336,7 +3351,7 @@ mod tests {
 
     #[test]
     fn send_service_response_sends_output() {
-        let (mut node, events, rx) = test_node();
+        let (mut node, events, mut rx) = test_node();
 
         // Simulate passing through a request_id from the incoming request
         let mut params = MetadataParameters::default();
@@ -3349,7 +3364,7 @@ mod tests {
 
         drop(node);
         drop(events);
-        let outputs: Vec<_> = rx.try_iter().collect();
+        let outputs = drain_channel(&mut rx);
         assert_eq!(outputs.len(), 1);
         assert_eq!(outputs[0]["id"], "response");
     }
@@ -3677,7 +3692,7 @@ mod tests {
 
     #[test]
     fn send_stream_chunk_sends_output() {
-        let (mut node, events, rx) = test_node();
+        let (mut node, events, mut rx) = test_node();
         let mut seg = StreamSegment::with_session_id("s1".into());
 
         node.send_stream_chunk("audio".into(), &mut seg, false, NullArray::new(0))
@@ -3685,7 +3700,7 @@ mod tests {
 
         drop(node);
         drop(events);
-        let outputs: Vec<_> = rx.try_iter().collect();
+        let outputs = drain_channel(&mut rx);
         assert_eq!(outputs.len(), 1);
         assert_eq!(outputs[0]["id"], "audio");
     }

--- a/docs/api-rust.md
+++ b/docs/api-rust.md
@@ -530,8 +530,11 @@ pub enum TestingOutput {
     // Write outputs as JSONL to any writer.
     ToWriter(Box<dyn std::io::Write + Send>),
 
-    // Send each output as a JSON object to a flume channel.
-    ToChannel(flume::Sender<serde_json::Map<String, serde_json::Value>>),
+    // Send each output as a JSON object to an unbounded channel.
+    // Build the pair with `integration_testing::unbounded_channel()` and read it
+    // with `integration_testing::drain_outputs()`. Unbounded because nothing
+    // drains the channel while the node runs.
+    ToChannel(UnboundedSender<OutputJson>),
 }
 ```
 

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -303,14 +303,14 @@ fn test_main_function() -> eyre::Result<()> {
     let inputs = TestingInput::Input(
         IntegrationTestInput::new("node_id".parse().unwrap(), events),
     );
-    let (tx, rx) = flume::unbounded();
+    let (tx, mut rx) = integration_testing::unbounded_channel();
     let outputs = TestingOutput::ToChannel(tx);
     let options = TestingOptions { skip_output_time_offsets: true };
 
     integration_testing::setup_integration_testing(inputs, outputs, options);
     crate::main()?;
 
-    let outputs = rx.try_iter().collect::<Vec<_>>();
+    let outputs = integration_testing::drain_outputs(&mut rx);
     assert_eq!(outputs, expected_outputs);
     Ok(())
 }

--- a/examples/cross-language/rust-receiver/src/tests.rs
+++ b/examples/cross-language/rust-receiver/src/tests.rs
@@ -1,5 +1,5 @@
 use dora_node_api::{
-    DoraNode, flume,
+    DoraNode,
     integration_testing::{
         IntegrationTestInput,
         integration_testing_format::{IncomingEvent, InputData, TimedIncomingEvent},
@@ -25,7 +25,7 @@ fn run_receiver(events: Vec<TimedIncomingEvent>) -> eyre::Result<()> {
     let inputs = dora_node_api::integration_testing::TestingInput::Input(
         IntegrationTestInput::new("rust-receiver".parse().unwrap(), events),
     );
-    let (tx, _rx) = flume::unbounded();
+    let (tx, _rx) = dora_node_api::integration_testing::unbounded_channel();
     let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
     let (node, events) = DoraNode::init_testing(inputs, testing_output, Default::default())?;
 

--- a/examples/cross-language/rust-sender/src/tests.rs
+++ b/examples/cross-language/rust-sender/src/tests.rs
@@ -1,5 +1,5 @@
 use dora_node_api::{
-    DoraNode, flume,
+    DoraNode,
     integration_testing::{
         IntegrationTestInput,
         integration_testing_format::{IncomingEvent, TimedIncomingEvent},
@@ -22,14 +22,14 @@ fn run_sender(events: Vec<TimedIncomingEvent>) -> eyre::Result<Vec<serde_json::V
     let inputs = dora_node_api::integration_testing::TestingInput::Input(
         IntegrationTestInput::new("rust-sender".parse().unwrap(), events),
     );
-    let (tx, rx) = flume::unbounded();
+    let (tx, mut rx) = dora_node_api::integration_testing::unbounded_channel();
     let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
     let (node, events) = DoraNode::init_testing(inputs, testing_output, Default::default())?;
 
     crate::run(node, events)?;
 
-    Ok(rx
-        .try_iter()
+    Ok(dora_node_api::integration_testing::drain_outputs(&mut rx)
+        .into_iter()
         .map(serde_json::Value::Object)
         .collect::<Vec<_>>())
 }

--- a/examples/multiple-daemons/node/src/tests.rs
+++ b/examples/multiple-daemons/node/src/tests.rs
@@ -1,5 +1,5 @@
 use dora_node_api::{
-    DoraNode, flume,
+    DoraNode,
     integration_testing::{
         IntegrationTestInput,
         integration_testing_format::{IncomingEvent, TimedIncomingEvent},
@@ -22,14 +22,14 @@ fn run_node(events: Vec<TimedIncomingEvent>) -> eyre::Result<Vec<serde_json::Val
     let inputs = dora_node_api::integration_testing::TestingInput::Input(
         IntegrationTestInput::new("multiple-daemons-node".parse().unwrap(), events),
     );
-    let (tx, rx) = flume::unbounded();
+    let (tx, mut rx) = dora_node_api::integration_testing::unbounded_channel();
     let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
     let (node, events) = DoraNode::init_testing(inputs, testing_output, Default::default())?;
 
     crate::run(node, events)?;
 
-    Ok(rx
-        .try_iter()
+    Ok(dora_node_api::integration_testing::drain_outputs(&mut rx)
+        .into_iter()
         .map(serde_json::Value::Object)
         .collect::<Vec<_>>())
 }

--- a/examples/multiple-daemons/sink/src/tests.rs
+++ b/examples/multiple-daemons/sink/src/tests.rs
@@ -1,5 +1,5 @@
 use dora_node_api::{
-    DoraNode, flume,
+    DoraNode,
     integration_testing::{
         IntegrationTestInput,
         integration_testing_format::{IncomingEvent, InputData, TimedIncomingEvent},
@@ -25,7 +25,7 @@ fn run_sink(events: Vec<TimedIncomingEvent>) -> eyre::Result<()> {
     let inputs = dora_node_api::integration_testing::TestingInput::Input(
         IntegrationTestInput::new("multiple-daemons-sink".parse().unwrap(), events),
     );
-    let (tx, _rx) = flume::unbounded();
+    let (tx, _rx) = dora_node_api::integration_testing::unbounded_channel();
     let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
     let (node, events) = DoraNode::init_testing(inputs, testing_output, Default::default())?;
 

--- a/examples/rust-dataflow/node/src/tests.rs
+++ b/examples/rust-dataflow/node/src/tests.rs
@@ -7,7 +7,6 @@ use dora_node_api::{
     DoraNode, Event, IntoArrow,
     arrow::array::{Array, NullArray},
     dora_core::config::DataId,
-    flume,
     integration_testing::{
         self, IntegrationTestInput, TestingOptions,
         integration_testing_format::{IncomingEvent, TimedIncomingEvent},
@@ -97,7 +96,7 @@ fn test_sample_output() -> eyre::Result<()> {
         IntegrationTestInput::new("node_id".parse().unwrap(), events),
     );
 
-    let (tx, rx) = flume::unbounded();
+    let (tx, mut rx) = dora_node_api::integration_testing::unbounded_channel();
     let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
     let (mut node, mut events) =
         DoraNode::init_testing(inputs, testing_output, Default::default())?;
@@ -128,7 +127,7 @@ fn test_sample_output() -> eyre::Result<()> {
     std::mem::drop(node);
     std::mem::drop(events);
 
-    let outputs = rx.try_iter().collect::<Vec<_>>();
+    let outputs = dora_node_api::integration_testing::drain_outputs(&mut rx);
     let expected: Vec<serde_json::Map<_, _>> = [
         serde_json::json!({
             "id": "i",

--- a/examples/rust-dataflow/sink/src/tests.rs
+++ b/examples/rust-dataflow/sink/src/tests.rs
@@ -1,5 +1,5 @@
 use dora_node_api::{
-    DoraNode, flume,
+    DoraNode,
     integration_testing::{
         IntegrationTestInput,
         integration_testing_format::{IncomingEvent, InputData, TimedIncomingEvent},
@@ -25,7 +25,7 @@ fn run_sink(events: Vec<TimedIncomingEvent>) -> eyre::Result<()> {
     let inputs = dora_node_api::integration_testing::TestingInput::Input(
         IntegrationTestInput::new("rust-sink".parse().unwrap(), events),
     );
-    let (tx, _rx) = flume::unbounded();
+    let (tx, _rx) = dora_node_api::integration_testing::unbounded_channel();
     let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
     let (node, events) = DoraNode::init_testing(inputs, testing_output, Default::default())?;
 

--- a/examples/rust-dataflow/status-node/src/tests.rs
+++ b/examples/rust-dataflow/status-node/src/tests.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use dora_node_api::{
-    DoraNode, flume,
+    DoraNode,
     integration_testing::{
         self, IntegrationTestInput, TestingOptions,
         integration_testing_format::{IncomingEvent, InputData, TimedIncomingEvent},
@@ -118,13 +118,13 @@ fn test_tick_counter_and_random_round_trip() -> eyre::Result<()> {
         IntegrationTestInput::new("rust-status-node".parse().unwrap(), events),
     );
 
-    let (tx, rx) = flume::unbounded();
+    let (tx, mut rx) = dora_node_api::integration_testing::unbounded_channel();
     let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
     let (node, events) = DoraNode::init_testing(inputs, testing_output, Default::default())?;
 
     crate::run(node, events)?;
 
-    let outputs = rx.try_iter().collect::<Vec<_>>();
+    let outputs = dora_node_api::integration_testing::drain_outputs(&mut rx);
     let expected_messages = [
         "operator received random value 0xaa after 0 ticks",
         "operator received random value 0xbb after 1 ticks",
@@ -165,7 +165,7 @@ fn test_non_uint64_random_input_errors() -> eyre::Result<()> {
         IntegrationTestInput::new("rust-status-node".parse().unwrap(), events),
     );
 
-    let (tx, _rx) = flume::unbounded();
+    let (tx, _rx) = dora_node_api::integration_testing::unbounded_channel();
     let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
     let (node, events) = DoraNode::init_testing(inputs, testing_output, Default::default())?;
 

--- a/examples/validated-pipeline/sink/src/tests.rs
+++ b/examples/validated-pipeline/sink/src/tests.rs
@@ -1,5 +1,5 @@
 use dora_node_api::{
-    DoraNode, flume,
+    DoraNode,
     integration_testing::{
         IntegrationTestInput,
         integration_testing_format::{IncomingEvent, InputData, TimedIncomingEvent},
@@ -25,7 +25,7 @@ fn run_sink(events: Vec<TimedIncomingEvent>) -> eyre::Result<()> {
     let inputs = dora_node_api::integration_testing::TestingInput::Input(
         IntegrationTestInput::new("sink".parse().unwrap(), events),
     );
-    let (tx, _rx) = flume::unbounded();
+    let (tx, _rx) = dora_node_api::integration_testing::unbounded_channel();
     let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
     let (node, events) = DoraNode::init_testing(inputs, testing_output, Default::default())?;
 

--- a/examples/validated-pipeline/source/src/tests.rs
+++ b/examples/validated-pipeline/source/src/tests.rs
@@ -1,5 +1,5 @@
 use dora_node_api::{
-    DoraNode, flume,
+    DoraNode,
     integration_testing::{
         IntegrationTestInput,
         integration_testing_format::{IncomingEvent, TimedIncomingEvent},
@@ -22,14 +22,14 @@ fn run_source(events: Vec<TimedIncomingEvent>) -> eyre::Result<Vec<serde_json::V
     let inputs = dora_node_api::integration_testing::TestingInput::Input(
         IntegrationTestInput::new("source".parse().unwrap(), events),
     );
-    let (tx, rx) = flume::unbounded();
+    let (tx, mut rx) = dora_node_api::integration_testing::unbounded_channel();
     let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
     let (node, events) = DoraNode::init_testing(inputs, testing_output, Default::default())?;
 
     crate::run(node, events)?;
 
-    Ok(rx
-        .try_iter()
+    Ok(dora_node_api::integration_testing::drain_outputs(&mut rx)
+        .into_iter()
         .map(serde_json::Value::Object)
         .collect::<Vec<_>>())
 }

--- a/examples/validated-pipeline/transform/src/tests.rs
+++ b/examples/validated-pipeline/transform/src/tests.rs
@@ -1,5 +1,5 @@
 use dora_node_api::{
-    DoraNode, flume,
+    DoraNode,
     integration_testing::{
         IntegrationTestInput,
         integration_testing_format::{IncomingEvent, InputData, TimedIncomingEvent},
@@ -25,14 +25,14 @@ fn run_transform(events: Vec<TimedIncomingEvent>) -> eyre::Result<Vec<serde_json
     let inputs = dora_node_api::integration_testing::TestingInput::Input(
         IntegrationTestInput::new("transform".parse().unwrap(), events),
     );
-    let (tx, rx) = flume::unbounded();
+    let (tx, mut rx) = dora_node_api::integration_testing::unbounded_channel();
     let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
     let (node, events) = DoraNode::init_testing(inputs, testing_output, Default::default())?;
 
     crate::run(node, events)?;
 
-    Ok(rx
-        .try_iter()
+    Ok(dora_node_api::integration_testing::drain_outputs(&mut rx)
+        .into_iter()
         .map(serde_json::Value::Object)
         .collect::<Vec<_>>())
 }

--- a/guide/src/development/testing.md
+++ b/guide/src/development/testing.md
@@ -291,14 +291,14 @@ fn test_main_function() -> eyre::Result<()> {
     let inputs = TestingInput::Input(
         IntegrationTestInput::new("node_id".parse().unwrap(), events),
     );
-    let (tx, rx) = flume::unbounded();
+    let (tx, mut rx) = integration_testing::unbounded_channel();
     let outputs = TestingOutput::ToChannel(tx);
     let options = TestingOptions { skip_output_time_offsets: true };
 
     integration_testing::setup_integration_testing(inputs, outputs, options);
     crate::main()?;
 
-    let outputs = rx.try_iter().collect::<Vec<_>>();
+    let outputs = integration_testing::drain_outputs(&mut rx);
     assert_eq!(outputs, expected_outputs);
     Ok(())
 }

--- a/guide/src/languages/rust.md
+++ b/guide/src/languages/rust.md
@@ -530,8 +530,11 @@ pub enum TestingOutput {
     // Write outputs as JSONL to any writer.
     ToWriter(Box<dyn std::io::Write + Send>),
 
-    // Send each output as a JSON object to a flume channel.
-    ToChannel(flume::Sender<serde_json::Map<String, serde_json::Value>>),
+    // Send each output as a JSON object to an unbounded channel.
+    // Build the pair with `integration_testing::unbounded_channel()` and read it
+    // with `integration_testing::drain_outputs()`. Unbounded because nothing
+    // drains the channel while the node runs.
+    ToChannel(UnboundedSender<OutputJson>),
 }
 ```
 


### PR DESCRIPTION
Fixes #2956.

## Problem

#1603 migrated `EventStream` from `flume` to `tokio::sync::mpsc`, but the
integration-testing **output** path was left behind: `TestingOutput::ToChannel`
still carried a `flume::Sender`, so the same spinlock lived on in the output
path and downstream test-util crates had to depend on both `flume` and `tokio`
just to capture node outputs.

## Fix

`ToChannel` now takes a `tokio::sync::mpsc::UnboundedSender`.

**Unbounded, not bounded.** The issue proposed the bounded `Sender`, but that
deadlocks. The daemon simulation thread parks in `blocking_send` on a full
output channel while the node thread is parked in `blocking_recv` awaiting that
same output's reply (`daemon_connection/mod.rs`) — the test hangs forever, with
no timeout and no diagnostic. Reproduced directly: a capacity-2 channel with
five outputs wedges at 0% CPU indefinitely.

Nothing consumes the channel while the node runs — every call site in the repo
drains only *after* the node finishes, and five of them keep the receiver alive
but never read it — so no caller can supply the backpressure a bounded channel
needs. `UnboundedSender` is an exact match for the `flume::unbounded()`
semantics all of these sites already had, and `send` needs no `blocking_send`,
so the output path no longer cares what thread or runtime it runs on.

## Changes

- `integration_testing.rs`: `ToChannel(UnboundedSender<OutputJson>)`, plus
  `unbounded_channel`, `drain_outputs` and the `OutputJson` alias so tests need
  no `tokio` dependency of their own. Only the unbounded API is re-exported, so
  the bounded constructor is not reachable through `dora-node-api`.
- `daemon_connection/node_integration_testing.rs`: `OutputWriter::Channel` type
  and a plain non-blocking `send`.
- All ten in-workspace example test crates migrated — these were the build break
  flagged in review; they are workspace members, so `cargo test --all` covered
  them and would have failed.
- The four guide/docs snippets that still showed the flume pattern.

## Tests

`to_channel_delivers_outputs_in_order` covers end-to-end delivery and ordering
through `ToChannel`. This path was previously untested — every existing
`ToChannel` test dropped the receiver (`let (tx, _rx) = …`).

`dora-node-api` 159/159, all ten example crates green, `cargo check --all
--tests`, CI-equivalent `cargo clippy --all -- -D warnings`, and
`cargo fmt --all -- --check` all clean.
