### PR TITLE
fix(cli): validate `dora replay --speed` instead of silently replaying at full speed

### DIFF
--- a/binaries/cli/src/command/replay.rs
+++ b/binaries/cli/src/command/replay.rs
@@ -45,7 +45,7 @@ pub struct Replay {
     replace: Vec<String>,
 
     /// Playback speed multiplier (default: 1.0, 0 = fast as possible)
-    #[clap(long, default_value = "1.0")]
+    #[clap(long, default_value = "1.0", value_parser = parse_speed)]
     speed: f64,
 
     /// Loop the recording
@@ -62,6 +62,46 @@ impl Executable for Replay {
         // Run::execute() sets up its own tracing subscriber.
         run_replay(self)
     }
+}
+
+/// Smallest positive `--speed` we accept. Below this the pacing math
+/// (`(delta as f64 / speed) as u64` nanoseconds) saturates to a sleep of many
+/// years, which is never intended; `1e-6` still permits extreme slow-motion (a
+/// 1 s recorded gap stretched to ~11.6 days), so it rejects only pathological
+/// denormal-ish values, not any plausible debugging speed.
+const MIN_SPEED: f64 = 1e-6;
+
+/// clap `value_parser` for `--speed`.
+///
+/// A bare `f64` parse accepts `-1`, `nan`, and `inf`. The pacing math
+/// (`replay-node::pacing_sleep_nanos`) treats anything `<= 0.0` as "as fast as
+/// possible", a `NaN` slips through that guard (`NaN <= 0.0` is false) only to
+/// yield `0` from the `as u64` cast, and a tiny positive value saturates that
+/// cast to a multi-year sleep — so negatives, `NaN`, and absurdly small values
+/// all silently misbehave. Validate here, at parse time, before `run_replay`
+/// opens the recording:
+///
+/// - `0` and `inf` both mean "as fast as possible"; `inf` is normalized to
+///   `0.0` rather than rejected because `dora replay` already accepts and acts
+///   on it, and `dora-cli` is inside the 1.0 stability guarantee (an
+///   overflowing literal like `1e400` parses to `inf` and lands here too).
+/// - any finite multiplier `>= MIN_SPEED` is accepted;
+/// - everything else (negative, `NaN`, `-inf`, `0 < speed < MIN_SPEED`) is a
+///   clean clap usage error that echoes what the user typed.
+fn parse_speed(s: &str) -> Result<f64, String> {
+    let speed: f64 = s
+        .parse()
+        .map_err(|e| format!("`{s}` is not a number: {e}"))?;
+    if speed == f64::INFINITY || speed == 0.0 {
+        return Ok(0.0);
+    }
+    if speed.is_finite() && speed >= MIN_SPEED {
+        return Ok(speed);
+    }
+    Err(format!(
+        "`{s}` is not a valid --speed: use 0 or `inf` for as-fast-as-possible, \
+         or a finite multiplier >= {MIN_SPEED}"
+    ))
 }
 
 fn run_replay(args: Replay) -> eyre::Result<()> {
@@ -477,6 +517,57 @@ mod tests {
             false,
         );
         serde_yaml::to_string(&descriptor).unwrap()
+    }
+
+    #[test]
+    fn parse_speed_accepts_valid_and_rejects_invalid() {
+        // Valid: 0 (as fast as possible) and any finite positive multiplier.
+        assert_eq!(parse_speed("0").unwrap(), 0.0);
+        assert_eq!(parse_speed("1.0").unwrap(), 1.0);
+        assert_eq!(parse_speed("0.25").unwrap(), 0.25);
+        assert_eq!(parse_speed("1000").unwrap(), 1000.0);
+
+        // `inf` — and an overflowing literal, which parses to `inf` — mean
+        // "as fast as possible" and normalize to 0.0 rather than erroring
+        // (`dora replay` already accepts them; dora-cli is 1.0-stable).
+        assert_eq!(parse_speed("inf").unwrap(), 0.0);
+        assert_eq!(parse_speed("1e400").unwrap(), 0.0);
+
+        // Invalid: negative, NaN, -inf, and an absurdly small value that would
+        // saturate the pacing cast to a multi-year sleep — all previously
+        // silent misbehavior — plus non-numbers.
+        assert!(parse_speed("-1").is_err());
+        assert!(parse_speed("nan").is_err());
+        assert!(parse_speed("-inf").is_err());
+        assert!(parse_speed("1e-300").is_err());
+        assert!(parse_speed("fast").is_err());
+
+        // The error echoes what the user typed, not the parsed f64.
+        let err = parse_speed("1e-300").unwrap_err();
+        assert!(err.contains("1e-300"), "error should name the input: {err}");
+    }
+
+    /// Guards that `value_parser = parse_speed` is actually wired onto the
+    /// `--speed` arg: without it these would parse as a bare `f64` and the
+    /// invalid values would slip through, so this fails if the attribute is
+    /// dropped even though `parse_speed_accepts_valid_and_rejects_invalid`
+    /// would still pass.
+    #[test]
+    fn speed_value_parser_is_wired_onto_the_arg() {
+        use clap::Parser;
+
+        #[derive(Parser)]
+        struct Cli {
+            #[command(flatten)]
+            replay: Replay,
+        }
+
+        // Rejected at parse time (use `=` so the leading `-` isn't read as a flag).
+        assert!(Cli::try_parse_from(["dora", "rec.drec", "--speed=-1"]).is_err());
+        assert!(Cli::try_parse_from(["dora", "rec.drec", "--speed=nan"]).is_err());
+        // `inf` is accepted and normalized to as-fast-as-possible (0.0).
+        let cli = Cli::try_parse_from(["dora", "rec.drec", "--speed=inf"]).unwrap();
+        assert_eq!(cli.replay.speed, 0.0);
     }
 
     #[test]


