### PR TITLE
fix(daemon): answer unsupported requests on the local listener

### DIFF
--- a/binaries/daemon/src/local_listener.rs
+++ b/binaries/daemon/src/local_listener.rs
@@ -142,9 +142,29 @@ async fn handle_connection_loop(
                 tracing::warn!("{err:?}");
                 break;
             }
-            _ => tracing::warn!(
-                "Unexpected Daemon Request that is not yet by Additional local listener controls"
-            ),
+            // `DaemonRequest` is `#[non_exhaustive]` and this listener only
+            // implements `NodeConfig`. A version-skewed or misbehaving client
+            // may send some other request and then block on the request/reply
+            // it expects. Mirror the node TCP listener
+            // (`node_communication::mod`): answer with an explicit error so the
+            // client fails loudly instead of hanging forever, and — like the
+            // `NodeConfig` arm above and `node_communication` — keep serving the
+            // connection afterwards rather than tearing it down.
+            Ok(Some(Timestamped { inner: other, .. })) => {
+                tracing::warn!("unsupported request on local listener: {other:?}");
+                let reply = DaemonReply::Result(Err(format!(
+                    "unsupported request on local listener (client is likely \
+                     newer than this daemon): {other:?}"
+                )));
+                match serde_json::to_vec(&reply).wrap_err("failed to serialize DaemonReply") {
+                    Ok(serialized) => {
+                        if let Err(err) = socket_stream_send(&mut connection, &serialized).await {
+                            tracing::warn!("failed to send unsupported-request reply: {err}");
+                        }
+                    }
+                    Err(err) => tracing::error!("{err:?}"),
+                }
+            }
         }
     }
 }
@@ -167,4 +187,66 @@ async fn receive_message(
     dora_message::decode(&raw)
         .wrap_err("failed to deserialize DaemonRequest")
         .map(Some)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dora_core::uhlc::HLC;
+
+    /// A well-formed request this listener does not implement must be answered
+    /// with an explicit error, so a request/reply client fails loudly instead
+    /// of blocking forever on a reply that never comes (the listener only
+    /// implements `NodeConfig`). The connection then keeps serving, so a second
+    /// unsupported request is answered too.
+    #[tokio::test]
+    async fn unsupported_request_gets_error_reply_and_keeps_serving() {
+        let (events_tx, _events_rx) = flume::unbounded();
+        let port = spawn_listener_loop("127.0.0.1:0".parse().unwrap(), events_tx)
+            .await
+            .expect("failed to spawn listener")
+            .expect("listener should bind to an ephemeral port");
+
+        let mut client = TcpStream::connect(("127.0.0.1", port))
+            .await
+            .expect("failed to connect to listener");
+
+        let clock = HLC::default();
+        // `Subscribe` is a valid, well-formed request the listener does not
+        // handle, so it exercises the unsupported-request arm. Send it twice on
+        // the same connection: the first proves the error reply, the second
+        // proves the connection is still being served afterwards.
+        for attempt in 0..2 {
+            let request = Timestamped {
+                inner: DaemonRequest::Subscribe,
+                timestamp: clock.new_timestamp(),
+            };
+            let encoded = dora_message::encode(&request).expect("failed to encode request");
+            socket_stream_send(&mut client, &encoded)
+                .await
+                .expect("failed to send request");
+
+            // Expect an explicit error reply rather than a hang.
+            let raw = socket_stream_receive_with_header_timeout(
+                &mut client,
+                Some(Duration::from_secs(5)),
+            )
+            .await
+            .unwrap_or_else(|e| {
+                panic!("attempt {attempt}: expected an error reply, not a hang: {e}")
+            });
+            let reply: DaemonReply = serde_json::from_slice(&raw).expect("failed to decode reply");
+            match reply {
+                DaemonReply::Result(Err(msg)) => {
+                    assert!(
+                        msg.contains("unsupported request"),
+                        "attempt {attempt}: unexpected error message: {msg}"
+                    );
+                }
+                other => {
+                    panic!("attempt {attempt}: expected DaemonReply::Result(Err(_)), got {other:?}")
+                }
+            }
+        }
+    }
 }

