### PR TITLE
fix(daemon): don't forward the spurious empty EOF line from node log readers

### DIFF
--- a/binaries/daemon/src/spawn/prepared.rs
+++ b/binaries/daemon/src/spawn/prepared.rs
@@ -151,6 +151,20 @@ where
     Ok(false)
 }
 
+/// The forward-or-skip decision shared by the stdout/stderr reader tasks and
+/// their tests: given the `raw` bytes [`read_capped_line`] just produced,
+/// return the line to forward downstream, or `None` to skip it.
+///
+/// `read_capped_line` leaves `raw` empty **only** on the final EOF read — a
+/// real blank line is `"\n"`, which is non-empty — so an empty `raw` is that
+/// EOF marker and is dropped. Forwarding it would emit a spurious empty log
+/// line, and under `send_stdout_as` a spurious empty-string Arrow output the
+/// node never produced (dora-rs/dora#3228). Keeping this in one function means
+/// the tasks and the regression test exercise the same guard.
+fn line_to_forward(raw: Vec<u8>) -> Option<Vec<u8>> {
+    (!raw.is_empty()).then_some(raw)
+}
+
 #[derive(Clone, Default)]
 struct RestartConfig {
     max_restarts: u32,
@@ -758,6 +772,12 @@ impl PreparedNode {
                     }
                 };
 
+                // Drop the empty final EOF read rather than forwarding a
+                // spurious empty log line — see `line_to_forward`.
+                let Some(raw) = line_to_forward(raw) else {
+                    continue;
+                };
+
                 let mut content = match String::from_utf8(raw) {
                     Ok(s) => s,
                     Err(err) => {
@@ -817,6 +837,12 @@ impl PreparedNode {
                         tracing::warn!("{err:?}");
                         true
                     }
+                };
+
+                // Drop the empty final EOF read rather than forwarding a
+                // spurious empty log line — see `line_to_forward`.
+                let Some(raw) = line_to_forward(raw) else {
+                    continue;
                 };
 
                 let mut content = match String::from_utf8(raw) {
@@ -1457,6 +1483,39 @@ mod tests {
             read_all_lines(b"a\nno-newline").await,
             vec![b"a\n".to_vec(), b"no-newline".to_vec()]
         );
+    }
+
+    /// Drive the reader loop through the **same** `line_to_forward` guard the
+    /// production stdout/stderr tasks use, collecting whatever it forwards.
+    /// Because it calls the production function (not a private copy), removing
+    /// the guard there fails the assertions below.
+    async fn forwarded_lines(input: &[u8]) -> Vec<Vec<u8>> {
+        let mut reader = tokio::io::BufReader::new(input).take(MAX_LOG_LINE_BYTES as u64);
+        let mut forwarded = Vec::new();
+        let mut finished = false;
+        while !finished {
+            let mut raw = Vec::new();
+            finished = read_capped_line(&mut reader, &mut raw).await.unwrap();
+            if let Some(raw) = super::line_to_forward(raw) {
+                forwarded.push(raw);
+            }
+        }
+        forwarded
+    }
+
+    #[tokio::test]
+    async fn empty_eof_read_is_not_forwarded() {
+        // Normal case: output ends in a newline. The trailing EOF read is
+        // empty and must not be forwarded as a spurious empty log line
+        // (dora-rs/dora#3228).
+        assert_eq!(
+            forwarded_lines(b"line1\nline2\n").await,
+            vec![b"line1\n".to_vec(), b"line2\n".to_vec()]
+        );
+        // A node that prints nothing at all forwards no line.
+        assert!(forwarded_lines(b"").await.is_empty());
+        // A genuine blank line ("\n") is non-empty `raw`, so it is preserved.
+        assert_eq!(forwarded_lines(b"\n").await, vec![b"\n".to_vec()]);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes #3228.

The per-node **stdout** and **stderr** log reader tasks in `binaries/daemon/src/spawn/prepared.rs` emitted one **spurious empty log line** every time a stream reached EOF (once per stream, on every node exit).

`read_capped_line` signals EOF as `Ok(true)` and leaves `raw` **empty**, but the reader loop only checked `finished` in the `while` condition — *after* the loop body had already built and sent the `LogLine`. On the final EOF iteration `raw` was empty → `content == ""` → an empty `LogLine` was forwarded, then the loop ended.

Nothing downstream filters it, so every node exit produced:
- an empty JSONL entry (`"msg": ""`) in the node log file,
- an empty `LogBroadcast` to `dora/logs` subscribers, and
- **most consequentially** — under `send_stdout_as` / `send_logs_as`, a spurious empty-string Arrow output message delivered to downstream dataflow consumers (an extra data item the node author never produced).

## Fix

The forward-or-skip decision is now a single shared function:

```rust
fn line_to_forward(raw: Vec<u8>) -> Option<Vec<u8>> {
    (!raw.is_empty()).then_some(raw)
}
```

Both reader tasks call it — `let Some(raw) = line_to_forward(raw) else { continue };` — so there's exactly one place the guard lives. An empty `raw` is only ever the EOF read (a genuine blank line is `"\n"`, non-empty), so it maps to `None` and is skipped; every non-empty line is forwarded, preserving real blank lines and any partial bytes read before an I/O error.

## Test

`empty_eof_read_is_not_forwarded` drives its loop through the same `super::line_to_forward` function, not a private copy of the guard, so the test genuinely exercises the production code:

- output ending in a newline (`"line1\nline2\n"`) forwards exactly the two real lines,
- a node that prints nothing forwards no line,
- a genuine blank line (`"\n"`) is still preserved.

**Verified the coupling**: replacing `line_to_forward`'s body with `Some(raw)` makes the test fail (trailing empty line); restoring the guard passes it. Thanks @phil-opp for pointing that out — the previous version's private copy of the guard would have kept the test green after deleting the production guards.

## Validation

- `cargo test -p dora-daemon --lib spawn::prepared` — 8 passed (incl. the new test, verified failing when the guard is removed)
- `cargo fmt -p dora-daemon -- --check` — clean