### PR TITLE
docs(node-api): document error conditions of output-sending methods

### DIFF
--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -1570,6 +1570,13 @@ impl DoraNode {
     /// Ignores the output if the given `output_id` is not specified as node output in the dataflow
     /// configuration file.
     ///
+    /// # Errors
+    ///
+    /// Returns [`NodeError::Output`] if the payload cannot be Arrow-IPC encoded, or if runtime type
+    /// checking is enabled in error mode (`DORA_RUNTIME_TYPE_CHECK=error`) and the array's Arrow
+    /// type does not match the output's declared type. An `output_id` that is not declared as an
+    /// output is *not* an error — the call is ignored and returns `Ok`.
+    ///
     /// ```no_run
     /// use dora_node_api::{DoraNode, MetadataParameters};
     /// use dora_core::config::DataId;
@@ -1607,6 +1614,15 @@ impl DoraNode {
     /// operator thread does the encoding so that no memory owned by the
     /// operator's language runtime is ever released on the node's thread — see
     /// [`SampleAllocator`] (dora-rs/dora#2742).
+    ///
+    /// Like [`send_output`](Self::send_output), an `output_id` that is not a
+    /// declared output is ignored (returns `Ok`).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NodeError::Output`] if runtime type checking is enabled in error mode
+    /// (`DORA_RUNTIME_TYPE_CHECK=error`) and the sample's Arrow type does not match the output's
+    /// declared type.
     pub fn send_output_encoded(
         &mut self,
         output_id: DataId,
@@ -1676,10 +1692,16 @@ impl DoraNode {
 
     /// Send the given raw byte data as output.
     ///
-    /// Might copy the data once to move it into shared memory.
+    /// Might copy the data once to move it into shared memory. `data_len` must equal `data.len()`;
+    /// the allocated sample is sized from `data_len` and the payload is copied from `data`.
     ///
     /// Ignores the output if the given `output_id` is not specified as node output in the dataflow
     /// configuration file.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NodeError::Output`] if `data_len` does not equal `data.len()` (which would
+    /// otherwise panic in the internal `copy_from_slice`).
     pub fn send_output_bytes(
         &mut self,
         output_id: DataId,
@@ -1879,6 +1901,12 @@ impl DoraNode {
     /// The node is not allowed to send more outputs with the closed IDs.
     ///
     /// Closing outputs early can be helpful to receivers.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NodeError::Output`] if any id is not a declared output of this node. Unlike
+    /// [`send_output`](Self::send_output), which silently ignores unknown outputs, this validates
+    /// the whole batch *before* closing any output, so on error none of them are closed.
     pub fn close_outputs(&mut self, outputs_ids: Vec<DataId>) -> NodeResult<()> {
         // Validate the whole batch before mutating any local state. Removing
         // outputs eagerly would leave the node's local output set out of sync
@@ -2336,6 +2364,10 @@ impl DoraNode {
     /// metadata parameters. Returns the generated request ID.
     ///
     /// Any existing `request_id` key in `parameters` is replaced.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from [`send_output`](Self::send_output).
     pub fn send_service_request(
         &mut self,
         output_id: DataId,
@@ -2374,6 +2406,10 @@ impl DoraNode {
     /// Send a streaming segment chunk. Convenience wrapper around
     /// [`send_output`](Self::send_output) that builds metadata from the
     /// [`StreamSegment`] builder.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from [`send_output`](Self::send_output).
     pub fn send_stream_chunk(
         &mut self,
         output_id: DataId,


### PR DESCRIPTION
## Summary

Several public `DoraNode` output methods return `NodeResult` but their docs described only the `Ok` path, so callers couldn't tell that a call which "looks" infallible can start returning `Err` — sometimes purely because of a deployment env var. This adds `# Errors` sections documenting the actual failure conditions (all verified against the code).

## Changes

- **`send_output` / `send_output_encoded`** — return `NodeError::Output` when runtime type checking is in error mode (`DORA_RUNTIME_TYPE_CHECK=error`) and the Arrow type mismatches the declared output type; `send_output` also errors if the payload cannot be Arrow-IPC encoded. Clarified that an undeclared `output_id` is *ignored* (returns `Ok`), not an error.
- **`send_output_bytes`** — returns `NodeError::Output` when `data_len != data.len()` (a guard that prevents an internal `copy_from_slice` panic). Documented the `data_len == data.len()` contract of the two-length signature.
- **`close_outputs`** — returns `NodeError::Output` for an unknown output id, validating the whole batch before closing any. This is the *opposite* of `send_output`'s silent-ignore behavior — an inconsistency users could not predict from the old docs.
- **`send_service_request` / `send_stream_chunk`** — note that they propagate errors from `send_output`.

## Validation

Doc-only change. `cargo doc -p dora-node-api` produces no new warnings (the `NodeError::Output` / `Self::send_output` intra-doc links resolve) and `cargo fmt --check` passes.

---

⚠️ **This pull request was generated by Claude Code (an AI agent). It is machine-generated; a human should review it carefully before merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgEQqEiqNp48KX73cVAaTm)_