--- a/binaries/daemon/src/local_listener.rs
+++ b/binaries/daemon/src/local_listener.rs
@@ -146,17 +146,33 @@ async fn handle_connection_loop(
             // implements `NodeConfig`. A version-skewed or misbehaving client
             // may send some other request and then block on the request/reply
             // it expects. Mirror the node TCP listener
-            // (`node_communication::mod`): answer with an explicit error so the
-            // client fails loudly instead of hanging forever, and — like the
-            // `NodeConfig` arm above and `node_communication` — keep serving the
-            // connection afterwards rather than tearing it down.
+            // (`node_communication::tcp::send_reply`): answer with an explicit
+            // error so the client fails loudly instead of hanging forever, and
+            // — like the `NodeConfig` arm above and `node_communication` — keep
+            // serving the connection afterwards rather than tearing it down.
+            //
+            // The reply codec is dictated by the *request*, not by this
+            // listener: `apis/rust/node/src/daemon_connection/tcp.rs` decodes
+            // with Postcard when `expects_tcp_binary_reply()`, with serde_json
+            // only for `NodeConfig` (handled above), and reads nothing at all
+            // otherwise. So encode with Postcard here — the serde_json used by
+            // the `NodeConfig` arm would land as a decode error on the client
+            // rather than as the message we built — and stay silent for the
+            // no-reply requests (`SendMessage`, `OutputSent`), where an
+            // unsolicited frame would be left buffered and desync the next
+            // request/reply on this connection.
             Ok(Some(Timestamped { inner: other, .. })) => {
                 tracing::warn!("unsupported request on local listener: {other:?}");
+                if !other.expects_tcp_binary_reply() {
+                    continue;
+                }
                 let reply = DaemonReply::Result(Err(format!(
                     "unsupported request on local listener (client is likely \
                      newer than this daemon): {other:?}"
                 )));
-                match serde_json::to_vec(&reply).wrap_err("failed to serialize DaemonReply") {
+                match dora_message::encode_presized(&reply, reply.encode_size_hint())
+                    .wrap_err("failed to serialize DaemonReply")
+                {
                     Ok(serialized) => {
                         if let Err(err) = socket_stream_send(&mut connection, &serialized).await {
                             tracing::warn!("failed to send unsupported-request reply: {err}");
@@ -193,38 +209,60 @@ async fn receive_message(
 mod tests {
     use super::*;
     use dora_core::uhlc::HLC;
+    use dora_message::metadata::Metadata;
 
-    /// A well-formed request this listener does not implement must be answered
-    /// with an explicit error, so a request/reply client fails loudly instead
-    /// of blocking forever on a reply that never comes (the listener only
-    /// implements `NodeConfig`). The connection then keeps serving, so a second
-    /// unsupported request is answered too.
-    #[tokio::test]
-    async fn unsupported_request_gets_error_reply_and_keeps_serving() {
-        let (events_tx, _events_rx) = flume::unbounded();
+    async fn connect_to_listener() -> (
+        TcpStream,
+        flume::Receiver<Timestamped<DynamicNodeEventWrapper>>,
+    ) {
+        let (events_tx, events_rx) = flume::unbounded();
         let port = spawn_listener_loop("127.0.0.1:0".parse().unwrap(), events_tx)
             .await
             .expect("failed to spawn listener")
             .expect("listener should bind to an ephemeral port");
-
-        let mut client = TcpStream::connect(("127.0.0.1", port))
+        let client = TcpStream::connect(("127.0.0.1", port))
             .await
             .expect("failed to connect to listener");
+        (client, events_rx)
+    }
 
+    async fn send_request(client: &mut TcpStream, request: DaemonRequest) {
         let clock = HLC::default();
+        let request = Timestamped {
+            inner: request,
+            timestamp: clock.new_timestamp(),
+        };
+        let encoded = dora_message::encode(&request).expect("failed to encode request");
+        socket_stream_send(client, &encoded)
+            .await
+            .expect("failed to send request");
+    }
+
+    /// A well-formed binary-reply request this listener does not implement must
+    /// be answered with an explicit error, so a request/reply client fails
+    /// loudly instead of blocking forever on a reply that never comes (the
+    /// listener only implements `NodeConfig`). The connection then keeps
+    /// serving, so a second unsupported request is answered too.
+    ///
+    /// The reply is decoded with Postcard — the codec the real client picks for
+    /// a `Subscribe` request (`expects_tcp_binary_reply()`), per
+    /// `apis/rust/node/src/daemon_connection/tcp.rs`. Decoding it as JSON here
+    /// would let a serde_json-encoded reply pass the test while the actual
+    /// client hit a decode error.
+    #[tokio::test]
+    async fn unsupported_request_gets_error_reply_and_keeps_serving() {
+        let (mut client, _events_rx) = connect_to_listener().await;
+
         // `Subscribe` is a valid, well-formed request the listener does not
         // handle, so it exercises the unsupported-request arm. Send it twice on
         // the same connection: the first proves the error reply, the second
         // proves the connection is still being served afterwards.
         for attempt in 0..2 {
-            let request = Timestamped {
-                inner: DaemonRequest::Subscribe,
-                timestamp: clock.new_timestamp(),
-            };
-            let encoded = dora_message::encode(&request).expect("failed to encode request");
-            socket_stream_send(&mut client, &encoded)
-                .await
-                .expect("failed to send request");
+            assert!(
+                DaemonRequest::Subscribe.expects_tcp_binary_reply(),
+                "test premise: the real client decodes a Subscribe reply with Postcard"
+            );
+            send_request(&mut client, DaemonRequest::Subscribe).await;
 
             // Expect an explicit error reply rather than a hang.
             let raw = socket_stream_receive_with_header_timeout(
@@ -235,7 +273,9 @@ mod tests {
             .unwrap_or_else(|e| {
                 panic!("attempt {attempt}: expected an error reply, not a hang: {e}")
             });
-            let reply: DaemonReply = serde_json::from_slice(&raw).expect("failed to decode reply");
+            let reply: DaemonReply = dora_message::decode(&raw).unwrap_or_else(|e| {
+                panic!("attempt {attempt}: reply must decode with the client's codec: {e:?}")
+            });
             match reply {
                 DaemonReply::Result(Err(msg)) => {
                     assert!(
@@ -248,5 +288,51 @@ mod tests {
                 }
             }
         }
+    }
+
+    /// `SendMessage` and `OutputSent` are fire-and-forget: the client reads no
+    /// reply at all (neither `expects_tcp_binary_reply` nor
+    /// `expects_tcp_json_reply`). Answering them would leave an unsolicited
+    /// frame buffered on the connection and desync the *next* request/reply, so
+    /// the listener must stay silent — and must still serve the connection.
+    #[tokio::test]
+    async fn no_reply_requests_are_not_answered() {
+        let (mut client, _events_rx) = connect_to_listener().await;
+
+        let no_reply = DaemonRequest::SendMessage {
+            output_id: "out".to_string().into(),
+            metadata: Metadata::new(HLC::default().new_timestamp()),
+            data: None,
+        };
+        assert!(
+            !no_reply.expects_tcp_binary_reply() && !no_reply.expects_tcp_json_reply(),
+            "test premise: the real client reads no reply for this request"
+        );
+        send_request(&mut client, no_reply).await;
+
+        // Nothing may come back. A short timeout is the assertion: the listener
+        // sending anything here is the bug.
+        let unexpected = socket_stream_receive_with_header_timeout(
+            &mut client,
+            Some(Duration::from_millis(500)),
+        )
+        .await;
+        assert!(
+            unexpected.is_err(),
+            "listener must not answer a no-reply request; got {} bytes",
+            unexpected.map(|r| r.len()).unwrap_or(0)
+        );
+
+        // The connection must still be alive and serving afterwards.
+        send_request(&mut client, DaemonRequest::Subscribe).await;
+        let raw =
+            socket_stream_receive_with_header_timeout(&mut client, Some(Duration::from_secs(5)))
+                .await
+                .expect("connection must still serve after a silently-ignored request");
+        let reply: DaemonReply = dora_message::decode(&raw).expect("failed to decode reply");
+        assert!(
+            matches!(reply, DaemonReply::Result(Err(ref msg)) if msg.contains("unsupported request")),
+            "unexpected reply: {reply:?}"
+        );
     }
 }

--- a/binaries/daemon/src/local_listener.rs
+++ b/binaries/daemon/src/local_listener.rs
@@ -143,13 +143,19 @@ async fn handle_connection_loop(
                 break;
             }
             // `DaemonRequest` is `#[non_exhaustive]` and this listener only
-            // implements `NodeConfig`. A version-skewed or misbehaving client
-            // may send some other request and then block on the request/reply
-            // it expects. Mirror the node TCP listener
+            // implements `NodeConfig`. A same-version client can still send a
+            // known-but-unhandled request to this port — a hand-rolled or
+            // misconfigured client — and then block on the request/reply it
+            // expects. Mirror the node TCP listener
             // (`node_communication::tcp::send_reply`): answer with an explicit
             // error so the client fails loudly instead of hanging forever, and
             // — like the `NodeConfig` arm above and `node_communication` — keep
             // serving the connection afterwards rather than tearing it down.
+            //
+            // A *newer* variant this daemon predates cannot reach here: its
+            // postcard discriminant fails to decode in `receive_message`, so
+            // that path takes the `Err(err) => break` arm above and closes the
+            // connection (the client sees EOF, not a hang).
             //
             // The reply codec is dictated by the *request*, not by this
             // listener: `apis/rust/node/src/daemon_connection/tcp.rs` decodes
@@ -161,14 +167,19 @@ async fn handle_connection_loop(
             // no-reply requests (`SendMessage`, `OutputSent`), where an
             // unsolicited frame would be left buffered and desync the next
             // request/reply on this connection.
+            //
+            // Log and report the request *kind* only, never `{other:?}`:
+            // `ExtensionStore`/`ExtensionRequest` carry multi-MB byte payloads,
+            // so Debug-formatting the whole request would amplify one such
+            // request into a huge log line and an equally huge reply body.
             Ok(Some(Timestamped { inner: other, .. })) => {
-                tracing::warn!("unsupported request on local listener: {other:?}");
+                let kind = request_kind(&other);
+                tracing::warn!("unsupported request on local listener: {kind}");
                 if !other.expects_tcp_binary_reply() {
                     continue;
                 }
                 let reply = DaemonReply::Result(Err(format!(
-                    "unsupported request on local listener (client is likely \
-                     newer than this daemon): {other:?}"
+                    "unsupported request `{kind}` on local listener"
                 )));
                 match dora_message::encode_presized(&reply, reply.encode_size_hint())
                     .wrap_err("failed to serialize DaemonReply")
@@ -182,6 +193,32 @@ async fn handle_connection_loop(
                 }
             }
         }
+    }
+}
+
+/// A short, static label for a `DaemonRequest` variant, for logs and error
+/// replies. Deliberately excludes the payload: `ExtensionStore` and
+/// `ExtensionRequest` carry multi-MB byte vectors, so Debug-formatting the
+/// whole request (`{req:?}`) would amplify one request into a huge string —
+/// both in the log and in the reply body that is then written back.
+fn request_kind(request: &DaemonRequest) -> &'static str {
+    match request {
+        DaemonRequest::Register(_) => "Register",
+        DaemonRequest::Subscribe => "Subscribe",
+        DaemonRequest::SendMessage { .. } => "SendMessage",
+        DaemonRequest::OutputSent { .. } => "OutputSent",
+        DaemonRequest::CloseOutputs(_) => "CloseOutputs",
+        DaemonRequest::OutputsDone => "OutputsDone",
+        DaemonRequest::NextEvent => "NextEvent",
+        DaemonRequest::EventStreamDropped => "EventStreamDropped",
+        DaemonRequest::NodeConfig { .. } => "NodeConfig",
+        DaemonRequest::ExtensionStore { .. } => "ExtensionStore",
+        DaemonRequest::ExtensionLoad { .. } => "ExtensionLoad",
+        DaemonRequest::ExtensionDrop { .. } => "ExtensionDrop",
+        DaemonRequest::ExtensionRequest { .. } => "ExtensionRequest",
+        // `DaemonRequest` is `#[non_exhaustive]`; a variant added later that
+        // this map has not been taught still gets a safe generic label.
+        _ => "unknown",
     }
 }
 
@@ -333,6 +370,49 @@ mod tests {
         assert!(
             matches!(reply, DaemonReply::Result(Err(ref msg)) if msg.contains("unsupported request")),
             "unexpected reply: {reply:?}"
+        );
+    }
+
+    /// The error reply must name only the request *kind*, never echo the
+    /// payload: `ExtensionRequest` carries an arbitrarily large byte vector, so
+    /// Debug-formatting the whole request would amplify a multi-MB request into
+    /// an equally large reply. Send a request with a recognizable payload and
+    /// assert the reply is the fixed kind-based string that does not contain it.
+    #[tokio::test]
+    async fn unsupported_request_reply_does_not_echo_payload() {
+        let (mut client, _events_rx) = connect_to_listener().await;
+
+        let payload = vec![0xABu8; 4096];
+        let request = DaemonRequest::ExtensionRequest {
+            namespace: "test-ns".to_string(),
+            payload: payload.clone(),
+        };
+        assert!(
+            request.expects_tcp_binary_reply(),
+            "test premise: ExtensionRequest gets a reply"
+        );
+        send_request(&mut client, request).await;
+
+        let raw =
+            socket_stream_receive_with_header_timeout(&mut client, Some(Duration::from_secs(5)))
+                .await
+                .expect("expected an error reply, not a hang");
+        let reply: DaemonReply = dora_message::decode(&raw).expect("failed to decode reply");
+        let msg = match reply {
+            DaemonReply::Result(Err(msg)) => msg,
+            other => panic!("expected DaemonReply::Result(Err(_)), got {other:?}"),
+        };
+        assert_eq!(
+            msg,
+            "unsupported request `ExtensionRequest` on local listener"
+        );
+        // The whole encoded reply frame must stay small — proof the payload was
+        // not folded into the reply body.
+        assert!(
+            raw.len() < payload.len(),
+            "reply frame ({} bytes) must not carry the {}-byte payload",
+            raw.len(),
+            payload.len()
         );
     }
 }


### PR DESCRIPTION
## Problem

`handle_connection_loop` in the dynamic-node local listener (`binaries/daemon/src/local_listener.rs`) only handles `DaemonRequest::NodeConfig`. Any other well-formed request fell into a catch-all arm that merely logged a warning and then looped back to `receive_message`:

```rust
_ => tracing::warn!(
    "Unexpected Daemon Request that is not yet by Additional local listener controls"
),
```

It **never sent a reply**. Because this listener speaks a request/reply protocol and `receive_message` uses no header timeout (`socket_stream_receive_with_header_timeout(connection, None)`), a client that sends such a request and waits for its reply blocks **indefinitely**.

The request that reaches this arm is a **same-version** client sending a known-but-unhandled request to the local-listener port — a hand-rolled or misconfigured client. (A *newer* `#[non_exhaustive]` variant this daemon predates cannot reach here: its postcard discriminant fails to decode in `receive_message`, so that path closes the connection via the `Err(_) => break` arm and the client sees EOF, not a hang.)

## Fix

Mirror the node TCP listener (`node_communication`), which already handles the unhandled-request case by replying with an explicit *"unsupported request"* error so the peer fails loudly, and then keeps serving the connection:

- Reply with `DaemonReply::Result(Err(..))` on the catch-all arm, and keep serving the connection afterwards — consistent with both `node_communication` and this listener's own `NodeConfig` arm (which also loops rather than closing).
- **Encode the reply with the codec the request implies** (commit 2): the reply codec is dictated by the *request*, not the listener. The client decodes with Postcard for `expects_tcp_binary_reply()` requests, serde_json only for `NodeConfig`, and reads nothing for the fire-and-forget `SendMessage`/`OutputSent`. So encode with `encode_presized` (Postcard) and stay silent for the no-reply requests — the original serde_json copy would have landed as a decode error, and a frame for a no-reply request would desync the connection.
- **Report the request *kind*, not the whole request** (commit 3): the arm logged and replied with `{other:?}`. `ExtensionStore`/`ExtensionRequest` carry multi-MB byte vectors, so Debug-formatting the whole request amplified one request into a huge log line and an equally huge reply body. A small `request_kind(&DaemonRequest) -> &'static str` is used in both places instead.

## Validation

- Regression tests: an unsupported binary-reply request is answered and the connection keeps serving; a no-reply request is *not* answered (would desync); and an `ExtensionRequest` reply names only the kind and does not echo its payload.
- `cargo test -p dora-daemon --lib` — passes (3 local_listener tests + the existing suite)
- `cargo clippy -p dora-daemon -- -D warnings`, `cargo fmt --all -- --check`

(toolchain 1.97.1, matching CI)

---

⚠️ **Machine-generated PR.** This change was written by Claude (an AI agent) as part of an automated codebase review. It has been machine-verified but should receive human review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fpABBRmVUEkE6a2RDk3cy