### PR TITLE
perf(message): serialize MemoryPoolWrite tensor_data as bulk bytes

### DIFF
--- a/libraries/message/src/bulk_bytes.rs
+++ b/libraries/message/src/bulk_bytes.rs
@@ -127,6 +127,62 @@ pub mod option {
     }
 }
 
+/// The same bulk-bytes treatment for a plain `Vec<u8>` field.
+///
+/// Used by cross-machine payloads that do not need the 128-byte Arrow
+/// alignment (`InterDaemonEvent::MemoryPoolWrite::tensor_data`), where the
+/// receiver copies the bytes into a mirror segment rather than decoding them
+/// zero-copy. The wire encoding is identical to serde's default `Vec<u8>`
+/// (postcard: varint length + raw bytes), so this is a pure speedup with no
+/// version bump — `vec_encoding_is_unchanged_from_the_seq_form` pins it.
+pub mod vec {
+    use serde::{
+        Deserializer, Serializer,
+        de::{self, Visitor},
+    };
+    use std::fmt;
+
+    pub fn serialize<S: Serializer>(value: &[u8], serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_bytes(value)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Vec<u8>, D::Error> {
+        deserializer.deserialize_bytes(VecPayloadVisitor)
+    }
+
+    struct VecPayloadVisitor;
+
+    impl<'de> Visitor<'de> for VecPayloadVisitor {
+        type Value = Vec<u8>;
+
+        fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("a byte array")
+        }
+
+        fn visit_bytes<E: de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+            Ok(v.to_vec())
+        }
+
+        fn visit_borrowed_bytes<E: de::Error>(self, v: &'de [u8]) -> Result<Self::Value, E> {
+            Ok(v.to_vec())
+        }
+
+        fn visit_byte_buf<E: de::Error>(self, v: Vec<u8>) -> Result<Self::Value, E> {
+            Ok(v)
+        }
+
+        /// Self-describing formats (notably JSON) render bytes as a sequence of
+        /// numbers and hand that back here rather than to `visit_bytes`.
+        fn visit_seq<A: de::SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+            let mut out = Vec::with_capacity(seq.size_hint().unwrap_or(0));
+            while let Some(byte) = seq.next_element::<u8>()? {
+                out.push(byte);
+            }
+            Ok(out)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -217,5 +273,58 @@ mod tests {
                 _ => panic!("option state changed across the round trip"),
             }
         }
+    }
+
+    // --- plain `Vec<u8>` variant (`crate::bulk_bytes::vec`) ---
+
+    #[derive(Serialize, Deserialize)]
+    struct VecSeqForm(Vec<u8>);
+
+    #[derive(Serialize, Deserialize)]
+    struct VecBytesForm(#[serde(with = "super::vec")] Vec<u8>);
+
+    fn vec_payload(len: usize) -> Vec<u8> {
+        (0..len).map(|i| (i % 251) as u8).collect()
+    }
+
+    /// Same premise as `encoding_is_unchanged_from_the_seq_form`, for the
+    /// plain-`Vec<u8>` helper used by `MemoryPoolWrite::tensor_data` (#3195):
+    /// swapping the per-element loop for a bulk copy must not move a byte on
+    /// the wire, including across postcard's 127/128 varint-prefix boundary.
+    #[test]
+    fn vec_encoding_is_unchanged_from_the_seq_form() {
+        for len in [0, 1, 127, 128, 129, 300, 4096, 70_000] {
+            let value = vec_payload(len);
+            assert_eq!(
+                postcard::to_stdvec(&VecSeqForm(value.clone())).expect("seq"),
+                postcard::to_stdvec(&VecBytesForm(value)).expect("bytes"),
+                "len {len}: bulk encoding differs from the sequence encoding — \
+                 this would be an unversioned wire break"
+            );
+        }
+    }
+
+    #[test]
+    fn vec_round_trips() {
+        for len in [0, 1, 128, 4096] {
+            let value = vec_payload(len);
+            let bytes = postcard::to_stdvec(&VecBytesForm(value.clone())).expect("serialize");
+            let back: VecBytesForm = postcard::from_bytes(&bytes).expect("deserialize");
+            assert_eq!(back.0, value, "len {len}: payload changed");
+        }
+    }
+
+    /// JSON hands bytes back as a sequence, so the visitor must accept that
+    /// shape too, and the JSON text must be unchanged from the sequence form.
+    #[test]
+    fn vec_survives_a_json_round_trip() {
+        let value = vec_payload(300);
+        let json = serde_json::to_string(&VecBytesForm(value.clone())).expect("to json");
+        let back: VecBytesForm = serde_json::from_str(&json).expect("from json");
+        assert_eq!(back.0, value);
+        assert_eq!(
+            json,
+            serde_json::to_string(&VecSeqForm(value)).expect("seq to json")
+        );
     }
 }

--- a/libraries/message/src/daemon_to_daemon.rs
+++ b/libraries/message/src/daemon_to_daemon.rs
@@ -30,6 +30,7 @@ pub enum InterDaemonEvent {
     MemoryPoolWrite {
         dataflow_id: DataflowId,
         shared_memory_id: String,
+        #[serde(with = "crate::bulk_bytes::vec")]
         tensor_data: Vec<u8>,
         size: usize,
         /// Per-pool write sequence assigned by the origin daemon. Echoed


### PR DESCRIPTION
## Summary

Fixes #3195.

`InterDaemonEvent::MemoryPoolWrite::tensor_data` is a plain `Vec<u8>`, so serde's default byte-container impl emits one `serialize_u8` per element, which postcard turns into a per-byte `try_push` — 40–50x slower than a bulk copy on payload-sized buffers. This is the **zenoh-relay fallback** path for the cross-machine tensor transport added in #3079 (commit `c1b225e`); it is used exactly on degraded/flaky links, where multi-MB tensors then pay that serialize/deserialize tax on top of an already-degraded link.

PR #3156 already routed `DataMessage::Vec` and `InterDaemonEvent::Output.data` through `serialize_bytes`/`deserialize_bytes` for the same reason. This PR applies the same treatment to the field #3079 reintroduced on the slow path.

## Changes

- Add a plain-`Vec<u8>` submodule (`crate::bulk_bytes::vec`) to the existing `bulk_bytes` module. The existing helper is typed for `AVec<u8, ConstAlign<128>>`; the mirror-segment receiver copies the bytes into its segment rather than decoding them zero-copy, so it does not need the 128-byte Arrow alignment. The visitor accepts both `visit_bytes` and `visit_seq` so self-describing formats (JSON) keep working.
- Annotate `MemoryPoolWrite::tensor_data` with `#[serde(with = "crate::bulk_bytes::vec")]`. The field type is unchanged (`Vec<u8>`), so no daemon producer/consumer code changes.

## Wire compatibility

The encoding is **byte-identical** to serde's default (postcard: varint length prefix + raw bytes), so this is a pure speedup — no `Metadata::CURRENT_VERSION` bump, no `.drec`/store schema change. A byte-identity test pins that across postcard's 127/128 varint length-prefix boundary, alongside postcard and JSON round-trip tests.

## Testing

- `cargo test -p dora-message bulk_bytes` — 7 passing, including the 3 new tests (`vec_encoding_is_unchanged_from_the_seq_form`, `vec_round_trips`, `vec_survives_a_json_round_trip`).
- `cargo clippy -p dora-message -- -D warnings` — clean.
- `cargo check -p dora-daemon` — clean (consumer type unchanged).
- `cargo fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZpoxgBdXvxZDwTN2bAu36)_