### PR TITLE
test(daemon): assert what each platform can see of an unreaped leader (#3150)

### DIFF
--- a/binaries/daemon/src/shutdown.rs
+++ b/binaries/daemon/src/shutdown.rs
@@ -191,7 +191,8 @@ fn kill_process_group(pid: u32) -> bool {
         // SAFETY: `killpg`/`kill` on a pid this process spawned as a group
         // leader. A pid the OS recycled is excluded upstream in
         // `live_children` — by the parentage check on the leader path and by
-        // the recycled-stranger guard on the group-fallback path (#3067).
+        // the recycled-stranger guard on the group-fallback path (#3067),
+        // with the one macOS exception that guard documents.
         let killed = unsafe { libc::killpg(pid as i32, libc::SIGKILL) } == 0;
         if killed {
             return true;
@@ -232,6 +233,31 @@ fn kill_process_group(pid: u32) -> bool {
 /// group whose leader is gone, so when the new owner sits elsewhere the members
 /// the probe found are still our orphans — giving up on them would re-open the
 /// leak the fallback exists to close (#3004). Hence both conditions (#3067).
+///
+/// # Known gap on macOS
+///
+/// Both conditions read the process still occupying `pid`, so both need the
+/// platform to expose one that has exited and not yet been reaped. Linux
+/// does: `/proc/<pid>` survives until the reap, so `sysinfo` reports the
+/// zombie with its real parent, and `getpgid` resolves any pid still in the
+/// table. macOS exposes neither, because both routes go through `proc_find`,
+/// which does not look at the zombie list — `kill` carries an explicit
+/// fallback for exactly that reason, `getpgid` carries none, and `sysinfo`'s
+/// `proc_pidinfo` call passes a zero `arg`, which is what would have made it
+/// consult that list. Its create path therefore gives up before it reads a
+/// status, and its update path un-marks the entry and has it dropped from the
+/// map.
+///
+/// So on macOS a stranger's zombie at a recycled pid is indistinguishable
+/// from our own unreaped leader, and both keep their group. That is the
+/// pre-#3067 behavior for that one case; the *live* stranger #3067 was filed
+/// for is still caught everywhere. Closing it is possible — `proc_pidinfo`
+/// with a non-zero `arg` fills a `proc_bsdinfo` whose `pbi_ppid` and
+/// `pbi_pgid` answer both questions for a zombie — but it is a macOS-only
+/// shim for a case that needs a node's pid to be reaped, recycled, made the
+/// leader of that same group id, and left an unreaped zombie itself, all
+/// inside the [`DESTROY_WAIT`] window. Declined as disproportionate rather
+/// than judged infeasible (dora-rs/dora#3150).
 fn pid_recycled_into_stranger(pid: u32, process: Option<&sysinfo::Process>, own_pid: u32) -> bool {
     let Some(process) = process else {
         return false;
@@ -437,15 +463,24 @@ mod tests {
         let _ = child.wait();
     }
 
-    /// A group leader that spawns a child into its group, exits, and is left
-    /// **unreaped**, so it presents as a zombie rather than disappearing from
-    /// the process table. Returns the handle (for cleanup) and its pid.
+    /// A group leader that spawns a child into its group, is confirmed as
+    /// `wait`'s while alive, then exits and is left **unreaped**, so it
+    /// presents as a zombie rather than disappearing from the process table.
+    /// Returns the handle (for cleanup) and its pid.
     ///
     /// Same shape as `a_wrapper_that_exits_does_not_hide_its_surviving_child`,
     /// including the `read`-on-stdin trick that makes the wrapper exit exactly
     /// where the caller wants rather than racing the first poll (#3023).
+    ///
+    /// The confirming poll is what makes the state under test the one that
+    /// ships. `confirmed` is only ever populated on the `leader_alive` branch,
+    /// so at runtime a pid reaches the group fallback having already been seen
+    /// alive — and `wait`'s `System` has an entry for it from that sighting.
+    /// A hand-injected `confirmed` against a never-refreshed `System` would
+    /// leave the tests exercising `sysinfo`'s create path where the daemon
+    /// exercises its update path, and those two do not have to agree.
     #[cfg(unix)]
-    fn spawn_unreaped_wrapper() -> (std::process::Child, u32) {
+    fn spawn_confirmed_then_unreaped_wrapper(wait: &mut DestroyWait) -> (std::process::Child, u32) {
         use std::os::unix::process::CommandExt as _;
 
         let mut wrapper = Command::new("sh")
@@ -459,44 +494,26 @@ mod tests {
             .expect("failed to spawn wrapper");
         let pid = wrapper.id();
 
+        assert_eq!(
+            wait.live_children(&[pid]),
+            vec![pid],
+            "the wrapper is alive, so it is this daemon's live child"
+        );
+        assert!(
+            wait.confirmed.contains(&pid),
+            "a leader seen alive is confirmed ours — that is what opens the \
+             group fallback the assertions below are about"
+        );
+
         // Close stdin so `read` hits EOF and the wrapper exits. No `wait()`:
         // without the reap it stays a zombie, which is the state under test.
         drop(wrapper.stdin.take());
 
         wait_for_exit_without_reaping(pid);
 
-        // The wrapper is now definitively an unreaped zombie. If `sysinfo`
-        // disagrees, that is a platform gap worth knowing about rather than a
-        // flake: `live_children` treats an unseen pid as *not* recycled
-        // (`pid_recycled_into_stranger` returns false for `None`), so a pid
-        // recycled into a stranger's zombie would be attributed to us and its
-        // group killed — the #3067 case. Fail loudly and name it.
-        //
-        // A failure here is narrower than it first reads, though. This is a
-        // *fresh* `System`, so sysinfo has to build the entry from nothing,
-        // and on macOS that path gives up on a process whose argv and exe path
-        // the kernel no longer serves — which is exactly a zombie. A
-        // long-lived `DestroyWait` keeps its `System` across polls and has
-        // already seen the pid alive, so it takes sysinfo's *update* path
-        // instead, which can still report `Zombie` where the create path
-        // returns nothing at all. So this bounds how much of the #3067 guard
-        // survives on a platform; it does not by itself condemn the whole of
-        // it.
-        let mut system = System::new();
-        system.refresh_processes_specifics(
-            ProcessesToUpdate::Some(&[Pid::from_u32(pid)]),
-            true,
-            ProcessRefreshKind::nothing(),
-        );
-        let seen = system.process(Pid::from_u32(pid)).map(|p| p.status());
-        assert_eq!(
-            seen,
-            Some(ProcessStatus::Zombie),
-            "`waitid` confirms the wrapper exited unreaped, but a fresh \
-             `sysinfo::System` reports {seen:?}. The zombie half of \
-             `is_live_child` / `pid_recycled_into_stranger` cannot work on \
-             this platform for a pid sysinfo has not already seen alive."
-        );
+        // Definitively an unreaped zombie now. Whether the *guard* can see one
+        // is a separate, platform-dependent question, asked at the use site —
+        // see `guard_saw_unreaped` (dora-rs/dora#3150).
         (wrapper, pid)
     }
 
@@ -581,18 +598,37 @@ mod tests {
         let _ = wrapper.wait();
     }
 
+    /// Whether the guard could *see* the unreaped process at `pid` on its
+    /// last look — the two facts [`pid_recycled_into_stranger`] needs to tell
+    /// our own not-yet-reaped leader from a stranger recycled into its pid,
+    /// and which macOS does not serve (see that function for why).
+    ///
+    /// Reads `wait`'s `System` exactly as [`DestroyWait::live_children`] left
+    /// it, deliberately without refreshing: an extra refresh would consume
+    /// the update path the daemon takes and leave the next `live_children`
+    /// rebuilding from an empty map, which is the cold lookup the daemon
+    /// never makes. Call it *after* the poll under test, not before.
+    #[cfg(unix)]
+    fn guard_saw_unreaped(wait: &DestroyWait, pid: u32) -> bool {
+        wait.system.process(Pid::from_u32(pid)).is_some() && leads_own_group(pid)
+    }
+
     /// One half of the #3067 guard: an *unreaped* leader of ours is not a
     /// recycled pid. It fails `is_live_child` exactly like a stranger would,
     /// so the fallback has to keep trusting its group — otherwise the orphan
     /// #3004 is about slips through whenever the daemon has not gotten around
     /// to reaping the wrapper yet.
+    ///
+    /// This half holds on every Unix, by whichever route the platform allows:
+    /// where the zombie is visible the guard recognizes it as ours, and where
+    /// it is not an unseen pid is not a recycled one either. Both land on
+    /// "keep trusting the group".
     #[cfg(unix)]
     #[tokio::test(start_paused = true)]
     async fn an_unreaped_leader_of_ours_still_covers_its_surviving_child() {
-        let (wrapper, pid) = spawn_unreaped_wrapper();
-
         let mut wait = DestroyWait::new();
-        wait.confirmed.insert(pid);
+        let (wrapper, pid) = spawn_confirmed_then_unreaped_wrapper(&mut wait);
+
         assert_eq!(
             wait.live_children(&[pid]),
             vec![pid],
@@ -607,22 +643,51 @@ mod tests {
     /// recycled into a stranger that has itself exited but not been reaped is
     /// a zombie too, and testing for `!= Zombie` would wave its group through
     /// to `killpg`. Parentage is what separates the two cases.
+    ///
+    /// Only where the platform lets the guard read it, though. Where it does
+    /// not — macOS, per [`pid_recycled_into_stranger`] — there is nothing to
+    /// discriminate with and the group is trusted, which makes this test say
+    /// the same thing as the one above rather than anything extra. That is
+    /// the gap, not a weaker form of the guard, and the assertions say so:
+    /// Linux is pinned to the discriminating outcome outright, and elsewhere
+    /// the expectation follows what the guard was actually able to see. The
+    /// nightly failure this replaces came from asserting the *capability* as
+    /// a precondition instead (dora-rs/dora#3150).
     #[cfg(unix)]
     #[tokio::test(start_paused = true)]
     async fn a_strangers_zombie_at_a_recycled_pid_does_not_make_its_group_ours() {
-        let (wrapper, pid) = spawn_unreaped_wrapper();
+        let mut wait = DestroyWait::new();
+        let (wrapper, pid) = spawn_confirmed_then_unreaped_wrapper(&mut wait);
 
         // Present the zombie as parented elsewhere, exactly as a pid recycled
         // into a stranger that then exited would. It still leads group `pid`
         // and the group still has a live member, so the bare probe passes and
         // only the parentage check keeps it out.
-        let mut wait = DestroyWait::new();
         wait.own_pid = std::process::id() + 424_242;
-        wait.confirmed.insert(pid);
+        let alive = wait.live_children(&[pid]);
+
+        // Linux serves both facts, and it is the platform the PR gate runs
+        // on, so pin the real outcome there — unconditionally, so this cannot
+        // quietly reduce to the sibling test the way it does on macOS.
+        #[cfg(target_os = "linux")]
         assert!(
-            wait.live_children(&[pid]).is_empty(),
+            alive.is_empty(),
             "a zombie parented elsewhere is a recycled pid, not our unreaped \
              leader — its group must not be attributed to us"
+        );
+
+        let saw_it = guard_saw_unreaped(&wait, pid);
+        assert_eq!(
+            alive,
+            if saw_it { Vec::new() } else { vec![pid] },
+            "the guard {} the unreaped process, so it must {} \
+             (dora-rs/dora#3150)",
+            if saw_it { "saw" } else { "could not see" },
+            if saw_it {
+                "have recognized a stranger and dropped its group"
+            } else {
+                "have fallen back to trusting the group"
+            }
         );
 
         kill_group_and_reap(wrapper, pid);


### PR DESCRIPTION
Fixes the two `test-cross-platform` (macOS) failures tracked in #3150.

`spawn_unreaped_wrapper` asserted that a fresh `sysinfo::System` reports `ProcessStatus::Zombie` for a wrapper `waitid` had just confirmed exited and unreaped. That asserts a platform *capability*, not a property of the code under test, and macOS does not have it — so both tests died at the precondition, before reaching a guard assertion. #3231 predicted this and left the assertion in to find out which way macOS would go.

**Why macOS cannot answer.** `pid_recycled_into_stranger` needs two facts about the process still occupying the pid: its parent (from `sysinfo`) and whether it leads group `pid` (from `getpgid`). Both routes go through XNU's `proc_find`, which does not look at the zombie list — `kill` carries an explicit fallback for exactly that reason, `getpgid` carries none, and `sysinfo`'s `proc_pidinfo` call passes a zero `arg`, which is what would have made it consult that list. Its create path gives up before it reads a status; its update path un-marks the entry and has it dropped from the map. So the warm `System` a long-lived `DestroyWait` keeps does not rescue it either, contrary to what #3231's body guessed.

The consequence is narrow and now documented on `pid_recycled_into_stranger` and on the `killpg` SAFETY comment it feeds: on macOS a stranger's zombie at a recycled pid is indistinguishable from our own unreaped leader, and both keep their group — the pre-#3067 behavior for that one case. The *live* stranger #3067 was actually filed for is still caught on every platform. Closing the remainder is possible (`proc_pidinfo` with a non-zero `arg` fills a `proc_bsdinfo` whose `pbi_ppid` and `pbi_pgid` answer both questions for a zombie) but it is a macOS-only shim for a case needing a node's pid to be reaped, recycled, made leader of that same group id, and left an unreaped zombie itself, all inside the 16 s `DESTROY_WAIT`. Declined as disproportionate rather than judged infeasible, and the doc says so in those words.

Two changes to make the tests test the guard instead:

The wrapper is now confirmed through `live_children` while alive rather than by hand-injecting into `confirmed`. That is the only way a pid reaches the group fallback at runtime, and it leaves `wait`'s `System` holding an entry — so the poll under test exercises sysinfo's update path, as the daemon does, not its create path.

The expectation is read from the state the poll left behind rather than from a second refresh (an extra refresh would consume the update path and leave the next `live_children` rebuilding from an empty map). Linux is pinned to the discriminating outcome unconditionally, so the assertion cannot quietly reduce to its sibling test the way it does on macOS; elsewhere the expectation follows what the guard was able to see, which means the strict assertion starts running by itself if a platform gains the ability.

Verified on Linux: 8/8 shutdown tests green over 15 repeat runs at 0.02 s each, full `dora-daemon` suite 231 passed, `cargo fmt --all --check` and `cargo clippy -p dora-daemon -- -D warnings` clean. (`--all-targets` clippy reports the same four pre-existing `lib.rs` findings as before, untouched here and outside CI's `--all` invocation.) The macOS half cannot be run here; the change is a test-module edit plus doc comments, and the degraded branch is what `live_children` already produces there today.

Refs #3150
