### PR TITLE
fix(runtime): stop freeing operator-owned payloads on the runtime thread (#2742)

### DIFF
--- a/apis/rust/node/src/lib.rs
+++ b/apis/rust/node/src/lib.rs
@@ -113,7 +113,8 @@ pub use futures;
 #[cfg(feature = "tracing")]
 pub use node::init_tracing;
 pub use node::{
-    DataSample, DoraNode, DoraNodeBuilder, StreamSegment, ZERO_COPY_THRESHOLD, arrow_utils,
+    DataSample, DoraNode, DoraNodeBuilder, EncodedSample, SampleAllocator, StreamSegment,
+    ZERO_COPY_THRESHOLD, arrow_utils,
 };
 pub use uuid;
 

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -724,7 +724,10 @@ pub struct DoraNode {
     /// `None` in interactive/testing mode.
     zenoh_session: Option<zenoh::Session>,
     /// Zenoh shared memory provider for zero-copy publishing.
-    zenoh_shm_provider: Option<zenoh::shm::ShmProvider<zenoh::shm::PosixShmProviderBackend>>,
+    /// Owns the SHM provider and the zero-copy threshold. Cloned out by
+    /// [`DoraNode::sample_allocator`] so an operator thread can build output
+    /// samples without reaching into the node (dora-rs/dora#2742).
+    sample_allocator: SampleAllocator,
     /// Per-output zenoh publishers with their handshake state, declared eagerly
     /// at init (see [`declare_output_publishers`]) so zenoh wires routes
     /// immediately and [`StartupHandshake`] can probe them before the first
@@ -751,7 +754,6 @@ pub struct DoraNode {
     /// the time of the last full-stream send (for the periodic in-band refresh).
     zenoh_schema_state: HashMap<DataId, SchemaOnceState>,
     /// Threshold for using zenoh SHM vs inline bytes (default 4096).
-    zenoh_zero_copy_threshold: usize,
 
     /// Diagnostic (dora-rs/dora#2742): how many large sends have already been
     /// traced hop-by-hop. The Windows nightly wedges the *runtime's* main loop
@@ -1265,7 +1267,7 @@ impl DoraNode {
 
                 match layout {
                     Some(layout) => match ShmProviderBuilder::default_backend(layout).wait() {
-                        Ok(provider) => Some(provider),
+                        Ok(provider) => Some(Arc::new(provider)),
                         Err(e) => {
                             warn!(
                                 "failed to create zenoh SHM provider ({e}); \
@@ -1373,12 +1375,14 @@ impl DoraNode {
             control_channel,
             clock,
             zenoh_session,
-            zenoh_shm_provider,
             zenoh_publishers,
             startup_handshake,
             zenoh_schema_publishers: HashMap::new(),
             zenoh_schema_state: HashMap::new(),
-            zenoh_zero_copy_threshold,
+            sample_allocator: SampleAllocator {
+                shm_provider: zenoh_shm_provider,
+                zero_copy_threshold: zenoh_zero_copy_threshold,
+            },
             large_send_diag_count: 0,
             dataflow_descriptor: serde_yaml::from_value(dataflow_descriptor),
             warned_unknown_output: BTreeSet::new(),
@@ -1515,78 +1519,83 @@ impl DoraNode {
         };
 
         let arrow_array = data.to_data();
+        self.check_output_type(&output_id, arrow_array.data_type(), &parameters)?;
 
-        // Runtime type check (only when DORA_RUNTIME_TYPE_CHECK is set).
-        //
-        // Skip the check when this message carries pattern metadata
-        // (`request_id`, `goal_id`, or `goal_status`). Service, action,
-        // and streaming patterns legitimately multiplex multiple Arrow
-        // schemas through a single output — a service server may reply
-        // with different response shapes for different request types —
-        // so a single declared Arrow type cannot cover all variants.
-        // Non-pattern messages still get full validation
-        // (dora-rs/adora#150).
-        if let Some((mode, checks)) = &self.runtime_type_checks
-            && let Some(expected) = checks.get(&output_id)
-            && !carries_pattern_correlation(&parameters)
-        {
-            let actual = arrow_array.data_type();
-            if actual != expected {
-                let msg = format!(
-                    "output \"{output_id}\": expected Arrow type {expected:?}, got {actual:?}"
-                );
-                match mode {
-                    RuntimeTypeCheck::Error => {
-                        return Err(NodeError::Output(msg));
-                    }
-                    RuntimeTypeCheck::Warn => {
-                        warn!("type mismatch: {msg}");
-                    }
-                    RuntimeTypeCheck::Off => unreachable!(),
-                }
-            }
-        }
-
-        self.send_output_array(output_id, parameters, arrow_array)
+        let encoded = self.sample_allocator.encode_arrow(&arrow_array)?;
+        self.send_encoded_unchecked(output_id, parameters, encoded.sample)
     }
 
-    /// IPC-encode `arrow_array` into a (shared-memory) sample and send it.
+    /// Send a payload that has already been IPC-encoded into a dora-owned
+    /// [`EncodedSample`] by [`SampleAllocator::encode_arrow`].
     ///
-    /// Every data-plane payload is a self-describing Arrow IPC stream. Uses the
-    /// hand-rolled 1-copy fast path when the array type is eligible, falling
-    /// back to the official writer (one extra copy) otherwise. The shared send
-    /// path for [`send_output`](Self::send_output) and
-    /// [`send_output_raw`](Self::send_output_raw).
-    fn send_output_array(
+    /// This is the entry point the runtime uses for operator outputs: the
+    /// operator thread does the encoding so that no memory owned by the
+    /// operator's language runtime is ever released on the node's thread — see
+    /// [`SampleAllocator`] (dora-rs/dora#2742).
+    pub fn send_output_encoded(
+        &mut self,
+        output_id: DataId,
+        parameters: MetadataParameters,
+        encoded: EncodedSample,
+    ) -> NodeResult<()> {
+        if !self.validate_output(&output_id) {
+            return Ok(());
+        };
+        self.check_output_type(&output_id, &encoded.data_type, &parameters)?;
+        self.send_encoded_unchecked(output_id, parameters, encoded.sample)
+    }
+
+    /// Tag an already-encoded sample as an Arrow IPC stream and send it. The
+    /// caller has already run `validate_output` and `check_output_type`.
+    fn send_encoded_unchecked(
         &mut self,
         output_id: DataId,
         mut parameters: MetadataParameters,
-        arrow_array: ArrayData,
+        sample: DataSample,
     ) -> NodeResult<()> {
         parameters.insert(
             FRAMING.to_string(),
             Parameter::String(FRAMING_ARROW_IPC.to_string()),
         );
 
-        let sample = match ipc_encode::ipc_fast_path_len(&arrow_array) {
-            Some(len) => {
-                let mut s = self.allocate_data_sample(len)?;
-                ipc_encode::encode_ipc_into(&arrow_array, &mut s)
-                    .map_err(|e| NodeError::Output(format!("Arrow IPC encode: {e}")))?;
-                s
-            }
-            None => {
-                let bytes = ipc_encode::encode_ipc_to_vec(&arrow_array)
-                    .map_err(|e| NodeError::Output(format!("Arrow IPC encode: {e}")))?;
-                let mut s = self.allocate_data_sample(bytes.len())?;
-                s.copy_from_slice(&bytes);
-                s
-            }
-        };
-
         self.send_output_sample(output_id, parameters, Some(sample))
             .wrap_err("failed to send output")?;
 
+        Ok(())
+    }
+
+    /// Runtime type check (only when `DORA_RUNTIME_TYPE_CHECK` is set).
+    ///
+    /// Skips the check when this message carries pattern metadata
+    /// (`request_id`, `goal_id`, or `goal_status`). Service, action, and
+    /// streaming patterns legitimately multiplex multiple Arrow schemas through
+    /// a single output — a service server may reply with different response
+    /// shapes for different request types — so a single declared Arrow type
+    /// cannot cover all variants. Non-pattern messages still get full
+    /// validation (dora-rs/adora#150).
+    fn check_output_type(
+        &self,
+        output_id: &DataId,
+        actual: &arrow_schema::DataType,
+        parameters: &MetadataParameters,
+    ) -> NodeResult<()> {
+        if let Some((mode, checks)) = &self.runtime_type_checks
+            && let Some(expected) = checks.get(output_id)
+            && !carries_pattern_correlation(parameters)
+            && actual != expected
+        {
+            let msg =
+                format!("output \"{output_id}\": expected Arrow type {expected:?}, got {actual:?}");
+            match mode {
+                RuntimeTypeCheck::Error => {
+                    return Err(NodeError::Output(msg));
+                }
+                RuntimeTypeCheck::Warn => {
+                    warn!("type mismatch: {msg}");
+                }
+                RuntimeTypeCheck::Off => unreachable!(),
+            }
+        }
         Ok(())
     }
 
@@ -1675,7 +1684,7 @@ impl DoraNode {
         // run pays one comparison per send and prints a handful of lines.
         // `warn!` so it survives the default stdout filter and reaches CI logs.
         let diag_bytes = finalized.as_ref().map_or(0, |f| f.byte_len());
-        let diag = diag_bytes >= self.zenoh_zero_copy_threshold
+        let diag = diag_bytes >= self.sample_allocator.zero_copy_threshold
             && self.large_send_diag_count < LARGE_SEND_DIAG_LIMIT;
         if diag {
             self.large_send_diag_count += 1;
@@ -1911,8 +1920,8 @@ impl DoraNode {
             // The heap buffer is only borrowed, so any put error can fall back
             // to the daemon path with the payload intact.
             FinalizedSample::Vec(avec) => {
-                if avec.len() >= self.zenoh_zero_copy_threshold
-                    && let Some(provider) = &self.zenoh_shm_provider
+                if avec.len() >= self.sample_allocator.zero_copy_threshold
+                    && let Some(provider) = &self.sample_allocator.shm_provider
                 {
                     use zenoh::shm::GarbageCollect;
                     // Non-blocking: garbage-collect freed chunks and allocate, but
@@ -1970,7 +1979,7 @@ impl DoraNode {
                 // reliable daemon path instead (TCP, up to `MAX_MESSAGE_BYTES`).
                 // Only sub-threshold payloads, which fit a single batch and never
                 // fragment, take the zenoh heap put below.
-                if avec.len() >= self.zenoh_zero_copy_threshold {
+                if avec.len() >= self.sample_allocator.zero_copy_threshold {
                     return Ok(PublishOutcome::NotPublished(FinalizedSample::Vec(avec)));
                 }
 
@@ -2015,7 +2024,7 @@ impl DoraNode {
                 // attachment bytes outlive the `put` below.
                 let schema_once = if schema_once_eligible(
                     avec.len(),
-                    self.zenoh_zero_copy_threshold,
+                    self.sample_allocator.zero_copy_threshold,
                     &metadata.parameters,
                 ) {
                     publish_schema_once(
@@ -2088,7 +2097,7 @@ impl DoraNode {
     /// `DORA_ZERO_COPY_THRESHOLD` env var, defaulting to
     /// [`ZERO_COPY_THRESHOLD`].
     pub fn zero_copy_threshold(&self) -> usize {
-        self.zenoh_zero_copy_threshold
+        self.sample_allocator.zero_copy_threshold
     }
 
     /// Returns true if this node was restarted after a previous exit or failure.
@@ -2280,55 +2289,18 @@ impl DoraNode {
 
     /// Allocates a [`DataSample`] of the specified size.
     ///
-    /// For payloads at or above the zero-copy threshold the buffer is allocated
-    /// directly from the zenoh SHM provider (when available), so the producer
-    /// writes straight into shared memory and publishing moves the buffer into
-    /// zenoh's `put` without a further copy. Smaller payloads — or the case
-    /// where no SHM provider exists (interactive/testing mode) — use a
-    /// heap-allocated, 128-byte-aligned buffer; the SHM provider is
-    /// page-aligned, so dedicating a full page to a small message is pure waste.
+    /// See [`SampleAllocator::allocate`] for the allocation strategy.
     pub fn allocate_data_sample(&mut self, data_len: usize) -> NodeResult<DataSample> {
-        if data_len >= self.zenoh_zero_copy_threshold
-            && let Some(provider) = &self.zenoh_shm_provider
-        {
-            use zenoh::Wait;
-            use zenoh::shm::GarbageCollect;
-            // Non-blocking (see `zenoh_publish`): GC and allocate, but fall back
-            // to a heap buffer rather than `BlockOn`-sleeping 1 ms when the pool
-            // is momentarily full under a large-message burst. The heap buffer
-            // costs one extra copy on publish but keeps the producer from
-            // stalling, which is what regressed sustained throughput (PR #2366).
-            match provider
-                .alloc(data_len)
-                .with_policy::<GarbageCollect>()
-                .wait()
-            {
-                Ok(sbuf) => {
-                    // Use the SHM buffer only when it is exactly the requested
-                    // size — zenoh 1.8 guarantees this (the logical length
-                    // matches the request even when the backing chunk is
-                    // larger). If a future provider ever over-allocates, fall
-                    // back to heap rather than expose or publish an oversized
-                    // slice (`DataSample` has no length cap of its own).
-                    if sbuf.as_ref().len() == data_len {
-                        return Ok(DataSample {
-                            storage: SampleStorage::Shm(sbuf),
-                        });
-                    }
-                    tracing::debug!(
-                        "zenoh SHM alloc returned {} bytes for a {data_len}-byte \
-                         request; using heap",
-                        sbuf.as_ref().len()
-                    );
-                }
-                Err(e) => {
-                    tracing::debug!("SHM alloc failed ({e}), using heap buffer");
-                }
-            }
-        }
+        self.sample_allocator.allocate(data_len)
+    }
 
-        let avec: AVec<u8, ConstAlign<128>> = AVec::__from_elem(128, 0, data_len);
-        Ok(avec.into())
+    /// A handle for building output samples off this node's thread.
+    ///
+    /// The runtime hands one to each operator thread so the operator can encode
+    /// its payload into a dora-owned [`DataSample`] itself — see
+    /// [`SampleAllocator`] for why that matters (dora-rs/dora#2742).
+    pub fn sample_allocator(&self) -> SampleAllocator {
+        self.sample_allocator.clone()
     }
 
     /// Returns the full dataflow descriptor that this node is part of.
@@ -2517,7 +2489,7 @@ impl Drop for DoraNode {
         // daemon-signaled `InputClosed` cannot overtake in-flight zenoh data.
         let publishers = std::mem::take(&mut self.zenoh_publishers);
         let schema_publishers = std::mem::take(&mut self.zenoh_schema_publishers);
-        let shm_provider = self.zenoh_shm_provider.take();
+        let shm_provider = self.sample_allocator.shm_provider.take();
         let session = self.zenoh_session.take();
         let runtime = self._owned_runtime.take();
         if session.is_none() && shm_provider.is_none() && publishers.is_empty() {
@@ -2574,6 +2546,157 @@ impl Drop for DoraNode {
         if let Err(err) = self.control_channel.report_outputs_done() {
             tracing::warn!("{err:?}")
         }
+    }
+}
+
+/// A payload already encoded as an Arrow IPC stream in a dora-owned sample,
+/// together with the Arrow type it was encoded from.
+///
+/// The two travel together so a consumer can still type-check the output after
+/// the source array is gone — see [`DoraNode::send_output_encoded`].
+#[derive(Debug)]
+pub struct EncodedSample {
+    sample: DataSample,
+    data_type: arrow_schema::DataType,
+}
+
+impl EncodedSample {
+    /// The Arrow type the payload was encoded from.
+    pub fn data_type(&self) -> &arrow_schema::DataType {
+        &self.data_type
+    }
+
+    /// The encoded Arrow IPC stream.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.sample
+    }
+}
+
+/// Builds dora-owned output samples without borrowing the node.
+///
+/// ## Why this exists (dora-rs/dora#2742)
+///
+/// An operator runs on its own thread and hands its outputs to the runtime's
+/// event loop. If what crosses that boundary is an Arrow array whose buffers
+/// belong to the operator's language runtime — a `pyarrow` array wrapping a
+/// numpy buffer, say — then the *runtime* ends up freeing them. Releasing a
+/// numpy-backed buffer acquires the Python GIL (pyarrow's `NumPyBuffer`
+/// destructor does `PyAcquireGIL`), so the runtime's event loop blocks for as
+/// long as the operator holds the GIL. That made a node unable to observe
+/// `Stop`, and the daemon force-killed it at the grace period.
+///
+/// Handing the operator thread an allocator instead lets it encode into memory
+/// dora owns and release its own payload while it still holds the GIL. It is
+/// not an extra copy: the IPC encode is the same single copy the node would
+/// otherwise have made, just performed on the other side of the channel.
+#[derive(Clone)]
+pub struct SampleAllocator {
+    shm_provider: Option<Arc<zenoh::shm::ShmProvider<zenoh::shm::PosixShmProviderBackend>>>,
+    zero_copy_threshold: usize,
+}
+
+impl SampleAllocator {
+    /// Allocates a [`DataSample`] of the specified size.
+    ///
+    /// For payloads at or above the zero-copy threshold the buffer is allocated
+    /// directly from the zenoh SHM provider (when available), so the producer
+    /// writes straight into shared memory and publishing moves the buffer into
+    /// zenoh's `put` without a further copy. Smaller payloads — or the case
+    /// where no SHM provider exists (interactive/testing mode) — use a
+    /// heap-allocated, 128-byte-aligned buffer; the SHM provider is
+    /// page-aligned, so dedicating a full page to a small message is pure waste.
+    pub fn allocate(&self, data_len: usize) -> NodeResult<DataSample> {
+        if data_len >= self.zero_copy_threshold
+            && let Some(provider) = &self.shm_provider
+        {
+            use zenoh::Wait;
+            use zenoh::shm::GarbageCollect;
+            // Non-blocking (see `zenoh_publish`): GC and allocate, but fall back
+            // to a heap buffer rather than `BlockOn`-sleeping 1 ms when the pool
+            // is momentarily full under a large-message burst. The heap buffer
+            // costs one extra copy on publish but keeps the producer from
+            // stalling, which is what regressed sustained throughput (PR #2366).
+            match provider
+                .alloc(data_len)
+                .with_policy::<GarbageCollect>()
+                .wait()
+            {
+                Ok(sbuf) => {
+                    // Use the SHM buffer only when it is exactly the requested
+                    // size — zenoh 1.8 guarantees this (the logical length
+                    // matches the request even when the backing chunk is
+                    // larger). If a future provider ever over-allocates, fall
+                    // back to heap rather than expose or publish an oversized
+                    // slice (`DataSample` has no length cap of its own).
+                    if sbuf.as_ref().len() == data_len {
+                        return Ok(DataSample {
+                            storage: SampleStorage::Shm(sbuf),
+                        });
+                    }
+                    tracing::debug!(
+                        "zenoh SHM alloc returned {} bytes for a {data_len}-byte \
+                         request; using heap",
+                        sbuf.as_ref().len()
+                    );
+                }
+                Err(e) => {
+                    tracing::debug!("SHM alloc failed ({e}), using heap buffer");
+                }
+            }
+        }
+
+        let avec: AVec<u8, ConstAlign<128>> = AVec::__from_elem(128, 0, data_len);
+        Ok(avec.into())
+    }
+
+    /// Encodes `array` as a complete Arrow IPC stream into a freshly allocated
+    /// sample. Uses the hand-rolled 1-copy fast path when the array type is
+    /// eligible, falling back to the official writer (one extra copy) otherwise.
+    ///
+    /// The returned sample shares no memory with `array`, so the caller may —
+    /// and, when the payload is owned by a foreign runtime, **must** — drop
+    /// `array` on its own thread rather than let it travel to the node.
+    pub fn encode_arrow(&self, array: &ArrayData) -> NodeResult<EncodedSample> {
+        let sample = match ipc_encode::ipc_fast_path_len(array) {
+            Some(len) => {
+                let mut sample = self.allocate(len)?;
+                ipc_encode::encode_ipc_into(array, &mut sample)
+                    .map_err(|e| NodeError::Output(format!("Arrow IPC encode: {e}")))?;
+                sample
+            }
+            None => {
+                let bytes = ipc_encode::encode_ipc_to_vec(array)
+                    .map_err(|e| NodeError::Output(format!("Arrow IPC encode: {e}")))?;
+                let mut sample = self.allocate(bytes.len())?;
+                sample.copy_from_slice(&bytes);
+                sample
+            }
+        };
+        Ok(EncodedSample {
+            sample,
+            data_type: array.data_type().clone(),
+        })
+    }
+
+    /// An allocator with no shared memory, so every sample is heap-backed.
+    ///
+    /// This is what a node without a zenoh session (interactive/testing mode)
+    /// uses; it also lets callers that only need the encoding — tests, most
+    /// obviously — build one without a live node.
+    pub fn heap() -> Self {
+        Self {
+            shm_provider: None,
+            zero_copy_threshold: ZERO_COPY_THRESHOLD,
+        }
+    }
+}
+
+impl std::fmt::Debug for SampleAllocator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SampleAllocator")
+            .field("shm", &self.shm_provider.is_some())
+            .field("zero_copy_threshold", &self.zero_copy_threshold)
+            .finish()
     }
 }
 
@@ -3750,5 +3873,109 @@ mod tests {
              force-kill grace ({DAEMON_FORCE_KILL_GRACE:?}); raising ZENOH_TEARDOWN_TIMEOUT \
              reintroduces dora-rs/dora#2742"
         );
+    }
+}
+
+/// Ownership invariant at the operator -> runtime boundary (dora-rs/dora#2742).
+///
+/// A [`SampleAllocator`] lets an operator thread encode its payload into a
+/// dora-owned [`EncodedSample`] itself, so the runtime never holds a reference
+/// to memory whose owner lives in another language runtime. The tests below pin
+/// the properties that make the result safe to hand across a thread boundary.
+#[cfg(test)]
+mod operator_boundary_tests {
+    use super::*;
+    use arrow::buffer::Buffer;
+    use std::ptr::NonNull;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    /// Stands in for a foreign owner of an Arrow payload buffer — a numpy array
+    /// held alive by pyarrow, or a buffer owned by an operator's `.so`. Flips
+    /// `released` when the last Arrow reference to the buffer goes away.
+    struct ForeignOwner {
+        released: Arc<AtomicBool>,
+        _backing: Vec<u8>,
+    }
+
+    impl Drop for ForeignOwner {
+        fn drop(&mut self) {
+            self.released.store(true, Ordering::SeqCst);
+        }
+    }
+
+    /// A `UInt8` array whose payload buffer is owned by `ForeignOwner`.
+    fn foreign_owned_array(len: usize) -> (ArrayData, Arc<AtomicBool>) {
+        let backing = vec![0xABu8; len];
+        // A `Vec`'s heap allocation does not move when the `Vec` itself is
+        // moved into `ForeignOwner` below, so this pointer stays valid for as
+        // long as the owner is alive — which is exactly what the `Allocation`
+        // contract requires.
+        let ptr = NonNull::new(backing.as_ptr() as *mut u8).expect("non-null");
+        let released = Arc::new(AtomicBool::new(false));
+        let owner = Arc::new(ForeignOwner {
+            released: released.clone(),
+            _backing: backing,
+        });
+        let buffer = unsafe { Buffer::from_custom_allocation(ptr, len, owner) };
+        let array = ArrayData::builder(arrow::datatypes::DataType::UInt8)
+            .len(len)
+            .add_buffer(buffer)
+            .build()
+            .expect("valid UInt8 array");
+        (array, released)
+    }
+
+    /// The heart of the #2742 fix: the sample the operator hands to the runtime
+    /// must be an independent, dora-owned copy. If it kept the source buffer
+    /// alive, the runtime would be the one releasing foreign memory — and for a
+    /// Python operator that release takes the GIL (pyarrow's `NumPyBuffer`
+    /// destructor), which stalls the runtime's event loop for as long as the
+    /// operator holds it.
+    #[test]
+    fn encoded_sample_does_not_retain_the_source_payload() {
+        let allocator = SampleAllocator::heap();
+        let (array, released) = foreign_owned_array(8192);
+
+        let sample = allocator
+            .encode_arrow(&array)
+            .expect("encoding a UInt8 array must succeed");
+
+        assert!(
+            !released.load(Ordering::SeqCst),
+            "sanity: the source buffer is still alive while the array is"
+        );
+        drop(array);
+        assert!(
+            released.load(Ordering::SeqCst),
+            "the encoded sample must not keep the operator's payload alive; \
+             otherwise the runtime frees foreign memory (dora-rs/dora#2742)"
+        );
+        drop(sample);
+    }
+
+    /// The encode must be lossless: the sample is the same Arrow IPC stream the
+    /// node would have produced when it did the encoding itself.
+    #[test]
+    fn encoded_sample_round_trips_to_the_source_array() {
+        let allocator = SampleAllocator::heap();
+        let (array, _released) = foreign_owned_array(1024);
+
+        let encoded = allocator.encode_arrow(&array).expect("encode");
+        assert_eq!(encoded.data_type(), array.data_type());
+        let decoded = crate::node::arrow_utils::decode_arrow_ipc(encoded.as_bytes())
+            .expect("the sample must be a well-formed Arrow IPC stream");
+
+        assert_eq!(decoded, array);
+    }
+
+    /// The allocator is handed to operator threads, so it has to cross thread
+    /// boundaries — and so does the sample it produces.
+    #[test]
+    fn allocator_and_sample_cross_thread_boundaries() {
+        const fn assert_send<T: Send>() {}
+        const fn assert_send_sync_clone<T: Send + Sync + Clone>() {}
+        assert_send::<DataSample>();
+        assert_send::<EncodedSample>();
+        assert_send_sync_clone::<SampleAllocator>();
     }
 }

--- a/binaries/runtime/src/lib.rs
+++ b/binaries/runtime/src/lib.rs
@@ -5,7 +5,7 @@ use dora_core::{
     descriptor::OperatorConfig,
 };
 use dora_message::daemon_to_node::{NodeConfig, RuntimeConfig};
-use dora_node_api::{DoraNode, Event};
+use dora_node_api::{DoraNode, Event, StopCause};
 use dora_tracing::TracingBuilder;
 use eyre::{Context, Result, bail};
 use futures::{Stream, StreamExt};
@@ -13,7 +13,7 @@ use futures_concurrency::stream::Merge;
 use operator::{OperatorEvent, RuntimeHandle, SharedAllocator, StopReason, run_operator};
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap, VecDeque},
     mem,
     sync::{Arc, Mutex, OnceLock},
     time::{Duration, Instant},
@@ -103,10 +103,11 @@ pub fn main() -> eyre::Result<()> {
 
     let operator_id = operator_definition.id.clone();
     // Keep the operator's shared library mapped until *after* the main event
-    // loop has joined below: its outputs are Arrow arrays whose FFI `release`
-    // callbacks live in the `.so`, and the loop may still hold in-flight arrays
-    // (see `run_operator` / `shared_lib::run`). Unloading it earlier dangles
-    // those callbacks and SIGSEGVs when the arrays are freed.
+    // loop has joined below. Since dora-rs/dora#2742 the loop no longer holds
+    // Arrow arrays exported by the operator, but values whose vtable lives in
+    // the `.so` can still be in flight (an `OperatorEvent::Panic` payload).
+    // Unloading it earlier dangles those (see `run_operator` /
+    // `shared_lib::run`).
     let _operator_library = run_operator(
         &node_id,
         operator_definition,
@@ -123,8 +124,7 @@ pub fn main() -> eyre::Result<()> {
     }
 
     // `_operator_library` drops (unloads the `.so`) at end of scope here, after
-    // the main loop has joined and released every Arrow array the operator
-    // exported.
+    // the main loop has joined and released everything the operator handed it.
     Ok(())
 }
 
@@ -231,11 +231,18 @@ async fn run(
         });
     }
 
+    // Events pulled off the stream while a send was in flight (see
+    // `await_send_watching_for_stop`); they are handled before the stream is
+    // polled again so ordering is preserved.
+    let mut pending: VecDeque<RuntimeEvent> = VecDeque::new();
+
     loop {
         *lock(&activity) = LoopActivity::Idle;
-        let Some(event) = events.next().await else {
-            break;
+        let next = match pending.pop_front() {
+            buffered @ Some(_) => buffered,
+            None => events.next().await,
         };
+        let Some(event) = next else { break };
         *lock(&activity) = LoopActivity::Handling {
             since: Instant::now(),
             what: describe_runtime_event(&event),
@@ -298,37 +305,24 @@ async fn run(
                     encoded,
                 } => {
                     let output_id = operator_output_id(&operator_id, &output_id);
-                    let result;
-                    (node, result) = tokio::task::spawn_blocking(move || {
+                    let mut send = tokio::task::spawn_blocking(move || {
                         let result = node.send_output_encoded(output_id, parameters, encoded);
                         (node, result)
-                    })
+                    });
+                    let result;
+                    (node, result) = await_send_watching_for_stop(
+                        &mut send,
+                        &mut events,
+                        &mut pending,
+                        &mut operator_channels,
+                    )
                     .await
                     .wrap_err("failed to wait for send_output task")?;
                     result.wrap_err("failed to send node output")?;
                 }
             },
             RuntimeEvent::Event(Event::Stop(cause)) => {
-                // Diagnostic (dora-rs/dora#2742): trace Stop delivery so a
-                // Windows nightly shows whether the runtime received Stop and
-                // whether each per-operator forward *completed*. A logged
-                // "received Stop" with no matching "forwarded Stop" means the
-                // forward blocked on a full operator channel — i.e. the operator
-                // is parked in its own `on_event` and never draining.
-                // `warn!` (not `info!`) so it survives the runtime's default
-                // stdout filter (`with_stdout("warn", …)`) and reaches the
-                // nightly log.
-                tracing::warn!(
-                    "runtime received Stop; forwarding to {} operator(s) (dora-rs/dora#2742 diagnostic)",
-                    operator_channels.len()
-                );
-                // forward stop event to all operators and close the event channels
-                for (id, channel) in operator_channels.drain() {
-                    let _ = channel.send_async(Event::Stop(cause.clone())).await;
-                    tracing::warn!(
-                        "forwarded Stop to operator `{id}` (dora-rs/dora#2742 diagnostic)"
-                    );
-                }
+                forward_stop(&mut operator_channels, &cause).await;
             }
             RuntimeEvent::Event(Event::Reload {
                 operator_id: Some(operator_id),
@@ -426,6 +420,82 @@ async fn run(
     Ok(())
 }
 
+/// Forward `Stop` to every operator and close their event channels.
+///
+/// Diagnostic (dora-rs/dora#2742): a logged "received Stop" with no matching
+/// "forwarded Stop" means the forward blocked on a full operator channel — i.e.
+/// the operator is parked in its own `on_event` and never draining. The `warn!`
+/// level is deliberate: the runtime's default stdout filter is `warn`
+/// (`with_stdout("warn", …)`), so anything quieter never reaches a nightly log —
+/// which is what made the original wedge invisible.
+async fn forward_stop(
+    operator_channels: &mut HashMap<OperatorId, flume::Sender<Event>>,
+    cause: &StopCause,
+) {
+    tracing::warn!(
+        "runtime received Stop; forwarding to {} operator(s) (dora-rs/dora#2742 diagnostic)",
+        operator_channels.len()
+    );
+    for (id, channel) in operator_channels.drain() {
+        let _ = channel.send_async(Event::Stop(cause.clone())).await;
+        tracing::warn!("forwarded Stop to operator `{id}` (dora-rs/dora#2742 diagnostic)");
+    }
+}
+
+/// Wait for an in-flight output send without going deaf to `Stop`
+/// (dora-rs/dora#2742).
+///
+/// The main loop is the only consumer of the merged operator/daemon event
+/// stream, so awaiting a send inline meant the node could not observe `Stop` —
+/// and could not let its operators start winding down — until the send
+/// returned. This keeps consuming the stream: `Stop` is forwarded to the
+/// operators immediately, everything else is buffered for the caller to handle,
+/// in order, once the send completes.
+///
+/// This does **not** rescue a send that never returns: the node still owes the
+/// daemon an exit and will be force-killed at the grace period. Bailing out of a
+/// wedged send is not possible from here — the `DoraNode` lives inside the
+/// blocking task, and `Runtime::drop` waits forever for `spawn_blocking` work,
+/// so a real escape needs `shutdown_background()` at the `main()` layer.
+async fn await_send_watching_for_stop<S, T>(
+    send: &mut tokio::task::JoinHandle<T>,
+    events: &mut S,
+    pending: &mut VecDeque<RuntimeEvent>,
+    operator_channels: &mut HashMap<OperatorId, flume::Sender<Event>>,
+) -> Result<T, tokio::task::JoinError>
+where
+    S: Stream<Item = RuntimeEvent> + Unpin,
+{
+    /// Stop pulling events into memory once this many are buffered. Each
+    /// buffered `Event::Input` pins its payload (a mapped shared-memory region
+    /// above the zero-copy threshold), so this is deliberately small: it only
+    /// has to cover the handful of events that can arrive while one send is in
+    /// flight. Beyond it the events simply stay in the stream.
+    const MAX_BUFFERED: usize = 4;
+
+    let mut stop_seen = false;
+    loop {
+        // Once `Stop` is forwarded there is nothing left to watch for, so stop
+        // consuming and just wait the send out.
+        let watching = !stop_seen && pending.len() < MAX_BUFFERED;
+        tokio::select! {
+            biased;
+            joined = &mut *send => return joined,
+            event = events.next(), if watching => {
+                match event {
+                    Some(RuntimeEvent::Event(Event::Stop(cause))) => {
+                        forward_stop(operator_channels, &cause).await;
+                        stop_seen = true;
+                    }
+                    Some(other) => pending.push_back(other),
+                    // The stream ended, so no `Stop` can arrive.
+                    None => stop_seen = true,
+                }
+            }
+        }
+    }
+}
+
 fn operator_output_id(operator_id: &OperatorId, output_id: &DataId) -> DataId {
     DataId::from(format!("{operator_id}/{output_id}"))
 }
@@ -479,4 +549,117 @@ fn lock<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
     mutex
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+#[cfg(test)]
+mod stop_responsiveness_tests {
+    use super::*;
+    use futures::stream;
+
+    fn operator_channel() -> (
+        HashMap<OperatorId, flume::Sender<Event>>,
+        flume::Receiver<Event>,
+    ) {
+        let (tx, rx) = flume::unbounded();
+        let mut channels = HashMap::new();
+        channels.insert(OperatorId::from("op".to_string()), tx);
+        (channels, rx)
+    }
+
+    /// The ordinary case: nothing else happens, the send completes, and no
+    /// event is buffered.
+    #[tokio::test]
+    async fn a_send_that_completes_is_returned() {
+        let mut send = tokio::spawn(async { 42 });
+        let mut events = stream::empty::<RuntimeEvent>();
+        let mut pending = VecDeque::new();
+        let (mut channels, _rx) = operator_channel();
+
+        let joined =
+            await_send_watching_for_stop(&mut send, &mut events, &mut pending, &mut channels)
+                .await
+                .expect("joined");
+
+        assert_eq!(joined, 42);
+        assert!(pending.is_empty());
+    }
+
+    /// The #2742 behaviour: a `Stop` arriving mid-send reaches the operator
+    /// without waiting for the send, and a non-`Stop` event is kept for the
+    /// caller rather than dropped or reordered.
+    #[tokio::test]
+    async fn stop_reaches_the_operator_while_a_send_is_in_flight() {
+        let (unblock_tx, unblock_rx) = tokio::sync::oneshot::channel::<()>();
+        let mut send = tokio::spawn(async move {
+            let _ = unblock_rx.await;
+            7
+        });
+        let mut events = stream::iter(vec![
+            RuntimeEvent::Event(Event::Reload { operator_id: None }),
+            RuntimeEvent::Event(Event::Stop(StopCause::Manual)),
+        ]);
+        let mut pending = VecDeque::new();
+        let (mut channels, rx) = operator_channel();
+
+        // Release the send only after the operator has been told to stop, which
+        // is only possible if the forward happened while the send was pending.
+        tokio::spawn(async move {
+            while rx.is_empty() {
+                tokio::task::yield_now().await;
+            }
+            assert!(matches!(rx.recv_async().await, Ok(Event::Stop(_))));
+            let _ = unblock_tx.send(());
+        });
+
+        let joined = tokio::time::timeout(
+            Duration::from_secs(5),
+            await_send_watching_for_stop(&mut send, &mut events, &mut pending, &mut channels),
+        )
+        .await
+        .expect("must not hang")
+        .expect("joined");
+
+        assert_eq!(joined, 7);
+        assert_eq!(
+            pending.len(),
+            1,
+            "the non-Stop event must be kept, not lost"
+        );
+        assert!(
+            channels.is_empty(),
+            "forwarding Stop closes the operator channels"
+        );
+    }
+
+    /// Buffering is bounded: a flood of events during a send does not pull the
+    /// whole stream into memory.
+    #[tokio::test]
+    async fn buffering_during_a_send_is_bounded() {
+        let (unblock_tx, unblock_rx) = tokio::sync::oneshot::channel::<()>();
+        let mut send = tokio::spawn(async move {
+            let _ = unblock_rx.await;
+            0
+        });
+        let flood = (0..1000)
+            .map(|_| RuntimeEvent::Event(Event::Reload { operator_id: None }))
+            .collect::<Vec<_>>();
+        let mut events = stream::iter(flood);
+        let mut pending = VecDeque::new();
+        let (mut channels, _rx) = operator_channel();
+
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            let _ = unblock_tx.send(());
+        });
+
+        await_send_watching_for_stop(&mut send, &mut events, &mut pending, &mut channels)
+            .await
+            .expect("joined");
+
+        assert!(
+            pending.len() <= 4,
+            "buffered {} events, expected the cap to hold",
+            pending.len()
+        );
+    }
 }

--- a/binaries/runtime/src/lib.rs
+++ b/binaries/runtime/src/lib.rs
@@ -10,12 +10,12 @@ use dora_tracing::TracingBuilder;
 use eyre::{Context, Result, bail};
 use futures::{Stream, StreamExt};
 use futures_concurrency::stream::Merge;
-use operator::{OperatorEvent, StopReason, run_operator};
+use operator::{OperatorEvent, RuntimeHandle, SharedAllocator, StopReason, run_operator};
 
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     mem,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, OnceLock},
     time::{Duration, Instant},
 };
 use tokio::{
@@ -86,6 +86,10 @@ pub fn main() -> eyre::Result<()> {
     .into_iter()
     .collect();
     let (init_done_tx, init_done) = oneshot::channel();
+    // Filled by `run` as soon as the node exists; operators encode their outputs
+    // through it (see `SharedAllocator`, dora-rs/dora#2742).
+    let allocator: SharedAllocator = Arc::new(OnceLock::new());
+    let run_allocator = allocator.clone();
     let main_task = std::thread::spawn(move || -> Result<()> {
         tokio_runtime.block_on(run(
             operator_config,
@@ -93,6 +97,7 @@ pub fn main() -> eyre::Result<()> {
             operator_events,
             operator_channels,
             init_done,
+            run_allocator,
         ))
     });
 
@@ -106,7 +111,7 @@ pub fn main() -> eyre::Result<()> {
         &node_id,
         operator_definition,
         incoming_events,
-        operator_events_tx,
+        RuntimeHandle::new(operator_events_tx, allocator),
         init_done_tx,
         &dataflow_descriptor,
     )
@@ -137,13 +142,14 @@ fn queue_sizes(
     sizes
 }
 
-#[tracing::instrument(skip(operator_events, operator_channels), level = "trace")]
+#[tracing::instrument(skip(operator_events, operator_channels, allocator), level = "trace")]
 async fn run(
     operators: HashMap<OperatorId, OperatorConfig>,
     config: NodeConfig,
     operator_events: impl Stream<Item = RuntimeEvent> + Unpin,
     mut operator_channels: HashMap<OperatorId, flume::Sender<Event>>,
     init_done: oneshot::Receiver<Result<()>>,
+    allocator: SharedAllocator,
 ) -> eyre::Result<()> {
     // Start the OTLP metrics exporter only when an endpoint is configured, and
     // spawn it as a background task. `run_metrics_monitor` is an `async fn`, so
@@ -174,6 +180,9 @@ async fn run(
     tracing::info!("All operators are ready, starting runtime");
 
     let (mut node, mut daemon_events) = DoraNode::init(config)?;
+    // Publish the allocator before any input can reach an operator, so an
+    // operator's first `send_output` already has somewhere to encode into.
+    let _ = allocator.set(node.sample_allocator());
     let (daemon_events_tx, daemon_event_stream) = flume::bounded(1);
     tokio::task::spawn_blocking(move || {
         while let Some(event) = daemon_events.recv() {
@@ -286,13 +295,12 @@ async fn run(
                 OperatorEvent::Output {
                     output_id,
                     parameters,
-                    arrow_array,
+                    encoded,
                 } => {
                     let output_id = operator_output_id(&operator_id, &output_id);
                     let result;
                     (node, result) = tokio::task::spawn_blocking(move || {
-                        let array = dora_node_api::arrow::array::make_array(arrow_array);
-                        let result = node.send_output(output_id, parameters, array);
+                        let result = node.send_output_encoded(output_id, parameters, encoded);
                         (node, result)
                     })
                     .await

--- a/binaries/runtime/src/operator/mod.rs
+++ b/binaries/runtime/src/operator/mod.rs
@@ -2,10 +2,71 @@ use dora_core::{
     config::{DataId, NodeId},
     descriptor::{Descriptor, OperatorDefinition, OperatorSource},
 };
-use dora_node_api::{Event, MetadataParameters, arrow::array::ArrayData};
+use dora_node_api::{
+    EncodedSample, Event, MetadataParameters, SampleAllocator, arrow::array::ArrayData,
+};
 use eyre::{Context, Result};
 use std::any::Any;
+use std::sync::{Arc, OnceLock};
 use tokio::sync::{mpsc::Sender, oneshot};
+
+/// Shared slot holding the node's [`SampleAllocator`].
+///
+/// The operator threads are started *before* `DoraNode::init` runs (the node
+/// only reports ready once every operator has initialized), so the allocator
+/// cannot be passed in at spawn time. The runtime fills this slot as soon as the
+/// node exists, which is strictly before any input — and therefore any output —
+/// can reach an operator.
+pub type SharedAllocator = Arc<OnceLock<SampleAllocator>>;
+
+/// An operator's side of the runtime: where to send events, and where to get
+/// output samples from.
+#[derive(Clone)]
+pub struct RuntimeHandle {
+    events_tx: Sender<OperatorEvent>,
+    allocator: SharedAllocator,
+}
+
+impl RuntimeHandle {
+    pub fn new(events_tx: Sender<OperatorEvent>, allocator: SharedAllocator) -> Self {
+        Self {
+            events_tx,
+            allocator,
+        }
+    }
+
+    /// Encode `array` into a dora-owned sample **on the calling (operator)
+    /// thread** and hand that to the runtime.
+    ///
+    /// This is the only place an `OperatorEvent::Output` is built, so the
+    /// ownership invariant that fixes dora-rs/dora#2742 holds for every operator
+    /// backend: `array` is borrowed, never sent, and the caller drops it while
+    /// it still holds whatever its language runtime needs to free it.
+    pub fn send_output(
+        &self,
+        output_id: DataId,
+        parameters: MetadataParameters,
+        array: &ArrayData,
+    ) -> Result<()> {
+        let allocator = self
+            .allocator
+            .get()
+            .ok_or_else(|| eyre::eyre!("cannot send an output before the node is initialized"))?;
+        let encoded = allocator.encode_arrow(array)?;
+        self.events_tx
+            .blocking_send(OperatorEvent::Output {
+                output_id,
+                parameters,
+                encoded,
+            })
+            .map_err(|_| eyre::eyre!("failed to send output to runtime"))
+    }
+
+    /// Report a lifecycle event (finished, error, panic) to the runtime.
+    pub fn report(&self, event: OperatorEvent) {
+        let _ = self.events_tx.blocking_send(event);
+    }
+}
 
 pub mod channel;
 #[cfg(feature = "python")]
@@ -13,17 +74,22 @@ mod python;
 mod shared_lib;
 
 /// Runs the operator to completion. Returns a shared library that the caller
-/// **must keep alive until after the runtime's main event loop has joined**: a
-/// shared-library operator's outputs are Arrow arrays whose FFI `release`
-/// callbacks point into the `.so`, and the main loop (on another thread) may
-/// still hold in-flight arrays when this returns. See `shared_lib::run`. Returns
-/// `None` for operator kinds with no such library (Python).
+/// **must keep alive until after the runtime's main event loop has joined**.
+///
+/// Since dora-rs/dora#2742 the main loop no longer holds Arrow arrays exported
+/// by the operator — outputs are encoded into dora-owned samples on the operator
+/// thread (see [`RuntimeHandle::send_output`]) — but other values can still
+/// carry `.so`-resident vtables across the channel, most notably an
+/// [`OperatorEvent::Panic`] payload. Unloading the library while the loop may
+/// still hold one dangles those, so the caller keeps it mapped. See
+/// `shared_lib::run`. Returns `None` for operator kinds with no such library
+/// (Python).
 #[allow(unused_variables)]
 pub fn run_operator(
     node_id: &NodeId,
     operator_definition: OperatorDefinition,
     incoming_events: flume::Receiver<Event>,
-    events_tx: Sender<OperatorEvent>,
+    handle: RuntimeHandle,
     init_done: oneshot::Sender<Result<()>>,
     dataflow_descriptor: &Descriptor,
 ) -> eyre::Result<Option<libloading::Library>> {
@@ -33,7 +99,7 @@ pub fn run_operator(
                 node_id,
                 &operator_definition.id,
                 source,
-                events_tx,
+                handle,
                 incoming_events,
                 init_done,
             )
@@ -53,7 +119,7 @@ pub fn run_operator(
                     node_id,
                     &operator_definition.id,
                     source,
-                    events_tx,
+                    handle,
                     incoming_events,
                     init_done,
                     dataflow_descriptor,
@@ -89,10 +155,15 @@ pub enum OperatorEvent {
     Output {
         output_id: DataId,
         parameters: MetadataParameters,
-        /// The output payload as an Arrow array. The runtime IPC-encodes it via
-        /// [`DoraNode::send_output`] (every data-plane payload is an Arrow IPC
-        /// stream).
-        arrow_array: ArrayData,
+        /// The payload, already IPC-encoded into a dora-owned sample **by the
+        /// operator thread** (see [`RuntimeHandle::send_output`]).
+        ///
+        /// Deliberately not an `ArrayData`: an operator's array may be backed by
+        /// memory its own language runtime owns, and releasing that memory can
+        /// need the owning runtime (a `pyarrow` array over a numpy buffer takes
+        /// the GIL to drop). Freeing it here would let an operator that holds
+        /// the GIL stall the runtime's event loop — dora-rs/dora#2742.
+        encoded: EncodedSample,
     },
     Error(eyre::Error),
     Panic(Box<dyn Any + Send>),
@@ -111,6 +182,97 @@ pub enum StopReason {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The #2742 invariant, at the level the fix actually lives: an operator's
+    /// array is *borrowed* by `send_output`, never sent. By the time the event
+    /// is on the channel the source payload has been released — on this thread,
+    /// where the operator still holds whatever its language runtime needs to
+    /// free it — and what crosses is a dora-owned `EncodedSample`.
+    #[test]
+    fn send_output_releases_the_operator_payload_before_it_crosses_the_channel() {
+        use arrow::buffer::Buffer;
+        use std::ptr::NonNull;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        /// Stands in for a foreign owner of the payload — numpy behind pyarrow,
+        /// or a buffer owned by an operator's `.so`.
+        struct ForeignOwner {
+            released: Arc<AtomicBool>,
+            _backing: Vec<u8>,
+        }
+        impl Drop for ForeignOwner {
+            fn drop(&mut self) {
+                self.released.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let backing = vec![0xCDu8; 4096];
+        let ptr = NonNull::new(backing.as_ptr() as *mut u8).expect("non-null");
+        let released = Arc::new(AtomicBool::new(false));
+        let owner = Arc::new(ForeignOwner {
+            released: released.clone(),
+            _backing: backing,
+        });
+        let buffer = unsafe { Buffer::from_custom_allocation(ptr, 4096, owner) };
+        let array = ArrayData::builder(dora_node_api::arrow::datatypes::DataType::UInt8)
+            .len(4096)
+            .add_buffer(buffer)
+            .build()
+            .expect("valid UInt8 array");
+
+        let (events_tx, mut events_rx) = tokio::sync::mpsc::channel(1);
+        let allocator: SharedAllocator = Arc::new(OnceLock::new());
+        allocator
+            .set(SampleAllocator::heap())
+            .expect("fresh OnceLock");
+        let handle = RuntimeHandle::new(events_tx, allocator);
+
+        handle
+            .send_output(
+                DataId::from("out".to_string()),
+                MetadataParameters::default(),
+                &array,
+            )
+            .expect("send_output");
+
+        // The operator drops its array here, on its own thread.
+        drop(array);
+        assert!(
+            released.load(Ordering::SeqCst),
+            "the queued event must not keep the operator's payload alive"
+        );
+
+        match events_rx.try_recv().expect("an output event was queued") {
+            OperatorEvent::Output { encoded, .. } => {
+                assert!(
+                    encoded.as_bytes().len() > 4096,
+                    "the sample must hold the encoded payload, not a reference to it"
+                );
+            }
+            other => panic!("expected an Output event, got {other:?}"),
+        }
+    }
+
+    /// Sending before the node exists must fail with a clear message rather
+    /// than panic.
+    #[test]
+    fn send_output_before_node_init_is_a_clear_error() {
+        let (events_tx, _events_rx) = tokio::sync::mpsc::channel(1);
+        let handle = RuntimeHandle::new(events_tx, SharedAllocator::default());
+        let array = ArrayData::new_null(&dora_node_api::arrow::datatypes::DataType::UInt8, 1);
+
+        let err = handle
+            .send_output(
+                DataId::from("out".to_string()),
+                MetadataParameters::default(),
+                &array,
+            )
+            .expect_err("no allocator yet");
+        assert!(
+            err.to_string().contains("before the node is initialized"),
+            "unexpected error: {err}"
+        );
+    }
 
     /// An unsupported operator source must surface a descriptive error from
     /// `run_operator` rather than returning `Ok(())` while silently dropping
@@ -131,7 +293,7 @@ mod tests {
             &NodeId::from("node".to_string()),
             operator_definition,
             incoming_events,
-            events_tx,
+            RuntimeHandle::new(events_tx, SharedAllocator::default()),
             init_done_tx,
             &dataflow,
         )

--- a/binaries/runtime/src/operator/python.rs
+++ b/binaries/runtime/src/operator/python.rs
@@ -21,7 +21,7 @@ use std::{
     panic::{AssertUnwindSafe, catch_unwind},
     path::Path,
 };
-use tokio::sync::{mpsc::Sender, oneshot};
+use tokio::sync::oneshot;
 use tracing::{error, field, span, warn};
 
 fn traceback(err: pyo3::PyErr) -> eyre::Report {
@@ -33,16 +33,19 @@ fn traceback(err: pyo3::PyErr) -> eyre::Report {
     }
 }
 
-#[tracing::instrument(skip(events_tx, incoming_events), level = "trace")]
+#[tracing::instrument(skip(handle, incoming_events), level = "trace")]
 pub fn run(
     node_id: &NodeId,
     operator_id: &OperatorId,
     python_source: &PythonSource,
-    events_tx: Sender<OperatorEvent>,
+    handle: super::RuntimeHandle,
     incoming_events: flume::Receiver<Event>,
     init_done: oneshot::Sender<Result<()>>,
     dataflow_descriptor: &Descriptor,
 ) -> eyre::Result<()> {
+    // Kept for the lifecycle events reported after the operator loop returns;
+    // `handle` itself moves into the send-output callback below.
+    let reporter = handle.clone();
     let path = if source_is_url(&python_source.source) {
         let target_path = Path::new("build");
         // try to download the shared library
@@ -68,9 +71,7 @@ pub fn run(
         .ok_or_else(|| eyre!("module file stem is not valid utf8"))?;
     let path_parent = path.parent();
 
-    let send_output = SendOutputCallback {
-        events_tx: events_tx.clone(),
-    };
+    let send_output = SendOutputCallback { handle };
 
     let init_operator = move |py: Python| {
         if let Some(parent_path) = path_parent {
@@ -280,13 +281,13 @@ pub fn run(
 
     match catch_unwind(closure) {
         Ok(Ok(reason)) => {
-            let _ = events_tx.blocking_send(OperatorEvent::Finished { reason });
+            reporter.report(OperatorEvent::Finished { reason });
         }
         Ok(Err(err)) => {
-            let _ = events_tx.blocking_send(OperatorEvent::Error(err));
+            reporter.report(OperatorEvent::Error(err));
         }
         Err(panic) => {
-            let _ = events_tx.blocking_send(OperatorEvent::Panic(panic));
+            reporter.report(OperatorEvent::Panic(panic));
         }
     }
 
@@ -296,13 +297,12 @@ pub fn run(
 #[pyclass(skip_from_py_object)]
 #[derive(Clone)]
 struct SendOutputCallback {
-    events_tx: Sender<OperatorEvent>,
+    /// Sends outputs, encoding them on this thread (dora-rs/dora#2742).
+    handle: super::RuntimeHandle,
 }
 
 #[allow(unsafe_op_in_unsafe_fn)]
 mod callback_impl {
-
-    use crate::operator::OperatorEvent;
 
     use super::SendOutputCallback;
     use arrow::{
@@ -312,7 +312,7 @@ mod callback_impl {
     use dora_operator_api_python::pydict_to_metadata;
     #[cfg(feature = "telemetry")]
     use dora_tracing::telemetry::deserialize_context;
-    use eyre::{Context, Result, eyre};
+    use eyre::{Context, Result};
     use pyo3::{
         Bound, Py, PyAny, Python, pymethods,
         types::{PyBytes, PyBytesMethods, PyDict},
@@ -359,9 +359,8 @@ mod callback_impl {
             }
             let _enter = span.enter();
 
-            // Build the output as an Arrow array. The runtime IPC-encodes it
-            // (every data-plane payload is a self-describing Arrow IPC stream).
-            // Raw `bytes` map to a `UInt8Array`.
+            // Build the output as an Arrow array. Raw `bytes` map to a
+            // `UInt8Array`.
             let arrow_array: ArrayData = if let Ok(py_bytes) = data.cast_bound::<PyBytes>(py) {
                 UInt8Array::from(py_bytes.as_bytes().to_vec()).into()
             } else if let Ok(arrow_array) = ArrayData::from_pyarrow_bound(data.bind(py)) {
@@ -369,16 +368,19 @@ mod callback_impl {
             } else {
                 eyre::bail!("invalid `data` type, must by `PyBytes` or arrow array")
             };
-
+            // `arrow_array` is only *borrowed* by the send below, so it is
+            // dropped at the end of this function — with the GIL held by this
+            // thread. Letting it travel to the runtime instead would make the
+            // runtime's event loop block on `PyAcquireGIL` inside pyarrow's
+            // `NumPyBuffer` destructor for as long as operator code holds the
+            // GIL (dora-rs/dora#2742).
+            //
+            // The encode inside needs no GIL, so run detached: it is the same
+            // single copy the node used to make, just on this side of the
+            // channel, and other Python threads stay runnable meanwhile.
             py.detach(|| {
-                let event = OperatorEvent::Output {
-                    output_id: output.to_owned().into(),
-                    parameters,
-                    arrow_array,
-                };
-                self.events_tx
-                    .blocking_send(event)
-                    .map_err(|_| eyre!("failed to send output to runtime"))
+                self.handle
+                    .send_output(output.to_owned().into(), parameters, &arrow_array)
             })?;
 
             Ok(())

--- a/binaries/runtime/src/operator/shared_lib.rs
+++ b/binaries/runtime/src/operator/shared_lib.rs
@@ -19,17 +19,20 @@ use std::{
     path::Path,
     sync::Arc,
 };
-use tokio::sync::{mpsc::Sender, oneshot};
+use tokio::sync::oneshot;
 use tracing::{field, span};
 
 pub fn run(
     _node_id: &NodeId,
     _operator_id: &OperatorId,
     source: &str,
-    events_tx: Sender<OperatorEvent>,
+    handle: super::RuntimeHandle,
     incoming_events: flume::Receiver<Event>,
     init_done: oneshot::Sender<Result<()>>,
 ) -> eyre::Result<libloading::Library> {
+    // Kept for the lifecycle events reported after the operator loop returns;
+    // `handle` itself moves into the operator below.
+    let reporter = handle.clone();
     let path = if source_is_url(source) {
         let target_path = &Path::new("build");
         // try to download the shared library
@@ -65,41 +68,43 @@ pub fn run(
         let operator = SharedLibraryOperator {
             incoming_events,
             bindings,
-            events_tx: events_tx.clone(),
+            handle,
         };
 
         operator.run(init_done)
     });
     match catch_unwind(closure) {
         Ok(Ok(reason)) => {
-            let _ = events_tx.blocking_send(OperatorEvent::Finished { reason });
+            reporter.report(OperatorEvent::Finished { reason });
         }
         Ok(Err(err)) => {
-            let _ = events_tx.blocking_send(OperatorEvent::Error(err));
+            reporter.report(OperatorEvent::Error(err));
         }
         Err(panic) => {
-            let _ = events_tx.blocking_send(OperatorEvent::Panic(panic));
+            reporter.report(OperatorEvent::Panic(panic));
         }
     }
 
     // Hand the loaded library back to the caller instead of dropping (unloading)
-    // it here. Arrow arrays produced by this operator are exported over the C
-    // data interface with a `release` callback that points *into* this `.so`
-    // (`arrow::ffi::from_ffi` imports them in `send_output_closure`). The runtime's
-    // main event loop runs on another thread and may still hold in-flight arrays
-    // when we return — the `OperatorEvent::Finished` above only guarantees the
-    // channel slot was taken, not that every prior output has been sent and
-    // dropped. Unloading the library now (dlclose on drop) would dangle those
-    // release callbacks, so freeing the arrays afterwards jumps into unmapped
-    // code (SIGSEGV, reproducible under a high output rate at shutdown). The
-    // caller keeps this alive until after the main loop has joined, by which
-    // point every exported array has been released.
+    // it here.
+    //
+    // Historically this guarded exported Arrow arrays: they carry a `release`
+    // callback pointing *into* this `.so`, the runtime's main loop held them,
+    // and unloading first turned freeing one into a jump into unmapped memory
+    // (SIGSEGV under a high output rate at shutdown). Since dora-rs/dora#2742
+    // outputs are encoded into dora-owned samples on this thread and the arrays
+    // never leave it, so that specific hazard is gone — but values whose vtable
+    // lives in the `.so` can still be in flight when we return (an
+    // `OperatorEvent::Panic` payload above is a `Box<dyn Any>` built inside it,
+    // and `OperatorEvent::Finished` only means the channel slot was taken). The
+    // caller keeps this mapped until the main loop has joined.
     Ok(library)
 }
 
 struct SharedLibraryOperator<'lib> {
     incoming_events: flume::Receiver<Event>,
-    events_tx: Sender<OperatorEvent>,
+    /// Sends outputs, encoding them on this thread (dora-rs/dora#2742).
+    handle: super::RuntimeHandle,
 
     bindings: Bindings<'lib>,
 }
@@ -146,20 +151,17 @@ impl SharedLibraryOperator<'_> {
                 Err(err) => return DoraResult::from_error(err.to_string()),
             };
 
-            let event = OperatorEvent::Output {
-                output_id: DataId::from(String::from(output_id)),
+            // `arrow_array` is only borrowed: it is encoded into a dora-owned
+            // sample here and dropped at the end of this closure, on the
+            // operator thread, so its `.so`-resident release callback never runs
+            // on the runtime's event loop (dora-rs/dora#2742).
+            match self.handle.send_output(
+                DataId::from(String::from(output_id)),
                 parameters,
-                arrow_array,
-            };
-
-            let result = self
-                .events_tx
-                .blocking_send(event)
-                .map_err(|_| eyre!("failed to send output to runtime"));
-
-            match result {
+                &arrow_array,
+            ) {
                 Ok(()) => DoraResult::SUCCESS,
-                Err(_) => DoraResult::from_error("runtime process closed unexpectedly".into()),
+                Err(err) => DoraResult::from_error(format!("{err}")),
             }
         });
 


### PR DESCRIPTION
Fixes the last surviving `cli-tests-python (windows)` failure in #2742.

## The bug

`webcam.py` builds its payload with `pa.array(frame.ravel())`. That is **zero-copy over numpy** — the Arrow buffer *is* the numpy allocation — so releasing it acquires the GIL (pyarrow's `NumPyBuffer` destructor does `PyAcquireGIL`). Verified locally against the same pyarrow 25.0.0 / numpy 2.5.1 the nightly installs: arrow buffer address == numpy data pointer, `pa.total_allocated_bytes()` delta 0.

That array was handed to the runtime's event loop, which dropped it on a tokio blocking thread holding no GIL. Measured with a pyo3 + arrow probe: **15.6 µs** to drop with the GIL free, **4.5 s** while another thread held it.

The GIL holder in the nightly is `webcam.py`'s `__del__` → `cv2.VideoCapture.release()`, run under `Python::attach` on the STOP tick. That is exactly the tick every observed wedge started on (`t=12.21s` on 08-09, `t=13.54s` on 07-29, both past `CI_HEADLESS_RUN_SECS=10`). The loop then observed neither `Stop` nor the operator's own `Finished`, and the daemon force-killed the node — `ExitCode(1)` on Windows, masked as `Signal(15)` on Unix.

The `#2885` hop diagnostics pointed at `report_output_sent` because that is the last instrumented hop; the stall is in the un-instrumented array drop immediately after it.

## The fix

**Commit 1 — operators encode their own outputs.** `OperatorEvent::Output` now carries an `EncodedSample` instead of an `ArrayData`, so foreign-owned memory structurally cannot cross the channel. `RuntimeHandle::send_output` is the single place the event is built; it borrows the array, so both backends drop it on their own thread — for Python, with the GIL held, where the release is free.

No extra payload copy: `encode_arrow` is the same `encode_ipc_into` the node already ran in `send_output_array`, moved to the other side of the channel. The runtime path actually loses a `make_array` + `to_data()` per output. The genuinely zero-copy `send_output_raw` path is untouched.

**Commit 2 — the loop stays responsive during a send.** Even with the above, any slow send (zenoh, daemon socket) made the node deaf to `Stop`. `await_send_watching_for_stop` keeps consuming the event stream: `Stop` is forwarded to the operators immediately, everything else is buffered and handled in order once the send completes.

It deliberately stops there. An earlier draft also abandoned a wedged send and returned early — that turned out to be inert: the `DoraNode` lives inside the blocking task and `Runtime::drop` "waits forever" for `spawn_blocking` work, so returning early just moves the wedge one frame up into the runtime's own shutdown. A real escape needs `shutdown_background()` at the `main()` layer; left as a follow-up, since after commit 1 the wedge this issue is about is gone at the source.

## Trade-offs

- The IPC encode now runs inside the operator's `send_output` rather than after the channel hand-off. With channel capacity 1 there was little pipelining to lose, but it is on the critical path of user callbacks now (~100 µs for a 1 MB frame).
- An SHM sample is allocated earlier and lives across the channel hop, so a producer can hold two chunks instead of one — ~12.5% more pressure on the default 8 MB pool at 1 MB payloads. Worth a throughput comparison before/after on a large-payload dataflow.
- The loop now pulls up to 4 events off the stream during a send instead of leaving them in the daemon channel, so a few input payloads are pinned slightly longer.
- `close_outputs` on the `Finished` path still awaits its `spawn_blocking` inline; the same treatment would apply there, but it is outside what this change needed.

## Not included

- The `#2857`/`#2885` diagnostics (`webcam.py` prints, the stall watchdog, the hop logs) are left in place; removing them belongs in a follow-up once a nightly confirms the fix.
- `webcam.py` still opens a `cv2.VideoCapture` when headless and only releases it in `__del__`. Worth fixing on its own, but it is no longer load-bearing.
- `ipc_encode::prepare()` runs twice per message (once for the length, once for the encode) — pre-existing, and `encode_arrow` is now the natural place to fix it.

Refs #2742
