### PR TITLE
fix(message): gate the daemon Metadata wire format at registration

### DIFF
--- a/libraries/message/src/daemon_to_coordinator.rs
+++ b/libraries/message/src/daemon_to_coordinator.rs
@@ -4,7 +4,8 @@ pub use crate::common::{
     DataMessage, LogLevel, LogMessage, NodeError, NodeErrorCause, NodeExitStatus, Timestamped,
 };
 use crate::{
-    BuildId, DataflowId, common::DaemonId, current_crate_version, id::NodeId, versions_compatible,
+    BuildId, DataflowId, common::DaemonId, current_crate_version, id::NodeId, metadata::Metadata,
+    versions_compatible,
 };
 
 /// Per-dataflow status reported by a daemon after (re-)registration.
@@ -46,6 +47,28 @@ pub struct DaemonRegisterRequest {
     /// distinguish them — an explicit flag can.
     #[serde(default)]
     supports_hub_sources: bool,
+
+    /// Layout version of [`Metadata`], which every `InterDaemonEvent::Output`
+    /// carries between daemons over zenoh.
+    ///
+    /// The coordinator is the only chokepoint that sees every daemon: there is
+    /// no daemon-to-daemon connection to handshake on, because that path is
+    /// zenoh pub/sub. Gating registration therefore gates the daemon-to-daemon
+    /// wire transitively — any two daemons routing a dataflow have both passed
+    /// this check, so they agree on the `Metadata` layout.
+    ///
+    /// `dora_version` alone does not cover this: #2366 dropped a `Metadata`
+    /// field without changing the version, and the resulting mid-stream desync
+    /// was #2742. The node-to-daemon path already gates this
+    /// ([`crate::node_to_daemon::NodeRegisterRequest::check_version`]); this is
+    /// the same gate one hop out.
+    ///
+    /// `#[serde(default)]` makes a pre-field daemon report 0 and fail the check
+    /// with a legible message. That works because this frame is JSON over the
+    /// coordinator WebSocket — a non-self-describing encoding would fail while
+    /// decoding the frame that carries the field, never reaching the check.
+    #[serde(default)]
+    metadata_version: u16,
 }
 
 impl DaemonRegisterRequest {
@@ -56,6 +79,7 @@ impl DaemonRegisterRequest {
             labels,
             // a daemon built from this crate understands hub git sources
             supports_hub_sources: true,
+            metadata_version: Metadata::CURRENT_VERSION,
         }
     }
 
@@ -70,6 +94,20 @@ impl DaemonRegisterRequest {
         let specified_version = &self.dora_version;
 
         if versions_compatible(&crate_version, specified_version)? {
+            // Even when semver matches, the payload layout can differ within a
+            // release series (#2366). Reject here so the failure is a legible
+            // registration error rather than a mid-stream desync between
+            // daemons routing the same dataflow (#2742).
+            if self.metadata_version != Metadata::CURRENT_VERSION {
+                return Err(format!(
+                    "message wire-format mismatch: this daemon speaks metadata format v{} \
+                     but the coordinator speaks v{}. The daemon and coordinator were built \
+                     from dora revisions with incompatible message formats; rebuild both \
+                     from the same revision.",
+                    self.metadata_version,
+                    Metadata::CURRENT_VERSION
+                ));
+            }
             Ok(())
         } else {
             // Direction-aware remediation: `versions_compatible` rejects both
@@ -115,7 +153,52 @@ mod register_version_tests {
             machine_id: None,
             labels: Default::default(),
             supports_hub_sources: true,
+            metadata_version: Metadata::CURRENT_VERSION,
         }
+    }
+
+    #[test]
+    fn same_version_daemon_with_a_different_metadata_layout_is_rejected() {
+        // The gap this closes: semver alone let #2366 through, where a
+        // `Metadata` field was dropped without a version bump. Two daemons
+        // routing one dataflow exchange `InterDaemonEvent::Output` over zenoh,
+        // which carries `Metadata` — and zenoh pub/sub has no connection to
+        // handshake on, so the coordinator is the only place this can be
+        // caught. A same-version daemon with a stale layout must be rejected
+        // here rather than desyncing mid-stream (#2742).
+        let mut req = DaemonRegisterRequest::new(None, Default::default());
+        req.metadata_version = Metadata::CURRENT_VERSION.wrapping_add(1);
+
+        let err = req
+            .check_version()
+            .expect_err("a metadata layout mismatch must be rejected");
+        assert!(err.contains("wire-format mismatch"), "{err}");
+        assert!(
+            err.contains("rebuild both"),
+            "the error should say how to fix it: {err}"
+        );
+    }
+
+    #[test]
+    fn a_daemon_predating_the_field_is_rejected_with_a_legible_error() {
+        // The frame is JSON over the coordinator WebSocket, so a daemon built
+        // before `metadata_version` existed simply omits it and `serde(default)`
+        // yields 0. That must fail the gate with a real message rather than
+        // being silently treated as compatible.
+        let json = serde_json::to_string(&DaemonRegisterRequest::new(None, Default::default()))
+            .expect("serialize");
+        let stripped: serde_json::Value = {
+            let mut v: serde_json::Value = serde_json::from_str(&json).unwrap();
+            v.as_object_mut().unwrap().remove("metadata_version");
+            v
+        };
+        let old: DaemonRegisterRequest =
+            serde_json::from_value(stripped).expect("a pre-field daemon must still deserialize");
+        assert_eq!(old.metadata_version, 0);
+        assert!(
+            old.check_version().is_err(),
+            "a pre-field daemon must not be treated as compatible"
+        );
     }
 
     #[test]


### PR DESCRIPTION
`InterDaemonEvent::Output` carries a `Metadata` between daemons, but nothing checked that two daemons agree on its layout.

`dora_version` does not cover this: #2366 dropped a `Metadata` field without changing the version, and the resulting mid-stream desync was #2742. The node→daemon path has gated it since then (`NodeRegisterRequest::check_version`); the daemon path never did.

### There is no daemon↔daemon handshake to add

That path is zenoh pub/sub — there is no connection to shake hands on. And semver compatibility between daemons is *already* guaranteed transitively, because registering with the coordinator is mandatory and `DaemonRegisterRequest::check_version()` rejects mismatches.

The coordinator is therefore the only chokepoint that sees every daemon, and gating there covers the daemon↔daemon wire transitively: any two daemons routing a dataflow have both passed the same check, so they agree on the `Metadata` layout.

So this adds `metadata_version` to `DaemonRegisterRequest` and checks it in `check_version()`, mirroring the node→daemon gate one hop out.

### On `#[serde(default)]`

A daemon built before the field omits it, `serde(default)` yields 0, and the check fails with a legible error rather than silently treating it as compatible.

That works because this frame is **JSON over the coordinator WebSocket**. In a non-self-describing encoding the peer would fail while decoding the very frame carrying the field and never reach the check — the same caveat the node→daemon gate already documents, and worth keeping in mind as more of the protocol moves to postcard.

Three tests: a same-version daemon with a stale layout is rejected, a pre-field daemon still deserializes but is rejected, and the existing direction-aware semver advice is unchanged.
