### PR TITLE
docs(arrow-convert): document and doctest the ArrowData read-back API

### DIFF
--- a/libraries/arrow-convert/src/lib.rs
+++ b/libraries/arrow-convert/src/lib.rs
@@ -48,6 +48,46 @@ pub trait IntoArrow {
 }
 
 /// Wrapper type for an Arrow [`ArrayRef`](arrow::array::ArrayRef).
+///
+/// `ArrowData` is the counterpart to [`IntoArrow`]: dora node APIs hand
+/// received outputs to nodes as `ArrowData`, which is read back into plain
+/// Rust values through its `TryFrom<&ArrowData>` implementations.
+///
+/// Two conversion shapes are provided, with different length contracts:
+///
+/// - **Scalar** conversions (`bool`, the primitive integer/float types,
+///   `String`, `&str`, and the `chrono` date/time types) require the array to
+///   hold **exactly one element and no nulls**; any other length is an error.
+/// - **Slice / `Vec`** conversions (`&[T]` and `Vec<T>` for the primitive
+///   types) accept **any length** but still reject **any null values**.
+///
+/// # Example
+///
+/// ```
+/// use std::sync::Arc;
+/// use dora_arrow_convert::{ArrowData, IntoArrow};
+///
+/// // Scalar: a single-element array converts to the value.
+/// let data = ArrowData(Arc::new(42_u8.into_arrow()));
+/// let scalar: u8 = (&data).try_into()?;
+/// assert_eq!(scalar, 42);
+///
+/// // Strings follow the same single-element rule.
+/// let data = ArrowData(Arc::new("hello".to_string().into_arrow()));
+/// let text: String = (&data).try_into()?;
+/// assert_eq!(text, "hello");
+///
+/// // Vec: any length, collected into an owned `Vec`.
+/// let data = ArrowData(Arc::new(vec![1_i32, 2, 3].into_arrow()));
+/// let values: Vec<i32> = (&data).try_into()?;
+/// assert_eq!(values, vec![1, 2, 3]);
+///
+/// // A multi-element array cannot be read as a scalar.
+/// let data = ArrowData(Arc::new(vec![1_i32, 2, 3].into_arrow()));
+/// let scalar: Result<i32, _> = (&data).try_into();
+/// assert!(scalar.is_err());
+/// # Ok::<(), eyre::Report>(())
+/// ```
 #[derive(Debug)]
 pub struct ArrowData(pub arrow::array::ArrayRef);
 


### PR DESCRIPTION
## Issue

`ArrowData`'s `TryFrom<&ArrowData>` implementations (`libraries/arrow-convert/src/from_impls.rs`) are the primary public API for reading received Arrow data back into Rust values — the read-back counterpart to `IntoArrow`. `IntoArrow` has a documented, compile-checked doctest (`lib.rs`), but the read-back side had none, and its non-obvious, load-bearing contract was only discoverable by reading the source:

- **scalar** conversions (`u8`, `f32`, `String`, `&str`, `chrono` types) require **exactly one element and no nulls**;
- **slice / `Vec`** conversions accept **any length** but reject **any nulls**.

## Fix

Expand the `ArrowData` doc comment to describe both conversion shapes and their length/null contracts, with a compile-checked doctest that:

- round-trips a scalar (`u8`), a `String`, and a `Vec<i32>` via `try_into()`, and
- shows that a multi-element array cannot be read as a scalar (returns `Err`).

Documentation only — no behavior change. This is a good fit for the "prefer compile-checked doctests" documentation goal: the doctest locks the contract against future drift.

## Validation

- `cargo test -p dora-arrow-convert --doc` — 2 passed (the new `ArrowData` doctest plus the existing `IntoArrow` one).
- `cargo fmt --all -- --check` and `cargo clippy -p dora-arrow-convert -- -D warnings` clean.

---

🤖 This is a machine-generated pull request opened by Claude Code as part of an automated code-review pass. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SD4dBVimzepwKSh2b9F8aG)_