### PR TITLE
docs(cli): attach `--env` help to the right field in `dora start`

### DIFF
--- a/binaries/cli/src/command/start/mod.rs
+++ b/binaries/cli/src/command/start/mod.rs
@@ -47,19 +47,6 @@ pub struct Start {
     /// Enable debug mode (publishes all messages to Zenoh for topic echo/hz/info)
     #[clap(long, action)]
     debug: bool,
-    /// Set an environment variable for every node of this dataflow
-    /// (repeatable). Merges into the dataflow-level `env:` block;
-    /// node-level `env:` entries still win on conflict.
-    ///
-    /// Nodes started via `dora start` are spawned by the DAEMON and do
-    /// NOT inherit this CLI invocation's environment — `--env` is the
-    /// supported way to parameterize a run without editing the YAML.
-    /// Applies at spawn time only; `build:` commands are unaffected.
-    /// Values must survive the descriptor encoding verbatim: a literal
-    /// `$` is refused (the receiving process would expand it) and so are
-    /// numeric-looking values that would be coerced. They are also
-    /// persisted with the dataflow in the coordinator's state store and
-    /// visible in `ps` — prefer a node `env:` block for secrets.
     /// Exit once every node has finished, treating `dora/timer/...`
     /// inputs as a clock rather than as work.
     ///
@@ -84,6 +71,19 @@ pub struct Start {
         value_name = "BOOL"
     )]
     pub exit_when_nodes_finish: Option<bool>,
+    /// Set an environment variable for every node of this dataflow
+    /// (repeatable). Merges into the dataflow-level `env:` block;
+    /// node-level `env:` entries still win on conflict.
+    ///
+    /// Nodes started via `dora start` are spawned by the DAEMON and do
+    /// NOT inherit this CLI invocation's environment — `--env` is the
+    /// supported way to parameterize a run without editing the YAML.
+    /// Applies at spawn time only; `build:` commands are unaffected.
+    /// Values must survive the descriptor encoding verbatim: a literal
+    /// `$` is refused (the receiving process would expand it) and so are
+    /// numeric-looking values that would be coerced. They are also
+    /// persisted with the dataflow in the coordinator's state store and
+    /// visible in `ps` — prefer a node `env:` block for secrets.
     #[clap(long = "env", value_name = "KEY=VALUE")]
     env: Vec<String>,
 }


### PR DESCRIPTION
## Issue

In `binaries/cli/src/command/start/mod.rs`, the `env` field's doc-comment block was written *above* the `exit_when_nodes_finish` field, with no field in between:

```rust
/// Set an environment variable for every node of this dataflow
/// ... (env docs) ...
/// visible in `ps` — prefer a node `env:` block for secrets.
/// Exit once every node has finished, treating `dora/timer/...`   // exit_when_nodes_finish docs
/// ...
#[clap(long, num_args = 0..=1, ...)]
pub exit_when_nodes_finish: Option<bool>,
#[clap(long = "env", value_name = "KEY=VALUE")]
env: Vec<String>,   // <- no doc comment
```

In clap's derive (like Rust doc comments) a `///` block attaches to the **next item**. So both blocks concatenated onto `exit_when_nodes_finish`, and `env` got none. The result in `dora start --help`:

- `--exit-when-nodes-finish <BOOL>` — help text begins *"Set an environment variable for every node of this dataflow…"* (wrong).
- `--env <KEY=VALUE>` — **no description** at all.

The sibling `dora run` command (`run.rs`) has the correct layout — one doc block per field — so `start` was the regressed copy.

## Fix

Reorder the two doc blocks so each sits directly above its own field, mirroring `run.rs`. This is a pure doc-comment move — no logic, no flag, and no behavior changes.

## Validation

- `cargo +1.97.1 fmt -p dora-cli -- --check` — clean.
- `cargo +1.97.1 clippy -p dora-cli -- -D warnings` — clean (compiles with the change).

---

⚠️ _This is a machine-generated pull request authored by Claude (Claude Code). A human should review before merging._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1Fmp8pELuTiPGTStomkZj)_