### PR TITLE
fix(core): regenerate the repo-root `dora-schema.json` (#3088)

### DIFF
--- a/.github/workflows/regenerate-schemas.yml
+++ b/.github/workflows/regenerate-schemas.yml
@@ -25,7 +25,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if git diff --exit-code -- libraries/core/dora-schema.json libraries/core/dora-node-schema.json; then
+          # Every generated file, including the repo-root `dora-schema.json` —
+          # that is the copy the guide publishes as a `$schema` URL, so leaving
+          # it out of these lists is what let it drift (#3088).
+          SCHEMAS="dora-schema.json libraries/core/dora-schema.json libraries/core/dora-node-schema.json"
+          if git diff --exit-code -- $SCHEMAS; then
               echo "Schema file is up to date"
           else
               # Reuse ONE branch + PR: force-push so an already-open sync PR is
@@ -33,7 +37,7 @@ jobs:
               # main (which otherwise piles up dozens of duplicates while the
               # schema stays drifted).
               git checkout -B auto/schema-update
-              git add libraries/core/dora-schema.json libraries/core/dora-node-schema.json
+              git add $SCHEMAS
               git config user.email "dora-bot@phil-opp.com"
               git config user.name "Dora Bot"
               git commit -m "Update JSON schema (${{ github.sha }})"

--- a/dora-schema.json
+++ b/dora-schema.json
@@ -14,6 +14,13 @@
         "$ref": "#/$defs/EnvValue"
       }
     },
