### PR TITLE
fix(core): gate ZENOH_CONFIG_PATH_ENV behind the zenoh feature

### DIFF
--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -60,6 +60,7 @@ pub const DORA_ZENOH_MULTICAST_ENV: &str = "DORA_ZENOH_MULTICAST";
 /// descriptor's `env:` (#2944) while still honoring it from its own
 /// environment — the documented way to point a whole deployment at a custom
 /// zenoh config.
+#[cfg(feature = "zenoh")]
 pub const ZENOH_CONFIG_PATH_ENV: &str = zenoh::Config::DEFAULT_CONFIG_PATH_ENV;
 
 /// Whether a session may discover peers by multicast scouting.


### PR DESCRIPTION
## Summary

Fixes #2995.

`libraries/core/src/topics.rs` defined:

```rust
pub const ZENOH_CONFIG_PATH_ENV: &str = zenoh::Config::DEFAULT_CONFIG_PATH_ENV;
```

with no `#[cfg(feature = "zenoh")]` gate, even though `zenoh` is an **optional, non-default** dependency of `dora-core` and every neighboring zenoh-touching item in the file is already gated. As a result, any build of the crate that did not enable the feature failed to compile:

```
error[E0433]: failed to resolve: use of unresolved module or unlinked crate `zenoh`
```

This broke the documented fast single-crate loop (`cargo build -p dora-core`, `cargo test -p dora-core`) and isolated builds of downstream crates that depend on `dora-core` without the feature (`dora-runtime`, `dora-hub-client`). Whole-workspace `--all` builds stayed green because feature unification turns the feature on via the daemon/CLI/coordinator.

## Fix

Add the `#[cfg(feature = "zenoh")]` gate to match its neighbors. The only consumer is the daemon spawner (`binaries/daemon/src/spawn/spawner.rs`), which always enables `dora-core/zenoh` (`features = ["build", "zenoh"]`), so gating is safe.

## Verification

- `cargo build -p dora-core` — now **Finished** (previously E0433).
- `cargo build -p dora-core --features zenoh` — Finished.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VSeehXFhKtMyFH67mSLBYt)_