### PR TITLE
test(e2e): guard that a dynamically added node gets ticks on a fresh timer interval (#2585)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7754,6 +7754,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "timer-tick-recorder-node"
+version = "1.0.0-rc.4"
+dependencies = [
+ "dora-node-api",
+ "eyre",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ members = [
     "tests/fault_tolerance/silent_source_node",
     "tests/fault_tolerance/stop_delay_node",
     "tests/fault_tolerance/timed_burst_source_node",
+    "tests/fault_tolerance/timer_tick_recorder_node",
     "xtask",
 ]
 

--- a/guide/src/operations/dynamic-topology.md
+++ b/guide/src/operations/dynamic-topology.md
@@ -29,9 +29,14 @@ id: filter
 path: filter.py
 outputs:
   - output
+inputs:
+  tick: dora/timer/millis/300
 ```
 
-After adding, wire inputs explicitly with `dora node connect`.
+Inputs can be declared inline like above, or wired after the fact with
+`dora node connect`. Timer inputs work either way, including on an
+interval that no already-running node subscribes to — adding the node
+starts a tick source for that interval.
 
 ## Examples
 

--- a/tests/fault_tolerance/timer_tick_recorder_node/Cargo.toml
+++ b/tests/fault_tolerance/timer_tick_recorder_node/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "timer-tick-recorder-node"
+edition.workspace = true
+rust-version.workspace = true
+version.workspace = true
+description.workspace = true
+documentation.workspace = true
+license.workspace = true
+publish = false
+
+# Test-only node that appends every input it receives to
+# `DORA_TEST_MARKER_FILE`. Used by tests/node-lifecycle-e2e.rs to observe
+# whether a dynamically added node's timer input actually fires
+# (dora-rs/dora#2585) — `dora node list` reports `Running` either way, so
+# a starved timer is only visible from the node side. Lives here
+# alongside the other test-only node crates (`stop-delay-node` and
+# `fire-and-forget-source-node` are likewise shared with
+# tests/node-lifecycle-e2e.rs).
+
+[[bin]]
+name = "timer-tick-recorder-node"
+path = "src/main.rs"
+
+[dependencies]
+dora-node-api = { workspace = true, default-features = false }
+eyre = { workspace = true }

--- a/tests/fault_tolerance/timer_tick_recorder_node/src/main.rs
+++ b/tests/fault_tolerance/timer_tick_recorder_node/src/main.rs
@@ -1,0 +1,71 @@
+//! Test-only node that records every input event it receives, so a test
+//! can assert that an input actually *fires* rather than that the node
+//! merely came up.
+//!
+//! Motivating case (dora-rs/dora#2585): a node added to an
+//! already-running dataflow via `dora node add` whose timer input uses an
+//! interval no existing node subscribes to used to be starved of ticks
+//! forever, because per-interval tick-emitting tasks are only ever
+//! spawned in `RunningDataflow::start()`. Such a node spawns fine and
+//! `dora node list` reports it as `Running`, so the silence is invisible
+//! from the daemon side — the only observable is a delivery the node
+//! itself reports.
+//!
+//! * `DORA_TEST_MARKER_FILE` (required) — path appended with one line per
+//!   received input, holding that input's id. Created (empty) at startup
+//!   so a test can tell "node came up but no input arrived" apart from
+//!   "node never came up". Same marker-file convention as
+//!   `stop_delay_node` / `clean_exit_node`.
+//!
+//! Exits on `Event::Stop`.
+
+use dora_node_api::{DoraNode, Event};
+use eyre::Context;
+use std::{io::Write, thread, time::Duration};
+
+/// Absolute lifetime cap. Nothing in the test path should reach this —
+/// the node exits on `Stop` — but an orphaned incarnation (killed daemon,
+/// timed-out CI step, severed connection that never yields `None`) would
+/// otherwise sit resident forever holding its shared-memory pool.
+/// `stop_delay_node` bounds itself the same way.
+const MAX_LIFETIME: Duration = Duration::from_secs(300);
+
+fn main() -> eyre::Result<()> {
+    let marker =
+        std::env::var("DORA_TEST_MARKER_FILE").context("DORA_TEST_MARKER_FILE must be set")?;
+
+    let (_node, mut events) =
+        DoraNode::init_from_env().context("failed to init dora node from env")?;
+
+    // Opened once, before any input can arrive, so the file's existence
+    // means "this node connected" and its emptiness means "connected but
+    // nothing was delivered" — the exact distinction #2585 turns on.
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&marker)
+        .with_context(|| format!("failed to open marker file {marker:?}"))?;
+
+    thread::spawn(|| {
+        thread::sleep(MAX_LIFETIME);
+        eprintln!("timer-tick-recorder-node: lifetime cap reached, exiting");
+        std::process::exit(0);
+    });
+
+    while let Some(event) = events.recv() {
+        match event {
+            Event::Input { id, .. } => {
+                writeln!(file, "{id}").context("failed to record input")?;
+                // Flushed per line: the test polls this file while the
+                // node is still running, so a buffered write it never
+                // sees is indistinguishable from an input that never
+                // arrived.
+                file.flush().context("failed to flush marker file")?;
+            }
+            Event::Stop(_) => break,
+            _ => {}
+        }
+    }
+
+    Ok(())
+}

--- a/tests/node-lifecycle-e2e.rs
+++ b/tests/node-lifecycle-e2e.rs
@@ -723,6 +723,143 @@ fn rust_dynamic_node_readd_same_id_ignores_stale_exit() {
     );
 }
 
+static BUILD_TICK_RECORDER: Once = Once::new();
+
+/// Build the `timer-tick-recorder-node` fixture used by the #2585
+/// regression test. Same rationale as `ensure_rust_filter_built`: `dora
+/// node add` never runs a `build:` field, so the binary has to exist
+/// beforehand.
+fn ensure_tick_recorder_built() {
+    BUILD_TICK_RECORDER.call_once(|| {
+        let dora_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let status = Command::new("cargo")
+            .args(["build", "-p", "timer-tick-recorder-node"])
+            .arg("--target-dir")
+            .arg(dora_root.join("target"))
+            .status()
+            .expect("failed to run cargo build for timer-tick-recorder-node");
+        assert!(status.success(), "failed to build timer-tick-recorder-node");
+    });
+}
+
+/// Regression for dora-rs/dora#2585: a node added to an already-running
+/// dataflow must actually *receive* ticks on a timer input, even when it
+/// is the first subscriber of that interval.
+///
+/// Per-interval tick-emitting tasks are only ever spawned by
+/// `RunningDataflow::start()`, which the daemon calls once, on the
+/// all-nodes-ready transition. `AddNode` registered the new node in
+/// `dataflow.timers` but did not re-invoke `start()`, so an interval no
+/// already-running node subscribed to never got a task and the added
+/// node's timer input was silent forever. The node still spawns and
+/// still reports `Running`, which is why the pre-existing lifecycle
+/// coverage (`lifecycle_rust_dynamic_add_remove` adds a node wired to
+/// the *sender's output*, and asserts only that it reaches `Running`)
+/// could not see this: the only observable is a delivery reported by the
+/// node itself.
+///
+/// The interval is deliberately one the running dataflow does not
+/// already use — reusing an existing interval passes even with the bug,
+/// because the task spawned at start-up keeps firing and the delivery
+/// path re-reads the (now larger) subscriber set on every tick.
+#[test]
+fn rust_dynamic_node_receives_ticks_on_fresh_timer_interval() {
+    let _guard = LIFECYCLE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let dataflow = Path::new(manifest_dir).join("examples/rust-dynamic-add-remove/dataflow.yml");
+
+    // Distinct from every interval `examples/rust-dynamic-add-remove`
+    // already subscribes to (sender 200ms, receiver 500ms), so the added
+    // node is the *first* subscriber of this one and a task genuinely has
+    // to be spawned for it.
+    const FRESH_INTERVAL_MS: u64 = 300;
+    // More than one, so a single stray delivery can't pass for a working
+    // timer; small enough to land well inside the poll deadline at 300ms
+    // apart.
+    const REQUIRED_TICKS: usize = 3;
+
+    // Before writing the spec below: the build both produces the binary
+    // the spec points at and guarantees `<manifest>/target/` exists,
+    // which a `CARGO_TARGET_DIR` override would otherwise leave absent.
+    ensure_tick_recorder_built();
+
+    // Artifacts under `target/` rather than the system temp dir, matching
+    // `write_stop_delay_yml`: gitignored, cleaned by `cargo clean`, and
+    // worth keeping after a failed run.
+    let dir = Path::new(manifest_dir).join("target");
+    let stem = format!("dora-timer-tick-{}", std::process::id());
+    let ticker_yml = dir.join(format!("{stem}.yml"));
+    let marker = dir.join(format!("{stem}.ticks"));
+    // A rerun in the same process would otherwise count the previous
+    // run's ticks.
+    let _ = fs::remove_file(&marker);
+    fs::write(
+        &ticker_yml,
+        format!(
+            "id: ticker\n\
+             path: {manifest_dir}/target/debug/timer-tick-recorder-node\n\
+             env:\n  \
+               DORA_TEST_MARKER_FILE: {marker}\n\
+             inputs:\n  \
+               tick: dora/timer/millis/{FRESH_INTERVAL_MS}\n",
+            marker = marker.display()
+        ),
+    )
+    .expect("failed to write ticker node spec");
+
+    let name = "rustlc-timer";
+    let fixture = LifecycleFixture {
+        dataflow_path: &dataflow,
+        filter_yml_path: &ticker_yml,
+        name,
+        sender_path_marker: "rust-dynamic-add-remove-sender",
+        use_uv: false,
+    };
+    let StartedLifecycle { dora, .. } = start_lifecycle(&fixture);
+    let _cleanup = CleanupGuard { dora: &dora };
+
+    add_node(&dora, name, &ticker_yml, "dora node add ticker");
+    let list_out = wait_for_list(&dora, name, Duration::from_secs(10), |m| {
+        m.get("ticker").is_some_and(|(s, _, _)| s == "Running")
+    });
+    assert!(
+        matches!(parse_node_list(&list_out).get("ticker"), Some((s, _, _)) if s == "Running"),
+        "ticker did not reach Running within 10s after `dora node add`; list:\n{list_out}"
+    );
+
+    let count_ticks = || {
+        fs::read_to_string(&marker)
+            .unwrap_or_default()
+            .lines()
+            .filter(|line| line.trim() == "tick")
+            .count()
+    };
+    // 15s covers ~50 ticks at 300ms, so this only expires if the timer is
+    // genuinely dead rather than merely slow to start (the node subscribes
+    // a moment after the task begins ticking, and ticks that predate the
+    // subscribe are dropped by the daemon's delivery path).
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    let mut ticks = count_ticks();
+    while ticks < REQUIRED_TICKS && std::time::Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(200));
+        ticks = count_ticks();
+    }
+
+    assert!(
+        marker.exists(),
+        "ticker never created its marker file at {}, so it never connected — \
+         this test can't say anything about timer delivery",
+        marker.display()
+    );
+    assert!(
+        ticks >= REQUIRED_TICKS,
+        "dynamically added node got {ticks} ticks on the previously-unused \
+         interval {FRESH_INTERVAL_MS}ms within 15s, expected at least \
+         {REQUIRED_TICKS} (dora-rs/dora#2585: no tick-emitting task was \
+         spawned for an interval registered after the dataflow started)"
+    );
+}
+
 static BUILD_STOP_DELAY: Once = Once::new();
 
 /// Build the `stop-delay-node` fixture used by the #2916 hot-swap


