### PR TITLE
fix(cli): guard `dora down`, and make `--force` actually clean up

### DIFF
--- a/binaries/cli/src/command/cluster/down.rs
+++ b/binaries/cli/src/command/cluster/down.rs
@@ -20,6 +20,10 @@ pub struct Down {
 impl Executable for Down {
     fn execute(self) -> eyre::Result<()> {
         default_tracing()?;
-        up::down(None, self.coordinator.socket_addr())
+        // `dora cluster down` keeps its existing unconditional behavior: it
+        // is an explicit cluster teardown, and the #2924 report is about
+        // `dora down`/`destroy` hitting an unrelated instance on the shared
+        // default port. Revisit if the same footgun shows up here.
+        up::down(None, self.coordinator.socket_addr(), true)
     }
 }

--- a/binaries/cli/src/command/down.rs
+++ b/binaries/cli/src/command/down.rs
@@ -10,11 +10,30 @@ pub struct Down {
     config: Option<PathBuf>,
     #[clap(flatten)]
     coordinator: CoordinatorOptions,
+    /// Destroy even if the coordinator still has running dataflows,
+    /// terminating them immediately first.
+    ///
+    /// Without this, `dora down` refuses when the target coordinator
+    /// reports running dataflows. Lifecycle commands reach whatever
+    /// coordinator owns the port, so the instance you hit may belong to
+    /// another checkout or project on the same machine
+    /// (dora-rs/dora#2924). Give each instance its own
+    /// `DORA_COORDINATOR_PORT` to keep them apart.
+    ///
+    /// This stops each dataflow before tearing the daemons down. `Destroy`
+    /// on its own does not wait for the stop to take effect, so a wedged
+    /// node would outlive its daemon and be orphaned.
+    #[clap(long, action)]
+    force: bool,
 }
 
 impl Executable for Down {
     fn execute(self) -> eyre::Result<()> {
         default_tracing()?;
-        up::down(self.config.as_deref(), self.coordinator.socket_addr())
+        up::down(
+            self.config.as_deref(),
+            self.coordinator.socket_addr(),
+            self.force,
+        )
     }
 }

--- a/binaries/cli/src/command/stop.rs
+++ b/binaries/cli/src/command/stop.rs
@@ -121,7 +121,7 @@ fn stop_dataflow_interactive(
     Ok(())
 }
 
-fn stop_dataflow(
+pub(crate) fn stop_dataflow(
     uuid: Uuid,
     grace_duration: Option<Duration>,
     force: bool,

--- a/binaries/cli/src/command/up.rs
+++ b/binaries/cli/src/command/up.rs
@@ -5,7 +5,10 @@ use crate::{
     common::{connect_to_coordinator, connect_with_retry, send_control_request},
 };
 use dora_core::topics::DORA_COORDINATOR_PORT_WS_DEFAULT;
-use dora_message::{cli_to_coordinator::ControlRequest, coordinator_to_cli::ControlRequestReply};
+use dora_message::{
+    cli_to_coordinator::ControlRequest,
+    coordinator_to_cli::{ControlRequestReply, DataflowIdAndName},
+};
 use eyre::{Context, ContextCompat, bail};
 use std::io::{Read, Seek};
 use std::path::PathBuf;
@@ -379,9 +382,32 @@ fn available_backup_path(path: &Path) -> eyre::Result<PathBuf> {
     bail!("could not find an available coordinator store backup path")
 }
 
+/// Whether `dora down` may destroy the coordinator it just connected to.
+///
+/// Separate from the command so the rule is testable: the CLI reaches
+/// whatever coordinator owns the port, which may belong to an unrelated
+/// project on the same machine (dora-rs/dora#2924).
+// No `PartialEq`: it would require widening `DataflowIdAndName` in
+// dora-message purely for test convenience. Tests destructure instead.
+#[derive(Debug)]
+pub(crate) enum DownDecision {
+    Proceed,
+    /// Running dataflows would be killed; the operator has not said so.
+    Refuse(Vec<DataflowIdAndName>),
+}
+
+pub(crate) fn down_decision(running: Vec<DataflowIdAndName>, force: bool) -> DownDecision {
+    if running.is_empty() || force {
+        DownDecision::Proceed
+    } else {
+        DownDecision::Refuse(running)
+    }
+}
+
 pub(crate) fn down(
     config_path: Option<&Path>,
     coordinator_addr: SocketAddr,
+    force: bool,
 ) -> Result<(), eyre::ErrReport> {
     let UpConfig {} = parse_dora_config(config_path)?;
     // Retry connection briefly — the coordinator may still be initializing after `dora up`.
@@ -391,6 +417,78 @@ pub(crate) fn down(
              hint: is it running? Start it with `dora up`"
         )
     })?;
+
+    // Look before destroying. Every lifecycle command targets whatever
+    // coordinator owns the port, so this may be an unrelated project's
+    // instance on the same machine (#2924).
+    let running = match send_control_request(&session, &ControlRequest::List) {
+        Ok(ControlRequestReply::DataflowList(list)) => list.get_active(),
+        // An unexpected reply or a transport error must not make `down`
+        // unusable: report what we could not determine and carry on, which
+        // is the pre-#2924 behavior.
+        Ok(other) => {
+            eprintln!(
+                "warning: could not determine running dataflows before destroying \
+                 (unexpected reply {other:?}); proceeding"
+            );
+            Vec::new()
+        }
+        Err(err) => {
+            eprintln!(
+                "warning: could not determine running dataflows before destroying \
+                 ({err}); proceeding"
+            );
+            Vec::new()
+        }
+    };
+
+    // `--force` means "clean up anyway", so it has to actually clean up.
+    // `Destroy` alone does not: the coordinator sends each dataflow a stop
+    // and then tears the daemons down immediately, without waiting for the
+    // stop ladder (grace -> SIGTERM -> SIGKILL) to run. A node that exits
+    // promptly on `Stop` is reaped; a wedged one outlives its daemon and is
+    // orphaned. Stopping first goes through the path that does wait, which
+    // is also the one the refusal message recommends.
+    if force && !running.is_empty() {
+        println!(
+            "Stopping {} running dataflow(s) before teardown...",
+            running.len()
+        );
+        for entry in &running {
+            if let Err(err) = crate::command::stop::stop_dataflow(entry.uuid, None, true, &session)
+            {
+                // Report and continue: a dataflow that cannot be stopped
+                // must not block teardown, which is what `--force` was
+                // asked for.
+                eprintln!("warning: failed to stop {entry}: {err}");
+            }
+        }
+    }
+
+    if let DownDecision::Refuse(running) = down_decision(running, force) {
+        let list = running
+            .iter()
+            .map(|d| format!("  - {d}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        eyre::bail!(
+            "refusing to destroy the coordinator at {coordinator_addr}: \
+             {} dataflow(s) still running\n{list}\n\n  \
+             This tears down the coordinator, its daemons and every dataflow \
+             above. Lifecycle commands target whatever coordinator owns the \
+             port, so this may not be the instance you meant — a different \
+             checkout or another project on this machine shares \
+             {coordinator_addr} by default.\n\n  \
+             hint: stop the dataflows first (`dora stop --all`), or re-run \
+             with `--force` if you do mean to kill them\n  \
+             hint: to keep instances isolated, give each one its own port via \
+             `DORA_COORDINATOR_PORT` (or `--coordinator-port`)",
+            running.len(),
+        );
+    }
+
+    println!("Destroying coordinator at {coordinator_addr}");
+
     // send destroy command to dora-coordinator
     let reply = send_control_request(&session, &ControlRequest::Destroy)?;
     match reply {
@@ -582,5 +680,62 @@ mod tests {
             .expect("second recreation did not acquire the released lock");
         drop(second);
         waiter.join().expect("join lock waiter");
+    }
+}
+
+#[cfg(test)]
+mod destroy_guard_tests {
+    use super::{DownDecision, down_decision};
+    use dora_message::coordinator_to_cli::DataflowIdAndName;
+
+    // ---- dora-rs/dora#2924: `dora down` must not silently destroy an
+    //      unrelated instance's coordinator ----
+
+    fn df(name: &str) -> DataflowIdAndName {
+        DataflowIdAndName {
+            uuid: uuid::Uuid::nil(),
+            name: Some(name.to_string()),
+        }
+    }
+
+    /// The reported case: a coordinator with live work is not torn down
+    /// just because someone ran `dora destroy` in another checkout.
+    #[test]
+    fn down_refuses_when_dataflows_are_running() {
+        match down_decision(vec![df("long-experiment")], false) {
+            DownDecision::Refuse(blocked) => {
+                let names: Vec<_> = blocked.iter().filter_map(|d| d.name.clone()).collect();
+                assert_eq!(
+                    names,
+                    vec!["long-experiment"],
+                    "the refusal must name what it would have killed, so the \
+                     operator can tell whose coordinator they just hit"
+                );
+            }
+            other => panic!(
+                "a destroy that would kill running dataflows must stop and say \
+                 so, got {other:?}"
+            ),
+        }
+    }
+
+    /// An idle coordinator is the normal teardown case and must stay
+    /// frictionless — otherwise every `dora up` / `dora down` loop grows a
+    /// flag and people learn to pass `--force` reflexively.
+    #[test]
+    fn down_proceeds_when_nothing_is_running() {
+        assert!(
+            matches!(down_decision(Vec::new(), false), DownDecision::Proceed),
+            "an idle coordinator must tear down without a flag"
+        );
+    }
+
+    /// `--force` is the documented escape hatch for "yes, kill them".
+    #[test]
+    fn force_destroys_despite_running_dataflows() {
+        assert!(
+            matches!(down_decision(vec![df("busy")], true), DownDecision::Proceed),
+            "`--force` is the documented way to say \"yes, kill them\""
+        );
     }
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -346,8 +346,33 @@ dora down [OPTIONS]
 
 | Flag | Default | Description |
 |------|---------|-------------|
+| `--force` | false | Tear down even if the coordinator has running dataflows, terminating them immediately first (a plain teardown does not wait for a stop to take effect, so a wedged node would be orphaned) |
 | `--coordinator-addr <IP>` | `127.0.0.1` | Coordinator address |
 | `--coordinator-port <PORT>` | `6013` | Coordinator port |
+
+> **This is machine-wide, not project-wide.** `dora down` has no notion of
+> "your" dataflow or checkout: it connects to whatever coordinator owns the
+> port and destroys it, along with its daemons and every dataflow running on
+> it. Two checkouts on one machine share `127.0.0.1:6013` by default, so a
+> `dora down` in one silently kills the other's work — indistinguishable from
+> a coordinator crash on the victim's side.
+>
+> Since [#2924] the command refuses when the target reports running
+> dataflows, listing them. `--force` proceeds, stopping each dataflow
+> first so nothing is left orphaned — including nodes that ignore a
+> cooperative stop.
+>
+> **To run instances side by side, give each its own port** — that is the
+> isolation mechanism, and every lifecycle command (`up`, `down`, `start`,
+> `stop`, `list`, `logs`) follows it:
+>
+> ```bash
+> DORA_COORDINATOR_PORT=6113 dora up
+> DORA_COORDINATOR_PORT=6113 dora start flow.yml
+> DORA_COORDINATOR_PORT=6113 dora down     # touches only this instance
+> ```
+
+[#2924]: https://github.com/dora-rs/dora/issues/2924
 
 #### `dora build`
 
@@ -1260,7 +1285,7 @@ All environment variables serve as fallbacks. CLI flags always take precedence.
 | Variable | Default | Commands | Description |
 |----------|---------|----------|-------------|
 | `DORA_COORDINATOR_ADDR` | `127.0.0.1` | All coordinator commands | Coordinator IP address |
-| `DORA_COORDINATOR_PORT` | `6013` | All coordinator commands | Coordinator WebSocket port |
+| `DORA_COORDINATOR_PORT` | `6013` | All coordinator commands | Coordinator WebSocket port. **This is how you isolate concurrent dora instances on one machine** — commands act on whichever coordinator owns the port, so two checkouts sharing the default will `down`/`stop` each other's dataflows |
 | `DORA_LOG_LEVEL` | `stdout` | `run`, `logs` | Default minimum log level |
 | `DORA_LOG_FORMAT` | `pretty` | `run`, `logs` | Default output format |
 | `DORA_LOG_FILTER` | | `run`, `logs` | Default per-node level overrides |

--- a/guide/src/operations/cli.md
+++ b/guide/src/operations/cli.md
@@ -348,8 +348,33 @@ dora down [OPTIONS]
 
 | Flag | Default | Description |
 |------|---------|-------------|
+| `--force` | false | Tear down even if the coordinator has running dataflows, terminating them immediately first (a plain teardown does not wait for a stop to take effect, so a wedged node would be orphaned) |
 | `--coordinator-addr <IP>` | `127.0.0.1` | Coordinator address |
 | `--coordinator-port <PORT>` | `6013` | Coordinator port |
+
+> **This is machine-wide, not project-wide.** `dora down` has no notion of
+> "your" dataflow or checkout: it connects to whatever coordinator owns the
+> port and destroys it, along with its daemons and every dataflow running on
+> it. Two checkouts on one machine share `127.0.0.1:6013` by default, so a
+> `dora down` in one silently kills the other's work — indistinguishable from
+> a coordinator crash on the victim's side.
+>
+> Since [#2924] the command refuses when the target reports running
+> dataflows, listing them. `--force` proceeds, stopping each dataflow
+> first so nothing is left orphaned — including nodes that ignore a
+> cooperative stop.
+>
+> **To run instances side by side, give each its own port** — that is the
+> isolation mechanism, and every lifecycle command (`up`, `down`, `start`,
+> `stop`, `list`, `logs`) follows it:
+>
+> ```bash
+> DORA_COORDINATOR_PORT=6113 dora up
+> DORA_COORDINATOR_PORT=6113 dora start flow.yml
+> DORA_COORDINATOR_PORT=6113 dora down     # touches only this instance
+> ```
+
+[#2924]: https://github.com/dora-rs/dora/issues/2924
 
 #### `dora build`
 
@@ -1123,7 +1148,7 @@ All environment variables serve as fallbacks. CLI flags always take precedence.
 | Variable | Default | Commands | Description |
 |----------|---------|----------|-------------|
 | `DORA_COORDINATOR_ADDR` | `127.0.0.1` | All coordinator commands | Coordinator IP address |
-| `DORA_COORDINATOR_PORT` | `6013` | All coordinator commands | Coordinator WebSocket port |
+| `DORA_COORDINATOR_PORT` | `6013` | All coordinator commands | Coordinator WebSocket port. **This is how you isolate concurrent dora instances on one machine** — commands act on whichever coordinator owns the port, so two checkouts sharing the default will `down`/`stop` each other's dataflows |
 | `DORA_LOG_LEVEL` | `stdout` | `run`, `logs` | Default minimum log level |
 | `DORA_LOG_FORMAT` | `pretty` | `run`, `logs` | Default output format |
 | `DORA_LOG_FILTER` | | `run`, `logs` | Default per-node level overrides |


### PR DESCRIPTION
Addresses #2924.

## The problem

Every lifecycle command reaches whatever coordinator owns the port, and two checkouts on one machine share `127.0.0.1:6013` by default. A `dora destroy` in a dev loop therefore tears down an unrelated project's coordinator, its daemons and every dataflow on it — no confirmation, no indication anything was running. From the victim's side it looks exactly like a coordinator crash. The reporter needed three kills and a process-capture tripwire to identify the cause.

## The guard

```
$ dora down
[ERROR]
refusing to destroy the coordinator at 127.0.0.1:6013: 1 dataflow(s) still running
  - [victim] 019fc838-d8b4-7587-b7d5-adad0299df7e

  This tears down the coordinator, its daemons and every dataflow above.
  Lifecycle commands target whatever coordinator owns the port, so this may
  not be the instance you meant — a different checkout or another project on
  this machine shares 127.0.0.1:6013 by default.

  hint: stop the dataflows first (`dora stop --all`), or re-run with `--force`
        if you do mean to kill them
  hint: to keep instances isolated, give each one its own port via
        `DORA_COORDINATOR_PORT` (or `--coordinator-port`)
```

It names the cause, not just the symptom: the surprise is not that destroy destroys, it is that it reached an instance you did not have in mind. The idle case is untouched, deliberately — `up`/`down` loops stay frictionless so nobody learns to type `--force` reflexively.

## `--force` had to be fixed before it could be recommended

It did not clean up. `Destroy` sends each dataflow a stop and then tears the daemons down **immediately**, without waiting for the stop ladder (grace → SIGTERM → SIGKILL). A node that exits promptly on `Stop` is reaped; a wedged one outlives its daemon and is orphaned.

Measured on a node that ignores **both** the cooperative stop and SIGTERM:

| | before | after |
|---|---|---|
| `dora down --force` | "destroyed successfully" in <1s | stops each dataflow first |
| wedged node | **still running** | SIGKILLed and reported |
| coordinator / daemon | gone | gone |

So `dora down`'s own documentation — *"Stops any running dataflows first"* — held only for well-behaved nodes. A guard whose escape hatch doesn't work would have been worse than no guard.

`--force` now stops each dataflow through the path that does wait, then destroys. I also verified the other route the error suggests: `dora stop --all` does work on a wedged dataflow (~10s via the grace ladder). Both ways out are real.

## Against the three asks

1. **Refuse when dataflows are running** — done, `--force` as the escape hatch, and it now genuinely cleans up.
2. **Isolation** — docs, not a new concept. Both CLI copies get a "machine-wide, not project-wide" callout with a working side-by-side recipe, and `DORA_COORDINATOR_PORT` is documented as *the* isolation mechanism rather than just "Coordinator WebSocket port". A first-class `--context`/profile is a design project, not a bug fix.
3. **Say which coordinator** — the refusal names the address and every running dataflow; the success path announces what it is destroying. PID and uptime aren't reachable over the control protocol today and would need a new request type.

## Verification

`down_decision` is a separate function rather than an inline check so the rule is unit-testable. Mutation-checked against production code both ways: dropping the guard fails `down_refuses_when_dataflows_are_running`; ignoring `--force` fails `force_destroys_despite_running_dataflows`.

End to end: idle `down` works; running `down` refuses and **the victim survives**; `--force` cleans up a node that ignores stop and SIGTERM; the `destroy` alias behaves identically.

Gate: fmt and clippy `-D warnings` pass locally. The full local sweep (workspace tests, `cargo check --examples`, `ws-cli-e2e`, `node-lifecycle-e2e`) was still running when this was opened — those suites call `up`/`down` constantly, which is how a teardown guard would break something unit tests can't see, so CI's run of them is the gate that matters here.

## Known limits

- **The underlying `handle_destroy` bug is untouched.** A direct `Destroy` still orphans wedged nodes; only the CLI's `--force` path compensates. Filed separately as #2980, since fixing it in the coordinator changes behavior for every caller and the right waiting policy is a judgment call.
- **`dora cluster down` keeps its current unconditional behavior**, with an explicit argument and a comment. It is an explicit cluster teardown and was not the reported footgun; a guard would break existing teardown scripts.
- **A failed pre-flight `List` warns and proceeds.** Refusing on a transport hiccup would make teardown unusable — a worse failure than the one being fixed.

Refs #2924

🤖 Generated with [Claude Code](https://claude.com/claude-code)
