### PR TITLE
refactor(arrow-convert): dedup temporal conversions, drop redundant check

### DIFF
--- a/libraries/arrow-convert/src/from_impls.rs
+++ b/libraries/arrow-convert/src/from_impls.rs
@@ -126,128 +126,105 @@ impl TryFrom<&ArrowData> for String {
 impl TryFrom<&ArrowData> for NaiveDate {
     type Error = eyre::Report;
     fn try_from(value: &ArrowData) -> Result<Self, Self::Error> {
+        const CTX: &str = "data type cannot be converted to NaiveDate";
         if let Some(array) = value.as_any().downcast_ref::<arrow::array::Date32Array>() {
-            if check_single_datetime(array) {
-                eyre::bail!("Not a valid array");
-            }
-            return array
-                .value_as_date(0)
-                .context("data type cannot be converted to NaiveDate");
+            return single_temporal(array, |a, i| a.value_as_date(i), CTX);
         }
         let array = value
             .as_any()
             .downcast_ref::<arrow::array::Date64Array>()
             .context("Reference is neither to a Date32Array nor a Date64Array")?;
-        if check_single_datetime(array) {
-            eyre::bail!("Not a valid array");
-        }
-        array
-            .value_as_date(0)
-            .context("data type cannot be converted to NaiveDate")
+        single_temporal(array, |a, i| a.value_as_date(i), CTX)
     }
 }
 
 impl TryFrom<&ArrowData> for NaiveTime {
     type Error = eyre::Report;
     fn try_from(value: &ArrowData) -> Result<Self, Self::Error> {
+        const CTX: &str = "data type cannot be converted to NaiveTime";
         if let Some(array) = value
             .as_any()
             .downcast_ref::<arrow::array::Time32SecondArray>()
         {
-            if check_single_datetime(array) {
-                eyre::bail!("Not a valid array");
-            }
-            return array
-                .value_as_time(0)
-                .context("data type cannot be converted to NaiveTime");
+            return single_temporal(array, |a, i| a.value_as_time(i), CTX);
         }
         if let Some(array) = value
             .as_any()
             .downcast_ref::<arrow::array::Time32MillisecondArray>()
         {
-            if check_single_datetime(array) {
-                eyre::bail!("Not a valid array");
-            }
-            return array
-                .value_as_time(0)
-                .context("data type cannot be converted to NaiveTime");
+            return single_temporal(array, |a, i| a.value_as_time(i), CTX);
         }
         if let Some(array) = value
             .as_any()
             .downcast_ref::<arrow::array::Time64MicrosecondArray>()
         {
-            if check_single_datetime(array) {
-                eyre::bail!("Not a valid array");
-            }
-            return array
-                .value_as_time(0)
-                .context("data type cannot be converted to NaiveTime");
+            return single_temporal(array, |a, i| a.value_as_time(i), CTX);
         }
         let array = value
             .as_primitive_opt::<arrow::datatypes::Time64NanosecondType>()
             .context("not any of the primitive Time arrays")?;
-        if check_single_datetime(array) {
-            eyre::bail!("Not a valid array");
-        }
-        array
-            .value_as_time(0)
-            .context("data type cannot be converted to NaiveTime")
+        single_temporal(array, |a, i| a.value_as_time(i), CTX)
     }
 }
 
 impl TryFrom<&ArrowData> for NaiveDateTime {
     type Error = eyre::Report;
     fn try_from(value: &ArrowData) -> Result<Self, Self::Error> {
+        const CTX: &str = "data type cannot be converted to NaiveDateTime";
         if let Some(array) = value
             .as_any()
             .downcast_ref::<arrow::array::TimestampSecondArray>()
         {
-            if check_single_datetime(array) {
-                eyre::bail!("Not a valid array");
-            }
-            return array
-                .value_as_datetime(0)
-                .context("data type cannot be converted to NaiveDateTime");
+            return single_temporal(array, |a, i| a.value_as_datetime(i), CTX);
         }
         if let Some(array) = value
             .as_any()
             .downcast_ref::<arrow::array::TimestampMillisecondArray>()
         {
-            if check_single_datetime(array) {
-                eyre::bail!("Not a valid array");
-            }
-            return array
-                .value_as_datetime(0)
-                .context("data type cannot be converted to NaiveDateTime");
+            return single_temporal(array, |a, i| a.value_as_datetime(i), CTX);
         }
         if let Some(array) = value
             .as_any()
             .downcast_ref::<arrow::array::TimestampMicrosecondArray>()
         {
-            if check_single_datetime(array) {
-                eyre::bail!("Not a valid array");
-            }
-            return array
-                .value_as_datetime(0)
-                .context("data type cannot be converted to NaiveDateTime");
+            return single_temporal(array, |a, i| a.value_as_datetime(i), CTX);
         }
         let array = value
             .as_primitive_opt::<arrow::datatypes::TimestampNanosecondType>()
             .context("not any of the primitive Timestamp arrays")?;
-        if check_single_datetime(array) {
-            eyre::bail!("Not a valid array");
-        }
-        array
-            .value_as_datetime(0)
-            .context("data type cannot be converted to NaiveDateTime")
+        single_temporal(array, |a, i| a.value_as_datetime(i), CTX)
     }
+}
+
+/// Extract the single scalar out of a length-1, non-null temporal array.
+///
+/// Every temporal `TryFrom<&ArrowData>` arm above shares the exact same shape:
+/// validate that the array holds exactly one non-null element, then convert
+/// element 0 via one of arrow's `value_as_{date,time,datetime}` accessors.
+/// Centralizing it here removes ~8 near-verbatim copies and keeps the
+/// validation and error text from drifting between them.
+fn single_temporal<T, R>(
+    array: &PrimitiveArray<T>,
+    convert: impl Fn(&PrimitiveArray<T>, usize) -> Option<R>,
+    context: &'static str,
+) -> Result<R, eyre::Error>
+where
+    T: ArrowTemporalType,
+{
+    if check_single_datetime(array) {
+        eyre::bail!("Not a valid array");
+    }
+    convert(array, 0).context(context)
 }
 
 fn check_single_datetime<T>(array: &PrimitiveArray<T>) -> bool
 where
     T: ArrowTemporalType,
 {
-    array.is_empty() || array.len() != 1 || array.null_count() != 0
+    // `len() != 1` already rejects the empty (`len() == 0`) case, so no separate
+    // `is_empty()` term is needed — unlike the primitive/`&str`/`bool` helpers,
+    // which branch on `is_empty()` to emit a distinct "empty array" message.
+    array.len() != 1 || array.null_count() != 0
 }
 fn extract_single_primitive<T>(array: &PrimitiveArray<T>) -> Result<T::Native, eyre::Error>
 where


### PR DESCRIPTION
## Summary

The `TryFrom<&ArrowData>` impls for `NaiveDate`, `NaiveTime`, and `NaiveDateTime` repeated the same three-line block for every supported array type: validate a length-1 non-null array, then convert element 0 via arrow's `value_as_{date,time,datetime}`.

- Extract a generic `single_temporal` helper that takes the array plus the accessor closure, collapsing ~8 near-verbatim copies into one and keeping the validation and error text from drifting between them. It reuses the existing `check_single_datetime`, mirroring the role `extract_single_primitive` plays for the primitive case.
- Drop the redundant `array.is_empty() ||` term in `check_single_datetime`: `len() != 1` already covers `len() == 0`, and this helper (unlike the primitive/`&str`/`bool` ones, which emit a distinct "empty array" message) collapses every failure to the same `"Not a valid array"` string, so the extra term was pure redundancy.

Behavior is unchanged.

## Validation

- The existing temporal round-trip tests in `tests/conversion_test.rs` (NaiveDate/NaiveTime/NaiveDateTime) still pass — `cargo test -p dora-arrow-convert` (29 tests, all green).
- `cargo fmt` / `cargo clippy --all-targets -D warnings` pass.

## Note

⚠️ This is a **machine-generated** change, authored by Claude (an AI assistant) as part of an automated code-review pass. It has been reviewed for correctness, but please review carefully before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FtaLn7JWcYzmYfb4ppgYYN)_