### PR TITLE
fix(node-api): honor timeout on merged (ROS2) event streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,6 +2512,7 @@ dependencies = [
  "eyre",
  "flume 0.12.0",
  "futures",
+ "futures-timer",
  "pyo3",
  "pyo3-build-config",
  "pythonize",

--- a/apis/python/node/Cargo.toml
+++ b/apis/python/node/Cargo.toml
@@ -37,6 +37,7 @@ flume = { workspace = true }
 arrow = { workspace = true, features = ["pyarrow"] }
 pythonize = { workspace = true }
 futures = { workspace = true }
+futures-timer = "3.0.4"
 dora-ros2-bridge-python = { workspace = true }
 dora-download = { workspace = true }
 dora-tensor-pool-python = { workspace = true, optional = true }

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -14,7 +14,9 @@ use dora_operator_api_python::{
 use dora_ros2_bridge_python::Ros2Subscription;
 use eyre::{Context, ContextCompat};
 
+use futures::future::{Either, select};
 use futures::{Stream, StreamExt};
+use futures_timer::Delay;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict};
 use tokio::runtime::{Builder, Runtime};
@@ -368,7 +370,8 @@ impl Node {
     ///                 case "image":
     /// ```
     ///
-    /// Default behaviour is to timeout after 2 seconds.
+    /// Iterating blocks until the next event is available; it does not time
+    /// out. Use `node.next(timeout=..)` if you need a bounded wait.
     ///
     /// :rtype: dict
     pub fn __next__(&self, py: Python) -> PyResult<Option<Py<PyDict>>> {
@@ -973,6 +976,33 @@ struct Events {
     _cleanup_handle: NodeCleanupHandle,
 }
 
+/// Await the next event from a merged (external/ROS2) stream, honoring an
+/// optional timeout.
+///
+/// The `timeout` was previously ignored on merged streams, so
+/// `node.next(timeout=..)` / `recv_async(timeout=..)` blocked forever once the
+/// upstream went quiet (dora-rs/dora#2027). Race the next event against a
+/// `Delay`, mirroring the Rust node API's own `EventStream::recv_async_timeout`.
+/// `Delay` needs no reactor, so this works both under `block_on` and in an
+/// async context. The event is polled first so a ready/buffered event wins over
+/// an already-elapsed (e.g. zero) timer, matching the `Dora` arm's
+/// `recv_timeout(ZERO)`.
+async fn recv_merged_with_timeout<S>(
+    events: &mut S,
+    timeout: Option<Duration>,
+) -> Option<MergedEvent<Py<PyAny>>>
+where
+    S: Stream<Item = MergedEvent<Py<PyAny>>> + Unpin,
+{
+    match timeout {
+        Some(timeout) => match select(events.next(), Delay::new(timeout)).await {
+            Either::Left((event, _)) => event,
+            Either::Right((_, _)) => None,
+        },
+        None => events.next().await,
+    }
+}
+
 impl Events {
     fn recv(&self, timeout: Option<Duration>) -> Option<PyEvent> {
         let mut inner = self.inner.blocking_lock();
@@ -981,7 +1011,9 @@ impl Events {
                 Some(timeout) => events.recv_timeout(timeout).map(MergedEvent::Dora),
                 None => events.recv().map(MergedEvent::Dora),
             },
-            EventsInner::Merged(events) => futures::executor::block_on(events.next()),
+            EventsInner::Merged(events) => {
+                futures::executor::block_on(recv_merged_with_timeout(events, timeout))
+            }
         };
         event.map(|event| PyEvent { event })
     }
@@ -1009,7 +1041,7 @@ impl Events {
                     .map(MergedEvent::Dora),
                 None => events.recv_async().await.map(MergedEvent::Dora),
             },
-            EventsInner::Merged(events) => events.next().await,
+            EventsInner::Merged(events) => recv_merged_with_timeout(events, timeout).await,
         };
         event.map(|event| PyEvent { event })
     }

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -981,8 +981,8 @@ struct Events {
 ///
 /// The `timeout` was previously ignored on merged streams, so
 /// `node.next(timeout=..)` / `recv_async(timeout=..)` blocked forever once the
-/// upstream went quiet (dora-rs/dora#2027). Race the next event against a
-/// `Delay`, mirroring the Rust node API's own `EventStream::recv_async_timeout`.
+/// upstream went quiet. Race the next event against a `Delay`, mirroring the
+/// Rust node API's own `EventStream::recv_async_timeout`.
 /// `Delay` needs no reactor, so this works both under `block_on` and in an
 /// async context. The event is polled first so a ready/buffered event wins over
 /// an already-elapsed (e.g. zero) timer, matching the `Dora` arm's
@@ -1245,6 +1245,46 @@ fn dora(_py: Python, m: Bound<'_, PyModule>) -> PyResult<()> {
 // `libraries/extensions/tensor-pool/python/src/transport.rs` (pure
 // decision logic, exercised without a GPU — see the `#[cfg(test)]` module
 // there). The `transport_tests` scaffolding that used to live here was
-// removed: it was empty, and this crate's test binary is excluded from
-// CI (`cargo test --all` skips the PyO3 crates), so the stub advertised
-// coverage that did not exist (bot review 5306582566).
+// removed: it was empty, and the stub advertised coverage that did not
+// exist (bot review 5306582566). `cargo test --all` skips this crate (its
+// test binary links libpython), but the module below still runs in CI via
+// the `contract-tests` job's `make qa-test-python`.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dora_node_api::{Event, StopCause};
+    use futures::executor::block_on;
+
+    // A merged stream that never yields must time out (return `None`) rather
+    // than block forever — the bug this change fixes. No ROS2 or GIL needed:
+    // the helper is generic over the stream and the pending stream yields no
+    // `Py<PyAny>`.
+    #[test]
+    fn merged_timeout_returns_none_when_stream_is_idle() {
+        let mut stream = futures::stream::pending::<MergedEvent<Py<PyAny>>>();
+        let event = block_on(recv_merged_with_timeout(
+            &mut stream,
+            Some(Duration::from_millis(10)),
+        ));
+        assert!(event.is_none());
+    }
+
+    // A ready event must win over an already-elapsed (zero) timer, matching the
+    // `Dora` arm's `recv_timeout(ZERO)` so `node.next(timeout=0)` can still
+    // drain a buffered event.
+    #[test]
+    fn merged_ready_event_wins_over_zero_timeout() {
+        let mut stream = futures::stream::iter([MergedEvent::Dora(Event::Stop(StopCause::Manual))]);
+        let event = block_on(recv_merged_with_timeout(&mut stream, Some(Duration::ZERO)));
+        assert!(matches!(event, Some(MergedEvent::Dora(Event::Stop(_)))));
+    }
+
+    // Without a timeout the helper simply awaits the next event.
+    #[test]
+    fn merged_no_timeout_yields_event() {
+        let mut stream = futures::stream::iter([MergedEvent::Dora(Event::Stop(StopCause::Manual))]);
+        let event = block_on(recv_merged_with_timeout(&mut stream, None));
+        assert!(matches!(event, Some(MergedEvent::Dora(Event::Stop(_)))));
+    }
+}


### PR DESCRIPTION
## Issue

In the Python node bindings, `Events::recv` and `Events::recv_async_timeout` (`apis/python/node/src/lib.rs`) apply the caller-supplied `timeout` only on the `EventsInner::Dora` arm:

```rust
EventsInner::Dora(events) => match timeout {
    Some(timeout) => events.recv_timeout(timeout).map(MergedEvent::Dora),
    None => events.recv().map(MergedEvent::Dora),
},
EventsInner::Merged(events) => futures::executor::block_on(events.next()), // timeout dropped
```

The `EventsInner::Merged` arm becomes active after a node calls `merge_external_events(...)` — i.e. any ROS2-integrated node. On that arm the `timeout` argument was silently discarded and both the sync and async paths blocked on `events.next()` with no timer.

### Failure scenario

A ROS2-integrated Python node does `node.merge_external_events(sub)` and then loops with `node.next(timeout=5.0)` (or `await node.recv_async(timeout=5.0)`) expecting to wake every 5 s to run periodic work (heartbeat, shutdown check, etc.). Because the timeout was ignored, `node.next` blocked indefinitely until the next Dora/ROS2 event arrived; if the upstream went quiet the node hung forever instead of returning `None`. The docstrings for `next` and `recv_async` explicitly promise the timeout behavior, and the `Dora` arm already implements it.

## Fix

Race the merged stream's `events.next()` against a `futures_timer::Delay`, returning `None` on elapse — exactly mirroring the Rust node API's own `EventStream::recv_async_timeout` (`apis/rust/node/src/event_stream/mod.rs`). `Delay` needs no async reactor, so the same construct works under the sync `futures::executor::block_on` and in the async path. The event future is polled first, so a ready/buffered event still wins over an already-elapsed timer (including `timeout=0`), matching the `Dora` arm's `recv_timeout(ZERO)`.

Also corrects the `__next__` docstring, which claimed a 2-second default timeout while the method actually blocks indefinitely (`self.next(py, None)`).

`futures-timer` is added to the crate's dependencies; it was already present in the lockfile (pulled in by `dora-node-api`), so only a dependency edge is added.

## ⚠️ Behavior change on a 1.0-guaranteed surface

`dora-node-api-python` is inside the 1.0 compatibility guarantee, and this changes an observable behavior on merged (ROS2) streams:

- **Before:** on a merged stream, `node.next(timeout=x)` / `recv_async(timeout=x)` returned `None` **only** when the stream ended; the timeout was ignored.
- **After:** it returns `None` when the timeout elapses, like the non-merged path and as the docstring already promised.

Existing ROS2 Python code that relied on the old behavior — e.g. `event = node.next(timeout=0.1); if event is None: break` — was correct before and will now exit early on an idle interval. This is defensible (it aligns the merged path with both the docstring and the `Dora` arm, and is not a 2.0 trigger), but it should be called out in the release notes so users aren't surprised.

## Validation

- `cargo fmt -p dora-node-api-python`
- `cargo clippy -p dora-node-api-python` — clean
- `cargo test --lib -p dora-node-api-python` (the `make qa-test-python` path) — the new `tests::merged_*` cases pass: an idle stream times out to `None`, a ready event wins over a zero timer, and the no-timeout path yields the event. These exercise `recv_merged_with_timeout` directly and need no ROS2 subscription or GIL.

---

⚠️ This is a machine-generated pull request (automated Claude Code code-review run). A human should review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dnk2Xoj1R4Nr4tL2sx6rk7