### PR TITLE
perf(coordinator): send watchdog heartbeats concurrently, not serially

### DIFF
--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -2135,30 +2135,36 @@ async fn start_inner(
                     expire_stopped_nodes(dataflow);
                 }
                 let mut disconnected = BTreeSet::new();
+                // Send the per-daemon heartbeats concurrently rather than
+                // awaiting each 500 ms-bounded send in turn. Each send awaits a
+                // bounded WS mpsc, so a single backpressured (slow/half-dead but
+                // not yet 30 s-stale) daemon would otherwise stall this control
+                // loop for up to 500 ms before the next daemon is even tried —
+                // and N such daemons stall it for N × 500 ms, delaying every
+                // spawn/stop/logs request. `join_all` bounds the whole tick at
+                // ~500 ms regardless of daemon count. Mirrors `destroy_daemons`.
+                let mut heartbeats = Vec::new();
                 for (machine_id, connection) in daemon_connections.iter_mut() {
-                    if connection.last_heartbeat.elapsed() > Duration::from_secs(15) {
+                    let elapsed = connection.last_heartbeat.elapsed();
+                    if elapsed > Duration::from_secs(15) {
                         tracing::warn!(
-                            "no heartbeat message from machine `{machine_id}` since {:?}",
-                            connection.last_heartbeat.elapsed()
+                            "no heartbeat message from machine `{machine_id}` since {elapsed:?}"
                         )
                     }
-                    if connection.last_heartbeat.elapsed() > Duration::from_secs(30) {
+                    if elapsed > Duration::from_secs(30) {
                         disconnected.insert(machine_id.clone());
                         continue;
                     }
-                    let result: eyre::Result<()> = tokio::time::timeout(
-                        Duration::from_millis(500),
-                        send_heartbeat_message(connection, clock.new_timestamp()),
-                    )
-                    .await
-                    .wrap_err("timeout")
-                    .and_then(|r| r)
-                    .wrap_err_with(|| {
-                        format!("failed to send heartbeat message to daemon at `{machine_id}`")
-                    });
+                    heartbeats.push(send_heartbeat_with_timeout(
+                        machine_id.clone(),
+                        connection,
+                        clock.new_timestamp(),
+                    ));
+                }
+                for (machine_id, result) in join_all(heartbeats).await {
                     if let Err(err) = result {
                         tracing::warn!("{err:?}");
-                        disconnected.insert(machine_id.clone());
+                        disconnected.insert(machine_id);
                     }
                 }
                 if !disconnected.is_empty() {
@@ -3082,6 +3088,25 @@ fn handle_spawn_result_ok(
             tracing::warn!("failed to persist dataflow running: {e}");
         }
     }
+}
+
+/// Send one heartbeat to `connection` with a 500 ms deadline, tagging the
+/// result with `machine_id` so the watchdog can act on failures after awaiting
+/// many of these concurrently via `join_all`.
+async fn send_heartbeat_with_timeout(
+    machine_id: DaemonId,
+    connection: &mut crate::state::DaemonConnection,
+    timestamp: dora_core::uhlc::Timestamp,
+) -> (DaemonId, eyre::Result<()>) {
+    let result = tokio::time::timeout(
+        Duration::from_millis(500),
+        send_heartbeat_message(connection, timestamp),
+    )
+    .await
+    .wrap_err("timeout")
+    .and_then(|r| r)
+    .wrap_err_with(|| format!("failed to send heartbeat message to daemon at `{machine_id}`"));
+    (machine_id, result)
 }
 
 /// Handle the failure arm of `Event::DataflowSpawnResult`.


### PR DESCRIPTION
## Issue

On every `DaemonHeartbeatInterval` tick, the coordinator's watchdog iterated the connected daemons and awaited a 500 ms-bounded `send_heartbeat_message` for each one **sequentially**, on the single control-plane event loop:

```rust
for (machine_id, connection) in daemon_connections.iter_mut() {
    ...
    let result = tokio::time::timeout(
        Duration::from_millis(500),
        send_heartbeat_message(connection, clock.new_timestamp()),
    ).await ...;   // <-- awaited before the next daemon is even tried
}
```

`send_heartbeat_message` → `DaemonConnection::send` awaits on a bounded `mpsc::Sender`. A daemon whose WS write side is backpressured (slow or half-dead, but not yet 30 s-stale, so not yet disconnected) consumes up to the full 500 ms timeout before the loop moves on. With N such daemons, a single tick stalls the event loop for up to **N × 500 ms**, during which every spawn/stop/logs/topic control request is delayed. The stall scales with deployment size and with the number of momentarily-slow daemons.

## Fix

Send the per-daemon heartbeats **concurrently** with `join_all`, so the whole tick is bounded at ~500 ms regardless of daemon count. This mirrors the existing `destroy_daemons` helper, which already fans out per-daemon sends this way.

- The classification is unchanged: `> 15 s` still warns, `> 30 s` still marks the daemon disconnected and skips its heartbeat.
- The send-failure bookkeeping is unchanged: a failed/timed-out heartbeat still adds the daemon to `disconnected`, driving the same downstream cleanup.
- Only the sends now overlap instead of running back-to-back. Each connection has its own mpsc, so overlapping the awaits is safe — that is exactly the wait being parallelized.

The per-daemon send + result tagging is factored into a small `send_heartbeat_with_timeout(machine_id, connection, timestamp)` helper so the futures collected for `join_all` share one type.

## Validation

- `cargo fmt -p dora-coordinator -- --check` — clean
- `cargo clippy -p dora-coordinator -- -D warnings` — clean
- `cargo test -p dora-coordinator` — 151 passed, 0 failed

The disconnect/cleanup semantics are exercised by the existing coordinator test suite; this change only alters the scheduling of the sends within a tick, not their outcomes.

---

*This is a machine-generated pull request authored by Claude (Claude Code). It has been verified locally as described above, but please review carefully before merging.*

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnVKJTwF81rQJ6eRbbX5QX)_