### PR TITLE
fix(daemon): reclaim extension-table entries on RemoveNode/ReplaceNode

### DIFF
--- a/binaries/daemon/src/extension_table.rs
+++ b/binaries/daemon/src/extension_table.rs
@@ -32,6 +32,15 @@ pub struct ExtensionKey {
 struct Entry {
     value: Vec<u8>,
     /// The node that stored it. Its exit reclaims the entry.
+    ///
+    /// A bare id, not (id, incarnation): a node that is removed and re-added
+    /// under the same id inherits whatever its predecessor stored, because
+    /// the daemon cannot tell the two apart here. That costs the removed
+    /// incarnation's stop-grace-window entries their prompt release — they
+    /// live until dataflow finish (dora-rs/dora#3177). Making ownership
+    /// generation-aware would close it; it needs the storing incarnation's
+    /// generation threaded down to `store`, which the daemon drops before
+    /// the `ExtensionStore` arm today.
     owner: NodeId,
     /// Everyone who stored or loaded it, and so must be told when it is
     /// dropped. Includes the owner.

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -2842,6 +2842,25 @@ impl Daemon {
                     Ok(())
                 })();
 
+                // Reclaim the removed node's extension-table entries. Its
+                // later `SpawnedNodeResult` exit event is swallowed by the
+                // generation guard (the node is already gone from
+                // `running_nodes`), so the reclaim at that call site is
+                // unreachable for a removed node — this is the only reachable
+                // point. Without it, repeated dynamic add/remove cycles of an
+                // entry-owning node leak entries toward the per-dataflow cap
+                // and readers never receive the drop notification
+                // (dora-rs/dora#3177, originally #2881/#3014).
+                if result.is_ok() {
+                    reclaim_extensions_of_exited_node(
+                        &mut self.extensions,
+                        self.running.get(&dataflow_id),
+                        dataflow_id,
+                        &node_id,
+                        &self.clock,
+                    );
+                }
+
                 // Outside the closure because it is async. Why removal
                 // has to drive the barrier at all: see
                 // `PendingNodes::handle_node_removal`.
@@ -3225,6 +3244,20 @@ impl Daemon {
                     // The outgoing (or an even earlier) incarnation's stale
                     // result must not be attributed to the replacement.
                     clear_node_result(&mut self.dataflow_node_results, dataflow_id, &node_id);
+                    // Reclaim the outgoing incarnation's extension-table
+                    // entries. Its exit event is dropped by the generation
+                    // guard, so this is the only reachable point to release
+                    // them. The freshly spawned replacement shares the node id
+                    // but has not stored anything yet, so this drops only the
+                    // outgoing incarnation's entries (dora-rs/dora#3177,
+                    // originally #2881/#3014).
+                    reclaim_extensions_of_exited_node(
+                        &mut self.extensions,
+                        self.running.get(&dataflow_id),
+                        dataflow_id,
+                        &node_id,
+                        &self.clock,
+                    );
                 }
                 let reply = DaemonCoordinatorReply::ReplaceNodeResult(
                     result.map_err(|err| format!("{err:?}")),

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -850,6 +850,21 @@ fn extract_node_results(
 }
 
 impl Daemon {
+    /// Release every extension-table entry owned by `node_id`, notifying the
+    /// nodes that read them. Thin wrapper over the free function so the call
+    /// sites do not each repeat the `running` lookup — the exception is the
+    /// clean-exit site, which holds a `&mut self.logger` borrow and so must
+    /// name the disjoint fields itself.
+    fn reclaim_extensions(&mut self, dataflow_id: DataflowId, node_id: &NodeId) {
+        reclaim_extensions_of_exited_node(
+            &mut self.extensions,
+            self.running.get(&dataflow_id),
+            dataflow_id,
+            node_id,
+            &self.clock,
+        );
+    }
+
     /// Runs the daemon. `zenoh_listen_addr` overrides the address this
     /// daemon's zenoh listener binds, and therefore the locator its peers are
     /// told to dial.
@@ -2846,19 +2861,20 @@ impl Daemon {
                 // later `SpawnedNodeResult` exit event is swallowed by the
                 // generation guard (the node is already gone from
                 // `running_nodes`), so the reclaim at that call site is
-                // unreachable for a removed node — this is the only reachable
-                // point. Without it, repeated dynamic add/remove cycles of an
-                // entry-owning node leak entries toward the per-dataflow cap
-                // and readers never receive the drop notification
-                // (dora-rs/dora#3177, originally #2881/#3014).
+                // unreachable for a removed node. Without a reclaim here,
+                // repeated dynamic add/remove cycles of an entry-owning node
+                // leak entries toward the per-dataflow cap and readers never
+                // receive the drop notification (dora-rs/dora#3177,
+                // originally #2881/#3014).
+                //
+                // Reclaiming here rather than only on the node's death also
+                // notifies readers promptly, and is the ONLY release for a
+                // node that never reports an exit at all (a dynamic node has
+                // no process handle to wait on). What it does not cover —
+                // stores made during the stop grace window — is picked up by
+                // the second reclaim on the dropped exit event.
                 if result.is_ok() {
-                    reclaim_extensions_of_exited_node(
-                        &mut self.extensions,
-                        self.running.get(&dataflow_id),
-                        dataflow_id,
-                        &node_id,
-                        &self.clock,
-                    );
+                    self.reclaim_extensions(dataflow_id, &node_id);
                 }
 
                 // Outside the closure because it is async. Why removal
@@ -3247,17 +3263,16 @@ impl Daemon {
                     // Reclaim the outgoing incarnation's extension-table
                     // entries. Its exit event is dropped by the generation
                     // guard, so this is the only reachable point to release
-                    // them. The freshly spawned replacement shares the node id
-                    // but has not stored anything yet, so this drops only the
-                    // outgoing incarnation's entries (dora-rs/dora#3177,
-                    // originally #2881/#3014).
-                    reclaim_extensions_of_exited_node(
-                        &mut self.extensions,
-                        self.running.get(&dataflow_id),
-                        dataflow_id,
-                        &node_id,
-                        &self.clock,
-                    );
+                    // them (dora-rs/dora#3177, originally #2881/#3014).
+                    //
+                    // Unlike `RemoveNode` this needs no second reclaim on the
+                    // exit event, and it drops only the outgoing incarnation's
+                    // entries: the replacement's higher generation is already
+                    // installed above, and the daemon's event loop is serial,
+                    // so it has not stored anything yet and the outgoing
+                    // incarnation's later stores are dropped as superseded
+                    // (#2926, #2927) instead of landing under the shared id.
+                    self.reclaim_extensions(dataflow_id, &node_id);
                 }
                 let reply = DaemonCoordinatorReply::ReplaceNodeResult(
                     result.map_err(|err| format!("{err:?}")),
@@ -5721,6 +5736,10 @@ impl Daemon {
                     .running
                     .get(&dataflow_id)
                     .and_then(|dataflow| dataflow.running_nodes.get(&node_id));
+                // Nothing owns the id: `RemoveNode` took the entry out, or the
+                // dataflow is gone. A mismatching generation with an entry
+                // still present means a replacement or a re-add owns it now.
+                let node_id_unowned = current_generation.is_none();
                 // Deliberate semantics of the entry-absent case: an exit
                 // arriving after `RemoveNode` took the entry out is dropped
                 // here WITHOUT running the finish accounting below. That
@@ -5741,6 +5760,22 @@ impl Daemon {
                             ),
                         )
                         .await;
+                    // A node removed while alive keeps its daemon connection
+                    // for the whole stop grace window — the node-event guard
+                    // deliberately lets its events through once the entry is
+                    // gone — so it can still store extension entries after
+                    // `RemoveNode`'s eager reclaim. This event is that process
+                    // actually dying: the last chance to release them, and
+                    // without it they would live until dataflow finish, which
+                    // is the accumulation dora-rs/dora#3177 set out to stop.
+                    // Only when nothing owns the id: ownership is keyed by node
+                    // id alone (see `ExtensionTable`), so reclaiming for a
+                    // replacement or a re-add would take the live incarnation's
+                    // entries with it. Idempotent — an already-reclaimed exit
+                    // finds nothing.
+                    if node_id_unowned {
+                        self.reclaim_extensions(dataflow_id, &node_id);
+                    }
                     if let Some(dataflow) = self.running.get_mut(&dataflow_id) {
                         dataflow
                             .grace_duration_kills
@@ -5913,6 +5948,8 @@ impl Daemon {
                 // A node that crashed cannot withdraw its own descriptors.
                 // Reclaiming here is the reason the extension table lives in
                 // the daemon at all (dora-rs/dora#2881).
+                // The free function, not the `&mut self` wrapper: `logger`
+                // holds a mutable borrow of `self.logger` across this point.
                 reclaim_extensions_of_exited_node(
                     &mut self.extensions,
                     self.running.get(&dataflow_id),
@@ -9256,6 +9293,51 @@ mod fault_tolerance_tests {
             &mut deadline,
             window
         ));
+    }
+
+    // -- dora#3177: extension entries of removed/replaced nodes --
+
+    fn ext_key(key: &str) -> ExtensionKey {
+        ExtensionKey {
+            dataflow_id: Uuid::nil().to_string(),
+            namespace: "dora-tensor-pool".into(),
+            key: key.into(),
+        }
+    }
+
+    /// The daemon-side half of reclamation, which `extension_table.rs`
+    /// cannot cover: the drop notification actually reaches the reader's
+    /// subscribe channel, so it can release what it derived from the value.
+    /// Every reclaim call site — `RemoveNode`, `ReplaceNode`, and both exit
+    /// paths — goes through this.
+    #[test]
+    fn reclaim_drops_owned_entries_and_notifies_readers() {
+        let mut df = test_dataflow();
+        let clock = test_clock();
+        let owner: NodeId = "owner".to_string().into();
+        let reader: NodeId = "reader".to_string().into();
+
+        let mut extensions = ExtensionTable::new();
+        extensions
+            .store(ext_key("pool_owner_1"), b"descriptor".to_vec(), &owner)
+            .unwrap();
+        extensions.load(&ext_key("pool_owner_1"), &reader).unwrap();
+
+        let (tx, mut rx) = mpsc::channel(NODE_EVENT_CHANNEL_CAPACITY);
+        df.subscribe_channels.insert(reader.clone(), tx);
+
+        reclaim_extensions_of_exited_node(&mut extensions, Some(&df), Uuid::nil(), &owner, &clock);
+
+        assert_eq!(extensions.len(), 0, "the owner's entry must be gone");
+        let events = drain_events(&mut rx);
+        assert!(
+            matches!(
+                events.as_slice(),
+                [NodeEvent::ExtensionDropped { namespace, key }]
+                    if namespace == "dora-tensor-pool" && key == "pool_owner_1"
+            ),
+            "reader must be notified exactly once: {events:?}"
+        );
     }
 }
 


### PR DESCRIPTION
Closes #3177.

When #3152 (`0442564`) moved the daemon's memory-pool manager behind the generic `ExtensionTable`, it carried over only **one** of #3014's three reclamation call sites (`SpawnedNodeResult`). That site is **unreachable** for a dynamically removed or replaced node: the generation guard drops the node's later exit event *before* the reclaim runs, because the node is already gone from `running_nodes` (`RemoveNode`) or superseded by a new incarnation (`ReplaceNode`).

As a result, an extension-table entry owned by a removed/replaced node was not released until dataflow finish (`reclaim_dataflow`). Repeated add/remove cycles of an entry-owning node accumulate toward `MAX_ENTRIES_PER_DATAFLOW = 8192`, after which `store()` fails for *every* node in the dataflow — the exact #2881 accumulation that #3014 set out to fix. Readers keyed on those entries also never received the drop notification the extension contract (`docs/extensions.md`) advertises.

## Fix

- **`RemoveNode`** — reclaim after a successful removal. This is also the only release for a node that never reports an exit at all (a dynamic node has no process handle to wait on).
- **`ReplaceNode`** — reclaim after a successful replace, next to the existing `clear_node_result`. The replacement's higher generation is installed first and the event loop is serial, so this drops only the outgoing incarnation's entries and its later stores are dropped as superseded (#2926/#2927).
- **`SpawnedNodeResult`, generation-guard branch** — a node removed while alive keeps its daemon connection for the whole stop grace window (10s, hard kill at 15s), and the node-event guard deliberately lets its events through once its `running_nodes` entry is gone. So it can still `store()` after `RemoveNode`'s eager reclaim, and those entries have no other release point. Reclaim again when the process actually dies — but only when nothing owns the id, since ownership is keyed by node id alone and a replacement or re-add would otherwise lose its entries.

The known residual: a node removed and re-added under the same id inherits its predecessor's grace-window entries until dataflow finish. Closing that needs generation-aware ownership in `ExtensionTable`, which needs the storing incarnation's generation threaded down to `store` — documented on `Entry::owner` rather than fixed here.

## Scope / risk

Bounded to the opt-in `tensor-pool` extension (or another out-of-tree extension) — nothing in a default build writes to the `ExtensionTable`, so default builds are unaffected. Latent regression against the daemon's documented extension-lifetime contract (Class A).

Not covered, and filed separately: after the cross-machine memory-pool work in `c1b225ea9`, peer daemons hold mirror descriptors owned by the *remote* sender node. `RemoveNode` reaches only the hosting daemon and node removal publishes no `FreePool`, so the same accumulation remains on the peer.

## Testing

`cargo fmt --all -- --check`, `cargo clippy --all -- -D warnings`, `cargo test --all` (workspace, Python crates excluded), `cargo check --examples` — all clean. New unit test covers the daemon-side half of reclamation that `extension_table.rs` cannot reach: the `ExtensionDropped` notification arriving on a reader's subscribe channel.
