### PR TITLE
fix(qa): unwrap-budget.sh silently passes on Windows checkouts with CRLF .unwrap-budget

### DIFF
--- a/scripts/qa/unwrap-budget.sh
+++ b/scripts/qa/unwrap-budget.sh
@@ -120,7 +120,7 @@ fi
 
 CURRENT=$(count_unwraps)
 
-BUDGET=$(cat "$BUDGET_FILE" | tr -d ' \n')
+BUDGET=$(cat "$BUDGET_FILE" | tr -d ' \r\n')
 
 echo "unwrap/expect count: $CURRENT (budget: $BUDGET)"
 


### PR DESCRIPTION
## Problem
`scripts/qa/unwrap-budget.sh` — part of the mandatory `make qa-fast` pre-commit gate documented in CLAUDE.md/AGENTS.md — strips spaces/LF from `.unwrap-budget` but not CR:

    BUDGET=$(cat "$BUDGET_FILE" | tr -d ' \n')

On any checkout with `core.autocrlf=true` (the Git-for-Windows installer's recommended default), `.unwrap-budget` gets CRLF line endings, so `BUDGET` becomes `"163\r"`. The subsequent

    if [[ "$CURRENT" -gt "$BUDGET" ]]; then ...
    if [[ "$CURRENT" -lt "$BUDGET" ]]; then ...

then throw a bash arithmetic syntax error that — being inside an `if` condition, exempt from `set -e` — is silently swallowed, and the script exits 0 regardless of whether the budget is actually exceeded.

Verified this is a genuine silent gate bypass, not just noisy output: with a CRLF-terminated budget file set to `1` and the real unwrap/expect count at 158 (158 >> 1), the unpatched script still exits 0.

## Fix
Strip `\r` too:

    -BUDGET=$(cat "$BUDGET_FILE" | tr -d ' \n')
    +BUDGET=$(cat "$BUDGET_FILE" | tr -d ' \r\n')

## Validation
- `bash scripts/qa/unwrap-budget.sh` now passes cleanly on a CRLF-terminated `.unwrap-budget` (verified on a fresh checkout with `core.autocrlf=true`)
- Confirmed the fix still correctly fails (exit 1, clear message) when the budget is genuinely exceeded, even with a CRLF-terminated `.unwrap-budget`
- Checked sibling QA scripts (`typos.sh`, `audit.sh`, `semver.sh`) for the same class of bug — none read a checked-in single-value file the same way, so this appears isolated to `unwrap-budget.sh`

**Class A** (mechanical one-line shell fix, no behavior change beyond correcting the bug) — `make qa-fast` is sufficient.

Not a duplicate of prior `unwrap-budget.sh` fixes (#2002 / #2012 / #2261 — those addressed awk truncation and test-code miscounting, not line endings).

Fixes #3008