### PR DESCRIPTION
> ⚠️ **Machine-generated PR.** Authored by an automated Claude Code code-review run. Please review carefully before merging.

## Issue

`dora replay --speed` was parsed as a bare `f64`, so clap accepted `-1`, `nan`, and `inf`. In `replay-node::pacing_sleep_nanos`, anything `<= 0.0` means "as fast as possible", a `NaN` slips through that guard (`NaN <= 0.0` is false) only to yield `0` from the `as u64` cast, and a tiny positive value saturates that cast to a **multi-year sleep**. So:

- a **negative, NaN, or infinite** `--speed` silently replayed at full speed with no diagnostic;
- an **absurdly small** one (e.g. `1e-300`) hung for ~584 years;
- the CLI's `== 0.0` overflow warning was skipped for a negative value.

## Fix

Validate `--speed` with a clap `value_parser` (`parse_speed`), so problems are a clean parse-time usage error before `run_replay` opens the recording:

- **`0` and `inf` both mean "as fast as possible".** `inf` is **normalized to `0.0`, not rejected** — `dora replay` already accepts and acts on it (identically to `--speed 0`), and dora-cli is inside the 1.0 stability guarantee (`docs/api-rust.md`), so rejecting it would be a behavior break. An overflowing literal like `1e400` parses to `inf` and is normalized the same way.
- **Any finite multiplier `>= 1e-6`** is accepted (still allows extreme slow-motion without risking a pathological multi-year sleep).
- **Negative, `NaN`, `-inf`, and `0 < speed < 1e-6`** are rejected with an error that echoes what the user typed, not the parsed `f64`.

## Validation

- `parse_speed_accepts_valid_and_rejects_invalid` — accepts `0`/`1.0`/`0.25`/`1000`, normalizes `inf`/`1e400` → `0.0`, rejects `-1`/`nan`/`-inf`/`1e-300`/non-numbers, and asserts the error names the raw input.
- `speed_value_parser_is_wired_onto_the_arg` — parses through a `#[command(flatten)] Replay` so it fails if `value_parser = parse_speed` is ever dropped from the field (which a predicate-only test would not catch).
- `cargo test -p dora-cli` lib green; `cargo fmt --check` and `cargo clippy -p dora-cli -- -D warnings` clean (toolchain 1.97.1). No `cli-surface.txt` change — `value_parser` is invisible to `cli_surface.rs::describe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124hkPzn2uwkd83cNFZxVgL