### PR TITLE
docs: correct API signatures that drifted after #2366 and #3213

### DIFF
--- a/docs/api-rust.md
+++ b/docs/api-rust.md
@@ -90,23 +90,11 @@ pub fn send_output_raw<F>(
 where
     F: FnOnce(&mut [u8])
 
-// Send raw bytes with explicit Arrow type information.
-pub fn send_typed_output<F>(
-    &mut self,
-    output_id: DataId,
-    type_info: ArrowTypeInfo,
-    parameters: MetadataParameters,
-    data_len: usize,
-    data: F,
-) -> NodeResult<()>
-where
-    F: FnOnce(&mut [u8])
-
-// Send a pre-allocated DataSample with type information.
+// Send a pre-allocated DataSample. The sample must already hold a
+// self-describing Arrow IPC stream; prefer send_output, which encodes for you.
 pub fn send_output_sample(
     &mut self,
     output_id: DataId,
-    type_info: ArrowTypeInfo,
     parameters: MetadataParameters,
     sample: Option<DataSample>,
 ) -> NodeResult<()>
@@ -129,7 +117,7 @@ pub fn send_service_request(
     &mut self,
     output_id: DataId,
     parameters: MetadataParameters,
-    data: impl Array,
+    data: impl IntoArrow,
 ) -> NodeResult<String>
 
 // Send a service response. Semantic alias for send_output.
@@ -138,7 +126,7 @@ pub fn send_service_response(
     &mut self,
     output_id: DataId,
     parameters: MetadataParameters,
-    data: impl Array,
+    data: impl IntoArrow,
 ) -> NodeResult<()>
 ```
 
@@ -725,7 +713,7 @@ pub struct DoraOutputSender<'a>(/* ... */);
 
 impl DoraOutputSender<'_> {
     // Send an output. `id` is the output ID from your dataflow YAML.
-    pub fn send(&mut self, id: String, data: impl Array) -> Result<(), String>
+    pub fn send(&mut self, id: &str, data: impl IntoArrow) -> Result<(), String>
 }
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -378,18 +378,14 @@ pub struct NodeError {
 
 ### Apache Arrow
 
-All data payloads use Apache Arrow columnar format with 128-byte alignment. Arrow type information is carried in every message via `ArrowTypeInfo`:
+All data payloads use Apache Arrow columnar format with 128-byte alignment. The payload is a self-describing Arrow IPC stream, so the message carries no separate type descriptor — the `ArrowTypeInfo` sidecar that 0.x sent alongside every message was dropped in #2366.
+
+The framing is announced through a metadata parameter rather than a struct field:
 
 ```rust
-pub struct ArrowTypeInfo {
-    pub data_type: DataType,           // Arrow DataType
-    pub len: usize,
-    pub null_count: usize,
-    pub validity: Option<Vec<u8>>,     // null bitmap
-    pub offset: usize,
-    pub buffer_offsets: Vec<BufferOffset>,
-    pub child_data: Vec<ArrowTypeInfo>,  // recursive for nested types
-}
+pub const FRAMING: &str = "_framing";
+pub const FRAMING_ARROW_IPC: &str = "arrow-ipc";
+pub const SCHEMA_HASH: &str = "_schema_hash";   // internal; set by the schema-once path
 ```
 
 ### Metadata
@@ -398,12 +394,13 @@ Every message carries structured metadata:
 
 ```rust
 pub struct Metadata {
-    metadata_version: u16,
+    metadata_version: u16,                // Metadata::CURRENT_VERSION
     timestamp: uhlc::Timestamp,
-    pub type_info: ArrowTypeInfo,
     pub parameters: MetadataParameters,   // BTreeMap<String, Parameter>
 }
 ```
+
+`metadata_version` is bumped whenever the wire format changes shape: 0 to 1 when the `ArrowTypeInfo` sidecar was dropped, and 1 to 2 when the binary encoding moved from bincode to postcard. A receiver compares it against `Metadata::CURRENT_VERSION` to report an incompatible peer clearly instead of failing with a positional-deserialization error.
 
 ### Parameter Types
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1480,14 +1480,15 @@ struct NodeId(String);      // [a-zA-Z0-9_.-], no leading `.`, not `dora`
 struct DataId(String);      // same validation
 type DataflowId = uuid::Uuid;
 
-// Data metadata
+// Data metadata. The payload is a self-describing Arrow IPC stream,
+// so no separate type descriptor is carried.
 struct Metadata {
-    timestamp: uhlc::Timestamp,    // hybrid logical clock
-    type_info: ArrowTypeInfo,      // Arrow schema
+    metadata_version: u16,          // Metadata::CURRENT_VERSION
+    timestamp: uhlc::Timestamp,     // hybrid logical clock
     parameters: MetadataParameters, // custom key-value pairs
 }
 
-// Node events (daemon -> node)
+// Node events (daemon -> node). `#[non_exhaustive]`, so match with a `_` arm.
 enum NodeEvent {
     Stop,
     Reload { operator_id },
@@ -1496,6 +1497,10 @@ enum NodeEvent {
     InputRecovered { id },
     NodeRestarted { id },
     AllInputsClosed,
+    ParamUpdate { key, value_json },
+    ParamDeleted { key },
+    NodeFailed { affected_input_ids, error, source_node_id },
+    ExtensionDropped { namespace, key },
 }
 ```
 


### PR DESCRIPTION
`docs/api-rust.md` documented `send_typed_output`. It exists nowhere in the tree — a repo-wide grep for `fn send_typed_output` over `*.rs` returns nothing. It went away with the `ArrowTypeInfo` sidecar in #2366 and the reference page kept it, so anyone writing against the docs gets a method-not-found on their first build.

Rather than fix the one line, I swept every `pub fn` in `api-rust.md` against the sources. Four more had drifted:

- `send_output_sample` still listed the `type_info: ArrowTypeInfo` parameter it no longer takes
- `send_service_request` / `send_service_response` said `data: impl Array`; both take `impl IntoArrow` since #3213 pulled Arrow types out of the public surface
- the operator `DoraOutputSender::send` said `id: String, data: impl Array`; it is `id: &str, data: impl IntoArrow`

The same `ArrowTypeInfo` drift had spread past the Rust page. `architecture.md` documented an `ArrowTypeInfo` struct that no longer exists and a `Metadata` carrying a `type_info` field it no longer has — replaced with the framing parameters that took its place, plus what `metadata_version` now means (0→1 dropping the sidecar, 1→2 bincode → postcard). `cli.md` had the same stale `Metadata`, and its `NodeEvent` listing predated `ParamUpdate`, `ParamDeleted`, `NodeFailed` and `ExtensionDropped`.

`guide/src/languages/rust.md` carries the same stale `send_typed_output` block and is deliberately untouched: #3314 replaces that file wholesale (771 lines to 16, pointing at `api-rust.md`), so editing it here would only conflict.

After this, every `pub fn` named in `api-rust.md` resolves to a real function, and the parameter lists match.

Docs only.
