### PR TITLE
fix(node-api): drop unused `OutputJson` test import

### DIFF
--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -3647,7 +3647,7 @@ mod tests {
         drop(events);
     }
 
-    use crate::integration_testing::{OutputJson, OutputReceiver, drain_outputs};
+    use crate::integration_testing::{OutputReceiver, drain_outputs};
 
     /// Helper: create a minimal test node with a channel output.
     fn test_node() -> (DoraNode, crate::EventStream, OutputReceiver) {


### PR DESCRIPTION
## Summary

Fixes #3259.

The `test_node` helper in `apis/rust/node/src/node/mod.rs` switched to returning the opaque `OutputReceiver` newtype in #3239 (`refactor!: hide tokio from the integration-testing API`). That left `OutputJson` imported but referenced nowhere else in the file:

```rust
use crate::integration_testing::{OutputJson, OutputReceiver, drain_outputs};
```

## Fix

Drop `OutputJson` from the import:

```rust
use crate::integration_testing::{OutputReceiver, drain_outputs};
```

The dangling import lives in a `#[cfg(test)]` module, so it is not caught by the standard PR gate (`cargo clippy --all -- -D warnings` does not compile `cfg(test)` modules), but it emits `warning: unused import: OutputJson` on `cargo test -p dora-node-api` and would fail a stricter `clippy --all-targets -- -D warnings` run.

## Validation

- `cargo test -p dora-node-api --no-run` — compiles clean, warning gone.
- `cargo clippy -p dora-node-api --all-targets` — no `OutputJson` / unused-import warning.
- `cargo fmt --all -- --check` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7q1v9CUH5yvDwL1gWMbwG)_