### PR TITLE
fix(cli): reject a malformed coordinator address/port in `dora up`

### DIFF
--- a/binaries/cli/src/command/up.rs
+++ b/binaries/cli/src/command/up.rs
@@ -49,14 +49,21 @@ struct UpConfig {}
 
 pub(crate) fn up(config_path: Option<&Path>, auth: bool, recreate_store: bool) -> eyre::Result<()> {
     let UpConfig {} = parse_dora_config(config_path)?;
-    let addr: std::net::IpAddr = std::env::var("DORA_COORDINATOR_ADDR")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(LOCALHOST);
-    let port: u16 = std::env::var("DORA_COORDINATOR_PORT")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(DORA_COORDINATOR_PORT_WS_DEFAULT);
+    // Surface a malformed value instead of silently falling back to the
+    // default: every other lifecycle command reads these env vars through
+    // clap's typed `env=` on `CoordinatorOptions`, which errors on an
+    // unparseable value. If `dora up` quietly ignored a typo it would bind a
+    // different port than `dora stop`/`list`/`down` then look for.
+    let addr: std::net::IpAddr = coordinator_env_value(
+        "DORA_COORDINATOR_ADDR",
+        std::env::var("DORA_COORDINATOR_ADDR").ok().as_deref(),
+        LOCALHOST,
+    )?;
+    let port: u16 = coordinator_env_value(
+        "DORA_COORDINATOR_PORT",
+        std::env::var("DORA_COORDINATOR_PORT").ok().as_deref(),
+        DORA_COORDINATOR_PORT_WS_DEFAULT,
+    )?;
     let coordinator_addr = (addr, port).into();
     if recreate_store && !addr.is_loopback() {
         bail!(
@@ -108,6 +115,24 @@ pub(crate) fn up(config_path: Option<&Path>, auth: bool, recreate_store: bool) -
     }
 
     Ok(())
+}
+
+/// Resolve a coordinator connection env var: `None` (unset) yields `default`,
+/// but a value that is present yet unparseable is a hard error rather than a
+/// silent fallback. This mirrors the strictness of clap's typed `env=` on
+/// `CoordinatorOptions`, so `dora up` and the other lifecycle commands agree
+/// on where the coordinator lives.
+fn coordinator_env_value<T>(var_name: &str, raw: Option<&str>, default: T) -> eyre::Result<T>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    match raw {
+        Some(s) => s
+            .parse()
+            .map_err(|e| eyre::eyre!("invalid {var_name}: {s:?} ({e})")),
+        None => Ok(default),
+    }
 }
 
 fn attach_to_running_coordinator(
@@ -680,6 +705,58 @@ mod tests {
             .expect("second recreation did not acquire the released lock");
         drop(second);
         waiter.join().expect("join lock waiter");
+    }
+}
+
+#[cfg(test)]
+mod coordinator_env_tests {
+    use super::{DORA_COORDINATOR_PORT_WS_DEFAULT, LOCALHOST, coordinator_env_value};
+    use std::net::IpAddr;
+
+    #[test]
+    fn unset_uses_default() {
+        let addr: IpAddr = coordinator_env_value("DORA_COORDINATOR_ADDR", None, LOCALHOST).unwrap();
+        assert_eq!(addr, LOCALHOST);
+        let port: u16 = coordinator_env_value(
+            "DORA_COORDINATOR_PORT",
+            None,
+            DORA_COORDINATOR_PORT_WS_DEFAULT,
+        )
+        .unwrap();
+        assert_eq!(port, DORA_COORDINATOR_PORT_WS_DEFAULT);
+    }
+
+    #[test]
+    fn valid_value_is_parsed() {
+        let addr: IpAddr =
+            coordinator_env_value("DORA_COORDINATOR_ADDR", Some("10.0.0.5"), LOCALHOST).unwrap();
+        assert_eq!(addr, "10.0.0.5".parse::<IpAddr>().unwrap());
+        let port: u16 = coordinator_env_value(
+            "DORA_COORDINATOR_PORT",
+            Some("6100"),
+            DORA_COORDINATOR_PORT_WS_DEFAULT,
+        )
+        .unwrap();
+        assert_eq!(port, 6100);
+    }
+
+    #[test]
+    fn malformed_value_errors_instead_of_defaulting() {
+        // Regression: `dora up` previously swallowed a parse error via
+        // `.and_then(|s| s.parse().ok()).unwrap_or(default)`, silently binding
+        // the default port while every other command errored on the same typo.
+        let err = coordinator_env_value::<u16>(
+            "DORA_COORDINATOR_PORT",
+            Some("not-a-port"),
+            DORA_COORDINATOR_PORT_WS_DEFAULT,
+        )
+        .expect_err("a malformed port must be rejected, not defaulted");
+        assert!(format!("{err:#}").contains("DORA_COORDINATOR_PORT"));
+
+        assert!(
+            coordinator_env_value::<IpAddr>("DORA_COORDINATOR_ADDR", Some("999.1.1.1"), LOCALHOST)
+                .is_err()
+        );
     }
 }
 

