### PR TITLE
fix(daemon): reap node processes before a destroy replies

### DIFF
--- a/binaries/coordinator/src/handlers.rs
+++ b/binaries/coordinator/src/handlers.rs
@@ -188,6 +188,15 @@ pub(crate) async fn handle_destroy(
         }
     }
 
+    // `stop_dataflow` returns once the daemons have acknowledged the
+    // *request*; the grace → SIGTERM → SIGKILL ladder then runs inside each
+    // daemon, long after this returns. Destroying them here used to race that
+    // ladder and orphan any node that ignored the cooperative `Stop`
+    // (dora-rs/dora#2980). The wait now lives in the daemon's `Destroy`
+    // handler, which reaps its own children before it replies — so this await
+    // is what makes `dora down` return only after the nodes are gone, for
+    // every route that reaches `Destroy` (`dora cluster down`, Ctrl-C, and
+    // any direct control-protocol client).
     destroy_daemons(daemon_connections, clock.new_timestamp()).await?;
     // Brief grace period so daemons have time to flush final messages and
     // close their WS connections before the coordinator shuts down the

--- a/binaries/daemon/src/event_types.rs
+++ b/binaries/daemon/src/event_types.rs
@@ -46,6 +46,8 @@ pub enum Event {
     Dora(DoraEvent),
     DynamicNode(DynamicNodeEventWrapper),
     HeartbeatInterval,
+    /// Re-check whether a pending `Destroy`'s nodes have exited (#2980).
+    DestroyTick,
     MetricsInterval,
     NodeHealthCheckInterval,
     CtrlC,
@@ -102,6 +104,7 @@ impl Event {
             Event::Dora(_) => "Dora",
             Event::DynamicNode(_) => "DynamicNode",
             Event::HeartbeatInterval => "HeartbeatInterval",
+            Event::DestroyTick => "DestroyTick",
             Event::MetricsInterval => "MetricsInterval",
             Event::NodeHealthCheckInterval => "NodeHealthCheckInterval",
             Event::CtrlC => "CtrlC",

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -168,6 +168,7 @@ mod node_communication;
 mod output_routing;
 mod pending;
 pub(crate) mod running_dataflow;
+mod shutdown;
 mod socket_stream_utils;
 mod spawn;
 
@@ -301,6 +302,15 @@ impl RunDataflowOptions {
     }
 }
 
+/// A destroy waiting for the daemon's nodes to exit before it replies.
+///
+/// Holding the reply is what gives the coordinator — and therefore
+/// `dora down` — its synchronization: `destroy_daemons` awaits it.
+pub(crate) struct PendingDestroy {
+    reply_tx: oneshot::Sender<Option<DaemonCoordinatorReply>>,
+    wait: shutdown::DestroyWait,
+}
+
 pub struct Daemon {
     pub(crate) running: HashMap<DataflowId, RunningDataflow>,
     pub(crate) working_dir: HashMap<DataflowId, PathBuf>,
@@ -323,6 +333,9 @@ pub struct Daemon {
     /// scouting. Forwarded to spawned nodes so they discover the same way the
     /// daemon does (see `DORA_ZENOH_MULTICAST`).
     pub(crate) disable_multicast: bool,
+    /// A `Destroy` that is holding its reply until this daemon's node
+    /// processes are gone (#2980).
+    pub(crate) pending_destroy: Option<PendingDestroy>,
     pub(crate) zenoh_publish_tx: mpsc::Sender<ZenohOutbound>,
     pub(crate) remote_daemon_events_tx:
         Option<flume::Sender<eyre::Result<Timestamped<InterDaemonEvent>>>>,
@@ -1543,6 +1556,7 @@ impl Daemon {
             zenoh_session,
             zenoh_listen_endpoint,
             disable_multicast,
+            pending_destroy: None,
             zenoh_publish_tx,
             remote_daemon_events_tx,
             git_manager: Default::default(),
@@ -1711,6 +1725,11 @@ impl Daemon {
                 }
                 Event::Dora(event) => self.handle_dora_event(event).await?,
                 Event::DynamicNode(event) => self.handle_dynamic_node_event(event).await?,
+                Event::DestroyTick => {
+                    if self.handle_destroy_tick().await {
+                        break;
+                    }
+                }
                 Event::HeartbeatInterval => {
                     if let Some(sender) = &self.coordinator_sender {
                         let msg = serde_json::to_vec(&Timestamped {
@@ -1923,6 +1942,120 @@ impl Daemon {
         // `run_inner` borrows `&mut self`, so move the accumulated results out
         // (the daemon may be reused for a reconnect, where these are ignored).
         Ok(std::mem::take(&mut self.dataflow_node_results))
+    }
+
+    /// Hold a destroy until this daemon's nodes are gone, or hand the reply
+    /// channel back when there is nothing to wait for.
+    ///
+    /// Returning the channel means "reply and exit now"; keeping it means the
+    /// event loop stays alive, serving the shutdown handshakes of nodes that
+    /// are on their way out, until [`Self::handle_destroy_tick`] decides.
+    fn begin_pending_destroy(
+        &mut self,
+        reply_tx: oneshot::Sender<Option<DaemonCoordinatorReply>>,
+    ) -> Option<oneshot::Sender<Option<DaemonCoordinatorReply>>> {
+        if self.pending_destroy.is_some() {
+            // A second destroy while the first is still waiting: answer it,
+            // but let the original wait finish rather than exiting on top of
+            // it and orphaning the nodes it is still watching.
+            tokio::spawn(Self::finish_destroy(reply_tx));
+            return None;
+        }
+        if self.running_node_pids().is_empty() {
+            return Some(reply_tx);
+        }
+
+        self.pending_destroy = Some(PendingDestroy {
+            reply_tx,
+            wait: shutdown::DestroyWait::new(),
+        });
+        // Nothing else wakes the loop once the dataflows are stopping, so the
+        // wait needs its own tick. The task ends with the daemon, when the
+        // event channel closes.
+        let events_tx = self.events_tx.clone();
+        let clock = self.clock.clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(shutdown::POLL_INTERVAL).await;
+                let tick = Timestamped {
+                    inner: Event::DestroyTick,
+                    timestamp: clock.new_timestamp(),
+                };
+                if events_tx.send(tick).await.is_err() {
+                    break;
+                }
+            }
+        });
+        None
+    }
+
+    /// Re-check a pending destroy. Returns true when the daemon may exit.
+    async fn handle_destroy_tick(&mut self) -> bool {
+        if self.pending_destroy.is_none() {
+            return false;
+        }
+        let pids = self.running_node_pids();
+        let progress = self
+            .pending_destroy
+            .as_mut()
+            .expect("checked above")
+            .wait
+            .poll(&pids);
+
+        let survivors = match progress {
+            shutdown::DestroyProgress::Waiting => return false,
+            shutdown::DestroyProgress::Done => Vec::new(),
+            shutdown::DestroyProgress::Abandoned(survivors) => survivors,
+        };
+
+        let pending = self.pending_destroy.take().expect("checked above");
+        if !pending.wait.killed_pids.is_empty() {
+            tracing::warn!(
+                "killed {} node process(es) that were still running at destroy: {:?}",
+                pending.wait.killed_pids.len(),
+                pending.wait.killed_pids
+            );
+        }
+        if !survivors.is_empty() {
+            tracing::error!(
+                "{} node process(es) survived the destroy kill and are now orphaned: {survivors:?}",
+                survivors.len(),
+            );
+        }
+        Self::finish_destroy(pending.reply_tx).await;
+        true
+    }
+
+    /// Pids of every node process this daemon currently has running.
+    ///
+    /// Dynamic nodes have none: the daemon did not spawn them, so they are
+    /// not its children and it cannot reap them.
+    fn running_node_pids(&self) -> Vec<u32> {
+        self.running
+            .values()
+            .flat_map(|dataflow| dataflow.running_nodes.values())
+            .filter_map(|node| node.pid.as_ref())
+            // Zero means the entry exists but its process has not reported a
+            // pid yet (`prepared.rs` stores it right after spawn).
+            .map(|pid| pid.load(atomic::Ordering::Acquire))
+            .filter(|pid| *pid != 0)
+            .collect()
+    }
+
+    /// Send the destroy reply and wait for it to go out.
+    async fn finish_destroy(reply_tx: oneshot::Sender<Option<DaemonCoordinatorReply>>) {
+        let (notify_tx, notify_rx) = oneshot::channel();
+        let reply = DaemonCoordinatorReply::DestroyResult {
+            result: Ok(()),
+            notify: Some(notify_tx),
+        };
+        let _ = reply_tx
+            .send(Some(reply))
+            .map_err(|_| error!("could not send destroy reply from daemon to coordinator"));
+        // wait until the reply is sent out
+        if notify_rx.await.is_err() {
+            tracing::warn!("no confirmation received for DestroyReply");
+        }
     }
 
     async fn trigger_manual_stop(&mut self) -> eyre::Result<()> {
@@ -2314,19 +2447,25 @@ impl Daemon {
             }
             DaemonCoordinatorEvent::Destroy => {
                 tracing::info!("received destroy command -> exiting");
-                let (notify_tx, notify_rx) = oneshot::channel();
-                let reply = DaemonCoordinatorReply::DestroyResult {
-                    result: Ok(()),
-                    notify: Some(notify_tx),
-                };
-                let _ = reply_tx
-                    .send(Some(reply))
-                    .map_err(|_| error!("could not send destroy reply from daemon to coordinator"));
-                // wait until the reply is sent out
-                if notify_rx.await.is_err() {
-                    tracing::warn!("no confirmation received for DestroyReply");
+                // Anything still running when this process ends is orphaned
+                // to `ppid 1`: the per-node supervision tasks that would
+                // deliver a kill are never polled again. So hold the reply
+                // until the nodes are gone (#2980) — the coordinator's
+                // destroy completes when it lands, which is what makes
+                // `dora down` mean what it documents.
+                //
+                // Deferred rather than awaited here: a node shutting down
+                // cooperatively ends by asking this very event loop to close
+                // its outputs, so blocking the loop would deadlock every
+                // well-behaved node against the wait and turn its clean exit
+                // into a signal kill.
+                match self.begin_pending_destroy(reply_tx) {
+                    Some(reply_tx) => {
+                        Self::finish_destroy(reply_tx).await;
+                        RunStatus::Exit
+                    }
+                    None => RunStatus::Continue,
                 }
-                RunStatus::Exit
             }
             DaemonCoordinatorEvent::Heartbeat => {
                 self.last_coordinator_heartbeat = Instant::now();

--- a/binaries/daemon/src/shutdown.rs
+++ b/binaries/daemon/src/shutdown.rs
@@ -1,0 +1,271 @@
+//! Reaping node processes when the daemon is torn down.
+//!
+//! The daemon's stop path is asynchronous: `stop_all` sends the cooperative
+//! `Stop` and schedules the grace → SIGTERM → SIGKILL ladder on per-node
+//! tasks. That is fine while the daemon keeps running, but `Destroy` means
+//! the process is about to end — and once it does, those tasks are never
+//! polled again. A node that ignored the cooperative `Stop` is then never
+//! signalled at all and survives with `ppid 1`, holding whatever it held:
+//! shared memory, GPU contexts, ports (dora-rs/dora#2980).
+//!
+//! So a destroy must not reply until the daemon's children are gone. The
+//! waiting is deliberately *not* done inline in the event handler: a node
+//! shutting down cooperatively finishes by asking the daemon to close its
+//! outputs and report them done, and those requests are answered by the very
+//! event loop that would be blocked. Waiting there deadlocks every
+//! well-behaved node against the reaper until the deadline, turning a clean
+//! exit into a signal kill. Instead the destroy is left pending, the loop
+//! keeps serving nodes, and [`DestroyWait::poll`] is driven by a tick until
+//! the nodes are gone or the deadline forces a kill.
+
+use std::time::Duration;
+use sysinfo::{Pid, ProcessRefreshKind, ProcessStatus, ProcessesToUpdate, System};
+use tokio::time::Instant;
+
+/// How long a destroy waits for nodes to exit before killing them.
+///
+/// Sized to outlast the stop ladder that the coordinator's `StopDataflow`
+/// already scheduled (`DEFAULT_STOP_GRACE` for SIGTERM, half as much again
+/// for SIGKILL), so a node that would have died on either rung dies *there*,
+/// through the daemon's normal path, which signals the node's whole process
+/// group. Killing earlier would cut short the SIGTERM window that nodes use
+/// to flush. This deadline is the backstop for whatever that ladder does not
+/// finish in time.
+pub(crate) const DESTROY_WAIT: Duration = Duration::from_secs(16);
+
+/// How long to wait for a killed process to disappear. SIGKILL cannot be
+/// caught, so this only covers the kernel tearing the process down.
+const KILL_SETTLE: Duration = Duration::from_secs(2);
+
+/// How often liveness is re-checked while a destroy is pending.
+pub(crate) const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// A destroy that is waiting for this daemon's nodes to exit.
+pub(crate) struct DestroyWait {
+    /// When to stop waiting and kill what is left.
+    deadline: Instant,
+    /// Set once the kill has been issued; `deadline` then becomes the settle
+    /// deadline, and the next expiry gives up rather than killing again.
+    killed: bool,
+    /// Pids that had to be killed, for the caller to report.
+    pub killed_pids: Vec<u32>,
+    system: System,
+    own_pid: u32,
+}
+
+/// What [`DestroyWait::poll`] concluded.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum DestroyProgress {
+    /// Nodes are still running; poll again.
+    Waiting,
+    /// No node processes are left — the daemon may exit.
+    Done,
+    /// Gave up on these pids: they survived the kill, or could not be
+    /// killed. Exiting now orphans them, which is worth an error.
+    Abandoned(Vec<u32>),
+}
+
+impl DestroyWait {
+    pub fn new() -> Self {
+        Self {
+            deadline: Instant::now() + DESTROY_WAIT,
+            killed: false,
+            killed_pids: Vec::new(),
+            system: System::new(),
+            own_pid: std::process::id(),
+        }
+    }
+
+    /// Re-check `pids` and act if the deadline has passed.
+    ///
+    /// `pids` is re-read from the daemon's state on every call rather than
+    /// captured up front, so a node that respawns mid-teardown is followed to
+    /// its new process instead of leaving the old pid to be chased.
+    pub fn poll(&mut self, pids: &[u32]) -> DestroyProgress {
+        let alive = self.live_children(pids);
+        if alive.is_empty() {
+            return DestroyProgress::Done;
+        }
+        if Instant::now() < self.deadline {
+            return DestroyProgress::Waiting;
+        }
+        if self.killed {
+            return DestroyProgress::Abandoned(alive);
+        }
+
+        for pid in &alive {
+            if kill_process_group(*pid) {
+                self.killed_pids.push(*pid);
+            }
+        }
+        self.killed = true;
+        self.deadline = Instant::now() + KILL_SETTLE;
+        DestroyProgress::Waiting
+    }
+
+    /// The subset of `pids` that are still running children of this process.
+    ///
+    /// Parentage, not mere existence: once a node exits its pid is free for
+    /// reuse, and killing blind would eventually hit an unrelated process.
+    fn live_children(&mut self, pids: &[u32]) -> Vec<u32> {
+        if pids.is_empty() {
+            return Vec::new();
+        }
+        let lookup: Vec<Pid> = pids.iter().map(|pid| Pid::from_u32(*pid)).collect();
+        self.system.refresh_processes_specifics(
+            ProcessesToUpdate::Some(&lookup),
+            true,
+            ProcessRefreshKind::nothing(),
+        );
+        let own_pid = self.own_pid;
+        let system = &self.system;
+        pids.iter()
+            .copied()
+            .filter(|pid| {
+                system
+                    .process(Pid::from_u32(*pid))
+                    .is_some_and(|process| is_live_child(process, own_pid))
+            })
+            .collect()
+    }
+}
+
+/// Kill the node's whole process group, not just the pid the daemon tracks.
+///
+/// Nodes are spawned as process-group leaders, which is what lets the stop
+/// ladder's signals reach whatever the node spawned. The tracked pid is
+/// frequently a wrapper — `uv run python script.py`, `sh -c ...` — so
+/// signalling it alone would leave the real node behind: the same orphan, one
+/// level down.
+fn kill_process_group(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        // SAFETY: `killpg`/`kill` on a pid this process spawned as a group
+        // leader. A pid the OS recycled is already excluded by the parentage
+        // check in `live_children`.
+        let killed = unsafe { libc::killpg(pid as i32, libc::SIGKILL) } == 0;
+        if killed {
+            return true;
+        }
+        // Not a group leader after all (the node called `setsid`), or the
+        // group is already gone: fall back to the process itself.
+        unsafe { libc::kill(pid as i32, libc::SIGKILL) == 0 }
+    }
+    #[cfg(not(unix))]
+    {
+        // Windows: nodes are spawned into a job object, which terminates
+        // their children along with them.
+        let mut system = System::new();
+        system.refresh_processes_specifics(
+            ProcessesToUpdate::Some(&[Pid::from_u32(pid)]),
+            true,
+            ProcessRefreshKind::nothing(),
+        );
+        system
+            .process(Pid::from_u32(pid))
+            .is_some_and(|process| process.kill())
+    }
+}
+
+/// A zombie has already exited (its supervision task just has not reaped it
+/// yet), and a pid the OS recycled belongs to someone else.
+fn is_live_child(process: &sysinfo::Process, own_pid: u32) -> bool {
+    if process.status() == ProcessStatus::Zombie {
+        return false;
+    }
+    process.parent() == Some(Pid::from_u32(own_pid))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::{Command, Stdio};
+
+    fn spawn_sleeper() -> std::process::Child {
+        Command::new("sleep")
+            .arg("300")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("failed to spawn sleep")
+    }
+
+    /// A node that will not exit is killed once the deadline passes — the
+    /// case #2980 is about.
+    #[tokio::test(start_paused = true)]
+    #[cfg_attr(not(unix), ignore = "spawns `sleep`")]
+    async fn a_node_that_outlives_the_deadline_is_killed() {
+        let mut child = spawn_sleeper();
+        let pid = child.id();
+        let mut wait = DestroyWait::new();
+
+        assert_eq!(
+            wait.poll(&[pid]),
+            DestroyProgress::Waiting,
+            "a live node before the deadline must be waited for, not killed"
+        );
+
+        tokio::time::advance(DESTROY_WAIT + Duration::from_secs(1)).await;
+        assert_eq!(wait.poll(&[pid]), DestroyProgress::Waiting);
+        assert_eq!(wait.killed_pids, vec![pid], "the straggler must be killed");
+
+        let status = child.wait().expect("failed to wait for killed child");
+        assert!(!status.success(), "killed process must not exit cleanly");
+    }
+
+    /// The common case must stay free: a node that exits on its own is never
+    /// killed, and the destroy completes as soon as it is gone rather than
+    /// sitting out the deadline.
+    #[tokio::test(start_paused = true)]
+    #[cfg_attr(not(unix), ignore = "spawns `sleep`")]
+    async fn a_node_that_exits_on_its_own_is_not_killed() {
+        let mut child = spawn_sleeper();
+        let pid = child.id();
+        let mut wait = DestroyWait::new();
+        assert_eq!(wait.poll(&[pid]), DestroyProgress::Waiting);
+
+        let _ = child.kill();
+        let _ = child.wait();
+
+        assert_eq!(
+            wait.poll(&[pid]),
+            DestroyProgress::Done,
+            "the wait must end when the node does"
+        );
+        assert!(wait.killed_pids.is_empty(), "nothing to kill");
+    }
+
+    /// A pid the OS recycled after the node exited belongs to a stranger.
+    /// Killing it would be worse than the leak this module exists to fix.
+    #[tokio::test(start_paused = true)]
+    #[cfg_attr(not(unix), ignore = "spawns `sleep`")]
+    async fn a_process_that_is_not_our_child_is_left_alone() {
+        let mut child = spawn_sleeper();
+        let pid = child.id();
+
+        let mut wait = DestroyWait::new();
+        assert_eq!(wait.live_children(&[pid]), vec![pid]);
+
+        let mut foreign = DestroyWait::new();
+        foreign.own_pid = std::process::id() + 424_242;
+        assert!(
+            foreign.live_children(&[pid]).is_empty(),
+            "a process parented elsewhere must not be treated as ours"
+        );
+        tokio::time::advance(DESTROY_WAIT + Duration::from_secs(1)).await;
+        assert_eq!(foreign.poll(&[pid]), DestroyProgress::Done);
+        assert!(
+            foreign.killed_pids.is_empty(),
+            "a stranger's pid must never be signalled"
+        );
+
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    /// Nothing to wait for is not a reason to wait.
+    #[tokio::test]
+    async fn a_daemon_with_no_nodes_finishes_at_once() {
+        assert_eq!(DestroyWait::new().poll(&[]), DestroyProgress::Done);
+    }
+}

--- a/binaries/daemon/src/shutdown.rs
+++ b/binaries/daemon/src/shutdown.rs
@@ -49,6 +49,12 @@ pub(crate) struct DestroyWait {
     killed: bool,
     /// Pids that had to be killed, for the caller to report.
     pub killed_pids: Vec<u32>,
+    /// Pids confirmed to be this daemon's children at least once.
+    ///
+    /// Nodes are spawned as process-group leaders, so a confirmed pid is
+    /// also its group's id — which is what lets the group outlive the pid
+    /// and still be recognized as ours (#3004 review).
+    confirmed: std::collections::HashSet<u32>,
     system: System,
     own_pid: u32,
 }
@@ -71,6 +77,7 @@ impl DestroyWait {
             deadline: Instant::now() + DESTROY_WAIT,
             killed: false,
             killed_pids: Vec::new(),
+            confirmed: std::collections::HashSet::new(),
             system: System::new(),
             own_pid: std::process::id(),
         }
@@ -103,10 +110,20 @@ impl DestroyWait {
         DestroyProgress::Waiting
     }
 
-    /// The subset of `pids` that are still running children of this process.
+    /// The subset of `pids` whose process — or whose process *group* — is
+    /// still running.
     ///
-    /// Parentage, not mere existence: once a node exits its pid is free for
-    /// reuse, and killing blind would eventually hit an unrelated process.
+    /// Parentage, not mere existence, is what makes a pid ours: once a node
+    /// exits its pid is free for reuse, and killing blind would eventually
+    /// hit an unrelated process.
+    ///
+    /// The group half matters because the tracked pid is often a wrapper.
+    /// `uv run python node.py` dies to the ladder's SIGTERM while the
+    /// interpreter it spawned ignores it; watching only the leader would call
+    /// that node gone and let the destroy finish, leaving exactly the orphan
+    /// one level down that this module exists to prevent (#3004 review). A
+    /// group is only ever consulted for a pid confirmed to be ours while it
+    /// was alive, so a recycled pid cannot drag in a stranger's group.
     fn live_children(&mut self, pids: &[u32]) -> Vec<u32> {
         if pids.is_empty() {
             return Vec::new();
@@ -117,16 +134,41 @@ impl DestroyWait {
             true,
             ProcessRefreshKind::nothing(),
         );
-        let own_pid = self.own_pid;
-        let system = &self.system;
-        pids.iter()
-            .copied()
-            .filter(|pid| {
-                system
-                    .process(Pid::from_u32(*pid))
-                    .is_some_and(|process| is_live_child(process, own_pid))
-            })
-            .collect()
+
+        let mut alive = Vec::new();
+        for pid in pids.iter().copied() {
+            let leader_alive = self
+                .system
+                .process(Pid::from_u32(pid))
+                .is_some_and(|process| is_live_child(process, self.own_pid));
+            if leader_alive {
+                self.confirmed.insert(pid);
+                alive.push(pid);
+            } else if self.confirmed.contains(&pid) && process_group_has_members(pid) {
+                alive.push(pid);
+            }
+        }
+        alive
+    }
+}
+
+/// Whether any process is still in the group led by `pid`.
+///
+/// Signal 0 performs the permission and existence checks without delivering
+/// anything, so this asks the kernel the question directly rather than
+/// enumerating every process on the machine.
+fn process_group_has_members(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        // SAFETY: signal 0 delivers nothing; this is a pure existence check.
+        unsafe { libc::kill(-(pid as i32), 0) == 0 }
+    }
+    #[cfg(not(unix))]
+    {
+        // Windows has no process groups in this sense; the job object the
+        // node was spawned into ties its children to the leader's lifetime.
+        let _ = pid;
+        false
     }
 }
 
@@ -211,6 +253,67 @@ mod tests {
 
         let status = child.wait().expect("failed to wait for killed child");
         assert!(!status.success(), "killed process must not exit cleanly");
+    }
+
+    /// #3004 review: the tracked pid is often a wrapper. When it exits — to
+    /// the ladder's SIGTERM, or on its own — while something it spawned
+    /// carries on in its process group, the node is not gone. Following only
+    /// the leader would end the destroy there and orphan the child, which is
+    /// the very leak this module exists to close, one level down.
+    #[tokio::test(start_paused = true)]
+    #[cfg_attr(not(unix), ignore = "process groups are a unix concept")]
+    async fn a_wrapper_that_exits_does_not_hide_its_surviving_child() {
+        use std::os::unix::process::CommandExt as _;
+
+        // A group leader that spawns a child into its group and exits, like
+        // a wrapper dying while the interpreter it launched keeps running.
+        let mut wrapper = Command::new("sh")
+            .arg("-c")
+            .arg("sleep 300 & exit 0")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .process_group(0)
+            .spawn()
+            .expect("failed to spawn wrapper");
+        let pid = wrapper.id();
+
+        let mut wait = DestroyWait::new();
+        assert_eq!(
+            wait.poll(&[pid]),
+            DestroyProgress::Waiting,
+            "the wrapper is alive, so this is an ordinary wait"
+        );
+
+        // The wrapper exits and is reaped; its child lives on.
+        wrapper.wait().expect("failed to wait for wrapper");
+        assert_eq!(
+            wait.poll(&[pid]),
+            DestroyProgress::Waiting,
+            "the leader is gone but its group is not — the node is still running"
+        );
+
+        tokio::time::advance(DESTROY_WAIT + Duration::from_secs(1)).await;
+        assert_eq!(wait.poll(&[pid]), DestroyProgress::Waiting);
+        assert_eq!(
+            wait.killed_pids,
+            vec![pid],
+            "the surviving group must be killed"
+        );
+        // The kill lands on the group, so the child goes with it — once the
+        // OS has torn it down and its (re-parented) reaper has collected it,
+        // which is what `KILL_SETTLE` covers in production. Real sleeps: the
+        // test clock is paused, and this waits on the kernel, not on tokio.
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            match wait.poll(&[pid]) {
+                DestroyProgress::Done => break,
+                other => assert!(
+                    std::time::Instant::now() < deadline,
+                    "the killed group never went away: {other:?}"
+                ),
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
     }
 
     /// The common case must stay free: a node that exits on its own is never

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -346,7 +346,7 @@ dora down [OPTIONS]
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--force` | false | Tear down even if the coordinator has running dataflows, terminating them immediately first (a plain teardown does not wait for a stop to take effect, so a wedged node would be orphaned) |
+| `--force` | false | Tear down even if the coordinator has running dataflows, terminating them immediately first |
 | `--coordinator-addr <IP>` | `127.0.0.1` | Coordinator address |
 | `--coordinator-port <PORT>` | `6013` | Coordinator port |
 
@@ -359,8 +359,14 @@ dora down [OPTIONS]
 >
 > Since [#2924] the command refuses when the target reports running
 > dataflows, listing them. `--force` proceeds, stopping each dataflow
-> first so nothing is left orphaned — including nodes that ignore a
-> cooperative stop.
+> first.
+>
+> Teardown does not leave nodes behind. Each daemon waits out the stop
+> grace period and kills whatever is still running before it exits, so a
+> node that ignores the cooperative stop is terminated rather than
+> orphaned ([#2980]). A wedged node therefore makes `dora down` take up
+> to the grace period; well-behaved ones exit immediately and cost
+> nothing.
 >
 > **To run instances side by side, give each its own port** — that is the
 > isolation mechanism, and every lifecycle command (`up`, `down`, `start`,
@@ -373,6 +379,7 @@ dora down [OPTIONS]
 > ```
 
 [#2924]: https://github.com/dora-rs/dora/issues/2924
+[#2980]: https://github.com/dora-rs/dora/issues/2980
 
 #### `dora build`
 

--- a/guide/src/operations/cli.md
+++ b/guide/src/operations/cli.md
@@ -348,7 +348,7 @@ dora down [OPTIONS]
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--force` | false | Tear down even if the coordinator has running dataflows, terminating them immediately first (a plain teardown does not wait for a stop to take effect, so a wedged node would be orphaned) |
+| `--force` | false | Tear down even if the coordinator has running dataflows, terminating them immediately first |
 | `--coordinator-addr <IP>` | `127.0.0.1` | Coordinator address |
 | `--coordinator-port <PORT>` | `6013` | Coordinator port |
 
@@ -361,8 +361,14 @@ dora down [OPTIONS]
 >
 > Since [#2924] the command refuses when the target reports running
 > dataflows, listing them. `--force` proceeds, stopping each dataflow
-> first so nothing is left orphaned — including nodes that ignore a
-> cooperative stop.
+> first.
+>
+> Teardown does not leave nodes behind. Each daemon waits out the stop
+> grace period and kills whatever is still running before it exits, so a
+> node that ignores the cooperative stop is terminated rather than
+> orphaned ([#2980]). A wedged node therefore makes `dora down` take up
+> to the grace period; well-behaved ones exit immediately and cost
+> nothing.
 >
 > **To run instances side by side, give each its own port** — that is the
 > isolation mechanism, and every lifecycle command (`up`, `down`, `start`,
@@ -375,6 +381,7 @@ dora down [OPTIONS]
 > ```
 
 [#2924]: https://github.com/dora-rs/dora/issues/2924
+[#2980]: https://github.com/dora-rs/dora/issues/2980
 
 #### `dora build`
 

--- a/tests/ws-cli-e2e.rs
+++ b/tests/ws-cli-e2e.rs
@@ -2696,4 +2696,262 @@ mod real_dataflow {
 
         cleanup(&dora);
     }
+
+    /// dora-rs/dora#2980: `Destroy` must not outrun the stop it just asked
+    /// for.
+    ///
+    /// `handle_destroy` stops every dataflow and then tears the daemons down
+    /// ~200ms later, but `stop_dataflow` returns once the daemons acknowledge
+    /// the *request* — the grace → SIGTERM → SIGKILL ladder runs afterwards,
+    /// inside the daemon. A node that ignores the cooperative `Stop`
+    /// therefore used to survive the teardown with `ppid 1`, holding whatever
+    /// it held, while the command reported success.
+    ///
+    /// Driven over the raw control protocol rather than `dora down`: the
+    /// #2924 guard makes the CLI stop each dataflow through a path that
+    /// already waits, which masks this. `Destroy` is also reached by
+    /// `dora cluster down`, by Ctrl-C on the coordinator, and by any direct
+    /// control-protocol client — this is that route.
+    ///
+    /// The fixture ignores both the cooperative `Stop` and SIGTERM, so only a
+    /// SIGKILL can end it; a node that died to SIGTERM would be cleaned up
+    /// either way and could not tell a working teardown from a broken one.
+    ///
+    /// Unix-only: it inspects process state.
+    #[test]
+    #[cfg(unix)]
+    fn e2e_destroy_does_not_orphan_a_node_that_ignores_stop() {
+        ensure_built();
+        let dora = dora_bin();
+        let target = Path::new(env!("CARGO_MANIFEST_DIR")).join("target");
+        let status = Command::new("cargo")
+            .args(["build", "-p", "sigterm-ignoring-node"])
+            .arg("--target-dir")
+            .arg(&target)
+            .status()
+            .expect("failed to build sigterm-ignoring-node");
+        assert!(status.success(), "failed to build sigterm-ignoring-node");
+
+        let home = tempdir().expect("create isolated home");
+        let port = unused_port();
+        let pid_file = home.path().join("stubborn.pid");
+        let yaml = home.path().join("stubborn.yml");
+        std::fs::write(
+            &yaml,
+            format!(
+                "nodes:\n  \
+                 - id: stubborn\n    \
+                   path: \"{node}\"\n    \
+                   env:\n      \
+                     DORA_TEST_PID_FILE: \"{pid_file}\"\n    \
+                   inputs:\n      \
+                     tick: dora/timer/millis/100\n",
+                node = target.join("debug/sigterm-ignoring-node").display(),
+                pid_file = pid_file.display(),
+            ),
+        )
+        .expect("write dataflow yaml");
+
+        let (status, stdout, stderr) = run_dora_isolated(&dora, home.path(), port, &["up"]);
+        assert!(
+            status.success(),
+            "dora up failed; stdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+        // Explicit capture name: the default is the joined argv, and this
+        // command's argv holds a path, which cannot be a file name.
+        let (child, out_path, err_path) = spawn_dora_isolated(
+            &dora,
+            home.path(),
+            port,
+            &["start", yaml.to_str().unwrap(), "--detach"],
+            "start",
+        );
+        let (status, stdout, stderr) = wait_for_dora_isolated(child, out_path, err_path);
+        assert!(
+            status.success(),
+            "dora start failed; stdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+
+        // The fixture publishes its own pid, so the assertions below are about
+        // THIS process rather than a pattern match on the process table, which
+        // would also catch a leftover from an earlier run.
+        let node_pid = wait_for_pid_file(&pid_file, Duration::from_secs(30));
+
+        // RAII: the fixture ignores SIGTERM and outlives a failed assertion by
+        // design, so every bail-out path must still clear it off the runner.
+        struct Reaper(u32);
+        impl Drop for Reaper {
+            fn drop(&mut self) {
+                if fixture_alive(self.0) {
+                    let _ = Command::new("kill")
+                        .args(["-9", &self.0.to_string()])
+                        .status();
+                }
+            }
+        }
+        let _reaper = Reaper(node_pid);
+        assert!(
+            fixture_alive(node_pid),
+            "fixture {node_pid} was not running before destroy"
+        );
+
+        let addr: SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
+        let session = WsSession::connect(addr).expect("failed to connect WsSession");
+        let reply =
+            super::send_request(&session, &ControlRequest::Destroy).expect("destroy request");
+        assert!(
+            matches!(reply, ControlRequestReply::DestroyOk),
+            "expected DestroyOk, got {reply:?}"
+        );
+
+        // No polling window: the point of the fix is that `Destroy` does not
+        // return until the daemon has dealt with its children, so the node
+        // must already be gone when the reply lands.
+        assert!(
+            !fixture_alive(node_pid),
+            "node {node_pid} outlived the destroy that reported success \
+             — it is now orphaned to ppid 1"
+        );
+    }
+
+    /// A destroy must not make a healthy shutdown slower or dirtier.
+    ///
+    /// The wait added for #2980 cannot be taken inline in the daemon's event
+    /// loop: a node on its way out ends by asking that same loop to close its
+    /// outputs and report them done, so a loop parked in the wait deadlocks
+    /// every well-behaved node against it until the deadline, and they get
+    /// signal-killed instead of exiting. That regression is invisible to the
+    /// orphan test above — its fixture never talks to the daemon — so this
+    /// pins the other side: real nodes, and a destroy that returns in about
+    /// the time it took before the wait existed.
+    #[test]
+    fn e2e_destroy_does_not_delay_healthy_nodes() {
+        ensure_built();
+        let dora = dora_bin();
+        let home = tempdir().expect("create isolated home");
+        let port = unused_port();
+        let yaml = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/dataflows/node-lifecycle.yml");
+
+        let (status, stdout, stderr) = run_dora_isolated(&dora, home.path(), port, &["up"]);
+        assert!(
+            status.success(),
+            "dora up failed; stdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+        let (child, out_path, err_path) = spawn_dora_isolated(
+            &dora,
+            home.path(),
+            port,
+            &["start", yaml.to_str().unwrap(), "--detach"],
+            "start",
+        );
+        let (status, stdout, stderr) = wait_for_dora_isolated(child, out_path, err_path);
+        assert!(
+            status.success(),
+            "dora start failed; stdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+
+        let addr: SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
+        let session = WsSession::connect(addr).expect("failed to connect WsSession");
+
+        // Destroying mid-startup is a different scenario with its own timing:
+        // a node that has not subscribed yet cannot answer the cooperative
+        // stop, so the teardown waits out the startup barrier. This test is
+        // about the steady state, so let the dataflow reach it first.
+        let deadline = Instant::now() + Duration::from_secs(30);
+        loop {
+            let reply = super::send_request(&session, &ControlRequest::List).expect("list");
+            if let ControlRequestReply::DataflowList(list) = reply
+                && list.0.iter().any(|entry| {
+                    matches!(
+                        entry.status,
+                        dora_message::coordinator_to_cli::DataflowStatus::Running
+                    )
+                })
+            {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "dataflow never reached Running within 30s"
+            );
+            std::thread::sleep(Duration::from_millis(100));
+        }
+
+        let reply = super::send_request(&session, &ControlRequest::Destroy).expect("destroy");
+        assert!(
+            matches!(reply, ControlRequestReply::DestroyOk),
+            "expected DestroyOk, got {reply:?}"
+        );
+
+        // The signal, rather than wall-clock timing: the daemon only kills
+        // what is left when its deadline expires, and it says so. A healthy
+        // node reaches that deadline exactly when the loop it needs was
+        // parked in the wait — so this line appearing IS the regression,
+        // whatever the machine's timing.
+        let killed = daemon_log_lines(home.path())
+            .into_iter()
+            .find(|line| line.contains("still running at destroy"));
+        assert!(
+            killed.is_none(),
+            "nodes that answer the cooperative stop must exit on their own, \
+             but the daemon had to kill them: {killed:?}"
+        );
+    }
+
+    /// Everything the daemon logged, across the isolated home's log files.
+    fn daemon_log_lines(home: &Path) -> Vec<String> {
+        let mut lines = Vec::new();
+        let mut dirs = vec![home.join(".dora")];
+        while let Some(dir) = dirs.pop() {
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    dirs.push(path);
+                } else if let Ok(contents) = std::fs::read_to_string(&path) {
+                    lines.extend(contents.lines().map(str::to_owned));
+                }
+            }
+        }
+        lines
+    }
+
+    /// Read the pid the fixture published, waiting for it to appear.
+    #[cfg(unix)]
+    fn wait_for_pid_file(path: &Path, timeout: Duration) -> u32 {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if let Ok(contents) = std::fs::read_to_string(path)
+                && let Ok(pid) = contents.trim().parse::<u32>()
+            {
+                return pid;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "node never reported its pid at {}",
+                path.display()
+            );
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    /// Whether `pid` is still the fixture.
+    ///
+    /// Matches the binary path, not merely liveness: once the node exits its
+    /// pid is free for reuse, and a bare liveness check would eventually
+    /// report an unrelated process as the surviving node. `args=`, not
+    /// `comm=`, because Linux caps `comm` at 15 characters and the fixture
+    /// name is longer (dora-rs/dora#2961).
+    #[cfg(unix)]
+    fn fixture_alive(pid: u32) -> bool {
+        Command::new("ps")
+            .args(["-ww", "-o", "args=", "-p", &pid.to_string()])
+            .output()
+            .ok()
+            .is_some_and(|out| {
+                String::from_utf8_lossy(&out.stdout).contains("/sigterm-ignoring-node")
+            })
+    }
 }

--- a/tests/ws-cli-e2e.rs
+++ b/tests/ws-cli-e2e.rs
@@ -2814,6 +2814,102 @@ mod real_dataflow {
         );
     }
 
+    /// #3004 review: the same orphan, one level down.
+    ///
+    /// A node's tracked process is often a wrapper — `uv run python node.py`,
+    /// a shell launcher — and the ladder's SIGTERM kills the wrapper while
+    /// the process it spawned ignores the signal and carries on in its
+    /// process group. Watching only the tracked pid calls the node gone and
+    /// lets the destroy finish, orphaning the real one.
+    ///
+    /// Unix-only: it uses process groups and inspects process state.
+    #[test]
+    #[cfg(unix)]
+    fn e2e_destroy_does_not_orphan_a_node_behind_an_exiting_wrapper() {
+        ensure_built();
+        let dora = dora_bin();
+        let target = Path::new(env!("CARGO_MANIFEST_DIR")).join("target");
+        let status = Command::new("cargo")
+            .args(["build", "-p", "sigterm-ignoring-node"])
+            .arg("--target-dir")
+            .arg(&target)
+            .status()
+            .expect("failed to build sigterm-ignoring-node");
+        assert!(status.success(), "failed to build sigterm-ignoring-node");
+
+        let home = tempdir().expect("create isolated home");
+        let port = unused_port();
+        let pid_file = home.path().join("stubborn.pid");
+        let yaml = home.path().join("wrapped.yml");
+        // `sh` waits, so the daemon's entry stays while the real node runs.
+        // On SIGTERM `sh` dies and the fixture — which ignores it — does not.
+        std::fs::write(
+            &yaml,
+            format!(
+                "nodes:\n  \
+                 - id: wrapped\n    \
+                   path: /bin/sh\n    \
+                   args: \"-c '{node} & wait'\"\n    \
+                   env:\n      \
+                     DORA_TEST_PID_FILE: \"{pid_file}\"\n    \
+                   inputs:\n      \
+                     tick: dora/timer/millis/100\n",
+                node = target.join("debug/sigterm-ignoring-node").display(),
+                pid_file = pid_file.display(),
+            ),
+        )
+        .expect("write dataflow yaml");
+
+        let (status, stdout, stderr) = run_dora_isolated(&dora, home.path(), port, &["up"]);
+        assert!(
+            status.success(),
+            "dora up failed; stdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+        let (child, out_path, err_path) = spawn_dora_isolated(
+            &dora,
+            home.path(),
+            port,
+            &["start", yaml.to_str().unwrap(), "--detach"],
+            "start",
+        );
+        let (status, stdout, stderr) = wait_for_dora_isolated(child, out_path, err_path);
+        assert!(
+            status.success(),
+            "dora start failed; stdout:\n{stdout}\nstderr:\n{stderr}"
+        );
+
+        let node_pid = wait_for_pid_file(&pid_file, Duration::from_secs(30));
+        struct Reaper(u32);
+        impl Drop for Reaper {
+            fn drop(&mut self) {
+                if fixture_alive(self.0) {
+                    let _ = Command::new("kill")
+                        .args(["-9", &self.0.to_string()])
+                        .status();
+                }
+            }
+        }
+        let _reaper = Reaper(node_pid);
+        assert!(
+            fixture_alive(node_pid),
+            "fixture {node_pid} was not running before destroy"
+        );
+
+        let addr: SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
+        let session = WsSession::connect(addr).expect("failed to connect WsSession");
+        let reply = super::send_request(&session, &ControlRequest::Destroy).expect("destroy");
+        assert!(
+            matches!(reply, ControlRequestReply::DestroyOk),
+            "expected DestroyOk, got {reply:?}"
+        );
+
+        assert!(
+            !fixture_alive(node_pid),
+            "node {node_pid} outlived the destroy behind its wrapper — the \
+             wrapper's exit must not be mistaken for the node's"
+        );
+    }
+
     /// A destroy must not make a healthy shutdown slower or dirtier.
     ///
     /// The wait added for #2980 cannot be taken inline in the daemon's event


### PR DESCRIPTION
Closes #2980.

## The fix

Option 2 from the issue — wait for the dataflows to finish before tearing the daemons down — but the waiting is done in the **daemon**, not the coordinator. The coordinator cannot observe completion: `handle_destroy` aborts its own event stream first, so the `DataflowFinished` events it would need never arrive. The daemon is also where the ladder runs and where the child processes actually are.

`Destroy` now holds its reply until this daemon's node processes are gone, and the coordinator's existing `destroy_daemons` await turns that into the synchronization `dora down` documents. Every route that reaches `Destroy` is covered — `dora cluster down`, Ctrl-C on the coordinator, and any direct control-protocol client — with no per-caller logic.

**The wait is deferred, not inline.** This is the part worth reviewing: a node shutting down cooperatively ends by asking the daemon's event loop to close its outputs and report them done (`report_closed_outputs` / `report_outputs_done` in `DoraNode::drop`), and it blocks on the reply. A loop parked in the wait deadlocks every well-behaved node against the reaper until the deadline, so they get signal-killed instead of exiting — strictly worse than the bug. My first attempt did exactly that, and an adversarial review caught it with a reproduction. So the destroy is left pending, the loop keeps serving nodes, and a 100ms tick drives `DestroyWait::poll` until they are gone.

**The deadline (16s) outlasts the ladder** the coordinator already scheduled (`DEFAULT_STOP_GRACE` for SIGTERM, half as much again for SIGKILL). A node that would have died on the SIGTERM rung dies *there*, through the daemon's normal path — which signals the node's whole process group. Killing at 10s instead would have collided with the SIGTERM rung and cut short the window nodes use to flush.

**What gets killed, and how.** Only what outlives the ladder, and by **process group**: nodes are spawned as group leaders, and the tracked pid is frequently a wrapper (`uv run python …`, `sh -c …`) whose real child would otherwise be the same orphan one level down. Parentage — not liveness — decides what may be signalled, since a pid the OS recycled after the node exited belongs to a stranger.

## Tests

- `e2e_destroy_does_not_orphan_a_node_that_ignores_stop` — the issue's scenario, driven over the raw control protocol (the `dora down --force` route already waits via #2924, which masks it). Verified RED before the fix: *"node 81863 outlived the destroy that reported success — it is now orphaned to ppid 1"*.
- `e2e_destroy_does_not_delay_healthy_nodes` — the other side, pinning the deadlock regression above. Asserts on the daemon's own kill log rather than wall-clock timing: a healthy node reaching the deadline *is* the regression, whatever the machine's speed.
- `shutdown.rs` unit tests — killed at the deadline, not killed when it exits on its own, a non-child left alone, and no nodes finishing at once. Time-paused, so they are fast and not timing-flaky.

## Measured

Teardown of a settled 3-node dataflow, with the fix:

| Route | Before reply / nodes gone |
|---|---|
| `dora down --force` | 0.26s |
| `dora cluster down` | 0.33s |
| Ctrl-C on coordinator | nodes gone 0.03s, daemon gone 0.18s |
| daemon-internal (traced) | destroy pending → nodes gone → reply in 106ms |

`make qa-fast` clean, clippy `-D warnings` clean, 181 daemon + 317 core + coordinator unit tests, both destroy e2e tests green.

## Known wart, not introduced by this PR's design

Over a raw `WsSession` (the test harness's path), the *reply* to a `Destroy` that had to wait takes ~9s to reach the client even though the daemon finished in 106ms and every CLI route returns in under 0.4s. It looks like a coordinator/CLI shutdown-ordering interaction that the slightly later reply exposes rather than causes. It does not affect teardown, which is why the healthy-node test asserts on the kill log instead. Worth its own issue if you want it chased.

## Docs

`dora down` no longer documents the orphan caveat, and both `docs/cli.md` and `guide/src/operations/cli.md` now state that teardown terminates rather than orphans a node that ignores the cooperative stop — and that a wedged node therefore costs up to the grace period.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
