### PR TITLE
refactor(python)!: move the CUDA helpers out of `dora` into the `dora_tensor_pool` extension

### DIFF
--- a/docs/api-python.md
+++ b/docs/api-python.md
@@ -743,10 +743,12 @@ Return the dictionary representation for YAML serialization.
 
 ---
 
-## CUDA Module
+## CUDA Module (opt-in extension)
+
+> **Not part of the 1.0 API.** These helpers moved out of the `dora` package into the `dora_tensor_pool` extension before 1.0 — they exist to serve the tensor-pool transport, which sits behind the extension seam, and are not covered by dora's 1.0 compatibility guarantees. Install from `libraries/extensions/tensor-pool/python`.
 
 ```python
-from dora.cuda import torch_to_ipc_buffer, ipc_buffer_to_ipc_handle, open_ipc_handle
+from dora_tensor_pool import torch_to_ipc_buffer, ipc_buffer_to_ipc_handle, open_ipc_handle
 ```
 
 Utilities for zero-copy GPU tensor sharing between nodes via CUDA IPC. Requires PyTorch with CUDA and Numba with CUDA support.
@@ -759,7 +761,7 @@ Convert a PyTorch CUDA tensor into an Arrow array containing the CUDA IPC handle
 import torch
 import pyarrow as pa
 from dora import Node
-from dora.cuda import torch_to_ipc_buffer
+from dora_tensor_pool import torch_to_ipc_buffer
 
 node = Node()
 tensor = torch.randn(1024, 768, device="cuda")
@@ -779,7 +781,7 @@ node.send_output("gpu_data", ipc_buffer, metadata)
 Reconstruct a CUDA IPC handle from a received Arrow buffer and metadata.
 
 ```python
-from dora.cuda import ipc_buffer_to_ipc_handle
+from dora_tensor_pool import ipc_buffer_to_ipc_handle
 
 event = node.next()
 ipc_handle = ipc_buffer_to_ipc_handle(event["value"], event["metadata"])
@@ -789,7 +791,7 @@ ipc_handle = ipc_buffer_to_ipc_handle(event["value"], event["metadata"])
 - `handle_buffer` (pyarrow.Array) -- The Arrow array from `event["value"]`.
 - `metadata` (dict) -- The metadata from `event["metadata"]`.
 
-**Returns:** `dora.cuda.IpcHandle` (a lightweight wrapper around `cudaIpcMemHandle_t`; call `.open()` to map the handle into the current process and get a device pointer, `.close()` to release it).
+**Returns:** `dora_tensor_pool.IpcHandle` (a lightweight wrapper around `cudaIpcMemHandle_t`; call `.open()` to map the handle into the current process and get a device pointer, `.close()` to release it).
 
 ---
 
@@ -798,7 +800,7 @@ ipc_handle = ipc_buffer_to_ipc_handle(event["value"], event["metadata"])
 Open a CUDA IPC handle and yield a PyTorch tensor. Use as a context manager to ensure proper cleanup.
 
 ```python
-from dora.cuda import ipc_buffer_to_ipc_handle, open_ipc_handle
+from dora_tensor_pool import ipc_buffer_to_ipc_handle, open_ipc_handle
 
 event = node.next()
 ipc_handle = ipc_buffer_to_ipc_handle(event["value"], event["metadata"])

--- a/examples/cuda-benchmark/README.md
+++ b/examples/cuda-benchmark/README.md
@@ -11,7 +11,7 @@ conda install pyarrow "arrow-cpp-proc=*=cuda" -c conda-forge
 ## Test installation with
 python -c "import pyarrow.cuda"
 
-# Install torch if it's not already present (dora.cuda uses ctypes + libcudart,
+# Install torch if it's not already present (dora_tensor_pool uses ctypes + libcudart,
 # no numba dependency needed).
 pip install torch
 

--- a/examples/cuda-benchmark/demo_receiver.py
+++ b/examples/cuda-benchmark/demo_receiver.py
@@ -8,7 +8,7 @@ import numpy as np
 import pyarrow as pa
 import torch
 from dora import Node
