### PR TITLE
refactor(message): give the OpenTelemetry context key a single const

### DIFF
--- a/apis/rust/node/src/lib.rs
+++ b/apis/rust/node/src/lib.rs
@@ -93,8 +93,9 @@ pub use dora_message::{
     DataflowId,
     metadata::{
         self, FIN, FLUSH, GOAL_ID, GOAL_STATUS, GOAL_STATUS_ABORTED, GOAL_STATUS_CANCELED,
-        GOAL_STATUS_SUCCEEDED, Metadata, MetadataParameters, Parameter, REQUEST_ID, SEGMENT_ID,
-        SEQ, SESSION_ID, get_bool_param, get_integer_param, get_string_param,
+        GOAL_STATUS_SUCCEEDED, Metadata, MetadataParameters, OPEN_TELEMETRY_CONTEXT, Parameter,
+        REQUEST_ID, SEGMENT_ID, SEQ, SESSION_ID, get_bool_param, get_integer_param,
+        get_string_param,
     },
 };
 use dora_message::{

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -1663,12 +1663,12 @@ impl DoraNode {
         // OTel Baggage is NOT propagated to avoid leaking sensitive data across
         // node boundaries. If a user explicitly provides this key, it wins.
         #[cfg(feature = "tracing")]
-        if !parameters.contains_key("open_telemetry_context") {
+        if !parameters.contains_key(crate::OPEN_TELEMETRY_CONTEXT) {
             let cx = opentelemetry::Context::current();
             let serialized = dora_tracing::telemetry::serialize_context(&cx);
             if !serialized.is_empty() {
                 parameters.insert(
-                    "open_telemetry_context".to_string(),
+                    crate::OPEN_TELEMETRY_CONTEXT.to_string(),
                     crate::Parameter::String(serialized),
                 );
             }

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -479,7 +479,7 @@ impl RunningDataflow {
                         } else {
                             let mut m = BTreeMap::new();
                             m.insert(
-                                "open_telemetry_context".to_string(),
+                                dora_node_api::metadata::OPEN_TELEMETRY_CONTEXT.to_string(),
                                 dora_node_api::Parameter::String(ctx),
                             );
                             m

--- a/binaries/runtime-python/src/runner.rs
+++ b/binaries/runtime-python/src/runner.rs
@@ -213,7 +213,7 @@ pub fn run(
                     let cx = span.context();
                     let string_cx = serialize_context(&cx);
                     metadata.parameters.insert(
-                        "open_telemetry_context".to_string(),
+                        dora_node_api::metadata::OPEN_TELEMETRY_CONTEXT.to_string(),
                         Parameter::String(string_cx),
                     );
                 }
@@ -346,7 +346,7 @@ mod callback_impl {
             #[cfg(feature = "telemetry")]
             {
                 let otel = if let Some(dora_node_api::Parameter::String(otel)) =
-                    parameters.get("open_telemetry_context")
+                    parameters.get(dora_node_api::metadata::OPEN_TELEMETRY_CONTEXT)
                 {
                     otel.to_string()
                 } else {

--- a/binaries/runtime-shared-lib/src/runner.rs
+++ b/binaries/runtime-shared-lib/src/runner.rs
@@ -142,7 +142,7 @@ impl SharedLibraryOperator<'_> {
             } = output;
             let mut parameters = BTreeMap::new();
             parameters.insert(
-                "open_telemetry_context".to_string(),
+                dora_node_api::metadata::OPEN_TELEMETRY_CONTEXT.to_string(),
                 Parameter::String(open_telemetry_context.to_string()),
             );
 
@@ -205,7 +205,7 @@ impl SharedLibraryOperator<'_> {
                     let cx = span.context();
                     let string_cx = serialize_context(&cx);
                     metadata.parameters.insert(
-                        "open_telemetry_context".to_string(),
+                        dora_node_api::metadata::OPEN_TELEMETRY_CONTEXT.to_string(),
                         Parameter::String(string_cx),
                     );
                 }

--- a/libraries/message/src/metadata.rs
+++ b/libraries/message/src/metadata.rs
@@ -99,7 +99,7 @@ impl Metadata {
     }
 
     pub fn open_telemetry_context(&self) -> String {
-        get_string_param(&self.parameters, "open_telemetry_context")
+        get_string_param(&self.parameters, OPEN_TELEMETRY_CONTEXT)
             .unwrap_or("")
             .to_string()
     }
@@ -218,6 +218,17 @@ pub const GOAL_STATUS_ABORTED: &str = "aborted";
 
 /// Goal was canceled by the client.
 pub const GOAL_STATUS_CANCELED: &str = "canceled";
+
+// ---------------------------------------------------------------------------
+// Well-known metadata parameter key for distributed tracing
+// ---------------------------------------------------------------------------
+
+/// Metadata key carrying the serialized OpenTelemetry propagation context, so a
+/// trace can be continued across a dora message hop. Read via
+/// [`Metadata::open_telemetry_context`]; stamped by the node and runtime send
+/// paths when tracing is enabled. Keep this the single source of truth so the
+/// write and read sides can never drift.
+pub const OPEN_TELEMETRY_CONTEXT: &str = "open_telemetry_context";
 
 // ---------------------------------------------------------------------------
 // Well-known metadata parameter keys for the streaming pattern


### PR DESCRIPTION
## Summary

Every well-known metadata key in `dora-message` is defined once as a named `pub const` — `REQUEST_ID`, `GOAL_ID`, `SCHEMA_HASH`, `WIRE_SIZE`, and so on — precisely so the producer and consumer sides can't drift. The surrounding doc comments explicitly call these "the single source of truth".

The OpenTelemetry propagation key was the lone exception. The bare literal `"open_telemetry_context"` was hand-duplicated across:

- `libraries/message/src/metadata.rs` — `Metadata::open_telemetry_context` (read side)
- `apis/rust/node/src/node/mod.rs` — the send-path stamp
- `binaries/daemon/src/running_dataflow.rs` — the timer-tick metadata
- `binaries/runtime-shared-lib/src/runner.rs` — operator send + receive
- `binaries/runtime-python/src/runner.rs` — operator send + receive

If any copy were mistyped, distributed-trace propagation would break silently — there is no compile-time guard tying the write and read sides together.

## Fix

Introduce `pub const OPEN_TELEMETRY_CONTEXT: &str = "open_telemetry_context";` in `dora-message`, re-export it through `dora_node_api::metadata`, and use it at every site.

This is a pure de-duplication: the key string is byte-for-byte identical, so there is **no behavior change** — it only removes the drift risk by making the key a single definition, matching the pattern already used for every other well-known key.

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p dora-message -p dora-node-api -p dora-daemon` (with `dora-node-api/tracing`) `-- -D warnings` — clean
- `cargo clippy -p dora-runtime-shared-lib --features telemetry -- -D warnings` — clean
- `cargo check -p dora-runtime-python --features telemetry` — clean
- `cargo test -p dora-message` and `cargo test -p dora-node-api --lib` — all passing (173 node lib tests). The only failing node tests, `zenoh_schema_cache::advanced_pub_cache_*`, fail identically on unmodified `origin/main` — they need zenoh networking unavailable in this sandbox and are unrelated to this diff.

---

⚠️ **This PR was generated by Claude (an AI agent).** It is machine-generated; please review carefully before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Gx9pmbBexUg4kniRCoHCr)_