### PR TITLE
fix(ros2-bridge): reject null primitive/bool elements in array/sequence serialization

### DIFF
--- a/libraries/extensions/ros2-bridge/arrow/src/serialize/array.rs
+++ b/libraries/extensions/ros2-bridge/arrow/src/serialize/array.rs
@@ -12,7 +12,7 @@ use serde::ser::SerializeTuple;
 
 use crate::TypeInfo;
 
-use super::{TypedValue, check_array_len, error, reject_null_string_element};
+use super::{TypedValue, check_array_len, error, reject_null_element, reject_null_string_element};
 
 /// Serialize an array with known size as tuple.
 pub struct ArraySerializeWrapper<'a> {
@@ -278,6 +278,7 @@ where
             .as_primitive_opt()
             .ok_or_else(|| error(format!("not a primitive {} array", type_name::<T>())))?;
         check_array_len(array.len(), self.len)?;
+        reject_null_element(array, type_name::<T>())?;
 
         for value in array.values() {
             seq.serialize_element(value)?;
@@ -303,6 +304,7 @@ impl serde::Serialize for BoolArrayAsTuple<'_> {
             .as_boolean_opt()
             .ok_or_else(|| error("not a boolean array"))?;
         check_array_len(array.len(), self.len)?;
+        reject_null_element(array, "bool")?;
 
         for value in array.values() {
             seq.serialize_element(&value)?;
@@ -353,7 +355,8 @@ mod tests {
 
     use arrow::{
         array::{
-            ArrayRef, BinaryArray, Int32Array, ListArray, StringArray, StructArray, UInt8Array,
+            ArrayRef, BinaryArray, BooleanArray, Int32Array, ListArray, StringArray, StructArray,
+            UInt8Array,
         },
         buffer::OffsetBuffer,
         datatypes::{DataType, Field},
@@ -641,5 +644,86 @@ mod tests {
             type_info: &type_info(3),
         })
         .expect_err("size-3 field with 2 bytes must error");
+    }
+
+    /// Build a struct with a `names` field wrapping the given `Int32` list, so
+    /// we can drive an `int32[3]` message column with per-element nulls.
+    fn build_int32_array(values: Vec<Option<i32>>) -> ArrayRef {
+        let item = Arc::new(Field::new("item", DataType::Int32, true));
+        let list = ListArray::new(
+            item.clone(),
+            OffsetBuffer::from_lengths([values.len()]),
+            Arc::new(Int32Array::from(values)),
+            None,
+        );
+        let struct_array = StructArray::from(vec![(
+            Arc::new(Field::new("names", DataType::List(item), false)),
+            Arc::new(list) as ArrayRef,
+        )]);
+        Arc::new(struct_array) as ArrayRef
+    }
+
+    /// Same shape for a `Bool` list, so we can drive a `bool[3]` column.
+    fn build_bool_array(values: Vec<Option<bool>>) -> ArrayRef {
+        let item = Arc::new(Field::new("item", DataType::Boolean, true));
+        let list = ListArray::new(
+            item.clone(),
+            OffsetBuffer::from_lengths([values.len()]),
+            Arc::new(BooleanArray::from(values)),
+            None,
+        );
+        let struct_array = StructArray::from(vec![(
+            Arc::new(Field::new("names", DataType::List(item), false)),
+            Arc::new(list) as ArrayRef,
+        )]);
+        Arc::new(struct_array) as ArrayRef
+    }
+
+    fn serializes_primitive_array(value: &ArrayRef, field_type: NestableType) -> bool {
+        let messages = fixed_array_message(field_type);
+        let type_info = TypeInfo {
+            package_name: Cow::Borrowed("test_msgs"),
+            message_name: Cow::Borrowed("ArrMsg"),
+            messages,
+        };
+        cdr_encoding::to_vec::<_, LittleEndian>(&TypedValue {
+            value,
+            type_info: &type_info,
+        })
+        .is_ok()
+    }
+
+    /// #3271: a null element in a fixed `int32[N]` field must be rejected. The
+    /// scalar and string-array paths already reject nulls; the primitive-array
+    /// path previously iterated `array.values()`, which ignores the validity
+    /// bitmap and silently encodes the raw buffer slot (`0`) — inventing a
+    /// value the producer never sent.
+    #[test]
+    fn fixed_int32_array_null_element_is_rejected() {
+        let with_null = build_int32_array(vec![Some(1), None, Some(3)]);
+        assert!(
+            !serializes_primitive_array(&with_null, NestableType::BasicType(BasicType::I32)),
+            "a null element in an int32[3] field must error, not encode as 0"
+        );
+        let all_present = build_int32_array(vec![Some(1), Some(2), Some(3)]);
+        assert!(
+            serializes_primitive_array(&all_present, NestableType::BasicType(BasicType::I32)),
+            "an all-present int32[3] field must still serialize"
+        );
+    }
+
+    /// #3271: same guard on the fixed `bool[N]` path.
+    #[test]
+    fn fixed_bool_array_null_element_is_rejected() {
+        let with_null = build_bool_array(vec![Some(true), None, Some(false)]);
+        assert!(
+            !serializes_primitive_array(&with_null, NestableType::BasicType(BasicType::Bool)),
+            "a null element in a bool[3] field must error, not encode as false"
+        );
+        let all_present = build_bool_array(vec![Some(true), Some(false), Some(true)]);
+        assert!(
+            serializes_primitive_array(&all_present, NestableType::BasicType(BasicType::Bool)),
+            "an all-present bool[3] field must still serialize"
+        );
     }
 }

--- a/libraries/extensions/ros2-bridge/arrow/src/serialize/mod.rs
+++ b/libraries/extensions/ros2-bridge/arrow/src/serialize/mod.rs
@@ -281,6 +281,30 @@ fn reject_null_string_element<E: serde::ser::Error>(
     })
 }
 
