### PR TITLE
fix(ros2-bridge): don't abort the process on a non-UTF-8 string field

### DIFF
--- a/libraries/extensions/ros2-bridge/src/_core/string.rs
+++ b/libraries/extensions/ros2-bridge/src/_core/string.rs
@@ -103,7 +103,24 @@ impl FFIToRust for FFIString {
     type Target = String;
 
     unsafe fn to_rust(&self) -> Self::Target {
-        unsafe { self.to_str().expect("CStr::to_str failed").to_string() }
+        // `to_str` already bounds the read by `size` and returns the borrowed
+        // `&str` for valid UTF-8 (and `""` when empty). A ROS2 `string` field
+        // is nominally UTF-8, but the bytes come off the wire / out of the C
+        // typesupport layer, so a buggy or hostile peer can deliver arbitrary
+        // bytes. `to_str` was deliberately made fallible precisely to handle
+        // that; discarding its `Err` with `expect` re-introduced a whole-process
+        // abort on a single malformed field. Fall back to lossy decoding
+        // instead, so an invalid field degrades to replacement characters —
+        // matching the sibling `FFIWString::to_rust`, which likewise never
+        // panics.
+        match unsafe { self.to_str() } {
+            Ok(s) => s.to_string(),
+            Err(_) => {
+                let bytes =
+                    unsafe { std::slice::from_raw_parts(self.data as *const u8, self.size) };
+                String::from_utf8_lossy(bytes).into_owned()
+            }
+        }
     }
 }
 
@@ -280,5 +297,43 @@ mod test {
         assert_eq!(result, U16String::from(vec![b'a'.into(), 0, b'b'.into()]));
         // Keep `data` alive until after the read above; `FFIWString` borrows it.
         drop(data);
+    }
+
+    #[test]
+    fn ffi_string_to_rust_is_lossy_on_invalid_utf8() {
+        // A `string` field is nominally UTF-8, but the bytes come off the wire
+        // / out of the C typesupport layer, so `to_rust` must degrade on
+        // invalid UTF-8 rather than abort the whole process. We construct the
+        // `FFIString` by hand to inject non-UTF-8 bytes (a Rust `String` could
+        // not hold them).
+        let mut data: Vec<u8> = vec![b'a', 0xFF, 0xFE, b'b'];
+        let native_string = FFIString {
+            data: data.as_mut_ptr() as *mut c_char,
+            size: data.len(),
+            capacity: data.len(),
+        };
+
+        // Must not panic; the invalid bytes become replacement chars while the
+        // surrounding valid ASCII survives.
+        let result = unsafe { native_string.to_rust() };
+        assert!(result.starts_with('a'), "unexpected result: {result:?}");
+        assert!(result.ends_with('b'), "unexpected result: {result:?}");
+        assert!(
+            result.contains('\u{FFFD}'),
+            "expected a replacement char: {result:?}"
+        );
+
+        // Keep `data` alive until after the read above; `FFIString` borrows it.
+        drop(data);
+    }
+
+    #[test]
+    fn ffi_string_to_rust_empty() {
+        let native_string = FFIString {
+            data: std::ptr::null_mut(),
+            size: 0,
+            capacity: 0,
+        };
+        assert_eq!(unsafe { native_string.to_rust() }, "");
     }
 }


### PR DESCRIPTION
## Problem

`FFIString::to_rust` (`libraries/extensions/ros2-bridge/src/_core/string.rs`) decoded a ROS2 `string` field with:

```rust
unsafe fn to_rust(&self) -> Self::Target {
    unsafe { self.to_str().expect("CStr::to_str failed").to_string() }
}
```

`to_str` was **deliberately** made fallible — and bounded by `size` — precisely so a malformed field could be handled rather than trusted (see its comment, and the parallel hardening of the sibling `FFIWString::to_rust`). But `to_rust` threw that `Result` away with `.expect()`, so a single field whose bytes are not valid UTF-8 **aborts the entire node process**.

A ROS2 string is nominally UTF-8, but the bytes arrive off the wire / out of the C typesupport layer, so a buggy or hostile peer can deliver arbitrary bytes. The 16-bit sibling `FFIWString::to_rust` already degrades without panicking; the 8-bit path was the lone outlier still discarding the error.

## Fix

Reuse `to_str` for the valid-UTF-8 (and empty) path, and fall back to `String::from_utf8_lossy` only on the `Err` branch, so an invalid field becomes replacement characters instead of a crash:

```rust
match unsafe { self.to_str() } {
    Ok(s) => s.to_string(),
    Err(_) => {
        let bytes = unsafe { std::slice::from_raw_parts(self.data as *const u8, self.size) };
        String::from_utf8_lossy(bytes).into_owned()
    }
}
```

## Scope note

The outbound `OwnedFFIString::from_rust` / `OwnedFFIWString::from_rust` still `.expect()` on an *interior NUL*. That is a distinct concern (outbound path, and the right degradation — truncate at the NUL vs. surface an error — is a semantics decision), so it is intentionally **left out** of this change.

## Validation

- Added regression tests for the invalid-UTF-8 and empty cases, constructing the `FFIString` by hand (a Rust `String` cannot hold the non-UTF-8 bytes), mirroring the existing `ffi_wstring_preserves_embedded_nul` test.
- `cargo test -p dora-ros2-bridge --lib _core::string` — 5 pass
- `cargo clippy -p dora-ros2-bridge -- -D warnings`, `cargo fmt --all -- --check`

(toolchain 1.97.1, matching CI)

---

⚠️ **Machine-generated PR.** This change was written by Claude (an AI agent) as part of an automated codebase review. It has been machine-verified but should receive human review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fpABBRmVUEkE6a2RDk3cy

---
_Generated by [Claude Code](https://claude.ai/code/session_018fpABBRmVUEkE6a2RDk3cy)_