### PR TITLE
fix(cli): avoid panic on a pre-epoch clock in timestamp formatting

### DIFF
--- a/binaries/cli/src/command/record.rs
+++ b/binaries/cli/src/command/record.rs
@@ -445,10 +445,13 @@ fn run_record_proxy(args: Record) -> eyre::Result<()> {
         .collect::<eyre::Result<Vec<_>>>()?;
     let (_subscription_id, data_rx) = session.subscribe_topics(dataflow_id, ws_topics)?;
 
-    // Set up recording writer
+    // Set up recording writer.
+    // `duration_since` errors only when the wall clock is set before the Unix
+    // epoch (e.g. an embedded target booting before an RTC/NTP sync); fall back
+    // to 0 rather than panicking before recording starts.
     let start_nanos = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
+        .unwrap_or_default()
         .as_nanos() as u64;
 
     let header = RecordingHeader {
@@ -559,9 +562,10 @@ fn run_record_proxy(args: Record) -> eyre::Result<()> {
                     }
                 };
 
+                // See `start_nanos` above: never panic on a pre-epoch clock.
                 let now_nanos = SystemTime::now()
                     .duration_since(SystemTime::UNIX_EPOCH)
-                    .unwrap()
+                    .unwrap_or_default()
                     .as_nanos() as u64;
 
                 let entry = RecordEntry {

--- a/binaries/cli/src/command/topic/echo.rs
+++ b/binaries/cli/src/command/topic/echo.rs
@@ -174,9 +174,12 @@ fn inspect(
                     .unwrap_or_else(|| output_id.clone());
                 let output_name = format!("{node_id}/{display_output}");
 
+                // `duration_since` errors only when the wall clock is set before
+                // the Unix epoch (e.g. an embedded target booting before an RTC
+                // or NTP sync). Fall back to 0 rather than panicking mid-stream.
                 let timestamp = SystemTime::now()
                     .duration_since(SystemTime::UNIX_EPOCH)
-                    .unwrap()
+                    .unwrap_or_default()
                     .as_millis();
 
                 let data_str = if let Some(data) = data {


### PR DESCRIPTION
## Issue

`dora topic echo --format json` and `dora record` build timestamps with:

```rust
SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap()
```

`SystemTime::duration_since` returns `Err` whenever the wall clock is set
**before** the Unix epoch. On a host whose real-time clock has not been
set yet — a realistic state for an embedded/robotics target that boots
before an NTP sync — this `unwrap()` panics and aborts the echo / record
loop mid-stream. This is an `unwrap()` on a genuinely fallible runtime
value; the surrounding code already goes out of its way to avoid the
analogous `Instant` panic with `checked_sub`, so the strictness here is
an inconsistency rather than an intended invariant.

## Fix

Replace the three runtime-path `unwrap()`s (one in
`topic/echo.rs`, two in `record.rs`) with `unwrap_or_default()`, falling
back to a zero `Duration` on a pre-epoch clock. These timestamps are
informational / ordering values, so a zero fallback is preferable to a
crash. The `#[cfg(test)]`-only `unique_temp_path` helper in
`build/mod.rs` is deliberately left as-is (test-only, not a runtime
path).

## Validation

- `cargo test -p dora-cli` (369 passed), `cargo clippy -p dora-cli -- -D
  warnings`, and `cargo fmt --all -- --check` all pass.

---

_This pull request was generated by **Claude Code** as part of an
automated code-review pass. The change is machine-generated — please
review it carefully before merging._

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9H14KAcrcHRKJxmb41KpS)_