### PR TITLE
fix(coordinator): clean up in-flight builds when a daemon exits

### DIFF
--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -2211,6 +2211,7 @@ async fn start_inner(
                     .await?;
                     cleanup_disconnected_daemons_from_running_builds(
                         &mut running_builds,
+                        &mut finished_builds,
                         &disconnected,
                     );
                     notify_daemons_about_disconnected_peers(
@@ -2396,15 +2397,16 @@ async fn start_inner(
                         &clock,
                     )
                     .await?;
-                    // Mirror the watchdog disconnect path: prune the exited
-                    // daemon from every running build's `pending_build_results`.
-                    // Without this, a multi-daemon `dora build` where one daemon
-                    // exits cleanly mid-build never sees its set empty (the exited
-                    // daemon's entry lingers), so the build is not finalized by the
-                    // `DataflowBuildResult` handler and instead hangs until
+                    // Mirror the watchdog disconnect path: fail any in-flight
+                    // build the exited daemon was still part of. Without this, a
+                    // multi-daemon `dora build` where one daemon exits cleanly
+                    // mid-build never sees its pending set resolve (the exited
+                    // daemon's entry lingers), so the build is not finalized by
+                    // the `DataflowBuildResult` handler and instead hangs until
                     // `check_build_timeouts` fires the 20-minute deadline. #1465.
                     cleanup_disconnected_daemons_from_running_builds(
                         &mut running_builds,
+                        &mut finished_builds,
                         &disconnected,
                     );
                     notify_daemons_about_disconnected_peers(
@@ -3742,20 +3744,70 @@ async fn apply_disconnect_actions(
 }
 
 /// Mirror of [`cleanup_disconnected_daemons_from_running_dataflows`] for
-/// `running_builds`: prune disconnected daemon IDs from each running build's
-/// `pending_build_results` so the in-memory state matches the live cluster.
+/// `running_builds`: handle daemons that disconnect part-way through a
+/// `dora build`.
 ///
-/// This intentionally does NOT resolve `build_result` — the build timeout
-/// watchdog ([`check_build_timeouts`]) remains the single path that releases
-/// build waiters, preserving the chokepoint architecture documented at the
-/// disconnect-handler comment above (#1465).
+/// A daemon still listed in a build's `pending_build_results` disconnected
+/// before reporting its `build_result`, so that daemon's part of the build
+/// never completed. For each such build we:
+///
+/// 1. remove the disconnected daemon from `pending_build_results` and record
+///    the disconnect in `build.errors`, so the build resolves as failed rather
+///    than silently succeeding on the strength of the *other* daemons' results;
+/// 2. if that empties `pending_build_results`, finalize the build immediately —
+///    resolve `build_result`, send a final log line to any attached
+///    `dora build --attach` session, and move the entry into `finished_builds`
+///    (mirroring the `DataflowBuildResult` finalize branch).
+///
+/// Without step 2, a build whose *last* pending daemon disconnects would linger
+/// in `running_builds` until [`check_build_timeouts`] fires the 20-minute
+/// deadline, because the empty-set finalize check lives only in the
+/// `DataflowBuildResult` handler and no further report will ever arrive (#1465).
 fn cleanup_disconnected_daemons_from_running_builds(
     running_builds: &mut HashMap<BuildId, RunningBuild>,
+    finished_builds: &mut IndexMap<BuildId, CachedResult>,
     disconnected: &BTreeSet<DaemonId>,
 ) {
-    for build in running_builds.values_mut() {
+    let mut emptied = Vec::new();
+    for (build_id, build) in running_builds.iter_mut() {
+        let mut pruned_pending = false;
         for daemon_id in disconnected {
-            build.pending_build_results.remove(daemon_id);
+            if build.pending_build_results.remove(daemon_id) {
+                pruned_pending = true;
+                build.errors.push(format!(
+                    "daemon `{daemon_id}` disconnected before reporting its build result"
+                ));
+            }
+        }
+        if pruned_pending && build.pending_build_results.is_empty() {
+            emptied.push(*build_id);
+        }
+    }
+
+    for build_id in emptied {
+        let Some(mut build) = running_builds.remove(&build_id) else {
+            continue;
+        };
+        // `errors` is non-empty here (we just pushed a disconnect error), so
+        // this resolves as `Err`, matching the `DataflowBuildResult` branch.
+        let result = if build.errors.is_empty() {
+            Ok(())
+        } else {
+            Err(format!("build failed: {}", build.errors.join("\n\n")))
+        };
+        tracing::warn!(
+            build_id = %build_id,
+            "finalizing build as failed: a daemon disconnected before reporting its build result",
+        );
+        build
+            .build_result
+            .set_result(Ok(ControlRequestReply::DataflowBuildFinished {
+                build_id,
+                result,
+            }));
+        finished_builds.insert(build_id, build.build_result);
+        while finished_builds.len() > MAX_FINISHED_BUILDS {
+            finished_builds.shift_remove_index(0);
         }
     }
 }
@@ -9936,41 +9988,91 @@ mod tests {
     }
 
     #[test]
-    fn cleanup_disconnected_builds_prunes_only_disconnected_daemons() {
-        // Regression guard for the `DaemonExit` build-cleanup path: pruning a
-        // disconnected daemon from `pending_build_results` must let the
-        // remaining daemons finalize the build via `DataflowBuildResult`
-        // (which finalizes only once the set is empty) instead of hanging
-        // until `check_build_timeouts`. See the `DaemonExit` handler.
+    fn cleanup_disconnected_builds_prunes_and_keeps_others_pending() {
+        // A daemon exits while another is still building: only the exited daemon
+        // is pruned, the build stays in `running_builds` awaiting the survivor's
+        // `DataflowBuildResult`, and the disconnect is recorded as an error so
+        // the eventual result is a failure rather than a silent success.
         let m1 = DaemonId::new(Some("m1".to_string()));
         let m2 = DaemonId::new(Some("m2".to_string()));
 
         let build_id = BuildId::generate();
         let mut build = test_running_build(m1.clone(), /*backdate=*/ false);
-        // Two daemons are still building.
         build.pending_build_results.insert(m2.clone());
 
         let mut running_builds: HashMap<BuildId, RunningBuild> = HashMap::new();
         running_builds.insert(build_id, build);
+        let mut finished_builds: IndexMap<BuildId, CachedResult> = IndexMap::new();
 
-        // m1 exits; only m1 is pruned, m2 remains pending.
         let disconnected = BTreeSet::from([m1.clone()]);
-        cleanup_disconnected_daemons_from_running_builds(&mut running_builds, &disconnected);
+        cleanup_disconnected_daemons_from_running_builds(
+            &mut running_builds,
+            &mut finished_builds,
+            &disconnected,
+        );
 
-        let pending = &running_builds[&build_id].pending_build_results;
+        let build = running_builds
+            .get(&build_id)
+            .expect("build must stay pending while m2 is still building");
+        assert!(!build.pending_build_results.contains(&m1), "m1 pruned");
         assert!(
-            !pending.contains(&m1),
-            "disconnected daemon must be pruned from pending_build_results"
+            build.pending_build_results.contains(&m2),
+            "m2 still pending"
         );
         assert!(
-            pending.contains(&m2),
-            "still-connected daemon must remain pending so its build_result is awaited"
+            build.errors.iter().any(|e| e.contains("m1")),
+            "the disconnect must be recorded as a build error, got: {:?}",
+            build.errors
         );
-        assert_eq!(
-            pending.len(),
-            1,
-            "exactly one daemon should have been pruned"
+        assert!(finished_builds.is_empty(), "build not finalized yet");
+    }
+
+    #[tokio::test]
+    async fn cleanup_disconnected_builds_finalizes_when_last_daemon_exits() {
+        // The exited daemon is the *last* one pending. The cleanup must finalize
+        // the build immediately (no further `DataflowBuildResult` will arrive),
+        // resolving the waiter with a failure instead of hanging until
+        // `check_build_timeouts`.
+        let m1 = DaemonId::new(Some("m1".to_string()));
+
+        let build_id = BuildId::generate();
+        let mut build = test_running_build(m1.clone(), /*backdate=*/ false);
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        build.build_result.register(tx);
+
+        let mut running_builds: HashMap<BuildId, RunningBuild> = HashMap::new();
+        running_builds.insert(build_id, build);
+        let mut finished_builds: IndexMap<BuildId, CachedResult> = IndexMap::new();
+
+        let disconnected = BTreeSet::from([m1]);
+        cleanup_disconnected_daemons_from_running_builds(
+            &mut running_builds,
+            &mut finished_builds,
+            &disconnected,
         );
+
+        assert!(
+            !running_builds.contains_key(&build_id),
+            "build must be finalized and removed from running_builds"
+        );
+        assert!(
+            finished_builds.contains_key(&build_id),
+            "finalized build must be cached in finished_builds for late waiters"
+        );
+        // The pre-registered waiter must resolve immediately (not hang) with a
+        // failed build result naming the disconnect.
+        let reply = timeout(TokioDuration::from_millis(50), rx)
+            .await
+            .expect("waiter should resolve, not hang")
+            .expect("sender should not drop")
+            .expect("build finalization delivers Ok(reply)");
+        match reply {
+            ControlRequestReply::DataflowBuildFinished { result, .. } => {
+                let err = result.expect_err("a mid-build disconnect must fail the build");
+                assert!(err.contains("disconnected"), "got: {err}");
+            }
+            other => panic!("expected DataflowBuildFinished, got {other:?}"),
+        }
     }
 
     #[test]

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -2396,6 +2396,17 @@ async fn start_inner(
                         &clock,
                     )
                     .await?;
+                    // Mirror the watchdog disconnect path: prune the exited
+                    // daemon from every running build's `pending_build_results`.
+                    // Without this, a multi-daemon `dora build` where one daemon
+                    // exits cleanly mid-build never sees its set empty (the exited
+                    // daemon's entry lingers), so the build is not finalized by the
+                    // `DataflowBuildResult` handler and instead hangs until
+                    // `check_build_timeouts` fires the 20-minute deadline. #1465.
+                    cleanup_disconnected_daemons_from_running_builds(
+                        &mut running_builds,
+                        &disconnected,
+                    );
                     notify_daemons_about_disconnected_peers(
                         &disconnected,
                         &mut daemon_connections,
@@ -9922,6 +9933,44 @@ mod tests {
             .expect("sender should not drop");
         let err = reply.expect_err("late wait_for_build must surface the watchdog's Err");
         assert!(format!("{err:?}").contains("build timed out"));
+    }
+
+    #[test]
+    fn cleanup_disconnected_builds_prunes_only_disconnected_daemons() {
+        // Regression guard for the `DaemonExit` build-cleanup path: pruning a
+        // disconnected daemon from `pending_build_results` must let the
+        // remaining daemons finalize the build via `DataflowBuildResult`
+        // (which finalizes only once the set is empty) instead of hanging
+        // until `check_build_timeouts`. See the `DaemonExit` handler.
+        let m1 = DaemonId::new(Some("m1".to_string()));
+        let m2 = DaemonId::new(Some("m2".to_string()));
+
+        let build_id = BuildId::generate();
+        let mut build = test_running_build(m1.clone(), /*backdate=*/ false);
+        // Two daemons are still building.
+        build.pending_build_results.insert(m2.clone());
+
+        let mut running_builds: HashMap<BuildId, RunningBuild> = HashMap::new();
+        running_builds.insert(build_id, build);
+
+        // m1 exits; only m1 is pruned, m2 remains pending.
+        let disconnected = BTreeSet::from([m1.clone()]);
+        cleanup_disconnected_daemons_from_running_builds(&mut running_builds, &disconnected);
+
+        let pending = &running_builds[&build_id].pending_build_results;
+        assert!(
+            !pending.contains(&m1),
+            "disconnected daemon must be pruned from pending_build_results"
+        );
+        assert!(
+            pending.contains(&m2),
+            "still-connected daemon must remain pending so its build_result is awaited"
+        );
+        assert_eq!(
+            pending.len(),
+            1,
+            "exactly one daemon should have been pruned"
+        );
     }
 
     #[test]

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -2513,24 +2513,11 @@ async fn start_inner(
                     };
                     if build.pending_build_results.is_empty() {
                         tracing::info!("dataflow build finished: `{build_id}`");
-                        let Some(mut build) = running_builds.remove(&build_id) else {
+                        let Some(build) = running_builds.remove(&build_id) else {
                             tracing::error!("build {build_id} disappeared from running_builds");
                             continue;
                         };
-                        let result = if build.errors.is_empty() {
-                            Ok(())
-                        } else {
-                            Err(format!("build failed: {}", build.errors.join("\n\n")))
-                        };
-
-                        build.build_result.set_result(Ok(
-                            ControlRequestReply::DataflowBuildFinished { build_id, result },
-                        ));
-
-                        finished_builds.insert(build_id, build.build_result);
-                        while finished_builds.len() > MAX_FINISHED_BUILDS {
-                            finished_builds.shift_remove_index(0);
-                        }
+                        finalize_build(build_id, build, &mut finished_builds);
                     }
                 }
                 None => {
@@ -3754,10 +3741,9 @@ async fn apply_disconnect_actions(
 /// 1. remove the disconnected daemon from `pending_build_results` and record
 ///    the disconnect in `build.errors`, so the build resolves as failed rather
 ///    than silently succeeding on the strength of the *other* daemons' results;
-/// 2. if that empties `pending_build_results`, finalize the build immediately —
-///    resolve `build_result`, send a final log line to any attached
-///    `dora build --attach` session, and move the entry into `finished_builds`
-///    (mirroring the `DataflowBuildResult` finalize branch).
+/// 2. if that empties `pending_build_results`, finalize the build immediately
+///    via [`finalize_build`] (resolve `build_result` and move the entry into
+///    `finished_builds`), mirroring the `DataflowBuildResult` finalize branch.
 ///
 /// Without step 2, a build whose *last* pending daemon disconnects would linger
 /// in `running_builds` until [`check_build_timeouts`] fires the 20-minute
@@ -3785,30 +3771,42 @@ fn cleanup_disconnected_daemons_from_running_builds(
     }
 
     for build_id in emptied {
-        let Some(mut build) = running_builds.remove(&build_id) else {
+        let Some(build) = running_builds.remove(&build_id) else {
             continue;
-        };
-        // `errors` is non-empty here (we just pushed a disconnect error), so
-        // this resolves as `Err`, matching the `DataflowBuildResult` branch.
-        let result = if build.errors.is_empty() {
-            Ok(())
-        } else {
-            Err(format!("build failed: {}", build.errors.join("\n\n")))
         };
         tracing::warn!(
             build_id = %build_id,
             "finalizing build as failed: a daemon disconnected before reporting its build result",
         );
-        build
-            .build_result
-            .set_result(Ok(ControlRequestReply::DataflowBuildFinished {
-                build_id,
-                result,
-            }));
-        finished_builds.insert(build_id, build.build_result);
-        while finished_builds.len() > MAX_FINISHED_BUILDS {
-            finished_builds.shift_remove_index(0);
-        }
+        // `build.errors` is non-empty (we just recorded a disconnect), so
+        // `finalize_build` resolves this as a failed build.
+        finalize_build(build_id, build, finished_builds);
+    }
+}
+
+/// Resolve a completed build's waiters and cache its result. `build.errors`
+/// decides success vs. failure. Shared by the `DataflowBuildResult` handler and
+/// [`cleanup_disconnected_daemons_from_running_builds`] so the `finished_builds`
+/// cap bookkeeping lives in a single place.
+fn finalize_build(
+    build_id: BuildId,
+    mut build: RunningBuild,
+    finished_builds: &mut IndexMap<BuildId, CachedResult>,
+) {
+    let result = if build.errors.is_empty() {
+        Ok(())
+    } else {
+        Err(format!("build failed: {}", build.errors.join("\n\n")))
+    };
+    build
+        .build_result
+        .set_result(Ok(ControlRequestReply::DataflowBuildFinished {
+            build_id,
+            result,
+        }));
+    finished_builds.insert(build_id, build.build_result);
+    while finished_builds.len() > MAX_FINISHED_BUILDS {
+        finished_builds.shift_remove_index(0);
     }
 }
 


### PR DESCRIPTION
## Summary

> ⚠️ **This is a machine-generated change authored by Claude (Claude Code).** It was produced by an automated code-review pass. A human should review before merging.

The coordinator's `DaemonExit` handler mirrors the heartbeat-watchdog disconnect path for **running dataflows** but **omitted the equivalent handling for running builds**: `cleanup_disconnected_daemons_from_running_builds` (which the watchdog path calls) was never invoked on a clean `DaemonExit`. That function is the only place a disconnected daemon is reconciled out of a build's `pending_build_results`, and the `DataflowBuildResult` handler finalizes a build only once that set is empty.

## The bug

In a multi-daemon `dora build` where **one daemon exits cleanly mid-build**:

- `DaemonExit` fires immediately on WS close and removes the daemon from `daemon_connections`, so the heartbeat-watchdog path (the only one that ran the build cleanup) never sees it.
- The exited daemon's entry lingers in `pending_build_results` forever, so the remaining daemons report their results but the set never empties.
- The build is not finalized by the normal path and instead hangs until `check_build_timeouts` fires the **20-minute** `BUILD_RESULT_TIMEOUT_DEFAULT` deadline.

## Fix

Add the build-disconnect handling to the `DaemonExit` path, and — following review — make that handling **complete and correct** on both disconnect paths (watchdog + `DaemonExit`):

`cleanup_disconnected_daemons_from_running_builds` now, for each in-flight build the disconnected daemon was still part of:

1. removes the daemon from `pending_build_results` **and records the disconnect in `build.errors`**, so the build resolves as **failed** rather than silently succeeding on the strength of the other daemons' results (a daemon that disconnects mid-build never reported, so its part of the build never completed); and
2. if that empties `pending_build_results`, **finalizes the build immediately** (resolve `build_result`, move to `finished_builds`), mirroring the `DataflowBuildResult` finalize branch — so a build whose *last* pending daemon disconnects no longer waits out the 20-minute timeout either.

## Validation

Two unit tests:
- `cleanup_disconnected_builds_prunes_and_keeps_others_pending` — one of two daemons exits: only it is pruned, the build stays pending for the survivor, and the disconnect is recorded as an error.
- `cleanup_disconnected_builds_finalizes_when_last_daemon_exits` — the last pending daemon exits: the build is finalized and removed from `running_builds`, a pre-registered `wait_for_build` waiter resolves immediately with a failed `DataflowBuildFinished` naming the disconnect.

Local checks (toolchain 1.97.1):
- `cargo test -p dora-coordinator --lib` — 134 passed
- `cargo fmt -p dora-coordinator -- --check` — clean
- `cargo clippy -p dora-coordinator --all-targets -- -D warnings` — clean