### PR TITLE
docs(node-api): correct EventStream trait reference in crate docs

### DIFF
--- a/apis/rust/node/src/lib.rs
+++ b/apis/rust/node/src/lib.rs
@@ -38,7 +38,9 @@
 //!
 //! ### Receiving Events
 //!
-//! The [`EventStream`] is an [`AsyncIterator`][std::async_iter::AsyncIterator] that yields the incoming [`Event`]s.
+//! The [`EventStream`] implements the [`Stream`](futures::Stream) trait, yielding the incoming
+//! [`Event`]s. Iterate it asynchronously with [`StreamExt::next`](futures::StreamExt::next), or use
+//! the synchronous [`recv`](EventStream::recv) loop.
 //!
 //! Nodes should iterate over this event stream and react to events that they are interested in.
 //! Typically, the most important event type is [`Event::Input`].


### PR DESCRIPTION
## Summary

The crate-root "Receiving Events" section of `dora-node-api` described `EventStream` as an `AsyncIterator`, linking to `std::async_iter::AsyncIterator`. That is wrong on two counts:

- `EventStream` implements **`futures::Stream`** (`impl Stream for EventStream` in `event_stream/mod.rs`), not `std::async_iter::AsyncIterator`.
- `std::async_iter::AsyncIterator` is a nightly-unstable trait with a different method surface (no `StreamExt` combinators), so a new node author following the link lands on something they can't use on stable.

The struct-level docs already correctly say it implements `Stream` and point at `StreamExt::next`, so the crate root — the first thing a new user reads — contradicted the type's own documentation.

## Fix

Reword the crate-root sentence to reference `futures::Stream`, `StreamExt::next`, and the synchronous `EventStream::recv` loop, matching the struct docs.

## Validation

Doc-only change. `cargo doc -p dora-node-api` produces no new warnings (the intra-doc links resolve) and `cargo fmt --check` passes.

---

⚠️ **This pull request was generated by Claude Code (an AI agent). It is machine-generated; a human should review it carefully before merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgEQqEiqNp48KX73cVAaTm)_