### PR TITLE
fix(core): reject QoS durations that overflow Duration before they panic the ROS2 bridge

### DIFF
--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -806,16 +806,16 @@ fn validate_ros2_qos(
                  must be between 1 and 10000"
         );
     }
-    if let Some(t) = qos.max_blocking_time
-        && (!t.is_finite() || t < 0.0)
-    {
-        bail!("node `{node_id}`: QoS max_blocking_time must be a finite non-negative number");
-    }
-    if let Some(t) = qos.lease_duration
-        && (!t.is_finite() || t < 0.0)
-    {
-        bail!("node `{node_id}`: QoS lease_duration must be a finite non-negative number");
-    }
+    // Both fields reach `Duration::from_secs_f64` in the ROS2 bridge QoS
+    // conversion and panic on a finite-but-overflowing value (e.g. `1e300`),
+    // not just on NaN/infinite/negative. `check_seconds_field` probes that
+    // exact boundary with `try_from_secs_f64`, matching every other
+    // second-valued field here, and keeps validating both fields whenever set
+    // (as the prior check did). `allow_zero = true`: `max_blocking_time`
+    // defaults to `0.0` and a zero lease is harmless.
+    let owner = format!("node `{node_id}`");
+    check_seconds_field(&owner, "QoS max_blocking_time", qos.max_blocking_time, true)?;
+    check_seconds_field(&owner, "QoS lease_duration", qos.lease_duration, true)?;
     Ok(())
 }
 
@@ -2513,6 +2513,55 @@ nodes:
         let err = validate_ros2_config(&NodeId::from("n".to_owned()), &config, &inputs, &outputs)
             .unwrap_err();
         assert!(err.to_string().contains("lease_duration"));
+    }
+
+    /// A finite but enormous QoS duration passes the old
+    /// `is_finite()` / `>= 0` check yet overflows `Duration`, which panics
+    /// `Duration::from_secs_f64` in the ROS2 bridge QoS conversion. Both
+    /// fields must be rejected at descriptor validation instead.
+    #[test]
+    fn validate_qos_overflowing_durations_are_rejected() {
+        let base = Ros2BridgeConfig {
+            service: Some("/svc".into()),
+            service_type: Some("a/B".into()),
+            role: Some(Ros2Role::Client),
+            ..Default::default()
+        };
+        let mut inputs = BTreeMap::new();
+        inputs.insert(DataId::from("request".to_owned()), dummy_input());
+        let mut outputs = BTreeSet::new();
+        outputs.insert(DataId::from("response".to_owned()));
+
+        // `1e300` seconds is finite and positive but far beyond `Duration::MAX`.
+        for (field, qos) in [
+            (
+                "lease_duration",
+                dora_message::descriptor::Ros2QosConfig {
+                    lease_duration: Some(1e300),
+                    ..Default::default()
+                },
+            ),
+            (
+                "max_blocking_time",
+                dora_message::descriptor::Ros2QosConfig {
+                    reliable: true,
+                    max_blocking_time: Some(1e300),
+                    ..Default::default()
+                },
+            ),
+        ] {
+            let config = Ros2BridgeConfig {
+                qos,
+                ..base.clone()
+            };
+            let err =
+                validate_ros2_config(&NodeId::from("n".to_owned()), &config, &inputs, &outputs)
+                    .unwrap_err();
+            assert!(
+                err.to_string().contains(field),
+                "expected error naming `{field}`, got: {err}"
+            );
+        }
     }
 
     // --- Wiring validation tests ---


### PR DESCRIPTION
## Summary

`validate_ros2_qos` (in `libraries/core/src/descriptor/validate.rs`) guarded the two ROS2 QoS duration fields with a bespoke check:

```rust
if let Some(t) = qos.max_blocking_time && (!t.is_finite() || t < 0.0) { bail!(...) }
if let Some(t) = qos.lease_duration && (!t.is_finite() || t < 0.0) { bail!(...) }
```

That rejects NaN, infinite, and negative values but **accepts a finite value too large to fit in a `std::time::Duration`** (e.g. `1e300`). Such a value flows into the ROS2 bridge's QoS conversion — `libraries/extensions/ros2-bridge/msg-gen/src/lib.rs` (`neutral_qos` for rmw-zenoh, and the rustdds path) — where `Duration::from_secs_f64` **panics** on any value above `Duration::MAX` (≈ 1.8e19 s):

```rust
// msg-gen/src/lib.rs
let lease = value.lease_duration.is_finite()
    .then(|| std::time::Duration::from_secs_f64(value.lease_duration.max(0.0)));
// ...
Reliability::Reliable { max_blocking_time: std::time::Duration::from_secs_f64(value.max_blocking_time.max(0.0)) }
```

So a descriptor with `lease_duration: 1e300` (or `max_blocking_time: 1e300` under reliable transport) passes validation and then panics the bridge at runtime.

Every **other** second-valued `f64` field in this file (`finish_grace_secs`, `health_check_timeout`, `restart_delay`, `input_timeout`, `health_check_interval`, …) already probes this exact boundary with the non-panicking `Duration::try_from_secs_f64` via the shared `check_seconds_field` helper. The two QoS durations were the exception. The Python QoS path in the bridge (`ros2-bridge/python/src/qos.rs`) also already defends with `try_from_secs_f64`, so this closes an inconsistency the maintainers were already aware of.

## Fix

Route both QoS durations through the existing `check_seconds_field` helper (`allow_zero = true`), which uses `try_from_secs_f64` to reject the overflow case too. This is a **removal of a special case** in favor of the shared mechanism, not a new special case.

Behavior is unchanged except for the previously-missed overflow: NaN/infinite/negative stay rejected, `0.0` stays accepted (`max_blocking_time` defaults to `0.0`). Both fields stay validated whenever set — matching the prior unconditional check — so a nonsensical value is always flagged with a clear, node-attributed error at descriptor load instead of panicking the bridge later.

## Validation

- Added `validate_qos_overflowing_durations_are_rejected` (table-driven over both `lease_duration` and `max_blocking_time`).
- `cargo test -p dora-core --lib` → 282 passed (incl. the existing `validate_qos_*` tests, which assert field-name substrings and still pass).
- `cargo clippy -p dora-core --lib -- -D warnings` → clean.
- `cargo fmt -p dora-core -- --check` → clean.
- Workspace-wide `cargo check --all --tests` (excluding the PyO3 crates) → clean, confirming no cross-crate breakage (internal validation logic, no signature change).

Toolchain: 1.97.1 (matches CI).

---

🤖 This pull request was generated by Claude (an AI agent) as part of an automated code-review pass. It is **machine-generated** and should be reviewed by a maintainer before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015TGPedF21kUm48aVTTp5zH)_