### PR TITLE
docs(cli): align --stop-after help examples with duration units

### DIFF
--- a/binaries/cli/src/command/run.rs
+++ b/binaries/cli/src/command/run.rs
@@ -48,9 +48,9 @@ pub struct Run {
     /// similar to pressing Ctrl-C. This gracefully stops all nodes in the dataflow.
     ///
     /// Examples:
-    ///   --stop-after 30      # 30 seconds
     ///   --stop-after 30s     # 30 seconds
     ///   --stop-after 5m      # 5 minutes
+    ///   --stop-after 1h      # 1 hour
     #[clap(long, value_name = "DURATION", verbatim_doc_comment)]
     #[arg(value_parser = parse_duration)]
     pub stop_after: Option<Duration>,


### PR DESCRIPTION
### Summary
- Updates (dora run --stop-after) help examples to use explicit duration units (30s, 5m, 1h)
- Removes the bare-number example that could confuse users copying from help !

Fixes #2867

 ### Test plan
- [x] Docs-only change in CLI help text
- [ ] Optional: build CLI and check (dora run --help)