### PR TITLE
refactor(cli): drop redundant node_infos clone in `dora top`

### DIFF
--- a/binaries/cli/src/command/inspect/top.rs
+++ b/binaries/cli/src/command/inspect/top.rs
@@ -299,8 +299,7 @@ fn run_app<B: Backend>(
 
     // Query node info once initially
     let reply = send_control_request(&session, &ControlRequest::GetNodeInfo)?;
-    let mut node_infos = expect_reply!(reply, NodeInfoList(infos))?;
-    app.update_stats(node_infos.clone());
+    app.update_stats(expect_reply!(reply, NodeInfoList(infos))?);
 
     loop {
         terminal
@@ -346,10 +345,9 @@ fn run_app<B: Backend>(
         if should_refresh(force_refresh, last_update.elapsed(), refresh_duration) {
             // Query node info every refresh interval to get updated metrics
             let reply = send_control_request(&session, &ControlRequest::GetNodeInfo)?;
-            node_infos = expect_reply!(reply, NodeInfoList(infos))?;
 
             // Update stats with current node info
-            app.update_stats(node_infos.clone());
+            app.update_stats(expect_reply!(reply, NodeInfoList(infos))?);
             last_update = Instant::now();
             force_refresh = false;
         }


### PR DESCRIPTION
## Issue

The `dora top` refresh loop bound each `NodeInfoList` reply to a local
`node_infos` and then passed `node_infos.clone()` to `update_stats`.
`update_stats` takes the vector **by value** and immediately `clear()`s
its own state, so the local was never read again after the clone. The
`mut` binding, the per-refresh reassignment, and both `.clone()` calls
were pure overhead — each refresh deep-copied the full node-metrics
vector only to throw the original away.

## Fix

Move the `expect_reply!` result straight into `update_stats` at both call
sites (initial query and per-refresh query) and remove the `node_infos`
binding. Purely a simplification — no behavior change.

## Validation

- `cargo test -p dora-cli` (369 passed), `cargo clippy -p dora-cli -- -D
  warnings`, and `cargo fmt --all -- --check` all pass.

---

_This pull request was generated by **Claude Code** as part of an
automated code-review pass. The change is machine-generated — please
review it carefully before merging._

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9H14KAcrcHRKJxmb41KpS)_