### PR TITLE
docs(message): fix the malformed YAML in the Descriptor example, make it a doctest

### DIFF
--- a/libraries/message/src/descriptor.rs
+++ b/libraries/message/src/descriptor.rs
@@ -45,9 +45,12 @@ pub const DYNAMIC_SOURCE: &str = "dynamic";
 ///
 /// ## Example
 ///
-/// ```yaml
+/// ```
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use dora_message::descriptor::Descriptor;
+/// let yaml = r#"
 /// nodes:
-///  - id: webcam
+///   - id: webcam
 ///     operator:
 ///       python: webcam.py
 ///       inputs:
@@ -59,6 +62,11 @@ pub const DYNAMIC_SOURCE: &str = "dynamic";
 ///       python: plot.py
 ///       inputs:
 ///         image: webcam/image
+/// "#;
+/// let descriptor: Descriptor = serde_yaml::from_str(yaml)?;
+/// assert_eq!(descriptor.nodes.len(), 2);
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]


### PR DESCRIPTION
> **Machine-generated PR.** This change was written by Claude Code (an AI agent) as part of an automated code-review sweep. Please review carefully before merging.

## Issue

The flagship example on the public `Descriptor` type — rendered on docs.rs and copy-pasted as a starting point — was **invalid YAML**:

```yaml
nodes:
 - id: webcam
    operator:          # over-indented relative to `id:`
      python: webcam.py
      ...
  - id: plot           # different indentation from the first item
    ...
```

The two `nodes` sequence items sat at different indentation and `operator:` was over-indented relative to its item's `id:`, so pasting the block into `serde_yaml::from_str::<Descriptor>()` / `dora check` fails to parse.

## Fix

Re-indent to the conventional 2-space layout (matching the correct smaller examples elsewhere in the same file) and convert the block into a **compile-checked doctest** that parses the example through `serde_yaml::from_str::<Descriptor>()` and asserts the node count. A future indentation regression is now caught by `cargo test --doc`.

## Validation

- `cargo test --doc -p dora-message` runs and passes the new `Descriptor` doctest.
- `cargo fmt --all -- --check` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ErLv16v4XQbr2dD8KBn4vA)_