### PR TITLE
ci(qa): guard the nightly reporting wiring against silent rot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -866,6 +866,16 @@ jobs:
       - name: Rust API of the crates 1.0 covers
         run: make qa-semver
 
+  # Structural check on nightly.yml's failure reporting: asserts that no job
+  # is silently unmonitored. Parses the workflow only -- no toolchain, no
+  # cache, sub-second -- so it stays within the lean-PR-CI budget.
+  ci-reporting:
+    name: Nightly reporting wiring
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - run: make qa-ci-reporting
+
   # ===== License check =====
   # Restored from upstream dora CI — explicit license validation.
   # cargo-deny (in the audit job) covers most license policy, but

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -874,6 +874,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      # The gate's own tests run first: if the parser stopped understanding
+      # the workflow, `make qa-ci-reporting` would print OK and mean nothing.
+      - run: make qa-ci-reporting-selftest
       - run: make qa-ci-reporting
 
   # ===== License check =====

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1978,7 +1978,10 @@ jobs:
   # `file-issue-on-failure` — `needs.<job>.result` reads `success` for a
   # continue-on-error job — which is why they failed silently from the
   # day they were added (#2790, 2026-07-21) until #2742 went looking.
-  # Drop `continue-on-error` once they are trustworthy.
+  # Drop `continue-on-error` once they are trustworthy (#2987). Until then
+  # the exemption is recorded in `.nightly-advisory-jobs`, which
+  # `scripts/qa/ci-nightly-reporting.sh` checks against this list — adding
+  # the flag to any other reported job now fails PR CI.
   ros2-zenoh-humble:
     name: ROS2 Zenoh Interop (Humble)
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2146,6 +2146,9 @@ jobs:
               smoke-suite)
                 echo 'cargo test -p dora-examples --test example-smoke -- --test-threads=1'
                 ;;
+              hub-smoke)
+                echo 'cargo test -p dora-examples --test hub-smoke -- --test-threads=1'
+                ;;
               log-sinks)
                 # Three dataflows in this job; run each individually on failure.
                 printf 'dora run examples/log-sink-file/dataflow.yml --uv --stop-after 15s\ndora run examples/log-sink-alert/dataflow.yml --uv --stop-after 15s\ndora run examples/log-sink-tcp/dataflow.yml --uv --stop-after 15s\n'
@@ -2227,6 +2230,8 @@ jobs:
             case "$1" in
               build-cli) echo '^Build dora CLI \(shared\)$' ;;
               smoke-suite) echo '^Smoke suite \(tests/example-smoke\.rs\)$' ;;
+              hub-smoke) echo '^Hub smoke suite \(tests/hub-smoke\.rs\)$' ;;
+              wheel-smoke) echo '^Python wheel smoke \(dora-rs \+ dora-rs-cli\)$' ;;
               log-sinks) echo '^Log-sink examples \(Python sources\)$' ;;
               service-action) echo '^Service / Action patterns \(Rust-only\)$' ;;
               streaming) echo '^Streaming example \(Python\)$' ;;

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2066,6 +2066,7 @@ jobs:
       - build-cli
       - wheel-smoke
       - smoke-suite
+      - hub-smoke
       - log-sinks
       - service-action
       - streaming
@@ -2628,6 +2629,7 @@ jobs:
       - build-cli
       - wheel-smoke
       - smoke-suite
+      - hub-smoke
       - log-sinks
       - service-action
       - streaming
@@ -2649,6 +2651,12 @@ jobs:
       - bench-example
       - cross-check
       - ros2-bridge
+      # Watched here too, not just by the reporter: a job the reporter watches
+      # and the closer does not produces a FLAPPING issue (filed by one
+      # nightly, closed by the next while still broken). Harmless while they
+      # are advisory (`result` reads `success`), correct once that drops (#2987).
+      - ros2-zenoh-humble
+      - ros2-zenoh-kilted
       - msrv
     # Inverse of `file-issue-on-failure`: on a scheduled run where the suite
     # actually ran (build-cli succeeded) and nothing failed or was cancelled

--- a/.nightly-advisory-jobs
+++ b/.nightly-advisory-jobs
@@ -1,0 +1,24 @@
+# Nightly jobs deliberately allowed to carry job-level `continue-on-error: true`
+# while they are listed in `file-issue-on-failure`'s `needs`.
+#
+# Checked by scripts/qa/ci-nightly-reporting.sh (`make qa-ci-reporting`).
+#
+# An entry here means: this job CANNOT report a failure. `needs.<job>.result`
+# reads `success` for a continue-on-error job, so the nightly issue will never
+# name it. That is a real monitoring hole — the point of this file is that the
+# hole is explicit, attributable, and shows up in a grep, instead of being an
+# invisible property of a flag buried in the job definition.
+#
+# Every entry needs a reason and the issue tracking its removal. Entries are
+# meant to be deleted, not accumulated.
+
+# Added 2026-07-21 (#2790), made advisory after they were found failing every
+# night on `maturin: command not found` (#2742). Both blockers on a green run
+# are now fixed: the missing maturin setup, and the exact rmw_zenoh apt pins
+# that broke roughly fortnightly as upstream published new builds (#3321).
+# #3321 also established that these jobs do not flake — across twenty scheduled
+# runs every failure was pin rot, none was docker/apt/ROS-mirror noise — so the
+# only thing still missing is a run of green nightlies on top of that fix.
+# Remove both once they have that stretch of green — tracked in #2987.
+ros2-zenoh-humble
+ros2-zenoh-kilted

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -39,6 +39,8 @@ merge:
     - Audit (cargo-audit + cargo-deny)
     - Unwrap budget
     - License check
