### PR TITLE
fix(tensor-pool): use wrapping_add for all inline seqlock generation increments

### DIFF
--- a/libraries/extensions/tensor-pool/python/src/transport.rs
+++ b/libraries/extensions/tensor-pool/python/src/transport.rs
@@ -1323,7 +1323,7 @@ unsafe fn seqlock_begin_if_even(gen_ptr: *mut u64) -> u64 {
     unsafe {
         let cur = std::ptr::read_volatile(gen_ptr);
         if cur.is_multiple_of(2) {
-            std::ptr::write_volatile(gen_ptr, cur + 1);
+            std::ptr::write_volatile(gen_ptr, cur.wrapping_add(1));
             std::sync::atomic::fence(std::sync::atomic::Ordering::Release);
         }
         cur & !1 // always return the even baseline
@@ -1725,7 +1725,7 @@ impl Pool<'_> {
         unsafe {
             let gen_ptr = shmem_ptr.add(96) as *mut u64;
             let old_gen = std::ptr::read_volatile(gen_ptr);
-            std::ptr::write_volatile(gen_ptr, old_gen + 1);
+            std::ptr::write_volatile(gen_ptr, old_gen.wrapping_add(1));
             std::sync::atomic::fence(std::sync::atomic::Ordering::Release);
         }
 
@@ -2175,7 +2175,7 @@ impl Pool<'_> {
         unsafe {
             let gen_ptr = shmem_ptr.add(96) as *mut u64;
             let old_gen = std::ptr::read_volatile(gen_ptr);
-            std::ptr::write_volatile(gen_ptr, old_gen + 1);
+            std::ptr::write_volatile(gen_ptr, old_gen.wrapping_add(1));
             std::sync::atomic::fence(std::sync::atomic::Ordering::Release);
         }
 

--- a/libraries/extensions/tensor-pool/src/daemon/mirror.rs
+++ b/libraries/extensions/tensor-pool/src/daemon/mirror.rs
@@ -70,7 +70,7 @@ pub(crate) unsafe fn seqlock_begin_if_even(gen_ptr: *mut u64) -> u64 {
     unsafe {
         let cur = std::ptr::read_volatile(gen_ptr);
         if cur.is_multiple_of(2) {
-            std::ptr::write_volatile(gen_ptr, cur + 1);
+            std::ptr::write_volatile(gen_ptr, cur.wrapping_add(1));
             std::sync::atomic::fence(std::sync::atomic::Ordering::Release);
         }
         cur & !1 // always return the even baseline


### PR DESCRIPTION
## Summary

Fixes #2890 — completes the follow-up left after #2865/#2866.

Give the tensor-pool seqlock generation counter (`header[96]`, `gen_ptr`) **uniform `wrapping_add` semantics** at every increment site, matching the `seqlock_end` helpers that already advance with `wrapping_add(2)`. Four increments of the same counter were still using the non-wrapping `+ 1`:

| location | role | before |
|---|---|---|
| `transport.rs` `seqlock_begin_if_even` | begin (odd) | `cur + 1` |
| `transport.rs` `write_tensor_pool` inline begin | "write-in-progress" (odd) | `old_gen + 1` |
| `transport.rs` `write_tensor_pool` inline end | "write-complete" (even) | `old_gen + 1` |
| `mirror.rs` `seqlock_begin_if_even` | begin (odd) | `cur + 1` |

The change replaces all four with `wrapping_add(1)`.

## Severity — consistency, not a panic fix

This is a **consistency/style cleanup, not a bug fix**. None of these sites can overflow in any build:

- the `begin_if_even` helpers only increment an **even** value, so the largest input is `u64::MAX - 1` and `+ 1` reaches `u64::MAX` without wrapping;
- the inline `write_tensor_pool` counters are initialized to `0` and only ever reach `1` then `2`.

So the earlier "debug-build panic divergence" framing was overstated. The value of the change is purely that the counter now reads uniformly — no site is the odd one out — which is what #2865/#2866 set out to achieve. Thanks @phil-opp for catching both the overstatement and the missed `mirror.rs` site.

## Why a fresh PR

Issue #2890 originally pointed at `apis/python/node/src/lib.rs`; the seqlock code has since moved into this crate, which left the prior PRs (#2902, #3149) with `needs-rebase`/`dirty` conflicts — they were closed as stale, not rejected on merit. This re-applies the fix at the code's current locations.

## Testing

- `cargo check -p dora-tensor-pool --features daemon` — clean
- `cargo check -p dora-tensor-pool-python` — clean
- `cargo fmt` — clean

No dedicated test is added: these increments live in raw-pointer seqlock code with no unit-testable seam, and (as above) the wrap they now use is unreachable. The existing `seqlock_tests` module continues to cover the begin/end parity invariants.