### PR TITLE
fix(mavlink2-bridge): reject an invalid `?baud=` instead of silently using 115200

### DIFF
--- a/libraries/extensions/mavlink2-bridge/src/transport.rs
+++ b/libraries/extensions/mavlink2-bridge/src/transport.rs
@@ -89,15 +89,36 @@ fn connect_serial(url: &Url) -> BridgeResult<Box<dyn MavConnection<MavMessage> +
             "missing device path in '{url}'"
         )));
     }
-    let baud = parse_baud(url).unwrap_or(DEFAULT_SERIAL_BAUD);
+    let baud = parse_baud(url)?;
     let version = parse_proto_query(url)?;
     open_mavlink_versioned(&format!("serial:{device}:{baud}"), version)
 }
 
-fn parse_baud(url: &Url) -> Option<u32> {
-    url.query_pairs()
-        .find(|(k, _)| k == "baud")
-        .and_then(|(_, v)| v.parse::<u32>().ok())
+/// Resolve the serial baud rate from an optional `?baud=` query parameter.
+///
+/// - absent → the [`DEFAULT_SERIAL_BAUD`] default;
+/// - a positive integer → that rate;
+/// - anything else (unparseable, or `0`) → a [`BridgeError::Config`].
+///
+/// The explicit error on an invalid value is deliberate and mirrors
+/// [`parse_proto_query`]: a typo such as `?baud=57600x` (or a stray `?baud=0`)
+/// previously fell back to `115_200` silently, so a misconfigured endpoint
+/// connected at the wrong baud with no diagnostic — producing a garbled or
+/// dead serial link. An absent parameter is distinct from an invalid one and
+/// still defaults quietly.
+fn parse_baud(url: &Url) -> BridgeResult<u32> {
+    match url.query_pairs().find(|(k, _)| k == "baud") {
+        None => Ok(DEFAULT_SERIAL_BAUD),
+        Some((_, v)) => v
+            .parse::<u32>()
+            .ok()
+            .filter(|&baud| baud > 0)
+            .ok_or_else(|| {
+                BridgeError::Config(format!(
+                    "invalid serial baud '{v}' in '{url}' (expected a positive integer)"
+                ))
+            }),
+    }
 }
 
 fn open_mavlink_versioned(
@@ -141,19 +162,34 @@ mod tests {
     #[test]
     fn parses_baud_query() {
         let url = Url::parse("serial:///dev/tty.usbmodem1?baud=57600").unwrap();
-        assert_eq!(parse_baud(&url), Some(57600));
+        assert_eq!(parse_baud(&url).unwrap(), 57600);
     }
 
     #[test]
     fn parses_baud_missing() {
+        // An absent `?baud=` defaults quietly — omission is not a misconfiguration.
         let url = Url::parse("serial:///dev/tty.usbmodem1").unwrap();
-        assert_eq!(parse_baud(&url), None);
+        assert_eq!(parse_baud(&url).unwrap(), DEFAULT_SERIAL_BAUD);
     }
 
     #[test]
-    fn parses_baud_garbage() {
+    fn rejects_baud_garbage() {
+        // A present-but-invalid `?baud=` is a hard error, not a silent fallback
+        // to 115200 (which would connect at the wrong baud with no diagnostic).
         let url = Url::parse("serial:///dev/tty.usbmodem1?baud=fast").unwrap();
-        assert_eq!(parse_baud(&url), None);
+        let err = parse_baud(&url).unwrap_err();
+        assert!(
+            matches!(err, BridgeError::Config(_)),
+            "expected a Config error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_baud_zero() {
+        // `?baud=0` parses as a u32 but is not a usable rate; reject it rather
+        // than handing `serial:/dev/...:0` to the mavlink layer.
+        let url = Url::parse("serial:///dev/tty.usbmodem1?baud=0").unwrap();
+        assert!(parse_baud(&url).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Issue

`connect_serial` in `libraries/extensions/mavlink2-bridge/src/transport.rs` resolved the serial baud with:

```rust
let baud = parse_baud(url).unwrap_or(DEFAULT_SERIAL_BAUD);
```

where `parse_baud` returned `Option<u32>` and mapped **both** an absent `?baud=` **and** a present-but-invalid one to `None`. So a typo such as `serial:///dev/ttyUSB0?baud=57600x` (or a stray `?baud=0`) silently fell back to 115200 and the endpoint connected at the wrong baud **with no diagnostic** — producing a garbled or dead serial link.

This is exactly the silent-misconfiguration failure mode the sibling `parse_proto_query` was deliberately rewritten to prevent. Its own doc comment says:

> The explicit error on an unrecognized value is deliberate: a typo such as `?proto=v3` previously fell back to V2 silently, so a misconfigured endpoint connected on the wrong protocol with no diagnostic.

The two query parsers were inconsistent: `proto` distinguished *absent* (default) from *invalid* (hard error), while `baud` conflated them.

## Fix

`parse_baud` now returns `BridgeResult<u32>`, mirroring `parse_proto_query`:

- absent `?baud=` → defaults quietly to `DEFAULT_SERIAL_BAUD` (115200);
- a positive integer → that rate;
- anything else (unparseable, or `0`) → a `BridgeError::Config` naming the bad value and URL.

`connect_serial` propagates the error with `?`.

## Validation

- The old `parses_baud_garbage` test (which asserted the silent-`None` behavior) is replaced by `rejects_baud_garbage`; a new `rejects_baud_zero` test covers the `?baud=0` case; `parses_baud_missing` now asserts the default is returned.
- `cargo fmt -p dora-mavlink2-bridge -- --check`, `cargo clippy -p dora-mavlink2-bridge -- -D warnings`, and `cargo test -p dora-mavlink2-bridge` all pass.

---

⚠️ **This is a machine-generated pull request authored by Claude (Claude Code).** A human should review it before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LTuREX2cXE4GRu9HtJZh5J)_