### PR TITLE
fix(daemon): compile out the unix-only shutdown tests on Windows (#2742)

### DIFF
--- a/binaries/daemon/src/shutdown.rs
+++ b/binaries/daemon/src/shutdown.rs
@@ -221,8 +221,16 @@ fn is_live_child(process: &sysinfo::Process, own_pid: u32) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // The `#[cfg(unix)]` tests below drive a real process through the Unix
+    // process model: `/bin/sleep`, process groups, `CommandExt::process_group`.
+    // They are compiled out rather than `ignore`d because `ignore` only skips
+    // a test at *runtime* — the body still has to compile, and the Unix-only
+    // APIs it uses do not exist on Windows (dora-rs/dora#2742).
+    #[cfg(unix)]
     use std::process::{Command, Stdio};
 
+    #[cfg(unix)]
     fn spawn_sleeper() -> std::process::Child {
         Command::new("sleep")
             .arg("300")
@@ -234,8 +242,8 @@ mod tests {
 
     /// A node that will not exit is killed once the deadline passes — the
     /// case #2980 is about.
+    #[cfg(unix)]
     #[tokio::test(start_paused = true)]
-    #[cfg_attr(not(unix), ignore = "spawns `sleep`")]
     async fn a_node_that_outlives_the_deadline_is_killed() {
         let mut child = spawn_sleeper();
         let pid = child.id();
@@ -260,8 +268,8 @@ mod tests {
     /// carries on in its process group, the node is not gone. Following only
     /// the leader would end the destroy there and orphan the child, which is
     /// the very leak this module exists to close, one level down.
+    #[cfg(unix)]
     #[tokio::test(start_paused = true)]
-    #[cfg_attr(not(unix), ignore = "process groups are a unix concept")]
     async fn a_wrapper_that_exits_does_not_hide_its_surviving_child() {
         use std::os::unix::process::CommandExt as _;
 
@@ -319,8 +327,8 @@ mod tests {
     /// The common case must stay free: a node that exits on its own is never
     /// killed, and the destroy completes as soon as it is gone rather than
     /// sitting out the deadline.
+    #[cfg(unix)]
     #[tokio::test(start_paused = true)]
-    #[cfg_attr(not(unix), ignore = "spawns `sleep`")]
     async fn a_node_that_exits_on_its_own_is_not_killed() {
         let mut child = spawn_sleeper();
         let pid = child.id();
@@ -340,8 +348,8 @@ mod tests {
 
     /// A pid the OS recycled after the node exited belongs to a stranger.
     /// Killing it would be worse than the leak this module exists to fix.
+    #[cfg(unix)]
     #[tokio::test(start_paused = true)]
-    #[cfg_attr(not(unix), ignore = "spawns `sleep`")]
     async fn a_process_that_is_not_our_child_is_left_alone() {
         let mut child = spawn_sleeper();
         let pid = child.id();


### PR DESCRIPTION
`a_wrapper_that_exits_does_not_hide_its_surviving_child` in
`binaries/daemon/src/shutdown.rs` was annotated
``#[cfg_attr(not(unix), ignore = "process groups are a unix concept")]``, but
`ignore` is a *runtime* skip — the body still has to compile. It uses
`std::os::unix::process::CommandExt` and `.process_group(0)`, neither of which
exists on Windows, so `cargo test -p dora-daemon` never got as far as skipping
it:

```
error[E0433]: cannot find `unix` in `os`
error[E0599]: no method named `process_group` found for mutable reference
              `&mut std::process::Command` in the current scope
error: could not compile `dora-daemon` (lib test) due to 2 previous errors
```

That is the `Test (windows-latest)` failure keeping the nightly red (#2742,
day 18); it arrived with #3004. It is distinct from the `sigterm-ignoring-node`
break fixed in #2982.

Switched to `#[cfg(unix)]`, which is what #2982 used for that fixture's `main`.

### The three sibling tests

`a_node_that_outlives_the_deadline_is_killed`,
`a_node_that_exits_on_its_own_is_not_killed` and
`a_process_that_is_not_our_child_is_left_alone` carried
``#[cfg_attr(not(unix), ignore = "spawns `sleep`")]``. Those three do compile on
Windows, so they are not broken today — but they are converted too, because the
uniform `ignore` is exactly what camouflaged the one site that was a compile
error rather than a skip. Four annotations that looked identical did not behave
identically, and only the odd one out was load-bearing.

Nothing is lost by the conversion: `ignore` already meant they never ran on
Windows, so executed coverage there is unchanged. `spawn_sleeper` and the
`std::process` import move under the same gate, which keeps the Windows build
warning-free. `a_daemon_with_no_nodes_finishes_at_once` needs no process at all
and stays ungated, so `DestroyWait` keeps a compiled, executed test on Windows.

### Why no gate caught it

Nothing in the merge path compiles test code for Windows:

- `Cross-check` (nightly) runs `cargo check --target <t> --all` with no
  `--tests`, so it only ever builds lib/bin targets.
- PR CI's `Check` is `cargo check --all` on the host — Linux, no `--target`.
- Trunk's `required_statuses` (`.trunk/trunk.yaml`) list `Test (ubuntu-latest)`
  and no Windows job at all.

So a Windows-only break in test code is invisible until the nightly Windows job
runs, a day after merge.

### Measured cost of adding `--tests` to Cross-check

This branch, 24-core Linux, warm cargo registry, full workspace minus the four
Python crates — the nightly invocation with and without `--tests`:

| target | `cargo check` | `cargo check --tests` | delta | new errors |
|---|---|---|---|---|
| `x86_64-pc-windows-gnu` | 70s | 73s | **+3s** | 0 |
| `x86_64-unknown-linux-gnu` | 81s | 80s | **~0** (noise) | 0 |
| `aarch64-unknown-linux-gnu` | — | — | — | 0 |

Adding `--tests` is essentially free cold: the extra test targets fan out into
cores the dependency graph already left idle. On a warm target dir (what
`rust-cache` gives CI) the incremental delta is +33s on both measured targets.

**No new errors on any target I could build.** New warnings: none on Linux; on
Windows it surfaces 15 pre-existing `dead_code` warnings in the `dora-examples`
test targets (`example-smoke`, `node-lifecycle-e2e`) — helpers used only by
unix-gated tests. Warnings, not errors, so the check still exits 0.

**One caveat worth knowing.** `--tests` pulls dev-dependencies in, which widens
the *native* dependency surface: on the two musl targets it adds `aws-lc-sys` to
the build graph. I could not build those rows here (see below), so whether the
`cross` images have what `aws-lc-sys` needs is unverified. That is the one place
adding `--tests` could plausibly turn a green row red for a toolchain reason
rather than a source reason.

**Not verified locally:** `i686-unknown-linux-gnu`, `aarch64-unknown-linux-musl`
and `armv7-unknown-linux-musleabihf` fail here in *both* phases on missing 32-bit
/ musl cross C toolchains (`ring`, `openssl-sys`, `libz-sys`) — an artifact of
this container, not the source; CI runs these under `cross`'s Docker images,
which supply them. The two `apple-darwin` rows need macOS.

### Recommendation

**Add `--tests` to the `x86_64-pc-windows-gnu` row of `Cross-check` first**, not
to all eight at once. Windows is the only non-unix target in the matrix, so it
is where the entire `cfg`-divergence risk concentrates; it is the row I measured
end-to-end at +3s and 0 new errors; and it sidesteps the unverified musl
`aws-lc-sys` question above. Widening to the other seven is a reasonable
follow-up once a nightly has shown the musl rows survive it.

**But be clear about what this does not buy: latency.** `Test (windows-latest)`
is already in the same nightly run, so `--tests` on cross-check would have
caught this break in the *same* nightly, not sooner. What it buys is signal
quality — a compile error on a 73s Linux job instead of one buried in an
hour-long Windows test log.

If the goal is to stop these reaching main at all, the cheap pre-merge fix is
one extra step on PR CI's existing (already-required) `Check` job:
`cargo check --tests --target x86_64-pc-windows-gnu`, cross-compiled on ubuntu
with `gcc-mingw-w64-x86-64` — no Windows runner, no test execution, ~73s of work
on a job that is not on the critical path. I have not made that change here:
CLAUDE.md is explicit that PR CI stays lean, this would be its first
cross-compile step, and it is a policy call rather than part of a bugfix.
