### PR TITLE
docs(node-api): remove stale misattributed comment on large_send_diag_count

### DIFF
--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -776,8 +776,6 @@ pub struct DoraNode {
     /// the schema is only re-published when it changes or a publish failed) and
     /// the time of the last full-stream send (for the periodic in-band refresh).
     zenoh_schema_state: HashMap<DataId, SchemaOnceState>,
-    /// Threshold for using zenoh SHM vs inline bytes (default 4096).
-
     /// Diagnostic (dora-rs/dora#2742): how many large sends have already been
     /// traced hop-by-hop. The Windows nightly wedges the *runtime's* main loop
     /// inside `send_output` on the very first large output, so tracing only the


### PR DESCRIPTION
> ⚠️ **Machine-generated PR.** This change was authored by Claude (Anthropic's Claude Code) during an automated codebase review. Please review carefully before merging.

## Issue

In `DoraNode` (`apis/rust/node/src/node/mod.rs`), an outer doc comment sat orphaned between two fields:

```rust
zenoh_schema_state: HashMap<DataId, SchemaOnceState>,
/// Threshold for using zenoh SHM vs inline bytes (default 4096).

/// Diagnostic (dora-rs/dora#2742): how many large sends have already been
/// traced hop-by-hop. ...
large_send_diag_count: u32,
```

The line `/// Threshold for using zenoh SHM vs inline bytes (default 4096).` is a leftover from when `DoraNode` had its own `zero_copy_threshold` field; that value now lives on `SampleAllocator` (`self.sample_allocator.zero_copy_threshold`). As an outer doc comment (`///`) it no longer documents any field — a blank line does **not** detach it — so it attaches to the next field, `large_send_diag_count`, prefixing that diagnostic counter's rendered docs with an unrelated, incorrect sentence about an SHM threshold.

## Fix

Delete the stale line. Documentation only — no behavior change.

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p dora-node-api -- -D warnings` — clean
- Confirmed there is no `threshold`/`zero_copy_threshold` field between the two comments; the threshold is stored only on `SampleAllocator`.
- Reviewed with `/code-review` and `/simplify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ND9WUgB4LmemR31SLpuXoF

---
_Generated by [Claude Code](https://claude.ai/code/session_01ND9WUgB4LmemR31SLpuXoF)_