### PR TITLE
fix(daemon): honor max_rotated_files == 0 in rotate_log_files

### DIFF
--- a/binaries/daemon/src/log.rs
+++ b/binaries/daemon/src/log.rs
@@ -46,6 +46,30 @@ pub fn rotate_log_files(
     node_id: &NodeId,
     max_files: u32,
 ) -> std::io::Result<()> {
+    // With no rotated copies requested, discard the current log instead of
+    // renaming it to `.1`. Otherwise the shift-then-rename logic below would
+    // move `current` to `log_<node>.1.jsonl` while the delete-oldest step
+    // targets the never-created `log_<node>.0.jsonl`, leaving one rotated file
+    // behind forever — contradicting `max_files == 0`. Also prune any rotated
+    // files a previous (non-zero) configuration may have left behind, so the
+    // "retain no rotated copies" contract holds regardless of history.
+    if max_files == 0 {
+        let current = log_path(working_dir, dataflow_id, node_id);
+        if current.exists() {
+            std::fs::remove_file(&current)?;
+        }
+        let mut index = 1u32;
+        loop {
+            let rotated = log_path_rotated(working_dir, dataflow_id, node_id, index);
+            if !rotated.exists() {
+                break;
+            }
+            std::fs::remove_file(&rotated)?;
+            index += 1;
+        }
+        return Ok(());
+    }
+
     // Delete the oldest if it exists
     let oldest = log_path_rotated(working_dir, dataflow_id, node_id, max_files);
     if oldest.exists() {
@@ -687,6 +711,54 @@ mod tests {
             std::fs::read_to_string(log_path_rotated(tmp.path(), &uuid, &node, 2)).unwrap(),
             "old1\n"
         );
+    }
+
+    #[test]
+    fn rotate_with_zero_max_files_discards_current() {
+        let tmp = tempfile::tempdir().unwrap();
+        let uuid = Uuid::nil();
+        let node = NodeId::from("n".to_string());
+
+        let dataflow_dir = tmp.path().join("out").join(uuid.to_string());
+        std::fs::create_dir_all(&dataflow_dir).unwrap();
+        let current = log_path(tmp.path(), &uuid, &node);
+        std::fs::write(&current, "current\n").unwrap();
+
+        rotate_log_files(tmp.path(), &uuid, &node, 0).unwrap();
+
+        // With max_files == 0 no rotated copy is retained: the current file is
+        // discarded and no `.1` file is left behind.
+        assert!(!current.exists());
+        assert!(!log_path_rotated(tmp.path(), &uuid, &node, 1).exists());
+
+        // A second rotation is still a no-op and does not accumulate files.
+        std::fs::write(&current, "again\n").unwrap();
+        rotate_log_files(tmp.path(), &uuid, &node, 0).unwrap();
+        assert!(!current.exists());
+        assert!(!log_path_rotated(tmp.path(), &uuid, &node, 1).exists());
+    }
+
+    #[test]
+    fn rotate_with_zero_max_files_prunes_preexisting_rotated_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let uuid = Uuid::nil();
+        let node = NodeId::from("n".to_string());
+
+        let dataflow_dir = tmp.path().join("out").join(uuid.to_string());
+        std::fs::create_dir_all(&dataflow_dir).unwrap();
+
+        // Simulate rotated files left behind by an earlier non-zero config.
+        let current = log_path(tmp.path(), &uuid, &node);
+        std::fs::write(&current, "current\n").unwrap();
+        std::fs::write(log_path_rotated(tmp.path(), &uuid, &node, 1), "old1\n").unwrap();
+        std::fs::write(log_path_rotated(tmp.path(), &uuid, &node, 2), "old2\n").unwrap();
+
+        rotate_log_files(tmp.path(), &uuid, &node, 0).unwrap();
+
+        // "retain no rotated copies" must hold even against pre-existing files.
+        assert!(!current.exists());
+        assert!(!log_path_rotated(tmp.path(), &uuid, &node, 1).exists());
+        assert!(!log_path_rotated(tmp.path(), &uuid, &node, 2).exists());
     }
 
     #[test]


### PR DESCRIPTION
## Issue

`rotate_log_files` (`binaries/daemon/src/log.rs`) rotates node logs by:
1. deleting the oldest rotated file `log_<node>.<max_files>.jsonl`,
2. shifting `.N -> .N+1` for `i in (1..max_files)`,
3. renaming the current file to `log_<node>.1.jsonl`.

When `max_files == 0`:
- the delete step targets `log_<node>.0.jsonl`, which is never created,
- the shift range `(1..0)` is empty,
- **but the current file is still renamed to `log_<node>.1.jsonl`**.

That `.1` file is never pruned on subsequent rotations either, so a node configured with `max_rotated_files: 0` keeps a rotated log forever instead of retaining zero — directly contradicting the requested value.

`max_rotated_files` is user-configurable through the dataflow descriptor (`libraries/message/src/descriptor.rs`) and reaches this public library function via `binaries/daemon/src/spawn/prepared.rs` (`.unwrap_or(DEFAULT_MAX_ROTATED_FILES)` only substitutes the default when the option is `None`, not when it is `Some(0)`), so `0` is a reachable input.

## Fix

Special-case `max_files == 0`: discard the current log **and** prune any rotated files a previous (non-zero) configuration may have left behind, so the "retain no rotated copies" contract holds regardless of history. All other values keep their existing behavior.

## Validation

- `rotate_with_zero_max_files_discards_current` — the current file is gone, no `.1` is left, and a repeated rotation does not accumulate files.
- `rotate_with_zero_max_files_prunes_preexisting_rotated_files` — pre-existing `.1`/`.2` rotated files are removed too.
- `cargo test -p dora-daemon --lib log::` — 12 passed (existing rotation tests unchanged).
- `cargo fmt --all -- --check` and `cargo clippy -p dora-daemon -- -D warnings` clean.

_The pre-existing-rotated-file pruning was added after an automated `/review` pass noted the original fix only removed the current file._

---

🤖 This is a machine-generated pull request opened by Claude Code as part of an automated code-review pass. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)