### PR TITLE
perf(daemon): keyed lookup in send_output_closed_events

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -5602,13 +5602,21 @@ impl Daemon {
             .running
             .get_mut(&dataflow_id)
             .wrap_err_with(|| format!("no running dataflow with ID `{dataflow_id}`"))?;
-        let local_node_inputs: BTreeSet<_> = dataflow
-            .mappings
-            .iter()
-            .filter(|(k, _)| k.0 == node_id && outputs.contains(&k.1))
-            .flat_map(|(_, v)| v)
-            .cloned()
-            .collect();
+        // Look each closed output up by key rather than scanning the whole
+        // `mappings` map: `outputs` is small (the outputs of one node), while
+        // `mappings` holds an entry per edge in the entire dataflow. This
+        // matches the keyed access every other delivery site uses (e.g.
+        // `send_output_to_local_receivers`) and is behavior-equivalent — the
+        // results are merged into the same deduplicating `BTreeSet`.
+        let mut local_node_inputs: BTreeSet<(NodeId, DataId)> = BTreeSet::new();
+        for output in &outputs {
+            if let Some(receivers) = dataflow
+                .mappings
+                .get(&OutputId(node_id.clone(), output.clone()))
+            {
+                local_node_inputs.extend(receivers.iter().cloned());
+            }
+        }
         for (receiver_id, input_id) in &local_node_inputs {
             close_input(dataflow, receiver_id, input_id, &self.clock);
         }


### PR DESCRIPTION
> ⚠️ **Machine-generated PR.** This change was produced by Claude (Claude Code) during an automated code-review pass. Please review carefully before merging.

## Issue

`send_output_closed_events` built the set of local receivers to close by scanning the **entire** `mappings` map and filtering, plus a linear `outputs.contains` per key:

```rust
let local_node_inputs: BTreeSet<_> = dataflow
    .mappings
    .iter()
    .filter(|(k, _)| k.0 == node_id && outputs.contains(&k.1))
    .flat_map(|(_, v)| v)
    .cloned()
    .collect();
```

`mappings` is a `HashMap<OutputId, BTreeSet<(NodeId, DataId)>>` (`running_dataflow.rs:311`) holding one entry per edge in the whole dataflow, so this is O(total-edges) with an inner scan — while `outputs` is just the outputs of the single node being closed. Every other delivery site in the file (`send_output_to_local_receivers`, `note_output_sent_to_local_receivers`) already does a direct `mappings.get(&output_id)`; this was the lone outlier.

## Fix

Look each closed output up by key instead, turning the full scan into O(|outputs|) hashed lookups:

```rust
let mut local_node_inputs: BTreeSet<(NodeId, DataId)> = BTreeSet::new();
for output in &outputs {
    if let Some(receivers) = dataflow
        .mappings
        .get(&OutputId(node_id.clone(), output.clone()))
    {
        local_node_inputs.extend(receivers.iter().cloned());
    }
}
```

This aligns the site with the keyed-access pattern used everywhere else and is behavior-equivalent — results merge into the same deduplicating `BTreeSet`. Not a hot path (runs on `CloseOutputs`, typically once per node at end-of-stream), so this is a consistency/clarity cleanup as much as a micro-optimization.

## Validation

- `cargo test -p dora-daemon --lib` — all 246 daemon lib unit tests pass unchanged.
- `cargo clippy -p dora-daemon -- -D warnings` — clean.
- Full-workspace `cargo fmt --all --check`, `cargo clippy --all -- -D warnings`, and `cargo check --examples` pass on the combined review branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMnr5LKUBWDnpw7VvsreRn

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMnr5LKUBWDnpw7VvsreRn)_