### PR TITLE
docs: correct the independently-versioned crates named in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ dora run examples/python-dataflow/dataflow.yml --uv --stop-after 10s
 
 ## Workspace Layout
 
-- **Rust edition 2024; MSRV and default workspace package metadata live in `[workspace.package]` in the root `Cargo.toml`.** Most crates inherit the workspace version via `version.workspace = true`, but a few (e.g. `apis/rust/operator/types`, the `examples/error-propagation/*` samples) pin their own version independently.
+- **Rust edition 2024; MSRV and default workspace package metadata live in `[workspace.package]` in the root `Cargo.toml`.** Most crates inherit the workspace version via `version.workspace = true`, but a few (the `examples/error-propagation/*` samples and `xtask`) pin their own version independently.
 - Python packages use PyO3 0.28 and are built with **maturin**, not cargo
 
 ### Key crates


### PR DESCRIPTION
`apis/rust/operator/types` inherits the workspace version (`version.workspace = true`), so naming it as an exception was wrong; `xtask` pins its own and was missing. Verified by sweeping every tracked manifest — note an unanchored grep matches `rust-version.workspace = true` as a substring and gets this wrong.