-from dora.cuda import ipc_buffer_to_ipc_handle, open_ipc_handle
+from dora_tensor_pool import ipc_buffer_to_ipc_handle, open_ipc_handle
 from helper import record_results
 from tqdm import tqdm
 

--- a/examples/cuda-benchmark/demo_sender.py
+++ b/examples/cuda-benchmark/demo_sender.py
@@ -9,7 +9,7 @@ import numpy as np
 import pyarrow as pa
 import torch
 from dora import Node
-from dora.cuda import torch_to_ipc_buffer
+from dora_tensor_pool import torch_to_ipc_buffer
 
 torch.tensor([], device="cuda")
 

--- a/examples/cuda-benchmark/receiver.py
+++ b/examples/cuda-benchmark/receiver.py
@@ -7,7 +7,7 @@ import time
 import pyarrow as pa
 import torch
 from dora import Node
-from dora.cuda import ipc_buffer_to_ipc_handle, open_ipc_handle
+from dora_tensor_pool import ipc_buffer_to_ipc_handle, open_ipc_handle
 from helper import record_results
 from tqdm import tqdm
 

--- a/examples/cuda-benchmark/sender.py
+++ b/examples/cuda-benchmark/sender.py
@@ -9,7 +9,7 @@ import numpy as np
 import pyarrow as pa
 import torch
 from dora import Node
-from dora.cuda import torch_to_ipc_buffer
+from dora_tensor_pool import torch_to_ipc_buffer
 
 torch.tensor([], device="cuda")
 

--- a/guide/src/languages/python.md
+++ b/guide/src/languages/python.md
@@ -743,10 +743,12 @@ Return the dictionary representation for YAML serialization.
 
 ---
 
-## CUDA Module
+## CUDA Module (opt-in extension)
+
+> **Not part of the 1.0 API.** These helpers moved out of the `dora` package into the `dora_tensor_pool` extension before 1.0 — they exist to serve the tensor-pool transport, which sits behind the extension seam, and are not covered by dora's 1.0 compatibility guarantees. Install from `libraries/extensions/tensor-pool/python`.
 
 ```python
-from dora.cuda import torch_to_ipc_buffer, ipc_buffer_to_ipc_handle, open_ipc_handle
+from dora_tensor_pool import torch_to_ipc_buffer, ipc_buffer_to_ipc_handle, open_ipc_handle
 ```
 
 Utilities for zero-copy GPU tensor sharing between nodes via CUDA IPC. Requires PyTorch with CUDA and Numba with CUDA support.
@@ -759,7 +761,7 @@ Convert a PyTorch CUDA tensor into an Arrow array containing the CUDA IPC handle
 import torch
 import pyarrow as pa
 from dora import Node
-from dora.cuda import torch_to_ipc_buffer
+from dora_tensor_pool import torch_to_ipc_buffer
 
 node = Node()
 tensor = torch.randn(1024, 768, device="cuda")
@@ -779,7 +781,7 @@ node.send_output("gpu_data", ipc_buffer, metadata)
 Reconstruct a CUDA IPC handle from a received Arrow buffer and metadata.
 
 ```python
-from dora.cuda import ipc_buffer_to_ipc_handle
+from dora_tensor_pool import ipc_buffer_to_ipc_handle
 
 event = node.next()
 ipc_handle = ipc_buffer_to_ipc_handle(event["value"], event["metadata"])
@@ -789,7 +791,7 @@ ipc_handle = ipc_buffer_to_ipc_handle(event["value"], event["metadata"])
 - `handle_buffer` (pyarrow.Array) -- The Arrow array from `event["value"]`.
 - `metadata` (dict) -- The metadata from `event["metadata"]`.
 
-**Returns:** `dora.cuda.IpcHandle` (a lightweight wrapper around `cudaIpcMemHandle_t`; call `.open()` to map the handle into the current process and get a device pointer, `.close()` to release it).
+**Returns:** `dora_tensor_pool.IpcHandle` (a lightweight wrapper around `cudaIpcMemHandle_t`; call `.open()` to map the handle into the current process and get a device pointer, `.close()` to release it).
 
 ---
 
@@ -798,7 +800,7 @@ ipc_handle = ipc_buffer_to_ipc_handle(event["value"], event["metadata"])
 Open a CUDA IPC handle and yield a PyTorch tensor. Use as a context manager to ensure proper cleanup.
 
 ```python
