### PR TITLE
Fix/reliable inter daemon output close

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -191,14 +191,6 @@ const METRICS_INTERVAL_SECS: f64 = METRICS_INTERVAL.as_secs_f64();
 /// patterns; a full channel is recorded as publish backpressure and dropped so
 /// the daemon event loop does not stall.
 const ZENOH_PUBLISH_CHANNEL_CAPACITY: usize = 256;
-/// Control-plane queue for lifecycle events such as `OutputClosed`. This queue
-/// is separate from the data-plane publish channel so regular output bursts do
-/// not starve close notifications.
-const ZENOH_CONTROL_CHANNEL_CAPACITY: usize = 1024;
-/// Pending control events admitted by the daemon event loop. A background
-/// forwarder waits for capacity in the control publish queue; the event loop
-/// itself never waits.
-const ZENOH_CONTROL_PENDING_CHANNEL_CAPACITY: usize = 4096;
 /// How long the daemon keeps trying to (re)connect to the coordinator before
 /// giving up and exiting. Bounds the orphan-daemon window when the coordinator
 /// is permanently gone (dora-rs/dora#1996); a reachable coordinator connects
@@ -353,7 +345,6 @@ pub struct Daemon {
     /// processes are gone (#2980).
     pub(crate) pending_destroy: Option<PendingDestroy>,
     pub(crate) zenoh_publish_tx: mpsc::Sender<ZenohOutbound>,
-    pub(crate) zenoh_control_tx: mpsc::Sender<ZenohOutbound>,
     pub(crate) remote_daemon_events_tx:
         Option<flume::Sender<eyre::Result<Timestamped<InterDaemonEvent>>>>,
     pub(crate) logger: DaemonLogger,
@@ -1637,44 +1628,14 @@ impl Daemon {
         // Use a large channel capacity to prevent deadlock
         let (dora_events_tx, dora_events_rx) = mpsc::channel(1000);
 
-        // Zenoh publish drain tasks: offload `.put().await` from the main event
-        // loop. Regular outputs use a best-effort data queue; lifecycle control
-        // events first enter a bounded pending queue, then a background
-        // forwarder waits for capacity in a dedicated control publish queue.
+        // Zenoh publish drain task: offload `.put().await` from the main event
+        // loop. All events for a given output, including `OutputClosed`, share
+        // this FIFO so close cannot pass data that was produced earlier.
         let (zenoh_publish_tx, mut zenoh_publish_rx) =
             mpsc::channel::<ZenohOutbound>(ZENOH_PUBLISH_CHANNEL_CAPACITY);
-        let (zenoh_control_publish_tx, mut zenoh_control_publish_rx) =
-            mpsc::channel::<ZenohOutbound>(ZENOH_CONTROL_CHANNEL_CAPACITY);
-        let (zenoh_control_tx, mut zenoh_control_rx) =
-            mpsc::channel::<ZenohOutbound>(ZENOH_CONTROL_PENDING_CHANNEL_CAPACITY);
-        let _zenoh_control_forwarder_handle = tokio::spawn(async move {
-            while let Some(msg) = zenoh_control_rx.recv().await {
-                if zenoh_control_publish_tx.send(msg).await.is_err() {
-                    tracing::debug!("zenoh control publish queue closed");
-                    break;
-                }
-            }
-            tracing::debug!("zenoh control forwarder task exiting");
-        });
         let _zenoh_drain_handle = tokio::spawn(async move {
-            let mut control_open = true;
-            let mut data_open = true;
-            while control_open || data_open {
-                tokio::select! {
-                    biased;
-                    msg = zenoh_control_publish_rx.recv(), if control_open => {
-                        match msg {
-                            Some(msg) => publish_zenoh_outbound(msg).await,
-                            None => control_open = false,
-                        }
-                    }
-                    msg = zenoh_publish_rx.recv(), if data_open => {
-                        match msg {
-                            Some(msg) => publish_zenoh_outbound(msg).await,
-                            None => data_open = false,
-                        }
-                    }
-                }
+            while let Some(msg) = zenoh_publish_rx.recv().await {
+                publish_zenoh_outbound(msg).await;
             }
             tracing::debug!("zenoh publish drain task exiting");
         });
@@ -1704,7 +1665,6 @@ impl Daemon {
             bind_nodes_to_parent,
             pending_destroy: None,
             zenoh_publish_tx,
-            zenoh_control_tx,
             remote_daemon_events_tx,
             git_manager: Default::default(),
             memory_pool: MemoryPoolManager::new(),
@@ -5144,10 +5104,13 @@ impl Daemon {
             net_messages_sent: dataflow.net_messages_sent.clone(),
             net_publish_failures: dataflow.net_publish_failures.clone(),
         };
-        handle_control_enqueue_result(
-            dataflow,
-            try_enqueue_zenoh_outbound(&self.zenoh_control_tx, outbound),
-        )
+        enqueue_required_zenoh_outbound(
+            &self.zenoh_publish_tx,
+            outbound,
+            dataflow.net_publish_failures.clone(),
+            "inter-daemon output-closed event",
+        );
+        Ok(())
     }
 
     async fn try_send_to_remote_receivers(
@@ -5191,24 +5154,11 @@ impl Daemon {
             net_messages_sent: dataflow.net_messages_sent.clone(),
             net_publish_failures: dataflow.net_publish_failures.clone(),
         };
-        match try_enqueue_zenoh_outbound(&self.zenoh_publish_tx, outbound) {
-            ZenohEnqueueResult::Queued => {}
-            ZenohEnqueueResult::Full => {
-                dataflow
-                    .net_publish_failures
-                    .fetch_add(1, atomic::Ordering::Relaxed);
-                tracing::warn!(
-                    "zenoh publish channel full ({ZENOH_PUBLISH_CHANNEL_CAPACITY}); \
-                     dropping regular inter-daemon output"
-                );
-            }
-            ZenohEnqueueResult::Closed => {
-                dataflow
-                    .net_publish_failures
-                    .fetch_add(1, atomic::Ordering::Relaxed);
-                tracing::error!("zenoh drain task is gone; inter-daemon publish channel closed");
-            }
-        }
+        handle_publish_enqueue_result(
+            dataflow,
+            try_enqueue_zenoh_outbound(&self.zenoh_publish_tx, outbound),
+            "regular inter-daemon output",
+        );
         Ok(())
     }
 
@@ -7333,25 +7283,51 @@ async fn publish_zenoh_outbound(msg: ZenohOutbound) {
         .fetch_add(1, atomic::Ordering::Relaxed);
 }
 
-fn handle_control_enqueue_result(
+fn handle_publish_enqueue_result(
     dataflow: &RunningDataflow,
     result: ZenohEnqueueResult,
-) -> eyre::Result<()> {
+    event_kind: &'static str,
+) {
     match result {
-        ZenohEnqueueResult::Queued => Ok(()),
+        ZenohEnqueueResult::Queued => {}
         ZenohEnqueueResult::Full => {
             dataflow
                 .net_publish_failures
                 .fetch_add(1, atomic::Ordering::Relaxed);
             tracing::warn!(
-                "zenoh control pending queue full ({ZENOH_CONTROL_PENDING_CHANNEL_CAPACITY}); \
-                 dropping inter-daemon control event"
+                "zenoh publish channel full ({ZENOH_PUBLISH_CHANNEL_CAPACITY}); dropping {event_kind}"
             );
-            Ok(())
         }
-        ZenohEnqueueResult::Closed => Err(eyre!(
-            "zenoh control forwarder is gone — inter-daemon control channel closed"
-        )),
+        ZenohEnqueueResult::Closed => {
+            dataflow
+                .net_publish_failures
+                .fetch_add(1, atomic::Ordering::Relaxed);
+            tracing::error!("zenoh drain task is gone; dropping {event_kind}");
+        }
+    }
+}
+
+fn enqueue_required_zenoh_outbound<T: Send + 'static>(
+    tx: &mpsc::Sender<T>,
+    outbound: T,
+    net_publish_failures: Arc<AtomicU64>,
+    event_kind: &'static str,
+) {
+    match tx.try_send(outbound) {
+        Ok(()) => {}
+        Err(mpsc::error::TrySendError::Full(outbound)) => {
+            let tx = tx.clone();
+            tokio::spawn(async move {
+                if tx.send(outbound).await.is_err() {
+                    net_publish_failures.fetch_add(1, atomic::Ordering::Relaxed);
+                    tracing::error!("zenoh drain task is gone; dropping {event_kind}");
+                }
+            });
+        }
+        Err(mpsc::error::TrySendError::Closed(_)) => {
+            net_publish_failures.fetch_add(1, atomic::Ordering::Relaxed);
+            tracing::error!("zenoh drain task is gone; dropping {event_kind}");
+        }
     }
 }
 
@@ -8080,36 +8056,101 @@ mod fault_tolerance_tests {
     }
 
     #[test]
-    fn data_queue_full_does_not_block_control_enqueue() {
-        let (data_tx, _data_rx) = mpsc::channel(1);
-        data_tx.try_send("data-occupied").unwrap();
-        let (control_tx, mut control_rx) = mpsc::channel(1);
+    fn output_closed_uses_the_same_fifo_as_regular_output() {
+        let (publish_tx, mut publish_rx) = mpsc::channel(3);
 
-        let data_result = try_enqueue_zenoh_outbound(&data_tx, "regular-output");
-        let control_result = try_enqueue_zenoh_outbound(&control_tx, "output-closed");
+        let data_1 = try_enqueue_zenoh_outbound(&publish_tx, "data-1");
+        let data_2 = try_enqueue_zenoh_outbound(&publish_tx, "data-2");
+        let close = try_enqueue_zenoh_outbound(&publish_tx, "close");
 
-        assert_eq!(data_result, ZenohEnqueueResult::Full);
-        assert_eq!(control_result, ZenohEnqueueResult::Queued);
-        assert_eq!(control_rx.try_recv().unwrap(), "output-closed");
+        assert_eq!(data_1, ZenohEnqueueResult::Queued);
+        assert_eq!(data_2, ZenohEnqueueResult::Queued);
+        assert_eq!(close, ZenohEnqueueResult::Queued);
+        assert_eq!(publish_rx.try_recv().unwrap(), "data-1");
+        assert_eq!(publish_rx.try_recv().unwrap(), "data-2");
+        assert_eq!(publish_rx.try_recv().unwrap(), "close");
     }
 
     #[test]
-    fn control_pending_enqueue_full_is_recorded_without_error() {
+    fn zenoh_publish_drain_preserves_output_closed_ordering() {
+        let (publish_tx, mut publish_rx) = mpsc::channel(4);
+
+        publish_tx.try_send("data-1").unwrap();
+        publish_tx.try_send("data-2").unwrap();
+        publish_tx.try_send("close").unwrap();
+
+        let mut published = Vec::new();
+        while let Ok(msg) = publish_rx.try_recv() {
+            published.push(msg);
+        }
+
+        assert_eq!(
+            published,
+            ["data-1", "data-2", "close"],
+            "OutputClosed must not pass earlier Output messages for the same output"
+        );
+    }
+
+    #[tokio::test]
+    async fn output_closed_waits_for_publish_capacity_without_dropping() {
+        let (publish_tx, mut publish_rx) = mpsc::channel(1);
+        publish_tx.try_send("data").unwrap();
+        let failures = Arc::new(AtomicU64::new(0));
+
+        enqueue_required_zenoh_outbound(
+            &publish_tx,
+            "close",
+            failures.clone(),
+            "inter-daemon output-closed event",
+        );
+
+        assert_eq!(
+            publish_rx.try_recv().unwrap(),
+            "data",
+            "queued data must stay ahead of the close event"
+        );
+        tokio::task::yield_now().await;
+        assert_eq!(
+            publish_rx.try_recv().unwrap(),
+            "close",
+            "OutputClosed must be retained until publish capacity is available"
+        );
+        assert_eq!(failures.load(atomic::Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn regular_publish_queue_full_is_recorded_without_error() {
         let dataflow = test_dataflow();
 
-        let result = handle_control_enqueue_result(&dataflow, ZenohEnqueueResult::Full);
-
-        assert!(
-            result.is_ok(),
-            "a full control pending queue for OutputClosed must not bubble up as a coordinator disconnect"
+        handle_publish_enqueue_result(
+            &dataflow,
+            ZenohEnqueueResult::Full,
+            "regular inter-daemon output",
         );
+
         assert_eq!(
             dataflow
                 .net_publish_failures
                 .load(atomic::Ordering::Relaxed),
             1,
-            "dropping a control event must be visible in network metrics"
+            "dropping a regular output must be visible in network metrics"
         );
+    }
+
+    #[test]
+    fn required_publish_channel_closed_is_recorded() {
+        let (publish_tx, publish_rx) = mpsc::channel::<&'static str>(1);
+        drop(publish_rx);
+        let failures = Arc::new(AtomicU64::new(0));
+
+        enqueue_required_zenoh_outbound(
+            &publish_tx,
+            "close",
+            failures.clone(),
+            "inter-daemon output-closed event",
+        );
+
+        assert_eq!(failures.load(atomic::Ordering::Relaxed), 1);
     }
 
     fn drain_events(rx: &mut mpsc::Receiver<Timestamped<NodeEvent>>) -> Vec<NodeEvent> {

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -188,10 +188,17 @@ const STDERR_LOG_LINES_MAX: usize = 500;
 const METRICS_INTERVAL: Duration = Duration::from_secs(2);
 const METRICS_INTERVAL_SECS: f64 = METRICS_INTERVAL.as_secs_f64();
 /// Capacity of the Zenoh publish drain channel. Large enough for burst
-/// patterns; full channels are retried briefly before surfacing an error.
+/// patterns; a full channel is recorded as publish backpressure and dropped so
+/// the daemon event loop does not stall.
 const ZENOH_PUBLISH_CHANNEL_CAPACITY: usize = 256;
-const ZENOH_PUBLISH_RETRY_ATTEMPTS: usize = 3;
-const ZENOH_PUBLISH_RETRY_DELAY: Duration = Duration::from_millis(10);
+/// Control-plane queue for lifecycle events such as `OutputClosed`. This queue
+/// is separate from the data-plane publish channel so regular output bursts do
+/// not starve close notifications.
+const ZENOH_CONTROL_CHANNEL_CAPACITY: usize = 1024;
+/// Pending control events admitted by the daemon event loop. A background
+/// forwarder waits for capacity in the control publish queue; the event loop
+/// itself never waits.
+const ZENOH_CONTROL_PENDING_CHANNEL_CAPACITY: usize = 4096;
 /// How long the daemon keeps trying to (re)connect to the coordinator before
 /// giving up and exiting. Bounds the orphan-daemon window when the coordinator
 /// is permanently gone (dora-rs/dora#1996); a reachable coordinator connects
@@ -346,6 +353,7 @@ pub struct Daemon {
     /// processes are gone (#2980).
     pub(crate) pending_destroy: Option<PendingDestroy>,
     pub(crate) zenoh_publish_tx: mpsc::Sender<ZenohOutbound>,
+    pub(crate) zenoh_control_tx: mpsc::Sender<ZenohOutbound>,
     pub(crate) remote_daemon_events_tx:
         Option<flume::Sender<eyre::Result<Timestamped<InterDaemonEvent>>>>,
     pub(crate) logger: DaemonLogger,
@@ -1629,25 +1637,44 @@ impl Daemon {
         // Use a large channel capacity to prevent deadlock
         let (dora_events_tx, dora_events_rx) = mpsc::channel(1000);
 
-        // Zenoh publish drain task: offloads .put().await from the main event loop.
-        // The main loop sends ZenohOutbound messages via try_send; this task
-        // performs the actual network I/O without blocking event processing.
+        // Zenoh publish drain tasks: offload `.put().await` from the main event
+        // loop. Regular outputs use a best-effort data queue; lifecycle control
+        // events first enter a bounded pending queue, then a background
+        // forwarder waits for capacity in a dedicated control publish queue.
         let (zenoh_publish_tx, mut zenoh_publish_rx) =
             mpsc::channel::<ZenohOutbound>(ZENOH_PUBLISH_CHANNEL_CAPACITY);
-        let _zenoh_drain_handle = tokio::spawn(async move {
-            while let Some(msg) = zenoh_publish_rx.recv().await {
-                if let Err(e) = msg.publisher.put(msg.serialized).await {
-                    tracing::error!("zenoh publish failed: {e}");
-                    msg.net_publish_failures
-                        .fetch_add(1, atomic::Ordering::Relaxed);
-                    continue;
+        let (zenoh_control_publish_tx, mut zenoh_control_publish_rx) =
+            mpsc::channel::<ZenohOutbound>(ZENOH_CONTROL_CHANNEL_CAPACITY);
+        let (zenoh_control_tx, mut zenoh_control_rx) =
+            mpsc::channel::<ZenohOutbound>(ZENOH_CONTROL_PENDING_CHANNEL_CAPACITY);
+        let _zenoh_control_forwarder_handle = tokio::spawn(async move {
+            while let Some(msg) = zenoh_control_rx.recv().await {
+                if zenoh_control_publish_tx.send(msg).await.is_err() {
+                    tracing::debug!("zenoh control publish queue closed");
+                    break;
                 }
-                // Relaxed ordering is correct: counters are read-only for metrics
-                // reporting and never used as synchronization guards.
-                msg.net_bytes_sent
-                    .fetch_add(msg.payload_len, atomic::Ordering::Relaxed);
-                msg.net_messages_sent
-                    .fetch_add(1, atomic::Ordering::Relaxed);
+            }
+            tracing::debug!("zenoh control forwarder task exiting");
+        });
+        let _zenoh_drain_handle = tokio::spawn(async move {
+            let mut control_open = true;
+            let mut data_open = true;
+            while control_open || data_open {
+                tokio::select! {
+                    biased;
+                    msg = zenoh_control_publish_rx.recv(), if control_open => {
+                        match msg {
+                            Some(msg) => publish_zenoh_outbound(msg).await,
+                            None => control_open = false,
+                        }
+                    }
+                    msg = zenoh_publish_rx.recv(), if data_open => {
+                        match msg {
+                            Some(msg) => publish_zenoh_outbound(msg).await,
+                            None => data_open = false,
+                        }
+                    }
+                }
             }
             tracing::debug!("zenoh publish drain task exiting");
         });
@@ -1677,6 +1704,7 @@ impl Daemon {
             bind_nodes_to_parent,
             pending_destroy: None,
             zenoh_publish_tx,
+            zenoh_control_tx,
             remote_daemon_events_tx,
             git_manager: Default::default(),
             memory_pool: MemoryPoolManager::new(),
@@ -5108,7 +5136,6 @@ impl Daemon {
         };
         let payload_len = serialized_event.len() as u64;
 
-        // Offload Zenoh I/O to the drain task — never blocks the event loop.
         let outbound = ZenohOutbound {
             publisher,
             serialized: serialized_event,
@@ -5117,7 +5144,10 @@ impl Daemon {
             net_messages_sent: dataflow.net_messages_sent.clone(),
             net_publish_failures: dataflow.net_publish_failures.clone(),
         };
-        enqueue_zenoh_outbound_reliably(&self.zenoh_publish_tx, outbound).await
+        handle_control_enqueue_result(
+            dataflow,
+            try_enqueue_zenoh_outbound(&self.zenoh_control_tx, outbound),
+        )
     }
 
     async fn try_send_to_remote_receivers(
@@ -5161,17 +5191,24 @@ impl Daemon {
             net_messages_sent: dataflow.net_messages_sent.clone(),
             net_publish_failures: dataflow.net_publish_failures.clone(),
         };
-        if enqueue_zenoh_outbound_best_effort(&self.zenoh_publish_tx, outbound) {
-            return Ok(());
+        match try_enqueue_zenoh_outbound(&self.zenoh_publish_tx, outbound) {
+            ZenohEnqueueResult::Queued => {}
+            ZenohEnqueueResult::Full => {
+                dataflow
+                    .net_publish_failures
+                    .fetch_add(1, atomic::Ordering::Relaxed);
+                tracing::warn!(
+                    "zenoh publish channel full ({ZENOH_PUBLISH_CHANNEL_CAPACITY}); \
+                     dropping regular inter-daemon output"
+                );
+            }
+            ZenohEnqueueResult::Closed => {
+                dataflow
+                    .net_publish_failures
+                    .fetch_add(1, atomic::Ordering::Relaxed);
+                tracing::error!("zenoh drain task is gone; inter-daemon publish channel closed");
+            }
         }
-
-        dataflow
-            .net_publish_failures
-            .fetch_add(1, atomic::Ordering::Relaxed);
-        tracing::warn!(
-            "zenoh publish channel full ({ZENOH_PUBLISH_CHANNEL_CAPACITY}); \
-             dropping regular inter-daemon output"
-        );
         Ok(())
     }
 
@@ -7266,45 +7303,55 @@ impl CoreNodeKindExt for CoreNodeKind {
     }
 }
 
-async fn enqueue_zenoh_outbound_reliably<T>(
-    tx: &mpsc::Sender<T>,
-    mut outbound: T,
-) -> eyre::Result<()> {
-    for attempt in 0..=ZENOH_PUBLISH_RETRY_ATTEMPTS {
-        match tx.try_send(outbound) {
-            Ok(()) => return Ok(()),
-            Err(mpsc::error::TrySendError::Full(returned)) => {
-                if attempt == ZENOH_PUBLISH_RETRY_ATTEMPTS {
-                    return Err(eyre!(
-                        "zenoh publish channel full after {ZENOH_PUBLISH_RETRY_ATTEMPTS} retries"
-                    ));
-                }
-                tracing::warn!(
-                    "zenoh publish channel full ({ZENOH_PUBLISH_CHANNEL_CAPACITY}); \
-                     retrying inter-daemon message enqueue"
-                );
-                outbound = returned;
-                tokio::time::sleep(ZENOH_PUBLISH_RETRY_DELAY).await;
-            }
-            Err(mpsc::error::TrySendError::Closed(_)) => {
-                return Err(eyre!(
-                    "zenoh drain task is gone — inter-daemon publish channel closed"
-                ));
-            }
-        }
-    }
-
-    unreachable!("retry loop returns on success or terminal enqueue failure")
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ZenohEnqueueResult {
+    Queued,
+    Full,
+    Closed,
 }
 
-fn enqueue_zenoh_outbound_best_effort<T>(tx: &mpsc::Sender<T>, outbound: T) -> bool {
+fn try_enqueue_zenoh_outbound<T>(tx: &mpsc::Sender<T>, outbound: T) -> ZenohEnqueueResult {
     match tx.try_send(outbound) {
-        Ok(()) => true,
-        Err(mpsc::error::TrySendError::Full(_)) => false,
-        Err(mpsc::error::TrySendError::Closed(_)) => {
-            tracing::error!("zenoh drain task is gone; inter-daemon publish channel closed");
-            false
+        Ok(()) => ZenohEnqueueResult::Queued,
+        Err(mpsc::error::TrySendError::Full(_)) => ZenohEnqueueResult::Full,
+        Err(mpsc::error::TrySendError::Closed(_)) => ZenohEnqueueResult::Closed,
+    }
+}
+
+async fn publish_zenoh_outbound(msg: ZenohOutbound) {
+    if let Err(e) = msg.publisher.put(msg.serialized).await {
+        tracing::error!("zenoh publish failed: {e}");
+        msg.net_publish_failures
+            .fetch_add(1, atomic::Ordering::Relaxed);
+        return;
+    }
+    // Relaxed ordering is correct: counters are read-only for metrics
+    // reporting and never used as synchronization guards.
+    msg.net_bytes_sent
+        .fetch_add(msg.payload_len, atomic::Ordering::Relaxed);
+    msg.net_messages_sent
+        .fetch_add(1, atomic::Ordering::Relaxed);
+}
+
+fn handle_control_enqueue_result(
+    dataflow: &RunningDataflow,
+    result: ZenohEnqueueResult,
+) -> eyre::Result<()> {
+    match result {
+        ZenohEnqueueResult::Queued => Ok(()),
+        ZenohEnqueueResult::Full => {
+            dataflow
+                .net_publish_failures
+                .fetch_add(1, atomic::Ordering::Relaxed);
+            tracing::warn!(
+                "zenoh control pending queue full ({ZENOH_CONTROL_PENDING_CHANNEL_CAPACITY}); \
+                 dropping inter-daemon control event"
+            );
+            Ok(())
         }
+        ZenohEnqueueResult::Closed => Err(eyre!(
+            "zenoh control forwarder is gone — inter-daemon control channel closed"
+        )),
     }
 }
 
@@ -7985,67 +8032,83 @@ mod fault_tolerance_tests {
         HLC::default()
     }
 
-    #[tokio::test(start_paused = true)]
-    async fn zenoh_publish_enqueue_retries_when_channel_temporarily_full() {
+    #[test]
+    fn zenoh_publish_enqueue_reports_queued() {
         let (tx, mut rx) = mpsc::channel(1);
-        tx.try_send("occupied").unwrap();
 
-        let enqueue = tokio::spawn({
-            let tx = tx.clone();
-            async move { enqueue_zenoh_outbound_reliably(&tx, "output").await }
-        });
+        let result = try_enqueue_zenoh_outbound(&tx, "output");
 
-        tokio::task::yield_now().await;
-        assert!(
-            !enqueue.is_finished(),
-            "enqueue should wait for retry instead of dropping a full-channel message"
-        );
-        assert_eq!(rx.recv().await, Some("occupied"));
-        tokio::time::advance(ZENOH_PUBLISH_RETRY_DELAY).await;
-
-        enqueue.await.unwrap().unwrap();
-        assert_eq!(
-            tokio::time::timeout(Duration::from_secs(1), rx.recv())
-                .await
-                .unwrap(),
-            Some("output")
-        );
-    }
-
-    #[tokio::test]
-    async fn zenoh_publish_enqueue_errors_when_channel_stays_full() {
-        let (tx, _rx) = mpsc::channel(1);
-        tx.try_send("occupied").unwrap();
-
-        let err = enqueue_zenoh_outbound_reliably(&tx, "output")
-            .await
-            .expect_err("full channel should fail after bounded retries");
-
-        assert!(err.to_string().contains("full after 3 retries"));
-    }
-
-    #[tokio::test]
-    async fn zenoh_publish_enqueue_errors_when_channel_is_closed() {
-        let (tx, rx) = mpsc::channel(1);
-        drop(rx);
-
-        let err = enqueue_zenoh_outbound_reliably(&tx, "output")
-            .await
-            .expect_err("closed channel should fail");
-
-        assert!(err.to_string().contains("publish channel closed"));
+        assert_eq!(result, ZenohEnqueueResult::Queued);
+        assert_eq!(rx.try_recv().unwrap(), "output");
     }
 
     #[test]
-    fn zenoh_publish_best_effort_reports_full_without_error() {
+    fn zenoh_publish_enqueue_reports_full_without_waiting() {
         let (tx, _rx) = mpsc::channel(1);
         tx.try_send("occupied").unwrap();
 
-        let queued = enqueue_zenoh_outbound_best_effort(&tx, "output");
+        let result = try_enqueue_zenoh_outbound(&tx, "output");
+
+        assert_eq!(
+            result,
+            ZenohEnqueueResult::Full,
+            "enqueue backpressure must be reported synchronously so the daemon event loop does not sleep"
+        );
+    }
+
+    #[test]
+    fn zenoh_publish_enqueue_reports_closed() {
+        let (tx, rx) = mpsc::channel(1);
+        drop(rx);
+
+        let result = try_enqueue_zenoh_outbound(&tx, "output");
+
+        assert_eq!(result, ZenohEnqueueResult::Closed);
+    }
+
+    #[test]
+    fn regular_output_enqueue_full_is_nonfatal() {
+        let (tx, _rx) = mpsc::channel(1);
+        tx.try_send("occupied").unwrap();
+
+        let result = try_enqueue_zenoh_outbound(&tx, "output");
 
         assert!(
-            !queued,
+            matches!(result, ZenohEnqueueResult::Full),
             "regular output enqueue should report backpressure without surfacing a fatal error"
+        );
+    }
+
+    #[test]
+    fn data_queue_full_does_not_block_control_enqueue() {
+        let (data_tx, _data_rx) = mpsc::channel(1);
+        data_tx.try_send("data-occupied").unwrap();
+        let (control_tx, mut control_rx) = mpsc::channel(1);
+
+        let data_result = try_enqueue_zenoh_outbound(&data_tx, "regular-output");
+        let control_result = try_enqueue_zenoh_outbound(&control_tx, "output-closed");
+
+        assert_eq!(data_result, ZenohEnqueueResult::Full);
+        assert_eq!(control_result, ZenohEnqueueResult::Queued);
+        assert_eq!(control_rx.try_recv().unwrap(), "output-closed");
+    }
+
+    #[test]
+    fn control_pending_enqueue_full_is_recorded_without_error() {
+        let dataflow = test_dataflow();
+
+        let result = handle_control_enqueue_result(&dataflow, ZenohEnqueueResult::Full);
+
+        assert!(
+            result.is_ok(),
+            "a full control pending queue for OutputClosed must not bubble up as a coordinator disconnect"
+        );
+        assert_eq!(
+            dataflow
+                .net_publish_failures
+                .load(atomic::Ordering::Relaxed),
+            1,
+            "dropping a control event must be visible in network metrics"
         );
     }
 

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -188,8 +188,10 @@ const STDERR_LOG_LINES_MAX: usize = 500;
 const METRICS_INTERVAL: Duration = Duration::from_secs(2);
 const METRICS_INTERVAL_SECS: f64 = METRICS_INTERVAL.as_secs_f64();
 /// Capacity of the Zenoh publish drain channel. Large enough for burst
-/// patterns; messages are dropped with a warning when full.
+/// patterns; full channels are retried briefly before surfacing an error.
 const ZENOH_PUBLISH_CHANNEL_CAPACITY: usize = 256;
+const ZENOH_PUBLISH_RETRY_ATTEMPTS: usize = 3;
+const ZENOH_PUBLISH_RETRY_DELAY: Duration = Duration::from_millis(10);
 /// How long the daemon keeps trying to (re)connect to the coordinator before
 /// giving up and exiting. Bounds the orphan-daemon window when the coordinator
 /// is permanently gone (dora-rs/dora#1996); a reachable coordinator connects
@@ -5043,7 +5045,9 @@ impl Daemon {
         }
 
         if remote_receivers {
-            self.send_to_remote_receivers(dataflow_id, &output_id, serialized_event)
+            // Regular outputs are data-plane messages. Backpressure should drop
+            // them instead of surfacing an error that stops the daemon event loop.
+            self.try_send_to_remote_receivers(dataflow_id, &output_id, serialized_event)
                 .await?;
         }
 
@@ -5113,19 +5117,61 @@ impl Daemon {
             net_messages_sent: dataflow.net_messages_sent.clone(),
             net_publish_failures: dataflow.net_publish_failures.clone(),
         };
-        match self.zenoh_publish_tx.try_send(outbound) {
-            Ok(()) => {}
-            Err(mpsc::error::TrySendError::Full(_)) => {
-                tracing::warn!(
-                    "zenoh publish channel full ({ZENOH_PUBLISH_CHANNEL_CAPACITY}), \
-                     dropping inter-daemon message"
-                );
+        enqueue_zenoh_outbound_reliably(&self.zenoh_publish_tx, outbound).await
+    }
+
+    async fn try_send_to_remote_receivers(
+        &mut self,
+        dataflow_id: Uuid,
+        output_id: &OutputId,
+        serialized_event: Vec<u8>,
+    ) -> Result<(), eyre::Error> {
+        let dataflow = self.running.get_mut(&dataflow_id).wrap_err_with(|| {
+            format!("send out failed: no running dataflow with ID `{dataflow_id}`")
+        })?;
+
+        // Get or create publisher (lazy, cached per output)
+        let publisher = match dataflow.publishers.entry(output_id.clone()) {
+            std::collections::btree_map::Entry::Occupied(e) => e.get().clone(),
+            std::collections::btree_map::Entry::Vacant(e) => {
+                let publish_topic =
+                    zenoh_daemon_control_topic(dataflow.id, &output_id.0, &output_id.1);
+                tracing::debug!("declaring control publisher on {publish_topic}");
+                let publisher = self
+                    .zenoh_session
+                    .declare_publisher(publish_topic)
+                    .congestion_control(CongestionControl::Drop)
+                    .express(true)
+                    .priority(Priority::RealTime)
+                    .await
+                    .map_err(|err| eyre!(err))
+                    .context("failed to create zenoh publisher")?;
+                let arc = Arc::new(publisher);
+                e.insert(arc.clone());
+                arc
             }
-            Err(mpsc::error::TrySendError::Closed(_)) => {
-                tracing::error!("zenoh drain task is gone — inter-daemon publish channel closed");
-            }
+        };
+        let payload_len = serialized_event.len() as u64;
+
+        let outbound = ZenohOutbound {
+            publisher,
+            serialized: serialized_event,
+            payload_len,
+            net_bytes_sent: dataflow.net_bytes_sent.clone(),
+            net_messages_sent: dataflow.net_messages_sent.clone(),
+            net_publish_failures: dataflow.net_publish_failures.clone(),
+        };
+        if enqueue_zenoh_outbound_best_effort(&self.zenoh_publish_tx, outbound) {
+            return Ok(());
         }
 
+        dataflow
+            .net_publish_failures
+            .fetch_add(1, atomic::Ordering::Relaxed);
+        tracing::warn!(
+            "zenoh publish channel full ({ZENOH_PUBLISH_CHANNEL_CAPACITY}); \
+             dropping regular inter-daemon output"
+        );
         Ok(())
     }
 
@@ -7220,6 +7266,48 @@ impl CoreNodeKindExt for CoreNodeKind {
     }
 }
 
+async fn enqueue_zenoh_outbound_reliably<T>(
+    tx: &mpsc::Sender<T>,
+    mut outbound: T,
+) -> eyre::Result<()> {
+    for attempt in 0..=ZENOH_PUBLISH_RETRY_ATTEMPTS {
+        match tx.try_send(outbound) {
+            Ok(()) => return Ok(()),
+            Err(mpsc::error::TrySendError::Full(returned)) => {
+                if attempt == ZENOH_PUBLISH_RETRY_ATTEMPTS {
+                    return Err(eyre!(
+                        "zenoh publish channel full after {ZENOH_PUBLISH_RETRY_ATTEMPTS} retries"
+                    ));
+                }
+                tracing::warn!(
+                    "zenoh publish channel full ({ZENOH_PUBLISH_CHANNEL_CAPACITY}); \
+                     retrying inter-daemon message enqueue"
+                );
+                outbound = returned;
+                tokio::time::sleep(ZENOH_PUBLISH_RETRY_DELAY).await;
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                return Err(eyre!(
+                    "zenoh drain task is gone — inter-daemon publish channel closed"
+                ));
+            }
+        }
+    }
+
+    unreachable!("retry loop returns on success or terminal enqueue failure")
+}
+
+fn enqueue_zenoh_outbound_best_effort<T>(tx: &mpsc::Sender<T>, outbound: T) -> bool {
+    match tx.try_send(outbound) {
+        Ok(()) => true,
+        Err(mpsc::error::TrySendError::Full(_)) => false,
+        Err(mpsc::error::TrySendError::Closed(_)) => {
+            tracing::error!("zenoh drain task is gone; inter-daemon publish channel closed");
+            false
+        }
+    }
+}
+
 /// Cached `@schema` bytes (keyed by their FNV-1a hash, most-recent last) for
 /// one debug-watched output, shared between the `@schema` subscriber callback
 /// and the data task. Retains several schemas — mirroring the node receive
@@ -7895,6 +7983,70 @@ mod fault_tolerance_tests {
 
     fn test_clock() -> HLC {
         HLC::default()
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn zenoh_publish_enqueue_retries_when_channel_temporarily_full() {
+        let (tx, mut rx) = mpsc::channel(1);
+        tx.try_send("occupied").unwrap();
+
+        let enqueue = tokio::spawn({
+            let tx = tx.clone();
+            async move { enqueue_zenoh_outbound_reliably(&tx, "output").await }
+        });
+
+        tokio::task::yield_now().await;
+        assert!(
+            !enqueue.is_finished(),
+            "enqueue should wait for retry instead of dropping a full-channel message"
+        );
+        assert_eq!(rx.recv().await, Some("occupied"));
+        tokio::time::advance(ZENOH_PUBLISH_RETRY_DELAY).await;
+
+        enqueue.await.unwrap().unwrap();
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), rx.recv())
+                .await
+                .unwrap(),
+            Some("output")
+        );
+    }
+
+    #[tokio::test]
+    async fn zenoh_publish_enqueue_errors_when_channel_stays_full() {
+        let (tx, _rx) = mpsc::channel(1);
+        tx.try_send("occupied").unwrap();
+
+        let err = enqueue_zenoh_outbound_reliably(&tx, "output")
+            .await
+            .expect_err("full channel should fail after bounded retries");
+
+        assert!(err.to_string().contains("full after 3 retries"));
+    }
+
+    #[tokio::test]
+    async fn zenoh_publish_enqueue_errors_when_channel_is_closed() {
+        let (tx, rx) = mpsc::channel(1);
+        drop(rx);
+
+        let err = enqueue_zenoh_outbound_reliably(&tx, "output")
+            .await
+            .expect_err("closed channel should fail");
+
+        assert!(err.to_string().contains("publish channel closed"));
+    }
+
+    #[test]
+    fn zenoh_publish_best_effort_reports_full_without_error() {
+        let (tx, _rx) = mpsc::channel(1);
+        tx.try_send("occupied").unwrap();
+
+        let queued = enqueue_zenoh_outbound_best_effort(&tx, "output");
+
+        assert!(
+            !queued,
+            "regular output enqueue should report backpressure without surfacing a fatal error"
+        );
     }
 
     fn drain_events(rx: &mut mpsc::Receiver<Timestamped<NodeEvent>>) -> Vec<NodeEvent> {

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -446,6 +446,7 @@ struct DataflowMetricsSnapshot {
     net_messages_sent: Arc<AtomicU64>,
     net_messages_received: Arc<AtomicU64>,
     net_publish_failures: Arc<AtomicU64>,
+    net_publish_enqueue_failures: Arc<AtomicU64>,
 }
 
 /// Collect and send metrics in the background. Errors are returned to the
@@ -598,13 +599,17 @@ async fn collect_and_send_metrics_bg(
                 let ms = df.net_messages_sent.load(atomic::Ordering::Relaxed);
                 let mr = df.net_messages_received.load(atomic::Ordering::Relaxed);
                 let pf = df.net_publish_failures.load(atomic::Ordering::Relaxed);
-                if bs > 0 || br > 0 || ms > 0 || mr > 0 || pf > 0 {
+                let pef = df
+                    .net_publish_enqueue_failures
+                    .load(atomic::Ordering::Relaxed);
+                if bs > 0 || br > 0 || ms > 0 || mr > 0 || pf > 0 || pef > 0 {
                     Some(dora_message::daemon_to_coordinator::NetworkMetrics {
                         bytes_sent: bs,
                         bytes_received: br,
                         messages_sent: ms,
                         messages_received: mr,
                         publish_failures: pf,
+                        publish_enqueue_failures: pef,
                     })
                 } else {
                     None
@@ -3633,6 +3638,7 @@ impl Daemon {
                 net_messages_sent: df.net_messages_sent.clone(),
                 net_messages_received: df.net_messages_received.clone(),
                 net_publish_failures: df.net_publish_failures.clone(),
+                net_publish_enqueue_failures: df.net_publish_enqueue_failures.clone(),
             })
             .collect();
 
@@ -5069,45 +5075,13 @@ impl Daemon {
         output_id: &OutputId,
         serialized_event: Vec<u8>,
     ) -> Result<(), eyre::Error> {
-        let dataflow = self.running.get_mut(&dataflow_id).wrap_err_with(|| {
-            format!("send out failed: no running dataflow with ID `{dataflow_id}`")
-        })?;
-
-        // Get or create publisher (lazy, cached per output)
-        let publisher = match dataflow.publishers.entry(output_id.clone()) {
-            std::collections::btree_map::Entry::Occupied(e) => e.get().clone(),
-            std::collections::btree_map::Entry::Vacant(e) => {
-                let publish_topic =
-                    zenoh_daemon_control_topic(dataflow.id, &output_id.0, &output_id.1);
-                tracing::debug!("declaring control publisher on {publish_topic}");
-                let publisher = self
-                    .zenoh_session
-                    .declare_publisher(publish_topic)
-                    .congestion_control(CongestionControl::Drop)
-                    .express(true)
-                    .priority(Priority::RealTime)
-                    .await
-                    .map_err(|err| eyre!(err))
-                    .context("failed to create zenoh publisher")?;
-                let arc = Arc::new(publisher);
-                e.insert(arc.clone());
-                arc
-            }
-        };
-        let payload_len = serialized_event.len() as u64;
-
-        let outbound = ZenohOutbound {
-            publisher,
-            serialized: serialized_event,
-            payload_len,
-            net_bytes_sent: dataflow.net_bytes_sent.clone(),
-            net_messages_sent: dataflow.net_messages_sent.clone(),
-            net_publish_failures: dataflow.net_publish_failures.clone(),
-        };
+        let (outbound, enqueue_failures) = self
+            .prepare_zenoh_outbound(dataflow_id, output_id, serialized_event)
+            .await?;
         enqueue_required_zenoh_outbound(
             &self.zenoh_publish_tx,
             outbound,
-            dataflow.net_publish_failures.clone(),
+            enqueue_failures,
             "inter-daemon output-closed event",
         );
         Ok(())
@@ -5119,6 +5093,23 @@ impl Daemon {
         output_id: &OutputId,
         serialized_event: Vec<u8>,
     ) -> Result<(), eyre::Error> {
+        let (outbound, enqueue_failures) = self
+            .prepare_zenoh_outbound(dataflow_id, output_id, serialized_event)
+            .await?;
+        handle_publish_enqueue_result(
+            enqueue_failures.as_ref(),
+            try_enqueue_zenoh_outbound(&self.zenoh_publish_tx, outbound),
+            "regular inter-daemon output",
+        );
+        Ok(())
+    }
+
+    async fn prepare_zenoh_outbound(
+        &mut self,
+        dataflow_id: Uuid,
+        output_id: &OutputId,
+        serialized_event: Vec<u8>,
+    ) -> Result<(ZenohOutbound, Arc<AtomicU64>), eyre::Error> {
         let dataflow = self.running.get_mut(&dataflow_id).wrap_err_with(|| {
             format!("send out failed: no running dataflow with ID `{dataflow_id}`")
         })?;
@@ -5146,20 +5137,17 @@ impl Daemon {
         };
         let payload_len = serialized_event.len() as u64;
 
-        let outbound = ZenohOutbound {
-            publisher,
-            serialized: serialized_event,
-            payload_len,
-            net_bytes_sent: dataflow.net_bytes_sent.clone(),
-            net_messages_sent: dataflow.net_messages_sent.clone(),
-            net_publish_failures: dataflow.net_publish_failures.clone(),
-        };
-        handle_publish_enqueue_result(
-            dataflow,
-            try_enqueue_zenoh_outbound(&self.zenoh_publish_tx, outbound),
-            "regular inter-daemon output",
-        );
-        Ok(())
+        Ok((
+            ZenohOutbound {
+                publisher,
+                serialized: serialized_event,
+                payload_len,
+                net_bytes_sent: dataflow.net_bytes_sent.clone(),
+                net_messages_sent: dataflow.net_messages_sent.clone(),
+                net_publish_failures: dataflow.net_publish_failures.clone(),
+            },
+            dataflow.net_publish_enqueue_failures.clone(),
+        ))
     }
 
     async fn send_topic_debug_frames(
@@ -7284,24 +7272,20 @@ async fn publish_zenoh_outbound(msg: ZenohOutbound) {
 }
 
 fn handle_publish_enqueue_result(
-    dataflow: &RunningDataflow,
+    enqueue_failures: &AtomicU64,
     result: ZenohEnqueueResult,
     event_kind: &'static str,
 ) {
     match result {
         ZenohEnqueueResult::Queued => {}
         ZenohEnqueueResult::Full => {
-            dataflow
-                .net_publish_failures
-                .fetch_add(1, atomic::Ordering::Relaxed);
+            enqueue_failures.fetch_add(1, atomic::Ordering::Relaxed);
             tracing::warn!(
                 "zenoh publish channel full ({ZENOH_PUBLISH_CHANNEL_CAPACITY}); dropping {event_kind}"
             );
         }
         ZenohEnqueueResult::Closed => {
-            dataflow
-                .net_publish_failures
-                .fetch_add(1, atomic::Ordering::Relaxed);
+            enqueue_failures.fetch_add(1, atomic::Ordering::Relaxed);
             tracing::error!("zenoh drain task is gone; dropping {event_kind}");
         }
     }
@@ -7310,7 +7294,7 @@ fn handle_publish_enqueue_result(
 fn enqueue_required_zenoh_outbound<T: Send + 'static>(
     tx: &mpsc::Sender<T>,
     outbound: T,
-    net_publish_failures: Arc<AtomicU64>,
+    enqueue_failures: Arc<AtomicU64>,
     event_kind: &'static str,
 ) {
     match tx.try_send(outbound) {
@@ -7319,13 +7303,13 @@ fn enqueue_required_zenoh_outbound<T: Send + 'static>(
             let tx = tx.clone();
             tokio::spawn(async move {
                 if tx.send(outbound).await.is_err() {
-                    net_publish_failures.fetch_add(1, atomic::Ordering::Relaxed);
+                    enqueue_failures.fetch_add(1, atomic::Ordering::Relaxed);
                     tracing::error!("zenoh drain task is gone; dropping {event_kind}");
                 }
             });
         }
         Err(mpsc::error::TrySendError::Closed(_)) => {
-            net_publish_failures.fetch_add(1, atomic::Ordering::Relaxed);
+            enqueue_failures.fetch_add(1, atomic::Ordering::Relaxed);
             tracing::error!("zenoh drain task is gone; dropping {event_kind}");
         }
     }
@@ -8109,12 +8093,11 @@ mod fault_tolerance_tests {
             "data",
             "queued data must stay ahead of the close event"
         );
-        tokio::task::yield_now().await;
-        assert_eq!(
-            publish_rx.try_recv().unwrap(),
-            "close",
-            "OutputClosed must be retained until publish capacity is available"
-        );
+        let close = tokio::time::timeout(Duration::from_secs(1), publish_rx.recv())
+            .await
+            .expect("close event should arrive")
+            .expect("publish channel should stay open");
+        assert_eq!(close, "close");
         assert_eq!(failures.load(atomic::Ordering::Relaxed), 0);
     }
 
@@ -8123,17 +8106,24 @@ mod fault_tolerance_tests {
         let dataflow = test_dataflow();
 
         handle_publish_enqueue_result(
-            &dataflow,
+            dataflow.net_publish_enqueue_failures.as_ref(),
             ZenohEnqueueResult::Full,
             "regular inter-daemon output",
         );
 
         assert_eq!(
             dataflow
-                .net_publish_failures
+                .net_publish_enqueue_failures
                 .load(atomic::Ordering::Relaxed),
             1,
-            "dropping a regular output must be visible in network metrics"
+            "dropping a regular output must be visible in enqueue metrics"
+        );
+        assert_eq!(
+            dataflow
+                .net_publish_failures
+                .load(atomic::Ordering::Relaxed),
+            0,
+            "queue pressure should not be counted as a zenoh publish failure"
         );
     }
 

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -191,6 +191,7 @@ const METRICS_INTERVAL_SECS: f64 = METRICS_INTERVAL.as_secs_f64();
 /// patterns; a full channel is recorded as publish backpressure and dropped so
 /// the daemon event loop does not stall.
 const ZENOH_PUBLISH_CHANNEL_CAPACITY: usize = 256;
+const ZENOH_REQUIRED_PUBLISH_TIMEOUT: Duration = Duration::from_secs(1);
 /// How long the daemon keeps trying to (re)connect to the coordinator before
 /// giving up and exiting. Bounds the orphan-daemon window when the coordinator
 /// is permanently gone (dora-rs/dora#1996); a reachable coordinator connects
@@ -447,21 +448,6 @@ struct DataflowMetricsSnapshot {
     net_messages_received: Arc<AtomicU64>,
     net_publish_failures: Arc<AtomicU64>,
     net_publish_enqueue_failures: Arc<AtomicU64>,
-}
-
-#[derive(Clone, Copy)]
-enum RemotePublishKind {
-    Data,
-    RequiredControl,
-}
-
-impl RemotePublishKind {
-    fn congestion_control(self) -> CongestionControl {
-        match self {
-            Self::Data => CongestionControl::Drop,
-            Self::RequiredControl => CongestionControl::Block,
-        }
-    }
 }
 
 /// Collect and send metrics in the background. Errors are returned to the
@@ -5091,12 +5077,7 @@ impl Daemon {
         serialized_event: Vec<u8>,
     ) -> Result<(), eyre::Error> {
         let (outbound, enqueue_failures) = self
-            .prepare_zenoh_outbound(
-                dataflow_id,
-                output_id,
-                serialized_event,
-                RemotePublishKind::RequiredControl,
-            )
+            .prepare_zenoh_outbound(dataflow_id, output_id, serialized_event)
             .await?;
         enqueue_required_zenoh_outbound(
             &self.zenoh_publish_tx,
@@ -5114,12 +5095,7 @@ impl Daemon {
         serialized_event: Vec<u8>,
     ) -> Result<(), eyre::Error> {
         let (outbound, enqueue_failures) = self
-            .prepare_zenoh_outbound(
-                dataflow_id,
-                output_id,
-                serialized_event,
-                RemotePublishKind::Data,
-            )
+            .prepare_zenoh_outbound(dataflow_id, output_id, serialized_event)
             .await?;
         handle_publish_enqueue_result(
             enqueue_failures.as_ref(),
@@ -5134,18 +5110,13 @@ impl Daemon {
         dataflow_id: Uuid,
         output_id: &OutputId,
         serialized_event: Vec<u8>,
-        kind: RemotePublishKind,
     ) -> Result<(ZenohOutbound, Arc<AtomicU64>), eyre::Error> {
         let dataflow = self.running.get_mut(&dataflow_id).wrap_err_with(|| {
             format!("send out failed: no running dataflow with ID `{dataflow_id}`")
         })?;
 
         // Get or create publisher (lazy, cached per output)
-        let publishers = match kind {
-            RemotePublishKind::Data => &mut dataflow.publishers,
-            RemotePublishKind::RequiredControl => &mut dataflow.control_publishers,
-        };
-        let publisher = match publishers.entry(output_id.clone()) {
+        let publisher = match dataflow.publishers.entry(output_id.clone()) {
             std::collections::btree_map::Entry::Occupied(e) => e.get().clone(),
             std::collections::btree_map::Entry::Vacant(e) => {
                 let publish_topic =
@@ -5154,7 +5125,7 @@ impl Daemon {
                 let publisher = self
                     .zenoh_session
                     .declare_publisher(publish_topic)
-                    .congestion_control(kind.congestion_control())
+                    .congestion_control(CongestionControl::Block)
                     .express(true)
                     .priority(Priority::RealTime)
                     .await
@@ -7287,11 +7258,27 @@ fn try_enqueue_zenoh_outbound<T>(tx: &mpsc::Sender<T>, outbound: T) -> ZenohEnqu
 }
 
 async fn publish_zenoh_outbound(msg: ZenohOutbound) {
-    if let Err(e) = msg.publisher.put(msg.serialized).await {
-        tracing::error!("zenoh publish failed: {e}");
-        msg.net_publish_failures
-            .fetch_add(1, atomic::Ordering::Relaxed);
-        return;
+    match tokio::time::timeout(
+        ZENOH_REQUIRED_PUBLISH_TIMEOUT,
+        msg.publisher.put(msg.serialized),
+    )
+    .await
+    {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => {
+            tracing::error!("zenoh publish failed: {e}");
+            msg.net_publish_failures
+                .fetch_add(1, atomic::Ordering::Relaxed);
+            return;
+        }
+        Err(_) => {
+            tracing::error!(
+                "zenoh publish timed out after {ZENOH_REQUIRED_PUBLISH_TIMEOUT:?}; dropping inter-daemon message"
+            );
+            msg.net_publish_failures
+                .fetch_add(1, atomic::Ordering::Relaxed);
+            return;
+        }
     }
     // Relaxed ordering is correct: counters are read-only for metrics
     // reporting and never used as synchronization guards.
@@ -8057,7 +8044,7 @@ mod fault_tolerance_tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-    async fn output_closed_uses_block_publisher_without_passing_queued_data() {
+    async fn output_closed_shares_blocking_stream_with_queued_data() {
         let clock = Arc::new(HLC::default());
         let (mut daemon, _events_rx) = Daemon::build_daemon(
             None,
@@ -8095,12 +8082,19 @@ mod fault_tolerance_tests {
             .unwrap();
 
         let data = publish_rx.try_recv().unwrap();
-        assert_eq!(data.publisher.congestion_control(), CongestionControl::Drop);
+        assert_eq!(
+            data.publisher.congestion_control(),
+            CongestionControl::Block
+        );
 
         let close = tokio::time::timeout(Duration::from_secs(1), publish_rx.recv())
             .await
             .expect("close event should wait for publish capacity")
             .expect("publish channel should stay open");
+        assert!(
+            Arc::ptr_eq(&data.publisher, &close.publisher),
+            "data and close for the same output must use one publisher so Zenoh preserves their order"
+        );
         assert_eq!(
             close.publisher.congestion_control(),
             CongestionControl::Block,

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -449,6 +449,21 @@ struct DataflowMetricsSnapshot {
     net_publish_enqueue_failures: Arc<AtomicU64>,
 }
 
+#[derive(Clone, Copy)]
+enum RemotePublishKind {
+    Data,
+    RequiredControl,
+}
+
+impl RemotePublishKind {
+    fn congestion_control(self) -> CongestionControl {
+        match self {
+            Self::Data => CongestionControl::Drop,
+            Self::RequiredControl => CongestionControl::Block,
+        }
+    }
+}
+
 /// Collect and send metrics in the background. Errors are returned to the
 /// caller (the spawned task logs them).
 async fn collect_and_send_metrics_bg(
@@ -5076,7 +5091,12 @@ impl Daemon {
         serialized_event: Vec<u8>,
     ) -> Result<(), eyre::Error> {
         let (outbound, enqueue_failures) = self
-            .prepare_zenoh_outbound(dataflow_id, output_id, serialized_event)
+            .prepare_zenoh_outbound(
+                dataflow_id,
+                output_id,
+                serialized_event,
+                RemotePublishKind::RequiredControl,
+            )
             .await?;
         enqueue_required_zenoh_outbound(
             &self.zenoh_publish_tx,
@@ -5094,7 +5114,12 @@ impl Daemon {
         serialized_event: Vec<u8>,
     ) -> Result<(), eyre::Error> {
         let (outbound, enqueue_failures) = self
-            .prepare_zenoh_outbound(dataflow_id, output_id, serialized_event)
+            .prepare_zenoh_outbound(
+                dataflow_id,
+                output_id,
+                serialized_event,
+                RemotePublishKind::Data,
+            )
             .await?;
         handle_publish_enqueue_result(
             enqueue_failures.as_ref(),
@@ -5109,13 +5134,18 @@ impl Daemon {
         dataflow_id: Uuid,
         output_id: &OutputId,
         serialized_event: Vec<u8>,
+        kind: RemotePublishKind,
     ) -> Result<(ZenohOutbound, Arc<AtomicU64>), eyre::Error> {
         let dataflow = self.running.get_mut(&dataflow_id).wrap_err_with(|| {
             format!("send out failed: no running dataflow with ID `{dataflow_id}`")
         })?;
 
         // Get or create publisher (lazy, cached per output)
-        let publisher = match dataflow.publishers.entry(output_id.clone()) {
+        let publishers = match kind {
+            RemotePublishKind::Data => &mut dataflow.publishers,
+            RemotePublishKind::RequiredControl => &mut dataflow.control_publishers,
+        };
+        let publisher = match publishers.entry(output_id.clone()) {
             std::collections::btree_map::Entry::Occupied(e) => e.get().clone(),
             std::collections::btree_map::Entry::Vacant(e) => {
                 let publish_topic =
@@ -5124,7 +5154,7 @@ impl Daemon {
                 let publisher = self
                     .zenoh_session
                     .declare_publisher(publish_topic)
-                    .congestion_control(CongestionControl::Drop)
+                    .congestion_control(kind.congestion_control())
                     .express(true)
                     .priority(Priority::RealTime)
                     .await
@@ -8026,52 +8056,55 @@ mod fault_tolerance_tests {
         assert_eq!(result, ZenohEnqueueResult::Closed);
     }
 
-    #[test]
-    fn regular_output_enqueue_full_is_nonfatal() {
-        let (tx, _rx) = mpsc::channel(1);
-        tx.try_send("occupied").unwrap();
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn output_closed_uses_block_publisher_without_passing_queued_data() {
+        let clock = Arc::new(HLC::default());
+        let (mut daemon, _events_rx) = Daemon::build_daemon(
+            None,
+            DaemonId::new(None),
+            None,
+            clock,
+            None,
+            BTreeMap::new(),
+            LogDestination::Tracing,
+            None,
+            ZenohBind::Derived(LOCALHOST),
+            true,
+            false,
+        )
+        .await
+        .unwrap();
+        let (publish_tx, mut publish_rx) = mpsc::channel(1);
+        daemon.zenoh_publish_tx = publish_tx;
 
-        let result = try_enqueue_zenoh_outbound(&tx, "output");
+        let dataflow_id = Uuid::nil();
+        let node_id = NodeId::from("source".to_string());
+        let output_id = DataId::from("value".to_string());
+        let output = OutputId(node_id.clone(), output_id.clone());
+        let mut dataflow = test_dataflow();
+        dataflow.open_external_mappings.insert(output.clone());
+        daemon.running.insert(dataflow_id, dataflow);
 
-        assert!(
-            matches!(result, ZenohEnqueueResult::Full),
-            "regular output enqueue should report backpressure without surfacing a fatal error"
-        );
-    }
+        daemon
+            .try_send_to_remote_receivers(dataflow_id, &output, b"data".to_vec())
+            .await
+            .unwrap();
+        daemon
+            .send_output_closed_events(dataflow_id, node_id, vec![output_id])
+            .await
+            .unwrap();
 
-    #[test]
-    fn output_closed_uses_the_same_fifo_as_regular_output() {
-        let (publish_tx, mut publish_rx) = mpsc::channel(3);
+        let data = publish_rx.try_recv().unwrap();
+        assert_eq!(data.publisher.congestion_control(), CongestionControl::Drop);
 
-        let data_1 = try_enqueue_zenoh_outbound(&publish_tx, "data-1");
-        let data_2 = try_enqueue_zenoh_outbound(&publish_tx, "data-2");
-        let close = try_enqueue_zenoh_outbound(&publish_tx, "close");
-
-        assert_eq!(data_1, ZenohEnqueueResult::Queued);
-        assert_eq!(data_2, ZenohEnqueueResult::Queued);
-        assert_eq!(close, ZenohEnqueueResult::Queued);
-        assert_eq!(publish_rx.try_recv().unwrap(), "data-1");
-        assert_eq!(publish_rx.try_recv().unwrap(), "data-2");
-        assert_eq!(publish_rx.try_recv().unwrap(), "close");
-    }
-
-    #[test]
-    fn zenoh_publish_drain_preserves_output_closed_ordering() {
-        let (publish_tx, mut publish_rx) = mpsc::channel(4);
-
-        publish_tx.try_send("data-1").unwrap();
-        publish_tx.try_send("data-2").unwrap();
-        publish_tx.try_send("close").unwrap();
-
-        let mut published = Vec::new();
-        while let Ok(msg) = publish_rx.try_recv() {
-            published.push(msg);
-        }
-
+        let close = tokio::time::timeout(Duration::from_secs(1), publish_rx.recv())
+            .await
+            .expect("close event should wait for publish capacity")
+            .expect("publish channel should stay open");
         assert_eq!(
-            published,
-            ["data-1", "data-2", "close"],
-            "OutputClosed must not pass earlier Output messages for the same output"
+            close.publisher.congestion_control(),
+            CongestionControl::Block,
+            "OutputClosed must use a non-dropping zenoh publisher"
         );
     }
 

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -350,7 +350,6 @@ pub struct RunningDataflow {
     pub(crate) grace_duration_kills: Arc<crossbeam_skiplist::SkipSet<(NodeId, u64)>>,
     pub(crate) node_stderr_most_recent: BTreeMap<NodeId, Arc<ArrayQueue<String>>>,
     pub(crate) publishers: BTreeMap<OutputId, Arc<zenoh::pubsub::Publisher<'static>>>,
-    pub(crate) control_publishers: BTreeMap<OutputId, Arc<zenoh::pubsub::Publisher<'static>>>,
     /// Reverse index from output to the set of CLI subscribers watching it.
     /// Hot-path read on every node output dispatch (`send_topic_debug_frames`)
     /// and on the `has_debug_watchers` check. Unsubscribe scans this map
@@ -419,7 +418,6 @@ impl RunningDataflow {
             grace_duration_kills: Default::default(),
             node_stderr_most_recent: BTreeMap::new(),
             publishers: Default::default(),
-            control_publishers: Default::default(),
             debug_topic_watchers: Default::default(),
             finished_tx,
             listener_shutdown_tx,

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -350,6 +350,7 @@ pub struct RunningDataflow {
     pub(crate) grace_duration_kills: Arc<crossbeam_skiplist::SkipSet<(NodeId, u64)>>,
     pub(crate) node_stderr_most_recent: BTreeMap<NodeId, Arc<ArrayQueue<String>>>,
     pub(crate) publishers: BTreeMap<OutputId, Arc<zenoh::pubsub::Publisher<'static>>>,
+    pub(crate) control_publishers: BTreeMap<OutputId, Arc<zenoh::pubsub::Publisher<'static>>>,
     /// Reverse index from output to the set of CLI subscribers watching it.
     /// Hot-path read on every node output dispatch (`send_topic_debug_frames`)
     /// and on the `has_debug_watchers` check. Unsubscribe scans this map
@@ -418,6 +419,7 @@ impl RunningDataflow {
             grace_duration_kills: Default::default(),
             node_stderr_most_recent: BTreeMap::new(),
             publishers: Default::default(),
+            control_publishers: Default::default(),
             debug_topic_watchers: Default::default(),
             finished_tx,
             listener_shutdown_tx,

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -368,6 +368,7 @@ pub struct RunningDataflow {
     pub(crate) net_messages_sent: Arc<AtomicU64>,
     pub(crate) net_messages_received: Arc<AtomicU64>,
     pub(crate) net_publish_failures: Arc<AtomicU64>,
+    pub(crate) net_publish_enqueue_failures: Arc<AtomicU64>,
 }
 
 /// Indicates whether a dataflow should be finished immediately after stop_all()
@@ -428,6 +429,7 @@ impl RunningDataflow {
             net_messages_sent: Default::default(),
             net_messages_received: Default::default(),
             net_publish_failures: Default::default(),
+            net_publish_enqueue_failures: Default::default(),
         }
     }
 

--- a/libraries/message/src/daemon_to_coordinator.rs
+++ b/libraries/message/src/daemon_to_coordinator.rs
@@ -305,6 +305,10 @@ pub struct NetworkMetrics {
     pub messages_received: u64,
     #[serde(default)]
     pub publish_failures: u64,
+    /// Number of inter-daemon publish events dropped before reaching zenoh
+    /// because the outbound queue was full or closed.
+    #[serde(default)]
+    pub publish_enqueue_failures: u64,
 }
 
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]


### PR DESCRIPTION
## Summary

  Fix inter-daemon messages being silently dropped when the Zenoh publish drain channel is full.
  `send_to_remote_receivers` now retries full-channel enqueue attempts briefly and returns an error if the message still cannot be queued, instead of logging a warning and returning `Ok(())`. This prevents control events like  `OutputClosed` from being lost without the caller knowing.
