### PR TITLE
fix(ros2-bridge/msg-gen): enforce per-element bound for bounded-string array/sequence defaults

### DIFF
--- a/libraries/extensions/ros2-bridge/msg-gen/src/parser/member.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/parser/member.rs
@@ -9,7 +9,10 @@ use nom::{
 };
 
 use super::{error::RclMsgError, ident, literal, types};
-use crate::types::{Member, MemberType, primitives::NestableType};
+use crate::types::{
+    Member, MemberType,
+    primitives::{GenericString, NestableType},
+};
 
 fn nestable_type_default(nestable_type: NestableType, default: &str) -> Result<Vec<String>> {
     match nestable_type {
@@ -44,10 +47,24 @@ fn array_type_default(value_type: NestableType, default: &str) -> Result<Vec<Str
         NestableType::NamespacedType(t) => {
             Err(RclMsgError::InvalidDefaultError(format!("{t}")).into())
         }
-        NestableType::GenericString(_) => {
+        NestableType::GenericString(t) => {
             let (rest, default) = literal::string_literal_sequence(default)
                 .map_err(|_| RclMsgError::ParseDefaultValueError(default.into()))?;
             ensure!(rest.is_empty());
+            // Enforce the per-element length bound for bounded strings, matching
+            // the scalar path in `nestable_type_default` (which threads the bound
+            // through `get_string_literal_parser`). Without this, an over-long
+            // element in a `string<=N[..]` / `wstring<=N[..]` default is silently
+            // accepted.
+            match t {
+                GenericString::BoundedString(max) => {
+                    ensure!(default.iter().all(|s| s.len() <= max));
+                }
+                GenericString::BoundedWString(max) => {
+                    ensure!(default.iter().all(|s| s.encode_utf16().count() <= max));
+                }
+                GenericString::String | GenericString::WString => {}
+            }
             Ok(default)
         }
     }
@@ -126,6 +143,29 @@ mod test {
     fn parse_member_def_with_invalid_default() -> Result<()> {
         assert!(member_def("uint8 aaa -1").is_err());
         assert!(member_def("uint8 aaa 256").is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn bounded_string_array_enforces_per_element_bound() -> Result<()> {
+        // Scalar bound is enforced ("hello" is 5 bytes > 3).
+        assert!(member_def(r#"string<=3 aaa "hello""#).is_err());
+        // The same bound must apply to each element of an array default.
+        assert!(member_def(r#"string<=3[2] aaa ["hello", "hi"]"#).is_err());
+        // ...and of a sequence default.
+        assert!(member_def(r#"string<=3[] aaa ["hello", "hi"]"#).is_err());
+        // Within-bound elements are still accepted.
+        let result = member_def(r#"string<=3[2] aaa ["ok", "hi"]"#)?;
+        assert_eq!(result.default, Some(vec!["ok".into(), "hi".into()]));
+        Ok(())
+    }
+
+    #[test]
+    fn bounded_wstring_array_enforces_per_element_bound() -> Result<()> {
+        // wstring bound is measured in UTF-16 code units.
+        assert!(member_def(r#"wstring<=3[2] aaa ["hello", "hi"]"#).is_err());
+        let result = member_def(r#"wstring<=3[2] aaa ["ok", "hi"]"#)?;
+        assert_eq!(result.default, Some(vec!["ok".into(), "hi".into()]));
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Fixes #3146.

When validating a **default value** for a member whose type is an **array or sequence of bounded strings** (`string<=N[..]` / `wstring<=N[..]`), the declared per-element length bound `N` was silently dropped and never checked. The equivalent scalar path *does* enforce the bound, so an over-long element in an array/sequence default was wrongly accepted while the same value as a scalar default was correctly rejected.

Root cause: in `libraries/extensions/ros2-bridge/msg-gen/src/parser/member.rs`, `array_type_default` matched `NestableType::GenericString(_)` and discarded the payload (which may carry `BoundedString(N)` / `BoundedWString(N)`), then called `literal::string_literal_sequence`, which performs no per-element length check. The scalar path in `nestable_type_default` threads the bound through `get_string_literal_parser`, which enforces `s.len() <= max` (UTF‑8 bytes) for `BoundedString` and `s.encode_utf16().count() <= max` (UTF‑16 code units) for `BoundedWString`.

## Changes

- Capture the `GenericString` variant in `array_type_default` and enforce the per-element bound for each element, mirroring the scalar validator's metric (bytes for `string<=N`, UTF‑16 code units for `wstring<=N`). Unbounded `String`/`WString` are unaffected.
- Add regression tests covering an over-long element in a `string<=N[..]` array default, a `string<=N[]` sequence default, a `wstring<=N[..]` default, and the within-bound accepted case.

## Testing

- `cargo test -p dora-ros2-bridge-msg-gen` (16 passed, including the two new tests)
- `cargo fmt -p dora-ros2-bridge-msg-gen -- --check`
- `cargo clippy -p dora-ros2-bridge-msg-gen -- -D warnings`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qa5guMNSXTu4qFqPZR9BNK)_