### PR TITLE
ci(clippy): lint every target, not just lib and bin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,20 +139,23 @@ jobs:
           # save, so the race can't cache a check-only (.rmeta) subset.
           shared-key: workspace
           save-if: false
+      # `--all-targets` so the lint gate covers what `cargo clippy --all`
+      # alone skips: unit tests, integration tests, benches, and example
+      # binaries. Those are a large share of the workspace's code, and
+      # until now the only compile gate on them was `cargo check --examples`
+      # plus `cargo test` -- neither of which lints.
       - run: >
-          cargo clippy --all
+          cargo clippy --all --all-targets
           --exclude dora-node-api-python
           --exclude dora-operator-api-python
           --exclude dora-ros2-bridge-python
           -- -D warnings
       # `--all` does not enable opt-in features, so neither the extension's
       # daemon half nor the daemon's wiring for it would otherwise be linted.
-      # `--all-targets` on the extension covers its tests, which live with the
-      # code it tests.
       - name: Clippy (tensor-pool extension)
         run: >
           cargo clippy -p dora-tensor-pool --features daemon --all-targets -- -D warnings
-          && cargo clippy -p dora-daemon --features tensor-pool -- -D warnings
+          && cargo clippy -p dora-daemon --features tensor-pool --all-targets -- -D warnings
 
   # Cheap compile gate on every PR. `cargo check` skips codegen/link,
   # so it's much faster than the full `test` job below. Exposed as the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ cargo test --all --exclude dora-runtime-python --exclude dora-node-api-python --
 cargo test -p dora-core
 
 # Lint
-cargo clippy --all
+cargo clippy --all --all-targets
 
 # Format
 cargo fmt --all
@@ -125,7 +125,7 @@ Run the `/simplify` skill to check for unnecessary complexity, code duplication,
 cargo fmt --all -- --check
 
 # 2. Clippy with warnings-as-errors — CI uses -D warnings
-cargo clippy --all \
+cargo clippy --all --all-targets \
   --exclude dora-node-api-python \
   --exclude dora-operator-api-python \
   --exclude dora-ros2-bridge-python \
@@ -186,7 +186,7 @@ The deeper QA gates — `make qa-full`, `make qa-deep`, `make qa-nightly`, `make
 
 **PR CI (`.github/workflows/ci.yml`, ~30-45 min, #1716):** Linux-only. Blocks merge.
 - `cargo fmt --all -- --check`
-- `cargo clippy --all -- -D warnings` (excluding Python packages)
+- `cargo clippy --all --all-targets -- -D warnings` (excluding Python packages) — `--all-targets` so tests, benches, and example binaries are linted too
 - `cargo test --all` on **ubuntu-latest only** (excluding Python packages)
 - `cargo check --all-targets` on the three PyO3 crates, so their `#[cfg(test)]` modules are at least type-checked on every PR (`cargo check --all` covers lib targets only)
 - E2E tests: `ws-cli-e2e` + `fault-tolerance-e2e`

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ qa-publish-graph:
 	@scripts/qa/publish-graph.sh
 
 qa-clippy:
-	@cargo clippy --all \
+	@cargo clippy --all --all-targets \
 		--exclude dora-node-api-python \
 		--exclude dora-operator-api-python \
 		--exclude dora-ros2-bridge-python \

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -8462,13 +8462,13 @@ mod fault_tolerance_tests {
     }
 
     fn matches_event(event: &NodeEvent, expected: &str) -> bool {
-        match (event, expected) {
-            (NodeEvent::InputClosed { .. }, "InputClosed") => true,
-            (NodeEvent::InputRecovered { .. }, "InputRecovered") => true,
-            (NodeEvent::AllInputsClosed, "AllInputsClosed") => true,
-            (NodeEvent::Input { .. }, "Input") => true,
-            _ => false,
-        }
+        matches!(
+            (event, expected),
+            (NodeEvent::InputClosed { .. }, "InputClosed")
+                | (NodeEvent::InputRecovered { .. }, "InputRecovered")
+                | (NodeEvent::AllInputsClosed, "AllInputsClosed")
+                | (NodeEvent::Input { .. }, "Input")
+        )
     }
 
     // -- Test 1: close_input removes input, sends InputClosed, no AllInputsClosed with remaining inputs --
