### PR TITLE
fix(message): declare uuid/v4 feature used by dora-message

### DIFF
--- a/libraries/message/Cargo.toml
+++ b/libraries/message/Cargo.toml
@@ -21,7 +21,11 @@ serde = { workspace = true }
 eyre = { workspace = true }
 arrow-schema = { workspace = true, features = ["serde"] }
 tokio = { workspace = true, features = ["sync"] }
-uuid = { workspace = true }
+# `v4` is used directly by this crate (see `Uuid::new_v4()` in `common.rs` /
+# `ws_protocol.rs`). Declared explicitly rather than relying on feature
+# unification from another crate, so an isolated build (`cargo bench -p
+# dora-message`) compiles on its own — see #3020.
+uuid = { workspace = true, features = ["v4"] }
 log = { version = "0.4.33", features = ["serde"] }
 aligned-vec = { version = "0.6.4", features = ["serde"] }
 semver = { workspace = true }


### PR DESCRIPTION
## Summary

Fixes #3020.

`dora-message` calls `Uuid::new_v4()` in `libraries/message/src/common.rs` and `libraries/message/src/ws_protocol.rs`, but declared the bare workspace `uuid` dependency, which enables only `v7` and `serde`:

```toml
uuid = { workspace = true }
```

This PR declares the `v4` feature explicitly where it is used:

```toml
uuid = { workspace = true, features = ["v4"] }
```

## Why

This is the "compiles by accident of feature unification" bug class described in the issue. `new_v4()` is only available because some *other* crate in the build set enables `uuid/v4` and cargo unifies features across the whole build.

Note on reproduction: on the current `main`, `cargo bench -p dora-message --no-run` actually **passes**, because `uhlc` (a direct dependency of `dora-message`) transitively enables `uuid/v4`:

```
uuid v1.24.0
├── dora-message
└── uhlc v0.5.2   # uhlc's Cargo.toml: uuid = { features = ["v4"] }
    └── dora-message
```

So the crate depends on `uhlc` continuing to pull in `v4`. Anything that drops that transitive activation — e.g. the pending `uhlc` upgrade in #3016, or a narrower build selection — re-exposes the original failure:

```
error[E0599]: no associated function or constant named `new_v4` found for struct `uuid::Uuid`
```

Declaring `v4` directly removes that hidden dependency and makes the intent explicit, which is the correct fix regardless of which crate happens to activate the feature today.

## Validation

- `cargo +1.97.1 check -p dora-message --tests` — passes
- `cargo +1.97.1 bench -p dora-message --no-run` — passes
- No `Cargo.lock` change (the `v4` feature was already resolved).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xrz6gC6syG2G6RZ2K1dUC8)_