### PR TITLE
fix(cli): parse the rotation index of legacy .txt log files

### DIFF
--- a/binaries/cli/src/command/logs.rs
+++ b/binaries/cli/src/command/logs.rs
@@ -752,9 +752,13 @@ fn find_log_files(dataflow_dir: &Path) -> Result<Vec<PathBuf>> {
 /// Extract rotation index from a log filename. Current file returns 0, `.1.jsonl` returns 1, etc.
 fn rotation_index(path: &Path) -> u32 {
     let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-    // Pattern: log_<node>.<N>.jsonl
+    // Pattern: log_<node>.<N>.<ext>, where <ext> is `jsonl` or the legacy
+    // `txt`. `find_log_files` collects both extensions, so both must be handled
+    // here or a rotated `.txt` file sorts as if it were the current file.
     if let Some(rest) = name.strip_prefix("log_")
-        && let Some(rest) = rest.strip_suffix(".jsonl")
+        && let Some(rest) = rest
+            .strip_suffix(".jsonl")
+            .or_else(|| rest.strip_suffix(".txt"))
     {
         // Check if the last segment after the last '.' is a number
         if let Some(dot_pos) = rest.rfind('.')
@@ -1289,6 +1293,15 @@ mod tests {
     #[test]
     fn rotation_index_txt_file() {
         assert_eq!(rotation_index(&PathBuf::from("log_sensor.txt")), 0);
+    }
+
+    #[test]
+    fn rotation_index_rotated_txt_file() {
+        // `find_log_files` collects rotated legacy `.txt` files too, so their
+        // index must be parsed like `.jsonl`. Before the fix this returned 0
+        // (treated as the current file) and sorted out of order.
+        assert_eq!(rotation_index(&PathBuf::from("log_sensor.1.txt")), 1);
+        assert_eq!(rotation_index(&PathBuf::from("log_sensor.3.txt")), 3);
     }
 
     // --- apply_time_filters ---


### PR DESCRIPTION
> ⚠️ **Machine-generated PR.** Authored by an automated Claude Code code-review run. Please review carefully before merging.

## Issue

In `binaries/cli/src/command/logs.rs`, `find_log_files` collects both `.jsonl` and legacy `.txt` log files and sorts them by `rotation_index` so older rotated files print before the current one. But `rotation_index` only stripped the `.jsonl` suffix, so a rotated `log_<node>.1.txt` returned `0` — indistinguishable from the current file — and sorted out of order relative to it.

Low impact (the daemon writes `.jsonl` now; `.txt` is legacy), but a real ordering bug for any dataflow with rotated `.txt` logs.

## Fix

Strip either `.jsonl` or `.txt` before parsing the numeric rotation segment, so both extensions are handled consistently with `find_log_files`.

## Validation

- Added `rotation_index_rotated_txt_file` (`log_sensor.1.txt` → 1, `log_sensor.3.txt` → 3); existing `rotation_index_*` tests still pass.
- `cargo test -p dora-cli` lib tests green; `cargo fmt --check` and `cargo clippy -p dora-cli -- -D warnings` clean (toolchain 1.97.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124hkPzn2uwkd83cNFZxVgL

---
_Generated by [Claude Code](https://claude.ai/code/session_0124hkPzn2uwkd83cNFZxVgL)_