### PR TITLE
fix(cli): reject cluster host/user starting with `-` (ssh arg injection)

### DIFF
--- a/binaries/cli/src/command/cluster/config.rs
+++ b/binaries/cli/src/command/cluster/config.rs
@@ -105,6 +105,20 @@ impl ClusterConfig {
             if m.host.is_empty() {
                 bail!("machine `{}` host must not be empty", m.id);
             }
+            // `host`/`user` are folded into the ssh *target* (`{user}@{host}`)
+            // and passed to the local `ssh` binary. They are deliberately not
+            // run through `validate_shell_safe` (a target legitimately carries
+            // `:`/`[`/`]` for IPv6 literals, `@`, etc.), but a value that begins
+            // with `-` is parsed by `ssh`'s own argument parser as an *option*
+            // rather than a hostname — e.g. `-oProxyCommand=...` executes an
+            // arbitrary command on the local machine before connecting (the
+            // classic ssh/git argument-injection class, cf. CVE-2017-1000117).
+            // Reject a leading dash on both fields; `run_ssh` additionally
+            // passes `--` before the target as defense-in-depth.
+            validate_no_leading_dash(&format!("machine `{}` host", m.id), &m.host)?;
+            if let Some(user) = &m.user {
+                validate_no_leading_dash(&format!("machine `{}` user", m.id), user)?;
+            }
             // Reject daemon_port = 0: the daemon would bind an ephemeral port
             // but exports DORA_DAEMON_LOCAL_LISTEN_PORT=0 to spawned nodes
             // (binaries/cli/src/command/daemon.rs), so they fail to connect.
@@ -125,6 +139,17 @@ fn validate_shell_safe(what: &str, value: &str) -> eyre::Result<()> {
         .find(|c| !c.is_ascii_alphanumeric() && *c != '_' && *c != '-' && *c != '.')
     {
         bail!("{what} contains invalid character `{ch}` -- only [a-zA-Z0-9_.-] are allowed");
+    }
+    Ok(())
+}
+
+/// Reject a value that begins with `-`, which the local `ssh` binary would
+/// otherwise parse as an option rather than a hostname/user (argument
+/// injection). Unlike [`validate_shell_safe`] this places no charset
+/// restriction, so IPv6 literals and normal `user@host` values stay valid.
+fn validate_no_leading_dash(what: &str, value: &str) -> eyre::Result<()> {
+    if value.starts_with('-') {
+        bail!("{what} must not start with `-` (would be parsed as an ssh option)");
     }
     Ok(())
 }
@@ -338,6 +363,51 @@ mod tests {
         );
         let cfg = ClusterConfig::load(f.path()).unwrap();
         assert_eq!(cfg.zenoh_peer.as_deref(), Some("tcp/[::1]:7447"));
+    }
+
+    #[test]
+    fn reject_host_with_leading_dash() {
+        // A `host` beginning with `-` is parsed by the local `ssh` binary as an
+        // option (e.g. `-oProxyCommand=touch /tmp/pwned;false`), giving arbitrary
+        // local command execution before any network connection is made.
+        let f = write_yaml(
+            "coordinator:\n  addr: 10.0.0.1\nmachines:\n  - id: a\n    host: \"-oProxyCommand=touch /tmp/pwned;false\"\n",
+        );
+        let err = ClusterConfig::load(f.path()).unwrap_err().to_string();
+        assert!(
+            err.contains("must not start with `-`") && err.contains("host"),
+            "host with leading dash should be rejected, got: {err}"
+        );
+    }
+
+    #[test]
+    fn reject_user_with_leading_dash() {
+        // `ssh_target` yields `{user}@{host}`, so a `user` beginning with `-`
+        // produces a target string that also starts with `-` — same vector.
+        let f = write_yaml(
+            "coordinator:\n  addr: 10.0.0.1\nmachines:\n  - id: a\n    host: h\n    user: \"-oProxyCommand=x\"\n",
+        );
+        let err = ClusterConfig::load(f.path()).unwrap_err().to_string();
+        assert!(
+            err.contains("must not start with `-`") && err.contains("user"),
+            "user with leading dash should be rejected, got: {err}"
+        );
+    }
+
+    #[test]
+    fn accept_ipv6_host() {
+        // An IPv6 literal host carries `:` (and may be bracketed) — the id
+        // charset would reject it, but host/user are only checked for a leading
+        // dash, so it must stay valid.
+        for host in ["::1", "2001:db8::1", "192.168.1.10"] {
+            let f = write_yaml(&format!(
+                "coordinator:\n  addr: 10.0.0.1\nmachines:\n  - id: a\n    host: \"{host}\"\n"
+            ));
+            assert!(
+                ClusterConfig::load(f.path()).is_ok(),
+                "host `{host}` should be accepted"
+            );
+        }
     }
 
     #[test]

