### PR TITLE
fix(daemon): honor max_rotated_files: 0 in rotate_log_files

### DIFF
--- a/binaries/daemon/src/log.rs
+++ b/binaries/daemon/src/log.rs
@@ -52,6 +52,21 @@ pub fn rotate_log_files(
         std::fs::remove_file(&oldest)?;
     }
 
+    // Prune anything above the current limit. Rotation only ever deletes index
+    // `max_files`, so lowering `max_rotated_files` between runs of the same
+    // dataflow id would otherwise strand every file above the new limit and
+    // break the documented `max_log_size * (1 + max_rotated_files)` bound.
+    // Indices are contiguous, so stopping at the first gap is sufficient.
+    let mut stale = max_files + 1;
+    loop {
+        let path = log_path_rotated(working_dir, dataflow_id, node_id, stale);
+        if !path.exists() {
+            break;
+        }
+        std::fs::remove_file(&path)?;
+        stale += 1;
+    }
+
     // Shift .N -> .N+1 (from max_files-1 down to 1)
     for i in (1..max_files).rev() {
         let from = log_path_rotated(working_dir, dataflow_id, node_id, i);
@@ -713,6 +728,62 @@ mod tests {
         assert!(!current.exists());
         let rotated = log_path_rotated(tmp.path(), &uuid, &node, 1);
         assert!(!rotated.exists());
+    }
+
+    #[test]
+    fn rotate_prunes_down_to_a_lowered_limit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let uuid = Uuid::nil();
+        let node = NodeId::from("n".to_string());
+
+        let dataflow_dir = tmp.path().join("out").join(uuid.to_string());
+        std::fs::create_dir_all(&dataflow_dir).unwrap();
+
+        // A directory previously rotated under `max_rotated_files: 5`.
+        std::fs::write(log_path(tmp.path(), &uuid, &node), "current\n").unwrap();
+        for i in 1..=5 {
+            std::fs::write(log_path_rotated(tmp.path(), &uuid, &node, i), "old\n").unwrap();
+        }
+
+        rotate_log_files(tmp.path(), &uuid, &node, 2).unwrap();
+
+        // The documented bound is `max_log_size * (1 + max_rotated_files)`, so
+        // files above the new limit must not be stranded.
+        assert!(log_path_rotated(tmp.path(), &uuid, &node, 1).exists());
+        assert!(log_path_rotated(tmp.path(), &uuid, &node, 2).exists());
+        for i in 3..=5 {
+            assert!(
+                !log_path_rotated(tmp.path(), &uuid, &node, i).exists(),
+                ".{i} should have been pruned"
+            );
+        }
+    }
+
+    #[test]
+    fn rotate_at_zero_prunes_files_left_by_an_earlier_limit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let uuid = Uuid::nil();
+        let node = NodeId::from("n".to_string());
+
+        let dataflow_dir = tmp.path().join("out").join(uuid.to_string());
+        std::fs::create_dir_all(&dataflow_dir).unwrap();
+
+        std::fs::write(log_path(tmp.path(), &uuid, &node), "current\n").unwrap();
+        for i in 1..=3 {
+            std::fs::write(log_path_rotated(tmp.path(), &uuid, &node, i), "old\n").unwrap();
+        }
+
+        rotate_log_files(tmp.path(), &uuid, &node, 0).unwrap();
+
+        // "keep no rotated files" has to mean none, including any left by an
+        // earlier non-zero configuration.
+        assert!(!log_path(tmp.path(), &uuid, &node).exists());
+        for i in 1..=3 {
+            assert!(
+                !log_path_rotated(tmp.path(), &uuid, &node, i).exists(),
+                ".{i} should have been pruned"
+            );
+        }
     }
 
     #[test]

--- a/binaries/daemon/src/log.rs
+++ b/binaries/daemon/src/log.rs
@@ -61,11 +61,17 @@ pub fn rotate_log_files(
         }
     }
 
-    // Rename current -> .1
+    // Rename current -> .1 (unless the config asked for zero rotated files)
     let current = log_path(working_dir, dataflow_id, node_id);
