### PR TITLE
fix(ros2-bridge): validate transient-local subscription history depth

### DIFF
--- a/libraries/extensions/ros2-bridge/src/transport/zenoh/pubsub.rs
+++ b/libraries/extensions/ros2-bridge/src/transport/zenoh/pubsub.rs
@@ -29,13 +29,26 @@ pub enum PublisherMode {
     },
 }
 
+/// Validate a `KeepLast` history depth and return it as a sample count.
+///
+/// The depth is a ROS `i32` and must be positive; a non-positive value
+/// (`<= 0`) is rejected rather than cast. Casting a negative `i32` straight to
+/// `usize` would wrap to a near-`usize::MAX` sample count — a nonsensical,
+/// memory-abusive cache config — so both the publisher and the subscriber
+/// route their `depth` through this one check to stay in agreement.
+fn keep_last_samples(depth: i32) -> Result<usize, PubSubError> {
+    usize::try_from(depth)
+        .ok()
+        .filter(|&samples| samples > 0)
+        .ok_or(PubSubError::InvalidDepth(depth))
+}
+
 impl PublisherMode {
     pub fn from_qos(qos: &Ros2Qos) -> Result<Self, PubSubError> {
         let block = matches!(qos.reliability, Reliability::Reliable { .. })
             || matches!(qos.history, History::KeepAll);
         let depth = match qos.history {
-            History::KeepLast { depth } if depth > 0 => Some(depth as usize),
-            History::KeepLast { depth } => return Err(PubSubError::InvalidDepth(depth)),
+            History::KeepLast { depth } => Some(keep_last_samples(depth)?),
             History::KeepAll => None,
         };
         let transient_local = qos.durability == Durability::TransientLocal;
@@ -361,7 +374,7 @@ impl<T: Send + 'static> RawSubscription<T> {
             use zenoh_ext::AdvancedSubscriberBuilderExt;
             let mut history = zenoh_ext::HistoryConfig::default().detect_late_publishers();
             if let Some(History::KeepLast { depth }) = qos.map(|value| value.history) {
-                history = history.max_samples(depth as usize);
+                history = history.max_samples(keep_last_samples(depth)?);
             }
             NativeSubscriber::Advanced {
                 _subscriber: builder
@@ -496,4 +509,35 @@ pub enum PubSubError {
     Session(String),
     #[error("failed to declare ROS graph endpoint: {0}")]
     Token(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PubSubError, keep_last_samples};
+
+    #[test]
+    fn keep_last_samples_accepts_positive_depth() {
+        assert_eq!(keep_last_samples(1).unwrap(), 1);
+        assert_eq!(keep_last_samples(10).unwrap(), 10);
+        assert_eq!(keep_last_samples(i32::MAX).unwrap(), i32::MAX as usize);
+    }
+
+    #[test]
+    fn keep_last_samples_rejects_zero_and_negative_depth() {
+        // A non-positive depth must be an error, not a `depth as usize` cast
+        // that would wrap `-1` into a near-`usize::MAX` sample count. This is
+        // the same rule the publisher path enforces.
+        assert!(matches!(
+            keep_last_samples(0),
+            Err(PubSubError::InvalidDepth(0))
+        ));
+        assert!(matches!(
+            keep_last_samples(-1),
+            Err(PubSubError::InvalidDepth(-1))
+        ));
+        assert!(matches!(
+            keep_last_samples(i32::MIN),
+            Err(PubSubError::InvalidDepth(i32::MIN))
+        ));
+    }
 }


### PR DESCRIPTION
## Summary

In `libraries/extensions/ros2-bridge/src/transport/zenoh/pubsub.rs`, the **publisher** path validated the QoS `KeepLast` history depth:

```rust
History::KeepLast { depth } if depth > 0 => Some(depth as usize),
History::KeepLast { depth } => return Err(PubSubError::InvalidDepth(depth)),
```

but the transient-local **subscription** path cast it straight to `usize` with no check:

```rust
if let Some(History::KeepLast { depth }) = qos.map(|value| value.history) {
    history = history.max_samples(depth as usize);
}
```

`depth` is a ROS `i32`. A negative value — which a config layer that truncates a larger unsigned ROS depth into `i32` can produce — becomes `depth as usize` = `18446744073709551615`, passed into `zenoh_ext::HistoryConfig::max_samples(...)`: a nonsensical, potentially memory-abusive cache config. The exact same `Ros2Qos` value is cleanly rejected on the publisher but silently accepted on the subscriber, and `depth == 0` (rejected by the publisher as `InvalidDepth(0)`) is likewise accepted here as `max_samples(0)`.

## Fix

Extract the publisher's positive-depth check into a shared `keep_last_samples(depth: i32) -> Result<usize, PubSubError>` helper and route **both** the publisher (`from_qos`) and the subscriber through it, so the two paths agree by construction. `from_qos`'s behavior is unchanged.

## Validation

- `cargo test -p dora-ros2-bridge --features rmw-zenoh` — new tests pass:
  - `keep_last_samples_accepts_positive_depth`
  - `keep_last_samples_rejects_zero_and_negative_depth`
- `cargo clippy -p dora-ros2-bridge --features rmw-zenoh --lib --tests -- -D warnings`
- `cargo fmt -p dora-ros2-bridge -- --check`

(Note: `--all-targets` surfaces a pre-existing, unrelated `single_component_path_imports` warning in `examples/ros2-bridge/rust/service-server/run.rs` that this PR does not touch and does not fix, per the repo's "don't fix unrelated warnings" convention.)

---

⚠️ **Machine-generated change.** This PR was authored by Claude (Claude Code), an AI assistant, as part of an automated code-review pass. It compiles and passes the new tests locally, but please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RoWA8SwvteRHxQ7npJsCyi)_