### PR TITLE
fix(daemon): isolate node lifecycle generations

### DIFF
--- a/binaries/daemon/src/event_types.rs
+++ b/binaries/daemon/src/event_types.rs
@@ -175,6 +175,7 @@ pub enum DoraEvent {
     SpawnedNodeResult {
         dataflow_id: DataflowId,
         node_id: NodeId,
+        generation: u64,
         dynamic_node: bool,
         exit_status: NodeExitStatus,
         restart: bool,
@@ -191,6 +192,8 @@ pub enum DoraEvent {
     ProcessHandleReplaced {
         dataflow_id: DataflowId,
         node_id: NodeId,
+        previous_generation: u64,
+        new_generation: u64,
         new_handle: crate::ProcessHandle,
     },
 }

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1712,14 +1712,14 @@ impl Daemon {
                     dynamic_node,
                     result,
                 } => match result {
-                    Ok(running_node) => {
+                    Ok(mut running_node) => {
                         if let Some(dataflow) = self.running.get_mut(&dataflow_id) {
+                            // Open the restart-loop gate before the insert:
+                            // the loop's first events are queued behind this
+                            // handler on the same event loop, so they cannot
+                            // be processed before the entry is registered.
+                            running_node.mark_registered();
                             dataflow.running_nodes.insert(node_id.clone(), running_node);
-                            dataflow
-                                .running_nodes
-                                .get_mut(&node_id)
-                                .expect("running node was just inserted")
-                                .mark_registered();
                         } else {
                             tracing::error!(
                                 "failed to handle SpawnNodeResult: no running dataflow with ID {dataflow_id}"
@@ -2344,7 +2344,7 @@ impl Daemon {
                         .await
                         .wrap_err("failed to prepare node")?;
                     let prepared = task.await.wrap_err("failed to build node")?;
-                    let running_node = prepared
+                    let mut running_node = prepared
                         .spawn(logger)
                         .await
                         .wrap_err("failed to spawn node")?;
@@ -2419,13 +2419,13 @@ impl Daemon {
                     // node that never subscribed could stall startup
                     // outright (dora-rs/dora#2917).
 
-                    // Insert the running node
+                    // Open the restart-loop gate and insert the running
+                    // node. Marking before the insert is safe: the loop's
+                    // first events queue behind this handler on the same
+                    // event loop, so they cannot be processed before the
+                    // entry is registered.
+                    running_node.mark_registered();
                     dataflow.running_nodes.insert(node_id.clone(), running_node);
-                    dataflow
-                        .running_nodes
-                        .get_mut(&node_id)
-                        .expect("running node was just inserted")
-                        .mark_registered();
 
                     // Update the daemon's stored descriptor so
                     // descriptor-based lookups (e.g. AllInputsClosed
@@ -5065,6 +5065,15 @@ impl Daemon {
                     .running
                     .get(&dataflow_id)
                     .and_then(|dataflow| dataflow.running_nodes.get(&node_id));
+                // Deliberate semantics of the entry-absent case: an exit
+                // arriving after `RemoveNode` took the entry out is dropped
+                // here WITHOUT running the finish accounting below. That
+                // means removing the last non-dynamic node leaves the
+                // dataflow alive (zero running nodes) until an explicit stop
+                // or a re-add — live-editing keep-alive, chosen over the
+                // pre-generation behavior where such a stale exit could both
+                // record a bogus result (dora-rs/dora#2926) and finish a
+                // dataflow out from under a concurrent re-add of the same id.
                 if !current_generation.is_some_and(|node| node.matches_generation(generation)) {
                     logger
                         .log(
@@ -5221,15 +5230,14 @@ impl Daemon {
                     }
                 };
 
-                // Clear the per-incarnation kill marker so it doesn't
-                // leak into the next incarnation. `grace_duration_kills`
-                // is keyed only by `node_id`; if `restart=true` and we
-                // didn't clear here, a later external SIGTERM or
-                // unrelated 143 exit from the restarted process would
-                // still see `grace_duration_kill=true` and be
-                // misreported as `Ok(())`. The marker has done its job
-                // for this exit — drop it. Same for the drain clock: a
-                // respawned node under the same id must start fresh.
+                // Drop the consumed kill marker. `grace_duration_kills` is
+                // keyed by `(node_id, generation)`, so a successor can no
+                // longer inherit its predecessor's marker structurally —
+                // removal here is hygiene for this incarnation's own entry
+                // (it was consumed classifying this exit), not the
+                // cross-incarnation leak protection it used to be. Same for
+                // the drain clock: a respawned node under the same id must
+                // start fresh.
                 // (`finish_escalated` is NOT cleared here — it is read
                 // and consumed by `handle_node_stop_inner` below to keep
                 // the coordinator-facing `clean_stop` flag honest; an
@@ -5384,18 +5392,30 @@ impl Daemon {
                 // predecessor's channel (dora-rs/adora#152).
                 if let Some(dataflow) = self.running.get_mut(&dataflow_id) {
                     if let Some(node) = dataflow.running_nodes.get_mut(&node_id) {
-                        if !node.replace_process_handle(
+                        match node.replace_process_handle(
                             previous_generation,
                             new_generation,
                             new_handle,
                         ) {
-                            tracing::warn!(
-                                %dataflow_id,
-                                %node_id,
-                                previous_generation,
-                                current_generation = node.generation,
-                                "ignoring stale ProcessHandleReplaced event"
-                            );
+                            running_dataflow::HandleReplacement::Replaced => {}
+                            running_dataflow::HandleReplacement::RejectedTeardown => {
+                                tracing::info!(
+                                    %dataflow_id,
+                                    %node_id,
+                                    new_generation,
+                                    "teardown won the respawn race: killed the \
+                                     replacement process, awaiting its terminal exit"
+                                );
+                            }
+                            running_dataflow::HandleReplacement::RejectedStale => {
+                                tracing::warn!(
+                                    %dataflow_id,
+                                    %node_id,
+                                    previous_generation,
+                                    current_generation = node.generation,
+                                    "ignoring stale ProcessHandleReplaced event"
+                                );
+                            }
                         }
                     } else {
                         tracing::warn!(
@@ -6670,6 +6690,7 @@ mod debug_topic_tests {
 #[cfg(test)]
 mod fault_tolerance_tests {
     use super::*;
+    use crate::running_dataflow::HandleReplacement;
     use std::sync::atomic::AtomicU32;
 
     use dora_message::{
@@ -6838,22 +6859,10 @@ mod fault_tolerance_tests {
         );
     }
 
-    #[tokio::test]
-    async fn restart_loop_waits_until_running_node_is_registered() {
-        let mut node = test_running_node();
-        let (start_tx, mut start_rx) = oneshot::channel();
-        node.restart_loop_start = Some(start_tx);
-
-        assert!(
-            tokio::time::timeout(Duration::from_millis(1), &mut start_rx)
-                .await
-                .is_err(),
-            "restart loop must remain gated before RunningNode insertion"
-        );
-
-        node.mark_registered();
-        assert!(start_rx.await.is_ok());
-    }
+    // The registration gate itself is tested through `restart_loop` in
+    // `spawn::prepared::tests` (`restart_loop_aborts_when_registration_never_happens`
+    // and `cancelled_restart_settles_terminal_exit`), which drive the real
+    // loop rather than restating oneshot-channel semantics here.
 
     #[test]
     fn planned_stop_markers_are_scoped_to_generation() {
@@ -6921,11 +6930,16 @@ mod fault_tolerance_tests {
         node.process = Some(ProcessHandle::new(live_tx));
 
         let (stale_tx, stale_rx) = flume::bounded(2);
-        let replaced = node.replace_process_handle(6, 8, ProcessHandle::new(stale_tx));
+        let outcome = node.replace_process_handle(6, 8, ProcessHandle::new(stale_tx));
 
-        assert!(
-            !replaced,
+        assert_eq!(
+            outcome,
+            HandleReplacement::RejectedStale,
             "a dead incarnation must not replace a live handle"
+        );
+        assert!(
+            node.matches_generation(7),
+            "a stale rejection must leave the live generation untouched"
         );
         assert!(
             live_rx.try_recv().is_err(),
@@ -6948,13 +6962,23 @@ mod fault_tolerance_tests {
         node.disable_restart();
 
         let (replacement_tx, replacement_rx) = flume::bounded(2);
-        let replaced = node.replace_process_handle(7, 8, ProcessHandle::new(replacement_tx));
+        let outcome = node.replace_process_handle(7, 8, ProcessHandle::new(replacement_tx));
 
-        assert!(
-            !replaced,
+        assert_eq!(
+            outcome,
+            HandleReplacement::RejectedTeardown,
             "teardown must win a race with process replacement"
         );
-        assert!(node.matches_generation(7));
+        // The generation must still advance: the restart loop now speaks
+        // generation 8, and its terminal SpawnedNodeResult has to match this
+        // entry or the node would stay registered forever and the dataflow
+        // could never finish.
+        assert!(node.matches_generation(8));
+        assert!(!node.matches_generation(7));
+        assert!(
+            node.process.is_some(),
+            "teardown rejection must not install the replacement handle"
+        );
         assert!(live_rx.try_recv().is_err());
         assert!(matches!(
             replacement_rx.try_recv(),
@@ -6971,9 +6995,9 @@ mod fault_tolerance_tests {
         node.process = Some(ProcessHandle::new(old_tx));
 
         let (new_tx, new_rx) = flume::bounded(2);
-        let replaced = node.replace_process_handle(7, 8, ProcessHandle::new(new_tx));
+        let outcome = node.replace_process_handle(7, 8, ProcessHandle::new(new_tx));
 
-        assert!(replaced);
+        assert_eq!(outcome, HandleReplacement::Replaced);
         assert!(node.matches_generation(8));
         assert!(
             matches!(old_rx.try_recv(), Ok(ProcessOperation::Kill)),

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -336,6 +336,16 @@ pub struct Daemon {
 
 type DaemonRunResult = BTreeMap<Uuid, BTreeMap<NodeId, Result<(), NodeError>>>;
 
+fn clear_node_result(results: &mut DaemonRunResult, dataflow_id: Uuid, node_id: &NodeId) {
+    let remove_dataflow = results.get_mut(&dataflow_id).is_some_and(|node_results| {
+        node_results.remove(node_id);
+        node_results.is_empty()
+    });
+    if remove_dataflow {
+        results.remove(&dataflow_id);
+    }
+}
+
 struct NodeBuildTask<F> {
     node_id: NodeId,
     dynamic_node: bool,
@@ -1704,7 +1714,12 @@ impl Daemon {
                 } => match result {
                     Ok(running_node) => {
                         if let Some(dataflow) = self.running.get_mut(&dataflow_id) {
-                            dataflow.running_nodes.insert(node_id, running_node);
+                            dataflow.running_nodes.insert(node_id.clone(), running_node);
+                            dataflow
+                                .running_nodes
+                                .get_mut(&node_id)
+                                .expect("running node was just inserted")
+                                .mark_registered();
                         } else {
                             tracing::error!(
                                 "failed to handle SpawnNodeResult: no running dataflow with ID {dataflow_id}"
@@ -2406,6 +2421,11 @@ impl Daemon {
 
                     // Insert the running node
                     dataflow.running_nodes.insert(node_id.clone(), running_node);
+                    dataflow
+                        .running_nodes
+                        .get_mut(&node_id)
+                        .expect("running node was just inserted")
+                        .mark_registered();
 
                     // Update the daemon's stored descriptor so
                     // descriptor-based lookups (e.g. AllInputsClosed
@@ -2489,6 +2509,9 @@ impl Daemon {
 
                 if let Err(err) = &result {
                     tracing::error!(%dataflow_id, %node_id, "AddNode failed: {err:?}");
+                }
+                if result.is_ok() {
+                    clear_node_result(&mut self.dataflow_node_results, dataflow_id, &node_id);
                 }
                 // Return a specific `AddNodeResult` variant so the
                 // coordinator can validate the reply against its
@@ -5019,6 +5042,7 @@ impl Daemon {
             DoraEvent::SpawnedNodeResult {
                 dataflow_id,
                 node_id,
+                generation,
                 dynamic_node,
                 exit_status,
                 restart,
@@ -5037,27 +5061,25 @@ impl Daemon {
                     )
                     .await;
 
-                if !restart
-                    && self
-                        .running
-                        .get(&dataflow_id)
-                        .and_then(|dataflow| dataflow.running_nodes.get(&node_id))
-                        .and_then(|node| node.pid.as_ref())
-                        .is_some_and(|current_pid| {
-                            current_pid.load(atomic::Ordering::Acquire) != pid
-                        })
-                {
+                let current_generation = self
+                    .running
+                    .get(&dataflow_id)
+                    .and_then(|dataflow| dataflow.running_nodes.get(&node_id));
+                if !current_generation.is_some_and(|node| node.matches_generation(generation)) {
                     logger
                         .log(
                             LogLevel::Debug,
                             Some("daemon".into()),
                             format!(
-                                "ignoring stale exit from pid {pid}; `{node_id}` has already been re-added"
+                                "ignoring stale exit from pid {pid} (generation {generation}); \
+                                 `{node_id}` has been removed or replaced"
                             ),
                         )
                         .await;
                     if let Some(dataflow) = self.running.get_mut(&dataflow_id) {
-                        dataflow.grace_duration_kills.remove(&node_id);
+                        dataflow
+                            .grace_duration_kills
+                            .remove(&(node_id.clone(), generation));
                     }
                     return Ok(());
                 }
@@ -5072,7 +5094,10 @@ impl Daemon {
                             })
                             .cloned();
                         let grace_duration_kill = dataflow
-                            .map(|d| d.grace_duration_kills.contains(&node_id))
+                            .map(|d| {
+                                d.grace_duration_kills
+                                    .contains(&(node_id.clone(), generation))
+                            })
                             .unwrap_or_default();
                         // Killed by the finish-straggler watchdog
                         // (dora-rs/dora#2152): the node blocked an
@@ -5211,7 +5236,9 @@ impl Daemon {
                 // escalated node never restarts, so it cannot leak into
                 // a next incarnation.)
                 if let Some(dataflow) = self.running.get_mut(&dataflow_id) {
-                    dataflow.grace_duration_kills.remove(&node_id);
+                    dataflow
+                        .grace_duration_kills
+                        .remove(&(node_id.clone(), generation));
                     dataflow.all_inputs_closed_at.remove(&node_id);
                     // a respawned node must re-subscribe before it counts as
                     // connected, else a slow restart could be silence-escalated
@@ -5346,6 +5373,8 @@ impl Daemon {
             DoraEvent::ProcessHandleReplaced {
                 dataflow_id,
                 node_id,
+                previous_generation,
+                new_generation,
                 new_handle,
             } => {
                 // The per-node restart_loop just spawned a replacement
@@ -5355,11 +5384,19 @@ impl Daemon {
                 // predecessor's channel (dora-rs/adora#152).
                 if let Some(dataflow) = self.running.get_mut(&dataflow_id) {
                     if let Some(node) = dataflow.running_nodes.get_mut(&node_id) {
-                        // Overwriting the previous Some(old_handle)
-                        // drops it, which currently fires its `Kill`
-                        // send on the already-closed old op_rx — a
-                        // no-op.
-                        node.process = Some(new_handle);
+                        if !node.replace_process_handle(
+                            previous_generation,
+                            new_generation,
+                            new_handle,
+                        ) {
+                            tracing::warn!(
+                                %dataflow_id,
+                                %node_id,
+                                previous_generation,
+                                current_generation = node.generation,
+                                "ignoring stale ProcessHandleReplaced event"
+                            );
+                        }
                     } else {
                         tracing::warn!(
                             %dataflow_id,
@@ -6757,6 +6794,8 @@ mod fault_tolerance_tests {
     fn test_running_node() -> RunningNode {
         RunningNode {
             process: None,
+            restart_loop_start: None,
+            generation: 7,
             node_config: NodeConfig {
                 dataflow_id: Uuid::nil(),
                 node_id: NodeId::from("test".to_string()),
@@ -6784,6 +6823,168 @@ mod fault_tolerance_tests {
             health_check_timeout: None,
             finish_grace_secs: None,
         }
+    }
+
+    #[test]
+    fn running_node_rejects_stale_generation() {
+        let mut node = test_running_node();
+        let reused_pid = Arc::new(AtomicU32::new(42));
+        node.pid = Some(reused_pid);
+
+        assert!(node.matches_generation(7));
+        assert!(
+            !node.matches_generation(6),
+            "a reused PID must not make an older generation current"
+        );
+    }
+
+    #[tokio::test]
+    async fn restart_loop_waits_until_running_node_is_registered() {
+        let mut node = test_running_node();
+        let (start_tx, mut start_rx) = oneshot::channel();
+        node.restart_loop_start = Some(start_tx);
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(1), &mut start_rx)
+                .await
+                .is_err(),
+            "restart loop must remain gated before RunningNode insertion"
+        );
+
+        node.mark_registered();
+        assert!(start_rx.await.is_ok());
+    }
+
+    #[test]
+    fn planned_stop_markers_are_scoped_to_generation() {
+        let dataflow = test_dataflow();
+        let node_id: NodeId = "readded".to_string().into();
+
+        dataflow.grace_duration_kills.insert((node_id.clone(), 7));
+
+        assert!(
+            dataflow
+                .grace_duration_kills
+                .contains(&(node_id.clone(), 7))
+        );
+        assert!(
+            !dataflow
+                .grace_duration_kills
+                .contains(&(node_id.clone(), 8)),
+            "a successor must not inherit its predecessor's planned-stop marker"
+        );
+        dataflow.grace_duration_kills.remove(&(node_id.clone(), 6));
+        assert!(
+            dataflow
+                .grace_duration_kills
+                .contains(&(node_id.clone(), 7)),
+            "cleaning a stale event must not clear another generation's marker"
+        );
+    }
+
+    #[test]
+    fn successful_readd_clears_only_the_previous_node_result() {
+        let dataflow_id = Uuid::new_v4();
+        let other_dataflow_id = Uuid::new_v4();
+        let single_result_dataflow_id = Uuid::new_v4();
+        let node_id: NodeId = "readded".to_string().into();
+        let other_node_id: NodeId = "other".to_string().into();
+        let mut results = BTreeMap::from([
+            (
+                dataflow_id,
+                BTreeMap::from([(node_id.clone(), Ok(())), (other_node_id.clone(), Ok(()))]),
+            ),
+            (
+                other_dataflow_id,
+                BTreeMap::from([(node_id.clone(), Ok(()))]),
+            ),
+            (
+                single_result_dataflow_id,
+                BTreeMap::from([(node_id.clone(), Ok(()))]),
+            ),
+        ]);
+
+        clear_node_result(&mut results, dataflow_id, &node_id);
+
+        assert!(!results[&dataflow_id].contains_key(&node_id));
+        assert!(results[&dataflow_id].contains_key(&other_node_id));
+        assert!(results[&other_dataflow_id].contains_key(&node_id));
+
+        clear_node_result(&mut results, single_result_dataflow_id, &node_id);
+        assert!(!results.contains_key(&single_result_dataflow_id));
+    }
+
+    #[test]
+    fn stale_handle_replacement_preserves_live_process() {
+        let mut node = test_running_node();
+        let (live_tx, live_rx) = flume::bounded(2);
+        node.process = Some(ProcessHandle::new(live_tx));
+
+        let (stale_tx, stale_rx) = flume::bounded(2);
+        let replaced = node.replace_process_handle(6, 8, ProcessHandle::new(stale_tx));
+
+        assert!(
+            !replaced,
+            "a dead incarnation must not replace a live handle"
+        );
+        assert!(
+            live_rx.try_recv().is_err(),
+            "rejecting a stale replacement must not kill the live successor"
+        );
+        assert!(
+            matches!(stale_rx.try_recv(), Ok(ProcessOperation::Kill)),
+            "the orphan process owned by the stale event should be killed"
+        );
+
+        // Avoid sending a drop-time Kill into `live_rx` after the assertions.
+        let _ = node.process.take();
+    }
+
+    #[test]
+    fn teardown_rejects_matching_handle_replacement() {
+        let mut node = test_running_node();
+        let (live_tx, live_rx) = flume::bounded(2);
+        node.process = Some(ProcessHandle::new(live_tx));
+        node.disable_restart();
+
+        let (replacement_tx, replacement_rx) = flume::bounded(2);
+        let replaced = node.replace_process_handle(7, 8, ProcessHandle::new(replacement_tx));
+
+        assert!(
+            !replaced,
+            "teardown must win a race with process replacement"
+        );
+        assert!(node.matches_generation(7));
+        assert!(live_rx.try_recv().is_err());
+        assert!(matches!(
+            replacement_rx.try_recv(),
+            Ok(ProcessOperation::Kill)
+        ));
+
+        let _ = node.process.take();
+    }
+
+    #[test]
+    fn current_handle_replacement_advances_generation() {
+        let mut node = test_running_node();
+        let (old_tx, old_rx) = flume::bounded(2);
+        node.process = Some(ProcessHandle::new(old_tx));
+
+        let (new_tx, new_rx) = flume::bounded(2);
+        let replaced = node.replace_process_handle(7, 8, ProcessHandle::new(new_tx));
+
+        assert!(replaced);
+        assert!(node.matches_generation(8));
+        assert!(
+            matches!(old_rx.try_recv(), Ok(ProcessOperation::Kill)),
+            "replacing the current incarnation should retire its old handle"
+        );
+        assert!(
+            new_rx.try_recv().is_err(),
+            "the replacement process must remain live"
+        );
+
+        let _ = node.process.take();
     }
 
     fn test_clock() -> HLC {

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -5398,13 +5398,18 @@ impl Daemon {
                             new_handle,
                         ) {
                             running_dataflow::HandleReplacement::Replaced => {}
-                            running_dataflow::HandleReplacement::RejectedTeardown => {
+                            running_dataflow::HandleReplacement::RejectedTeardown(new_handle) => {
+                                dataflow.stop_rejected_replacement(
+                                    &node_id,
+                                    new_generation,
+                                    new_handle,
+                                );
                                 tracing::info!(
                                     %dataflow_id,
                                     %node_id,
                                     new_generation,
-                                    "teardown won the respawn race: killed the \
-                                     replacement process, awaiting its terminal exit"
+                                    "teardown won the respawn race: stopping the replacement \
+                                     process with the active dataflow stop policy"
                                 );
                             }
                             running_dataflow::HandleReplacement::RejectedStale => {
@@ -6690,7 +6695,7 @@ mod debug_topic_tests {
 #[cfg(test)]
 mod fault_tolerance_tests {
     use super::*;
-    use crate::running_dataflow::HandleReplacement;
+    use crate::running_dataflow::{HandleReplacement, StopProcessPolicy};
     use std::sync::atomic::AtomicU32;
 
     use dora_message::{
@@ -6932,9 +6937,8 @@ mod fault_tolerance_tests {
         let (stale_tx, stale_rx) = flume::bounded(2);
         let outcome = node.replace_process_handle(6, 8, ProcessHandle::new(stale_tx));
 
-        assert_eq!(
-            outcome,
-            HandleReplacement::RejectedStale,
+        assert!(
+            matches!(outcome, HandleReplacement::RejectedStale),
             "a dead incarnation must not replace a live handle"
         );
         assert!(
@@ -6964,9 +6968,16 @@ mod fault_tolerance_tests {
         let (replacement_tx, replacement_rx) = flume::bounded(2);
         let outcome = node.replace_process_handle(7, 8, ProcessHandle::new(replacement_tx));
 
-        assert_eq!(
-            outcome,
-            HandleReplacement::RejectedTeardown,
+        let HandleReplacement::RejectedTeardown(replacement) = outcome else {
+            panic!("teardown must win a race with process replacement");
+        };
+        assert!(
+            replacement_rx.try_recv().is_err(),
+            "the caller must retain the replacement for planned-stop routing"
+        );
+        drop(replacement);
+        assert!(
+            matches!(replacement_rx.try_recv(), Ok(ProcessOperation::Kill)),
             "teardown must win a race with process replacement"
         );
         // The generation must still advance: the restart loop now speaks
@@ -6980,12 +6991,52 @@ mod fault_tolerance_tests {
             "teardown rejection must not install the replacement handle"
         );
         assert!(live_rx.try_recv().is_err());
+        let _ = node.process.take();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn teardown_replacement_uses_configured_grace_period() {
+        let mut dataflow = test_dataflow();
+        dataflow.stop_process_policy = Some(StopProcessPolicy::Graceful(Duration::from_secs(4)));
+        let mut node = test_running_node();
+        node.disable_restart();
+
+        let (replacement_tx, replacement_rx) = flume::bounded(4);
+        let outcome = node.replace_process_handle(7, 8, ProcessHandle::new(replacement_tx));
+        let HandleReplacement::RejectedTeardown(replacement) = outcome else {
+            panic!("teardown must retain ownership of the replacement handle");
+        };
+
+        let node_id: NodeId = "test".to_string().into();
+        dataflow.stop_rejected_replacement(&node_id, 8, replacement);
+        tokio::task::yield_now().await;
+
+        assert!(
+            replacement_rx.try_recv().is_err(),
+            "a racing replacement must not be killed immediately"
+        );
+        tokio::time::advance(Duration::from_secs(3)).await;
+        assert!(replacement_rx.try_recv().is_err());
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        tokio::task::yield_now().await;
+        assert!(matches!(
+            replacement_rx.try_recv(),
+            Ok(ProcessOperation::SoftKill)
+        ));
+        assert!(
+            dataflow
+                .grace_duration_kills
+                .contains(&(node_id.clone(), 8)),
+            "the replacement stop must be classified as daemon-initiated"
+        );
+
+        tokio::time::advance(Duration::from_secs(2)).await;
+        tokio::task::yield_now().await;
         assert!(matches!(
             replacement_rx.try_recv(),
             Ok(ProcessOperation::Kill)
         ));
-
-        let _ = node.process.take();
     }
 
     #[test]
@@ -6997,7 +7048,7 @@ mod fault_tolerance_tests {
         let (new_tx, new_rx) = flume::bounded(2);
         let outcome = node.replace_process_handle(7, 8, ProcessHandle::new(new_tx));
 
-        assert_eq!(outcome, HandleReplacement::Replaced);
+        assert!(matches!(outcome, HandleReplacement::Replaced));
         assert!(node.matches_generation(8));
         assert!(
             matches!(old_rx.try_recv(), Ok(ProcessOperation::Kill)),

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -40,6 +40,7 @@ use std::{
 use tokio::sync::{
     broadcast,
     mpsc::{self, Sender},
+    oneshot,
 };
 use tracing::warn;
 
@@ -80,6 +81,11 @@ impl InputDeadline {
 #[derive(Debug)]
 pub struct RunningNode {
     pub(crate) process: Option<ProcessHandle>,
+    pub(crate) restart_loop_start: Option<oneshot::Sender<()>>,
+    /// Monotonic identity of the process incarnation currently registered
+    /// under this node ID. Lifecycle events from older incarnations must not
+    /// mutate this entry or contribute results to it.
+    pub(crate) generation: u64,
     pub(crate) node_config: NodeConfig,
     pub(crate) pid: Option<Arc<AtomicU32>>,
     pub(crate) restart_count: Arc<AtomicU32>,
@@ -101,6 +107,31 @@ pub struct RunningNode {
 }
 
 impl RunningNode {
+    pub(crate) fn mark_registered(&mut self) {
+        if let Some(start) = self.restart_loop_start.take() {
+            let _ = start.send(());
+        }
+    }
+
+    pub(crate) fn matches_generation(&self, generation: u64) -> bool {
+        self.generation == generation
+    }
+
+    pub(crate) fn replace_process_handle(
+        &mut self,
+        previous_generation: u64,
+        new_generation: u64,
+        new_handle: ProcessHandle,
+    ) -> bool {
+        if !self.matches_generation(previous_generation) || self.restarts_disabled() {
+            return false;
+        }
+
+        self.process = Some(new_handle);
+        self.generation = new_generation;
+        true
+    }
+
     pub fn restarts_disabled(&self) -> bool {
         self.disable_restart.load(atomic::Ordering::Acquire)
     }
@@ -108,6 +139,18 @@ impl RunningNode {
     pub fn disable_restart(&mut self) {
         self.disable_restart.store(true, atomic::Ordering::Release);
     }
+}
+
+static NEXT_NODE_GENERATION: AtomicU64 = AtomicU64::new(1);
+
+pub(crate) fn next_node_generation() -> u64 {
+    NEXT_NODE_GENERATION
+        .fetch_update(
+            atomic::Ordering::Relaxed,
+            atomic::Ordering::Relaxed,
+            |generation| generation.checked_add(1),
+        )
+        .expect("node generation counter exhausted")
 }
 
 #[derive(Debug)]
@@ -245,7 +288,7 @@ pub struct RunningDataflow {
     pub(crate) stop_sent: bool,
     pub(crate) empty_set: BTreeSet<DataId>,
     pub(crate) cascading_error_causes: CascadingErrorCauses,
-    pub(crate) grace_duration_kills: Arc<crossbeam_skiplist::SkipSet<NodeId>>,
+    pub(crate) grace_duration_kills: Arc<crossbeam_skiplist::SkipSet<(NodeId, u64)>>,
     pub(crate) node_stderr_most_recent: BTreeMap<NodeId, Arc<ArrayQueue<String>>>,
     pub(crate) publishers: BTreeMap<OutputId, Arc<zenoh::pubsub::Publisher<'static>>>,
     /// Reverse index from output to the set of CLI subscribers watching it.
@@ -484,10 +527,10 @@ impl RunningDataflow {
         let running_processes: Vec<_> = self
             .running_nodes
             .iter_mut()
-            .map(|(id, n)| (id.clone(), n.process.take()))
+            .map(|(id, n)| (id.clone(), n.generation, n.process.take()))
             .collect();
         if force {
-            for (node, proc) in &running_processes {
+            for (node, generation, proc) in &running_processes {
                 if let Some(proc) = proc
                     && proc.submit(ProcessOperation::Kill)
                 {
@@ -497,7 +540,8 @@ impl RunningDataflow {
                     // failure. Mirrors the graceful branch below; exit
                     // classification keys "the daemon asked this node to stop"
                     // off `grace_duration_kills` (see lib.rs exit handling).
-                    self.grace_duration_kills.insert(node.clone());
+                    self.grace_duration_kills
+                        .insert((node.clone(), *generation));
                 }
             }
         } else {
@@ -506,22 +550,22 @@ impl RunningDataflow {
                 let duration = grace_duration.unwrap_or(DEFAULT_STOP_GRACE);
                 tokio::time::sleep(duration).await;
 
-                for (node, proc) in &running_processes {
+                for (node, generation, proc) in &running_processes {
                     if let Some(proc) = proc
                         && proc.submit(ProcessOperation::SoftKill)
                     {
-                        grace_duration_kills.insert(node.clone());
+                        grace_duration_kills.insert((node.clone(), *generation));
                     }
                 }
 
                 let kill_duration = duration / 2;
                 tokio::time::sleep(kill_duration).await;
 
-                for (node, proc) in &running_processes {
+                for (node, generation, proc) in &running_processes {
                     if let Some(proc) = proc
                         && proc.submit(ProcessOperation::Kill)
                     {
-                        grace_duration_kills.insert(node.clone());
+                        grace_duration_kills.insert((node.clone(), *generation));
                         warn!(
                             "{node} was killed due to not stopping within the {:#?} grace period",
                             duration + kill_duration
@@ -561,9 +605,11 @@ impl RunningDataflow {
             .get_mut(node_id)
             .ok_or_else(|| eyre!("node `{node_id}` not found in running dataflow"))?;
         node.disable_restart();
+        let generation = node.generation;
         let process = node.process.take();
         self.send_stop_and_schedule_kill(
             node_id,
+            generation,
             process,
             clock,
             grace_duration,
@@ -603,6 +649,7 @@ impl RunningDataflow {
                  already exited terminally)"
             ));
         }
+        let generation = node.generation;
         let process = node.process.take();
         // Clear any prior disable (e.g. from an earlier stop_single_node
         // or a cascading AllInputsClosed) so the restart_loop will pick
@@ -632,6 +679,7 @@ impl RunningDataflow {
         self.finish_escalated.remove(node_id);
         self.send_stop_and_schedule_kill(
             node_id,
+            generation,
             process,
             clock,
             grace_duration,
@@ -644,6 +692,7 @@ impl RunningDataflow {
     fn send_stop_and_schedule_kill(
         &self,
         node_id: &NodeId,
+        generation: u64,
         process: Option<ProcessHandle>,
         clock: &HLC,
         grace_duration: Option<Duration>,
@@ -671,11 +720,11 @@ impl RunningDataflow {
             tokio::spawn(async move {
                 tokio::time::sleep(duration).await;
                 if proc.submit(ProcessOperation::SoftKill) {
-                    grace_duration_kills.insert(node_id.clone());
+                    grace_duration_kills.insert((node_id.clone(), generation));
                 }
                 tokio::time::sleep(duration / 2).await;
                 if proc.submit(ProcessOperation::Kill) {
-                    grace_duration_kills.insert(node_id);
+                    grace_duration_kills.insert((node_id, generation));
                 }
             });
         }

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -81,6 +81,10 @@ impl InputDeadline {
 #[derive(Debug)]
 pub struct RunningNode {
     pub(crate) process: Option<ProcessHandle>,
+    /// Gates this node's `restart_loop` until the daemon has inserted the
+    /// entry into `running_nodes` (`mark_registered`), so the loop's first
+    /// events cannot race ahead of registration. Dropping the sender without
+    /// firing it (entry never registered) cancels the loop.
     pub(crate) restart_loop_start: Option<oneshot::Sender<()>>,
     /// Monotonic identity of the process incarnation currently registered
     /// under this node ID. Lifecycle events from older incarnations must not
@@ -117,19 +121,36 @@ impl RunningNode {
         self.generation == generation
     }
 
+    /// Install a respawned incarnation's process handle.
+    ///
+    /// On every non-`Replaced` outcome `new_handle` is dropped here, and
+    /// `ProcessHandle::drop` submits `Kill` — that Drop is what reaps the
+    /// replacement process, so the handle must never be returned or leaked.
     pub(crate) fn replace_process_handle(
         &mut self,
         previous_generation: u64,
         new_generation: u64,
         new_handle: ProcessHandle,
-    ) -> bool {
-        if !self.matches_generation(previous_generation) || self.restarts_disabled() {
-            return false;
+    ) -> HandleReplacement {
+        if !self.matches_generation(previous_generation) {
+            // A dead incarnation must not replace a live successor's handle
+            // (dora-rs/dora#2926). Dropping `new_handle` kills the orphan.
+            return HandleReplacement::RejectedStale;
+        }
+        if self.restarts_disabled() {
+            // Teardown won the race: keep `process` empty (stop_all already
+            // took the old handle) and let the dropped `new_handle` kill the
+            // replacement. Still advance the generation: the restart loop
+            // already speaks `new_generation`, and its terminal
+            // `SpawnedNodeResult` must match this entry or the node would
+            // stay registered forever and the dataflow could never finish.
+            self.generation = new_generation;
+            return HandleReplacement::RejectedTeardown;
         }
 
         self.process = Some(new_handle);
         self.generation = new_generation;
-        true
+        HandleReplacement::Replaced
     }
 
     pub fn restarts_disabled(&self) -> bool {
@@ -141,8 +162,27 @@ impl RunningNode {
     }
 }
 
+/// Outcome of [`RunningNode::replace_process_handle`]. In both `Rejected*`
+/// cases the offered handle was dropped, which kills the replacement process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HandleReplacement {
+    /// The handle was installed and the entry advanced to the new generation.
+    Replaced,
+    /// Teardown disabled restarts first; the entry's generation was still
+    /// advanced so the restart loop's terminal exit event is accepted.
+    RejectedTeardown,
+    /// The event belongs to a dead incarnation (generation mismatch); the
+    /// entry was left untouched.
+    RejectedStale,
+}
+
 static NEXT_NODE_GENERATION: AtomicU64 = AtomicU64::new(1);
 
+/// Generations are unique across the whole daemon process — not per node —
+/// so a re-added node ID (or any freshly built `RunningNode`) can never
+/// reuse a predecessor's generation. Equality against the entry's stored
+/// generation is therefore collision-free proof that an event belongs to
+/// the currently registered incarnation.
 pub(crate) fn next_node_generation() -> u64 {
     NEXT_NODE_GENERATION
         .fetch_update(
@@ -288,6 +328,10 @@ pub struct RunningDataflow {
     pub(crate) stop_sent: bool,
     pub(crate) empty_set: BTreeSet<DataId>,
     pub(crate) cascading_error_causes: CascadingErrorCauses,
+    /// Planned-stop kill markers keyed by `(node id, generation)`: scoped to
+    /// one process incarnation so a re-added successor never inherits its
+    /// predecessor's marker, and cleaning up a stale event cannot clear a
+    /// live incarnation's marker.
     pub(crate) grace_duration_kills: Arc<crossbeam_skiplist::SkipSet<(NodeId, u64)>>,
     pub(crate) node_stderr_most_recent: BTreeMap<NodeId, Arc<ArrayQueue<String>>>,
     pub(crate) publishers: BTreeMap<OutputId, Arc<zenoh::pubsub::Publisher<'static>>>,

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -123,9 +123,10 @@ impl RunningNode {
 
     /// Install a respawned incarnation's process handle.
     ///
-    /// On every non-`Replaced` outcome `new_handle` is dropped here, and
-    /// `ProcessHandle::drop` submits `Kill` — that Drop is what reaps the
-    /// replacement process, so the handle must never be returned or leaked.
+    /// A stale replacement is dropped here, which kills that orphan process.
+    /// A replacement rejected during teardown is returned to the caller so it
+    /// can follow the dataflow's configured stop policy instead of being
+    /// hard-killed by [`ProcessHandle::drop`].
     pub(crate) fn replace_process_handle(
         &mut self,
         previous_generation: u64,
@@ -138,14 +139,13 @@ impl RunningNode {
             return HandleReplacement::RejectedStale;
         }
         if self.restarts_disabled() {
-            // Teardown won the race: keep `process` empty (stop_all already
-            // took the old handle) and let the dropped `new_handle` kill the
-            // replacement. Still advance the generation: the restart loop
-            // already speaks `new_generation`, and its terminal
-            // `SpawnedNodeResult` must match this entry or the node would
-            // stay registered forever and the dataflow could never finish.
+            // Teardown won the race. Still advance the generation: the restart
+            // loop already speaks `new_generation`, and its terminal
+            // `SpawnedNodeResult` must match this entry or the node would stay
+            // registered forever and the dataflow could never finish. Return
+            // the handle so RunningDataflow can apply the active stop policy.
             self.generation = new_generation;
-            return HandleReplacement::RejectedTeardown;
+            return HandleReplacement::RejectedTeardown(new_handle);
         }
 
         self.process = Some(new_handle);
@@ -162,18 +162,24 @@ impl RunningNode {
     }
 }
 
-/// Outcome of [`RunningNode::replace_process_handle`]. In both `Rejected*`
-/// cases the offered handle was dropped, which kills the replacement process.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Outcome of [`RunningNode::replace_process_handle`].
+#[derive(Debug)]
 pub(crate) enum HandleReplacement {
     /// The handle was installed and the entry advanced to the new generation.
     Replaced,
-    /// Teardown disabled restarts first; the entry's generation was still
-    /// advanced so the restart loop's terminal exit event is accepted.
-    RejectedTeardown,
+    /// Teardown disabled restarts first. The entry's generation was advanced
+    /// so the restart loop's terminal exit event is accepted, and the handle
+    /// must be stopped according to the active dataflow stop policy.
+    RejectedTeardown(ProcessHandle),
     /// The event belongs to a dead incarnation (generation mismatch); the
     /// entry was left untouched.
     RejectedStale,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum StopProcessPolicy {
+    Force,
+    Graceful(Duration),
 }
 
 static NEXT_NODE_GENERATION: AtomicU64 = AtomicU64::new(1);
@@ -326,6 +332,10 @@ pub struct RunningDataflow {
     /// changes when nodes are told to stop.
     pub(crate) timers_gate_drain: bool,
     pub(crate) stop_sent: bool,
+    /// Resolved process-stop policy for this dataflow. A respawn that races
+    /// after `stop_all` moved the previously-known handles out of
+    /// `running_nodes` must use this same policy.
+    pub(crate) stop_process_policy: Option<StopProcessPolicy>,
     pub(crate) empty_set: BTreeSet<DataId>,
     pub(crate) cascading_error_causes: CascadingErrorCauses,
     /// Planned-stop kill markers keyed by `(node id, generation)`: scoped to
@@ -396,6 +406,7 @@ impl RunningDataflow {
             data_inputs: BTreeMap::new(),
             timers_gate_drain: true,
             stop_sent: false,
+            stop_process_policy: None,
             empty_set: BTreeSet::new(),
             cascading_error_causes: Default::default(),
             grace_duration_kills: Default::default(),
@@ -560,6 +571,13 @@ impl RunningDataflow {
             node.disable_restart();
         }
 
+        let stop_process_policy = if force {
+            StopProcessPolicy::Force
+        } else {
+            StopProcessPolicy::Graceful(grace_duration.unwrap_or(DEFAULT_STOP_GRACE))
+        };
+        self.stop_process_policy = Some(stop_process_policy);
+
         for (node_id, channel) in self.subscribe_channels.drain() {
             if send_with_timestamp(&channel, NodeEvent::Stop, clock).ok() == Some(true)
                 && let Some(counter) = self.pending_messages.get(&node_id)
@@ -573,54 +591,65 @@ impl RunningDataflow {
             .iter_mut()
             .map(|(id, n)| (id.clone(), n.generation, n.process.take()))
             .collect();
-        if force {
-            for (node, generation, proc) in &running_processes {
-                if let Some(proc) = proc
-                    && proc.submit(ProcessOperation::Kill)
-                {
-                    // Record the daemon-initiated kill so a node that ignores
-                    // the pre-kill `Stop` and gets SIGKILLed is classified as
-                    // a planned `GraceDuration` stop rather than a genuine node
-                    // failure. Mirrors the graceful branch below; exit
-                    // classification keys "the daemon asked this node to stop"
-                    // off `grace_duration_kills` (see lib.rs exit handling).
-                    self.grace_duration_kills
-                        .insert((node.clone(), *generation));
-                }
+        for (node_id, generation, process) in running_processes {
+            if let Some(process) = process {
+                self.schedule_process_stop(node_id, generation, process, stop_process_policy);
             }
-        } else {
-            let grace_duration_kills = self.grace_duration_kills.clone();
-            tokio::spawn(async move {
-                let duration = grace_duration.unwrap_or(DEFAULT_STOP_GRACE);
-                tokio::time::sleep(duration).await;
-
-                for (node, generation, proc) in &running_processes {
-                    if let Some(proc) = proc
-                        && proc.submit(ProcessOperation::SoftKill)
-                    {
-                        grace_duration_kills.insert((node.clone(), *generation));
-                    }
-                }
-
-                let kill_duration = duration / 2;
-                tokio::time::sleep(kill_duration).await;
-
-                for (node, generation, proc) in &running_processes {
-                    if let Some(proc) = proc
-                        && proc.submit(ProcessOperation::Kill)
-                    {
-                        grace_duration_kills.insert((node.clone(), *generation));
-                        warn!(
-                            "{node} was killed due to not stopping within the {:#?} grace period",
-                            duration + kill_duration
-                        );
-                    }
-                }
-            });
         }
         self.stop_sent = true;
 
         Ok(self.should_finish_immediately())
+    }
+
+    fn schedule_process_stop(
+        &self,
+        node_id: NodeId,
+        generation: u64,
+        process: ProcessHandle,
+        policy: StopProcessPolicy,
+    ) {
+        let grace_duration_kills = self.grace_duration_kills.clone();
+        match policy {
+            StopProcessPolicy::Force => {
+                if process.submit(ProcessOperation::Kill) {
+                    grace_duration_kills.insert((node_id, generation));
+                }
+            }
+            StopProcessPolicy::Graceful(duration) => {
+                tokio::spawn(async move {
+                    tokio::time::sleep(duration).await;
+                    if process.submit(ProcessOperation::SoftKill) {
+                        grace_duration_kills.insert((node_id.clone(), generation));
+                    }
+
+                    let kill_duration = duration / 2;
+                    tokio::time::sleep(kill_duration).await;
+                    if process.submit(ProcessOperation::Kill) {
+                        grace_duration_kills.insert((node_id.clone(), generation));
+                        warn!(
+                            "{node_id} was killed due to not stopping within the {:#?} grace period",
+                            duration + kill_duration
+                        );
+                    }
+                });
+            }
+        }
+    }
+
+    pub(crate) fn stop_rejected_replacement(
+        &self,
+        node_id: &NodeId,
+        generation: u64,
+        process: ProcessHandle,
+    ) {
+        if let Some(policy) = self.stop_process_policy {
+            self.schedule_process_stop(node_id.clone(), generation, process, policy);
+        } else {
+            // Restarts can also be disabled by AllInputsClosed. That path has
+            // no operator-supplied grace policy, so retain its existing
+            // immediate orphan-reaping behavior.
+            drop(process);
+        }
     }
 
     fn should_finish_immediately(&self) -> FinishDataflowWhen {

--- a/binaries/daemon/src/spawn/prepared.rs
+++ b/binaries/daemon/src/spawn/prepared.rs
@@ -152,6 +152,7 @@ pub struct PreparedNode {
     pub(super) node_working_dir: PathBuf,
     pub(super) dataflow_id: DataflowId,
     pub(super) node: ResolvedNode,
+    pub(super) generation: u64,
     pub(super) node_config: NodeConfig,
     pub(super) clock: Arc<HLC>,
     pub(super) daemon_tx: mpsc::Sender<Timestamped<Event>>,
@@ -172,6 +173,7 @@ impl PreparedNode {
     pub async fn spawn(self, mut logger: NodeLogger<'static>) -> eyre::Result<RunningNode> {
         let (op_tx, op_rx) = flume::bounded(2);
         let (finished_tx, finished_rx) = oneshot::channel();
+        let (registered_tx, registered_rx) = oneshot::channel();
         let kind = self
             .clone()
             .spawn_inner(&mut logger, op_rx, finished_tx)
@@ -186,6 +188,8 @@ impl PreparedNode {
                 NodeKind::Dynamic => None,
                 NodeKind::Spawned { .. } => Some(crate::ProcessHandle::new(op_tx)),
             },
+            restart_loop_start: Some(registered_tx),
+            generation: self.generation,
             node_config: self.node_config.clone(),
             restart_policy: self.restart_policy(),
             disable_restart: disable_restart.clone(),
@@ -205,7 +209,10 @@ impl PreparedNode {
 
         tokio::spawn(self.restart_loop(
             logger,
-            finished_rx,
+            RestartLoopReceivers {
+                finished: finished_rx,
+                registered: registered_rx,
+            },
             disable_restart,
             force_restart_next,
             pid,
@@ -255,12 +262,17 @@ impl PreparedNode {
     async fn restart_loop(
         mut self,
         mut logger: NodeLogger<'static>,
-        mut finished_rx: oneshot::Receiver<NodeProcessFinished>,
+        receivers: RestartLoopReceivers,
         disable_restart: Arc<AtomicBool>,
         force_restart_next: Arc<AtomicBool>,
         pid: Arc<AtomicU32>,
         shared_restart_count: Arc<AtomicU32>,
     ) {
+        if receivers.registered.await.is_err() {
+            return;
+        }
+        let mut finished_rx = receivers.finished;
+        let mut generation = self.generation;
         let config = self.restart_config();
         let mut restart_count: u32 = 0;
         let mut window_start = tokio::time::Instant::now();
@@ -351,6 +363,7 @@ impl PreparedNode {
             let event = DoraEvent::SpawnedNodeResult {
                 dataflow_id: self.dataflow_id,
                 node_id: self.node.id.clone(),
+                generation,
                 exit_status,
                 dynamic_node: self.node.kind.dynamic(),
                 restart,
@@ -461,14 +474,30 @@ impl PreparedNode {
                 match result {
                     Ok(NodeKind::Spawned { pid: new_pid }) => {
                         finished_rx = finished_rx_new;
+                        let new_handle = crate::ProcessHandle::new(op_tx_new);
+                        if disable_restart.load(atomic::Ordering::Acquire) {
+                            logger
+                                .log(
+                                    LogLevel::Info,
+                                    Some("daemon".into()),
+                                    "restart cancelled: dataflow stopped during respawn"
+                                        .to_string(),
+                                )
+                                .await;
+                            drop(new_handle);
+                            break;
+                        }
                         pid.store(new_pid, atomic::Ordering::Release);
+                        let new_generation = crate::running_dataflow::next_node_generation();
                         // Install the new `ProcessHandle` in
                         // `running_nodes` so subsequent stop/kill
                         // operations target this incarnation.
                         let handle_replaced = DoraEvent::ProcessHandleReplaced {
                             dataflow_id: self.dataflow_id,
                             node_id: self.node.id.clone(),
-                            new_handle: crate::ProcessHandle::new(op_tx_new),
+                            previous_generation: generation,
+                            new_generation,
+                            new_handle,
                         }
                         .into();
                         let msg = Timestamped {
@@ -476,6 +505,7 @@ impl PreparedNode {
                             timestamp: self.clock.clone().new_timestamp(),
                         };
                         let _ = self.daemon_tx.clone().send(msg).await;
+                        generation = new_generation;
                     }
                     Ok(NodeKind::Dynamic) => {
                         logger
@@ -1062,6 +1092,11 @@ struct NodeProcessFinished {
     // (dora-rs/adora#152). The receiver is now dropped at the end of
     // the spawn_inner task and each restart creates a fresh channel
     // pair.
+}
+
+struct RestartLoopReceivers {
+    finished: oneshot::Receiver<NodeProcessFinished>,
+    registered: oneshot::Receiver<()>,
 }
 
 #[cfg(test)]

--- a/binaries/daemon/src/spawn/prepared.rs
+++ b/binaries/daemon/src/spawn/prepared.rs
@@ -511,30 +511,6 @@ impl PreparedNode {
                     Ok(NodeKind::Spawned { pid: new_pid }) => {
                         finished_rx = finished_rx_new;
                         let new_handle = crate::ProcessHandle::new(op_tx_new);
-                        if disable_restart.load(atomic::Ordering::Acquire) {
-                            logger
-                                .log(
-                                    LogLevel::Info,
-                                    Some("daemon".into()),
-                                    "restart cancelled: dataflow stopped during respawn"
-                                        .to_string(),
-                                )
-                                .await;
-                            // Dropping the handle kills the just-spawned
-                            // replacement (ProcessHandle::drop submits Kill).
-                            drop(new_handle);
-                            // The daemon still awaits a terminal event after
-                            // the earlier `restart: true`; settle it so the
-                            // entry is removed and the dataflow can finish.
-                            self.send_terminal_exit(
-                                generation,
-                                exit_status,
-                                restart_count,
-                                exited_pid,
-                            )
-                            .await;
-                            break;
-                        }
                         pid.store(new_pid, atomic::Ordering::Release);
                         let new_generation = crate::running_dataflow::next_node_generation();
                         // Install the new `ProcessHandle` in

--- a/binaries/daemon/src/spawn/prepared.rs
+++ b/binaries/daemon/src/spawn/prepared.rs
@@ -259,6 +259,37 @@ impl PreparedNode {
         }
     }
 
+    /// Settle the daemon's restart debt when the loop aborts after having
+    /// announced `restart: true`: the daemon's `SpawnedNodeResult` restart
+    /// arm keeps the node's `running_nodes` entry registered awaiting a
+    /// later terminal event, and only that terminal event removes the entry
+    /// and lets the dataflow finish. Every abort path following a
+    /// `restart: true` announcement must call this before returning.
+    async fn send_terminal_exit(
+        &self,
+        generation: u64,
+        exit_status: NodeExitStatus,
+        restart_count: u32,
+        pid: u32,
+    ) {
+        let event = DoraEvent::SpawnedNodeResult {
+            dataflow_id: self.dataflow_id,
+            node_id: self.node.id.clone(),
+            generation,
+            exit_status,
+            dynamic_node: self.node.kind.dynamic(),
+            restart: false,
+            restart_count,
+            pid,
+        }
+        .into();
+        let event = Timestamped {
+            inner: event,
+            timestamp: self.clock.clone().new_timestamp(),
+        };
+        let _ = self.daemon_tx.clone().send(event).await;
+    }
+
     async fn restart_loop(
         mut self,
         mut logger: NodeLogger<'static>,
@@ -364,7 +395,7 @@ impl PreparedNode {
                 dataflow_id: self.dataflow_id,
                 node_id: self.node.id.clone(),
                 generation,
-                exit_status,
+                exit_status: exit_status.clone(),
                 dynamic_node: self.node.kind.dynamic(),
                 restart,
                 restart_count,
@@ -416,6 +447,11 @@ impl PreparedNode {
                             Some("daemon".into()),
                             "restart cancelled: inputs closed before respawn".to_string(),
                         )
+                        .await;
+                    // The daemon was told `restart: true` above and kept this
+                    // node registered awaiting a successor. Settle that debt
+                    // before aborting, or the dataflow can never finish.
+                    self.send_terminal_exit(generation, exit_status, restart_count, exited_pid)
                         .await;
                     break;
                 }
@@ -484,7 +520,19 @@ impl PreparedNode {
                                         .to_string(),
                                 )
                                 .await;
+                            // Dropping the handle kills the just-spawned
+                            // replacement (ProcessHandle::drop submits Kill).
                             drop(new_handle);
+                            // The daemon still awaits a terminal event after
+                            // the earlier `restart: true`; settle it so the
+                            // entry is removed and the dataflow can finish.
+                            self.send_terminal_exit(
+                                generation,
+                                exit_status,
+                                restart_count,
+                                exited_pid,
+                            )
+                            .await;
                             break;
                         }
                         pid.store(new_pid, atomic::Ordering::Release);
@@ -524,6 +572,10 @@ impl PreparedNode {
                                 Some("daemon".into()),
                                 format!("failed to restart node: {err:?}"),
                             )
+                            .await;
+                        // Same restart debt as the cancel branches above:
+                        // without a terminal event the node stays registered.
+                        self.send_terminal_exit(generation, exit_status, restart_count, exited_pid)
                             .await;
                         break;
                     }
@@ -1102,6 +1154,173 @@ struct RestartLoopReceivers {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Deserialize from YAML (mirroring `dora_core::build` tests) to avoid
+    /// coupling this fixture to ResolvedNode's exact field list.
+    fn test_resolved_node(restart_delay_secs: f64) -> dora_core::descriptor::ResolvedNode {
+        serde_yaml::from_str(&format!(
+            "id: test\n\
+             custom:\n  \
+             path: /nonexistent\n  \
+             source: Local\n  \
+             restart_policy: always\n  \
+             restart_delay: {restart_delay_secs}\n"
+        ))
+        .expect("parse test node descriptor")
+    }
+
+    fn test_node_config() -> NodeConfig {
+        NodeConfig {
+            dataflow_id: uuid::Uuid::nil(),
+            node_id: NodeId::from("test".to_string()),
+            run_config: serde_yaml::from_str("inputs: {}\noutputs: []\n")
+                .expect("parse empty run config"),
+            daemon_communication: None,
+            dataflow_descriptor: serde_yaml::Value::Null,
+            dynamic: false,
+            write_events_to: None,
+            restart_count: 0,
+            output_routing: None,
+        }
+    }
+
+    fn test_prepared_node(
+        daemon_tx: tokio::sync::mpsc::Sender<Timestamped<Event>>,
+        generation: u64,
+        restart_delay_secs: f64,
+    ) -> PreparedNode {
+        PreparedNode {
+            command: None,
+            spawn_error_msg: "test node has no spawnable command".into(),
+            node_working_dir: PathBuf::from("."),
+            dataflow_id: uuid::Uuid::nil(),
+            node: test_resolved_node(restart_delay_secs),
+            generation,
+            node_config: test_node_config(),
+            clock: Arc::new(HLC::default()),
+            daemon_tx,
+            node_stderr_most_recent: Arc::new(ArrayQueue::new(4)),
+            last_activity: Arc::new(AtomicU64::new(0)),
+            ft_stats: Arc::new(crate::FaultToleranceStats::default()),
+        }
+    }
+
+    async fn test_logger() -> NodeLogger<'static> {
+        let logger = crate::log::Logger {
+            destination: crate::log::LogDestination::Tracing,
+            daemon_id: dora_message::common::DaemonId::new(None),
+            clock: Arc::new(HLC::default()),
+        };
+        let mut daemon_logger = logger.for_daemon(dora_message::common::DaemonId::new(None));
+        daemon_logger
+            .for_dataflow(uuid::Uuid::nil())
+            .try_clone()
+            .await
+            .expect("clone dataflow logger")
+            .for_node(NodeId::from("test".to_string()))
+    }
+
+    /// The registered-gate abort path: a `RunningNode` dropped without
+    /// `mark_registered` (its dataflow vanished before insertion) must
+    /// cancel the restart loop outright — no events, no respawns.
+    #[tokio::test]
+    async fn restart_loop_aborts_when_registration_never_happens() {
+        let (daemon_tx, mut daemon_rx) = tokio::sync::mpsc::channel(8);
+        let node = test_prepared_node(daemon_tx, 7, 0.0);
+        let (_finished_tx, finished_rx) = oneshot::channel();
+        let (registered_tx, registered_rx) = oneshot::channel::<()>();
+        drop(registered_tx);
+
+        node.restart_loop(
+            test_logger().await,
+            RestartLoopReceivers {
+                finished: finished_rx,
+                registered: registered_rx,
+            },
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(AtomicU32::new(0)),
+            Arc::new(AtomicU32::new(0)),
+        )
+        .await;
+
+        assert!(
+            daemon_rx.try_recv().is_err(),
+            "an unregistered restart loop must terminate without emitting events"
+        );
+    }
+
+    /// A stop that lands during restart backoff (after `restart: true` was
+    /// announced) must settle the daemon's restart debt with a terminal
+    /// `SpawnedNodeResult` — otherwise the node entry is never removed and
+    /// the dataflow can never finish (dora-rs/dora#2926 review).
+    #[tokio::test]
+    async fn cancelled_restart_settles_terminal_exit() {
+        let (daemon_tx, mut daemon_rx) = tokio::sync::mpsc::channel(8);
+        // Long backoff so the disable flag flips deterministically mid-sleep.
+        let node = test_prepared_node(daemon_tx, 7, 0.5);
+        let (finished_tx, finished_rx) = oneshot::channel();
+        let (registered_tx, registered_rx) = oneshot::channel();
+        let disable_restart = Arc::new(AtomicBool::new(false));
+
+        let loop_task = tokio::spawn(node.restart_loop(
+            test_logger().await,
+            RestartLoopReceivers {
+                finished: finished_rx,
+                registered: registered_rx,
+            },
+            disable_restart.clone(),
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(AtomicU32::new(0)),
+            Arc::new(AtomicU32::new(0)),
+        ));
+
+        registered_tx.send(()).expect("open registration gate");
+        assert!(
+            finished_tx
+                .send(NodeProcessFinished {
+                    exit_status: NodeExitStatus::ExitCode(1),
+                    pid: 42,
+                })
+                .is_ok(),
+            "report node exit"
+        );
+
+        let first = daemon_rx.recv().await.expect("restart announcement");
+        match first.inner {
+            Event::Dora(DoraEvent::SpawnedNodeResult {
+                generation,
+                restart,
+                ..
+            }) => {
+                assert_eq!(generation, 7);
+                assert!(restart, "first event must announce the restart");
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+
+        // Stop lands while the loop sleeps out its restart backoff.
+        disable_restart.store(true, atomic::Ordering::Release);
+
+        let second = daemon_rx.recv().await.expect("terminal settlement");
+        match second.inner {
+            Event::Dora(DoraEvent::SpawnedNodeResult {
+                generation,
+                restart,
+                ..
+            }) => {
+                assert_eq!(generation, 7, "terminal event must match the entry");
+                assert!(!restart, "cancelled restart must settle terminally");
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+
+        loop_task.await.expect("restart loop must exit");
+        assert!(
+            daemon_rx.try_recv().is_err(),
+            "no further events after the terminal settlement"
+        );
+    }
 
     async fn read_all_lines(input: &[u8]) -> Vec<Vec<u8>> {
         let mut reader = tokio::io::BufReader::new(input).take(MAX_LOG_LINE_BYTES as u64);

--- a/binaries/daemon/src/spawn/spawner.rs
+++ b/binaries/daemon/src/spawn/spawner.rs
@@ -660,6 +660,7 @@ impl Spawner {
             node_working_dir,
             dataflow_id,
             node,
+            generation: crate::running_dataflow::next_node_generation(),
             node_config,
             clock: self.clock,
             daemon_tx: self.daemon_tx,

--- a/tests/node-lifecycle-e2e.rs
+++ b/tests/node-lifecycle-e2e.rs
@@ -1127,6 +1127,134 @@ fn hot_swap_survives_predecessor_exit_before_readd() {
     );
 }
 
+/// The dynamic-successor ordering from dora-rs/dora#2926 (scenario 2):
+/// a removed incarnation's failure lands while the id has no entry, so
+/// it is recorded under the bare node id — and a *dynamic* successor
+/// never emits a `SpawnedNodeResult` that would incidentally overwrite
+/// it. Only the `AddNode` handler's `clear_node_result` keeps the dead
+/// predecessor's exit code from being attributed to the successor when
+/// the dataflow stops.
+///
+/// (The issue's other named scenario — a `restart_loop` respawn racing
+/// a same-id re-add — has no deterministic e2e without a spawn-hold
+/// test hook in the daemon; both of its sides are pinned at unit level
+/// instead: `stale_handle_replacement_preserves_live_process` for the
+/// daemon-side rejection and `cancelled_restart_settles_terminal_exit`
+/// for the loop side.)
+#[test]
+#[cfg(unix)]
+fn hot_swap_dynamic_successor_not_blamed_for_predecessor_exit() {
+    let _guard = LIFECYCLE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let name = "rustlc-swap-dynamic";
+    let broken = write_stop_delay_yml("dynamic-broken", 0, 1);
+    let dora = start_hot_swap_fixture(name);
+    let _cleanup = CleanupGuard { dora: &dora };
+
+    let old_pid = add_filter_and_wait(&dora, name, &broken.yml, "dora node add filter (broken)");
+
+    let (ok, _, stderr) = run_capture(
+        Command::new(&dora).args(["node", "remove", "--dataflow", name, "filter"]),
+        "dora node remove filter",
+    );
+    assert!(ok, "dora node remove failed.\nstderr:\n{stderr}");
+
+    // Enforce the ordering this scenario is about: the failure must be
+    // recorded while the id has no running_nodes entry.
+    wait_for_process_exit(&old_pid, Duration::from_secs(30));
+    assert_eq!(
+        broken.recorded_exits(),
+        vec!["1"],
+        "the removed incarnation must have exited 1 for this test to mean \
+         anything; marker file {:?} says otherwise",
+        broken.marker
+    );
+
+    // Re-add the same id as a DYNAMIC node: it never spawns a process
+    // and never reports a result, so nothing ever overwrites the
+    // predecessor's recorded failure — only `AddNode`'s result clearing
+    // protects the successor.
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let dynamic_spec = Path::new(manifest_dir)
+        .join("target")
+        .join(format!("dora-dynamic-successor-{}.yml", std::process::id()));
+    fs::write(
+        &dynamic_spec,
+        "id: filter\npath: dynamic\noutputs:\n  - value\n",
+    )
+    .expect("failed to write dynamic successor spec");
+    add_node(
+        &dora,
+        name,
+        &dynamic_spec,
+        "dora node re-add filter (dynamic)",
+    );
+
+    // Let the daemon settle the add before stopping.
+    std::thread::sleep(Duration::from_secs(2));
+
+    let (ok, stdout, stderr) = run_capture(
+        Command::new(&dora).args(["stop", "--name", name, "--grace-duration", "5s"]),
+        "dora stop",
+    );
+    assert!(
+        ok,
+        "`dora stop` blames the dynamic successor for the removed \
+         incarnation's exit 1 — the stale node result was not cleared on \
+         re-add.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
+/// Pins the deliberate keep-alive semantics of the generation guard
+/// (dora-rs/dora#2926 review, D2): an exit event whose entry was removed
+/// runs no finish accounting, so removing every node leaves a zero-node
+/// dataflow alive — for live editing and same-id re-adds — until an
+/// explicit `dora stop`, which must then succeed cleanly.
+#[test]
+#[cfg(unix)]
+fn removing_all_nodes_keeps_dataflow_alive_until_explicit_stop() {
+    let _guard = LIFECYCLE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let name = "rustlc-remove-all";
+    let dora = start_hot_swap_fixture(name);
+    let _cleanup = CleanupGuard { dora: &dora };
+
+    for node in ["receiver", "sender"] {
+        let (ok, _, stderr) = run_capture(
+            Command::new(&dora).args(["node", "remove", "--dataflow", name, node]),
+            "dora node remove",
+        );
+        assert!(ok, "dora node remove {node} failed.\nstderr:\n{stderr}");
+    }
+
+    // Give the removed nodes' exit events time to reach the daemon; the
+    // generation guard must drop them without finishing the dataflow.
+    std::thread::sleep(Duration::from_secs(3));
+
+    let (ok, list_out, stderr) = run_capture(
+        Command::new(&dora).args(["list", "--format", "json"]),
+        "dora list after removing all nodes",
+    );
+    assert!(ok, "dora list failed.\nstderr:\n{stderr}");
+    let entry = list_out
+        .lines()
+        .find(|l| l.contains(&format!("\"name\":\"{name}\"")))
+        .unwrap_or_else(|| panic!("dataflow {name} missing from list:\n{list_out}"));
+    assert!(
+        entry.contains("\"status\":\"Running\""),
+        "a fully-emptied dataflow must stay alive until an explicit stop \
+         (live-editing keep-alive); got:\n{entry}"
+    );
+
+    let (ok, stdout, stderr) = run_capture(
+        Command::new(&dora).args(["stop", "--name", name, "--grace-duration", "5s"]),
+        "dora stop",
+    );
+    assert!(
+        ok,
+        "`dora stop` on an intentionally-emptied dataflow must succeed.\
+         \nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}
+
 /// A binary that exits non-zero immediately without ever connecting to
 /// the daemon — the "crashed at import" shape from dora-rs/dora#2917.
 ///


### PR DESCRIPTION
## Summary

- assign a monotonic generation to each node process incarnation and reject stale lifecycle events
- scope planned-stop markers and stored node results so removed or restarted nodes cannot affect a live successor
- gate restart-loop events until node registration and make teardown win concurrent respawn races
- add regression coverage for stale exits, stale handle replacement, PID reuse, registration ordering, and result cleanup

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all --exclude dora-node-api-python --exclude dora-operator-api-python --exclude dora-ros2-bridge-python -- -D warnings`
- `cargo test --all --exclude dora-node-api-python --exclude dora-operator-api-python --exclude dora-ros2-bridge-python --exclude dora-cli-api-python --exclude dora-examples`
- `cargo check --examples`
- `cargo test -p dora-daemon fault_tolerance_tests:: -- --test-threads=1` (47 passed)

The targeted `node-lifecycle-e2e` invocation could not start because the existing default local coordinator store uses schema v2 while this checkout expects schema v3. The store was left untouched.

Closes #2926