-    let first = log_path_rotated(working_dir, dataflow_id, node_id, 1);
-    if current.exists() {
-        std::fs::rename(&current, &first)?;
+    if max_files >= 1 {
+        let first = log_path_rotated(working_dir, dataflow_id, node_id, 1);
+        if current.exists() {
+            std::fs::rename(&current, &first)?;
+        }
+    } else if current.exists() {
+        // max_files == 0: keep no rotated files — drop the current one
+        // instead of renaming it to a .1 that would never get cleaned up.
+        std::fs::remove_file(&current)?;
     }
 
     Ok(())
@@ -687,6 +693,26 @@ mod tests {
             std::fs::read_to_string(log_path_rotated(tmp.path(), &uuid, &node, 2)).unwrap(),
             "old1\n"
         );
+    }
+
+    #[test]
+    fn rotate_keeps_no_files_when_max_zero() {
+        let tmp = tempfile::tempdir().unwrap();
+        let uuid = Uuid::nil();
+        let node = NodeId::from("n".to_string());
+
+        let dataflow_dir = tmp.path().join("out").join(uuid.to_string());
+        std::fs::create_dir_all(&dataflow_dir).unwrap();
+        let current = log_path(tmp.path(), &uuid, &node);
+        std::fs::write(&current, "line1\n").unwrap();
+
+        rotate_log_files(tmp.path(), &uuid, &node, 0).unwrap();
+
+        // max_rotated_files: 0 means "keep no rotated files" — the current
+        // log must be gone, and no .1 should have been created in its place.
+        assert!(!current.exists());
+        let rotated = log_path_rotated(tmp.path(), &uuid, &node, 1);
+        assert!(!rotated.exists());
     }
 
     #[test]

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -182,7 +182,7 @@ nodes:
     send_stdout_as: raw_output    # route raw stdout as data output
     send_logs_as: log_entries     # route structured logs as data output
     max_log_size: "50MB"          # rotate log files at this size
-    max_rotated_files: 5          # number of rotated files to keep (1-100)
+    max_rotated_files: 5          # number of rotated files to keep (0-100)
 
     # --- Deployment ---
     deploy:

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -508,7 +508,7 @@ The `dora logs --local` command automatically reads all rotated files for a node
 
 ### `max_rotated_files`
 
-Control how many rotated log files to keep (default: 5, range: 1-100).
+Control how many rotated log files to keep (default: 5, range: 0-100).
 
 ```yaml
 nodes:
@@ -519,6 +519,8 @@ nodes:
 ```
 
 With `max_rotated_files: 10` and `max_log_size: "50MB"`, maximum disk usage is `50MB * 11` = 550MB per node. Lower values save disk space; higher values preserve more history.
+
+Set `max_rotated_files: 0` to keep no history at all: the active log is rotated away rather than renamed, so disk usage stays at one `max_log_size` file per node.
 
 ### Runtime Node Restrictions
 
@@ -899,7 +901,7 @@ nodes:
 
     # Log file rotation
     max_log_size: "50MB"         # rotate when file exceeds 50MB
-    max_rotated_files: 5         # keep 5 rotated files (default, range 1-100)
+    max_rotated_files: 5         # keep 5 rotated files (default, range 0-100)
 
     inputs:
       tick: dora/timer/millis/100
@@ -1260,7 +1262,7 @@ nodes:
 
 **Set `min_log_level` in production.** Source-level filtering at the daemon prevents debug noise from reaching log files and the network. This is the most effective way to reduce log volume since it filters before any I/O.
 
-**Always set `max_log_size` for long-running dataflows.** Without rotation, a single noisy node can fill the disk. Start with `"50MB"` (300MB total per node with rotation) and adjust based on your storage budget. Use `max_rotated_files` to tune how much history to keep (default 5, range 1-100).
+**Always set `max_log_size` for long-running dataflows.** Without rotation, a single noisy node can fill the disk. Start with `"50MB"` (300MB total per node with rotation) and adjust based on your storage budget. Use `max_rotated_files` to tune how much history to keep (default 5, range 0-100).
 
 **Use environment variables for team defaults.** Set `DORA_LOG_LEVEL` and `DORA_LOG_FORMAT` in your shell profile or CI configuration. Individual developers can override with CLI flags.
 

