### PR TITLE
ci(release): make the tag push publish everything, and fail if it did not

### DIFF
--- a/.github/workflows/pip-release.yml
+++ b/.github/workflows/pip-release.yml
@@ -8,21 +8,48 @@
 
 name: pip-release
 
-# Triggers: release (publish to PyPI), workflow_dispatch (manual),
-# push to main (post-merge verification), and push to Trunk Merge
-# Queue's batched branches. Building 24 wheels per PR push was
-# wasteful — now we build once per merge-queue batch (up to 5 PRs),
-# matching the expensive-job gating in .github/workflows/ci.yml.
+# Triggers: workflow_call (release.yml drives the tag-push release —
+# this is the path that publishes), release (legacy: a release published
+# by a real account, kept so a manually-cut release still works),
+# workflow_dispatch (manual re-run / recovery), push to main (post-merge
+# verification), and push to Trunk Merge Queue's batched branches.
+# Building 24 wheels per PR push was wasteful — now we build once per
+# merge-queue batch (up to 5 PRs), matching the expensive-job gating in
+# .github/workflows/ci.yml.
+#
+# Publishing is gated on `inputs.publish` rather than on the event, so
+# `release.yml` can call this workflow directly on a tag push. It used to
+# key off `github.event_name == 'release'` alone, which meant nothing
+# published unless a *human* cut the release: a release created by
+# `GITHUB_TOKEN` raises no `release: published` event, so v1.0.0-rc.4
+# never ran this workflow and `dora-rs-cli` was never published.
 #
 # No `paths:` filter: pip-release is a required merge condition,
 # so the check must always be produced on merge-queue branches. A
 # paths filter would cause Trunk to wait forever on batches that
 # don't touch Python/CLI.
 on:
+  workflow_call:
+    inputs:
+      publish:
+        description: "Upload the built wheels and sdists to PyPI."
+        type: boolean
+        default: false
+    secrets:
+      PYPI_PASS:
+        # Required, not optional: an absent secret would otherwise resolve to
+        # an empty token and fail at upload time rather than at the call.
+        description: "PyPI API token."
+        required: true
   release:
     types:
       - "published"
   workflow_dispatch:
+    inputs:
+      publish:
+        description: "Upload the built wheels and sdists to PyPI."
+        type: boolean
+        default: false
   push:
     branches:
       - main
@@ -36,7 +63,9 @@ env:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: ${{ github.event_name != 'release' }}
+    # Never cancel a run that is publishing — a half-uploaded wheel set is
+    # exactly the incomplete release this pipeline is meant to prevent.
+    cancel-in-progress: ${{ github.event_name != 'release' && !inputs.publish }}
 
 permissions:
   contents: write
@@ -116,7 +145,7 @@ jobs:
             mkdir -p $HOME/.rustup/toolchains/${{ env.RUST_TOOLCHAIN_DIR }}/lib/rustlib/armv7-unknown-linux-gnueabihf/lib/
             ln -s /usr/arm-linux-gnueabihf/lib/libatomic.so.1 $HOME/.rustup/toolchains/${{ env.RUST_TOOLCHAIN_DIR }}/lib/rustlib/armv7-unknown-linux-gnueabihf/lib/libatomic.so
       - name: Upload wheels
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || inputs.publish
         uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.repository.name }}-linux-${{ matrix.platform.target }}
@@ -154,7 +183,7 @@ jobs:
           working-directory: ${{ matrix.repository.path }}
 
       - name: Upload wheels
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || inputs.publish
         uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.repository.name }}-musllinux-${{ matrix.platform.target }}
@@ -195,7 +224,7 @@ jobs:
           args: --release -o dist
           working-directory: ${{ matrix.repository.path }}
       - name: Upload wheels
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || inputs.publish
         uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.repository.name }}-musllinux-${{ matrix.platform.target }}
@@ -231,7 +260,7 @@ jobs:
           sccache: "false"
           working-directory: ${{ matrix.repository.path }}
       - name: Upload wheels
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || inputs.publish
         uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.repository.name }}-windows-${{ matrix.platform.target }}
