### PR TITLE
docs(patterns): correct the Python metadata shape in the service/streaming examples

### DIFF
--- a/docs/api-python.md
+++ b/docs/api-python.md
@@ -208,14 +208,19 @@ node.send_output("goal", data, {"goal_id": goal_id})
 **Streaming example** (flush downstream queues on user interruption):
 
 ```python
-params = {
-    "session_id": session_id,
-    "segment_id": 1,
-    "seq": 0,
-    "fin": False,
-    "flush": True,
-}
-node.send_output("text", data, metadata={"parameters": params})
+# `metadata` is a flat dict of parameter name -> value; there is no
+# enclosing "parameters" key.
+node.send_output(
+    "text",
+    data,
+    metadata={
+        "session_id": session_id,
+        "segment_id": 1,
+        "seq": 0,
+        "fin": False,
+        "flush": True,
+    },
+)
 ```
 
 See [patterns.md](patterns.md) for the full guide.

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -250,15 +250,19 @@ when using flush.
 ### Python
 
 ```python
-# Streaming metadata is a plain dict
-params = {
-    "session_id": session_id,
-    "segment_id": 1,
-    "seq": 0,
-    "fin": False,
-    "flush": True,  # flush older queued messages
-}
-node.send_output("text", data, metadata={"parameters": params})
+# `metadata` is a flat dict of parameter name -> value; there is no
+# enclosing "parameters" key.
+node.send_output(
+    "text",
+    data,
+    metadata={
+        "session_id": session_id,
+        "segment_id": 1,
+        "seq": 0,
+        "fin": False,
+        "flush": True,  # flush older queued messages
+    },
+)
 ```
 
 ## 5. Choosing a pattern
@@ -324,14 +328,36 @@ Python nodes use the same metadata conventions. Parameters are plain dicts
 with string keys:
 
 ```python
+# Service client -- `send_service_request` generates the request_id (uuid7,
+# time-ordered, matching the Rust API) and returns it to correlate on.
+request_id = node.send_service_request("request", data)
+
+# Service server -- echo the request's metadata back, which carries request_id
+node.send_service_response("response", result, metadata=event["metadata"])
+```
+
+`metadata` is a **flat** dict of parameter name -> value, the same shape
+`event["metadata"]` has on the receiving side:
+
+```python
+node.send_output("goal", data, metadata={"goal_id": goal_id})
+assert event["metadata"]["goal_id"] == goal_id
+```
+
+Wrapping it in an enclosing `{"parameters": ...}` key does not fail loudly:
+the dict is not a supported parameter type, so it is coerced to its string
+representation under a parameter literally named `parameters` (with a
+warning). The correlation key never arrives, and the peer sees no
+`request_id`/`goal_id` at all.
+
+If you need the id before sending -- or are not using the service helpers --
+set it yourself, still flat:
+
+```python
 import uuid
 
-# Service client (uuid7 for time-ordered IDs, matching Rust API)
-params = {"request_id": str(uuid.uuid7())}
-node.send_output("request", data, metadata={"parameters": params})
-
-# Service server -- pass through parameters
-node.send_output("response", result, metadata=event["metadata"])
+request_id = str(uuid.uuid7())
+node.send_output("request", data, metadata={"request_id": request_id})
 ```
 
 > **Note**: `uuid.uuid7()` requires Python 3.13+. On older versions, use the

--- a/guide/src/concepts/patterns.md
+++ b/guide/src/concepts/patterns.md
@@ -191,15 +191,19 @@ when using flush.
 ### Python
 
 ```python
-# Streaming metadata is a plain dict
-params = {
-    "session_id": session_id,
-    "segment_id": 1,
-    "seq": 0,
-    "fin": False,
-    "flush": True,  # flush older queued messages
-}
-node.send_output("text", data, metadata={"parameters": params})
+# `metadata` is a flat dict of parameter name -> value; there is no
+# enclosing "parameters" key.
+node.send_output(
+    "text",
+    data,
+    metadata={
+        "session_id": session_id,
+        "segment_id": 1,
+        "seq": 0,
+        "fin": False,
+        "flush": True,  # flush older queued messages
+    },
+)
 ```
 
 ## 5. Choosing a pattern
