### PR TITLE
ci(nightly): pace the cluster-record-replay replay so its assertion holds

### DIFF
--- a/scripts/qa/ci-nightly-jobs.sh
+++ b/scripts/qa/ci-nightly-jobs.sh
@@ -1179,13 +1179,27 @@ EOF
   # `dora replay` runs a local single-daemon `dora run` from the deploy-free
   # descriptor stored in the .drec. The recorded source nodes (rust-node and
   # rust-status-node) are swapped for replay nodes; rust-sink reprocesses the
-  # replayed status strings. `--speed 0` replays as fast as possible. Invoked
-  # from the repo root so the replay-node binary resolves under target/debug;
-  # the run's working_dir is the .drec's parent ($WORK), so node logs land in
-  # $WORK/out/.
+  # replayed status strings. Invoked from the repo root so the replay-node
+  # binary resolves under target/debug; the run's working_dir is the .drec's
+  # parent ($WORK), so node logs land in $WORK/out/.
+  #
+  # Paced replay (`--speed 1`), not `--speed 0`: the validation below asserts
+  # that every recorded message reaches the sink, and only a paced replay
+  # makes that assertion sound. `dora replay` already sizes each replayed
+  # input's queue to the recorded message count under `queue_policy:
+  # backpressure` (#2144), but that only covers the node-level queue; the
+  # direct node-to-node zenoh data plane below it is declared
+  # `CongestionControl::Drop`, and an unpaced burst can lose a sample there
+  # with the sender still reporting success (see the note on
+  # `raise_replayed_input_queue_sizes` in binaries/cli/src/command/replay.rs:
+  # "Drops below this layer ... are not addressed here"). That is what made
+  # this job fail in the 2026-09-01 nightly (dora-rs/dora#3372): 99 of 100
+  # values reached the sink, the recording and the replay node both reporting
+  # a clean 100. The recording spans ~1s of 10ms ticks, so replaying it at
+  # the rate the cluster produced it costs about a second.
   echo "=== dora replay $DREC (local single-daemon run) ==="
   rm -rf "$WORK/out"
-  if ! timeout -k 30s 120s dora replay "$DREC" --speed 0; then
+  if ! timeout -k 30s 120s dora replay "$DREC" --speed 1; then
     echo "ERROR: dora replay failed or exceeded 120s"
     rm -rf "$WORK"
     return 1
@@ -1208,10 +1222,11 @@ EOF
   fi
 
   # Validate that the replayed random-value sequence exactly reproduces the
-  # committed seed(42) baseline. dora's transport delivers every recorded
-  # output (reliable, ordered), so the replayed sink must see the full
-  # baseline sequence in order -- any drop, reorder, or value change is a
-  # genuine record/replay regression, not expected noise.
+  # committed seed(42) baseline. At the paced `--speed 1` used above, dora
+  # delivers every recorded output in order, so the replayed sink must see
+  # the full baseline sequence -- any drop, reorder, or value change is a
+  # genuine record/replay regression, not expected noise. (This does not hold
+  # for an unpaced `--speed 0` replay; see the note on the replay invocation.)
   echo "=== validate replayed state against seed(42) baseline ==="
   local baseline="tests/sample-inputs/expected-outputs-rust-status-node.jsonl"
   if ! python3 - "$sink_log" "$baseline" <<'PY'; then


### PR DESCRIPTION
One of the two failures in #3372. (The other is #3375.)

## What failed

```
ERROR: replayed sequence (99 values) does not match the seed(42) baseline (100 values)
  first divergence at index 95: replayed=0x8c6aa3daf78f20fb baseline=0x97655829d71700a3
```

Checked against the committed baseline: `0x8c6aa3daf78f20fb` is `baseline[96]`. So `baseline[95]` is simply **missing** and everything after it matches in order — one message lost mid-stream, not a corruption or a reorder.

Both producers reported a clean run. The recording held 100 status entries, and the replay node logged `replayed 100 messages (0 skipped)`. The message vanished between the replay node's send and the sink's receipt, with the sender seeing success.

## Why — the job's premise, not a code regression

The 2026-08-31 nightly (run `33393182881`, `e89fd6d`) was green; 09-01 ran on `b37f8fc`. That range is 19 commits, 13 docs-only, and none touches the data plane, the record or replay node, the input scheduler, or this script.

