### PR TITLE
fix(node): JSON-escape plain-text input in read_json_bytes_as_arrow

### DIFF
--- a/apis/rust/node/src/daemon_connection/json_to_arrow.rs
+++ b/apis/rust/node/src/daemon_connection/json_to_arrow.rs
@@ -10,9 +10,14 @@ pub fn read_json_bytes_as_arrow(data: &[u8]) -> eyre::Result<ArrayData> {
     match arrow_json::reader::infer_json_schema(wrapped(data), None) {
         Ok((schema, _)) => read_from_json_with_schema(wrapped(data), schema),
         Err(_) => {
-            // try again with quoting the input to treat it as a string
-            match arrow_json::reader::infer_json_schema(wrapped_quoted(data), None) {
-                Ok((schema, _)) => read_from_json_with_schema(wrapped_quoted(data), schema),
+            // Try again by treating the input as a plain string. The bytes may
+            // contain characters that are not valid on their own inside a JSON
+            // string literal (`"`, `\`, raw control characters), so JSON-escape
+            // them first instead of wrapping the raw bytes in quotes — otherwise
+            // any such input produces invalid JSON and is rejected.
+            let quoted = json_quote(data);
+            match arrow_json::reader::infer_json_schema(wrapped(quoted.as_bytes()), None) {
+                Ok((schema, _)) => read_from_json_with_schema(wrapped(quoted.as_bytes()), schema),
                 Err(err) => eyre::bail!("failed to infer JSON schema: {err}"),
             }
         }
@@ -39,10 +44,12 @@ fn wrapped(data: impl BufRead) -> impl BufRead {
     "{ \"inner\":".as_bytes().chain(data).chain("}".as_bytes())
 }
 
-// wrap data into JSON object to also allow bare JSON values
-fn wrapped_quoted(data: impl BufRead) -> impl BufRead {
-    let quoted = "\"".as_bytes().chain(data).chain("\"".as_bytes());
-    wrapped(quoted)
+/// JSON-encode the given bytes as a quoted string literal, escaping any
+/// characters that are not valid inside a JSON string (`"`, `\`, control
+/// characters). Non-UTF-8 bytes are replaced lossily.
+fn json_quote(data: &[u8]) -> String {
+    // Serializing a `String` into JSON never fails.
+    serde_json::Value::String(String::from_utf8_lossy(data).into_owned()).to_string()
 }
 
 /// convert the given JSON object to the closed arrow representation
@@ -61,4 +68,52 @@ pub fn read_json_value_as_arrow(
         .context("failed to read record batch")?
         .context("no record batch in JSON")?;
     Ok(batch.column(0).to_data())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{StringArray, make_array};
+
+    fn as_single_string(data: ArrayData) -> String {
+        let array = make_array(data);
+        let strings = array
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("expected a string array");
+        assert_eq!(strings.len(), 1);
+        strings.value(0).to_owned()
+    }
+
+    #[test]
+    fn plain_text_with_double_quotes_round_trips() {
+        // Previously this produced invalid JSON (`{ "inner":"say "hi""}`) and
+        // was rejected instead of being treated as a plain string.
+        let data = read_json_bytes_as_arrow(br#"say "hi""#).unwrap();
+        assert_eq!(as_single_string(data), r#"say "hi""#);
+    }
+
+    #[test]
+    fn plain_text_with_backslash_round_trips() {
+        let data = read_json_bytes_as_arrow(br"C:\Users\node").unwrap();
+        assert_eq!(as_single_string(data), r"C:\Users\node");
+    }
+
+    #[test]
+    fn plain_text_with_control_characters_round_trips() {
+        let data = read_json_bytes_as_arrow(b"line1\nline2\ttab").unwrap();
+        assert_eq!(as_single_string(data), "line1\nline2\ttab");
+    }
+
+    #[test]
+    fn bare_json_values_still_parse_natively() {
+        // A bare JSON number is parsed as a number, not wrapped as a string.
+        let data = read_json_bytes_as_arrow(b"42").unwrap();
+        let array = make_array(data);
+        assert_eq!(array.len(), 1);
+        assert!(
+            array.as_any().downcast_ref::<StringArray>().is_none(),
+            "bare JSON number should not be parsed as a string"
+        );
+    }
 }


### PR DESCRIPTION
## Issue

`read_json_bytes_as_arrow` (`apis/rust/node/src/daemon_connection/json_to_arrow.rs`) first tries to parse the input as JSON, and on failure retries by treating it as a plain string. The retry (`wrapped_quoted`) wrapped the **raw** bytes in `"` quotes:

```rust
fn wrapped_quoted(data: impl BufRead) -> impl BufRead {
    let quoted = "\"".as_bytes().chain(data).chain("\"".as_bytes());
    wrapped(quoted)
}
```

If the input itself contains a `"`, a backslash, or a raw control character (newline/tab), the wrapped result is **invalid JSON**, so both the JSON attempt and the string-fallback attempt fail and the whole call errors with `failed to infer JSON schema` instead of yielding a string array.

This is reachable from `dora run` **interactive mode**, whose Data prompt advertises "String/JSON …" (`apis/rust/node/src/daemon_connection/interactive.rs:140`). Concretely, these all failed before this change:

- typing `say "hi"` → produced `{ "inner":"say "hi""}` (invalid JSON)
- entering a Windows path `C:\Users\node`
- pasting a multi-line value

## Fix

JSON-escape the bytes via `serde_json` before wrapping, so any plain-text input becomes a valid JSON string literal. `wrapped_quoted` is replaced by a small `json_quote` helper. Behavior for bare JSON values (numbers, objects, arrays) is unchanged — they still parse natively on the first attempt.

## Validation

- Added regression tests in `json_to_arrow.rs` covering double quotes, backslashes, and control characters round-tripping to the expected string, plus a guard that a bare JSON number still parses as a non-string array.
- `cargo test -p dora-node-api --lib json_to_arrow` — 4 passed.
- `cargo fmt --all -- --check` and `cargo clippy -p dora-node-api -- -D warnings` clean.

---

🤖 This is a machine-generated pull request opened by Claude Code as part of an automated code-review pass. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SD4dBVimzepwKSh2b9F8aG)_