### PR TITLE
refactor(core): drop the two schema post-processing steps that match nothing

### DIFF
--- a/libraries/core/src/bin/generate_schema.rs
+++ b/libraries/core/src/bin/generate_schema.rs
@@ -36,23 +36,9 @@ fn descriptor_schema_json() -> String {
     //
     // 'OneOf' such as Custom Nodes, Operators and Single Operators overwrite property values of the initial struct `Nodes`.`
     // which make the original properties such as `id` and `name` not validated by IDE extensions.
-    let raw_schema = raw_schema.replace(
+    raw_schema.replace(
         "\"additionalProperties\": false",
         "\"additionalProperties\": true",
-    );
-
-    // Remove `serde(from=` nested field as they are not handled properly by `schemars`
-    let raw_schema = raw_schema.replace(
-        "\"python\": {
-              \"$ref\": \"#/definitions/PythonSource\"
-            }",
-        "",
-    );
-    raw_schema.replace(
-        "{
-            \"$ref\": \"#/definitions/Input\"
-          }",
-        "true",
     )
 }
 


### PR DESCRIPTION
Rewritten after a rebase: what this branch originally carried is on `main` already, from two directions at once.

- The staleness guard — `descriptor_schema_json()` plus `checked_in_descriptor_schema_is_current` — landed in #3389.
- The regenerated schema landed in #3361, byte-identical to the copy this branch carried.

So the guard half of this PR is redundant, and #3369 is fixed on `main` whether or not this merges. What is left is the one finding from the original description that `main` does not carry.

## The change

`descriptor_schema_json` runs three string replacements over the serialized schema. Two of them match `#/definitions/PythonSource` and `#/definitions/Input`, and schemars 1.2.2 emits draft 2020-12 — every one of the 41 `$ref`s in the committed schema is `#/$defs/`. Neither pattern has matched since that upgrade. Both `python` properties the first one meant to erase are still in the published schema, and inputs still `$ref` `Input` rather than being collapsed to `true`.

They are not worth porting to `$defs`, because the thing they worked around is fixed. Both existed because schemars mis-modelled the `serde(from = ...)` types. schemars 1.x models them correctly:

- `$defs/Input` is an `anyOf` of `InputMapping` and the options mapping — the two YAML spellings, `my_input: node/output` and `my_input: {source: ..., queue_size: ...}`.
- `$defs/PythonSource` is an `anyOf` of the string and object forms.

Porting the replacements would take that back out of a schema 1.0 freezes.

## Verification

- `cargo run -p dora-core --bin generate_schema` leaves `git diff` empty — the generated bytes are identical before and after, which is what makes this a dead-code removal rather than a schema change. `qa-breaking` therefore compares exactly the bytes it compared before.
- `cargo test -p dora-core --bin generate_schema` — 3 passed, including #3389's `checked_in_descriptor_schema_is_current` and `root_schema_matches_crate_copy`.
- `cargo fmt --all -- --check` and `cargo clippy -p dora-core --all-targets -- -D warnings` clean.

The other finding from the original description — `regenerate-schemas.yml` force-pushing itself out of the merge queue — is also fixed on `main`, by the content-hashed branch names and the never-push-to-an-open-PR check now in that workflow. Nothing left to do there.

Closes nothing on its own; #3369 is already satisfied by #3389 + #3361 and can be closed independently of this PR.
