### PR TITLE
feat(node-api): non-blocking correlated receives for service and action clients

### DIFF
--- a/apis/c++/node/README.md
+++ b/apis/c++/node/README.md
@@ -343,7 +343,14 @@ auto reply = recv_service_response_from(
 The set governs only restart detection; which reply matches is decided by
 `request_id` alone. A restart of any listed node is reported as
 `ServerRestarted` naming that node — a notification, not a verdict, since
-the other candidates may still answer.
+the other candidates may still answer, so the request's deadline keeps
+running on its original clock.
+
+A list holding exactly one id is treated as the single-server case, not
+as a one-element set: with nobody else to answer, that restart *is* the
+verdict, and the orphaned request's deadline is released with it. The
+single-server polls above take the same path, so they behave
+identically.
 
 The server must echo the request's `request_id` back, which is why it needs
 `event_as_input_with_metadata`:

--- a/apis/c++/node/README.md
+++ b/apis/c++/node/README.md
@@ -282,9 +282,25 @@ The framework owns the deadline: the first poll carrying a `timeout_ms`
 registers it against that `request_id`, and a later poll past it returns
 `Timeout` exactly once. A caller passes the same `timeout_ms` every
 iteration and reacts to `Timeout` like any other status — no deadline
-bookkeeping of its own. Pass `0` for no deadline. The clock starts at
-that first poll rather than at send time, and the first deadline
-registered for an id wins.
+bookkeeping of its own. The clock starts at that first poll rather than
+at send time, and the first deadline registered for an id wins.
+
+`timeout_ms == 0` means **no deadline**, not "return immediately" — a
+poll never blocks anyway, so there is nothing to time out. This inverts
+the usual convention for a `timeout` argument, so it is worth a second
+look when reading calling code.
+
+A poll drops its own registration on a match, an error or expiry. If the
+node abandons a request it will never poll again — the peer died, the
+operator cancelled, the reply stopped mattering — release it explicitly,
+or that one entry lives until the event stream is dropped:
+
+```c++
+cancel_correlation(dora_node.events, request_id);
+```
+
+Safe to call for an id that was never registered, so a cancel racing a
+reply is harmless.
 
 > **Ordering matters.** The polls and your own `next_event` read the same
 > event stream, so whichever runs first consumes what is there. A poll

--- a/apis/c++/node/README.md
+++ b/apis/c++/node/README.md
@@ -334,8 +334,8 @@ acceptable responders — an empty vector means any node:
 
 ```c++
 rust::Vec<rust::String> candidates;
-candidates.push_back("cam-eo");
-candidates.push_back("cam-ir");
+candidates.push_back("a");
+candidates.push_back("b");
 auto reply = recv_service_response_from(
     dora_node.events, request_id, candidates, /* timeout_ms */ 5000);
 ```

--- a/apis/c++/node/README.md
+++ b/apis/c++/node/README.md
@@ -250,6 +250,76 @@ The `event` field also carries a matching `DoraEventType` (`Timeout` /
 `server_node_id` yields `DoraPatternStatus::InvalidArgument` rather than
 aborting the process.
 
+#### Clients that cannot block
+
+`recv_service_response` waits. A single-threaded node with its own
+schedule to keep, or several requests outstanding at once, cannot afford
+that. `try_recv_service_response` polls instead and returns
+`DoraPatternStatus::NotReady` when the reply has not arrived — the same
+convention `try_next_event` uses for plain events. Buffering, restart
+detection and correlation are unchanged; only the waiting is gone.
+
+```c++
+// per loop iteration, for each outstanding request
+auto poll = try_recv_service_response(dora_node.events, request_id, "server-node-id");
+switch (poll.status)
+{
+case DoraPatternStatus::Matched:
+    complete(event_as_input(std::move(poll.event)));
+    break;
+case DoraPatternStatus::NotReady:
+    break; // nothing to do, and no time spent
+default:
+    std::cerr << std::string(poll.error) << std::endl;
+}
+```
+
+There is no deadline, so `Timeout` never comes back from a poll — keeping
+deadlines is the caller's job.
+
+> **Ordering matters.** The polls and your own `next_event` read the same
+> event stream, so whichever runs first consumes what is there. A poll
+> correlates the reply it wants and buffers everything else for a later
+> `next_event`, so polling first loses nothing. The reverse is not true:
+> a reply handed to `next_event` is gone, and no later poll can see it.
+> Poll first, then drain your own events with `try_next_event`.
+
+`try_recv_action_result` is the equivalent for actions. See
+`examples/c++-service-action/nodes/polling-client.cc` for a client with
+several requests in flight that never blocks.
+
+#### Fanning one request out to several servers
+
+`send_service_request` mints a fresh `request_id` per call, so it cannot
+express one logical request sent to several nodes. Mint the id once and
+send each copy with `send_service_request_with_id`:
+
+```c++
+auto request_id = std::string(new_request_id());
+for (const auto &server : servers)
+{
+    send_service_request_with_id(
+        dora_node.send_output, server.output, payload, new_metadata(), request_id);
+}
+```
+
+Then await whichever answers first with `recv_service_response_from` (or
+`try_recv_service_response_from`), which take a `Vec<String>` of
+acceptable responders — an empty vector means any node:
+
+```c++
+rust::Vec<rust::String> candidates;
+candidates.push_back("cam-eo");
+candidates.push_back("cam-ir");
+auto reply = recv_service_response_from(
+    dora_node.events, request_id, candidates, /* timeout_ms */ 5000);
+```
+
+The set governs only restart detection; which reply matches is decided by
+`request_id` alone. A restart of any listed node is reported as
+`ServerRestarted` naming that node — a notification, not a verdict, since
+the other candidates may still answer.
+
 The server must echo the request's `request_id` back, which is why it needs
 `event_as_input_with_metadata`:
 

--- a/apis/c++/node/README.md
+++ b/apis/c++/node/README.md
@@ -261,7 +261,8 @@ detection and correlation are unchanged; only the waiting is gone.
 
 ```c++
 // per loop iteration, for each outstanding request
-auto poll = try_recv_service_response(dora_node.events, request_id, "server-node-id");
+auto poll = try_recv_service_response(
+    dora_node.events, request_id, "server-node-id", /* timeout_ms */ 5000);
 switch (poll.status)
 {
 case DoraPatternStatus::Matched:
@@ -269,13 +270,21 @@ case DoraPatternStatus::Matched:
     break;
 case DoraPatternStatus::NotReady:
     break; // nothing to do, and no time spent
+case DoraPatternStatus::Timeout:
+    give_up(); // the registered deadline lapsed; reported once
+    break;
 default:
     std::cerr << std::string(poll.error) << std::endl;
 }
 ```
 
-There is no deadline, so `Timeout` never comes back from a poll — keeping
-deadlines is the caller's job.
+The framework owns the deadline: the first poll carrying a `timeout_ms`
+registers it against that `request_id`, and a later poll past it returns
+`Timeout` exactly once. A caller passes the same `timeout_ms` every
+iteration and reacts to `Timeout` like any other status — no deadline
+bookkeeping of its own. Pass `0` for no deadline. The clock starts at
+that first poll rather than at send time, and the first deadline
+registered for an id wins.
 
 > **Ordering matters.** The polls and your own `next_event` read the same
 > event stream, so whichever runs first consumes what is there. A poll

--- a/apis/c++/node/README.md
+++ b/apis/c++/node/README.md
@@ -257,6 +257,31 @@ The `event` field also carries a matching `DoraEventType` (`Timeout` /
 `server_node_id` yields `DoraPatternStatus::InvalidArgument` rather than
 aborting the process.
 
+#### Reacting to a restart with several requests in flight
+
+A restart is reported to the *one* correlation that consumes it — the wait or
+poll that happened to be reading the stream. Others outstanding against the
+same server are not told, and would otherwise sit until their own deadlines.
+Handling the event in your own loop covers them:
+
+```c++
+case DoraEventType::NodeRestarted:
+{
+    const auto who = std::string(event_as_node_restarted(std::move(event)));
+    // Everything still outstanding against that node is orphaned: the
+    // instance that would have answered is gone.
+    for (const auto &entry : pending_for(who))
+    {
+        cancel_correlation(dora_node.events, entry.request_id);
+    }
+    resend_against_new_instance(who);
+    break;
+}
+```
+
+`cancel_correlation` releases the framework's deadline for those requests;
+resending is yours to do, under a fresh `request_id` from `new_request_id()`.
+
 #### Clients that cannot block
 
 `recv_service_response` waits. A single-threaded node with its own

--- a/apis/c++/node/README.md
+++ b/apis/c++/node/README.md
@@ -245,6 +245,13 @@ default:
 
 Events that arrive during the wait but do not match are buffered and
 replayed by later `next_event` calls, so your main event loop loses nothing.
+
+`ServerRestarted` is reported for a restart that lands while a wait or poll
+is running, because the correlation is reading the stream then. One that
+lands between calls reaches your own loop as `DoraEventType::NodeRestarted`
+(use `event_as_node_restarted` for the id). Ignore it and the next request
+will wait out its whole deadline against a server you had already been told
+had restarted.
 The `event` field also carries a matching `DoraEventType` (`Timeout` /
 `AllInputsClosed` / `Empty`), so you can branch on either field. A malformed
 `server_node_id` yields `DoraPatternStatus::InvalidArgument` rather than

--- a/apis/c++/node/README.md
+++ b/apis/c++/node/README.md
@@ -317,10 +317,11 @@ iteration and reacts to `Timeout` like any other status — no deadline
 bookkeeping of its own. The clock starts at that first poll rather than
 at send time, and the first deadline registered for an id wins.
 
-`timeout_ms == 0` means **no deadline**, not "return immediately" — a
-poll never blocks anyway, so there is nothing to time out. This inverts
-the usual convention for a `timeout` argument, so it is worth a second
-look when reading calling code.
+`timeout_ms` carries one meaning across the whole header: `0` expires
+immediately, exactly as it does for the blocking `recv_service_response`,
+and `UINT64_MAX` is the spelling for **no practical deadline**. Moving a
+request from a blocking wait to a poll by changing the function name
+therefore never silently drops its deadline.
 
 A poll drops its own registration on a match, an error or expiry. If the
 node abandons a request it will never poll again — the peer died, the

--- a/apis/c++/node/src/lib.rs
+++ b/apis/c++/node/src/lib.rs
@@ -2089,14 +2089,14 @@ mod tests {
 
     #[test]
     fn server_list_parses_every_entry() {
-        let Ok(parsed) = parse_server_list(&["cam-eo", "cam-ir"]) else {
+        let Ok(parsed) = parse_server_list(&["a", "b"]) else {
             panic!("both ids are valid");
         };
         match parsed {
             OwnedServers::Some(ids) => {
                 assert_eq!(ids.len(), 2);
-                assert_eq!(ids[0].as_ref(), "cam-eo");
-                assert_eq!(ids[1].as_ref(), "cam-ir");
+                assert_eq!(ids[0].as_ref(), "a");
+                assert_eq!(ids[1].as_ref(), "b");
             }
             OwnedServers::Any => panic!("a non-empty list must not widen to Any"),
         }
@@ -2106,7 +2106,7 @@ mod tests {
     fn empty_entry_inside_a_list_is_rejected() {
         // Silently treating this as "any" would let one stray "" switch
         // off restart detection for the whole set.
-        let result = parse_server_list(&["cam-eo", ""]);
+        let result = parse_server_list(&["a", ""]);
         match result {
             Err(failure) => assert!(matches!(
                 failure.status,
@@ -2151,13 +2151,13 @@ mod tests {
         let timeout = try_pattern_result(Err(PatternError::Timeout));
         assert!(matches!(timeout.status, ffi::DoraPatternStatus::Timeout));
 
-        let restarted = try_pattern_result(Err(PatternError::ServerRestarted("cam-ir".into())));
+        let restarted = try_pattern_result(Err(PatternError::ServerRestarted("b".into())));
         assert!(matches!(
             restarted.status,
             ffi::DoraPatternStatus::ServerRestarted
         ));
         assert!(
-            restarted.error.contains("cam-ir"),
+            restarted.error.contains("b"),
             "the restarted node's id must reach the C++ caller: {}",
             restarted.error
         );

--- a/apis/c++/node/src/lib.rs
+++ b/apis/c++/node/src/lib.rs
@@ -366,25 +366,40 @@ mod ffi {
         /// state carries across calls — so polling in a loop is
         /// equivalent to waiting, minus the blocking.
         ///
-        /// There is no deadline, so `Timeout` is never returned; keeping
-        /// deadlines is the caller's job. Pass an empty
-        /// `server_node_id` to accept a reply from any node and skip
-        /// restart correlation.
+        /// `timeout_ms` is owned by the framework: the first poll
+        /// carrying one registers a deadline for `request_id`, and a
+        /// later poll past it returns `Timeout` exactly once. So a
+        /// caller does not sweep deadlines itself — it passes the same
+        /// `timeout_ms` every iteration and reacts to `Timeout` like
+        /// any other status. Pass `0` for no deadline.
+        ///
+        /// The clock starts at that first poll rather than at send
+        /// time, and the first deadline registered for an id wins.
+        ///
+        /// Pass an empty `server_node_id` to accept a reply from any
+        /// node and skip restart correlation.
         fn try_recv_service_response(
             events: &mut Box<Events>,
             request_id: &str,
             server_node_id: &str,
+            timeout_ms: u64,
         ) -> DoraPatternResult;
 
         /// Non-blocking poll for a *terminal* result for `goal_id`.
         ///
         /// Returns `NotReady` while the goal is still running. Feedback
-        /// messages stay buffered for the caller's own event loop. Pass
-        /// an empty `server_node_id` to accept any responder.
+        /// messages stay buffered for the caller's own event loop.
+        ///
+        /// `timeout_ms` behaves as in `try_recv_service_response`, but
+        /// bounds the *whole goal* rather than the gap between feedback
+        /// messages: a long goal that is making visible progress will
+        /// still expire. Pass `0` for no deadline, and an empty
+        /// `server_node_id` to accept any responder.
         fn try_recv_action_result(
             events: &mut Box<Events>,
             goal_id: &str,
             server_node_id: &str,
+            timeout_ms: u64,
         ) -> DoraPatternResult;
 
         /// `recv_service_response` over a set of acceptable responders,
@@ -418,6 +433,7 @@ mod ffi {
             events: &mut Box<Events>,
             request_id: &str,
             server_node_ids: &Vec<String>,
+            timeout_ms: u64,
         ) -> DoraPatternResult;
 
         /// Non-blocking `recv_action_result_from`.
@@ -425,6 +441,7 @@ mod ffi {
             events: &mut Box<Events>,
             goal_id: &str,
             server_node_ids: &Vec<String>,
+            timeout_ms: u64,
         ) -> DoraPatternResult;
 
         /// Send a service request under a caller-supplied `request_id`.
@@ -1361,28 +1378,34 @@ fn try_recv_service_response(
     events: &mut Box<Events>,
     request_id: &str,
     server_node_id: &str,
+    timeout_ms: u64,
 ) -> ffi::DoraPatternResult {
     let servers = match parse_server_list(std::slice::from_ref(&server_node_id)) {
         Ok(servers) => servers,
         Err(result) => return result,
     };
-    try_pattern_result(
-        events
-            .0
-            .try_recv_service_response(request_id, servers.as_ref()),
-    )
+    try_pattern_result(events.0.try_recv_service_response(
+        request_id,
+        servers.as_ref(),
+        poll_timeout(timeout_ms),
+    ))
 }
 
 fn try_recv_action_result(
     events: &mut Box<Events>,
     goal_id: &str,
     server_node_id: &str,
+    timeout_ms: u64,
 ) -> ffi::DoraPatternResult {
     let servers = match parse_server_list(std::slice::from_ref(&server_node_id)) {
         Ok(servers) => servers,
         Err(result) => return result,
     };
-    try_pattern_result(events.0.try_recv_action_result(goal_id, servers.as_ref()))
+    try_pattern_result(events.0.try_recv_action_result(
+        goal_id,
+        servers.as_ref(),
+        poll_timeout(timeout_ms),
+    ))
 }
 
 /// `&Vec<String>` rather than `&[String]`: cxx maps `Vec<String>` to
@@ -1442,16 +1465,17 @@ fn try_recv_service_response_from(
     events: &mut Box<Events>,
     request_id: &str,
     server_node_ids: &Vec<String>,
+    timeout_ms: u64,
 ) -> ffi::DoraPatternResult {
     let servers = match parse_server_strings(server_node_ids) {
         Ok(servers) => servers,
         Err(result) => return result,
     };
-    try_pattern_result(
-        events
-            .0
-            .try_recv_service_response(request_id, servers.as_ref()),
-    )
+    try_pattern_result(events.0.try_recv_service_response(
+        request_id,
+        servers.as_ref(),
+        poll_timeout(timeout_ms),
+    ))
 }
 
 /// `&Vec<String>` rather than `&[String]`: cxx maps `Vec<String>` to
@@ -1463,12 +1487,17 @@ fn try_recv_action_result_from(
     events: &mut Box<Events>,
     goal_id: &str,
     server_node_ids: &Vec<String>,
+    timeout_ms: u64,
 ) -> ffi::DoraPatternResult {
     let servers = match parse_server_strings(server_node_ids) {
         Ok(servers) => servers,
         Err(result) => return result,
     };
-    try_pattern_result(events.0.try_recv_action_result(goal_id, servers.as_ref()))
+    try_pattern_result(events.0.try_recv_action_result(
+        goal_id,
+        servers.as_ref(),
+        poll_timeout(timeout_ms),
+    ))
 }
 
 /// Owned form of [`ExpectedServers`], which borrows.
@@ -1512,6 +1541,21 @@ fn parse_server_list(ids: &[&str]) -> Result<OwnedServers, ffi::DoraPatternResul
         parsed.push(parse_server_node_id(id)?);
     }
     Ok(OwnedServers::Some(parsed))
+}
+
+/// Map a C++ `timeout_ms` onto the Rust poll's optional deadline.
+///
+/// `0` means "no deadline" — the poll then behaves exactly as it did
+/// before deadlines existed. Any other value is clamped the same way
+/// `clamp_pattern_timeout` clamps the blocking waits, because it
+/// crosses the bridge as an unbounded `u64` and ends up in an
+/// `Instant + Duration`.
+fn poll_timeout(timeout_ms: u64) -> Option<Duration> {
+    if timeout_ms == 0 {
+        None
+    } else {
+        Some(clamp_pattern_timeout(timeout_ms))
+    }
 }
 
 /// Map a non-blocking correlated receive onto the C++ result struct.
@@ -1996,6 +2040,22 @@ mod tests {
             pinned.get(dora_node_api::REQUEST_ID),
             Some(&DoraParameter::String("req-fixed".into()))
         );
+    }
+
+    #[test]
+    fn zero_timeout_means_no_deadline() {
+        // `0` has to keep meaning "poll forever", or a caller that
+        // never wanted a deadline would start getting Timeout.
+        assert!(poll_timeout(0).is_none());
+    }
+
+    #[test]
+    fn nonzero_timeout_is_clamped_like_the_blocking_waits() {
+        let clamped = poll_timeout(u64::MAX).expect("a non-zero timeout is a deadline");
+        assert_eq!(clamped, clamp_pattern_timeout(u64::MAX));
+
+        let ordinary = poll_timeout(5_000).expect("a non-zero timeout is a deadline");
+        assert_eq!(ordinary, Duration::from_millis(5_000));
     }
 
     #[test]

--- a/apis/c++/node/src/lib.rs
+++ b/apis/c++/node/src/lib.rs
@@ -444,6 +444,18 @@ mod ffi {
             timeout_ms: u64,
         ) -> DoraPatternResult;
 
+        /// Forget an outstanding correlation's deadline.
+        ///
+        /// A poll drops its own registration on a match, an error or
+        /// expiry, so this is only needed when a node abandons a
+        /// request it will never poll again — a peer died, the operator
+        /// cancelled, the reply stopped mattering. Without it that one
+        /// entry lives until the event stream is dropped, which for a
+        /// long-running node is an unbounded slow leak.
+        ///
+        /// Safe to call for an id that was never registered.
+        fn cancel_correlation(events: &mut Box<Events>, correlation_id: &str);
+
         /// Send a service request under a caller-supplied `request_id`.
         ///
         /// `send_service_request` mints a fresh id per call, so it
@@ -1543,6 +1555,10 @@ fn parse_server_list(ids: &[&str]) -> Result<OwnedServers, ffi::DoraPatternResul
     Ok(OwnedServers::Some(parsed))
 }
 
+fn cancel_correlation(events: &mut Box<Events>, correlation_id: &str) {
+    events.0.cancel_correlation(correlation_id);
+}
+
 /// Map a C++ `timeout_ms` onto the Rust poll's optional deadline.
 ///
 /// `0` means "no deadline" — the poll then behaves exactly as it did
@@ -2001,10 +2017,6 @@ mod tests {
         dora_node_api::uuid::Uuid::parse_str(&new_goal_id()).expect("goal id should be a UUID");
     }
 
-    /// A caller-supplied `request_id` must be replaced, matching
-    /// `DoraNode::send_service_request`. Silently honouring it would let
-    /// two in-flight requests share a correlation key.
-    #[test]
     // ---- dora-rs/dora#3046 ----
 
     /// The whole point of the `_with_id` variant: the caller's id must
@@ -2151,6 +2163,9 @@ mod tests {
         );
     }
 
+    /// A caller-supplied `request_id` must be replaced, matching
+    /// `DoraNode::send_service_request`. Silently honouring it would let
+    /// two in-flight requests share a correlation key.
     #[test]
     fn insert_request_id_overwrites_caller_value() {
         let mut parameters = DoraMetadataParameters::default();

--- a/apis/c++/node/src/lib.rs
+++ b/apis/c++/node/src/lib.rs
@@ -1527,7 +1527,24 @@ impl OwnedServers {
     fn as_ref(&self) -> ExpectedServers<'_> {
         match self {
             Self::Any => ExpectedServers::Any,
-            Self::Some(ids) => ExpectedServers::AnyOf(ids),
+            // Exactly one candidate is `One`, not a one-element `AnyOf`.
+            //
+            // The two differ in what a restart *means*: with a set,
+            // a restart is a notification because the others may still
+            // answer, so the deadline keeps running. With a single
+            // server there is nobody else, so the restart is the
+            // verdict and the deadline must go with the orphaned
+            // request.
+            //
+            // This is the path every C++ single-server poll takes —
+            // `try_recv_service_response(.., server_node_id, ..)` wraps
+            // its lone id in a slice — so without this it would leak one
+            // deadline entry per abandoned request, which is exactly
+            // what `cancel_correlation` was added to avoid needing.
+            Self::Some(ids) => match ids.as_slice() {
+                [only] => ExpectedServers::One(only),
+                many => ExpectedServers::AnyOf(many),
+            },
         }
     }
 }
@@ -2085,6 +2102,45 @@ mod tests {
             panic!("an empty id is the 'any' spelling and must be accepted");
         };
         assert!(matches!(parsed, OwnedServers::Any));
+    }
+
+    /// The C++ single-server polls wrap their lone id in a slice, so
+    /// this is the mapping every one of them goes through. It has to
+    /// land on `One`: with a single candidate a restart is terminal, and
+    /// `One` is what drops the orphaned request's deadline. A
+    /// one-element `AnyOf` would keep it, leaking one entry per
+    /// abandoned request.
+    ///
+    /// Paired with `a_one_server_restart_clears_the_deadline` in
+    /// `dora-node-api`, which pins the clearing behaviour itself.
+    #[test]
+    fn a_single_server_maps_to_one_not_a_one_element_any_of() {
+        let Ok(parsed) = parse_server_list(&["srv"]) else {
+            panic!("a single valid id must parse");
+        };
+        assert!(
+            matches!(parsed.as_ref(), ExpectedServers::One(id) if id.as_ref() == "srv"),
+            "a lone server must become One, or its restart will not clear the deadline"
+        );
+    }
+
+    #[test]
+    fn several_servers_still_map_to_any_of() {
+        let Ok(parsed) = parse_server_list(&["a", "b"]) else {
+            panic!("both ids are valid");
+        };
+        assert!(
+            matches!(parsed.as_ref(), ExpectedServers::AnyOf(ids) if ids.len() == 2),
+            "a real fan-out must keep AnyOf semantics"
+        );
+    }
+
+    #[test]
+    fn no_servers_still_maps_to_any() {
+        let Ok(parsed) = parse_server_list(&[]) else {
+            panic!("an empty list is valid");
+        };
+        assert!(matches!(parsed.as_ref(), ExpectedServers::Any));
     }
 
     #[test]

--- a/apis/c++/node/src/lib.rs
+++ b/apis/c++/node/src/lib.rs
@@ -11,7 +11,7 @@ use chrono::DateTime;
 #[cfg(any(feature = "ros2-bridge", test))]
 use dora_node_api::merged::MergeExternal;
 use dora_node_api::{
-    self, Event, EventStream, Metadata as DoraMetadata,
+    self, Event, EventStream, ExpectedServers, Metadata as DoraMetadata,
     MetadataParameters as DoraMetadataParameters, Parameter as DoraParameter, PatternError,
     TryRecvError,
     arrow_v59::array::{AsArray, UInt8Array},
@@ -116,6 +116,11 @@ mod ffi {
         /// A caller-supplied argument was rejected (e.g. a malformed
         /// server node id). Nothing was awaited.
         InvalidArgument,
+        /// Returned only by the `try_recv_*` polls: no correlated reply
+        /// is available yet. Not an error — call again on a later
+        /// iteration. Distinct from `Timeout`, which means a deadline
+        /// actually elapsed.
+        NotReady,
     }
 
     /// Result of `recv_service_response` / `recv_action_result`.
@@ -348,6 +353,94 @@ mod ffi {
             server_node_id: &str,
             timeout_ms: u64,
         ) -> DoraPatternResult;
+
+        /// Non-blocking poll for the response carrying `request_id`.
+        ///
+        /// Returns `NotReady` when the reply has not arrived yet, so a
+        /// single-threaded node can check several outstanding requests
+        /// per event-loop iteration without ever stalling. Follows the
+        /// same convention as `try_next_event`.
+        ///
+        /// Non-matching events are buffered for later `next_event`
+        /// calls exactly as in `recv_service_response`, and correlation
+        /// state carries across calls — so polling in a loop is
+        /// equivalent to waiting, minus the blocking.
+        ///
+        /// There is no deadline, so `Timeout` is never returned; keeping
+        /// deadlines is the caller's job. Pass an empty
+        /// `server_node_id` to accept a reply from any node and skip
+        /// restart correlation.
+        fn try_recv_service_response(
+            events: &mut Box<Events>,
+            request_id: &str,
+            server_node_id: &str,
+        ) -> DoraPatternResult;
+
+        /// Non-blocking poll for a *terminal* result for `goal_id`.
+        ///
+        /// Returns `NotReady` while the goal is still running. Feedback
+        /// messages stay buffered for the caller's own event loop. Pass
+        /// an empty `server_node_id` to accept any responder.
+        fn try_recv_action_result(
+            events: &mut Box<Events>,
+            goal_id: &str,
+            server_node_id: &str,
+        ) -> DoraPatternResult;
+
+        /// `recv_service_response` over a set of acceptable responders,
+        /// for a request fanned out to several nodes under one
+        /// `request_id` where the first reply wins.
+        ///
+        /// An empty `server_node_ids` accepts a reply from any node.
+        /// The set only affects restart detection: which reply matches
+        /// is decided by `request_id` alone. A restart of any listed
+        /// node is reported as `ServerRestarted` naming that node — a
+        /// notification, not a verdict, since the other candidates may
+        /// still answer.
+        fn recv_service_response_from(
+            events: &mut Box<Events>,
+            request_id: &str,
+            server_node_ids: &Vec<String>,
+            timeout_ms: u64,
+        ) -> DoraPatternResult;
+
+        /// `recv_action_result` over a set of acceptable responders.
+        /// See `recv_service_response_from`.
+        fn recv_action_result_from(
+            events: &mut Box<Events>,
+            goal_id: &str,
+            server_node_ids: &Vec<String>,
+            timeout_ms: u64,
+        ) -> DoraPatternResult;
+
+        /// Non-blocking `recv_service_response_from`: the fan-out poll.
+        fn try_recv_service_response_from(
+            events: &mut Box<Events>,
+            request_id: &str,
+            server_node_ids: &Vec<String>,
+        ) -> DoraPatternResult;
+
+        /// Non-blocking `recv_action_result_from`.
+        fn try_recv_action_result_from(
+            events: &mut Box<Events>,
+            goal_id: &str,
+            server_node_ids: &Vec<String>,
+        ) -> DoraPatternResult;
+
+        /// Send a service request under a caller-supplied `request_id`.
+        ///
+        /// `send_service_request` mints a fresh id per call, so it
+        /// cannot express one logical request fanned out to several
+        /// nodes. Use `new_request_id()` once, then send each copy with
+        /// this, and await them with `recv_service_response_from` /
+        /// `try_recv_service_response_from`.
+        fn send_service_request_with_id(
+            output_sender: &mut Box<OutputSender>,
+            output_id: String,
+            data: &[u8],
+            metadata: Box<Metadata>,
+            request_id: &str,
+        ) -> DoraResult;
 
         fn next(self: &mut CombinedEvents) -> CombinedEvent;
 
@@ -1264,6 +1357,205 @@ fn recv_action_result(
     ))
 }
 
+fn try_recv_service_response(
+    events: &mut Box<Events>,
+    request_id: &str,
+    server_node_id: &str,
+) -> ffi::DoraPatternResult {
+    let servers = match parse_server_list(std::slice::from_ref(&server_node_id)) {
+        Ok(servers) => servers,
+        Err(result) => return result,
+    };
+    try_pattern_result(
+        events
+            .0
+            .try_recv_service_response(request_id, servers.as_ref()),
+    )
+}
+
+fn try_recv_action_result(
+    events: &mut Box<Events>,
+    goal_id: &str,
+    server_node_id: &str,
+) -> ffi::DoraPatternResult {
+    let servers = match parse_server_list(std::slice::from_ref(&server_node_id)) {
+        Ok(servers) => servers,
+        Err(result) => return result,
+    };
+    try_pattern_result(events.0.try_recv_action_result(goal_id, servers.as_ref()))
+}
+
+/// `&Vec<String>` rather than `&[String]`: cxx maps `Vec<String>` to
+/// `rust::Vec<rust::String>` and has no slice-of-String equivalent, so
+/// the signature is dictated by the bridge (the same reason the
+/// `borrowed_box` allow appears elsewhere in this file).
+#[allow(clippy::ptr_arg)]
+fn recv_service_response_from(
+    events: &mut Box<Events>,
+    request_id: &str,
+    server_node_ids: &Vec<String>,
+    timeout_ms: u64,
+) -> ffi::DoraPatternResult {
+    let servers = match parse_server_strings(server_node_ids) {
+        Ok(servers) => servers,
+        Err(result) => return result,
+    };
+    pattern_result(futures_lite::future::block_on(
+        events.0.recv_service_response_from(
+            request_id,
+            servers.as_ref(),
+            clamp_pattern_timeout(timeout_ms),
+        ),
+    ))
+}
+
+/// `&Vec<String>` rather than `&[String]`: cxx maps `Vec<String>` to
+/// `rust::Vec<rust::String>` and has no slice-of-String equivalent, so
+/// the signature is dictated by the bridge (the same reason the
+/// `borrowed_box` allow appears elsewhere in this file).
+#[allow(clippy::ptr_arg)]
+fn recv_action_result_from(
+    events: &mut Box<Events>,
+    goal_id: &str,
+    server_node_ids: &Vec<String>,
+    timeout_ms: u64,
+) -> ffi::DoraPatternResult {
+    let servers = match parse_server_strings(server_node_ids) {
+        Ok(servers) => servers,
+        Err(result) => return result,
+    };
+    pattern_result(futures_lite::future::block_on(
+        events.0.recv_action_result_from(
+            goal_id,
+            servers.as_ref(),
+            clamp_pattern_timeout(timeout_ms),
+        ),
+    ))
+}
+
+/// `&Vec<String>` rather than `&[String]`: cxx maps `Vec<String>` to
+/// `rust::Vec<rust::String>` and has no slice-of-String equivalent, so
+/// the signature is dictated by the bridge (the same reason the
+/// `borrowed_box` allow appears elsewhere in this file).
+#[allow(clippy::ptr_arg)]
+fn try_recv_service_response_from(
+    events: &mut Box<Events>,
+    request_id: &str,
+    server_node_ids: &Vec<String>,
+) -> ffi::DoraPatternResult {
+    let servers = match parse_server_strings(server_node_ids) {
+        Ok(servers) => servers,
+        Err(result) => return result,
+    };
+    try_pattern_result(
+        events
+            .0
+            .try_recv_service_response(request_id, servers.as_ref()),
+    )
+}
+
+/// `&Vec<String>` rather than `&[String]`: cxx maps `Vec<String>` to
+/// `rust::Vec<rust::String>` and has no slice-of-String equivalent, so
+/// the signature is dictated by the bridge (the same reason the
+/// `borrowed_box` allow appears elsewhere in this file).
+#[allow(clippy::ptr_arg)]
+fn try_recv_action_result_from(
+    events: &mut Box<Events>,
+    goal_id: &str,
+    server_node_ids: &Vec<String>,
+) -> ffi::DoraPatternResult {
+    let servers = match parse_server_strings(server_node_ids) {
+        Ok(servers) => servers,
+        Err(result) => return result,
+    };
+    try_pattern_result(events.0.try_recv_action_result(goal_id, servers.as_ref()))
+}
+
+/// Owned form of [`ExpectedServers`], which borrows.
+///
+/// The parsed `NodeId`s must outlive the borrow handed to the receive,
+/// so they are held here and lent out via [`Self::as_ref`].
+enum OwnedServers {
+    /// No node ids were supplied — accept any responder.
+    Any,
+    /// One or more parsed node ids.
+    Some(Vec<NodeId>),
+}
+
+impl OwnedServers {
+    fn as_ref(&self) -> ExpectedServers<'_> {
+        match self {
+            Self::Any => ExpectedServers::Any,
+            Self::Some(ids) => ExpectedServers::AnyOf(ids),
+        }
+    }
+}
+
+/// Parse a C++-supplied list of server node ids.
+///
+/// An empty list — or a single empty string, which is how the
+/// single-server polls spell "anyone" — means [`OwnedServers::Any`].
+/// Empty entries in a non-trivial list are rejected rather than silently
+/// widening the set to "any", which would be a surprising way for a
+/// stray `""` to disable restart detection.
+fn parse_server_strings(ids: &[String]) -> Result<OwnedServers, ffi::DoraPatternResult> {
+    let borrowed: Vec<&str> = ids.iter().map(String::as_str).collect();
+    parse_server_list(&borrowed)
+}
+
+fn parse_server_list(ids: &[&str]) -> Result<OwnedServers, ffi::DoraPatternResult> {
+    if ids.is_empty() || (ids.len() == 1 && ids[0].is_empty()) {
+        return Ok(OwnedServers::Any);
+    }
+    let mut parsed = Vec::with_capacity(ids.len());
+    for id in ids {
+        parsed.push(parse_server_node_id(id)?);
+    }
+    Ok(OwnedServers::Some(parsed))
+}
+
+/// Map a non-blocking correlated receive onto the C++ result struct.
+///
+/// `Ok(None)` becomes `NotReady` with an `Empty` event, mirroring how
+/// `try_next_event` reports "nothing available" — deliberately distinct
+/// from `Timeout`, since no deadline was involved.
+fn try_pattern_result(outcome: Result<Option<Event>, PatternError>) -> ffi::DoraPatternResult {
+    match outcome {
+        Ok(Some(event)) => pattern_result(Ok(event)),
+        Ok(None) => pattern_failure(
+            ffi::DoraPatternStatus::NotReady,
+            String::new(),
+            EventOrReason::Empty,
+        ),
+        Err(err) => pattern_result(Err(err)),
+    }
+}
+
+#[allow(clippy::boxed_local)] // `Box<Metadata>` is mandated by the cxx bridge signature.
+fn send_service_request_with_id(
+    sender: &mut Box<OutputSender>,
+    output_id: String,
+    data: &[u8],
+    metadata: Box<Metadata>,
+    request_id: &str,
+) -> ffi::DoraResult {
+    let mut parameters = (*metadata).into_parameters();
+    set_request_id(&mut parameters, request_id);
+    send_output_internal(sender, output_id, data, parameters)
+}
+
+/// Pin `parameters` to a caller-supplied `request_id`.
+///
+/// The counterpart of [`insert_request_id`], which always mints a fresh
+/// one. Split out so the "the caller's id survives" contract can be
+/// tested without a live daemon connection.
+fn set_request_id(parameters: &mut DoraMetadataParameters, request_id: &str) {
+    parameters.insert(
+        dora_node_api::REQUEST_ID.to_string(),
+        DoraParameter::String(request_id.to_owned()),
+    );
+}
+
 /// Validate and normalise the arguments shared by both pattern-aware
 /// waits, before anything is awaited.
 ///
@@ -1275,14 +1567,26 @@ fn pattern_wait_args(
     server_node_id: &str,
     timeout_ms: u64,
 ) -> Result<(NodeId, Duration), ffi::DoraPatternResult> {
-    let server = server_node_id.parse::<NodeId>().map_err(|e| {
+    Ok((
+        parse_server_node_id(server_node_id)?,
+        clamp_pattern_timeout(timeout_ms),
+    ))
+}
+
+/// Parse one server node id, reporting a malformed one as
+/// `InvalidArgument` instead of panicking.
+///
+/// `FromStr` rather than `From<String>`: the latter is documented as
+/// panicking on invalid characters (`libraries/message/src/id.rs`), so a
+/// typo in a C++ string literal would abort the whole node.
+fn parse_server_node_id(server_node_id: &str) -> Result<NodeId, ffi::DoraPatternResult> {
+    server_node_id.parse::<NodeId>().map_err(|e| {
         pattern_failure(
             ffi::DoraPatternStatus::InvalidArgument,
             format!("invalid server node id '{server_node_id}': {e}"),
             EventOrReason::Empty,
         )
-    })?;
-    Ok((server, clamp_pattern_timeout(timeout_ms)))
+    })
 }
 
 /// Convert `timeout_ms` into a `Duration` that `Instant::now() + dur`
@@ -1656,6 +1960,137 @@ mod tests {
     /// A caller-supplied `request_id` must be replaced, matching
     /// `DoraNode::send_service_request`. Silently honouring it would let
     /// two in-flight requests share a correlation key.
+    #[test]
+    // ---- dora-rs/dora#3046 ----
+
+    /// The whole point of the `_with_id` variant: the caller's id must
+    /// survive, or a fan-out cannot share one correlation.
+    #[test]
+    fn send_service_request_with_id_preserves_the_caller_id() {
+        let mut parameters = DoraMetadataParameters::default();
+        parameters.insert(
+            dora_node_api::REQUEST_ID.to_string(),
+            DoraParameter::String("stale".into()),
+        );
+
+        set_request_id(&mut parameters, "caller-supplied");
+
+        assert_eq!(
+            parameters.get(dora_node_api::REQUEST_ID),
+            Some(&DoraParameter::String("caller-supplied".into())),
+            "the caller's id must replace whatever the metadata carried"
+        );
+    }
+
+    /// The two id paths must stay distinguishable: one mints, one obeys.
+    #[test]
+    fn set_request_id_and_insert_request_id_differ() {
+        let mut minted = DoraMetadataParameters::default();
+        let generated = insert_request_id(&mut minted);
+
+        let mut pinned = DoraMetadataParameters::default();
+        set_request_id(&mut pinned, "req-fixed");
+
+        assert_ne!(generated, "req-fixed");
+        assert_eq!(
+            pinned.get(dora_node_api::REQUEST_ID),
+            Some(&DoraParameter::String("req-fixed".into()))
+        );
+    }
+
+    #[test]
+    fn empty_server_list_means_any() {
+        let Ok(parsed) = parse_server_list(&[]) else {
+            panic!("an empty list is valid and means Any");
+        };
+        assert!(matches!(parsed, OwnedServers::Any));
+    }
+
+    #[test]
+    fn single_empty_server_id_means_any() {
+        // How the single-server polls spell "accept any responder".
+        let Ok(parsed) = parse_server_list(&[""]) else {
+            panic!("an empty id is the 'any' spelling and must be accepted");
+        };
+        assert!(matches!(parsed, OwnedServers::Any));
+    }
+
+    #[test]
+    fn server_list_parses_every_entry() {
+        let Ok(parsed) = parse_server_list(&["cam-eo", "cam-ir"]) else {
+            panic!("both ids are valid");
+        };
+        match parsed {
+            OwnedServers::Some(ids) => {
+                assert_eq!(ids.len(), 2);
+                assert_eq!(ids[0].as_ref(), "cam-eo");
+                assert_eq!(ids[1].as_ref(), "cam-ir");
+            }
+            OwnedServers::Any => panic!("a non-empty list must not widen to Any"),
+        }
+    }
+
+    #[test]
+    fn empty_entry_inside_a_list_is_rejected() {
+        // Silently treating this as "any" would let one stray "" switch
+        // off restart detection for the whole set.
+        let result = parse_server_list(&["cam-eo", ""]);
+        match result {
+            Err(failure) => assert!(matches!(
+                failure.status,
+                ffi::DoraPatternStatus::InvalidArgument
+            )),
+            Ok(_) => panic!("an empty entry in a real list must be rejected"),
+        }
+    }
+
+    #[test]
+    fn invalid_server_id_in_a_list_is_reported_not_panicked() {
+        let result = parse_server_list(&["ok", "bad id/with slash"]);
+        match result {
+            Err(failure) => {
+                assert!(matches!(
+                    failure.status,
+                    ffi::DoraPatternStatus::InvalidArgument
+                ));
+                assert!(failure.error.contains("bad id/with slash"));
+            }
+            Ok(_) => panic!("a malformed node id must be rejected"),
+        }
+    }
+
+    #[test]
+    fn not_ready_is_distinct_from_timeout_and_carries_no_error() {
+        let not_ready = try_pattern_result(Ok(None));
+        assert!(matches!(not_ready.status, ffi::DoraPatternStatus::NotReady));
+        assert!(
+            not_ready.error.is_empty(),
+            "NotReady is not a failure, so it must not carry an error string: {}",
+            not_ready.error
+        );
+        assert!(matches!(
+            event_type(&not_ready.event),
+            ffi::DoraEventType::Empty
+        ));
+    }
+
+    #[test]
+    fn try_pattern_result_passes_errors_through_unchanged() {
+        let timeout = try_pattern_result(Err(PatternError::Timeout));
+        assert!(matches!(timeout.status, ffi::DoraPatternStatus::Timeout));
+
+        let restarted = try_pattern_result(Err(PatternError::ServerRestarted("cam-ir".into())));
+        assert!(matches!(
+            restarted.status,
+            ffi::DoraPatternStatus::ServerRestarted
+        ));
+        assert!(
+            restarted.error.contains("cam-ir"),
+            "the restarted node's id must reach the C++ caller: {}",
+            restarted.error
+        );
+    }
+
     #[test]
     fn insert_request_id_overwrites_caller_value() {
         let mut parameters = DoraMetadataParameters::default();

--- a/apis/c++/node/src/lib.rs
+++ b/apis/c++/node/src/lib.rs
@@ -62,6 +62,22 @@ mod ffi {
         /// exists so C++ nodes can react to reloads (e.g. flushing
         /// caches) rather than treating them as `Unknown`.
         Reload,
+        /// An upstream node restarted after a failure. Use
+        /// `event_as_node_restarted` for its id.
+        ///
+        /// Same reason as `Reload`: without a variant of its own this
+        /// arrived as `Unknown`, so a C++ node could not reset state or
+        /// re-send work it had in flight, and could not even tell that
+        /// anything had happened.
+        ///
+        /// It matters to the correlated receives in particular. They
+        /// report `ServerRestarted` for a restart that lands *while a
+        /// wait or poll is running*, because the correlation owns the
+        /// stream then. One that lands while the node is in its own
+        /// `next_event` arrives here instead — and used to be silently
+        /// dropped, leaving the next request to wait out its whole
+        /// deadline over a server the node already knew was gone.
+        NodeRestarted,
     }
 
     struct DoraInput {
@@ -226,6 +242,12 @@ mod ffi {
         fn event_as_input_with_metadata(event: Box<DoraEvent>) -> Result<DoraInputWithMetadata>;
         /// Extract the failure payload from a `NodeFailed` event.
         fn event_as_node_failed(event: Box<DoraEvent>) -> Result<DoraNodeFailed>;
+        /// Id of the node that restarted, for a `NodeRestarted` event.
+        ///
+        /// Errors for any other event, so a caller that branched on
+        /// `event_type` wrongly is told rather than handed something
+        /// plausible.
+        fn event_as_node_restarted(event: Box<DoraEvent>) -> Result<String>;
         /// Selectively close one or more of this node's outputs without
         /// shutting the whole node down. Subsequent downstream
         /// subscribers see the corresponding `InputClosed` event.
@@ -333,6 +355,14 @@ mod ffi {
         /// main event loop loses nothing. If `server_node_id` restarts
         /// while waiting, the wait ends early with `ServerRestarted`
         /// rather than hanging until the deadline.
+        ///
+        /// Note the scope of that last sentence. The correlation only
+        /// sees a restart it consumes itself, which means one that
+        /// lands while this call is running. A restart that lands
+        /// between calls is delivered to the node's own loop as
+        /// `DoraEventType::NodeRestarted`, and a client that ignores it
+        /// will wait out the next request's full deadline against a
+        /// server it had already been told about.
         fn recv_service_response(
             events: &mut Box<Events>,
             request_id: &str,
@@ -719,6 +749,7 @@ fn event_type(event: &DoraEvent) -> ffi::DoraEventType {
             Event::Error(_) => ffi::DoraEventType::Error,
             Event::NodeFailed { .. } => ffi::DoraEventType::NodeFailed,
             Event::Reload { .. } => ffi::DoraEventType::Reload,
+            Event::NodeRestarted { .. } => ffi::DoraEventType::NodeRestarted,
             _ => ffi::DoraEventType::Unknown,
         },
         EventOrReason::Closed => ffi::DoraEventType::AllInputsClosed,
@@ -771,6 +802,14 @@ fn input_bytes(data: &dora_node_api::DoraArray) -> eyre::Result<Vec<u8>> {
             );
         }
     }
+}
+
+#[allow(clippy::boxed_local)] // `Box<DoraEvent>` is mandated by the cxx bridge signature.
+fn event_as_node_restarted(event: Box<DoraEvent>) -> eyre::Result<String> {
+    let EventOrReason::Event(Event::NodeRestarted { id }) = event.0 else {
+        bail!("not a NodeRestarted event");
+    };
+    Ok(id.to_string())
 }
 
 #[allow(clippy::boxed_local)] // `Box<DoraEvent>` is mandated by the cxx bridge signature.
@@ -2081,6 +2120,36 @@ mod tests {
         assert_eq!(
             pinned.get(dora_node_api::REQUEST_ID),
             Some(&DoraParameter::String("req-fixed".into()))
+        );
+    }
+
+    /// A restart must reach C++ as itself, not as `Unknown`.
+    ///
+    /// Without this the event still arrived — it simply could not be
+    /// identified, so a node had no way to reset state or resend work,
+    /// and no way to know anything had happened at all.
+    #[test]
+    fn a_node_restart_is_reported_as_itself_not_unknown() {
+        let event = Box::new(DoraEvent(EventOrReason::Event(Event::NodeRestarted {
+            id: dora_node_api::dora_core::config::NodeId::from("calc".to_string()),
+        })));
+        assert!(matches!(
+            event_type(&event),
+            ffi::DoraEventType::NodeRestarted
+        ));
+
+        let id = event_as_node_restarted(event).expect("a NodeRestarted event carries its id");
+        assert_eq!(id, "calc");
+    }
+
+    #[test]
+    fn event_as_node_restarted_rejects_other_events() {
+        let event = Box::new(DoraEvent(EventOrReason::Event(Event::Stop(
+            dora_node_api::StopCause::Manual,
+        ))));
+        assert!(
+            event_as_node_restarted(event).is_err(),
+            "a caller that branched wrongly must be told, not handed a plausible id"
         );
     }
 

--- a/apis/c++/node/src/lib.rs
+++ b/apis/c++/node/src/lib.rs
@@ -454,6 +454,19 @@ mod ffi {
         /// long-running node is an unbounded slow leak.
         ///
         /// Safe to call for an id that was never registered.
+        ///
+        /// It releases the deadline and nothing else. A reply arriving
+        /// *after* its request timed out or was cancelled matches no
+        /// live correlation, so the next poll buffers it for
+        /// `next_event` like any other unrelated input. A node that
+        /// reads its events clears those as a matter of course; one
+        /// that only polls and never reads keeps one buffered event per
+        /// unclaimed reply.
+        ///
+        /// Do not "fix" that with a loop that reads until empty:
+        /// `try_next_event` returns buffered events first but then
+        /// falls through to the live stream, so such a loop can consume
+        /// and discard a reply a later poll was going to correlate.
         fn cancel_correlation(events: &mut Box<Events>, correlation_id: &str);
 
         /// Send a service request under a caller-supplied `request_id`.

--- a/apis/c++/node/src/lib.rs
+++ b/apis/c++/node/src/lib.rs
@@ -401,7 +401,11 @@ mod ffi {
         /// later poll past it returns `Timeout` exactly once. So a
         /// caller does not sweep deadlines itself — it passes the same
         /// `timeout_ms` every iteration and reacts to `Timeout` like
-        /// any other status. Pass `0` for no deadline.
+        /// any other status.
+        ///
+        /// `timeout_ms` means the same here as in the blocking
+        /// `recv_service_response`: `0` expires immediately, and
+        /// `UINT64_MAX` is the spelling for "no practical deadline".
         ///
         /// The clock starts at that first poll rather than at send
         /// time, and the first deadline registered for an id wins.
@@ -423,8 +427,8 @@ mod ffi {
         /// `timeout_ms` behaves as in `try_recv_service_response`, but
         /// bounds the *whole goal* rather than the gap between feedback
         /// messages: a long goal that is making visible progress will
-        /// still expire. Pass `0` for no deadline, and an empty
-        /// `server_node_id` to accept any responder.
+        /// still expire. Pass `UINT64_MAX` for no practical deadline,
+        /// and an empty `server_node_id` to accept any responder.
         fn try_recv_action_result(
             events: &mut Box<Events>,
             goal_id: &str,
@@ -1448,10 +1452,10 @@ fn try_recv_service_response(
         Ok(servers) => servers,
         Err(result) => return result,
     };
-    try_pattern_result(events.0.try_recv_service_response(
+    try_pattern_result(events.0.try_recv_service_response_from(
         request_id,
         servers.as_ref(),
-        poll_timeout(timeout_ms),
+        Some(clamp_pattern_timeout(timeout_ms)),
     ))
 }
 
@@ -1465,10 +1469,10 @@ fn try_recv_action_result(
         Ok(servers) => servers,
         Err(result) => return result,
     };
-    try_pattern_result(events.0.try_recv_action_result(
+    try_pattern_result(events.0.try_recv_action_result_from(
         goal_id,
         servers.as_ref(),
-        poll_timeout(timeout_ms),
+        Some(clamp_pattern_timeout(timeout_ms)),
     ))
 }
 
@@ -1535,10 +1539,10 @@ fn try_recv_service_response_from(
         Ok(servers) => servers,
         Err(result) => return result,
     };
-    try_pattern_result(events.0.try_recv_service_response(
+    try_pattern_result(events.0.try_recv_service_response_from(
         request_id,
         servers.as_ref(),
-        poll_timeout(timeout_ms),
+        Some(clamp_pattern_timeout(timeout_ms)),
     ))
 }
 
@@ -1557,10 +1561,10 @@ fn try_recv_action_result_from(
         Ok(servers) => servers,
         Err(result) => return result,
     };
-    try_pattern_result(events.0.try_recv_action_result(
+    try_pattern_result(events.0.try_recv_action_result_from(
         goal_id,
         servers.as_ref(),
-        poll_timeout(timeout_ms),
+        Some(clamp_pattern_timeout(timeout_ms)),
     ))
 }
 
@@ -1626,21 +1630,6 @@ fn parse_server_list(ids: &[&str]) -> Result<OwnedServers, ffi::DoraPatternResul
 
 fn cancel_correlation(events: &mut Box<Events>, correlation_id: &str) {
     events.0.cancel_correlation(correlation_id);
-}
-
-/// Map a C++ `timeout_ms` onto the Rust poll's optional deadline.
-///
-/// `0` means "no deadline" — the poll then behaves exactly as it did
-/// before deadlines existed. Any other value is clamped the same way
-/// `clamp_pattern_timeout` clamps the blocking waits, because it
-/// crosses the bridge as an unbounded `u64` and ends up in an
-/// `Instant + Duration`.
-fn poll_timeout(timeout_ms: u64) -> Option<Duration> {
-    if timeout_ms == 0 {
-        None
-    } else {
-        Some(clamp_pattern_timeout(timeout_ms))
-    }
 }
 
 /// Map a non-blocking correlated receive onto the C++ result struct.
@@ -2153,20 +2142,29 @@ mod tests {
         );
     }
 
+    /// `timeout_ms` must mean one thing across the whole header.
+    ///
+    /// The polls once mapped `0` to "no deadline" while the blocking
+    /// waits mapped it to `Duration::ZERO`, so moving a request from
+    /// `recv_service_response` to `try_recv_service_response` silently
+    /// dropped its deadline. Both forms now go through
+    /// `clamp_pattern_timeout`, and `UINT64_MAX` is the spelling for
+    /// "no practical deadline" (dora-rs/dora#3046).
     #[test]
-    fn zero_timeout_means_no_deadline() {
-        // `0` has to keep meaning "poll forever", or a caller that
-        // never wanted a deadline would start getting Timeout.
-        assert!(poll_timeout(0).is_none());
+    fn zero_timeout_means_the_same_for_polls_and_blocking_waits() {
+        assert_eq!(clamp_pattern_timeout(0), Duration::ZERO);
     }
 
     #[test]
-    fn nonzero_timeout_is_clamped_like_the_blocking_waits() {
-        let clamped = poll_timeout(u64::MAX).expect("a non-zero timeout is a deadline");
-        assert_eq!(clamped, clamp_pattern_timeout(u64::MAX));
-
-        let ordinary = poll_timeout(5_000).expect("a non-zero timeout is a deadline");
-        assert_eq!(ordinary, Duration::from_millis(5_000));
+    fn u64_max_is_the_no_practical_deadline_spelling() {
+        let clamped = clamp_pattern_timeout(u64::MAX);
+        assert!(
+            clamped > Duration::from_secs(60 * 60 * 24 * 365),
+            "UINT64_MAX must clamp to a deadline no caller will reach, got {clamped:?}"
+        );
+        Instant::now()
+            .checked_add(clamped)
+            .expect("the clamped deadline must be representable");
     }
 
     #[test]

--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -1482,7 +1482,22 @@ impl EventStream {
                 }
                 CorrelationOutcome::ServerRestarted => {
                     let restarted = restarted_node_id(&event);
-                    self.correlation_deadlines.remove(needle);
+                    // Whether the deadline dies with the restart depends
+                    // on what the restart *means* for this caller.
+                    //
+                    // For `One` it is terminal: that request is orphaned,
+                    // so its deadline goes with it.
+                    //
+                    // For `AnyOf` it is only a notification — the other
+                    // candidates may still answer, and the caller is
+                    // documented as free to keep waiting. Dropping the
+                    // deadline there would let the next poll register a
+                    // fresh one on a new clock, so a node that keeps
+                    // flapping would reset the deadline indefinitely and
+                    // the caller could never observe `Timeout`.
+                    if !matches!(expected, ExpectedServers::AnyOf(_)) {
+                        self.correlation_deadlines.remove(needle);
+                    }
                     self.pending_passthrough.push_back(event);
                     return Err(PatternError::ServerRestarted(restarted));
                 }
@@ -1665,7 +1680,13 @@ pub enum ExpectedServers<'a> {
     /// [`PatternError::ServerRestarted`] naming that node. It is a
     /// notification, not a verdict: the remaining candidates may still
     /// answer, so a caller that does not care can simply wait again —
-    /// buffered events and the correlation are preserved across calls.
+    /// buffered events, the correlation **and its deadline** are
+    /// preserved across calls. The deadline deliberately keeps running
+    /// on its original clock, so a node that keeps flapping cannot hold
+    /// the correlation open past the timeout the caller asked for.
+    ///
+    /// [`One`](Self::One) treats a restart as terminal instead: that
+    /// request is orphaned, so its deadline is dropped with it.
     AnyOf(&'a [NodeId]),
     /// Accept a reply from anyone and never correlate restarts. Use when
     /// the responder is not known up front; the wait then ends only on a
@@ -2207,6 +2228,23 @@ impl EventStream {
     /// scheduler mode, simulating an input the scheduler held back while
     /// prioritizing `Stop`. Used to verify `recv_async` drains buffered inputs
     /// after `Stop` instead of dropping them (dora-rs/dora#2027).
+    /// Test-only: deliver a `NodeRestarted` through the *stream* rather
+    /// than the passthrough buffer, so `try_correlation` classifies it
+    /// for real. The scripted integration harness has no
+    /// `IncomingEvent::NodeRestarted`, and pushing into
+    /// `pending_passthrough` would bypass the classifier entirely
+    /// (dora-rs/dora#3046).
+    fn push_scheduler_node_restarted_for_testing(&mut self, id: &str) {
+        use crate::event_stream::thread::EventItem;
+        use dora_message::daemon_to_node::NodeEvent;
+        self.use_scheduler = true;
+        self.scheduler.add_event(EventItem::NodeEvent {
+            event: NodeEvent::NodeRestarted {
+                id: id.to_owned().into(),
+            },
+        });
+    }
+
     fn push_scheduler_input_for_testing(&mut self, id: &str) {
         use crate::event_stream::thread::EventItem;
         use dora_message::{daemon_to_node::NodeEvent, metadata::Metadata};
@@ -2693,12 +2731,12 @@ mod tests {
 
     #[test]
     fn expected_servers_any_of_matches_each_listed_node() {
-        let eo = NodeId::from("cam-eo".to_string());
-        let ir = NodeId::from("cam-ir".to_string());
+        let a = NodeId::from("a".to_string());
+        let b = NodeId::from("b".to_string());
         let other = NodeId::from("other".to_string());
-        let list = [eo.clone(), ir.clone()];
-        assert!(ExpectedServers::AnyOf(&list).contains(&eo));
-        assert!(ExpectedServers::AnyOf(&list).contains(&ir));
+        let list = [a.clone(), b.clone()];
+        assert!(ExpectedServers::AnyOf(&list).contains(&a));
+        assert!(ExpectedServers::AnyOf(&list).contains(&b));
         assert!(!ExpectedServers::AnyOf(&list).contains(&other));
     }
 
@@ -2719,10 +2757,10 @@ mod tests {
 
     #[test]
     fn classify_any_of_restart_returns_server_restarted() {
-        let eo = NodeId::from("cam-eo".to_string());
-        let ir = NodeId::from("cam-ir".to_string());
-        let list = [eo.clone(), ir.clone()];
-        let event = Event::NodeRestarted { id: ir };
+        let a = NodeId::from("a".to_string());
+        let b = NodeId::from("b".to_string());
+        let list = [a.clone(), b.clone()];
+        let event = Event::NodeRestarted { id: b };
         assert_eq!(
             classify_correlation_event(
                 &event,
@@ -2735,8 +2773,8 @@ mod tests {
 
     #[test]
     fn classify_any_of_unlisted_restart_is_passthrough() {
-        let eo = NodeId::from("cam-eo".to_string());
-        let list = [eo];
+        let a = NodeId::from("a".to_string());
+        let list = [a];
         let event = Event::NodeRestarted {
             id: NodeId::from("unrelated".to_string()),
         };
@@ -2766,7 +2804,7 @@ mod tests {
         // The core fan-out guarantee: a reply is correlated by
         // `request_id` alone, so it matches even when it comes from a
         // node the caller never listed.
-        let listed = NodeId::from("cam-eo".to_string());
+        let listed = NodeId::from("a".to_string());
         let list = [listed];
         let event = make_input_event("response", request_id_params("req-42"));
         for expected in [
@@ -2786,9 +2824,9 @@ mod tests {
         // With `AnyOf` the caller does not know which candidate went
         // down, so the reported name has to come from the event.
         let event = Event::NodeRestarted {
-            id: NodeId::from("cam-ir".to_string()),
+            id: NodeId::from("b".to_string()),
         };
-        assert_eq!(restarted_node_id(&event), "cam-ir");
+        assert_eq!(restarted_node_id(&event), "b");
     }
 
     // ---- dora-rs/adora#172: pending_passthrough integration ----
@@ -3278,6 +3316,65 @@ mod tests {
         );
     }
 
+    /// dora-rs/dora#3046 review: an `AnyOf` restart is documented as a
+    /// notification the caller may wait past, so it must not destroy the
+    /// deadline. If it did, the next poll would register a fresh one on
+    /// a new clock and a flapping node could hold the correlation open
+    /// forever.
+    #[test]
+    fn an_any_of_restart_preserves_the_deadline() {
+        // No scripted events: the restart is injected straight into the
+        // scheduler below, so nothing races it out of the receiver.
+        let (_node, mut events) = scripted_event_stream(vec![]);
+        let a = NodeId::from("a".to_string());
+        let b = NodeId::from("b".to_string());
+        let candidates = [a, b];
+        let timeout = Some(Duration::from_secs(3600));
+
+        // Register the deadline without touching the stream, then note
+        // exactly what it is.
+        assert!(!events.correlation_expired("req-1", timeout));
+        let registered = events.correlation_deadlines["req-1"];
+
+        events.push_scheduler_node_restarted_for_testing("b");
+        let restarted =
+            events.try_recv_service_response("req-1", ExpectedServers::AnyOf(&candidates), timeout);
+        assert!(
+            matches!(&restarted, Err(PatternError::ServerRestarted(id)) if id == "b"),
+            "expected a ServerRestarted naming b, got {restarted:?}"
+        );
+
+        assert_eq!(
+            events.correlation_deadlines.get("req-1"),
+            Some(&registered),
+            "an AnyOf restart must leave the original deadline running, \
+             or a flapping node resets the clock on every poll"
+        );
+    }
+
+    /// The intentional asymmetry: for `One` the restart *is* the verdict,
+    /// so the orphaned request's deadline goes with it rather than
+    /// lingering until the stream drops.
+    #[test]
+    fn a_one_server_restart_clears_the_deadline() {
+        let (_node, mut events) = scripted_event_stream(vec![]);
+        let server = NodeId::from("calc".to_string());
+        let timeout = Some(Duration::from_secs(3600));
+
+        assert!(!events.correlation_expired("req-1", timeout));
+        assert!(events.correlation_deadlines.contains_key("req-1"));
+
+        events.push_scheduler_node_restarted_for_testing("calc");
+        let restarted =
+            events.try_recv_service_response("req-1", ExpectedServers::One(&server), timeout);
+        assert!(matches!(restarted, Err(PatternError::ServerRestarted(_))));
+
+        assert!(
+            !events.correlation_deadlines.contains_key("req-1"),
+            "a One restart orphans the request, so its deadline must go too"
+        );
+    }
+
     #[test]
     fn cancel_correlation_is_safe_for_an_unknown_id() {
         // Callers cancel on paths where the request may already have
@@ -3319,9 +3416,9 @@ mod tests {
             stop_at(),
         ]);
 
-        let eo = NodeId::from("cam-eo".to_string());
-        let ir = NodeId::from("cam-ir".to_string());
-        let candidates = [eo, ir];
+        let a = NodeId::from("a".to_string());
+        let b = NodeId::from("b".to_string());
+        let candidates = [a, b];
         let matched = poll_until(|| {
             events.try_recv_service_response("req-1", ExpectedServers::AnyOf(&candidates), None)
         });

--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -1217,21 +1217,53 @@ impl EventStream {
         expected_server: &NodeId,
         timeout: Duration,
     ) -> Result<Event, PatternError> {
-        self.wait_for_correlation(
-            timeout,
-            expected_server,
-            |event, request_id| match event {
-                Event::Input { metadata, .. } => {
-                    dora_message::metadata::get_string_param(
-                        &metadata.parameters,
-                        dora_message::metadata::REQUEST_ID,
-                    ) == Some(request_id)
-                }
-                _ => false,
-            },
-            request_id,
-        )
-        .await
+        self.recv_service_response_from(request_id, ExpectedServers::One(expected_server), timeout)
+            .await
+    }
+
+    /// [`recv_service_response`](Self::recv_service_response) over a set
+    /// of acceptable responders.
+    ///
+    /// Use this for a request fanned out to several nodes under one
+    /// `request_id`, where the first reply wins. See
+    /// [`ExpectedServers`] for what the choice does and does not affect.
+    pub async fn recv_service_response_from(
+        &mut self,
+        request_id: &str,
+        expected: ExpectedServers<'_>,
+        timeout: Duration,
+    ) -> Result<Event, PatternError> {
+        self.wait_for_correlation(timeout, expected, matches_request_id, request_id)
+            .await
+    }
+
+    /// Non-blocking [`recv_service_response`](Self::recv_service_response).
+    ///
+    /// Returns `Ok(None)` when the reply has not arrived yet, so a
+    /// single-threaded event loop can poll several outstanding requests
+    /// per iteration without ever blocking on one of them. Non-matching
+    /// events are buffered for the caller's own `recv()` exactly as in
+    /// the blocking form, and correlation state survives across calls.
+    ///
+    /// Because there is no deadline, this never reports
+    /// [`PatternError::Timeout`] — deadlines are the caller's to keep.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // once per event-loop iteration, for each outstanding request
+    /// match events.try_recv_service_response(&request_id, ExpectedServers::One(&server))? {
+    ///     Some(Event::Input { data, .. }) => complete(data),
+    ///     Some(_) => unreachable!(),
+    ///     None => {} // not ready — carry on with the rest of the tick
+    /// }
+    /// ```
+    pub fn try_recv_service_response(
+        &mut self,
+        request_id: &str,
+        expected: ExpectedServers<'_>,
+    ) -> Result<Option<Event>, PatternError> {
+        self.try_correlation(expected, matches_request_id, request_id)
     }
 
     /// Waits for a terminal action result (`goal_status` ∈
@@ -1248,33 +1280,34 @@ impl EventStream {
         expected_server: &NodeId,
         timeout: Duration,
     ) -> Result<Event, PatternError> {
-        self.wait_for_correlation(
-            timeout,
-            expected_server,
-            |event, goal_id| match event {
-                Event::Input { metadata, .. } => {
-                    let matches_goal = dora_message::metadata::get_string_param(
-                        &metadata.parameters,
-                        dora_message::metadata::GOAL_ID,
-                    ) == Some(goal_id);
-                    if !matches_goal {
-                        return false;
-                    }
-                    matches!(
-                        dora_message::metadata::get_string_param(
-                            &metadata.parameters,
-                            dora_message::metadata::GOAL_STATUS,
-                        ),
-                        Some(dora_message::metadata::GOAL_STATUS_SUCCEEDED)
-                            | Some(dora_message::metadata::GOAL_STATUS_ABORTED)
-                            | Some(dora_message::metadata::GOAL_STATUS_CANCELED)
-                    )
-                }
-                _ => false,
-            },
-            goal_id,
-        )
-        .await
+        self.recv_action_result_from(goal_id, ExpectedServers::One(expected_server), timeout)
+            .await
+    }
+
+    /// [`recv_action_result`](Self::recv_action_result) over a set of
+    /// acceptable responders. See [`ExpectedServers`].
+    pub async fn recv_action_result_from(
+        &mut self,
+        goal_id: &str,
+        expected: ExpectedServers<'_>,
+        timeout: Duration,
+    ) -> Result<Event, PatternError> {
+        self.wait_for_correlation(timeout, expected, matches_terminal_action_result, goal_id)
+            .await
+    }
+
+    /// Non-blocking [`recv_action_result`](Self::recv_action_result).
+    ///
+    /// Returns `Ok(None)` while the goal is still running. Feedback
+    /// events keep being buffered for the caller's own `recv()`, so a
+    /// polling client observes progress through its normal event loop
+    /// and learns about completion here.
+    pub fn try_recv_action_result(
+        &mut self,
+        goal_id: &str,
+        expected: ExpectedServers<'_>,
+    ) -> Result<Option<Event>, PatternError> {
+        self.try_correlation(expected, matches_terminal_action_result, goal_id)
     }
 
     /// Core loop for the pattern-aware helpers. Waits up to `timeout`
@@ -1284,7 +1317,7 @@ impl EventStream {
     async fn wait_for_correlation<F>(
         &mut self,
         timeout: Duration,
-        expected_server: &NodeId,
+        expected: ExpectedServers<'_>,
         is_match: F,
         needle: &str,
     ) -> Result<Event, PatternError>
@@ -1331,11 +1364,12 @@ impl EventStream {
                 Either::Right((Some(e), _)) => e,
             };
 
-            match classify_correlation_event(&event, expected_server, |e| is_match(e, needle)) {
+            match classify_correlation_event(&event, expected, |e| is_match(e, needle)) {
                 CorrelationOutcome::Match => return Ok(event),
                 CorrelationOutcome::ServerRestarted => {
+                    let restarted = restarted_node_id(&event);
                     self.pending_passthrough.push_back(event);
-                    return Err(PatternError::ServerRestarted(expected_server.to_string()));
+                    return Err(PatternError::ServerRestarted(restarted));
                 }
                 CorrelationOutcome::StreamEnded => {
                     self.pending_passthrough.push_back(event);
@@ -1352,6 +1386,130 @@ impl EventStream {
                 }
             }
         }
+    }
+
+    /// Non-blocking counterpart of [`wait_for_correlation`](Self::wait_for_correlation).
+    ///
+    /// Drains whatever is ready right now and returns `Ok(None)` the
+    /// moment the stream would block. Every non-matching event is
+    /// buffered exactly as in the blocking form, so repeated calls
+    /// accumulate correlation state instead of losing it — that is what
+    /// makes polling across successive event-loop iterations correct.
+    ///
+    /// Note the cost: one call drains *all* currently-ready events, so
+    /// it is O(ready events) rather than O(1). That is what lets a poll
+    /// find a reply queued behind unrelated traffic. It never waits, but
+    /// a large ready burst is still a large amount of work in one call.
+    fn try_correlation<F>(
+        &mut self,
+        expected: ExpectedServers<'_>,
+        is_match: F,
+        needle: &str,
+    ) -> Result<Option<Event>, PatternError>
+    where
+        F: Fn(&Event, &str) -> bool,
+    {
+        // Same rationale as the blocking form: an earlier wait may have
+        // already buffered the reply we are now looking for.
+        if let Some(pos) = self
+            .pending_passthrough
+            .iter()
+            .position(|event| is_match(event, needle))
+            && let Some(event) = self.pending_passthrough.remove(pos)
+        {
+            return Ok(Some(event));
+        }
+
+        loop {
+            // `recv_from_stream`, not `recv_async`: the latter drains
+            // `pending_passthrough` and would re-hand us the events we
+            // buffer below (see `recv_from_stream`'s docs).
+            let event = match pin!(self.recv_from_stream()).now_or_never() {
+                // Nothing ready — the caller can get on with its loop.
+                None => return Ok(None),
+                Some(None) => return Err(PatternError::StreamEnded),
+                Some(Some(event)) => event,
+            };
+
+            match classify_correlation_event(&event, expected, |e| is_match(e, needle)) {
+                CorrelationOutcome::Match => return Ok(Some(event)),
+                CorrelationOutcome::ServerRestarted => {
+                    let restarted = restarted_node_id(&event);
+                    self.pending_passthrough.push_back(event);
+                    return Err(PatternError::ServerRestarted(restarted));
+                }
+                CorrelationOutcome::StreamEnded => {
+                    self.pending_passthrough.push_back(event);
+                    return Err(PatternError::StreamEnded);
+                }
+                CorrelationOutcome::StreamError => {
+                    if let Event::Error(err) = event {
+                        return Err(PatternError::StreamError(err));
+                    }
+                    unreachable!("StreamError only returned for Event::Error");
+                }
+                CorrelationOutcome::Passthrough => {
+                    self.pending_passthrough.push_back(event);
+                }
+            }
+        }
+    }
+}
+
+/// Whether `event` is the service reply carrying `request_id`.
+///
+/// Shared by the blocking and polling receives so both agree on what
+/// counts as a match.
+fn matches_request_id(event: &Event, request_id: &str) -> bool {
+    match event {
+        Event::Input { metadata, .. } => {
+            dora_message::metadata::get_string_param(
+                &metadata.parameters,
+                dora_message::metadata::REQUEST_ID,
+            ) == Some(request_id)
+        }
+        _ => false,
+    }
+}
+
+/// Whether `event` is a *terminal* action result for `goal_id`.
+///
+/// Feedback messages carry the same `goal_id` without a terminal
+/// `goal_status`, so they deliberately do not match — they stay
+/// available to the caller's own event loop.
+fn matches_terminal_action_result(event: &Event, goal_id: &str) -> bool {
+    match event {
+        Event::Input { metadata, .. } => {
+            let matches_goal = dora_message::metadata::get_string_param(
+                &metadata.parameters,
+                dora_message::metadata::GOAL_ID,
+            ) == Some(goal_id);
+            if !matches_goal {
+                return false;
+            }
+            matches!(
+                dora_message::metadata::get_string_param(
+                    &metadata.parameters,
+                    dora_message::metadata::GOAL_STATUS,
+                ),
+                Some(dora_message::metadata::GOAL_STATUS_SUCCEEDED)
+                    | Some(dora_message::metadata::GOAL_STATUS_ABORTED)
+                    | Some(dora_message::metadata::GOAL_STATUS_CANCELED)
+            )
+        }
+        _ => false,
+    }
+}
+
+/// Name of the node in a [`CorrelationOutcome::ServerRestarted`] event.
+///
+/// With [`ExpectedServers::AnyOf`] the restarted node is whichever
+/// candidate the event names, so it has to come from the event rather
+/// than from the caller's expectation.
+fn restarted_node_id(event: &Event) -> String {
+    match event {
+        Event::NodeRestarted { id } => id.to_string(),
+        _ => unreachable!("ServerRestarted is only returned for Event::NodeRestarted"),
     }
 }
 
@@ -1374,7 +1532,7 @@ enum CorrelationOutcome {
 
 fn classify_correlation_event<F>(
     event: &Event,
-    expected_server: &NodeId,
+    expected: ExpectedServers<'_>,
     is_match: F,
 ) -> CorrelationOutcome
 where
@@ -1384,10 +1542,49 @@ where
         return CorrelationOutcome::Match;
     }
     match event {
-        Event::NodeRestarted { id } if id == expected_server => CorrelationOutcome::ServerRestarted,
+        Event::NodeRestarted { id } if expected.contains(id) => CorrelationOutcome::ServerRestarted,
         Event::Stop(_) => CorrelationOutcome::StreamEnded,
         Event::Error(_) => CorrelationOutcome::StreamError,
         _ => CorrelationOutcome::Passthrough,
+    }
+}
+
+/// Which node(s) a correlated receive treats as "its" server when
+/// deciding whether an [`Event::NodeRestarted`] orphans the in-flight
+/// request.
+///
+/// This only controls *restart* detection. Which reply satisfies the
+/// wait is decided purely by the correlation id (`request_id` /
+/// `goal_id`), never by the sender — so a fan-out request is matched by
+/// whichever node answers first regardless of this setting.
+#[derive(Debug, Clone, Copy)]
+pub enum ExpectedServers<'a> {
+    /// Exactly one server. A restart of that node ends the wait with
+    /// [`PatternError::ServerRestarted`].
+    One(&'a NodeId),
+    /// A fan-out request sent to several nodes, where the first reply
+    /// wins.
+    ///
+    /// A restart of *any* listed node is surfaced as
+    /// [`PatternError::ServerRestarted`] naming that node. It is a
+    /// notification, not a verdict: the remaining candidates may still
+    /// answer, so a caller that does not care can simply wait again —
+    /// buffered events and the correlation are preserved across calls.
+    AnyOf(&'a [NodeId]),
+    /// Accept a reply from anyone and never correlate restarts. Use when
+    /// the responder is not known up front; the wait then ends only on a
+    /// match, the deadline, or the stream ending.
+    Any,
+}
+
+impl ExpectedServers<'_> {
+    /// Whether a restart of `id` should orphan the in-flight request.
+    fn contains(&self, id: &NodeId) -> bool {
+        match self {
+            Self::One(expected) => *expected == id,
+            Self::AnyOf(expected) => expected.contains(id),
+            Self::Any => false,
+        }
     }
 }
 
@@ -2217,7 +2414,11 @@ mod tests {
         let server = NodeId::from("calc".to_string());
         let event = make_input_event("response", request_id_params("req-42"));
         assert_eq!(
-            classify_correlation_event(&event, &server, is_request_match("req-42")),
+            classify_correlation_event(
+                &event,
+                ExpectedServers::One(&server),
+                is_request_match("req-42")
+            ),
             CorrelationOutcome::Match
         );
     }
@@ -2227,7 +2428,11 @@ mod tests {
         let server = NodeId::from("calc".to_string());
         let event = make_input_event("response", request_id_params("req-99"));
         assert_eq!(
-            classify_correlation_event(&event, &server, is_request_match("req-42")),
+            classify_correlation_event(
+                &event,
+                ExpectedServers::One(&server),
+                is_request_match("req-42")
+            ),
             CorrelationOutcome::Passthrough
         );
     }
@@ -2237,7 +2442,11 @@ mod tests {
         let server = NodeId::from("calc".to_string());
         let event = Event::NodeRestarted { id: server.clone() };
         assert_eq!(
-            classify_correlation_event(&event, &server, is_request_match("req-42")),
+            classify_correlation_event(
+                &event,
+                ExpectedServers::One(&server),
+                is_request_match("req-42")
+            ),
             CorrelationOutcome::ServerRestarted
         );
     }
@@ -2249,7 +2458,11 @@ mod tests {
             id: NodeId::from("other".to_string()),
         };
         assert_eq!(
-            classify_correlation_event(&event, &server, is_request_match("req-42")),
+            classify_correlation_event(
+                &event,
+                ExpectedServers::One(&server),
+                is_request_match("req-42")
+            ),
             CorrelationOutcome::Passthrough
         );
     }
@@ -2259,7 +2472,11 @@ mod tests {
         let server = NodeId::from("calc".to_string());
         let event = Event::Stop(StopCause::Manual);
         assert_eq!(
-            classify_correlation_event(&event, &server, is_request_match("req-42")),
+            classify_correlation_event(
+                &event,
+                ExpectedServers::One(&server),
+                is_request_match("req-42")
+            ),
             CorrelationOutcome::StreamEnded
         );
     }
@@ -2269,7 +2486,11 @@ mod tests {
         let server = NodeId::from("calc".to_string());
         let event = Event::Error("boom".to_string());
         assert_eq!(
-            classify_correlation_event(&event, &server, is_request_match("req-42")),
+            classify_correlation_event(
+                &event,
+                ExpectedServers::One(&server),
+                is_request_match("req-42")
+            ),
             CorrelationOutcome::StreamError
         );
     }
@@ -2279,7 +2500,11 @@ mod tests {
         let server = NodeId::from("calc".to_string());
         let event = make_input_event("sensor", MetadataParameters::new());
         assert_eq!(
-            classify_correlation_event(&event, &server, is_request_match("req-42")),
+            classify_correlation_event(
+                &event,
+                ExpectedServers::One(&server),
+                is_request_match("req-42")
+            ),
             CorrelationOutcome::Passthrough
         );
     }
@@ -2293,7 +2518,11 @@ mod tests {
             value: serde_json::json!(0.85),
         };
         assert_eq!(
-            classify_correlation_event(&event, &server, is_request_match("req-42")),
+            classify_correlation_event(
+                &event,
+                ExpectedServers::One(&server),
+                is_request_match("req-42")
+            ),
             CorrelationOutcome::Passthrough
         );
     }
@@ -2303,7 +2532,11 @@ mod tests {
         let server = NodeId::from("nav".to_string());
         let event = make_input_event("result", goal_params("goal-1", Some(GOAL_STATUS_SUCCEEDED)));
         assert_eq!(
-            classify_correlation_event(&event, &server, is_action_result_match("goal-1")),
+            classify_correlation_event(
+                &event,
+                ExpectedServers::One(&server),
+                is_action_result_match("goal-1")
+            ),
             CorrelationOutcome::Match
         );
     }
@@ -2313,7 +2546,11 @@ mod tests {
         let server = NodeId::from("nav".to_string());
         let event = make_input_event("result", goal_params("goal-1", Some(GOAL_STATUS_ABORTED)));
         assert_eq!(
-            classify_correlation_event(&event, &server, is_action_result_match("goal-1")),
+            classify_correlation_event(
+                &event,
+                ExpectedServers::One(&server),
+                is_action_result_match("goal-1")
+            ),
             CorrelationOutcome::Match
         );
     }
@@ -2325,7 +2562,11 @@ mod tests {
         let server = NodeId::from("nav".to_string());
         let event = make_input_event("feedback", goal_params("goal-1", None));
         assert_eq!(
-            classify_correlation_event(&event, &server, is_action_result_match("goal-1")),
+            classify_correlation_event(
+                &event,
+                ExpectedServers::One(&server),
+                is_action_result_match("goal-1")
+            ),
             CorrelationOutcome::Passthrough
         );
     }
@@ -2335,9 +2576,123 @@ mod tests {
         let server = NodeId::from("nav".to_string());
         let event = make_input_event("result", goal_params("goal-2", Some(GOAL_STATUS_SUCCEEDED)));
         assert_eq!(
-            classify_correlation_event(&event, &server, is_action_result_match("goal-1")),
+            classify_correlation_event(
+                &event,
+                ExpectedServers::One(&server),
+                is_action_result_match("goal-1")
+            ),
             CorrelationOutcome::Passthrough
         );
+    }
+
+    // ---- dora-rs/dora#3046: ExpectedServers ----
+
+    #[test]
+    fn expected_servers_one_matches_only_that_node() {
+        let calc = NodeId::from("calc".to_string());
+        let other = NodeId::from("other".to_string());
+        assert!(ExpectedServers::One(&calc).contains(&calc));
+        assert!(!ExpectedServers::One(&calc).contains(&other));
+    }
+
+    #[test]
+    fn expected_servers_any_of_matches_each_listed_node() {
+        let eo = NodeId::from("cam-eo".to_string());
+        let ir = NodeId::from("cam-ir".to_string());
+        let other = NodeId::from("other".to_string());
+        let list = [eo.clone(), ir.clone()];
+        assert!(ExpectedServers::AnyOf(&list).contains(&eo));
+        assert!(ExpectedServers::AnyOf(&list).contains(&ir));
+        assert!(!ExpectedServers::AnyOf(&list).contains(&other));
+    }
+
+    #[test]
+    fn expected_servers_any_never_correlates_restarts() {
+        // `Any` means "no restart correlation" — not "every restart is
+        // mine". A node that did not know its responder up front must
+        // not be told an unrelated restart orphaned its request.
+        let calc = NodeId::from("calc".to_string());
+        assert!(!ExpectedServers::Any.contains(&calc));
+    }
+
+    #[test]
+    fn expected_servers_any_of_empty_matches_nothing() {
+        let calc = NodeId::from("calc".to_string());
+        assert!(!ExpectedServers::AnyOf(&[]).contains(&calc));
+    }
+
+    #[test]
+    fn classify_any_of_restart_returns_server_restarted() {
+        let eo = NodeId::from("cam-eo".to_string());
+        let ir = NodeId::from("cam-ir".to_string());
+        let list = [eo.clone(), ir.clone()];
+        let event = Event::NodeRestarted { id: ir };
+        assert_eq!(
+            classify_correlation_event(
+                &event,
+                ExpectedServers::AnyOf(&list),
+                is_request_match("req-42")
+            ),
+            CorrelationOutcome::ServerRestarted
+        );
+    }
+
+    #[test]
+    fn classify_any_of_unlisted_restart_is_passthrough() {
+        let eo = NodeId::from("cam-eo".to_string());
+        let list = [eo];
+        let event = Event::NodeRestarted {
+            id: NodeId::from("unrelated".to_string()),
+        };
+        assert_eq!(
+            classify_correlation_event(
+                &event,
+                ExpectedServers::AnyOf(&list),
+                is_request_match("req-42")
+            ),
+            CorrelationOutcome::Passthrough
+        );
+    }
+
+    #[test]
+    fn classify_any_ignores_restart() {
+        let event = Event::NodeRestarted {
+            id: NodeId::from("calc".to_string()),
+        };
+        assert_eq!(
+            classify_correlation_event(&event, ExpectedServers::Any, is_request_match("req-42")),
+            CorrelationOutcome::Passthrough
+        );
+    }
+
+    #[test]
+    fn classify_match_wins_regardless_of_expected_servers() {
+        // The core fan-out guarantee: a reply is correlated by
+        // `request_id` alone, so it matches even when it comes from a
+        // node the caller never listed.
+        let listed = NodeId::from("cam-eo".to_string());
+        let list = [listed];
+        let event = make_input_event("response", request_id_params("req-42"));
+        for expected in [
+            ExpectedServers::Any,
+            ExpectedServers::AnyOf(&list),
+            ExpectedServers::AnyOf(&[]),
+        ] {
+            assert_eq!(
+                classify_correlation_event(&event, expected, is_request_match("req-42")),
+                CorrelationOutcome::Match,
+            );
+        }
+    }
+
+    #[test]
+    fn restarted_node_id_reports_the_event_not_the_expectation() {
+        // With `AnyOf` the caller does not know which candidate went
+        // down, so the reported name has to come from the event.
+        let event = Event::NodeRestarted {
+            id: NodeId::from("cam-ir".to_string()),
+        };
+        assert_eq!(restarted_node_id(&event), "cam-ir");
     }
 
     // ---- dora-rs/adora#172: pending_passthrough integration ----
@@ -2549,6 +2904,183 @@ mod tests {
             matches!(&buffered, Some(Event::Input { id, .. }) if id.as_str() == "sensor"),
             "expected the buffered non-matching 'sensor' input, got {buffered:?}"
         );
+    }
+
+    // ---- dora-rs/dora#3046: non-blocking correlated receive ----
+
+    /// Build a testing `EventStream` from a scripted event list.
+    fn scripted_event_stream(events: Vec<TimedIncomingEvent>) -> (crate::DoraNode, EventStream) {
+        let inputs = TestingInput::Input(IntegrationTestInput::new(
+            "test-node".parse().unwrap(),
+            events,
+        ));
+        let (tx, _rx) = crate::integration_testing::output_channel();
+        let outputs = TestingOutput::ToChannel(tx);
+        let options = TestingOptions {
+            skip_output_time_offsets: true,
+        };
+        crate::DoraNode::init_testing(inputs, outputs, options).unwrap()
+    }
+
+    fn input_at(id: &str, metadata: Option<MetadataParameters>) -> TimedIncomingEvent {
+        TimedIncomingEvent {
+            time_offset_secs: 0.0,
+            event: IncomingEvent::Input {
+                id: id.parse().unwrap(),
+                metadata,
+                data: None,
+            },
+        }
+    }
+
+    fn stop_at() -> TimedIncomingEvent {
+        TimedIncomingEvent {
+            time_offset_secs: 0.0,
+            event: IncomingEvent::Stop,
+        }
+    }
+
+    /// Poll until a correlated reply appears, giving up after a bounded
+    /// number of attempts.
+    ///
+    /// The bound is what makes this a real test of non-blocking
+    /// behaviour: an implementation that blocked, or that never returned
+    /// `Ok(None)`, would fail here instead of hanging the suite.
+    fn poll_until<F>(mut poll: F) -> Event
+    where
+        F: FnMut() -> Result<Option<Event>, PatternError>,
+    {
+        for _ in 0..2_000 {
+            match poll() {
+                Ok(Some(event)) => return event,
+                Ok(None) => std::thread::sleep(Duration::from_millis(1)),
+                Err(e) => panic!("poll failed: {e:?}"),
+            }
+        }
+        panic!("correlated reply never arrived after 2000 polls");
+    }
+
+    #[test]
+    fn try_recv_service_response_matches_already_buffered_reply() {
+        // Fully deterministic: the reply is buffered before the poll, so
+        // the buffer scan (not the stream pump) must find it. This is
+        // the pipelined case — the reply to `req-2` can be buffered
+        // while an earlier wait for `req-1` was running.
+        let (_node, mut events) = scripted_event_stream(vec![stop_at()]);
+        events
+            .push_passthrough_for_testing(make_input_event("response", request_id_params("req-2")));
+
+        let server = NodeId::from("calc".to_string());
+        let got = events
+            .try_recv_service_response("req-2", ExpectedServers::One(&server))
+            .expect("poll must not error");
+        match got {
+            Some(Event::Input { id, .. }) => assert_eq!(id.as_str(), "response"),
+            other => panic!("expected the buffered response, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn try_recv_service_response_returns_none_when_nothing_matches() {
+        // A buffered *non-matching* event must not satisfy the poll, and
+        // must not be consumed by it either.
+        let (_node, mut events) = scripted_event_stream(vec![stop_at()]);
+        events.push_passthrough_for_testing(make_input_event(
+            "response",
+            request_id_params("req-other"),
+        ));
+
+        let server = NodeId::from("calc".to_string());
+        let result = events.try_recv_service_response("req-1", ExpectedServers::One(&server));
+
+        // Deliberately not asserting `Ok(None)`: whether the scripted
+        // `Stop` has been delivered yet is a race, and a `Stop` in the
+        // stream correctly ends the poll with `StreamEnded`. What must
+        // hold either way is that the unrelated buffered reply never
+        // counts as a match.
+        assert!(
+            !matches!(result, Ok(Some(_))),
+            "an unrelated buffered reply must not satisfy the poll, got {result:?}"
+        );
+
+        // ...and the poll must not have eaten it either: it still
+        // belongs to the caller's own event loop.
+        let buffered = events.recv();
+        assert!(
+            matches!(&buffered, Some(Event::Input { id, .. }) if id.as_str() == "response"),
+            "the unrelated reply must survive the poll, got {buffered:?}"
+        );
+    }
+
+    #[test]
+    fn try_recv_service_response_polls_without_blocking_and_buffers_others() {
+        let (_node, mut events) = scripted_event_stream(vec![
+            input_at("sensor", None),
+            input_at("response", Some(request_id_params("req-1"))),
+            stop_at(),
+        ]);
+
+        let server = NodeId::from("calc".to_string());
+        let matched =
+            poll_until(|| events.try_recv_service_response("req-1", ExpectedServers::One(&server)));
+        match matched {
+            Event::Input { id, .. } => assert_eq!(id.as_str(), "response"),
+            other => panic!("expected the correlated response, got {other:?}"),
+        }
+
+        // Polling must preserve the caller's own events exactly as the
+        // blocking form does.
+        let buffered = events.recv();
+        assert!(
+            matches!(&buffered, Some(Event::Input { id, .. }) if id.as_str() == "sensor"),
+            "expected the buffered non-matching 'sensor' input, got {buffered:?}"
+        );
+    }
+
+    #[test]
+    fn try_recv_action_result_polling_passes_feedback_through() {
+        let (_node, mut events) = scripted_event_stream(vec![
+            input_at("feedback", Some(goal_params("goal-1", None))),
+            input_at(
+                "result",
+                Some(goal_params("goal-1", Some(GOAL_STATUS_SUCCEEDED))),
+            ),
+            stop_at(),
+        ]);
+
+        let server = NodeId::from("nav".to_string());
+        let matched =
+            poll_until(|| events.try_recv_action_result("goal-1", ExpectedServers::One(&server)));
+        match matched {
+            Event::Input { id, .. } => assert_eq!(id.as_str(), "result"),
+            other => panic!("expected the terminal result, got {other:?}"),
+        }
+
+        // Feedback for the same goal is not terminal, so it belongs to
+        // the caller's loop rather than to the poll.
+        let buffered = events.recv();
+        assert!(
+            matches!(&buffered, Some(Event::Input { id, .. }) if id.as_str() == "feedback"),
+            "expected the buffered 'feedback' input, got {buffered:?}"
+        );
+    }
+
+    #[test]
+    fn try_recv_service_response_correlates_fan_out_reply_from_any_of() {
+        // One request id, several possible responders: whichever answers
+        // first satisfies the poll.
+        let (_node, mut events) = scripted_event_stream(vec![
+            input_at("response", Some(request_id_params("req-1"))),
+            stop_at(),
+        ]);
+
+        let eo = NodeId::from("cam-eo".to_string());
+        let ir = NodeId::from("cam-ir".to_string());
+        let candidates = [eo, ir];
+        let matched = poll_until(|| {
+            events.try_recv_service_response("req-1", ExpectedServers::AnyOf(&candidates))
+        });
+        assert!(matches!(matched, Event::Input { .. }));
     }
 
     /// Regression: a pattern-aware wait must find its correlated response even

--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -113,6 +113,19 @@ pub struct EventStream {
     /// the caller's main event loop never loses intermediate events
     /// (dora-rs/adora#148).
     pending_passthrough: std::collections::VecDeque<Event>,
+    /// Deadlines for outstanding correlations polled via
+    /// `try_recv_service_response` / `try_recv_action_result`
+    /// (dora-rs/dora#3046).
+    ///
+    /// The blocking receives own their deadline inside a single call;
+    /// a poll returns immediately, so the deadline has to survive
+    /// between calls. Keyed by correlation id (`request_id` /
+    /// `goal_id`), which is exactly what the caller already passes.
+    ///
+    /// An entry is created by the first deadline-carrying poll for an
+    /// id and removed as soon as that poll reaches a terminal outcome —
+    /// a match, an error, or the deadline itself.
+    correlation_deadlines: HashMap<String, std::time::Instant>,
     /// Set to true after an `Event::Stop` has been delivered. Zenoh
     /// subscriber threads hold clones of the event channel sender, so
     /// the daemon thread's sender drop alone is not enough to close
@@ -766,6 +779,7 @@ impl EventStream {
             use_scheduler,
             input_type_checks,
             pending_passthrough: std::collections::VecDeque::new(),
+            correlation_deadlines: HashMap::new(),
             stop_received: false,
             testing_shutdown,
         })
@@ -1245,25 +1259,39 @@ impl EventStream {
     /// events are buffered for the caller's own `recv()` exactly as in
     /// the blocking form, and correlation state survives across calls.
     ///
-    /// Because there is no deadline, this never reports
-    /// [`PatternError::Timeout`] — deadlines are the caller's to keep.
+    /// `timeout` is owned by the framework, not the caller: the first
+    /// poll carrying one registers a deadline for `request_id`, and a
+    /// later poll past it returns [`PatternError::Timeout`] exactly
+    /// once. A caller therefore does not sweep deadlines itself — it
+    /// passes the same timeout each iteration and reacts to `Timeout`
+    /// like any other outcome. Pass `None` to poll without a deadline.
+    ///
+    /// The clock starts at that first poll rather than at send time
+    /// (see [`correlation_expired`](Self::correlation_expired)), and the
+    /// first registered deadline wins if later polls pass a different
+    /// one. Use [`cancel_correlation`](Self::cancel_correlation) to drop
+    /// a request that will never be polled again.
     ///
     /// # Example
     ///
     /// ```ignore
     /// // once per event-loop iteration, for each outstanding request
-    /// match events.try_recv_service_response(&request_id, ExpectedServers::One(&server))? {
-    ///     Some(Event::Input { data, .. }) => complete(data),
-    ///     Some(_) => unreachable!(),
-    ///     None => {} // not ready — carry on with the rest of the tick
+    /// let timeout = Some(Duration::from_secs(5));
+    /// match events.try_recv_service_response(&request_id, ExpectedServers::One(&server), timeout) {
+    ///     Ok(Some(Event::Input { data, .. })) => complete(data),
+    ///     Ok(None) => {} // not ready — carry on with the rest of the tick
+    ///     Err(PatternError::Timeout) => give_up(),
+    ///     Err(e) => return Err(e.into()),
+    ///     _ => unreachable!(),
     /// }
     /// ```
     pub fn try_recv_service_response(
         &mut self,
         request_id: &str,
         expected: ExpectedServers<'_>,
+        timeout: Option<Duration>,
     ) -> Result<Option<Event>, PatternError> {
-        self.try_correlation(expected, matches_request_id, request_id)
+        self.try_correlation(expected, matches_request_id, request_id, timeout)
     }
 
     /// Waits for a terminal action result (`goal_status` ∈
@@ -1302,12 +1330,20 @@ impl EventStream {
     /// events keep being buffered for the caller's own `recv()`, so a
     /// polling client observes progress through its normal event loop
     /// and learns about completion here.
+    ///
+    /// `timeout` works exactly as in
+    /// [`try_recv_service_response`](Self::try_recv_service_response):
+    /// the framework registers the deadline on the first poll carrying
+    /// one and reports `Timeout` once. Note it bounds the *whole goal*,
+    /// not the gap between feedback messages — a long-running goal that
+    /// is making visible progress will still expire.
     pub fn try_recv_action_result(
         &mut self,
         goal_id: &str,
         expected: ExpectedServers<'_>,
+        timeout: Option<Duration>,
     ) -> Result<Option<Event>, PatternError> {
-        self.try_correlation(expected, matches_terminal_action_result, goal_id)
+        self.try_correlation(expected, matches_terminal_action_result, goal_id, timeout)
     }
 
     /// Core loop for the pattern-aware helpers. Waits up to `timeout`
@@ -1405,19 +1441,27 @@ impl EventStream {
         expected: ExpectedServers<'_>,
         is_match: F,
         needle: &str,
+        timeout: Option<Duration>,
     ) -> Result<Option<Event>, PatternError>
     where
         F: Fn(&Event, &str) -> bool,
     {
         // Same rationale as the blocking form: an earlier wait may have
-        // already buffered the reply we are now looking for.
+        // already buffered the reply we are now looking for. Checked
+        // before the deadline so a reply that did arrive in time is
+        // never discarded by an expiry noticed late.
         if let Some(pos) = self
             .pending_passthrough
             .iter()
             .position(|event| is_match(event, needle))
             && let Some(event) = self.pending_passthrough.remove(pos)
         {
+            self.correlation_deadlines.remove(needle);
             return Ok(Some(event));
+        }
+
+        if timeout.is_some() && self.correlation_expired(needle, timeout) {
+            return Err(PatternError::Timeout);
         }
 
         loop {
@@ -1432,17 +1476,23 @@ impl EventStream {
             };
 
             match classify_correlation_event(&event, expected, |e| is_match(e, needle)) {
-                CorrelationOutcome::Match => return Ok(Some(event)),
+                CorrelationOutcome::Match => {
+                    self.correlation_deadlines.remove(needle);
+                    return Ok(Some(event));
+                }
                 CorrelationOutcome::ServerRestarted => {
                     let restarted = restarted_node_id(&event);
+                    self.correlation_deadlines.remove(needle);
                     self.pending_passthrough.push_back(event);
                     return Err(PatternError::ServerRestarted(restarted));
                 }
                 CorrelationOutcome::StreamEnded => {
+                    self.correlation_deadlines.remove(needle);
                     self.pending_passthrough.push_back(event);
                     return Err(PatternError::StreamEnded);
                 }
                 CorrelationOutcome::StreamError => {
+                    self.correlation_deadlines.remove(needle);
                     if let Event::Error(err) = event {
                         return Err(PatternError::StreamError(err));
                     }
@@ -1453,6 +1503,52 @@ impl EventStream {
                 }
             }
         }
+    }
+
+    /// Whether `needle`'s deadline has passed, registering it on first
+    /// sight.
+    ///
+    /// The clock starts at the **first deadline-carrying poll** for an
+    /// id, not at send time: `EventStream` does not see the send, and
+    /// threading registration through `DoraNode` would couple the two
+    /// for no practical gain — a client polls in the same iteration it
+    /// sends, so the difference is one iteration.
+    ///
+    /// A later poll passing a different `timeout` does not move an
+    /// existing deadline; the first one registered wins. Otherwise a
+    /// caller that recomputed a relative timeout each iteration would
+    /// push its own deadline forward forever and never time out.
+    ///
+    /// Returns `true` exactly once per registration: the entry is
+    /// removed as it expires, so the caller sees one `Timeout` rather
+    /// than a `Timeout` on every subsequent poll.
+    fn correlation_expired(&mut self, needle: &str, timeout: Option<Duration>) -> bool {
+        let Some(timeout) = timeout else {
+            return false;
+        };
+        let now = std::time::Instant::now();
+        let deadline = *self
+            .correlation_deadlines
+            .entry(needle.to_owned())
+            // Saturating: `timeout` crosses the C++ boundary as an
+            // unbounded value, and `Instant + Duration` panics on
+            // overflow.
+            .or_insert_with(|| now.checked_add(timeout).unwrap_or(now));
+        if now >= deadline {
+            self.correlation_deadlines.remove(needle);
+            return true;
+        }
+        false
+    }
+
+    /// Forget an outstanding correlation's deadline.
+    ///
+    /// A poll drops its own entry on a match, an error or expiry, so
+    /// this is only needed when a caller abandons a request it will
+    /// never poll again — otherwise that one entry lives until the
+    /// `EventStream` is dropped.
+    pub fn cancel_correlation(&mut self, correlation_id: &str) {
+        self.correlation_deadlines.remove(correlation_id);
     }
 }
 
@@ -2972,7 +3068,7 @@ mod tests {
 
         let server = NodeId::from("calc".to_string());
         let got = events
-            .try_recv_service_response("req-2", ExpectedServers::One(&server))
+            .try_recv_service_response("req-2", ExpectedServers::One(&server), None)
             .expect("poll must not error");
         match got {
             Some(Event::Input { id, .. }) => assert_eq!(id.as_str(), "response"),
@@ -2991,7 +3087,7 @@ mod tests {
         ));
 
         let server = NodeId::from("calc".to_string());
-        let result = events.try_recv_service_response("req-1", ExpectedServers::One(&server));
+        let result = events.try_recv_service_response("req-1", ExpectedServers::One(&server), None);
 
         // Deliberately not asserting `Ok(None)`: whether the scripted
         // `Stop` has been delivered yet is a race, and a `Stop` in the
@@ -3021,8 +3117,9 @@ mod tests {
         ]);
 
         let server = NodeId::from("calc".to_string());
-        let matched =
-            poll_until(|| events.try_recv_service_response("req-1", ExpectedServers::One(&server)));
+        let matched = poll_until(|| {
+            events.try_recv_service_response("req-1", ExpectedServers::One(&server), None)
+        });
         match matched {
             Event::Input { id, .. } => assert_eq!(id.as_str(), "response"),
             other => panic!("expected the correlated response, got {other:?}"),
@@ -3049,8 +3146,9 @@ mod tests {
         ]);
 
         let server = NodeId::from("nav".to_string());
-        let matched =
-            poll_until(|| events.try_recv_action_result("goal-1", ExpectedServers::One(&server)));
+        let matched = poll_until(|| {
+            events.try_recv_action_result("goal-1", ExpectedServers::One(&server), None)
+        });
         match matched {
             Event::Input { id, .. } => assert_eq!(id.as_str(), "result"),
             other => panic!("expected the terminal result, got {other:?}"),
@@ -3066,6 +3164,142 @@ mod tests {
     }
 
     #[test]
+    fn poll_without_a_timeout_never_expires() {
+        let (_node, mut events) = scripted_event_stream(vec![stop_at()]);
+        let server = NodeId::from("calc".to_string());
+
+        // `None` is the pre-deadline behaviour: whatever happens, it is
+        // never a Timeout.
+        for _ in 0..3 {
+            let result =
+                events.try_recv_service_response("req-1", ExpectedServers::One(&server), None);
+            assert!(
+                !matches!(result, Err(PatternError::Timeout)),
+                "a poll without a deadline must never time out, got {result:?}"
+            );
+        }
+        assert!(events.correlation_deadlines.is_empty());
+    }
+
+    #[test]
+    fn expired_correlation_reports_timeout_exactly_once() {
+        let (_node, mut events) = scripted_event_stream(vec![stop_at()]);
+
+        // A zero timeout is already expired when registered, so this is
+        // deterministic without sleeping.
+        let expired = Some(Duration::ZERO);
+        assert!(
+            events.correlation_expired("req-1", expired),
+            "a zero timeout must be expired on the first poll"
+        );
+
+        // The entry is dropped as it expires, so the caller is not told
+        // the same request timed out on every subsequent poll. The next
+        // call re-registers instead.
+        assert!(
+            !events.correlation_deadlines.contains_key("req-1"),
+            "an expired registration must not linger"
+        );
+    }
+
+    #[test]
+    fn first_registered_deadline_wins() {
+        let (_node, mut events) = scripted_event_stream(vec![stop_at()]);
+
+        // Register a long deadline, then poll again with a short one. If
+        // the later value replaced the earlier, a caller recomputing a
+        // relative timeout every iteration would push its own deadline
+        // forward forever and never expire.
+        assert!(!events.correlation_expired("req-1", Some(Duration::from_secs(3600))));
+        let registered = events.correlation_deadlines["req-1"];
+
+        assert!(!events.correlation_expired("req-1", Some(Duration::ZERO)));
+        assert_eq!(
+            events.correlation_deadlines["req-1"], registered,
+            "a later poll must not move an already-registered deadline"
+        );
+    }
+
+    #[test]
+    fn a_matched_reply_clears_its_deadline() {
+        let (_node, mut events) = scripted_event_stream(vec![stop_at()]);
+        events
+            .push_passthrough_for_testing(make_input_event("response", request_id_params("req-1")));
+
+        let server = NodeId::from("calc".to_string());
+        // Register a deadline, then let the buffered reply satisfy it.
+        assert!(!events.correlation_expired("req-1", Some(Duration::from_secs(60))));
+        assert!(events.correlation_deadlines.contains_key("req-1"));
+
+        let got = events
+            .try_recv_service_response(
+                "req-1",
+                ExpectedServers::One(&server),
+                Some(Duration::from_secs(60)),
+            )
+            .expect("the buffered reply must satisfy the poll");
+        assert!(got.is_some());
+        assert!(
+            !events.correlation_deadlines.contains_key("req-1"),
+            "a completed correlation must not leave a deadline behind"
+        );
+    }
+
+    #[test]
+    fn a_buffered_reply_beats_an_expired_deadline() {
+        // The reply did arrive in time; the caller simply polled late.
+        // Reporting Timeout here would discard a reply the framework
+        // already holds.
+        let (_node, mut events) = scripted_event_stream(vec![stop_at()]);
+        events
+            .push_passthrough_for_testing(make_input_event("response", request_id_params("req-1")));
+
+        let server = NodeId::from("calc".to_string());
+        let got = events
+            .try_recv_service_response("req-1", ExpectedServers::One(&server), Some(Duration::ZERO))
+            .expect("a buffered reply must win over an expired deadline");
+        match got {
+            Some(Event::Input { id, .. }) => assert_eq!(id.as_str(), "response"),
+            other => panic!("expected the buffered reply, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cancel_correlation_drops_an_abandoned_registration() {
+        let (_node, mut events) = scripted_event_stream(vec![stop_at()]);
+
+        assert!(!events.correlation_expired("req-1", Some(Duration::from_secs(60))));
+        assert!(events.correlation_deadlines.contains_key("req-1"));
+
+        events.cancel_correlation("req-1");
+        assert!(
+            !events.correlation_deadlines.contains_key("req-1"),
+            "cancel_correlation must drop the registration"
+        );
+    }
+
+    #[test]
+    fn deadlines_are_tracked_per_correlation_id() {
+        let (_node, mut events) = scripted_event_stream(vec![stop_at()]);
+
+        assert!(!events.correlation_expired("req-1", Some(Duration::from_secs(3600))));
+        // A different id expiring must not disturb the first.
+        assert!(events.correlation_expired("req-2", Some(Duration::ZERO)));
+        assert!(
+            events.correlation_deadlines.contains_key("req-1"),
+            "one request's expiry must not clear another's deadline"
+        );
+    }
+
+    #[test]
+    fn an_absurd_timeout_does_not_panic() {
+        // `timeout_ms` crosses the C++ boundary unbounded, and
+        // `Instant + Duration` panics on overflow.
+        let (_node, mut events) = scripted_event_stream(vec![stop_at()]);
+        let _ = events.correlation_expired("req-1", Some(Duration::from_secs(u64::MAX)));
+    }
+
+    #[test]
     fn try_recv_service_response_correlates_fan_out_reply_from_any_of() {
         // One request id, several possible responders: whichever answers
         // first satisfies the poll.
@@ -3078,7 +3312,7 @@ mod tests {
         let ir = NodeId::from("cam-ir".to_string());
         let candidates = [eo, ir];
         let matched = poll_until(|| {
-            events.try_recv_service_response("req-1", ExpectedServers::AnyOf(&candidates))
+            events.try_recv_service_response("req-1", ExpectedServers::AnyOf(&candidates), None)
         });
         assert!(matches!(matched, Event::Input { .. }));
     }

--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -3279,6 +3279,17 @@ mod tests {
     }
 
     #[test]
+    fn cancel_correlation_is_safe_for_an_unknown_id() {
+        // Callers cancel on paths where the request may already have
+        // completed — a double cancel, or one racing a reply — so an
+        // unknown id has to be a no-op rather than a panic.
+        let (_node, mut events) = scripted_event_stream(vec![stop_at()]);
+        events.cancel_correlation("never-registered");
+        events.cancel_correlation("never-registered");
+        assert!(events.correlation_deadlines.is_empty());
+    }
+
+    #[test]
     fn deadlines_are_tracked_per_correlation_id() {
         let (_node, mut events) = scripted_event_stream(vec![stop_at()]);
 

--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -1562,6 +1562,25 @@ impl EventStream {
     /// this is only needed when a caller abandons a request it will
     /// never poll again — otherwise that one entry lives until the
     /// `EventStream` is dropped.
+    ///
+    /// # It does not discard a reply that arrives later
+    ///
+    /// This clears the deadline and nothing else. A reply that arrives
+    /// *after* its request timed out or was cancelled matches no live
+    /// correlation, so the next poll buffers it for the caller's own
+    /// event loop, exactly like any other unrelated input.
+    ///
+    /// [`recv`](Self::recv) and friends drain that buffer, so a client
+    /// that reads its events at all clears these as a matter of course.
+    /// A client that *only* polls and never reads events keeps one
+    /// buffered event per unclaimed reply.
+    ///
+    /// Draining defensively is not as simple as it looks:
+    /// [`try_recv`](Self::try_recv) returns buffered events first but
+    /// then falls through to the live stream, so a loop that reads
+    /// until empty can consume — and discard — a reply a later poll was
+    /// going to correlate. Read events you can classify yourself rather
+    /// than discarding whatever comes back.
     pub fn cancel_correlation(&mut self, correlation_id: &str) {
         self.correlation_deadlines.remove(correlation_id);
     }

--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -1272,6 +1272,12 @@ impl EventStream {
     /// one. Use [`cancel_correlation`](Self::cancel_correlation) to drop
     /// a request that will never be polled again.
     ///
+    /// A reply that arrived before the deadline always wins over it,
+    /// whether it was already buffered or still unread on the stream:
+    /// the deadline is consulted only after everything available has
+    /// been examined. So `Timeout` means the reply had genuinely not
+    /// arrived, not merely that the caller polled late.
+    ///
     /// # Example
     ///
     /// ```ignore
@@ -1447,9 +1453,7 @@ impl EventStream {
         F: Fn(&Event, &str) -> bool,
     {
         // Same rationale as the blocking form: an earlier wait may have
-        // already buffered the reply we are now looking for. Checked
-        // before the deadline so a reply that did arrive in time is
-        // never discarded by an expiry noticed late.
+        // already buffered the reply we are now looking for.
         if let Some(pos) = self
             .pending_passthrough
             .iter()
@@ -1460,17 +1464,17 @@ impl EventStream {
             return Ok(Some(event));
         }
 
-        if timeout.is_some() && self.correlation_expired(needle, timeout) {
-            return Err(PatternError::Timeout);
-        }
-
         loop {
             // `recv_from_stream`, not `recv_async`: the latter drains
             // `pending_passthrough` and would re-hand us the events we
             // buffer below (see `recv_from_stream`'s docs).
             let event = match pin!(self.recv_from_stream()).now_or_never() {
-                // Nothing ready — the caller can get on with its loop.
-                None => return Ok(None),
+                // Nothing more is ready. Fall through to the deadline
+                // check below rather than returning here: a reply that
+                // reached the stream before the deadline must win over
+                // it, and it can only do that if everything already
+                // available has been looked at first.
+                None => break,
                 Some(None) => return Err(PatternError::StreamEnded),
                 Some(Some(event)) => event,
             };
@@ -1518,6 +1522,13 @@ impl EventStream {
                 }
             }
         }
+
+        // Everything that had already arrived has now been examined, so
+        // a deadline reached here really did lapse without a reply.
+        if timeout.is_some() && self.correlation_expired(needle, timeout) {
+            return Err(PatternError::Timeout);
+        }
+        Ok(None)
     }
 
     /// Whether `needle`'s deadline has passed, registering it on first
@@ -2260,6 +2271,33 @@ impl EventStream {
         self.scheduler.add_event(EventItem::NodeEvent {
             event: NodeEvent::NodeRestarted {
                 id: id.to_owned().into(),
+            },
+        });
+    }
+
+    /// Test-only: put an input carrying `parameters` on the *stream*
+    /// (via the scheduler) without it passing through
+    /// `pending_passthrough` first.
+    ///
+    /// That distinction is the whole point: a reply reached by the
+    /// buffer scan and a reply still sitting unread on the stream take
+    /// different paths through `try_correlation`, and only the second
+    /// one exercises the deadline ordering (dora-rs/dora#3046).
+    fn push_scheduler_input_with_params_for_testing(
+        &mut self,
+        id: &str,
+        parameters: dora_message::metadata::MetadataParameters,
+    ) {
+        use crate::event_stream::thread::EventItem;
+        use dora_message::{daemon_to_node::NodeEvent, metadata::Metadata};
+        self.use_scheduler = true;
+        let mut meta = Metadata::new(dora_core::uhlc::HLC::default().new_timestamp());
+        meta.parameters = parameters;
+        self.scheduler.add_event(EventItem::NodeEvent {
+            event: NodeEvent::Input {
+                id: id.into(),
+                metadata: std::sync::Arc::new(meta),
+                data: None,
             },
         });
     }
@@ -3391,6 +3429,65 @@ mod tests {
         assert!(
             !events.correlation_deadlines.contains_key("req-1"),
             "a One restart orphans the request, so its deadline must go too"
+        );
+    }
+
+    /// A reply that reached the stream before the deadline must win over
+    /// it, even when the caller polls after the deadline has passed.
+    ///
+    /// The expiry check used to run before the stream was drained, so a
+    /// reply sitting unread in the receiver lost to a deadline that had
+    /// only just lapsed — reported `Timeout` for a request that had in
+    /// fact been answered in time.
+    ///
+    /// The reply is pushed straight onto the stream rather than into
+    /// `pending_passthrough`: routed through the buffer it would be
+    /// found by the buffer scan, which was always ahead of the deadline
+    /// check, and the test would pass either way.
+    #[test]
+    fn a_reply_already_on_the_stream_beats_an_expired_deadline() {
+        let (_node, mut events) = scripted_event_stream(vec![]);
+        let server = NodeId::from("calc".to_string());
+
+        events.push_scheduler_input_with_params_for_testing("response", request_id_params("req-1"));
+        assert!(
+            events.pending_passthrough.is_empty(),
+            "the reply must start on the stream, not in the buffer"
+        );
+
+        let got = events.try_recv_service_response(
+            "req-1",
+            ExpectedServers::One(&server),
+            Some(Duration::ZERO),
+        );
+        match got {
+            Ok(Some(Event::Input { id, .. })) => assert_eq!(id.as_str(), "response"),
+            other => panic!(
+                "a reply that arrived before the deadline must not be reported as Timeout: {other:?}"
+            ),
+        }
+    }
+
+    /// The complement: with nothing on the stream, an lapsed deadline
+    /// still reports `Timeout` rather than hanging on `Ok(None)`.
+    #[test]
+    fn an_expired_deadline_still_reports_timeout_when_nothing_arrived() {
+        let (_node, mut events) = scripted_event_stream(vec![]);
+        let server = NodeId::from("calc".to_string());
+
+        let got = events.try_recv_service_response(
+            "req-1",
+            ExpectedServers::One(&server),
+            Some(Duration::ZERO),
+        );
+        // An empty scripted stream closes, which is terminal in its own
+        // right; either way it must not be a silent `Ok(None)`.
+        assert!(
+            matches!(
+                got,
+                Err(PatternError::Timeout) | Err(PatternError::StreamEnded)
+            ),
+            "an lapsed deadline with nothing to show must be terminal, got {got:?}"
         );
     }
 

--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -1468,14 +1468,27 @@ impl EventStream {
             // `recv_from_stream`, not `recv_async`: the latter drains
             // `pending_passthrough` and would re-hand us the events we
             // buffer below (see `recv_from_stream`'s docs).
-            let event = match pin!(self.recv_from_stream()).now_or_never() {
+            // Bound to a local first: the pinned future borrows `self`
+            // for the whole of its enclosing statement, so matching on
+            // it directly would keep that borrow alive across the
+            // arms that need `&mut self`.
+            let polled = pin!(self.recv_from_stream()).now_or_never();
+            let event = match polled {
                 // Nothing more is ready. Fall through to the deadline
                 // check below rather than returning here: a reply that
                 // reached the stream before the deadline must win over
                 // it, and it can only do that if everything already
                 // available has been looked at first.
                 None => break,
-                Some(None) => return Err(PatternError::StreamEnded),
+                // Same cleanup as the `Event::Stop` arm below. The
+                // stream is dead either way, so this costs nothing
+                // today; it exists so both routes to `StreamEnded`
+                // leave the same state behind rather than only one of
+                // them being safe to reason about.
+                Some(None) => {
+                    self.correlation_deadlines.remove(needle);
+                    return Err(PatternError::StreamEnded);
+                }
                 Some(Some(event)) => event,
             };
 
@@ -3488,6 +3501,43 @@ mod tests {
                 Err(PatternError::Timeout) | Err(PatternError::StreamEnded)
             ),
             "an lapsed deadline with nothing to show must be terminal, got {got:?}"
+        );
+    }
+
+    /// Both routes to `StreamEnded` — a buffered `Event::Stop` and a
+    /// closed receiver — must leave the same state behind, so nothing
+    /// downstream has to know which one it came from.
+    #[test]
+    fn a_closed_stream_clears_the_deadline_like_a_stop_does() {
+        let (_node, mut events) = scripted_event_stream(vec![]);
+        let server = NodeId::from("calc".to_string());
+
+        assert!(!events.correlation_expired("req-1", Some(Duration::from_secs(60))));
+        assert!(events.correlation_deadlines.contains_key("req-1"));
+
+        // The stream closes on its own, but not instantly — an early
+        // poll just reports `Ok(None)` because nothing is ready yet.
+        let mut saw_end = false;
+        for _ in 0..2_000 {
+            let polled = events.try_recv_service_response(
+                "req-1",
+                ExpectedServers::One(&server),
+                Some(Duration::from_secs(60)),
+            );
+            if matches!(polled, Err(PatternError::StreamEnded)) {
+                saw_end = true;
+                break;
+            }
+            assert!(
+                matches!(polled, Ok(None)),
+                "an empty stream should only ever be 'not ready' or ended, got {polled:?}"
+            );
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        assert!(saw_end, "an empty scripted stream must close");
+        assert!(
+            !events.correlation_deadlines.contains_key("req-1"),
+            "a closed stream must clear the deadline, as the Stop path does"
         );
     }
 

--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -1283,7 +1283,7 @@ impl EventStream {
     /// ```ignore
     /// // once per event-loop iteration, for each outstanding request
     /// let timeout = Some(Duration::from_secs(5));
-    /// match events.try_recv_service_response(&request_id, ExpectedServers::One(&server), timeout) {
+    /// match events.try_recv_service_response(&request_id, &server, timeout) {
     ///     Ok(Some(Event::Input { data, .. })) => complete(data),
     ///     Ok(None) => {} // not ready — carry on with the rest of the tick
     ///     Err(PatternError::Timeout) => give_up(),
@@ -1292,6 +1292,28 @@ impl EventStream {
     /// }
     /// ```
     pub fn try_recv_service_response(
+        &mut self,
+        request_id: &str,
+        expected_server: &NodeId,
+        timeout: Option<Duration>,
+    ) -> Result<Option<Event>, PatternError> {
+        self.try_recv_service_response_from(
+            request_id,
+            ExpectedServers::One(expected_server),
+            timeout,
+        )
+    }
+
+    /// [`try_recv_service_response`](Self::try_recv_service_response)
+    /// over a set of acceptable responders.
+    ///
+    /// Stands to `try_recv_service_response` exactly as
+    /// [`recv_service_response_from`](Self::recv_service_response_from)
+    /// stands to [`recv_service_response`](Self::recv_service_response):
+    /// same semantics, a set of acceptable responders instead of one.
+    /// See [`ExpectedServers`] for what that choice does and does not
+    /// affect.
+    pub fn try_recv_service_response_from(
         &mut self,
         request_id: &str,
         expected: ExpectedServers<'_>,
@@ -1344,6 +1366,22 @@ impl EventStream {
     /// not the gap between feedback messages — a long-running goal that
     /// is making visible progress will still expire.
     pub fn try_recv_action_result(
+        &mut self,
+        goal_id: &str,
+        expected_server: &NodeId,
+        timeout: Option<Duration>,
+    ) -> Result<Option<Event>, PatternError> {
+        self.try_recv_action_result_from(goal_id, ExpectedServers::One(expected_server), timeout)
+    }
+
+    /// [`try_recv_action_result`](Self::try_recv_action_result) over a
+    /// set of acceptable responders.
+    ///
+    /// Stands to `try_recv_action_result` exactly as
+    /// [`recv_action_result_from`](Self::recv_action_result_from)
+    /// stands to [`recv_action_result`](Self::recv_action_result).
+    /// See [`ExpectedServers`].
+    pub fn try_recv_action_result_from(
         &mut self,
         goal_id: &str,
         expected: ExpectedServers<'_>,
@@ -1566,13 +1604,21 @@ impl EventStream {
             return false;
         };
         let now = std::time::Instant::now();
-        let deadline = *self
-            .correlation_deadlines
-            .entry(needle.to_owned())
-            // Saturating: `timeout` crosses the C++ boundary as an
-            // unbounded value, and `Instant + Duration` panics on
-            // overflow.
-            .or_insert_with(|| now.checked_add(timeout).unwrap_or(now));
+        // `get` before `entry`: the hit is the common case — a poll loop
+        // re-checks the same in-flight ids every iteration — and `entry`
+        // would allocate a `String` key on every one of those hits.
+        let deadline = match self.correlation_deadlines.get(needle) {
+            Some(deadline) => *deadline,
+            None => {
+                // Saturating: `timeout` crosses the C++ boundary as an
+                // unbounded value, and `Instant + Duration` panics on
+                // overflow.
+                let deadline = now.checked_add(timeout).unwrap_or(now);
+                self.correlation_deadlines
+                    .insert(needle.to_owned(), deadline);
+                deadline
+            }
+        };
         if now >= deadline {
             self.correlation_deadlines.remove(needle);
             return true;
@@ -1605,6 +1651,20 @@ impl EventStream {
     /// until empty can consume — and discard — a reply a later poll was
     /// going to correlate. Read events you can classify yourself rather
     /// than discarding whatever comes back.
+    ///
+    /// # Restarts with several requests in flight
+    ///
+    /// A restart is reported as [`PatternError::ServerRestarted`] to the
+    /// *one* correlation that consumes it — the wait or poll that
+    /// happened to be reading the stream when it arrived. Other requests
+    /// outstanding against the same server are not told, and would
+    /// otherwise sit until their own deadlines lapse. A restart that
+    /// lands between calls reaches the caller's own [`recv`](Self::recv)
+    /// as [`Event::NodeRestarted`] instead.
+    ///
+    /// So a node with more than one request in flight should react to
+    /// that event directly: cancel each correlation outstanding against
+    /// the restarted node, then resend under a fresh `request_id`.
     pub fn cancel_correlation(&mut self, correlation_id: &str) {
         self.correlation_deadlines.remove(correlation_id);
     }
@@ -2267,10 +2327,6 @@ impl EventStream {
         self.pending_passthrough.push_back(event);
     }
 
-    /// Test-only: buffer an empty input directly in the scheduler and force
-    /// scheduler mode, simulating an input the scheduler held back while
-    /// prioritizing `Stop`. Used to verify `recv_async` drains buffered inputs
-    /// after `Stop` instead of dropping them (dora-rs/dora#2027).
     /// Test-only: deliver a `NodeRestarted` through the *stream* rather
     /// than the passthrough buffer, so `try_correlation` classifies it
     /// for real. The scripted integration harness has no
@@ -2315,6 +2371,10 @@ impl EventStream {
         });
     }
 
+    /// Test-only: buffer an empty input directly in the scheduler and force
+    /// scheduler mode, simulating an input the scheduler held back while
+    /// prioritizing `Stop`. Used to verify `recv_async` drains buffered inputs
+    /// after `Stop` instead of dropping them (dora-rs/dora#2027).
     fn push_scheduler_input_for_testing(&mut self, id: &str) {
         use crate::event_stream::thread::EventItem;
         use dora_message::{daemon_to_node::NodeEvent, metadata::Metadata};
@@ -3176,7 +3236,7 @@ mod tests {
 
         let server = NodeId::from("calc".to_string());
         let got = events
-            .try_recv_service_response("req-2", ExpectedServers::One(&server), None)
+            .try_recv_service_response("req-2", &server, None)
             .expect("poll must not error");
         match got {
             Some(Event::Input { id, .. }) => assert_eq!(id.as_str(), "response"),
@@ -3195,7 +3255,7 @@ mod tests {
         ));
 
         let server = NodeId::from("calc".to_string());
-        let result = events.try_recv_service_response("req-1", ExpectedServers::One(&server), None);
+        let result = events.try_recv_service_response("req-1", &server, None);
 
         // Deliberately not asserting `Ok(None)`: whether the scripted
         // `Stop` has been delivered yet is a race, and a `Stop` in the
@@ -3225,9 +3285,7 @@ mod tests {
         ]);
 
         let server = NodeId::from("calc".to_string());
-        let matched = poll_until(|| {
-            events.try_recv_service_response("req-1", ExpectedServers::One(&server), None)
-        });
+        let matched = poll_until(|| events.try_recv_service_response("req-1", &server, None));
         match matched {
             Event::Input { id, .. } => assert_eq!(id.as_str(), "response"),
             other => panic!("expected the correlated response, got {other:?}"),
@@ -3254,9 +3312,7 @@ mod tests {
         ]);
 
         let server = NodeId::from("nav".to_string());
-        let matched = poll_until(|| {
-            events.try_recv_action_result("goal-1", ExpectedServers::One(&server), None)
-        });
+        let matched = poll_until(|| events.try_recv_action_result("goal-1", &server, None));
         match matched {
             Event::Input { id, .. } => assert_eq!(id.as_str(), "result"),
             other => panic!("expected the terminal result, got {other:?}"),
@@ -3279,8 +3335,7 @@ mod tests {
         // `None` is the pre-deadline behaviour: whatever happens, it is
         // never a Timeout.
         for _ in 0..3 {
-            let result =
-                events.try_recv_service_response("req-1", ExpectedServers::One(&server), None);
+            let result = events.try_recv_service_response("req-1", &server, None);
             assert!(
                 !matches!(result, Err(PatternError::Timeout)),
                 "a poll without a deadline must never time out, got {result:?}"
@@ -3340,11 +3395,7 @@ mod tests {
         assert!(events.correlation_deadlines.contains_key("req-1"));
 
         let got = events
-            .try_recv_service_response(
-                "req-1",
-                ExpectedServers::One(&server),
-                Some(Duration::from_secs(60)),
-            )
+            .try_recv_service_response("req-1", &server, Some(Duration::from_secs(60)))
             .expect("the buffered reply must satisfy the poll");
         assert!(got.is_some());
         assert!(
@@ -3364,7 +3415,7 @@ mod tests {
 
         let server = NodeId::from("calc".to_string());
         let got = events
-            .try_recv_service_response("req-1", ExpectedServers::One(&server), Some(Duration::ZERO))
+            .try_recv_service_response("req-1", &server, Some(Duration::ZERO))
             .expect("a buffered reply must win over an expired deadline");
         match got {
             Some(Event::Input { id, .. }) => assert_eq!(id.as_str(), "response"),
@@ -3407,8 +3458,11 @@ mod tests {
         let registered = events.correlation_deadlines["req-1"];
 
         events.push_scheduler_node_restarted_for_testing("b");
-        let restarted =
-            events.try_recv_service_response("req-1", ExpectedServers::AnyOf(&candidates), timeout);
+        let restarted = events.try_recv_service_response_from(
+            "req-1",
+            ExpectedServers::AnyOf(&candidates),
+            timeout,
+        );
         assert!(
             matches!(&restarted, Err(PatternError::ServerRestarted(id)) if id == "b"),
             "expected a ServerRestarted naming b, got {restarted:?}"
@@ -3435,8 +3489,7 @@ mod tests {
         assert!(events.correlation_deadlines.contains_key("req-1"));
 
         events.push_scheduler_node_restarted_for_testing("calc");
-        let restarted =
-            events.try_recv_service_response("req-1", ExpectedServers::One(&server), timeout);
+        let restarted = events.try_recv_service_response("req-1", &server, timeout);
         assert!(matches!(restarted, Err(PatternError::ServerRestarted(_))));
 
         assert!(
@@ -3468,11 +3521,7 @@ mod tests {
             "the reply must start on the stream, not in the buffer"
         );
 
-        let got = events.try_recv_service_response(
-            "req-1",
-            ExpectedServers::One(&server),
-            Some(Duration::ZERO),
-        );
+        let got = events.try_recv_service_response("req-1", &server, Some(Duration::ZERO));
         match got {
             Ok(Some(Event::Input { id, .. })) => assert_eq!(id.as_str(), "response"),
             other => panic!(
@@ -3488,11 +3537,7 @@ mod tests {
         let (_node, mut events) = scripted_event_stream(vec![]);
         let server = NodeId::from("calc".to_string());
 
-        let got = events.try_recv_service_response(
-            "req-1",
-            ExpectedServers::One(&server),
-            Some(Duration::ZERO),
-        );
+        let got = events.try_recv_service_response("req-1", &server, Some(Duration::ZERO));
         // An empty scripted stream closes, which is terminal in its own
         // right; either way it must not be a silent `Ok(None)`.
         assert!(
@@ -3519,11 +3564,8 @@ mod tests {
         // poll just reports `Ok(None)` because nothing is ready yet.
         let mut saw_end = false;
         for _ in 0..2_000 {
-            let polled = events.try_recv_service_response(
-                "req-1",
-                ExpectedServers::One(&server),
-                Some(Duration::from_secs(60)),
-            );
+            let polled =
+                events.try_recv_service_response("req-1", &server, Some(Duration::from_secs(60)));
             if matches!(polled, Err(PatternError::StreamEnded)) {
                 saw_end = true;
                 break;
@@ -3586,7 +3628,11 @@ mod tests {
         let b = NodeId::from("b".to_string());
         let candidates = [a, b];
         let matched = poll_until(|| {
-            events.try_recv_service_response("req-1", ExpectedServers::AnyOf(&candidates), None)
+            events.try_recv_service_response_from(
+                "req-1",
+                ExpectedServers::AnyOf(&candidates),
+                None,
+            )
         });
         assert!(matches!(matched, Event::Input { .. }));
     }

--- a/apis/rust/node/src/lib.rs
+++ b/apis/rust/node/src/lib.rs
@@ -147,7 +147,7 @@ use dora_message::{
     node_to_daemon::DaemonRequest,
 };
 pub use event_stream::{
-    Event, EventScheduler, EventStream, StopCause, TryRecvError,
+    Event, EventScheduler, EventStream, ExpectedServers, StopCause, TryRecvError,
     input_tracker::{InputState, InputTracker},
     merged,
 };

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -2305,13 +2305,48 @@ impl DoraNode {
     pub fn send_service_request(
         &mut self,
         output_id: DataId,
-        mut parameters: MetadataParameters,
+        parameters: MetadataParameters,
         data: impl IntoArrow,
     ) -> NodeResult<String> {
         if parameters.contains_key(dora_message::metadata::REQUEST_ID) {
-            tracing::warn!("send_service_request: caller-provided request_id will be overwritten");
+            tracing::warn!(
+                "send_service_request: caller-provided request_id will be overwritten; \
+                 use send_service_request_with_id to keep it"
+            );
         }
         let request_id = Self::new_request_id();
+        self.send_service_request_with_id(output_id, parameters, data, request_id)
+    }
+
+    /// Send a service request under a caller-supplied `request_id`.
+    ///
+    /// [`send_service_request`](Self::send_service_request) mints a fresh
+    /// id per call, which makes it unusable for a request fanned out to
+    /// several nodes: each publish would carry a different correlation
+    /// and no single receive could await "whichever answers first". This
+    /// variant sends every copy under one id instead.
+    ///
+    /// The id is returned unchanged, so callers can use the two
+    /// interchangeably.
+    ///
+    /// ```ignore
+    /// let request_id = DoraNode::new_request_id();
+    /// for server in &servers {
+    ///     node.send_service_request_with_id(
+    ///         server.output.clone(), params.clone(), data.clone(), request_id.clone(),
+    ///     )?;
+    /// }
+    /// let reply = events
+    ///     .recv_service_response_from(&request_id, ExpectedServers::AnyOf(&servers), timeout)
+    ///     .await?;
+    /// ```
+    pub fn send_service_request_with_id(
+        &mut self,
+        output_id: DataId,
+        mut parameters: MetadataParameters,
+        data: impl IntoArrow,
+        request_id: String,
+    ) -> NodeResult<String> {
         parameters.insert(
             dora_message::metadata::REQUEST_ID.to_string(),
             dora_message::metadata::Parameter::String(request_id.clone()),

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -97,6 +97,59 @@ intermediate inputs, parameter updates, or lifecycle events.
 
 **Example**: `examples/service-example/`
 
+#### Clients that cannot block
+
+`recv_service_response` waits. A single-threaded node with its own
+schedule to keep — or several requests outstanding at once — cannot
+afford that: the wait stalls everything else, and on a wedged server it
+stalls for the whole timeout.
+
+`try_recv_service_response` polls instead, returning `Ok(None)` when the
+reply has not arrived (dora-rs/dora#3046). Buffering, restart detection
+and correlation are identical; only the waiting is gone. Deadlines
+become the caller's responsibility, since there is none to enforce.
+
+```rust
+// once per loop iteration, for each outstanding request
+match events.try_recv_service_response(&rid, ExpectedServers::One(&server))? {
+    Some(Event::Input { data, .. }) => complete(data),
+    None => {} // not ready — get on with the rest of the iteration
+    _ => unreachable!(),
+}
+```
+
+> **Ordering matters.** The polls and your own `recv()` read the same
+> stream, so whichever runs first consumes what is there. A poll
+> correlates the reply it wants and buffers everything else for a later
+> `recv()`, so polling first loses nothing. The reverse is not true: a
+> reply consumed by `recv()` is gone, and no later poll can see it.
+> Poll first, then drain your own events.
+
+`try_recv_action_result` is the same for actions.
+
+#### Fanning one request out to several servers
+
+`send_service_request` mints a fresh `request_id` per call, so it cannot
+express one logical request sent to several nodes. Use
+`send_service_request_with_id` with a shared id, and await it with
+`ExpectedServers::AnyOf`, which accepts whichever node answers first:
+
+```rust
+let request_id = DoraNode::new_request_id();
+for server in &servers {
+    node.send_service_request_with_id(
+        output.clone(), params.clone(), data.clone(), request_id.clone(),
+    )?;
+}
+let reply = events
+    .recv_service_response_from(&request_id, ExpectedServers::AnyOf(&servers), timeout)
+    .await?;
+```
+
+The server set only governs *restart* detection — which reply matches is
+decided by `request_id` alone. `ExpectedServers::Any` skips restart
+correlation entirely, for when the responder is not known up front.
+
 ## 3. Action (goal/feedback/result)
 
 A client sends a goal and receives periodic feedback plus a final result.
@@ -348,8 +401,14 @@ into `dora-node-api.h` (dora-rs/dora#2686).
 | `DoraNode::new_request_id` / `new_goal_id` | `new_request_id()` / `new_goal_id()` |
 | `DoraNode::send_service_request` | `send_service_request(...)` / `send_arrow_service_request(...)` |
 | `DoraNode::send_service_response` | `send_service_response(...)` |
+| `DoraNode::send_service_request_with_id` | `send_service_request_with_id(...)` |
 | `EventStream::recv_service_response` | `recv_service_response(...)` |
 | `EventStream::recv_action_result` | `recv_action_result(...)` |
+| `EventStream::try_recv_service_response` | `try_recv_service_response(...)` |
+| `EventStream::try_recv_action_result` | `try_recv_action_result(...)` |
+| `EventStream::recv_service_response_from` | `recv_service_response_from(...)` |
+| `EventStream::recv_action_result_from` | `recv_action_result_from(...)` |
+| `ExpectedServers::AnyOf` / `::Any` | a `Vec<String>` of node ids / an empty one |
 | `GOAL_STATUS_SUCCEEDED` / `_ABORTED` / `_CANCELED` | `goal_status_succeeded()` / `_aborted()` / `_canceled()` |
 | `PatternError` | `DoraPatternStatus` |
 
@@ -385,6 +444,36 @@ auto input = event_as_input_with_metadata(std::move(event));
 send_service_response(
     node.send_output, "response", result, std::move(input.metadata));
 ```
+
+A C++ node that cannot block uses `try_recv_service_response`, which
+returns `DoraPatternStatus::NotReady` instead of waiting — the same
+convention `try_next_event` already uses for plain events:
+
+```cpp
+// per loop iteration, for each outstanding request
+auto poll = try_recv_service_response(node.events, request_id, "server");
+switch (poll.status) {
+case DoraPatternStatus::Matched:
+    complete(event_as_input(std::move(poll.event)));
+    break;
+case DoraPatternStatus::NotReady:
+    break; // nothing to do, and no time spent
+default:
+    std::cerr << std::string(poll.error) << std::endl;
+}
+```
+
+The same ordering rule as in Rust applies: poll before consuming events
+yourself, or a reply your own `next_event` picked up is lost. Passing an
+empty `server_node_id` accepts a reply from any node.
+
+For a request fanned out to several servers, mint the id once with
+`new_request_id()`, send each copy with `send_service_request_with_id`,
+and await them with `recv_service_response_from` /
+`try_recv_service_response_from`, which take a `Vec<String>` of
+acceptable responders (empty means any).
+
+**Example**: `examples/c++-service-action/nodes/polling-client.cc`
 
 For actions, set `goal_id` on the metadata (`metadata->set_goal_id(...)`),
 send with `send_output_with_metadata`, and wait with `recv_action_result`.

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -171,6 +171,15 @@ The server set only governs *restart* detection — which reply matches is
 decided by `request_id` alone. `ExpectedServers::Any` skips restart
 correlation entirely, for when the responder is not known up front.
 
+A restart means different things to the two variants, and the deadline
+follows that. For `One` it is terminal: the request is orphaned and its
+deadline is dropped with it. For `AnyOf` it is only a notification — the
+other candidates may still answer — so the correlation *and its
+deadline* survive, still running on the original clock. That last part
+matters: if a restart reset the clock, a node that keeps flapping would
+hold the correlation open indefinitely and the caller would never see
+`Timeout`.
+
 ## 3. Action (goal/feedback/result)
 
 A client sends a goal and receives periodic feedback plus a final result.

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -128,8 +128,16 @@ match events.try_recv_service_response(&rid, ExpectedServers::One(&server), time
 ```
 
 The clock starts at that first poll rather than at send time, and the
-first deadline registered for an id wins. `cancel_correlation` drops a
-request that will never be polled again.
+first deadline registered for an id wins.
+
+A poll drops its own registration on a match, an error or expiry.
+`cancel_correlation` releases one the node abandons and will never poll
+again; without it that entry lives until the stream is dropped. It is
+available in both Rust and C++ and is a no-op for an unknown id.
+
+In C++ the timeout is `timeout_ms`, where `0` means *no deadline* rather
+than "return immediately" — a poll never blocks, so there is nothing to
+time out. That inverts the usual convention for a timeout argument.
 
 > **Ordering matters.** The polls and your own `recv()` read the same
 > stream, so whichever runs first consumes what is there. A poll

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -180,6 +180,12 @@ matters: if a restart reset the clock, a node that keeps flapping would
 hold the correlation open indefinitely and the caller would never see
 `Timeout`.
 
+What decides this is how many candidates there actually are, not which
+spelling the caller used. A C++ list holding exactly one id — and the
+single-server polls, which wrap their lone id the same way — resolve to
+`One`, so their restart releases the deadline rather than leaving an
+entry behind.
+
 ## 3. Action (goal/feedback/result)
 
 A client sends a goal and receives periodic feedback plus a final result.

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -105,18 +105,31 @@ afford that: the wait stalls everything else, and on a wedged server it
 stalls for the whole timeout.
 
 `try_recv_service_response` polls instead, returning `Ok(None)` when the
-reply has not arrived (dora-rs/dora#3046). Buffering, restart detection
-and correlation are identical; only the waiting is gone. Deadlines
-become the caller's responsibility, since there is none to enforce.
+reply has not arrived (dora-rs/dora#3046). Buffering, restart detection,
+correlation *and the deadline* are all handled as in the blocking form;
+only the waiting is gone.
+
+The framework owns the timeout: the first poll carrying one registers a
+deadline for that `request_id`, and a later poll past it returns
+`PatternError::Timeout` once. A caller passes the same timeout every
+iteration and reacts to `Timeout` like any other outcome — it does not
+sweep deadlines itself. Pass `None` to poll without one.
 
 ```rust
 // once per loop iteration, for each outstanding request
-match events.try_recv_service_response(&rid, ExpectedServers::One(&server))? {
-    Some(Event::Input { data, .. }) => complete(data),
-    None => {} // not ready — get on with the rest of the iteration
+let timeout = Some(Duration::from_secs(5));
+match events.try_recv_service_response(&rid, ExpectedServers::One(&server), timeout) {
+    Ok(Some(Event::Input { data, .. })) => complete(data),
+    Ok(None) => {}                        // not ready — get on with the iteration
+    Err(PatternError::Timeout) => give_up(),
+    Err(e) => return Err(e.into()),
     _ => unreachable!(),
 }
 ```
+
+The clock starts at that first poll rather than at send time, and the
+first deadline registered for an id wins. `cancel_correlation` drops a
+request that will never be polled again.
 
 > **Ordering matters.** The polls and your own `recv()` read the same
 > stream, so whichever runs first consumes what is there. A poll
@@ -451,19 +464,24 @@ convention `try_next_event` already uses for plain events:
 
 ```cpp
 // per loop iteration, for each outstanding request
-auto poll = try_recv_service_response(node.events, request_id, "server");
+auto poll = try_recv_service_response(node.events, request_id, "server", 5000);
 switch (poll.status) {
 case DoraPatternStatus::Matched:
     complete(event_as_input(std::move(poll.event)));
     break;
 case DoraPatternStatus::NotReady:
     break; // nothing to do, and no time spent
+case DoraPatternStatus::Timeout:
+    give_up(); // the registered deadline lapsed; reported once
+    break;
 default:
     std::cerr << std::string(poll.error) << std::endl;
 }
 ```
 
-The same ordering rule as in Rust applies: poll before consuming events
+`timeout_ms` works as in Rust — registered once per `request_id` by the
+framework, reported as `Timeout` when it lapses; pass `0` for no
+deadline. The same ordering rule applies: poll before consuming events
 yourself, or a reply your own `next_event` picked up is lost. Passing an
 empty `server_node_id` accepts a reply from any node.
 

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -135,6 +135,15 @@ A poll drops its own registration on a match, an error or expiry.
 again; without it that entry lives until the stream is dropped. It is
 available in both Rust and C++ and is a no-op for an unknown id.
 
+It releases the deadline only. A reply that arrives *after* its request
+timed out or was cancelled matches no live correlation, so the next poll
+buffers it for the caller's event loop like any other unrelated input.
+Reading events clears those; a node that only polls and never reads
+keeps one buffered event per unclaimed reply. Do not work around that
+with a loop that reads until empty — the non-blocking read returns
+buffered events first but then falls through to the live stream, so it
+can consume and discard a reply a later poll was going to correlate.
+
 In C++ the timeout is `timeout_ms`, where `0` means *no deadline* rather
 than "return immediately" — a poll never blocks, so there is nothing to
 time out. That inverts the usual convention for a timeout argument.

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -118,7 +118,7 @@ sweep deadlines itself. Pass `None` to poll without one.
 ```rust
 // once per loop iteration, for each outstanding request
 let timeout = Some(Duration::from_secs(5));
-match events.try_recv_service_response(&rid, ExpectedServers::One(&server), timeout) {
+match events.try_recv_service_response(&rid, &server, timeout) {
     Ok(Some(Event::Input { data, .. })) => complete(data),
     Ok(None) => {}                        // not ready — get on with the iteration
     Err(PatternError::Timeout) => give_up(),
@@ -144,9 +144,11 @@ with a loop that reads until empty — the non-blocking read returns
 buffered events first but then falls through to the live stream, so it
 can consume and discard a reply a later poll was going to correlate.
 
-In C++ the timeout is `timeout_ms`, where `0` means *no deadline* rather
-than "return immediately" — a poll never blocks, so there is nothing to
-time out. That inverts the usual convention for a timeout argument.
+In C++ the timeout is `timeout_ms`, and it means the same thing for the
+polls as for the blocking waits: `0` expires immediately, and
+`UINT64_MAX` is the spelling for "no practical deadline". Moving a
+request between the two forms therefore never silently changes its
+deadline.
 
 > **Ordering matters.** The polls and your own `recv()` read the same
 > stream, so whichever runs first consumes what is there. A poll
@@ -397,6 +399,16 @@ in §2 and §3 above). They:
    instance without hanging.
 3. Buffer non-matching events so your main event loop keeps working.
 
+**With several requests in flight, handle the event yourself too.** A
+`NodeRestarted` is reported to the *one* correlation that consumes it —
+the wait or poll that happened to be reading the stream when it arrived.
+Other requests outstanding against the same server are not told, and
+would otherwise sit until their own deadlines lapse. A restart that lands
+between calls reaches your own `recv()` as `Event::NodeRestarted { id }`
+instead. So a node with more than one request in flight should react to
+that event directly: `cancel_correlation` each request outstanding
+against the restarted node, then resend under a fresh `request_id`.
+
 Alternatively, handle the fault manually:
 
 ```rust
@@ -453,6 +465,8 @@ into `dora-node-api.h` (dora-rs/dora#2686).
 | `EventStream::try_recv_action_result` | `try_recv_action_result(...)` |
 | `EventStream::recv_service_response_from` | `recv_service_response_from(...)` |
 | `EventStream::recv_action_result_from` | `recv_action_result_from(...)` |
+| `EventStream::try_recv_service_response_from` | `try_recv_service_response_from(...)` |
+| `EventStream::try_recv_action_result_from` | `try_recv_action_result_from(...)` |
 | `ExpectedServers::AnyOf` / `::Any` | a `Vec<String>` of node ids / an empty one |
 | `GOAL_STATUS_SUCCEEDED` / `_ABORTED` / `_CANCELED` | `goal_status_succeeded()` / `_aborted()` / `_canceled()` |
 | `PatternError` | `DoraPatternStatus` |

--- a/examples/c++-service-action/dataflow.yml
+++ b/examples/c++-service-action/dataflow.yml
@@ -10,10 +10,22 @@ nodes:
     outputs:
       - request
 
+  # A second client for the same server, this one non-blocking: several
+  # requests in flight at a time, polled without blocking (dora-rs/dora#3046).
+  - id: cxx-polling-client
+    path: build/polling_client
+    inputs:
+      # No tick: this node runs on its own wall clock and lets the
+      # correlated polls own the event stream entirely.
+      response: cxx-service-server/response
+    outputs:
+      - request
+
   - id: cxx-service-server
     path: build/service_server
     inputs:
       request: cxx-service-client/request
+      polling_request: cxx-polling-client/request
     outputs:
       - response
 

--- a/examples/c++-service-action/nodes/polling-client.cc
+++ b/examples/c++-service-action/nodes/polling-client.cc
@@ -1,0 +1,230 @@
+// A service client that never blocks (dora-rs/dora#3046).
+//
+// `service-client.cc` in this example is the simple shape: send one
+// request, block in `recv_service_response` until it comes back, repeat.
+// That is fine when waiting is all the node has to do.
+//
+// This node is the other shape — the one a single-threaded node driven by
+// something other than dora needs:
+//
+//   * several requests are in flight at once,
+//   * the node's own schedule (here a wall clock; in a real node an
+//     external transport, a sensor, a control loop) must keep running,
+//   * so it can never afford to stop inside a receive.
+//
+// It uses `try_recv_service_response`, which returns `NotReady` instead
+// of waiting, and keeps a small table of outstanding requests. Every
+// iteration polls each entry exactly once, so the loop is bounded no
+// matter how slow or wedged a server is.
+//
+// ---------------------------------------------------------------------
+// ONE RULE WORTH KNOWING
+//
+// The correlated polls and `next_event` read the *same* event stream, so
+// whichever runs first consumes what is there. A poll correlates the
+// reply it wants and buffers everything else for a later `next_event`,
+// so polling first never loses anything. The reverse is not true: a
+// reply handed to `next_event` has been consumed, and no later poll can
+// see it.
+//
+// This node therefore lets the polls own the stream completely — it has
+// no tick input and never calls `next_event`. Shutdown arrives through
+// the polls as `StreamEnded`. A node that does need its own dora inputs
+// should poll first, then drain with `try_next_event`.
+// ---------------------------------------------------------------------
+
+#include <dora-node-api.h>
+
+#include <chrono>
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace
+{
+
+constexpr const char *SERVER = "cxx-service-server";
+
+// How many requests this demo completes before exiting.
+constexpr int REQUEST_BUDGET = 6;
+
+// How long a request may stay outstanding. The framework applies no
+// deadline to a poll — that is the trade for not blocking — so the
+// client keeps its own, per request.
+constexpr auto REQUEST_DEADLINE = std::chrono::seconds(5);
+
+// How many requests may be outstanding at once. This is the property
+// under test: a blocking client is structurally limited to one.
+constexpr std::size_t MAX_IN_FLIGHT = 3;
+
+// How long the node sleeps between sweeps. Its own choice, which is the
+// point — nothing here is dictated by how fast a server replies.
+constexpr auto POLL_INTERVAL = std::chrono::milliseconds(10);
+
+using Clock = std::chrono::steady_clock;
+
+struct Pending
+{
+    std::string request_id;
+    std::uint8_t a;
+    std::uint8_t b;
+    Clock::time_point sent_at;
+};
+
+/// Fire one request without waiting for it, returning its correlation id.
+///
+/// `new_request_id()` + `send_service_request_with_id` rather than
+/// `send_service_request`, because the id is needed *before* the reply
+/// comes back — it goes straight into the pending table.
+std::string send_one(DoraNode &node, std::uint8_t a, std::uint8_t b)
+{
+    auto request_id = std::string(new_request_id());
+
+    std::vector<std::uint8_t> payload{a, b};
+    rust::Slice<const std::uint8_t> slice{payload.data(), payload.size()};
+
+    auto result = send_service_request_with_id(
+        node.send_output,
+        "request",
+        slice,
+        new_metadata(),
+        request_id);
+    const std::string error(result.error);
+    if (!error.empty())
+    {
+        std::cerr << "[polling-client] send failed: " << error << std::endl;
+        return {};
+    }
+    return request_id;
+}
+
+/// Outcome of one sweep over the outstanding requests.
+struct SweepResult
+{
+    int completed = 0;
+    bool stream_ended = false;
+};
+
+/// Poll every outstanding request exactly once.
+///
+/// Always returns promptly: `NotReady` costs nothing and simply leaves
+/// the entry in the table for the next sweep.
+SweepResult sweep(DoraNode &node, std::vector<Pending> &pending)
+{
+    SweepResult out;
+    std::vector<Pending> still_waiting;
+    still_waiting.reserve(pending.size());
+    const auto now = Clock::now();
+
+    for (auto &entry : pending)
+    {
+        auto result = try_recv_service_response(node.events, entry.request_id, SERVER);
+
+        switch (result.status)
+        {
+        case DoraPatternStatus::Matched:
+        {
+            auto input = event_as_input(std::move(result.event));
+            const unsigned sum = input.data.empty() ? 0u : static_cast<unsigned>(input.data[0]);
+            std::cout << "[polling-client] " << entry.request_id << ": "
+                      << static_cast<unsigned>(entry.a) << " + " << static_cast<unsigned>(entry.b)
+                      << " = " << sum << std::endl;
+            out.completed++;
+            break;
+        }
+
+        case DoraPatternStatus::NotReady:
+            if (now - entry.sent_at > REQUEST_DEADLINE)
+            {
+                std::cerr << "[polling-client] deadline passed for " << entry.request_id
+                          << std::endl;
+            }
+            else
+            {
+                still_waiting.push_back(entry);
+            }
+            break;
+
+        case DoraPatternStatus::StreamEnded:
+            // The dataflow is shutting down; stop cleanly.
+            out.stream_ended = true;
+            break;
+
+        case DoraPatternStatus::ServerRestarted:
+            // The in-flight correlation is orphaned; a real client would
+            // resend against the new instance.
+            std::cerr << "[polling-client] server restarted, dropping " << entry.request_id
+                      << std::endl;
+            break;
+
+        default:
+            std::cerr << "[polling-client] " << entry.request_id
+                      << " failed: " << std::string(result.error) << std::endl;
+            break;
+        }
+
+        if (out.stream_ended)
+        {
+            // Leave `pending` untouched: entries after this one have not
+            // been looked at, so replacing it with the partial
+            // `still_waiting` would under-report what is outstanding.
+            return out;
+        }
+    }
+
+    pending = std::move(still_waiting);
+    return out;
+}
+
+} // namespace
+
+int main()
+{
+    auto dora_node = init_dora_node();
+
+    std::vector<Pending> pending;
+    std::uint8_t next = 0;
+    int completed = 0;
+    int issued = 0;
+
+    while (completed < REQUEST_BUDGET || !pending.empty())
+    {
+        // The node's own work, on its own schedule — never gated on a
+        // reply. This is what a blocking receive would have stalled: it
+        // fills the pipeline to MAX_IN_FLIGHT before looking at any of
+        // the answers.
+        while (issued < REQUEST_BUDGET && pending.size() < MAX_IN_FLIGHT)
+        {
+            const auto a = next;
+            const auto b = static_cast<std::uint8_t>(next + 10);
+            auto request_id = send_one(dora_node, a, b);
+            if (request_id.empty())
+            {
+                break;
+            }
+            pending.push_back(Pending{request_id, a, b, Clock::now()});
+            std::cout << "[polling-client] sent " << request_id << ": "
+                      << static_cast<unsigned>(a) << " + " << static_cast<unsigned>(b) << " ("
+                      << pending.size() << " in flight)" << std::endl;
+            next++;
+            issued++;
+        }
+
+        auto result = sweep(dora_node, pending);
+        completed += result.completed;
+        if (result.stream_ended)
+        {
+            std::cerr << "[polling-client] stream ended with " << pending.size()
+                      << " request(s) outstanding" << std::endl;
+            return 0;
+        }
+
+        std::this_thread::sleep_for(POLL_INTERVAL);
+    }
+
+    std::cout << "[polling-client] completed " << completed
+              << " request(s), several in flight at a time, never blocking" << std::endl;
+    return 0;
+}

--- a/examples/c++-service-action/nodes/polling-client.cc
+++ b/examples/c++-service-action/nodes/polling-client.cc
@@ -17,6 +17,11 @@
 // iteration polls each entry exactly once, so the loop is bounded no
 // matter how slow or wedged a server is.
 //
+// Note what is *not* here: no deadline arithmetic. The timeout passed to
+// each poll is registered by the framework against the request id, which
+// then reports `Timeout` once when it lapses. The table holds only what
+// this node needs to print a result.
+//
 // ---------------------------------------------------------------------
 // ONE RULE WORTH KNOWING
 //
@@ -50,10 +55,10 @@ constexpr const char *SERVER = "cxx-service-server";
 // How many requests this demo completes before exiting.
 constexpr int REQUEST_BUDGET = 6;
 
-// How long a request may stay outstanding. The framework applies no
-// deadline to a poll — that is the trade for not blocking — so the
-// client keeps its own, per request.
-constexpr auto REQUEST_DEADLINE = std::chrono::seconds(5);
+// How long a request may stay outstanding. Passed to every poll; the
+// framework registers it once per request_id and reports Timeout when
+// it lapses, so this node keeps no deadline bookkeeping of its own.
+constexpr std::uint64_t REQUEST_TIMEOUT_MS = 5000;
 
 // How many requests may be outstanding at once. This is the property
 // under test: a blocking client is structurally limited to one.
@@ -63,14 +68,11 @@ constexpr std::size_t MAX_IN_FLIGHT = 3;
 // point — nothing here is dictated by how fast a server replies.
 constexpr auto POLL_INTERVAL = std::chrono::milliseconds(10);
 
-using Clock = std::chrono::steady_clock;
-
 struct Pending
 {
     std::string request_id;
     std::uint8_t a;
     std::uint8_t b;
-    Clock::time_point sent_at;
 };
 
 /// Fire one request without waiting for it, returning its correlation id.
@@ -116,11 +118,11 @@ SweepResult sweep(DoraNode &node, std::vector<Pending> &pending)
     SweepResult out;
     std::vector<Pending> still_waiting;
     still_waiting.reserve(pending.size());
-    const auto now = Clock::now();
 
     for (auto &entry : pending)
     {
-        auto result = try_recv_service_response(node.events, entry.request_id, SERVER);
+        auto result = try_recv_service_response(
+            node.events, entry.request_id, SERVER, REQUEST_TIMEOUT_MS);
 
         switch (result.status)
         {
@@ -136,15 +138,16 @@ SweepResult sweep(DoraNode &node, std::vector<Pending> &pending)
         }
 
         case DoraPatternStatus::NotReady:
-            if (now - entry.sent_at > REQUEST_DEADLINE)
-            {
-                std::cerr << "[polling-client] deadline passed for " << entry.request_id
-                          << std::endl;
-            }
-            else
-            {
-                still_waiting.push_back(entry);
-            }
+            // Still outstanding, and still within its deadline — the
+            // framework would have said Timeout otherwise. No clock
+            // arithmetic here on purpose.
+            still_waiting.push_back(entry);
+            break;
+
+        case DoraPatternStatus::Timeout:
+            // The deadline registered on the first poll has lapsed.
+            // Reported once, then the registration is gone.
+            std::cerr << "[polling-client] timed out: " << entry.request_id << std::endl;
             break;
 
         case DoraPatternStatus::StreamEnded:
@@ -204,7 +207,7 @@ int main()
             {
                 break;
             }
-            pending.push_back(Pending{request_id, a, b, Clock::now()});
+            pending.push_back(Pending{request_id, a, b});
             std::cout << "[polling-client] sent " << request_id << ": "
                       << static_cast<unsigned>(a) << " + " << static_cast<unsigned>(b) << " ("
                       << pending.size() << " in flight)" << std::endl;

--- a/examples/c++-service-action/nodes/polling-client.cc
+++ b/examples/c++-service-action/nodes/polling-client.cc
@@ -106,6 +106,14 @@ std::string send_one(DoraNode &node, std::uint8_t a, std::uint8_t b)
 struct SweepResult
 {
     int completed = 0;
+    /// Requests that reached a terminal outcome without a reply —
+    /// timed out, orphaned by a restart, or errored.
+    ///
+    /// Counted separately from `completed` but tracked just as
+    /// carefully: a request that ends without an answer has still
+    /// *ended*, and the main loop needs to know that or it will wait
+    /// for a reply that is never coming.
+    int failed = 0;
     bool stream_ended = false;
 };
 
@@ -148,6 +156,7 @@ SweepResult sweep(DoraNode &node, std::vector<Pending> &pending)
             // The deadline registered on the first poll has lapsed.
             // Reported once, then the registration is gone.
             std::cerr << "[polling-client] timed out: " << entry.request_id << std::endl;
+            out.failed++;
             break;
 
         case DoraPatternStatus::StreamEnded:
@@ -160,11 +169,13 @@ SweepResult sweep(DoraNode &node, std::vector<Pending> &pending)
             // resend against the new instance.
             std::cerr << "[polling-client] server restarted, dropping " << entry.request_id
                       << std::endl;
+            out.failed++;
             break;
 
         default:
             std::cerr << "[polling-client] " << entry.request_id
                       << " failed: " << std::string(result.error) << std::endl;
+            out.failed++;
             break;
         }
 
@@ -190,9 +201,16 @@ int main()
     std::vector<Pending> pending;
     std::uint8_t next = 0;
     int completed = 0;
+    int failed = 0;
     int issued = 0;
 
-    while (completed < REQUEST_BUDGET || !pending.empty())
+    // Terminate on requests *settled*, not requests answered. A request
+    // that timed out or was orphaned is finished too; waiting for it to
+    // "complete" would spin here forever, and — because `sweep` only
+    // polls entries still in `pending` — with nothing left to poll the
+    // node would never see `StreamEnded` either, so it could not even
+    // shut down with the dataflow.
+    while (completed + failed < REQUEST_BUDGET || !pending.empty())
     {
         // The node's own work, on its own schedule — never gated on a
         // reply. This is what a blocking receive would have stalled: it
@@ -205,6 +223,11 @@ int main()
             auto request_id = send_one(dora_node, a, b);
             if (request_id.empty())
             {
+                // A request that never reached the wire is settled too.
+                // Counting it keeps a persistently failing send from
+                // retrying forever.
+                failed++;
+                issued++;
                 break;
             }
             pending.push_back(Pending{request_id, a, b});
@@ -217,6 +240,7 @@ int main()
 
         auto result = sweep(dora_node, pending);
         completed += result.completed;
+        failed += result.failed;
         if (result.stream_ended)
         {
             std::cerr << "[polling-client] stream ended with " << pending.size()
@@ -227,7 +251,11 @@ int main()
         std::this_thread::sleep_for(POLL_INTERVAL);
     }
 
-    std::cout << "[polling-client] completed " << completed
-              << " request(s), several in flight at a time, never blocking" << std::endl;
+    std::cout << "[polling-client] completed " << completed << " request(s)";
+    if (failed > 0)
+    {
+        std::cout << ", " << failed << " unanswered";
+    }
+    std::cout << ", several in flight at a time, never blocking" << std::endl;
     return 0;
 }

--- a/examples/c++-service-action/nodes/polling-client.cc
+++ b/examples/c++-service-action/nodes/polling-client.cc
@@ -36,6 +36,18 @@
 // no tick input and never calls `next_event`. Shutdown arrives through
 // the polls as `StreamEnded`. A node that does need its own dora inputs
 // should poll first, then drain with `try_next_event`.
+//
+// That is fine for a demo that exits after a fixed number of requests.
+// A long-lived node should know the cost: anything a poll consumes but
+// does not want — notably a reply that arrives after its request timed
+// out — is buffered for `next_event`, and a node that never reads events
+// never releases it. `cancel_correlation` frees the deadline, not the
+// buffered reply.
+//
+// Do not "fix" that with a loop that reads until empty: `try_next_event`
+// hands back buffered events first but then falls through to the live
+// stream, so such a loop can consume and discard a reply a later poll
+// was going to correlate. Read events you can classify yourself.
 // ---------------------------------------------------------------------
 
 #include <dora-node-api.h>

--- a/examples/c++-service-action/run.rs
+++ b/examples/c++-service-action/run.rs
@@ -5,6 +5,7 @@ use std::{env::consts::EXE_SUFFIX, path::Path, time::Duration};
 /// Nodes to compile: (source file stem, output binary name).
 const NODES: &[(&str, &str)] = &[
     ("service-client", "service_client"),
+    ("polling-client", "polling_client"),
     ("service-server", "service_server"),
     ("action-client", "action_client"),
     ("action-server", "action_server"),


### PR DESCRIPTION
Closes #3046.

## What

#2853 gave the C++ binding the Service and Action patterns. The server side
was complete; the client side was only usable from a node that can afford to
stop and wait. This adds the three pieces #3046 asked for, all additive — no
existing signature changes.

### 1. Non-blocking correlated receive

| Rust | C++ |
|------|-----|
| `EventStream::try_recv_service_response` | `try_recv_service_response(...)` |
| `EventStream::try_recv_action_result` | `try_recv_action_result(...)` |

Returns `Ok(None)` / `DoraPatternStatus::NotReady` instead of waiting.
Buffering, restart detection, correlation **and the deadline** are all
handled as in the blocking form; only the waiting is gone.

The framework owns the timeout. The first poll carrying one registers a
deadline against the correlation id, and a later poll past it returns
`Timeout` exactly once — the registration is dropped as it expires, and also
on a match or terminal error. A caller passes the same timeout every
iteration and reacts to `Timeout` like any other outcome; it does not sweep
deadlines itself. Rust takes `Option<Duration>`; C++ spells "no deadline" as
`timeout_ms == 0`.

Decisions worth a look:

- **The clock starts at the first deadline-carrying poll, not at send time.**
  `EventStream` does not see the send, and threading registration through
  `DoraNode` would couple the two for no practical gain — a client polls in
  the same iteration it sends.
- **The first deadline registered for an id wins.** Otherwise a caller
  recomputing a relative timeout each iteration would push its own deadline
  forward forever and never expire.
- **A reply that arrived before the deadline always wins over it**, whether it
  was already buffered or still unread on the stream — the deadline is
  consulted only after everything available has been examined. So `Timeout`
  means the reply had genuinely not arrived, not that the caller polled late.
- `cancel_correlation` (Rust **and** C++) drops a registration for a request
  that will never be polled again — a peer died, the operator cancelled, the
  reply stopped mattering. Without it that entry lives until the stream is
  dropped, which on a node running for days is an unbounded slow leak. It is
  a no-op for an unknown id, so a cancel racing a reply is harmless.
- **`timeout_ms == 0` means "no deadline", not "return immediately."** That
  is right here — a poll never blocks, so there is nothing to time out — but
  it inverts the usual convention for a timeout argument, so both docs now
  say so explicitly. Flagging it in case a different spelling is preferred.
- For actions the timeout bounds the *whole goal*, not the gap between
  feedback messages.

`NotReady` follows the convention `try_next_event` already established for
plain events, and stays distinct from `Timeout`: "not yet" and "too late"
are different answers, and only the second is terminal.

### 2. Caller-supplied `request_id`

| Rust | C++ |
|------|-----|
| `DoraNode::send_service_request_with_id` | `send_service_request_with_id(...)` |

`send_service_request` mints a fresh id per call, so it cannot express one
logical request fanned out to several nodes. It now delegates to the new
variant and its warning points at it. Existing behaviour is unchanged.

### 3. Correlation without a single fixed server

New `ExpectedServers` enum — `One(&NodeId)` / `AnyOf(&[NodeId])` / `Any` —
plus `recv_service_response_from`, `recv_action_result_from` and the `_from`
polls. In C++ these take a `Vec<String>`; empty means "any".

The existing `recv_service_response(request_id, &NodeId, timeout)` delegates
to `ExpectedServers::One`, so nothing breaks.

Two semantics worth checking in review:

- **The server set governs only restart detection.** Which reply matches is
  decided by `request_id` alone, so a fan-out reply is correlated even from a
  node the caller never listed. There is a test pinning this.
- **`AnyOf` reports a restart of any listed node**, naming that node (taken
  from the event, not the caller's expectation). For a first-reply-wins
  fan-out that is a notification rather than a verdict — the other candidates
  may still answer — so the caller can simply wait again. Buffered events,
  the correlation **and its deadline** survive across calls.
- **What counts as `One` is decided by candidate count, not spelling.** The
  C++ single-server polls wrap their lone id in a slice, and a one-element
  `Vec` passed to a `_from` variant is the same thing — both resolve to
  `One`, so their restart releases the deadline. Routing them through a
  one-element `AnyOf` (as an earlier revision did) kept the entry alive and
  leaked it on the give-up path.
- **A restart therefore affects the deadline differently per variant.** For
  `One` it is terminal: the request is orphaned and its deadline is dropped
  with it. For `AnyOf` the deadline keeps running on its *original* clock. An
  earlier revision dropped it in both cases, which meant a caller following
  the documented "just wait again" advice re-registered a fresh deadline
  every poll — so a flapping node could hold the correlation open forever and
  `Timeout` would never fire. Caught in review; both branches are now pinned
  by tests.

## One thing that came out of building the example

The polls and the caller's own `next_event` read the **same** stream, so
whichever runs first consumes what is there. A poll correlates the reply it
wants and buffers everything else, so polling first loses nothing. The
reverse is not true: a reply handed to `next_event` is gone, and no later
poll can see it.

My first version of the example got this wrong and silently timed out every
request. That ordering rule is now documented in `docs/patterns.md`, the C++
README, and prominently in the example itself. It may be worth a maintainer's
eye — it is inherent to polling a single shared stream rather than something
this PR introduces, but it is a sharp edge.

## Why the deadline part is here

The first revision of this PR punted timeouts to the caller. Re-reading
#3046's acceptance criteria — *"timeout and server-restart handling for those
requests come from the framework rather than from caller-side bookkeeping"* —
that only got half way: restarts came from the framework, deadlines did not,
and the issue explicitly expected to be able to delete its deadline sweep.
The example proves the difference — `polling-client.cc` no longer does any
clock arithmetic.

## `DoraEventType::NodeRestarted`

`Event::NodeRestarted` had no C++ variant and no accessor, so it fell through
`event_type`'s catch-all and arrived as `Unknown` — delivered but
unidentifiable. Added the variant plus `event_as_node_restarted`, following
`NodeFailed` / `Reload`, whose own doc comment gives this same reason.

This bears on the `ServerRestarted` contract. The correlation reports it for a
restart that lands *while a wait or poll is running*, since it owns the stream
then — verified by driving a blocking `recv_service_response` against a restart
on the stream. A restart landing between calls belongs to the node's own loop,
and that route used to drop it silently, leaving the next request to wait out
its full deadline against a server the node had already been told about. The
bridge doc and README now scope which restarts go where.

## Two confirmed issues left open for a maintainer's call

Both reproduced, both raised in the PR discussion rather than fixed here.

**A `NodeRestarted` reaches only the first-polled correlation.** Less severe
since `DoraEventType::NodeRestarted` landed: the restart now reaches the node's
own loop, so a client can cancel and resend the others itself (the C++ README
shows the loop). The framework still does not do it for you.

Originally: With N requests
in flight to one server, one gets `ServerRestarted` and the other N-1 wait out
their deadlines; the restart is buffered and never re-classified. Fixing it
means new per-correlation state and making registration unconditional, which
widens the surface `cancel_correlation` manages. Polling-only, so
`wait_for_correlation` is unaffected.

**`pending_passthrough` is unbounded and escapes the per-input queue policy** (now tracked in #3197)
applied in `Scheduler::add_event`, so a poll-only node with a high-rate input
grows where it previously dropped oldest. I started on a cap and backed out: the
buffer is written by `wait_for_correlation` too, so any cap changes behaviour for
API shipped in #2853, for users who never touch the polls.

## Known limitation: late replies stay buffered

A reply that arrives after its request timed out or was cancelled matches no
live correlation, so the next poll buffers it for the caller's event loop.
`cancel_correlation` releases the deadline, not that buffered event. Measured:
three unclaimed replies leave the buffer at three, three `cancel_correlation`
calls leave it at three, three `recv()` calls take it to zero.

Not a correctness issue — nothing is lost or misrouted — and only reachable by
a client that polls and never reads events at all; any node with inputs of its
own drains as a matter of course. Growth is one buffered event per unclaimed
reply, so it tracks the failure path rather than steady-state traffic.

Worth flagging because the obvious mitigation is wrong: `try_recv` returns
buffered events first but then falls through to the live stream, so a loop
reading until empty can consume and discard a reply a later poll was going to
correlate. Confirmed by driving it. The docs now say so in both APIs and in the
example.

A buffer-only drain would close this properly. That is new API surface and felt
like the wrong thing to add here, so it is documented rather than fixed — happy
to do it in a follow-up if you would rather have it.

## Cost note

One poll drains *all* currently-ready events, so it is O(ready events), not
O(1). That is exactly what lets it find a reply queued behind unrelated
traffic. It never waits, but a large ready burst is still a large amount of
work in one call. Documented on the method.

## Testing

**New example node** — `examples/c++-service-action/nodes/polling-client.cc`:
a client with several requests in flight that never blocks. Already covered
by the nightly `examples` job, which runs `cargo run --example
cxx-service-action` and builds every node in the directory. Verified against
a live daemon:

```
[polling-client] sent 019fd0f3-5a24-...: 0 + 10 (1 in flight)
[polling-client] sent 019fd0f3-5a25-...: 1 + 11 (2 in flight)
[polling-client] sent 019fd0f3-5a25-...: 2 + 12 (3 in flight)
[polling-client] 019fd0f3-5a24-...: 0 + 10 = 10
[polling-client] 019fd0f3-5a25-...: 1 + 11 = 12
[polling-client] 019fd0f3-5a25-...: 2 + 12 = 14
...
[polling-client] completed 6 request(s), several in flight at a time, never blocking
```

All five nodes exit `finished successfully`.

The failure path is verified too, since the happy path is all CI walks. The
service server already skips requests whose payload is under two bytes
without replying, so a one-byte payload plus a short timeout makes every
request time out. The client prints `completed 0 request(s), 6 unanswered`
and exits immediately. An earlier revision hung there instead — it counted
only answered requests toward its budget, so an unanswered one left it
spinning with nothing in `pending` to poll, which also meant it never saw
`StreamEnded` and held up dataflow teardown.

**44 new unit/integration tests** — `ExpectedServers` membership, each
`classify_correlation_event` outcome under `One`/`AnyOf`/`Any`, the
restarted-node name coming from the event, match-wins-regardless-of-server,
polling with buffered passthrough, feedback passing through an action poll,
the fan-out correlation, `NotReady` mapping, server-list parsing (empty,
`""`, malformed, empty-entry-inside-a-list), and the caller-id contract.

For deadlines: expiry reported exactly once, first-registration-wins, a match
clearing its deadline, a buffered reply beating an expired deadline,
per-correlation-id isolation, `cancel_correlation`, `u64::MAX` not panicking,
and `timeout_ms == 0` meaning no deadline.

Both new C++ entry points were confirmed to actually execute across the FFI
boundary, not merely compile, using temporary probes in the example that were
removed before commit: `Timeout` fired for a correlation nobody answers, and
`cancel_correlation` ran repeatedly (including for an unregistered id)
without disturbing the run.

The polling integration tests are bounded (2000 attempts), so an
implementation that blocked or never returned `Ok(None)` fails rather than
hangs.

**Gates:** `cargo fmt --all -- --check`, `cargo clippy --all -- -D warnings`,
`cargo test -p dora-node-api -p dora-node-api-cxx`, `cargo check --examples`,
`g++ -Wall -Wextra` on all example sources including with `-include X11/X.h`
(the `None`/`Success` macro trap from #2853), and a compile check of every
C++ snippet added to the README.

**The full `cargo test --all`** does not fit on my disk locally, and I had
previously written here that CI covers it. That was wrong for a PR: `Test
(ubuntu-latest)`, `E2E Tests`, `Semantic contract tests` and `Benchmark
regression check` all carry `if: github.event_name != 'pull_request'`, so the
green checks on this PR do not include any of them — they run on push to
`main`, in the Trunk merge queue, or on `workflow_dispatch`.

So I dispatched the same workflow against this branch on my fork, where the
condition holds and those jobs actually run. Result linked in the comments.

## Notes

- `#[allow(clippy::ptr_arg)]` on the four `&Vec<String>` functions: cxx maps
  `Vec<String>` to `rust::Vec<rust::String>` and has no slice-of-String
  equivalent, so the signature is dictated by the bridge — same situation as
  the existing `borrowed_box` allows in this file.
- An empty entry inside a non-empty server list is rejected rather than
  silently widening the set to "any", so a stray `""` cannot quietly disable
  restart detection.










