### PR TITLE
fix(replay-node): skip a corrupt recorded payload instead of aborting replay

### DIFF
--- a/binaries/replay-node/src/main.rs
+++ b/binaries/replay-node/src/main.rs
@@ -24,6 +24,15 @@ fn decode_recorded_payload(data: Option<&[u8]>) -> eyre::Result<ArrayData> {
     }
 }
 
+/// Whether a replay pass emitted nothing usable: every matching record was
+/// skipped as undecodable. This is a hard failure (a systematically corrupt or
+/// format-drifted recording), distinct from a pass that legitimately matched no
+/// records at all (`replayed == 0 && skipped == 0` -- the node simply had no
+/// recorded output), which is not a failure.
+fn replay_emitted_nothing_usable(replayed: u64, skipped: u64) -> bool {
+    replayed == 0 && skipped > 0
+}
+
 /// Nanoseconds to sleep before emitting an entry, given the previous entry's
 /// recording offset, this entry's offset, and the replay `speed`.
 ///
@@ -66,6 +75,7 @@ fn main() -> eyre::Result<()> {
         // output — is honored, preserving cross-node alignment on replay.
         let mut prev_offset: u64 = 0;
         let mut replayed = 0u64;
+        let mut skipped = 0u64;
 
         while let Some(entry) = reader.next_entry()? {
             if entry.node_id != replay_node {
@@ -88,6 +98,7 @@ fn main() -> eyre::Result<()> {
                             "warning: failed to deserialize event for {}/{}: {e}",
                             entry.node_id, entry.output_id
                         );
+                        skipped += 1;
                         continue;
                     }
                 };
@@ -115,6 +126,7 @@ fn main() -> eyre::Result<()> {
                                 "warning: skipping undecodable payload for {}/{output_id}: {e:#}",
                                 entry.node_id
                             );
+                            skipped += 1;
                             continue;
                         }
                     };
@@ -128,7 +140,23 @@ fn main() -> eyre::Result<()> {
             }
         }
 
