### PR TITLE
docs(node-api): correct Event::Reload operator_id doc

### DIFF
--- a/apis/rust/node/src/event_stream/event.rs
+++ b/apis/rust/node/src/event_stream/event.rs
@@ -73,7 +73,10 @@ pub enum Event {
     Reload {
         /// The ID of the operator that should be reloaded.
         ///
-        /// There is currently no case where `operator_id` is `None`.
+        /// `Some(id)` targets a single operator (the Python-operator reload
+        /// path always sets this). `None` requests reloading the whole runtime
+        /// node, which the runtime currently rejects with a warning rather than
+        /// acting on ("Reloading runtime nodes is not supported").
         operator_id: Option<OperatorId>,
     },
     /// A runtime parameter has been updated via `dora param set`.


### PR DESCRIPTION
> ⚠️ **Machine-generated PR.** This change was authored by Claude (Anthropic's Claude Code) during an automated codebase review. Please review carefully before merging.

## Issue

The doc comment on the public `Event::Reload { operator_id }` field (`apis/rust/node/src/event_stream/event.rs`) claimed:

```rust
/// There is currently no case where `operator_id` is `None`.
operator_id: Option<OperatorId>,
```

This is contradicted by the codebase itself. The runtime explicitly matches and handles the `None` arm (`binaries/runtime-api/src/lib.rs`):

```rust
RuntimeEvent::Event(Event::Reload { operator_id: None }) => {
    tracing::warn!("Reloading runtime nodes is not supported");
}
```

and `convert_event_item` passes the wire value straight through as `Option` without substituting a value, so a `None` can in fact be delivered. The absolute "no case where it is `None`" note is therefore misleading.

## Fix

Reword to describe the actual behavior: `Some(id)` targets a single operator (the Python-operator reload path always sets it), while `None` requests a whole-node reload that the runtime currently rejects with a warning. Documentation only — no behavior change.

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p dora-node-api -- -D warnings` — clean
- Verified the reworded doc matches the `None` handling in `runtime-api/src/lib.rs`.
- Reviewed with `/code-review` and `/simplify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ND9WUgB4LmemR31SLpuXoF

---
_Generated by [Claude Code](https://claude.ai/code/session_01ND9WUgB4LmemR31SLpuXoF)_