### PR TITLE
fix(daemon): don't start a stopping dataflow when a node death completes the barrier

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -7860,7 +7860,13 @@ impl Daemon {
         // non-cohort survivor that was answered `Ok(())` (since #2933) isn't
         // left parked on a dataflow that never starts and never tears down
         // (#2967). `start()` is idempotent and guarded by `dataflow_started`.
-        if matches!(status, DataflowStatus::AllNodesReady) && !dataflow.dataflow_started {
+        //
+        // `should_start_on_barrier_completion` also gates on `!stop_sent`
+        // (dora-rs/dora#3053): unlike the subscribe / `AddNode` callers — which
+        // can no longer fire after `stop_all` drained `subscribe_channels` —
+        // this death-driven trigger is reachable during teardown, because the
+        // stop ladder itself kills a still-pending non-dynamic cohort member.
+        if dataflow.should_start_on_barrier_completion(&status) {
             logger
                 .log(
                     LogLevel::Info,
@@ -10368,6 +10374,34 @@ mod fault_tolerance_tests {
         assert!(!df.dataflow_started);
         df.start(&events_tx, &clock).await.unwrap();
         assert!(df.dataflow_started);
+    }
+
+    // dora-rs/dora#3053: the death-driven start trigger in
+    // `handle_node_stop_inner` (added in #2970) can fire during teardown,
+    // because `stop_all` kills a still-pending non-dynamic cohort member and
+    // that death completes the startup barrier. `should_start_on_barrier_completion`
+    // gates the start on `!stop_sent` so a stopping dataflow is never (re)started.
+    #[test]
+    fn barrier_completion_does_not_start_a_stopping_dataflow() {
+        let mut df = test_dataflow();
+
+        // A fresh dataflow whose barrier just completed should start.
+        assert!(df.should_start_on_barrier_completion(&DataflowStatus::AllNodesReady));
+
+        // Once stop has been sent, the same completion must not start it.
+        df.stop_sent = true;
+        assert!(
+            !df.should_start_on_barrier_completion(&DataflowStatus::AllNodesReady),
+            "a stopping dataflow must not be started by a barrier-completing node death"
+        );
+
+        // A `Pending` status never starts, stopping or not.
+        df.stop_sent = false;
+        assert!(!df.should_start_on_barrier_completion(&DataflowStatus::Pending));
+
+        // An already-started dataflow is not started again either.
+        df.dataflow_started = true;
+        assert!(!df.should_start_on_barrier_completion(&DataflowStatus::AllNodesReady));
     }
 
     fn test_running_node() -> RunningNode {

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -186,7 +186,6 @@ pub(crate) use running_dataflow::{
 use crate::{
     extension_table::{ExtensionKey, ExtensionTable},
     extract_err_from_stderr::extract_err_from_stderr,
-    pending::DataflowStatus,
 };
 use dora_tensor_pool::TensorPoolManager;
 use shared_memory_extended::ShmemConf;
@@ -3710,7 +3709,14 @@ impl Daemon {
                                 &mut dataflow.cascading_error_causes,
                             )
                             .await?;
-                        if ready {
+                        // Not gated on `dataflow_started` — `start()` is
+                        // idempotent — but it must not resurrect a dataflow that
+                        // is already tearing down (dora-rs/dora#3053). The
+                        // release can legitimately arrive after a local stop: the
+                        // daemon can stop on its own (`trigger_manual_stop`), and
+                        // the coordinator replays `AllNodesReady` to a daemon
+                        // that reconnects.
+                        if ready && !dataflow.stop_sent {
                             logger.log(LogLevel::Info, None,
                                 Some("daemon".into()),
                                 "coordinator reported that all nodes are ready, starting dataflow",
@@ -4310,8 +4316,13 @@ impl Daemon {
                                     )
                                     .await;
                                 match status {
-                                    Ok(DataflowStatus::AllNodesReady)
-                                        if !dataflow.dataflow_started =>
+                                    // Removing the last pending cohort member
+                                    // completes the barrier, and a `RemoveNode`
+                                    // can land mid-teardown, so this shares the
+                                    // `!stop_sent` gate with the subscribe and
+                                    // node-death triggers (dora-rs/dora#3053).
+                                    Ok(status)
+                                        if dataflow.should_start_on_barrier_completion(&status) =>
                                     {
                                         logger
                                             .log(
@@ -6524,21 +6535,26 @@ impl Daemon {
                                 &mut logger,
                             )
                             .await?;
-                        match status {
-                            DataflowStatus::AllNodesReady if !dataflow.dataflow_started => {
-                                logger
-                                    .log(
-                                        LogLevel::Info,
-                                        None,
-                                        Some("daemon".into()),
-                                        "all nodes are ready, starting dataflow",
-                                    )
-                                    .await;
-                                // `start()` sets `dataflow_started`; the guard
-                                // above keeps this to a single spawn.
-                                dataflow.start(&self.events_tx, &self.clock).await?;
-                            }
-                            _ => {}
+                        // `should_start_on_barrier_completion` keeps this to a
+                        // single spawn (`start()` sets `dataflow_started`) and
+                        // suppresses it entirely once `stop_sent` is set. A late
+                        // subscribe during teardown is an expected path, not a
+                        // hypothetical one: `subscribe()` above has a dedicated
+                        // `stop_sent` branch that answers such a node with
+                        // `Stop`. If that node is the last pending cohort member,
+                        // its subscription completes the barrier and would
+                        // otherwise start the dataflow that is already stopping
+                        // (dora-rs/dora#3053).
+                        if dataflow.should_start_on_barrier_completion(&status) {
+                            logger
+                                .log(
+                                    LogLevel::Info,
+                                    None,
+                                    Some("daemon".into()),
+                                    "all nodes are ready, starting dataflow",
+                                )
+                                .await;
+                            dataflow.start(&self.events_tx, &self.clock).await?;
                         }
                     }
                 }
@@ -7859,13 +7875,11 @@ impl Daemon {
         // and both of those callers start the dataflow here. Do the same, so a
         // non-cohort survivor that was answered `Ok(())` (since #2933) isn't
         // left parked on a dataflow that never starts and never tears down
-        // (#2967). `start()` is idempotent and guarded by `dataflow_started`.
-        //
-        // `should_start_on_barrier_completion` also gates on `!stop_sent`
-        // (dora-rs/dora#3053): unlike the subscribe / `AddNode` callers — which
-        // can no longer fire after `stop_all` drained `subscribe_channels` —
-        // this death-driven trigger is reachable during teardown, because the
-        // stop ladder itself kills a still-pending non-dynamic cohort member.
+        // (#2967). `should_start_on_barrier_completion` keeps that idempotent
+        // (it gates on `dataflow_started`) and additionally suppresses the start
+        // once the dataflow is stopping (dora-rs/dora#3053) — the stop ladder
+        // itself kills a still-pending non-dynamic cohort member, so this
+        // trigger is reachable during teardown.
         if dataflow.should_start_on_barrier_completion(&status) {
             logger
                 .log(
@@ -10254,6 +10268,7 @@ mod debug_topic_tests {
 #[cfg(test)]
 mod fault_tolerance_tests {
     use super::*;
+    use crate::pending::DataflowStatus;
     use crate::running_dataflow::{HandleReplacement, StopProcessPolicy};
     use std::sync::atomic::AtomicU32;
 
@@ -10376,30 +10391,49 @@ mod fault_tolerance_tests {
         assert!(df.dataflow_started);
     }
 
-    // dora-rs/dora#3053: the death-driven start trigger in
-    // `handle_node_stop_inner` (added in #2970) can fire during teardown,
-    // because `stop_all` kills a still-pending non-dynamic cohort member and
-    // that death completes the startup barrier. `should_start_on_barrier_completion`
-    // gates the start on `!stop_sent` so a stopping dataflow is never (re)started.
-    #[test]
-    fn barrier_completion_does_not_start_a_stopping_dataflow() {
+    fn test_logger(clock: Arc<HLC>) -> DaemonLogger {
+        Logger {
+            destination: log::LogDestination::Tracing,
+            daemon_id: DaemonId::new(None),
+            clock,
+        }
+        .for_daemon(DaemonId::new(None))
+    }
+
+    // dora-rs/dora#3053: a startup-barrier completion can arrive *during*
+    // teardown — a pending cohort member subscribing inside the stop grace
+    // window, that member being killed when the window expires (the death
+    // trigger from #2970), or a `RemoveNode` dropping the last pending member.
+    // `should_start_on_barrier_completion` gates all three on `!stop_sent`, so
+    // a stopping dataflow is never (re)started. Drives `stop_all` rather than
+    // assigning `stop_sent`, so the test tracks the real teardown entry point.
+    #[tokio::test]
+    async fn barrier_completion_does_not_start_a_stopping_dataflow() {
+        let clock = Arc::new(HLC::default());
+        let mut daemon_logger = test_logger(clock.clone());
+        let mut logger = daemon_logger.for_dataflow(Uuid::nil());
         let mut df = test_dataflow();
 
         // A fresh dataflow whose barrier just completed should start.
         assert!(df.should_start_on_barrier_completion(&DataflowStatus::AllNodesReady));
 
-        // Once stop has been sent, the same completion must not start it.
-        df.stop_sent = true;
-        assert!(
-            !df.should_start_on_barrier_completion(&DataflowStatus::AllNodesReady),
-            "a stopping dataflow must not be started by a barrier-completing node death"
-        );
-
-        // A `Pending` status never starts, stopping or not.
-        df.stop_sent = false;
+        // A `Pending` status never starts.
         assert!(!df.should_start_on_barrier_completion(&DataflowStatus::Pending));
 
+        // Once the dataflow is stopping, the same completion must not start it.
+        let finish_when = df
+            .stop_all(&mut None, &clock, None, false, &mut logger)
+            .await
+            .unwrap();
+        assert!(matches!(finish_when, FinishDataflowWhen::Now));
+        assert!(df.stop_sent, "stop_all must record that stop was sent");
+        assert!(
+            !df.should_start_on_barrier_completion(&DataflowStatus::AllNodesReady),
+            "a stopping dataflow must not be started by a completing startup barrier"
+        );
+
         // An already-started dataflow is not started again either.
+        let mut df = test_dataflow();
         df.dataflow_started = true;
         assert!(!df.should_start_on_barrier_completion(&DataflowStatus::AllNodesReady));
     }

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -1,7 +1,9 @@
 //! Running dataflow state and associated types.
 
 use crate::{
-    DoraEvent, OutputId, coordinator, fault_tolerance::CascadingErrorCauses, pending::PendingNodes,
+    DoraEvent, OutputId, coordinator,
+    fault_tolerance::CascadingErrorCauses,
+    pending::{DataflowStatus, PendingNodes},
     send_with_timestamp,
 };
 use dora_core::{
@@ -446,6 +448,21 @@ impl RunningDataflow {
         self.input_deadlines.retain(|(n, _), _| n != node_id);
         self.broken_inputs.retain(|(n, _), _| n != node_id);
         self.node_stderr_most_recent.remove(node_id);
+    }
+
+    /// Whether a startup-barrier completion (reported as
+    /// [`DataflowStatus::AllNodesReady`]) should start this dataflow.
+    ///
+    /// The subscribe / `AddNode` start triggers only reach a barrier
+    /// completion while the dataflow is still coming up. The death-driven
+    /// trigger in `handle_node_stop_inner` (dora-rs/dora#2970) is different:
+    /// it can fire during teardown, because `stop_all` kills a still-pending
+    /// non-dynamic cohort member and that death completes the barrier. Suppress
+    /// the start once the dataflow is already started or being stopped
+    /// (dora-rs/dora#3053), so teardown never spawns no-op timer tasks nor
+    /// momentarily flips `dataflow_started` back on for a racing `dora list`.
+    pub(crate) fn should_start_on_barrier_completion(&self, status: &DataflowStatus) -> bool {
+        matches!(status, DataflowStatus::AllNodesReady) && !self.dataflow_started && !self.stop_sent
     }
 
     pub(crate) async fn start(

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -453,14 +453,22 @@ impl RunningDataflow {
     /// Whether a startup-barrier completion (reported as
     /// [`DataflowStatus::AllNodesReady`]) should start this dataflow.
     ///
-    /// The subscribe / `AddNode` start triggers only reach a barrier
-    /// completion while the dataflow is still coming up. The death-driven
-    /// trigger in `handle_node_stop_inner` (dora-rs/dora#2970) is different:
-    /// it can fire during teardown, because `stop_all` kills a still-pending
-    /// non-dynamic cohort member and that death completes the barrier. Suppress
-    /// the start once the dataflow is already started or being stopped
-    /// (dora-rs/dora#3053), so teardown never spawns no-op timer tasks nor
-    /// momentarily flips `dataflow_started` back on for a racing `dora list`.
+    /// Every barrier-completion trigger — a node subscribing, a `RemoveNode`
+    /// dropping the last pending member, and a cohort member dying before it
+    /// subscribed (dora-rs/dora#2970) — can fire *during teardown*, so all three
+    /// share this gate (dora-rs/dora#3053). `stop_all` neither closes the node
+    /// listener nor completes the barrier for still-pending non-dynamic members:
+    /// it only drains the *existing* `subscribe_channels`, drops the pending
+    /// *dynamic* nodes, and schedules a (by default graceful) process stop. A
+    /// pending cohort member can therefore still subscribe within the grace
+    /// window — `Daemon::subscribe` has a dedicated `stop_sent` branch for
+    /// exactly that — or be killed when the window expires, and either way
+    /// completes the barrier.
+    ///
+    /// Starting a stopping dataflow spawns timer tasks that tick into a
+    /// teardown until the dataflow is dropped, and flips `dataflow_started` on,
+    /// which is the flag a racing `AddNode` reads to decide it may spawn timer
+    /// tasks of its own.
     pub(crate) fn should_start_on_barrier_completion(&self, status: &DataflowStatus) -> bool {
         matches!(status, DataflowStatus::AllNodesReady) && !self.dataflow_started && !self.stop_sent
     }


### PR DESCRIPTION
Fixes #3053.

A startup-barrier completion can arrive *during* teardown, and every trigger that
turns one into `dataflow.start()` was reachable that way:

- **node death** (`handle_node_stop_inner`, added in #2970) — `stop_all` SIGKILLs a
  still-pending non-dynamic cohort member when the grace window expires, and that
  death completes the barrier;
- **subscribe** — `stop_all` drains the *existing* `subscribe_channels` but does not
  close the node listener, so a pending cohort member can still subscribe inside the
  grace window. `Daemon::subscribe` has a dedicated `stop_sent` branch for exactly
  that node; if it is the last pending member, its subscription completes the barrier;
- **`RemoveNode`** — removing the last pending member completes the barrier, and the
  request can land mid-teardown;
- **coordinator `AllNodesReady`** — had no guard at all. The release can legitimately
  land after a local stop: the daemon can stop itself (`trigger_manual_stop`), and the
  coordinator replays `AllNodesReady` to a reconnecting daemon.

Starting a stopping dataflow spawns timer tasks that tick into the teardown until the
dataflow is dropped, and flips `dataflow_started` on — which is the flag a racing
`AddNode` reads to decide it may spawn timer tasks of its own.

## Change

- Add `RunningDataflow::should_start_on_barrier_completion`, which gates on
  `AllNodesReady && !dataflow_started && !stop_sent`, and route the node-death,
  subscribe, and `RemoveNode` call sites through it.
- Gate the coordinator `AllNodesReady` path on `!stop_sent`.
- Unit test drives `stop_all` (rather than assigning `stop_sent`) so it tracks the
  real teardown entry point.

Nothing is re-stranded by suppressing the start: parked subscribers are answered by
`answer_subscribe_requests` inside `handle_node_stop`, independently of the start
decision, so the #2967 guarantee still holds.

## Testing

- `cargo test -p dora-daemon` — 234 passed
- `cargo test --all` (Python + examples excluded) — green apart from the two
  `rmw_zenoh_pubsub` tests that need multicast
- `cargo fmt --all -- --check`, `cargo clippy -p dora-daemon -- -D warnings`,
  `cargo check --examples` — clean
