### PR TITLE
fix(daemon): reclaim memory pools once no live node can reach them

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -694,6 +694,37 @@ fn reclaim_memory_pools_after_exit(
     }
 }
 
+/// Release everything this daemon still holds for a dataflow that just
+/// finished here: its pool table entries, plus the `/dev/shm` segments of
+/// `owned_nodes` that no table entry covers.
+///
+/// A daemon that outlives the dataflow (`dora up`) would otherwise carry
+/// every unfreed pool — table entry and segment alike — until it exits
+/// (dora-rs/dora#2881). Releasing the table entries is unconditional,
+/// deliberately: a dynamic node can outlive the finish (`should_finish`
+/// ignores them), but the dataflow's routing, channels and listeners are gone
+/// by now, so it can no longer send or receive anything a pool would serve,
+/// and no later event would ever reach [`reclaim_memory_pools_after_exit`]
+/// for this dataflow.
+///
+/// This is a *per-daemon* finish and `/dev/shm` is host-wide, so the sweep is
+/// restricted to this daemon's own nodes — see
+/// [`MemoryPoolManager::cleanup_orphans`].
+///
+/// A free function rather than a method so it can be exercised without a
+/// whole `Daemon`.
+fn release_memory_pools_of_finished_dataflow(
+    memory_pool: &MemoryPoolManager,
+    dataflow_id: Uuid,
+    owned_nodes: &BTreeSet<NodeId>,
+) {
+    let dataflow_id = dataflow_id.to_string();
+    memory_pool.cleanup_dataflow(&dataflow_id);
+    MemoryPoolManager::cleanup_orphans(&dataflow_id, |node| {
+        owned_nodes.iter().any(|id| id.as_ref() == node)
+    });
+}
+
 /// Convert MemoryPoolMetadata into daemon-protocol MetadataParameters.
 fn pool_metadata_to_params(meta: &MemoryPoolMetadata) -> MetadataParameters {
     use dora_message::metadata::Parameter;
@@ -2835,6 +2866,9 @@ impl Daemon {
                     // entry is registered.
                     running_node.mark_registered();
                     dataflow.running_nodes.insert(node_id.clone(), running_node);
+                    // Added after the spawn cohort, so it is not in
+                    // `spawn_nodes` — record it as ours for the orphan sweep.
+                    dataflow.owned_nodes.insert(node_id.clone());
 
                     // Update the daemon's stored descriptor so
                     // descriptor-based lookups (e.g. AllInputsClosed
@@ -3995,10 +4029,13 @@ impl Daemon {
         uv: bool,
         write_events_to: Option<PathBuf>,
     ) -> eyre::Result<impl Future<Output = eyre::Result<()>> + use<>> {
-        // Sweep orphaned /dev/shm segments from a previous crash of the
-        // same dataflow (keyed by dataflow_id, a UUID — safe in multi-
-        // daemon setups).
-        MemoryPoolManager::cleanup_orphans(&dataflow_id.to_string());
+        // Sweep orphaned /dev/shm segments left by a previous crash of this
+        // dataflow's nodes, scoped to the nodes this daemon spawns — a
+        // co-located daemon may be spawning the other half of the same
+        // dataflow right now (see `cleanup_orphans`).
+        MemoryPoolManager::cleanup_orphans(&dataflow_id.to_string(), |node| {
+            spawn_nodes.iter().any(|id| id.as_ref() == node)
+        });
 
         let mut logger = self
             .logger
@@ -4011,6 +4048,7 @@ impl Daemon {
             self.daemon_id.clone(),
             dataflow_descriptor.clone(),
         );
+        dataflow.owned_nodes = spawn_nodes.clone();
         // Read from the descriptor, which is the one copy that survives
         // everything a dataflow outlives: auto-recovery re-spawn,
         // coordinator restart with state reconstruction, and `dora
@@ -5699,24 +5737,13 @@ impl Daemon {
         if let Some(df) = self.running.get(&dataflow_id) {
             let _ = df.listener_shutdown_tx.send(true);
         }
-        self.running.remove(&dataflow_id);
+        let owned_nodes = self
+            .running
+            .remove(&dataflow_id)
+            .map(|dataflow| dataflow.owned_nodes)
+            .unwrap_or_default();
 
-        // Release the dataflow's memory pools. A daemon that outlives the
-        // dataflow (`dora up`) would otherwise carry every unfreed pool —
-        // table entry and /dev/shm segment alike — until it exits
-        // (dora-rs/dora#2881). The orphan sweep additionally catches
-        // segments a node created but crashed before registering, which no
-        // table entry covers.
-        //
-        // Unconditional, deliberately: a dynamic node can outlive the
-        // finish (`should_finish` ignores them), but the remove above just
-        // discarded its routing, channels and listeners, so it can no
-        // longer send or receive anything a pool would serve. Keeping the
-        // pools would strand them until daemon exit with no path left to
-        // reclaim them — this dataflow will never reach `reclaim_unreachable`
-        // again.
-        self.memory_pool.cleanup_dataflow(&dataflow_id.to_string());
-        MemoryPoolManager::cleanup_orphans(&dataflow_id.to_string());
+        release_memory_pools_of_finished_dataflow(&self.memory_pool, dataflow_id, &owned_nodes);
 
         Ok(())
     }
@@ -9814,6 +9841,54 @@ mod fault_tolerance_tests {
 
             assert_eq!(memory_pool.table_size(), expected, "case: {case}");
         }
+    }
+
+    #[test]
+    fn finishing_a_dataflow_releases_every_pool_it_still_holds() {
+        let (_running, memory_pool) = dataflow_with_pool(&[("sender", "recv")], &["recv"]);
+
+        // Owned nodes only scope the /dev/shm sweep; the table release is
+        // unconditional. `recv` was still running and could still have
+        // reached this pool, but the dataflow is over and no later event
+        // would ever reclaim it.
+        release_memory_pools_of_finished_dataflow(&memory_pool, Uuid::nil(), &BTreeSet::new());
+
+        assert_eq!(memory_pool.table_size(), 0);
+    }
+
+    /// `finish_dataflow` is a *per-daemon* finish, but `/dev/shm` is
+    /// host-wide: with two daemons serving one dataflow on one machine, the
+    /// first to finish must not unlink the segments of the second daemon's
+    /// still-running nodes (dora-rs/dora#2881 review). `cleanup_orphans` has
+    /// its own test for which names it matches; this one pins the wiring —
+    /// that the finish path passes its own nodes and not something wider.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn finishing_a_dataflow_sweeps_only_this_daemons_segments() {
+        let dataflow_id = Uuid::new_v4();
+        let segment = |node: &str| {
+            std::path::PathBuf::from(format!("/dev/shm/dora_pool_{dataflow_id}_{node}_0"))
+        };
+        // `ours` never registered its pool — a crash between creating the
+        // segment and registering it is exactly what the orphan sweep is
+        // for. `theirs` belongs to the co-located daemon.
+        for node in ["ours", "theirs"] {
+            std::fs::write(segment(node), b"x").unwrap();
+        }
+
+        let owned_nodes = BTreeSet::from([NodeId::from("ours".to_string())]);
+        release_memory_pools_of_finished_dataflow(
+            &MemoryPoolManager::new(),
+            dataflow_id,
+            &owned_nodes,
+        );
+
+        let (ours, theirs) = (segment("ours").exists(), segment("theirs").exists());
+        for node in ["ours", "theirs"] {
+            let _ = std::fs::remove_file(segment(node));
+        }
+        assert!(!ours, "this daemon's orphaned segment must be swept");
+        assert!(theirs, "the co-located daemon's live segment must survive");
     }
 }
 

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -694,6 +694,30 @@ fn reclaim_memory_pools_after_exit(
     }
 }
 