### PR DESCRIPTION
Both code fixes for #2585 already landed — #2474 made `AddNode` re-invoke
`RunningDataflow::start()`, #2810 made `RemoveNode` cancel a timer task whose
last subscriber went away. The coverage gap the issue itself called out did
not: nothing adds a node with a fresh timer interval and checks that ticks
actually arrive. `lifecycle_rust_dynamic_add_remove` adds a node wired to the
sender's output and asserts only that it reaches `Running` — which is exactly
what the bug looked like from the daemon side.

Adds `rust_dynamic_node_receives_ticks_on_fresh_timer_interval`: starts
`examples/rust-dynamic-add-remove` (timers at 200ms and 500ms), `dora node
add`s a node whose only input is `dora/timer/millis/300`, then asserts at
least 3 ticks reach it within 15s. The interval has to be one no running node
subscribes to — reusing an existing one passes even with the bug, because that
interval's task is already ticking and the delivery path re-reads the
subscriber set every tick.

Observing delivery needs a node that reports what it received, so this adds
the `timer-tick-recorder-node` fixture (appends each input id to
`DORA_TEST_MARKER_FILE`, same convention as `stop-delay-node`).

Checked against a revert of the `AddNode` → `start()` call: the test fails
with `got 0 ticks on the previously-unused interval 300ms`, and passes on
current `main`.

Also documents that a dynamic node's YAML can declare `inputs:` inline,
including timers — the guide only mentioned wiring them afterwards with `dora
node connect`.