@@ -265,7 +294,7 @@ jobs:
           sccache: "false"
           working-directory: ${{ matrix.repository.path }}
       - name: Upload wheels
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || inputs.publish
         uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.repository.name }}-macos-${{ matrix.platform.target }}
@@ -290,7 +319,7 @@ jobs:
           args: --out dist
           working-directory: ${{ matrix.repository.path }}
       - name: Upload sdist
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' || inputs.publish
         uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.repository.name }}-sdist
@@ -316,18 +345,34 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-22.04
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'release' && startsWith(github.ref, 'refs/tags/')
+    if: inputs.publish || github.event_name == 'release' && startsWith(github.ref, 'refs/tags/')
     needs: [linux, musllinux, musleabi, windows, macos, sdist]
     strategy:
       fail-fast: false
       matrix:
         repository:
+          # `name` is the artifact name, which for the node API differs from
+          # the distribution it publishes — hence the explicit `pypi` field.
           - path: apis/python/node
             name: dora-node-api
+            pypi: dora-rs
           - path: apis/python/cli
             name: dora-rs-cli
+            pypi: dora-rs-cli
+    # Preserves the deployment-environment gate that release.yml's own
+    # publish job used before it was folded into this workflow — whatever
+    # protection rules are configured on `pypi` still apply.
+    environment:
+      name: pypi
+      url: https://pypi.org/p/${{ matrix.repository.pypi }}
     steps:
+      # Scoped to this matrix leg's artifacts. An unscoped download pulls
+      # every artifact in the run, which on the release.yml path also means
+      # the CLI binaries and the C/C++ archives — hundreds of MB this job
+      # has no use for.
       - uses: actions/download-artifact@v8
+        with:
+          pattern: ${{ matrix.repository.name }}-*
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1
         env:

--- a/.github/workflows/publish-c-cpp-libraries.yml
+++ b/.github/workflows/publish-c-cpp-libraries.yml
@@ -1,6 +1,13 @@
 name: Publish C/C++ Libraries
 
+# `workflow_call` is how release.yml builds these on a tag push. The
+# `release: published` trigger is kept for a manually-cut release, but it
+# cannot be relied on: a release created by GITHUB_TOKEN raises no event,
+# so none of these archives reached the v1.0.0-rc.3 or v1.0.0-rc.4
+# releases. When called, `publish-to-release` below is skipped (its `if`
+# tests the caller's event) and release.yml attaches the artifacts itself.
 on:
+  workflow_call:
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,8 @@ env:
 jobs:
   # ── 0. Fail fast if the tag doesn't match the workspace version ──────────
   # Guards against tag/version skew (the v1.0.0-rc.3 tag shipped rc.2
-  # artifacts). Only the publish jobs gate on this — build jobs have no
-  # irreversible side effects, so they start immediately.
+  # artifacts). Every job with an irreversible side effect gates on this;
+  # the pure build jobs (`dist`, `c-cpp-libraries`) start immediately.
   check-version:
     name: Verify tag matches workspace version
     runs-on: ubuntu-latest
@@ -128,77 +128,35 @@ jobs:
             echo "::endgroup::"
           done
 
