### PR TITLE
docs(cli): document JSON output shape for every --format flag

### DIFF
--- a/binaries/cli/src/command/clean.rs
+++ b/binaries/cli/src/command/clean.rs
@@ -31,8 +31,9 @@ pub struct CleanArgs {
     coordinator: CoordinatorOptions,
     /// Output format
     ///
-    /// `json` emits JSON Lines (one object per line); failures are
-    /// emitted as JSON Lines on stderr.
+    /// `json` emits JSON Lines (one object per line). Each failure is
+    /// additionally emitted as one JSON object line on stderr, followed
+    /// by a plain-text error summary (the command exits non-zero).
     #[clap(long, short = 'f', value_name = "FORMAT", default_value_t = OutputFormat::Table)]
     pub format: OutputFormat,
     /// Only print cleaned dataflow UUIDs, one per line
@@ -169,5 +170,49 @@ fn clean(
             "{} dataflow(s) could not be removed from the persisted store; their in-memory entries are preserved so a later `dora clean` can retry",
             failures.len()
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CleanedEntry, FailedEntry};
+    use dora_message::coordinator_to_cli::DataflowStatus;
+    use uuid::Uuid;
+
+    /// Pins the JSONL contract the help text promises for `--format json`:
+    /// cleaned entries on stdout and failure entries on stderr each
+    /// serialize to a single line that parses as an independent JSON
+    /// object with stable keys.
+    #[test]
+    fn clean_entries_serialize_as_independent_single_line_objects() {
+        let cleaned = serde_json::to_string(&CleanedEntry {
+            uuid: Uuid::nil(),
+            name: "df".into(),
+            status: DataflowStatus::Finished,
+        })
+        .expect("serialize cleaned entry");
+        let failed = serde_json::to_string(&FailedEntry {
+            uuid: Uuid::nil(),
+            name: "df".into(),
+            error: "store unavailable".into(),
+        })
+        .expect("serialize failed entry");
+
+        for line in [&cleaned, &failed] {
+            assert!(!line.contains('\n'), "JSONL entries must be single-line");
+        }
+        let cleaned: serde_json::Value =
+            serde_json::from_str(&cleaned).expect("cleaned entry parses as standalone JSON");
+        for key in ["uuid", "name", "status"] {
+            assert!(
+                cleaned.get(key).is_some(),
+                "cleaned entry must have `{key}`"
+            );
+        }
+        let failed: serde_json::Value =
+            serde_json::from_str(&failed).expect("failed entry parses as standalone JSON");
+        for key in ["uuid", "name", "error"] {
+            assert!(failed.get(key).is_some(), "failed entry must have `{key}`");
+        }
     }
 }

