### PR TITLE
fix(ros2-bridge): reject null string elements in array/sequence serialization

### DIFF
--- a/libraries/extensions/ros2-bridge/arrow/src/serialize/array.rs
+++ b/libraries/extensions/ros2-bridge/arrow/src/serialize/array.rs
@@ -12,7 +12,7 @@ use serde::ser::SerializeTuple;
 
 use crate::TypeInfo;
 
-use super::{TypedValue, check_array_len, error};
+use super::{TypedValue, check_array_len, error, reject_null_string_element};
 
 /// Serialize an array with known size as tuple.
 pub struct ArraySerializeWrapper<'a> {
@@ -323,8 +323,8 @@ where
 {
     check_array_len(array.len(), array_len)?;
     let mut seq = serializer.serialize_tuple(array_len)?;
-    for s in array.iter() {
-        seq.serialize_element(s.unwrap_or_default())?;
+    for (i, s) in array.iter().enumerate() {
+        seq.serialize_element(reject_null_string_element(s, i)?)?;
     }
     seq.end()
 }
@@ -340,8 +340,8 @@ where
 {
     check_array_len(array.len(), array_len)?;
     let mut seq = serializer.serialize_tuple(array_len)?;
-    for s in array.iter() {
-        let utf16: Vec<u16> = s.unwrap_or_default().encode_utf16().collect();
+    for (i, s) in array.iter().enumerate() {
+        let utf16: Vec<u16> = reject_null_string_element(s, i)?.encode_utf16().collect();
         seq.serialize_element(&utf16)?;
     }
     seq.end()
@@ -396,30 +396,9 @@ mod tests {
         messages: &Arc<HashMap<String, HashMap<String, Message>>>,
         names: &[&str],
     ) -> bool {
-        // An array field's column is a single-element `List` whose inner value
-        // holds the array elements (mirrors how dora wraps message fields).
-        let item = Arc::new(Field::new("item", DataType::Utf8, true));
-        let list = ListArray::new(
-            item.clone(),
-            OffsetBuffer::from_lengths([names.len()]),
-            Arc::new(StringArray::from(names.to_vec())),
-            None,
-        );
-        let struct_array = StructArray::from(vec![(
-            Arc::new(Field::new("names", DataType::List(item), false)),
-            Arc::new(list) as ArrayRef,
-        )]);
-        let value = Arc::new(struct_array) as ArrayRef;
-        let type_info = TypeInfo {
-            package_name: Cow::Borrowed("test_msgs"),
-            message_name: Cow::Borrowed("ArrMsg"),
-            messages: messages.clone(),
-        };
-        let typed = TypedValue {
-            value: &value,
-            type_info: &type_info,
-        };
-        cdr_encoding::to_vec::<_, LittleEndian>(&typed).is_ok()
+        // All-present case: delegate to the nullable helper below, which handles
+        // the (superset) `Vec<Option<&str>>` shape.
+        serializes_ok_with_nulls(messages, names.iter().map(|s| Some(*s)).collect())
     }
 
     /// #2027: a fixed-size `string[3]` field given the wrong number of elements
@@ -449,6 +428,67 @@ mod tests {
         assert!(
             serializes_ok(&messages, &["a", "b", "c"]),
             "size-3 field with 3 elements must serialize"
+        );
+    }
+
+    /// Like `serializes_ok`, but the inner `StringArray` may contain nulls so we
+    /// can exercise the null-element path of a fixed `string[N]` field.
+    fn serializes_ok_with_nulls(
+        messages: &Arc<HashMap<String, HashMap<String, Message>>>,
+        names: Vec<Option<&str>>,
+    ) -> bool {
+        let item = Arc::new(Field::new("item", DataType::Utf8, true));
+        let list = ListArray::new(
+            item.clone(),
+            OffsetBuffer::from_lengths([names.len()]),
+            Arc::new(StringArray::from(names)),
+            None,
+        );
+        let struct_array = StructArray::from(vec![(
+            Arc::new(Field::new("names", DataType::List(item), false)),
+            Arc::new(list) as ArrayRef,
+        )]);
+        let value = Arc::new(struct_array) as ArrayRef;
+        let type_info = TypeInfo {
+            package_name: Cow::Borrowed("test_msgs"),
+            message_name: Cow::Borrowed("ArrMsg"),
+            messages: messages.clone(),
+        };
+        let typed = TypedValue {
+            value: &value,
+            type_info: &type_info,
+        };
+        cdr_encoding::to_vec::<_, LittleEndian>(&typed).is_ok()
+    }
+
+    /// A null element in a fixed `string[N]` field must error rather than be
+    /// silently encoded as `""`. The scalar-string path already rejects nulls
+    /// (ROS2/CDR has no null concept); the array path must honor the same
+    /// invariant instead of inventing an empty string the producer never sent.
+    #[test]
+    fn fixed_string_array_null_element_is_rejected() {
+        let messages = fixed_array_message(NestableType::GenericString(GenericString::String));
+        assert!(
+            !serializes_ok_with_nulls(&messages, vec![Some("a"), None, Some("c")]),
+            "a null element in a string[3] field must error, not encode as \"\""
+        );
+        assert!(
+            serializes_ok_with_nulls(&messages, vec![Some("a"), Some("b"), Some("c")]),
+            "an all-present string[3] field must still serialize"
+        );
+    }
+
+    /// Same null guard on the `wstring[N]` path.
+    #[test]
+    fn fixed_wstring_array_null_element_is_rejected() {
+        let messages = fixed_array_message(NestableType::GenericString(GenericString::WString));
+        assert!(
+            !serializes_ok_with_nulls(&messages, vec![Some("a"), None, Some("c")]),
+            "a null element in a wstring[3] field must error, not encode as \"\""
+        );
+        assert!(
+            serializes_ok_with_nulls(&messages, vec![Some("a"), Some("b"), Some("c")]),
+            "an all-present wstring[3] field must still serialize"
         );
     }
 

--- a/libraries/extensions/ros2-bridge/arrow/src/serialize/mod.rs
+++ b/libraries/extensions/ros2-bridge/arrow/src/serialize/mod.rs
@@ -261,6 +261,26 @@ fn check_not_null<E: serde::ser::Error>(
     Ok(())
 }
 
+/// Reject a null element in a ROS2 `string[]`/`string[N]` (or wstring) column.
+///
+/// The scalar-string path already refuses nulls via [`check_not_null`]; the
+/// array and sequence string paths must honor the same invariant. A ROS2 string
+/// array element is non-nullable on the CDR wire, so a null in the Arrow column
+/// would otherwise be silently encoded as `""` — inventing an empty string the
+/// producer never sent. Reject it instead, matching the scalar path and the
+/// sibling `arrow-convert`/`mavlink2-bridge` layers that also refuse nulls
+/// rather than substitute a default.
+fn reject_null_string_element<E: serde::ser::Error>(
+    element: Option<&str>,
+    index: usize,
+) -> Result<&str, E> {
+    element.ok_or_else(|| {
+        serde::ser::Error::custom(format!(
+            "string array element at index {index} is null, but ROS2 messages cannot represent null"
+        ))
+    })
+}
+
 /// Guard for fixed-size array fields: a ROS2 `T[N]` array has no length prefix
 /// on the CDR wire, so the Arrow column must have exactly `expected` elements.
 /// A mismatch would otherwise emit the wrong element count into a fixed tuple

--- a/libraries/extensions/ros2-bridge/arrow/src/serialize/sequence.rs
+++ b/libraries/extensions/ros2-bridge/arrow/src/serialize/sequence.rs
@@ -9,7 +9,7 @@ use serde::ser::SerializeSeq;
 
 use crate::TypeInfo;
 
-use super::{TypedValue, error};
+use super::{TypedValue, error, reject_null_string_element};
 
 /// Serialize a variable-sized sequence.
 pub struct SequenceSerializeWrapper<'a> {
@@ -215,8 +215,8 @@ where
     O: OffsetSizeTrait,
 {
     let mut seq = serializer.serialize_seq(Some(array.len()))?;
-    for s in array.iter() {
-        seq.serialize_element(s.unwrap_or_default())?;
+    for (i, s) in array.iter().enumerate() {
+        seq.serialize_element(reject_null_string_element(s, i)?)?;
     }
     seq.end()
 }
@@ -230,8 +230,8 @@ where
     O: OffsetSizeTrait,
 {
     let mut seq = serializer.serialize_seq(Some(array.len()))?;
-    for s in array.iter() {
-        let utf16: Vec<u16> = s.unwrap_or_default().encode_utf16().collect();
+    for (i, s) in array.iter().enumerate() {
+        let utf16: Vec<u16> = reject_null_string_element(s, i)?.encode_utf16().collect();
         seq.serialize_element(&utf16)?;
     }
     seq.end()
@@ -354,7 +354,8 @@ mod tests {
 
     use arrow::{
         array::{
-            ArrayRef, BinaryArray, BooleanArray, Int32Array, ListArray, StructArray, UInt8Array,
+            ArrayRef, BinaryArray, BooleanArray, Int32Array, ListArray, StringArray, StructArray,
+            UInt8Array,
         },
         buffer::OffsetBuffer,
         datatypes::{DataType, Field},
@@ -362,7 +363,7 @@ mod tests {
     use byteorder::LittleEndian;
     use dora_ros2_bridge_msg_gen::types::{
         Member, MemberType, Message,
-        primitives::{BasicType, NestableType},
+        primitives::{BasicType, GenericString, NestableType},
         sequences::{BoundedSequence, Sequence},
     };
 
@@ -679,5 +680,70 @@ mod tests {
             type_info: &type_info,
         })
         .expect("Binary within max_size must serialize");
+    }
+
+    /// A message with a single `sequence<string>` (`string[]`) field.
+    fn string_seq_message() -> Arc<HashMap<String, HashMap<String, Message>>> {
+        let message = Message {
+            package: "test_msgs".to_string(),
+            name: "StrSeqMsg".to_string(),
+            members: vec![Member {
+                name: "names".to_string(),
+                r#type: MemberType::Sequence(Sequence {
+                    value_type: NestableType::GenericString(GenericString::String),
+                }),
+                default: None,
+            }],
+            constants: vec![],
+        };
+        let mut package = HashMap::new();
+        package.insert("StrSeqMsg".to_string(), message);
+        let mut messages = HashMap::new();
+        messages.insert("test_msgs".to_string(), package);
+        Arc::new(messages)
+    }
+
+    fn string_seq_serializes_ok(
+        messages: &Arc<HashMap<String, HashMap<String, Message>>>,
+        names: Vec<Option<&str>>,
+    ) -> bool {
+        let item = Arc::new(Field::new("item", DataType::Utf8, true));
+        let list = ListArray::new(
+            item.clone(),
+            OffsetBuffer::from_lengths([names.len()]),
+            Arc::new(StringArray::from(names)),
+            None,
+        );
+        let value = Arc::new(StructArray::from(vec![(
+            Arc::new(Field::new("names", DataType::List(item), false)),
+            Arc::new(list) as ArrayRef,
+        )])) as ArrayRef;
+        let type_info = TypeInfo {
+            package_name: Cow::Borrowed("test_msgs"),
+            message_name: Cow::Borrowed("StrSeqMsg"),
+            messages: messages.clone(),
+        };
+        cdr_encoding::to_vec::<_, LittleEndian>(&TypedValue {
+            value: &value,
+            type_info: &type_info,
+        })
+        .is_ok()
+    }
+
+    /// A null element in a `sequence<string>` (`string[]`) field must error
+    /// rather than be silently encoded as `""` — the scalar-string path already
+    /// rejects nulls (ROS2/CDR cannot represent null) and the sequence path must
+    /// honor the same invariant.
+    #[test]
+    fn string_sequence_null_element_is_rejected() {
+        let messages = string_seq_message();
+        assert!(
+            !string_seq_serializes_ok(&messages, vec![Some("a"), None, Some("c")]),
+            "a null element in a string[] field must error, not encode as \"\""
+        );
+        assert!(
+            string_seq_serializes_ok(&messages, vec![Some("a"), Some("b"), Some("c")]),
+            "an all-present string[] field must still serialize"
+        );
     }
 }


### PR DESCRIPTION
## Summary

The scalar-string serialization path in `libraries/extensions/ros2-bridge/arrow/src/serialize/mod.rs` deliberately **rejects** a null value via `check_not_null`, with a documented rationale:

> ROS2 messages (and the CDR wire format) have no null concept… Serializing that would invent a value the producer never sent, so reject it instead.

The **array** (`string[N]`) and **sequence** (`string[]`) string paths violated that same invariant: they encoded a null element as `""` via `s.unwrap_or_default()`.

## Issue

A producer emitting an Arrow `List<Utf8>` (or `LargeList`) for a ROS2 string-array field with a **null element** — e.g. a `pyarrow` node that leaves a slot unset — had that null silently turned into an empty string on the CDR wire, rather than surfacing an error. This is inconsistent with the module's own null-rejection policy for scalar strings, and invents data the producer never sent (an empty string is a *value*, not "absent", on the wire).

Four functions were affected:
- `serialize_arrow_string` / `serialize_arrow_wstring` in `serialize/array.rs` (fixed `T[N]`)
- `serialize_arrow_string` / `serialize_arrow_wstring` in `serialize/sequence.rs` (variable `T[]`)

## Fix

Route all four element loops through a shared `reject_null_string_element` helper added next to the existing `check_not_null`. It mirrors the scalar path — erroring on a null element (naming the offending index) instead of substituting a default — so scalar, array, and sequence string paths now enforce the identical invariant. No change to the all-present (happy) path: the error `format!` is lazy (`ok_or_else`), so it allocates only when a null is actually present (which aborts the message anyway).

## Validation

- Added regression tests for a null element in `string[N]`, `wstring[N]`, and `string[]` (each asserts the null case errors and the all-present case still serializes). The all-present array test helper was consolidated to delegate to the nullable one (no duplicate scaffolding).
- `cargo test -p dora-ros2-bridge-arrow` → 24 passed, 0 failed.
- `cargo fmt -p dora-ros2-bridge-arrow -- --check` clean; `cargo clippy -p dora-ros2-bridge-arrow --tests -- -D warnings` clean.
- Rebased on current `origin/main`; full-workspace fmt + clippy pass, and the full test suite passes except pre-existing zenoh/rmw networking tests that require IPv6 (unavailable in this CI sandbox) — unrelated to this change.

---

⚠️ **This is a machine-generated change**, authored by Claude (an AI agent) as part of an automated code-review pass and reviewed for correctness. Please review carefully before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_014Yn5Z4p2j3uCKvBRaRh241)_