### PR TITLE
fix(record): stop dora record silently dropping messages

### DIFF
--- a/binaries/cli/src/command/mod.rs
+++ b/binaries/cli/src/command/mod.rs
@@ -762,6 +762,18 @@ mod tests {
     }
 
     #[test]
+    fn parse_record_queue_size() {
+        parse_ok(&["dora", "record", "dataflow.yml", "--queue-size", "1000"]);
+    }
+
+    #[test]
+    fn reject_record_zero_queue_size() {
+        // A zero depth would silently fall back to the backpressure hard cap
+        // rather than doing what it says; reject it at parse time instead.
+        parse_err(&["dora", "record", "dataflow.yml", "--queue-size", "0"]);
+    }
+
+    #[test]
     fn reject_record_no_file() {
         parse_err(&["dora", "record"]);
     }

--- a/binaries/cli/src/command/record.rs
+++ b/binaries/cli/src/command/record.rs
@@ -16,6 +16,16 @@ use eyre::{Context, bail};
 
 use crate::command::{Executable, Run, default_tracing, topic::selector::public_topic_output_id};
 
+/// Default per-topic queue depth for the injected record node.
+///
+/// Ten times dora's real-time `DEFAULT_QUEUE_SIZE`, and paired with
+/// `backpressure` (which buffers another 10x on top), so a recorder that
+/// briefly falls behind its producers buffers instead of discarding. At 30 Hz
+/// that is ~3s of slack before backpressure engages and ~33s before anything
+/// is dropped -- enough to ride out a stalled write without holding an
+/// unbounded amount of payload memory. `--queue-size` tunes it.
+const DEFAULT_RECORD_QUEUE_SIZE: u64 = 100;
+
 /// Record dataflow messages to a file for offline replay.
 ///
 /// Injects a record node into the dataflow that captures all (or filtered)
@@ -55,6 +65,24 @@ pub struct Record {
     /// Just generate modified YAML, don't run
     #[clap(long, value_name = "PATH")]
     output_yaml: Option<String>,
+
+    /// Per-topic queue depth for the injected record node.
+    ///
+    /// The recorder writes to disk, so a producer burst or a stalled write can
+    /// outrun it. Each recorded topic gets this queue depth with
+    /// `queue_policy: backpressure`, which buffers up to 10x that before it
+    /// drops anything. Raise it to absorb longer stalls, at the cost of the
+    /// memory the buffered payloads hold.
+    ///
+    /// Ignored in `--proxy` mode, which records over the WebSocket instead of
+    /// injecting a node.
+    #[clap(
+        long,
+        value_name = "N",
+        default_value_t = DEFAULT_RECORD_QUEUE_SIZE,
+        value_parser = clap::value_parser!(u64).range(1..),
+    )]
+    queue_size: u64,
 
     /// Stream data through coordinator WebSocket instead of recording on target.
     /// Useful when the target machine has no local disk.
@@ -157,6 +185,49 @@ fn extend_prefixed_outputs(
     }
 }
 
