### PR TITLE
fix: allow symlinked module directories and fix project root on symlinked entrypoints (#3247)

### DIFF
--- a/binaries/cli/src/command/validate.rs
+++ b/binaries/cli/src/command/validate.rs
@@ -58,10 +58,13 @@ fn validate_node_manifest(path: &Path) -> eyre::Result<()> {
 }
 
 fn validate_dataflow(dataflow: &Path, strict_types: bool, offline: bool) -> eyre::Result<()> {
-    let working_dir = dataflow
+    let parent = dataflow
         .parent()
         .filter(|p| !p.as_os_str().is_empty())
         .unwrap_or_else(|| std::path::Path::new("."));
+    let working_dir = parent
+        .canonicalize()
+        .with_context(|| format!("failed to resolve working directory for `{}`", dataflow.display()))?;
 
     println!("Validating {}...", dataflow.display());
 
@@ -74,7 +77,7 @@ fn validate_dataflow(dataflow: &Path, strict_types: bool, offline: bool) -> eyre
                 dataflow.display()
             )
         })?
-        .expand(working_dir)
+        .expand(&working_dir)
         .context("failed to expand modules in dataflow descriptor")?;
 
     let strict = strict_types || descriptor.strict_types.unwrap_or(false);
@@ -150,7 +153,7 @@ fn validate_dataflow(dataflow: &Path, strict_types: bool, offline: bool) -> eyre
     println!("Descriptor config OK.");
 
     // Inject contracts from node manifests adjacent to path: nodes (§6.2)
-    let injection = inject_adjacent_manifests(&mut descriptor, working_dir, &mut registry);
+    let injection = inject_adjacent_manifests(&mut descriptor, &working_dir, &mut registry);
     for note in &injection.notes {
         println!("  {note}");
     }

--- a/binaries/cli/src/command/validate.rs
+++ b/binaries/cli/src/command/validate.rs
@@ -62,9 +62,12 @@ fn validate_dataflow(dataflow: &Path, strict_types: bool, offline: bool) -> eyre
         .parent()
         .filter(|p| !p.as_os_str().is_empty())
         .unwrap_or_else(|| std::path::Path::new("."));
-    let working_dir = parent
-        .canonicalize()
-        .with_context(|| format!("failed to resolve working directory for `{}`", dataflow.display()))?;
+    let working_dir = parent.canonicalize().with_context(|| {
+        format!(
+            "failed to resolve working directory for `{}`",
+            dataflow.display()
+        )
+    })?;
 
     println!("Validating {}...", dataflow.display());
 

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1528,12 +1528,15 @@ impl Daemon {
             Some(p) => p
                 .canonicalize()
                 .context("failed to canonicalize working_dir override")?,
-            None => dataflow_path
-                .canonicalize()
-                .context("failed to canonicalize dataflow path")?
-                .parent()
-                .ok_or_else(|| eyre::eyre!("canonicalized dataflow path has no parent"))?
-                .to_owned(),
+            None => {
+                let parent = dataflow_path
+                    .parent()
+                    .filter(|p| !p.as_os_str().is_empty())
+                    .unwrap_or_else(|| Path::new("."));
+                parent
+                    .canonicalize()
+                    .context("failed to canonicalize dataflow parent directory")?
+            }
         };
 
         // `hub:` dataflows are desugared in memory by `dora build` — the

--- a/libraries/core/src/descriptor/expand.rs
+++ b/libraries/core/src/descriptor/expand.rs
@@ -108,11 +108,10 @@ pub fn expand_modules_with_boundaries(
     // Lexical project root: used by the module containment check so that a
     // symlinked `modules/` directory inside the project root is accepted,
     // consistent with how node path confinement works (#3247).
-    let absolute_base =
-        dunce::simplified(&std::path::absolute(base_dir).with_context(|| {
-            format!("failed to make base_dir absolute: {}", base_dir.display())
-        })?)
-        .to_path_buf();
+    let absolute_base = normalize_path(dunce::simplified(
+        &std::path::absolute(base_dir)
+            .with_context(|| format!("failed to make base_dir absolute: {}", base_dir.display()))?,
+    ));
     let mut seen = HashSet::new();
     let mut flat_nodes = Vec::new();
     let mut output_maps: BTreeMap<String, ModuleOutputMap> = BTreeMap::new();
@@ -3818,6 +3817,51 @@ nodes:
         );
 
         let expanded = expand_modules(&desc, &symlinked_project).unwrap();
