### PR TITLE
fix(python-node): reject negative shape dims in tensor_from_info GPU guard

### DIFF
--- a/apis/python/node/dora/cuda.py
+++ b/apis/python/node/dora/cuda.py
@@ -383,6 +383,17 @@ def tensor_from_info(tensor_info: dict) -> torch.Tensor:
         # claims a large shape over a small buffer would produce an
         # out-of-bounds GPU tensor (the CPU path is saved by numpy
         # reshape, but the GPU path has no equivalent backstop).
+        #
+        # Reject negative dimensions first: the size check below uses a
+        # plain running product, and a negative dim makes that product
+        # negative, so `expected_bytes > size` would be False and the
+        # guard would be silently bypassed — exactly the malformed
+        # (peer-controlled) header it exists to reject. A zero dim is a
+        # legitimate empty tensor and passes the size check as 0 <= size.
+        if any(dim < 0 for dim in shape):
+            raise ValueError(
+                f"tensor shape {shape} has a negative dimension — header may be corrupted"
+            )
         expected_bytes = np.dtype(np_dtype).itemsize
         for dim in shape:
             expected_bytes *= dim


### PR DESCRIPTION
## Summary

Fixes #3208.

The GPU size guard added to `tensor_from_info` in #3079 (`apis/python/node/dora/cuda.py`) computes `prod(shape) * itemsize` with a plain running product and rejects the header when it exceeds the registered pool `size`. Because `shape` is peer/header-controlled and carried as signed ints, a **negative** dimension makes the running product negative, so `expected_bytes > size` evaluates to `False` and the guard is silently bypassed — exactly the malformed-header class the guard was written to reject.

## Change

Reject negative dimensions explicitly before the size check:

```python
if any(dim < 0 for dim in shape):
    raise ValueError(
        f"tensor shape {shape} has a negative dimension — header may be corrupted"
    )
```

A zero dimension is a legitimately empty tensor and still passes the size check as `0 <= size`, so only negatives are rejected. This matches the fix suggested in the issue.

## Scope / testing

Defense-in-depth, reachable only on the opt-in cross-machine GPU read path (`DORA_MEMORY_POOL_CROSS_MACHINE`). The change is a pure-Python guard that runs before `torch.as_tensor`. There is no existing Python unit-test harness for `cuda.py` (it requires torch + a CUDA device, which is why #3079 shipped the original guard without one), so no automated test is added here; `python3 -m py_compile` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYaXAByMZaV36WJfHbfZ1N)_