### PR TITLE
fix(core): move newer `bail!` sites out of expression position (partial #2835, complements #2843)

### DIFF
--- a/libraries/core/src/build/git.rs
+++ b/libraries/core/src/build/git.rs
@@ -103,7 +103,7 @@ impl GitManager {
                 "the build directory is still in use by the following \
                     dataflows, please stop them before rebuilding: {}",
                 using.iter().join(", ")
-            )
+            );
         }
 
         let reuse = if self.clone_dir_ready(session_id, &clone_dir) {
@@ -293,7 +293,7 @@ impl GitFolder {
                             .log_message(LogLevel::Error, format!("{err:?}"))
                             .await;
                         cleanup_failed_clone(logger, &target_dir).await;
-                        bail!(err)
+                        bail!(err);
                     }
                 }
             }
@@ -345,7 +345,7 @@ impl GitFolder {
                     Ok(()) => target_dir,
                     Err(err) => {
                         cleanup_failed_clone(logger, &target_dir).await;
-                        bail!(err)
+                        bail!(err);
                     }
                 }
             }
@@ -379,7 +379,7 @@ impl GitFolder {
                     Ok(()) => target_dir,
                     Err(err) => {
                         cleanup_failed_clone(logger, &target_dir).await;
-                        bail!(err)
+                        bail!(err);
                     }
                 }
             }
@@ -432,12 +432,14 @@ impl GitFolder {
                         // in-progress set only covers one GitManager and the CLI
                         // builds with its own, so deleting here is how #2711
                         // wipes out a live build. Fail loudly, leave the dir.
-                        Err(err) => bail!(
-                            "couldn't verify clone dir {} is on commit {commit_hash}: {err:?}; \
-                             leaving it in place in case another build is writing it, \
-                             please retry",
-                            dir.display()
-                        ),
+                        Err(err) => {
+                            bail!(
+                                "couldn't verify clone dir {} is on commit {commit_hash}: {err:?}; \
+                                 leaving it in place in case another build is writing it, \
+                                 please retry",
+                                dir.display()
+                            );
+                        }
                     }
                 }
 

--- a/libraries/core/src/descriptor/expand.rs
+++ b/libraries/core/src/descriptor/expand.rs
@@ -693,10 +693,12 @@ fn rewrite_module_input(
                         }))
                     }
                     None if optional_inputs.contains(&port_name) => Ok(None),
-                    None => bail!(
-                        "module input reference `_mod/{}` not found in module node inputs",
-                        port_name,
-                    ),
+                    None => {
+                        bail!(
+                            "module input reference `_mod/{}` not found in module node inputs",
+                            port_name,
+                        );
+                    }
                 }
             } else if inner_node_ids.contains(&source_str) {
                 // Internal cross-reference: prefix with module_id

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -355,7 +355,7 @@ fn node_kind_mut(node: &mut Node) -> eyre::Result<NodeKindMut<'_>> {
                 "module node `{}` must be expanded before resolution — \
                  call expand_modules() first",
                 node.id
-            )
+            );
         }
         NodeKind::Standard(_) => {
             let source = match (&node.git, &node.branch, &node.tag, &node.rev) {
@@ -369,7 +369,7 @@ fn node_kind_mut(node: &mut Node) -> eyre::Result<NodeKindMut<'_>> {
                         other @ (_, _, _) => {
                             eyre::bail!(
                                 "only one of `branch`, `tag`, and `rev` are allowed (got {other:?})"
-                            )
+                            );
                         }
                     };
                     NodeSource::GitBranch {
@@ -378,7 +378,7 @@ fn node_kind_mut(node: &mut Node) -> eyre::Result<NodeKindMut<'_>> {
                     }
                 }
                 (None, _, _, _) => {
-                    eyre::bail!("`git` source required when using branch, tag, or rev")
+                    eyre::bail!("`git` source required when using branch, tag, or rev");
                 }
             };
 
@@ -454,7 +454,7 @@ pub fn resolve_path(source: &str, working_dir: &Path) -> Result<PathBuf> {
     } else if let Ok(abs_path) = which::which(&path) {
         Ok(abs_path)
     } else {
-        bail!("Could not find source path {}", path.display())
+        bail!("Could not find source path {}", path.display());
     }
 }
 
@@ -500,7 +500,7 @@ pub fn resolve_path_confined(
         python_env_dir
             .map(|env| format!(" or its managed environment `{}`", env.display()))
             .unwrap_or_default(),
-    )
+    );
 }
 
 /// Canonicalize `candidate` and require it to stay under `root`.
@@ -605,7 +605,7 @@ impl NodeExt for Node {
                 eyre::bail!(
                     "node `{}` requires a `path`, `custom`, `operators`, `ros2`, or `module` field",
                     self.id
-                )
+                );
             }
             (None, None, None, Some(operator), None, None) => Ok(NodeKind::Operator(operator)),
             (None, None, Some(custom), None, None, None) => Ok(NodeKind::Custom(custom)),
@@ -617,7 +617,7 @@ impl NodeExt for Node {
                 eyre::bail!(
                     "node `{}` has multiple exclusive fields set, only one of `path`, `custom`, `operators`, `operator`, `ros2`, and `module` is allowed",
                     self.id
-                )
+                );
             }
         }
     }

