### PR TITLE
fix(core): bracket IPv6 coordinator address in zenoh connect/endpoints

### DIFF
--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -184,6 +184,20 @@ pub async fn open_zenoh_session(coordinator_addr: Option<IpAddr>) -> eyre::Resul
 /// shared by the caller (e.g. `dora cluster up`), not per-daemon
 /// state to advertise back to nodes.
 ///
+/// Builds the zenoh `connect/endpoints` JSON5 for a coordinator peer.
+///
+/// The peer address is formatted through a [`SocketAddr`] so that IPv6
+/// addresses are bracketed (`tcp/[::1]:5456`), matching zenoh's TCP locator
+/// grammar. Interpolating a bare [`IpAddr`] instead would emit `tcp/::1:5456`
+/// for IPv6 — a malformed locator where the port colon is indistinguishable
+/// from the address colons, which `insert_json5` rejects (#3041). This is the
+/// same bracketing [`reserve_zenoh_endpoint`] already relies on.
+#[cfg(feature = "zenoh")]
+fn coordinator_connect_endpoints(addr: IpAddr) -> String {
+    let peer = SocketAddr::new(addr, 5456);
+    format!(r#"{{ router: ["tcp/[::]:7447"], peer: ["tcp/{peer}"] }}"#)
+}
+
 /// `multicast` lets a caller that establishes every link explicitly opt out of
 /// scouting — see [`DORA_ZENOH_MULTICAST_ENV`], honored in addition to this
 /// argument. It is a request, not a command: it is ignored unless this session
@@ -399,13 +413,8 @@ pub async fn open_zenoh_session_with_listen(
             }
 
             if let Some(addr) = coordinator_addr
-                && let Err(err) = zenoh_config.insert_json5(
-                    "connect/endpoints",
-                    &format!(
-                        r#"{{ router: ["tcp/[::]:7447"], peer: ["tcp/{}:5456"] }}"#,
-                        addr
-                    ),
-                )
+                && let Err(err) = zenoh_config
+                    .insert_json5("connect/endpoints", &coordinator_connect_endpoints(addr))
             {
                 warn!("failed to set zenoh connect/endpoints for coordinator {addr}: {err}");
             }
@@ -838,6 +847,29 @@ mod tests {
                 ) || e.raw_os_error() == Some(97) => {}
             Err(e) => panic!("unexpected error reserving ::1 endpoint: {e}"),
         }
