### PR TITLE
chore: stop publishing the pyo3-linking crates to crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,10 +84,8 @@ jobs:
             dora-operator-api-c
             dora-coordinator
             dora-daemon
-            dora-operator-api-python
             dora-runtime-api
             dora-runtime-shared-lib
-            dora-runtime-python
             dora-cli
             dora-ros2-bridge-msg-gen
             dora-ros2-bridge

--- a/apis/python/operator/Cargo.toml
+++ b/apis/python/operator/Cargo.toml
@@ -8,6 +8,13 @@ readme.workspace = true
 description.workspace = true
 license.workspace = true
 repository.workspace = true
+publish = false  # PyO3 glue, not a crates.io API -- see below
+# Links `pyo3`, and `pyo3-ffi` declares `links = "python"`, so cargo refuses
+# two pyo3 versions in one build graph. Publishing this crate would therefore
+# force any downstream that builds its own PyO3 extension onto dora's exact
+# pyo3 minor, and freeze that minor for the life of 1.x. It reaches users
+# compiled into the `dora-rs` wheel instead, where the pyo3 version is an
+# implementation detail. Nothing published depends on it.
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/binaries/runtime-python/Cargo.toml
+++ b/binaries/runtime-python/Cargo.toml
@@ -8,6 +8,13 @@ readme.workspace = true
 description.workspace = true
 license.workspace = true
 repository.workspace = true
+publish = false  # PyO3 glue, not a crates.io API -- see below
+# Links `pyo3`, and `pyo3-ffi` declares `links = "python"`, so cargo refuses
+# two pyo3 versions in one build graph. Publishing this crate would therefore
+# force any downstream that builds its own PyO3 extension onto dora's exact
+# pyo3 minor, and freeze that minor for the life of 1.x. It reaches users
+# compiled into the `dora-rs` wheel instead, where the pyo3 version is an
+# implementation detail. Nothing published depends on it.
 
 # Python (PyO3) operator runtime backend. Loads a Python module's `Operator`
 # class and runs it on the `dora-runtime-api` event loop. Shipped inside the

--- a/docs/api-rust.md
+++ b/docs/api-rust.md
@@ -793,6 +793,16 @@ dataflow or a `Cargo.toml`.
 | `dora_arrow_convert::internal` | `pub` only because Rust has no cross-crate `pub(crate)`; never re-exported from `dora-node-api` |
 | The Arrow major version | See the Arrow version policy above |
 
+Two of those crates are not on crates.io at all: `dora-operator-api-python`
+and `dora-runtime-python` are `publish = false`, and reach users compiled into
+the `dora-rs` wheel. Both link `pyo3`, and `pyo3-ffi` declares
+`links = "python"`, so cargo refuses two pyo3 versions in a single build graph.
+Published, they would force anyone building their own PyO3 extension onto
+dora's exact pyo3 minor and freeze that minor for the life of 1.x — for a
+delivery channel nobody uses, since writing a Python operator needs no Rust
+dependency. Unpublished, dora's pyo3 version stays an implementation detail
+that can move in a minor.
+
 ### Internal
 
 Crates that exist only to build the above. They are published to crates.io


### PR DESCRIPTION
`dora-operator-api-python` and `dora-runtime-python` link `pyo3`, and `pyo3-ffi` declares `links = "python"` — so cargo refuses two pyo3 versions in one build graph. While these are on crates.io, anyone building their own PyO3 extension against them is pinned to dora's exact pyo3 minor, and 1.0 would freeze that minor for the life of 1.x.

Nothing needs that channel. Both reach users compiled into the `dora-rs` wheel, and writing a Python operator requires no Rust dependency at all — a Python operator is a `.py` file with an `Operator` class. The only published crate that depended on either was `dora-runtime-python` itself, so both can go `publish = false` together without breaking cargo's rule that a published crate's dependencies must be published.

Also drops them from the ordered publish list in `release.yml`, which would otherwise fail on `publish = false`.

Unrelated, found while verifying: `dora-daemon` is published but has an optional dependency on `dora-tensor-pool`, which is `publish = false`. Pre-existing and not touched here, but worth a look before the 1.0 release.
