### PR TITLE
fix(node): guard the SHM copy-fallback against an over-allocated buffer

### DIFF
--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -1936,24 +1936,43 @@ impl DoraNode {
                         .wait()
                     {
                         Ok(mut sbuf) => {
-                            sbuf.as_mut().copy_from_slice(&avec);
-                            if diag {
-                                tracing::warn!(
-                                    "output `{output_id}`: entering zenoh put of a \
-                                     copied SHM buffer (dora-rs/dora#2742 diagnostic)"
-                                );
-                            }
-                            return match publisher.put(sbuf).attachment(&metadata_bytes[..]).wait()
-                            {
-                                Ok(()) => Ok(PublishOutcome::Published),
-                                Err(e) => {
+                            // Mirror the guard in `allocate_data_sample`: only
+                            // copy into the SHM buffer when it is exactly the
+                            // requested size. zenoh 1.8 guarantees the logical
+                            // length matches the request, but `copy_from_slice`
+                            // requires equal lengths and would panic on the
+                            // node's send thread if a future provider ever
+                            // over-allocated. Fall through to the reliable
+                            // daemon path instead of risking that panic.
+                            if sbuf.as_mut().len() == avec.len() {
+                                sbuf.as_mut().copy_from_slice(&avec);
+                                if diag {
                                     tracing::warn!(
-                                        "zenoh SHM publish failed ({e}); \
-                                         falling back to daemon path"
+                                        "output `{output_id}`: entering zenoh put of a \
+                                         copied SHM buffer (dora-rs/dora#2742 diagnostic)"
                                     );
-                                    Ok(PublishOutcome::NotPublished(FinalizedSample::Vec(avec)))
                                 }
-                            };
+                                return match publisher
+                                    .put(sbuf)
+                                    .attachment(&metadata_bytes[..])
+                                    .wait()
+                                {
+                                    Ok(()) => Ok(PublishOutcome::Published),
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            "zenoh SHM publish failed ({e}); \
+                                             falling back to daemon path"
+                                        );
+                                        Ok(PublishOutcome::NotPublished(FinalizedSample::Vec(avec)))
+                                    }
+                                };
+                            }
+                            tracing::debug!(
+                                "zenoh SHM alloc returned {} bytes for a {}-byte \
+                                 request; using daemon path",
+                                sbuf.as_ref().len(),
+                                avec.len()
+                            );
                         }
                         Err(e) => {
                             tracing::debug!("SHM alloc failed ({e}), using heap buffer");


### PR DESCRIPTION
## Issue

The heap→SHM copy path in `zenoh_publish` (`apis/rust/node/src/node/mod.rs`) does:

```rust
Ok(mut sbuf) => {
    sbuf.as_mut().copy_from_slice(&avec);   // no length check
```

on the buffer returned by `provider.alloc(avec.len())`. `<[u8]>::copy_from_slice`
**panics** when the source and destination lengths differ, and this runs on the
node's send thread — so a length mismatch crashes the node rather than falling
back.

The sibling allocation site `allocate_data_sample` already guards exactly this
case:

```rust
if sbuf.as_ref().len() == data_len {
    return Ok(DataSample { storage: SampleStorage::Shm(sbuf) });
}
// "If a future provider ever over-allocates, fall back to heap rather than
//  expose or publish an oversized slice."
```

So the codebase already recognizes that `provider.alloc(n)` may return a buffer
whose `.len()` exceeds `n` and guards one call site — but not this one. The two
paths were inconsistent: one falls back safely, the other panics.

## Fix

Mirror the blessed guard: only `copy_from_slice` when
`sbuf.as_mut().len() == avec.len()`. On a mismatch, log at `debug` and fall
through to the reliable daemon path (the `avec` payload is still owned, so the
existing `NotPublished(Vec(avec))` fallthrough at the bottom of the arm routes
it correctly).

zenoh 1.8 guarantees the logical length matches the request today, so this is
defensive hardening that closes a latent panic and makes the two SHM-allocation
sites consistent. No behavior change on the normal (equal-length) path.

## Validation

- `cargo build -p dora-node-api` — clean
- `cargo test -p dora-node-api --lib` — 162 passed
- `cargo clippy -p dora-node-api --lib -- -D warnings` — clean
- fmt clean

(The 2 failing `zenoh_schema_cache` integration tests fail identically on
unmodified `origin/main` — they need zenoh networking unavailable in the CI
sandbox — so they are pre-existing and unrelated to this change.)

---

🤖 This is a machine-generated pull request authored by Claude (Claude Code), part of an automated codebase review. Each finding was verified against `origin/main` before opening. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzFF4tZy8gAEh9sBeXCJcf)_