### PR TITLE
fix(cli): don't panic the hot-reload watcher thread on a closed channel

### DIFF
--- a/binaries/cli/src/command/start/attach.rs
+++ b/binaries/cli/src/command/start/attach.rs
@@ -83,14 +83,17 @@ pub fn attach_dataflow(
             {
                 for path in paths {
                     if let Some((dataflow_id, node_id, operator_id)) = node_path_lookup.get(&path) {
-                        watcher_tx
-                            .send(AttachEvent::Control(ControlRequest::Reload {
-                                dataflow_id: *dataflow_id,
-                                node_id: node_id.clone(),
-                                operator_id: operator_id.clone(),
-                            }))
-                            .context("Could not send reload request to the cli loop")
-                            .unwrap();
+                        // A filesystem event can arrive on the watcher thread
+                        // after the control loop has stopped and dropped `rx`
+                        // (the dataflow finished or errored out). A closed
+                        // channel just means the CLI is shutting down, so drop
+                        // the reload instead of panicking the watcher thread —
+                        // matching the ctrl-c and log senders in this function.
+                        let _ = watcher_tx.send(AttachEvent::Control(ControlRequest::Reload {
+                            dataflow_id: *dataflow_id,
+                            node_id: node_id.clone(),
+                            operator_id: operator_id.clone(),
+                        }));
                     }
                 }
                 // TODO: Manage different file event


### PR DESCRIPTION
## Issue

The `notify` file-watcher callback in `binaries/cli/src/command/start/attach.rs` (`dora start`/`dora run --attach` with `--hot-reload`) sent its `Reload` request like this:

```rust
watcher_tx
    .send(AttachEvent::Control(ControlRequest::Reload { .. }))
    .context("Could not send reload request to the cli loop")
    .unwrap();
```

`send` returns `Err` once the receiver (`rx`, owned by the control loop) is gone. The control loop drops `rx` as soon as the dataflow stops (`DataflowStopped` → `break`) or any error return unwinds the request path. A filesystem modify event delivered on the watcher's **own thread** after that point makes `send` fail, and the `.unwrap()` panics that thread.

## Impact

Saving a watched source file while a hot-reload-attached dataflow is shutting down (or has just failed) panics the watcher thread with a "Could not send reload request to the cli loop" message — noise on an otherwise-normal shutdown.

Every other sender in the same function already treats a closed channel as "the CLI is shutting down": the ctrl-c sender uses `.ok()`, the ctrl-c fallback uses `let _ =`, and the log forwarder uses `.is_err()`.

## Fix

Make the watcher callback consistent — drop the reload on send failure via `let _ = watcher_tx.send(...)` instead of unwrapping.

## Validation

- `cargo clippy -p dora-cli -- -D warnings` — clean (`Context` import still used elsewhere in the file).
- `cargo test -p dora-cli` — passes.
- `cargo fmt --all -- --check` — clean.

---

⚠️ This PR was generated autonomously by Claude (Claude Code) as part of a machine-driven code-review pass. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VchUUr2sfktdyXiwAu2QBj)_