### PR TITLE
fix(cli): drop stray space before the colon for the default daemon in pretty logs

### DIFF
--- a/binaries/cli/src/output.rs
+++ b/binaries/cli/src/output.rs
@@ -125,13 +125,16 @@ fn format_pretty_line(log_message: &LogMessage, config: &LogOutputConfig) -> Str
         }
         _ => String::new().cyan(),
     };
-    let daemon = match daemon_id {
-        Some(id) if config.print_daemon_name => match id.machine_id() {
+    let daemon = if config.print_daemon_name {
+        // A daemon with no machine id (or no daemon at all) is the default
+        // daemon; both render the same, with no trailing space so the colon
+        // that follows a node-scoped label abuts it directly.
+        match daemon_id.as_ref().and_then(|id| id.machine_id()) {
             Some(machine_id) => format!("on daemon `{machine_id}`"),
-            None => "on default daemon ".to_string(),
-        },
-        None if config.print_daemon_name => "on default daemon".to_string(),
-        _ => String::new(),
+            None => "on default daemon".to_string(),
+        }
+    } else {
+        String::new()
     }
     .bright_black();
     let time = format!("{}", timestamp.with_timezone(&Local).format("%H:%M:%S"));
@@ -445,6 +448,26 @@ mod tests {
         let config = LogOutputConfig::default();
         let rest = rendered_rest(pretty_message(None, None, "coordinator ready"), &config);
         assert_eq!(rest, "INFO   [dora]: coordinator ready");
+    }
+
+    #[test]
+    fn pretty_line_default_daemon_no_space_before_colon() {
+        // A node-scoped message on the unnamed/default daemon (a `DaemonId`
+        // with no machine id) with `print_daemon_name` on must render the same
+        // way the named-daemon path does — no stray space before the colon
+        // (regression: `sensor on default daemon : hello`).
+        let config = LogOutputConfig {
+            print_daemon_name: true,
+            ..LogOutputConfig::default()
+        };
+        let mut msg = pretty_message(Some("sensor"), None, "hello");
+        msg.daemon_id = Some(dora_message::common::DaemonId::new(None));
+        let rest = rendered_rest(msg, &config);
+        assert_eq!(rest, "INFO   sensor on default daemon: hello");
+        assert!(
+            !rest.contains("on default daemon :"),
+            "stray space before the colon: {rest:?}"
+        );
     }
 
     // --- parse_log_level_str ---


### PR DESCRIPTION
> **Machine-generated PR.** This change was written by Claude Code (an AI agent) as part of an automated code-review sweep. Please review carefully before merging.

## Issue

In `format_pretty_line`, the daemon label for a `DaemonId` with no `machine_id` was `"on default daemon "` **with a trailing space**, while both the named-daemon arm and the node-less default-daemon arm have none. For a node-scoped message on the unnamed/default daemon with `print_daemon_name` enabled, the line builder appends the colon directly after the label, producing:

```
sensor on default daemon : hello
```

— a stray space before the colon that the named-daemon path (`sensor on daemon `m`: hello`) does not have.

## Fix

- Remove the trailing space.
- Collapse the two divergent `"on default daemon"` literals (the `Some(id)`-no-machine-id arm and the `None` arm) into a single arm by hoisting the `print_daemon_name` guard and matching on `daemon_id.as_ref().and_then(|id| id.machine_id())`, so the two copies cannot drift apart again (this near-duplication is what let the spacing diverge in the first place).

## Validation

- Added a `format_pretty_line` regression test for the default-daemon + `print_daemon_name` case, which was previously untested (the test helper always set `daemon_id: None`).
- `cargo test -p dora-cli --lib`, `cargo clippy -p dora-cli --lib`, `cargo fmt --all -- --check` pass locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ErLv16v4XQbr2dD8KBn4vA)_