+    "exit_when_nodes_finish": {
+      "description": "Finish the dataflow once every node has, treating\n`dora/timer/...` inputs as a clock rather than as work.\n\nA timer input has no upstream node, so it never closes. By default\na node consuming one is therefore never told its inputs are done\nand the graph cannot end on its own, even after every node doing\nreal work has exited (dora-rs/dora#2920).\n\nOff by default: for a long-lived dataflow the timer is precisely\nwhat keeps it alive. Nodes with no data inputs at all (timer-only\nsources, or no inputs) are unaffected either way -- they have no\ndependency that could finish, so they are treated as sources.\n\nSet by `dora run --exit-when-nodes-finish` and `dora start\n--exit-when-nodes-finish`, and settable directly in YAML. It lives\non the descriptor rather than on the wire so that it survives the\nevents a dataflow outlives: auto-recovery re-spawn, coordinator\nrestart with state reconstruction, and `dora restart`.\n\n## Example\n\n```yaml\nexit_when_nodes_finish: true\nnodes:\n  - id: worker\n    path: ./worker\n    inputs:\n      tick: dora/timer/millis/100\n```",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
     "health_check_interval": {
       "description": "How often the daemon checks node health (in seconds).\n\nDefaults to 5.0 seconds if not specified. Lower values detect hung nodes\nfaster but add more overhead.",
       "type": [
@@ -97,7 +104,7 @@
           "format": "double"
         },
         "health_check_timeout": {
-          "description": "Health check timeout in seconds.\n\nWhen set, the daemon monitors this node for activity. If the node does not\ncommunicate with the daemon within this timeout, it is killed and the restart\npolicy is evaluated.",
+          "description": "Health check timeout in seconds.\n\nWhen set, the daemon monitors this node for activity **once it has\nconnected** (i.e. subscribed to events during `Node::init`). If the\nconnected node then does not communicate with the daemon within this\ntimeout, it is killed and the restart policy is evaluated.\n\nThis bounds post-connection liveness only, not startup time: a node\nstill in a slow cold start has not connected yet and is never killed by\nthis watchdog. A node that hangs before it ever subscribes is therefore\nnot reaped here either.",
           "type": [
             "number",
             "null"
@@ -326,6 +333,7 @@
       ]
     },
     "Input": {
+      "description": "A single input subscription of a node, as declared under `inputs:` in a\ndataflow descriptor.\n\nIn YAML an input is written either as a bare mapping string\n(`source_node/output`) or as a mapping plus per-input options; both forms\ndeserialize into this struct (see [`InputDef`]).",
       "anyOf": [
         {
           "$ref": "#/$defs/InputMapping"
@@ -369,14 +377,17 @@
       ]
     },
     "InputMapping": {
+      "description": "The source an [`Input`] subscribes to.\n\nThe wire form is a `/`-separated string; [`FromStr`] parses it and\n[`fmt::Display`] renders it back, so the two round-trip:\n\n```\nuse dora_message::config::InputMapping;\n\nlet mapping: InputMapping = \"camera/image\".parse().unwrap();\nassert!(matches!(mapping, InputMapping::User(_)));\nassert_eq!(mapping.to_string(), \"camera/image\");\n\n// Built-in timer source.\nlet timer: InputMapping = \"dora/timer/millis/100\".parse().unwrap();\nassert_eq!(timer.to_string(), \"dora/timer/millis/100\");\n\n// A mapping without a `/` separator is rejected.\nassert!(\"no-slash\".parse::<InputMapping>().is_err());\n```",
       "oneOf": [
         {
+          "description": "A built-in timer that fires at a fixed `interval`.\n\nSyntax: `dora/timer/{unit}/{value}`, e.g. `dora/timer/millis/100`.",
           "type": "object",
           "properties": {
             "Timer": {
               "type": "object",
               "properties": {
                 "interval": {
+                  "description": "How often the timer fires.",
                   "$ref": "#/$defs/Duration"
                 }
               },
@@ -404,6 +415,7 @@
           ]
         },
         {
+          "description": "Subscribe to another node's output — the common case.",
           "type": "object",
           "properties": {
             "User": {
@@ -523,7 +535,7 @@
           ]
         },
         "health_check_timeout": {
-          "description": "Health check timeout in seconds.\n\nWhen set, the daemon monitors this node for activity. If the node does not\ncommunicate with the daemon within this timeout, it is killed and the restart\npolicy is evaluated.",
+          "description": "Health check timeout in seconds.\n\nWhen set, the daemon monitors this node for activity **once it has\nconnected** (i.e. subscribed to events during `Node::init`). If the\nconnected node then does not communicate with the daemon within this\ntimeout, it is killed and the restart policy is evaluated.\n\nThis bounds post-connection liveness only, not startup time: a node\nstill in a slow cold start has not connected yet and is never killed by\nthis watchdog. A node that hangs before it ever subscribes is therefore\nnot reaped here either.",
           "type": [
             "number",
             "null"
@@ -1037,6 +1049,21 @@
         }
       ]
     },
+    "RmwZenohCompatibility": {
+      "description": "Wire-compatibility profile for the `rmw_zenoh_cpp` protocol.",
+      "oneOf": [
+        {
+          "description": "ROS2 Humble, whose endpoint identity uses `TypeHashNotSupported`.",
+          "type": "string",
+          "const": "humble"
+        },
+        {
+          "description": "ROS2 distributions whose endpoint identity uses REP-2016 type hashes.",
+          "type": "string",
+          "const": "rep2016"
+        }
+      ]
+    },
     "Ros2BridgeConfig": {
       "description": "ROS2 bridge configuration for declarative ROS2 bridging.\n\nThis allows nodes to interact with ROS2 topics, services, and actions\nwithout writing any custom code. The framework spawns a bridge binary that\nhandles the ROS2 DDS communication and Arrow data conversion.\n\nExactly one of `topic`, `topics`, `service`, or `action` must be set.",
       "type": "object",
@@ -1127,6 +1154,13 @@
           ],
           "items": {
             "$ref": "#/$defs/Ros2TopicConfig"
+          }
+        },
+        "transport": {
+          "description": "Native transport used to communicate with the ROS2 graph.\n\nDefaults to the existing DDS implementation.",
+          "$ref": "#/$defs/Ros2TransportConfig",
+          "default": {
+            "kind": "dds"
           }
         }
       },
@@ -1264,6 +1298,51 @@
       "required": [
         "topic",
         "message_type"
+      ]
+    },
+    "Ros2TransportConfig": {
+      "description": "Native transport used by a ROS2 bridge context.",
+      "oneOf": [
+        {
+          "description": "The existing `ros2-client` and RustDDS transport.",
+          "type": "object",
+          "properties": {
+            "kind": {
+              "type": "string",
+              "const": "dds"
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "kind"
+          ]
+        },
+        {
+          "description": "Direct interoperability with `rmw_zenoh_cpp` peers.",
+          "type": "object",
+          "properties": {
+            "compatibility": {
+              "description": "Wire-compatibility profile used by the target ROS2 distribution.",
+              "$ref": "#/$defs/RmwZenohCompatibility"
+            },
+            "config_uri": {
+              "description": "Optional Zenoh session configuration path.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "kind": {
+              "type": "string",
+              "const": "zenoh"
+            }
+          },
+          "additionalProperties": true,
+          "required": [
+            "kind",
+            "compatibility"
+          ]
+        }
       ]
     },
     "RuntimeNode": {
@@ -1446,12 +1525,15 @@
       ]
     },
     "UserInputMapping": {
+      "description": "A subscription to another node's output, written as `source/output` in YAML.",
       "type": "object",
       "properties": {
         "output": {
+          "description": "The id of that node's output to subscribe to.",
           "$ref": "#/$defs/DataId"
         },
         "source": {
+          "description": "The id of the node that produces the output.",
           "$ref": "#/$defs/NodeId"
         }
       },

--- a/libraries/core/dora-schema.json
+++ b/libraries/core/dora-schema.json
@@ -104,7 +104,7 @@
           "format": "double"
         },
         "health_check_timeout": {
-          "description": "Health check timeout in seconds.\n\nWhen set, the daemon monitors this node for activity. If the node does not\ncommunicate with the daemon within this timeout, it is killed and the restart\npolicy is evaluated.",
+          "description": "Health check timeout in seconds.\n\nWhen set, the daemon monitors this node for activity **once it has\nconnected** (i.e. subscribed to events during `Node::init`). If the\nconnected node then does not communicate with the daemon within this\ntimeout, it is killed and the restart policy is evaluated.\n\nThis bounds post-connection liveness only, not startup time: a node\nstill in a slow cold start has not connected yet and is never killed by\nthis watchdog. A node that hangs before it ever subscribes is therefore\nnot reaped here either.",
           "type": [
             "number",
             "null"
@@ -535,7 +535,7 @@
           ]
         },
         "health_check_timeout": {
-          "description": "Health check timeout in seconds.\n\nWhen set, the daemon monitors this node for activity. If the node does not\ncommunicate with the daemon within this timeout, it is killed and the restart\npolicy is evaluated.",
+          "description": "Health check timeout in seconds.\n\nWhen set, the daemon monitors this node for activity **once it has\nconnected** (i.e. subscribed to events during `Node::init`). If the\nconnected node then does not communicate with the daemon within this\ntimeout, it is killed and the restart policy is evaluated.\n\nThis bounds post-connection liveness only, not startup time: a node\nstill in a slow cold start has not connected yet and is never killed by\nthis watchdog. A node that hangs before it ever subscribes is therefore\nnot reaped here either.",
           "type": [
             "number",
             "null"

--- a/libraries/core/src/bin/generate_schema.rs
+++ b/libraries/core/src/bin/generate_schema.rs
@@ -1,8 +1,26 @@
-use std::{env, path::Path};
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+};
 
 use dora_core::manifest::NodeManifest;
 use dora_message::descriptor::Descriptor;
 use schemars::schema_for;
+
+/// The workspace root, i.e. where the second published copy of the descriptor
+/// schema lives.
+///
+/// `CARGO_MANIFEST_DIR` is `libraries/core`, so the root is two levels up. That
+/// is checked rather than assumed: this binary ships inside the published
+/// `dora-core` crate, where `../..` is a registry directory that must not be
+/// written to. Returns `None` when the parent is not the dora workspace.
+fn workspace_root(manifest_dir: &Path) -> Option<PathBuf> {
+    let root = manifest_dir.parent()?.parent()?;
+    let cargo_toml = fs::read_to_string(root.join("Cargo.toml")).ok()?;
+    cargo_toml
+        .contains("[workspace]")
+        .then(|| root.to_path_buf())
+}
 
 fn main() {
     let schema = schema_for!(Descriptor);
@@ -34,18 +52,84 @@ fn main() {
 
     // Get the Cargo root manifest directory
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is not set");
+    let manifest_dir = Path::new(&manifest_dir);
 
     // Create the path for the new file next to Cargo.toml
-    let new_file_path = Path::new(&manifest_dir).join("dora-schema.json");
+    let new_file_path = manifest_dir.join("dora-schema.json");
 
     // write to file
-    std::fs::write(new_file_path, raw_schema).expect("Could not write schema to file");
+    fs::write(new_file_path, &raw_schema).expect("Could not write schema to file");
+
+    // The repo root holds a second copy, and it is the one the guide hands out
+    // as a `$schema` URL, so it has to be regenerated in the same breath (#3088).
+    if let Some(root) = workspace_root(manifest_dir) {
+        fs::write(root.join("dora-schema.json"), &raw_schema)
+            .expect("Could not write schema to workspace root");
+    }
 
     // Node manifest schema (dora-node.yml, see docs/plan-node-hub.md §5)
     let node_schema = schema_for!(NodeManifest);
     let raw_node_schema = serde_json::to_string_pretty(&node_schema)
         .expect("Could not serialize node manifest schema to json");
-    let node_schema_path = Path::new(&manifest_dir).join("dora-node-schema.json");
-    std::fs::write(node_schema_path, raw_node_schema)
+    let node_schema_path = manifest_dir.join("dora-node-schema.json");
+    fs::write(node_schema_path, raw_node_schema)
         .expect("Could not write node manifest schema to file");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::workspace_root;
+    use std::{fs, path::Path};
+
+    /// The descriptor schema is published at two URLs: the repo-root copy that
+    /// `docs/yaml-spec.md` and `guide/src/concepts/dataflow-yaml.md` paste into
+    /// users' `# yaml-language-server: $schema=` lines, and the
+    /// `libraries/core` copy that `libraries/core/README.md` points at. Both are
+    /// live, so they must not drift (#3088 — the root copy silently stopped
+    /// tracking the descriptor after #2512).
+    #[test]
+    fn root_schema_matches_crate_copy() {
+        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        // No repo above the packaged crate — nothing to keep in sync there.
+        let Ok(root_copy) = fs::read_to_string(manifest_dir.join("../../dora-schema.json")) else {
+            return;
+        };
+
+        // The root copy is only rewritten when `main` recognizes the workspace,
+        // and a failed detection is silent, so pin it here too.
+        assert!(
+            workspace_root(manifest_dir).is_some(),
+            "the repo-root `dora-schema.json` exists, but `workspace_root` did \
+             not recognize the workspace, so `generate_schema` would skip it"
+        );
+
+        let crate_copy = fs::read_to_string(manifest_dir.join("dora-schema.json"))
+            .expect("libraries/core/dora-schema.json is missing");
+
+        assert!(
+            root_copy == crate_copy,
+            "the repo-root `dora-schema.json` drifted from \
+             `libraries/core/dora-schema.json`; run \
+             `cargo run -p dora-core --bin generate_schema` to rewrite both"
+        );
+    }
+
+    /// Guards the registry case: `<crate>/../..` there is somebody else's
+    /// directory, and a stray `dora-schema.json` must not be written into it.
+    #[test]
+    fn workspace_root_rejects_a_plain_package_parent() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_dir = dir.path().join("libraries/core");
+        fs::create_dir_all(&manifest_dir).unwrap();
+        fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"other\"\n",
+        )
+        .unwrap();
+
+        assert_eq!(workspace_root(&manifest_dir), None);
+
+        fs::write(dir.path().join("Cargo.toml"), "[workspace]\nmembers = []\n").unwrap();
+        assert_eq!(workspace_root(&manifest_dir).as_deref(), Some(dir.path()));
+    }
 }


### PR DESCRIPTION
Fixes #3088.

The repo has two copies of the descriptor schema, but `generate_schema` wrote
only `libraries/core/dora-schema.json` and the sync workflow diffed and
committed only that one. The root `dora-schema.json` therefore stopped tracking
the descriptor after #2512 — while `docs/yaml-spec.md` and
`guide/src/concepts/dataflow-yaml.md` hand users *its*
`raw.githubusercontent.com` URL as their `# yaml-language-server: $schema=`
line. Editors loading it got no completion or hover for `compatibility`,
`config_uri`, `exit_when_nodes_finish`, `kind` or `transport`.

Kept the root copy rather than deleting it (option 1 in the issue): that URL is
already published in the guide and pasted into users' YAML, so removing it would
404 their `$schema` line with no warning.

- `generate_schema` writes the root copy in the same run. It resolves the root
  as `CARGO_MANIFEST_DIR/../..` but verifies the `[workspace]` marker first —
  the binary ships inside the published `dora-core` crate, where `../..` is a
  registry directory it must not write to.
- `regenerate-schemas.yml` diffs and commits all three generated files from one
  `SCHEMAS` list, so a fourth cannot be added to one place and forgotten in the
  other.
- A unit test next to the generator fails if the two committed copies drift
  again, and a second one pins the registry guard.
- Both copies are regenerated here, so the root one gains the five missing
  properties. That includes the `health_check_timeout` description the open
  auto-sync PR #3030 carries — the two copies have to be identical for the new
  test to hold, and #3030 stays mergeable as a no-op.
