### PR TITLE
fix(daemon): log instead of propagate an extension-request handler error

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -5273,14 +5273,27 @@ impl Daemon {
                 reply_sender,
             } => {
                 #[cfg(feature = "tensor-pool")]
-                self.handle_extension_request(
-                    dataflow_id,
-                    node_id,
-                    namespace,
-                    payload,
-                    reply_sender,
-                )
-                .await?;
+                if let Err(err) = self
+                    .handle_extension_request(
+                        dataflow_id,
+                        node_id,
+                        namespace,
+                        payload,
+                        reply_sender,
+                    )
+                    .await
+                {
+                    // Defensive: the handler currently always returns `Ok(())`
+                    // at function scope, so this arm is unreachable today, but
+                    // its signature is fallible. If it ever did return `Err`, a
+                    // `?` here would unwind the daemon's main loop and drop the
+                    // coordinator connection — losing every other dataflow's
+                    // connection too — and it owns the reply channel (it may
+                    // already have answered the node). Log and carry on,
+                    // matching the `ExtensionStore`/`ExtensionLoad`/
+                    // `ExtensionDrop` arms rather than diverging from them.
+                    tracing::error!("failed to handle extension request: {err:?}");
+                }
                 // The node asked for an extension this daemon was not built
                 // with. Answer explicitly so it fails loudly instead of
                 // waiting on a reply that never comes.


### PR DESCRIPTION
> ⚠️ **Machine-generated PR.** Authored by an automated Claude Code code-review run. Please review carefully before merging.

> **Note:** This is **defensive hardening, not a fix for an observed failure.** The error path being removed is unreachable today (see below). Framing softened after review feedback from @phil-opp.

## What

The `tensor-pool` arm of `DaemonNodeEvent::ExtensionRequest` (`binaries/daemon/src/lib.rs`) propagated `handle_extension_request`'s error with `?`. Every sibling extension arm (`ExtensionStore` / `ExtensionLoad` / `ExtensionDrop`) instead logs the error and continues. This aligns the `ExtensionRequest` arm with them.

## Why it's currently a latent footgun, not a live bug

`handle_extension_request` delegates to `tensor-pool::daemon::handlers::handle_pool_node_request`, which returns `Ok(())` on **every function-scope path** — the only `Err` values in that function are produced by inner closures (they return `Result<_, String>`). So the `?` never actually fires today.

It's still the wrong shape for the daemon's **main event loop**: the signature is fallible, and if a future change made the handler return `Err`, a `?` here would unwind the loop and drop the coordinator connection — taking every other running dataflow's connection with it. Logging and continuing removes that possibility before it can arise.

## Follow-up (intentionally not addressed here)

Because the error path is unreachable, this PR leaves one thing for whoever makes it reachable: the log-and-continue arm drops `reply_sender`, so a future error before the handler answers would leave the node observing a closed oneshot rather than a reply. Making that path reachable should also hand the sender back so the error arm can still reply. Noted in the commit message and code comment.

## Validation

- `cargo fmt --check` clean; `cargo clippy -p dora-daemon --features tensor-pool -- -D warnings` clean (compiles the changed path — PR-level `Clippy`/`Check` don't, since `tensor-pool` is non-default); `cargo check -p dora-daemon` (default features) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124hkPzn2uwkd83cNFZxVgL