### PR TITLE
feat(cli): `--exit-when-nodes-finish` for `dora start`, via the descriptor

### DIFF
--- a/binaries/cli/src/command/run.rs
+++ b/binaries/cli/src/command/run.rs
@@ -133,8 +133,19 @@ pub struct Run {
     /// Nodes whose inputs are all timers are unaffected: they have no
     /// data dependency that could finish, so they are treated as
     /// sources, exactly as a node with no inputs is.
-    #[clap(long, action)]
-    pub exit_when_nodes_finish: bool,
+    ///
+    /// Overrides `exit_when_nodes_finish:` in the dataflow YAML in
+    /// either direction: pass the flag to force it on, or
+    /// `--exit-when-nodes-finish=false` to force it off for a descriptor
+    /// that asks for it. Omit it entirely and the descriptor decides.
+    #[clap(
+        long,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        value_name = "BOOL"
+    )]
+    pub exit_when_nodes_finish: Option<bool>,
 }
 
 impl Run {
@@ -154,7 +165,7 @@ impl Run {
             working_dir: None,
             hub_override: Vec::new(),
             env: Vec::new(),
-            exit_when_nodes_finish: false,
+            exit_when_nodes_finish: None,
         }
     }
 
@@ -287,7 +298,11 @@ impl Executable for Run {
                 working_dir_override,
                 // hub-resolved descriptor and/or `--env` merge — see above
                 descriptor_override,
-                RunDataflowOptions::default().exit_when_nodes_finish(exit_when_nodes_finish),
+                // Left unset the descriptor decides; given, it overrides.
+                match exit_when_nodes_finish {
+                    Some(v) => RunDataflowOptions::default().exit_when_nodes_finish(v),
+                    None => RunDataflowOptions::default(),
+                },
             )
             .await
         });

--- a/binaries/cli/src/command/start/mod.rs
+++ b/binaries/cli/src/command/start/mod.rs
@@ -60,6 +60,30 @@ pub struct Start {
     /// numeric-looking values that would be coerced. They are also
     /// persisted with the dataflow in the coordinator's state store and
     /// visible in `ps` — prefer a node `env:` block for secrets.
+    /// Exit once every node has finished, treating `dora/timer/...`
+    /// inputs as a clock rather than as work.
+    ///
+    /// A timer input never closes, so by default a dataflow in which any
+    /// node consumes one cannot end on its own, even after every node
+    /// doing real work has exited. With this flag a node is finished once
+    /// its DATA inputs have closed.
+    ///
+    /// Note this is usually what you want only for batch-style runs: a
+    /// long-lived dataflow is normally ended with `dora stop`, and there
+    /// the timer is exactly what keeps it alive.
+    ///
+    /// Overrides `exit_when_nodes_finish:` in the dataflow YAML in
+    /// either direction: pass the flag to force it on, or
+    /// `--exit-when-nodes-finish=false` to force it off for a descriptor
+    /// that asks for it. Omit it entirely and the descriptor decides.
+    #[clap(
+        long,
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "true",
+        value_name = "BOOL"
+    )]
+    pub exit_when_nodes_finish: Option<bool>,
     #[clap(long = "env", value_name = "KEY=VALUE")]
     env: Vec<String>,
 }
