### PR TITLE
fix(ros2-bridge): accept Binary/LargeBinary for fixed-size byte arrays

### DIFF
--- a/libraries/extensions/ros2-bridge/arrow/src/serialize/array.rs
+++ b/libraries/extensions/ros2-bridge/arrow/src/serialize/array.rs
@@ -26,6 +26,30 @@ impl serde::Serialize for ArraySerializeWrapper<'_> {
     where
         S: serde::Serializer,
     {
+        // A byte-typed fixed array (`uint8[N]`, `char[N]`, `byte[N]`) may be
+        // supplied as an Arrow `Binary`/`LargeBinary` column — the idiomatic
+        // representation a `pyarrow` producer uses for a byte buffer. The
+        // variable-length sequence path already accepts this (#2507/#2816); the
+        // fixed-array path must be consistent, otherwise the same 16 bytes that
+        // serialize fine as `uint8[]` fail as `uint8[16]`. The row's *bytes* are
+        // the array elements, so handle it here before the generic `List`
+        // extraction below.
+        if let Some(binary) = self.column.as_binary_opt::<i32>() {
+            return serialize_binary_fixed_array(
+                serializer,
+                binary,
+                &self.array_info.value_type,
+                self.array_info.size,
+            );
+        } else if let Some(binary) = self.column.as_binary_opt::<i64>() {
+            return serialize_binary_fixed_array(
+                serializer,
+                binary,
+                &self.array_info.value_type,
+                self.array_info.size,
+            );
+        }
+
         let entry = if let Some(list) = self.column.as_list_opt::<i32>() {
             if list.len() != 1 {
                 return Err(error(format!(
@@ -192,6 +216,46 @@ impl serde::Serialize for ArraySerializeWrapper<'_> {
     }
 }
 
+/// Serialize a byte-typed fixed-size array (`uint8[N]`, `char[N]`, `byte[N]`)
+/// supplied as a single-row Arrow `Binary`/`LargeBinary` column.
+///
+/// The single row's bytes are the array elements, so the fixed-size length
+/// check (`check_array_len`, #2027) is applied to the byte count. Only byte
+/// element types can originate from a `Binary` column; any other element type
+/// is a genuine type mismatch and is rejected.
+fn serialize_binary_fixed_array<S, O>(
+    serializer: S,
+    binary: &arrow::array::GenericByteArray<datatypes::GenericBinaryType<O>>,
+    value_type: &NestableType,
+    size: usize,
+) -> Result<<S as serde::Serializer>::Ok, <S as serde::Serializer>::Error>
+where
+    S: serde::Serializer,
+    O: OffsetSizeTrait,
+{
+    match value_type {
+        NestableType::BasicType(BasicType::U8 | BasicType::Char | BasicType::Byte) => {}
+        other => {
+            return Err(error(format!(
+                "Binary column is only valid for a byte-typed fixed array, not {other:?}"
+            )));
+        }
+    }
+    if binary.len() != 1 {
+        return Err(error(format!(
+            "expected single-element binary, got length {}",
+            binary.len()
+        )));
+    }
+    let bytes: &[u8] = binary.value(0);
+    check_array_len(bytes.len(), size)?;
+    let mut seq = serializer.serialize_tuple(size)?;
+    for b in bytes {
+        seq.serialize_element(b)?;
+    }
+    seq.end()
+}
+
 /// Serializes a primitive array with known size as tuple.
 struct BasicArrayAsTuple<'a, T> {
     len: usize,
@@ -288,14 +352,16 @@ mod tests {
     use std::{borrow::Cow, collections::HashMap, sync::Arc};
 
     use arrow::{
-        array::{ArrayRef, ListArray, StringArray, StructArray},
+        array::{
+            ArrayRef, BinaryArray, Int32Array, ListArray, StringArray, StructArray, UInt8Array,
+        },
         buffer::OffsetBuffer,
         datatypes::{DataType, Field},
     };
     use byteorder::LittleEndian;
     use dora_ros2_bridge_msg_gen::types::{
         Member, MemberType, Message,
-        primitives::{GenericString, NestableType},
+        primitives::{BasicType, GenericString, NestableType},
         sequences::Array as ArrayType,
     };
 
@@ -384,5 +450,156 @@ mod tests {
             serializes_ok(&messages, &["a", "b", "c"]),
             "size-3 field with 3 elements must serialize"
         );
+    }
+
+    /// A message with a single fixed-size `uint8[<size>]` field followed by an
+    /// `int32` field, so we can verify the trailing field survives the byte
+    /// encoding (mirrors the `unique_identifier_msgs/msg/UUID` shape from #3065).
+    fn byte_array_then_int32_message(
+        size: usize,
+    ) -> Arc<HashMap<String, HashMap<String, Message>>> {
+        let message = Message {
+            package: "test_msgs".to_string(),
+            name: "ByteArrMsg".to_string(),
+            members: vec![
+                Member {
+                    name: "data".to_string(),
+                    r#type: MemberType::Array(ArrayType {
+                        value_type: NestableType::BasicType(BasicType::U8),
+                        size,
+                    }),
+                    default: None,
+                },
+                Member {
+                    name: "tail".to_string(),
+                    r#type: MemberType::NestableType(NestableType::BasicType(BasicType::I32)),
+                    default: None,
+                },
+            ],
+            constants: vec![],
+        };
+        let mut package = HashMap::new();
+        package.insert("ByteArrMsg".to_string(), message);
+        let mut messages = HashMap::new();
+        messages.insert("test_msgs".to_string(), package);
+        Arc::new(messages)
+    }
+
+    /// The `data` field as an Arrow `List<UInt8>` (the representation dora's
+    /// deserializer emits).
+    fn build_byte_array_list(data: &[u8], tail: i32) -> ArrayRef {
+        let list = ListArray::new(
+            Arc::new(Field::new("item", DataType::UInt8, true)),
+            OffsetBuffer::from_lengths([data.len()]),
+            Arc::new(UInt8Array::from(data.to_vec())),
+            None,
+        );
+        let struct_array = StructArray::from(vec![
+            (
+                Arc::new(Field::new(
+                    "data",
+                    DataType::List(Arc::new(Field::new("item", DataType::UInt8, true))),
+                    false,
+                )),
+                Arc::new(list) as ArrayRef,
+            ),
+            (
+                Arc::new(Field::new("tail", DataType::Int32, false)),
+                Arc::new(Int32Array::from(vec![tail])) as ArrayRef,
+            ),
+        ]);
+        Arc::new(struct_array) as ArrayRef
+    }
+
+    /// The same `data` field as an Arrow `Binary` column (what a `pyarrow`
+    /// producer idiomatically yields for a byte buffer).
+    fn build_byte_array_binary(data: &[u8], tail: i32) -> ArrayRef {
+        let binary = BinaryArray::from_vec(vec![data]);
+        let struct_array = StructArray::from(vec![
+            (
+                Arc::new(Field::new("data", DataType::Binary, false)),
+                Arc::new(binary) as ArrayRef,
+            ),
+            (
+                Arc::new(Field::new("tail", DataType::Int32, false)),
+                Arc::new(Int32Array::from(vec![tail])) as ArrayRef,
+            ),
+        ]);
+        Arc::new(struct_array) as ArrayRef
+    }
+
+    /// #3065: a byte-valued fixed-size array (`uint8[N]`) supplied as an Arrow
+    /// `Binary` column must serialize, and encode identically to the same value
+    /// supplied as `List<UInt8>`. A fixed array has no CDR length prefix, so the
+    /// trailing field must stay byte-aligned across both representations.
+    #[test]
+    fn fixed_byte_array_binary_matches_list() {
+        let data = vec![10u8, 20, 30];
+        let tail = 0x1234_5678_i32;
+
+        let messages = byte_array_then_int32_message(data.len());
+        let type_info = TypeInfo {
+            package_name: Cow::Borrowed("test_msgs"),
+            message_name: Cow::Borrowed("ByteArrMsg"),
+            messages,
+        };
+
+        let list_bytes = cdr_encoding::to_vec::<_, LittleEndian>(&TypedValue {
+            value: &build_byte_array_list(&data, tail),
+            type_info: &type_info,
+        })
+        .expect("serialize List<UInt8> fixed array to CDR");
+
+        let binary_bytes = cdr_encoding::to_vec::<_, LittleEndian>(&TypedValue {
+            value: &build_byte_array_binary(&data, tail),
+            type_info: &type_info,
+        })
+        .expect("serialize Binary fixed array to CDR");
+
+        assert_eq!(
+            binary_bytes, list_bytes,
+            "Binary fixed-array encoding diverges from List<UInt8>"
+        );
+
+        // Decode with a real CDR reader to confirm the trailing field aligns.
+        // A `uint8[3]` field is a bare 3-tuple (no length prefix) on the wire.
+        let (decoded, _consumed): (([u8; 3], i32), _) =
+            cdr_encoding::from_bytes::<([u8; 3], i32), LittleEndian>(&binary_bytes)
+                .expect("deserialize fixed array from CDR");
+        assert_eq!(
+            decoded.0,
+            data.as_slice(),
+            "fixed byte-array values corrupted"
+        );
+        assert_eq!(
+            decoded.1, tail,
+            "trailing field after fixed byte array corrupted"
+        );
+    }
+
+    /// #3065: the fixed-size length check (#2027) must also apply to the `Binary`
+    /// representation — a wrong-length byte buffer must error, not silently emit
+    /// a mis-sized tuple.
+    #[test]
+    fn fixed_byte_array_binary_length_is_checked() {
+        let type_info = |size| TypeInfo {
+            package_name: Cow::Borrowed("test_msgs"),
+            message_name: Cow::Borrowed("ByteArrMsg"),
+            messages: byte_array_then_int32_message(size),
+        };
+
+        // 3 bytes into a `uint8[3]` field: serializes.
+        cdr_encoding::to_vec::<_, LittleEndian>(&TypedValue {
+            value: &build_byte_array_binary(&[1, 2, 3], 0),
+            type_info: &type_info(3),
+        })
+        .expect("size-3 field with 3 bytes must serialize");
+
+        // 2 bytes into a `uint8[3]` field: must error.
+        cdr_encoding::to_vec::<_, LittleEndian>(&TypedValue {
+            value: &build_byte_array_binary(&[1, 2], 0),
+            type_info: &type_info(3),
+        })
+        .expect_err("size-3 field with 2 bytes must error");
     }
 }

--- a/libraries/extensions/ros2-bridge/arrow/src/serialize/array.rs
+++ b/libraries/extensions/ros2-bridge/arrow/src/serialize/array.rs
@@ -579,7 +579,7 @@ mod tests {
 
     /// #3065: the fixed-size length check (#2027) must also apply to the `Binary`
     /// representation — a wrong-length byte buffer must error, not silently emit
-    /// a mis-sized tuple.
+    /// a wrong-sized tuple.
     #[test]
     fn fixed_byte_array_binary_length_is_checked() {
         let type_info = |size| TypeInfo {


### PR DESCRIPTION
## Summary

Fixes #3065.

The serializer for **fixed-size array** message fields (`type[N]`, e.g. `uint8[16] uuid`) only accepted an Arrow `List`/`LargeList` column. The **variable-length sequence** serializer, by contrast, was extended in #2507 / #2816 to also accept an Arrow `Binary`/`LargeBinary` column — the representation a `pyarrow` producer naturally uses for a byte buffer. As a result, a byte-valued fixed-size array supplied as a `Binary` column failed serialization with `value is not compatible with expected array type`, while the identical value in a `sequence`/`uint8[]` field serialized fine.

This affected common messages such as `unique_identifier_msgs/msg/UUID` (`uint8[16] uuid`) when the field is produced as an Arrow `Binary` column.

## Changes

`libraries/extensions/ros2-bridge/arrow/src/serialize/array.rs`:

- `ArraySerializeWrapper::serialize` now handles a single-row `Binary`/`LargeBinary` column before the generic `List` extraction, mirroring the sequence path.
- New `serialize_binary_fixed_array` helper serializes the row's bytes directly into the fixed-size tuple, keeping the existing fixed-size length check (`check_array_len`, #2027) — now applied to the byte count.
- A `Binary` column supplied for a **non-byte** element type is rejected as a genuine type mismatch, rather than silently mis-serialized.

## Behavior

- `uint8[N]` / `char[N]` / `byte[N]` supplied as `Binary`/`LargeBinary` now serializes, and encodes byte-for-byte identically to the same value supplied as `List<UInt8>`.
- A wrong-length `Binary` buffer still errors (fixed arrays have no CDR length prefix, so length must match exactly).
- The dora-internal round trip is unaffected — the deserializer still emits `List`; this only closes the gap for external Arrow producers that use `Binary` for byte fields.

## Tests

Added regression tests in the same file:

- `fixed_byte_array_binary_matches_list` — a `uint8[3]` field as `Binary` encodes identically to `List<UInt8>`, with a trailing `int32` field decoded via a real CDR reader to verify wire alignment.
- `fixed_byte_array_binary_length_is_checked` — a wrong-length byte buffer errors; a correct-length one serializes.

All 21 tests in the crate pass; `cargo fmt --check` and `cargo clippy -- -D warnings` are clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_013CswsuhodunaWKhA77nuXa)_