### PR TITLE
fix(operator-api): surface stream Event::Error to Rust operators

### DIFF
--- a/apis/rust/operator/src/lib.rs
+++ b/apis/rust/operator/src/lib.rs
@@ -55,9 +55,10 @@ pub mod raw;
 /// An event delivered to an operator's [`DoraOperator::on_event`] callback.
 ///
 /// The dataflow runtime dispatches one `Event` per occurrence: a received
-/// input, a failed input decode, an input that will produce no more data, or a
-/// request to shut down. The enum is `#[non_exhaustive]`, so implementations
-/// must include a catch-all arm to stay forward-compatible with future variants.
+/// input, a failed input decode, an input that will produce no more data, a
+/// runtime error on the event stream, or a request to shut down. The enum is
+/// `#[non_exhaustive]`, so implementations must include a catch-all arm to stay
+/// forward-compatible with future variants.
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum Event<'a> {
@@ -89,6 +90,19 @@ pub enum Event<'a> {
     /// The runtime requested a graceful shutdown. The operator should finish
     /// any pending work and return [`DoraStatus::Stop`].
     Stop,
+    /// The runtime reported an error on the event stream itself — for example a
+    /// payload that could not be deserialized, an unrecognized daemon event, or
+    /// a fatal stream failure.
+    ///
+    /// This is distinct from [`InputParseError`](Event::InputParseError), which
+    /// is tied to a specific input id; an `Error` concerns the stream as a
+    /// whole. The operator can log or surface it and decide how to proceed;
+    /// returning `Err` from `on_event` reports it as fatal and stops the
+    /// operator.
+    Error {
+        /// A human-readable description of the error.
+        error: &'a str,
+    },
 }
 
 /// Trait implemented by every dora operator.
