### PR TITLE
docs(message): complete the DataId From panic conditions

### DIFF
--- a/libraries/message/src/id.rs
+++ b/libraries/message/src/id.rs
@@ -285,7 +285,11 @@ impl From<DataId> for String {
 
 /// # Panics
 ///
-/// Panics if `id` contains invalid characters (not in `[a-zA-Z0-9_./-]`).
+/// Panics if `id` is not a valid data id: if it is empty, contains
+/// characters outside `[a-zA-Z0-9_./-]`, or has an empty path segment (a
+/// leading, trailing, or consecutive `/`). Pre-validating against the
+/// character set alone is *not* sufficient to make this conversion
+/// infallible.
 ///
 /// **For untrusted input, use `id.parse::<DataId>()`** which calls
 /// `FromStr::from_str` and returns `Result<Self, InvalidId>`.
@@ -294,6 +298,13 @@ impl From<DataId> for String {
 /// auto-derived blanket impl that delegates to this `From` impl, so it
 /// panics exactly like `.into()`. Only `parse::<DataId>()` / `from_str`
 /// is fallible.
+///
+/// ```should_panic
+/// use dora_message::id::DataId;
+/// // A trailing '/' contains only valid characters but is still rejected
+/// // (empty path segment), so this conversion panics.
+/// let _ = DataId::from("op/".to_string());
+/// ```
 impl From<String> for DataId {
     fn from(id: String) -> Self {
         if let Err(e) = validate_data_id(&id) {
@@ -305,7 +316,9 @@ impl From<String> for DataId {
 
 /// # Panics
 ///
-/// Panics if `id` contains invalid characters. Prefer `id.parse::<DataId>()`
+/// Panics if `id` is not a valid data id: if it is empty, contains
+/// characters outside `[a-zA-Z0-9_./-]`, or has an empty path segment (a
+/// leading, trailing, or consecutive `/`). Prefer `id.parse::<DataId>()`
 /// when handling untrusted input.
 impl From<&str> for DataId {
     fn from(id: &str) -> Self {


### PR DESCRIPTION
## Summary

The `# Panics` docs on `impl From<String> for DataId` and `impl From<&str> for DataId` (`libraries/message/src/id.rs`) claimed the conversion panics only when the id *"contains invalid characters (not in `[a-zA-Z0-9_./-]`)"*. But both conversions run through `validate_data_id`, which **also** rejects — and therefore panics on:

- the **empty string** (`"identifier must not be empty"`), and
- **malformed slash patterns**: a leading `/`, a trailing `/`, or a consecutive `//` (`"empty path segment"`).

So a value such as `"op/"` — which contains only valid characters — still panics, contradicting the documented condition. (The module's own existing `should_panic` doctest already exercises `"a//b"`, which likewise has no invalid characters.)

## Fix

- Rewrote both `# Panics` sections to enumerate the full set of panic conditions, matching the completeness of the sibling `impl From<String> for NodeId` doc, which already notes that character-set pre-validation alone is *not* sufficient to make the conversion infallible.
- Added a compile-checked `should_panic` doctest exercising the previously-undocumented empty-path-segment case (`DataId::from("op/")`).

Documentation-only change; no runtime behavior changes.

## Validation

- `cargo test -p dora-message --doc` — 11 doctests pass, including the new one
- `cargo clippy -p dora-message -- -D warnings`
- `cargo fmt --all -- --check`

(toolchain 1.97.1, matching CI)

---

⚠️ **Machine-generated PR.** This change was written by Claude (an AI agent) as part of an automated codebase review. It has been machine-verified but should receive human review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fpABBRmVUEkE6a2RDk3cy

---
_Generated by [Claude Code](https://claude.ai/code/session_018fpABBRmVUEkE6a2RDk3cy)_