--- a/binaries/cli/src/command/clean.rs
+++ b/binaries/cli/src/command/clean.rs
@@ -30,6 +30,9 @@ pub struct CleanArgs {
     #[clap(flatten)]
     coordinator: CoordinatorOptions,
     /// Output format
+    ///
+    /// `json` emits JSON Lines (one object per line); failures are
+    /// emitted as JSON Lines on stderr.
     #[clap(long, short = 'f', value_name = "FORMAT", default_value_t = OutputFormat::Table)]
     pub format: OutputFormat,
     /// Only print cleaned dataflow UUIDs, one per line

--- a/binaries/cli/src/command/list.rs
+++ b/binaries/cli/src/command/list.rs
@@ -31,6 +31,8 @@ pub struct ListArgs {
     #[clap(flatten)]
     coordinator: CoordinatorOptions,
     /// Output format
+    ///
+    /// `json` emits JSON Lines (one object per line).
     #[clap(long, short = 'f', value_name = "FORMAT", default_value_t = OutputFormat::Table)]
     pub format: OutputFormat,
     /// Filter by status (running, finished, failed)

--- a/binaries/cli/src/command/logs.rs
+++ b/binaries/cli/src/command/logs.rs
@@ -66,6 +66,8 @@ pub struct LogsArgs {
     #[arg(value_parser = parse_log_level_str)]
     pub level: dora_core::build::LogLevelOrStdout,
     /// Output format for log messages
+    ///
+    /// `json` emits JSON Lines (one object per log message).
     #[clap(long, default_value = "pretty", env = "DORA_LOG_FORMAT")]
     pub log_format: LogFormat,
     /// Per-node log level filter (e.g. "sensor=debug,processor=warn")

--- a/binaries/cli/src/command/mod.rs
+++ b/binaries/cli/src/command/mod.rs
@@ -244,6 +244,56 @@ mod tests {
         Args::try_parse_from(args).unwrap_or_else(|e| panic!("failed to parse {args:?}: {e}"));
     }
 
+    /// Every `--format` flag must state its JSON output shape in `--help`,
+    /// so scripters learn whether to parse line-wise (JSON Lines) or as a
+    /// single document without reading the source (#2922).
+    #[test]
+    fn help_documents_json_output_shape_for_every_format_flag() {
+        let cases: &[(&[&str], &str)] = &[
+            (
+                &["dora", "list", "--help"],
+                "JSON Lines (one object per line)",
+            ),
+            (
+                &["dora", "clean", "--help"],
+                "JSON Lines (one object per line)",
+            ),
+            (
+                &["dora", "topic", "list", "--help"],
+                "JSON Lines (one object per line)",
+            ),
+            (
+                &["dora", "topic", "echo", "--help"],
+                "JSON Lines (one object per message)",
+            ),
+            (
+                &["dora", "node", "list", "--help"],
+                "JSON Lines (one object per line)",
+            ),
+            (
+                &["dora", "node", "info", "--help"],
+                "a single pretty-printed JSON document",
+            ),
+            (
+                &["dora", "system", "status", "--help"],
+                "a single pretty-printed JSON document",
+            ),
+            (
+                &["dora", "param", "list", "--help"],
+                "a single pretty-printed JSON document",
+            ),
+        ];
+        for (args, expected) in cases {
+            let error = Args::try_parse_from(*args).expect_err("--help should stop parsing");
+            assert_eq!(error.kind(), clap::error::ErrorKind::DisplayHelp);
+            let help = error.to_string();
+            assert!(
+                help.contains(expected),
+                "help for {args:?} must contain {expected:?}, got:\n{help}"
+            );
+        }
+    }
+
     fn parse_err(args: &[&str]) {
         assert!(
             Args::try_parse_from(args).is_err(),

--- a/binaries/cli/src/command/mod.rs
+++ b/binaries/cli/src/command/mod.rs
@@ -264,7 +264,25 @@ mod tests {
             ),
             (
                 &["dora", "topic", "echo", "--help"],
-                "JSON Lines (one object per message)",
+                "JSON Lines (one object per decoded message)",
+            ),
+            (
+                &["dora", "logs", "--help"],
+                "JSON Lines (one object per log message)",
+            ),
+            (
+                &["dora", "run", "--help"],
+                "JSON Lines (one object per log message)",
+            ),
+            (
+                // top-level alias of `dora system status`
+                &["dora", "status", "--help"],
+                "a single pretty-printed JSON document",
+            ),
+            (
+                // `ps` alias resolves to `dora list`
+                &["dora", "ps", "--help"],
+                "JSON Lines (one object per line)",
             ),
             (
                 &["dora", "node", "list", "--help"],
@@ -546,6 +564,9 @@ mod tests {
     #[test]
     fn parse_node_list() {
         parse_ok(&["dora", "node", "list"]);
+        parse_ok(&["dora", "node", "list", "--format", "json"]);
+        // --quiet and --format conflict (documented in the flag table)
+        parse_err(&["dora", "node", "list", "-q", "--format", "json"]);
     }
 
     #[test]

--- a/binaries/cli/src/command/node/info.rs
+++ b/binaries/cli/src/command/node/info.rs
@@ -46,6 +46,8 @@ pub struct Info {
     pub dataflow: Option<String>,
 
     /// Output format
+    ///
+    /// `json` emits a single pretty-printed JSON document.
     #[clap(long, short = 'f', value_name = "FORMAT", default_value_t = OutputFormat::Table)]
     pub format: OutputFormat,
 

--- a/binaries/cli/src/command/node/list.rs
+++ b/binaries/cli/src/command/node/list.rs
@@ -204,7 +204,6 @@ fn list(
 #[cfg(test)]
 mod tests {
     use super::OutputEntry;
-    use clap::{Parser as _, error::ErrorKind};
 
     fn entry(node: &str, dataflow: Option<&str>) -> OutputEntry {
         OutputEntry {
@@ -241,20 +240,6 @@ mod tests {
         assert!(
             filtered.get("dataflow").is_none(),
             "`dataflow` must be omitted, not null, when filtering by dataflow"
-        );
-    }
-
-    #[test]
-    fn help_documents_json_lines_output() {
-        let error = crate::Args::try_parse_from(["dora", "node", "list", "--help"])
-            .expect_err("--help should stop command parsing");
-
-        assert_eq!(error.kind(), ErrorKind::DisplayHelp);
-        assert!(
-            error
-                .to_string()
-                .contains("JSON Lines (one object per line)"),
-            "node list help must describe the line-oriented JSON contract"
         );
     }
 }

--- a/binaries/cli/src/command/node/list.rs
+++ b/binaries/cli/src/command/node/list.rs
@@ -32,7 +32,11 @@ pub struct List {
     #[clap(long, short = 'd', value_name = "NAME_OR_UUID")]
     pub dataflow: Option<String>,
 
-    /// Output format. `json` emits JSON Lines (one object per line)
+    /// Output format
+    ///
+    /// `json` emits JSON Lines (one object per line). All fields are
+    /// formatted strings; the `dataflow` field is omitted from each
+    /// object when `--dataflow` is given.
     #[clap(long, short = 'f', value_name = "FORMAT", default_value_t = OutputFormat::Table)]
     pub format: OutputFormat,
 
@@ -199,7 +203,46 @@ fn list(
 
 #[cfg(test)]
 mod tests {
+    use super::OutputEntry;
     use clap::{Parser as _, error::ErrorKind};
+
+    fn entry(node: &str, dataflow: Option<&str>) -> OutputEntry {
+        OutputEntry {
+            node: node.into(),
+            status: "Running".into(),
+            pid: "123".into(),
+            cpu: "0.1%".into(),
+            memory: "10 MB".into(),
+            restarts: "0".into(),
+            dataflow: dataflow.map(Into::into),
+        }
+    }
+
+    /// Pins the runtime JSON contract the help text promises: each entry
+    /// serializes to a single line that parses as an independent JSON
+    /// object, and the `dataflow` key is omitted (not null) when the
+    /// listing is filtered to one dataflow.
+    #[test]
+    fn json_entries_serialize_as_independent_single_line_objects() {
+        let unfiltered = serde_json::to_string(&entry("a", Some("df"))).expect("serialize entry");
+        let filtered = serde_json::to_string(&entry("b", None)).expect("serialize entry");
+
+        for line in [&unfiltered, &filtered] {
+            assert!(!line.contains('\n'), "JSONL entries must be single-line");
+            serde_json::from_str::<serde_json::Value>(line)
+                .expect("each output line must parse as standalone JSON");
+        }
+
+        let unfiltered: serde_json::Value =
+            serde_json::from_str(&unfiltered).expect("parse unfiltered entry");
+        assert_eq!(unfiltered["dataflow"], "df");
+        let filtered: serde_json::Value =
+            serde_json::from_str(&filtered).expect("parse filtered entry");
+        assert!(
+            filtered.get("dataflow").is_none(),
+            "`dataflow` must be omitted, not null, when filtering by dataflow"
+        );
+    }
 
     #[test]
     fn help_documents_json_lines_output() {

--- a/binaries/cli/src/command/param/list.rs
+++ b/binaries/cli/src/command/param/list.rs
@@ -33,7 +33,9 @@ pub struct List {
     #[clap(long, short = 'd', value_name = "NAME_OR_UUID")]
     pub dataflow: Option<String>,
 
-    /// Output format: table or json
+    /// Output format
+    ///
+    /// `json` emits a single pretty-printed JSON document.
     #[clap(long, default_value = "table")]
     pub format: OutputFormat,
 

--- a/binaries/cli/src/command/run.rs
+++ b/binaries/cli/src/command/run.rs
@@ -62,6 +62,8 @@ pub struct Run {
     #[arg(value_parser = parse_log_level_str)]
     pub log_level: LogLevelOrStdout,
     /// Output format for log messages
+    ///
+    /// `json` emits JSON Lines (one object per log message).
     #[clap(long, default_value = "pretty", env = "DORA_LOG_FORMAT")]
     pub log_format: LogFormat,
     /// Per-node log level filter

--- a/binaries/cli/src/command/system/status.rs
+++ b/binaries/cli/src/command/system/status.rs
@@ -184,7 +184,9 @@ pub struct Status {
     /// Path to the dataflow descriptor file (enables additional checks)
     #[clap(long, value_name = "PATH", value_hint = clap::ValueHint::FilePath)]
     dataflow: Option<PathBuf>,
-    /// Output format (table or json)
+    /// Output format
+    ///
+    /// `json` emits a single pretty-printed JSON document.
     #[clap(long, short = 'f', value_name = "FORMAT", default_value_t = OutputFormat::Table)]
     format: OutputFormat,
     #[clap(flatten)]

--- a/binaries/cli/src/command/topic/echo.rs
+++ b/binaries/cli/src/command/topic/echo.rs
@@ -43,7 +43,8 @@ pub struct Echo {
 
     /// Output format
     ///
-    /// `json` emits JSON Lines (one object per message).
+    /// `json` emits JSON Lines (one object per decoded message);
+    /// diagnostics go to stderr.
     #[clap(long, value_name = "FORMAT", default_value_t = OutputFormat::Table)]
     pub format: OutputFormat,
 

--- a/binaries/cli/src/command/topic/echo.rs
+++ b/binaries/cli/src/command/topic/echo.rs
@@ -42,6 +42,8 @@ pub struct Echo {
     selector: TopicSelector,
 
     /// Output format
+    ///
+    /// `json` emits JSON Lines (one object per message).
     #[clap(long, value_name = "FORMAT", default_value_t = OutputFormat::Table)]
     pub format: OutputFormat,
 

--- a/binaries/cli/src/command/topic/list.rs
+++ b/binaries/cli/src/command/topic/list.rs
@@ -28,6 +28,8 @@ pub struct List {
     selector: DataflowSelector,
 
     /// Output format
+    ///
+    /// `json` emits JSON Lines (one object per line).
     #[clap(long, value_name = "FORMAT", default_value_t = OutputFormat::Table)]
     pub format: OutputFormat,
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -285,7 +285,7 @@ dora run <PATH> [OPTIONS]
 | `--allow-shell-nodes` | false | Enable shell-based node execution |
 | `--exit-when-nodes-finish[=BOOL]` | descriptor | Exit once all nodes finish, treating `dora/timer/...` inputs as a clock rather than as work. Overrides `exit_when_nodes_finish:` in the YAML; omit it and the YAML decides |
 | `--log-level <LEVEL>` | `stdout` | Min display level: `error\|warn\|info\|debug\|trace\|stdout` |
-| `--log-format <FORMAT>` | `pretty` | Output format: `pretty\|json\|compact` |
+| `--log-format <FORMAT>` | `pretty` | Output format: `pretty\|json\|compact`; `json` emits JSON Lines (one object per log message) |
 | `--log-filter <FILTER>` | | Per-node level overrides: `"node1=debug,node2=warn"` |
 
 **Examples:**
@@ -530,7 +530,7 @@ dora clean [OPTIONS]
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--format <FMT>`, `-f` | `table` | Output format: `table\|json`. JSON output uses JSON Lines (one object per line); failures go to stderr as JSON Lines |
+| `--format <FMT>`, `-f` | `table` | Output format: `table\|json`. JSON output uses JSON Lines (one object per line); each failure is also one JSON object line on stderr, followed by a plain-text error summary (exit code is non-zero) |
 | `--quiet`, `-q` | false | Print only cleaned UUIDs |
 | `--coordinator-addr <IP>` | `127.0.0.1` | Coordinator address |
 | `--coordinator-port <PORT>` | `6013` | Coordinator port |
@@ -582,7 +582,7 @@ dora logs [UUID_OR_NAME] [OPTIONS]
 | `--since <DURATION>` | | Show logs newer than duration ago |
 | `--until <DURATION>` | | Show logs older than duration ago |
 | `--level <LEVEL>` | `stdout` | Min log level |
-| `--log-format <FORMAT>` | `pretty` | Output format |
+| `--log-format <FORMAT>` | `pretty` | Output format: `pretty\|json\|compact`; `json` emits JSON Lines (one object per log message) |
 | `--log-filter <FILTER>` | | Per-node level overrides |
 | `--grep <PATTERN>` | | Case-insensitive text search |
 | `--coordinator-addr <IP>` | `127.0.0.1` | Coordinator address |
@@ -680,7 +680,7 @@ dora topic echo [OPTIONS] [DATA...]
 |------|---------|-------------|
 | `-d <DATAFLOW>`, `--dataflow` | required | Dataflow UUID or name |
 | `[DATA...]` | all outputs | Topics to echo (e.g., `node1/output`) |
-| `--format <FMT>` | `table` | Output format: `table\|json`. JSON output uses JSON Lines (one object per message) |
+| `--format <FMT>` | `table` | Output format: `table\|json`. JSON output uses JSON Lines (one object per decoded message); diagnostics go to stderr |
 
 Requires `_unstable_debug.enable_debug_inspection: true` in the descriptor.
 
@@ -1020,6 +1020,11 @@ dora status [OPTIONS]
 ```
 
 Reports coordinator connectivity, daemon status, and active dataflow count.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-f <FORMAT>`, `--format` | `table` | Output format: `table\|json`. JSON output is a single pretty-printed document, printed even when checks fail (failure detail goes to stderr; exit code is non-zero) |
+| `--dataflow <PATH>` | | Descriptor file to enable additional checks |
 
 #### `dora new`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -510,7 +510,7 @@ dora list [OPTIONS]
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--format <FMT>`, `-f` | `table` | Output format: `table\|json` |
+| `--format <FMT>`, `-f` | `table` | Output format: `table\|json`. JSON output uses JSON Lines (one object per line) |
 | `--status <STATUS>` | | Filter: `running\|finished\|failed` |
 | `--name <PATTERN>` | | Filter by name (case-insensitive substring) |
 | `--sort-by <FIELD>` | | Sort by: `cpu\|memory` |
@@ -530,7 +530,7 @@ dora clean [OPTIONS]
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--format <FMT>`, `-f` | `table` | Output format: `table\|json` |
+| `--format <FMT>`, `-f` | `table` | Output format: `table\|json`. JSON output uses JSON Lines (one object per line); failures go to stderr as JSON Lines |
 | `--quiet`, `-q` | false | Print only cleaned UUIDs |
 | `--coordinator-addr <IP>` | `127.0.0.1` | Coordinator address |
 | `--coordinator-port <PORT>` | `6013` | Coordinator port |
@@ -666,7 +666,7 @@ dora topic list [OPTIONS]
 | Flag | Default | Description |
 |------|---------|-------------|
 | `-d <DATAFLOW>`, `--dataflow` | interactive | Dataflow UUID or name |
-| `--format <FMT>` | `table` | Output format: `table\|json` |
+| `--format <FMT>` | `table` | Output format: `table\|json`. JSON output uses JSON Lines (one object per line) |
 
 #### `dora topic echo`
 
@@ -680,7 +680,7 @@ dora topic echo [OPTIONS] [DATA...]
 |------|---------|-------------|
 | `-d <DATAFLOW>`, `--dataflow` | required | Dataflow UUID or name |
 | `[DATA...]` | all outputs | Topics to echo (e.g., `node1/output`) |
-| `--format <FMT>` | `table` | Output format: `table\|json` |
+| `--format <FMT>` | `table` | Output format: `table\|json`. JSON output uses JSON Lines (one object per message) |
 
 Requires `_unstable_debug.enable_debug_inspection: true` in the descriptor.
 
@@ -733,8 +733,8 @@ Lists nodes in a running dataflow with their status, CPU, memory, and restart co
 | Flag | Default | Description |
 |------|---------|-------------|
 | `-d <DATAFLOW>`, `--dataflow` | all dataflows | Dataflow UUID or name |
-| `-f <FORMAT>`, `--format` | `table` | Output format: `table\|json`. JSON output uses JSON Lines (one object per line) |
-| `-q`, `--quiet` | | Print only node IDs, one per line |
+| `-f <FORMAT>`, `--format` | `table` | Output format: `table\|json`. JSON output uses JSON Lines (one object per line); all fields are formatted strings, and the `dataflow` field is omitted when `-d` is given |
+| `-q`, `--quiet` | | Print only node IDs, one per line (conflicts with `--format`) |
 
 ##### `dora node info`
 
@@ -748,7 +748,7 @@ dora node info <NODE> [OPTIONS]
 |------|---------|-------------|
 | `<NODE>` | required | Node ID to inspect |
 | `-d <DATAFLOW>`, `--dataflow` | interactive | Dataflow UUID or name |
-| `-f <FORMAT>`, `--format` | `table` | Output format: `table\|json` |
+| `-f <FORMAT>`, `--format` | `table` | Output format: `table\|json`. JSON output is a single pretty-printed document |
 
 ##### `dora node restart`
 
@@ -863,7 +863,7 @@ dora param list <NODE> [OPTIONS]
 |------|---------|-------------|
 | `<NODE>` | required | Node ID |
 | `-d <DATAFLOW>`, `--dataflow` | interactive | Dataflow UUID or name |
-| `--format <FMT>` | `table` | Output format: `table\|json` |
+| `--format <FMT>` | `table` | Output format: `table\|json`. JSON output is a single pretty-printed document |
 
 ##### `dora param get`
 

--- a/guide/src/operations/cli.md
+++ b/guide/src/operations/cli.md
@@ -293,7 +293,7 @@ dora run <PATH> [OPTIONS]
 | `--allow-shell-nodes` | false | Enable shell-based node execution |
 | `--exit-when-nodes-finish[=BOOL]` | descriptor | Exit once all nodes finish, treating `dora/timer/...` inputs as a clock rather than as work. Overrides `exit_when_nodes_finish:` in the YAML; omit it and the YAML decides |
 | `--log-level <LEVEL>` | `stdout` | Min display level: `error\|warn\|info\|debug\|trace\|stdout` |
-| `--log-format <FORMAT>` | `pretty` | Output format: `pretty\|json\|compact` |
+| `--log-format <FORMAT>` | `pretty` | Output format: `pretty\|json\|compact`; `json` emits JSON Lines (one object per log message) |
 | `--log-filter <FILTER>` | | Per-node level overrides: `"node1=debug,node2=warn"` |
 | `--locked` | false | Use pinned git source commits from a build lockfile |
 | `--write-lockfile` | false | Write resolved git source commits to a lockfile during pre-run build |
@@ -531,7 +531,7 @@ dora clean [OPTIONS]
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--format <FMT>`, `-f` | `table` | Output format: `table\|json`. JSON output uses JSON Lines (one object per line); failures go to stderr as JSON Lines |
+| `--format <FMT>`, `-f` | `table` | Output format: `table\|json`. JSON output uses JSON Lines (one object per line); each failure is also one JSON object line on stderr, followed by a plain-text error summary (exit code is non-zero) |
 | `--quiet`, `-q` | false | Print only cleaned UUIDs |
 | `--coordinator-addr <IP>` | `127.0.0.1` | Coordinator address |
 | `--coordinator-port <PORT>` | `6013` | Coordinator port |
@@ -565,7 +565,7 @@ Node selection is via the `--node <NAME>` flag (not positional, as of #1883).
 | `--since <DURATION>` | | Show logs newer than duration ago |
 | `--until <DURATION>` | | Show logs older than duration ago |
 | `--level <LEVEL>` | `stdout` | Min log level |
-| `--log-format <FORMAT>` | `pretty` | Output format |
+| `--log-format <FORMAT>` | `pretty` | Output format: `pretty\|json\|compact`; `json` emits JSON Lines (one object per log message) |
 | `--log-filter <FILTER>` | | Per-node level overrides |
 | `--grep <PATTERN>` | | Case-insensitive text search |
 | `--coordinator-addr <IP>` | `127.0.0.1` | Coordinator address |
@@ -663,7 +663,7 @@ dora topic echo [OPTIONS] [DATA...]
 |------|---------|-------------|
 | `-d <DATAFLOW>`, `--dataflow` | required | Dataflow UUID or name |
 | `[DATA...]` | all outputs | Topics to echo (e.g., `node1/output`) |
-| `--format <FMT>` | `table` | Output format: `table\|json`. JSON output uses JSON Lines (one object per message) |
+| `--format <FMT>` | `table` | Output format: `table\|json`. JSON output uses JSON Lines (one object per decoded message); diagnostics go to stderr |
 
 Requires `_unstable_debug.enable_debug_inspection: true` in the descriptor.
 
@@ -960,6 +960,11 @@ dora status [OPTIONS]
 ```
 
 Reports coordinator connectivity, daemon status, and active dataflow count.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-f <FORMAT>`, `--format` | `table` | Output format: `table\|json`. JSON output is a single pretty-printed document, printed even when checks fail (failure detail goes to stderr; exit code is non-zero) |
+| `--dataflow <PATH>` | | Descriptor file to enable additional checks |
 
 #### `dora new`
 

--- a/guide/src/operations/cli.md
+++ b/guide/src/operations/cli.md
@@ -511,7 +511,7 @@ dora list [OPTIONS]
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--format <FMT>`, `-f` | `table` | Output format: `table\|json` |
+| `--format <FMT>`, `-f` | `table` | Output format: `table\|json`. JSON output uses JSON Lines (one object per line) |
 | `--status <STATUS>` | | Filter: `running\|finished\|failed` |
 | `--name <PATTERN>` | | Filter by name (case-insensitive substring) |
 | `--sort-by <FIELD>` | | Sort by: `cpu\|memory` |
@@ -531,7 +531,7 @@ dora clean [OPTIONS]
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--format <FMT>`, `-f` | `table` | Output format: `table\|json` |
+| `--format <FMT>`, `-f` | `table` | Output format: `table\|json`. JSON output uses JSON Lines (one object per line); failures go to stderr as JSON Lines |
 | `--quiet`, `-q` | false | Print only cleaned UUIDs |
 | `--coordinator-addr <IP>` | `127.0.0.1` | Coordinator address |
 | `--coordinator-port <PORT>` | `6013` | Coordinator port |
@@ -649,7 +649,7 @@ dora topic list [OPTIONS]
 | Flag | Default | Description |
 |------|---------|-------------|
 | `-d <DATAFLOW>`, `--dataflow` | interactive | Dataflow UUID or name |
-| `--format <FMT>` | `table` | Output format: `table\|json` |
+| `--format <FMT>` | `table` | Output format: `table\|json`. JSON output uses JSON Lines (one object per line) |
 
 #### `dora topic echo`
 
@@ -663,7 +663,7 @@ dora topic echo [OPTIONS] [DATA...]
 |------|---------|-------------|
 | `-d <DATAFLOW>`, `--dataflow` | required | Dataflow UUID or name |
 | `[DATA...]` | all outputs | Topics to echo (e.g., `node1/output`) |
-| `--format <FMT>` | `table` | Output format: `table\|json` |
+| `--format <FMT>` | `table` | Output format: `table\|json`. JSON output uses JSON Lines (one object per message) |
 
 Requires `_unstable_debug.enable_debug_inspection: true` in the descriptor.
 
@@ -716,8 +716,8 @@ Lists nodes in a running dataflow with their status, CPU, memory, and restart co
 | Flag | Default | Description |
 |------|---------|-------------|
 | `-d <DATAFLOW>`, `--dataflow` | all dataflows | Dataflow UUID or name |
-| `-f <FORMAT>`, `--format` | `table` | Output format: `table\|json`. JSON output uses JSON Lines (one object per line) |
-| `-q`, `--quiet` | | Print only node IDs, one per line |
+| `-f <FORMAT>`, `--format` | `table` | Output format: `table\|json`. JSON output uses JSON Lines (one object per line); all fields are formatted strings, and the `dataflow` field is omitted when `-d` is given |
+| `-q`, `--quiet` | | Print only node IDs, one per line (conflicts with `--format`) |
 
 ##### `dora node info`
 
@@ -731,7 +731,7 @@ dora node info <NODE> [OPTIONS]
 |------|---------|-------------|
 | `<NODE>` | required | Node ID to inspect |
 | `-d <DATAFLOW>`, `--dataflow` | interactive | Dataflow UUID or name |
-| `-f <FORMAT>`, `--format` | `table` | Output format: `table\|json` |
+| `-f <FORMAT>`, `--format` | `table` | Output format: `table\|json`. JSON output is a single pretty-printed document |
 
 ##### `dora node restart`
 
@@ -803,7 +803,7 @@ dora param list <NODE> [OPTIONS]
 |------|---------|-------------|
 | `<NODE>` | required | Node ID |
 | `-d <DATAFLOW>`, `--dataflow` | interactive | Dataflow UUID or name |
-| `--format <FMT>` | `table` | Output format: `table\|json` |
+| `--format <FMT>` | `table` | Output format: `table\|json`. JSON output is a single pretty-printed document |
 
 ##### `dora param get`
 


### PR DESCRIPTION
## Summary

Follow-up to #2976: the undocumented-JSON-shape confusion from #2922 existed on every other `--format` command. This PR states the contract everywhere the flag appears.

- **JSON Lines** (one object per line): `dora list`, `dora clean` (failures as JSON Lines on stderr), `dora topic list`, `dora topic echo` (one object per message), `dora node list`
- **Single pretty-printed JSON document**: `dora node info`, `dora system status` / `dora status`, `dora param list`
- Doc comments are split into a short first line plus a long-help paragraph, so `-h` stays a one-liner and `--help` carries the shape contract
- `dora node list` JSON record schema is now documented: all fields are formatted strings, and the `dataflow` field is omitted (not null) when `--dataflow` is given; `-q` conflicts with `--format`
- Flag tables in `docs/cli.md` and `guide/src/operations/cli.md` updated to match

## Tests

- `help_documents_json_output_shape_for_every_format_flag` — one help-contract test covering all eight `--format` flags
- `json_entries_serialize_as_independent_single_line_objects` — pins the node list JSONL record contract at the serialization layer (single-line, independently parseable, `dataflow` key omitted rather than null), so a switch to array or pretty output fails a test rather than only drifting from help text

## Validation

- `make qa-fast` (fmt, clippy -D warnings, cargo-audit/deny, unwrap budget, typos)
- `cargo test -p dora-cli` (291 passed)

Related to #2922

🤖 Generated with [Claude Code](https://claude.com/claude-code)
