### PR TITLE
docs(message): document the OperatorId public type

### DIFF
--- a/libraries/message/src/id.rs
+++ b/libraries/message/src/id.rs
@@ -192,6 +192,32 @@ impl AsRef<str> for NodeId {
     }
 }
 
+/// The identifier of an operator running inside a `dora runtime` node.
+///
+/// An operator is addressed as `<node_id>/<operator_id>/<output_id>`, so an
+/// `OperatorId` is the middle segment of a runtime output's fully-qualified
+/// name.
+///
+/// Unlike [`NodeId`] and [`DataId`], an `OperatorId` is **not** validated:
+/// [`FromStr`] is [`Infallible`] and [`From<String>`] accepts any string
+/// verbatim (this is why it derives `Deserialize` directly rather than through
+/// a validating deserializer). Callers are responsible for not embedding a `/`
+/// in an operator id — a `/` collides with the `<node>/<operator>/<output>`
+/// addressing separator and makes the operator unaddressable (it would resolve
+/// to a different operator/output split).
+///
+/// ```
+/// use dora_message::id::OperatorId;
+///
+/// // Construction is infallible from both `&str` and `String`:
+/// let from_str: OperatorId = "detector".parse().unwrap(); // FromStr is Infallible
+/// let from_string = OperatorId::from("detector".to_string());
+/// assert_eq!(from_str, from_string);
+///
+/// // Display and AsRef expose the underlying id:
+/// assert_eq!(from_str.to_string(), "detector");
+/// assert_eq!(from_str.as_ref(), "detector");
+/// ```
 #[derive(
     Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize, JsonSchema,
 )]


### PR DESCRIPTION
> ⚠️ **Machine-generated PR.** This change was authored by Claude (Anthropic's Claude Code) during an automated codebase review. Please review carefully before merging.

## Issue

`OperatorId` is a public type in `dora-message` (`libraries/message/src/id.rs`), but — unlike its siblings `NodeId` and `DataId` in the same file, which each carry extensive doc comments and validating constructors — it had **no documentation at all**. It sits in the middle of the `<node_id>/<operator_id>/<output_id>` addressing syntax, yet nothing explained its role or the notable asymmetry that, unlike `NodeId`/`DataId`, it is intentionally **unvalidated**: `FromStr` is `Infallible`, `From<String>` accepts any string verbatim, and it derives `Deserialize` directly rather than through a validating deserializer.

## Fix

Add a doc comment matching the `NodeId`/`DataId` style, including:
- what an `OperatorId` is and its place in the addressing syntax,
- the intentional lack of validation and why it differs from the siblings,
- an explicit caller caveat that a `/` in an operator id collides with the addressing separator,
- a **compile-checked doctest** covering construction (from `&str` and `String`), `Display`, and `AsRef`.

Documentation only — no behavior change. Scoped deliberately to docs; adding validation would be a behavior change (it could reject operator ids that existing dataflows use) and is out of scope here.

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p dora-message -- -D warnings` — clean
- `cargo test -p dora-message --doc` — 11 doctests pass, including the new `OperatorId` example
- Reviewed with `/code-review` and `/simplify`: every doc claim verified accurate against the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ND9WUgB4LmemR31SLpuXoF

---
_Generated by [Claude Code](https://claude.ai/code/session_01ND9WUgB4LmemR31SLpuXoF)_