### PR TITLE
perf(message): avoid eager fallback evaluation in LogMessage::from

### DIFF
--- a/libraries/message/src/common.rs
+++ b/libraries/message/src/common.rs
@@ -47,33 +47,49 @@ pub struct LogMessageHelper {
 impl From<LogMessageHelper> for LogMessage {
     fn from(helper: LogMessageHelper) -> Self {
         let fields = helper.fields.as_ref();
+        // Use `or_else` throughout so each fallback (a `BTreeMap` lookup plus a
+        // `String` clone, and sometimes a parse) is computed only when the
+        // typed field is absent. `or` would evaluate every fallback eagerly and
+        // discard it whenever the typed field is already `Some`.
         LogMessage {
-            build_id: helper.build_id.or(fields
-                .and_then(|f| f.get("build_id").cloned())
-                .and_then(|id| BuildId::from_display_str(&id))),
-            dataflow_id: helper.dataflow_id.or(fields
-                .and_then(|f| f.get("dataflow_id").cloned())
-                .and_then(|id| Uuid::parse_str(&id).ok())),
-            node_id: helper.node_id.or(fields
-                .and_then(|f| f.get("node_id").cloned())
-                .and_then(|id| id.parse::<NodeId>().ok())),
-            daemon_id: helper.daemon_id.or(fields
-                .and_then(|f| f.get("daemon_id").cloned())
-                .and_then(|id| DaemonId::from_display_str(&id))),
+            build_id: helper.build_id.or_else(|| {
+                fields
+                    .and_then(|f| f.get("build_id").cloned())
+                    .and_then(|id| BuildId::from_display_str(&id))
+            }),
+            dataflow_id: helper.dataflow_id.or_else(|| {
+                fields
+                    .and_then(|f| f.get("dataflow_id").cloned())
+                    .and_then(|id| Uuid::parse_str(&id).ok())
+            }),
+            node_id: helper.node_id.or_else(|| {
+                fields
+                    .and_then(|f| f.get("node_id").cloned())
+                    .and_then(|id| id.parse::<NodeId>().ok())
+            }),
+            daemon_id: helper.daemon_id.or_else(|| {
+                fields
+                    .and_then(|f| f.get("daemon_id").cloned())
+                    .and_then(|id| DaemonId::from_display_str(&id))
+            }),
             level: helper.level,
             target: helper
                 .target
-                .or(fields.and_then(|f| f.get("target").cloned())),
+                .or_else(|| fields.and_then(|f| f.get("target").cloned())),
             module_path: helper
                 .module_path
-                .or(fields.and_then(|f| f.get("module_path").cloned())),
-            file: helper.file.or(fields.and_then(|f| f.get("file").cloned())),
-            line: helper.line.or(fields
-                .and_then(|f| f.get("line").cloned())
-                .and_then(|s| s.parse().ok())),
+                .or_else(|| fields.and_then(|f| f.get("module_path").cloned())),
+            file: helper
+                .file
+                .or_else(|| fields.and_then(|f| f.get("file").cloned())),
+            line: helper.line.or_else(|| {
+                fields
+                    .and_then(|f| f.get("line").cloned())
+                    .and_then(|s| s.parse().ok())
+            }),
             message: helper
                 .message
-                .or(fields.and_then(|f| f.get("message").cloned()))
+                .or_else(|| fields.and_then(|f| f.get("message").cloned()))
                 .unwrap_or_default(),
             fields: helper.fields,
             timestamp: helper.timestamp,


### PR DESCRIPTION
## Issue

`From<LogMessageHelper> for LogMessage` (`libraries/message/src/common.rs`) recovers ~8 fields from the `fields` map when the corresponding typed field is absent, using `Option::or`:

```rust
build_id: helper.build_id.or(fields
    .and_then(|f| f.get("build_id").cloned())
    .and_then(|id| BuildId::from_display_str(&id))),
```

`Option::or(self, optb)` evaluates `optb` **eagerly**, regardless of whether `self` is `Some`. So for every field this performs a `BTreeMap` lookup plus a `String` clone (and, for `build_id`/`dataflow_id`/`node_id`/`daemon_id`/`line`, a parse) even when the typed field is already populated and the fallback result is immediately discarded. `LogMessage` construction is on the per-log-line ingestion path.

## Fix

Switch each `.or(<expr>)` to `.or_else(|| <expr>)` so the fallback is computed only when the primary is `None`. Purely mechanical — no behavior change.

## Validation

- `cargo fmt -p dora-message`
- `cargo clippy -p dora-message` — clean
- `cargo test -p dora-message` — all pass, including `build_id_recovered_from_fields_survives_display_round_trip` and `node_id_recovered_from_fields_is_validated`, which exercise the fallback-from-`fields` path and confirm it is preserved.

---

⚠️ This is a machine-generated pull request (automated Claude Code code-review run). A human should review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dnk2Xoj1R4Nr4tL2sx6rk7)_