+/// Widen the reader set of every pool the new edge `source` -> `target`
+/// exposes, so reclamation cannot outrun a rewiring of a running dataflow.
+///
+/// Whoever can reach a pool can forward its id along a new outgoing edge, so
+/// `target` — and everything downstream of it — joins the pools `source`
+/// could already reach. `source` registering the pool itself is the case
+/// that bites: it is in its own reader set, so without this an exiting
+/// `source` would take the pool with it while the freshly connected
+/// consumer still holds the id (dora-rs/dora#2881).
+///
+/// Must run *after* the edge is recorded, so the closure sees it.
+fn extend_pool_readers_for_new_edge(
+    memory_pool: &MemoryPoolManager,
+    dataflow: &RunningDataflow,
+    source: &NodeId,
+    target: &NodeId,
+) {
+    memory_pool.extend_potential_readers(
+        &dataflow.id.to_string(),
+        source.as_ref(),
+        &dataflow.downstream_closure(target),
+    );
+}
+
 /// Release everything this daemon still holds for a dataflow that just
 /// finished here: its pool table entries, plus the `/dev/shm` segments of
 /// `owned_nodes` that no table entry covers.
@@ -2847,6 +2871,20 @@ impl Daemon {
                         }
                     }
 
+                    // Same as `AddMapping`: each input the new node declares
+                    // is a new edge, so the pools its source can reach must
+                    // now count this node as a possible reader.
+                    for input in inputs.values() {
+                        if let InputMapping::User(mapping) = &input.mapping {
+                            extend_pool_readers_for_new_edge(
+                                &self.memory_pool,
+                                dataflow,
+                                &mapping.source,
+                                &node_id,
+                            );
+                        }
+                    }
+
                     if is_dynamic {
                         dataflow.dynamic_nodes.insert(node_id.clone());
                     }
@@ -3459,7 +3497,20 @@ impl Daemon {
                 // explicit `AddMappingResult` so the coordinator can pattern-
                 // match the outcome (same class as #1682's AddNodeResult).
                 let result = if let Some(dataflow) = self.running.get_mut(&dataflow_id) {
-                    dataflow.add_mapping(source_node, source_output, target_node, target_input);
+                    dataflow.add_mapping(
+                        source_node.clone(),
+                        source_output,
+                        target_node.clone(),
+                        target_input,
+                    );
+                    // The new edge gives `target_node` a path to the source's
+                    // pools — including any the source registered itself.
+                    extend_pool_readers_for_new_edge(
+                        &self.memory_pool,
+                        dataflow,
+                        &source_node,
+                        &target_node,
+                    );
                     Ok(())
                 } else {
                     Err(format!("no running dataflow with ID `{dataflow_id}`"))
@@ -4166,9 +4217,17 @@ impl Daemon {
                         }
                     }
                 } else if let InputMapping::User(mapping) = input.mapping {
+                    let output_id = OutputId(mapping.source, mapping.output);
+                    // This daemon does not deliver the edge, but it still
+                    // needs to know it exists: the receiver's own consumers
+                    // may be local again, and a memory-pool id can travel
+                    // the whole chain (`downstream_closure`).
                     dataflow
-                        .open_external_mappings
-                        .insert(OutputId(mapping.source, mapping.output));
+                        .remote_edges
+                        .entry(output_id.clone())
+                        .or_default()
+                        .insert(node.id.clone());
+                    dataflow.open_external_mappings.insert(output_id);
                 }
             }
         }
@@ -9841,6 +9900,61 @@ mod fault_tolerance_tests {
 
             assert_eq!(memory_pool.table_size(), expected, "case: {case}");
         }
+    }
+
+    /// `potential_readers` is captured at registration time, so rewiring a
+    /// running dataflow would otherwise leave it stale. The registrar is in
+    /// its own reader set and reclamation fires on its exit, so without the
+    /// update the pool — and its `/dev/shm` segment — would go away while a
+    /// consumer connected a moment ago still had its id in flight
+    /// (dora-rs/dora#2881 review).
+    #[test]
+    fn a_consumer_connected_after_registration_still_pins_the_pool() {
+        let sender = NodeId::from("sender".to_string());
+        let consumer = NodeId::from("consumer".to_string());
+
+        let mut df = test_dataflow();
+        df.running_nodes.insert(sender.clone(), test_running_node());
+
+        // Registered while `sender` has no consumers at all.
+        let memory_pool = MemoryPoolManager::new();
+        memory_pool
+            .register_memory_pool(
+                MemoryPoolId {
+                    dataflow_id: Uuid::nil().to_string(),
+                    id: "pool-1".to_string(),
+                },
+                MemoryPoolMetadata::default(),
+                sender.to_string(),
+                df.downstream_closure(&sender),
+            )
+            .unwrap();
+
+        // `dora graph connect sender/out consumer/in`.
+        df.add_mapping(
+            sender.clone(),
+            DataId::from("out".to_string()),
+            consumer.clone(),
+            DataId::from("in".to_string()),
+        );
+        df.running_nodes
+            .insert(consumer.clone(), test_running_node());
+        extend_pool_readers_for_new_edge(&memory_pool, &df, &sender, &consumer);
+
+        // The sender sends the pool id along the new edge and exits.
+        let mut running = HashMap::from([(Uuid::nil(), df)]);
+        reclaim_memory_pools_after_exit(&memory_pool, &running, Uuid::nil(), &sender);
+        assert_eq!(
+            memory_pool.table_size(),
+            1,
+            "the newly connected consumer can still read the pool"
+        );
+
+        // ...and it is reclaimed once that consumer is gone too.
+        let df = running.get_mut(&Uuid::nil()).expect("dataflow is present");
+        df.running_nodes.remove(&sender);
+        reclaim_memory_pools_after_exit(&memory_pool, &running, Uuid::nil(), &consumer);
+        assert_eq!(memory_pool.table_size(), 0);
     }
 
     #[test]

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -651,6 +651,49 @@ async fn collect_and_send_metrics_bg(
     Ok(())
 }
 
+/// Release the memory pools that nothing can reach now that `exited_node`'s
+/// incarnation is gone.
+///
+/// Which pools those are is decided by the rest of the dataflow: see
+/// [`MemoryPoolManager::reclaim_unreachable`] for why an exited node's pools
+/// cannot simply be dropped (dora-rs/dora#2881).
+///
+/// Every path that ends an incarnation calls this: `RemoveNode`,
+/// `ReplaceNode` (whose outgoing exit event the generation guard drops), and
+/// `SpawnedNodeResult` for a crash, a clean exit or a restart. `exited_node`
+/// is excluded from the live set explicitly, because the last of those runs
+/// before the node leaves `running_nodes` — and because a replacement or
+/// restart under the same id never touched its predecessor's pools.
+///
+/// Takes its two fields separately rather than `&self` so callers can hold a
+/// logger (which borrows `self.logger`) across it.
+fn reclaim_memory_pools_after_exit(
+    memory_pool: &MemoryPoolManager,
+    running: &HashMap<DataflowId, RunningDataflow>,
+    dataflow_id: Uuid,
+    exited_node: &NodeId,
+) {
+    // No dataflow left means `finish_dataflow` already released its pools
+    // unconditionally.
+    let Some(dataflow) = running.get(&dataflow_id) else {
+        return;
+    };
+    let released = memory_pool.reclaim_unreachable(&dataflow_id.to_string(), |node| {
+        dataflow
+            .running_nodes
+            .keys()
+            .any(|id| id != exited_node && id.as_ref() == node)
+    });
+    if !released.is_empty() {
+        tracing::info!(
+            %dataflow_id,
+            node_id = %exited_node,
+            "released {} memory pool(s) that no live node can reach any more",
+            released.len(),
+        );
+    }
+}
+
 /// Convert MemoryPoolMetadata into daemon-protocol MetadataParameters.
 fn pool_metadata_to_params(meta: &MemoryPoolMetadata) -> MetadataParameters {
     use dora_message::metadata::Parameter;
@@ -2957,6 +3000,17 @@ impl Daemon {
                     Ok(())
                 })();
 
