### PR TITLE
fix(coordinator): prune dead daemon from running builds on DaemonExit

### DIFF
--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -2396,6 +2396,25 @@ async fn start_inner(
                         &clock,
                     )
                     .await?;
+                    // Prune the exited daemon from every running build's
+                    // `pending_build_results`. Without this, an in-progress
+                    // multi-daemon `dora build` would sit with a dead
+                    // daemon in `pending_build_results` until the 20-minute
+                    // `check_build_timeouts` watchdog fires, even after
+                    // every surviving daemon has reported. The heartbeat-
+                    // timeout path (`Event::HeartbeatInterval`) already
+                    // does this at lib.rs:2212; `DaemonExit` fires on the
+                    // common WebSocket-close path well before the 30 s
+                    // heartbeat staleness threshold and removes the daemon
+                    // from `daemon_connections`, so the heartbeat path
+                    // will never subsequently catch it. Mirror the
+                    // heartbeat path here. Finalization is left to
+                    // `check_build_timeouts` / a surviving daemon's later
+                    // `DataflowBuildResult` — see the fn docstring (#3272).
+                    cleanup_disconnected_daemons_from_running_builds(
+                        &mut running_builds,
+                        &disconnected,
+                    );
                     notify_daemons_about_disconnected_peers(
                         &disconnected,
                         &mut daemon_connections,
@@ -10032,6 +10051,57 @@ mod tests {
             pending_restarts.len(),
             1,
             "original PendingRestart must not be overwritten by duplicate"
+        );
+    }
+
+    /// #3272: `cleanup_disconnected_daemons_from_running_builds` must prune
+    /// the given daemon(s) from every running build's `pending_build_results`
+    /// so a mixed disconnect (one daemon dies mid-build, others still to
+    /// report) can be finalized by the survivor's later `DataflowBuildResult`
+    /// rather than waiting for the 20-minute `check_build_timeouts` watchdog.
+    ///
+    /// This locks in the invariant the `DaemonExit` handler now relies on:
+    /// after the call, the pruned daemon's entry is gone but the build is
+    /// still present with its remaining `pending_build_results` (finalization
+    /// stays owned by the `DataflowBuildResult` handler / watchdog).
+    #[test]
+    fn cleanup_disconnected_daemons_from_running_builds_prunes_only_listed_daemons() {
+        let build_id = BuildId::generate();
+        let dead = DaemonId::new(Some("dead".to_string()));
+        let alive = DaemonId::new(Some("alive".to_string()));
+        let mut pending = BTreeSet::new();
+        pending.insert(dead.clone());
+        pending.insert(alive.clone());
+
+        let build = RunningBuild {
+            errors: Vec::new(),
+            build_result: CachedResult::default(),
+            buffered_log_messages: Vec::new(),
+            log_subscribers: Vec::new(),
+            pending_build_results: pending,
+            build_started_at: Instant::now(),
+        };
+        let mut running_builds: HashMap<BuildId, RunningBuild> = HashMap::new();
+        running_builds.insert(build_id, build);
+
+        let disconnected = BTreeSet::from([dead.clone()]);
+        cleanup_disconnected_daemons_from_running_builds(&mut running_builds, &disconnected);
+
+        let build = running_builds
+            .get(&build_id)
+            .expect("build must still be in running_builds — finalization is owned elsewhere");
+        assert!(
+            !build.pending_build_results.contains(&dead),
+            "dead daemon must be pruned from pending_build_results"
+        );
+        assert!(
+            build.pending_build_results.contains(&alive),
+            "surviving daemons must NOT be pruned"
+        );
+        assert!(
+            build.build_result.is_pending(),
+            "cleanup must NOT itself resolve build_result — the watchdog / \
+             surviving daemon's DataflowBuildResult owns finalization"
         );
     }
 }


### PR DESCRIPTION
## Summary

The coordinator has two daemon-disconnect paths, and they handled in-progress **builds** asymmetrically:

- **Heartbeat-timeout path** (`binaries/coordinator/src/lib.rs:2191-2222`) called `cleanup_disconnected_daemons_from_running_builds`, pruning the dead daemon from every running build's `pending_build_results`.
- **`Event::DaemonExit` path** (`lib.rs:2370-2411`) called `cleanup_disconnected_daemons_from_running_dataflows` + `apply_disconnect_actions`, but never called `cleanup_disconnected_daemons_from_running_builds`.

`DaemonExit` fires on the common WebSocket-close path (i.e. as soon as the daemon process dies), well before the 30-second heartbeat-staleness threshold at `lib.rs:2175` — and because `DaemonExit` removes the daemon from `daemon_connections` (`lib.rs:2381`), the heartbeat watchdog (which only iterates `daemon_connections`) never subsequently fires for that daemon. So the build-pruning call was simply skipped for the overwhelmingly common case.

## Why it hung the build

A distributed build only finalizes when `pending_build_results.is_empty()` (`lib.rs:2501`). Scenario:

1. Multi-daemon `dora build` spans daemons A and B.
2. A's process exits after accepting the build RPC but before reporting its `DataflowBuildResult`.
3. Coordinator gets `Event::DaemonExit{A}` → removes A from `daemon_connections` but leaves A in `pending_build_results`.
4. B finishes and sends its result; the handler removes B, but A is still present, so `pending_build_results.is_empty()` is false and the build is never finalized.
5. `wait_for_build` blocks until the `check_build_timeouts` watchdog fires — `BUILD_RESULT_TIMEOUT_DEFAULT` = 20 min (`lib.rs:116`) — and only then reports the build as failed.

On the heartbeat-timeout path the identical disconnect prunes A from `pending_build_results`, so B's later report finalizes the build promptly.

## Fix

Mirror the heartbeat path from the `DaemonExit` handler — one added call, positioned like the heartbeat-path call it mirrors (after the dataflow cleanup, before `notify_daemons_about_disconnected_peers`):

```rust
cleanup_disconnected_daemons_from_running_builds(
    &mut running_builds,
    &disconnected,
);
```

Finalization stays owned by the `DataflowBuildResult` handler / `check_build_timeouts` watchdog — the helper's docstring (`lib.rs:3733-3740`, #1465) intentionally leaves that as the single chokepoint. In the mixed case above, the surviving daemon's later `DataflowBuildResult` now performs the finalization once the dead daemon has been pruned; the all-gone case still falls to the watchdog.

## Tests

New regression test `cleanup_disconnected_daemons_from_running_builds_prunes_only_listed_daemons` locks in the pruning invariant the `DaemonExit` handler now relies on:

- The pruned daemon is gone from `pending_build_results`.
- Surviving daemons are untouched.
- `build_result` remains `Pending` — the cleanup helper must never itself finalize.

`cargo test -p dora-coordinator --lib` — 133 passed. `cargo fmt --all -- --check` clean; `cargo clippy -p dora-coordinator --lib --tests -- -D warnings` clean (a pre-existing `needless_late_init` warning under the newer Rust toolchain fires in `dora-tracing`, unrelated to this diff).

Closes #3272

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8qqV6bANor86uowodNAe8)_