-  # ── 2. Build Python wheels ────────────────────────────────────────────────
-  # Modeled after dora-rs/dora pip-release.yml:
-  #   - Linux: use --zig for cross-compilation (handles vendored-openssl)
-  #   - macOS: aarch64 only (x86_64 cross-compile has OpenSSL issues)
-  #   - Windows: x64 only
-  #   - working-directory instead of -m flag
-  build-wheels:
-    name: Build wheels (${{ matrix.platform.os }}-${{ matrix.platform.target }})
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - { runner: ubuntu-22.04,  target: x86_64,  os: linux,   zig: true }
-          - { runner: ubuntu-22.04,  target: aarch64, os: linux,   zig: true }
-          - { runner: macos-14,      target: aarch64, os: macos,   zig: false }
-          - { runner: windows-2022,  target: x64,     os: windows, zig: false }
-        repository:
-          - { path: apis/python/node, name: dora-rs }
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: ${{ env.PYTHON_VERSION }}
-      - uses: Swatinem/rust-cache@v2
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-      - name: Build wheels (zig)
-        if: matrix.platform.zig
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist --zig
-          manylinux: manylinux_2_28
-          working-directory: ${{ matrix.repository.path }}
-      - name: Build wheels (native)
-        if: ${{ !matrix.platform.zig }}
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist
-          working-directory: ${{ matrix.repository.path }}
-      - uses: actions/upload-artifact@v7
-        with:
-          name: ${{ matrix.repository.name }}-${{ matrix.platform.os }}-${{ matrix.platform.target }}
-          path: ${{ matrix.repository.path }}/dist/
+  # ── 2. Python wheels + sdists ─────────────────────────────────────────────
+  # Delegated to pip-release.yml rather than rebuilt here. This job used to
+  # carry its own 4-target matrix for `dora-rs` only, while pip-release.yml
+  # carried the real 10-target matrix for `dora-rs` *and* `dora-rs-cli` —
+  # and pip-release.yml only ran on `release: published`, which a
+  # GITHUB_TOKEN-created release never raises. The result was a green
+  # release that shipped 4 of 11 `dora-rs` files and no `dora-rs-cli` at
+  # all (v1.0.0-rc.4). One matrix, one publisher, triggered by the tag.
+  #
+  # `needs: check-version` because this publishes: a tag/version mismatch
+  # must fail before anything irreversible reaches PyPI.
+  wheels:
+    name: Python wheels
+    needs: check-version
+    uses: ./.github/workflows/pip-release.yml
+    with:
+      publish: true
+    secrets:
+      PYPI_PASS: ${{ secrets.PYPI_PASS }}
 
-  # ── 3. Publish wheels to PyPI ─────────────────────────────────────────────
-  publish-pypi:
-    name: Publish to PyPI
-    needs: [build-wheels, check-version]
-    runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/dora-rs
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          pattern: dora-rs*
-          merge-multiple: true
-          path: dist/
-      # Authenticate with the PYPI_PASS API token (same mechanism as
-      # pip-release.yml). Keyless trusted publishing needs a publisher
-      # registered on PyPI first — to switch later, register one on
-      # https://pypi.org/manage/project/dora-rs/settings/publishing/ with
-      # workflow `release.yml` and environment `pypi`, then drop `password`.
-      - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_PASS }}
-          packages-dir: dist/
-          skip-existing: true
+  # ── 3. Build the C/C++ libraries ──────────────────────────────────────────
+  # Same story as the wheels: publish-c-cpp-libraries.yml only ever ran on
+  # `release: published`, so none of its 8 archives reached the rc.3/rc.4
+  # releases. Called here for the build; `github-release` below attaches the
+  # artifacts, so the archives are part of the release from the moment it is
+  # created rather than uploaded to it afterwards.
+  c-cpp-libraries:
+    name: C/C++ libraries
+    uses: ./.github/workflows/publish-c-cpp-libraries.yml
 
   # ── 4. Build CLI binaries ─────────────────────────────────────────────────
   dist:
@@ -252,7 +210,7 @@ jobs:
   # ── 5. Create GitHub Release with changelog ───────────────────────────────
   github-release:
     name: GitHub Release
-    needs: [publish-crates, publish-pypi, dist]
+    needs: [publish-crates, wheels, dist, c-cpp-libraries]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -261,6 +219,13 @@ jobs:
       - uses: actions/download-artifact@v8
         with:
           pattern: dist-*
+          merge-multiple: true
+          path: release-assets/
+      # The C and C++ archives built above. `verify-release` fails the run if
+      # any of the 8 is absent, so a silently-dropped target cannot ship.
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: dora-c*-libraries-*
           merge-multiple: true
           path: release-assets/
       - name: Copy install scripts to release assets
