### PR TITLE
fix(core): don't warn on timer/log inputs during manifest injection

### DIFF
--- a/libraries/core/src/manifest/inject.rs
+++ b/libraries/core/src/manifest/inject.rs
@@ -16,7 +16,7 @@ use std::path::{Path, PathBuf};
 
 use crate::descriptor::normalize_path;
 
-use dora_message::{descriptor::Descriptor, id::NodeId};
+use dora_message::{config::InputMapping, descriptor::Descriptor, id::NodeId};
 
 use super::{
     MANIFEST_FILENAME, NodeManifest,
@@ -261,8 +261,15 @@ pub fn apply_manifest_contracts(
         return;
     }
 
-    // the dataflow's wiring must stay within the declared ports (spec §10.1)
-    for input in node.inputs.keys() {
+    // the dataflow's wiring must stay within the declared ports (spec §10.1).
+    // Only user data-port subscriptions are governed by the manifest; built-in
+    // `dora/timer/*` and `dora/logs/*` subscriptions are dataflow-level wiring,
+    // not node contract ports, so they must not be flagged as "not declared"
+    // (which is fatal under `strict_types`).
+    for (input, def) in &node.inputs {
+        if !matches!(def.mapping, InputMapping::User(_)) {
+            continue;
+        }
         if !manifest.inputs.contains_key(input.as_str()) {
             result.warnings.push(sanitize(&format!(
                 "node \"{}\": input `{input}` is not declared in {}",
@@ -446,6 +453,38 @@ nodes:
         assert!(all.contains("input `depth` is not declared"), "{all}");
         assert!(all.contains("output `points` is not declared"), "{all}");
         assert!(all.contains("required input `image` is not wired"), "{all}");
+    }
+
+    #[test]
+    fn timer_and_log_inputs_do_not_warn_as_undeclared() {
+        // A node commonly subscribes to a built-in timer/log stream alongside
+        // its manifest data ports. Those subscriptions are dataflow wiring, not
+        // node contract ports, so they must not be reported as "not declared"
+        // (which is fatal under `strict_types`).
+        let tmp = tempfile::tempdir().unwrap();
+        write_manifest(&tmp.path().join("yolo"), MANIFEST);
+        let mut df = dataflow(
+            r#"
+nodes:
+  - id: camera
+    path: cam
+    outputs: [image]
+  - id: detector
+    path: yolo/target/release/dora-yolo
+    inputs:
+      image: camera/image
+      tick: dora/timer/millis/100
+      logs: dora/logs
+    outputs: [bbox]
+"#,
+        );
+        let mut registry = TypeRegistry::new();
+        let result = inject_adjacent_manifests(&mut df, tmp.path(), &mut registry);
+        assert_eq!(
+            result.warnings,
+            Vec::<String>::new(),
+            "timer/log subscriptions must not be flagged as undeclared inputs"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`apply_manifest_contracts` (in `libraries/core/src/manifest/inject.rs`) checks every entry of `node.inputs` against a node manifest's declared ports and emits an `input `X` is not declared` warning for any that is missing. It iterated over **all** inputs, including built-in `dora/timer/*` and `dora/logs/*` subscriptions — which are dataflow-level wiring, not node contract ports, and are never listed in a `dora-node.yml` manifest.

As a result, any manifest-backed node that also subscribes to a timer or log stream — a very common pattern — produced a bogus warning:

```yaml
nodes:
  - id: detector
    path: yolo/target/release/dora-yolo   # has an adjacent dora-node.yml
    inputs:
      image: camera/image                 # declared data port
      tick: dora/timer/millis/100         # timer — NOT a manifest port
```

→ `node "detector": input `tick` is not declared in …/dora-node.yml`

Per `InjectionResult`'s own doc, these warnings are printed and **fatal under `strict_types`**. So a dataflow with `strict_types: true`, a manifest-backed node, and any timer/log input would **fail to build** on a non-existent contract violation.

## Fix

Only check `InputMapping::User` subscriptions against the manifest, skipping `Timer`/`Logs`. This mirrors how the analogous edge checker in `descriptor/validate.rs` already special-cases those variants, and matches the established `matches!(input.mapping, InputMapping::User(_))` idiom used across the daemon and core. Type injection itself is unaffected — it iterates `manifest.inputs`, not `node.inputs`.

## Validation

- Added a regression test (`timer_and_log_inputs_do_not_warn_as_undeclared`) with a node subscribing to both a timer and the log stream alongside a declared data port; asserts no warnings. Confirmed it fails before the fix (emits the two spurious warnings) and passes after.
- `cargo fmt -p dora-core -- --check`, `cargo clippy -p dora-core --all-targets -- -D warnings`, and the full `cargo test -p dora-core` suite (283 tests) pass locally on rustc 1.97.1.

---

⚠️ **This is a machine-generated pull request**, authored by Claude (Claude Code). It has been verified locally as described above but should receive human review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DY5kNaoUXqmLD3VYGLrSv4)_