### PR TITLE
fix(daemon): key the cross-write safety-net timeout to the effective seq

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1735,26 +1735,36 @@ fn resolve_cross_write_ack(
 }
 
 /// Fire the safety-net timeout for a pending cross-machine write: remove the
-/// entry under `seq` and fail the node's blocked `WritePinnedMemory`. Returns
-/// whether an entry existed.
+/// entry under the write's *effective* seq and fail the node's blocked
+/// `WritePinnedMemory`. Returns whether an entry existed.
 ///
-/// The caller passes the write's *effective* seq — the one the entry is live
-/// under now, which advances from the original `seq` to a fresh `relay_seq` on
-/// a direct-TCP → zenoh failover. Keying the timeout to the pre-failover seq
-/// makes it a no-op after a re-key, leaving the write hung forever (#3193).
-fn fire_cross_write_timeout(dataflow_id: Uuid, shared_memory_id: String, seq: u64) -> bool {
-    if let Some(tx) = CROSS_WRITE_PENDING
+/// `effective_seq` is the seq the entry is live under now, which advances from
+/// the original `seq` to a fresh `relay_seq` on a direct-TCP → zenoh failover.
+/// Keying the timeout to the pre-failover seq makes it a no-op after a re-key,
+/// leaving the write hung forever (#3193).
+///
+/// The load happens *under the pending-map guard*, the same one
+/// `rekey_cross_write_to_relay` holds while it re-keys and stores. Loading
+/// outside it would reopen #3193 as a race: a failover landing between the load
+/// and the `remove` would leave the removal targeting a key that has already
+/// moved, and nothing retries.
+fn fire_cross_write_timeout(
+    dataflow_id: Uuid,
+    shared_memory_id: &str,
+    effective_seq: &std::sync::atomic::AtomicU64,
+) -> bool {
+    let mut pending = CROSS_WRITE_PENDING
         .lock()
-        .unwrap_or_else(|e| e.into_inner())
-        .remove(&(dataflow_id, shared_memory_id, seq))
-    {
-        let _ = tx.send(DaemonReply::Result(Err(
-            "cross-machine write timed out waiting for the remote commit ack".to_string(),
-        )));
-        true
-    } else {
-        false
-    }
+        .unwrap_or_else(|e| e.into_inner());
+    let seq = effective_seq.load(std::sync::atomic::Ordering::SeqCst);
+    let Some(tx) = pending.remove(&(dataflow_id, shared_memory_id.to_string(), seq)) else {
+        return false;
+    };
+    drop(pending);
+    let _ = tx.send(DaemonReply::Result(Err(
+        "cross-machine write timed out waiting for the remote commit ack".to_string(),
+    )));
+    true
 }
 
 /// Re-key a pending cross-machine write from `seq` to a fresh relay seq for the
@@ -1773,10 +1783,18 @@ fn rekey_cross_write_to_relay(
     seq: u64,
     effective_seq: &std::sync::atomic::AtomicU64,
 ) -> Option<u64> {
-    let tx = CROSS_WRITE_PENDING
+    // Remove, re-key and store under a *single* pending-map guard. Releasing
+    // it between the remove and the insert would leave the entry in no map at
+    // all, so a concurrent `drain_cross_write_pending` walks past it and the
+    // re-insert then outlives `finish_dataflow` — the node stays blocked until
+    // the 120s safety net and the entry leaks past the dataflow it belongs to.
+    // The counter bump nests `CROSS_WRITE_SEQ` inside this guard; that is the
+    // only nesting of the two (every other site drops the seq lock before
+    // touching the pending map), so the order cannot deadlock.
+    let mut pending = CROSS_WRITE_PENDING
         .lock()
-        .unwrap_or_else(|e| e.into_inner())
-        .remove(&(dataflow_id, shared_memory_id.to_string(), seq))?;
+        .unwrap_or_else(|e| e.into_inner());
+    let tx = pending.remove(&(dataflow_id, shared_memory_id.to_string(), seq))?;
     let relay_seq = {
         let mut seqs = CROSS_WRITE_SEQ.lock().unwrap_or_else(|e| e.into_inner());
         let counter = seqs
@@ -1785,10 +1803,9 @@ fn rekey_cross_write_to_relay(
         *counter += 1;
         *counter
     };
-    CROSS_WRITE_PENDING
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
-        .insert((dataflow_id, shared_memory_id.to_string(), relay_seq), tx);
+    pending.insert((dataflow_id, shared_memory_id.to_string(), relay_seq), tx);
+    // Still under the guard: `fire_cross_write_timeout` loads this while
+    // holding the same lock, so it can never observe a stale seq (#3193).
     effective_seq.store(relay_seq, std::sync::atomic::Ordering::SeqCst);
     Some(relay_seq)
 }
@@ -7013,14 +7030,14 @@ impl Daemon {
                     }
                 });
                 // Safety net: if the ack never arrives (peer restart,