@@ -223,14 +227,29 @@ Python nodes use the same metadata conventions. Parameters are plain dicts
 with string keys:
 
 ```python
+# Service client -- `send_service_request` generates the request_id (uuid7,
+# time-ordered, matching the Rust API) and returns it to correlate on.
+request_id = node.send_service_request("request", data)
+
+# Service server -- echo the request's metadata back, which carries request_id
+node.send_service_response("response", result, metadata=event["metadata"])
+```
+
+`metadata` is a **flat** dict of parameter name -> value, the same shape
+`event["metadata"]` has on the receiving side. Wrapping it in an enclosing
+`{"parameters": ...}` key does not fail loudly: the dict is not a supported
+parameter type, so it is coerced to its string representation under a
+parameter literally named `parameters` (with a warning), and the correlation
+key never arrives.
+
+If you need the id before sending -- or are not using the service helpers --
+set it yourself, still flat:
+
+```python
 import uuid
 
-# Service client (uuid7 for time-ordered IDs, matching Rust API)
-params = {"request_id": str(uuid.uuid7())}
-node.send_output("request", data, metadata={"parameters": params})
-
-# Service server -- pass through parameters
-node.send_output("response", result, metadata=event["metadata"])
+request_id = str(uuid.uuid7())
+node.send_output("request", data, metadata={"request_id": request_id})
 ```
 
 > **Note**: `uuid.uuid7()` requires Python 3.13+. On older versions, use the

--- a/guide/src/languages/python.md
+++ b/guide/src/languages/python.md
@@ -200,14 +200,19 @@ node.send_output("goal", data, {"goal_id": goal_id})
 **Streaming example** (flush downstream queues on user interruption):
 
 ```python
-params = {
-    "session_id": session_id,
-    "segment_id": 1,
-    "seq": 0,
-    "fin": False,
-    "flush": True,
-}
-node.send_output("text", data, metadata={"parameters": params})
+# `metadata` is a flat dict of parameter name -> value; there is no
+# enclosing "parameters" key.
+node.send_output(
+    "text",
+    data,
+    metadata={
+        "session_id": session_id,
+        "segment_id": 1,
+        "seq": 0,
+        "fin": False,
+        "flush": True,
+    },
+)
 ```
 
 See [patterns.md](patterns.md) for the full guide.


### PR DESCRIPTION
The Python snippets in the patterns docs pass correlation parameters as `metadata={"parameters": params}`, but `metadata` is a **flat** dict of parameter name → value.

`pydict_to_metadata` (`apis/python/operator/src/lib.rs:262`) iterates the dict directly. A nested dict is not a supported parameter type, so it falls through to the string-coercion branch: the message carries a single parameter literally named `parameters` holding the dict's `str()`, under a `tracing::warn!`.

So the correlation key never arrives. A server written against these docs finds no `request_id` in `event["metadata"]` and replies are never matched to requests — and nothing fails loudly at the send site.

The same snippet gave it away: its server half already used the correct flat form (`metadata=event["metadata"]`). That is also the shape `test_mock_node_metadata` asserts and the shape `send_output`'s own docstring shows.

Six sites across four files, all copies of the same two snippets:

- `docs/patterns.md` (streaming + service)
- `docs/api-python.md` (streaming)
- `guide/src/concepts/patterns.md` (streaming + service)
- `guide/src/languages/python.md` (streaming)

The service example now leads with `send_service_request` / `send_service_response`, which generate and thread `request_id` for you, with the manual flat form kept for callers that need the id up front. Both patterns pages also state what the wrong shape does, so it is recognizable if someone hits it in existing code.

Documentation only — no behavior change. Worth taking before 1.0: `patterns.md` is the canonical reference for the service/action/streaming surface, and this is the first thing a Python user copies.
