### PR TITLE
fix(cli): honor per-node --log-filter levels when following logs

### DIFF
--- a/binaries/cli/src/command/logs.rs
+++ b/binaries/cli/src/command/logs.rs
@@ -122,7 +122,6 @@ impl Executable for LogsArgs {
                 self.tail,
                 self.follow,
                 self.grep.as_deref(),
-                &self.level,
                 self.since,
                 self.until,
                 &config,
@@ -147,7 +146,6 @@ impl Executable for LogsArgs {
                     &session,
                     uuid,
                     None,
-                    &self.level,
                     self.since,
                     self.until,
                     self.grep.as_deref(),
@@ -1093,27 +1091,58 @@ fn matches_node_filter(msg_node: Option<&str>, want: Option<&str>) -> bool {
     }
 }
 
+/// The level to subscribe the coordinator log stream at when following: the
+/// most verbose (highest) filter across the global `level` and every per-node
+/// `--log-filter` override.
+///
+/// The coordinator drops any message strictly more verbose than the
+/// subscription level, so the stream must be opened at least as verbosely as
+/// the loosest filter the client might display; the precise per-node decision
+/// is left to the client-side `should_display`. `Stdout` maps to `Trace` (the
+/// most permissive filter), matching how the coordinator treats it.
+fn follow_subscription_level(
+    level: &dora_core::build::LogLevelOrStdout,
+    node_filters: &HashMap<String, dora_core::build::LogLevelOrStdout>,
+) -> log::LevelFilter {
+    fn as_filter(level: &dora_core::build::LogLevelOrStdout) -> log::LevelFilter {
+        match level {
+            dora_core::build::LogLevelOrStdout::Stdout => log::LevelFilter::Trace,
+            dora_core::build::LogLevelOrStdout::LogLevel(l) => l.to_level_filter(),
+        }
+    }
+    node_filters
+        .values()
+        .map(as_filter)
+        .fold(as_filter(level), std::cmp::max)
+}
+
 /// Subscribe to coordinator log stream with time/grep/node filtering.
 ///
 /// `node`, when set, restricts the stream to messages from that single node —
 /// mirroring the node scoping already applied to the historical fetch in
 /// [`logs`]. Without this, `--node <N> --follow` would show history for `N`
 /// but then stream live logs from every node once following began.
-#[allow(clippy::too_many_arguments)]
 fn stream_logs_from_coordinator(
     session: &WsSession,
     uuid: Uuid,
     node: Option<&NodeId>,
-    level: &dora_core::build::LogLevelOrStdout,
     since: Option<std::time::Duration>,
     until: Option<std::time::Duration>,
     grep: Option<&str>,
     config: &LogOutputConfig,
 ) -> Result<()> {
-    let log_level = match level {
-        dora_core::build::LogLevelOrStdout::Stdout => log::LevelFilter::Trace,
-        dora_core::build::LogLevelOrStdout::LogLevel(l) => l.to_level_filter(),
-    };
+    // Subscribe at the most verbose level requested by *any* active filter --
+    // the global `--level` and every per-node `--log-filter` override. The
+    // coordinator drops messages more verbose than the subscription level
+    // (`LogSubscriber::send_message`), so subscribing at only the global level
+    // would starve a per-node filter that is more verbose than the global one:
+    // the historical dump (fetched unfiltered, filtered client-side) would show
+    // those lines but the live `--follow` stream never would. The precise
+    // per-node filtering is then applied client-side by `print_log_message`.
+    //
+    // Both the subscription width and the client-side display filter read from
+    // the same `config`, so they cannot drift apart.
+    let log_level = follow_subscription_level(&config.min_level, &config.node_filters);
 
     let now = Utc::now();
     let since_threshold =
@@ -1185,7 +1214,6 @@ pub fn logs(
     tail: Option<usize>,
     follow: bool,
     grep: Option<&str>,
-    level: &dora_core::build::LogLevelOrStdout,
     since: Option<std::time::Duration>,
     until: Option<std::time::Duration>,
     config: &LogOutputConfig,
@@ -1229,16 +1257,7 @@ pub fn logs(
         return Ok(());
     }
 
-    stream_logs_from_coordinator(
-        session,
-        uuid,
-        Some(&node),
-        level,
-        since,
-        until,
-        grep,
-        config,
-    )
+    stream_logs_from_coordinator(session, uuid, Some(&node), since, until, grep, config)
 }
 
 #[cfg(test)]
@@ -1982,5 +2001,63 @@ mod tests {
             ..Default::default()
         };
         assert!(level_filter_is_active(&restrictive));
+    }
+
+    // --- follow_subscription_level ---
+
+    #[test]
+    fn follow_subscription_level_uses_global_when_no_node_filters() {
+        let level = LogLevelOrStdout::LogLevel(log::Level::Error);
+        assert_eq!(
+            follow_subscription_level(&level, &HashMap::new()),
+            log::LevelFilter::Error
+        );
+    }
+
+    #[test]
+    fn follow_subscription_level_widens_to_more_verbose_node_filter() {
+        // Global `error`, but node `x` is filtered at `debug`. The coordinator
+        // drops anything more verbose than the subscription level, so
+        // subscribing at `error` would never deliver `x`'s debug/info/warn
+        // lines even though the client would display them. The subscription
+        // must widen to `debug`.
+        let level = LogLevelOrStdout::LogLevel(log::Level::Error);
+        let mut node_filters = HashMap::new();
+        node_filters.insert(
+            "x".to_string(),
+            LogLevelOrStdout::LogLevel(log::Level::Debug),
+        );
+        assert_eq!(
+            follow_subscription_level(&level, &node_filters),
+            log::LevelFilter::Debug
+        );
+    }
+
+    #[test]
+    fn follow_subscription_level_keeps_global_when_node_filter_is_less_verbose() {
+        // Global `debug`, node `x` only wants `error`. The global level is the
+        // loosest, so the subscription stays at `debug` and the client filters
+        // `x` down to `error`.
+        let level = LogLevelOrStdout::LogLevel(log::Level::Debug);
+        let mut node_filters = HashMap::new();
+        node_filters.insert(
+            "x".to_string(),
+            LogLevelOrStdout::LogLevel(log::Level::Error),
+        );
+        assert_eq!(
+            follow_subscription_level(&level, &node_filters),
+            log::LevelFilter::Debug
+        );
+    }
+
+    #[test]
+    fn follow_subscription_level_stdout_filter_is_most_permissive() {
+        let level = LogLevelOrStdout::LogLevel(log::Level::Error);
+        let mut node_filters = HashMap::new();
+        node_filters.insert("x".to_string(), LogLevelOrStdout::Stdout);
+        assert_eq!(
+            follow_subscription_level(&level, &node_filters),
+            log::LevelFilter::Trace
+        );
     }
 }


