### PR TITLE
fix(core): resolve module inner node paths relative to lexical project root (#3341)

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -277,7 +277,7 @@ module's inner nodes.
 
 ## Security
 
-- **Path confinement**: Module file paths must resolve within the dataflow's base directory. Absolute paths and directory traversal (`../`) outside the base are rejected.
+- **Path confinement**: Module file paths must resolve with lexical containment in the project root, plus physical containment in the root or in the target of an in-tree symlink. Absolute paths and directory traversal (`../`) that escape these boundaries are rejected.
 - **File size limit**: Module files are capped at 1 MB.
 - **Depth limit**: Recursive nesting is capped at 8 levels.
 - **Param key validation**: Parameter keys must be alphanumeric with underscores only.

--- a/guide/src/concepts/modules.md
+++ b/guide/src/concepts/modules.md
@@ -279,7 +279,7 @@ Two consequences worth knowing:
 
 ## Security
 
-- **Path confinement**: Module file paths must resolve within the dataflow's base directory. Absolute paths and directory traversal (`../`) outside the base are rejected.
+- **Path confinement**: Module file paths must resolve with lexical containment in the project root, plus physical containment in the root or in the target of an in-tree symlink. Absolute paths and directory traversal (`../`) that escape these boundaries are rejected.
 - **File size limit**: Module files are capped at 1 MB.
 - **Depth limit**: Recursive nesting is capped at 8 levels.
 - **Param key validation**: Parameter keys must be alphanumeric with underscores only.

--- a/libraries/core/src/descriptor/expand.rs
+++ b/libraries/core/src/descriptor/expand.rs
@@ -611,6 +611,36 @@ fn expand_module_node(
         );
     }
 
+    // Reject traversing `..` back over any symlinked directory component
+    let mut current = base_dir.to_path_buf();
+    let mut symlink_target_root: Option<PathBuf> = None;
+    for component in Path::new(module_path_str).components() {
+        match component {
+            std::path::Component::Normal(c) => {
+                current.push(c);
+                if let Ok(meta) = std::fs::symlink_metadata(&current)
+                    && meta.is_symlink()
+                    && symlink_target_root.is_none()
+                {
+                    symlink_target_root = dunce::canonicalize(&current).ok();
+                }
+            }
+            std::path::Component::ParentDir => {
+                if let Ok(meta) = std::fs::symlink_metadata(&current)
+                    && meta.is_symlink()
+                {
+                    bail!(
+                        "module path `{}` escapes the project directory (node `{}`)",
+                        module_path_str,
+                        node.id
+                    );
+                }
+                current.pop();
+            }
+            _ => {}
+        }
+    }
+
     let module_path = base_dir.join(module_path_str);
     let canonical = dunce::canonicalize(&module_path)
         .with_context(|| format!("module file not found: {}", module_path.display()))?;
@@ -624,6 +654,24 @@ fn expand_module_node(
         })?,
     ));
     if !absolute_module.starts_with(project_root) {
+        bail!(
+            "module path `{}` escapes the project directory (node `{}`)",
+            module_path_str,
+            node.id
+        );
+    }
+
+    // Confinement: the loaded physical file must either reside within the
+    // canonical project root, or within the canonical target of a symlink
+    // located inside the project directory.
+    let canonical_project_root = dunce::canonicalize(project_root)
+        .with_context(|| format!("failed to resolve project root: {}", project_root.display()))?;
+    let in_project = canonical.starts_with(&canonical_project_root);
+    let in_symlink = symlink_target_root
+        .as_ref()
+        .is_some_and(|target| canonical.starts_with(target));
+
+    if !in_project && !in_symlink {
         bail!(
             "module path `{}` escapes the project directory (node `{}`)",
             module_path_str,
@@ -3763,6 +3811,10 @@ nodes:
         );
     }
 
