### PR TITLE
fix(message): recover build_id from its Display form in log fields

### DIFF
--- a/libraries/message/src/common.rs
+++ b/libraries/message/src/common.rs
@@ -50,7 +50,7 @@ impl From<LogMessageHelper> for LogMessage {
         LogMessage {
             build_id: helper.build_id.or(fields
                 .and_then(|f| f.get("build_id").cloned())
-                .and_then(|id| Uuid::parse_str(&id).ok().map(BuildId))),
+                .and_then(|id| BuildId::from_display_str(&id))),
             dataflow_id: helper.dataflow_id.or(fields
                 .and_then(|f| f.get("dataflow_id").cloned())
                 .and_then(|id| Uuid::parse_str(&id).ok())),
@@ -480,6 +480,48 @@ mod tests {
         // silently wrapped into an unvalidated NodeId.
         assert_eq!(LogMessage::from(make("a/b")).node_id, None);
         assert_eq!(LogMessage::from(make("../evil")).node_id, None);
+    }
+
+    /// A `build_id` back-filled from the `fields` map must survive a
+    /// `Display` round trip. `BuildId`'s `Display` wraps the UUID as
+    /// `BuildId(<uuid>)` -- the exact string emitted by the idiomatic
+    /// `tracing::info!(build_id = %build_id, ...)` (e.g. the coordinator's
+    /// build warnings). Recovery previously used `Uuid::parse_str`, which
+    /// rejects that wrapper and silently dropped the id; it now goes through
+    /// `BuildId::from_display_str`, matching how `daemon_id` is recovered.
+    #[test]
+    fn build_id_recovered_from_fields_survives_display_round_trip() {
+        let build_id = BuildId(Uuid::new_v4());
+        let make = |value: &str| LogMessageHelper {
+            build_id: None,
+            dataflow_id: None,
+            node_id: None,
+            daemon_id: None,
+            level: LogLevelOrStdout::Stdout,
+            target: None,
+            module_path: None,
+            file: None,
+            line: None,
+            message: Some("m".to_string()),
+            timestamp: Utc::now(),
+            fields: Some(BTreeMap::from([(
+                "build_id".to_string(),
+                value.to_string(),
+            )])),
+        };
+
+        // The `Display` form (`BuildId(<uuid>)`) is recovered...
+        assert_eq!(
+            LogMessage::from(make(&build_id.to_string())).build_id,
+            Some(build_id)
+        );
+        // ...and a bare UUID still works, for backward compatibility.
+        assert_eq!(
+            LogMessage::from(make(&build_id.uuid().to_string())).build_id,
+            Some(build_id)
+        );
+        // Garbage is rejected rather than wrapped into a bogus id.
+        assert_eq!(LogMessage::from(make("not-a-build-id")).build_id, None);
     }
 
     /// #2027: `DaemonId` must survive a `Display` -> `from_display_str` round

--- a/libraries/message/src/lib.rs
+++ b/libraries/message/src/lib.rs
@@ -72,6 +72,35 @@ impl BuildId {
     pub fn generate() -> Self {
         Self(Uuid::new_v7(Timestamp::now(uuid::NoContext)))
     }
+
+    /// Parse a `BuildId` from its [`Display`](std::fmt::Display) form,
+    /// `BuildId(<uuid>)`, so a value logged with `%build_id` round-trips.
+    ///
+    /// A bare UUID is also accepted for backward compatibility.
+    ///
+    /// ```
+    /// use dora_message::BuildId;
+    ///
+    /// let id = BuildId::generate();
+    /// // The `Display` form recovers the original id...
+    /// assert_eq!(BuildId::from_display_str(&id.to_string()), Some(id));
+    /// // ...as does a bare UUID.
+    /// assert_eq!(BuildId::from_display_str(&id.uuid().to_string()), Some(id));
+    /// // Garbage does not parse to a bogus id.
+    /// assert_eq!(BuildId::from_display_str("not-a-build-id"), None);
+    /// ```
+    pub fn from_display_str(s: &str) -> Option<Self> {
+        let inner = s
+            .strip_prefix("BuildId(")
+            .and_then(|rest| rest.strip_suffix(')'))
+            .unwrap_or(s);
+        Uuid::parse_str(inner).ok().map(BuildId)
+    }
+
+    /// The underlying UUID.
+    pub fn uuid(&self) -> uuid::Uuid {
+        self.0
+    }
 }
 
 impl std::fmt::Display for BuildId {


### PR DESCRIPTION
## Summary

`LogMessage::from(LogMessageHelper)` back-fills each optional identity field from the untrusted structured-logging `fields` map. Every other field is recovered with a parser matched to its type's `Display`:

- `daemon_id` → `DaemonId::from_display_str`
- `node_id` → `NodeId::from_str`
- `dataflow_id` (a bare `Uuid`) → `Uuid::parse_str`

`build_id` was the odd one out. Its `Display` wraps the UUID as `BuildId(<uuid>)`, but recovery used `Uuid::parse_str`, which rejects that wrapper. So a `build_id` emitted the idiomatic way — e.g. the coordinator's `tracing::warn!(build_id = %build_id, ...)` build warnings, which render `BuildId(<uuid>)` — was **silently dropped to `None`** when reconstructed from the `fields` map.

## Fix

Add `BuildId::from_display_str`, mirroring the existing `DaemonId::from_display_str`: it strips the `BuildId(...)` wrapper before parsing and still accepts a bare UUID for backward compatibility. Also expose `BuildId::uuid()` for symmetry with `SessionId`.

## Validation

- New regression test `build_id_recovered_from_fields_survives_display_round_trip` pins the `Display` round trip, the bare-UUID path, and rejection of garbage.
- New compile-checked doctest on `BuildId::from_display_str`.
- `cargo test -p dora-message` (141 unit + doctests), `cargo clippy -p dora-message -- -D warnings`, `cargo fmt --check` — all green.

---

⚠️ **This is a machine-generated pull request authored by Claude (an AI agent).** Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZRfXvMfoesmRj3M8Fdpmz)_