### PR TITLE
ci: pin maturin-version to skip the flaky versions-manifest lookup

### DIFF
--- a/.github/workflows/pip-release.yml
+++ b/.github/workflows/pip-release.yml
@@ -94,6 +94,11 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
+          # Pin the maturin version so the action skips its versions-manifest
+          # lookup (an unretried api.github.com / raw.githubusercontent.com
+          # fetch that intermittently fails with a self-signed-certificate TLS
+          # error and ejects PRs from the merge queue). See dora-rs/dora#3161.
+          maturin-version: v1.14.1
           target: ${{ matrix.platform.target }}
           args: --release --out dist --zig
           manylinux: manylinux_2_28
@@ -147,6 +152,11 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
+          # Pin the maturin version so the action skips its versions-manifest
+          # lookup (an unretried api.github.com / raw.githubusercontent.com
+          # fetch that intermittently fails with a self-signed-certificate TLS
+          # error and ejects PRs from the merge queue). See dora-rs/dora#3161.
+          maturin-version: v1.14.1
           target: ${{ matrix.platform.target }}
           args: --release --out dist
           sccache: "false"
@@ -189,6 +199,11 @@ jobs:
       - name: Build Wheels
         uses: PyO3/maturin-action@v1
         with:
+          # Pin the maturin version so the action skips its versions-manifest
+          # lookup (an unretried api.github.com / raw.githubusercontent.com
+          # fetch that intermittently fails with a self-signed-certificate TLS
+          # error and ejects PRs from the merge queue). See dora-rs/dora#3161.
+          maturin-version: v1.14.1
           target: ${{ matrix.platform.target }}
           manylinux: auto
           container: off
@@ -223,6 +238,11 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
+          # Pin the maturin version so the action skips its versions-manifest
+          # lookup (an unretried api.github.com / raw.githubusercontent.com
+          # fetch that intermittently fails with a self-signed-certificate TLS
+          # error and ejects PRs from the merge queue). See dora-rs/dora#3161.
+          maturin-version: v1.14.1
           target: ${{ matrix.platform.target }}
           args: --release --out dist -i ${{ env.PYTHON_VERSION }}
           # Was "true" — sccache floods the 10 GB repo cache with
@@ -258,6 +278,11 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
+          # Pin the maturin version so the action skips its versions-manifest
+          # lookup (an unretried api.github.com / raw.githubusercontent.com
+          # fetch that intermittently fails with a self-signed-certificate TLS
+          # error and ejects PRs from the merge queue). See dora-rs/dora#3161.
+          maturin-version: v1.14.1
           target: ${{ matrix.platform.target }}
           args: --release --out dist -i ${{ env.PYTHON_VERSION }}
           # Explicit: never enable the sccache GitHub-cache backend here
@@ -286,6 +311,11 @@ jobs:
       - name: Build sdist
         uses: PyO3/maturin-action@v1
         with:
+          # Pin the maturin version so the action skips its versions-manifest
+          # lookup (an unretried api.github.com / raw.githubusercontent.com
+          # fetch that intermittently fails with a self-signed-certificate TLS
+          # error and ejects PRs from the merge queue). See dora-rs/dora#3161.
+          maturin-version: v1.14.1
           command: sdist
           args: --out dist
           working-directory: ${{ matrix.repository.path }}
@@ -333,5 +363,10 @@ jobs:
         env:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_PASS }}
         with:
+          # Pin the maturin version so the action skips its versions-manifest
+          # lookup (an unretried api.github.com / raw.githubusercontent.com
+          # fetch that intermittently fails with a self-signed-certificate TLS
+          # error and ejects PRs from the merge queue). See dora-rs/dora#3161.
+          maturin-version: v1.14.1
           command: upload
           args: --non-interactive --skip-existing ${{ matrix.repository.name }}-*/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,6 +160,11 @@ jobs:
         if: matrix.platform.zig
         uses: PyO3/maturin-action@v1
         with:
+          # Pin the maturin version so the action skips its versions-manifest
+          # lookup (an unretried api.github.com / raw.githubusercontent.com
+          # fetch that intermittently fails with a self-signed-certificate TLS
+          # error and ejects PRs from the merge queue). See dora-rs/dora#3161.
+          maturin-version: v1.14.1
           target: ${{ matrix.platform.target }}
           args: --release --out dist --zig
           manylinux: manylinux_2_28
@@ -168,6 +173,11 @@ jobs:
         if: ${{ !matrix.platform.zig }}
         uses: PyO3/maturin-action@v1
         with:
+          # Pin the maturin version so the action skips its versions-manifest
+          # lookup (an unretried api.github.com / raw.githubusercontent.com
+          # fetch that intermittently fails with a self-signed-certificate TLS
+          # error and ejects PRs from the merge queue). See dora-rs/dora#3161.
+          maturin-version: v1.14.1
           target: ${{ matrix.platform.target }}
           args: --release --out dist
           working-directory: ${{ matrix.repository.path }}


### PR DESCRIPTION
## Summary

Closes #3161.

The wheel-build jobs in `pip-release.yml` (and the `release.yml` build steps) intermittently die during setup — before any build work — with a Node.js TLS error:

```
Error: self-signed certificate; if the root CA is installed locally,
try running Node.js with --use-system-ca
```

As the issue diagnoses, the failing request is **not** the maturin download but `maturin-action`'s versions-manifest lookup — `findReleaseFromManifest` → `tc.getManifestFromRepo('PyO3', 'maturin', …)`, an unretried `api.github.com` / `raw.githubusercontent.com` fetch used only to turn `maturin>=0.13.2` into a concrete version. Because `pip-release all green` is a required merge-queue status (`.trunk/trunk.yaml`), an affected job ejects the whole batch from the queue.

## Fix

Set the action's `maturin-version` input so it short-circuits `findVersion` and skips the manifest lookup entirely. Pinned to `v1.14.1` — the version the manifest resolves to today, so this is **not** a version change, only a surface reduction.

Applied to all **7** `maturin-action` steps in `.github/workflows/pip-release.yml` (linux / musllinux / windows / macos / sdist / upload) and **both** in `.github/workflows/release.yml` (zig + native builds).

## Residual risk

This is a surface reduction, not a proof against recurrence: the release download that follows the (now-skipped) lookup is still a single unretried fetch and could hit the same upstream TLS-interception event. If the download step starts failing the same way, that's a separate follow-up (per the issue's note).

## Testing

Config-only change. Both workflow files parse as valid YAML; each of the 9 `maturin-action` steps now carries exactly one `maturin-version: v1.14.1` pin. There is no local way to exercise the release runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVUG1DfmpuprUTffuXU1eY

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVUG1DfmpuprUTffuXU1eY)_