### PR TITLE
fix(cli): parse JSONL log lines that omit or capitalize the level field

### DIFF
--- a/binaries/cli/src/output.rs
+++ b/binaries/cli/src/output.rs
@@ -183,15 +183,16 @@ pub fn parse_jsonl_line(line: &str) -> Option<LogMessage> {
     let v: serde_json::Value = serde_json::from_str(line).ok()?;
     let ts = v.get("ts")?.as_str()?;
     let timestamp = chrono::DateTime::parse_from_rfc3339(ts).ok()?.to_utc();
-    let level_str = v.get("level")?.as_str().unwrap_or("stdout");
-    let level = match level_str {
-        "error" => LogLevelOrStdout::LogLevel(log::Level::Error),
-        "warn" => LogLevelOrStdout::LogLevel(log::Level::Warn),
-        "info" => LogLevelOrStdout::LogLevel(log::Level::Info),
-        "debug" => LogLevelOrStdout::LogLevel(log::Level::Debug),
-        "trace" => LogLevelOrStdout::LogLevel(log::Level::Trace),
-        _ => LogLevelOrStdout::Stdout,
-    };
+    // A missing `level` key, a non-string value, or an unrecognized level all
+    // default to stdout, so that externally-produced JSONL log lines are still
+    // shown rather than silently dropped. Reuse `parse_log_level_str` (the
+    // single source of truth for level names) so a capitalized level such as
+    // "INFO" is classified correctly instead of falling through to stdout.
+    let level = v
+        .get("level")
+        .and_then(|l| l.as_str())
+        .and_then(|s| parse_log_level_str(s).ok())
+        .unwrap_or(LogLevelOrStdout::Stdout);
     let node_id = v
         .get("node")
         .and_then(|n| n.as_str())
@@ -450,6 +451,43 @@ mod tests {
             LogLevelOrStdout::LogLevel(log::Level::Info)
         ));
         assert_eq!(msg.node_id.unwrap().to_string(), "sensor");
+    }
+
+    #[test]
+    fn parse_jsonl_missing_level_defaults_to_stdout() {
+        // A line without a `level` key must still be parsed (defaulting to
+        // stdout), not silently dropped.
+        let line = r#"{"ts":"2025-01-01T00:00:00Z","node":"sensor","msg":"hello"}"#;
+        let msg = parse_jsonl_line(line).expect("line without level should still parse");
+        assert_eq!(msg.message, "hello");
+        assert!(matches!(msg.level, LogLevelOrStdout::Stdout));
+        assert_eq!(msg.node_id.unwrap().to_string(), "sensor");
+    }
+
+    #[test]
+    fn parse_jsonl_non_string_level_defaults_to_stdout() {
+        let line = r#"{"ts":"2025-01-01T00:00:00Z","level":42,"msg":"hi"}"#;
+        let msg = parse_jsonl_line(line).expect("line with non-string level should still parse");
+        assert!(matches!(msg.level, LogLevelOrStdout::Stdout));
+    }
+
+    #[test]
+    fn parse_jsonl_capitalized_level_is_classified() {
+        // An external tool emitting a capitalized level must be classified,
+        // not silently treated as stdout.
+        let line = r#"{"ts":"2025-01-01T00:00:00Z","level":"INFO","msg":"hi"}"#;
+        let msg = parse_jsonl_line(line).unwrap();
+        assert!(matches!(
+            msg.level,
+            LogLevelOrStdout::LogLevel(log::Level::Info)
+        ));
+    }
+
+    #[test]
+    fn parse_jsonl_unknown_level_defaults_to_stdout() {
+        let line = r#"{"ts":"2025-01-01T00:00:00Z","level":"bogus","msg":"hi"}"#;
+        let msg = parse_jsonl_line(line).unwrap();
+        assert!(matches!(msg.level, LogLevelOrStdout::Stdout));
     }
 
     #[test]


### PR DESCRIPTION
## Issue

`parse_jsonl_line` (`binaries/cli/src/output.rs`) parses daemon/compact JSONL log lines and is documented to tolerate compact formats. It had two related problems in its level handling:

```rust
let level_str = v.get("level")?.as_str().unwrap_or("stdout");
let level = match level_str {
    "error" => ..., "warn" => ..., "info" => ..., "debug" => ..., "trace" => ...,
    _ => LogLevelOrStdout::Stdout,
};
```

1. **Missing key drops the line.** The `?` on `v.get("level")` returns `None` — dropping the **entire line** — whenever the `level` key is absent. The `.unwrap_or("stdout")` fallback was therefore unreachable for the common "no level key" case, so any externally-produced JSONL line with `ts`/`msg` but no `level` was silently discarded.
2. **Case-sensitive misclassification.** The inline match compared only lowercase literals and duplicated `parse_log_level_str` (the single source of truth for level names, which lowercases first). An external tool emitting a capitalized level like `"INFO"` hit the `_ => Stdout` arm — the line was shown but misclassified as stdout, breaking `--log-level` filtering and coloring.

## Fix

Look the level up through `parse_log_level_str`, defaulting to stdout when the key is missing, non-string, or unrecognized:

```rust
let level = v
    .get("level")
    .and_then(|l| l.as_str())
    .and_then(|s| parse_log_level_str(s).ok())
    .unwrap_or(LogLevelOrStdout::Stdout);
```

A line without a level is now kept (as stdout) instead of dropped, a capitalized level is classified correctly, and the duplicated match is removed.

## Validation

Four tests were added. Two are genuinely RED against the pre-fix code; two are green on both and kept as guard tests:

| Test | Pre-fix | Why |
|------|---------|-----|
| `parse_jsonl_missing_level_defaults_to_stdout` | **RED** | `v.get("level")?` dropped the whole line on a missing key |
| `parse_jsonl_capitalized_level_is_classified` (`"INFO"` → Info) | **RED** | case-sensitive match misclassified `"INFO"` as stdout |
| `parse_jsonl_non_string_level_defaults_to_stdout` (`42`) | green (guard) | old path already fell through: `.as_str()` → `None` → `.unwrap_or("stdout")` → `_ => Stdout` |
| `parse_jsonl_unknown_level_defaults_to_stdout` (`"bogus"`) | green (guard) | old path already matched `_ => Stdout` |

- `cargo test -p dora-cli --lib output::` — 21 passed.
- `cargo fmt --all -- --check` and `cargo clippy -p dora-cli -- -D warnings` clean.

_The capitalization fix and the `parse_log_level_str` reuse were added after an automated `/review` + `/simplify` pass flagged the case-sensitive duplication._

---

🤖 This is a machine-generated pull request opened by Claude Code as part of an automated code-review pass. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)