### PR TITLE
fix(python-node): propagate drain() conversion errors instead of faking {}

### DIFF
--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -1360,16 +1360,20 @@ impl Node {
             .drain()
             .context("Could not drain events. Channel is closed")?
             .into_iter()
+            // Propagate a conversion failure rather than substituting an empty
+            // `{}` placeholder or silently dropping the event. A bogus `{}` is
+            // indistinguishable from a real event and makes downstream
+            // `event["type"]`/`event["id"]` access raise `KeyError`; silently
+            // dropping is worse still — a lost service-response event would hang
+            // the requester with no Python-visible signal (only a `tracing`
+            // warning the node usually can't see). Surfacing the error matches
+            // `next()`, which also propagates via `?`.
             .map(|event| {
                 event
                     .to_py_dict(py)
                     .context("Could not convert event into a dict")
-                    .unwrap_or_else(|err| {
-                        tracing::warn!("failed to convert event to dict: {err:?}");
-                        PyDict::new(py).into()
-                    })
             })
-            .collect();
+            .collect::<eyre::Result<Vec<_>>>()?;
         Ok(events)
     }
 


### PR DESCRIPTION
## Summary

`Node.drain()` (in `apis/python/node/src/lib.rs`) converts each buffered event to a Python dict. On a conversion failure it substituted an **empty `PyDict` (`{}`)** into the returned list:

```rust
.unwrap_or_else(|err| {
    tracing::warn!("failed to convert event to dict: {err:?}");
    PyDict::new(py).into()   // <-- pushes {} into the result
})
```

## Issue

The empty `{}` is indistinguishable from a genuine event. Downstream Python code that iterates the drained events and accesses `event["type"]` / `event["id"]` raises `KeyError` on the placeholder, and the real conversion error is only logged — never surfaced.

## Fix

Make `drain()` **propagate** the conversion error via `?` (collecting into `eyre::Result<Vec<_>>`), exactly as `next()` already does.

An earlier revision of this PR *skipped* the failed event via `filter_map`. Per review feedback that's worse than the `{}` it replaces: a silently-dropped event has **no Python-visible signal at all** (only a `tracing` warning the node typically has no subscriber for), so e.g. a lost service-response event would hang the requester indefinitely. Propagating surfaces the failure as a normal Python exception and is consistent with `next()` — and with the project's own audit note (`docs/audit-2026-03-21-closure.md` Q4), which already describes the intended fix as drain "propagates the error".

This does not regress normal operation: a genuine conversion failure is an internal error, and `Stop`/error events carry no `value`/`metadata` so they cannot fail here — only an exceptional path changes, from silent corruption to a surfaced exception.

## Validation

- `cargo fmt -p dora-node-api-python`
- `cargo check -p dora-node-api-python` — compiles cleanly (the remaining `dead_code` warnings pre-date this change).

_This crate is excluded from `cargo test` in both `ci.yml` and `nightly.yml` (its tests link libpython / are built with maturin), so a unit test here would not run in CI; the change is a small, type-checked swap of the collection strategy._

---

⚠️ **This PR was generated by Claude (an AI agent).** It is machine-generated; please review carefully before merging.