### PR TITLE
ci: give the E2E test step a cold-cache time budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,7 +362,16 @@ jobs:
       - name: Run E2E tests
         run: >
           cargo test --test ws-cli-e2e -- --test-threads=1
-        timeout-minutes: 10
+        # First dev-profile cargo invocation in this job, so it absorbs the
+        # entire cold-cache compile: ~6m30 of actual tests on a warm runner,
+        # plus ~4m35 of dependency codegen and ~3m20 of nested fixture
+        # `cargo build` calls on top when rust-cache misses. Cold misses are
+        # not hypothetical — the floating `Swatinem/rust-cache@v2` tag moving
+        # to 2.9.2 rotated the environment hash and stranded every entry at
+        # once, and the old 10-minute cap turned that into a timeout here
+        # (#3030's merge-queue run). Budget for the cold path; a warm run
+        # still finishes in well under half of this.
+        timeout-minutes: 25
       - name: Run fault-tolerance tests
         run: >
           cargo test --test fault-tolerance-e2e -- --test-threads=1


### PR DESCRIPTION
`Run E2E tests` is the first dev-profile `cargo` invocation in the `e2e` job, so
it absorbs the entire cold dependency compile whenever rust-cache misses. Warm it
takes 6m26 of its 10-minute cap; cold it needs roughly 14m20 — 4m35 of dependency
codegen before the first test runs, plus ~3m20 of nested fixture `cargo build`
calls the tests shell out for. The cap only ever held because the cache was warm.

It stopped holding on 2026-08-06, when the floating `Swatinem/rust-cache@v2` tag
moved to 2.9.2. That release's "correctly sort and dedupe Rust versions" fix
changed `getRustVersions` from returning a `Set<RustVersion>` of *objects* — where
identity semantics meant it never deduped, so a single installed toolchain got
hashed twice (`rustc -vV` and `rustup run 1.97.1 rustc -vV`) — to a deduped
`Array<string>`. Same toolchain, same lockfile, different digest:

```
Aug 5  v0-rust-e2e-Linux-x64-19bf01fc-37d8d8b3   Restored ... full match: true
Aug 9  v0-rust-e2e-Linux-x64-93857598-37d8d8b3   No cache found.
```

Only the environment-hash segment moved, and it moved for every key at once. The
`Pin toolchain set` step guards against the runner image bumping its default
toolchain, but nothing guards against the action itself changing how it hashes.

`test`, `bench` and `check-license` all pass cold — verified in the merge-queue run
for #3030, where they were green against the same `93857598` miss. `e2e` is the one
job whose per-step cap was tight enough to convert the miss into a failure, and
because rust-cache's post step is gated on `success() || CACHE_ON_FAILURE == 'true'`,
a timing-out `e2e` never writes its cache — so it could not recover on its own.

25 minutes leaves ~40% margin on the cold path; a warm run still finishes in well
under half. The remaining steps in the job are already sized for cold, since they
reuse `target/` once this step has populated it.

The merge-queue run for this PR exercises the new cap directly: `e2e` is skipped on
`pull_request` events and only runs on the `trunk-merge/**` push, which uses this
branch's workflow file.
