### PR TITLE
fix(node-api): skip the send-side output type check for Null payloads

### DIFF
--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -1668,21 +1668,34 @@ impl DoraNode {
         actual: &arrow_schema::DataType,
         parameters: &MetadataParameters,
     ) -> NodeResult<()> {
+        // `is_output_type_mismatch` decides whether to flag; the `mode` here
+        // decides whether a flagged mismatch errors or only warns.
         if let Some((mode, checks)) = &self.runtime_type_checks
             && let Some(expected) = checks.get(output_id)
-            && !carries_pattern_correlation(parameters)
-            && actual != expected
         {
-            let msg =
-                format!("output \"{output_id}\": expected Arrow type {expected:?}, got {actual:?}");
-            match mode {
-                RuntimeTypeCheck::Error => {
-                    return Err(NodeError::Output(msg));
+            if is_output_type_mismatch(actual, expected, parameters) {
+                let msg = format!(
+                    "output \"{output_id}\": expected Arrow type {expected:?}, got {actual:?}"
+                );
+                match mode {
+                    RuntimeTypeCheck::Error => {
+                        return Err(NodeError::Output(msg));
+                    }
+                    RuntimeTypeCheck::Warn => {
+                        warn!("type mismatch: {msg}");
+                    }
+                    RuntimeTypeCheck::Off => unreachable!(),
                 }
-                RuntimeTypeCheck::Warn => {
-                    warn!("type mismatch: {msg}");
-                }
-                RuntimeTypeCheck::Off => unreachable!(),
+            } else if *actual == arrow_schema::DataType::Null
+                && *expected != arrow_schema::DataType::Null
+            {
+                // The `Null` carve-out is intentional (timer ticks, empty
+                // metadata-only sends, stream flushes), but log it so relaxing
+                // an `=error` check for this send is not entirely silent.
+                debug!(
+                    "output \"{output_id}\": skipping runtime type check for Null \
+                     payload on a typed output (expected {expected:?})"
+                );
             }
         }
         Ok(())
@@ -3253,6 +3266,36 @@ fn schema_once_eligible(
     payload_len < zero_copy_threshold && !carries_pattern_correlation(params)
 }
 
+/// Whether a send-side runtime output type check should flag this payload.
+///
+/// A message is *not* flagged when:
+/// - it carries pattern-correlation metadata (`request_id`/`goal_id`/
+///   `goal_status`): such an output is polymorphic by design and a single
+///   declared Arrow type cannot cover every reply/feedback shape
+///   (dora-rs/adora#150); or
+/// - its payload is a `Null` array (timer ticks, metadata-only sends such as
+///   `send_output(id, params, ())`, and the documented stream flush
+///   `send_output(id, seg.flush(), empty)` in `docs/patterns.md`, whose
+///   `flush`/`session_id`/`seq` metadata is not pattern-correlation).
+///
+/// The `Null` carve-out keeps the send side consistent with the receive-side
+/// first-message check in [`EventStream::note_produced_event`], which already
+/// skips `Null`. Without it, a node emitting an empty tick on a typed output
+/// would fail under `DORA_RUNTIME_TYPE_CHECK=error` even though the identical
+/// message is accepted on the consuming node.
+fn is_output_type_mismatch(
+    actual: &arrow_schema::DataType,
+    expected: &arrow_schema::DataType,
+    parameters: &MetadataParameters,
+) -> bool {
+    // Ordered cheapest-first for short-circuiting: a matching type (the common
+    // case) and a `Null` payload are single discriminant compares, so both bail
+    // before `carries_pattern_correlation`'s three `BTreeMap` lookups.
+    actual != expected
+        && *actual != arrow_schema::DataType::Null
+        && !carries_pattern_correlation(parameters)
+}
+
 /// Init Opentelemetry Tracing
 ///
 /// This requires a tokio runtime spawning this function to be functional
@@ -4044,6 +4087,97 @@ mod tests {
         assert!(
             schema_once_eligible(100, THRESHOLD, &stream),
             "small streaming chunk (stable schema) stays eligible for schema-once"
+        );
+    }
+
+    /// End-to-end through `check_output_type` (the send path's actual gate)
+    /// under `DORA_RUNTIME_TYPE_CHECK=error`: a `Null` payload on a typed output
+    /// is accepted, everything else keeps its prior behavior. This is the
+    /// user-visible contract — `send_output` calls `check_output_type`, and
+    /// before this change a `Null` payload (an empty tick, or the documented
+    /// stream flush `send_output(id, seg.flush(), empty)`) returned `Err`.
+    #[test]
+    fn check_output_type_accepts_null_payload_on_typed_output() {
+        use arrow_schema::DataType;
+
+        let (mut node, events, _rx) = test_node();
+        node.runtime_type_checks = Some((
+            RuntimeTypeCheck::Error,
+            HashMap::from([(DataId::from("out".to_string()), DataType::Float32)]),
+        ));
+        let out: DataId = "out".into();
+        let plain = MetadataParameters::default();
+
+        // Null payload on a typed output → accepted (the fix): mirrors the
+        // receive-side carve-out in `EventStream::note_produced_event`.
+        assert!(
+            node.check_output_type(&out, &DataType::Null, &plain)
+                .is_ok(),
+            "a Null payload must not be rejected under =error"
+        );
+        // Matching type → accepted.
+        assert!(
+            node.check_output_type(&out, &DataType::Float32, &plain)
+                .is_ok(),
+            "a matching type must be accepted"
+        );
+        // Genuinely wrong non-null type → still an error.
+        assert!(
+            node.check_output_type(&out, &DataType::Int64, &plain)
+                .is_err(),
+            "a mismatched non-null type must still error under =error"
+        );
+        // Pattern-correlation output stays exempt regardless of type.
+        let mut pattern = MetadataParameters::default();
+        pattern.insert(
+            dora_message::metadata::REQUEST_ID.to_string(),
+            dora_message::metadata::Parameter::String("req-1".into()),
+        );
+        assert!(
+            node.check_output_type(&out, &DataType::Int64, &pattern)
+                .is_ok(),
+            "a pattern-correlation message stays exempt from the type check"
+        );
+        // An untyped output (not in the map) is never checked.
+        assert!(
+            node.check_output_type(&"other".into(), &DataType::Int64, &plain)
+                .is_ok(),
+            "an output with no declared type must not be checked"
+        );
+
+        drop(node);
+        drop(events);
+    }
+
+    /// Unit-level coverage of the `is_output_type_mismatch` predicate itself,
+    /// including the ordering-independent cases the end-to-end test above does
+    /// not separately isolate.
+    #[test]
+    fn is_output_type_mismatch_predicate() {
+        use arrow_schema::DataType;
+        let plain = MetadataParameters::default();
+
+        assert!(
+            !is_output_type_mismatch(&DataType::Null, &DataType::Float32, &plain),
+            "a Null payload must never be flagged as a type mismatch"
+        );
+        assert!(
+            is_output_type_mismatch(&DataType::Int64, &DataType::Float32, &plain),
+            "a mismatched non-null type must be flagged"
+        );
+        assert!(
+            !is_output_type_mismatch(&DataType::Float32, &DataType::Float32, &plain),
+            "a matching type must not be flagged"
+        );
+
+        let mut pattern = MetadataParameters::default();
+        pattern.insert(
+            dora_message::metadata::REQUEST_ID.to_string(),
+            dora_message::metadata::Parameter::String("req-1".into()),
+        );
+        assert!(
+            !is_output_type_mismatch(&DataType::Int64, &DataType::Float32, &pattern),
+            "a pattern-correlation message stays exempt from the type check"
         );
     }
 


### PR DESCRIPTION
> ⚠️ **Machine-generated PR.** Authored by an automated Claude Code code-review run. Please review carefully before merging.

## Issue

The receive-side first-message type check in `EventStream::note_produced_event` deliberately skips `Null` payloads (timer ticks, empty/metadata-only messages). The send-side check in `check_output_type` (`apis/rust/node/src/node/mod.rs`) had **no such carve-out**, so the two ends of the same rule disagreed.

Under `DORA_RUNTIME_TYPE_CHECK=error`, a node emitting an empty payload on a typed output was rejected on send even though the identical message is accepted on the consuming node. This is not just a hand-written `send_output(id, params, ())` tick — it also rejects the **documented streaming flush** in `docs/patterns.md`:

```rust
// On user interruption: flush downstream queues and start a new segment.
let flush_params = seg.flush();
node.send_output("text".into(), flush_params, empty_data)?;
```

`seg.flush()` sets `flush`/`session_id`/`seq` metadata — none of which `carries_pattern_correlation` recognizes (it checks only `request_id`/`goal_id`/`goal_status`) — so before this change a documented interruption flush on a typed output errors under `=error`.

## Fix

Extract the send-side decision into a pure `is_output_type_mismatch` helper that adds the `Null` carve-out, matching the receive side. The pattern-correlation exemption (dora-rs/adora#150) is preserved. The predicate is ordered cheapest-first (a matching type or `Null` payload short-circuits before `carries_pattern_correlation`'s `BTreeMap` lookups), and a `tracing::debug!` marks the skipped-`Null` path so relaxing an `=error` check for a send isn't entirely silent.

Pairs with #3430, which fixes the same rule's false negative on the receive side (different file, no conflict).

## Validation

- `check_output_type_accepts_null_payload_on_typed_output` drives the **actual send-path gate** `check_output_type` under `=error`: Null accepted, matching type accepted, wrong non-null type still errors, pattern-correlation exempt, untyped output unchecked. Plus `is_output_type_mismatch_predicate` for the predicate itself.
- `cargo test -p dora-node-api` lib (184 passed); `cargo fmt --check` and `cargo clippy -p dora-node-api -- -D warnings` clean (toolchain 1.97.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124hkPzn2uwkd83cNFZxVgL