### PR TITLE
fix(c-api): return a null pointer for an empty UInt8 input payload

### DIFF
--- a/apis/c/node/src/lib.rs
+++ b/apis/c/node/src/lib.rs
@@ -187,9 +187,17 @@ pub unsafe extern "C" fn read_dora_input_data(
         Event::Input { data, .. } => match data.data_type() {
             dora_node_api::arrow::datatypes::DataType::UInt8 => {
                 let array: &UInt8Array = data.as_primitive();
-                let ptr = array.values().as_ptr();
-                // Use the actual buffer length (the decoded array's own length).
-                let len = array.values().len();
+                let values = array.values();
+                // A zero-length payload carries no data. `values().as_ptr()`
+                // returns a non-null, dangling-but-aligned pointer for an empty
+                // buffer, so report it as "no data" (null pointer, length 0) to
+                // honor the documented `out_ptr == NULL` contract and match the
+                // `Null` arm below; otherwise expose the actual buffer.
+                let (ptr, len) = if values.is_empty() {
+                    (ptr::null(), 0)
+                } else {
+                    (values.as_ptr(), values.len())
+                };
                 unsafe {
                     *out_ptr = ptr;
                     *out_len = len;
@@ -425,6 +433,40 @@ mod tests {
             "expected null out_ptr for non-UInt8 input"
         );
         assert_eq!(out_len, 0, "expected zero out_len for non-UInt8 input");
+    }
+
+    /// An empty `UInt8` input payload (a node emitting a zero-length byte
+    /// array) must report "no data" the same way the `Null` arm does: a null
+    /// `out_ptr` and `out_len == 0`. `UInt8Array::values().as_ptr()` returns a
+    /// non-null dangling pointer for an empty buffer, so without the explicit
+    /// zero-length guard a caller following the documented `out_ptr == NULL`
+    /// convention would misread the empty message as carrying data.
+    #[test]
+    fn read_dora_input_data_empty_uint8_returns_null() {
+        let array: ArrayRef = Arc::new(UInt8Array::from(Vec::<u8>::new()));
+        let event = Event::Input {
+            id: "my_input".into(),
+            metadata: Metadata::new(HLC::default().new_timestamp()),
+            data: ArrowData(array),
+        };
+        let event_ptr: *const () = (&event as *const Event).cast();
+
+        // Seed with non-null sentinels so we can prove the function overwrites them.
+        let sentinel: u8 = 0;
+        let mut out_ptr: *const u8 = &sentinel;
+        let mut out_len: usize = 42;
+        unsafe {
+            read_dora_input_data(event_ptr, &mut out_ptr, &mut out_len);
+        }
+
+        assert!(
+            out_ptr.is_null(),
+            "expected null out_ptr for an empty UInt8 payload"
+        );
+        assert_eq!(
+            out_len, 0,
+            "expected zero out_len for an empty UInt8 payload"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`read_dora_input_data` (the C node API) documents:

> Writes a null pointer and length `0` [...] when an input event has no associated data.

The `Null` arm honors that, but the `UInt8` arm wrote `array.values().as_ptr()` **unconditionally**. For a zero-length `UInt8` payload — which a node produces by emitting an empty byte array, and which decodes back to `UInt8` (len 0) rather than `Null` (confirmed by `ipc_roundtrip_empty_typed_array_preserves_type` in `dora-node-api`) — `values().as_ptr()` returns a **non-null, dangling-but-aligned** pointer. A C caller that follows the documented convention and tests `out_ptr == NULL` to detect "no data" would then wrongly conclude the empty message carried data.

## Fix

In the `UInt8` arm, report an empty buffer as "no data" (null pointer, length 0), matching the documented contract and the `Null` arm. The write is funneled through a single `(ptr, len)` computation.

```rust
let values = array.values();
let (ptr, len) = if values.is_empty() {
    (ptr::null(), 0)
} else {
    (values.as_ptr(), values.len())
};
unsafe { *out_ptr = ptr; *out_len = len; }
```

## Validation

- New regression test `read_dora_input_data_empty_uint8_returns_null` constructs an empty `UInt8Array` input and asserts `out_ptr` is null and `out_len` is 0.
- `cargo fmt` / `cargo clippy -D warnings` / `cargo test -p dora-node-api-c` all pass (5 tests).

## Note

⚠️ This is a **machine-generated** change, authored by Claude (an AI assistant) as part of an automated code-review pass. It has been reviewed for correctness, but please review carefully before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtaLn7JWcYzmYfb4ppgYYN)_