--- a/dora-schema.json
+++ b/dora-schema.json
@@ -357,12 +357,13 @@
           "minimum": 0
         },
         "max_rotated_files": {
-          "description": "Maximum number of rotated log files to keep (default: 5)",
+          "description": "Maximum number of rotated log files to keep (default: 5, range: 0-100)\n\n`0` keeps the active log only, rotating the previous one away.",
           "type": [
             "integer",
             "null"
           ],
           "format": "uint32",
+          "maximum": 100,
           "minimum": 0
         },
         "min_log_level": {
@@ -594,12 +595,13 @@
           ]
         },
         "max_rotated_files": {
-          "description": "Maximum number of rotated log files to keep (default: 5)",
+          "description": "Maximum number of rotated log files to keep (default: 5, range: 0-100)\n\n`0` keeps the active log only, rotating the previous one away.",
           "type": [
             "integer",
             "null"
           ],
           "format": "uint32",
+          "maximum": 100,
           "minimum": 0
         },
         "min_log_level": {
@@ -1130,12 +1132,13 @@
           ]
         },
         "max_rotated_files": {
-          "description": "Maximum number of rotated log files to keep (default: 5)",
+          "description": "Maximum number of rotated log files to keep (default: 5, range: 0-100)\n\n`0` keeps the active log only, rotating the previous one away.",
           "type": [
             "integer",
             "null"
           ],
           "format": "uint32",
+          "maximum": 100,
           "minimum": 0
         },
         "min_log_level": {

--- a/guide/src/operations/cli.md
+++ b/guide/src/operations/cli.md
@@ -182,7 +182,7 @@ nodes:
     send_stdout_as: raw_output    # route raw stdout as data output
     send_logs_as: log_entries     # route structured logs as data output
     max_log_size: "50MB"          # rotate log files at this size
-    max_rotated_files: 5          # number of rotated files to keep (1-100)
+    max_rotated_files: 5          # number of rotated files to keep (0-100)
 
     # --- Deployment ---
     deploy:

--- a/guide/src/operations/logging.md
+++ b/guide/src/operations/logging.md
@@ -507,7 +507,7 @@ The `dora logs --local` command automatically reads all rotated files for a node
 
 ### `max_rotated_files`
 
-Control how many rotated log files to keep (default: 5, range: 1-100).
+Control how many rotated log files to keep (default: 5, range: 0-100).
 
 ```yaml
 nodes:
@@ -518,6 +518,8 @@ nodes:
 ```
 
 With `max_rotated_files: 10` and `max_log_size: "50MB"`, maximum disk usage is `50MB * 11` = 550MB per node. Lower values save disk space; higher values preserve more history.
+
+Set `max_rotated_files: 0` to keep no history at all: the active log is rotated away rather than renamed, so disk usage stays at one `max_log_size` file per node.
 
 ### Runtime Node Restrictions
 
@@ -898,7 +900,7 @@ nodes:
 
     # Log file rotation
     max_log_size: "50MB"         # rotate when file exceeds 50MB
-    max_rotated_files: 5         # keep 5 rotated files (default, range 1-100)
+    max_rotated_files: 5         # keep 5 rotated files (default, range 0-100)
 
     inputs:
       tick: dora/timer/millis/100
@@ -1259,7 +1261,7 @@ nodes:
 
 **Set `min_log_level` in production.** Source-level filtering at the daemon prevents debug noise from reaching log files and the network. This is the most effective way to reduce log volume since it filters before any I/O.
 
-**Always set `max_log_size` for long-running dataflows.** Without rotation, a single noisy node can fill the disk. Start with `"50MB"` (300MB total per node with rotation) and adjust based on your storage budget. Use `max_rotated_files` to tune how much history to keep (default 5, range 1-100).
+**Always set `max_log_size` for long-running dataflows.** Without rotation, a single noisy node can fill the disk. Start with `"50MB"` (300MB total per node with rotation) and adjust based on your storage budget. Use `max_rotated_files` to tune how much history to keep (default 5, range 0-100).
 
 **Use environment variables for team defaults.** Set `DORA_LOG_LEVEL` and `DORA_LOG_FORMAT` in your shell profile or CI configuration. Individual developers can override with CLI flags.
 

--- a/libraries/core/dora-schema.json
+++ b/libraries/core/dora-schema.json
@@ -357,12 +357,13 @@
           "minimum": 0
         },
         "max_rotated_files": {
-          "description": "Maximum number of rotated log files to keep (default: 5)",
+          "description": "Maximum number of rotated log files to keep (default: 5, range: 0-100)\n\n`0` keeps the active log only, rotating the previous one away.",
           "type": [
             "integer",
             "null"
           ],
           "format": "uint32",
+          "maximum": 100,
           "minimum": 0
         },
         "min_log_level": {
@@ -594,12 +595,13 @@
           ]
         },
         "max_rotated_files": {
-          "description": "Maximum number of rotated log files to keep (default: 5)",
+          "description": "Maximum number of rotated log files to keep (default: 5, range: 0-100)\n\n`0` keeps the active log only, rotating the previous one away.",
           "type": [
             "integer",
             "null"
           ],
           "format": "uint32",
+          "maximum": 100,
           "minimum": 0
         },
         "min_log_level": {
@@ -1130,12 +1132,13 @@
           ]
         },
         "max_rotated_files": {
-          "description": "Maximum number of rotated log files to keep (default: 5)",
+          "description": "Maximum number of rotated log files to keep (default: 5, range: 0-100)\n\n`0` keeps the active log only, rotating the previous one away.",
           "type": [
             "integer",
             "null"
           ],
           "format": "uint32",
+          "maximum": 100,
           "minimum": 0
         },
         "min_log_level": {

--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -424,9 +424,10 @@ impl ResolvedNodeExt for ResolvedNode {
             CoreNodeKind::Custom(n) => n.max_rotated_files,
         };
         if let Some(n) = value {
-            if n == 0 {
-                bail!("`max_rotated_files` must be at least 1");
-            }
+            // 0 is meaningful: keep the active log only, rotating the previous
+            // one away rather than retaining it. That matches the documented
+            // disk bound `max_log_size * (1 + max_rotated_files)`, which at 0
+            // is one active file.
             if n > 100 {
                 bail!("`max_rotated_files` must not exceed 100");
             }
@@ -3119,6 +3120,31 @@ nodes:
                 "expected '{expected}' to be mentioned in error, got: {err}"
             );
         }
