### PR TITLE
refactor!: narrow the `dora_core` re-export out of the 1.0 surface

### DIFF
--- a/apis/rust/node/src/lib.rs
+++ b/apis/rust/node/src/lib.rs
@@ -112,7 +112,26 @@ pub use arrow58 as arrow_v58;
 // Arrow-typed, semver-exempt seam for dora's own crates and must not become
 // reachable through the frozen `dora-node-api` surface.
 pub use dora_arrow_convert::{DoraArray, IntoArrow, into_vec};
-pub use dora_core::{self, uhlc};
+pub use dora_core::uhlc;
+
+/// The subset of [`dora_core`] that is part of dora's public API.
+///
+/// Deliberately not `pub use dora_core::self`. Re-exporting the whole crate
+/// froze `dora_core`'s descriptor, topics, build, manifest and type-registry
+/// surface into dora's 1.0 guarantee, none of which a node needs — the only
+/// items reached through this path anywhere are the three id types below and
+/// `uhlc`, which is re-exported at the crate root.
+///
+/// The `config` path is preserved verbatim because
+/// `dora_node_api::dora_core::config::DataId` is what `dora new` scaffolds and
+/// what the Rust API reference documents.
+pub mod dora_core {
+    /// Identifier types used in node and dataflow configuration.
+    pub mod config {
+        pub use dora_core::config::{DataId, NodeId, OperatorId};
+    }
+    pub use dora_core::uhlc;
+}
 pub use dora_message::{
     DataflowId,
     metadata::{


### PR DESCRIPTION
`pub use dora_core::{self, uhlc};` re-exported the entire crate, so `dora_core`'s descriptor, topics, build, manifest and type-registry modules were all reachable as `dora_node_api::dora_core::*` — and would have been frozen by the 1.0 guarantee. A node needs none of them.

An audit of every crate reaching `dora_core` through `dora-node-api` without declaring its own dependency found the complete set to be exactly `config::{DataId, NodeId, OperatorId}` and `uhlc::HLC` — 30 files across 26 crates, none touching the other modules. The replacement shim keeps that set and nothing else, and **the whole workspace compiles unchanged**.

The `config` path is preserved verbatim rather than flattened, because `dora_node_api::dora_core::config::DataId` is what `dora new` scaffolds (`binaries/cli/src/template/rust/talker/main-template.rs`) and what `docs/api-rust.md` documents. Verified the scaffolded template still compiles.

Breaking only for code reaching `dora_node_api::dora_core::{descriptor, topics, build, manifest, types}`. Nothing in-repo does, and the fix is a direct `dora-core` dependency.

Part of the pre-1.0 re-export cleanup alongside #3213, which removed Arrow from the same surface.
