### PR TITLE
refactor(core): decouple the graph visualizer from the literal "op"

### DIFF
--- a/libraries/core/src/descriptor/visualize.rs
+++ b/libraries/core/src/descriptor/visualize.rs
@@ -4,7 +4,7 @@ use dora_message::{
     id::{DataId, NodeId},
 };
 
-use super::{CustomNode, ModuleBoundaries, ResolvedNode, RuntimeNode};
+use super::{CustomNode, ModuleBoundaries, ResolvedNode, RuntimeNode, SINGLE_OPERATOR_DEFAULT_ID};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     fmt::Write as _,
@@ -140,18 +140,23 @@ fn visualize_runtime_node(
     operators: &[OperatorDefinition],
     flowchart: &mut String,
 ) {
-    if operators.len() == 1 && operators[0].id.to_string() == "op" {
+    if operators.len() == 1 && operators[0].id.as_ref() == SINGLE_OPERATOR_DEFAULT_ID {
         let operator = &operators[0];
+        // The node's mermaid id must match how edges reference this operator,
+        // which `visualize_node_inputs` builds as `{node_id}/{operator.id}`.
+        // Use the operator id here rather than a second literal `op` so the two
+        // can never drift apart if `SINGLE_OPERATOR_DEFAULT_ID` changes.
+        let operator_id = &operator.id;
         // single operator node
         if operator.config.inputs.is_empty() {
             // source node
-            writeln!(flowchart, "  {node_id}/op[\\{node_id}/]").unwrap();
+            writeln!(flowchart, "  {node_id}/{operator_id}[\\{node_id}/]").unwrap();
         } else if operator.config.outputs.is_empty() {
             // sink node
-            writeln!(flowchart, "  {node_id}/op[/{node_id}\\]").unwrap();
+            writeln!(flowchart, "  {node_id}/{operator_id}[/{node_id}\\]").unwrap();
         } else {
             // normal node
-            writeln!(flowchart, "  {node_id}/op[{node_id}]").unwrap();
+            writeln!(flowchart, "  {node_id}/{operator_id}[{node_id}]").unwrap();
         }
     } else {
         writeln!(flowchart, "subgraph {node_id}").unwrap();


### PR DESCRIPTION
## Summary

`visualize_runtime_node` (`libraries/core/src/descriptor/visualize.rs`) collapses a single-operator runtime node into an inline mermaid node when `operators[0].id.to_string() == "op"`, then emits that node's id as `{node_id}/op` — hardcoding the literal `"op"` in **two** places.

That value is really `descriptor::SINGLE_OPERATOR_DEFAULT_ID` (defined in `descriptor/mod.rs`, the id injected for a defaulted single `operator:`), and the edge builder in `visualize_node_inputs` already references the operator as `{node_id}/{operator.id}` (the actual id).

So the three literals only agree by coincidence. If `SINGLE_OPERATOR_DEFAULT_ID` were ever changed, the branch condition would still fire for the new default id while the emitted node id stayed `/op`, silently diverging from the `/{operator.id}` the edges use — a dangling node vs. dangling edge in the rendered graph.

## Fix

- Compare against the `SINGLE_OPERATOR_DEFAULT_ID` constant instead of the literal `"op"` (this also drops a per-call `String` allocation, since `.as_ref()` compares against a `&str`).
- Emit the node id from `operator.id` (which equals the constant on this branch) so the node declaration and the edge references are derived from the same source and cannot drift.

Output is byte-identical for the default `op` id — this is a decoupling refactor, so the existing (unchanged) descriptor tests continue to cover it.

## Validation

- `cargo test -p dora-core --lib` — 314 pass
- `cargo clippy -p dora-core -- -D warnings`, `cargo fmt --all -- --check`

(toolchain 1.97.1, matching CI)

---

⚠️ **Machine-generated PR.** This change was written by Claude (an AI agent) as part of an automated codebase review. It has been machine-verified but should receive human review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fpABBRmVUEkE6a2RDk3cy

---
_Generated by [Claude Code](https://claude.ai/code/session_018fpABBRmVUEkE6a2RDk3cy)_