### PR TITLE
fix(core/build): build test `file://` URLs with `Url::from_file_path` (#3137)

### DIFF
--- a/libraries/core/src/build/git.rs
+++ b/libraries/core/src/build/git.rs
@@ -757,6 +757,15 @@ mod tests {
             .to_string()
     }
 
+    // A `file://` URL for a local absolute path. `format!("file://{}", p.display())`
+    // is not portable: on Windows it yields `file://C:\...`, which puts the drive
+    // letter in the authority and leaves the backslashes as non-separators, so
+    // libgit2 refuses to resolve it (#3137). `Url::from_file_path` emits the
+    // well-formed `file:///C:/...` on every platform.
+    fn file_url(path: &Path) -> Url {
+        Url::from_file_path(path).expect("test repo path must be absolute")
+    }
+
     #[test]
     fn clone_dir_path_keeps_a_file_url_drive_letter_out_of_the_on_disk_path() {
         // A `file://` URL to a Windows-style absolute path parses with the
@@ -922,7 +931,8 @@ mod tests {
         let repo_dir = tempfile::tempdir().unwrap();
         let repo_path = repo_dir.path().join("repo");
         let commit = init_repo_with_commit(&repo_path);
-        let repo_url_str = format!("file://{}", repo_path.display());
+        let repo_url = file_url(&repo_path);
+        let repo_url_str = repo_url.to_string();
         let target_dir = tempfile::tempdir().unwrap();
 
         let mut manager = GitManager::default();
@@ -945,8 +955,7 @@ mod tests {
         // before it's a valid, HEAD-resolvable repo). Session B must see
         // this as owned by an in-flight build, not as a finished clone to
         // verify.
-        let parsed = Url::parse(&repo_url_str).unwrap();
-        let clone_dir = GitManager::clone_dir_path(target_dir.path(), &parsed, &commit).unwrap();
+        let clone_dir = GitManager::clone_dir_path(target_dir.path(), &repo_url, &commit).unwrap();
         std::fs::create_dir_all(&clone_dir).unwrap();
 
         let session_b = SessionId::generate();
@@ -981,7 +990,8 @@ mod tests {
         let repo_dir = tempfile::tempdir().unwrap();
         let repo_path = repo_dir.path().join("repo");
         let commit = init_repo_with_commit(&repo_path);
-        let repo_url_str = format!("file://{}", repo_path.display());
+        let repo_url = file_url(&repo_path);
+        let repo_url_str = repo_url.to_string();
         let target_dir = tempfile::tempdir().unwrap();
 
         let mut manager = GitManager::default();
@@ -1012,8 +1022,7 @@ mod tests {
         // The dir shows up on disk, then A finishes and drops its claim.
         // B is still writing, so a third session must not get a commit to
         // verify.
-        let parsed = Url::parse(&repo_url_str).unwrap();
-        let clone_dir = GitManager::clone_dir_path(target_dir.path(), &parsed, &commit).unwrap();
+        let clone_dir = GitManager::clone_dir_path(target_dir.path(), &repo_url, &commit).unwrap();
         std::fs::create_dir_all(&clone_dir).unwrap();
         drop(folder_a);
 
@@ -1077,7 +1086,7 @@ mod tests {
         let repo_dir = tempfile::tempdir().unwrap();
         let repo_path = repo_dir.path().join("repo");
         let old_commit = init_repo_with_commit(&repo_path);
-        let repo_url = format!("file://{}", repo_path.display());
+        let repo_url = file_url(&repo_path).to_string();
 
         let target_dir = tempfile::tempdir().unwrap();
         let mut manager = GitManager::default();
@@ -1255,8 +1264,7 @@ mod tests {
     // Clone `origin` into `dest` so `dest` carries an `origin` remote that
     // `fetch_changes` can pull from — the shape the Copy/Rename arms expect.
     fn clone_from_origin(origin: &Path, dest: &Path) {
-        let url = format!("file://{}", origin.display());
-        git2::Repository::clone(&url, dest).unwrap();
+        git2::Repository::clone(file_url(origin).as_str(), dest).unwrap();
     }
 
     fn head_commit(dir: &Path) -> String {
@@ -1335,7 +1343,7 @@ mod tests {
         let repo_dir = tempfile::tempdir().unwrap();
         let repo_path = repo_dir.path().join("repo");
         let commit = init_repo_with_commit(&repo_path);
-        let repo_url = Url::parse(&format!("file://{}", repo_path.display())).unwrap();
+        let repo_url = file_url(&repo_path);
 
         let base = tempfile::tempdir().unwrap();
         let target = base.path().join("localhost").join(&commit);
@@ -1367,7 +1375,7 @@ mod tests {
         std::fs::create_dir_all(target.parent().unwrap()).unwrap();
         // A file:// URL to a path that isn't a git repo -> clone fails.
         let missing = base.path().join("does-not-exist");
-        let repo_url = Url::parse(&format!("file://{}", missing.display())).unwrap();
+        let repo_url = file_url(&missing);
 
         let folder = GitFolder {
             reuse: ReuseOptions::NewClone {


### PR DESCRIPTION
Fixes #3137 — the `test-cross-platform` nightly failure on the Windows runner.

## The failure

Two tests in `libraries/core/src/build/git.rs` failed on the Windows runner (333 passed, 2 failed):

```
---- build::git::tests::copy_and_fetch_promotes_into_target stdout ----
thread 'build::git::tests::copy_and_fetch_promotes_into_target' panicked at libraries\core\src\build\git.rs:1259:45:
called `Result::unwrap()` on an `Err` value: Error { code: -1, klass: 2,
  message: "failed to resolve path 'file://C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\.tmp9Db4Gl\\origin':
            The filename, directory name, or volume label syntax is incorrect." }
```

Line 1259 was the test helper `clone_from_origin`:

```rust
let url = format!("file://{}", origin.display());
git2::Repository::clone(&url, dest).unwrap();
```

`format!("file://{}", path.display())` is only well-formed for a `/`-rooted Unix path. On Windows it produces `file://C:\Users\...`, which puts the drive letter in the URL *authority* and leaves the backslashes as non-separators, so the string doesn't address the repo at all and libgit2 refuses to resolve it.

Introduced by #2809 (merged 2026-08-11), which added the Copy/Rename promotion tests and this helper; the nightly failed the next morning. The other `format!("file://…")` sites in the module survived only because they funnel the string through `Url::parse`, and the url crate silently normalizes the malformed spelling to `file:///C:/…`.

**Production is not affected.** `clone_into` (`libraries/core/src/build/git.rs:632`) takes an already-parsed `url::Url`, and `GitManager::choose_clone_dir` parses the descriptor's `git:` field with `Url::parse`, so a real build never sees the raw `format!` spelling. This is a test-side bug only — the same run's `new_clone_promotes_temp_into_target_and_cleans_up`, which clones through a parsed `Url`, passed on that Windows runner.

## The change

Route every test-side `file://` construction through one helper:

```rust
fn file_url(path: &Path) -> Url {
    Url::from_file_path(path).expect("test repo path must be absolute")
}
```

`Url::from_file_path` emits the well-formed `file:///C:/Users/…` on every platform, so the tests now exercise the same URL shape production does. Six call sites converted; `clone_from_origin` passes `file_url(origin).as_str()` straight to git2.

Two `Url::parse(&repo_url_str).unwrap()` round-trips fall out as dead weight, since the helper hands back a `Url` the tests can pass to `clone_dir_path` directly.

No production code changed; no behavior change on Linux/macOS, where the old and new spellings are byte-identical.

## Validation

Class A (test-only, no behavior change), per `docs/agentic-qa-policy.md`:

- `cargo test -p dora-core --all-features` — **339 passed, 0 failed** (the 23 `build::git::tests::*` included)
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p dora-core --all-features --all-targets -- -D warnings` — clean
- `/review` — no findings; `/simplify` — applied its findings (dropped a self-referential round-trip test that only exercised the `url` crate, trimmed the duplicated comment, removed the two redundant re-parses)

Not run locally: the full `cargo test --all` sweep — this container ran out of disk partway through linking the workspace's example binaries (`No space left on device`), not on any test failure. Since the change lives entirely inside dora-core's `#[cfg(test)]` module, no other crate compiles it. The Windows half of the fix is verified by the nightly `test-cross-platform` job, which is what has to go green.

## Out of scope

`tests/hub-smoke.rs` has six instances of the same `format!("file://{}", src.display())` idiom (lines 107, 636, 687, 710, 770, 810). Its nightly job is `ubuntu-latest` only, so they are not currently broken; worth a follow-up if hub-smoke ever runs on Windows.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C74rZYpFMVdg4B9HHt5BYL)_