### PR TITLE
docs(node-api): correct ZERO_COPY_THRESHOLD doc — small payloads use a heap put, not TCP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,8 @@ CLI  -->  Coordinator  -->  Daemon(s)  -->  Nodes / Operators
 - **CLI <-> Coordinator**: WebSocket (port 6013) for build/run/stop commands
 - **Coordinator <-> Daemon**: WebSocket for node spawning and dataflow lifecycle
 - **Daemon <-> Daemon**: Zenoh for distributed cross-machine communication
-- **Daemon <-> Node**: Shared memory for messages >4KB (zero-copy), TCP for small messages
+- **Daemon <-> Node**: TCP — the reliable path; payloads are copied into a `DataMessage::Vec`
+- **Node <-> Node**: direct zenoh data plane — zenoh shared memory at/above `ZERO_COPY_THRESHOLD` (4KB, zero-copy), heap-buffered `put` below it
 - **Data format**: Apache Arrow columnar format throughout (zero serialization overhead)
 
 ### Dataflow specification

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -128,12 +128,14 @@ mod runtime_type_check_tests {
 ///
 /// Using shared memory for messages smaller than the page size still requires
 /// sharing a full page, so we have some memory overhead. We also have some
-/// performance overhead because we need to issue multiple syscalls. For small
-/// messages it is faster to send them over a traditional TCP stream (or similar).
+/// performance overhead because setting up a shared segment is not free. For
+/// small messages it is cheaper to copy them into a heap-buffered publish.
 ///
-/// This hardcoded threshold value specifies which messages are sent through
-/// shared memory. Messages that are smaller than this threshold are sent through
-/// TCP.
+/// On the zenoh data plane this threshold selects *how* an output is
+/// published: payloads at or above it go through zenoh shared memory
+/// (zero-copy for local subscribers), while smaller payloads are published via
+/// zenoh with a heap-buffered `put`. See [`DoraNode::zero_copy_threshold`] for
+/// the runtime value (overridable via `DORA_ZERO_COPY_THRESHOLD`).
 pub const ZERO_COPY_THRESHOLD: usize = 4096;
 
 /// How many large outbound sends are traced hop-by-hop

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -134,8 +134,11 @@ mod runtime_type_check_tests {
 /// On the zenoh data plane this threshold selects *how* an output is
 /// published: payloads at or above it go through zenoh shared memory
 /// (zero-copy for local subscribers), while smaller payloads are published via
-/// zenoh with a heap-buffered `put`. See [`DoraNode::zero_copy_threshold`] for
-/// the runtime value (overridable via `DORA_ZERO_COPY_THRESHOLD`).
+/// zenoh with a heap-buffered `put`. A large payload that did not get a
+/// shared-memory buffer takes the reliable daemon path instead of the zenoh
+/// one, because a fragmented express publish would be silently dropped
+/// (dora-rs/dora#2366). See [`DoraNode::zero_copy_threshold`] for the runtime
+/// value (overridable via `DORA_ZERO_COPY_THRESHOLD`).
 pub const ZERO_COPY_THRESHOLD: usize = 4096;
 
 /// How many large outbound sends are traced hop-by-hop

--- a/docs/api-rust.md
+++ b/docs/api-rust.md
@@ -442,7 +442,7 @@ pub enum TryRecvError {
 pub const ZERO_COPY_THRESHOLD: usize = 4096;
 ```
 
-Messages smaller than this threshold are sent via TCP. Messages at or above this size use shared memory for zero-copy transfer.
+Messages at or above this threshold are published through zenoh shared memory for zero-copy transfer; smaller messages are published through zenoh with a heap-buffered `put`. Outputs that cannot take the direct zenoh path — an output whose consumer lives on another daemon, for example — fall back to the daemon path (TCP) regardless of size.
 
 #### ArrowData
 

--- a/guide/src/languages/rust.md
+++ b/guide/src/languages/rust.md
@@ -442,7 +442,7 @@ pub enum TryRecvError {
 pub const ZERO_COPY_THRESHOLD: usize = 4096;
 ```
 
-Messages smaller than this threshold are sent via TCP. Messages at or above this size use shared memory for zero-copy transfer.
+Messages at or above this threshold are published through zenoh shared memory for zero-copy transfer; smaller messages are published through zenoh with a heap-buffered `put`. Outputs that cannot take the direct zenoh path — an output whose consumer lives on another daemon, for example — fall back to the daemon path (TCP) regardless of size.
 
 #### ArrowData
 


### PR DESCRIPTION
> **Machine-generated PR.** This change was written by Claude Code (an AI agent) as part of an automated code-review sweep. Please review carefully before merging.

## Issue

The public `ZERO_COPY_THRESHOLD` constant's doc described the old daemon-centric design:

> This hardcoded threshold value specifies which messages are sent through shared memory. Messages that are smaller than this threshold are sent through **TCP**.

On the current zenoh data plane this is wrong. A direct-ready output publishes sub-threshold payloads via **zenoh with a heap-buffered `put`** (not TCP), and at/above the threshold via zenoh shared memory; the threshold only selects SHM-vs-heap *within the zenoh path* (see `zenoh_publish`). The daemon/TCP path is used when the output is not direct-ready, regardless of size. The old wording also directly contradicted the `DoraNode::zero_copy_threshold()` method doc.

## Fix

Reword the constant's doc to match the actual behavior and cross-link `DoraNode::zero_copy_threshold` (and the `DORA_ZERO_COPY_THRESHOLD` override). Documentation only — no code change.

## Validation

- `cargo doc -p dora-node-api --no-deps` builds and the new intra-doc link resolves (the remaining doc warnings are pre-existing and unrelated).
- Cross-checked against `zenoh_publish` and `zero_copy_threshold()` in the same file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ErLv16v4XQbr2dD8KBn4vA)_