### PR TITLE
docs(message): correct LogLevelOrStdout::passes filter semantics

### DIFF
--- a/libraries/message/src/common.rs
+++ b/libraries/message/src/common.rs
@@ -93,8 +93,15 @@ pub enum LogLevelOrStdout {
 impl LogLevelOrStdout {
     /// Returns true if a message at this level passes the given minimum level filter.
     ///
-    /// Ordering: Stdout < Error < Warn < Info < Debug < Trace.
-    /// A message passes if its level is "at or above" (i.e. <=) the minimum.
+    /// `Stdout` is treated as a distinct channel rather than a severity, so it
+    /// does not participate in the `Error < Warn < Info < Debug < Trace`
+    /// ordering (where `Error` is the most severe and `Trace` the least):
+    ///
+    /// - A `Stdout` message passes only a `Stdout` filter; it is never
+    ///   delivered to a severity filter.
+    /// - A `LogLevel` message always passes a `Stdout` filter (the most
+    ///   permissive), and passes a `LogLevel` filter `min` when its severity is
+    ///   at least as severe as `min` (`msg <= min` in log-crate ordering).
     pub fn passes(&self, min: &LogLevelOrStdout) -> bool {
         match (self, min) {
             (LogLevelOrStdout::Stdout, LogLevelOrStdout::Stdout) => true,


### PR DESCRIPTION
## Summary

The doc comment on the public `LogLevelOrStdout::passes` (`libraries/message/src/common.rs`) described the wrong behavior for the `Stdout` case.

It claimed a single total order `Stdout < Error < Warn < Info < Debug < Trace` and that "a message passes if its level is at or above (`<=`) the minimum". Taken literally that makes `Stdout` the smallest element, so a `Stdout` message would pass **every** filter. The implementation does the opposite:

```rust
(LogLevelOrStdout::Stdout, LogLevelOrStdout::Stdout) => true,
(LogLevelOrStdout::Stdout, _) => false,   // Stdout does NOT pass a severity filter
```

and the existing `stdout_does_not_pass_log_level_filters` test pins exactly that. A reader relying on the comment would get the `Stdout` case backwards.

## Fix

Reword the doc comment to describe the actual rule: `Stdout` is a distinct channel, not a severity.

- A `Stdout` message passes only a `Stdout` filter.
- A `LogLevel` message always passes a `Stdout` filter (the most permissive), and passes a `LogLevel` filter when it is at least as severe.

Documentation only — no behavior change.

## Validation

- `cargo test -p dora-message` (existing tests already encode the described behavior)
- `cargo clippy -p dora-message -- -D warnings`
- `cargo fmt -p dora-message -- --check`

---

⚠️ **Machine-generated change.** This PR was authored by Claude (Claude Code), an AI assistant, as part of an automated code-review pass. It has been reviewed against the existing tests and compiled locally, but please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RoWA8SwvteRHxQ7npJsCyi)_