### PR TITLE
ci(nightly): give the ROS2 Zenoh interop jobs the maturin they need (#2742)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1786,6 +1786,13 @@ jobs:
         run: cargo test -p dora-ros2-bridge-python
 
   # ===== MSRV check =====
+  # Advisory (`continue-on-error`) until these have run green for a
+  # stretch: they drive real ROS 2 containers, so a docker/apt hiccup
+  # should not redden a nightly. NOTE that this also hides them from
+  # `file-issue-on-failure` — `needs.<job>.result` reads `success` for a
+  # continue-on-error job — which is why they failed silently from the
+  # day they were added (#2790, 2026-07-21) until #2742 went looking.
+  # Drop `continue-on-error` once they are trustworthy.
   ros2-zenoh-humble:
     name: ROS2 Zenoh Interop (Humble)
     runs-on: ubuntu-latest
@@ -1796,6 +1803,16 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_VERSION }}
+      # `ros2-zenoh-interop.sh` builds the ROS2 bridge wheel with maturin
+      # and installs it with pip, so the job needs a >=3.11 interpreter
+      # and maturin on PATH. Without them the script died on
+      # `maturin: command not found` (exit 127) before running a single
+      # case.
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install maturin
+        run: pip install maturin
       - run: scripts/ros2-zenoh-interop.sh humble all
       - if: failure()
         uses: actions/upload-artifact@v7
@@ -1803,6 +1820,7 @@ jobs:
           name: ros2-zenoh-humble-logs
           path: target/ros2-zenoh-logs
 
+  # Advisory for the same reason as `ros2-zenoh-humble` above.
   ros2-zenoh-kilted:
     name: ROS2 Zenoh Interop (Kilted)
     runs-on: ubuntu-latest
@@ -1813,6 +1831,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.RUST_VERSION }}
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install maturin
+        run: pip install maturin
       - run: scripts/ros2-zenoh-interop.sh kilted all
       - if: failure()
         uses: actions/upload-artifact@v7

--- a/scripts/ros2-zenoh-interop.sh
+++ b/scripts/ros2-zenoh-interop.sh
@@ -16,6 +16,22 @@ if [[ "$CASE" != all ]] && [[ ! " ${CASES[*]} " =~ " $CASE " ]]; then
   exit 2
 fi
 
+# Preflight the host tools before spending ~2 min pulling and booting a
+# ROS container. `maturin` in particular used to surface only as a bare
+# `line 49: maturin: command not found` (exit 127) *after* the pull, on
+# every nightly from #2790 until #2742 — far enough from the cause to
+# read as a ROS problem rather than a missing build tool.
+missing=()
+for tool in docker maturin; do
+  command -v "$tool" >/dev/null || missing+=("$tool")
+done
+if ((${#missing[@]})); then
+  echo "missing required tool(s): ${missing[*]}" >&2
+  echo "  docker:  https://docs.docker.com/engine/install/" >&2
+  echo "  maturin: pip install maturin" >&2
+  exit 1
+fi
+
 PROJECT="dora-rmw-zenoh-${DISTRO}-$$"
 compose=("${COMPOSE[@]}" "$DISTRO" -p "$PROJECT")
 service="${DISTRO}-router"


### PR DESCRIPTION
`scripts/ros2-zenoh-interop.sh` builds the ROS2 bridge wheel with `maturin build`
and installs it with pip, but the two jobs only set up a Rust toolchain. Every
run since they were added (#2790, 2026-07-21) has died at the same line, after
spending ~2 minutes pulling and booting the ROS container:

```
scripts/ros2-zenoh-interop.sh: line 49: maturin: command not found
##[error]Process completed with exit code 127
```

Both jobs have failed identically every night for two weeks and have never
passed. Nobody noticed because they are `continue-on-error: true`, which makes
`needs.<job>.result` read `success` — so `file-issue-on-failure` never listed
them and the nightly issue (#2742) never mentioned them.

Add `actions/setup-python@v6` + `pip install maturin`, mirroring the
`ros2-bridge` job's Python setup, and preflight `docker`/`maturin` in the script
so a missing tool is named up front with a fix hint instead of surfacing as a
bare 127 after the container pull.

Left advisory for now — these drive real ROS 2 containers, and a job that has
never run green should not start blocking nightlies on its first day. There is a
comment recording that `continue-on-error` is what hid the failure and that it
should go once the jobs are trustworthy.

Verified the preflight fires with the expected message and exit code, and that
argument validation still runs first.

Refs #2742
