### PR TITLE
fix(daemon): forget cascading-error cause when a node is removed

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -3162,7 +3162,8 @@ impl Daemon {
                     dataflow.all_inputs_closed_at.remove(&node_id);
                     dataflow.connected_nodes.remove(&node_id);
                     dataflow.finish_escalated.remove(&node_id);
-                    dataflow.cascading_error_causes.forget(&node_id);
+                    // `forget_node_bookkeeping` also drops the recorded
+                    // cascading-error cause for this id (see its doc comment).
                     dataflow.forget_node_bookkeeping(&node_id);
                     dataflow
                         .node_stderr_most_recent
@@ -8246,6 +8247,7 @@ mod fault_tolerance_tests {
         let input_x: DataId = "input_x".to_string().into();
         let timeout = Duration::from_secs(1);
 
+        let upstream: NodeId = "upstream".to_string().into();
         for node in [&node_a, &node_b] {
             df.input_deadlines.insert(
                 (node.clone(), input_x.clone()),
@@ -8258,6 +8260,9 @@ mod fault_tolerance_tests {
                 .insert((node.clone(), input_x.clone()), timeout);
             df.node_stderr_most_recent
                 .insert(node.clone(), Arc::new(ArrayQueue::new(4)));
+            // Both nodes were recorded as cascading victims of `upstream`.
+            df.cascading_error_causes
+                .report_cascading_error(upstream.clone(), node.clone());
         }
 
         df.forget_node_bookkeeping(&node_a);
@@ -8272,6 +8277,10 @@ mod fault_tolerance_tests {
                 .contains_key(&(node_a.clone(), input_x.clone()))
         );
         assert!(!df.node_stderr_most_recent.contains_key(&node_a));
+        // … including the stale cascading-error cause, so a re-added/replaced
+        // `node_a` incarnation is classified by its own failure, not a stale
+        // upstream cause (dora-rs/dora#2927).
+        assert_eq!(df.cascading_error_causes.error_caused_by(&node_a), None);
 
         // … while node_b's are untouched.
         assert!(
@@ -8283,6 +8292,10 @@ mod fault_tolerance_tests {
                 .contains_key(&(node_b.clone(), input_x.clone()))
         );
         assert!(df.node_stderr_most_recent.contains_key(&node_b));
+        assert_eq!(
+            df.cascading_error_causes.error_caused_by(&node_b),
+            Some(&upstream)
+        );
     }
 
     // -- Test 3: close_input defers AllInputsClosed when broken_inputs exist --

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -432,7 +432,7 @@ impl RunningDataflow {
     }
 
     /// Drop per-node bookkeeping that is keyed by node id but not covered by
-    /// the routing-table cleanup in the `RemoveNode` handler.
+    /// the routing-table cleanup in the `RemoveNode` / `ReplaceNode` handlers.
     ///
     /// Without this, removing a node (dynamic reconfiguration) leaves stale
     /// `input_deadlines` / `broken_inputs` entries behind. A never-armed
@@ -442,10 +442,19 @@ impl RunningDataflow {
     /// receipt, which a removed node never sees). Together with the
     /// `node_stderr_most_recent` queue this is an unbounded accumulation
     /// across repeated add/remove cycles.
+    ///
+    /// The recorded cascading-error cause is dropped for the same reason: a
+    /// `caused_by` entry is otherwise never removed (dora-rs/dora#2927), so a
+    /// node id reused by a later incarnation — whether re-added after a
+    /// `RemoveNode` or swapped in by `ReplaceNode` — would have a genuine
+    /// failure of the *new* incarnation misattributed to the stale cause and
+    /// classified as `NodeErrorCause::Cascading`, suppressing its real stderr
+    /// capture.
     pub(crate) fn forget_node_bookkeeping(&mut self, node_id: &NodeId) {
         self.input_deadlines.retain(|(n, _), _| n != node_id);
         self.broken_inputs.retain(|(n, _), _| n != node_id);
         self.node_stderr_most_recent.remove(node_id);
+        self.cascading_error_causes.forget(node_id);
     }
 
     pub(crate) async fn start(


### PR DESCRIPTION
## Issue

`ReplaceNode` scrubs the per-node cascading-error record via `cascading_error_causes.forget()` (dora-rs/dora#2927) so that a replacement incarnation of a node id is not blamed for its predecessor's cohort-era failure. The `RemoveNode` cleanup path did **not**: it called `forget_node_bookkeeping()` — which only touches `input_deadlines`, `broken_inputs`, and `node_stderr_most_recent` — but never `cascading_error_causes.forget()`.

A `caused_by` entry is otherwise never removed. So after a `dora node remove X` followed by `dora node add X` (both first-class dynamic-reconfiguration flows), a stale `caused_by[X] = Y` survives the removal.

## Impact

When the **new** incarnation of `X` later exits with a genuine error, the classifier (`cascading_error_causes.error_caused_by(&node_id)` in `binaries/daemon/src/lib.rs`) finds the stale entry and tags the failure as `NodeErrorCause::Cascading { caused_by_node: Y }`. This suppresses the real stderr capture (`NodeErrorCause::Other`) and blames a node that has nothing to do with the new failure — exactly the stale-attribution class that `CascadingErrorCauses::forget` was introduced to prevent.

## Fix

Move the `cascading_error_causes.forget()` call **into** `forget_node_bookkeeping()`, which both `RemoveNode` and `ReplaceNode` already call, and drop the now-redundant explicit call in `ReplaceNode`. This closes the `RemoveNode` gap without changing `ReplaceNode` behavior.

- `binaries/daemon/src/running_dataflow.rs` — `forget_node_bookkeeping` now also calls `self.cascading_error_causes.forget(node_id)`; doc comment updated.
- `binaries/daemon/src/lib.rs` — removed the redundant `cascading_error_causes.forget(&node_id)` from the `ReplaceNode` handler (behavior preserved).

## Validation

- Extended the existing `forget_node_bookkeeping_purges_only_that_node` regression test to seed a cascading cause for two nodes and assert the removed node's cause is dropped while the other node's is untouched.
- `cargo test -p dora-daemon` — 214 passed.
- `cargo clippy -p dora-daemon -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.

---

⚠️ This PR was generated autonomously by Claude (Claude Code) as part of a machine-driven code-review pass. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VchUUr2sfktdyXiwAu2QBj)_