### PR TITLE
ci(nightly): give the macOS Python dynamic-node step a realistic timeout

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1596,7 +1596,10 @@ jobs:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
-    timeout-minutes: 90
+    # Headroom for the raised `Test Python Dynamic Node example` cap below:
+    # the last green macos-latest run of this job took 64m with that step at
+    # 14m, so a step allowed to reach 40m would sit right on a 90m job cap.
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master
@@ -1678,7 +1681,16 @@ jobs:
           dora run examples/python-dataflow/dataflow.yml --uv --stop-after 10s
 
       - name: Test Python Dynamic Node example
-        timeout-minutes: 20
+        # 40, not 20: the `uv pip install` below is a second from-scratch
+        # build of the PyO3 extension (uv builds it in an isolated env, so
+        # the `Set up Python venv` build above is not reused), and on macOS
+        # that build alone dominates the step. The last green nightly before
+        # dora-rs/dora#3372 spent 14m01s here on macos-latest against the
+        # 20-minute cap -- 70% of budget -- and the next one crossed it while
+        # still on `Building dora-rs`. Linux and Windows run this in ~40s.
+        # Reusing the first build instead of redoing it would be the real
+        # fix; until then the cap has to reflect what the step actually costs.
+        timeout-minutes: 40
         shell: bash
         run: |
           dora build examples/python-dataflow/dataflow_dynamic.yml --uv


### PR DESCRIPTION
One of the two failures in #3372.

## What failed

`cli-tests-python` on **macos-latest** hit `The action 'Test Python Dynamic Node example' has timed out after 20 minutes`, with the log ending on:

```
Building dora-rs @ file:///Users/runner/work/dora/dora/apis/python/node
```

It did not hang or crash — it was still compiling when the cap expired.

## Why

Not a code regression. The 2026-08-31 nightly (run `33393182881`, `e89fd6d`) was green; 09-01 ran on `b37f8fc`. That range is 19 commits, 13 of them docs-only, and none touches the Python bindings, PyO3, or their dependencies.

The step simply has no headroom on macOS. Its `uv pip install -e apis/python/node` is a **second from-scratch build** of the PyO3 extension: uv builds in an isolated environment, so the identical install in `Set up Python venv` earlier in the same job is not reused. The reinstall exists only because `dora build --uv` pulls `dora-rs` from PyPI over the local build.

Measured on the last green nightly:

| platform | `Test Python Dynamic Node example` | cap |
|---|---|---|
| macos-latest | **14m01s** | 20m |
| ubuntu-latest | 32s | 20m |
| windows-latest | 40s | 20m |

70% of budget consumed on macOS. The next run crossed it.

## Change

- `Test Python Dynamic Node example`: `timeout-minutes` 20 → **40**
- `cli-tests-python` job: `timeout-minutes` 90 → **120**

The job bump is needed for the step bump to be reachable: that green macOS job took 64m in total with this step at 14m, so a step allowed to reach 40m would sit right on a 90m job cap. Both new values carry the measurement they came from in a comment.

## Scope

This is the cap catching up with what the step costs, not a fix for the cost. The real fix is to stop building the extension twice — a prebuilt wheel reused by both steps, or `--no-build-isolation` with maturin in the venv — which would cut ~14 minutes per platform per nightly. That needs CI iteration to land safely (maturin invocation, the Windows leg, build-isolation semantics), and I could not verify it from this environment, so I left it as a follow-up rather than pushing it blind.

## Validation

`.github/workflows/nightly.yml` parses, and the two values land where intended:

```
job timeout: 120
[('Test Python Dynamic Node example', 40)]
```

No Rust or shell changed, so the fmt/clippy/test gates are unaffected by this diff. The change itself can only be exercised by a nightly run.

Refs #3372

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLf4qxSrcugDGL4fNnVdyj)_