### PR TITLE
test(daemon): deflake a_wrapper_that_exits_does_not_hide_its_surviving_child

### DIFF
--- a/binaries/daemon/src/shutdown.rs
+++ b/binaries/daemon/src/shutdown.rs
@@ -275,9 +275,19 @@ mod tests {
 
         // A group leader that spawns a child into its group and exits, like
         // a wrapper dying while the interpreter it launched keeps running.
+        //
+        // The wrapper blocks on `read` rather than `exit 0` so its lifetime is
+        // controlled by the test, not by a race: nothing ordered the first
+        // `poll` before a bare `exit 0`, so on a loaded machine the wrapper
+        // could already be a reaped-later zombie by then, `is_live_child`
+        // returns false, and — being the first poll — the `confirmed`-group
+        // fallback does not yet apply, so `poll` returned `Done` and the
+        // "wrapper is alive" assertion flaked (#3023). Closing stdin below makes
+        // `read` hit EOF, so the wrapper exits exactly where the test wants it.
         let mut wrapper = Command::new("sh")
             .arg("-c")
-            .arg("sleep 300 & exit 0")
+            .arg("sleep 300 & read line")
+            .stdin(Stdio::piped())
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .process_group(0)
@@ -292,7 +302,9 @@ mod tests {
             "the wrapper is alive, so this is an ordinary wait"
         );
 
-        // The wrapper exits and is reaped; its child lives on.
+        // Close stdin so the wrapper's `read` hits EOF and it exits; its child
+        // lives on. The wrapper is reaped by the `wait()` below.
+        drop(wrapper.stdin.take());
         wrapper.wait().expect("failed to wait for wrapper");
         assert_eq!(
             wait.poll(&[pid]),


### PR DESCRIPTION
## Summary

Fixes #3023.

`shutdown::tests::a_wrapper_that_exits_does_not_hide_its_surviving_child` (`binaries/daemon/src/shutdown.rs`) fails intermittently under load — it passes in isolation but flakes in `cargo test --all` and can hit CI:

```
assertion `left == right` failed: the wrapper is alive, so this is an ordinary wait
  left: Done
 right: Waiting
```

## Root cause

The test spawns a wrapper *designed* to exit immediately (`sleep 300 & exit 0`), then asserts the first `DestroyWait::poll` returns `Waiting`. Nothing orders that poll before the wrapper exits. When the poll loses the race:

- `sh` has exited and is an unreaped zombie (the test only calls `wrapper.wait()` later).
- `is_live_child` returns `false` for a zombie.
- It's the *first* poll, so `self.confirmed` is empty and the `confirmed && process_group_has_members` fallback in `live_children` does not apply.
- `alive` is empty → `poll` returns `Done` instead of `Waiting`.

Pure test-side race; the production behavior under test (a group outliving its leader) is fine.

## Fix

Give the wrapper a deterministic live window: block it on stdin (`read`) instead of `exit 0`, and close the pipe where the test previously expected the exit. The wrapper is now provably alive for the first poll (which also records the pid so the group fallback covers the second poll), and closing stdin makes `read` hit EOF so `sh` exits exactly on cue.

## Validation

- `cargo test -p dora-daemon --lib a_wrapper_that_exits` — passes.
- Stress reproduction from the issue (12-way concurrent runs × 3 rounds of the daemon lib test binary): **0 failures / 36 runs** on this branch (issue reports ~9/36 without the fix).
- `cargo fmt --all -- --check` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xrz6gC6syG2G6RZ2K1dUC8)_