### PR TITLE
fix(ci): repair the two nightly regressions from the 2026-08-13 batch (#3150)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1792,6 +1792,7 @@ jobs:
           --exclude dora-ros2-bridge-python
           --exclude dora-runtime-python
           --exclude dora-cli-api-python
+          --exclude dora-tensor-pool-python
       - name: Check (cross)
         if: matrix.cross
         run: >
@@ -1801,6 +1802,7 @@ jobs:
           --exclude dora-ros2-bridge-python
           --exclude dora-runtime-python
           --exclude dora-cli-api-python
+          --exclude dora-tensor-pool-python
 
   # ===== ROS2 bridge basic checks =====
   # Keep nightly coverage for ROS2 bridge code that does not require a full ROS

--- a/examples/rust-dataflow-git/dataflow.yml
+++ b/examples/rust-dataflow-git/dataflow.yml
@@ -4,15 +4,16 @@
 # change lands on main — otherwise the CI job catches the mismatch and
 # signals a compatibility break, which is the whole point of this test.
 #
-# Currently pinned past #2774, which added a `metadata_version` field to
-# `NodeRegisterRequest` to reject metadata-format skew at registration. The
-# previous pin (07ed3be, from #2745) predated that, so its nodes failed to
-# register against a current daemon with `unexpected end of file` (#2742).
-# (#2745 had likewise moved the pin past #2366's payload-format v1 break.)
+# Currently pinned past #3153, which replaced bincode with postcard on the
+# node<->daemon wire. The previous pin (c9a3699, from #2779) predated that, so
+# its bincode-framed nodes failed to register against a postcard daemon with
+# `Serde Deserialization Error` / `server disconnected unexpectedly` (#3150).
+# (Earlier bumps moved the pin past #2774's `metadata_version` field and
+# #2366's payload-format v1 break — both caught the same way, see #2742.)
 nodes:
   - id: rust-node
     git: https://github.com/dora-rs/dora.git
-    rev: c9a3699209f6bb771952e365df044788d1347626
+    rev: c1b225ea94cf140cb033cf636d849f9e9fd8fada
     build: cargo build -p rust-dataflow-example-node
     path: target/debug/rust-dataflow-example-node
     inputs:
@@ -22,7 +23,7 @@ nodes:
 
   - id: rust-status-node
     git: https://github.com/dora-rs/dora.git
-    rev: c9a3699209f6bb771952e365df044788d1347626
+    rev: c1b225ea94cf140cb033cf636d849f9e9fd8fada
     build: cargo build -p rust-dataflow-example-status-node
     path: target/debug/rust-dataflow-example-status-node
     inputs:
@@ -33,7 +34,7 @@ nodes:
 
   - id: rust-sink
     git: https://github.com/dora-rs/dora.git
-    rev: c9a3699209f6bb771952e365df044788d1347626
+    rev: c1b225ea94cf140cb033cf636d849f9e9fd8fada
     build: cargo build -p rust-dataflow-example-sink
     path: target/debug/rust-dataflow-example-sink
     inputs:

--- a/scripts/qa/ci-nightly-jobs.sh
+++ b/scripts/qa/ci-nightly-jobs.sh
@@ -1961,33 +1961,43 @@ job_kani_proofs() {
 # toolchains that aren't always present locally. CI does the full matrix.
 # -----------------------------------------------------------------------------
 job_cross_check() {
+  # Each `cargo check` below is prefixed with the GHA job-level
+  # `PYO3_NO_PYTHON: "1"` (kept per-command so it doesn't leak into the jobs
+  # that run after this one). Without it a local run resolves the host
+  # interpreter and passes even when CI cannot, which is exactly how the
+  # `dora-tensor-pool-python` breakage (#3150) reached nightly: every
+  # pyo3-linking crate must be excluded here, and only the no-interpreter
+  # build proves it.
   case "$OS" in
     Linux)
-      cargo check --target x86_64-unknown-linux-gnu --all \
+      PYO3_NO_PYTHON=1 cargo check --target x86_64-unknown-linux-gnu --all \
         --exclude dora-node-api-python \
         --exclude dora-operator-api-python \
         --exclude dora-ros2-bridge-python \
         --exclude dora-runtime-python \
-        --exclude dora-cli-api-python
+        --exclude dora-cli-api-python \
+        --exclude dora-tensor-pool-python
       ;;
     Darwin)
       # uname -m is arm64 on Apple Silicon, x86_64 on Intel.
       local arch
       arch="$(uname -m)"
       if [ "$arch" = "arm64" ]; then
-        cargo check --target aarch64-apple-darwin --all \
+        PYO3_NO_PYTHON=1 cargo check --target aarch64-apple-darwin --all \
           --exclude dora-node-api-python \
           --exclude dora-operator-api-python \
           --exclude dora-ros2-bridge-python \
           --exclude dora-runtime-python \
-          --exclude dora-cli-api-python
+          --exclude dora-cli-api-python \
+          --exclude dora-tensor-pool-python
       else
-        cargo check --target x86_64-apple-darwin --all \
+        PYO3_NO_PYTHON=1 cargo check --target x86_64-apple-darwin --all \
           --exclude dora-node-api-python \
           --exclude dora-operator-api-python \
           --exclude dora-ros2-bridge-python \
           --exclude dora-runtime-python \
-          --exclude dora-cli-api-python
+          --exclude dora-cli-api-python \
+          --exclude dora-tensor-pool-python
       fi
       ;;
     *)


### PR DESCRIPTION
Fixes the two nightly regressions tracked in #3150 (both started with the 2026-08-13 batch, both reproduce deterministically on Linux).

**`examples` (all 3 platforms)** — `rust-dataflow-git` pins `rev: c9a3699` (2026-07-20), which predates #3153's bincode→postcard switch on the node↔daemon wire. The pinned nodes fail at registration with `Serde Deserialization Error` / `server disconnected unexpectedly`. That is the break this example is designed to catch, so the fix is the pin bump — to `c1b225ea` (current main).

**`cross-check` (linux-gnu + both darwin targets)** — #3152 added `dora-tensor-pool-python`, which links pyo3 but was not added to the job's python-crate exclude list. The job builds with `PYO3_NO_PYTHON=1`, so pyo3-ffi's build script fails with *"attempted to link to Python shared library but config does not contain lib_name"*. Not a macOS runner problem — it reproduces on `x86_64-unknown-linux-gnu`.

The local driver `scripts/qa/ci-nightly-jobs.sh cross-check` did not set `PYO3_NO_PYTHON`, so it found the host interpreter and passed where CI could not; it now mirrors the GHA job env (per-command, so it doesn't leak into later jobs).

Verified locally: `cargo run --example rust-dataflow-git` runs to completion and self-terminates in ~2s; `scripts/qa/ci-nightly-jobs.sh cross-check` passes with the new exclude and fails without it.

The remaining `ROS2 Zenoh Interop (Humble)` failure on the same issue predates this batch (failing since at least 2026-08-11) and is untouched here.
