### PR TITLE
test(daemon): wait for the zombie with waitid, not a sysinfo poll

### DIFF
--- a/binaries/daemon/src/shutdown.rs
+++ b/binaries/daemon/src/shutdown.rs
@@ -463,29 +463,7 @@ mod tests {
         // without the reap it stays a zombie, which is the state under test.
         drop(wrapper.stdin.take());
 
-        // Block until the kernel says it has exited, *without* reaping it.
-        // `WNOWAIT` leaves the status pending, so the process stays a zombie
-        // for the assertions below and for `kill_group_and_reap` to clean up.
-        //
-        // This replaces a poll for `ProcessStatus::Zombie` (dora-rs/dora#3150):
-        // that made the precondition depend on `sysinfo` *observing* the
-        // zombie, which is a platform question, not the one under test. The
-        // poll timed out on macOS nightly while passing on Linux. `waitid` is
-        // POSIX and answers the actual question — has it exited yet — with no
-        // deadline to lose.
-        //
-        // SAFETY: `waitid` only reads the exit state of a child this test
-        // spawned; `WNOWAIT` means it does not consume it.
-        let rc = unsafe {
-            let mut info: libc::siginfo_t = std::mem::zeroed();
-            libc::waitid(
-                libc::P_PID,
-                pid as libc::id_t,
-                &mut info,
-                libc::WEXITED | libc::WNOWAIT,
-            )
-        };
-        assert_eq!(rc, 0, "waitid on the wrapper failed");
+        wait_for_exit_without_reaping(pid);
 
         // The wrapper is now definitively an unreaped zombie. If `sysinfo`
         // disagrees, that is a platform gap worth knowing about rather than a
@@ -493,6 +471,17 @@ mod tests {
         // (`pid_recycled_into_stranger` returns false for `None`), so a pid
         // recycled into a stranger's zombie would be attributed to us and its
         // group killed — the #3067 case. Fail loudly and name it.
+        //
+        // A failure here is narrower than it first reads, though. This is a
+        // *fresh* `System`, so sysinfo has to build the entry from nothing,
+        // and on macOS that path gives up on a process whose argv and exe path
+        // the kernel no longer serves — which is exactly a zombie. A
+        // long-lived `DestroyWait` keeps its `System` across polls and has
+        // already seen the pid alive, so it takes sysinfo's *update* path
+        // instead, which can still report `Zombie` where the create path
+        // returns nothing at all. So this bounds how much of the #3067 guard
+        // survives on a platform; it does not by itself condemn the whole of
+        // it.
         let mut system = System::new();
         system.refresh_processes_specifics(
             ProcessesToUpdate::Some(&[Pid::from_u32(pid)]),
@@ -503,11 +492,86 @@ mod tests {
         assert_eq!(
             seen,
             Some(ProcessStatus::Zombie),
-            "`waitid` confirms the wrapper exited unreaped, but sysinfo \
-             reports {seen:?}. The zombie checks in `is_live_child` and \
-             `pid_recycled_into_stranger` cannot work on this platform."
+            "`waitid` confirms the wrapper exited unreaped, but a fresh \
+             `sysinfo::System` reports {seen:?}. The zombie half of \
+             `is_live_child` / `pid_recycled_into_stranger` cannot work on \
+             this platform for a pid sysinfo has not already seen alive."
         );
         (wrapper, pid)
+    }
+
+    /// Block until the child at `pid` has exited, *without* reaping it.
+    ///
+    /// `WNOWAIT` leaves the exit status pending, so the process stays an
+    /// unreaped zombie for the caller's assertions and for the later
+    /// `Child::wait` in `kill_group_and_reap` to consume.
+    ///
+    /// This replaces a poll for `ProcessStatus::Zombie` (dora-rs/dora#3150):
+    /// that made the precondition depend on `sysinfo` *observing* the zombie,
+    /// which is a platform question, not the one under test. The poll timed
+    /// out on the macOS nightly while passing on Linux. `waitid` is POSIX and
+    /// answers the question the helper is actually asking — has it exited yet
+    /// — with no sleep to lose. Measured on Linux: it returns in about a
+    /// millisecond.
+    ///
+    /// The wait runs on its own thread only so that a wrapper which never
+    /// exits fails *here*, with this message, instead of blocking until the CI
+    /// job's own timeout kills the run and reports nothing. That deadline
+    /// bounds the pathological case; it is not part of the normal path, and
+    /// unlike the poll it replaces it cannot expire while the answer is
+    /// already available. The thread stays parked in `waitid` if it does fire,
+    /// which is harmless — the panic is taking the process down anyway.
+    #[cfg(unix)]
+    fn wait_for_exit_without_reaping(pid: u32) {
+        use std::sync::mpsc::RecvTimeoutError;
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let result = loop {
+                // SAFETY: `waitid` only reads the exit state of a child this
+                // test spawned. Its one out-parameter is `info`, a valid,
+                // aligned, uniquely borrowed `siginfo_t` that outlives the
+                // call; zeroing it first is sound because every field is an
+                // integer, a `pid_t`/`uid_t`, a raw pointer, or padding, for
+                // all of which all-zeros is a valid bit pattern. `WNOWAIT`
+                // leaves the status unconsumed, so the child stays reapable.
+                let rc = unsafe {
+                    let mut info: libc::siginfo_t = std::mem::zeroed();
+                    libc::waitid(
+                        libc::P_PID,
+                        pid as libc::id_t,
+                        &mut info,
+                        libc::WEXITED | libc::WNOWAIT,
+                    )
+                };
+                if rc == 0 {
+                    break Ok(());
+                }
+                // A signal delivered to this thread must not be reported as
+                // the child failing to exit — that is the flake class this
+                // helper exists to remove.
+                let err = std::io::Error::last_os_error();
+                if err.kind() == std::io::ErrorKind::Interrupted {
+                    continue;
+                }
+                break Err(err);
+            };
+            let _ = tx.send(result);
+        });
+
+        match rx.recv_timeout(Duration::from_secs(30)) {
+            Ok(Ok(())) => {}
+            // `ECHILD` here would mean something reaped the wrapper out from
+            // under the test; `EINVAL` would mean the options are wrong for
+            // this platform. Both are worth telling apart from a timeout.
+            Ok(Err(err)) => panic!("waitid on the wrapper failed: {err}"),
+            Err(RecvTimeoutError::Timeout) => {
+                panic!("the wrapper never exited: waitid blocked for 30s")
+            }
+            Err(RecvTimeoutError::Disconnected) => {
+                panic!("the thread waiting on the wrapper died")
+            }
+        }
     }
 
     #[cfg(unix)]

--- a/binaries/daemon/src/shutdown.rs
+++ b/binaries/daemon/src/shutdown.rs
@@ -461,29 +461,52 @@ mod tests {
 
         // Close stdin so `read` hits EOF and the wrapper exits. No `wait()`:
         // without the reap it stays a zombie, which is the state under test.
-        // Spin until the kernel has actually gotten there — callers pause the
-        // test clock, so this waits on the OS, not on tokio.
         drop(wrapper.stdin.take());
-        let deadline = std::time::Instant::now() + Duration::from_secs(5);
-        loop {
-            let mut system = System::new();
-            system.refresh_processes_specifics(
-                ProcessesToUpdate::Some(&[Pid::from_u32(pid)]),
-                true,
-                ProcessRefreshKind::nothing(),
-            );
-            let zombie = system
-                .process(Pid::from_u32(pid))
-                .is_some_and(|process| process.status() == ProcessStatus::Zombie);
-            if zombie {
-                break;
-            }
-            assert!(
-                std::time::Instant::now() < deadline,
-                "the wrapper never became a zombie"
-            );
-            std::thread::sleep(Duration::from_millis(20));
-        }
+
+        // Block until the kernel says it has exited, *without* reaping it.
+        // `WNOWAIT` leaves the status pending, so the process stays a zombie
+        // for the assertions below and for `kill_group_and_reap` to clean up.
+        //
+        // This replaces a poll for `ProcessStatus::Zombie` (dora-rs/dora#3150):
+        // that made the precondition depend on `sysinfo` *observing* the
+        // zombie, which is a platform question, not the one under test. The
+        // poll timed out on macOS nightly while passing on Linux. `waitid` is
+        // POSIX and answers the actual question — has it exited yet — with no
+        // deadline to lose.
+        //
+        // SAFETY: `waitid` only reads the exit state of a child this test
+        // spawned; `WNOWAIT` means it does not consume it.
+        let rc = unsafe {
+            let mut info: libc::siginfo_t = std::mem::zeroed();
+            libc::waitid(
+                libc::P_PID,
+                pid as libc::id_t,
+                &mut info,
+                libc::WEXITED | libc::WNOWAIT,
+            )
+        };
+        assert_eq!(rc, 0, "waitid on the wrapper failed");
+
+        // The wrapper is now definitively an unreaped zombie. If `sysinfo`
+        // disagrees, that is a platform gap worth knowing about rather than a
+        // flake: `live_children` treats an unseen pid as *not* recycled
+        // (`pid_recycled_into_stranger` returns false for `None`), so a pid
+        // recycled into a stranger's zombie would be attributed to us and its
+        // group killed — the #3067 case. Fail loudly and name it.
+        let mut system = System::new();
+        system.refresh_processes_specifics(
+            ProcessesToUpdate::Some(&[Pid::from_u32(pid)]),
+            true,
+            ProcessRefreshKind::nothing(),
+        );
+        let seen = system.process(Pid::from_u32(pid)).map(|p| p.status());
+        assert_eq!(
+            seen,
+            Some(ProcessStatus::Zombie),
+            "`waitid` confirms the wrapper exited unreaped, but sysinfo \
+             reports {seen:?}. The zombie checks in `is_live_child` and \
+             `pid_recycled_into_stranger` cannot work on this platform."
+        );
         (wrapper, pid)
     }
 


### PR DESCRIPTION
`spawn_unreaped_wrapper` polled `sysinfo` for `ProcessStatus::Zombie` with a 5-second deadline. That made the test's *precondition* depend on sysinfo observing the zombie — a platform question, not the one under test. The poll timed out on the 2026-08-19 macOS nightly (#3150) while passing on Linux, so `an_unreaped_leader_of_ours_still_covers_its_surviving_child` and `a_strangers_zombie_at_a_recycled_pid_does_not_make_its_group_ours` both died at `the wrapper never became a zombie`, before reaching an assertion.

`waitid(P_PID, pid, WEXITED | WNOWAIT)` answers the question the helper is actually asking — has it exited yet — and `WNOWAIT` leaves the status pending, so the process stays an unreaped zombie for the assertions and for `kill_group_and_reap`. Measured on Linux: returns in ~0.9 ms, a second `waitid` still succeeds (i.e. still unreaped), `kill(-pid, 0)` still finds the group, and the later `Child::wait` still reaps.

Three details the call needs to be worth trusting. It retries on `EINTR`, so a signal delivered to the waiting thread is not reported as the child failing to exit — that is the flake class this change exists to remove. It reports `errno` on failure, because `ECHILD` (something reaped the wrapper out from under the test) and `EINVAL` (wrong options for this platform) are the two answers worth telling apart. And it runs on its own thread with a 30-second recv deadline, so a wrapper that never exits fails *here* with a message rather than blocking until the CI job's own timeout kills the run and reports nothing. Unlike the poll it replaces, that deadline cannot expire while the answer is already available.

The sysinfo check is kept, as an explicit assertion rather than a poll, because a disagreement between the two is worth surfacing. `live_children` treats a pid sysinfo cannot see as *not* recycled — `pid_recycled_into_stranger` returns `false` for `None` — so on a platform where zombies are invisible to sysinfo, a pid recycled into a **stranger's** zombie is attributed to us and its process group gets `killpg`'d. That is the #3067 case, fixed on Linux by #3076.

Reading sysinfo 0.39's `src/unix/apple/macos/process.rs` says which way macOS will go, and it is the unhappy one. For a pid not already in the map, `create_new_process` returns `Err(())` unless `sysctl(KERN_PROCARGS2)` or `proc_pidpath` succeeds — both read state the kernel no longer serves for a zombie — so `System::process()` yields `None` and the `SZOMB => Zombie` arm is never reached. That is precisely what the old poll was waiting for, which explains the nightly timeout. So expect this to leave the macOS job red, failing fast at the new assertion instead of after 5 seconds of nothing.

The blast radius is narrower than that assertion firing suggests, though, and its message now says so. The helper builds a *fresh* `System`; a long-lived `DestroyWait` keeps its `System` across polls and has already seen the pid alive, so it takes sysinfo's *update* path, which can still report `Zombie` where the create path returns nothing. The macOS follow-up is real but should be scoped to that difference rather than filed as "the guard does not work".

Full `dora-daemon` lib suite passes (253), shutdown tests green over 15 repeat runs at 0.02 s each, `cargo fmt --check` and `cargo clippy -p dora-daemon -- -D warnings` clean. (`--all-targets` clippy reports four pre-existing findings in `lib.rs`, untouched here and not covered by CI's `--all` invocation.)

Refs #3150