+    - Breaking changes
+    - Nightly reporting wiring
     # Expensive (run on trunk-merge/* batches)
     - Test (ubuntu-latest)
     - E2E Tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,7 @@ make qa-test-python
 # cargo test -p <crate-name>
 ```
 
-**Shortcut**: `make qa-fast` runs fmt + clippy + supply-chain audit + unwrap budget + secret-files + typos + publish-graph + package-includes + the no-compile half of the 1.x compatibility gate in ~30 seconds. Use it as a sanity check before every commit. Then run the full `cargo test` above before `git push`.
+**Shortcut**: `make qa-fast` runs fmt + clippy + supply-chain audit + unwrap budget + secret-files + typos + publish-graph + package-includes + the no-compile half of the 1.x compatibility gate + nightly-reporting wiring in ~30 seconds. Use it as a sanity check before every commit. Then run the full `cargo test` above before `git push`.
 
 If you add new example dataflows, also run `./scripts/smoke-all.sh --rust-only` to verify smoke tests pass.
 
@@ -200,6 +200,7 @@ The deeper QA gates — `make qa-full`, `make qa-deep`, `make qa-nightly`, `make
 - crates.io publish-graph check (`make qa-publish-graph`, a step in the `Check` job): no published crate may depend on a `publish = false` one, and the ordered publish list in `release.yml` must name every dependency before its dependents (#3304)
 - Breaking-change gate (`make qa-breaking ARGS="--fast"` + `cargo-semver-checks`): every surface dora 1.x freezes — the C header, the cxx bridge, the dataflow YAML schema, the postcard wire format, the `dora` command snapshot, the Python floor, and the Rust API of the covered crates — diffed against the last release tag
 - Build-time include check (`make qa-package-includes`, a step in the `Check` job): every `include_str!` / `include_bytes!` target of a publishable crate must be a git-tracked file inside that crate, since `cargo package` ships nothing else. `dora-operator-api-c` read its cmake templates from the sibling `apis/c/node/` crate, which built here and broke `cargo install dora-cli` on 1.0.0 (#3400)
+- Nightly reporting wiring (`make qa-ci-reporting`, its own checkout-only job): asserts every `nightly.yml` job is actually watched by `file-issue-on-failure` and `close-issue-on-success`, and that none of them is silently advisory, so a regression cannot go unreported (#2987)
 - License check (`cargo-lichking`)
 - Rust toolchain pinned to 1.97.1 (see `.github/workflows/ci.yml`)
 

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@
         qa-examples qa-cluster-e2e qa-cluster-record-replay qa-docker-slim \
         ros2-zenoh-humble ros2-zenoh-kilted \
         qa-fmt qa-audit qa-unwrap qa-secret-files qa-publish-graph qa-package-includes \
-        qa-ci-reporting qa-clippy qa-test qa-test-python \
+        qa-ci-reporting qa-ci-reporting-selftest qa-clippy qa-test qa-test-python \
         qa-test-python-node qa-coverage qa-mutants qa-semver qa-breaking qa-breaking-update \
         qa-adversarial qa-kani qa-pgo qa-install qa-pgo-install qa-kani-install \
         qa-verify-release
@@ -164,6 +164,12 @@ qa-package-includes:
 # only -- runs no nightly job, takes well under a second.
 qa-ci-reporting:
 	@scripts/qa/ci-nightly-reporting.sh
+
+# The gate's own tests: feed known-broken workflows through the real script
+# and assert it goes red. A structural check that only ever prints OK is
+# indistinguishable from one that stopped parsing.
+qa-ci-reporting-selftest:
+	@python3 scripts/qa/tests/test_ci_nightly_reporting.py
 
 qa-clippy:
 	@cargo clippy --all --all-targets \

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@
         qa-examples qa-cluster-e2e qa-cluster-record-replay qa-docker-slim \
         ros2-zenoh-humble ros2-zenoh-kilted \
         qa-fmt qa-audit qa-unwrap qa-secret-files qa-publish-graph qa-package-includes \
-        qa-clippy qa-test qa-test-python \
+        qa-ci-reporting qa-clippy qa-test qa-test-python \
         qa-test-python-node qa-coverage qa-mutants qa-semver qa-breaking qa-breaking-update \
         qa-adversarial qa-kani qa-pgo qa-install qa-pgo-install qa-kani-install \
         qa-verify-release
@@ -159,6 +159,11 @@ qa-publish-graph:
 # file inside that crate, or the published `.crate` will not have it.
 qa-package-includes:
 	@scripts/qa/package-includes.sh
+
+# Structural check on nightly.yml failure reporting. Parses the workflow
+# only -- runs no nightly job, takes well under a second.
+qa-ci-reporting:
+	@scripts/qa/ci-nightly-reporting.sh
 
 qa-clippy:
 	@cargo clippy --all --all-targets \

--- a/docs/agentic-qa-policy.md
+++ b/docs/agentic-qa-policy.md
@@ -64,7 +64,7 @@ impact. Current list (update when a new subsystem earns it):
 
 ### Class A — Low-risk
 
-- [ ] `make qa-fast` (fmt + clippy + audit + unwrap-budget + secret-files + typos + publish-graph + package-includes).
+- [ ] `make qa-fast` (fmt + clippy + audit + unwrap-budget + secret-files + typos + publish-graph + package-includes + ci-reporting).
 
 That's the whole bar. Don't over-test cosmetic changes — reviewers can
 eyeball them and CI backs it up. `typos` is now part of `qa-fast`

--- a/docs/agentic-qa-policy.md
+++ b/docs/agentic-qa-policy.md
@@ -64,7 +64,7 @@ impact. Current list (update when a new subsystem earns it):
 
 ### Class A — Low-risk
 
-- [ ] `make qa-fast` (fmt + clippy + audit + unwrap-budget + secret-files + typos + publish-graph + package-includes + ci-reporting).
+- [ ] `make qa-fast` (fmt + clippy + audit + unwrap-budget + secret-files + typos + publish-graph + package-includes + breaking-changes + ci-reporting).
 
 That's the whole bar. Don't over-test cosmetic changes — reviewers can
 eyeball them and CI backs it up. `typos` is now part of `qa-fast`

--- a/docs/contributor-qa-cheatsheet.md
+++ b/docs/contributor-qa-cheatsheet.md
@@ -70,6 +70,7 @@ Runs:
 - typo check
 - crates.io publish-graph check
 - build-time include check (every `include_str!` target ships with its crate)
+- nightly reporting-wiring check (`nightly.yml`: no job unmonitored)
 
 ### Before push
 

--- a/docs/contributor-qa-cheatsheet.md
+++ b/docs/contributor-qa-cheatsheet.md
@@ -70,6 +70,8 @@ Runs:
 - typo check
 - crates.io publish-graph check
 - build-time include check (every `include_str!` target ships with its crate)
+- frozen 1.x surface check (C header, cxx bridge, YAML schema, wire format,
+  CLI snapshot, Python floor — the no-compile half)
 - nightly reporting-wiring check (`nightly.yml`: no job unmonitored)
 
 ### Before push

--- a/docs/qa-runbook.md
+++ b/docs/qa-runbook.md
@@ -255,11 +255,13 @@ Two failures that read oddly:
 
 **Cause**: a change to `.github/workflows/nightly.yml` left one of its jobs outside the failure-reporting wiring. Both reporter jobs read `needs.<job>.result`, so a job missing from a `needs` list — or carrying job-level `continue-on-error: true` — can never be named in the `nightly-regression` issue. The gate reports one of three things.
 
-**"job-level `continue-on-error: true` on jobs listed in `file-issue-on-failure` needs"**: `needs.<job>.result` reads `success` for such a job even when it failed, so it is listed as reported while being unreportable — how the two `ros2-zenoh-*` jobs failed silently for two weeks across thirteen nightly issues (#2742). Drop the flag, or, if the job has to stay advisory while it earns trust, add it to [`.nightly-advisory-jobs`](../.nightly-advisory-jobs) with a reason and the issue tracking its removal. Step-level `continue-on-error` is not flagged and needs no exemption — it does not touch `needs.<job>.result`.
+**"job-level `continue-on-error` on jobs listed in `file-issue-on-failure` needs"**: `needs.<job>.result` reads `success` for such a job even when it failed, so it is listed as reported while being unreportable — how the two `ros2-zenoh-*` jobs failed silently for two weeks across thirteen nightly issues (#2742). Drop the flag, or, if the job has to stay advisory while it earns trust, add it to [`.nightly-advisory-jobs`](../.nightly-advisory-jobs) with a reason and the issue tracking its removal. Any value but `false` counts — `True`, a quoted `"true"`, a value with a trailing comment, and a `${{ }}` expression, which is a flag whenever it evaluates true. Step-level `continue-on-error` is not flagged and needs no exemption — it does not touch `needs.<job>.result`.
 
 **"nightly jobs missing from `file-issue-on-failure` needs"**: add the job to that list. Omission leaves it unmonitored in exactly the same way a flag does; `hub-smoke` sat unreported like this from the day it was added.
 
 **"jobs watched by `file-issue-on-failure` but not by `close-issue-on-success`"**: add it to the closer as well. A job only the reporter watches produces a *flapping* issue — filed by one nightly, closed by the next while the job is still red, so the tracker asserts the problem is fixed.
+
+**"unreadable job header"** (exit 2, not 1): the parser found a line where a job name belongs that it cannot read — a quoted name, say. It stops rather than skipping the job, because a skipped job is missing from the second check *and* has its `needs` and `continue-on-error` read as the job above it, which is the silent pass this gate exists to prevent. Write the name as `  <job>:`, with a trailing comment if you want one, or teach the parser.
 
 Reproduce locally with `make qa-ci-reporting`; the three invariants and the failure each one is named after are documented at the top of [`scripts/qa/ci-nightly-reporting.sh`](../scripts/qa/ci-nightly-reporting.sh).
 

--- a/docs/qa-runbook.md
+++ b/docs/qa-runbook.md
@@ -51,7 +51,7 @@ rustup component add miri --toolchain nightly   # optional; for unsafe-code anal
 
 | Target | Runs | Budget | When to use |
 |---|---|---|---|
-| `make qa-fast` | fmt + clippy + audit + unwrap-budget + secret-files + typos + publish-graph + package-includes + breaking-changes | ~15 s | Pre-commit |
+| `make qa-fast` | fmt + clippy + audit + unwrap-budget + secret-files + typos + publish-graph + package-includes + breaking-changes + ci-reporting | ~15 s | Pre-commit |
 | `make qa-full` | `qa-fast` + full test suite + coverage | ~5-10 min | Pre-push |
 | `make qa-deep` | `qa-full` + mutation testing on diff + semver | ~15 min | Target Tier 1 local gate (stronger than today's CI: adds coverage, adversarial, mutants, semver) |
 | `make qa-tier1` | alias for `qa-deep` | — | Back-compat; prefer `qa-deep` |
@@ -250,6 +250,18 @@ Two failures that read oddly:
 
 - **"major version bump ..."** — a 2.0 withdraws the promises the gate measures against, so it stops there rather than reporting a green or a red that means nothing. When the bump is deliberate, `ALLOW_MAJOR_BUMP=1 make qa-breaking` (and set the same variable on the `breaking-changes` job for the PR that carries it).
 - **"the generated surface files are stale"** — regenerating changed the tree, so the comparison ran against an out-of-date snapshot and its "ok" meant nothing. Commit the regenerated files and read the report again.
+
+### 3.13 `ci-reporting` failed
+
+**Cause**: a change to `.github/workflows/nightly.yml` left one of its jobs outside the failure-reporting wiring. Both reporter jobs read `needs.<job>.result`, so a job missing from a `needs` list — or carrying job-level `continue-on-error: true` — can never be named in the `nightly-regression` issue. The gate reports one of three things.
+
+**"job-level `continue-on-error: true` on jobs listed in `file-issue-on-failure` needs"**: `needs.<job>.result` reads `success` for such a job even when it failed, so it is listed as reported while being unreportable — how the two `ros2-zenoh-*` jobs failed silently for two weeks across thirteen nightly issues (#2742). Drop the flag, or, if the job has to stay advisory while it earns trust, add it to [`.nightly-advisory-jobs`](../.nightly-advisory-jobs) with a reason and the issue tracking its removal. Step-level `continue-on-error` is not flagged and needs no exemption — it does not touch `needs.<job>.result`.
+
+**"nightly jobs missing from `file-issue-on-failure` needs"**: add the job to that list. Omission leaves it unmonitored in exactly the same way a flag does; `hub-smoke` sat unreported like this from the day it was added.
+
+**"jobs watched by `file-issue-on-failure` but not by `close-issue-on-success`"**: add it to the closer as well. A job only the reporter watches produces a *flapping* issue — filed by one nightly, closed by the next while the job is still red, so the tracker asserts the problem is fixed.
+
+Reproduce locally with `make qa-ci-reporting`; the three invariants and the failure each one is named after are documented at the top of [`scripts/qa/ci-nightly-reporting.sh`](../scripts/qa/ci-nightly-reporting.sh).
 
 ### 3.14 `Docker Image CI/CD` failed
 

--- a/docs/qa-runbook.md
+++ b/docs/qa-runbook.md
@@ -414,6 +414,13 @@ If you want to add a new QA check:
 4. Add it to `scripts/qa/all.sh` in the appropriate tier (fast / full / tier1) — unless it needs infrastructure the ladder cannot assume (a Docker daemon, an sshd), in which case leave it out and say so in the Makefile target, as `qa-docker-slim` and `qa-cluster-e2e` do.
 5. Add a CI job to `.github/workflows/ci.yml` that calls `make qa-<name>`.
 6. Document it in this runbook (Section 3).
+7. If the gate should be able to block a merge, add its **check name** — the
+   job's `name:`, spelled exactly — to `merge.required_statuses` in
+   `.trunk/trunk.yaml`. Branch protection only gates entry to the queue;
+   that list is what Trunk waits on while it tests a batch, so a gate
+   missing from it can go red without holding the batch it is red on. Only
+   add a check that is produced on *every* batch branch — the header of
+   that file explains which ones are not.
 
 ---
 

--- a/scripts/qa/all.sh
+++ b/scripts/qa/all.sh
@@ -7,7 +7,8 @@
 # Modes (increasing thoroughness):
 #   --fast            ~1 min     pre-commit sanity (fmt, clippy, audit, unwrap,
 #                                secret-files, typos, publish-graph,
-#                                package-includes, breaking-changes)
+#                                package-includes, breaking-changes,
+#                                ci-reporting)
 #   --full            ~5-10 min  pre-push (fast + tests + coverage + optional adversarial)
 #   --deep            ~15 min    target Tier 1 gate, stronger than today's CI
 #                                (full + mutants on diff + breaking-changes; see strategy doc §5 for why the
@@ -123,6 +124,7 @@ Will run:
   9. breaking-changes -- 1.x frozen surfaces vs the last release tag
                          (C header, cxx bridge, YAML schema, wire format,
                           CLI snapshot, Python floor; no build)
+  10. ci-reporting    -- nightly.yml failure-reporting wiring (no job unmonitored)
 ============================================================
 EOF
       ;;
@@ -132,12 +134,13 @@ EOF
 ============================================================
 $header
 Will run:
-  1-9. everything from qa-fast                  (fmt/clippy/audit/unwrap/
+  1-10. everything from qa-fast                 (fmt/clippy/audit/unwrap/
                                                  secret-files/typos/publish-graph/
-                                                 package-includes/breaking-changes)
-  10.  test         -- cargo test --all         (workspace test suite)
-  11.  coverage     -- cargo llvm-cov           (writes lcov.info)
-  12.  adversarial  -- codex/claude review      (optional; skipped if unavailable)
+                                                 package-includes/breaking-changes/
+                                                 ci-reporting)
+  11.  test         -- cargo test --all         (workspace test suite)
+  12.  coverage     -- cargo llvm-cov           (writes lcov.info)
+  13.  adversarial  -- codex/claude review      (optional; skipped if unavailable)
 ============================================================
 EOF
       ;;
@@ -148,7 +151,7 @@ EOF
 $header
 Today's CI PR gate only runs a subset of this: fmt, clippy, typos,
 audit, unwrap-budget, secret-files, publish-graph, package-includes,
-and the workspace test suite.
+ci-reporting, and the workspace test suite.
 qa-deep adds the planned Tier 1 extras (see
 docs/plan-agentic-qa-strategy.md §5) that are kept laptop-only today
 because they're too slow for every PR: coverage, adversarial review,
@@ -156,12 +159,12 @@ diff-scoped mutation testing, and the compile half of the
 compatibility gate.
 
 Will run:
-  1-9.  everything from qa-fast                 (in CI today)
-  10.   test         -- cargo test --all        (in CI today)
-  11.   coverage     -- cargo llvm-cov          (NOT in CI; laptop-only)
-  12.   adversarial  -- codex/claude review     (NOT in CI; skipped w/o tools)
-  13.   mutants      -- cargo-mutants on diff   (NOT in CI; laptop-only)
-  14.   breaking-changes -- cargo-semver-checks + snapshot freshness
+  1-10. everything from qa-fast                 (in CI today)
+  11.   test         -- cargo test --all        (in CI today)
+  12.   coverage     -- cargo llvm-cov          (NOT in CI; laptop-only)
+  13.   adversarial  -- codex/claude review     (NOT in CI; skipped w/o tools)
+  14.   mutants      -- cargo-mutants on diff   (NOT in CI; laptop-only)
+  15.   breaking-changes -- cargo-semver-checks + snapshot freshness
                        (the no-compile half already ran in step 9)
 ============================================================
 EOF
@@ -172,13 +175,13 @@ EOF
 ============================================================
 $header
 For overnight runs on a powerful machine. Will run:
-  1-9.   everything from qa-fast
-  10-12. everything from qa-full                (test, coverage, adversarial)
-  13.    mutants (diff-scoped)                  -- same as qa-deep
-  14.    breaking-changes                       -- cargo-semver-checks + snapshot freshness
-  15.    proptest @ 1000 cases per property     (vs 50 cases in Tier 1)
-  16.    miri                                   -- undefined-behavior check (SKIP if cargo +nightly miri missing)
-  17.    example-smoke                          -- tests/example-smoke.rs (52 tests;
+  1-10.  everything from qa-fast
+  11-13. everything from qa-full                (test, coverage, adversarial)
+  14.    mutants (diff-scoped)                  -- same as qa-deep
+  15.    breaking-changes                       -- cargo-semver-checks + snapshot freshness
+  16.    proptest @ 1000 cases per property     (vs 50 cases in Tier 1)
+  17.    miri                                   -- undefined-behavior check (SKIP if cargo +nightly miri missing)
+  18.    example-smoke                          -- tests/example-smoke.rs (52 tests;
                                                    covers GHA smoke-suite + log-sinks
                                                    + service-action + streaming).
                                                    Runs inside a scratch uv venv that
@@ -186,14 +189,14 @@ For overnight runs on a powerful machine. Will run:
                                                    matching the GHA Python setup exactly
                                                    (so workspace Python bindings are used,
                                                    NOT PyPI). Requires uv.
-  17.   hub-smoke                              -- tests/hub-smoke.rs -- the Hub
+  19.   hub-smoke                              -- tests/hub-smoke.rs -- the Hub
                                                    e2e (publish / build / run /
                                                    yank / outdated / --hub-override
                                                    / binary / identity). Hermetic
                                                    (local git fixture, no network),
                                                    Rust-only -- no venv. Runs
                                                    regardless of the uv/3.12 setup.
-  18.   ci-nightly-jobs                         -- scripts/qa/ci-nightly-jobs.sh
+  20.   ci-nightly-jobs                         -- scripts/qa/ci-nightly-jobs.sh
                                                    Platform-aware: runs the subset of GHA
                                                    nightly jobs that applies to the dev's OS.
                                                    Covers record-replay, cluster-smoke,
@@ -266,10 +269,10 @@ EOF
 ============================================================
 $header
 The automatable parts of the Tier 3 release gate. Will run:
-  1-9.    everything from qa-fast
-  10-12.  everything from qa-full                (test, coverage, adversarial)
-  13.     mutants (diff-scoped)
-  14.     breaking-changes                       -- every surface dora 1.x freezes
+  1-10.   everything from qa-fast
+  11-13.  everything from qa-full                (test, coverage, adversarial)
+  14.     mutants (diff-scoped)
+  15.     breaking-changes                       -- every surface dora 1.x freezes
 Non-automatable Tier 3 gates (external security audit, 7-day dogfood
 campaign, migration validation on external repos) are human-gated --
 see docs/plan-agentic-qa-strategy.md §7.
@@ -298,6 +301,7 @@ run "package-includes" scripts/qa/package-includes.sh
 # YAML schema, wire format, CLI snapshot, Python floor. Seconds, so it
 # belongs in the per-commit tier -- the compile half runs in --deep.
 run "breaking-changes" scripts/qa/breaking-changes.sh --fast
+run "ci-reporting"  scripts/qa/ci-nightly-reporting.sh
 
 case "$MODE" in
   --fast)

--- a/scripts/qa/ci-nightly-reporting.sh
+++ b/scripts/qa/ci-nightly-reporting.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# scripts/qa/ci-nightly-reporting.sh — structural check on nightly failure reporting
+#
+# The nightly workflow reports itself through two jobs that consume every
+# other job via `needs`:
+#
+#   file-issue-on-failure   opens/updates the `nightly-regression` issue
+#   close-issue-on-success  closes it again once the nightly is green
+#
+# Both read `needs.<job>.result`, and that indirection has silently lost
+# regressions three separate times (#2742, #2987). This script asserts the
+# three structural invariants those failures violated. It parses
+# .github/workflows/nightly.yml only — it does not run any nightly job.
+#
+#   1. No job in `file-issue-on-failure`'s `needs` carries JOB-LEVEL
+#      `continue-on-error: true`.
+#
+#      `needs.<job>.result` reads `success` for a continue-on-error job even
+#      when it failed, so such a job is listed as reported but cannot ever
+#      be reported. The two `ros2-zenoh-*` jobs failed every night for two
+#      weeks this way (#2790 added them 2026-07-21, #2742 found them
+#      2026-08-03) across thirteen nightly issues, none of which named them.
+#
+#      Deliberate exceptions live in `.nightly-advisory-jobs` (see #2987) —
+#      a job may be advisory while it earns trust, but the exemption is
+#      explicit, dated, and greppable rather than invisible.
+#
+#      STEP-level `continue-on-error` is unaffected and not checked: it does
+#      not touch `needs.<job>.result`. `smoke-suite` uses it legitimately to
+#      capture an exit code into a step output and re-raise it later, so a
+#      naive `grep continue-on-error` would flag a correct job. The two are
+#      told apart by indentation (4 spaces = job key, 8 = step key).
+#
+#   2. Every job in the workflow appears in `file-issue-on-failure`'s
+#      `needs` (the two reporter jobs themselves excepted).
+#
+#      A job missing from that list is unmonitored in the same way, just via
+#      omission instead of a flag. `hub-smoke` sat unreported this way from
+#      the day it was added.
+#
+#   3. `close-issue-on-success`'s `needs` covers everything
+#      `file-issue-on-failure`'s does.
+#
+#      The closer refuses to close while any job it watches is red. A job the
+#      reporter watches but the closer does not produces a FLAPPING issue:
+#      the nightly files it, and the next nightly closes it again while the
+#      job is still broken. Failing that way is arguably worse than silence,
+#      because the issue tracker actively asserts the problem is fixed.
+#
+# Exit codes: 0 all invariants hold, 1 a violation, 2 the workflow could not
+# be parsed (missing file / renamed reporter job) — never a silent pass.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+WORKFLOW=".github/workflows/nightly.yml"
+EXCEPTIONS=".nightly-advisory-jobs"
+REPORTER="file-issue-on-failure"
+CLOSER="close-issue-on-success"
+
+if [[ ! -f "$WORKFLOW" ]]; then
+  echo "ci-nightly-reporting: $WORKFLOW not found" >&2
+  exit 2
+fi
+
+# Flatten the workflow into three record types:
+#   JOB  <job>         a top-level key under `jobs:`
+#   COE  <job>         that job carries job-level `continue-on-error: true`
+#   NEED <job> <dep>   <job> lists <dep> in its `needs:`
+#
+# Indentation is the whole grammar here: 2 spaces = job name, 4 = job key,
+# 6 = `needs:` list item, 8 = step key. That is load-bearing (see invariant 1
+# above), so the patterns anchor on exact leading whitespace rather than
+# using a looser match.
+parse_workflow() {
+  awk '
+    # --- track entry into / exit from the top-level `jobs:` mapping ---
+    /^jobs:[[:space:]]*$/ { injobs = 1; next }
+    injobs && /^[^[:space:]#]/ { injobs = 0; job = ""; inneeds = 0 }
+    !injobs { next }
+
+    # --- job header: `  <name>:` ---
+    /^  [A-Za-z0-9_-]+:[[:space:]]*$/ {
+      job = $0
+      sub(/^  /, "", job)
+      sub(/:[[:space:]]*$/, "", job)
+      inneeds = 0
+      print "JOB " job
+      next
+    }
+
+    job == "" { next }
+
+    # --- `needs:` block-list items: `      - <dep>` ---
+    inneeds && /^      -[[:space:]]/ {
+      dep = $0
+      sub(/^      -[[:space:]]+/, "", dep)
+      sub(/[[:space:]]+$/, "", dep)
+      sub(/[[:space:]]*#.*$/, "", dep)
+      if (dep != "") print "NEED " job " " dep
+      next
+    }
+    # Any other job-level key ends the needs block. No `next` — the line
+    # still has to be offered to the rules below.
+    inneeds && /^    [A-Za-z]/ { inneeds = 0 }
+
+    # --- `needs:` in its three YAML spellings ---
+    /^    needs:[[:space:]]*$/ { inneeds = 1; next }
+    /^    needs:[[:space:]]*\[/ {
+      list = $0
+      sub(/^    needs:[[:space:]]*\[/, "", list)
+      sub(/\].*$/, "", list)
+      n = split(list, parts, ",")
+      for (i = 1; i <= n; i++) {
+        gsub(/[[:space:]"'"'"']/, "", parts[i])
+        if (parts[i] != "") print "NEED " job " " parts[i]
+      }
+      next
+    }
+    /^    needs:[[:space:]]*[A-Za-z0-9_-]+/ {
+      dep = $0
+      sub(/^    needs:[[:space:]]*/, "", dep)
+      sub(/[[:space:]]*#.*$/, "", dep)
+      sub(/[[:space:]]+$/, "", dep)
+      if (dep != "") print "NEED " job " " dep
+      next
+    }
+
+    # --- job-level `continue-on-error: true` (exactly 4 spaces) ---
+    /^    continue-on-error:[[:space:]]*true[[:space:]]*$/ { print "COE " job; next }
+  ' "$WORKFLOW"
+}
+
+RECORDS="$(parse_workflow)"
+
+jobs_list()  { printf '%s\n' "$RECORDS" | awk '$1=="JOB"{print $2}' | sort -u; }
+coe_list()   { printf '%s\n' "$RECORDS" | awk '$1=="COE"{print $2}' | sort -u; }
+needs_of()   { printf '%s\n' "$RECORDS" | awk -v j="$1" '$1=="NEED" && $2==j {print $3}' | sort -u; }
+
+ALL_JOBS="$(jobs_list)"
+COE_JOBS="$(coe_list)"
+REPORTER_NEEDS="$(needs_of "$REPORTER")"
+CLOSER_NEEDS="$(needs_of "$CLOSER")"
+
+# A rename or refactor that makes the reporter unparseable must not read as
+# "all invariants hold" — that is precisely the silent-pass this script exists
+# to prevent.
+if ! printf '%s\n' "$ALL_JOBS" | grep -qx "$REPORTER"; then
+  echo "ci-nightly-reporting: no '$REPORTER' job in $WORKFLOW" >&2
+  echo "If the reporting job was renamed, update REPORTER in this script." >&2
+  exit 2
+fi
+if ! printf '%s\n' "$ALL_JOBS" | grep -qx "$CLOSER"; then
+  echo "ci-nightly-reporting: no '$CLOSER' job in $WORKFLOW" >&2
+  echo "If the closing job was renamed, update CLOSER in this script." >&2
+  exit 2
+fi
+if [[ -z "$REPORTER_NEEDS" ]]; then
+  echo "ci-nightly-reporting: '$REPORTER' has an empty 'needs:' list" >&2
+  echo "That reports nothing at all. Check the parser against $WORKFLOW." >&2
+  exit 2
+fi
+
+# Advisory allowlist: blank lines and `#` comments ignored, one job per line.
+ADVISORY=""
+if [[ -f "$EXCEPTIONS" ]]; then
+  ADVISORY="$(sed -e 's/[[:space:]]*#.*$//' -e '/^[[:space:]]*$/d' \
+                  -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' "$EXCEPTIONS" | sort -u)"
+fi
+
+fail=0
+note() { echo "  - $1"; }
+
+# --- Invariant 1: nothing in the reporter's needs is silently advisory ------
+advisory_violations=""
+while IFS= read -r j; do
+  [[ -z "$j" ]] && continue
+  printf '%s\n' "$REPORTER_NEEDS" | grep -qx "$j" || continue
+  printf '%s\n' "$ADVISORY" | grep -qx "$j" && continue
+  advisory_violations+="$j"$'\n'
+done <<< "$COE_JOBS"
+
+if [[ -n "${advisory_violations//[$'\n']/}" ]]; then
+  fail=1
+  echo "FAIL: job-level 'continue-on-error: true' on jobs listed in '$REPORTER' needs:"
+  while IFS= read -r j; do [[ -n "$j" ]] && note "$j"; done <<< "$advisory_violations"
+  echo
+  echo "  'needs.<job>.result' reads 'success' for a continue-on-error job, so"
+  echo "  these are listed as reported but can never actually report. Either"
+  echo "  drop the flag, or add the job to $EXCEPTIONS with a reason and issue"
+  echo "  reference if it is deliberately advisory for now."
+  echo
+fi
+
+# --- Invariant 2: every job is watched by the reporter ---------------------
+unwatched=""
+while IFS= read -r j; do
+  [[ -z "$j" ]] && continue
+  [[ "$j" == "$REPORTER" || "$j" == "$CLOSER" ]] && continue
+  printf '%s\n' "$REPORTER_NEEDS" | grep -qx "$j" && continue
+  unwatched+="$j"$'\n'
+done <<< "$ALL_JOBS"
+
+if [[ -n "${unwatched//[$'\n']/}" ]]; then
+  fail=1
+  echo "FAIL: nightly jobs missing from '$REPORTER' needs:"
+  while IFS= read -r j; do [[ -n "$j" ]] && note "$j"; done <<< "$unwatched"
+  echo
+  echo "  A job absent from that list can fail every night without filing"
+  echo "  anything. Add it to the '$REPORTER' needs list."
+  echo
+fi
+
+# --- Invariant 3: the closer watches everything the reporter does ----------
+unclosed=""
+while IFS= read -r j; do
+  [[ -z "$j" ]] && continue
+  printf '%s\n' "$CLOSER_NEEDS" | grep -qx "$j" && continue
+  unclosed+="$j"$'\n'
+done <<< "$REPORTER_NEEDS"
+
+if [[ -n "${unclosed//[$'\n']/}" ]]; then
+  fail=1
+  echo "FAIL: jobs watched by '$REPORTER' but not by '$CLOSER':"
+  while IFS= read -r j; do [[ -n "$j" ]] && note "$j"; done <<< "$unclosed"
+  echo
+  echo "  The nightly issue would be filed when these fail and then closed"
+  echo "  again by the next nightly while they are still failing. Add them to"
+  echo "  the '$CLOSER' needs list."
+  echo
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "ci-nightly-reporting: FAILED (see $WORKFLOW)" >&2
+  exit 1
+fi
+
+job_count="$(printf '%s\n' "$ALL_JOBS" | grep -c . || true)"
+advisory_count="$(printf '%s\n' "$ADVISORY" | grep -c . || true)"
+echo "ci-nightly-reporting: OK — ${job_count} jobs, all reported and closable" \
+     "(${advisory_count} documented advisory)"

--- a/scripts/qa/ci-nightly-reporting.sh
+++ b/scripts/qa/ci-nightly-reporting.sh
@@ -64,15 +64,33 @@ if [[ ! -f "$WORKFLOW" ]]; then
   exit 2
 fi
 
-# Flatten the workflow into three record types:
-#   JOB  <job>         a top-level key under `jobs:`
-#   COE  <job>         that job carries job-level `continue-on-error: true`
-#   NEED <job> <dep>   <job> lists <dep> in its `needs:`
+# Flatten the workflow into four record types:
+#   JOB  <job>            a top-level key under `jobs:`
+#   COE  <job> <value>    that job carries a job-level `continue-on-error`
+#                         whose value is not `false`
+#   NEED <job> <dep>      <job> lists <dep> in its `needs:`
+#   UNPARSED <line>       a line where a job header belongs that this parser
+#                         does not recognise (see below)
 #
 # Indentation is the whole grammar here: 2 spaces = job name, 4 = job key,
 # 6 = `needs:` list item, 8 = step key. That is load-bearing (see invariant 1
 # above), so the patterns anchor on exact leading whitespace rather than
 # using a looser match.
+#
+# What is *inside* a line is matched loosely, in the other direction: a value
+# is read as a value rather than as one literal spelling. `true`, `True`,
+# `TRUE`, `"true"` and `true  # while it settles` are the same flag to GitHub,
+# and a trailing comment is the likeliest thing to be written next to one, so
+# the value is stripped of its comment, quotes and case before it is judged —
+# and anything that is not `false` counts, including a `${{ }}` expression this
+# script cannot evaluate. The same tolerance applies to a job header, which may
+# carry a trailing comment.
+#
+# A 2-space line that is *not* recognised as a job header is fatal rather than
+# skipped: the job would drop out of invariant 2 entirely, and its keys would
+# be attributed to the job above it, so both the omission and the
+# misattribution would pass silently. That is the failure this whole script
+# exists to prevent, so the parser refuses to analyse instead.
 parse_workflow() {
   awk '
     # --- track entry into / exit from the top-level `jobs:` mapping ---
@@ -80,15 +98,20 @@ parse_workflow() {
     injobs && /^[^[:space:]#]/ { injobs = 0; job = ""; inneeds = 0 }
     !injobs { next }
 
-    # --- job header: `  <name>:` ---
-    /^  [A-Za-z0-9_-]+:[[:space:]]*$/ {
+    # --- job header: `  <name>:`, optionally with a trailing comment ---
+    /^  [A-Za-z0-9_-]+:[[:space:]]*(#.*)?$/ {
       job = $0
       sub(/^  /, "", job)
+      sub(/[[:space:]]*#.*$/, "", job)
       sub(/:[[:space:]]*$/, "", job)
       inneeds = 0
       print "JOB " job
       next
     }
+
+    # Anything else at job-header depth: a quoted name, or a spelling this
+    # parser does not know. Reported, not ignored — see the header comment.
+    /^  [^[:space:]#]/ { print "UNPARSED " NR; next }
 
     job == "" { next }
 
@@ -106,7 +129,7 @@ parse_workflow() {
     inneeds && /^    [A-Za-z]/ { inneeds = 0 }
 
     # --- `needs:` in its three YAML spellings ---
-    /^    needs:[[:space:]]*$/ { inneeds = 1; next }
+    /^    needs:[[:space:]]*(#.*)?$/ { inneeds = 1; next }
     /^    needs:[[:space:]]*\[/ {
       list = $0
       sub(/^    needs:[[:space:]]*\[/, "", list)
@@ -127,8 +150,24 @@ parse_workflow() {
       next
     }
 
-    # --- job-level `continue-on-error: true` (exactly 4 spaces) ---
-    /^    continue-on-error:[[:space:]]*true[[:space:]]*$/ { print "COE " job; next }
+    # --- job-level `continue-on-error` (exactly 4 spaces) ---
+    #
+    # Not `== "true"`: `True`, `TRUE` and a quoted `"true"` are the same
+    # boolean to GitHub, and a `${{ }}` expression is a flag this script cannot
+    # evaluate. Only a literal `false` — the default, spelled out — is treated
+    # as "this job can report".
+    /^    continue-on-error:/ {
+      val = $0
+      sub(/^    continue-on-error:[[:space:]]*/, "", val)
+      sub(/[[:space:]]*#.*$/, "", val)
+      sub(/[[:space:]]+$/, "", val)
+      # Judged unquoted and case-folded, but reported as written, so the
+      # message quotes the file rather than a normalised rewrite of it.
+      norm = tolower(val)
+      gsub(/["'"'"']/, "", norm)
+      if (norm != "false") print "COE " job " " (val == "" ? "(empty)" : val)
+      next
+    }
   ' "$WORKFLOW"
 }
 
@@ -137,6 +176,24 @@ RECORDS="$(parse_workflow)"
 jobs_list()  { printf '%s\n' "$RECORDS" | awk '$1=="JOB"{print $2}' | sort -u; }
 coe_list()   { printf '%s\n' "$RECORDS" | awk '$1=="COE"{print $2}' | sort -u; }
 needs_of()   { printf '%s\n' "$RECORDS" | awk -v j="$1" '$1=="NEED" && $2==j {print $3}' | sort -u; }
+# The value as written, for the failure message: `true`, `True`, an expression.
+coe_value()  { printf '%s\n' "$RECORDS" \
+                 | awk -v j="$1" '$1=="COE" && $2==j { sub(/^COE [^ ]+ /, ""); print; exit }'; }
+
+# A job header this parser cannot read is not a job it may skip: the job would
+# be missing from invariant 2, and the keys under it -- its own `needs`, its
+# own `continue-on-error` -- would be read as the previous job's. Both would
+# pass silently, so refuse to answer instead.
+UNPARSED_LINES="$(printf '%s\n' "$RECORDS" | awk '$1=="UNPARSED"{print $2}')"
+if [[ -n "$UNPARSED_LINES" ]]; then
+  echo "ci-nightly-reporting: unreadable job header in $WORKFLOW, line(s):" >&2
+  while IFS= read -r n; do
+    [[ -n "$n" ]] && printf '  %s: %s\n' "$n" "$(sed -n "${n}p" "$WORKFLOW")" >&2
+  done <<< "$UNPARSED_LINES"
+  echo "A job name is matched as '  <name>:', optionally with a trailing" >&2
+  echo "comment. Rename the job to that form, or teach the parser above." >&2
+  exit 2
+fi
 
 ALL_JOBS="$(jobs_list)"
 COE_JOBS="$(coe_list)"
@@ -183,13 +240,18 @@ done <<< "$COE_JOBS"
 
 if [[ -n "${advisory_violations//[$'\n']/}" ]]; then
   fail=1
-  echo "FAIL: job-level 'continue-on-error: true' on jobs listed in '$REPORTER' needs:"
-  while IFS= read -r j; do [[ -n "$j" ]] && note "$j"; done <<< "$advisory_violations"
+  echo "FAIL: job-level 'continue-on-error' on jobs listed in '$REPORTER' needs:"
+  while IFS= read -r j; do
+    [[ -n "$j" ]] && note "$j (continue-on-error: $(coe_value "$j"))"
+  done <<< "$advisory_violations"
   echo
   echo "  'needs.<job>.result' reads 'success' for a continue-on-error job, so"
   echo "  these are listed as reported but can never actually report. Either"
   echo "  drop the flag, or add the job to $EXCEPTIONS with a reason and issue"
   echo "  reference if it is deliberately advisory for now."
+  echo
+  echo "  A \${{ }} expression counts as well: whenever it evaluates true, the"
+  echo "  job cannot report that night."
   echo
 fi
 

--- a/scripts/qa/ci-nightly-reporting.sh
+++ b/scripts/qa/ci-nightly-reporting.sh
@@ -86,6 +86,11 @@ fi
 # script cannot evaluate. The same tolerance applies to a job header, which may
 # carry a trailing comment.
 #
+# Only the leading whitespace is fixed; whitespace *after* the key name is not.
+# `continue-on-error : true` is the same key to YAML as `continue-on-error:`,
+# so every key here is matched as `<name>[[:space:]]*:` — an optional space
+# before the colon must not be the difference between flagged and green.
+#
 # A 2-space line that is *not* recognised as a job header is fatal rather than
 # skipped: the job would drop out of invariant 2 entirely, and its keys would
 # be attributed to the job above it, so both the omission and the
@@ -99,11 +104,11 @@ parse_workflow() {
     !injobs { next }
 
     # --- job header: `  <name>:`, optionally with a trailing comment ---
-    /^  [A-Za-z0-9_-]+:[[:space:]]*(#.*)?$/ {
+    /^  [A-Za-z0-9_-]+[[:space:]]*:[[:space:]]*(#.*)?$/ {
       job = $0
       sub(/^  /, "", job)
       sub(/[[:space:]]*#.*$/, "", job)
-      sub(/:[[:space:]]*$/, "", job)
+      sub(/[[:space:]]*:[[:space:]]*$/, "", job)
       inneeds = 0
       print "JOB " job
       next
@@ -129,10 +134,10 @@ parse_workflow() {
     inneeds && /^    [A-Za-z]/ { inneeds = 0 }
 
     # --- `needs:` in its three YAML spellings ---
-    /^    needs:[[:space:]]*(#.*)?$/ { inneeds = 1; next }
-    /^    needs:[[:space:]]*\[/ {
+    /^    needs[[:space:]]*:[[:space:]]*(#.*)?$/ { inneeds = 1; next }
+    /^    needs[[:space:]]*:[[:space:]]*\[/ {
       list = $0
-      sub(/^    needs:[[:space:]]*\[/, "", list)
+      sub(/^    needs[[:space:]]*:[[:space:]]*\[/, "", list)
       sub(/\].*$/, "", list)
       n = split(list, parts, ",")
       for (i = 1; i <= n; i++) {
@@ -141,9 +146,9 @@ parse_workflow() {
       }
       next
     }
-    /^    needs:[[:space:]]*[A-Za-z0-9_-]+/ {
+    /^    needs[[:space:]]*:[[:space:]]*[A-Za-z0-9_-]+/ {
       dep = $0
-      sub(/^    needs:[[:space:]]*/, "", dep)
+      sub(/^    needs[[:space:]]*:[[:space:]]*/, "", dep)
       sub(/[[:space:]]*#.*$/, "", dep)
       sub(/[[:space:]]+$/, "", dep)
       if (dep != "") print "NEED " job " " dep
@@ -152,13 +157,16 @@ parse_workflow() {
 
     # --- job-level `continue-on-error` (exactly 4 spaces) ---
     #
+    # The key tolerates a space before its colon; the indentation in front
+    # of it does not move.
+    #
     # Not `== "true"`: `True`, `TRUE` and a quoted `"true"` are the same
     # boolean to GitHub, and a `${{ }}` expression is a flag this script cannot
     # evaluate. Only a literal `false` — the default, spelled out — is treated
     # as "this job can report".
-    /^    continue-on-error:/ {
+    /^    continue-on-error[[:space:]]*:/ {
       val = $0
-      sub(/^    continue-on-error:[[:space:]]*/, "", val)
+      sub(/^    continue-on-error[[:space:]]*:[[:space:]]*/, "", val)
       sub(/[[:space:]]*#.*$/, "", val)
       sub(/[[:space:]]+$/, "", val)
       # Judged unquoted and case-folded, but reported as written, so the

--- a/scripts/qa/tests/test_ci_nightly_reporting.py
+++ b/scripts/qa/tests/test_ci_nightly_reporting.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Tests for the nightly reporting-wiring guard.
+
+`scripts/qa/ci-nightly-reporting.sh` is a structural check, so the only thing
+that distinguishes a working one from a no-op is that a *broken* workflow makes
+it red. Two review rounds found spellings that slipped past it silently --
+`continue-on-error: True`, a trailing comment, a space before the colon -- and
+each fix so far has been argued from a mutation table written by hand in a
+commit message. The table lives here instead.
+
+Every case mutates a minimal workflow fixture and asserts the exit code:
+
+    0  the wiring is sound
+    1  an invariant is violated
+    2  the workflow could not be parsed -- never a silent pass
+
+Run: python3 scripts/qa/tests/test_ci_nightly_reporting.py
+     python3 -m unittest discover -s scripts/qa/tests
+"""
+
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+GUARD = ROOT / "scripts/qa/ci-nightly-reporting.sh"
+
+# Two ordinary jobs, both watched by both reporters. `beta` carries a
+# *step*-level `continue-on-error`, which is legitimate and must never be
+# flagged -- `smoke-suite` uses exactly this shape in the real workflow.
+FIXTURE = """\
+name: Nightly
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+
+env:
+  RUST_VERSION: "1.97.1"
+
+jobs:
+  alpha:
+    name: Alpha
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo alpha
+
+  beta:
+    name: Beta
+    runs-on: ubuntu-latest
+    steps:
+      - name: capture the exit code rather than failing the job
+        continue-on-error: true
+        run: echo beta
+
+  file-issue-on-failure:
+    if: always()
+    needs:
+      - alpha
+      - beta
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo report
+
+  close-issue-on-success:
+    if: always()
+    needs:
+      - alpha
+      - beta
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo close
+"""
+
+ADVISORY = """\
+# One job id per line. Blank lines and comments ignored.
+"""
+
+
+class GuardCase(unittest.TestCase):
+    def run_guard(self, workflow=FIXTURE, advisory=ADVISORY, write_workflow=True):
+        """Run the real guard against a throwaway tree, return (code, output)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tree = Path(tmp)
+            (tree / "scripts/qa").mkdir(parents=True)
+            (tree / ".github/workflows").mkdir(parents=True)
+            shutil.copy2(GUARD, tree / "scripts/qa" / GUARD.name)
+            if write_workflow:
+                (tree / ".github/workflows/nightly.yml").write_text(workflow)
+            (tree / ".nightly-advisory-jobs").write_text(advisory)
+            proc = subprocess.run(
+                ["bash", str(tree / "scripts/qa" / GUARD.name)],
+                capture_output=True,
+                text=True,
+            )
+        return proc.returncode, proc.stdout + proc.stderr
+
+    def assertGuard(self, expected, workflow=FIXTURE, advisory=ADVISORY, **kw):
+        code, out = self.run_guard(workflow, advisory, **kw)
+        self.assertEqual(expected, code, f"expected exit {expected}, got {code}:\n{out}")
+        return out
+
+    @staticmethod
+    def with_job_key(line, job="  alpha:\n"):
+        """Insert a job-level key directly under `job`'s header."""
+        assert FIXTURE.count(job) == 1
+        return FIXTURE.replace(job, job + line)
+
+    @staticmethod
+    def with_extra_job(name, keys="", watched=False):
+        """Add a third ordinary job, optionally into both `needs` lists."""
+        anchor = "  file-issue-on-failure:\n"
+        assert FIXTURE.count(anchor) == 1
+        block = (f"  {name}:\n{keys}    runs-on: ubuntu-latest\n"
+                 f"    steps:\n      - run: echo {name}\n\n")
+        wf = FIXTURE.replace(anchor, block + anchor)
+        if watched:
+            assert wf.count("      - beta\n") == 2
+            wf = wf.replace("      - beta\n", f"      - beta\n      - {name}\n")
+        return wf
+
+
+class TestSoundWiring(GuardCase):
+    def test_baseline_is_green(self):
+        out = self.assertGuard(0)
+        self.assertIn("4 jobs", out)
+
+    def test_step_level_continue_on_error_is_not_flagged(self):
+        # `beta`'s step-level flag is in the baseline; assert the reason
+        # explicitly so a parser that stopped honouring indentation fails here.
+        self.assertIn("        continue-on-error: true", FIXTURE)
+        self.assertGuard(0)
+
+    def test_inline_needs_list(self):
+        wf = FIXTURE.replace("    needs:\n      - alpha\n      - beta\n",
+                             "    needs: [alpha, beta]\n")
+        self.assertEqual(wf.count("needs: [alpha, beta]"), 2)
+        self.assertGuard(0, wf)
+
+    def test_scalar_needs_with_one_job(self):
+        self.assertGuard(0, self.with_extra_job("gamma", "    needs: alpha\n",
+                                                watched=True))
+
+    def test_job_header_with_trailing_comment(self):
+        self.assertGuard(0, FIXTURE.replace("  alpha:\n", "  alpha: # the first one\n"))
+
+    def test_job_header_with_space_before_the_colon(self):
+        self.assertGuard(0, FIXTURE.replace("  alpha:\n", "  alpha :\n"))
+
+    def test_needs_with_space_before_the_colon(self):
+        self.assertGuard(0, FIXTURE.replace("    needs:\n", "    needs :\n"))
+
+
+class TestInvariant1AdvisoryJobs(GuardCase):
+    """Job-level `continue-on-error` on a job the reporter claims to watch."""
+
+    SPELLINGS = [
+        "    continue-on-error: true\n",
+        "    continue-on-error: true  # temporary, while it settles\n",
+        "    continue-on-error: True\n",
+        "    continue-on-error: TRUE\n",
+        '    continue-on-error: "true"\n',
+        "    continue-on-error: 'true'\n",
+        "    continue-on-error : true\n",
+        "    continue-on-error:true\n",
+        "    continue-on-error: ${{ github.event_name == 'schedule' }}\n",
+        "    continue-on-error:\n",
+    ]
+
+    def test_every_truthy_spelling_is_flagged(self):
+        for line in self.SPELLINGS:
+            with self.subTest(line=line.strip()):
+                out = self.assertGuard(1, self.with_job_key(line))
+                self.assertIn("- alpha (continue-on-error:", out)
+
+    def test_the_value_is_reported_as_written(self):
+        out = self.assertGuard(1, self.with_job_key("    continue-on-error: True\n"))
+        self.assertIn("- alpha (continue-on-error: True)", out)
+
+    def test_literal_false_is_the_one_value_that_passes(self):
+        for line in ("    continue-on-error: false\n",
+                     "    continue-on-error: False\n",
+                     '    continue-on-error: "false"\n',
+                     "    continue-on-error: false  # the default, spelled out\n"):
+            with self.subTest(line=line.strip()):
+                self.assertGuard(0, self.with_job_key(line))
+
+    def test_an_allowlisted_job_is_exempt(self):
+        wf = self.with_job_key("    continue-on-error: true\n")
+        self.assertGuard(1, wf)
+        out = self.assertGuard(0, wf, ADVISORY + "alpha  # flaky, tracked in #0000\n")
+        self.assertIn("1 documented advisory", out)
+
+    def test_allowlist_comments_and_blanks_are_ignored(self):
+        wf = self.with_job_key("    continue-on-error: true\n")
+        self.assertGuard(1, wf, ADVISORY + "\n# alpha\n   \n")
+
+
+class TestInvariant2EveryJobIsWatched(GuardCase):
+    def test_job_missing_from_the_reporter_is_flagged(self):
+        wf = FIXTURE.replace("    needs:\n      - alpha\n      - beta\n",
+                             "    needs:\n      - beta\n", 1)
+        out = self.assertGuard(1, wf)
+        self.assertIn("missing from 'file-issue-on-failure' needs", out)
+        self.assertIn("- alpha", out)
+
+    def test_a_new_job_nobody_watches_is_flagged(self):
+        out = self.assertGuard(1, self.with_extra_job("gamma"))
+        self.assertIn("- gamma", out)
+
+
+class TestInvariant3TheCloserAgrees(GuardCase):
+    def test_job_watched_by_the_reporter_but_not_the_closer(self):
+        head, sep, tail = FIXTURE.rpartition("    needs:\n      - alpha\n      - beta\n")
+        wf = head + "    needs:\n      - alpha\n" + tail
+        out = self.assertGuard(1, wf)
+        self.assertIn("not by 'close-issue-on-success'", out)
+        self.assertIn("- beta", out)
+
+
+class TestUnparseableIsFatal(GuardCase):
+    """Exit 2, never 0: an unreadable workflow must not read as "all sound"."""
+
+    def test_missing_workflow(self):
+        out = self.assertGuard(2, write_workflow=False)
+        self.assertIn("not found", out)
+
+    def test_quoted_job_name(self):
+        out = self.assertGuard(2, FIXTURE.replace("  alpha:\n", '  "alpha":\n'))
+        self.assertIn("unreadable job header", out)
+        self.assertIn('"alpha":', out)
+
+    def test_a_job_name_the_parser_cannot_read_is_not_silently_reattributed(self):
+        # The danger is not just the missing job: `needs` and
+        # `continue-on-error` under an unreadable header would be read as the
+        # *previous* job's, so an omission and a misattribution both pass.
+        wf = FIXTURE.replace("  beta:\n", '  "beta":\n')
+        self.assertGuard(2, wf)
+
+    def test_renamed_reporter(self):
+        out = self.assertGuard(2, FIXTURE.replace("  file-issue-on-failure:\n",
+                                                  "  open-issue-on-failure:\n"))
+        self.assertIn("no 'file-issue-on-failure' job", out)
+
+    def test_renamed_closer(self):
+        out = self.assertGuard(2, FIXTURE.replace("  close-issue-on-success:\n",
+                                                  "  resolve-issue-on-success:\n"))
+        self.assertIn("no 'close-issue-on-success' job", out)
+
+    def test_reporter_with_an_empty_needs_list(self):
+        wf = FIXTURE.replace("    needs:\n      - alpha\n      - beta\n",
+                             "    needs: []\n", 1)
+        out = self.assertGuard(2, wf)
+        self.assertIn("empty 'needs:' list", out)
+
+
+class TestAgainstTheRealWorkflow(GuardCase):
+    def test_the_checked_in_nightly_passes(self):
+        proc = subprocess.run(["bash", str(GUARD)], capture_output=True, text=True)
+        self.assertEqual(0, proc.returncode, proc.stdout + proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #2987 — the "Generalization worth considering" half. #3321 took the other one.

The nightly reports itself through two jobs that consume every other job via `needs`: `file-issue-on-failure` opens the `nightly-regression` issue, `close-issue-on-success` closes it again. Both read `needs.<job>.result`, and that indirection has now lost regressions three separate times — the two `ros2-zenoh-*` jobs were listed in the reporter's `needs` while job-level `continue-on-error: true` made their `result` read `success` even when they failed (thirteen nightly issues in two weeks, none naming them, #2742); `hub-smoke` was in neither list at all; `CLI Tests (windows-latest)` went unreported for five nights because a timed-out job reports `cancelled`. Nothing in the repo checks any of this, so the next instance is a matter of time.

`scripts/qa/ci-nightly-reporting.sh` parses `nightly.yml` — it runs no nightly job and takes well under a second — and asserts three invariants:

1. **No job in the reporter's `needs` carries job-level `continue-on-error: true`**, so nothing is listed as reported while being unreportable. Step-level is deliberately not flagged: `smoke-suite` uses it correctly to capture an exit code and re-raise it, so a plain grep would fail a correct job. Indentation tells the two apart.
2. **Every job in the workflow appears in that `needs` list.** Omission leaves a job just as unmonitored as the flag does — the `hub-smoke` case.
3. **`close-issue-on-success`'s `needs` covers the reporter's.** A job watched by one and not the other produces a *flapping* issue: filed by one nightly, closed by the next while the job is still red, so the tracker actively asserts the problem is fixed.

Deliberate exceptions live in `.nightly-advisory-jobs`, seeded with the two `ros2-zenoh-*` jobs. The exemption does not go away — it becomes explicit, dated and greppable, attached to the issue tracking its removal, rather than an invisible property of a flag buried in a job definition. The first commit closes the two wiring holes the guard would otherwise trip on.

What makes that entry temporary rather than permanent is #3321, and its finding is what the entry records: twenty scheduled runs, zero flakes, every failure pin rot. That also settles #2987's fallback — there is no flakiness to add retry logic around. Closing #2987 is then deleting those two lines and the two flags, and the guard enforces the result: leave one behind, or add one anywhere else in the reporter's `needs`, and PR CI fails by name.

Cost is a checkout-only PR CI job — no toolchain, no cache, sub-second — plus a seventh entry in `qa-fast`, with the step numbers in `scripts/qa/all.sh`'s overviews renumbered to match (already one behind since `publish-graph` became the sixth in #3304).

Mutation-tested against the workflow as it stands; each fails with the right invariant named:

| Mutation | Result |
|---|---|
| un-exempt `ros2-zenoh-humble` from the allowlist | exit 1 — invariant 1 |
| add job-level `continue-on-error: true` to `msrv` | exit 1 — invariant 1 |
| add a job absent from the reporter's `needs` | exit 1 — invariant 2 |
| drop `ros2-bridge` from the closer's `needs` | exit 1 — invariant 3 |
| rename `file-issue-on-failure` | **exit 2** — not a silent pass |
| unmodified tree | exit 0 |

`smoke-suite`'s step-level flag stays clean throughout, and the parser was cross-checked against PyYAML on the current `nightly.yml`: 30 jobs, 28 watched by both, 2 documented advisory.

Not in this PR, deliberately:

- **Dropping `continue-on-error` from the two jobs.** #2987 gates that on a week of green nightlies; #3321 merged 2026-08-27, so that week has not elapsed and removing the flags now would be on faith rather than on the evidence the issue asked for.
- **Anything under `docker-compose.ros2-zenoh.yml` or `scripts/ros2-zenoh-interop.sh`.** #3321 owns those; this PR touches neither.
