### PR TITLE
fix: allow publishing dora-tensor-pool and check for unpublished deps (#3304)

### DIFF
--- a/.github/workflows/cargo-release.yml
+++ b/.github/workflows/cargo-release.yml
@@ -107,6 +107,7 @@ jobs:
           # Publish binaries crates (before the ROS2 bridge, whose
           # dev-deps on dora-daemon/dora-cli must resolve during verify)
           publish_if_not_exists dora-coordinator
+          publish_if_not_exists dora-tensor-pool
           publish_if_not_exists dora-daemon
           publish_if_not_exists dora-operator-api-python
           # The former `dora-runtime`, split per language. `dora-cli` depends on

--- a/.github/workflows/cargo-release.yml
+++ b/.github/workflows/cargo-release.yml
@@ -109,12 +109,13 @@ jobs:
           publish_if_not_exists dora-coordinator
           publish_if_not_exists dora-tensor-pool
           publish_if_not_exists dora-daemon
-          publish_if_not_exists dora-operator-api-python
           # The former `dora-runtime`, split per language. `dora-cli` depends on
           # `dora-runtime-shared-lib` (→ `-api`), so both must land first.
+          # The third split, `dora-runtime-python`, is absent on purpose, as is
+          # `dora-operator-api-python`: both went `publish = false` in #3303 and
+          # reach users compiled into the `dora-rs` wheel.
           publish_if_not_exists dora-runtime-api
           publish_if_not_exists dora-runtime-shared-lib
-          publish_if_not_exists dora-runtime-python
           publish_if_not_exists dora-cli
 
           # Publish ROS2 bridge (before the cxx APIs, which optionally

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,27 @@ jobs:
         run: |
           cargo check -p dora-node-api-c
           cargo check -p dora-node-api-cxx
+      # Ensure published crates do not depend on unpublished crates (#3304).
+      - name: Check no published crate depends on an unpublished crate
+        run: |
+          cargo metadata --format-version 1 --no-deps | python3 -c "
+          import json, sys
+          m = json.load(sys.stdin)
+          hits = []
+          for p in m['packages']:
+              if p.get('publish') == []:
+                  continue
+              for d in p['dependencies']:
+                  dep = next((q for q in m['packages'] if q['name'] == d['name']), None)
+                  if dep and dep.get('publish') == [] and d['kind'] is None:
+                      hits.append(f\"{p['name']} -> {d['name']}\")
+          if hits:
+              print('ERROR: published crate(s) depend on unpublished crate(s):')
+              for h in hits:
+                  print(' ', h)
+              sys.exit(1)
+          print('OK: no published crate depends on an unpublished one')
+          "
 
   test:
     # Linux-only on PR CI (#1716). macOS + Windows coverage runs in nightly.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,12 @@ jobs:
           # Restore the shared dev-profile cache; only `test` writes it.
           shared-key: workspace
           save-if: false
+      # Manifest-only, so it costs seconds and goes before the compile gates
+      # below: nothing else fails on a broken publish graph until release
+      # time, and by then the release has already uploaded crates that
+      # crates.io will not let anyone take back (#3304).
+      - name: Check the crates.io publish graph
+        run: make qa-publish-graph
       - name: Check
         run: cargo check --all
       # `cargo check --all` does NOT build `[[example]]` targets, so
@@ -212,27 +218,6 @@ jobs:
         run: |
           cargo check -p dora-node-api-c
           cargo check -p dora-node-api-cxx
-      # Ensure published crates do not depend on unpublished crates (#3304).
-      - name: Check no published crate depends on an unpublished crate
-        run: |
-          cargo metadata --format-version 1 --no-deps | python3 -c "
-          import json, sys
-          m = json.load(sys.stdin)
-          hits = []
-          for p in m['packages']:
-              if p.get('publish') == []:
-                  continue
-              for d in p['dependencies']:
-                  dep = next((q for q in m['packages'] if q['name'] == d['name']), None)
-                  if dep and dep.get('publish') == [] and d['kind'] is None:
-                      hits.append(f\"{p['name']} -> {d['name']}\")
-          if hits:
-              print('ERROR: published crate(s) depend on unpublished crate(s):')
-              for h in hits:
-                  print(' ', h)
-              sys.exit(1)
-          print('OK: no published crate depends on an unpublished one')
-          "
 
   test:
     # Linux-only on PR CI (#1716). macOS + Windows coverage runs in nightly.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,7 @@ jobs:
             dora-node-api-c
             dora-operator-api-c
             dora-coordinator
+            dora-tensor-pool
             dora-daemon
             dora-runtime-api
             dora-runtime-shared-lib

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,7 @@ make qa-test-python
 # cargo test -p <crate-name>
 ```
 
-**Shortcut**: `make qa-fast` runs fmt + clippy + supply-chain audit + unwrap budget + typos in ~30 seconds. Use it as a sanity check before every commit. Then run the full `cargo test` above before `git push`.
+**Shortcut**: `make qa-fast` runs fmt + clippy + supply-chain audit + unwrap budget + typos + publish-graph in ~30 seconds. Use it as a sanity check before every commit. Then run the full `cargo test` above before `git push`.
 
 If you add new example dataflows, also run `./scripts/smoke-all.sh --rust-only` to verify smoke tests pass.
 
@@ -180,7 +180,7 @@ The deeper QA gates — `make qa-full`, `make qa-deep`, `make qa-nightly`, `make
 - `make qa-kani` — ~5-10 min cold, <1 min warm. Formal verification: runs the `#[kani::proof]` harnesses (Kani/CBMC model checker) in `dora-message` (auth `constant_time_eq`). A passing proof is exhaustive over the harness state space, not sampled. Run when touching files with `#[cfg(kani)]` proof modules and in pre-release gating; install via `make qa-kani-install`. See [`docs/formal-verification.md`](docs/formal-verification.md).
 - `make qa-pgo` — ~30-40 min. Profile-Guided Optimization measurement: builds `dora-cli` with `cargo-pgo` (instrument → train on `examples/benchmark/` → optimize), then runs the benchmark twice (baseline vs PGO) and prints a side-by-side comparison with a +5%-throughput-geomean verdict. Run on your target platform — PGO results don't transfer across OS/arch. macOS-arm64 first-measurement showed +25% throughput geomean, latency unchanged (see [#331](https://github.com/dora-rs/dora/issues/331)). **Do not add to CI** — the build pipeline cost is release-pipeline scope, not per-commit. Install via `make qa-pgo-install`.
 
-**Remote CI is deliberately kept lean** — only the fast hard gates (fmt, clippy, test on Linux, typos, supply chain audit, unwrap budget, E2E, contract tests, benchmark regression, license check) — so it stays fast (~30-45 min critical path) and runner capacity is not a bottleneck. Do not expand PR CI with slow jobs. See [`docs/qa-runbook.md`](docs/qa-runbook.md) for when and how to use each deep gate locally.
+**Remote CI is deliberately kept lean** — only the fast hard gates (fmt, clippy, test on Linux, typos, supply chain audit, unwrap budget, publish-graph, E2E, contract tests, benchmark regression, license check) — so it stays fast (~30-45 min critical path) and runner capacity is not a bottleneck. Do not expand PR CI with slow jobs. See [`docs/qa-runbook.md`](docs/qa-runbook.md) for when and how to use each deep gate locally.
 
 ### Remote CI jobs
 
@@ -195,6 +195,7 @@ The deeper QA gates — `make qa-full`, `make qa-deep`, `make qa-nightly`, `make
 - Typo checking via `crate-ci/typos` (config: `_typos.toml`)
 - Supply-chain audit (`cargo-audit` + `cargo-deny`)
 - Unwrap-budget check (production `.unwrap()` / `.expect(` ratchet)
+- crates.io publish-graph check (`make qa-publish-graph`, a step in the `Check` job): no published crate may depend on a `publish = false` one, and the ordered publish lists in `release.yml` / `cargo-release.yml` must agree and list every dependency before its dependents (#3304)
 - License check (`cargo-lichking`)
 - Rust toolchain pinned to 1.97.1 (see `.github/workflows/ci.yml`)
 

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,8 @@
 
 .PHONY: qa qa-fast qa-full qa-deep qa-tier1 qa-nightly qa-release-gate qa-mutation-audit \
         qa-examples qa-cluster-e2e qa-cluster-record-replay ros2-zenoh-humble ros2-zenoh-kilted \
-        qa-fmt qa-audit qa-unwrap qa-clippy qa-test qa-test-python qa-coverage qa-mutants qa-semver \
+        qa-fmt qa-audit qa-unwrap qa-publish-graph qa-clippy qa-test qa-test-python qa-coverage \
+        qa-mutants qa-semver \
         qa-adversarial qa-kani qa-pgo qa-install qa-pgo-install qa-kani-install
 
 qa: qa-fast
@@ -128,6 +129,12 @@ qa-audit:
 
 qa-unwrap:
 	@scripts/qa/unwrap-budget.sh
+
+# Manifest-only crates.io publish-graph gate (#3304): no published crate
+# may depend on a `publish = false` one, and release.yml /
+# cargo-release.yml must list every dependency before its dependents.
+qa-publish-graph:
+	@scripts/qa/publish-graph.sh
 
 qa-clippy:
 	@cargo clippy --all \

--- a/docs/agentic-qa-policy.md
+++ b/docs/agentic-qa-policy.md
@@ -64,7 +64,7 @@ impact. Current list (update when a new subsystem earns it):
 
 ### Class A — Low-risk
 
-- [ ] `make qa-fast` (fmt + clippy + audit + unwrap-budget + typos).
+- [ ] `make qa-fast` (fmt + clippy + audit + unwrap-budget + typos + publish-graph).
 
 That's the whole bar. Don't over-test cosmetic changes — reviewers can
 eyeball them and CI backs it up. `typos` is now part of `qa-fast`

--- a/docs/api-rust.md
+++ b/docs/api-rust.md
@@ -789,7 +789,7 @@ dataflow or a `Cargo.toml`.
 | `operators:` / `operator:`, `dora-operator-api`(+`-types`, `-macros`, `-c`, `-cxx`, `-python`), `dora-runtime-*` | Documented experimental; `StopAll` is not implemented |
 | `ros2:` descriptor field, `dora-ros2-bridge`(+`-msg-gen`, `-arrow`) | Crate docs state it may change at any point |
 | `dora-mavlink2-bridge`, `dora-mavlink2-bridge-node` | Domain-specific protocol bridge |
-| tensor-pool | Behind a generic extension seam, opt-in (#3152) |
+| tensor-pool (`dora-tensor-pool`) | Behind a generic extension seam, opt-in (#3152) |
 | `dora_arrow_convert::internal` | `pub` only because Rust has no cross-crate `pub(crate)`; never re-exported from `dora-node-api` |
 | The Arrow major version | See the Arrow version policy above |
 | The pyo3 version | `pyo3-ffi` declares `links = "python"`, so a build graph can hold exactly one; dora's is an implementation detail behind the wheels. See the Python version policy below |
@@ -805,6 +805,8 @@ delivery channel nobody uses, since writing a Python operator needs no Rust
 dependency. Unpublished, dora's pyo3 version stays an implementation detail
 that can move in a minor.
 
+One goes the other way: `dora-tensor-pool` is exempt and *is* on crates.io, for the reason the internal crates below are. `dora-daemon` names it in an optional dependency, cargo resolves every dependency of a published crate against the registry, and so leaving it `publish = false` would have blocked `dora-daemon`'s own release ([#3304](https://github.com/dora-rs/dora/issues/3304)). Reaching crates.io is not a promotion: the crate's description and its README both carry the exemption, and they are what its crates.io page shows.
+
 ### Internal
 
 Crates that exist only to build the above. They are published to crates.io
@@ -817,7 +819,7 @@ because cargo requires every dependency of a published crate to be published
 
 ### How this is enforced
 
-Documentation alone would not survive contact with cargo, so two mechanisms
+Documentation alone would not survive contact with cargo, so three mechanisms
 back it:
 
 1. **Exact version pins.** Workspace crates depend on each other with `=`
@@ -829,6 +831,7 @@ back it:
    `default = []`, so using it is an affirmative act recorded in the
    consumer's `Cargo.toml` rather than a warning they can tune out.
    `arrow-v58` / `arrow-v59` are the pattern.
+3. **A publish-graph gate.** `make qa-publish-graph`, also run in PR CI, fails if a published crate depends on a `publish = false` one, or if the ordered publish lists in `.github/workflows/release.yml` and `.github/workflows/cargo-release.yml` would publish a crate before something it depends on. Which tier a crate sits in is only a document until something checks the manifests against it: #3304 was a published crate depending on an unpublished one, and nothing would have said so until a release had already uploaded half the workspace.
 
 A consequence of (1): a patch fix in an internal crate requires re-releasing
 its dependents. With `shared-version = true` in `release.toml` that already

--- a/docs/contributor-qa-cheatsheet.md
+++ b/docs/contributor-qa-cheatsheet.md
@@ -67,6 +67,7 @@ Runs:
 - supply-chain audit
 - unwrap-budget check
 - typo check
+- crates.io publish-graph check
 
 ### Before push
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -123,6 +123,8 @@ by default) and **outside the 1.0 compatibility guarantees** — that combinatio
 is the point: a transport can ship in-tree, be built and used, and still not
 freeze anything into dora's stable surface.
 
+`dora-tensor-pool` is on crates.io even so, because `dora-daemon` is, and cargo will not publish a crate whose dependency is missing from the registry ([#3304](https://github.com/dora-rs/dora/issues/3304)). That changes where the crate is downloaded from and nothing about what it promises; the stability tiers are in [`docs/api-rust.md`](api-rust.md#stability-scope-at-10).
+
 Its daemon half — mirror segments, the DORADMA header, the seqlock, the
 direct-TCP data plane, CUDA IPC — lives in that same crate, behind its own
 `daemon` feature, and reaches the daemon only through `DaemonServices`. The

--- a/docs/qa-runbook.md
+++ b/docs/qa-runbook.md
@@ -51,7 +51,7 @@ rustup component add miri --toolchain nightly   # optional; for unsafe-code anal
 
 | Target | Runs | Budget | When to use |
 |---|---|---|---|
-| `make qa-fast` | fmt + clippy + audit + unwrap-budget + typos | ~15 s | Pre-commit |
+| `make qa-fast` | fmt + clippy + audit + unwrap-budget + typos + publish-graph | ~15 s | Pre-commit |
 | `make qa-full` | `qa-fast` + full test suite + coverage | ~5-10 min | Pre-push |
 | `make qa-deep` | `qa-full` + mutation testing on diff + semver | ~15 min | Target Tier 1 local gate (stronger than today's CI: adds coverage, adversarial, mutants, semver) |
 | `make qa-tier1` | alias for `qa-deep` | — | Back-compat; prefer `qa-deep` |
@@ -148,7 +148,19 @@ Compare against `git diff` to see which ones are yours.
 
 Note: the budget ratchet is intentionally asymmetric. You can reduce the number freely; any increase needs justification.
 
-### 3.5 `test` failed
+### 3.5 `publish-graph` failed
+
+**Cause**: a change to the publish graph that `cargo publish` would reject — but only at release time, once crates.io already holds whatever the release uploaded before the failure. The gate reports one of three things.
+
+**"X depends on Y, which is `publish = false`"**: cargo resolves every dependency of a published crate against the registry, so Y has to be on crates.io for X to publish. Either publish Y (drop `publish = false`, add it to both publish lists, and place it in a tier in [`api-rust.md`](api-rust.md#stability-scope-at-10)), or stop X from naming it. Optional dependencies are not an escape: they are in the published manifest whether or not the feature is on. That is #3304, and it is why `dora-tensor-pool` is published.
+
+**"the publish lists differ"**: `.github/workflows/release.yml` and `.github/workflows/cargo-release.yml` each carry the ordered list, and each says to keep it in sync with the other. Edit both.
+
+**"which the publish lists publish after it" / "missing from the publish lists"**: the lists are consumed in order, and a crate cannot publish before its dependencies exist in the index. Move the dependency earlier, or add it.
+
+Reproduce locally with `make qa-publish-graph`; the rules and what each protects are documented at the top of [`scripts/qa/publish-graph.sh`](../scripts/qa/publish-graph.sh).
+
+### 3.6 `test` failed
 
 **Cause**: you broke a test.
 
@@ -160,7 +172,7 @@ cargo test -p <crate> <test_name> -- --nocapture
 
 If the test was wrong and the code is right, fix the test. If the code was wrong, fix the code. Don't fix the test to match broken code.
 
-### 3.6 `coverage` (soft) flagged
+### 3.7 `coverage` (soft) flagged
 
 **Cause**: the diff coverage gate (if running on a PR) found less than 70% of your new/changed lines are covered by tests.
 
@@ -171,7 +183,7 @@ make qa-coverage
 open target/llvm-cov/html/index.html   # if you also run `cargo llvm-cov --html`
 ```
 
-### 3.7 `mutation` escaped
+### 3.8 `mutation` escaped
 
 **Cause**: `cargo-mutants` found a mutation that no test detected — meaning your tests are incomplete for the mutated code path.
 
@@ -192,7 +204,7 @@ Construct an input where the mutated version produces a different output from th
 
 **Do not** waive mutations just to make the gate pass. The point of the gate is to surface weak tests.
 
-### 3.8 `semver` (soft) flagged
+### 3.9 `semver` (soft) flagged
 
 **Cause**: `cargo-semver-checks` found a breaking change in a publishable crate's public API since the last tag.
 

--- a/libraries/extensions/tensor-pool/Cargo.toml
+++ b/libraries/extensions/tensor-pool/Cargo.toml
@@ -4,7 +4,9 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 documentation.workspace = true
-readme.workspace = true
+# The crate has its own README carrying the 1.0-exemption warning; point at it
+# so crates.io renders that page instead of the workspace root README.
+readme = "README.md"
 description = "Daemon-side helper for the tensor-pool extension: reclaims orphaned /dev/shm segments. Not covered by dora's 1.0 compatibility guarantees — see libraries/extensions/tensor-pool/README.md."
 license.workspace = true
 repository.workspace = true

--- a/libraries/extensions/tensor-pool/Cargo.toml
+++ b/libraries/extensions/tensor-pool/Cargo.toml
@@ -8,7 +8,6 @@ readme.workspace = true
 description = "Daemon-side helper for the tensor-pool extension: reclaims orphaned /dev/shm segments. Not covered by dora's 1.0 compatibility guarantees — see libraries/extensions/tensor-pool/README.md."
 license.workspace = true
 repository.workspace = true
-publish = false
 
 [features]
 # The daemon half: mirror segments, the direct-TCP data plane, and the

--- a/scripts/qa/all.sh
+++ b/scripts/qa/all.sh
@@ -5,7 +5,8 @@
 # Designed for local-first execution: same script runs locally and in CI.
 #
 # Modes (increasing thoroughness):
-#   --fast            ~1 min     pre-commit sanity (fmt, clippy, audit, unwrap, typos)
+#   --fast            ~1 min     pre-commit sanity (fmt, clippy, audit, unwrap,
+#                                typos, publish-graph)
 #   --full            ~5-10 min  pre-push (fast + tests + coverage + optional adversarial)
 #   --deep            ~15 min    target Tier 1 gate, stronger than today's CI
 #                                (full + mutants on diff + semver; see strategy doc §5 for why the
@@ -106,6 +107,7 @@ Will run:
   3. audit          -- cargo-audit + cargo-deny on the dependency tree
   4. unwrap-budget  -- count production .unwrap() / .expect( regressions
   5. typos          -- spell-check against _typos.toml allowlist
+  6. publish-graph  -- crates.io publish order / no unpublished deps
 ============================================================
 EOF
       ;;
@@ -115,10 +117,11 @@ EOF
 ============================================================
 $header
 Will run:
-  1-5. everything from qa-fast                  (fmt/clippy/audit/unwrap/typos)
-  6.   test         -- cargo test --all         (workspace test suite)
-  7.   coverage     -- cargo llvm-cov           (writes lcov.info)
-  8.   adversarial  -- codex/claude review      (optional; skipped if unavailable)
+  1-6. everything from qa-fast                  (fmt/clippy/audit/unwrap/typos/
+                                                 publish-graph)
+  7.   test         -- cargo test --all         (workspace test suite)
+  8.   coverage     -- cargo llvm-cov           (writes lcov.info)
+  9.   adversarial  -- codex/claude review      (optional; skipped if unavailable)
 ============================================================
 EOF
       ;;
@@ -128,10 +131,11 @@ EOF
 ============================================================
 $header
 Today's CI PR gate only runs a subset of this: fmt, clippy, typos,
-audit, unwrap-budget, and the workspace test suite. qa-deep adds the
-planned Tier 1 extras (see docs/plan-agentic-qa-strategy.md §5) that
-are kept laptop-only today because they're too slow for every PR:
-coverage, adversarial review, diff-scoped mutation testing, semver.
+audit, unwrap-budget, publish-graph, and the workspace test suite.
+qa-deep adds the planned Tier 1 extras (see
+docs/plan-agentic-qa-strategy.md §5) that are kept laptop-only today
+because they're too slow for every PR: coverage, adversarial review,
+diff-scoped mutation testing, semver.
 
 Will run:
   1-5.  everything from qa-fast                 (in CI today)
@@ -263,6 +267,7 @@ run "clippy"        cargo clippy --all \
 run "audit"         scripts/qa/audit.sh
 run "unwrap-budget" scripts/qa/unwrap-budget.sh
 run "typos"         scripts/qa/typos.sh
+run "publish-graph" scripts/qa/publish-graph.sh
 
 case "$MODE" in
   --fast)

--- a/scripts/qa/publish-graph.sh
+++ b/scripts/qa/publish-graph.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# scripts/qa/publish-graph.sh — crates.io publish-graph gate (#3304)
+#
+# `cargo publish` resolves every dependency of a crate against crates.io,
+# so a release breaks — halfway through, after some crates are already
+# irreversibly uploaded — if either half of the publish graph is wrong:
+#
+#   1. A published crate depends on a `publish = false` crate. That crate
+#      is never uploaded, so the dependent's manifest names something the
+#      registry does not have. #3304 is this: `dora-daemon` (published)
+#      had an optional dependency on `dora-tensor-pool` (`publish = false`).
+#
+#   2. A published crate's workspace dependency is missing from — or comes
+#      *after* it in — the ordered publish lists in `release.yml` /
+#      `cargo-release.yml`. Marking a crate publishable is only half the
+#      fix; if the lists are not updated in the same change, CI stays
+#      green and the failure moves to release time.
+#
+# Both lists are maintained by hand and each carries a "keep in sync with
+# the other" comment, so this script also checks they are identical.
+#
+# Which dependencies count: all of them, in every kind. `cargo package`
+# strips only dev-dependencies declared without a version requirement
+# (`cargo metadata` reports those as `req == "*"`). Every other
+# dependency — normal, build, dev, optional, target-specific — keeps its
+# requirement in the published manifest and has to resolve. This workspace
+# declares its internal deps through `[workspace.dependencies]` with
+# `version = "=<workspace version>"`, so nothing is stripped in practice.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "scripts/qa/publish-graph.sh requires python3 on PATH" >&2
+  exit 2
+fi
+
+META="$(mktemp)"
+trap 'rm -f "$META"' EXIT
+cargo metadata --format-version 1 --no-deps >"$META"
+
+python3 - \
+  "$META" \
+  .github/workflows/release.yml \
+  .github/workflows/cargo-release.yml \
+  <<'PY'
+import json
+import re
+import sys
+
+meta_path, release_yml, cargo_release_yml = sys.argv[1:4]
+
+with open(meta_path, encoding="utf-8") as f:
+    meta = json.load(f)
+
+# `--no-deps` limits `packages` to workspace members, so a name lookup here
+# can only ever resolve to a crate in this repository.
+packages = {p["name"]: p for p in meta["packages"]}
+unpublished = {n for n, p in packages.items() if p.get("publish") == []}
+
+errors = []
+
+
+def workspace_deps(pkg):
+    """Deps on other workspace members that survive `cargo package`.
+
+    `source is None` means a path dependency, which is what distinguishes a
+    workspace member from a same-named crate pulled off crates.io.
+    """
+    for dep in pkg["dependencies"]:
+        if dep["source"] is not None or dep["name"] not in packages:
+            continue
+        # Version-less dev-deps are dropped from the published manifest.
+        if dep["kind"] == "dev" and dep["req"] == "*":
+            continue
+        yield dep
+
+
+# --- 1. no published crate may depend on an unpublished one ---------------
+for name, pkg in sorted(packages.items()):
+    if name in unpublished:
+        continue
+    for dep in workspace_deps(pkg):
+        if dep["name"] in unpublished:
+            errors.append(
+                f"{name} depends on {dep['name']}, which is `publish = false` "
+                f"(kind: {dep['kind'] or 'normal'})"
+            )
+
+
+# --- 2. the two ordered publish lists must agree --------------------------
+def read_release_yml(path):
+    with open(path, encoding="utf-8") as f:
+        block = re.search(r"^\s*CRATES=\((.*?)^\s*\)", f.read(), re.S | re.M)
+    if block is None:
+        sys.exit(f"could not find the CRATES=(...) list in {path}")
+    # Drop shell comments, so a comment inside the array is not read as a
+    # crate name (`cargo-release.yml`'s list is already comment-tolerant:
+    # only `publish_if_not_exists` lines are matched there).
+    lines = [ln.split("#", 1)[0] for ln in block.group(1).splitlines()]
+    return " ".join(lines).split()
+
+
+def read_cargo_release_yml(path):
+    with open(path, encoding="utf-8") as f:
+        return re.findall(r"^\s*publish_if_not_exists\s+(\S+)", f.read(), re.M)
+
+
+release_list = read_release_yml(release_yml)
+cargo_release_list = read_cargo_release_yml(cargo_release_yml)
+
+if not release_list:
+    sys.exit(f"{release_yml}: publish list is empty")
+
+if release_list != cargo_release_list:
+    errors.append(
+        f"{release_yml} and {cargo_release_yml} publish lists differ "
+        "(they must list the same crates in the same order):\n"
+        f"      only in {release_yml}: "
+        f"{sorted(set(release_list) - set(cargo_release_list)) or 'none'}\n"
+        f"      only in {cargo_release_yml}: "
+        f"{sorted(set(cargo_release_list) - set(release_list)) or 'none'}"
+    )
+
+seen = set()
+for name in release_list:
+    if name in seen:
+        errors.append(f"{release_yml}: {name} is listed more than once")
+    seen.add(name)
+    if name not in packages:
+        errors.append(f"{release_yml}: {name} is not a workspace member")
+    elif name in unpublished:
+        errors.append(f"{release_yml}: {name} is `publish = false`")
+
+
+# --- 3. every dep of a listed crate must be listed, earlier ---------------
+position = {name: i for i, name in enumerate(release_list)}
+for name in release_list:
+    pkg = packages.get(name)
+    if pkg is None:
+        continue
+    for dep in workspace_deps(pkg):
+        if dep["name"] in unpublished:
+            continue  # already reported above
+        if dep["name"] not in position:
+            errors.append(
+                f"{name} depends on {dep['name']}, which is missing from the "
+                "publish lists"
+            )
+        elif position[dep["name"]] > position[name]:
+            errors.append(
+                f"{name} depends on {dep['name']}, which the publish lists "
+                "publish after it"
+            )
+
+if errors:
+    print("publish-graph check FAILED:")
+    for e in dict.fromkeys(errors):
+        print(f"  - {e}")
+    print()
+    print(
+        "docs/qa-runbook.md section 3.5 walks through each of these; the rules "
+        "and what they protect are at the top of scripts/qa/publish-graph.sh."
+    )
+    sys.exit(1)
+
+print(
+    f"publish-graph OK: {len(release_list)} crates, "
+    f"{len(unpublished)} `publish = false` workspace members, "
+    "no unpublished dependency and no out-of-order publish"
+)
+PY


### PR DESCRIPTION
Fixes #3304.

`dora-daemon` is published to crates.io and optionally depends on `dora-tensor-pool`, which was `publish = false`. Optional or not, that dependency is in `dora-daemon`'s published manifest, and cargo resolves every dependency of a published crate against the registry — so `cargo publish -p dora-daemon` would have failed partway through a release, after earlier crates were already uploaded and unremovable.

`dora-tensor-pool` is now publishable and ordered before `dora-daemon` in both publish lists. Its own README — the one with the "not covered by the 1.0 guarantees" warning at the top — becomes its crates.io landing page, and `docs/api-rust.md` gains the stability note #3304 asked for: it is the one exempt crate that is nonetheless on crates.io, for the same reason the internal crates are, and reaching crates.io promotes nothing.

The rest is the gate. `scripts/qa/publish-graph.sh` (`make qa-publish-graph`, in `qa-fast` and in the `Check` job) checks three things, because the first alone would not have protected the release:

- no published crate depends on a `publish = false` one, in **any** dependency kind — build- and dev-dependencies survive `cargo package` whenever they carry a version requirement, which every dep declared through `[workspace.dependencies]` does;
- `release.yml` and `cargo-release.yml` list the same crates in the same order, since each is a hand-maintained copy of the other;
- every workspace dependency of a listed crate is itself listed, earlier — dropping `publish = false` without touching the lists otherwise leaves CI green and moves the failure to release time.

It found a live one immediately: #3303 made the two pyo3-linking crates `publish = false` and updated `release.yml`, but `cargo-release.yml` still tried to publish them. That is the first commit here.

Each rule is covered by a negative test run by hand: restoring `publish = false`, deleting a crate from one list, reordering it after its dependent, and adding a versioned dev- or build-dep on an unpublished crate all fail the gate; a version-less dev-dep correctly does not.