### PR DESCRIPTION
## Summary

`dora logs --follow` subscribed the coordinator log stream using only the global `--level`. The coordinator drops any message strictly more verbose than the subscription level (`LogSubscriber::send_message` in `binaries/coordinator/src/log_subscriber.rs`), so a per-node `--log-filter` that is **more verbose** than the global level was silently starved on the live stream.

## The bug

For a command like:

```
dora logs <df> --node x --level error --log-filter x=debug --follow
```

- The **historical** dump is fetched unfiltered (`tail: None` whenever a level filter is active) and filtered client-side by `apply_level_filter` → `should_display`, which honors `node_filters`, so `x`'s debug lines are shown.
- The **follow** stream is subscribed at `error`, so the coordinator never sends `x`'s debug/info/warn lines and the client never displays them.

History and follow therefore disagreed for the same invocation.

## The fix

Subscribe at the most verbose level across the global `--level` **and** every per-node `--log-filter` override (new `follow_subscription_level` helper, a `max`-fold over the filters), and let the existing client-side `should_display` apply the precise per-node filtering. When a per-node filter is *less* verbose than the global level, the global level still governs the subscription, so no extra traffic is streamed.

Both the subscription width and the client-side display filter now read from the same `LogOutputConfig` (`config.min_level` + `config.node_filters`), so they cannot drift apart. The redundant `level` parameter — a second copy of the level that `build_log_config` already stores in `config.min_level` — was removed from `logs`, `stream_logs_from_coordinator`, and their call sites.

## Validation

- New unit tests for `follow_subscription_level`: global-only, more-verbose-node (widens), less-verbose-node (keeps global), and stdout-filter (most permissive) cases.
- `cargo test -p dora-cli` (373 passed), `cargo clippy -p dora-cli -- -D warnings`, `cargo fmt --all -- --check` all pass.

---

> **Note:** This pull request was generated by Claude (an AI assistant) as part of an automated code-review pass. It is machine-generated; the changes were verified by a human-run local build and test run, but please review carefully before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_019ujcQjrE1bb5eCowxnKvhQ)_