### PR TITLE
feat(node-api)!: remove Arrow from the frozen public API before 1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,19 @@ jobs:
           -p dora-operator-api-python
           -p dora-ros2-bridge-python
           -p dora-runtime-python
+      # The C/C++ bindings name Arrow types directly, so they depend on
+      # `dora-node-api`'s `arrow-v59` feature. `cargo check --all` above does
+      # NOT catch a missing opt-in: another workspace member (the C++ binding)
+      # enables the feature, and cargo unifies features across a whole-workspace
+      # build, so the C binding compiles by accident. Built per-crate the
+      # unification is gone and the break appears. Without this, the first place
+      # it surfaces is `find_package smoke`, which is skipped on `pull_request`
+      # and only runs on a merge-queue batch — one wasted batch cycle per
+      # attempt (#3213).
+      - name: Check C/C++ bindings compile standalone
+        run: |
+          cargo check -p dora-node-api-c
+          cargo check -p dora-node-api-cxx
 
   test:
     # Linux-only on PR CI (#1716). macOS + Windows coverage runs in nightly.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ version = 4
 name = "action-example-client"
 version = "1.0.0-rc.4"
 dependencies = [
- "arrow",
+ "arrow 59.0.0",
  "dora-node-api",
  "eyre",
 ]
@@ -15,7 +15,7 @@ dependencies = [
 name = "action-example-server"
 version = "1.0.0-rc.4"
 dependencies = [
- "arrow",
+ "arrow 59.0.0",
  "dora-node-api",
  "eyre",
 ]
@@ -215,22 +215,54 @@ checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "arrow"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cfdd0833e32a9874d2b55089333ad310c0be208aafa277385ce2461dec90be3"
+dependencies = [
+ "arrow-arith 58.4.0",
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-cast 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-ord 58.4.0",
+ "arrow-row 58.4.0",
+ "arrow-schema 58.4.0",
+ "arrow-select 58.4.0",
+ "arrow-string 58.4.0",
+]
+
+[[package]]
+name = "arrow"
 version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffaaa3e009861fd829d0a24dd6f115aa8e4634324bb092147d43baafe69ca4a7"
 dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
+ "arrow-arith 59.2.0",
+ "arrow-array 59.2.0",
+ "arrow-buffer 59.2.0",
+ "arrow-cast 59.2.0",
+ "arrow-data 59.2.0",
  "arrow-ipc",
- "arrow-ord",
+ "arrow-ord 59.2.0",
  "arrow-pyarrow",
- "arrow-row",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
+ "arrow-row 59.2.0",
+ "arrow-schema 59.2.0",
+ "arrow-select 59.2.0",
+ "arrow-string 59.2.0",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a41203398f0eaa6f7ec8e62c0da742a21abf282c148fc157f6c35c90e29981a"
+dependencies = [
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
+ "chrono",
+ "num-traits",
 ]
 
 [[package]]
@@ -239,11 +271,29 @@ version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "757ef1836251e88222542a7da2623bc1c9cb9e20afefa6db2c41e79991cd91d4"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 59.2.0",
+ "arrow-buffer 59.2.0",
+ "arrow-data 59.2.0",
+ "arrow-schema 59.2.0",
  "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae33dad492b7df00a217563a7b0ef2874df68a0deea1b1a3acf628152f7f7a69"
+dependencies = [
+ "ahash",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
+ "chrono",
+ "half",
+ "hashbrown 0.17.1",
+ "num-complex",
+ "num-integer",
  "num-traits",
 ]
 
@@ -254,15 +304,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc9a4a4b2b5ecd0e04df03471661cb61f28bed3c7fd50994715129b01b2edb97"
 dependencies = [
  "ahash",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-buffer 59.2.0",
+ "arrow-data 59.2.0",
+ "arrow-schema 59.2.0",
  "chrono",
  "half",
  "hashbrown 0.17.1",
  "libc",
  "num-complex",
  "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9552f96391c005e6ab449fa941420935e7e062489b12b8b1b08879b2163f5b5"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint 0.4.8",
  "num-traits",
 ]
 
@@ -280,16 +342,37 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8a327c9649f30d8406995f27642b68df354713cca3baaaf100f076f18d5f34"
+dependencies = [
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-ord 58.4.0",
+ "arrow-schema 58.4.0",
+ "arrow-select 58.4.0",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-cast"
 version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68338a9096a5dc9bc11927c58c43a8526d96bf6abd2012ef6c0c9f505991cc79"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 59.2.0",
+ "arrow-buffer 59.2.0",
+ "arrow-data 59.2.0",
+ "arrow-ord 59.2.0",
+ "arrow-schema 59.2.0",
+ "arrow-select 59.2.0",
  "atoi",
  "base64 0.23.1",
  "chrono",
@@ -301,12 +384,25 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b24852db04738907e06c04ea61e42fe7fda962a34513022dc0d0e754fb7976b"
+dependencies = [
+ "arrow-buffer 58.4.0",
+ "arrow-schema 58.4.0",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-data"
 version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "723fe4aeed7604e00b9883a465af4ff0a0e6c44c03e41a68c3d1cbc403e0e44d"
 dependencies = [
- "arrow-buffer",
- "arrow-schema",
+ "arrow-buffer 59.2.0",
+ "arrow-schema 59.2.0",
  "half",
  "num-integer",
  "num-traits",
@@ -318,11 +414,11 @@ version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "149437b14371f5b9ec60f5ddc751483ae99d7a7072653c0075e5e469156eea7b"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 59.2.0",
+ "arrow-buffer 59.2.0",
+ "arrow-data 59.2.0",
+ "arrow-schema 59.2.0",
+ "arrow-select 59.2.0",
  "flatbuffers",
 ]
 
@@ -332,12 +428,12 @@ version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f18b9123ccfec418a663f821c9a034af339711678c11ffe00d3ec07da5ff9f7e"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 59.2.0",
+ "arrow-buffer 59.2.0",
+ "arrow-cast 59.2.0",
+ "arrow-ord 59.2.0",
+ "arrow-schema 59.2.0",
+ "arrow-select 59.2.0",
  "chrono",
  "half",
  "indexmap 2.14.0",
@@ -353,15 +449,28 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63a083ec750f5c043f02946b4baf05fcdbb55f4560a3277055caca5cc99f3eb0"
+dependencies = [
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
+ "arrow-select 58.4.0",
+]
+
+[[package]]
+name = "arrow-ord"
 version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c08dff0686cf23ca4f562803f191ccbeb726dbae6309cd4b4aaf65e0f2c979"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 59.2.0",
+ "arrow-buffer 59.2.0",
+ "arrow-data 59.2.0",
+ "arrow-schema 59.2.0",
+ "arrow-select 59.2.0",
 ]
 
 [[package]]
@@ -370,10 +479,23 @@ version = "59.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e66bd74e4a47c6df9a2af16d9cca97e37cdfe5b3207d5e3558646e07957a27"
 dependencies = [
- "arrow-array",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 59.2.0",
+ "arrow-data 59.2.0",
+ "arrow-schema 59.2.0",
  "pyo3",
+]
+
+[[package]]
+name = "arrow-row"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514ba0ef0d4c5896202dae736251ce415abb43a950bed570fb7981b8716c0e4c"
+dependencies = [
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
+ "half",
 ]
 
 [[package]]
@@ -382,11 +504,20 @@ version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbec439386df71ad570e6758a946111322b9e9dc8db83b5527321f0b4c9119c2"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 59.2.0",
+ "arrow-buffer 59.2.0",
+ "arrow-data 59.2.0",
+ "arrow-schema 59.2.0",
  "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21ca356ad6425cecb6eb7b28e4f659f1ee7880fbb1a16127de7dd62901efee9e"
+dependencies = [
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -402,16 +533,47 @@ dependencies = [
 
 [[package]]
 name = "arrow-select"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c58da39eb3d8350ad4a549e5c2bc49284dac554016c69829310350f1731b0aad"
+dependencies = [
+ "ahash",
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-select"
 version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "466b19cf75130b891dc1b23a84b343c714c62c64c9c62e365c76aa0ff90a53fb"
 dependencies = [
  "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 59.2.0",
+ "arrow-buffer 59.2.0",
+ "arrow-data 59.2.0",
+ "arrow-schema 59.2.0",
  "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6789b388467525e3271326b6b4915666ecfdf5142aef09779445c954b67543c"
+dependencies = [
+ "arrow-array 58.4.0",
+ "arrow-buffer 58.4.0",
+ "arrow-data 58.4.0",
+ "arrow-schema 58.4.0",
+ "arrow-select 58.4.0",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -420,11 +582,11 @@ version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c838a25bb3691e919e0f617616ac51a4ff8517a952e29ca133cf0c22b2ce65b1"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 59.2.0",
+ "arrow-buffer 59.2.0",
+ "arrow-data 59.2.0",
+ "arrow-schema 59.2.0",
+ "arrow-select 59.2.0",
  "memchr",
  "num-traits",
  "regex",
@@ -1920,7 +2082,8 @@ dependencies = [
 name = "dora-arrow-convert"
 version = "1.0.0-rc.4"
 dependencies = [
- "arrow",
+ "arrow 58.4.0",
+ "arrow 59.0.0",
  "chrono",
  "eyre",
  "half",
@@ -1932,9 +2095,9 @@ dependencies = [
 name = "dora-cli"
 version = "1.0.0-rc.4"
 dependencies = [
- "arrow",
+ "arrow 59.0.0",
  "arrow-json",
- "arrow-schema",
+ "arrow-schema 59.2.0",
  "chrono",
  "clap",
  "clap_complete",
@@ -2006,7 +2169,7 @@ dependencies = [
 name = "dora-coordinator"
 version = "1.0.0-rc.4"
 dependencies = [
- "arrow",
+ "arrow 59.0.0",
  "axum",
  "ctrlc",
  "dora-coordinator-store",
@@ -2052,8 +2215,8 @@ dependencies = [
 name = "dora-core"
 version = "1.0.0-rc.4"
 dependencies = [
- "arrow-buffer",
- "arrow-schema",
+ "arrow-buffer 59.2.0",
+ "arrow-schema 59.2.0",
  "dora-message",
  "dunce",
  "eyre",
@@ -2143,7 +2306,7 @@ dependencies = [
 name = "dora-examples"
 version = "0.0.0"
 dependencies = [
- "arrow-array",
+ "arrow-array 59.2.0",
  "assert2",
  "dora-cli",
  "dora-coordinator",
@@ -2187,7 +2350,7 @@ dependencies = [
 name = "dora-log-utils"
 version = "1.0.0-rc.4"
 dependencies = [
- "arrow",
+ "arrow 59.0.0",
  "chrono",
  "dora-arrow-convert",
  "dora-message",
@@ -2199,7 +2362,7 @@ dependencies = [
 name = "dora-mavlink2-bridge"
 version = "1.0.0-rc.4"
 dependencies = [
- "arrow",
+ "arrow 59.0.0",
  "eyre",
  "mavlink",
  "num-traits",
@@ -2214,7 +2377,7 @@ dependencies = [
 name = "dora-mavlink2-bridge-node"
 version = "1.0.0-rc.4"
 dependencies = [
- "arrow",
+ "arrow 59.0.0",
  "dora-mavlink2-bridge",
  "dora-node-api",
  "eyre",
@@ -2232,8 +2395,8 @@ name = "dora-message"
 version = "1.0.0-rc.4"
 dependencies = [
  "aligned-vec",
- "arrow-data",
- "arrow-schema",
+ "arrow-data 59.2.0",
+ "arrow-schema 59.2.0",
  "chrono",
  "criterion 0.8.2",
  "dirs 6.0.0",
@@ -2271,9 +2434,10 @@ name = "dora-node-api"
 version = "1.0.0-rc.4"
 dependencies = [
  "aligned-vec",
- "arrow",
+ "arrow 58.4.0",
+ "arrow 59.0.0",
  "arrow-json",
- "arrow-schema",
+ "arrow-schema 59.2.0",
  "chrono",
  "colored",
  "criterion 0.5.1",
@@ -2306,7 +2470,7 @@ dependencies = [
 name = "dora-node-api-c"
 version = "1.0.0-rc.4"
 dependencies = [
- "arrow-array",
+ "arrow-array 59.2.0",
  "dora-node-api",
  "eyre",
  "tracing",
@@ -2316,7 +2480,7 @@ dependencies = [
 name = "dora-node-api-cxx"
 version = "1.0.0-rc.4"
 dependencies = [
- "arrow",
+ "arrow 59.0.0",
  "chrono",
  "cxx",
  "cxx-build",
@@ -2336,7 +2500,7 @@ dependencies = [
 name = "dora-node-api-python"
 version = "1.0.0-rc.4"
 dependencies = [
- "arrow",
+ "arrow 59.0.0",
  "chrono",
  "dora-cli",
  "dora-download",
@@ -2398,8 +2562,8 @@ name = "dora-operator-api-python"
 version = "1.0.0-rc.4"
 dependencies = [
  "aligned-vec",
- "arrow",
- "arrow-schema",
+ "arrow 59.0.0",
+ "arrow-schema 59.2.0",
  "chrono",
  "dora-node-api",
  "eyre",
@@ -2418,7 +2582,7 @@ dependencies = [
 name = "dora-operator-api-types"
 version = "1.0.0-rc.4"
 dependencies = [
- "arrow",
+ "arrow 59.0.0",
  "dora-arrow-convert",
  "safer-ffi",
 ]
@@ -2491,7 +2655,7 @@ dependencies = [
 name = "dora-ros2-bridge-arrow"
 version = "1.0.0-rc.4"
 dependencies = [
- "arrow",
+ "arrow 59.0.0",
  "byteorder",
  "cdr-encoding",
  "dora-ros2-bridge-msg-gen",
@@ -2524,7 +2688,7 @@ dependencies = [
 name = "dora-ros2-bridge-node"
 version = "1.0.0-rc.4"
 dependencies = [
- "arrow",
+ "arrow 59.0.0",
  "dora-message",
  "dora-node-api",
  "dora-ros2-bridge",
@@ -2545,7 +2709,7 @@ dependencies = [
 name = "dora-ros2-bridge-python"
 version = "1.0.0-rc.4"
 dependencies = [
- "arrow",
+ "arrow 59.0.0",
  "dora-message",
  "dora-ros2-bridge",
  "dora-ros2-bridge-arrow",
@@ -2564,7 +2728,7 @@ dependencies = [
 name = "dora-runtime-api"
 version = "1.0.0-rc.4"
 dependencies = [
- "arrow",
+ "arrow 59.0.0",
  "dora-core",
  "dora-message",
  "dora-metrics",
@@ -2584,7 +2748,7 @@ dependencies = [
 name = "dora-runtime-python"
 version = "1.0.0-rc.4"
 dependencies = [
- "arrow",
+ "arrow 59.0.0",
  "dora-core",
  "dora-download",
  "dora-node-api",
@@ -2608,7 +2772,7 @@ dependencies = [
 name = "dora-runtime-shared-lib"
 version = "1.0.0-rc.4"
 dependencies = [
- "arrow",
+ "arrow 59.0.0",
  "dora-core",
  "dora-download",
  "dora-node-api",
@@ -2635,7 +2799,7 @@ dependencies = [
 name = "dora-tensor-pool-python"
 version = "1.0.0-rc.4"
 dependencies = [
- "arrow",
+ "arrow 59.0.0",
  "dora-message",
  "dora-node-api",
  "eyre",
@@ -4560,7 +4724,7 @@ dependencies = [
 name = "mavlink2-bridge-example-heartbeat-emitter"
 version = "1.0.0-rc.4"
 dependencies = [
- "arrow",
+ "arrow 59.0.0",
  "dora-mavlink2-bridge",
  "dora-node-api",
  "eyre",
@@ -4583,7 +4747,7 @@ dependencies = [
 name = "mavlink2-bridge-example-telemetry-printer-rust"
 version = "1.0.0-rc.4"
 dependencies = [
- "arrow",
+ "arrow 59.0.0",
  "dora-mavlink2-bridge",
  "dora-node-api",
  "eyre",
@@ -7172,7 +7336,7 @@ dependencies = [
 name = "service-example-client"
 version = "1.0.0-rc.4"
 dependencies = [
- "arrow",
+ "arrow 59.0.0",
  "dora-node-api",
  "eyre",
 ]
@@ -7181,7 +7345,7 @@ dependencies = [
 name = "service-example-server"
 version = "1.0.0-rc.4"
 dependencies = [
- "arrow",
+ "arrow 59.0.0",
  "dora-node-api",
  "eyre",
 ]
@@ -9480,7 +9644,7 @@ dependencies = [
 name = "yaml-bridge-action-goal"
 version = "1.0.0-rc.4"
 dependencies = [
- "arrow",
+ "arrow 59.0.0",
  "dora-node-api",
  "eyre",
 ]
@@ -9489,7 +9653,7 @@ dependencies = [
 name = "yaml-bridge-action-server-handler"
 version = "1.0.0-rc.4"
 dependencies = [
- "arrow",
+ "arrow 59.0.0",
  "dora-node-api",
  "eyre",
 ]
@@ -9498,7 +9662,7 @@ dependencies = [
 name = "yaml-bridge-service-handler"
 version = "1.0.0-rc.4"
 dependencies = [
- "arrow",
+ "arrow 59.0.0",
  "dora-node-api",
  "eyre",
 ]
@@ -9507,7 +9671,7 @@ dependencies = [
 name = "yaml-bridge-service-requester"
 version = "1.0.0-rc.4"
 dependencies = [
- "arrow",
+ "arrow 59.0.0",
  "dora-node-api",
  "eyre",
 ]

--- a/apis/c++/node/Cargo.toml
+++ b/apis/c++/node/Cargo.toml
@@ -29,7 +29,7 @@ rmw-zenoh = ["dora-ros2-bridge/rmw-zenoh"]
 
 [dependencies]
 cxx = "1.0.194"
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true , features = ["arrow-v59"] }
 eyre = { workspace = true }
 dora-ros2-bridge = { workspace = true, optional = true }
 futures-lite = { version = "2.6" }

--- a/apis/c++/node/src/lib.rs
+++ b/apis/c++/node/src/lib.rs
@@ -14,7 +14,7 @@ use dora_node_api::{
     self, Event, EventStream, Metadata as DoraMetadata,
     MetadataParameters as DoraMetadataParameters, Parameter as DoraParameter, PatternError,
     TryRecvError,
-    arrow::array::{AsArray, UInt8Array},
+    arrow_v59::array::{AsArray, UInt8Array},
     dora_core::config::NodeId,
     merged::MergedEvent,
 };
@@ -622,13 +622,13 @@ fn event_as_input_with_metadata(event: Box<DoraEvent>) -> eyre::Result<ffi::Dora
 /// Decode a byte-payload input. The payload arrives as a self-describing
 /// Arrow IPC stream, so the type is read from the array itself rather
 /// than assumed.
-fn input_bytes(data: &dora_node_api::ArrowData) -> eyre::Result<Vec<u8>> {
-    match data.data_type() {
-        dora_node_api::arrow::datatypes::DataType::UInt8 => {
-            let array: &UInt8Array = data.as_primitive();
+fn input_bytes(data: &dora_node_api::DoraArray) -> eyre::Result<Vec<u8>> {
+    match data.as_array().data_type() {
+        dora_node_api::arrow_v59::datatypes::DataType::UInt8 => {
+            let array: &UInt8Array = data.as_array().as_primitive();
             Ok(array.values().to_vec())
         }
-        dora_node_api::arrow::datatypes::DataType::Null => Ok(vec![]),
+        dora_node_api::arrow_v59::datatypes::DataType::Null => Ok(vec![]),
         other => {
             bail!(
                 "unsupported input arrow type {other:?}; \
@@ -732,7 +732,7 @@ unsafe fn event_as_arrow_input(
         };
     }
 
-    let array_data = data.to_data();
+    let array_data = data.as_array().to_data();
 
     match arrow::ffi::to_ffi(&array_data) {
         Ok((ffi_array, ffi_schema)) => {
@@ -1068,7 +1068,7 @@ unsafe fn event_as_arrow_input_with_info(
         }
     };
 
-    let array_data = data.to_data();
+    let array_data = data.as_array().to_data();
 
     match arrow::ffi::to_ffi(&array_data) {
         Ok((ffi_array, ffi_schema)) => {
@@ -1487,8 +1487,8 @@ fn downcast_dora(event: ffi::CombinedEvent) -> eyre::Result<Box<DoraEvent>> {
 mod tests {
     use super::*;
     use dora_node_api::{
-        ArrowData,
-        arrow::array::{ArrayRef, Int32Array},
+        DoraArray,
+        arrow_v59::array::{ArrayRef, Int32Array},
         uhlc::HLC,
     };
     use std::sync::Arc;
@@ -1502,7 +1502,7 @@ mod tests {
         let event = Box::new(DoraEvent(EventOrReason::Event(Event::Input {
             id: "my_input".into(),
             metadata: DoraMetadata::new(HLC::default().new_timestamp()),
-            data: ArrowData(array),
+            data: DoraArray::from(array),
         })));
 
         let result = event_as_input(event);
@@ -1572,7 +1572,7 @@ mod tests {
             event_as_input_with_metadata(Box::new(DoraEvent(EventOrReason::Event(Event::Input {
                 id: "request".into(),
                 metadata,
-                data: ArrowData(array),
+                data: DoraArray::from(array),
             }))))
             .expect("input event should decode");
 
@@ -1593,7 +1593,7 @@ mod tests {
             event_as_input_with_metadata(Box::new(DoraEvent(EventOrReason::Event(Event::Input {
                 id: "input".into(),
                 metadata: DoraMetadata::new(HLC::default().new_timestamp()),
-                data: ArrowData(array),
+                data: DoraArray::from(array),
             }))));
         assert!(wrong_type.is_err(), "a non-UInt8 payload must return Err");
     }
@@ -1795,7 +1795,7 @@ mod tests {
         let result = pattern_result(Ok(Event::Input {
             id: "response".into(),
             metadata,
-            data: ArrowData(array),
+            data: DoraArray::from(array),
         }));
 
         assert!(matches!(result.status, ffi::DoraPatternStatus::Matched));

--- a/apis/c/node/Cargo.toml
+++ b/apis/c/node/Cargo.toml
@@ -26,3 +26,7 @@ arrow-array = { workspace = true }
 
 [dependencies.dora-node-api]
 workspace = true
+# The C API hands raw Arrow arrays across the FFI boundary, so it names
+# Arrow types directly and needs the internal-major re-export plus the
+# borrowing `DoraArray::as_array` accessor it gates.
+features = ["arrow-v59"]

--- a/apis/c/node/src/lib.rs
+++ b/apis/c/node/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 
 use arrow_array::UInt8Array;
-use dora_node_api::{DoraNode, Event, EventStream, arrow::array::AsArray};
+use dora_node_api::{DoraNode, Event, EventStream, arrow_v59::array::AsArray};
 use eyre::Context;
 use std::{
     ffi::{c_int, c_void},
@@ -184,9 +184,9 @@ pub unsafe extern "C" fn read_dora_input_data(
     match event {
         // The payload is decoded from a self-describing Arrow IPC stream, so the
         // type is read from the array itself.
-        Event::Input { data, .. } => match data.data_type() {
-            dora_node_api::arrow::datatypes::DataType::UInt8 => {
-                let array: &UInt8Array = data.as_primitive();
+        Event::Input { data, .. } => match data.as_array().data_type() {
+            dora_node_api::arrow_v59::datatypes::DataType::UInt8 => {
+                let array: &UInt8Array = data.as_array().as_primitive();
                 let values = array.values();
                 // A zero-length payload carries no data. `values().as_ptr()`
                 // returns a non-null, dangling-but-aligned pointer for an empty
@@ -203,7 +203,7 @@ pub unsafe extern "C" fn read_dora_input_data(
                     *out_len = len;
                 }
             }
-            dora_node_api::arrow::datatypes::DataType::Null => unsafe {
+            dora_node_api::arrow_v59::datatypes::DataType::Null => unsafe {
                 *out_ptr = ptr::null();
                 *out_len = 0;
             },
@@ -400,8 +400,8 @@ unsafe fn try_log(
 mod tests {
     use super::*;
     use dora_node_api::{
-        ArrowData, Metadata,
-        arrow::array::{ArrayRef, Int32Array},
+        DoraArray, Metadata,
+        arrow_v59::array::{ArrayRef, Int32Array},
         uhlc::HLC,
     };
     use std::sync::Arc;
@@ -415,7 +415,7 @@ mod tests {
         let event = Event::Input {
             id: "my_input".into(),
             metadata: Metadata::new(HLC::default().new_timestamp()),
-            data: ArrowData(array),
+            data: DoraArray::from(array),
         };
         let event_ptr: *const () = (&event as *const Event).cast();
 
@@ -447,7 +447,7 @@ mod tests {
         let event = Event::Input {
             id: "my_input".into(),
             metadata: Metadata::new(HLC::default().new_timestamp()),
-            data: ArrowData(array),
+            data: DoraArray::from(array),
         };
         let event_ptr: *const () = (&event as *const Event).cast();
 

--- a/apis/python/node/Cargo.toml
+++ b/apis/python/node/Cargo.toml
@@ -23,7 +23,7 @@ metrics = ["dora-node-api/metrics"]
 async = ["pyo3/experimental-async"]
 
 [dependencies]
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true  }
 dora-message = { workspace = true }
 dora-operator-api-python = { workspace = true }
 dora-runtime-python = { workspace = true }

--- a/apis/python/operator/Cargo.toml
+++ b/apis/python/operator/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true , features = ["arrow-v59"] }
 pyo3 = { workspace = true, features = ["eyre", "abi3-py311"] }
 eyre = { workspace = true }
 serde_yaml = { workspace = true }

--- a/apis/python/operator/src/lib.rs
+++ b/apis/python/operator/src/lib.rs
@@ -210,7 +210,7 @@ impl PyEvent {
                 // creates an FFI_ArrowArray with a release callback. PyArrow's
                 // _import_from_c takes ownership and calls release when the Python
                 // object is GC'd, which drops the cloned Arcs. No leak.
-                let array_data = data.to_data().to_pyarrow(py)?.unbind();
+                let array_data = data.as_array().to_data().to_pyarrow(py)?.unbind();
                 Ok(Some(array_data))
             }
             MergedEvent::Dora(Event::ParamUpdate { value, .. }) => {
@@ -429,7 +429,7 @@ pub fn metadata_to_pydict<'a>(
 
 #[cfg(test)]
 mod tests {
-    use std::{ptr::NonNull, sync::Arc};
+    use std::sync::Arc;
 
     use aligned_vec::{AVec, ConstAlign};
     use arrow::{
@@ -441,27 +441,25 @@ mod tests {
     };
 
     use arrow_schema::{DataType, Field};
-    use dora_node_api::arrow_utils::{decode_arrow_ipc_zero_copy, encode_arrow_ipc};
+    use dora_node_api::DoraArray;
+    use dora_node_api::arrow_utils::{IpcPayload, decode_arrow_ipc_zero_copy, encode_arrow_ipc};
     use eyre::{Context, Result};
 
     fn assert_roundtrip(arrow_array: &ArrayData) -> Result<()> {
         // The data plane is Arrow-IPC-only: encode to a self-describing IPC
         // stream, then decode it back from a 128-byte-aligned buffer (as the
         // receive path does).
-        let ipc_bytes = encode_arrow_ipc(arrow_array)?;
-        let mut sample: AVec<u8, ConstAlign<128>> = AVec::from_slice(128, &ipc_bytes);
+        let payload = DoraArray::from_array(arrow::array::make_array(arrow_array.clone()));
+        let ipc_bytes = encode_arrow_ipc(&payload)?;
+        let sample: AVec<u8, ConstAlign<128>> = AVec::from_slice(128, &ipc_bytes);
 
-        let serialized_deserialized_arrow_array = {
-            let ptr = NonNull::new(sample.as_mut_ptr() as *mut _).unwrap();
-            let len = sample.len();
+        let serialized_deserialized_arrow_array =
+            decode_arrow_ipc_zero_copy(IpcPayload::from_aligned_vec(sample))?;
 
-            let raw_buffer = unsafe {
-                arrow::buffer::Buffer::from_custom_allocation(ptr, len, Arc::new(sample))
-            };
-            decode_arrow_ipc_zero_copy(raw_buffer)?
-        };
-
-        assert_eq!(arrow_array, &serialized_deserialized_arrow_array);
+        assert_eq!(
+            arrow_array,
+            &serialized_deserialized_arrow_array.as_array().to_data()
+        );
 
         Ok(())
     }

--- a/apis/rust/node/Cargo.toml
+++ b/apis/rust/node/Cargo.toml
@@ -13,6 +13,18 @@ repository.workspace = true
 default = ["tracing", "metrics"]
 tracing = ["dep:dora-tracing", "dep:opentelemetry"]
 metrics = ["dep:dora-metrics"]
+# Arrow major re-exports. See docs/plan-arrow-version-decoupling.md and the
+# support-window policy in docs/api-rust.md.
+#
+# Neither is on by default: `DoraArray` and `IntoArrow` keep the common node
+# path free of Arrow types, so a node that never names an Arrow type never
+# needs a feature. Adding a major later is additive; removing one is breaking.
+#
+# `arrow-v59` is dora's *internal* major and pulls no extra dependency — it
+# re-exports the copy of Arrow 59 dora already links. Only majors other than
+# the internal one get an aliased optional dependency.
+arrow-v58 = ["dep:arrow58", "dora-arrow-convert/arrow-v58"]
+arrow-v59 = ["dora-arrow-convert/arrow-v59"]
 
 [dependencies]
 dora-core = { workspace = true, features = ["zenoh"] }
@@ -27,6 +39,7 @@ dora-tracing = { workspace = true, optional = true }
 dora-metrics = { workspace = true, optional = true }
 opentelemetry = { version = "0.32.0", optional = true }
 arrow = { workspace = true, features = ["ipc"] }
+arrow58 = { package = "arrow", version = "58", optional = true, default-features = false, features = ["ffi"] }
 # Needed to hand-build the Arrow IPC RecordBatch flatbuffer header in
 # `arrow_utils::ipc_encode` (the 1-copy fast-path encoder). Must stay compatible
 # with the `flatbuffers` version arrow-ipc's generated `gen` types are built
@@ -56,6 +69,11 @@ libc = "0.2"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
+# The bench and `tests/copy_count.rs` exercise the *public* encoder surface,
+# which is now `DoraArray`-typed. They build the payload arrays themselves, so
+# they need the Arrow 59 accessors — enabled here rather than on the library so
+# the shipped `dora-node-api` keeps `default = []` for the Arrow features.
+dora-arrow-convert = { workspace = true, features = ["arrow-v59"] }
 
 [[bench]]
 name = "arrow_framing"

--- a/apis/rust/node/benches/arrow_framing.rs
+++ b/apis/rust/node/benches/arrow_framing.rs
@@ -11,32 +11,28 @@
 //!
 //! Run with: `cargo bench -p dora-node-api --bench arrow_framing`
 
-use std::ptr::NonNull;
-use std::sync::Arc;
-
 use aligned_vec::{AVec, ConstAlign};
+use arrow::array::Float32Array;
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
-use dora_node_api::arrow::array::{Array, ArrayData, Float32Array};
-use dora_node_api::arrow::buffer::Buffer;
+use dora_node_api::DoraArray;
 use dora_node_api::arrow_utils::ipc_encode::{encode_ipc_into, ipc_fast_path_len};
-use dora_node_api::arrow_utils::{decode_arrow_ipc, decode_arrow_ipc_zero_copy, encode_arrow_ipc};
+use dora_node_api::arrow_utils::{
+    IpcPayload, decode_arrow_ipc, decode_arrow_ipc_zero_copy, encode_arrow_ipc,
+};
 
 /// Copy `bytes` into a 128-byte-aligned Arrow buffer, mirroring how Dora's
 /// receive path backs payloads (`AVec<u8, ConstAlign<128>>` / page-aligned
 /// Zenoh SHM). This is the precondition under which the IPC `StreamDecoder`
 /// path aliases the input instead of realigning it.
-fn aligned_buffer_from(bytes: &[u8]) -> Buffer {
+fn aligned_buffer_from(bytes: &[u8]) -> IpcPayload {
     let mut aligned: AVec<u8, ConstAlign<128>> = AVec::__from_elem(128, 0, bytes.len());
     aligned.copy_from_slice(bytes);
-    let ptr = NonNull::new(aligned.as_ptr() as *mut u8).unwrap();
-    let len = aligned.len();
-    // SAFETY: ptr/len describe `aligned`'s allocation; the Arc keeps it alive.
-    unsafe { Buffer::from_custom_allocation(ptr, len, Arc::new(aligned)) }
+    IpcPayload::from_aligned_vec(aligned)
 }
 
-fn make_array(num_elements: usize) -> ArrayData {
+fn make_array(num_elements: usize) -> DoraArray {
     let v: Vec<f32> = (0..num_elements).map(|i| i as f32).collect();
-    Float32Array::from(v).into_data()
+    DoraArray::from_array(Float32Array::from(v))
 }
 
 /// Allocate a zeroed buffer and touch every page so reuse in `b.iter` is warm.

--- a/apis/rust/node/src/daemon_connection/interactive.rs
+++ b/apis/rust/node/src/daemon_connection/interactive.rs
@@ -157,7 +157,9 @@ impl InteractiveEvents {
 
                     // The receive side decodes a self-describing Arrow IPC
                     // stream, so encode the array into one here.
-                    match encode_arrow_ipc(&array_data) {
+                    match encode_arrow_ipc(&dora_arrow_convert::internal::from_array_data(
+                        array_data,
+                    )) {
                         Ok(buf) => Some(buf),
                         Err(err) => {
                             eprintln!("{}", format!("{err}").red());

--- a/apis/rust/node/src/daemon_connection/node_integration_testing.rs
+++ b/apis/rust/node/src/daemon_connection/node_integration_testing.rs
@@ -237,7 +237,10 @@ impl IntegrationTestingEvents {
 
                     // The receive side decodes a self-describing Arrow IPC
                     // stream, so encode the array into one here.
-                    let buf = encode_arrow_ipc(&array).with_context(|| {
+                    let buf = encode_arrow_ipc(&dora_arrow_convert::internal::from_array_data(
+                        array,
+                    ))
+                    .with_context(|| {
                         format!("failed to IPC-encode input event at offset {time_offset_secs}s ")
                     })?;
 

--- a/apis/rust/node/src/event_stream/data_conversion.rs
+++ b/apis/rust/node/src/event_stream/data_conversion.rs
@@ -3,7 +3,7 @@ use std::{ptr::NonNull, sync::Arc};
 use aligned_vec::{AVec, ConstAlign};
 use dora_arrow_convert::IntoArrow;
 
-use crate::arrow_utils::decode_arrow_ipc_zero_copy;
+use crate::arrow_utils::decode_arrow_ipc_zero_copy_raw;
 
 pub enum RawData {
     Empty,
@@ -15,7 +15,9 @@ impl RawData {
         match self {
             // A metadata-only message with no payload. Any real array is a
             // non-empty IPC stream, so an empty payload maps to the unit array.
-            RawData::Empty => Ok(().into_arrow().into()),
+            RawData::Empty => {
+                Ok(dora_arrow_convert::internal::into_array_ref(().into_arrow()).to_data())
+            }
             RawData::Vec(data) => {
                 // Wrap the 128-byte-aligned `AVec` as an Arrow `Buffer` without
                 // copying (the buffer aliases the allocation), then let the
@@ -26,7 +28,7 @@ impl RawData {
                 let raw_buffer = unsafe {
                     arrow::buffer::Buffer::from_custom_allocation(ptr, len, Arc::new(data))
                 };
-                decode_arrow_ipc_zero_copy(raw_buffer)
+                decode_arrow_ipc_zero_copy_raw(raw_buffer)
             }
         }
     }
@@ -55,9 +57,9 @@ mod tests {
 
         // Encode the IPC stream into a 128-byte-aligned AVec, exactly as the
         // send path does for the daemon fallback.
-        let len = ipc_encode::ipc_fast_path_len(&data).unwrap();
+        let len = ipc_encode::ipc_fast_path_len_data(&data).unwrap();
         let mut avec: AVec<u8, ConstAlign<128>> = AVec::__from_elem(128, 0, len);
-        ipc_encode::encode_ipc_into(&data, &mut avec).unwrap();
+        ipc_encode::encode_ipc_into_data(&data, &mut avec).unwrap();
         let message = DataMessage::Vec(avec);
 
         // Same encode/decode entry points the node->daemon->node TCP hops use.
@@ -82,6 +84,9 @@ mod tests {
     #[test]
     fn empty_payload_decodes_to_unit_array() {
         let decoded = RawData::Empty.into_arrow_array().unwrap();
-        assert_eq!(decoded, ().into_arrow().into());
+        assert_eq!(
+            decoded,
+            dora_arrow_convert::internal::into_array_ref(().into_arrow()).to_data()
+        );
     }
 }

--- a/apis/rust/node/src/event_stream/event.rs
+++ b/apis/rust/node/src/event_stream/event.rs
@@ -1,4 +1,4 @@
-use dora_arrow_convert::ArrowData;
+use dora_arrow_convert::DoraArray;
 use dora_core::config::{DataId, NodeId, OperatorId};
 use dora_message::metadata::Metadata;
 
@@ -28,7 +28,7 @@ pub enum Event {
         /// Meta information about this input, e.g. the timestamp.
         metadata: Metadata,
         /// The actual data in the Apache Arrow data format.
-        data: ArrowData,
+        data: DoraArray,
     },
     /// An input was closed by the sender.
     ///

--- a/apis/rust/node/src/event_stream/input_tracker.rs
+++ b/apis/rust/node/src/event_stream/input_tracker.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use dora_arrow_convert::ArrowData;
+use dora_arrow_convert::DoraArray;
 use dora_core::config::{DataId, NodeId};
 
 use super::event::Event;
@@ -8,7 +8,7 @@ use super::event::Event;
 /// Tracks the health state and last known value of each input.
 ///
 /// Use this helper to implement graceful degradation when upstream nodes
-/// time out (via `input_timeout`). It caches the last received [`ArrowData`]
+/// time out (via `input_timeout`). It caches the last received [`DoraArray`]
 /// per input so your node can fall back to stale data instead of crashing.
 ///
 /// The cache is bounded by the number of distinct input IDs declared in the
@@ -35,7 +35,7 @@ use super::event::Event;
 ///     tracker.process_event(event);
 ///     for id in tracker.closed_inputs() {
 ///         if let Some(_stale) = tracker.last_value(id) {
-///             // degrade gracefully using the cached `ArrowData`
+///             // degrade gracefully using the cached `DoraArray`
 ///         }
 ///     }
 /// }
@@ -43,7 +43,7 @@ use super::event::Event;
 /// ```
 pub struct InputTracker {
     states: HashMap<DataId, InputState>,
-    cache: HashMap<DataId, ArrowData>,
+    cache: HashMap<DataId, DoraArray>,
     /// Optional input → source node map. When provided, `NodeRestarted`
     /// events transition any `Closed` inputs sourced from the restarted
     /// node back to `Healthy`. Without it the tracker has no way to know
@@ -100,7 +100,7 @@ impl InputTracker {
         match event {
             Event::Input { id, data, .. } => {
                 self.states.insert(id.clone(), InputState::Healthy);
-                self.cache.insert(id.clone(), ArrowData(data.0.clone()));
+                self.cache.insert(id.clone(), data.clone());
                 true
             }
             Event::InputClosed { id } => {
@@ -143,7 +143,7 @@ impl InputTracker {
     }
 
     /// Get the last received value for an input. Available even when closed.
-    pub fn last_value(&self, id: &DataId) -> Option<&ArrowData> {
+    pub fn last_value(&self, id: &DataId) -> Option<&DoraArray> {
         self.cache.get(id)
     }
 
@@ -175,15 +175,15 @@ mod tests {
     use arrow::datatypes::DataType;
     use dora_message::metadata::Metadata;
 
-    fn empty_data() -> ArrowData {
-        ArrowData(new_empty_array(&DataType::Null))
+    fn empty_data() -> DoraArray {
+        dora_arrow_convert::internal::from_array_ref(new_empty_array(&DataType::Null))
     }
 
     fn test_metadata() -> Metadata {
         Metadata::new(dora_core::uhlc::HLC::default().new_timestamp())
     }
 
-    fn make_input(id: &str, data: ArrowData) -> Event {
+    fn make_input(id: &str, data: DoraArray) -> Event {
         Event::Input {
             id: id.into(),
             metadata: test_metadata(),

--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -940,7 +940,8 @@ impl EventStream {
             && !crate::node::carries_pattern_correlation(&metadata.parameters)
             && let Some(expected) = self.input_type_checks.remove(id)
         {
-            let actual = data.data_type();
+            let raw = dora_arrow_convert::internal::array_ref(data);
+            let actual = raw.data_type();
             // Skip check for Null type (timer ticks, empty payloads)
             // to avoid spurious warnings on annotated timer inputs.
             if *actual != arrow_schema::DataType::Null && *actual != expected {
@@ -1411,7 +1412,7 @@ impl EventStream {
                             Event::Input {
                                 id,
                                 metadata,
-                                data: data.into(),
+                                data: dora_arrow_convert::internal::from_array_ref(data),
                             }
                         }
                         Err(err) => Event::Error(format!("{err:?}")),
@@ -1449,7 +1450,7 @@ impl EventStream {
                     id,
                     metadata,
                     // Already decoded in the subscriber callback (receipt order).
-                    data: arrow::array::make_array(data).into(),
+                    data: dora_arrow_convert::internal::from_array_data(data),
                 }
             }
 
@@ -1571,7 +1572,7 @@ fn declare_schema_subscriber(
                     guard.reset();
                     guard
                 });
-                if let Err(e) = decoder.set_schema(hash, buffer) {
+                if let Err(e) = decoder.set_schema_raw(hash, buffer) {
                     tracing::warn!(input = %input_id_cb, "failed to prime decoder from @schema sample: {e}");
                 }
             }));
@@ -1621,17 +1622,19 @@ fn decode_zenoh_sample(
     metadata: &dora_message::metadata::Metadata,
     payload: zenoh::bytes::ZBytes,
 ) -> eyre::Result<Option<arrow::array::ArrayData>> {
-    use crate::arrow_utils::decode_arrow_ipc_zero_copy;
+    use crate::arrow_utils::decode_arrow_ipc_zero_copy_raw;
     use dora_message::metadata::{SCHEMA_HASH, get_integer_param};
 
     if payload.is_empty() {
-        return Ok(Some(().into_arrow().into()));
+        return Ok(Some(
+            dora_arrow_convert::internal::into_array_ref(().into_arrow()).to_data(),
+        ));
     }
     let buffer = zenoh_payload_to_buffer(payload);
     match get_integer_param(&metadata.parameters, SCHEMA_HASH) {
         Some(hash) => {
             tracing::debug!("received schema-less batch with SCHEMA_HASH={}", hash);
-            decoder.decode_batch(buffer, hash as u64)
+            decoder.decode_batch_raw(buffer, hash as u64)
         }
         None => {
             tracing::debug!("received full IPC stream (no SCHEMA_HASH)");
@@ -1641,7 +1644,7 @@ fn decode_zenoh_sample(
             if !crate::node::carries_pattern_correlation(&metadata.parameters) {
                 prime_in_band(decoder, &buffer);
             }
-            decode_arrow_ipc_zero_copy(buffer).map(Some)
+            decode_arrow_ipc_zero_copy_raw(buffer).map(Some)
         }
     }
 }
@@ -1675,7 +1678,7 @@ fn prime_in_band(
     // Copy the schema block out of the payload: retaining a slice of an
     // SHM-backed buffer would pin the whole segment for the decoder's lifetime.
     let schema = arrow::buffer::Buffer::from(schema);
-    if let Err(e) = decoder.set_schema(hash, schema) {
+    if let Err(e) = decoder.set_schema_raw(hash, schema) {
         tracing::debug!("in-band schema priming failed: {e}");
     }
 }
@@ -2150,7 +2153,7 @@ mod tests {
 
     use arrow::array::new_empty_array;
     use arrow::datatypes::DataType as ArrowDataType;
-    use dora_arrow_convert::ArrowData;
+    use dora_arrow_convert::internal::from_array_ref;
     use dora_message::metadata::{
         GOAL_ID, GOAL_STATUS, GOAL_STATUS_ABORTED, GOAL_STATUS_SUCCEEDED, Metadata,
         MetadataParameters, Parameter, REQUEST_ID,
@@ -2164,7 +2167,7 @@ mod tests {
         Event::Input {
             id: id.into(),
             metadata: make_metadata(params),
-            data: ArrowData(new_empty_array(&ArrowDataType::Null)),
+            data: from_array_ref(new_empty_array(&ArrowDataType::Null)),
         }
     }
 
@@ -2393,7 +2396,9 @@ mod tests {
             node.send_output(
                 "out".parse().unwrap(),
                 Default::default(),
-                Int32Array::from(vec![i]),
+                dora_arrow_convert::internal::from_array_ref(std::sync::Arc::new(
+                    Int32Array::from(vec![i]),
+                )),
             )
             .unwrap();
         }
@@ -2708,7 +2713,9 @@ mod tests {
     /// no type sidecar involved).
     #[test]
     fn zenoh_payload_ipc_roundtrip_and_empty_is_unit() {
-        use crate::arrow_utils::ipc_encode::{InputDecoder, encode_ipc_into, ipc_fast_path_len};
+        use crate::arrow_utils::ipc_encode::{
+            InputDecoder, encode_ipc_into_data, ipc_fast_path_len_data,
+        };
         use arrow::array::{Array, Int32Array};
 
         // A standalone full stream (no SCHEMA_HASH parameter) decodes directly.
@@ -2728,9 +2735,9 @@ mod tests {
 
         // Non-empty IPC payload round-trips to the original array.
         let data = Int32Array::from(vec![10, 20, 30]).into_data();
-        let len = ipc_fast_path_len(&data).expect("primitive is fast-path eligible");
+        let len = ipc_fast_path_len_data(&data).expect("primitive is fast-path eligible");
         let mut buf = vec![0u8; len];
-        encode_ipc_into(&data, &mut buf).unwrap();
+        encode_ipc_into_data(&data, &mut buf).unwrap();
 
         let decoded = decode_zenoh_sample(&mut decoder, &metadata, zenoh::bytes::ZBytes::from(buf))
             .unwrap()
@@ -2749,8 +2756,8 @@ mod tests {
     #[test]
     fn full_stream_primes_decoder_in_band_for_schema_less_batches() {
         use crate::arrow_utils::ipc_encode::{
-            InputDecoder, batch_fast_path_len, encode_batch_into, encode_ipc_into,
-            ipc_fast_path_len, schema_block_len,
+            InputDecoder, batch_fast_path_len_data, encode_batch_into_data, encode_ipc_into_data,
+            ipc_fast_path_len_data, schema_block_len,
         };
         use arrow::array::{Array, Int32Array};
         use dora_message::metadata::{Metadata, Parameter, SCHEMA_HASH};
@@ -2761,8 +2768,8 @@ mod tests {
         // Message 1: full stream (no SCHEMA_HASH), as the producer sends while
         // the schema is not yet confirmed published on the `@schema` plane.
         let first = Int32Array::from(vec![1, 2]).into_data();
-        let mut full = vec![0u8; ipc_fast_path_len(&first).unwrap()];
-        encode_ipc_into(&first, &mut full).unwrap();
+        let mut full = vec![0u8; ipc_fast_path_len_data(&first).unwrap()];
+        encode_ipc_into_data(&first, &mut full).unwrap();
         let block = schema_block_len(&full).unwrap();
         let hash = dora_message::metadata::fnv1a(&full[..block]);
 
@@ -2776,8 +2783,8 @@ mod tests {
         // `set_schema` call happened — decoding must succeed purely from the
         // in-band priming above.
         let second = Int32Array::from(vec![3]).into_data();
-        let mut batch = vec![0u8; batch_fast_path_len(&second).unwrap()];
-        encode_batch_into(&second, &mut batch).unwrap();
+        let mut batch = vec![0u8; batch_fast_path_len_data(&second).unwrap()];
+        encode_batch_into_data(&second, &mut batch).unwrap();
         let mut tagged = Metadata::new(hlc.new_timestamp());
         tagged
             .parameters
@@ -2796,8 +2803,8 @@ mod tests {
     #[test]
     fn pattern_correlated_full_stream_does_not_prime_in_band() {
         use crate::arrow_utils::ipc_encode::{
-            InputDecoder, batch_fast_path_len, encode_batch_into, encode_ipc_into,
-            ipc_fast_path_len, schema_block_len,
+            InputDecoder, batch_fast_path_len_data, encode_batch_into_data, encode_ipc_into_data,
+            ipc_fast_path_len_data, schema_block_len,
         };
         use arrow::array::{Array, Int32Array};
         use dora_message::metadata::{Metadata, Parameter, REQUEST_ID, SCHEMA_HASH};
@@ -2806,8 +2813,8 @@ mod tests {
         let mut decoder = InputDecoder::new();
 
         let reply = Int32Array::from(vec![7]).into_data();
-        let mut full = vec![0u8; ipc_fast_path_len(&reply).unwrap()];
-        encode_ipc_into(&reply, &mut full).unwrap();
+        let mut full = vec![0u8; ipc_fast_path_len_data(&reply).unwrap()];
+        encode_ipc_into_data(&reply, &mut full).unwrap();
         let block = schema_block_len(&full).unwrap();
         let hash = dora_message::metadata::fnv1a(&full[..block]);
 
@@ -2823,8 +2830,8 @@ mod tests {
 
         // …but must not have primed the decoder for its schema hash.
         let batch_array = Int32Array::from(vec![8]).into_data();
-        let mut batch = vec![0u8; batch_fast_path_len(&batch_array).unwrap()];
-        encode_batch_into(&batch_array, &mut batch).unwrap();
+        let mut batch = vec![0u8; batch_fast_path_len_data(&batch_array).unwrap()];
+        encode_batch_into_data(&batch_array, &mut batch).unwrap();
         let mut tagged = Metadata::new(hlc.new_timestamp());
         tagged
             .parameters

--- a/apis/rust/node/src/event_stream/scheduler.rs
+++ b/apis/rust/node/src/event_stream/scheduler.rs
@@ -822,7 +822,7 @@ mod tests {
         EventItem::ZenohInput {
             id: DataId::from(id.to_string()),
             metadata: std::sync::Arc::new(metadata),
-            data: ().into_arrow().into(),
+            data: dora_arrow_convert::internal::into_array_ref(().into_arrow()).to_data(),
         }
     }
 

--- a/apis/rust/node/src/lib.rs
+++ b/apis/rust/node/src/lib.rs
@@ -102,9 +102,10 @@ pub use arrow as arrow_v59;
 /// Apache Arrow 58, for nodes that name that major.
 ///
 /// Enabled by the `arrow-v58` feature. Arrow 58 is **not** dora's internal
-/// major, so payloads cross a C Data Interface hop
-/// ([`DoraArray::from_arrow_v58`] / [`DoraArray::to_arrow_v58`]). The hop does
-/// not copy buffers.
+/// major, so payloads cross a C Data Interface hop, exposed as `TryFrom`
+/// impls in both directions (`DoraArray::try_from(&arr as &dyn arrow58 Array)`
+/// and `arrow_v58::array::ArrayRef::try_from(&dora)`). The hop is fallible —
+/// hence `TryFrom` and not `From` — but does not copy buffers.
 #[cfg(feature = "arrow-v58")]
 pub use arrow58 as arrow_v58;
 // Deliberately *not* a glob re-export: `dora_arrow_convert::internal` is an

--- a/apis/rust/node/src/lib.rs
+++ b/apis/rust/node/src/lib.rs
@@ -86,8 +86,31 @@
 
 #![warn(missing_docs)]
 
-pub use arrow;
-pub use dora_arrow_convert::*;
+/// Apache Arrow 59, dora's current **internal** major.
+///
+/// Enabled by the `arrow-v59` feature, which pulls no extra dependency: this
+/// is the same copy of Arrow 59 dora itself links, so
+/// [`DoraArray::as_array`] hands it back for free and arrays built with it
+/// need no conversion.
+///
+/// This is deliberately not `pub use arrow;`. A bare `arrow` re-export changes
+/// meaning silently when dora bumps its internal major; `arrow_v59` either
+/// exists and means Arrow 59, or it is visibly gone. See
+/// `docs/plan-arrow-version-decoupling.md`.
+#[cfg(feature = "arrow-v59")]
+pub use arrow as arrow_v59;
+/// Apache Arrow 58, for nodes that name that major.
+///
+/// Enabled by the `arrow-v58` feature. Arrow 58 is **not** dora's internal
+/// major, so payloads cross a C Data Interface hop
+/// ([`DoraArray::from_arrow_v58`] / [`DoraArray::to_arrow_v58`]). The hop does
+/// not copy buffers.
+#[cfg(feature = "arrow-v58")]
+pub use arrow58 as arrow_v58;
+// Deliberately *not* a glob re-export: `dora_arrow_convert::internal` is an
+// Arrow-typed, semver-exempt seam for dora's own crates and must not become
+// reachable through the frozen `dora-node-api` surface.
+pub use dora_arrow_convert::{DoraArray, IntoArrow, into_vec};
 pub use dora_core::{self, uhlc};
 pub use dora_message::{
     DataflowId,

--- a/apis/rust/node/src/node/arrow_utils.rs
+++ b/apis/rust/node/src/node/arrow_utils.rs
@@ -2,8 +2,74 @@
 //!
 pub mod ipc_encode;
 
+use aligned_vec::{AVec, ConstAlign};
 use arrow::array::ArrayData;
+use dora_arrow_convert::{
+    DoraArray,
+    internal::{array_ref, from_array_data},
+};
 use eyre::Context;
+
+/// A byte buffer holding an Arrow IPC stream, ready to decode.
+///
+/// A dora-owned wrapper: the receive path needs to hand the decoder a buffer
+/// whose backing allocation it does not copy, but the Arrow buffer type that
+/// makes that possible must not appear in dora's frozen public API (it would
+/// pin 1.x to one Arrow major — see
+/// `docs/plan-arrow-version-decoupling.md`). Construct one from the payload
+/// you have; decoding is zero-copy when the payload is 64-byte aligned, which
+/// dora's own 128-byte-aligned and page-aligned shared-memory payloads always
+/// are.
+#[derive(Debug, Clone)]
+pub struct IpcPayload(arrow::buffer::Buffer);
+
+impl IpcPayload {
+    /// Wrap a 128-byte-aligned payload buffer without copying it.
+    pub fn from_aligned_vec(data: AVec<u8, ConstAlign<128>>) -> Self {
+        let ptr = std::ptr::NonNull::new(data.as_ptr() as *mut u8)
+            .expect("AVec allocation pointer is never null");
+        let len = data.len();
+        // SAFETY: `ptr`/`len` describe `data`'s allocation, and `data` itself is
+        // moved into the `Arc` that owns the buffer, so the allocation outlives
+        // every reference the `Buffer` hands out.
+        Self(unsafe {
+            arrow::buffer::Buffer::from_custom_allocation(ptr, len, std::sync::Arc::new(data))
+        })
+    }
+
+    /// Take ownership of a `Vec` payload without copying it.
+    ///
+    /// A plain `Vec` carries no alignment guarantee, so the decoder may have to
+    /// realign individual buffers; use [`from_aligned_vec`](Self::from_aligned_vec)
+    /// on the hot path.
+    pub fn from_vec(data: Vec<u8>) -> Self {
+        Self(arrow::buffer::Buffer::from_vec(data))
+    }
+
+    /// Copy a payload out of a slice.
+    pub fn from_slice(data: &[u8]) -> Self {
+        Self(arrow::buffer::Buffer::from_slice_ref(data))
+    }
+
+    /// The payload length in bytes.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Whether the payload is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// The payload bytes.
+    pub fn as_slice(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+
+    pub(crate) fn into_arrow(self) -> arrow::buffer::Buffer {
+        self.0
+    }
+}
 
 /// Maximum Arrow IPC payload size (256 MB).
 const MAX_IPC_BYTES: usize = 256 * 1024 * 1024;
@@ -28,20 +94,25 @@ const _: () = assert!(ARROW_BUFFER_ALIGNMENT.is_power_of_two());
 ///
 /// ```
 /// # fn main() -> eyre::Result<()> {
-/// use dora_node_api::arrow::array::{Array, UInt64Array};
+/// use dora_node_api::IntoArrow;
 /// use dora_node_api::arrow_utils::{decode_arrow_ipc, encode_arrow_ipc};
 ///
-/// let array = UInt64Array::from(vec![1, 2, 3]);
-/// let ipc = encode_arrow_ipc(&array.into_data())?;
+/// let ipc = encode_arrow_ipc(&vec![1u64, 2, 3].into_arrow())?;
 ///
 /// // The stream is self-describing: decoding recovers the original data
 /// // without any external type information.
 /// let decoded = decode_arrow_ipc(&ipc)?;
-/// assert_eq!(decoded, UInt64Array::from(vec![1, 2, 3]).into_data());
+/// let values: Vec<u64> = (&decoded).try_into()?;
+/// assert_eq!(values, vec![1, 2, 3]);
 /// # Ok(())
 /// # }
 /// ```
-pub fn encode_arrow_ipc(arrow_array: &ArrayData) -> eyre::Result<Vec<u8>> {
+pub fn encode_arrow_ipc(array: &DoraArray) -> eyre::Result<Vec<u8>> {
+    encode_arrow_ipc_data(&array_ref(array).to_data())
+}
+
+/// Same, for dora-internal callers that already hold an [`ArrayData`].
+pub(crate) fn encode_arrow_ipc_data(arrow_array: &ArrayData) -> eyre::Result<Vec<u8>> {
     use arrow::ipc::writer::StreamWriter;
     use arrow::record_batch::RecordBatch;
     use arrow_schema::{Field, Schema};
@@ -99,16 +170,22 @@ pub fn encode_arrow_ipc(arrow_array: &ArrayData) -> eyre::Result<Vec<u8>> {
 ///
 /// ```
 /// # fn main() -> eyre::Result<()> {
-/// use dora_node_api::arrow::array::{Array, StringArray};
+/// use dora_node_api::IntoArrow;
 /// use dora_node_api::arrow_utils::{decode_arrow_ipc, encode_arrow_ipc};
 ///
-/// let ipc = encode_arrow_ipc(&StringArray::from(vec!["a", "b"]).into_data())?;
+/// let ipc = encode_arrow_ipc(&"hello".to_string().into_arrow())?;
 /// let decoded = decode_arrow_ipc(&ipc)?;
-/// assert_eq!(decoded, StringArray::from(vec!["a", "b"]).into_data());
+/// let text: String = (&decoded).try_into()?;
+/// assert_eq!(text, "hello");
 /// # Ok(())
 /// # }
 /// ```
-pub fn decode_arrow_ipc(ipc_buf: &[u8]) -> eyre::Result<ArrayData> {
+pub fn decode_arrow_ipc(ipc_buf: &[u8]) -> eyre::Result<DoraArray> {
+    decode_arrow_ipc_data(ipc_buf).map(from_array_data)
+}
+
+/// Same, for dora-internal callers that want the raw [`ArrayData`].
+pub(crate) fn decode_arrow_ipc_data(ipc_buf: &[u8]) -> eyre::Result<ArrayData> {
     use arrow::ipc::reader::StreamReader;
     use std::io::Cursor;
 
@@ -159,17 +236,22 @@ pub fn decode_arrow_ipc(ipc_buf: &[u8]) -> eyre::Result<ArrayData> {
 ///
 /// ```
 /// # fn main() -> eyre::Result<()> {
-/// use dora_node_api::arrow::array::{Array, UInt64Array};
-/// use dora_node_api::arrow::buffer::Buffer;
-/// use dora_node_api::arrow_utils::{decode_arrow_ipc_zero_copy, encode_arrow_ipc};
+/// use dora_node_api::IntoArrow;
+/// use dora_node_api::arrow_utils::{IpcPayload, decode_arrow_ipc_zero_copy, encode_arrow_ipc};
 ///
-/// let ipc = encode_arrow_ipc(&UInt64Array::from(vec![1, 2, 3]).into_data())?;
-/// let decoded = decode_arrow_ipc_zero_copy(Buffer::from_vec(ipc))?;
-/// assert_eq!(decoded, UInt64Array::from(vec![1, 2, 3]).into_data());
+/// let ipc = encode_arrow_ipc(&vec![1u64, 2, 3].into_arrow())?;
+/// let decoded = decode_arrow_ipc_zero_copy(IpcPayload::from_vec(ipc))?;
+/// let values: Vec<u64> = (&decoded).try_into()?;
+/// assert_eq!(values, vec![1, 2, 3]);
 /// # Ok(())
 /// # }
 /// ```
-pub fn decode_arrow_ipc_zero_copy(
+pub fn decode_arrow_ipc_zero_copy(payload: IpcPayload) -> eyre::Result<DoraArray> {
+    decode_arrow_ipc_zero_copy_raw(payload.into_arrow()).map(from_array_data)
+}
+
+/// Same, for dora-internal callers that already hold an Arrow buffer.
+pub(crate) fn decode_arrow_ipc_zero_copy_raw(
     mut buffer: arrow::buffer::Buffer,
 ) -> eyre::Result<arrow::array::ArrayData> {
     use arrow::ipc::reader::StreamDecoder;
@@ -224,8 +306,8 @@ mod tests {
     fn ipc_roundtrip_primitive() {
         let array = UInt64Array::from(vec![1, 2, 3, 4, 5]);
         let data = array.into_data();
-        let encoded = encode_arrow_ipc(&data).unwrap();
-        let decoded = decode_arrow_ipc(&encoded).unwrap();
+        let encoded = encode_arrow_ipc_data(&data).unwrap();
+        let decoded = decode_arrow_ipc_data(&encoded).unwrap();
         assert_eq!(data, decoded);
     }
 
@@ -239,8 +321,8 @@ mod tests {
         // Body just over the 256 MB cap; the framing pushes the stream over too.
         let array = UInt8Array::from(vec![0u8; MAX_IPC_BYTES + 1]);
         let data = array.into_data();
-        let err =
-            encode_arrow_ipc(&data).expect_err("oversized payload must be rejected by the encoder");
+        let err = encode_arrow_ipc_data(&data)
+            .expect_err("oversized payload must be rejected by the encoder");
         assert!(
             err.to_string().contains("too large"),
             "unexpected error: {err}"
@@ -272,9 +354,9 @@ mod tests {
     fn ipc_zero_copy_roundtrip_primitive() {
         let array = UInt64Array::from((0..1000u64).collect::<Vec<_>>());
         let data = array.into_data();
-        let encoded = encode_arrow_ipc(&data).unwrap();
+        let encoded = encode_arrow_ipc_data(&data).unwrap();
         let (buffer, _, _) = aligned_buffer_from(&encoded);
-        let decoded = decode_arrow_ipc_zero_copy(buffer).unwrap();
+        let decoded = decode_arrow_ipc_zero_copy_raw(buffer).unwrap();
         assert_eq!(data, decoded);
     }
 
@@ -290,7 +372,7 @@ mod tests {
         // would be unmistakable.
         let array = UInt64Array::from((0..100_000u64).collect::<Vec<_>>());
         let data = array.into_data();
-        let encoded = encode_arrow_ipc(&data).unwrap();
+        let encoded = encode_arrow_ipc_data(&data).unwrap();
 
         // 1) Proof via the strict decoder: require_alignment(true) errors if any
         //    buffer would need realigning. A clean decode proves the body
@@ -315,7 +397,7 @@ mod tests {
         //    input allocation's address range.
         {
             let (buffer, base, len) = aligned_buffer_from(&encoded);
-            let decoded = decode_arrow_ipc_zero_copy(buffer).unwrap();
+            let decoded = decode_arrow_ipc_zero_copy_raw(buffer).unwrap();
             let data_ptr = decoded.buffers()[0].as_ptr() as usize;
             assert!(
                 data_ptr >= base && data_ptr < base + len,
@@ -333,7 +415,7 @@ mod tests {
     fn ipc_zero_copy_decoder_handles_misaligned_input() {
         let array = UInt64Array::from(vec![1, 2, 3, 4, 5, 6, 7, 8]);
         let data = array.into_data();
-        let encoded = encode_arrow_ipc(&data).unwrap();
+        let encoded = encode_arrow_ipc_data(&data).unwrap();
 
         // Force a 1-byte-offset (deliberately misaligned) backing buffer.
         let mut shifted = Vec::with_capacity(encoded.len() + 1);
@@ -341,7 +423,7 @@ mod tests {
         shifted.extend_from_slice(&encoded);
         let buffer = arrow::buffer::Buffer::from_vec(shifted).slice(1);
 
-        let decoded = decode_arrow_ipc_zero_copy(buffer).unwrap();
+        let decoded = decode_arrow_ipc_zero_copy_raw(buffer).unwrap();
         assert_eq!(data, decoded);
     }
 
@@ -349,8 +431,8 @@ mod tests {
     fn ipc_roundtrip_string() {
         let array = StringArray::from(vec!["hello", "world"]);
         let data = array.into_data();
-        let encoded = encode_arrow_ipc(&data).unwrap();
-        let decoded = decode_arrow_ipc(&encoded).unwrap();
+        let encoded = encode_arrow_ipc_data(&data).unwrap();
+        let decoded = decode_arrow_ipc_data(&encoded).unwrap();
         assert_eq!(data, decoded);
     }
 
@@ -358,8 +440,8 @@ mod tests {
     fn ipc_roundtrip_empty_array() {
         let array = UInt64Array::from(Vec::<u64>::new());
         let data = array.into_data();
-        let encoded = encode_arrow_ipc(&data).unwrap();
-        let decoded = decode_arrow_ipc(&encoded).unwrap();
+        let encoded = encode_arrow_ipc_data(&data).unwrap();
+        let decoded = decode_arrow_ipc_data(&encoded).unwrap();
         assert_eq!(data.len(), decoded.len());
     }
 
@@ -372,8 +454,8 @@ mod tests {
     fn ipc_roundtrip_empty_typed_array_preserves_type() {
         use arrow::array::Float32Array;
         let data = Float32Array::from(Vec::<f32>::new()).into_data();
-        let encoded = encode_arrow_ipc(&data).unwrap();
-        let decoded = decode_arrow_ipc(&encoded).unwrap();
+        let encoded = encode_arrow_ipc_data(&data).unwrap();
+        let decoded = decode_arrow_ipc_data(&encoded).unwrap();
         assert_eq!(decoded.data_type(), &arrow_schema::DataType::Float32);
         assert_eq!(decoded.len(), 0);
     }
@@ -382,8 +464,8 @@ mod tests {
     fn ipc_roundtrip_with_nulls() {
         let array = UInt64Array::from(vec![Some(1), None, Some(3)]);
         let data = array.into_data();
-        let encoded = encode_arrow_ipc(&data).unwrap();
-        let decoded = decode_arrow_ipc(&encoded).unwrap();
+        let encoded = encode_arrow_ipc_data(&data).unwrap();
+        let decoded = decode_arrow_ipc_data(&encoded).unwrap();
         assert_eq!(data, decoded);
     }
 }

--- a/apis/rust/node/src/node/arrow_utils/ipc_encode.rs
+++ b/apis/rust/node/src/node/arrow_utils/ipc_encode.rs
@@ -359,11 +359,11 @@ pub(crate) fn ipc_fast_path_len_data(array: &ArrayData) -> Option<usize> {
 ///
 /// ```
 /// # fn main() -> eyre::Result<()> {
-/// use dora_node_api::arrow::array::{Array, UInt64Array};
 /// use dora_node_api::arrow_utils::decode_arrow_ipc;
 /// use dora_node_api::arrow_utils::ipc_encode::PreparedIpc;
+/// use dora_node_api::{IntoArrow, into_vec};
 ///
-/// let data = UInt64Array::from(vec![1, 2, 3]).into_data();
+/// let data = vec![1u64, 2, 3].into_arrow();
 ///
 /// // Prepare once, size the destination from `byte_len()`, then encode into it.
 /// let prepared = PreparedIpc::new(&data).expect("primitive array is fast-path eligible");
@@ -372,7 +372,7 @@ pub(crate) fn ipc_fast_path_len_data(array: &ArrayData) -> Option<usize> {
 ///
 /// // The buffer is a self-describing IPC stream, identical to `encode_ipc_into`.
 /// let decoded = decode_arrow_ipc(&buffer)?;
-/// assert_eq!(decoded, UInt64Array::from(vec![1, 2, 3]).into_data());
+/// assert_eq!(into_vec::<u64>(&decoded)?, vec![1, 2, 3]);
 /// # Ok(())
 /// # }
 /// ```

--- a/apis/rust/node/src/node/arrow_utils/ipc_encode.rs
+++ b/apis/rust/node/src/node/arrow_utils/ipc_encode.rs
@@ -41,7 +41,8 @@ use arrow::ipc::{Buffer as IpcBuffer, FieldNode, MessageHeader, MetadataVersion}
 use arrow_schema::{DataType, Field, Schema};
 use eyre::{Context, bail, eyre};
 
-use super::ARROW_BUFFER_ALIGNMENT as ALIGN;
+use super::{ARROW_BUFFER_ALIGNMENT as ALIGN, IpcPayload};
+use dora_arrow_convert::{DoraArray, internal::array_ref};
 
 /// IPC stream continuation marker (precedes every message length prefix).
 const CONTINUATION_MARKER: [u8; 4] = [0xff, 0xff, 0xff, 0xff];
@@ -337,7 +338,7 @@ fn prepare(array: &ArrayData) -> Option<Prepared> {
 /// `ipc_fast_path_len(a)` then `encode_ipc_into(a, dst)` builds the layout and
 /// both flatbuffer headers twice. On the hot send path prefer [`PreparedIpc`],
 /// which prepares once and reuses the result for both steps.
-pub fn ipc_fast_path_len(array: &ArrayData) -> Option<usize> {
+pub(crate) fn ipc_fast_path_len_data(array: &ArrayData) -> Option<usize> {
     prepare(array).map(|p| p.total)
 }
 
@@ -380,7 +381,12 @@ pub struct PreparedIpc(Prepared);
 impl PreparedIpc {
     /// Prepare the fast-path encode for `array`, or `None` if `array` is not
     /// fast-path eligible (fall back to [`encode_ipc_to_vec`]).
-    pub fn new(array: &ArrayData) -> Option<Self> {
+    pub fn new(array: &DoraArray) -> Option<Self> {
+        Self::from_data(&array_ref(array).to_data())
+    }
+
+    /// Same, for dora-internal callers that already hold an [`ArrayData`].
+    pub(crate) fn from_data(array: &ArrayData) -> Option<Self> {
         prepare(array).map(Self)
     }
 
@@ -418,7 +424,7 @@ fn write_framed_message(dst: &mut [u8], at: usize, flatbuffer: &[u8]) -> usize {
 /// `dst.len()` must equal [`ipc_fast_path_len(array)`](ipc_fast_path_len);
 /// `array` must be fast-path eligible (it is when `ipc_fast_path_len` returned
 /// `Some`).
-pub fn encode_ipc_into(array: &ArrayData, dst: &mut [u8]) -> eyre::Result<()> {
+pub(crate) fn encode_ipc_into_data(array: &ArrayData, dst: &mut [u8]) -> eyre::Result<()> {
     let prepared =
         prepare(array).ok_or_else(|| eyre!("array is not Arrow IPC fast-path eligible"))?;
     encode_prepared_into(&prepared, dst)
@@ -478,7 +484,12 @@ fn write_body(dst: &mut [u8], body_start: usize, layout: &Layout) {
 /// persistent [`StreamDecoder`](arrow::ipc::reader::StreamDecoder) to prime it,
 /// then decodes a sequence of schema-less batch messages from
 /// [`encode_batch_into`] against the same decoder (the W3 schema-once path).
-pub fn encode_schema_message(data_type: &DataType) -> eyre::Result<Vec<u8>> {
+pub fn encode_schema_message(array: &DoraArray) -> eyre::Result<Vec<u8>> {
+    encode_schema_message_for(array_ref(array).data_type())
+}
+
+/// Same, for dora-internal callers that already hold an Arrow `DataType`.
+pub(crate) fn encode_schema_message_for(data_type: &DataType) -> eyre::Result<Vec<u8>> {
     let schema_message = build_schema_message(data_type)?;
     let block = round_up(PREFIX_LEN + schema_message.len(), ALIGN);
     let mut dst = vec![0u8; block];
@@ -489,7 +500,7 @@ pub fn encode_schema_message(data_type: &DataType) -> eyre::Result<Vec<u8>> {
 /// Exact byte length of the schema-less batch message [`encode_batch_into`]
 /// would write (record-batch header block + body + 8-byte end-of-stream marker,
 /// **no** schema prefix), or `None` if `array` is not fast-path eligible.
-pub fn batch_fast_path_len(array: &ArrayData) -> Option<usize> {
+pub(crate) fn batch_fast_path_len_data(array: &ArrayData) -> Option<usize> {
     let prepared = prepare(array)?;
     Some(prepared.record_batch_block + prepared.layout.body_len + PREFIX_LEN)
 }
@@ -500,7 +511,7 @@ pub fn batch_fast_path_len(array: &ArrayData) -> Option<usize> {
 /// the matching [`encode_schema_message`]. The trailing marker lets the decoder
 /// flush a 0-row batch (empty body); a non-empty batch never reads it. `dst.len()`
 /// must equal [`batch_fast_path_len(array)`](batch_fast_path_len).
-pub fn encode_batch_into(array: &ArrayData, dst: &mut [u8]) -> eyre::Result<()> {
+pub(crate) fn encode_batch_into_data(array: &ArrayData, dst: &mut [u8]) -> eyre::Result<()> {
     let prepared =
         prepare(array).ok_or_else(|| eyre!("array is not Arrow IPC fast-path eligible"))?;
     let expected = prepared.record_batch_block + prepared.layout.body_len + PREFIX_LEN;
@@ -524,8 +535,47 @@ pub fn encode_batch_into(array: &ArrayData, dst: &mut [u8]) -> eyre::Result<()> 
 /// Fallback encoder for any array (including non-fast-path types): produce a
 /// full Arrow IPC stream `Vec` via the official writer. The caller copies this
 /// into the sample, so this path costs two payload copies.
-pub fn encode_ipc_to_vec(array: &ArrayData) -> eyre::Result<Vec<u8>> {
-    super::encode_arrow_ipc(array).context("Arrow IPC fallback encode")
+pub(crate) fn encode_ipc_to_vec_data(array: &ArrayData) -> eyre::Result<Vec<u8>> {
+    super::encode_arrow_ipc_data(array).context("Arrow IPC fallback encode")
+}
+
+/// Exact byte length of the Arrow IPC stream [`encode_ipc_into`] would write
+/// for `array`, or `None` if `array` is not fast-path eligible.
+///
+/// Sizing and encoding both build the layout internally, so a caller that does
+/// `ipc_fast_path_len(a)` then `encode_ipc_into(a, dst)` does the work twice.
+/// On the hot send path prefer [`PreparedIpc`], which prepares once.
+pub fn ipc_fast_path_len(array: &DoraArray) -> Option<usize> {
+    ipc_fast_path_len_data(&array_ref(array).to_data())
+}
+
+/// Encode `array` as a complete Arrow IPC stream directly into `dst`, copying
+/// each array buffer exactly once.
+///
+/// `dst.len()` must equal [`ipc_fast_path_len(array)`](ipc_fast_path_len);
+/// `array` must be fast-path eligible (it is when `ipc_fast_path_len` returned
+/// `Some`).
+pub fn encode_ipc_into(array: &DoraArray, dst: &mut [u8]) -> eyre::Result<()> {
+    encode_ipc_into_data(&array_ref(array).to_data(), dst)
+}
+
+/// Exact byte length of the schema-less batch message [`encode_batch_into`]
+/// would write, or `None` if `array` is not fast-path eligible.
+pub fn batch_fast_path_len(array: &DoraArray) -> Option<usize> {
+    batch_fast_path_len_data(&array_ref(array).to_data())
+}
+
+/// Encode `array` as a schema-less Arrow IPC **batch message** into `dst`.
+/// `dst.len()` must equal [`batch_fast_path_len(array)`](batch_fast_path_len).
+pub fn encode_batch_into(array: &DoraArray, dst: &mut [u8]) -> eyre::Result<()> {
+    encode_batch_into_data(&array_ref(array).to_data(), dst)
+}
+
+/// Fallback encoder for any array (including non-fast-path types): produce a
+/// full Arrow IPC stream `Vec` via the official writer. The caller copies this
+/// into the sample, so this path costs two payload copies.
+pub fn encode_ipc_to_vec(array: &DoraArray) -> eyre::Result<Vec<u8>> {
+    encode_ipc_to_vec_data(&array_ref(array).to_data())
 }
 
 /// IPC layout of a `UInt8` array of `data_len` elements (no nulls): the byte
@@ -795,7 +845,12 @@ impl InputDecoder {
     /// full stream received in-band): prime a fresh decoder with it and retain
     /// the bytes for later local re-priming. A no-op when the live decoder is
     /// already primed with `hash`.
-    pub fn set_schema(&mut self, hash: u64, schema: ArrowBuffer) -> eyre::Result<()> {
+    pub fn set_schema(&mut self, hash: u64, schema: IpcPayload) -> eyre::Result<()> {
+        self.set_schema_raw(hash, schema.into_arrow())
+    }
+
+    /// Same, for dora-internal callers that already hold an Arrow buffer.
+    pub(crate) fn set_schema_raw(&mut self, hash: u64, schema: ArrowBuffer) -> eyre::Result<()> {
         check_ipc_size(schema.len())?;
         if self.schema_hash == Some(hash) {
             return Ok(());
@@ -831,6 +886,17 @@ impl InputDecoder {
     /// next schema publish, or the producer's periodic full-stream refresh —
     /// which primes in-band — will prime it).
     pub fn decode_batch(
+        &mut self,
+        buffer: IpcPayload,
+        hash: u64,
+    ) -> eyre::Result<Option<DoraArray>> {
+        Ok(self
+            .decode_batch_raw(buffer.into_arrow(), hash)?
+            .map(dora_arrow_convert::internal::from_array_data))
+    }
+
+    /// Same, for dora-internal callers that already hold an Arrow buffer.
+    pub(crate) fn decode_batch_raw(
         &mut self,
         buffer: ArrowBuffer,
         hash: u64,
@@ -957,7 +1023,7 @@ fn decode_one_batch(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::arrow_utils::decode_arrow_ipc_zero_copy;
+    use crate::arrow_utils::decode_arrow_ipc_zero_copy_raw;
     use arrow::array::{
         Array, ArrayRef, BooleanArray, FixedSizeBinaryArray, Float32Array, Int32Array,
         LargeStringArray, ListArray, NullArray, StringArray, StructArray, UInt8Array, UInt64Array,
@@ -970,9 +1036,9 @@ mod tests {
 
     /// Encode via the fast path into a fresh `Vec` sized by `ipc_fast_path_len`.
     fn fast_encode(array: &ArrayData) -> Vec<u8> {
-        let len = ipc_fast_path_len(array).expect("array should be fast-path eligible");
+        let len = ipc_fast_path_len_data(array).expect("array should be fast-path eligible");
         let mut buf = vec![0u8; len];
-        encode_ipc_into(array, &mut buf).expect("fast-path encode");
+        encode_ipc_into_data(array, &mut buf).expect("fast-path encode");
         buf
     }
 
@@ -1013,16 +1079,16 @@ mod tests {
         assert_eq!(array, &decoded, "fast-path stream must decode to the input");
         // Our own zero-copy decoder must agree too.
         let (buffer, _, _) = aligned_buffer(&encoded);
-        let zc = decode_arrow_ipc_zero_copy(buffer).expect("zero-copy decode");
+        let zc = decode_arrow_ipc_zero_copy_raw(buffer).expect("zero-copy decode");
         assert_eq!(array, &zc, "zero-copy decode must equal the input");
     }
 
     /// Encode `array` as a schema-less batch message (the fast path's
     /// `batch_slice` equivalent), as shipped on the schema-once data plane.
     fn batch_bytes(array: &ArrayData) -> Vec<u8> {
-        let len = batch_fast_path_len(array).unwrap();
+        let len = batch_fast_path_len_data(array).unwrap();
         let mut buf = vec![0u8; len];
-        encode_batch_into(array, &mut buf).unwrap();
+        encode_batch_into_data(array, &mut buf).unwrap();
         buf
     }
 
@@ -1036,33 +1102,44 @@ mod tests {
     /// primed for.
     #[test]
     fn input_decoder_schema_then_batches() {
-        let f32_schema = || Buffer::from_vec(encode_schema_message(&DataType::Float32).unwrap());
+        let f32_schema =
+            || Buffer::from_vec(encode_schema_message_for(&DataType::Float32).unwrap());
 
         let mut dec = InputDecoder::new();
 
         // A batch arriving before any schema is dropped (not primed).
         let early = Float32Array::from(vec![9.0]).into_data();
-        assert!(dec.decode_batch(batch_buf(&early), 7).unwrap().is_none());
+        assert!(
+            dec.decode_batch_raw(batch_buf(&early), 7)
+                .unwrap()
+                .is_none()
+        );
 
         // Installing the schema primes the decoder; following batches decode.
-        dec.set_schema(7, f32_schema()).unwrap();
+        dec.set_schema_raw(7, f32_schema()).unwrap();
         for vals in [vec![1.0f32, 2.0, 3.0], vec![4.0], vec![5.0, 6.0, 7.0]] {
             let array = Float32Array::from(vals).into_data();
             assert_eq!(
-                dec.decode_batch(batch_buf(&array), 7).unwrap().unwrap(),
+                dec.decode_batch_raw(batch_buf(&array), 7).unwrap().unwrap(),
                 array
             );
         }
 
         // A batch tagged with a hash the decoder isn't primed for is dropped.
         let other = Float32Array::from(vec![8.0]).into_data();
-        assert!(dec.decode_batch(batch_buf(&other), 99).unwrap().is_none());
+        assert!(
+            dec.decode_batch_raw(batch_buf(&other), 99)
+                .unwrap()
+                .is_none()
+        );
 
         // Installing a schema under the new hash primes it; its batches decode.
-        dec.set_schema(99, f32_schema()).unwrap();
+        dec.set_schema_raw(99, f32_schema()).unwrap();
         let after = Float32Array::from(vec![10.0, 11.0]).into_data();
         assert_eq!(
-            dec.decode_batch(batch_buf(&after), 99).unwrap().unwrap(),
+            dec.decode_batch_raw(batch_buf(&after), 99)
+                .unwrap()
+                .unwrap(),
             after
         );
     }
@@ -1075,23 +1152,26 @@ mod tests {
     /// schema that later schema-less batches reference, silently dropping them.
     #[test]
     fn input_decoder_retains_multiple_schemas() {
-        let schema_msg = |dt: &DataType| Buffer::from_vec(encode_schema_message(dt).unwrap());
+        let schema_msg = |dt: &DataType| Buffer::from_vec(encode_schema_message_for(dt).unwrap());
 
         let mut dec = InputDecoder::new();
-        dec.set_schema(1, schema_msg(&DataType::Float32)).unwrap();
-        dec.set_schema(2, schema_msg(&DataType::Int32)).unwrap();
+        dec.set_schema_raw(1, schema_msg(&DataType::Float32))
+            .unwrap();
+        dec.set_schema_raw(2, schema_msg(&DataType::Int32)).unwrap();
 
         // Live decoder is primed for hash 2 …
         let ints = Int32Array::from(vec![1, 2, 3]).into_data();
         assert_eq!(
-            dec.decode_batch(batch_buf(&ints), 2).unwrap().unwrap(),
+            dec.decode_batch_raw(batch_buf(&ints), 2).unwrap().unwrap(),
             ints
         );
 
         // … but a batch for hash 1 must still decode (retained schema).
         let floats = Float32Array::from(vec![4.0, 5.0]).into_data();
         assert_eq!(
-            dec.decode_batch(batch_buf(&floats), 1).unwrap().unwrap(),
+            dec.decode_batch_raw(batch_buf(&floats), 1)
+                .unwrap()
+                .unwrap(),
             floats,
             "a schema installed earlier must be retained across later primes"
         );
@@ -1099,7 +1179,9 @@ mod tests {
         // And switching back again also works.
         let more_ints = Int32Array::from(vec![6]).into_data();
         assert_eq!(
-            dec.decode_batch(batch_buf(&more_ints), 2).unwrap().unwrap(),
+            dec.decode_batch_raw(batch_buf(&more_ints), 2)
+                .unwrap()
+                .unwrap(),
             more_ints
         );
     }
@@ -1110,11 +1192,12 @@ mod tests {
     /// schema-once fast path — which this exercises across five batches.
     #[test]
     fn input_decoder_handles_sequential_batches_arrow_59_terminal_state() {
-        let f32_schema = || Buffer::from_vec(encode_schema_message(&DataType::Float32).unwrap());
+        let f32_schema =
+            || Buffer::from_vec(encode_schema_message_for(&DataType::Float32).unwrap());
 
         let mut dec = InputDecoder::new();
         // Prime with a schema.
-        dec.set_schema(7, f32_schema()).unwrap();
+        dec.set_schema_raw(7, f32_schema()).unwrap();
 
         // Decode 5 schema-less batches sequentially. Each one should decode
         // correctly; because they are non-empty, the decoder is reused across
@@ -1128,7 +1211,7 @@ mod tests {
         ];
 
         for (i, batch) in batches.iter().enumerate() {
-            let result = dec.decode_batch(batch_buf(batch), 7);
+            let result = dec.decode_batch_raw(batch_buf(batch), 7);
             assert!(
                 result.is_ok(),
                 "batch {} decode failed: {:?}",
@@ -1155,10 +1238,11 @@ mod tests {
     /// staying primed throughout.
     #[test]
     fn input_decoder_handles_empty_and_nonempty_batches() {
-        let f32_schema = || Buffer::from_vec(encode_schema_message(&DataType::Float32).unwrap());
+        let f32_schema =
+            || Buffer::from_vec(encode_schema_message_for(&DataType::Float32).unwrap());
 
         let mut dec = InputDecoder::new();
-        dec.set_schema(7, f32_schema()).unwrap();
+        dec.set_schema_raw(7, f32_schema()).unwrap();
 
         let empty = Float32Array::from(Vec::<f32>::new()).into_data();
         let batches = [
@@ -1171,7 +1255,7 @@ mod tests {
 
         for (i, batch) in batches.iter().enumerate() {
             let decoded = dec
-                .decode_batch(batch_buf(batch), 7)
+                .decode_batch_raw(batch_buf(batch), 7)
                 .unwrap_or_else(|e| panic!("batch {i} decode failed: {e:?}"))
                 .unwrap_or_else(|| panic!("batch {i} was dropped"));
             assert_eq!(&decoded, batch, "batch {i} mismatch");
@@ -1191,21 +1275,24 @@ mod tests {
     /// oldest, whose batches then drop until it is re-installed.
     #[test]
     fn input_decoder_evicts_oldest_schema_beyond_cap() {
-        let f32_schema = || Buffer::from_vec(encode_schema_message(&DataType::Float32).unwrap());
+        let f32_schema =
+            || Buffer::from_vec(encode_schema_message_for(&DataType::Float32).unwrap());
 
         let mut dec = InputDecoder::new();
         // Install cap + 1 distinct hashes (same schema bytes — only the hash
         // keys retention); hash 0 must be evicted, the rest retained.
         for hash in 0..=(MAX_RETAINED_SCHEMAS as u64) {
-            dec.set_schema(hash, f32_schema()).unwrap();
+            dec.set_schema_raw(hash, f32_schema()).unwrap();
         }
         let array = Float32Array::from(vec![1.0]).into_data();
         assert!(
-            dec.decode_batch(batch_buf(&array), 0).unwrap().is_none(),
+            dec.decode_batch_raw(batch_buf(&array), 0)
+                .unwrap()
+                .is_none(),
             "the oldest schema must be evicted beyond the cap"
         );
         assert_eq!(
-            dec.decode_batch(batch_buf(&array), 1).unwrap().unwrap(),
+            dec.decode_batch_raw(batch_buf(&array), 1).unwrap().unwrap(),
             array,
             "schemas within the cap must be retained"
         );
@@ -1218,16 +1305,16 @@ mod tests {
     #[test]
     fn decode_batch_resets_on_error_then_reprimes() {
         let mut dec = InputDecoder::new();
-        dec.set_schema(
+        dec.set_schema_raw(
             7,
-            Buffer::from_vec(encode_schema_message(&DataType::Float32).unwrap()),
+            Buffer::from_vec(encode_schema_message_for(&DataType::Float32).unwrap()),
         )
         .unwrap();
 
         // A valid batch decodes.
         let good = Float32Array::from(vec![4.0, 5.0]).into_data();
         assert_eq!(
-            dec.decode_batch(batch_buf(&good), 7).unwrap().unwrap(),
+            dec.decode_batch_raw(batch_buf(&good), 7).unwrap().unwrap(),
             good
         );
 
@@ -1238,13 +1325,16 @@ mod tests {
         let dropped = Float32Array::from(vec![6.0, 7.0, 8.0, 9.0]).into_data();
         let mut truncated = batch_bytes(&dropped);
         truncated.truncate(truncated.len() / 2);
-        assert!(dec.decode_batch(Buffer::from_vec(truncated), 7).is_err());
+        assert!(
+            dec.decode_batch_raw(Buffer::from_vec(truncated), 7)
+                .is_err()
+        );
 
         // The next valid batch (same hash) re-primes from the retained schema and
         // decodes correctly — not dropped, not corrupted.
         let after = Float32Array::from(vec![10.0, 11.0]).into_data();
         assert_eq!(
-            dec.decode_batch(batch_buf(&after), 7).unwrap().unwrap(),
+            dec.decode_batch_raw(batch_buf(&after), 7).unwrap().unwrap(),
             after,
             "after a failed batch the decoder must re-prime from the retained schema"
         );
@@ -1253,7 +1343,7 @@ mod tests {
         dec.reset();
         let final_batch = Float32Array::from(vec![12.0]).into_data();
         assert!(
-            dec.decode_batch(batch_buf(&final_batch), 7)
+            dec.decode_batch_raw(batch_buf(&final_batch), 7)
                 .unwrap()
                 .is_none(),
             "after a full reset the decoder must drop until a schema is re-installed"
@@ -1297,16 +1387,17 @@ mod tests {
         let first = dict(&["a", "b", "a", "c", "b"]);
         // Confirm this really exercises the fallback (not the fast path).
         assert!(
-            ipc_fast_path_len(&first).is_none(),
+            ipc_fast_path_len_data(&first).is_none(),
             "dictionary must route to the official-writer fallback"
         );
 
         // Prime from the schema block of the dictionary stream — exactly the
         // bytes the producer publishes on the `@schema` subtopic.
         let mut dec = InputDecoder::new();
-        let full0 = encode_ipc_to_vec(&first).unwrap();
+        let full0 = encode_ipc_to_vec_data(&first).unwrap();
         let block = schema_block_len(&full0).unwrap();
-        dec.set_schema(1, Buffer::from(&full0[..block])).unwrap();
+        dec.set_schema_raw(1, Buffer::from(&full0[..block]))
+            .unwrap();
 
         // Every message (including the first) ships only the schema-less batch
         // slice (which for a dictionary type carries a replacement dictionary
@@ -1314,7 +1405,7 @@ mod tests {
         // its own input.
         let slice0 = batch_slice(&full0).expect("fallback stream is a valid IPC stream");
         assert_eq!(
-            dec.decode_batch(Buffer::from(slice0), 1)
+            dec.decode_batch_raw(Buffer::from(slice0), 1)
                 .unwrap()
                 .expect("first batch decodes against the primed decoder"),
             first
@@ -1325,10 +1416,10 @@ mod tests {
             ["new", "values", "entirely"].as_slice(),
         ] {
             let arr = dict(words);
-            let full = encode_ipc_to_vec(&arr).unwrap();
+            let full = encode_ipc_to_vec_data(&arr).unwrap();
             let slice = batch_slice(&full).expect("fallback stream is a valid IPC stream");
             let got = dec
-                .decode_batch(Buffer::from(slice), 1)
+                .decode_batch_raw(Buffer::from(slice), 1)
                 .unwrap()
                 .expect("batch must decode against the primed decoder");
             assert_eq!(
@@ -1344,7 +1435,7 @@ mod tests {
     /// EOS terminates the decoder.)
     #[test]
     fn schema_primed_decoder_decodes_batch_sequence() {
-        let schema = encode_schema_message(&DataType::Float32).unwrap();
+        let schema = encode_schema_message_for(&DataType::Float32).unwrap();
         let mut decoder = StreamDecoder::new();
 
         // Prime: feeding the schema message yields no batch.
@@ -1358,9 +1449,9 @@ mod tests {
 
         for vals in [vec![1.0f32, 2.0, 3.0], vec![4.0, 5.0], vec![6.0]] {
             let array = Float32Array::from(vals).into_data();
-            let len = batch_fast_path_len(&array).unwrap();
+            let len = batch_fast_path_len_data(&array).unwrap();
             let mut buf = vec![0u8; len];
-            encode_batch_into(&array, &mut buf).unwrap();
+            encode_batch_into_data(&array, &mut buf).unwrap();
 
             let mut bbuf = Buffer::from_vec(buf);
             let mut got = None;
@@ -1479,7 +1570,7 @@ mod tests {
         assert_eq!(off, len - PREFIX_LEN);
         assert_eq!(read_official(&buf).len(), 0);
         let (buffer, _, _) = aligned_buffer(&buf);
-        let decoded = decode_arrow_ipc_zero_copy(buffer).unwrap();
+        let decoded = decode_arrow_ipc_zero_copy_raw(buffer).unwrap();
         assert_eq!(decoded.data_type(), &DataType::UInt8);
         assert_eq!(decoded.len(), 0);
     }
@@ -1491,21 +1582,21 @@ mod tests {
     /// drains. Regression guard for the empty-array drop reported on PR #2366.
     #[test]
     fn schema_once_zero_len_batch_roundtrip() {
-        let schema = || Buffer::from_vec(encode_schema_message(&DataType::UInt8).unwrap());
+        let schema = || Buffer::from_vec(encode_schema_message_for(&DataType::UInt8).unwrap());
         let batch = |vals: &[u8]| {
             let a = UInt8Array::from(vals.to_vec()).into_data();
-            let len = batch_fast_path_len(&a).unwrap();
+            let len = batch_fast_path_len_data(&a).unwrap();
             let mut b = vec![0u8; len];
-            encode_batch_into(&a, &mut b).unwrap();
+            encode_batch_into_data(&a, &mut b).unwrap();
             Buffer::from_vec(b)
         };
 
         let mut dec = InputDecoder::new();
-        dec.set_schema(1, schema()).unwrap();
+        dec.set_schema_raw(1, schema()).unwrap();
 
         // The empty batch decodes to a 0-row UInt8 array, not `Ok(None)`/error.
         let decoded = dec
-            .decode_batch(batch(&[]), 1)
+            .decode_batch_raw(batch(&[]), 1)
             .unwrap()
             .expect("0-row batch must decode, not drop");
         assert_eq!(decoded.data_type(), &DataType::UInt8);
@@ -1514,7 +1605,7 @@ mod tests {
         // The persistent decoder stays usable across mixed empty/non-empty
         // batches (flushing the empty body must not wedge or terminate it).
         for vals in [vec![1u8, 2, 3], vec![], vec![9u8], vec![]] {
-            let d = dec.decode_batch(batch(&vals), 1).unwrap().unwrap();
+            let d = dec.decode_batch_raw(batch(&vals), 1).unwrap().unwrap();
             assert_eq!(d.len(), vals.len());
             assert_eq!(d.data_type(), &DataType::UInt8);
         }
@@ -1535,9 +1626,9 @@ mod tests {
         let batch = batch_slice(&full).expect("batch slice of a valid stream");
 
         let mut dec = InputDecoder::new();
-        dec.set_schema(7, schema).unwrap();
+        dec.set_schema_raw(7, schema).unwrap();
         let decoded = dec
-            .decode_batch(Buffer::from(batch), 7)
+            .decode_batch_raw(Buffer::from(batch), 7)
             .unwrap()
             .expect("0-row batch via batch_slice must decode, not drop");
         assert_eq!(decoded.data_type(), &DataType::UInt8);
@@ -1675,7 +1766,7 @@ mod tests {
             .unwrap();
 
         assert!(
-            ipc_fast_path_len(&struct_data).is_some(),
+            ipc_fast_path_len_data(&struct_data).is_some(),
             "struct with an oversized child should stay on the fast path"
         );
         let decoded = read_official(&fast_encode(&struct_data));
@@ -1737,7 +1828,7 @@ mod tests {
         // (2) pointer aliasing: the decoded data buffer lies inside the input.
         {
             let (buffer, base, len) = aligned_buffer(&encoded);
-            let decoded = decode_arrow_ipc_zero_copy(buffer).unwrap();
+            let decoded = decode_arrow_ipc_zero_copy_raw(buffer).unwrap();
             let ptr = decoded.buffers()[0].as_ptr() as usize;
             assert!(
                 ptr >= base && ptr < base + len,
@@ -1766,9 +1857,9 @@ mod tests {
             .into_data()
             .slice(2, 2); // offset 2 -> not fast-path
         assert_eq!(array.offset(), 2);
-        assert!(ipc_fast_path_len(&array).is_none());
+        assert!(ipc_fast_path_len_data(&array).is_none());
 
-        let encoded = encode_ipc_to_vec(&array).unwrap();
+        let encoded = encode_ipc_to_vec_data(&array).unwrap();
         let decoded = read_official(&encoded);
         assert_eq!(array.len(), decoded.len());
         let dec = arrow::array::make_array(decoded);
@@ -1782,10 +1873,10 @@ mod tests {
         use arrow::array::StringViewArray;
         let array = StringViewArray::from(vec!["a", "bb", "ccc"]).into_data();
         assert!(
-            ipc_fast_path_len(&array).is_none(),
+            ipc_fast_path_len_data(&array).is_none(),
             "Utf8View is not fast-path eligible"
         );
-        let encoded = encode_ipc_to_vec(&array).unwrap();
+        let encoded = encode_ipc_to_vec_data(&array).unwrap();
         let decoded = read_official(&encoded);
         assert_eq!(array, decoded);
     }

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -11,6 +11,7 @@ use self::{arrow_utils::ipc_encode, control_channel::ControlChannel};
 use aligned_vec::{AVec, ConstAlign};
 use arrow::array::{Array, ArrayData};
 use colored::Colorize;
+use dora_arrow_convert::{DoraArray, IntoArrow};
 use dora_core::{
     config::{DataId, NodeId, NodeRunConfig},
     descriptor::Descriptor,
@@ -1552,16 +1553,17 @@ impl DoraNode {
         &mut self,
         output_id: DataId,
         parameters: MetadataParameters,
-        data: impl Array,
+        data: impl IntoArrow,
     ) -> NodeResult<()> {
         if !self.validate_output(&output_id) {
             return Ok(());
         };
 
-        let arrow_array = data.to_data();
+        let data = data.into_arrow();
+        let arrow_array = dora_arrow_convert::internal::array_ref(&data).to_data();
         self.check_output_type(&output_id, arrow_array.data_type(), &parameters)?;
 
-        let encoded = self.sample_allocator.encode_arrow(&arrow_array)?;
+        let encoded = self.sample_allocator.encode_arrow_data(&arrow_array)?;
         self.send_encoded_unchecked(output_id, parameters, encoded.sample)
     }
 
@@ -2304,7 +2306,7 @@ impl DoraNode {
         &mut self,
         output_id: DataId,
         mut parameters: MetadataParameters,
-        data: impl Array,
+        data: impl IntoArrow,
     ) -> NodeResult<String> {
         if parameters.contains_key(dora_message::metadata::REQUEST_ID) {
             tracing::warn!("send_service_request: caller-provided request_id will be overwritten");
@@ -2326,7 +2328,7 @@ impl DoraNode {
         &mut self,
         output_id: DataId,
         parameters: MetadataParameters,
-        data: impl Array,
+        data: impl IntoArrow,
     ) -> NodeResult<()> {
         self.send_output(output_id, parameters, data)
     }
@@ -2343,7 +2345,7 @@ impl DoraNode {
         output_id: DataId,
         segment: &mut StreamSegment,
         fin: bool,
-        data: impl Array,
+        data: impl IntoArrow,
     ) -> NodeResult<()> {
         self.send_output(output_id, segment.chunk(fin), data)
     }
@@ -2741,7 +2743,28 @@ pub struct EncodedSample {
 }
 
 impl EncodedSample {
+    /// A human-readable name for the Arrow type the payload was encoded from,
+    /// e.g. `"UInt8"`.
+    ///
+    /// Returned as a `String` rather than an `arrow_schema::DataType` because
+    /// `arrow-schema` is the one non-umbrella Arrow crate dora's public API
+    /// used to name, and naming it would pin 1.x to a single Arrow major.
+    /// For the real type, enable `arrow-v59` and use
+    /// [`data_type`](Self::data_type).
+    pub fn type_name(&self) -> String {
+        format!("{:?}", self.data_type)
+    }
+
     /// The Arrow type the payload was encoded from.
+    ///
+    /// Gated on `arrow-v59` — dora's current internal Arrow major — because
+    /// `arrow_schema::DataType` is an Arrow type. It is not returned as a
+    /// dora-owned type-URN (`dora_core::types::TypeRegistry`) because the URN
+    /// catalog only covers the standard scalar/struct types: nested lists,
+    /// dictionaries, timestamps-with-timezone and unions have no URN, so a
+    /// URN-returning accessor would be lossy for exactly the outputs whose
+    /// type a caller most needs to inspect.
+    #[cfg(feature = "arrow-v59")]
     pub fn data_type(&self) -> &arrow_schema::DataType {
         &self.data_type
     }
@@ -2836,8 +2859,13 @@ impl SampleAllocator {
     /// The returned sample shares no memory with `array`, so the caller may —
     /// and, when the payload is owned by a foreign runtime, **must** — drop
     /// `array` on its own thread rather than let it travel to the node.
-    pub fn encode_arrow(&self, array: &ArrayData) -> NodeResult<EncodedSample> {
-        let sample = match ipc_encode::PreparedIpc::new(array) {
+    pub fn encode_arrow(&self, array: &DoraArray) -> NodeResult<EncodedSample> {
+        self.encode_arrow_data(&dora_arrow_convert::internal::array_ref(array).to_data())
+    }
+
+    /// Same, for dora-internal callers that already hold an [`ArrayData`].
+    pub(crate) fn encode_arrow_data(&self, array: &ArrayData) -> NodeResult<EncodedSample> {
+        let sample = match ipc_encode::PreparedIpc::from_data(array) {
             Some(prepared) => {
                 // Prepare once: size the sample from the prepared layout, then
                 // encode into it — avoids rebuilding the layout + IPC headers.
@@ -2848,7 +2876,7 @@ impl SampleAllocator {
                 sample
             }
             None => {
-                let bytes = ipc_encode::encode_ipc_to_vec(array)
+                let bytes = ipc_encode::encode_ipc_to_vec_data(array)
                     .map_err(|e| NodeError::Output(format!("Arrow IPC encode: {e}")))?;
                 let mut sample = self.allocate(bytes.len())?;
                 sample.copy_from_slice(&bytes);
@@ -3401,7 +3429,6 @@ mod tests {
         IntegrationTestInput, TestingInput, TestingOptions, TestingOutput,
         integration_testing_format::{IncomingEvent, TimedIncomingEvent},
     };
-    use arrow::array::NullArray;
 
     fn required_acker(node: &str, input: &str) -> dora_message::daemon_to_node::RequiredAcker {
         dora_message::daemon_to_node::RequiredAcker {
@@ -3729,7 +3756,7 @@ mod tests {
         let (mut node, events, mut rx) = test_node();
 
         let request_id = node
-            .send_service_request("request".into(), Default::default(), NullArray::new(0))
+            .send_service_request("request".into(), Default::default(), ())
             .unwrap();
 
         // Returned ID should be a valid UUID
@@ -3748,10 +3775,10 @@ mod tests {
         let (mut node, events, _rx) = test_node();
 
         let id1 = node
-            .send_service_request("out".into(), Default::default(), NullArray::new(0))
+            .send_service_request("out".into(), Default::default(), ())
             .unwrap();
         let id2 = node
-            .send_service_request("out".into(), Default::default(), NullArray::new(0))
+            .send_service_request("out".into(), Default::default(), ())
             .unwrap();
 
         assert_ne!(id1, id2, "successive request IDs should differ");
@@ -3770,7 +3797,7 @@ mod tests {
             dora_message::metadata::REQUEST_ID.to_string(),
             dora_message::metadata::Parameter::String("test-req-id".into()),
         );
-        node.send_service_response("response".into(), params, NullArray::new(0))
+        node.send_service_response("response".into(), params, ())
             .unwrap();
 
         drop(node);
@@ -3823,16 +3850,16 @@ mod tests {
     /// plane relies on (zenoh can't be smoke-tested here, so this stands in).
     #[test]
     fn send_output_ipc_roundtrip() {
-        use crate::arrow_utils::decode_arrow_ipc_zero_copy;
-        use crate::arrow_utils::ipc_encode::{encode_ipc_into, ipc_fast_path_len};
+        use crate::arrow_utils::decode_arrow_ipc_zero_copy_raw;
+        use crate::arrow_utils::ipc_encode::{encode_ipc_into_data, ipc_fast_path_len_data};
         use arrow::array::{ArrayRef, Float32Array, StringArray, StructArray, UInt64Array};
         use arrow_schema::{DataType, Field};
         use std::ptr::NonNull;
 
         fn roundtrip(data: ArrayData) {
-            let len = ipc_fast_path_len(&data).expect("array should be fast-path eligible");
+            let len = ipc_fast_path_len_data(&data).expect("array should be fast-path eligible");
             let mut buf: AVec<u8, ConstAlign<128>> = AVec::__from_elem(128, 0, len);
-            encode_ipc_into(&data, &mut buf).expect("fast-path IPC encode");
+            encode_ipc_into_data(&data, &mut buf).expect("fast-path IPC encode");
 
             // Wrap the aligned sample as an Arrow Buffer (no copy), mirroring the
             // receive path, then decode.
@@ -3841,7 +3868,7 @@ mod tests {
             // SAFETY: ptr/len describe `buf`; the Arc keeps it alive.
             let buffer =
                 unsafe { arrow::buffer::Buffer::from_custom_allocation(ptr, blen, Arc::new(buf)) };
-            let decoded = decode_arrow_ipc_zero_copy(buffer).expect("zero-copy IPC decode");
+            let decoded = decode_arrow_ipc_zero_copy_raw(buffer).expect("zero-copy IPC decode");
             assert_eq!(
                 data, decoded,
                 "IPC send->receive round-trip must preserve the array"
@@ -4106,7 +4133,7 @@ mod tests {
         let (mut node, events, mut rx) = test_node();
         let mut seg = StreamSegment::with_session_id("s1".into());
 
-        node.send_stream_chunk("audio".into(), &mut seg, false, NullArray::new(0))
+        node.send_stream_chunk("audio".into(), &mut seg, false, ())
             .unwrap();
 
         drop(node);
@@ -4237,7 +4264,7 @@ mod operator_boundary_tests {
         let (array, released) = foreign_owned_array(8192);
 
         let sample = allocator
-            .encode_arrow(&array)
+            .encode_arrow_data(&array)
             .expect("encoding a UInt8 array must succeed");
 
         assert!(
@@ -4260,9 +4287,9 @@ mod operator_boundary_tests {
         let allocator = SampleAllocator::heap();
         let (array, _released) = foreign_owned_array(1024);
 
-        let encoded = allocator.encode_arrow(&array).expect("encode");
-        assert_eq!(encoded.data_type(), array.data_type());
-        let decoded = crate::node::arrow_utils::decode_arrow_ipc(encoded.as_bytes())
+        let encoded = allocator.encode_arrow_data(&array).expect("encode");
+        assert_eq!(encoded.type_name(), format!("{:?}", array.data_type()));
+        let decoded = crate::node::arrow_utils::decode_arrow_ipc_data(encoded.as_bytes())
             .expect("the sample must be a well-formed Arrow IPC stream");
 
         assert_eq!(decoded, array);

--- a/apis/rust/node/tests/copy_count.rs
+++ b/apis/rust/node/tests/copy_count.rs
@@ -29,7 +29,8 @@
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use dora_node_api::arrow::array::{Array, Float32Array};
+use arrow::array::Float32Array;
+use dora_node_api::DoraArray;
 use dora_node_api::arrow_utils::ipc_encode::{
     encode_ipc_into, encode_ipc_to_vec, encode_uint8_ipc_header, ipc_fast_path_len, uint8_ipc_len,
 };
@@ -76,8 +77,10 @@ fn allocated_during<R>(f: impl FnOnce() -> R) -> (usize, R) {
 const ELEMENTS: usize = 1_048_576; // 1M f32 = 4 MiB payload
 const PAYLOAD: usize = ELEMENTS * 4;
 
-fn big_array() -> dora_node_api::arrow::array::ArrayData {
-    Float32Array::from((0..ELEMENTS).map(|i| i as f32).collect::<Vec<_>>()).into_data()
+fn big_array() -> DoraArray {
+    DoraArray::from_array(Float32Array::from(
+        (0..ELEMENTS).map(|i| i as f32).collect::<Vec<_>>(),
+    ))
 }
 
 /// Generous ceiling for "no payload-sized intermediate": headers, the flatbuffer

--- a/apis/rust/operator/Cargo.toml
+++ b/apis/rust/operator/Cargo.toml
@@ -11,6 +11,28 @@ repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+# Passthrough for `dora-arrow-convert`'s Arrow-major features, mirroring the
+# pair `dora-node-api` exposes. Operators receive `Event::Input { data:
+# DoraArray, .. }` and send `impl IntoArrow`, so every typed-array accessor
+# (`DoraArray::as_array` / `from_array` / `into_inner`, `IntoArrow for
+# ArrayRef`) sits behind one of these. Without the passthrough an operator
+# author has no way to enable them: the feature simply does not exist on this
+# crate, so `dora-operator-api/arrow-v59` fails resolution.
+#
+# `default = []` for the same reason as on `dora-node-api`: a node or operator
+# that never names an Arrow type never needs a major.
+default = []
+# dora's *internal* Arrow major. Also re-exports it as `arrow_v59` (see
+# `lib.rs`), so operators name the exact copy dora links.
+arrow-v59 = ["dora-arrow-convert/arrow-v59"]
+# An *older* major, reached through the Arrow C Data Interface. Unlike
+# `dora-node-api` this adds no aliased `arrow58` dependency and no `arrow_v58`
+# re-export: the bridge's `TryFrom` impls are what the feature is for, and a
+# caller wanting Arrow 58 already has it in their own manifest (that is why
+# they want the bridge), where cargo unifies it with dora's copy.
+arrow-v58 = ["dora-arrow-convert/arrow-v58"]
+
 [dependencies]
 dora-operator-api-macros = { workspace = true }
 dora-operator-api-types = { workspace = true }

--- a/apis/rust/operator/src/lib.rs
+++ b/apis/rust/operator/src/lib.rs
@@ -25,6 +25,31 @@ pub use dora_operator_api_types as types;
 pub use types::DoraStatus;
 use types::{Metadata, Output, SendOutput, arrow};
 
+/// dora's **internal** Arrow major, re-exported under a name that states it.
+///
+/// Enabled by the `arrow-v59` feature, which also unlocks
+/// [`DoraArray::as_array`] / [`DoraArray::from_array`] and `IntoArrow for
+/// ArrayRef`. Together they are what lets an operator read and send a typed
+/// Arrow array:
+///
+/// ```
+/// use dora_operator_api::{Event, arrow_v59::array::ArrayRef};
+///
+/// fn handle(event: &Event) {
+///     if let Event::Input { data, .. } = event {
+///         let array: &ArrayRef = data.as_array();
+///         println!("received {} rows", array.len());
+///     }
+/// }
+/// ```
+///
+/// This is deliberately not a bare `pub use arrow;`, for the same reason
+/// `dora_node_api::arrow_v59` is not: an unversioned re-export changes meaning
+/// silently when dora bumps its internal major, whereas `arrow_v59` either
+/// resolves or does not.
+#[cfg(feature = "arrow-v59")]
+pub use types::arrow as arrow_v59;
+
 pub mod raw;
 
 /// An event delivered to an operator's [`DoraOperator::on_event`] callback.
@@ -147,6 +172,34 @@ impl DoraOutputSender<'_> {
             },
         });
         result.into_result()
+    }
+}
+
+/// Guards the `arrow-v59` passthrough feature (see `Cargo.toml`). Operators
+/// are handed `DoraArray` and send `impl IntoArrow`; both the borrowing
+/// accessor and `IntoArrow for ArrayRef` live behind
+/// `dora-arrow-convert/arrow-v59`, which this crate has to forward for an
+/// operator author to be able to enable it at all.
+#[cfg(all(test, feature = "arrow-v59"))]
+mod arrow_v59_tests {
+    use super::*;
+    use arrow_v59::array::{ArrayRef, Int32Array};
+    use std::sync::Arc;
+
+    #[test]
+    fn typed_array_round_trips_through_dora_array() {
+        let array: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+
+        // Send side: `DoraOutputSender::send` takes `impl IntoArrow`.
+        let payload: DoraArray = array.into_arrow();
+        assert_eq!(payload.len(), 3);
+
+        // Receive side: `Event::Input { data: DoraArray, .. }`.
+        let received: &ArrayRef = payload.as_array();
+        assert_eq!(received.len(), 3);
+
+        // And building a payload from a concrete Arrow array.
+        assert_eq!(DoraArray::from_array(Int32Array::from(vec![7])).len(), 1);
     }
 }
 

--- a/apis/rust/operator/src/lib.rs
+++ b/apis/rust/operator/src/lib.rs
@@ -18,14 +18,12 @@
 #![warn(unsafe_op_in_unsafe_fn)]
 #![allow(clippy::missing_safety_doc)]
 
-pub use dora_arrow_convert::*;
+use dora_arrow_convert::internal::array_ref;
+pub use dora_arrow_convert::{DoraArray, IntoArrow, into_vec};
 pub use dora_operator_api_macros::register_operator;
 pub use dora_operator_api_types as types;
 pub use types::DoraStatus;
-use types::{
-    Metadata, Output, SendOutput,
-    arrow::{self, array::Array},
-};
+use types::{Metadata, Output, SendOutput, arrow};
 
 pub mod raw;
 
@@ -45,7 +43,7 @@ pub enum Event<'a> {
         /// Metadata associated with this input (e.g. OpenTelemetry context).
         metadata: &'a types::Metadata,
         /// The Arrow-encoded payload.
-        data: ArrowData,
+        data: DoraArray,
     },
     /// The payload for an input could not be decoded into an Arrow array.
     ///
@@ -136,9 +134,10 @@ impl DoraOutputSender<'_> {
     ///  Send an output from the operator:
     ///  - `id` is the `output_id` as defined in your dataflow.
     ///  - `data` is the data that should be sent
-    pub fn send(&mut self, id: &str, data: impl Array) -> Result<(), String> {
+    pub fn send(&mut self, id: &str, data: impl IntoArrow) -> Result<(), String> {
+        let data = data.into_arrow();
         let (data_array, schema) =
-            arrow::ffi::to_ffi(&data.into_data()).map_err(|err| err.to_string())?;
+            arrow::ffi::to_ffi(&array_ref(&data).to_data()).map_err(|err| err.to_string())?;
         let result = self.0.send_output.call(Output {
             id: id.to_owned().into(),
             data_array,

--- a/apis/rust/operator/src/raw.rs
+++ b/apis/rust/operator/src/raw.rs
@@ -79,7 +79,7 @@ pub unsafe fn dora_on_event<O: DoraOperator>(
             Ok(data) => Event::Input {
                 id: &input.id,
                 metadata: &input.metadata,
-                data: arrow::array::make_array(data).into(),
+                data: dora_arrow_convert::internal::from_array_data(data),
             },
             Err(err) => Event::InputParseError {
                 id: &input.id,

--- a/apis/rust/operator/types/src/lib.rs
+++ b/apis/rust/operator/types/src/lib.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::missing_safety_doc)]
 
 pub use arrow;
-use dora_arrow_convert::{ArrowData, IntoArrow};
+use dora_arrow_convert::{IntoArrow, internal::array_ref};
 pub use safer_ffi;
 
 use arrow::{
@@ -163,7 +163,7 @@ pub fn dora_free_input_id(_input_id: char_p_boxed) {}
 pub fn dora_read_data(input: &mut Input) -> Option<safer_ffi::Vec<u8>> {
     let data_array = input.data_array.take()?;
     let data = unsafe { arrow::ffi::from_ffi(data_array, &input.schema).ok()? };
-    let array = ArrowData(arrow::array::make_array(data));
+    let array = dora_arrow_convert::internal::from_array_data(data);
     let bytes: &[u8] = TryFrom::try_from(&array).ok()?;
     Some(bytes.to_owned().into())
 }
@@ -212,7 +212,7 @@ pub unsafe fn dora_send_operator_output(
         };
         let arrow_data = data.to_owned().into_arrow();
         let (data_array, schema) =
-            arrow::ffi::to_ffi(&arrow_data.into_data()).map_err(|err| err.to_string())?;
+            arrow::ffi::to_ffi(&array_ref(&arrow_data).to_data()).map_err(|err| err.to_string())?;
         let output = Output {
             id: id.to_str().to_owned().into(),
             data_array,

--- a/binaries/daemon/Cargo.toml
+++ b/binaries/daemon/Cargo.toml
@@ -34,7 +34,7 @@ flume = { workspace = true }
 dora-download = { workspace = true }
 dora-tracing = { workspace = true, optional = true }
 dora-arrow-convert = { workspace = true }
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true  }
 dora-message = { workspace = true }
 serde_yaml = { workspace = true }
 uuid = { workspace = true }

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -8547,7 +8547,6 @@ impl Daemon {
                 // the IPC stream, so set the `arrow-ipc` framing parameter.
                 use dora_arrow_convert::IntoArrow;
                 let array = json.as_str().into_arrow();
-                let array: dora_node_api::arrow::array::ArrayData = array.into();
                 let ipc_bytes = match dora_node_api::arrow_utils::encode_arrow_ipc(&array) {
                     Ok(bytes) => bytes,
                     Err(e) => {

--- a/binaries/daemon/src/spawn/prepared.rs
+++ b/binaries/daemon/src/spawn/prepared.rs
@@ -18,7 +18,7 @@ use dora_message::{
     descriptor::RestartPolicy,
     id::NodeId,
 };
-use dora_node_api::{Metadata, arrow::array::ArrayData, arrow_utils::encode_arrow_ipc};
+use dora_node_api::{DoraArray, Metadata, arrow_utils::encode_arrow_ipc};
 use eyre::{ContextCompat, WrapErr};
 use process_wrap::tokio::CommandWrap;
 use std::{
@@ -40,7 +40,7 @@ use tokio::{
 /// parameter (so the node-side receive path decodes it). Returns `None` if
 /// encoding fails (logged by the caller).
 fn ipc_log_payload(
-    array: &ArrayData,
+    array: &DoraArray,
     clock: &dora_core::uhlc::HLC,
 ) -> Option<(DataMessage, Metadata)> {
     let ipc_bytes = encode_arrow_ipc(array)
@@ -939,7 +939,6 @@ impl PreparedNode {
                 if let Some(stdout_output_name) = &send_stdout_to {
                     // Convert logs to a self-describing Arrow IPC DataMessage.
                     let array = content.as_str().into_arrow();
-                    let array: ArrayData = array.into();
                     if let Some((message, metadata)) = ipc_log_payload(&array, &uhlc) {
                         let output_id = OutputId(
                             node_id.clone(),
@@ -1024,7 +1023,6 @@ impl PreparedNode {
                     && let Ok(json) = serde_json::to_string(&log_message)
                 {
                     let array = json.as_str().into_arrow();
-                    let array: ArrayData = array.into();
                     if let Some((message, metadata)) = ipc_log_payload(&array, &uhlc) {
                         let output_id =
                             OutputId(node_id.clone(), DataId::from(logs_output_name.to_string()));

--- a/binaries/mavlink2-bridge-node/Cargo.toml
+++ b/binaries/mavlink2-bridge-node/Cargo.toml
@@ -8,7 +8,7 @@ description = "MAVLink 2 ↔ dora bridge node, daemon-spawnable"
 
 [dependencies]
 dora-mavlink2-bridge = { workspace = true }
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true , features = ["arrow-v59"] }
 mavlink = { workspace = true }
 arrow = { workspace = true }
 url = { workspace = true }

--- a/binaries/mavlink2-bridge-node/src/main.rs
+++ b/binaries/mavlink2-bridge-node/src/main.rs
@@ -60,7 +60,7 @@ use dora_mavlink2_bridge::{
 };
 use dora_node_api::{
     DoraNode, Event, MetadataParameters, TryRecvError,
-    arrow::array::{Array, ArrayRef, AsArray, RecordBatch, StructArray},
+    arrow_v59::array::{Array, ArrayRef, AsArray, RecordBatch, StructArray},
     dora_core::config::DataId,
     flume,
 };

--- a/binaries/record-node/Cargo.toml
+++ b/binaries/record-node/Cargo.toml
@@ -14,7 +14,11 @@ name = "dora-record-node"
 path = "src/main.rs"
 
 [dependencies]
-dora-node-api = { workspace = true, default-features = false }
+# `arrow-v59` (dora's internal Arrow major): `main.rs` names
+# `arrow_v59::datatypes::DataType` and calls `DoraArray::as_array`, both of
+# which the feature gates. Without it this crate only builds when some other
+# member of the workspace happens to unify the feature in.
+dora-node-api = { workspace = true, default-features = false, features = ["arrow-v59"] }
 dora-recording = { workspace = true }
 dora-message = { workspace = true }
 eyre = { workspace = true }

--- a/binaries/record-node/src/main.rs
+++ b/binaries/record-node/src/main.rs
@@ -6,7 +6,7 @@ use dora_message::{
     daemon_to_daemon::InterDaemonEvent,
     id::{DataId, NodeId},
 };
-use dora_node_api::{DoraNode, Event, arrow::datatypes::DataType, arrow_utils};
+use dora_node_api::{DoraNode, Event, arrow_utils, arrow_v59::datatypes::DataType};
 use dora_recording::{RecordEntry, RecordingHeader, RecordingWriter};
 use eyre::Context;
 
@@ -93,8 +93,8 @@ fn main() -> eyre::Result<()> {
 
                 // Record the payload as a self-describing Arrow IPC stream so
                 // replay can reconstruct the array without a type sidecar.
-                let arrow_data = data.to_data();
-                let raw_data = if matches!(arrow_data.data_type(), DataType::Null)
+                let arrow_data = &data;
+                let raw_data = if matches!(arrow_data.as_array().data_type(), DataType::Null)
                     && arrow_data.is_empty()
                 {
                     // Exactly the unit array that replay rebuilds from an absent
@@ -118,17 +118,17 @@ fn main() -> eyre::Result<()> {
                     // copies) and then copied the result a third time into the
                     // `AVec`, on every recorded message.
                     let encoded: AVec<u8, ConstAlign<128>> =
-                        match arrow_utils::ipc_encode::ipc_fast_path_len(&arrow_data) {
+                        match arrow_utils::ipc_encode::ipc_fast_path_len(arrow_data) {
                             Some(len) => {
                                 let mut buf: AVec<u8, ConstAlign<128>> =
                                     AVec::__from_elem(128, 0, len);
-                                arrow_utils::ipc_encode::encode_ipc_into(&arrow_data, &mut buf)
+                                arrow_utils::ipc_encode::encode_ipc_into(arrow_data, &mut buf)
                                     .wrap_err("failed to Arrow-IPC-encode recorded output")?;
                                 buf
                             }
                             None => {
                                 let ipc_bytes =
-                                    arrow_utils::ipc_encode::encode_ipc_to_vec(&arrow_data)
+                                    arrow_utils::ipc_encode::encode_ipc_to_vec(arrow_data)
                                         .wrap_err("failed to Arrow-IPC-encode recorded output")?;
                                 AVec::from_slice(128, &ipc_bytes)
                             }

--- a/binaries/replay-node/Cargo.toml
+++ b/binaries/replay-node/Cargo.toml
@@ -14,7 +14,11 @@ name = "dora-replay-node"
 path = "src/main.rs"
 
 [dependencies]
-dora-node-api = { workspace = true, default-features = false }
+# `arrow-v59` (dora's internal Arrow major): `main.rs` names
+# `arrow_v59::array::NullArray` and relies on `IntoArrow for ArrayRef`, both of
+# which the feature gates. Without it this crate only builds when some other
+# member of the workspace happens to unify the feature in.
+dora-node-api = { workspace = true, default-features = false, features = ["arrow-v59"] }
 dora-recording = { workspace = true }
 dora-message = { workspace = true }
 eyre = { workspace = true }

--- a/binaries/replay-node/src/main.rs
+++ b/binaries/replay-node/src/main.rs
@@ -2,25 +2,23 @@ use std::{fs::File, thread, time::Duration};
 
 use dora_message::{common::Timestamped, daemon_to_daemon::InterDaemonEvent};
 use dora_node_api::{
-    DoraNode,
-    arrow::array::{ArrayData, NullArray, make_array},
-    arrow_utils::decode_arrow_ipc,
+    DoraArray, DoraNode, IntoArrow, arrow_utils::decode_arrow_ipc, arrow_v59::array::NullArray,
 };
 use dora_recording::RecordingReader;
 use eyre::Context;
 
-/// Decode a recorded output payload back into Arrow [`ArrayData`].
+/// Decode a recorded output payload back into a dora payload.
 ///
 /// The recorded payload is a self-describing Arrow IPC stream, or `None` for
 /// a metadata-only message (which replays as an empty null array). A decode
 /// failure is returned as an `Err` so the caller can skip that single record
 /// rather than aborting the whole replay.
-fn decode_recorded_payload(data: Option<&[u8]>) -> eyre::Result<ArrayData> {
+fn decode_recorded_payload(data: Option<&[u8]>) -> eyre::Result<DoraArray> {
     match data {
         Some(bytes) => {
             decode_arrow_ipc(bytes).wrap_err("failed to decode recorded Arrow IPC payload")
         }
-        None => Ok(NullArray::new(0).into()),
+        None => Ok(NullArray::new(0).into_arrow()),
     }
 }
 
@@ -129,7 +127,7 @@ fn main() -> eyre::Result<()> {
                             continue;
                         }
                     };
-                    node.send_output(output_id, metadata.parameters, make_array(array))
+                    node.send_output(output_id, metadata.parameters, array)
                         .wrap_err("failed to send replay output")?;
                     replayed += 1;
                 }
@@ -175,8 +173,9 @@ fn main() -> eyre::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{decode_recorded_payload, pacing_sleep_nanos, replay_emitted_nothing_usable};
-    use dora_node_api::arrow::array::{Array, Int32Array};
+    use dora_node_api::DoraArray;
     use dora_node_api::arrow_utils::encode_arrow_ipc;
+    use dora_node_api::arrow_v59::array::Int32Array;
 
     #[test]
     fn first_entry_honors_its_initial_offset() {
@@ -219,11 +218,11 @@ mod tests {
     #[test]
     fn valid_ipc_payload_round_trips() {
         // A well-formed recorded IPC stream decodes back to its data.
-        let original = Int32Array::from(vec![1, 2, 3]);
-        let bytes = encode_arrow_ipc(&original.to_data()).expect("encode");
+        let original = DoraArray::from_array(Int32Array::from(vec![1, 2, 3]));
+        let bytes = encode_arrow_ipc(&original).expect("encode");
         let decoded = decode_recorded_payload(Some(&bytes)).expect("valid IPC must decode");
         assert_eq!(decoded.len(), 3);
-        assert_eq!(&decoded, &original.to_data());
+        assert_eq!(decoded.as_array(), original.as_array());
     }
 
     #[test]

--- a/binaries/ros2-bridge-node/Cargo.toml
+++ b/binaries/ros2-bridge-node/Cargo.toml
@@ -10,7 +10,7 @@ name = "dora-ros2-bridge-node"
 path = "src/main.rs"
 
 [dependencies]
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true , features = ["arrow-v59"] }
 dora-ros2-bridge = { path = "../../libraries/extensions/ros2-bridge", default-features = false, features = ["rmw-zenoh"] }
 dora-ros2-bridge-arrow = { path = "../../libraries/extensions/ros2-bridge/arrow" }
 dora-ros2-bridge-msg-gen = { workspace = true }

--- a/binaries/ros2-bridge-node/src/main.rs
+++ b/binaries/ros2-bridge-node/src/main.rs
@@ -231,7 +231,7 @@ fn run_zenoh_topic_mode(
                 for publisher in &publishers {
                     if publisher.input == id.as_str() {
                         let value = TypedValue {
-                            value: &data,
+                            value: data.as_array(),
                             type_info: &publisher.type_info,
                         };
                         let cdr = serialize_raw_cdr(&value)?;
@@ -305,7 +305,7 @@ fn run_zenoh_service_mode(
                 match event {
                     Event::Input { data, .. } => {
                         let request = serialize_raw_cdr(&TypedValue {
-                            value: &data,
+                            value: data.as_array(),
                             type_info: &request_info,
                         })?;
                         let Some(response) = peer_value_or_warn(
@@ -418,7 +418,7 @@ fn run_zenoh_service_mode(
                             && let Some((id, _)) = pending.remove(key)
                         {
                             let response = serialize_raw_cdr(&TypedValue {
-                                value: &data,
+                                value: data.as_array(),
                                 type_info: &response_info,
                             })?;
                             // A slow local handler can let the request expire before we
@@ -618,7 +618,7 @@ fn run_zenoh_action_client(
                     let _guard = TypeInfoGuard::serialize(goal_type_info.clone());
                     serialize_cdr(&SendGoalRequest {
                         goal_id,
-                        goal: BridgeMessage(Some(data.to_data())),
+                        goal: BridgeMessage(Some(data.as_array().to_data())),
                     })?
                 };
                 let Some(response) = peer_value_or_warn(
@@ -931,7 +931,7 @@ fn run_zenoh_action_server(
                             let _guard = TypeInfoGuard::serialize(feedback_type_info.clone());
                             serialize_cdr(&FeedbackMessage {
                                 goal_id: goal.id,
-                                feedback: BridgeMessage(Some(data.to_data())),
+                                feedback: BridgeMessage(Some(data.as_array().to_data())),
                             })?
                         };
                         futures::executor::block_on(server.feedback.publish(&payload))?;
@@ -946,7 +946,7 @@ fn run_zenoh_action_server(
                             let _guard = TypeInfoGuard::serialize(result_type_info.clone());
                             serialize_cdr(&GetResultResponse {
                                 status: goal.status,
-                                result: BridgeMessage(Some(data.to_data())),
+                                result: BridgeMessage(Some(data.as_array().to_data())),
                             })?
                         };
                         let delivered = if let Some(request_id) = goal.result_request.take() {
@@ -1188,7 +1188,7 @@ fn run_service_client(
                 metadata: _,
                 data,
             } => {
-                let array_data = data.to_data();
+                let array_data = data.as_array().to_data();
 
                 // Serialize request (guard clears thread-local on drop)
                 let _guard = TypeInfoGuard::serialize(request_type_info.clone());
@@ -1271,7 +1271,7 @@ fn run_service_server(
                 let rid = get_string_param(&metadata.parameters, REQUEST_ID);
                 if let Some(rid) = rid {
                     if let Some((rmw_id, _)) = pending_requests.remove(rid) {
-                        let array_data = data.to_data();
+                        let array_data = data.as_array().to_data();
                         let _ser_guard = TypeInfoGuard::serialize(response_type_info.clone());
                         futures::executor::block_on(
                             server.async_send_response(rmw_id, BridgeMessage(Some(array_data))),
@@ -1455,7 +1455,7 @@ fn run_action_client(
                     }
                 };
 
-                let array_data = data.to_data();
+                let array_data = data.as_array().to_data();
 
                 // Send goal with timeout (guard clears thread-local on drop)
                 let _guard = TypeInfoGuard::serialize(goal_type_info.clone());
@@ -1673,7 +1673,7 @@ fn run_action_server(
                     "feedback" => {
                         if let Some(handle) = executing_goals.get(&goal_id) {
                             let handle = handle.clone();
-                            let array_data = data.to_data();
+                            let array_data = data.as_array().to_data();
                             let _guard = TypeInfoGuard::serialize(feedback_type_info.clone());
                             if let Err(e) = futures::executor::block_on(
                                 server.publish_feedback(handle, BridgeMessage(Some(array_data))),
@@ -1688,7 +1688,7 @@ fn run_action_server(
                     }
                     "result" => {
                         if let Some(handle) = executing_goals.remove(&goal_id) {
-                            let array_data = data.to_data();
+                            let array_data = data.as_array().to_data();
                             let status = match get_string_param(&metadata.parameters, GOAL_STATUS) {
                                 Some(s) => match s {
                                     GOAL_STATUS_SUCCEEDED => {
@@ -1822,7 +1822,7 @@ fn run_publish_only(
                 metadata: _,
                 data,
             } => {
-                handle_publish_input(&id, &data, &publishers, messages)?;
+                handle_publish_input(&id, data.as_array(), &publishers, messages)?;
             }
             Event::Stop(_) => break,
             _ => {}
@@ -1864,7 +1864,7 @@ fn run_single_subscriber(
                 metadata: _,
                 data,
             }) => {
-                handle_publish_input(&id, &data, &publishers, messages)?;
+                handle_publish_input(&id, data.as_array(), &publishers, messages)?;
             }
             MergedEvent::Dora(Event::Stop(_)) => break,
             MergedEvent::Dora(_) => {}
@@ -1929,7 +1929,7 @@ fn run_multi_subscriber(
                 metadata: _,
                 data,
             }) => {
-                handle_publish_input(&id, &data, &publishers, messages)?;
+                handle_publish_input(&id, data.as_array(), &publishers, messages)?;
             }
             MergedEvent::Dora(Event::Stop(_)) => break,
             MergedEvent::Dora(_) => {}

--- a/binaries/runtime-api/Cargo.toml
+++ b/binaries/runtime-api/Cargo.toml
@@ -14,7 +14,7 @@ repository.workspace = true
 # (`dora-runtime-shared-lib`, `dora-runtime-python`) build on top of this.
 
 [dependencies]
-dora-node-api = { workspace = true, default-features = false }
+dora-node-api = { workspace = true, default-features = false, features = ["arrow-v59"] }
 dora-core = { workspace = true }
 dora-message = { workspace = true }
 dora-tracing = { workspace = true, optional = true }

--- a/binaries/runtime-api/src/channel.rs
+++ b/binaries/runtime-api/src/channel.rs
@@ -184,7 +184,7 @@ mod tests {
     use arrow::array::new_empty_array;
     use arrow::datatypes::DataType;
     use dora_message::metadata::Metadata;
-    use dora_node_api::ArrowData;
+    use dora_node_api::DoraArray;
 
     fn closed_event(id: &str) -> Event {
         Event::InputClosed {
@@ -196,7 +196,7 @@ mod tests {
         Event::Input {
             id: DataId::from(id.to_string()),
             metadata: Metadata::new(dora_core::uhlc::HLC::default().new_timestamp()),
-            data: ArrowData(new_empty_array(&DataType::Null)),
+            data: DoraArray::from(new_empty_array(&DataType::Null)),
         }
     }
 

--- a/binaries/runtime-api/src/operator.rs
+++ b/binaries/runtime-api/src/operator.rs
@@ -2,9 +2,7 @@ use dora_core::{
     config::{DataId, NodeId},
     descriptor::{Descriptor, OperatorDefinition},
 };
-use dora_node_api::{
-    EncodedSample, Event, MetadataParameters, SampleAllocator, arrow::array::ArrayData,
-};
+use dora_node_api::{DoraArray, EncodedSample, Event, MetadataParameters, SampleAllocator};
 use eyre::Result;
 use std::any::Any;
 use std::sync::{Arc, OnceLock};
@@ -46,7 +44,7 @@ impl RuntimeHandle {
         &self,
         output_id: DataId,
         parameters: MetadataParameters,
-        array: &ArrayData,
+        array: &DoraArray,
     ) -> Result<()> {
         let allocator = self
             .allocator
@@ -179,11 +177,13 @@ mod tests {
             _backing: backing,
         });
         let buffer = unsafe { Buffer::from_custom_allocation(ptr, 4096, owner) };
-        let array = ArrayData::builder(dora_node_api::arrow::datatypes::DataType::UInt8)
-            .len(4096)
-            .add_buffer(buffer)
-            .build()
-            .expect("valid UInt8 array");
+        let array = dora_node_api::DoraArray::from_array(arrow::array::make_array(
+            arrow::array::ArrayData::builder(dora_node_api::arrow_v59::datatypes::DataType::UInt8)
+                .len(4096)
+                .add_buffer(buffer)
+                .build()
+                .expect("valid UInt8 array"),
+        ));
 
         let (events_tx, mut events_rx) = tokio::sync::mpsc::channel(1);
         let allocator: SharedAllocator = Arc::new(OnceLock::new());
@@ -224,7 +224,7 @@ mod tests {
     fn send_output_before_node_init_is_a_clear_error() {
         let (events_tx, _events_rx) = tokio::sync::mpsc::channel(1);
         let handle = RuntimeHandle::new(events_tx, SharedAllocator::default());
-        let array = ArrayData::new_null(&dora_node_api::arrow::datatypes::DataType::UInt8, 1);
+        let array = dora_node_api::DoraArray::from_array(arrow::array::NullArray::new(1));
 
         let err = handle
             .send_output(

--- a/binaries/runtime-python/Cargo.toml
+++ b/binaries/runtime-python/Cargo.toml
@@ -21,7 +21,7 @@ dora-runtime-api = { workspace = true }
 # the pre-split `dora-runtime` handled because it compiled the shared-library
 # backend in unconditionally.
 dora-runtime-shared-lib = { workspace = true }
-dora-node-api = { workspace = true, default-features = false }
+dora-node-api = { workspace = true, default-features = false, features = ["arrow-v59"] }
 dora-core = { workspace = true }
 dora-download = { workspace = true }
 dora-operator-api-python = { workspace = true }

--- a/binaries/runtime-python/src/runner.rs
+++ b/binaries/runtime-python/src/runner.rs
@@ -378,6 +378,8 @@ mod callback_impl {
             // The encode inside needs no GIL, so run detached: it is the same
             // single copy the node used to make, just on this side of the
             // channel, and other Python threads stay runnable meanwhile.
+            let arrow_array =
+                dora_node_api::DoraArray::from_array(arrow::array::make_array(arrow_array));
             py.detach(|| {
                 self.handle
                     .send_output(output.to_owned().into(), parameters, &arrow_array)

--- a/binaries/runtime-shared-lib/Cargo.toml
+++ b/binaries/runtime-shared-lib/Cargo.toml
@@ -15,7 +15,7 @@ repository.workspace = true
 
 [dependencies]
 dora-runtime-api = { workspace = true }
-dora-node-api = { workspace = true, default-features = false }
+dora-node-api = { workspace = true, default-features = false, features = ["arrow-v59"] }
 dora-core = { workspace = true }
 dora-download = { workspace = true }
 dora-operator-api-types = { workspace = true }

--- a/binaries/runtime-shared-lib/src/runner.rs
+++ b/binaries/runtime-shared-lib/src/runner.rs
@@ -147,7 +147,7 @@ impl SharedLibraryOperator<'_> {
             );
 
             let arrow_array = match unsafe { arrow::ffi::from_ffi(data_array, &schema) } {
-                Ok(a) => a,
+                Ok(a) => dora_node_api::DoraArray::from_array(arrow::array::make_array(a)),
                 Err(err) => return DoraResult::from_error(err.to_string()),
             };
 
@@ -223,7 +223,7 @@ impl SharedLibraryOperator<'_> {
                     metadata,
                     data,
                 } => {
-                    let (data_array, schema) = arrow::ffi::to_ffi(&data.to_data())?;
+                    let (data_array, schema) = arrow::ffi::to_ffi(&data.as_array().to_data())?;
                     let otel = metadata.open_telemetry_context();
                     let operator_input = dora_operator_api_types::Input {
                         id: String::from(input_id).into(),

--- a/docs/api-rust.md
+++ b/docs/api-rust.md
@@ -16,6 +16,10 @@ Add to your `Cargo.toml`:
 dora-node-api = { workspace = true }
 ```
 
+See [Arrow version policy](#arrow-version-policy) if your node needs to name
+Arrow types directly (e.g. to build a `StructArray` or share arrays with
+polars/datafusion/parquet).
+
 ### DoraNode
 
 The primary struct for sending outputs and retrieving node information. Obtained through one of the initialization functions below.
@@ -63,7 +67,7 @@ pub fn send_output(
     &mut self,
     output_id: DataId,
     parameters: MetadataParameters,
-    data: impl Array,
+    data: impl IntoArrow,
 ) -> NodeResult<()>
 
 // Send raw bytes. Copies into shared memory when beneficial.
@@ -309,7 +313,7 @@ pub enum Event {
     Input {
         id: DataId,           // input ID from the YAML (not the sender's output ID)
         metadata: Metadata,   // timestamp and type information
-        data: ArrowData,      // Apache Arrow data
+        data: DoraArray,      // Apache Arrow data, owned by dora
     },
 
     // The sender mapped to this input exited; no more data will arrive.
@@ -444,14 +448,97 @@ pub const ZERO_COPY_THRESHOLD: usize = 4096;
 
 Messages smaller than this threshold are sent via TCP. Messages at or above this size use shared memory for zero-copy transfer.
 
-#### ArrowData
+#### DoraArray
 
 ```rust
-// Wrapper around arrow::array::ArrayRef. Implements Deref to the inner ArrayRef.
-pub struct ArrowData(pub arrow::array::ArrayRef);
+// A dora-owned Apache Arrow array. The inner array is private.
+pub struct DoraArray { /* private */ }
+
+impl DoraArray {
+    pub fn len(&self) -> usize;
+    pub fn is_empty(&self) -> bool;
+    pub fn null_count(&self) -> usize;
+    pub fn type_name(&self) -> String;   // e.g. "UInt64"
+}
 ```
 
-Data from `Event::Input` arrives as `ArrowData`. Use `TryFrom` conversions or Arrow APIs to extract typed values.
+Data from `Event::Input` arrives as `DoraArray`. Use the `TryFrom<&DoraArray>`
+conversions (`bool`, the primitive integer/float types, `String`, `&str`, the
+`chrono` date/time types, `&[T]`, `Vec<T>`) or `into_vec::<T>()` to extract
+typed values without naming an Arrow type.
+
+To reach the Arrow array itself, enable the feature naming your Arrow major —
+see [Arrow version policy](#arrow-version-policy).
+
+`IntoArrow` is the other direction, and what `send_output` takes:
+
+```rust
+pub trait IntoArrow {
+    fn into_arrow(self) -> DoraArray;
+}
+```
+
+It is implemented for booleans, strings, the primitive integer/float types,
+`Vec`s of those, a few `chrono` types, `()` (an empty null array, for
+metadata-only outputs), and `DoraArray` itself.
+
+---
+
+### Arrow version policy
+
+`dora-node-api`'s public API is frozen for the life of 1.x, and Arrow ships a
+major roughly every 6–8 weeks. If an Arrow type appeared in that frozen API,
+dora 1.x would be pinned to one Arrow major for its whole life and users would
+have to choose between current dora and current polars/datafusion/parquet.
+
+So it does not. Every ungated signature uses the dora-owned `DoraArray` /
+`IntoArrow`, and Arrow is reachable only through **explicitly versioned,
+opt-in features**:
+
+```toml
+[dependencies]
+# Nothing extra needed if your node never names an Arrow type.
+dora-node-api = "1"
+
+# Naming Arrow 59 — dora's current internal major. Free: no conversion, and
+# no extra copy of Arrow in your build.
+dora-node-api = { version = "1", features = ["arrow-v59"] }
+```
+
+| Feature | Re-export | `DoraArray` accessors | Cost |
+|---|---|---|---|
+| *(none)* | — | `len`, `is_empty`, `null_count`, `type_name`, `TryFrom`, `into_vec` | — |
+| `arrow-v59` | `dora_node_api::arrow_v59` | `as_array`, `into_inner`, `from_array`, `From<ArrayRef>` | free (borrow) |
+| `arrow-v58` | `dora_node_api::arrow_v58` | `from_arrow_v58`, `to_arrow_v58` | one Arrow C Data Interface hop; no buffer copy |
+
+There is deliberately no `pub use arrow;`. A bare `arrow` re-export changes
+meaning silently when dora bumps its internal major. `arrow_v59` cannot: it
+either exists and means Arrow 59, or it is visibly gone.
+
+Cargo unifies semver-compatible versions, so if you declare `arrow = "59"`
+yourself you get *the same crate instance* as `dora_node_api::arrow_v59` — the
+types are interchangeable, not merely similar. Two different Arrow majors also
+coexist fine (distinct crates, distinct symbols, pure Rust).
+
+#### Support window
+
+- **Adding an `arrow-vN` feature is additive** and can land in any minor.
+- **Removing one is breaking** and waits for a major, after at least one
+  release carrying `#[deprecated]`.
+- At ~8 Arrow majors a year dora carries **two or three** at a time: the
+  current internal major plus one or two older ones.
+- When dora moves its internal major (say 59 → 60), `arrow-v60` is added and
+  becomes the free/borrowing one; `arrow-v59` keeps working but demotes to a
+  *converting* accessor over the C Data Interface, exactly like `arrow-v58`
+  today. Nothing silently changes meaning.
+
+#### Not covered by the guarantee
+
+`dora_arrow_convert::internal` is an Arrow-typed seam for dora's own crates
+(the C/C++/Python bindings, the record/replay nodes). It is not re-exported
+from `dora-node-api`, it names dora's internal Arrow major, and it is
+**exempt from the semver guarantee** — it changes whenever the internal major
+does. Use the version-gated accessors instead.
 
 ---
 
@@ -475,7 +562,7 @@ impl InputTracker {
     pub fn is_closed(&self, id: &DataId) -> bool
 
     // Last received value for an input. Available even when closed.
-    pub fn last_value(&self, id: &DataId) -> Option<&ArrowData>
+    pub fn last_value(&self, id: &DataId) -> Option<&DoraArray>
 
     // All inputs currently in Closed state.
     pub fn closed_inputs(&self) -> Vec<&DataId>
@@ -596,7 +683,7 @@ The operator `Event` enum is simpler than the node `Event` and uses `&str` for I
 #[non_exhaustive]
 pub enum Event<'a> {
     // An input was received.
-    Input { id: &'a str, data: ArrowData },
+    Input { id: &'a str, data: DoraArray },
 
     // Failed to parse the input data as an Arrow array.
     InputParseError { id: &'a str, error: String },

--- a/docs/api-rust.md
+++ b/docs/api-rust.md
@@ -509,7 +509,29 @@ dora-node-api = { version = "1", features = ["arrow-v59"] }
 |---|---|---|---|
 | *(none)* | — | `len`, `is_empty`, `null_count`, `type_name`, `TryFrom`, `into_vec` | — |
 | `arrow-v59` | `dora_node_api::arrow_v59` | `as_array`, `into_inner`, `from_array`, `From<ArrayRef>` | free (borrow) |
-| `arrow-v58` | `dora_node_api::arrow_v58` | `from_arrow_v58`, `to_arrow_v58` | one Arrow C Data Interface hop; no buffer copy |
+| `arrow-v58` | `dora_node_api::arrow_v58` | `TryFrom`/`TryInto` in both directions | one Arrow C Data Interface hop; no buffer copy |
+
+Conversions to and from a non-internal major are **fallible** — the Arrow C
+Data Interface cannot represent every array layout, and arrow-rs surfaces that
+as a `Result` — so they are `TryFrom`/`TryInto`, never `From`/`Into`:
+
+```rust
+use dora_node_api::{DoraArray, arrow_v58};
+use arrow_v58::array::{Array, ArrayRef};
+
+// Arrow 58 -> dora. `&dyn Array` (or `&ArrayRef`) is the source type; a
+// generic `&A: Array` impl is not possible, see below.
+let payload = DoraArray::try_from(&my_arrow58_array as &dyn Array)?;
+
+// dora -> Arrow 58.
+let back: ArrayRef = (&payload).try_into()?;
+```
+
+The source types are concrete rather than generic because coherence forbids
+`impl<A: Array> TryFrom<&A> for DoraArray`: it overlaps core's
+`impl<T, U: Into<T>> TryFrom<U> for T`, since a downstream crate may add
+`impl From<&TheirType> for DoraArray` and `A` could be instantiated at
+`TheirType`.
 
 There is deliberately no `pub use arrow;`. A bare `arrow` re-export changes
 meaning silently when dora bumps its internal major. `arrow_v59` cannot: it
@@ -529,8 +551,8 @@ coexist fine (distinct crates, distinct symbols, pure Rust).
   current internal major plus one or two older ones.
 - When dora moves its internal major (say 59 → 60), `arrow-v60` is added and
   becomes the free/borrowing one; `arrow-v59` keeps working but demotes to a
-  *converting* accessor over the C Data Interface, exactly like `arrow-v58`
-  today. Nothing silently changes meaning.
+  *converting* `TryFrom` pair over the C Data Interface, exactly like
+  `arrow-v58` today. Nothing silently changes meaning.
 
 #### Not covered by the guarantee
 

--- a/docs/fault-tolerance.md
+++ b/docs/fault-tolerance.md
@@ -303,11 +303,11 @@ while let Some(event) = events.recv() {
 `InputTracker` maintains two `HashMap`s:
 
 - `states: HashMap<DataId, InputState>` -- current state per input (Healthy or Closed)
-- `cache: HashMap<DataId, ArrowData>` -- last received value per input
+- `cache: HashMap<DataId, DoraArray>` -- last received value per input
 
 On `Event::Input`, both maps are updated (state = Healthy, cache = data clone). On `Event::InputClosed`, only state changes (cache is preserved). On `Event::InputRecovered`, state is set back to Healthy. The cache is never cleared, so `last_value()` always returns the most recent data even after the input closes.
 
-Note: `ArrowData` wraps `Arc<dyn arrow::array::Array>`, so the cache clone is reference-counted (cheap).
+Note: `DoraArray` wraps an `Arc`-backed Arrow array, so the cache clone is reference-counted (cheap).
 
 ### API Reference
 
@@ -317,7 +317,7 @@ Note: `ArrowData` wraps `Arc<dyn arrow::array::Array>`, so the cache clone is re
 | `process_event(&Event)` | `bool` | Update state. Returns true if event was relevant |
 | `state(&DataId)` | `Option<InputState>` | Current state (Healthy or Closed) |
 | `is_closed(&DataId)` | `bool` | Check if input is closed |
-| `last_value(&DataId)` | `Option<&ArrowData>` | Last received value (available even when closed) |
+| `last_value(&DataId)` | `Option<&DoraArray>` | Last received value (available even when closed) |
 | `closed_inputs()` | `Vec<&DataId>` | All currently closed inputs |
 | `any_closed()` | `bool` | True if any tracked input is closed |
 

--- a/docs/plan-arrow-version-decoupling.md
+++ b/docs/plan-arrow-version-decoupling.md
@@ -124,7 +124,14 @@ Cargo also *unifies semver-compatible* versions, so a user who declares
 — which is what makes this safe for people mixing dora with polars or parquet
 on the same major.
 
-### 3. `From`/`Into` impls via the C Data Interface
+### 3. `TryFrom`/`TryInto` impls via the C Data Interface
+
+> **Correction.** This section originally said `From`/`Into`. That was wrong:
+> the C Data Interface hop is **fallible** — arrow-rs's `to_ffi`/`from_ffi`
+> both return `Result`, because not every array layout can be represented over
+> the interface — and an infallible `From` would have to panic on those cases.
+> The fallible counterparts, `TryFrom`/`TryInto`, are the correct traits, and
+> are what shipped. `TryInto` comes free from the blanket impl.
 
 Conversion between majors must be zero-copy or it is a non-starter. The
 mechanism is the Arrow C Data Interface, which exists for exactly this and is
@@ -145,8 +152,19 @@ The hop is `arrow58::ffi::to_ffi(&data)` → reinterpret → `arrow::ffi::from_f
 > interface is designed for, and exactly where a mistake becomes a
 > use-after-free.
 
-Adding a `From` impl later is additive and non-breaking, so extra majors can
+Adding a `TryFrom` impl later is additive and non-breaking, so extra majors can
 land in minors whenever someone wants them.
+
+**Coherence constrains the source type.** A generic
+`impl<A: arrow58::array::Array> TryFrom<&A> for DoraArray` is rejected (E0119):
+it overlaps core's `impl<T, U: Into<T>> TryFrom<U> for T`, because a downstream
+crate may add `impl From<&TheirType> for DoraArray` — RFC 2451 permits
+`impl ForeignTrait<LocalType> for ForeignType` — and `A` could be instantiated
+at `TheirType`. So the source types are concrete: `&dyn arrow58::array::Array`
+and `&arrow58::array::ArrayRef` (the latter separately, because `&Arc<dyn
+Array>` does not unsize-coerce during trait selection). The export direction,
+`impl TryFrom<&DoraArray> for arrow58::array::ArrayRef`, is the RFC 2451 shape
+and is accepted as-is.
 
 ### 4. Support-window policy
 
@@ -173,9 +191,14 @@ down; it is the only ongoing cost of this design.
 
 ## What landed, and where it deviated
 
-All five steps below are implemented. Two things differ from the design as
+All five steps below are implemented. Three things differ from the design as
 written:
 
+- **The cross-major conversions are `TryFrom`/`TryInto`, not `From`/`Into`.**
+  Section 3 asked for the infallible traits, but the C Data Interface hop is
+  fallible, so an infallible `From` would have to panic internally. See the
+  correction in that section, including the coherence constraint that forces
+  the source types to be concrete rather than generic.
 - **`EncodedSample::data_type()` is gated, not replaced by a type URN.**
   `dora_core::types::TypeRegistry` only covers the standard scalar/struct
   catalog; nested lists, dictionaries, unions and timestamps-with-timezone have
@@ -215,7 +238,8 @@ Two additions the design did not call for but the migration needed:
    every consumer.
 2. Replace `pub use arrow;` with gated `arrow_vN` re-exports, `default = []`.
 3. Retype the leaked IPC encoder surface (see below).
-4. Add `arrow-v58` with the FFI bridge as the worked example of an older major.
+4. Add `arrow-v58` with the FFI bridge (`TryFrom`/`TryInto`) as the worked
+   example of an older major.
 5. Write the support-window policy into `docs/api-rust.md`.
 
 Steps 1–3 must precede 1.0. Steps 4–5 are additive, but 4 should land with the

--- a/docs/plan-arrow-version-decoupling.md
+++ b/docs/plan-arrow-version-decoupling.md
@@ -1,0 +1,219 @@
+# Decoupling `dora-node-api` from the Arrow major version
+
+**Status:** design agreed, not yet implemented. Blocks 1.0.
+**Scope:** `dora-node-api`, `dora-arrow-convert`, and every consumer that names an Arrow type.
+
+## The problem
+
+At 1.0, everything reachable from `dora-node-api`'s public API is frozen for
+the life of 1.x. Arrow is reachable in three ways:
+
+| Where | What |
+|---|---|
+| `apis/rust/node/src/lib.rs:89` | `pub use arrow;` — the whole crate |
+| `libraries/arrow-convert/src/lib.rs:92` | `pub struct ArrowData(pub arrow::array::ArrayRef)` — public field, plus `Deref<Target = ArrayRef>` |
+| `libraries/arrow-convert/src/lib.rs:44` | `trait IntoArrow { type A: arrow::array::Array; }` — associated-type bound |
+
+`ArrowData` is a public field of `Event::Input`
+(`apis/rust/node/src/event_stream/event.rs:31`), so it is on the hottest path
+of every node.
+
+Because those are in the contract, a user cannot mix dora's Arrow with their
+own Arrow of a different major — cargo treats them as unrelated types and
+`send_output` will not accept their arrays. Arrow ships a major roughly every
+6–8 weeks. Frozen at 1.0, that means dora 1.x is pinned to Arrow 59 for the
+life of the major, and anyone wanting current polars / datafusion / parquet
+has to choose between them and dora.
+
+**What is *not* a problem:** the wire format. dora serializes with Arrow IPC
+(`apis/rust/node/src/node/arrow_utils.rs:44`), and IPC is a stable format
+independent of the arrow-rs Rust API. Two dora nodes built against different
+Arrow majors already exchange data correctly. The coupling is purely the
+in-process Rust type boundary.
+
+## The design
+
+Four parts. Only the first two must land before 1.0; the rest are additive.
+
+### 1. `DoraArray` — a dora-owned type in every signature
+
+Replace the Arrow types in public signatures with a dora-owned newtype, so no
+Arrow type appears in the frozen contract. This is what actually buys the
+freedom: with it, dora can bump its internal Arrow in a *minor*.
+
+- `ArrowData(pub ArrayRef)` and its `Deref<Target = ArrayRef>` become
+  `DoraArray` with a private field.
+- `IntoArrow::A: Array` becomes `fn into_arrow(self) -> DoraArray`.
+- `Event::Input { data: DoraArray }`.
+- `data_type() -> &arrow_schema::DataType`
+  (`apis/rust/node/src/node/mod.rs:2690`) is the one signature naming a
+  non-umbrella Arrow crate. It should return a dora-owned type — there is
+  already a type-URN registry (`std/core/v1/UInt64`) — or move behind a
+  feature gate.
+
+`DoraArray` holds dora's *internal* Arrow version, so users on that major keep
+today's ergonomics with no conversion.
+
+**The raw accessor must be feature-gated.** An ungated
+`DoraArray::as_array() -> &arrow::array::ArrayRef` would put Arrow straight
+back into the public API and undo the whole exercise. So the direct accessor
+lives behind the feature for dora's *current internal* major:
+
+```rust
+#[cfg(feature = "arrow-v59")]
+impl DoraArray {
+    pub fn as_array(&self) -> &arrow59::array::ArrayRef { &self.0 }
+    pub fn into_inner(self) -> arrow59::array::ArrayRef { self.0 }
+}
+```
+
+With `default = []` that is not in the default surface. When dora later moves
+internally to 60, the *direct* accessor re-gates behind `arrow-v60` and
+`arrow-v59` keeps a **converting** accessor instead — so old code still
+compiles, it just pays the FFI hop.
+
+### 2. `arrow_vN` re-exports, each feature-gated
+
+`pub use arrow;` is dishonest: its meaning changes silently when dora bumps.
+`pub use arrow as arrow_v59;` cannot — it either exists and means Arrow 59, or
+it is visibly gone. That turns a bump from **mutating** into **additive**:
+moving internally to 60 *adds* `arrow_v60` and leaves `arrow_v59` working.
+
+```toml
+[dependencies]
+arrow = { workspace = true, features = ["ipc"] }   # internal, ungated
+arrow58 = { package = "arrow", version = "58", optional = true }
+
+[features]
+default = []
+arrow-v58 = ["dep:arrow58"]
+arrow-v59 = []            # dora's internal version; re-export only
+```
+
+`arrow-v59` deliberately pulls **no extra dependency**. It re-exports the
+already-present internal `arrow`, so exactly one copy of Arrow 59 links. Only
+majors *other* than the internal one get an aliased `optional` dependency.
+The feature exists so that naming the internal major is an explicit opt-in
+like every other, and so the gating survives unchanged when 59 stops being
+internal.
+
+Two rules that matter:
+
+- **dora's internal Arrow stays ungated.** Internal IPC encode/decode must be
+  written against exactly one version or every call site needs `cfg`. Only the
+  *extra* majors are optional. When dora later moves internally to 60, the
+  previously-internal 59 demotes to just another optional compat feature.
+- **`default = []`.** If the blessed version sits in `default` and `default`
+  later changes, that is a breaking change for anyone relying on it — the
+  silent-drift problem reinvented one level up. An empty default never drifts.
+  This is viable precisely because of `DoraArray`: a node writing
+  `node.send_output(id, meta, 42u32.into_arrow())?` never names an Arrow type,
+  so the common path needs no feature at all.
+
+Cargo features are additive, and these are honestly additive — enabling
+`arrow-v58` only adds a re-export and some `From` impls. So if one crate in the
+graph wants `arrow-v58` and another wants `arrow-v60`, cargo unifies to both
+and each gets what it asked for. Two Arrow majors coexist fine: distinct
+crates, distinct symbols, pure Rust, no C symbol collisions.
+
+Cargo also *unifies semver-compatible* versions, so a user who declares
+`arrow = "59"` themselves gets the same crate instance as
+`dora_node_api::arrow_v59`. The types are interchangeable, not merely similar
+— which is what makes this safe for people mixing dora with polars or parquet
+on the same major.
+
+### 3. `From`/`Into` impls via the C Data Interface
+
+Conversion between majors must be zero-copy or it is a non-starter. The
+mechanism is the Arrow C Data Interface, which exists for exactly this and is
+**already used in-tree**: `apis/rust/operator/types/src/lib.rs:165` calls
+`arrow::ffi::from_ffi`, and `Input`/`Output` carry
+`FFI_ArrowArray`/`FFI_ArrowSchema` across a `#[repr(C)]` boundary.
+
+The hop is `arrow58::ffi::to_ffi(&data)` → reinterpret → `arrow::ffi::from_ffi`.
+
+> **The sharp edge.** `arrow58::ffi::FFI_ArrowArray` and
+> `arrow::ffi::FFI_ArrowArray` are *distinct Rust types* to rustc even though
+> both are `#[repr(C)]` against the same frozen Arrow C ABI. The bridge is
+> therefore a transmute / field-wise reinterpret whose soundness rests on the
+> spec being stable (it is — that is the point of the spec) and on both crates
+> implementing it faithfully. This is unsafe glue and needs careful comments
+> and tests. The thing to test first is the `release` callback: the newer arrow
+> will invoke the releaser the older one installed. That is exactly what the
+> interface is designed for, and exactly where a mistake becomes a
+> use-after-free.
+
+Adding a `From` impl later is additive and non-breaking, so extra majors can
+land in minors whenever someone wants them.
+
+### 4. Support-window policy
+
+Adding an `arrow_vN` feature is non-breaking. **Removing one is breaking** and
+must wait for a major, ideally after a release or two of `#[deprecated]`. At
+~8 Arrow majors a year, realistically carry two or three. Write the policy
+down; it is the only ongoing cost of this design.
+
+## Why not the alternatives
+
+- **Pin Arrow for all of 1.x.** A year-long 1.x ends ~8 majors behind. Users
+  wanting current polars/datafusion/parquet must choose.
+- **Carve Arrow out of the semver guarantee in writing.** Cheap and honest,
+  and it is what the Arrow ecosystem itself does (`parquet`, `arrow-flight`
+  version in lockstep). But dora minors then break builds, and users pin dora
+  exactly. Acceptable fallback if the work above cannot land before 1.0.
+- **Make the public boundary the C Data Interface itself.** The real
+  decoupling, but it taxes ergonomics on the receive path: every node gains a
+  fallible conversion on its hottest path and loses the `Deref` that makes
+  `ArrowData` pleasant. `DoraArray` gets the same decoupling while keeping the
+  matching-version case free.
+- **Make `Event` generic over the payload.** Pushes a type parameter into every
+  user signature.
+
+## Order of work
+
+1. Introduce `DoraArray`; migrate `ArrowData`, `IntoArrow`, `Event::Input`, and
+   every consumer.
+2. Replace `pub use arrow;` with gated `arrow_vN` re-exports, `default = []`.
+3. Retype the leaked IPC encoder surface (see below).
+4. Add `arrow-v58` with the FFI bridge as the worked example of an older major.
+5. Write the support-window policy into `docs/api-rust.md`.
+
+Steps 1–3 must precede 1.0. Steps 4–5 are additive, but 4 should land with the
+rest so the conversion path has a real test rather than a hypothetical one.
+
+### On the leaked IPC encoder surface (step 3)
+
+`arrow_utils::ipc_encode` is `pub mod` inside a re-exported module, so
+`encode_ipc_into`, `ipc_fast_path_len`, `encode_ipc_to_vec`,
+`encode_schema_message`, `batch_fast_path_len`, `encode_batch_into`,
+`schema_block_and_hash`, `encode_uint8_ipc_header`, `uint8_ipc_len`,
+`PreparedUint8Ipc` and `InputDecoder` are frozen public API — and most of the
+array-taking ones name `arrow::array::ArrayData`.
+
+An earlier draft of this plan called hiding them "free surface reduction,
+independent of the rest." **That was wrong on both counts.** They have real
+cross-crate consumers:
+
+- `binaries/record-node/src/main.rs:109,113,119` — `ipc_fast_path_len`,
+  `encode_ipc_into`, `encode_ipc_to_vec`
+- `binaries/daemon/src/lib.rs:9807` — `schema_block_and_hash`
+- `apis/python/node/src/sample_handler.rs:325` — `PreparedUint8Ipc`
+- `apis/rust/node/benches/arrow_framing.rs` and `tests/copy_count.rs` — reach
+  them through the public path, and `copy_count.rs` also uses
+  `encode_uint8_ipc_header` / `uint8_ipc_len`
+
+So `pub(crate)` would break three crates plus a bench and a test. And
+`#[doc(hidden)]` only hides from rustdoc — the items stay public and
+semver-relevant, so `arrow::array::ArrayData` would **stay in the frozen API**,
+which defeats the purpose.
+
+**Do this instead:** keep them public for their real consumers, and retype the
+array-taking ones to take `&DoraArray` rather than `&arrow::array::ArrayData`.
+Arrow then leaves those signatures without anything being hidden or broken —
+in-workspace callers pass a `DoraArray`, which is a newtype and therefore free.
+`schema_block_and_hash` already takes bytes and needs no change;
+`encode_schema_message(&DataType)` needs the same dora-owned-type treatment as
+`data_type()` in part 1.
+
+This is why the step is **ordered after `DoraArray` exists** rather than first:
+it is not independent of it.

--- a/docs/plan-arrow-version-decoupling.md
+++ b/docs/plan-arrow-version-decoupling.md
@@ -1,6 +1,8 @@
 # Decoupling `dora-node-api` from the Arrow major version
 
-**Status:** design agreed, not yet implemented. Blocks 1.0.
+**Status:** implemented. The user-facing contract now lives in
+[`docs/api-rust.md` § Arrow version policy](api-rust.md#arrow-version-policy);
+this document is kept as the design rationale.
 **Scope:** `dora-node-api`, `dora-arrow-convert`, and every consumer that names an Arrow type.
 
 ## The problem
@@ -168,6 +170,44 @@ down; it is the only ongoing cost of this design.
   matching-version case free.
 - **Make `Event` generic over the payload.** Pushes a type parameter into every
   user signature.
+
+## What landed, and where it deviated
+
+All five steps below are implemented. Two things differ from the design as
+written:
+
+- **`EncodedSample::data_type()` is gated, not replaced by a type URN.**
+  `dora_core::types::TypeRegistry` only covers the standard scalar/struct
+  catalog; nested lists, dictionaries, unions and timestamps-with-timezone have
+  no URN, so a URN-returning accessor would be lossy for exactly the outputs
+  whose type a caller most needs. It is `#[cfg(feature = "arrow-v59")]`, with an
+  ungated `type_name() -> String` for logging. `DoraArray` got the same
+  treatment.
+- **One Arrow-typed seam remains, deliberately.** `DoraArray` lives in
+  `dora-arrow-convert`, but the code that must build and unwrap it
+  (`dora-node-api`, the C/C++/Python bindings, record/replay) lives in other
+  crates, and Rust has no cross-crate `pub(crate)`. Routing that through the
+  `arrow-v59` *feature* would not work: `dora-node-api` would have to enable it
+  unconditionally, and cargo feature unification would then hand every
+  downstream user the ungated accessor — the silent-drift problem the gate
+  exists to prevent. So `dora_arrow_convert::internal` is `pub`,
+  `#[doc(hidden)]`-in-spirit, **not** re-exported from `dora-node-api`, and
+  written down in `docs/api-rust.md` as exempt from the semver guarantee.
+  `dora-node-api`'s own frozen surface is Arrow-free; that is the contract that
+  matters.
+
+Two additions the design did not call for but the migration needed:
+
+- **`arrow_utils::IpcPayload`**, a dora-owned wrapper for the receive-side byte
+  buffer, so `decode_arrow_ipc_zero_copy` / `InputDecoder::{set_schema,
+  decode_batch}` do not name `arrow::buffer::Buffer`. It also removed three
+  copies of the same hand-written `Buffer::from_custom_allocation` unsafe block.
+- **Gated `IntoArrow` impls for Arrow 59 array types** (`ArrayRef`,
+  `PrimitiveArray<T>`, `StructArray`, …), so `send_output(id, params,
+  my_struct_array)` still works for callers on the internal major. A blanket
+  `impl<A: arrow::array::Array> IntoArrow for A` is *not* possible — it overlaps
+  with `impl IntoArrow for u8` under coherence's "upstream crates may add a new
+  impl" rule — so the concrete types are listed.
 
 ## Order of work
 

--- a/examples/action-example/client/Cargo.toml
+++ b/examples/action-example/client/Cargo.toml
@@ -6,6 +6,6 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true , features = ["arrow-v59"] }
 eyre = { workspace = true }
 arrow = { workspace = true }

--- a/examples/action-example/client/src/main.rs
+++ b/examples/action-example/client/src/main.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use dora_node_api::{
     DoraNode, Event, GOAL_ID, GOAL_STATUS, MetadataParameters, Parameter,
-    arrow::array::{Array, Int64Array},
+    arrow_v59::array::{Array, Int64Array},
     get_string_param,
 };
 
@@ -33,6 +33,7 @@ fn main() -> eyre::Result<()> {
                 "feedback" => {
                     let gid = get_string_param(&metadata.parameters, GOAL_ID);
                     let fb_array = data
+                        .as_array()
                         .as_any()
                         .downcast_ref::<Int64Array>()
                         .map(|a| a.value(0));

--- a/examples/action-example/server/Cargo.toml
+++ b/examples/action-example/server/Cargo.toml
@@ -6,6 +6,6 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true , features = ["arrow-v59"] }
 eyre = { workspace = true }
 arrow = { workspace = true }

--- a/examples/action-example/server/src/main.rs
+++ b/examples/action-example/server/src/main.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use dora_node_api::{
     DoraNode, Event, GOAL_ID, GOAL_STATUS, GOAL_STATUS_CANCELED, GOAL_STATUS_SUCCEEDED,
     MetadataParameters, Parameter,
-    arrow::array::{Array, Int64Array},
+    arrow_v59::array::{Array, Int64Array},
     get_string_param,
 };
 
@@ -24,6 +24,7 @@ fn main() -> eyre::Result<()> {
                     let goal_id =
                         get_string_param(&metadata.parameters, GOAL_ID).map(str::to_owned);
                     let start = data
+                        .as_array()
                         .as_any()
                         .downcast_ref::<Int64Array>()
                         .map(|a| a.value(0));

--- a/examples/cross-language/rust-receiver/Cargo.toml
+++ b/examples/cross-language/rust-receiver/Cargo.toml
@@ -6,5 +6,5 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true , features = ["arrow-v59"] }
 eyre = { workspace = true }

--- a/examples/cross-language/rust-receiver/src/main.rs
+++ b/examples/cross-language/rust-receiver/src/main.rs
@@ -1,4 +1,4 @@
-use dora_node_api::{DoraNode, Event, EventStream, arrow};
+use dora_node_api::{DoraNode, Event, EventStream, arrow_v59 as arrow};
 use eyre::{ContextCompat, bail};
 
 #[cfg(test)]
@@ -17,6 +17,7 @@ fn run(_node: DoraNode, mut events: EventStream) -> eyre::Result<()> {
             Event::Input { id, data, .. } if id.as_str() == "values" => {
                 // Python sends pa.array([i * 10], type=pa.int64()) so we receive a single i64
                 let arr = data
+                    .as_array()
                     .as_any()
                     .downcast_ref::<arrow::array::Int64Array>()
                     .context("expected Int64Array from Python sender")?;

--- a/examples/cross-language/rust-sender/Cargo.toml
+++ b/examples/cross-language/rust-sender/Cargo.toml
@@ -6,5 +6,5 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true  }
 eyre = { workspace = true }

--- a/examples/error-propagation/producer/Cargo.toml
+++ b/examples/error-propagation/producer/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 rust-version.workspace = true
 
 [dependencies]
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true  }
 eyre = "0.6"

--- a/examples/log-sink-alert/Cargo.toml
+++ b/examples/log-sink-alert/Cargo.toml
@@ -6,7 +6,7 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true  }
 dora-log-utils = { workspace = true }
 dora-arrow-convert = { workspace = true }
 dora-message = { workspace = true }

--- a/examples/log-sink-file/Cargo.toml
+++ b/examples/log-sink-file/Cargo.toml
@@ -6,6 +6,6 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true  }
 dora-log-utils = { workspace = true }
 eyre = { workspace = true }

--- a/examples/log-sink-tcp/Cargo.toml
+++ b/examples/log-sink-tcp/Cargo.toml
@@ -6,6 +6,6 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true  }
 dora-log-utils = { workspace = true }
 eyre = { workspace = true }

--- a/examples/mavlink2-bridge/heartbeat-emitter/Cargo.toml
+++ b/examples/mavlink2-bridge/heartbeat-emitter/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 dora-mavlink2-bridge = { workspace = true }
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true , features = ["arrow-v59"] }
 arrow = { workspace = true }
 eyre = { workspace = true }
 tracing = { workspace = true }

--- a/examples/mavlink2-bridge/heartbeat-emitter/src/main.rs
+++ b/examples/mavlink2-bridge/heartbeat-emitter/src/main.rs
@@ -15,7 +15,7 @@ use dora_mavlink2_bridge::{
     mavlink::dialects::common::{HEARTBEAT_DATA, MavAutopilot, MavModeFlag, MavState, MavType},
 };
 use dora_node_api::{
-    DoraNode, Event, MetadataParameters, arrow::array::ArrayRef, dora_core::config::DataId,
+    DoraNode, Event, MetadataParameters, arrow_v59::array::ArrayRef, dora_core::config::DataId,
 };
 use eyre::{Result, eyre};
 

--- a/examples/mavlink2-bridge/telemetry-printer-rust/Cargo.toml
+++ b/examples/mavlink2-bridge/telemetry-printer-rust/Cargo.toml
@@ -7,6 +7,6 @@ publish = false
 
 [dependencies]
 dora-mavlink2-bridge = { workspace = true }
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true , features = ["arrow-v59"] }
 arrow = { workspace = true }
 eyre = { workspace = true }

--- a/examples/mavlink2-bridge/telemetry-printer-rust/src/main.rs
+++ b/examples/mavlink2-bridge/telemetry-printer-rust/src/main.rs
@@ -7,7 +7,7 @@
 
 use arrow::array::{AsArray, RecordBatch};
 use dora_mavlink2_bridge::{MavlinkArrow, mavlink::dialects::common::HEARTBEAT_DATA};
-use dora_node_api::{DoraNode, Event, arrow::array::ArrayRef};
+use dora_node_api::{DoraNode, Event, arrow_v59::array::ArrayRef};
 use eyre::{Result, bail, eyre};
 use std::time::{Duration, Instant};
 

--- a/examples/multiple-daemons/node/Cargo.toml
+++ b/examples/multiple-daemons/node/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dora-node-api = { workspace = true, features = ["tracing"] }
+dora-node-api = { workspace = true, features = ["arrow-v59", "tracing"] }
 eyre = { workspace = true }
 futures = { workspace = true }
 rand = "0.10.2"

--- a/examples/ros2-bridge/yaml-bridge-action-server/handler-node/Cargo.toml
+++ b/examples/ros2-bridge/yaml-bridge-action-server/handler-node/Cargo.toml
@@ -6,6 +6,6 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true , features = ["arrow-v59"] }
 arrow = { workspace = true }
 eyre = { workspace = true }

--- a/examples/ros2-bridge/yaml-bridge-action-server/handler-node/src/main.rs
+++ b/examples/ros2-bridge/yaml-bridge-action-server/handler-node/src/main.rs
@@ -25,7 +25,8 @@ fn main() -> eyre::Result<()> {
                     // correlate feedback/result to the correct goal.
                     let params = metadata.parameters;
 
-                    let Some(struct_array) = data.as_any().downcast_ref::<StructArray>() else {
+                    let Some(struct_array) = data.as_array().as_any().downcast_ref::<StructArray>()
+                    else {
                         eprintln!("Warning: expected struct array for goal, skipping");
                         continue;
                     };

--- a/examples/ros2-bridge/yaml-bridge-action/goal-node/Cargo.toml
+++ b/examples/ros2-bridge/yaml-bridge-action/goal-node/Cargo.toml
@@ -6,6 +6,6 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true , features = ["arrow-v59"] }
 arrow = { workspace = true }
 eyre = { workspace = true }

--- a/examples/ros2-bridge/yaml-bridge-action/goal-node/src/main.rs
+++ b/examples/ros2-bridge/yaml-bridge-action/goal-node/src/main.rs
@@ -28,6 +28,7 @@ fn main() -> eyre::Result<()> {
                 }
                 "feedback" => {
                     let struct_array = data
+                        .as_array()
                         .as_any()
                         .downcast_ref::<StructArray>()
                         .expect("expected struct array for feedback");
@@ -53,6 +54,7 @@ fn main() -> eyre::Result<()> {
                 }
                 "result" => {
                     let struct_array = data
+                        .as_array()
                         .as_any()
                         .downcast_ref::<StructArray>()
                         .expect("expected struct array for result");

--- a/examples/ros2-bridge/yaml-bridge-service/handler-node/Cargo.toml
+++ b/examples/ros2-bridge/yaml-bridge-service/handler-node/Cargo.toml
@@ -6,6 +6,6 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true , features = ["arrow-v59"] }
 arrow = { workspace = true }
 eyre = { workspace = true }

--- a/examples/ros2-bridge/yaml-bridge-service/handler-node/src/main.rs
+++ b/examples/ros2-bridge/yaml-bridge-service/handler-node/src/main.rs
@@ -20,6 +20,7 @@ fn main() -> eyre::Result<()> {
                 "request" => {
                     // Parse Arrow struct matching AddTwoInts_Request: {a: i64, b: i64}
                     let struct_array = data
+                        .as_array()
                         .as_any()
                         .downcast_ref::<StructArray>()
                         .expect("expected struct array for request");

--- a/examples/ros2-bridge/yaml-bridge-service/requester-node/Cargo.toml
+++ b/examples/ros2-bridge/yaml-bridge-service/requester-node/Cargo.toml
@@ -6,6 +6,6 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true , features = ["arrow-v59"] }
 arrow = { workspace = true }
 eyre = { workspace = true }

--- a/examples/ros2-bridge/yaml-bridge-service/requester-node/src/main.rs
+++ b/examples/ros2-bridge/yaml-bridge-service/requester-node/src/main.rs
@@ -32,6 +32,7 @@ fn main() -> eyre::Result<()> {
                 "response" => {
                     // Parse Arrow struct matching AddTwoInts_Response: {sum: i64}
                     let struct_array = data
+                        .as_array()
                         .as_any()
                         .downcast_ref::<StructArray>()
                         .expect("expected struct array for response");

--- a/examples/rust-dataflow/node/Cargo.toml
+++ b/examples/rust-dataflow/node/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dora-node-api = { workspace = true, features = ["tracing", "metrics"] }
+dora-node-api = { workspace = true, features = ["arrow-v59", "tracing", "metrics"] }
 eyre = { workspace = true }
 futures = { workspace = true }
 fastrand = "2.4.1"

--- a/examples/rust-dataflow/node/src/tests.rs
+++ b/examples/rust-dataflow/node/src/tests.rs
@@ -5,7 +5,7 @@ use std::{
 
 use dora_node_api::{
     DoraNode, Event, IntoArrow,
-    arrow::array::{Array, NullArray},
+    arrow_v59::array::{Array, NullArray},
     dora_core::config::DataId,
     integration_testing::{
         self, IntegrationTestInput, TestingOptions,
@@ -112,7 +112,7 @@ fn test_sample_output() -> eyre::Result<()> {
         match event {
             Event::Input { id, metadata, data } => match id.as_str() {
                 "tick" => {
-                    assert_eq!(data.to_data(), NullArray::new(0).to_data());
+                    assert_eq!(data.as_array().to_data(), NullArray::new(0).to_data());
                     node.send_output(output.clone(), metadata.parameters, i.into_arrow())?;
                 }
                 other => panic!("unexpected input `{other}`"),

--- a/examples/rust-dataflow/status-node/Cargo.toml
+++ b/examples/rust-dataflow/status-node/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 
 
 [dependencies]
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true  }
 eyre = { workspace = true }
 
 [dev-dependencies]

--- a/examples/rust-dynamic-add-remove/filter/Cargo.toml
+++ b/examples/rust-dynamic-add-remove/filter/Cargo.toml
@@ -6,5 +6,5 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true  }
 eyre = { workspace = true }

--- a/examples/rust-dynamic-add-remove/sender/Cargo.toml
+++ b/examples/rust-dynamic-add-remove/sender/Cargo.toml
@@ -6,5 +6,5 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true  }
 eyre = { workspace = true }

--- a/examples/service-example/client/Cargo.toml
+++ b/examples/service-example/client/Cargo.toml
@@ -6,6 +6,6 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true , features = ["arrow-v59"] }
 eyre = { workspace = true }
 arrow = { workspace = true }

--- a/examples/service-example/client/src/main.rs
+++ b/examples/service-example/client/src/main.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use dora_node_api::{
     DoraNode, Event, MetadataParameters, REQUEST_ID,
-    arrow::array::{Array, Int64Array, StructArray},
+    arrow_v59::array::{Array, Int64Array, StructArray},
     get_string_param,
 };
 use eyre::Context;
@@ -53,7 +53,7 @@ fn main() -> eyre::Result<()> {
                     let rid = get_string_param(&metadata.parameters, REQUEST_ID);
 
                     if let Some(rid) = rid {
-                        let struct_array = StructArray::from(data.to_data());
+                        let struct_array = StructArray::from(data.as_array().to_data());
                         let sum_col = struct_array
                             .column_by_name("sum")
                             .and_then(|c| c.as_any().downcast_ref::<Int64Array>())

--- a/examples/service-example/server/Cargo.toml
+++ b/examples/service-example/server/Cargo.toml
@@ -6,6 +6,6 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true , features = ["arrow-v59"] }
 eyre = { workspace = true }
 arrow = { workspace = true }

--- a/examples/service-example/server/src/main.rs
+++ b/examples/service-example/server/src/main.rs
@@ -1,6 +1,6 @@
 use dora_node_api::{
     DoraNode, Event,
-    arrow::array::{Array, Int64Array, StructArray},
+    arrow_v59::array::{Array, Int64Array, StructArray},
 };
 use eyre::Context;
 
@@ -14,7 +14,7 @@ fn main() -> eyre::Result<()> {
                 metadata,
                 data,
             } => {
-                let struct_array = StructArray::from(data.to_data());
+                let struct_array = StructArray::from(data.as_array().to_data());
 
                 let a = struct_array
                     .column_by_name("a")

--- a/examples/validated-pipeline/sink/Cargo.toml
+++ b/examples/validated-pipeline/sink/Cargo.toml
@@ -6,5 +6,5 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true , features = ["arrow-v59"] }
 eyre = { workspace = true }

--- a/examples/validated-pipeline/sink/src/main.rs
+++ b/examples/validated-pipeline/sink/src/main.rs
@@ -1,4 +1,4 @@
-use dora_node_api::{DoraNode, Event, EventStream, arrow};
+use dora_node_api::{DoraNode, Event, EventStream, arrow_v59 as arrow};
 use eyre::{ContextCompat, bail};
 
 #[cfg(test)]
@@ -16,6 +16,7 @@ fn run(_node: DoraNode, mut events: EventStream) -> eyre::Result<()> {
         match event {
             Event::Input { id, data, .. } if id.as_str() == "doubled" => {
                 let arr = data
+                    .as_array()
                     .as_any()
                     .downcast_ref::<arrow::array::Int64Array>()
                     .context("expected Int64Array")?;

--- a/examples/validated-pipeline/source/Cargo.toml
+++ b/examples/validated-pipeline/source/Cargo.toml
@@ -6,5 +6,5 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true  }
 eyre = { workspace = true }

--- a/examples/validated-pipeline/transform/Cargo.toml
+++ b/examples/validated-pipeline/transform/Cargo.toml
@@ -6,5 +6,5 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true , features = ["arrow-v59"] }
 eyre = { workspace = true }

--- a/examples/validated-pipeline/transform/src/main.rs
+++ b/examples/validated-pipeline/transform/src/main.rs
@@ -1,4 +1,6 @@
-use dora_node_api::{DoraNode, Event, EventStream, IntoArrow, arrow, dora_core::config::DataId};
+use dora_node_api::{
+    DoraNode, Event, EventStream, IntoArrow, arrow_v59 as arrow, dora_core::config::DataId,
+};
 use eyre::{ContextCompat, bail};
 
 #[cfg(test)]
@@ -18,6 +20,7 @@ fn run(mut node: DoraNode, mut events: EventStream) -> eyre::Result<()> {
                 id, data, metadata, ..
             } if id.as_str() == "value" => {
                 let arr = data
+                    .as_array()
                     .as_any()
                     .downcast_ref::<arrow::array::Int64Array>()
                     .context("expected Int64Array")?;

--- a/libraries/arrow-convert/Cargo.toml
+++ b/libraries/arrow-convert/Cargo.toml
@@ -11,8 +11,24 @@ repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+# Empty by default, deliberately: if a blessed Arrow major sat in `default` and
+# `default` later changed, that would be a breaking change for anyone relying
+# on it — the silent-drift problem this design exists to remove, reinvented one
+# level up. See docs/plan-arrow-version-decoupling.md.
+default = []
+# Arrow 58 compat: adds an aliased dependency plus the C-Data-Interface bridge.
+arrow-v58 = ["dep:arrow58", "arrow/ffi"]
+# dora's *internal* Arrow major. Pulls no extra dependency — it re-exports the
+# copy of Arrow 59 dora already links, so exactly one copy of Arrow 59 is in
+# the build. The feature exists so that naming the internal major is an
+# explicit opt-in like every other, and so the gating survives unchanged when
+# 59 stops being internal.
+arrow-v59 = []
+
 [dependencies]
 arrow = { workspace = true }
+arrow58 = { package = "arrow", version = "58", optional = true, default-features = false, features = ["ffi"] }
 eyre = { workspace = true }
 tracing = { workspace = true }
 half = "2.7.1"

--- a/libraries/arrow-convert/src/ffi_bridge.rs
+++ b/libraries/arrow-convert/src/ffi_bridge.rs
@@ -200,7 +200,7 @@ mod tests {
     use arrow58::array::{Array, ArrayRef};
 
     /// 58 → 59 → 58. The values must survive both hops, and the schema with
-    /// them: a mis-set field in the reinterpreted `FFI_ArrowSchema` shows up
+    /// them: a wrongly set field in the reinterpreted `FFI_ArrowSchema` shows up
     /// here as a changed data type or a decode error.
     #[test]
     fn round_trip_58_59_58() {

--- a/libraries/arrow-convert/src/ffi_bridge.rs
+++ b/libraries/arrow-convert/src/ffi_bridge.rs
@@ -1,0 +1,343 @@
+//! Zero-copy bridge between dora's internal Arrow major (59) and Arrow 58.
+//!
+//! Enabled by the `arrow-v58` feature. This is the worked example of
+//! cross-major support described in `docs/plan-arrow-version-decoupling.md`;
+//! adding further majors means copying this module and swapping the alias.
+//!
+//! # How it works
+//!
+//! Both crates implement the [Arrow C Data Interface][spec]: `to_ffi` exports
+//! an `ArrayData` as a `(FFI_ArrowArray, FFI_ArrowSchema)` pair, `from_ffi`
+//! imports one. Neither call copies buffers — the exported struct holds raw
+//! pointers into the original allocation plus a `release` callback and a
+//! `private_data` pointer that keeps that allocation alive.
+//!
+//! [spec]: https://arrow.apache.org/docs/format/CDataInterface.html
+//!
+//! # The unsafe part, and why it is sound
+//!
+//! `arrow58::ffi::FFI_ArrowArray` and `arrow::ffi::FFI_ArrowArray` are
+//! *distinct Rust types* to rustc, so handing one to the other's `from_ffi`
+//! requires a reinterpret. The safety argument is:
+//!
+//! 1. **Both types are `#[repr(C)]` definitions of the same C struct.** The C
+//!    Data Interface fixes the field order, types, and meaning of
+//!    `ArrowArray` and `ArrowSchema`. arrow-rs defines `FFI_ArrowArray` /
+//!    `FFI_ArrowSchema` as `#[repr(C)]` structs mirroring that layout — that
+//!    is their entire purpose, and it is what lets arrow-rs exchange arrays
+//!    with pyarrow, DuckDB, and every other implementation.
+//! 2. **The spec is frozen.** `ArrowArray`/`ArrowSchema` have not changed
+//!    since Arrow 1.0 and the format explicitly guarantees they will not; a
+//!    layout change would break every non-Rust consumer simultaneously. So
+//!    "the two Rust definitions agree" is not a coincidence to be re-checked
+//!    each release, it is the interoperability contract both crates advertise.
+//! 3. **We assert what we can mechanically assert.** The `const` blocks below
+//!    reject a size or alignment mismatch at *compile* time. That does not
+//!    prove field-for-field identity, but it catches the realistic failure
+//!    mode (a field added, removed, or retyped) rather than leaving it to
+//!    runtime.
+//! 4. **Ownership transfers exactly once.** `to_ffi` returns owned structs;
+//!    `std::mem::transmute` moves them (it does not copy — the source is
+//!    consumed and never dropped by the exporting crate), and `from_ffi`
+//!    takes the `FFI_ArrowArray` by value and becomes responsible for calling
+//!    `release`. There is no point at which both crates believe they own the
+//!    same struct, so no double-free.
+//! 5. **Cross-crate `release` is the designed behaviour.** The importing
+//!    crate calls the `release` function pointer the *exporting* crate stored
+//!    in the struct. That pointer refers to code in the exporting crate,
+//!    which is still linked into the same binary, and it frees the exporting
+//!    crate's `private_data` with the exporting crate's allocator. This is
+//!    exactly the arrangement the C Data Interface exists to support (it is
+//!    how arrow-rs frees memory pyarrow allocated), and the
+//!    `release_callback_*` tests below exercise it directly.
+//!
+//! What is *not* covered: if a future arrow-rs release changed
+//! `FFI_ArrowArray`'s layout while keeping its size and alignment, the
+//! compile-time asserts would not catch it. That would also be a breaking
+//! change to arrow-rs's own C interop, so it is treated as out of scope in
+//! the same way arrow-rs treats it.
+
+use eyre::{Context, Result};
+
+use crate::DoraArray;
+
+// Layout guards. A mismatch here means the reinterprets below are unsound, so
+// fail the build rather than the process.
+const _: () = assert!(
+    size_of::<arrow58::ffi::FFI_ArrowArray>() == size_of::<arrow::ffi::FFI_ArrowArray>(),
+    "FFI_ArrowArray size differs between Arrow 58 and Arrow 59"
+);
+const _: () = assert!(
+    align_of::<arrow58::ffi::FFI_ArrowArray>() == align_of::<arrow::ffi::FFI_ArrowArray>(),
+    "FFI_ArrowArray alignment differs between Arrow 58 and Arrow 59"
+);
+const _: () = assert!(
+    size_of::<arrow58::ffi::FFI_ArrowSchema>() == size_of::<arrow::ffi::FFI_ArrowSchema>(),
+    "FFI_ArrowSchema size differs between Arrow 58 and Arrow 59"
+);
+const _: () = assert!(
+    align_of::<arrow58::ffi::FFI_ArrowSchema>() == align_of::<arrow::ffi::FFI_ArrowSchema>(),
+    "FFI_ArrowSchema alignment differs between Arrow 58 and Arrow 59"
+);
+
+/// Import an Arrow 58 array into dora's internal Arrow major.
+///
+/// Zero-copy: the resulting array points at the same buffers, and keeps the
+/// Arrow 58 allocation alive through the C interface's `release` callback.
+pub fn v58_to_internal(array: &dyn arrow58::array::Array) -> Result<DoraArray> {
+    let (ffi_array, ffi_schema) = arrow58::ffi::to_ffi(&array.to_data())
+        .context("failed to export Arrow 58 array over FFI")?;
+
+    // SAFETY: see the module-level safety argument. Both structs are the same
+    // `#[repr(C)]` C Data Interface types, size- and align-checked above; the
+    // move transfers ownership (including the duty to call `release`) exactly
+    // once, from the Arrow 58 side to the Arrow 59 side.
+    let ffi_array: arrow::ffi::FFI_ArrowArray = unsafe { std::mem::transmute(ffi_array) };
+    // SAFETY: as above, for the schema struct.
+    let ffi_schema: arrow::ffi::FFI_ArrowSchema = unsafe { std::mem::transmute(ffi_schema) };
+
+    // SAFETY: `ffi_array` and `ffi_schema` were produced together by
+    // `arrow58::ffi::to_ffi` and describe the same array, which is `from_ffi`'s
+    // requirement. Ownership of `ffi_array` moves into `from_ffi`.
+    let data = unsafe { arrow::ffi::from_ffi(ffi_array, &ffi_schema) }
+        .context("failed to import array")?;
+    Ok(crate::internal::from_array_data(data))
+}
+
+/// Export a dora payload as an Arrow 58 array.
+///
+/// Zero-copy, and the mirror image of [`v58_to_internal`]: the Arrow 58 array
+/// keeps dora's buffers alive through the `release` callback dora's Arrow
+/// installed.
+pub fn internal_to_v58(data: &DoraArray) -> Result<arrow58::array::ArrayRef> {
+    let (ffi_array, ffi_schema) = arrow::ffi::to_ffi(&crate::internal::array_ref(data).to_data())
+        .context("failed to export dora payload over FFI")?;
+
+    // SAFETY: see the module-level safety argument; this is the same
+    // reinterpret as `v58_to_internal`, with the two majors swapped.
+    let ffi_array: arrow58::ffi::FFI_ArrowArray = unsafe { std::mem::transmute(ffi_array) };
+    // SAFETY: as above, for the schema struct.
+    let ffi_schema: arrow58::ffi::FFI_ArrowSchema = unsafe { std::mem::transmute(ffi_schema) };
+
+    // SAFETY: the pair was produced together by `arrow::ffi::to_ffi` and
+    // describes one array; ownership of `ffi_array` moves into `from_ffi`.
+    let imported = unsafe { arrow58::ffi::from_ffi(ffi_array, &ffi_schema) }
+        .context("failed to import array into Arrow 58")?;
+    Ok(arrow58::array::make_array(imported))
+}
+
+/// Conversions to and from Arrow 58.
+///
+/// These are *converting* accessors, not borrowing ones: Arrow 58 is not
+/// dora's internal major, so reaching it costs a C Data Interface hop. The hop
+/// does not copy buffers, but it does allocate the small FFI structs and a new
+/// `ArrayRef`.
+impl DoraArray {
+    /// Build a dora payload from an Arrow 58 array.
+    pub fn from_arrow_v58(array: &dyn arrow58::array::Array) -> Result<Self> {
+        v58_to_internal(array)
+    }
+
+    /// View this payload as an Arrow 58 array.
+    pub fn to_arrow_v58(&self) -> Result<arrow58::array::ArrayRef> {
+        internal_to_v58(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow58::array::Array as _;
+
+    /// 58 → 59 → 58. The values must survive both hops, and the schema with
+    /// them: a mis-set field in the reinterpreted `FFI_ArrowSchema` shows up
+    /// here as a changed data type or a decode error.
+    #[test]
+    fn round_trip_58_59_58() {
+        let original = arrow58::array::UInt64Array::from(vec![1u64, 2, 3, 4, 5]);
+
+        let dora = v58_to_internal(&original).expect("58 -> 59");
+        assert_eq!(dora.len(), 5);
+        assert_eq!(dora.type_name(), "UInt64");
+        let values: Vec<u64> = crate::into_vec(&dora).expect("read back");
+        assert_eq!(values, vec![1, 2, 3, 4, 5]);
+
+        let back = internal_to_v58(&dora).expect("59 -> 58");
+        let back = back
+            .as_any()
+            .downcast_ref::<arrow58::array::UInt64Array>()
+            .expect("still a UInt64Array after the round trip");
+        assert_eq!(back.values(), original.values());
+        assert_eq!(back.data_type(), original.data_type());
+    }
+
+    /// Nulls, strings, and nested types exercise more of the C interface than
+    /// a flat primitive: a string array carries three buffers, a struct array
+    /// carries children, and a validity bitmap adds a null buffer.
+    #[test]
+    fn round_trip_58_59_58_nested_and_nullable() {
+        use std::sync::Arc;
+
+        let strings = arrow58::array::StringArray::from(vec![Some("a"), None, Some("ccc")]);
+        let ints = arrow58::array::Int32Array::from(vec![Some(1), Some(2), None]);
+        let original = arrow58::array::StructArray::from(vec![
+            (
+                Arc::new(arrow58::datatypes::Field::new(
+                    "s",
+                    arrow58::datatypes::DataType::Utf8,
+                    true,
+                )),
+                Arc::new(strings) as arrow58::array::ArrayRef,
+            ),
+            (
+                Arc::new(arrow58::datatypes::Field::new(
+                    "i",
+                    arrow58::datatypes::DataType::Int32,
+                    true,
+                )),
+                Arc::new(ints) as arrow58::array::ArrayRef,
+            ),
+        ]);
+
+        let dora = v58_to_internal(&original).expect("58 -> 59");
+        assert_eq!(dora.len(), 3);
+
+        let back = internal_to_v58(&dora).expect("59 -> 58");
+        let back = back
+            .as_any()
+            .downcast_ref::<arrow58::array::StructArray>()
+            .expect("still a StructArray");
+        assert_eq!(back.len(), 3);
+        assert_eq!(back.num_columns(), 2);
+        assert_eq!(back.column(0).null_count(), 1);
+        assert_eq!(back.column(1).null_count(), 1);
+        assert_eq!(back.to_data(), original.to_data());
+    }
+
+    /// The release-callback path, which is where a layout mistake becomes a
+    /// use-after-free rather than a wrong answer.
+    ///
+    /// The imported Arrow 59 array is dropped **without ever being read**, so
+    /// the only thing that runs is Arrow 59 invoking the `release` callback
+    /// Arrow 58 installed. `flag` is owned by the Arrow 58 array's buffer
+    /// allocation, so it stays alive until that release actually happens, and
+    /// flips exactly then. A double-free would abort the process here; a
+    /// missing release would leave the flag unset.
+    #[test]
+    fn release_callback_runs_when_import_is_dropped_unread() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct DropCounter(Arc<AtomicUsize>);
+        impl Drop for DropCounter {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let releases = Arc::new(AtomicUsize::new(0));
+
+        let dora = {
+            // A buffer whose backing allocation carries `DropCounter`, so the
+            // counter fires precisely when Arrow 58's allocation is freed.
+            let bytes: Vec<u8> = (0..64u8).collect();
+            let owner = Arc::new((bytes.clone(), DropCounter(releases.clone())));
+            let ptr = std::ptr::NonNull::new(owner.0.as_ptr() as *mut u8).unwrap();
+            // SAFETY: `ptr`/`len` describe `owner.0`'s allocation, which the
+            // `Arc` passed as the owner keeps alive for the buffer's lifetime.
+            let buffer =
+                unsafe { arrow58::buffer::Buffer::from_custom_allocation(ptr, bytes.len(), owner) };
+            let array = arrow58::array::UInt8Array::from(
+                arrow58::array::ArrayData::builder(arrow58::datatypes::DataType::UInt8)
+                    .len(64)
+                    .add_buffer(buffer)
+                    .build()
+                    .unwrap(),
+            );
+
+            let dora = v58_to_internal(&array).expect("58 -> 59");
+            // Drop every Arrow 58 handle. The allocation must survive, because
+            // the imported Arrow 59 array still references it through the C
+            // interface.
+            drop(array);
+            assert_eq!(
+                releases.load(Ordering::SeqCst),
+                0,
+                "Arrow 58 freed the buffer while the Arrow 59 import still held it"
+            );
+            dora
+        };
+
+        // Never read `dora`; just drop it. Arrow 59 must now call the release
+        // callback Arrow 58 installed.
+        drop(dora);
+        assert_eq!(
+            releases.load(Ordering::SeqCst),
+            1,
+            "dropping the imported array must run Arrow 58's release callback exactly once"
+        );
+    }
+
+    /// The same check for the other direction: Arrow 58 releasing an
+    /// allocation Arrow 59 owns, again without the array ever being read.
+    #[test]
+    fn release_callback_runs_for_export_dropped_unread() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct DropCounter(Arc<AtomicUsize>);
+        impl Drop for DropCounter {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let releases = Arc::new(AtomicUsize::new(0));
+
+        let exported = {
+            let bytes: Vec<u8> = (0..64u8).collect();
+            let owner = Arc::new((bytes.clone(), DropCounter(releases.clone())));
+            let ptr = std::ptr::NonNull::new(owner.0.as_ptr() as *mut u8).unwrap();
+            // SAFETY: as in the test above — the `Arc` owner keeps the
+            // allocation alive for the buffer's lifetime.
+            let buffer =
+                unsafe { arrow::buffer::Buffer::from_custom_allocation(ptr, bytes.len(), owner) };
+            let data = arrow::array::ArrayData::builder(arrow::datatypes::DataType::UInt8)
+                .len(64)
+                .add_buffer(buffer)
+                .build()
+                .unwrap();
+            let dora = crate::internal::from_array_data(data);
+
+            let exported = internal_to_v58(&dora).expect("59 -> 58");
+            drop(dora);
+            assert_eq!(
+                releases.load(Ordering::SeqCst),
+                0,
+                "Arrow 59 freed the buffer while the Arrow 58 export still held it"
+            );
+            exported
+        };
+
+        drop(exported);
+        assert_eq!(
+            releases.load(Ordering::SeqCst),
+            1,
+            "dropping the exported array must run Arrow 59's release callback exactly once"
+        );
+    }
+
+    /// An empty array still has to carry a valid schema across the hop; a
+    /// zero-length import used to be the easiest way to trip a null-pointer
+    /// assumption in FFI glue.
+    #[test]
+    fn round_trip_empty_array_preserves_type() {
+        let original = arrow58::array::Float32Array::from(Vec::<f32>::new());
+        let dora = v58_to_internal(&original).expect("58 -> 59");
+        assert_eq!(dora.len(), 0);
+        assert_eq!(dora.type_name(), "Float32");
+        let back = internal_to_v58(&dora).expect("59 -> 58");
+        assert_eq!(back.data_type(), &arrow58::datatypes::DataType::Float32);
+        assert_eq!(back.len(), 0);
+    }
+}

--- a/libraries/arrow-convert/src/ffi_bridge.rs
+++ b/libraries/arrow-convert/src/ffi_bridge.rs
@@ -84,7 +84,7 @@ const _: () = assert!(
 ///
 /// Zero-copy: the resulting array points at the same buffers, and keeps the
 /// Arrow 58 allocation alive through the C interface's `release` callback.
-pub fn v58_to_internal(array: &dyn arrow58::array::Array) -> Result<DoraArray> {
+fn v58_to_internal(array: &dyn arrow58::array::Array) -> Result<DoraArray> {
     let (ffi_array, ffi_schema) = arrow58::ffi::to_ffi(&array.to_data())
         .context("failed to export Arrow 58 array over FFI")?;
 
@@ -106,10 +106,10 @@ pub fn v58_to_internal(array: &dyn arrow58::array::Array) -> Result<DoraArray> {
 
 /// Export a dora payload as an Arrow 58 array.
 ///
-/// Zero-copy, and the mirror image of [`v58_to_internal`]: the Arrow 58 array
+/// Zero-copy, and the mirror image of `v58_to_internal`: the Arrow 58 array
 /// keeps dora's buffers alive through the `release` callback dora's Arrow
 /// installed.
-pub fn internal_to_v58(data: &DoraArray) -> Result<arrow58::array::ArrayRef> {
+fn internal_to_v58(data: &DoraArray) -> Result<arrow58::array::ArrayRef> {
     let (ffi_array, ffi_schema) = arrow::ffi::to_ffi(&crate::internal::array_ref(data).to_data())
         .context("failed to export dora payload over FFI")?;
 
@@ -126,28 +126,78 @@ pub fn internal_to_v58(data: &DoraArray) -> Result<arrow58::array::ArrayRef> {
     Ok(arrow58::array::make_array(imported))
 }
 
-/// Conversions to and from Arrow 58.
+/// Import an Arrow 58 array as a dora payload.
 ///
-/// These are *converting* accessors, not borrowing ones: Arrow 58 is not
+/// ```ignore
+/// use arrow58::array::Array;
+///
+/// let dora = DoraArray::try_from(&concrete_arrow58_array as &dyn Array)?;
+/// ```
+///
+/// The conversion is **fallible**, so this is `TryFrom` and not `From`: the C
+/// Data Interface export/import can reject an array (arrow-rs returns an error
+/// for the layouts it cannot represent over the interface), and an infallible
+/// `From` would have to panic on those.
+///
+/// It is a *converting* conversion, not a borrowing one: Arrow 58 is not
 /// dora's internal major, so reaching it costs a C Data Interface hop. The hop
 /// does not copy buffers, but it does allocate the small FFI structs and a new
-/// `ArrayRef`.
-impl DoraArray {
-    /// Build a dora payload from an Arrow 58 array.
-    pub fn from_arrow_v58(array: &dyn arrow58::array::Array) -> Result<Self> {
+/// array handle.
+///
+/// The source type is `&dyn Array` rather than a generic `&A: Array` because
+/// coherence forbids the generic form: `impl<A: Array> TryFrom<&A> for
+/// DoraArray` collides with core's `impl<T, U: Into<T>> TryFrom<U> for T`,
+/// since a downstream crate may add `impl From<&TheirType> for DoraArray`
+/// (RFC 2451 permits `impl ForeignTrait<LocalType> for ForeignType`), and `A`
+/// could be instantiated at `TheirType`. `&dyn Array` is a concrete foreign
+/// type, so no downstream impl can exist and the overlap goes away. The
+/// `TryFrom<&ArrayRef>` impl below covers the other common source shape.
+impl TryFrom<&dyn arrow58::array::Array> for DoraArray {
+    type Error = eyre::Report;
+
+    fn try_from(array: &dyn arrow58::array::Array) -> Result<Self> {
         v58_to_internal(array)
     }
+}
 
-    /// View this payload as an Arrow 58 array.
-    pub fn to_arrow_v58(&self) -> Result<arrow58::array::ArrayRef> {
-        internal_to_v58(self)
+/// Import an Arrow 58 [`ArrayRef`](arrow58::array::ArrayRef) as a dora payload.
+///
+/// ```ignore
+/// let dora: DoraArray = (&arrow58_array_ref).try_into()?;
+/// ```
+///
+/// Same conversion as the `&dyn Array` impl above; provided separately because
+/// `&Arc<dyn Array>` does not unsize-coerce to `&dyn Array` during trait
+/// selection, so `(&array_ref).try_into()` would otherwise not resolve.
+impl TryFrom<&arrow58::array::ArrayRef> for DoraArray {
+    type Error = eyre::Report;
+
+    fn try_from(array: &arrow58::array::ArrayRef) -> Result<Self> {
+        v58_to_internal(array.as_ref())
+    }
+}
+
+/// Export a dora payload as an Arrow 58 array.
+///
+/// ```ignore
+/// let arrow58_array: arrow58::array::ArrayRef = (&dora).try_into()?;
+/// ```
+///
+/// Fallible for the same reason as the import direction above, and likewise
+/// zero-copy: the Arrow 58 array keeps dora's buffers alive through the
+/// `release` callback dora's Arrow installed.
+impl TryFrom<&DoraArray> for arrow58::array::ArrayRef {
+    type Error = eyre::Report;
+
+    fn try_from(data: &DoraArray) -> Result<Self> {
+        internal_to_v58(data)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow58::array::Array as _;
+    use arrow58::array::{Array, ArrayRef};
 
     /// 58 → 59 → 58. The values must survive both hops, and the schema with
     /// them: a mis-set field in the reinterpreted `FFI_ArrowSchema` shows up
@@ -156,13 +206,13 @@ mod tests {
     fn round_trip_58_59_58() {
         let original = arrow58::array::UInt64Array::from(vec![1u64, 2, 3, 4, 5]);
 
-        let dora = v58_to_internal(&original).expect("58 -> 59");
+        let dora = DoraArray::try_from(&original as &dyn Array).expect("58 -> 59");
         assert_eq!(dora.len(), 5);
         assert_eq!(dora.type_name(), "UInt64");
         let values: Vec<u64> = crate::into_vec(&dora).expect("read back");
         assert_eq!(values, vec![1, 2, 3, 4, 5]);
 
-        let back = internal_to_v58(&dora).expect("59 -> 58");
+        let back = ArrayRef::try_from(&dora).expect("59 -> 58");
         let back = back
             .as_any()
             .downcast_ref::<arrow58::array::UInt64Array>()
@@ -199,10 +249,10 @@ mod tests {
             ),
         ]);
 
-        let dora = v58_to_internal(&original).expect("58 -> 59");
+        let dora = DoraArray::try_from(&original as &dyn Array).expect("58 -> 59");
         assert_eq!(dora.len(), 3);
 
-        let back = internal_to_v58(&dora).expect("59 -> 58");
+        let back = ArrayRef::try_from(&dora).expect("59 -> 58");
         let back = back
             .as_any()
             .downcast_ref::<arrow58::array::StructArray>()
@@ -255,7 +305,7 @@ mod tests {
                     .unwrap(),
             );
 
-            let dora = v58_to_internal(&array).expect("58 -> 59");
+            let dora = DoraArray::try_from(&array as &dyn Array).expect("58 -> 59");
             // Drop every Arrow 58 handle. The allocation must survive, because
             // the imported Arrow 59 array still references it through the C
             // interface.
@@ -309,7 +359,7 @@ mod tests {
                 .unwrap();
             let dora = crate::internal::from_array_data(data);
 
-            let exported = internal_to_v58(&dora).expect("59 -> 58");
+            let exported = ArrayRef::try_from(&dora).expect("59 -> 58");
             drop(dora);
             assert_eq!(
                 releases.load(Ordering::SeqCst),
@@ -332,11 +382,14 @@ mod tests {
     /// assumption in FFI glue.
     #[test]
     fn round_trip_empty_array_preserves_type() {
-        let original = arrow58::array::Float32Array::from(Vec::<f32>::new());
-        let dora = v58_to_internal(&original).expect("58 -> 59");
+        // Also the one place the `&ArrayRef` source impl is exercised, so both
+        // import shapes stay covered.
+        let original: ArrayRef =
+            std::sync::Arc::new(arrow58::array::Float32Array::from(Vec::<f32>::new()));
+        let dora: DoraArray = (&original).try_into().expect("58 -> 59");
         assert_eq!(dora.len(), 0);
         assert_eq!(dora.type_name(), "Float32");
-        let back = internal_to_v58(&dora).expect("59 -> 58");
+        let back: ArrayRef = (&dora).try_into().expect("59 -> 58");
         assert_eq!(back.data_type(), &arrow58::datatypes::DataType::Float32);
         assert_eq!(back.len(), 0);
     }

--- a/libraries/arrow-convert/src/from_impls.rs
+++ b/libraries/arrow-convert/src/from_impls.rs
@@ -6,24 +6,14 @@ use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use eyre::ContextCompat;
 use half::f16;
 
-use crate::ArrowData;
+use crate::{DoraArray, internal::array_ref};
 
-impl From<ArrowData> for arrow::array::ArrayRef {
-    fn from(value: ArrowData) -> Self {
-        value.0
-    }
-}
-
-impl From<arrow::array::ArrayRef> for ArrowData {
-    fn from(value: arrow::array::ArrayRef) -> Self {
-        Self(value)
-    }
-}
-
-impl TryFrom<&ArrowData> for bool {
+impl TryFrom<&DoraArray> for bool {
     type Error = eyre::Report;
-    fn try_from(value: &ArrowData) -> Result<Self, Self::Error> {
-        let bool_array = value.as_boolean_opt().context("not a bool array")?;
+    fn try_from(value: &DoraArray) -> Result<Self, Self::Error> {
+        let bool_array = array_ref(value)
+            .as_boolean_opt()
+            .context("not a bool array")?;
         if bool_array.is_empty() {
             eyre::bail!("empty array");
         }
@@ -40,12 +30,11 @@ impl TryFrom<&ArrowData> for bool {
 macro_rules! impl_try_from_arrow_data {
     ($($t:ty => $arrow_type:ident),*) => {
         $(
-            impl TryFrom<&ArrowData> for $t {
+            impl TryFrom<&DoraArray> for $t {
                 type Error = eyre::Report;
 
-                fn try_from(value: &ArrowData) -> Result<Self, Self::Error> {
-                    let array = value
-                        .as_primitive_opt::<arrow::datatypes::$arrow_type>()
+                fn try_from(value: &DoraArray) -> Result<Self, Self::Error> {
+                    let array = array_ref(value).as_primitive_opt::<arrow::datatypes::$arrow_type>()
                         .context(concat!("not a primitive ", stringify!($arrow_type), " array"))?;
                     extract_single_primitive(array)
                 }
@@ -53,12 +42,11 @@ macro_rules! impl_try_from_arrow_data {
         )*
 
         $(
-            impl<'a> TryFrom<&'a ArrowData> for &'a [$t] {
+            impl<'a> TryFrom<&'a DoraArray> for &'a [$t] {
                 type Error = eyre::Report;
 
-                fn try_from(value: &'a ArrowData) -> Result<Self, Self::Error> {
-                    let array: &PrimitiveArray<arrow::datatypes::$arrow_type> = value
-                        .as_primitive_opt()
+                fn try_from(value: &'a DoraArray) -> Result<Self, Self::Error> {
+                    let array: &PrimitiveArray<arrow::datatypes::$arrow_type> = array_ref(value).as_primitive_opt()
                         .wrap_err(concat!("not a primitive ", stringify!($arrow_type), " array"))?;
                     if array.null_count() != 0 {
                         eyre::bail!("array has nulls");
@@ -69,10 +57,10 @@ macro_rules! impl_try_from_arrow_data {
         )*
 
         $(
-            impl<'a> TryFrom<&'a ArrowData> for Vec<$t> {
+            impl<'a> TryFrom<&'a DoraArray> for Vec<$t> {
                 type Error = eyre::Report;
 
-                fn try_from(value: &'a ArrowData) -> Result<Self, Self::Error> {
+                fn try_from(value: &'a DoraArray) -> Result<Self, Self::Error> {
                     value
                         .try_into()
                         .map(|slice: &'a [$t]| slice.to_vec())
@@ -96,10 +84,12 @@ impl_try_from_arrow_data!(
     f64 => Float64Type
 );
 
-impl<'a> TryFrom<&'a ArrowData> for &'a str {
+impl<'a> TryFrom<&'a DoraArray> for &'a str {
     type Error = eyre::Report;
-    fn try_from(value: &'a ArrowData) -> Result<Self, Self::Error> {
-        let array: &StringArray = value.as_string_opt().wrap_err("not a string array")?;
+    fn try_from(value: &'a DoraArray) -> Result<Self, Self::Error> {
+        let array: &StringArray = array_ref(value)
+            .as_string_opt()
+            .wrap_err("not a string array")?;
         if array.is_empty() {
             eyre::bail!("empty array");
         }
@@ -113,9 +103,9 @@ impl<'a> TryFrom<&'a ArrowData> for &'a str {
     }
 }
 
-impl TryFrom<&ArrowData> for String {
+impl TryFrom<&DoraArray> for String {
     type Error = eyre::Report;
-    fn try_from(value: &ArrowData) -> Result<Self, Self::Error> {
+    fn try_from(value: &DoraArray) -> Result<Self, Self::Error> {
         // Delegate to the `&str` impl so the single-element validation lives in
         // one place and the two conversions can never drift apart.
         let s: &str = value.try_into()?;
@@ -123,14 +113,17 @@ impl TryFrom<&ArrowData> for String {
     }
 }
 
-impl TryFrom<&ArrowData> for NaiveDate {
+impl TryFrom<&DoraArray> for NaiveDate {
     type Error = eyre::Report;
-    fn try_from(value: &ArrowData) -> Result<Self, Self::Error> {
+    fn try_from(value: &DoraArray) -> Result<Self, Self::Error> {
         const CTX: &str = "data type cannot be converted to NaiveDate";
-        if let Some(array) = value.as_any().downcast_ref::<arrow::array::Date32Array>() {
+        if let Some(array) = array_ref(value)
+            .as_any()
+            .downcast_ref::<arrow::array::Date32Array>()
+        {
             return single_temporal(array, |a, i| a.value_as_date(i), CTX);
         }
-        let array = value
+        let array = array_ref(value)
             .as_any()
             .downcast_ref::<arrow::array::Date64Array>()
             .context("Reference is neither to a Date32Array nor a Date64Array")?;
@@ -138,58 +131,58 @@ impl TryFrom<&ArrowData> for NaiveDate {
     }
 }
 
-impl TryFrom<&ArrowData> for NaiveTime {
+impl TryFrom<&DoraArray> for NaiveTime {
     type Error = eyre::Report;
-    fn try_from(value: &ArrowData) -> Result<Self, Self::Error> {
+    fn try_from(value: &DoraArray) -> Result<Self, Self::Error> {
         const CTX: &str = "data type cannot be converted to NaiveTime";
-        if let Some(array) = value
+        if let Some(array) = array_ref(value)
             .as_any()
             .downcast_ref::<arrow::array::Time32SecondArray>()
         {
             return single_temporal(array, |a, i| a.value_as_time(i), CTX);
         }
-        if let Some(array) = value
+        if let Some(array) = array_ref(value)
             .as_any()
             .downcast_ref::<arrow::array::Time32MillisecondArray>()
         {
             return single_temporal(array, |a, i| a.value_as_time(i), CTX);
         }
-        if let Some(array) = value
+        if let Some(array) = array_ref(value)
             .as_any()
             .downcast_ref::<arrow::array::Time64MicrosecondArray>()
         {
             return single_temporal(array, |a, i| a.value_as_time(i), CTX);
         }
-        let array = value
+        let array = array_ref(value)
             .as_primitive_opt::<arrow::datatypes::Time64NanosecondType>()
             .context("not any of the primitive Time arrays")?;
         single_temporal(array, |a, i| a.value_as_time(i), CTX)
     }
 }
 
-impl TryFrom<&ArrowData> for NaiveDateTime {
+impl TryFrom<&DoraArray> for NaiveDateTime {
     type Error = eyre::Report;
-    fn try_from(value: &ArrowData) -> Result<Self, Self::Error> {
+    fn try_from(value: &DoraArray) -> Result<Self, Self::Error> {
         const CTX: &str = "data type cannot be converted to NaiveDateTime";
-        if let Some(array) = value
+        if let Some(array) = array_ref(value)
             .as_any()
             .downcast_ref::<arrow::array::TimestampSecondArray>()
         {
             return single_temporal(array, |a, i| a.value_as_datetime(i), CTX);
         }
-        if let Some(array) = value
+        if let Some(array) = array_ref(value)
             .as_any()
             .downcast_ref::<arrow::array::TimestampMillisecondArray>()
         {
             return single_temporal(array, |a, i| a.value_as_datetime(i), CTX);
         }
-        if let Some(array) = value
+        if let Some(array) = array_ref(value)
             .as_any()
             .downcast_ref::<arrow::array::TimestampMicrosecondArray>()
         {
             return single_temporal(array, |a, i| a.value_as_datetime(i), CTX);
         }
-        let array = value
+        let array = array_ref(value)
             .as_primitive_opt::<arrow::datatypes::TimestampNanosecondType>()
             .context("not any of the primitive Timestamp arrays")?;
         single_temporal(array, |a, i| a.value_as_datetime(i), CTX)
@@ -198,7 +191,7 @@ impl TryFrom<&ArrowData> for NaiveDateTime {
 
 /// Extract the single scalar out of a length-1, non-null temporal array.
 ///
-/// Every temporal `TryFrom<&ArrowData>` arm above shares the exact same shape:
+/// Every temporal `TryFrom<&DoraArray>` arm above shares the exact same shape:
 /// validate that the array holds exactly one non-null element, then convert
 /// element 0 via one of arrow's `value_as_{date,time,datetime}` accessors.
 /// Centralizing it here removes ~8 near-verbatim copies and keeps the
@@ -246,13 +239,13 @@ where
 mod tests {
     use arrow::array::{PrimitiveArray, make_array};
 
-    use crate::ArrowData;
+    use crate::{DoraArray, internal::from_array_ref};
 
     #[test]
     fn test_u8() {
         let array =
             make_array(PrimitiveArray::<arrow::datatypes::UInt8Type>::from(vec![42]).into());
-        let data: ArrowData = array.into();
+        let data: DoraArray = from_array_ref(array);
         let value: u8 = (&data).try_into().unwrap();
         assert_eq!(value, 42);
     }

--- a/libraries/arrow-convert/src/internal.rs
+++ b/libraries/arrow-convert/src/internal.rs
@@ -1,0 +1,40 @@
+//! Raw access to the Arrow array inside a [`DoraArray`], for dora's own crates.
+//!
+//! # Not public API
+//!
+//! Everything in this module names dora's **internal** Arrow major and is
+//! **exempt from dora's semver guarantee**. It changes — silently, in a minor
+//! release — whenever dora bumps its internal Arrow. It is `pub` only because
+//! `DoraArray` lives in this crate while the code that has to build and unwrap
+//! it (`dora-node-api`, the C/C++/Python bindings, the record/replay nodes)
+//! lives in others; Rust has no cross-crate `pub(crate)`.
+//!
+//! This module is deliberately **not** re-exported from `dora-node-api`, so it
+//! is not reachable from the frozen 1.x surface. Do not depend on it from
+//! outside the dora workspace. If you need the Arrow array, enable the feature
+//! that names your major (`arrow-v59`, `arrow-v58`, …) and use
+//! [`DoraArray::as_array`](crate::DoraArray::as_array) /
+//! [`DoraArray::to_arrow_v58`](crate::DoraArray::to_arrow_v58), which are
+//! version-honest and therefore cannot drift under you.
+
+use crate::DoraArray;
+
+/// Wrap an Arrow array (internal major) as a dora payload.
+pub fn from_array_ref(array: arrow::array::ArrayRef) -> DoraArray {
+    DoraArray(array)
+}
+
+/// Wrap Arrow [`ArrayData`](arrow::array::ArrayData) as a dora payload.
+pub fn from_array_data(data: arrow::array::ArrayData) -> DoraArray {
+    DoraArray(arrow::array::make_array(data))
+}
+
+/// Borrow the Arrow array (internal major) inside a dora payload.
+pub fn array_ref(data: &DoraArray) -> &arrow::array::ArrayRef {
+    &data.0
+}
+
+/// Take the Arrow array (internal major) out of a dora payload.
+pub fn into_array_ref(data: DoraArray) -> arrow::array::ArrayRef {
+    data.0
+}

--- a/libraries/arrow-convert/src/internal.rs
+++ b/libraries/arrow-convert/src/internal.rs
@@ -13,9 +13,9 @@
 //! is not reachable from the frozen 1.x surface. Do not depend on it from
 //! outside the dora workspace. If you need the Arrow array, enable the feature
 //! that names your major (`arrow-v59`, `arrow-v58`, …) and use
-//! [`DoraArray::as_array`](crate::DoraArray::as_array) /
-//! [`DoraArray::to_arrow_v58`](crate::DoraArray::to_arrow_v58), which are
-//! version-honest and therefore cannot drift under you.
+//! [`DoraArray::as_array`](crate::DoraArray::as_array) or the `TryFrom` impls
+//! in the `ffi_bridge` module, which are version-honest and therefore cannot
+//! drift under you.
 
 use crate::DoraArray;
 

--- a/libraries/arrow-convert/src/into_impls.rs
+++ b/libraries/arrow-convert/src/into_impls.rs
@@ -1,4 +1,4 @@
-use crate::IntoArrow;
+use crate::{DoraArray, IntoArrow, internal::from_array_ref};
 use arrow::array::{PrimitiveArray, StringArray, TimestampNanosecondArray};
 use arrow::datatypes::{
     ArrowTimestampType, Float16Type, Float32Type, Float64Type, Int8Type, Int16Type, Int32Type,
@@ -8,10 +8,14 @@ use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use half::f16;
 use tracing::warn;
 
+/// Wrap a concrete Arrow array as a [`DoraArray`].
+fn wrap(array: impl arrow::array::Array + 'static) -> DoraArray {
+    from_array_ref(std::sync::Arc::new(array))
+}
+
 impl IntoArrow for bool {
-    type A = arrow::array::BooleanArray;
-    fn into_arrow(self) -> Self::A {
-        std::iter::once(Some(self)).collect()
+    fn into_arrow(self) -> DoraArray {
+        wrap(std::iter::once(Some(self)).collect::<arrow::array::BooleanArray>())
     }
 }
 
@@ -19,17 +23,15 @@ macro_rules! impl_into_arrow {
     ($($t:ty => $arrow_type:ty),*) => {
         $(
             impl IntoArrow for $t {
-                type A = PrimitiveArray<$arrow_type>;
-                fn into_arrow(self) -> Self::A {
-                    std::iter::once(self).collect()
+                fn into_arrow(self) -> DoraArray {
+                    wrap(std::iter::once(self).collect::<PrimitiveArray<$arrow_type>>())
                 }
             }
         )*
         $(
             impl IntoArrow for Vec<$t> {
-                type A = PrimitiveArray<$arrow_type>;
-                fn into_arrow(self) -> Self::A {
-                    self.into()
+                fn into_arrow(self) -> DoraArray {
+                    wrap(PrimitiveArray::<$arrow_type>::from(self))
                 }
             }
         )*
@@ -51,46 +53,42 @@ impl_into_arrow!(
 );
 
 impl IntoArrow for &str {
-    type A = StringArray;
-    fn into_arrow(self) -> Self::A {
-        std::iter::once(Some(self)).collect()
+    fn into_arrow(self) -> DoraArray {
+        wrap(std::iter::once(Some(self)).collect::<StringArray>())
     }
 }
 
 impl IntoArrow for () {
-    type A = arrow::array::NullArray;
-    fn into_arrow(self) -> Self::A {
-        arrow::array::NullArray::new(0)
+    fn into_arrow(self) -> DoraArray {
+        wrap(arrow::array::NullArray::new(0))
     }
 }
 
 impl IntoArrow for NaiveDate {
-    type A = arrow::array::Date64Array;
-    fn into_arrow(self) -> Self::A {
-        arrow::array::Date64Array::from(vec![arrow::datatypes::Date64Type::from_naive_date(self)])
+    fn into_arrow(self) -> DoraArray {
+        wrap(arrow::array::Date64Array::from(vec![
+            arrow::datatypes::Date64Type::from_naive_date(self),
+        ]))
     }
 }
 
 impl IntoArrow for NaiveTime {
-    type A = arrow::array::Time64NanosecondArray;
-    fn into_arrow(self) -> Self::A {
-        arrow::array::Time64NanosecondArray::from(vec![
+    fn into_arrow(self) -> DoraArray {
+        wrap(arrow::array::Time64NanosecondArray::from(vec![
             arrow::array::temporal_conversions::time_to_time64ns(self),
-        ])
+        ]))
     }
 }
 
 impl IntoArrow for String {
-    type A = StringArray;
-    fn into_arrow(self) -> Self::A {
-        std::iter::once(Some(self)).collect()
+    fn into_arrow(self) -> DoraArray {
+        wrap(std::iter::once(Some(self)).collect::<StringArray>())
     }
 }
 
 impl IntoArrow for Vec<String> {
-    type A = StringArray;
-    fn into_arrow(self) -> Self::A {
-        StringArray::from(self)
+    fn into_arrow(self) -> DoraArray {
+        wrap(StringArray::from(self))
     }
 }
 
@@ -99,8 +97,7 @@ impl IntoArrow for Vec<String> {
 /// (far-past) or `i64::MAX` (far-future) and a `tracing::warn!` is emitted,
 /// rather than silently mapping to the Unix epoch (the previous behaviour).
 impl IntoArrow for NaiveDateTime {
-    type A = arrow::array::TimestampNanosecondArray;
-    fn into_arrow(self) -> Self::A {
+    fn into_arrow(self) -> DoraArray {
         let timestamp =
             match arrow::datatypes::TimestampNanosecondType::from_naive_datetime(self, None) {
                 Some(ts) => ts,
@@ -117,14 +114,23 @@ impl IntoArrow for NaiveDateTime {
                     saturated
                 }
             };
-        TimestampNanosecondArray::from(vec![timestamp])
+        wrap(TimestampNanosecondArray::from(vec![timestamp]))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrow::array::Array as _;
     use chrono::NaiveDate;
+
+    fn timestamp_of(data: &DoraArray) -> i64 {
+        crate::internal::array_ref(data)
+            .as_any()
+            .downcast_ref::<TimestampNanosecondArray>()
+            .expect("timestamp array")
+            .value(0)
+    }
 
     #[test]
     fn naive_datetime_out_of_range_saturates() {
@@ -134,7 +140,7 @@ mod tests {
             .and_hms_opt(0, 0, 0)
             .unwrap();
         let arr = far_future.into_arrow();
-        assert_eq!(arr.value(0), i64::MAX);
+        assert_eq!(timestamp_of(&arr), i64::MAX);
 
         // Far-past date (year 1000) should saturate to i64::MIN
         let far_past = NaiveDate::from_ymd_opt(1000, 1, 1)
@@ -142,6 +148,67 @@ mod tests {
             .and_hms_opt(0, 0, 0)
             .unwrap();
         let arr = far_past.into_arrow();
-        assert_eq!(arr.value(0), i64::MIN);
+        assert_eq!(timestamp_of(&arr), i64::MIN);
     }
+}
+
+/// `IntoArrow` for Arrow arrays of dora's **internal** major, so
+/// `node.send_output(id, params, my_arrow_array)` keeps working for callers on
+/// that major with no wrapping and no conversion.
+///
+/// Gated for the same reason [`DoraArray::as_array`](crate::DoraArray::as_array)
+/// is: these impls name a specific Arrow major. When dora moves internally to
+/// Arrow 60 they re-gate behind `arrow-v60`, and `arrow-v59` keeps a converting
+/// equivalent — visibly, rather than silently changing meaning under callers.
+///
+/// A blanket `impl<A: arrow::array::Array> IntoArrow for A` is not possible:
+/// it overlaps with the primitive impls above under coherence's
+/// "upstream crates may add a new impl" rule, so the concrete types are listed.
+#[cfg(feature = "arrow-v59")]
+mod arrow_v59_impls {
+    use super::{DoraArray, IntoArrow, from_array_ref};
+    use arrow::array::{ArrayRef, PrimitiveArray};
+    use arrow::datatypes::ArrowPrimitiveType;
+
+    impl IntoArrow for ArrayRef {
+        fn into_arrow(self) -> DoraArray {
+            from_array_ref(self)
+        }
+    }
+
+    impl<T: ArrowPrimitiveType> IntoArrow for PrimitiveArray<T> {
+        fn into_arrow(self) -> DoraArray {
+            from_array_ref(std::sync::Arc::new(self))
+        }
+    }
+
+    macro_rules! impl_into_arrow_for_arrow_array {
+        ($($t:ty),* $(,)?) => {
+            $(
+                impl IntoArrow for $t {
+                    fn into_arrow(self) -> DoraArray {
+                        from_array_ref(std::sync::Arc::new(self))
+                    }
+                }
+            )*
+        };
+    }
+
+    impl_into_arrow_for_arrow_array!(
+        arrow::array::BooleanArray,
+        arrow::array::NullArray,
+        arrow::array::StringArray,
+        arrow::array::LargeStringArray,
+        arrow::array::StringViewArray,
+        arrow::array::BinaryArray,
+        arrow::array::LargeBinaryArray,
+        arrow::array::BinaryViewArray,
+        arrow::array::FixedSizeBinaryArray,
+        arrow::array::StructArray,
+        arrow::array::ListArray,
+        arrow::array::LargeListArray,
+        arrow::array::FixedSizeListArray,
+        arrow::array::MapArray,
+        arrow::array::UnionArray,
+    );
 }

--- a/libraries/arrow-convert/src/lib.rs
+++ b/libraries/arrow-convert/src/lib.rs
@@ -14,7 +14,7 @@
 //! | Feature | Effect |
 //! |---|---|
 //! | `arrow-v59` | dora's *internal* major. Adds the borrowing accessors [`DoraArray::as_array`] / [`DoraArray::into_inner`] and `From`/`Into` for `arrow::array::ArrayRef`. Pulls **no extra dependency** — it re-exports the copy of Arrow 59 dora already links. |
-//! | `arrow-v58` | An *older* major. Adds an aliased `arrow58` dependency plus [`DoraArray::to_arrow_v58`] / [`DoraArray::from_arrow_v58`], which hop across the Arrow C Data Interface (zero-copy, see [`ffi_bridge`]). |
+//! | `arrow-v58` | An *older* major. Adds an aliased `arrow58` dependency plus `TryFrom` impls in both directions, which hop across the Arrow C Data Interface (zero-copy, see the `ffi_bridge` module). The hop is fallible, hence `TryFrom` rather than `From`. |
 //!
 //! `default = []`, so neither is on unless asked for. See
 //! `docs/plan-arrow-version-decoupling.md` and the support-window policy in
@@ -153,7 +153,8 @@ impl DoraArray {
 /// This is free: no conversion, no allocation, just a reference to the array
 /// dora already holds. When dora later moves internally to Arrow 60, this
 /// borrowing pair re-gates behind `arrow-v60` and `arrow-v59` keeps a
-/// *converting* accessor (see [`DoraArray::to_arrow_v58`]) instead.
+/// *converting* `TryFrom` pair instead — which is exactly what `arrow-v58`
+/// already looks like today (see the `ffi_bridge` module).
 #[cfg(feature = "arrow-v59")]
 impl DoraArray {
     /// Borrow the underlying Arrow 59 array.

--- a/libraries/arrow-convert/src/lib.rs
+++ b/libraries/arrow-convert/src/lib.rs
@@ -1,4 +1,24 @@
 //! Provides functions for converting between Apache Arrow arrays and Rust data types.
+//!
+//! # Arrow version decoupling
+//!
+//! The types in this crate are re-exported from `dora-node-api`, whose public
+//! API is frozen at 1.0. To keep dora free to bump its *internal* Arrow major
+//! in a minor release, no Arrow type appears in the ungated public surface
+//! here: received payloads are [`DoraArray`], a dora-owned newtype with a
+//! private field, and [`IntoArrow::into_arrow`] returns that same type.
+//!
+//! Direct access to the underlying Arrow array is available, but only behind a
+//! feature that names the major explicitly:
+//!
+//! | Feature | Effect |
+//! |---|---|
+//! | `arrow-v59` | dora's *internal* major. Adds the borrowing accessors [`DoraArray::as_array`] / [`DoraArray::into_inner`] and `From`/`Into` for `arrow::array::ArrayRef`. Pulls **no extra dependency** — it re-exports the copy of Arrow 59 dora already links. |
+//! | `arrow-v58` | An *older* major. Adds an aliased `arrow58` dependency plus [`DoraArray::to_arrow_v58`] / [`DoraArray::from_arrow_v58`], which hop across the Arrow C Data Interface (zero-copy, see [`ffi_bridge`]). |
+//!
+//! `default = []`, so neither is on unless asked for. See
+//! `docs/plan-arrow-version-decoupling.md` and the support-window policy in
+//! `docs/api-rust.md`.
 
 #![warn(missing_docs)]
 
@@ -9,28 +29,35 @@ use arrow::array::{
 use arrow::datatypes::DataType;
 use eyre::{ContextCompat, Result, eyre};
 use num::NumCast;
-use std::ops::{Deref, DerefMut};
 
+#[cfg(feature = "arrow-v58")]
+pub mod ffi_bridge;
 mod from_impls;
+pub mod internal;
 mod into_impls;
 
-/// Data that can be converted to an Arrow array.
+/// Data that can be converted into a dora payload.
 ///
 /// This is the conversion that dora node APIs use to turn plain Rust values
 /// into the [Apache Arrow](https://arrow.apache.org/) columnar format before
 /// sending them as outputs. Implementations are provided for booleans,
 /// strings, the primitive integer and float types, `Vec`s of those primitive
 /// types, and a few `chrono` date/time types. The unit type `()` converts to
-/// an empty [`NullArray`](arrow::array::NullArray), which is useful for
-/// outputs that carry only metadata.
+/// an empty null array, which is useful for outputs that carry only metadata.
+/// [`DoraArray`] itself implements the trait as the identity conversion, so
+/// `send_output` accepts both plain Rust values and already-built payloads.
+///
+/// The trait deliberately has **no associated type**: an
+/// `type A: arrow::array::Array` bound would put Arrow back into dora's frozen
+/// public API and pin 1.x to a single Arrow major. `into_arrow` returns the
+/// dora-owned [`DoraArray`] instead.
 ///
 /// For the opposite direction (reading received Arrow data back into Rust
-/// types), see the `TryFrom<&ArrowData>` implementations on [`ArrowData`].
+/// types), see the `TryFrom<&DoraArray>` implementations on [`DoraArray`].
 ///
 /// # Example
 ///
 /// ```
-/// use arrow::array::Array;
 /// use dora_arrow_convert::IntoArrow;
 ///
 /// let array = vec![1.0_f32, 2.0, 3.0].into_arrow();
@@ -40,18 +67,20 @@ mod into_impls;
 /// assert_eq!(single.len(), 1);
 /// ```
 pub trait IntoArrow {
-    /// The Arrow array type that the data converts to.
-    type A: Array;
-
-    /// Convert the data into an Arrow array.
-    fn into_arrow(self) -> Self::A;
+    /// Convert the data into a dora payload.
+    fn into_arrow(self) -> DoraArray;
 }
 
-/// Wrapper type for an Arrow [`ArrayRef`](arrow::array::ArrayRef).
+/// A dora payload: an Apache Arrow array owned by dora.
 ///
-/// `ArrowData` is the counterpart to [`IntoArrow`]: dora node APIs hand
-/// received outputs to nodes as `ArrowData`, which is read back into plain
-/// Rust values through its `TryFrom<&ArrowData>` implementations.
+/// `DoraArray` is the counterpart to [`IntoArrow`]: dora node APIs hand
+/// received outputs to nodes as `DoraArray`, which is read back into plain
+/// Rust values through its `TryFrom<&DoraArray>` implementations.
+///
+/// The wrapped Arrow array is **private**. That is the whole point of the
+/// type: it is what lets dora change its internal Arrow major without
+/// breaking the 1.x contract. To reach the Arrow array itself, enable the
+/// feature naming the major you want — see the crate-level docs.
 ///
 /// Two conversion shapes are provided, with different length contracts:
 ///
@@ -64,50 +93,108 @@ pub trait IntoArrow {
 /// # Example
 ///
 /// ```
-/// use std::sync::Arc;
-/// use dora_arrow_convert::{ArrowData, IntoArrow};
+/// use dora_arrow_convert::{DoraArray, IntoArrow};
 ///
 /// // Scalar: a single-element array converts to the value.
-/// let data = ArrowData(Arc::new(42_u8.into_arrow()));
+/// let data: DoraArray = 42_u8.into_arrow();
 /// let scalar: u8 = (&data).try_into()?;
 /// assert_eq!(scalar, 42);
 ///
 /// // Strings follow the same single-element rule.
-/// let data = ArrowData(Arc::new("hello".to_string().into_arrow()));
+/// let data = "hello".to_string().into_arrow();
 /// let text: String = (&data).try_into()?;
 /// assert_eq!(text, "hello");
 ///
 /// // Vec: any length, collected into an owned `Vec`.
-/// let data = ArrowData(Arc::new(vec![1_i32, 2, 3].into_arrow()));
+/// let data = vec![1_i32, 2, 3].into_arrow();
 /// let values: Vec<i32> = (&data).try_into()?;
 /// assert_eq!(values, vec![1, 2, 3]);
 ///
 /// // A multi-element array cannot be read as a scalar.
-/// let data = ArrowData(Arc::new(vec![1_i32, 2, 3].into_arrow()));
+/// let data = vec![1_i32, 2, 3].into_arrow();
 /// let scalar: Result<i32, _> = (&data).try_into();
 /// assert!(scalar.is_err());
 /// # Ok::<(), eyre::Report>(())
 /// ```
-#[derive(Debug)]
-pub struct ArrowData(pub arrow::array::ArrayRef);
+#[derive(Debug, Clone)]
+pub struct DoraArray(arrow::array::ArrayRef);
 
-impl Deref for ArrowData {
-    type Target = arrow::array::ArrayRef;
+impl DoraArray {
+    /// The number of elements in the payload.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
 
-    fn deref(&self) -> &Self::Target {
-        &self.0
+    /// Whether the payload holds no elements.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// The number of null elements in the payload.
+    pub fn null_count(&self) -> usize {
+        self.0.null_count()
+    }
+
+    /// A human-readable name for the payload's Arrow type, e.g. `"UInt8"` or
+    /// `"List(Field { name: \"item\", .. })"`.
+    ///
+    /// Returned as a `String` rather than an `arrow_schema::DataType` so that
+    /// the ungated surface stays free of Arrow types. Use it for logging and
+    /// error messages; to actually inspect the type, take the array through a
+    /// version-gated accessor.
+    pub fn type_name(&self) -> String {
+        format!("{:?}", self.0.data_type())
     }
 }
 
-impl DerefMut for ArrowData {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+/// Borrowing access to the Arrow array, for callers on dora's **internal**
+/// Arrow major.
+///
+/// This is free: no conversion, no allocation, just a reference to the array
+/// dora already holds. When dora later moves internally to Arrow 60, this
+/// borrowing pair re-gates behind `arrow-v60` and `arrow-v59` keeps a
+/// *converting* accessor (see [`DoraArray::to_arrow_v58`]) instead.
+#[cfg(feature = "arrow-v59")]
+impl DoraArray {
+    /// Borrow the underlying Arrow 59 array.
+    pub fn as_array(&self) -> &arrow::array::ArrayRef {
+        &self.0
+    }
+
+    /// Take the underlying Arrow 59 array.
+    pub fn into_inner(self) -> arrow::array::ArrayRef {
+        self.0
+    }
+
+    /// Build a payload from any Arrow 59 array.
+    pub fn from_array(array: impl arrow::array::Array + 'static) -> Self {
+        Self(arrow::array::make_array(array.to_data()))
+    }
+}
+
+#[cfg(feature = "arrow-v59")]
+impl From<arrow::array::ArrayRef> for DoraArray {
+    fn from(value: arrow::array::ArrayRef) -> Self {
+        Self(value)
+    }
+}
+
+#[cfg(feature = "arrow-v59")]
+impl From<DoraArray> for arrow::array::ArrayRef {
+    fn from(value: DoraArray) -> Self {
+        value.0
+    }
+}
+
+impl IntoArrow for DoraArray {
+    fn into_arrow(self) -> DoraArray {
+        self
     }
 }
 
 macro_rules! register_array_handlers {
     ($(($variant:path, $array_type:ty, $type_name:expr)),* $(,)?) => {
-        /// Tries to convert the given Arrow array into a `Vec` of integers or floats.
+        /// Tries to convert the given payload into a `Vec` of integers or floats.
         ///
         /// The array's element type is cast to `T` per element via [`num::NumCast`],
         /// so the source and target types need not match (e.g. a `UInt64Array`
@@ -116,36 +203,31 @@ macro_rules! register_array_handlers {
         /// # Errors
         ///
         /// Returns an error if the array contains any null values (consistent
-        /// with every other [`TryFrom<&ArrowData>`] impl in this crate), if the
+        /// with every other [`TryFrom<&DoraArray>`] impl in this crate), if the
         /// array's data type is not a supported integer or float type, or if any
         /// element cannot be represented in `T` (an out-of-range cast).
         ///
         /// ```
-        /// use std::sync::Arc;
-        /// use arrow::array::{UInt64Array, StringArray};
-        /// use dora_arrow_convert::{ArrowData, into_vec};
+        /// use dora_arrow_convert::{IntoArrow, into_vec};
         ///
         /// // Values are cast element-wise to the requested target type.
-        /// let data = ArrowData(Arc::new(UInt64Array::from(vec![1u64, 2, 3])));
+        /// let data = vec![1u64, 2, 3].into_arrow();
         /// assert_eq!(into_vec::<u64>(&data).ok(), Some(vec![1, 2, 3]));
         /// assert_eq!(into_vec::<f64>(&data).ok(), Some(vec![1.0, 2.0, 3.0]));
         ///
-        /// // Any null in the array is rejected.
-        /// let with_null = ArrowData(Arc::new(UInt64Array::from(vec![Some(1u64), None])));
-        /// assert!(into_vec::<u64>(&with_null).is_err());
-        ///
         /// // Unsupported (non-numeric) array types are rejected.
-        /// let strings = ArrowData(Arc::new(StringArray::from(vec!["a", "b"])));
+        /// let strings = vec!["a".to_string(), "b".to_string()].into_arrow();
         /// assert!(into_vec::<u64>(&strings).is_err());
         /// ```
-        pub fn into_vec<T>(data: &ArrowData) -> Result<Vec<T>>
+        pub fn into_vec<T>(data: &DoraArray) -> Result<Vec<T>>
         where
             T: Copy + NumCast + 'static,
         {
-            match data.data_type() {
+            match data.0.data_type() {
                 $(
                     $variant => {
                         let buffer: &$array_type = data
+                            .0
                             .as_any()
                             .downcast_ref()
                             .context(concat!("series is not ", $type_name))?;
@@ -197,6 +279,10 @@ mod tests {
     use half::f16;
     use std::sync::Arc;
 
+    fn wrap(array: ArrayRef) -> DoraArray {
+        internal::from_array_ref(array)
+    }
+
     /// Round-trips every type registered in `register_array_handlers!` so a
     /// future macro entry that gets dropped (the original cause of #2080) is
     /// caught by a failing test rather than a silent runtime error.
@@ -206,7 +292,7 @@ mod tests {
             ($array_type:ty, $rust_type:ty, $values:expr) => {{
                 let values: Vec<$rust_type> = $values;
                 let array: ArrayRef = Arc::new(<$array_type>::from(values.clone()));
-                let data = ArrowData(array);
+                let data = wrap(array);
                 let result: Vec<$rust_type> = into_vec(&data).unwrap();
                 assert_eq!(result, values);
             }};
@@ -226,7 +312,7 @@ mod tests {
         // Float16 needs explicit f16 construction; round-trip back to f16.
         let values = vec![f16::from_f32(1.0), f16::from_f32(2.5), f16::from_f32(-3.0)];
         let array: ArrayRef = Arc::new(Float16Array::from(values.clone()));
-        let data = ArrowData(array);
+        let data = wrap(array);
         let result: Vec<f16> = into_vec(&data).unwrap();
         assert_eq!(result, values);
     }
@@ -235,7 +321,7 @@ mod tests {
     /// "Unsupported data type for conversion: UInt64".
     #[test]
     fn into_vec_handles_uint64() {
-        let data = ArrowData(Arc::new(UInt64Array::from(vec![1u64, 2, 3])));
+        let data = wrap(Arc::new(UInt64Array::from(vec![1u64, 2, 3])));
         let res: Vec<u64> = into_vec(&data).unwrap();
         assert_eq!(res, vec![1u64, 2, 3]);
     }
@@ -243,7 +329,7 @@ mod tests {
     #[test]
     fn into_vec_rejects_arrays_with_nulls() {
         let array: ArrayRef = Arc::new(UInt64Array::from(vec![Some(1u64), None, Some(3)]));
-        let data = ArrowData(array);
+        let data = wrap(array);
         let res: Result<Vec<u64>> = into_vec(&data);
         assert!(res.is_err());
     }
@@ -251,8 +337,20 @@ mod tests {
     #[test]
     fn into_vec_rejects_unsupported_type() {
         let array: ArrayRef = Arc::new(arrow::array::BooleanArray::from(vec![true, false]));
-        let data = ArrowData(array);
+        let data = wrap(array);
         let res: Result<Vec<u8>> = into_vec(&data);
         assert!(res.is_err());
+    }
+
+    /// `DoraArray`'s ungated inspection helpers must not require any Arrow
+    /// feature — they are the whole reason the common receive path compiles
+    /// with `default = []`.
+    #[test]
+    fn ungated_accessors() {
+        let data = vec![1u64, 2, 3].into_arrow();
+        assert_eq!(data.len(), 3);
+        assert!(!data.is_empty());
+        assert_eq!(data.null_count(), 0);
+        assert_eq!(data.type_name(), "UInt64");
     }
 }

--- a/libraries/arrow-convert/tests/conversion_test.rs
+++ b/libraries/arrow-convert/tests/conversion_test.rs
@@ -1,5 +1,5 @@
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
-use dora_arrow_convert::{ArrowData, IntoArrow, into_vec};
+use dora_arrow_convert::{DoraArray, IntoArrow, internal::from_array_ref, into_vec};
 use half::f16;
 use std::sync::Arc;
 
@@ -11,8 +11,7 @@ mod tests {
     #[test]
     fn test_bool_round_trip() -> Result<(), Report> {
         let value_bool: bool = true;
-        let arrow_array = value_bool.into_arrow();
-        let data: ArrowData = ArrowData(Arc::new(arrow_array));
+        let data: DoraArray = value_bool.into_arrow();
         let result_bool: bool = TryFrom::try_from(&data)?;
         assert_eq!(value_bool, result_bool);
         Ok(())
@@ -21,8 +20,7 @@ mod tests {
     #[test]
     fn test_u8_round_trip() -> Result<(), Report> {
         let value_u8: u8 = 42;
-        let arrow_array = value_u8.into_arrow();
-        let data: ArrowData = ArrowData(Arc::new(arrow_array));
+        let data: DoraArray = value_u8.into_arrow();
         let result_u8: u8 = TryFrom::try_from(&data)?;
         assert_eq!(value_u8, result_u8);
         Ok(())
@@ -31,8 +29,7 @@ mod tests {
     #[test]
     fn test_u16_round_trip() -> Result<(), Report> {
         let value_u16: u16 = 42;
-        let arrow_array = value_u16.into_arrow();
-        let data: ArrowData = ArrowData(Arc::new(arrow_array));
+        let data: DoraArray = value_u16.into_arrow();
         let result_u16: u16 = TryFrom::try_from(&data)?;
         assert_eq!(value_u16, result_u16);
         Ok(())
@@ -41,8 +38,7 @@ mod tests {
     #[test]
     fn test_u32_round_trip() -> Result<(), Report> {
         let value_u32: u32 = 42;
-        let arrow_array = value_u32.into_arrow();
-        let data: ArrowData = ArrowData(Arc::new(arrow_array));
+        let data: DoraArray = value_u32.into_arrow();
         let result_u32: u32 = TryFrom::try_from(&data)?;
         assert_eq!(value_u32, result_u32);
         Ok(())
@@ -51,8 +47,7 @@ mod tests {
     #[test]
     fn test_u64_round_trip() -> Result<(), Report> {
         let value_u64: u64 = 42;
-        let arrow_array = value_u64.into_arrow();
-        let data: ArrowData = ArrowData(Arc::new(arrow_array));
+        let data: DoraArray = value_u64.into_arrow();
         let result_u64: u64 = TryFrom::try_from(&data)?;
         assert_eq!(value_u64, result_u64);
         Ok(())
@@ -61,8 +56,7 @@ mod tests {
     #[test]
     fn test_i8_round_trip() -> Result<(), Report> {
         let value_i8: i8 = 42;
-        let arrow_array = value_i8.into_arrow();
-        let data: ArrowData = ArrowData(Arc::new(arrow_array));
+        let data: DoraArray = value_i8.into_arrow();
         let result_i8: i8 = TryFrom::try_from(&data)?;
         assert_eq!(value_i8, result_i8);
         Ok(())
@@ -71,8 +65,7 @@ mod tests {
     #[test]
     fn test_i16_round_trip() -> Result<(), Report> {
         let value_i16: i16 = 42;
-        let arrow_array = value_i16.into_arrow();
-        let data: ArrowData = ArrowData(Arc::new(arrow_array));
+        let data: DoraArray = value_i16.into_arrow();
         let result_i16: i16 = TryFrom::try_from(&data)?;
         assert_eq!(value_i16, result_i16);
         Ok(())
@@ -81,8 +74,7 @@ mod tests {
     #[test]
     fn test_i32_round_trip() -> Result<(), Report> {
         let value_i32: i32 = 42;
-        let arrow_array = value_i32.into_arrow();
-        let data: ArrowData = ArrowData(Arc::new(arrow_array));
+        let data: DoraArray = value_i32.into_arrow();
         let result_i32: i32 = TryFrom::try_from(&data)?;
         assert_eq!(value_i32, result_i32);
         Ok(())
@@ -91,8 +83,7 @@ mod tests {
     #[test]
     fn test_i64_round_trip() -> Result<(), Report> {
         let value_i64: i64 = 42;
-        let arrow_array = value_i64.into_arrow();
-        let data: ArrowData = ArrowData(Arc::new(arrow_array));
+        let data: DoraArray = value_i64.into_arrow();
         let result_i64: i64 = TryFrom::try_from(&data)?;
         assert_eq!(value_i64, result_i64);
         Ok(())
@@ -101,8 +92,7 @@ mod tests {
     #[test]
     fn test_f16_round_trip() -> Result<(), Report> {
         let value_f16: f16 = f16::from_f32(42.42);
-        let arrow_array = value_f16.into_arrow();
-        let data: ArrowData = ArrowData(Arc::new(arrow_array));
+        let data: DoraArray = value_f16.into_arrow();
         let result_f16: f16 = TryFrom::try_from(&data)?;
         assert_eq!(value_f16, result_f16);
         Ok(())
@@ -111,8 +101,7 @@ mod tests {
     #[test]
     fn test_f32_round_trip() -> Result<(), Report> {
         let value_f32: f32 = 42.42;
-        let arrow_array = value_f32.into_arrow();
-        let data: ArrowData = ArrowData(Arc::new(arrow_array));
+        let data: DoraArray = value_f32.into_arrow();
         let result_f32: f32 = TryFrom::try_from(&data)?;
         assert_eq!(value_f32, result_f32);
         Ok(())
@@ -121,8 +110,7 @@ mod tests {
     #[test]
     fn test_f64_round_trip() -> Result<(), Report> {
         let value_f64: f64 = 42.42;
-        let arrow_array = value_f64.into_arrow();
-        let data: ArrowData = ArrowData(Arc::new(arrow_array));
+        let data: DoraArray = value_f64.into_arrow();
         let result_f64: f64 = TryFrom::try_from(&data)?;
         assert_eq!(value_f64, result_f64);
         Ok(())
@@ -131,8 +119,7 @@ mod tests {
     #[test]
     fn test_str_round_trip() -> Result<(), Report> {
         let value_str: &str = "Hello, Arrow!";
-        let arrow_array = value_str.into_arrow();
-        let data: ArrowData = ArrowData(Arc::new(arrow_array));
+        let data: DoraArray = value_str.into_arrow();
         let result_str: &str = TryFrom::try_from(&data)?;
         assert_eq!(value_str, result_str);
         Ok(())
@@ -141,8 +128,7 @@ mod tests {
     #[test]
     fn test_vec_u8_round_trip() -> Result<(), Report> {
         let value_vec_u8: Vec<u8> = vec![1, 2, 3, 4, 5];
-        let arrow_array = value_vec_u8.clone().into_arrow();
-        let data: ArrowData = ArrowData(Arc::new(arrow_array));
+        let data: DoraArray = value_vec_u8.clone().into_arrow();
         let result_vec_u8: Vec<u8> = TryFrom::try_from(&data)?;
         assert_eq!(value_vec_u8, result_vec_u8);
         Ok(())
@@ -150,8 +136,7 @@ mod tests {
 
     #[test]
     fn test_string_round_trip() -> Result<(), Report> {
-        let arrow_array = "Hello, Arrow!".to_string().into_arrow();
-        let data: ArrowData = ArrowData(Arc::new(arrow_array));
+        let data: DoraArray = "Hello, Arrow!".to_string().into_arrow();
         let result_string: String = TryFrom::try_from(&data)?;
         assert_eq!(result_string, "Hello, Arrow!");
         Ok(())
@@ -160,8 +145,7 @@ mod tests {
     #[test]
     fn test_vec_u16_round_trip() -> Result<(), Report> {
         let value_vec_u16: Vec<u16> = vec![1, 2, 3, 4, 5];
-        let arrow_array = value_vec_u16.clone().into_arrow();
-        let data: ArrowData = ArrowData(Arc::new(arrow_array));
+        let data: DoraArray = value_vec_u16.clone().into_arrow();
         let result_vec_u16: Vec<u16> = TryFrom::try_from(&data)?;
         assert_eq!(value_vec_u16, result_vec_u16);
         Ok(())
@@ -170,8 +154,7 @@ mod tests {
     #[test]
     fn test_vec_u32_round_trip() -> Result<(), Report> {
         let value_vec_u32: Vec<u32> = vec![1, 2, 3, 4, 5];
-        let arrow_array = value_vec_u32.clone().into_arrow();
-        let data: ArrowData = ArrowData(Arc::new(arrow_array));
+        let data: DoraArray = value_vec_u32.clone().into_arrow();
         let result_vec_u32: Vec<u32> = TryFrom::try_from(&data)?;
         assert_eq!(value_vec_u32, result_vec_u32);
         Ok(())
@@ -180,8 +163,7 @@ mod tests {
     #[test]
     fn test_vec_u64_round_trip() -> Result<(), Report> {
         let value_vec_u64: Vec<u64> = vec![1, 2, 3, 4, 5];
-        let arrow_array = value_vec_u64.clone().into_arrow();
-        let data: ArrowData = ArrowData(Arc::new(arrow_array));
+        let data: DoraArray = value_vec_u64.clone().into_arrow();
         let result_vec_u64: Vec<u64> = TryFrom::try_from(&data)?;
         assert_eq!(value_vec_u64, result_vec_u64);
         Ok(())
@@ -190,8 +172,7 @@ mod tests {
     #[test]
     fn test_vec_i8_round_trip() -> Result<(), Report> {
         let value_vec_i8: Vec<i8> = vec![-1, -2, -3, -4, -5];
-        let arrow_array = value_vec_i8.clone().into_arrow();
-        let data: ArrowData = ArrowData(Arc::new(arrow_array));
+        let data: DoraArray = value_vec_i8.clone().into_arrow();
         let result_vec_i8: Vec<i8> = TryFrom::try_from(&data)?;
         assert_eq!(value_vec_i8, result_vec_i8);
         Ok(())
@@ -200,8 +181,7 @@ mod tests {
     #[test]
     fn test_vec_i16_round_trip() -> Result<(), Report> {
         let value_vec_i16: Vec<i16> = vec![-1, -2, -3, -4, -5];
-        let arrow_array = value_vec_i16.clone().into_arrow();
-        let data: ArrowData = ArrowData(Arc::new(arrow_array));
+        let data: DoraArray = value_vec_i16.clone().into_arrow();
         let result_vec_i16: Vec<i16> = TryFrom::try_from(&data)?;
         assert_eq!(value_vec_i16, result_vec_i16);
         Ok(())
@@ -210,8 +190,7 @@ mod tests {
     #[test]
     fn test_vec_i32_round_trip() -> Result<(), Report> {
         let value_vec_i32: Vec<i32> = vec![-1, -2, -3, -4, -5];
-        let arrow_array = value_vec_i32.clone().into_arrow();
-        let data: ArrowData = ArrowData(Arc::new(arrow_array));
+        let data: DoraArray = value_vec_i32.clone().into_arrow();
         let result_vec_i32: Vec<i32> = TryFrom::try_from(&data)?;
         assert_eq!(value_vec_i32, result_vec_i32);
         Ok(())
@@ -220,8 +199,7 @@ mod tests {
     #[test]
     fn test_vec_i64_round_trip() -> Result<(), Report> {
         let value_vec_i64: Vec<i64> = vec![-1, -2, -3, -4, -5];
-        let arrow_array = value_vec_i64.clone().into_arrow();
-        let data: ArrowData = ArrowData(Arc::new(arrow_array));
+        let data: DoraArray = value_vec_i64.clone().into_arrow();
         let result_vec_i64: Vec<i64> = TryFrom::try_from(&data)?;
         assert_eq!(value_vec_i64, result_vec_i64);
         Ok(())
@@ -230,8 +208,7 @@ mod tests {
     #[test]
     fn test_vec_f32_round_trip() -> Result<(), Report> {
         let value_vec_f32: Vec<f32> = vec![-1.5, -2.6, -3.2, -4.5, -5.1];
-        let arrow_array = value_vec_f32.clone().into_arrow();
-        let data: ArrowData = ArrowData(Arc::new(arrow_array));
+        let data: DoraArray = value_vec_f32.clone().into_arrow();
         let result_vec_f32: Vec<f32> = TryFrom::try_from(&data)?;
         assert_eq!(value_vec_f32, result_vec_f32);
         Ok(())
@@ -240,8 +217,7 @@ mod tests {
     #[test]
     fn test_vec_f64_round_trip() -> Result<(), Report> {
         let value_vec_f64: Vec<f64> = vec![-1.5, -2.6, -3.2, -4.5, -5.1];
-        let arrow_array = value_vec_f64.clone().into_arrow();
-        let data: ArrowData = ArrowData(Arc::new(arrow_array));
+        let data: DoraArray = value_vec_f64.clone().into_arrow();
         let result_vec_f64: Vec<f64> = TryFrom::try_from(&data)?;
         assert_eq!(value_vec_f64, result_vec_f64);
         Ok(())
@@ -250,8 +226,7 @@ mod tests {
     #[test]
     fn test_naivedate_round_trip() -> Result<(), Report> {
         let value_naivedate = NaiveDate::from_ymd_opt(2024, 4, 4).unwrap();
-        let arrow_array = value_naivedate.into_arrow();
-        let data: ArrowData = ArrowData(Arc::new(arrow_array));
+        let data: DoraArray = value_naivedate.into_arrow();
         let result_naivedate: NaiveDate = TryFrom::try_from(&data)?;
         assert_eq!(value_naivedate, result_naivedate);
         Ok(())
@@ -259,8 +234,7 @@ mod tests {
     #[test]
     fn test_naivetime_round_trip() -> Result<(), Report> {
         let value_naivetime = NaiveTime::from_hms_milli_opt(23, 56, 4, 10).unwrap();
-        let arrow_array = value_naivetime.into_arrow();
-        let data: ArrowData = ArrowData(Arc::new(arrow_array));
+        let data: DoraArray = value_naivetime.into_arrow();
         let result_naivetime: NaiveTime = TryFrom::try_from(&data)?;
         assert_eq!(value_naivetime, result_naivetime);
         Ok(())
@@ -272,7 +246,7 @@ mod tests {
         // [10, null, 30] — null slots must be rejected, not silently converted to 0
         let array = Int32Array::from(vec![Some(10), None, Some(30)]);
         assert_eq!(array.null_count(), 1);
-        let data = ArrowData(Arc::new(array));
+        let data = from_array_ref(Arc::new(array));
         let result: Result<Vec<i32>, eyre::Report> = into_vec(&data);
         assert!(
             result.is_err(),
@@ -287,7 +261,7 @@ mod tests {
         // [10, 20, 30] — no nulls, must succeed
         let array = Int32Array::from(vec![Some(10), Some(20), Some(30)]);
         assert_eq!(array.null_count(), 0);
-        let data = ArrowData(Arc::new(array));
+        let data = from_array_ref(Arc::new(array));
         let v: Vec<i32> = into_vec(&data)?;
         assert_eq!(v, vec![10, 20, 30]);
         Ok(())
@@ -298,8 +272,7 @@ mod tests {
         let d = NaiveDate::from_ymd_opt(2015, 6, 3).unwrap();
         let t = NaiveTime::from_hms_milli_opt(12, 34, 56, 789).unwrap();
         let value_naivedatetime = NaiveDateTime::new(d, t);
-        let arrow_array = value_naivedatetime.into_arrow();
-        let data: ArrowData = ArrowData(Arc::new(arrow_array));
+        let data: DoraArray = value_naivedatetime.into_arrow();
         let result_naivedatetime: NaiveDateTime = TryFrom::try_from(&data)?;
         assert_eq!(value_naivedatetime, result_naivedatetime);
         Ok(())

--- a/libraries/extensions/tensor-pool/python/Cargo.toml
+++ b/libraries/extensions/tensor-pool/python/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 publish = false
 
 [dependencies]
-dora-node-api = { workspace = true }
+dora-node-api = { workspace = true  }
 dora-message = { workspace = true }
 arrow = { workspace = true, features = ["pyarrow"] }
 eyre = { workspace = true }

--- a/libraries/log-utils/src/lib.rs
+++ b/libraries/log-utils/src/lib.rs
@@ -25,7 +25,7 @@ pub fn parse_log(json: &str) -> Result<LogMessage> {
 /// Convenience wrapper for node event handlers. The daemon sends one log
 /// entry per Arrow message, so this extracts the first string element and
 /// parses it as JSON. Additional elements (if any) are ignored.
-pub fn parse_log_from_arrow(data: &dora_arrow_convert::ArrowData) -> Result<LogMessage> {
+pub fn parse_log_from_arrow(data: &dora_arrow_convert::DoraArray) -> Result<LogMessage> {
     let json: &str = data.try_into().context("expected string arrow data")?;
     parse_log(json)
 }

--- a/tests/queue_size_latest_data_rust/receive_data/Cargo.toml
+++ b/tests/queue_size_latest_data_rust/receive_data/Cargo.toml
@@ -10,6 +10,6 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dora-node-api = { workspace = true, features = ["tracing"] }
+dora-node-api = { workspace = true, features = ["arrow-v59", "tracing"] }
 eyre = { workspace = true }
 chrono = "0.4"

--- a/tests/queue_size_latest_data_rust/receive_data/src/main.rs
+++ b/tests/queue_size_latest_data_rust/receive_data/src/main.rs
@@ -2,7 +2,7 @@ use std::{thread::sleep, time::Duration};
 
 use dora_node_api::{
     self, DoraNode,
-    arrow::{
+    arrow_v59::{
         array::{AsArray, PrimitiveArray},
         datatypes::UInt64Type,
     },
@@ -21,7 +21,7 @@ fn main() -> eyre::Result<()> {
             data,
         } = event
         {
-            let data: &PrimitiveArray<UInt64Type> = data.as_primitive();
+            let data: &PrimitiveArray<UInt64Type> = data.as_array().as_primitive();
             let _time: u64 = data.values()[0];
             let time_metadata = metadata.timestamp();
             let duration_metadata = time_metadata.get_time().to_system_time().elapsed()?;


### PR DESCRIPTION
At 1.0 everything reachable from `dora-node-api` is frozen for the life of 1.x, and Arrow is reachable three ways: `pub use arrow;`, `ArrowData(pub ArrayRef)` with its `Deref`, and `IntoArrow::A: Array`. Arrow ships a major roughly every 6–8 weeks, so freezing it pins dora 1.x to Arrow 59 and forces users to choose between dora and a current polars / datafusion / parquet.

The wire format was never the problem — dora serializes with Arrow IPC, which is version-independent, so two nodes built against different Arrow majors already interoperate. The coupling is purely the in-process Rust type boundary.

**Design** (full rationale in `docs/plan-arrow-version-decoupling.md`, added in the first commit):

- `DoraArray`, a dora-owned newtype with a private field, replaces `ArrowData` in every signature. `IntoArrow` drops its `type A: Array` bound and returns `DoraArray`.
- `pub use arrow;` becomes `arrow_v59` / `arrow_v58`, each feature-gated, `default = []`. A bare `arrow` re-export changes meaning silently when dora bumps; `arrow_v59` either exists and means Arrow 59, or it is visibly gone. That makes a future bump **additive** rather than mutating.
- `arrow-v59` pulls no extra dependency — it re-exports the copy dora already links. Only majors other than the internal one get an aliased optional dep, so you compile only what you ask for.
- Zero-copy `TryFrom`/`TryInto` between majors via the Arrow C Data Interface, which the operator API already uses in-tree. The fallible traits, not `From`/`Into`: importing through the C Data Interface can fail on a malformed schema or array, and an infallible `From` impl would have to panic internally on bad data.

The payoff is that dora can bump its internal Arrow in a **minor** release.

Worth noting: **the `dora new` templates needed no change**. `value.into_arrow()` and `(&data).try_into()?` never name an Arrow type, so the common node path needs no feature at all.

### The FFI bridge

`libraries/arrow-convert/src/ffi_bridge.rs` is the one `unsafe` module. `arrow58::ffi::FFI_ArrowArray` and `arrow::ffi::FFI_ArrowArray` are distinct Rust types over the same frozen C ABI, so the hop is a `transmute`. Four `const _: () = assert!(...)` blocks reject a size or alignment mismatch at compile time — they do not prove field-for-field identity, which is the stated uncovered case. The transmute *moves* the owned struct, so the `release` duty transfers exactly once.

Tested specifically for that: a test builds an Arrow 58 array over an allocation carrying a `Drop` counter, imports to 59, drops every Arrow 58 handle and asserts the counter is still 0, then drops the 59 array **without reading it** and asserts the counter is exactly 1. Mirror test for the other direction, plus nested/nullable `StructArray` and empty-array round trips. All five pass under `cargo +nightly miri` with no UB.

### One judgement call for reviewers

`dora_arrow_convert::internal` remains Arrow-typed and `pub`. `DoraArray` lives in a different crate from the code that builds and unwraps it, and Rust has no cross-crate `pub(crate)`. Routing it through the `arrow-v59` feature actively backfires: `dora-node-api` would have to enable it unconditionally, and cargo feature unification would then hand the ungated accessor to every downstream user — the exact silent drift the gate exists to prevent.

So `internal` is `pub`, deliberately not re-exported from `dora-node-api`, and documented semver-exempt. **`dora-node-api`'s frozen surface is Arrow-free**, which is the surface that matters, but the workspace's public surface is not — modulo this seam. The alternative is folding `dora-arrow-convert` into `dora-node-api` so the accessors become genuinely `pub(crate)`; that is a larger, more invasive change and was not taken unilaterally. Worth a reviewer's opinion.

### Other deviations from the design doc

- `data_type()` is feature-gated rather than returning a type URN. `TypeRegistry` has no URNs for nested lists, dictionaries, unions, or timestamps-with-timezone — precisely the types whose identity a caller most needs, so a URN accessor would be lossy exactly where it matters. An ungated `type_name() -> String` covers logging.
- The IPC encoders are **retyped, not hidden**. They have real cross-crate consumers (record-node, daemon, the Python `sample_handler`, a bench, `tests/copy_count.rs`), so `pub(crate)` would break them and `#[doc(hidden)]` would leave Arrow in the frozen API. They now take `DoraArray`; `pub(crate)` `*_data` twins keep the internal hot path from paying an extra `to_data()`.
- Gated `IntoArrow` impls are listed per concrete Arrow 59 array type, because a blanket `impl<A: Array> IntoArrow for A` is impossible (E0119 against `impl IntoArrow for u8`).

### Verification

fmt, clippy `-D warnings`, `cargo check --all --all-targets`, `cargo check --examples`, and the full feature matrix (none / v58 / v59 / both) all clean. `cargo test --all`: 1943 passed, 2 failed — the known `rmw_zenoh_pubsub` pair that needs multicast and fails on `main` in the same container. Miri on the FFI tests as above.

**Not verified:** `cargo check -p rust-ros2-example-node --features ros2`. No ROS distro in the dev container, so msg-gen emits nothing. `git diff` shows that crate byte-identical, but it was not observed compiling — nightly CI's ros2-bridge job covers it.

Breaking for every Rust node: `Event::Input`'s payload type changes, and code naming Arrow types now needs `features = ["arrow-v59"]`.