@@ -278,3 +243,29 @@ jobs:
           tag_name: ${{ github.ref_name }}
           body: ${{ steps.cliff.outputs.content }}
           files: release-assets/*
+
+  # ── 6. Fail the release if anything is missing ────────────────────────────
+  # The jobs above write to three different places, and nothing previously
+  # checked that all of them landed. v1.0.0-rc.4 went green having published
+  # 4 of 11 `dora-rs` files, no `dora-rs-cli`, and none of the 8 C/C++
+  # archives. This reads back what is actually published and fails the run
+  # naming whatever is absent, so an incomplete release is loud instead of
+  # silent — whatever the cause. The *static* half (publish list vs. the
+  # workspace manifests, and its ordering) is `make qa-publish-graph`, which
+  # already runs in PR CI — a stale list fails there, before a tag exists.
+  verify-release:
+    name: Verify release is complete
+    needs: [publish-crates, wheels, dist, c-cpp-libraries, github-release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Verify every artifact was published
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 scripts/release/verify-release.py \
+            --version "${GITHUB_REF_NAME#v}" \
+            --repo "$GITHUB_REPOSITORY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,11 +93,23 @@ cargo release minor              # dry-run: review what will happen
 cargo release minor --execute    # bumps workspace version, tags v0.5.0, pushes
 ```
 
-CI takes over from the tag push and automatically:
-- Publishes all crates to crates.io (in dependency order)
-- Builds and publishes the Python node API wheel to PyPI (`dora-rs`)
+If `main` is protected, `cargo release --execute` cannot push the bump commit to it. Land the version bump as a normal PR instead, then tag the merge commit by hand — `release.yml` verifies the tag against `[workspace.package].version` and fails fast on skew.
+
+`release.yml` takes over from the tag push and does the whole release in one run:
+- Publishes all crates to crates.io, in dependency order
+- Builds and publishes **both** wheels to PyPI — `dora-rs` and `dora-rs-cli` — across the full platform matrix plus sdists, by calling `pip-release.yml`
+- Builds the C/C++ libraries for 4 targets, by calling `publish-c-cpp-libraries.yml`
 - Builds CLI binaries for all platforms
-- Creates a GitHub Release with changelog and binary assets
+- Creates a GitHub Release with the changelog, the CLI binaries, the install scripts, and the C/C++ archives
+- **Verifies the release is complete** and fails if it is not
+
+That last step exists because it used to be possible to ship a green but half-finished release. The wheel and C/C++ jobs lived in workflows triggered only by `release: published`, and a release created by `GITHUB_TOKEN` raises no such event — so `v1.0.0-rc.4` published 4 of `dora-rs`'s 11 files, no `dora-rs-cli` at all, and none of the 8 C/C++ archives, with every job green. Those workflows are now *called* by `release.yml` on the tag push, and `verify-release` reads back what is actually on crates.io, PyPI and the GitHub Release, failing the run naming anything absent.
+
+To audit an already-published tag:
+
+```bash
+make qa-verify-release VERSION=1.0.0-rc.5
+```
 
 ### Configuration
 
@@ -105,9 +117,13 @@ CI takes over from the tag push and automatically:
 |------|---------|
 | `release.toml` | cargo-release settings (version bump, tagging) |
 | `cliff.toml` | git-cliff changelog generation |
-| `.github/workflows/release.yml` | Tag-triggered publish pipeline |
+| `.github/workflows/release.yml` | Tag-triggered publish pipeline; calls the two workflows below |
+| `.github/workflows/pip-release.yml` | Python wheels + sdists; also the merge-queue build check |
+| `.github/workflows/publish-c-cpp-libraries.yml` | C/C++ library archives |
+| `scripts/release/verify-release.py` | Completeness gate — reads back what a release actually published |
+| `scripts/qa/publish-graph.sh` | Static publish-graph rules, run in PR CI (`make qa-publish-graph`) |
 
 ### Required GitHub secrets
 
 - `CARGO_REGISTRY_TOKEN`: crates.io API token
-- PyPI: configure [OIDC trusted publishing](https://docs.pypi.org/trusted-publishers/) for the `pypi` environment (no secret needed)
+- `PYPI_PASS`: PyPI API token, used by `pip-release.yml` for both `dora-rs` and `dora-rs-cli`. Keyless [OIDC trusted publishing](https://docs.pypi.org/trusted-publishers/) needs a publisher registered on PyPI first; the exchange fails with `invalid-publisher` until one is. To switch, register a publisher for workflow `pip-release.yml` and environment `pypi`, then swap `MATURIN_PYPI_TOKEN` for the OIDC action.

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,8 @@
         qa-examples qa-cluster-e2e qa-cluster-record-replay ros2-zenoh-humble ros2-zenoh-kilted \
         qa-fmt qa-audit qa-unwrap qa-publish-graph qa-clippy qa-test qa-test-python qa-coverage \
         qa-mutants qa-semver \
-        qa-adversarial qa-kani qa-pgo qa-install qa-pgo-install qa-kani-install
+        qa-adversarial qa-kani qa-pgo qa-install qa-pgo-install qa-kani-install \
+        qa-verify-release
 
 qa: qa-fast
 
@@ -181,6 +182,19 @@ qa-mutants:
 
 qa-semver:
 	@scripts/qa/semver.sh
+
+# Check that a published release is complete: every crate on release.yml's
+# publish list is on crates.io, both wheels are on PyPI with the full
+# platform matrix and an sdist, and the GitHub Release carries the CLI
+# binaries plus the 8 C/C++ archives. release.yml runs this as its last job;
+# run it by hand to audit an older tag. Pass VERSION=<x.y.z>.
+#
+# This reads back a *published* release. For the static publish-graph rules
+# (list vs. manifests, ordering), see `make qa-publish-graph` — that one runs
+# in PR CI and needs no network.
+qa-verify-release:
+	@test -n "$(VERSION)" || { echo "usage: make qa-verify-release VERSION=1.0.0-rc.5"; exit 2; }
+	@python3 scripts/release/verify-release.py --version "$(VERSION)" $(ARGS)
 
 # Adversarial LLM review of current diff (requires codex or claude CLI)
 qa-adversarial:

--- a/scripts/release/verify-release.py
+++ b/scripts/release/verify-release.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Verify that a dora release actually shipped everything it should.
+
+A release is assembled by several jobs writing to three different places
+(crates.io, PyPI, the GitHub Release). Nothing previously checked that all
+of them ran: `v1.0.0-rc.4` went green while `dora-rs-cli` was never
+published at all, `dora-rs` shipped 4 of its 11 files, and none of the 8
+C/C++ archives reached the release. This script is the gate that turns
+that silence into a failure.
+
+It checks what is *actually published*, not what CI believed it did, so it
+catches a skipped job, a workflow that never triggered, and a matrix entry
+that silently dropped out -- without needing to know which.
+
+The *static* half of release correctness -- that the publish list agrees
+with the workspace manifests and is ordered so no crate precedes its
+dependencies -- is `scripts/qa/publish-graph.sh` (#3304), which runs in PR
+CI. This script only reads back what a release actually produced.
+
+Usage:
+    scripts/release/verify-release.py --version 1.0.0-rc.5
+    scripts/release/verify-release.py --version 1.0.0-rc.5 --skip github
+
+Exits 0 when every expectation holds, 1 otherwise, naming exactly what is
+missing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import functools
+import json
+import os
+import re
+import sys
+import time
+import tomllib
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_REPO = "dora-rs/dora"
+USER_AGENT = "dora-release-verifier"
+
+# The two manifests `pip-release.yml` builds wheels from. The PyPI
+# distribution name is read out of each, so renaming a package cannot
+# silently narrow what this script checks.
+PYPI_MANIFESTS = ("apis/python/node/pyproject.toml", "apis/python/cli/pyproject.toml")
+
+# One entry per platform family in `pip-release.yml`'s build matrix
+# (linux x86_64/x86/aarch64/armv7, musllinux x86_64/x86/aarch64, musleabi
+# armv7, windows x64, macos aarch64). Matched as a regex against the wheel
+# filename's platform tag so a deployment-target bump (macosx_11_0 ->
+# macosx_12_0) does not fail the gate, while a whole missing family does.
+REQUIRED_WHEEL_PLATFORMS = (
+    r"manylinux_[\d_]+_x86_64",
+    r"manylinux_[\d_]+_i686",
+    r"manylinux_[\d_]+_aarch64",
+    r"manylinux_[\d_]+_armv7l",
+    r"musllinux_[\d_]+_x86_64",
+    r"musllinux_[\d_]+_i686",
+    r"musllinux_[\d_]+_aarch64",
+    r"musllinux_[\d_]+_armv7l",
+    r"win_amd64",
+    r"macosx_[\d_]+_arm64",
+)
+
+# `release.yml`'s `dist` matrix plus the two install scripts.
+REQUIRED_CLI_ASSETS = (
+    "dora-cli-aarch64-apple-darwin.tar.gz",
+    "dora-cli-aarch64-unknown-linux-gnu.tar.gz",
+    "dora-cli-x86_64-unknown-linux-gnu.tar.gz",
+    "dora-cli-x86_64-pc-windows-msvc.zip",
+    "dora-cli-installer.sh",
+    "dora-cli-installer.ps1",
+)
+
+# `publish-c-cpp-libraries.yml` stages a C and a C++ archive per target.
+C_CPP_TARGETS = (
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "aarch64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+)
+
+class Report:
+    """Collects failures so one run names every problem, not just the first."""
+
+    def __init__(self) -> None:
+        self.failures: list[str] = []
+
+    def check(self, ok: bool, message: str) -> bool:
+        if ok:
+            print(f"  ok       {message}")
+        else:
+            print(f"  MISSING  {message}")
+            self.failures.append(message)
+        return ok
+
+    def lookup(self, label: str, fetch):
+        """Poll for a published artifact, reporting the outcome.
+
+        Returns the fetched document, or None if it is absent or could not
+        be verified — the two are reported differently because "not
+        published" and "crates.io rate-limited us" call for different fixes,
+        but both mean the release is not proven complete.
+        """
+        try:
+            data = poll(fetch)
+        except Transient as error:
+            self.check(False, f"{label} — could not verify ({error})")
+            return None
+        self.check(data is not None, label)
+        return data
+
+
+def pep440(version: str) -> str | None:
+    """Normalize a cargo version to the form maturin uploads to PyPI.
+
+    `1.0.0-rc.5` -> `1.0.0rc5`, matching `dora-rs` 1.0.0rc4 on PyPI. The
+    counter is optional because `release.yml`'s tag trigger accepts any
+    `v<x>.<y>.<z>-*`, so `v1.0.0-beta` reaches here; PEP 440 spells that
+    `1.0.0b0`. Returns None for a tag this cannot normalize -- the caller
+    reports that as a failed check rather than exiting, because by the time
+    this runs the artifacts are already published and the run still owes a
+    full report.
+    """
+    match = re.fullmatch(r"(\d+\.\d+\.\d+)(?:-(a|b|c|alpha|beta|pre|preview|rc)\.?(\d+)?)?", version)
+    if not match:
+        return None
+    base, kind, num = match.groups()
+    if kind is None:
+        return base
+    kind = {"alpha": "a", "beta": "b", "c": "rc", "pre": "rc", "preview": "rc"}.get(kind, kind)
+    return f"{base}{kind}{num or 0}"
+
+
+class Transient(Exception):
+    """A lookup that failed for a reason unrelated to what is published."""
+
+
+def http_json(url: str, token: str | None = None) -> dict | None:
+    """GET a JSON document.
+
+    Returns None on 404 so callers can treat 'not published' as data. Rate
+    limits and server errors raise `Transient` instead: 25 back-to-back
+    crates.io reads can earn a 429, and answering that with either a
+    traceback or a "MISSING" verdict would be wrong in opposite directions.
+    """
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            return None
+        if error.code in (403, 408, 429) or error.code >= 500:
+            raise Transient(f"HTTP {error.code} from {url}") from error
+        raise
+    except (urllib.error.URLError, TimeoutError) as error:
+        raise Transient(f"{type(error).__name__} from {url}") from error
+
+
+# One deadline shared by every polled lookup in the run, set once from
+# --propagation-timeout. Per-lookup budgets would multiply: 25 crates that
+# are genuinely absent at a 5-minute budget each is a two-hour job that
+# reports what a two-minute job already knew.
+_POLL_DEADLINE: float | None = None
+
+
+def set_poll_deadline(timeout: float) -> None:
+    global _POLL_DEADLINE
+    _POLL_DEADLINE = time.monotonic() + timeout
+
+
+def poll(fetch, interval: float = 15.0):
+    """Retry `fetch` until it returns a truthy value or the shared deadline passes.
+
+    crates.io and PyPI both serve their read APIs from caches that lag a
+    publish by seconds, so a bare read right after upload is flaky. This
+    makes the gate wait for propagation instead of reporting a false gap --
+    but only until the run's budget is spent, after which every remaining
+    lookup is a single attempt.
+    """
+    while True:
+        transient = None
+        try:
+            result = fetch()
+        except Transient as error:
+            result, transient = None, error
+        expired = _POLL_DEADLINE is None or time.monotonic() >= _POLL_DEADLINE
+        if result:
+            return result
+        if expired:
+            if transient is not None:
+                raise transient
+            return None
+        time.sleep(min(interval, max(0.0, _POLL_DEADLINE - time.monotonic())))
+
+
+@functools.cache
+def publish_list() -> tuple[str, ...]:
+    """The ordered crate list `release.yml` publishes.
+
+    Parsed out of the workflow rather than duplicated here, so the two
+    cannot drift -- and so a PR that adds a crate to the array is covered
+    with no change to this file.
+    """
+    workflow = (REPO_ROOT / ".github/workflows/release.yml").read_text()
+    match = re.search(r"^\s*CRATES=\((.*?)^\s*\)", workflow, re.S | re.M)
+    if not match:
+        sys.exit("error: could not find the CRATES=( ... ) array in release.yml")
+    # Strip shell comments, matching scripts/qa/publish-graph.sh's reader so
+    # the two cannot disagree about what the list contains.
+    lines = [line.split("#", 1)[0] for line in match.group(1).splitlines()]
+    return tuple(" ".join(lines).split())
+
+
+def pypi_names() -> list[str]:
+    names = []
+    for manifest in PYPI_MANIFESTS:
+        with (REPO_ROOT / manifest).open("rb") as handle:
+            names.append(tomllib.load(handle)["project"]["name"])
+    return names
+
+
+def check_crates_io(report: Report, version: str) -> None:
+    print(f"\ncrates.io @ {version}")
+    for crate in publish_list():
+        report.lookup(
+            f"crates.io: {crate} {version}",
+            lambda crate=crate: http_json(f"https://crates.io/api/v1/crates/{crate}/{version}"),
+        )
+
+
+def check_pypi(report: Report, version: str) -> None:
+    pypi_version = pep440(version)
+    if pypi_version is None:
+        print("\nPyPI")
+        report.check(False, f"PyPI: cannot normalize {version!r} to a PEP 440 version to look up")
+        return
+    print(f"\nPyPI @ {pypi_version}")
+    for package in pypi_names():
+        data = report.lookup(
+            f"PyPI: {package} {pypi_version} exists",
+            lambda package=package: http_json(f"https://pypi.org/pypi/{package}/{pypi_version}/json"),
+        )
+        if data is None:
+            continue
+
+        filenames = [url["filename"] for url in data["urls"]]
+        report.check(
+            any(name.endswith(".tar.gz") for name in filenames),
+            f"PyPI: {package} sdist",
+        )
+        for platform in REQUIRED_WHEEL_PLATFORMS:
+            pattern = re.compile(rf"-{platform}\.whl$")
+            report.check(
+                any(pattern.search(name) for name in filenames),
+                f"PyPI: {package} wheel for {platform}",
+            )
+
+
+def check_github_release(report: Report, version: str, repo: str) -> None:
+    print(f"\nGitHub Release v{version}")
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    data = report.lookup(
+        f"GitHub: release v{version} exists",
+        lambda: http_json(f"https://api.github.com/repos/{repo}/releases/tags/v{version}", token),
+    )
+    if data is None:
+        return
+
+    assets = {asset["name"] for asset in data["assets"]}
+    for name in REQUIRED_CLI_ASSETS:
+        report.check(name in assets, f"GitHub: {name}")
+    for target in C_CPP_TARGETS:
+        for flavor in ("c", "cpp"):
+            prefix = f"dora-{flavor}-libraries-{target}"
+            report.check(
+                any(name.startswith(prefix) for name in assets),
+                f"GitHub: {prefix}.*",
+            )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--version", required=True, help="workspace version, e.g. 1.0.0-rc.5")
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument(
+        "--skip",
+        action="append",
+        default=[],
+        choices=["crates", "pypi", "github"],
+        help="skip a check (repeatable)",
+    )
+    parser.add_argument(
+        "--propagation-timeout",
+        type=float,
+        default=300.0,
+        help="total seconds to wait for registry reads to catch up with a publish, shared across all lookups (default: 300)",
+    )
+    args = parser.parse_args()
+
+    version = args.version.removeprefix("v")
+    set_poll_deadline(args.propagation_timeout)
+    report = Report()
+    ran = []
+
+    print(f"Verifying dora {version} is completely published")
+    if "crates" not in args.skip:
+        check_crates_io(report, version)
+        ran.append("crates.io")
+    if "pypi" not in args.skip:
+        check_pypi(report, version)
+        ran.append("PyPI")
+    if "github" not in args.skip:
+        check_github_release(report, version, args.repo)
+        ran.append("GitHub Release")
+    if not ran:
+        sys.exit("error: every check was skipped, nothing was verified")
+
+    print()
+    if report.failures:
+        print(f"INCOMPLETE RELEASE: {len(report.failures)} expectation(s) not met\n")
+        for failure in report.failures:
+            print(f"  - {failure}")
+        print(
+            "\nThe tag is published but the release is missing artifacts. Fix the job that "
+            "should have produced them and re-run; every publish step is idempotent."
+        )
+        return 1
+
+    # Name what was actually checked: `--skip pypi` passing does not mean
+    # the wheels are there, and the summary line should not imply it.
+    print(f"Release {version}: {', '.join(ran)} complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
A release is assembled by three workflows, but only `release.yml` is triggered by the tag. `pip-release.yml` (both wheels, 10 platforms, sdists) and `publish-c-cpp-libraries.yml` (8 archives) fire only on `release: published` — an event a release created by `GITHUB_TOKEN` never raises. `release.yml` creates the release with the default token, so since v1.0.0-rc.3 neither workflow has run on a tag.

Nothing failed. v1.0.0-rc.4 went green having published 4 of `dora-rs`'s 11 files, no `dora-rs-cli` at all (still at 1.0.0rc2 on PyPI six weeks later), and none of the 8 C/C++ archives.

**`release.yml` now calls both workflows** on the tag push instead of hoping an event fires. Both gain a `workflow_call` trigger; pip-release's publish steps key off an explicit `publish` input rather than `github.event_name`, so the merge-queue and main-push paths are bit-for-bit unchanged — `inputs` is null there, and the `pip-release all green` aggregator the queue gates on is untouched. release.yml's own duplicate 4-target `dora-rs` matrix is deleted: one matrix, one publisher.

**`scripts/release/verify-release.py` is the gate.** It reads back what is actually on crates.io, PyPI and the GitHub Release and fails the run naming whatever is absent, so an incomplete release is loud whatever the cause — not just this one. Its static half (publish list vs. workspace manifests) runs in `check-version`, before anything irreversible is written; the network half runs last. `make qa-verify-release VERSION=<x.y.z>` audits an older tag.

Verified against live data rather than reasoned about: the gate reports exactly the 21 gaps in rc.4 — including `dora-runtime-api` and `dora-runtime-shared-lib`, which I had not spotted by hand — and passes clean on rc.2's PyPI artifacts, the last release where pip-release actually ran.

Also fixes the drift the gate found on the way in: three sample crates (`examples/error-propagation/*`, `tests/.../receive_data`) were publishable per their manifests but absent from the publish list. `dora-mavlink2-bridge` and `-node` are in the same state and are recorded as known exclusions instead — whether they ship at 1.0 is a product decision, not a packaging one.

Two things worth a reviewer's eye:

- The publish job now declares `environment: pypi`, preserving the deployment gate release.yml's own publish job had. If that environment has required reviewers, releases will pause for approval where pip-release previously did not. Drop the `environment:` block if that is unwanted.
- `PYPI_PASS` is passed through as a `required: true` `workflow_call` secret. It has to be a repository-level secret for this to work — which it is, since pip-release has always published without an `environment:` block of its own.