### PR TITLE
fix(test): identify the fixture by `args`, not `comm` — comm truncates on Linux

### DIFF
--- a/tests/node-lifecycle-e2e.rs
+++ b/tests/node-lifecycle-e2e.rs
@@ -1899,14 +1899,38 @@ fn run_killed_by_sigterm_terminates_nodes_and_exits() {
 /// mistaken for a surviving node.
 #[cfg(unix)]
 fn node_is_fixture(pid: u32) -> bool {
-    if !process_alive(&pid.to_string()) {
-        return false;
-    }
-    let out = Command::new("ps")
-        .args(["-o", "comm=", "-p", &pid.to_string()])
+    // `expect`, not a silent false: this feeds the assertions, and the
+    // final one is `!node_is_fixture(..)`. If a failure to RUN `ps` were
+    // folded into "not our process", an unavailable `ps` would satisfy
+    // that assertion and the test would report success having verified
+    // nothing.
+    let args = ps_args(pid).expect("failed to run `ps -o args=`");
+    process_alive(&pid.to_string()) && args.contains(FIXTURE_BIN)
+}
+
+/// Matched with a leading `/` so it hits the spawned binary's path and not
+/// a process that merely *names* it in its arguments — `cargo build -p
+/// sigterm-ignoring-node`, which this test itself runs.
+const FIXTURE_BIN: &str = "/sigterm-ignoring-node";
+
+/// The full command line of `pid`. `None` if `ps` could not be run at all;
+/// `Some("")` if it ran and the pid is gone.
+///
+/// `args=`, NOT `comm=`: on Linux `comm` is `/proc/<pid>/comm`, which the
+/// kernel caps at `TASK_COMM_LEN - 1` = 15 characters. `sigterm-ignoring-node`
+/// is 21, so a `comm` match silently fails there while passing on macOS,
+/// where `comm` carries the full path — which is exactly how this shipped
+/// green from a Mac and turned CI red (dora-rs/dora#2961).
+///
+/// The two states are kept apart so callers can choose: assertions must
+/// fail loudly when the check itself is broken, while `Drop` must not.
+#[cfg(unix)]
+fn ps_args(pid: u32) -> Option<String> {
+    Command::new("ps")
+        .args(["-ww", "-o", "args=", "-p", &pid.to_string()])
         .output()
-        .expect("failed to run `ps -o comm=`");
-    String::from_utf8_lossy(&out.stdout).contains("sigterm-ignoring-node")
+        .ok()
+        .map(|out| String::from_utf8_lossy(&out.stdout).into_owned())
 }
 
 /// Same question, but safe to ask from a `Drop`: never panics.
@@ -1918,12 +1942,5 @@ fn node_is_fixture(pid: u32) -> bool {
 /// a kill rather than risking one against the wrong target.
 #[cfg(unix)]
 fn still_our_fixture(pid: u32) -> bool {
-    Command::new("ps")
-        .args(["-o", "comm=", "-p", &pid.to_string()])
-        .output()
-        .map(|out| {
-            out.status.success()
-                && String::from_utf8_lossy(&out.stdout).contains("sigterm-ignoring-node")
-        })
-        .unwrap_or(false)
+    ps_args(pid).is_some_and(|args| args.contains(FIXTURE_BIN))
 }


### PR DESCRIPTION
**Main's `E2E Tests` job is red and has been since #2961 merged.** This fixes it.

## What is failing

`run_killed_by_sigterm_terminates_nodes_and_exits` fails at its own precondition on every Linux CI run:

```
panicked at tests/node-lifecycle-e2e.rs:
  precondition: node <pid> should be running our fixture before we signal
```

## Why, and why it was not caught

The identity check came out of review on #2961 — a real pid-reuse hazard, where a recycled pid could be mistaken for a surviving node and get SIGKILLed. The guard was right; the implementation was not portable:

- on **Linux**, `ps -o comm=` reads `/proc/<pid>/comm`, which the kernel caps at `TASK_COMM_LEN - 1` = **15** characters
- `sigterm-ignoring-node` is **21**, so Linux sees `sigterm-ignorin`
- `.contains("sigterm-ignoring-node")` is therefore always false

On macOS `comm` returns the full path, so it matched. Every local run passed, including mutation checks — those proved the test *discriminates*, which says nothing about whether it *ports*. The test was written, reviewed, mutation-verified and merged without ever running on the platform CI uses.

## The fix

`ps -ww -o args=` carries the full command line on both platforms. Both identity checks now route through a single `ps_args` helper so they cannot drift apart — the same consolidation lesson that produced the bug they guard (a correct check added in one place, missed in its sibling).

The pid-reuse guard is unaffected: it still confirms the process is ours before asserting on it or signalling its group.

## Verification

Passes on macOS (607s, no leftover processes). **Linux CI on this PR is the real check** — that is the platform the bug is specific to, and the one I could not exercise locally.

Refs #2961