@@ -211,6 +225,7 @@ mod tests {
     #[derive(Default)]
     struct RecordingOperator {
         parse_errors: Vec<(String, String)>,
+        stream_errors: Vec<String>,
     }
 
     impl DoraOperator for RecordingOperator {
@@ -219,8 +234,14 @@ mod tests {
             event: &Event,
             _output_sender: &mut DoraOutputSender,
         ) -> Result<DoraStatus, String> {
-            if let Event::InputParseError { id, error } = event {
-                self.parse_errors.push((id.to_string(), error.clone()));
+            match event {
+                Event::InputParseError { id, error } => {
+                    self.parse_errors.push((id.to_string(), error.clone()));
+                }
+                Event::Error { error } => {
+                    self.stream_errors.push(error.to_string());
+                }
+                _ => {}
             }
             Ok(DoraStatus::Continue)
         }
@@ -331,6 +352,61 @@ mod tests {
         assert_eq!(op.parse_errors.len(), 2);
         assert_eq!(op.parse_errors[0].0, "x");
         assert_eq!(op.parse_errors[1].0, "z");
+    }
+
+    /// A stream-level `Event::Error` is populated by the runtime into
+    /// `RawEvent::error`; the FFI dispatch must deliver it to `on_event` rather
+    /// than silently dropping it (the runtime builds it for decode/stream
+    /// failures, and it previously fell through to the "unknown event" arm).
+    #[test]
+    fn stream_error_dispatched_to_on_event() {
+        let sender = noop_send_output();
+        let mut op = RecordingOperator::default();
+        let ctx: *mut std::ffi::c_void = (&mut op as *mut RecordingOperator).cast();
+
+        let mut event = types::RawEvent {
+            input: None,
+            input_closed: None,
+            stop: false,
+            error: Some("fatal event stream error".to_string().into()),
+        };
+
+        let result =
+            unsafe { crate::raw::dora_on_event::<RecordingOperator>(&mut event, &sender, ctx) };
+
+        assert!(
+            result.result.error.is_none(),
+            "a handled stream error must not itself surface as a dispatch error"
+        );
+        assert!(matches!(result.status, DoraStatus::Continue));
+        assert_eq!(
+            op.stream_errors,
+            vec!["fatal event stream error".to_string()]
+        );
+    }
+
+    /// A truly empty `RawEvent` (no input/close/stop/error) is still ignored as
+    /// an unknown event, without reaching `on_event`.
+    #[test]
+    fn empty_raw_event_is_ignored() {
+        let sender = noop_send_output();
+        let mut op = RecordingOperator::default();
+        let ctx: *mut std::ffi::c_void = (&mut op as *mut RecordingOperator).cast();
+
+        let mut event = types::RawEvent {
+            input: None,
+            input_closed: None,
+            stop: false,
+            error: None,
+        };
+
+        let result =
+            unsafe { crate::raw::dora_on_event::<RecordingOperator>(&mut event, &sender, ctx) };
+
+        assert!(result.result.error.is_none());
+        assert!(matches!(result.status, DoraStatus::Continue));
+        assert!(op.stream_errors.is_empty());
+        assert!(op.parse_errors.is_empty());
     }
 
     #[test]

--- a/apis/rust/operator/src/raw.rs
+++ b/apis/rust/operator/src/raw.rs
@@ -90,6 +90,13 @@ pub unsafe fn dora_on_event<O: DoraOperator>(
         Event::InputClosed { id: input_id }
     } else if event.stop {
         Event::Stop
+    } else if let Some(error) = &event.error {
+        // The runtime populates `RawEvent::error` for a stream-level
+        // `Event::Error` (a decode failure, a fatal stream error, …). Dispatch
+        // it to the operator like `InputParseError` rather than dropping it —
+        // it used to fall through to the "unknown event" arm below and vanish
+        // silently, with the operator never notified.
+        Event::Error { error }
     } else {
         // ignore unknown events
         return OnEventResult {


### PR DESCRIPTION
> ⚠️ **Machine-generated PR.** This change was produced by Claude (Claude Code) during an automated code-review pass. Please review carefully before merging.

## Issue

The shared-library operator runtime translates each node-stream `Event` into an FFI `RawEvent`, and it already builds `RawEvent { error: Some(..) }` for an `Event::Error`:

```rust
// binaries/runtime-shared-lib/src/runner.rs:253
Event::Error(err) => dora_operator_api_types::RawEvent {
    error: Some(err.into()),
    input_closed: None, input: None, stop: false,
},
```

But the FFI dispatch on the operator side (`apis/rust/operator/src/raw.rs::dora_on_event`) only inspected `input`, `input_closed`, and `stop`. A `RawEvent` carrying only `error` fell through to the *"ignore unknown events"* arm and returned `Continue` with no error — so stream-level failures (payload-decode errors, unrecognized daemon events, fatal stream errors — see `dora_node_api::event_stream`) were dropped **silently**: the operator's `on_event` was never called and nothing was logged. The populated `RawEvent::error` field had no consumer.

## Fix

Add an `Event::Error { error }` variant to the operator-facing `Event` enum (which is `#[non_exhaustive]`, so this is backward compatible) and dispatch `RawEvent::error` to it, mirroring the existing `InputParseError` handling. The variant borrows `&str` from the `RawEvent`, so there's no added allocation on the runtime path.

Operators can now observe and react to stream errors; returning `Err` from `on_event` reports it as fatal, exactly as the runtime already intended when it populated the field. `Error` is kept deliberately distinct from `InputParseError` (whole-stream vs. tied to one input id), matching the upstream node-api `Event` model.

## Validation

- `cargo test -p dora-operator-api` — all 9 lib tests + doctest pass, including two new regression tests (`stream_error_dispatched_to_on_event`, `empty_raw_event_is_ignored`).
- `cargo clippy -p dora-operator-api -- -D warnings` — clean.
- Existing downstream consumers already carry catch-all arms, so nothing breaks: the C++ operator bridge (`apis/c++/operator/src/lib.rs`, whose comment already lists `Error`) and the `dora new` Rust template. The PyO3 operator crate matches on `dora_node_api::Event`, not this enum, so it is unaffected.
- Full-workspace `cargo fmt --all --check`, `cargo clippy --all -- -D warnings`, and `cargo check --examples` pass on the combined review branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMnr5LKUBWDnpw7VvsreRn

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMnr5LKUBWDnpw7VvsreRn)_