### PR TITLE
refactor(core): resolve the descriptor once in check_dataflow

### DIFF
--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -26,12 +26,17 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 /// reference points to a declared output on the source node.
 pub fn check_wiring(dataflow: &Descriptor) -> eyre::Result<()> {
     let nodes = dataflow.resolve_aliases_and_set_defaults()?;
+    check_wiring_resolved(&nodes)
+}
 
+/// [`check_wiring`] on an already-resolved node map, so callers that have
+/// resolved the descriptor can avoid re-resolving it.
+fn check_wiring_resolved(nodes: &BTreeMap<NodeId, ResolvedNode>) -> eyre::Result<()> {
     for node in nodes.values() {
         match &node.kind {
             descriptor::CoreNodeKind::Custom(custom_node) => {
                 for (input_id, input) in &custom_node.run_config.inputs {
-                    check_input(input, &nodes, &format!("{}/{input_id}", node.id))?;
+                    check_input(input, nodes, &format!("{}/{input_id}", node.id))?;
                 }
             }
             descriptor::CoreNodeKind::Runtime(runtime_node) => {
@@ -39,7 +44,7 @@ pub fn check_wiring(dataflow: &Descriptor) -> eyre::Result<()> {
                     for (input_id, input) in &operator_definition.config.inputs {
                         check_input(
                             input,
-                            &nodes,
+                            nodes,
                             &format!("{}/{}/{input_id}", node.id, operator_definition.id),
                         )?;
                     }
@@ -59,14 +64,31 @@ pub fn check_wiring(dataflow: &Descriptor) -> eyre::Result<()> {
 /// step and adds source-path existence and Python runtime checks on top.
 pub fn check_dataflow_static(dataflow: &Descriptor) -> eyre::Result<()> {
     // validate ROS2 bridge configs before resolution
+    validate_ros2_configs(dataflow)?;
+
+    let nodes = dataflow.resolve_aliases_and_set_defaults()?;
+    check_dataflow_static_resolved(dataflow, &nodes)
+}
+
+/// Validate all ROS2 bridge configs on the *unresolved* descriptor.
+///
+/// Run before [`Descriptor::resolve_aliases_and_set_defaults`] so a ROS2
+/// misconfiguration is reported ahead of any alias-resolution error.
+fn validate_ros2_configs(dataflow: &Descriptor) -> eyre::Result<()> {
     for node in &dataflow.nodes {
         if let Some(ros2) = &node.ros2 {
             validate_ros2_config(&node.id, ros2, &node.inputs, &node.outputs)?;
         }
     }
+    Ok(())
+}
 
-    let nodes = dataflow.resolve_aliases_and_set_defaults()?;
-
+/// The resolution-dependent part of [`check_dataflow_static`], operating on an
+/// already-resolved node map so callers don't re-resolve the descriptor.
+fn check_dataflow_static_resolved(
+    dataflow: &Descriptor,
+    nodes: &BTreeMap<NodeId, ResolvedNode>,
+) -> eyre::Result<()> {
     // reject negative / non-finite / overflowing timing values before they
     // reach the daemon, where `Duration::from_secs_f64` would panic on spawn.
     for node in nodes.values() {
@@ -97,7 +119,7 @@ pub fn check_dataflow_static(dataflow: &Descriptor) -> eyre::Result<()> {
     )?;
 
     // check that all inputs mappings point to an existing output
-    check_wiring(dataflow)?;
+    check_wiring_resolved(nodes)?;
 
     // Check that nodes can resolve `send_stdout_as`, `send_logs_as`, `min_log_level`
     for node in nodes.values() {
@@ -117,9 +139,13 @@ pub fn check_dataflow_static(dataflow: &Descriptor) -> eyre::Result<()> {
 }
 
 pub fn check_dataflow(dataflow: &Descriptor, working_dir: &Path) -> eyre::Result<()> {
-    check_dataflow_static(dataflow)?;
-
+    // Resolve the descriptor once and share the result across every check
+    // (static validation + path/runtime existence) instead of re-resolving it
+    // for each, which clones the whole node topology on every call.
+    validate_ros2_configs(dataflow)?;
     let nodes = dataflow.resolve_aliases_and_set_defaults()?;
+    check_dataflow_static_resolved(dataflow, &nodes)?;
+
     let mut has_python_operator = false;
 
     // check that nodes and operators exist


### PR DESCRIPTION
## Issue

`check_dataflow` (`libraries/core/src/descriptor/validate.rs`) resolved the descriptor **three times** on every call:

1. `check_dataflow_static` → `dataflow.resolve_aliases_and_set_defaults()`
2. `check_dataflow_static` → `check_wiring(dataflow)` → resolves again
3. `check_dataflow` → resolves a third time for the path/runtime existence checks

`resolve_aliases_and_set_defaults` clones the entire node topology and rebuilds a `BTreeMap<NodeId, ResolvedNode>`. The three resolutions are deterministic and identical, so two of them are pure wasted work — O(nodes) on every `dora check` / `dora run` / `dora start` validation.

## Fix

Resolve once and thread the resolved node map through the checks:

- `check_wiring_resolved(&nodes)` holds the wiring loop; `check_wiring` keeps its public signature by resolving then delegating.
- `check_dataflow_static_resolved(dataflow, &nodes)` holds the resolution-dependent static checks; `check_dataflow_static` keeps its public signature the same way.
- ROS2-config validation is extracted into `validate_ros2_configs`, still run on the **unresolved** descriptor *before* resolution — preserving the original error precedence (a ROS2 misconfig is reported ahead of an alias-resolution error).

`check_dataflow` now resolves exactly once and reuses the result. Public API signatures, behavior, and error ordering are all unchanged.

## Validation

- `cargo test -p dora-core --lib descriptor::` — 156 passed (includes the full `validate::tests` and `wiring_*` suites).
- `cargo fmt --all -- --check` and `cargo clippy -p dora-core -- -D warnings` clean.

---

🤖 This is a machine-generated pull request opened by Claude Code as part of an automated code-review pass. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SD4dBVimzepwKSh2b9F8aG)_