### PR TITLE
fix(cli): reject a malformed DORA_COORDINATOR_ADDR/PORT in `dora up`

### DIFF
--- a/binaries/cli/src/command/up.rs
+++ b/binaries/cli/src/command/up.rs
@@ -47,16 +47,38 @@ impl Executable for Up {
 #[serde(deny_unknown_fields)]
 struct UpConfig {}
 
+/// Resolve the coordinator bind address from `DORA_COORDINATOR_ADDR`.
+///
+/// Unlike every other subcommand — which routes these env vars through clap's
+/// typed `value_parser` and hard-errors on a bad value — `dora up` reads them
+/// by hand. A malformed value must be a hard error too, otherwise `up` would
+/// silently bind the default endpoint while the very next `dora start`/`list`
+/// (parsed through clap) rejects the same env var, leaving the two halves of a
+/// workflow disagreeing about where the coordinator lives.
+fn coordinator_addr_from_env(raw: Option<String>) -> eyre::Result<std::net::IpAddr> {
+    match raw {
+        Some(s) => s
+            .parse()
+            .with_context(|| format!("invalid DORA_COORDINATOR_ADDR `{s}`")),
+        None => Ok(LOCALHOST),
+    }
+}
+
+/// Resolve the coordinator port from `DORA_COORDINATOR_PORT`; see
+/// [`coordinator_addr_from_env`] for why a malformed value is a hard error.
+fn coordinator_port_from_env(raw: Option<String>) -> eyre::Result<u16> {
+    match raw {
+        Some(s) => s
+            .parse()
+            .with_context(|| format!("invalid DORA_COORDINATOR_PORT `{s}`")),
+        None => Ok(DORA_COORDINATOR_PORT_WS_DEFAULT),
+    }
+}
+
 pub(crate) fn up(config_path: Option<&Path>, auth: bool, recreate_store: bool) -> eyre::Result<()> {
     let UpConfig {} = parse_dora_config(config_path)?;
-    let addr: std::net::IpAddr = std::env::var("DORA_COORDINATOR_ADDR")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(LOCALHOST);
-    let port: u16 = std::env::var("DORA_COORDINATOR_PORT")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(DORA_COORDINATOR_PORT_WS_DEFAULT);
+    let addr = coordinator_addr_from_env(std::env::var("DORA_COORDINATOR_ADDR").ok())?;
+    let port = coordinator_port_from_env(std::env::var("DORA_COORDINATOR_PORT").ok())?;
     let coordinator_addr = (addr, port).into();
     if recreate_store && !addr.is_loopback() {
         bail!(
@@ -736,6 +758,56 @@ mod destroy_guard_tests {
         assert!(
             matches!(down_decision(vec![df("busy")], true), DownDecision::Proceed),
             "`--force` is the documented way to say \"yes, kill them\""
+        );
+    }
+}
+
+#[cfg(test)]
+mod coordinator_env_tests {
+    use super::{
+        DORA_COORDINATOR_PORT_WS_DEFAULT, LOCALHOST, coordinator_addr_from_env,
+        coordinator_port_from_env,
+    };
+
+    #[test]
+    fn absent_env_falls_back_to_defaults() {
+        assert_eq!(coordinator_addr_from_env(None).unwrap(), LOCALHOST);
+        assert_eq!(
+            coordinator_port_from_env(None).unwrap(),
+            DORA_COORDINATOR_PORT_WS_DEFAULT
+        );
+    }
+
+    #[test]
+    fn valid_env_is_honored() {
+        assert_eq!(
+            coordinator_addr_from_env(Some("127.0.0.1".to_string())).unwrap(),
+            LOCALHOST
+        );
+        assert_eq!(
+            coordinator_port_from_env(Some("7000".to_string())).unwrap(),
+            7000
+        );
+    }
+
+    #[test]
+    fn malformed_env_is_a_hard_error_not_a_silent_default() {
+        // A typo must not silently bind the default endpoint while the next
+        // clap-parsed subcommand rejects the same value (dora-rs/dora).
+        let addr_err = coordinator_addr_from_env(Some("not-an-ip".to_string()))
+            .expect_err("a malformed address must be rejected");
+        assert!(
+            format!("{addr_err:#}").contains("DORA_COORDINATOR_ADDR"),
+            "error should name the offending variable: {addr_err:#}"
+        );
+
+        // Out of u16 range and a non-numeric value both fail.
+        assert!(coordinator_port_from_env(Some("70000".to_string())).is_err());
+        let port_err = coordinator_port_from_env(Some("6O12".to_string()))
+            .expect_err("a non-numeric port must be rejected");
+        assert!(
+            format!("{port_err:#}").contains("DORA_COORDINATOR_PORT"),
+            "error should name the offending variable: {port_err:#}"
         );
     }
 }


### PR DESCRIPTION
## Summary

`dora up` is the only place in the CLI that parses the coordinator address and port env vars by hand:

```rust
let addr = std::env::var("DORA_COORDINATOR_ADDR")
    .ok().and_then(|s| s.parse().ok()).unwrap_or(LOCALHOST);
let port = std::env::var("DORA_COORDINATOR_PORT")
    .ok().and_then(|s| s.parse().ok()).unwrap_or(DORA_COORDINATOR_PORT_WS_DEFAULT);
```

The `.and_then(|s| s.parse().ok())` **swallows a parse error**, so a malformed value silently falls back to the default endpoint:

- `DORA_COORDINATOR_PORT=70000` (out of `u16` range) → binds the default port
- `DORA_COORDINATOR_PORT=6O12` (letter `O` typo) → binds the default port
- `DORA_COORDINATOR_ADDR=<not-an-ip>` → binds loopback

Every **other** subcommand routes the same env vars through clap's typed `value_parser` (see `common.rs`, `daemon.rs`, `build/mod.rs`, `coordinator.rs`), which **hard-errors** on a bad value. So the next `dora start` / `dora list` / `dora stop` in the same workflow rejects the value `up` just ignored — or connects to the default port and reports the coordinator as "not running". The two halves of a single workflow disagree about where the coordinator lives, with no diagnostic.

## Fix

Parse both vars strictly via two small helpers that surface a contextual error (`invalid DORA_COORDINATOR_ADDR `…``), falling back to the default only when the var is **unset** — matching clap's behavior in the sibling subcommands. The helpers take an `Option<String>` (rather than reading the env internally) so the parse logic is unit-testable without mutating process env.

Note: a var set to an *empty string* now hard-errors, which is intentional — clap's `env=` in the other subcommands rejects an empty value too, so this keeps `up` consistent with them (treating empty as "unset" would reintroduce the very divergence this fixes).

## Validation

- Added unit tests for the absent (→ default), valid, and malformed (→ error naming the offending variable, both out-of-range and non-numeric) cases.
- `cargo fmt -p dora-cli -- --check`, `cargo clippy -p dora-cli -- -D warnings` (the CI gate command), and `cargo test -p dora-cli coordinator_env_tests` pass locally on rustc 1.97.1. Only `up.rs` is touched.

---

⚠️ **This is a machine-generated pull request**, authored by Claude (Claude Code). It has been verified locally as described above but should receive human review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DY5kNaoUXqmLD3VYGLrSv4)_