### PR TITLE
refactor!: hide tokio from the integration-testing API

### DIFF
--- a/apis/rust/node/src/daemon_connection/node_integration_testing.rs
+++ b/apis/rust/node/src/daemon_connection/node_integration_testing.rs
@@ -264,7 +264,7 @@ impl IntegrationTestingEvents {
 
 enum OutputWriter {
     Writer(Box<dyn Write + Send>),
-    Channel(tokio::sync::mpsc::UnboundedSender<serde_json::Map<String, serde_json::Value>>),
+    Channel(crate::integration_testing::OutputSender),
 }
 
 pub fn convert_output_to_json(

--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -2357,7 +2357,7 @@ mod tests {
             "test-node".parse().unwrap(),
             events,
         ));
-        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let (tx, _rx) = crate::integration_testing::output_channel();
         let outputs = TestingOutput::ToChannel(tx);
         let options = TestingOptions {
             skip_output_time_offsets: true,
@@ -2385,7 +2385,7 @@ mod tests {
             "test-node".parse().unwrap(),
             events,
         ));
-        let (tx, mut rx) = crate::integration_testing::unbounded_channel();
+        let (tx, mut rx) = crate::integration_testing::output_channel();
         let outputs = TestingOutput::ToChannel(tx);
         let options = TestingOptions {
             skip_output_time_offsets: true,
@@ -2524,7 +2524,7 @@ mod tests {
             "test-node".parse().unwrap(),
             events,
         ));
-        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let (tx, _rx) = crate::integration_testing::output_channel();
         let outputs = TestingOutput::ToChannel(tx);
         let options = TestingOptions {
             skip_output_time_offsets: true,
@@ -2591,7 +2591,7 @@ mod tests {
             "test-node".parse().unwrap(),
             events,
         ));
-        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let (tx, _rx) = crate::integration_testing::output_channel();
         let outputs = TestingOutput::ToChannel(tx);
         let options = TestingOptions {
             skip_output_time_offsets: true,

--- a/apis/rust/node/src/integration_testing.rs
+++ b/apis/rust/node/src/integration_testing.rs
@@ -49,7 +49,7 @@
 //!    );
 //!
 //!    // send the node's outputs to a channel so we can verify them later
-//!    let (tx, mut rx) = dora_node_api::integration_testing::unbounded_channel();
+//!    let (tx, mut rx) = dora_node_api::integration_testing::output_channel();
 //!    let outputs = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
 //!
 //!    // don't include time offsets in the outputs to make them deterministic
@@ -167,20 +167,47 @@ use std::cell::Cell;
 
 pub use dora_message::integration_testing_format::{self, IntegrationTestInput};
 
-/// Re-exported so tests can build the [`TestingOutput::ToChannel`] pair without
-/// taking their own `tokio` dependency. Only the unbounded API is re-exported —
-/// see [`TestingOutput::ToChannel`] for why a bounded channel is not usable here.
-pub use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
-
 /// A single node output, encoded as a JSON object.
 pub type OutputJson = serde_json::Map<String, serde_json::Value>;
+
+/// Sending half of a testing output channel, built by [`output_channel`] and
+/// handed to [`TestingOutput::ToChannel`].
+///
+/// Deliberately an opaque newtype rather than a re-exported channel type. The
+/// point is the same as the old `pub use tokio::sync::mpsc::…` — a test should
+/// not need its own channel dependency — but wrapping it also keeps the choice
+/// of channel out of dora's public API, so it is not frozen by the 1.0
+/// guarantee and can be swapped without a breaking change.
+#[derive(Debug, Clone)]
+pub struct OutputSender(tokio::sync::mpsc::UnboundedSender<OutputJson>);
+
+impl OutputSender {
+    pub(crate) fn send(&self, output: OutputJson) -> Result<(), eyre::Report> {
+        self.0
+            .send(output)
+            .map_err(|_| eyre::eyre!("testing output channel is closed"))
+    }
+}
+
+/// Receiving half of a testing output channel. Read it with [`drain_outputs`].
+#[derive(Debug)]
+pub struct OutputReceiver(tokio::sync::mpsc::UnboundedReceiver<OutputJson>);
+
+/// Creates the channel pair for [`TestingOutput::ToChannel`].
+///
+/// The channel is unbounded — see [`TestingOutput::ToChannel`] for why a
+/// bounded one would deadlock.
+pub fn output_channel() -> (OutputSender, OutputReceiver) {
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    (OutputSender(tx), OutputReceiver(rx))
+}
 
 /// Collects every output queued on a [`TestingOutput::ToChannel`] receiver
 /// without blocking.
 ///
 /// Call this once the node has finished; anything it sent is already queued.
-pub fn drain_outputs(rx: &mut UnboundedReceiver<OutputJson>) -> Vec<OutputJson> {
-    std::iter::from_fn(|| rx.try_recv().ok()).collect()
+pub fn drain_outputs(rx: &mut OutputReceiver) -> Vec<OutputJson> {
+    std::iter::from_fn(|| rx.0.try_recv().ok()).collect()
 }
 
 thread_local! {
@@ -282,9 +309,9 @@ pub enum TestingOutput {
     ToFile(std::path::PathBuf),
     /// Writes the output as JSONL file to the given writer.
     ToWriter(Box<dyn std::io::Write + Send>),
-    /// Sends each output as a JSON object to the given [`UnboundedReceiver`].
+    /// Sends each output as a JSON object to the paired [`OutputReceiver`].
     ///
-    /// Create the pair with [`unbounded_channel`] and read it with
+    /// Create the pair with [`output_channel`] and read it with
     /// [`drain_outputs`] once the node has finished.
     ///
     /// The channel is unbounded because nothing consumes it while the node
@@ -292,7 +319,7 @@ pub enum TestingOutput {
     /// outputs than its capacity: the node blocks waiting for the daemon's
     /// reply to that very output, and the reply cannot be produced until the
     /// output is accepted.
-    ToChannel(UnboundedSender<OutputJson>),
+    ToChannel(OutputSender),
 }
 
 /// Options for integration testing.

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -3630,10 +3630,10 @@ mod tests {
         drop(events);
     }
 
-    use crate::integration_testing::{OutputJson, UnboundedReceiver, drain_outputs};
+    use crate::integration_testing::{OutputJson, OutputReceiver, drain_outputs};
 
     /// Helper: create a minimal test node with a channel output.
-    fn test_node() -> (DoraNode, crate::EventStream, UnboundedReceiver<OutputJson>) {
+    fn test_node() -> (DoraNode, crate::EventStream, OutputReceiver) {
         let events = vec![TimedIncomingEvent {
             time_offset_secs: 0.1,
             event: IncomingEvent::Stop,
@@ -3642,7 +3642,7 @@ mod tests {
             "test-node".parse().unwrap(),
             events,
         ));
-        let (tx, rx) = crate::integration_testing::unbounded_channel();
+        let (tx, rx) = crate::integration_testing::output_channel();
         let outputs = TestingOutput::ToChannel(tx);
         let options = TestingOptions {
             skip_output_time_offsets: true,
@@ -3666,7 +3666,7 @@ mod tests {
             "drop-hang-node".parse().unwrap(),
             events,
         ));
-        let (tx, _rx) = crate::integration_testing::unbounded_channel();
+        let (tx, _rx) = crate::integration_testing::output_channel();
         let outputs = TestingOutput::ToChannel(tx);
         let (node, event_stream) =
             DoraNode::init_testing(inputs, outputs, TestingOptions::default()).unwrap();

--- a/examples/cross-language/rust-receiver/src/tests.rs
+++ b/examples/cross-language/rust-receiver/src/tests.rs
@@ -25,7 +25,7 @@ fn run_receiver(events: Vec<TimedIncomingEvent>) -> eyre::Result<()> {
     let inputs = dora_node_api::integration_testing::TestingInput::Input(
         IntegrationTestInput::new("rust-receiver".parse().unwrap(), events),
     );
-    let (tx, _rx) = dora_node_api::integration_testing::unbounded_channel();
+    let (tx, _rx) = dora_node_api::integration_testing::output_channel();
     let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
     let (node, events) = DoraNode::init_testing(inputs, testing_output, Default::default())?;
 

--- a/examples/cross-language/rust-sender/src/tests.rs
+++ b/examples/cross-language/rust-sender/src/tests.rs
@@ -22,7 +22,7 @@ fn run_sender(events: Vec<TimedIncomingEvent>) -> eyre::Result<Vec<serde_json::V
     let inputs = dora_node_api::integration_testing::TestingInput::Input(
         IntegrationTestInput::new("rust-sender".parse().unwrap(), events),
     );
-    let (tx, mut rx) = dora_node_api::integration_testing::unbounded_channel();
+    let (tx, mut rx) = dora_node_api::integration_testing::output_channel();
     let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
     let (node, events) = DoraNode::init_testing(inputs, testing_output, Default::default())?;
 

--- a/examples/multiple-daemons/node/src/tests.rs
+++ b/examples/multiple-daemons/node/src/tests.rs
@@ -22,7 +22,7 @@ fn run_node(events: Vec<TimedIncomingEvent>) -> eyre::Result<Vec<serde_json::Val
     let inputs = dora_node_api::integration_testing::TestingInput::Input(
         IntegrationTestInput::new("multiple-daemons-node".parse().unwrap(), events),
     );
-    let (tx, mut rx) = dora_node_api::integration_testing::unbounded_channel();
+    let (tx, mut rx) = dora_node_api::integration_testing::output_channel();
     let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
     let (node, events) = DoraNode::init_testing(inputs, testing_output, Default::default())?;
 

--- a/examples/multiple-daemons/sink/src/tests.rs
+++ b/examples/multiple-daemons/sink/src/tests.rs
@@ -25,7 +25,7 @@ fn run_sink(events: Vec<TimedIncomingEvent>) -> eyre::Result<()> {
     let inputs = dora_node_api::integration_testing::TestingInput::Input(
         IntegrationTestInput::new("multiple-daemons-sink".parse().unwrap(), events),
     );
-    let (tx, _rx) = dora_node_api::integration_testing::unbounded_channel();
+    let (tx, _rx) = dora_node_api::integration_testing::output_channel();
     let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
     let (node, events) = DoraNode::init_testing(inputs, testing_output, Default::default())?;
 

--- a/examples/rust-dataflow/node/src/tests.rs
+++ b/examples/rust-dataflow/node/src/tests.rs
@@ -96,7 +96,7 @@ fn test_sample_output() -> eyre::Result<()> {
         IntegrationTestInput::new("node_id".parse().unwrap(), events),
     );
 
-    let (tx, mut rx) = dora_node_api::integration_testing::unbounded_channel();
+    let (tx, mut rx) = dora_node_api::integration_testing::output_channel();
     let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
     let (mut node, mut events) =
         DoraNode::init_testing(inputs, testing_output, Default::default())?;

--- a/examples/rust-dataflow/sink/src/tests.rs
+++ b/examples/rust-dataflow/sink/src/tests.rs
@@ -25,7 +25,7 @@ fn run_sink(events: Vec<TimedIncomingEvent>) -> eyre::Result<()> {
     let inputs = dora_node_api::integration_testing::TestingInput::Input(
         IntegrationTestInput::new("rust-sink".parse().unwrap(), events),
     );
-    let (tx, _rx) = dora_node_api::integration_testing::unbounded_channel();
+    let (tx, _rx) = dora_node_api::integration_testing::output_channel();
     let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
     let (node, events) = DoraNode::init_testing(inputs, testing_output, Default::default())?;
 

--- a/examples/rust-dataflow/status-node/src/tests.rs
+++ b/examples/rust-dataflow/status-node/src/tests.rs
@@ -118,7 +118,7 @@ fn test_tick_counter_and_random_round_trip() -> eyre::Result<()> {
         IntegrationTestInput::new("rust-status-node".parse().unwrap(), events),
     );
 
-    let (tx, mut rx) = dora_node_api::integration_testing::unbounded_channel();
+    let (tx, mut rx) = dora_node_api::integration_testing::output_channel();
     let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
     let (node, events) = DoraNode::init_testing(inputs, testing_output, Default::default())?;
 
@@ -165,7 +165,7 @@ fn test_non_uint64_random_input_errors() -> eyre::Result<()> {
         IntegrationTestInput::new("rust-status-node".parse().unwrap(), events),
     );
 
-    let (tx, _rx) = dora_node_api::integration_testing::unbounded_channel();
+    let (tx, _rx) = dora_node_api::integration_testing::output_channel();
     let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
     let (node, events) = DoraNode::init_testing(inputs, testing_output, Default::default())?;
 

--- a/examples/validated-pipeline/sink/src/tests.rs
+++ b/examples/validated-pipeline/sink/src/tests.rs
@@ -25,7 +25,7 @@ fn run_sink(events: Vec<TimedIncomingEvent>) -> eyre::Result<()> {
     let inputs = dora_node_api::integration_testing::TestingInput::Input(
         IntegrationTestInput::new("sink".parse().unwrap(), events),
     );
-    let (tx, _rx) = dora_node_api::integration_testing::unbounded_channel();
+    let (tx, _rx) = dora_node_api::integration_testing::output_channel();
     let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
     let (node, events) = DoraNode::init_testing(inputs, testing_output, Default::default())?;
 

--- a/examples/validated-pipeline/source/src/tests.rs
+++ b/examples/validated-pipeline/source/src/tests.rs
@@ -22,7 +22,7 @@ fn run_source(events: Vec<TimedIncomingEvent>) -> eyre::Result<Vec<serde_json::V
     let inputs = dora_node_api::integration_testing::TestingInput::Input(
         IntegrationTestInput::new("source".parse().unwrap(), events),
     );
-    let (tx, mut rx) = dora_node_api::integration_testing::unbounded_channel();
+    let (tx, mut rx) = dora_node_api::integration_testing::output_channel();
     let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
     let (node, events) = DoraNode::init_testing(inputs, testing_output, Default::default())?;
 

--- a/examples/validated-pipeline/transform/src/tests.rs
+++ b/examples/validated-pipeline/transform/src/tests.rs
@@ -25,7 +25,7 @@ fn run_transform(events: Vec<TimedIncomingEvent>) -> eyre::Result<Vec<serde_json
     let inputs = dora_node_api::integration_testing::TestingInput::Input(
         IntegrationTestInput::new("transform".parse().unwrap(), events),
     );
-    let (tx, mut rx) = dora_node_api::integration_testing::unbounded_channel();
+    let (tx, mut rx) = dora_node_api::integration_testing::output_channel();
     let testing_output = dora_node_api::integration_testing::TestingOutput::ToChannel(tx);
     let (node, events) = DoraNode::init_testing(inputs, testing_output, Default::default())?;
 


### PR DESCRIPTION
`tokio` was in `dora-node-api`'s public surface through exactly one line — `pub use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel}` in `integration_testing` — which would have frozen a tokio major into the 1.0 guarantee.

### Why this isn't the feature gate that was planned

The plan of record was to gate the whole `integration_testing` module behind a non-default feature. Investigating it turned up three costs:

- **The module is load-bearing on the *non*-test path.** `init_from_env` reads `DORA_TEST_WITH_INPUTS`, `DORA_TEST_WRITE_OUTPUTS_TO`, and `DORA_TEST_NO_OUTPUT_TIME_OFFSET`, so gating removes env-var testing from release builds.
- **It would have silently disabled a test tier.** `tests/example-tests.rs` drives that mode with `cargo run -p <crate>`, which builds *without* dev-dependencies — so a dev-dep-only feature leaves the harness green while testing nothing.
- **It contradicts the mode's rationale.** Env-var testing exists to exercise "the exact same executable as used in the dataflow"; a feature flag makes that untrue by construction.

None of it was necessary. Tokio's exposure was only those three items, and the env-var path never touches them — it uses `TestingOutput::ToFile`. Wrapping them achieves the goal with no gate at all:

| before | after |
|---|---|
| `unbounded_channel()` | `output_channel()` |
| `UnboundedSender<OutputJson>` | `OutputSender` |
| `UnboundedReceiver<OutputJson>` | `OutputReceiver` |

The newtypes serve the same purpose the re-export did — a test needs no channel dependency of its own, which is what the old doc comment gave as the reason for it — and additionally keep *which* channel library dora uses out of the frozen API, so it can be swapped later without a breaking change.

### Verification

`pub use tokio` and every `tokio::` path are now absent from all public signatures. **`cargo test --test example-tests` passes** — that is specifically the tier a feature gate would have broken, so it is the meaningful check here rather than a formality.

Also confirmed, since it was an open question blocking the original plan: the record/replay path does not touch `integration_testing_format`, so nothing there is affected.

Breaking for tests using the old names; the fix is the rename in the table.
