### PR TITLE
fix(daemon): drop a removed node's cached remote publishers on cleanup

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -3598,7 +3598,10 @@ impl Daemon {
                     dataflow.connected_nodes.remove(&node_id);
                     dataflow.finish_escalated.remove(&node_id);
                     // `forget_node_bookkeeping` also drops the recorded
-                    // cascading-error cause for this id (see its doc comment).
+                    // cascading-error cause and the id's `OutputId`-keyed
+                    // remote publishers / debug-topic watchers for this id
+                    // (see its doc comment). The replacement re-declares any
+                    // publisher on its next remote send.
                     dataflow.forget_node_bookkeeping(&node_id);
                     dataflow
                         .node_stderr_most_recent
@@ -8930,6 +8933,7 @@ mod fault_tolerance_tests {
         let node_a: NodeId = "node_a".to_string().into();
         let node_b: NodeId = "node_b".to_string().into();
         let input_x: DataId = "input_x".to_string().into();
+        let output_m: DataId = "message".to_string().into();
         let timeout = Duration::from_secs(1);
 
         let upstream: NodeId = "upstream".to_string().into();
@@ -8948,6 +8952,11 @@ mod fault_tolerance_tests {
             // Both nodes were recorded as cascading victims of `upstream`.
             df.cascading_error_causes
                 .report_cascading_error(upstream.clone(), node.clone());
+            // Both nodes have a debug-topic watcher on their `message` output.
+            df.debug_topic_watchers.insert(
+                OutputId(node.clone(), output_m.clone()),
+                std::collections::BTreeSet::from([uuid::Uuid::new_v4()]),
+            );
         }
 
         df.forget_node_bookkeeping(&node_a);
@@ -8966,6 +8975,12 @@ mod fault_tolerance_tests {
         // `node_a` incarnation is classified by its own failure, not a stale
         // upstream cause (dora-rs/dora#2927).
         assert_eq!(df.cascading_error_causes.error_caused_by(&node_a), None);
+        // … and its `OutputId`-keyed debug-topic watcher, which would otherwise
+        // leak across repeated dynamic add/remove cycles.
+        assert!(
+            !df.debug_topic_watchers
+                .contains_key(&OutputId(node_a.clone(), output_m.clone()))
+        );
 
         // … while node_b's are untouched.
         assert!(
@@ -8980,6 +8995,10 @@ mod fault_tolerance_tests {
         assert_eq!(
             df.cascading_error_causes.error_caused_by(&node_b),
             Some(&upstream)
+        );
+        assert!(
+            df.debug_topic_watchers
+                .contains_key(&OutputId(node_b.clone(), output_m.clone()))
         );
     }
 

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -3238,6 +3238,10 @@ impl Daemon {
                     // every tick forever and the stderr queue leaks across
                     // repeated dynamic add/remove cycles.
                     dataflow.forget_node_bookkeeping(&node_id);
+                    // The node is gone for good and emits no more frames, so
+                    // its debug-topic watchers can go too. `ReplaceNode` must
+                    // NOT do this — see the method's doc comment.
+                    dataflow.forget_debug_topic_watchers(&node_id);
 
                     // Remove from stored descriptor (inverse of AddNode
                     // push) so descriptor-based lookups stay consistent.
@@ -3599,9 +3603,15 @@ impl Daemon {
                     dataflow.finish_escalated.remove(&node_id);
                     // `forget_node_bookkeeping` also drops the recorded
                     // cascading-error cause and the id's `OutputId`-keyed
-                    // remote publishers / debug-topic watchers for this id
-                    // (see its doc comment). The replacement re-declares any
-                    // publisher on its next remote send.
+                    // remote publishers (see its doc comment). The replacement
+                    // re-declares any publisher on its next remote send.
+                    //
+                    // A fourth deliberate NON-reset belongs with the three
+                    // above: `debug_topic_watchers` is node-id-keyed
+                    // subscription state that only a fresh
+                    // `StartTopicDebugStream` can recreate, so purging it here
+                    // would silently kill an active `dora topic` stream across
+                    // the restart. It is dropped on `RemoveNode` only.
                     dataflow.forget_node_bookkeeping(&node_id);
                     dataflow
                         .node_stderr_most_recent
@@ -8955,7 +8965,7 @@ mod fault_tolerance_tests {
             // Both nodes have a debug-topic watcher on their `message` output.
             df.debug_topic_watchers.insert(
                 OutputId(node.clone(), output_m.clone()),
-                std::collections::BTreeSet::from([uuid::Uuid::new_v4()]),
+                BTreeSet::from([uuid::Uuid::new_v4()]),
             );
         }
 
@@ -8975,11 +8985,17 @@ mod fault_tolerance_tests {
         // `node_a` incarnation is classified by its own failure, not a stale
         // upstream cause (dora-rs/dora#2927).
         assert_eq!(df.cascading_error_causes.error_caused_by(&node_a), None);
-        // … and its `OutputId`-keyed debug-topic watcher, which would otherwise
-        // leak across repeated dynamic add/remove cycles.
+        // … but NOT its debug-topic watchers. `ReplaceNode` calls only this
+        // method, and a replacement resumes under the same
+        // `OutputId(node_id, output)` with nothing to re-register watchers, so
+        // purging them here would silently kill an active `dora topic` stream
+        // across a fault-tolerant restart. `RemoveNode` drops them separately
+        // via `forget_debug_topic_watchers`.
         assert!(
-            !df.debug_topic_watchers
-                .contains_key(&OutputId(node_a.clone(), output_m.clone()))
+            df.debug_topic_watchers
+                .contains_key(&OutputId(node_a.clone(), output_m.clone())),
+            "debug-topic watchers must survive `forget_node_bookkeeping`, so a \
+             ReplaceNode restart keeps an active debug stream alive"
         );
 
         // … while node_b's are untouched.
@@ -8999,6 +9015,46 @@ mod fault_tolerance_tests {
         assert!(
             df.debug_topic_watchers
                 .contains_key(&OutputId(node_b.clone(), output_m.clone()))
+        );
+    }
+
+    #[test]
+    fn forget_debug_topic_watchers_purges_only_that_node() {
+        // The `RemoveNode`-only half of the purge: a removed node emits no more
+        // frames, so its `OutputId`-keyed watchers must go, otherwise they are
+        // reaped only by an explicit unsubscribe and leak across repeated
+        // dynamic add/remove cycles. Other nodes' watchers must be untouched.
+        let mut df = test_dataflow();
+        let node_a: NodeId = "node_a".to_string().into();
+        let node_b: NodeId = "node_b".to_string().into();
+        let output_m: DataId = "message".to_string().into();
+        let output_n: DataId = "status".to_string().into();
+
+        for node in [&node_a, &node_b] {
+            for output in [&output_m, &output_n] {
+                df.debug_topic_watchers.insert(
+                    OutputId(node.clone(), output.clone()),
+                    BTreeSet::from([uuid::Uuid::new_v4()]),
+                );
+            }
+        }
+
+        df.forget_debug_topic_watchers(&node_a);
+
+        // Every output of node_a is gone, regardless of output name …
+        assert!(
+            !df.debug_topic_watchers
+                .keys()
+                .any(|OutputId(node, _)| node == &node_a)
+        );
+        // … while node_b keeps all of its watchers.
+        assert!(
+            df.debug_topic_watchers
+                .contains_key(&OutputId(node_b.clone(), output_m.clone()))
+        );
+        assert!(
+            df.debug_topic_watchers
+                .contains_key(&OutputId(node_b.clone(), output_n.clone()))
         );
     }
 

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -3238,10 +3238,6 @@ impl Daemon {
                     // every tick forever and the stderr queue leaks across
                     // repeated dynamic add/remove cycles.
                     dataflow.forget_node_bookkeeping(&node_id);
-                    // The node is gone for good and emits no more frames, so
-                    // its debug-topic watchers can go too. `ReplaceNode` must
-                    // NOT do this — see the method's doc comment.
-                    dataflow.forget_debug_topic_watchers(&node_id);
 
                     // Remove from stored descriptor (inverse of AddNode
                     // push) so descriptor-based lookups stay consistent.
@@ -3601,17 +3597,11 @@ impl Daemon {
                     dataflow.all_inputs_closed_at.remove(&node_id);
                     dataflow.connected_nodes.remove(&node_id);
                     dataflow.finish_escalated.remove(&node_id);
-                    // `forget_node_bookkeeping` also drops the recorded
-                    // cascading-error cause and the id's `OutputId`-keyed
-                    // remote publishers (see its doc comment). The replacement
-                    // re-declares any publisher on its next remote send.
-                    //
-                    // A fourth deliberate NON-reset belongs with the three
-                    // above: `debug_topic_watchers` is node-id-keyed
-                    // subscription state that only a fresh
-                    // `StartTopicDebugStream` can recreate, so purging it here
-                    // would silently kill an active `dora topic` stream across
-                    // the restart. It is dropped on `RemoveNode` only.
+                    // Also drops the cascading-error cause and the id's
+                    // `OutputId`-keyed remote publishers (re-declared on the
+                    // replacement's next remote send); `debug_topic_watchers`
+                    // is left intact on every path. See the method's doc
+                    // comment for the full rationale.
                     dataflow.forget_node_bookkeeping(&node_id);
                     dataflow
                         .node_stderr_most_recent
@@ -8985,17 +8975,19 @@ mod fault_tolerance_tests {
         // `node_a` incarnation is classified by its own failure, not a stale
         // upstream cause (dora-rs/dora#2927).
         assert_eq!(df.cascading_error_causes.error_caused_by(&node_a), None);
-        // … but NOT its debug-topic watchers. `ReplaceNode` calls only this
-        // method, and a replacement resumes under the same
-        // `OutputId(node_id, output)` with nothing to re-register watchers, so
-        // purging them here would silently kill an active `dora topic` stream
-        // across a fault-tolerant restart. `RemoveNode` drops them separately
-        // via `forget_debug_topic_watchers`.
+        // … but NOT its debug-topic watchers. This cleanup runs on both the
+        // `RemoveNode` and `ReplaceNode` paths, and neither re-registers a
+        // watcher afterwards (only a fresh `StartTopicDebugStream` does). Since
+        // remove + re-add and replace both resume under the same
+        // `OutputId(node_id, output)`, purging here would silently kill an
+        // active `dora topic` stream across the cycle. Watchers are never
+        // purged by node-id churn anywhere; this pins that.
         assert!(
             df.debug_topic_watchers
                 .contains_key(&OutputId(node_a.clone(), output_m.clone())),
-            "debug-topic watchers must survive `forget_node_bookkeeping`, so a \
-             ReplaceNode restart keeps an active debug stream alive"
+            "debug-topic watchers must survive `forget_node_bookkeeping` on \
+             every path, so a remove+re-add or ReplaceNode keeps an active \
+             debug stream alive"
         );
 
         // … while node_b's are untouched.
@@ -9015,46 +9007,6 @@ mod fault_tolerance_tests {
         assert!(
             df.debug_topic_watchers
                 .contains_key(&OutputId(node_b.clone(), output_m.clone()))
-        );
-    }
-
-    #[test]
-    fn forget_debug_topic_watchers_purges_only_that_node() {
-        // The `RemoveNode`-only half of the purge: a removed node emits no more
-        // frames, so its `OutputId`-keyed watchers must go, otherwise they are
-        // reaped only by an explicit unsubscribe and leak across repeated
-        // dynamic add/remove cycles. Other nodes' watchers must be untouched.
-        let mut df = test_dataflow();
-        let node_a: NodeId = "node_a".to_string().into();
-        let node_b: NodeId = "node_b".to_string().into();
-        let output_m: DataId = "message".to_string().into();
-        let output_n: DataId = "status".to_string().into();
-
-        for node in [&node_a, &node_b] {
-            for output in [&output_m, &output_n] {
-                df.debug_topic_watchers.insert(
-                    OutputId(node.clone(), output.clone()),
-                    BTreeSet::from([uuid::Uuid::new_v4()]),
-                );
-            }
-        }
-
-        df.forget_debug_topic_watchers(&node_a);
-
-        // Every output of node_a is gone, regardless of output name …
-        assert!(
-            !df.debug_topic_watchers
-                .keys()
-                .any(|OutputId(node, _)| node == &node_a)
-        );
-        // … while node_b keeps all of its watchers.
-        assert!(
-            df.debug_topic_watchers
-                .contains_key(&OutputId(node_b.clone(), output_m.clone()))
-        );
-        assert!(
-            df.debug_topic_watchers
-                .contains_key(&OutputId(node_b.clone(), output_n.clone()))
         );
     }
 

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -468,11 +468,30 @@ impl RunningDataflow {
     /// failure of the *new* incarnation misattributed to the stale cause and
     /// classified as `NodeErrorCause::Cascading`, suppressing its real stderr
     /// capture.
+    ///
+    /// The two `OutputId`-keyed (`(node id, output)`) maps that the
+    /// `RemoveNode` / `ReplaceNode` routing cleanup never touched are dropped
+    /// too — otherwise each accumulates unboundedly across repeated dynamic
+    /// add/remove cycles that use fresh node ids or output names:
+    /// - the lazily-declared remote `publishers`, created on demand in
+    ///   `send_to_remote_receivers`: a removed node's zenoh `Publisher` (and
+    ///   its retained session clone) would otherwise stay declared for the life
+    ///   of the dataflow. A re-added node re-declares its publisher on the next
+    ///   send;
+    /// - the `debug_topic_watchers` registered when the coordinator forwards a
+    ///   `StartTopicDebugStream`: without this they are only reaped on an
+    ///   explicit unsubscribe, so a debug-watched output of a since-removed node
+    ///   lingers. A dead source produces no frames, so dropping its watchers is
+    ///   safe (a later unsubscribe simply finds nothing for that output).
     pub(crate) fn forget_node_bookkeeping(&mut self, node_id: &NodeId) {
         self.input_deadlines.retain(|(n, _), _| n != node_id);
         self.broken_inputs.retain(|(n, _), _| n != node_id);
         self.node_stderr_most_recent.remove(node_id);
         self.cascading_error_causes.forget(node_id);
+        self.publishers
+            .retain(|output_id, _| &output_id.0 != node_id);
+        self.debug_topic_watchers
+            .retain(|output_id, _| &output_id.0 != node_id);
     }
 
     /// Whether a startup-barrier completion (reported as

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -469,20 +469,19 @@ impl RunningDataflow {
     /// classified as `NodeErrorCause::Cascading`, suppressing its real stderr
     /// capture.
     ///
-    /// The two `OutputId`-keyed (`(node id, output)`) maps that the
-    /// `RemoveNode` / `ReplaceNode` routing cleanup never touched are dropped
-    /// too — otherwise each accumulates unboundedly across repeated dynamic
-    /// add/remove cycles that use fresh node ids or output names:
-    /// - the lazily-declared remote `publishers`, created on demand in
-    ///   `send_to_remote_receivers`: a removed node's zenoh `Publisher` (and
-    ///   its retained session clone) would otherwise stay declared for the life
-    ///   of the dataflow. A re-added node re-declares its publisher on the next
-    ///   send;
-    /// - the `debug_topic_watchers` registered when the coordinator forwards a
-    ///   `StartTopicDebugStream`: without this they are only reaped on an
-    ///   explicit unsubscribe, so a debug-watched output of a since-removed node
-    ///   lingers. A dead source produces no frames, so dropping its watchers is
-    ///   safe (a later unsubscribe simply finds nothing for that output).
+    /// The lazily-declared remote `publishers` — an `OutputId`-keyed
+    /// (`(node id, output)`) map that the `RemoveNode` / `ReplaceNode` routing
+    /// cleanup never touched — are dropped too. They are created on demand in
+    /// `send_to_remote_receivers`, so without this a removed node's zenoh
+    /// `Publisher` (and its retained session clone) would stay declared for the
+    /// life of the dataflow, accumulating unboundedly across repeated dynamic
+    /// add/remove cycles that use fresh node ids or output names. Dropping them
+    /// is safe on both call sites because the next remote send re-declares the
+    /// publisher.
+    ///
+    /// The sibling `debug_topic_watchers` map is deliberately *not* purged here
+    /// — see [`Self::forget_debug_topic_watchers`], which the `RemoveNode` call
+    /// site invokes separately.
     pub(crate) fn forget_node_bookkeeping(&mut self, node_id: &NodeId) {
         self.input_deadlines.retain(|(n, _), _| n != node_id);
         self.broken_inputs.retain(|(n, _), _| n != node_id);
@@ -490,6 +489,26 @@ impl RunningDataflow {
         self.cascading_error_causes.forget(node_id);
         self.publishers
             .retain(|output_id, _| &output_id.0 != node_id);
+    }
+
+    /// Drops the `OutputId`-keyed debug-topic watchers registered for `node_id`
+    /// when the coordinator forwarded a `StartTopicDebugStream`.
+    ///
+    /// Otherwise they are only reaped on an explicit unsubscribe, so a
+    /// debug-watched output of a since-removed node lingers for the life of the
+    /// dataflow. A dead source produces no frames, so dropping its watchers is
+    /// safe (a later unsubscribe simply finds nothing for that output).
+    ///
+    /// This is **`RemoveNode`-only**, and deliberately not folded into
+    /// [`Self::forget_node_bookkeeping`]. A `ReplaceNode` resumes under the
+    /// *same* `OutputId(node_id, output)` and nothing on that path
+    /// re-registers watchers — they are only ever (re)created by a fresh
+    /// `StartTopicDebugStream` from the coordinator. Purging them on replace
+    /// would silently drop an active `dora topic` / debug-inspection stream
+    /// across a fault-tolerant restart, never to recover, which is exactly the
+    /// class of node-id-keyed subscription state that path preserves on
+    /// purpose.
+    pub(crate) fn forget_debug_topic_watchers(&mut self, node_id: &NodeId) {
         self.debug_topic_watchers
             .retain(|output_id, _| &output_id.0 != node_id);
     }

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -479,38 +479,25 @@ impl RunningDataflow {
     /// is safe on both call sites because the next remote send re-declares the
     /// publisher.
     ///
-    /// The sibling `debug_topic_watchers` map is deliberately *not* purged here
-    /// — see [`Self::forget_debug_topic_watchers`], which the `RemoveNode` call
-    /// site invokes separately.
+    /// The sibling `debug_topic_watchers` map is deliberately *not* purged —
+    /// not here and not on any other path. A watcher is only ever (re)created
+    /// by a fresh `StartTopicDebugStream` from the coordinator, and neither the
+    /// `AddNode` re-add path nor the `ReplaceNode` restart re-sends one — only
+    /// a full daemon reconnect does, via the coordinator's
+    /// `restore_topic_debug_streams_for_daemon`. Remove + re-add of the same
+    /// node id is a supported flow (see `added_node_output_routing`) that
+    /// resumes under the same `OutputId(node_id, output)`, exactly like a
+    /// `ReplaceNode`, so purging the watcher would silently kill an active
+    /// `dora topic` stream across that cycle, never to recover. The map only
+    /// grows while a user holds a `dora topic` subscription, and
+    /// `StopTopicDebugStream` already reaps its entries on unsubscribe, so it is
+    /// bounded by live subscriptions rather than by add/remove churn.
     pub(crate) fn forget_node_bookkeeping(&mut self, node_id: &NodeId) {
         self.input_deadlines.retain(|(n, _), _| n != node_id);
         self.broken_inputs.retain(|(n, _), _| n != node_id);
         self.node_stderr_most_recent.remove(node_id);
         self.cascading_error_causes.forget(node_id);
-        self.publishers
-            .retain(|output_id, _| &output_id.0 != node_id);
-    }
-
-    /// Drops the `OutputId`-keyed debug-topic watchers registered for `node_id`
-    /// when the coordinator forwarded a `StartTopicDebugStream`.
-    ///
-    /// Otherwise they are only reaped on an explicit unsubscribe, so a
-    /// debug-watched output of a since-removed node lingers for the life of the
-    /// dataflow. A dead source produces no frames, so dropping its watchers is
-    /// safe (a later unsubscribe simply finds nothing for that output).
-    ///
-    /// This is **`RemoveNode`-only**, and deliberately not folded into
-    /// [`Self::forget_node_bookkeeping`]. A `ReplaceNode` resumes under the
-    /// *same* `OutputId(node_id, output)` and nothing on that path
-    /// re-registers watchers — they are only ever (re)created by a fresh
-    /// `StartTopicDebugStream` from the coordinator. Purging them on replace
-    /// would silently drop an active `dora topic` / debug-inspection stream
-    /// across a fault-tolerant restart, never to recover, which is exactly the
-    /// class of node-id-keyed subscription state that path preserves on
-    /// purpose.
-    pub(crate) fn forget_debug_topic_watchers(&mut self, node_id: &NodeId) {
-        self.debug_topic_watchers
-            .retain(|output_id, _| &output_id.0 != node_id);
+        retain_other_nodes(&mut self.publishers, node_id);
     }
 
     /// Whether a startup-barrier completion (reported as
@@ -1281,6 +1268,15 @@ fn select_finish_stragglers<'a>(
         .collect()
 }
 
+/// Drops every entry of an `OutputId`-keyed map whose output belongs to
+/// `node_id`, keeping all others. Extracted so the keying can be unit-tested:
+/// its one production caller purges [`RunningDataflow::publishers`], whose value
+/// type (`Arc<zenoh::pubsub::Publisher>`) can't be constructed in-process, so a
+/// direct map-shape test of that field isn't possible.
+fn retain_other_nodes<V>(map: &mut BTreeMap<OutputId, V>, node_id: &NodeId) {
+    map.retain(|output_id, _| &output_id.0 != node_id);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1293,6 +1289,29 @@ mod tests {
 
     fn data_id(name: &str) -> DataId {
         DataId::from(name.to_string())
+    }
+
+    #[test]
+    fn retain_other_nodes_drops_only_that_nodes_outputs() {
+        // Covers the `OutputId` keying of the `publishers` purge in
+        // `forget_node_bookkeeping`, whose real value type
+        // (`Arc<zenoh::pubsub::Publisher>`) can't be built in a unit test — a
+        // dummy value stands in for the map shape. Guards against the purge
+        // being keyed on the wrong `OutputId` field, which would silently
+        // reintroduce the per-dataflow publisher leak across add/remove cycles.
+        let node_a = node_id("node_a");
+        let node_b = node_id("node_b");
+        let mut map: BTreeMap<OutputId, u32> = BTreeMap::new();
+        map.insert(OutputId(node_a.clone(), data_id("x")), 1);
+        map.insert(OutputId(node_a.clone(), data_id("y")), 2);
+        map.insert(OutputId(node_b.clone(), data_id("x")), 3);
+
+        retain_other_nodes(&mut map, &node_a);
+
+        // Every output of node_a is gone, regardless of output name …
+        assert!(!map.keys().any(|OutputId(n, _)| n == &node_a));
+        // … while node_b keeps its entry untouched.
+        assert_eq!(map.get(&OutputId(node_b.clone(), data_id("x"))), Some(&3));
     }
 
     // ---- node_output_ids: remote-only outputs must be included ----


### PR DESCRIPTION
## Summary

_Machine-generated by the Claude Code review bot — please review before merging._

`RunningDataflow::publishers` — an `OutputId`-keyed (`(node id, output)`) map of lazily-declared remote zenoh publishers, created on demand in `send_to_remote_receivers` — was never touched by the `RemoveNode` / `ReplaceNode` routing cleanup. A removed node's zenoh `Publisher` (plus its retained session clone) stayed declared for the life of the dataflow, accumulating unboundedly across repeated dynamic add/remove cycles that use fresh node ids or output names.

## Fix

Purge `publishers` in `forget_node_bookkeeping` — the existing home for per-node bookkeeping the routing cleanup doesn't cover (it already handles `input_deadlines`, `broken_inputs`, the stderr queue and the cascading-error cause, and is called by both the `RemoveNode` and `ReplaceNode` handlers). A re-added or replacement node re-declares its publisher on the next remote send, so the purge is safe and behaviorally identical on both paths.

The `OutputId`-keyed retain is extracted into a small generic `retain_other_nodes` helper so its keying can be unit-tested directly — the real value type `Arc<zenoh::Publisher>` can't be constructed in-process, so the field itself isn't unit-testable.

### `debug_topic_watchers` is deliberately left intact

An earlier revision of this PR also purged the sibling `debug_topic_watchers` map. That has been removed. A watcher is only ever (re)registered by a fresh `StartTopicDebugStream` from the coordinator, and nothing on the `AddNode` re-add path re-sends one — only a full daemon reconnect does, via the coordinator's `restore_topic_debug_streams_for_daemon`. Since remove + re-add of the same node id is a supported flow that resumes under the same `OutputId(node_id, output)` (exactly like `ReplaceNode`), purging on removal would silently kill an active `dora topic` stream across the cycle, never to recover. The map is bounded by live subscriptions — `StopTopicDebugStream` reaps entries on unsubscribe — not by add/remove churn, so it is left untouched on every path.

## Validation

- `cargo fmt -p dora-daemon -- --check` ✓
- `cargo clippy -p dora-daemon -- -D warnings` ✓
- `cargo test -p dora-daemon` — 247 passed ✓, including:
  - `retain_other_nodes_drops_only_that_nodes_outputs` — pins the `OutputId` keying of the `publishers` purge (RED-GREEN for the one live behavioral change);
  - `forget_node_bookkeeping_purges_only_that_node` — asserts `debug_topic_watchers` survive the shared cleanup on every path, so a remove+re-add or `ReplaceNode` keeps an active debug stream alive.

Note: the `Test` CI job is skipped by the repo's change-detection gate, so the daemon unit tests run only locally — the counts above are from a local run on this head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015A4U4dL172qDwiG9Qx2cyy