### PR TITLE
fix(python-node): use wrapping_add for the inline seqlock generation increments

### DIFF
--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -2060,7 +2060,7 @@ impl Node {
         unsafe {
             let gen_ptr = shmem_ptr.add(96) as *mut u64;
             let old_gen = std::ptr::read_volatile(gen_ptr);
-            std::ptr::write_volatile(gen_ptr, old_gen + 1);
+            std::ptr::write_volatile(gen_ptr, old_gen.wrapping_add(1));
             std::sync::atomic::fence(std::sync::atomic::Ordering::Release);
         }
 
@@ -2331,7 +2331,7 @@ impl Node {
         unsafe {
             let gen_ptr = shmem_ptr.add(96) as *mut u64;
             let old_gen = std::ptr::read_volatile(gen_ptr);
-            std::ptr::write_volatile(gen_ptr, old_gen + 1);
+            std::ptr::write_volatile(gen_ptr, old_gen.wrapping_add(1));
             std::sync::atomic::fence(std::sync::atomic::Ordering::Release);
         }
 


### PR DESCRIPTION
## Summary

Fixes #2890 (completes the follow-up left after #2865/#2866).

The memory-pool seqlock generation counter in `apis/python/node/src/lib.rs` is incremented with `wrapping_add` everywhere except two inline blocks in the plain-CPU-copy path of `write_memory_pool`, which hand-rolled the begin-write / end-write increment with non-wrapping `old_gen + 1`:

- line 2063 — "increment generation to odd (write-in-progress)"
- line 2334 — "increment generation to even (write-complete)"

These were the only non-wrapping increments of the same counter (the shared `seqlock_begin_write` / `seqlock_end_write` helpers already use `wrapping_add(1)` / `wrapping_add(2)`). On overflow they would panic in debug builds instead of wrapping silently like every other increment — the precise inconsistency #2865/#2866 aimed to eliminate.

## Changes

- Replace `old_gen + 1` with `old_gen.wrapping_add(1)` in both inline seqlock increments, giving the counter uniform wrapping semantics across all update sites.

Behavior is unchanged in release builds. Overflow remains practically unreachable — `gen` is `u64` and advances by 2 per write, so it would take ~2^63 writes; this is a consistency/robustness cleanup, not an active runtime bug (as noted in the issue). No dedicated test is added because the increment lives inside `write_memory_pool`'s raw-pointer seqlock code with no unit-testable seam, and the overflow it guards against is unreachable — matching how the sibling helper fix (#2866) was landed.

## Testing

- `cargo check -p dora-node-api-python`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qa5guMNSXTu4qFqPZR9BNK)_