### PR TITLE
fix(metrics): honor `DORA_OTLP_ENDPOINT` for system/process metrics

### DIFF
--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -3236,12 +3236,12 @@ pub fn init_tracing(
     // attempt to connect to `localhost:4317` on every node startup. Mirrors
     // the gating applied to tracing above.
     #[cfg(feature = "metrics")]
-    if std::env::var("DORA_OTLP_ENDPOINT").is_ok() {
+    if let Ok(endpoint) = std::env::var("DORA_OTLP_ENDPOINT") {
         let id = format!("{dataflow_id}/{node_id}");
         let monitor_task = async move {
             use dora_metrics::run_metrics_monitor;
 
-            if let Err(e) = run_metrics_monitor(id.clone())
+            if let Err(e) = run_metrics_monitor(id.clone(), &endpoint)
                 .await
                 .wrap_err("metrics monitor exited unexpectedly")
             {

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -253,12 +253,12 @@ async fn start_with_events(
     // Start WS server
     #[cfg(feature = "metrics")]
     let _meter_provider = {
-        // Honor `DORA_OTLP_ENDPOINT` when set, falling back to the OTLP gRPC
-        // default so the previous (endpoint-less) behaviour is preserved when
-        // it is unset.
-        let endpoint = std::env::var("DORA_OTLP_ENDPOINT")
-            .unwrap_or_else(|_| "http://localhost:4317".to_string());
-        let provider = dora_metrics::init_metrics(&endpoint)?;
+        // Pin the exporter to `DORA_OTLP_ENDPOINT` when set; when unset, pass
+        // `None` so the previous (endpoint-less) behaviour is preserved — the
+        // exporter then resolves its target from the OTel-standard
+        // `OTEL_EXPORTER_OTLP_ENDPOINT` env vars (defaulting to localhost).
+        let endpoint = std::env::var("DORA_OTLP_ENDPOINT").ok();
+        let provider = dora_metrics::init_metrics(endpoint.as_deref())?;
         opentelemetry::global::set_meter_provider(provider.clone());
         provider
     };

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -253,7 +253,12 @@ async fn start_with_events(
     // Start WS server
     #[cfg(feature = "metrics")]
     let _meter_provider = {
-        let provider = dora_metrics::init_metrics()?;
+        // Honor `DORA_OTLP_ENDPOINT` when set, falling back to the OTLP gRPC
+        // default so the previous (endpoint-less) behaviour is preserved when
+        // it is unset.
+        let endpoint = std::env::var("DORA_OTLP_ENDPOINT")
+            .unwrap_or_else(|_| "http://localhost:4317".to_string());
+        let provider = dora_metrics::init_metrics(&endpoint)?;
         opentelemetry::global::set_meter_provider(provider.clone());
         provider
     };

--- a/binaries/runtime-api/src/lib.rs
+++ b/binaries/runtime-api/src/lib.rs
@@ -181,12 +181,12 @@ async fn run(
     // so it must be spawned rather than awaited inline. Mirrors the gating and
     // spawning used by the node API (`apis/rust/node/src/node/mod.rs`).
     #[cfg(feature = "metrics")]
-    if std::env::var("DORA_OTLP_ENDPOINT").is_ok() {
+    if let Ok(endpoint) = std::env::var("DORA_OTLP_ENDPOINT") {
         use dora_metrics::run_metrics_monitor;
 
         let meter_id = config.node_id.to_string();
         tokio::spawn(async move {
-            if let Err(e) = run_metrics_monitor(meter_id)
+            if let Err(e) = run_metrics_monitor(meter_id, &endpoint)
                 .await
                 .wrap_err("metrics monitor exited unexpectedly")
             {

--- a/libraries/extensions/telemetry/metrics/src/lib.rs
+++ b/libraries/extensions/telemetry/metrics/src/lib.rs
@@ -22,17 +22,23 @@
 
 use eyre::{Result, WrapErr};
 use opentelemetry::{InstrumentationScope, global};
-use opentelemetry_otlp::MetricExporter;
+use opentelemetry_otlp::{MetricExporter, WithExportConfig};
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use opentelemetry_system_metrics::init_process_observer;
-/// Init opentelemetry meter
+/// Init opentelemetry meter, exporting via OTLP to `endpoint`.
 ///
-/// Use the default Opentelemetry exporter with default config
-/// TODO: Make Opentelemetry configurable
-///
-pub fn init_metrics() -> Result<SdkMeterProvider> {
+/// `endpoint` should be the OTLP endpoint the caller derives from
+/// `DORA_OTLP_ENDPOINT` (e.g. `"http://localhost:4317"`). Passing it
+/// explicitly avoids the previous behaviour where the metric exporter ignored
+/// `DORA_OTLP_ENDPOINT` and always fell back to the OTLP gRPC default
+/// (`http://localhost:4317`), so system/process metrics silently diverged from
+/// the trace exporter (which already threads the endpoint through) whenever a
+/// remote collector was configured. Mirrors
+/// `dora_tracing::telemetry::init_meter_provider`.
+pub fn init_metrics(endpoint: &str) -> Result<SdkMeterProvider> {
     let exporter = MetricExporter::builder()
         .with_tonic()
+        .with_endpoint(endpoint)
         .build()
         .wrap_err("failed to create metric exporter")?;
 
@@ -41,8 +47,8 @@ pub fn init_metrics() -> Result<SdkMeterProvider> {
         .build())
 }
 
-pub async fn run_metrics_monitor(meter_id: String) -> Result<()> {
-    let meter_provider = init_metrics()?;
+pub async fn run_metrics_monitor(meter_id: String, endpoint: &str) -> Result<()> {
+    let meter_provider = init_metrics(endpoint)?;
     global::set_meter_provider(meter_provider.clone());
     let scope = InstrumentationScope::builder(meter_id)
         .with_version("1.0")

--- a/libraries/extensions/telemetry/metrics/src/lib.rs
+++ b/libraries/extensions/telemetry/metrics/src/lib.rs
@@ -25,20 +25,28 @@ use opentelemetry::{InstrumentationScope, global};
 use opentelemetry_otlp::{MetricExporter, WithExportConfig};
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use opentelemetry_system_metrics::init_process_observer;
-/// Init opentelemetry meter, exporting via OTLP to `endpoint`.
+/// Init opentelemetry meter.
 ///
-/// `endpoint` should be the OTLP endpoint the caller derives from
-/// `DORA_OTLP_ENDPOINT` (e.g. `"http://localhost:4317"`). Passing it
-/// explicitly avoids the previous behaviour where the metric exporter ignored
-/// `DORA_OTLP_ENDPOINT` and always fell back to the OTLP gRPC default
-/// (`http://localhost:4317`), so system/process metrics silently diverged from
-/// the trace exporter (which already threads the endpoint through) whenever a
-/// remote collector was configured. Mirrors
-/// `dora_tracing::telemetry::init_meter_provider`.
-pub fn init_metrics(endpoint: &str) -> Result<SdkMeterProvider> {
-    let exporter = MetricExporter::builder()
-        .with_tonic()
-        .with_endpoint(endpoint)
+/// When `endpoint` is `Some`, the OTLP exporter is pinned to it explicitly —
+/// pass the `DORA_OTLP_ENDPOINT` value here (e.g. `"http://localhost:4317"`).
+/// This avoids the previous behaviour where the metric exporter ignored
+/// `DORA_OTLP_ENDPOINT` and always fell back to the OTLP gRPC default, so
+/// system/process metrics silently diverged from the trace exporter (which
+/// already threads the endpoint through) whenever a remote collector was
+/// configured. Mirrors `dora_tracing::telemetry::init_meter_provider`.
+///
+/// When `endpoint` is `None`, no endpoint is set programmatically, so the
+/// exporter resolves its target from the OTel-standard
+/// `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` env
+/// vars (defaulting to `http://localhost:4317`). A programmatic
+/// `.with_endpoint()` would take precedence over those vars, so it must be
+/// skipped when `DORA_OTLP_ENDPOINT` is unset to keep them working.
+pub fn init_metrics(endpoint: Option<&str>) -> Result<SdkMeterProvider> {
+    let mut builder = MetricExporter::builder().with_tonic();
+    if let Some(endpoint) = endpoint {
+        builder = builder.with_endpoint(endpoint);
+    }
+    let exporter = builder
         .build()
         .wrap_err("failed to create metric exporter")?;
 
@@ -48,7 +56,7 @@ pub fn init_metrics(endpoint: &str) -> Result<SdkMeterProvider> {
 }
 
 pub async fn run_metrics_monitor(meter_id: String, endpoint: &str) -> Result<()> {
-    let meter_provider = init_metrics(endpoint)?;
+    let meter_provider = init_metrics(Some(endpoint))?;
     global::set_meter_provider(meter_provider.clone());
     let scope = InstrumentationScope::builder(meter_id)
         .with_version("1.0")


### PR DESCRIPTION
## Issue

`dora_metrics::init_metrics` (`libraries/extensions/telemetry/metrics/src/lib.rs`) built its OTLP `MetricExporter` **without** calling `.with_endpoint(...)`:

```rust
let exporter = MetricExporter::builder()
    .with_tonic()
    .build()?;          // no endpoint → OTLP gRPC default http://localhost:4317
```

Both hot callers gate the metrics monitor on `DORA_OTLP_ENDPOINT` being set, but never passed that value down:

- `binaries/runtime-api/src/lib.rs` — `if std::env::var("DORA_OTLP_ENDPOINT").is_ok() { … run_metrics_monitor(meter_id) … }`
- `apis/rust/node/src/node/mod.rs` — same gate, then `run_metrics_monitor(id)`

So with `DORA_OTLP_ENDPOINT=http://remote-collector:4317`, **traces** reached the remote collector (the trace exporter threads the endpoint through `dora_tracing::telemetry::init_tracing`), but **system/process metrics** (CPU/memory/disk) silently went to `localhost:4317` on the node/runtime host and were dropped if nothing listened there.

This is the exact defect the sibling crate already fixed — see the doc comment on `dora_tracing::telemetry::init_meter_provider` (`libraries/extensions/telemetry/tracing/src/metrics.rs`), which notes it passes the endpoint explicitly to avoid *"the previous behaviour where the metric exporter ignored `DORA_OTLP_ENDPOINT` and always fell back to the OTLP gRPC default"*. That fix landed in the tracing crate's meter provider but not in `dora-metrics`, which is the one wired into the runtime/node startup paths.

## Fix

Thread the endpoint through, mirroring the tracing crate:

- `init_metrics(endpoint: &str)` and `run_metrics_monitor(meter_id, endpoint: &str)` now call `.with_endpoint(endpoint)`.
- The two gated callers (`runtime-api`, `node`) already read `DORA_OTLP_ENDPOINT` — they now capture the value (`if let Ok(endpoint) = …`) and pass it through.
- The coordinator (`binaries/coordinator/src/lib.rs`) inits metrics **unconditionally** under the `metrics` feature; it now reads `DORA_OTLP_ENDPOINT` with a `http://localhost:4317` fallback, so its previous behaviour is preserved when the env var is unset while honoring it when set.

The exporter still honors the OTel-standard `OTEL_EXPORTER_OTLP_ENDPOINT` / `..._METRICS_ENDPOINT` env vars; this change only restores dora's own `DORA_OTLP_ENDPOINT` on the metrics path.

Out of scope (noted for a follow-up): the metrics gate checks only `DORA_OTLP_ENDPOINT`, whereas the trace path also accepts `DORA_JAEGER_TRACING` — a `DORA_JAEGER_TRACING`-only user gets traces but no metrics monitor. Left unchanged to keep this fix focused on the endpoint threading.

## Validation

Built and linted the metrics crate and every caller **with the `metrics` feature enabled** (the changed code is behind `#[cfg(feature = "metrics")]`):

- `cargo build -p dora-metrics -p dora-runtime-api --features dora-runtime-api/metrics -p dora-coordinator --features dora-coordinator/metrics` → OK
- `cargo build -p dora-node-api --features metrics` → OK
- `cargo clippy` on all four with the feature, `-D warnings` → clean
- `cargo fmt … -- --check` → clean

`dora_metrics` is documented as internal (not covered by the 1.0 stability guarantee), so the signature change to `init_metrics`/`run_metrics_monitor` is an internal-only change.

---

⚠️ *This is a machine-generated pull request authored by Claude (Claude Code). A human should review it before merging.*

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBFpa44oHdDJxVTphFBTsV)_