### PR TITLE
fix(coordinator): skip finalized nodes when exporting OTEL metrics

### DIFF
--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -2370,6 +2370,15 @@ async fn start_inner(
                         use opentelemetry::KeyValue;
                         let df_id = dataflow_id.to_string();
                         for (node_id, node_metrics) in &metrics {
+                            // Same authority as the in-memory table above: a
+                            // finalized node's delayed metrics push is a stale
+                            // pre-exit snapshot. Skip it here too, so OTEL does
+                            // not record a fresh data point that resurrects the
+                            // node's CPU/memory time series one push past its
+                            // death.
+                            if dataflow.node_finalized.contains(node_id) {
+                                continue;
+                            }
                             let daemon = dataflow
                                 .node_to_daemon
                                 .get(node_id)


### PR DESCRIPTION
## Issue

In the coordinator's `NodeMetrics` handler (`binaries/coordinator/src/lib.rs`),
the in-memory metrics table deliberately drops any push for a node in
`node_finalized` (covering both a clean `Stopped` and a crashed `Failed`), so a
daemon's delayed pre-exit snapshot cannot revive a dead node's row:

```rust
for (node_id, node_metrics) in &metrics {
    if dataflow.node_finalized.contains(node_id) { continue; }   // authoritative
    dataflow.node_metrics.insert(node_id.clone(), node_metrics.clone());
}
```

The `#[cfg(feature = "metrics")]` OTEL export loop directly below iterates the
**same raw `metrics` map without that guard**, so it records a fresh
CPU / memory / pending / restart data point for an already-finalized node —
resurrecting its OpenTelemetry time series one push past its death, exactly the
behavior `node_finalized` exists to prevent for the in-memory table.

## Fix

Apply the same `node_finalized` filter at the top of the OTEL loop, mirroring
the guard on the in-memory table just above it (same iteration source, same
predicate).

Feature-gated (`metrics`); no effect on the default build.

## Validation

- `cargo clippy -p dora-coordinator --features metrics --all-targets -- -D warnings` — clean
- `cargo test -p dora-coordinator --features metrics` — 4 passed
- fmt clean

---

🤖 This is a machine-generated pull request authored by Claude (Claude Code), part of an automated codebase review. Each finding was verified against `origin/main` before opening. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PzFF4tZy8gAEh9sBeXCJcf)_