### PR TITLE
fix(daemon): stop the finish-straggler watchdog misclassifying operator nodes as sources

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -7857,6 +7857,18 @@ mod fault_tolerance_tests {
         df.connected_nodes.insert(node.clone());
     }
 
+    /// Record a real `User` data input for `node`, exactly as the spawn and
+    /// `AddNode` paths do. `node_never_finishes` classifies "is this a source"
+    /// from `data_inputs`, so a fixture that skips this models a *source*, and
+    /// a source vetoes the watchdog for the whole dataflow — every assertion
+    /// below about a user-input node needs the input recorded to mean anything.
+    fn register_data_input(df: &mut RunningDataflow, node: &NodeId) {
+        df.data_inputs
+            .entry(node.clone())
+            .or_default()
+            .insert("value".to_string().into());
+    }
+
     #[test]
     fn timer_fed_node_is_not_a_finish_straggler() {
         // A long-running timer-only node never drains and sends no daemon
@@ -7885,6 +7897,7 @@ mod fault_tolerance_tests {
         let mut df = test_dataflow();
         let stuck: NodeId = "stuck".to_string().into();
         insert_silent_node(&mut df, &stuck);
+        register_data_input(&mut df, &stuck);
 
         let now = node_communication::current_millis();
         let selected = df.finish_stragglers(Duration::from_millis(1), now);
@@ -7901,6 +7914,7 @@ mod fault_tolerance_tests {
         let running = test_running_node();
         running.last_activity.store(1, atomic::Ordering::Release);
         df.running_nodes.insert(starting.clone(), running);
+        register_data_input(&mut df, &starting);
         // NOTE: deliberately NOT added to subscribe_channels (not connected).
 
         let now = node_communication::current_millis();
@@ -7922,6 +7936,7 @@ mod fault_tolerance_tests {
         running.last_activity.store(1, atomic::Ordering::Release);
         df.running_nodes.insert(stuck.clone(), running);
         df.connected_nodes.insert(stuck.clone());
+        register_data_input(&mut df, &stuck);
         // NOTE: no subscribe_channels entry — the event stream was dropped.
 
         let now = node_communication::current_millis();
@@ -7942,6 +7957,7 @@ mod fault_tolerance_tests {
         let running = test_running_node();
         running.last_activity.store(1, atomic::Ordering::Release);
         df.running_nodes.insert(node_a.clone(), running);
+        register_data_input(&mut df, &node_a);
 
         let now = node_communication::current_millis();
         let selected = df.finish_stragglers(Duration::from_millis(1), now);
@@ -7959,6 +7975,7 @@ mod fault_tolerance_tests {
         let mut df = test_dataflow();
         let node: NodeId = "reused".to_string().into();
         insert_silent_node(&mut df, &node);
+        register_data_input(&mut df, &node);
         df.timers
             .entry(Duration::from_millis(100))
             .or_default()
@@ -7998,6 +8015,7 @@ mod fault_tolerance_tests {
         );
         df.running_nodes.insert(node.clone(), running);
         df.connected_nodes.insert(node.clone());
+        register_data_input(&mut df, &node);
         df.all_inputs_closed_at.insert(
             node.clone(),
             std::time::Instant::now() - Duration::from_secs(1),

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -1082,17 +1082,16 @@ impl RunningDataflow {
         if !self.timers_gate_drain && self.is_drained(node_id) {
             return false;
         }
-        // NOTE: this misclassifies a runtime (`operators:`) node as a
-        // source, because its inputs live under `operators[].config.inputs`
-        // and the top-level map is empty. Pre-existing and left alone here:
-        // correcting it would newly arm the straggler watchdog for operator
-        // dataflows, which is a behavior change well outside #2920.
-        let is_source = self
-            .descriptor
-            .nodes
-            .iter()
-            .find(|n| &n.id == node_id)
-            .is_some_and(|n| n.inputs.is_empty());
+        // `has_data_input` reads `data_inputs`, recorded at registration
+        // time, rather than the raw descriptor: a runtime (`operators:`)
+        // node keeps its inputs under `operators[].config.inputs` and has
+        // an empty top-level `inputs` map, so a descriptor-derived check
+        // reports every operator node as a source and permanently disarms
+        // the straggler watchdog for the whole dataflow the moment one is
+        // running (`select_finish_stragglers` returns early on the first
+        // `never_finishes` node it sees). Same fix `is_finished_non_source`
+        // already applies for the same reason.
+        let is_source = !self.has_data_input(node_id);
         let has_timer = self
             .timers
             .values()
@@ -1303,6 +1302,30 @@ mod tests {
                     .insert(input);
             }
         }
+    }
+
+    /// A node with a real data input but an empty top-level `inputs` map
+    /// (the shape of a runtime/`operators:` node — its inputs live under
+    /// `operators[].config.inputs`) must not be classified as a source.
+    /// `node_never_finishes` used to derive "is this a source" from the raw
+    /// descriptor's top-level `inputs`, so every operator node with real
+    /// inputs read as a source and permanently vetoed the finish-straggler
+    /// watchdog for the whole dataflow.
+    #[test]
+    fn operator_shaped_node_with_data_input_is_not_a_source() {
+        // Empty top-level `inputs` mirrors an `operators:` node's descriptor
+        // shape; `register_inputs` then records a real data input the way
+        // the daemon does for `operators[].config.inputs`.
+        let node = node_id("op");
+        let mut df = dataflow_with_node("op", &[]);
+        register_inputs(&mut df, "op", &[("value", false)]);
+
+        assert!(
+            !df.node_never_finishes(&node),
+            "a node with a registered data input can reach natural finish \
+             and must not be treated as a source, regardless of what its \
+             top-level descriptor `inputs` map looks like"
+        );
     }
 
     /// Default behavior is unchanged: every input gates the drain, so a


### PR DESCRIPTION
Fixes #3021 

`node_never_finishes` derived "is this a source" from the descriptor's
top-level `inputs` map, which is always empty for a runtime
(`operators:`) node its inputs live under `operators[].config.inputs`.
Every operator node with real inputs was misclassified as a source.

Impact was dataflow-wide: `select_finish_stragglers` bails out entirely
(no escalation for anyone) on the first `never_finishes` node it sees,
so one operator node permanently disarmed the finish-straggler watchdog
for the whole dataflow.

Already found and knowingly deferred in #2957. The sibling case in this
file (`is_drained`/`has_data_input`) was already fixed the same way;
`node_never_finishes` just never got it.

Reuses `has_data_input`, which reads `data_inputs` recorded at
registration time instead of the raw descriptor.

**Test:** a node with an empty top-level `inputs` map but a registered
data input (the operator-node shape) must not be classified as a source.

`cargo test -p dora-daemon`, `cargo clippy -p dora-daemon -- -D warnings`,
`cargo fmt --all -- --check` all pass.
