### PR TITLE
fix(cli): reject a leading dash in cluster `zenoh_peer`

### DIFF
--- a/binaries/cli/src/command/cluster/config.rs
+++ b/binaries/cli/src/command/cluster/config.rs
@@ -176,6 +176,14 @@ fn validate_no_leading_dash(what: &str, value: &str) -> eyre::Result<()> {
 /// `[`/`]` around an IPv6 literal like `tcp/[::1]:7447`. It still rejects
 /// whitespace and shell metacharacters (`;`, `|`, `$`, backtick, ...), so the
 /// value cannot break out of the remote command.
+///
+/// It also rejects a leading `-`, the same guard `validate_shell_safe` applies
+/// at a token start: `zenoh_peer` is interpolated as the whole argument of
+/// `dora daemon --zenoh-peer {ep}`, so a value like `-tcp/1.2.3.4:5456` is
+/// parsed by the remote daemon's clap as an option flag instead of the
+/// endpoint, and the daemon never starts — surfacing only later as a confusing
+/// "daemon(s) did not register" timeout. No legitimate Zenoh endpoint begins
+/// with `-`.
 fn validate_endpoint_shell_safe(what: &str, value: &str) -> eyre::Result<()> {
     if let Some(ch) = value.chars().find(|c| {
         !c.is_ascii_alphanumeric() && !matches!(c, '_' | '-' | '.' | '/' | ':' | '[' | ']')
@@ -183,6 +191,9 @@ fn validate_endpoint_shell_safe(what: &str, value: &str) -> eyre::Result<()> {
         bail!(
             "{what} contains invalid character `{ch}` -- only [a-zA-Z0-9_.:/] and `[`/`]` are allowed"
         );
+    }
+    if value.starts_with('-') {
+        bail!("{what} must not start with `-`");
     }
     Ok(())
 }
@@ -416,6 +427,24 @@ mod tests {
             err.contains("invalid character") && err.contains("zenoh_peer"),
             "malicious zenoh_peer should be rejected, got: {err}"
         );
+    }
+
+    #[test]
+    fn reject_zenoh_peer_with_leading_dash() {
+        // A leading `-` passes the endpoint charset check but makes the remote
+        // `dora daemon --zenoh-peer {ep}` parse the endpoint as an option flag,
+        // so the daemon silently fails to start. Reject it up front, matching
+        // the guard on the machine id / label key.
+        for bad in ["-tcp/1.2.3.4:5456", "--zenoh-peer", "-"] {
+            let f = write_yaml(&format!(
+                "coordinator:\n  addr: 10.0.0.1\nzenoh_peer: \"{bad}\"\nmachines:\n  - id: a\n    host: h\n"
+            ));
+            let err = ClusterConfig::load(f.path()).unwrap_err().to_string();
+            assert!(
+                err.contains("must not start with `-`") && err.contains("zenoh_peer"),
+                "zenoh_peer `{bad}` should be rejected, got: {err}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Issue

`ClusterConfig::validate` (`binaries/cli/src/command/cluster/config.rs`) runs the `zenoh_peer` field through `validate_endpoint_shell_safe`. Its call-site comment states the field *"needs the same guard as the id/labels below"*, but the function only performed a charset check — it was **missing the leading-dash guard** that the sibling `validate_shell_safe` (used for `machine.id` and label keys, with `at_token_start = true`) applies.

`zenoh_peer` is interpolated as the whole argument of the remote command:

```
dora daemon ... --zenoh-peer {ep} ...        # binaries/cli/src/command/cluster/up.rs:70
```

So a value like `zenoh_peer: "-tcp/1.2.3.4:5456"` passes validation, but on the remote host the daemon's clap parser (`--zenoh-peer` has no `allow_hyphen_values`) treats `-tcp/...` as an unknown **option flag** rather than the endpoint. The daemon then fails to start, and the user only sees a confusing *"daemon(s) did not register"* timeout later — exactly the failure mode the id/labels leading-dash guard was added to prevent (see the existing `reject_id_with_leading_dash` / `reject_label_key_with_leading_dash` tests).

## Fix

Add the same leading-dash rejection to `validate_endpoint_shell_safe`, so `zenoh_peer` is now validated consistently with `machine.id` and label keys. No legitimate Zenoh endpoint (`tcp/…`, `udp/…`, `tls/…`, `quic/…`, `tcp/[::1]:7447`, …) begins with `-`, so nothing valid is rejected.

```rust
if value.starts_with('-') {
    bail!("{what} must not start with `-`");
}
```

A regression test (`reject_zenoh_peer_with_leading_dash`) covers `-tcp/1.2.3.4:5456`, `--zenoh-peer`, and `-`. The existing `accept_ipv6_zenoh_peer` test confirms `tcp/[::1]:7447` still validates.

## Validation

- `cargo test -p dora-cli --lib -- config::tests` → **25 passed, 0 failed** (incl. the new test)
- `cargo fmt -p dora-cli -- --check` → clean
- `cargo clippy -p dora-cli --all-targets -- -D warnings` → clean

Scoped to `binaries/cli/src/command/cluster/config.rs` (one guard clause + one test); no behavior change for any valid endpoint.

---

⚠️ *This is a machine-generated pull request authored by Claude (Claude Code). A human should review it before merging.*

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBFpa44oHdDJxVTphFBTsV)_