@@ -10084,14 +10084,11 @@ mod announce_zenoh_bind_tests {
 
 #[cfg(test)]
 mod node_results_cleanup_tests {
-    use super::{NodeId, extract_node_results};
+    use super::{DaemonRunResult, NodeId, extract_node_results};
     use std::collections::BTreeMap;
     use uuid::Uuid;
 
-    fn populated() -> (
-        Uuid,
-        BTreeMap<Uuid, BTreeMap<NodeId, Result<(), super::NodeError>>>,
-    ) {
+    fn populated() -> (Uuid, DaemonRunResult) {
         let id = Uuid::new_v4();
         let mut inner = BTreeMap::new();
         inner.insert(NodeId::from("node".to_string()), Ok(()));

--- a/docs/contributor-qa-cheatsheet.md
+++ b/docs/contributor-qa-cheatsheet.md
@@ -63,7 +63,7 @@ make qa-fast
 Runs:
 
 - `cargo fmt --all -- --check`
-- `cargo clippy --all -- -D warnings` with Python crates excluded
+- `cargo clippy --all --all-targets -- -D warnings` with Python crates excluded
 - supply-chain audit
 - unwrap-budget check
 - typo check
@@ -199,7 +199,7 @@ could silently break without failing any unit/integration test.
 ```bash
 cargo fmt --all -- --check
 
-cargo clippy --all \
+cargo clippy --all --all-targets \
   --exclude dora-node-api-python \
   --exclude dora-operator-api-python \
   --exclude dora-ros2-bridge-python \

--- a/docs/qa-runbook.md
+++ b/docs/qa-runbook.md
@@ -60,7 +60,7 @@ rustup component add miri --toolchain nightly   # optional; for unsafe-code anal
 | `make qa-mutation-audit` | `cargo-mutants --full` on 6 critical crates | ~10-18 hrs | Deliberate test-quality audit, not every nightly |
 | `make qa-examples` | `scripts/smoke-all.sh` -- all smoke-eligible example dataflows end-to-end (skips CUDA/ROS2/webcam/C++/interactive) | ~15-20 min | When you want actual dataflows exercised. Orthogonal to ladder -- qa-fast/full/deep all `--exclude dora-examples`. Pass `ARGS="--rust-only"` etc. |
 | `make qa-fmt` | `cargo fmt --all -- --check` | ~2 s | Spot-check |
-| `make qa-clippy` | `cargo clippy --all -- -D warnings` (excluding Python) | ~1 min | After mechanical edits |
+| `make qa-clippy` | `cargo clippy --all --all-targets -- -D warnings` (excluding Python) | ~1 min | After mechanical edits |
 | `make qa-audit` | `cargo audit` + `cargo deny check` | ~10 s | After bumping deps |
 | `make qa-unwrap` | count `.unwrap()` / `.expect(` in production code | ~2 s | After adding unwraps |
 | `make qa-test` | `cargo test --all` (excluding Python) | ~3-5 min | After code changes |

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -20,7 +20,7 @@ Run these three commands to validate that the workspace is healthy:
 cargo fmt --all -- --check
 
 # 2. Lint (~60s first run, cached after)
-cargo clippy --all \
+cargo clippy --all --all-targets \
   --exclude dora-node-api-python \
   --exclude dora-operator-api-python \
   --exclude dora-ros2-bridge-python \
@@ -41,7 +41,7 @@ All three must pass before opening a PR. Python packages are excluded because th
 | Tier | What it covers | Command | Speed |
 |------|---------------|---------|-------|
 | **Format** | Code style | `cargo fmt --all -- --check` | ~5s |
-| **Lint** | Warnings, correctness | `cargo clippy --all ...` | ~60s |
+| **Lint** | Warnings, correctness | `cargo clippy --all --all-targets ...` | ~60s |
 | **Unit** | Individual functions | `cargo test --all ...` | ~90s |
 | **CLI** | Command parsing, validation | `cargo test -p dora-cli` | ~5s |
 | **Integration** | Node I/O via env vars | `cargo test --test example-tests` | ~30s |
@@ -229,7 +229,7 @@ Two workflows split by cadence (#1716):
 | Job | Runner | What runs |
 |-----|--------|-----------|
 | **fmt** | ubuntu-latest | `cargo fmt --all -- --check` |
-| **clippy** | ubuntu-latest | `cargo clippy --all ... -- -D warnings` |
+| **clippy** | ubuntu-latest | `cargo clippy --all --all-targets ... -- -D warnings` |
 | **test** | ubuntu-latest | `cargo check`, `cargo build`, `cargo test --all ...` (excluding Python crates and `dora-examples`) plus fast CLI smoke/semantic checks |
 | **e2e** | ubuntu-latest | `ws-cli-e2e` and `fault-tolerance-e2e` |
 | **contract-tests** | ubuntu-latest | `tests/example-smoke.rs::contract_*` behavior contracts |

--- a/docs/testing-matrix.md
+++ b/docs/testing-matrix.md
@@ -21,7 +21,7 @@ Fast gates. Must pass for every PR.
 | Area | Where | How |
 |---|---|---|
 | Format | `.github/workflows/ci.yml` `fmt` | `cargo fmt --all -- --check` |
-| Clippy | `.github/workflows/ci.yml` `clippy` | `cargo clippy --all -- -D warnings` |
+| Clippy | `.github/workflows/ci.yml` `clippy` | `cargo clippy --all --all-targets -- -D warnings` |
 | Core tests (Linux) | `.github/workflows/ci.yml` `test` | `cargo test --all` (Python crates excluded) on ubuntu-latest |
 | CLI smoke (argparse, `validate`, `expand`, `graph`) | `.github/workflows/ci.yml` `test` | Per-subcommand `--help` + validate/expand/graph on representative YAMLs (ubuntu-latest) |
 | Core tests (macOS + Windows) | `.github/workflows/nightly.yml` `test-cross-platform` | same steps as PR `test`, nightly-gated (#1716) |

--- a/examples/ros2-bridge/rust/service-server/run.rs
+++ b/examples/ros2-bridge/rust/service-server/run.rs
@@ -1,7 +1,6 @@
 use dora_cli::{BuildConfig, build, run};
 use eyre::Context;
 use std::{path::Path, sync::mpsc};
-use tokio;
 
 use process_wrap::tokio::{ChildWrapper, CommandWrap};
 

--- a/libraries/extensions/tensor-pool/python/src/transport.rs
+++ b/libraries/extensions/tensor-pool/python/src/transport.rs
@@ -762,6 +762,10 @@ fn check_capacity_gpu_pool(
 mod transport_tests {
     use super::*;
 
+    /// One row of the exhaustive `classify_transport` matrix:
+    /// `(src_dev, dst_dev, p2p, is_cuda)` paired with the expected path.
+    type TransportCase = ((i32, i32, bool, bool), TransportPath);
+
     // -- classify_transport -------------------------------------------------
 
     #[test]
@@ -814,7 +818,7 @@ mod transport_tests {
 
     #[test]
     fn classify_transport_full_8_case_matrix() {
-        let cases: &[((i32, i32, bool, bool), TransportPath)] = &[
+        let cases: &[TransportCase] = &[
             // (src_dev, dst_dev, p2p, is_cuda) → expected
             ((0, 0, false, false), TransportPath::SameDeviceDtoD),
             ((0, 0, false, true), TransportPath::SameDeviceDtoD),

--- a/libraries/message/benches/message_serde.rs
+++ b/libraries/message/benches/message_serde.rs
@@ -1,5 +1,6 @@
 use aligned_vec::AVec;
-use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 use dora_message::{
     common::DataMessage, id::DataId, metadata::Metadata, node_to_daemon::DaemonRequest,

--- a/scripts/qa/all.sh
+++ b/scripts/qa/all.sh
@@ -103,7 +103,8 @@ print_overview() {
 $header
 Will run:
   1. fmt            -- cargo fmt --all -- --check
-  2. clippy         -- cargo clippy --all -- -D warnings (excluding Python)
+  2. clippy         -- cargo clippy --all --all-targets -- -D warnings
+                       (excluding Python)
   3. audit          -- cargo-audit + cargo-deny on the dependency tree
   4. unwrap-budget  -- count production .unwrap() / .expect( regressions
   5. typos          -- spell-check against _typos.toml allowlist
@@ -259,7 +260,7 @@ print_overview "$MODE"
 
 # ----- Always run (fast) -----
 run "fmt"           cargo fmt --all -- --check
-run "clippy"        cargo clippy --all \
+run "clippy"        cargo clippy --all --all-targets \
                       --exclude dora-node-api-python \
                       --exclude dora-operator-api-python \
                       --exclude dora-ros2-bridge-python \

--- a/tests/example-smoke.rs
+++ b/tests/example-smoke.rs
@@ -2035,16 +2035,18 @@ fn run_cross_local_smoke_test(name: &str, yaml_path: &str, timeout: Duration) {
     // Daemon A (listens on the zenoh peer port) and daemon B (dials it).
     // Each daemon also gets an explicit local listen port: two daemons on
     // one host would otherwise pick the same default and collide.
-    let mut local_listen_port = TcpListener::bind("127.0.0.1:0")
+    let base_listen_port = TcpListener::bind("127.0.0.1:0")
         .and_then(|l| l.local_addr())
         .map(|a| a.port())
         .expect("pick local listen port");
-    for (machine, dial) in [
+    for (offset, (machine, dial)) in [
         ("A", format!("tcp/0.0.0.0:{zenoh_port}")),
         ("B", format!("tcp/127.0.0.1:{zenoh_port}")),
-    ] {
-        let listen_port = local_listen_port;
-        local_listen_port += 1;
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let listen_port = base_listen_port + offset as u16;
         let log = tmp.join(format!("daemon-{machine}.log"));
         // The yml's `working_dir: .` is relative to
         // the daemon's cwd (the repo root, per the multiple-daemons


### PR DESCRIPTION
`cargo clippy --all` builds only the default targets, so unit tests, integration tests, benches, and example binaries were never linted. That is a large share of the workspace — the whole `tests/` tree, every `#[cfg(test)]` module, and 40+ example node crates. Their only compile gate was `cargo check --examples` plus `cargo test`, neither of which runs clippy.

First commit adds `--all-targets` to the workspace clippy invocation and to the `dora-daemon --features tensor-pool` one (the tensor-pool extension already had it), plus the local mirrors of the gate in `make qa-clippy` and `scripts/qa/all.sh` so the laptop check matches CI. The PyO3 crates stay excluded — their test binaries link libpython.

Second commit clears the six sites this uncovered, all behavior-preserving:

- `message_serde` bench: `criterion::black_box` is deprecated in favour of `std::hint::black_box` (9 call sites, import swapped)
- daemon `matches_event`: a 5-arm `match` returning bools is a `matches!`
- daemon `node_results_cleanup_tests::populated`: spelled out the map type the crate already has an alias for (`DaemonRunResult`)
- tensor-pool python `classify_transport_full_8_case_matrix`: gave the case-table row type a name (`TransportCase`)
- ros2-bridge service-server example: `use tokio;` is redundant
- `example-smoke`: a hand-rolled loop counter for the per-daemon listen port, now `.enumerate()` over a base port

Cost is small — the targets were already being compiled by `cargo test` and `cargo check --examples`; clippy just looks at them now.
