### PR TITLE
docs(cli): add compile-checked doctests for parse_log_filter and parse_log_level_str

### DIFF
--- a/binaries/cli/src/output.rs
+++ b/binaries/cli/src/output.rs
@@ -258,7 +258,29 @@ pub fn parse_jsonl_line(line: &str) -> Option<LogMessage> {
     })
 }
 
-/// Parse a log filter string like "sensor=debug,processor=warn".
+/// Parse a log filter string like `"sensor=debug,processor=warn"` into a
+/// per-node level map.
+///
+/// Segments are comma-separated `node=level` pairs; surrounding whitespace is
+/// trimmed and empty segments are skipped. A segment without `=`, or one whose
+/// level is not one of `error|warn|info|debug|trace|stdout` (see
+/// [`parse_log_level_str`]), is an error.
+///
+/// ```
+/// # fn main() -> Result<(), String> {
+/// use dora_cli::output::parse_log_filter;
+///
+/// let map = parse_log_filter("sensor=debug, processor=warn")?;
+/// assert_eq!(map.len(), 2);
+///
+/// // Trailing/empty segments are ignored.
+/// assert_eq!(parse_log_filter("sensor=info,")?.len(), 1);
+///
+/// // A segment without `=` is rejected.
+/// assert!(parse_log_filter("sensor").is_err());
+/// # Ok(())
+/// # }
+/// ```
 pub fn parse_log_filter(s: &str) -> Result<HashMap<String, LogLevelOrStdout>, String> {
     let mut map = HashMap::new();
     for pair in s.split(',') {
@@ -275,6 +297,18 @@ pub fn parse_log_filter(s: &str) -> Result<HashMap<String, LogLevelOrStdout>, St
     Ok(map)
 }
 
+/// Parse a single log-level token into a [`LogLevelOrStdout`].
+///
+/// Accepts `error|warn|info|debug|trace|stdout`, case-insensitively; any other
+/// value is an error.
+///
+/// ```
+/// use dora_cli::output::parse_log_level_str;
+///
+/// assert!(parse_log_level_str("INFO").is_ok());
+/// assert!(parse_log_level_str("stdout").is_ok());
+/// assert!(parse_log_level_str("verbose").is_err());
+/// ```
 pub fn parse_log_level_str(s: &str) -> Result<LogLevelOrStdout, String> {
     match s.to_lowercase().as_str() {
         "error" => Ok(LogLevelOrStdout::LogLevel(log::Level::Error)),


### PR DESCRIPTION
> **Machine-generated PR.** This change was written by Claude Code (an AI agent) as part of an automated code-review sweep. Please review carefully before merging.

## Issue

`parse_log_filter` and `parse_log_level_str` (in `dora_cli::output`) are public helpers that encode a user-facing mini-format — the `node=level,node2=level2` filter string and the `error|warn|info|debug|trace|stdout` level vocabulary — but neither documented its contract (trimming, empty-segment skipping, case-insensitivity, error behavior).

## Fix

Add compile-checked doctests to both that exercise and lock in that behavior, plus fuller prose. Documentation only — no behavior change.

## Validation

- `cargo test --doc -p dora-cli` runs and passes both new doctests.
- `cargo fmt --all -- --check` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ErLv16v4XQbr2dD8KBn4vA)_