### PR TITLE
docs(cli): split the merged `--env` / `--exit-when-nodes-finish` help on `dora start`

### DIFF
--- a/binaries/cli/src/command/start/mod.rs
+++ b/binaries/cli/src/command/start/mod.rs
@@ -47,19 +47,6 @@ pub struct Start {
     /// Enable debug mode (publishes all messages to Zenoh for topic echo/hz/info)
     #[clap(long, action)]
     debug: bool,
-    /// Set an environment variable for every node of this dataflow
-    /// (repeatable). Merges into the dataflow-level `env:` block;
-    /// node-level `env:` entries still win on conflict.
-    ///
-    /// Nodes started via `dora start` are spawned by the DAEMON and do
-    /// NOT inherit this CLI invocation's environment — `--env` is the
-    /// supported way to parameterize a run without editing the YAML.
-    /// Applies at spawn time only; `build:` commands are unaffected.
-    /// Values must survive the descriptor encoding verbatim: a literal
-    /// `$` is refused (the receiving process would expand it) and so are
-    /// numeric-looking values that would be coerced. They are also
-    /// persisted with the dataflow in the coordinator's state store and
-    /// visible in `ps` — prefer a node `env:` block for secrets.
     /// Exit once every node has finished, treating `dora/timer/...`
     /// inputs as a clock rather than as work.
     ///
@@ -84,6 +71,19 @@ pub struct Start {
         value_name = "BOOL"
     )]
     pub exit_when_nodes_finish: Option<bool>,
+    /// Set an environment variable for every node of this dataflow
+    /// (repeatable). Merges into the dataflow-level `env:` block;
+    /// node-level `env:` entries still win on conflict.
+    ///
+    /// Nodes started via `dora start` are spawned by the DAEMON and do
+    /// NOT inherit this CLI invocation's environment — `--env` is the
+    /// supported way to parameterize a run without editing the YAML.
+    /// Applies at spawn time only; `build:` commands are unaffected.
+    /// Values must survive the descriptor encoding verbatim: a literal
+    /// `$` is refused (the receiving process would expand it) and so are
+    /// numeric-looking values that would be coerced. They are also
+    /// persisted with the dataflow in the coordinator's state store and
+    /// visible in `ps` — prefer a node `env:` block for secrets.
     #[clap(long = "env", value_name = "KEY=VALUE")]
     env: Vec<String>,
 }


### PR DESCRIPTION
## Summary

On `dora start` (`binaries/cli/src/command/start/mod.rs`), the doc comment intended for `--env` ran without a break straight into the doc comment for `--exit-when-nodes-finish`. In Rust the entire block therefore annotates the field that follows it (`exit_when_nodes_finish`), and the `env` field below had **no** doc comment at all.

Result: `dora start --help` shows `--exit-when-nodes-finish` with a large help blob whose first ~13 lines actually describe `--env`, while `--env` shows no description. The sibling `dora run` command (`run.rs`) already keeps the two descriptions separate — this was just never propagated to `start`.

## Fix

Split the block so each field carries its own help:

- exit-policy paragraphs → above `exit_when_nodes_finish`
- environment-variable paragraphs → above the `env` field

Pure doc-comment reordering; the field declarations, `#[clap(...)]` attributes, and runtime behavior are unchanged.

## Validation

- `cargo clippy -p dora-cli --lib -- -D warnings`
- `cargo fmt -p dora-cli -- --check`
- Confirmed no snapshot/help test pins this text.

---

⚠️ **Machine-generated change.** This PR was authored by Claude (Claude Code), an AI assistant, as part of an automated code-review pass. Please review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RoWA8SwvteRHxQ7npJsCyi)_