### PR TITLE
docs(message): document SessionId and BuildId identifier types

### DIFF
--- a/libraries/message/src/lib.rs
+++ b/libraries/message/src/lib.rs
@@ -169,27 +169,50 @@ use uuid::{Timestamp, Uuid};
 /// Dora assigns each dataflow instance a unique ID on start.
 pub type DataflowId = uuid::Uuid;
 
+/// Unique identifier for a CLI/coordinator session.
+///
+/// A session groups the CLI commands issued against one coordinator connection.
+/// The id is a time-ordered UUIDv7, so sessions sort by creation time.
+///
+/// ```
+/// use dora_message::SessionId;
+///
+/// let a = SessionId::generate();
+/// let b = SessionId::generate();
+/// assert_ne!(a, b);
+/// assert_eq!(a.uuid().get_version_num(), 7);
+/// ```
 #[derive(
     Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash,
 )]
 pub struct SessionId(uuid::Uuid);
 
 impl SessionId {
+    /// Generate a fresh, unique session id (a time-ordered UUIDv7).
     pub fn generate() -> Self {
         Self(Uuid::new_v7(Timestamp::now(uuid::NoContext)))
     }
 
+    /// The underlying UUID.
     pub fn uuid(&self) -> uuid::Uuid {
         self.0
     }
 }
 
+/// Unique identifier for one `dora build` of a dataflow.
+///
+/// Assigned when a build starts and carried through to the run so a dataflow
+/// can be matched to the artifacts it was built from. Like [`SessionId`], it is
+/// a time-ordered UUIDv7. Its [`Display`](std::fmt::Display) form is
+/// `BuildId(<uuid>)`; use [`from_display_str`](BuildId::from_display_str) to
+/// recover a value from that form.
 #[derive(
     Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash,
 )]
 pub struct BuildId(uuid::Uuid);
 
 impl BuildId {
+    /// Generate a fresh, unique build id (a time-ordered UUIDv7).
     pub fn generate() -> Self {
         Self(Uuid::new_v7(Timestamp::now(uuid::NoContext)))
     }


### PR DESCRIPTION
> ⚠️ **Machine-generated PR.** This change was produced by Claude (Claude Code) during an automated code-review pass. Please review carefully before merging.

## Issue

`SessionId` and `BuildId` are public, crate-root identifier types in `libraries/message/src/lib.rs`, but the struct definitions and `SessionId`'s `generate`/`uuid` methods carried no doc comments — inconsistent with their neighbor `DataflowId` (documented) and `BuildId::from_display_str` (documented, with a doctest).

## Fix

Documentation only — no behavior change:

- Struct-level docs explaining what each id identifies (a CLI/coordinator session; one `dora build` of a dataflow) and that both are time-ordered UUIDv7s.
- Method docs on `SessionId::generate` / `SessionId::uuid`.
- A **compile-checked doctest** on `SessionId` demonstrating uniqueness and the v7 version.

## Validation

- `cargo test --doc -p dora-message` — the new `SessionId` doctest passes (11 doctests total, all green).
- `cargo fmt -p dora-message --check` — clean.
- `cargo fmt --all --check` and `cargo clippy --all -- -D warnings` pass on the combined review branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMnr5LKUBWDnpw7VvsreRn

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMnr5LKUBWDnpw7VvsreRn)_