### PR TITLE
fix(download): percent-decode the URL-derived filename

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2296,6 +2296,7 @@ name = "dora-download"
 version = "1.0.0-rc.4"
 dependencies = [
  "eyre",
+ "percent-encoding",
  "reqwest",
  "sha2 0.11.0",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,6 +204,7 @@ proptest = "1.11"
 mavlink = { version = "0.18", default-features = false, features = ["std", "serde", "dialect-common", "transport-tcp", "transport-udp", "transport-direct-serial"] }
 serialport = "4.9"
 url = "2.5"
+percent-encoding = "2.3"
 
 # Opt in per crate via `[lints] workspace = true`. `cfg(kani)` gates the
 # formal-verification proof harnesses (`make qa-kani`,

--- a/libraries/extensions/download/Cargo.toml
+++ b/libraries/extensions/download/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace = true
 
 [dependencies]
 eyre = { workspace = true }
+percent-encoding = { workspace = true }
 reqwest = { version = "0.13.4", default-features = false, features = [
     "rustls",
 ] }

--- a/libraries/extensions/download/src/lib.rs
+++ b/libraries/extensions/download/src/lib.rs
@@ -120,10 +120,20 @@ fn split_disposition_params(header: &str) -> impl Iterator<Item = &str> {
 /// query string and fragment (e.g. the long presigned-URL parameters that S3
 /// and GitHub-release redirects append) never leak into the name. Returns
 /// `None` when the URL has no non-empty path segment.
+///
+/// `Url::path_segments` yields segments in their percent-*encoded* form, so the
+/// chosen segment is decoded before use: a download from `.../my%20model.bin`
+/// must land on disk as `my model.bin`, not the literal `my%20model.bin`. Bytes
+/// that do not form valid UTF-8 after decoding become the Unicode replacement
+/// character (`decode_utf8_lossy`) rather than dropping the name; the result is
+/// still vetted by `sanitize_filename`.
 fn filename_from_url(url: &reqwest::Url) -> Option<String> {
-    url.path_segments()?
-        .rfind(|segment| !segment.is_empty())
-        .map(|segment| segment.to_string())
+    let segment = url.path_segments()?.rfind(|segment| !segment.is_empty())?;
+    Some(
+        percent_encoding::percent_decode_str(segment)
+            .decode_utf8_lossy()
+            .into_owned(),
+    )
 }
 
 /// Sanitize a candidate filename: strip path components to prevent traversal,
@@ -325,6 +335,17 @@ mod tests {
         assert_eq!(
             name_from("https://example.com/a/b/weights.safetensors"),
             Some("weights.safetensors".to_string())
+        );
+    }
+
+    #[test]
+    fn url_filename_percent_decoded() {
+        // Regression: `Url::path_segments` returns percent-encoded segments, so
+        // a URL ending in `my%20model.bin` must be decoded to `my model.bin`
+        // rather than saved as the literal `my%20model.bin`.
+        assert_eq!(
+            name_from("https://example.com/models/my%20model.bin"),
+            Some("my model.bin".to_string())
         );
     }
 


### PR DESCRIPTION
## Issue

When a download response has no `Content-Disposition` header,
`dora-download` derives the target filename from the URL's last path
segment via `Url::path_segments`. That API yields segments in their
percent-**encoded** form, so a download from `.../my%20model.bin` was
written to disk as the literal `my%20model.bin` instead of
`my model.bin`. The mis-named path is then returned to the caller and
used as the artifact's load path.

The existing tests only covered already-decoded names
(`model.bin`, `weights.safetensors`), so this went unnoticed. The
`Content-Disposition` path is unaffected (header values are not
URL-encoded); only the URL fallback was wrong.

## Fix

Percent-decode the chosen segment (using the `percent-encoding` crate,
already present transitively via `url`/`reqwest` and now promoted to a
direct dependency) before it is passed to `sanitize_filename`. Because
decoding happens at the extraction point, the existing traversal / NUL /
Windows-reserved-name checks still run on the decoded name. Bytes that do
not form valid UTF-8 after decoding become the Unicode replacement
character (`decode_utf8_lossy`) rather than dropping the name; the result
is still vetted by `sanitize_filename`.

## Validation

- New regression test `url_filename_percent_decoded` asserts
  `.../my%20model.bin` → `my model.bin`.
- `cargo test -p dora-download` (25 passed), `cargo clippy -p dora-download
  -- -D warnings`, and `cargo fmt --all -- --check` all pass.

---

_This pull request was generated by **Claude Code** as part of an
automated code-review pass. The change is machine-generated — please
review it carefully before merging._

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9H14KAcrcHRKJxmb41KpS)_