### PR TITLE
fix(cli): resolve the dora executable via sys.argv[0] in the wheel (#3327)

### DIFF
--- a/binaries/cli/src/command/mod.rs
+++ b/binaries/cli/src/command/mod.rs
@@ -32,6 +32,7 @@ mod validate;
 
 pub use build::{BuildConfig, build};
 pub use run::{Run, run};
+pub(crate) use up::set_python_executable_path;
 
 use build::Build;
 use clean::CleanArgs;

--- a/binaries/cli/src/command/up.rs
+++ b/binaries/cli/src/command/up.rs
@@ -545,16 +545,104 @@ fn parse_dora_config(config_path: Option<&Path>) -> Result<UpConfig, eyre::ErrRe
     Ok(config)
 }
 
-pub(crate) fn dora_executable_path() -> eyre::Result<std::ffi::OsString> {
-    if cfg!(feature = "python") {
-        // When invoked via Python wrapper, argv[1] is the real dora binary path
-        std::env::args_os()
-            .nth(1)
-            .context("could not get dora path from Python wrapper arguments")
+/// Path to the `dora` console script recorded by the `dora-rs-cli` wheel's
+/// `py_main`. See [`set_python_executable_path`].
+static PYTHON_EXECUTABLE_PATH: std::sync::OnceLock<std::ffi::OsString> = std::sync::OnceLock::new();
+
+/// Record the console-script/executable path (`sys.argv[0]`) that the wheel's
+/// `py_main` was launched with, so [`dora_executable_path`] can re-spawn the
+/// real `dora` binary (`dora coordinator`, `dora daemon`, …).
+///
+/// `sys.argv[0]` is the robust source on **both** platforms: pip's launcher
+/// puts the console-script path there on Unix and the `dora.exe` path there on
+/// Windows. This is called from [`crate::lib_main_from_argv`], the single entry
+/// point both the wheel and the standalone binary go through.
+pub(crate) fn set_python_executable_path(path: std::ffi::OsString) {
+    // First writer wins; a second call (there is none in practice) is ignored.
+    let _ = PYTHON_EXECUTABLE_PATH.set(path);
+}
+
+/// Decide which executable to re-spawn as `dora`.
+///
+/// Split out from [`dora_executable_path`] so the platform-independent decision
+/// is unit-testable without the `python` feature compiled in.
+///
+/// - From the Python wrapper (`dora-rs-cli` wheel): use the recorded
+///   `sys.argv[0]`. `current_exe()` is wrong there — inside the embedded
+///   interpreter it returns the Python interpreter on Unix, so spawning it would
+///   run `python coordinator`. The previous `args_os().nth(1)` was also wrong on
+///   Windows, where the process argv has no interpreter entry and `nth(1)` is
+///   the subcommand (e.g. `"up"`) rather than the dora path (#3327).
+/// - Standalone binary: use `current_exe()`.
+fn choose_executable_path(
+    from_python_wrapper: bool,
+    recorded: Option<std::ffi::OsString>,
+    current_exe: impl FnOnce() -> std::io::Result<PathBuf>,
+) -> eyre::Result<std::ffi::OsString> {
+    if from_python_wrapper {
+        recorded.context(
+            "could not determine the dora executable path from the Python wrapper \
+             (sys.argv[0] was not recorded)",
+        )
     } else {
-        std::env::current_exe()
+        current_exe()
             .map(Into::into)
             .wrap_err("could not determine dora executable path")
+    }
+}
+
+pub(crate) fn dora_executable_path() -> eyre::Result<std::ffi::OsString> {
+    choose_executable_path(
+        cfg!(feature = "python"),
+        PYTHON_EXECUTABLE_PATH.get().cloned(),
+        std::env::current_exe,
+    )
+}
+
+#[cfg(test)]
+mod executable_path_tests {
+    use super::choose_executable_path;
+    use std::ffi::OsString;
+    use std::path::PathBuf;
+
+    #[test]
+    fn python_wrapper_uses_recorded_argv0() {
+        // In the wheel, the recorded `sys.argv[0]` (the console-script path) must
+        // be used verbatim -- not `current_exe()`, which would be the embedded
+        // Python interpreter on Unix.
+        let path = choose_executable_path(true, Some(OsString::from("/opt/venv/bin/dora")), || {
+            panic!("current_exe must not be consulted for the Python wrapper")
+        })
+        .expect("recorded path should resolve");
+        assert_eq!(path, OsString::from("/opt/venv/bin/dora"));
+    }
+
+    #[test]
+    fn python_wrapper_without_recorded_path_errors() {
+        let err = choose_executable_path(true, None, || Ok(PathBuf::from("/should/not/be/used")))
+            .expect_err("missing recorded path must be an error, not a wrong fallback");
+        assert!(
+            format!("{err:#}").contains("Python wrapper"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn standalone_binary_uses_current_exe() {
+        let path = choose_executable_path(false, None, || Ok(PathBuf::from("/usr/bin/dora")))
+            .expect("current_exe should resolve");
+        assert_eq!(path, OsString::from("/usr/bin/dora"));
+    }
+
+    #[test]
+    fn standalone_binary_ignores_any_recorded_path() {
+        // Even if a path was recorded, the standalone binary trusts `current_exe`.
+        let path =
+            choose_executable_path(false, Some(OsString::from("/opt/venv/bin/dora")), || {
+                Ok(PathBuf::from("/usr/bin/dora"))
+            })
+            .expect("current_exe should resolve");
+        assert_eq!(path, OsString::from("/usr/bin/dora"));
     }
 }
 

--- a/binaries/cli/src/lib.rs
+++ b/binaries/cli/src/lib.rs
@@ -79,6 +79,18 @@ where
 {
     use clap::Parser as _;
 
+    let argv: Vec<std::ffi::OsString> = argv.into_iter().map(Into::into).collect();
+
+    // Record argv[0] -- the console-script/executable path -- so that, in the
+    // `dora-rs-cli` wheel, `dora up` / `dora cluster up` re-spawn the real
+    // `dora` binary via `sys.argv[0]` rather than a fixed `args_os()` index that
+    // is wrong on Windows (#3327). `py_main` passes the normalized `sys.argv`
+    // here, whose first element is that path on both Unix and Windows. Harmless
+    // in the standalone binary, where `dora_executable_path` uses `current_exe`.
+    if let Some(exe) = argv.first() {
+        command::set_python_executable_path(exe.clone());
+    }
+
     lib_main(Args::try_parse_from(argv).unwrap_or_else(|err| err.exit()))
 }
 


### PR DESCRIPTION
Fixes #3327.

## Problem

`dora_executable_path()` (`binaries/cli/src/command/up.rs`) resolves the `dora`
binary that `dora up`, `dora cluster up`, and `dora cluster upgrade` re-spawn as
`dora coordinator` / `dora daemon`. Under the `python` feature — i.e. inside the
`dora-rs-cli` wheel — it used a fixed `std::env::args_os().nth(1)`:

```rust
std::env::args_os().nth(1).context("could not get dora path from Python wrapper arguments")
```

That index only happens to be the dora path on Unix (the pip console script is a
shebang script, so the process argv is `["<python>", "<.../bin/dora>", "up"]`).
On **Windows** the pip-generated `dora.exe` launcher has **no** interpreter entry
in the process command line, so `args_os()` is `["dora.exe", "up"]` and
`nth(1)` yields the subcommand `"up"` — the spawn then does
`Command::new("up")` and fails (or targets the wrong program).

This became reachable again after #3300 restored the wheel's `dora` console
script, whose own `py_main` doc comment already documents exactly this
platform divergence.

## Fix

`sys.argv[0]` is the console-script/executable path pip sets on **both**
platforms, and it re-runs `dora` correctly on both. It is the same `sys.argv`
that `py_main` already reads for argument parsing.

- `lib_main_from_argv` — the single entry point both `py_main` (wheel) and
  `main.rs` (standalone binary) go through — now records `argv[0]` into a
  process-global `OnceLock` before parsing.
- `dora_executable_path()` consumes that recorded path under the `python`
  feature. `current_exe()` is not a drop-in replacement here: inside the
  embedded interpreter it returns the Python interpreter on Unix, which would
  spawn `python coordinator`.
- The platform-independent decision is factored into a `choose_executable_path`
  helper so it is unit-testable without the `python` feature compiled in.

The change is a no-op for the standalone binary: `argv[0]` is recorded but never
read, since `dora_executable_path()` still uses `current_exe()` when the
`python` feature is off.

## Tests

Added `executable_path_tests` covering all four cases of `choose_executable_path`
(wheel-with/without recorded path, standalone with/without a recorded path). The
prior test gap noted in the issue — the `wheel-smoke` nightly job only exercises
`dora --version` — remains open for a future Windows wheel-level `dora up` smoke
test; that needs a Windows runner and is out of scope for this unit-level fix.

## Validation

- `cargo test -p dora-cli executable_path` — 4 passed
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p dora-cli` — no warnings in the changed files

---
_Generated by [Claude Code](https://claude.ai/code/session_012angTTNwfxeMpwdz5ZTaL5)_