### PR TITLE
test(python): run apis/python/node/tests in CI (#3305)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -608,8 +608,17 @@ jobs:
           uv venv --seed -p 3.12
           echo "VIRTUAL_ENV=$PWD/.venv" >> "$GITHUB_ENV"
           source .venv/bin/activate
-          uv pip install pyarrow
+          uv pip install pyarrow pytest
           uv pip install -e apis/python/node
+      # Python-level unit tests of the installed `dora` package (the `dora`
+      # compat shim dora-hub nodes import, the `dora.builder` API, and
+      # `dora.testing.MockNode`). They live in apis/python/node/tests/ and ran
+      # in no CI job before (#3305); this job is their home because it is the
+      # one that installs `dora-rs` into a venv above.
+      - name: Run Python node API unit tests (dora package)
+        run: |
+          source .venv/bin/activate
+          make qa-test-python-node
       - name: Run semantic contract tests
         run: >
           cargo test -p dora-examples --test example-smoke contract_

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,8 @@
 
 .PHONY: qa qa-fast qa-full qa-deep qa-tier1 qa-nightly qa-release-gate qa-mutation-audit \
         qa-examples qa-cluster-e2e qa-cluster-record-replay ros2-zenoh-humble ros2-zenoh-kilted \
-        qa-fmt qa-audit qa-unwrap qa-publish-graph qa-clippy qa-test qa-test-python qa-coverage \
-        qa-mutants qa-semver \
+        qa-fmt qa-audit qa-unwrap qa-publish-graph qa-clippy qa-test qa-test-python \
+        qa-test-python-node qa-coverage qa-mutants qa-semver \
         qa-adversarial qa-kani qa-pgo qa-install qa-pgo-install qa-kani-install \
         qa-verify-release
 
@@ -173,6 +173,14 @@ qa-test-python:
 		-p dora-operator-api-python \
 		-p dora-ros2-bridge-python \
 		-p dora-runtime-python
+
+# Python-level unit tests of the `dora` package under apis/python/node/tests/
+# (the `dora` compat shim, the `dora.builder` API, and `dora.testing.MockNode`).
+# These exercise the *installed* package, so they need `dora-rs` importable —
+# run inside a venv that has `uv pip install -e apis/python/node` (plus pytest).
+# CI runs this in ci.yml's `contract-tests` job, which sets that venv up (#3305).
+qa-test-python-node:
+	@python -m pytest apis/python/node/tests/
 
 qa-coverage:
 	@scripts/qa/coverage.sh


### PR DESCRIPTION
## Summary

Fixes #3305.

The three pytest files under `apis/python/node/tests/` ran in **no CI job** — the `uv run pytest` invocations in nightly are inside generated template projects (`dora new …`), not this directory:

- `test_builder.py` — the `dora.builder` (`DataflowBuilder`) API
- `test_dora_compat.py` — the `from dora import Node` / `from dora import DoraStatus` / `build` / `run` patterns dora-hub nodes depend on
- `test_mock_node.py` — `dora.testing.MockNode`

## Change

- **`Makefile`**: new `qa-test-python-node` target (`python -m pytest apis/python/node/tests/`), documented as needing an active venv with `dora-rs` installed. Added to `.PHONY`.
- **`.github/workflows/ci.yml`** (`contract-tests` job): this job already does `uv pip install -e apis/python/node` into a venv, so `dora` is importable there — the issue's suggested home. Added `pytest` to that venv install and a step that runs `make qa-test-python-node` with the venv activated.

## Verification

This was previously blocked because the dev container had no way to run pytest. With a working environment I built the PyO3 extension (`uv pip install -e apis/python/node`) and ran the suite — **all 31 tests pass against the workspace bindings, nothing had bit-rotted**:

```
apis/python/node/tests/test_builder.py ..............     [ 45%]
apis/python/node/tests/test_dora_compat.py .......        [ 67%]
apis/python/node/tests/test_mock_node.py ..........       [100%]
============================== 31 passed ==============================
```

`make qa-test-python-node` was run through the exact CI invocation path (activate venv → `make …`), and `ci.yml` was YAML-validated.

## Note

The companion PR #3301 (which adds `test_public_surface.py` + a `qa-test-python-surface` target) is not yet merged; this PR is intentionally self-contained and does not depend on it. If both land, the two pytest targets can later be consolidated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbuQLCE7EQBdoT9n17BvrG

---
_Generated by [Claude Code](https://claude.ai/code/session_01WbuQLCE7EQBdoT9n17BvrG)_