### PR TITLE
chore: pin intra-workspace versions and mark the internal crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,36 +110,36 @@ license = "Apache-2.0"
 repository = "https://github.com/dora-rs/dora/"
 
 [workspace.dependencies]
-dora-node-api = { version = "1.0.0-rc.4", path = "apis/rust/node", default-features = false }
-dora-node-api-python = { version = "1.0.0-rc.4", path = "apis/python/node", default-features = false }
-dora-operator-api = { version = "1.0.0-rc.4", path = "apis/rust/operator", default-features = false }
-dora-operator-api-macros = { version = "1.0.0-rc.4", path = "apis/rust/operator/macros" }
-dora-operator-api-types = { version = "1.0.0-rc.4", path = "apis/rust/operator/types" }
-dora-operator-api-python = { version = "1.0.0-rc.4", path = "apis/python/operator" }
-dora-operator-api-c = { version = "1.0.0-rc.4", path = "apis/c/operator" }
-dora-node-api-c = { version = "1.0.0-rc.4", path = "apis/c/node" }
-dora-core = { version = "1.0.0-rc.4", path = "libraries/core" }
-dora-hub-client = { version = "1.0.0-rc.4", path = "libraries/hub-client" }
-dora-recording = { version = "1.0.0-rc.4", path = "libraries/recording" }
-dora-arrow-convert = { version = "1.0.0-rc.4", path = "libraries/arrow-convert" }
-dora-tracing = { version = "1.0.0-rc.4", path = "libraries/extensions/telemetry/tracing" }
-dora-metrics = { version = "1.0.0-rc.4", path = "libraries/extensions/telemetry/metrics" }
-dora-download = { version = "1.0.0-rc.4", path = "libraries/extensions/download" }
-dora-log-utils = { version = "1.0.0-rc.4", path = "libraries/log-utils" }
-dora-coordinator-store = { version = "1.0.0-rc.4", path = "libraries/coordinator-store" }
-dora-cli = { version = "1.0.0-rc.4", path = "binaries/cli" }
-dora-runtime-api = { version = "1.0.0-rc.4", path = "binaries/runtime-api" }
-dora-runtime-shared-lib = { version = "1.0.0-rc.4", path = "binaries/runtime-shared-lib" }
-dora-runtime-python = { version = "1.0.0-rc.4", path = "binaries/runtime-python" }
-dora-daemon = { version = "1.0.0-rc.4", path = "binaries/daemon" }
-dora-coordinator = { version = "1.0.0-rc.4", path = "binaries/coordinator" }
-dora-ros2-bridge = { version = "1.0.0-rc.4", path = "libraries/extensions/ros2-bridge" }
-dora-ros2-bridge-msg-gen = { version = "1.0.0-rc.4", path = "libraries/extensions/ros2-bridge/msg-gen" }
+dora-node-api = { version = "=1.0.0-rc.4", path = "apis/rust/node", default-features = false }
+dora-node-api-python = { version = "=1.0.0-rc.4", path = "apis/python/node", default-features = false }
+dora-operator-api = { version = "=1.0.0-rc.4", path = "apis/rust/operator", default-features = false }
+dora-operator-api-macros = { version = "=1.0.0-rc.4", path = "apis/rust/operator/macros" }
+dora-operator-api-types = { version = "=1.0.0-rc.4", path = "apis/rust/operator/types" }
+dora-operator-api-python = { version = "=1.0.0-rc.4", path = "apis/python/operator" }
+dora-operator-api-c = { version = "=1.0.0-rc.4", path = "apis/c/operator" }
+dora-node-api-c = { version = "=1.0.0-rc.4", path = "apis/c/node" }
+dora-core = { version = "=1.0.0-rc.4", path = "libraries/core" }
+dora-hub-client = { version = "=1.0.0-rc.4", path = "libraries/hub-client" }
+dora-recording = { version = "=1.0.0-rc.4", path = "libraries/recording" }
+dora-arrow-convert = { version = "=1.0.0-rc.4", path = "libraries/arrow-convert" }
+dora-tracing = { version = "=1.0.0-rc.4", path = "libraries/extensions/telemetry/tracing" }
+dora-metrics = { version = "=1.0.0-rc.4", path = "libraries/extensions/telemetry/metrics" }
+dora-download = { version = "=1.0.0-rc.4", path = "libraries/extensions/download" }
+dora-log-utils = { version = "=1.0.0-rc.4", path = "libraries/log-utils" }
+dora-coordinator-store = { version = "=1.0.0-rc.4", path = "libraries/coordinator-store" }
+dora-cli = { version = "=1.0.0-rc.4", path = "binaries/cli" }
+dora-runtime-api = { version = "=1.0.0-rc.4", path = "binaries/runtime-api" }
+dora-runtime-shared-lib = { version = "=1.0.0-rc.4", path = "binaries/runtime-shared-lib" }
+dora-runtime-python = { version = "=1.0.0-rc.4", path = "binaries/runtime-python" }
+dora-daemon = { version = "=1.0.0-rc.4", path = "binaries/daemon" }
+dora-coordinator = { version = "=1.0.0-rc.4", path = "binaries/coordinator" }
+dora-ros2-bridge = { version = "=1.0.0-rc.4", path = "libraries/extensions/ros2-bridge" }
+dora-ros2-bridge-msg-gen = { version = "=1.0.0-rc.4", path = "libraries/extensions/ros2-bridge/msg-gen" }
 dora-ros2-bridge-python = { path = "libraries/extensions/ros2-bridge/python" }
