### PR TITLE
docs(cli): fix misattached --env / --exit-when-nodes-finish help in `dora start`

### DIFF
--- a/binaries/cli/src/command/start/mod.rs
+++ b/binaries/cli/src/command/start/mod.rs
@@ -47,19 +47,6 @@ pub struct Start {
     /// Enable debug mode (publishes all messages to Zenoh for topic echo/hz/info)
     #[clap(long, action)]
     debug: bool,
-    /// Set an environment variable for every node of this dataflow
-    /// (repeatable). Merges into the dataflow-level `env:` block;
-    /// node-level `env:` entries still win on conflict.
-    ///
-    /// Nodes started via `dora start` are spawned by the DAEMON and do
-    /// NOT inherit this CLI invocation's environment — `--env` is the
-    /// supported way to parameterize a run without editing the YAML.
-    /// Applies at spawn time only; `build:` commands are unaffected.
-    /// Values must survive the descriptor encoding verbatim: a literal
-    /// `$` is refused (the receiving process would expand it) and so are
-    /// numeric-looking values that would be coerced. They are also
-    /// persisted with the dataflow in the coordinator's state store and
-    /// visible in `ps` — prefer a node `env:` block for secrets.
     /// Exit once every node has finished, treating `dora/timer/...`
     /// inputs as a clock rather than as work.
     ///
@@ -84,6 +71,19 @@ pub struct Start {
         value_name = "BOOL"
     )]
     pub exit_when_nodes_finish: Option<bool>,
+    /// Set an environment variable for every node of this dataflow
+    /// (repeatable). Merges into the dataflow-level `env:` block;
+    /// node-level `env:` entries still win on conflict.
+    ///
+    /// Nodes started via `dora start` are spawned by the DAEMON and do
+    /// NOT inherit this CLI invocation's environment — `--env` is the
+    /// supported way to parameterize a run without editing the YAML.
+    /// Applies at spawn time only; `build:` commands are unaffected.
+    /// Values must survive the descriptor encoding verbatim: a literal
+    /// `$` is refused (the receiving process would expand it) and so are
+    /// numeric-looking values that would be coerced. They are also
+    /// persisted with the dataflow in the coordinator's state store and
+    /// visible in `ps` — prefer a node `env:` block for secrets.
     #[clap(long = "env", value_name = "KEY=VALUE")]
     env: Vec<String>,
 }


### PR DESCRIPTION
## Issue

In `binaries/cli/src/command/start/mod.rs`, the doc comment describing `--env` ran — with no separating field between them — straight into the `--exit-when-nodes-finish` documentation, and the whole merged `///` block was attached to the `exit_when_nodes_finish` field. The `env` field that followed had **no** doc comment at all.

As a result, `dora start --help` printed the entire *"Set an environment variable…"* paragraph as the description of `--exit-when-nodes-finish`, while `--env` itself showed no description.

## Fix

Split the block so each flag documents its own field, mirroring the already-correct layout in `dora run` (`binaries/cli/src/command/run.rs`). No behavior change — this is a rustdoc / clap-help attribution fix only.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p dora-cli -- -D warnings`

Both pass. Also verified as part of a combined full-workspace `cargo test` run across all three of this run's changes.

---

⚠️ **This pull request was generated autonomously by Claude (an AI agent).** It is machine-generated; please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ltyvv3SpFoRwR3ckEDUpjQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ltyvv3SpFoRwR3ckEDUpjQ)_