### PR TITLE
chore(deps): upgrade uhlc 0.5 -> 0.9 (#2446)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2252,7 +2252,7 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "tokio",
- "uhlc 0.5.2",
+ "uhlc 0.9.0",
  "uuid",
 ]
 
@@ -8258,24 +8258,23 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uhlc"
-version = "0.5.2"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d291a7454d390b753ef68df8145da18367e32883ec2fa863959f0aefb915cdb"
+checksum = "b62a645e3e4e6c85b7abe49b086aa3204119431f42b6123b0070419fb6e9d24e"
 dependencies = [
- "hex",
  "humantime",
  "lazy_static",
  "log",
+ "rand 0.8.7",
  "serde",
- "spin 0.9.9",
- "uuid",
+ "spin 0.10.1",
 ]
 
 [[package]]
 name = "uhlc"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62a645e3e4e6c85b7abe49b086aa3204119431f42b6123b0070419fb6e9d24e"
+checksum = "55bb25449f66ea76693b51f631fdd190821683c65e65e68d990b36c2d1ae9dd2"
 dependencies = [
  "humantime",
  "lazy_static",

--- a/binaries/cli/src/ws_client.rs
+++ b/binaries/cli/src/ws_client.rs
@@ -12,8 +12,9 @@ use tokio_tungstenite::tungstenite::Message;
 use uuid::Uuid;
 
 /// Helper for deserializing incoming WS frames without going through
-/// `serde_json::Value` for the result/payload fields. This preserves
-/// u128 fidelity for uhlc::ID inside timestamps.
+/// `serde_json::Value` for the result/payload fields: they are handed to the
+/// caller as raw bytes to be parsed into their real type, so they are never
+/// re-serialized from an intermediate `Value`.
 #[derive(serde::Deserialize)]
 struct IncomingFrame {
     #[serde(default)]
@@ -494,7 +495,8 @@ fn handle_response(
             let err_reply = dora_message::coordinator_to_cli::ControlRequestReply::Error(error);
             Ok(serde_json::to_vec(&err_reply).unwrap_or_default())
         } else if let Some(raw) = result {
-            // Preserve raw JSON bytes to maintain u128 fidelity for uhlc::ID
+            // Hand the raw JSON bytes to the caller, which parses them into the
+            // concrete reply type.
             Ok(raw.get().as_bytes().to_vec())
         } else {
             Err(eyre!("empty WS response"))

--- a/binaries/coordinator/src/run/mod.rs
+++ b/binaries/coordinator/src/run/mod.rs
@@ -281,9 +281,10 @@ mod tests {
     /// `DaemonCoordinatorEvent` variant name from each incoming message,
     /// passes the variant to `reply_fn`, and resolves the pending oneshot.
     ///
-    /// Full deserialization of `Timestamped<DaemonCoordinatorEvent>` is
-    /// intentionally skipped because uhlc timestamps use u128, which does
-    /// not round-trip through `serde_json::Value`.
+    /// It also asserts that the params deserialize into a real
+    /// `Timestamped<DaemonCoordinatorEvent>`, so a malformed frame fails here
+    /// rather than being reduced to an empty variant name and silently taking
+    /// the `reply_fn` fallback branch.
     fn mock_daemon(
         reply_fn: impl Fn(&str) -> DaemonCoordinatorReply + Send + 'static,
     ) -> DaemonConnection {
@@ -296,6 +297,13 @@ mod tests {
             while let Some(msg) = rx.recv().await {
                 let v: serde_json::Value = serde_json::from_str(&msg).unwrap();
                 let id: Uuid = v["id"].as_str().unwrap().parse().unwrap();
+
+                // The whole frame must be a well-formed daemon command, not just
+                // something whose `inner` happens to have one key. This runs in
+                // the mock's task, so a failure surfaces as this panic plus the
+                // caller timing out waiting for a reply that never comes.
+                serde_json::from_value::<Timestamped<DaemonCoordinatorEvent>>(v["params"].clone())
+                    .expect("coordinator sent a malformed Timestamped<DaemonCoordinatorEvent>");
 
                 // Extract variant name from `params.inner`. The params field
                 // is embedded as raw JSON (not a string). For externally-tagged

--- a/binaries/coordinator/src/state.rs
+++ b/binaries/coordinator/src/state.rs
@@ -150,8 +150,8 @@ impl DaemonConnection {
 
     /// Send a message to the daemon and wait for a reply.
     ///
-    /// Embeds raw JSON bytes directly to preserve u128 fidelity
-    /// for uhlc::ID inside timestamps.
+    /// `message` is already-serialized JSON, so it is embedded into the envelope
+    /// verbatim rather than re-parsed into a `serde_json::Value` first.
     pub(crate) async fn send_and_receive(&self, message: &[u8]) -> eyre::Result<Vec<u8>> {
         let id = Uuid::new_v4();
         let params_str =
@@ -206,8 +206,8 @@ impl DaemonConnection {
 
     /// Send a message to the daemon without waiting for a reply (fire-and-forget).
     ///
-    /// Embeds raw JSON bytes directly to preserve u128 fidelity
-    /// for uhlc::ID inside timestamps.
+    /// `message` is already-serialized JSON, so it is embedded into the envelope
+    /// verbatim rather than re-parsed into a `serde_json::Value` first.
     pub(crate) async fn send(&self, message: &[u8]) -> eyre::Result<()> {
         let params_str =
             std::str::from_utf8(message).map_err(|e| eyre!("outgoing message not UTF-8: {e}"))?;

--- a/binaries/coordinator/src/ws_control.rs
+++ b/binaries/coordinator/src/ws_control.rs
@@ -45,8 +45,9 @@ async fn send_ws_response(
 
 /// Format a `WsResponse`-shaped JSON envelope using `serde_json::to_string`.
 ///
-/// This is needed (instead of `send_ws_response`) for replies that contain u128
-/// values (e.g. uhlc::ID) which lose fidelity through `serde_json::Value`.
+/// Used instead of `send_ws_response` where the reply is already a concrete
+/// type: it serializes straight into the envelope rather than materializing an
+/// intermediate `serde_json::Value` for the `WsResponse::result` field.
 fn format_response_json(id: Uuid, reply: &impl serde::Serialize) -> String {
     match serde_json::to_string(reply) {
         Ok(result_json) => {
@@ -370,8 +371,6 @@ pub(crate) async fn handle_control_ws(
 
                 let stop = matches!(reply, ControlRequestReply::CoordinatorStopped);
 
-                // Serialize reply via to_string (not to_value) to preserve u128
-                // fidelity for uhlc::ID inside DataflowResult timestamps.
                 let resp_json = format_response_json(req.id, &reply);
                 if ws_tx.send(Message::Text(resp_json.into())).await.is_err() || stop {
                     break;

--- a/binaries/coordinator/src/ws_daemon.rs
+++ b/binaries/coordinator/src/ws_daemon.rs
@@ -54,7 +54,8 @@ pub(crate) async fn handle_daemon_ws(
                 };
 
                 // Distinguish request vs response by checking for "method" key.
-                // Parse to Value first just for routing (u128 precision loss is OK here).
+                // Parse to Value first just for routing; the typed payload is
+                // deserialized from the raw text below.
                 let value: serde_json::Value = match serde_json::from_str(&text) {
                     Ok(v) => v,
                     Err(e) => {
@@ -65,7 +66,8 @@ pub(crate) async fn handle_daemon_ws(
 
                 if value.get("method").is_some() {
                     // Daemon request: deserialize Timestamped<CoordinatorRequest>
-                    // directly from raw text to preserve u128 fidelity (uhlc::ID).
+                    // directly from the raw text, skipping a second pass over
+                    // the `Value` we only built for routing.
                     if !handle_daemon_request(
                         &text,
                         &event_tx,
@@ -106,8 +108,8 @@ pub(crate) async fn handle_daemon_ws(
 }
 
 /// A helper struct to deserialize `Timestamped<CoordinatorRequest>` directly
-/// from the raw JSON text, bypassing `serde_json::Value` which cannot represent
-/// `u128` numbers (used by `uhlc::ID(NonZeroU128)` in uhlc 0.5.x).
+/// from the raw JSON text, so the payload is parsed once into its real type
+/// instead of going through the `serde_json::Value` used for routing.
 #[derive(serde::Deserialize)]
 struct DaemonWsRequestRaw {
     params: dora_message::daemon_to_coordinator::Timestamped<

--- a/binaries/coordinator/tests/ws_daemon_tests.rs
+++ b/binaries/coordinator/tests/ws_daemon_tests.rs
@@ -37,11 +37,9 @@ async fn connect_control(
 
 /// Build a daemon Register WsRequest JSON string.
 ///
-/// Constructs the full JSON string directly (bypassing `serde_json::Value`)
-/// because `uhlc::ID(NonZeroU128)` can be serialized to a JSON string via
-/// `serde_json::to_string` but not via `serde_json::to_value` (u128 out of range
-/// for the `Value::Number` type). The coordinator deserializes from the raw
-/// JSON text (`serde_json::from_str`), so this matches the real wire format.
+/// Constructs the full JSON string directly, exactly as the daemon does in
+/// `dora_daemon::coordinator::register`, so the test exercises the real wire
+/// format rather than a `serde_json::Value` re-encoding of it.
 fn make_register_request() -> (Uuid, String) {
     let id = Uuid::new_v4();
     let register = CoordinatorRequest::Register(DaemonRegisterRequest::new(
@@ -53,7 +51,7 @@ fn make_register_request() -> (Uuid, String) {
         timestamp: dora_message::uhlc::HLC::default().new_timestamp(),
     };
     // Build WsRequest-shaped JSON manually, embedding the Timestamped params
-    // as a raw JSON fragment to preserve u128 fidelity.
+    // as a raw JSON fragment.
     let params_json = serde_json::to_string(&timestamped).unwrap();
     let full_json = format!(r#"{{"id":"{id}","method":"daemon_request","params":{params_json}}}"#,);
     (id, full_json)

--- a/binaries/daemon/src/coordinator.rs
+++ b/binaries/daemon/src/coordinator.rs
@@ -62,8 +62,8 @@ impl CoordinatorSender {
 
     /// Send a serialized event message to the coordinator (fire-and-forget).
     ///
-    /// Embeds the raw JSON bytes directly to preserve u128 fidelity
-    /// for uhlc::ID inside timestamps.
+    /// `message` is already-serialized JSON, so it is embedded into the envelope
+    /// verbatim rather than re-parsed into a `serde_json::Value` first.
     pub async fn send_event(&self, message: &[u8]) -> eyre::Result<()> {
         let json = Self::format_event_message(message).map_err(|err| eyre!("{err}"))?;
         self.sender
@@ -149,9 +149,8 @@ pub async fn register(
     // The coordinator sender writes to this, and the spawned task reads and forwards to WS.
     let (send_tx, mut send_rx) = mpsc::channel::<String>(64);
 
-    // Send Register request.
-    // Serialize params via to_string (not to_value) to preserve u128 fidelity
-    // for uhlc::ID(NonZeroU128) inside the timestamp.
+    // Send Register request. The params are serialized straight into the
+    // envelope, so they never round-trip through a `serde_json::Value`.
     let register_params_json = serde_json::to_string(&Timestamped {
         inner: CoordinatorRequest::Register(DaemonRegisterRequest::new(machine_id, labels)),
         timestamp: clock.new_timestamp(),
@@ -180,7 +179,7 @@ pub async fn register(
                 continue;
             };
 
-            // Parse directly from raw text to preserve u128 fidelity.
+            // Parse the frame straight into its typed form.
             let raw: RegisterReplyRaw = match serde_json::from_str(&text) {
                 Ok(r) => r,
                 Err(_) => continue,
@@ -225,8 +224,7 @@ pub async fn register(
                         }
                     };
 
-                    // Parse directly from raw text to preserve u128 fidelity
-                    // for uhlc::ID inside timestamps.
+                    // Parse the frame straight into its typed form.
                     let raw: CoordinatorCommandRaw = match serde_json::from_str(&text) {
                         Ok(r) => r,
                         Err(e) => {
@@ -301,15 +299,15 @@ pub async fn register(
     ))
 }
 
-/// Helper for deserializing register reply directly from raw JSON text,
-/// bypassing `serde_json::Value` to preserve u128 fidelity for uhlc::ID.
+/// Helper for deserializing the register reply directly from the raw JSON text,
+/// so the payload is parsed once into its real type.
 #[derive(serde::Deserialize)]
 struct RegisterReplyRaw {
     params: Timestamped<RegisterResult>,
 }
 
-/// Helper for deserializing coordinator commands directly from raw JSON text,
-/// bypassing `serde_json::Value` to preserve u128 fidelity for uhlc::ID.
+/// Helper for deserializing coordinator commands directly from the raw JSON
+/// text, so the payload is parsed once into its real type.
 #[derive(serde::Deserialize)]
 struct CoordinatorCommandRaw {
     id: Uuid,

--- a/libraries/coordinator-store/Cargo.toml
+++ b/libraries/coordinator-store/Cargo.toml
@@ -24,3 +24,6 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+# See the matching note in `libraries/message/Cargo.toml`: `Uuid::new_v4` is
+# test-only here too, and uhlc 0.5 used to enable `uuid/v4` for us by accident.
+uuid = { workspace = true, features = ["v4"] }

--- a/libraries/message/Cargo.toml
+++ b/libraries/message/Cargo.toml
@@ -26,7 +26,7 @@ log = { version = "0.4.33", features = ["serde"] }
 aligned-vec = { version = "0.6.4", features = ["serde"] }
 semver = { workspace = true }
 schemars = "1.2.1"
-uhlc = "0.5.1"
+uhlc = "0.9.0"
 serde_yaml = { workspace = true }
 serde-with-expand-env = "1.1.0"
 bincode = { workspace = true }

--- a/libraries/message/Cargo.toml
+++ b/libraries/message/Cargo.toml
@@ -42,6 +42,10 @@ libc = "0.2"
 tempfile = { workspace = true }
 criterion = { version = "0.8", features = ["html_reports"] }
 proptest = { workspace = true }
+# `Uuid::new_v4` is used only by the `#[cfg(test)]` modules, so `v4` is
+# dev-only. It used to arrive by accident through feature unification: uhlc 0.5
+# depended on `uuid` with `v4` enabled, and the uhlc 0.9 bump dropped that dep.
+uuid = { workspace = true, features = ["v4"] }
 
 [[bench]]
 name = "message_serde"

--- a/libraries/message/tests/uhlc_wire_format.rs
+++ b/libraries/message/tests/uhlc_wire_format.rs
@@ -1,0 +1,164 @@
+//! Wire-format contract between `dora-message` and its `uhlc` dependency.
+//!
+//! `uhlc::Timestamp` is embedded in every bincode-encoded daemon↔node,
+//! daemon↔daemon and record-file message (`Metadata`, `Timestamped`), and in
+//! every JSON-encoded CLI↔coordinator and coordinator↔daemon WebSocket frame.
+//! Its encoding is therefore part of dora's on-the-wire protocol even though the
+//! type is owned by an upstream crate — a silent change to it would corrupt HLC
+//! clock identities across a mixed-version deployment rather than failing
+//! loudly.
+//!
+//! The golden vectors below pin that encoding so a future `uhlc` bump cannot
+//! move it unnoticed. They were captured under `uhlc 0.5.2` and still hold
+//! under `uhlc 0.9.0` (dora-rs/dora#2446): 0.9 changed the in-memory
+//! representation of `ID` from `NonZeroU128` to `[u8; 16]`, but both encode to
+//! the same 16 little-endian bytes under bincode, so the binary plane is
+//! untouched. The JSON plane *did* change shape (see
+//! `timestamp_json_encoding_is_pinned`) — that link is version-gated and now
+//! survives `serde_json::Value`, which the `NonZeroU128` form could not.
+
+use dora_message::{
+    common::Timestamped,
+    metadata::Metadata,
+    uhlc::{ID, NTP64, Timestamp},
+};
+
+/// The pinned bincode encoding of [`golden_timestamp`]: the NTP64 as a
+/// little-endian `u64`, then the HLC id as its 16 little-endian bytes.
+///
+/// This exact vector is what a uhlc-0.5 dora produced and what a uhlc-0.9 dora
+/// produces. If a bump changes it, every daemon↔node message, every inter-daemon
+/// zenoh sample and every `dora record` file written by a different dora version
+/// becomes unreadable — so a test failing against it means a protocol migration
+/// is genuinely required, not that the vector needs updating.
+const TIMESTAMP_HEX: &str = "88776655443322110102030405060708090a0b0c0d0e0f10";
+
+/// A fixed timestamp: an arbitrary but non-round NTP64 and a 16-byte HLC id
+/// whose bytes are all distinct, so any reordering (the failure mode #2446
+/// feared) shows up immediately rather than being masked by symmetry.
+fn golden_timestamp() -> Timestamp {
+    let id_bytes: [u8; 16] = [
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+        0x10,
+    ];
+    Timestamp::new(
+        NTP64(0x1122_3344_5566_7788),
+        ID::try_from(&id_bytes).expect("non-zero id"),
+    )
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+#[test]
+fn timestamp_bincode_encoding_is_pinned() {
+    let encoded = bincode::serialize(&golden_timestamp()).expect("serialize timestamp");
+    assert_eq!(
+        hex(&encoded),
+        TIMESTAMP_HEX,
+        "uhlc::Timestamp bincode encoding changed — this is a protocol break"
+    );
+}
+
+#[test]
+fn timestamp_bincode_round_trips() {
+    let original = golden_timestamp();
+    let encoded = bincode::serialize(&original).expect("serialize");
+    let decoded: Timestamp = bincode::deserialize(&encoded).expect("deserialize");
+
+    assert_eq!(decoded, original);
+    // Compare the id through its byte form too: `PartialEq` alone would still
+    // hold if both sides reordered consistently.
+    assert_eq!(
+        hex(&decoded.get_id().to_le_bytes()),
+        "0102030405060708090a0b0c0d0e0f10"
+    );
+    assert_eq!(decoded.get_time().as_u64(), 0x1122_3344_5566_7788);
+}
+
+#[test]
+fn metadata_bincode_encoding_is_pinned() {
+    // `Metadata` is the envelope that actually rides on every output message,
+    // so pin the composite too: `metadata_version` as a little-endian u16, the
+    // 24-byte timestamp, then the parameter map length as a little-endian u64.
+    let encoded = bincode::serialize(&Metadata::new(golden_timestamp())).expect("serialize");
+    assert_eq!(
+        hex(&encoded),
+        format!(
+            "{version}{TIMESTAMP_HEX}{empty_parameter_map}",
+            version = "0100",
+            empty_parameter_map = "0000000000000000",
+        ),
+        "Metadata bincode encoding changed — bump Metadata::CURRENT_VERSION"
+    );
+}
+
+#[test]
+fn timestamped_bincode_prefix_is_the_inner_value() {
+    // `Timestamped<T>` puts `inner` first and the timestamp last, so the
+    // timestamp's 24 bytes are the tail of every daemon↔coordinator frame.
+    let timestamped = Timestamped {
+        inner: 0xABu8,
+        timestamp: golden_timestamp(),
+    };
+    let encoded = bincode::serialize(&timestamped).expect("serialize");
+    assert_eq!(hex(&encoded), format!("ab{TIMESTAMP_HEX}"));
+}
+
+#[test]
+fn timestamp_json_encoding_is_pinned() {
+    // The CLI↔coordinator and coordinator↔daemon WebSocket links carry
+    // `Timestamped<_>` as JSON text. Under uhlc 0.5 the id serialized as a bare
+    // `u128` number; under 0.9 it is a 16-element little-endian byte array. The
+    // byte *values* are the same and in the same order — only the JSON shape
+    // changed. Both links are gated by the `dora_version` semver handshake, and
+    // a version mismatch now fails at parse time with a type error rather than
+    // being silently misread.
+    let json = serde_json::to_string(&golden_timestamp()).expect("serialize");
+    assert_eq!(
+        json,
+        r#"{"time":1234605616436508552,"id":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]}"#
+    );
+
+    let decoded: Timestamp = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(decoded, golden_timestamp());
+}
+
+#[test]
+fn timestamp_survives_a_serde_json_value_round_trip() {
+    // The property the WS layers could not rely on under uhlc 0.5: an HLC id
+    // large enough to need all 16 bytes exceeds `u64`, and `serde_json::Value`
+    // has no `u128` variant, so `to_value` failed outright with "number out of
+    // range" for *every* real timestamp. That is why the coordinator, daemon
+    // and CLI all embed pre-serialized JSON fragments instead of composing
+    // `Value`s. With the `[u8; 16]` form the round trip is lossless, so that
+    // constraint no longer applies.
+    let original = Timestamped {
+        inner: "payload".to_string(),
+        timestamp: golden_timestamp(),
+    };
+
+    let value = serde_json::to_value(&original).expect("Timestamped must survive to_value");
+    let decoded: Timestamped<String> = serde_json::from_value(value).expect("from_value");
+
+    assert_eq!(decoded.timestamp, original.timestamp);
+    assert_eq!(decoded.inner, original.inner);
+}
+
+#[test]
+fn a_freshly_generated_hlc_id_uses_all_sixteen_bytes() {
+    // Guards the premise of the test above: if `HLC::default()` ever produced a
+    // short id, the `serde_json::Value` round trip would pass for reasons that
+    // do not generalize to production timestamps.
+    let timestamp = dora_message::uhlc::HLC::default().new_timestamp();
+    assert_eq!(timestamp.get_id().size(), 16);
+
+    let value = serde_json::to_value(Timestamped {
+        inner: (),
+        timestamp,
+    })
+    .expect("real HLC timestamp must survive to_value");
+    let decoded: Timestamped<()> = serde_json::from_value(value).expect("from_value");
+    assert_eq!(decoded.timestamp, timestamp);
+}


### PR DESCRIPTION
`dora-message` pinned `uhlc = "0.5.1"`. #2446 deferred the bump to 0.9 on the grounds that 0.9 serializes the HLC `ID` byte-reversed under bincode, so it needed a coordinated protocol migration or a custom serde impl.

That premise is wrong. 0.9 changes the in-memory representation of `ID` from `NonZeroU128` to `[u8; 16]`, but both serialize to the same 16 little-endian bytes — bincode writes a `u128` little-endian, and 0.5 built that `u128` from the id bytes in little-endian order to begin with. Verified by running the new golden-vector tests against both versions with the real `dora-message` types: every bincode vector is byte-identical, and a 0.5-encoded `Timestamp` cross-deserializes into 0.9 (and back) with its id bytes intact. What actually reversed in 0.9 is `ID`'s `Display`/`FromStr`, which dora never uses.

So the binary plane is untouched: daemon↔node, inter-daemon zenoh, and `dora record` files all keep their encoding, and existing recordings replay unchanged. No protocol version bump is needed — bumping `Metadata::CURRENT_VERSION` would have broken node↔daemon compatibility for nothing.

The JSON plane does change shape: on the CLI↔coordinator and coordinator↔daemon WebSocket links the timestamp `id` goes from a bare `u128` number to a 16-element byte array. Both links are already gated by the `dora_version` semver handshake, a mismatch now fails at parse time with a serde type error rather than being misread, and nothing persists a uhlc timestamp as JSON on disk.

That reshape is a net win. Under 0.5 a real HLC id used all 16 bytes, so `serde_json::to_value` failed outright with "number out of range" for *every* timestamp — which is why the coordinator, daemon and CLI all pass pre-serialized JSON fragments around. The `[u8; 16]` form round-trips through `serde_json::Value` losslessly, so this PR corrects the comments documenting that constraint (several still cited `NonZeroU128`) and turns the one place that skipped a check because of it — the coordinator's mock daemon — into a real assertion that daemon commands deserialize.

No source changes were required for the bump itself: `update_with_timestamp`'s error type went from `String` to `ExceedingDeltaError`, but all eight call sites only `Display` it. The dependency tree shrinks — uhlc 0.9's `rand`/`spin` were already present via zenoh's uhlc 0.8, while the 0.5 copy's `hex` and `uuid` deps drop out. MSRV 1.88 still builds.

New `libraries/message/tests/uhlc_wire_format.rs` pins both encodings so a future bump cannot move them unnoticed.

Fixes #2446.
