### PR TITLE
fix(record-node): don't panic the recorder on a pre-epoch system clock

### DIFF
--- a/binaries/record-node/src/main.rs
+++ b/binaries/record-node/src/main.rs
@@ -40,6 +40,21 @@ fn build_reverse_map(topics_json: &str) -> eyre::Result<HashMap<String, (NodeId,
     Ok(reverse_map)
 }
 
+/// Nanoseconds since the Unix epoch, saturating to 0 when the wall clock reads
+/// a pre-epoch time.
+///
+/// `SystemTime::duration_since(UNIX_EPOCH)` returns `Err` whenever the clock is
+/// set before 1970 — common on battery-less embedded/robotics hardware that
+/// boots at (or before) the epoch until NTP/GPS sync lands. This runs once per
+/// recorded message, so an `.unwrap()` here would abort the recorder mid-capture.
+/// Saturating to 0 matches the `saturating_sub` already used when computing the
+/// per-entry offset from `start_nanos`.
+fn unix_nanos(now: SystemTime) -> u64 {
+    now.duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0)
+}
+
 fn main() -> eyre::Result<()> {
     let output_file =
         std::env::var("DORA_RECORD_FILE").wrap_err("DORA_RECORD_FILE env var not set")?;
@@ -52,10 +67,7 @@ fn main() -> eyre::Result<()> {
 
     let (_node, mut events) = DoraNode::init_from_env()?;
 
-    let start_nanos = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos() as u64;
+    let start_nanos = unix_nanos(SystemTime::now());
 
     let header = RecordingHeader {
         version: dora_recording::FORMAT_VERSION,
@@ -139,10 +151,7 @@ fn main() -> eyre::Result<()> {
                 };
                 let event_bytes = timestamped.serialize()?;
 
-                let now_nanos = SystemTime::now()
-                    .duration_since(SystemTime::UNIX_EPOCH)
-                    .unwrap()
-                    .as_nanos() as u64;
+                let now_nanos = unix_nanos(SystemTime::now());
 
                 let entry = RecordEntry {
                     node_id: source_node.to_string(),
@@ -169,7 +178,21 @@ fn main() -> eyre::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::build_reverse_map;
+    use super::{build_reverse_map, unix_nanos};
+    use std::time::{Duration, SystemTime};
+
+    #[test]
+    fn unix_nanos_saturates_on_pre_epoch_clock() {
+        // A pre-epoch wall clock must not panic the recorder mid-capture.
+        let before_epoch = SystemTime::UNIX_EPOCH - Duration::from_secs(60);
+        assert_eq!(unix_nanos(before_epoch), 0);
+        // The epoch itself is 0, and a post-epoch time is its offset in nanos.
+        assert_eq!(unix_nanos(SystemTime::UNIX_EPOCH), 0);
+        assert_eq!(
+            unix_nanos(SystemTime::UNIX_EPOCH + Duration::from_nanos(1_500)),
+            1_500
+        );
+    }
 
     #[test]
     fn valid_topics_parse() {


### PR DESCRIPTION
## Issue

`binaries/record-node/src/main.rs` computes timestamps with:

```rust
let now_nanos = SystemTime::now()
    .duration_since(SystemTime::UNIX_EPOCH)
    .unwrap()          // panics if now < 1970
    .as_nanos() as u64;
```

`duration_since(UNIX_EPOCH)` returns `Err` whenever the wall clock is set before 1970-01-01, and `.unwrap()` then panics. The line-142 call runs for **every recorded message**, so this aborts the recorder mid-capture (there is an identical call at startup for `start_nanos`).

## Impact

This is directly relevant to the robotics/embedded target: devices without a battery-backed RTC frequently boot with the clock at or before the epoch until NTP/GPS sync lands. The offset computation immediately after already guards the clock going *backward* with `saturating_sub(start_nanos)`, so the unwrap was an inconsistency in an otherwise-defensive path.

## Fix

Extract a small helper that saturates to `0` on a pre-epoch clock (matching the existing `saturating_sub` philosophy) and use it at both call sites:

```rust
fn unix_nanos(now: SystemTime) -> u64 {
    now.duration_since(SystemTime::UNIX_EPOCH)
        .map(|d| d.as_nanos() as u64)
        .unwrap_or(0)
}
```

## Validation

- New unit test `unix_nanos_saturates_on_pre_epoch_clock` (pre-epoch → 0, epoch → 0, post-epoch → offset).
- `cargo test -p dora-record-node` — 5 passed.
- `cargo clippy -p dora-record-node -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.

---

⚠️ This PR was generated autonomously by Claude (Claude Code) as part of a machine-driven code-review pass. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VchUUr2sfktdyXiwAu2QBj)_