### PR TITLE
fix(daemon): don't await NodeRestarted delivery on the main event loop

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -6074,44 +6074,65 @@ impl Daemon {
                                         // NodeRestarted is a critical lifecycle event:
                                         // dropping it leaves service/action clients
                                         // blocked on pre-crash correlations forever
-                                        // (dora-rs/adora#148). Use an unconditional
-                                        // backpressure-aware send to guarantee delivery.
+                                        // (dora-rs/adora#148). Guarantee delivery with a
+                                        // backpressure-aware send — but do NOT await it
+                                        // on the daemon main loop.
                                         //
-                                        // This blocks the daemon main loop until the
-                                        // receiver drains one slot. Acceptable because:
-                                        // - NodeRestarted is rare (only on crash+restart)
-                                        // - The receiver (Listener::run_inner) is a tokio
-                                        //   task on the same runtime, so it will make
-                                        //   progress cooperatively
-                                        // - If the receiver is dead the channel is closed
-                                        //   and send() returns Err immediately
+                                        // Awaiting here suspends the single serial event
+                                        // loop until the receiver drains a slot. If that
+                                        // receiver's Listener is itself parked on
+                                        // `daemon_tx.send().await` (the daemon event
+                                        // channel at capacity), it never returns to drain
+                                        // its subscribe channel, so the two block each
+                                        // other forever and the whole daemon hangs
+                                        // (dora-rs/dora#3066). Offload the awaiting send
+                                        // to a detached task holding cloned handles so the
+                                        // main loop keeps draining `dora_events_rx`.
                                         tracing::warn!(
                                             %dataflow_id,
                                             restarted_node = %node_id,
                                             %receiver_id,
                                             "NodeRestarted try_send failed (channel full); \
-                                             awaiting backpressure delivery"
+                                             offloading backpressure delivery to a task"
                                         );
+                                        let channel = channel.clone();
+                                        // Clone the receiver's pending counter so the task
+                                        // can pair the enqueue with `inc_pending` off the
+                                        // main loop. The Listener decrements once per
+                                        // drained event, so the increment must land iff
+                                        // the message is actually enqueued (Ok), exactly
+                                        // as the inline delivery sites do (dora-rs/dora#2827).
+                                        let pending =
+                                            dataflow.pending_messages.get(receiver_id).cloned();
                                         let msg = Timestamped {
                                             inner: NodeEvent::NodeRestarted {
                                                 id: node_id.clone(),
                                             },
                                             timestamp: self.clock.new_timestamp(),
                                         };
-                                        match channel.send(msg).await {
-                                            Ok(()) => {
-                                                dataflow.inc_pending(receiver_id);
+                                        let restarted_node = node_id.clone();
+                                        let receiver = receiver_id.clone();
+                                        tokio::spawn(async move {
+                                            match channel.send(msg).await {
+                                                Ok(()) => {
+                                                    if let Some(counter) = pending {
+                                                        counter.fetch_add(
+                                                            1,
+                                                            std::sync::atomic::Ordering::Relaxed,
+                                                        );
+                                                    }
+                                                }
+                                                Err(_closed) => {
+                                                    tracing::warn!(
+                                                        %dataflow_id,
+                                                        %restarted_node,
+                                                        %receiver,
+                                                        "NodeRestarted delivery failed: \
+                                                         receiver channel closed"
+                                                    );
+                                                }
                                             }
-                                            Err(_closed) => {
-                                                tracing::warn!(
-                                                    %dataflow_id,
-                                                    restarted_node = %node_id,
-                                                    %receiver_id,
-                                                    "NodeRestarted delivery failed: \
-                                                     receiver channel closed"
-                                                );
-                                            }
-                                        }
+                                        });
                                     }
                                     Err(_) => {
                                         tracing::warn!(


### PR DESCRIPTION
## Summary

Fixes #3066.

When a crashed node is restarted, the daemon notifies each downstream receiver with `NodeRestarted`. The fast path is a non-blocking `send_with_timestamp` (control-classed, so it uses the control-headroom reservation). When that still reports the channel full (`Ok(false)`), the fallback did an **unconditional, backpressure-aware `channel.send(msg).await` directly on the daemon's single serial event loop** to guarantee the critical lifecycle event isn't dropped.

### Why that can deadlock

The daemon runs one serial loop that consumes `dora_events_rx` and `.await`s `handle_dora_event`. Awaiting the per-node send inside that loop suspends the entire loop until the receiver drains a slot:

1. Main loop blocks at `channel.send().await`, waiting on receiver **B**'s full subscribe channel.
2. While blocked, it stops draining `dora_events_rx`, which fills to its 1000-slot capacity under load.
3. Receiver **B**'s `Listener`, having taken a message from node B, is parked in `process_daemon_event` on the now-full `daemon_tx.send().await` — so it's **not** in its select loop and never drains B's subscribe channel.
4. Circular wait → the whole daemon (and every dataflow on the machine) hangs.

This was the only unconditional blocking send on the main loop; every other delivery site uses the non-blocking `send_with_timestamp` / `try_send`.

## Fix

Offload the guaranteed delivery to a detached `tokio::spawn` task holding a **cloned** channel (`mpsc::Sender`) and a **clone of the receiver's pending counter** (`Arc<AtomicU64>`). The main loop no longer awaits a per-node channel, so it keeps draining `dora_events_rx` and the circular wait cannot form.

This is exactly the direction suggested in the issue.

### Accounting is preserved

`inc_pending` is a `fetch_add` on the receiver's `pending_messages` counter, and the `Listener` decrements it once per drained event. The increment must land **iff** the message is actually enqueued, or the count underflows to `u64::MAX` (#2827). The detached task increments the cloned counter only on `Ok(())` from `send().await` — the same pairing (and the same post-send ordering) the inline `channel.send(...).await` had, just moved off the main loop.

## Trade-off

Under this rare channel-full condition, a later event to the same receiver could now be enqueued ahead of the `NodeRestarted` (the awaiting send is no longer a barrier on the main loop). `NodeRestarted` concerns a node that has just crashed and is only now restarting, so reordering it relative to unrelated downstream traffic is benign — and vastly preferable to a full-daemon hang.

## Testing

- `cargo build -p dora-daemon`, `cargo clippy -p dora-daemon -- -D warnings`, and `cargo fmt --check` all pass.

The deadlock is a liveness bug that requires a specific concurrent backpressure state (both the subscribe channel and `dora_events_rx` at capacity during a crash+restart) and is not reproducible in a unit test with the current harness, so this change is verified by construction/reasoning rather than a new regression test. The change is a minimal, behavior-preserving relocation of the existing send.

---
_Generated by [Claude Code](https://claude.ai/code/session_013CswsuhodunaWKhA77nuXa)_