-        eprintln!("dora-replay-node[{replay_node}]: replayed {replayed} messages");
+        eprintln!(
+            "dora-replay-node[{replay_node}]: replayed {replayed} messages ({skipped} skipped)"
+        );
+
+        // A pass that matched records but could decode none of them emitted
+        // nothing. Skipping individual corrupt records keeps replay resilient,
+        // but a *systematically* undecodable recording (format drift like
+        // dora-rs/dora#2366, or a truncated file) would otherwise print
+        // per-record warnings, report `replayed 0`, and exit 0 -- turning a
+        // data-integrity failure into a silent wrong answer. Fail instead.
+        if replay_emitted_nothing_usable(replayed, skipped) {
+            eyre::bail!(
+                "replay of {replay_file} for node `{replay_node}` emitted nothing: \
+                 all {skipped} matching record(s) were undecodable \
+                 (corrupt or format-drifted recording)"
+            );
+        }
 
         if !do_loop {
             break;
@@ -141,7 +169,7 @@ fn main() -> eyre::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{decode_recorded_payload, pacing_sleep_nanos};
+    use super::{decode_recorded_payload, pacing_sleep_nanos, replay_emitted_nothing_usable};
     use dora_node_api::arrow::array::{Array, Int32Array};
     use dora_node_api::arrow_utils::encode_arrow_ipc;
 
@@ -191,6 +219,18 @@ mod tests {
         let decoded = decode_recorded_payload(Some(&bytes)).expect("valid IPC must decode");
         assert_eq!(decoded.len(), 3);
         assert_eq!(&decoded, &original.to_data());
+    }
+
+    #[test]
+    fn total_failure_only_when_records_matched_but_none_decoded() {
+        // Emitted something -> not a failure, regardless of skips.
+        assert!(!replay_emitted_nothing_usable(5, 0));
+        assert!(!replay_emitted_nothing_usable(5, 3));
+        // Matched nothing at all (node had no recorded output) -> not a failure.
+        assert!(!replay_emitted_nothing_usable(0, 0));
+        // Matched records but decoded none of them -> hard failure.
+        assert!(replay_emitted_nothing_usable(0, 1));
+        assert!(replay_emitted_nothing_usable(0, 42));
     }
 
     #[test]

--- a/binaries/replay-node/src/main.rs
+++ b/binaries/replay-node/src/main.rs
@@ -3,11 +3,26 @@ use std::{fs::File, thread, time::Duration};
 use dora_message::{common::Timestamped, daemon_to_daemon::InterDaemonEvent};
 use dora_node_api::{
     DoraNode,
-    arrow::array::{NullArray, make_array},
+    arrow::array::{ArrayData, NullArray, make_array},
     arrow_utils::decode_arrow_ipc,
 };
 use dora_recording::RecordingReader;
 use eyre::Context;
+
+/// Decode a recorded output payload back into Arrow [`ArrayData`].
+///
+/// The recorded payload is a self-describing Arrow IPC stream, or `None` for
+/// a metadata-only message (which replays as an empty null array). A decode
+/// failure is returned as an `Err` so the caller can skip that single record
+/// rather than aborting the whole replay.
+fn decode_recorded_payload(data: Option<&[u8]>) -> eyre::Result<ArrayData> {
+    match data {
+        Some(bytes) => {
+            decode_arrow_ipc(bytes).wrap_err("failed to decode recorded Arrow IPC payload")
+        }
+        None => Ok(NullArray::new(0).into()),
+    }
+}
 
 /// Nanoseconds to sleep before emitting an entry, given the previous entry's
 /// recording offset, this entry's offset, and the replay `speed`.
@@ -88,10 +103,20 @@ fn main() -> eyre::Result<()> {
                     // stream (or absent for metadata-only messages). Decode it
                     // back to an array and re-send; `send_output` re-encodes it
                     // into a fresh IPC stream on the wire.
-                    let array = match &data {
-                        Some(bytes) => decode_arrow_ipc(bytes)
-                            .wrap_err("failed to decode recorded Arrow IPC payload")?,
-                        None => NullArray::new(0).into(),
+                    let array = match decode_recorded_payload(data.as_deref()) {
+                        Ok(array) => array,
+                        Err(e) => {
+                            // A single corrupt-but-complete payload must not
+                            // abort the whole replay. Skip it, matching the
+                            // bincode branch above and the recording layer's
+                            // torn-record resilience (dropping a bad record
+                            // rather than failing the run).
+                            eprintln!(
+                                "warning: skipping undecodable payload for {}/{output_id}: {e:#}",
+                                entry.node_id
+                            );
+                            continue;
+                        }
                     };
                     node.send_output(output_id, metadata.parameters, make_array(array))
                         .wrap_err("failed to send replay output")?;
@@ -116,7 +141,9 @@ fn main() -> eyre::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::pacing_sleep_nanos;
+    use super::{decode_recorded_payload, pacing_sleep_nanos};
+    use dora_node_api::arrow::array::{Array, Int32Array};
+    use dora_node_api::arrow_utils::encode_arrow_ipc;
 
     #[test]
     fn first_entry_honors_its_initial_offset() {
@@ -146,5 +173,32 @@ mod tests {
     fn non_monotonic_offset_saturates_to_zero() {
         // A later entry with a smaller offset must not underflow into a huge sleep.
         assert_eq!(pacing_sleep_nanos(1_000_000_000, 500_000_000, 1.0), 0);
+    }
+
+    #[test]
+    fn metadata_only_payload_decodes_to_empty_null_array() {
+        // A `None` payload (metadata-only message) replays as an empty array,
+        // never an error.
+        let array = decode_recorded_payload(None).expect("None must decode");
+        assert_eq!(array.len(), 0);
+    }
+
+    #[test]
+    fn valid_ipc_payload_round_trips() {
+        // A well-formed recorded IPC stream decodes back to its data.
+        let original = Int32Array::from(vec![1, 2, 3]);
+        let bytes = encode_arrow_ipc(&original.to_data()).expect("encode");
+        let decoded = decode_recorded_payload(Some(&bytes)).expect("valid IPC must decode");
+        assert_eq!(decoded.len(), 3);
+        assert_eq!(&decoded, &original.to_data());
+    }
+
+    #[test]
+    fn corrupt_payload_is_an_error_not_a_panic() {
+        // A corrupt-but-present payload returns `Err` so the caller can skip
+        // that single record instead of aborting the whole replay. This is the
+        // behavior the `main` loop relies on to stay resilient.
+        let garbage = [0xde, 0xad, 0xbe, 0xef, 0x00, 0x01, 0x02, 0x03];
+        assert!(decode_recorded_payload(Some(&garbage)).is_err());
     }
 }


### PR DESCRIPTION
## Summary

The replay loop deserializes each recorded entry in two steps. A `bincode::deserialize` failure on the event envelope already warns and `continue`s to the next entry, but a `decode_arrow_ipc` failure on the payload propagated with `?` out of `main`, **terminating the replay of every remaining message** (and, under `DORA_REPLAY_LOOP`, the whole loop) over a single corrupt-but-complete record.

That is inconsistent with the sibling bincode branch and with the recording layer, which deliberately drops torn trailing records rather than failing the replay (see `truncated_record_body_stops_gracefully`).

## Fix

Extract the payload decode into `decode_recorded_payload` and, on error, warn and `continue` — matching the bincode branch. A genuinely fatal condition (failure to send to the daemon) still aborts.

## Validation

- Tests cover the extracted helper: a metadata-only (`None`) payload decodes to an empty array, a valid IPC stream round-trips, and a corrupt payload returns `Err` (the signal `main` uses to skip the record).
- `cargo test -p dora-replay-node` (7 tests), `cargo clippy -p dora-replay-node`, `cargo fmt --check` — all green.

---

⚠️ **This is a machine-generated pull request authored by Claude (an AI agent).** Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZRfXvMfoesmRj3M8Fdpmz)_