### PR TITLE
fix(qa): resolve the cargo target dir instead of hardcoding `target/`

### DIFF
--- a/scripts/cargo-target-dir.sh
+++ b/scripts/cargo-target-dir.sh
@@ -1,0 +1,31 @@
+# shellcheck shell=bash
+#
+# Resolve the cargo target directory for the workspace.
+#
+# The QA and smoke scripts locate prebuilt binaries by path, so hardcoding
+# `<repo>/target` breaks them whenever the target dir moves -- a
+# CARGO_TARGET_DIR override, or a `build.target-dir` / `build.build-dir` in
+# some .cargo/config.toml (e.g. one target dir shared across git worktrees, so
+# that deps are not rebuilt per worktree).
+#
+# `cargo metadata` is authoritative: it already accounts for CARGO_TARGET_DIR
+# and every config source cargo itself honors. We only fall back to
+# `<root>/target` when cargo cannot answer at all (cargo or python3 missing, no
+# manifest reachable), which reproduces the previous hardcoded behavior.
+#
+# Usage:
+#   source "$SCRIPT_DIR/cargo-target-dir.sh"
+#   TARGET_DIR="$(cargo_target_dir "$ROOT")"
+cargo_target_dir() {
+    local root="${1:-$PWD}"
+    local dir
+
+    # A failure anywhere in this chain -- no cargo, no python3, no reachable
+    # manifest -- leaves $dir empty, and the fallback below takes over.
+    dir="$(cd "$root" 2> /dev/null \
+        && cargo metadata --format-version 1 --no-deps 2> /dev/null \
+        | python3 -c 'import json,sys; print(json.load(sys.stdin)["target_directory"])' 2> /dev/null)" \
+        || dir=""
+
+    printf '%s\n' "${dir:-${CARGO_TARGET_DIR:-$root/target}}"
+}

--- a/scripts/qa/all.sh
+++ b/scripts/qa/all.sh
@@ -40,6 +40,10 @@ set -euo pipefail
 
 cd "$(dirname "$0")/../.."
 
+# shellcheck source=../cargo-target-dir.sh
+source scripts/cargo-target-dir.sh
+TARGET_DIR="$(cargo_target_dir "$PWD")"
+
 MODE="${1:---fast}"
 FAILED=()
 
@@ -353,7 +357,7 @@ case "$MODE" in
     elif ! uv python find 3.12 > /dev/null 2>&1; then
       nightly_py_missing "Python 3.12"
     else
-      NIGHTLY_VENV="$(pwd)/target/qa-nightly-venv"
+      NIGHTLY_VENV="$TARGET_DIR/qa-nightly-venv"
       echo
       echo "=== preparing ambient Python venv at $NIGHTLY_VENV ==="
       echo "=== (matches GHA smoke-suite's 'uv pip install -e apis/python/node') ==="

--- a/scripts/qa/ci-nightly-jobs.sh
+++ b/scripts/qa/ci-nightly-jobs.sh
@@ -74,6 +74,10 @@ set -euo pipefail
 
 cd "$(dirname "$0")/../.."
 
+# shellcheck source=../cargo-target-dir.sh
+source scripts/cargo-target-dir.sh
+TARGET_DIR="$(cargo_target_dir "$PWD")"
+
 # -----------------------------------------------------------------------------
 # Platform + env setup
 # -----------------------------------------------------------------------------
