### PR TITLE
chore(deps): redb 2 -> 4 and sysinfo 0.38 -> 0.39, MSRV 1.88 -> 1.95 (#2449)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Key communication paths:
 ## Workspace Facts
 
 - Rust edition: 2024
-- MSRV: 1.88.0
+- MSRV: 1.95.0
 - Shared workspace versioning
 - Python packages are built with `maturin`, not normal `cargo` flows
 - The repository is in an `adora` -> `dora` consolidation transition. Prefer `dora` names for new code, but preserve documented compatibility paths unless the change is explicitly a breaking cleanup.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1963,7 +1963,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2 0.11.0",
- "sysinfo 0.38.4",
+ "sysinfo 0.39.6",
  "tabwriter",
  "tempfile",
  "termcolor",
@@ -2107,7 +2107,7 @@ dependencies = [
  "shared_memory_extended",
  "shellexpand 3.1.2",
  "shlex",
- "sysinfo 0.38.4",
+ "sysinfo 0.39.6",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -4980,6 +4980,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.13.1",
+ "dispatch2",
+ "objc2",
 ]
 
 [[package]]
@@ -5006,6 +5008,17 @@ checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -6126,9 +6139,9 @@ dependencies = [
 
 [[package]]
 name = "redb"
-version = "2.6.3"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
+checksum = "8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839"
 dependencies = [
  "libc",
 ]
@@ -7511,15 +7524,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.38.4"
+version = "0.39.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
+ "objc2-open-directory",
  "windows 0.62.2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ members = [
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.88.0"
+rust-version = "1.95.0"
 # Python packages derive version from CARGO_PKG_VERSION automatically.
 version = "1.0.0-rc.4"
 description = "`dora` goal is to be a low latency, composable, and distributed data flow."
@@ -165,7 +165,7 @@ tracing = "0.1.44"
 uuid = { version = "1.23", features = ["serde", "v7"] }
 futures = { version = "0.3.32", default-features = false, features = ["std", "async-await"] }
 fs2 = "0.4.3"
-redb = "2"
+redb = "4.1"
 bincode = "1.3.3"
 flume = "0.12.0"
 tempfile = "3.27.0"

--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -68,7 +68,7 @@ colored = { workspace = true }
 crossterm = "0.29.0"
 ratatui = "0.30.2"
 itertools = "0.15"
-sysinfo = "0.38.4"
+sysinfo = "0.39"
 
 env_logger = "0.11.11"
 # self_update 0.44 made the HTTP backend an explicit feature; without

--- a/binaries/daemon/Cargo.toml
+++ b/binaries/daemon/Cargo.toml
@@ -57,7 +57,7 @@ memchr = "2.8.2"
 chrono = { version = "0.4", features = ["serde"] }
 shellexpand = "3.1.2"
 shlex = "2"
-sysinfo = "0.38.4"
+sysinfo = "0.39"
 clonable-command = "0.2.0"
 tokio-tungstenite = "0.29"
 

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -8,7 +8,7 @@ This guide covers how to run, write, and troubleshoot tests across the Dora work
 
 ## Prerequisites
 
-- Rust toolchain — MSRV is the workspace `rust-version` in `Cargo.toml` (currently 1.88.0)
+- Rust toolchain — MSRV is the workspace `rust-version` in `Cargo.toml` (currently 1.95.0)
 - Python 3 with `numpy` and `pyarrow` installed (`pip install numpy pyarrow`) — required for Python smoke tests
 
 ## Quick Start (5-minute validation)

--- a/libraries/coordinator-store/src/lib.rs
+++ b/libraries/coordinator-store/src/lib.rs
@@ -5,10 +5,13 @@ mod redb_store;
 
 pub use in_memory::InMemoryStore;
 
-/// Marker prefix of the error produced by `RedbStore::open` on a schema
-/// version mismatch. The CLI (`dora up`) matches coordinator stderr against
-/// this exact string to decide whether to suggest `--recreate-store`, so any
-/// rewording must update both sites together (covered end-to-end by
+/// Marker prefix of the error produced by `RedbStore::open` when the store on
+/// disk is unusable by this binary: either the record schema version differs,
+/// or the file predates the redb v3 on-disk format (#2449). Both are recovered
+/// the same way -- archive the old file and start fresh -- so they share one
+/// marker. The CLI (`dora up`) matches coordinator stderr against this exact
+/// string to decide whether to suggest `--recreate-store`, so any rewording
+/// must update both sites together (covered end-to-end by
 /// `tests/ws-cli-e2e.rs::e2e_up_reports_incompatible_coordinator_store`).
 pub const SCHEMA_MISMATCH_MARKER: &str = "redb schema version mismatch";
 

--- a/libraries/coordinator-store/src/redb_store.rs
+++ b/libraries/coordinator-store/src/redb_store.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use dora_message::common::DaemonId;
 use eyre::{Result, WrapErr, eyre};
-use redb::{Database, ReadableTable, TableDefinition};
+use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition};
 use uuid::Uuid;
 
 use dora_message::id::NodeId;
@@ -62,8 +62,27 @@ impl RedbStore {
     /// table. On subsequent opens, validates that the stored version matches
     /// the compiled-in version and returns an error if they differ.
     pub fn open(path: &Path) -> Result<Self> {
-        let db = with_restrictive_umask(|| Database::create(path))
-            .wrap_err("failed to open redb database")?;
+        let db = match with_restrictive_umask(|| Database::create(path)) {
+            Ok(db) => db,
+            // redb 3 dropped the v2 on-disk format, so a store written by a
+            // dora built against redb 2.x cannot be read at all (#2449). redb
+            // reports this as a bare "Manual upgrade required", which tells the
+            // user nothing about how to recover, so translate it into the same
+            // marked error a schema bump produces -- `dora up` matches the
+            // marker to suggest `--recreate-store`, which archives the old file
+            // rather than deleting it.
+            Err(redb::DatabaseError::UpgradeRequired(version)) => {
+                return Err(eyre!(
+                    "{marker}: database at `{path}` uses the redb v{version} file format, \
+                     which this binary cannot read. \
+                     Move the file aside and restart to create a fresh database, \
+                     or use `--store memory` to bypass persistence.",
+                    marker = crate::SCHEMA_MISMATCH_MARKER,
+                    path = path.display()
+                ));
+            }
+            Err(err) => return Err(err).wrap_err("failed to open redb database"),
+        };
 
         // Restrict file permissions to owner-only on Unix.
         // NOTE: On Windows, file permissions are governed by ACLs and not
@@ -801,6 +820,53 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// redb 3 dropped support for the v2 on-disk format, so a store written by
+    /// an older dora (redb 2.x) is unreadable after the redb 4 upgrade (#2449).
+    /// That failure must carry [`crate::SCHEMA_MISMATCH_MARKER`] like a bincode
+    /// schema bump does, so `dora up` offers the same `--recreate-store`
+    /// recovery instead of surfacing a bare redb error the user cannot act on.
+    #[test]
+    fn redb_v2_file_format_is_reported_as_a_store_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("v2-format.redb");
+
+        // Create a healthy store, then downgrade its header to the v2 file
+        // format. redb's super-header holds two 128-byte commit slots at
+        // offsets 64 and 192, each starting with a one-byte format version;
+        // it checks that byte before the slot checksum, so stamping both is
+        // enough to make redb reject the file as `UpgradeRequired`.
+        const SLOT_OFFSETS: [u64; 2] = [64, 192];
+        const FILE_FORMAT_VERSION2: u8 = 2;
+        RedbStore::open(&path).unwrap();
+        {
+            use std::io::{Seek, SeekFrom, Write};
+            let mut file = std::fs::OpenOptions::new().write(true).open(&path).unwrap();
+            for offset in SLOT_OFFSETS {
+                file.seek(SeekFrom::Start(offset)).unwrap();
+                file.write_all(&[FILE_FORMAT_VERSION2]).unwrap();
+            }
+            file.sync_all().unwrap();
+        }
+
+        let Err(err) = RedbStore::open(&path) else {
+            panic!("a v2-format store must be rejected");
+        };
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains(crate::SCHEMA_MISMATCH_MARKER),
+            "a v2-format store must be reported with the `{}` marker so `dora up` \
+             can offer `--recreate-store`, got: {msg}",
+            crate::SCHEMA_MISMATCH_MARKER
+        );
+        // Guards the hand-stamped header above: if redb's slot layout ever
+        // moves, the patch stops producing an upgrade error and this fails
+        // rather than silently passing on some unrelated open failure.
+        assert!(
+            msg.contains("file format"),
+            "expected a file-format diagnostic naming the incompatible format, got: {msg}"
+        );
     }
 
     // --- Focused tests for redb_store edge cases (added 2026-04-08) ---

--- a/libraries/extensions/ros2-bridge/msg-gen/src/types/package.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/types/package.rs
@@ -17,7 +17,7 @@ pub struct Package {
 }
 
 impl Package {
-    pub fn new(name: String) -> Self {
+    pub const fn new(name: String) -> Self {
         Self {
             name,
             path: PathBuf::new(),

--- a/tests/ws-cli-e2e.rs
+++ b/tests/ws-cli-e2e.rs
@@ -1017,7 +1017,7 @@ mod real_dataflow {
         cli_to_coordinator::ControlRequest, coordinator_to_cli::ControlRequestReply,
     };
     use fs2::FileExt as _;
-    use redb::{Database, TableDefinition};
+    use redb::{Database, ReadableDatabase, TableDefinition};
     use std::net::SocketAddr;
     use std::path::Path;
     use std::process::{Command, Stdio};


### PR DESCRIPTION
Closes #2449.

Both deps were held back only by the workspace MSRV: every redb 3.x/4.x needs Rust 1.89, and sysinfo 0.39 needs 1.95. This raises `rust-version` to **1.95.0** — the lowest floor that admits both — and takes redb 2.6.3 → 4.1.0 and sysinfo 0.38.4 → 0.39.6. The lockfile diff is exactly those two crates plus one macOS-only transitive (`objc2-open-directory`).

**The store-format break.** redb 3 dropped the v2 on-disk format, so a coordinator store written by an older dora cannot be opened after this bump. redb reports that as a bare `Manual upgrade required. Expected file format version 3, but file is version 2`, which gives the user nothing to act on. `RedbStore::open` now maps `DatabaseError::UpgradeRequired` onto the existing `SCHEMA_MISMATCH_MARKER`, routing it into the recovery path a bincode schema bump already uses: `dora up` prints the `--recreate-store` hint, which *archives* the old file rather than deleting it.

I deliberately did not carry a redb 2.6 dependency to do an in-place `Database::upgrade()`. The store holds coordinator state that daemons re-register on reconnect, `--recreate-store` already preserves the old file, and a permanent second redb major in the tree is a poor trade for a one-time pre-1.0 migration. Happy to revisit if the persisted state turns out to be worth more than that.

**API migration** was small: `begin_read` moved to the new `ReadableDatabase` trait (coordinator-store + the e2e test). The rest of the surface we use is `&str`/`&[u8]`/`u32` tables, so redb 3's variable-width tuple re-encoding and the `Legacy` removal don't apply. sysinfo 0.39 needed no code changes at all.

One incidental fix: raising the MSRV let clippy's MSRV-aware `missing_const_for_fn` reach `Package::new`, which is now `const`.

### Verification

- `cargo fmt --all -- --check`, `cargo clippy --all -- -D warnings` — clean
- `cargo test --all` — 1537 passed. The 2 failures are the container-local `rmw_zenoh_pubsub` discovery timeouts (no multicast), which fail on `main` here too
- `cargo check --examples` — clean
- `cargo test --test ws-cli-e2e -- store` — 5/5, including `e2e_up_recreate_store_archives_incompatible_store`
- `cargo hack check --rust-version --workspace --ignore-private --locked` — 29/29 crates check at 1.95.0
- `make qa-fast` — audit (advisories/bans/**licenses**/sources), typos, unwrap-budget all pass

New regression test `redb_v2_file_format_is_reported_as_a_store_mismatch` stamps a real store's header down to the v2 format and asserts the marked error, so the recovery hint can't silently regress.

### Two things to know

1. **MSRV 1.95.0 is a real jump** (from 1.88.0). Rust 1.95 shipped 2026-04-14, so it's ~4 months old at time of writing. Downstream users on 1.88–1.94 are cut off. If that's too aggressive, a redb-only variant at MSRV 1.89 is a one-line change — sysinfo 0.39 would go back on the blocked list.
2. **The nightly `msrv` job is already failing on `main`**, unrelated to this PR: `dora-core` (and therefore `dora-hub-client`) references `zenoh::Config` at `libraries/core/src/topics.rs:63` while `zenoh` is an optional feature-gated dep, so neither crate builds standalone with default features. It reproduces on stable 1.97.1. Those two are the only crates excluded from the `cargo hack` run above; worth a separate issue.
