### PR TITLE
fix(cli): report operator-backed inputs/outputs in `dora node info`

### DIFF
--- a/binaries/cli/src/command/node/info.rs
+++ b/binaries/cli/src/command/node/info.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::io::Write;
 
 use clap::Args;
@@ -19,8 +20,10 @@ use crate::{
 };
 use dora_core::config::InputMapping;
 use dora_message::{
-    cli_to_coordinator::ControlRequest, coordinator_to_cli::NodeInfo, descriptor::Descriptor,
-    id::NodeId,
+    cli_to_coordinator::ControlRequest,
+    coordinator_to_cli::NodeInfo,
+    descriptor::Descriptor,
+    id::{DataId, NodeId},
 };
 
 /// Show detailed information about a specific node.
@@ -213,24 +216,26 @@ fn build_output_info(
     // and `operators:` nodes (their topics live under `operator.config.*` /
     // `operators[].config.*`), so iterating the raw fields would omit every
     // operator node's outputs and every operator-node subscriber.
-    node_topic_outputs(node_desc)
+    let outputs = node_topic_outputs(node_desc);
+    let mut subscribers: BTreeMap<&DataId, Vec<String>> =
+        outputs.iter().map(|o| (o, Vec::new())).collect();
+    // Scan every node's inputs once (not once per output): for each consumer of
+    // one of this node's outputs, append it to that output's subscriber list.
+    for other_node in &descriptor.nodes {
+        for (input_id, input) in node_topic_inputs(other_node) {
+            if let InputMapping::User(user) = &input.mapping
+                && user.source == node_desc.id
+                && let Some(list) = subscribers.get_mut(&user.output)
+            {
+                list.push(format!("{}/{}", other_node.id, input_id));
+            }
+        }
+    }
+    outputs
         .iter()
-        .map(|output_id| {
-            let mut subscribers = Vec::new();
-            for other_node in &descriptor.nodes {
-                for (input_id, input) in node_topic_inputs(other_node) {
-                    if let InputMapping::User(user) = &input.mapping
-                        && user.source == node_desc.id
-                        && user.output == *output_id
-                    {
-                        subscribers.push(format!("{}/{}", other_node.id, input_id));
-                    }
-                }
-            }
-            OutputInfo {
-                id: output_id.to_string(),
-                subscribers,
-            }
+        .map(|output_id| OutputInfo {
+            id: output_id.to_string(),
+            subscribers: subscribers.remove(output_id).unwrap_or_default(),
         })
         .collect()
 }

--- a/binaries/cli/src/command/node/info.rs
+++ b/binaries/cli/src/command/node/info.rs
@@ -6,7 +6,10 @@ use serde::Serialize;
 use tabwriter::TabWriter;
 
 use crate::{
-    command::{Executable, default_tracing},
+    command::{
+        Executable, default_tracing,
+        topic::selector::{node_topic_inputs, node_topic_outputs},
+    },
     common::{
         CoordinatorOptions, expect_reply, resolve_dataflow_identifier_interactive,
         send_control_request,
@@ -205,13 +208,17 @@ fn build_output_info(
     node_desc: &dora_message::descriptor::Node,
     descriptor: &Descriptor,
 ) -> Vec<OutputInfo> {
-    node_desc
-        .outputs
+    // `node_topic_outputs` / `node_topic_inputs` include operator-backed
+    // inputs/outputs. `Node::outputs` / `Node::inputs` are empty for `operator:`
+    // and `operators:` nodes (their topics live under `operator.config.*` /
+    // `operators[].config.*`), so iterating the raw fields would omit every
+    // operator node's outputs and every operator-node subscriber.
+    node_topic_outputs(node_desc)
         .iter()
         .map(|output_id| {
             let mut subscribers = Vec::new();
             for other_node in &descriptor.nodes {
-                for (input_id, input) in &other_node.inputs {
+                for (input_id, input) in node_topic_inputs(other_node) {
                     if let InputMapping::User(user) = &input.mapping
                         && user.source == node_desc.id
                         && user.output == *output_id
@@ -229,9 +236,10 @@ fn build_output_info(
 }
 
 fn build_input_info(node_desc: &dora_message::descriptor::Node) -> Vec<InputInfo> {
-    node_desc
-        .inputs
-        .iter()
+    // Use the operator-aware helper: `Node::inputs` is empty for operator-backed
+    // nodes (see `build_output_info`).
+    node_topic_inputs(node_desc)
+        .into_iter()
         .map(|(input_id, input)| InputInfo {
             id: input_id.to_string(),
             // Use `InputMapping`'s canonical `Display` rather than re-deriving the
@@ -321,5 +329,77 @@ fn print_table(output: &NodeInfoOutput) {
         let _ = tw.flush();
     } else {
         println!("  <not running or metrics unavailable>");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture() -> Descriptor {
+        // `detect` is an `operator:` node and `plot` an `operators:` node, so
+        // both have empty `Node::inputs`/`Node::outputs` -- their topics live
+        // under `operator.config.*` / `operators[].config.*`.
+        serde_yaml::from_str(
+            "\
+nodes:
+  - id: camera
+    path: camera
+    outputs:
+      - frame
+  - id: detect
+    operator:
+      python: detect.py
+      inputs:
+        image: camera/frame
+      outputs:
+        - bbox
+  - id: plot
+    operators:
+      - id: op
+        python: plot.py
+        inputs:
+          det: detect/bbox
+",
+        )
+        .expect("parse descriptor")
+    }
+
+    fn node<'a>(descriptor: &'a Descriptor, id: &str) -> &'a dora_message::descriptor::Node {
+        descriptor
+            .nodes
+            .iter()
+            .find(|n| n.id.to_string() == id)
+            .expect("node in fixture")
+    }
+
+    #[test]
+    fn build_input_info_reports_operator_backed_inputs() {
+        let descriptor = fixture();
+        let inputs = build_input_info(node(&descriptor, "detect"));
+        assert_eq!(inputs.len(), 1, "operator node's input must be reported");
+        assert_eq!(inputs[0].id, "image");
+    }
+
+    #[test]
+    fn build_output_info_reports_operator_backed_outputs() {
+        let descriptor = fixture();
+        let outputs = build_output_info(node(&descriptor, "detect"), &descriptor);
+        assert_eq!(outputs.len(), 1, "operator node's output must be reported");
+        assert_eq!(outputs[0].id, "bbox");
+        // `plot`'s operator consumes `detect/bbox`, so it must appear as a
+        // subscriber even though `plot`'s own `Node::inputs` is empty.
+        assert_eq!(outputs[0].subscribers, vec!["plot/det".to_string()]);
+    }
+
+    #[test]
+    fn build_output_info_lists_operator_node_as_subscriber() {
+        let descriptor = fixture();
+        // `detect` (an operator node) consumes `camera/frame`; a subscriber
+        // listing built from the raw `Node::inputs` would omit it entirely.
+        let outputs = build_output_info(node(&descriptor, "camera"), &descriptor);
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(outputs[0].id, "frame");
+        assert_eq!(outputs[0].subscribers, vec!["detect/image".to_string()]);
     }
 }


### PR DESCRIPTION
## Summary

> ⚠️ **This is a machine-generated change authored by Claude (Claude Code).** It was produced by an automated code-review pass. A human should review before merging.

`dora node info`'s `build_output_info` / `build_input_info` iterated the raw `Node::outputs` / `Node::inputs` fields. Those `BTreeMap`/`Vec` fields are **empty** for `operator:` and `operators:` nodes — their inputs/outputs live under `operator.config.*` / `operators[].config.*` (documented at `topic/selector.rs`). As a result:

- `dora node info <operator-node>` printed `Inputs: <none>` and `Outputs: <none>` for any single-`operator:` or multi-`operators:` node, even though it has both.
- The subscriber scan walked `other_node.inputs`, so an operator-backed **consumer** was never listed as a subscriber — even when the *target* node is an ordinary producer. So `dora node info camera` omitted an operator node consuming `camera/image`.

Every equivalent site was already fixed for exactly this (`topic/info.rs`, `topic/list.rs`, output routing) using the operator-aware `node_topic_inputs` / `node_topic_outputs` helpers. `node/info.rs` was the overlooked instance. (This is distinct from the earlier `dora node info` **ports** fix.)

## Fix

Switch `build_output_info` / `build_input_info` to the existing `pub(crate)` helpers `node_topic_outputs` / `node_topic_inputs` from `topic::selector`, matching `topic/info.rs`.

## Validation

New regression tests in `node/info.rs`:
- `build_input_info_reports_operator_backed_inputs` — an `operator:` node's input is reported.
- `build_output_info_reports_operator_backed_outputs` — an `operator:` node's output is reported, and an `operators:` consumer of it appears as a subscriber.
- `build_output_info_lists_operator_node_as_subscriber` — an operator node consuming a *plain* producer's output is listed as a subscriber.

Local checks (toolchain 1.97.1):
- `cargo test -p dora-cli --lib` (new tests) — pass
- `cargo fmt -p dora-cli -- --check` — clean
- `cargo clippy -p dora-cli --all-targets -- -D warnings` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEZNMs7aQj25CJz8DxVvsW)_