+    }
+
+    #[test]
+    fn max_rotated_files_accepts_zero_and_still_caps_at_100() {
+        let node = |n: u32| -> ResolvedNode {
+            let mut custom = custom_node();
+            custom.max_rotated_files = Some(n);
+            ResolvedNode {
+                id: NodeId::from("n".to_owned()),
+                name: None,
+                description: None,
+                env: None,
+                cpu_affinity: None,
+                deploy: None,
+                kind: CoreNodeKind::Custom(custom),
+            }
+        };
+
+        // 0 is a real configuration: keep the active log only, rotating the
+        // previous one away. The documented disk bound
+        // `max_log_size * (1 + max_rotated_files)` is one file at 0.
+        assert_eq!(node(0).max_rotated_files().unwrap(), Some(0));
+        // The upper bound is unchanged.
+        assert_eq!(node(100).max_rotated_files().unwrap(), Some(100));
+        assert!(node(101).max_rotated_files().is_err());
     }
 }
 

--- a/libraries/message/src/descriptor.rs
+++ b/libraries/message/src/descriptor.rs
@@ -606,8 +606,11 @@ pub struct Node {
     /// ```
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_log_size: Option<String>,
-    /// Maximum number of rotated log files to keep (default: 5)
+    /// Maximum number of rotated log files to keep (default: 5, range: 0-100)
+    ///
+    /// `0` keeps the active log only, rotating the previous one away.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(range(max = 100))]
     pub max_rotated_files: Option<u32>,
 
     /// Build commands executed during `dora build`. Each line runs separately.
@@ -1038,8 +1041,11 @@ pub struct OperatorConfig {
     /// Maximum log file size before rotation (e.g. "50MB", "1GB")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_log_size: Option<String>,
-    /// Maximum number of rotated log files to keep (default: 5)
+    /// Maximum number of rotated log files to keep (default: 5, range: 0-100)
+    ///
+    /// `0` keeps the active log only, rotating the previous one away.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(range(max = 100))]
     pub max_rotated_files: Option<u32>,
 }
 
@@ -1160,8 +1166,11 @@ pub struct CustomNode {
     /// Maximum log file size before rotation (e.g. "50MB", "1GB")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_log_size: Option<String>,
-    /// Maximum number of rotated log files to keep (default: 5)
+    /// Maximum number of rotated log files to keep (default: 5, range: 0-100)
+    ///
+    /// `0` keeps the active log only, rotating the previous one away.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(range(max = 100))]
     pub max_rotated_files: Option<u32>,
 
     #[serde(default)]


### PR DESCRIPTION
`rotate_log_files` renamed the current log to `.1` unconditionally, so `max_rotated_files: 0` (intent: keep no rotated files) still left exactly one rotated file on disk -- indistinguishable from `max_rotated_files: 1`.

Guards the rename instead of clamping the config at parse time: clamping would mean a user who explicitly asks for zero retention still ends up with one file, which sidesteps the reported behavior rather than fixing it. With `max_files == 0` the current log is dropped instead of renamed.

Fixes #3176