### PR TITLE
fix(cli): apply --exit-when-nodes-finish after the hub fingerprint gate

### DIFF
--- a/binaries/cli/src/command/start/mod.rs
+++ b/binaries/cli/src/command/start/mod.rs
@@ -16,7 +16,12 @@ use crate::{
 use dora_core::descriptor::{Descriptor, DescriptorExt};
 use dora_message::{cli_to_coordinator::ControlRequest, common::LogMessage, descriptor::EnvValue};
 use eyre::Context;
-use std::{collections::BTreeMap, io::IsTerminal, net::SocketAddr, path::PathBuf};
+use std::{
+    collections::BTreeMap,
+    io::IsTerminal,
+    net::SocketAddr,
+    path::{Path, PathBuf},
+};
 use uuid::Uuid;
 
 mod attach;
@@ -156,11 +161,54 @@ fn start_dataflow(
     exit_when_nodes_finish: Option<bool>,
 ) -> Result<(PathBuf, Descriptor, WsSession, Uuid), eyre::Error> {
     let dataflow = resolve_dataflow(dataflow).context("could not resolve dataflow")?;
+    // No extra context on the error: every failure inside already carries a
+    // user-facing, actionable message.
+    let (dataflow_descriptor, dataflow_session) =
+        prepare_descriptor(&dataflow, debug, env_overrides, exit_when_nodes_finish)?;
+
+    let session = connect_to_coordinator(coordinator_socket)?;
+
+    let local_working_dir = local_working_dir(&dataflow, &dataflow_descriptor, &session)?;
+
+    let dataflow_id = {
+        let dataflow = dataflow_descriptor.clone();
+        let reply = send_control_request(
+            &session,
+            &ControlRequest::Start {
+                build_id: dataflow_session.build_id,
+                session_id: dataflow_session.session_id,
+                dataflow,
+                name,
+                local_working_dir,
+                uv,
+                write_events_to: write_events_to(),
+            },
+        )?;
+        let uuid = expect_reply!(reply, DataflowStartTriggered { uuid })?;
+        println!("dataflow start triggered: {uuid}");
+        uuid
+    };
+    Ok((dataflow, dataflow_descriptor, session, dataflow_id))
+}
+
+/// Read, expand and finalize the descriptor that `dora start` hands to the
+/// coordinator, together with the dataflow session it belongs to.
+///
+/// Split out of [`start_dataflow`] because the order of the steps below is
+/// load-bearing (see the `--env` / `--exit-when-nodes-finish` comments) and
+/// everything here is filesystem-only — the network starts at
+/// `connect_to_coordinator`, so this half is unit-testable on its own.
+fn prepare_descriptor(
+    dataflow: &Path,
+    debug: bool,
+    env_overrides: BTreeMap<String, EnvValue>,
+    exit_when_nodes_finish: Option<bool>,
+) -> eyre::Result<(Descriptor, DataflowSession)> {
     let working_dir = dataflow
         .parent()
         .filter(|p| !p.as_os_str().is_empty())
         .unwrap_or_else(|| std::path::Path::new("."));
-    let mut dataflow_descriptor = Descriptor::blocking_read(&dataflow)
+    let mut dataflow_descriptor = Descriptor::blocking_read(dataflow)
         .wrap_err_with(|| {
             format!(
                 "failed to read dataflow at `{}`\n\n  \
@@ -171,7 +219,7 @@ fn start_dataflow(
         .expand(working_dir)
         .wrap_err("failed to expand modules in dataflow descriptor")?;
     let mut dataflow_session =
-        DataflowSession::read_session(&dataflow).context("failed to read DataflowSession")?;
+        DataflowSession::read_session(dataflow).context("failed to read DataflowSession")?;
     // `hub:` references are desugared by `dora build`, which stores the
     // resolved descriptor in the session — `dora start` requires that prior
     // build, exactly like git sources require a prior clone. Compare the
@@ -201,7 +249,7 @@ fn start_dataflow(
         .context("failed to resolve nodes for session fingerprint")?;
     if dataflow_session.invalidate_if_build_inputs_changed(&resolved_for_fingerprint) {
         dataflow_session
-            .write_out_for_dataflow(&dataflow)
+            .write_out_for_dataflow(dataflow)
             .context("failed to persist invalidated dataflow session")?;
     }
     drop(resolved_for_fingerprint);
@@ -248,29 +296,7 @@ fn start_dataflow(
     // stands.
     dataflow_descriptor.apply_exit_when_nodes_finish(exit_when_nodes_finish);
 
-    let session = connect_to_coordinator(coordinator_socket)?;
-
-    let local_working_dir = local_working_dir(&dataflow, &dataflow_descriptor, &session)?;
-
-    let dataflow_id = {
-        let dataflow = dataflow_descriptor.clone();
-        let reply = send_control_request(
-            &session,
-            &ControlRequest::Start {
-                build_id: dataflow_session.build_id,
-                session_id: dataflow_session.session_id,
-                dataflow,
-                name,
-                local_working_dir,
-                uv,
-                write_events_to: write_events_to(),
-            },
-        )?;
-        let uuid = expect_reply!(reply, DataflowStartTriggered { uuid })?;
-        println!("dataflow start triggered: {uuid}");
-        uuid
-    };
-    Ok((dataflow, dataflow_descriptor, session, dataflow_id))
+    Ok((dataflow_descriptor, dataflow_session))
 }
 
 fn wait_until_dataflow_started(
@@ -371,5 +397,92 @@ mod tests {
         assert!(!local_build_blocks_distributed_start(true, false));
         // nothing built: nothing to block -> allow.
         assert!(!local_build_blocks_distributed_start(false, false));
+    }
+
+    /// A `hub:` dataflow on disk plus the session `dora build` would have left
+    /// behind: the desugared descriptor and the digest of the source it was
+    /// desugared from. Returns the dataflow path.
+    fn hub_dataflow_fixture(dir: &Path, source: &str, resolved: &str) -> PathBuf {
+        std::fs::create_dir_all(dir).unwrap();
+        let dataflow = dir.join("hubflow.yml");
+        std::fs::write(&dataflow, source).unwrap();
+
+        let expanded = Descriptor::parse(source.as_bytes().to_vec())
+            .unwrap()
+            .expand(dir)
+            .unwrap();
+        let resolved = Descriptor::parse(resolved.as_bytes().to_vec()).unwrap();
+        let session = DataflowSession {
+            source_fingerprint: DataflowSession::fingerprint_source(&expanded),
+            resolved_dataflow: Some(resolved.clone()),
+            // matching, so `invalidate_if_build_inputs_changed` stays inert
+            // and the fixture models a dataflow that is up to date with its
+            // build rather than one that needs rebuilding.
+            build_fingerprint: Some(DataflowSession::fingerprint_build_inputs(
+                &resolved.resolve_aliases_and_set_defaults().unwrap(),
+            )),
+            ..Default::default()
+        };
+        session.write_out_for_dataflow(&dataflow).unwrap();
+        dataflow
+    }
+
+    const HUB_SOURCE: &str = "nodes:\n  - id: a\n    hub: dora-yolo@^0.5\n";
+    const HUB_RESOLVED: &str = "nodes:\n  - id: a\n    path: ./a\n";
+
+    #[test]
+    fn hub_start_applies_exit_when_nodes_finish_in_both_directions() {
+        // Regression test for #2996. `--exit-when-nodes-finish` used to be
+        // folded into the descriptor *before* the hub build-fingerprint gate.
+        // The field is serialized, so an override that differed from the
+        // on-disk YAML moved `fingerprint_source` and made this exact
+        // invocation bail with "changed since the last `dora build`" — and on
+        // the paths where the digest still matched, the gate's
+        // `dataflow_descriptor = resolved` dropped the flag instead. Both
+        // directions of the override have to survive to the final descriptor.
+        let dir = tempfile::tempdir().unwrap();
+
+        // YAML says nothing -> the flag turns it on.
+        let dataflow = hub_dataflow_fixture(dir.path(), HUB_SOURCE, HUB_RESOLVED);
+        let (descriptor, _) =
+            prepare_descriptor(&dataflow, false, BTreeMap::new(), Some(true)).unwrap();
+        assert_eq!(descriptor.exit_when_nodes_finish, Some(true));
+        // and we are looking at the hub-resolved descriptor, not the on-disk one
+        assert!(descriptor.nodes.iter().all(|n| n.hub.is_none()));
+
+        // omitted -> the descriptor's own setting stands, untouched.
+        let (descriptor, _) = prepare_descriptor(&dataflow, false, BTreeMap::new(), None).unwrap();
+        assert_eq!(descriptor.exit_when_nodes_finish, None);
+
+        // YAML says `true` -> the documented `=false` force-off must apply.
+        let on = "exit_when_nodes_finish: true\n";
+        let dataflow = hub_dataflow_fixture(
+            &dir.path().join("forced"),
+            &format!("{on}{HUB_SOURCE}"),
+            &format!("{on}{HUB_RESOLVED}"),
+        );
+        let (descriptor, _) =
+            prepare_descriptor(&dataflow, false, BTreeMap::new(), Some(false)).unwrap();
+        assert_eq!(descriptor.exit_when_nodes_finish, Some(false));
+
+        let (descriptor, _) = prepare_descriptor(&dataflow, false, BTreeMap::new(), None).unwrap();
+        assert_eq!(descriptor.exit_when_nodes_finish, Some(true));
+    }
+
+    #[test]
+    fn hub_start_still_rejects_a_dataflow_edited_since_the_build() {
+        // Taking the flag out of `fingerprint_source` must not disarm the
+        // staleness gate: a real on-disk edit still has to be caught, because
+        // `dora start` cannot re-resolve `hub:` references itself.
+        let dir = tempfile::tempdir().unwrap();
+        let dataflow = hub_dataflow_fixture(dir.path(), HUB_SOURCE, HUB_RESOLVED);
+        std::fs::write(&dataflow, format!("{HUB_SOURCE}  - id: b\n    path: ./b\n")).unwrap();
+
+        let err = prepare_descriptor(&dataflow, false, BTreeMap::new(), Some(true)).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("changed since the last `dora build`"),
+            "expected the staleness bail, got: {err:#}"
+        );
     }
 }

--- a/binaries/cli/src/command/start/mod.rs
+++ b/binaries/cli/src/command/start/mod.rs
@@ -170,11 +170,6 @@ fn start_dataflow(
         })?
         .expand(working_dir)
         .wrap_err("failed to expand modules in dataflow descriptor")?;
-    // Fold the flag into the descriptor, which is what the daemon reads
-    // and the one copy that survives auto-recovery, coordinator restart
-    // and `dora restart` (#2920). Given, it overrides the descriptor in
-    // either direction; omitted, the descriptor's own setting stands.
-    dataflow_descriptor.apply_exit_when_nodes_finish(exit_when_nodes_finish);
     let mut dataflow_session =
         DataflowSession::read_session(&dataflow).context("failed to read DataflowSession")?;
     // `hub:` references are desugared by `dora build`, which stores the
@@ -240,6 +235,18 @@ fn start_dataflow(
     // earlier would reject hub dataflows as "changed since build" and
     // invalidate the cached build id on every `--env` change.
     crate::env_overrides::apply_env_overrides(&mut dataflow_descriptor, env_overrides);
+
+    // Fold `--exit-when-nodes-finish` in LAST, for the same reason as `--env`
+    // above: it is a spawn-time override that mutates a serialized descriptor
+    // field, so applying it before the hub block moved `fingerprint_source`
+    // and made hub dataflows bail with a misleading "changed since the last
+    // `dora build`" (and the hub block then discarded the flag anyway) —
+    // #2996. Here it lands on the final, hub-resolved descriptor, which is
+    // what the daemon reads and the one copy that survives auto-recovery,
+    // coordinator restart and `dora restart` (#2920). Given, it overrides the
+    // descriptor in either direction; omitted, the descriptor's own setting
+    // stands.
+    dataflow_descriptor.apply_exit_when_nodes_finish(exit_when_nodes_finish);
 
     let session = connect_to_coordinator(coordinator_socket)?;
 

--- a/binaries/cli/src/command/start/mod.rs
+++ b/binaries/cli/src/command/start/mod.rs
@@ -170,11 +170,6 @@ fn start_dataflow(
         })?
         .expand(working_dir)
         .wrap_err("failed to expand modules in dataflow descriptor")?;
-    // Fold the flag into the descriptor, which is what the daemon reads
-    // and the one copy that survives auto-recovery, coordinator restart
-    // and `dora restart` (#2920). Given, it overrides the descriptor in
-    // either direction; omitted, the descriptor's own setting stands.
-    dataflow_descriptor.apply_exit_when_nodes_finish(exit_when_nodes_finish);
     let mut dataflow_session =
         DataflowSession::read_session(&dataflow).context("failed to read DataflowSession")?;
     // `hub:` references are desugared by `dora build`, which stores the
@@ -240,6 +235,21 @@ fn start_dataflow(
     // earlier would reject hub dataflows as "changed since build" and
     // invalidate the cached build id on every `--env` change.
     crate::env_overrides::apply_env_overrides(&mut dataflow_descriptor, env_overrides);
+
+    // Fold the `--exit-when-nodes-finish` flag into the descriptor LAST, for
+    // the same reason `--env` is merged last (see above): it is a spawn-time
+    // override, not a build input, so it must not be part of the hub
+    // `fingerprint_source` comparison. Applied before the hub block, a value
+    // differing from the on-disk YAML changed the serialized
+    // descriptor and its fingerprint, making a `hub:` dataflow bail with a
+    // misleading "changed since the last `dora build`" error — and the hub
+    // block's `dataflow_descriptor = resolved` then discarded the flag anyway
+    // (#2996). Folding it in here targets the final (hub-resolved) descriptor,
+    // which is what the daemon reads and the one copy that survives
+    // auto-recovery, coordinator restart and `dora restart` (#2920). Given, it
+    // overrides the descriptor in either direction; omitted, the descriptor's
+    // own setting stands.
+    dataflow_descriptor.apply_exit_when_nodes_finish(exit_when_nodes_finish);
 
     let session = connect_to_coordinator(coordinator_socket)?;
 


### PR DESCRIPTION
Fixes #2996.

`dora start` folded the `--exit-when-nodes-finish` override into the descriptor **before** the `hub:` build-fingerprint check. The descriptor field is serialized (skipped only when `None`), so an override that differed from the on-disk YAML changed the serialized descriptor and therefore its `fingerprint_source` hash. On a hub dataflow the flag either bailed with a misleading `this dataflow changed since the last dora build` error, or got silently dropped when the hub block's `dataflow_descriptor = resolved` overwrote it — so it only ever "worked" when it agreed with what the YAML already said.

It is now applied after the hub block and the build-input invalidation, next to `apply_env_overrides`: both are spawn-time inputs, not build inputs, so neither belongs in the build fingerprint. That is also the ordering `dora run` already uses (the daemon applies it after consuming the resolved descriptor). `dora run` and non-hub `dora start` are unaffected.

To make the ordering testable without a coordinator, the descriptor-preparation half of `start_dataflow` is split into `prepare_descriptor` — everything in it is filesystem-only; the network starts at `connect_to_coordinator`. The new tests build a `hub:` dataflow plus the session `dora build` would have left behind, then assert the override reaches the final hub-resolved descriptor in both directions (`--exit-when-nodes-finish` and the documented `=false` force-off), that an omitted flag leaves the descriptor alone, and that a genuine on-disk edit is still rejected by the staleness gate.
