### PR TITLE
fix(coordinator): stop succeeded dataflow orphans on status report

### DIFF
--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -2623,13 +2623,13 @@ async fn start_inner(
                                     }
                                 }
                             }
-                            StoreDataflowStatus::Failed { terminal: true, .. } => {
-                                // Terminal failure (watchdog or equivalent
-                                // coordinator-side verdict). Daemon's report
-                                // is ignored to preserve the verdict the
-                                // user already received via wait_for_spawn.
+                            status if status_report_should_stop_orphan(&status) => {
+                                // Terminal state (success, watchdog failure, or
+                                // equivalent coordinator-side verdict). Daemon's
+                                // report is ignored to preserve the verdict the
+                                // user already received.
                                 tracing::warn!(
-                                    "daemon {daemon_id} reports terminally-failed \
+                                    "daemon {daemon_id} reports terminal \
                                      dataflow {df_id} as running; skipping reconcile",
                                 );
                                 // Stop the orphaned nodes the daemon kept alive
@@ -3266,6 +3266,13 @@ fn reestablish_running_dataflow(
     // replay exactly as the relink path does. Returning a flat `false` here is
     // what left orphan-reclaim and coordinator-restart reconnects hanging.
     record.ready_barrier_released
+}
+
+fn status_report_should_stop_orphan(status: &StoreDataflowStatus) -> bool {
+    matches!(
+        status,
+        StoreDataflowStatus::Failed { terminal: true, .. } | StoreDataflowStatus::Succeeded
+    )
 }
 
 /// Tell a single daemon to stop a dataflow the coordinator has terminally given
@@ -8545,6 +8552,17 @@ mod tests {
         assert!(
             !archived_dataflows.contains_key(&unknown),
             "unknown dataflow must NOT be flagged (normal reconcile path applies)"
+        );
+    }
+
+    #[test]
+    fn status_report_reconcile_stops_succeeded_dataflows_reported_as_running() {
+        let status = StoreDataflowStatus::Succeeded;
+
+        assert!(
+            status_report_should_stop_orphan(&status),
+            "a Succeeded store record is terminal; a daemon reporting it as still \
+             running must be stopped rather than ignored"
         );
     }
 


### PR DESCRIPTION
  ## Summary

  Fixes a coordinator reconciliation gap where a daemon could report a dataflow  as still running even though the coordinator store already marked it as  `Succeeded`.

  Previously, the `DaemonStatusReport` handler handled:

  - `Pending` / `Recovering` / non-terminal `Failed`: reconcile back to  `Running`
  - `Running`: re-establish live coordinator state
  - terminal `Failed`: preserve the terminal verdict and stop orphaned daemon-  side nodes
  - `Succeeded`: fell through to `_ => {}`  after the coordinator had already recorded the dataflow as successfully  finished.

  This change treats `Succeeded` as a terminal state for status-report reconciliation and reuses the existing orphan cleanup path.
