### PR TITLE
docs(cli): correct the `dora stop --grace-duration` kill-ladder timing

### DIFF
--- a/binaries/cli/src/command/stop.rs
+++ b/binaries/cli/src/command/stop.rs
@@ -30,7 +30,8 @@ pub struct Stop {
     /// Specifically, it does the following:
     /// 1. Sends `Event::Stop` to all nodes of the dataflow.
     /// 2. After DURATION, performs a soft kill (sending SIGTERM, or Ctrl-Break on Windows).
-    /// 3. If the dataflow is still running after DURATION * 0.5, terminates all its processes.
+    /// 3. If the dataflow is still running after a further DURATION / 2 (i.e. DURATION * 1.5 in
+    ///    total), forcibly terminates (SIGKILL) all its processes.
     #[clap(
         long,
         value_name = "DURATION",


### PR DESCRIPTION
## Issue

The `--grace-duration` help text (`dora stop --help`) described a chronologically impossible escalation ladder:

```
2. After DURATION, performs a soft kill (sending SIGTERM, or Ctrl-Break on Windows).
3. If the dataflow is still running after DURATION * 0.5, terminates all its processes.
```

Step 3's deadline (`DURATION * 0.5`) is **earlier** than step 2's (`DURATION`), so as written SIGKILL would precede the SIGTERM it's supposed to follow.

## Actual behavior

The daemon's real ladder in `binaries/daemon/src/running_dataflow.rs` (`schedule_process_stop` and `send_stop_message`) does:

```rust
tokio::time::sleep(duration).await;            // = DURATION
proc.submit(ProcessOperation::SoftKill);       // SIGTERM
tokio::time::sleep(duration / 2).await;        // + DURATION/2
proc.submit(ProcessOperation::Kill);           // SIGKILL   -> total DURATION * 1.5
```

matching the `shutdown` module's own comment: *"DEFAULT_STOP_GRACE for SIGTERM, half as much again for SIGKILL"*.

## Fix

Correct the help text so the timeline is monotonic and accurate: SIGKILL fires after a further `DURATION / 2` (i.e. `DURATION * 1.5` in total). **Documentation-only change** — no behavior change.

## Validation

- `cargo build -p dora-cli` — clean.
- `cargo fmt --all -- --check` — clean.

---

⚠️ This PR was generated autonomously by Claude (Claude Code) as part of a machine-driven code-review pass. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VchUUr2sfktdyXiwAu2QBj)_