### PR TITLE
fix(node): use tokio mpsc for testing output channel

### DIFF
--- a/apis/rust/node/src/daemon_connection/node_integration_testing.rs
+++ b/apis/rust/node/src/daemon_connection/node_integration_testing.rs
@@ -167,7 +167,7 @@ impl IntegrationTestingEvents {
             }
             OutputWriter::Channel(sender) => {
                 sender
-                    .send(output)
+                    .blocking_send(output)
                     .context("failed to send output to channel")?;
             }
         }
@@ -234,7 +234,7 @@ impl IntegrationTestingEvents {
 
 enum OutputWriter {
     Writer(Box<dyn Write + Send>),
-    Channel(flume::Sender<serde_json::Map<String, serde_json::Value>>),
+    Channel(tokio::sync::mpsc::Sender<serde_json::Map<String, serde_json::Value>>),
 }
 
 pub fn convert_output_to_json(

--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -2314,7 +2314,7 @@ mod tests {
             "test-node".parse().unwrap(),
             events,
         ));
-        let (tx, _rx) = flume::unbounded();
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
         let outputs = TestingOutput::ToChannel(tx);
         let options = TestingOptions {
             skip_output_time_offsets: true,
@@ -2430,7 +2430,7 @@ mod tests {
             "test-node".parse().unwrap(),
             events,
         ));
-        let (tx, _rx) = flume::unbounded();
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
         let outputs = TestingOutput::ToChannel(tx);
         let options = TestingOptions {
             skip_output_time_offsets: true,
@@ -2497,7 +2497,7 @@ mod tests {
             "test-node".parse().unwrap(),
             events,
         ));
-        let (tx, _rx) = flume::unbounded();
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
         let outputs = TestingOutput::ToChannel(tx);
         let options = TestingOptions {
             skip_output_time_offsets: true,

--- a/apis/rust/node/src/integration_testing.rs
+++ b/apis/rust/node/src/integration_testing.rs
@@ -49,7 +49,7 @@
 //!    );
 //!
 //!    // send the node's outputs to a channel so we can verify them later
-//!    let (tx, rx) = flume::unbounded();
+//!    let (tx, mut rx) = tokio::sync::mpsc::channel(16);
 //!    let outputs = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
 //!
 //!    // don't include time offsets in the outputs to make them deterministic
@@ -65,7 +65,7 @@
 //!     crate::main()?;
 //!
 //!     // collect the nodes's outputs and compare them
-//!     let outputs = rx.try_iter().collect::<Vec<_>>();
+//!     let outputs = std::iter::from_fn(|| rx.try_recv().ok()).collect::<Vec<_>>();
 //!     assert_eq!(outputs, expected_outputs);
 //!
 //!     Ok(())
@@ -266,10 +266,10 @@ pub enum TestingOutput {
     ToFile(std::path::PathBuf),
     /// Writes the output as JSONL file to the given writer.
     ToWriter(Box<dyn std::io::Write + Send>),
-    /// Sends each output as a JSON object to the given [`flume::Receiver`].
+    /// Sends each output as a JSON object to the given [`tokio::sync::mpsc::Sender`].
     ///
     /// Note: When using a bounded channel, the node may block when the channel is full.
-    ToChannel(flume::Sender<serde_json::Map<String, serde_json::Value>>),
+    ToChannel(tokio::sync::mpsc::Sender<serde_json::Map<String, serde_json::Value>>),
 }
 
 /// Options for integration testing.
@@ -280,4 +280,16 @@ pub struct TestingOptions {
     /// Skipping time offsets makes the outputs deterministic and easier to compare against
     /// expected outputs.
     pub skip_output_time_offsets: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TestingOutput;
+
+    #[test]
+    fn testing_output_to_channel_accepts_tokio_mpsc_sender() {
+        let (tx, _rx) = tokio::sync::mpsc::channel::<serde_json::Map<String, serde_json::Value>>(1);
+
+        let _output = TestingOutput::ToChannel(tx);
+    }
 }

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -3279,7 +3279,7 @@ mod tests {
     fn test_node() -> (
         DoraNode,
         crate::EventStream,
-        flume::Receiver<serde_json::Map<String, serde_json::Value>>,
+        tokio::sync::mpsc::Receiver<serde_json::Map<String, serde_json::Value>>,
     ) {
         let events = vec![TimedIncomingEvent {
             time_offset_secs: 0.1,
@@ -3289,7 +3289,7 @@ mod tests {
             "test-node".parse().unwrap(),
             events,
         ));
-        let (tx, rx) = flume::unbounded();
+        let (tx, rx) = tokio::sync::mpsc::channel(16);
         let outputs = TestingOutput::ToChannel(tx);
         let options = TestingOptions {
             skip_output_time_offsets: true,
@@ -3300,7 +3300,7 @@ mod tests {
 
     #[test]
     fn send_service_request_returns_valid_id_and_sends_output() {
-        let (mut node, events, rx) = test_node();
+        let (mut node, events, mut rx) = test_node();
 
         let request_id = node
             .send_service_request("request".into(), Default::default(), NullArray::new(0))
@@ -3312,7 +3312,7 @@ mod tests {
         // Output should have been sent to the channel
         drop(node);
         drop(events);
-        let outputs: Vec<_> = rx.try_iter().collect();
+        let outputs: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
         assert_eq!(outputs.len(), 1);
         assert_eq!(outputs[0]["id"], "request");
     }
@@ -3336,7 +3336,7 @@ mod tests {
 
     #[test]
     fn send_service_response_sends_output() {
-        let (mut node, events, rx) = test_node();
+        let (mut node, events, mut rx) = test_node();
 
         // Simulate passing through a request_id from the incoming request
         let mut params = MetadataParameters::default();
@@ -3349,7 +3349,7 @@ mod tests {
 
         drop(node);
         drop(events);
-        let outputs: Vec<_> = rx.try_iter().collect();
+        let outputs: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
         assert_eq!(outputs.len(), 1);
         assert_eq!(outputs[0]["id"], "response");
     }
@@ -3677,7 +3677,7 @@ mod tests {
 
     #[test]
     fn send_stream_chunk_sends_output() {
-        let (mut node, events, rx) = test_node();
+        let (mut node, events, mut rx) = test_node();
         let mut seg = StreamSegment::with_session_id("s1".into());
 
         node.send_stream_chunk("audio".into(), &mut seg, false, NullArray::new(0))
@@ -3685,7 +3685,7 @@ mod tests {
 
         drop(node);
         drop(events);
-        let outputs: Vec<_> = rx.try_iter().collect();
+        let outputs: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
         assert_eq!(outputs.len(), 1);
         assert_eq!(outputs[0]["id"], "audio");
     }


### PR DESCRIPTION
## Summary

  - migrate `TestingOutput::ToChannel` from `flume::Sender` to
  `tokio::sync::mpsc::Sender`
  - use `blocking_send` when integration-test output is emitted from the
  synchronous testing daemon path
  - update node API tests and docs examples to use tokio mpsc channels

  ## Why

  `EventStream` already moved from `flume` to `tokio::sync::mpsc` to avoid
  the flume/PyO3 async waker deadlock class tracked in #1603. The
  integration testing output channel was a remaining node API testing path
  that still exposed `flume::Sender`.

  Closes #2956.
