### PR TITLE
fix(coordinator): box CachedResult::Cached to fix large_enum_variant on Windows

### DIFF
--- a/binaries/coordinator/src/state.rs
+++ b/binaries/coordinator/src/state.rs
@@ -486,7 +486,9 @@ impl RunningDataflow {
             node_stopped_at: BTreeMap::new(),
             network_metrics: None,
             spawn_result: CachedResult::Cached {
-                result: Ok(ControlRequestReply::DataflowSpawned { uuid: record.uuid }),
+                result: Box::new(Ok(ControlRequestReply::DataflowSpawned {
+                    uuid: record.uuid,
+                })),
             },
             stop_reply_senders: Vec::new(),
             buffered_log_messages: Vec::new(),
@@ -541,8 +543,11 @@ pub(crate) enum CachedResult {
     Pending {
         result_senders: Vec<oneshot::Sender<eyre::Result<ControlRequestReply>>>,
     },
+    // Boxed because `ControlRequestReply` is large: without the box the
+    // `Cached` variant dwarfs `Pending`, which trips clippy's
+    // `large_enum_variant` on some targets (e.g. Windows) but not others (#2979).
     Cached {
-        result: eyre::Result<ControlRequestReply>,
+        result: Box<eyre::Result<ControlRequestReply>>,
     },
 }
 
@@ -573,7 +578,9 @@ impl CachedResult {
                 for sender in result_senders.drain(..) {
                     Self::send_result_to(&result, sender);
                 }
-                *self = CachedResult::Cached { result };
+                *self = CachedResult::Cached {
+                    result: Box::new(result),
+                };
             }
             CachedResult::Cached { .. } => {}
         }
@@ -592,7 +599,7 @@ impl CachedResult {
     /// the spawn-timeout watchdog (or any other terminal-failure path)
     /// has already marked as failed.
     pub(crate) fn is_terminal_error(&self) -> bool {
-        matches!(self, CachedResult::Cached { result: Err(_) })
+        matches!(self, CachedResult::Cached { result } if result.is_err())
     }
 
     /// Returns `true` if a successful result has been cached, i.e. the dataflow
@@ -601,7 +608,7 @@ impl CachedResult {
     /// that are past spawn — spawn-pending ones remain the spawn-timeout
     /// watchdog's domain. See #2028.
     pub(crate) fn is_cached_ok(&self) -> bool {
-        matches!(self, CachedResult::Cached { result: Ok(_) })
+        matches!(self, CachedResult::Cached { result } if result.is_ok())
     }
 
     fn send_result_to(


### PR DESCRIPTION
## Summary

Fixes #2979.

`CachedResult` in `binaries/coordinator/src/state.rs` had one large variant and one small one:

```rust
pub(crate) enum CachedResult {
    Pending { result_senders: Vec<oneshot::Sender<eyre::Result<ControlRequestReply>>> },
    Cached  { result: eyre::Result<ControlRequestReply> },  // large
}
```

`ControlRequestReply` is large, so `Cached` dwarfs `Pending`. Clippy's `large_enum_variant` heuristic flags this **on some targets (Windows) but not others (Linux)** for identical code, toolchain (1.97.1), and lockfile. Because PR CI only runs `clippy` on ubuntu-latest, `cargo clippy --all -- -D warnings` — the documented cross-platform pre-commit/pre-push gate — passed in CI yet failed for Windows contributors running the exact command the docs tell them to.

## Fix

Box the `result` field so `Cached` becomes a single pointer, making the two variants comparable in size:

```rust
    Cached { result: Box<eyre::Result<ControlRequestReply>> },
```

The two `matches!` arms that destructured the field (`is_terminal_error`, `is_cached_ok`) are rewritten with `.is_err()` / `.is_ok()` guards, since box deref-patterns are unstable. All construction sites now `Box::new(...)` the result. `send_result_to` is unchanged — `&Box<T>` deref-coerces to `&T` at the call sites.

## Verification

- `cargo clippy -p dora-coordinator --all-targets -- -D warnings` — passes (exit 0).
- `cargo test -p dora-coordinator --lib` — `110 passed; 0 failed`.

Note: because the lint only fires on Windows, the fix can't be observed to remove the diagnostic on this Linux runner, but it is a strict size reduction of the flagged variant and the behavior-preserving change is covered by the existing lib tests (including the reconstruction test that asserts on `CachedResult::Cached { result } if result.is_ok()`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01VSeehXFhKtMyFH67mSLBYt)_