### PR TITLE
docs: state the Python version promise for 1.x

### DIFF
--- a/docs/api-python.md
+++ b/docs/api-python.md
@@ -6,6 +6,14 @@ This document covers the Python APIs for building dora nodes, operators, and dat
 pip install dora-rs
 ```
 
+**Supported interpreters: CPython 3.11 and later.** The wheels are built
+`abi3-py311`, so a single wheel works on every later CPython without waiting for
+a dora release — 3.11 is a floor dora 1.x will not raise, not a version it is
+pinned to. Free-threaded builds (`python3.13t`, `python3.14t`) are not
+supported: abi3 does not cover them and no wheels are published for them. See
+[Python version policy](api-rust.md#python-version-policy) for the full
+guarantee.
+
 ---
 
 ## Table of Contents

--- a/docs/api-rust.md
+++ b/docs/api-rust.md
@@ -792,6 +792,8 @@ dataflow or a `Cargo.toml`.
 | tensor-pool | Behind a generic extension seam, opt-in (#3152) |
 | `dora_arrow_convert::internal` | `pub` only because Rust has no cross-crate `pub(crate)`; never re-exported from `dora-node-api` |
 | The Arrow major version | See the Arrow version policy above |
+| The pyo3 version | `pyo3-ffi` declares `links = "python"`, so a build graph can hold exactly one; dora's is an implementation detail behind the wheels. See the Python version policy below |
+| `dora-cli`'s `python` feature | Internal wheel plumbing — it marks a build hosted by the `dora-rs-cli` wheel, not a supported knob |
 
 ### Internal
 
@@ -821,6 +823,33 @@ back it:
 A consequence of (1): a patch fix in an internal crate requires re-releasing
 its dependents. With `shared-version = true` in `release.toml` that already
 happens on every release, so the extra cost is close to zero.
+
+### Python version policy
+
+Both wheels are built `abi3-py311`, so **dora 1.x supports CPython 3.11 and
+later**. That floor is part of the 1.0 guarantee: raising it inside 1.x would
+uninstall dora for users on a Python it used to support, and no crates.io
+semver check would ever see it.
+
+abi3 makes the two directions asymmetric, in dora's favour:
+
+- **Newer CPython** — one `cp311-abi3` wheel loads on 3.12, 3.13 and later with
+  no rebuild, so a new interpreter release does not require a new dora release.
+  This is also the direction a pyo3 bump would otherwise threaten, which is why
+  the pyo3 version can stay exempt.
+- **Older CPython** — `requires-python = ">=3.11"` in both `pyproject.toml`s
+  makes pip refuse to install. This is the direction that breaks users, and it
+  moves only if dora deliberately moves it.
+
+Two limits stated rather than left implied:
+
+- **Free-threaded builds are not supported.** abi3 does not cover
+  `Py_GIL_DISABLED`; those interpreters need their own wheels and the release
+  matrix builds none, so there is no dora wheel for `python3.13t` or `3.14t`.
+- **CPython 3.11 reaches end of life in October 2027**, inside 1.x's expected
+  life. pyo3 drops old interpreters over time, so dora will eventually have to
+  either raise the floor — breaking users — or hold pyo3 back. Better decided
+  deliberately than under a deadline.
 
 ## Quick Start Example: Node
 


### PR DESCRIPTION
`requires-python = ">=3.11"` sits in both pyproject.toml files and nowhere else. The stability scope never said which interpreters 1.x supports, even though the Python node API is heading into the covered tier and its guarantee attaches to the Python module surface.

Adds a Python version policy section: 3.11 is a floor 1.x will not raise, and abi3 makes that asymmetric — newer CPythons load the same wheel with no rebuild, older ones are refused by pip. Names two limits that were true but unstated: free-threaded builds are unsupported (abi3 does not cover `Py_GIL_DISABLED` and the release matrix builds no `cp313t`/`cp314t` wheels), and CPython 3.11 goes EOL in October 2027, inside 1.x's expected life — at which point dora must either raise the floor or hold pyo3 back.

Also names the pyo3 version and `dora-cli`'s `python` feature in the outside-the-guarantee table, and repeats the supported-interpreter line at the top of `docs/api-python.md`, where Python users actually look.

Docs only.