-                // lost ack), fail the write rather than hang the node. Read
-                // the effective seq *after* sleeping so the removal follows
-                // any direct-TCP → relay re-key that happened meanwhile
-                // (#3193).
+                // lost ack), fail the write rather than hang the node.
+                // `fire_cross_write_timeout` reads the effective seq itself,
+                // under the pending-map guard, so the removal follows any
+                // direct-TCP → relay re-key that happened meanwhile — including
+                // one that lands while this task is waking up (#3193).
                 tokio::spawn(async move {
                     tokio::time::sleep(CROSS_WRITE_ACK_TIMEOUT).await;
-                    let seq = timeout_seq.load(std::sync::atomic::Ordering::SeqCst);
-                    fire_cross_write_timeout(dataflow_id, timeout_pool, seq);
+                    fire_cross_write_timeout(dataflow_id, &timeout_pool, &timeout_seq);
                 });
             }
             DaemonNodeEvent::RegisterCrossMachinePool {
@@ -8137,15 +8154,31 @@ impl Daemon {
                 .unwrap_or_else(|e| e.into_inner());
             locks.retain(|(df, _), _| *df != dataflow_id);
         }
-        {
-            let mut seqs = CROSS_WRITE_SEQ.lock().unwrap_or_else(|e| e.into_inner());
-            seqs.retain(|(df, _), _| *df != dataflow_id);
-        }
         // Fail any cross-machine write replies still pending for this
         // dataflow. Without it a node whose write was in flight at finish
         // hangs until the 120s safety-net timeout, and a relay entry orphaned
         // by a failover (#3193) would leak for the daemon's lifetime.
-        drain_cross_write_pending(dataflow_id);
+        //
+        // Must run *before* the `CROSS_WRITE_SEQ` retain below: a spawned
+        // write task that fails over concurrently re-keys under the pending
+        // guard, and it bumps the per-pool counter only if it found something
+        // pending. Draining first therefore makes the re-key a no-op instead
+        // of letting it resurrect a counter this function has already cleared
+        // — a resurrected counter restarts at 0, mints a relay seq *below* the
+        // abandoned one (breaking the monotonicity the write path relies on)
+        // and leaks for the daemon's lifetime, since finish runs once.
+        let stranded = drain_cross_write_pending(dataflow_id);
+        if stranded > 0 {
+            tracing::debug!(
+                %dataflow_id,
+                stranded,
+                "failed cross-machine writes still pending at dataflow finish"
+            );
+        }
+        {
+            let mut seqs = CROSS_WRITE_SEQ.lock().unwrap_or_else(|e| e.into_inner());
+            seqs.retain(|(df, _), _| *df != dataflow_id);
+        }
         {
             let mut degraded = CROSS_DIRECT_DEGRADED
                 .lock()
@@ -10013,25 +10046,12 @@ mod cross_write_failover_tests {
             .unwrap_or_else(|e| e.into_inner())
             .insert((df, pool.clone(), seq), tx);
 
-        // Rekey (mirrors the direct-failure arm): remove the old seq,
-        // bump the per-pool counter, re-insert under the fresh seq. The
-        // counter is what guarantees relay_seq != seq (the seq always
-        // derives from it).
-        let tx = CROSS_WRITE_PENDING
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .remove(&(df, pool.clone(), seq))
+        // Rekey via the production helper the direct-failure arm calls, so
+        // this asserts against the real path rather than a copy of it.
+        let effective_seq = std::sync::atomic::AtomicU64::new(seq);
+        let relay_seq = rekey_cross_write_to_relay(df, &pool, seq, &effective_seq)
             .expect("pending entry present");
-        let mut seqs = CROSS_WRITE_SEQ.lock().unwrap_or_else(|e| e.into_inner());
-        let counter = seqs.entry((df, pool.clone())).or_insert(0);
-        *counter += 1;
-        let relay_seq = *counter;
-        drop(seqs);
         assert_ne!(relay_seq, seq, "rekey must produce a fresh seq");
-        CROSS_WRITE_PENDING
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .insert((df, pool.clone(), relay_seq), tx);
 
         // The stale direct-plane ok:false arrives first: no pending entry
         // under the old seq, so it is dropped without touching the node.
@@ -10097,18 +10117,20 @@ mod cross_write_failover_tests {
             "re-key must advance the effective seq the timeout follows"
         );
 
-        // Timing out on the pre-failover seq is now a no-op (the entry moved).
-        assert!(!fire_cross_write_timeout(df, pool.clone(), seq));
+        // A timeout still keyed to the pre-failover seq is a no-op: the entry
+        // moved. This is the #3193 regression, reproduced by handing the
+        // helper an atomic frozen at the stale seq.
+        let stale_seq = std::sync::atomic::AtomicU64::new(seq);
+        assert!(!fire_cross_write_timeout(df, &pool, &stale_seq));
         assert!(
             rx.try_recv().is_err(),
             "write must still be pending after a timeout keyed to the stale seq"
         );
 
-        // The safety-net timeout task keys off the atomic; reading it and
-        // firing resolves the re-keyed entry, failing the node's write cleanly
-        // instead of hanging.
-        let timeout_seq = effective_seq.load(std::sync::atomic::Ordering::SeqCst);
-        assert!(fire_cross_write_timeout(df, pool.clone(), timeout_seq));
+        // The real safety net passes the shared atomic the re-key advanced —
+        // the helper loads it under the pending guard — so it resolves the
+        // re-keyed entry and fails the node's write cleanly instead of hanging.
+        assert!(fire_cross_write_timeout(df, &pool, &effective_seq));
         assert!(
             matches!(rx.try_recv(), Ok(DaemonReply::Result(Err(_)))),
             "the timeout keyed to the effective seq must fail the node's write"

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1757,6 +1757,42 @@ fn fire_cross_write_timeout(dataflow_id: Uuid, shared_memory_id: String, seq: u6
     }
 }
 
+/// Re-key a pending cross-machine write from `seq` to a fresh relay seq for the
+/// zenoh fallback hop, advancing `effective_seq` to match. Returns the new
+/// relay seq, or `None` if nothing was pending under `seq` (already resolved).
+///
+/// The re-key drops the stale direct-plane `ok:false` (published the instant a
+/// mid-frame direct read fails) via the first-wins resolver, and keeps the
+/// per-pool counter monotonic so the next write cannot collide with the
+/// re-keyed seq. Advancing `effective_seq` is the crucial half: the safety-net
+/// timeout task reads it, so a relay ack lost after the re-key is still
+/// reclaimed rather than hanging the node forever (#3193).
+fn rekey_cross_write_to_relay(
+    dataflow_id: Uuid,
+    shared_memory_id: &str,
+    seq: u64,
+    effective_seq: &std::sync::atomic::AtomicU64,
+) -> Option<u64> {
+    let tx = CROSS_WRITE_PENDING
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .remove(&(dataflow_id, shared_memory_id.to_string(), seq))?;
+    let relay_seq = {
+        let mut seqs = CROSS_WRITE_SEQ.lock().unwrap_or_else(|e| e.into_inner());
+        let counter = seqs
+            .entry((dataflow_id, shared_memory_id.to_string()))
+            .or_insert(0);
+        *counter += 1;
+        *counter
+    };
+    CROSS_WRITE_PENDING
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert((dataflow_id, shared_memory_id.to_string(), relay_seq), tx);
+    effective_seq.store(relay_seq, std::sync::atomic::Ordering::SeqCst);
+    Some(relay_seq)
+}
+
 /// Fail and drop every cross-machine write reply still pending for
 /// `dataflow_id`, unblocking any node stuck in `WritePinnedMemory`. Returns the
 /// number of stranded writes reclaimed.
@@ -6930,35 +6966,18 @@ impl Daemon {
                                 // byte-for-byte. Re-key the pending entry to
                                 // a fresh seq for the relay hop so the stale
                                 // ok:false is dropped by the first-wins
-                                // resolver, and keep the per-pool counter
-                                // monotonic so the next write cannot
-                                // collide with this re-keyed seq (bot
-                                // review 5307022693).
-                                let rekeyed = CROSS_WRITE_PENDING
-                                    .lock()
-                                    .unwrap_or_else(|e| e.into_inner())
-                                    .remove(&(dataflow_id, shared_memory_id.clone(), seq));
-                                if let Some(tx) = rekeyed {
-                                    let mut seqs =
-                                        CROSS_WRITE_SEQ.lock().unwrap_or_else(|e| e.into_inner());
-                                    let counter = seqs
-                                        .entry((dataflow_id, shared_memory_id.clone()))
-                                        .or_insert(0);
-                                    *counter += 1;
-                                    relay_seq = *counter;
-                                    drop(seqs);
-                                    CROSS_WRITE_PENDING
-                                        .lock()
-                                        .unwrap_or_else(|e| e.into_inner())
-                                        .insert(
-                                            (dataflow_id, shared_memory_id.clone(), relay_seq),
-                                            tx,
-                                        );
-                                    // Point the safety-net timeout at the
-                                    // re-keyed entry so it can still reclaim
-                                    // it if the relay ack is lost (#3193).
-                                    effective_seq
-                                        .store(relay_seq, std::sync::atomic::Ordering::SeqCst);
+                                // resolver, keep the per-pool counter
+                                // monotonic so the next write cannot collide
+                                // with this re-keyed seq (bot review
+                                // 5307022693), and advance `effective_seq`
+                                // so the safety-net timeout follows it (#3193).
+                                if let Some(new_seq) = rekey_cross_write_to_relay(
+                                    dataflow_id,
+                                    &shared_memory_id,
+                                    seq,
+                                    &effective_seq,
+                                ) {
+                                    relay_seq = new_seq;
                                 }
                             }
                         }
@@ -9964,7 +9983,7 @@ mod cross_mirror_descriptor_tests {
 mod cross_write_failover_tests {
     use super::{
         CROSS_WRITE_PENDING, CROSS_WRITE_SEQ, drain_cross_write_pending, fire_cross_write_timeout,
-        resolve_cross_write_ack,
+        rekey_cross_write_to_relay, resolve_cross_write_ack,
     };
     use dora_message::DataflowId;
     use dora_message::daemon_to_node::DaemonReply;
@@ -10040,42 +10059,56 @@ mod cross_write_failover_tests {
     }
 
     #[test]
-    fn safety_net_timeout_follows_the_relay_rekey() {
-        // #3193: after a direct-TCP → zenoh failover re-keys the pending
-        // entry from `seq` to `relay_seq`, the safety-net timeout must fire
-        // against `relay_seq`. Keyed to the pre-failover `seq` (as it was),
-        // the timeout is a silent no-op and the node's write hangs forever.
+    fn rekey_advances_effective_seq_so_the_timeout_follows_it() {
+        // #3193: drives the production re-key path (`rekey_cross_write_to_relay`,
+        // the direct-TCP → zenoh failover arm) and pins the actual fix — that
+        // it advances the shared `effective_seq` the safety-net timeout reads.
+        // Deleting the `effective_seq.store(relay_seq)` inside the helper makes
+        // the `effective_seq` assertion below fail, and the timeout then reads
+        // the stale seq (a no-op) so the final resolve fails too — i.e. this
+        // test fails exactly when the write would hang forever.
         let df = DataflowId::new_v4();
-        let pool = "pool_timeout_follows_rekey".to_string();
+        let pool = "pool_rekey_atomic".to_string();
         let (tx, mut rx) = tokio::sync::oneshot::channel();
 
-        // Insert under the original seq, then re-key to a fresh relay seq
-        // (mirrors the direct-failure arm of the WriteMemoryPool handler).
+        // Allocate the seq exactly as the handler does (counter 0 -> 1) and
+        // insert the pending reply under it.
+        let seq = {
+            let mut seqs = CROSS_WRITE_SEQ.lock().unwrap_or_else(|e| e.into_inner());
+            let counter = seqs.entry((df, pool.clone())).or_insert(0);
+            *counter += 1;
+            *counter
+        };
         CROSS_WRITE_PENDING
             .lock()
             .unwrap_or_else(|e| e.into_inner())
-            .insert((df, pool.clone(), 1), tx);
-        let tx = CROSS_WRITE_PENDING
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .remove(&(df, pool.clone(), 1))
-            .expect("pending entry present");
-        CROSS_WRITE_PENDING
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .insert((df, pool.clone(), 2), tx);
+            .insert((df, pool.clone(), seq), tx);
+        let effective_seq = std::sync::atomic::AtomicU64::new(seq);
 
-        // Timing out on the pre-failover seq is the bug: a no-op that leaves
-        // the write pending.
-        assert!(!fire_cross_write_timeout(df, pool.clone(), 1));
+        // Run the real re-key the handler runs on a direct-send failure.
+        let relay_seq = rekey_cross_write_to_relay(df, &pool, seq, &effective_seq)
+            .expect("a pending entry under the original seq");
+        assert_ne!(relay_seq, seq, "re-key must allocate a fresh monotonic seq");
+        // The crux of the fix: the atomic the timeout task reads was advanced
+        // to the re-keyed seq.
+        assert_eq!(
+            effective_seq.load(std::sync::atomic::Ordering::SeqCst),
+            relay_seq,
+            "re-key must advance the effective seq the timeout follows"
+        );
+
+        // Timing out on the pre-failover seq is now a no-op (the entry moved).
+        assert!(!fire_cross_write_timeout(df, pool.clone(), seq));
         assert!(
             rx.try_recv().is_err(),
             "write must still be pending after a timeout keyed to the stale seq"
         );
 
-        // The effective (relay) seq resolves it: the node's write fails
-        // cleanly instead of hanging.
-        assert!(fire_cross_write_timeout(df, pool.clone(), 2));
+        // The safety-net timeout task keys off the atomic; reading it and
+        // firing resolves the re-keyed entry, failing the node's write cleanly
+        // instead of hanging.
+        let timeout_seq = effective_seq.load(std::sync::atomic::Ordering::SeqCst);
+        assert!(fire_cross_write_timeout(df, pool.clone(), timeout_seq));
         assert!(
             matches!(rx.try_recv(), Ok(DaemonReply::Result(Err(_)))),
             "the timeout keyed to the effective seq must fail the node's write"

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1825,13 +1825,11 @@ fn drain_cross_write_pending(dataflow_id: Uuid) -> usize {
         let mut pending = CROSS_WRITE_PENDING
             .lock()
             .unwrap_or_else(|e| e.into_inner());
-        let keys: Vec<(Uuid, String, u64)> = pending
-            .keys()
-            .filter(|(df, _, _)| *df == dataflow_id)
-            .cloned()
-            .collect();
-        keys.into_iter()
-            .filter_map(|k| pending.remove(&k))
+        // One pass, no key clones: the previous scan-clone-then-remove shape
+        // allocated a `String` per match just to look each entry back up.
+        pending
+            .extract_if(|(df, _, _), _| *df == dataflow_id)
+            .map(|(_, tx)| tx)
             .collect()
     };
     let count = stranded.len();
@@ -6988,13 +6986,25 @@ impl Daemon {
                                 // with this re-keyed seq (bot review
                                 // 5307022693), and advance `effective_seq`
                                 // so the safety-net timeout follows it (#3193).
-                                if let Some(new_seq) = rekey_cross_write_to_relay(
+                                match rekey_cross_write_to_relay(
                                     dataflow_id,
                                     &shared_memory_id,
                                     seq,
                                     &effective_seq,
                                 ) {
-                                    relay_seq = new_seq;
+                                    Some(new_seq) => relay_seq = new_seq,
+                                    // Nothing was pending under `seq`, so this
+                                    // write is already resolved: the mirror's
+                                    // stale ok:false won the race, the safety
+                                    // net fired, or `finish_dataflow` drained
+                                    // it. Falling through would publish the
+                                    // whole payload to the mirror anyway — it
+                                    // would memcpy the frame and advance the
+                                    // seqlock, so a receiver there reads as
+                                    // "stable" a frame this daemon already told
+                                    // the sender had failed, and a full-size WAN
+                                    // transfer burns with nobody awaiting it.
+                                    None => return,
                                 }
                             }
                         }

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1734,6 +1734,62 @@ fn resolve_cross_write_ack(
     }
 }
 
+/// Fire the safety-net timeout for a pending cross-machine write: remove the
+/// entry under `seq` and fail the node's blocked `WritePinnedMemory`. Returns
+/// whether an entry existed.
+///
+/// The caller passes the write's *effective* seq — the one the entry is live
+/// under now, which advances from the original `seq` to a fresh `relay_seq` on
+/// a direct-TCP → zenoh failover. Keying the timeout to the pre-failover seq
+/// makes it a no-op after a re-key, leaving the write hung forever (#3193).
+fn fire_cross_write_timeout(dataflow_id: Uuid, shared_memory_id: String, seq: u64) -> bool {
+    if let Some(tx) = CROSS_WRITE_PENDING
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .remove(&(dataflow_id, shared_memory_id, seq))
+    {
+        let _ = tx.send(DaemonReply::Result(Err(
+            "cross-machine write timed out waiting for the remote commit ack".to_string(),
+        )));
+        true
+    } else {
+        false
+    }
+}
+
+/// Fail and drop every cross-machine write reply still pending for
+/// `dataflow_id`, unblocking any node stuck in `WritePinnedMemory`. Returns the
+/// number of stranded writes reclaimed.
+///
+/// Called from `finish_dataflow`: the per-write safety-net timeout normally
+/// reclaims these, but a dataflow that finishes first (node crash, `dora stop`,
+/// or a relay entry orphaned by a failover) would otherwise leave the entry —
+/// and the node's blocked write — hanging until that timeout, and leak the
+/// entry for the daemon's lifetime if the reply channel is already gone (#3193).
+/// Mirrors how the sibling cross-write maps are already drained here.
+fn drain_cross_write_pending(dataflow_id: Uuid) -> usize {
+    let stranded: Vec<_> = {
+        let mut pending = CROSS_WRITE_PENDING
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let keys: Vec<(Uuid, String, u64)> = pending
+            .keys()
+            .filter(|(df, _, _)| *df == dataflow_id)
+            .cloned()
+            .collect();
+        keys.into_iter()
+            .filter_map(|k| pending.remove(&k))
+            .collect()
+    };
+    let count = stranded.len();
+    for tx in stranded {
+        let _ = tx.send(DaemonReply::Result(Err(
+            "dataflow finished before the cross-machine write was acknowledged".to_string(),
+        )));
+    }
+    count
+}
+
 /// Size of the daemon's zenoh SHM provider segment. Memory-pool control
 /// notifications (RegisterPool/RegisterPoolAck/FreePool) are KB-scale,
 /// so a small segment carries all in-flight control traffic with headroom;
@@ -6767,7 +6823,16 @@ impl Daemon {
                     .lock()
                     .unwrap_or_else(|e| e.into_inner())
                     .insert((dataflow_id, shared_memory_id.clone(), seq), reply_sender);
-                let pending_key = (dataflow_id, shared_memory_id.clone(), seq);
+                // The seq the pending entry is live under. Starts at `seq`;
+                // a direct-TCP → zenoh failover re-keys the entry to a fresh
+                // `relay_seq` below and advances this to match, so the
+                // safety-net timeout removes the entry under whatever seq is
+                // actually live. Keying the timeout to the pre-failover seq
+                // (as it did) makes it a no-op after a re-key, leaving the
+                // node's write blocked forever (#3193).
+                let effective_seq = Arc::new(std::sync::atomic::AtomicU64::new(seq));
+                let timeout_seq = effective_seq.clone();
+                let timeout_pool = shared_memory_id.clone();
                 // Direct-TCP data plane: when the register ack reported a
                 // data listener, writes bypass the zenoh relay entirely —
                 // one user-space copy on this side (segment → send
@@ -6889,6 +6954,11 @@ impl Daemon {
                                             (dataflow_id, shared_memory_id.clone(), relay_seq),
                                             tx,
                                         );
+                                    // Point the safety-net timeout at the
+                                    // re-keyed entry so it can still reclaim
+                                    // it if the relay ack is lost (#3193).
+                                    effective_seq
+                                        .store(relay_seq, std::sync::atomic::Ordering::SeqCst);
                                 }
                             }
                         }
@@ -6924,19 +6994,14 @@ impl Daemon {
                     }
                 });
                 // Safety net: if the ack never arrives (peer restart,
-                // lost ack), fail the write rather than hang the node.
+                // lost ack), fail the write rather than hang the node. Read
+                // the effective seq *after* sleeping so the removal follows
+                // any direct-TCP → relay re-key that happened meanwhile
+                // (#3193).
                 tokio::spawn(async move {
                     tokio::time::sleep(CROSS_WRITE_ACK_TIMEOUT).await;
-                    if let Some(tx) = CROSS_WRITE_PENDING
-                        .lock()
-                        .unwrap_or_else(|e| e.into_inner())
-                        .remove(&pending_key)
-                    {
-                        let _ = tx.send(DaemonReply::Result(Err(
-                            "cross-machine write timed out waiting for the remote commit ack"
-                                .to_string(),
-                        )));
-                    }
+                    let seq = timeout_seq.load(std::sync::atomic::Ordering::SeqCst);
+                    fire_cross_write_timeout(dataflow_id, timeout_pool, seq);
                 });
             }
             DaemonNodeEvent::RegisterCrossMachinePool {
@@ -8057,6 +8122,11 @@ impl Daemon {
             let mut seqs = CROSS_WRITE_SEQ.lock().unwrap_or_else(|e| e.into_inner());
             seqs.retain(|(df, _), _| *df != dataflow_id);
         }
+        // Fail any cross-machine write replies still pending for this
+        // dataflow. Without it a node whose write was in flight at finish
+        // hangs until the 120s safety-net timeout, and a relay entry orphaned
+        // by a failover (#3193) would leak for the daemon's lifetime.
+        drain_cross_write_pending(dataflow_id);
         {
             let mut degraded = CROSS_DIRECT_DEGRADED
                 .lock()
@@ -9892,7 +9962,10 @@ mod cross_mirror_descriptor_tests {
 
 #[cfg(test)]
 mod cross_write_failover_tests {
-    use super::{CROSS_WRITE_PENDING, CROSS_WRITE_SEQ, resolve_cross_write_ack};
+    use super::{
+        CROSS_WRITE_PENDING, CROSS_WRITE_SEQ, drain_cross_write_pending, fire_cross_write_timeout,
+        resolve_cross_write_ack,
+    };
     use dora_message::DataflowId;
     use dora_message::daemon_to_node::DaemonReply;
 
@@ -9964,6 +10037,83 @@ mod cross_write_failover_tests {
             matches!(result, DaemonReply::Result(Ok(()))),
             "node must see the relay's success, not the stale direct failure"
         );
+    }
+
+    #[test]
+    fn safety_net_timeout_follows_the_relay_rekey() {
+        // #3193: after a direct-TCP → zenoh failover re-keys the pending
+        // entry from `seq` to `relay_seq`, the safety-net timeout must fire
+        // against `relay_seq`. Keyed to the pre-failover `seq` (as it was),
+        // the timeout is a silent no-op and the node's write hangs forever.
+        let df = DataflowId::new_v4();
+        let pool = "pool_timeout_follows_rekey".to_string();
+        let (tx, mut rx) = tokio::sync::oneshot::channel();
+
+        // Insert under the original seq, then re-key to a fresh relay seq
+        // (mirrors the direct-failure arm of the WriteMemoryPool handler).
+        CROSS_WRITE_PENDING
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert((df, pool.clone(), 1), tx);
+        let tx = CROSS_WRITE_PENDING
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&(df, pool.clone(), 1))
+            .expect("pending entry present");
+        CROSS_WRITE_PENDING
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert((df, pool.clone(), 2), tx);
+
+        // Timing out on the pre-failover seq is the bug: a no-op that leaves
+        // the write pending.
+        assert!(!fire_cross_write_timeout(df, pool.clone(), 1));
+        assert!(
+            rx.try_recv().is_err(),
+            "write must still be pending after a timeout keyed to the stale seq"
+        );
+
+        // The effective (relay) seq resolves it: the node's write fails
+        // cleanly instead of hanging.
+        assert!(fire_cross_write_timeout(df, pool.clone(), 2));
+        assert!(
+            matches!(rx.try_recv(), Ok(DaemonReply::Result(Err(_)))),
+            "the timeout keyed to the effective seq must fail the node's write"
+        );
+    }
+
+    #[test]
+    fn finish_dataflow_drain_fails_pending_cross_writes() {
+        // #3193: a dataflow that finishes with a write still pending (node
+        // crash / stop, or a relay entry orphaned by failover) must have that
+        // entry reclaimed and the node unblocked, not left to leak. An
+        // unrelated dataflow's pending write must survive the drain.
+        let df = DataflowId::new_v4();
+        let other_df = DataflowId::new_v4();
+        let pool = "pool_finish_drain".to_string();
+        let (tx, mut rx) = tokio::sync::oneshot::channel();
+        let (other_tx, mut other_rx) = tokio::sync::oneshot::channel();
+
+        {
+            let mut pending = CROSS_WRITE_PENDING
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            pending.insert((df, pool.clone(), 7), tx);
+            pending.insert((other_df, pool.clone(), 7), other_tx);
+        }
+
+        assert_eq!(drain_cross_write_pending(df), 1);
+        assert!(
+            matches!(rx.try_recv(), Ok(DaemonReply::Result(Err(_)))),
+            "the finishing dataflow's pending write must be failed"
+        );
+        assert!(
+            other_rx.try_recv().is_err(),
+            "an unrelated dataflow's pending write must be untouched"
+        );
+
+        // Leave the shared static tidy for other tests.
+        drain_cross_write_pending(other_df);
     }
 
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Summary

Fixes #3193.

The cross-machine memory-pool write (added in #3079, commit `c1b225e`) withholds a node's `WritePinnedMemory` reply until the mirror daemon's `MemoryPoolWriteAck` arrives, with a 120s safety-net timeout that fails the write if the ack never comes. On a direct-TCP → zenoh failover the pending entry is re-keyed from the original `seq` to a fresh `relay_seq` (deliberate — it drops the stale `ok:false` via first-wins), but the timeout task captured the **original** `seq`.

After a re-key, the timeout's `remove(&pending_key)` targets a key that is already gone — a silent no-op — so a lost relay ack (peer restart, dropped zenoh sample) leaves the node's write blocked **forever** and leaks the `CROSS_WRITE_PENDING` entry for the daemon's lifetime. The safety net is defeated in exactly the failover case it was written to protect.

## Failure scenario

1. A cross-machine pool has a direct-TCP data endpoint (steady state).
2. The direct send fails mid-frame (flaky WAN); the handler re-keys the pending entry from `seq` to `relay_seq` and falls back to the zenoh relay.
3. The relay `MemoryPoolWrite` publish **succeeds** (so the publish-error path doesn't fire).
4. The relay's `MemoryPoolWriteAck` never arrives.
5. The safety net fires and removes `(df, pool, seq)` — already gone since step 2 — so it's a no-op. The `relay_seq` entry is never removed → hang + leak.

## Fix

- Share the write's **effective seq** between the write task and the timeout task via an `AtomicU64`. The write task advances it to `relay_seq` when it re-keys; the timeout task reads it *after* sleeping and removes the entry under whatever seq is actually live. The removal is extracted into `fire_cross_write_timeout`.
- Drain `CROSS_WRITE_PENDING` in `finish_dataflow` (via `drain_cross_write_pending`), matching how the sibling cross-write maps (`CROSS_WRITE_SEQ`, `CROSS_POOL_WRITE_LOCKS`, `CROSS_DIRECT_DEGRADED`, `cross_data_endpoints`) are already reclaimed there. A dataflow that finishes with a write still pending (node crash, `dora stop`, or a relay entry orphaned by failover) now unblocks the node immediately instead of waiting out the 120s timeout, and cannot leak the entry for the daemon's lifetime.

The first fully fixes the hang; the second bounds the blast radius and closes the `finish_dataflow` gap the issue calls out.

## Testing

Adds two regression tests to `cross_write_failover_tests`:
- `safety_net_timeout_follows_the_relay_rekey` — after a re-key, timing out on the stale seq is a no-op (leaves the write pending); timing out on the effective seq fails the node's write cleanly.
- `finish_dataflow_drain_fails_pending_cross_writes` — the drain fails a finishing dataflow's pending write while leaving an unrelated dataflow's untouched.

```
cargo test -p dora-daemon cross_write   # 4 passed
cargo clippy -p dora-daemon -- -D warnings   # clean
cargo fmt --all -- --check   # clean
```

A full multi-daemon e2e reproduction (real coordinator + two daemons + a mid-frame direct disconnect) is out of scope for this unit-level fix; the tests exercise the seq-keying logic directly against the shared pending map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016ZpoxgBdXvxZDwTN2bAu36)_