### PR TITLE
fix(runtime): reject an invalid operator output id instead of aborting across FFI

### DIFF
--- a/binaries/runtime-shared-lib/src/runner.rs
+++ b/binaries/runtime-shared-lib/src/runner.rs
@@ -155,11 +155,18 @@ impl SharedLibraryOperator<'_> {
             // sample here and dropped at the end of this closure, on the
             // operator thread, so its `.so`-resident release callback never runs
             // on the runtime's event loop (dora-rs/dora#2742).
-            match self.handle.send_output(
-                DataId::from(String::from(output_id)),
-                parameters,
-                &arrow_array,
-            ) {
+            // Parse the operator-supplied output id fallibly. `DataId::from`
+            // panics on an invalid id (empty, a space, an empty path segment,
+            // any char outside `[a-zA-Z0-9_./-]`), and this closure runs inside
+            // the `extern "C"` send-output trampoline the operator calls — a
+            // panic here would unwind across the FFI boundary and abort the
+            // whole runtime process. An ordinary typo in an operator's
+            // `send_output` id must surface as a returned error instead.
+            let output_id = match String::from(output_id).parse::<DataId>() {
+                Ok(id) => id,
+                Err(err) => return DoraResult::from_error(format!("invalid output id: {err}")),
+            };
+            match self.handle.send_output(output_id, parameters, &arrow_array) {
                 Ok(()) => DoraResult::SUCCESS,
                 Err(err) => DoraResult::from_error(format!("{err}")),
             }


### PR DESCRIPTION
## Issue

The shared-library operator runtime's `send_output` trampoline built the output `DataId` with `DataId::from(String)`, which **panics** on an id that is empty, contains a space, has an empty path segment, or any character outside `[a-zA-Z0-9_./-]` (see `libraries/message/src/id.rs`, `# Panics`).

This closure is invoked through the `extern "C"` send-output callback the operator itself calls, so a panic here unwinds **across the FFI boundary and aborts the whole runtime process** (for a C/C++ operator it unwinds into C — UB/abort). It also fires *before* the `catch_unwind` around the user's `on_event`, because the panic originates in the runtime-side closure.

An ordinary typo in an operator's `send_output` id — e.g. `"my output"` (space) or `"a//b"` (empty segment) — thus crashed the process instead of returning an error the operator could handle.

## Fix

Parse the operator-supplied id fallibly with `parse::<DataId>()` and return a `DoraResult` error on failure, matching how the neighbouring FFI-array conversion in the same closure already reports errors.

## Validation

- `cargo +1.97.1 fmt -p dora-runtime-shared-lib -- --check`
- `cargo +1.97.1 clippy -p dora-runtime-shared-lib --all-targets -- -D warnings`
- `cargo +1.97.1 build -p dora-runtime-shared-lib`
- `cargo +1.97.1 check -p dora-cli` compiles

---

⚠️ **This is a machine-generated change** produced by Claude Code (an AI agent) during an automated code-review pass. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mZ1m3YVxCz4MrcYCqZX5d

---
_Generated by [Claude Code](https://claude.ai/code/session_011mZ1m3YVxCz4MrcYCqZX5d)_