### PR TITLE
fix(ci): keep the Kani proofs running after the MSRV 1.95 bump (#3090)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,9 @@ members = [
 
 [workspace.package]
 edition = "2024"
+# Raising this does not raise `dora-message`, which pins its own lower
+# `rust-version` so Kani's bundled toolchain can still build the proof
+# harnesses (#3090). Bump that one only against Kani's rustc.
 rust-version = "1.95.0"
 # Python packages derive version from CARGO_PKG_VERSION automatically.
 version = "1.0.0-rc.4"

--- a/docs/formal-verification.md
+++ b/docs/formal-verification.md
@@ -92,6 +92,30 @@ nightly workflow runs the proofs daily (`kani-proofs` job in
 `scripts/qa/ci-nightly-jobs.sh kani-proofs`), so a broken harness is
 caught within a day and auto-filed as a `nightly-regression` issue.
 
+### Proof crates must stay below Kani's bundled toolchain
+
+Kani does not build with the workspace toolchain — it ships its own
+nightly (0.67.0 → `nightly-2025-11-21`, rustc 1.93.0-nightly). Cargo
+refuses to compile a package whose `rust-version` exceeds the running
+rustc, so **a proof crate whose MSRV outruns Kani's rustc stops being
+verified at all**: `cargo kani` fails before codegen, reporting "Found 0
+compilation errors" rather than a failed proof. That is how #3090
+happened — the workspace MSRV went to 1.95 in #3017 and every nightly
+run after it was red with zero proofs run.
+
+So `dora-message` pins its own `rust-version` (currently 1.88.0) instead
+of inheriting `[workspace.package]`, with a comment in its `Cargo.toml`
+saying why. Any crate that gains a `#[kani::proof]` harness needs the
+same treatment. Two guards keep the pin honest: the nightly `msrv` job
+runs `cargo hack check --rust-version`, which fails if the crate no
+longer builds on the version it advertises, and the `kani-proofs` job
+fails if the pin ever climbs past Kani's rustc.
+
+Cargo compares only the release numbers here, ignoring the pre-release
+tag, so `rust-version = "1.93.0"` would be accepted by rustc
+1.93.0-nightly. The pin sits a few releases lower anyway, to leave room
+for a workspace MSRV bump landing before the matching Kani release.
+
 ## Adding a new proof
 
 1. Prefer extracting the invariant-bearing logic into a small **pure
@@ -110,10 +134,14 @@ caught within a day and auto-filed as a `nightly-regression` issue.
    workspace = true
    ```
 
-4. Nothing else: `scripts/qa/kani.sh` discovers proof crates by scanning
+4. In the same `Cargo.toml`, replace `rust-version.workspace = true` with
+   a pin at or below Kani's bundled rustc (see the section above) —
+   otherwise the crate silently drops out of verification the next time
+   the workspace MSRV moves ahead of Kani.
+5. Nothing else: `scripts/qa/kani.sh` discovers proof crates by scanning
    for `#[kani::proof]`, so `make qa-kani` picks the new harness up
    automatically.
-5. State each property in prose in the harness doc comment, and aim for the
+6. State each property in prose in the harness doc comment, and aim for the
    soundness/completeness pair — one-directional proofs silently miss
    "rejects everything" regressions.
 

--- a/libraries/message/Cargo.toml
+++ b/libraries/message/Cargo.toml
@@ -2,7 +2,16 @@
 name = "dora-message"
 version.workspace = true
 edition.workspace = true
-rust-version.workspace = true
+# Deliberately pinned below the workspace MSRV, not inherited (#3090).
+# This is the only crate carrying `#[kani::proof]` harnesses, and Kani
+# builds it with its own bundled toolchain — 0.67.0 ships rustc
+# 1.93.0-nightly — which cargo refuses to use the moment this crate
+# requires something newer, before a single proof runs. Nothing here
+# needs the workspace floor: the sysinfo 0.39 / redb 4 requirement that
+# raised it to 1.95 (#3017) belongs to the CLI, daemon, and coordinator
+# store. Keep this at or below Kani's rustc — see
+# `docs/formal-verification.md`.
+rust-version = "1.88.0"
 documentation.workspace = true
 readme.workspace = true
 description.workspace = true


### PR DESCRIPTION
Fixes #3090.

`cargo kani` does not build with the workspace toolchain — it ships its own, and
0.67.0 (still the newest release) bundles `nightly-2025-11-21`, rustc
1.93.0-nightly. Since #3017 raised the workspace `rust-version` to 1.95, cargo
refused to compile `dora-message` under it, so the nightly `kani-proofs` job died
before codegen every night with "Found 0 compilation errors" — the
`constant_time_eq` proofs were not running at all.

`dora-message` now pins `rust-version = "1.88.0"` instead of inheriting the
workspace floor. It is the only crate with `#[kani::proof]` harnesses, and
nothing in it needs 1.95: the sysinfo 0.39 / redb 4 requirement that raised the
floor belongs to the CLI, daemon, and coordinator store, and this crate's whole
dependency closure declares at most 1.85. Kani exposes no way to forward
`--ignore-rust-version` to cargo, and cargo has no config key or env var for it,
so a per-crate pin is the only fix that keeps verification switched on.

Option 1 from the issue (wait for a Kani release on a ≥1.95 toolchain) has
nothing to pin to yet: 0.67.0 from January is still the newest release. Kani
`main` has since moved to `nightly-2026-02-18` (rustc 1.95.0-nightly), which
would satisfy the current floor — cargo compares release numbers and ignores the
`-nightly` pre-release tag — but no release carries it.

The pin is enforced, not asserted: the nightly `msrv` job runs `cargo hack check
--rust-version`, which checks `dora-message` at 1.88 and fails if the crate stops
building there, while `kani-proofs` fails if the pin ever climbs past Kani's
rustc. Both sites that spring the trap now say so — a comment on the workspace
`rust-version`, and a section in `docs/formal-verification.md` covering why proof
crates must stay below Kani's bundled toolchain and what to do when adding a new
one.

Verified with the same Kani build CI installs (0.67.0 / `nightly-2025-11-21`):
`scripts/qa/kani.sh` reproduces the failure on `main` and now reports
`VERIFICATION:- SUCCESSFUL` — 133 checks, 0 failed. `cargo hack check
--rust-version --workspace --ignore-private --locked` passes all 31 packages,
checking `dora-message` at 1.88. `cargo update --dry-run` resolves identically
with and without the pin, so the lower floor holds no dependency back.