@@ -879,14 +883,12 @@ job_cluster_e2e() {
       exit 1
     fi
 
-    local REPO_ROOT
-    REPO_ROOT="$(pwd)"
     cat > "$WORK/dataflow.yml" <<EOF
 nodes:
   - id: rust-node
     _unstable_deploy:
       machine: m1
-    path: $REPO_ROOT/target/debug/rust-dataflow-example-node
+    path: $TARGET_DIR/debug/rust-dataflow-example-node
     inputs:
       tick: dora/timer/millis/10
     outputs:
@@ -896,7 +898,7 @@ nodes:
   - id: rust-status-node
     _unstable_deploy:
       machine: m2
-    path: $REPO_ROOT/target/debug/rust-dataflow-example-status-node
+    path: $TARGET_DIR/debug/rust-dataflow-example-status-node
     inputs:
       tick: dora/timer/millis/100
       random: rust-node/random
@@ -909,7 +911,7 @@ nodes:
   - id: rust-sink
     _unstable_deploy:
       machine: m3
-    path: $REPO_ROOT/target/debug/rust-dataflow-example-sink
+    path: $TARGET_DIR/debug/rust-dataflow-example-sink
     inputs:
       message: rust-status-node/status
     input_types:
@@ -1067,9 +1069,6 @@ job_cluster_record_replay() {
 
     cluster_up_and_verify || exit 1
 
-    local REPO_ROOT
-    REPO_ROOT="$(pwd)"
-
     # plain.yml: the deploy-free, build-free, absolute-path descriptor. This
     # is what gets embedded in the .drec and replayed locally, so it must NOT
     # carry `_unstable_deploy` (local `dora run` rejects it) or `build:`
@@ -1078,7 +1077,7 @@ job_cluster_record_replay() {
     cat > "$WORK/plain.yml" <<EOF
 nodes:
   - id: rust-node
-    path: $REPO_ROOT/target/debug/rust-dataflow-example-node
+    path: $TARGET_DIR/debug/rust-dataflow-example-node
     inputs:
       tick: dora/timer/millis/10
     outputs:
@@ -1086,7 +1085,7 @@ nodes:
     output_types:
       random: std/core/v1/UInt64
   - id: rust-status-node
-    path: $REPO_ROOT/target/debug/rust-dataflow-example-status-node
+    path: $TARGET_DIR/debug/rust-dataflow-example-status-node
     inputs:
       tick: dora/timer/millis/100
       random: rust-node/random
@@ -1097,7 +1096,7 @@ nodes:
     output_types:
       status: std/core/v1/String
   - id: rust-sink
-    path: $REPO_ROOT/target/debug/rust-dataflow-example-sink
+    path: $TARGET_DIR/debug/rust-dataflow-example-sink
     inputs:
       message: rust-status-node/status
     input_types:
@@ -1421,10 +1420,10 @@ job_redb_backend() {
   rm -f "$STORE"
 
   # Inline dataflow fixture
-  cat > examples/rust-dataflow/redb-smoke.yml <<'EOF'
+  cat > examples/rust-dataflow/redb-smoke.yml <<EOF
 nodes:
   - id: source
-    path: ../../target/debug/rust-dataflow-example-node
+    path: $TARGET_DIR/debug/rust-dataflow-example-node
     inputs:
       tick: dora/timer/millis/500
     outputs:
@@ -1568,10 +1567,10 @@ job_state_reconstruction() {
   local STORE=/tmp/state-reconstruct.db
   rm -f "$STORE"
 
-  cat > examples/rust-dataflow/long-running.yml <<'EOF'
+  cat > examples/rust-dataflow/long-running.yml <<EOF
 nodes:
   - id: source
-    path: ../../target/debug/rust-dataflow-example-node
+    path: $TARGET_DIR/debug/rust-dataflow-example-node
     inputs:
       tick: dora/timer/millis/500
     outputs:

--- a/scripts/qa/pgo.sh
+++ b/scripts/qa/pgo.sh
@@ -26,6 +26,10 @@ set -euo pipefail
 cd "$(dirname "$0")/../.."
 REPO_ROOT="$PWD"
 
+# shellcheck source=../cargo-target-dir.sh
+source scripts/cargo-target-dir.sh
+TARGET_DIR="$(cargo_target_dir "$REPO_ROOT")"
+
 # ---- Preflight ----
 if ! command -v cargo-pgo >/dev/null; then
   echo "ERROR: cargo-pgo not installed. Run:"
@@ -55,13 +59,13 @@ if ! command -v python3 >/dev/null; then
 fi
 
 HOST=$(rustc -vV | awk '/host:/ {print $2}')
-OUT_DIR="$REPO_ROOT/target/pgo-bench"
-# Force --target $HOST for both baseline and PGO builds so paths are
-# predictable regardless of user's cargo config. Step 3 (instrument) will
-# overwrite the binary at target/$HOST/dist/dora, but step 2 has already
-# captured the baseline CSV by then, so we also copy the binary to OUT_DIR
-# so it survives the overwrite and can be re-inspected.
-HOST_DIST_DORA="$REPO_ROOT/target/$HOST/dist/dora"
+OUT_DIR="$TARGET_DIR/pgo-bench"
+# Force --target $HOST for both baseline and PGO builds so the layout under
+# the target dir is predictable. Step 3 (instrument) will overwrite the binary
+# at $TARGET_DIR/$HOST/dist/dora, but step 2 has already captured the baseline
+# CSV by then, so we also copy the binary to OUT_DIR so it survives the
+# overwrite and can be re-inspected.
+HOST_DIST_DORA="$TARGET_DIR/$HOST/dist/dora"
 BASELINE_DORA="$OUT_DIR/baseline-dora"
 PGO_DORA="$HOST_DIST_DORA"
 
@@ -95,11 +99,11 @@ echo "Baseline CSV: $OUT_DIR/baseline.csv"
 
 # ---- 3/5: PGO instrumented build ----
 # Force --target $HOST so the instrumented binary always overwrites the
-# baseline at target/$HOST/dist/dora. Without it, if cargo-pgo's behavior
-# or the user's cargo config sends output elsewhere, the existence check
-# below would pass against the stale baseline binary from step 1, and
-# steps 4-5 would silently train+benchmark the baseline instead of the
-# instrumented build — producing a meaningless +0% comparison.
+# baseline at $TARGET_DIR/$HOST/dist/dora. Without it, if cargo-pgo's behavior
+# sends output elsewhere, the existence check below would pass against the
+# stale baseline binary from step 1, and steps 4-5 would silently
+# train+benchmark the baseline instead of the instrumented build — producing
+# a meaningless +0% comparison.
 echo ""
 echo "=== [3/5] PGO instrumented build (~10 min) ==="
 cargo pgo instrument build -- \
@@ -127,7 +131,7 @@ echo ""
 echo "=== [4/5] Training run + PGO optimize build (~7 min) ==="
 (
   cd examples/benchmark
-  LLVM_PROFILE_FILE="$REPO_ROOT/target/pgo-profiles/dora_%m_%p.profraw" \
+  LLVM_PROFILE_FILE="$TARGET_DIR/pgo-profiles/dora_%m_%p.profraw" \
     "$PGO_DORA" run dataflow.yml \
     > "$OUT_DIR/training.txt" 2>&1
 )

--- a/scripts/ros2-zenoh-interop.sh
+++ b/scripts/ros2-zenoh-interop.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+# shellcheck source=cargo-target-dir.sh
+source "$ROOT/scripts/cargo-target-dir.sh"
+TARGET_DIR="$(cargo_target_dir "$ROOT")"
 COMPOSE=(docker compose -f "$ROOT/docker-compose.ros2-zenoh.yml" --profile)
 CASES=(topic-pub topic-sub service-client service-server action-client action-server graph domain namespace qos-transient-local)
 DISTRO=${1:-}
@@ -44,7 +47,7 @@ timeout -k 30s 180 bash -c 'until [[ $(docker inspect -f "{{.State.Health.Status
   "source /opt/ros/$DISTRO/setup.bash; dpkg-query -W 'ros-${DISTRO}-rmw-zenoh-cpp'; ros2 pkg executables rmw_zenoh_cpp"
 
 container="${PROJECT}-${service}-1"
-export DORA_ROS2_ZENOH_ARTIFACTS="$ROOT/target/ros2-zenoh-logs/$PROJECT"
+export DORA_ROS2_ZENOH_ARTIFACTS="$TARGET_DIR/ros2-zenoh-logs/$PROJECT"
 export DORA_ROS2_ZENOH_PYTHON="$DORA_ROS2_ZENOH_ARTIFACTS/python"
 export DORA_ROS2_ZENOH_AMENT="$DORA_ROS2_ZENOH_ARTIFACTS/ament"
 if [[ -z "${DORA_ROS2_ZENOH_PYTHON_EXECUTABLE:-}" ]]; then
@@ -59,7 +62,7 @@ if [[ -z "${DORA_ROS2_ZENOH_PYTHON_EXECUTABLE:-}" ]]; then
 fi
 : "${DORA_ROS2_ZENOH_PYTHON_EXECUTABLE:?Python 3.11 or newer is required}"
 export DORA_ROS2_ZENOH_PYTHON_EXECUTABLE
-WHEEL_DIR="${CARGO_TARGET_DIR:-$ROOT/target}/wheels"
+WHEEL_DIR="$TARGET_DIR/wheels"
 mkdir -p "$DORA_ROS2_ZENOH_PYTHON" "$DORA_ROS2_ZENOH_AMENT"
 docker cp "$container:/opt/ros/$DISTRO/share" "$DORA_ROS2_ZENOH_AMENT/"
 maturin build --release --manifest-path "$ROOT/libraries/extensions/ros2-bridge/python/Cargo.toml"

--- a/scripts/smoke-all.sh
+++ b/scripts/smoke-all.sh
@@ -38,6 +38,10 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$ROOT"
 
+# shellcheck source=cargo-target-dir.sh
+source "$SCRIPT_DIR/cargo-target-dir.sh"
+TARGET_DIR="$(cargo_target_dir "$ROOT")"
+
 PASS=0
 FAIL=0
 SKIP=0
@@ -83,7 +87,7 @@ if [ "$VERBOSE" = false ] && [ "$SHOW_OUTPUT" = true ]; then
     echo "(tip: -v streams dora live; -q suppresses the per-example tail)"
 fi
 
-DORA="${DORA_BIN:-$ROOT/target/debug/dora}"
+DORA="${DORA_BIN:-$TARGET_DIR/debug/dora}"
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -130,15 +134,20 @@ cleanup_stale() {
     # goes away (see dora-rs/dora#1996), so reap any repo-local coordinator/daemon
     # stragglers. Otherwise they hold port 6013 or leave stale "Running" entries
     # that contaminate the next example's verdict.
-    pkill -f "$ROOT/target/debug/dora .*(coordinator|daemon)" > /dev/null 2>&1 || true
-    pkill -f "$ROOT/target/debug/dora-(coordinator|daemon|runtime)" > /dev/null 2>&1 || true
+    #
+    # These patterns scope to $TARGET_DIR, so when several git worktrees share
+    # one target dir they all resolve to the same binary path and this reaps
+    # across worktrees. That is unavoidable (the binary genuinely is one file),
+    # and concurrent smoke runs already contend on port 6013 anyway.
+    pkill -f "$TARGET_DIR/debug/dora .*(coordinator|daemon)" > /dev/null 2>&1 || true
+    pkill -f "$TARGET_DIR/debug/dora-(coordinator|daemon|runtime)" > /dev/null 2>&1 || true
     # Reap orphan example nodes that bind a FIXED port -- e.g. the MAVLink bridge
     # on udp:14550. If one lingers (hard-killed local run, or not self-exiting on
     # coordinator loss), the next mavlink example dies with "Address already in
     # use". These patterns only match the mavlink example binaries, so they're
     # no-ops for every other example.
-    pkill -f "$ROOT/target/(debug|release)/dora-mavlink2-bridge-node" > /dev/null 2>&1 || true
-    pkill -f "$ROOT/target/(debug|release)/mavlink2-bridge-example" > /dev/null 2>&1 || true
+    pkill -f "$TARGET_DIR/(debug|release)/dora-mavlink2-bridge-node" > /dev/null 2>&1 || true
+    pkill -f "$TARGET_DIR/(debug|release)/mavlink2-bridge-example" > /dev/null 2>&1 || true
     sleep 0.5
 }
 
@@ -179,8 +188,8 @@ ensure_python_bindings() {
         echo "        Python examples may fail with a version mismatch (pip install maturin)."
         return 0
     fi
-    local venv="$ROOT/target/smoke-venv"
-    echo "Setting up workspace Python bindings in target/smoke-venv (maturin build, first time ~1-3 min)..."
+    local venv="$TARGET_DIR/smoke-venv"
+    echo "Setting up workspace Python bindings in $venv (maturin build, first time ~1-3 min)..."
     uv venv --seed -p 3.12 "$venv" > /dev/null 2>&1 || uv venv --seed "$venv" > /dev/null 2>&1
     # shellcheck disable=SC1091
     source "$venv/bin/activate"


### PR DESCRIPTION
The QA and smoke scripts locate prebuilt binaries at `<repo>/target/...`, so they break whenever the target dir moves — a `CARGO_TARGET_DIR` override, or a `build.target-dir` in a `.cargo/config.toml`. The motivating case is one target dir shared across git worktrees, so third-party deps are compiled once instead of once per worktree.

Symptoms were `dora start` failing with `Could not find source path ../../target/debug/<bin>`, and `dora replay` silently falling through to `cargo install` from crates.io.

Adds `scripts/cargo-target-dir.sh`, which asks `cargo metadata` for `target_directory` — authoritative, since it already accounts for `CARGO_TARGET_DIR` and every config source cargo honors. It falls back to `<root>/target` only when cargo cannot answer at all (cargo or python3 missing, no reachable manifest), which reproduces the previous behavior exactly.

Converts all 29 hardcoded sites across `smoke-all.sh`, `qa/all.sh`, `qa/pgo.sh`, `qa/ci-nightly-jobs.sh` and `ros2-zenoh-interop.sh`. Two heredocs that generate dataflow descriptors are unquoted so the path interpolates, and two `REPO_ROOT` locals that became dead are dropped.

Verified with `./scripts/smoke-all.sh --rust-only` against a relocated target dir, plus `make qa-fast` (fmt/clippy/audit/unwrap-budget/typos all pass). The helper's four resolution paths — config-based, `CARGO_TARGET_DIR` override, no reachable manifest, no `python3` — were each exercised directly.

Two things deliberately left out of scope:

- `dora_cli::command::node_binary::search` honors `CARGO_TARGET_DIR` but not `build.target-dir`, so `dora replay` can still miss `dora-replay-node` under a relocated target dir. That is production code in `dora-cli` and wants its own change with a test.
- 42 example dataflow descriptors hardcode `path: ../../target/debug/<bin>`, which dora resolves relative to the descriptor. Those relative paths are what users copy into their own projects, so they should stay; a `target` symlink is the right local workaround.
