### PR TITLE
perf(daemon): drop the per-log-line String reallocation in the log task

### DIFF
--- a/binaries/daemon/src/spawn/prepared.rs
+++ b/binaries/daemon/src/spawn/prepared.rs
@@ -88,6 +88,20 @@ fn truncate_log_line(content: &mut String) {
     }
 }
 
+/// Drop a single trailing line terminator (`\n`, or `\r\n`) from an owned
+/// log line, in place. `content` holds one logical line (the reader stops at
+/// the first `\n`), so this reproduces what `content.lines().next()` would
+/// yield without allocating a new `String`.
+fn strip_trailing_newline(mut content: String) -> String {
+    if content.ends_with('\n') {
+        content.pop();
+        if content.ends_with('\r') {
+            content.pop();
+        }
+    }
+    content
+}
+
 /// Read a single log line from `reader`, buffering at most
 /// `MAX_LOG_LINE_BYTES + 1` bytes into `raw`. Returns `Ok(true)` once the
 /// stream reaches EOF (nothing more to read).
@@ -948,10 +962,11 @@ impl PreparedNode {
                     }
                 }
 
-                let formatted = content.lines().fold(String::default(), |mut output, line| {
-                    output.push_str(line);
-                    output
-                });
+                // `content` is a single logical line (the reader stops at the
+                // first `\n`), so this only needs to drop the trailing line
+                // terminator. Reuse the already-owned buffer instead of
+                // allocating and copying a fresh String on every log line.
+                let formatted = strip_trailing_newline(content);
 
                 // Build a LogMessage for both file writing and channel forwarding
                 let log_message = match serde_json::de::from_str::<LogMessageHelper>(&formatted) {
@@ -1156,6 +1171,38 @@ struct RestartLoopReceivers {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn strip_trailing_newline_matches_lines_for_single_line() {
+        // The previous implementation was
+        // `content.lines().fold(String::new(), |mut o, l| { o.push_str(l); o })`.
+        // For the single-line inputs the reader produces, the in-place strip
+        // must be byte-for-byte identical.
+        let old = |content: &str| -> String {
+            content.lines().fold(String::new(), |mut output, line| {
+                output.push_str(line);
+                output
+            })
+        };
+        for case in [
+            "hello",
+            "hello\n",
+            "hello\r\n",
+            "hello\r",
+            "",
+            "\n",
+            "\r\n",
+            "a\rb\n",
+            "trailing spaces  \n",
+            "... [truncated]",
+        ] {
+            assert_eq!(
+                strip_trailing_newline(case.to_string()),
+                old(case),
+                "mismatch for {case:?}"
+            );
+        }
+    }
 
     /// Deserialize from YAML (mirroring `dora_core::build` tests) to avoid
     /// coupling this fixture to ResolvedNode's exact field list.


### PR DESCRIPTION
## Issue

The daemon's per-node file-logging task ran this for **every** log line of **every** spawned node (`binaries/daemon/src/spawn/prepared.rs`):

```rust
let formatted = content.lines().fold(String::default(), |mut output, line| {
    output.push_str(line);
    output
});
```

`content` is an owned `String` moved out of the `LogLine` and not used afterward. It holds a single logical line — `read_capped_line` stops at the first `\n` — so this fold does nothing but strip the trailing newline, yet it heap-allocates a brand-new `String` and copies the entire line byte-for-byte. On a node logging at high frequency that's an allocation + full copy per line, on the log hot path, for no benefit.

## Fix

Introduce a small `strip_trailing_newline(String) -> String` helper that pops a trailing `\n` (and a preceding `\r`) from the already-owned buffer in place, and use it instead of the fold. No allocation, no copy.

For the single-line inputs the reader produces, the result is byte-for-byte identical to `content.lines().next()`.

## Validation

- Added `strip_trailing_newline_matches_lines_for_single_line`, which diffs the helper against the **old** `.lines().fold(...)` implementation across `\n`, `\r\n`, bare `\r`, empty, mid-line `\r`, trailing-spaces, and truncated-marker cases.
- `cargo +1.97.1 fmt -p dora-daemon -- --check` — clean.
- `cargo +1.97.1 clippy -p dora-daemon -- -D warnings` — clean.
- `cargo +1.97.1 test -p dora-daemon strip_trailing` — passes.

---

⚠️ _This is a machine-generated pull request authored by Claude (Claude Code). A human should review before merging._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1Fmp8pELuTiPGTStomkZj)_