### PR TITLE
fix(node-api): re-prompt instead of panicking on an invalid interactive input ID

### DIFF
--- a/apis/rust/node/src/daemon_connection/interactive.rs
+++ b/apis/rust/node/src/daemon_connection/interactive.rs
@@ -6,6 +6,7 @@ use dora_core::uhlc::HLC;
 use dora_message::{
     common::{DataMessage, Timestamped},
     daemon_to_node::{DaemonReply, NodeEvent},
+    id::DataId,
     metadata::Metadata,
     node_to_daemon::DaemonRequest,
 };
@@ -104,79 +105,85 @@ impl InteractiveEvents {
             );
             return Ok(None);
         }
-        let stdout_lock = stdout().lock();
-        let id = inquire::Text::new("Input ID")
-            .with_help_message("empty input ID to stop")
-            .prompt()?;
-        std::mem::drop(stdout_lock);
-        let event = if id.is_empty() {
-            println!("{}", "given input ID is empty -> stopping".blue());
-            self.stopped = true;
-            NodeEvent::Stop
-        } else {
-            let id = id.into();
-            let data = loop {
-                let stdout_lock = stdout().lock();
-                let data = inquire::Text::new("Data")
-                    .with_help_message(
-                        "String/JSON, FILE:<path.arrow>, HEX:<hexbytes>, or esc to skip",
-                    )
-                    .prompt_skippable()?;
-                std::mem::drop(stdout_lock);
-                let typed_data = if let Some(data) = data {
-                    let array_data = if let Some(path) = data.strip_prefix("FILE:") {
-                        match read_arrow_ipc_file(Path::new(path.trim())) {
-                            Ok(d) => d,
-                            Err(err) => {
-                                eprintln!("{}", format!("{err}").red());
-                                continue;
-                            }
+        let id: DataId = loop {
+            let stdout_lock = stdout().lock();
+            let id = inquire::Text::new("Input ID")
+                .with_help_message("empty input ID to stop")
+                .prompt()?;
+            std::mem::drop(stdout_lock);
+            if id.is_empty() {
+                println!("{}", "given input ID is empty -> stopping".blue());
+                self.stopped = true;
+                return Ok(Some(NodeEvent::Stop));
+            }
+            // `id` is typed at an interactive prompt, so parse it fallibly:
+            // `DataId`'s `From<String>` (`.into()`) panics on an invalid id — e.g.
+            // one containing a space or `;` — which would crash the whole node.
+            // Re-prompt instead, matching how the `Data` prompt below rejects bad
+            // input rather than aborting.
+            match id.parse() {
+                Ok(id) => break id,
+                Err(err) => {
+                    eprintln!("{}", format!("invalid input ID: {err}").red());
+                }
+            }
+        };
+        let data = loop {
+            let stdout_lock = stdout().lock();
+            let data = inquire::Text::new("Data")
+                .with_help_message("String/JSON, FILE:<path.arrow>, HEX:<hexbytes>, or esc to skip")
+                .prompt_skippable()?;
+            std::mem::drop(stdout_lock);
+            let typed_data = if let Some(data) = data {
+                let array_data = if let Some(path) = data.strip_prefix("FILE:") {
+                    match read_arrow_ipc_file(Path::new(path.trim())) {
+                        Ok(d) => d,
+                        Err(err) => {
+                            eprintln!("{}", format!("{err}").red());
+                            continue;
                         }
-                    } else if let Some(hex) = data.strip_prefix("HEX:") {
-                        match decode_hex_as_uint8_array(hex.trim()) {
-                            Ok(d) => d,
-                            Err(err) => {
-                                eprintln!("{}", format!("{err}").red());
-                                continue;
-                            }
-                        }
-                    } else {
-                        // JSON or plain text
-                        match read_json_bytes_as_arrow(data.as_bytes()) {
-                            Ok(d) => d,
-                            Err(err) => {
-                                eprintln!("{}", format!("{err}").red());
-                                continue;
-                            }
-                        }
-                    };
-
-                    // The receive side decodes a self-describing Arrow IPC
-                    // stream, so encode the array into one here.
-                    match encode_arrow_ipc(&dora_arrow_convert::internal::from_array_data(
-                        array_data,
-                    )) {
-                        Ok(buf) => Some(buf),
+                    }
+                } else if let Some(hex) = data.strip_prefix("HEX:") {
+                    match decode_hex_as_uint8_array(hex.trim()) {
+                        Ok(d) => d,
                         Err(err) => {
                             eprintln!("{}", format!("{err}").red());
                             continue;
                         }
                     }
                 } else {
-                    None
+                    // JSON or plain text
+                    match read_json_bytes_as_arrow(data.as_bytes()) {
+                        Ok(d) => d,
+                        Err(err) => {
+                            eprintln!("{}", format!("{err}").red());
+                            continue;
+                        }
+                    }
                 };
-                break typed_data;
-            };
 
-            NodeEvent::Input {
-                id,
-                metadata: std::sync::Arc::new(Metadata::new(HLC::default().new_timestamp())),
-                data: data.map(|d| {
-                    std::sync::Arc::new(DataMessage::Vec(aligned_vec::AVec::from_slice(1, &d)))
-                }),
-            }
+                // The receive side decodes a self-describing Arrow IPC
+                // stream, so encode the array into one here.
+                match encode_arrow_ipc(&dora_arrow_convert::internal::from_array_data(array_data)) {
+                    Ok(buf) => Some(buf),
+                    Err(err) => {
+                        eprintln!("{}", format!("{err}").red());
+                        continue;
+                    }
+                }
+            } else {
+                None
+            };
+            break typed_data;
         };
-        Ok(Some(event))
+
+        Ok(Some(NodeEvent::Input {
+            id,
+            metadata: std::sync::Arc::new(Metadata::new(HLC::default().new_timestamp())),
+            data: data.map(|d| {
+                std::sync::Arc::new(DataMessage::Vec(aligned_vec::AVec::from_slice(1, &d)))
+            }),
+        }))
     }
 }
 
@@ -237,6 +244,23 @@ fn decode_hex_as_uint8_array(hex: &str) -> eyre::Result<arrow::array::ArrayData>
 mod tests {
     use super::*;
     use arrow::array::ArrayRef;
+
+    /// The interactive `Input ID` prompt parses the typed id fallibly
+    /// (`str::parse`) instead of `DataId::from(String)` / `.into()`, which
+    /// panics on an invalid id and would crash the whole node. Guard that
+    /// contract: ids a user could plausibly mistype are rejected as `Err`, not
+    /// a panic, so the prompt loop can re-ask.
+    #[test]
+    fn invalid_input_id_is_rejected_not_panicked() {
+        for bad in ["my input", "a;b", "a b/c", "café"] {
+            assert!(
+                bad.parse::<DataId>().is_err(),
+                "expected `{bad}` to be rejected via parse"
+            );
+        }
+        // a well-formed id still parses
+        assert!("valid_id.0-1/sub".parse::<DataId>().is_ok());
+    }
 
     #[test]
     fn test_decode_hex_valid() {

--- a/apis/rust/node/src/daemon_connection/interactive.rs
+++ b/apis/rust/node/src/daemon_connection/interactive.rs
@@ -6,7 +6,7 @@ use dora_core::uhlc::HLC;
 use dora_message::{
     common::{DataMessage, Timestamped},
     daemon_to_node::{DaemonReply, NodeEvent},
-    id::DataId,
+    id::{DataId, InvalidId},
     metadata::Metadata,
     node_to_daemon::DaemonRequest,
 };
@@ -116,12 +116,12 @@ impl InteractiveEvents {
                 self.stopped = true;
                 return Ok(Some(NodeEvent::Stop));
             }
-            // `id` is typed at an interactive prompt, so parse it fallibly:
-            // `DataId`'s `From<String>` (`.into()`) panics on an invalid id — e.g.
-            // one containing a space or `;` — which would crash the whole node.
-            // Re-prompt instead, matching how the `Data` prompt below rejects bad
-            // input rather than aborting.
-            match id.parse() {
+            // `id` is typed at an interactive prompt, so parse it fallibly via
+            // `parse_input_id` (see its docs): `DataId::from(String)` / `.into()`
+            // would panic on an invalid id and crash the whole node. Re-prompt
+            // instead, matching how the `Data` prompt below rejects bad input
+            // rather than aborting.
+            match parse_input_id(&id) {
                 Ok(id) => break id,
                 Err(err) => {
                     eprintln!("{}", format!("invalid input ID: {err}").red());
@@ -187,6 +187,18 @@ impl InteractiveEvents {
     }
 }
 
+/// Parse a `DataId` typed at the interactive `Input ID` prompt.
+///
+/// Deliberately fallible: `DataId`'s `From<String>` (`.into()`) panics on an
+/// invalid id — e.g. one containing a space or `;` — which would crash the
+/// whole node. Returning `Err` lets the prompt loop re-ask instead of aborting.
+/// Keeping this as a named helper (rather than an inline `.parse()`) gives the
+/// call site one testable seam and a place to document why `.into()` must not
+/// be used here.
+fn parse_input_id(raw: &str) -> Result<DataId, InvalidId> {
+    raw.parse()
+}
+
 /// Read the first batch from an Arrow IPC file and return it as `ArrayData`.
 ///
 /// This opens arbitrary user-provided file paths. It is intended for
@@ -245,21 +257,27 @@ mod tests {
     use super::*;
     use arrow::array::ArrayRef;
 
-    /// The interactive `Input ID` prompt parses the typed id fallibly
-    /// (`str::parse`) instead of `DataId::from(String)` / `.into()`, which
-    /// panics on an invalid id and would crash the whole node. Guard that
-    /// contract: ids a user could plausibly mistype are rejected as `Err`, not
-    /// a panic, so the prompt loop can re-ask.
+    /// The interactive `Input ID` prompt routes the typed id through
+    /// [`parse_input_id`] — a fallible `str::parse` — instead of
+    /// `DataId::from(String)` / `.into()`, which panics on an invalid id and
+    /// would crash the whole node. Guard that contract on the actual helper the
+    /// call site uses: ids a user could plausibly mistype come back as `Err` (so
+    /// the prompt loop re-asks) rather than panicking, and a well-formed id
+    /// parses. If `parse_input_id` regressed to `.into()`, the first assertion
+    /// would panic instead of returning `Err`, failing this test.
     #[test]
-    fn invalid_input_id_is_rejected_not_panicked() {
+    fn parse_input_id_rejects_invalid_without_panicking() {
         for bad in ["my input", "a;b", "a b/c", "café"] {
             assert!(
-                bad.parse::<DataId>().is_err(),
-                "expected `{bad}` to be rejected via parse"
+                parse_input_id(bad).is_err(),
+                "expected `{bad}` to be rejected by parse_input_id"
             );
         }
-        // a well-formed id still parses
-        assert!("valid_id.0-1/sub".parse::<DataId>().is_ok());
+        // a well-formed id still parses and round-trips unchanged
+        assert_eq!(
+            &*parse_input_id("valid_id.0-1/sub").expect("valid id should parse"),
+            "valid_id.0-1/sub"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Issue

The interactive (REPL) daemon connection — `dora run` in interactive mode / the `InteractiveEvents` harness in `apis/rust/node/src/daemon_connection/interactive.rs` — read the **Input ID** prompt and converted the raw string with `id.into()`, i.e. `DataId`'s `From<String>`.

That `From` impl **panics** on any id outside `[a-zA-Z0-9_./-]` (see `libraries/message/src/id.rs`, whose docs explicitly warn *"For untrusted input, use `id.parse::<DataId>()`"*). So typing an id with a space, a `;`, or a stray `//` (e.g. `my input`, `a//b`) crashed the whole node process — inconsistent with the sibling **Data** prompt a few lines below, which rejects bad input with a red error and re-asks.

## Fix

Parse the id fallibly with `str::parse::<DataId>()` inside a re-prompt loop:

- an **empty** id still stops (unchanged),
- an **invalid** id prints `invalid input ID: …` in red and re-prompts,
- a **valid** id proceeds to the data prompt as before.

Removing the outer `if/else` flattened a nesting level in the data-reading loop (whitespace-only reindent accounts for most of the diff).

## Validation

- Added a regression test (`invalid_input_id_is_rejected_not_panicked`) locking in that plausibly-mistyped ids (`"my input"`, `"a;b"`, `"café"`, …) are rejected via `parse` (Err) rather than panicking as `.into()` would, while a well-formed id still parses. The interactive loop itself blocks on terminal I/O and cannot be unit-tested directly.
- `cargo test -p dora-node-api` (incl. the new test), `cargo clippy -p dora-node-api -- -D warnings`, and `cargo fmt --all -- --check` all pass.

---

⚠️ **This is a machine-generated pull request**, authored by Claude Code as part of an automated code-review pass. It has been reviewed for correctness before submission, but please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WT1bKZjSHyyKoJSJeRizyk)_