+                // Without this, repeated add/remove cycles walk the daemon
+                // into its pool cap (dora-rs/dora#2881).
+                if result.is_ok() {
+                    reclaim_memory_pools_after_exit(
+                        &self.memory_pool,
+                        &self.running,
+                        dataflow_id,
+                        &node_id,
+                    );
+                }
+
                 // Outside the closure because it is async. Why removal
                 // has to drive the barrier at all: see
                 // `PendingNodes::handle_node_removal`.
@@ -3340,6 +3394,15 @@ impl Daemon {
                     // The outgoing (or an even earlier) incarnation's stale
                     // result must not be attributed to the replacement.
                     clear_node_result(&mut self.dataflow_node_results, dataflow_id, &node_id);
+                    // The outgoing incarnation's exit event is dropped by
+                    // the generation guard, so this is the only place its
+                    // pools can be reclaimed (dora-rs/dora#2881).
+                    reclaim_memory_pools_after_exit(
+                        &self.memory_pool,
+                        &self.running,
+                        dataflow_id,
+                        &node_id,
+                    );
                 }
                 let reply = DaemonCoordinatorReply::ReplaceNodeResult(
                     result.map_err(|err| format!("{err:?}")),
@@ -4825,6 +4888,16 @@ impl Daemon {
                         ));
                     }
 
+                    // Snapshot who may still ask for this pool without
+                    // having opened it yet, so that reclaiming the pools of
+                    // an exited node cannot cut off a transfer that is still
+                    // on its way (dora-rs/dora#2881).
+                    let potential_readers = self
+                        .running
+                        .get(&dataflow_id)
+                        .map(|dataflow| dataflow.downstream_closure(&node_id))
+                        .unwrap_or_default();
+
                     self.memory_pool.register_memory_pool(
                         MemoryPoolId {
                             dataflow_id: dataflow_id.to_string(),
@@ -4832,6 +4905,7 @@ impl Daemon {
                         },
                         pool_metadata,
                         node_id.to_string(),
+                        potential_readers,
                     )
                 })();
                 let _ = reply_sender.send(DaemonReply::Result(result));
@@ -5627,6 +5701,23 @@ impl Daemon {
         }
         self.running.remove(&dataflow_id);
 
+        // Release the dataflow's memory pools. A daemon that outlives the
+        // dataflow (`dora up`) would otherwise carry every unfreed pool —
+        // table entry and /dev/shm segment alike — until it exits
+        // (dora-rs/dora#2881). The orphan sweep additionally catches
+        // segments a node created but crashed before registering, which no
+        // table entry covers.
+        //
+        // Unconditional, deliberately: a dynamic node can outlive the
+        // finish (`should_finish` ignores them), but the remove above just
+        // discarded its routing, channels and listeners, so it can no
+        // longer send or receive anything a pool would serve. Keeping the
+        // pools would strand them until daemon exit with no path left to
+        // reclaim them — this dataflow will never reach `reclaim_unreachable`
+        // again.
+        self.memory_pool.cleanup_dataflow(&dataflow_id.to_string());
+        MemoryPoolManager::cleanup_orphans(&dataflow_id.to_string());
+
         Ok(())
     }
 
@@ -6047,6 +6138,15 @@ impl Daemon {
                     // mid-startup (dora-rs/dora#2270).
                     dataflow.connected_nodes.remove(&node_id);
                 }
