### PR TITLE
ci(nightly): stop pinning rmw_zenoh to an exact apt build

### DIFF
--- a/docker-compose.ros2-zenoh.yml
+++ b/docker-compose.ros2-zenoh.yml
@@ -1,11 +1,13 @@
-# The `rmw_version` pins below name an exact apt version *including* its build
-# date, which is the only way to make a container's `apt-get install` land on a
-# known rmw_zenoh build. Note that packages.ros.org serves only the newest build
-# of each package: when upstream publishes a new one, the pinned version stops
-# resolving and the router container dies during boot. Symptom is the health
-# wait in `scripts/ros2-zenoh-interop.sh` timing out (exit 124) — that script
-# dumps the container log on the way out, and the apt error names the versions
-# that do exist. Bump the pin to one of those.
+# The routers install their rmw_zenoh packages on boot, deliberately *unpinned*.
+# packages.ros.org serves only the newest build of each package, so an exact
+# `=<version>` pin stops resolving the day upstream publishes a new one: the
+# `apt-get install` below fails, the container never reports healthy, and the
+# job dies in the health wait in `scripts/ros2-zenoh-interop.sh`. That rot is
+# every failure these jobs have ever had — humble 2026-08-08..08-21 (#3263),
+# kilted from 2026-08-22 (#2987) — and it silenced them for weeks at a time.
+# Taking whatever the index currently serves is also what a user gets. The
+# version that lands is recorded, and floored, by the interop script; the base
+# images stay digest-pinned, so the ROS core underneath does not move.
 services:
   humble-router:
     profiles: [humble]
@@ -13,14 +15,8 @@ services:
     environment: { RMW_IMPLEMENTATION: rmw_zenoh_cpp }
     network_mode: host
     command: >-
-      bash -lc 'architecture=$$(dpkg --print-architecture) &&
-      case "$$architecture" in
-      amd64) rmw_version=0.1.9-1jammy.20260723.022609 ;;
-      arm64) rmw_version=0.1.9-1jammy.20260725.135946 ;;
-      *) echo "unsupported architecture: $$architecture" >&2; exit 1 ;;
-      esac && apt-get update -qq && apt-get install -y --no-install-recommends
-      "ros-humble-rmw-zenoh-cpp=$$rmw_version" ros-humble-rclpy
-      ros-humble-example-interfaces &&
+      bash -lc 'apt-get update -qq && apt-get install -y --no-install-recommends
+      ros-humble-rmw-zenoh-cpp ros-humble-rclpy ros-humble-example-interfaces &&
       source /opt/ros/humble/setup.bash && ros2 run rmw_zenoh_cpp rmw_zenohd'
     healthcheck:
       test: [CMD-SHELL, "test -x /opt/ros/humble/lib/rmw_zenoh_cpp/rmw_zenohd && pgrep -x rmw_zenohd >/dev/null"]
@@ -35,14 +31,8 @@ services:
     environment: { RMW_IMPLEMENTATION: rmw_zenoh_cpp }
     network_mode: host
     command: >-
-      bash -lc 'architecture=$$(dpkg --print-architecture) &&
-      case "$$architecture" in
-      amd64) rmw_version=0.6.6-1noble.20260603.151244 ;;
-      arm64) rmw_version=0.6.6-1noble.20260603.150157 ;;
-      *) echo "unsupported architecture: $$architecture" >&2; exit 1 ;;
-      esac && apt-get update -qq && apt-get install -y --no-install-recommends
-      "ros-kilted-rmw-zenoh-cpp=$$rmw_version" ros-kilted-rclpy
-      ros-kilted-example-interfaces &&
+      bash -lc 'apt-get update -qq && apt-get install -y --no-install-recommends
+      ros-kilted-rmw-zenoh-cpp ros-kilted-rclpy ros-kilted-example-interfaces &&
       source /opt/ros/kilted/setup.bash && ros2 run rmw_zenoh_cpp rmw_zenohd'
     healthcheck:
       test: [CMD-SHELL, "test -x /opt/ros/kilted/lib/rmw_zenoh_cpp/rmw_zenohd && pgrep -x rmw_zenohd >/dev/null"]

--- a/scripts/ros2-zenoh-interop.sh
+++ b/scripts/ros2-zenoh-interop.sh
@@ -47,16 +47,35 @@ container="${PROJECT}-${service}-1"
 # The router installs its rmw_zenoh packages on boot, so "still booting" and
 # "the apt install failed" look identical from out here — both are just an
 # unhealthy container. Dump the log when the wait runs out, or the whole
