### PR TITLE
test(message): deflake HLC timestamp serde_json::Value round-trip test

### DIFF
--- a/libraries/message/tests/uhlc_wire_format.rs
+++ b/libraries/message/tests/uhlc_wire_format.rs
@@ -147,12 +147,20 @@ fn timestamp_survives_a_serde_json_value_round_trip() {
 }
 
 #[test]
-fn a_freshly_generated_hlc_id_uses_all_sixteen_bytes() {
-    // Guards the premise of the test above: if `HLC::default()` ever produced a
-    // short id, the `serde_json::Value` round trip would pass for reasons that
-    // do not generalize to production timestamps.
+fn a_freshly_generated_hlc_timestamp_survives_a_serde_json_value_round_trip() {
+    // Companion to `timestamp_survives_a_serde_json_value_round_trip`, which pins
+    // the property on the deterministic full-width `golden_timestamp` (top byte
+    // `0x10`, so it exceeds `u64`): confirm a *real* `HLC::default()` timestamp
+    // also survives `serde_json::Value`.
+    //
+    // We deliberately do NOT assert that the id uses all sixteen bytes. Under
+    // uhlc 0.9 `HLC::default()` seeds its id with a uniformly random 128-bit
+    // value (`ID::rand()`), whose most-significant byte is zero ~1/256 of the
+    // time, so `size() == 16` is probabilistic and would flake ~1 run in 256
+    // (dora-rs/dora#3104). The round trip below is lossless for an id of any
+    // width — that, not the byte count of a random id, is the property that
+    // matters here.
     let timestamp = dora_message::uhlc::HLC::default().new_timestamp();
-    assert_eq!(timestamp.get_id().size(), 16);
 
     let value = serde_json::to_value(Timestamped {
         inner: (),


### PR DESCRIPTION
## Summary

Fixes #3104.

The test `a_freshly_generated_hlc_id_uses_all_sixteen_bytes` in `libraries/message/tests/uhlc_wire_format.rs` was non-deterministic and failed on roughly **1 in 256** `cargo test` runs. Because `dora-message` is exercised by `cargo test --all` in both the PR gate and nightly, this introduced an intermittent, hard-to-reproduce CI failure.

## Root cause

Under uhlc 0.9, `HLC::default()` seeds its id via `ID::rand()` — a uniformly random 128-bit value. `ID::size()` returns the number of *significant* little-endian bytes, so `size() == 16` only holds when the most-significant byte is non-zero. That byte is zero with probability `1/256`, so the assertion `assert_eq!(timestamp.get_id().size(), 16)` failed ~0.39% of the time. Under uhlc 0.5 the id was seeded from a UUID whose top bits were fixed version/variant nibbles, so it was effectively always 16 bytes — the assertion was implicitly safe then and became flaky after the 0.5 → 0.9 bump (#3016).

No production path depends on `size() == 16`; the JSON round-trip works for any non-zero id. This is a test-quality defect, not a runtime bug.

## Fix

The full-width (`> u64`) property is already pinned **deterministically** by `timestamp_survives_a_serde_json_value_round_trip`, which uses `golden_timestamp` (top byte `0x10`). This test's remaining value is confirming that a *real*, randomly-generated `HLC::default()` timestamp survives the `serde_json::Value` round trip — which is lossless for an id of any width.

So the probabilistic `size()` assertion is dropped and the real-HLC round-trip check is kept (and the test renamed accordingly). This removes the flakiness while preserving the real-HLC coverage the original test added, on top of the deterministic full-width coverage that already exists.

## Testing

- `cargo test -p dora-message --test uhlc_wire_format` — all 7 tests pass.
- `cargo fmt -p dora-message -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZXbbi2V3Dw4174Xn3AgMX

---
_Generated by [Claude Code](https://claude.ai/code/session_01EZXbbi2V3Dw4174Xn3AgMX)_