### PR TITLE
fix(daemon): fold local exit into the release-path start verdict

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -2616,14 +2616,23 @@ impl Daemon {
                 )).await;
                 match self.running.get_mut(&dataflow_id) {
                     Some(dataflow) => {
-                        let ready = exited_before_subscribe.is_empty();
-                        dataflow
+                        // The verdict must fold in this daemon's local
+                        // `exited_before_subscribe`, not just the coordinator's
+                        // external list: a cohort member that died before
+                        // subscribing while this daemon was disconnected is
+                        // invisible to the replayed external list, but
+                        // `answer_subscribe_requests` still fails the parked
+                        // survivors on it. Deciding `start()` from the external
+                        // list alone would start the dataflow while failing a
+                        // healthy cohort node's init (dora-rs/dora#3243).
+                        let status = dataflow
                             .pending_nodes
                             .handle_external_all_nodes_ready(
                                 exited_before_subscribe,
                                 &mut dataflow.cascading_error_causes,
                             )
                             .await?;
+                        let ready = matches!(status, crate::pending::DataflowStatus::AllNodesReady);
                         // Not gated on `dataflow_started` — `start()` is
                         // idempotent — but it must not resurrect a dataflow that
                         // is already tearing down (dora-rs/dora#3053). The

--- a/binaries/daemon/src/pending.rs
+++ b/binaries/daemon/src/pending.rs
@@ -221,7 +221,7 @@ impl PendingNodes {
         &mut self,
         exited_before_subscribe: Vec<NodeId>,
         cascading_errors: &mut CascadingErrorCauses,
-    ) -> eyre::Result<()> {
+    ) -> eyre::Result<DataflowStatus> {
         if !self.local_nodes.is_empty() {
             tracing::warn!(
                 remaining = ?self.local_nodes,
@@ -229,6 +229,20 @@ impl PendingNodes {
                  proceeding anyway (coordinator may be ahead of this daemon)"
             );
         }
+
+        // The start verdict must agree with the reply each parked subscriber
+        // actually receives. `answer_subscribe_requests` (below) prioritizes
+        // this daemon's LOCAL `exited_before_subscribe`, so fold it into the
+        // verdict here — otherwise a local cohort loss the coordinator never
+        // learned about (a node that died before subscribing while this daemon
+        // was disconnected, so the replayed barrier carries an empty external
+        // list — #3013/#3052) would start the dataflow while simultaneously
+        // failing a surviving cohort node's `Node()` init. This mirrors the
+        // late-subscriber fold-in in `update_dataflow_status`, keeping the
+        // "start verdict == subscriber reply" invariant on the release path too
+        // (dora-rs/dora#3243).
+        let barrier_succeeded =
+            exited_before_subscribe.is_empty() && self.exited_before_subscribe.is_empty();
 
         // Latch before answering: the coordinator fires this once, so
         // everything that subscribes from here on has to be answered
@@ -239,7 +253,11 @@ impl PendingNodes {
         self.answer_subscribe_requests(exited_before_subscribe, cascading_errors)
             .await;
 
-        Ok(())
+        Ok(if barrier_succeeded {
+            DataflowStatus::AllNodesReady
+        } else {
+            DataflowStatus::Pending
+        })
     }
 
     /// Re-evaluate the barrier after something changed the pending set.
@@ -1025,6 +1043,46 @@ mod tests {
         );
         let err = reply_of(&mut rx)
             .expect_err("the surviving cohort member must inherit the local startup failure");
+        assert!(
+            err.contains("locally-dead"),
+            "the failure must name the locally dead node: {err}"
+        );
+    }
+
+    /// dora-rs/dora#3243: the release path must enforce the same combined
+    /// verdict the late-subscriber path does. When a cohort member is already
+    /// parked at release/replay time and a local cohort member died before
+    /// subscribing (a loss the coordinator never saw, so its replayed external
+    /// list is empty), `handle_external_all_nodes_ready` must report `Pending`
+    /// — otherwise the daemon starts the dataflow while `answer_subscribe_requests`
+    /// simultaneously fails the parked survivor's `Node()` init, the exact
+    /// inconsistency #3052 set out to remove, one step earlier than #3055 fixed.
+    #[tokio::test]
+    async fn release_verdict_respects_a_local_exit_with_a_pre_parked_survivor() {
+        let (dead, survivor) = (node("locally-dead"), node("survivor"));
+        let mut p = external_barrier();
+        p.cohort.insert(dead.clone());
+        p.cohort.insert(survivor.clone());
+        // A cohort member is already parked, waiting on the barrier...
+        let mut rx = park(&mut p, &survivor);
+        // ...and a local cohort member died before subscribing while this
+        // daemon was disconnected, so the coordinator's replayed list is empty.
+        p.exited_before_subscribe.push(dead.clone());
+
+        // The coordinator replays `AllNodesReady([])` on reconnect.
+        let status = p
+            .handle_external_all_nodes_ready(Vec::new(), &mut CascadingErrorCauses::default())
+            .await
+            .expect("handle the replayed barrier");
+
+        assert!(
+            matches!(status, DataflowStatus::Pending),
+            "a local cohort loss must keep the release path from starting the \
+             dataflow even when the coordinator's external verdict was success; \
+             got {status:?}"
+        );
+        let err = reply_of(&mut rx)
+            .expect_err("the pre-parked survivor must inherit the local startup failure");
         assert!(
             err.contains("locally-dead"),
             "the failure must name the locally dead node: {err}"


### PR DESCRIPTION
## Summary

Fixes #3243.

The `#3052` fix (PR #3055) closed the **late-subscriber** path but left the structurally-parallel **release-time** path unguarded. When the coordinator's `AllNodesReady` is received/replayed and a cohort subscriber is already parked, the daemon decided `dataflow.start()` from the coordinator's **external** `exited_before_subscribe` list only, while `answer_subscribe_requests` fails the parked subscriber based on this daemon's **local** `exited_before_subscribe`. The two halves disagreed — exactly the inconsistency #3052 set out to remove — so the dataflow could start while simultaneously failing a healthy surviving cohort node's `Node()` init.

This is reachable via the #3052 reconnect/replay scenario, one step earlier than the case #3055 fixed: it bites the already-parked survivor at reconnect time. A cohort member that dies before subscribing while the daemon is disconnected is invisible to the coordinator, so the replayed barrier carries an empty external list — `ready` computed as `exited_before_subscribe.is_empty()` was `true`, and `start()` ran.

## Change

- `PendingNodes::handle_external_all_nodes_ready` now returns a `DataflowStatus` computed from the **combined** verdict `external.is_empty() && self.exited_before_subscribe.is_empty()`, mirroring the late-subscriber fold-in already present in `update_dataflow_status` (added by #3055). This keeps the "start verdict == subscriber reply" invariant in one place for both paths.
- The `lib.rs` `AllNodesReady` handler gates `start()` on the returned status instead of the raw external-only flag. The existing `!stop_sent` / idempotency semantics are preserved.

`start()` is now suppressed in exactly the one buggy case — external list empty but local list non-empty — where the dataflow's startup has actually failed and it should tear down rather than start.

## Test

Adds `release_verdict_respects_a_local_exit_with_a_pre_parked_survivor` in `pending.rs`, mirroring `latch_verdict_respects_a_local_exit_the_coordinator_never_saw` (from #3055) but driving the release path with a **pre-parked** cohort survivor and a local exit the coordinator never saw. It asserts the verdict is `Pending` (not `AllNodesReady`) and that the parked survivor is answered with the `Err` naming the locally-dead node.

## Validation

- `cargo test -p dora-daemon --lib pending::` — all 20 pass, including the new regression test
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p dora-daemon -- -D warnings` (CI toolchain 1.97.1) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Byrb4vD4xGfQkEZfCXkano

---
_Generated by [Claude Code](https://claude.ai/code/session_01Byrb4vD4xGfQkEZfCXkano)_