### PR TITLE
fix(core): don't panic on an invalid operator output id during module expansion

### DIFF
--- a/libraries/core/src/descriptor/expand.rs
+++ b/libraries/core/src/descriptor/expand.rs
@@ -796,11 +796,23 @@ fn expand_module_node(
             final_nodes.extend(nested);
         } else {
             for (name, output_ref) in node_output_refs(&inner_node) {
+                // `output_ref` may be an operator-qualified `<op_id>/<output>`
+                // form, and `OperatorId` is unvalidated, so parse fallibly
+                // instead of `output_ref.into()` — `DataId::from` panics on
+                // characters outside `[a-zA-Z0-9_./-]`, which would abort
+                // expansion on an otherwise-parseable descriptor. Mirrors
+                // `prefix_output_with_operator_id` in `descriptor/mod.rs`.
+                let output: DataId = output_ref.parse().map_err(|e| {
+                    eyre::eyre!(
+                        "node `{}` produces an invalid output id `{output_ref}`: {e}",
+                        inner_node.id
+                    )
+                })?;
                 direct_output_targets.entry(name).or_default().push((
-                    format!("{}/{}", inner_node.id, output_ref),
+                    format!("{}/{output}", inner_node.id),
                     UserInputMapping {
                         source: inner_node.id.clone(),
-                        output: output_ref.into(),
+                        output,
                     },
                 ));
             }
@@ -1368,6 +1380,46 @@ nodes:
         assert_eq!(descriptor.exit_when_nodes_finish, None);
         let expanded = expand_modules(&descriptor, tmp.path()).unwrap();
         assert_eq!(expanded.exit_when_nodes_finish, None);
+    }
+
+    /// A module whose inner runtime node declares an operator with an id
+    /// containing characters outside `[a-zA-Z0-9_./-]` must surface a clean
+    /// descriptor error, not panic. `OperatorId` is unvalidated, so its id
+    /// flows verbatim into the `<op_id>/<output>` qualified output id, which
+    /// used to be built with `DataId::from` (panics) rather than a fallible
+    /// parse.
+    #[test]
+    fn expand_rejects_invalid_operator_output_id_without_panicking() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+        write_file(
+            base,
+            "bad_module.yml",
+            r#"
+module:
+  name: bad
+  outputs: [data_out]
+
+nodes:
+  - id: runtime_node
+    operators:
+      - id: "bad id"
+        shared-library: op
+        outputs:
+          - data_out
+"#,
+        );
+        let descriptor = parse_descriptor(
+            r#"
+nodes:
+  - id: my_mod
+    module: bad_module.yml
+"#,
+        );
+        let err = expand_modules(&descriptor, base)
+            .expect_err("an invalid operator output id must be a clean error, not a panic");
+        let msg = err.to_string();
+        assert!(msg.contains("invalid output id"), "unexpected error: {msg}");
     }
 
     #[test]


### PR DESCRIPTION
> ⚠️ **Machine-generated PR.** Authored by an automated Claude Code code-review run. Please review carefully before merging.

## Issue

`expand_module_node` (`libraries/core/src/descriptor/expand.rs`) built each direct child's qualified output id with `output_ref.into()`, i.e. `DataId::from(String)`, which **panics** on any character outside `[a-zA-Z0-9_./-]`.

For a runtime (`operators:`) inner node, `node_output_refs` forms the reference as `<operator_id>/<output>`, and `OperatorId` is deliberately **unvalidated** (`FromStr` is `Infallible`, `From<String>` stores verbatim). So a module whose inner operator declares an id like `"bad id"` (a space) aborts `dora build` / `dora check` on an otherwise-parseable descriptor.

This is the same footgun already guarded on the non-module path by `prefix_output_with_operator_id` in `descriptor/mod.rs`, which parses fallibly *precisely because* `DataId::from` panics.

## Fix

Parse `output_ref` fallibly with `.parse::<DataId>()` and surface a clean `eyre` descriptor error instead of panicking, mirroring `prefix_output_with_operator_id`. For valid ids the resulting map key is byte-identical to before.

## Validation

- Added a regression test (`expand_rejects_invalid_operator_output_id_without_panicking`) that builds a module whose inner operator has a space in its id; it reproduced the panic before the fix (`DataId::from` at `message/src/id.rs`) and now asserts a clean `Err`.
- `cargo test -p dora-core` (320 lib tests) green; `cargo fmt --check` and `cargo clippy -p dora-core -- -D warnings` clean (toolchain 1.97.1, matching CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124hkPzn2uwkd83cNFZxVgL

---
_Generated by [Claude Code](https://claude.ai/code/session_0124hkPzn2uwkd83cNFZxVgL)_