@@ -77,6 +101,7 @@ impl Executable for Start {
             self.uv,
             self.debug,
             env_overrides,
+            self.exit_when_nodes_finish,
         )?;
 
         let attach = match (self.attach, self.detach) {
@@ -128,6 +153,7 @@ fn start_dataflow(
     uv: bool,
     debug: bool,
     env_overrides: BTreeMap<String, EnvValue>,
+    exit_when_nodes_finish: Option<bool>,
 ) -> Result<(PathBuf, Descriptor, WsSession, Uuid), eyre::Error> {
     let dataflow = resolve_dataflow(dataflow).context("could not resolve dataflow")?;
     let working_dir = dataflow
@@ -144,6 +170,11 @@ fn start_dataflow(
         })?
         .expand(working_dir)
         .wrap_err("failed to expand modules in dataflow descriptor")?;
+    // Fold the flag into the descriptor, which is what the daemon reads
+    // and the one copy that survives auto-recovery, coordinator restart
+    // and `dora restart` (#2920). Given, it overrides the descriptor in
+    // either direction; omitted, the descriptor's own setting stands.
+    dataflow_descriptor.apply_exit_when_nodes_finish(exit_when_nodes_finish);
     let mut dataflow_session =
         DataflowSession::read_session(&dataflow).context("failed to read DataflowSession")?;
     // `hub:` references are desugared by `dora build`, which stores the

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -1605,6 +1605,7 @@ async fn start_inner(
                                             strict_types: None,
                                             type_rules: Vec::new(),
                                             env: dataflow.descriptor.env.clone(),
+                                            exit_when_nodes_finish: None,
                                         };
                                         match tmp_desc.resolve_aliases_and_set_defaults() {
                                             Ok(mut resolved_map) => {

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -94,6 +94,7 @@ pub mod bench_support {
             debug: dora_message::descriptor::Debug::default(),
             health_check_interval: None,
             strict_types: None,
+            exit_when_nodes_finish: None,
             type_rules: vec![],
             env: None,
         };
@@ -275,11 +276,16 @@ pub struct RunDataflowOptions {
     /// Let the dataflow finish once every node has, treating
     /// `dora/timer/...` inputs as a clock rather than as work.
     ///
+    /// `None` leaves the descriptor's own `exit_when_nodes_finish`
+    /// setting alone; `Some(v)` overrides it in either direction, so a
+    /// caller can force the policy off for a descriptor that asks for
+    /// it.
+    ///
     /// A timer input never closes, so by default a node consuming one is
     /// never told its inputs are done and the graph cannot end on its own
     /// (dora-rs/dora#2920). Off by default: for a long-lived dataflow the
     /// timer is exactly what keeps it alive.
-    pub exit_when_nodes_finish: bool,
+    pub exit_when_nodes_finish: Option<bool>,
 }
 
 impl RunDataflowOptions {
@@ -290,7 +296,7 @@ impl RunDataflowOptions {
     /// directly, which is what lets a future option be added without
     /// breaking them.
     pub fn exit_when_nodes_finish(mut self, exit_when_nodes_finish: bool) -> Self {
-        self.exit_when_nodes_finish = exit_when_nodes_finish;
+        self.exit_when_nodes_finish = Some(exit_when_nodes_finish);
         self
     }
 }
@@ -304,12 +310,6 @@ pub struct Daemon {
     pub(crate) daemon_id: DaemonId,
     pub(crate) exit_when_done: Option<BTreeSet<(Uuid, NodeId)>>,
     pub(crate) exit_when_all_finished: bool,
-    /// Run-scoped copy of `RunningDataflow::timers_gate_drain`, applied
-    /// to each dataflow as it is spawned. Only `dora run` can turn it
-    /// off (`--exit-when-nodes-finish`); a daemon serving a coordinator
-    /// keeps the default, since a long-lived dataflow is stopped
-    /// explicitly rather than by running out of work (#2920).
-    pub(crate) timers_gate_drain: bool,
     pub(crate) dataflow_node_results: BTreeMap<Uuid, BTreeMap<NodeId, Result<(), NodeError>>>,
     pub(crate) clock: Arc<uhlc::HLC>,
     pub(crate) ft_stats: Arc<FaultToleranceStats>,
@@ -1124,6 +1124,13 @@ impl Daemon {
         if debug {
             descriptor.debug.enable_debug_inspection = true;
         }
+        // Fold the option into the descriptor, which is what the daemon
+        // actually reads. `dora start` sets the same field from its own
+        // flag, so both entry points converge on one source of truth
+        // rather than each carrying the setting separately (#2920).
+        // Set explicitly, so it overrides the descriptor either way; left
+        // unset, the descriptor's own setting stands.
+        descriptor.apply_exit_when_nodes_finish(exit_when_nodes_finish);
         if let Some(node) = descriptor.nodes.iter().find(|n| n.deploy.is_some()) {
             eyre::bail!(
                 "node {} has a `deploy` section, which is not supported in `dora run`\n\n
@@ -1255,7 +1262,6 @@ impl Daemon {
             // the daemon find each other, so keep it on when the descriptor
             // declares any.
             !has_dynamic_nodes,
-            exit_when_nodes_finish,
         );
 
         let spawn_result = reply_rx
@@ -1303,7 +1309,6 @@ impl Daemon {
         health_check_interval_duration: Option<Duration>,
         inter_daemon_peer: Option<String>,
         disable_multicast: bool,
-        exit_when_nodes_finish: bool,
     ) -> eyre::Result<DaemonRunResult> {
         // Single-shot path (`dora run`): build the daemon and run one event
         // loop. The reconnecting daemon binary instead builds the daemon once
@@ -1325,9 +1330,6 @@ impl Daemon {
             disable_multicast,
         )
         .await?;
-        // Applied to every dataflow this daemon spawns; only the
-        // single-shot `dora run` path can turn it off.
-        daemon.timers_gate_drain = !exit_when_nodes_finish;
         daemon
             .run_inner(
                 external_events,
@@ -1475,7 +1477,6 @@ impl Daemon {
             daemon_id,
             exit_when_done,
             exit_when_all_finished: false,
-            timers_gate_drain: true,
             dataflow_node_results: BTreeMap::new(),
             clock,
             ft_stats: Default::default(),
@@ -3221,7 +3222,13 @@ impl Daemon {
             self.daemon_id.clone(),
             dataflow_descriptor.clone(),
         );
-        dataflow.timers_gate_drain = self.timers_gate_drain;
+        // Read from the descriptor, which is the one copy that survives
+        // everything a dataflow outlives: auto-recovery re-spawn,
+        // coordinator restart with state reconstruction, and `dora
+        // restart`. A daemon serving a coordinator hosts many dataflows
+        // and only some are batch-style, so this is necessarily
+        // per-dataflow rather than daemon-wide (#2920).
+        dataflow.timers_gate_drain = !dataflow.descriptor.exit_when_nodes_finish.unwrap_or(false);
         // Decide who dials whom before anything spawns: zenoh 1.9 peers do not
         // relay, so a producer/consumer pair that never forms a direct link can
         // never exchange data. Assign the links explicitly instead of leaving
@@ -6643,6 +6650,7 @@ mod fault_tolerance_tests {
             debug: DescriptorDebug::default(),
             health_check_interval: None,
             strict_types: None,
+            exit_when_nodes_finish: None,
             type_rules: vec![],
             env: None,
         };

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -1467,6 +1467,7 @@ mod tests {
             debug: DescriptorDebug::default(),
             health_check_interval: None,
             strict_types: None,
+            exit_when_nodes_finish: None,
             type_rules: vec![],
             env: None,
         }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -283,7 +283,7 @@ dora run <PATH> [OPTIONS]
 | `--uv` | false | Use `uv` for Python node management |
 | `--debug` | false | Enable debug topics (equivalent to `enable_debug_inspection: true`) |
 | `--allow-shell-nodes` | false | Enable shell-based node execution |
-| `--exit-when-nodes-finish` | false | Exit once all nodes finish, treating `dora/timer/...` inputs as a clock rather than as work |
+| `--exit-when-nodes-finish[=BOOL]` | descriptor | Exit once all nodes finish, treating `dora/timer/...` inputs as a clock rather than as work. Overrides `exit_when_nodes_finish:` in the YAML; omit it and the YAML decides |
 | `--log-level <LEVEL>` | `stdout` | Min display level: `error\|warn\|info\|debug\|trace\|stdout` |
 | `--log-format <FORMAT>` | `pretty` | Output format: `pretty\|json\|compact` |
 | `--log-filter <FILTER>` | | Per-node level overrides: `"node1=debug,node2=warn"` |
@@ -386,6 +386,7 @@ dora start <PATH> [OPTIONS]
 | `--debug` | false | Enable debug topics (equivalent to `enable_debug_inspection: true`) |
 | `--hot-reload` | false | Watch Python files and reload on change |
 | `--uv` | false | Use `uv` for Python nodes |
+| `--exit-when-nodes-finish[=BOOL]` | descriptor | Finish once all nodes have, treating `dora/timer/...` inputs as a clock rather than as work. Overrides `exit_when_nodes_finish:` in the YAML; omit it and the YAML decides |
 | `--coordinator-addr <IP>` | `127.0.0.1` | Coordinator address |
 | `--coordinator-port <PORT>` | `6013` | Coordinator port |
 

--- a/docs/yaml-spec.md
+++ b/docs/yaml-spec.md
@@ -40,8 +40,49 @@ nodes:
 | `strict_types` | bool | `false` | Treat type warnings as errors in `validate` and `build` |
 | `type_rules` | list | `[]` | User-defined type compatibility rules (see [Type Annotations](types.md#user-defined-compatibility-rules)) |
 | `health_check_interval` | float | `5.0` | Seconds between daemon health check sweeps. For each node with `health_check_timeout` set, the daemon checks whether the node has communicated within its timeout; if not, the node is killed and its `restart_policy` is evaluated |
+| `exit_when_nodes_finish` | bool | `false` | Finish the dataflow once every node has, treating `dora/timer/...` inputs as a clock rather than as work. A timer input has no upstream node, so it never closes: by default a node consuming one is never told its inputs are done and the graph cannot end on its own. Overridden by `--exit-when-nodes-finish[=BOOL]` on `dora run` and `dora start` (see [Completion](#completion)) |
 | `_unstable_deploy` | object | -- | Root-level deployment config (see [Deployment](#deployment)) |
 | `_unstable_debug` | object | -- | Debug options (see [Debug](#debug)) |
+
+## Completion
+
+By default a dataflow ends when every node has exited. A node is told its
+inputs are closed only when *all* of them are, and a `dora/timer/...`
+input never closes -- it has no upstream node that could finish it. So a
+graph in which any node consumes a timer cannot end on its own, even
+after every node doing real work has exited:
+
+```yaml
+nodes:
+  - id: worker
+    path: ./worker
+    inputs:
+      data: producer/out
+      tick: dora/timer/millis/100   # never closes
+```
+
+Set `exit_when_nodes_finish` to make a node finish once its **data**
+inputs have closed, with the timer treated as a clock rather than as work:
+
+```yaml
+exit_when_nodes_finish: true
+```
+
+Off by default, and usually only wanted for batch-style runs: for a
+long-lived dataflow the timer is precisely what keeps it alive, and such
+a dataflow is normally ended with `dora stop`.
+
+Nodes with no data inputs at all -- timer-only sources, or nodes with no
+inputs -- are unaffected. They have no dependency that could finish, so
+they are treated as sources and are never told to stop.
+
+The command line overrides this field in either direction:
+
+```bash
+dora run flow.yml --exit-when-nodes-finish          # force on
+dora start flow.yml --exit-when-nodes-finish=false  # force off
+dora start flow.yml                                 # the YAML decides
+```
 
 ## Node Configuration
 

--- a/guide/src/operations/cli.md
+++ b/guide/src/operations/cli.md
@@ -291,7 +291,7 @@ dora run <PATH> [OPTIONS]
 | `--uv` | false | Use `uv` for Python node management |
 | `--debug` | false | Enable debug topics (equivalent to `enable_debug_inspection: true`) |
 | `--allow-shell-nodes` | false | Enable shell-based node execution |
-| `--exit-when-nodes-finish` | false | Exit once all nodes finish, treating `dora/timer/...` inputs as a clock rather than as work |
+| `--exit-when-nodes-finish[=BOOL]` | descriptor | Exit once all nodes finish, treating `dora/timer/...` inputs as a clock rather than as work. Overrides `exit_when_nodes_finish:` in the YAML; omit it and the YAML decides |
 | `--log-level <LEVEL>` | `stdout` | Min display level: `error\|warn\|info\|debug\|trace\|stdout` |
 | `--log-format <FORMAT>` | `pretty` | Output format: `pretty\|json\|compact` |
 | `--log-filter <FILTER>` | | Per-node level overrides: `"node1=debug,node2=warn"` |
@@ -387,6 +387,7 @@ dora start <PATH> [OPTIONS]
 | `--debug` | false | Enable debug topics (equivalent to `enable_debug_inspection: true`) |
 | `--hot-reload` | false | Watch Python files and reload on change |
 | `--uv` | false | Use `uv` for Python nodes |
+| `--exit-when-nodes-finish[=BOOL]` | descriptor | Finish once all nodes have, treating `dora/timer/...` inputs as a clock rather than as work. Overrides `exit_when_nodes_finish:` in the YAML; omit it and the YAML decides |
 | `--coordinator-addr <IP>` | `127.0.0.1` | Coordinator address |
 | `--coordinator-port <PORT>` | `6013` | Coordinator port |
 

--- a/libraries/core/dora-schema.json
+++ b/libraries/core/dora-schema.json
@@ -14,6 +14,13 @@
         "$ref": "#/$defs/EnvValue"
       }
     },
+    "exit_when_nodes_finish": {
+      "description": "Finish the dataflow once every node has, treating\n`dora/timer/...` inputs as a clock rather than as work.\n\nA timer input has no upstream node, so it never closes. By default\na node consuming one is therefore never told its inputs are done\nand the graph cannot end on its own, even after every node doing\nreal work has exited (dora-rs/dora#2920).\n\nOff by default: for a long-lived dataflow the timer is precisely\nwhat keeps it alive. Nodes with no data inputs at all (timer-only\nsources, or no inputs) are unaffected either way -- they have no\ndependency that could finish, so they are treated as sources.\n\nSet by `dora run --exit-when-nodes-finish` and `dora start\n--exit-when-nodes-finish`, and settable directly in YAML. It lives\non the descriptor rather than on the wire so that it survives the\nevents a dataflow outlives: auto-recovery re-spawn, coordinator\nrestart with state reconstruction, and `dora restart`.\n\n## Example\n\n```yaml\nexit_when_nodes_finish: true\nnodes:\n  - id: worker\n    path: ./worker\n    inputs:\n      tick: dora/timer/millis/100\n```",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
     "health_check_interval": {
       "description": "How often the daemon checks node health (in seconds).\n\nDefaults to 5.0 seconds if not specified. Lower values detect hung nodes\nfaster but add more overhead.",
       "type": [

--- a/libraries/core/src/descriptor/expand.rs
+++ b/libraries/core/src/descriptor/expand.rs
@@ -157,6 +157,7 @@ pub fn expand_modules_with_boundaries(
             debug: descriptor.debug.clone(),
             health_check_interval: descriptor.health_check_interval,
             strict_types: descriptor.strict_types,
+            exit_when_nodes_finish: descriptor.exit_when_nodes_finish,
             type_rules: descriptor.type_rules.clone(),
             env: descriptor.env.clone(),
         },
@@ -852,6 +853,86 @@ mod tests {
 
     fn parse_descriptor(yaml: &str) -> Descriptor {
         serde_yaml::from_str(yaml).unwrap()
+    }
+
+    /// dora-rs/dora#2920: expansion rebuilds the `Descriptor` field by
+    /// field, so any dataflow-level setting it forgets to copy is
+    /// silently dropped for every dataflow that uses modules. The
+    /// completion policy decides whether the graph can ever end, so
+    /// losing it turns a batch run into a hang.
+    ///
+    /// The descriptor MUST contain a module: without one,
+    /// `expand_modules_with_boundaries` short-circuits to a whole-struct
+    /// clone and never reaches the field-by-field rebuild this guards.
+    #[test]
+    fn expand_preserves_exit_when_nodes_finish() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+        write_file(
+            base,
+            "echo_module.yml",
+            r#"
+module:
+  name: echo
+  inputs: [data_in]
+  outputs: [data_out]
+
+nodes:
+  - id: passthrough
+    path: echo.py
+    inputs:
+      incoming: _mod/data_in
+    outputs:
+      - data_out
+"#,
+        );
+        let descriptor = parse_descriptor(
+            r#"
+exit_when_nodes_finish: true
+
+nodes:
+  - id: source
+    path: source.py
+    outputs:
+      - number
+
+  - id: my_echo
+    module: echo_module.yml
+    inputs:
+      data_in: source/number
+"#,
+        );
+        assert_eq!(descriptor.exit_when_nodes_finish, Some(true));
+        assert!(
+            descriptor.nodes.iter().any(|n| n.module.is_some()),
+            "precondition: without a module, expansion clones the whole \
+             descriptor and this test would pass even if the rebuild \
+             dropped the field"
+        );
+
+        let expanded = expand_modules(&descriptor, base).unwrap();
+        assert_eq!(
+            expanded.exit_when_nodes_finish,
+            Some(true),
+            "expansion must carry the completion policy through, or a \
+             module-using dataflow silently loses it and never ends"
+        );
+    }
+
+    /// Absent means absent: it must not become `Some(false)`, which
+    /// would be indistinguishable from an explicit opt out and would
+    /// start round-tripping into serialized output.
+    #[test]
+    fn expand_leaves_exit_when_nodes_finish_unset() {
+        let tmp = TempDir::new().unwrap();
+        let descriptor = parse_descriptor(
+            "nodes:\n  \
+               - id: worker\n    \
+                 path: ./worker\n",
+        );
+        assert_eq!(descriptor.exit_when_nodes_finish, None);
+        let expanded = expand_modules(&descriptor, tmp.path()).unwrap();
+        assert_eq!(expanded.exit_when_nodes_finish, None);
     }
 
     #[test]

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -36,6 +36,20 @@ pub trait DescriptorExt {
         &self,
         boundaries: &ModuleBoundaries,
     ) -> eyre::Result<String>;
+    /// Apply a command-line override to the dataflow's completion policy.
+    ///
+    /// `None` leaves the descriptor's own `exit_when_nodes_finish`
+    /// alone, so a setting written in the YAML stands; `Some(v)`
+    /// overrides it in either direction, so `--exit-when-nodes-finish`
+    /// can force the policy on and `=false` can force it off for a
+    /// descriptor that asks for it (dora-rs/dora#2920).
+    ///
+    /// Shared rather than spelled out at each call site: `dora run`,
+    /// `dora start` and the daemon all have to agree, and three copies
+    /// of the same three lines is how one of them ends up not being
+    /// updated.
+    fn apply_exit_when_nodes_finish(&mut self, over: Option<bool>);
+
     fn blocking_read(path: &Path) -> eyre::Result<Descriptor>;
     fn parse(buf: Vec<u8>) -> eyre::Result<Descriptor>;
     fn check(&self, working_dir: &Path) -> eyre::Result<()>;
@@ -244,6 +258,12 @@ impl DescriptorExt for Descriptor {
         let resolved = self.resolve_aliases_and_set_defaults()?;
         let flowchart = visualize::visualize_nodes_with_boundaries(&resolved, boundaries);
         Ok(flowchart)
+    }
+
+    fn apply_exit_when_nodes_finish(&mut self, over: Option<bool>) {
+        if let Some(over) = over {
+            self.exit_when_nodes_finish = Some(over);
+        }
     }
 
     fn blocking_read(path: &Path) -> eyre::Result<Descriptor> {
@@ -606,6 +626,51 @@ enum NodeKindMut<'a> {
 
 #[cfg(test)]
 mod tests {
+    /// dora-rs/dora#2920: the command-line flag beats the descriptor in
+    /// BOTH directions, and its absence beats neither.
+    ///
+    /// The third state matters: if "flag omitted" meant `false`, a YAML
+    /// `exit_when_nodes_finish: true` would be overridden on every
+    /// invocation, and since `dora run` and `dora start` are the only
+    /// ways to start a dataflow, the descriptor field could never take
+    /// effect at all.
+    #[test]
+    fn exit_when_nodes_finish_override_semantics() {
+        use super::DescriptorExt;
+
+        let parse = |yaml: &str| -> Descriptor { serde_yaml::from_str(yaml).expect("parse") };
+        let with_setting = "exit_when_nodes_finish: true\nnodes:\n  - id: a\n    path: ./a\n";
+        let without = "nodes:\n  - id: a\n    path: ./a\n";
+
+        // Omitted: the descriptor decides, either way.
+        let mut d = parse(with_setting);
+        d.apply_exit_when_nodes_finish(None);
+        assert_eq!(
+            d.exit_when_nodes_finish,
+            Some(true),
+            "omitting the flag must not silently disable a policy the \
+             dataflow file asked for"
+        );
+
+        let mut d = parse(without);
+        d.apply_exit_when_nodes_finish(None);
+        assert_eq!(d.exit_when_nodes_finish, None, "and must not invent one");
+
+        // Given: it wins, including against an opposite descriptor value.
+        let mut d = parse(with_setting);
+        d.apply_exit_when_nodes_finish(Some(false));
+        assert_eq!(
+            d.exit_when_nodes_finish,
+            Some(false),
+            "`--exit-when-nodes-finish=false` must be able to turn OFF a \
+             policy the dataflow file turned on"
+        );
+
+        let mut d = parse(without);
+        d.apply_exit_when_nodes_finish(Some(true));
+        assert_eq!(d.exit_when_nodes_finish, Some(true));
+    }
+
     use super::*;
 
     fn env(pairs: &[(&str, &str)]) -> BTreeMap<String, EnvValue> {

--- a/libraries/message/src/descriptor.rs
+++ b/libraries/message/src/descriptor.rs
@@ -114,6 +114,38 @@ pub struct Descriptor {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub strict_types: Option<bool>,
 
+    /// Finish the dataflow once every node has, treating
+    /// `dora/timer/...` inputs as a clock rather than as work.
+    ///
+    /// A timer input has no upstream node, so it never closes. By default
+    /// a node consuming one is therefore never told its inputs are done
+    /// and the graph cannot end on its own, even after every node doing
+    /// real work has exited (dora-rs/dora#2920).
+    ///
+    /// Off by default: for a long-lived dataflow the timer is precisely
+    /// what keeps it alive. Nodes with no data inputs at all (timer-only
+    /// sources, or no inputs) are unaffected either way -- they have no
+    /// dependency that could finish, so they are treated as sources.
+    ///
+    /// Set by `dora run --exit-when-nodes-finish` and `dora start
+    /// --exit-when-nodes-finish`, and settable directly in YAML. It lives
+    /// on the descriptor rather than on the wire so that it survives the
+    /// events a dataflow outlives: auto-recovery re-spawn, coordinator
+    /// restart with state reconstruction, and `dora restart`.
+    ///
+    /// ## Example
+    ///
+    /// ```yaml
+    /// exit_when_nodes_finish: true
+    /// nodes:
+    ///   - id: worker
+    ///     path: ./worker
+    ///     inputs:
+    ///       tick: dora/timer/millis/100
+    /// ```
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit_when_nodes_finish: Option<bool>,
+
     /// Custom type compatibility rules.
     ///
     /// Each rule declares that a source type can be implicitly converted to

--- a/tests/ws-cli-e2e.rs
+++ b/tests/ws-cli-e2e.rs
@@ -1470,6 +1470,145 @@ mod real_dataflow {
         let _ = std::fs::remove_file(&record);
     }
 
+    /// dora-rs/dora#2920: `dora start --exit-when-nodes-finish` must let
+    /// a timer-driven dataflow finish on its own.
+    ///
+    /// The `dora run` half of this shipped first; `start` goes through a
+    /// completely different path — CLI to coordinator to daemon — so it
+    /// needs its own proof. The setting travels on the descriptor rather
+    /// than the wire precisely so it survives that trip (and later,
+    /// auto-recovery and restart), which is exactly what this checks.
+    ///
+    /// Status, not absence: a finished dataflow REMAINS in `dora list`
+    /// with status `Finished`, so "no longer listed" would never become
+    /// true and would make this pass for the wrong reason.
+    #[test]
+    #[cfg(unix)]
+    fn e2e_start_exit_when_nodes_finish_terminates_timer_driven_graph() {
+        ensure_built();
+        let dora = dora_bin();
+        let status = Command::new("cargo")
+            .args([
+                "build",
+                "-p",
+                "emit-then-exit-source-node",
+                "-p",
+                "drain-recording-node",
+            ])
+            .status()
+            .expect("failed to build fixtures");
+        assert!(status.success(), "failed to build fixtures");
+
+        let target = Path::new(env!("CARGO_MANIFEST_DIR")).join("target");
+        let yaml = target.join(format!("dora-start-2920-{}.yml", std::process::id()));
+        std::fs::write(
+            &yaml,
+            format!(
+                "nodes:\n  \
+                 - id: producer\n    \
+                   path: {producer}\n    \
+                   inputs:\n      \
+                     tick: dora/timer/millis/100\n    \
+                   outputs:\n      - value\n  \
+                 - id: consumer\n    \
+                   path: {consumer}\n    \
+                   inputs:\n      \
+                     value: producer/value\n      \
+                     tick: dora/timer/millis/200\n",
+                producer = target.join("debug/emit-then-exit-source-node").display(),
+                consumer = target.join("debug/drain-recording-node").display(),
+            ),
+        )
+        .expect("failed to write dataflow yaml");
+
+        start_cluster(&dora);
+        // Tear the cluster down on EVERY exit path. The premise assertion
+        // below fires before the explicit cleanup, so without this a
+        // broken premise would strand a coordinator, a daemon and this
+        // dataflow's nodes for the rest of the suite.
+        let _guard = ClusterGuard(&dora);
+
+        let status_of = |name: &str| -> String {
+            let out = Command::new(&dora)
+                .arg("list")
+                .output()
+                .expect("failed to run dora list");
+            String::from_utf8_lossy(&out.stdout)
+                .lines()
+                .find(|l| l.split_whitespace().nth(1) == Some(name))
+                .and_then(|l| l.split_whitespace().nth(2).map(str::to_owned))
+                .unwrap_or_default()
+        };
+        let settle = |name: &str, secs: u64| -> String {
+            let deadline = std::time::Instant::now() + Duration::from_secs(secs);
+            loop {
+                let s = status_of(name);
+                if s == "Finished" || std::time::Instant::now() >= deadline {
+                    break s;
+                }
+                std::thread::sleep(Duration::from_millis(500));
+            }
+        };
+
+        // Premise: without the flag this graph does not finish on its own.
+        let started = Command::new(&dora)
+            .args([
+                "start",
+                yaml.to_str().unwrap(),
+                "--detach",
+                "--name",
+                "e2e2920noflag",
+            ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .expect("failed to run dora start");
+        assert!(started.success(), "dora start (no flag) failed");
+        let without = settle("e2e2920noflag", 15);
+        let _ = Command::new(&dora)
+            .args(["stop", "--name", "e2e2920noflag"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+        assert_ne!(
+            without, "Finished",
+            "test premise broken: this graph finished WITHOUT \
+             --exit-when-nodes-finish, so the flag is not what this test \
+             thinks it is measuring"
+        );
+
+        // With the flag it must reach `Finished` on its own.
+        let started = Command::new(&dora)
+            .args([
+                "start",
+                yaml.to_str().unwrap(),
+                "--detach",
+                "--name",
+                "e2e2920flag",
+                "--exit-when-nodes-finish",
+            ])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .expect("failed to run dora start");
+        assert!(started.success(), "dora start (with flag) failed");
+        let with = settle("e2e2920flag", 60);
+
+        let _ = Command::new(&dora)
+            .args(["stop", "--name", "e2e2920flag"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+        let _ = std::fs::remove_file(&yaml);
+
+        assert_eq!(
+            with, "Finished",
+            "`dora start --exit-when-nodes-finish` left the dataflow in state \
+             `{with}` — the timer is still gating the drain across the \
+             coordinator path (#2920)"
+        );
+    }
+
     /// #2919 P2: a node added to a RUNNING dataflow must inherit that
     /// dataflow's env, including anything set via `dora start --env`.
     ///


### PR DESCRIPTION
Completes the first ask of #2920. [#2957](https://github.com/dora-rs/dora/pull/2957) shipped `dora run --exit-when-nodes-finish`; the issue asks for `run/start`, and `start` reaches the daemon by a different route, so the flag did not exist there.

## Why the descriptor, not the wire

`start` goes CLI → coordinator → daemon, and the setting has to survive three things `run` never faced: **auto-recovery re-spawn**, **coordinator restart** with state reconstruction, and **`dora restart`**.

Carrying it on the wire meant remembering it in five places — `ControlRequest::Start`, `SpawnDataflowNodes`, the coordinator's `RunningDataflow`, its persisted record plus reconstruction, and `PendingRestart`. Miss one and the setting silently vanishes. That is the same drop-one-copy shape that already cost this issue two rounds (the operator-node check in #2957, the pid guard in #2961).

The descriptor is already carried through every one of those. Putting it there means:

- **no protocol change at all** — the `Start` / `Spawn` fields I first added are reverted
- **essentially no coordinator change** — one single-node temp descriptor literal
- `dora run` folds its `RunDataflowOptions` onto the same field, so both entry points share one source of truth instead of a daemon-scoped flag plus a wire field
- it becomes settable in YAML, so a batch dataflow can declare its own policy

## Semantics

The flag overrides the descriptor in **both** directions, and is tri-state:

```bash
dora start flow.yml --exit-when-nodes-finish          # force on
dora start flow.yml --exit-when-nodes-finish=false    # force off
dora start flow.yml                                   # the YAML decides
```

Absence deliberately does **not** mean `false`. `run` and `start` are the only ways to start a dataflow, so "absent means off" would override a YAML `true` on every invocation and the descriptor field could never take effect. A test pins both halves, so a later "simplification" back to a plain bool fails with an explanation.

`DescriptorExt::apply_exit_when_nodes_finish` is the single place the field is written.

## Verification

All four combinations, end to end:

| YAML | flag | result |
|---|---|---|
| `true` | omitted | finishes — descriptor decides |
| `true` | `=false` | hangs — flag overrides off |
| unset | bare | finishes — flag overrides on |
| unset | omitted | hangs — default |

Mutation-checked against **production** code, not tests:

- daemon ignores the descriptor field → **both** the `run` and `start` e2e fail, each with its own diagnostic
- `expand()` drops the field → propagation test fails
- override reverted to "only turns on" → semantics test fails
- override changed to "absent means false" → semantics test fails

The propagation test carries a precondition assert: without a module in the fixture, `expand_modules` short-circuits to a whole-struct clone and never reaches the field-by-field rebuild, so an earlier version of that test passed under mutation and proved nothing.

Gate: fmt, clippy `-D warnings`, workspace tests, `cargo check --examples`, timer e2e (`run` + `start`), fault-tolerance (11), finish-straggler (1), node-lifecycle (10). No leftover processes.

## Docs and schema

- both CLI flag tables — the `dora run` row claimed a `false` default, which is no longer true
- `docs/yaml-spec.md`: root-level field plus a **Completion** section on why a timer stops a graph ending
- `libraries/core/dora-schema.json` regenerated

The root `dora-schema.json` is deliberately untouched: the generator does not write it and it was already 86 lines stale before this change. Worth a separate look.

## Note

`RunDataflowOptions::exit_when_nodes_finish` becomes `Option<bool>` to carry the third state. It shipped in #2957 today with the workspace version unchanged, so nothing is published with the old shape; the builder setter keeps its `bool` signature.

Refs #2920

🤖 Generated with [Claude Code](https://claude.com/claude-code)
