### PR TITLE
feat(daemon): discover peer zenoh endpoints through the coordinator

### DIFF
--- a/binaries/cli/src/command/cluster/up.rs
+++ b/binaries/cli/src/command/cluster/up.rs
@@ -1,7 +1,6 @@
 use std::{
     net::SocketAddr,
     path::PathBuf,
-    process::Command,
     time::{Duration, Instant},
 };
 
@@ -9,11 +8,8 @@ use clap::Args;
 use eyre::Context;
 
 use crate::{
-    command::{
-        Executable, default_tracing,
-        up::{detach_process, dora_executable_path},
-    },
-    common::{connect_to_coordinator, connect_with_retry},
+    command::{Executable, default_tracing, up},
+    common::connect_to_coordinator,
 };
 
 use super::config::{ClusterConfig, ZenohMesh};
@@ -52,10 +48,16 @@ impl Executable for Up {
                 s
             }
             Err(_) => {
-                start_coordinator(config.coordinator.port)?;
-                connect_with_retry(coordinator_addr, Duration::from_secs(10)).map_err(|err| {
-                    eyre::eyre!("timed out waiting for coordinator at {coordinator_addr}: {err}")
-                })?
+                // Shared with `dora up` so the two cannot drift apart again;
+                // the wildcard bind is what makes the coordinator reachable
+                // from the machines we are about to ssh into.
+                let startup = up::spawn_coordinator(up::CoordinatorSpawn {
+                    interface: Some(std::net::Ipv4Addr::UNSPECIFIED.into()),
+                    port: Some(config.coordinator.port),
+                    auth: false,
+                })
+                .wrap_err("failed to start dora coordinator")?;
+                up::wait_for_coordinator_start(coordinator_addr, config.coordinator.port, startup)?
             }
         };
 
@@ -188,23 +190,6 @@ impl Executable for Up {
             )
         }
     }
-}
-
-fn start_coordinator(port: u16) -> eyre::Result<()> {
-    let path = dora_executable_path()?;
-    let mut cmd = Command::new(path);
-    cmd.args([
-        "coordinator",
-        "--interface",
-        "0.0.0.0",
-        "--port",
-        &port.to_string(),
-        "--quiet",
-    ]);
-    detach_process(&mut cmd);
-    cmd.spawn().wrap_err("failed to start dora coordinator")?;
-    println!("Started coordinator on 0.0.0.0:{port}");
-    Ok(())
 }
 
 /// Print the tail of each unreachable daemon's log.

