### PR TITLE
refactor(core): share one lexical path normalizer between the two callers

### DIFF
--- a/libraries/core/src/descriptor/expand.rs
+++ b/libraries/core/src/descriptor/expand.rs
@@ -7,24 +7,10 @@ use eyre::{Context, bail};
 use serde::Deserialize;
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
-    path::{Component, Path, PathBuf},
+    path::{Path, PathBuf},
 };
 
-/// Lexically normalize a path (collapse `.` and resolve `..`) without touching
-/// the filesystem — the executable may not be built yet when this is called.
-fn normalize_path(path: &Path) -> PathBuf {
-    let mut out = PathBuf::new();
-    for component in path.components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                out.pop();
-            }
-            other => out.push(other),
-        }
-    }
-    out
-}
+use super::normalize_path;
 
 /// Check if a path string is absolute on any platform.
 /// On Windows, `Path::is_absolute()` returns false for Unix-style `/foo` paths,

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -7,7 +7,7 @@ use eyre::{Context, OptionExt, Result, bail};
 use std::{
     collections::{BTreeMap, HashMap},
     env::consts::EXE_EXTENSION,
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
     process::Command,
 };
 
@@ -20,6 +20,26 @@ pub use dora_message::descriptor::{
 };
 pub use validate::ResolvedNodeExt;
 pub use visualize::collect_dora_timers;
+
+/// Lexically normalize a path (collapse `.` and resolve `..`) without touching
+/// the filesystem — the executable may not be built yet when this is called.
+///
+/// Used to sanitize untrusted node paths before a containment check, so the
+/// two callers (module expansion and manifest injection) must collapse `..`
+/// identically; keeping a single implementation prevents them from drifting.
+pub(crate) fn normalize_path(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                out.pop();
+            }
+            other => out.push(other),
+        }
+    }
+    out
+}
 
 mod expand;
 pub mod validate;

--- a/libraries/core/src/manifest/inject.rs
+++ b/libraries/core/src/manifest/inject.rs
@@ -12,7 +12,9 @@
 //! first-message type check or `dora graph`, which read the descriptor
 //! through paths that don't inject (deliberate for now; see plan §6.2).
 
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
+
+use crate::descriptor::normalize_path;
 
 use dora_message::{descriptor::Descriptor, id::NodeId};
 
@@ -191,7 +193,7 @@ fn find_manifest_for(
             // manifests are written once and consumed on any platform —
             // treat `\` in the entrypoint as a separator everywhere
             let entrypoint = manifest.entrypoint.replace('\\', "/");
-            if normalize(&dir.join(entrypoint)) == full {
+            if normalize_path(&dir.join(entrypoint)) == full {
                 return Some((candidate, manifest));
             }
             // A bare `path:` (console script) commonly shares its working dir
@@ -222,33 +224,17 @@ fn find_manifest_for(
 /// silently dropped instead of detected as escapes.
 fn containment_roots(path: &str, working_dir: &Path) -> Option<(PathBuf, PathBuf)> {
     let working_dir = if working_dir.is_absolute() {
-        normalize(working_dir)
+        normalize_path(working_dir)
     } else {
         let cwd = std::env::current_dir().ok()?;
-        normalize(&cwd.join(working_dir))
+        normalize_path(&cwd.join(working_dir))
     };
-    let full = normalize(&working_dir.join(path));
+    let full = normalize_path(&working_dir.join(path));
     if full.starts_with(&working_dir) {
         Some((full, working_dir))
     } else {
         None
     }
-}
-
-/// Lexically normalize a path (collapse `.` and resolve `..`) without
-/// touching the filesystem — the executable may not be built yet.
-fn normalize(path: &Path) -> PathBuf {
-    let mut out = PathBuf::new();
-    for component in path.components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                out.pop();
-            }
-            other => out.push(other),
-        }
-    }
-    out
 }
 
 /// Apply a manifest's contracts to a descriptor node: validate the


### PR DESCRIPTION
## Summary

`descriptor::expand::normalize_path` and `manifest::inject::normalize` were **byte-for-byte identical**: the same lexical `.`/`..` collapse, both used to sanitize an untrusted node path before a `starts_with` containment check.

Two copies of the same security-sensitive routine can drift apart — a fix or hardening applied to one could silently miss the other, weakening a path-escape check.

## Fix

Hoist a single `pub(crate) fn normalize_path` into `libraries/core/src/descriptor/mod.rs` (reachable crate-wide, since `manifest` is not a descendant of `descriptor` and could not see a helper private to `expand`) and route both call sites through it:

- `descriptor/expand.rs` — drop the local copy, `use super::normalize_path`
- `manifest/inject.rs` — drop the local `normalize`, call the shared `normalize_path` at all four sites

No behavior change; the implementation is identical to what each site used before.

## Validation

- `cargo test -p dora-core` — 272 lib tests pass, including the module-expansion and manifest-containment tests (`relative_working_dir_does_not_collapse_containment`, `paths_outside_working_dir_are_skipped`, `dot_segments_in_path_still_match`, …)
- `cargo clippy -p dora-core --all-targets -- -D warnings`
- `cargo fmt -p dora-core -- --check`

---

⚠️ **Machine-generated change.** This PR was authored by Claude (Claude Code), an AI assistant, as part of an automated code-review pass. It compiles and passes the crate's test suite locally, but please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RoWA8SwvteRHxQ7npJsCyi)_