### PR TITLE
fix(cli): resolve `dora topic <node-id>` to all of a node's outputs

### DIFF
--- a/binaries/cli/src/command/topic/selector.rs
+++ b/binaries/cli/src/command/topic/selector.rs
@@ -1,5 +1,4 @@
 use std::{
-    borrow::Cow,
     collections::{BTreeSet, HashMap},
     fmt,
 };
@@ -54,7 +53,7 @@ pub struct TopicSelector {
     pub data: Vec<String>,
 }
 
-#[derive(Clone, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq)]
 pub struct TopicIdentifier {
     pub node_id: NodeId,
     pub data_id: DataId,
@@ -85,81 +84,188 @@ impl TopicSelector {
         session: &WsSession,
     ) -> eyre::Result<(DataflowId, BTreeSet<TopicIdentifier>, Descriptor)> {
         let (dataflow_id, dataflow_descriptor) = self.dataflow.resolve(session)?;
-
-        let node_map = dataflow_descriptor
-            .nodes
-            .iter()
-            .map(|node| (&node.id, node))
-            .collect::<HashMap<_, _>>();
-
-        let mut data = BTreeSet::new();
-        if self.data.is_empty() {
-            data.extend(dataflow_descriptor.nodes.iter().flat_map(|node| {
-                node.outputs.iter().map(|output| TopicIdentifier {
-                    node_id: node.id.clone(),
-                    data_id: output.clone(),
-                })
-            }));
-            return Ok((dataflow_id, data, dataflow_descriptor));
-        }
-
-        for s in &self.data {
-            let mut s = Cow::Borrowed(s.as_str());
-            if !s.contains('/') {
-                s.to_mut().push('/');
-            }
-            match s.parse() {
-                Ok(InputMapping::User(user)) => {
-                    let node = *node_map.get(&user.source).with_context(|| {
-                        format!(
-                            "unknown node `{}`\n\n  \
-                             hint: available nodes: {}",
-                            user.source,
-                            node_map
-                                .keys()
-                                .map(|k| k.to_string())
-                                .collect::<Vec<_>>()
-                                .join(", ")
-                        )
-                    })?;
-                    if user.output.is_empty() {
-                        data.extend(node.outputs.iter().map(|output| TopicIdentifier {
-                            node_id: user.source.clone(),
-                            data_id: output.clone(),
-                        }));
-                    } else if node.outputs.contains(&user.output) {
-                        data.insert(TopicIdentifier {
-                            node_id: user.source,
-                            data_id: user.output,
-                        });
-                    } else {
-                        bail!(
-                            "node `{}` does not have output `{}`\n\n  \
-                             hint: available outputs: {}",
-                            user.source,
-                            user.output,
-                            node.outputs
-                                .iter()
-                                .map(|o| o.to_string())
-                                .collect::<Vec<_>>()
-                                .join(", ")
-                        );
-                    }
-                }
-                Ok(_) => {
-                    bail!("Reserved input mapping cannot be inspected")
-                }
-                Err(e) => bail!("Invalid output id `{s}`: {e}"),
-            }
-        }
-
-        if data.is_empty() {
-            bail!(
-                "no outputs found in this dataflow\n\n  \
-                 hint: ensure nodes in the dataflow declare `outputs` in their YAML definition"
-            );
-        }
-
+        let data = resolve_topics(&self.data, &dataflow_descriptor)?;
         Ok((dataflow_id, data, dataflow_descriptor))
+    }
+}
+
+/// Resolve the requested `data` selectors against a dataflow `descriptor` into a
+/// concrete set of `node/output` topics.
+///
+/// Each selector is one of:
+/// - empty list -> every output of every node in the dataflow;
+/// - a bare node id (`camera`) -> every output declared by that node;
+/// - a fully-qualified `node/output` (`camera/frame`) -> exactly that output.
+///
+/// A bare node id is handled explicitly here. It must not be turned into
+/// `node/` and fed through [`InputMapping`] parsing: the segment after the
+/// first `/` is parsed as a [`DataId`], which rejects the empty string, so
+/// `"camera/".parse::<InputMapping>()` errors out — meaning the "all outputs of
+/// a node" case would never be reached (dora-rs/dora, `dora topic <node>`).
+fn resolve_topics(
+    data: &[String],
+    descriptor: &Descriptor,
+) -> eyre::Result<BTreeSet<TopicIdentifier>> {
+    let node_map = descriptor
+        .nodes
+        .iter()
+        .map(|node| (&node.id, node))
+        .collect::<HashMap<_, _>>();
+
+    let unknown_node_err = |node: &NodeId| {
+        format!(
+            "unknown node `{}`\n\n  \
+             hint: available nodes: {}",
+            node,
+            node_map
+                .keys()
+                .map(|k| k.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    };
+
+    let mut topics = BTreeSet::new();
+    if data.is_empty() {
+        topics.extend(descriptor.nodes.iter().flat_map(|node| {
+            node.outputs.iter().map(|output| TopicIdentifier {
+                node_id: node.id.clone(),
+                data_id: output.clone(),
+            })
+        }));
+        return Ok(topics);
+    }
+
+    for s in data {
+        // A bare node id (no `/`) selects every output of that node. Handle it
+        // directly rather than synthesizing `node/` and relying on an empty
+        // `DataId`, which the identifier validator rejects.
+        if !s.contains('/') {
+            let node_id: NodeId = s
+                .parse()
+                .wrap_err_with(|| format!("invalid node id `{s}`"))?;
+            let node = *node_map
+                .get(&node_id)
+                .with_context(|| unknown_node_err(&node_id))?;
+            topics.extend(node.outputs.iter().map(|output| TopicIdentifier {
+                node_id: node_id.clone(),
+                data_id: output.clone(),
+            }));
+            continue;
+        }
+
+        match s.parse() {
+            Ok(InputMapping::User(user)) => {
+                let node = *node_map
+                    .get(&user.source)
+                    .with_context(|| unknown_node_err(&user.source))?;
+                if node.outputs.contains(&user.output) {
+                    topics.insert(TopicIdentifier {
+                        node_id: user.source,
+                        data_id: user.output,
+                    });
+                } else {
+                    bail!(
+                        "node `{}` does not have output `{}`\n\n  \
+                         hint: available outputs: {}",
+                        user.source,
+                        user.output,
+                        node.outputs
+                            .iter()
+                            .map(|o| o.to_string())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    );
+                }
+            }
+            Ok(_) => {
+                bail!("Reserved input mapping cannot be inspected")
+            }
+            Err(e) => bail!("Invalid output id `{s}`: {e}"),
+        }
+    }
+
+    if topics.is_empty() {
+        bail!(
+            "no outputs found in this dataflow\n\n  \
+             hint: ensure nodes in the dataflow declare `outputs` in their YAML definition"
+        );
+    }
+
+    Ok(topics)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn descriptor() -> Descriptor {
+        serde_yaml::from_str(
+            "\
+nodes:
+  - id: camera
+    path: camera
+    outputs:
+      - frame
+      - status
+  - id: sink
+    path: sink
+    inputs:
+      image: camera/frame
+",
+        )
+        .expect("parse descriptor")
+    }
+
+    fn topic(node: &str, output: &str) -> TopicIdentifier {
+        TopicIdentifier {
+            node_id: node.to_string().into(),
+            data_id: output.to_string().into(),
+        }
+    }
+
+    #[test]
+    fn bare_node_id_expands_to_all_outputs() {
+        // Regression: `dora topic <node>` (a bare node id) previously errored
+        // with `Invalid output id `camera/`: identifier must not be empty`
+        // because the code appended `/` and relied on an empty `DataId`.
+        let topics = resolve_topics(&["camera".to_string()], &descriptor()).unwrap();
+        assert_eq!(
+            topics,
+            BTreeSet::from([topic("camera", "frame"), topic("camera", "status")])
+        );
+    }
+
+    #[test]
+    fn qualified_output_selects_exactly_one() {
+        let topics = resolve_topics(&["camera/frame".to_string()], &descriptor()).unwrap();
+        assert_eq!(topics, BTreeSet::from([topic("camera", "frame")]));
+    }
+
+    #[test]
+    fn empty_selector_returns_every_output() {
+        let topics = resolve_topics(&[], &descriptor()).unwrap();
+        assert_eq!(
+            topics,
+            BTreeSet::from([topic("camera", "frame"), topic("camera", "status")])
+        );
+    }
+
+    #[test]
+    fn unknown_bare_node_reports_hint() {
+        let err = resolve_topics(&["ghost".to_string()], &descriptor()).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("unknown node `ghost`"), "unexpected: {msg}");
+        assert!(msg.contains("available nodes"), "unexpected: {msg}");
+    }
+
+    #[test]
+    fn unknown_output_reports_hint() {
+        let err = resolve_topics(&["camera/nope".to_string()], &descriptor()).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("does not have output `nope`"),
+            "unexpected: {msg}"
+        );
     }
 }


