### PR TITLE
perf(daemon): move the log message into the coordinator event instead of cloning

### DIFF
--- a/binaries/daemon/src/log.rs
+++ b/binaries/daemon/src/log.rs
@@ -347,7 +347,7 @@ impl Logger {
                 let message = Timestamped {
                     inner: CoordinatorRequest::Event {
                         daemon_id,
-                        event: DaemonEvent::Log(message.clone()),
+                        event: DaemonEvent::Log(message),
                     },
                     timestamp: self.clock.new_timestamp(),
                 };


### PR DESCRIPTION
## Summary

`Logger::log`'s `Coordinator` destination arm (`binaries/daemon/src/log.rs`) built `DaemonEvent::Log` with `message.clone()`, deep-copying the whole `LogMessage` (its message `String` plus several `Option` fields) on every log line forwarded to the coordinator.

## The issue

The owned `message` parameter is not used after this point: the surrounding `let message = Timestamped { ... }` shadows it and `log_to_coordinator` receives the new binding, so the clone was redundant. The other two match arms already move/borrow the parameter, and the arms are mutually exclusive, so moving it in the `Coordinator` arm type-checks.

```rust
let message = Timestamped {
    inner: CoordinatorRequest::Event {
        daemon_id,
-       event: DaemonEvent::Log(message.clone()),
+       event: DaemonEvent::Log(message),
    },
    timestamp: self.clock.new_timestamp(),
};
```

No behavior change; this only removes a per-log-line allocation on the daemon-to-coordinator log path.

## Validation

- `cargo test -p dora-daemon` (246 passed), `cargo clippy -p dora-daemon -- -D warnings`, `cargo fmt --all -- --check` all pass.

---

> **Note:** This pull request was generated by Claude (an AI assistant) as part of an automated code-review pass. It is machine-generated; the changes were verified by a human-run local build and test run, but please review carefully before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_019ujcQjrE1bb5eCowxnKvhQ)_