### PR TITLE
refactor(recording): drop the inert footer re-validation in next_entry

### DIFF
--- a/libraries/recording/src/lib.rs
+++ b/libraries/recording/src/lib.rs
@@ -223,14 +223,15 @@ impl<R: Read> RecordingReader<R> {
             Err(e) => return Err(e).wrap_err("failed to read record length"),
         }
 
-        // Check if this is a footer marker instead of a record
+        // A record can never legitimately begin with the footer magic prefix:
+        // that would require a length prefix of 0x41524F44 ("DORA" little-endian
+        // ≈ 1.09 GB), far above MAX_RECORD_BYTES, so such a length is never
+        // written. The moment the 4-byte length prefix equals the footer prefix
+        // we're therefore at the footer (or trailing garbage) — either way,
+        // stop reading. (The trailing "END\0" bytes are not re-validated: both
+        // outcomes of that check already meant "stop", so reading them was dead
+        // work.)
         if len_buf == FOOTER_MAGIC[..4] {
-            let mut rest = [0u8; 4];
-            match self.reader.read_exact(&mut rest) {
-                Ok(()) if rest == FOOTER_MAGIC[4..] => return Ok(None),
-                _ => {}
-            }
-            // Not actually footer magic, treat as corrupted -- stop reading
             return Ok(None);
         }
 


### PR DESCRIPTION
## Issue

When a record's 4-byte length prefix equalled the footer magic prefix, `RecordingReader::next_entry` read the next 4 bytes and matched them against the rest of `FOOTER_MAGIC` — but **every arm of that match returned `Ok(None)`**, so the extra read and comparison were dead work, and the "distinguish footer from corruption" comment was misleading (the code did not actually distinguish them).

## Fix

A record can never legitimately begin with the footer prefix anyway: that would require a length prefix of `0x41524F44` ("DORA" little-endian ≈ 1.09 GB), far above `MAX_RECORD_BYTES` (64 MB), so such a length is never written. Collapse the block to simply stop reading at the footer prefix.

Behaviour is identical (both old arms returned `Ok(None)`); the existing footer/round-trip tests still pass.

## Validation

- `cargo +1.97.1 fmt -p dora-recording -- --check`
- `cargo +1.97.1 clippy -p dora-recording --all-targets -- -D warnings`
- `cargo +1.97.1 test -p dora-recording` — all tests pass
- `cargo +1.97.1 check -p dora-cli` compiles

---

⚠️ **This is a machine-generated change** produced by Claude Code (an AI agent) during an automated code-review pass. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011mZ1m3YVxCz4MrcYCqZX5d

---
_Generated by [Claude Code](https://claude.ai/code/session_011mZ1m3YVxCz4MrcYCqZX5d)_