### PR TITLE
fix(message): don't mislabel signal 23 as SIGURG on macOS/BSD daemon hosts

### DIFF
--- a/libraries/message/src/common.rs
+++ b/libraries/message/src/common.rs
@@ -140,8 +140,23 @@ impl std::fmt::Display for NodeError {
                     13 => "SIGPIPE".into(),
                     14 => "SIGALRM".into(),
                     15 => "SIGTERM".into(),
+                    // Signals 1..=22 above share the same number on every Unix
+                    // dora targets. Numbers past that diverge — signal 23 is
+                    // SIGURG on Linux but SIGIO on macOS/BSD — so name 23 per
+                    // target OS and fall back to the raw number on any other
+                    // platform rather than printing a wrong name.
                     22 => "SIGTTOU".into(),
+                    #[cfg(any(target_os = "linux", target_os = "android"))]
                     23 => "SIGURG".into(),
+                    #[cfg(any(
+                        target_os = "macos",
+                        target_os = "ios",
+                        target_os = "freebsd",
+                        target_os = "openbsd",
+                        target_os = "netbsd",
+                        target_os = "dragonfly"
+                    ))]
+                    23 => "SIGIO".into(),
                     other => other.to_string().into(),
                 };
                 if matches!(self.cause, NodeErrorCause::GraceDuration) {
@@ -399,8 +414,23 @@ mod tests {
     }
 
     #[test]
-    fn node_error_signal_display_uses_linux_signal_names() {
-        for (signal, name) in [(6, "SIGABRT"), (22, "SIGTTOU"), (23, "SIGURG")] {
+    fn node_error_signal_display_uses_platform_signal_names() {
+        // Portable across every Unix dora targets.
+        let mut cases = vec![(6, "SIGABRT"), (22, "SIGTTOU")];
+        // Signal 23 diverges: SIGURG on Linux, SIGIO on macOS/BSD.
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        cases.push((23, "SIGURG"));
+        #[cfg(any(
+            target_os = "macos",
+            target_os = "ios",
+            target_os = "freebsd",
+            target_os = "openbsd",
+            target_os = "netbsd",
+            target_os = "dragonfly"
+        ))]
+        cases.push((23, "SIGIO"));
+
+        for (signal, name) in cases {
             assert_eq!(
                 node_error_with_signal(signal).to_string(),
                 format!("exited because of signal {name}")


### PR DESCRIPTION
## Issue

`NodeError`'s `Display` impl (`libraries/message/src/common.rs`) maps `NodeExitStatus::Signal(n)` to a signal name from a hard-coded table:

```rust
22 => "SIGTTOU".into(),
23 => "SIGURG".into(),
other => other.to_string().into(),
```

Those are the Linux/glibc numbers. But `NodeExitStatus::Signal` is produced from `ExitStatus::signal()` under `#[cfg(unix)]` (same file), which also covers macOS and the BSDs — and signal numbers past the portable POSIX range diverge there:

| number | Linux | macOS / BSD |
|-------:|-------|-------------|
| 23 | `SIGURG` | **`SIGIO`** |

So a node killed by signal 23 on a macOS/BSD daemon host was reported as `SIGURG` when it was actually `SIGIO`. (Severity is low — it only affects the human-readable message, not control flow — but it is a genuine cross-platform mislabel, and the test was even named `..._uses_linux_signal_names`, baking in the assumption silently.)

## Fix

Signals `1..=22` in the table share the same number on every Unix dora targets, so they stay unconditional. Name signal 23 per target OS and fall back to the raw number on any other platform rather than printing a wrong name:

```rust
22 => "SIGTTOU".into(),
#[cfg(any(target_os = "linux", target_os = "android"))]
23 => "SIGURG".into(),
#[cfg(any(target_os = "macos", target_os = "ios", target_os = "freebsd",
          target_os = "openbsd", target_os = "netbsd", target_os = "dragonfly"))]
23 => "SIGIO".into(),
other => other.to_string().into(),
```

The existing test is renamed to `node_error_signal_display_uses_platform_signal_names` and made platform-aware, so the **macOS nightly CI job actually exercises the `SIGIO` mapping**.

## Validation

```
cargo test -p dora-message      # 140 passed (incl. the updated signal test)
cargo clippy -p dora-message -- -D warnings
cargo fmt --all -- --check
```

Verified against 1.97.1 (the CI-pinned toolchain).

---

⚠️ **This is a machine-generated PR** authored by Claude (Claude Code) as part of an automated codebase review. The finding was verified by hand against `origin/main` before opening. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PYiYgEo2WKBXfGooqP2WG5)_