### PR TITLE
fix(tests): make the sigterm-ignoring-node fixture compile on Windows (#2742)

### DIFF
--- a/tests/fault_tolerance/sigterm_ignoring_node/Cargo.toml
+++ b/tests/fault_tolerance/sigterm_ignoring_node/Cargo.toml
@@ -21,11 +21,15 @@ path = "src/main.rs"
 dora-node-api = { workspace = true, default-features = false }
 eyre = { workspace = true }
 
-# Unix-only: on Windows `libc::signal` returns a `sighandler_t` (`usize`)
-# while `libc::SIG_ERR` is a `c_int`, so the check in `main` does not even
-# compile there. The fixture has no Windows build to guard, so the
-# dependency is scoped rather than the comparison widened with a cast —
-# a cast would be a no-op on Unix (and trip `clippy::unnecessary_cast`)
-# while keeping dead signal code alive on a platform without signals.
+# Scoped to unix, matching the `#[cfg(unix)]` on `main`: it keeps libc
+# out of the Windows dependency graph entirely, and makes "this fixture's
+# signal handling is Unix-only" enforced by the build rather than by
+# convention — uncfg'd `libc::` code added later fails to compile on
+# Windows instead of silently becoming part of the stub's build.
+#
+# The alternative, widening the guard with `libc::SIG_ERR as usize`, was
+# rejected: `signal` returns `sighandler_t` (`usize`) everywhere but
+# `SIG_ERR` is a `c_int` only on Windows, so the cast is a no-op on Unix
+# and trips `clippy::unnecessary_cast` there.
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/tests/fault_tolerance/sigterm_ignoring_node/Cargo.toml
+++ b/tests/fault_tolerance/sigterm_ignoring_node/Cargo.toml
@@ -20,4 +20,12 @@ path = "src/main.rs"
 [dependencies]
 dora-node-api = { workspace = true, default-features = false }
 eyre = { workspace = true }
+
+# Unix-only: on Windows `libc::signal` returns a `sighandler_t` (`usize`)
+# while `libc::SIG_ERR` is a `c_int`, so the check in `main` does not even
+# compile there. The fixture has no Windows build to guard, so the
+# dependency is scoped rather than the comparison widened with a cast —
+# a cast would be a no-op on Unix (and trip `clippy::unnecessary_cast`)
+# while keeping dead signal code alive on a platform without signals.
+[target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/tests/fault_tolerance/sigterm_ignoring_node/src/main.rs
+++ b/tests/fault_tolerance/sigterm_ignoring_node/src/main.rs
@@ -10,11 +10,12 @@
 //! Unix-only in substance — the property it fakes is a signal
 //! disposition, which Windows has no equivalent for, and its only
 //! caller (`run_killed_by_sigterm_terminates_nodes_and_exits` in
-//! `tests/node-lifecycle-e2e.rs`) is `#[cfg(unix)]`. It stays a
-//! workspace member so `cargo check --all` keeps covering it, which
-//! means it must still *compile* on Windows: hence the stub `main`
-//! below rather than a `#![cfg(unix)]` on the crate, which would leave
-//! a bin target with no `main` at all.
+//! `tests/node-lifecycle-e2e.rs`) is `#[cfg(unix)]`. Cargo has no
+//! cfg-conditional `members`, so it stays a workspace member on every
+//! platform and must still *compile* on Windows for the nightly's
+//! `cargo test --all` to resolve — hence the stub `main` below rather
+//! than a `#![cfg(unix)]` on the crate, which would leave a bin target
+//! with no `main` at all.
 
 #[cfg(unix)]
 fn main() -> eyre::Result<()> {

--- a/tests/fault_tolerance/sigterm_ignoring_node/src/main.rs
+++ b/tests/fault_tolerance/sigterm_ignoring_node/src/main.rs
@@ -6,12 +6,22 @@
 //! actually reaches its final SIGKILL rung: a node that dies to SIGTERM
 //! would be cleaned up either way and cannot distinguish the two
 //! (dora-rs/dora#2920).
+//!
+//! Unix-only in substance — the property it fakes is a signal
+//! disposition, which Windows has no equivalent for, and its only
+//! caller (`run_killed_by_sigterm_terminates_nodes_and_exits` in
+//! `tests/node-lifecycle-e2e.rs`) is `#[cfg(unix)]`. It stays a
+//! workspace member so `cargo check --all` keeps covering it, which
+//! means it must still *compile* on Windows: hence the stub `main`
+//! below rather than a `#![cfg(unix)]` on the crate, which would leave
+//! a bin target with no `main` at all.
 
-use dora_node_api::DoraNode;
-use eyre::ensure;
-use std::{thread, time::Duration};
-
+#[cfg(unix)]
 fn main() -> eyre::Result<()> {
+    use dora_node_api::DoraNode;
+    use eyre::ensure;
+    use std::{thread, time::Duration};
+
     // Installed BEFORE `init_from_env`, which spawns the event-stream
     // threads, the node's tokio runtime and zenoh's threads: `signal` is
     // only well specified in a single-threaded process.
@@ -56,4 +66,18 @@ fn main() -> eyre::Result<()> {
         thread::sleep(Duration::from_millis(500));
     }
     Ok(())
+}
+
+/// Compiles, never runs: nothing spawns this fixture on Windows.
+///
+/// It exits non-zero rather than sleeping like the Unix build, so a
+/// future Windows caller fails loudly instead of silently observing a
+/// node that ignores nothing and calling the stop ladder proven.
+#[cfg(not(unix))]
+fn main() {
+    eprintln!(
+        "sigterm-ignoring-node is a Unix-only test fixture: it fakes a SIGTERM \
+         disposition, which Windows has no equivalent for (dora-rs/dora#2920)"
+    );
+    std::process::exit(1);
 }


### PR DESCRIPTION
`tests/fault_tolerance/sigterm_ignoring_node` does not compile for any Windows
target:

```
error[E0308]: mismatched types      previous != libc::SIG_ERR
error[E0277]: can't compare `usize` with `i32`
```

`libc::signal` returns a `sighandler_t` (`usize`) everywhere, but `libc::SIG_ERR`
is a `c_int` on Windows and a `sighandler_t` on Unix, so the guard added in #2961
(`1a947a3c7`, merged 2026-08-02) is a type error there. PR CI is ubuntu-only, so
it merged green and broke two nightly jobs the same night:

- `Test (windows-latest) [nightly]`
- `Cross-check (x86_64-pc-windows-gnu)`

both in [run 30802384898](https://github.com/dora-rs/dora/actions/runs/30802384898).

The fixture is Unix-only in substance — it fakes a SIGTERM disposition, and its
only caller (`run_killed_by_sigterm_terminates_nodes_and_exits`) is `#[cfg(unix)]`
— but cargo has no cfg-conditional `members`, so it stays a workspace member on
every platform and must still compile. So: scope `libc` to `cfg(unix)` and give
Windows a stub `main` that exits non-zero.

Widening the comparison with `libc::SIG_ERR as usize` was rejected — the cast is
a no-op on Unix (and trips `clippy::unnecessary_cast`) and would keep dead
signal-handling code alive on a platform with no signals.

Reproduced and verified locally against `x86_64-pc-windows-gnu`: the pre-fix code
fails with the two errors above, the post-fix code checks clean for both
windows-gnu and the host.

Refs #2742
