### PR TITLE
fix(daemon): reject a stranger's higher generation in the node-event gate (#2997)

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -465,14 +465,37 @@ type DaemonRunResult = BTreeMap<Uuid, BTreeMap<NodeId, Result<(), NodeError>>>;
 
 /// Whether a node-connection event belongs to a superseded incarnation.
 ///
-/// Strictly-older comparison, deliberately not equality: generations are
-/// globally monotonic, and the restart loop publishes a successor's
-/// generation to the listener BEFORE spawning it, so a fast successor's
-/// events can carry a generation NEWER than the entry until its
-/// `ProcessHandleReplaced` is processed. Dropping those would eat the
-/// successor's one-shot `Subscribe` (dora-rs/dora#2988 review, finding 1).
-fn event_generation_is_stale(entry_generation: u64, event_generation: u64) -> bool {
-    event_generation < entry_generation
+/// An event is fresh only when its generation belongs to this entry's own
+/// incarnation lineage: either the currently-registered incarnation
+/// (`entry_generation`) or the successor this entry's OWN restart loop
+/// announced before spawning it (`successor_generation`, published into the
+/// entry's shared `generation_counter` before the successor connects).
+///
+/// The successor exception is why this is not a plain `== entry_generation`
+/// check: the restart loop publishes the successor's generation to the
+/// listener and spawns it BEFORE the daemon processes the matching
+/// `ProcessHandleReplaced` (which advances `entry_generation`), so a fast
+/// successor's `Subscribe`/`SendOut` can arrive while the entry still holds
+/// the predecessor's generation. Dropping those would eat the successor's
+/// one-shot `Subscribe` (dora-rs/dora#2988 review, finding 1).
+///
+/// The reason it is not a plain `event < entry` check either: that wrongly
+/// accepts a *stranger's* higher generation. When `dora node replace` races a
+/// restart of the outgoing node, the outgoing incarnation's restart loop mints
+/// a generation ABOVE the replacement's (both draw from the same global
+/// counter, but the replacement's is minted first, before its slow build). Its
+/// zombie's events would then pass a `<` gate and be applied to the
+/// replacement — reinstalling a dead subscribe channel, closing the
+/// replacement's outputs, injecting spurious output (dora-rs/dora#2997).
+/// Matching on the entry's OWN announced successor rejects that stranger — the
+/// stranger's generation lives in the outgoing lineage's counter, never the
+/// replacement's — while still letting the real successor through.
+fn event_generation_is_stale(
+    entry_generation: u64,
+    successor_generation: u64,
+    event_generation: u64,
+) -> bool {
+    event_generation != entry_generation && event_generation != successor_generation
 }
 
 /// Patch a stored descriptor entry with a replacement node's definition
@@ -1732,14 +1755,19 @@ impl Daemon {
                     // replaced or re-added id's old connection must not
                     // mutate the current entry (close its outputs, remove
                     // its subscription, ...) — dora-rs/dora#2926, #2927.
-                    // STRICTLY older only: the restart loop publishes the
-                    // successor's generation before spawning it, so a fast
-                    // successor can connect (and Subscribe) while the entry
-                    // still holds the predecessor's generation — a NEWER
-                    // event generation is that successor racing its own
-                    // `ProcessHandleReplaced` and must not be dropped, or
-                    // its one-shot Subscribe is lost and the incarnation
-                    // stays disconnected. Entry-absent passes through:
+                    // Accept only this entry's own lineage: its current
+                    // generation, or the successor its OWN restart loop
+                    // announced into `generation_counter` before spawning it.
+                    // The successor exception lets a fast successor's Subscribe
+                    // through while the entry still holds the predecessor's
+                    // generation (before its `ProcessHandleReplaced` lands),
+                    // without which its one-shot Subscribe is lost and the
+                    // incarnation stays disconnected. The lineage restriction
+                    // rejects a stranger's HIGHER generation — e.g. a
+                    // concurrent restart of a node being replaced mints a
+                    // generation above the replacement's — instead of
+                    // misapplying its zombie's events to the replacement
+                    // (dora-rs/dora#2997). Entry-absent passes through:
                     // during startup a node can register before its
                     // RunningNode is inserted, and the pending-nodes
                     // barrier owns that window.
@@ -1747,7 +1775,13 @@ impl Daemon {
                         .running
                         .get(&dataflow)
                         .and_then(|df| df.running_nodes.get(&node_id))
-                        .is_some_and(|node| event_generation_is_stale(node.generation, generation));
+                        .is_some_and(|node| {
+                            event_generation_is_stale(
+                                node.generation,
+                                node.generation_counter.load(atomic::Ordering::Acquire),
+                                generation,
+                            )
+                        });
                     if superseded {
                         tracing::debug!(
                             %dataflow,
@@ -7521,6 +7555,7 @@ mod fault_tolerance_tests {
             restart_loop_start: None,
             _listener_shutdown: None,
             generation: 7,
+            generation_counter: Arc::new(AtomicU64::new(7)),
             node_config: NodeConfig {
                 dataflow_id: Uuid::nil(),
                 node_id: NodeId::from("test".to_string()),
@@ -7550,23 +7585,45 @@ mod fault_tolerance_tests {
         }
     }
 
-    /// dora-rs/dora#2988 review, finding 1: the Event::Node gate must be
-    /// STRICTLY-older, not exact-match. The restart loop publishes a
-    /// successor's generation before spawning it, so the successor's
-    /// connection can emit its one-shot Subscribe with a generation NEWER
-    /// than the entry — dropping that leaves the incarnation disconnected
-    /// forever.
+    /// dora-rs/dora#2988 review, finding 1 (still upheld) and dora-rs/dora#2997:
+    /// the Event::Node gate accepts only the entry's own lineage — its current
+    /// generation or the successor its own restart loop announced into
+    /// `generation_counter`. It must let a fast successor's early events through
+    /// (or the incarnation stays disconnected forever) yet reject a stranger's
+    /// higher generation (or a replace-vs-restart zombie corrupts the
+    /// replacement).
     #[test]
-    fn node_event_gate_drops_only_strictly_older_generations() {
+    fn node_event_gate_accepts_only_own_lineage() {
+        // No pending successor announced: counter == entry generation.
         // Predecessor's connection after a swap advanced the entry: stale.
-        assert!(event_generation_is_stale(8, 7));
-        // The entry's current incarnation: current.
-        assert!(!event_generation_is_stale(8, 8));
-        // Successor racing its own ProcessHandleReplaced: must pass.
+        assert!(event_generation_is_stale(8, 8, 7));
+        // The entry's current incarnation: fresh.
+        assert!(!event_generation_is_stale(8, 8, 8));
+        // A higher generation with no announced successor is a stranger: stale.
         assert!(
-            !event_generation_is_stale(8, 9),
+            event_generation_is_stale(8, 8, 9),
+            "a newer generation the entry never announced must be dropped"
+        );
+
+        // The entry's own restart loop announced successor generation 9 (into
+        // `generation_counter`) before spawning it. Its early Subscribe races
+        // ahead of `ProcessHandleReplaced`, so the entry still reads generation
+        // 8; that successor's events must pass.
+        assert!(
+            !event_generation_is_stale(8, 9, 9),
             "a successor's early events must not be dropped while the \
              entry still holds the predecessor's generation"
+        );
+
+        // #2997: `dora node replace` minted the replacement at generation 10
+        // (its counter is 10, no successor announced), while a concurrent
+        // restart of the outgoing node minted a zombie at generation 11 in a
+        // DIFFERENT lineage's counter. The zombie's events (gen 11) must not be
+        // applied to the replacement, even though 11 > 10.
+        assert!(
+            event_generation_is_stale(10, 10, 11),
+            "a stranger incarnation's higher generation must be rejected, \
+             not misattributed to the replacement"
         );
     }
 

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -95,6 +95,17 @@ pub struct RunningNode {
     /// under this node ID. Lifecycle events from older incarnations must not
     /// mutate this entry or contribute results to it.
     pub(crate) generation: u64,
+    /// Shared counter into which *this entry's own* restart loop publishes its
+    /// successor's generation, before spawning that successor (see
+    /// `RawSpawner::restart_loop`). Because the successor can connect and
+    /// `Subscribe` before the daemon processes the matching
+    /// `ProcessHandleReplaced` (which advances [`Self::generation`]), the event
+    /// gate must accept a generation equal to this announced successor even
+    /// though it is newer than [`Self::generation`]. Crucially it is *this*
+    /// lineage's counter: a stranger incarnation (e.g. a concurrent restart of
+    /// a node being replaced) mints a higher generation into a *different*
+    /// counter, so its events are still rejected (dora-rs/dora#2997).
+    pub(crate) generation_counter: Arc<AtomicU64>,
     pub(crate) node_config: NodeConfig,
     pub(crate) pid: Option<Arc<AtomicU32>>,
     pub(crate) restart_count: Arc<AtomicU32>,

--- a/binaries/daemon/src/spawn/prepared.rs
+++ b/binaries/daemon/src/spawn/prepared.rs
@@ -201,6 +201,7 @@ impl PreparedNode {
             restart_loop_start: Some(registered_tx),
             _listener_shutdown: Some(self.listener_shutdown.clone()),
             generation: self.generation,
+            generation_counter: self.generation_counter.clone(),
             node_config: self.node_config.clone(),
             restart_policy: self.restart_policy(),
             disable_restart: disable_restart.clone(),


### PR DESCRIPTION
Fixes #2997

## Problem

The `Event::Node` staleness gate in the daemon event loop dropped **only strictly-older** generations:

```rust
fn event_generation_is_stale(entry_generation: u64, event_generation: u64) -> bool {
    event_generation < entry_generation
}
```

This is deliberately permissive so a fast restart successor's early `Subscribe` — published to the listener *before* the daemon processes the matching `ProcessHandleReplaced` — is not lost.

But `dora node replace` breaks the underlying assumption that *"any newer-than-entry generation is the entry's own racing restart successor"*. A replacement is a brand-new incarnation whose generation is minted **early** (before its slow build), while a concurrent restart of the *outgoing* node mints a **higher** generation from the same global counter. The outgoing incarnation's restart-zombie then carries a generation *above* the replacement's, so its `Subscribe` / `SendOut` / `OutputsDone` events pass the `<` gate and are applied to the replacement:

- `Subscribe` reinstalls the subscribe channel pointing at the dying zombie → the replacement receives no inputs and silently hangs.
- `OutputsDone` / `CloseOutputs` propagates output-closed downstream → consumers stop reading the replacement's outputs.
- `SendOut` injects spurious/duplicate output under the node id.

The terminal-exit path was already safe because it uses exact `matches_generation`; that asymmetry (terminal = exact-match, control/data = strictly-older) was the tell.

## Fix

Track each entry's **own lineage** instead of trusting "newer = mine". `RunningNode` now carries a clone of the shared `generation_counter` that its *own* restart loop publishes the successor generation into (before spawning the successor, so the value is visible by the time the successor connects). The gate accepts an event only when its generation equals:

- the entry's current generation, **or**
- the successor the entry's own restart loop announced (`generation_counter`).

A stranger's higher generation — minted into a **different** lineage's counter (the outgoing node's, not the replacement's) — is now rejected, while the real successor's early events still pass. This also brings the control/data path in line with the exact-match terminal path.

Because generations are globally monotonic and the replacement's counter only advances via its own restart loop, a replace-race zombie's generation can never coincide with the replacement's announced-successor value, so the gate rejects it reliably.

## Tests

- Rewrote the gate unit test (`node_event_gate_accepts_only_own_lineage`) to cover all four cases: current generation accepted, older dropped, a fast **announced** successor accepted, and a **stranger's** higher generation dropped (the #2997 case).

## Validation

- `cargo build -p dora-daemon` ✓
- `cargo test -p dora-daemon` ✓ (214 passed)
- `cargo clippy -p dora-daemon -- -D warnings` ✓
- `cargo fmt --all -- --check` ✓

---

_This PR was created by an automated Claude Code session working through auto-filed issues._

---
_Generated by [Claude Code](https://claude.ai/code/session_012FqbGAM7vQCCMYUuSTCfVP)_