### PR TITLE
Add startup timeout for nodes stuck before connection

### DIFF
--- a/binaries/cli/src/command/node/info.rs
+++ b/binaries/cli/src/command/node/info.rs
@@ -83,6 +83,8 @@ struct NodeInfoOutput {
     #[serde(skip_serializing_if = "Option::is_none")]
     health_check_timeout: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    startup_timeout: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     finish_grace_secs: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     metrics: Option<MetricsOutput>,
@@ -166,6 +168,7 @@ fn info(
         max_restarts: node_desc.max_restarts,
         restart_delay: node_desc.restart_delay,
         health_check_timeout: node_desc.health_check_timeout,
+        startup_timeout: node_desc.startup_timeout,
         finish_grace_secs: node_desc.finish_grace_secs,
         metrics: metrics.and_then(|m| m.metrics).map(|m| MetricsOutput {
             status: m.status.to_string(),
@@ -271,6 +274,9 @@ fn print_table(output: &NodeInfoOutput) {
     }
     if let Some(timeout) = output.health_check_timeout {
         println!("  Health check timeout: {timeout}s");
+    }
+    if let Some(timeout) = output.startup_timeout {
+        println!("  Startup timeout: {timeout}s");
     }
     if let Some(grace) = output.finish_grace_secs {
         println!("  Finish grace: {grace}s");

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -403,6 +403,7 @@ fn patch_descriptor_entry(
         entry.max_restart_delay = custom.max_restart_delay;
         entry.restart_window = custom.restart_window;
         entry.health_check_timeout = custom.health_check_timeout;
+        entry.startup_timeout = custom.startup_timeout;
         entry.finish_grace_secs = custom.finish_grace_secs;
         entry.send_stdout_as = custom.send_stdout_as.clone();
         entry.send_logs_as = custom.send_logs_as.clone();
@@ -1890,6 +1891,7 @@ impl Daemon {
                 }
                 Event::NodeHealthCheckInterval => {
                     self.check_node_health();
+                    self.check_startup_timeouts();
                     self.check_input_timeouts();
                     self.check_finish_stragglers();
                     if self.ft_stats.any_nonzero() {
@@ -2818,6 +2820,7 @@ impl Daemon {
                             max_restart_delay: None,
                             restart_window: None,
                             health_check_timeout: None,
+                            startup_timeout: None,
                             finish_grace_secs: None,
                             module: None,
                             params: Default::default(),
@@ -3557,6 +3560,39 @@ impl Daemon {
                 self.ft_stats
                     .health_check_kills
                     .fetch_add(1, atomic::Ordering::Relaxed);
+                if let Some(process) = &node.process {
+                    process.submit(ProcessOperation::Kill);
+                }
+            }
+        }
+    }
+
+    fn check_startup_timeouts(&mut self) {
+        let now_millis = node_communication::current_millis();
+        for (dataflow_id, dataflow) in &mut self.running {
+            for (node_id, node) in &dataflow.running_nodes {
+                let Some(timeout) = node.startup_timeout else {
+                    continue;
+                };
+                let timeout_key = (node_id.clone(), node.generation);
+                let timed_out = startup_timeout_should_kill(
+                    dataflow.pending_nodes.is_pending(node_id),
+                    dataflow.connected_nodes.contains(node_id),
+                    dataflow.startup_timeout_kills.contains_key(&timeout_key),
+                    node.last_activity.load(atomic::Ordering::Acquire),
+                    now_millis,
+                    timeout,
+                );
+                if !timed_out {
+                    continue;
+                }
+                tracing::warn!(
+                    %dataflow_id,
+                    %node_id,
+                    generation = node.generation,
+                    "node did not initialize dora connection within {timeout:?}; killing"
+                );
+                dataflow.startup_timeout_kills.insert(timeout_key, timeout);
                 if let Some(process) = &node.process {
                     process.submit(ProcessOperation::Kill);
                 }
@@ -5856,10 +5892,14 @@ impl Daemon {
                         dataflow
                             .grace_duration_kills
                             .remove(&(node_id.clone(), generation));
+                        dataflow
+                            .startup_timeout_kills
+                            .remove(&(node_id.clone(), generation));
                     }
                     return Ok(());
                 }
 
+                let lifecycle_key = (node_id.clone(), generation);
                 let node_result = match exit_status {
                     NodeExitStatus::Success => Ok(()),
                     exit_status => {
@@ -5872,9 +5912,12 @@ impl Daemon {
                         let grace_duration_kill = dataflow
                             .map(|d| {
                                 d.grace_duration_kills
-                                    .contains(&(node_id.clone(), generation))
+                                    .contains(&lifecycle_key)
                             })
                             .unwrap_or_default();
+                        let startup_timeout_kill = dataflow.and_then(|d| {
+                            d.startup_timeout_kills.get(&lifecycle_key).copied()
+                        });
                         // Killed by the finish-straggler watchdog
                         // (dora-rs/dora#2152): the node blocked an
                         // otherwise-finished dataflow past the drain grace
@@ -5969,6 +6012,11 @@ impl Daemon {
                                 None if grace_duration_kill || finish_escalated => {
                                     NodeErrorCause::GraceDuration
                                 }
+                                None if let Some(timeout) = startup_timeout_kill => {
+                                    NodeErrorCause::StartupTimeout {
+                                        timeout_secs: timeout.as_secs_f64(),
+                                    }
+                                }
                                 None => {
                                     let cause = dataflow
                                         .and_then(|d| d.node_stderr_most_recent.get(&node_id))
@@ -6013,7 +6061,10 @@ impl Daemon {
                 if let Some(dataflow) = self.running.get_mut(&dataflow_id) {
                     dataflow
                         .grace_duration_kills
-                        .remove(&(node_id.clone(), generation));
+                        .remove(&lifecycle_key);
+                    if !restart {
+                        dataflow.startup_timeout_kills.remove(&lifecycle_key);
+                    }
                     dataflow.all_inputs_closed_at.remove(&node_id);
                     // a respawned node must re-subscribe before it counts as
                     // connected, else a slow restart could be silence-escalated
@@ -6164,8 +6215,15 @@ impl Daemon {
                             new_generation,
                             new_handle,
                         ) {
-                            running_dataflow::HandleReplacement::Replaced => {}
+                            running_dataflow::HandleReplacement::Replaced => {
+                                dataflow
+                                    .startup_timeout_kills
+                                    .remove(&(node_id.clone(), previous_generation));
+                            }
                             running_dataflow::HandleReplacement::RejectedTeardown(new_handle) => {
+                                dataflow
+                                    .startup_timeout_kills
+                                    .remove(&(node_id.clone(), previous_generation));
                                 dataflow.stop_rejected_replacement(
                                     &node_id,
                                     new_generation,
@@ -6917,6 +6975,28 @@ fn health_check_should_kill(
     elapsed_ms > timeout.as_millis() as u64
 }
 
+/// Whether the startup watchdog should kill a node that has not initialized its
+/// Dora connection yet.
+///
+/// This is deliberately separate from [`health_check_should_kill`]:
+/// `health_check_timeout` covers post-connection silence, while
+/// `startup_timeout` covers the pre-connection gap where a process can hang
+/// before its first `Subscribe` and keep the startup barrier pending forever.
+fn startup_timeout_should_kill(
+    pending: bool,
+    connected: bool,
+    already_killed: bool,
+    last_activity_millis: u64,
+    now_millis: u64,
+    timeout: Duration,
+) -> bool {
+    if !pending || connected || already_killed {
+        return false;
+    }
+    let elapsed_ms = now_millis.saturating_sub(last_activity_millis);
+    elapsed_ms > timeout.as_millis() as u64
+}
+
 /// Grace period before the finish-straggler watchdog escalates a stuck node, or
 /// `None` if the watchdog has been explicitly **disabled**.
 ///
@@ -7658,6 +7738,7 @@ mod fault_tolerance_tests {
             force_restart_next: Arc::new(AtomicBool::new(false)),
             last_activity: Arc::new(AtomicU64::new(0)),
             health_check_timeout: None,
+            startup_timeout: None,
             finish_grace_secs: None,
         }
     }
@@ -8588,6 +8669,8 @@ mod fault_tolerance_tests {
             );
             df.broken_inputs
                 .insert((node.clone(), input_x.clone()), timeout);
+            df.startup_timeout_kills
+                .insert((node.clone(), 7), timeout);
             df.node_stderr_most_recent
                 .insert(node.clone(), Arc::new(ArrayQueue::new(4)));
         }
@@ -8603,6 +8686,10 @@ mod fault_tolerance_tests {
             !df.broken_inputs
                 .contains_key(&(node_a.clone(), input_x.clone()))
         );
+        assert!(
+            !df.startup_timeout_kills
+                .contains_key(&(node_a.clone(), 7))
+        );
         assert!(!df.node_stderr_most_recent.contains_key(&node_a));
 
         // … while node_b's are untouched.
@@ -8613,6 +8700,10 @@ mod fault_tolerance_tests {
         assert!(
             df.broken_inputs
                 .contains_key(&(node_b.clone(), input_x.clone()))
+        );
+        assert!(
+            df.startup_timeout_kills
+                .contains_key(&(node_b.clone(), 7))
         );
         assert!(df.node_stderr_most_recent.contains_key(&node_b));
     }
@@ -9717,5 +9808,58 @@ mod health_check_tests {
         let last = 10_000u64;
         let now = 1_000u64;
         assert!(!health_check_should_kill(true, last, now, TIMEOUT));
+    }
+}
+
+#[cfg(test)]
+mod startup_timeout_tests {
+    use super::startup_timeout_should_kill;
+    use std::time::Duration;
+
+    const TIMEOUT: Duration = Duration::from_secs(5);
+
+    #[test]
+    fn pending_unconnected_node_past_startup_timeout_is_killed() {
+        let spawn = 1_000u64;
+        let now = spawn + 6_000;
+        assert!(startup_timeout_should_kill(
+            true, false, false, spawn, now, TIMEOUT
+        ));
+    }
+
+    #[test]
+    fn subscribed_node_is_not_killed_by_startup_timeout() {
+        let spawn = 1_000u64;
+        let now = spawn + 6_000;
+        assert!(!startup_timeout_should_kill(
+            false, true, false, spawn, now, TIMEOUT
+        ));
+    }
+
+    #[test]
+    fn non_pending_node_is_not_killed_by_startup_timeout() {
+        let spawn = 1_000u64;
+        let now = spawn + 6_000;
+        assert!(!startup_timeout_should_kill(
+            false, false, false, spawn, now, TIMEOUT
+        ));
+    }
+
+    #[test]
+    fn startup_timeout_kill_is_one_shot_per_generation() {
+        let spawn = 1_000u64;
+        let now = spawn + 6_000;
+        assert!(!startup_timeout_should_kill(
+            true, false, true, spawn, now, TIMEOUT
+        ));
+    }
+
+    #[test]
+    fn exactly_at_startup_timeout_is_not_killed() {
+        let spawn = 1_000u64;
+        let now = spawn + 5_000;
+        assert!(!startup_timeout_should_kill(
+            true, false, false, spawn, now, TIMEOUT
+        ));
     }
 }

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -109,6 +109,7 @@ pub struct RunningNode {
     pub(crate) force_restart_next: Arc<AtomicBool>,
     pub(crate) last_activity: Arc<AtomicU64>,
     pub(crate) health_check_timeout: Option<Duration>,
+    pub(crate) startup_timeout: Option<Duration>,
     /// Per-node finish-drain grace override (from `finish_grace_secs` in the
     /// descriptor). When `Some`, overrides the global `DORA_FINISH_DRAIN_GRACE_SECS`
     /// for this node in the finish-straggler watchdog.
@@ -314,6 +315,9 @@ pub struct RunningDataflow {
     pub(crate) connected_nodes: BTreeSet<NodeId>,
     /// Nodes already escalated by the finish-straggler watchdog (one-shot).
     pub(crate) finish_escalated: BTreeSet<NodeId>,
+    /// Startup timeout kills keyed by `(node id, generation)`, so a restarted
+    /// successor never inherits the previous incarnation's timeout marker.
+    pub(crate) startup_timeout_kills: BTreeMap<(NodeId, u64), Duration>,
     /// Per node, the inputs that can ever close — i.e. those fed by
     /// another node's output rather than by the daemon.
     ///
@@ -408,6 +412,7 @@ impl RunningDataflow {
             all_inputs_closed_at: HashMap::new(),
             connected_nodes: BTreeSet::new(),
             finish_escalated: BTreeSet::new(),
+            startup_timeout_kills: BTreeMap::new(),
             data_inputs: BTreeMap::new(),
             timers_gate_drain: true,
             stop_sent: false,
@@ -445,6 +450,7 @@ impl RunningDataflow {
     pub(crate) fn forget_node_bookkeeping(&mut self, node_id: &NodeId) {
         self.input_deadlines.retain(|(n, _), _| n != node_id);
         self.broken_inputs.retain(|(n, _), _| n != node_id);
+        self.startup_timeout_kills.retain(|(n, _), _| n != node_id);
         self.node_stderr_most_recent.remove(node_id);
     }
 

--- a/binaries/daemon/src/spawn/prepared.rs
+++ b/binaries/daemon/src/spawn/prepared.rs
@@ -215,6 +215,7 @@ impl PreparedNode {
             },
             last_activity: self.last_activity.clone(),
             health_check_timeout: self.health_check_timeout(),
+            startup_timeout: self.startup_timeout(),
             finish_grace_secs: self.finish_grace_secs(),
         };
 
@@ -244,6 +245,15 @@ impl PreparedNode {
         match &self.node.kind {
             dora_core::descriptor::CoreNodeKind::Custom(n) => {
                 n.health_check_timeout.map(Duration::from_secs_f64)
+            }
+            dora_core::descriptor::CoreNodeKind::Runtime(_) => None,
+        }
+    }
+
+    fn startup_timeout(&self) -> Option<Duration> {
+        match &self.node.kind {
+            dora_core::descriptor::CoreNodeKind::Custom(n) => {
+                n.startup_timeout.map(Duration::from_secs_f64)
             }
             dora_core::descriptor::CoreNodeKind::Runtime(_) => None,
         }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -614,6 +614,7 @@ pub enum RestartPolicy {
 - `restart_delay` — initial backoff in seconds (doubles each attempt)
 - `max_restart_delay` — caps exponential backoff
 - `restart_window` — reset counter after N seconds (enables "N restarts per M seconds")
+- `startup_timeout` — kill node if it does not initialize its Dora connection within this duration
 - `health_check_timeout` — kill node if no activity within this duration, measured only after the node connects (post-connection liveness, not a startup deadline)
 
 ### Health Monitoring

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -175,6 +175,7 @@ nodes:
     restart_delay: 1.0            # initial backoff in seconds
     max_restart_delay: 30.0       # backoff cap in seconds
     restart_window: 300.0         # reset counter after N seconds
+    startup_timeout: 60.0         # kill if startup never reaches Node::init
     health_check_timeout: 30.0    # kill if no activity for N seconds
 
     # --- Logging ---

--- a/docs/fault-tolerance.md
+++ b/docs/fault-tolerance.md
@@ -7,6 +7,7 @@ Dora provides built-in fault tolerance for robotic and AI dataflows. Nodes can a
 | Feature | Scope | Config |
 |---------|-------|--------|
 | Restart policies | Per-node | `restart_policy`, `max_restarts`, `restart_delay`, ... |
+| Startup deadline | Per-node | `startup_timeout`, `health_check_interval` (dataflow-level) |
 | Health monitoring | Per-node | `health_check_timeout`, `health_check_interval` (dataflow-level) |
 | Input timeouts | Per-input | `input_timeout` |
 | Circuit breaker | Automatic | Triggered by `input_timeout`, auto-recovers |
@@ -122,6 +123,7 @@ health_check_interval: 2.0  # seconds (default: 5.0, dataflow-level)
 nodes:
   - id: my-node
     path: ./target/debug/my-node
+    startup_timeout: 60.0       # seconds to reach Node::init (per-node)
     health_check_timeout: 30.0  # seconds (per-node)
     restart_policy: on-failure
 ```
@@ -159,11 +161,11 @@ mid-startup -- and under `restart_policy: always`/`on-failure` that becomes an
 unescapable restart loop.
 
 The tradeoff is that a node that hangs **before** it ever subscribes -- a
-deadlock in import or init code that never reaches `Node::init` -- is not
-reaped by this watchdog, and the dataflow stays in its pending state waiting
-for that node. Slow-but-legitimate startup and hung startup are
-indistinguishable before the node connects, so bounding them needs a separate
-startup deadline rather than this timeout.
+deadlock in import or init code that never reaches `Node::init` -- is outside
+this watchdog. Use `startup_timeout` when you want to bound that pre-connection
+phase: if the node does not initialize its Dora connection before the deadline,
+the daemon kills that process and the normal restart policy decides whether to
+retry.
 
 ### What Counts as "Activity"
 

--- a/docs/yaml-spec.md
+++ b/docs/yaml-spec.md
@@ -326,6 +326,7 @@ For a complete guide to all logging features, see [Logging](logging.md).
 | `max_restart_delay` | float | -- | Cap for exponential backoff |
 | `restart_window` | float | -- | Time window for counting restarts. The counter resets after this many seconds since the first restart in the current window. Enables "N restarts per M seconds" semantics with `max_restarts` |
 | `health_check_timeout` | float | -- | Once the node has connected (subscribed to events), if it then does not communicate with the daemon (send outputs, acknowledge ticks, etc.) for this many seconds, the daemon kills the process and evaluates the `restart_policy`. Covers **post-connection** liveness only -- it does not bound startup time, so a node that hangs before it ever subscribes is not killed |
+| `startup_timeout` | float | -- | If the node does not initialize its Dora connection within this many seconds, the daemon kills the process and lets the `restart_policy` decide whether to retry. Covers **pre-connection** startup hangs only |
 
 Restart policies:
 
@@ -343,6 +344,7 @@ Example with exponential backoff:
   restart_delay: 1.0         # 1s, 2s, 4s, 8s, 16s
   max_restart_delay: 30.0    # capped at 30s
   restart_window: 300.0      # 5 restarts per 5 minutes
+  startup_timeout: 60.0      # kill if startup never reaches Node::init
   health_check_timeout: 30.0
 ```
 

--- a/guide/src/concepts/architecture.md
+++ b/guide/src/concepts/architecture.md
@@ -584,7 +584,8 @@ pub enum RestartPolicy {
 - `restart_delay` — initial backoff in seconds (doubles each attempt)
 - `max_restart_delay` — caps exponential backoff
 - `restart_window` — reset counter after N seconds (enables "N restarts per M seconds")
-- `health_check_timeout` — kill node if no activity within this duration
+- `startup_timeout` — kill node if it does not initialize its Dora connection within this duration
+- `health_check_timeout` — kill node if no activity within this duration, measured only after the node connects
 
 ### Health Monitoring
 

--- a/guide/src/concepts/dataflow-yaml.md
+++ b/guide/src/concepts/dataflow-yaml.md
@@ -277,7 +277,8 @@ For a complete guide to all logging features, see [Logging](logging.md).
 | `restart_delay` | float | -- | Initial backoff in seconds. Doubles each attempt |
 | `max_restart_delay` | float | -- | Cap for exponential backoff |
 | `restart_window` | float | -- | Time window for counting restarts. The counter resets after this many seconds since the first restart in the current window. Enables "N restarts per M seconds" semantics with `max_restarts` |
-| `health_check_timeout` | float | -- | If the node does not communicate with the daemon (send outputs, subscribe, etc.) for this many seconds, the daemon kills the process and evaluates the `restart_policy` |
+| `startup_timeout` | float | -- | If the node does not initialize its Dora connection within this many seconds, the daemon kills the process and lets the `restart_policy` decide whether to retry. Covers **pre-connection** startup hangs only |
+| `health_check_timeout` | float | -- | Once the node has connected, if it then does not communicate with the daemon (send outputs, acknowledge ticks, etc.) for this many seconds, the daemon kills the process and evaluates the `restart_policy`. Covers **post-connection** liveness only |
 
 Restart policies:
 
@@ -295,6 +296,7 @@ Example with exponential backoff:
   restart_delay: 1.0         # 1s, 2s, 4s, 8s, 16s
   max_restart_delay: 30.0    # capped at 30s
   restart_window: 300.0      # 5 restarts per 5 minutes
+  startup_timeout: 60.0      # kill if startup never reaches Node::init
   health_check_timeout: 30.0
 ```
 

--- a/guide/src/operations/cli.md
+++ b/guide/src/operations/cli.md
@@ -175,6 +175,7 @@ nodes:
     restart_delay: 1.0            # initial backoff in seconds
     max_restart_delay: 30.0       # backoff cap in seconds
     restart_window: 300.0         # reset counter after N seconds
+    startup_timeout: 60.0         # kill if startup never reaches Node::init
     health_check_timeout: 30.0    # kill if no activity for N seconds
 
     # --- Logging ---

--- a/guide/src/operations/fault-tolerance.md
+++ b/guide/src/operations/fault-tolerance.md
@@ -7,6 +7,7 @@ Dora provides built-in fault tolerance for robotic and AI dataflows. Nodes can a
 | Feature | Scope | Config |
 |---------|-------|--------|
 | Restart policies | Per-node | `restart_policy`, `max_restarts`, `restart_delay`, ... |
+| Startup deadline | Per-node | `startup_timeout`, `health_check_interval` (dataflow-level) |
 | Health monitoring | Per-node | `health_check_timeout`, `health_check_interval` (dataflow-level) |
 | Input timeouts | Per-input | `input_timeout` |
 | Circuit breaker | Automatic | Triggered by `input_timeout`, auto-recovers |
@@ -122,6 +123,7 @@ health_check_interval: 2.0  # seconds (default: 5.0, dataflow-level)
 nodes:
   - id: my-node
     path: ./target/debug/my-node
+    startup_timeout: 60.0       # seconds to reach Node::init (per-node)
     health_check_timeout: 30.0  # seconds (per-node)
     restart_policy: on-failure
 ```
@@ -159,11 +161,11 @@ mid-startup -- and under `restart_policy: always`/`on-failure` that becomes an
 unescapable restart loop.
 
 The tradeoff is that a node that hangs **before** it ever subscribes -- a
-deadlock in import or init code that never reaches `Node::init` -- is not
-reaped by this watchdog, and the dataflow stays in its pending state waiting
-for that node. Slow-but-legitimate startup and hung startup are
-indistinguishable before the node connects, so bounding them needs a separate
-startup deadline rather than this timeout.
+deadlock in import or init code that never reaches `Node::init` -- is outside
+this watchdog. Use `startup_timeout` when you want to bound that pre-connection
+phase: if the node does not initialize its Dora connection before the deadline,
+the daemon kills that process and the normal restart policy decides whether to
+retry.
 
 ### What Counts as "Activity"
 

--- a/libraries/core/dora-schema.json
+++ b/libraries/core/dora-schema.json
@@ -104,7 +104,15 @@
           "format": "double"
         },
         "health_check_timeout": {
-          "description": "Health check timeout in seconds.\n\nWhen set, the daemon monitors this node for activity. If the node does not\ncommunicate with the daemon within this timeout, it is killed and the restart\npolicy is evaluated.",
+          "description": "Health check timeout in seconds.\n\nWhen set, the daemon monitors this node for activity **once it has\nconnected** (i.e. subscribed to events during `Node::init`). If the\nconnected node then does not communicate with the daemon within this\ntimeout, it is killed and the restart policy is evaluated.\n\nThis bounds post-connection liveness only, not startup time: a node\nstill in a slow cold start has not connected yet and is never killed by\nthis watchdog. A node that hangs before it ever subscribes is therefore\nnot reaped here either.",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "startup_timeout": {
+          "description": "Startup timeout in seconds.\n\nWhen set, the daemon kills this node if it does not initialize its Dora\nconnection within the timeout. This bounds pre-connection startup hangs;\nafter the node has connected, `health_check_timeout` handles liveness.",
           "type": [
             "number",
             "null"
@@ -535,7 +543,15 @@
           ]
         },
         "health_check_timeout": {
-          "description": "Health check timeout in seconds.\n\nWhen set, the daemon monitors this node for activity. If the node does not\ncommunicate with the daemon within this timeout, it is killed and the restart\npolicy is evaluated.",
+          "description": "Health check timeout in seconds.\n\nWhen set, the daemon monitors this node for activity **once it has\nconnected** (i.e. subscribed to events during `Node::init`). If the\nconnected node then does not communicate with the daemon within this\ntimeout, it is killed and the restart policy is evaluated.\n\nThis bounds post-connection liveness only, not startup time: a node\nstill in a slow cold start has not connected yet and is never killed by\nthis watchdog. A node that hangs before it ever subscribes is therefore\nnot reaped here either.",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "startup_timeout": {
+          "description": "Startup timeout in seconds.\n\nWhen set, the daemon kills this node if it does not initialize its Dora\nconnection within the timeout. This bounds pre-connection startup hangs;\nafter the node has connected, `health_check_timeout` handles liveness.",
           "type": [
             "number",
             "null"

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -195,6 +195,7 @@ pub fn resolve_aliases_and_set_defaults_in_topology(
                 max_restart_delay: node.max_restart_delay,
                 restart_window: node.restart_window,
                 health_check_timeout: node.health_check_timeout,
+                startup_timeout: node.startup_timeout,
                 finish_grace_secs: node.finish_grace_secs,
             }),
             NodeKindMut::Custom(node) => CoreNodeKind::Custom(node.clone()),
@@ -241,6 +242,7 @@ pub fn resolve_aliases_and_set_defaults_in_topology(
                     max_restart_delay: node.max_restart_delay,
                     restart_window: node.restart_window,
                     health_check_timeout: node.health_check_timeout,
+                    startup_timeout: node.startup_timeout,
                     finish_grace_secs: node.finish_grace_secs,
                 })
             }

--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -208,6 +208,7 @@ fn check_timing_fields(
     for (field, value) in [
         ("finish_grace_secs", custom.finish_grace_secs),
         ("health_check_timeout", custom.health_check_timeout),
+        ("startup_timeout", custom.startup_timeout),
         ("restart_delay", custom.restart_delay),
         ("max_restart_delay", custom.max_restart_delay),
         ("restart_window", custom.restart_window),
@@ -1386,6 +1387,7 @@ operators:
             max_restart_delay: None,
             restart_window: None,
             health_check_timeout: None,
+            startup_timeout: None,
             finish_grace_secs: None,
             run_config: serde_yaml::from_str("{}").unwrap(),
         }
@@ -1400,6 +1402,7 @@ operators:
         // a large finite grace is fine
         node.finish_grace_secs = Some(3600.0);
         node.health_check_timeout = Some(0.0);
+        node.startup_timeout = Some(0.0);
         check_timing_fields(&id, &node).unwrap();
     }
 
@@ -1411,6 +1414,18 @@ operators:
         let err = check_timing_fields(&id, &node).unwrap_err().to_string();
         assert!(
             err.contains("finish_grace_secs") && err.contains("non-negative"),
+            "error should name the field and the constraint, got: {err}"
+        );
+    }
+
+    #[test]
+    fn timing_fields_reject_negative_startup_timeout() {
+        let id = NodeId::from("n".to_owned());
+        let mut node = custom_node();
+        node.startup_timeout = Some(-1.0);
+        let err = check_timing_fields(&id, &node).unwrap_err().to_string();
+        assert!(
+            err.contains("startup_timeout") && err.contains("non-negative"),
             "error should name the field and the constraint, got: {err}"
         );
     }

--- a/libraries/message/src/common.rs
+++ b/libraries/message/src/common.rs
@@ -162,6 +162,11 @@ impl std::fmt::Display for NodeError {
                 f,
                 ". This error occurred because node `{caused_by_node}` exited before connecting to dora."
             )?,
+            NodeErrorCause::StartupTimeout { timeout_secs } => write!(
+                f,
+                ". Dora killed the node because it did not initialize its \
+                 connection within {timeout_secs}s."
+            )?,
             NodeErrorCause::FailedToSpawn(_) => unreachable!(), // handled above
             NodeErrorCause::Other { stderr } if stderr.is_empty() => {}
             NodeErrorCause::Other { stderr } => {
@@ -182,6 +187,9 @@ pub enum NodeErrorCause {
     /// Node failed because another node failed before,
     Cascading {
         caused_by_node: NodeId,
+    },
+    StartupTimeout {
+        timeout_secs: f64,
     },
     FailedToSpawn(String),
     Other {

--- a/libraries/message/src/descriptor.rs
+++ b/libraries/message/src/descriptor.rs
@@ -829,6 +829,14 @@ pub struct Node {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub health_check_timeout: Option<f64>,
 
+    /// Startup timeout in seconds.
+    ///
+    /// When set, the daemon kills this node if it does not initialize its Dora
+    /// connection within the timeout. This bounds pre-connection startup hangs;
+    /// after the node has connected, `health_check_timeout` handles liveness.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub startup_timeout: Option<f64>,
+
     /// Per-node finish-drain grace period in seconds.
     ///
     /// Overrides the global `DORA_FINISH_DRAIN_GRACE_SECS` for this node only.
@@ -1166,6 +1174,14 @@ pub struct CustomNode {
     /// not reaped here either.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub health_check_timeout: Option<f64>,
+
+    /// Startup timeout in seconds.
+    ///
+    /// When set, the daemon kills this node if it does not initialize its Dora
+    /// connection within the timeout. This bounds pre-connection startup hangs;
+    /// after the node has connected, `health_check_timeout` handles liveness.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub startup_timeout: Option<f64>,
 
     /// Per-node finish-drain grace period in seconds.
     ///


### PR DESCRIPTION
Adds a per-node `startup_timeout` setting that bounds pre-connection startup hangs. If a node does not initialize its Dora connection before the configured deadline, the daemon kills that process and lets the existing `restart_policy` decide whether to retry.

This complements `health_check_timeout`, which only applies after a node has connected.

Fixes #3022.

## Changes

- Add `startup_timeout` to node descriptors, schema, validation, CLI info, and docs
- Add daemon startup-timeout checks for pending, unconnected nodes
- Track timeout kills per node generation so restarted successors do not inherit stale markers
- Report startup timeout failures with a dedicated `NodeErrorCause`
- Add focused tests for validation and timeout predicate behavior

## Testing

- `git diff --check`
- `jq empty libraries/core/dora-schema.json`