### PR TITLE
fix(daemon): end `dora run` nodes when the CLI is killed outright (#2856)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2292,6 +2292,7 @@ dependencies = [
  "futures-timer",
  "inquire",
  "is-terminal",
+ "libc",
  "opentelemetry",
  "serde_json",
  "serde_yaml",

--- a/apis/rust/node/Cargo.toml
+++ b/apis/rust/node/Cargo.toml
@@ -49,6 +49,12 @@ is-terminal = "0.4.17"
 thiserror = { workspace = true }
 uuid = { workspace = true }
 
+# Process-group signalling for the `dora run` orphan guard (`orphan_guard.rs`).
+# Unix-only: the mechanism is `getppid`/`killpg`, which Windows has no
+# equivalent of.
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
 

--- a/apis/rust/node/src/lib.rs
+++ b/apis/rust/node/src/lib.rs
@@ -126,6 +126,7 @@ mod error;
 pub mod event_stream;
 pub mod integration_testing;
 mod node;
+mod orphan_guard;
 
 pub use error::{NodeError, NodeResult, PatternError};
 

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -1130,6 +1130,11 @@ impl DoraNode {
         node_config: NodeConfig,
         testing_communication: Option<TestingCommunication>,
     ) -> NodeResult<(Self, EventStream)> {
+        // Before anything that can fail or block: a node spawned by `dora run`
+        // must not outlive the CLI even if the rest of this initialization
+        // stalls (dora-rs/dora#2856). A no-op on every other spawn path.
+        crate::orphan_guard::arm_if_run_child();
+
         let NodeConfig {
             dataflow_id,
             node_id,

--- a/apis/rust/node/src/orphan_guard.rs
+++ b/apis/rust/node/src/orphan_guard.rs
@@ -1,0 +1,286 @@
+//! Ending a node whose `dora run` parent was killed outright.
+//!
+//! Every cooperative teardown path — the `Stop` event, the daemon's
+//! SIGTERM/SIGKILL ladder, the destroy reaper — needs the daemon to still be
+//! running. `SIGKILL` to `dora run` leaves none of them: the signal is neither
+//! catchable nor blockable, so no CLI- or daemon-side code executes afterwards.
+//!
+//! A node that polls its event stream still notices, because the daemon
+//! connection hits EOF. A node that does not poll — one busy in a long
+//! computation, or blocked on a device — notices nothing and runs forever with
+//! `ppid 1`, holding whatever it held (dora-rs/dora#2856). Nodes are spawned as
+//! process-group *leaders*, on purpose, so that a terminal `Ctrl-C` cannot kill
+//! them out from under the daemon; the same property means neither inherited
+//! signal delivery nor a group-kill of the CLI can reach the orphan.
+//!
+//! So the node watches for itself. The daemon hands it
+//! [`DORA_RUN_PARENT_PID_ENV`] — and *only* when daemon and node-parent are the
+//! same process, which is `dora run` and the other in-process
+//! `Daemon::run_dataflow` callers. Once that pid is gone, this guard `SIGKILL`s
+//! the node's own process group.
+//!
+//! # Why the whole group, not just this process
+//!
+//! The process the daemon tracks is frequently a wrapper: `uv run python
+//! node.py`, `sh -c ...`, a console script. The real node is one level down, in
+//! the wrapper's process group. Ending only the calling process would leave the
+//! interpreter behind — the same orphan, one level down — so the guard signals
+//! the group, exactly as the daemon's own reaper does.
+//!
+//! # Why not `PR_SET_PDEATHSIG`
+//!
+//! Linux can ask the kernel to signal a child when its parent dies, which
+//! needs no thread and covers a node that is killed before it reaches `init`.
+//! It is not enough on its own, and it is not free:
+//!
+//! - It reaches only the *direct* child. Under `--uv` that child is `uv run
+//!   python ...` and the node is one level down, so the interpreter is left
+//!   exactly as orphaned as before — the shape this issue was reported for.
+//! - It fires when the parent **thread** exits, not the parent process. The
+//!   daemon spawns from a tokio worker thread, so the guarantee is only as
+//!   stable as which thread happened to run the spawn — a spawn moved behind
+//!   `spawn_blocking` would start killing nodes early, silently.
+//! - It is Linux-only, and the report is from macOS.
+//!
+//! It remains a reasonable *complement* for the pre-`init` window (see
+//! "Coverage" below); it is not the mechanism.
+//!
+//! # Why `SIGKILL` rather than a `SIGTERM` grace period first
+//!
+//! By the time this fires the daemon is already gone: there is nothing to flush
+//! outputs to, no coordinator to report to, and no one to answer a cooperative
+//! stop. A grace period would also be self-defeating here — `SIGTERM` to the
+//! group includes *this* process, so if it dies on the first rung nothing is
+//! left to deliver the second one to a sibling that ignores `SIGTERM`.
+//!
+//! # Coverage
+//!
+//! A node is guarded from [`DoraNode::init`][crate::DoraNode::init] onwards, so
+//! two gaps remain. A process killed *before* it gets there — a Python node
+//! still in `import torch`, a `uv run` still resolving dependencies — is
+//! orphaned as before. And a node that never calls `init` at all (a `path:
+//! shell` command) is never guarded, because nothing of dora's runs in it.
+//!
+//! Unix only; on Windows this module compiles to a no-op and the gap remains.
+//! Windows has no process groups in this sense, so a node cannot contain its
+//! own tree the way `killpg` does here. The idiomatic equivalent is the job
+//! object the daemon already spawns nodes into (`process_wrap`'s `JobObject`),
+//! which ties the tree to the parent's handle only once
+//! `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` is set — a daemon-side change that
+//! `process-wrap` couples to its `KillOnDrop` wrapper, and therefore to
+//! `Command::kill_on_drop`, altering when every node dies. That is not
+//! verifiable from this workspace, so it is left to a follow-up rather than
+//! shipped untested (dora-rs/dora#2856).
+
+use dora_core::topics::DORA_RUN_PARENT_PID_ENV;
+use std::sync::Once;
+
+/// How often the parent is re-checked.
+///
+/// The parent is already dead when this matters, so the interval is pure
+/// latency between the kill and the node's exit; it buys nothing to poll
+/// faster, and one sleeping thread per node costs nothing to poll this often.
+#[cfg(unix)]
+const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(500);
+
+/// One guard per process, so initializing several nodes (the operator runtime
+/// does) does not accumulate threads all watching the same pid.
+static ARMED: Once = Once::new();
+
+/// Arm the guard if this node was spawned by `dora run`.
+///
+/// A no-op when [`DORA_RUN_PARENT_PID_ENV`] is absent, which is every other
+/// way a node starts: `dora up` + `dora start` (where the node is *meant* to
+/// outlive daemon restarts — dora-rs/dora#2029), a manually launched dynamic
+/// node, interactive mode, and the integration-test harness.
+pub(crate) fn arm_if_run_child() {
+    let Ok(raw) = std::env::var(DORA_RUN_PARENT_PID_ENV) else {
+        return;
+    };
+    let Ok(parent) = raw.trim().parse::<u32>() else {
+        warn(&format!(
+            "ignoring malformed {DORA_RUN_PARENT_PID_ENV}={raw:?}"
+        ));
+        return;
+    };
+    ARMED.call_once(|| arm(parent));
+}
+
+#[cfg(not(unix))]
+fn arm(_parent: u32) {}
+
+#[cfg(unix)]
+fn arm(parent: u32) {
+    let plan = ContainmentPlan::new(parent);
+    // Checked before the thread starts, because the parent may ALREADY be gone:
+    // it can be killed between forking this node and this node reaching
+    // `init`, and a first check only after one sleep would be a window in which
+    // the very orphan this exists to prevent is created.
+    if plan.parent_is_gone() {
+        plan.contain();
+    }
+    let spawned = std::thread::Builder::new()
+        .name("dora-orphan-guard".into())
+        .spawn(move || {
+            loop {
+                std::thread::sleep(POLL_INTERVAL);
+                if plan.parent_is_gone() {
+                    plan.contain();
+                }
+            }
+        });
+    if let Err(err) = spawned {
+        // Not fatal: the node works, it just loses the guarantee. Say so, since
+        // the symptom otherwise only appears much later as a stranded process.
+        warn(&format!(
+            "failed to start the orphan guard ({err}); this node may outlive a \
+             killed `dora run`"
+        ));
+    }
+}
+
+/// What this node will do once `parent` is gone, decided while the parent is
+/// still alive and therefore still inspectable.
+#[cfg(unix)]
+struct ContainmentPlan {
+    parent: libc::pid_t,
+    /// True when this process is the parent's direct child, which makes
+    /// `getppid()` an exact liveness test — see [`Self::parent_is_gone`].
+    direct_child: bool,
+}
+
+#[cfg(unix)]
+impl ContainmentPlan {
+    fn new(parent: u32) -> Self {
+        let parent = parent as libc::pid_t;
+        // SAFETY: reads this process's own parent id.
+        let direct_child = unsafe { libc::getppid() } == parent;
+        Self {
+            parent,
+            direct_child,
+        }
+    }
+
+    /// Whether the process this node may not outlive has exited.
+    ///
+    /// Two checks because there are two shapes. A direct child can settle it
+    /// exactly: the kernel reparents an orphan, so `getppid()` moving away from
+    /// the recorded pid proves that pid is gone, whether or not the id has
+    /// since been recycled.
+    ///
+    /// A node under a wrapper (`uv run python ...`) has the wrapper as its
+    /// parent, not the CLI, so it has to ask about the pid directly. That check
+    /// is one-sided: it can only be fooled by the OS handing the CLI's pid to
+    /// an unrelated process within a poll interval, which reports the parent as
+    /// alive and leaves the node running — today's behavior, never a wrong kill.
+    fn parent_is_gone(&self) -> bool {
+        if self.direct_child {
+            // SAFETY: reads this process's own parent id.
+            return unsafe { libc::getppid() } != self.parent;
+        }
+        // SAFETY: signal 0 delivers nothing; it is a pure existence check.
+        let probe = unsafe { libc::kill(self.parent, 0) };
+        // `EPERM` means the process exists but is not ours to signal, so only
+        // an outright lookup failure counts as gone.
+        probe != 0 && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
+    }
+
+    /// End this node, and everything it spawned alongside it.
+    fn contain(&self) -> ! {
+        // Logged before the kill, which lands on this process too.
+        warn(&format!(
+            "the `dora run` that spawned this node (pid {}) is gone; terminating",
+            self.parent
+        ));
+        // The whole group, not just this process. Signalling only ourselves
+        // would leave a wrapper — and anything else the node started — running:
+        // the same orphan, one level down.
+        //
+        // The group is safe to signal without further checks *because* this
+        // process was handed `DORA_RUN_PARENT_PID`: only the daemon sets it,
+        // only on processes it spawns, and every unix spawn goes through
+        // `ProcessGroup::leader()`, so the group exists solely for this node.
+        //
+        // SAFETY: signals this process's own group. Not a pid lookup, so
+        // nothing here can land on a recycled id.
+        unsafe { libc::killpg(libc::getpgrp(), libc::SIGKILL) };
+        // Reached only if the signal did not land; this process must end anyway.
+        //
+        // `_exit`, not `std::process::exit`: this runs on a background thread
+        // while the node's own threads keep going, and `exit` would run their
+        // `atexit`/destructor work concurrently — which can block on a lock one
+        // of those threads holds and leave the node alive after all. There is
+        // nothing worth flushing; the daemon that owned the other end of this
+        // node's pipes is gone.
+        //
+        // SAFETY: `_exit` ends the process; it touches no state of ours.
+        unsafe { libc::_exit(1) }
+    }
+}
+
+/// Report a guard problem without depending on a `tracing` subscriber being
+/// installed (nodes commonly have none) and without `eprintln!`'s panic on a
+/// broken stderr pipe.
+fn warn(message: &str) {
+    use std::io::Write as _;
+    let _ = writeln!(std::io::stderr(), "dora: orphan guard: {message}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The environment variable is the entire gate: without it — the `dora up`
+    /// case, a manually started dynamic node, interactive mode — nothing is
+    /// armed, so nothing can kill a node that is supposed to outlive its
+    /// daemon (dora-rs/dora#2029).
+    #[test]
+    fn nothing_is_armed_without_the_variable() {
+        assert!(
+            std::env::var_os(DORA_RUN_PARENT_PID_ENV).is_none(),
+            "test environment must not set {DORA_RUN_PARENT_PID_ENV}"
+        );
+        arm_if_run_child();
+        assert!(
+            !ARMED.is_completed(),
+            "a node with no `dora run` parent must not be armed"
+        );
+    }
+
+    /// A live parent must never read as gone — the check that stands between
+    /// this module and killing healthy nodes twice a second.
+    ///
+    /// Asserted on both shapes: this process is its runner's direct child, so
+    /// the exact `getppid` branch applies, while a plan built for the runner's
+    /// *own* parent exercises the `kill(pid, 0)` branch a wrapped node takes.
+    #[cfg(unix)]
+    #[test]
+    fn a_live_parent_is_never_reported_gone() {
+        // SAFETY: reads this process's own parent id.
+        let runner = unsafe { libc::getppid() };
+        let direct = ContainmentPlan::new(runner as u32);
+        assert!(
+            direct.direct_child,
+            "the test binary is its runner's direct child"
+        );
+        assert!(
+            !direct.parent_is_gone(),
+            "the test runner is alive while it waits for this test"
+        );
+
+        // SAFETY: reads the runner's parent id; a failure yields -1, handled
+        // by the `is_positive` guard below.
+        let grandparent = unsafe { libc::getpgid(runner) };
+        if grandparent.is_positive() && grandparent != runner {
+            let wrapped = ContainmentPlan::new(grandparent as u32);
+            assert!(
+                !wrapped.direct_child,
+                "the runner's own parent is not this process's parent"
+            );
+            assert!(
+                !wrapped.parent_is_gone(),
+                "a live process must not read as gone through the probe branch"
+            );
+        }
+    }
+}

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -333,6 +333,13 @@ pub struct Daemon {
     /// scouting. Forwarded to spawned nodes so they discover the same way the
     /// daemon does (see `DORA_ZENOH_MULTICAST`).
     pub(crate) disable_multicast: bool,
+    /// Whether this daemon runs in-process with whoever started it (the
+    /// `run_dataflow` shape), making that process's death the end of the
+    /// dataflow. Forwarded to spawned nodes via `DORA_RUN_PARENT_PID` so a
+    /// `SIGKILL`ed parent does not strand them (dora-rs/dora#2856). False for
+    /// the `dora up` daemon, whose nodes are deliberately decoupled from it
+    /// (#2029).
+    pub(crate) bind_nodes_to_parent: bool,
     /// A `Destroy` that is holding its reply until this daemon's node
     /// processes are gone (#2980).
     pub(crate) pending_destroy: Option<PendingDestroy>,
@@ -1017,6 +1024,10 @@ impl Daemon {
                                 inter_daemon_peer.clone(),
                                 zenoh_bind,
                                 disable_multicast,
+                                // A standalone daemon outlives nothing its
+                                // nodes depend on: they survive coordinator
+                                // drops and reconnects on purpose (#2029).
+                                false,
                             )
                             .await?;
                             daemon = Some(built);
@@ -1382,6 +1393,11 @@ impl Daemon {
         // `dora run` is single-machine by construction: the daemon, its nodes
         // and the in-process coordinator all live on this host, so loopback is
         // both sufficient and the least exposed choice.
+        //
+        // Being that single process is also why the nodes are bound to it: it
+        // is their parent, and its death — `SIGKILL` included, which no
+        // teardown code of ours survives — is the end of the dataflow (#2856).
+        let bind_nodes_to_parent = true;
         let (mut daemon, mut dora_events_rx) = Self::build_daemon(
             coordinator_sender,
             daemon_id,
@@ -1393,6 +1409,7 @@ impl Daemon {
             inter_daemon_peer,
             ZenohBind::Derived(LOCALHOST),
             disable_multicast,
+            bind_nodes_to_parent,
         )
         .await?;
         daemon
@@ -1425,6 +1442,7 @@ impl Daemon {
         inter_daemon_peer: Option<String>,
         zenoh_bind: ZenohBind,
         disable_multicast: bool,
+        bind_nodes_to_parent: bool,
     ) -> eyre::Result<(Self, mpsc::Receiver<Timestamped<Event>>)> {
         // Fold in `DORA_ZENOH_MULTICAST` so this is the daemon's *effective*
         // decision, not just its flag. The zenoh session honors the variable on
@@ -1556,6 +1574,7 @@ impl Daemon {
             zenoh_session,
             zenoh_listen_endpoint,
             disable_multicast,
+            bind_nodes_to_parent,
             pending_destroy: None,
             zenoh_publish_tx,
             remote_daemon_events_tx,
@@ -2539,6 +2558,7 @@ impl Daemon {
                         zenoh_connect_endpoint: self.zenoh_listen_endpoint.clone(),
                         zenoh_peering: dataflow.zenoh_peering.clone(),
                         disable_multicast: self.disable_multicast,
+                        bind_nodes_to_parent: self.bind_nodes_to_parent,
                     };
                     let mut logger = self
                         .logger
@@ -3050,6 +3070,7 @@ impl Daemon {
                         zenoh_connect_endpoint: self.zenoh_listen_endpoint.clone(),
                         zenoh_peering: dataflow.zenoh_peering.clone(),
                         disable_multicast: self.disable_multicast,
+                        bind_nodes_to_parent: self.bind_nodes_to_parent,
                     };
                     let mut logger = self
                         .logger
@@ -4095,6 +4116,7 @@ impl Daemon {
             zenoh_connect_endpoint: self.zenoh_listen_endpoint.clone(),
             zenoh_peering: dataflow.zenoh_peering.clone(),
             disable_multicast: self.disable_multicast,
+            bind_nodes_to_parent: self.bind_nodes_to_parent,
         };
 
         // Startup-handshake routing, from actual placement (`spawn_nodes`):

--- a/binaries/daemon/src/spawn/spawner.rs
+++ b/binaries/daemon/src/spawn/spawner.rs
@@ -14,8 +14,8 @@ use dora_core::{
     },
     get_python_path,
     topics::{
-        DORA_ZENOH_CONNECT_ENV, DORA_ZENOH_LISTEN_ENV, DORA_ZENOH_MULTICAST_ENV,
-        ZENOH_CONFIG_PATH_ENV,
+        DORA_RUN_PARENT_PID_ENV, DORA_ZENOH_CONNECT_ENV, DORA_ZENOH_LISTEN_ENV,
+        DORA_ZENOH_MULTICAST_ENV, ZENOH_CONFIG_PATH_ENV,
     },
     uhlc::HLC,
 };
@@ -70,6 +70,12 @@ const CONTROL_PLANE_ENV: &[&str] = &[
     DORA_ZENOH_LISTEN_ENV,
     DORA_ZENOH_CONNECT_ENV,
     DORA_ZENOH_MULTICAST_ENV,
+    // Names a pid the node will SIGKILL its own process group over once that
+    // pid is gone. A descriptor-supplied value would be an arbitrary
+    // self-destruct trigger, and an inherited one (from an outer `dora run`,
+    // or a shell that happened to export it) would arm the guard against the
+    // wrong process — so it is refused from both and set only here.
+    DORA_RUN_PARENT_PID_ENV,
 ];
 
 /// Whether `key` names the reserved variable `reserved`.
@@ -379,6 +385,14 @@ pub struct Spawner {
     /// should too (see [`DORA_ZENOH_MULTICAST_ENV`]). Mixing modes leaves a
     /// node scouting for a daemon that no longer answers.
     pub disable_multicast: bool,
+    /// Whether this daemon runs *inside* the process that invoked it — the
+    /// `Daemon::run_dataflow` case, where caller, coordinator and daemon are
+    /// one process and the nodes are its children.
+    ///
+    /// Only then may a node treat its parent's death as the end of the
+    /// dataflow; see [`DORA_RUN_PARENT_PID_ENV`] for why the `dora up` +
+    /// `dora start` path must not.
+    pub bind_nodes_to_parent: bool,
 }
 
 impl Spawner {
@@ -433,6 +447,9 @@ impl Spawner {
             command = apply_descriptor_env(command, *envs);
         }
         command = command.env(config_key, config_yaml);
+        if self.bind_nodes_to_parent {
+            command = command.env(DORA_RUN_PARENT_PID_ENV, std::process::id().to_string());
+        }
         self.maybe_inject_zenoh_connect(command, node_id)
     }
 
@@ -818,6 +835,9 @@ mod tests {
             // one a node without its own peering plan takes.
             zenoh_peering: Arc::new(BTreeMap::new()),
             disable_multicast,
+            // The `dora up` shape: a long-lived daemon whose nodes outlive it.
+            // The `dora run` shape is covered by its own test below.
+            bind_nodes_to_parent: false,
         }
     }
 
@@ -1038,6 +1058,52 @@ mod tests {
             env_of(&command, ZENOH_CONFIG_PATH_ENV),
             None,
             "a daemon-level zenoh config must still reach its nodes by inheritance"
+        );
+    }
+
+    /// dora-rs/dora#2856: under `dora run` the daemon *is* the CLI process, so
+    /// its death ends the dataflow — and `SIGKILL` leaves no code of ours to
+    /// notice. The node is told which pid to watch so it can end itself.
+    #[test]
+    fn dora_run_tells_its_nodes_which_parent_to_outlive() {
+        let mut spawner = spawner_for(None, false);
+        spawner.bind_nodes_to_parent = true;
+        let command = spawner.compose_node_env(
+            Command::new("true"),
+            &node("sink"),
+            &[None],
+            "DORA_NODE_CONFIG",
+            "real-config".into(),
+        );
+
+        assert_eq!(
+            env_of(&command, DORA_RUN_PARENT_PID_ENV).flatten(),
+            Some(OsString::from(std::process::id().to_string())),
+            "a `dora run` node must be pointed at the process it may not outlive"
+        );
+    }
+
+    /// The `dora up` half of the same rule. A daemon-spawned node deliberately
+    /// outlives coordinator drops, reconnects and watchdog disconnects while
+    /// keeping its pid (#2029) — arming the guard there would kill nodes that
+    /// are supposed to survive. The variable must be *removed*, never merely
+    /// left unset, because nodes inherit the daemon's environment and a stale
+    /// value from the shell that started it would arm them against a stranger.
+    #[test]
+    fn a_daemon_spawned_node_is_not_bound_to_the_daemons_lifetime() {
+        let spawner = spawner_for(None, false);
+        let command = spawner.compose_node_env(
+            Command::new("true"),
+            &node("sink"),
+            &[None],
+            "DORA_NODE_CONFIG",
+            "real-config".into(),
+        );
+
+        assert_eq!(
+            env_of(&command, DORA_RUN_PARENT_PID_ENV),
+            Some(None),
+            "`dora up` nodes must not be armed, by injection or by inheritance"
         );
     }
 

--- a/docs/yaml-spec.md
+++ b/docs/yaml-spec.md
@@ -280,6 +280,7 @@ Some names are reserved and are dropped (with a warning in the daemon log) when 
 |----------|-----|
 | `DORA_NODE_CONFIG`, `DORA_RUNTIME_CONFIG` | The daemon's own handle to the node — dataflow id, node id, and how to reach the daemon |
 | `DORA_ZENOH_LISTEN`, `DORA_ZENOH_CONNECT`, `DORA_ZENOH_MULTICAST`, `ZENOH_CONFIG` | Node-to-node wiring. Overriding these produces a dataflow that starts cleanly and then exchanges nothing. Set `ZENOH_CONFIG` in the daemon's own environment instead — nodes inherit it |
+| `DORA_RUN_PARENT_PID` | Names the process whose death ends the node. `dora run` sets it so a hard-killed CLI cannot strand nodes; a descriptor-supplied value would be an arbitrary self-destruct trigger |
 | `LD_PRELOAD`, `LD_AUDIT`, `LD_LIBRARY_PATH`, `DYLD_INSERT_LIBRARIES`, `DYLD_LIBRARY_PATH` | Loader hijacking |
 | `DORA_AUTH_TOKEN`, `DORA_ALLOW_SHELL_NODES` | Daemon-level security settings |
 

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -50,6 +50,29 @@ pub const DORA_ZENOH_LISTEN_ENV: &str = "DORA_ZENOH_LISTEN";
 /// `--zenoh-no-multicast`, so a single flag covers the whole process tree.
 pub const DORA_ZENOH_MULTICAST_ENV: &str = "DORA_ZENOH_MULTICAST";
 
+/// Pid of the process whose death must end this node, injected **only** by a
+/// daemon that runs in-process with whoever started it: `Daemon::run_dataflow`
+/// and its callers — `dora run`, `dora daemon --run-dataflow`, and embedders
+/// that drive one dataflow to completion.
+///
+/// There, the one process is coordinator, daemon and node-parent at once, so
+/// its death is the end of the dataflow by definition. Every teardown path
+/// dora has is cooperative and so cannot survive `SIGKILL`, which is neither
+/// catchable nor blockable: no CLI- or daemon-side code runs after it. Nodes
+/// are deliberately spawned as process-group leaders (so a terminal `Ctrl-C`
+/// cannot kill them out from under the daemon), which also means an orphan
+/// keeps running with `ppid 1` in a group of its own — unreachable by both
+/// inherited signal delivery and a group-kill of the parent. Handing the node
+/// the pid lets it notice on its own (dora-rs/dora#2856).
+///
+/// Deliberately NOT set on the `dora up` + `dora start` path: there the parent
+/// is a long-lived daemon whose lifetime is decoupled from its nodes on
+/// purpose — a node survives a coordinator drop, a reconnect, and a watchdog
+/// disconnect while keeping its pid (dora-rs/dora#2029). Tying node lifetime
+/// to that parent would break exactly the property `daemon-reconnect-e2e`
+/// asserts.
+pub const DORA_RUN_PARENT_PID_ENV: &str = "DORA_RUN_PARENT_PID";
+
 /// Zenoh's own config-file override, honored by
 /// [`open_zenoh_session_with_listen`].
 ///

--- a/tests/node-lifecycle-e2e.rs
+++ b/tests/node-lifecycle-e2e.rs
@@ -2122,152 +2122,11 @@ fn run_killed_by_sigterm_terminates_nodes_and_exits() {
     // liveness windows in sibling tests are tuned for an unloaded runner.
     let _guard = LIFECYCLE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
 
-    ensure_cli_built();
-    let dora = dora_bin();
-    let target = Path::new(env!("CARGO_MANIFEST_DIR")).join("target");
-    // `--target-dir` pinned for the same reason as the sibling helpers:
-    // the descriptor below hard-codes the workspace-relative path, so a
-    // `CARGO_TARGET_DIR` override would build the fixture somewhere the
-    // daemon will not look, and the failure would surface later as a
-    // misleading "node never reported its pid".
-    let status = Command::new("cargo")
-        .args(["build", "-p", "sigterm-ignoring-node"])
-        .arg("--target-dir")
-        .arg(&target)
-        .status()
-        .expect("failed to run cargo build for sigterm-ignoring-node");
-    assert!(status.success(), "failed to build sigterm-ignoring-node");
-
-    // Sweep artifacts from earlier runs, as the sibling tests do.
-    if let Ok(entries) = fs::read_dir(&target) {
-        for entry in entries.flatten() {
-            if entry
-                .file_name()
-                .to_string_lossy()
-                .starts_with("dora-2920-orphan-")
-            {
-                let _ = fs::remove_file(entry.path());
-            }
-        }
-    }
-    let pid_file = target.join(format!("dora-2920-orphan-{}.pid", std::process::id()));
-    let yaml = target.join(format!("dora-2920-orphan-{}.yml", std::process::id()));
-    fs::write(
-        &yaml,
-        format!(
-            "nodes:\n  \
-             - id: stubborn\n    \
-               path: \"{node}\"\n    \
-               env:\n      \
-                 DORA_TEST_PID_FILE: \"{pid_file}\"\n    \
-               inputs:\n      \
-                 tick: dora/timer/millis/100\n",
-            node = target.join("debug/sigterm-ignoring-node").display(),
-            pid_file = pid_file.display(),
-        ),
-    )
-    .expect("failed to write dataflow yaml");
-
-    let log = target.join(format!("dora-2920-orphan-{}.log", std::process::id()));
-    let log_file = fs::File::create(&log).expect("failed to create log file");
-    let mut run = Command::new(&dora)
-        .args(["run", yaml.to_str().unwrap()])
-        .stdout(Stdio::null())
-        // Captured, not discarded: the failure this test exists to catch
-        // is a wedge on a remote runner, where the log is the only
-        // forensic artifact.
-        .stderr(Stdio::from(log_file))
-        .spawn()
-        .expect("failed to spawn dora run");
-
-    // RAII so every panic path below tears down the CLI *and* the node.
-    // The node ignores SIGTERM and outlives this test by design, so a
-    // bail-out that only kills the CLI would strand it on the runner for
-    // the rest of the suite.
-    struct Teardown {
-        cli_pid: u32,
-        /// Set once `try_wait` has reaped the CLI. After that its pid is
-        /// free for reuse and must never be signalled again.
-        cli_reaped: bool,
-        node_pid: Option<u32>,
-        files: Vec<std::path::PathBuf>,
-    }
-    impl Drop for Teardown {
-        fn drop(&mut self) {
-            // Signal the CLI only while it is UNREAPED: an unreaped child
-            // is a zombie at worst, so the kernel still holds its pid and
-            // it cannot have been recycled. Once reaped the pid is free,
-            // and a blind `kill` here would eventually hit a stranger.
-            if !self.cli_reaped {
-                let _ = Command::new("kill")
-                    .args(["-KILL", &self.cli_pid.to_string()])
-                    .status();
-            }
-            // The node is the daemon's child, never ours, so we can never
-            // reap it and cannot lean on the rule above. Confirm identity
-            // instead -- and note the target is a process GROUP, so a
-            // recycled pgid would take out an unrelated group, not just a
-            // stray process.
-            if let Some(pid) = self.node_pid
-                && still_our_fixture(pid)
-            {
-                let _ = Command::new("kill")
-                    .args(["-KILL", &format!("-{pid}")])
-                    .status();
-            }
-            for f in &self.files {
-                let _ = fs::remove_file(f);
-            }
-        }
-    }
-    let mut teardown = Teardown {
-        cli_pid: run.id(),
-        cli_reaped: false,
-        node_pid: None,
-        files: vec![yaml.clone(), pid_file.clone(), log.clone()],
-    };
-
-    let tail = |path: &std::path::Path| -> String {
-        fs::read_to_string(path)
-            .map(|s| s.lines().rev().take(20).collect::<Vec<_>>().join("\n"))
-            .unwrap_or_else(|e| format!("<could not read {}: {e}>", path.display()))
-    };
-
-    // Wait for the node to actually be up before signalling; otherwise we
-    // could tear down before it ever spawned and prove nothing.
-    let deadline = std::time::Instant::now() + Duration::from_secs(60);
-    let node_pid = loop {
-        // If the CLI already died, say so with its status and stderr
-        // rather than blaming the pid file 60s from now.
-        if let Some(status) = run.try_wait().expect("try_wait failed") {
-            teardown.cli_reaped = true;
-            panic!(
-                "`dora run` exited early with {status} before the node reported \
-                 its pid.\nstderr tail:\n{}",
-                tail(&log)
-            );
-        }
-        if let Ok(contents) = fs::read_to_string(&pid_file)
-            && let Ok(pid) = contents.trim().parse::<u32>()
-        {
-            break pid;
-        }
-        assert!(
-            std::time::Instant::now() < deadline,
-            "node never reported its pid to {}\nstderr tail:\n{}",
-            pid_file.display(),
-            tail(&log)
-        );
-        std::thread::sleep(Duration::from_millis(200));
-    };
-    teardown.node_pid = Some(node_pid);
-    assert!(
-        node_is_fixture(node_pid),
-        "precondition: node {node_pid} should be running our fixture before we signal"
-    );
+    let mut run = StubbornRun::start("dora-2920-orphan", false);
+    let node_pid = run.wait_for_node();
 
     let signalled = Command::new("kill")
-        .args(["-TERM", &run.id().to_string()])
+        .args(["-TERM", &run.cli.id().to_string()])
         .status()
         .expect("failed to run `kill`");
     // Checked: an undelivered signal would make the wait below time out
@@ -2280,15 +2139,15 @@ fn run_killed_by_sigterm_terminates_nodes_and_exits() {
     // inflates teardown is caught rather than passing silently.
     let deadline = std::time::Instant::now() + Duration::from_secs(60);
     let status = loop {
-        match run.try_wait().expect("try_wait failed") {
+        match run.cli.try_wait().expect("try_wait failed") {
             Some(status) => {
-                teardown.cli_reaped = true;
+                run.cli_reaped = true;
                 break status;
             }
             None if std::time::Instant::now() >= deadline => panic!(
                 "`dora run` did not exit within 60s of SIGTERM — teardown \
                  wedged, so the run never returns (#2920)\nstderr tail:\n{}",
-                tail(&log)
+                run.stderr_tail()
             ),
             None => std::thread::sleep(Duration::from_millis(250)),
         }
@@ -2303,6 +2162,240 @@ fn run_killed_by_sigterm_terminates_nodes_and_exits() {
          ladder never reached its SIGKILL rung, so killing the CLI strands \
          nodes (#2920)"
     );
+}
+
+/// dora-rs/dora#2856: `SIGKILL` to `dora run` must not strand its nodes.
+///
+/// The sibling test above covers the signals the CLI can still *handle*.
+/// `SIGKILL` is the case where it cannot: nothing of ours runs after it, so
+/// the stop ladder, the destroy reaper and every other daemon-side teardown
+/// path are unavailable by construction. And because nodes are spawned as
+/// process-group leaders — deliberately, so a terminal `Ctrl-C` cannot kill
+/// them out from under the daemon — the orphan ends up with `ppid 1` in a
+/// group of its own, which neither inherited signal delivery nor a group-kill
+/// of the CLI reaches.
+///
+/// The containment therefore has to live in the node: `dora run` tells each
+/// node it spawns which pid it may not outlive (`DORA_RUN_PARENT_PID`), and
+/// the node's guard `SIGKILL`s its own process group once that pid is gone.
+///
+/// The fixture is the point of the test. It sets `SIGTERM` to `SIG_IGN` and
+/// never polls its event stream, so it survives every cooperative path AND a
+/// containment scheme that only manages to deliver `SIGTERM`. A node that died
+/// to either would pass this test without the fix.
+///
+/// Unix-only: it signals the CLI and inspects process state.
+#[test]
+#[cfg(unix)]
+fn run_killed_by_sigkill_does_not_orphan_nodes() {
+    let _guard = LIFECYCLE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+    // Its own process group, so that nothing this test does -- and nothing the
+    // daemon or a node does on the way down -- can be delivered to the test
+    // harness's own group by accident.
+    let mut run = StubbornRun::start("dora-2856-orphan", true);
+    let node_pid = run.wait_for_node();
+
+    let killed = Command::new("kill")
+        .args(["-KILL", &run.cli.id().to_string()])
+        .status()
+        .expect("failed to run `kill`");
+    // Checked: an undelivered signal would make the wait below time out and
+    // report an orphan that was never actually orphaned.
+    assert!(killed.success(), "failed to SIGKILL `dora run`");
+    // Reaped immediately: the CLI cannot run teardown code after SIGKILL, so
+    // there is nothing to wait for, and leaving it unreaped would keep a
+    // zombie around for the rest of the suite.
+    let status = run.cli.wait().expect("failed to reap `dora run`");
+    run.cli_reaped = true;
+
+    // The guard re-checks the parent twice a second, so a working containment
+    // lands in about a second. 30s is slack for a loaded runner while still
+    // bounding it: an orphan is forever, not slow.
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    while node_is_fixture(node_pid) {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "node {node_pid} outlived `dora run` ({status}) by 30s: killing the \
+             CLI outright strands its nodes (#2856)\nstderr tail:\n{}",
+            run.stderr_tail()
+        );
+        std::thread::sleep(Duration::from_millis(250));
+    }
+}
+
+/// A `dora run` of the stubborn fixture, plus the RAII teardown both orphan
+/// tests need.
+///
+/// The fixture ignores `SIGTERM` and never polls its event stream, so it
+/// outlives a failing test by design: a bail-out that only killed the CLI
+/// would strand it on the runner for the rest of the suite. Every panic path
+/// therefore has to tear down the CLI *and* the node, which is why this is a
+/// `Drop` type rather than cleanup code at the end of each test.
+#[cfg(unix)]
+struct StubbornRun {
+    cli: std::process::Child,
+    /// Set once `try_wait`/`wait` has reaped the CLI. After that its pid is
+    /// free for reuse and must never be signalled again.
+    cli_reaped: bool,
+    node_pid: Option<u32>,
+    /// The CLI's captured stderr. The failures these tests exist to catch
+    /// happen on remote runners, where this is the only forensic artifact.
+    log: std::path::PathBuf,
+    /// Where the fixture publishes its own pid, so the tests assert on THAT
+    /// process rather than pattern-matching the process table (which would
+    /// also catch a leftover from an earlier run).
+    pid_file: std::path::PathBuf,
+    files: Vec<std::path::PathBuf>,
+}
+
+#[cfg(unix)]
+impl Drop for StubbornRun {
+    fn drop(&mut self) {
+        // Signal the CLI only while it is UNREAPED: an unreaped child is a
+        // zombie at worst, so the kernel still holds its pid and it cannot have
+        // been recycled. Once reaped the pid is free, and a blind `kill` here
+        // would eventually hit a stranger.
+        if !self.cli_reaped {
+            let _ = Command::new("kill")
+                .args(["-KILL", &self.cli.id().to_string()])
+                .status();
+        }
+        // The node is the daemon's child, never ours, so we can never reap it
+        // and cannot lean on the rule above. Confirm identity instead -- and
+        // note the target is a process GROUP, so a recycled pgid would take out
+        // an unrelated group, not just a stray process.
+        if let Some(pid) = self.node_pid
+            && still_our_fixture(pid)
+        {
+            let _ = Command::new("kill")
+                .args(["-KILL", &format!("-{pid}")])
+                .status();
+        }
+        for f in &self.files {
+            let _ = fs::remove_file(f);
+        }
+    }
+}
+
+#[cfg(unix)]
+impl StubbornRun {
+    /// Build the fixture, write a one-node dataflow for it, and start
+    /// `dora run` on it. `own_process_group` puts the CLI in a group of its
+    /// own.
+    ///
+    /// `--target-dir` is pinned for the same reason as the sibling helpers: the
+    /// descriptor hard-codes the workspace-relative binary path, so a
+    /// `CARGO_TARGET_DIR` override would build the fixture somewhere the daemon
+    /// will not look, and the failure would surface later as a misleading "node
+    /// never reported its pid".
+    fn start(prefix: &str, own_process_group: bool) -> Self {
+        use std::os::unix::process::CommandExt as _;
+
+        ensure_cli_built();
+        let dora = dora_bin();
+        let target = Path::new(env!("CARGO_MANIFEST_DIR")).join("target");
+        let built = Command::new("cargo")
+            .args(["build", "-p", "sigterm-ignoring-node"])
+            .arg("--target-dir")
+            .arg(&target)
+            .status()
+            .expect("failed to run cargo build for sigterm-ignoring-node");
+        assert!(built.success(), "failed to build sigterm-ignoring-node");
+
+        // Sweep artifacts from earlier runs: a stale pid file would be read as
+        // this run's node, and the test would assert against a process that
+        // exited long ago.
+        if let Ok(entries) = fs::read_dir(&target) {
+            for entry in entries.flatten() {
+                if entry.file_name().to_string_lossy().starts_with(prefix) {
+                    let _ = fs::remove_file(entry.path());
+                }
+            }
+        }
+        let scratch = |ext: &str| target.join(format!("{prefix}-{}.{ext}", std::process::id()));
+        let (yaml, pid_file, log) = (scratch("yml"), scratch("pid"), scratch("log"));
+        fs::write(
+            &yaml,
+            format!(
+                "nodes:\n  \
+                 - id: stubborn\n    \
+                   path: \"{node}\"\n    \
+                   env:\n      \
+                     DORA_TEST_PID_FILE: \"{pid_file}\"\n    \
+                   inputs:\n      \
+                     tick: dora/timer/millis/100\n",
+                node = target.join("debug/sigterm-ignoring-node").display(),
+                pid_file = pid_file.display(),
+            ),
+        )
+        .expect("failed to write dataflow yaml");
+
+        let log_file = fs::File::create(&log).expect("failed to create log file");
+        let mut command = Command::new(&dora);
+        command
+            .args(["run", yaml.to_str().unwrap()])
+            .stdout(Stdio::null())
+            .stderr(Stdio::from(log_file));
+        if own_process_group {
+            command.process_group(0);
+        }
+        let cli = command.spawn().expect("failed to spawn dora run");
+
+        Self {
+            cli,
+            cli_reaped: false,
+            node_pid: None,
+            files: vec![yaml, pid_file.clone(), log.clone()],
+            log,
+            pid_file,
+        }
+    }
+
+    fn stderr_tail(&self) -> String {
+        fs::read_to_string(&self.log)
+            .map(|s| s.lines().rev().take(20).collect::<Vec<_>>().join("\n"))
+            .unwrap_or_else(|e| format!("<could not read {}: {e}>", self.log.display()))
+    }
+
+    /// Block until the node reports its pid, and record it for teardown.
+    ///
+    /// Both tests must know the node is actually up before they signal;
+    /// otherwise a teardown that ran before it ever spawned would "pass"
+    /// having proved nothing.
+    fn wait_for_node(&mut self) -> u32 {
+        let deadline = std::time::Instant::now() + Duration::from_secs(60);
+        let node_pid = loop {
+            // If the CLI already died, say so with its status and stderr rather
+            // than blaming the pid file 60s from now.
+            if let Some(status) = self.cli.try_wait().expect("try_wait failed") {
+                self.cli_reaped = true;
+                panic!(
+                    "`dora run` exited early with {status} before the node reported \
+                     its pid.\nstderr tail:\n{}",
+                    self.stderr_tail()
+                );
+            }
+            if let Ok(contents) = fs::read_to_string(&self.pid_file)
+                && let Ok(pid) = contents.trim().parse::<u32>()
+            {
+                break pid;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "node never reported its pid to {}\nstderr tail:\n{}",
+                self.pid_file.display(),
+                self.stderr_tail()
+            );
+            std::thread::sleep(Duration::from_millis(200));
+        };
+        self.node_pid = Some(node_pid);
+        assert!(
+            node_is_fixture(node_pid),
+            "precondition: node {node_pid} should be running our fixture before we signal"
+        );
+        node_pid
+    }
 }
 
 /// Whether `pid` is alive AND is our fixture, so a recycled pid is not


### PR DESCRIPTION
Closes the residual half of #2856. The busy-spin is gone and #2949/#2961 fixed
`SIGTERM`/`SIGHUP` to `dora run`, but `SIGKILL` still orphaned every node that
does not poll its event stream: nothing of ours runs after `SIGKILL`, so the
stop ladder and the destroy reaper are unavailable by construction. And because
nodes are spawned as process-group leaders on purpose (so a terminal `Ctrl-C`
cannot kill them out from under the daemon), the orphan ends up with `ppid 1`
in a group of its own — reachable by neither inherited signal delivery nor a
group-kill of the CLI.

The containment therefore has to live in the node. `Daemon::run_dataflow` — the
in-process shape used by `dora run`, `dora daemon --run-dataflow` and
embedders — injects `DORA_RUN_PARENT_PID` into the nodes it spawns. The node
API arms a watchdog thread from it at `DoraNode::init`, and once that pid is
gone it `SIGKILL`s its own process group. The group, not the process, because
the tracked child is often a wrapper (`uv run python …`) with the real node one
level down — the reporter's shape, verified by hand.

`dora up` + `dora start` deliberately does not set the variable, and it is
scrubbed from the inherited environment there, so a node keeps outliving
coordinator drops, reconnects and watchdog disconnects (#2029).

`PR_SET_PDEATHSIG` was rejected as the mechanism: it reaches only the direct
child (missing the `uv` wrapper), it fires on parent *thread* exit while the
daemon spawns from a tokio worker, and it is Linux-only while the report is
from macOS.

Not covered, deliberately: a node killed before it reaches `init`, a node that
never calls `init` (`path: shell`), and Windows — where the equivalent is
`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` on the job object nodes already run in,
which `process-wrap` couples to `Command::kill_on_drop` and which cannot be
verified from this workspace.

`tests/node-lifecycle-e2e.rs` gains a sibling of the `SIGTERM` test: it starts
`dora run` in its own process group, `SIGKILL`s the CLI, and asserts the
fixture node is gone within 30s. The fixture ignores `SIGTERM` and never polls
its event stream, so a containment scheme that only delivers `SIGTERM` fails
it. Verified failing before the fix (node survived the full 30s) and passing
after. The two orphan tests now share one `StubbornRun` harness instead of a
duplicated teardown.

Refs #2856.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
