### PR TITLE
chore(deps): bump chacha20 to 0.10.2 (0.10.1 was yanked)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,9 +1099,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if 1.0.4",
  "cpufeatures 0.3.0",


### PR DESCRIPTION
`chacha20 0.10.1` was yanked upstream on 2026-08-27, right after RustCrypto shipped `0.10.2` to fix [an SSE4.1 intrinsic used in the SSE2 backend](https://github.com/RustCrypto/stream-ciphers/pull/580). Our `Cargo.lock` still pinned the yanked version, so `deny.toml`'s `yanked = "deny"` started failing the Audit job on every open PR and on `main`. That is what is red on #3301, which touches only Python tests and docs.

The crate is transitive only — `rand 0.10` (via `petname` → `dora-coordinator`) and `quinn-proto` (via zenoh) — so this is a lockfile-only bump.

Verified with `cargo metadata --locked`, a `cargo check --locked -p dora-coordinator -p dora-daemon`, and a sweep of all 862 crates.io entries in the lockfile against the sparse index: no yanked versions left.