--- a/binaries/cli/src/command/up.rs
+++ b/binaries/cli/src/command/up.rs
@@ -54,16 +54,9 @@ pub(crate) fn up(config_path: Option<&Path>, auth: bool, recreate_store: bool) -
     // clap's typed `env=` on `CoordinatorOptions`, which errors on an
     // unparseable value. If `dora up` quietly ignored a typo it would bind a
     // different port than `dora stop`/`list`/`down` then look for.
-    let addr: std::net::IpAddr = coordinator_env_value(
-        "DORA_COORDINATOR_ADDR",
-        std::env::var("DORA_COORDINATOR_ADDR").ok().as_deref(),
-        LOCALHOST,
-    )?;
-    let port: u16 = coordinator_env_value(
-        "DORA_COORDINATOR_PORT",
-        std::env::var("DORA_COORDINATOR_PORT").ok().as_deref(),
-        DORA_COORDINATOR_PORT_WS_DEFAULT,
-    )?;
+    let addr: std::net::IpAddr = coordinator_env_value("DORA_COORDINATOR_ADDR", LOCALHOST)?;
+    let port: u16 =
+        coordinator_env_value("DORA_COORDINATOR_PORT", DORA_COORDINATOR_PORT_WS_DEFAULT)?;
     let coordinator_addr = (addr, port).into();
     if recreate_store && !addr.is_loopback() {
         bail!(
@@ -117,12 +110,22 @@ pub(crate) fn up(config_path: Option<&Path>, auth: bool, recreate_store: bool) -
     Ok(())
 }
 
-/// Resolve a coordinator connection env var: `None` (unset) yields `default`,
-/// but a value that is present yet unparseable is a hard error rather than a
-/// silent fallback. This mirrors the strictness of clap's typed `env=` on
+/// Resolve a coordinator connection env var: unset yields `default`, but a
+/// value that is present yet unparseable is a hard error rather than a silent
+/// fallback. This mirrors the strictness of clap's typed `env=` on
 /// `CoordinatorOptions`, so `dora up` and the other lifecycle commands agree
 /// on where the coordinator lives.
-fn coordinator_env_value<T>(var_name: &str, raw: Option<&str>, default: T) -> eyre::Result<T>
+fn coordinator_env_value<T>(var_name: &str, default: T) -> eyre::Result<T>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    parse_coordinator_env(var_name, std::env::var(var_name).ok().as_deref(), default)
+}
+
+/// Testable core of [`coordinator_env_value`], split out so tests can supply a
+/// raw value without touching the process-global environment.
+fn parse_coordinator_env<T>(var_name: &str, raw: Option<&str>, default: T) -> eyre::Result<T>
 where
     T: std::str::FromStr,
     T::Err: std::fmt::Display,
