### PR TITLE
fix(coordinator): tolerate transient log-subscriber send timeouts

### DIFF
--- a/binaries/coordinator/src/handlers.rs
+++ b/binaries/coordinator/src/handlers.rs
@@ -71,12 +71,43 @@ pub(crate) async fn send_log_message(
     log_subscribers: &mut Vec<LogSubscriber>,
     message: &LogMessage,
 ) {
+    // Tolerate transient slowness the same way `send_topic_frames` does: a
+    // single 100 ms timeout — which happens whenever a `dora logs -f` reader
+    // stalls long enough to keep its bounded channel full during a log burst —
+    // must not permanently drop the subscription. Only close after the channel
+    // is actually gone, or after a sustained streak of timeouts.
+    const MAX_CONSECUTIVE_LOG_SEND_TIMEOUTS: usize = 100;
     for subscriber in log_subscribers.iter_mut() {
         let send_result =
-            tokio::time::timeout(Duration::from_millis(100), subscriber.send_message(message));
-
-        if send_result.await.is_err() {
-            subscriber.close();
+            tokio::time::timeout(Duration::from_millis(100), subscriber.send_message(message))
+                .await;
+        match send_result {
+            // Actually enqueued — the subscriber is keeping up, clear the streak.
+            Ok(Ok(true)) => {
+                subscriber.reset_timeout_streak();
+            }
+            // Dropped by the level filter — not a delivery attempt, so leave the
+            // streak untouched (resetting here would let below-filter traffic
+            // keep a stuck subscriber alive forever).
+            Ok(Ok(false)) => {}
+            Ok(Err(_)) => {
+                subscriber.close();
+            }
+            Err(_) => {
+                let timeouts = subscriber.record_timeout();
+                if timeouts >= MAX_CONSECUTIVE_LOG_SEND_TIMEOUTS {
+                    tracing::warn!(
+                        timeouts,
+                        "closing slow log subscriber after repeated send timeouts"
+                    );
+                    subscriber.close();
+                } else {
+                    tracing::warn!(
+                        timeouts,
+                        "timed out sending log message to CLI subscriber; keeping subscription active"
+                    );
+                }
+            }
         }
     }
     log_subscribers.retain(|s| !s.is_closed());
@@ -1054,6 +1085,101 @@ mod tests {
         assert!(
             msg.contains("broken"),
             "error must name the failed daemon: {msg}"
+        );
+    }
+
+    fn test_log_message() -> LogMessage {
+        LogMessage {
+            build_id: None,
+            dataflow_id: None,
+            node_id: None,
+            daemon_id: None,
+            // Warn passes an Info-level subscriber, so `send_message` actually
+            // enqueues rather than dropping it at the level filter.
+            level: dora_message::common::LogLevel::Warn.into(),
+            target: None,
+            module_path: None,
+            file: None,
+            line: None,
+            message: "hello".to_string(),
+            timestamp: std::time::SystemTime::UNIX_EPOCH.into(),
+            fields: None,
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn send_log_message_resets_timeout_streak_on_successful_send() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(4);
+        let mut subscriber = LogSubscriber::new(log::LevelFilter::Info, tx);
+        // Prime the counter: simulate 3 prior timeouts.
+        assert_eq!(subscriber.record_timeout(), 1);
+        assert_eq!(subscriber.record_timeout(), 2);
+        assert_eq!(subscriber.record_timeout(), 3);
+
+        let mut subscribers = vec![subscriber];
+        // A real send should succeed (channel has capacity) and reset the streak.
+        send_log_message(&mut subscribers, &test_log_message()).await;
+
+        assert!(
+            rx.try_recv().is_ok(),
+            "subscriber should receive the log message"
+        );
+        assert_eq!(subscribers.len(), 1, "subscriber must not be evicted");
+        assert_eq!(
+            subscribers[0].record_timeout(),
+            1,
+            "streak must be back to 0 after a successful send"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn send_log_message_closes_subscriber_after_100_consecutive_timeouts() {
+        // Capacity 1 + pre-filled + rx never drained = every send times out.
+        // `start_paused = true` makes tokio auto-advance through the 100 × 100ms
+        // timeouts without real wall-clock delay.
+        let (tx, _rx_never_drained) = tokio::sync::mpsc::channel(1);
+        tx.send("prefill".to_string()).await.unwrap();
+
+        let mut subscribers = vec![LogSubscriber::new(log::LevelFilter::Info, tx)];
+
+        for i in 1..=99 {
+            send_log_message(&mut subscribers, &test_log_message()).await;
+            assert_eq!(
+                subscribers.len(),
+                1,
+                "subscriber evicted prematurely at iteration {i}"
+            );
+        }
+        // 100th consecutive timeout triggers the close + retain eviction.
+        send_log_message(&mut subscribers, &test_log_message()).await;
+        assert!(
+            subscribers.is_empty(),
+            "subscriber should be evicted after 100 consecutive timeouts"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn send_log_message_filtered_message_does_not_reset_streak() {
+        // A message dropped by the level filter is not a delivery attempt, so
+        // it must leave the timeout streak untouched — otherwise below-filter
+        // traffic could keep a stuck subscriber alive forever.
+        let (tx, _rx) = tokio::sync::mpsc::channel(4);
+        let mut subscriber = LogSubscriber::new(log::LevelFilter::Info, tx);
+        assert_eq!(subscriber.record_timeout(), 1);
+        assert_eq!(subscriber.record_timeout(), 2);
+        let mut subscribers = vec![subscriber];
+
+        // Debug is below the Info filter, so this is not delivered.
+        let mut msg = test_log_message();
+        msg.level = dora_message::common::LogLevel::Debug.into();
+        send_log_message(&mut subscribers, &msg).await;
+
+        assert_eq!(subscribers.len(), 1, "subscriber must not be evicted");
+        // Streak preserved at 2, so the next timeout yields 3 (not reset to 1).
+        assert_eq!(
+            subscribers[0].record_timeout(),
+            3,
+            "a filtered message must not reset the timeout streak"
         );
     }
 }

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -130,6 +130,7 @@ mod log_subscriber;
 mod otel_metrics;
 mod run;
 mod state;
+mod timeout_streak;
 mod topic_subscriber;
 mod ws_control;
 mod ws_daemon;

--- a/binaries/coordinator/src/log_subscriber.rs
+++ b/binaries/coordinator/src/log_subscriber.rs
@@ -1,9 +1,11 @@
+use crate::timeout_streak::TimeoutStreak;
 use dora_message::coordinator_to_cli::LogMessage;
 use eyre::{Context, ContextCompat};
 
 pub struct LogSubscriber {
     pub level: log::LevelFilter,
     sender: Option<tokio::sync::mpsc::Sender<String>>,
+    timeouts: TimeoutStreak,
 }
 
 impl LogSubscriber {
@@ -11,14 +13,22 @@ impl LogSubscriber {
         Self {
             level,
             sender: Some(sender),
+            timeouts: TimeoutStreak::default(),
         }
     }
 
-    pub async fn send_message(&mut self, message: &LogMessage) -> eyre::Result<()> {
+    /// Deliver `message` to this subscriber.
+    ///
+    /// Returns `Ok(true)` when the message was actually enqueued and
+    /// `Ok(false)` when it was dropped by the level filter (not a delivery
+    /// attempt). The caller uses this to keep the timeout streak meaningful:
+    /// a filtered message must not reset the streak, or a stuck subscriber
+    /// that keeps seeing below-filter traffic would never be evicted.
+    pub async fn send_message(&mut self, message: &LogMessage) -> eyre::Result<bool> {
         match message.level {
             dora_core::build::LogLevelOrStdout::LogLevel(level) => {
                 if level > self.level {
-                    return Ok(());
+                    return Ok(false);
                 }
             }
             dora_core::build::LogLevelOrStdout::Stdout => {}
@@ -34,7 +44,17 @@ impl LogSubscriber {
             .send(json)
             .await
             .map_err(|_e| eyre::eyre!("WS log subscriber channel closed"))?;
-        Ok(())
+        Ok(true)
+    }
+
+    /// Reset the consecutive-timeout streak after a successful send.
+    pub fn reset_timeout_streak(&mut self) {
+        self.timeouts.reset();
+    }
+
+    /// Record a send timeout and return the new consecutive-timeout count.
+    pub fn record_timeout(&mut self) -> usize {
+        self.timeouts.record()
     }
 
     pub fn is_closed(&self) -> bool {
@@ -46,5 +66,33 @@ impl LogSubscriber {
 
     pub fn close(&mut self) {
         self.sender = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn new_subscriber(capacity: usize) -> (LogSubscriber, tokio::sync::mpsc::Receiver<String>) {
+        let (tx, rx) = tokio::sync::mpsc::channel(capacity);
+        (LogSubscriber::new(log::LevelFilter::Info, tx), rx)
+    }
+
+    #[test]
+    fn record_timeout_is_monotonic_and_resets() {
+        let (mut sub, _rx) = new_subscriber(1);
+        assert_eq!(sub.record_timeout(), 1);
+        assert_eq!(sub.record_timeout(), 2);
+        assert_eq!(sub.record_timeout(), 3);
+        sub.reset_timeout_streak();
+        assert_eq!(sub.record_timeout(), 1);
+    }
+
+    #[test]
+    fn close_marks_subscriber_closed() {
+        let (mut sub, _rx) = new_subscriber(1);
+        assert!(!sub.is_closed());
+        sub.close();
+        assert!(sub.is_closed());
     }
 }

--- a/binaries/coordinator/src/timeout_streak.rs
+++ b/binaries/coordinator/src/timeout_streak.rs
@@ -1,0 +1,40 @@
+/// Tracks a run of consecutive send timeouts to a bounded-channel WS
+/// subscriber.
+///
+/// A transiently-slow `dora logs -f` / topic-debug reader can keep its channel
+/// full for a single 100 ms send window; that must not evict it. Both
+/// `LogSubscriber` and `TopicSubscriber` embed this counter and only close a
+/// subscriber once the streak reaches their eviction threshold, so the two
+/// paths share one definition of "how many timeouts in a row is too many".
+#[derive(Debug, Default)]
+pub(crate) struct TimeoutStreak {
+    consecutive: usize,
+}
+
+impl TimeoutStreak {
+    /// Record a timeout and return the new consecutive-timeout count.
+    pub(crate) fn record(&mut self) -> usize {
+        self.consecutive += 1;
+        self.consecutive
+    }
+
+    /// Reset the streak after a successful send.
+    pub(crate) fn reset(&mut self) {
+        self.consecutive = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TimeoutStreak;
+
+    #[test]
+    fn record_is_monotonic_and_reset_returns_to_zero() {
+        let mut streak = TimeoutStreak::default();
+        assert_eq!(streak.record(), 1);
+        assert_eq!(streak.record(), 2);
+        assert_eq!(streak.record(), 3);
+        streak.reset();
+        assert_eq!(streak.record(), 1);
+    }
+}

--- a/binaries/coordinator/src/topic_subscriber.rs
+++ b/binaries/coordinator/src/topic_subscriber.rs
@@ -11,7 +11,7 @@ pub(crate) struct TopicSubscriber {
         Vec<(dora_message::id::NodeId, dora_message::id::DataId)>,
     >,
     sender: Option<tokio::sync::mpsc::Sender<TopicFrame>>,
-    consecutive_timeouts: usize,
+    timeouts: crate::timeout_streak::TimeoutStreak,
 }
 
 impl TopicSubscriber {
@@ -25,7 +25,7 @@ impl TopicSubscriber {
         Self {
             outputs_by_daemon,
             sender: Some(sender),
-            consecutive_timeouts: 0,
+            timeouts: crate::timeout_streak::TimeoutStreak::default(),
         }
     }
 
@@ -51,12 +51,11 @@ impl TopicSubscriber {
     }
 
     pub(crate) fn reset_timeout_streak(&mut self) {
-        self.consecutive_timeouts = 0;
+        self.timeouts.reset();
     }
 
     pub(crate) fn record_timeout(&mut self) -> usize {
-        self.consecutive_timeouts += 1;
-        self.consecutive_timeouts
+        self.timeouts.record()
     }
 
     pub(crate) fn is_closed(&self) -> bool {


### PR DESCRIPTION
## Summary

`send_log_message` (in `binaries/coordinator/src/handlers.rs`) closed a log subscriber on a **single** 100 ms send timeout:

```rust
let send_result = tokio::time::timeout(Duration::from_millis(100), subscriber.send_message(message));
if send_result.await.is_err() {
    subscriber.close();   // one hiccup ends the subscription
}
```

`send_message` writes to a bounded `mpsc` channel feeding a `dora logs -f` CLI. Whenever that reader stalls long enough to keep the channel full for 100 ms during a log burst, this permanently closes the subscriber and silently ends the log stream.

The sibling `send_topic_frames` in the *same file* was deliberately hardened against exactly this failure mode: it keeps a per-subscriber consecutive-timeout counter, resets it on any successful send, and only closes after `100` **consecutive** timeouts. `LogSubscriber` had no such tolerance, so the two structurally-parallel "stream to a CLI" paths degraded differently.

## Fix

- Give `LogSubscriber` the same tolerance and rewrite `send_log_message` to mirror the topic path: reset the streak on success, close on an actually-closed channel, and close on a timeout only after 100 consecutive ones.
- `send_message` now reports whether the message was **actually enqueued** vs **dropped by the level filter**. A filtered message is not a delivery attempt, so it leaves the streak untouched — otherwise a stuck subscriber that keeps seeing below-filter traffic (e.g. a Warn-level reader during Info/Debug chatter) would reset the streak on every filtered message and never be evicted.
- Both subscribers now **share the streak counter**: a small `TimeoutStreak` (`record`/`reset`) is extracted into its own module and embedded in `LogSubscriber` and `TopicSubscriber`, so the counter mechanism has one definition instead of two byte-identical copies. The send loops themselves stay separate (the log path's level filter makes them genuinely different).

## Validation

- `cargo test -p dora-coordinator` — all pass, including:
  - `timeout_streak::tests::record_is_monotonic_and_reset_returns_to_zero`
  - `handlers::tests::send_log_message_resets_timeout_streak_on_successful_send`
  - `handlers::tests::send_log_message_closes_subscriber_after_100_consecutive_timeouts` (uses `start_paused` to auto-advance the 100 timeouts)
  - `handlers::tests::send_log_message_filtered_message_does_not_reset_streak`
  - the existing `send_topic_frames_*` tests still pass unchanged
- `cargo clippy -p dora-coordinator --all-targets -- -D warnings`
- `cargo fmt -p dora-coordinator -- --check`

---

⚠️ **Machine-generated change.** This PR was authored by Claude (Claude Code), an AI assistant, as part of an automated code-review pass. It compiles and passes the crate's test suite locally, but please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)