### PR TITLE
fix(cli): don't fail `dora logs --follow` on an already-finished dataflow

### DIFF
--- a/binaries/cli/src/command/logs.rs
+++ b/binaries/cli/src/command/logs.rs
@@ -8,8 +8,8 @@ use super::{Executable, default_tracing};
 use crate::common::parse_duration;
 use crate::{
     common::{
-        CoordinatorOptions, expect_reply, resolve_dataflow_identifier_interactive,
-        send_control_request,
+        CoordinatorOptions, error_indicates_dataflow_finished, expect_reply,
+        resolve_dataflow_identifier_interactive, send_control_request,
     },
     output::{
         LogFormat, LogOutputConfig, level_filter_is_active, message_passes_level_filter,
@@ -787,13 +787,21 @@ fn stream_logs_from_coordinator(
         until.and_then(|d| chrono::TimeDelta::from_std(d).ok().map(|td| now - td));
     let want_node = node.map(|n| n.as_ref());
 
-    let log_rx = session.subscribe_logs(
-        &serde_json::to_vec(&ControlRequest::LogSubscribe {
-            dataflow_id: uuid,
-            level: log_level,
-        })
-        .wrap_err("failed to serialize message")?,
-    )?;
+    let request = serde_json::to_vec(&ControlRequest::LogSubscribe {
+        dataflow_id: uuid,
+        level: log_level,
+    })
+    .wrap_err("failed to serialize message")?;
+    let log_rx = match session.subscribe_logs(&request) {
+        Ok(rx) => rx,
+        // The dataflow finished (and was dropped from the running table)
+        // before the live subscription was accepted. The historical logs
+        // have already been printed by `logs`, so this is a clean end of
+        // stream, not an error — mirror `wait_until_dataflow_started`, which
+        // tolerates the same race for sub-second dataflows.
+        Err(err) if error_indicates_dataflow_finished(&err.to_string()) => return Ok(()),
+        Err(err) => return Err(err).wrap_err("failed to subscribe to logs"),
+    };
 
     while let Ok(raw) = log_rx.recv() {
         let raw = match raw {


### PR DESCRIPTION
## Issue

`dora logs <uuid> --follow` prints the historical logs correctly and then exits **non-zero** when the target dataflow has already finished.

The `logs()` command runs in two steps:
1. Fetch and print historical logs via a `Logs` request — this succeeds for finished/archived dataflows.
2. If `--follow` was passed, open a live subscription via `stream_logs_from_coordinator` → `session.subscribe_logs(...)`.

For a dataflow that has already finished, the coordinator has dropped it from its running-dataflows table, so `LogSubscribe` is rejected with `"no running dataflow with id X"` (`binaries/coordinator/src/ws_control.rs:165`). In `stream_logs_from_coordinator` that error was propagated with `?`, so the command emitted the full history and then failed.

This is exactly the sub-second/finished race that the CLI already recognizes elsewhere: `common.rs::error_indicates_dataflow_finished` exists for it, and `start/mod.rs::wait_until_dataflow_started` deliberately tolerates it. The `--follow` path did not. It is reachable for `dora logs <finished-uuid> --follow`, `--node <n> --follow`, and `--all-nodes --follow`, because `resolve_logs_dataflow_identifier` accepts a UUID without requiring the dataflow to still be running.

## Fix

In `stream_logs_from_coordinator`, match on the result of `subscribe_logs`. When the error indicates a finished dataflow, return `Ok(())` — a clean end of stream after the history has already been printed — mirroring `wait_until_dataflow_started`. Any other subscription error is still surfaced (now with a clearer `failed to subscribe to logs` context).

```rust
let log_rx = match session.subscribe_logs(&request) {
    Ok(rx) => rx,
    Err(err) if error_indicates_dataflow_finished(&err.to_string()) => return Ok(()),
    Err(err) => return Err(err).wrap_err("failed to subscribe to logs"),
};
```

## Validation

- `cargo fmt -p dora-cli -- --check` — clean
- `cargo clippy -p dora-cli -- -D warnings` — clean
- `cargo test -p dora-cli` — 320 passed, 0 failed
- Manual: start a dataflow that exits immediately, then `dora logs <uuid> --follow`. Before: prints logs, exits non-zero. After: prints logs, exits 0.

---

*This is a machine-generated pull request authored by Claude (Claude Code). It has been verified locally as described above, but please review carefully before merging.*

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnVKJTwF81rQJ6eRbbX5QX)_