### PR TITLE
ci(nightly): add concurrency group so stale nightly runs are cancelled

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,6 +44,15 @@ on:
     paths:
       - ".github/workflows/nightly.yml"
 
+# A newer nightly makes older ones obsolete, so don't let them pile up.
+# Scheduled runs share `github.ref` (refs/heads/main), so a fresh run
+# cancels a still-queued/running earlier one instead of competing with it
+# (and with the merge queue) for the runner pool. Nightly is not a
+# merge-queue required status, so cancelling a run cannot wedge the queue.
+concurrency:
+  group: nightly-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   actions: read


### PR DESCRIPTION
## Summary

Fixes #3019.

`.github/workflows/nightly.yml` had no `concurrency:` block, so nothing cancels a previous nightly when a new one starts. On days with several `nightly.yml` edits (its `push` trigger is path-filtered to the workflow itself) or overlapping scheduled/dispatch runs, multiple ~30-job matrices across Linux/macOS/Windows could queue simultaneously and compete with each other — and with the Trunk merge queue — for the shared runner pool. The older runs have no value once a newer one exists.

## Change

Adds the concurrency block suggested in the issue, right after the `on:` triggers:

```yaml
concurrency:
  group: nightly-${{ github.ref }}
  cancel-in-progress: true
```

Scheduled runs share `github.ref` (`refs/heads/main`), so a fresh nightly supersedes an in-flight/queued earlier one instead of stacking.

## Risk

Low. Nightly is not a merge-queue required status, so cancelling one of its runs cannot wedge the queue.

## Validation

- YAML parses; `concurrency` key present; all 30 jobs still parse.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xrz6gC6syG2G6RZ2K1dUC8)_