+
+                // This incarnation is gone — crash, clean exit, or a restart
+                // about to spawn a fresh one (dora-rs/dora#2881).
+                reclaim_memory_pools_after_exit(
+                    &self.memory_pool,
+                    &self.running,
+                    dataflow_id,
+                    &node_id,
+                );
 
                 logger
                     .log(
@@ -8037,7 +8137,14 @@ mod fault_tolerance_tests {
 
         let id = test_pool_id("pool-1");
         pools
-            .register_memory_pool(id.clone(), test_pool_metadata(), registrar.to_string())
+            .register_memory_pool(
+                id.clone(),
+                test_pool_metadata(),
+                registrar.to_string(),
+                // No edges in this fixture, so no downstream consumer can
+                // learn the id; the free path ignores the set either way.
+                Default::default(),
+            )
             .unwrap();
         pools
             .read_memory_pool(&id, reader.as_ref())
@@ -8176,7 +8283,12 @@ mod fault_tolerance_tests {
         let pools = MemoryPoolManager::new();
         let id = test_pool_id("pool-1");
         pools
-            .register_memory_pool(id.clone(), test_pool_metadata(), "registrar".into())
+            .register_memory_pool(
+                id.clone(),
+                test_pool_metadata(),
+                "registrar".into(),
+                Default::default(),
+            )
             .unwrap();
 
         free_pool_and_notify(&pools, None, &id, "registrar", &clock).expect("free should succeed");
@@ -9603,6 +9715,105 @@ mod fault_tolerance_tests {
             &mut deadline,
             window
         ));
+    }
+
+    // -- dora#2881: memory pools must be reclaimed once nothing can reach them --
+
+    /// A dataflow whose `sender` registered one pool, with `edges` wired up
+    /// and every node of `running` marked as running.
+    fn dataflow_with_pool(
+        edges: &[(&str, &str)],
+        running: &[&str],
+    ) -> (HashMap<DataflowId, RunningDataflow>, MemoryPoolManager) {
+        let mut df = test_dataflow();
+        for (from, to) in edges {
+            df.add_mapping(
+                NodeId::from(from.to_string()),
+                DataId::from("out".to_string()),
+                NodeId::from(to.to_string()),
+                DataId::from("in".to_string()),
+            );
+        }
+        for node in running {
+            df.running_nodes
+                .insert(NodeId::from(node.to_string()), test_running_node());
+        }
+
+        let memory_pool = MemoryPoolManager::new();
+        let sender = NodeId::from("sender".to_string());
+        memory_pool
+            .register_memory_pool(
+                MemoryPoolId {
+                    dataflow_id: Uuid::nil().to_string(),
+                    id: "pool-1".to_string(),
+                },
+                MemoryPoolMetadata::default(),
+                sender.to_string(),
+                df.downstream_closure(&sender),
+            )
+            .unwrap();
+
+        (HashMap::from([(Uuid::nil(), df)]), memory_pool)
+    }
+
+    #[test]
+    fn a_pool_is_reclaimed_on_node_exit_exactly_when_nothing_can_reach_it() {
+        // (case, edges, still-running nodes, exiting node, pools left)
+        let cases = [
+            // The receiver has not read the pool yet — it only learns the id
+            // from the message the sender put in flight before exiting.
+            // Freeing here would break that transfer, which is why
+            // reclamation is reachability-based rather than eager.
+            (
+                "consumer still running",
+                &[("sender", "recv")][..],
+                &["recv"][..],
+                "sender",
+                1,
+            ),
+            // ...and once that consumer is gone too, nothing can reach it.
+            (
+                "last consumer gone",
+                &[("sender", "recv")][..],
+                &[][..],
+                "recv",
+                0,
+            ),
+            // Callers run before the node leaves `running_nodes`, so its own
+            // stale entry must not count as a live reference — otherwise a
+            // sender with no consumers could never be reclaimed.
+            (
+                "exiting node is not itself live",
+                &[][..],
+                &["sender"][..],
+                "sender",
+                0,
+            ),
+            // Liveness is checked against the pool's own reference set, not
+            // the dataflow as a whole: a node that is neither downstream of
+            // the sender nor has ever opened the pool cannot reach it, so a
+            // long-lived unrelated node must not pin it (the leak this fixes).
+            (
+                "unrelated node running",
+                &[("other_source", "other_sink")][..],
+                &["other_sink"][..],
+                "sender",
+                0,
+            ),
+        ];
+
+        for (case, edges, running_nodes, exiting, expected) in cases {
+            let (running, memory_pool) = dataflow_with_pool(edges, running_nodes);
+
+            reclaim_memory_pools_after_exit(
+                &memory_pool,
+                &running,
+                Uuid::nil(),
+                &NodeId::from(exiting.to_string()),
+            );
+
+            assert_eq!(memory_pool.table_size(), expected, "case: {case}");
+        }
     }
 }
 

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -30,7 +30,7 @@ use crossbeam::queue::ArrayQueue;
 use eyre::eyre;
 use futures::FutureExt;
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     sync::{
         Arc,
         atomic::{self, AtomicBool, AtomicU32, AtomicU64},
@@ -1007,6 +1007,36 @@ impl RunningDataflow {
         node_output_ids(&self.mappings, &self.open_external_mappings, node_id)
     }
 
+    /// Every node reachable from `source` by following output→input edges,
+    /// transitively, plus `source` itself.
+    ///
+    /// Used to snapshot who may still learn a memory-pool id registered by
+    /// `source`: the id travels the dataflow as ordinary message data, so any
+    /// node downstream of the registrar may still receive it — including
+    /// nodes further along that a direct consumer forwards it to. The daemon
+    /// cannot see pool ids inside payloads, so the whole downstream closure
+    /// counts as a potential reader (dora-rs/dora#2881).
+    ///
+    /// Returns node ids as `String` because that is how the pool table keys
+    /// them.
+    pub(crate) fn downstream_closure(&self, source: &NodeId) -> HashSet<String> {
+        let mut reachable = HashSet::from([source.to_string()]);
+        let mut queue = vec![source.clone()];
+        while let Some(node) = queue.pop() {
+            for (output_id, receivers) in &self.mappings {
+                if output_id.0 != node {
+                    continue;
+                }
+                for (receiver, _input) in receivers {
+                    if reachable.insert(receiver.to_string()) {
+                        queue.push(receiver.clone());
+                    }
+                }
+            }
+        }
+        reachable
+    }
+
     /// Nodes blocking an otherwise-finished dataflow (dora-rs/dora#2152).
     ///
     /// Returns nodes that should be force-stopped because the dataflow is
@@ -1622,6 +1652,46 @@ mod tests {
             type_rules: vec![],
             env: None,
         }
+    }
+
+    // ---- dora-rs/dora#2881: downstream closure for memory-pool reachability ----
+
+    /// Wire `from/out -> to/in`.
+    fn edge(df: &mut RunningDataflow, from: &str, to: &str) {
+        df.add_mapping(node_id(from), data_id("out"), node_id(to), data_id("in"));
+    }
+
+    #[test]
+    fn downstream_closure_follows_edges_transitively() {
+        let mut df =
+            RunningDataflow::new(uuid::Uuid::nil(), DaemonId::new(None), empty_descriptor());
+        edge(&mut df, "sender", "middle");
+        edge(&mut df, "middle", "sink");
+        edge(&mut df, "unrelated", "other");
+
+        // A direct consumer may forward a pool id further down, so the whole
+        // downstream chain counts — and nothing outside it does.
+        assert_eq!(
+            df.downstream_closure(&node_id("sender")),
+            HashSet::from([
+                "sender".to_string(),
+                "middle".to_string(),
+                "sink".to_string(),
+            ]),
+        );
+    }
+
+    #[test]
+    fn downstream_closure_terminates_on_a_cycle() {
+        let mut df =
+            RunningDataflow::new(uuid::Uuid::nil(), DaemonId::new(None), empty_descriptor());
+        edge(&mut df, "sender", "peer");
+        edge(&mut df, "peer", "sender");
+
+        assert_eq!(
+            df.downstream_closure(&node_id("sender")),
+            HashSet::from(["sender".to_string(), "peer".to_string()]),
+        );
     }
 
     #[test]

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -292,6 +292,11 @@ pub struct RunningDataflow {
     /// Per-node pending message counters (incremented on send, decremented on recv)
     pub(crate) pending_messages: HashMap<NodeId, Arc<AtomicU64>>,
     pub(crate) mappings: HashMap<OutputId, BTreeSet<(NodeId, DataId)>>,
+    /// Edges whose receiver lives on another daemon, which `mappings` (this
+    /// daemon's delivery table) does not record. Only `downstream_closure`
+    /// reads them, to follow a chain that leaves this daemon and returns to
+    /// it (dora-rs/dora#2881).
+    pub(crate) remote_edges: HashMap<OutputId, BTreeSet<NodeId>>,
     pub(crate) timers: BTreeMap<Duration, BTreeSet<(NodeId, DataId)>>,
     /// Nodes subscribing to `dora/logs` virtual input.
     pub(crate) log_subscribers: Vec<LogSubscriber>,
@@ -402,6 +407,7 @@ impl RunningDataflow {
             subscribe_channels: HashMap::new(),
             pending_messages: HashMap::new(),
             mappings: HashMap::new(),
+            remote_edges: HashMap::new(),
             timers: BTreeMap::new(),
             log_subscribers: Vec::new(),
             open_inputs: BTreeMap::new(),
@@ -1024,20 +1030,32 @@ impl RunningDataflow {
     /// cannot see pool ids inside payloads, so the whole downstream closure
     /// counts as a potential reader (dora-rs/dora#2881).
     ///
+    /// Remote receivers are followed too, via `remote_edges`: `mappings`
+    /// holds only edges this daemon delivers, so a chain that leaves the
+    /// daemon and comes back — `local -> remote -> local` — would otherwise
+    /// stop at the first hop and lose the local node at its end. A remote
+    /// node never counts as live (pools are host-local), so including it
+    /// costs nothing; reaching *past* it is the point.
+    ///
     /// Returns node ids as `String` because that is how the pool table keys
     /// them.
     pub(crate) fn downstream_closure(&self, source: &NodeId) -> HashSet<String> {
         let mut reachable = HashSet::from([source.to_string()]);
         let mut queue = vec![source.clone()];
         while let Some(node) = queue.pop() {
-            for (output_id, receivers) in &self.mappings {
-                if output_id.0 != node {
-                    continue;
-                }
-                for (receiver, _input) in receivers {
-                    if reachable.insert(receiver.to_string()) {
-                        queue.push(receiver.clone());
-                    }
+            let local = self
+                .mappings
+                .iter()
+                .filter(|(output_id, _)| output_id.0 == node)
+                .flat_map(|(_, receivers)| receivers.iter().map(|(receiver, _input)| receiver));
+            let remote = self
+                .remote_edges
+                .iter()
+                .filter(|(output_id, _)| output_id.0 == node)
+                .flat_map(|(_, receivers)| receivers.iter());
+            for receiver in local.chain(remote) {
+                if reachable.insert(receiver.to_string()) {
+                    queue.push(receiver.clone());
                 }
             }
         }
@@ -1678,6 +1696,30 @@ mod tests {
 
         // A direct consumer may forward a pool id further down, so the whole
         // downstream chain counts — and nothing outside it does.
+        assert_eq!(
+            df.downstream_closure(&node_id("sender")),
+            HashSet::from([
+                "sender".to_string(),
+                "middle".to_string(),
+                "sink".to_string(),
+            ]),
+        );
+    }
+
+    #[test]
+    fn downstream_closure_follows_a_chain_through_another_daemon() {
+        let mut df =
+            RunningDataflow::new(uuid::Uuid::nil(), DaemonId::new(None), empty_descriptor());
+        // `sender -> middle` leaves this daemon, so it is not in `mappings`;
+        // `middle -> sink` comes back to a local node. A pool id can travel
+        // the whole chain, so `sink` must count as a potential reader even
+        // though the only path to it runs through the other daemon.
+        df.remote_edges
+            .entry(OutputId(node_id("sender"), data_id("out")))
+            .or_default()
+            .insert(node_id("middle"));
+        edge(&mut df, "middle", "sink");
+
         assert_eq!(
             df.downstream_closure(&node_id("sender")),
             HashSet::from([

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -299,6 +299,12 @@ pub struct RunningDataflow {
     pub(crate) input_deadlines: HashMap<(NodeId, DataId), InputDeadline>,
     pub(crate) broken_inputs: HashMap<(NodeId, DataId), Duration>,
     pub(crate) running_nodes: BTreeMap<NodeId, RunningNode>,
+    /// Every node of this dataflow that runs on *this* daemon, whether or
+    /// not it is still running. Only grows, so it still answers "was this
+    /// node ours?" at teardown, when `running_nodes` has long since dropped
+    /// the exited ones. Scopes the `/dev/shm` orphan sweep — see
+    /// `MemoryPoolManager::cleanup_orphans` (dora-rs/dora#2881).
+    pub(crate) owned_nodes: BTreeSet<NodeId>,
     pub(crate) dynamic_nodes: BTreeSet<NodeId>,
     pub(crate) open_external_mappings: BTreeSet<OutputId>,
     pub(crate) _timer_handles: BTreeMap<Duration, futures::future::RemoteHandle<()>>,
@@ -402,6 +408,7 @@ impl RunningDataflow {
             input_deadlines: HashMap::new(),
             broken_inputs: HashMap::new(),
             running_nodes: BTreeMap::new(),
+            owned_nodes: BTreeSet::new(),
             dynamic_nodes: BTreeSet::new(),
             open_external_mappings: Default::default(),
             _timer_handles: BTreeMap::new(),

--- a/examples/memory-pool/README.md
+++ b/examples/memory-pool/README.md
@@ -67,8 +67,22 @@ Expected warnings/info:
 - write after free:
   - `Attempt to write memory pool [memory_pool_id] failed - reason: pool does not exist. Operation aborted.`
 - auto cleanup:
-  - `Detected xx unreleased memory pool, releasing...`
-  - `Successfully released xx unreleased memory pools!`
+  - `Detected xx unreleased memory pool of finished dataflow <id>, releasing...`
+
+## Pool lifetime
+
+A pool outlives the node that registered it. The normal lifecycle is that a
+sender registers a pool and a *receiver* reads it — and possibly frees it —
+which may happen after the sender has already exited. The daemon therefore
+never drops a node's pools just because that node went away.
+
+Instead each pool records who can still reach it: the nodes that have opened
+it, plus the registering node's downstream consumers, which can still learn
+the pool id from a message that is already in flight. A pool is released as
+soon as none of those nodes is running any more, and unconditionally when the
+dataflow finishes — so a node that crashes or is removed with `dora node
+remove` no longer strands its pools for the rest of the dataflow
+([#2881](https://github.com/dora-rs/dora/issues/2881)).
 
 ## Notes
 

--- a/libraries/extensions/memory-pool/src/lib.rs
+++ b/libraries/extensions/memory-pool/src/lib.rs
@@ -56,9 +56,11 @@ pub struct MemoryPoolEntry {
     pub touched_by: HashSet<String>,
     /// Nodes that have not opened this pool (yet) but could still learn its
     /// id from a message in flight — the registering node's downstream
-    /// consumers as of registration time. Together with `touched_by` this is
-    /// the set of nodes that may still reference the pool; see
-    /// [`MemoryPoolManager::reclaim_unreachable`].
+    /// consumers. Together with `touched_by` this is the set of nodes that
+    /// may still reference the pool; see
+    /// [`MemoryPoolManager::reclaim_unreachable`]. Rewiring a running
+    /// dataflow adds to it, via
+    /// [`MemoryPoolManager::extend_potential_readers`].
     pub potential_readers: HashSet<String>,
 }
 
@@ -69,6 +71,11 @@ impl MemoryPoolEntry {
             .iter()
             .chain(&self.potential_readers)
             .any(|node| is_live(node))
+    }
+
+    /// Whether `node` is one of the nodes that may reference this pool.
+    fn references(&self, node: &str) -> bool {
+        self.touched_by.contains(node) || self.potential_readers.contains(node)
     }
 }
 
@@ -284,6 +291,33 @@ impl MemoryPoolManager {
         is_live: impl Fn(&str) -> bool,
     ) -> Vec<MemoryPoolId> {
         self.release_matching(dataflow_id, |entry| !entry.reachable(&is_live))
+    }
+
+    /// Record that `new_readers` can now reach every pool of `dataflow_id`
+    /// that `via` can already reach.
+    ///
+    /// Reachability is otherwise fixed at registration time, which
+    /// under-approximates the moment a running dataflow is rewired. A new
+    /// edge out of `via` — `dora graph connect`, or a node added with an
+    /// input from `via` — hands its target a path to every pool `via` can
+    /// reach, the ones `via` registered itself included. Without this the
+    /// pool would be released when `via` exits, while the new consumer still
+    /// has its id in flight and the segment unlinked under it.
+    ///
+    /// Callers pass the target's *downstream closure*, not just the target:
+    /// the pool id can be forwarded on from there like any other.
+    pub fn extend_potential_readers(
+        &self,
+        dataflow_id: &str,
+        via: &str,
+        new_readers: &HashSet<String>,
+    ) {
+        let mut table = self.lock_table();
+        for (id, entry) in table.iter_mut() {
+            if id.dataflow_id == dataflow_id && entry.references(via) {
+                entry.potential_readers.extend(new_readers.iter().cloned());
+            }
+        }
     }
 
     /// Release every pool of a finished dataflow, and return the released
@@ -787,6 +821,36 @@ mod tests {
         assert!(
             mgr.read_memory_pool(&other, "sender").is_some(),
             "a same-named pool of another dataflow must not be touched"
+        );
+    }
+
+    #[test]
+    fn extending_the_reader_set_only_touches_pools_the_source_can_reach() {
+        let mgr = MemoryPoolManager::new();
+        let mine = make_id("pool-1");
+        mgr.register_memory_pool(mine.clone(), make_metadata(), "sender".into(), readers(&[]))
+            .unwrap();
+        let other = make_id("pool-2");
+        mgr.register_memory_pool(
+            other.clone(),
+            make_metadata(),
+            "stranger".into(),
+            readers(&[]),
+        )
+        .unwrap();
+
+        // `sender` is wired to a new consumer after registering `pool-1`.
+        mgr.extend_potential_readers("test_df", "sender", &readers(&["late_consumer"]));
+
+        let released = mgr.reclaim_unreachable("test_df", |node| node == "late_consumer");
+        assert_eq!(
+            released,
+            vec![other],
+            "only the pool `sender` can reach may gain the new reader"
+        );
+        assert!(
+            mgr.read_memory_pool(&mine, "late_consumer").is_some(),
+            "the consumer wired to `sender` must keep `pool-1` alive"
         );
     }
 

--- a/libraries/extensions/memory-pool/src/lib.rs
+++ b/libraries/extensions/memory-pool/src/lib.rs
@@ -54,6 +54,22 @@ pub struct MemoryPoolEntry {
     /// All nodes that have accessed this pool (registered or read).
     /// Used to send targeted cleanup notifications on free.
     pub touched_by: HashSet<String>,
+    /// Nodes that have not opened this pool (yet) but could still learn its
+    /// id from a message in flight — the registering node's downstream
+    /// consumers as of registration time. Together with `touched_by` this is
+    /// the set of nodes that may still reference the pool; see
+    /// [`MemoryPoolManager::reclaim_unreachable`].
+    pub potential_readers: HashSet<String>,
+}
+
+impl MemoryPoolEntry {
+    /// Whether any node that could still reference this pool is alive.
+    fn reachable(&self, is_live: &impl Fn(&str) -> bool) -> bool {
+        self.touched_by
+            .iter()
+            .chain(&self.potential_readers)
+            .any(|node| is_live(node))
+    }
 }
 
 /// Result summary for daemon shutdown cleanup.
@@ -89,11 +105,17 @@ impl MemoryPoolManager {
     }
 
     /// Register a memory pool with the given ID and metadata.
+    ///
+    /// `potential_readers` lists the nodes that may still ask for this pool
+    /// without having opened it yet (the registrar's downstream consumers).
+    /// It keeps the pool alive until none of them can use it any more — see
+    /// [`Self::reclaim_unreachable`].
     pub fn register_memory_pool(
         &self,
         id: MemoryPoolId,
         metadata: MemoryPoolMetadata,
         registered_by: String,
+        potential_readers: HashSet<String>,
     ) -> Result<(), String> {
         let mut table = self.lock_table();
 
@@ -109,6 +131,7 @@ impl MemoryPoolManager {
                 metadata,
                 registered_by,
                 touched_by: touched,
+                potential_readers,
             },
         );
 
@@ -179,13 +202,17 @@ impl MemoryPoolManager {
             );
         }
 
-        if let Some(shm_name) = &entry.metadata.shared_memory_name
-            && !shm_name.is_empty()
-        {
-            self.free_shared_memory(shm_name)?;
-        }
+        self.release_segment(&entry.metadata)?;
 
         Ok((entry.metadata, entry.touched_by))
+    }
+
+    /// Unlink an entry's backing segment, if it has one.
+    fn release_segment(&self, metadata: &MemoryPoolMetadata) -> Result<(), String> {
+        match &metadata.shared_memory_name {
+            Some(name) if !name.is_empty() => self.free_shared_memory(name),
+            _ => Ok(()),
+        }
     }
 
     fn free_shared_memory(&self, shm_name: &str) -> Result<(), String> {
@@ -223,6 +250,87 @@ impl MemoryPoolManager {
                 shm_name
             ))
         }
+    }
+
+    /// Release every pool of `dataflow_id` that no live node can reach any
+    /// more, and return the released ids.
+    ///
+    /// A pool deliberately outlives the node that registered it: the normal
+    /// lifecycle is that a sender registers a pool and a *receiver* reads
+    /// and frees it, possibly well after the sender exited. Dropping a
+    /// node's pools the moment it goes away would therefore break in-flight
+    /// transfers. Instead every entry records who can still reach it — the
+    /// nodes that already opened it (`touched_by`) plus the registrar's
+    /// downstream consumers (`potential_readers`), which can still learn the
+    /// pool id from a message that is already on its way. The pool is
+    /// released once none of those nodes is running any more, which for a
+    /// removed or crashed node happens as soon as the last of its consumers
+    /// is gone instead of only at dataflow teardown (dora-rs/dora#2881).
+    ///
+    /// Because a released pool has no live node in `touched_by`, there is
+    /// nobody left to send a `FreeMemoryPool` notification to — unlike
+    /// `free_memory_pool`, which must tell the other holders to drop their
+    /// per-process buffers.
+    ///
+    /// `is_live` reports whether a node is still running **on this daemon**.
+    /// Nodes on other daemons never qualify, and must not: pools are
+    /// host-local shared memory and every daemon keeps its own table, so a
+    /// remote consumer can never open this one's segments. It is called
+    /// with the pool table locked, so it must stay cheap and must not
+    /// re-enter the manager.
+    pub fn reclaim_unreachable(
+        &self,
+        dataflow_id: &str,
+        is_live: impl Fn(&str) -> bool,
+    ) -> Vec<MemoryPoolId> {
+        self.release_matching(dataflow_id, |entry| !entry.reachable(&is_live))
+    }
+
+    /// Release every pool of a finished dataflow, and return the released
+    /// ids.
+    ///
+    /// Unlike [`Self::reclaim_unreachable`] this needs no liveness check:
+    /// the dataflow is over, so none of its nodes can ask for a pool any
+    /// more. Without it a daemon that outlives the dataflow (`dora up`)
+    /// would hold every unfreed pool until it exits (dora-rs/dora#2881).
+    pub fn cleanup_dataflow(&self, dataflow_id: &str) -> Vec<MemoryPoolId> {
+        let released = self.release_matching(dataflow_id, |_| true);
+        if !released.is_empty() {
+            tracing::info!(
+                "Detected {} unreleased memory pool of finished dataflow {dataflow_id}, releasing...",
+                released.len(),
+            );
+        }
+        released
+    }
+
+    /// Drop the entries of `dataflow_id` that `should_release` accepts and
+    /// unlink their segments, returning the released ids.
+    ///
+    /// The table lock is released before the unlinks, matching
+    /// `free_memory_pool`: the `remove_file` syscalls must not serialize
+    /// unrelated pool operations.
+    fn release_matching(
+        &self,
+        dataflow_id: &str,
+        mut should_release: impl FnMut(&MemoryPoolEntry) -> bool,
+    ) -> Vec<MemoryPoolId> {
+        let released: Vec<(MemoryPoolId, MemoryPoolEntry)> = {
+            let mut table = self.lock_table();
+            table
+                .extract_if(|id, entry| id.dataflow_id == dataflow_id && should_release(entry))
+                .collect()
+        };
+
+        released
+            .into_iter()
+            .map(|(id, entry)| {
+                if let Err(err) = self.release_segment(&entry.metadata) {
+                    tracing::warn!("failed to release memory pool {}: {err}", id.id);
+                }
+                id
+            })
+            .collect()
     }
 
     /// Sweep orphaned shared-memory segments from a previous crash or
@@ -268,12 +376,10 @@ impl MemoryPoolManager {
 
     /// Cleanup all memory pools on shutdown.
     pub fn cleanup_all(&self) -> Result<CleanupSummary, Vec<String>> {
-        let mut table = self.lock_table();
         // Drain the table in one move instead of cloning every key into a
-        // `Vec` only to look each one back up and remove it. The guard is held
-        // for the rest of the function (matching the previous locking window);
-        // `free_shared_memory` does not re-enter the table.
-        let drained = std::mem::take(&mut *table);
+        // `Vec` only to look each one back up and remove it, and release the
+        // guard before the unlinks below (see `release_matching`).
+        let drained = std::mem::take(&mut *self.lock_table());
         let unreleased_count = drained.len();
         let mut errors = Vec::new();
 
@@ -285,10 +391,7 @@ impl MemoryPoolManager {
         }
 
         for (_id, entry) in drained {
-            if let Some(shm_name) = &entry.metadata.shared_memory_name
-                && !shm_name.is_empty()
-                && let Err(err) = self.free_shared_memory(shm_name)
-            {
+            if let Err(err) = self.release_segment(&entry.metadata) {
                 errors.push(err);
             }
         }
@@ -349,13 +452,18 @@ mod tests {
         }
     }
 
+    /// The registrar's downstream consumers at registration time.
+    fn readers(nodes: &[&str]) -> HashSet<String> {
+        nodes.iter().map(|n| n.to_string()).collect()
+    }
+
     #[test]
     fn register_and_read() {
         let mgr = MemoryPoolManager::new();
         let id = make_id("pool-1");
         let meta = make_metadata();
 
-        mgr.register_memory_pool(id.clone(), meta.clone(), "node_a".into())
+        mgr.register_memory_pool(id.clone(), meta.clone(), "node_a".into(), readers(&[]))
             .unwrap();
         let read = mgr
             .read_memory_pool(&id, "node_a")
@@ -373,10 +481,10 @@ mod tests {
         let id = make_id("pool-1");
         let meta = make_metadata();
 
-        mgr.register_memory_pool(id.clone(), meta.clone(), "node_a".into())
+        mgr.register_memory_pool(id.clone(), meta.clone(), "node_a".into(), readers(&[]))
             .unwrap();
         let err = mgr
-            .register_memory_pool(id, meta, "node_a".into())
+            .register_memory_pool(id, meta, "node_a".into(), readers(&[]))
             .unwrap_err();
 
         assert!(err.contains("already registered"));
@@ -390,7 +498,7 @@ mod tests {
         let id = make_id("pool-1");
         let meta = make_metadata();
 
-        mgr.register_memory_pool(id.clone(), meta, "node_a".into())
+        mgr.register_memory_pool(id.clone(), meta, "node_a".into(), readers(&[]))
             .unwrap();
         // A different node frees the pool — this must succeed.
         mgr.free_memory_pool(&id, "node_b").unwrap();
@@ -405,7 +513,7 @@ mod tests {
         let id = make_id("pool-1");
         let meta = make_metadata();
 
-        mgr.register_memory_pool(id.clone(), meta, "node_a".into())
+        mgr.register_memory_pool(id.clone(), meta, "node_a".into(), readers(&[]))
             .unwrap();
         mgr.free_memory_pool(&id, "node_a").unwrap();
 
@@ -426,6 +534,7 @@ mod tests {
                 make_id(&format!("pool-{i}")),
                 make_metadata(),
                 "node_a".into(),
+                readers(&[]),
             )
             .unwrap();
         }
@@ -453,6 +562,7 @@ mod tests {
                 make_id(&format!("pool-{}", i)),
                 make_metadata(),
                 "node_a".into(),
+                readers(&[]),
             )
             .unwrap();
         }
@@ -468,13 +578,18 @@ mod tests {
         let mgr = MemoryPoolManager::new();
 
         // One entry frees cleanly (no backing shmem name)...
-        mgr.register_memory_pool(make_id("ok"), make_metadata(), "node_a".into())
-            .unwrap();
+        mgr.register_memory_pool(
+            make_id("ok"),
+            make_metadata(),
+            "node_a".into(),
+            readers(&[]),
+        )
+        .unwrap();
         // ...and one whose shared_memory_name fails the `dora_pool_` validation
         // in `free_shared_memory`, so its release errors.
         let mut bad_meta = make_metadata();
         bad_meta.shared_memory_name = Some("invalid_name".to_string());
-        mgr.register_memory_pool(make_id("bad"), bad_meta, "node_a".into())
+        mgr.register_memory_pool(make_id("bad"), bad_meta, "node_a".into(), readers(&[]))
             .unwrap();
 
         // cleanup_all must surface the failure (rather than silently claiming
@@ -490,7 +605,7 @@ mod tests {
         assert_eq!(mgr.table_size(), 0);
 
         let id = make_id("pool-1");
-        mgr.register_memory_pool(id.clone(), make_metadata(), "node_a".into())
+        mgr.register_memory_pool(id.clone(), make_metadata(), "node_a".into(), readers(&[]))
             .unwrap();
         assert_eq!(mgr.table_size(), 1);
 
@@ -514,5 +629,126 @@ mod tests {
     fn cleanup_orphans_runs_without_panic() {
         // Sweep should run cleanly without panicking regardless of platform.
         MemoryPoolManager::cleanup_orphans("test-dataflow-uuid");
+    }
+
+    // -- dora#2881: pools must be reclaimed once nothing can reach them --
+
+    #[test]
+    fn registrar_exit_keeps_a_pool_a_live_reader_can_still_reach() {
+        // The normal lifecycle: the sender registers a pool, sends its id
+        // downstream and exits. The receiver has not opened the pool yet,
+        // so `touched_by` is still just the sender — freeing here would
+        // break the in-flight transfer.
+        let mgr = MemoryPoolManager::new();
+        let id = make_id("pool-1");
+        mgr.register_memory_pool(
+            id.clone(),
+            make_metadata(),
+            "sender".into(),
+            readers(&["recv"]),
+        )
+        .unwrap();
+
+        let released = mgr.reclaim_unreachable("test_df", |node| node == "recv");
+
+        assert!(
+            released.is_empty(),
+            "pool must survive: `recv` can still read it"
+        );
+        assert!(mgr.read_memory_pool(&id, "recv").is_some());
+    }
+
+    #[test]
+    fn pool_is_released_once_no_live_node_can_reach_it() {
+        let mgr = MemoryPoolManager::new();
+        let id = make_id("pool-1");
+        mgr.register_memory_pool(
+            id.clone(),
+            make_metadata(),
+            "sender".into(),
+            readers(&["recv"]),
+        )
+        .unwrap();
+
+        // Both the sender and its only downstream consumer are gone.
+        let released = mgr.reclaim_unreachable("test_df", |_| false);
+
+        assert_eq!(released, vec![id.clone()]);
+        assert_eq!(mgr.table_size(), 0);
+    }
+
+    #[test]
+    fn a_live_reader_that_never_was_a_potential_reader_keeps_the_pool() {
+        // `potential_readers` is a snapshot of the topology at registration
+        // time; a node that actually opened the pool must keep it alive on
+        // its own, even if it is not in that snapshot.
+        let mgr = MemoryPoolManager::new();
+        let id = make_id("pool-1");
+        mgr.register_memory_pool(id.clone(), make_metadata(), "sender".into(), readers(&[]))
+            .unwrap();
+        mgr.read_memory_pool(&id, "late_reader").unwrap();
+
+        let released = mgr.reclaim_unreachable("test_df", |node| node == "late_reader");
+
+        assert!(released.is_empty());
+        assert_eq!(mgr.table_size(), 1);
+    }
+
+    #[test]
+    fn reclaim_is_scoped_to_one_dataflow() {
+        let mgr = MemoryPoolManager::new();
+        let mine = make_id("pool-1");
+        let other = MemoryPoolId {
+            dataflow_id: "other_df".to_string(),
+            id: "pool-1".to_string(),
+        };
+        mgr.register_memory_pool(mine.clone(), make_metadata(), "sender".into(), readers(&[]))
+            .unwrap();
+        mgr.register_memory_pool(
+            other.clone(),
+            make_metadata(),
+            "sender".into(),
+            readers(&[]),
+        )
+        .unwrap();
+
+        let released = mgr.reclaim_unreachable("test_df", |_| false);
+
+        assert_eq!(released, vec![mine]);
+        assert!(
+            mgr.read_memory_pool(&other, "sender").is_some(),
+            "a same-named pool of another dataflow must not be touched"
+        );
+    }
+
+    #[test]
+    fn cleanup_dataflow_releases_every_pool_of_that_dataflow() {
+        let mgr = MemoryPoolManager::new();
+        for i in 0..3 {
+            mgr.register_memory_pool(
+                make_id(&format!("pool-{i}")),
+                make_metadata(),
+                "sender".into(),
+                readers(&["recv"]),
+            )
+            .unwrap();
+        }
+        let other = MemoryPoolId {
+            dataflow_id: "other_df".to_string(),
+            id: "pool-1".to_string(),
+        };
+        mgr.register_memory_pool(
+            other.clone(),
+            make_metadata(),
+            "sender".into(),
+            readers(&[]),
+        )
+        .unwrap();
+
+        // A finished dataflow has no nodes left, so liveness plays no role.
+        let released = mgr.cleanup_dataflow("test_df");
+
+        assert_eq!(released.len(), 3);
+        assert_eq!(mgr.table_size(), 1, "the other dataflow's pool must remain");
     }
 }

--- a/libraries/extensions/memory-pool/src/lib.rs
+++ b/libraries/extensions/memory-pool/src/lib.rs
@@ -333,14 +333,28 @@ impl MemoryPoolManager {
             .collect()
     }
 
-    /// Sweep orphaned shared-memory segments from a previous crash or
-    /// SIGKILL of the same dataflow.
+    /// Sweep orphaned shared-memory segments of `dataflow_id` that belong to
+    /// one of *this daemon's* nodes.
     ///
-    /// `dataflow_id` scopes the sweep — only files matching
-    /// `dora_pool_{dataflow_id}_*` are removed.  This is safe even when
-    /// other daemons are running on the same host, because dataflow IDs
-    /// are UUIDs and no two daemons run the same one concurrently.
-    pub fn cleanup_orphans(dataflow_id: &str) {
+    /// Catches what the pool table cannot: a segment whose creator died
+    /// between `shm_open` and `register_memory_pool` has no entry to release.
+    ///
+    /// Ownership matters because `/dev/shm` is host-wide while the segment
+    /// name carries only the *dataflow* id: sweeping by dataflow id alone
+    /// reaches every daemon on the host. Two daemons serving one dataflow on
+    /// one machine (a `machine:` split) is a supported deployment, and there
+    /// the daemon that finishes first would unlink the other's *live*
+    /// segments, leaving a consumer over there with `ENOENT`. Both call sites
+    /// are per-daemon: the spawn-time sweep races the peer daemon's spawn,
+    /// the finish-time one runs while the peer may still be going. A node id
+    /// belongs to at most one daemon, so `is_local_node` keeps the sweep
+    /// host-safe without narrowing what it can reclaim.
+    ///
+    /// Segments are named `dora_pool_{dataflow_id}_{node_id}_{counter}`. Node
+    /// ids may contain `_`, the counter never does, so the last component
+    /// splits off the node id; a name that does not fit the pattern belongs
+    /// to nobody identifiable and is left alone.
+    pub fn cleanup_orphans(dataflow_id: &str, is_local_node: impl Fn(&str) -> bool) {
         #[cfg(target_os = "linux")]
         {
             let prefix = format!("dora_pool_{}_", dataflow_id);
@@ -349,8 +363,16 @@ impl MemoryPoolManager {
                     for entry in entries.flatten() {
                         let name = entry.file_name();
                         let name = name.to_string_lossy();
-                        if name.starts_with(&prefix)
-                            && let Err(err) = std::fs::remove_file(entry.path())
+                        let Some((node_id, counter)) = name
+                            .strip_prefix(&prefix)
+                            .and_then(|rest| rest.rsplit_once('_'))
+                        else {
+                            continue;
+                        };
+                        if counter.parse::<u64>().is_err() || !is_local_node(node_id) {
+                            continue;
+                        }
+                        if let Err(err) = std::fs::remove_file(entry.path())
                             && err.kind() != std::io::ErrorKind::NotFound
                         {
                             tracing::debug!(
@@ -370,7 +392,7 @@ impl MemoryPoolManager {
         }
         #[cfg(not(target_os = "linux"))]
         {
-            let _ = dataflow_id;
+            let _ = (dataflow_id, is_local_node);
         }
     }
 
@@ -628,7 +650,54 @@ mod tests {
     #[test]
     fn cleanup_orphans_runs_without_panic() {
         // Sweep should run cleanly without panicking regardless of platform.
-        MemoryPoolManager::cleanup_orphans("test-dataflow-uuid");
+        MemoryPoolManager::cleanup_orphans("test-dataflow-uuid", |_| true);
+    }
+
+    /// Two daemons on one host serve one dataflow, so both see the other's
+    /// segments under the same `dora_pool_{dataflow_id}_` prefix. The sweep
+    /// must unlink only its own daemon's nodes, or a finishing daemon
+    /// destroys a live segment the peer daemon's consumer has not mapped
+    /// yet (dora-rs/dora#2881 review).
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn cleanup_orphans_leaves_another_daemons_segments_alone() {
+        // Unique per run, so concurrent tests cannot collide in /dev/shm.
+        let dataflow_id = format!("test-df-{}-scoped", std::process::id());
+        let segment = |name: &str| std::path::PathBuf::from(format!("/dev/shm/{name}"));
+        // (segment name, must survive the sweep)
+        let files = [
+            (format!("dora_pool_{dataflow_id}_local_0"), false),
+            // A node id may itself contain '_', so only the last component
+            // is the counter: this is node `local_with_underscore`, not
+            // `local_with` or `local`.
+            (
+                format!("dora_pool_{dataflow_id}_local_with_underscore_7"),
+                false,
+            ),
+            (format!("dora_pool_{dataflow_id}_remote_0"), true),
+            // Not `{node}_{counter}` — attributable to nobody, so kept.
+            (format!("dora_pool_{dataflow_id}_local_notacounter"), true),
+            // Another dataflow entirely, even for a local node id.
+            (format!("dora_pool_{dataflow_id}other_local_0"), true),
+        ];
+        for (file, _) in &files {
+            std::fs::write(segment(file), b"x").unwrap();
+        }
+
+        MemoryPoolManager::cleanup_orphans(&dataflow_id, |node| {
+            matches!(node, "local" | "local_with_underscore")
+        });
+
+        let outcome: Vec<(&str, bool)> = files
+            .iter()
+            .map(|(file, _)| (file.as_str(), segment(file).exists()))
+            .collect();
+        for (file, _) in &files {
+            let _ = std::fs::remove_file(segment(file));
+        }
+        for ((file, expected_kept), (_, kept)) in files.iter().zip(&outcome) {
+            assert_eq!(kept, expected_kept, "{file}");
+        }
     }
 
     // -- dora#2881: pools must be reclaimed once nothing can reach them --


### PR DESCRIPTION
Fixes #2881.

Pools registered by a node stayed in the daemon's table until the daemon itself
exited: neither `RemoveNode` nor a node crash released them, and `finish_dataflow`
did not either — so a long-running daemon (`dora up`) accumulated table entries and
`/dev/shm` segments across dataflows, walking toward the 512-entry pool cap.

Eagerly freeing a node's pools when it goes away would be wrong, as @SaitejaKommi
pointed out on the issue: a pool deliberately outlives its registrar. The normal
lifecycle is that a sender registers a pool and a *receiver* reads and frees it,
possibly well after the sender exited.

So reclaim by reachability instead. Each entry records who can still reach it:

- `touched_by` — nodes that have opened the pool, and
- `potential_readers` — the registrar's transitive downstream consumers as of
  registration time, which can still learn the pool id from a message already in
  flight (the daemon cannot see pool ids inside payloads, so the whole downstream
  closure counts).

A pool is released once none of those is still running locally. Every path that ends
an incarnation now checks: `RemoveNode`, `ReplaceNode` (whose outgoing exit event the
generation guard drops), and a crash, clean exit or restart. `finish_dataflow`
releases the remainder unconditionally — a finished dataflow has no node left to
serve, and its routing, channels and listeners are discarded in the same breath.

Nodes on other daemons never count as live: pools are host-local shared memory and
each daemon keeps its own table, so a remote consumer can never open this one's
segments.

Because a reclaimed pool has no live node in `touched_by`, there is nobody to send a
`FreeMemoryPool` notification to — unlike `free_memory_pool`, which must tell the
other holders to drop their per-process buffers.

`finish_dataflow` also sweeps the `/dev/shm` segments no table entry covers — a node
that died between creating a segment and registering it. That sweep is now scoped to
the nodes of *this* daemon, which it was not before: `/dev/shm` is host-wide, the
segment name embeds only the dataflow id, and `finish_dataflow` is a per-daemon
finish. With two daemons serving one dataflow on one machine (a `machine:` split),
whichever finished first would have unlinked the other's *live* segments, leaving a
consumer over there with `ENOENT`. `RunningDataflow` tracks its local nodes for this,
and the pre-existing spawn-time sweep — same hazard, narrower window — is scoped the
same way.

`register_memory_pool` gains a `potential_readers` parameter, `MemoryPoolEntry` a
field, and `cleanup_orphans` an `is_local_node` predicate, so this is a breaking
change to the `dora-memory-pool` crate surface. Its only consumer is `dora-daemon`.

Reachability cannot be a registration-time snapshot, because a running dataflow can
be rewired. `dora graph connect S/out C/in` after `S` registered a pool gives `C` a
path to it, and `S` is in its own reader set, so reclamation on `S`'s exit would have
unlinked the segment while `C` still had the id in flight. `AddMapping` and `AddNode`
therefore widen the reader set of every pool the edge's source can reach, by the new
target's downstream closure. Recomputing the whole set at reclaim time is not an
option — `RemoveNode` tears the node's mappings down first — but widening on the two
paths that create edges covers the same ground.

The closure also follows edges whose receiver is on another daemon. `mappings` holds
only what this daemon delivers, so a `local -> remote -> local` chain used to stop at
the first hop and drop the local node at its end, even though a pool id can travel
the whole way. A remote node never counts as live, so following through one costs
nothing.

Tests: reachability rules and dataflow-scoped cleanup in `dora-memory-pool`; the
downstream closure (transitive, cycle-safe) on `RunningDataflow`; and the daemon
wiring — a pool survives an exited sender while its consumer runs, and is reclaimed
once the last consumer is gone, when the exiting node is its only reference, and
regardless of unrelated long-lived nodes. The finish path is covered too: it releases
a pool a live consumer could still reach, and its `/dev/shm` sweep unlinks this
daemon's orphan while leaving a co-located daemon's segment alone. Plus the two
reachability gaps: a consumer connected after registration keeps the pool alive until
it too is gone, and the closure reaches a local node whose only path runs through
another daemon.
