### PR TITLE
fix(mavlink2-bridge-node): reject unknown keys in MAVLINK_BRIDGE_CONFIG

### DIFF
--- a/binaries/mavlink2-bridge-node/src/main.rs
+++ b/binaries/mavlink2-bridge-node/src/main.rs
@@ -168,7 +168,13 @@ fn classify_recv_error(err: &MessageReadError, datagram: bool) -> RecvDispositio
     }
 }
 
+/// `deny_unknown_fields` turns a mistyped key into a hard parse error rather
+/// than silently ignoring it and falling back to the default. Without it,
+/// `systemid: 10` (missing underscore) is dropped and the node quietly runs
+/// with `system_id = 255`; a `MAVLINK_BRIDGE_CONFIG` typo would otherwise
+/// misconfigure the bridge with no diagnostic.
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct Config {
     endpoint: String,
     #[serde(default = "default_system_id")]
@@ -1059,6 +1065,28 @@ mod tests {
         assert!(
             msg.contains("nullable") || msg.contains("null"),
             "error must mention null rows, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn config_parses_minimal_and_applies_defaults() {
+        let cfg: Config = serde_yaml::from_str("endpoint: udp://127.0.0.1:14550").unwrap();
+        assert_eq!(cfg.endpoint, "udp://127.0.0.1:14550");
+        assert_eq!(cfg.system_id, default_system_id());
+        assert_eq!(cfg.component_id, default_component_id());
+    }
+
+    #[test]
+    fn config_rejects_unknown_field() {
+        // A mistyped key (`systemid` instead of `system_id`) must be a hard
+        // error, not silently ignored — otherwise the node would run with the
+        // default system_id (255) and no diagnostic.
+        let err = serde_yaml::from_str::<Config>("endpoint: udp://127.0.0.1:14550\nsystemid: 10")
+            .expect_err("unknown config key must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("systemid") || msg.contains("unknown field"),
+            "error should name the unknown field, got: {msg}"
         );
     }
 }


### PR DESCRIPTION
## Issue

The bridge node's `Config` (in `binaries/mavlink2-bridge-node/src/main.rs`) is deserialized from the `MAVLINK_BRIDGE_CONFIG` env var but did **not** set `#[serde(deny_unknown_fields)]`. So a mistyped key was silently ignored and the corresponding field kept its default:

```yaml
endpoint: udp://127.0.0.1:14550
systemid: 10        # typo of system_id
```

parses successfully, the `systemid` line is dropped, and the node quietly runs with `system_id = 255` — no error, no warning. This is the same silent-misconfiguration footgun that the transport-layer query parsers (`?proto=`, and now `?baud=`) explicitly guard against.

## Fix

Add `#[serde(deny_unknown_fields)]` to `Config` so an unknown/typo'd key becomes a hard parse error, surfaced through the existing `.context("parsing MAVLINK_BRIDGE_CONFIG")`. The three real keys (`endpoint`, `system_id`, `component_id`) are unaffected, and this matches the convention already used by other config structs in the workspace (e.g. the dataflow descriptor).

### Note on YAML merge keys (`<<: *anchor`)

`deny_unknown_fields` also rejects a top-level YAML merge key. I verified this does **not** remove working behavior: `serde_yaml` 0.9 does not apply merge keys when deserializing directly into a struct via `from_str`, so a merge key was already silently dropped — e.g. `<<: {system_id: 7}` + `endpoint: ...` deserialized to `system_id = 0` (the default), not 7. So merge keys never functioned in this path; this change turns that silently-wrong config into a loud error, consistent with the PR's intent, rather than removing a capability.

## Validation

- `config_rejects_unknown_field` — a `systemid` typo now produces a parse error naming the unknown field.
- `config_parses_minimal_and_applies_defaults` — a minimal valid config still parses and applies the `system_id`/`component_id` defaults.
- `cargo fmt`/`cargo clippy -p dora-mavlink2-bridge-node -- -D warnings` clean; full bin unit suite → 17 passed.

---

⚠️ **This is a machine-generated pull request authored by Claude (Claude Code).** A human should review it before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)