-from dora.cuda import ipc_buffer_to_ipc_handle, open_ipc_handle
+from dora_tensor_pool import ipc_buffer_to_ipc_handle, open_ipc_handle
 
 event = node.next()
 ipc_handle = ipc_buffer_to_ipc_handle(event["value"], event["metadata"])

--- a/libraries/extensions/tensor-pool/README.md
+++ b/libraries/extensions/tensor-pool/README.md
@@ -46,7 +46,7 @@ those are what the daemon half implements.
 
 ```python
 from dora import Node
-from dora.cuda import get_tensor_info, tensor_from_info   # helpers, torch-only
+from dora_tensor_pool import get_tensor_info, tensor_from_info   # helpers, torch-only
 
 node = Node()
 pool_id = node.register_tensor_pool(get_tensor_info(tensor), device="cuda:0")
@@ -114,7 +114,7 @@ the generic channel instead.
 | `src/lib.rs` | `TensorPoolManager` — the pool table and `/dev/shm` reclamation |
 | `python/src/transport.rs` | the transport: segment layout, seqlock, CUDA helpers, the four operations |
 | `python/src/seam.rs` | descriptor encode/decode over the extension channel |
-| `python/tensor_info_helpers.py` | `get_tensor_info` / `tensor_from_info` for torch tensors |
+| `python/dora_tensor_pool/` | `get_tensor_info` / `tensor_from_info` and the CUDA IPC helpers, importable as `dora_tensor_pool` |
 | `examples/` | dataflows, CPU and CUDA |
 | `tests/` | smoke tests (need `torch`; not wired to the default suite) |
 

--- a/libraries/extensions/tensor-pool/examples/receiver.py
+++ b/libraries/extensions/tensor-pool/examples/receiver.py
@@ -7,7 +7,7 @@ import time
 import pyarrow as pa
 import torch
 from dora import Node
-from dora.cuda import tensor_from_info
+from dora_tensor_pool import tensor_from_info
 from tqdm import tqdm
 
 node = Node("receiver_node")

--- a/libraries/extensions/tensor-pool/examples/sender.py
+++ b/libraries/extensions/tensor-pool/examples/sender.py
@@ -9,7 +9,7 @@ import numpy as np
 import pyarrow as pa
 import torch
 from dora import Node
-from dora.cuda import get_tensor_info
+from dora_tensor_pool import get_tensor_info
 
 SIZE = 15000 * 512
 MESSAGE_COUNT = int(os.getenv("message_num", "100"))

--- a/libraries/extensions/tensor-pool/python/dora_tensor_pool/__init__.py
+++ b/libraries/extensions/tensor-pool/python/dora_tensor_pool/__init__.py
@@ -1,0 +1,27 @@
+"""Python helpers for dora's tensor-pool transport.
+
+**Opt-in extension. Not covered by dora's 1.0 compatibility guarantees.**
+See ``libraries/extensions/tensor-pool/README.md``.
+
+These lived in ``dora.cuda`` until 1.0. They moved here because they exist to
+serve the tensor-pool transport, which sits behind the extension seam (#3152),
+and freezing them into the 1.0 Python API would have committed dora to a
+surface that is still changing. Nothing in dora itself imports them.
+"""
+
+from .cuda import (
+    IpcHandle,
+    ipc_buffer_to_ipc_handle,
+    open_ipc_handle,
+    torch_to_ipc_buffer,
+)
+from .tensor_info import get_tensor_info, tensor_from_info
+
+__all__ = [
+    "IpcHandle",
+    "get_tensor_info",
+    "ipc_buffer_to_ipc_handle",
+    "open_ipc_handle",
+    "tensor_from_info",
+    "torch_to_ipc_buffer",
+]

--- a/libraries/extensions/tensor-pool/python/dora_tensor_pool/cuda.py
+++ b/libraries/extensions/tensor-pool/python/dora_tensor_pool/cuda.py
@@ -31,7 +31,7 @@ class _CudaIpcMemHandle(ctypes.Structure):
 @functools.lru_cache(maxsize=1)
 def _libcudart():
     # Resolve the CUDA runtime lazily so non-CUDA hosts (and macOS/Windows
-    # importers that never touch IPC) can `import dora.cuda` without blowing
+    # importers that never touch IPC) can `import dora_tensor_pool` without blowing
     # up at module load. Raises a descriptive RuntimeError on failure.
     name = {"linux": "libcudart.so", "darwin": "libcudart.dylib"}.get(
         sys.platform, "cudart64_12.dll"
@@ -229,7 +229,7 @@ def ipc_buffer_to_ipc_handle(handle_buffer: pa.array, metadata: dict) -> IpcHand
 
     Example::
 
-        from dora.cuda import ipc_buffer_to_ipc_handle, open_ipc_handle
+        from dora_tensor_pool import ipc_buffer_to_ipc_handle, open_ipc_handle
 
         event = node.next()
         ipc_handle = ipc_buffer_to_ipc_handle(event["value"], event["metadata"])
@@ -268,7 +268,7 @@ def open_ipc_handle(
 
     Example::
 
-        from dora.cuda import ipc_buffer_to_ipc_handle, open_ipc_handle
+        from dora_tensor_pool import ipc_buffer_to_ipc_handle, open_ipc_handle
 
         event = node.next()
         ipc_handle = ipc_buffer_to_ipc_handle(event["value"], event["metadata"])
@@ -289,134 +289,3 @@ def open_ipc_handle(
         yield tensor
     finally:
         ipc_handle.close()
-
-
-# ---- memory-pool helpers (ported from the pre-tensor-pool branch) ----
-_DTYPE_MAP = {
-    "<i8": torch.int64,
-    "<i4": torch.int32,
-    "<i2": torch.int16,
-    "<f4": torch.float32,
-    "<f8": torch.float64,
-    "<f2": torch.float16,
-    "<u1": torch.uint8,
-    "|b1": torch.bool,
-    "int64": torch.int64,
-    "int32": torch.int32,
-    "int16": torch.int16,
-    "float32": torch.float32,
-    "float64": torch.float64,
-    "float16": torch.float16,
-    "uint8": torch.uint8,
-    "bool": torch.bool,
-    # Torch type names (used by tensor_from_info)
-    "torch.int64": torch.int64,
-    "torch.int32": torch.int32,
-    "torch.int16": torch.int16,
-    "torch.float32": torch.float32,
-    "torch.float64": torch.float64,
-    "torch.float16": torch.float16,
-    "torch.uint8": torch.uint8,
-    "torch.bool": torch.bool,
-    "torch.int8": torch.int8,
-    "torch.bfloat16": torch.bfloat16,
-}
-
-# Torch dtype -> numpy dtype mapping (used by tensor_from_info for
-# constructing numpy arrays from raw memory pointers).
-_TORCH_TO_NUMPY_DTYPE_MAP = {
-    torch.int64: np.int64,
-    torch.float32: np.float32,
-    torch.float64: np.float64,
-    torch.int32: np.int32,
-    torch.int16: np.int16,
-    torch.int8: np.int8,
-    torch.uint8: np.uint8,
-    torch.bool: np.bool_,
-    torch.float16: np.float16,
-    torch.bfloat16: np.float16,  # bfloat16 maps to float16 in numpy
-}
-
-def get_tensor_info(tensor: torch.Tensor) -> dict:
-    """Serialize a tensor into a ``tensor_info`` dict containing pointer,
-    size, dtype, shape, and device.
-
-    This is the canonical way to pass tensor metadata to memory-pool
-    operations such as ``register_tensor_pool`` and ``write_tensor_pool``.
-    """
-    if not tensor.is_contiguous():
-        tensor = tensor.contiguous()
-    return {
-        "ptr": tensor.data_ptr(),
-        "size": tensor.nbytes,
-        "dtype": str(tensor.dtype),
-        "shape": list(tensor.shape),
-        "device": str(tensor.device),
-    }
-
-
-def tensor_from_info(tensor_info: dict) -> torch.Tensor:
-    """Reconstruct a PyTorch tensor from a ``tensor_info`` dict (zero-copy).
-
-    The returned tensor shares the same underlying memory as the original
-    tensor that produced the ``tensor_info``.  Used by consumers that read
-    a memory pool via ``read_memory_pool``.
-    """
-    ptr = tensor_info.get('ptr', 0)
-    if ptr == 0:
-        raise ValueError("tensor_info has null pointer (ptr=0); pool may not exist or has been freed")
-    dtype_str = tensor_info["dtype"]
-    shape = tensor_info["shape"]
-    device = tensor_info.get("device", "cpu")
-    size = tensor_info.get("size", 0)
-
-    dtype = _DTYPE_MAP.get(dtype_str, torch.int64)
-
-    if device.startswith("cuda"):
-        # CUDA tensor — zero-copy via __cuda_array_interface__
-        np_dtype = _TORCH_TO_NUMPY_DTYPE_MAP.get(dtype)
-        if np_dtype is None:
-            raise ValueError(f"Unsupported dtype: {dtype}")
-
-        # Validate that product(shape) * itemsize(dtype) does not
-        # exceed the registered size — a peer-controlled header that
-        # claims a large shape over a small buffer would produce an
-        # out-of-bounds GPU tensor (the CPU path is saved by numpy
-        # reshape, but the GPU path has no equivalent backstop).
-        #
-        # Reject negative dimensions first: the size check below uses a
-        # plain running product, and a negative dim makes that product
-        # negative, so `expected_bytes > size` would be False and the
-        # guard would be silently bypassed — exactly the malformed
-        # (peer-controlled) header it exists to reject. A zero dim is a
-        # legitimate empty tensor and passes the size check as 0 <= size.
-        if any(dim < 0 for dim in shape):
-            raise ValueError(
-                f"tensor shape {shape} has a negative dimension — header may be corrupted"
-            )
-        expected_bytes = np.dtype(np_dtype).itemsize
-        for dim in shape:
-            expected_bytes *= dim
-        if expected_bytes > size:
-            raise ValueError(
-                f"tensor shape {shape} * {np_dtype} itemsize = {expected_bytes} bytes "
-                f"exceeds registered size {size} bytes — header may be corrupted"
-            )
-
-        typestr = np.dtype(np_dtype).str
-        wrapper = _CudaArrayInterface(ptr, shape, None, typestr)
-        return torch.as_tensor(wrapper, device="cuda")
-    else:
-        # CPU tensor — zero-copy via numpy / torch.frombuffer
-        np_dtype = _TORCH_TO_NUMPY_DTYPE_MAP.get(dtype)
-        if np_dtype is None and dtype != torch.bfloat16:
-            raise ValueError(f"Unsupported dtype: {dtype}")
-
-        c_array = (ctypes.c_byte * size).from_address(ptr)
-
-        if dtype == torch.bfloat16:
-            byte_tensor = torch.frombuffer(c_array, dtype=torch.uint8)
-            return byte_tensor.view(dtype=torch.bfloat16).reshape(shape)
-
-        np_array = np.frombuffer(c_array, dtype=np_dtype).reshape(shape)
-        return torch.from_numpy(np_array)

--- a/libraries/extensions/tensor-pool/python/dora_tensor_pool/tensor_info.py
+++ b/libraries/extensions/tensor-pool/python/dora_tensor_pool/tensor_info.py
@@ -5,7 +5,7 @@ removed `register_tensor_pool` / `write_tensor_pool` / `read_tensor_pool`
 methods, and the two dtype maps existed only to serve them. They have no
 other caller in dora, so they travelled with the transport.
 
-`_CudaArrayInterface` stays in `dora/cuda.py` — `open_ipc_handle` still uses
+`_CudaArrayInterface` lives in `cuda.py` alongside these — `open_ipc_handle` still uses
 it. Reinstating these belongs on the dora-pool side of the seam, not in the
 `dora` package. See ../README.md.
 """
@@ -119,6 +119,17 @@ def tensor_from_info(tensor_info: dict) -> torch.Tensor:
         # claims a large shape over a small buffer would produce an
         # out-of-bounds GPU tensor (the CPU path is saved by numpy
         # reshape, but the GPU path has no equivalent backstop).
+        #
+        # Reject negative dimensions first: the size check below uses a
+        # plain running product, and a negative dim makes that product
+        # negative, so `expected_bytes > size` would be False and the
+        # guard would be silently bypassed — exactly the malformed
+        # (peer-controlled) header it exists to reject. A zero dim is a
+        # legitimate empty tensor and passes the size check as 0 <= size.
+        if any(dim < 0 for dim in shape):
+            raise ValueError(
+                f"tensor shape {shape} has a negative dimension — header may be corrupted"
+            )
         expected_bytes = np.dtype(np_dtype).itemsize
         for dim in shape:
             expected_bytes *= dim

--- a/libraries/extensions/tensor-pool/python/pyproject.toml
+++ b/libraries/extensions/tensor-pool/python/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dora-tensor-pool"
+version = "0.1.0"
+description = "Python helpers for dora's tensor-pool transport. Opt-in extension — NOT covered by dora's 1.0 compatibility guarantees."
+readme = "../README.md"
+requires-python = ">=3.9"
+# torch, numpy and pyarrow are imported lazily by the CUDA helpers; a consumer
+# that only needs `get_tensor_info` still needs torch, so they are not optional
+# here. Left unpinned so this tracks whatever the consuming node already has.
+dependencies = ["numpy", "pyarrow", "torch"]
+
+[tool.setuptools]
+packages = ["dora_tensor_pool"]


### PR DESCRIPTION
`dora/cuda.py` was about to be frozen into the 1.0 Python API, but nothing in dora imports it. Its only consumers are `examples/cuda-benchmark/` and the tensor-pool extension's own examples, and neither runs in CI — both are on the skip list for want of a CUDA toolkit (`scripts/smoke-all.sh:630`, `tests/example-smoke.rs`). It is about ten weeks old, has been reworked twice in the last week (#3079, #3152), and carries an open defect against the guard #3079 added (#3208). Removing a documented symbol after 1.0 needs a major bump; adding one back in 1.1 is additive — so it moves now, behind the same seam #3152 put the rest of the tensor pool behind.

The helpers become a real package rather than a third parked file: `libraries/extensions/tensor-pool/python/dora_tensor_pool`, installable from that directory and importable as `dora_tensor_pool`. `tensor_info_helpers.py` — parked out of `dora/cuda.py` by #3152 and never given an import path, which is exactly why the extension README and its own examples still read `from dora.cuda import` — folds in as `tensor_info.py`.

`get_tensor_info` and `tensor_from_info` existed in both files, identical apart from one docstring word (`read_memory_pool` vs `read_tensor_pool`). The extension's copy wins and the `dora/cuda.py` duplicate is dropped. Both carried the #3208 negative-dimension bypass, so that defect now sits entirely outside the 1.0 guarantees rather than half in and half out.

Updated consumers: four files in `examples/cuda-benchmark/`, both tensor-pool examples, the extension README, `docs/api-python.md` and `guide/src/languages/python.md`. The two doc pages now state plainly that the module is not part of the 1.0 API and where to install it from.

`cargo check -p dora-node-api-python` passes — the Rust binding never referenced the module. The package's three files parse, and every name `__init__` re-exports is defined. Not runnable end-to-end from here: the examples need a CUDA toolkit, same as before the move.