+/// Reject a null element in a ROS2 numeric/bool `T[]`/`T[N]` column.
+///
+/// The scalar-primitive and scalar-bool paths already refuse nulls via
+/// [`check_not_null`]; the array and sequence primitive/bool paths must honor
+/// the same invariant. `PrimitiveArray::values()` / `BooleanArray::values()`
+/// return the raw value buffer, so a null slot silently reads as the buffer
+/// default (`0` / `false`) — inventing a value the producer never sent. Reject
+/// it instead, matching the scalar path and the string-element helper
+/// [`reject_null_string_element`] introduced in #3254.
+fn reject_null_element<E: serde::ser::Error>(
+    array: &dyn arrow::array::Array,
+    type_name: &str,
+) -> Result<(), E> {
+    if array.null_count() == 0 {
+        return Ok(());
+    }
+    let index = (0..array.len())
+        .find(|&i| array.is_null(i))
+        .unwrap_or_default();
+    Err(serde::ser::Error::custom(format!(
+        "{type_name} element at index {index} is null, but ROS2 messages cannot represent null"
+    )))
+}
+
 /// Guard for fixed-size array fields: a ROS2 `T[N]` array has no length prefix
 /// on the CDR wire, so the Arrow column must have exactly `expected` elements.
 /// A mismatch would otherwise emit the wrong element count into a fixed tuple

--- a/libraries/extensions/ros2-bridge/arrow/src/serialize/sequence.rs
+++ b/libraries/extensions/ros2-bridge/arrow/src/serialize/sequence.rs
@@ -9,7 +9,7 @@ use serde::ser::SerializeSeq;
 
 use crate::TypeInfo;
 
-use super::{TypedValue, error, reject_null_string_element};
+use super::{TypedValue, error, reject_null_element, reject_null_string_element};
 
 /// Serialize a variable-sized sequence.
 pub struct SequenceSerializeWrapper<'a> {
@@ -255,6 +255,7 @@ where
             .value
             .as_primitive_opt()
             .ok_or_else(|| error(format!("not a primitive {} array", type_name::<T>())))?;
+        reject_null_element(array, type_name::<T>())?;
 
         let mut seq = serializer.serialize_seq(Some(array.len()))?;
 
@@ -334,6 +335,7 @@ impl serde::Serialize for BoolArray<'_> {
             .value
             .as_boolean_opt()
             .ok_or_else(|| error("not a boolean array"))?;
+        reject_null_element(array, "bool")?;
         // Variable-length `sequence<bool>` / `bool[]` must be encoded with a
         // serde sequence so the CDR codec emits the mandatory u32 length
         // prefix. Using `serialize_tuple` here omits that prefix, which makes