+    }
+
+    // The coordinator peer endpoint must bracket IPv6 too, or `insert_json5`
+    // rejects the malformed locator and the peer connect-endpoint is silently
+    // dropped (#3041). Pure string formatting — no session is opened.
+    #[cfg(feature = "zenoh")]
+    #[test]
+    fn coordinator_connect_endpoints_bracket_ipv6() {
+        let v6 = coordinator_connect_endpoints(IpAddr::V6(std::net::Ipv6Addr::LOCALHOST));
+        assert!(
+            v6.contains(r#"peer: ["tcp/[::1]:5456"]"#),
+            "IPv6 coordinator peer must be bracketed, got {v6}"
+        );
+        assert!(
+            !v6.contains("tcp/::1:5456"),
+            "unbracketed IPv6 peer locator is malformed, got {v6}"
+        );
+
+        let v4 = coordinator_connect_endpoints(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
+        assert!(
+            v4.contains(r#"peer: ["tcp/127.0.0.1:5456"]"#),
+            "IPv4 coordinator peer must be unbracketed, got {v4}"
+        );
     }
 
     // The filter behind the routing lookup, tested directly rather than through

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -154,6 +154,20 @@ pub async fn open_zenoh_session(coordinator_addr: Option<IpAddr>) -> eyre::Resul
     Ok(session)
 }
 
+/// Builds the zenoh `connect/endpoints` JSON5 for a coordinator peer.
+///
+/// The peer address is formatted through a [`SocketAddr`] so that IPv6
+/// addresses are bracketed (`tcp/[::1]:5456`), matching zenoh's TCP locator
+/// grammar. Interpolating a bare [`IpAddr`] instead would emit `tcp/::1:5456`
+/// for IPv6 — a malformed locator where the port colon is indistinguishable
+/// from the address colons, which `insert_json5` rejects (#3041). This is the
+/// same bracketing [`reserve_zenoh_endpoint`] already relies on.
+#[cfg(feature = "zenoh")]
+fn coordinator_connect_endpoints(addr: IpAddr) -> String {
+    let peer = SocketAddr::new(addr, 5456);
+    format!(r#"{{ router: ["tcp/[::]:7447"], peer: ["tcp/{peer}"] }}"#)
+}
+
 /// Like [`open_zenoh_session`], but also configures the session to listen on
 /// the given endpoint (e.g. `tcp/127.0.0.1:43217`, or a routable address such as
 /// `tcp/10.0.2.100:43217` for a daemon in a cluster). The daemon uses this so
@@ -184,20 +198,6 @@ pub async fn open_zenoh_session(coordinator_addr: Option<IpAddr>) -> eyre::Resul
 /// shared by the caller (e.g. `dora cluster up`), not per-daemon
 /// state to advertise back to nodes.
 ///
-/// Builds the zenoh `connect/endpoints` JSON5 for a coordinator peer.
-///
-/// The peer address is formatted through a [`SocketAddr`] so that IPv6
-/// addresses are bracketed (`tcp/[::1]:5456`), matching zenoh's TCP locator
-/// grammar. Interpolating a bare [`IpAddr`] instead would emit `tcp/::1:5456`
-/// for IPv6 — a malformed locator where the port colon is indistinguishable
-/// from the address colons, which `insert_json5` rejects (#3041). This is the
-/// same bracketing [`reserve_zenoh_endpoint`] already relies on.
-#[cfg(feature = "zenoh")]
-fn coordinator_connect_endpoints(addr: IpAddr) -> String {
-    let peer = SocketAddr::new(addr, 5456);
-    format!(r#"{{ router: ["tcp/[::]:7447"], peer: ["tcp/{peer}"] }}"#)
-}
-
 /// `multicast` lets a caller that establishes every link explicitly opt out of
 /// scouting — see [`DORA_ZENOH_MULTICAST_ENV`], honored in addition to this
 /// argument. It is a request, not a command: it is ignored unless this session


### PR DESCRIPTION
## Summary

Fixes #3041.

In `open_zenoh_session_with_listen` (`libraries/core/src/topics.rs`), the zenoh `connect/endpoints` peer entry was built by interpolating the coordinator address with a bare `{}`:

```rust
format!(r#"{{ router: ["tcp/[::]:7447"], peer: ["tcp/{}:5456"] }}"#, addr)
```

For an `IpAddr::V6`, `Display` emits the address **without** brackets, so the result is a malformed zenoh TCP locator — `tcp/::1:5456` — where the port colon is indistinguishable from the address colons. `insert_json5` rejects it, the code falls into the `warn!` branch, and the coordinator peer connect-endpoint is silently never configured. IPv4 addresses were unaffected. (Note the *router* entry on the same line, `tcp/[::]:7447`, was already bracketed — the bracketing was simply omitted for the dynamic `peer`.)

## Fix

Format the peer address through a `SocketAddr`, exactly as `reserve_zenoh_endpoint` already does — `SocketAddr`'s `Display` brackets IPv6 and leaves IPv4 bare. The endpoint-string construction is extracted into a small `coordinator_connect_endpoints(addr)` helper so it is unit-testable without opening a real session:

```rust
fn coordinator_connect_endpoints(addr: IpAddr) -> String {
    let peer = SocketAddr::new(addr, 5456);
    format!(r#"{{ router: ["tcp/[::]:7447"], peer: ["tcp/{peer}"] }}"#)
}
```

The helper and its test are gated on the `zenoh` feature (matching the only call site, which is `#[cfg(feature = "zenoh")]`).

## Impact

Currently latent: every in-tree caller passes `None` for `coordinator_addr` today. But `open_zenoh_session` is public `dora-core` API accepting an `IpAddr`, so any external/future caller passing an IPv6 coordinator address hits this and silently loses its peer connect endpoint. Consistent now with the file's own `ipv6_endpoints_are_bracketed` convention.

## Validation (toolchain 1.97.1, `--features zenoh`)

- New test `topics::tests::coordinator_connect_endpoints_bracket_ipv6` — passes (asserts `tcp/[::1]:5456`, not `tcp/::1:5456`, for IPv6 and `tcp/127.0.0.1:5456` for IPv4)
- `cargo test -p dora-core --features zenoh` (existing `ipv6_endpoints_are_bracketed` etc.) — passes
- `cargo clippy -p dora-core --features zenoh --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xrz6gC6syG2G6RZ2K1dUC8)_