### PR TITLE
fix(core): don't report an annotated-but-typoed upstream as having "no type annotation"

### DIFF
--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -920,6 +920,26 @@ pub struct TypeCheckResult {
 /// Timer nodes auto-inject this type.
 const TIMER_TYPE: &str = "std/core/v1/UInt64";
 
+/// Register one declared output type under `key` (a `(node_id, output_ref)`
+/// pair). The port is *always* recorded in `annotated` so a typo'd or
+/// otherwise unresolvable URN still suppresses the strict-mode "upstream has
+/// no type annotation" warning; it is additionally recorded in
+/// `output_type_map` (the map used for cross-edge type matching) only when its
+/// URN resolves. Keeping both writes behind one call makes the two structures
+/// impossible to desync — the invariant the strict-mode check relies on.
+fn register_output_type(
+    output_type_map: &mut BTreeMap<(String, String), String>,
+    annotated: &mut BTreeSet<(String, String)>,
+    key: (String, String),
+    urn: &str,
+    registry: &crate::types::TypeRegistry,
+) {
+    annotated.insert(key.clone());
+    if registry.resolve(urn).is_some() {
+        output_type_map.insert(key, urn.to_string());
+    }
+}
+
 /// Check type annotations in a dataflow, with strict mode support.
 ///
 /// Returns the collected warnings plus any inferred edge types.
@@ -955,7 +975,16 @@ pub fn check_type_annotations_full(
     let compat = CompatibilityGraph::new(&user_rules);
 
     // Map of (source_node_id, output_ref) -> type_urn for cross-edge checking.
+    // Only outputs whose declared URN *resolves* are registered here.
     let mut output_type_map: BTreeMap<(String, String), String> = BTreeMap::new();
+
+    // Every (source_node_id, output_ref) that carries *some* output-type
+    // annotation, including one whose URN does not resolve (a typo). Used to
+    // suppress the strict-mode "upstream has no type annotation" warning on a
+    // port that *is* annotated but with an unknown URN — that URN is already
+    // reported by `check_port_types`, so the extra "no annotation" warning
+    // would be factually wrong and misdirect the user.
+    let mut annotated_output_ports: BTreeSet<(String, String)> = BTreeSet::new();
 
     for node in &dataflow.nodes {
         let nid = node.id.to_string();
@@ -971,9 +1000,13 @@ pub fn check_type_annotations_full(
         );
         // Register node outputs for cross-edge checking
         for (output_id, urn) in &node.output_types {
-            if registry.resolve(urn).is_some() {
-                output_type_map.insert((nid.clone(), output_id.to_string()), urn.clone());
-            }
+            register_output_type(
+                &mut output_type_map,
+                &mut annotated_output_ports,
+                (nid.clone(), output_id.to_string()),
+                urn,
+                registry,
+            );
         }
 
         // Check node-level input_types
@@ -1011,20 +1044,29 @@ pub fn check_type_annotations_full(
                 &mut warnings,
             );
             for (output_id, urn) in &op.config.output_types {
-                if registry.resolve(urn).is_some() {
-                    // A consumer of a single-`operator:` node references its
-                    // output in short form (`node/output`) in the source YAML;
-                    // the `op/` prefix is only injected later by
-                    // `resolve_aliases_and_set_defaults`, which this pre-build
-                    // check never runs. Register both the prefixed key and the
-                    // bare `output_id` so short-form edges resolve here too —
-                    // otherwise the upstream type is invisible, silently
-                    // dropping genuine mismatches and, under `strict`, emitting
-                    // a false "upstream has no type annotation" warning.
-                    output_type_map
-                        .insert((nid.clone(), format!("{op_id}/{output_id}")), urn.clone());
-                    output_type_map.insert((nid.clone(), output_id.to_string()), urn.clone());
-                }
+                // A consumer of a single-`operator:` node references its output
+                // in short form (`node/output`) in the source YAML; the `op/`
+                // prefix is only injected later by
+                // `resolve_aliases_and_set_defaults`, which this pre-build check
+                // never runs. Register both the prefixed key and the bare
+                // `output_id` so short-form edges resolve here too — otherwise
+                // the upstream type is invisible, silently dropping genuine
+                // mismatches and, under `strict`, emitting a false "upstream has
+                // no type annotation" warning.
+                register_output_type(
+                    &mut output_type_map,
+                    &mut annotated_output_ports,
+                    (nid.clone(), format!("{op_id}/{output_id}")),
+                    urn,
+                    registry,
+                );
+                register_output_type(
+                    &mut output_type_map,
+                    &mut annotated_output_ports,
+                    (nid.clone(), output_id.to_string()),
+                    urn,
+                    registry,
+                );
             }
             check_port_types(
                 &nid,
@@ -1054,10 +1096,13 @@ pub fn check_type_annotations_full(
                     &mut warnings,
                 );
                 for (output_id, urn) in &op.config.output_types {
-                    if registry.resolve(urn).is_some() {
-                        output_type_map
-                            .insert((nid.clone(), format!("{}/{output_id}", op.id)), urn.clone());
-                    }
+                    register_output_type(
+                        &mut output_type_map,
+                        &mut annotated_output_ports,
+                        (nid.clone(), format!("{}/{output_id}", op.id)),
+                        urn,
+                        registry,
+                    );
                 }
                 check_port_types(
                     &label,
@@ -1088,6 +1133,7 @@ pub fn check_type_annotations_full(
             &node.input_types,
             &node.inputs,
             &output_type_map,
+            &annotated_output_ports,
             &timer_types,
             &compat,
             registry,
@@ -1103,6 +1149,7 @@ pub fn check_type_annotations_full(
                 &op.config.input_types,
                 &op.config.inputs,
                 &output_type_map,
+                &annotated_output_ports,
                 &op_timer,
                 &compat,
                 registry,
@@ -1120,6 +1167,7 @@ pub fn check_type_annotations_full(
                     &op.config.input_types,
                     &op.config.inputs,
                     &output_type_map,
+                    &annotated_output_ports,
                     &op_timer,
                     &compat,
                     registry,
@@ -1228,6 +1276,7 @@ fn check_edge_mismatches_with_compat(
     input_types: &BTreeMap<DataId, String>,
     inputs: &BTreeMap<DataId, Input>,
     output_type_map: &BTreeMap<(String, String), String>,
+    annotated_output_ports: &BTreeSet<(String, String)>,
     timer_types: &BTreeMap<DataId, String>,
     compat: &crate::types::CompatibilityGraph,
     registry: &crate::types::TypeRegistry,
@@ -1264,7 +1313,16 @@ fn check_edge_mismatches_with_compat(
                             source: format!("{}/{}", mapping.source, mapping.output),
                         });
                     }
-                    (None, Some(in_urn)) if strict => {
+                    // Strict mode, and the upstream has no *resolvable* type.
+                    // The guard also excludes an upstream that *is* annotated
+                    // but with an unresolvable URN (a typo): such a port is
+                    // absent from `output_type_map` yet present in
+                    // `annotated_output_ports`, so it falls through to `_` with
+                    // no warning here. `check_port_types` already reports the
+                    // unknown URN, so a second "has no type annotation" warning
+                    // would be factually wrong and send the user chasing a
+                    // missing annotation instead of the typo.
+                    (None, Some(in_urn)) if strict && !annotated_output_ports.contains(&key) => {
                         warnings.push(TypeWarning {
                             node_id: node_id.to_string(),
                             message: format!(
@@ -2257,6 +2315,52 @@ nodes:
         let result = check_type_annotations_full(&dataflow, &reg, true);
         assert!(!result.warnings.is_empty());
         assert!(result.warnings[0].message.contains("no type annotation"));
+    }
+
+    /// Regression: an upstream output that *is* annotated but with an
+    /// unresolvable URN (a typo) must not trigger the strict-mode "upstream
+    /// has no type annotation" warning. The unknown URN is already reported by
+    /// the port-type check; a second "no annotation" warning would be
+    /// factually wrong and send the user chasing a missing annotation instead
+    /// of the typo.
+    #[test]
+    fn strict_mode_no_missing_annotation_warning_for_typoed_upstream() {
+        let dataflow = parse_dataflow(
+            "\
+nodes:
+  - id: sender
+    outputs:
+      - image
+    output_types:
+      image: std/media/v1/Imag
+  - id: receiver
+    inputs:
+      image: sender/image
+    input_types:
+      image: std/media/v1/Image
+",
+        );
+        let reg = TypeRegistry::new();
+        let result = check_type_annotations_full(&dataflow, &reg, true);
+        // The typo itself is still reported...
+        assert!(
+            result
+                .warnings
+                .iter()
+                .any(|w| w.message.contains("unknown type")),
+            "expected an unknown-type warning for the typo, got: {:?}",
+            result.warnings
+        );
+        // ...but the misleading "no type annotation" warning must not appear:
+        // the upstream *is* annotated, just misspelled.
+        assert!(
+            !result
+                .warnings
+                .iter()
+                .any(|w| w.message.contains("no type annotation")),
+            "must not claim the annotated-but-typoed upstream has no annotation, got: {:?}",
+            result.warnings
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Issue

In strict type-checking mode (`strict_types: true`), an upstream output whose declared type URN does **not resolve** — i.e. a typo — is reported to the user as if it carried *no type annotation at all*.

Given:

```yaml
nodes:
  - id: sender
    outputs: [image]
    output_types:
      image: std/media/v1/Imag      # typo of ...Image
  - id: receiver
    inputs:
      image: sender/image
    input_types:
      image: std/media/v1/Image
strict_types: true
```

the user gets **two** warnings:

```
unknown type "std/media/v1/Imag" on output "image" (did you mean "std/media/v1/Image"?)   ✅ correct
input "image" expects type "std/media/v1/Image" but upstream sender/image has no type annotation   ❌ false
```

The second is factually wrong — the upstream *is* annotated, just misspelled — and it sends the user chasing a nonexistent missing-annotation instead of fixing the typo the first warning already points at.

**Root cause:** in `check_type_annotations_full`, an output is only inserted into `output_type_map` when `registry.resolve(urn).is_some()`. So an unresolvable annotation never lands in the map and is indistinguishable, at the strict-mode edge check, from a genuinely absent one — which then falls into the `(None, Some(in_urn)) if strict` arm that emits "has no type annotation".

## Fix

Track every output port that carries *some* annotation — regardless of whether its URN resolves — in a new `annotated_output_ports: BTreeSet<(String, String)>` (populated alongside `output_type_map` at all three registration sites: node-level, single-`operator:`, and `operators:` runtime, using the same key forms). The strict-mode "no annotation" arm now also requires `!annotated_output_ports.contains(&key)`, so an annotated-but-unresolvable upstream falls through with no warning here. The unknown-URN warning from `check_port_types` still fires, and genuinely unannotated upstreams still warn exactly as before.

## Validation

- New regression test `strict_mode_no_missing_annotation_warning_for_typoed_upstream`: **fails before the fix** (asserts the misleading "no type annotation" warning is absent — both warnings were emitted) and **passes after**. Verified the RED state directly by reverting only the guard.
- Full `cargo test -p dora-core` passes (282 lib tests + doctests); `cargo fmt -p dora-core -- --check` and `cargo clippy -p dora-core -- -D warnings` clean.

---

⚠️ **This is a machine-generated pull request authored by Claude (Claude Code).** A human should review it before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LTuREX2cXE4GRu9HtJZh5J)_