--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -425,7 +425,9 @@ fn parse_byte_size(s: &str) -> eyre::Result<u64> {
         "KB" | "K" => 1024,
         "MB" | "M" => 1024 * 1024,
         "GB" | "G" => 1024 * 1024 * 1024,
-        _ => bail!("unknown byte size unit: '{unit}', expected B, KB, MB, or GB"),
+        _ => {
+            bail!("unknown byte size unit: '{unit}', expected B, KB, MB, or GB");
+        }
     };
     // Use integer parse when possible to avoid float rounding
     if let Ok(num) = num_str.parse::<u64>() {
@@ -472,9 +474,11 @@ fn parse_log_level(s: &str) -> eyre::Result<dora_message::common::LogLevelOrStdo
             log::Level::Trace,
         )),
         "stdout" => Ok(dora_message::common::LogLevelOrStdout::Stdout),
-        _ => bail!(
-            "invalid min_log_level: '{s}', expected one of: error, warn, info, debug, trace, stdout"
-        ),
+        _ => {
+            bail!(
+                "invalid min_log_level: '{s}', expected one of: error, warn, info, debug, trace, stdout"
+            );
+        }
     }
 }
 
@@ -565,7 +569,7 @@ assert dora.__version__=='{VERSION}',  'Python dora-rs should be {VERSION}, but 
         .wrap_err("Could not get exit status when checking python dora-rs")?;
 
     if !status.success() {
-        bail!("Something went wrong with Python dora-rs. {reinstall_command}")
+        bail!("Something went wrong with Python dora-rs. {reinstall_command}");
     }
 
     Ok(())
@@ -757,19 +761,23 @@ fn validate_ros2_qos(
     if let Some(d) = &qos.durability {
         match d.as_str() {
             "volatile" | "transient_local" => {}
-            _ => bail!(
-                "node `{node_id}`: invalid QoS durability `{d}`, \
-                 expected \"volatile\" or \"transient_local\""
-            ),
+            _ => {
+                bail!(
+                    "node `{node_id}`: invalid QoS durability `{d}`, \
+                     expected \"volatile\" or \"transient_local\""
+                );
+            }
         }
     }
     if let Some(l) = &qos.liveliness {
         match l.as_str() {
             "automatic" | "manual_by_participant" | "manual_by_topic" => {}
-            _ => bail!(
-                "node `{node_id}`: invalid QoS liveliness `{l}`, \
-                 expected \"automatic\", \"manual_by_participant\", or \"manual_by_topic\""
-            ),
+            _ => {
+                bail!(
+                    "node `{node_id}`: invalid QoS liveliness `{l}`, \
+                     expected \"automatic\", \"manual_by_participant\", or \"manual_by_topic\""
+                );
+            }
         }
     }
     if let Some(depth) = qos.keep_last


### PR DESCRIPTION
## Summary

Part of #2835. **Complements the pre-existing #2843** — please land both.

`eyre::bail!` / `bail!` expand to a block ending in a semicolon (`{ return Err(..); }`). Used as the **tail expression of a block** or as a **bare `match` arm**, that trailing semicolon is in expression position, which trips `semicolon_in_expressions_from_macros` / `semicolon_in_expressions_from_non_local_macros` — denied under `future_incompatible` on recent nightlies, failing `dora-core` compilation.

## Relationship to #2843

#2843 (opened 2026-07-26, `Closes #2835`) fixes this lint class across the whole workspace (48 files: node API, CLI, etc.). Since then, newer code has merged into `main` that introduced **additional** expression-position `bail!` sites in `dora-core` which #2843 does not cover. This PR fixes those.

The two PRs are **disjoint — no overlapping files** — so both can land independently, and `dora-core` is only fully clean once both do:

| dora-core file | fixed by |
|---|---|
| `build/git.rs`, `descriptor/mod.rs`, `descriptor/validate.rs`, `descriptor/expand.rs` | **this PR** |
| `topics.rs`, `build/mod.rs` | #2843 |

## What changed here

Moved every affected call in the files above to statement position:

- **Block-tail calls** (`{ …; bail!(..) }`): added a trailing `;`.
- **Bare `match` arms** (`_ => bail!(..)`): wrapped in a `{ bail!(..); }` block.

18 sites total. Every one diverges (`bail!` returns early), so it still coerces to the surrounding arm/expression type via the never type — **no runtime behavior change**.

## Verification

Toolchain: `rustc 1.99.0-nightly (771916f90 2026-08-08)`.

- `cargo +nightly check -p dora-core` — the 13 diagnostics that were reported at these sites are gone. (Note: which sites a given nightly flags for the non-local `eyre::bail!` variant varies by toolchain build; the `topics.rs` / `build/mod.rs` sites owned by #2843 are the remaining ones needed for full cross-toolchain coverage.)
- `cargo +1.97.1 check -p dora-core` — clean on the pinned toolchain.
- `cargo +1.97.1 clippy -p dora-core -- -D warnings` — clean.
- `cargo +1.97.1 fmt -p dora-core -- --check` — clean.
- `cargo +1.97.1 test -p dora-core` — 272 passing.