### PR TITLE
docs(node-api): correct drain_drop_counts backpressure cap and eviction

### DIFF
--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -989,9 +989,12 @@ impl EventStream {
 
     /// Returns and resets the accumulated drop counts per input ID.
     ///
-    /// When inputs overflow their queue limits, the oldest messages are discarded.
-    /// For `drop_oldest` inputs this happens at `queue_size`. For `backpressure`
-    /// inputs this happens at a hard safety cap of 10x `queue_size`.
+    /// When inputs overflow their queue limits, events are discarded to keep memory bounded. For
+    /// `drop_oldest` inputs the cap is `queue_size` (clamped to at least 1); an overflow normally
+    /// evicts the oldest queued event, but correlated service/action messages and the `Stop` event
+    /// are preserved where possible, so the evicted event may instead be a newer one (or the
+    /// incoming event itself). For `backpressure` inputs the hard safety cap is
+    /// `max(10 × queue_size, 100)`.
     /// This method returns a map from input ID to the number of messages dropped
     /// since the last call.
     pub fn drain_drop_counts(&mut self) -> HashMap<DataId, u64> {


### PR DESCRIPTION
## Summary

The doc comment on `EventStream::drain_drop_counts` misstated two things about how inputs overflow their queue limits:

1. **Backpressure cap.** It said the `backpressure` safety cap is "10x `queue_size`". The actual cap is `queue_size.saturating_mul(10).max(100)` (see `QueuePolicy::effective_cap` in `dora-message`), i.e. `max(10 × queue_size, 100)` — a floor of 100 that the config-level doc already documents. For any `queue_size < 10` the effective cap is 100, not 10×, so the old text understated worst-case buffering for the small queues users size against this exact number.
2. **Eviction rule.** It said "the oldest messages are discarded". For `drop_oldest` the scheduler's eviction is correlation-aware (`select_eviction`): it preserves correlated service/action messages and the `Stop` event where possible, so the dropped event can be a newer queued event or the incoming event itself, not necessarily the oldest.

## Fix

Reword the comment to state the `max(10 × queue_size, 100)` backpressure cap and the correlation-aware `drop_oldest` eviction, and note the `drop_oldest` cap is clamped to at least 1.

## Validation

Doc-only change. `cargo doc -p dora-node-api` produces no new warnings and `cargo fmt --check` passes.

---

⚠️ **This pull request was generated by Claude Code (an AI agent). It is machine-generated; a human should review it carefully before merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgEQqEiqNp48KX73cVAaTm)_