### PR TITLE
docs(node): add a compile-checked doctest for the PreparedIpc fast path

### DIFF
--- a/apis/rust/node/src/node/arrow_utils/ipc_encode.rs
+++ b/apis/rust/node/src/node/arrow_utils/ipc_encode.rs
@@ -353,6 +353,28 @@ pub fn ipc_fast_path_len(array: &ArrayData) -> Option<usize> {
 /// small/medium messages.
 ///
 /// The emitted bytes are identical to [`encode_ipc_into`].
+///
+/// # Example
+///
+/// ```
+/// # fn main() -> eyre::Result<()> {
+/// use dora_node_api::arrow::array::{Array, UInt64Array};
+/// use dora_node_api::arrow_utils::decode_arrow_ipc;
+/// use dora_node_api::arrow_utils::ipc_encode::PreparedIpc;
+///
+/// let data = UInt64Array::from(vec![1, 2, 3]).into_data();
+///
+/// // Prepare once, size the destination from `byte_len()`, then encode into it.
+/// let prepared = PreparedIpc::new(&data).expect("primitive array is fast-path eligible");
+/// let mut buffer = vec![0u8; prepared.byte_len()];
+/// prepared.encode_into(&mut buffer)?;
+///
+/// // The buffer is a self-describing IPC stream, identical to `encode_ipc_into`.
+/// let decoded = decode_arrow_ipc(&buffer)?;
+/// assert_eq!(decoded, UInt64Array::from(vec![1, 2, 3]).into_data());
+/// # Ok(())
+/// # }
+/// ```
 pub struct PreparedIpc(Prepared);
 
 impl PreparedIpc {


### PR DESCRIPTION
## Issue

`arrow_utils::ipc_encode::PreparedIpc` is public API — it is re-exported at the crate root via `dora_node_api::arrow_utils` (`pub use node::{… arrow_utils}`, and `pub mod ipc_encode` within it). It is the prepare-once counterpart to `encode_arrow_ipc` / `decode_arrow_ipc`, both of which already carry runnable, compile-checked doctests in `arrow_utils.rs`.

`PreparedIpc` itself had only prose. Its core usage contract — the destination passed to `encode_into` must be **exactly** `byte_len()` bytes — is precisely the kind of invariant a doctest pins and keeps from silently rotting.

## Fix

Add a `# Example` doctest to `PreparedIpc` that:

1. builds an array and prepares it,
2. sizes a buffer from `byte_len()`,
3. encodes with `encode_into`,
4. round-trips the bytes through `decode_arrow_ipc` and asserts equality.

It mirrors the style of the existing `encode_arrow_ipc` / `decode_arrow_ipc` doctests. This is a documentation-only change — no code is modified.

## Validation

- `cargo fmt -p dora-node-api -- --check` — clean
- `cargo clippy -p dora-node-api -- -D warnings` — clean
- `cargo test -p dora-node-api --doc ipc_encode` — the new `PreparedIpc` doctest compiles and passes (1 passed)

---

*This is a machine-generated pull request authored by Claude (Claude Code). It has been verified locally as described above, but please review carefully before merging.*

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnVKJTwF81rQJ6eRbbX5QX)_