### PR TITLE
chore(deps): bump eyre to 0.6.14 to fix expression-position `bail!` (supersedes #2843, #3086)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2883,10 +2883,11 @@ checksum = "320bea982e85d42441eb25c49b41218e7eaa2657e8f90bc4eca7437376751e23"
 
 [[package]]
 name = "eyre"
-version = "0.6.12"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+checksum = "c08309dbcc659c5549a24ddb9b27027640641b282ef5768267c7e675558986a3"
 dependencies = [
+ "autocfg",
  "indenter",
  "once_cell",
 ]


### PR DESCRIPTION
## Summary

Fixes #2835 upstream instead of in our source. eyre 0.6.14 removes the trailing semicolon from every arm of the `bail!` macro, which was the sole cause of the `semicolon_in_expressions_from_macros` / `semicolon_in_expressions_from_non_local_macros` diagnostics.

```diff
 macro_rules! bail {
     ($msg:literal $(,)?) => {
-        return $crate::private::Err($crate::eyre!($msg));
+        return $crate::private::Err($crate::eyre!($msg))
     };
     ($err:expr $(,)?) => {
-        return $crate::private::Err($crate::eyre!($err));
+        return $crate::private::Err($crate::eyre!($err))
     };
     ($fmt:expr, $($arg:tt)*) => {
-        return $crate::private::Err($crate::eyre!($fmt, $($arg)*));
+        return $crate::private::Err($crate::eyre!($fmt, $($arg)*))
     };
 }
```

The diff here is a one-package lockfile bump — **no dora source changes**.

## Supersedes #2843 and #3086

Both open PRs fix this by hand-editing call sites (adding `;` after block-tail `bail!`, wrapping bare `match` arms in a block). With 0.6.14 neither is needed: the lint has nothing left to fire on. Landing this instead avoids 365 lines of churn across 52 files and — more importantly — avoids a rule that every future `bail!` call site has to remember.

| | approach | files touched |
|---|---|---|
| #2843 | edit call sites | 48 |
| #3086 | edit call sites | 4 |
| this PR | bump dependency | 1 (`Cargo.lock`) |

## Verification

Toolchain: `rustc 1.99.0-nightly (12c36e253 2026-08-10)`.

Workspace-wide `cargo +nightly check --all` (excluding the three PyO3 crates), counting `trailing semicolon in macro used in expression position`:

| eyre | diagnostics |
|---|---|
| 0.6.12 | **154** across 17 crates (cli 57, core 21, coordinator 17, node 17, daemon 10, …) |
| 0.6.14 | **0** |

Isolated before/after on a minimal crate with `#[deny(future_incompatible)]`, covering both reported shapes (block-tail `bail!("boom")` and bare match arm `_ => bail!("nope")`): fails to compile on 0.6.12, compiles clean on 0.6.14, identical source.

Also run:

- `cargo +1.97.1 fmt --all -- --check` — clean
- `cargo +1.97.1 clippy --all -- -D warnings` (excluding PyO3 crates) — clean
- `cargo +nightly check -p dora-core` — clean, the crate from #2835

Note on severity: the reporter in #2835 saw hard **errors** on `nightly (da86f4d07 2026-07-24)`; on the nightly used here the non-local variant surfaces as future-incompat **warnings**. Which nightly builds hard-error varies, which is exactly why the dependency fix is the durable one.

The only future-incompat report left in the workspace comes from third-party `static_init_macro v1.0.4` and is unrelated to this change.

## Version delta review

0.6.12 → 0.6.14 also drops eyre's optional `pyo3` dependency (a feature dora never enabled) and adds an `autocfg` build dependency (already in our tree). `rust-version` stays at 1.65.0, well under the workspace MSRV of 1.95.0.

## Note

This bumps `Cargo.lock` only; the workspace requirement stays `eyre = "0.6.12"`, so normal resolution picks up 0.6.14 and above. If you'd rather encode the fix as a hard floor — relevant only under minimal-version resolution — say the word and I'll bump the requirement to `0.6.14` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BRDAyUb1r1nLd3i4Sc2UXy

---
_Generated by [Claude Code](https://claude.ai/code/session_01BRDAyUb1r1nLd3i4Sc2UXy)_