### PR TITLE
fix(coordinator): reject Stop/StopByName on a dataflow with a pending…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -412,6 +412,15 @@ jobs:
         run: >
           cargo test -p dora-examples --test finish-straggler-e2e -- --test-threads=1
         timeout-minutes: 10
+      # Coordinator Stop-vs-Restart race regression: a `Stop` landing while
+      # a `Restart` is pending must cancel the restart and actually stop the
+      # dataflow, not report success while a new incarnation keeps running.
+      # Lives in `dora-examples` (excluded from the bulk `cargo test --all`
+      # step), so it needs an explicit invocation.
+      - name: Run coordinator stop/restart race E2E
+        run: >
+          cargo test -p dora-examples --test stop-restart-race-e2e -- --test-threads=1
+        timeout-minutes: 10
 
   # Semantic contract tests — promoted from nightly per #1632.
   #

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -3525,13 +3525,14 @@ async fn check_spawn_timeouts(
             // reachable from any other code path; defensive.)
             continue;
         };
-        // A restart can be pending for a dataflow whose spawn (the new
-        // incarnation `initiate_restart` kicked off) is itself the one
-        // that got stuck — `running_dataflows` only needs to contain the
-        // UUID, which it does while the spawn is pending. Without this,
-        // the entry would never drain (only `DataflowFinishedOnDaemon`
-        // and the daemon-disconnect path do), permanently wedging both
-        // the parked restart caller and any future `Stop` for this UUID.
+        // `PendingRestart` is keyed by this (old) UUID: `initiate_restart`
+        // only requires the UUID to be present in `running_dataflows`,
+        // which it is while this very spawn is stuck — i.e. a restart was
+        // requested for this dataflow while it was still spawning, before
+        // this watchdog gave up on it. Without this, the entry would never
+        // drain (only `DataflowFinishedOnDaemon` and the daemon-disconnect
+        // path do), permanently wedging both the parked restart caller and
+        // any future `Stop` for this UUID.
         cancel_pending_restart(
             pending_restarts,
             uuid,

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -896,19 +896,23 @@ async fn start_inner(
                             // A pending restart already sent `StopDataflow` to
                             // the daemon(s) and is waiting for
                             // `DataflowFinishedOnDaemon` to spawn the new
-                            // incarnation under a fresh UUID. `running_dataflows`
-                            // still contains the old UUID in the meantime, so
-                            // without this guard `stop_dataflow` below would
-                            // "succeed" against the old UUID while the restart
-                            // silently spawns a new one that keeps running —
-                            // the stop caller would see success but the
-                            // dataflow is still alive under a different UUID.
-                            if pending_restarts.contains_key(&dataflow_uuid) {
-                                let _ = reply_sender.send(Err(eyre!(
-                                    "dataflow `{dataflow_uuid}` is being restarted – cannot stop it until the restart finishes"
-                                )));
-                                continue;
-                            }
+                            // incarnation under a fresh UUID; `running_dataflows`
+                            // still contains the old UUID in the meantime. An
+                            // explicit `Stop` for that UUID means the caller
+                            // wants the dataflow gone, not restarted — cancel
+                            // the pending restart (erroring its caller) rather
+                            // than letting it silently spawn a new incarnation
+                            // after this stop reports success. Last-writer-wins,
+                            // and unlike an outright rejection this doesn't
+                            // block `--force` from ever landing while a
+                            // long-`--grace-duration` restart is in flight.
+                            cancel_pending_restart(
+                                &mut pending_restarts,
+                                dataflow_uuid,
+                                format!(
+                                    "dataflow `{dataflow_uuid}` was stopped before the restart could complete"
+                                ),
+                            );
 
                             // `dataflow_results` is filled incrementally, one
                             // entry per daemon, while a multi-daemon dataflow is
@@ -963,14 +967,15 @@ async fn start_inner(
                             force,
                         } => match resolve_name(name, &running_dataflows, &archived_dataflows) {
                             Ok(dataflow_uuid) => {
-                                // Same pending-restart guard as `Stop` — see
-                                // the comment there for why this is needed.
-                                if pending_restarts.contains_key(&dataflow_uuid) {
-                                    let _ = reply_sender.send(Err(eyre!(
-                                        "dataflow `{dataflow_uuid}` is being restarted – cannot stop it until the restart finishes"
-                                    )));
-                                    continue;
-                                }
+                                // Same pending-restart cancellation as `Stop`
+                                // — see the comment there for why.
+                                cancel_pending_restart(
+                                    &mut pending_restarts,
+                                    dataflow_uuid,
+                                    format!(
+                                        "dataflow `{dataflow_uuid}` was stopped before the restart could complete"
+                                    ),
+                                );
 
                                 // Same partial-completion guard as `Stop`: a
                                 // still-running multi-daemon dataflow has a
@@ -2129,6 +2134,7 @@ async fn start_inner(
                     &mut archived_dataflows,
                     &mut dataflow_results,
                     &mut daemon_connections,
+                    &mut pending_restarts,
                     &clock,
                     store.as_ref(),
                 )
@@ -3061,6 +3067,21 @@ enum DisconnectAction {
     ReclaimOrphaned(DataflowId),
 }
 
+/// Cancel a pending restart for `uuid`, if one exists: removes it from
+/// `pending_restarts` and replies to the parked restart caller with `Err`
+/// explaining why. No-op if there is no pending restart for `uuid`.
+fn cancel_pending_restart(
+    pending_restarts: &mut HashMap<DataflowId, PendingRestart>,
+    uuid: DataflowId,
+    reason: impl std::fmt::Display,
+) {
+    if let Some(restart) = pending_restarts.remove(&uuid) {
+        let reason = reason.to_string();
+        tracing::warn!(dataflow = %uuid, "cancelling pending restart: {reason}");
+        let _ = restart.reply_sender.send(Err(eyre!("{reason}")));
+    }
+}
+
 fn cleanup_disconnected_daemons_from_running_dataflows(
     running_dataflows: &mut HashMap<DataflowId, RunningDataflow>,
     disconnected: &BTreeSet<DaemonId>,
@@ -3103,15 +3124,11 @@ fn cleanup_disconnected_daemons_from_running_dataflows(
     // daemon(s) will never send DataflowFinishedOnDaemon, so any caller
     // waiting on a deferred restart would hang indefinitely (#2082 H1).
     for uuid in &affected_uuids {
-        if let Some(restart) = pending_restarts.remove(uuid) {
-            tracing::warn!(
-                dataflow = %uuid,
-                "daemon disconnected while restart was pending; cancelling restart"
-            );
-            let _ = restart.reply_sender.send(Err(eyre!(
-                "daemon disconnected while restart was pending for dataflow `{uuid}`"
-            )));
-        }
+        cancel_pending_restart(
+            pending_restarts,
+            *uuid,
+            format!("daemon disconnected while restart was pending for dataflow `{uuid}`"),
+        );
     }
     actions
 }
@@ -3427,6 +3444,7 @@ async fn check_spawn_timeouts(
     archived_dataflows: &mut IndexMap<DataflowId, ArchivedDataflow>,
     dataflow_results: &mut IndexMap<DataflowId, BTreeMap<DaemonId, DataflowDaemonResult>>,
     daemon_connections: &mut DaemonConnections,
+    pending_restarts: &mut HashMap<DataflowId, PendingRestart>,
     clock: &HLC,
     store: &dyn CoordinatorStore,
 ) {
@@ -3507,6 +3525,18 @@ async fn check_spawn_timeouts(
             // reachable from any other code path; defensive.)
             continue;
         };
+        // A restart can be pending for a dataflow whose spawn (the new
+        // incarnation `initiate_restart` kicked off) is itself the one
+        // that got stuck — `running_dataflows` only needs to contain the
+        // UUID, which it does while the spawn is pending. Without this,
+        // the entry would never drain (only `DataflowFinishedOnDaemon`
+        // and the daemon-disconnect path do), permanently wedging both
+        // the parked restart caller and any future `Stop` for this UUID.
+        cancel_pending_restart(
+            pending_restarts,
+            uuid,
+            format!("dataflow `{uuid}`'s spawn timed out while a restart was pending"),
+        );
         let err_msg = format!(
             "spawn timed out after {}s; {} daemon(s) never reported \
              spawn_result; rolled back {} previously-started daemon(s)",
@@ -4734,6 +4764,10 @@ async fn initiate_restart(
             reply_sender,
         },
     );
+    // Logged (rather than left silent) so a test can poll for the exact
+    // moment the restart becomes cancellable via a `Stop`, instead of
+    // guessing a fixed delay.
+    tracing::info!(dataflow = %dataflow_uuid, "restart pending; waiting for dataflow to finish stopping");
 }
 
 #[cfg(test)]
@@ -6585,12 +6619,14 @@ mod tests {
         let mut archived_dataflows: IndexMap<DataflowId, ArchivedDataflow> = IndexMap::new();
         let mut dataflow_results: IndexMap<DataflowId, BTreeMap<DaemonId, DataflowDaemonResult>> =
             IndexMap::new();
+        let mut pending_restarts: HashMap<DataflowId, PendingRestart> = HashMap::new();
 
         check_spawn_timeouts(
             &mut running_dataflows,
             &mut archived_dataflows,
             &mut dataflow_results,
             &mut daemon_connections,
+            &mut pending_restarts,
             &clock,
             store.as_ref(),
         )
@@ -6645,12 +6681,14 @@ mod tests {
         let mut archived_dataflows: IndexMap<DataflowId, ArchivedDataflow> = IndexMap::new();
         let mut dataflow_results: IndexMap<DataflowId, BTreeMap<DaemonId, DataflowDaemonResult>> =
             IndexMap::new();
+        let mut pending_restarts: HashMap<DataflowId, PendingRestart> = HashMap::new();
 
         check_spawn_timeouts(
             &mut running_dataflows,
             &mut archived_dataflows,
             &mut dataflow_results,
             &mut daemon_connections,
+            &mut pending_restarts,
             &clock,
             store.as_ref(),
         )
@@ -6692,12 +6730,14 @@ mod tests {
         let mut archived_dataflows: IndexMap<DataflowId, ArchivedDataflow> = IndexMap::new();
         let mut dataflow_results: IndexMap<DataflowId, BTreeMap<DaemonId, DataflowDaemonResult>> =
             IndexMap::new();
+        let mut pending_restarts: HashMap<DataflowId, PendingRestart> = HashMap::new();
 
         check_spawn_timeouts(
             &mut running_dataflows,
             &mut archived_dataflows,
             &mut dataflow_results,
             &mut daemon_connections,
+            &mut pending_restarts,
             &clock,
             store.as_ref(),
         )
@@ -6778,12 +6818,14 @@ mod tests {
         let mut archived_dataflows: IndexMap<DataflowId, ArchivedDataflow> = IndexMap::new();
         let mut dataflow_results: IndexMap<DataflowId, BTreeMap<DaemonId, DataflowDaemonResult>> =
             IndexMap::new();
+        let mut pending_restarts: HashMap<DataflowId, PendingRestart> = HashMap::new();
 
         check_spawn_timeouts(
             &mut running_dataflows,
             &mut archived_dataflows,
             &mut dataflow_results,
             &mut daemon_connections,
+            &mut pending_restarts,
             &clock,
             store.as_ref(),
         )
@@ -7125,12 +7167,14 @@ mod tests {
         let mut archived_dataflows: IndexMap<DataflowId, ArchivedDataflow> = IndexMap::new();
         let mut dataflow_results: IndexMap<DataflowId, BTreeMap<DaemonId, DataflowDaemonResult>> =
             IndexMap::new();
+        let mut pending_restarts: HashMap<DataflowId, PendingRestart> = HashMap::new();
 
         check_spawn_timeouts(
             &mut running_dataflows,
             &mut archived_dataflows,
             &mut dataflow_results,
             &mut daemon_connections,
+            &mut pending_restarts,
             &clock,
             store.as_ref(),
         )
@@ -7171,12 +7215,14 @@ mod tests {
         let mut archived_dataflows: IndexMap<DataflowId, ArchivedDataflow> = IndexMap::new();
         let mut dataflow_results: IndexMap<DataflowId, BTreeMap<DaemonId, DataflowDaemonResult>> =
             IndexMap::new();
+        let mut pending_restarts: HashMap<DataflowId, PendingRestart> = HashMap::new();
 
         check_spawn_timeouts(
             &mut running_dataflows,
             &mut archived_dataflows,
             &mut dataflow_results,
             &mut daemon_connections,
+            &mut pending_restarts,
             &clock,
             store.as_ref(),
         )
@@ -7232,12 +7278,14 @@ mod tests {
         let mut archived_dataflows: IndexMap<DataflowId, ArchivedDataflow> = IndexMap::new();
         let mut dataflow_results: IndexMap<DataflowId, BTreeMap<DaemonId, DataflowDaemonResult>> =
             IndexMap::new();
+        let mut pending_restarts: HashMap<DataflowId, PendingRestart> = HashMap::new();
 
         check_spawn_timeouts(
             &mut running_dataflows,
             &mut archived_dataflows,
             &mut dataflow_results,
             &mut daemon_connections,
+            &mut pending_restarts,
             &clock,
             store.as_ref(),
         )
@@ -7317,11 +7365,13 @@ mod tests {
         }
         assert_eq!(dataflow_results.len(), MAX_DATAFLOW_RESULTS);
 
+        let mut pending_restarts: HashMap<DataflowId, PendingRestart> = HashMap::new();
         check_spawn_timeouts(
             &mut running_dataflows,
             &mut archived_dataflows,
             &mut dataflow_results,
             &mut daemon_connections,
+            &mut pending_restarts,
             &clock,
             store.as_ref(),
         )
@@ -7402,12 +7452,14 @@ mod tests {
         let mut archived_dataflows: IndexMap<DataflowId, ArchivedDataflow> = IndexMap::new();
         let mut dataflow_results: IndexMap<DataflowId, BTreeMap<DaemonId, DataflowDaemonResult>> =
             IndexMap::new();
+        let mut pending_restarts: HashMap<DataflowId, PendingRestart> = HashMap::new();
 
         check_spawn_timeouts(
             &mut running_dataflows,
             &mut archived_dataflows,
             &mut dataflow_results,
             &mut daemon_connections,
+            &mut pending_restarts,
             &clock,
             store.as_ref(),
         )
@@ -7632,12 +7684,14 @@ mod tests {
         let mut archived_dataflows: IndexMap<DataflowId, ArchivedDataflow> = IndexMap::new();
         let mut dataflow_results: IndexMap<DataflowId, BTreeMap<DaemonId, DataflowDaemonResult>> =
             IndexMap::new();
+        let mut pending_restarts: HashMap<DataflowId, PendingRestart> = HashMap::new();
 
         check_spawn_timeouts(
             &mut running_dataflows,
             &mut archived_dataflows,
             &mut dataflow_results,
             &mut daemon_connections,
+            &mut pending_restarts,
             &clock,
             store.as_ref(),
         )
@@ -7703,12 +7757,14 @@ mod tests {
         let mut archived_dataflows: IndexMap<DataflowId, ArchivedDataflow> = IndexMap::new();
         let mut dataflow_results: IndexMap<DataflowId, BTreeMap<DaemonId, DataflowDaemonResult>> =
             IndexMap::new();
+        let mut pending_restarts: HashMap<DataflowId, PendingRestart> = HashMap::new();
 
         check_spawn_timeouts(
             &mut running_dataflows,
             &mut archived_dataflows,
             &mut dataflow_results,
             &mut daemon_connections,
+            &mut pending_restarts,
             &clock,
             store.as_ref(),
         )
@@ -7786,11 +7842,13 @@ mod tests {
         // If `NodeId::from("<watchdog>")` is reintroduced, this awaits
         // a panic and the test fails. Currently uses `"watchdog"` which
         // passes validation.
+        let mut pending_restarts: HashMap<DataflowId, PendingRestart> = HashMap::new();
         check_spawn_timeouts(
             &mut running_dataflows,
             &mut archived_dataflows,
             &mut dataflow_results,
             &mut daemon_connections,
+            &mut pending_restarts,
             &clock,
             store.as_ref(),
         )

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -893,6 +893,23 @@ async fn start_inner(
                             grace_duration,
                             force,
                         } => {
+                            // A pending restart already sent `StopDataflow` to
+                            // the daemon(s) and is waiting for
+                            // `DataflowFinishedOnDaemon` to spawn the new
+                            // incarnation under a fresh UUID. `running_dataflows`
+                            // still contains the old UUID in the meantime, so
+                            // without this guard `stop_dataflow` below would
+                            // "succeed" against the old UUID while the restart
+                            // silently spawns a new one that keeps running —
+                            // the stop caller would see success but the
+                            // dataflow is still alive under a different UUID.
+                            if pending_restarts.contains_key(&dataflow_uuid) {
+                                let _ = reply_sender.send(Err(eyre!(
+                                    "dataflow `{dataflow_uuid}` is being restarted – cannot stop it until the restart finishes"
+                                )));
+                                continue;
+                            }
+
                             // `dataflow_results` is filled incrementally, one
                             // entry per daemon, while a multi-daemon dataflow is
                             // still running on the others (see
@@ -946,6 +963,15 @@ async fn start_inner(
                             force,
                         } => match resolve_name(name, &running_dataflows, &archived_dataflows) {
                             Ok(dataflow_uuid) => {
+                                // Same pending-restart guard as `Stop` — see
+                                // the comment there for why this is needed.
+                                if pending_restarts.contains_key(&dataflow_uuid) {
+                                    let _ = reply_sender.send(Err(eyre!(
+                                        "dataflow `{dataflow_uuid}` is being restarted – cannot stop it until the restart finishes"
+                                    )));
+                                    continue;
+                                }
+
                                 // Same partial-completion guard as `Stop`: a
                                 // still-running multi-daemon dataflow has a
                                 // partial `dataflow_results` entry, but must

--- a/tests/stop-restart-race-e2e.rs
+++ b/tests/stop-restart-race-e2e.rs
@@ -8,15 +8,23 @@
 //! through to `stop_dataflow` and "succeed" against the old UUID, while the
 //! restart went on to spawn a fresh incarnation under a new UUID that kept
 //! running — the caller saw a clean success with no indication the
-//! dataflow was still alive. The fix rejects `Stop`/`StopByName` outright
-//! while `pending_restarts` still holds the UUID.
+//! dataflow was still alive.
+//!
+//! The fix cancels the pending restart (erroring its caller) rather than
+//! rejecting the `Stop` outright: an explicit `Stop` means the caller wants
+//! the dataflow gone, and an outright rejection would otherwise block every
+//! control verb — including `--force` — for the entire
+//! `--grace-duration`/`Event::Stop`-ignoring window a restart can be
+//! in flight for.
 //!
 //! The window between `StopDataflow` being sent and `DataflowFinishedOnDaemon`
 //! arriving is normally just tens of milliseconds (as long as the node takes
 //! to exit), which is too timing-dependent for a deterministic test. This
 //! test widens it on purpose using the shared `stop-delay-node` fixture's
-//! `DORA_TEST_STOP_DELAY_MS` knob, so `stop` reliably lands while the
-//! restart is still pending instead of only doing so most of the time.
+//! `DORA_TEST_STOP_DELAY_MS` knob, and pins the exact moment `stop` is fired
+//! to the coordinator's own "restart pending" log line rather than a fixed
+//! sleep, so it reliably lands while the restart is pending instead of only
+//! doing so most of the time.
 //!
 //! Heavyweight (spawns processes). Run with
 //! `cargo test -p dora-examples --test stop-restart-race-e2e`.
@@ -74,6 +82,12 @@ fn free_port() -> u16 {
 
 fn port_open(port: u16) -> bool {
     TcpStream::connect(("127.0.0.1", port)).is_ok()
+}
+
+fn log_contains(path: &Path, needle: &str) -> bool {
+    std::fs::read_to_string(path)
+        .map(|s| s.contains(needle))
+        .unwrap_or(false)
 }
 
 fn wait_until(mut f: impl FnMut() -> bool, timeout: Duration, what: &str) {
@@ -142,10 +156,11 @@ impl Drop for Cleanup {
     }
 }
 
-/// A `Stop` racing a `Restart` on the same dataflow must be rejected, not
-/// silently reported as successful while a new incarnation keeps running.
+/// A `Stop` racing a `Restart` on the same dataflow must cancel the restart
+/// and actually stop the dataflow — not report success while a new
+/// incarnation keeps running, and not refuse to stop it either.
 #[test]
-fn stop_racing_pending_restart_is_rejected() {
+fn stop_racing_pending_restart_cancels_the_restart() {
     ensure_built();
 
     let dora = bin("dora");
@@ -226,10 +241,6 @@ fn stop_racing_pending_restart_is_rejected() {
     );
     let dataflow_id = list_active(port).expect("list active")[0];
 
-    // Fire `restart` and `stop` on the same UUID: `restart` first (so its
-    // `StopDataflow` send + `pending_restarts` insert — near-instant —
-    // reliably happens before `stop` is issued), then `stop` while the
-    // node's 5s shutdown delay keeps the restart pending.
     let restart_child = Command::new(&dora)
         .arg("restart")
         .arg(dataflow_id.to_string())
@@ -240,7 +251,19 @@ fn stop_racing_pending_restart_is_rejected() {
         .spawn()
         .expect("failed to spawn dora restart");
 
-    std::thread::sleep(Duration::from_millis(300));
+    // Wait for the coordinator's own confirmation that the restart is
+    // registered in `pending_restarts` — deterministic, unlike a fixed
+    // sleep that could flake on a loaded runner.
+    wait_until(
+        || {
+            log_contains(
+                &coord_log,
+                "restart pending; waiting for dataflow to finish stopping",
+            )
+        },
+        Duration::from_secs(10),
+        "coordinator to register the pending restart",
+    );
 
     let stop_output = Command::new(&dora)
         .arg("stop")
@@ -254,41 +277,40 @@ fn stop_racing_pending_restart_is_rejected() {
         .wait_with_output()
         .expect("failed to wait on dora restart");
 
-    if !restart_output.status.success() {
+    // Core assertion 1: `stop` must actually stop the dataflow — the whole
+    // point of cancelling the restart instead of refusing the stop.
+    if !stop_output.status.success() {
         dump_logs(&coord_log, &daemon_log);
         panic!(
-            "dora restart failed: stdout={} stderr={}",
-            String::from_utf8_lossy(&restart_output.stdout),
-            String::from_utf8_lossy(&restart_output.stderr),
+            "dora stop failed while cancelling a pending restart for {dataflow_id}: stdout={} stderr={}",
+            String::from_utf8_lossy(&stop_output.stdout),
+            String::from_utf8_lossy(&stop_output.stderr),
         );
     }
 
-    // Core assertion: `stop` must be rejected, not report success while a
-    // restart is in flight for the same UUID (the silent-loss race).
-    let stop_stderr = String::from_utf8_lossy(&stop_output.stderr);
-    if stop_output.status.success() {
+    // Core assertion 2: the restart must be cancelled, not silently
+    // completed — its caller sees a clear error, not `DataflowRestarted`.
+    let restart_stderr = String::from_utf8_lossy(&restart_output.stderr);
+    if restart_output.status.success() {
         dump_logs(&coord_log, &daemon_log);
         panic!(
-            "dora stop unexpectedly succeeded while a restart was pending for {dataflow_id} \
-             (stdout={:?}); this is the silent-loss race the fix guards against",
-            String::from_utf8_lossy(&stop_output.stdout),
+            "dora restart unexpectedly succeeded for {dataflow_id} after a concurrent stop \
+             (stdout={:?}); the restart should have been cancelled instead",
+            String::from_utf8_lossy(&restart_output.stdout),
         );
     }
     assert!(
-        stop_stderr.contains("is being restarted"),
-        "expected the pending-restart rejection message, got stderr={stop_stderr:?}"
+        restart_stderr.contains("was stopped before the restart could complete"),
+        "expected the restart-cancelled error, got stderr={restart_stderr:?}"
     );
 
-    // The restart itself must still complete normally: exactly one
-    // dataflow running, under a fresh UUID (not the one `stop` targeted).
+    // Core assertion 3: no new incarnation was spawned — the dataflow ends
+    // up genuinely stopped, not replaced by a fresh UUID under a different
+    // name (the silent-loss shape the original bug had).
     wait_until(
-        || {
-            list_active(port)
-                .map(|v| v.len() == 1 && !v.contains(&dataflow_id))
-                .unwrap_or(false)
-        },
+        || list_active(port).map(|v| v.is_empty()).unwrap_or(false),
         Duration::from_secs(30),
-        "restarted dataflow to come back up under a new UUID",
+        "dataflow to be fully stopped with no replacement incarnation",
     );
 
     let _ = Command::new(&dora)

--- a/tests/stop-restart-race-e2e.rs
+++ b/tests/stop-restart-race-e2e.rs
@@ -1,0 +1,302 @@
+//! End-to-end regression test for the coordinator `Stop` vs. `Restart`
+//! race.
+//!
+//! `initiate_restart` sends `StopDataflow` to the daemon and registers a
+//! `PendingRestart` for the dataflow's UUID, but leaves the UUID in
+//! `running_dataflows` until the daemon reports `DataflowFinishedOnDaemon`.
+//! A `Stop`/`StopByName` request that lands in that window used to fall
+//! through to `stop_dataflow` and "succeed" against the old UUID, while the
+//! restart went on to spawn a fresh incarnation under a new UUID that kept
+//! running — the caller saw a clean success with no indication the
+//! dataflow was still alive. The fix rejects `Stop`/`StopByName` outright
+//! while `pending_restarts` still holds the UUID.
+//!
+//! The window between `StopDataflow` being sent and `DataflowFinishedOnDaemon`
+//! arriving is normally just tens of milliseconds (as long as the node takes
+//! to exit), which is too timing-dependent for a deterministic test. This
+//! test widens it on purpose using the shared `stop-delay-node` fixture's
+//! `DORA_TEST_STOP_DELAY_MS` knob, so `stop` reliably lands while the
+//! restart is still pending instead of only doing so most of the time.
+//!
+//! Heavyweight (spawns processes). Run with
+//! `cargo test -p dora-examples --test stop-restart-race-e2e`.
+
+use std::net::{SocketAddr, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::Once;
+use std::time::{Duration, Instant};
+
+use dora_cli::WsSession;
+use dora_message::{cli_to_coordinator::ControlRequest, coordinator_to_cli::ControlRequestReply};
+use uuid::Uuid;
+
+static BUILD: Once = Once::new();
+
+fn ensure_built() {
+    BUILD.call_once(|| {
+        let status = Command::new("cargo")
+            .args(["build", "-p", "dora-cli", "-p", "stop-delay-node"])
+            .status()
+            .expect("failed to run cargo build");
+        assert!(status.success(), "failed to build test prerequisites");
+    });
+}
+
+fn target_dir() -> PathBuf {
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    std::env::var("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| Path::new(manifest).join("target"))
+}
+
+fn bin(name: &str) -> PathBuf {
+    let exe = format!("{name}{}", std::env::consts::EXE_SUFFIX);
+    let path = target_dir().join("debug").join(exe);
+    assert!(
+        path.exists(),
+        "binary not found: {} (did ensure_built run?)",
+        path.display()
+    );
+    path
+}
+
+/// Grab a currently-free TCP port. There is a small TOCTOU window between
+/// closing this listener and the coordinator binding it, but it is more
+/// than adequate to keep parallel test binaries off each other's ports.
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("failed to bind ephemeral port")
+        .local_addr()
+        .expect("failed to read local addr")
+        .port()
+}
+
+fn port_open(port: u16) -> bool {
+    TcpStream::connect(("127.0.0.1", port)).is_ok()
+}
+
+fn wait_until(mut f: impl FnMut() -> bool, timeout: Duration, what: &str) {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if f() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    panic!("timed out after {timeout:?} waiting for: {what}");
+}
+
+fn spawn_coordinator(dora: &Path, port: u16, redb: &Path, log: &Path) -> Child {
+    let out = std::fs::File::create(log).expect("create coordinator log");
+    let err = out.try_clone().expect("clone coordinator log");
+    Command::new(dora)
+        .arg("coordinator")
+        .arg("--port")
+        .arg(port.to_string())
+        .arg("--store")
+        .arg(format!("redb:{}", redb.display()))
+        .stdout(Stdio::from(out))
+        .stderr(Stdio::from(err))
+        .spawn()
+        .expect("failed to spawn coordinator")
+}
+
+/// Query the coordinator for the set of `Running` dataflow uuids.
+fn list_active(port: u16) -> eyre::Result<Vec<Uuid>> {
+    let addr: SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
+    let session = WsSession::connect(addr)?;
+    let data = serde_json::to_vec(&ControlRequest::List)?;
+    let reply_bytes = session.request(&data)?;
+    let reply: ControlRequestReply = serde_json::from_slice(&reply_bytes)?;
+    match reply {
+        ControlRequestReply::DataflowList(list) => {
+            Ok(list.get_active().into_iter().map(|d| d.uuid).collect())
+        }
+        other => eyre::bail!("unexpected list reply: {other:?}"),
+    }
+}
+
+fn dump_logs(coord_log: &Path, daemon_log: &Path) {
+    for (label, path) in [("coordinator", coord_log), ("daemon", daemon_log)] {
+        eprintln!("--- {label} log ({}) ---", path.display());
+        eprintln!("{}", std::fs::read_to_string(path).unwrap_or_default());
+    }
+}
+
+/// Best-effort teardown that always runs, even on panic.
+struct Cleanup {
+    coordinator: Option<Child>,
+    daemon: Option<Child>,
+}
+
+impl Drop for Cleanup {
+    fn drop(&mut self) {
+        for child in [self.daemon.as_mut(), self.coordinator.as_mut()]
+            .into_iter()
+            .flatten()
+        {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+/// A `Stop` racing a `Restart` on the same dataflow must be rejected, not
+/// silently reported as successful while a new incarnation keeps running.
+#[test]
+fn stop_racing_pending_restart_is_rejected() {
+    ensure_built();
+
+    let dora = bin("dora");
+    let node = bin("stop-delay-node");
+
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let redb = tmp.path().join("coordinator.redb");
+    let coord_log = tmp.path().join("coordinator.log");
+    let daemon_log = tmp.path().join("daemon.log");
+    let dataflow_yml = tmp.path().join("dataflow.yml");
+
+    // The node lingers 5s after receiving `Stop` before actually exiting,
+    // which keeps the restart's `DataflowFinishedOnDaemon` from arriving
+    // for that long — guaranteeing the coordinator's `pending_restarts`
+    // entry is still present when the concurrent `stop` reaches it below.
+    std::fs::write(
+        &dataflow_yml,
+        format!(
+            "nodes:\n  \
+             - id: slow-stop\n    \
+             path: {node}\n    \
+             env:\n      \
+             DORA_TEST_STOP_DELAY_MS: \"5000\"\n",
+            node = node.display(),
+        ),
+    )
+    .expect("write dataflow yml");
+
+    let port = free_port();
+    let daemon_listen_port = free_port();
+
+    let mut cleanup = Cleanup {
+        coordinator: None,
+        daemon: None,
+    };
+
+    cleanup.coordinator = Some(spawn_coordinator(&dora, port, &redb, &coord_log));
+    wait_until(
+        || port_open(port),
+        Duration::from_secs(20),
+        "coordinator to accept connections",
+    );
+
+    let daemon_out = std::fs::File::create(&daemon_log).expect("create daemon log");
+    let daemon_err = daemon_out.try_clone().expect("clone daemon log");
+    cleanup.daemon = Some(
+        Command::new(&dora)
+            .arg("daemon")
+            .arg("--coordinator-port")
+            .arg(port.to_string())
+            .arg("--local-listen-port")
+            .arg(daemon_listen_port.to_string())
+            .stdout(Stdio::from(daemon_out))
+            .stderr(Stdio::from(daemon_err))
+            .spawn()
+            .expect("failed to spawn daemon"),
+    );
+
+    let start = Command::new(&dora)
+        .arg("start")
+        .arg(&dataflow_yml)
+        .arg("--detach")
+        .arg("--coordinator-port")
+        .arg(port.to_string())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("failed to run dora start");
+    if !start.success() {
+        dump_logs(&coord_log, &daemon_log);
+        panic!("dora start failed");
+    }
+
+    wait_until(
+        || list_active(port).map(|v| v.len() == 1).unwrap_or(false),
+        Duration::from_secs(30),
+        "dataflow to register as Running",
+    );
+    let dataflow_id = list_active(port).expect("list active")[0];
+
+    // Fire `restart` and `stop` on the same UUID: `restart` first (so its
+    // `StopDataflow` send + `pending_restarts` insert — near-instant —
+    // reliably happens before `stop` is issued), then `stop` while the
+    // node's 5s shutdown delay keeps the restart pending.
+    let restart_child = Command::new(&dora)
+        .arg("restart")
+        .arg(dataflow_id.to_string())
+        .arg("--coordinator-port")
+        .arg(port.to_string())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn dora restart");
+
+    std::thread::sleep(Duration::from_millis(300));
+
+    let stop_output = Command::new(&dora)
+        .arg("stop")
+        .arg(dataflow_id.to_string())
+        .arg("--coordinator-port")
+        .arg(port.to_string())
+        .output()
+        .expect("failed to run dora stop");
+
+    let restart_output = restart_child
+        .wait_with_output()
+        .expect("failed to wait on dora restart");
+
+    if !restart_output.status.success() {
+        dump_logs(&coord_log, &daemon_log);
+        panic!(
+            "dora restart failed: stdout={} stderr={}",
+            String::from_utf8_lossy(&restart_output.stdout),
+            String::from_utf8_lossy(&restart_output.stderr),
+        );
+    }
+
+    // Core assertion: `stop` must be rejected, not report success while a
+    // restart is in flight for the same UUID (the silent-loss race).
+    let stop_stderr = String::from_utf8_lossy(&stop_output.stderr);
+    if stop_output.status.success() {
+        dump_logs(&coord_log, &daemon_log);
+        panic!(
+            "dora stop unexpectedly succeeded while a restart was pending for {dataflow_id} \
+             (stdout={:?}); this is the silent-loss race the fix guards against",
+            String::from_utf8_lossy(&stop_output.stdout),
+        );
+    }
+    assert!(
+        stop_stderr.contains("is being restarted"),
+        "expected the pending-restart rejection message, got stderr={stop_stderr:?}"
+    );
+
+    // The restart itself must still complete normally: exactly one
+    // dataflow running, under a fresh UUID (not the one `stop` targeted).
+    wait_until(
+        || {
+            list_active(port)
+                .map(|v| v.len() == 1 && !v.contains(&dataflow_id))
+                .unwrap_or(false)
+        },
+        Duration::from_secs(30),
+        "restarted dataflow to come back up under a new UUID",
+    );
+
+    let _ = Command::new(&dora)
+        .arg("stop")
+        .arg("--all")
+        .arg("--coordinator-port")
+        .arg(port.to_string())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+}


### PR DESCRIPTION
initiate_restart() sends StopDataflow and registers a PendingRestart under
the dataflow's UUID, but leaves the entry in running_dataflows until
DataflowFinishedOnDaemon fires. Stop/StopByName only checked
running_dataflows, not pending_restarts, so a concurrent Stop would fall
through to stop_dataflow(), succeed, and get queued — then silently lose
when the pending restart resolved first and spawned a new incarnation
under a fresh UUID. The caller saw a clean 'stop succeeded' while the
dataflow kept running under a different UUID.

Reproduced live 3/3 with dora restart + dora stop fired concurrently on
a real coordinator+daemon+node setup. Now rejects the stop with a clear
error instead of silently losing.

## Why not a duplicate

- #2936 (open) — daemon-level node restart-loop leak in a single daemon's
  running_nodes, not this coordinator-level Restart control-request path
- #3053 (open) — dataflow.start() firing on an already-stopping dataflow via
  the startup barrier, a different trigger mechanism
- #2131 (closed) — stale PendingRestart hangs the caller when a daemon dies
  mid-restart; already fixed by draining pending_restarts on disconnect.
  Doesn't cover a concurrent Stop racing a healthy in-progress Restart.
- No existing e2e test (daemon-reconnect-e2e.rs, fault-tolerance-e2e.rs,
  node-lifecycle-e2e.rs, ws_control_tests.rs) exercises Restart racing Stop
  on the same UUID.
- Unrelated to PR #3040 (CMake path fix) and PR #3001 (CachedResult boxing) —
  this branch is based cleanly on origin/main and touches neither file.

## Verification

- cargo check -p dora-coordinator — clean
- cargo clippy -p dora-coordinator -- -D warnings — clean (aside from the
  pre-existing unrelated large_enum_variant warning tracked by #3001)
- cargo fmt --all -- --check — clean
- cargo test -p dora-coordinator --lib — 107 passed, 0 failed
- Live repro: dora restart <uuid> & dora stop <uuid> & fired concurrently,
  3/3 runs — 2/3 hit the new guard directly (clear rejection error), 1/3
  the restart had already resolved before stop arrived so it correctly
  reported the now-genuinely-finished old UUID (no silent loss in any run)