--- a/binaries/cli/src/command/cluster/mod.rs
+++ b/binaries/cli/src/command/cluster/mod.rs
@@ -102,7 +102,11 @@ pub(super) fn run_ssh(target: &str, port: Option<u16>, cmd: &str) -> eyre::Resul
     if let Some(p) = port {
         command.args(["-p", &p.to_string()]);
     }
-    command.args([target, cmd]);
+    // `--` marks the end of options so a `target` beginning with `-` (e.g. a
+    // malicious `-oProxyCommand=...`) is treated as the hostname, not an ssh
+    // option. Defense-in-depth: `ClusterConfig::validate` already rejects a
+    // leading dash on `host`/`user`.
+    command.args(["--", target, cmd]);
     let status = command
         .status()
         .with_context(|| format!("failed to run ssh to {target}"))?;


### PR DESCRIPTION
## Summary

Closes #3133.

`dora cluster` builds its ssh target by folding `machine.host`/`machine.user` verbatim (`{user}@{host}`) and passes it to the local `ssh` binary **with no `--` end-of-options separator** (`run_ssh`). If `host` (or `user`) begins with `-`, the local `ssh` client parses the target as an **option** rather than a hostname — the classic ssh/git argument-injection class (cf. CVE-2017-1000117).

### Exploit

```yaml
machines:
  - id: a
    host: "-oProxyCommand=touch /tmp/pwned;false"
```

produces `ssh … -oProxyCommand=touch /tmp/pwned;false <cmd>`, so `ssh` runs `touch /tmp/pwned;false` **on the machine running `dora cluster up`**, before/instead of connecting. `user` is an equivalent vector since `ssh_target` yields `{user}@{host}`.

#2861 deliberately left `host`/`user` unvalidated because they legitimately carry characters the id charset rejects (IPv6 literals, `@`), but that reasoning only ruled out injection into the *remote* shell — it overlooked injection into the *local* ssh argv, which executes before any network connection.

## Changes

Two complementary defenses (matching the issue's suggested fix):

1. **`ClusterConfig::validate` rejects a `host`/`user` beginning with `-`** via a dedicated `validate_no_leading_dash` check. This can't be folded into `validate_shell_safe` (whose `[a-zA-Z0-9_.-]` charset would reject the `:`/`[`/`]` in an IPv6 literal), so it's a separate leading-dash-only check that keeps IPv6 literals and normal `user@host` values valid.
2. **`run_ssh` inserts a literal `--` before the target** (`command.args(["--", target, cmd])`) as defense-in-depth — OpenSSH treats `--` as an end-of-options marker, and because every `dora cluster` subcommand routes through `run_ssh`, one change covers them all.

## Tests

Added to `binaries/cli/src/command/cluster/config.rs`:
- `reject_host_with_leading_dash` — the `-oProxyCommand=…` payload is rejected.
- `reject_user_with_leading_dash` — the equivalent `user` vector is rejected.
- `accept_ipv6_host` — `::1`, `2001:db8::1`, and a plain IPv4 host stay valid (regression guard so the new check doesn't over-reject).

`cargo test -p dora-cli` (21 cluster tests pass), `cargo clippy -p dora-cli -- -D warnings`, and `cargo fmt --check` are all green.

## Note on a related low-severity observation

The issue also mentions `validate_endpoint_shell_safe` permitting `[`/`]` in `zenoh_peer` (interpolated unquoted into the remote command). As the issue itself notes, that is not command injection under default `sh`/`bash` — it's left out of this PR to keep the change focused on the security-relevant argument-injection fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xtgsx6GZ58s8Hm4G6AECrF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xtgsx6GZ58s8Hm4G6AECrF)_