+        assert_eq!(expanded.nodes.len(), 1);
+        assert_eq!(expanded.nodes[0].id.to_string(), "m.worker");
+        assert_eq!(
+            Path::new(expanded.nodes[0].path.as_ref().unwrap()),
+            Path::new("worker.py")
+        );
+    }
+
+    #[test]
+    fn expand_modules_accepts_dotdot_in_base_dir() {
+        let tmp = TempDir::new().unwrap();
+        let sub = tmp.path().join("sub");
+        std::fs::create_dir_all(&sub).unwrap();
+        let project_dir = sub.join("..").join("project");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        write_file(
+            &project_dir,
+            "mod.yml",
+            r#"
+module:
+  name: inner
+  inputs: [in_val]
+  outputs: [out_val]
+
+nodes:
+  - id: worker
+    path: worker.py
+    inputs:
+      data: _mod/in_val
+    outputs:
+      - out_val
+"#,
+        );
+
+        let desc = parse_descriptor(
+            r#"
+nodes:
+  - id: m
+    module: mod.yml
+    inputs:
+      in_val: source/data
+"#,
+        );
+
+        let expanded = expand_modules(&desc, &project_dir).unwrap();
         assert_eq!(expanded.nodes.len(), 1);
         assert_eq!(expanded.nodes[0].id.to_string(), "m.worker");
         assert_eq!(

--- a/libraries/core/src/descriptor/expand.rs
+++ b/libraries/core/src/descriptor/expand.rs
@@ -103,9 +103,14 @@ pub fn expand_modules_with_boundaries(
         });
     }
 
-    let canonical_base = base_dir
-        .canonicalize()
+    let canonical_base = dunce::canonicalize(base_dir)
         .with_context(|| format!("failed to resolve base directory: {}", base_dir.display()))?;
+    // Lexical project root: used by the module containment check so that a
+    // symlinked `modules/` directory inside the project root is accepted,
+    // consistent with how node path confinement works (#3247).
+    let absolute_base = dunce::simplified(&std::path::absolute(base_dir)
+        .with_context(|| format!("failed to make base_dir absolute: {}", base_dir.display()))?)
+        .to_path_buf();
     let mut seen = HashSet::new();
     let mut flat_nodes = Vec::new();
     let mut output_maps: BTreeMap<String, ModuleOutputMap> = BTreeMap::new();
