### PR TITLE
perf(daemon): build the output routing key once per message in send_out

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -144,9 +144,9 @@ pub mod bench_support {
 
     /// Run one iteration of the routing hot path using pre-built fixture.
     pub async fn route_message(df: &mut RunningDataflow, fixture: &RoutingFixture, clock: &HLC) {
+        let output_id = OutputId(fixture.sender_id.clone(), fixture.output_id.clone());
         let _ = send_output_to_local_receivers(
-            fixture.sender_id.clone(),
-            fixture.output_id.clone(),
+            &output_id,
             df,
             &fixture.metadata,
             Some(fixture.data_msg.clone()),
@@ -3741,9 +3741,11 @@ impl Daemon {
                     let dataflow = self.running.get_mut(&dataflow_id).wrap_err_with(|| {
                         format!("send out failed: no running dataflow with ID `{dataflow_id}`")
                     })?;
+                    // `node_id` is still needed below for the error logger, so
+                    // clone it into the key; `output_id` is moved.
+                    let output_id_key = OutputId(node_id.clone(), output_id);
                     send_output_to_local_receivers(
-                        node_id.clone(),
-                        output_id.clone(),
+                        &output_id_key,
                         dataflow,
                         &metadata,
                         data.map(DataMessage::Vec),
@@ -5013,17 +5015,18 @@ impl Daemon {
             self.log_late_node_output(&dataflow_id, &node_id, &output_id, "send out");
             return Ok(());
         };
-        let output_id_key = OutputId(node_id.clone(), output_id.clone());
+        // Build the `(NodeId, DataId)` routing key once by moving `node_id`/
+        // `output_id` in (neither is read past this point). It is used for the
+        // two `contains` lookups below, passed by reference into local delivery,
+        // and reused for the inter-daemon path — avoiding the previous
+        // per-message clone of the `NodeId`/`DataId` on this output-dispatch hot
+        // path.
+        let output_id_key = OutputId(node_id, output_id);
         let remote_receivers = dataflow.open_external_mappings.contains(&output_id_key)
             || dataflow.enable_debug_inspection;
         let has_debug_watchers = dataflow.debug_topic_watchers.contains_key(&output_id_key);
-        // `node_id`/`output_id` are not read past this call — the later
-        // inter-daemon path uses `output_id_key` (cloned just above) instead —
-        // so move them in rather than adding a second per-message clone of the
-        // `NodeId`/`DataId` on this output-dispatch hot path.
         let data_bytes = send_output_to_local_receivers(
-            node_id,
-            output_id,
+            &output_id_key,
             dataflow,
             &metadata,
             data,
@@ -6630,8 +6633,7 @@ fn note_output_sent_to_local_receivers(
 
 #[allow(clippy::too_many_arguments)]
 async fn send_output_to_local_receivers(
-    node_id: NodeId,
-    output_id: DataId,
+    output_id: &OutputId,
     dataflow: &mut RunningDataflow,
     metadata: &metadata::Metadata,
     data: Option<DataMessage>,
@@ -6641,8 +6643,7 @@ async fn send_output_to_local_receivers(
 ) -> Result<Option<AVec<u8, ConstAlign<128>>>, eyre::ErrReport> {
     let timestamp = metadata.timestamp();
     let empty_set = BTreeSet::new();
-    let output_id = OutputId(node_id, output_id);
-    let local_receivers = dataflow.mappings.get(&output_id).unwrap_or(&empty_set);
+    let local_receivers = dataflow.mappings.get(output_id).unwrap_or(&empty_set);
     let data = data.map(Arc::new);
     let mut closed = Vec::new();
     // Clone the metadata into an `Arc` lazily, on the first actual delivery.
@@ -9022,8 +9023,9 @@ mod fault_tolerance_tests {
         // Send data from upstream
         let metadata = metadata::Metadata::new(clock.new_timestamp());
 
+        let output_id = OutputId(sender, output);
         let result = send_output_to_local_receivers(
-            sender, output, &mut df, &metadata, None, &clock, None, false,
+            &output_id, &mut df, &metadata, None, &clock, None, false,
         )
         .await;
         assert!(result.is_ok());
@@ -9067,9 +9069,9 @@ mod fault_tolerance_tests {
         let mut df = test_dataflow();
         let metadata = metadata::Metadata::new(clock.new_timestamp());
         let data = DataMessage::Vec(AVec::from_slice(128, &payload));
+        let output_id = OutputId(sender.clone(), output.clone());
         let result = send_output_to_local_receivers(
-            sender.clone(),
-            output.clone(),
+            &output_id,
             &mut df,
             &metadata,
             Some(data),
@@ -9094,9 +9096,9 @@ mod fault_tolerance_tests {
         df.subscribe_channels.insert(receiver.clone(), tx);
         let metadata = metadata::Metadata::new(clock.new_timestamp());
         let data = DataMessage::Vec(AVec::from_slice(128, &payload));
+        let output_id = OutputId(sender, output);
         let result = send_output_to_local_receivers(
-            sender,
-            output,
+            &output_id,
             &mut df,
             &metadata,
             Some(data),
@@ -9172,8 +9174,9 @@ mod fault_tolerance_tests {
         // Step 2: Upstream sends data again — recovery
         let metadata = metadata::Metadata::new(clock.new_timestamp());
 
+        let output_id = OutputId(sender, output);
         let result = send_output_to_local_receivers(
-            sender, output, &mut df, &metadata, None, &clock, None, false,
+            &output_id, &mut df, &metadata, None, &clock, None, false,
         )
         .await;
         assert!(result.is_ok());


### PR DESCRIPTION
## Issue

`Daemon::send_out` (`binaries/daemon/src/lib.rs`) runs for **every** message on the daemon path. It cloned `node_id` and `output_id` to build an `OutputId` key for two map lookups (`open_external_mappings`, `debug_topic_watchers`), then moved the originals into `send_output_to_local_receivers`, which immediately rebuilt the *identical* `OutputId` from them:

```rust
let output_id_key = OutputId(node_id.clone(), output_id.clone()); // 2 String allocations
...
send_output_to_local_receivers(node_id, output_id, ...);          // rebuilds OutputId(node_id, output_id)
```

`NodeId`/`DataId` are `String`-backed, so this is two heap allocations per message purely to construct a key that is then reconstructed.

## Fix

Change `send_output_to_local_receivers` to take `output_id: &OutputId`. `send_out` now builds the key **once** by moving `node_id`/`output_id` in (neither is read afterwards) and passes it by reference; the key is reused for both `contains` checks, local delivery, and the inter-daemon path. The inter-daemon (`handle_inter_daemon_event`) call site keeps a single `node_id.clone()` because `node_id` is still needed there by the error logger. All call sites (production + the four routing/circuit-breaker unit tests + the routing bench helper) are updated.

Net effect: 2 `String` allocations per daemon-path message → 0 (main path) / 1 (inter-daemon error-logging path). Behavior is unchanged.

## Validation

- `cargo test -p dora-daemon --lib` green (173 tests, incl. the circuit-breaker recovery tests that exercise `send_output_to_local_receivers` directly).
- `cargo clippy -p dora-daemon -- -D warnings` and `cargo fmt --all -- --check` clean; whole-workspace `cargo check --all` clean.

---

🤖 **This is a machine-generated pull request.** It was produced by Claude (an AI agent, model Opus 4.8) during an automated code-review pass over the repository. Please review carefully before merging; a human maintainer should confirm the analysis and the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166mzsNqG9bPzoKoQSS3CWk

---
_Generated by [Claude Code](https://claude.ai/code/session_0166mzsNqG9bPzoKoQSS3CWk)_