### PR TITLE
refactor(node-api): drop dead Result wrapping in data_to_arrow_array

### DIFF
--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -1713,15 +1713,10 @@ fn prime_in_band(
 pub fn data_to_arrow_array(
     data: Option<DataMessage>,
 ) -> eyre::Result<Arc<dyn arrow::array::Array>> {
-    let data: eyre::Result<Option<RawData>> = match data {
-        None => Ok(None),
-        Some(DataMessage::Vec(v)) => Ok(Some(RawData::Vec(v))),
-    };
-
-    data.and_then(|data| {
-        let raw_data = data.unwrap_or(RawData::Empty);
-        raw_data.into_arrow_array().map(arrow::array::make_array)
-    })
+    // `DataMessage` has a single infallible variant, so the conversion cannot
+    // fail; the only fallible step is `into_arrow_array`.
+    let raw_data = data.map_or(RawData::Empty, |DataMessage::Vec(v)| RawData::Vec(v));
+    raw_data.into_arrow_array().map(arrow::array::make_array)
 }
 
 impl Stream for EventStream {


### PR DESCRIPTION
> ⚠️ **Machine-generated PR.** This change was authored by Claude (Anthropic's Claude Code) during an automated codebase review. Please review carefully before merging.

## Issue

`data_to_arrow_array` (`apis/rust/node/src/event_stream/mod.rs`) wrapped an **infallible** conversion in `eyre::Result` and threaded it through `and_then`:

```rust
let data: eyre::Result<Option<RawData>> = match data {
    None => Ok(None),
    Some(DataMessage::Vec(v)) => Ok(Some(RawData::Vec(v))),
};
data.and_then(|data| {
    let raw_data = data.unwrap_or(RawData::Empty);
    raw_data.into_arrow_array().map(arrow::array::make_array)
})
```

`DataMessage` is a single-variant enum (`Vec(..)` only — see `libraries/message/src/common.rs`), so neither match arm can ever produce `Err`. The `Result`/`and_then` scaffolding was pure ceremony around a conversion that cannot fail.

## Fix

Collapse to a direct `map_or`, leaving `into_arrow_array` as the sole genuinely fallible step:

```rust
let raw_data = data.map_or(RawData::Empty, |DataMessage::Vec(v)| RawData::Vec(v));
raw_data.into_arrow_array().map(arrow::array::make_array)
```

No behavior change — the decoded-input path is identical, just clearer.

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p dora-node-api -- -D warnings` — clean
- `cargo test -p dora-node-api` — all lib/integration tests pass (182 lib tests green). The two `zenoh_schema_cache` integration tests fail identically on unmodified `origin/main` in this sandbox (they require zenoh multicast/liveliness networking that is unavailable here) — unrelated to this change, which those tests do not exercise.
- Reviewed with `/code-review` and `/simplify`: confirmed `DataMessage` is genuinely single-variant, so the rewrite is behavior-preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ND9WUgB4LmemR31SLpuXoF

---
_Generated by [Claude Code](https://claude.ai/code/session_01ND9WUgB4LmemR31SLpuXoF)_