### PR DESCRIPTION
## Issue

`dora topic echo/hz/info <node-id>` — passing a **bare node id**, which is meant to select *every output of that node* — always fails with a confusing error:

```
Invalid output id `camera/`: identifier must not be empty
```

`TopicSelector::resolve_with_descriptor` appended a trailing `/` to any argument without a slash and then relied on `InputMapping` parsing to yield an *empty* output id, dispatching through the `user.output.is_empty()` branch to expand to all outputs. But `InputMapping::from_str` (`libraries/message/src/config.rs`) splits on the first `/` and parses the remainder as a `DataId`, whose validator (`libraries/message/src/id.rs`) rejects the empty string. So `"camera/".parse::<InputMapping>()` returns `Err`, control falls to `Err(e) => bail!("Invalid output id ...")`, and the `is_empty()` branch was **unreachable dead code**.

## Fix

Handle the bare-node case explicitly, *before* touching `InputMapping` parsing: a slash-less selector is parsed as a `NodeId` and expanded to every declared output. The fragile append-`/` hack is removed. The topic-resolution logic is extracted into a pure `resolve_topics(data, descriptor)` function so it can be unit-tested without a live coordinator session, and the "unknown node" hint is deduplicated into a small closure shared by both the bare-node and qualified-output paths.

## Validation

- New regression tests (5) cover bare-node expansion, qualified-output selection, the empty-selector case, and the unknown-node / unknown-output error hints — all passing (`cargo test -p dora-cli --lib command::topic::selector`).
- `cargo test -p dora-cli --lib` green (325 tests); `cargo fmt --all -- --check` and `cargo clippy -p dora-cli -- -D warnings` clean; whole-workspace `cargo check --all` clean.
- Verified the explicit-trailing-slash case (`dora topic camera/`) still errors as before — no behavior regression.

---

🤖 **This is a machine-generated pull request.** It was produced by Claude (an AI agent, model Opus 4.8) during an automated code-review pass over the repository. Please review carefully before merging; a human maintainer should confirm the analysis and the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166mzsNqG9bPzoKoQSS3CWk

---
_Generated by [Claude Code](https://claude.ai/code/session_0166mzsNqG9bPzoKoQSS3CWk)_