### PR TITLE
refactor!: remove deprecated descriptor surface before 1.0

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -579,7 +579,7 @@ jobs:
     # list/info/echo/hz/pub`. Each has a non-interactive mode (--once /
     # built-in exit / --duration / --count). Topic inspection (echo/hz/info)
     # streams over the coordinator WebSocket (PR #238) — requires
-    # `_unstable_debug.publish_all_messages_to_zenoh: true` in the fixture.
+    # `_unstable_debug.enable_debug_inspection: true` in the fixture.
     #
     # Uses Python source nodes (ticker.py / sink.py) so the dataflow runs
     # indefinitely until stopped (rust-dataflow nodes hit tick limits).

--- a/binaries/cli/src/command/replay.rs
+++ b/binaries/cli/src/command/replay.rs
@@ -296,9 +296,9 @@ fn raise_replayed_input_queue_sizes(
             continue;
         }
 
-        // Inputs can live at the node level, under the legacy `custom:` key,
-        // under a single `operator:`, or per-entry in an `operators:` list.
-        for holder_key in ["inputs", "custom", "operator"] {
+        // Inputs can live at the node level, under a single `operator:`, or
+        // per-entry in an `operators:` list.
+        for holder_key in ["inputs", "operator"] {
             let Some(holder) = node.get_mut(holder_key) else {
                 continue;
             };
@@ -452,7 +452,7 @@ mod tests {
     }
 
     #[test]
-    fn operator_and_custom_inputs_are_rewritten() {
+    fn operator_inputs_are_rewritten() {
         let out = run_rewrite(
             concat!(
                 "nodes:\n",
@@ -465,10 +465,6 @@ mod tests {
                 "  operator:\n",
                 "    inputs:\n",
                 "      image: source/status\n",
-                "- id: legacy\n",
-                "  custom:\n",
-                "    inputs:\n",
-                "      image: source/status\n",
             ),
             &["source"],
             &[("source", "status", 100)],
@@ -477,7 +473,6 @@ mod tests {
         for input in [
             &parsed["nodes"][0]["operators"][0]["inputs"]["image"],
             &parsed["nodes"][1]["operator"]["inputs"]["image"],
-            &parsed["nodes"][2]["custom"]["inputs"]["image"],
         ] {
             assert_eq!(input["queue_size"].as_u64(), Some(100));
             assert_eq!(input["queue_policy"].as_str(), Some("backpressure"));

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -3858,10 +3858,7 @@ async fn start_topic_debug_stream(
 ) -> eyre::Result<Uuid> {
     let outputs_by_daemon = topic_outputs_by_daemon(running_dataflows, dataflow_id, &topics)?;
     if !topic_debug_enabled(running_dataflows, dataflow_id)? {
-        eyre::bail!(
-            "topic inspection requires `_unstable_debug.enable_debug_inspection: true` \
-             (the flag was previously named `publish_all_messages_to_zenoh`; the old name is still accepted)"
-        );
+        eyre::bail!("topic inspection requires `_unstable_debug.enable_debug_inspection: true`");
     }
     let subscription_id = Uuid::new_v4();
     running_dataflows

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -4338,7 +4338,6 @@ fn resolve_single_node(
 ) -> eyre::Result<(NodeId, ResolvedNode)> {
     let tmp_desc = Descriptor {
         nodes: vec![node],
-        communication: Default::default(),
         deploy: None,
         debug: Default::default(),
         health_check_interval: None,

--- a/binaries/coordinator/src/ws_control.rs
+++ b/binaries/coordinator/src/ws_control.rs
@@ -306,7 +306,7 @@ pub(crate) async fn handle_control_ws(
                             let resp = WsResponse::err(
                                 req.id,
                                 format!(
-                                    "dataflow {dataflow_id} not found, output unavailable, or topic publish requires `_unstable_debug.enable_debug_inspection: true` (previously named `publish_all_messages_to_zenoh`; old name is still accepted)"
+                                    "dataflow {dataflow_id} not found, output unavailable, or topic publish requires `_unstable_debug.enable_debug_inspection: true`"
                                 ),
                             );
                             let _ = send_ws_response(&mut ws_tx, &resp).await;

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -89,7 +89,6 @@ pub mod bench_support {
     ) {
         let descriptor = dora_message::descriptor::Descriptor {
             nodes: vec![],
-            communication: dora_message::config::CommunicationConfig::default(),
             deploy: None,
             debug: dora_message::descriptor::Debug::default(),
             health_check_interval: None,

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -2249,10 +2249,6 @@ impl Daemon {
                 nodes_on_machine,
                 uv,
             }) => {
-                match dataflow_descriptor.communication.remote {
-                    dora_core::config::RemoteCommunicationConfig::Tcp => {}
-                }
-
                 let base_working_dir = self.base_working_dir(local_working_dir, session_id)?;
 
                 let result = self
@@ -2313,10 +2309,6 @@ impl Daemon {
                 write_events_to,
                 artifact_base_url: _,
             }) => {
-                match dataflow_descriptor.communication.remote {
-                    dora_core::config::RemoteCommunicationConfig::Tcp => {}
-                }
-
                 let base_working_dir = self.base_working_dir(local_working_dir, session_id)?;
 
                 let result = self
@@ -2813,7 +2805,6 @@ impl Daemon {
                             operators: None,
                             operator: None,
                             ros2: None,
-                            custom: None,
                             outputs: Default::default(),
                             output_types: Default::default(),
                             output_framing: Default::default(),
@@ -7557,7 +7548,6 @@ mod fault_tolerance_tests {
     use std::sync::atomic::AtomicU32;
 
     use dora_message::{
-        config::CommunicationConfig,
         daemon_to_node::NodeEvent,
         descriptor::{Debug as DescriptorDebug, Descriptor},
     };
@@ -7566,7 +7556,6 @@ mod fault_tolerance_tests {
     fn test_dataflow() -> RunningDataflow {
         let descriptor = Descriptor {
             nodes: vec![],
-            communication: CommunicationConfig::default(),
             deploy: None,
             debug: DescriptorDebug::default(),
             health_check_interval: None,

--- a/binaries/daemon/src/node_communication/mod.rs
+++ b/binaries/daemon/src/node_communication/mod.rs
@@ -1,9 +1,5 @@
 use crate::{DaemonNodeEvent, Event};
-use dora_core::{
-    config::{LocalCommunicationConfig, NodeId},
-    topics::LOCALHOST,
-    uhlc,
-};
+use dora_core::{config::NodeId, topics::LOCALHOST, uhlc};
 use dora_message::{
     DataflowId,
     common::Timestamped,
@@ -44,46 +40,39 @@ pub async fn spawn_listener_loop(
     node_id: &NodeId,
     generation: Arc<AtomicU64>,
     daemon_tx: &mpsc::Sender<Timestamped<Event>>,
-    config: LocalCommunicationConfig,
     clock: Arc<uhlc::HLC>,
     last_activity: Arc<AtomicU64>,
     shutdown: tokio::sync::watch::Receiver<bool>,
     node_shutdown: tokio::sync::watch::Receiver<bool>,
 ) -> eyre::Result<DaemonCommunication> {
-    match config {
-        LocalCommunicationConfig::Tcp => {
-            let socket = match TcpListener::bind((LOCALHOST, 0)).await {
-                Ok(socket) => socket,
-                Err(err) => {
-                    return Err(
-                        eyre::Report::new(err).wrap_err("failed to create local TCP listener")
-                    );
-                }
-            };
-            let socket_addr = socket
-                .local_addr()
-                .wrap_err("failed to get local addr of socket")?;
-
-            let event_loop_node_id = format!("{dataflow_id}/{node_id}");
-            let daemon_tx = daemon_tx.clone();
-            let shutdown = shutdown.clone();
-            tokio::spawn(async move {
-                tcp::listener_loop(
-                    socket,
-                    generation,
-                    daemon_tx,
-                    clock,
-                    last_activity,
-                    shutdown,
-                    node_shutdown,
-                )
-                .await;
-                tracing::debug!("event listener loop finished for `{event_loop_node_id}`");
-            });
-
-            Ok(DaemonCommunication::Tcp { socket_addr })
+    let socket = match TcpListener::bind((LOCALHOST, 0)).await {
+        Ok(socket) => socket,
+        Err(err) => {
+            return Err(eyre::Report::new(err).wrap_err("failed to create local TCP listener"));
         }
-    }
+    };
+    let socket_addr = socket
+        .local_addr()
+        .wrap_err("failed to get local addr of socket")?;
+
+    let event_loop_node_id = format!("{dataflow_id}/{node_id}");
+    let daemon_tx = daemon_tx.clone();
+    let shutdown = shutdown.clone();
+    tokio::spawn(async move {
+        tcp::listener_loop(
+            socket,
+            generation,
+            daemon_tx,
+            clock,
+            last_activity,
+            shutdown,
+            node_shutdown,
+        )
+        .await;
+        tracing::debug!("event listener loop finished for `{event_loop_node_id}`");
+    });
+
+    Ok(DaemonCommunication::Tcp { socket_addr })
 }
 
 struct Listener {

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -1610,10 +1610,9 @@ mod tests {
     }
 
     fn empty_descriptor() -> Descriptor {
-        use dora_message::{config::CommunicationConfig, descriptor::Debug as DescriptorDebug};
+        use dora_message::descriptor::Debug as DescriptorDebug;
         Descriptor {
             nodes: vec![],
-            communication: CommunicationConfig::default(),
             deploy: None,
             debug: DescriptorDebug::default(),
             health_check_interval: None,

--- a/binaries/daemon/src/spawn/spawner.rs
+++ b/binaries/daemon/src/spawn/spawner.rs
@@ -488,7 +488,6 @@ impl Spawner {
             &node_id,
             generation_counter.clone(),
             &self.daemon_tx,
-            self.dataflow_descriptor.communication.local,
             self.clock.clone(),
             last_activity.clone(),
             self.shutdown.clone(),

--- a/dora-schema.json
+++ b/dora-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "dora-rs specification",
-  "description": "The main configuration structure for defining a Dora dataflow. Dataflows are\nspecified through YAML files that describe the nodes, their connections, and\nexecution parameters.\n\n## Structure\n\nA dataflow consists of:\n- **Nodes**: The computational units that process data\n- **Communication**: Optional communication configuration\n- **Deployment**: Optional deployment configuration (unstable)\n- **Debug options**: Optional development and debugging settings (unstable)\n\n## Example\n\n```yaml\nnodes:\n - id: webcam\n    operator:\n      python: webcam.py\n      inputs:\n        tick: dora/timer/millis/100\n      outputs:\n        - image\n  - id: plot\n    operator:\n      python: plot.py\n      inputs:\n        image: webcam/image\n```",
+  "description": "The main configuration structure for defining a Dora dataflow. Dataflows are\nspecified through YAML files that describe the nodes, their connections, and\nexecution parameters.\n\n## Structure\n\nA dataflow consists of:\n- **Nodes**: The computational units that process data\n- **Deployment**: Optional deployment configuration (unstable)\n- **Debug options**: Optional development and debugging settings (unstable)\n\n## Example\n\n```yaml\nnodes:\n - id: webcam\n    operator:\n      python: webcam.py\n      inputs:\n        tick: dora/timer/millis/100\n      outputs:\n        - image\n  - id: plot\n    operator:\n      python: plot.py\n      inputs:\n        image: webcam/image\n```",
   "type": "object",
   "properties": {
     "env": {
@@ -68,190 +68,6 @@
         }
       ]
     },
-    "CustomNode": {
-      "description": "Contains the input and output configuration of the node.",
-      "type": "object",
-      "properties": {
-        "args": {
-          "description": "Args for the executable.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "build": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "envs": {
-          "description": "Environment variables for the custom nodes\n\nDeprecated, use outer-level `env` field instead.",
-          "type": [
-            "object",
-            "null"
-          ],
-          "additionalProperties": {
-            "$ref": "#/$defs/EnvValue"
-          }
-        },
-        "finish_grace_secs": {
-          "description": "Per-node finish-drain grace period in seconds.\n\nOverrides the global `DORA_FINISH_DRAIN_GRACE_SECS` for this node only.",
-          "type": [
-            "number",
-            "null"
-          ],
-          "format": "double"
-        },
-        "health_check_timeout": {
-          "description": "Health check timeout in seconds.\n\nWhen set, the daemon monitors this node for activity **once it has\nconnected** (i.e. subscribed to events during `Node::init`). If the\nconnected node then does not communicate with the daemon within this\ntimeout, it is killed and the restart policy is evaluated.\n\nThis bounds post-connection liveness only, not startup time: a node\nstill in a slow cold start has not connected yet and is never killed by\nthis watchdog. A node that hangs before it ever subscribes is therefore\nnot reaped here either.",
-          "type": [
-            "number",
-            "null"
-          ],
-          "format": "double"
-        },
-        "input_types": {
-          "description": "Optional type annotations for inputs",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "inputs": {
-          "description": "Inputs for the nodes as a map from input ID to `node_id/output_id`.\n\ne.g.\n\ninputs:\n\n  example_input: example_node/example_output1",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/Input"
-          },
-          "default": {}
-        },
-        "max_log_size": {
-          "description": "Maximum log file size before rotation (e.g. \"50MB\", \"1GB\")",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "max_restart_delay": {
-          "description": "Maximum delay in seconds for exponential backoff.",
-          "type": [
-            "number",
-            "null"
-          ],
-          "format": "double"
-        },
-        "max_restarts": {
-          "description": "Maximum number of restart attempts. 0 means unlimited.",
-          "type": "integer",
-          "format": "uint32",
-          "default": 0,
-          "minimum": 0
-        },
-        "max_rotated_files": {
-          "description": "Maximum number of rotated log files to keep (default: 5)",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint32",
-          "minimum": 0
-        },
-        "min_log_level": {
-          "description": "Minimum log level for this node",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "output_framing": {
-          "description": "Per-output framing overrides (default: Raw for all).",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/OutputFraming"
-          }
-        },
-        "output_types": {
-          "description": "Optional type annotations for outputs",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "outputs": {
-          "description": "List of output IDs.\n\ne.g.\n\noutputs:\n\n - output_1\n\n - output_2",
-          "type": "array",
-          "default": [],
-          "items": {
-            "$ref": "#/$defs/DataId"
-          },
-          "uniqueItems": true
-        },
-        "path": {
-          "description": "Path of the source code\n\nIf you want to use a specific `conda` environment.\nProvide the python path within the source.\n\nsource: /home/peter/miniconda3/bin/python\n\nargs: some_node.py\n\nSource can match any executable in PATH.",
-          "type": "string"
-        },
-        "path_sha256": {
-          "description": "SHA-256 the `path` download must match (set for hub binary artifacts,\nspec §8.2). When present the daemon fetches `path` as a verified URL\ndownload regardless of confinement — the checksum is the trust anchor.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "restart_delay": {
-          "description": "Initial delay in seconds before restarting (exponential backoff).",
-          "type": [
-            "number",
-            "null"
-          ],
-          "format": "double"
-        },
-        "restart_policy": {
-          "$ref": "#/$defs/RestartPolicy",
-          "default": "never"
-        },
-        "restart_window": {
-          "description": "Time window in seconds for counting restarts.",
-          "type": [
-            "number",
-            "null"
-          ],
-          "format": "double"
-        },
-        "send_logs_as": {
-          "description": "Redirect structured log entries to a data output as JSON strings",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "send_stdout_as": {
-          "description": "Send stdout and stderr to another node",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "shared_memory_pool_size": {
-          "description": "Size of the zenoh shared memory pool for zero-copy output publishing.\n\nAccepts an integer (raw bytes) or a string with a unit suffix\n(`KB`, `MB`, `GB`, case-insensitive).\n\ne.g.\n\nshared_memory_pool_size: 128MB",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ByteSize"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "source": {
-          "$ref": "#/$defs/NodeSource"
-        }
-      },
-      "required": [
-        "path",
-        "source"
-      ]
-    },
     "DataId": {
       "description": "A validated data (output) identifier.\n\nA `DataId` may contain only `[a-zA-Z0-9_./-]` and must be non-empty. Unlike\n[`NodeId`], a `DataId` **may** contain `/` (runtime-operator outputs are\nnamespaced as `<operator-id>/<output-name>`), but leading, trailing, or\nconsecutive slashes — which would produce empty path segments — are\nrejected.\n\n# Parsing vs. conversion (panic footgun)\n\nUse [`str::parse`] / [`FromStr`](std::str::FromStr) for untrusted input: it\nreturns `Result<DataId, InvalidId>`. The `From<String>` / `From<&str>`\nconversions — and therefore `.into()` and the auto-derived `TryFrom` —\n**panic** on an invalid id.\n\n```\nuse dora_message::id::DataId;\n\nassert!(\"image\".parse::<DataId>().is_ok());\nassert!(\"op/status\".parse::<DataId>().is_ok()); // '/' is allowed in a DataId\nassert!(\"a//b\".parse::<DataId>().is_err());     // empty path segment rejected\nassert!(\"/out\".parse::<DataId>().is_err());     // leading '/' rejected\nassert!(\"bad id\".parse::<DataId>().is_err());   // space rejected\n```\n\nThe infallible-looking conversion panics on the same invalid input:\n\n```should_panic\nuse dora_message::id::DataId;\nlet _ = DataId::from(\"a//b\".to_string()); // panics — prefer .parse()\n```",
       "type": "string"
@@ -290,46 +106,6 @@
         },
         {
           "type": "string"
-        }
-      ]
-    },
-    "GitRepoRev": {
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "Branch": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": true,
-          "required": [
-            "Branch"
-          ]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "Tag": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": true,
-          "required": [
-            "Tag"
-          ]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "Rev": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": true,
-          "required": [
-            "Rev"
-          ]
         }
       ]
     },
@@ -491,17 +267,6 @@
             "format": "uint",
             "minimum": 0
           }
-        },
-        "custom": {
-          "description": "Legacy node configuration (deprecated).\n\nPlease use the top-level [`path`](Self::path), [`args`](Self::args), etc. fields instead.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/CustomNode"
-            },
-            {
-              "type": "null"
-            }
-          ]
         },
         "description": {
           "description": "Detailed description of the node's functionality.\n\n## Example\n\n```yaml\nnodes:\n  - id: camera_node\n    description: \"Captures video frames from webcam\"\n```",
@@ -784,46 +549,6 @@
     "NodeId": {
       "description": "A validated node identifier.\n\nA `NodeId` may contain only `[a-zA-Z0-9_.-]`, must be non-empty, and must\nnot start with `.` (dot-segments like `.` or `..` could traverse into a\nparent directory when the id is joined into a filesystem path). Unlike\n[`DataId`], a `NodeId` may **not** contain `/`, which separates\n`<node_id>/<output_id>` in input-mapping syntax.\n\n# Parsing vs. conversion (panic footgun)\n\nUse [`str::parse`] / [`FromStr`](std::str::FromStr) for untrusted input: it\nreturns `Result<NodeId, InvalidId>`. The `From<String>` conversion — and\ntherefore `.into()` and the auto-derived `TryFrom<String>` — **panics** on\nan invalid id.\n\n```\nuse dora_message::id::NodeId;\n\n// Fallible path — always safe for untrusted input:\nassert!(\"camera_node\".parse::<NodeId>().is_ok());\nassert!(\"node/out\".parse::<NodeId>().is_err()); // '/' is not allowed in a NodeId\nassert!(\"\".parse::<NodeId>().is_err());         // empty is rejected\nassert!(\".hidden\".parse::<NodeId>().is_err());  // leading '.' is rejected\n```\n\nThe infallible-looking conversion panics on the same invalid input:\n\n```should_panic\nuse dora_message::id::NodeId;\nlet _ = NodeId::from(\"node/out\".to_string()); // panics — prefer .parse()\n```",
       "type": "string"
-    },
-    "NodeSource": {
-      "oneOf": [
-        {
-          "type": "string",
-          "enum": [
-            "Local"
-          ]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "GitBranch": {
-              "type": "object",
-              "properties": {
-                "repo": {
-                  "type": "string"
-                },
-                "rev": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/$defs/GitRepoRev"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                }
-              },
-              "required": [
-                "repo"
-              ]
-            }
-          },
-          "additionalProperties": true,
-          "required": [
-            "GitBranch"
-          ]
-        }
-      ]
     },
     "OperatorDefinition": {
       "type": "object",

--- a/examples/python-operator-dataflow/dataflow_llm.yml
+++ b/examples/python-operator-dataflow/dataflow_llm.yml
@@ -28,17 +28,16 @@ nodes:
 
   ## Speech to text
   - id: keyboard
-    custom:
-      source: keyboard_op.py
-      outputs:
-        - buffer
-        - submitted
-        - record
-        - ask
-        - send
-        - change
-      inputs:
-        recording: whisper/text
+    path: keyboard_op.py
+    outputs:
+      - buffer
+      - submitted
+      - record
+      - ask
+      - send
+      - change
+    inputs:
+      recording: whisper/text
 
   - id: microphone
     operator:

--- a/libraries/core/dora-schema.json
+++ b/libraries/core/dora-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "dora-rs specification",
-  "description": "The main configuration structure for defining a Dora dataflow. Dataflows are\nspecified through YAML files that describe the nodes, their connections, and\nexecution parameters.\n\n## Structure\n\nA dataflow consists of:\n- **Nodes**: The computational units that process data\n- **Communication**: Optional communication configuration\n- **Deployment**: Optional deployment configuration (unstable)\n- **Debug options**: Optional development and debugging settings (unstable)\n\n## Example\n\n```yaml\nnodes:\n - id: webcam\n    operator:\n      python: webcam.py\n      inputs:\n        tick: dora/timer/millis/100\n      outputs:\n        - image\n  - id: plot\n    operator:\n      python: plot.py\n      inputs:\n        image: webcam/image\n```",
+  "description": "The main configuration structure for defining a Dora dataflow. Dataflows are\nspecified through YAML files that describe the nodes, their connections, and\nexecution parameters.\n\n## Structure\n\nA dataflow consists of:\n- **Nodes**: The computational units that process data\n- **Deployment**: Optional deployment configuration (unstable)\n- **Debug options**: Optional development and debugging settings (unstable)\n\n## Example\n\n```yaml\nnodes:\n - id: webcam\n    operator:\n      python: webcam.py\n      inputs:\n        tick: dora/timer/millis/100\n      outputs:\n        - image\n  - id: plot\n    operator:\n      python: plot.py\n      inputs:\n        image: webcam/image\n```",
   "type": "object",
   "properties": {
     "env": {
@@ -68,190 +68,6 @@
         }
       ]
     },
-    "CustomNode": {
-      "description": "Contains the input and output configuration of the node.",
-      "type": "object",
-      "properties": {
-        "args": {
-          "description": "Args for the executable.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "build": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "envs": {
-          "description": "Environment variables for the custom nodes\n\nDeprecated, use outer-level `env` field instead.",
-          "type": [
-            "object",
-            "null"
-          ],
-          "additionalProperties": {
-            "$ref": "#/$defs/EnvValue"
-          }
-        },
-        "finish_grace_secs": {
-          "description": "Per-node finish-drain grace period in seconds.\n\nOverrides the global `DORA_FINISH_DRAIN_GRACE_SECS` for this node only.",
-          "type": [
-            "number",
-            "null"
-          ],
-          "format": "double"
-        },
-        "health_check_timeout": {
-          "description": "Health check timeout in seconds.\n\nWhen set, the daemon monitors this node for activity **once it has\nconnected** (i.e. subscribed to events during `Node::init`). If the\nconnected node then does not communicate with the daemon within this\ntimeout, it is killed and the restart policy is evaluated.\n\nThis bounds post-connection liveness only, not startup time: a node\nstill in a slow cold start has not connected yet and is never killed by\nthis watchdog. A node that hangs before it ever subscribes is therefore\nnot reaped here either.",
-          "type": [
-            "number",
-            "null"
-          ],
-          "format": "double"
-        },
-        "input_types": {
-          "description": "Optional type annotations for inputs",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "inputs": {
-          "description": "Inputs for the nodes as a map from input ID to `node_id/output_id`.\n\ne.g.\n\ninputs:\n\n  example_input: example_node/example_output1",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/Input"
-          },
-          "default": {}
-        },
-        "max_log_size": {
-          "description": "Maximum log file size before rotation (e.g. \"50MB\", \"1GB\")",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "max_restart_delay": {
-          "description": "Maximum delay in seconds for exponential backoff.",
-          "type": [
-            "number",
-            "null"
-          ],
-          "format": "double"
-        },
-        "max_restarts": {
-          "description": "Maximum number of restart attempts. 0 means unlimited.",
-          "type": "integer",
-          "format": "uint32",
-          "default": 0,
-          "minimum": 0
-        },
-        "max_rotated_files": {
-          "description": "Maximum number of rotated log files to keep (default: 5)",
-          "type": [
-            "integer",
-            "null"
-          ],
-          "format": "uint32",
-          "minimum": 0
-        },
-        "min_log_level": {
-          "description": "Minimum log level for this node",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "output_framing": {
-          "description": "Per-output framing overrides (default: Raw for all).",
-          "type": "object",
-          "additionalProperties": {
-            "$ref": "#/$defs/OutputFraming"
-          }
-        },
-        "output_types": {
-          "description": "Optional type annotations for outputs",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "outputs": {
-          "description": "List of output IDs.\n\ne.g.\n\noutputs:\n\n - output_1\n\n - output_2",
-          "type": "array",
-          "default": [],
-          "items": {
-            "$ref": "#/$defs/DataId"
-          },
-          "uniqueItems": true
-        },
-        "path": {
-          "description": "Path of the source code\n\nIf you want to use a specific `conda` environment.\nProvide the python path within the source.\n\nsource: /home/peter/miniconda3/bin/python\n\nargs: some_node.py\n\nSource can match any executable in PATH.",
-          "type": "string"
-        },
-        "path_sha256": {
-          "description": "SHA-256 the `path` download must match (set for hub binary artifacts,\nspec §8.2). When present the daemon fetches `path` as a verified URL\ndownload regardless of confinement — the checksum is the trust anchor.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "restart_delay": {
-          "description": "Initial delay in seconds before restarting (exponential backoff).",
-          "type": [
-            "number",
-            "null"
-          ],
-          "format": "double"
-        },
-        "restart_policy": {
-          "$ref": "#/$defs/RestartPolicy",
-          "default": "never"
-        },
-        "restart_window": {
-          "description": "Time window in seconds for counting restarts.",
-          "type": [
-            "number",
-            "null"
-          ],
-          "format": "double"
-        },
-        "send_logs_as": {
-          "description": "Redirect structured log entries to a data output as JSON strings",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "send_stdout_as": {
-          "description": "Send stdout and stderr to another node",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "shared_memory_pool_size": {
-          "description": "Size of the zenoh shared memory pool for zero-copy output publishing.\n\nAccepts an integer (raw bytes) or a string with a unit suffix\n(`KB`, `MB`, `GB`, case-insensitive).\n\ne.g.\n\nshared_memory_pool_size: 128MB",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ByteSize"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "source": {
-          "$ref": "#/$defs/NodeSource"
-        }
-      },
-      "required": [
-        "path",
-        "source"
-      ]
-    },
     "DataId": {
       "description": "A validated data (output) identifier.\n\nA `DataId` may contain only `[a-zA-Z0-9_./-]` and must be non-empty. Unlike\n[`NodeId`], a `DataId` **may** contain `/` (runtime-operator outputs are\nnamespaced as `<operator-id>/<output-name>`), but leading, trailing, or\nconsecutive slashes — which would produce empty path segments — are\nrejected.\n\n# Parsing vs. conversion (panic footgun)\n\nUse [`str::parse`] / [`FromStr`](std::str::FromStr) for untrusted input: it\nreturns `Result<DataId, InvalidId>`. The `From<String>` / `From<&str>`\nconversions — and therefore `.into()` and the auto-derived `TryFrom` —\n**panic** on an invalid id.\n\n```\nuse dora_message::id::DataId;\n\nassert!(\"image\".parse::<DataId>().is_ok());\nassert!(\"op/status\".parse::<DataId>().is_ok()); // '/' is allowed in a DataId\nassert!(\"a//b\".parse::<DataId>().is_err());     // empty path segment rejected\nassert!(\"/out\".parse::<DataId>().is_err());     // leading '/' rejected\nassert!(\"bad id\".parse::<DataId>().is_err());   // space rejected\n```\n\nThe infallible-looking conversion panics on the same invalid input:\n\n```should_panic\nuse dora_message::id::DataId;\nlet _ = DataId::from(\"a//b\".to_string()); // panics — prefer .parse()\n```",
       "type": "string"
@@ -290,46 +106,6 @@
         },
         {
           "type": "string"
-        }
-      ]
-    },
-    "GitRepoRev": {
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "Branch": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": true,
-          "required": [
-            "Branch"
-          ]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "Tag": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": true,
-          "required": [
-            "Tag"
-          ]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "Rev": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": true,
-          "required": [
-            "Rev"
-          ]
         }
       ]
     },
@@ -491,17 +267,6 @@
             "format": "uint",
             "minimum": 0
           }
-        },
-        "custom": {
-          "description": "Legacy node configuration (deprecated).\n\nPlease use the top-level [`path`](Self::path), [`args`](Self::args), etc. fields instead.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/CustomNode"
-            },
-            {
-              "type": "null"
-            }
-          ]
         },
         "description": {
           "description": "Detailed description of the node's functionality.\n\n## Example\n\n```yaml\nnodes:\n  - id: camera_node\n    description: \"Captures video frames from webcam\"\n```",
@@ -784,46 +549,6 @@
     "NodeId": {
       "description": "A validated node identifier.\n\nA `NodeId` may contain only `[a-zA-Z0-9_.-]`, must be non-empty, and must\nnot start with `.` (dot-segments like `.` or `..` could traverse into a\nparent directory when the id is joined into a filesystem path). Unlike\n[`DataId`], a `NodeId` may **not** contain `/`, which separates\n`<node_id>/<output_id>` in input-mapping syntax.\n\n# Parsing vs. conversion (panic footgun)\n\nUse [`str::parse`] / [`FromStr`](std::str::FromStr) for untrusted input: it\nreturns `Result<NodeId, InvalidId>`. The `From<String>` conversion — and\ntherefore `.into()` and the auto-derived `TryFrom<String>` — **panics** on\nan invalid id.\n\n```\nuse dora_message::id::NodeId;\n\n// Fallible path — always safe for untrusted input:\nassert!(\"camera_node\".parse::<NodeId>().is_ok());\nassert!(\"node/out\".parse::<NodeId>().is_err()); // '/' is not allowed in a NodeId\nassert!(\"\".parse::<NodeId>().is_err());         // empty is rejected\nassert!(\".hidden\".parse::<NodeId>().is_err());  // leading '.' is rejected\n```\n\nThe infallible-looking conversion panics on the same invalid input:\n\n```should_panic\nuse dora_message::id::NodeId;\nlet _ = NodeId::from(\"node/out\".to_string()); // panics — prefer .parse()\n```",
       "type": "string"
-    },
-    "NodeSource": {
-      "oneOf": [
-        {
-          "type": "string",
-          "enum": [
-            "Local"
-          ]
-        },
-        {
-          "type": "object",
-          "properties": {
-            "GitBranch": {
-              "type": "object",
-              "properties": {
-                "repo": {
-                  "type": "string"
-                },
-                "rev": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/$defs/GitRepoRev"
-                    },
-                    {
-                      "type": "null"
-                    }
-                  ]
-                }
-              },
-              "required": [
-                "repo"
-              ]
-            }
-          },
-          "additionalProperties": true,
-          "required": [
-            "GitBranch"
-          ]
-        }
-      ]
     },
     "OperatorDefinition": {
       "type": "object",

--- a/libraries/core/src/descriptor/expand.rs
+++ b/libraries/core/src/descriptor/expand.rs
@@ -138,7 +138,6 @@ pub fn expand_modules_with_boundaries(
     Ok(ExpandedDescriptor {
         descriptor: Descriptor {
             nodes: flat_nodes,
-            communication: descriptor.communication.clone(),
             deploy: descriptor.deploy.clone(),
             debug: descriptor.debug.clone(),
             health_check_interval: descriptor.health_check_interval,
@@ -356,9 +355,6 @@ fn node_input_maps(node: &Node) -> Vec<&BTreeMap<DataId, Input>> {
     if let Some(ref operator) = node.operator {
         maps.push(&operator.config.inputs);
     }
-    if let Some(ref custom) = node.custom {
-        maps.push(&custom.run_config.inputs);
-    }
     maps
 }
 
@@ -377,9 +373,6 @@ fn node_input_maps_mut(node: &mut Node) -> Vec<&mut BTreeMap<DataId, Input>> {
     if let Some(ref mut operator) = node.operator {
         maps.push(&mut operator.config.inputs);
     }
-    if let Some(ref mut custom) = node.custom {
-        maps.push(&mut custom.run_config.inputs);
-    }
     maps
 }
 
@@ -388,8 +381,8 @@ fn node_input_maps_mut(node: &mut Node) -> Vec<&mut BTreeMap<DataId, Input>> {
 ///
 /// The two differ only for multi-operator runtime nodes: their outputs live in
 /// `operators[].config.outputs` and must be referenced as
-/// `<operator_id>/<output>`. Node-level `outputs`, legacy `custom:`
-/// `run_config.outputs`, and single `operator:` outputs are all referenced by
+/// `<operator_id>/<output>`. Node-level `outputs` and single `operator:`
+/// outputs are both referenced by
 /// their bare name — for `operator:` the `op/` prefix is injected later by
 /// `resolve_aliases_and_set_defaults`, so adding it here would double it up.
 ///
@@ -414,9 +407,6 @@ fn node_output_refs(node: &Node) -> Vec<(String, String)> {
     }
     if let Some(ref operator) = node.operator {
         refs.extend(bare(&operator.config.outputs));
-    }
-    if let Some(ref custom) = node.custom {
-        refs.extend(bare(&custom.run_config.outputs));
     }
     refs
 }
@@ -703,9 +693,6 @@ fn prepend_module_build_to_node(node: &mut Node, module_build: &str) {
     if let Some(ref mut operator) = node.operator {
         prepend_build(&mut operator.config.build, module_build);
     }
-    if let Some(ref mut custom) = node.custom {
-        prepend_build(&mut custom.build, module_build);
-    }
 }
 
 fn prepend_build(build: &mut Option<String>, module_build: &str) {
@@ -852,9 +839,6 @@ fn rewrite_external_refs(
         }
         if let Some(ref mut operator) = node.operator {
             rewrite_inputs_map(&mut operator.config.inputs, output_maps, &node.id)?;
-        }
-        if let Some(ref mut custom) = node.custom {
-            rewrite_inputs_map(&mut custom.run_config.inputs, output_maps, &node.id)?;
         }
     }
     Ok(())
@@ -1968,7 +1952,7 @@ nodes:
 module:
   name: inner_kind_builds
   inputs: [data]
-  outputs: [from_runtime, from_operator, from_custom]
+  outputs: [from_runtime, from_operator]
 
 build: pip install shared
 
@@ -1991,16 +1975,6 @@ nodes:
         data: _mod/data
       outputs:
         - from_operator
-
-  - id: runner
-    custom:
-      path: runner.py
-      source: Local
-      build: pip install runner
-      inputs:
-        data: _mod/data
-      outputs:
-        - from_custom
 "#,
         );
 
@@ -2038,14 +2012,6 @@ nodes:
             .unwrap();
         let single_build = single.operator.as_ref().unwrap().config.build.as_deref();
         assert_eq!(single_build, Some("pip install shared\npip install single"));
-
-        let runner = expanded
-            .nodes
-            .iter()
-            .find(|n| n.id.to_string() == "m.runner")
-            .unwrap();
-        let custom_build = runner.custom.as_ref().unwrap().build.as_deref();
-        assert_eq!(custom_build, Some("pip install shared\npip install runner"));
     }
 
     // ---- Feature 1: boundaries metadata ----
@@ -2796,80 +2762,6 @@ nodes:
         assert!(err.to_string().contains("_mod/nonexistent"));
     }
 
-    /// Regression test for #2441: legacy `custom:` inner nodes have the same
-    /// blind spot as operator nodes — their inputs live in
-    /// `run_config.inputs`, not the node-level `inputs` map.
-    #[test]
-    fn expand_rewrites_custom_node_inputs() {
-        let tmp = TempDir::new().unwrap();
-        let base = tmp.path();
-
-        write_file(
-            base,
-            "custom_module.yml",
-            r#"
-module:
-  name: legacy
-  inputs: [data]
-
-nodes:
-  - id: stage_a
-    path: a.py
-    outputs: [aux]
-
-  - id: runner
-    custom:
-      path: node.py
-      source: Local
-      inputs:
-        x: _mod/data
-        y: stage_a/aux
-      outputs:
-        - result
-"#,
-        );
-
-        let desc = parse_descriptor(
-            r#"
-nodes:
-  - id: src
-    path: src.py
-    outputs: [val]
-  - id: m
-    module: custom_module.yml
-    inputs:
-      data: src/val
-"#,
-        );
-
-        let expanded = expand_modules(&desc, base).unwrap();
-
-        let runner = expanded
-            .nodes
-            .iter()
-            .find(|n| n.id.to_string() == "m.runner")
-            .unwrap();
-        let custom = runner.custom.as_ref().unwrap();
-
-        let x = &custom.run_config.inputs[&DataId::from("x".to_string())];
-        match &x.mapping {
-            InputMapping::User(m) => {
-                assert_eq!(m.source.to_string(), "src");
-                assert_eq!(m.output.to_string(), "val");
-            }
-            _ => panic!("expected user mapping"),
-        }
-
-        let y = &custom.run_config.inputs[&DataId::from("y".to_string())];
-        match &y.mapping {
-            InputMapping::User(m) => {
-                assert_eq!(m.source.to_string(), "m.stage_a");
-                assert_eq!(m.output.to_string(), "aux");
-            }
-            _ => panic!("expected user mapping"),
-        }
-    }
-
     /// Expand a dataflow whose single module node `m` re-exports `result`, and
     /// return the mapping the downstream `sink` node ends up with. Also asserts
     /// that the expanded dataflow passes wiring validation, which is what
@@ -2975,44 +2867,11 @@ nodes:
         assert_eq!(mapping.output.to_string(), "result");
     }
 
-    /// Regression test for #2817: same for a legacy `custom:` inner node, whose
-    /// outputs live in `run_config.outputs`.
-    #[test]
-    fn expand_resolves_custom_produced_module_output() {
-        let tmp = TempDir::new().unwrap();
-        let base = tmp.path();
-
-        write_file(
-            base,
-            "mod.yml",
-            r#"
-module:
-  name: legacy
-  inputs: [data]
-  outputs: [result]
-
-nodes:
-  - id: runner
-    custom:
-      path: node.py
-      source: Local
-      inputs:
-        x: _mod/data
-      outputs:
-        - result
-"#,
-        );
-
-        let mapping = expand_and_resolve_sink_input(base);
-        assert_eq!(mapping.source.to_string(), "m.runner");
-        assert_eq!(mapping.output.to_string(), "result");
-    }
-
     /// Regression test for #2817: `check_module_file` must accept a declared
-    /// output produced by an operator or legacy custom inner node, and still
-    /// reject one nothing produces.
+    /// output produced by an operator inner node, and still reject one nothing
+    /// produces.
     #[test]
-    fn check_module_file_accepts_operator_and_custom_produced_outputs() {
+    fn check_module_file_accepts_operator_produced_outputs() {
         let tmp = TempDir::new().unwrap();
         let base = tmp.path();
 
@@ -3023,7 +2882,7 @@ nodes:
 module:
   name: mixed
   inputs: [data]
-  outputs: [from_operator, from_custom]
+  outputs: [from_operator]
 
 nodes:
   - id: runtime
@@ -3034,15 +2893,6 @@ nodes:
           x: _mod/data
         outputs:
           - from_operator
-
-  - id: runner
-    custom:
-      path: node.py
-      source: Local
-      inputs:
-        y: _mod/data
-      outputs:
-        - from_custom
 "#,
         );
         check_module_file(&path).unwrap();

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -167,7 +167,6 @@ pub fn resolve_aliases_and_set_defaults_in_topology(
                 .iter_mut()
                 .flat_map(|op| op.config.inputs.values_mut())
                 .collect(),
-            NodeKindMut::Custom(node) => node.run_config.inputs.values_mut().collect(),
             NodeKindMut::Operator(operator) => operator.config.inputs.values_mut().collect(),
             NodeKindMut::Ros2Bridge(_) => vec![],
         };
@@ -217,7 +216,6 @@ pub fn resolve_aliases_and_set_defaults_in_topology(
                 health_check_timeout: node.health_check_timeout,
                 finish_grace_secs: node.finish_grace_secs,
             }),
-            NodeKindMut::Custom(node) => CoreNodeKind::Custom(node.clone()),
             NodeKindMut::Runtime(node) => CoreNodeKind::Runtime(node.clone()),
             NodeKindMut::Operator(op) => CoreNodeKind::Runtime(RuntimeNode {
                 operators: vec![OperatorDefinition {
@@ -418,11 +416,6 @@ fn node_kind_mut(node: &mut Node) -> eyre::Result<NodeKindMut<'_>> {
             .as_mut()
             .map(NodeKindMut::Runtime)
             .ok_or_eyre("no operators"),
-        NodeKind::Custom(_) => node
-            .custom
-            .as_mut()
-            .map(NodeKindMut::Custom)
-            .ok_or_eyre("no custom"),
         NodeKind::Operator(_) => node
             .operator
             .as_mut()
@@ -621,26 +614,24 @@ impl NodeExt for Node {
         match (
             &self.path,
             &self.operators,
-            &self.custom,
             &self.operator,
             &self.ros2,
             &self.module,
         ) {
-            (None, None, None, None, None, None) => {
+            (None, None, None, None, None) => {
                 eyre::bail!(
-                    "node `{}` requires a `path`, `custom`, `operators`, `ros2`, or `module` field",
+                    "node `{}` requires a `path`, `operators`, `ros2`, or `module` field",
                     self.id
                 )
             }
-            (None, None, None, Some(operator), None, None) => Ok(NodeKind::Operator(operator)),
-            (None, None, Some(custom), None, None, None) => Ok(NodeKind::Custom(custom)),
-            (None, Some(runtime), None, None, None, None) => Ok(NodeKind::Runtime(runtime)),
-            (Some(path), None, None, None, None, None) => Ok(NodeKind::Standard(path)),
-            (None, None, None, None, Some(ros2), None) => Ok(NodeKind::Ros2Bridge(ros2)),
-            (None, None, None, None, None, Some(module)) => Ok(NodeKind::Module(module)),
+            (None, None, Some(operator), None, None) => Ok(NodeKind::Operator(operator)),
+            (None, Some(runtime), None, None, None) => Ok(NodeKind::Runtime(runtime)),
+            (Some(path), None, None, None, None) => Ok(NodeKind::Standard(path)),
+            (None, None, None, Some(ros2), None) => Ok(NodeKind::Ros2Bridge(ros2)),
+            (None, None, None, None, Some(module)) => Ok(NodeKind::Module(module)),
             _ => {
                 eyre::bail!(
-                    "node `{}` has multiple exclusive fields set, only one of `path`, `custom`, `operators`, `operator`, `ros2`, and `module` is allowed",
+                    "node `{}` has multiple exclusive fields set, only one of `path`, `operators`, `operator`, `ros2`, and `module` is allowed",
                     self.id
                 )
             }
@@ -653,7 +644,6 @@ pub enum NodeKind<'a> {
     Standard(&'a String),
     /// Dora runtime node
     Runtime(&'a RuntimeNode),
-    Custom(&'a CustomNode),
     Operator(&'a SingleOperatorDefinition),
     /// ROS2 bridge node
     Ros2Bridge(&'a Ros2BridgeConfig),
@@ -670,7 +660,6 @@ enum NodeKindMut<'a> {
     },
     /// Dora runtime node
     Runtime(&'a mut RuntimeNode),
-    Custom(&'a mut CustomNode),
     Operator(&'a mut SingleOperatorDefinition),
     /// ROS2 bridge node
     Ros2Bridge(&'a Ros2BridgeConfig),

--- a/libraries/message/src/config.rs
+++ b/libraries/message/src/config.rs
@@ -517,49 +517,6 @@ pub struct UserInputMapping {
     pub output: DataId,
 }
 
-#[derive(Debug, Default, Serialize, Deserialize, JsonSchema, Clone)]
-#[serde(deny_unknown_fields, rename_all = "lowercase")]
-pub struct CommunicationConfig {
-    // see https://github.com/dtolnay/serde-yaml/issues/298
-    #[serde(
-        default,
-        with = "serde_yaml::with::singleton_map",
-        rename = "_unstable_local"
-    )]
-    #[schemars(with = "String")]
-    pub local: LocalCommunicationConfig,
-    #[serde(
-        default,
-        with = "serde_yaml::with::singleton_map",
-        rename = "_unstable_remote"
-    )]
-    #[schemars(with = "String")]
-    pub remote: RemoteCommunicationConfig,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default)]
-#[serde(rename_all = "lowercase")]
-pub enum LocalCommunicationConfig {
-    #[default]
-    Tcp,
-}
-
-impl fmt::Display for LocalCommunicationConfig {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Tcp => write!(f, "tcp"),
-        }
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(deny_unknown_fields, rename_all = "lowercase")]
-#[derive(Default)]
-pub enum RemoteCommunicationConfig {
-    #[default]
-    Tcp,
-}
-
 /// A byte size that can be deserialized from either an integer (raw bytes) or a
 /// string with a unit suffix (`KB`, `MB`, `GB`, case-insensitive).
 ///
@@ -1077,42 +1034,6 @@ mod tests {
                 node_filter: None,
             })
         ));
-    }
-
-    #[test]
-    fn communication_config_local_tcp_lowercase() {
-        let yaml = "_unstable_local: tcp\n";
-        let config: CommunicationConfig = serde_yaml::from_str(yaml).unwrap();
-        assert_eq!(config.local, LocalCommunicationConfig::Tcp);
-    }
-
-    #[test]
-    fn communication_config_remote_tcp_lowercase() {
-        let yaml = "_unstable_remote: tcp\n";
-        let config: CommunicationConfig = serde_yaml::from_str(yaml).unwrap();
-        assert!(matches!(config.remote, RemoteCommunicationConfig::Tcp));
-    }
-
-    #[test]
-    fn communication_config_unknown_local_variant_errors() {
-        let yaml = "_unstable_local: unixdomain\n";
-        assert!(serde_yaml::from_str::<CommunicationConfig>(yaml).is_err());
-    }
-
-    #[test]
-    fn local_communication_config_display() {
-        assert_eq!(LocalCommunicationConfig::Tcp.to_string(), "tcp");
-    }
-
-    #[test]
-    fn communication_config_roundtrip_local() {
-        let config = CommunicationConfig {
-            local: LocalCommunicationConfig::Tcp,
-            remote: RemoteCommunicationConfig::Tcp,
-        };
-        let yaml = serde_yaml::to_string(&config).unwrap();
-        let parsed: CommunicationConfig = serde_yaml::from_str(&yaml).unwrap();
-        assert_eq!(parsed.local, LocalCommunicationConfig::Tcp);
     }
 
     #[test]

--- a/libraries/message/src/descriptor.rs
+++ b/libraries/message/src/descriptor.rs
@@ -1,7 +1,7 @@
 #![warn(missing_docs)]
 
 use crate::{
-    config::{ByteSize, CommunicationConfig, Input, NodeRunConfig},
+    config::{ByteSize, Input, NodeRunConfig},
     id::{DataId, NodeId, OperatorId},
 };
 use schemars::JsonSchema;
@@ -40,7 +40,6 @@ pub const DYNAMIC_SOURCE: &str = "dynamic";
 ///
 /// A dataflow consists of:
 /// - **Nodes**: The computational units that process data
-/// - **Communication**: Optional communication configuration
 /// - **Deployment**: Optional deployment configuration (unstable)
 /// - **Debug options**: Optional development and debugging settings (unstable)
 ///
@@ -85,11 +84,6 @@ pub struct Descriptor {
     /// For each node, you need to specify the `path` of the executable or script that Dora should run when starting the node.
     /// Most of the other node fields are optional, but you typically want to specify at least some `inputs` and/or `outputs`.
     pub nodes: Vec<Node>,
-
-    /// Communication configuration (optional, uses defaults)
-    #[schemars(skip)]
-    #[serde(default)]
-    pub communication: CommunicationConfig,
 
     /// Deployment configuration (optional, unstable)
     #[schemars(skip)]
@@ -243,16 +237,12 @@ pub enum DistributeStrategy {
 
 /// Debug options for dataflow development and troubleshooting.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct Debug {
     /// When true, daemons mirror every node output to the coordinator WebSocket
     /// so that `dora topic echo`, `dora topic hz`, and `dora topic info` can
     /// inspect runtime messages.
-    ///
-    /// The field was previously named `publish_all_messages_to_zenoh` (from
-    /// before the CLI inspection path moved off zenoh in PR #238). Serde still
-    /// accepts the old name as an alias for backward compatibility with
-    /// existing dataflow YAML; the alias will be removed in a future release.
-    #[serde(default, alias = "publish_all_messages_to_zenoh")]
+    #[serde(default)]
     pub enable_debug_inspection: bool,
 }
 
@@ -442,12 +432,6 @@ pub struct Node {
     /// ```
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ros2: Option<Ros2BridgeConfig>,
-
-    /// Legacy node configuration (deprecated).
-    ///
-    /// Please use the top-level [`path`](Self::path), [`args`](Self::args), etc. fields instead.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub custom: Option<CustomNode>,
 
     /// Output data identifiers produced by this node.
     ///
@@ -1134,9 +1118,11 @@ pub struct CustomNode {
     /// Args for the executable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub args: Option<String>,
-    /// Environment variables for the custom nodes
+    /// Environment variables injected during resolution.
     ///
-    /// Deprecated, use outer-level `env` field instead.
+    /// Not user-writable: [`Node::env`] is the YAML surface. Resolution folds
+    /// it into this field, and the ROS2 bridge desugaring uses it to pass
+    /// `DORA_ROS2_BRIDGE_CONFIG` to the spawned bridge binary.
     pub envs: Option<BTreeMap<String, EnvValue>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub build: Option<String>,
@@ -1559,10 +1545,13 @@ _unstable_debug:
     }
 
     #[test]
-    fn debug_flag_accepts_legacy_alias() {
-        // Backward-compat regression guard (#240): dataflow YAML in the wild
-        // still uses `publish_all_messages_to_zenoh`. The serde alias must
-        // keep deserializing that into the renamed field.
+    fn debug_flag_rejects_the_removed_legacy_alias() {
+        // The `publish_all_messages_to_zenoh` alias was removed for 1.0. It
+        // must *error* rather than deserialize to the default: silently
+        // ignoring it would leave debug inspection off while the dataflow
+        // looks like it enabled it, and `dora topic echo` would return
+        // nothing with no explanation. `deny_unknown_fields` on `Debug` is
+        // what turns that into a diagnosable failure.
         let yaml = r#"
 nodes:
   - id: test
@@ -1570,8 +1559,12 @@ nodes:
 _unstable_debug:
   publish_all_messages_to_zenoh: true
 "#;
-        let desc: Descriptor = serde_yaml::from_str(yaml).unwrap();
-        assert!(desc.debug.enable_debug_inspection);
+        let err = serde_yaml::from_str::<Descriptor>(yaml)
+            .expect_err("removed alias must be rejected, not silently ignored");
+        assert!(
+            err.to_string().contains("publish_all_messages_to_zenoh"),
+            "error should name the offending field, got: {err}"
+        );
     }
 
     #[test]

--- a/tests/fixtures/zenoh-debug-dataflow.yml
+++ b/tests/fixtures/zenoh-debug-dataflow.yml
@@ -1,5 +1,5 @@
-# Dataflow with `enable_debug_inspection: true` enabled (previously named
-# `publish_all_messages_to_zenoh`) — required for `dora topic echo`,
+# Dataflow with `enable_debug_inspection: true` enabled — required for
+# `dora topic echo`,
 # `topic info`, and `topic pub` to inspect/inject runtime messages.
 # Used by the nightly TUI smoke job.
 #


### PR DESCRIPTION
Once 1.0 ships, every deprecated field in the descriptor is frozen for the life of 1.x. These all have replacements or no behavior at all, so this is the last cheap moment to drop them.

- **`custom:` legacy node config** → top-level `path` / `args` / `build` / `env`.
- **`communication:` (`_unstable_local` / `_unstable_remote`)** — dead config. `LocalCommunicationConfig` and `RemoteCommunicationConfig` were single-variant enums whose only variant was the default, so the block accepted exactly one value: the one you got anyway. The daemon's dispatch on them was three no-op matches.
- **`publish_all_messages_to_zenoh` serde alias** → `enable_debug_inspection`.

Two things worth review attention:

**`CustomNode` stays, and so does its `envs` field.** The struct is the *resolved* node representation behind `CoreNodeKind::Custom`, which the ROS2 bridge desugaring constructs to pass `DORA_ROS2_BRIDGE_CONFIG`. Removing the `custom:` YAML field is what takes it off the user-facing surface — which was the actual goal, and it settles the `envs` deprecation too, since the field is no longer reachable from YAML. Its doc comment is corrected to say so.

**`Debug` gains `deny_unknown_fields`.** Without it the removed alias would be silently ignored rather than rejected: debug inspection stays off while the YAML looks like it enabled it, and `dora topic echo` returns nothing with no explanation. The replacement test asserts the error names the offending field.

Not removed: the hidden `dora logs <node>` positional. It is already non-functional — it exists only to turn the old invocation into a migration hint, so it isn't frozen surface, and dropping it would downgrade that hint to clap's generic "unexpected argument".

One example dataflow (`python-operator-dataflow/dataflow_llm.yml`) used `custom:` and is migrated to the flat form. `dora-schema.json` regenerated (both copies).

Breaking for any 0.x dataflow YAML still using `custom:` or the zenoh alias.
