### PR TITLE
fix(cli): normalize workspace path to forward slashes for CMake templates

### DIFF
--- a/binaries/cli/src/template/c/mod.rs
+++ b/binaries/cli/src/template/c/mod.rs
@@ -80,7 +80,7 @@ fn create_cmakefile(root: PathBuf, use_path_deps: bool) -> Result<(), eyre::ErrR
     const CMAKEFILE: &str = include_str!("cmake-template.txt");
 
     let cmake_file = if use_path_deps {
-        CMAKEFILE.replace("__DORA_PATH__", super::workspace_dir()?)
+        CMAKEFILE.replace("__DORA_PATH__", &super::workspace_dir()?)
     } else {
         CMAKEFILE.replace("__DORA_PATH__", "")
     };
@@ -136,7 +136,7 @@ fn create_node_cmakefile(
     let cmake_content = if use_path_deps {
         NODE_CMAKE
             .replace("___name___", name)
-            .replace("__DORA_PATH__", super::workspace_dir()?)
+            .replace("__DORA_PATH__", &super::workspace_dir()?)
     } else {
         NODE_CMAKE
             .replace("___name___", name)

--- a/binaries/cli/src/template/cxx/mod.rs
+++ b/binaries/cli/src/template/cxx/mod.rs
@@ -79,7 +79,7 @@ fn create_cmakefile(root: PathBuf, use_path_deps: bool) -> Result<(), eyre::ErrR
     const CMAKEFILE: &str = include_str!("cmake-template.txt");
 
     let cmake_file = if use_path_deps {
-        CMAKEFILE.replace("__DORA_PATH__", super::workspace_dir()?)
+        CMAKEFILE.replace("__DORA_PATH__", &super::workspace_dir()?)
     } else {
         CMAKEFILE.replace("__DORA_PATH__", "")
     };
@@ -132,7 +132,7 @@ fn create_node_cmakefile(
     let cmake_content = if use_path_deps {
         NODE_CMAKE
             .replace("___name___", name)
-            .replace("__DORA_PATH__", super::workspace_dir()?)
+            .replace("__DORA_PATH__", &super::workspace_dir()?)
     } else {
         NODE_CMAKE
             .replace("___name___", name)

--- a/binaries/cli/src/template/mod.rs
+++ b/binaries/cli/src/template/mod.rs
@@ -17,23 +17,29 @@ fn workspace_dir() -> eyre::Result<String> {
         .context("Could not get manifest grandparent folder")?
         .to_str()
         .context("dora workspace path is not valid UTF-8")?;
-    // CMake treats `\` as a string escape character, so a raw Windows path
-    // (e.g. `C:\Users\...`) substituted into CMakeLists.txt fails to parse.
-    // Both CMake and Windows accept `/`, so normalize before substitution.
-    Ok(dir.replace('\\', "/"))
+    Ok(normalize_for_cmake(dir))
+}
+
+// CMake treats `\` as a string escape character, so a raw Windows path
+// (e.g. `C:\Users\...`) substituted into CMakeLists.txt fails to parse.
+// Both CMake and Windows accept `/`, so normalize before substitution.
+fn normalize_for_cmake(path: &str) -> String {
+    path.replace('\\', "/")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    // Uses a hardcoded Windows-style sample path rather than the live
+    // `workspace_dir()` output, since on Linux/macOS CI runners the real
+    // path never contains a backslash and the assertion would pass
+    // trivially without exercising the normalization at all.
     #[test]
-    fn workspace_dir_has_no_backslashes() {
-        let dir = workspace_dir().unwrap();
-        assert!(
-            !dir.contains('\\'),
-            "workspace_dir() must use forward slashes for CMake compatibility, got: {dir}"
-        );
+    fn normalize_for_cmake_replaces_backslashes() {
+        let normalized = normalize_for_cmake(r"C:\Users\example\dora");
+        assert_eq!(normalized, "C:/Users/example/dora");
+        assert!(!normalized.contains('\\'));
     }
 }
 

--- a/binaries/cli/src/template/mod.rs
+++ b/binaries/cli/src/template/mod.rs
@@ -9,14 +9,32 @@ mod rust;
 /// Path to the dora workspace root (two levels above the CLI crate
 /// manifest), used by the C/C++ templates to reference dora via path
 /// dependencies when `use_path_deps` is set.
-fn workspace_dir() -> eyre::Result<&'static str> {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
+fn workspace_dir() -> eyre::Result<String> {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .context("Could not get manifest parent folder")?
         .parent()
         .context("Could not get manifest grandparent folder")?
         .to_str()
-        .context("dora workspace path is not valid UTF-8")
+        .context("dora workspace path is not valid UTF-8")?;
+    // CMake treats `\` as a string escape character, so a raw Windows path
+    // (e.g. `C:\Users\...`) substituted into CMakeLists.txt fails to parse.
+    // Both CMake and Windows accept `/`, so normalize before substitution.
+    Ok(dir.replace('\\', "/"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workspace_dir_has_no_backslashes() {
+        let dir = workspace_dir().unwrap();
+        assert!(
+            !dir.contains('\\'),
+            "workspace_dir() must use forward slashes for CMake compatibility, got: {dir}"
+        );
+    }
 }
 
 pub fn create(args: crate::CommandNew, use_path_deps: bool) -> eyre::Result<()> {

--- a/binaries/coordinator/src/state.rs
+++ b/binaries/coordinator/src/state.rs
@@ -486,9 +486,7 @@ impl RunningDataflow {
             node_stopped_at: BTreeMap::new(),
             network_metrics: None,
             spawn_result: CachedResult::Cached {
-                result: Box::new(Ok(ControlRequestReply::DataflowSpawned {
-                    uuid: record.uuid,
-                })),
+                result: Ok(ControlRequestReply::DataflowSpawned { uuid: record.uuid }),
             },
             stop_reply_senders: Vec::new(),
             buffered_log_messages: Vec::new(),
@@ -544,7 +542,7 @@ pub(crate) enum CachedResult {
         result_senders: Vec<oneshot::Sender<eyre::Result<ControlRequestReply>>>,
     },
     Cached {
-        result: Box<eyre::Result<ControlRequestReply>>,
+        result: eyre::Result<ControlRequestReply>,
     },
 }
 
@@ -575,9 +573,7 @@ impl CachedResult {
                 for sender in result_senders.drain(..) {
                     Self::send_result_to(&result, sender);
                 }
-                *self = CachedResult::Cached {
-                    result: Box::new(result),
-                };
+                *self = CachedResult::Cached { result };
             }
             CachedResult::Cached { .. } => {}
         }
@@ -596,7 +592,7 @@ impl CachedResult {
     /// the spawn-timeout watchdog (or any other terminal-failure path)
     /// has already marked as failed.
     pub(crate) fn is_terminal_error(&self) -> bool {
-        matches!(self, CachedResult::Cached { result } if result.is_err())
+        matches!(self, CachedResult::Cached { result: Err(_) })
     }
 
     /// Returns `true` if a successful result has been cached, i.e. the dataflow
@@ -605,7 +601,7 @@ impl CachedResult {
     /// that are past spawn — spawn-pending ones remain the spawn-timeout
     /// watchdog's domain. See #2028.
     pub(crate) fn is_cached_ok(&self) -> bool {
-        matches!(self, CachedResult::Cached { result } if result.is_ok())
+        matches!(self, CachedResult::Cached { result: Ok(_) })
     }
 
     fn send_result_to(

--- a/binaries/coordinator/src/state.rs
+++ b/binaries/coordinator/src/state.rs
@@ -486,7 +486,9 @@ impl RunningDataflow {
             node_stopped_at: BTreeMap::new(),
             network_metrics: None,
             spawn_result: CachedResult::Cached {
-                result: Ok(ControlRequestReply::DataflowSpawned { uuid: record.uuid }),
+                result: Box::new(Ok(ControlRequestReply::DataflowSpawned {
+                    uuid: record.uuid,
+                })),
             },
             stop_reply_senders: Vec::new(),
             buffered_log_messages: Vec::new(),
@@ -542,7 +544,7 @@ pub(crate) enum CachedResult {
         result_senders: Vec<oneshot::Sender<eyre::Result<ControlRequestReply>>>,
     },
     Cached {
-        result: eyre::Result<ControlRequestReply>,
+        result: Box<eyre::Result<ControlRequestReply>>,
     },
 }
 
@@ -573,7 +575,9 @@ impl CachedResult {
                 for sender in result_senders.drain(..) {
                     Self::send_result_to(&result, sender);
                 }
-                *self = CachedResult::Cached { result };
+                *self = CachedResult::Cached {
+                    result: Box::new(result),
+                };
             }
             CachedResult::Cached { .. } => {}
         }
@@ -592,7 +596,7 @@ impl CachedResult {
     /// the spawn-timeout watchdog (or any other terminal-failure path)
     /// has already marked as failed.
     pub(crate) fn is_terminal_error(&self) -> bool {
-        matches!(self, CachedResult::Cached { result: Err(_) })
+        matches!(self, CachedResult::Cached { result } if result.is_err())
     }
 
     /// Returns `true` if a successful result has been cached, i.e. the dataflow
@@ -601,7 +605,7 @@ impl CachedResult {
     /// that are past spawn — spawn-pending ones remain the spawn-timeout
     /// watchdog's domain. See #2028.
     pub(crate) fn is_cached_ok(&self) -> bool {
-        matches!(self, CachedResult::Cached { result: Ok(_) })
+        matches!(self, CachedResult::Cached { result } if result.is_ok())
     }
 
     fn send_result_to(


### PR DESCRIPTION
## Problem

`workspace_dir()` in `binaries/cli/src/template/mod.rs` resolved the dora
workspace root from `env!("CARGO_MANIFEST_DIR")` and returned it as a raw OS
path. On Windows that's backslash-separated (e.g. `C:\Users\...`). This
string was substituted verbatim — no escaping — into the `__DORA_PATH__`
placeholder in the C/C++ CMake templates
(`binaries/cli/src/template/c/mod.rs`, `binaries/cli/src/template/cxx/mod.rs`),
producing a generated `CMakeLists.txt` line like:

    set(DORA_ROOT_DIR "C:\Users\alok0\...\dora" CACHE FILEPATH "Path to the root of dora")

CMake treats `\` inside a quoted string as an escape character. `\U`, `\D`,
etc. are not recognized escapes, so `cmake -B build` failed immediately with
a parse error (`Invalid character escape '\U'`), before any compiler/generator
logic ran. This only affects `dora new --lang c/cxx --internal-create-with-path-dependencies`
(the flag used to build templates against a local checkout) — the default
`dora new` flow substitutes an empty string and git-clones instead, so it
never hit this.

This is why it was never caught in CI: `.github/workflows/nightly.yml`
exercises this exact `dora new --lang c/cxx --internal-create-with-path-dependencies`
+ `cmake -B` flow, but is gated `if: runner.os == 'Linux'`, where paths are
already forward-slash.

## Fix

`workspace_dir()` now normalizes `\` to `/` before returning, since both
CMake and Windows accept forward slashes. Added a regression test
(`workspace_dir_has_no_backslashes`) asserting the returned path never
contains a backslash.

## Verification

- Built the actual `dora` CLI and ran
  `dora new test_c_project --lang c --internal-create-with-path-dependencies`
  — the generated `CMakeLists.txt` now contains
  `set(DORA_ROOT_DIR "C:/Users/.../dora" ...)` (forward slashes).
- `cmake -B build` on the generated project no longer hits the
  backslash-escape parse error (progresses past it to the `project()` step;
  the only remaining error is an unrelated missing MSVC/nmake toolchain on
  this machine).
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p dora-cli -- -D warnings` — clean
- `cargo test -p dora-cli workspace_dir_has_no_backslashes` — pass

Fixes #3038