+/// Build the `inputs:` mapping for the injected `__dora_record__` node.
+///
+/// Each topic is emitted as a mapping (`source` + `queue_size` +
+/// `queue_policy`) rather than as a bare `node/output` string. A bare string
+/// takes dora's real-time defaults -- a `DEFAULT_QUEUE_SIZE` queue with
+/// `drop_oldest` -- which is exactly wrong for a recorder: the node's work is
+/// disk I/O, so any producer burst or stalled write makes the scheduler evict
+/// the oldest events *before they reach the writer*, and the `.drec` is short
+/// with nothing in it to say so.
+///
+/// `backpressure` buffers 10x `queue_size` before dropping anything, and logs
+/// an error at that hard cap, so residual overflow is loud rather than silent
+/// (the record node also totals the drops into its final summary).
+///
+/// This mirrors what `dora replay` already does for the opposite direction --
+/// see `replay::raise_input_queue_sizes`, which sizes *receiver* queues so a
+/// full-speed replay cannot silently drop (#2144). Unlike replay there is no
+/// user-authored config to preserve here: this node is appended by the CLI, so
+/// every input is ours to size.
+fn build_record_inputs(topics: &BTreeMap<String, String>, queue_size: u64) -> serde_yaml::Mapping {
+    let mut inputs = serde_yaml::Mapping::new();
+    for (topic, input_id) in topics {
+        let mut input = serde_yaml::Mapping::new();
+        input.insert(
+            serde_yaml::Value::String("source".to_string()),
+            serde_yaml::Value::String(topic.clone()),
+        );
+        input.insert(
+            serde_yaml::Value::String("queue_size".to_string()),
+            serde_yaml::Value::Number(queue_size.into()),
+        );
+        input.insert(
+            serde_yaml::Value::String("queue_policy".to_string()),
+            serde_yaml::Value::String("backpressure".to_string()),
+        );
+        inputs.insert(
+            serde_yaml::Value::String(input_id.clone()),
+            serde_yaml::Value::Mapping(input),
+        );
+    }
+    inputs
+}
+
 fn run_record(args: Record) -> eyre::Result<()> {
     let yaml_bytes =
         std::fs::read(&args.file).wrap_err_with(|| format!("failed to read {}", args.file))?;
@@ -213,13 +284,7 @@ fn run_record(args: Record) -> eyre::Result<()> {
         serde_json::to_string(&topic_map).wrap_err("failed to serialize topic map")?;
 
     // Build inputs mapping for the record node YAML entry
-    let mut inputs_mapping = serde_yaml::Mapping::new();
-    for (topic, input_id) in &topics {
-        inputs_mapping.insert(
-            serde_yaml::Value::String(input_id.clone()),
-            serde_yaml::Value::String(topic.clone()),
-        );
-    }
+    let inputs_mapping = build_record_inputs(&topics, args.queue_size);
 
     // Build env vars
     let mut env_mapping = serde_yaml::Mapping::new();
@@ -714,6 +779,76 @@ mod tests {
             topics,
             vec!["standard/status", "single/image", "runtime/op/status"]
         );
+    }
+
+    #[test]
+    fn record_inputs_carry_an_explicit_queue_size_and_backpressure() {
+        let topics = BTreeMap::from([
+            ("camera/image".to_string(), "camera___image".to_string()),
+            ("lidar/points".to_string(), "lidar___points".to_string()),
+        ]);
+
+        let inputs = build_record_inputs(&topics, DEFAULT_RECORD_QUEUE_SIZE);
+
+        assert_eq!(inputs.len(), 2);
+        for input_id in ["camera___image", "lidar___points"] {
+            let input = inputs
+                .get(serde_yaml::Value::String(input_id.to_string()))
+                .unwrap_or_else(|| panic!("missing input `{input_id}`"));
+            // A bare `node/output` string would silently take the real-time
+            // defaults (queue_size 10, drop_oldest) -- the bug this guards.
+            assert!(
+                input.is_mapping(),
+                "`{input_id}` must be a mapping, not a bare source string"
+            );
+            assert_eq!(
+                input["queue_size"].as_u64(),
+                Some(DEFAULT_RECORD_QUEUE_SIZE)
+            );
+            assert_eq!(input["queue_policy"].as_str(), Some("backpressure"));
+        }
+        assert_eq!(
+            inputs[serde_yaml::Value::String("camera___image".to_string())]["source"].as_str(),
+            Some("camera/image")
+        );
+    }
+
+    #[test]
+    fn record_inputs_honor_a_custom_queue_size() {
+        let topics = BTreeMap::from([("camera/image".to_string(), "camera___image".to_string())]);
+        let inputs = build_record_inputs(&topics, 4096);
+        assert_eq!(
+            inputs[serde_yaml::Value::String("camera___image".to_string())]["queue_size"].as_u64(),
+            Some(4096)
+        );
+    }
+
+    #[test]
+    fn generated_record_inputs_deserialize_to_the_intended_capacity() {
+        // End-to-end on the YAML contract: what the CLI writes is what the
+        // node API reads back. Pins the actual effective capacity rather than
+        // just the literal keys, so a rename or default change on either side
+        // of the boundary fails here.
+        use dora_message::config::{Input, QueuePolicy};
+
+        let topics = BTreeMap::from([("camera/image".to_string(), "camera___image".to_string())]);
+        let inputs = build_record_inputs(&topics, DEFAULT_RECORD_QUEUE_SIZE);
+
+        let yaml = serde_yaml::to_string(&inputs).unwrap();
+        let parsed: BTreeMap<String, Input> = serde_yaml::from_str(&yaml).unwrap();
+
+        let input = &parsed["camera___image"];
+        assert_eq!(input.mapping.to_string(), "camera/image");
+        assert_eq!(input.queue_size, Some(DEFAULT_RECORD_QUEUE_SIZE as usize));
+        assert_eq!(input.queue_policy, Some(QueuePolicy::Backpressure));
+
+        let policy = input.queue_policy.unwrap_or_default();
+        let size = input
+            .queue_size
+            .unwrap_or(dora_message::config::DEFAULT_QUEUE_SIZE);
+        // 10x headroom on top of the configured depth, versus the 10-message
+        // drop_oldest queue a bare source string would have produced.
+        assert_eq!(policy.effective_cap(size), 1000);
     }
 
     #[test]

--- a/binaries/record-node/src/main.rs
+++ b/binaries/record-node/src/main.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, fs::File, time::SystemTime};
+use std::{
+    collections::{BTreeMap, HashMap},
+    fs::File,
+    time::SystemTime,
+};
 
 use aligned_vec::{AVec, ConstAlign};
 use dora_message::{
@@ -55,6 +59,50 @@ fn unix_nanos(now: SystemTime) -> u64 {
         .unwrap_or(0)
 }
 
+/// Fold one batch of per-input drop counts into the running total.
+///
+/// The node API caps every input queue and evicts the oldest events once a
+/// producer outruns this node's disk writes. It reports those evictions only
+/// through `tracing`, and this binary installs no subscriber, so without this
+/// accounting the drops are invisible: the recording is short and the final
+/// `Messages:` line still reports a confident total.
+fn accumulate_drops(total: &mut BTreeMap<String, u64>, batch: HashMap<DataId, u64>) {
+    for (input_id, count) in batch {
+        *total.entry(input_id.to_string()).or_insert(0) += count;
+    }
+}
+
+/// Render the incomplete-recording warning, or `None` when nothing was dropped.
+///
+/// Input ids are translated back to their `source_node/source_output` topic via
+/// `reverse_map` -- the record node's own input ids are the sanitized
+/// `node___output` form, which is not what the user asked to record.
+fn format_drop_report(
+    dropped: &BTreeMap<String, u64>,
+    reverse_map: &HashMap<String, (NodeId, DataId)>,
+) -> Option<String> {
+    if dropped.is_empty() {
+        return None;
+    }
+    let total: u64 = dropped.values().sum();
+    let mut report = format!(
+        "  WARNING:  {total} message(s) were dropped before reaching the recorder.\n            \
+         THIS RECORDING IS INCOMPLETE."
+    );
+    for (input_id, count) in dropped {
+        let topic = match reverse_map.get(input_id) {
+            Some((node, output)) => format!("{node}/{output}"),
+            None => input_id.clone(),
+        };
+        report.push_str(&format!("\n              {topic}: {count}"));
+    }
+    report.push_str(
+        "\n            The recorder could not keep up with its producers. Re-record with a \
+         larger `dora record --queue-size`, or record fewer topics with `--topics`.",
+    );
+    Some(report)
+}
+
 fn main() -> eyre::Result<()> {
     let output_file =
         std::env::var("DORA_RECORD_FILE").wrap_err("DORA_RECORD_FILE env var not set")?;
@@ -80,10 +128,14 @@ fn main() -> eyre::Result<()> {
         File::create(&output_file).wrap_err_with(|| format!("failed to create {output_file}"))?;
     let mut writer = RecordingWriter::new(file, &header)?;
     let mut msg_count: u64 = 0;
+    let mut dropped: BTreeMap<String, u64> = BTreeMap::new();
 
     eprintln!("dora-record-node: recording to {output_file}");
 
     while let Some(event) = events.recv() {
+        // Drain per-event: the counters reset on read, so folding them here
+        // keeps a complete total even for a recording that ends abruptly.
+        accumulate_drops(&mut dropped, events.drain_drop_counts());
         match event {
             Event::Input { id, metadata, data } => {
                 let (source_node, source_output) = match reverse_map.get(&*id) {
@@ -167,19 +219,78 @@ fn main() -> eyre::Result<()> {
         }
     }
 
+    // Anything the scheduler evicted between the last event and the stop.
+    accumulate_drops(&mut dropped, events.drain_drop_counts());
+
     let footer = writer.finish()?;
     eprintln!("dora-record-node: recording complete");
     eprintln!("  Messages: {msg_count}");
     eprintln!("  Bytes:    {}", footer.total_bytes);
     eprintln!("  File:     {output_file}");
+    if let Some(report) = format_drop_report(&dropped, &reverse_map) {
+        eprintln!("{report}");
+    }
 
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{build_reverse_map, unix_nanos};
+    use super::{accumulate_drops, build_reverse_map, format_drop_report, unix_nanos};
+    use dora_message::id::DataId;
+    use std::collections::{BTreeMap, HashMap};
     use std::time::{Duration, SystemTime};
+
+    #[test]
+    fn drop_counts_accumulate_across_drains() {
+        // `drain_drop_counts` resets on read, so the totals must be summed
+        // across calls -- not overwritten by the latest batch.
+        let mut total = BTreeMap::new();
+        accumulate_drops(
+            &mut total,
+            HashMap::from([(DataId::from("a".to_string()), 2)]),
+        );
+        accumulate_drops(
+            &mut total,
+            HashMap::from([
+                (DataId::from("a".to_string()), 3),
+                (DataId::from("b".to_string()), 1),
+            ]),
+        );
+        assert_eq!(total.get("a"), Some(&5));
+        assert_eq!(total.get("b"), Some(&1));
+    }
+
+    #[test]
+    fn a_clean_recording_reports_no_drops() {
+        let reverse_map = build_reverse_map(r#"{"camera___image":"camera/image"}"#).unwrap();
+        assert!(format_drop_report(&BTreeMap::new(), &reverse_map).is_none());
+    }
+
+    #[test]
+    fn drop_report_names_the_topic_not_the_sanitized_input_id() {
+        // The record node's input ids are the sanitized `node___output` form;
+        // a user who asked to record `camera/image` needs to read that back.
+        let reverse_map = build_reverse_map(r#"{"camera___image":"camera/image"}"#).unwrap();
+        let dropped = BTreeMap::from([("camera___image".to_string(), 7)]);
+
+        let report = format_drop_report(&dropped, &reverse_map).expect("drops must be reported");
+        assert!(report.contains("camera/image: 7"), "{report}");
+        assert!(report.contains("INCOMPLETE"), "{report}");
+        assert!(report.contains("--queue-size"), "{report}");
+    }
+
+    #[test]
+    fn drop_report_falls_back_to_the_raw_id_for_an_unmapped_input() {
+        // Non-topic pseudo-inputs (the node API's internal event queue) have
+        // no entry in the reverse map; report them rather than dropping them
+        // from the total.
+        let reverse_map = build_reverse_map(r#"{"camera___image":"camera/image"}"#).unwrap();
+        let dropped = BTreeMap::from([("dora/some_internal".to_string(), 3)]);
+
+        let report = format_drop_report(&dropped, &reverse_map).expect("drops must be reported");
+        assert!(report.contains("dora/some_internal: 3"), "{report}");
+    }
 
     #[test]
     fn unix_nanos_saturates_on_pre_epoch_clock() {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -509,8 +509,11 @@ dora record <DATAFLOW_YAML> [OPTIONS]
 | `--topics <TOPICS>` | all | Comma-separated `node/output` topics to record |
 | `--proxy` | false | Stream via WebSocket instead of recording on target |
 | `--output-yaml <PATH>` | | Write modified YAML without running (dry run) |
+| `--queue-size <N>` | `100` | Per-topic queue depth for the injected record node (default mode only) |
 
 Default mode injects a record node into the dataflow. `--proxy` mode requires a running dataflow and `enable_debug_inspection: true`.
+
+**Recorder queue depth:** the injected node subscribes with `queue_size: 100` and `queue_policy: backpressure`, so a producer burst or a stalled write is buffered rather than discarded. If the recorder still cannot keep up, it reports how many messages were dropped and marks the recording incomplete — re-record with a larger `--queue-size`, or narrow the capture with `--topics`. Deeper queues cost memory: buffered messages hold their payloads until they are written.
 
 **Ctrl-C in `--proxy` mode:** the first press stops the recording and finalizes the file. A second press exits immediately with status `130`, for the case where finalizing is itself stuck (a full disk or a stalled network mount). The recording is flushed before finalizing, so an escalated exit costs only the file's footer — `dora replay` still reads it, as a recording that ends early.
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -157,6 +157,32 @@ This injects a hidden `__dora_record__` node into the dataflow that subscribes t
 
 The recording runs until you press Ctrl-C or the dataflow stops.
 
+### Recording Completeness
+
+The record node writes to disk, so a fast producer or a stalled write can outrun it. Each recorded topic is therefore subscribed with `queue_size: 100` and `queue_policy: backpressure`, which buffers up to 10x that depth before anything is discarded.
+
+If the recorder still falls behind, the run ends with a report naming the affected topics:
+
+```text
+dora-record-node: recording complete
+  Messages: 8412
+  WARNING:  193 message(s) were dropped before reaching the recorder.
+            THIS RECORDING IS INCOMPLETE.
+              sensor/image: 193
+```
+
+Treat that as a failed capture — replaying it reproduces the gaps. Re-record with a deeper queue, or capture fewer topics:
+
+```bash
+# Absorb longer stalls (costs memory: buffered messages hold their payloads)
+dora record dataflow.yml --queue-size 1000
+
+# Or record only what you need
+dora record dataflow.yml --topics sensor/image
+```
+
+No warning means every message the recorder was subscribed to reached the file.
+
 ### Recording Specific Topics
 
 ```bash

--- a/guide/src/operations/cli.md
+++ b/guide/src/operations/cli.md
@@ -510,8 +510,11 @@ dora record <DATAFLOW_YAML> [OPTIONS]
 | `--topics <TOPICS>` | all | Comma-separated `node/output` topics to record |
 | `--proxy` | false | Stream via WebSocket instead of recording on target |
 | `--output-yaml <PATH>` | | Write modified YAML without running (dry run) |
+| `--queue-size <N>` | `100` | Per-topic queue depth for the injected record node (default mode only) |
 
 Default mode injects a record node into the dataflow. `--proxy` mode requires a running dataflow and `enable_debug_inspection: true`.
+
+**Recorder queue depth:** the injected node subscribes with `queue_size: 100` and `queue_policy: backpressure`, so a producer burst or a stalled write is buffered rather than discarded. If the recorder still cannot keep up, it reports how many messages were dropped and marks the recording incomplete — re-record with a larger `--queue-size`, or narrow the capture with `--topics`. Deeper queues cost memory: buffered messages hold their payloads until they are written.
 
 #### `dora replay`
 

--- a/guide/src/operations/debugging.md
+++ b/guide/src/operations/debugging.md
@@ -131,6 +131,32 @@ This injects a hidden `__dora_record__` node into the dataflow that subscribes t
 
 The recording runs until you press Ctrl-C or the dataflow stops.
 
+### Recording Completeness
+
+The record node writes to disk, so a fast producer or a stalled write can outrun it. Each recorded topic is therefore subscribed with `queue_size: 100` and `queue_policy: backpressure`, which buffers up to 10x that depth before anything is discarded.
+
+If the recorder still falls behind, the run ends with a report naming the affected topics:
+
+```text
+dora-record-node: recording complete
+  Messages: 8412
+  WARNING:  193 message(s) were dropped before reaching the recorder.
+            THIS RECORDING IS INCOMPLETE.
+              sensor/image: 193
+```
+
+Treat that as a failed capture — replaying it reproduces the gaps. Re-record with a deeper queue, or capture fewer topics:
+
+```bash
+# Absorb longer stalls (costs memory: buffered messages hold their payloads)
+dora record dataflow.yml --queue-size 1000
+
+# Or record only what you need
+dora record dataflow.yml --topics sensor/image
+```
+
+No warning means every message the recorder was subscribed to reached the file.
+
 ### Recording Specific Topics
 
 ```bash


### PR DESCRIPTION
Closes #3282 

## Problem

`dora record` appends a hidden `__dora_record__` node subscribed to every topic, writing those subscriptions as bare `node/output` strings. A bare string carries no `queue_size` or `queue_policy`, so each recorded topic got dora's real-time defaults: a 10-message queue with `drop_oldest`. The recorder's work is disk I/O, so any producer burst or stalled write made the scheduler evict the oldest events *before they reached the writer*, leaving a short `.drec`.

The drops were invisible: the scheduler reports them via `tracing` and `dora-record-node` installs no subscriber, `drain_drop_counts()` had no callers, and the final `Messages: N` line counts only what was written.

`dora replay` already guards the mirror-image case — `raise_input_queue_sizes` sets `queue_policy: backpressure` so a fast replay cannot silently drop (#2144). That fix (#2146) touched only `replay.rs`.

## Fix

- **`record.rs`** — emit each input as a mapping with an explicit `queue_size` and `queue_policy: backpressure`. New `--queue-size <N>`, default 100, rejected at parse time when 0.
- **`record-node/main.rs`** — total `drain_drop_counts()` per event and at shutdown, and end the run with an INCOMPLETE report naming the affected topics:

```text
  Messages: 8412
  WARNING:  193 message(s) were dropped before reaching the recorder.
            THIS RECORDING IS INCOMPLETE.
              sensor/image: 193
```

`--proxy` mode is untouched it never injects a node.

## Worth a second opinion

`backpressure` caps at 10x the configured depth, so `--queue-size 100` buffers up to 1000 messages per topic for 6 MB frames that is ~6 GB worst case, against ~60 MB under today's silent `drop_oldest` 10. The report makes overflow visible either way, but it is a real memory tradeoff on embedded targets. Happy to lower the default; it is a one-line change.

I also left the exit code unchanged on drops: the recorder is a dataflow node, so exiting non-zero would mark the whole dataflow failed a bigger behavioral change than this fix should carry.

## Tests

9 new unit tests. The load-bearing one, `generated_record_inputs_deserialize_to_the_intended_capacity`, round-trips the generated YAML back through `dora_message::config::Input` and asserts `effective_cap() == 1000`  pinning the real capacity across the CLI/node-API boundary, not just the literal YAML keys.

Docs: `--queue-size` row plus a "Recording Completeness" section in `docs/{cli,debugging}.md`, with the `guide/src/operations/` copies updated in the same commit so this adds no drift to #3252.

## Verification

`cargo fmt --all` clean · `clippy -p dora-cli -p dora-record-node --all-targets -D warnings` clean · `cargo test -p dora-cli` 370 passed · `cargo test -p dora-record-node` 9 passed. Not run locally: `make qa-fast` and the `record-replay` e2e — left to CI.

