### PR TITLE
docs(node-api): add compile-checked doctests for send_output and recv

### DIFF
--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -787,6 +787,28 @@ impl EventStream {
     /// If you want to receive the events in their original chronological order, use the
     /// asynchronous [`StreamExt::next`](futures::StreamExt::next) method instead ([`EventStream`] implements the
     /// [`Stream`] trait).
+    ///
+    /// The canonical node loop drains this stream until it closes, reacting to
+    /// the events the node cares about (typically [`Event::Input`]) and ignoring
+    /// the rest:
+    ///
+    /// ```no_run
+    /// use dora_node_api::{DoraNode, Event};
+    ///
+    /// let (_node, mut events) = DoraNode::init_from_env()?;
+    ///
+    /// while let Some(event) = events.recv() {
+    ///     match event {
+    ///         Event::Input { id, metadata: _, data } => {
+    ///             // react to the input `id`, reading the Arrow `data`
+    ///             println!("received input `{id}` with {} element(s)", data.len());
+    ///         }
+    ///         Event::Stop(_) => break,
+    ///         _ => {}
+    ///     }
+    /// }
+    /// # Ok::<(), eyre::Report>(())
+    /// ```
     pub fn recv(&mut self) -> Option<Event> {
         futures::executor::block_on(self.recv_async())
     }

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -1557,14 +1557,31 @@ impl DoraNode {
         self.send_output_sample(output_id, parameters, Some(sample))
     }
 
-    /// Sends the give Arrow array as an output message.
+    /// Sends the given Arrow array as an output message.
     ///
-    /// Uses shared memory for efficient data transfer if suitable.
+    /// This is the recommended way to emit data from a node: pass any value that
+    /// implements [`IntoArrow`] (primitives, `Vec<T>`, `&str`, an Arrow array,
+    /// …) and dora moves it into shared memory for an efficient, near-zero-copy
+    /// transfer to downstream nodes.
     ///
-    /// This method might copy the message once to move it to shared memory.
+    /// Uses shared memory for efficient data transfer if suitable. This method
+    /// might copy the message once to move it to shared memory.
     ///
     /// Ignores the output if the given `output_id` is not specified as node output in the dataflow
     /// configuration file.
+    ///
+    /// ```no_run
+    /// use dora_node_api::{DoraNode, MetadataParameters};
+    /// use dora_core::config::DataId;
+    ///
+    /// let (mut node, _events) = DoraNode::init_from_env()?;
+    ///
+    /// let output = DataId::from("output_id".to_owned());
+    /// let parameters = MetadataParameters::default();
+    ///
+    /// node.send_output(output, parameters, vec![1.0f32, 2.0, 3.0])?;
+    /// # Ok::<(), eyre::Report>(())
+    /// ```
     pub fn send_output(
         &mut self,
         output_id: DataId,


### PR DESCRIPTION
## Summary

The two primary verbs of the node API — sending an output and receiving an event — had **no runnable examples** on their own doc pages, even though the lower-level `send_output_raw` already carries one. This PR fills that gap with compile-checked (`no_run`) doctests.

## Issue

- `DoraNode::send_output` (`apis/rust/node/src/node/mod.rs`) is the recommended way to emit data (`IntoArrow` payload → shared memory), but its doc block was prose-only, while the more advanced `send_output_raw` right below it has a full example. New users hit the example on the wrong (lower-level) method.
- `EventStream::recv` (`apis/rust/node/src/event_stream/mod.rs`) described the canonical `while let Some(event) = events.recv()` / `match Event::Input { .. }` loop in prose but showed no code — this is the single most-copied snippet for anyone writing a node.

## Fix

- Added a `no_run` doctest to `send_output` showing an `IntoArrow` payload (`Vec<f32>`) being sent, and noted the `IntoArrow` contract in the prose.
- Added a `no_run` doctest to `recv` showing the canonical event loop (react to `Event::Input`, `break` on `Event::Stop`, ignore the rest).
- Fixed a small typo in the `send_output` summary ("give" → "given").

Both examples are written to compile without warnings (no unused imports/bindings).

## Validation

- `cargo test --doc -p dora-node-api` compiles both new doctests (`send_output` and `recv`) with no warnings.
- `cargo fmt` clean.
- These follow the pattern of recently-merged doctest PRs in this repo (e.g. #3227, #3225).

---

⚠️ **This is a machine-generated change**, authored by Claude (an AI agent) as part of an automated code-review pass and reviewed for correctness. Please review carefully before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_014Yn5Z4p2j3uCKvBRaRh241)_