### PR TITLE
docs(blog): add the 1.0 launch post (#3320)

### DIFF
--- a/docs/blog/2026-09-02-dora-1.0.md
+++ b/docs/blog/2026-09-02-dora-1.0.md
@@ -1,12 +1,17 @@
 # dora 1.0
 
-dora is stable. As of 1.0 the wire format and the public APIs are frozen for the life of the 1.x series: a node you write today keeps compiling and keeps talking to a dora daemon until 2.0.
+dora 1.0 is out. Starting with this release, the wire format and the public node APIs are frozen for the whole 1.x series: a node written against 1.0 will keep building, and keep talking to a dora daemon, until there is a 2.0.
 
-This post covers four things — what dora is, how it works, what the freeze actually promises, and what changed to get here. If you already run dora, the short version is that **1.0 is a hard break from 0.x** and the [migration guide](../migration-from-0.x.md) is the page you want.
+```bash
+cargo install dora-cli        # or: pip install dora-rs-cli
+pip install dora-rs
+```
+
+This post is for two kinds of reader. If you have not used dora before, the next sections explain what it is, how it is put together, and what writing a node looks like. If you already run dora 0.x, the one thing to know before anything else is that 1.0 does not interoperate with 0.x at all. Skip ahead to [Upgrading from 0.x](#upgrading-from-0x) and keep the [migration guide](../migration-from-0.x.md) open while you update.
 
 ## What dora is
 
-dora — *Agentic Dataflow-Oriented Robotic Architecture* — is a framework for building real-time robotics and AI applications. You describe your system as a graph of nodes in YAML, write each node in Rust, Python, C, or C++, and dora handles the rest: spawning processes, routing messages, moving data between machines, restarting what crashes.
+dora is a framework for building robotics and AI applications out of small programs that pass data to each other. You describe the application as a graph in a YAML file, write each node in Rust, Python, C or C++, and dora starts the processes, connects them, moves data between them, and restarts the ones that crash if you ask it to.
 
 ```yaml
 nodes:
@@ -15,7 +20,8 @@ nodes:
     outputs: [frame]
 
   - id: detector
-    path: detector.py
+    build: cargo build -p detector --release
+    path: target/release/detector
     inputs:
       frame: camera/frame
     outputs: [boxes]
@@ -27,146 +33,76 @@ nodes:
       frame: camera/frame
 ```
 
+Each `inputs:` entry names the node and output it subscribes to, so the file above describes this graph:
+
+```mermaid
+graph LR
+    camera -- frame --> detector
+    detector -- boxes --> display
+    camera -- frame --> display
+```
+
 ```bash
 dora run dataflow.yml
 ```
 
-That's a complete, running system. No build step for the Python nodes, no ROS workspace, no launch files, no code generation.
+That is the whole setup: `dora run` runs each node's `build:` command, then starts the processes. There is no message definition language, no code generation step and no workspace to source. A Python node is a Python script; a Rust node is a binary.
 
-The comparison people reach for is ROS2, and the honest summary is that dora is **10–17x lower latency than ROS2 Python** on equivalent workloads. That number is not a micro-benchmark artifact — it comes from the same Python workload run on both frameworks ([`examples/ros2-comparison/`](../../examples/ros2-comparison/)), and it comes from three structural choices rather than from tuning.
+The natural comparison is ROS 2, and the most concrete difference is latency. On the same Python workload, node-to-node latency in dora is 10–17x lower than with rclpy. The benchmark behind that number is in the repository ([`examples/ros2-comparison/`](../../examples/ros2-comparison/)); it runs identical Python senders and receivers on both frameworks, so it measures framework overhead rather than language speed. The gap comes from three design decisions.
 
-### Apache Arrow, end to end
+### Apache Arrow, everywhere
 
-Every message in dora is an Apache Arrow array. Not "serialized to Arrow at the boundary" — Arrow *is* the in-memory representation, in every language binding.
+Every message in dora is an Apache Arrow array, in memory, in every language binding. A Python node builds a `pyarrow` array and the Rust node downstream receives an `arrow` array over the same bytes. Nothing was encoded on the way out or decoded on the way in, so sending data between two languages costs the same as sending it within one.
 
-The consequence is that there is no serialization step to pay for. A Python node builds a `pa.array`, a Rust node downstream receives an `arrow::array::Array` backed by the same bytes, and nothing was encoded or decoded in between. Cross-language messaging is the same cost as same-language messaging, because the format does not change at the boundary.
+A useful side effect is that messages are already in a format the rest of the data ecosystem reads. A frame or a point cloud that arrives as Arrow goes straight into numpy, pandas, polars or DuckDB.
 
-It also means the ecosystem comes for free: a message is already a thing pandas, polars, DuckDB, and numpy understand.
+### Shared memory above 4 KB
 
-### Zero-copy shared memory above 4 KB
+Messages of 4 KB and more are published through Zenoh shared memory, from one node directly to the next, without passing through the daemon. The receiver maps the pages the sender wrote, so nobody copies the payload, and latency stays roughly flat from 4 KB up to the 4 MB frames the benchmark tops out at.
 
-Messages at or above 4 KB travel through Zenoh shared memory, published node-to-node without passing through the daemon. The receiver maps the same pages the sender wrote. Latency is flat from 4 KB to 4 MB — a 4 MB camera frame costs approximately what a 4 KB one does, because in neither case does anyone copy the payload.
+Below 4 KB the message is copied into a heap buffer instead. Shared memory works in whole pages, and for a small message the cost of setting up a shared page is higher than the copy it would save. The threshold sits where the two costs cross on a 4 KiB page, and can be changed with `DORA_ZERO_COPY_THRESHOLD`.
 
-Below 4 KB, dora uses a heap-buffered `put` instead. Page alignment has a fixed cost, and for small messages that cost exceeds what zero-copy saves — so the threshold is where the two curves actually cross, not a round number.
+### A Rust core
 
-Fan-out is `Arc`-wrapped: sending one message to ten subscribers costs one message, not ten copies.
+The daemon, the coordinator, the CLI and everything on the routing path are Rust. Python nodes are ordinary Python processes, but no Python runs in the transport between them: there is no GIL shared between two nodes, and a slow callback in one node cannot hold up delivery to the others. Fan-out to several subscribers shares one buffer rather than copying it per receiver.
 
-### Rust all the way down
+## How the pieces fit together
 
-The daemon, the coordinator, the CLI, and the routing hot paths are Rust. Python nodes are real Python, but nothing in the transport is — there is no GIL between two of your nodes, and a slow Python callback cannot stall the event loop that is delivering to everyone else.
+Here is the example from above, with `display` moved to a second machine. Dotted arrows are the control plane, solid ones the data plane.
 
-## The architecture
-
+```mermaid
+flowchart TB
+    CLI -. "WebSocket, port 6013" .-> Coordinator
+    Coordinator -. WebSocket .-> DR
+    Coordinator -. WebSocket .-> DW
+    subgraph robot
+        DR[Daemon] -. TCP .-> camera
+        DR -. TCP .-> detector
+        camera == "frame, shared memory" ==> detector
+    end
+    subgraph workstation
+        DW[Daemon] -. TCP .-> display
+    end
+    detector == "boxes, Zenoh" ==> display
+    camera == "frame, Zenoh" ==> display
 ```
-control plane   CLI ──ws:6013──▶ Coordinator ──ws──▶ Daemon ──tcp──▶ Node
-                                  (one, global)   (per machine)   (your code)
 
-data plane      Node ─────────────────── Zenoh ───────────────────▶ Node
-                     shared memory when co-located (≥ 4 KB, zero-copy)
-                     network when the two nodes are on different machines
-```
+There are four kinds of process:
 
-Four moving parts, each with one job:
+- **The CLI** (`dora`) is what you type: `run`, `build`, `start`, `stop`, `logs`, `top`, `record`, `replay`. It talks to the coordinator over WebSocket on port 6013 and keeps no state of its own.
+- **The coordinator** keeps track of which daemons exist, which dataflows are running and where each node lives. There is one per deployment. By default it persists its state to a small redb database, so a coordinator restart does not forget what is running.
+- **A daemon** runs on each machine. It spawns node processes, watches them, restarts them according to each node's `restart_policy`, and relays messages that need to cross to another machine.
+- **Nodes** are your programs. Each connects to its local daemon over TCP for control and events.
 
-- **The CLI** (`dora`) is how you interact with everything: `run`, `build`, `start`, `stop`, `logs`, `top`, `record`, `replay`. It talks to the coordinator over WebSocket on port 6013 and holds no state.
-- **The coordinator** orchestrates. It knows which daemons exist, which dataflows are running, and where each node lives. It is the only global component, and it persists its state (redb by default) so a coordinator restart does not lose the record of what is running.
-- **A daemon** runs on each machine. It spawns node processes, supervises them, restarts them per your policy, and routes messages between nodes that share its machine.
-- **Nodes** are your processes. They connect to their local daemon over TCP for control and events.
+Control and data are kept apart. Starting, stopping, health, logs and metrics go through the coordinator. Data does not: two nodes on the same machine exchange messages through shared memory, and two nodes on different machines connect to each other over Zenoh once their daemons have exchanged addresses, with the daemons' own Zenoh link as the fallback while that connection comes up. The coordinator never sees a payload, which is why a busy dataflow does not make `dora stop` slow.
 
-The part worth understanding is that **the control plane and the data plane are separate**. Control — start, stop, health, logs — flows through the coordinator. Data does not. Two nodes on the same machine exchange payloads through shared memory directly; two nodes on different machines exchange them through Zenoh directly. The coordinator is never in the path of your data, which is why a busy dataflow does not make `dora stop` slow.
+It also means that moving a node to another machine is a `deploy:` block in the YAML. The node's code does not change, and neither do the edges; only the transport underneath them does.
 
-This is also what makes distribution unremarkable. Moving a node to another machine is a `deploy:` line in the YAML. The node's code does not change, and neither does the dataflow's shape — only the transport underneath it, from shared memory to network, chosen automatically.
+## Writing nodes
 
-## What 1.0 promises
+### Python
 
-A version number is a claim about the future, so it is worth being exact about which one.
-
-**Frozen until 2.0:** `dora-node-api` (Rust), `dora-node-api-c`, `dora-node-api-cxx`, the `dora-rs` Python wheel's module surface, `dora-arrow-convert`, `dora-message` (the wire protocol), and `dora-cli` — the `dora` command, its subcommands, and the dataflow YAML schema.
-
-All four node APIs are covered on equal terms. dora advertises Rust, C, C++ and Python as first-class languages; freezing only the Rust one would leave most of the actual user-facing surface unstated.
-
-**Shipped but explicitly outside the guarantee**, and each of them opt-in: the `hub:` field and `dora hub`, operators (`operators:` / `operator:` and the `dora-operator-api` family), the `ros2:` bridge, the MAVLink bridge, and the tensor pool. These may change in a *minor* release. You do not encounter one by accident — using any of them is a line you wrote in a dataflow or a `Cargo.toml`.
-
-**Also exempt:** the Arrow major version and the PyO3 version. Arrow moves fast and pinning dora's users to one major for the life of 1.x would be a worse promise than the one we are making; instead Arrow is behind `arrow-v58` / `arrow-v59` feature gates, so you choose.
-
-**CPython 3.11 or later**, and that floor is itself part of the guarantee — raising it inside 1.x would uninstall dora for people on a Python it used to support, and no semver check would ever catch that. Both wheels are `abi3-py311`, so a single wheel loads on 3.12, 3.13 and whatever comes next without a dora release.
-
-The freeze is enforced, not just documented. Workspace crates pin each other with exact `=` requirements, so a change in an internal crate cannot break an already-published public one. Optional surfaces are feature-gated with `default = []`, so using one is recorded in your manifest rather than in a warning you can tune out. A CI gate (`make qa-publish-graph`) fails if a published crate depends on an unpublished one. And because the Python API ships as a wheel where none of those mechanisms reach, [`test_public_surface.py`](../../apis/python/node/tests/test_public_surface.py) pins the names importable from `dora`: a name that disappears fails CI, and a *new* one fails until someone files it as covered or exempt.
-
-## How we got here: the decisions behind the freeze
-
-The rc window was mostly spent taking things *out* of 1.0. That deserves an explanation, because it looks backwards.
-
-The asymmetry is this: **removing a symbol after the tag needs a 2.0. Adding one back in 1.1 is additive.** So anything not ready to be frozen had to leave before the tag, and the cost of being wrong is wildly different in the two directions. Nearly every change below narrows what 1.0 promises.
-
-### Arrow left the public API (#3213)
-
-dora's messages are Arrow arrays, so Arrow types appeared throughout `dora-node-api`'s signatures. Freezing those signatures would have frozen the arrow-rs major version for the life of 1.x — a promise that costs users more than it gives them, since arrow-rs majors land regularly and carry things people want.
-
-Arrow now sits behind `arrow-v58` / `arrow-v59` features. You pick the major; dora does not pick it for you, and a future `arrow-v60` is a minor release rather than a 2.0.
-
-### bincode → postcard (#3153)
-
-The wire encoding was bincode, which is unmaintained — development stopped at 1.3.3 and every version carries RUSTSEC-2025-0141. That is not something to commit to for the life of a stable line.
-
-postcard is serde-based, so no message *type* changed, only the bytes. Unlike bincode it has a documented, stable wire specification, which is the property that actually matters under a stability guarantee. As a bonus, messages shrank 25–27 bytes each (`Metadata`: 34 → 27 B) from varint integers and shorter length prefixes.
-
-### uhlc 0.5 → 0.9 (#3016)
-
-dora uses a hybrid logical clock for distributed causality. The 0.9 bump changes how timestamp IDs are represented, and taking it after the tag would have cost a major bump — so it was taken before.
-
-The binary plane was unaffected: `NonZeroU128` and `[u8; 16]` serialize identically, verified byte-for-byte against golden vectors run under both 0.5.2 and 0.9.0. What changed is the JSON plane, where a timestamp `id` goes from a bare number to a 16-byte array — and that change is an improvement, because a real HLC id exceeded every number `serde_json` can represent, so the old form could not round-trip through `serde_json::Value` at all.
-
-### Wire-protocol enums are `#[non_exhaustive]` (#3151)
-
-A frozen wire protocol that cannot gain a message variant is a protocol that cannot gain a feature. Marking the protocol enums `#[non_exhaustive]` means 1.x can add variants without a major bump. The cost is a `_ =>` arm in your matches, paid once.
-
-### Deprecated descriptor surface removed (#3158, #3220)
-
-`custom:`, `publish_all_messages_to_zenoh`, and the `communication:` block are gone — carrying deprecated YAML into a frozen schema would have made it permanent. Separately, the `_unstable_` prefix was dropped from `deploy` and `debug`: both are ready, and shipping a stable feature under a name that says otherwise is its own kind of broken promise.
-
-### Re-exports narrowed (#3221, #3237, #3239)
-
-`dora_core`, `flume`, and tokio were reachable through the public API. Each one silently made a dependency's major version part of dora's frozen surface — a `flume` re-export means a flume 1.0 is a dora 2.0. All three are out. If you reached `dora_node_api::dora_core::…`, depend on `dora-core` directly, understanding that it is internal and outside the guarantee.
-
-### The extension seam (#3152, #3219, #3249)
-
-The tensor pool — CUDA and pinned-host memory transport for high-throughput GPU work — is real, useful, and not ready to be frozen. Rather than choosing between shipping it frozen and not shipping it, it moved behind a generic extension seam: it ships, it is documented, and it is explicitly outside the 1.0 guarantee. The CUDA helpers moved from `dora.cuda` to the separate `dora_tensor_pool` package (#3249) so the exempt surface is not inside the frozen module.
-
-This seam is the general answer to "we want this in the release but not in the promise", and it is why the covered list could stay honest.
-
-### Topic subscriptions check their encoding (#3160)
-
-The WebSocket topic data channel hands raw binary frames to third-party subscribers with no envelope and no self-describing encoding — so a subscriber speaking a different format *misparses* frames rather than failing on them. Before 1.0 there was no version exchange at all, which meant silent corruption. Both sides now exchange `protocol_version` and refuse on mismatch, naming which side is old.
-
-### redb 2 → 4, MSRV 1.88 → 1.95 (#3017)
-
-Both are the same reasoning as uhlc: a dependency major and a toolchain floor are cheaper to move before a stability promise than after one.
-
-## Migrating from 0.x
-
-**The single most important thing: a 0.x node cannot talk to a 1.0 daemon.** Not degraded, not negotiated down — it fails on the first frame. The binary encoding itself changed, and there is no mixed-version mode. Plan a full-cluster restart; do not plan a rolling upgrade.
-
-Expect an ugly error rather than a clean one. `NodeRegisterRequest` carries a `metadata_version` field so that layout drift *within* an encoding is caught with a legible message, but it cannot catch a change *of* the encoding: the register frame is encoded the same way as every other frame, so decoding fails before the version check can run.
-
-Four format versions moved together, and each fails loudly rather than misparsing:
-
-| Surface | 0.x | 1.0 | What a stale peer or file gets |
-|---|---|---|---|
-| `Metadata::CURRENT_VERSION` (node ↔ daemon) | 1 | 2 | decode failure at register |
-| Coordinator store `SCHEMA_VERSION` (redb) | 4 | 5 | coordinator refuses to open the database |
-| `.drec` recording `FORMAT_VERSION` | 1 | 2 | `dora replay` refuses the file |
-| Topic data channel `protocol_version` | absent | 2 | subscription refused at handshake |
-
-If you run `--store redb`, the 0.x database is not migrated — the coordinator names the file and tells you to delete it or use `--store memory`. The default `memory` backend needs no action.
-
-The full guide, with before/after snippets for every language and the descriptor surface, is [`docs/migration-from-0.x.md`](../migration-from-0.x.md). There is no `dora migrate` tool: the breaks are few and mechanical, and a tool that silently rewrote your dataflows would be a worse deal than a page you read once.
-
-## A tour, in four examples
-
-### A node
-
-The whole Python API is three things — construct, iterate, send:
+A node constructs `Node`, iterates over events, and sends outputs:
 
 ```python
 import pyarrow as pa
@@ -182,58 +118,69 @@ for event in node:
         break
 ```
 
-`event["value"]` is an Arrow array. It was not deserialized on the way in, and `pa.array([...])` is not serialized on the way out.
+`event["value"]` is a `pyarrow` array backed by the bytes the sender wrote, and the array passed to `send_output` is handed on the same way.
 
-The Rust API is the same shape, with the event stream as a `Stream` and outputs sent through `send_output`. C and C++ nodes get native APIs — not wrappers — sharing the same Arrow C Data Interface across the boundary.
+### Rust
+
+The Rust API has the same shape: an event stream (which also implements `futures::Stream`) and `send_output`.
+
+```rust
+use dora_node_api::{DoraNode, Event, IntoArrow, dora_core::config::DataId};
+
+fn main() -> eyre::Result<()> {
+    let (mut node, mut events) = DoraNode::init_from_env()?;
+    let output = DataId::from("random".to_owned());
+
+    while let Some(event) = events.recv() {
+        match event {
+            Event::Input { id, metadata, .. } if id.as_str() == "tick" => {
+                let value: u64 = fastrand::u64(..);
+                node.send_output(output.clone(), metadata.parameters, value.into_arrow())?;
+            }
+            Event::Stop(_) => break,
+            _ => {}
+        }
+    }
+    Ok(())
+}
+```
+
+C and C++ nodes have their own APIs, with Arrow crossing the language boundary through the Arrow C Data Interface rather than through a copy.
 
 ### Mixing languages
 
-Nodes do not know what language their neighbors are written in, so mixing them costs nothing:
+The example at the top already mixes Python and Rust. Nodes do not know what language their neighbours are written in, so adding a C++ controller that consumes the detector's boxes is one more entry:
 
 ```yaml
-nodes:
-  - id: camera            # Python — easiest place to use OpenCV
-    path: camera.py
-    outputs: [frame]
-
-  - id: detector          # Rust — where the frame budget actually matters
-    build: cargo build -p detector --release
-    path: target/release/detector
-    inputs:
-      frame: camera/frame
-    outputs: [boxes]
-
-  - id: controller        # C++ — talks to existing vendor SDK
+  - id: controller        # C++: talks to an existing vendor SDK
     build: cmake --build build
     path: build/controller
     inputs:
       boxes: detector/boxes
 ```
 
-A 4 MB frame from the Python camera node reaches the Rust detector through shared memory with no copy and no serialization, because both sides are holding Arrow.
+A 4 MB frame from the Python camera reaches the Rust detector through shared memory, with no copy and no serialization, because both sides hold it as Arrow.
 
-### Beyond pub/sub
+### Request/reply and long-running goals
 
-Topics are the default, but request/reply and long-running goals are first-class rather than something you build on top:
+Plain pub/sub is the default, but request/reply and goal-style interactions are built in rather than something you assemble on top:
 
 ```python
-# Service — the client sends a request and gets back the id to match on
+# Service: the client sends a request and gets back the id to match on
 request_id = node.send_service_request("request", data)
 
-# … and the server echoes the request's metadata back, carrying request_id
+# ... and the server echoes the request's metadata back, carrying request_id
 node.send_service_response("response", result, metadata=event["metadata"])
 
-# Action — a goal with feedback and a terminal result, cancellable
+# Action: a goal with feedback and a terminal result, cancellable
 node.send_output("goal", data, metadata={"goal_id": goal_id})
 node.send_output("result", data, metadata={"goal_id": goal_id,
                                            "goal_status": "succeeded"})
 ```
 
-Both are ordinary dataflow edges with well-known metadata keys (`request_id`, `goal_id`, `goal_status`), so `dora topic echo` shows them, `dora record` captures them, and replay reproduces them. There is no separate service transport to debug. See [`docs/patterns.md`](../patterns.md).
+Both are ordinary dataflow edges with agreed metadata keys (`request_id`, `goal_id`, `goal_status`). That keeps them visible to the rest of the tooling: `dora topic echo` shows them, `dora record` captures them, and `dora replay` reproduces them. The details are in [`docs/patterns.md`](../patterns.md).
 
-### Distribution
-
-Add one line per node:
+### Running across machines
 
 ```yaml
 nodes:
@@ -247,39 +194,136 @@ nodes:
     build: cargo build -p detector --release
     path: target/release/detector
     deploy:
+      machine: robot
+    inputs:
+      frame: camera/frame
+    outputs: [boxes]
+
+  - id: display
+    path: display.py
+    deploy:
       machine: workstation
     inputs:
+      boxes: detector/boxes
       frame: camera/frame
 ```
 
-The node code is unchanged. dora picks the transport — shared memory when the two nodes share a machine, Zenoh when they don't — and `dora top` shows per-node CPU, memory, queue depth, and restart counts across every machine at once.
+Nothing in the node code changes. A daemon runs on each machine, the coordinator places nodes by their `deploy` block, and the two edges into `display` switch from shared memory to the network while `camera/frame` into `detector` stays local. `dora cluster` brings the daemons up over SSH, and `dora top` shows CPU, memory, queue depth and restart counts for every node on every machine in one view.
 
-### And when it breaks
+### Looking inside a running system
 
 ```bash
-dora logs <dataflow> <node>       # per-node logs, filterable by level
-dora top                          # live TUI across all machines
-dora topic echo <node>/<output>   # print live messages
-dora topic hz <node>/<output>     # frequency analysis
-dora record <dataflow>            # capture to a .drec file
-dora replay recording.drec        # replay offline, at any speed
+dora logs <dataflow> -n <node> --level warn   # per-node logs
+dora top                                      # live view across all machines
+dora topic echo <node>/<output>               # print messages as they pass
+dora topic hz <node>/<output>                 # publish rate
+dora record dataflow.yml                      # capture every output to a .drec file
+dora replay recording.drec --speed 0          # play it back, here as fast as possible
 ```
 
-Record/replay is the one worth knowing about: capture a failure once on the robot, then replay it into a modified node on your laptop as many times as you need. Nodes can be substituted at replay time, which makes a captured production failure into a regression test.
+Record and replay work by rewriting the dataflow. `record` adds a node that writes every output to a file; `replay` swaps the recorded source nodes for ones that play the file back, at any speed, while the rest of the dataflow runs unchanged. That turns a failure captured on the robot into something you can run against a modified node on a laptop as many times as you need.
+
+The inspection commands talk to the coordinator, so they apply to dataflows started with `dora up` and `dora start`. `dora run` is a self-contained mode for development that does not start one.
+
+## What 1.0 promises
+
+A version number is a statement about the future, so here is exactly what this one covers.
+
+**Frozen until 2.0:** `dora-node-api` (Rust), `dora-node-api-c`, `dora-node-api-cxx`, the module surface of the `dora-rs` Python wheel, `dora-arrow-convert`, `dora-message` (the wire protocol), and `dora-cli`: the `dora` command, its subcommands, and the dataflow YAML schema.
+
+All four node APIs are covered on the same terms. dora presents Rust, C, C++ and Python as equal ways to write a node, and freezing only the Rust one would leave most of what people actually use unstated.
+
+**Shipped, but outside the guarantee:** the `hub:` field and `dora hub`, operators (`operators:` / `operator:` and the `dora-operator-api` family), the `ros2:` bridge, the MAVLink bridge, and the tensor pool. These may change in a minor release. Each is opt-in, so you will not be depending on one without having written it into a dataflow or a `Cargo.toml`.
+
+**Also outside it:** the Arrow major version and the PyO3 version. Arrow releases a new major several times a year, and pinning every dora user to one of them for the life of 1.x would be a worse deal than the guarantee is worth. Instead the Arrow major is selected with the `arrow-v58` / `arrow-v59` features, and adding an `arrow-v60` later is a minor release.
+
+**CPython 3.11 or later.** That floor is itself part of the promise: raising it inside 1.x would break `pip install` for people on an interpreter that used to work, and no API check would catch it. Both wheels are built as `abi3-py311`, so a single wheel loads on 3.12, 3.13 and whatever comes next without a new dora release.
+
+The freeze is enforced in CI rather than only written down. Workspace crates pin each other with exact `=` requirements, so a change in an internal crate cannot break an already-published public one. Optional surfaces are feature-gated with `default = []`, so using one is recorded in your manifest rather than in a warning you can tune out. A CI gate (`make qa-publish-graph`) fails if a published crate depends on an unpublished one. And because the Python API ships as a wheel where none of those mechanisms reach, [`test_public_surface.py`](../../apis/python/node/tests/test_public_surface.py) pins the names importable from `dora`: a name that disappears fails CI, and a new one fails until someone records it as covered or exempt.
+
+## What changed in the release candidates, and why
+
+Most of the rc window went into removing things from the 1.0 surface, which can look like the wrong direction for a release to move in. The reason is an asymmetry. Removing something after the tag needs a 2.0; adding it back in 1.1 is an ordinary minor release. So anything we were not ready to freeze had to leave before the tag, and most of the changes below narrow what 1.0 commits to.
+
+### Arrow left the public API ([#3213](https://github.com/dora-rs/dora/pull/3213))
+
+dora's messages are Arrow arrays, so Arrow types appeared throughout the signatures of `dora-node-api`. Freezing those signatures would have frozen the arrow-rs major version for the life of 1.x, which is a promise that costs users more than it gives them: arrow-rs majors land regularly and carry things people want.
+
+Arrow now sits behind the `arrow-v58` / `arrow-v59` features. You pick the major, and a future `arrow-v60` is a minor release rather than a 2.0.
+
+### bincode → postcard ([#3153](https://github.com/dora-rs/dora/pull/3153))
+
+The wire encoding was bincode, whose maintainers have stopped development ([RUSTSEC-2025-0141](https://rustsec.org/advisories/RUSTSEC-2025-0141.html)). That is not something to build a format on that has to last the whole of 1.x.
+
+postcard is serde-based, so no message type changed, only the bytes on the wire. Unlike bincode it has a documented, stable wire specification, which is the property that matters once the format is frozen. Messages also got a little smaller, by 25–27 bytes each (`Metadata`: 34 → 27 B), from varint integers and shorter length prefixes.
+
+### uhlc 0.5 → 0.9 ([#3016](https://github.com/dora-rs/dora/pull/3016))
+
+dora uses a hybrid logical clock for ordering across machines. The 0.9 bump changes how timestamp ids are represented, so taking it after the tag would have cost a major release. It was taken before.
+
+The binary encoding did not move: `NonZeroU128` and `[u8; 16]` serialize to the same bytes, which was checked against golden vectors under both versions. The JSON encoding did, with a timestamp `id` going from a bare number to a 16-byte array. That is an improvement in its own right, since a real clock id exceeds every number `serde_json` can represent and the old form could not round-trip through `serde_json::Value` at all.
+
+### Wire-protocol enums are `#[non_exhaustive]` ([#3151](https://github.com/dora-rs/dora/pull/3151))
+
+A frozen protocol that cannot gain a message variant cannot gain a feature either. Marking the protocol enums `#[non_exhaustive]` lets 1.x add variants without a major bump. The cost is a `_ =>` arm in your matches, paid once.
+
+### Deprecated descriptor surface removed ([#3158](https://github.com/dora-rs/dora/pull/3158), [#3220](https://github.com/dora-rs/dora/pull/3220))
+
+`custom:`, `publish_all_messages_to_zenoh` and the `communication:` block are gone; carrying deprecated YAML into a frozen schema would have made it permanent. Separately, `deploy` and `debug` lost their `_unstable_` prefix. Both are ready, and a stable feature should not ship under a name that says otherwise.
+
+### Re-exports narrowed ([#3221](https://github.com/dora-rs/dora/pull/3221), [#3237](https://github.com/dora-rs/dora/pull/3237), [#3239](https://github.com/dora-rs/dora/pull/3239))
+
+`dora_core`, `flume` and tokio were reachable through the public API, and each one quietly made a dependency's major version part of dora's frozen surface: a `flume` re-export means a flume 1.0 is a dora 2.0. `flume` is no longer re-exported (add it to your own `Cargo.toml`), the tokio types in `integration_testing` became dora-owned newtypes, and `dora_node_api::dora_core` now exposes only `config::{DataId, NodeId, OperatorId}` and `uhlc`. Anything else you reached through it lives in `dora-core`, which is an internal crate outside the guarantee.
+
+### The extension seam ([#3152](https://github.com/dora-rs/dora/pull/3152), [#3219](https://github.com/dora-rs/dora/pull/3219), [#3249](https://github.com/dora-rs/dora/pull/3249))
+
+The tensor pool, a CUDA and pinned-host-memory transport for high-throughput GPU work, is useful and not ready to be frozen. Rather than choosing between shipping it frozen and not shipping it, it moved behind a generic extension seam: it ships, it is documented, and it is explicitly outside the 1.0 guarantee. The CUDA helpers moved from `dora.cuda` to the separate `dora_tensor_pool` package ([#3249](https://github.com/dora-rs/dora/pull/3249)) so that the exempt surface is not inside the frozen module.
+
+The seam is the general answer to "we want this in the release but not in the promise", and it is what let the covered list stay short.
+
+### Topic subscriptions check their encoding ([#3160](https://github.com/dora-rs/dora/pull/3160))
+
+The WebSocket topic data channel hands raw binary frames to third-party subscribers with no envelope, so a subscriber expecting a different encoding misparses frames rather than rejecting them. The subscription handshake now carries a `protocol_version` in both directions, and either side refuses on a mismatch with a message naming which side is older.
+
+### redb 2 → 4, MSRV 1.88 → 1.95 ([#3017](https://github.com/dora-rs/dora/pull/3017))
+
+Same reasoning as uhlc: a dependency major and a toolchain floor are cheaper to move before a stability promise than after one.
+
+## Upgrading from 0.x
+
+**A 0.x node cannot talk to a 1.0 daemon, and a 0.x CLI cannot talk to a 1.0 coordinator.** The binary encoding changed and there is no compatibility mode, so the upgrade is a full restart of every component rather than a rolling one.
+
+The break is this complete because the control plane was rebuilt along with the encoding: the CLI now talks to the coordinator over WebSocket rather than TCP, so there was no compatible path to keep even at the command level.
+
+Expect a decode error rather than a friendly version message. `NodeRegisterRequest` carries a `metadata_version` field, which catches layout drift within an encoding, but it cannot catch a change of the encoding itself: the register frame is encoded like every other frame, so decoding fails before the version check runs.
+
+Things you will hit first:
+
+- **Python 3.11 or newer is required.** 0.x wheels supported 3.8; 1.0 wheels are `abi3-py311`. Upgrade the interpreter before upgrading dora.
+- **Rust nodes select an Arrow version.** Enable `arrow-v58` or `arrow-v59` on `dora-node-api`, and expect `NodeResult` instead of `eyre::Result` from the fallible methods.
+- **Some YAML keys are now rejected by name:** `custom:`, `publish_all_messages_to_zenoh`, `communication:`, and the `_unstable_` prefix on `deploy` and `debug`. The error names the field.
+- **Two CLI commands are gone:** `dora destroy` is `dora down`, and `dora version` is `dora --version` (the CLI and coordinator now check versions on every connection).
+- **If you ran a release candidate**, three more formats moved with the encoding change, and each refuses old data rather than misreading it:
+
+| Surface | rc | 1.0 | What a stale peer or file gets |
+|---|---|---|---|
+| `Metadata::CURRENT_VERSION` (node ↔ daemon) | 1 | 2 | decode failure at register |
+| Coordinator store `SCHEMA_VERSION` (redb) | 4 | 5 | coordinator refuses to open the database |
+| `.drec` recording `FORMAT_VERSION` | 1 | 2 | `dora replay` refuses the file |
+| Topic data channel `protocol_version` | absent | 2 | subscription refused at handshake |
+
+The coordinator store is redb by default, so if you ran an rc there is a `coordinator.redb` from it. `dora up` prints the fix when it sees the mismatch: `dora up --recreate-store` moves the old file aside as a `.backup` and starts fresh. Daemons re-register their state on reconnect, so nothing you need is lost.
+
+The full guide, with before/after snippets for every language and the descriptor surface, is [`docs/migration-from-0.x.md`](../migration-from-0.x.md).
 
 ## What's next
 
-1.0 is a commitment to stability, not a declaration that the work is done. The 1.1 milestone is where the features that were too young to freeze get to grow up — the tensor pool and its cross-machine transport, the hub, richer dynamic topology, and the operator API.
+1.0 is a commitment to stability, not a claim that the work is done. The [1.1 milestone](https://github.com/dora-rs/dora/milestone/4) is where the features that were too young to freeze get to mature: the tensor pool and its cross-machine transport ([#1872](https://github.com/dora-rs/dora/issues/1872)), direct cross-machine routing for every edge ([#2813](https://github.com/dora-rs/dora/issues/2813)), services and actions in the C++ API ([#2686](https://github.com/dora-rs/dora/issues/2686)), and the hub ([#2097](https://github.com/dora-rs/dora/issues/2097)). The operator API stays experimental for now.
 
-The extension seam is what makes that possible without another hard break. A feature can ship, get used, and get revised, without its first API being frozen with it.
+The extension seam is what makes that possible without another hard break. A feature can ship, get used, and be revised, without its first API being frozen along with it.
 
 - **Getting started:** [dora-rs.ai](https://www.dora-rs.ai) · [User Guide](https://dora-rs.ai/dora/)
 - **Upgrading:** [`docs/migration-from-0.x.md`](../migration-from-0.x.md)
-- **What's covered by the freeze:** ["Stability scope at 1.0"](../api-rust.md#stability-scope-at-10)
+- **What the freeze covers:** ["Stability scope at 1.0"](../api-rust.md#stability-scope-at-10)
 - **Source and issues:** [github.com/dora-rs/dora](https://github.com/dora-rs/dora)
 - **Chat:** [Discord](https://discord.gg/6eMGGutkfE)
-
-```bash
-cargo install dora-cli
-pip install dora-rs
-```

--- a/docs/blog/2026-09-02-dora-1.0.md
+++ b/docs/blog/2026-09-02-dora-1.0.md
@@ -1,0 +1,285 @@
+# dora 1.0
+
+dora is stable. As of 1.0 the wire format and the public APIs are frozen for the life of the 1.x series: a node you write today keeps compiling and keeps talking to a dora daemon until 2.0.
+
+This post covers four things — what dora is, how it works, what the freeze actually promises, and what changed to get here. If you already run dora, the short version is that **1.0 is a hard break from 0.x** and the [migration guide](../migration-from-0.x.md) is the page you want.
+
+## What dora is
+
+dora — *Agentic Dataflow-Oriented Robotic Architecture* — is a framework for building real-time robotics and AI applications. You describe your system as a graph of nodes in YAML, write each node in Rust, Python, C, or C++, and dora handles the rest: spawning processes, routing messages, moving data between machines, restarting what crashes.
+
+```yaml
+nodes:
+  - id: camera
+    path: camera.py
+    outputs: [frame]
+
+  - id: detector
+    path: detector.py
+    inputs:
+      frame: camera/frame
+    outputs: [boxes]
+
+  - id: display
+    path: display.py
+    inputs:
+      boxes: detector/boxes
+      frame: camera/frame
+```
+
+```bash
+dora run dataflow.yml
+```
+
+That's a complete, running system. No build step for the Python nodes, no ROS workspace, no launch files, no code generation.
+
+The comparison people reach for is ROS2, and the honest summary is that dora is **10–17x lower latency than ROS2 Python** on equivalent workloads. That number is not a micro-benchmark artifact — it comes from the same Python workload run on both frameworks ([`examples/ros2-comparison/`](../../examples/ros2-comparison/)), and it comes from three structural choices rather than from tuning.
+
+### Apache Arrow, end to end
+
+Every message in dora is an Apache Arrow array. Not "serialized to Arrow at the boundary" — Arrow *is* the in-memory representation, in every language binding.
+
+The consequence is that there is no serialization step to pay for. A Python node builds a `pa.array`, a Rust node downstream receives an `arrow::array::Array` backed by the same bytes, and nothing was encoded or decoded in between. Cross-language messaging is the same cost as same-language messaging, because the format does not change at the boundary.
+
+It also means the ecosystem comes for free: a message is already a thing pandas, polars, DuckDB, and numpy understand.
+
+### Zero-copy shared memory above 4 KB
+
+Messages at or above 4 KB travel through Zenoh shared memory, published node-to-node without passing through the daemon. The receiver maps the same pages the sender wrote. Latency is flat from 4 KB to 4 MB — a 4 MB camera frame costs approximately what a 4 KB one does, because in neither case does anyone copy the payload.
+
+Below 4 KB, dora uses a heap-buffered `put` instead. Page alignment has a fixed cost, and for small messages that cost exceeds what zero-copy saves — so the threshold is where the two curves actually cross, not a round number.
+
+Fan-out is `Arc`-wrapped: sending one message to ten subscribers costs one message, not ten copies.
+
+### Rust all the way down
+
+The daemon, the coordinator, the CLI, and the routing hot paths are Rust. Python nodes are real Python, but nothing in the transport is — there is no GIL between two of your nodes, and a slow Python callback cannot stall the event loop that is delivering to everyone else.
+
+## The architecture
+
+```
+control plane   CLI ──ws:6013──▶ Coordinator ──ws──▶ Daemon ──tcp──▶ Node
+                                  (one, global)   (per machine)   (your code)
+
+data plane      Node ─────────────────── Zenoh ───────────────────▶ Node
+                     shared memory when co-located (≥ 4 KB, zero-copy)
+                     network when the two nodes are on different machines
+```
+
+Four moving parts, each with one job:
+
+- **The CLI** (`dora`) is how you interact with everything: `run`, `build`, `start`, `stop`, `logs`, `top`, `record`, `replay`. It talks to the coordinator over WebSocket on port 6013 and holds no state.
+- **The coordinator** orchestrates. It knows which daemons exist, which dataflows are running, and where each node lives. It is the only global component, and it persists its state (redb by default) so a coordinator restart does not lose the record of what is running.
+- **A daemon** runs on each machine. It spawns node processes, supervises them, restarts them per your policy, and routes messages between nodes that share its machine.
+- **Nodes** are your processes. They connect to their local daemon over TCP for control and events.
+
+The part worth understanding is that **the control plane and the data plane are separate**. Control — start, stop, health, logs — flows through the coordinator. Data does not. Two nodes on the same machine exchange payloads through shared memory directly; two nodes on different machines exchange them through Zenoh directly. The coordinator is never in the path of your data, which is why a busy dataflow does not make `dora stop` slow.
+
+This is also what makes distribution unremarkable. Moving a node to another machine is a `deploy:` line in the YAML. The node's code does not change, and neither does the dataflow's shape — only the transport underneath it, from shared memory to network, chosen automatically.
+
+## What 1.0 promises
+
+A version number is a claim about the future, so it is worth being exact about which one.
+
+**Frozen until 2.0:** `dora-node-api` (Rust), `dora-node-api-c`, `dora-node-api-cxx`, the `dora-rs` Python wheel's module surface, `dora-arrow-convert`, `dora-message` (the wire protocol), and `dora-cli` — the `dora` command, its subcommands, and the dataflow YAML schema.
+
+All four node APIs are covered on equal terms. dora advertises Rust, C, C++ and Python as first-class languages; freezing only the Rust one would leave most of the actual user-facing surface unstated.
+
+**Shipped but explicitly outside the guarantee**, and each of them opt-in: the `hub:` field and `dora hub`, operators (`operators:` / `operator:` and the `dora-operator-api` family), the `ros2:` bridge, the MAVLink bridge, and the tensor pool. These may change in a *minor* release. You do not encounter one by accident — using any of them is a line you wrote in a dataflow or a `Cargo.toml`.
+
+**Also exempt:** the Arrow major version and the PyO3 version. Arrow moves fast and pinning dora's users to one major for the life of 1.x would be a worse promise than the one we are making; instead Arrow is behind `arrow-v58` / `arrow-v59` feature gates, so you choose.
+
+**CPython 3.11 or later**, and that floor is itself part of the guarantee — raising it inside 1.x would uninstall dora for people on a Python it used to support, and no semver check would ever catch that. Both wheels are `abi3-py311`, so a single wheel loads on 3.12, 3.13 and whatever comes next without a dora release.
+
+The freeze is enforced, not just documented. Workspace crates pin each other with exact `=` requirements, so a change in an internal crate cannot break an already-published public one. Optional surfaces are feature-gated with `default = []`, so using one is recorded in your manifest rather than in a warning you can tune out. A CI gate (`make qa-publish-graph`) fails if a published crate depends on an unpublished one. And because the Python API ships as a wheel where none of those mechanisms reach, [`test_public_surface.py`](../../apis/python/node/tests/test_public_surface.py) pins the names importable from `dora`: a name that disappears fails CI, and a *new* one fails until someone files it as covered or exempt.
+
+## How we got here: the decisions behind the freeze
+
+The rc window was mostly spent taking things *out* of 1.0. That deserves an explanation, because it looks backwards.
+
+The asymmetry is this: **removing a symbol after the tag needs a 2.0. Adding one back in 1.1 is additive.** So anything not ready to be frozen had to leave before the tag, and the cost of being wrong is wildly different in the two directions. Nearly every change below narrows what 1.0 promises.
+
+### Arrow left the public API (#3213)
+
+dora's messages are Arrow arrays, so Arrow types appeared throughout `dora-node-api`'s signatures. Freezing those signatures would have frozen the arrow-rs major version for the life of 1.x — a promise that costs users more than it gives them, since arrow-rs majors land regularly and carry things people want.
+
+Arrow now sits behind `arrow-v58` / `arrow-v59` features. You pick the major; dora does not pick it for you, and a future `arrow-v60` is a minor release rather than a 2.0.
+
+### bincode → postcard (#3153)
+
+The wire encoding was bincode, which is unmaintained — development stopped at 1.3.3 and every version carries RUSTSEC-2025-0141. That is not something to commit to for the life of a stable line.
+
+postcard is serde-based, so no message *type* changed, only the bytes. Unlike bincode it has a documented, stable wire specification, which is the property that actually matters under a stability guarantee. As a bonus, messages shrank 25–27 bytes each (`Metadata`: 34 → 27 B) from varint integers and shorter length prefixes.
+
+### uhlc 0.5 → 0.9 (#3016)
+
+dora uses a hybrid logical clock for distributed causality. The 0.9 bump changes how timestamp IDs are represented, and taking it after the tag would have cost a major bump — so it was taken before.
+
+The binary plane was unaffected: `NonZeroU128` and `[u8; 16]` serialize identically, verified byte-for-byte against golden vectors run under both 0.5.2 and 0.9.0. What changed is the JSON plane, where a timestamp `id` goes from a bare number to a 16-byte array — and that change is an improvement, because a real HLC id exceeded every number `serde_json` can represent, so the old form could not round-trip through `serde_json::Value` at all.
+
+### Wire-protocol enums are `#[non_exhaustive]` (#3151)
+
+A frozen wire protocol that cannot gain a message variant is a protocol that cannot gain a feature. Marking the protocol enums `#[non_exhaustive]` means 1.x can add variants without a major bump. The cost is a `_ =>` arm in your matches, paid once.
+
+### Deprecated descriptor surface removed (#3158, #3220)
+
+`custom:`, `publish_all_messages_to_zenoh`, and the `communication:` block are gone — carrying deprecated YAML into a frozen schema would have made it permanent. Separately, the `_unstable_` prefix was dropped from `deploy` and `debug`: both are ready, and shipping a stable feature under a name that says otherwise is its own kind of broken promise.
+
+### Re-exports narrowed (#3221, #3237, #3239)
+
+`dora_core`, `flume`, and tokio were reachable through the public API. Each one silently made a dependency's major version part of dora's frozen surface — a `flume` re-export means a flume 1.0 is a dora 2.0. All three are out. If you reached `dora_node_api::dora_core::…`, depend on `dora-core` directly, understanding that it is internal and outside the guarantee.
+
+### The extension seam (#3152, #3219, #3249)
+
+The tensor pool — CUDA and pinned-host memory transport for high-throughput GPU work — is real, useful, and not ready to be frozen. Rather than choosing between shipping it frozen and not shipping it, it moved behind a generic extension seam: it ships, it is documented, and it is explicitly outside the 1.0 guarantee. The CUDA helpers moved from `dora.cuda` to the separate `dora_tensor_pool` package (#3249) so the exempt surface is not inside the frozen module.
+
+This seam is the general answer to "we want this in the release but not in the promise", and it is why the covered list could stay honest.
+
+### Topic subscriptions check their encoding (#3160)
+
+The WebSocket topic data channel hands raw binary frames to third-party subscribers with no envelope and no self-describing encoding — so a subscriber speaking a different format *misparses* frames rather than failing on them. Before 1.0 there was no version exchange at all, which meant silent corruption. Both sides now exchange `protocol_version` and refuse on mismatch, naming which side is old.
+
+### redb 2 → 4, MSRV 1.88 → 1.95 (#3017)
+
+Both are the same reasoning as uhlc: a dependency major and a toolchain floor are cheaper to move before a stability promise than after one.
+
+## Migrating from 0.x
+
+**The single most important thing: a 0.x node cannot talk to a 1.0 daemon.** Not degraded, not negotiated down — it fails on the first frame. The binary encoding itself changed, and there is no mixed-version mode. Plan a full-cluster restart; do not plan a rolling upgrade.
+
+Expect an ugly error rather than a clean one. `NodeRegisterRequest` carries a `metadata_version` field so that layout drift *within* an encoding is caught with a legible message, but it cannot catch a change *of* the encoding: the register frame is encoded the same way as every other frame, so decoding fails before the version check can run.
+
+Four format versions moved together, and each fails loudly rather than misparsing:
+
+| Surface | 0.x | 1.0 | What a stale peer or file gets |
+|---|---|---|---|
+| `Metadata::CURRENT_VERSION` (node ↔ daemon) | 1 | 2 | decode failure at register |
+| Coordinator store `SCHEMA_VERSION` (redb) | 4 | 5 | coordinator refuses to open the database |
+| `.drec` recording `FORMAT_VERSION` | 1 | 2 | `dora replay` refuses the file |
+| Topic data channel `protocol_version` | absent | 2 | subscription refused at handshake |
+
+If you run `--store redb`, the 0.x database is not migrated — the coordinator names the file and tells you to delete it or use `--store memory`. The default `memory` backend needs no action.
+
+The full guide, with before/after snippets for every language and the descriptor surface, is [`docs/migration-from-0.x.md`](../migration-from-0.x.md). There is no `dora migrate` tool: the breaks are few and mechanical, and a tool that silently rewrote your dataflows would be a worse deal than a page you read once.
+
+## A tour, in four examples
+
+### A node
+
+The whole Python API is three things — construct, iterate, send:
+
+```python
+import pyarrow as pa
+from dora import Node
+
+node = Node()
+
+for event in node:
+    if event["type"] == "INPUT":
+        value = event["value"].to_pylist()[0]
+        node.send_output("doubled", pa.array([value * 2]))
+    elif event["type"] == "STOP":
+        break
+```
+
+`event["value"]` is an Arrow array. It was not deserialized on the way in, and `pa.array([...])` is not serialized on the way out.
+
+The Rust API is the same shape, with the event stream as a `Stream` and outputs sent through `send_output`. C and C++ nodes get native APIs — not wrappers — sharing the same Arrow C Data Interface across the boundary.
+
+### Mixing languages
+
+Nodes do not know what language their neighbors are written in, so mixing them costs nothing:
+
+```yaml
+nodes:
+  - id: camera            # Python — easiest place to use OpenCV
+    path: camera.py
+    outputs: [frame]
+
+  - id: detector          # Rust — where the frame budget actually matters
+    build: cargo build -p detector --release
+    path: target/release/detector
+    inputs:
+      frame: camera/frame
+    outputs: [boxes]
+
+  - id: controller        # C++ — talks to existing vendor SDK
+    build: cmake --build build
+    path: build/controller
+    inputs:
+      boxes: detector/boxes
+```
+
+A 4 MB frame from the Python camera node reaches the Rust detector through shared memory with no copy and no serialization, because both sides are holding Arrow.
+
+### Beyond pub/sub
+
+Topics are the default, but request/reply and long-running goals are first-class rather than something you build on top:
+
+```python
+# Service — the client sends a request and gets back the id to match on
+request_id = node.send_service_request("request", data)
+
+# … and the server echoes the request's metadata back, carrying request_id
+node.send_service_response("response", result, metadata=event["metadata"])
+
+# Action — a goal with feedback and a terminal result, cancellable
+node.send_output("goal", data, metadata={"goal_id": goal_id})
+node.send_output("result", data, metadata={"goal_id": goal_id,
+                                           "goal_status": "succeeded"})
+```
+
+Both are ordinary dataflow edges with well-known metadata keys (`request_id`, `goal_id`, `goal_status`), so `dora topic echo` shows them, `dora record` captures them, and replay reproduces them. There is no separate service transport to debug. See [`docs/patterns.md`](../patterns.md).
+
+### Distribution
+
+Add one line per node:
+
+```yaml
+nodes:
+  - id: camera
+    path: camera.py
+    deploy:
+      machine: robot
+    outputs: [frame]
+
+  - id: detector
+    build: cargo build -p detector --release
+    path: target/release/detector
+    deploy:
+      machine: workstation
+    inputs:
+      frame: camera/frame
+```
+
+The node code is unchanged. dora picks the transport — shared memory when the two nodes share a machine, Zenoh when they don't — and `dora top` shows per-node CPU, memory, queue depth, and restart counts across every machine at once.
+
+### And when it breaks
+
+```bash
+dora logs <dataflow> <node>       # per-node logs, filterable by level
+dora top                          # live TUI across all machines
+dora topic echo <node>/<output>   # print live messages
+dora topic hz <node>/<output>     # frequency analysis
+dora record <dataflow>            # capture to a .drec file
+dora replay recording.drec        # replay offline, at any speed
+```
+
+Record/replay is the one worth knowing about: capture a failure once on the robot, then replay it into a modified node on your laptop as many times as you need. Nodes can be substituted at replay time, which makes a captured production failure into a regression test.
+
+## What's next
+
+1.0 is a commitment to stability, not a declaration that the work is done. The 1.1 milestone is where the features that were too young to freeze get to grow up — the tensor pool and its cross-machine transport, the hub, richer dynamic topology, and the operator API.
+
+The extension seam is what makes that possible without another hard break. A feature can ship, get used, and get revised, without its first API being frozen with it.
+
+- **Getting started:** [dora-rs.ai](https://www.dora-rs.ai) · [User Guide](https://dora-rs.ai/dora/)
+- **Upgrading:** [`docs/migration-from-0.x.md`](../migration-from-0.x.md)
+- **What's covered by the freeze:** ["Stability scope at 1.0"](../api-rust.md#stability-scope-at-10)
+- **Source and issues:** [github.com/dora-rs/dora](https://github.com/dora-rs/dora)
+- **Chat:** [Discord](https://discord.gg/6eMGGutkfE)
+
+```bash
+cargo install dora-cli
+pip install dora-rs
+```


### PR DESCRIPTION
Closes #3320.

The launch post, covering the four things the issue asks for: the announcement and what the freeze covers, an introduction for readers who don't know dora, the reasoning behind each rc-era breaking change, and the migration story.

The through-line from the issue is the spine of the "how we got here" section — nearly every rc-window change *narrows* what 1.0 promises, because removing a symbol after the tag needs a 2.0 while adding one back in 1.1 is additive. Each change gets its reason rather than its diff.

Two open questions from the issue, answered in the draft:

- **Link or inline the migration guide?** Link. The post inlines only the hard-break headline (a 0.x node cannot talk to a 1.0 daemon) and the four format-version bumps — what an upgrader needs before deciding to read further. The per-language before/after belongs in the guide, which already has it.
- **Name the known issues?** Not in the post. The milestone is still moving two days out, so a list written now would be wrong at tag time; the release notes are the right place.

Placement is a maintainer call — it lands in `docs/blog/` so it is reviewable in-tree and its relative links resolve, but the published home is presumably the website.

Every factual claim was checked against the tree rather than against the issue: `SCHEMA_VERSION = 5`, `Metadata::CURRENT_VERSION = 2`, port 6013, `rust-version = 1.95.0`, the covered/exempt crate lists in `api-rust.md`, and the YAML/Python snippets against the real examples and PyO3 signatures. Three drafting errors were caught that way and fixed — a `machine/node/output` input reference (input refs are `node/output` regardless of `deploy:`), a `send_service_request(..., request_id=...)` kwarg that does not exist (the helper generates and returns the id), and an architecture diagram that drew Zenoh between daemon and coordinator instead of node to node.