@@ -744,6 +746,113 @@ mod tests {
         assert!(
             string_seq_serializes_ok(&messages, vec![Some("a"), Some("b"), Some("c")]),
             "an all-present string[] field must still serialize"
+        );
+    }
+
+    /// A message with a single `sequence<T>` field of the given `value_type`.
+    fn primitive_seq_message(
+        value_type: NestableType,
+    ) -> Arc<HashMap<String, HashMap<String, Message>>> {
+        let message = Message {
+            package: "test_msgs".to_string(),
+            name: "PrimSeqMsg".to_string(),
+            members: vec![Member {
+                name: "values".to_string(),
+                r#type: MemberType::Sequence(Sequence { value_type }),
+                default: None,
+            }],
+            constants: vec![],
+        };
+        let mut package = HashMap::new();
+        package.insert("PrimSeqMsg".to_string(), message);
+        let mut messages = HashMap::new();
+        messages.insert("test_msgs".to_string(), package);
+        Arc::new(messages)
+    }
+
+    fn primitive_seq_serializes_ok(
+        messages: &Arc<HashMap<String, HashMap<String, Message>>>,
+        list: ArrayRef,
+        item_ty: DataType,
+    ) -> bool {
+        let value = Arc::new(StructArray::from(vec![(
+            Arc::new(Field::new(
+                "values",
+                DataType::List(Arc::new(Field::new("item", item_ty, true))),
+                false,
+            )),
+            list,
+        )])) as ArrayRef;
+        let type_info = TypeInfo {
+            package_name: Cow::Borrowed("test_msgs"),
+            message_name: Cow::Borrowed("PrimSeqMsg"),
+            messages: messages.clone(),
+        };
+        cdr_encoding::to_vec::<_, LittleEndian>(&TypedValue {
+            value: &value,
+            type_info: &type_info,
+        })
+        .is_ok()
+    }
+
+    /// #3271: a null element in a `sequence<int32>` (`int32[]`) field must
+    /// error. `BasicSequence::serialize` previously iterated `array.values()`,
+    /// which returns the raw value buffer — a null slot decoded as `0` on the
+    /// receiving ROS2 peer, inventing a value the producer never sent.
+    #[test]
+    fn int32_sequence_null_element_is_rejected() {
+        let messages = primitive_seq_message(NestableType::BasicType(BasicType::I32));
+        let item = Arc::new(Field::new("item", DataType::Int32, true));
+        let with_null = ListArray::new(
+            item.clone(),
+            OffsetBuffer::from_lengths([3usize]),
+            Arc::new(Int32Array::from(vec![Some(1), None, Some(3)])),
+            None,
+        );
+        assert!(
+            !primitive_seq_serializes_ok(&messages, Arc::new(with_null), DataType::Int32),
+            "a null element in an int32[] field must error, not encode as 0"
+        );
+        let all_present = ListArray::new(
+            item,
+            OffsetBuffer::from_lengths([3usize]),
+            Arc::new(Int32Array::from(vec![Some(1), Some(2), Some(3)])),
+            None,
+        );
+        assert!(
+            primitive_seq_serializes_ok(&messages, Arc::new(all_present), DataType::Int32),
+            "an all-present int32[] field must still serialize"
+        );
+    }
+
+    /// #3271: same guard on the `sequence<bool>` (`bool[]`) path.
+    #[test]
+    fn bool_sequence_null_element_is_rejected() {
+        let messages = primitive_seq_message(NestableType::BasicType(BasicType::Bool));
+        let item = Arc::new(Field::new("item", DataType::Boolean, true));
+        let with_null = ListArray::new(
+            item.clone(),
+            OffsetBuffer::from_lengths([3usize]),
+            Arc::new(BooleanArray::from(vec![Some(true), None, Some(false)])),
+            None,
+        );
+        assert!(
+            !primitive_seq_serializes_ok(&messages, Arc::new(with_null), DataType::Boolean),
+            "a null element in a bool[] field must error, not encode as false"
+        );
+        let all_present = ListArray::new(
+            item,
+            OffsetBuffer::from_lengths([3usize]),
+            Arc::new(BooleanArray::from(vec![
+                Some(true),
+                Some(false),
+                Some(true),
+            ])),
+            None,
+        );
+        assert!(
+            primitive_seq_serializes_ok(&messages, Arc::new(all_present), DataType::Boolean),
+            "an all-present bool[] field must still serialize"
         );
     }
 }


### PR DESCRIPTION
## Summary

In the ROS2-bridge Arrow→CDR serializer, a null element inside a primitive or bool `array`/`sequence` field was silently encoded as the buffer default (`0` / `false`) instead of being rejected — a valid CDR message containing values the producer never sent (silent data corruption).

This is the primitive/bool analog of #3254, which covered the string element path. The invariant is documented in `check_not_null` (`serialize/mod.rs`).

**Repro:** producer sends `int32[3] = [1, null, 3]` as a `List<Int32>` → CDR bytes `[1, 0, 3]` reach the ROS2 peer with no error.

**Affected code** (all iterated `array.values()`, which returns the raw value buffer and ignores the validity bitmap):

- `BasicArrayAsTuple::serialize` — fixed `int8[N]`…`float64[N]` (`serialize/array.rs`)
- `BoolArrayAsTuple::serialize` — fixed `bool[N]` (`serialize/array.rs`)
- `BasicSequence::serialize` — `int8[]`…`float64[]` (`serialize/sequence.rs`)
- `BoolArray::serialize` — `bool[]` (`serialize/sequence.rs`)

## Fix

- Add `reject_null_element(array, type_name)` in `serialize/mod.rs`. Short-circuits when `array.null_count() == 0`; otherwise reports the first null index in the same format as the existing `reject_null_string_element`.
- Call it from the four sites above, right after the existing `check_array_len` guard (fixed) or before allocating the seq (sequence).
- No change to the `ByteSequence` / `Binary` byte-buffer paths — a `Binary` value has no per-element validity.

## Tests

New regression tests, added alongside the existing `null_scalar_field_is_rejected` / `*_string_array_null_element_is_rejected` cases:

- `fixed_int32_array_null_element_is_rejected` (`int32[3]`)
- `fixed_bool_array_null_element_is_rejected` (`bool[3]`)
- `int32_sequence_null_element_is_rejected` (`int32[]`)
- `bool_sequence_null_element_is_rejected` (`bool[]`)

Each test asserts (a) a `[Some, None, Some]` list is rejected and (b) an all-present list still serializes. `cargo test -p dora-ros2-bridge-arrow --lib`: 28 passed, 0 failed. `cargo fmt --all -- --check` and `cargo clippy -p dora-ros2-bridge-arrow --all-targets -- -D warnings` are clean.

Closes #3271

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8qqV6bANor86uowodNAe8)_