### PR TITLE
feat: cross-machine node-to-node zenoh links and an explicit daemon mesh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2223,6 +2223,7 @@ dependencies = [
  "fs_extra",
  "git2",
  "itertools 0.15.0",
+ "json5",
  "log",
  "proptest",
  "schemars 1.2.2",

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -195,10 +195,11 @@ type ZenohPublishers = HashMap<DataId, DirectOutput>;
 /// Declare a direct-zenoh data publisher for every output that may ever take
 /// the direct path, plus the per-output ack state the startup handshake needs.
 ///
-/// Outputs the daemon pinned `daemon_only` (some consumer runs under another
-/// daemon, so delivery must go through this daemon's inter-daemon forwarding —
-/// #2738) get no publisher and no markers: they stay on the daemon path for
-/// the node's lifetime. Every other output gets a publisher declared eagerly
+/// Outputs the daemon pinned `daemon_only` — a consumer only inter-daemon
+/// forwarding can reach (a dynamic node on another daemon, or a remote static
+/// one with no dialable endpoint for this node), and forwarding is fed solely
+/// by daemon-path sends (#2738) — get no publisher and no markers: they stay on
+/// the daemon path for the node's lifetime. Every other output gets a publisher declared eagerly
 /// at init (rather than on first send) for two reasons: zenoh starts wiring
 /// routes immediately, and [`StartupHandshake`] needs the publishers to probe
 /// those routes before the node's first real send. An output with no required
@@ -235,7 +236,8 @@ fn declare_output_publishers(
         if output_routing.daemon_only {
             debug!(
                 output = %output_id,
-                "output pinned to the daemon path (a consumer runs under another daemon)"
+                "output pinned to the daemon path (a consumer is reachable only by \
+                 inter-daemon forwarding)"
             );
             continue;
         }
@@ -630,7 +632,7 @@ fn wait_for_grace(ack_states: &[Arc<AckState>], grace: Duration) {
             .iter()
             .all(|state| state.ready.load(Ordering::Relaxed))
         {
-            return;
+            break;
         }
         if Instant::now() >= grace_deadline {
             break;
@@ -649,6 +651,15 @@ fn wait_for_grace(ack_states: &[Arc<AckState>], grace: Duration) {
                 "startup handshake incomplete after {}ms; output stays on the \
                  reliable daemon path for the rest of the run",
                 grace.as_millis()
+            );
+        } else {
+            // The positive half of the same decision, and the only signal that
+            // an output is *off* the daemon path — which for a consumer on
+            // another machine means its data no longer crosses two daemons.
+            // Logged per output, once, at the moment it is settled for the run.
+            debug!(
+                output = %state.output_id,
+                "startup handshake complete; output takes the direct zenoh path"
             );
         }
     }
@@ -1819,8 +1830,9 @@ impl DoraNode {
                     return Err(NodeError::Output(format!(
                         "output \"{output_id}\": IPC-encoded message is {} bytes, exceeding \
                          the {}-byte daemon transport limit (the output is on the daemon \
-                         path: pinned for a consumer on another daemon, its startup \
-                         handshake did not complete, or no zenoh route is available)",
+                         path: pinned for a consumer only forwarding can reach, its \
+                         startup handshake did not complete, or no zenoh route is \
+                         available)",
                         v.len(),
                         dora_message::MAX_MESSAGE_BYTES,
                     )));

--- a/binaries/cli/src/command/cluster/config.rs
+++ b/binaries/cli/src/command/cluster/config.rs
@@ -207,8 +207,7 @@ impl ClusterConfig {
     }
 
     /// Per-machine `--zenoh-listen`/`--zenoh-connect` arguments wiring every
-    /// daemon to dial every other one, or `None` when the mesh cannot be
-    /// derived.
+    /// daemon to dial every other one.
     ///
     /// Since zenoh 1.9, peers do not relay for each other: two daemons that
     /// never form a direct link exchange nothing, with no fallback to wait
@@ -216,29 +215,44 @@ impl ClusterConfig {
     /// also what makes a cluster work on a network without multicast (a mesh
     /// VPN carries none).
     ///
-    /// `None` — rather than a partial mesh — when a machine has no dialable
-    /// address or when a rendezvous is configured instead. A half-meshed
-    /// cluster is the worst of both: the unmeshed daemons still need discovery,
-    /// but the meshed ones have disabled multicast by having explicit connect
-    /// endpoints.
-    pub fn zenoh_mesh_args(&self) -> Option<BTreeMap<&str, String>> {
+    /// Nothing is derived unless *every* machine gets an endpoint. A half-mesh
+    /// is the worst of both: the unmeshed daemons still need discovery, but the
+    /// meshed ones disabled multicast by having explicit connect endpoints.
+    pub fn zenoh_mesh_args(&self) -> ZenohMesh<'_> {
         if self.zenoh_peer.is_some() || self.machines.len() < 2 {
-            return None;
+            // A rendezvous was chosen instead, or there is nobody to dial.
+            return ZenohMesh::NotNeeded;
         }
-        let endpoints: Vec<(&str, IpAddr, u16)> = self
-            .machines
-            .iter()
-            .map(|m| {
-                let addr = m.zenoh_addr()?;
-                Some((
-                    m.id.as_str(),
-                    addr,
-                    m.zenoh_port.unwrap_or(DORA_ZENOH_LISTEN_PORT_DEFAULT),
-                ))
-            })
-            .collect::<Option<_>>()?;
+        let mut endpoints: Vec<(&str, IpAddr, u16)> = Vec::new();
+        for machine in &self.machines {
+            let Some(addr) = machine.zenoh_addr() else {
+                return ZenohMesh::Unavailable(format!(
+                    "machine `{}` has no dialable zenoh address (`host` is not an \
+                     IP address and `zenoh_addr` is unset)",
+                    machine.id
+                ));
+            };
+            let port = machine.zenoh_port.unwrap_or(DORA_ZENOH_LISTEN_PORT_DEFAULT);
+            // Two daemons on one host is a supported shape (`daemon_port`
+            // exists for it), and there they share a default zenoh port too.
+            // Both would bind the same endpoint: the second daemon's bind is
+            // fatal — it was named explicitly — and it dies in the background
+            // where `dora cluster up` cannot see it. Say so instead.
+            if let Some((other, _, _)) = endpoints
+                .iter()
+                .find(|(_, other_addr, other_port)| (*other_addr, *other_port) == (addr, port))
+            {
+                return ZenohMesh::Unavailable(format!(
+                    "machines `{other}` and `{}` would both bind zenoh endpoint {}; \
+                     give one of them a distinct `zenoh_port`",
+                    machine.id,
+                    SocketAddr::new(addr, port)
+                ));
+            }
+            endpoints.push((machine.id.as_str(), addr, port));
+        }
 
-        Some(
+        ZenohMesh::Derived(
             endpoints
                 .iter()
                 .map(|(id, addr, port)| {
@@ -265,6 +279,20 @@ impl ClusterConfig {
                 .collect(),
         )
     }
+}
+
+/// Whether `dora cluster up` can wire the daemons into an explicit zenoh mesh.
+#[derive(Debug)]
+pub enum ZenohMesh<'a> {
+    /// Per-machine daemon arguments: each listens on its own endpoint and dials
+    /// every other machine.
+    Derived(BTreeMap<&'a str, String>),
+    /// Deliberately not derived — a `zenoh_peer` rendezvous is configured, or
+    /// there is only one machine.
+    NotNeeded,
+    /// Could not be derived. The message says why and which field fixes it;
+    /// the cluster falls back to its previous discovery behaviour.
+    Unavailable(String),
 }
 
 /// Reject a value that will be interpolated into the remote SSH command unless
@@ -639,7 +667,9 @@ mod tests {
     fn mesh_wires_every_machine_to_every_other() {
         let f = write_yaml(TWO_IP_MACHINES);
         let config = ClusterConfig::load(f.path()).unwrap();
-        let args = config.zenoh_mesh_args().expect("both hosts are IPs");
+        let ZenohMesh::Derived(args) = config.zenoh_mesh_args() else {
+            panic!("both hosts are IPs, so the mesh must derive");
+        };
         assert_eq!(
             args.get("a").map(String::as_str),
             Some(" --zenoh-listen 100.64.0.2:5456 --zenoh-connect tcp/100.64.0.3:5456")
@@ -661,7 +691,9 @@ mod tests {
              - id: b\n    host: 100.64.0.2\n    zenoh_port: 5457\n",
         );
         let config = ClusterConfig::load(f.path()).unwrap();
-        let args = config.zenoh_mesh_args().expect("both have addresses");
+        let ZenohMesh::Derived(args) = config.zenoh_mesh_args() else {
+            panic!("both machines have addresses, so the mesh must derive");
+        };
         assert!(args["a"].contains("--zenoh-listen 100.64.0.2:5456"));
         assert!(args["a"].contains("--zenoh-connect tcp/100.64.0.2:5457"));
         assert!(args["b"].contains("--zenoh-listen 100.64.0.2:5457"));
@@ -678,14 +710,65 @@ mod tests {
              - id: b\n    host: jetson.local\n",
         );
         let config = ClusterConfig::load(f.path()).unwrap();
-        assert!(config.zenoh_mesh_args().is_none());
+        let ZenohMesh::Unavailable(reason) = config.zenoh_mesh_args() else {
+            panic!("a machine with no dialable address must block the mesh");
+        };
+        assert!(
+            reason.contains("`b`"),
+            "reason must name the machine: {reason}"
+        );
+        assert!(
+            reason.contains("zenoh_addr"),
+            "reason must name the fix: {reason}"
+        );
 
         // A single-machine cluster has nobody to dial.
         let f = write_yaml(
             "coordinator:\n  addr: 100.64.0.1\nmachines:\n  - id: a\n    host: 100.64.0.2\n",
         );
         let config = ClusterConfig::load(f.path()).unwrap();
-        assert!(config.zenoh_mesh_args().is_none());
+        assert!(matches!(config.zenoh_mesh_args(), ZenohMesh::NotNeeded));
+    }
+
+    /// Two daemons on one host is a supported shape (`daemon_port` exists for
+    /// it), and there both would default to the same zenoh port. The second
+    /// daemon's bind is fatal — it was named explicitly — and it dies in the
+    /// background where `dora cluster up` never sees it, so the collision has
+    /// to be caught here.
+    #[test]
+    fn colliding_endpoints_block_the_mesh() {
+        let f = write_yaml(
+            "coordinator:\n  addr: 100.64.0.1\nmachines:\n  \
+             - id: a\n    host: 100.64.0.2\n    daemon_port: 53291\n  \
+             - id: b\n    host: 100.64.0.2\n    daemon_port: 53292\n",
+        );
+        let config = ClusterConfig::load(f.path()).unwrap();
+        let ZenohMesh::Unavailable(reason) = config.zenoh_mesh_args() else {
+            panic!("two daemons sharing an endpoint must block the mesh");
+        };
+        assert!(
+            reason.contains("100.64.0.2:5456"),
+            "unexpected reason: {reason}"
+        );
+        assert!(
+            reason.contains("zenoh_port"),
+            "reason must name the fix: {reason}"
+        );
+
+        // Distinct ports make the same pair meshable.
+        let f = write_yaml(
+            "coordinator:\n  addr: 100.64.0.1\nmachines:\n  \
+             - id: a\n    host: 100.64.0.2\n    daemon_port: 53291\n  \
+             - id: b\n    host: 100.64.0.2\n    daemon_port: 53292\n    zenoh_port: 5457\n",
+        );
+        let config = ClusterConfig::load(f.path()).unwrap();
+        let ZenohMesh::Derived(args) = config.zenoh_mesh_args() else {
+            panic!("distinct ports must derive");
+        };
+        assert!(args["a"].contains("--zenoh-listen 100.64.0.2:5456"));
+        assert!(args["a"].contains("--zenoh-connect tcp/100.64.0.2:5457"));
+        assert!(args["b"].contains("--zenoh-listen 100.64.0.2:5457"));
+        assert!(args["b"].contains("--zenoh-connect tcp/100.64.0.2:5456"));
     }
 
     // The rendezvous and the mesh answer the same question two ways; setting
@@ -707,7 +790,7 @@ mod tests {
              - id: a\n    host: 100.64.0.2\n  - id: b\n    host: 100.64.0.3\n",
         );
         let config = ClusterConfig::load(f.path()).unwrap();
-        assert!(config.zenoh_mesh_args().is_none());
+        assert!(matches!(config.zenoh_mesh_args(), ZenohMesh::NotNeeded));
     }
 
     #[test]

--- a/binaries/cli/src/command/cluster/config.rs
+++ b/binaries/cli/src/command/cluster/config.rs
@@ -79,7 +79,7 @@ impl MachineConfig {
     /// A hostname in `host` yields `None`: `--zenoh-listen` needs an address to
     /// *bind*, which only the remote machine could resolve, and dora will not
     /// guess on its behalf.
-    fn zenoh_addr(&self) -> Option<IpAddr> {
+    fn dialable_addr(&self) -> Option<IpAddr> {
         match &self.zenoh_addr {
             Some(addr) => addr.parse().ok(),
             None => self.host.parse().ok(),
@@ -225,7 +225,7 @@ impl ClusterConfig {
         }
         let mut endpoints: Vec<(&str, IpAddr, u16)> = Vec::new();
         for machine in &self.machines {
-            let Some(addr) = machine.zenoh_addr() else {
+            let Some(addr) = machine.dialable_addr() else {
                 return ZenohMesh::Unavailable(format!(
                     "machine `{}` has no dialable zenoh address (`host` is not an \
                      IP address and `zenoh_addr` is unset)",

--- a/binaries/cli/src/command/cluster/config.rs
+++ b/binaries/cli/src/command/cluster/config.rs
@@ -1,11 +1,13 @@
 use eyre::{Context, bail};
 use std::{
     collections::{BTreeMap, HashSet},
-    net::IpAddr,
+    net::{IpAddr, SocketAddr},
     path::Path,
 };
 
-use dora_core::topics::DORA_COORDINATOR_PORT_WS_DEFAULT;
+use dora_core::topics::{
+    DORA_COORDINATOR_PORT_WS_DEFAULT, DORA_ZENOH_LISTEN_PORT_DEFAULT, zenoh_endpoint,
+};
 
 #[derive(Debug, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -54,6 +56,35 @@ pub struct MachineConfig {
     /// Labels for label-based scheduling (e.g. `gpu: "true"`, `arch: arm64`).
     #[serde(default)]
     pub labels: BTreeMap<String, String>,
+    /// Address the *other daemons* use to reach this machine's zenoh listener.
+    ///
+    /// Defaults to `host` when that is an IP address, which is the common case:
+    /// on a mesh VPN the tunnel address is both how you SSH in and how peers
+    /// dial. Set it when the two differ — an SSH-only jump address, a hostname
+    /// rather than an IP, or a multi-homed machine whose SSH interface is not
+    /// the one the other daemons can reach.
+    #[serde(default)]
+    pub zenoh_addr: Option<String>,
+    /// Port this machine's zenoh listener binds. Defaults to 5456.
+    ///
+    /// Per-machine like `daemon_port`, so two daemons on one host stay
+    /// expressible.
+    #[serde(default)]
+    pub zenoh_port: Option<u16>,
+}
+
+impl MachineConfig {
+    /// The address peers dial to reach this machine, if one can be determined.
+    ///
+    /// A hostname in `host` yields `None`: `--zenoh-listen` needs an address to
+    /// *bind*, which only the remote machine could resolve, and dora will not
+    /// guess on its behalf.
+    fn zenoh_addr(&self) -> Option<IpAddr> {
+        match &self.zenoh_addr {
+            Some(addr) => addr.parse().ok(),
+            None => self.host.parse().ok(),
+        }
+    }
 }
 
 impl ClusterConfig {
@@ -129,8 +160,110 @@ impl ClusterConfig {
             if m.daemon_port == Some(0) {
                 bail!("machine `{}` daemon_port must not be 0", m.id);
             }
+            // Same reasoning as `zenoh_peer` above: both fields are
+            // interpolated verbatim into the remote command
+            // (`--zenoh-listen {addr}:{port} --zenoh-connect ...`).
+            if let Some(addr) = &m.zenoh_addr {
+                validate_endpoint_shell_safe(
+                    &format!("machine `{}` zenoh_addr `{addr}`", m.id),
+                    addr,
+                )?;
+                if addr.parse::<IpAddr>().is_err() {
+                    bail!(
+                        "machine `{}` zenoh_addr `{addr}` is not an IP address. \
+                         Peers dial the address the daemon binds, and only an \
+                         address can be bound — a hostname would have to be \
+                         resolved on the remote machine, which dora cannot do \
+                         from here.",
+                        m.id
+                    );
+                }
+            }
+            // Port 0 would bind an ephemeral port, leaving peers dialing `:0`.
+            if m.zenoh_port == Some(0) {
+                bail!("machine `{}` zenoh_port must not be 0", m.id);
+            }
+        }
+        // The mesh and the rendezvous are two answers to the same question, and
+        // mixing them wires every daemon to dial both. Rather than silently
+        // pick one, say which to drop.
+        if self.zenoh_peer.is_some()
+            && self
+                .machines
+                .iter()
+                .any(|m| m.zenoh_addr.is_some() || m.zenoh_port.is_some())
+        {
+            bail!(
+                "cluster config sets both `zenoh_peer` and per-machine zenoh \
+                 addresses. `zenoh_peer` is a single shared rendezvous the \
+                 daemons discover each other through; per-machine addresses \
+                 wire them into an explicit mesh instead. Keep one: drop \
+                 `zenoh_peer` for the mesh (recommended — it needs no hub and \
+                 no gossip), or drop the per-machine fields to keep the \
+                 rendezvous."
+            );
         }
         Ok(())
+    }
+
+    /// Per-machine `--zenoh-listen`/`--zenoh-connect` arguments wiring every
+    /// daemon to dial every other one, or `None` when the mesh cannot be
+    /// derived.
+    ///
+    /// Since zenoh 1.9, peers do not relay for each other: two daemons that
+    /// never form a direct link exchange nothing, with no fallback to wait
+    /// for. Naming every peer establishes that clique by construction, which is
+    /// also what makes a cluster work on a network without multicast (a mesh
+    /// VPN carries none).
+    ///
+    /// `None` — rather than a partial mesh — when a machine has no dialable
+    /// address or when a rendezvous is configured instead. A half-meshed
+    /// cluster is the worst of both: the unmeshed daemons still need discovery,
+    /// but the meshed ones have disabled multicast by having explicit connect
+    /// endpoints.
+    pub fn zenoh_mesh_args(&self) -> Option<BTreeMap<&str, String>> {
+        if self.zenoh_peer.is_some() || self.machines.len() < 2 {
+            return None;
+        }
+        let endpoints: Vec<(&str, IpAddr, u16)> = self
+            .machines
+            .iter()
+            .map(|m| {
+                let addr = m.zenoh_addr()?;
+                Some((
+                    m.id.as_str(),
+                    addr,
+                    m.zenoh_port.unwrap_or(DORA_ZENOH_LISTEN_PORT_DEFAULT),
+                ))
+            })
+            .collect::<Option<_>>()?;
+
+        Some(
+            endpoints
+                .iter()
+                .map(|(id, addr, port)| {
+                    let peers: Vec<String> = endpoints
+                        .iter()
+                        .filter(|(peer_id, _, _)| peer_id != id)
+                        .map(|(_, peer_addr, peer_port)| zenoh_endpoint(*peer_addr, *peer_port))
+                        .collect();
+                    // A dial is one-directional but the transport it opens is
+                    // not, so the full mesh is |machines| * (|machines| - 1)
+                    // dials for |machines| * (|machines| - 1) / 2 links. The
+                    // duplication is deliberate: whichever daemon starts first
+                    // reaches the other as soon as it comes up, in either
+                    // order, and zenoh drops the redundant attempt.
+                    (
+                        *id,
+                        format!(
+                            " --zenoh-listen {} --zenoh-connect {}",
+                            SocketAddr::new(*addr, *port),
+                            peers.join(",")
+                        ),
+                    )
+                })
+                .collect(),
+        )
     }
 }
 
@@ -494,5 +627,106 @@ mod tests {
             "coordinator:\n  addr: 10.0.0.1\n  bogus: true\nmachines:\n  - id: a\n    host: b\n",
         );
         assert!(ClusterConfig::load(f.path()).is_err());
+    }
+
+    const TWO_IP_MACHINES: &str = "coordinator:\n  addr: 100.64.0.1\nmachines:\n  \
+                                   - id: a\n    host: 100.64.0.2\n  \
+                                   - id: b\n    host: 100.64.0.3\n";
+
+    // Every daemon listens on its own endpoint and dials every other one: the
+    // clique zenoh 1.9 requires, established without multicast or gossip.
+    #[test]
+    fn mesh_wires_every_machine_to_every_other() {
+        let f = write_yaml(TWO_IP_MACHINES);
+        let config = ClusterConfig::load(f.path()).unwrap();
+        let args = config.zenoh_mesh_args().expect("both hosts are IPs");
+        assert_eq!(
+            args.get("a").map(String::as_str),
+            Some(" --zenoh-listen 100.64.0.2:5456 --zenoh-connect tcp/100.64.0.3:5456")
+        );
+        assert_eq!(
+            args.get("b").map(String::as_str),
+            Some(" --zenoh-listen 100.64.0.3:5456 --zenoh-connect tcp/100.64.0.2:5456")
+        );
+    }
+
+    // `zenoh_addr` overrides `host` — the SSH address and the address peers
+    // dial are not always the same interface — and `zenoh_port` keeps two
+    // daemons on one host expressible.
+    #[test]
+    fn mesh_honors_explicit_address_and_port() {
+        let f = write_yaml(
+            "coordinator:\n  addr: 100.64.0.1\nmachines:\n  \
+             - id: a\n    host: jump.example.com\n    zenoh_addr: 100.64.0.2\n  \
+             - id: b\n    host: 100.64.0.2\n    zenoh_port: 5457\n",
+        );
+        let config = ClusterConfig::load(f.path()).unwrap();
+        let args = config.zenoh_mesh_args().expect("both have addresses");
+        assert!(args["a"].contains("--zenoh-listen 100.64.0.2:5456"));
+        assert!(args["a"].contains("--zenoh-connect tcp/100.64.0.2:5457"));
+        assert!(args["b"].contains("--zenoh-listen 100.64.0.2:5457"));
+    }
+
+    // A machine dora cannot address leaves the cluster unmeshed rather than
+    // half-meshed: explicit connect endpoints disable multicast scouting for
+    // the daemons that have them, so a partial mesh partitions the rest.
+    #[test]
+    fn mesh_is_all_or_nothing() {
+        let f = write_yaml(
+            "coordinator:\n  addr: 100.64.0.1\nmachines:\n  \
+             - id: a\n    host: 100.64.0.2\n  \
+             - id: b\n    host: jetson.local\n",
+        );
+        let config = ClusterConfig::load(f.path()).unwrap();
+        assert!(config.zenoh_mesh_args().is_none());
+
+        // A single-machine cluster has nobody to dial.
+        let f = write_yaml(
+            "coordinator:\n  addr: 100.64.0.1\nmachines:\n  - id: a\n    host: 100.64.0.2\n",
+        );
+        let config = ClusterConfig::load(f.path()).unwrap();
+        assert!(config.zenoh_mesh_args().is_none());
+    }
+
+    // The rendezvous and the mesh answer the same question two ways; setting
+    // both would have every daemon dial a hub *and* its peers.
+    #[test]
+    fn rendezvous_and_mesh_are_mutually_exclusive() {
+        let f = write_yaml(
+            "coordinator:\n  addr: 100.64.0.1\nzenoh_peer: tcp/100.64.0.1:5456\nmachines:\n  \
+             - id: a\n    host: 100.64.0.2\n    zenoh_addr: 100.64.0.2\n  \
+             - id: b\n    host: 100.64.0.3\n",
+        );
+        let err = ClusterConfig::load(f.path()).unwrap_err().to_string();
+        assert!(err.contains("zenoh_peer"), "unexpected error: {err}");
+
+        // Without per-machine fields, `zenoh_peer` still means "rendezvous, not
+        // mesh" — the daemons keep discovering each other through the hub.
+        let f = write_yaml(
+            "coordinator:\n  addr: 100.64.0.1\nzenoh_peer: tcp/100.64.0.1:5456\nmachines:\n  \
+             - id: a\n    host: 100.64.0.2\n  - id: b\n    host: 100.64.0.3\n",
+        );
+        let config = ClusterConfig::load(f.path()).unwrap();
+        assert!(config.zenoh_mesh_args().is_none());
+    }
+
+    #[test]
+    fn reject_unusable_zenoh_fields() {
+        for (yaml, expected) in [
+            ("    zenoh_addr: jetson.local\n", "not an IP address"),
+            ("    zenoh_port: 0\n", "must not be 0"),
+            (
+                "    zenoh_addr: \"1.2.3.4; rm -rf /\"\n",
+                "invalid character",
+            ),
+        ] {
+            let f = write_yaml(&format!(
+                "coordinator:\n  addr: 100.64.0.1\nmachines:\n  - id: a\n    host: 100.64.0.2\n{yaml}"
+            ));
+            let err = ClusterConfig::load(f.path())
+                .expect_err("must be rejected")
+                .to_string();
+            assert!(err.contains(expected), "unexpected error: {err}");
+        }
     }
 }

--- a/binaries/cli/src/command/cluster/up.rs
+++ b/binaries/cli/src/command/cluster/up.rs
@@ -155,6 +155,7 @@ impl Executable for Up {
                         "WARNING: timed out waiting for daemon(s): {}",
                         missing_daemons.join(", ")
                     );
+                    report_missing_daemon_logs(&config, &missing_daemons);
                     break;
                 }
                 std::thread::sleep(Duration::from_millis(500));
@@ -204,4 +205,32 @@ fn start_coordinator(port: u16) -> eyre::Result<()> {
     cmd.spawn().wrap_err("failed to start dora coordinator")?;
     println!("Started coordinator on 0.0.0.0:{port}");
     Ok(())
+}
+
+/// Print the tail of each unreachable daemon's log.
+///
+/// A daemon that dies during startup writes the reason to
+/// `/tmp/dora-daemon-<id>.log` on its own host and never registers, so without
+/// this the operator sees only "timed out waiting for daemon(s)" and has to go
+/// find the file themselves. The common causes are diagnosable from the log and
+/// nowhere else: a `--zenoh-listen` address that is not on the machine (a NAT
+/// or VIP `host:` in cluster.yml), or its port already held by a stale daemon —
+/// both fatal by design for an explicitly named listener, since a daemon that
+/// silently fails to bind is undialable.
+///
+/// Best-effort: a machine we cannot ssh back into is skipped quietly, because
+/// this runs on a path that has already failed and must not fail differently.
+fn report_missing_daemon_logs(config: &ClusterConfig, missing: &[String]) {
+    for machine_id in missing {
+        let Some(machine) = config.machines.iter().find(|m| &m.id == machine_id) else {
+            continue;
+        };
+        // `machine.id` is charset-validated by `ClusterConfig::validate`, so it
+        // cannot break out of the remote command.
+        let cmd = format!("tail -n 20 /tmp/dora-daemon-{machine_id}.log 2>/dev/null");
+        eprintln!("  --- last log lines from `{machine_id}` ---");
+        if run_ssh(&ssh_target(machine), machine.port, &cmd).is_err() {
+            eprintln!("  (could not read the log — ssh to `{machine_id}` failed)");
+        }
+    }
 }

--- a/binaries/cli/src/command/cluster/up.rs
+++ b/binaries/cli/src/command/cluster/up.rs
@@ -16,7 +16,7 @@ use crate::{
     common::{connect_to_coordinator, connect_with_retry},
 };
 
-use super::config::ClusterConfig;
+use super::config::{ClusterConfig, ZenohMesh};
 use super::{
     format_daemon_port_arg, format_labels_arg, format_zenoh_peer_arg, query_connected_daemons,
     run_ssh, ssh_target,
@@ -65,16 +65,19 @@ impl Executable for Up {
         // it. Falling back is deliberate: a partial mesh is worse than none,
         // since explicit connect endpoints turn multicast scouting off for the
         // daemons that have them while the rest still depend on it.
-        let zenoh_mesh_args = config.zenoh_mesh_args();
-        if zenoh_mesh_args.is_none() && config.zenoh_peer.is_none() && config.machines.len() > 1 {
-            eprintln!(
-                "WARNING: not all machines have a dialable zenoh address (an IP in `host`, \
-                 or `zenoh_addr`), so the daemons are left to discover each other by \
-                 multicast. On a network without multicast — a mesh VPN carries none — \
-                 they will not find each other. Set `zenoh_addr` per machine, or a shared \
-                 `zenoh_peer` rendezvous."
-            );
-        }
+        let zenoh_mesh_args = match config.zenoh_mesh_args() {
+            ZenohMesh::Derived(args) => Some(args),
+            ZenohMesh::NotNeeded => None,
+            ZenohMesh::Unavailable(reason) => {
+                eprintln!(
+                    "WARNING: {reason}, so the daemons are left to discover each other \
+                     by multicast. On a network without multicast — a mesh VPN carries \
+                     none — they will not find each other. Fix the field named above, \
+                     or configure a shared `zenoh_peer` rendezvous."
+                );
+                None
+            }
+        };
         let mut ssh_failures: Vec<(String, String)> = Vec::new();
         for machine in &config.machines {
             let target = ssh_target(machine);

--- a/binaries/cli/src/command/cluster/up.rs
+++ b/binaries/cli/src/command/cluster/up.rs
@@ -61,13 +61,32 @@ impl Executable for Up {
 
         // 2. SSH into each machine to start a daemon
         let zenoh_peer_arg = format_zenoh_peer_arg(config.zenoh_peer.as_deref());
+        // Wire the daemons into an explicit zenoh mesh where the config allows
+        // it. Falling back is deliberate: a partial mesh is worse than none,
+        // since explicit connect endpoints turn multicast scouting off for the
+        // daemons that have them while the rest still depend on it.
+        let zenoh_mesh_args = config.zenoh_mesh_args();
+        if zenoh_mesh_args.is_none() && config.zenoh_peer.is_none() && config.machines.len() > 1 {
+            eprintln!(
+                "WARNING: not all machines have a dialable zenoh address (an IP in `host`, \
+                 or `zenoh_addr`), so the daemons are left to discover each other by \
+                 multicast. On a network without multicast — a mesh VPN carries none — \
+                 they will not find each other. Set `zenoh_addr` per machine, or a shared \
+                 `zenoh_peer` rendezvous."
+            );
+        }
         let mut ssh_failures: Vec<(String, String)> = Vec::new();
         for machine in &config.machines {
             let target = ssh_target(machine);
             let labels_arg = format_labels_arg(&machine.labels);
             let daemon_port_arg = format_daemon_port_arg(machine.daemon_port);
+            let mesh_arg = zenoh_mesh_args
+                .as_ref()
+                .and_then(|args| args.get(machine.id.as_str()))
+                .map(String::as_str)
+                .unwrap_or_default();
             let remote_cmd = format!(
-                "nohup dora daemon --machine-id {id} --coordinator-addr {addr} --coordinator-port {port}{daemon_port_arg}{zenoh_peer_arg}{labels} --quiet > /tmp/dora-daemon-{id}.log 2>&1 &",
+                "nohup dora daemon --machine-id {id} --coordinator-addr {addr} --coordinator-port {port}{daemon_port_arg}{zenoh_peer_arg}{mesh_arg}{labels} --quiet > /tmp/dora-daemon-{id}.log 2>&1 &",
                 id = machine.id,
                 addr = config.coordinator.addr,
                 port = config.coordinator.port,

--- a/binaries/cli/src/command/daemon.rs
+++ b/binaries/cli/src/command/daemon.rs
@@ -4,7 +4,7 @@ use dora_core::{
     descriptor::DescriptorExt,
     topics::{
         DORA_COORDINATOR_PORT_WS_DEFAULT, DORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT,
-        DORA_DAEMON_LOCAL_LISTEN_PORT_ENV, LOCALHOST, ZenohListen,
+        DORA_DAEMON_LOCAL_LISTEN_PORT_ENV, DORA_ZENOH_CONFIG_OVERLAY_ENV, LOCALHOST, ZenohListen,
     },
 };
 
@@ -116,6 +116,20 @@ pub struct Daemon {
     /// daemon-to-daemon links to gossip.
     #[clap(long, value_name = "ENDPOINT", value_delimiter = ',')]
     zenoh_connect: Vec<String>,
+    /// JSON5 file of zenoh settings to layer on top of the configuration dora
+    /// computes, for this daemon and the nodes it spawns.
+    ///
+    /// Use it to point a deployment at zenoh routers you run yourself:
+    /// `{ connect: { endpoints: ["tcp/10.0.0.1:7447"] } }`. The two endpoint
+    /// lists (`connect.endpoints`, `listen.endpoints`) are *added* to dora's;
+    /// every other key replaces dora's value for that key.
+    ///
+    /// This is the additive counterpart to the `ZENOH_CONFIG` environment
+    /// variable, which builds the session entirely from its file — discarding
+    /// the direct node-to-node links the daemon plans, so same-machine traffic
+    /// ends up relayed through your router too. Setting both is an error.
+    #[clap(long, value_name = "PATH")]
+    zenoh_config_overlay: Option<PathBuf>,
     /// Suppresses all log output to stdout.
     #[clap(long)]
     quiet: bool,
@@ -151,6 +165,13 @@ impl Executable for Daemon {
                 DORA_DAEMON_LOCAL_LISTEN_PORT_ENV,
                 self.local_listen_port.to_string(),
             );
+        }
+        // Exported rather than passed down: the nodes this daemon spawns
+        // inherit it, so one flag configures the whole process tree the same
+        // way `ZENOH_CONFIG` does.
+        if let Some(overlay) = &self.zenoh_config_overlay {
+            // SAFETY: as above — no threads yet.
+            unsafe { std::env::set_var(DORA_ZENOH_CONFIG_OVERLAY_ENV, overlay) };
         }
 
         let mut builder = Builder::new_multi_thread();

--- a/binaries/cli/src/command/daemon.rs
+++ b/binaries/cli/src/command/daemon.rs
@@ -4,7 +4,7 @@ use dora_core::{
     descriptor::DescriptorExt,
     topics::{
         DORA_COORDINATOR_PORT_WS_DEFAULT, DORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT,
-        DORA_DAEMON_LOCAL_LISTEN_PORT_ENV, LOCALHOST,
+        DORA_DAEMON_LOCAL_LISTEN_PORT_ENV, LOCALHOST, ZenohListen,
     },
 };
 
@@ -82,8 +82,8 @@ pub struct Daemon {
     /// daemon's listen endpoint) for them yourself when using this flag.
     #[clap(long)]
     zenoh_no_multicast: bool,
-    /// IP address this daemon's Zenoh listener binds (e.g. `--zenoh-listen
-    /// 100.64.0.3`).
+    /// Address, and optionally port, this daemon's Zenoh listener binds (e.g.
+    /// `--zenoh-listen 100.64.0.3` or `--zenoh-listen 100.64.0.3:5456`).
     ///
     /// Zenoh advertises the address it binds, and remote daemons dial exactly
     /// that, so this is the address other daemons will use to reach this one.
@@ -93,8 +93,29 @@ pub struct Daemon {
     /// tunnel address on a mesh VPN such as Tailscale. Set this explicitly on a
     /// multi-homed host that would otherwise advertise an interface the other
     /// daemons cannot reach.
-    #[clap(long, value_name = "IP")]
-    zenoh_listen: Option<IpAddr>,
+    ///
+    /// Naming a port makes this daemon dialable *before* it has announced
+    /// anything, which is what `--zenoh-connect` on the other daemons needs.
+    /// Without one, the OS picks the port and peers can only learn it by
+    /// discovery. Bracket IPv6 when naming a port (`[fd7a:1::2]:5456`);
+    /// unbracketed, the trailing `:5456` reads as part of the address.
+    #[clap(long, value_name = "IP[:PORT]")]
+    zenoh_listen: Option<ZenohListen>,
+    /// Zenoh endpoints of the other daemons this one should dial (e.g.
+    /// `--zenoh-connect tcp/100.64.0.4:5456,tcp/100.64.0.5:5456`). Repeatable.
+    ///
+    /// Since zenoh 1.9, peers do not relay for each other: two daemons that
+    /// never form a direct link exchange nothing, with no fallback. Naming
+    /// every other daemon here establishes that clique by construction, with no
+    /// dependence on multicast or on gossip converging in time. Pair it with
+    /// `--zenoh-listen <IP>:<PORT>` so the peers dialing *this* daemon have an
+    /// endpoint they can predict.
+    ///
+    /// This is the mesh alternative to `--zenoh-peer`, which is a single shared
+    /// rendezvous every daemon both binds and dials, leaving the actual
+    /// daemon-to-daemon links to gossip.
+    #[clap(long, value_name = "ENDPOINT", value_delimiter = ',')]
+    zenoh_connect: Vec<String>,
     /// Suppresses all log output to stdout.
     #[clap(long)]
     quiet: bool,
@@ -285,7 +306,18 @@ impl Executable for Daemon {
                         handle_dataflow_result(result, None)
                     }
                     None => {
-                        dora_daemon::Daemon::run_with_zenoh_listen(SocketAddr::new(self.coordinator_addr, self.coordinator_port), self.machine_id, self.labels.unwrap_or_default(), self.local_listen_port, self.zenoh_peer, self.zenoh_listen, self.zenoh_no_multicast).await
+                        dora_daemon::Daemon::run_with_zenoh_listen(
+                            SocketAddr::new(self.coordinator_addr, self.coordinator_port),
+                            self.machine_id,
+                            self.labels.unwrap_or_default(),
+                            self.local_listen_port,
+                            dora_daemon::ZenohOptions {
+                                inter_daemon_peer: self.zenoh_peer,
+                                listen: self.zenoh_listen,
+                                connect: self.zenoh_connect,
+                                disable_multicast: self.zenoh_no_multicast,
+                            },
+                        ).await
                     }
                 }
             })

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -19,7 +19,7 @@ use dora_core::{
         read_as_descriptor, validate,
     },
     topics::{
-        DORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT, LOCALHOST, MulticastScouting,
+        DORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT, LOCALHOST, MulticastScouting, ZenohListen,
         open_zenoh_session_with_listen, reserve_zenoh_endpoint, validate_zenoh_listen,
         zenoh_bind_address_for, zenoh_daemon_control_topic, zenoh_output_publish_topic,
     },
@@ -1047,6 +1047,33 @@ async fn collect_and_send_metrics_bg(
     Ok(())
 }
 
+/// How a daemon wires its zenoh session: who it listens as, and who it dials.
+///
+/// Grouped rather than passed as four more positionals, because every field is
+/// optional and they are only meaningful together — a `listen` port with no
+/// peer `connect`ing to it, or the reverse, is a half-built mesh.
+#[derive(Debug, Default, Clone)]
+pub struct ZenohOptions {
+    /// Shared rendezvous endpoint every daemon both binds and dials
+    /// (`--zenoh-peer`). The first to bind it becomes the gossip hub; the rest
+    /// fall through to connect-only. Discovery still goes through gossip, so
+    /// the daemon-to-daemon links themselves are best-effort.
+    pub inter_daemon_peer: Option<String>,
+    /// Address, and optionally port, this daemon's listener binds
+    /// (`--zenoh-listen`). `None` derives it from the coordinator address,
+    /// which is right whenever daemons reach each other over the network they
+    /// reach the coordinator over — a LAN, or a mesh VPN. An address named here
+    /// must bind: unlike the derived one, failing to bind it is fatal.
+    pub listen: Option<ZenohListen>,
+    /// Peers this daemon dials directly (`--zenoh-connect`) — the explicit
+    /// mesh. Dial-only, unlike `inter_daemon_peer`, and it establishes the
+    /// clique zenoh 1.9 requires by construction rather than by gossip.
+    pub connect: Vec<String>,
+    /// Open sessions without multicast scouting, for this daemon and the nodes
+    /// it spawns (`--zenoh-no-multicast`).
+    pub disable_multicast: bool,
+}
+
 /// Where the daemon's zenoh listen address came from, which decides what a bind
 /// failure means.
 ///
@@ -1059,20 +1086,34 @@ async fn collect_and_send_metrics_bg(
 #[derive(Debug, Clone, Copy)]
 enum ZenohBind {
     /// Derived from the coordinator address; a bind failure can fall back.
+    /// Always an ephemeral port — nobody named one, so nobody is waiting to
+    /// dial a specific one either.
     Derived(IpAddr),
-    /// Named via `--zenoh-listen`; a bind failure is fatal.
-    Explicit(IpAddr),
+    /// Named via `--zenoh-listen`; a bind failure is fatal. Carries a port when
+    /// the operator named one, which is what lets peers dial this daemon
+    /// without discovering it first.
+    Explicit(ZenohListen),
 }
 
 impl ZenohBind {
     fn addr(self) -> IpAddr {
         match self {
-            Self::Derived(addr) | Self::Explicit(addr) => addr,
+            Self::Derived(addr) => addr,
+            Self::Explicit(listen) => listen.addr,
         }
     }
 
     fn is_explicit(self) -> bool {
         matches!(self, Self::Explicit(_))
+    }
+
+    /// The endpoint to request from zenoh: a named port verbatim, an ephemeral
+    /// one reserved from the OS otherwise.
+    fn endpoint(self) -> std::io::Result<String> {
+        match self {
+            Self::Derived(addr) => reserve_zenoh_endpoint(addr),
+            Self::Explicit(listen) => listen.endpoint(),
+        }
     }
 }
 
@@ -1096,9 +1137,10 @@ impl ZenohBind {
 fn announce_zenoh_bind(zenoh_bind: ZenohBind, coordinator_ws_addr: SocketAddr) -> eyre::Result<()> {
     if zenoh_bind.addr().is_loopback() && !coordinator_ws_addr.ip().is_loopback() {
         match zenoh_bind {
-            ZenohBind::Explicit(addr) => {
+            ZenohBind::Explicit(listen) => {
+                let addr = listen.addr;
                 eyre::bail!(
-                    "--zenoh-listen {addr} is a loopback address, but the coordinator \
+                    "--zenoh-listen {listen} is a loopback address, but the coordinator \
                      at {coordinator_ws_addr} is remote, so other daemons must be able \
                      to reach this one. A loopback listener advertises {addr} to peers, \
                      who would dial their own loopback and reach nothing. Pass the \
@@ -1166,56 +1208,46 @@ impl Daemon {
         );
     }
 
-    /// Runs the daemon. `zenoh_listen_addr` overrides the address this
-    /// daemon's zenoh listener binds, and therefore the locator its peers are
-    /// told to dial.
-    ///
-    /// Leave it `None` to derive it from `coordinator_ws_addr`, which is correct
-    /// whenever the daemons reach each other over the same network they reach
-    /// the coordinator over — a LAN, or a mesh VPN. Set it explicitly on a
-    /// multi-homed host that would otherwise advertise the wrong interface. An
-    /// address given here must bind: unlike the derived one, failing to bind it
-    /// is fatal rather than a fallback.
+    /// Runs the daemon with the given zenoh wiring; see [`ZenohOptions`].
     pub async fn run_with_zenoh_listen(
         coordinator_ws_addr: SocketAddr,
         machine_id: Option<String>,
         labels: BTreeMap<String, String>,
         local_listen_port: u16,
-        inter_daemon_peer: Option<String>,
-        zenoh_listen_addr: Option<IpAddr>,
-        disable_multicast: bool,
+        zenoh: ZenohOptions,
     ) -> eyre::Result<()> {
         Self::run_inner_with_builds(
             coordinator_ws_addr,
             machine_id,
             labels,
             local_listen_port,
-            inter_daemon_peer,
-            zenoh_listen_addr,
-            disable_multicast,
+            zenoh,
             Default::default(),
         )
         .await
     }
 
-    #[allow(clippy::too_many_arguments)]
     async fn run_inner_with_builds(
         coordinator_ws_addr: SocketAddr,
         machine_id: Option<String>,
         labels: BTreeMap<String, String>,
         local_listen_port: u16,
-        inter_daemon_peer: Option<String>,
-        zenoh_listen_addr: Option<IpAddr>,
-        disable_multicast: bool,
+        zenoh: ZenohOptions,
         initial_builds: BTreeMap<BuildId, BuildInfo>,
     ) -> eyre::Result<()> {
-        let zenoh_bind = match zenoh_listen_addr {
-            Some(addr) => {
-                validate_zenoh_listen(addr).wrap_err(
+        let ZenohOptions {
+            inter_daemon_peer,
+            listen: zenoh_listen,
+            connect: zenoh_connect,
+            disable_multicast,
+        } = zenoh;
+        let zenoh_bind = match zenoh_listen {
+            Some(listen) => {
+                validate_zenoh_listen(listen.addr).wrap_err(
                     "invalid --zenoh-listen address (omit the flag to derive it \
                      from --coordinator-addr)",
                 )?;
-                ZenohBind::Explicit(addr)
+                ZenohBind::Explicit(listen)
             }
             None => ZenohBind::Derived(zenoh_bind_address_for(coordinator_ws_addr)),
         };
@@ -1226,14 +1258,26 @@ impl Daemon {
         // looks like a connectivity problem for minutes before it looks like a
         // typo. Whether the address exists is not racy, so checking it early
         // costs nothing but a bind and a drop.
-        if let ZenohBind::Explicit(addr) = zenoh_bind {
-            std::net::TcpListener::bind((addr, 0))
+        //
+        // A *named* port is probed too, and there the bind is not only an
+        // existence check: it also reports the port already being in use, which
+        // is the likely mistake when two daemons share a host. That much is
+        // racy — the probe drops the socket before zenoh binds — but losing the
+        // race just defers the same error to the `info().locators()` check,
+        // which is fatal for an explicit bind either way.
+        if let ZenohBind::Explicit(listen) = zenoh_bind {
+            std::net::TcpListener::bind((listen.addr, listen.port.unwrap_or(0)))
                 .map(drop)
-                .wrap_err_with(|| {
-                    format!(
-                        "cannot bind the zenoh listen address {addr} given via \
+                .wrap_err_with(|| match listen.port {
+                    Some(port) => format!(
+                        "cannot bind the zenoh listen address {listen} given via \
+                         --zenoh-listen; either the address does not exist on this \
+                         host or port {port} is already in use"
+                    ),
+                    None => format!(
+                        "cannot bind the zenoh listen address {listen} given via \
                          --zenoh-listen; it does not appear to exist on this host"
-                    )
+                    ),
                 })?;
         }
         announce_zenoh_bind(zenoh_bind, coordinator_ws_addr)?;
@@ -1349,6 +1393,7 @@ impl Daemon {
                                 initial_builds.clone(),
                                 log_destination,
                                 inter_daemon_peer.clone(),
+                                zenoh_connect.clone(),
                                 zenoh_bind,
                                 disable_multicast,
                                 // A standalone daemon outlives nothing its
@@ -1739,6 +1784,8 @@ impl Daemon {
             builds,
             log_destination,
             inter_daemon_peer,
+            // `dora run` is single-machine: no remote daemon to dial.
+            Vec::new(),
             ZenohBind::Derived(LOCALHOST),
             disable_multicast,
             bind_nodes_to_parent,
@@ -1773,6 +1820,7 @@ impl Daemon {
         builds: BTreeMap<BuildId, BuildInfo>,
         log_destination: LogDestination,
         inter_daemon_peer: Option<String>,
+        zenoh_connect: Vec<String>,
         zenoh_bind: ZenohBind,
         disable_multicast: bool,
         bind_nodes_to_parent: bool,
@@ -1785,9 +1833,10 @@ impl Daemon {
         // scouting by multicast (#2991 review).
         let disable_multicast = dora_core::topics::multicast_disabled(disable_multicast);
 
-        // Reserve a port and have zenoh listen on it. The endpoint is injected
-        // into spawned nodes via `DORA_ZENOH_CONNECT` so peer discovery works
-        // without multicast (#1778).
+        // Decide the endpoint zenoh listens on. A named port is used verbatim;
+        // otherwise a free one is reserved from the OS. The endpoint is
+        // injected into spawned nodes via `DORA_ZENOH_CONNECT` so peer
+        // discovery works without multicast (#1778).
         //
         // `zenoh_bind` is loopback for single-machine deployments and an
         // address on the coordinator's network otherwise. It is not merely a
@@ -1806,7 +1855,7 @@ impl Daemon {
         // the exact failure this code exists to prevent. Someone who named an
         // address explicitly is also, almost by definition, on a network where
         // multicast will not save them. So: fatal when explicit.
-        let requested_listen_endpoint = match reserve_zenoh_endpoint(zenoh_bind.addr()) {
+        let requested_listen_endpoint = match zenoh_bind.endpoint() {
             Ok(ep) => Some(ep),
             Err(err) if zenoh_bind.is_explicit() => {
                 return Err(err).wrap_err_with(|| {
@@ -1836,6 +1885,7 @@ impl Daemon {
             open_zenoh_session_with_listen(dora_core::topics::ZenohSessionParams {
                 listen_endpoint: requested_listen_endpoint.as_deref(),
                 inter_daemon_peer: inter_daemon_peer.as_deref(),
+                connect_endpoints: &zenoh_connect,
                 multicast: if disable_multicast {
                     MulticastScouting::Disabled
                 } else {
@@ -9941,13 +9991,18 @@ mod announce_zenoh_bind_tests {
         SocketAddr::new(ip, 6012)
     }
 
+    /// An `--zenoh-listen <IP>` with no port named, which is what these cases
+    /// are about: the port never changes whether the *address* is advertisable.
+    fn explicit(addr: IpAddr) -> ZenohBind {
+        ZenohBind::Explicit(ZenohListen { addr, port: None })
+    }
+
     #[test]
     fn explicit_loopback_under_remote_coordinator_is_rejected() {
         // #2770: an operator who names a loopback address while the coordinator
         // is remote gets a silently-undialable daemon. The `Explicit` contract
         // is "bind a routable address or exit", so this must be a hard error.
-        let err = announce_zenoh_bind(ZenohBind::Explicit(LOOPBACK), sock(REMOTE_COORDINATOR))
-            .unwrap_err();
+        let err = announce_zenoh_bind(explicit(LOOPBACK), sock(REMOTE_COORDINATOR)).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("loopback"), "unexpected error: {msg}");
         assert!(msg.contains("--zenoh-listen"), "unexpected error: {msg}");
@@ -9964,16 +10019,12 @@ mod announce_zenoh_bind_tests {
     fn explicit_loopback_under_local_coordinator_is_allowed() {
         // Single-machine `dora run`: coordinator and nodes share loopback, so a
         // loopback listener is both sufficient and correct.
-        announce_zenoh_bind(ZenohBind::Explicit(LOOPBACK), sock(LOOPBACK)).unwrap();
+        announce_zenoh_bind(explicit(LOOPBACK), sock(LOOPBACK)).unwrap();
     }
 
     #[test]
     fn explicit_routable_address_is_allowed() {
-        announce_zenoh_bind(
-            ZenohBind::Explicit(ROUTABLE_LOCAL),
-            sock(REMOTE_COORDINATOR),
-        )
-        .unwrap();
+        announce_zenoh_bind(explicit(ROUTABLE_LOCAL), sock(REMOTE_COORDINATOR)).unwrap();
     }
 }
 

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -446,7 +446,7 @@ pub struct Daemon {
     /// `None` for a single-machine daemon, whose zenoh listener is on loopback:
     /// handing that address to a consumer on another machine would point it at
     /// its own loopback. Used to give a node with cross-machine consumers a
-    /// second, network-reachable listener (see `plan_zenoh_peering`).
+    /// second, network-reachable listener (see `spawn::reserve_node_listeners`).
     pub(crate) zenoh_routable_addr: Option<IpAddr>,
     /// Whether this daemon opened its zenoh session without multicast
     /// scouting. Forwarded to spawned nodes so they discover the same way the
@@ -4348,12 +4348,32 @@ impl Daemon {
         // relay, so a producer/consumer pair that never forms a direct link can
         // never exchange data. Assign the links explicitly instead of leaving
         // them to gossip's best-effort autoconnect.
-        dataflow.zenoh_peering = Arc::new(crate::spawn::plan_zenoh_peering(
+        //
+        // Three steps, in this order because each needs the previous one's
+        // result: reserve this daemon's own listeners, trade endpoints with the
+        // daemons running the rest of the dataflow, then build the dial lists.
+        // The trade has to finish before any node spawns — a node's zenoh
+        // session reads its dial list once at startup and never again.
+        let listeners =
+            crate::spawn::reserve_node_listeners(&nodes, &spawn_nodes, self.zenoh_routable_addr);
+        let (remote_endpoints, endpoint_queryable) = crate::spawn::endpoint_exchange::exchange(
+            &self.zenoh_session,
+            dataflow_id,
+            &self.daemon_id,
+            listeners
+                .iter()
+                .filter_map(|(id, l)| Some((id.clone(), l.routable()?.to_string())))
+                .collect(),
+            crate::spawn::remote_sources_of_local_nodes(&nodes, &spawn_nodes),
+        )
+        .await;
+        dataflow.zenoh_peering = Arc::new(crate::spawn::build_peering_plan(
             &nodes,
-            &spawn_nodes,
+            &listeners,
             self.zenoh_listen_endpoint.as_deref(),
-            self.zenoh_routable_addr,
+            &remote_endpoints,
         ));
+        dataflow.endpoint_queryable = endpoint_queryable;
         let dataflow = match self.running.entry(dataflow_id) {
             std::collections::hash_map::Entry::Vacant(entry) => {
                 self.working_dir

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -441,6 +441,13 @@ pub struct Daemon {
     /// peer without multicast (#1778). `None` when the OS rejected the
     /// reservation; nodes then fall back to multicast scouting.
     pub(crate) zenoh_listen_endpoint: Option<String>,
+    /// Address other machines reach this host at, when there is one.
+    ///
+    /// `None` for a single-machine daemon, whose zenoh listener is on loopback:
+    /// handing that address to a consumer on another machine would point it at
+    /// its own loopback. Used to give a node with cross-machine consumers a
+    /// second, network-reachable listener (see `plan_zenoh_peering`).
+    pub(crate) zenoh_routable_addr: Option<IpAddr>,
     /// Whether this daemon opened its zenoh session without multicast
     /// scouting. Forwarded to spawned nodes so they discover the same way the
     /// daemon does (see `DORA_ZENOH_MULTICAST`).
@@ -1961,6 +1968,9 @@ impl Daemon {
             ft_stats: Default::default(),
             zenoh_session,
             zenoh_listen_endpoint,
+            // A loopback bind is not an address anyone else can dial, so it is
+            // not a routable one; see the field docs.
+            zenoh_routable_addr: Some(zenoh_bind.addr()).filter(|addr| !addr.is_loopback()),
             disable_multicast,
             bind_nodes_to_parent,
             pending_destroy: None,
@@ -4342,6 +4352,7 @@ impl Daemon {
             &nodes,
             &spawn_nodes,
             self.zenoh_listen_endpoint.as_deref(),
+            self.zenoh_routable_addr,
         ));
         let dataflow = match self.running.entry(dataflow_id) {
             std::collections::hash_map::Entry::Vacant(entry) => {

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -4660,10 +4660,19 @@ impl Daemon {
         };
 
         // Startup-handshake routing, from actual placement (`spawn_nodes`):
-        // which outputs are pinned to the daemon path (remote consumers) and
-        // which local static consumers must ack before an output may switch to
-        // the direct zenoh path.
-        let mut output_routing = output_routing::compute_output_routing(&nodes, &spawn_nodes);
+        // which outputs are pinned to the daemon path and which static
+        // consumers must ack before an output may switch to the direct zenoh
+        // path. A remote consumer can only ack a producer it can dial, so the
+        // set of producers that got a routable endpoint decides which
+        // cross-machine edges are even candidates.
+        let routable_producers: BTreeSet<NodeId> = dataflow
+            .zenoh_peering
+            .iter()
+            .filter(|(_, peering)| peering.routable)
+            .map(|(id, _)| id.clone())
+            .collect();
+        let mut output_routing =
+            output_routing::compute_output_routing(&nodes, &spawn_nodes, &routable_producers);
 
         let mut tasks = Vec::new();
 

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1832,18 +1832,19 @@ impl Daemon {
         // the listen/endpoints insert. Otherwise we must not inject
         // `DORA_ZENOH_CONNECT` into spawned nodes — they would try to connect
         // to an endpoint that nothing is listening on (#1856).
-        let (zenoh_session, zenoh_listen_endpoint) = open_zenoh_session_with_listen(
-            None,
-            requested_listen_endpoint.as_deref(),
-            inter_daemon_peer.as_deref(),
-            if disable_multicast {
-                MulticastScouting::Disabled
-            } else {
-                MulticastScouting::Allowed
-            },
-        )
-        .await
-        .wrap_err("failed to open zenoh session")?;
+        let (zenoh_session, zenoh_listen_endpoint) =
+            open_zenoh_session_with_listen(dora_core::topics::ZenohSessionParams {
+                listen_endpoint: requested_listen_endpoint.as_deref(),
+                inter_daemon_peer: inter_daemon_peer.as_deref(),
+                multicast: if disable_multicast {
+                    MulticastScouting::Disabled
+                } else {
+                    MulticastScouting::Allowed
+                },
+                ..Default::default()
+            })
+            .await
+            .wrap_err("failed to open zenoh session")?;
         // Same-host control notifications (`PeerMessage::Register`/`PeerMessage::Free`) go over
         // zenoh SHM: the payload stays in shared memory and peer daemons
         if requested_listen_endpoint.is_some() && zenoh_listen_endpoint.is_none() {

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -4356,24 +4356,27 @@ impl Daemon {
         // session reads its dial list once at startup and never again.
         let listeners =
             crate::spawn::reserve_node_listeners(&nodes, &spawn_nodes, self.zenoh_routable_addr);
-        let (remote_endpoints, endpoint_queryable) = crate::spawn::endpoint_exchange::exchange(
-            &self.zenoh_session,
-            dataflow_id,
-            &self.daemon_id,
-            listeners
-                .iter()
-                .filter_map(|(id, l)| Some((id.clone(), l.routable()?.to_string())))
-                .collect(),
-            crate::spawn::remote_sources_of_local_nodes(&nodes, &spawn_nodes),
-        )
-        .await;
-        dataflow.zenoh_peering = Arc::new(crate::spawn::build_peering_plan(
-            &nodes,
-            &listeners,
-            self.zenoh_listen_endpoint.as_deref(),
-            &remote_endpoints,
-        ));
-        dataflow.endpoint_queryable = endpoint_queryable;
+        // Started here but awaited below, so its bounded wait overlaps the
+        // build metadata and working-directory work in between rather than
+        // stalling the event loop on its own. Same reason the memory-pool
+        // subscriber above runs off the loop: a degraded inter-daemon link must
+        // not wedge this spawn handler and every event queued behind it.
+        let wanted = crate::spawn::remote_sources_of_local_nodes(&nodes, &spawn_nodes);
+        let local_endpoints: BTreeMap<NodeId, String> = listeners
+            .iter()
+            .filter_map(|(id, l)| Some((id.clone(), l.routable()?.to_string())))
+            .collect();
+        let endpoint_exchange = (!wanted.is_empty() || !local_endpoints.is_empty()).then(|| {
+            let session = self.zenoh_session.clone();
+            let daemon_id = self.daemon_id.clone();
+            tokio::spawn(crate::spawn::endpoint_exchange::exchange(
+                session,
+                dataflow_id,
+                daemon_id,
+                local_endpoints,
+                wanted,
+            ))
+        });
         let dataflow = match self.running.entry(dataflow_id) {
             std::collections::hash_map::Entry::Vacant(entry) => {
                 self.working_dir
@@ -4643,6 +4646,26 @@ impl Daemon {
                 }
             }
         }
+
+        // Collect the endpoint exchange started before the build metadata work
+        // above, and only now build the dial lists — this is the last moment
+        // before nodes spawn, and a node reads its dial list once at startup.
+        // A task that panicked or was cancelled resolves to "no remote
+        // endpoints", which is the same degradation as an expired deadline.
+        let (remote_endpoints, endpoint_queryable) = match endpoint_exchange {
+            Some(task) => task.await.unwrap_or_else(|err| {
+                tracing::warn!("zenoh node-endpoint exchange failed: {err}");
+                Default::default()
+            }),
+            None => Default::default(),
+        };
+        dataflow.zenoh_peering = Arc::new(crate::spawn::build_peering_plan(
+            &nodes,
+            &listeners,
+            self.zenoh_listen_endpoint.as_deref(),
+            &remote_endpoints,
+        ));
+        dataflow.endpoint_queryable = endpoint_queryable;
 
         let spawner = Spawner {
             dataflow_id,

--- a/binaries/daemon/src/output_routing.rs
+++ b/binaries/daemon/src/output_routing.rs
@@ -9,25 +9,32 @@
 //! (`dora_message::daemon_to_node::NodeConfig`).
 //!
 //! Policy (see the `OutputRouting` docs for the consumer-side contract):
-//! - a consumer under **another daemon** pins the output to the daemon path
-//!   (`daemon_only`): the node-to-node zenoh mesh is same-machine only, and
-//!   only daemon-path sends feed the inter-daemon forwarder (dora #2738).
-//!   This holds for dynamic remote consumers too — they can only ever be
-//!   reached through forwarding.
-//! - a **local static** consumer becomes a required acker: the producer keeps
-//!   the output on the lossless daemon path until this consumer's startup ack
-//!   proves the direct zenoh route end-to-end. The producer gives that proof a
-//!   bounded startup window and pins the output to the daemon path for the run
-//!   if it does not arrive in time, so adding a required acker that is slow to
-//!   answer costs the fast path rather than reordering a live topic
-//!   (dora-rs/dora#2891).
+//! - a **static** consumer becomes a required acker, wherever it runs: the
+//!   producer keeps the output on the lossless daemon path until this
+//!   consumer's startup ack proves the direct zenoh route end-to-end. The
+//!   producer gives that proof a bounded startup window and pins the output to
+//!   the daemon path for the run if it does not arrive in time, so adding a
+//!   required acker that is slow to answer costs the fast path rather than
+//!   reordering a live topic (dora-rs/dora#2891).
+//! - a **remote static** consumer only qualifies when its producer has an
+//!   endpoint that consumer's machine can dial — `routable_producers`, decided
+//!   by `spawn::reserve_node_listeners`. Without one there is no route to
+//!   prove, so waiting for an ack that cannot come would spend a whole startup
+//!   window before falling back to where the output belonged all along:
+//!   `daemon_only`.
+//! - a consumer under another daemon that is **dynamic** pins the output to the
+//!   daemon path unconditionally: it joins at an arbitrary time, so no endpoint
+//!   can be planned for it and only forwarding can ever reach it.
 //! - **local dynamic** consumers are neither: they join at arbitrary times (or
 //!   never), so nothing may wait on them, and their pre-join messages are
 //!   inherently out of scope.
 //!
-//! When cross-machine node-to-node zenoh lands, only this policy changes:
-//! remote static consumers become required ackers instead of forcing
-//! `daemon_only`, and a fully-acked output goes pure-zenoh across machines.
+//! A remote static consumer that acks takes its edge off the daemon path
+//! entirely — producer node to consumer node, one zenoh hop, no daemon on
+//! either side of the wire. Note that `daemon_only` remains sticky per
+//! *output*, not per consumer: an output with a remote dynamic consumer stays
+//! pinned for all of them, because only daemon-path sends feed the inter-daemon
+//! forwarder (dora #2738).
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
@@ -45,11 +52,15 @@ use crate::{CoreNodeKindExt, OutputId, node_inputs};
 /// Every declared output of a local producer gets an entry (a zero-consumer
 /// output resolves to the default routing: no pin, no required ackers — the
 /// producer may use the direct zenoh path immediately). Consumers of remote
-/// producers are ignored here; the remote producer's own daemon sees those
-/// consumers as non-local and pins the output on its side.
+/// producers are ignored here; the remote producer's own daemon decides those.
+///
+/// `routable_producers` are the local nodes that were given an endpoint
+/// reachable from other machines, which is what makes a *remote* consumer's
+/// direct route possible at all.
 pub fn compute_output_routing(
     nodes: &BTreeMap<NodeId, ResolvedNode>,
     local_nodes: &BTreeSet<NodeId>,
+    routable_producers: &BTreeSet<NodeId>,
 ) -> BTreeMap<NodeId, BTreeMap<DataId, OutputRouting>> {
     let mut routing: BTreeMap<NodeId, BTreeMap<DataId, OutputRouting>> = local_nodes
         .iter()
@@ -82,13 +93,23 @@ pub fn compute_output_routing(
             let Some(entry) = outputs.get_mut(&mapping.output) else {
                 continue;
             };
-            if !consumer_local {
-                entry.daemon_only = true;
-            } else if !consumer_dynamic {
+            // A dynamic consumer is never an acker — nothing may wait on a node
+            // that may never join — and a *remote* one additionally pins the
+            // output, since forwarding is the only way to reach it.
+            if consumer_dynamic {
+                if !consumer_local {
+                    entry.daemon_only = true;
+                }
+            } else if consumer_local || routable_producers.contains(&mapping.source) {
                 entry.required_ackers.insert(RequiredAcker {
                     node_id: consumer.id.clone(),
                     input_id,
                 });
+            } else {
+                // Remote static consumer with no dialable producer endpoint:
+                // there is no direct route to prove, so pin rather than spend a
+                // startup window waiting for an ack that cannot arrive.
+                entry.daemon_only = true;
             }
         }
     }
@@ -149,9 +170,19 @@ mod tests {
     use super::*;
     use dora_core::descriptor::{Descriptor, DescriptorExt};
 
+    /// Routing where every local producer is dialable from other machines —
+    /// the state after a successful endpoint exchange.
     fn routing_for(
         yaml: &str,
         local: &[&str],
+    ) -> BTreeMap<NodeId, BTreeMap<DataId, OutputRouting>> {
+        routing_with_routable(yaml, local, local)
+    }
+
+    fn routing_with_routable(
+        yaml: &str,
+        local: &[&str],
+        routable: &[&str],
     ) -> BTreeMap<NodeId, BTreeMap<DataId, OutputRouting>> {
         let descriptor: Descriptor = serde_yaml::from_str(yaml).expect("parse descriptor");
         let nodes = descriptor
@@ -161,7 +192,11 @@ mod tests {
             .iter()
             .map(|id| NodeId::from(id.to_string()))
             .collect();
-        compute_output_routing(&nodes, &local_nodes)
+        let routable_producers: BTreeSet<NodeId> = routable
+            .iter()
+            .map(|id| NodeId::from(id.to_string()))
+            .collect();
+        compute_output_routing(&nodes, &local_nodes, &routable_producers)
     }
 
     fn acker(node: &str, input: &str) -> RequiredAcker {
@@ -244,20 +279,41 @@ nodes:
     }
 
     #[test]
-    fn remote_consumers_pin_daemon_only_static_or_dynamic() {
-        // Remote *static* consumer pins.
-        let routing = routing_for(CHAIN, &["source", "dynamic-sink"]);
-        assert!(output(&routing, "source", "image").daemon_only);
+    fn a_remote_static_consumer_acks_instead_of_pinning() {
+        // `static-sink` runs under another daemon and `source` is dialable from
+        // there, so the edge has a direct route to prove — the whole point of
+        // the cross-machine node mesh. Until it is proven the producer stays on
+        // the daemon path, so this is a fast path won, never a message lost.
+        let routing = routing_with_routable(CHAIN, &["source", "dynamic-sink"], &["source"]);
+        let image = output(&routing, "source", "image");
+        assert!(!image.daemon_only);
+        assert_eq!(
+            image.required_ackers,
+            BTreeSet::from([acker("static-sink", "camera")])
+        );
+    }
 
-        // Remote *dynamic* consumer pins too: a dynamic node on another daemon
-        // can only ever be reached through inter-daemon forwarding, which only
-        // daemon-path sends feed (#2738).
-        let routing = routing_for(CHAIN, &["source", "static-sink"]);
+    #[test]
+    fn a_remote_static_consumer_pins_when_its_producer_is_undialable() {
+        // No routable endpoint for `source` — a single-machine bind, or an
+        // endpoint exchange that timed out. There is no route to prove, and
+        // waiting for an ack that cannot arrive would burn a whole startup
+        // window before landing on the daemon path anyway.
+        let routing = routing_with_routable(CHAIN, &["source", "dynamic-sink"], &[]);
         let image = output(&routing, "source", "image");
         assert!(image.daemon_only);
-        // The local acker is still recorded accurately alongside the pin (the
-        // producer ignores ackers on pinned outputs today; the cross-machine
-        // follow-up flips this policy).
+        assert!(image.required_ackers.is_empty());
+    }
+
+    #[test]
+    fn a_remote_dynamic_consumer_still_pins() {
+        // A dynamic node on another daemon joins at an arbitrary time, so no
+        // endpoint can be planned for it and only inter-daemon forwarding can
+        // reach it — which only daemon-path sends feed (#2738).
+        let routing = routing_with_routable(CHAIN, &["source", "static-sink"], &["source"]);
+        let image = output(&routing, "source", "image");
+        assert!(image.daemon_only);
+        // The local acker is still recorded accurately alongside the pin.
         assert_eq!(
             image.required_ackers,
             BTreeSet::from([acker("static-sink", "camera")])

--- a/binaries/daemon/src/output_routing.rs
+++ b/binaries/daemon/src/output_routing.rs
@@ -81,6 +81,9 @@ pub fn compute_output_routing(
         let consumer_local = local_nodes.contains(&consumer.id);
         let consumer_dynamic = consumer.kind.dynamic();
         for (input_id, input) in node_inputs(consumer) {
+            // A liveness deadline on a *remote* input is only fed by the
+            // daemon path (see the `daemon_only` reasoning below).
+            let watches_liveness = input.input_timeout.is_some();
             let InputMapping::User(mapping) = input.mapping else {
                 continue;
             };
@@ -100,15 +103,31 @@ pub fn compute_output_routing(
                 if !consumer_local {
                     entry.daemon_only = true;
                 }
-            } else if consumer_local || routable_producers.contains(&mapping.source) {
+            } else if consumer_local
+                || (routable_producers.contains(&mapping.source) && !watches_liveness)
+            {
                 entry.required_ackers.insert(RequiredAcker {
                     node_id: consumer.id.clone(),
                     input_id,
                 });
             } else {
-                // Remote static consumer with no dialable producer endpoint:
-                // there is no direct route to prove, so pin rather than spend a
-                // startup window waiting for an ack that cannot arrive.
+                // Two reasons to pin a remote static consumer's output.
+                //
+                // No dialable producer endpoint: there is no direct route to
+                // prove, so pinning beats spending a startup window waiting for
+                // an ack that cannot arrive.
+                //
+                // Or the consumer declares an `input_timeout`: its deadline is
+                // armed unfired and refreshed only when its *own* daemon sees
+                // the message — either delivering it (`send_output_to_local_
+                // receivers`) or being told about it by a local producer
+                // (`note_output_sent_to_local_receivers`, which walks local
+                // mappings only). A direct cross-machine send reaches neither,
+                // so `last_received` would stay `None`, the deadline would
+                // never fire, and `input_timeout` — plus the circuit breaker
+                // built on it — would silently stop working on exactly the
+                // edges most likely to need it. The fast path is not worth a
+                // liveness guarantee the descriptor asked for.
                 entry.daemon_only = true;
             }
         }
@@ -303,6 +322,42 @@ nodes:
         let image = output(&routing, "source", "image");
         assert!(image.daemon_only);
         assert!(image.required_ackers.is_empty());
+    }
+
+    /// An `input_timeout` on a remote input is refreshed only when the
+    /// consumer's *own* daemon sees the message, and a direct cross-machine
+    /// send bypasses it. Taking the fast path would leave the deadline armed
+    /// but unfired forever — the descriptor asked for liveness detection, so
+    /// the daemon path wins.
+    #[test]
+    fn a_remote_consumer_watching_liveness_keeps_the_daemon_path() {
+        let yaml = r#"
+nodes:
+  - id: source
+    path: ./source
+    outputs:
+      - image
+  - id: watchful-sink
+    path: ./sink
+    inputs:
+      camera:
+        source: source/image
+        input_timeout: 5
+"#;
+        let routing = routing_with_routable(yaml, &["source"], &["source"]);
+        let image = output(&routing, "source", "image");
+        assert!(image.daemon_only);
+        assert!(image.required_ackers.is_empty());
+
+        // The same consumer on this machine is unaffected: its daemon is the
+        // one delivering (or being notified of) every message either way.
+        let routing = routing_with_routable(yaml, &["source", "watchful-sink"], &["source"]);
+        let image = output(&routing, "source", "image");
+        assert!(!image.daemon_only);
+        assert_eq!(
+            image.required_ackers,
+            BTreeSet::from([acker("watchful-sink", "camera")])
+        );
     }
 
     #[test]

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -297,8 +297,12 @@ pub struct RunningDataflow {
     pub(crate) descriptor: Descriptor,
     /// Per-node zenoh listener + dial-list, so the node↔node links this dataflow
     /// needs are established deterministically rather than left to gossip.
-    /// Populated when the dataflow is spawned; see `plan_zenoh_peering`.
+    /// Populated when the dataflow is spawned; see `spawn::build_peering_plan`.
     pub(crate) zenoh_peering: Arc<BTreeMap<NodeId, crate::spawn::NodeZenohPeering>>,
+    /// Keeps this daemon answering other daemons' node-endpoint queries for as
+    /// long as the dataflow runs. Dropped with the dataflow; see
+    /// `spawn::endpoint_exchange`.
+    pub(crate) endpoint_queryable: Option<crate::spawn::endpoint_exchange::EndpointQueryable>,
     pub(crate) pending_nodes: PendingNodes,
     pub(crate) dataflow_started: bool,
     pub(crate) subscribe_channels: HashMap<NodeId, Sender<Timestamped<NodeEvent>>>,
@@ -404,6 +408,7 @@ impl RunningDataflow {
         Self {
             id: dataflow_id,
             zenoh_peering: Arc::new(BTreeMap::new()),
+            endpoint_queryable: None,
             pending_nodes: PendingNodes::new(dataflow_id, daemon_id),
             dataflow_started: false,
             subscribe_channels: HashMap::new(),

--- a/binaries/daemon/src/spawn/endpoint_exchange.rs
+++ b/binaries/daemon/src/spawn/endpoint_exchange.rs
@@ -103,23 +103,56 @@ pub struct EndpointQueryable {
 /// deadline all resolve to "fewer endpoints than asked for", which leaves those
 /// edges on the daemon-forwarded path.
 pub async fn exchange(
-    session: &zenoh::Session,
+    session: zenoh::Session,
     dataflow_id: Uuid,
-    daemon_id: &DaemonId,
+    daemon_id: DaemonId,
     local: Endpoints,
     wanted: BTreeSet<NodeId>,
 ) -> (Endpoints, Option<EndpointQueryable>) {
-    let queryable = declare(session, dataflow_id, daemon_id, local).await;
-    if wanted.is_empty() {
+    let budget = timeout();
+    if budget.is_zero() {
+        // The documented off switch: every cross-machine edge keeps the daemon
+        // path, and nothing is declared or asked.
+        return (BTreeMap::new(), None);
+    }
+    let started = tokio::time::Instant::now();
+
+    // `declare_queryable` is itself a zenoh operation that can block on a
+    // degraded inter-daemon link, so it gets a deadline too — bounding only the
+    // query would leave the caller waiting with no limit at all, on the path
+    // that must finish before any node spawns.
+    let queryable =
+        match tokio::time::timeout(budget, declare(&session, dataflow_id, &daemon_id, local)).await
+        {
+            Ok(queryable) => queryable,
+            Err(_) => {
+                tracing::warn!(
+                    "declaring the zenoh node-endpoint queryable did not finish within \
+                 {budget:?}; consumers on other daemons will receive this daemon's \
+                 outputs over the daemon path"
+                );
+                None
+            }
+        };
+
+    let remaining = budget.saturating_sub(started.elapsed());
+    if wanted.is_empty() || remaining.is_zero() {
         // Nothing to collect — but stay answerable, since peers that consume
-        // from this daemon's nodes still need what we just declared.
+        // from this daemon's nodes still need what was just declared.
         return (BTreeMap::new(), queryable);
     }
-    let deadline = timeout();
-    if deadline.is_zero() {
-        return (BTreeMap::new(), queryable);
-    }
-    let found = collect(session, dataflow_id, &wanted, deadline).await;
+
+    // Collecting is bounded twice over: `collect` stops asking at its deadline,
+    // and the timeout covers a single `get` that never resolves. The queryable
+    // survives either way, so peers keep getting answers even when this daemon
+    // gave up asking.
+    let found = tokio::time::timeout(
+        remaining,
+        collect(&session, dataflow_id, &wanted, remaining),
+    )
+    .await
+    .unwrap_or_default();
+
     if !found.is_empty() {
         // The observable that says the mesh formed: every endpoint here is a
         // cross-machine edge that can now skip both daemons.
@@ -136,7 +169,7 @@ pub async fn exchange(
             .filter(|id| !found.contains_key(*id))
             .collect();
         tracing::warn!(
-            "no zenoh endpoint for remote node(s) {missing:?} after {deadline:?}; \
+            "no zenoh endpoint for remote node(s) {missing:?} after {budget:?}; \
              their outputs will reach this daemon's nodes over the daemon path \
              instead of directly (set {TIMEOUT_ENV} to allow longer)"
         );

--- a/binaries/daemon/src/spawn/endpoint_exchange.rs
+++ b/binaries/daemon/src/spawn/endpoint_exchange.rs
@@ -120,6 +120,16 @@ pub async fn exchange(
         return (BTreeMap::new(), queryable);
     }
     let found = collect(session, dataflow_id, &wanted, deadline).await;
+    if !found.is_empty() {
+        // The observable that says the mesh formed: every endpoint here is a
+        // cross-machine edge that can now skip both daemons.
+        tracing::debug!(
+            "resolved {}/{} remote node zenoh endpoints: {:?}",
+            found.len(),
+            wanted.len(),
+            found,
+        );
+    }
     if found.len() < wanted.len() {
         let missing: Vec<&NodeId> = wanted
             .iter()

--- a/binaries/daemon/src/spawn/endpoint_exchange.rs
+++ b/binaries/daemon/src/spawn/endpoint_exchange.rs
@@ -1,0 +1,284 @@
+//! Exchanging node zenoh endpoints between the daemons of one dataflow.
+//!
+//! A consumer can only dial a producer on another machine if it knows that
+//! producer's endpoint *before* it opens its zenoh session: zenoh reads
+//! `connect/endpoints` once at startup and never re-reads it, so an endpoint
+//! learned later cannot be used at all. The daemon that owns a node is also the
+//! only one that can reserve a port for it. So the endpoints have to travel
+//! daemon-to-daemon, before either side spawns anything.
+//!
+//! Each daemon declares a queryable carrying its own local nodes' routable
+//! endpoints, then queries for its peers'. A query rather than a publication on
+//! purpose: it is pull-based, so a daemon that starts late still gets a complete
+//! answer by asking again, where a publication that landed before the subscriber
+//! existed is simply gone (the memory-pool path documents exactly that race).
+//!
+//! Whatever is still missing when the deadline expires is not an error: those
+//! edges keep the daemon-forwarded path they use today, which is slower but
+//! lossless. That makes this an optimization that degrades, never a barrier that
+//! can fail a dataflow.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    time::Duration,
+};
+
+use dora_message::{common::DaemonId, id::NodeId};
+use uuid::Uuid;
+use zenoh::Wait;
+
+/// How long to keep asking peers for endpoints before spawning anyway.
+///
+/// Paid only by dataflows that actually span machines, and only once per spawn.
+/// Short on purpose: this runs on the daemon's event loop, and the fallback —
+/// the daemon-forwarded path — is correct, just slower.
+const DEFAULT_TIMEOUT: Duration = Duration::from_millis(1500);
+
+/// Env var overriding [`DEFAULT_TIMEOUT`], in milliseconds.
+///
+/// A slow or congested link may need longer; `0` skips the exchange entirely
+/// and keeps every cross-machine edge on the daemon path.
+const TIMEOUT_ENV: &str = "DORA_ZENOH_ENDPOINT_EXCHANGE_TIMEOUT_MS";
+
+/// How long to wait for replies to a single query before asking again.
+const QUERY_ROUND: Duration = Duration::from_millis(100);
+
+/// Zenoh key a daemon answers its local nodes' endpoints on.
+///
+/// The daemon id is sanitized into one key chunk: a machine id is operator
+/// input and may contain characters (`/`, `*`) that would silently reshape the
+/// key expression. The id's uuid suffix survives sanitization untouched, so
+/// distinct daemons keep distinct keys even if their machine ids collapse to
+/// the same sanitized form.
+fn endpoints_key(dataflow_id: Uuid, daemon_id: &DaemonId) -> String {
+    let daemon: String = daemon_id
+        .to_string()
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '.' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    format!("dora/default/{dataflow_id}/node-endpoints/{daemon}")
+}
+
+/// Selector matching every daemon's endpoints key for this dataflow.
+fn endpoints_selector(dataflow_id: Uuid) -> String {
+    format!("dora/default/{dataflow_id}/node-endpoints/*")
+}
+
+fn timeout() -> Duration {
+    match std::env::var(TIMEOUT_ENV).ok().and_then(|v| v.parse().ok()) {
+        Some(ms) => Duration::from_millis(ms),
+        None => DEFAULT_TIMEOUT,
+    }
+}
+
+/// A daemon's answer: the routable endpoint of each of its local nodes that a
+/// remote consumer may need to dial.
+type Endpoints = BTreeMap<NodeId, String>;
+
+/// Keeps this daemon answering endpoint queries for one dataflow.
+///
+/// Held for the dataflow's lifetime rather than just the exchange: a daemon
+/// that joins late (a restarted node, a second `dora start` against the same
+/// graph) asks the same question, and an undeclared queryable answers nothing.
+/// Dropped in `finish_dataflow`; an abandoned handle would keep the queryable,
+/// its session clone and its payload alive for the daemon's whole lifetime.
+pub struct EndpointQueryable {
+    _queryable: zenoh::query::Queryable<()>,
+}
+
+/// Publish this daemon's node endpoints and collect the peers' — see the module
+/// docs.
+///
+/// `local` maps each local node to the endpoint remote consumers should dial;
+/// `wanted` names the remote nodes this daemon's own consumers need. Returns
+/// the endpoints found (a subset of `wanted`) plus the queryable to keep alive.
+///
+/// Never fails the spawn: a zenoh error, an unanswered query or an expired
+/// deadline all resolve to "fewer endpoints than asked for", which leaves those
+/// edges on the daemon-forwarded path.
+pub async fn exchange(
+    session: &zenoh::Session,
+    dataflow_id: Uuid,
+    daemon_id: &DaemonId,
+    local: Endpoints,
+    wanted: BTreeSet<NodeId>,
+) -> (Endpoints, Option<EndpointQueryable>) {
+    let queryable = declare(session, dataflow_id, daemon_id, local).await;
+    if wanted.is_empty() {
+        // Nothing to collect — but stay answerable, since peers that consume
+        // from this daemon's nodes still need what we just declared.
+        return (BTreeMap::new(), queryable);
+    }
+    let deadline = timeout();
+    if deadline.is_zero() {
+        return (BTreeMap::new(), queryable);
+    }
+    let found = collect(session, dataflow_id, &wanted, deadline).await;
+    if found.len() < wanted.len() {
+        let missing: Vec<&NodeId> = wanted
+            .iter()
+            .filter(|id| !found.contains_key(*id))
+            .collect();
+        tracing::warn!(
+            "no zenoh endpoint for remote node(s) {missing:?} after {deadline:?}; \
+             their outputs will reach this daemon's nodes over the daemon path \
+             instead of directly (set {TIMEOUT_ENV} to allow longer)"
+        );
+    }
+    (found, queryable)
+}
+
+/// Declare the queryable that answers this daemon's endpoints.
+async fn declare(
+    session: &zenoh::Session,
+    dataflow_id: Uuid,
+    daemon_id: &DaemonId,
+    local: Endpoints,
+) -> Option<EndpointQueryable> {
+    if local.is_empty() {
+        // No node here is consumed from another machine, so there is nothing to
+        // answer. Peers still query, and get no reply from us — which is the
+        // same answer an empty map would give them.
+        return None;
+    }
+    let key = endpoints_key(dataflow_id, daemon_id);
+    let payload = match serde_json::to_vec(&local) {
+        Ok(payload) => payload,
+        Err(err) => {
+            tracing::warn!("failed to serialize local zenoh node endpoints: {err}");
+            return None;
+        }
+    };
+    let reply_key = key.clone();
+    let queryable = session
+        .declare_queryable(key.clone())
+        .complete(true)
+        .callback(move |query| {
+            if let Err(err) = query.reply(reply_key.clone(), payload.clone()).wait() {
+                tracing::warn!("failed to answer a zenoh node-endpoint query: {err}");
+            }
+        })
+        .await;
+    match queryable {
+        Ok(queryable) => Some(EndpointQueryable {
+            _queryable: queryable,
+        }),
+        Err(err) => {
+            // Peers keep their cross-machine edges on the daemon path, which is
+            // where they are today.
+            tracing::warn!("failed to declare the zenoh node-endpoint queryable on {key}: {err}");
+            None
+        }
+    }
+}
+
+/// Query peers until every wanted endpoint is known or the deadline expires.
+async fn collect(
+    session: &zenoh::Session,
+    dataflow_id: Uuid,
+    wanted: &BTreeSet<NodeId>,
+    deadline: Duration,
+) -> Endpoints {
+    let selector = endpoints_selector(dataflow_id);
+    let started = tokio::time::Instant::now();
+    let mut found: Endpoints = BTreeMap::new();
+    while started.elapsed() < deadline {
+        // A peer that has not processed its own spawn yet has no queryable to
+        // answer with, so an empty round means "ask again", not "there is
+        // nobody". `ConsolidationMode::None` because every daemon answers on
+        // its own key and consolidation would be free to keep just one reply
+        // per key — a silent way to lose a whole daemon's endpoints.
+        let replies = session
+            .get(&selector)
+            .consolidation(zenoh::query::ConsolidationMode::None)
+            .timeout(QUERY_ROUND)
+            .await;
+        match replies {
+            Ok(replies) => {
+                while let Ok(reply) = replies.recv_async().await {
+                    let Ok(sample) = reply.result() else { continue };
+                    let payload = sample.payload().to_bytes();
+                    match serde_json::from_slice::<Endpoints>(&payload) {
+                        Ok(endpoints) => found.extend(
+                            endpoints
+                                .into_iter()
+                                .filter(|(node_id, _)| wanted.contains(node_id)),
+                        ),
+                        Err(err) => {
+                            tracing::warn!("ignoring malformed zenoh node-endpoint reply: {err}")
+                        }
+                    }
+                }
+            }
+            Err(err) => {
+                tracing::warn!("zenoh node-endpoint query failed: {err}");
+                return found;
+            }
+        }
+        if wanted.iter().all(|id| found.contains_key(id)) {
+            break;
+        }
+    }
+    found
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn uuid() -> Uuid {
+        Uuid::from_u128(0x1234_5678_9abc_def0_1234_5678_9abc_def0)
+    }
+
+    /// The selector must match the keys daemons answer on — a mismatch would
+    /// look exactly like "no peer replied", i.e. a silent fallback to the
+    /// daemon path on every cross-machine edge.
+    #[test]
+    fn the_selector_matches_a_daemon_key() {
+        let key = endpoints_key(uuid(), &DaemonId::new(Some("edge-01".into())));
+        let selector = endpoints_selector(uuid());
+        let prefix = selector.strip_suffix('*').expect("selector ends in `*`");
+        assert!(key.starts_with(prefix), "{key} does not match {selector}");
+        // One chunk after the prefix: a `/` in the daemon id would push the key
+        // a level deeper, where a single-`*` selector no longer matches it.
+        assert!(
+            !key[prefix.len()..].contains('/'),
+            "key has extra chunks: {key}"
+        );
+    }
+
+    /// Distinct daemons need distinct keys, or their replies collide.
+    #[test]
+    fn sanitizing_a_machine_id_keeps_daemons_distinct() {
+        let hostile = DaemonId::new(Some("a/b*c".into()));
+        let plain = DaemonId::new(Some("a_b_c".into()));
+        let hostile_key = endpoints_key(uuid(), &hostile);
+        assert!(!hostile_key.contains('/') || hostile_key.matches('/').count() == 4);
+        assert!(!hostile_key.contains('*'));
+        assert_ne!(hostile_key, endpoints_key(uuid(), &plain));
+        // Same daemon, same key, every time it is asked.
+        assert_eq!(hostile_key, endpoints_key(uuid(), &hostile));
+    }
+
+    /// `0` is the documented way to switch the exchange off; anything
+    /// unparseable falls back to the default rather than to no waiting at all.
+    #[test]
+    fn timeout_falls_back_to_the_default() {
+        // Reading the real env var here would race other tests in this binary,
+        // so exercise the same parse the getter uses.
+        let parse = |v: Option<&str>| match v.and_then(|v| v.parse().ok()) {
+            Some(ms) => Duration::from_millis(ms),
+            None => DEFAULT_TIMEOUT,
+        };
+        assert_eq!(parse(None), DEFAULT_TIMEOUT);
+        assert_eq!(parse(Some("nonsense")), DEFAULT_TIMEOUT);
+        assert_eq!(parse(Some("0")), Duration::ZERO);
+        assert_eq!(parse(Some("5000")), Duration::from_secs(5));
+    }
+}

--- a/binaries/daemon/src/spawn/endpoint_exchange.rs
+++ b/binaries/daemon/src/spawn/endpoint_exchange.rs
@@ -232,6 +232,13 @@ async fn collect(
     let started = tokio::time::Instant::now();
     let mut found: Endpoints = BTreeMap::new();
     while started.elapsed() < deadline {
+        // `timeout(QUERY_ROUND)` bounds how long a round *may* take, not how
+        // long it does: a peer whose queryable is already declared answers at
+        // once, so without pacing the loop would re-issue the query as fast as
+        // replies arrive and turn the retry into a query storm on the
+        // inter-daemon session. Round start is captured here and slept out at
+        // the bottom, so each round costs one `QUERY_ROUND` regardless.
+        let round_started = tokio::time::Instant::now();
         // A peer that has not processed its own spawn yet has no queryable to
         // answer with, so an empty round means "ask again", not "there is
         // nobody". `ConsolidationMode::None` because every daemon answers on
@@ -267,6 +274,15 @@ async fn collect(
         if wanted.iter().all(|id| found.contains_key(id)) {
             break;
         }
+        // Pace the next round. Capped at the remaining budget so pacing can
+        // never push the exchange past `deadline` — the caller awaits this on
+        // the daemon event loop, so overrunning would stall it further.
+        let elapsed = started.elapsed();
+        let Some(remaining) = deadline.checked_sub(elapsed) else {
+            break;
+        };
+        let till_next_round = QUERY_ROUND.saturating_sub(round_started.elapsed());
+        tokio::time::sleep(till_next_round.min(remaining)).await;
     }
     found
 }

--- a/binaries/daemon/src/spawn/mod.rs
+++ b/binaries/daemon/src/spawn/mod.rs
@@ -1,7 +1,11 @@
 pub use prepared::PreparedNode;
-pub use spawner::{NodeZenohPeering, Spawner, plan_zenoh_peering};
+pub use spawner::{
+    NodeZenohPeering, Spawner, build_peering_plan, remote_sources_of_local_nodes,
+    reserve_node_listeners,
+};
 
 mod command;
+pub mod endpoint_exchange;
 mod prepared;
 mod runtime_registry;
 mod spawner;

--- a/binaries/daemon/src/spawn/spawner.rs
+++ b/binaries/daemon/src/spawn/spawner.rs
@@ -11,8 +11,8 @@ use dora_core::{
     config::{Input, InputMapping, NodeId},
     descriptor::{CoreNodeKind, Descriptor, ResolvedNode},
     topics::{
-        DORA_RUN_PARENT_PID_ENV, DORA_ZENOH_CONNECT_ENV, DORA_ZENOH_LISTEN_ENV,
-        DORA_ZENOH_MULTICAST_ENV, ZENOH_CONFIG_PATH_ENV,
+        DORA_RUN_PARENT_PID_ENV, DORA_ZENOH_CONFIG_OVERLAY_ENV, DORA_ZENOH_CONNECT_ENV,
+        DORA_ZENOH_LISTEN_ENV, DORA_ZENOH_MULTICAST_ENV, ZENOH_CONFIG_PATH_ENV,
     },
     uhlc::HLC,
 };
@@ -53,6 +53,12 @@ const ENV_DENYLIST: &[&str] = &[
 /// custom search path gets it from the environment the daemon runs in
 /// (#2991 review).
 const SEARCH_PATH_ENV: &[&str] = &["LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH"];
+
+/// Zenoh configuration a *deployment* sets, not a dataflow: refused from a
+/// descriptor's `env:` like the control-plane wiring below, but deliberately
+/// still inherited (see [`deny_inherited_env`]), so one variable on the daemon
+/// covers every node it spawns.
+const DEPLOYMENT_ZENOH_ENV: &[&str] = &[ZENOH_CONFIG_PATH_ENV, DORA_ZENOH_CONFIG_OVERLAY_ENV];
 
 /// Control-plane variables the daemon injects into every node it spawns.
 /// Descriptor `env:` / `envs:` entries must not override them: they configure
@@ -106,7 +112,7 @@ fn is_denied_env(key: &str) -> bool {
         true
     } else if CONTROL_PLANE_ENV
         .iter()
-        .chain(std::iter::once(&ZENOH_CONFIG_PATH_ENV))
+        .chain(DEPLOYMENT_ZENOH_ENV)
         .any(|d| env_key_matches(key, d))
     {
         tracing::warn!(
@@ -161,7 +167,7 @@ fn apply_descriptor_env(
 /// that started the daemon cannot wrongly wire nodes the daemon deliberately
 /// left unwired.
 ///
-/// [`ZENOH_CONFIG_PATH_ENV`] and [`SEARCH_PATH_ENV`] are deliberately absent:
+/// [`DEPLOYMENT_ZENOH_ENV`] and [`SEARCH_PATH_ENV`] are deliberately absent:
 /// refused from a descriptor, but inheriting them is how a deployment points
 /// every process at a custom zenoh config, and how a node linked against a
 /// sourced ROS or CUDA install finds its libraries.
@@ -950,12 +956,14 @@ mod tests {
                 "`{key}` is daemon-managed control-plane wiring and must be denied"
             );
         }
-        assert!(
-            is_denied_env(ZENOH_CONFIG_PATH_ENV),
-            "`{ZENOH_CONFIG_PATH_ENV}` builds the whole zenoh session from a file, \
-             skipping every DORA_ZENOH_* variable — denying those and not this one \
-             leaves the bypass open"
-        );
+        for key in DEPLOYMENT_ZENOH_ENV {
+            assert!(
+                is_denied_env(key),
+                "`{key}` reconfigures the node's zenoh session wholesale, skipping \
+                 or overriding the DORA_ZENOH_* wiring — denying those and not this \
+                 one leaves the bypass open"
+            );
+        }
         assert!(
             !is_denied_env("MY_APP_SETTING"),
             "ordinary variables must still pass through"
@@ -999,7 +1007,7 @@ mod tests {
         let spawner = spawner_for(Some("tcp/127.0.0.1:7447"), true);
         let forged: BTreeMap<String, EnvValue> = CONTROL_PLANE_ENV
             .iter()
-            .chain(std::iter::once(&ZENOH_CONFIG_PATH_ENV))
+            .chain(DEPLOYMENT_ZENOH_ENV)
             .map(|key| (key.to_string(), EnvValue::String("FORGED".into())))
             .collect();
         let ordinary: BTreeMap<String, EnvValue> = [(
@@ -1033,11 +1041,13 @@ mod tests {
             Some(OsStr::new("off")),
             "the daemon's multicast decision must win"
         );
-        assert_eq!(
-            env(ZENOH_CONFIG_PATH_ENV),
-            None,
-            "a descriptor must not hand the node its own zenoh config file"
-        );
+        for key in DEPLOYMENT_ZENOH_ENV {
+            assert_eq!(
+                env(key),
+                None,
+                "a descriptor must not hand the node its own zenoh config via `{key}`"
+            );
+        }
         assert_eq!(
             env("MY_APP_SETTING").as_deref(),
             Some(OsStr::new("kept")),
@@ -1096,11 +1106,14 @@ mod tests {
                 "`{key}` must be removed from the inherited environment, not merely unset"
             );
         }
-        assert_eq!(
-            env_of(&command, ZENOH_CONFIG_PATH_ENV),
-            None,
-            "a daemon-level zenoh config must still reach its nodes by inheritance"
-        );
+        for key in DEPLOYMENT_ZENOH_ENV {
+            assert_eq!(
+                env_of(&command, key),
+                None,
+                "a daemon-level zenoh config (`{key}`) must still reach its nodes \
+                 by inheritance"
+            );
+        }
     }
 
     /// dora-rs/dora#2856: under `dora run` the daemon *is* the CLI process, so

--- a/binaries/daemon/src/spawn/spawner.rs
+++ b/binaries/daemon/src/spawn/spawner.rs
@@ -29,6 +29,7 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     ffi::OsString,
     future::Future,
+    net::IpAddr,
     path::{Path, PathBuf},
     sync::{Arc, atomic::AtomicU64},
 };
@@ -218,8 +219,14 @@ fn apply_managed_python_runtime_env(
 /// dial. See [`plan_zenoh_peering`].
 #[derive(Clone, Debug)]
 pub struct NodeZenohPeering {
-    /// Loopback endpoint this node listens on, so its consumers can dial it.
-    pub listen: String,
+    /// Endpoints this node listens on, so its consumers can dial it.
+    ///
+    /// Always a loopback endpoint for its same-machine consumers, plus — when
+    /// the node has a consumer on another daemon — one on the address this
+    /// host is reachable at. Listening on both keeps same-machine consumers on
+    /// loopback, where the transport can carry shared memory, while remote ones
+    /// get an endpoint they can actually dial.
+    pub listen: Vec<String>,
     /// Endpoints this node dials: the daemon, plus each node it consumes from.
     pub connect: Vec<String>,
 }
@@ -264,35 +271,45 @@ pub struct NodeZenohPeering {
 /// is silent data loss; closing the window fully requires holding each reservation
 /// until the child binds, or verifying the per-node bind and re-planning on failure.
 ///
-/// Only *local* nodes are planned. `nodes` spans the whole dataflow including
-/// nodes on other daemons, whose endpoints are not on this host's loopback, so a
-/// local consumer of a remote producer gets no dial for it and keeps the existing
-/// cross-machine behavior. Multi-machine/NAT deployments supply their own zenoh
-/// config via `ZENOH_CONFIG_PATH`, which bypasses this path entirely and can put
-/// a real router (which *does* still relay) in between.
+/// Only *local* nodes are planned: `nodes` spans the whole dataflow, and this
+/// daemon can only reserve ports on its own host. A local consumer of a remote
+/// producer therefore gets no dial for it here — the remote producer's endpoint
+/// arrives separately, from the daemon that owns it.
+///
+/// # Cross-machine consumers
+///
+/// A node whose consumers are all on this machine listens on loopback only,
+/// which is both sufficient and the least exposed choice. A node with a
+/// consumer on *another* daemon also listens on `routable_addr`, the address
+/// this host is reachable at, so that consumer has something to dial. That
+/// second listener is what lets cross-machine edges skip the daemon relay
+/// entirely.
+///
+/// `routable_addr` is `None` for a single-machine daemon, and a loopback
+/// address is refused for this purpose: advertising `127.0.0.1` to a remote
+/// consumer points it at its *own* loopback, which is the silent-partition
+/// failure this planning exists to prevent. Either way the edge falls back to
+/// the daemon path, which is where it lives today.
 pub fn plan_zenoh_peering(
     nodes: &BTreeMap<NodeId, ResolvedNode>,
     local_nodes: &BTreeSet<NodeId>,
     daemon_endpoint: Option<&str>,
+    routable_addr: Option<IpAddr>,
 ) -> BTreeMap<NodeId, NodeZenohPeering> {
-    // Reserve a listener per node first, so the dial-lists below can reference
+    let remotely_consumed = remotely_consumed_nodes(nodes, local_nodes);
+    // Reserve listeners per node first, so the dial-lists below can reference
     // every node regardless of spawn order.
     //
-    // Only nodes this daemon spawns get one: the endpoints are *loopback*, so
-    // handing a local consumer the "endpoint" of a node running on another
-    // machine would point it at this host's 127.0.0.1 — either a failed dial or,
-    // worse, an unrelated local process. A local consumer of a remote producer
-    // therefore gets no dial for it and keeps the existing cross-machine
-    // behavior (see the `ZENOH_CONFIG_PATH` note above).
-    let mut listeners: BTreeMap<NodeId, String> = BTreeMap::new();
+    // Only nodes this daemon spawns get one: the loopback endpoint of a node
+    // running on another machine would point a local consumer at this host's
+    // 127.0.0.1 — either a failed dial or, worse, an unrelated local process.
+    let mut listeners: BTreeMap<NodeId, NodeListeners> = BTreeMap::new();
     for (node_id, node) in nodes {
         if node.kind.dynamic() || !local_nodes.contains(node_id) {
             continue;
         }
-        match dora_core::topics::reserve_loopback_zenoh_endpoint() {
-            Ok(ep) => {
-                listeners.insert(node_id.clone(), ep);
-            }
+        let loopback = match dora_core::topics::reserve_loopback_zenoh_endpoint() {
+            Ok(ep) => ep,
             Err(err) => {
                 // Fall back to gossip for this node rather than failing the
                 // dataflow; it just loses the determinism guarantee.
@@ -301,8 +318,27 @@ pub fn plan_zenoh_peering(
                     "failed to reserve a zenoh listen endpoint ({err}); \
                      falling back to gossip discovery for this node"
                 );
+                continue;
             }
-        }
+        };
+        // Only pay for a network-reachable listener where a remote consumer
+        // actually needs one.
+        let routable = match routable_addr.filter(|_| remotely_consumed.contains(node_id)) {
+            Some(addr) => match dora_core::topics::reserve_zenoh_endpoint(addr) {
+                Ok(ep) => Some(ep),
+                Err(err) => {
+                    tracing::warn!(
+                        node = %node_id,
+                        "failed to reserve a routable zenoh listen endpoint on {addr} \
+                         ({err}); consumers on other daemons will keep receiving this \
+                         node's outputs over the daemon path"
+                    );
+                    None
+                }
+            },
+            None => None,
+        };
+        listeners.insert(node_id.clone(), NodeListeners { loopback, routable });
     }
 
     let mut plan = BTreeMap::new();
@@ -321,19 +357,52 @@ pub fn plan_zenoh_peering(
                 continue;
             }
             if let Some(ep) = listeners.get(&source) {
-                connect.push(ep.clone());
+                connect.push(ep.loopback.clone());
             }
         }
         connect.dedup();
         plan.insert(
             node_id.clone(),
             NodeZenohPeering {
-                listen: listen.clone(),
+                listen: listen.endpoints(),
                 connect,
             },
         );
     }
     plan
+}
+
+/// The endpoints reserved for one local node.
+struct NodeListeners {
+    /// Always present: this is how same-machine consumers reach the node, and
+    /// a loopback transport is the one that can carry shared memory.
+    loopback: String,
+    /// Present only when a consumer on another daemon needs to dial in.
+    routable: Option<String>,
+}
+
+impl NodeListeners {
+    fn endpoints(&self) -> Vec<String> {
+        let mut endpoints = vec![self.loopback.clone()];
+        endpoints.extend(self.routable.clone());
+        endpoints
+    }
+}
+
+/// Local nodes that at least one *other daemon's* static node consumes from.
+///
+/// Dynamic consumers are excluded: they are not in any spawn set, so nothing
+/// can plan a dial for them, and their edges stay on the daemon path.
+fn remotely_consumed_nodes(
+    nodes: &BTreeMap<NodeId, ResolvedNode>,
+    local_nodes: &BTreeSet<NodeId>,
+) -> BTreeSet<NodeId> {
+    nodes
+        .iter()
+        .filter(|(id, node)| !local_nodes.contains(*id) && !node.kind.dynamic())
+        .flat_map(|(_, consumer)| input_sources(consumer))
+        .filter(|source| local_nodes.contains(source))
+        .collect()
 }
 
 /// The nodes whose outputs `node` subscribes to (deduplicated).
@@ -415,7 +484,7 @@ impl Spawner {
     fn maybe_inject_zenoh_connect(&self, command: Command, node_id: &NodeId) -> Command {
         let command = match self.zenoh_peering.get(node_id) {
             Some(peering) => {
-                let command = command.env(DORA_ZENOH_LISTEN_ENV, &peering.listen);
+                let command = command.env(DORA_ZENOH_LISTEN_ENV, peering.listen.join(","));
                 if peering.connect.is_empty() {
                     command
                 } else {
@@ -752,9 +821,10 @@ mod tests {
         let nodes = descriptor
             .resolve_aliases_and_set_defaults()
             .expect("resolve nodes");
-        // Default: every node is local to this daemon.
+        // Default: every node is local to this daemon, so nothing needs a
+        // routable listener.
         let local: BTreeSet<NodeId> = nodes.keys().cloned().collect();
-        plan_zenoh_peering(&nodes, &local, daemon)
+        plan_zenoh_peering(&nodes, &local, daemon, None)
     }
 
     fn plan_for_local(
@@ -762,12 +832,26 @@ mod tests {
         local: &[&str],
         daemon: Option<&str>,
     ) -> BTreeMap<NodeId, NodeZenohPeering> {
+        plan_for_local_with_routable(yaml, local, daemon, None)
+    }
+
+    fn plan_for_local_with_routable(
+        yaml: &str,
+        local: &[&str],
+        daemon: Option<&str>,
+        routable: Option<IpAddr>,
+    ) -> BTreeMap<NodeId, NodeZenohPeering> {
         let descriptor: Descriptor = serde_yaml::from_str(yaml).expect("parse descriptor");
         let nodes = descriptor
             .resolve_aliases_and_set_defaults()
             .expect("resolve nodes");
         let local: BTreeSet<NodeId> = local.iter().map(|id| node(id)).collect();
-        plan_zenoh_peering(&nodes, &local, daemon)
+        plan_zenoh_peering(&nodes, &local, daemon, routable)
+    }
+
+    /// The loopback listener, which every planned node has.
+    fn loopback_of(plan: &BTreeMap<NodeId, NodeZenohPeering>, id: &str) -> String {
+        plan[&node(id)].listen[0].clone()
     }
 
     fn node(id: &str) -> NodeId {
@@ -1042,7 +1126,7 @@ nodes:
             Some("tcp/127.0.0.1:1"),
         );
 
-        let listen_of = |id: &str| plan[&node(id)].listen.clone();
+        let listen_of = |id: &str| loopback_of(&plan, id);
 
         // A pure source has no `User` inputs, so it dials only the daemon: a
         // timer mapping is not a peer.
@@ -1063,7 +1147,7 @@ nodes:
         assert!(!plan[&node("sink")].connect.contains(&listen_of("source")));
 
         // Listeners must be distinct, or two nodes would fight for a port.
-        let listeners: BTreeSet<_> = plan.values().map(|p| p.listen.clone()).collect();
+        let listeners: BTreeSet<_> = plan.values().flat_map(|p| p.listen.clone()).collect();
         assert_eq!(listeners.len(), 3, "each node needs its own listener");
     }
 
@@ -1090,20 +1174,15 @@ nodes:
 "#,
             None,
         );
-        assert_eq!(
-            plan[&node("a")].connect,
-            vec![plan[&node("b")].listen.clone()]
-        );
-        assert_eq!(
-            plan[&node("b")].connect,
-            vec![plan[&node("a")].listen.clone()]
-        );
+        assert_eq!(plan[&node("a")].connect, vec![loopback_of(&plan, "b")]);
+        assert_eq!(plan[&node("b")].connect, vec![loopback_of(&plan, "a")]);
     }
 
     /// `nodes` spans the whole dataflow, including nodes owned by other daemons.
     /// Their listeners would be on *this* host's loopback, so dialing one would hit
     /// nothing (or an unrelated local process). A local consumer of a remote
-    /// producer must therefore get no dial for it.
+    /// producer must therefore get no dial for it here — the remote producer's
+    /// real endpoint arrives from the daemon that owns it.
     #[test]
     fn remote_nodes_are_never_dialled_on_local_loopback() {
         let yaml = r#"
@@ -1124,9 +1203,75 @@ nodes:
             !plan.contains_key(&node("remote_source")),
             "a node on another daemon must not be assigned a local loopback listener"
         );
-        // The local consumer dials only the daemon: there is no local endpoint
-        // for its remote producer, and inventing one would be worse than none.
         assert_eq!(plan[&node("local_sink")].connect, vec!["tcp/127.0.0.1:1"]);
+    }
+
+    const CROSS_MACHINE_YAML: &str = r#"
+nodes:
+  - id: local_source
+    path: local_source
+    outputs:
+      - value
+  - id: local_sink
+    path: local_sink
+    inputs:
+      v: local_source/value
+  - id: remote_sink
+    path: remote_sink
+    inputs:
+      v: local_source/value
+"#;
+
+    /// A node consumed from another machine needs an endpoint that machine can
+    /// dial, or the edge can only ever be relayed by the two daemons. It keeps
+    /// its loopback listener too: that is the one its same-machine consumers
+    /// use, and the only one whose transport can carry shared memory.
+    #[test]
+    fn a_node_with_a_remote_consumer_also_listens_routably() {
+        let routable: IpAddr = "127.0.0.2".parse().unwrap();
+        let plan = plan_for_local_with_routable(
+            CROSS_MACHINE_YAML,
+            &["local_source", "local_sink"],
+            Some("tcp/127.0.0.1:1"),
+            Some(routable),
+        );
+
+        let source = &plan[&node("local_source")];
+        assert_eq!(source.listen.len(), 2, "loopback plus routable: {source:?}");
+        assert!(source.listen[0].starts_with("tcp/127.0.0.1:"));
+        assert!(
+            source.listen[1].starts_with("tcp/127.0.0.2:"),
+            "the remote consumer needs a dialable endpoint, got {:?}",
+            source.listen
+        );
+
+        // `local_sink` is consumed by nobody off-machine, so it stays loopback
+        // only — exposure follows the dataflow, not the deployment.
+        assert_eq!(plan[&node("local_sink")].listen.len(), 1);
+    }
+
+    /// A loopback "routable" address is worse than none: advertised to a remote
+    /// consumer it points at *that* machine's loopback, which is the silent
+    /// partition this planning exists to prevent. Same for a single-machine
+    /// daemon, which has no routable address at all.
+    #[test]
+    fn a_loopback_or_absent_routable_address_yields_no_second_listener() {
+        for routable in [None, Some("127.0.0.1".parse().unwrap())] {
+            let plan = plan_for_local_with_routable(
+                CROSS_MACHINE_YAML,
+                &["local_source", "local_sink"],
+                Some("tcp/127.0.0.1:1"),
+                // A loopback address never reaches here in production —
+                // `zenoh_routable_addr` filters it out — so passing `None` for
+                // it is the honest simulation of that filter.
+                routable.filter(|addr: &IpAddr| !addr.is_loopback()),
+            );
+            assert_eq!(
+                plan[&node("local_source")].listen.len(),
+                1,
+                "no dialable address means the edge stays on the daemon path"
+            );
+        }
     }
 
     /// Dynamic nodes join at arbitrary times and aren't part of the spawn set,

--- a/binaries/daemon/src/spawn/spawner.rs
+++ b/binaries/daemon/src/spawn/spawner.rs
@@ -260,21 +260,32 @@ pub struct NodeZenohPeering {
 ///
 /// # Caveat: per-node endpoints are advertised before they bind (#2762)
 ///
-/// This reserves each local node's loopback port with
-/// `dora_core::topics::reserve_loopback_zenoh_endpoint`
-/// — which binds `127.0.0.1:0`, reads the port, and drops the socket — and commits
-/// that port into every *consumer's* dial list here at plan time, i.e. **before the
-/// producing node process has bound it**. Unlike the daemon's own listener, these
-/// per-node endpoints are therefore *not* covered by the bind-verification in
-/// `open_zenoh_session_with_listen` (#1858): the node opens with
-/// `listen/exit_on_failure: false` and discards its own `effective_listen_endpoint`,
-/// so a lost reserve→bind race (another process grabs the port in the window) leaves
-/// the producer listener-less while its consumers hold a dead endpoint. Because those
-/// consumers also have explicit `connect/endpoints`, multicast scouting is disabled
-/// for them, so there is no fallback and that edge is silently partitioned. The
-/// probability is low (the OS keeps handing out fresh ephemeral ports) but the impact
-/// is silent data loss; closing the window fully requires holding each reservation
-/// until the child binds, or verifying the per-node bind and re-planning on failure.
+/// Each local node's port is reserved here — `reserve_zenoh_endpoint` binds it,
+/// reads the port, and drops the socket — and committed into every *consumer's*
+/// dial list at plan time, i.e. **before the producing node process has bound
+/// it**. Unlike the daemon's own listener, these per-node endpoints are not
+/// covered by the bind-verification in `open_zenoh_session_with_listen`
+/// (#1858): the node opens with `listen/exit_on_failure: false` and discards
+/// its own `effective_listen_endpoint`, so if another process grabs the port
+/// inside the reserve→bind window, the producer runs listener-less while its
+/// consumers hold a dead endpoint — and since those consumers have explicit
+/// `connect/endpoints`, multicast scouting is off for them, so nothing
+/// rediscovers it.
+///
+/// Two things bound the damage, and neither is the fix #2762 proposes:
+///
+/// * **Holding the reservation until the child binds cannot work.** The daemon
+///   and the node are separate processes, so a held `TcpListener` is exactly
+///   what makes the node's own bind fail with `EADDRINUSE` — the port can be
+///   claimed by one of them, not handed over. Passing the bound socket to the
+///   child instead would need zenoh to accept a pre-bound listener, which it
+///   has no API for.
+/// * **The route is proven before it is used.** A consumer that cannot dial its
+///   producer never acks the producer's startup marker, so that output freezes
+///   on the daemon path for the run (#2891, `wait_for_grace`). The outcome of a
+///   lost race is therefore the slower path, not lost data — the cost is one
+///   startup grace window, and the warning naming the unbound endpoint comes
+///   from the node's own session (#2762's diagnostic half).
 ///
 /// Only *local* nodes are planned: `nodes` spans the whole dataflow, and this
 /// daemon can only reserve ports on its own host. A local consumer of a remote

--- a/binaries/daemon/src/spawn/spawner.rs
+++ b/binaries/daemon/src/spawn/spawner.rs
@@ -229,6 +229,12 @@ pub struct NodeZenohPeering {
     pub listen: Vec<String>,
     /// Endpoints this node dials: the daemon, plus each node it consumes from.
     pub connect: Vec<String>,
+    /// Whether one of `listen` is an address other machines can dial.
+    ///
+    /// Decides whether a consumer under another daemon has a direct route to
+    /// prove at all, and so whether it can be a required acker rather than a
+    /// reason to pin the output (see `crate::output_routing`).
+    pub routable: bool,
 }
 
 /// Reserve the listen endpoints for this daemon's local nodes, so the links the
@@ -402,6 +408,7 @@ pub fn build_peering_plan(
             NodeZenohPeering {
                 listen: listen.endpoints(),
                 connect,
+                routable: listen.routable.is_some(),
             },
         );
     }

--- a/binaries/daemon/src/spawn/spawner.rs
+++ b/binaries/daemon/src/spawn/spawner.rs
@@ -216,7 +216,7 @@ fn apply_managed_python_runtime_env(
 }
 
 /// Where a single node's zenoh session should listen, and which peers it must
-/// dial. See [`plan_zenoh_peering`].
+/// dial. See [`reserve_node_listeners`] and [`build_peering_plan`].
 #[derive(Clone, Debug)]
 pub struct NodeZenohPeering {
     /// Endpoints this node listens on, so its consumers can dial it.
@@ -231,8 +231,13 @@ pub struct NodeZenohPeering {
     pub connect: Vec<String>,
 }
 
-/// Assign every node a loopback listener and dial-list so the links the dataflow
-/// needs are established *by construction*.
+/// Reserve the listen endpoints for this daemon's local nodes, so the links the
+/// dataflow needs can be established *by construction*.
+///
+/// One half of the peering plan; [`build_peering_plan`] is the other. They are
+/// split because the daemon-to-daemon endpoint exchange runs between them: a
+/// daemon must know its own nodes' endpoints before it can publish them, and
+/// its peers' before it can build dial lists that include them.
 ///
 /// Zenoh 1.9's `peer` hat hardcodes `full_linkstate: false` (its release notes
 /// list "Disable `full_linkstate` in `peer::Hat::Network`" under Bug fixes),
@@ -290,12 +295,11 @@ pub struct NodeZenohPeering {
 /// consumer points it at its *own* loopback, which is the silent-partition
 /// failure this planning exists to prevent. Either way the edge falls back to
 /// the daemon path, which is where it lives today.
-pub fn plan_zenoh_peering(
+pub fn reserve_node_listeners(
     nodes: &BTreeMap<NodeId, ResolvedNode>,
     local_nodes: &BTreeSet<NodeId>,
-    daemon_endpoint: Option<&str>,
     routable_addr: Option<IpAddr>,
-) -> BTreeMap<NodeId, NodeZenohPeering> {
+) -> BTreeMap<NodeId, NodeListeners> {
     let remotely_consumed = remotely_consumed_nodes(nodes, local_nodes);
     // Reserve listeners per node first, so the dial-lists below can reference
     // every node regardless of spawn order.
@@ -340,7 +344,23 @@ pub fn plan_zenoh_peering(
         };
         listeners.insert(node_id.clone(), NodeListeners { loopback, routable });
     }
+    listeners
+}
 
+/// Build each local node's dial list from the reserved local listeners plus
+/// `remote_endpoints`, the endpoints other daemons reported for *their* nodes
+/// (see `endpoint_exchange`).
+///
+/// A local consumer dials its local producers on loopback and its remote ones
+/// on the endpoint their own daemon reserved. A remote producer that is absent
+/// from `remote_endpoints` simply gets no dial, and that edge keeps the
+/// daemon-forwarded path.
+pub fn build_peering_plan(
+    nodes: &BTreeMap<NodeId, ResolvedNode>,
+    listeners: &BTreeMap<NodeId, NodeListeners>,
+    daemon_endpoint: Option<&str>,
+    remote_endpoints: &BTreeMap<NodeId, String>,
+) -> BTreeMap<NodeId, NodeZenohPeering> {
     let mut plan = BTreeMap::new();
     for (node_id, node) in nodes {
         let Some(listen) = listeners.get(node_id) else {
@@ -356,8 +376,13 @@ pub fn plan_zenoh_peering(
             if &source == node_id {
                 continue;
             }
+            // A local producer is reachable on loopback, which is also the
+            // transport that can carry shared memory; a remote one only at the
+            // address its own daemon reserved.
             if let Some(ep) = listeners.get(&source) {
                 connect.push(ep.loopback.clone());
+            } else if let Some(ep) = remote_endpoints.get(&source) {
+                connect.push(ep.clone());
             }
         }
         connect.dedup();
@@ -373,7 +398,7 @@ pub fn plan_zenoh_peering(
 }
 
 /// The endpoints reserved for one local node.
-struct NodeListeners {
+pub struct NodeListeners {
     /// Always present: this is how same-machine consumers reach the node, and
     /// a loopback transport is the one that can carry shared memory.
     loopback: String,
@@ -382,6 +407,11 @@ struct NodeListeners {
 }
 
 impl NodeListeners {
+    /// The endpoint a consumer on another machine dials, when there is one.
+    pub fn routable(&self) -> Option<&str> {
+        self.routable.as_deref()
+    }
+
     fn endpoints(&self) -> Vec<String> {
         let mut endpoints = vec![self.loopback.clone()];
         endpoints.extend(self.routable.clone());
@@ -393,7 +423,7 @@ impl NodeListeners {
 ///
 /// Dynamic consumers are excluded: they are not in any spawn set, so nothing
 /// can plan a dial for them, and their edges stay on the daemon path.
-fn remotely_consumed_nodes(
+pub fn remotely_consumed_nodes(
     nodes: &BTreeMap<NodeId, ResolvedNode>,
     local_nodes: &BTreeSet<NodeId>,
 ) -> BTreeSet<NodeId> {
@@ -402,6 +432,24 @@ fn remotely_consumed_nodes(
         .filter(|(id, node)| !local_nodes.contains(*id) && !node.kind.dynamic())
         .flat_map(|(_, consumer)| input_sources(consumer))
         .filter(|source| local_nodes.contains(source))
+        .collect()
+}
+
+/// Remote static nodes that this daemon's local nodes consume from.
+///
+/// The exact set of endpoints worth asking peers for: a remote node nobody here
+/// subscribes to is never dialled, and a dynamic one cannot be planned.
+pub fn remote_sources_of_local_nodes(
+    nodes: &BTreeMap<NodeId, ResolvedNode>,
+    local_nodes: &BTreeSet<NodeId>,
+) -> BTreeSet<NodeId> {
+    nodes
+        .iter()
+        .filter(|(id, node)| local_nodes.contains(*id) && !node.kind.dynamic())
+        .flat_map(|(_, consumer)| input_sources(consumer))
+        .filter(|source| {
+            !local_nodes.contains(source) && nodes.get(source).is_some_and(|n| !n.kind.dynamic())
+        })
         .collect()
 }
 
@@ -445,7 +493,7 @@ pub struct Spawner {
     /// output crosses machines by daemon-level forwarding, not node-to-node.
     pub zenoh_connect_endpoint: Option<String>,
     /// Per-node listener + dial-list, so the node↔node links the dataflow needs
-    /// are established deterministically. See [`plan_zenoh_peering`].
+    /// are established deterministically. See [`build_peering_plan`].
     pub zenoh_peering: Arc<BTreeMap<NodeId, NodeZenohPeering>>,
     /// Whether this daemon runs without multicast scouting, so spawned nodes
     /// should too (see [`DORA_ZENOH_MULTICAST_ENV`]). Mixing modes leaves a
@@ -824,7 +872,8 @@ mod tests {
         // Default: every node is local to this daemon, so nothing needs a
         // routable listener.
         let local: BTreeSet<NodeId> = nodes.keys().cloned().collect();
-        plan_zenoh_peering(&nodes, &local, daemon, None)
+        let listeners = reserve_node_listeners(&nodes, &local, None);
+        build_peering_plan(&nodes, &listeners, daemon, &BTreeMap::new())
     }
 
     fn plan_for_local(
@@ -841,12 +890,25 @@ mod tests {
         daemon: Option<&str>,
         routable: Option<IpAddr>,
     ) -> BTreeMap<NodeId, NodeZenohPeering> {
+        plan_with_remote_endpoints(yaml, local, daemon, routable, &BTreeMap::new())
+    }
+
+    /// The full pipeline a spawn runs: reserve local listeners, then build the
+    /// dial lists with whatever the endpoint exchange returned.
+    fn plan_with_remote_endpoints(
+        yaml: &str,
+        local: &[&str],
+        daemon: Option<&str>,
+        routable: Option<IpAddr>,
+        remote_endpoints: &BTreeMap<NodeId, String>,
+    ) -> BTreeMap<NodeId, NodeZenohPeering> {
         let descriptor: Descriptor = serde_yaml::from_str(yaml).expect("parse descriptor");
         let nodes = descriptor
             .resolve_aliases_and_set_defaults()
             .expect("resolve nodes");
         let local: BTreeSet<NodeId> = local.iter().map(|id| node(id)).collect();
-        plan_zenoh_peering(&nodes, &local, daemon, routable)
+        let listeners = reserve_node_listeners(&nodes, &local, routable);
+        build_peering_plan(&nodes, &listeners, daemon, remote_endpoints)
     }
 
     /// The loopback listener, which every planned node has.
@@ -1248,6 +1310,66 @@ nodes:
         // `local_sink` is consumed by nobody off-machine, so it stays loopback
         // only — exposure follows the dataflow, not the deployment.
         assert_eq!(plan[&node("local_sink")].listen.len(), 1);
+    }
+
+    /// The point of the whole exchange: once a remote producer's endpoint is
+    /// known, its local consumer dials it directly instead of waiting on the
+    /// daemon to relay every message.
+    #[test]
+    fn a_local_consumer_dials_a_remote_producer_it_has_an_endpoint_for() {
+        let remote = BTreeMap::from([(node("remote_source"), "tcp/10.0.2.7:41000".to_string())]);
+        let plan = plan_with_remote_endpoints(
+            r#"
+nodes:
+  - id: remote_source
+    path: remote_source
+    outputs:
+      - value
+  - id: local_sink
+    path: local_sink
+    inputs:
+      v: remote_source/value
+"#,
+            &["local_sink"],
+            Some("tcp/127.0.0.1:1"),
+            Some("127.0.0.2".parse().unwrap()),
+            &remote,
+        );
+
+        assert_eq!(
+            plan[&node("local_sink")].connect,
+            vec![
+                "tcp/127.0.0.1:1".to_string(),
+                "tcp/10.0.2.7:41000".to_string()
+            ],
+            "the consumer must dial the daemon and its remote producer"
+        );
+        // Still no listener for a node this daemon does not run.
+        assert!(!plan.contains_key(&node("remote_source")));
+    }
+
+    /// An endpoint the exchange did not return leaves that edge exactly where it
+    /// is today — on the daemon path — rather than inventing a dial.
+    #[test]
+    fn a_remote_producer_without_an_endpoint_is_not_dialled() {
+        let plan = plan_with_remote_endpoints(
+            r#"
+nodes:
+  - id: remote_source
+    path: remote_source
+    outputs:
+      - value
+  - id: local_sink
+    path: local_sink
+    inputs:
+      v: remote_source/value
+"#,
+            &["local_sink"],
+            Some("tcp/127.0.0.1:1"),
+            Some("127.0.0.2".parse().unwrap()),
+            &BTreeMap::new(),
+        );
+        assert_eq!(plan[&node("local_sink")].connect, vec!["tcp/127.0.0.1:1"]);
     }
 
     /// A loopback "routable" address is worse than none: advertised to a remote

--- a/binaries/daemon/src/spawn/spawner.rs
+++ b/binaries/daemon/src/spawn/spawner.rs
@@ -12,7 +12,8 @@ use dora_core::{
     descriptor::{CoreNodeKind, Descriptor, ResolvedNode},
     topics::{
         DORA_RUN_PARENT_PID_ENV, DORA_ZENOH_CONFIG_OVERLAY_ENV, DORA_ZENOH_CONNECT_ENV,
-        DORA_ZENOH_LISTEN_ENV, DORA_ZENOH_MULTICAST_ENV, ZENOH_CONFIG_PATH_ENV,
+        DORA_ZENOH_LISTEN_ENV, DORA_ZENOH_LISTEN_EXTRA_ENV, DORA_ZENOH_MULTICAST_ENV,
+        ZENOH_CONFIG_PATH_ENV,
     },
     uhlc::HLC,
 };
@@ -72,6 +73,7 @@ const CONTROL_PLANE_ENV: &[&str] = &[
     "DORA_NODE_CONFIG",
     "DORA_RUNTIME_CONFIG",
     DORA_ZENOH_LISTEN_ENV,
+    DORA_ZENOH_LISTEN_EXTRA_ENV,
     DORA_ZENOH_CONNECT_ENV,
     DORA_ZENOH_MULTICAST_ENV,
     // Names a pid the node will SIGKILL its own process group over once that
@@ -556,7 +558,28 @@ impl Spawner {
     fn maybe_inject_zenoh_connect(&self, command: Command, node_id: &NodeId) -> Command {
         let command = match self.zenoh_peering.get(node_id) {
             Some(peering) => {
-                let command = command.env(DORA_ZENOH_LISTEN_ENV, peering.listen.join(","));
+                // `listen[0]` is always the loopback endpoint
+                // (`NodeListeners::endpoints`); any routable one follows. They
+                // go into separate variables so a node built before
+                // `DORA_ZENOH_LISTEN_EXTRA` existed still parses the loopback
+                // one — it reads `DORA_ZENOH_LISTEN` as a single locator, so a
+                // comma-separated value would cost it every listener, not just
+                // the routable one (see `DORA_ZENOH_LISTEN_EXTRA_ENV`).
+                let (loopback, extra) = peering
+                    .listen
+                    .split_first()
+                    .map_or((None, &[] as &[String]), |(first, rest)| {
+                        (Some(first), rest)
+                    });
+                let command = match loopback {
+                    Some(ep) => command.env(DORA_ZENOH_LISTEN_ENV, ep),
+                    None => command,
+                };
+                let command = if extra.is_empty() {
+                    command
+                } else {
+                    command.env(DORA_ZENOH_LISTEN_EXTRA_ENV, extra.join(","))
+                };
                 if peering.connect.is_empty() {
                     command
                 } else {
@@ -858,6 +881,60 @@ mod tests {
             // The `dora run` shape is covered by its own test below.
             bind_nodes_to_parent: false,
         }
+    }
+
+    /// The listen endpoints must reach a node in two variables, not one
+    /// comma-separated value: a node binary built before
+    /// `DORA_ZENOH_LISTEN_EXTRA` existed pushes `DORA_ZENOH_LISTEN` into
+    /// `listen/endpoints` verbatim as a single locator, so a list there would
+    /// be rejected wholesale and cost it the loopback listener too — cutting it
+    /// off from its same-machine consumers, not just its remote one
+    /// (dora-rs/dora#2742).
+    #[test]
+    fn a_routable_listener_goes_in_the_extra_var_not_appended_to_the_first() {
+        let mut spawner = spawner_for(None, false);
+        spawner.zenoh_peering = Arc::new(BTreeMap::from([(
+            node("sink"),
+            NodeZenohPeering {
+                listen: vec!["tcp/127.0.0.1:41000".into(), "tcp/10.0.0.2:41001".into()],
+                connect: Vec::new(),
+                routable: true,
+            },
+        )]));
+        let command = spawner.maybe_inject_zenoh_connect(Command::new("true"), &node("sink"));
+
+        assert_eq!(
+            env_of(&command, DORA_ZENOH_LISTEN_ENV),
+            Some(Some(OsString::from("tcp/127.0.0.1:41000"))),
+            "the loopback endpoint must stand alone, parseable by an older node"
+        );
+        assert_eq!(
+            env_of(&command, DORA_ZENOH_LISTEN_EXTRA_ENV),
+            Some(Some(OsString::from("tcp/10.0.0.2:41001"))),
+            "the routable endpoint belongs in the extra var"
+        );
+    }
+
+    /// The common case — no remote consumer — must not set the extra variable
+    /// at all, so nothing changes for a single-machine deployment.
+    #[test]
+    fn a_loopback_only_node_gets_no_extra_listen_var() {
+        let mut spawner = spawner_for(None, false);
+        spawner.zenoh_peering = Arc::new(BTreeMap::from([(
+            node("sink"),
+            NodeZenohPeering {
+                listen: vec!["tcp/127.0.0.1:41000".into()],
+                connect: Vec::new(),
+                routable: false,
+            },
+        )]));
+        let command = spawner.maybe_inject_zenoh_connect(Command::new("true"), &node("sink"));
+
+        assert_eq!(
+            env_of(&command, DORA_ZENOH_LISTEN_ENV),
+            Some(Some(OsString::from("tcp/127.0.0.1:41000")))
+        );
+        assert_eq!(env_of(&command, DORA_ZENOH_LISTEN_EXTRA_ENV), None);
     }
 
     fn injected_multicast(spawner: &Spawner) -> Option<OsString> {

--- a/docs/distributed-deployment.md
+++ b/docs/distributed-deployment.md
@@ -8,6 +8,8 @@ Dora supports deploying dataflows across multiple machines for multi-robot fleet
 - [Quick Start](#quick-start)
 - [Features at a Glance](#features-at-a-glance)
 - [Cluster Configuration Reference](#cluster-configuration-reference)
+- [Cross-Machine Node Communication](#cross-machine-node-communication)
+- [Custom Zenoh Configuration](#custom-zenoh-configuration)
 - [Cluster Commands Reference](#cluster-commands-reference)
   - [dora cluster up](#dora-cluster-up)
   - [dora cluster status](#dora-cluster-status)
@@ -211,6 +213,35 @@ machines:
 - `zenoh_peer` and per-machine zenoh addresses are mutually exclusive.
 - Unknown fields are rejected (`deny_unknown_fields`).
 
+### Example: 3-Machine GPU Cluster
+
+```yaml
+coordinator:
+  addr: 192.168.1.1
+
+machines:
+  - id: coordinator-host
+    host: 192.168.1.1
+    labels:
+      role: control
+
+  - id: gpu-a100
+    host: 192.168.1.10
+    user: ml
+    labels:
+      gpu: a100
+      arch: x86_64
+
+  - id: jetson-01
+    host: 192.168.1.20
+    user: nvidia
+    labels:
+      gpu: jetson
+      arch: arm64
+```
+
+---
+
 ## Cross-Machine Node Communication
 
 Once the daemons can reach each other, the nodes do too. A node whose output is
@@ -231,7 +262,14 @@ than losing messages. Edges that stay on the daemon path:
   nothing a remote consumer could dial;
 - an endpoint exchange that **timed out** (default 1.5s; set
   `DORA_ZENOH_ENDPOINT_EXCHANGE_TIMEOUT_MS` to allow longer, or `0` to keep
-  every cross-machine edge on the daemon path).
+  every cross-machine edge on the daemon path);
+- a remote consumer that declares **`input_timeout`**. Its deadline is refreshed
+  only when the consumer's own daemon sees the message, and a direct
+  cross-machine send bypasses that daemon entirely — so the deadline would never
+  fire and `input_timeout` (plus the circuit breaker built on it) would silently
+  stop working on exactly the edges most likely to need it. The direct path is
+  not worth losing a liveness guarantee the descriptor asked for. Remove
+  `input_timeout` from that input if you would rather have the fast path.
 
 Node processes therefore accept connections on the cluster network wherever a
 dataflow spans machines. That is intended to sit inside a tailnet or behind
@@ -265,35 +303,6 @@ lost. Setting both is an error.
 ```bash
 dora daemon --machine-id edge-01 --coordinator-addr 10.0.0.1   --zenoh-config-overlay routers.json5
 ```
-
-### Example: 3-Machine GPU Cluster
-
-```yaml
-coordinator:
-  addr: 192.168.1.1
-
-machines:
-  - id: coordinator-host
-    host: 192.168.1.1
-    labels:
-      role: control
-
-  - id: gpu-a100
-    host: 192.168.1.10
-    user: ml
-    labels:
-      gpu: a100
-      arch: x86_64
-
-  - id: jetson-01
-    host: 192.168.1.20
-    user: nvidia
-    labels:
-      gpu: jetson
-      arch: arm64
-```
-
----
 
 ## Cluster Commands Reference
 

--- a/docs/distributed-deployment.md
+++ b/docs/distributed-deployment.md
@@ -120,7 +120,8 @@ coordinator:
   addr: 10.0.0.1            # IP address the coordinator binds to (required)
   port: 6013                 # WebSocket port (default: 6013)
 
-zenoh_peer: tcp/10.0.0.1:5456  # Shared inter-daemon Zenoh rendezvous (optional)
+zenoh_peer: tcp/10.0.0.1:5456  # Shared inter-daemon Zenoh rendezvous (optional;
+                               # mutually exclusive with the mesh below)
 
 machines:
   - id: edge-01              # Unique machine identifier (required)
@@ -128,6 +129,8 @@ machines:
     user: ubuntu              # SSH user (optional, defaults to current user)
     port: 2222                # SSH port (optional, defaults to 22)
     daemon_port: 53291        # Daemon local-listen port (optional, defaults to 53291)
+    zenoh_addr: 10.0.0.2      # Address peers dial (optional, defaults to `host`)
+    zenoh_port: 5456          # Zenoh listen port (optional, defaults to 5456)
     labels:                   # Key-value labels for scheduling (optional)
       gpu: "true"
       arch: arm64
@@ -151,18 +154,33 @@ machines:
 > **Every daemon must be dialable by every other daemon.** Zenoh advertises the
 > address a daemon binds, and remote daemons dial exactly that; since zenoh 1.9
 > peers do not relay for each other, a pair that cannot form a direct link has no
-> fallback and silently exchanges nothing. By default a daemon binds the local
-> address that routes toward `coordinator.addr` — the LAN address on a LAN, the
-> tunnel address on a mesh VPN such as Tailscale — which is correct without
-> configuration. On a multi-homed machine that would otherwise advertise an
-> interface the other daemons cannot reach, override it with
-> `dora daemon --zenoh-listen <IP>`. A daemon whose coordinator is loopback stays
-> on loopback and is not reachable from the network at all.
+> fallback and silently exchanges nothing.
 >
-> `--zenoh-listen` must be a concrete address: a wildcard (`0.0.0.0`) is rejected
-> because zenoh would bind every interface but advertise a concrete one. An
-> address given explicitly must bind, or the daemon exits rather than starting
-> without a listener.
+> When every machine has a dialable address, `dora cluster up` wires the daemons
+> into an explicit mesh: each one gets
+> `--zenoh-listen <its addr>:<its port> --zenoh-connect <every other machine>`.
+> That needs no multicast and no gossip, which is what makes it the right shape
+> for a mesh VPN — a tailnet carries no multicast. The addresses come from `host`
+> when it is an IP, so the common case needs no extra configuration.
+>
+> If any machine has no dialable address (a hostname in `host` and no
+> `zenoh_addr`), `dora cluster up` warns and derives **nothing**, leaving the
+> whole cluster on the old discovery path. A partial mesh would be worse than
+> none: explicit connect endpoints turn multicast scouting off for the daemons
+> that have them, so the unmeshed remainder is left with no way to be found.
+>
+> `zenoh_peer` selects the older rendezvous shape instead — one shared endpoint
+> every daemon binds and dials, with the daemon-to-daemon links left to gossip.
+> Setting it *and* per-machine addresses is rejected rather than silently
+> resolved.
+>
+> Running daemons by hand, the same applies via `dora daemon --zenoh-listen
+> <IP>[:<PORT>]` and `--zenoh-connect <endpoint>,...`. Naming a port is what lets
+> peers dial a daemon before it has announced anything; without one the OS picks
+> the port and peers can only learn it by discovery. `--zenoh-listen` must be a
+> concrete address — a wildcard (`0.0.0.0`) is rejected because zenoh would bind
+> every interface but advertise a concrete one — and an address given explicitly
+> must bind, or the daemon exits rather than starting without a listener.
 
 **coordinator**
 
@@ -180,6 +198,8 @@ machines:
 | `user` | string | current user | SSH username |
 | `port` | u16 | `22` | SSH port. Set when sshd listens on a non-standard port (e.g., containerized or hardened deployments). Applied to both `ssh` (`-p`) and `scp` (`-P`). |
 | `daemon_port` | u16 | `53291` | Daemon local-listen port (passed to `dora daemon --local-listen-port`). Set when running multiple `dora daemon` instances on the same host so each daemon binds a unique port. See [`examples/multiple-daemons/`](../examples/multiple-daemons/). |
+| `zenoh_addr` | IP address | `host` | Address the *other daemons* dial to reach this machine. Defaults to `host` when that is an IP, which is the common case: on a mesh VPN the tunnel address is both how you SSH in and how peers dial. Set it when the two differ — an SSH-only jump address, a hostname rather than an IP, or a multi-homed machine whose SSH interface is not the one other daemons can reach. Must be an address, not a hostname: only the remote machine could resolve a name, and the daemon has to *bind* it. |
+| `zenoh_port` | u16 | `5456` | Port this machine's Zenoh listener binds. Per-machine like `daemon_port`, so two daemons on one host stay expressible. |
 | `labels` | map | empty | Key-value pairs for label-based scheduling |
 
 ### Validation Rules
@@ -187,7 +207,64 @@ machines:
 - At least one machine must be defined.
 - Machine IDs must be non-empty and unique.
 - Machine hosts must be non-empty.
+- `zenoh_addr` must be an IP address; `zenoh_port` and `daemon_port` must not be 0.
+- `zenoh_peer` and per-machine zenoh addresses are mutually exclusive.
 - Unknown fields are rejected (`deny_unknown_fields`).
+
+## Cross-Machine Node Communication
+
+Once the daemons can reach each other, the nodes do too. A node whose output is
+consumed on another machine listens on an address that machine can dial, the
+daemons trade those endpoints before spawning anything, and the consumer dials
+the producer directly. The daemon is then out of the data path entirely:
+producer node → consumer node, one Zenoh hop, instead of node → daemon → daemon
+→ node.
+
+The switch is proven, not assumed. The producer keeps every output on the
+lossless daemon path until the consumer's startup ack comes back over the
+direct link, so an edge that fails to wire up degrades to the old path rather
+than losing messages. Edges that stay on the daemon path:
+
+- a **dynamic** consumer on another machine — it joins at an arbitrary time, so
+  no endpoint can be planned for it;
+- a producer with **no dialable address** — a daemon bound to loopback has
+  nothing a remote consumer could dial;
+- an endpoint exchange that **timed out** (default 1.5s; set
+  `DORA_ZENOH_ENDPOINT_EXCHANGE_TIMEOUT_MS` to allow longer, or `0` to keep
+  every cross-machine edge on the daemon path).
+
+Node processes therefore accept connections on the cluster network wherever a
+dataflow spans machines. That is intended to sit inside a tailnet or behind
+ACLs; where it must be hardened further, Zenoh's TLS and authentication
+settings can be layered on with the config overlay below.
+
+## Custom Zenoh Configuration
+
+Two ways to change the Zenoh configuration dora computes, for the daemon and
+every node it spawns:
+
+| | `--zenoh-config-overlay <PATH>` / `DORA_ZENOH_CONFIG_OVERLAY` | `ZENOH_CONFIG` |
+|---|---|---|
+| Effect | Layers a JSON5 file **onto** dora's config | Builds the session **entirely** from the file |
+| `connect.endpoints` / `listen.endpoints` | Added to dora's | Replace dora's |
+| Other keys | Replace dora's value for that key | — |
+| Per-node links | Kept | **Discarded** |
+
+Prefer the overlay. Because `ZENOH_CONFIG` discards the per-node connect/listen
+plan, a router named there ends up relaying same-machine traffic too — off the
+host and back, if the router runs elsewhere — and the direct zero-copy path is
+lost. Setting both is an error.
+
+```json5
+// routers.json5 — also reach these routers, keep everything dora planned
+{
+  connect: { endpoints: ["tcp/10.0.0.1:7447"] },
+}
+```
+
+```bash
+dora daemon --machine-id edge-01 --coordinator-addr 10.0.0.1   --zenoh-config-overlay routers.json5
+```
 
 ### Example: 3-Machine GPU Cluster
 

--- a/examples/multiple-daemons/README.md
+++ b/examples/multiple-daemons/README.md
@@ -31,6 +31,12 @@ Execute the following steps in this directory:
 
 # Usage Across Multiple Machines
 
+The steps below start each daemon by hand. For a managed cluster — machine list
+in a `cluster.yml`, SSH lifecycle commands, label-based scheduling, systemd
+services — see the [Distributed Deployment Guide](../../docs/distributed-deployment.md),
+which also documents how each daemon picks the address it advertises to the
+others.
+
 1. Start the dora coordinator on some machine that is reachable by IP by all other machines
     ```bash
     dora coordinator
@@ -47,13 +53,20 @@ Execute the following steps in this directory:
       You can **omit the `--machine-id` argument on one machine**. This will be the default machine for nodes that don't specify deploy information.
 
       The `RUST_LOG=debug` environment variable is optional. It enables some interesting debug output about the dataflow run.
-    - If daemons/coordinator are in **different networks** (e.g. behind a [NAT](https://en.wikipedia.org/wiki/Network_address_translation)), you need to set up one or multiple [zenoh routers](https://zenoh.io/docs/getting-started/deployment/#zenoh-router). This requires running a [`zenohd`](https://zenoh.io/docs/getting-started/installation/) instance for every subnet. This is also possible [using a Docker container](https://zenoh.io/docs/getting-started/quick-test/).
+    - If daemons/coordinator are in **different networks** (e.g. behind a [NAT](https://en.wikipedia.org/wiki/Network_address_translation)), put the machines on a **mesh VPN** such as [Tailscale](https://tailscale.com/), [WireGuard](https://www.wireguard.com/), or [Nebula](https://github.com/slackhq/nebula). This is the recommended setup: once every machine has a tunnel address, the machines are mutually dialable and dora needs no extra zenoh configuration. Each daemon binds the local address that routes toward the coordinator — the tunnel address, when the coordinator is reached through the tunnel — and advertises exactly that to the other daemons.
+      ```bash
+      RUST_LOG=debug dora daemon --coordinator-addr <COORDINATOR_TUNNEL_IP> --machine-id <MACHINE_ID> \
+        --zenoh-peer tcp/<COORDINATOR_TUNNEL_IP>:5456
+      ```
+      A mesh VPN carries no multicast, so daemons cannot find each other by scouting. `--zenoh-peer` gives them an explicit rendezvous instead: pass the *same* endpoint to every daemon, and the first one to bind it serves as the rendezvous for the others. On a multi-homed machine that would otherwise advertise an interface the other daemons cannot reach, name the address explicitly with `--zenoh-listen <TUNNEL_IP>`.
 
-      Once your `zenohd` instances are running, you can start the `dora daemon` instances as before, but now with a `ZENOH_CONFIG` environment variable set:
+      A [zenoh router](https://zenoh.io/docs/getting-started/deployment/#zenoh-router) is **not** a substitute for this. Since zenoh 1.9, peers no longer relay for each other, and peers that sit under one router in a single region are no exception: two NAT'd daemons will discover each other through a `zenohd` and still exchange nothing. A router helps only where the daemons are mutually dialable anyway (it then supplies discovery, which `--zenoh-peer` also does), or where the peers are split into separate router subregions.
+
+      If you do run your own [`zenohd`](https://zenoh.io/docs/getting-started/installation/) instances, point dora at them with a `ZENOH_CONFIG` environment variable:
       ```bash
       ZENOH_CONFIG=<ZENOH_CONFIG_FILE_PATH> RUST_LOG=debug dora daemon --coordinator-addr <IP> --machine-id <MACHINE_ID>
       ```
-      Replace `<ZENOH_CONFIG_FILE_PATH>`  with the path to a [zenoh configuration file](https://zenoh.io/docs/manual/configuration/#configuration-files) that lists the corresponding `zenohd` instance(s) under `connect.endpoints`.
+      Replace `<ZENOH_CONFIG_FILE_PATH>` with the path to a [zenoh configuration file](https://zenoh.io/docs/manual/configuration/#configuration-files) that lists the corresponding `zenohd` instance(s) under `connect.endpoints`. Note that this variable replaces dora's zenoh configuration **wholesale**, including the direct node-to-node links the daemon plans for same-machine communication — so same-machine traffic is relayed through the router too, which is slower and, if the router runs on another host, sends that traffic off the machine and back.
 
 3. In your `dataflow.yml` file, add an `deploy` key to all nodes that should not run on the default machine:
     ```yml

--- a/examples/multiple-daemons/README.md
+++ b/examples/multiple-daemons/README.md
@@ -56,9 +56,14 @@ others.
     - If daemons/coordinator are in **different networks** (e.g. behind a [NAT](https://en.wikipedia.org/wiki/Network_address_translation)), put the machines on a **mesh VPN** such as [Tailscale](https://tailscale.com/), [WireGuard](https://www.wireguard.com/), or [Nebula](https://github.com/slackhq/nebula). This is the recommended setup: once every machine has a tunnel address, the machines are mutually dialable and dora needs no extra zenoh configuration. Each daemon binds the local address that routes toward the coordinator — the tunnel address, when the coordinator is reached through the tunnel — and advertises exactly that to the other daemons.
       ```bash
       RUST_LOG=debug dora daemon --coordinator-addr <COORDINATOR_TUNNEL_IP> --machine-id <MACHINE_ID> \
-        --zenoh-peer tcp/<COORDINATOR_TUNNEL_IP>:5456
+        --zenoh-listen <THIS_MACHINE_TUNNEL_IP>:5456 \
+        --zenoh-connect tcp/<OTHER_MACHINE_TUNNEL_IP>:5456
       ```
-      A mesh VPN carries no multicast, so daemons cannot find each other by scouting. `--zenoh-peer` gives them an explicit rendezvous instead: pass the *same* endpoint to every daemon, and the first one to bind it serves as the rendezvous for the others. On a multi-homed machine that would otherwise advertise an interface the other daemons cannot reach, name the address explicitly with `--zenoh-listen <TUNNEL_IP>`.
+      A mesh VPN carries no multicast, so daemons cannot find each other by scouting. Giving each daemon its own `--zenoh-listen` and dialing the others with `--zenoh-connect` wires them into an explicit mesh, which needs neither multicast nor gossip — the same shape `dora cluster up` derives automatically, and the recommended one. Pass every *other* machine's endpoint to `--zenoh-connect` (comma-separated); the dial is one-directional but the link it opens is not, so either daemon starting first is fine.
+
+      For a larger fleet, where enumerating peers on every command line gets unwieldy, `--zenoh-peer` is the simpler alternative: pass the *same* endpoint to every daemon and the first one to bind it becomes a rendezvous the rest gossip through. It costs a hop of indirection and depends on that one daemon being up, which is why the explicit mesh is preferred where you can spell it out. The two are mutually exclusive — `dora cluster up` refuses a `cluster.yml` that sets both.
+
+      An explicitly named `--zenoh-listen` address **must** bind or the daemon exits: a daemon that silently fails to bind is undialable, and failing loudly beats a cluster that looks up and exchanges nothing. Make sure the address is one this machine actually holds (a NAT or VIP address is not) and that the port is free.
 
       A [zenoh router](https://zenoh.io/docs/getting-started/deployment/#zenoh-router) is **not** a substitute for this. Since zenoh 1.9, peers no longer relay for each other, and peers that sit under one router in a single region are no exception: two NAT'd daemons will discover each other through a `zenohd` and still exchange nothing. A router helps only where the daemons are mutually dialable anyway (it then supplies discovery, which `--zenoh-peer` also does), or where the peers are split into separate router subregions.
 

--- a/libraries/core/Cargo.toml
+++ b/libraries/core/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 
 [features]
 build = ["dep:git2", "dep:url"]
-zenoh = ["dep:zenoh"]
+zenoh = ["dep:zenoh", "dep:json5"]
 
 [dependencies]
 dora-message = { workspace = true }
@@ -41,6 +41,10 @@ git2 = { workspace = true, optional = true }
 fs_extra = "1.3.0"
 splitty = "1.0.2"
 zenoh = { workspace = true, optional = true }
+# Zenoh's own config format, so an operator's overlay file can carry comments
+# and unquoted keys like the config files zenoh documents. Already in the tree
+# via zenoh itself, so this adds no crate to the dependency graph.
+json5 = { version = "0.4", optional = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -29,7 +29,25 @@ pub const DORA_ZENOH_CONNECT_ENV: &str = "DORA_ZENOH_CONNECT";
 /// that never form a direct link simply cannot exchange data — no amount of
 /// waiting fixes it. Assigning each node a known listener makes those links
 /// deterministic instead of racy.
+///
+/// **Stays single-valued.** A node that also needs a routable listener gets it
+/// via [`DORA_ZENOH_LISTEN_EXTRA_ENV`] rather than as a second entry here,
+/// because a node binary built before that variable existed pushes this value
+/// into `listen/endpoints` verbatim as *one* locator. A comma-separated value
+/// would therefore be rejected wholesale by such a node, costing it the
+/// loopback listener too and partitioning it from its same-machine consumers.
+/// Keeping the old variable's shape means an older node degrades to
+/// loopback-only — same-machine links keep working, cross-machine ones fall
+/// back to the daemon path — instead of losing every link (dora-rs/dora#2742).
 pub const DORA_ZENOH_LISTEN_ENV: &str = "DORA_ZENOH_LISTEN";
+
+/// Additional zenoh endpoints a spawned node should listen on, beyond the
+/// loopback one in [`DORA_ZENOH_LISTEN_ENV`]. Comma-separated; injected by the
+/// daemon only for a node that has a consumer under another daemon.
+///
+/// Split out from [`DORA_ZENOH_LISTEN_ENV`] for forward compatibility — see the
+/// note there. A node that does not know this variable simply ignores it.
+pub const DORA_ZENOH_LISTEN_EXTRA_ENV: &str = "DORA_ZENOH_LISTEN_EXTRA";
 
 /// Opt out of zenoh multicast scouting for this process, regardless of whether
 /// explicit connect endpoints replaced it.
@@ -142,6 +160,23 @@ fn split_endpoints(value: &str) -> impl Iterator<Item = String> + '_ {
         .map(str::trim)
         .filter(|s| !s.is_empty())
         .map(String::from)
+}
+
+/// Assemble a node's listen endpoints from the two env vars the daemon sets.
+///
+/// Split across two variables rather than one comma-separated value for
+/// forward compatibility — see [`DORA_ZENOH_LISTEN_EXTRA_ENV`]. Both are run
+/// through [`split_endpoints`] so a hand-set list in either keeps working, and
+/// so the loopback entry stays first: `listen/endpoints` order is what decides
+/// which locator a same-machine consumer picks, and loopback is the one whose
+/// transport can carry shared memory.
+#[cfg(feature = "zenoh")]
+fn listen_endpoints_from_env(listen: Option<&str>, extra: Option<&str>) -> Vec<String> {
+    listen
+        .into_iter()
+        .chain(extra)
+        .flat_map(split_endpoints)
+        .collect()
 }
 
 /// Path to a JSON5 file whose contents are layered on top of the zenoh config
@@ -591,15 +626,18 @@ pub async fn open_zenoh_session_with_listen(
             // since zenoh 1.9 peers do not relay, a consumer that cannot dial its
             // producer never receives its data at all.
             //
-            // The variable carries a *list*, because a node with a consumer on
-            // another machine listens both on loopback (for its same-machine
-            // consumers, whose transport can then carry shared memory) and on a
-            // routable address (for the remote one).
-            let env_listen = std::env::var(DORA_ZENOH_LISTEN_ENV).ok();
-            let env_listen_endpoints: Vec<String> = env_listen
-                .as_deref()
-                .map(|value| split_endpoints(value).collect())
-                .unwrap_or_default();
+            // A node with a consumer on another machine listens both on
+            // loopback (for its same-machine consumers, whose transport can
+            // then carry shared memory) and on a routable address (for the
+            // remote one). The two arrive in *separate* variables so an older
+            // node binary, which treats `DORA_ZENOH_LISTEN` as a single
+            // locator, still gets a valid one — see the doc on
+            // `DORA_ZENOH_LISTEN_EXTRA_ENV`. `split_endpoints` is applied to
+            // both so a hand-set list in either keeps working.
+            let env_listen_endpoints = listen_endpoints_from_env(
+                std::env::var(DORA_ZENOH_LISTEN_ENV).ok().as_deref(),
+                std::env::var(DORA_ZENOH_LISTEN_EXTRA_ENV).ok().as_deref(),
+            );
 
             let mut listen_eps: Vec<String> = Vec::new();
             if let Some(ep) = listen_endpoint {
@@ -1155,6 +1193,55 @@ pub fn dataflow_extension_topic(dataflow_id: &uuid::Uuid, namespace: &str) -> St
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The forward-compat contract: the loopback endpoint stays alone in
+    /// `DORA_ZENOH_LISTEN` so a node built before `DORA_ZENOH_LISTEN_EXTRA`
+    /// existed — which pushes that value in as a *single* locator — still gets
+    /// a usable one. A list there would be rejected wholesale by such a node,
+    /// costing it loopback too and partitioning it from same-machine consumers
+    /// (dora-rs/dora#2742).
+    #[cfg(feature = "zenoh")]
+    #[test]
+    fn listen_endpoints_keep_loopback_first_and_merge_the_extra_var() {
+        assert_eq!(
+            listen_endpoints_from_env(Some("tcp/127.0.0.1:41000"), Some("tcp/10.0.0.2:41001")),
+            vec![
+                "tcp/127.0.0.1:41000".to_string(),
+                "tcp/10.0.0.2:41001".to_string()
+            ],
+            "loopback must stay first — order decides which locator a \
+             same-machine consumer picks, and only loopback carries shared memory"
+        );
+    }
+
+    #[cfg(feature = "zenoh")]
+    #[test]
+    fn listen_endpoints_tolerate_an_absent_or_empty_extra_var() {
+        assert_eq!(
+            listen_endpoints_from_env(Some("tcp/127.0.0.1:41000"), None),
+            vec!["tcp/127.0.0.1:41000".to_string()]
+        );
+        assert_eq!(
+            listen_endpoints_from_env(Some("tcp/127.0.0.1:41000"), Some("")),
+            vec!["tcp/127.0.0.1:41000".to_string()]
+        );
+        assert!(listen_endpoints_from_env(None, None).is_empty());
+    }
+
+    /// A hand-set list in either variable keeps working, so an operator who
+    /// already scripted a comma-separated `DORA_ZENOH_LISTEN` is not broken by
+    /// the split.
+    #[cfg(feature = "zenoh")]
+    #[test]
+    fn listen_endpoints_still_accept_a_list_in_either_var() {
+        assert_eq!(
+            listen_endpoints_from_env(Some("tcp/127.0.0.1:41000, tcp/10.0.0.2:41001"), None),
+            vec![
+                "tcp/127.0.0.1:41000".to_string(),
+                "tcp/10.0.0.2:41001".to_string()
+            ]
+        );
+    }
 
     #[cfg(feature = "zenoh")]
     #[test]

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -148,10 +148,47 @@ fn split_endpoints(value: &str) -> impl Iterator<Item = String> + '_ {
 pub async fn open_zenoh_session(coordinator_addr: Option<IpAddr>) -> eyre::Result<zenoh::Session> {
     // Nodes and the coordinator have no in-process way to know, so
     // [`DORA_ZENOH_MULTICAST_ENV`] (honored inside) is their only channel.
-    let (session, _) =
-        open_zenoh_session_with_listen(coordinator_addr, None, None, MulticastScouting::Allowed)
-            .await?;
+    let (session, _) = open_zenoh_session_with_listen(ZenohSessionParams {
+        coordinator_addr,
+        ..Default::default()
+    })
+    .await?;
     Ok(session)
+}
+
+/// How a dora process wants its zenoh session wired.
+///
+/// A struct rather than a parameter list because every field is optional and
+/// most callers set one of them: the positional form made
+/// `open_zenoh_session_with_listen(None, None, None, Allowed)` a common sight,
+/// where a misplaced `None` is a silent partition rather than a type error.
+/// [`Default`] gives "a plain peer with whatever the environment says", which
+/// is what nodes and the coordinator want.
+#[cfg(feature = "zenoh")]
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ZenohSessionParams<'a> {
+    /// Coordinator to reach through a zenoh router/peer pair. Unused by every
+    /// in-tree caller today; see the `coordinator_addr` branch below.
+    pub coordinator_addr: Option<IpAddr>,
+    /// Endpoint this session listens on and advertises to its peers, e.g.
+    /// `tcp/127.0.0.1:43217` for a single-machine daemon or `tcp/10.0.2.100:5456`
+    /// for one in a cluster. Verified against `info().locators()` after open;
+    /// see the return value.
+    pub listen_endpoint: Option<&'a str>,
+    /// Shared rendezvous endpoint for daemon-to-daemon discovery when multicast
+    /// isn't available: added to *both* listen and connect endpoints, so the
+    /// first daemon to bind it becomes the gossip hub and the rest fall through
+    /// to connect-only.
+    pub inter_daemon_peer: Option<&'a str>,
+    /// Peers this session dials, in addition to whatever
+    /// [`DORA_ZENOH_CONNECT_ENV`] carries. This is how a deployment wires its
+    /// daemons into an explicit mesh instead of relying on gossip through a
+    /// single rendezvous: every daemon dials every other one, which is the
+    /// clique zenoh 1.9 requires of a peer region.
+    pub connect_endpoints: &'a [String],
+    /// Whether this session may scout by multicast. A request, not a command —
+    /// see the `#1856` guard below.
+    pub multicast: MulticastScouting,
 }
 
 /// Builds the zenoh `connect/endpoints` JSON5 for a coordinator peer.
@@ -168,11 +205,18 @@ fn coordinator_connect_endpoints(addr: IpAddr) -> String {
     format!(r#"{{ router: ["tcp/[::]:7447"], peer: ["tcp/{peer}"] }}"#)
 }
 
-/// Like [`open_zenoh_session`], but also configures the session to listen on
-/// the given endpoint (e.g. `tcp/127.0.0.1:43217`, or a routable address such as
-/// `tcp/10.0.2.100:43217` for a daemon in a cluster). The daemon uses this so
+/// Like [`open_zenoh_session`], but takes the full [`ZenohSessionParams`]: a
+/// listen endpoint to bind and advertise (e.g. `tcp/127.0.0.1:43217`, or a
+/// routable address such as `tcp/10.0.2.100:5456` for a daemon in a cluster),
+/// extra peers to dial, and the multicast request. The daemon uses this so
 /// spawned nodes can connect via `DORA_ZENOH_CONNECT` without multicast
 /// scouting, and so that other daemons can dial it.
+///
+/// `connect_endpoints` are dialed in addition to whatever
+/// [`DORA_ZENOH_CONNECT_ENV`] carries, deduplicated against it. They are
+/// dial-only, which is what distinguishes an explicit mesh (each daemon
+/// listens on its own endpoint and dials its peers') from the rendezvous
+/// below (every daemon both listens on and dials the *same* endpoint).
 ///
 /// `inter_daemon_peer` is an optional shared endpoint used as the
 /// rendezvous for daemon-to-daemon discovery when multicast isn't
@@ -204,13 +248,18 @@ fn coordinator_connect_endpoints(addr: IpAddr) -> String {
 /// ends up reachable some other way (see the `#1856` guard below).
 #[cfg(feature = "zenoh")]
 pub async fn open_zenoh_session_with_listen(
-    coordinator_addr: Option<IpAddr>,
-    listen_endpoint: Option<&str>,
-    inter_daemon_peer: Option<&str>,
-    multicast: MulticastScouting,
+    params: ZenohSessionParams<'_>,
 ) -> eyre::Result<(zenoh::Session, Option<String>)> {
     use eyre::{Context, eyre};
     use tracing::warn;
+
+    let ZenohSessionParams {
+        coordinator_addr,
+        listen_endpoint,
+        inter_daemon_peer,
+        connect_endpoints,
+        multicast,
+    } = params;
 
     // Source-of-truth for the listener: stays `None` unless we actually
     // accepted `listen/endpoints` into the config below. Callers use this
@@ -283,23 +332,38 @@ pub async fn open_zenoh_session_with_listen(
             // bytes onto the wire (i.e. copied) instead of sent as a ~16-byte
             // descriptor.
 
-            // Build the connect-endpoint list from two sources:
+            // Build the connect-endpoint list from three sources:
             //   1. DORA_ZENOH_CONNECT env var — daemon-bootstrapped local
             //      discovery for spawned nodes (#1778).
-            //   2. `inter_daemon_peer` — shared rendezvous for daemon-to-
+            //   2. `connect_endpoints` — peers this process was told to dial,
+            //      i.e. the explicit daemon↔daemon mesh (`--zenoh-connect`).
+            //      Unlike (3) this is dial-only: a mesh member listens on its
+            //      own advertised endpoint, not on its peers'.
+            //   3. `inter_daemon_peer` — shared rendezvous for daemon-to-
             //      daemon discovery (extends #1778 to the daemon↔daemon
             //      hop). One daemon binds it as a listener, others connect
             //      and gossip-discover their peers via it.
-            // Both are explicit endpoints; if we set any of them we
+            // All are explicit endpoints; if we set any of them we
             // disable multicast scouting so we don't end up with mixed
             // discovery modes.
             let mut connect_eps: Vec<String> = Vec::new();
             if let Ok(eps) = std::env::var(DORA_ZENOH_CONNECT_ENV) {
                 connect_eps.extend(split_endpoints(&eps));
             }
+            connect_eps.extend(connect_endpoints.iter().cloned());
             if let Some(peer) = inter_daemon_peer {
                 connect_eps.push(peer.to_string());
             }
+            // A duplicate dial is not fatal, but it is a wasted connection
+            // attempt per duplicate and, when the peer is unreachable, a
+            // second retry loop against it — which is exactly what keeps the
+            // net runtime busy (#2776). Callers can legitimately overlap:
+            // `--zenoh-connect` may name the same endpoint the environment
+            // already carries. `retain` over a seen-set rather than `dedup`,
+            // which only collapses *adjacent* equals and would leave the
+            // env/param/rendezvous interleaving untouched.
+            let mut seen_connect = std::collections::HashSet::new();
+            connect_eps.retain(|ep| seen_connect.insert(ep.clone()));
             let mut connect_inserted = false;
             if !connect_eps.is_empty() {
                 let json = format!(
@@ -524,6 +588,32 @@ pub async fn open_zenoh_session_with_listen(
     Ok((zenoh_session, effective_listen_endpoint))
 }
 
+/// Default TCP port for a daemon's inter-daemon zenoh listener.
+///
+/// Only used when a deployment *names* the port — `--zenoh-listen <IP>` alone
+/// still reserves an ephemeral one. An explicit mesh needs a port its peers can
+/// predict, since they must dial the endpoint before the daemon has told anyone
+/// what it bound. 5456 is the port dora already uses for a zenoh peer in
+/// [`coordinator_connect_endpoints`] and in every deployment doc example.
+pub const DORA_ZENOH_LISTEN_PORT_DEFAULT: u16 = 5456;
+
+/// Format `addr:port` as a zenoh TCP endpoint string.
+///
+/// The address goes through [`SocketAddr`], whose `Display` brackets IPv6 —
+/// which is also zenoh's locator grammar (`tcp/[::1]:7447`). Interpolating a
+/// bare [`IpAddr`] instead would emit `tcp/::1:7447`, where the port colon is
+/// indistinguishable from the address colons and `insert_json5` rejects the
+/// result (#3041).
+///
+/// Unlike [`reserve_zenoh_endpoint`] this binds nothing, so there is no
+/// reserve→bind window for another process to slip into: a named port is
+/// either free when zenoh binds it or it is not, and the
+/// `info().locators()` check in [`open_zenoh_session_with_listen`] tells the
+/// caller which.
+pub fn zenoh_endpoint(addr: IpAddr, port: u16) -> String {
+    format!("tcp/{}", SocketAddr::new(addr, port))
+}
+
 /// Reserve an unused TCP port on `bind` for use as a zenoh listen endpoint.
 /// Returns a string suitable for the zenoh `listen/endpoints` config
 /// (e.g. `tcp/127.0.0.1:43217`, or `tcp/[::1]:43217` for IPv6).
@@ -563,9 +653,7 @@ pub fn reserve_zenoh_endpoint(bind: IpAddr) -> std::io::Result<String> {
     let listener = std::net::TcpListener::bind((bind, 0))?;
     let port = listener.local_addr()?.port();
     drop(listener);
-    // `SocketAddr`'s Display brackets IPv6 for us, which is also zenoh's
-    // endpoint syntax (`tcp/[::1]:7447`).
-    Ok(format!("tcp/{}", SocketAddr::new(bind, port)))
+    Ok(zenoh_endpoint(bind, port))
 }
 
 /// Loopback case of [`reserve_zenoh_endpoint`] — the right choice when every
@@ -926,6 +1014,33 @@ mod tests {
                 "error should tell the operator to pass a concrete address, got: {err}"
             );
         }
+    }
+
+    // An IPv6 endpoint must bracket its address, or the port colon is
+    // indistinguishable from the address colons and `insert_json5` rejects the
+    // locator outright (#3041). A named-port endpoint has to match the shape
+    // `reserve_zenoh_endpoint` produces, because both end up in the same
+    // `listen/endpoints` list and are compared verbatim against
+    // `info().locators()` after open.
+    #[test]
+    fn zenoh_endpoint_brackets_ipv6_and_matches_the_reserved_shape() {
+        assert_eq!(
+            zenoh_endpoint("10.0.2.100".parse().unwrap(), 5456),
+            "tcp/10.0.2.100:5456"
+        );
+        assert_eq!(
+            zenoh_endpoint("::1".parse().unwrap(), 5456),
+            "tcp/[::1]:5456"
+        );
+
+        let reserved = reserve_zenoh_endpoint(LOCALHOST).expect("loopback reservation");
+        let port = reserved
+            .rsplit_once(':')
+            .expect("reserved endpoint carries a port")
+            .1
+            .parse()
+            .expect("reserved port is numeric");
+        assert_eq!(zenoh_endpoint(LOCALHOST, port), reserved);
     }
 
     // Concrete addresses pass validation whether or not they exist on this host:

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -387,12 +387,14 @@ pub async fn open_zenoh_session_with_listen(
             // We don't promote it to `effective_listen_endpoint` until the
             // configured open succeeds — the fallback default-config path
             // below has no listener and must not advertise one (#1856).
-            // We only track `listen_endpoint` (the per-daemon listener that
-            // gets advertised to spawned nodes), NOT `inter_daemon_peer`
-            // which is cluster-wide config — daemons that bind it act as
-            // the rendezvous, but advertising it back to nodes would be
-            // wrong (nodes would try to reach it through what may be a
-            // remote address, defeating the loopback shortcut).
+            // We only track the caller's own `listen_endpoint` (the per-daemon
+            // listener that gets advertised to spawned nodes), NOT
+            // `inter_daemon_peer` which is cluster-wide config — daemons that
+            // bind it act as the rendezvous, but advertising it back to nodes
+            // would be wrong (nodes would try to reach it through what may be a
+            // remote address, defeating the loopback shortcut) — and not the
+            // env-supplied node listeners either, which the daemon planned and
+            // already knows.
             let mut listen_inserted_into_configured: Option<String> = None;
             // Any accepted listener, including the cluster-wide rendezvous that
             // is deliberately absent from `listen_inserted_into_configured`.
@@ -406,18 +408,27 @@ pub async fn open_zenoh_session_with_listen(
             // daemon proceed even if some don't bind — e.g. the second
             // daemon to start on the same host with the same rendezvous
             // port falls through to connect-only.
-            // A spawned node gets its listener from the daemon via
+            // A spawned node gets its listeners from the daemon via
             // `DORA_ZENOH_LISTEN` (the daemon itself passes `listen_endpoint`
             // directly). Without a known listener a node cannot be dialled, and
             // since zenoh 1.9 peers do not relay, a consumer that cannot dial its
             // producer never receives its data at all.
-            let env_listen_endpoint = std::env::var(DORA_ZENOH_LISTEN_ENV).ok();
-            let listen_endpoint = listen_endpoint.or(env_listen_endpoint.as_deref());
+            //
+            // The variable carries a *list*, because a node with a consumer on
+            // another machine listens both on loopback (for its same-machine
+            // consumers, whose transport can then carry shared memory) and on a
+            // routable address (for the remote one).
+            let env_listen = std::env::var(DORA_ZENOH_LISTEN_ENV).ok();
+            let env_listen_endpoints: Vec<String> = env_listen
+                .as_deref()
+                .map(|value| split_endpoints(value).collect())
+                .unwrap_or_default();
 
             let mut listen_eps: Vec<String> = Vec::new();
             if let Some(ep) = listen_endpoint {
                 listen_eps.push(ep.to_string());
             }
+            listen_eps.extend(env_listen_endpoints.iter().cloned());
             if let Some(peer) = inter_daemon_peer {
                 listen_eps.push(peer.to_string());
             }
@@ -499,7 +510,19 @@ pub async fn open_zenoh_session_with_listen(
                     // bound" query (unstable API gated behind the workspace
                     // `unstable` feature, already enabled in the root Cargo.toml
                     // zenoh dependency).
-                    if let Some(requested) = listen_inserted_into_configured {
+                    // Verify every endpoint we asked for, but only ever
+                    // *return* the caller's own: the env-supplied ones belong
+                    // to a node whose daemon planned them and already knows
+                    // them, so there they are a diagnostic, not a value to
+                    // propagate.
+                    let mut verify: Vec<&str> = listen_inserted_into_configured
+                        .iter()
+                        .map(String::as_str)
+                        .collect();
+                    if listen_configured {
+                        verify.extend(env_listen_endpoints.iter().map(String::as_str));
+                    }
+                    if !verify.is_empty() {
                         let bound_locators: Vec<String> = zenoh_session
                             .info()
                             .locators()
@@ -530,37 +553,41 @@ pub async fn open_zenoh_session_with_listen(
                         // than reach this check, which would read the mismatch
                         // as "the listener did not bind" and silently fall back
                         // to multicast scouting.
-                        let bound = bound_locators
-                            .iter()
-                            .any(|l| l.split(['?', '#']).next() == Some(requested.as_str()));
-                        if bound {
-                            effective_listen_endpoint = Some(requested);
-                        } else if connect_inserted {
-                            // We set explicit `connect/endpoints` above, so
-                            // multicast scouting was disabled for this session
-                            // (#1856). There is therefore NO discovery fallback:
-                            // peers already told to dial `{requested}` (e.g. via
-                            // the per-node `DORA_ZENOH_CONNECT` plan from #2716)
-                            // cannot reach this now-listener-less session, and it
-                            // cannot be scouted either — that edge is silently
-                            // partitioned. Do not claim "multicast scouting only"
-                            // here; that fallback does not exist in this mode and
-                            // the old message pointed debuggers the wrong way
-                            // (#2762).
-                            warn!(
-                                "zenoh session opened but listener for `{requested}` \
-                                 did not bind (actually bound: {bound_locators:?}); \
-                                 multicast scouting is disabled for this session \
-                                 (explicit connect endpoints are set), so peers told \
-                                 to dial `{requested}` have no fallback path to reach \
-                                 it (#2762)"
-                            );
-                        } else {
-                            warn!(
-                                "zenoh session opened but listener for `{requested}` \
-                                 did not bind (actually bound: {bound_locators:?}); \
-                                 falling back to multicast scouting for discovery"
-                            );
+                        for requested in verify {
+                            let bound = bound_locators
+                                .iter()
+                                .any(|l| l.split(['?', '#']).next() == Some(requested));
+                            if bound {
+                                if listen_inserted_into_configured.as_deref() == Some(requested) {
+                                    effective_listen_endpoint = Some(requested.to_string());
+                                }
+                            } else if connect_inserted {
+                                // We set explicit `connect/endpoints` above, so
+                                // multicast scouting was disabled for this session
+                                // (#1856). There is therefore NO discovery fallback:
+                                // peers already told to dial `{requested}` (e.g. via
+                                // the per-node `DORA_ZENOH_CONNECT` plan from #2716)
+                                // cannot reach this now-listener-less session, and it
+                                // cannot be scouted either — that edge is silently
+                                // partitioned. Do not claim "multicast scouting only"
+                                // here; that fallback does not exist in this mode and
+                                // the old message pointed debuggers the wrong way
+                                // (#2762).
+                                warn!(
+                                    "zenoh session opened but listener for `{requested}` \
+                                     did not bind (actually bound: {bound_locators:?}); \
+                                     multicast scouting is disabled for this session \
+                                     (explicit connect endpoints are set), so peers told \
+                                     to dial `{requested}` have no fallback path to reach \
+                                     it (#2762)"
+                                );
+                            } else {
+                                warn!(
+                                    "zenoh session opened but listener for `{requested}` \
+                                     did not bind (actually bound: {bound_locators:?}); \
+                                     falling back to multicast scouting for discovery"
+                                );
+                            }
                         }
                     }
                     zenoh_session

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -144,6 +144,152 @@ fn split_endpoints(value: &str) -> impl Iterator<Item = String> + '_ {
         .map(String::from)
 }
 
+/// Path to a JSON5 file whose contents are layered on top of the zenoh config
+/// dora computes.
+///
+/// The additive counterpart to [`ZENOH_CONFIG_PATH_ENV`], which replaces the
+/// whole config — including the per-node connect/listen plan the daemon builds,
+/// so a router named there ends up relaying even same-machine traffic. An
+/// overlay keeps that plan and adds to it, which is what "point this deployment
+/// at my routers" actually means. Setting both is refused rather than merged.
+///
+/// Inherited by spawned nodes (like [`ZENOH_CONFIG_PATH_ENV`]) so one variable
+/// covers a whole process tree, and refused from a descriptor's `env:` for the
+/// same reason: it is deployment wiring, not per-node configuration.
+#[cfg(feature = "zenoh")]
+pub const DORA_ZENOH_CONFIG_OVERLAY_ENV: &str = "DORA_ZENOH_CONFIG_OVERLAY";
+
+/// Operator-supplied zenoh settings to layer onto dora's computed config.
+///
+/// Split into the two endpoint lists, which **merge** with what dora computed,
+/// and everything else, which **replaces** it. Merging is what makes the
+/// overlay additive where it matters: naming a router under
+/// `connect.endpoints` adds a path to it without deleting the direct node links
+/// dora planned, which is exactly the difference from a wholesale
+/// [`ZENOH_CONFIG_PATH_ENV`].
+#[cfg(feature = "zenoh")]
+#[derive(Debug, Default, Clone)]
+pub struct ZenohOverlay {
+    /// Extra peers to dial, appended to dora's `connect/endpoints`.
+    pub connect_endpoints: Vec<String>,
+    /// Extra addresses to bind, appended to dora's `listen/endpoints`.
+    pub listen_endpoints: Vec<String>,
+    /// Every other setting, applied after dora's own inserts.
+    rest: serde_json::Map<String, serde_json::Value>,
+}
+
+#[cfg(feature = "zenoh")]
+impl ZenohOverlay {
+    /// Read the overlay named by [`DORA_ZENOH_CONFIG_OVERLAY_ENV`], if any.
+    ///
+    /// A named file that cannot be read or parsed is a hard error: the operator
+    /// asked for these settings, and a session silently opened without them is
+    /// the kind of "runs but talks to nobody" outcome that takes hours to
+    /// diagnose.
+    pub fn from_env() -> eyre::Result<Option<Self>> {
+        use eyre::Context;
+
+        let Some(path) = std::env::var_os(DORA_ZENOH_CONFIG_OVERLAY_ENV) else {
+            return Ok(None);
+        };
+        let path = std::path::PathBuf::from(path);
+        let contents = std::fs::read_to_string(&path).wrap_err_with(|| {
+            format!(
+                "failed to read the zenoh config overlay at `{}` named by {}",
+                path.display(),
+                DORA_ZENOH_CONFIG_OVERLAY_ENV
+            )
+        })?;
+        Self::parse(&contents)
+            .wrap_err_with(|| format!("invalid zenoh config overlay at `{}`", path.display()))
+            .map(Some)
+    }
+
+    /// Parse an overlay from JSON5 — zenoh's own config dialect, so an operator
+    /// can paste a fragment of a zenoh config file, comments and all.
+    pub fn parse(json5_str: &str) -> eyre::Result<Self> {
+        use eyre::{Context, eyre};
+
+        let value: serde_json::Value = json5::from_str(json5_str)
+            .map_err(|err| eyre!("{err}"))
+            .wrap_err(
+                "overlay must be a JSON5 object of zenoh config keys, e.g. \
+                 `{ connect: { endpoints: [\"tcp/10.0.0.1:7447\"] } }`",
+            )?;
+        let serde_json::Value::Object(mut object) = value else {
+            eyre::bail!("overlay must be a JSON5 object, not a bare value");
+        };
+
+        let mut overlay = Self::default();
+        for (key, endpoints) in [
+            ("connect", &mut overlay.connect_endpoints),
+            ("listen", &mut overlay.listen_endpoints),
+        ] {
+            let Some(serde_json::Value::Object(section)) = object.get_mut(key) else {
+                continue;
+            };
+            // Taken out of `rest` so the merged list survives: re-inserting the
+            // section wholesale afterwards would overwrite it.
+            let Some(value) = section.remove("endpoints") else {
+                continue;
+            };
+            let serde_json::Value::Array(list) = value else {
+                eyre::bail!("`{key}.endpoints` must be an array of endpoint strings");
+            };
+            for entry in list {
+                match entry {
+                    serde_json::Value::String(endpoint) => endpoints.push(endpoint),
+                    other => eyre::bail!(
+                        "`{key}.endpoints` must contain endpoint strings, found `{other}`"
+                    ),
+                }
+            }
+            // An emptied section would otherwise be re-inserted as `{}`.
+            if section.is_empty() {
+                object.remove(key);
+            }
+        }
+        overlay.rest = object;
+        Ok(overlay)
+    }
+
+    /// Apply everything except the endpoint lists, which the caller has already
+    /// merged into its own.
+    ///
+    /// Each setting is inserted at its deepest path, so an overlay touching one
+    /// subkey leaves its siblings alone. A path zenoh rejects is retried one
+    /// level up, because some sections only accept a whole-object write —
+    /// `insert_json5("gateway/south", ..)` is refused where
+    /// `insert_json5("gateway", ..)` is accepted (dora-rs/dora#2721).
+    fn apply(&self, config: &mut zenoh::Config) -> eyre::Result<()> {
+        for (key, value) in &self.rest {
+            insert_overlay_value(config, key, value)?;
+        }
+        Ok(())
+    }
+}
+
+/// Insert one overlay value, descending into objects and falling back to a
+/// whole-object write when a subpath is rejected. See [`ZenohOverlay::apply`].
+#[cfg(feature = "zenoh")]
+fn insert_overlay_value(
+    config: &mut zenoh::Config,
+    path: &str,
+    value: &serde_json::Value,
+) -> eyre::Result<()> {
+    if let serde_json::Value::Object(fields) = value
+        && !fields.is_empty()
+        && fields.iter().all(|(field, child)| {
+            insert_overlay_value(config, &format!("{path}/{field}"), child).is_ok()
+        })
+    {
+        return Ok(());
+    }
+    config
+        .insert_json5(path, &value.to_string())
+        .map_err(|err| eyre::eyre!("failed to apply zenoh config overlay key `{path}`: {err}"))
+}
+
 #[cfg(feature = "zenoh")]
 pub async fn open_zenoh_session(coordinator_addr: Option<IpAddr>) -> eyre::Result<zenoh::Session> {
     // Nodes and the coordinator have no in-process way to know, so
@@ -266,8 +412,27 @@ pub async fn open_zenoh_session_with_listen(
     // (not their requested endpoint) to advertise the listener to peers.
     let mut effective_listen_endpoint: Option<String> = None;
 
+    let overlay = ZenohOverlay::from_env()?;
+
     let zenoh_session = match std::env::var(zenoh::Config::DEFAULT_CONFIG_PATH_ENV) {
         Ok(path) => {
+            if overlay.is_some() {
+                // Merging the two would be guesswork: the file replaces the
+                // config dora computed, so there is no dora-side endpoint list
+                // left for the overlay's to append to, and "append to whatever
+                // the file happened to set" is not a rule anyone could predict.
+                eyre::bail!(
+                    "both {} and {} are set. {} replaces the whole zenoh \
+                     configuration, while {} layers onto the one dora computes — \
+                     keep one. Prefer the overlay: it adds your endpoints \
+                     without discarding the direct node-to-node links the daemon \
+                     plans for this dataflow.",
+                    zenoh::Config::DEFAULT_CONFIG_PATH_ENV,
+                    DORA_ZENOH_CONFIG_OVERLAY_ENV,
+                    zenoh::Config::DEFAULT_CONFIG_PATH_ENV,
+                    DORA_ZENOH_CONFIG_OVERLAY_ENV,
+                );
+            }
             let zenoh_config = zenoh::Config::from_file(&path)
                 .map_err(|e| eyre!(e))
                 .wrap_err_with(|| format!("failed to read zenoh config from {path}"))?;
@@ -354,6 +519,9 @@ pub async fn open_zenoh_session_with_listen(
             if let Some(peer) = inter_daemon_peer {
                 connect_eps.push(peer.to_string());
             }
+            if let Some(overlay) = &overlay {
+                connect_eps.extend(overlay.connect_endpoints.iter().cloned());
+            }
             // A duplicate dial is not fatal, but it is a wasted connection
             // attempt per duplicate and, when the peer is unreachable, a
             // second retry loop against it — which is exactly what keeps the
@@ -432,6 +600,9 @@ pub async fn open_zenoh_session_with_listen(
             if let Some(peer) = inter_daemon_peer {
                 listen_eps.push(peer.to_string());
             }
+            if let Some(overlay) = &overlay {
+                listen_eps.extend(overlay.listen_endpoints.iter().cloned());
+            }
             if !listen_eps.is_empty() {
                 let json = format!(
                     "[{}]",
@@ -492,6 +663,12 @@ pub async fn open_zenoh_session_with_listen(
                     .insert_json5("connect/endpoints", &coordinator_connect_endpoints(addr))
             {
                 warn!("failed to set zenoh connect/endpoints for coordinator {addr}: {err}");
+            }
+            // Last, so an operator's setting wins over dora's default for the
+            // same key. The endpoint lists are already merged above rather than
+            // overwritten here — that is what makes the overlay additive.
+            if let Some(overlay) = &overlay {
+                overlay.apply(&mut zenoh_config)?;
             }
             match zenoh::open(zenoh_config).await {
                 Ok(zenoh_session) => {
@@ -1198,6 +1375,81 @@ mod tests {
             .parse::<ZenohListen>()
             .expect_err("garbage must be rejected");
         assert!(err.contains("neither"), "unexpected error: {err}");
+    }
+
+    // The endpoint lists merge with dora's rather than replacing them — the
+    // whole difference between an overlay and `ZENOH_CONFIG`. Naming a router
+    // must add a path to it, not delete the direct node links dora planned.
+    #[cfg(feature = "zenoh")]
+    #[test]
+    fn an_overlay_splits_off_the_endpoint_lists() {
+        let overlay = ZenohOverlay::parse(
+            r#"{
+                // a router of our own, plus a second listen address
+                connect: { endpoints: ["tcp/10.0.0.1:7447"], timeout_ms: 5000 },
+                listen: { endpoints: ["tcp/10.0.0.2:7448"] },
+                scouting: { multicast: { enabled: true } },
+            }"#,
+        )
+        .expect("valid overlay");
+
+        assert_eq!(overlay.connect_endpoints, ["tcp/10.0.0.1:7447"]);
+        assert_eq!(overlay.listen_endpoints, ["tcp/10.0.0.2:7448"]);
+        // `endpoints` is taken out of the sections so re-applying them cannot
+        // overwrite the merged list; a section left empty is dropped entirely.
+        assert!(overlay.rest.contains_key("connect"));
+        assert!(!overlay.rest.contains_key("listen"));
+        assert!(overlay.rest.contains_key("scouting"));
+    }
+
+    // An overlay is applied to a real config: the values must land where zenoh
+    // expects them, and a subkey must not wipe its siblings.
+    #[cfg(feature = "zenoh")]
+    #[test]
+    fn an_overlay_applies_onto_a_zenoh_config() {
+        let mut config = zenoh::Config::default();
+        config
+            .insert_json5("connect/endpoints", r#"["tcp/127.0.0.1:1"]"#)
+            .expect("dora's own endpoints");
+
+        ZenohOverlay::parse(r#"{ connect: { timeout_ms: 5000 }, mode: "peer" }"#)
+            .expect("valid overlay")
+            .apply(&mut config)
+            .expect("overlay applies");
+
+        let rendered = config.to_string();
+        assert!(
+            rendered.contains("5000"),
+            "overlay value missing: {rendered}"
+        );
+        assert!(
+            rendered.contains("tcp/127.0.0.1:1"),
+            "writing a sibling subkey must not wipe dora's endpoints: {rendered}"
+        );
+    }
+
+    // A malformed overlay must fail loudly: the operator asked for these
+    // settings, and a session quietly opened without them is the "runs but
+    // talks to nobody" outcome that takes hours to diagnose.
+    #[cfg(feature = "zenoh")]
+    #[test]
+    fn a_malformed_overlay_is_rejected() {
+        for (bad, expected) in [
+            ("not an object", "object"),
+            (
+                r#"{ connect: { endpoints: "tcp/10.0.0.1:7447" } }"#,
+                "array",
+            ),
+            (r#"{ listen: { endpoints: [7447] } }"#, "endpoint strings"),
+        ] {
+            let err = ZenohOverlay::parse(bad)
+                .expect_err("must be rejected")
+                .to_string();
+            assert!(
+                err.contains(expected),
+                "unexpected error for `{bad}`: {err}"
+            );
+        }
     }
 
     // Concrete addresses pass validation whether or not they exist on this host:

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -279,11 +279,20 @@ fn insert_overlay_value(
 ) -> eyre::Result<()> {
     if let serde_json::Value::Object(fields) = value
         && !fields.is_empty()
-        && fields.iter().all(|(field, child)| {
-            insert_overlay_value(config, &format!("{path}/{field}"), child).is_ok()
-        })
     {
-        return Ok(());
+        let mut written = true;
+        for (field, child) in fields {
+            if insert_overlay_value(config, &format!("{path}/{field}"), child).is_err() {
+                written = false;
+                break;
+            }
+        }
+        if written {
+            return Ok(());
+        }
+        // Falling through re-writes the fields that did land, with the same
+        // values — `value` still contains them — so a partial descent is not
+        // left half-applied.
     }
     config
         .insert_json5(path, &value.to_string())

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -691,6 +691,89 @@ pub fn zenoh_bind_address_for(coordinator_addr: SocketAddr) -> IpAddr {
     local_address_toward(coordinator_addr).unwrap_or(LOCALHOST)
 }
 
+/// Where a daemon's zenoh listener binds: an address, and optionally the port.
+///
+/// Both forms are accepted from `--zenoh-listen`:
+///
+/// * `10.0.2.100` — the port is left to the OS. Peers learn the resulting
+///   endpoint by gossip, so this suits a deployment with a rendezvous
+///   (`--zenoh-peer`) or working multicast.
+/// * `10.0.2.100:5456`, `[fd7a:1::2]:5456` — a named port, which peers can dial
+///   without having discovered it first. This is what an explicit mesh needs:
+///   every daemon's endpoint has to be known before any of them has announced
+///   anything.
+///
+/// IPv6 must be bracketed when naming a port, because `fd7a:1::2:5456` is
+/// itself a valid IPv6 address and is read as one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ZenohListen {
+    /// Address to bind, which is also the address advertised to peers.
+    pub addr: IpAddr,
+    /// Port to bind, or `None` to let the OS pick one.
+    pub port: Option<u16>,
+}
+
+impl ZenohListen {
+    /// The endpoint to request, reserving an ephemeral port if none was named.
+    ///
+    /// A named port skips the reservation entirely: it has no reserve→bind
+    /// window for another process to slip into, and zenoh's own bind is the
+    /// only claim on it.
+    pub fn endpoint(&self) -> std::io::Result<String> {
+        match self.port {
+            Some(port) => Ok(zenoh_endpoint(self.addr, port)),
+            None => reserve_zenoh_endpoint(self.addr),
+        }
+    }
+}
+
+impl std::fmt::Display for ZenohListen {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.port {
+            Some(port) => write!(f, "{}", SocketAddr::new(self.addr, port)),
+            None => write!(f, "{}", self.addr),
+        }
+    }
+}
+
+impl std::str::FromStr for ZenohListen {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // `SocketAddr` first: `10.0.2.100:5456` is not an `IpAddr`, while a
+        // bare `::1` is not a `SocketAddr`, so neither form is stolen by the
+        // other. The one genuine ambiguity — unbracketed IPv6 with a port —
+        // resolves to "address", which is why the docs above insist on
+        // brackets.
+        let listen = if let Ok(socket) = s.parse::<SocketAddr>() {
+            Self {
+                addr: socket.ip(),
+                port: Some(socket.port()),
+            }
+        } else if let Ok(addr) = s.parse::<IpAddr>() {
+            Self { addr, port: None }
+        } else {
+            return Err(format!(
+                "`{s}` is neither an IP address (`10.0.2.100`) nor an address \
+                 with a port (`10.0.2.100:5456`, `[fd7a:1::2]:5456`)"
+            ));
+        };
+        if listen.port == Some(0) {
+            // Port 0 binds an ephemeral port, which is fine, but the endpoint
+            // we advertise would still say `:0` — no peer could dial it, and
+            // the `info().locators()` check would read the mismatch as "the
+            // listener did not bind". Omitting the port asks for the same thing
+            // and reserves a concrete one to advertise.
+            return Err(format!(
+                "`{s}` names port 0; omit the port to let the OS pick one \
+                 (dora then advertises the concrete port it reserved)"
+            ));
+        }
+        validate_zenoh_listen(listen.addr).map_err(|err| format!("{err}"))?;
+        Ok(listen)
+    }
+}
+
 /// Reject a zenoh listen address that cannot be advertised to peers.
 ///
 /// Only the wildcard is rejected here, and only because it is *structurally*
@@ -1041,6 +1124,53 @@ mod tests {
             .parse()
             .expect("reserved port is numeric");
         assert_eq!(zenoh_endpoint(LOCALHOST, port), reserved);
+    }
+
+    // `--zenoh-listen` takes both forms, and which one was given decides
+    // whether peers can dial this daemon before it has announced anything.
+    #[test]
+    fn zenoh_listen_parses_address_with_and_without_port() {
+        let addr_only: ZenohListen = "10.0.2.100".parse().unwrap();
+        assert_eq!(addr_only.addr, "10.0.2.100".parse::<IpAddr>().unwrap());
+        assert_eq!(addr_only.port, None);
+
+        let with_port: ZenohListen = "10.0.2.100:5456".parse().unwrap();
+        assert_eq!(with_port.port, Some(5456));
+        assert_eq!(with_port.endpoint().unwrap(), "tcp/10.0.2.100:5456");
+
+        // IPv6 needs brackets to carry a port; unbracketed, the trailing group
+        // is part of the address. Both parse — they just mean different things,
+        // which is why the flag docs insist on brackets.
+        let v6_port: ZenohListen = "[fd7a:1::2]:5456".parse().unwrap();
+        assert_eq!(v6_port.port, Some(5456));
+        assert_eq!(v6_port.endpoint().unwrap(), "tcp/[fd7a:1::2]:5456");
+        let v6_bare: ZenohListen = "fd7a:1::2:5456".parse().unwrap();
+        assert_eq!(v6_bare.port, None);
+    }
+
+    // A wildcard has nothing to advertise, and port 0 would advertise `:0`.
+    // Both are rejected at parse time so the operator hears about it at the
+    // command line rather than as a silent partition later.
+    #[test]
+    fn zenoh_listen_rejects_unadvertisable_forms() {
+        for bad in ["0.0.0.0", "0.0.0.0:5456", "::"] {
+            let err = bad
+                .parse::<ZenohListen>()
+                .expect_err("wildcard must be rejected");
+            assert!(
+                err.contains("concrete"),
+                "unexpected error for {bad}: {err}"
+            );
+        }
+        let err = "10.0.2.100:0"
+            .parse::<ZenohListen>()
+            .expect_err("port 0 must be rejected");
+        assert!(err.contains("port 0"), "unexpected error: {err}");
+
+        let err = "not-an-address"
+            .parse::<ZenohListen>()
+            .expect_err("garbage must be rejected");
+        assert!(err.contains("neither"), "unexpected error: {err}");
     }
 
     // Concrete addresses pass validation whether or not they exist on this host:

--- a/tests/multi-daemon-e2e.rs
+++ b/tests/multi-daemon-e2e.rs
@@ -68,14 +68,13 @@ fn ensure_built() {
 /// The local address another machine would reach this host at, or `None` when
 /// there is no route out (an offline sandbox).
 ///
-/// `connect` on a UDP socket sends no packets — it only asks the routing table
-/// which source address applies — which is the same trick the daemon uses to
-/// derive its own zenoh bind address.
+/// Derived by the same helper the daemon uses for its own zenoh bind address,
+/// so the test asks the routing table exactly the question the daemon would.
+/// It answers loopback when it learns nothing, which here means "cannot test".
 fn routable_local_addr() -> Option<std::net::IpAddr> {
-    let socket = std::net::UdpSocket::bind("0.0.0.0:0").ok()?;
-    socket.connect("8.8.8.8:53").ok()?;
-    let addr = socket.local_addr().ok()?.ip();
-    (!addr.is_loopback() && !addr.is_unspecified()).then_some(addr)
+    let off_host = SocketAddr::from(([8, 8, 8, 8], 53));
+    let addr = dora_core::topics::zenoh_bind_address_for(off_host);
+    (!addr.is_loopback()).then_some(addr)
 }
 
 /// Wait for a child to exit, killing it if it outstays `timeout`.
@@ -451,7 +450,8 @@ fn cross_machine_nodes_link_directly_over_an_explicit_mesh() {
 
     let ports = free_ports(4);
     let (coordinator_port, zenoh_a, zenoh_b) = (ports[0], ports[1], ports[2]);
-    let mut daemon_listen_ports = [ports[3]].into_iter();
+    // Only one daemon can hold the default node-listen port on a shared host.
+    let node_listen_ports = [None, Some(ports[3])];
     let coord_log = tmp.path().join("coordinator.log");
     let coord_out = std::fs::File::create(&coord_log).expect("create coordinator log");
     let coord_err = coord_out.try_clone().expect("clone coordinator log");
@@ -484,7 +484,9 @@ fn cross_machine_nodes_link_directly_over_an_explicit_mesh() {
     // the other one, with multicast off. No rendezvous, no gossip — the shape
     // `dora cluster up` derives from a cluster.yml.
     let daemon_log = |machine: &str| tmp.path().join(format!("daemon-{machine}.log"));
-    for (machine, listen, connect) in [("A", zenoh_a, zenoh_b), ("B", zenoh_b, zenoh_a)] {
+    let daemons = [("A", zenoh_a, zenoh_b), ("B", zenoh_b, zenoh_a)];
+    for ((machine, listen, connect), node_listen_port) in daemons.into_iter().zip(node_listen_ports)
+    {
         let log = daemon_log(machine);
         let out = std::fs::File::create(&log).expect("create daemon log");
         let err = out.try_clone().expect("clone daemon log");
@@ -505,8 +507,7 @@ fn cross_machine_nodes_link_directly_over_an_explicit_mesh() {
             .env("RUST_LOG", "dora_daemon=debug")
             .stdout(Stdio::from(out))
             .stderr(Stdio::from(err));
-        // Only one daemon can hold the default node port on a shared host.
-        if let Some(port) = daemon_listen_ports.next() {
+        if let Some(port) = node_listen_port {
             command.arg("--local-listen-port").arg(port.to_string());
         }
         deployment

--- a/tests/multi-daemon-e2e.rs
+++ b/tests/multi-daemon-e2e.rs
@@ -45,11 +45,52 @@ static BUILD: Once = Once::new();
 fn ensure_built() {
     BUILD.call_once(|| {
         let status = Command::new("cargo")
-            .args(["build", "-p", "dora-cli", "-p", "reconnect-survivor-node"])
+            .args([
+                "build",
+                "-p",
+                "dora-cli",
+                "-p",
+                "reconnect-survivor-node",
+                // Producer/consumer pair for the cross-machine data test: the
+                // sink fails its node if no `random` value ever arrives, so a
+                // finished dataflow is proof of delivery.
+                "-p",
+                "multiple-daemons-example-node",
+                "-p",
+                "multiple-daemons-example-sink",
+            ])
             .status()
             .expect("failed to run cargo build");
         assert!(status.success(), "failed to build test prerequisites");
     });
+}
+
+/// The local address another machine would reach this host at, or `None` when
+/// there is no route out (an offline sandbox).
+///
+/// `connect` on a UDP socket sends no packets — it only asks the routing table
+/// which source address applies — which is the same trick the daemon uses to
+/// derive its own zenoh bind address.
+fn routable_local_addr() -> Option<std::net::IpAddr> {
+    let socket = std::net::UdpSocket::bind("0.0.0.0:0").ok()?;
+    socket.connect("8.8.8.8:53").ok()?;
+    let addr = socket.local_addr().ok()?.ip();
+    (!addr.is_loopback() && !addr.is_unspecified()).then_some(addr)
+}
+
+/// Wait for a child to exit, killing it if it outstays `timeout`.
+fn wait_for_exit(child: &mut Child, timeout: Duration) -> Option<std::process::ExitStatus> {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        match child.try_wait() {
+            Ok(Some(status)) => return Some(status),
+            Ok(None) => std::thread::sleep(Duration::from_millis(200)),
+            Err(_) => return None,
+        }
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+    None
 }
 
 fn target_dir() -> PathBuf {
@@ -356,6 +397,166 @@ fn node_added_to_distributed_dataflow_finishes_init() {
             "the node added at runtime never finished `Node()` init: its \
              subscribe was parked with nothing left to answer it \
              (dora-rs/dora#2938)",
+        );
+    }
+}
+
+/// A cross-machine edge must survive being wired as an explicit zenoh mesh
+/// with multicast off — the deployment shape a mesh VPN forces — and the
+/// daemons must trade their nodes' endpoints over it, which is what lets the
+/// producer and consumer link up directly instead of relaying through both
+/// daemons.
+///
+/// Delivery is asserted by construction: `multiple-daemons-example-sink` fails
+/// its node if no `random` value ever arrives, so a dataflow that finishes
+/// successfully is proof that the cross-machine edge carried data. The daemon
+/// log then shows *how*: machine B resolved machine A's node endpoint, so the
+/// two node processes had a direct link rather than two daemon hops.
+#[test]
+fn cross_machine_nodes_link_directly_over_an_explicit_mesh() {
+    ensure_built();
+
+    // The endpoint a remote consumer dials has to be one it can reach, and dora
+    // refuses to advertise loopback for that (it would point the peer at its
+    // own machine). Without a routable address there is nothing to test.
+    let Some(routable) = routable_local_addr() else {
+        eprintln!("skipping: no routable local address on this host");
+        return;
+    };
+
+    let dora = bin("dora");
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let dataflow_yml = tmp.path().join("dataflow.yml");
+
+    // Producer on A, consumer on B, and no same-machine consumer for `random` —
+    // so the only path from producer to sink is the cross-machine one.
+    std::fs::write(
+        &dataflow_yml,
+        format!(
+            "nodes:\n  \
+             - id: producer\n    \
+               deploy:\n      machine: A\n    \
+               path: {producer}\n    \
+               inputs:\n      tick: dora/timer/millis/10\n    \
+               outputs:\n      - random\n  \
+             - id: sink\n    \
+               deploy:\n      machine: B\n    \
+               path: {sink}\n    \
+               inputs:\n      random: producer/random\n",
+            producer = bin("multiple-daemons-example-node").display(),
+            sink = bin("multiple-daemons-example-sink").display(),
+        ),
+    )
+    .expect("write dataflow yml");
+
+    let ports = free_ports(4);
+    let (coordinator_port, zenoh_a, zenoh_b) = (ports[0], ports[1], ports[2]);
+    let mut daemon_listen_ports = [ports[3]].into_iter();
+    let coord_log = tmp.path().join("coordinator.log");
+    let coord_out = std::fs::File::create(&coord_log).expect("create coordinator log");
+    let coord_err = coord_out.try_clone().expect("clone coordinator log");
+
+    let mut deployment = Deployment {
+        dora: dora.clone(),
+        coordinator_port,
+        children: vec![
+            Command::new(&dora)
+                .arg("coordinator")
+                .arg("--port")
+                .arg(coordinator_port.to_string())
+                .arg("--store")
+                .arg(format!(
+                    "redb:{}",
+                    tmp.path().join("coordinator.redb").display()
+                ))
+                .stdout(Stdio::from(coord_out))
+                .stderr(Stdio::from(coord_err))
+                .spawn()
+                .expect("failed to spawn coordinator"),
+        ],
+        logs: vec![coord_log],
+    };
+    if !wait_until(|| port_open(coordinator_port), Duration::from_secs(20)) {
+        deployment.fail("coordinator did not accept connections within 20s");
+    }
+
+    // The mesh: each daemon listens on a port its peer can predict and dials
+    // the other one, with multicast off. No rendezvous, no gossip — the shape
+    // `dora cluster up` derives from a cluster.yml.
+    let daemon_log = |machine: &str| tmp.path().join(format!("daemon-{machine}.log"));
+    for (machine, listen, connect) in [("A", zenoh_a, zenoh_b), ("B", zenoh_b, zenoh_a)] {
+        let log = daemon_log(machine);
+        let out = std::fs::File::create(&log).expect("create daemon log");
+        let err = out.try_clone().expect("clone daemon log");
+        let mut command = Command::new(&dora);
+        command
+            .arg("daemon")
+            .arg("--machine-id")
+            .arg(machine)
+            .arg("--coordinator-port")
+            .arg(coordinator_port.to_string())
+            .arg("--zenoh-listen")
+            .arg(format!("{routable}:{listen}"))
+            .arg("--zenoh-connect")
+            .arg(format!("tcp/{routable}:{connect}"))
+            .arg("--zenoh-no-multicast")
+            // The endpoint exchange logs its result at debug, and the daemon's
+            // own filter pins `dora_daemon=info` unless RUST_LOG names it.
+            .env("RUST_LOG", "dora_daemon=debug")
+            .stdout(Stdio::from(out))
+            .stderr(Stdio::from(err));
+        // Only one daemon can hold the default node port on a shared host.
+        if let Some(port) = daemon_listen_ports.next() {
+            command.arg("--local-listen-port").arg(port.to_string());
+        }
+        deployment
+            .children
+            .push(command.spawn().expect("failed to spawn daemon"));
+        deployment.logs.push(log);
+    }
+
+    if !wait_until(
+        || {
+            connected_machines(coordinator_port)
+                .map(|m| m.iter().any(|id| id == "A") && m.iter().any(|id| id == "B"))
+                .unwrap_or(false)
+        },
+        Duration::from_secs(30),
+    ) {
+        deployment.fail("daemons A and B did not both register within 30s");
+    }
+
+    // Attached (no `--detach`), so the exit status carries the dataflow's
+    // result: the sink bails if it never received a cross-machine value.
+    let mut start = Command::new(&dora)
+        .arg("start")
+        .arg(&dataflow_yml)
+        .arg("--name")
+        .arg("cross-machine-direct")
+        .arg("--coordinator-port")
+        .arg(coordinator_port.to_string())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to run dora start");
+    let Some(status) = wait_for_exit(&mut start, Duration::from_secs(120)) else {
+        deployment.fail("the cross-machine dataflow did not finish within 120s");
+    };
+    if !status.success() {
+        deployment.fail(format!(
+            "the cross-machine dataflow failed ({status}); the sink fails its \
+             node when no `random` value arrives, so this is a delivery failure"
+        ));
+    }
+
+    // Delivery is proven above; this is the *how*. Machine B resolving A's node
+    // endpoint is what gives the sink something to dial, so without it the edge
+    // would have quietly fallen back to two daemon hops.
+    let log_b = std::fs::read_to_string(daemon_log("B")).unwrap_or_default();
+    if !log_b.contains("remote node zenoh endpoints") {
+        deployment.fail(
+            "daemon B never resolved a remote node endpoint: the cross-machine \
+             edge fell back to daemon forwarding instead of a direct node link",
         );
     }
 }


### PR DESCRIPTION
Cross-machine dataflows currently relay every edge through two daemons, and the daemons themselves only find each other by multicast or a single gossip rendezvous — neither of which works on a mesh VPN, the deployment we want to support. This wires both tiers explicitly and takes the daemon off the cross-machine hot path.

**Daemon tier.** `--zenoh-listen` takes an optional port and `--zenoh-connect` names the peers to dial, so every daemon listens where its peers can predict and dials every other one — the clique zenoh 1.9 requires, with no multicast and no waiting for gossip. `dora cluster up` derives that mesh from `cluster.yml`, using `host` when it is an IP (the common tailnet case needs no new configuration) with per-machine `zenoh_addr` / `zenoh_port` overrides. Deriving nothing is preferred over deriving half a mesh: explicit connect endpoints disable multicast for the daemons that have them, so a partial mesh partitions the rest.

**Node tier.** A node consumed from another machine now also listens on a routable address, the daemons trade those endpoints over a zenoh queryable before spawning anything, and the consumer dials the producer directly. The trade has to happen up front because zenoh reads `connect/endpoints` once at startup and never re-reads it (verified in 1.9.0's `orchestrator.rs`). A remote static consumer becomes a required acker instead of pinning the output, so the switch is proven end-to-end before it is used — until the ack lands, and if it never lands, the output stays on the lossless daemon path. Edges that keep the daemon path: a dynamic consumer on another machine, a producer with no dialable address, an exchange that timed out, and a consumer declaring `input_timeout` (its deadline is refreshed only by its own daemon, so a direct send would leave liveness detection silently disarmed).

**Routers.** `--zenoh-config-overlay` layers a JSON5 file onto the config dora computes, appending to the endpoint lists rather than replacing them. `ZENOH_CONFIG` remains the wholesale escape hatch, but it discards the per-node plan — so a router named there relays same-machine traffic too, off the host and back if it runs elsewhere. Setting both is refused.

Also corrects `examples/multiple-daemons/README.md`, whose "run a `zenohd` per subnet" advice does not work for the NAT case it is offered for (a router relays 0/5 for non-clique peers under zenoh 1.9, measured in #2721), and the `plan_zenoh_peering` caveat claiming #2762 causes silent data loss — since #2891 an unproven route freezes on the daemon path, and holding the reservation as that issue proposes cannot work, because a held `TcpListener` is exactly what makes the node's own bind fail.

Design decisions here were made by @phil-opp; #2721 was blocked waiting on them.

## Validation

**Class**: C (daemon spawn wiring and the data path)

- `make qa-fast` equivalents: `cargo fmt --all -- --check` ✅, `cargo clippy --all -- -D warnings` ✅ (whole workspace, C++ crates included)
- `cargo test --all` (Python crates and `dora-examples` excluded per CLAUDE.md): ✅
- `cargo check --examples`: ✅
- `cargo test --test fault-tolerance-e2e -- --test-threads=1`: ✅ 11 passed
- Contract tests: 4 passed, 4 failed — all four failures are the Python/`uv` tests (`uv` is not installed in this dev container; the daemon log shows `spawning: uv run python -u ...` then a non-zero exit). Needs a re-run where `uv` is present.
- Targeted feature test: `tests/multi-daemon-e2e.rs::cross_machine_nodes_link_directly_over_an_explicit_mesh` — two daemons on an explicit mesh with multicast off, producer on one machine and consumer on the other. Delivery is asserted by construction (the sink fails its node if no cross-machine value arrives) and the daemon log proves the endpoint exchange carried it. Verified as a real guard: with `DORA_ZENOH_ENDPOINT_EXCHANGE_TIMEOUT_MS=0` the dataflow still delivers (daemon fallback intact) but the test fails on the direct-link assertion.
- `/code-review high`: ran; three findings, all fixed in `fix(daemon): keep liveness, mesh and event-loop guarantees intact` (the `input_timeout` regression, a mesh endpoint collision for two daemons on one host, and the exchange blocking the daemon event loop with an unbounded `declare_queryable`).
- `/simplify`: ran; three cleanups applied, no behavior change.

Closes part of #2721. Corrects the #2762 analysis without closing it (the reserve→bind window remains, now accurately described).
