### PR TITLE
perf(daemon): avoid per-message OutputId key clone in send_to_remote_receivers

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -5487,26 +5487,28 @@ impl Daemon {
             format!("send out failed: no running dataflow with ID `{dataflow_id}`")
         })?;
 
-        // Get or create publisher (lazy, cached per output)
-        let publisher = match dataflow.publishers.entry(output_id.clone()) {
-            std::collections::btree_map::Entry::Occupied(e) => e.get().clone(),
-            std::collections::btree_map::Entry::Vacant(e) => {
-                let publish_topic =
-                    zenoh_daemon_control_topic(dataflow.id, &output_id.0, &output_id.1);
-                tracing::debug!("declaring control publisher on {publish_topic}");
-                let publisher = self
-                    .zenoh_session
-                    .declare_publisher(publish_topic)
-                    .congestion_control(CongestionControl::Drop)
-                    .express(true)
-                    .priority(Priority::RealTime)
-                    .await
-                    .map_err(|err| eyre!(err))
-                    .context("failed to create zenoh publisher")?;
-                let arc = Arc::new(publisher);
-                e.insert(arc.clone());
-                arc
-            }
+        // Get or create publisher (lazy, cached per output). The cache is
+        // populated once per output and hit on every subsequent message, so
+        // probe it by reference first and only clone the `OutputId` key (two
+        // heap strings) on the one-time miss — `entry(output_id.clone())` would
+        // otherwise clone the key on every message just to hit the cache.
+        let publisher = if let Some(publisher) = dataflow.publishers.get(output_id) {
+            publisher.clone()
+        } else {
+            let publish_topic = zenoh_daemon_control_topic(dataflow.id, &output_id.0, &output_id.1);
+            tracing::debug!("declaring control publisher on {publish_topic}");
+            let publisher = self
+                .zenoh_session
+                .declare_publisher(publish_topic)
+                .congestion_control(CongestionControl::Drop)
+                .express(true)
+                .priority(Priority::RealTime)
+                .await
+                .map_err(|err| eyre!(err))
+                .context("failed to create zenoh publisher")?;
+            let arc = Arc::new(publisher);
+            dataflow.publishers.insert(output_id.clone(), arc.clone());
+            arc
         };
         let payload_len = serialized_event.len() as u64;
 


### PR DESCRIPTION
## Issue

`send_to_remote_receivers` (`binaries/daemon/src/lib.rs`) fetches the cached zenoh publisher for an output with:

```rust
let publisher = match dataflow.publishers.entry(output_id.clone()) { … };
```

The publisher cache is populated **once per output** and hit on **every** subsequent message, so the owned key is only needed on the one-time `Vacant` insert. Yet `entry(output_id.clone())` clones the `OutputId` — a `NodeId` + `DataId`, i.e. **two heap `String`s** — on every call, including the overwhelmingly common `Occupied` hit.

This runs once per output message that has a cross-machine consumer (and for every output while debug inspection is active), so on a high-rate inter-daemon topic it is two `String` allocations per message purely to probe a cache that almost always hits — the same class of hot-path key clone removed elsewhere on the send path.

## Fix

Probe the cache by reference with `get(output_id)` first and clone the key only on the genuine miss:

```rust
let publisher = if let Some(publisher) = dataflow.publishers.get(output_id) {
    publisher.clone()
} else {
    // declare the zenoh publisher …
    dataflow.publishers.insert(output_id.clone(), arc.clone());
    arc
};
```

The `.await` between the `get` and the `insert` is sound: the daemon owns `dataflow` via `&mut self` on its single-threaded event loop, and `self.zenoh_session` is a disjoint field (the previous `Vacant` arm already borrowed both simultaneously). Only the `Arc` is cloned on the hit path.

## Validation

- Behavior-preserving refactor; the full `cargo test -p dora-daemon` suite (246 tests) passes.
- `cargo clippy -p dora-daemon -- -D warnings` and `cargo fmt --all -- --check` pass.

---

⚠️ **This is a machine-generated pull request**, authored by Claude Code as part of an automated code-review pass. It has been reviewed for correctness before submission, but please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WT1bKZjSHyyKoJSJeRizyk)_