### PR TITLE
fix(cli): accept full SHA-256 commit hashes in git rev resolution

### DIFF
--- a/binaries/cli/src/command/build/git.rs
+++ b/binaries/cli/src/command/build/git.rs
@@ -47,15 +47,14 @@ pub fn fetch_commit_hash(repo_url: String, rev: Option<GitRepoRev>) -> eyre::Res
 }
 
 /// Returns whether `rev` could be a git object id (a short or full commit
-/// hash).
-///
-/// Git object ids are hexadecimal, between 4 (the minimum abbreviation git
-/// accepts) and 40 (a full SHA-1) characters long. Restricting to this range
-/// rejects mistyped refs like `mybranchtypo` early with the clear "no matching
-/// commit" error instead of letting them fail later with a lower-level git
-/// error.
+/// hash): hexadecimal, from 4 (git's minimum abbreviation) to 64 (a full
+/// SHA-256 id — a full SHA-1 is 40) characters. The hub resolution paths accept
+/// the same full-hash lengths, so capping at 40 here would reject a full
+/// SHA-256 `rev:` the rest of the CLI happily consumes. The range still rejects
+/// mistyped refs like `mybranchtypo` early with a clear "no matching commit"
+/// error instead of a lower-level git failure later.
 fn looks_like_commit_hash(rev: &str) -> bool {
-    (4..=40).contains(&rev.len()) && rev.bytes().all(|b| b.is_ascii_hexdigit())
+    (4..=64).contains(&rev.len()) && rev.bytes().all(|b| b.is_ascii_hexdigit())
 }
 
 #[cfg(test)]
@@ -66,10 +65,23 @@ mod tests {
     fn accepts_short_and_full_hashes() {
         assert!(looks_like_commit_hash("abcd"));
         assert!(looks_like_commit_hash("a7b8969"));
+        // full SHA-1 (40 hex chars)
         assert!(looks_like_commit_hash(
             "a7b89691e0000000000000000000000000000000"
         ));
         assert!(looks_like_commit_hash("0123456789ABCDEF"));
+    }
+
+    #[test]
+    fn accepts_full_sha256_hash() {
+        // A full SHA-256 commit id is 64 hex chars; a SHA-256 abbreviation can
+        // also be longer than a full SHA-1 (40).
+        assert!(looks_like_commit_hash(
+            "a7b89691e0000000000000000000000000000000000000000000000000000000"
+        ));
+        assert!(looks_like_commit_hash(
+            "a7b89691e00000000000000000000000000000000"
+        ));
     }
 
     #[test]
@@ -83,9 +95,9 @@ mod tests {
     fn rejects_out_of_range_lengths() {
         assert!(!looks_like_commit_hash(""));
         assert!(!looks_like_commit_hash("abc"));
-        // longer than a full SHA-1
+        // longer than a full SHA-256 (64 hex chars)
         assert!(!looks_like_commit_hash(
-            "a7b89691e00000000000000000000000000000000"
+            "a7b89691e00000000000000000000000000000000000000000000000000000000"
         ));
     }
 }


### PR DESCRIPTION
## Summary

`looks_like_commit_hash` (in `binaries/cli/src/command/build/git.rs`) capped an acceptable git object id at **40 hex characters** — a full SHA-1. When a node is built from `git: <url>` with a `rev:` pinned to a full **64-character SHA-256** commit in a SHA-256 repository, `fetch_commit_hash` first tries to match the rev against advertised ref names (which it never will — ref names look like `refs/heads/...`), then falls back to accepting the rev as a raw object id **only if `looks_like_commit_hash` returns true**. Because that helper rejects anything longer than 40 chars, a full SHA-256 `rev:` fails the check and `dora build` bails with `no matching commit`.

This is inconsistent with the rest of the CLI, which accepts **both** SHA-1 and SHA-256 commit lengths everywhere else it validates one:

- `binaries/cli/src/command/build/hub.rs:292` — `matches!(pin.commit_hash.len(), 40 | 64)`
- `binaries/cli/src/command/hub/publish.rs:87` — `matches!(commit.len(), 40 | 64)`
- `binaries/cli/src/command/hub/fetch.rs:173` — `matches!(source.commit_hash.len(), 40 | 64)`

So a SHA-256 hash the locked/hub paths would happily consume can't even be resolved by a plain `git build`.

## Fix

Widen the accepted length range from `4..=40` to `4..=64` so a full SHA-256 hash (and any abbreviation of either hash type) resolves, while still rejecting mistyped refs like `mybranchtypo` early with the clear "no matching commit" error. `looks_like_commit_hash` remains an approximate gate — the authoritative resolution still happens in git.

## Validation

- Added `accepts_full_sha256_hash` (full 64-char id + a >40-char SHA-256 abbreviation) and updated `rejects_out_of_range_lengths` to the new 64-char upper bound.
- `cargo test -p dora-cli --lib git::` → 4 passed.
- `cargo clippy -p dora-cli --lib -- -D warnings` → clean.
- `cargo fmt -p dora-cli -- --check` → clean.
- Workspace-wide `cargo check --all --tests` (excluding the PyO3 crates) → clean, confirming no cross-crate breakage (the change touches only a private helper).

Toolchain: 1.97.1 (matches CI).

---

🤖 This pull request was generated by Claude (an AI agent) as part of an automated code-review pass. It is **machine-generated** and should be reviewed by a maintainer before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015TGPedF21kUm48aVTTp5zH)_