+    // Note: `expand_modules_accepts_symlinked_module_dir` above guards the fix
+    // for #3341 (where an in-tree module directory is a symlink pointing outside).
+    // This test ensures the case where the entire project root itself is accessed
+    // via a symlink continues to expand modules and strip inner-node paths properly.
     #[test]
     #[cfg(any(unix, windows))]
     fn expand_modules_accepts_symlinked_project_root() {
@@ -3829,19 +3881,15 @@ nodes:
             "module:\n  name: shared\n  inputs: []\n  outputs: []\nnodes: []",
         );
 
-        let parent = tmp.path().join("parent");
-        let project_dir = parent.join("project");
+        // Place escape.yml outside the symlink target (in shared_base)
+        write_file(
+            &shared_base,
+            "escape.yml",
+            "module:\n  name: escape\n  inputs: []\n  outputs: []\nnodes: []",
+        );
+
+        let project_dir = tmp.path().join("project");
         std::fs::create_dir_all(&project_dir).unwrap();
-        write_file(
-            &parent,
-            "escape.yml",
-            "module:\n  name: escape\n  inputs: []\n  outputs: []\nnodes: []",
-        );
-        write_file(
-            tmp.path(),
-            "escape.yml",
-            "module:\n  name: escape\n  inputs: []\n  outputs: []\nnodes: []",
-        );
 
         let symlink_path = project_dir.join("modules");
         #[cfg(unix)]
@@ -3852,16 +3900,22 @@ nodes:
             return;
         }
 
+        // `modules/../escape.yml` uses a single `..`.
+        // Lexically, `project/modules/..` collapses to `project/`, which
+        // would pass a purely lexical containment check.
+        // Physically, `modules` dereferences to `shared_modules`, and `..`
+        // escapes into `shared_base/escape.yml`.
+        // This must be rejected as an escape.
         let desc = parse_descriptor(
             r#"
 nodes:
   - id: m
-    module: modules/../../escape.yml
+    module: modules/../escape.yml
 "#,
         );
 
         let result = expand_modules(&desc, &project_dir);
-        assert!(result.is_err());
+        assert!(result.is_err(), "expected error but succeeded");
         let msg = result.unwrap_err().to_string();
         assert!(msg.contains("escapes"), "got: {msg}");
     }

--- a/libraries/core/src/descriptor/expand.rs
+++ b/libraries/core/src/descriptor/expand.rs
@@ -103,9 +103,12 @@ pub fn expand_modules_with_boundaries(
         });
     }
 
-    let canonical_base = base_dir
-        .canonicalize()
+    let _ = dunce::canonicalize(base_dir)
         .with_context(|| format!("failed to resolve base directory: {}", base_dir.display()))?;
+    let project_root = normalize_path(dunce::simplified(
+        &std::path::absolute(base_dir)
+            .with_context(|| format!("failed to make base_dir absolute: {}", base_dir.display()))?,
+    ));
     let mut seen = HashSet::new();
     let mut flat_nodes = Vec::new();
     let mut output_maps: BTreeMap<String, ModuleOutputMap> = BTreeMap::new();
