### PR TITLE
docs(operator): document the public unsafe FFI entry points in raw.rs

### DIFF
--- a/apis/rust/operator/src/raw.rs
+++ b/apis/rust/operator/src/raw.rs
@@ -1,9 +1,28 @@
+//! Low-level FFI entry points backing the [`register_operator!`] macro.
+//!
+//! [`register_operator!`] generates the three `extern "C"` shims the dora
+//! runtime calls — `dora_init_operator`, `dora_drop_operator`, and
+//! `dora_on_event` — and forwards each to the matching function here,
+//! monomorphized for the user's operator type. These functions are `unsafe`
+//! because they move ownership of the operator across the C ABI boundary as a
+//! raw `*mut c_void`; user code should never call them directly.
+//!
+//! [`register_operator!`]: crate::register_operator
+
 use crate::{DoraOperator, DoraOutputSender, DoraStatus, Event};
 use dora_operator_api_types::{
     DoraInitResult, DoraResult, OnEventResult, RawEvent, SendOutput, arrow,
 };
 use std::ffi::c_void;
 
+/// Construct the operator (`O::default()`), box it, and hand ownership back to
+/// the runtime as an opaque `operator_context` pointer.
+///
+/// # Safety
+///
+/// The returned `operator_context` points to a leaked `Box<O>`. The caller must
+/// eventually pass it to [`dora_drop_operator::<O>`] exactly once (with the same
+/// `O`) to reclaim it, and must not use it after that.
 pub unsafe fn dora_init_operator<O: DoraOperator>() -> DoraInitResult {
     let operator: O = Default::default();
     let ptr: *mut O = Box::leak(Box::new(operator));
@@ -14,12 +33,30 @@ pub unsafe fn dora_init_operator<O: DoraOperator>() -> DoraInitResult {
     }
 }
 
+/// Reclaim and drop the operator behind `operator_context`.
+///
+/// # Safety
+///
+/// `operator_context` must be a pointer previously returned by
+/// [`dora_init_operator::<O>`] for the same `O`, and must not have been dropped
+/// already. After this call the pointer is dangling and must not be reused.
 pub unsafe fn dora_drop_operator<O>(operator_context: *mut c_void) -> DoraResult {
     let raw: *mut O = operator_context.cast();
     drop(unsafe { Box::from_raw(raw) });
     DoraResult { error: None }
 }
 
+/// Dispatch one runtime event to the operator's [`DoraOperator::on_event`].
+///
+/// A panic in the user's `on_event` is caught and reported as an operator error
+/// (with `DoraStatus::Stop`) rather than being allowed to unwind across the C
+/// ABI boundary, which would abort the process.
+///
+/// # Safety
+///
+/// `operator_context` must be a valid pointer returned by
+/// [`dora_init_operator::<O>`] for the same `O` and not yet dropped. `event` and
+/// `send_output` must be valid for the duration of the call.
 pub unsafe fn dora_on_event<O: DoraOperator>(
     event: &mut RawEvent,
     send_output: &SendOutput,


### PR DESCRIPTION
## Issue

`apis/rust/operator/src/raw.rs` exposes the three low-level FFI functions (`dora_init_operator`, `dora_drop_operator`, `dora_on_event`) that the `register_operator!` macro wraps in generated `extern "C"` shims. Unlike the rest of the crate (`DoraOperator`, `Event`, `DoraOutputSender` are all richly documented), this module had **no module doc and no per-function docs**, and the three `pub unsafe fn`s carried no `# Safety` section describing their ownership/validity contracts.

## Fix

Documentation only — no behavior change:

- Add a module doc explaining these are the macro-driven FFI entry points and should not be called directly by users.
- Add per-function docs, each with a `# Safety` section stating the pointer-ownership/validity contract (e.g. the `operator_context` must come from `dora_init_operator::<O>` and be dropped exactly once). For `dora_on_event`, document that it catches a panic in the user's `on_event` and reports it as an operator error rather than unwinding across the C ABI boundary (which would abort the process).

## Validation

- `cargo test -p dora-operator-api` green (unit tests + 1 doctest); `cargo doc` renders the new docs.
- `cargo clippy -p dora-operator-api -- -D warnings` and `cargo fmt --all -- --check` clean; whole-workspace `cargo check --all` clean.

---

🤖 **This is a machine-generated pull request.** It was produced by Claude (an AI agent, model Opus 4.8) during an automated code-review pass over the repository. Please review carefully before merging; a human maintainer should confirm the documented safety contracts are accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166mzsNqG9bPzoKoQSS3CWk

---
_Generated by [Claude Code](https://claude.ai/code/session_0166mzsNqG9bPzoKoQSS3CWk)_