### PR TITLE
refactor(coordinator): resolve archived log daemon by direct node lookup

### DIFF
--- a/binaries/coordinator/src/handlers.rs
+++ b/binaries/coordinator/src/handlers.rs
@@ -456,20 +456,15 @@ fn resolve_log_daemon_id(
     daemon_connections: &DaemonConnections,
 ) -> eyre::Result<DaemonId> {
     if let Some(nodes) = archived_nodes {
-        let machine_ids: Vec<Option<String>> = nodes
-            .values()
-            .filter(|node| node.id == *node_id)
-            .map(|node| node.deploy.as_ref().and_then(|d| d.machine.clone()))
-            .collect();
-
-        let machine_id = match &machine_ids[..] {
-            [machine_id] => machine_id.clone(),
-            [] => bail!("No machine contains {}/{}", dataflow_id, node_id),
-            _ => bail!(
-                "More than one machine contains {}/{}. However, it should only be present on one.",
-                dataflow_id,
-                node_id
-            ),
+        // `nodes` is keyed by `NodeId` and every `ResolvedNode.id` equals its map
+        // key (see `resolve_aliases_and_set_defaults_in_topology`, which also
+        // rejects duplicate ids), so a direct lookup is equivalent to — and
+        // cheaper than — scanning every entry for a matching `id`. The previous
+        // `Vec` scan additionally carried an "more than one machine" arm that the
+        // map key uniqueness made unreachable.
+        let machine_id = match nodes.get(node_id) {
+            Some(node) => node.deploy.as_ref().and_then(|d| d.machine.clone()),
+            None => bail!("No machine contains {}/{}", dataflow_id, node_id),
         };
 
         let daemon_ids: Vec<_> = match &machine_id {


### PR DESCRIPTION
## Summary

`resolve_log_daemon_id` (in `binaries/coordinator/src/handlers.rs`) resolves which daemon holds a node's logs. For an **archived** dataflow it scanned every entry of the `BTreeMap<NodeId, ResolvedNode>` with a `filter(|node| node.id == *node_id)`, collected into a `Vec`, then matched on the slice:

```rust
let machine_id = match &machine_ids[..] {
    [machine_id] => machine_id.clone(),
    [] => bail!("No machine contains {}/{}", dataflow_id, node_id),
    _ => bail!("More than one machine contains {}/{}. ...", ...),
};
```

## Issue

That map is keyed by `NodeId`, and every `ResolvedNode.id` equals its map key — this is established in `resolve_aliases_and_set_defaults_in_topology` (`libraries/core/src/descriptor/mod.rs`), which inserts `resolved.insert(node.id.clone(), ResolvedNode { id: node.id, ... })` and additionally `bail!`s on a duplicate id. `ArchivedDataflow` is built by cloning that same map (`coordinator/src/state.rs`).

Consequently the filter can never match more than one entry:
- The `_ =>` ("More than one machine contains …") arm is **unreachable dead code**.
- The O(n) `values().filter(...)` scan is a `BTreeMap::get` (O(log n)) written the long way.

## Fix

Replace the scan + three-arm match with a direct lookup:

```rust
let machine_id = match nodes.get(node_id) {
    Some(node) => node.deploy.as_ref().and_then(|d| d.machine.clone()),
    None => bail!("No machine contains {}/{}", dataflow_id, node_id),
};
```

Behavior is preserved, including the `No machine contains …` error for an unknown node id. Only the unreachable arm and the redundant scan are removed.

## Validation

- `cargo fmt -p dora-coordinator`
- `cargo clippy -p dora-coordinator -- -D warnings` — clean
- `cargo test -p dora-coordinator` — all passing (unit + `ws_daemon_tests`)

---

⚠️ **This PR was generated by Claude (an AI agent).** It is machine-generated; please review carefully before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Gx9pmbBexUg4kniRCoHCr)_