### PR TITLE
ci(nightly): size the topic-and-top budget for its maturin build, and report cancelled runs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -529,7 +529,11 @@ jobs:
     name: Topic & top inspection smoke
     runs-on: ubuntu-latest
     needs: build-cli
-    timeout-minutes: 15
+    # Sized as "the capped build step below, plus slack for everything else".
+    # Setup actions take ~20s and the actual inspection smokes take ~20s (see
+    # the successful runs on 2026-08-08/09/10), so this cap only bites if the
+    # build step's own 25-minute cap somehow does not.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
@@ -544,15 +548,38 @@ jobs:
       - uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
-      - name: Set up Python venv with local dora-rs
-        # Required so the Python source nodes import dora-rs 0.2.1 (matching
-        # the daemon's message format), not the 0.5.0 from PyPI.
+      - name: Set up Python venv
         run: |
           uv venv --seed -p 3.12
           echo "VIRTUAL_ENV=$PWD/.venv" >> "$GITHUB_ENV"
           source .venv/bin/activate
           uv pip install pyarrow
+      - name: Build local dora-rs Python bindings into the venv
+        # Required so the Python source nodes import dora-rs 0.2.1 (matching
+        # the daemon's message format), not the 0.5.0 from PyPI.
+        #
+        # Split out of the venv setup and capped separately because it is
+        # essentially the whole job: it is a from-source maturin build of
+        # `dora-node-api-python`, and `rust-cache` runs with `save-if: false`
+        # here, so this job never populates a cache and only ever gets a warm
+        # `target/` by luck. The three runs that completed took 11m23, 12m29
+        # and 13m29 in this step alone, while everything after it — CLI
+        # download, `dora up`, and all twenty inspection assertions — took
+        # 16-20 seconds. The old 15-minute *job* cap therefore left the build
+        # ~14m30, which the runner-speed spread overruns often: six of the
+        # eleven nightlies between 2026-08-06 and 2026-08-18 died right here,
+        # and because a timed-out job reports as `cancelled` the whole run
+        # concluded `cancelled` and both nightly automations skipped.
+        #
+        # 25 minutes is ~1.9x the slowest build that has actually finished,
+        # matching the headroom #3094 gave the E2E step for the same
+        # cold-cache reason. Keep it: an overrun here now means the build
+        # genuinely wedged, and an overrun of the job cap means the smoke
+        # assertions wedged. Trimming this back just re-creates the timeout.
+        run: |
+          source .venv/bin/activate
           uv pip install -e apis/python/node
+        timeout-minutes: 25
       - name: Download dora CLI
         uses: actions/download-artifact@v8
         with:
@@ -1982,7 +2009,17 @@ jobs:
     # `always() && contains(needs.*.result, 'failure')` covers both direct
     # failures and the case where build-cli fails and downstream jobs get
     # skipped (plain `failure()` would miss the skipped-cascade case).
-    if: always() && contains(needs.*.result, 'failure') && github.event_name == 'schedule'
+    #
+    # `cancelled` is included because GitHub Actions reports a job that blows
+    # its `timeout-minutes` cap as `cancelled`, not `failure` — so a timed-out
+    # subjob used to make the whole run conclude `cancelled` while this
+    # reporter (and the closer below) both skipped, i.e. a real regression
+    # produced silence. This gate is deliberately coarse: `cancel-in-progress`
+    # (#3043) also marks jobs `cancelled` when a newer run supersedes this
+    # one, and the two cases are told apart in the step below, which knows the
+    # per-job timings. It exits 0 without filing if every cancellation turns
+    # out to be a supersede.
+    if: always() && github.event_name == 'schedule' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
     steps:
       - uses: actions/checkout@v6
       - name: Create or update regression issue
@@ -2105,6 +2142,7 @@ jobs:
               record-replay) echo '^Record/replay round-trip$' ;;
               cluster-smoke) echo '^Cluster lifecycle smoke$' ;;
               cluster-e2e) echo '^Cluster SSH end-to-end$' ;;
