### PR TITLE
fix(daemon): don't kill the daemon on a non-dynamic node's late stop event

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -5092,9 +5092,24 @@ impl Daemon {
                 );
                 return Ok(());
             }
-            None => eyre::bail!(
-                "failed to get downstream nodes: no running dataflow with ID `{dataflow_id}`"
-            ),
+            None => {
+                // The dataflow finished before this non-dynamic node's stop
+                // event was processed. A node's exit and its `SpawnNodeResult`
+                // arrive on independent paths, so `should_finish` can conclude
+                // the dataflow is done (every remaining `running_nodes` entry is
+                // dynamic) and `finish_dataflow` can run before this stop lands
+                // — the same "two independent paths" ordering that produced the
+                // late-output race fixed in #2742, just narrower. Bailing here
+                // returns `Err` up through the daemon's main loop, unwinding
+                // `run()` and tearing down the coordinator connection (or
+                // failing the whole `dora run`). Treat the missing dataflow as
+                // benign — matching the `dynamic_node` arm above and the
+                // late-output handling in `send_out`/`output_sent`. Kept at
+                // `warn` rather than `debug` because a non-dynamic node arriving
+                // late is less expected than a dynamic one (#2986).
+                tracing::warn!("node {dataflow_id}/{node_id} stopped after dataflow was done");
+                return Ok(());
+            }
         };
 
         dataflow


### PR DESCRIPTION
## Summary

Fixes #2986.

`handle_node_stop_inner` (`binaries/daemon/src/lib.rs`) bailed with an error when a **non-dynamic** node's stop was processed after its dataflow had already finished:

```rust
None => eyre::bail!(
    "failed to get downstream nodes: no running dataflow with ID `{dataflow_id}`"
),
```

That `Err` propagates via `?` through the daemon's main loop (the `Event::SpawnNodeResult` Err arm and `DoraEvent::SpawnedNodeResult`), unwinding `run()`. In practice the daemon then drops its coordinator connection and re-adopts, or under `dora run` (in-process daemon) fails the whole run:

```
daemon disconnected from coordinator: ... no running dataflow with ID `...`. Attempting reconnect...
```

A node's exit and its `SpawnNodeResult` arrive on independent paths, so `should_finish` can conclude the dataflow is done (every remaining `running_nodes` entry is dynamic) and `finish_dataflow` can run before a non-dynamic node's stop lands. This is the same "two independent paths" ordering behind the late-output race fixed in #2742 — just narrower, which is why it was left out of that fix rather than patched speculatively. It's the last reply-less arm of `handle_node_event` that still treats a missing dataflow as fatal; `handle_dora_event`, `handle_inter_daemon_event`, `handle_dynamic_node_event`, `handle_debug_topic_data`, and `handle_coordinator_event` already handle it non-fatally.

## Fix

Treat the missing dataflow as benign — log and return `Ok(())`, matching the `dynamic_node` arm directly above and the `log_late_node_output` treatment in `send_out`/`output_sent`. Kept at `warn` (not `debug`) because a non-dynamic node arriving late is less expected than a dynamic one.

## Verification

- `cargo check -p dora-daemon` — Finished (exit 0).
- `cargo clippy -p dora-daemon` — Finished, no warnings.
- `cargo fmt --all -- --check` — clean.

## Testing note

The issue suggests a regression test in `tests/daemon-reconnect-e2e.rs` alongside a `late_output_from_a_finished_dataflow_does_not_kill_the_daemon` structural test. That sibling test does not yet exist in the tree (it was referenced from the #2742 work), and this defect is a timing-dependent race with no deterministic structural trigger for the *non-dynamic* path — a node must lose the race between its `Subscribe`/`SpawnNodeResult` path and `finish_dataflow`. Rather than land a flaky test, this PR ships the behavior-preserving fix (which strictly mirrors the already-tested sibling arm). Happy to add a structural e2e test if a maintainer can point to the intended harness for forcing this ordering.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VSeehXFhKtMyFH67mSLBYt)_