### PR TITLE
fix(telemetry): set service.name to the node id on OTLP traces and metrics

### DIFF
--- a/libraries/extensions/telemetry/tracing/src/lib.rs
+++ b/libraries/extensions/telemetry/tracing/src/lib.rs
@@ -181,7 +181,7 @@ impl TracingBuilder {
         // Initialize OTLP tracing - this returns a tracer and sets the global provider
         let sdk_tracer_provider = crate::telemetry::init_tracing(&self.name, &endpoint)
             .wrap_err("failed to initialize OTLP tracing exporter")?;
-        let meter_provider = metrics::init_meter_provider(&endpoint)
+        let meter_provider = metrics::init_meter_provider(&self.name, &endpoint)
             .wrap_err("failed to initialize OTLP metrics exporter")?;
 
         // TODO: Maybe this needs to be removed in favor of application level global.

--- a/libraries/extensions/telemetry/tracing/src/metrics.rs
+++ b/libraries/extensions/telemetry/tracing/src/metrics.rs
@@ -11,7 +11,7 @@ use opentelemetry_sdk::metrics::SdkMeterProvider;
 /// where the metric exporter ignored `DORA_OTLP_ENDPOINT` and always fell back
 /// to the OTLP gRPC default (`http://localhost:4317`), silently diverging from
 /// the trace exporter when a remote collector was configured.
-pub fn init_meter_provider(endpoint: &str) -> eyre::Result<SdkMeterProvider> {
+pub fn init_meter_provider(name: &str, endpoint: &str) -> eyre::Result<SdkMeterProvider> {
     let exporter = MetricExporter::builder()
         .with_tonic()
         .with_endpoint(endpoint)
@@ -19,6 +19,7 @@ pub fn init_meter_provider(endpoint: &str) -> eyre::Result<SdkMeterProvider> {
         .wrap_err("failed to create metric exporter")?;
 
     Ok(SdkMeterProvider::builder()
+        .with_resource(crate::telemetry::service_resource(name))
         .with_periodic_exporter(exporter)
         .build())
 }

--- a/libraries/extensions/telemetry/tracing/src/telemetry.rs
+++ b/libraries/extensions/telemetry/tracing/src/telemetry.rs
@@ -40,7 +40,7 @@ impl Extractor for MetadataMap<'_> {
 /// docker run -d -p 4317:4317 -p 4318:4318 -p 16686:16686 jaegertracing/all-in-one:latest
 /// ```
 ///
-pub fn init_tracing(_name: &str, endpoint: &str) -> eyre::Result<sdktrace::SdkTracerProvider> {
+pub fn init_tracing(name: &str, endpoint: &str) -> eyre::Result<sdktrace::SdkTracerProvider> {
     let exporter = opentelemetry_otlp::SpanExporter::builder()
         .with_tonic()
         .with_endpoint(endpoint)
@@ -48,8 +48,18 @@ pub fn init_tracing(_name: &str, endpoint: &str) -> eyre::Result<sdktrace::SdkTr
         .wrap_err("failed to build OTLP span exporter")?;
 
     Ok(SdkTracerProvider::builder()
+        .with_resource(service_resource(name))
         .with_batch_exporter(exporter)
         .build())
+}
+
+/// Resource tagging every exported span with the dora service name (the node
+/// id). Without it OTel backends fall back to the SDK default
+/// `unknown_service:<binary>` and cannot attribute spans per node.
+pub(crate) fn service_resource(name: &str) -> opentelemetry_sdk::Resource {
+    opentelemetry_sdk::Resource::builder()
+        .with_service_name(name.to_string())
+        .build()
 }
 
 /// Separator between entries in the serialized trace context.
@@ -105,6 +115,19 @@ pub fn deserialize_to_hashmap(string_context: &str) -> HashMap<&str, &str> {
 
 #[cfg(test)]
 mod tests {
+    use super::service_resource;
+    use opentelemetry::Key;
+
+    #[test]
+    fn service_resource_sets_service_name() {
+        let resource = service_resource("planner_node");
+        let value = resource
+            .get(&Key::from_static_str("service.name"))
+            .expect("service.name is set")
+            .clone();
+        assert_eq!(value.as_str(), "planner_node");
+    }
+
     use super::{deserialize_context, deserialize_to_hashmap, serialize_context};
 
     #[test]


### PR DESCRIPTION
## Problem
init_tracing accepts a `name` argument (documented as "Service name
for the traces") but ignores it, so every dora node exports with the
OTel SDK default `unknown_service:<binary>`. Backends (Jaeger, Tempo,
Grafana, Studio) cannot attribute spans or metrics per node —
per-node flame graphs and service filtering are unusable.

## Fix
Attach a service.name resource to both the tracer and meter providers.
dora nodes already pass their node id as the name
(TracingBuilder::new(node_id)).

## Test plan
- cargo test -p dora-tracing: 8 unit + 1 doc tests pass
  (added service_resource_sets_service_name)
- Manual: run a dataflow with DORA_OTLP_ENDPOINT pointed at an OTLP
  backend; spans now carry the node id as service.name