-# failure is a bare `exit 124` three minutes in: that is how a pinned
-# `ros-humble-rmw-zenoh-cpp` version aging out of packages.ros.org read as a
-# docker hiccup for a month of nightlies.
+# failure is a bare `exit 124` three minutes in: that is how a month of
+# nightlies read an unresolvable apt pin as a docker hiccup (#3263). The
+# pins are gone now, but a mirror or network hiccup lands here the same way.
 if ! timeout -k 30s 180 bash -c 'until [[ $(docker inspect -f "{{.State.Health.Status}}" "$1" 2>/dev/null) == healthy ]]; do sleep 2; done' _ "$container"; then
   echo "$service never became healthy within 180s; container log follows:" >&2
   "${compose[@]}" logs --tail 100 "$service" >&2 || true
   exit 1
 fi
+# The compose file installs rmw_zenoh unpinned, because an exact `=<version>`
+# apt pin stops resolving as soon as upstream publishes a new build and takes
+# the whole job down with it — that rot, not any interop bug, is every failure
+# these jobs have ever had (#3263, #2987). What the pin was actually good for
+# is caught here instead: record the version that landed, so a future breakage
+# names it, and floor it, so a build too old to interop fails by name rather
+# than as ten confusing case failures.
+case "$DISTRO" in
+  humble) rmw_floor=0.1.9 ;;
+  kilted) rmw_floor=0.6.7 ;;
+esac
+rmw_installed=$("${compose[@]}" exec -T "$service" \
+  dpkg-query -W -f '${Version}' "ros-${DISTRO}-rmw-zenoh-cpp" | tr -d '\r')
+echo "ros-${DISTRO}-rmw-zenoh-cpp=$rmw_installed (floor $rmw_floor)"
+if ! "${compose[@]}" exec -T "$service" \
+  dpkg --compare-versions "$rmw_installed" ge "$rmw_floor"; then
+  echo "rmw_zenoh_cpp $rmw_installed is older than the $rmw_floor floor" >&2
+  exit 1
+fi
 "${compose[@]}" exec -T "$service" bash -lc \
-  "source /opt/ros/$DISTRO/setup.bash; dpkg-query -W 'ros-${DISTRO}-rmw-zenoh-cpp'; ros2 pkg executables rmw_zenoh_cpp"
+  "source /opt/ros/$DISTRO/setup.bash; ros2 pkg executables rmw_zenoh_cpp"
 
 export DORA_ROS2_ZENOH_ARTIFACTS="$TARGET_DIR/ros2-zenoh-logs/$PROJECT"
 export DORA_ROS2_ZENOH_PYTHON="$DORA_ROS2_ZENOH_ARTIFACTS/python"


### PR DESCRIPTION
Closes #2987 (the "turn them green" half — see below for the `continue-on-error` drop).

The two `ROS2 Zenoh Interop` jobs pinned `ros-<distro>-rmw-zenoh-cpp` to an exact apt version including its build date. packages.ros.org serves only the newest build of each package, so every such pin is a dead man's switch: the day upstream publishes a successor the router container's `apt-get install` fails on boot, it never reports healthy, and the job dies in the 180s health wait.

That is not hypothetical — it is *every* failure these jobs have ever had:

| Nightlies | Humble | Kilted |
|---|---|---|
| 2026-08-06..07 | green | green |
| 2026-08-08..21 | **red** — 0.1.8 superseded by 0.1.9 | green |
| 2026-08-22..26 | green — pin bumped by #3263 | **red** — 0.6.6 superseded by 0.6.7 |

Twenty scheduled runs, zero flakes, zero interop regressions: the jobs pass every time the pin happens to resolve. Bumping kilted to 0.6.7 would turn tomorrow green and re-arm the switch — which matters, because #2987 gates dropping `continue-on-error` on a week of green nightlies, and the pins have been rotting about once a fortnight across the pair.

So install what the index serves, which is also what a user gets. The base images stay digest-pinned, so the ROS core underneath does not move. The pin's one real job — not silently testing an ancient build — moves into `scripts/ros2-zenoh-interop.sh`, which now records the version that actually landed (so a future breakage names it) and floors it with `dpkg --compare-versions`. A floor needs no maintenance as upstream advances, which is the point.

Not in this PR, deliberately:

- **Dropping `continue-on-error`.** #2987 asks for a week of green nightlies first, and this changes how the packages install, so that week should start now.
- **Retry around the apt step.** #2987 offers it as the answer *if* the jobs turn out to be genuinely flaky. Twenty runs say they are not; adding untested retry logic to a container boot command would be speculative.
- **The `continue-on-error`-in-`needs` lint** from the issue's "Generalization worth considering" — separate concern, separate PR.