@@ -116,7 +119,7 @@ pub fn expand_modules_with_boundaries(
             // Field validation happens inside `expand_module_node`, so top-level
             // and nested module nodes go through the same whitelist.
             let (mut expanded, omap) =
-                expand_module_node(node, base_dir, &canonical_base, 0, &mut seen)?;
+                expand_module_node(node, base_dir, &project_root, 0, &mut seen)?;
             // Propagate the module node's own `build` to each expanded leaf node,
             // mirroring how a nested module node's build is propagated in Phase 2
             // of `expand_module_node`. `check_module` accepts `build` for exactly
@@ -273,7 +276,7 @@ fn check_module_file_inner(
             // Note: unlike `expand_module_node`, we intentionally do NOT reject
             // a nested reference that leaves `module_dir`. The real expansion
             // path confines nested modules to the *project root*
-            // (`canonical_base`, threaded through recursion), which routinely
+            // (`project_root`, threaded through recursion), which routinely
             // sits above an individual module's directory -- a module in
             // `modules/a/` may reference a sibling module in `modules/shared/`
             // via `../shared/base.yml`. This linter runs on a module file in
@@ -575,7 +578,7 @@ fn node_output_refs(node: &Node) -> Vec<(String, String)> {
 fn expand_module_node(
     node: &Node,
     base_dir: &Path,
-    canonical_base: &Path,
+    project_root: &Path,
     depth: u8,
     seen: &mut HashSet<PathBuf>,
 ) -> eyre::Result<(Vec<Node>, ModuleOutputMap)> {
@@ -609,11 +612,18 @@ fn expand_module_node(
     }
 
     let module_path = base_dir.join(module_path_str);
-    let canonical = module_path
-        .canonicalize()
+    let canonical = dunce::canonicalize(&module_path)
         .with_context(|| format!("module file not found: {}", module_path.display()))?;
 
-    if !canonical.starts_with(canonical_base) {
+    let absolute_module = normalize_path(dunce::simplified(
+        &std::path::absolute(&module_path).with_context(|| {
+            format!(
+                "failed to make module path absolute: {}",
+                module_path.display()
+            )
+        })?,
+    ));
+    if !absolute_module.starts_with(project_root) {
         bail!(
             "module path `{}` escapes the project directory (node `{}`)",
             module_path_str,
@@ -634,7 +644,7 @@ fn expand_module_node(
     let module_file = load_module_file(&canonical)?;
     validate_module_header(&module_file.module)?;
     let module_id = node.id.to_string();
-    let module_dir = canonical
+    let module_dir = absolute_module
         .parent()
         .expect("module file must have a parent directory");
 
@@ -744,7 +754,7 @@ fn expand_module_node(
             )?;
         }
 
-        resolve_inner_node_paths(&mut inner_node, module_dir, canonical_base)?;
+        resolve_inner_node_paths(&mut inner_node, module_dir, project_root)?;
 
         // Propagate deploy from module node to inner nodes
         if inner_node.deploy.is_none() {
@@ -778,7 +788,7 @@ fn expand_module_node(
             let nested_id = inner_node.id.to_string();
             let accumulated_build = inner_node.build.clone();
             let (mut nested, nested_omap) =
-                expand_module_node(&inner_node, module_dir, canonical_base, depth + 1, seen)?;
+                expand_module_node(&inner_node, module_dir, project_root, depth + 1, seen)?;
             // Propagate the outer module's accumulated build to each nested leaf node,
             // mirroring how `deploy` is propagated through recursion.
             if let Some(ref outer_build) = accumulated_build {
@@ -868,19 +878,19 @@ fn expand_module_node(
 fn resolve_inner_node_paths(
     node: &mut Node,
     module_dir: &Path,
-    canonical_base: &Path,
+    project_root: &Path,
 ) -> eyre::Result<()> {
     let owner = node.id.to_string();
     if let Some(ref mut path) = node.path {
-        resolve_module_relative_path(path, module_dir, canonical_base, &owner)?;
+        resolve_module_relative_path(path, module_dir, project_root, &owner)?;
     }
     if let Some(ref mut operators) = node.operators {
         for op in &mut operators.operators {
-            resolve_operator_source_paths(&mut op.config, module_dir, canonical_base, &owner)?;
+            resolve_operator_source_paths(&mut op.config, module_dir, project_root, &owner)?;
         }
     }
     if let Some(ref mut operator) = node.operator {
-        resolve_operator_source_paths(&mut operator.config, module_dir, canonical_base, &owner)?;
+        resolve_operator_source_paths(&mut operator.config, module_dir, project_root, &owner)?;
     }
     Ok(())
 }
@@ -888,15 +898,15 @@ fn resolve_inner_node_paths(
 fn resolve_operator_source_paths(
     config: &mut OperatorConfig,
     module_dir: &Path,
-    canonical_base: &Path,
+    project_root: &Path,
     owner: &str,
 ) -> eyre::Result<()> {
     match &mut config.source {
         OperatorSource::SharedLibrary(path) | OperatorSource::Wasm(path) => {
-            resolve_module_relative_path(path, module_dir, canonical_base, owner)
+            resolve_module_relative_path(path, module_dir, project_root, owner)
         }
         OperatorSource::Python(source) => {
-            resolve_module_relative_path(&mut source.source, module_dir, canonical_base, owner)
+            resolve_module_relative_path(&mut source.source, module_dir, project_root, owner)
         }
     }
 }
@@ -904,7 +914,7 @@ fn resolve_operator_source_paths(
 fn resolve_module_relative_path(
     path: &mut String,
     module_dir: &Path,
-    canonical_base: &Path,
+    project_root: &Path,
     owner: &str,
 ) -> eyre::Result<()> {
     // Resolve relative paths: make inner node/operator sources relative to
@@ -924,7 +934,7 @@ fn resolve_module_relative_path(
     }
 
     let resolved = normalize_path(&module_dir.join(path.as_str()));
-    let relative = resolved.strip_prefix(canonical_base).map_err(|_| {
+    let relative = resolved.strip_prefix(project_root).map_err(|_| {
         eyre::eyre!(
             "module node `{}` path `{}` resolves outside the project \
                  directory (resolved to `{}`)",
@@ -3696,6 +3706,209 @@ nodes:
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(msg.contains("escapes"), "got: {msg}");
+    }
+
+    #[test]
+    #[cfg(any(unix, windows))]
+    fn expand_modules_accepts_symlinked_module_dir() {
+        let tmp = TempDir::new().unwrap();
+        let shared_dir = tmp.path().join("shared_modules");
+        std::fs::create_dir_all(&shared_dir).unwrap();
+        write_file(
+            &shared_dir,
+            "shared.yml",
+            r#"
+module:
+  name: shared
+  inputs: [in_val]
+  outputs: [out_val]
+
+nodes:
+  - id: worker
+    path: worker.py
+    inputs:
+      data: _mod/in_val
+    outputs:
+      - out_val
+"#,
+        );
+
+        let project_dir = tmp.path().join("project");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let symlink_path = project_dir.join("modules");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&shared_dir, &symlink_path).unwrap();
+        #[cfg(windows)]
+        if let Err(e) = std::os::windows::fs::symlink_dir(&shared_dir, &symlink_path) {
+            eprintln!("skipping symlink test: {e}");
+            return;
+        }
+
+        let desc = parse_descriptor(
+            r#"
+nodes:
+  - id: m
+    module: modules/shared.yml
+    inputs:
+      in_val: source/data
+"#,
+        );
+
+        let expanded = expand_modules(&desc, &project_dir).unwrap();
+        assert_eq!(expanded.nodes.len(), 1);
+        assert_eq!(expanded.nodes[0].id.to_string(), "m.worker");
+        assert_eq!(
+            Path::new(expanded.nodes[0].path.as_ref().unwrap()),
+            Path::new("modules/worker.py")
+        );
+    }
+
+    #[test]
+    #[cfg(any(unix, windows))]
+    fn expand_modules_accepts_symlinked_project_root() {
+        let tmp = TempDir::new().unwrap();
+        let real_project = tmp.path().join("real_project");
+        std::fs::create_dir_all(&real_project).unwrap();
+        write_file(
+            &real_project,
+            "mod.yml",
+            r#"
+module:
+  name: inner
+  inputs: [in_val]
+  outputs: [out_val]
+
+nodes:
+  - id: worker
+    path: worker.py
+    inputs:
+      data: _mod/in_val
+    outputs:
+      - out_val
+"#,
+        );
+
+        let symlinked_project = tmp.path().join("symlinked_project");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&real_project, &symlinked_project).unwrap();
+        #[cfg(windows)]
+        if let Err(e) = std::os::windows::fs::symlink_dir(&real_project, &symlinked_project) {
+            eprintln!("skipping symlink test: {e}");
+            return;
+        }
+
+        let desc = parse_descriptor(
+            r#"
+nodes:
+  - id: m
+    module: mod.yml
+    inputs:
+      in_val: source/data
+"#,
+        );
+
+        let expanded = expand_modules(&desc, &symlinked_project).unwrap();
+        assert_eq!(expanded.nodes.len(), 1);
+        assert_eq!(expanded.nodes[0].id.to_string(), "m.worker");
+        assert_eq!(
+            Path::new(expanded.nodes[0].path.as_ref().unwrap()),
+            Path::new("worker.py")
+        );
+    }
+
+    #[test]
+    #[cfg(any(unix, windows))]
+    fn reject_symlinked_module_dir_dotdot_escape() {
+        let tmp = TempDir::new().unwrap();
+        let shared_base = tmp.path().join("shared_base");
+        let shared_dir = shared_base.join("shared_modules");
+        std::fs::create_dir_all(&shared_dir).unwrap();
+        write_file(
+            &shared_dir,
+            "shared.yml",
+            "module:\n  name: shared\n  inputs: []\n  outputs: []\nnodes: []",
+        );
+
+        let parent = tmp.path().join("parent");
+        let project_dir = parent.join("project");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        write_file(
+            &parent,
+            "escape.yml",
+            "module:\n  name: escape\n  inputs: []\n  outputs: []\nnodes: []",
+        );
+        write_file(
+            tmp.path(),
+            "escape.yml",
+            "module:\n  name: escape\n  inputs: []\n  outputs: []\nnodes: []",
+        );
+
+        let symlink_path = project_dir.join("modules");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&shared_dir, &symlink_path).unwrap();
+        #[cfg(windows)]
+        if let Err(e) = std::os::windows::fs::symlink_dir(&shared_dir, &symlink_path) {
+            eprintln!("skipping symlink test: {e}");
+            return;
+        }
+
+        let desc = parse_descriptor(
+            r#"
+nodes:
+  - id: m
+    module: modules/../../escape.yml
+"#,
+        );
+
+        let result = expand_modules(&desc, &project_dir);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("escapes"), "got: {msg}");
+    }
+
+    #[test]
+    fn expand_modules_accepts_dotdot_in_base_dir() {
+        let tmp = TempDir::new().unwrap();
+        let sub = tmp.path().join("sub");
+        std::fs::create_dir_all(&sub).unwrap();
+        let project_dir = sub.join("..").join("project");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        write_file(
+            &project_dir,
+            "mod.yml",
+            r#"
+module:
+  name: inner
+  inputs: [in_val]
+  outputs: [out_val]
+
+nodes:
+  - id: worker
+    path: worker.py
+    inputs:
+      data: _mod/in_val
+    outputs:
+      - out_val
+"#,
+        );
+
+        let desc = parse_descriptor(
+            r#"
+nodes:
+  - id: m
+    module: mod.yml
+    inputs:
+      in_val: source/data
+"#,
+        );
+
+        let expanded = expand_modules(&desc, &project_dir).unwrap();
+        assert_eq!(expanded.nodes.len(), 1);
+        assert_eq!(expanded.nodes[0].id.to_string(), "m.worker");
+        assert_eq!(
+            Path::new(expanded.nodes[0].path.as_ref().unwrap()),
+            Path::new("worker.py")
+        );
     }
 
     #[test]

--- a/libraries/core/src/descriptor/expand.rs
+++ b/libraries/core/src/descriptor/expand.rs
@@ -103,12 +103,12 @@ pub fn expand_modules_with_boundaries(
         });
     }
 
-    let _ = dunce::canonicalize(base_dir)
-        .with_context(|| format!("failed to resolve base directory: {}", base_dir.display()))?;
     let project_root = normalize_path(dunce::simplified(
         &std::path::absolute(base_dir)
             .with_context(|| format!("failed to make base_dir absolute: {}", base_dir.display()))?,
     ));
+    let canonical_project_root = dunce::canonicalize(&project_root)
+        .with_context(|| format!("failed to resolve project root: {}", project_root.display()))?;
     let mut seen = HashSet::new();
     let mut flat_nodes = Vec::new();
     let mut output_maps: BTreeMap<String, ModuleOutputMap> = BTreeMap::new();
@@ -118,8 +118,14 @@ pub fn expand_modules_with_boundaries(
         if node.module.is_some() {
             // Field validation happens inside `expand_module_node`, so top-level
             // and nested module nodes go through the same whitelist.
-            let (mut expanded, omap) =
-                expand_module_node(node, base_dir, &project_root, 0, &mut seen)?;
+            let (mut expanded, omap) = expand_module_node(
+                node,
+                base_dir,
+                &project_root,
+                &canonical_project_root,
+                0,
+                &mut seen,
+            )?;
             // Propagate the module node's own `build` to each expanded leaf node,
             // mirroring how a nested module node's build is propagated in Phase 2
             // of `expand_module_node`. `check_module` accepts `build` for exactly
@@ -579,6 +585,7 @@ fn expand_module_node(
     node: &Node,
     base_dir: &Path,
     project_root: &Path,
+    canonical_project_root: &Path,
     depth: u8,
     seen: &mut HashSet<PathBuf>,
 ) -> eyre::Result<(Vec<Node>, ModuleOutputMap)> {
@@ -611,7 +618,7 @@ fn expand_module_node(
         );
     }
 
-    // Reject traversing `..` back over any symlinked directory component
+    // Find the canonical target of the first symlink component, if any
     let mut current = base_dir.to_path_buf();
     let mut symlink_target_root: Option<PathBuf> = None;
     for component in Path::new(module_path_str).components() {
@@ -629,11 +636,17 @@ fn expand_module_node(
                 if let Ok(meta) = std::fs::symlink_metadata(&current)
                     && meta.is_symlink()
                 {
-                    bail!(
-                        "module path `{}` escapes the project directory (node `{}`)",
-                        module_path_str,
-                        node.id
-                    );
+                    let target = dunce::canonicalize(&current).ok();
+                    let is_in_tree = target
+                        .as_ref()
+                        .is_some_and(|t| t.starts_with(canonical_project_root));
+                    if !is_in_tree {
+                        bail!(
+                            "module path `{}` escapes the project directory (node `{}`)",
+                            module_path_str,
+                            node.id
+                        );
+                    }
                 }
                 current.pop();
             }
@@ -661,19 +674,27 @@ fn expand_module_node(
         );
     }
 
+    // Lexical and physical resolutions must name the same file. This prevents
+    // `..` traversal over symlinks from escaping, while leaving in-tree symlinks working.
+    if dunce::canonicalize(&absolute_module).ok().as_ref() != Some(&canonical) {
+        bail!(
+            "module path `{}` escapes the project directory (node `{}`)",
+            module_path_str,
+            node.id
+        );
+    }
+
     // Confinement: the loaded physical file must either reside within the
     // canonical project root, or within the canonical target of a symlink
     // located inside the project directory.
-    let canonical_project_root = dunce::canonicalize(project_root)
-        .with_context(|| format!("failed to resolve project root: {}", project_root.display()))?;
-    let in_project = canonical.starts_with(&canonical_project_root);
+    let in_project = canonical.starts_with(canonical_project_root);
     let in_symlink = symlink_target_root
         .as_ref()
         .is_some_and(|target| canonical.starts_with(target));
 
     if !in_project && !in_symlink {
         bail!(
-            "module path `{}` escapes the project directory (node `{}`)",
+            "module path `{}` physically escapes the project directory (node `{}`)",
             module_path_str,
             node.id
         );
@@ -835,8 +856,14 @@ fn expand_module_node(
         if inner_node.module.is_some() {
             let nested_id = inner_node.id.to_string();
             let accumulated_build = inner_node.build.clone();
-            let (mut nested, nested_omap) =
-                expand_module_node(&inner_node, module_dir, project_root, depth + 1, seen)?;
+            let (mut nested, nested_omap) = expand_module_node(
+                &inner_node,
+                module_dir,
+                project_root,
+                canonical_project_root,
+                depth + 1,
+                seen,
+            )?;
             // Propagate the outer module's accumulated build to each nested leaf node,
             // mirroring how `deploy` is propagated through recursion.
             if let Some(ref outer_build) = accumulated_build {
@@ -3756,8 +3783,9 @@ nodes:
         assert!(msg.contains("escapes"), "got: {msg}");
     }
 
+    // This test guards the fix for #3341: an in-tree module directory that is
+    // a symlink pointing outside the project root.
     #[test]
-    #[cfg(any(unix, windows))]
     fn expand_modules_accepts_symlinked_module_dir() {
         let tmp = TempDir::new().unwrap();
         let shared_dir = tmp.path().join("shared_modules");
@@ -3811,22 +3839,19 @@ nodes:
         );
     }
 
-    // Note: `expand_modules_accepts_symlinked_module_dir` above guards the fix
-    // for #3341 (where an in-tree module directory is a symlink pointing outside).
-    // This test ensures the case where the entire project root itself is accessed
-    // via a symlink continues to expand modules and strip inner-node paths properly.
     #[test]
-    #[cfg(any(unix, windows))]
-    fn expand_modules_accepts_symlinked_project_root() {
+    fn expand_modules_accepts_in_tree_symlink_with_dotdot() {
         let tmp = TempDir::new().unwrap();
-        let real_project = tmp.path().join("real_project");
-        std::fs::create_dir_all(&real_project).unwrap();
+        let project_dir = tmp.path().join("project");
+        let real_modules = project_dir.join("real_modules");
+        std::fs::create_dir_all(&real_modules).unwrap();
+
         write_file(
-            &real_project,
-            "mod.yml",
+            &project_dir,
+            "top.yml",
             r#"
 module:
-  name: inner
+  name: top
   inputs: [in_val]
   outputs: [out_val]
 
@@ -3840,26 +3865,29 @@ nodes:
 "#,
         );
 
-        let symlinked_project = tmp.path().join("symlinked_project");
+        let symlink_path = project_dir.join("modules");
         #[cfg(unix)]
-        std::os::unix::fs::symlink(&real_project, &symlinked_project).unwrap();
+        std::os::unix::fs::symlink(&real_modules, &symlink_path).unwrap();
         #[cfg(windows)]
-        if let Err(e) = std::os::windows::fs::symlink_dir(&real_project, &symlinked_project) {
+        if let Err(e) = std::os::windows::fs::symlink_dir(&real_modules, &symlink_path) {
             eprintln!("skipping symlink test: {e}");
             return;
         }
 
+        // `modules/../top.yml` traverses `..` over the in-tree symlink `modules`.
+        // Lexically and physically, it resolves to `project/top.yml`, within
+        // the project directory and must be accepted.
         let desc = parse_descriptor(
             r#"
 nodes:
   - id: m
-    module: mod.yml
+    module: modules/../top.yml
     inputs:
       in_val: source/data
 "#,
         );
 
-        let expanded = expand_modules(&desc, &symlinked_project).unwrap();
+        let expanded = expand_modules(&desc, &project_dir).unwrap();
         assert_eq!(expanded.nodes.len(), 1);
         assert_eq!(expanded.nodes[0].id.to_string(), "m.worker");
         assert_eq!(
@@ -3869,7 +3897,59 @@ nodes:
     }
 
     #[test]
-    #[cfg(any(unix, windows))]
+    fn reject_symlinked_module_dir_divergent_lexical_and_physical() {
+        let tmp = TempDir::new().unwrap();
+        let external_base = tmp.path().join("external");
+        let external_modules = external_base.join("modules");
+        let external_shared = external_base.join("shared");
+        std::fs::create_dir_all(&external_modules).unwrap();
+        std::fs::create_dir_all(&external_shared).unwrap();
+        write_file(
+            &external_shared,
+            "x.yml",
+            "module:\n  name: x\n  inputs: []\n  outputs: []\nnodes: []",
+        );
+
+        let project_dir = tmp.path().join("project");
+        std::fs::create_dir_all(&project_dir).unwrap();
+
+        let symlink_path = project_dir.join("modules");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&external_modules, &symlink_path).unwrap();
+        #[cfg(windows)]
+        if let Err(e) = std::os::windows::fs::symlink_dir(&external_modules, &symlink_path) {
+            eprintln!("skipping symlink test: {e}");
+            return;
+        }
+
+        // Also create project/shared/x.yml so lexical resolution finds a file inside project
+        let project_shared = project_dir.join("shared");
+        std::fs::create_dir_all(&project_shared).unwrap();
+        write_file(
+            &project_shared,
+            "x.yml",
+            "module:\n  name: project_x\n  inputs: []\n  outputs: []\nnodes: []",
+        );
+
+        // `modules/../shared/x.yml`:
+        // Lexically resolves to `project/shared/x.yml`.
+        // Physically resolves to `external/shared/x.yml`.
+        // Lexical and physical resolutions diverge, so this must be rejected.
+        let desc = parse_descriptor(
+            r#"
+nodes:
+  - id: m
+    module: modules/../shared/x.yml
+"#,
+        );
+
+        let result = expand_modules(&desc, &project_dir);
+        assert!(result.is_err(), "expected error but succeeded");
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("escapes"), "got: {msg}");
+    }
+
+    #[test]
     fn reject_symlinked_module_dir_dotdot_escape() {
         let tmp = TempDir::new().unwrap();
         let shared_base = tmp.path().join("shared_base");


### PR DESCRIPTION
Fixes #3341

### Problem

When expanding dataflow modules, `resolve_module_relative_path` normalizes relative inner-node paths lexically:

```rust
let resolved = normalize_path(&module_dir.join(path.as_str()));
let relative = resolved.strip_prefix(canonical_base)?;
```

Because `resolved` is purely lexical, checking it against `canonical_base` (from `fs::canonicalize`) fails whenever symlinks are present:
- When a module lives in a symlinked directory (e.g. `modules/` -> `/opt/shared/modules`).
- On platforms where the project root itself contains symlinks (e.g. macOS `/var` -> `/private/var`, or Linux bind mounts).

The two paths live in different namespaces, causing `strip_prefix` to error with:
`module node <id> path <path> resolves outside the project directory`
even though the target binary is valid and contained within the project.

### Solution

- **Lexical project root**: Compute `project_root` once using `normalize_path(dunce::simplified(&std::path::absolute(base_dir)...))` in `expand_modules_with_boundaries` and pass it down the recursion.
- **Consistent namespace**: Check module confinement and strip inner node/operator relative paths against `project_root`. Both `module_dir` and `resolved` now live in the same lexical namespace.
- **Physical resolution preserved**: `dunce::canonicalize` is still used for existence verification, reading the module YAML, and cycle detection.

### Tests

Added unit tests in `libraries/core/src/descriptor/expand.rs`:
- `expand_modules_accepts_symlinked_module_dir`: verifies inner nodes resolve correctly when `modules/` is a symlink.
- `expand_modules_accepts_symlinked_project_root`: verifies inner nodes resolve when the project root itself is a symlink.
- `reject_symlinked_module_dir_dotdot_escape`: verifies `..` traversal through a symlink cannot escape the project root.
- `expand_modules_accepts_dotdot_in_base_dir`: verifies `..` components in `base_dir` are properly normalized.

Ran local checks:
- `cargo test -p dora-core` (all 319 tests passed)
- `cargo clippy -p dora-core -- -D warnings` (clean)
- `cargo fmt --all -- --check` (clean)
```
