### PR TITLE
docs(node-api): document the error conditions of the Arrow IPC encode/decode APIs

### DIFF
--- a/apis/rust/node/src/node/arrow_utils.rs
+++ b/apis/rust/node/src/node/arrow_utils.rs
@@ -90,6 +90,14 @@ const _: () = assert!(ARROW_BUFFER_ALIGNMENT.is_power_of_two());
 /// batch, and an end-of-stream marker. This is self-describing and can be
 /// decoded without external type information.
 ///
+/// # Errors
+///
+/// Returns an error if the encoded IPC stream would exceed 256 MB — the limit
+/// every decode path (`decode_arrow_ipc`, `decode_arrow_ipc_zero_copy`, and the
+/// streaming input decoder) also enforces. Encoding fails loudly here rather
+/// than emitting a payload that every receiver would reject; split the array
+/// into smaller batches.
+///
 /// # Example
 ///
 /// ```
@@ -232,6 +240,12 @@ pub(crate) fn decode_arrow_ipc_data(ipc_buf: &[u8]) -> eyre::Result<ArrayData> {
 /// copying just the misaligned buffers rather than erroring. This keeps the
 /// receive path robust while preserving zero-copy for the common SHM case.
 ///
+/// # Errors
+///
+/// Like [`decode_arrow_ipc`], returns an error for an empty, truncated, or
+/// otherwise malformed stream, for a batch whose column count is not exactly
+/// one, and for any payload larger than 256 MB — it never panics on bad input.
+///
 /// # Example
 ///
 /// ```
@@ -243,6 +257,9 @@ pub(crate) fn decode_arrow_ipc_data(ipc_buf: &[u8]) -> eyre::Result<ArrayData> {
 /// let decoded = decode_arrow_ipc_zero_copy(IpcPayload::from_vec(ipc))?;
 /// let values: Vec<u64> = (&decoded).try_into()?;
 /// assert_eq!(values, vec![1, 2, 3]);
+///
+/// // A malformed stream is rejected with an error rather than panicking.
+/// assert!(decode_arrow_ipc_zero_copy(IpcPayload::from_vec(vec![0u8; 8])).is_err());
 /// # Ok(())
 /// # }
 /// ```


### PR DESCRIPTION
## Issue

`encode_arrow_ipc` and `decode_arrow_ipc_zero_copy` (`apis/rust/node/src/node/arrow_utils.rs`) are both fallible, but their doc comments described only the happy path — unlike the sibling `decode_arrow_ipc`, whose docs already spell out its failure modes (*"Returns an error for an empty, truncated, or otherwise malformed stream, and for any payload larger than 256 MB."*).

A caller reading only these two functions' docs had no signal that they return `Err` on oversized/malformed input, even though both enforce the same `MAX_IPC_BYTES` (256 MB) limit and the tests already exercise those paths.

## Fix

Docs-only additions:

- **`encode_arrow_ipc`**: an `# Errors` note that encoding fails when the IPC stream would exceed the 256 MB limit every decode path enforces (keeping the existing "split into smaller batches" guidance).
- **`decode_arrow_ipc_zero_copy`**: an `# Errors` note mirroring `decode_arrow_ipc` (empty/truncated/malformed stream, wrong column count, oversized payload — never a panic), plus a compile-checked doctest assertion that a malformed stream is rejected with an error rather than panicking.

## Validation

- `cargo test -p dora-node-api --doc` passes, including the new doctest assertion.
- `cargo clippy -p dora-node-api -- -D warnings` and `cargo fmt --all -- --check` pass.

---

⚠️ **This is a machine-generated pull request**, authored by Claude Code as part of an automated code-review pass. It has been reviewed for correctness before submission, but please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WT1bKZjSHyyKoJSJeRizyk)_