The job replays with `--speed 0`, which disables pacing outright — `pacing_sleep_nanos` returns `0` for `speed <= 0.0` (`binaries/replay-node/src/main.rs:46`) — and then asserts byte-exact lossless delivery on the stated grounds that *"dora's transport delivers every recorded output (reliable, ordered)"*.

That is true of the node-level queue but not of the layer beneath it:

- **Input queue — covered.** `dora replay` already rewrites each input fed by a replayed node to `queue_size: <recorded count>` with `queue_policy: backpressure` (`raise_replayed_input_queue_sizes`, #2144). For this job that makes `rust-sink`'s `message` input `queue_size: 100, queue_policy: backpressure` — an effective cap of 1000. Not the drop point.
- **Zenoh data plane — not covered.** The direct node-to-node publisher is declared `CongestionControl::Drop` (`apis/rust/node/src/node/mod.rs:259`), and a congestion drop there returns `Ok` to the sender. The node API says so: *"A congestion drop reports `Ok` and stays undetectable — inherent to `CongestionControl::Drop`."* And `dora replay`'s own docs disclaim it: *"Drops below this layer (zenoh congestion on multi-daemon replay) are not addressed here."*

An unpaced burst of 100 messages into a `Drop`-configured publisher is exactly the condition that layer is documented not to survive.

## Change

`--speed 0` → `--speed 1` for the replay, plus the two comments that asserted unconditional lossless delivery now say which layer guarantees what.

The recording spans ~1s of 10ms ticks, so replaying at the rate the cluster produced it costs about a second and stays far inside the existing 120s bound. It also makes this job consistent with the plain `record-replay` job, which has always called `dora replay "$DREC"` with no `--speed` flag — i.e. the default paced 1.0. `cluster-record-replay` is the only job that passes `--speed 0`, and the only one asserting byte-exact delivery.

## Validation — reproduced

Record `examples/rust-dataflow/dataflow.yml` once (124905 bytes, 100 values), then replay the **same** recording repeatedly, counting `random value 0x…` lines in `log_rust-sink.jsonl`. Toolchain 1.97.1, Linux, 4 cores.

**`--speed 0` (current) — 3 of 5 runs lost messages:**

| run | 1 | 2 | 3 | 4 | 5 |
|---|---|---|---|---|---|
| values at sink | **88** | **63** | 100 | **99** | 100 |

**`--speed 1` (this PR) — 25 of 25 runs clean:** first batch 100/100/100/100/100, then a 20-run soak with 0/20 lost.

Run 4 of the unpaced batch is 99/100 — the exact signature of the nightly failure. Run 2 lost 37 of 100, so this is not a rare edge; it usually just loses few enough (or none) to pass unnoticed.

Two things this pins down beyond the reasoning above:

1. **The loss is in the replay leg, not the cluster leg.** This is a plain local single-daemon `dora replay` — no SSH cluster, no multi-daemon recording, no inter-daemon forwarding — and it still drops.
2. **It is not the input queue.** `dora replay` had already applied `queue_size: 100, queue_policy: backpressure` in every one of these runs. The drop is below that layer.

The cluster half could not run in my environment (it hard-requires `openssh-server` for the loopback sshd), but the replay leg is single-daemon in both this job and the plain `record-replay` job, so the reproduction covers exactly the behavior this change relies on. `bash -n` passes on the script.

## Scope

This makes *this job's* assertion sound. It does **not** make `dora replay --speed 0` lossless in general — the numbers above are a reproducible demonstration that it is not, for anyone relying on it outside CI. Whether replay should force `CongestionControl::Block` on the direct path, or `--speed 0` should warn that it is lossy, is a design call left to the maintainers rather than folded into a CI fix.

## Note, not fixed here

The doc comment describing the queue-sizing guard sits above the **wrong function** — it is attached to `replace_recorded_nodes_with_replay` (`binaries/cli/src/command/replay.rs:231`), which does no queue sizing, while `raise_replayed_input_queue_sizes` (line 338) does the work and carries no doc comment. That misattribution is what initially sent me looking at the input queue as the culprit. Left out of this PR to keep it to the failing job; happy to send it separately.

Fixes the `cluster-record-replay` half of #3372.