### PR TITLE
fix(tensor-pool): add missing imports in tensor_info.py

### DIFF
--- a/libraries/extensions/tensor-pool/python/dora_tensor_pool/tensor_info.py
+++ b/libraries/extensions/tensor-pool/python/dora_tensor_pool/tensor_info.py
@@ -10,6 +10,13 @@ it. Reinstating these belongs on the dora-pool side of the seam, not in the
 `dora` package. See ../README.md.
 """
 
+import ctypes
+
+import numpy as np
+import torch
+
+from .cuda import _CudaArrayInterface
+
 _DTYPE_MAP = {
     "<i8": torch.int64,
     "<i4": torch.int32,


### PR DESCRIPTION
## Summary

`libraries/extensions/tensor-pool/python/dora_tensor_pool/tensor_info.py` referenced `torch`, `np`, `ctypes`, and `_CudaArrayInterface` at module scope and in function bodies but had **no** `import` statements. Because `dora_tensor_pool/__init__.py` re-exports `get_tensor_info` / `tensor_from_info` from that module, plain `import dora_tensor_pool` failed at module load time with `NameError: name 'torch' is not defined` (triggered by `_DTYPE_MAP` at module scope). Every consumer that #3249 rewired to the new package was broken.

## Fix

Add the four missing imports at the top of `tensor_info.py`:

- `import ctypes` — used by `tensor_from_info` (`ctypes.c_byte * size`)
- `import numpy as np` — used by `_TORCH_TO_NUMPY_DTYPE_MAP` and the size / shape / dtype validation
- `import torch` — used by both dtype maps and the tensor helpers
- `from .cuda import _CudaArrayInterface` — used in the CUDA branch of `tensor_from_info`. Kept internal to the package by importing the underscore-prefixed name directly from the sibling module (matches how `cuda.py` defines it).

No behavior change — this restores the module to a state where its own code can execute.

Closes #3270

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8qqV6bANor86uowodNAe8)_