+              cluster-record-replay) echo '^Cluster record/replay end-to-end$' ;;
               topic-and-top-smoke) echo '^Topic & top inspection smoke$' ;;
               cpu-affinity-smoke) echo '^cpu_affinity end-to-end \(Linux\)$' ;;
               redb-backend-smoke) echo '^redb backend end-to-end$' ;;
@@ -2119,6 +2157,11 @@ jobs:
               bench-example) echo '^Bench Example \(.+\)$' ;;
               cross-check) echo '^Cross-check \(.+\)$' ;;
               ros2-bridge) echo '^ROS2 Bridge Basic Checks$' ;;
+              # `continue-on-error` keeps these two out of `failed_jobs`, but
+              # the cancellation classifier looks up every job in `needs`, and
+              # an unmapped name there defaults to "report it".
+              ros2-zenoh-humble) echo '^ROS2 Zenoh Interop \(Humble\)$' ;;
+              ros2-zenoh-kilted) echo '^ROS2 Zenoh Interop \(Kilted\)$' ;;
               msrv) echo '^MSRV check$' ;;
               *) echo '' ;;
             esac
@@ -2134,23 +2177,112 @@ jobs:
           skipped_jobs=$(echo "$NEEDS_JSON" \
             | jq -r 'to_entries | map(select(.value.result == "skipped")) | .[].key' \
             | sort)
+          # Jobs whose result is `cancelled`. Two very different things land
+          # here; see the classifier below.
+          cancelled_jobs=$(echo "$NEEDS_JSON" \
+            | jq -r 'to_entries | map(select(.value.result == "cancelled")) | .[].key' \
+            | sort)
 
+          run_job_rows=$(mktemp)
           failed_job_rows=$(mktemp)
           failed_log_index=$(mktemp)
           failed_logs_error=$(mktemp)
           failed_logs_dir=$(mktemp -d)
-          trap 'rm -rf "$failed_job_rows" "$failed_log_index" "$failed_logs_error" "$failed_logs_dir"' EXIT
+          trap 'rm -rf "$run_job_rows" "$failed_job_rows" "$failed_log_index" "$failed_logs_error" "$failed_logs_dir"' EXIT
 
           # Do not use whole-run logs here: this reporter job is still
           # running, and GitHub does not expose whole-run logs until the run
-          # completes. Completed failed jobs already have individual logs, so
+          # completes. Completed jobs already have individual logs, so
           # enumerate them and download each job log directly.
+          #
+          # One enumeration feeds both the failure excerpts and the
+          # cancellation classifier. Columns:
+          #   id \t name \t conclusion \t started_at \t completed_at \t cancelled step
           if gh api --paginate "/repos/$REPO/actions/runs/$RUN_ID/jobs?per_page=100" \
-            --jq '.jobs[] | select(.status == "completed" and .conclusion == "failure") | [.id, .name] | @tsv' \
-            > "$failed_job_rows" 2> "$failed_logs_error"; then
+            --jq '.jobs[] | select(.status == "completed") | [.id, .name, .conclusion, .started_at, .completed_at, ((.steps // []) | map(select(.conclusion == "cancelled")) | (.[0].name // ""))] | @tsv' \
+            > "$run_job_rows" 2> "$failed_logs_error"; then
             logs_available=1
           else
             logs_available=0