--- a/binaries/cli/src/command/daemon.rs
+++ b/binaries/cli/src/command/daemon.rs
@@ -72,8 +72,12 @@ pub struct Daemon {
     /// multicast graph can keep zenoh from binding its scouting group, which
     /// fails session startup outright.
     ///
-    /// Not for multi-daemon setups without `--zenoh-peer`: those discover each
-    /// other *by* multicast, and this would leave them unable to.
+    /// Safe for a multi-daemon setup as long as the daemons can reach the
+    /// coordinator: it hands each of them the endpoints of the daemons that
+    /// registered earlier, so they wire themselves without scouting. Only a
+    /// deployment that has no such path — daemons whose listeners are not
+    /// mutually dialable — still depends on multicast, and this would leave
+    /// those unable to find each other.
     ///
     /// Dynamic nodes need care too. They are started outside the daemon, so
     /// they inherit neither its environment nor a `DORA_ZENOH_CONNECT`, and

--- a/binaries/cli/src/command/up.rs
+++ b/binaries/cli/src/command/up.rs
@@ -28,6 +28,17 @@ pub struct Up {
     /// this token to connect.
     #[clap(long)]
     auth: bool,
+    /// Network interface the coordinator binds to.
+    ///
+    /// Defaults to loopback, which keeps a development coordinator off the
+    /// network. Pass a routable address (or `0.0.0.0`) when daemons on other
+    /// machines have to reach it — a loopback coordinator refuses their
+    /// connections, and the daemon only reports a connect timeout.
+    ///
+    /// This is the *bind* address. `DORA_COORDINATOR_ADDR` stays the address
+    /// this and every other lifecycle command connects to.
+    #[clap(long, value_name = "IP", default_value_t = LOCALHOST, env = "DORA_COORDINATOR_INTERFACE")]
+    interface: std::net::IpAddr,
     /// Archive the default coordinator store before starting a fresh coordinator.
     ///
     /// Use this after an upgrade when the on-disk schema is incompatible.
@@ -39,7 +50,12 @@ pub struct Up {
 impl Executable for Up {
     fn execute(self) -> eyre::Result<()> {
         default_tracing()?;
-        up(self.config.as_deref(), self.auth, self.recreate_store)
+        up(
+            self.config.as_deref(),
+            self.auth,
+            self.recreate_store,
+            self.interface,
+        )
     }
 }
 
@@ -47,21 +63,56 @@ impl Executable for Up {
 #[serde(deny_unknown_fields)]
 struct UpConfig {}
 
-pub(crate) fn up(config_path: Option<&Path>, auth: bool, recreate_store: bool) -> eyre::Result<()> {
+pub(crate) fn up(
+    config_path: Option<&Path>,
+    auth: bool,
+    recreate_store: bool,
+    interface: std::net::IpAddr,
+) -> eyre::Result<()> {
     let UpConfig {} = parse_dora_config(config_path)?;
     // Surface a malformed value instead of silently falling back to the
     // default: every other lifecycle command reads these env vars through
     // clap's typed `env=` on `CoordinatorOptions`, which errors on an
     // unparseable value. If `dora up` quietly ignored a typo it would bind a
     // different port than `dora stop`/`list`/`down` then look for.
-    let addr: std::net::IpAddr = coordinator_env_value("DORA_COORDINATOR_ADDR", LOCALHOST)?;
+    // A coordinator bound to a concrete non-loopback interface does *not*
+    // accept connections on loopback, so that interface is also the address
+    // this command — and the readiness poll below, which would otherwise time
+    // out and kill the coordinator it just started — has to connect to. The
+    // wildcard is the exception: it covers loopback too, so the default stands.
+    //
+    // An explicit `DORA_COORDINATOR_ADDR` still wins: it is how a user points
+    // these commands at a coordinator reachable under a different address than
+    // the one it binds (a NAT, a container port mapping).
+    let env_addr: Option<std::net::IpAddr> = coordinator_env_opt("DORA_COORDINATOR_ADDR")?;
+    let addr = env_addr.unwrap_or(if interface.is_unspecified() {
+        LOCALHOST
+    } else {
+        interface
+    });
     let port: u16 =
         coordinator_env_value("DORA_COORDINATOR_PORT", DORA_COORDINATOR_PORT_WS_DEFAULT)?;
     let coordinator_addr = (addr, port).into();
-    if recreate_store && !addr.is_loopback() {
+    // The port is passed explicitly so the spawned coordinator binds the same
+    // one every other lifecycle command connects to; without it a
+    // `DORA_COORDINATOR_PORT` set only in this process's environment would be
+    // read by the child too, but a `--port` on the command line would not.
+    let spawn = CoordinatorSpawn {
+        interface: Some(interface),
+        port: Some(port),
+        auth,
+    };
+    // Keyed off the *explicit* env var rather than `addr`: a `--interface`
+    // pointing at one of this machine's own addresses still means a local
+    // store, and refusing it would be wrong. Only a user-supplied address can
+    // mean "some other machine's coordinator".
+    if recreate_store
+        && let Some(env_addr) = env_addr
+        && !env_addr.is_loopback()
+    {
         bail!(
             "--recreate-store only applies to the local default coordinator store, \
-             but DORA_COORDINATOR_ADDR is set to the non-loopback address {addr}\n\n  \
+             but DORA_COORDINATOR_ADDR is set to the non-loopback address {env_addr}\n\n  \
              hint: unset DORA_COORDINATOR_ADDR, or run this command on the machine \
              that hosts the coordinator store"
         );
@@ -80,15 +131,31 @@ pub(crate) fn up(config_path: Option<&Path>, auth: bool, recreate_store: bool) -
                 Err(err) => {
                     ensure_no_listener_before_archive(coordinator_addr, err)?;
                     archive_default_coordinator_store()?;
-                    start_and_wait_for_coordinator(coordinator_addr, port, auth)?
+                    start_and_wait_for_coordinator(coordinator_addr, port, spawn)?
                 }
             }
         }
-        Err(_) => start_and_wait_for_coordinator(coordinator_addr, port, auth)?,
+        Err(_) => {
+            ensure_no_coordinator_elsewhere_on_port(coordinator_addr)?;
+            start_and_wait_for_coordinator(coordinator_addr, port, spawn)?
+        }
     };
 
     if !daemon_running(&session)? {
-        start_daemon().wrap_err("failed to start dora-daemon")?;
+        // A wildcard bind has no single address to hand the daemon, so it stays
+        // on loopback: its nodes are then reachable only through the
+        // daemon-forwarded path from other machines. Naming a concrete
+        // interface instead gives remote daemons something to dial.
+        let daemon_coordinator_addr =
+            Some(interface).filter(|i| !i.is_loopback() && !i.is_unspecified());
+        if interface.is_unspecified() {
+            println!(
+                "note: the local daemon's zenoh listener stays on loopback with a wildcard \
+                 --interface; pass this machine's address (e.g. --interface 192.168.1.10) \
+                 so daemons on other machines can dial its nodes directly"
+            );
+        }
+        start_daemon(daemon_coordinator_addr).wrap_err("failed to start dora-daemon")?;
 
         // wait a bit until daemon is connected
         let mut i = 0;
@@ -123,6 +190,17 @@ where
     parse_coordinator_env(var_name, std::env::var(var_name).ok().as_deref(), default)
 }
 
+/// Like [`coordinator_env_value`], but reports whether the variable was set at
+/// all, for callers whose default depends on other flags. A present-but-
+/// unparseable value is still a hard error.
+fn coordinator_env_opt<T>(var_name: &str) -> eyre::Result<Option<T>>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    parse_coordinator_env_opt(var_name, std::env::var(var_name).ok().as_deref())
+}
+
 /// Testable core of [`coordinator_env_value`], split out so tests can supply a
 /// raw value without touching the process-global environment.
 fn parse_coordinator_env<T>(var_name: &str, raw: Option<&str>, default: T) -> eyre::Result<T>
@@ -130,11 +208,22 @@ where
     T: std::str::FromStr,
     T::Err: std::fmt::Display,
 {
+    Ok(parse_coordinator_env_opt(var_name, raw)?.unwrap_or(default))
+}
+
+/// Parsing core shared by both accessors: an absent variable is `None`, a
+/// present but unparseable one is an error.
+fn parse_coordinator_env_opt<T>(var_name: &str, raw: Option<&str>) -> eyre::Result<Option<T>>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
     match raw {
         Some(s) => s
             .parse()
+            .map(Some)
             .map_err(|e| eyre::eyre!("invalid {var_name}: {s:?} ({e})")),
-        None => Ok(default),
+        None => Ok(None),
     }
 }
 
@@ -162,18 +251,59 @@ fn ensure_no_listener_before_archive(
     coordinator_addr: SocketAddr,
     connect_err: eyre::Report,
 ) -> eyre::Result<()> {
-    if std::net::TcpStream::connect_timeout(&coordinator_addr, Duration::from_secs(1)).is_ok() {
-        return Err(connect_err.wrap_err(format!(
-            "refusing to archive the coordinator store: a process is listening on \
-             {coordinator_addr} but the connection failed\n\n  \
-             hint: resolve the connection error below (e.g. an auth token mismatch), \
-             or stop the coordinator with `dora down` before recreating the store"
-        )));
+    // Probe loopback as well as the address we tried to reach. The store being
+    // archived is this machine's *default* one, and the coordinator holding it
+    // may well be bound somewhere we were not looking: a plain `dora up` binds
+    // loopback, so a later `dora up --recreate-store --interface <routable IP>`
+    // would find nothing at the routable address and rename the redb file out
+    // from under that live coordinator. Any listener on this port locally is
+    // reason enough to refuse.
+    let probes = [
+        coordinator_addr,
+        (LOCALHOST, coordinator_addr.port()).into(),
+    ];
+    for addr in probes {
+        if std::net::TcpStream::connect_timeout(&addr, Duration::from_secs(1)).is_ok() {
+            return Err(connect_err.wrap_err(format!(
+                "refusing to archive the coordinator store: a process is listening on \
+                 {addr} but the connection failed\n\n  \
+                 hint: resolve the connection error below (e.g. an auth token mismatch), \
+                 or stop the coordinator with `dora down` before recreating the store"
+            )));
+        }
     }
     Ok(())
 }
 
-struct CoordinatorStartup {
+/// Refuse to start a second coordinator when one already holds this port at a
+/// different local address.
+///
+/// `--interface` moved the address we probe, so a coordinator started by a
+/// plain `dora up` (loopback) is invisible to the probe above. Spawning anyway
+/// produces a child that dies on the redb lock and surfaces as "coordinator
+/// exited before it became ready", which says nothing about the real cause.
+///
+/// Only the loopback/derived pair is checked, which is what distinguishes the
+/// two `dora up` invocations from each other; a coordinator on some third
+/// interface still falls through to the port-in-use error.
+fn ensure_no_coordinator_elsewhere_on_port(coordinator_addr: SocketAddr) -> eyre::Result<()> {
+    let loopback = SocketAddr::from((LOCALHOST, coordinator_addr.port()));
+    if coordinator_addr == loopback {
+        return Ok(());
+    }
+    if std::net::TcpStream::connect_timeout(&loopback, Duration::from_secs(1)).is_ok() {
+        bail!(
+            "a coordinator is already running on port {} bound to loopback, so it \
+             cannot be reached at {coordinator_addr}\n\n  \
+             hint: stop it with `dora down` and re-run, or drop --interface to \
+             attach to the loopback coordinator",
+            coordinator_addr.port()
+        );
+    }
+    Ok(())
+}
+
+pub(crate) struct CoordinatorStartup {
     child: std::process::Child,
     /// `None` when the capture file could not be created; startup proceeds
     /// without stderr in error reports rather than failing.
@@ -183,13 +313,13 @@ struct CoordinatorStartup {
 fn start_and_wait_for_coordinator(
     coordinator_addr: SocketAddr,
     port: u16,
-    auth: bool,
+    spawn: CoordinatorSpawn,
 ) -> eyre::Result<crate::ws_client::WsSession> {
-    let startup = start_coordinator(auth).wrap_err("failed to start dora-coordinator")?;
+    let startup = spawn_coordinator(spawn).wrap_err("failed to start dora-coordinator")?;
     wait_for_coordinator_start(coordinator_addr, port, startup)
 }
 
-fn wait_for_coordinator_start(
+pub(crate) fn wait_for_coordinator_start(
     coordinator_addr: SocketAddr,
     port: u16,
     mut startup: CoordinatorStartup,
@@ -576,11 +706,39 @@ fn detach_process_with_stderr(cmd: &mut Command, stderr: impl Into<Stdio>) {
     }
 }
 
-fn start_coordinator(auth: bool) -> eyre::Result<CoordinatorStartup> {
+/// How a spawned `dora coordinator` child should be configured.
+///
+/// Both `dora up` and `dora cluster up` start a coordinator, and they used to
+/// do it with two independent implementations that disagreed on the most
+/// important default: `dora up` passed no `--interface` at all (so the child
+/// inherited loopback and no remote daemon could reach it) while
+/// `dora cluster up` passed `0.0.0.0`. The teardown half of the pair has been
+/// shared since `dora cluster down` started delegating to [`down`]; this is
+/// the same consolidation for startup.
+///
+/// `None` means "do not pass the flag", leaving the coordinator's own default.
+pub(crate) struct CoordinatorSpawn {
+    pub interface: Option<std::net::IpAddr>,
+    pub port: Option<u16>,
+    pub auth: bool,
+}
+
+pub(crate) fn spawn_coordinator(spawn: CoordinatorSpawn) -> eyre::Result<CoordinatorStartup> {
+    let CoordinatorSpawn {
+        interface,
+        port,
+        auth,
+    } = spawn;
     let path = dora_executable_path()?;
     let mut cmd = Command::new(path);
     cmd.arg("coordinator");
     cmd.arg("--quiet");
+    if let Some(interface) = interface {
+        cmd.args(["--interface".to_string(), interface.to_string()]);
+    }
+    if let Some(port) = port {
+        cmd.args(["--port".to_string(), port.to_string()]);
+    }
     if auth {
         cmd.arg("--auth");
     }
@@ -596,16 +754,48 @@ fn start_coordinator(auth: bool) -> eyre::Result<CoordinatorStartup> {
          hint: ensure the `dora` binary is in your PATH",
     )?;
 
-    println!("started dora coordinator");
+    match interface {
+        Some(interface) if !interface.is_loopback() && !interface.is_unspecified() => {
+            // Every other lifecycle command (`list`, `logs`, `stop`, `start`,
+            // `down`) defaults `--coordinator-addr` to loopback, where a
+            // coordinator bound to a concrete address does not answer. `dora up`
+            // derives its own connect address from `--interface`; the rest
+            // cannot, so say plainly what they need.
+            println!("started dora coordinator on {interface} (reachable from other machines)");
+            println!(
+                "  other commands default to loopback — export \
+                 DORA_COORDINATOR_ADDR={interface} (or pass --coordinator-addr {interface})"
+            );
+        }
+        Some(interface) if !interface.is_loopback() => {
+            println!("started dora coordinator on {interface} (reachable from other machines)");
+        }
+        _ => println!("started dora coordinator"),
+    }
 
     Ok(CoordinatorStartup { child, stderr })
 }
 
-fn start_daemon() -> eyre::Result<()> {
+/// Start the local daemon that `dora up` manages.
+///
+/// `coordinator_addr` is the address the daemon should use to reach the
+/// coordinator. It is not merely how the daemon connects: the daemon derives
+/// the address its *zenoh* listener binds from it (the local address that
+/// routes toward the coordinator), and a loopback coordinator therefore yields
+/// a loopback listener that no other machine can dial. Passing the routable
+/// interface through is what lets a daemon on another machine reach this one
+/// directly instead of falling back to multicast — see `zenoh_bind_address_for`.
+///
+/// `None` leaves the daemon's own default (loopback), which is what a
+/// single-machine `dora up` wants.
+fn start_daemon(coordinator_addr: Option<std::net::IpAddr>) -> eyre::Result<()> {
     let path = dora_executable_path()?;
     let mut cmd = Command::new(path);
     cmd.arg("daemon");
     cmd.arg("--quiet");
+    if let Some(addr) = coordinator_addr {
+        cmd.args(["--coordinator-addr".to_string(), addr.to_string()]);
+    }
     detach_process(&mut cmd);
     cmd.spawn().wrap_err(
         "failed to run `dora daemon`\n\n  \
@@ -626,6 +816,30 @@ mod tests {
     };
     use std::sync::mpsc;
     use std::time::Duration;
+
+    /// A coordinator bound to loopback must block the archive even when the
+    /// address we failed to connect to was a different one.
+    ///
+    /// `dora up --recreate-store --interface <routable IP>` connects to that
+    /// routable address; a coordinator started by a plain `dora up` earlier is
+    /// listening on loopback and never sees that probe. Probing only the
+    /// address we tried would archive the redb file out from under it.
+    #[test]
+    fn archive_refused_when_a_coordinator_holds_the_port_on_loopback_only() {
+        let listener =
+            std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback coordinator stand-in");
+        let port = listener.local_addr().expect("read local addr").port();
+
+        // A routable-looking address on the same port, which nothing is bound
+        // to — exactly what `--interface <routable IP>` would hand us.
+        let unbound: std::net::SocketAddr = format!("10.255.255.1:{port}").parse().unwrap();
+        let result = ensure_no_listener_before_archive(unbound, eyre::eyre!("connection refused"));
+
+        assert!(
+            result.is_err(),
+            "archive must be refused while a coordinator holds port {port} on loopback"
+        );
+    }
 
     #[test]
     fn archive_refused_while_store_file_is_locked() {

--- a/binaries/cli/src/command/up.rs
+++ b/binaries/cli/src/command/up.rs
@@ -37,8 +37,8 @@ pub struct Up {
     ///
     /// This is the *bind* address. `DORA_COORDINATOR_ADDR` stays the address
     /// this and every other lifecycle command connects to.
-    #[clap(long, value_name = "IP", default_value_t = LOCALHOST, env = "DORA_COORDINATOR_INTERFACE")]
-    interface: std::net::IpAddr,
+    #[clap(long, value_name = "IP", env = "DORA_COORDINATOR_INTERFACE")]
+    interface: Option<std::net::IpAddr>,
     /// Archive the default coordinator store before starting a fresh coordinator.
     ///
     /// Use this after an upgrade when the on-disk schema is incompatible.
@@ -67,7 +67,7 @@ pub(crate) fn up(
     config_path: Option<&Path>,
     auth: bool,
     recreate_store: bool,
-    interface: std::net::IpAddr,
+    interface: Option<std::net::IpAddr>,
 ) -> eyre::Result<()> {
     let UpConfig {} = parse_dora_config(config_path)?;
     // Surface a malformed value instead of silently falling back to the
@@ -85,11 +85,7 @@ pub(crate) fn up(
     // these commands at a coordinator reachable under a different address than
     // the one it binds (a NAT, a container port mapping).
     let env_addr: Option<std::net::IpAddr> = coordinator_env_opt("DORA_COORDINATOR_ADDR")?;
-    let addr = env_addr.unwrap_or(if interface.is_unspecified() {
-        LOCALHOST
-    } else {
-        interface
-    });
+    let addr = connect_addr_for(env_addr, interface)?;
     let port: u16 =
         coordinator_env_value("DORA_COORDINATOR_PORT", DORA_COORDINATOR_PORT_WS_DEFAULT)?;
     let coordinator_addr = (addr, port).into();
@@ -98,7 +94,7 @@ pub(crate) fn up(
     // `DORA_COORDINATOR_PORT` set only in this process's environment would be
     // read by the child too, but a `--port` on the command line would not.
     let spawn = CoordinatorSpawn {
-        interface: Some(interface),
+        interface,
         port: Some(port),
         auth,
     };
@@ -136,7 +132,7 @@ pub(crate) fn up(
             }
         }
         Err(_) => {
-            ensure_no_coordinator_elsewhere_on_port(coordinator_addr)?;
+            ensure_no_coordinator_elsewhere_on_port(coordinator_addr, interface)?;
             start_and_wait_for_coordinator(coordinator_addr, port, spawn)?
         }
     };
@@ -146,16 +142,19 @@ pub(crate) fn up(
         // on loopback: its nodes are then reachable only through the
         // daemon-forwarded path from other machines. Naming a concrete
         // interface instead gives remote daemons something to dial.
+        // `addr` — not `interface` — because that is the address this daemon
+        // must actually reach the coordinator at, and the one it derives its
+        // zenoh bind from.
         let daemon_coordinator_addr =
-            Some(interface).filter(|i| !i.is_loopback() && !i.is_unspecified());
-        if interface.is_unspecified() {
+            Some(addr).filter(|i| !i.is_loopback() && !i.is_unspecified());
+        if interface.is_some_and(|i| i.is_unspecified()) {
             println!(
                 "note: the local daemon's zenoh listener stays on loopback with a wildcard \
                  --interface; pass this machine's address (e.g. --interface 192.168.1.10) \
                  so daemons on other machines can dial its nodes directly"
             );
         }
-        start_daemon(daemon_coordinator_addr).wrap_err("failed to start dora-daemon")?;
+        start_daemon(daemon_coordinator_addr, port).wrap_err("failed to start dora-daemon")?;
 
         // wait a bit until daemon is connected
         let mut i = 0;
@@ -188,6 +187,38 @@ where
     T::Err: std::fmt::Display,
 {
     parse_coordinator_env(var_name, std::env::var(var_name).ok().as_deref(), default)
+}
+
+/// The address `dora up` — and its readiness poll — connects to.
+///
+/// `--interface` is the *bind* address; this is the one to reach it on. They
+/// are not interchangeable: a coordinator bound to a concrete non-loopback
+/// address does not answer on loopback, so polling loopback would time out and
+/// kill the coordinator we just started, reporting "is port N already in use?"
+/// — which names the wrong cause entirely.
+///
+/// A wildcard bind covers loopback, so the default stands there. An explicit
+/// `DORA_COORDINATOR_ADDR` wins, since it is how a user points these commands
+/// at a coordinator reachable under a different address than the one it binds
+/// (a NAT, a container port mapping) — except when it contradicts a concrete
+/// `--interface`, which is a mistake worth naming rather than silently
+/// resolving into a startup timeout.
+fn connect_addr_for(
+    env_addr: Option<std::net::IpAddr>,
+    interface: Option<std::net::IpAddr>,
+) -> eyre::Result<std::net::IpAddr> {
+    let bound_concretely = interface.filter(|i| !i.is_unspecified());
+    match (env_addr, bound_concretely) {
+        (Some(env), Some(iface)) if env != iface => bail!(
+            "DORA_COORDINATOR_ADDR is {env} but --interface is {iface}, so the \
+             coordinator would bind {iface} and answer nowhere else while every \
+             command looked for it on {env}\n\n  \
+             hint: drop one of them, or set DORA_COORDINATOR_ADDR={iface}"
+        ),
+        (Some(env), _) => Ok(env),
+        (None, Some(iface)) => Ok(iface),
+        (None, None) => Ok(LOCALHOST),
+    }
 }
 
 /// Like [`coordinator_env_value`], but reports whether the variable was set at
@@ -258,10 +289,14 @@ fn ensure_no_listener_before_archive(
     // would find nothing at the routable address and rename the redb file out
     // from under that live coordinator. Any listener on this port locally is
     // reason enough to refuse.
-    let probes = [
-        coordinator_addr,
-        (LOCALHOST, coordinator_addr.port()).into(),
-    ];
+    let loopback = SocketAddr::from((LOCALHOST, coordinator_addr.port()));
+    // Deduplicated: on the default path both entries are loopback, and probing
+    // it twice doubles the wait wherever the port is DROP-filtered rather than
+    // refused.
+    let mut probes = vec![coordinator_addr];
+    if coordinator_addr != loopback {
+        probes.push(loopback);
+    }
     for addr in probes {
         if std::net::TcpStream::connect_timeout(&addr, Duration::from_secs(1)).is_ok() {
             return Err(connect_err.wrap_err(format!(
@@ -286,7 +321,17 @@ fn ensure_no_listener_before_archive(
 /// Only the loopback/derived pair is checked, which is what distinguishes the
 /// two `dora up` invocations from each other; a coordinator on some third
 /// interface still falls through to the port-in-use error.
-fn ensure_no_coordinator_elsewhere_on_port(coordinator_addr: SocketAddr) -> eyre::Result<()> {
+fn ensure_no_coordinator_elsewhere_on_port(
+    coordinator_addr: SocketAddr,
+    interface: Option<std::net::IpAddr>,
+) -> eyre::Result<()> {
+    // Only when `--interface` is what moved us off loopback. A plain
+    // `DORA_COORDINATOR_ADDR` pointing elsewhere is a deliberate "reach the
+    // coordinator over there", and the hint below ("drop --interface") would
+    // name a flag the user never passed.
+    if interface.is_none() {
+        return Ok(());
+    }
     let loopback = SocketAddr::from((LOCALHOST, coordinator_addr.port()));
     if coordinator_addr == loopback {
         return Ok(());
@@ -788,11 +833,15 @@ pub(crate) fn spawn_coordinator(spawn: CoordinatorSpawn) -> eyre::Result<Coordin
 ///
 /// `None` leaves the daemon's own default (loopback), which is what a
 /// single-machine `dora up` wants.
-fn start_daemon(coordinator_addr: Option<std::net::IpAddr>) -> eyre::Result<()> {
+fn start_daemon(coordinator_addr: Option<std::net::IpAddr>, port: u16) -> eyre::Result<()> {
     let path = dora_executable_path()?;
     let mut cmd = Command::new(path);
     cmd.arg("daemon");
     cmd.arg("--quiet");
+    // Passed explicitly for the same reason the coordinator's is: relying on
+    // environment inheritance means a port resolved here from a flag rather
+    // than a variable would not reach the child.
+    cmd.args(["--coordinator-port".to_string(), port.to_string()]);
     if let Some(addr) = coordinator_addr {
         cmd.args(["--coordinator-addr".to_string(), addr.to_string()]);
     }
@@ -811,11 +860,52 @@ fn start_daemon(coordinator_addr: Option<std::net::IpAddr>) -> eyre::Result<()> 
 #[cfg(feature = "redb-backend")]
 mod tests {
     use super::{
-        archive_coordinator_store, available_backup_path, ensure_no_listener_before_archive,
-        lock_coordinator_store_recreation,
+        LOCALHOST, archive_coordinator_store, available_backup_path, connect_addr_for,
+        ensure_no_listener_before_archive, lock_coordinator_store_recreation,
     };
     use std::sync::mpsc;
     use std::time::Duration;
+
+    /// The crux of the `--interface` handling: the address we poll for
+    /// readiness has to be one the coordinator actually answers on, or `dora up`
+    /// kills the coordinator it just started and blames the port.
+    #[test]
+    fn connect_address_follows_a_concrete_bind_interface() {
+        use std::net::IpAddr;
+        let iface: IpAddr = "192.168.1.10".parse().unwrap();
+
+        // Nothing configured: loopback, exactly as before this flag existed.
+        assert_eq!(connect_addr_for(None, None).unwrap(), LOCALHOST);
+        // A concrete bind is also where it answers.
+        assert_eq!(connect_addr_for(None, Some(iface)).unwrap(), iface);
+        // A wildcard bind covers loopback, so the default stands.
+        assert_eq!(
+            connect_addr_for(None, Some("0.0.0.0".parse().unwrap())).unwrap(),
+            LOCALHOST
+        );
+        // An explicit env var wins — that is how a NAT or port mapping is
+        // expressed — including alongside a wildcard bind.
+        let env: IpAddr = "10.9.9.9".parse().unwrap();
+        assert_eq!(connect_addr_for(Some(env), None).unwrap(), env);
+        assert_eq!(
+            connect_addr_for(Some(env), Some("0.0.0.0".parse().unwrap())).unwrap(),
+            env
+        );
+        // Agreeing values are not a conflict.
+        assert_eq!(connect_addr_for(Some(iface), Some(iface)).unwrap(), iface);
+    }
+
+    /// A contradiction is named rather than resolved into a startup timeout:
+    /// `DORA_COORDINATOR_ADDR=127.0.0.1` in a shell profile plus
+    /// `--interface <routable>` used to bind one address and poll another.
+    #[test]
+    fn a_bind_interface_contradicting_the_connect_address_is_rejected() {
+        let err = connect_addr_for(Some(LOCALHOST), Some("192.168.1.10".parse().unwrap()))
+            .expect_err("contradicting addresses must be refused");
+        let msg = format!("{err}");
+        assert!(msg.contains("DORA_COORDINATOR_ADDR"), "{msg}");
+        assert!(msg.contains("--interface"), "{msg}");
+    }
 
     /// A coordinator bound to loopback must block the archive even when the
     /// address we failed to connect to was a different one.

--- a/binaries/coordinator/src/events.rs
+++ b/binaries/coordinator/src/events.rs
@@ -29,6 +29,18 @@ pub enum Event {
     Control(ControlEvent),
     Daemon(DaemonRequest),
     DaemonHeartbeatInterval,
+    /// A daemon reported the zenoh endpoint it bound, for the coordinator to
+    /// hand to daemons registering later.
+    DaemonZenohEndpoint {
+        daemon_id: DaemonId,
+        /// Connection-instance ID stamped at registration, checked the same way
+        /// `DaemonExit` checks it (#2392): a report from a superseded
+        /// connection must not overwrite the endpoint of the connection that
+        /// replaced it, which for a restarted daemon is a different port.
+        connection_id: Uuid,
+        /// `Some` confirms the advertised endpoint, `None` withdraws it.
+        endpoint: Option<String>,
+    },
     CtrlC,
     Log(LogMessage),
     DaemonExit {
@@ -99,6 +111,7 @@ impl Event {
             Event::Control(_) => "Control",
             Event::Daemon(_) => "Daemon",
             Event::DaemonHeartbeatInterval => "DaemonHeartbeatInterval",
+            Event::DaemonZenohEndpoint { .. } => "DaemonZenohEndpoint",
             Event::CtrlC => "CtrlC",
             Event::Log(_) => "Log",
             Event::DaemonExit { .. } => "DaemonExit",

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -437,10 +437,16 @@ async fn start_inner(
                         None => DaemonId::new(machine_id),
                     };
 
+                    // Gathered before `add` below, so the joining daemon is
+                    // not in the map yet and receives exactly the peers that
+                    // preceded it — see `RegisterResult::Ok::peer_zenoh_endpoints`
+                    // for why only earlier daemons are needed.
+                    let peer_zenoh_endpoints = daemon_connections.zenoh_endpoints_for(&daemon_id);
                     let reply: Timestamped<RegisterResult> = Timestamped {
                         inner: match version_check_result.as_ref() {
                             Ok(_) => RegisterResult::Ok {
                                 daemon_id: daemon_id.clone(),
+                                peer_zenoh_endpoints,
                             },
                             Err(err) => RegisterResult::Err(err.clone()),
                         },
@@ -2316,6 +2322,37 @@ async fn start_inner(
                     if let Some(stats) = ft_stats {
                         connection.ft_stats = Some(stats);
                     }
+                }
+            }
+            Event::DaemonZenohEndpoint {
+                daemon_id,
+                connection_id,
+                endpoint,
+            } => {
+                // Same guard as `DaemonExit` below (#2392): a report still in
+                // flight from a connection that has since been replaced would
+                // otherwise overwrite the live endpoint with a dead one, and
+                // every daemon registering afterwards would be handed it.
+                if daemon_connections.connection_id_of(&daemon_id) == Some(connection_id) {
+                    match &endpoint {
+                        Some(ep) => {
+                            tracing::debug!("daemon `{daemon_id}` confirmed zenoh endpoint `{ep}`")
+                        }
+                        // The daemon advertised an endpoint when it registered
+                        // and then failed to bind it. Withdrawing stops the
+                        // coordinator handing a dead endpoint to every daemon
+                        // that registers from here on.
+                        None => tracing::warn!(
+                            "daemon `{daemon_id}` withdrew its zenoh endpoint: its listener \
+                             did not bind, so other daemons cannot reach it directly"
+                        ),
+                    }
+                    daemon_connections.set_zenoh_endpoint(&daemon_id, endpoint);
+                } else {
+                    tracing::debug!(
+                        "ignoring zenoh endpoint {endpoint:?} from a superseded \
+                         connection of daemon `{daemon_id}`"
+                    );
                 }
             }
             Event::Log(message) => {

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -437,17 +437,22 @@ async fn start_inner(
                         None => DaemonId::new(machine_id),
                     };
 
-                    // Gathered before `add` below, so the joining daemon is
-                    // not in the map yet and receives exactly the peers that
-                    // preceded it — see `RegisterResult::Ok::peer_zenoh_endpoints`
-                    // for why only earlier daemons are needed.
-                    let peer_zenoh_endpoints = daemon_connections.zenoh_endpoints_for(&daemon_id);
                     let reply: Timestamped<RegisterResult> = Timestamped {
                         inner: match version_check_result.as_ref() {
-                            Ok(_) => RegisterResult::Ok {
-                                daemon_id: daemon_id.clone(),
-                                peer_zenoh_endpoints,
-                            },
+                            // Gathered here rather than before the match, so a
+                            // version-mismatched daemon retrying in a loop does
+                            // not make the coordinator walk its whole daemon map
+                            // and clone every endpoint per attempt — on the
+                            // serial event loop that is time no one gets back.
+                            //
+                            // Gathered before `add` below, so the joining daemon
+                            // is not in the map yet and receives exactly the
+                            // peers that preceded it; see
+                            // `RegisterResult::Ok::peer_zenoh_endpoints`.
+                            Ok(_) => RegisterResult::ok(
+                                daemon_id.clone(),
+                                daemon_connections.zenoh_endpoints_for(&daemon_id),
+                            ),
                             Err(err) => RegisterResult::Err(err.clone()),
                         },
                         timestamp: clock.new_timestamp(),

--- a/binaries/coordinator/src/state.rs
+++ b/binaries/coordinator/src/state.rs
@@ -77,6 +77,30 @@ impl DaemonConnections {
         self.daemons.get(daemon_id).map(|c| c.connection_id)
     }
 
+    /// Zenoh endpoints of every connected daemon except `joining`, for a
+    /// daemon that is registering now to dial.
+    ///
+    /// `joining` is excluded so a re-registering daemon is not told to dial
+    /// its own previous listener: `add` has not replaced its entry yet at the
+    /// point the register reply is built, and that endpoint is either its own
+    /// (a self-dial) or dead (the process restarted with a fresh ephemeral
+    /// port).
+    pub(crate) fn zenoh_endpoints_for(&self, joining: &DaemonId) -> Vec<String> {
+        self.daemons
+            .iter()
+            .filter(|(id, _)| *id != joining)
+            .filter_map(|(_, conn)| conn.zenoh_listen_endpoint.clone())
+            .collect()
+    }
+
+    /// Record (or, with `None`, withdraw) a daemon's zenoh endpoint after it
+    /// verified its listener. Unknown daemon → no-op.
+    pub(crate) fn set_zenoh_endpoint(&mut self, id: &DaemonId, endpoint: Option<String>) {
+        if let Some(conn) = self.daemons.get_mut(id) {
+            conn.zenoh_listen_endpoint = endpoint;
+        }
+    }
+
     pub(crate) fn unnamed(&self) -> impl Iterator<Item = &DaemonId> {
         self.daemons.keys().filter(|id| id.machine_id().is_none())
     }
@@ -115,6 +139,15 @@ pub(crate) struct DaemonConnection {
     /// connection's `DaemonExit` from a freshly re-registered connection
     /// that reused the same `DaemonId` (daemon reconnect race, #2392).
     pub(crate) connection_id: Uuid,
+    /// The zenoh endpoint this daemon reported as bound, handed to daemons
+    /// that register later so they can dial it.
+    ///
+    /// `None` until the daemon reports one, and it only reports a listener it
+    /// verified as bound — so an entry here always has something behind it.
+    /// Lives on the connection rather than in a side map so it is pruned with
+    /// the connection: a daemon that dropped must not keep being advertised,
+    /// and a restarted one replaces its own stale entry on re-register.
+    pub(crate) zenoh_listen_endpoint: Option<String>,
 }
 
 /// The envelope `handle_daemon_response` (see `ws_daemon.rs`) produces when a
@@ -143,6 +176,7 @@ impl DaemonConnection {
             // conservative default keeps non-registration constructors safe
             supports_hub_sources: false,
             connection_id: Uuid::new_v4(),
+            zenoh_listen_endpoint: None,
         }
     }
 
@@ -764,5 +798,128 @@ mod send_and_receive_tests {
             err.to_string().contains("daemon blew up"),
             "error should carry the daemon's message, got: {err}"
         );
+    }
+}
+
+#[cfg(test)]
+mod zenoh_endpoint_registry_tests {
+    use super::*;
+
+    fn connection() -> DaemonConnection {
+        let (tx, _rx) = mpsc::channel(1);
+        DaemonConnection::new(tx, Arc::new(Mutex::new(HashMap::new())), BTreeMap::new())
+    }
+
+    fn daemon(machine: &str) -> DaemonId {
+        DaemonId::new(Some(machine.to_string()))
+    }
+
+    /// The joining daemon is handed every *other* daemon's endpoint. This is
+    /// the whole mechanism: without it a multi-machine deployment has to name
+    /// each daemon's address on every other daemon's command line.
+    #[test]
+    fn a_joining_daemon_is_given_the_endpoints_of_the_daemons_before_it() {
+        let mut connections = DaemonConnections::default();
+        let (a, b) = (daemon("A"), daemon("B"));
+        connections.add(a.clone(), connection());
+        connections.add(b.clone(), connection());
+        connections.set_zenoh_endpoint(&a, Some("tcp/10.0.2.100:5456".into()));
+        connections.set_zenoh_endpoint(&b, Some("tcp/10.0.2.101:5456".into()));
+
+        let mut given = connections.zenoh_endpoints_for(&daemon("C"));
+        given.sort();
+        assert_eq!(given, ["tcp/10.0.2.100:5456", "tcp/10.0.2.101:5456"]);
+    }
+
+    /// A daemon must never be told to dial itself. On re-registration its old
+    /// connection is still in the map when the reply is built, and that
+    /// endpoint is either its own or a dead one from the previous process.
+    #[test]
+    fn a_re_registering_daemon_is_not_told_to_dial_itself() {
+        let mut connections = DaemonConnections::default();
+        let a = daemon("A");
+        connections.add(a.clone(), connection());
+        connections.set_zenoh_endpoint(&a, Some("tcp/10.0.2.100:5456".into()));
+
+        assert!(connections.zenoh_endpoints_for(&a).is_empty());
+    }
+
+    /// The ordering the whole mechanism rests on: a daemon's endpoint is set on
+    /// its connection *before* that connection is added, so it is already
+    /// visible to the next daemon's register reply. The coordinator's event
+    /// loop handles registrations one at a time, so two daemons starting
+    /// simultaneously are ordered by it and the later one always sees the
+    /// earlier — there is no window in which both see nothing.
+    #[test]
+    fn an_endpoint_registered_with_the_connection_is_visible_to_the_next_daemon() {
+        let mut connections = DaemonConnections::default();
+
+        // What the register handler does for daemon A.
+        let mut conn_a = connection();
+        conn_a.zenoh_listen_endpoint = Some("tcp/10.0.2.100:5456".into());
+        connections.add(daemon("A"), conn_a);
+
+        // B registers immediately afterwards, before A has confirmed anything.
+        assert_eq!(
+            connections.zenoh_endpoints_for(&daemon("B")),
+            ["tcp/10.0.2.100:5456"],
+        );
+    }
+
+    /// A daemon whose listener failed to bind withdraws its endpoint, so it
+    /// stops being handed to daemons that register later. Without this the
+    /// coordinator would keep advertising a port with nothing behind it.
+    #[test]
+    fn a_withdrawn_endpoint_is_no_longer_handed_out() {
+        let mut connections = DaemonConnections::default();
+        let a = daemon("A");
+        let mut conn_a = connection();
+        conn_a.zenoh_listen_endpoint = Some("tcp/10.0.2.100:5456".into());
+        connections.add(a.clone(), conn_a);
+
+        connections.set_zenoh_endpoint(&a, None);
+
+        assert!(connections.zenoh_endpoints_for(&daemon("B")).is_empty());
+    }
+
+    /// A daemon that has not reported an endpoint contributes none. It has
+    /// either not opened its session yet or bound loopback, and advertising a
+    /// loopback endpoint would point a remote peer at its own machine.
+    #[test]
+    fn a_daemon_without_a_reported_endpoint_contributes_nothing() {
+        let mut connections = DaemonConnections::default();
+        let (a, b) = (daemon("A"), daemon("B"));
+        connections.add(a.clone(), connection());
+        connections.add(b.clone(), connection());
+        connections.set_zenoh_endpoint(&b, Some("tcp/10.0.2.101:5456".into()));
+
+        assert_eq!(
+            connections.zenoh_endpoints_for(&daemon("C")),
+            ["tcp/10.0.2.101:5456"]
+        );
+    }
+
+    /// A dropped daemon stops being advertised, because the endpoint lives on
+    /// the connection rather than in a side map that would have to be pruned
+    /// separately.
+    #[test]
+    fn removing_a_daemon_withdraws_its_endpoint() {
+        let mut connections = DaemonConnections::default();
+        let a = daemon("A");
+        connections.add(a.clone(), connection());
+        connections.set_zenoh_endpoint(&a, Some("tcp/10.0.2.100:5456".into()));
+        connections.remove(&a);
+
+        assert!(connections.zenoh_endpoints_for(&daemon("C")).is_empty());
+    }
+
+    /// Setting an endpoint for a daemon that is not connected is a no-op
+    /// rather than an insertion: a late report from a connection the
+    /// coordinator has already dropped must not resurrect it.
+    #[test]
+    fn reporting_an_endpoint_for_an_unknown_daemon_is_ignored() {
+        let mut connections = DaemonConnections::default();
+        connections.set_zenoh_endpoint(&daemon("ghost"), Some("tcp/10.0.2.100:5456".into()));
+        assert!(connections.zenoh_endpoints_for(&daemon("C")).is_empty());
     }
 }

--- a/binaries/coordinator/src/ws_daemon.rs
+++ b/binaries/coordinator/src/ws_daemon.rs
@@ -182,7 +182,25 @@ async fn handle_daemon_request(
             let version_check_result = register_request.check_version();
             // capture before the partial moves below consume `register_request`
             let supports_hub_sources = register_request.supports_hub_sources();
-            let zenoh_listen_endpoint = register_request.zenoh_listen_endpoint;
+            // Validated on ingest: this is the only value in the registration
+            // that the coordinator re-publishes to *other* daemons, where it
+            // lands in their zenoh `connect/endpoints`. A daemon is not a
+            // trusted input just because it registered.
+            let zenoh_listen_endpoint = match register_request.zenoh_listen_endpoint {
+                Some(ep) => match dora_core::topics::validate_zenoh_endpoint(&ep) {
+                    Ok(()) => Some(ep),
+                    Err(err) => {
+                        // Dropped rather than fatal: the daemon is otherwise
+                        // fine and can still run nodes over the daemon-forwarded
+                        // path; only direct peer dialing is lost.
+                        tracing::warn!(
+                            "ignoring zenoh endpoint reported by registering daemon: {err}"
+                        );
+                        None
+                    }
+                },
+                None => None,
+            };
             let labels = register_request.labels;
             let machine_id = register_request.machine_id;
             let mut connection =

--- a/binaries/coordinator/src/ws_daemon.rs
+++ b/binaries/coordinator/src/ws_daemon.rs
@@ -182,25 +182,10 @@ async fn handle_daemon_request(
             let version_check_result = register_request.check_version();
             // capture before the partial moves below consume `register_request`
             let supports_hub_sources = register_request.supports_hub_sources();
-            // Validated on ingest: this is the only value in the registration
-            // that the coordinator re-publishes to *other* daemons, where it
-            // lands in their zenoh `connect/endpoints`. A daemon is not a
-            // trusted input just because it registered.
-            let zenoh_listen_endpoint = match register_request.zenoh_listen_endpoint {
-                Some(ep) => match dora_core::topics::validate_zenoh_endpoint(&ep) {
-                    Ok(()) => Some(ep),
-                    Err(err) => {
-                        // Dropped rather than fatal: the daemon is otherwise
-                        // fine and can still run nodes over the daemon-forwarded
-                        // path; only direct peer dialing is lost.
-                        tracing::warn!(
-                            "ignoring zenoh endpoint reported by registering daemon: {err}"
-                        );
-                        None
-                    }
-                },
-                None => None,
-            };
+            let zenoh_listen_endpoint = accept_reported_zenoh_endpoint(
+                register_request.zenoh_listen_endpoint,
+                "registering",
+            );
             let labels = register_request.labels;
             let machine_id = register_request.machine_id;
             let mut connection =
@@ -311,6 +296,34 @@ async fn handle_daemon_request(
     }
 }
 
+/// Accept a zenoh endpoint a daemon reported, or drop it.
+///
+/// Both ways a daemon can report one — in its registration, and in the
+/// `ZenohListenEndpoint` correction that follows — end at the same place: the
+/// coordinator stores it and hands it to every daemon that registers later,
+/// which puts it straight into their zenoh `connect/endpoints`. So both are
+/// checked here, through one function, rather than at each site: a daemon is
+/// not a trusted input just because it registered, and the correction exists
+/// precisely to *replace* the registered value, so validating only the
+/// registration would have left the invariant to whichever path ran last.
+///
+/// A rejected value becomes `None`, which withdraws any endpoint already on
+/// record rather than leaving a stale one standing. Withdrawal is the safe
+/// direction: the daemon simply is not dialed directly and its dataflows fall
+/// back to the daemon-forwarded path. Never fatal — the daemon is otherwise
+/// healthy, and dropping its connection over a malformed endpoint would cost
+/// far more than the direct link is worth.
+fn accept_reported_zenoh_endpoint(endpoint: Option<String>, state: &str) -> Option<String> {
+    let endpoint = endpoint?;
+    match dora_core::topics::validate_zenoh_endpoint(&endpoint) {
+        Ok(()) => Some(endpoint),
+        Err(err) => {
+            tracing::warn!("ignoring zenoh endpoint reported by {state} daemon: {err}");
+            None
+        }
+    }
+}
+
 fn translate_daemon_event(
     daemon_id: DaemonId,
     event: DaemonEvent,
@@ -341,7 +354,7 @@ fn translate_daemon_event(
         DaemonEvent::ZenohListenEndpoint { endpoint } => Some(Event::DaemonZenohEndpoint {
             daemon_id,
             connection_id,
-            endpoint,
+            endpoint: accept_reported_zenoh_endpoint(endpoint, "connected"),
         }),
         DaemonEvent::Log(message) => Some(Event::Log(message)),
         DaemonEvent::Exit => Some(Event::DaemonExit {
@@ -435,5 +448,54 @@ async fn handle_daemon_response(
         let _ = sender.send(result_json);
     } else {
         tracing::warn!("no pending reply for daemon WS response id {}", response.id);
+    }
+}
+
+#[cfg(test)]
+mod reported_endpoint_tests {
+    use super::*;
+
+    fn endpoint_of(event: Option<Event>) -> Option<String> {
+        match event {
+            Some(Event::DaemonZenohEndpoint { endpoint, .. }) => endpoint,
+            other => panic!("expected a DaemonZenohEndpoint event, got {other:?}"),
+        }
+    }
+
+    fn translate(endpoint: Option<String>) -> Option<String> {
+        endpoint_of(translate_daemon_event(
+            DaemonId::new(Some("A".to_string())),
+            DaemonEvent::ZenohListenEndpoint { endpoint },
+            Uuid::new_v4(),
+        ))
+    }
+
+    #[test]
+    fn a_valid_reported_endpoint_is_kept() {
+        assert_eq!(
+            translate(Some("tcp/10.0.2.100:5456".into())),
+            Some("tcp/10.0.2.100:5456".to_string())
+        );
+    }
+
+    /// The correction path is the *second* way a daemon can report an endpoint,
+    /// and it is designed to replace the value validated at registration — so
+    /// it has to be checked too, or the invariant holds only until the
+    /// correction arrives.
+    #[test]
+    fn an_invalid_reported_endpoint_is_dropped_on_the_correction_path() {
+        assert_eq!(
+            translate(Some(r#"tcp/1.2.3.4:1","tcp/evil:7447"#.into())),
+            None
+        );
+        assert_eq!(translate(Some("tcp/1.2.3.4:1 rm -rf".into())), None);
+        assert_eq!(translate(Some("a".repeat(300))), None);
+    }
+
+    /// An explicit withdrawal must still reach the coordinator: it is how a
+    /// daemon whose listener failed to bind stops being advertised.
+    #[test]
+    fn an_explicit_withdrawal_passes_through() {
+        assert_eq!(translate(None), None);
     }
 }

--- a/binaries/coordinator/src/ws_daemon.rs
+++ b/binaries/coordinator/src/ws_daemon.rs
@@ -182,12 +182,17 @@ async fn handle_daemon_request(
             let version_check_result = register_request.check_version();
             // capture before the partial moves below consume `register_request`
             let supports_hub_sources = register_request.supports_hub_sources();
+            let zenoh_listen_endpoint = register_request.zenoh_listen_endpoint;
             let labels = register_request.labels;
             let machine_id = register_request.machine_id;
             let mut connection =
                 DaemonConnection::new(cmd_tx.clone(), pending_replies.clone(), labels.clone());
             connection.supports_hub_sources = supports_hub_sources;
             connection.peer_addr = Some(peer_addr);
+            // Recorded here, so it is on the connection before it is added to
+            // the registry — the next daemon's register reply, built later on
+            // the same serial event loop, therefore already contains it.
+            connection.zenoh_listen_endpoint = zenoh_listen_endpoint;
             // Capture the connection_id before moving `connection` into the event.
             let connection_id = connection.connection_id;
             let (daemon_id_tx, daemon_id_rx) = oneshot::channel();
@@ -314,6 +319,11 @@ fn translate_daemon_event(
         DaemonEvent::Heartbeat { ft_stats } => Some(Event::DaemonHeartbeat {
             daemon_id,
             ft_stats,
+        }),
+        DaemonEvent::ZenohListenEndpoint { endpoint } => Some(Event::DaemonZenohEndpoint {
+            daemon_id,
+            connection_id,
+            endpoint,
         }),
         DaemonEvent::Log(message) => Some(Event::Log(message)),
         DaemonEvent::Exit => Some(Event::DaemonExit {

--- a/binaries/daemon/src/coordinator.rs
+++ b/binaries/daemon/src/coordinator.rs
@@ -189,11 +189,19 @@ pub async fn register(
     // register round-trip rather than however long the retry loop above took.
     // Only on the first connect: a reconnect reuses the still-open session's
     // port, and re-reserving would hand out one nothing is listening on.
+    // Only a derived bind reaches the reservation here; an explicit one was
+    // reserved before the connect loop precisely so its failures stay fatal
+    // instead of being retried as connectivity problems. A derived reservation
+    // never fails fatally — it degrades to `None`.
     let reserved_listen_endpoint = match zenoh.reserved {
         Some(ep) => Some(ep),
         None => crate::reserve_zenoh_listen_endpoint(zenoh.bind)?,
     };
-    let advertised_listen_endpoint = reserved_listen_endpoint.clone().filter(|_| zenoh.advertise);
+    let advertised_listen_endpoint = match zenoh.advertise {
+        crate::AdvertiseListener::Never => None,
+        crate::AdvertiseListener::Reserved => reserved_listen_endpoint.clone(),
+        crate::AdvertiseListener::Bound(bound) => bound,
+    };
 
     let (mut ws_tx, mut ws_rx) = ws_stream.split();
 

--- a/binaries/daemon/src/coordinator.rs
+++ b/binaries/daemon/src/coordinator.rs
@@ -122,13 +122,21 @@ static COORDINATOR_PENDING: std::sync::LazyLock<
     >,
 > = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
 
+/// Register with the coordinator.
+///
+/// Returns the assigned id, the zenoh endpoints of the daemons that were
+/// already registered (see `RegisterResult::Ok::peer_zenoh_endpoints`), the
+/// event sender and the incoming event stream.
 pub async fn register(
     addr: SocketAddr,
     machine_id: Option<String>,
     labels: std::collections::BTreeMap<String, String>,
+    zenoh: crate::ZenohRegistration,
     clock: Arc<HLC>,
 ) -> eyre::Result<(
     DaemonId,
+    Option<String>,
+    Vec<String>,
     CoordinatorSender,
     impl Stream<Item = Timestamped<CoordinatorEvent>>,
 )> {
@@ -176,6 +184,17 @@ pub async fn register(
         }
     };
 
+    // Reserve the zenoh listen port now, with the coordinator socket already
+    // up, so the window between reserving the port and zenoh binding it is one
+    // register round-trip rather than however long the retry loop above took.
+    // Only on the first connect: a reconnect reuses the still-open session's
+    // port, and re-reserving would hand out one nothing is listening on.
+    let reserved_listen_endpoint = match zenoh.reserved {
+        Some(ep) => Some(ep),
+        None => crate::reserve_zenoh_listen_endpoint(zenoh.bind)?,
+    };
+    let advertised_listen_endpoint = reserved_listen_endpoint.clone().filter(|_| zenoh.advertise);
+
     let (mut ws_tx, mut ws_rx) = ws_stream.split();
 
     // Channel for outgoing messages (daemon events + command replies).
@@ -187,7 +206,11 @@ pub async fn register(
     // Serialize params via to_string (not to_value) to preserve u128 fidelity
     // for uhlc::ID(NonZeroU128) inside the timestamp.
     let register_params_json = serde_json::to_string(&Timestamped {
-        inner: CoordinatorRequest::Register(DaemonRegisterRequest::new(machine_id, labels)),
+        inner: CoordinatorRequest::Register(DaemonRegisterRequest::with_zenoh_endpoint(
+            machine_id,
+            labels,
+            advertised_listen_endpoint,
+        )),
         timestamp: clock.new_timestamp(),
     })?;
     let register_id = Uuid::new_v4();
@@ -202,7 +225,7 @@ pub async fn register(
     // Wait for register reply with timeout.
     // The coordinator's register handler sends back Timestamped<RegisterResult>
     // wrapped in a WsRequest with method "daemon_event".
-    let daemon_id = tokio::time::timeout(REGISTER_TIMEOUT, async {
+    let (daemon_id, peer_zenoh_endpoints) = tokio::time::timeout(REGISTER_TIMEOUT, async {
         loop {
             let msg = ws_rx
                 .next()
@@ -225,7 +248,7 @@ pub async fn register(
                 tracing::warn!("failed to update timestamp after register: {err}");
             }
 
-            break result.inner.to_result();
+            break result.inner.into_parts();
         }
     })
     .await
@@ -268,6 +291,8 @@ pub async fn register(
 
     Ok((
         daemon_id,
+        reserved_listen_endpoint,
+        peer_zenoh_endpoints,
         CoordinatorSender { sender: send_tx },
         ReceiverStream::new(rx),
     ))

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1148,6 +1148,65 @@ fn announce_zenoh_bind(zenoh_bind: ZenohBind, coordinator_ws_addr: SocketAddr) -
     Ok(())
 }
 
+/// What `register` needs to reserve and advertise this daemon's zenoh listener.
+///
+/// Grouped because the three travel together through every hop between the run
+/// loop and the register frame, and separately they read as three unrelated
+/// booleans-and-options at each call site.
+pub(crate) struct ZenohRegistration {
+    /// Where the listener binds, and whether a bind failure is fatal.
+    pub bind: ZenohBind,
+    /// Whether the resulting endpoint is worth telling peers about — false for
+    /// a loopback bind, which would point a remote daemon at its own host.
+    pub advertise: bool,
+    /// The endpoint already reserved on a previous connect, reused so a
+    /// reconnect does not reserve a port the open session never bound.
+    pub reserved: Option<String>,
+}
+
+/// Reserve the endpoint this daemon's zenoh listener will bind.
+///
+/// Split out of `build_daemon` so it can run *before* the daemon registers:
+/// the endpoint is advertised in the registration, which is what lets the
+/// coordinator hand it to daemons that register afterwards without a window in
+/// which two of them learn nothing about each other (see
+/// `DaemonRegisterRequest::zenoh_listen_endpoint`).
+///
+/// A reservation binds an ephemeral port and drops the socket, so there is a
+/// window before zenoh's own bind in which another process could take it. That
+/// window already existed; registering first widens it by one round-trip. It
+/// stays tolerable because the listener is verified after `zenoh::open` — a
+/// port lost in the window is caught there, and the advertised endpoint is
+/// withdrawn rather than left to mislead peers.
+///
+/// Failing to reserve is fatal for an address the operator *named*: continuing
+/// would leave the daemon with no listener at all — undialable and silently
+/// dead — and someone who had to say the address out loud is, almost by
+/// definition, on a network where multicast will not rescue them. A derived
+/// address falls back instead: loopback always exists, so the error was
+/// effectively unreachable anyway.
+fn reserve_zenoh_listen_endpoint(zenoh_bind: ZenohBind) -> eyre::Result<Option<String>> {
+    match zenoh_bind.endpoint() {
+        Ok(ep) => Ok(Some(ep)),
+        Err(err) if zenoh_bind.is_explicit() => Err(err).wrap_err_with(|| {
+            format!(
+                "failed to bind the zenoh listen address {} given via \
+                 --zenoh-listen; other daemons would have no way to reach this \
+                 one. Check that this address exists on this host",
+                zenoh_bind.addr()
+            )
+        }),
+        Err(err) => {
+            tracing::warn!(
+                "failed to reserve zenoh listen endpoint on {}: {err}; \
+                 falling back to multicast scouting only",
+                zenoh_bind.addr()
+            );
+            Ok(None)
+        }
+    }
+}
+
 /// Extract a finished dataflow's collected node results out of
 /// `dataflow_node_results` for its terminal [`DataflowDaemonResult`].
 ///
@@ -1258,6 +1317,20 @@ impl Daemon {
                 })?;
         }
         announce_zenoh_bind(zenoh_bind, coordinator_ws_addr)?;
+        // Reserved lazily, by `register`, once the coordinator socket is up —
+        // *not* here. A reservation binds an ephemeral port and drops the
+        // socket, so everything between it and zenoh's own bind is a window in
+        // which another process can take that port; reserving here would stretch
+        // that window across the whole coordinator connect loop, which retries
+        // for many minutes when the coordinator is not up yet. Cached across
+        // reconnects because the session (and its bound port) outlives them.
+        let mut requested_listen_endpoint: Option<String> = None;
+        // Only a routable listener is worth advertising — handing `127.0.0.1`
+        // to a daemon on another machine would point it at its own loopback,
+        // and dialing it would cost that daemon its multicast fallback for
+        // nothing. A single-machine deployment therefore advertises nothing and
+        // keeps exactly the behavior it has today.
+        let advertise_listen_endpoint = !zenoh_bind.addr().is_loopback();
         let clock = Arc::new(HLC::default());
         let mut ctrlc_events = set_up_ctrlc_handler(clock.clone())?;
         // Tracks whether we've ever connected to the coordinator. The initial
@@ -1304,6 +1377,11 @@ impl Daemon {
                     coordinator_ws_addr,
                     &machine_id,
                     labels.clone(),
+                    ZenohRegistration {
+                        bind: zenoh_bind,
+                        advertise: advertise_listen_endpoint,
+                        reserved: requested_listen_endpoint.clone(),
+                    },
                     &clock,
                     remote_daemon_events_rx,
                     dynamic_node_events_rx.clone(),
@@ -1339,7 +1417,17 @@ impl Daemon {
             };
 
             match connect_result {
-                Ok((daemon_id, coordinator_sender, incoming_events)) => {
+                Ok((
+                    daemon_id,
+                    reserved_listen_endpoint,
+                    peer_zenoh_endpoints,
+                    coordinator_sender,
+                    incoming_events,
+                )) => {
+                    // Cache the port `register` reserved so a reconnect reuses
+                    // it rather than reserving a second one the session never
+                    // bound.
+                    requested_listen_endpoint = reserved_listen_endpoint;
                     connected_once = true;
                     // Fresh successful connection: a later disconnect starts a
                     // new retry window rather than inheriting an old deadline.
@@ -1371,6 +1459,18 @@ impl Daemon {
                                 log_destination,
                                 inter_daemon_peer.clone(),
                                 zenoh_connect.clone(),
+                                requested_listen_endpoint.clone(),
+                                // Peers the coordinator knows about, dialed in
+                                // addition to any named on the command line.
+                                // `open_zenoh_session_with_listen` deduplicates,
+                                // so an endpoint given both ways costs nothing.
+                                //
+                                // Only applied on the first connect: this is
+                                // where the zenoh session is opened, and zenoh
+                                // reads `connect/endpoints` once. A reconnect
+                                // reuses the existing session (and its links),
+                                // so a later reply's list has nothing to act on.
+                                peer_zenoh_endpoints,
                                 zenoh_bind,
                                 disable_multicast,
                                 // A standalone daemon outlives nothing its
@@ -1761,7 +1861,10 @@ impl Daemon {
             builds,
             log_destination,
             inter_daemon_peer,
-            // `dora run` is single-machine: no remote daemon to dial.
+            // `dora run` is single-machine: no remote daemon to dial, and no
+            // coordinator to have discovered one from.
+            Vec::new(),
+            reserve_zenoh_listen_endpoint(ZenohBind::Derived(LOCALHOST))?,
             Vec::new(),
             ZenohBind::Derived(LOCALHOST),
             disable_multicast,
@@ -1798,6 +1901,13 @@ impl Daemon {
         log_destination: LogDestination,
         inter_daemon_peer: Option<String>,
         zenoh_connect: Vec<String>,
+        // The endpoint this daemon will bind, already reserved by the caller.
+        requested_listen_endpoint: Option<String>,
+        // Peers the coordinator reported at registration. Kept separate from
+        // `zenoh_connect` (which the operator named) because a discovered list
+        // must not disable multicast scouting — see
+        // `ZenohSessionParams::discovered_connect_endpoints`.
+        zenoh_discovered_connect: Vec<String>,
         zenoh_bind: ZenohBind,
         disable_multicast: bool,
         bind_nodes_to_parent: bool,
@@ -1832,27 +1942,9 @@ impl Daemon {
         // the exact failure this code exists to prevent. Someone who named an
         // address explicitly is also, almost by definition, on a network where
         // multicast will not save them. So: fatal when explicit.
-        let requested_listen_endpoint = match zenoh_bind.endpoint() {
-            Ok(ep) => Some(ep),
-            Err(err) if zenoh_bind.is_explicit() => {
-                return Err(err).wrap_err_with(|| {
-                    format!(
-                        "failed to bind the zenoh listen address {} given via \
-                         --zenoh-listen; other daemons would have no way to reach this \
-                         one. Check that this address exists on this host",
-                        zenoh_bind.addr()
-                    )
-                });
-            }
-            Err(err) => {
-                tracing::warn!(
-                    "failed to reserve zenoh listen endpoint on {}: {err}; \
-                     falling back to multicast scouting only",
-                    zenoh_bind.addr()
-                );
-                None
-            }
-        };
+        // Reserved by the caller, before registering, so the endpoint can
+        // travel *with* the registration — see
+        // `DaemonRegisterRequest::zenoh_listen_endpoint`.
         // The helper is the source of truth for whether the listener actually
         // bound: `zenoh_listen_endpoint` only becomes `Some` if zenoh accepted
         // the listen/endpoints insert. Otherwise we must not inject
@@ -1863,6 +1955,7 @@ impl Daemon {
                 listen_endpoint: requested_listen_endpoint.as_deref(),
                 inter_daemon_peer: inter_daemon_peer.as_deref(),
                 connect_endpoints: &zenoh_connect,
+                discovered_connect_endpoints: &zenoh_discovered_connect,
                 multicast: if disable_multicast {
                     MulticastScouting::Disabled
                 } else {
@@ -2054,6 +2147,41 @@ impl Daemon {
                 && let Err(err) = sender.send_event(&bytes).await
             {
                 tracing::warn!("failed to send status report to coordinator: {err}");
+            }
+
+            // Confirm — or withdraw — the endpoint advertised at registration,
+            // now that the session is open and the listener has been checked
+            // against `info().locators()`.
+            //
+            // The announcement itself happened in the register request, because
+            // it has to be on record before the *next* daemon's reply is built;
+            // see `DaemonRegisterRequest::zenoh_listen_endpoint`. This is only
+            // the correction, and it matters most in the failure case: a daemon
+            // that advertised a port and then lost it to another process must
+            // say so, or the coordinator hands that dead endpoint to every
+            // daemon that registers afterwards.
+            //
+            // Skipped entirely when nothing was advertised (`zenoh_routable_addr`
+            // is `None` for a loopback bind — a single-machine deployment), since
+            // there is then nothing to confirm or withdraw.
+            //
+            // Re-sent on every reconnect, so a coordinator that restarted and
+            // lost the registry relearns this daemon's endpoint.
+            if self.zenoh_routable_addr.is_some() {
+                let stamped = Timestamped {
+                    inner: CoordinatorRequest::Event {
+                        daemon_id: self.daemon_id.clone(),
+                        event: DaemonEvent::ZenohListenEndpoint {
+                            endpoint: self.zenoh_listen_endpoint.clone(),
+                        },
+                    },
+                    timestamp: self.clock.new_timestamp(),
+                };
+                if let Ok(bytes) = serde_json::to_vec(&stamped)
+                    && let Err(err) = sender.send_event(&bytes).await
+                {
+                    tracing::warn!("failed to report zenoh listen endpoint to coordinator: {err}");
+                }
             }
         }
 
@@ -6882,6 +7010,8 @@ async fn set_up_event_stream(
     coordinator_ws_addr: SocketAddr,
     machine_id: &Option<String>,
     labels: BTreeMap<String, String>,
+    // Reservation happens inside `register`, once the coordinator socket is up.
+    zenoh: ZenohRegistration,
     clock: &Arc<HLC>,
     remote_daemon_events_rx: flume::Receiver<eyre::Result<Timestamped<InterDaemonEvent>>>,
     // Events from the dynamic-node listener. The listener is bound once by the
@@ -6890,6 +7020,8 @@ async fn set_up_event_stream(
     dynamic_node_events_rx: flume::Receiver<Timestamped<DynamicNodeEventWrapper>>,
 ) -> eyre::Result<(
     DaemonId,
+    Option<String>,
+    Vec<String>,
     coordinator::CoordinatorSender,
     impl Stream<Item = Timestamped<Event>> + Unpin,
 )> {
@@ -6904,10 +7036,17 @@ async fn set_up_event_stream(
             timestamp: clock_cloned.new_timestamp(),
         },
     });
-    let (daemon_id, coordinator_sender, coordinator_events) = coordinator::register(
+    let (
+        daemon_id,
+        reserved_listen_endpoint,
+        peer_zenoh_endpoints,
+        coordinator_sender,
+        coordinator_events,
+    ) = coordinator::register(
         coordinator_ws_addr,
         machine_id.clone(),
         labels,
+        zenoh,
         clock.clone(),
     )
     .await
@@ -6931,7 +7070,13 @@ async fn set_up_event_stream(
         dynamic_node_events,
     )
         .merge();
-    Ok((daemon_id, coordinator_sender, incoming))
+    Ok((
+        daemon_id,
+        reserved_listen_endpoint,
+        peer_zenoh_endpoints,
+        coordinator_sender,
+        incoming,
+    ))
 }
 
 fn note_output_sent_to_local_receivers(

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1156,12 +1156,32 @@ fn announce_zenoh_bind(zenoh_bind: ZenohBind, coordinator_ws_addr: SocketAddr) -
 pub(crate) struct ZenohRegistration {
     /// Where the listener binds, and whether a bind failure is fatal.
     pub bind: ZenohBind,
-    /// Whether the resulting endpoint is worth telling peers about — false for
-    /// a loopback bind, which would point a remote daemon at its own host.
-    pub advertise: bool,
-    /// The endpoint already reserved on a previous connect, reused so a
-    /// reconnect does not reserve a port the open session never bound.
+    /// What to tell the coordinator this daemon is reachable at.
+    pub advertise: AdvertiseListener,
+    /// The endpoint already reserved, reused so a reconnect does not reserve a
+    /// port the open session never bound. Pre-filled for an explicit bind,
+    /// whose reservation happens before the connect loop.
     pub reserved: Option<String>,
+}
+
+/// Which endpoint a registration advertises to the coordinator.
+///
+/// Spelled out rather than left as a bool plus the reserved value, because the
+/// reserved endpoint and the *bound* one diverge exactly when it matters: a
+/// listener that lost its port between reservation and `zenoh::open` leaves the
+/// daemon holding a reserved string nothing is listening on, and re-advertising
+/// it on the next reconnect would hand that dead port to every daemon that
+/// registers afterwards.
+pub(crate) enum AdvertiseListener {
+    /// Nothing — a loopback bind, which would point a remote daemon at its own
+    /// host.
+    Never,
+    /// Whatever `register` reserves. The first connect, where no session exists
+    /// yet and the reserved endpoint is the only candidate.
+    Reserved,
+    /// What the open session actually bound, verified against
+    /// `info().locators()`. `None` withdraws a previously advertised endpoint.
+    Bound(Option<String>),
 }
 
 /// Reserve the endpoint this daemon's zenoh listener will bind.
@@ -1317,14 +1337,31 @@ impl Daemon {
                 })?;
         }
         announce_zenoh_bind(zenoh_bind, coordinator_ws_addr)?;
-        // Reserved lazily, by `register`, once the coordinator socket is up —
-        // *not* here. A reservation binds an ephemeral port and drops the
-        // socket, so everything between it and zenoh's own bind is a window in
-        // which another process can take that port; reserving here would stretch
-        // that window across the whole coordinator connect loop, which retries
-        // for many minutes when the coordinator is not up yet. Cached across
-        // reconnects because the session (and its bound port) outlives them.
-        let mut requested_listen_endpoint: Option<String> = None;
+        // A *derived* address is reserved lazily, by `register`, once the
+        // coordinator socket is up. A reservation binds an ephemeral port and
+        // drops the socket, so everything between it and zenoh's own bind is a
+        // window in which another process can take that port; reserving here
+        // would stretch that window across the whole coordinator connect loop,
+        // which retries for many minutes when the coordinator is not up yet.
+        //
+        // An address the operator *named* is reserved here instead, because
+        // failing to reserve it is fatal, and a fatal error raised from inside
+        // `register` would surface as a coordinator-connection failure: the
+        // daemon would log "waiting for coordinator", reconnect, re-reserve and
+        // repeat forever, blaming the network for a local bind problem. Doing
+        // it up front costs a wider window for the one case that names an
+        // address without a port; a named port reserves nothing at all, so the
+        // common explicit form pays nothing. It also means the call inside
+        // `register` only ever sees a derived bind, whose failures are
+        // non-fatal by construction.
+        //
+        // Either way the result is cached across reconnects, because the
+        // session — and the port it bound — outlives them.
+        let mut requested_listen_endpoint: Option<String> = if zenoh_bind.is_explicit() {
+            reserve_zenoh_listen_endpoint(zenoh_bind)?
+        } else {
+            None
+        };
         // Only a routable listener is worth advertising — handing `127.0.0.1`
         // to a daemon on another machine would point it at its own loopback,
         // and dialing it would cost that daemon its multicast fallback for
@@ -1379,7 +1416,16 @@ impl Daemon {
                     labels.clone(),
                     ZenohRegistration {
                         bind: zenoh_bind,
-                        advertise: advertise_listen_endpoint,
+                        // On a reconnect the session is already open, so the
+                        // endpoint it *bound* is the truth — not the one we
+                        // reserved, which may be a port we lost.
+                        advertise: if !advertise_listen_endpoint {
+                            AdvertiseListener::Never
+                        } else if let Some(d) = daemon.as_ref() {
+                            AdvertiseListener::Bound(d.zenoh_listen_endpoint.clone())
+                        } else {
+                            AdvertiseListener::Reserved
+                        },
                         reserved: requested_listen_endpoint.clone(),
                     },
                     &clock,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1702,15 +1702,45 @@ class Operator:
 ### Setup
 
 ```bash
-# Machine A (coordinator + daemon)
-dora up
+# Machine A (coordinator + daemon).
+# The coordinator binds loopback by default, which no other machine can reach,
+# so bind the address the daemons will dial. Without this, machine B and C only
+# report a connection timeout.
+#
+# Name the concrete address rather than `0.0.0.0`: machine A's own daemon
+# derives its zenoh listener from this address too, so a wildcard leaves that
+# daemon on loopback and invisible to B and C.
+#
+# The coordinator then answers on 192.168.1.10 and *not* on loopback, while
+# `dora list`/`logs`/`stop`/`start`/`down` all default to loopback — so set the
+# address for them once, on machine A and on any machine you drive the dataflow
+# from. (`dora up` derives it from `--interface` on its own; the others do not.)
+export DORA_COORDINATOR_ADDR=192.168.1.10
+dora up --interface 192.168.1.10
 
-# Machine B (daemon only, pointing to coordinator on Machine A)
-dora daemon --interface 0.0.0.0 --coordinator-addr 192.168.1.10 --machine-id B
+# Machine B (daemon only, pointing to the coordinator on Machine A)
+dora daemon --coordinator-addr 192.168.1.10 --machine-id B
 
 # Machine C (same)
-dora daemon --interface 0.0.0.0 --coordinator-addr 192.168.1.10 --machine-id C
+dora daemon --coordinator-addr 192.168.1.10 --machine-id C
 ```
+
+Each daemon derives the address its peers should dial from `--coordinator-addr`
+(the local address that routes toward the coordinator, which is the LAN address
+on a LAN and the tunnel address on a mesh VPN), sends it along with its
+registration, and receives in return the addresses of the daemons that
+registered before it. Each daemon dialing the ones that
+preceded it builds the full mesh, so nothing else has to be configured for the
+daemons to reach each other — including on a network without multicast, such as
+a mesh VPN.
+
+Override the derived address with `--zenoh-listen <IP>` on a multi-homed host
+that would otherwise advertise an interface the other machines cannot reach.
+
+The daemons can be started in any order, and simultaneously: each advertises
+its endpoint in its own registration, and the coordinator handles registrations
+one at a time, so whichever registers second is always handed the first one's
+address.
 
 ### Dataflow with Machine Assignment
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1702,21 +1702,24 @@ class Operator:
 ### Setup
 
 ```bash
-# Machine A (coordinator + daemon).
 # The coordinator binds loopback by default, which no other machine can reach,
-# so bind the address the daemons will dial. Without this, machine B and C only
+# so bind the address the daemons will dial. Without this, machines B and C only
 # report a connection timeout.
 #
-# Name the concrete address rather than `0.0.0.0`: machine A's own daemon
-# derives its zenoh listener from this address too, so a wildcard leaves that
-# daemon on loopback and invisible to B and C.
-#
-# The coordinator then answers on 192.168.1.10 and *not* on loopback, while
-# `dora list`/`logs`/`stop`/`start`/`down` all default to loopback — so set the
-# address for them once, on machine A and on any machine you drive the dataflow
-# from. (`dora up` derives it from `--interface` on its own; the others do not.)
+# `dora list`/`logs`/`stop`/`start`/`down` all default to loopback, so set the
+# address once for them — on machine A and on any machine you drive the dataflow
+# from.
 export DORA_COORDINATOR_ADDR=192.168.1.10
-dora up --interface 192.168.1.10
+
+# Machine A: coordinator, plus its own *named* daemon.
+#
+# `dora up` would start an unnamed daemon, which `deploy: {machine: A}` can
+# never place a node on — so start the two separately whenever machine A is
+# itself a deploy target. Name the concrete address rather than `0.0.0.0`: each
+# daemon derives its zenoh listener from the coordinator address, and a wildcard
+# leaves A's daemon on loopback and undialable by B and C.
+dora coordinator --interface 192.168.1.10
+dora daemon --coordinator-addr 192.168.1.10 --machine-id A
 
 # Machine B (daemon only, pointing to the coordinator on Machine A)
 dora daemon --coordinator-addr 192.168.1.10 --machine-id B
@@ -1724,6 +1727,10 @@ dora daemon --coordinator-addr 192.168.1.10 --machine-id B
 # Machine C (same)
 dora daemon --coordinator-addr 192.168.1.10 --machine-id C
 ```
+
+`dora up --interface 192.168.1.10` remains the shortcut for a machine that only
+hosts the coordinator and runs no deployed nodes of its own: it starts both, but
+its daemon is unnamed.
 
 Each daemon derives the address its peers should dial from `--coordinator-addr`
 (the local address that routes toward the coordinator, which is the LAN address

--- a/docs/distributed-deployment.md
+++ b/docs/distributed-deployment.md
@@ -179,12 +179,24 @@ machines:
 > in its own registration, and the coordinator processes registrations serially,
 > so the one that registers second is always handed the first one's address.
 >
-> One residual gap: the registry lives in the coordinator's memory, so a
-> coordinator restart empties it until the daemons re-register (which they do
-> automatically, re-advertising as they go). A *new* daemon that registers
-> during that gap can be handed an incomplete list. Existing daemons are
-> unaffected — their zenoh links do not run through the coordinator and survive
-> its restart — and with multicast available the gap is covered by scouting.
+> Three residual gaps, all covered by multicast where it is available, which is
+> why it stays on by default:
+>
+> * The registry lives in the coordinator's memory, so a coordinator restart
+>   empties it until the daemons re-register (which they do automatically,
+>   re-advertising as they go). A *new* daemon registering during that gap can
+>   be handed an incomplete list. Existing daemons are unaffected — their zenoh
+>   links do not run through the coordinator and survive its restart.
+> * A daemon is handed endpoints once, at registration. If one of them is stale,
+>   that daemon has no way to recover: zenoh reads `connect/endpoints` at session
+>   open and never again. The advertising daemon withdraws a listener that failed
+>   to bind, which bounds the exposure for daemons registering *later*, but not
+>   for one that already has it.
+> * Discovery is one-directional by construction — only the joiner dials. Where
+>   a firewall permits connections in one direction only, the explicit
+>   `--zenoh-connect` mesh could still form the link from the reachable side,
+>   because both ends dial; this cannot. Name the endpoints explicitly for such
+>   a topology.
 >
 > The flags below remain for the cases the automatic path cannot cover: a
 > multi-homed host that would advertise the wrong interface (`--zenoh-listen`), a

--- a/docs/distributed-deployment.md
+++ b/docs/distributed-deployment.md
@@ -158,6 +158,39 @@ machines:
 > peers do not relay for each other, a pair that cannot form a direct link has no
 > fallback and silently exchanges nothing.
 >
+> **The coordinator wires this automatically.** Each daemon derives the address
+> its peers should dial from `--coordinator-addr` (the local address that routes
+> toward the coordinator — the LAN address on a LAN, the tunnel address on a mesh
+> VPN), sends it along with its registration, and receives in return the
+> endpoints of the daemons that registered before it. (It confirms the endpoint
+> once its listener is verified, and withdraws it if the bind failed, so a dead
+> endpoint is not handed out for long.) Each daemon
+> dialing the ones that preceded it builds the full clique, so a deployment where
+> every daemon can reach the coordinator needs no zenoh configuration at all —
+> not even on a network without multicast.
+>
+> Only a *routable* listener is distributed: a daemon that bound loopback (which
+> is what a coordinator on `127.0.0.1` yields) reports nothing, because handing
+> `127.0.0.1` to another machine would point it at its own loopback. That is why
+> a coordinator meant to serve remote daemons must bind a routable address —
+> `dora up --interface <IP>`, or `dora cluster up`, which does it for you.
+>
+> Daemons may start in any order and all at once: each advertises its endpoint
+> in its own registration, and the coordinator processes registrations serially,
+> so the one that registers second is always handed the first one's address.
+>
+> One residual gap: the registry lives in the coordinator's memory, so a
+> coordinator restart empties it until the daemons re-register (which they do
+> automatically, re-advertising as they go). A *new* daemon that registers
+> during that gap can be handed an incomplete list. Existing daemons are
+> unaffected — their zenoh links do not run through the coordinator and survive
+> its restart — and with multicast available the gap is covered by scouting.
+>
+> The flags below remain for the cases the automatic path cannot cover: a
+> multi-homed host that would advertise the wrong interface (`--zenoh-listen`), a
+> deployment that must be wired before the coordinator is reachable, or a
+> topology with your own routers (`--zenoh-config-overlay`).
+>
 > When every machine has a dialable address, `dora cluster up` wires the daemons
 > into an explicit mesh: each one gets
 > `--zenoh-listen <its addr>:<its port> --zenoh-connect <every other machine>`.
@@ -335,9 +368,10 @@ dora cluster up <PATH>
 
 ```bash
 $ dora cluster up cluster.yml
-Starting coordinator on 10.0.0.1:6013...
-Starting daemon on robot (ubuntu@10.0.0.2)... OK
-Starting daemon on gpu-server (ubuntu@10.0.0.3)... OK
+started dora coordinator on 0.0.0.0 (reachable from other machines)
+Starting daemon on robot (ubuntu@10.0.0.2)
+Starting daemon on gpu-server (ubuntu@10.0.0.3)
+Waiting for 2 daemon(s) to connect...
 All 2 daemons connected.
 ```
 

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -612,14 +612,15 @@ pub async fn open_zenoh_session_with_listen(
             connect_eps.retain(|ep| seen_connect.insert(ep.clone()));
             let mut connect_inserted = false;
             if !connect_eps.is_empty() {
-                let json = format!(
-                    "[{}]",
-                    connect_eps
-                        .iter()
-                        .map(|s| format!(r#""{s}""#))
-                        .collect::<Vec<_>>()
-                        .join(",")
-                );
+                // Serialized, not interpolated. These strings are no longer all
+                // operator-supplied: the coordinator hands over endpoints that
+                // other daemons reported, so a `"` in one would otherwise end
+                // the JSON5 string and either break the whole array — costing
+                // this session every connect endpoint, legitimate ones included
+                // — or append endpoints of someone else's choosing to the dial
+                // list. `endpoint_array_json` escapes; `validate_zenoh_endpoint`
+                // rejects such a value on ingest. Both, deliberately.
+                let json = endpoint_array_json(&connect_eps);
                 match zenoh_config.insert_json5("connect/endpoints", &json) {
                     Ok(()) => connect_inserted = true,
                     Err(err) => {
@@ -685,14 +686,7 @@ pub async fn open_zenoh_session_with_listen(
                 listen_eps.extend(overlay.listen_endpoints.iter().cloned());
             }
             if !listen_eps.is_empty() {
-                let json = format!(
-                    "[{}]",
-                    listen_eps
-                        .iter()
-                        .map(|s| format!(r#""{s}""#))
-                        .collect::<Vec<_>>()
-                        .join(",")
-                );
+                let json = endpoint_array_json(&listen_eps);
                 let listen_inserted = match zenoh_config.insert_json5("listen/endpoints", &json) {
                     Ok(()) => {
                         listen_inserted_into_configured = listen_endpoint.map(String::from);
@@ -733,8 +727,15 @@ pub async fn open_zenoh_session_with_listen(
             // absolute would disarm that recovery and strand the daemon.
             let requested_off =
                 multicast_disabled(matches!(multicast, MulticastScouting::Disabled));
-            if ((connect_inserted && has_authoritative_connect)
-                || (requested_off && listen_configured))
+            // Computed once and reused by the listener-did-not-bind diagnostic
+            // below, which used to test `connect_inserted` alone — a proxy that
+            // disagreed with this in both directions, telling a session with
+            // scouting off that it was "falling back to multicast scouting"
+            // (and vice versa). That is the same class of misdirection #2762
+            // fixed once already.
+            let multicast_scouting_off = (connect_inserted && has_authoritative_connect)
+                || (requested_off && listen_configured);
+            if multicast_scouting_off
                 && let Err(err) = zenoh_config.insert_json5("scouting/multicast/enabled", "false")
             {
                 warn!("failed to disable zenoh scouting/multicast: {err}");
@@ -820,15 +821,9 @@ pub async fn open_zenoh_session_with_listen(
                                 if listen_inserted_into_configured.as_deref() == Some(requested) {
                                     effective_listen_endpoint = Some(requested.to_string());
                                 }
-                            } else if connect_inserted && has_authoritative_connect {
-                                // We set operator-supplied `connect/endpoints`
-                                // above, so multicast scouting was disabled for this
-                                // session (#1856). (A connect list that is only
-                                // *discovered* leaves scouting on, and so takes the
-                                // `else` branch below instead — telling a debugger
-                                // there is no fallback when there is would point
-                                // them the wrong way just as surely as #2762 did.)
-                                // There is therefore NO discovery fallback:
+                            } else if multicast_scouting_off {
+                                // Scouting is off for this session, so there is
+                                // NO discovery fallback:
                                 // peers already told to dial `{requested}` (e.g. via
                                 // the per-node `DORA_ZENOH_CONNECT` plan from #2716)
                                 // cannot reach this now-listener-less session, and it
@@ -877,6 +872,57 @@ pub async fn open_zenoh_session_with_listen(
         ),
     };
     Ok((zenoh_session, effective_listen_endpoint))
+}
+
+/// Render endpoints as a JSON array for `insert_json5`, escaping each one.
+///
+/// `serde_json` output is valid JSON5, and escaping is what keeps a hostile or
+/// merely malformed endpoint from reshaping the array around it.
+#[cfg(feature = "zenoh")]
+fn endpoint_array_json(endpoints: &[String]) -> String {
+    serde_json::Value::Array(
+        endpoints
+            .iter()
+            .map(|e| serde_json::Value::String(e.clone()))
+            .collect(),
+    )
+    .to_string()
+}
+
+/// Whether `endpoint` is safe to accept from the network as a zenoh locator.
+///
+/// Applied to the endpoint a daemon reports to the coordinator, which is the
+/// first value to reach dora's zenoh config from off-machine — everything
+/// before it came from the operator's own command line. The coordinator hands
+/// it to every daemon that registers later, so an unchecked value would travel
+/// straight into their `connect/endpoints`.
+///
+/// Deliberately a charset check rather than a locator parse: zenoh's locator
+/// grammar covers protocols dora does not model (`quic`, `unixsock-stream`,
+/// metadata after `?`, config after `#`), and rejecting a valid endpoint would
+/// break a working deployment. What matters is that nothing here can terminate
+/// a JSON string or escape it — so quotes, backslashes and control characters
+/// are refused, along with anything long enough to be worth truncating.
+pub fn validate_zenoh_endpoint(endpoint: &str) -> Result<(), String> {
+    const MAX_LEN: usize = 256;
+    if endpoint.is_empty() {
+        return Err("zenoh endpoint must not be empty".to_string());
+    }
+    if endpoint.len() > MAX_LEN {
+        return Err(format!(
+            "zenoh endpoint is {} bytes, over the {MAX_LEN}-byte limit",
+            endpoint.len()
+        ));
+    }
+    if let Some(bad) = endpoint
+        .chars()
+        .find(|c| !matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '.' | ':' | '/' | '-' | '_' | '[' | ']' | '%' | '?' | '#' | '=' | '&' | '+' | '*' | ','))
+    {
+        return Err(format!(
+            "zenoh endpoint contains the disallowed character {bad:?}"
+        ));
+    }
+    Ok(())
 }
 
 /// Default TCP port for a daemon's inter-daemon zenoh listener.
@@ -1228,6 +1274,51 @@ pub fn zenoh_daemon_control_topic(
 pub fn dataflow_extension_topic(dataflow_id: &uuid::Uuid, namespace: &str) -> String {
     let network_id = "default";
     format!("dora/{network_id}/{dataflow_id}/ext/{namespace}")
+}
+
+#[cfg(test)]
+mod endpoint_validation_tests {
+    use super::validate_zenoh_endpoint;
+
+    #[test]
+    fn ordinary_locators_are_accepted() {
+        for ok in [
+            "tcp/127.0.0.1:7447",
+            "tcp/10.0.2.100:5456",
+            "tcp/[fd7a:1::2]:5456",
+            "udp/192.168.1.1:7447",
+            "tcp/host.example:7447",
+            "tcp/10.0.0.1:7447?prio=high",
+            "tcp/10.0.0.1:7447#iface=eth0",
+        ] {
+            assert!(validate_zenoh_endpoint(ok).is_ok(), "rejected `{ok}`");
+        }
+    }
+
+    /// The reason this validator exists: the endpoint reaches dora's zenoh
+    /// config from off-machine, and a quote would end the JSON string it is
+    /// written into — either breaking the whole array (costing that daemon
+    /// every connect endpoint) or appending endpoints of someone else's
+    /// choosing to it.
+    #[test]
+    fn quotes_and_escapes_are_rejected() {
+        for bad in [
+            r#"tcp/1.2.3.4:1"#.to_string() + "\"",
+            r#"tcp/1.2.3.4:1","tcp/evil:7447"#.to_string(),
+            r"tcp/1.2.3.4:1\u0022".to_string(),
+            "tcp/1.2.3.4:1\n".to_string(),
+            "tcp/1.2.3.4:1 ".to_string(),
+        ] {
+            assert!(validate_zenoh_endpoint(&bad).is_err(), "accepted `{bad}`");
+        }
+    }
+
+    #[test]
+    fn empty_and_oversized_endpoints_are_rejected() {
+        assert!(validate_zenoh_endpoint("").is_err());
+        assert!(validate_zenoh_endpoint(&"a".repeat(257)).is_err());
+        assert!(validate_zenoh_endpoint(&"a".repeat(256)).is_ok());
+    }
 }
 
 #[cfg(test)]

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -375,7 +375,25 @@ pub struct ZenohSessionParams<'a> {
     /// daemons into an explicit mesh instead of relying on gossip through a
     /// single rendezvous: every daemon dials every other one, which is the
     /// clique zenoh 1.9 requires of a peer region.
+    ///
+    /// Operator-supplied, and therefore *authoritative*: naming them is a
+    /// statement that this deployment does not rely on scouting, so they
+    /// replace multicast (see the `#1856` guard below).
     pub connect_endpoints: &'a [String],
+    /// Peers this session dials that dora *discovered* rather than the operator
+    /// naming them — today, the endpoints the coordinator handed back at
+    /// registration.
+    ///
+    /// Dialed exactly like [`Self::connect_endpoints`], but deliberately
+    /// excluded from the decision to turn multicast scouting off. A discovered
+    /// list can be incomplete or stale in ways an operator-supplied one cannot:
+    /// a peer that has not yet reported its endpoint is missing from it, and a
+    /// peer that died moments ago is still in it until the coordinator notices.
+    /// Letting such a list disable scouting would make a partial answer *worse*
+    /// than no answer — it would strip the fallback that was working — so
+    /// discovery here is strictly additive: it adds links, and multicast stays
+    /// available to cover whatever it missed.
+    pub discovered_connect_endpoints: &'a [String],
     /// Whether this session may scout by multicast. A request, not a command —
     /// see the `#1856` guard below.
     pub multicast: MulticastScouting,
@@ -448,6 +466,7 @@ pub async fn open_zenoh_session_with_listen(
         listen_endpoint,
         inter_daemon_peer,
         connect_endpoints,
+        discovered_connect_endpoints,
         multicast,
     } = params;
 
@@ -552,14 +571,21 @@ pub async fn open_zenoh_session_with_listen(
             //      daemon discovery (extends #1778 to the daemon↔daemon
             //      hop). One daemon binds it as a listener, others connect
             //      and gossip-discover their peers via it.
-            // All are explicit endpoints; if we set any of them we
-            // disable multicast scouting so we don't end up with mixed
-            // discovery modes.
+            //   4. `discovered_connect_endpoints` — peers the coordinator
+            //      reported. Dialed like the rest, but see below: because a
+            //      discovered list can be incomplete or stale, it alone does
+            //      not disable scouting.
+            // Setting any of the *operator-supplied* ones disables multicast
+            // scouting, so we don't end up with mixed discovery modes.
             let mut connect_eps: Vec<String> = Vec::new();
             if let Ok(eps) = std::env::var(DORA_ZENOH_CONNECT_ENV) {
                 connect_eps.extend(split_endpoints(&eps));
             }
             connect_eps.extend(connect_endpoints.iter().cloned());
+            // Everything appended from here on is dialed but does not, on its
+            // own, justify dropping multicast — see `discovered_connect_endpoints`.
+            let authoritative_connect_eps = connect_eps.len();
+            connect_eps.extend(discovered_connect_endpoints.iter().cloned());
             if let Some(peer) = inter_daemon_peer {
                 connect_eps.push(peer.to_string());
             }
@@ -575,6 +601,14 @@ pub async fn open_zenoh_session_with_listen(
             // which only collapses *adjacent* equals and would leave the
             // env/param/rendezvous interleaving untouched.
             let mut seen_connect = std::collections::HashSet::new();
+            // Counted before dedup: `retain` only ever removes later duplicates
+            // of an earlier entry, and the authoritative entries come first, so
+            // "were there any" is unaffected by it.
+            let has_authoritative_connect = authoritative_connect_eps > 0
+                || inter_daemon_peer.is_some()
+                || overlay
+                    .as_ref()
+                    .is_some_and(|o| !o.connect_endpoints.is_empty());
             connect_eps.retain(|ep| seen_connect.insert(ep.clone()));
             let mut connect_inserted = false;
             if !connect_eps.is_empty() {
@@ -699,7 +733,8 @@ pub async fn open_zenoh_session_with_listen(
             // absolute would disarm that recovery and strand the daemon.
             let requested_off =
                 multicast_disabled(matches!(multicast, MulticastScouting::Disabled));
-            if (connect_inserted || (requested_off && listen_configured))
+            if ((connect_inserted && has_authoritative_connect)
+                || (requested_off && listen_configured))
                 && let Err(err) = zenoh_config.insert_json5("scouting/multicast/enabled", "false")
             {
                 warn!("failed to disable zenoh scouting/multicast: {err}");
@@ -785,10 +820,15 @@ pub async fn open_zenoh_session_with_listen(
                                 if listen_inserted_into_configured.as_deref() == Some(requested) {
                                     effective_listen_endpoint = Some(requested.to_string());
                                 }
-                            } else if connect_inserted {
-                                // We set explicit `connect/endpoints` above, so
-                                // multicast scouting was disabled for this session
-                                // (#1856). There is therefore NO discovery fallback:
+                            } else if connect_inserted && has_authoritative_connect {
+                                // We set operator-supplied `connect/endpoints`
+                                // above, so multicast scouting was disabled for this
+                                // session (#1856). (A connect list that is only
+                                // *discovered* leaves scouting on, and so takes the
+                                // `else` branch below instead — telling a debugger
+                                // there is no fallback when there is would point
+                                // them the wrong way just as surely as #2762 did.)
+                                // There is therefore NO discovery fallback:
                                 // peers already told to dial `{requested}` (e.g. via
                                 // the per-node `DORA_ZENOH_CONNECT` plan from #2716)
                                 // cannot reach this now-listener-less session, and it

--- a/libraries/core/src/topics.rs
+++ b/libraries/core/src/topics.rs
@@ -585,7 +585,23 @@ pub async fn open_zenoh_session_with_listen(
             // Everything appended from here on is dialed but does not, on its
             // own, justify dropping multicast — see `discovered_connect_endpoints`.
             let authoritative_connect_eps = connect_eps.len();
-            connect_eps.extend(discovered_connect_endpoints.iter().cloned());
+            // Discovered endpoints are checked here as well as by whoever handed
+            // them over. The coordinator validates what daemons report to it, so
+            // this is not the only guard — but it is the one that sits where the
+            // value is *used*, which keeps the property true for any future
+            // source of discovered endpoints and for a coordinator that is
+            // itself wrong. Operator-supplied endpoints are deliberately not
+            // filtered: someone who typed an endpoint on the command line is
+            // owed a zenoh error about it, not silence.
+            connect_eps.extend(discovered_connect_endpoints.iter().filter_map(|ep| {
+                match validate_zenoh_endpoint(ep) {
+                    Ok(()) => Some(ep.clone()),
+                    Err(err) => {
+                        warn!("ignoring discovered zenoh endpoint: {err}");
+                        None
+                    }
+                }
+            }));
             if let Some(peer) = inter_daemon_peer {
                 connect_eps.push(peer.to_string());
             }
@@ -896,6 +912,12 @@ fn endpoint_array_json(endpoints: &[String]) -> String {
 /// before it came from the operator's own command line. The coordinator hands
 /// it to every daemon that registers later, so an unchecked value would travel
 /// straight into their `connect/endpoints`.
+///
+/// Called on every hop that value takes: both ways a daemon can report one
+/// (`accept_reported_zenoh_endpoint` in the coordinator covers the registration
+/// *and* the later correction, which exists to replace it), and again where a
+/// receiving daemon merges the result into its own dial list. Validating only
+/// at the first hop would leave the property depending on which path ran last.
 ///
 /// Deliberately a charset check rather than a locator parse: zenoh's locator
 /// grammar covers protocols dora does not model (`quic`, `unixsock-stream`,

--- a/libraries/message/src/coordinator_to_daemon.rs
+++ b/libraries/message/src/coordinator_to_daemon.rs
@@ -39,7 +39,14 @@ pub enum StateCatchUpOperation {
 pub use crate::common::Timestamped;
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
 pub enum RegisterResult {
+    /// Constructed through [`RegisterResult::ok`], not by literal: the variant
+    /// is `#[non_exhaustive]` so that the *next* field added here is a minor
+    /// change rather than a 2.0. Adding `peer_zenoh_endpoints` to an exhaustive
+    /// variant was itself a major break (`enum_struct_variant_field_added`);
+    /// paying it once, with the attribute, is what keeps it from recurring.
+    #[non_exhaustive]
     Ok {
         /// unique ID assigned by the coordinator
         daemon_id: DaemonId,
@@ -84,6 +91,14 @@ pub enum RegisterResult {
 }
 
 impl RegisterResult {
+    /// A successful registration: the assigned id and the peers to dial.
+    pub fn ok(daemon_id: DaemonId, peer_zenoh_endpoints: Vec<String>) -> Self {
+        Self::Ok {
+            daemon_id,
+            peer_zenoh_endpoints,
+        }
+    }
+
     /// The assigned id alone, for callers that do not wire zenoh.
     pub fn to_result(self) -> eyre::Result<DaemonId> {
         self.into_parts().map(|(daemon_id, _)| daemon_id)

--- a/libraries/message/src/coordinator_to_daemon.rs
+++ b/libraries/message/src/coordinator_to_daemon.rs
@@ -43,14 +43,60 @@ pub enum RegisterResult {
     Ok {
         /// unique ID assigned by the coordinator
         daemon_id: DaemonId,
+        /// Zenoh listen endpoints of the daemons that were already registered
+        /// when this one joined, for it to dial.
+        ///
+        /// The coordinator is the only component every daemon already talks
+        /// to, which makes it the one place a daemon can learn where its peers
+        /// are without anyone configuring an address twice. Without this a
+        /// multi-machine deployment has to name every daemon's endpoint on
+        /// every other daemon's command line (`--zenoh-connect`), or rely on
+        /// multicast — which a mesh VPN does not carry.
+        ///
+        /// Only endpoints a daemon *verified as bound* appear here (see the
+        /// `info().locators()` check in `open_zenoh_session_with_listen`), so a
+        /// dial planned from this list has a listener behind it.
+        ///
+        /// Deliberately only the *earlier* daemons: zenoh reads
+        /// `connect/endpoints` once at session open and never re-reads it, so a
+        /// daemon cannot act on an endpoint that arrives later. It does not
+        /// need to — a zenoh transport is bidirectional, so the joining
+        /// daemon's dial carries traffic in both directions. Each daemon
+        /// dialing everyone who came before it therefore builds the full
+        /// clique, with no daemon ever needing to learn about a later one.
+        ///
+        /// Daemons may start simultaneously: each advertises its endpoint in
+        /// its own registration (see
+        /// [`crate::daemon_to_coordinator::DaemonRegisterRequest::zenoh_listen_endpoint`]),
+        /// and the coordinator handles registrations one at a time, so the one
+        /// that registers second always sees the first. That ordering is what
+        /// removes the need for a daemon to ever act on a *later* report —
+        /// which it could not do anyway, zenoh having no runtime equivalent of
+        /// `connect/endpoints`.
+        ///
+        /// `#[serde(default)]` keeps a daemon built before this field existed
+        /// decodable: it sees no peers and falls back to the multicast/explicit
+        /// wiring it already had.
+        #[serde(default)]
+        peer_zenoh_endpoints: Vec<String>,
     },
     Err(String),
 }
 
 impl RegisterResult {
+    /// The assigned id alone, for callers that do not wire zenoh.
     pub fn to_result(self) -> eyre::Result<DaemonId> {
+        self.into_parts().map(|(daemon_id, _)| daemon_id)
+    }
+
+    /// The assigned id plus the peer endpoints to dial; see
+    /// [`RegisterResult::Ok::peer_zenoh_endpoints`].
+    pub fn into_parts(self) -> eyre::Result<(DaemonId, Vec<String>)> {
         match self {
-            RegisterResult::Ok { daemon_id } => Ok(daemon_id),
+            RegisterResult::Ok {
+                daemon_id,
+                peer_zenoh_endpoints,
+            } => Ok((daemon_id, peer_zenoh_endpoints)),
             RegisterResult::Err(err) => Err(eyre::eyre!(err)),
         }
     }
@@ -235,4 +281,42 @@ pub struct SpawnDataflowNodes {
     /// When set, daemons can pull binaries from `{artifact_base_url}/{build_id}/{node_id}`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub artifact_base_url: Option<String>,
+}
+
+#[cfg(test)]
+mod register_result_tests {
+    use super::*;
+
+    /// A daemon built before `peer_zenoh_endpoints` existed sends a reply
+    /// without the field. It must still decode — into "no peers to dial" —
+    /// rather than failing registration outright, which would take the whole
+    /// daemon down over a field it does not need.
+    #[test]
+    fn a_reply_without_peer_endpoints_decodes_as_no_peers() {
+        let legacy = r#"{"Ok":{"daemon_id":{"machine_id":"A","uuid":"00000000-0000-0000-0000-000000000001"}}}"#;
+        let decoded: RegisterResult =
+            serde_json::from_str(legacy).expect("legacy register reply must stay decodable");
+        let (_, peers) = decoded.into_parts().expect("legacy reply is Ok");
+        assert!(peers.is_empty());
+    }
+
+    #[test]
+    fn peer_endpoints_round_trip() {
+        let peers = vec!["tcp/10.0.2.100:5456".to_string()];
+        let encoded = serde_json::to_string(&RegisterResult::Ok {
+            daemon_id: DaemonId::new(Some("A".to_string())),
+            peer_zenoh_endpoints: peers.clone(),
+        })
+        .expect("serialize");
+        let decoded: RegisterResult = serde_json::from_str(&encoded).expect("deserialize");
+        assert_eq!(decoded.into_parts().expect("ok").1, peers);
+    }
+
+    /// `to_result` is the id-only convenience over `into_parts`; an `Err` reply
+    /// must stay an error through both.
+    #[test]
+    fn an_error_reply_is_an_error_through_both_accessors() {
+        assert!(RegisterResult::Err("nope".into()).to_result().is_err());
+        assert!(RegisterResult::Err("nope".into()).into_parts().is_err());
+    }
 }

--- a/libraries/message/src/daemon_to_coordinator.rs
+++ b/libraries/message/src/daemon_to_coordinator.rs
@@ -69,10 +69,47 @@ pub struct DaemonRegisterRequest {
     /// decoding the frame that carries the field, never reaching the check.
     #[serde(default)]
     metadata_version: u16,
+
+    /// The zenoh endpoint this daemon is about to bind, so the coordinator can
+    /// hand it to daemons that register after this one.
+    ///
+    /// Carried *in the registration* rather than reported once the session is
+    /// open, and that timing is the whole point. The coordinator handles
+    /// registrations one at a time on its event loop, so an endpoint that
+    /// arrives with the registration is already on record before the next
+    /// daemon's reply is built — two daemons starting simultaneously are
+    /// ordered by that loop and the later one always learns about the earlier.
+    /// Reporting after the session opened instead left a window (register →
+    /// listener bound) in which both daemons could register, each be handed a
+    /// list without the other, and stay partitioned: zenoh reads
+    /// `connect/endpoints` once at session open, so neither could act on the
+    /// other's later report.
+    ///
+    /// The port is reserved before registering, so this is the endpoint the
+    /// daemon *will* bind rather than one it has bound. A bind that then fails
+    /// verification is withdrawn with
+    /// [`DaemonEvent::ZenohListenEndpoint`]`(None)`, so the coordinator never
+    /// keeps handing out an endpoint with nothing behind it for long.
+    ///
+    /// `None` for a daemon with no dialable listener — a single-machine
+    /// deployment (loopback, which would point a remote peer at its own host)
+    /// or a failed reservation.
+    #[serde(default)]
+    pub zenoh_listen_endpoint: Option<String>,
 }
 
 impl DaemonRegisterRequest {
     pub fn new(machine_id: Option<String>, labels: BTreeMap<String, String>) -> Self {
+        Self::with_zenoh_endpoint(machine_id, labels, None)
+    }
+
+    /// [`Self::new`] plus the zenoh endpoint this daemon will bind; see
+    /// [`Self::zenoh_listen_endpoint`].
+    pub fn with_zenoh_endpoint(
+        machine_id: Option<String>,
+        labels: BTreeMap<String, String>,
+        zenoh_listen_endpoint: Option<String>,
+    ) -> Self {
         Self {
             dora_version: current_crate_version(),
             machine_id,
@@ -80,6 +117,7 @@ impl DaemonRegisterRequest {
             // a daemon built from this crate understands hub git sources
             supports_hub_sources: true,
             metadata_version: Metadata::CURRENT_VERSION,
+            zenoh_listen_endpoint,
         }
     }
 
@@ -154,6 +192,7 @@ mod register_version_tests {
             labels: Default::default(),
             supports_hub_sources: true,
             metadata_version: Metadata::CURRENT_VERSION,
+            zenoh_listen_endpoint: None,
         }
     }
 
@@ -266,6 +305,28 @@ pub enum DaemonEvent {
     Heartbeat {
         #[serde(default)]
         ft_stats: Option<FaultToleranceSnapshot>,
+    },
+    /// The zenoh endpoint this daemon actually bound and is reachable at,
+    /// sent once its session is open.
+    ///
+    /// The coordinator records it and hands it to daemons that register later
+    /// (see `RegisterResult::Ok::peer_zenoh_endpoints`), which is what lets a
+    /// multi-machine deployment wire itself without every daemon being told
+    /// every other daemon's address.
+    ///
+    /// Confirms or withdraws the endpoint this daemon advertised in its
+    /// registration, once its zenoh session is open and the listener has been
+    /// verified against `info().locators()`.
+    ///
+    /// `Some(endpoint)` confirms (and would correct a differing one);
+    /// `None` withdraws, which is what a daemon whose listener did not bind
+    /// must do so the coordinator stops handing out a dead endpoint.
+    ///
+    /// The registration carries the endpoint in the first place — see
+    /// [`DaemonRegisterRequest::zenoh_listen_endpoint`] for why it cannot wait
+    /// until here. This is the correction, not the announcement.
+    ZenohListenEndpoint {
+        endpoint: Option<String>,
     },
     /// Sent by the daemon after registration to report its current state.
     /// Enables coordinator-daemon reconciliation on reconnect.

--- a/tests/multi-daemon-e2e.rs
+++ b/tests/multi-daemon-e2e.rs
@@ -527,11 +527,16 @@ fn cross_machine_nodes_link_directly_over_an_explicit_mesh() {
         deployment.fail("daemons A and B did not both register within 30s");
     }
 
-    // Attached (no `--detach`), so the exit status carries the dataflow's
-    // result: the sink bails if it never received a cross-machine value.
+    // `--attach` explicitly: without it `dora start` decides by whether stdin is
+    // a terminal, and under `cargo test` it is not — so the command would
+    // detach, return success the moment the dataflow was accepted, and the
+    // status checked below would say nothing at all about delivery. Attached,
+    // it waits for the dataflow to finish and carries its result, and the sink
+    // bails if it never received a cross-machine value.
     let mut start = Command::new(&dora)
         .arg("start")
         .arg(&dataflow_yml)
+        .arg("--attach")
         .arg("--name")
         .arg("cross-machine-direct")
         .arg("--coordinator-port")
@@ -559,5 +564,187 @@ fn cross_machine_nodes_link_directly_over_an_explicit_mesh() {
             "daemon B never resolved a remote node endpoint: the cross-machine \
              edge fell back to daemon forwarding instead of a direct node link",
         );
+    }
+}
+
+/// Two daemons must find each other with **no zenoh configuration at all** —
+/// no `--zenoh-listen`, no `--zenoh-connect`, no `--zenoh-peer` — given only
+/// the coordinator's address.
+///
+/// This is the deployment shape the 1.0 docs promise: start a coordinator, then
+/// start daemons pointing at it. Each daemon derives the address its peers
+/// should dial from `--coordinator-addr` (`zenoh_bind_address_for`), reports it
+/// to the coordinator once its listener is confirmed bound, and receives the
+/// endpoints of the daemons that registered before it in its register reply.
+/// Every daemon dialing the ones that preceded it builds the full clique, which
+/// is what zenoh 1.9 requires of a peer region since it stopped relaying.
+///
+/// **Multicast is explicitly disabled on both daemons**, so it cannot be the
+/// explanation for them finding each other. That is deliberate on two counts:
+/// it makes the test assert the coordinator registry specifically, and it makes
+/// the test runnable where multicast is unavailable (dev containers, most CI
+/// runners) — which is exactly where the previous multi-daemon coverage had to
+/// fall back to naming endpoints by hand.
+///
+/// Delivery is asserted by construction, as in the mesh test above: the sink
+/// fails its node when no `random` value arrives, so a dataflow that finishes
+/// is proof the cross-machine edge carried data.
+#[test]
+fn daemons_discover_each_other_through_the_coordinator_without_zenoh_config() {
+    ensure_built();
+
+    // The daemons derive their zenoh bind from the coordinator address, and a
+    // loopback coordinator yields a loopback bind that no peer may be handed.
+    // Without a routable address there is nothing to test.
+    let Some(routable) = routable_local_addr() else {
+        eprintln!("skipping: no routable local address on this host");
+        return;
+    };
+
+    let dora = bin("dora");
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let dataflow_yml = tmp.path().join("dataflow.yml");
+
+    // Producer on A, consumer on B, with no same-machine consumer for `random`,
+    // so the only path from producer to sink crosses the daemon boundary.
+    std::fs::write(
+        &dataflow_yml,
+        format!(
+            "nodes:\n  \
+             - id: producer\n    \
+               deploy:\n      machine: A\n    \
+               path: {producer}\n    \
+               inputs:\n      tick: dora/timer/millis/10\n    \
+               outputs:\n      - random\n  \
+             - id: sink\n    \
+               deploy:\n      machine: B\n    \
+               path: {sink}\n    \
+               inputs:\n      random: producer/random\n",
+            producer = bin("multiple-daemons-example-node").display(),
+            sink = bin("multiple-daemons-example-sink").display(),
+        ),
+    )
+    .expect("write dataflow yml");
+
+    let ports = free_ports(2);
+    let coordinator_port = ports[0];
+    // Only one daemon can hold the default node-listen port on a shared host.
+    let node_listen_ports = [None, Some(ports[1])];
+    let coord_log = tmp.path().join("coordinator.log");
+    let coord_out = std::fs::File::create(&coord_log).expect("create coordinator log");
+    let coord_err = coord_out.try_clone().expect("clone coordinator log");
+
+    let mut deployment = Deployment {
+        dora: dora.clone(),
+        coordinator_port,
+        children: vec![
+            Command::new(&dora)
+                .arg("coordinator")
+                // Wildcard so the daemons can reach it at `routable` while the
+                // test's own helpers keep using loopback — the same bind
+                // `dora cluster up` uses.
+                .arg("--interface")
+                .arg("0.0.0.0")
+                .arg("--port")
+                .arg(coordinator_port.to_string())
+                .arg("--store")
+                .arg(format!(
+                    "redb:{}",
+                    tmp.path().join("coordinator.redb").display()
+                ))
+                .stdout(Stdio::from(coord_out))
+                .stderr(Stdio::from(coord_err))
+                .spawn()
+                .expect("failed to spawn coordinator"),
+        ],
+        logs: vec![coord_log],
+    };
+    if !wait_until(|| port_open(coordinator_port), Duration::from_secs(20)) {
+        deployment.fail("coordinator did not accept connections within 20s");
+    }
+
+    // Started **concurrently**, with no wait between them, which is the case
+    // the registry has to get right: each daemon advertises its endpoint in its
+    // own register request, and the coordinator handles registrations one at a
+    // time on its event loop, so whichever is second is handed the first one's
+    // endpoint no matter how close together they start.
+    //
+    // This is the regression guard for the window that existed while daemons
+    // reported their endpoint only *after* opening their zenoh session: two
+    // daemons registering inside it were each handed a list without the other,
+    // and — since zenoh reads `connect/endpoints` once — neither could act on
+    // the other's later report. With multicast off, as here, that pair stayed
+    // partitioned for the life of the process.
+    let daemon_log = |machine: &str| tmp.path().join(format!("daemon-{machine}.log"));
+    for (machine, node_listen_port) in ["A", "B"].into_iter().zip(node_listen_ports) {
+        let log = daemon_log(machine);
+        let out = std::fs::File::create(&log).expect("create daemon log");
+        let err = out.try_clone().expect("clone daemon log");
+        let mut command = Command::new(&dora);
+        command
+            .arg("daemon")
+            .arg("--machine-id")
+            .arg(machine)
+            // The *only* address configured anywhere. Everything zenoh needs is
+            // derived from it or learned from the coordinator.
+            .arg("--coordinator-addr")
+            .arg(routable.to_string())
+            .arg("--coordinator-port")
+            .arg(coordinator_port.to_string())
+            // Proves the coordinator registry did the wiring: with scouting off
+            // there is no other way for these two to find each other.
+            .arg("--zenoh-no-multicast")
+            // The endpoint exchange logs its result at debug, and the daemon's
+            // own filter pins `dora_daemon=info` unless RUST_LOG names it.
+            .env("RUST_LOG", "dora_daemon=debug")
+            .stdout(Stdio::from(out))
+            .stderr(Stdio::from(err));
+        if let Some(port) = node_listen_port {
+            command.arg("--local-listen-port").arg(port.to_string());
+        }
+        deployment
+            .children
+            .push(command.spawn().expect("failed to spawn daemon"));
+        deployment.logs.push(log);
+    }
+
+    if !wait_until(
+        || {
+            connected_machines(coordinator_port)
+                .map(|m| m.iter().any(|id| id == "A") && m.iter().any(|id| id == "B"))
+                .unwrap_or(false)
+        },
+        Duration::from_secs(30),
+    ) {
+        deployment.fail("daemons A and B did not both register within 30s");
+    }
+
+    // `--attach` explicitly: without it `dora start` decides by whether stdin is
+    // a terminal, and under `cargo test` it is not — so the command would
+    // detach, return success the moment the dataflow was accepted, and the
+    // status checked below would say nothing at all about delivery. Attached,
+    // it waits for the dataflow to finish and carries its result, and the sink
+    // bails if it never received a cross-machine value.
+    let mut start = Command::new(&dora)
+        .arg("start")
+        .arg(&dataflow_yml)
+        .arg("--attach")
+        .arg("--name")
+        .arg("zero-config-discovery")
+        .arg("--coordinator-port")
+        .arg(coordinator_port.to_string())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to run dora start");
+    let Some(status) = wait_for_exit(&mut start, Duration::from_secs(120)) else {
+        deployment.fail("the cross-machine dataflow did not finish within 120s");
+    };
+    if !status.success() {
+        deployment.fail(format!(
+            "the cross-machine dataflow failed ({status}); with multicast off and \
+             no zenoh flags, the daemons had only the coordinator's endpoint \
+             registry to find each other by"
+        ));
     }
 }


### PR DESCRIPTION
A multi-machine deployment currently has to name every daemon's zenoh endpoint on every other daemon's command line (`--zenoh-listen` + `--zenoh-connect`), or rely on multicast — which a mesh VPN does not carry. The coordinator is the one component every daemon already talks to, so it can carry that wiring instead.

Each daemon derives the address its peers should dial from `--coordinator-addr` (the local address routing toward the coordinator: the LAN address on a LAN, the tunnel address on a tailnet), sends it with its registration, and gets back the endpoints of the daemons that registered before it. Each daemon dialing its predecessors builds the full clique — zenoh transports are bidirectional, so no daemon needs to learn about a later one. Starting a coordinator and pointing daemons at it is now enough, with no zenoh configuration and no multicast.

The endpoint travels **in the register request** rather than being reported once the listener is bound. The coordinator handles registrations serially, so an endpoint arriving with the registration is already on record when the next daemon's reply is built — daemons may start simultaneously. Reporting after the session opened left a window in which two daemons were each handed a list without the other and stayed partitioned, with no recovery, since zenoh reads `connect/endpoints` once at session open. The endpoint is confirmed, or withdrawn, once the listener is verified against `info().locators()`, so a port lost between reservation and bind is not handed out indefinitely.

Discovered endpoints are kept separate from operator-supplied ones and deliberately **do not** disable multicast scouting. A discovered list can be incomplete or stale in ways an operator-supplied one cannot, and letting a partial answer strip a working fallback would be worse than no answer. Only a routable, verified listener is distributed, so a single-machine deployment advertises nothing and behaves exactly as before.

`dora up` gains `--interface`, without which the coordinator it starts binds loopback and no remote daemon can reach it. Its coordinator-spawn path is now shared with `dora cluster up`, which had a second implementation disagreeing on that very default; the teardown half has been shared since `dora cluster down` started delegating to `down`.

Two pre-existing defects found on the way:

- `docs/cli.md` told users to run `dora daemon --interface 0.0.0.0` — a flag that does not exist, so the documented ad-hoc multi-machine setup could not work as written.
- `cross_machine_nodes_link_directly_over_an_explicit_mesh` asserted delivery it never checked: `dora start` detaches when stdin is not a terminal, so under `cargo test` it returned success the instant the dataflow was accepted. Both cross-machine tests now pass `--attach`.

The new e2e test starts two daemons **concurrently** with multicast explicitly off, so the coordinator registry is the only way they can find each other. Verified failing on the pre-change design (dataflow never delivers) and passing after.

### Residual gap

The registry lives in the coordinator's memory, so a coordinator restart empties it until daemons re-register (which they do automatically, re-advertising as they go). A *new* daemon registering during that gap can get an incomplete list. Existing daemons are unaffected — their zenoh links do not run through the coordinator and survive its restart — and multicast covers the gap where available. Persisting endpoints would trade this for a staler hazard, since a restarted daemon returns on a different ephemeral port.

`dora-message` is covered by the 1.0 freeze, so the two wire fields (both `#[serde(default)]`) need to land before GA or wait for 2.0.

### Semver

Verified with `cargo-semver-checks` against `v1.0.0-rc.5`. `dora-node-api` and `dora-arrow-convert` are unaffected (196/196 pass).

- **`dora-message`** (covered by the 1.0 guarantee): `RegisterResult` and its `Ok` variant are now `#[non_exhaustive]`, constructed via `RegisterResult::ok`. That is a major break, taken deliberately in place of the `enum_struct_variant_field_added` break that adding `peer_zenoh_endpoints` would otherwise have caused — paying it once with the attribute is what stops the *next* field here from being another 2.0. Either way this lands before the freeze or waits.
- **`dora-core`** (published, but explicitly outside the guarantee — see the stability scope in `docs/api-rust.md`): `ZenohSessionParams` gains `discovered_connect_endpoints`, a `constructible_struct_adds_field` break. Recorded rather than papered over; marking it `#[non_exhaustive]` would need a builder, which is not worth it for an internal crate.
- `DaemonEvent` is already `#[non_exhaustive]`, so the new variant is not a break, and `DaemonRegisterRequest` has private fields, so its new field is not either.

The **wire** is compatible in both directions independent of the above: both new fields are `#[serde(default)]`, neither side uses `deny_unknown_fields`, and an old coordinator that cannot decode the new `ZenohListenEndpoint` variant warns and keeps the connection, degrading to pre-change behaviour. This matters because `versions_compatible` uses caret semantics, so a 1.0 daemon and a 1.1 coordinator genuinely can register with each other.

### Design residuals

Documented next to the coordinator-restart gap in `docs/distributed-deployment.md`; all three are covered by multicast, which is why it stays on by default:

- A daemon receives endpoints once, at registration. A stale one has no recovery on that daemon, since zenoh reads `connect/endpoints` only at session open. The withdrawal bounds exposure for daemons registering later, not for one already holding it.
- Discovery is one-directional — only the joiner dials. Under an asymmetric firewall the explicit `--zenoh-connect` mesh could still form the link because both ends dial; this cannot.
