### PR TITLE
fix(daemon): stop descriptor `env:` from overriding the daemon's control-plane variables

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1413,6 +1413,14 @@ impl Daemon {
         zenoh_bind: ZenohBind,
         disable_multicast: bool,
     ) -> eyre::Result<(Self, mpsc::Receiver<Timestamped<Event>>)> {
+        // Fold in `DORA_ZENOH_MULTICAST` so this is the daemon's *effective*
+        // decision, not just its flag. The zenoh session honors the variable on
+        // its own, but the spawner forwards this field to nodes — and nodes no
+        // longer inherit the variable — so a daemon started with the variable
+        // instead of `--zenoh-no-multicast` would otherwise leave its nodes
+        // scouting by multicast (#2991 review).
+        let disable_multicast = dora_core::topics::multicast_disabled(disable_multicast);
+
         // Reserve a port and have zenoh listen on it. The endpoint is injected
         // into spawned nodes via `DORA_ZENOH_CONNECT` so peer discovery works
         // without multicast (#1778).

--- a/binaries/daemon/src/spawn/spawner.rs
+++ b/binaries/daemon/src/spawn/spawner.rs
@@ -45,16 +45,64 @@ const ENV_DENYLIST: &[&str] = &[
     "DORA_ALLOW_SHELL_NODES",
 ];
 
+/// Control-plane variables the daemon injects into every node it spawns.
+/// Descriptor `env:` / `envs:` entries must not override them: they configure
+/// how the node reaches its daemon and peers, and a forged value produces a
+/// dataflow that starts cleanly but silently exchanges nothing (#2944).
+///
+/// `DORA_NODE_CONFIG` was previously safe only because `spawn_inner`
+/// re-serializes it after the command is built (a restart-count fix, not a
+/// security measure); listing it here makes that safety intentional.
+const CONTROL_PLANE_ENV: &[&str] = &[
+    "DORA_NODE_CONFIG",
+    "DORA_RUNTIME_CONFIG",
+    DORA_ZENOH_LISTEN_ENV,
+    DORA_ZENOH_CONNECT_ENV,
+    DORA_ZENOH_MULTICAST_ENV,
+];
+
 /// Returns true if the env var key is denied, logging a warning if so.
+///
+/// Matched case-insensitively: Windows environment variables are
+/// case-insensitive (and last-insert-wins in the std `Command` env map), so
+/// a `dora_zenoh_connect` descriptor entry would otherwise bypass both the
+/// denylist and the inject-last ordering there.
 fn is_denied_env(key: &str) -> bool {
-    if ENV_DENYLIST.contains(&key) {
+    if ENV_DENYLIST.iter().any(|d| key.eq_ignore_ascii_case(d)) {
         tracing::warn!(
             "skipping denied environment variable '{key}' (security: could inject shared libraries)"
+        );
+        true
+    } else if CONTROL_PLANE_ENV
+        .iter()
+        .any(|d| key.eq_ignore_ascii_case(d))
+    {
+        tracing::warn!(
+            "ignoring `{key}` from the descriptor env: it is control-plane wiring \
+             set by the daemon and cannot be overridden"
         );
         true
     } else {
         false
     }
+}
+
+/// Apply descriptor-provided env (`env:` / `envs:`) to the command, dropping
+/// denied keys with a warning. Must run BEFORE the daemon injects its
+/// control-plane variables so the daemon's wiring wins by construction even
+/// for a key the denylist misses (#2944).
+fn apply_descriptor_env(
+    mut command: Command,
+    envs: Option<&BTreeMap<String, EnvValue>>,
+) -> Command {
+    if let Some(envs) = envs {
+        for (key, value) in envs {
+            if !is_denied_env(key) {
+                command = command.env(key, value.to_string());
+            }
+        }
+    }
+    command
 }
 
 /// Strip all denied env vars from the inherited process environment.
@@ -305,6 +353,23 @@ impl Spawner {
         }
     }
 
+    /// Inject the daemon's control-plane variables (`config_key` +
+    /// `DORA_ZENOH_*`). Must run AFTER [`apply_descriptor_env`] — a later
+    /// `.env()` overwrites an earlier one — so the daemon's wiring cannot be
+    /// overridden from the descriptor (#2944). The denylist in
+    /// [`is_denied_env`] additionally turns an override attempt into a
+    /// visible warning instead of a silent no-op.
+    fn inject_control_plane_env(
+        &self,
+        command: Command,
+        node_id: &NodeId,
+        config_key: &str,
+        config_yaml: String,
+    ) -> Command {
+        let command = command.env(config_key, config_yaml);
+        self.maybe_inject_zenoh_connect(command, node_id)
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub async fn spawn_node(
         self,
@@ -424,29 +489,16 @@ impl Spawner {
                     command = command.stdin(Stdio::Null);
                     command = strip_denied_env(command);
 
-                    command = command.env(
+                    // Descriptor env first, daemon control-plane wiring last (#2944).
+                    command = apply_descriptor_env(command, node.env.as_ref());
+                    command = apply_descriptor_env(command, n.envs.as_ref());
+                    command = self.inject_control_plane_env(
+                        command,
+                        &node.id,
                         "DORA_NODE_CONFIG",
-                        serde_yaml::to_string(&node_config.clone())
+                        serde_yaml::to_string(&node_config)
                             .wrap_err("failed to serialize node config")?,
                     );
-                    command = self.maybe_inject_zenoh_connect(command, &node.id);
-                    // Injecting the env variable defined in the `yaml` into
-                    // the node runtime.
-                    if let Some(envs) = &node.env {
-                        for (key, value) in envs {
-                            if !is_denied_env(key) {
-                                command = command.env(key, value.to_string());
-                            }
-                        }
-                    }
-                    if let Some(envs) = &n.envs {
-                        // node has some inner env variables -> add them too
-                        for (key, value) in envs {
-                            if !is_denied_env(key) {
-                                command = command.env(key, value.to_string());
-                            }
-                        }
-                    }
 
                     // For managed Python custom nodes, also set VIRTUAL_ENV and
                     // prepend the env's bin dir to PATH so subprocesses, console
@@ -631,21 +683,15 @@ impl Spawner {
                     command = command.current_dir(&node_working_dir);
                     command = strip_denied_env(command);
 
-                    command = command.env(
+                    // Descriptor env first, daemon control-plane wiring last (#2944).
+                    command = apply_descriptor_env(command, node.env.as_ref());
+                    command = self.inject_control_plane_env(
+                        command,
+                        &node.id,
                         "DORA_RUNTIME_CONFIG",
                         serde_yaml::to_string(&runtime_config)
                             .wrap_err("failed to serialize runtime config")?,
                     );
-                    command = self.maybe_inject_zenoh_connect(command, &node.id);
-                    // Injecting the env variable defined in the `yaml` into
-                    // the node runtime.
-                    if let Some(envs) = &node.env {
-                        for (key, value) in envs {
-                            if !is_denied_env(key) {
-                                command = command.env(key, value.to_string());
-                            }
-                        }
-                    }
 
                     // For managed Python runtime nodes (Python operator + uv on),
                     // set VIRTUAL_ENV and prepend the env's bin dir to PATH so
@@ -769,6 +815,94 @@ mod tests {
 
     fn node(id: &str) -> NodeId {
         NodeId::from(id.to_string())
+    }
+
+    /// #2944: the daemon's own wiring variables must be rejected from
+    /// descriptor `env:` entries — they configure how the node reaches its
+    /// daemon and peers, and a descriptor that sets them produces a dataflow
+    /// that starts cleanly but silently exchanges nothing.
+    #[test]
+    fn reserved_control_plane_keys_are_denied() {
+        for key in [
+            "DORA_NODE_CONFIG",
+            "DORA_RUNTIME_CONFIG",
+            DORA_ZENOH_LISTEN_ENV,
+            DORA_ZENOH_CONNECT_ENV,
+            DORA_ZENOH_MULTICAST_ENV,
+        ] {
+            assert!(
+                is_denied_env(key),
+                "`{key}` is daemon-managed control-plane wiring and must be denied"
+            );
+        }
+        // Windows env vars are case-insensitive, so case variants must be
+        // denied too — an exact-match list is a bypass there.
+        assert!(is_denied_env("dora_zenoh_connect"));
+        assert!(is_denied_env("ld_preload"));
+        assert!(
+            !is_denied_env("MY_APP_SETTING"),
+            "ordinary variables must still pass through"
+        );
+    }
+
+    /// #2944 regression: a descriptor that spells the daemon's wiring
+    /// variables in `env:` must not win. Pins both defenses at once: denied
+    /// keys are dropped with a warning, and the daemon injects its variables
+    /// AFTER descriptor env is applied, so the spawned command always carries
+    /// the daemon's values.
+    #[test]
+    fn descriptor_env_cannot_override_the_daemons_wiring() {
+        let spawner = spawner_for(Some("tcp/127.0.0.1:7447"), true);
+        let forged: BTreeMap<String, EnvValue> = CONTROL_PLANE_ENV
+            .iter()
+            .map(|key| (key.to_string(), EnvValue::String("FORGED".into())))
+            .collect();
+
+        // Pre-seed a forged value directly (bypassing the denylist) so this
+        // test pins the ordering defense on its own: a control-plane variable
+        // the denylist misses must still be overwritten by the daemon's
+        // inject-last injection.
+        let command = Command::new("true").env("DORA_NODE_CONFIG", "FORGED");
+        let command = apply_descriptor_env(command, Some(&forged));
+        let command = spawner.inject_control_plane_env(
+            command,
+            &node("sink"),
+            "DORA_NODE_CONFIG",
+            "real-config".into(),
+        );
+
+        let env = |key: &str| {
+            command
+                .environment
+                .get(&OsString::from(key))
+                .cloned()
+                .flatten()
+        };
+        assert_eq!(
+            env("DORA_NODE_CONFIG").as_deref(),
+            Some(OsStr::new("real-config")),
+            "the node must receive the daemon's config, not the descriptor's"
+        );
+        assert_eq!(
+            env(DORA_ZENOH_CONNECT_ENV).as_deref(),
+            Some(OsStr::new("tcp/127.0.0.1:7447")),
+            "the node must dial the daemon's endpoint, not the descriptor's"
+        );
+        assert_eq!(
+            env(DORA_ZENOH_MULTICAST_ENV).as_deref(),
+            Some(OsStr::new("off")),
+            "the daemon's multicast decision must win"
+        );
+        assert_eq!(
+            env(DORA_ZENOH_LISTEN_ENV),
+            None,
+            "a wiring variable the daemon did not inject must not appear at all"
+        );
+        assert_eq!(
+            env("DORA_RUNTIME_CONFIG"),
+            None,
+            "a forged runtime config must not reach a custom node"
+        );
     }
 
     /// Since zenoh 1.9 peers don't relay, a consumer that never dials its

--- a/binaries/daemon/src/spawn/spawner.rs
+++ b/binaries/daemon/src/spawn/spawner.rs
@@ -37,16 +37,24 @@ use std::{
 };
 use tokio::sync::mpsc;
 
-/// Environment variable names that must never be passed to spawned nodes.
+/// Environment variable names that must never be passed to spawned nodes:
+/// loader-injection vectors and daemon-level secrets. Refused from a
+/// descriptor *and* scrubbed from the environment nodes inherit.
 const ENV_DENYLIST: &[&str] = &[
     "LD_PRELOAD",
     "LD_AUDIT",
     "DYLD_INSERT_LIBRARIES",
-    "DYLD_LIBRARY_PATH",
-    "LD_LIBRARY_PATH",
     "DORA_AUTH_TOKEN",
     "DORA_ALLOW_SHELL_NODES",
 ];
+
+/// Library *search* paths. Refused from a descriptor like the hijack variables
+/// above, but deliberately still inherited: a daemon started from a sourced
+/// ROS or CUDA environment must keep passing these on, or a dynamically linked
+/// node fails to start before it can report anything. A node that needs a
+/// custom search path gets it from the environment the daemon runs in
+/// (#2991 review).
+const SEARCH_PATH_ENV: &[&str] = &["LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH"];
 
 /// Control-plane variables the daemon injects into every node it spawns.
 /// Descriptor `env:` / `envs:` entries must not override them: they configure
@@ -84,6 +92,12 @@ fn is_denied_env(key: &str) -> bool {
     if ENV_DENYLIST.iter().any(|d| env_key_matches(key, d)) {
         tracing::warn!(
             "skipping denied environment variable {key:?} (security: could inject shared libraries)"
+        );
+        true
+    } else if SEARCH_PATH_ENV.iter().any(|d| env_key_matches(key, d)) {
+        tracing::warn!(
+            "skipping {key:?} from the descriptor env: library search paths are \
+             inherited from the environment the daemon runs in"
         );
         true
     } else if CONTROL_PLANE_ENV
@@ -143,9 +157,10 @@ fn apply_descriptor_env(
 /// that started the daemon cannot wrongly wire nodes the daemon deliberately
 /// left unwired.
 ///
-/// [`ZENOH_CONFIG_PATH_ENV`] is deliberately absent: refused from a
-/// descriptor, but inheriting it is how a deployment points every process at a
-/// custom zenoh config.
+/// [`ZENOH_CONFIG_PATH_ENV`] and [`SEARCH_PATH_ENV`] are deliberately absent:
+/// refused from a descriptor, but inheriting them is how a deployment points
+/// every process at a custom zenoh config, and how a node linked against a
+/// sourced ROS or CUDA install finds its libraries.
 ///
 /// Inserts the `None` removal sentinel directly rather than calling
 /// `Command::env_remove`, which `clonable_command` implements as a map
@@ -1024,6 +1039,35 @@ mod tests {
             None,
             "a daemon-level zenoh config must still reach its nodes by inheritance"
         );
+    }
+
+    /// The scrub must not strand a dynamically linked node: a daemon started
+    /// from a sourced ROS or CUDA environment is the only source of these, and
+    /// a descriptor cannot supply them, so scrubbing them means the node's
+    /// loader fails before the node can report anything (#2991 review).
+    #[test]
+    fn library_search_paths_survive_the_scrub() {
+        let spawner = spawner_for(None, false);
+        let command = spawner.compose_node_env(
+            Command::new("true"),
+            &node("sink"),
+            &[None],
+            "DORA_NODE_CONFIG",
+            "real-config".into(),
+        );
+
+        for key in SEARCH_PATH_ENV {
+            assert_eq!(
+                env_of(&command, key),
+                None,
+                "`{key}` must keep being inherited — a node linked against a \
+                 sourced install has no other way to find its libraries"
+            );
+            assert!(
+                is_denied_env(key),
+                "`{key}` is still not something a descriptor gets to set"
+            );
+        }
     }
 
     /// Since zenoh 1.9 peers don't relay, a consumer that never dials its

--- a/binaries/daemon/src/spawn/spawner.rs
+++ b/binaries/daemon/src/spawn/spawner.rs
@@ -13,7 +13,10 @@ use dora_core::{
         CoreNodeKind, Descriptor, OperatorDefinition, OperatorSource, PythonSource, ResolvedNode,
     },
     get_python_path,
-    topics::{DORA_ZENOH_CONNECT_ENV, DORA_ZENOH_LISTEN_ENV, DORA_ZENOH_MULTICAST_ENV},
+    topics::{
+        DORA_ZENOH_CONNECT_ENV, DORA_ZENOH_LISTEN_ENV, DORA_ZENOH_MULTICAST_ENV,
+        ZENOH_CONFIG_PATH_ENV,
+    },
     uhlc::HLC,
 };
 use dora_message::{
@@ -61,25 +64,42 @@ const CONTROL_PLANE_ENV: &[&str] = &[
     DORA_ZENOH_MULTICAST_ENV,
 ];
 
-/// Returns true if the env var key is denied, logging a warning if so.
+/// Whether `key` names the reserved variable `reserved`.
 ///
-/// Matched case-insensitively: Windows environment variables are
-/// case-insensitive (and last-insert-wins in the std `Command` env map), so
-/// a `dora_zenoh_connect` descriptor entry would otherwise bypass both the
-/// denylist and the inject-last ordering there.
+/// Exact on Unix, where `ld_preload` and `LD_PRELOAD` are genuinely different
+/// variables and folding case would silently drop a legitimate descriptor
+/// entry. On Windows the OS folds env keys with its uppercase mapping before
+/// the child sees them, so a case (or Unicode) variant of a reserved name
+/// collides with the real one and must be denied.
+fn env_key_matches(key: &str, reserved: &str) -> bool {
+    if cfg!(windows) {
+        key.to_uppercase() == reserved.to_uppercase()
+    } else {
+        key == reserved
+    }
+}
+
+/// Returns true if the env var key is denied, logging a warning if so.
 fn is_denied_env(key: &str) -> bool {
-    if ENV_DENYLIST.iter().any(|d| key.eq_ignore_ascii_case(d)) {
+    if ENV_DENYLIST.iter().any(|d| env_key_matches(key, d)) {
         tracing::warn!(
-            "skipping denied environment variable '{key}' (security: could inject shared libraries)"
+            "skipping denied environment variable {key:?} (security: could inject shared libraries)"
         );
         true
     } else if CONTROL_PLANE_ENV
         .iter()
-        .any(|d| key.eq_ignore_ascii_case(d))
+        .chain(std::iter::once(&ZENOH_CONFIG_PATH_ENV))
+        .any(|d| env_key_matches(key, d))
     {
         tracing::warn!(
-            "ignoring `{key}` from the descriptor env: it is control-plane wiring \
+            "ignoring {key:?} from the descriptor env: it is control-plane wiring \
              set by the daemon and cannot be overridden"
+        );
+        true
+    } else if is_malformed_env_key(key) {
+        tracing::warn!(
+            "skipping malformed environment variable name {key:?}: names cannot be \
+             empty or contain `=`, whitespace, or NUL"
         );
         true
     } else {
@@ -87,10 +107,22 @@ fn is_denied_env(key: &str) -> bool {
     }
 }
 
+/// Whether the OS would refuse to treat `key` as one variable name.
+///
+/// A key containing `=` is handed to `execve` verbatim, so the entry
+/// `LD_PRELOAD=/tmp/evil.so ` (denylist miss: the whole string is the *key*)
+/// reaches the child as a real `LD_PRELOAD` assignment, since the loader
+/// splits its value on whitespace. Rejecting the shape closes that off for
+/// every reserved name at once.
+fn is_malformed_env_key(key: &str) -> bool {
+    key.is_empty()
+        || key.contains('=')
+        || key.contains('\0')
+        || key.chars().any(char::is_whitespace)
+}
+
 /// Apply descriptor-provided env (`env:` / `envs:`) to the command, dropping
-/// denied keys with a warning. Must run BEFORE the daemon injects its
-/// control-plane variables so the daemon's wiring wins by construction even
-/// for a key the denylist misses (#2944).
+/// denied keys with a warning.
 fn apply_descriptor_env(
     mut command: Command,
     envs: Option<&BTreeMap<String, EnvValue>>,
@@ -105,12 +137,24 @@ fn apply_descriptor_env(
     command
 }
 
-/// Strip all denied env vars from the inherited process environment.
-/// This prevents the daemon's own env (e.g. `DORA_AUTH_TOKEN`) from leaking
-/// to child nodes via `/proc/<pid>/environ`.
-fn strip_denied_env(mut command: Command) -> Command {
-    for key in ENV_DENYLIST {
-        command = command.env_remove(key);
+/// Keep the daemon's own environment from reaching child nodes: loader-hijack
+/// variables and `DORA_AUTH_TOKEN` (via `/proc/<pid>/environ`), plus the
+/// control-plane wiring, so a stale `DORA_ZENOH_CONNECT` exported in the shell
+/// that started the daemon cannot wrongly wire nodes the daemon deliberately
+/// left unwired.
+///
+/// [`ZENOH_CONFIG_PATH_ENV`] is deliberately absent: refused from a
+/// descriptor, but inheriting it is how a deployment points every process at a
+/// custom zenoh config.
+///
+/// Inserts the `None` removal sentinel directly rather than calling
+/// `Command::env_remove`, which `clonable_command` implements as a map
+/// *removal* — that erases any explicit entry but leaves inheritance untouched,
+/// so the whole scrub was a no-op (only `None` values become
+/// `std::process::Command::env_remove` calls when the command is converted).
+fn deny_inherited_env(mut command: Command) -> Command {
+    for key in ENV_DENYLIST.iter().chain(CONTROL_PLANE_ENV) {
+        command.environment.insert(OsString::from(*key), None);
     }
     command
 }
@@ -353,20 +397,27 @@ impl Spawner {
         }
     }
 
-    /// Inject the daemon's control-plane variables (`config_key` +
-    /// `DORA_ZENOH_*`). Must run AFTER [`apply_descriptor_env`] — a later
-    /// `.env()` overwrites an earlier one — so the daemon's wiring cannot be
-    /// overridden from the descriptor (#2944). The denylist in
-    /// [`is_denied_env`] additionally turns an override attempt into a
-    /// visible warning instead of a silent no-op.
-    fn inject_control_plane_env(
+    /// Compose a spawned node's environment: scrub what must not be inherited,
+    /// apply the descriptor's `env:` (and a custom node's inner `envs:`), then
+    /// inject the daemon's control-plane wiring LAST.
+    ///
+    /// The order is the protection (#2944). A later `.env()` overwrites an
+    /// earlier one, so injecting last means a descriptor entry cannot override
+    /// the daemon's wiring even for a control-plane key [`is_denied_env`]
+    /// misses. Both spawn paths compose through here so the two cannot drift.
+    fn compose_node_env(
         &self,
-        command: Command,
+        mut command: Command,
         node_id: &NodeId,
+        descriptor_envs: &[Option<&BTreeMap<String, EnvValue>>],
         config_key: &str,
         config_yaml: String,
     ) -> Command {
-        let command = command.env(config_key, config_yaml);
+        command = deny_inherited_env(command);
+        for envs in descriptor_envs {
+            command = apply_descriptor_env(command, *envs);
+        }
+        command = command.env(config_key, config_yaml);
         self.maybe_inject_zenoh_connect(command, node_id)
     }
 
@@ -487,14 +538,10 @@ impl Spawner {
                 let command = if let Some(mut command) = command {
                     command = command.current_dir(&node_working_dir);
                     command = command.stdin(Stdio::Null);
-                    command = strip_denied_env(command);
-
-                    // Descriptor env first, daemon control-plane wiring last (#2944).
-                    command = apply_descriptor_env(command, node.env.as_ref());
-                    command = apply_descriptor_env(command, n.envs.as_ref());
-                    command = self.inject_control_plane_env(
+                    command = self.compose_node_env(
                         command,
                         &node.id,
+                        &[node.env.as_ref(), n.envs.as_ref()],
                         "DORA_NODE_CONFIG",
                         serde_yaml::to_string(&node_config)
                             .wrap_err("failed to serialize node config")?,
@@ -681,13 +728,10 @@ impl Spawner {
 
                 let command = if let Some(mut command) = command {
                     command = command.current_dir(&node_working_dir);
-                    command = strip_denied_env(command);
-
-                    // Descriptor env first, daemon control-plane wiring last (#2944).
-                    command = apply_descriptor_env(command, node.env.as_ref());
-                    command = self.inject_control_plane_env(
+                    command = self.compose_node_env(
                         command,
                         &node.id,
+                        &[node.env.as_ref()],
                         "DORA_RUNTIME_CONFIG",
                         serde_yaml::to_string(&runtime_config)
                             .wrap_err("failed to serialize runtime config")?,
@@ -823,61 +867,80 @@ mod tests {
     /// that starts cleanly but silently exchanges nothing.
     #[test]
     fn reserved_control_plane_keys_are_denied() {
-        for key in [
-            "DORA_NODE_CONFIG",
-            "DORA_RUNTIME_CONFIG",
-            DORA_ZENOH_LISTEN_ENV,
-            DORA_ZENOH_CONNECT_ENV,
-            DORA_ZENOH_MULTICAST_ENV,
-        ] {
+        for key in CONTROL_PLANE_ENV {
             assert!(
                 is_denied_env(key),
                 "`{key}` is daemon-managed control-plane wiring and must be denied"
             );
         }
-        // Windows env vars are case-insensitive, so case variants must be
-        // denied too — an exact-match list is a bypass there.
-        assert!(is_denied_env("dora_zenoh_connect"));
-        assert!(is_denied_env("ld_preload"));
+        assert!(
+            is_denied_env(ZENOH_CONFIG_PATH_ENV),
+            "`{ZENOH_CONFIG_PATH_ENV}` builds the whole zenoh session from a file, \
+             skipping every DORA_ZENOH_* variable — denying those and not this one \
+             leaves the bypass open"
+        );
         assert!(
             !is_denied_env("MY_APP_SETTING"),
             "ordinary variables must still pass through"
         );
+        // Unix env vars are case-sensitive, so `ld_preload` is a different
+        // (harmless) variable and must not be dropped. Windows folds keys, so
+        // there the variant IS the reserved name.
+        assert_eq!(
+            is_denied_env("dora_zenoh_connect"),
+            cfg!(windows),
+            "case variants are only a bypass where the OS folds env keys"
+        );
+        assert_eq!(is_denied_env("ld_preload"), cfg!(windows));
     }
 
-    /// #2944 regression: a descriptor that spells the daemon's wiring
-    /// variables in `env:` must not win. Pins both defenses at once: denied
-    /// keys are dropped with a warning, and the daemon injects its variables
-    /// AFTER descriptor env is applied, so the spawned command always carries
-    /// the daemon's values.
+    /// A descriptor key the OS would not read as one variable name is a
+    /// denylist bypass: `env: { "LD_PRELOAD=/tmp/evil.so ": "" }` reaches
+    /// `execve` verbatim and the loader reads it as a real `LD_PRELOAD`.
+    #[test]
+    fn malformed_env_names_are_rejected() {
+        for key in [
+            "LD_PRELOAD=/tmp/evil.so ",
+            "DORA_NODE_CONFIG=forged",
+            "HAS SPACE",
+            "",
+        ] {
+            assert!(is_denied_env(key), "{key:?} is not a usable variable name");
+        }
+    }
+
+    fn env_of(command: &Command, key: &str) -> Option<Option<OsString>> {
+        command.environment.get(&OsString::from(key)).cloned()
+    }
+
+    /// #2944 regression, driven through the same helper both spawn paths use.
+    /// Pins the ordering defense independently of the denylist: a
+    /// control-plane value already on the command (as if the denylist had
+    /// missed it) must still lose to the daemon's inject-last wiring.
     #[test]
     fn descriptor_env_cannot_override_the_daemons_wiring() {
         let spawner = spawner_for(Some("tcp/127.0.0.1:7447"), true);
         let forged: BTreeMap<String, EnvValue> = CONTROL_PLANE_ENV
             .iter()
+            .chain(std::iter::once(&ZENOH_CONFIG_PATH_ENV))
             .map(|key| (key.to_string(), EnvValue::String("FORGED".into())))
             .collect();
+        let ordinary: BTreeMap<String, EnvValue> = [(
+            "MY_APP_SETTING".to_string(),
+            EnvValue::String("kept".into()),
+        )]
+        .into();
 
-        // Pre-seed a forged value directly (bypassing the denylist) so this
-        // test pins the ordering defense on its own: a control-plane variable
-        // the denylist misses must still be overwritten by the daemon's
-        // inject-last injection.
-        let command = Command::new("true").env("DORA_NODE_CONFIG", "FORGED");
-        let command = apply_descriptor_env(command, Some(&forged));
-        let command = spawner.inject_control_plane_env(
-            command,
+        let command = spawner.compose_node_env(
+            // Pre-seeded as if the denylist had missed the key.
+            Command::new("true").env("DORA_NODE_CONFIG", "FORGED"),
             &node("sink"),
+            &[Some(&forged), Some(&ordinary)],
             "DORA_NODE_CONFIG",
             "real-config".into(),
         );
 
-        let env = |key: &str| {
-            command
-                .environment
-                .get(&OsString::from(key))
-                .cloned()
-                .flatten()
-        };
+        let env = |key: &str| env_of(&command, key).flatten();
         assert_eq!(
             env("DORA_NODE_CONFIG").as_deref(),
             Some(OsStr::new("real-config")),
@@ -894,14 +957,72 @@ mod tests {
             "the daemon's multicast decision must win"
         );
         assert_eq!(
-            env(DORA_ZENOH_LISTEN_ENV),
+            env(ZENOH_CONFIG_PATH_ENV),
             None,
-            "a wiring variable the daemon did not inject must not appear at all"
+            "a descriptor must not hand the node its own zenoh config file"
         );
         assert_eq!(
-            env("DORA_RUNTIME_CONFIG"),
+            env("MY_APP_SETTING").as_deref(),
+            Some(OsStr::new("kept")),
+            "ordinary descriptor env must still reach the node"
+        );
+    }
+
+    /// The operator runtime composes its env through the same helper. It has
+    /// no accidental backstop (`spawn_inner` re-serializes `DORA_NODE_CONFIG`
+    /// only), so a forged `DORA_RUNTIME_CONFIG` would hand the runtime the
+    /// wrong operator set.
+    #[test]
+    fn the_runtime_config_is_composed_like_a_node_config() {
+        let spawner = spawner_for(Some("tcp/127.0.0.1:7447"), false);
+        let forged: BTreeMap<String, EnvValue> = [(
+            "DORA_RUNTIME_CONFIG".to_string(),
+            EnvValue::String("FORGED".into()),
+        )]
+        .into();
+
+        let command = spawner.compose_node_env(
+            Command::new("true").env("DORA_RUNTIME_CONFIG", "FORGED"),
+            &node("op"),
+            &[Some(&forged)],
+            "DORA_RUNTIME_CONFIG",
+            "real-runtime-config".into(),
+        );
+
+        assert_eq!(
+            env_of(&command, "DORA_RUNTIME_CONFIG").flatten().as_deref(),
+            Some(OsStr::new("real-runtime-config")),
+            "the runtime must receive the daemon's operator set"
+        );
+    }
+
+    /// Nodes inherit the daemon's environment, so the scrub is the only thing
+    /// keeping `DORA_AUTH_TOKEN` out of `/proc/<pid>/environ` and a stale
+    /// `DORA_ZENOH_CONNECT` from the daemon's shell out of a node the daemon
+    /// deliberately left unwired. Only a `None` entry becomes a real
+    /// `Command::env_remove`; an absent key inherits.
+    #[test]
+    fn the_daemons_own_environment_does_not_leak_into_nodes() {
+        let spawner = spawner_for(None, false);
+        let command = spawner.compose_node_env(
+            Command::new("true"),
+            &node("sink"),
+            &[None],
+            "DORA_NODE_CONFIG",
+            "real-config".into(),
+        );
+
+        for key in ["DORA_AUTH_TOKEN", "LD_PRELOAD", DORA_ZENOH_LISTEN_ENV] {
+            assert_eq!(
+                env_of(&command, key),
+                Some(None),
+                "`{key}` must be removed from the inherited environment, not merely unset"
+            );
+        }
+        assert_eq!(
+            env_of(&command, ZENOH_CONFIG_PATH_ENV),
             None,
-            "a forged runtime config must not reach a custom node"
+            "a daemon-level zenoh config must still reach its nodes by inheritance"
         );
     }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -175,7 +175,7 @@ The daemon runs one per machine and manages the lifecycle of all nodes on that m
 1. Create working directory for the node
 2. Set up communication channel (TCP or shmem)
 3. Serialize `NodeConfig` to environment variable
-4. Spawn process with sanitized environment (blocks `LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`, etc.)
+4. Spawn process with sanitized environment (blocks `LD_PRELOAD`, `DYLD_INSERT_LIBRARIES`, etc.; descriptor `env:` entries cannot override the daemon's own control-plane variables — `DORA_NODE_CONFIG`, `DORA_RUNTIME_CONFIG`, `DORA_ZENOH_*`)
 5. Monitor via `ProcessHandle`
 
 ### Runtime

--- a/docs/yaml-spec.md
+++ b/docs/yaml-spec.md
@@ -274,6 +274,17 @@ env:
 
 Environment variables apply to both `build` commands and node execution. Values support `$VAR` expansion syntax.
 
+Some names are reserved and are dropped (with a warning in the daemon log) when set on a node:
+
+| Reserved | Why |
+|----------|-----|
+| `DORA_NODE_CONFIG`, `DORA_RUNTIME_CONFIG` | The daemon's own handle to the node — dataflow id, node id, and how to reach the daemon |
+| `DORA_ZENOH_LISTEN`, `DORA_ZENOH_CONNECT`, `DORA_ZENOH_MULTICAST`, `ZENOH_CONFIG` | Node-to-node wiring. Overriding these produces a dataflow that starts cleanly and then exchanges nothing. Set `ZENOH_CONFIG` in the daemon's own environment instead — nodes inherit it |
+| `LD_PRELOAD`, `LD_AUDIT`, `LD_LIBRARY_PATH`, `DYLD_INSERT_LIBRARIES`, `DYLD_LIBRARY_PATH` | Loader hijacking |
+| `DORA_AUTH_TOKEN`, `DORA_ALLOW_SHELL_NODES` | Daemon-level security settings |
+
+Names that are empty or contain `=`, whitespace, or NUL are rejected as well.
+
 ### Logging
 
 | Field | Type | Default | Description |

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -84,6 +84,19 @@ fn multicast_disabled_by_env() -> bool {
     multicast_disabled_by_value(std::env::var(DORA_ZENOH_MULTICAST_ENV).ok().as_deref())
 }
 
+/// The effective decision for a process that also has its own request.
+///
+/// [`open_zenoh_session_with_listen`] ORs the caller's request with
+/// [`DORA_ZENOH_MULTICAST_ENV`], so a process that has to *forward* its
+/// decision — the daemon, to the nodes it spawns — must OR them the same way.
+/// Forwarding only its own flag drops the environment half, leaving nodes
+/// scouting by multicast in exactly the environments where the variable was
+/// set to stop them.
+#[cfg(feature = "zenoh")]
+pub fn multicast_disabled(requested_off: bool) -> bool {
+    requested_off || multicast_disabled_by_env()
+}
+
 /// Parse a [`DORA_ZENOH_MULTICAST_ENV`] value (`None` when the var is unset).
 ///
 /// Split from [`multicast_disabled_by_env`] so it is testable without mutating
@@ -354,7 +367,7 @@ pub async fn open_zenoh_session_with_listen(
             // multicast scouting only" and mean it. Treating the request as
             // absolute would disarm that recovery and strand the daemon.
             let requested_off =
-                matches!(multicast, MulticastScouting::Disabled) || multicast_disabled_by_env();
+                multicast_disabled(matches!(multicast, MulticastScouting::Disabled));
             if (connect_inserted || (requested_off && listen_configured))
                 && let Err(err) = zenoh_config.insert_json5("scouting/multicast/enabled", "false")
             {
@@ -738,6 +751,16 @@ mod tests {
                 "{value:?} must not disable multicast scouting"
             );
         }
+    }
+
+    /// A caller's own request must survive the fold, whatever the environment
+    /// says. The environment half is covered by the value tests above; this
+    /// pins that [`multicast_disabled`] never *weakens* an explicit request —
+    /// the daemon forwards its result to every node it spawns.
+    #[cfg(feature = "zenoh")]
+    #[test]
+    fn an_explicit_multicast_disable_is_never_lost() {
+        assert!(multicast_disabled(true));
     }
 
     #[test]

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -50,6 +50,18 @@ pub const DORA_ZENOH_LISTEN_ENV: &str = "DORA_ZENOH_LISTEN";
 /// `--zenoh-no-multicast`, so a single flag covers the whole process tree.
 pub const DORA_ZENOH_MULTICAST_ENV: &str = "DORA_ZENOH_MULTICAST";
 
+/// Zenoh's own config-file override, honored by
+/// [`open_zenoh_session_with_listen`].
+///
+/// Takes precedence over every `DORA_ZENOH_*` variable: when it is set the
+/// session is built entirely from the named file, so the connect/listen plan
+/// and the multicast decision are never read. That makes it a full bypass of
+/// the daemon's node wiring, which is why the daemon refuses it from a
+/// descriptor's `env:` (#2944) while still honoring it from its own
+/// environment — the documented way to point a whole deployment at a custom
+/// zenoh config.
+pub const ZENOH_CONFIG_PATH_ENV: &str = zenoh::Config::DEFAULT_CONFIG_PATH_ENV;
+
 /// Whether a session may discover peers by multicast scouting.
 ///
 /// Spelled as an enum rather than a bool because the concept flips polarity at


### PR DESCRIPTION
Closes #2944.

## Problem

In both spawn paths the daemon injected `DORA_NODE_CONFIG` / `DORA_RUNTIME_CONFIG` and the `DORA_ZENOH_*` wiring **before** applying descriptor `env:` entries, and `is_denied_env` did not cover those keys — so a later `.env()` from the descriptor won. A forged `DORA_ZENOH_CONNECT` cuts a node off from its peers: the dataflow starts cleanly and silently exchanges nothing. `DORA_NODE_CONFIG` was safe only because `spawn_inner` re-serializes it after command build (a restart-count fix, not a security measure).

## Fix

Both defenses suggested in the issue, so the protection is layered and intentional:

1. **Deny with a warning** — new `CONTROL_PLANE_ENV` list (`DORA_NODE_CONFIG`, `DORA_RUNTIME_CONFIG`, `DORA_ZENOH_LISTEN`, `DORA_ZENOH_CONNECT`, `DORA_ZENOH_MULTICAST`) checked by `is_denied_env` with a wiring-specific message, turning a silent misconfiguration into a visible one. Matching is now **case-insensitive** for both lists: Windows env vars are case-insensitive (and last-insert-wins in the std `Command` env map), so `dora_zenoh_connect:` would otherwise bypass both defenses there.
2. **Inject last** — both spawn paths now apply descriptor env first (`apply_descriptor_env`, which also dedups the three copy-pasted env loops) and inject the daemon's variables afterwards (`inject_control_plane_env`), so the daemon's wiring wins by construction even for a control-plane key the list misses.

`strip_denied_env` intentionally still strips only the original `ENV_DENYLIST`: ambient `DORA_ZENOH_*` inheritance from the daemon's environment (e.g. an externally configured router) is untouched.

## Tests

- `reserved_control_plane_keys_are_denied` — all five keys plus case variants are denied; ordinary vars pass.
- `descriptor_env_cannot_override_the_daemons_wiring` — pins both defenses independently: forged descriptor entries are dropped, and a pre-seeded forged `DORA_NODE_CONFIG` (bypassing the denylist) is still overwritten by inject-last ordering; a wiring variable the daemon did not inject does not appear at all.

## Validation

- `make qa-fast` (fmt, clippy `-D warnings`, audit, unwrap budget, typos) clean
- `cargo test -p dora-daemon --lib`: 173 passed
- full workspace tests + `cargo check --examples` + `replace_swaps_running_node_without_blaming_successor` e2e (real spawn through the modified path) green

## Follow-up candidate (not this PR)

The deny warning surfaces in the daemon log at spawn time; descriptor validation (`libraries/core/src/descriptor/validate.rs`) is env-blind, so `dora build`/`dora start` give no CLI-visible feedback for a reserved key in `env:`. A validation-time warning would surface it where the author is looking — same follow-up shape as the existing `ENV_DENYLIST` behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
