### PR TITLE
fix(tensor-pool): correct seqlock publish/re-read memory fences (#3288)

### DIFF
--- a/libraries/extensions/tensor-pool/python/src/transport.rs
+++ b/libraries/extensions/tensor-pool/python/src/transport.rs
@@ -1429,12 +1429,16 @@ unsafe fn seqlock_begin_if_even(gen_ptr: *mut u64) -> u64 {
 /// in `write_tensor_pool`.
 unsafe fn seqlock_end(gen_ptr: *mut u64, pre_write_gen: u64, copy_ok: bool) {
     unsafe {
+        // Release fence BEFORE the completion store, so the writer's payload
+        // writes are ordered before the even ("complete") generation becomes
+        // visible. A fence placed *after* the store orders nothing on a
+        // weakly-ordered CPU (dora-rs/dora#3288).
+        std::sync::atomic::fence(std::sync::atomic::Ordering::Release);
         if copy_ok {
             std::ptr::write_volatile(gen_ptr, pre_write_gen.wrapping_add(2));
         } else {
             std::ptr::write_volatile(gen_ptr, pre_write_gen);
         }
-        std::sync::atomic::fence(std::sync::atomic::Ordering::Release);
     }
 }
 
@@ -2271,8 +2275,11 @@ impl Pool<'_> {
         unsafe {
             let gen_ptr = shmem_ptr.add(96) as *mut u64;
             let old_gen = std::ptr::read_volatile(gen_ptr);
-            std::ptr::write_volatile(gen_ptr, old_gen.wrapping_add(1));
+            // Release fence BEFORE the completion store (dora-rs/dora#3288):
+            // it orders the preceding payload writes before the "complete"
+            // generation is published; a fence after the store is inert.
             std::sync::atomic::fence(std::sync::atomic::Ordering::Release);
+            std::ptr::write_volatile(gen_ptr, old_gen.wrapping_add(1));
         }
 
         // Store shmem in pool (keep alive)
@@ -3774,7 +3781,12 @@ impl Pool<'_> {
             };
         }
 
-        // Seqlock: re-read generation — mismatch means data changed during read
+        // Seqlock: re-read generation — mismatch means data changed during read.
+        // Acquire fence BEFORE the re-read so the payload loads above cannot be
+        // reordered past this load; otherwise a concurrent write that bumps the
+        // generation mid-read is not detected on a weakly-ordered CPU
+        // (dora-rs/dora#3288).
+        std::sync::atomic::fence(std::sync::atomic::Ordering::Acquire);
         let read_gen2 = unsafe { std::ptr::read_volatile(shmem_ptr.add(96) as *const u64) };
         if read_gen2 != read_gen {
             return Ok(None);

--- a/libraries/extensions/tensor-pool/src/daemon/mirror.rs
+++ b/libraries/extensions/tensor-pool/src/daemon/mirror.rs
@@ -83,12 +83,16 @@ pub(crate) unsafe fn seqlock_begin_if_even(gen_ptr: *mut u64) -> u64 {
 /// node API's `seqlock_end`.
 pub(crate) unsafe fn seqlock_end(gen_ptr: *mut u64, pre_write_gen: u64, copy_ok: bool) {
     unsafe {
+        // Release fence BEFORE the completion store, so the writer's payload
+        // writes are ordered before the even ("complete") generation becomes
+        // visible. A fence placed *after* the store orders nothing on a
+        // weakly-ordered CPU (dora-rs/dora#3288).
+        std::sync::atomic::fence(std::sync::atomic::Ordering::Release);
         if copy_ok {
             std::ptr::write_volatile(gen_ptr, pre_write_gen.wrapping_add(2));
         } else {
             std::ptr::write_volatile(gen_ptr, pre_write_gen);
         }
-        std::sync::atomic::fence(std::sync::atomic::Ordering::Release);
     }
 }
 


### PR DESCRIPTION
Fixes #3288.

## Problem

The tensor-pool seqlock uses `write_volatile` on the generation counter (`header[96]`) plus manual `std::sync::atomic::fence`s to publish and validate frames. Two of those fences were on the **wrong side** of the sequence access, so on weakly-ordered architectures (aarch64 — Jetson and other ARM robotics hosts are primary dora targets) the seqlock did **not** actually prevent torn/stale reads. It was latent on x86-64 only because TSO happens to forbid the offending reorderings.

## Fix

Both defects from the issue, applied mechanically as suggested (the `begin` sites already order correctly and are untouched):

- **Defect A — writer publish fence placed *after* the completion store.** A release fence establishes ordering only w.r.t. a store *sequenced after* it; with the store first, the fence was inert and the payload writes were not ordered before the "complete" generation became visible. Moved the release fence **before** the completion store at every publish site:
  - `seqlock_end` — `libraries/extensions/tensor-pool/python/src/transport.rs`
  - `seqlock_end` — `libraries/extensions/tensor-pool/src/daemon/mirror.rs` (kept bit-identical to the node-side copy)
  - inline write-complete in `register_tensor_pool` — `transport.rs`

- **Defect B — reader missing the acquire fence before the second sequence load.** Added `fence(Acquire)` immediately before the `read_gen2` re-read so the payload loads cannot be reordered past it; otherwise a concurrent write that bumps the generation mid-read is not detected on a weakly-ordered CPU.

Both defects are independent — both are required for the seqlock to be sound on aarch64.

The issue also floats a longer-term migration of `header[96]` to `AtomicU64` with `store(Release)`/`load(Acquire)`. That is a larger change the issue flagged for human confirmation, so it is intentionally **not** included here; this PR is the minimal, mechanical correctness fix.

## Validation

- `cargo check -p dora-tensor-pool --features daemon` and `cargo check -p dora-tensor-pool-python --all-targets` — pass.
- `cargo clippy -p dora-tensor-pool --features daemon -- -D warnings` — clean.
- `cargo fmt -p dora-tensor-pool -p dora-tensor-pool-python -- --check` — clean.
- `cargo test -p dora-tensor-pool --features daemon` — the 39 seqlock/other tests pass. Two `cross_pool_write_tests` (zenoh networking) fail, but they fail identically on pristine `origin/main` in this sandbox — pre-existing and unrelated to this change.

No regression test is included: the defect only manifests under ARM instruction reordering, which is not reproducible portably in a unit test (the existing seqlock unit tests exercise single-threaded parity, not ordering). The change is a mechanical fence reordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7t4QaCSrLeKWmbU6jxMns)_