### PR TITLE
fix(cli): don't discard a located node binary when canonicalization fails

### DIFF
--- a/binaries/cli/src/command/node_binary.rs
+++ b/binaries/cli/src/command/node_binary.rs
@@ -83,7 +83,19 @@ fn search(binary_name: &str) -> Option<PathBuf> {
         .unwrap_or_else(|_| PathBuf::from("target"));
     for profile in ["debug", "release"] {
         if let Some(candidate) = probe_dir(&cargo_target.join(profile), binary_name) {
-            return dunce::canonicalize(candidate).ok();
+            // Fall back if canonicalization fails (e.g. a transient race against
+            // the build, or a symlink/permission edge case). The other branches
+            // above return the located path directly; discarding a binary we
+            // just found — and thereby also skipping the remaining `release`
+            // probe — would be worse. Make the fallback absolute so it still
+            // resolves like the other branches' paths even if the working
+            // directory changes before the binary is spawned (`cargo_target`
+            // may be the relative default `target/`).
+            return Some(
+                dunce::canonicalize(&candidate)
+                    .or_else(|_| std::path::absolute(&candidate))
+                    .unwrap_or(candidate),
+            );
         }
     }
 


### PR DESCRIPTION
> ⚠️ **Machine-generated PR.** Authored by an automated Claude Code code-review run. Please review carefully before merging.

## Issue

In `binaries/cli/src/command/node_binary.rs`, `search()`'s cargo-target branch returned `dunce::canonicalize(candidate).ok()`. Any canonicalization failure (a race against the in-progress build, a symlink or permission edge case) therefore **threw away a binary that was just found** and made `search()` return `None`. Because the `return` sits inside the `["debug", "release"]` loop, a failure on the `debug` candidate also skipped probing `release` entirely.

Every other branch in `search()` (next-to-exe, `PATH`) returns the located path directly.

## Fix

Fall back to the located path when canonicalization fails, and make that fallback **absolute** (via `std::path::absolute`) so it still resolves like the other branches' absolute paths even if `CARGO_TARGET_DIR` is unset (the relative default `target/`) and the working directory later changes. Canonicalization becomes best-effort normalization rather than a failure point.

## Validation

- `cargo fmt --check` and `cargo clippy -p dora-cli -- -D warnings` clean (toolchain 1.97.1); existing `probe_dir` unit test green.
- Cold path (binary lookup / auto-build), so no hot-path impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124hkPzn2uwkd83cNFZxVgL

---
_Generated by [Claude Code](https://claude.ai/code/session_0124hkPzn2uwkd83cNFZxVgL)_