### PR TITLE
fix(cli): don't panic on a pre-epoch clock in `topic echo` / `record`

### DIFF
--- a/binaries/cli/src/command/record.rs
+++ b/binaries/cli/src/command/record.rs
@@ -445,10 +445,14 @@ fn run_record_proxy(args: Record) -> eyre::Result<()> {
         .collect::<eyre::Result<Vec<_>>>()?;
     let (_subscription_id, data_rx) = session.subscribe_topics(dataflow_id, ws_topics)?;
 
-    // Set up recording writer
+    // Set up recording writer. `duration_since(UNIX_EPOCH)` errors when the
+    // wall clock is set before 1970 (e.g. an embedded target booting with an
+    // unset RTC before NTP sync); fall back to a zero base rather than
+    // panicking the recorder. Entry offsets stay consistent because `now_nanos`
+    // below uses the same fallback.
     let start_nanos = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
+        .unwrap_or_default()
         .as_nanos() as u64;
 
     let header = RecordingHeader {
@@ -559,9 +563,11 @@ fn run_record_proxy(args: Record) -> eyre::Result<()> {
                     }
                 };
 
+                // Same pre-epoch fallback as `start_nanos` above so
+                // `timestamp_offset_nanos` stays consistent (and never panics).
                 let now_nanos = SystemTime::now()
                     .duration_since(SystemTime::UNIX_EPOCH)
-                    .unwrap()
+                    .unwrap_or_default()
                     .as_nanos() as u64;
 
                 let entry = RecordEntry {

--- a/binaries/cli/src/command/record.rs
+++ b/binaries/cli/src/command/record.rs
@@ -16,6 +16,17 @@ use eyre::{Context, bail};
 
 use crate::command::{Executable, Run, default_tracing, topic::selector::public_topic_output_id};
 
+/// Wall-clock nanoseconds since the Unix epoch, falling back to `0` when the
+/// clock is set before 1970 (e.g. an embedded target booting with an unset RTC
+/// before NTP sync) rather than panicking. Using the same fallback for both the
+/// recording base and each entry keeps `timestamp_offset_nanos` consistent.
+fn epoch_nanos() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos() as u64
+}
+
 /// Record dataflow messages to a file for offline replay.
 ///
 /// Injects a record node into the dataflow that captures all (or filtered)
@@ -446,14 +457,9 @@ fn run_record_proxy(args: Record) -> eyre::Result<()> {
     let (_subscription_id, data_rx) = session.subscribe_topics(dataflow_id, ws_topics)?;
 
     // Set up recording writer. `duration_since(UNIX_EPOCH)` errors when the
-    // wall clock is set before 1970 (e.g. an embedded target booting with an
-    // unset RTC before NTP sync); fall back to a zero base rather than
-    // panicking the recorder. Entry offsets stay consistent because `now_nanos`
-    // below uses the same fallback.
-    let start_nanos = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos() as u64;
+    // wall clock is set before 1970; `epoch_nanos` falls back to a zero base
+    // rather than panicking the recorder (see its doc).
+    let start_nanos = epoch_nanos();
 
     let header = RecordingHeader {
         version: dora_recording::FORMAT_VERSION,
@@ -563,12 +569,7 @@ fn run_record_proxy(args: Record) -> eyre::Result<()> {
                     }
                 };
 
-                // Same pre-epoch fallback as `start_nanos` above so
-                // `timestamp_offset_nanos` stays consistent (and never panics).
-                let now_nanos = SystemTime::now()
-                    .duration_since(SystemTime::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_nanos() as u64;
+                let now_nanos = epoch_nanos();
 
                 let entry = RecordEntry {
                     node_id,

--- a/binaries/cli/src/command/topic/echo.rs
+++ b/binaries/cli/src/command/topic/echo.rs
@@ -174,9 +174,14 @@ fn inspect(
                     .unwrap_or_else(|| output_id.clone());
                 let output_name = format!("{node_id}/{display_output}");
 
+                // `duration_since(UNIX_EPOCH)` errors when the wall clock is set
+                // before 1970 (e.g. an embedded target booting with an unset RTC
+                // before NTP sync). Fall back to a zero timestamp rather than
+                // panicking a live `dora topic echo`, mirroring the daemon's
+                // `current_millis()` helper.
                 let timestamp = SystemTime::now()
                     .duration_since(SystemTime::UNIX_EPOCH)
-                    .unwrap()
+                    .unwrap_or_default()
                     .as_millis();
 
                 let data_str = if let Some(data) = data {


### PR DESCRIPTION
## Summary

> ⚠️ **This is a machine-generated change authored by Claude (Claude Code).** It was produced by an automated code-review pass. A human should review before merging.

Three CLI call sites computed a wall-clock timestamp with `SystemTime::now().duration_since(UNIX_EPOCH).unwrap()`:

- `binaries/cli/src/command/topic/echo.rs` — the per-message display timestamp
- `binaries/cli/src/command/record.rs` — the recording's `start_nanos` base, and each entry's `now_nanos`

`duration_since(UNIX_EPOCH)` returns `Err` whenever the wall clock is set **before 1970**. On robotics/embedded targets this is a real window, not a theoretical one: a board that boots with an unset RTC reads a pre-epoch default until NTP sync. In that window, `dora topic echo` and `dora record` would **panic outright**, aborting a live inspection or recording.

## Fix

Replace the `.unwrap()`s with `.unwrap_or_default()` — a zero timestamp is a harmless fallback for a display value / relative-offset base. This matches the daemon's own `current_millis()` helper (`binaries/daemon/src/node_communication/mod.rs`), which already uses `.unwrap_or_default()` for exactly this reason. In `record.rs`, both the base `start_nanos` and per-entry `now_nanos` use the same fallback, so `timestamp_offset_nanos` (computed via `saturating_sub`) stays consistent.

## Validation

These sites depend on the process wall clock, which can't be injected in a unit test, so the change is verified by build + lint rather than a new test:
- `cargo build -p dora-cli` — compiles
- `cargo fmt -p dora-cli -- --check` — clean
- `cargo clippy -p dora-cli --all-targets -- -D warnings` — clean

(Distinct from the earlier pre-epoch fix in timestamp *formatting* — these are separate `SystemTime::now()` call sites.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEZNMs7aQj25CJz8DxVvsW)_