-dora-mavlink2-bridge = { version = "1.0.0-rc.4", path = "libraries/extensions/mavlink2-bridge" }
-dora-tensor-pool = { version = "1.0.0-rc.4", path = "libraries/extensions/tensor-pool" }
-dora-tensor-pool-python = { version = "1.0.0-rc.4", path = "libraries/extensions/tensor-pool/python" }
-dora-message = { version = "1.0.0-rc.4", path = "libraries/message" }
+dora-mavlink2-bridge = { version = "=1.0.0-rc.4", path = "libraries/extensions/mavlink2-bridge" }
+dora-tensor-pool = { version = "=1.0.0-rc.4", path = "libraries/extensions/tensor-pool" }
+dora-tensor-pool-python = { version = "=1.0.0-rc.4", path = "libraries/extensions/tensor-pool/python" }
+dora-message = { version = "=1.0.0-rc.4", path = "libraries/message" }
 # Declared here so `dora-ros2-bridge` and `dora-ros2-bridge-arrow` cannot drift
 # apart on the ROS distro. `humble` selects the 24-byte `Gid` layout used by
 # `rmw_dds_common` graph discovery (see `ros2-client`'s `src/gid.rs`), matching

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -1,3 +1,13 @@
+//! **Internal to dora — not a public API.**
+//!
+//! This crate is published to crates.io only because cargo requires every
+//! dependency of a published crate to be published; `dora-node-api` and
+//! `dora-cli` depend on it. It is not covered by dora's 1.0 stability
+//! guarantee and may change in any release, including a patch.
+//!
+//! Depend on it directly at your own risk. See the "Stability scope at 1.0"
+//! section of `docs/api-rust.md`.
+//!
 use crate::{
     events::set_up_ctrlc_handler,
     handlers::{

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1,3 +1,13 @@
+//! **Internal to dora — not a public API.**
+//!
+//! This crate is published to crates.io only because cargo requires every
+//! dependency of a published crate to be published; `dora-node-api` and
+//! `dora-cli` depend on it. It is not covered by dora's 1.0 stability
+//! guarantee and may change in any release, including a patch.
+//!
+//! Depend on it directly at your own risk. See the "Stability scope at 1.0"
+//! section of `docs/api-rust.md`.
+//!
 use aligned_vec::{AVec, ConstAlign};
 use coordinator::CoordinatorEvent;
 use crossbeam::queue::ArrayQueue;

--- a/binaries/runtime-api/src/lib.rs
+++ b/binaries/runtime-api/src/lib.rs
@@ -1,3 +1,13 @@
+//! **Internal to dora — not a public API.**
+//!
+//! This crate is published to crates.io only because cargo requires every
+//! dependency of a published crate to be published; `dora-node-api` and
+//! `dora-cli` depend on it. It is not covered by dora's 1.0 stability
+//! guarantee and may change in any release, including a patch.
+//!
+//! Depend on it directly at your own risk. See the "Stability scope at 1.0"
+//! section of `docs/api-rust.md`.
+//!
 #![warn(unsafe_op_in_unsafe_fn)]
 
 use dora_core::{

--- a/libraries/coordinator-store/src/lib.rs
+++ b/libraries/coordinator-store/src/lib.rs
@@ -1,3 +1,13 @@
+//! **Internal to dora — not a public API.**
+//!
+//! This crate is published to crates.io only because cargo requires every
+//! dependency of a published crate to be published; `dora-node-api` and
+//! `dora-cli` depend on it. It is not covered by dora's 1.0 stability
+//! guarantee and may change in any release, including a patch.
+//!
+//! Depend on it directly at your own risk. See the "Stability scope at 1.0"
+//! section of `docs/api-rust.md`.
+//!
 mod in_memory;
 
 #[cfg(feature = "redb-backend")]

--- a/libraries/core/src/lib.rs
+++ b/libraries/core/src/lib.rs
@@ -1,3 +1,13 @@
+//! **Internal to dora — not a public API.**
+//!
+//! This crate is published to crates.io only because cargo requires every
+//! dependency of a published crate to be published; `dora-node-api` and
+//! `dora-cli` depend on it. It is not covered by dora's 1.0 stability
+//! guarantee and may change in any release, including a patch.
+//!
+//! Depend on it directly at your own risk. See the "Stability scope at 1.0"
+//! section of `docs/api-rust.md`.
+//!
 use eyre::{Context, bail, eyre};
 use std::{
     env::consts::{DLL_PREFIX, DLL_SUFFIX},

--- a/libraries/extensions/download/src/lib.rs
+++ b/libraries/extensions/download/src/lib.rs
@@ -1,3 +1,13 @@
+//! **Internal to dora — not a public API.**
+//!
+//! This crate is published to crates.io only because cargo requires every
+//! dependency of a published crate to be published; `dora-node-api` and
+//! `dora-cli` depend on it. It is not covered by dora's 1.0 stability
+//! guarantee and may change in any release, including a patch.
+//!
+//! Depend on it directly at your own risk. See the "Stability scope at 1.0"
+//! section of `docs/api-rust.md`.
+//!
 use eyre::{Context, ContextCompat};
 use sha2::{Digest, Sha256};
 #[cfg(unix)]

--- a/libraries/extensions/telemetry/metrics/src/lib.rs
+++ b/libraries/extensions/telemetry/metrics/src/lib.rs
@@ -1,3 +1,13 @@
+//! **Internal to dora — not a public API.**
+//!
+//! This crate is published to crates.io only because cargo requires every
+//! dependency of a published crate to be published; `dora-node-api` and
+//! `dora-cli` depend on it. It is not covered by dora's 1.0 stability
+//! guarantee and may change in any release, including a patch.
+//!
+//! Depend on it directly at your own risk. See the "Stability scope at 1.0"
+//! section of `docs/api-rust.md`.
+//!
 //! Enable system metric through opentelemetry exporter.
 //!
 //! This module fetch system information using [`sysinfo`] and

--- a/libraries/extensions/telemetry/tracing/src/lib.rs
+++ b/libraries/extensions/telemetry/tracing/src/lib.rs
@@ -1,3 +1,13 @@
+//! **Internal to dora — not a public API.**
+//!
+//! This crate is published to crates.io only because cargo requires every
+//! dependency of a published crate to be published; `dora-node-api` and
+//! `dora-cli` depend on it. It is not covered by dora's 1.0 stability
+//! guarantee and may change in any release, including a patch.
+//!
+//! Depend on it directly at your own risk. See the "Stability scope at 1.0"
+//! section of `docs/api-rust.md`.
+//!
 //! Enable tracing using OpenTelemetry with OTLP.
 //!
 //! This module initializes a tracing propagator for Rust code that requires tracing, and is

--- a/libraries/log-utils/src/lib.rs
+++ b/libraries/log-utils/src/lib.rs
@@ -1,3 +1,13 @@
+//! **Internal to dora — not a public API.**
+//!
+//! This crate is published to crates.io only because cargo requires every
+//! dependency of a published crate to be published; `dora-node-api` and
+//! `dora-cli` depend on it. It is not covered by dora's 1.0 stability
+//! guarantee and may change in any release, including a patch.
+//!
+//! Depend on it directly at your own risk. See the "Stability scope at 1.0"
+//! section of `docs/api-rust.md`.
+//!
 use dora_message::common::LogMessage;
 use eyre::{Context, Result, bail};
 

--- a/libraries/recording/src/lib.rs
+++ b/libraries/recording/src/lib.rs
@@ -1,3 +1,13 @@
+//! **Internal to dora — not a public API.**
+//!
+//! This crate is published to crates.io only because cargo requires every
+//! dependency of a published crate to be published; `dora-node-api` and
+//! `dora-cli` depend on it. It is not covered by dora's 1.0 stability
+//! guarantee and may change in any release, including a patch.
+//!
+//! Depend on it directly at your own risk. See the "Stability scope at 1.0"
+//! section of `docs/api-rust.md`.
+//!
 //! Binary `.drec` recording format for dora dataflow message capture and replay.
 //!
 //! A recording is a [`RecordingHeader`], a sequence of [`RecordEntry`] records,

--- a/scripts/qa/semver.sh
+++ b/scripts/qa/semver.sh
@@ -16,10 +16,20 @@ if ! command -v cargo-semver-checks >/dev/null; then
   exit 2
 fi
 
+# Only the crates covered by dora's 1.0 stability guarantee — see the
+# "Stability scope at 1.0" section of docs/api-rust.md.
+#
+# Deliberately absent:
+#   dora-core         internal; published only because dora-node-api and
+#                     dora-cli depend on it, and cargo requires a published
+#                     crate's dependencies to be published
+#   dora-operator-api shipped outside the guarantee (experimental), so a
+#                     breaking change here is expected, not a regression
+#   dora-cli          its Rust lib target is internal; the surface 1.0 covers
+#                     is the `dora` command and the dataflow YAML schema,
+#                     neither of which cargo-semver-checks can see
 PUBLIC_CRATES=(
   dora-node-api
-  dora-operator-api
-  dora-core
   dora-message
   dora-arrow-convert
 )


### PR DESCRIPTION
At 1.0 every workspace crate publishes at `1.0.0`, including ~10 that exist only to build `dora-node-api` and `dora-cli`. `publish = false` cannot fix that: `cargo publish` resolves path dependencies against crates.io, so an unpublished dependency makes its dependents unpublishable.

The internal crates therefore have to ship — but nothing requires pretending they are an API.

**Exact version pins.** The 29 intra-workspace dependencies move from `version = "1.0.0-rc.4"` (i.e. `^1.0.0-rc.4`) to `"=1.0.0-rc.4"`.

This is the part that does mechanical work rather than documentation work: without it, a breaking change in an internal crate breaks *already published* versions of the public ones, because `dora-node-api` 1.0.0 asking for `^1.0.0` would resolve to a later, incompatible `dora-core`. Exact pins keep every published version building forever.

**`Cargo.lock` is unchanged** — the pins resolve identically today and only bite when versions diverge, which is exactly the intent. `shared-version = true` stays, so there is still a single version number for the workspace.

The cost: a patch fix in an internal crate requires re-releasing its dependents. With lockstep releases that already happens every time, so it is close to free.

**Crate-level notices.** The 10 internal crates gain a `//!` block stating they are not public API and why they are on crates.io at all. Crate-level docs are what docs.rs renders first — where someone about to depend on `dora-daemon` actually looks.

**Scoped semver check.** `scripts/qa/semver.sh` now covers only the crates the guarantee covers, with each exclusion justified inline: `dora-operator-api` ships outside the guarantee so breakage is expected rather than a regression, `dora-core` is internal, and `dora-cli`'s Rust lib target is internal too — the surface 1.0 covers there is the `dora` command and the YAML schema, neither of which `cargo-semver-checks` can see.

Implements the enforcement half of the tiers documented in the stability-scope PR.