+          fi
+          awk -F'\t' '$3 == "failure" { printf "%s\t%s\n", $1, $2 }' "$run_job_rows" > "$failed_job_rows"
+
+          # --- Telling a blown `timeout-minutes` cap apart from a supersede ---
+          #
+          # GitHub reports both as `cancelled`, but they need opposite
+          # handling: a timed-out subjob is a regression worth an issue, while
+          # a run superseded by `concurrency: cancel-in-progress` (#3043) is
+          # routine and must stay silent, or every push to main that lands
+          # during a nightly files a bogus report.
+          #
+          # The tell is whether the *run* carried on afterwards. A
+          # `timeout-minutes` cap kills exactly one job while the rest of the
+          # matrix keeps working for many minutes; a supersede kills
+          # everything in flight in one wave and the run ends right there, so
+          # nothing completes more than a few seconds later. Run 32107803630
+          # (`topic-and-top-smoke` blew its cap at 07:09:27, other jobs ran on
+          # until ~08:00) classifies as a timeout; the 12:07:49-12:08:03 wave
+          # that ended run 32022246649 classifies as a supersede.
+          #
+          # A run with a single cancelled job cannot be a supersede either — a
+          # supersede would have taken this reporter down with it rather than
+          # letting it run — so that shortcut is checked first and also covers
+          # the case where the cancelled job happens to be the run's last.
+          # Unmappable job names are reported rather than swallowed: silence
+          # is the failure mode this whole change exists to remove.
+          #
+          # Note this is orthogonal to the skipped-cascade above: a failed
+          # `build-cli` marks its dependents `skipped`, never `cancelled`.
+          SUPERSEDE_WINDOW_SECONDS=120
+          run_last_completed=$(cut -f5 "$run_job_rows" | sort | tail -1)
+          run_cancelled_count=$(awk -F'\t' '$3 == "cancelled"' "$run_job_rows" | wc -l | tr -d '[:space:]')
+
+          to_epoch() {
+            date -u -d "$1" +%s 2>/dev/null || echo 0
+          }
+
+          # Emits "<completed_at>\t<cancelled step>\t<duration minutes>" for the
+          # latest cancelled GitHub job matching a `needs` job id, or nothing.
+          cancelled_job_facts() {
+            local pattern gid gname gconc gstart gdone gstep best_done best_step best_mins
+            pattern=$(job_log_pattern "$1")
+            [ -n "$pattern" ] || return 0
+            best_done=""
+            while IFS=$'\t' read -r gid gname gconc gstart gdone gstep; do
+              [ "$gconc" = "cancelled" ] || continue
+              [[ "$gname" =~ $pattern ]] || continue
+              if [ -z "$best_done" ] || [[ "$gdone" > "$best_done" ]]; then
+                best_done="$gdone"
+                best_step="$gstep"
+                best_mins=$(( ($(to_epoch "$gdone") - $(to_epoch "$gstart")) / 60 ))
+              fi
+            done < "$run_job_rows"
+            [ -n "$best_done" ] || return 0
+            printf '%s\t%s\t%s\n' "$best_done" "$best_step" "$best_mins"
+          }
+
+          timed_out_jobs=""
+          superseded_jobs=""
+          run_last_epoch=$(to_epoch "$run_last_completed")
+          while IFS= read -r job; do
+            [ -n "$job" ] || continue
+            facts=$(cancelled_job_facts "$job")
+            job_done=$(printf '%s' "$facts" | cut -f1)
+            if [ "$run_cancelled_count" -le 1 ] || [ -z "$job_done" ] \
+              || [ $((run_last_epoch - $(to_epoch "$job_done"))) -ge "$SUPERSEDE_WINDOW_SECONDS" ]; then
+              timed_out_jobs+="$job"$'\n'
+            else
+              superseded_jobs+="$job"$'\n'
+            fi
+          done <<< "$cancelled_jobs"
+
+          if [ -n "$superseded_jobs" ]; then
+            echo "Cancellations attributed to a concurrency supersede (not reported):"
+            printf '%s' "$superseded_jobs"
+          fi
+          if [ -z "$failed_jobs" ] && [ -z "$timed_out_jobs" ]; then
+            echo "Nothing failed and every cancellation looks like a concurrency supersede; not filing an issue."
+            exit 0
           fi
 
           fetch_failed_job_log_once() {
@@ -2328,6 +2460,25 @@ jobs:
               details+="$job_header$excerpt$job_footer"
             done <<< "$failed_jobs"
           fi
+          if [ -n "$timed_out_jobs" ]; then
+            details+=$'\n### Timed out (job hit its `timeout-minutes` cap)\n\n'
+            details+=$'GitHub Actions reports a job that runs out of time as `cancelled`, so\nthese read like somebody stopped the run — nobody did. Each job below\nwas still working when its cap expired, and the step named is where it\nwas when the clock ran out.\n\n'
+            while IFS= read -r job; do
+              [ -z "$job" ] && continue
+              facts=$(cancelled_job_facts "$job")
+              job_step=$(printf '%s' "$facts" | cut -f2)
+              job_mins=$(printf '%s' "$facts" | cut -f3)
+              details+="- \`$job\`"
+              if [ -n "$job_mins" ]; then
+                details+=" — ran out of time after ~${job_mins}m"
+              fi
+              if [ -n "$job_step" ]; then
+                details+=", in step \`$job_step\`"
+              fi
+              details+=$'\n\n  Reproduce locally:\n\n  ```\n  '"$(job_repro "$job")"$'\n  ```\n\n'
+            done <<< "$timed_out_jobs"
+            details+=$'Either the step got slower or its budget is too tight — check the\nstep timings in the run before assuming the code regressed.\n'
+          fi
           if [ -n "$skipped_jobs" ]; then
             details+=$'\n### Skipped (cascading from a failed dependency)\n\n'
             while IFS= read -r job; do
@@ -2339,12 +2490,22 @@ jobs:
 
           # Issue/comment composer. Exports COMMENT_BODY and ISSUE_BODY
           # so the gh commands below can pick them up.
-          comment_body="Another failure on $DATE.
+          # A run with no `failure` at all got here because a job timed out;
+          # say so rather than claiming something failed.
+          if [ -n "$failed_jobs" ]; then
+            comment_lead="Another failure on $DATE."
+            issue_lead="Nightly regression suite failed on $DATE."
+          else
+            comment_lead="Another timeout on $DATE."
+            issue_lead="Nightly regression suite timed out on $DATE."
+          fi
+
+          comment_body="$comment_lead
 
           Run: $RUN_URL
           Commit: \`$COMMIT_SHA\`
           $details"
-          issue_body="Nightly regression suite failed on $DATE.
+          issue_body="$issue_lead
 
           Run: $RUN_URL
           Commit: \`$COMMIT_SHA\`


### PR DESCRIPTION
The nightly has been substantively green for days but cannot conclude
`success`: `topic-and-top-smoke` keeps blowing its 15-minute cap, and a
timed-out job reports as `cancelled`, which makes the whole run
`cancelled` and skips *both* nightly automations. Six of the eleven
nightlies between 08-06 and 08-18 ended that way, including 32107803630,
where every other job — Examples on all 3 platforms, CLI Tests: Python on
all 3, Test (windows), Kani, all 8 cross-check targets — was green. The
Phase 5b exit criterion (7 consecutive clean nightlies) is unreachable
while that holds.

Two fixes.

**Give the job a budget that matches what it does.** The job is ~99% one
step: a from-source maturin build of `dora-node-api-python`, which took
11m23 / 12m29 / 13m29 in the three runs that finished, while the CLI
download, `dora up` and all twenty inspection assertions after it took
16-20 seconds. `rust-cache` runs `save-if: false` here, so the job never
populates a cache and only gets a warm `target/` by luck. The build moves
into its own step with a 25-minute cap (~1.9x the slowest build that has
actually completed, the same headroom #3094 gave the E2E step for the
same reason); the job cap goes to 30. An overrun now says which half
broke.

**Report cancellations instead of going silent.** `file-issue-on-failure`
also fires on `cancelled`, and the issue body gets a "Timed out" section
that names the step the job was in and how long it ran — a blown cap is a
different diagnosis from a test failure, and "cancelled" reads like
somebody stopped the run.

The catch is #3043's `cancel-in-progress`: a superseded run marks every
in-flight job `cancelled`, and firing on that would file an issue on every
push to main that lands during a nightly. The step classifies each
cancellation by whether the run carried on afterwards — a `timeout-minutes`
cap kills one job while the rest of the matrix works for many more minutes,
a supersede kills everything in one wave and the run ends there. Checked
against real data: run 32107803630 (cap blown at 07:09:27, other jobs ran
until ~08:00) files; the 12:07:49-12:08:03 wave that ended run 32022246649
does not. A run with a single cancelled job is a timeout by construction —
a supersede would have taken the reporter down too.

`close-issue-on-success` is unchanged and still refuses to close on a
cancelled run.