@@ -116,7 +121,7 @@ pub fn expand_modules_with_boundaries(
             // Field validation happens inside `expand_module_node`, so top-level
             // and nested module nodes go through the same whitelist.
             let (mut expanded, omap) =
-                expand_module_node(node, base_dir, &canonical_base, 0, &mut seen)?;
+                expand_module_node(node, base_dir, &canonical_base, &absolute_base, 0, &mut seen)?;
             // Propagate the module node's own `build` to each expanded leaf node,
             // mirroring how a nested module node's build is propagated in Phase 2
             // of `expand_module_node`. `check_module` accepts `build` for exactly
@@ -576,6 +581,7 @@ fn expand_module_node(
     node: &Node,
     base_dir: &Path,
     canonical_base: &Path,
+    absolute_project_root: &Path,
     depth: u8,
     seen: &mut HashSet<PathBuf>,
 ) -> eyre::Result<(Vec<Node>, ModuleOutputMap)> {
@@ -609,11 +615,16 @@ fn expand_module_node(
     }
 
     let module_path = base_dir.join(module_path_str);
-    let canonical = module_path
-        .canonicalize()
+    let canonical = dunce::canonicalize(&module_path)
         .with_context(|| format!("module file not found: {}", module_path.display()))?;
 
-    if !canonical.starts_with(canonical_base) {
+    // Use a lexical absolute path for the containment check so that a
+    // symlinked `modules/` directory inside the project root is accepted,
+    // consistent with how node path confinement works (#3247).
+    let absolute_module_buf = std::path::absolute(&module_path)
+        .with_context(|| format!("failed to make module path absolute: {}", module_path.display()))?;
+    let absolute_module = dunce::simplified(&absolute_module_buf);
+    if !absolute_module.starts_with(absolute_project_root) {
         bail!(
             "module path `{}` escapes the project directory (node `{}`)",
             module_path_str,
@@ -778,7 +789,7 @@ fn expand_module_node(
             let nested_id = inner_node.id.to_string();
             let accumulated_build = inner_node.build.clone();
             let (mut nested, nested_omap) =
-                expand_module_node(&inner_node, module_dir, canonical_base, depth + 1, seen)?;
+                expand_module_node(&inner_node, module_dir, canonical_base, absolute_project_root, depth + 1, seen)?;
             // Propagate the outer module's accumulated build to each nested leaf node,
             // mirroring how `deploy` is propagated through recursion.
             if let Some(ref outer_build) = accumulated_build {
@@ -3644,6 +3655,51 @@ nodes:
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(msg.contains("escapes"), "got: {msg}");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn expand_modules_accepts_symlinked_module_dir() {
+        let tmp = TempDir::new().unwrap();
+        let shared_dir = tmp.path().join("shared_modules");
+        std::fs::create_dir_all(&shared_dir).unwrap();
+        write_file(
+            &shared_dir,
+            "shared.yml",
+            r#"
+module:
+  name: shared
+  inputs: [in_val]
+  outputs: [out_val]
+
+nodes:
+  - id: worker
+    path: worker.py
+    inputs:
+      data: _mod/in_val
+    outputs:
+      - out_val
+"#,
+        );
+
+        let project_dir = tmp.path().join("project");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let symlink_path = project_dir.join("modules");
+        std::os::unix::fs::symlink(&shared_dir, &symlink_path).unwrap();
+
+        let desc = parse_descriptor(
+            r#"
+nodes:
+  - id: m
+    module: modules/shared.yml
+    inputs:
+      in_val: source/data
+"#,
+        );
+
+        let expanded = expand_modules(&desc, &project_dir).unwrap();
+        assert_eq!(expanded.nodes.len(), 1);
+        assert_eq!(expanded.nodes[0].id.as_str(), "m/worker");
     }
 
     #[test]

--- a/libraries/core/src/descriptor/expand.rs
+++ b/libraries/core/src/descriptor/expand.rs
@@ -103,7 +103,7 @@ pub fn expand_modules_with_boundaries(
         });
     }
 
-    let canonical_base = dunce::canonicalize(base_dir)
+    let _ = dunce::canonicalize(base_dir)
         .with_context(|| format!("failed to resolve base directory: {}", base_dir.display()))?;
     // Lexical project root: used by the module containment check so that a
     // symlinked `modules/` directory inside the project root is accepted,
@@ -123,7 +123,7 @@ pub fn expand_modules_with_boundaries(
             // Field validation happens inside `expand_module_node`, so top-level
             // and nested module nodes go through the same whitelist.
             let (mut expanded, omap) =
-                expand_module_node(node, base_dir, &canonical_base, &absolute_base, 0, &mut seen)?;
+                expand_module_node(node, base_dir, &absolute_base, 0, &mut seen)?;
             // Propagate the module node's own `build` to each expanded leaf node,
             // mirroring how a nested module node's build is propagated in Phase 2
             // of `expand_module_node`. `check_module` accepts `build` for exactly
@@ -280,7 +280,7 @@ fn check_module_file_inner(
             // Note: unlike `expand_module_node`, we intentionally do NOT reject
             // a nested reference that leaves `module_dir`. The real expansion
             // path confines nested modules to the *project root*
-            // (`canonical_base`, threaded through recursion), which routinely
+            // (`absolute_project_root`, threaded through recursion), which routinely
             // sits above an individual module's directory -- a module in
             // `modules/a/` may reference a sibling module in `modules/shared/`
             // via `../shared/base.yml`. This linter runs on a module file in
@@ -582,7 +582,6 @@ fn node_output_refs(node: &Node) -> Vec<(String, String)> {
 fn expand_module_node(
     node: &Node,
     base_dir: &Path,
-    canonical_base: &Path,
     absolute_project_root: &Path,
     depth: u8,
     seen: &mut HashSet<PathBuf>,
@@ -761,7 +760,7 @@ fn expand_module_node(
             )?;
         }
 
-        resolve_inner_node_paths(&mut inner_node, module_dir, canonical_base)?;
+        resolve_inner_node_paths(&mut inner_node, module_dir, absolute_project_root)?;
 
         // Propagate deploy from module node to inner nodes
         if inner_node.deploy.is_none() {
@@ -797,7 +796,6 @@ fn expand_module_node(
             let (mut nested, nested_omap) = expand_module_node(
                 &inner_node,
                 module_dir,
-                canonical_base,
                 absolute_project_root,
                 depth + 1,
                 seen,
@@ -879,19 +877,19 @@ fn expand_module_node(
 fn resolve_inner_node_paths(
     node: &mut Node,
     module_dir: &Path,
-    canonical_base: &Path,
+    project_root: &Path,
 ) -> eyre::Result<()> {
     let owner = node.id.to_string();
     if let Some(ref mut path) = node.path {
-        resolve_module_relative_path(path, module_dir, canonical_base, &owner)?;
+        resolve_module_relative_path(path, module_dir, project_root, &owner)?;
     }
     if let Some(ref mut operators) = node.operators {
         for op in &mut operators.operators {
-            resolve_operator_source_paths(&mut op.config, module_dir, canonical_base, &owner)?;
+            resolve_operator_source_paths(&mut op.config, module_dir, project_root, &owner)?;
         }
     }
     if let Some(ref mut operator) = node.operator {
-        resolve_operator_source_paths(&mut operator.config, module_dir, canonical_base, &owner)?;
+        resolve_operator_source_paths(&mut operator.config, module_dir, project_root, &owner)?;
     }
     Ok(())
 }
@@ -899,15 +897,15 @@ fn resolve_inner_node_paths(
 fn resolve_operator_source_paths(
     config: &mut OperatorConfig,
     module_dir: &Path,
-    canonical_base: &Path,
+    project_root: &Path,
     owner: &str,
 ) -> eyre::Result<()> {
     match &mut config.source {
         OperatorSource::SharedLibrary(path) | OperatorSource::Wasm(path) => {
-            resolve_module_relative_path(path, module_dir, canonical_base, owner)
+            resolve_module_relative_path(path, module_dir, project_root, owner)
         }
         OperatorSource::Python(source) => {
-            resolve_module_relative_path(&mut source.source, module_dir, canonical_base, owner)
+            resolve_module_relative_path(&mut source.source, module_dir, project_root, owner)
         }
     }
 }
@@ -915,7 +913,7 @@ fn resolve_operator_source_paths(
 fn resolve_module_relative_path(
     path: &mut String,
     module_dir: &Path,
-    canonical_base: &Path,
+    project_root: &Path,
     owner: &str,
 ) -> eyre::Result<()> {
     // Resolve relative paths: make inner node/operator sources relative to
@@ -935,7 +933,7 @@ fn resolve_module_relative_path(
     }
 
     let resolved = normalize_path(&module_dir.join(path.as_str()));
-    let relative = resolved.strip_prefix(canonical_base).map_err(|_| {
+    let relative = resolved.strip_prefix(project_root).map_err(|_| {
         eyre::eyre!(
             "module node `{}` path `{}` resolves outside the project \
                  directory (resolved to `{}`)",
@@ -3728,7 +3726,8 @@ nodes:
     #[cfg(any(unix, windows))]
     fn reject_symlinked_module_dir_dotdot_escape() {
         let tmp = TempDir::new().unwrap();
-        let shared_dir = tmp.path().join("shared_modules");
+        let shared_base = tmp.path().join("shared_base");
+        let shared_dir = shared_base.join("shared_modules");
         std::fs::create_dir_all(&shared_dir).unwrap();
         write_file(
             &shared_dir,
@@ -3741,6 +3740,12 @@ nodes:
         std::fs::create_dir_all(&project_dir).unwrap();
         write_file(
             &parent,
+            "escape.yml",
+            "module:\n  name: escape\n  inputs: []\n  outputs: []\nnodes: []",
+        );
+        // Ensure physical target exists so canonicalize succeeds and the lexical check is exercised
+        write_file(
+            tmp.path(),
             "escape.yml",
             "module:\n  name: escape\n  inputs: []\n  outputs: []\nnodes: []",
         );
@@ -3766,6 +3771,59 @@ nodes:
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(msg.contains("escapes"), "got: {msg}");
+    }
+
+    #[test]
+    #[cfg(any(unix, windows))]
+    fn expand_modules_accepts_symlinked_project_root() {
+        let tmp = TempDir::new().unwrap();
+        let real_project = tmp.path().join("real_project");
+        std::fs::create_dir_all(&real_project).unwrap();
+        write_file(
+            &real_project,
+            "mod.yml",
+            r#"
+module:
+  name: inner
+  inputs: [in_val]
+  outputs: [out_val]
+
+nodes:
+  - id: worker
+    path: worker.py
+    inputs:
+      data: _mod/in_val
+    outputs:
+      - out_val
+"#,
+        );
+
+        let symlinked_project = tmp.path().join("symlinked_project");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&real_project, &symlinked_project).unwrap();
+        #[cfg(windows)]
+        if let Err(e) = std::os::windows::fs::symlink_dir(&real_project, &symlinked_project) {
+            eprintln!("skipping symlink test: {e}");
+            return;
+        }
+
+        let desc = parse_descriptor(
+            r#"
+nodes:
+  - id: m
+    module: mod.yml
+    inputs:
+      in_val: source/data
+"#,
+        );
+
+        let expanded = expand_modules(&desc, &symlinked_project).unwrap();
+        assert_eq!(expanded.nodes.len(), 1);
+        assert_eq!(expanded.nodes[0].id.to_string(), "m.worker");
+        assert_eq!(
+            Path::new(expanded.nodes[0].path.as_ref().unwrap()),
+            Path::new("worker.py")
+        );
     }
 
     #[test]

--- a/libraries/core/src/descriptor/expand.rs
+++ b/libraries/core/src/descriptor/expand.rs
@@ -108,8 +108,10 @@ pub fn expand_modules_with_boundaries(
     // Lexical project root: used by the module containment check so that a
     // symlinked `modules/` directory inside the project root is accepted,
     // consistent with how node path confinement works (#3247).
-    let absolute_base = dunce::simplified(&std::path::absolute(base_dir)
-        .with_context(|| format!("failed to make base_dir absolute: {}", base_dir.display()))?)
+    let absolute_base =
+        dunce::simplified(&std::path::absolute(base_dir).with_context(|| {
+            format!("failed to make base_dir absolute: {}", base_dir.display())
+        })?)
         .to_path_buf();
     let mut seen = HashSet::new();
     let mut flat_nodes = Vec::new();
@@ -621,10 +623,14 @@ fn expand_module_node(
     // Use a lexical absolute path for the containment check so that a
     // symlinked `modules/` directory inside the project root is accepted,
     // consistent with how node path confinement works (#3247).
-    let absolute_module_buf = std::path::absolute(&module_path)
-        .with_context(|| format!("failed to make module path absolute: {}", module_path.display()))?;
-    let absolute_module = dunce::simplified(&absolute_module_buf);
-    if !absolute_module.starts_with(absolute_project_root) {
+    let absolute_module_buf = std::path::absolute(&module_path).with_context(|| {
+        format!(
+            "failed to make module path absolute: {}",
+            module_path.display()
+        )
+    })?;
+    let normalized_module = normalize_path(dunce::simplified(&absolute_module_buf));
+    if !normalized_module.starts_with(absolute_project_root) {
         bail!(
             "module path `{}` escapes the project directory (node `{}`)",
             module_path_str,
@@ -645,7 +651,7 @@ fn expand_module_node(
     let module_file = load_module_file(&canonical)?;
     validate_module_header(&module_file.module)?;
     let module_id = node.id.to_string();
-    let module_dir = canonical
+    let module_dir = normalized_module
         .parent()
         .expect("module file must have a parent directory");
 
@@ -788,8 +794,14 @@ fn expand_module_node(
         if inner_node.module.is_some() {
             let nested_id = inner_node.id.to_string();
             let accumulated_build = inner_node.build.clone();
-            let (mut nested, nested_omap) =
-                expand_module_node(&inner_node, module_dir, canonical_base, absolute_project_root, depth + 1, seen)?;
+            let (mut nested, nested_omap) = expand_module_node(
+                &inner_node,
+                module_dir,
+                canonical_base,
+                absolute_project_root,
+                depth + 1,
+                seen,
+            )?;
             // Propagate the outer module's accumulated build to each nested leaf node,
             // mirroring how `deploy` is propagated through recursion.
             if let Some(ref outer_build) = accumulated_build {
@@ -3658,7 +3670,7 @@ nodes:
     }
 
     #[test]
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     fn expand_modules_accepts_symlinked_module_dir() {
         let tmp = TempDir::new().unwrap();
         let shared_dir = tmp.path().join("shared_modules");
@@ -3685,7 +3697,13 @@ nodes:
         let project_dir = tmp.path().join("project");
         std::fs::create_dir_all(&project_dir).unwrap();
         let symlink_path = project_dir.join("modules");
+        #[cfg(unix)]
         std::os::unix::fs::symlink(&shared_dir, &symlink_path).unwrap();
+        #[cfg(windows)]
+        if let Err(e) = std::os::windows::fs::symlink_dir(&shared_dir, &symlink_path) {
+            eprintln!("skipping symlink test: {e}");
+            return;
+        }
 
         let desc = parse_descriptor(
             r#"
@@ -3699,7 +3717,55 @@ nodes:
 
         let expanded = expand_modules(&desc, &project_dir).unwrap();
         assert_eq!(expanded.nodes.len(), 1);
-        assert_eq!(expanded.nodes[0].id.as_str(), "m/worker");
+        assert_eq!(expanded.nodes[0].id.to_string(), "m.worker");
+        assert_eq!(
+            Path::new(expanded.nodes[0].path.as_ref().unwrap()),
+            Path::new("modules/worker.py")
+        );
+    }
+
+    #[test]
+    #[cfg(any(unix, windows))]
+    fn reject_symlinked_module_dir_dotdot_escape() {
+        let tmp = TempDir::new().unwrap();
+        let shared_dir = tmp.path().join("shared_modules");
+        std::fs::create_dir_all(&shared_dir).unwrap();
+        write_file(
+            &shared_dir,
+            "shared.yml",
+            "module:\n  name: shared\n  inputs: []\n  outputs: []\nnodes: []",
+        );
+
+        let parent = tmp.path().join("parent");
+        let project_dir = parent.join("project");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        write_file(
+            &parent,
+            "escape.yml",
+            "module:\n  name: escape\n  inputs: []\n  outputs: []\nnodes: []",
+        );
+
+        let symlink_path = project_dir.join("modules");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&shared_dir, &symlink_path).unwrap();
+        #[cfg(windows)]
+        if let Err(e) = std::os::windows::fs::symlink_dir(&shared_dir, &symlink_path) {
+            eprintln!("skipping symlink test: {e}");
+            return;
+        }
+
+        let desc = parse_descriptor(
+            r#"
+nodes:
+  - id: m
+    module: modules/../../escape.yml
+"#,
+        );
+
+        let result = expand_modules(&desc, &project_dir);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("escapes"), "got: {msg}");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #3247

### Problem
1. When referencing modules via a symlinked `modules/` directory, `expand_module_node` rejected the path with `escapes the project directory`. This was because the confinement check compared the canonicalized path of the module file against the canonicalized base dir, which fails whenever the symlink target lives outside the entrypoint directory.
2. When the entrypoint dataflow YAML was itself a symlink, `dora run` canonicalized the file path before taking its parent directory (landing in the nested real directory), while `dora validate` took the parent directly (landing in the directory containing the symlink).

### Solution
- Switched the module confinement check in `expand_module_node` to use lexical absolute paths (`std::path::absolute` + `dunce::simplified`) instead of canonical paths. This matches how node paths are handled and allows symlinked module directories to work. `canonicalize` is kept for existence checking and cycle detection.
- In both `daemon::run_dataflow_with` and `dora validate`, canonicalized the parent directory of `dataflow_path` so both commands consistently resolve the project root to where the entrypoint file was invoked.
- Added a unit test covering symlinked module expansion.

### Testing
- `cargo test -p dora-core` (311 tests passed)
- `cargo test -p dora-cli` (365 tests passed)