@@ -710,14 +713,14 @@ mod tests {
 
 #[cfg(test)]
 mod coordinator_env_tests {
-    use super::{DORA_COORDINATOR_PORT_WS_DEFAULT, LOCALHOST, coordinator_env_value};
+    use super::{DORA_COORDINATOR_PORT_WS_DEFAULT, LOCALHOST, parse_coordinator_env};
     use std::net::IpAddr;
 
     #[test]
     fn unset_uses_default() {
-        let addr: IpAddr = coordinator_env_value("DORA_COORDINATOR_ADDR", None, LOCALHOST).unwrap();
+        let addr: IpAddr = parse_coordinator_env("DORA_COORDINATOR_ADDR", None, LOCALHOST).unwrap();
         assert_eq!(addr, LOCALHOST);
-        let port: u16 = coordinator_env_value(
+        let port: u16 = parse_coordinator_env(
             "DORA_COORDINATOR_PORT",
             None,
             DORA_COORDINATOR_PORT_WS_DEFAULT,
@@ -729,9 +732,9 @@ mod coordinator_env_tests {
     #[test]
     fn valid_value_is_parsed() {
         let addr: IpAddr =
-            coordinator_env_value("DORA_COORDINATOR_ADDR", Some("10.0.0.5"), LOCALHOST).unwrap();
+            parse_coordinator_env("DORA_COORDINATOR_ADDR", Some("10.0.0.5"), LOCALHOST).unwrap();
         assert_eq!(addr, "10.0.0.5".parse::<IpAddr>().unwrap());
-        let port: u16 = coordinator_env_value(
+        let port: u16 = parse_coordinator_env(
             "DORA_COORDINATOR_PORT",
             Some("6100"),
             DORA_COORDINATOR_PORT_WS_DEFAULT,
@@ -745,7 +748,7 @@ mod coordinator_env_tests {
         // Regression: `dora up` previously swallowed a parse error via
         // `.and_then(|s| s.parse().ok()).unwrap_or(default)`, silently binding
         // the default port while every other command errored on the same typo.
-        let err = coordinator_env_value::<u16>(
+        let err = parse_coordinator_env::<u16>(
             "DORA_COORDINATOR_PORT",
             Some("not-a-port"),
             DORA_COORDINATOR_PORT_WS_DEFAULT,
@@ -754,7 +757,7 @@ mod coordinator_env_tests {
         assert!(format!("{err:#}").contains("DORA_COORDINATOR_PORT"));
 
         assert!(
-            coordinator_env_value::<IpAddr>("DORA_COORDINATOR_ADDR", Some("999.1.1.1"), LOCALHOST)
+            parse_coordinator_env::<IpAddr>("DORA_COORDINATOR_ADDR", Some("999.1.1.1"), LOCALHOST)
                 .is_err()
         );
     }


### PR DESCRIPTION
## Issue

`dora up` resolved the coordinator location from `DORA_COORDINATOR_ADDR` / `DORA_COORDINATOR_PORT` like this (`binaries/cli/src/command/up.rs`):

```rust
let addr: std::net::IpAddr = std::env::var("DORA_COORDINATOR_ADDR")
    .ok().and_then(|s| s.parse().ok()).unwrap_or(LOCALHOST);
let port: u16 = std::env::var("DORA_COORDINATOR_PORT")
    .ok().and_then(|s| s.parse().ok()).unwrap_or(DORA_COORDINATOR_PORT_WS_DEFAULT);
```

`.and_then(|s| s.parse().ok())` throws away a parse **error**, so a present-but-unparseable value silently falls back to the default. Every *other* lifecycle command reads the same two env vars through clap's typed `env=` on `CoordinatorOptions` (`common.rs`), which **errors** on an unparseable value.

The result is a silent divergence: `DORA_COORDINATOR_PORT=abc dora up` starts a coordinator on the **default** port `53290`, while `dora stop` / `dora list` / `dora down` abort with `invalid value for '--coordinator-port'` — so they can no longer find the coordinator that `up` just started.

## Fix

Add a small `coordinator_env_value` helper that returns the default **only** when the variable is unset, and returns an error when it is set but unparseable — mirroring the strictness of `CoordinatorOptions`. Route both reads through it. Behavior is unchanged for the unset case and for valid values.

## Validation

- Added unit tests (`coordinator_env_tests`): unset → default, valid → parsed, malformed → error (not defaulted).
- `cargo +1.97.1 fmt -p dora-cli -- --check` — clean.
- `cargo +1.97.1 clippy -p dora-cli -- -D warnings` — clean.
- `cargo +1.97.1 test -p dora-cli coordinator_env` — 3 passed.

---

⚠️ _This is a machine-generated pull request authored by Claude (Claude Code). A human should review before merging._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1Fmp8pELuTiPGTStomkZj)_