### PR TITLE
fix(cli): trim whitespace around `dora daemon --labels` keys and values

### DIFF
--- a/binaries/cli/src/command/daemon.rs
+++ b/binaries/cli/src/command/daemon.rs
@@ -303,7 +303,40 @@ fn parse_labels(s: &str) -> Result<BTreeMap<String, String>, String> {
         let (k, v) = pair
             .split_once('=')
             .ok_or_else(|| format!("invalid label `{pair}`, expected key=value"))?;
-        map.insert(k.to_string(), v.to_string());
+        // Trim each half, not just the whole pair: `--labels "gpu = true"`
+        // must yield key `gpu` / value `true`, otherwise the surrounding
+        // whitespace leaks into the label and it silently fails to match a
+        // node's `gpu: true` requirement at scheduling time.
+        let k = k.trim();
+        if k.is_empty() {
+            return Err(format!("invalid label `{pair}`, key must not be empty"));
+        }
+        map.insert(k.to_string(), v.trim().to_string());
     }
     Ok(map)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_labels;
+
+    #[test]
+    fn parse_labels_trims_keys_and_values() {
+        let map = parse_labels("gpu = true, arch =arm64,zone= eu ").unwrap();
+        assert_eq!(map.get("gpu").map(String::as_str), Some("true"));
+        assert_eq!(map.get("arch").map(String::as_str), Some("arm64"));
+        assert_eq!(map.get("zone").map(String::as_str), Some("eu"));
+    }
+
+    #[test]
+    fn parse_labels_skips_empty_pairs() {
+        let map = parse_labels("a=1,,b=2,").unwrap();
+        assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn parse_labels_rejects_missing_value_and_empty_key() {
+        assert!(parse_labels("gpu").is_err());
+        assert!(parse_labels(" =true").is_err());
+    }
 }


### PR DESCRIPTION
## Summary

`parse_labels` (in `binaries/cli/src/command/daemon.rs`) trimmed each comma-separated pair as a whole, but not the two halves of `key=value`:

```rust
let pair = pair.trim();
let (k, v) = pair.split_once('=')?;
map.insert(k.to_string(), v.to_string());   // "gpu " => " true"
```

So `--labels "gpu = true"` produces key `"gpu "` and value `" true"`. Those never match a node's `gpu: true` deploy requirement, so the daemon silently advertises a label that cannot be scheduled against — with no error surfaced to the user. The sibling `parse_log_filter` in `output.rs` already trims both `node` and `level`; this is the one label path where surrounding whitespace leaks in.

## Fix

- Trim both halves after the split.
- Reject an empty key so a stray `=value` is a clear error rather than a blank label.
- Add unit tests covering trimming, empty-pair skipping, and the missing-value / empty-key error cases.

## Validation

- `cargo test -p dora-cli --lib parse_labels` — 3 new tests pass
- `cargo clippy -p dora-cli --lib -- -D warnings`
- `cargo fmt -p dora-cli -- --check`

---

⚠️ **Machine-generated change.** This PR was authored by Claude (Claude Code), an AI assistant, as part of an automated code-review pass. It compiles and passes the new tests locally, but please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RoWA8SwvteRHxQ7npJsCyi)_