### PR TITLE
ci: gate committed credentials, close the docker publish hole, pin actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+# Keeps the SHA-pinned GitHub Actions current.
+#
+# The third-party actions in .github/workflows/ are pinned to commit SHAs
+# with the version in a trailing comment, so a compromised upstream tag or
+# branch cannot silently change what runs in CI. That covers the ones on
+# mutable branch refs and the four holding the most privilege (release
+# publishing, `@claude`, issue labelling); vendor-owned `actions/*` and
+# `docker/*` stay on major tags. The cost of a SHA pin is that it never
+# moves on its own: without an updater it also stops receiving upstream
+# security fixes, and the `# vN` comments rot as tags are re-pointed.
+#
+# Dependabot resolves both halves — it bumps the SHA and rewrites the
+# version comment in the same PR — which is what makes SHA pinning
+# sustainable rather than a one-time snapshot.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Batch into one PR per week; action bumps are individually trivial and
+    # separate PRs would each pay a full CI run against the lean PR gate.
+    groups:
+      github-actions:
+        patterns: ["*"]
+    labels:
+      - "dependencies"

--- a/.github/workflows/cargo-release.yml
+++ b/.github/workflows/cargo-release.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: r7kamura/rust-problem-matchers@v1.5.1
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         if: runner.os == 'Linux'
         with:
           # this might remove tools that are actually needed,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
           components: rustfmt
@@ -122,7 +122,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
           components: clippy
@@ -162,7 +162,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      # Pure git, so it costs no time and genuinely goes first — before the
+      # toolchain install and cache restore, so a leaked credential fails in
+      # seconds rather than after CI has provisioned a Rust build. A
+      # committed credential cannot be walked back once pushed: the blob
+      # stays readable in history and in every fork. .gitignore already
+      # listed `.adora-token` and still did not stop it reaching the public
+      # repo, because gitignore does not apply to an import or a
+      # squash-merge of another repo's history (#2194).
+      - name: Check for committed credential files
+        run: make qa-secret-files
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - name: Pin toolchain set for a stable rust-cache key (see header)
@@ -230,7 +240,7 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - name: Pin toolchain set for a stable rust-cache key (see header)
@@ -389,7 +399,7 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - name: Pin toolchain set for a stable rust-cache key (see header)
@@ -540,7 +550,7 @@ jobs:
       MATURIN_PEP517_ARGS: "--profile dev"
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - name: Pin toolchain set for a stable rust-cache key (see header)
@@ -654,7 +664,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - name: Pin toolchain set for a stable rust-cache key (see header)
@@ -730,7 +740,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: crate-ci/typos@master
+      - uses: crate-ci/typos@d43b6c087ac471e2ea7b8af622ff15f05c0c365b # v1.50.1
 
   # ===== Fast supply-chain gates =====
   # Only the cheap, deterministic QA gates run remotely. The deeper
@@ -743,7 +753,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: taiki-e/install-action@v2
@@ -777,7 +787,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - name: Pin toolchain set for a stable rust-cache key (see header)

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -32,6 +32,6 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@8251c103ac8c1d761882c86aba1412c7f583c844 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -19,11 +19,41 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # Only the publish step below needs this, and it is gated to `push`.
+      # `permissions:` accepts no expressions, so the scope cannot be
+      # narrowed per event from here — genuinely withholding it on PR runs
+      # means splitting publish into its own job, which is only coherent
+      # once the build is fixed (see the FIXME below).
       packages: write
+    env:
+      IMAGE: ghcr.io/dora-rs/dora-slim:latest
     steps:
       - uses: actions/checkout@v6
 
+      # Registry credentials and the publish step are gated on `push`, i.e.
+      # a merge to main. This job also runs on `pull_request`, where the
+      # point is to prove the Dockerfile still builds -- not to publish it.
+      #
+      # Without the gate, a PR touching `docker/**` would overwrite the
+      # public `:latest` tag with its own unreviewed Dockerfile. Fork PRs
+      # could not (GitHub downgrades GITHUB_TOKEN to read-only there
+      # regardless of the `permissions:` block above), but PRs from branches
+      # in this repo -- how most work here lands -- carry the real write
+      # token. The hole was latent rather than exploited: the build step has
+      # failed on every run since at least 2026-03, so the push was never
+      # reached.
+      #
+      # FIXME: that failure is `Multi-platform build is not supported for
+      # the docker driver` -- plain `docker build` cannot do the four
+      # platforms this asks for. The fix is `docker/setup-buildx-action` +
+      # `docker/build-push-action` with `push: ${{ github.event_name ==
+      # 'push' }}`, which also makes the multi-arch manifest publishable at
+      # all (a buildx multi-platform build cannot be `--load`ed locally, so
+      # the build/push split below could not work even once buildx is set
+      # up). Deliberately left for a separate change: this one closes the
+      # publish hole without touching what the workflow builds.
       - name: "Login to GitHub Container Registry"
+        if: github.event_name == 'push'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -31,6 +61,8 @@ jobs:
           password: ${{secrets.GITHUB_TOKEN}}
 
       - name: Build the Docker image
-        run: |
-          docker build docker/slim --platform linux/amd64,linux/arm64,linux/arm32v6,linux/arm32v7 -t multi-platform --tag ghcr.io/dora-rs/dora-slim:latest
-          docker push ghcr.io/dora-rs/dora-slim:latest
+        run: docker build docker/slim --platform linux/amd64,linux/arm64,linux/arm32v6,linux/arm32v7 -t multi-platform --tag "$IMAGE"
+
+      - name: Push the Docker image
+        if: github.event_name == 'push'
+        run: docker push "$IMAGE"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: github/issue-labeler@v3.1 #May not be the latest version
+      - uses: github/issue-labeler@e24a3eb6b2e28c8904d086302a2b760647f5f45c # v3.1 (not the latest; pinned to preserve current behavior)
         with:
           repo-token: "${{ github.token }}"
           configuration-path: .github/labeler.yml

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -80,7 +80,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
@@ -127,7 +127,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
@@ -148,7 +148,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
@@ -207,7 +207,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
@@ -229,7 +229,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
@@ -275,7 +275,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
@@ -346,7 +346,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
@@ -417,7 +417,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
@@ -507,7 +507,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
@@ -549,7 +549,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
@@ -598,7 +598,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
@@ -832,7 +832,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
@@ -886,7 +886,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
@@ -985,7 +985,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
@@ -1074,7 +1074,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
@@ -1101,7 +1101,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
@@ -1184,7 +1184,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
@@ -1211,7 +1211,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
@@ -1334,14 +1334,14 @@ jobs:
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: false
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         if: runner.os == 'Linux'
         with:
           tool-cache: true
@@ -1445,14 +1445,14 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: false
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         if: runner.os == 'Linux'
         with:
           tool-cache: true
@@ -1602,14 +1602,14 @@ jobs:
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: false
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         if: runner.os == 'Linux'
         with:
           tool-cache: true
@@ -1808,7 +1808,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
@@ -1869,7 +1869,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
           targets: ${{ matrix.target }}
@@ -1917,14 +1917,14 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: false
       - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: false
           android: true
@@ -1979,7 +1979,7 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       # `ros2-zenoh-interop.sh` builds the ROS2 bridge wheel with maturin
@@ -2007,7 +2007,7 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: actions/setup-python@v6
@@ -2031,7 +2031,7 @@ jobs:
     # (PR-CI gate removed; runs independently in nightly)
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       # PyO3's abi3-py311 floor still needs a real interpreter when checking

--- a/.github/workflows/publish-c-cpp-libraries.yml
+++ b/.github/workflows/publish-c-cpp-libraries.yml
@@ -41,8 +41,11 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        # SHA-pinned like the rest. The v1 tree makes `toolchain` a required
+        # input (the @stable *branch* defaulted it), hence naming it here.
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
+          toolchain: stable
           targets: ${{ matrix.target }}
 
       - name: Reuse Rust cache from main branch (read-only)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
@@ -172,7 +172,7 @@ jobs:
           - { target: x86_64-pc-windows-msvc,    runner: windows-2022 }
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ env.RUST_VERSION }}
           targets: ${{ matrix.target }}
@@ -233,12 +233,12 @@ jobs:
           cp install.sh release-assets/dora-cli-installer.sh
           cp install.ps1 release-assets/dora-cli-installer.ps1
       - name: Generate changelog
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@3d96a18cc4ec17e9dc69ddcc424ccafaf1f78ce2 # v4.9.0
         id: cliff
         with:
           config: cliff.toml
           args: --latest --strip header
-      - uses: softprops/action-gh-release@v3
+      - uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           tag_name: ${{ github.ref_name }}
           body: ${{ steps.cliff.outputs.content }}

--- a/.github/workflows/test-c-cpp-libraries.yml
+++ b/.github/workflows/test-c-cpp-libraries.yml
@@ -199,8 +199,11 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        # SHA-pinned like the rest. The v1 tree makes `toolchain` a required
+        # input (the @stable *branch* defaulted it), hence naming it here.
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
+          toolchain: stable
           targets: ${{ matrix.target }}
 
       - name: Cache cargo target

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,7 @@ make qa-test-python
 # cargo test -p <crate-name>
 ```
 
-**Shortcut**: `make qa-fast` runs fmt + clippy + supply-chain audit + unwrap budget + typos + publish-graph in ~30 seconds. Use it as a sanity check before every commit. Then run the full `cargo test` above before `git push`.
+**Shortcut**: `make qa-fast` runs fmt + clippy + supply-chain audit + unwrap budget + secret-files + typos + publish-graph in ~30 seconds. Use it as a sanity check before every commit. Then run the full `cargo test` above before `git push`.
 
 If you add new example dataflows, also run `./scripts/smoke-all.sh --rust-only` to verify smoke tests pass.
 
@@ -195,6 +195,7 @@ The deeper QA gates — `make qa-full`, `make qa-deep`, `make qa-nightly`, `make
 - Typo checking via `crate-ci/typos` (config: `_typos.toml`)
 - Supply-chain audit (`cargo-audit` + `cargo-deny`)
 - Unwrap-budget check (production `.unwrap()` / `.expect(` ratchet)
+- Committed-credential check (`make qa-secret-files`, a step in the `Check` job): fails if git tracks a file whose name says it holds a secret. .gitignore is not enough on its own — it does not apply to files arriving through an import or a squash-merge of another repo's history, which is how `.adora-token` reached the public repo (#2194)
 - crates.io publish-graph check (`make qa-publish-graph`, a step in the `Check` job): no published crate may depend on a `publish = false` one, and the ordered publish lists in `release.yml` / `cargo-release.yml` must agree and list every dependency before its dependents (#3304)
 - License check (`cargo-lichking`)
 - Rust toolchain pinned to 1.97.1 (see `.github/workflows/ci.yml`)

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@
 
 .PHONY: qa qa-fast qa-full qa-deep qa-tier1 qa-nightly qa-release-gate qa-mutation-audit \
         qa-examples qa-cluster-e2e qa-cluster-record-replay ros2-zenoh-humble ros2-zenoh-kilted \
-        qa-fmt qa-audit qa-unwrap qa-publish-graph qa-clippy qa-test qa-test-python \
+        qa-fmt qa-audit qa-unwrap qa-secret-files qa-publish-graph qa-clippy qa-test qa-test-python \
         qa-test-python-node qa-coverage qa-mutants qa-semver \
         qa-adversarial qa-kani qa-pgo qa-install qa-pgo-install qa-kani-install \
         qa-verify-release
@@ -130,6 +130,12 @@ qa-audit:
 
 qa-unwrap:
 	@scripts/qa/unwrap-budget.sh
+
+# Credential-file gate (#2194): fail if git tracks a file whose name says
+# it holds a secret. .gitignore did not stop `.adora-token` reaching the
+# public repo, because it only covers files git is not already tracking.
+qa-secret-files:
+	@scripts/qa/secret-files.sh
 
 # Manifest-only crates.io publish-graph gate (#3304): no published crate
 # may depend on a `publish = false` one, and release.yml /

--- a/README.md
+++ b/README.md
@@ -625,7 +625,7 @@ Dora ships with a three-tier QA system designed for AI-authored code. Everything
 
 ```bash
 make qa-install        # one-time: install cargo-audit, cargo-deny, cargo-llvm-cov, cargo-mutants, cargo-semver-checks
-make qa-fast           # ~15s    -- fmt + clippy + audit + unwrap-budget + typos (pre-commit)
+make qa-fast           # ~15s    -- fmt + clippy + audit + unwrap-budget + secret-files + typos + publish-graph (pre-commit)
 make qa-full           # ~5-10m  -- qa-fast + tests + coverage (pre-push)
 make qa-deep           # ~15m    -- qa-full + mutation testing + semver (target Tier 1 gate, stronger than today's CI; alias: qa-tier1)
 make qa-nightly        # ~3-4h -- qa-deep + proptest@1000 + miri + example-smoke + ci-nightly-jobs (full parity with .github/workflows/nightly.yml)

--- a/docs/agentic-qa-policy.md
+++ b/docs/agentic-qa-policy.md
@@ -64,7 +64,7 @@ impact. Current list (update when a new subsystem earns it):
 
 ### Class A — Low-risk
 
-- [ ] `make qa-fast` (fmt + clippy + audit + unwrap-budget + typos + publish-graph).
+- [ ] `make qa-fast` (fmt + clippy + audit + unwrap-budget + secret-files + typos + publish-graph).
 
 That's the whole bar. Don't over-test cosmetic changes — reviewers can
 eyeball them and CI backs it up. `typos` is now part of `qa-fast`

--- a/docs/contributor-qa-cheatsheet.md
+++ b/docs/contributor-qa-cheatsheet.md
@@ -66,6 +66,7 @@ Runs:
 - `cargo clippy --all -- -D warnings` with Python crates excluded
 - supply-chain audit
 - unwrap-budget check
+- committed-credential check
 - typo check
 - crates.io publish-graph check
 

--- a/docs/qa-runbook.md
+++ b/docs/qa-runbook.md
@@ -51,7 +51,7 @@ rustup component add miri --toolchain nightly   # optional; for unsafe-code anal
 
 | Target | Runs | Budget | When to use |
 |---|---|---|---|
-| `make qa-fast` | fmt + clippy + audit + unwrap-budget + typos + publish-graph | ~15 s | Pre-commit |
+| `make qa-fast` | fmt + clippy + audit + unwrap-budget + secret-files + typos + publish-graph | ~15 s | Pre-commit |
 | `make qa-full` | `qa-fast` + full test suite + coverage | ~5-10 min | Pre-push |
 | `make qa-deep` | `qa-full` + mutation testing on diff + semver | ~15 min | Target Tier 1 local gate (stronger than today's CI: adds coverage, adversarial, mutants, semver) |
 | `make qa-tier1` | alias for `qa-deep` | — | Back-compat; prefer `qa-deep` |
@@ -148,7 +148,19 @@ Compare against `git diff` to see which ones are yours.
 
 Note: the budget ratchet is intentionally asymmetric. You can reduce the number freely; any increase needs justification.
 
-### 3.5 `publish-graph` failed
+### 3.5 `secret-files` failed
+
+**Cause**: git is tracking a file that either matches a `.gitignore` rule or carries a name that claims to hold a credential.
+
+**If it is a real credential**: deleting the file is not the fix. The value stays readable in history (`git show <commit>^:<path>`) and in every clone and fork that already pulled — which is why `.adora-token` (#2194) needed rotation, not just removal. Rotate the credential first, then remove the file.
+
+**If it is a fixture or a template**: rename it so the name no longer claims to be live — `.env.example`, `test-key.pem.template`. The gate anchors its patterns at the end of the name, so those suffixed forms pass.
+
+**If the `.gitignore` half is what flagged it**: a tracked file matching an ignore rule is worth a human look even when it holds no secret. It means the file was force-added or arrived through an import that bypassed the ignore rules — exactly how `.adora-token` got in.
+
+Reproduce locally with `make qa-secret-files`; the rationale is documented at the top of [`scripts/qa/secret-files.sh`](../scripts/qa/secret-files.sh).
+
+### 3.6 `publish-graph` failed
 
 **Cause**: a change to the publish graph that `cargo publish` would reject — but only at release time, once crates.io already holds whatever the release uploaded before the failure. The gate reports one of three things.
 
@@ -160,7 +172,7 @@ Note: the budget ratchet is intentionally asymmetric. You can reduce the number 
 
 Reproduce locally with `make qa-publish-graph`; the rules and what each protects are documented at the top of [`scripts/qa/publish-graph.sh`](../scripts/qa/publish-graph.sh).
 
-### 3.6 `test` failed
+### 3.7 `test` failed
 
 **Cause**: you broke a test.
 
@@ -172,7 +184,7 @@ cargo test -p <crate> <test_name> -- --nocapture
 
 If the test was wrong and the code is right, fix the test. If the code was wrong, fix the code. Don't fix the test to match broken code.
 
-### 3.7 `coverage` (soft) flagged
+### 3.8 `coverage` (soft) flagged
 
 **Cause**: the diff coverage gate (if running on a PR) found less than 70% of your new/changed lines are covered by tests.
 
@@ -183,7 +195,7 @@ make qa-coverage
 open target/llvm-cov/html/index.html   # if you also run `cargo llvm-cov --html`
 ```
 
-### 3.8 `mutation` escaped
+### 3.9 `mutation` escaped
 
 **Cause**: `cargo-mutants` found a mutation that no test detected — meaning your tests are incomplete for the mutated code path.
 
@@ -204,7 +216,7 @@ Construct an input where the mutated version produces a different output from th
 
 **Do not** waive mutations just to make the gate pass. The point of the gate is to surface weak tests.
 
-### 3.9 `semver` (soft) flagged
+### 3.10 `semver` (soft) flagged
 
 **Cause**: `cargo-semver-checks` found a breaking change in a publishable crate's public API since the last tag.
 

--- a/scripts/qa/all.sh
+++ b/scripts/qa/all.sh
@@ -6,7 +6,7 @@
 #
 # Modes (increasing thoroughness):
 #   --fast            ~1 min     pre-commit sanity (fmt, clippy, audit, unwrap,
-#                                typos, publish-graph)
+#                                secret-files, typos, publish-graph)
 #   --full            ~5-10 min  pre-push (fast + tests + coverage + optional adversarial)
 #   --deep            ~15 min    target Tier 1 gate, stronger than today's CI
 #                                (full + mutants on diff + semver; see strategy doc §5 for why the
@@ -106,8 +106,9 @@ Will run:
   2. clippy         -- cargo clippy --all -- -D warnings (excluding Python)
   3. audit          -- cargo-audit + cargo-deny on the dependency tree
   4. unwrap-budget  -- count production .unwrap() / .expect( regressions
-  5. typos          -- spell-check against _typos.toml allowlist
-  6. publish-graph  -- crates.io publish order / no unpublished deps
+  5. secret-files   -- no credential-shaped filenames tracked by git
+  6. typos          -- spell-check against _typos.toml allowlist
+  7. publish-graph  -- crates.io publish order / no unpublished deps
 ============================================================
 EOF
       ;;
@@ -117,11 +118,11 @@ EOF
 ============================================================
 $header
 Will run:
-  1-6. everything from qa-fast                  (fmt/clippy/audit/unwrap/typos/
-                                                 publish-graph)
-  7.   test         -- cargo test --all         (workspace test suite)
-  8.   coverage     -- cargo llvm-cov           (writes lcov.info)
-  9.   adversarial  -- codex/claude review      (optional; skipped if unavailable)
+  1-7. everything from qa-fast                  (fmt/clippy/audit/unwrap/
+                                                 secret-files/typos/publish-graph)
+  8.   test         -- cargo test --all         (workspace test suite)
+  9.   coverage     -- cargo llvm-cov           (writes lcov.info)
+  10.  adversarial  -- codex/claude review      (optional; skipped if unavailable)
 ============================================================
 EOF
       ;;
@@ -131,19 +132,20 @@ EOF
 ============================================================
 $header
 Today's CI PR gate only runs a subset of this: fmt, clippy, typos,
-audit, unwrap-budget, publish-graph, and the workspace test suite.
+audit, unwrap-budget, secret-files, publish-graph, and the workspace
+test suite.
 qa-deep adds the planned Tier 1 extras (see
 docs/plan-agentic-qa-strategy.md §5) that are kept laptop-only today
 because they're too slow for every PR: coverage, adversarial review,
 diff-scoped mutation testing, semver.
 
 Will run:
-  1-5.  everything from qa-fast                 (in CI today)
-  6.    test         -- cargo test --all        (in CI today)
-  7.    coverage     -- cargo llvm-cov          (NOT in CI; laptop-only)
-  8.    adversarial  -- codex/claude review     (NOT in CI; skipped w/o tools)
-  9.    mutants      -- cargo-mutants on diff   (NOT in CI; laptop-only)
-  10.   semver       -- cargo-semver-checks     (NOT in CI; pre-release only)
+  1-7.  everything from qa-fast                 (in CI today)
+  8.    test         -- cargo test --all        (in CI today)
+  9.    coverage     -- cargo llvm-cov          (NOT in CI; laptop-only)
+  10.   adversarial  -- codex/claude review     (NOT in CI; skipped w/o tools)
+  11.   mutants      -- cargo-mutants on diff   (NOT in CI; laptop-only)
+  12.   semver       -- cargo-semver-checks     (NOT in CI; pre-release only)
 ============================================================
 EOF
       ;;
@@ -153,13 +155,13 @@ EOF
 ============================================================
 $header
 For overnight runs on a powerful machine. Will run:
-  1-5.  everything from qa-fast
-  6-8.  everything from qa-full                 (test, coverage, adversarial)
-  9.    mutants (diff-scoped)                   -- same as qa-deep
-  10.   semver                                  -- cargo-semver-checks vs last tag
-  11.   proptest @ 1000 cases per property      (vs 50 cases in Tier 1)
-  12.   miri                                    -- undefined-behavior check (SKIP if cargo +nightly miri missing)
-  13.   example-smoke                           -- tests/example-smoke.rs (52 tests;
+  1-7.  everything from qa-fast
+  8-10. everything from qa-full                 (test, coverage, adversarial)
+  11.   mutants (diff-scoped)                   -- same as qa-deep
+  12.   semver                                  -- cargo-semver-checks vs last tag
+  13.   proptest @ 1000 cases per property      (vs 50 cases in Tier 1)
+  14.   miri                                    -- undefined-behavior check (SKIP if cargo +nightly miri missing)
+  15.   example-smoke                           -- tests/example-smoke.rs (52 tests;
                                                    covers GHA smoke-suite + log-sinks
                                                    + service-action + streaming).
                                                    Runs inside a scratch uv venv that
@@ -167,14 +169,14 @@ For overnight runs on a powerful machine. Will run:
                                                    matching the GHA Python setup exactly
                                                    (so workspace Python bindings are used,
                                                    NOT PyPI). Requires uv.
-  14.   hub-smoke                              -- tests/hub-smoke.rs -- the Hub
+  16.   hub-smoke                              -- tests/hub-smoke.rs -- the Hub
                                                    e2e (publish / build / run /
                                                    yank / outdated / --hub-override
                                                    / binary / identity). Hermetic
                                                    (local git fixture, no network),
                                                    Rust-only -- no venv. Runs
                                                    regardless of the uv/3.12 setup.
-  15.   ci-nightly-jobs                         -- scripts/qa/ci-nightly-jobs.sh
+  17.   ci-nightly-jobs                         -- scripts/qa/ci-nightly-jobs.sh
                                                    Platform-aware: runs the subset of GHA
                                                    nightly jobs that applies to the dev's OS.
                                                    Covers record-replay, cluster-smoke,
@@ -242,10 +244,10 @@ EOF
 ============================================================
 $header
 The automatable parts of the Tier 3 release gate. Will run:
-  1-5.   everything from qa-fast
-  6-8.   everything from qa-full                 (test, coverage, adversarial)
-  9.     mutants (diff-scoped)
-  10.    semver
+  1-7.   everything from qa-fast
+  8-10.  everything from qa-full                 (test, coverage, adversarial)
+  11.    mutants (diff-scoped)
+  12.    semver
 Non-automatable Tier 3 gates (external security audit, 7-day dogfood
 campaign, migration validation on external repos) are human-gated --
 see docs/plan-agentic-qa-strategy.md §7.
@@ -266,6 +268,7 @@ run "clippy"        cargo clippy --all \
                       -- -D warnings
 run "audit"         scripts/qa/audit.sh
 run "unwrap-budget" scripts/qa/unwrap-budget.sh
+run "secret-files"  scripts/qa/secret-files.sh
 run "typos"         scripts/qa/typos.sh
 run "publish-graph" scripts/qa/publish-graph.sh
 

--- a/scripts/qa/secret-files.sh
+++ b/scripts/qa/secret-files.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# scripts/qa/secret-files.sh — credential-file gate (#2194)
+#
+# Two checks over what git actually tracks, reported separately because
+# they mean different things and need different fixes.
+#
+# Why this is a gate and not just a .gitignore rule: it already was a
+# .gitignore rule, and that did not help. `.adora-token` — a real 64-hex
+# coordinator bearer token — reached the public repo during the v1.0
+# consolidation squash-merge (#2194) and was removed in #2225. .gitignore
+# only suppresses files git is not already tracking, so anything arriving
+# through an import, a squash of another repo's history, or a deliberate
+# `git add -f` walks straight past it. What ships is the tree, so the tree
+# is what this checks.
+#
+# Scope: filenames only. This is a fast, zero-false-positive backstop for
+# the mistake that actually happened here, not a content scanner — a
+# credential pasted into a .rs or .md file sails past it. The deeper
+# control is GitHub's secret-scanning push protection, which is
+# server-side, content-based, and blocks before the blob ever lands.
+# Enable that too; it is a repo setting, not something expressible here.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+status=0
+
+# --- Check 1: tracked despite being ignored ---------------------------
+# Treats .gitignore as the source of truth instead of restating it, so a
+# token name added there is covered here for free. This is the exact
+# shape of the #2194 failure: `.adora-token` was listed in .gitignore and
+# tracked anyway. Not a credential finding on its own — .gitignore is
+# mostly broad content rules (`*.png`, `examples/**/*.txt`) — so it gets
+# its own wording rather than credential-rotation advice.
+tracked_but_ignored="$(git ls-files -c -i --exclude-standard)"
+
+if [ -n "$tracked_but_ignored" ]; then
+  echo "error: git tracks files that .gitignore says to ignore:" >&2
+  echo "$tracked_but_ignored" | sed 's/^/  /' >&2
+  cat >&2 <<'EOF'
+
+A tracked file matching an ignore rule was force-added, or arrived through
+an import that bypassed the ignore rules. Either untrack it
+(`git rm --cached <path>`) or, if it belongs in the repo, add a negation
+(`!<path>`) to .gitignore so the rules say what is actually true.
+
+If it turns out to hold a credential, see the rotation note below.
+EOF
+  status=1
+fi
+
+# --- Check 2: credential-shaped filenames -----------------------------
+# Names .gitignore does not happen to carry. Anchored at the end so safe
+# neighbours stay allowed: `.env.example`, `id_ed25519.pub`,
+# `config.pem.template`.
+PATTERN='(^|/)('
+PATTERN+='\.env|\.env\.(local|dev|development|test|staging|prod|production)'
+PATTERN+='|\.dora-token|\.adora-token'
+PATTERN+='|\.netrc|\.npmrc|\.pypirc|credentials'
+PATTERN+='|id_(rsa|dsa|ecdsa|ed25519)'
+PATTERN+=')$|\.(pem|key|p12|pfx|jks|keystore)$'
+
+credential_shaped="$(git ls-files | grep -iE "$PATTERN" || true)"
+
+if [ -n "$credential_shaped" ]; then
+  echo "error: git is tracking credential-shaped files:" >&2
+  echo "$credential_shaped" | sed 's/^/  /' >&2
+  cat >&2 <<'EOF'
+
+If one of these is a real credential, removing it from the tree is not
+enough — the value stays readable in history (`git show <commit>^:<path>`)
+and in every clone and fork that already pulled. Rotate it first, then
+remove the file.
+
+If it is a fixture or a template, rename it so the name does not claim to
+be a live credential (`.env.example`, `test-key.pem.template`, ...).
+EOF
+  status=1
+fi
+
+if [ "$status" -eq 0 ]; then
+  echo "secret-files: OK (no credential-shaped or wrongly-tracked files)"
+fi
+
+exit "$status"


### PR DESCRIPTION
Three findings from a repo-wide security sweep. Nothing malicious turned up — the dependency graph is clean (955 crates, zero non-crates.io sources, no `[patch]` overrides), the install scripts and auth code are sound, and no secrets are in tracked files. These are the gaps worth closing.

**A committed credential is still readable in history.** `.adora-token` — a real 64-hex coordinator bearer token — reached the public repo in the v1.0 consolidation squash-merge and was removed from the tree in #2225. That does not un-leak it: `git show 119521741^:.adora-token` still prints the value today, as does any clone or fork that already pulled. `.gitignore` listed the name and did not stop it, because gitignore only suppresses files git is not already tracking — anything arriving through an import or a squash of another repo's history walks straight past it. `scripts/qa/secret-files.sh` checks the tree instead, in two parts reported separately so they get the right remediation: files tracked despite git's own ignore rules (the exact shape of that failure, and worth a look even when the file is a stray screenshot), and credential-shaped filenames `.gitignore` does not happen to carry. It runs as the first step of `Check` — pure git, ahead of the toolchain install, so a leak fails in seconds rather than after CI provisions a Rust build — and in `make qa-fast`. **Rotating the token itself is still a human action and is not done here.**

**`docker-image.yml` could publish from an unreviewed PR.** It ran on `pull_request` with `packages: write` and pushed `ghcr.io/dora-rs/dora-slim:latest` unconditionally. Fork PRs could not reach it — GitHub downgrades `GITHUB_TOKEN` to read-only there regardless of the declared permissions — but a PR from a branch in this repo carries the real write token, so an unreviewed Dockerfile could overwrite the public tag. Login and push are now gated on `push`; the build still runs on PRs, which is the part with review value. Worth stating plainly: the hole was latent, not exploited. That build step has failed on *every* run since at least 2026-03 with `Multi-platform build is not supported for the docker driver`, so the push was never reached. Repairing that is deliberately left out of this PR — it changes what the workflow builds — but there is a `FIXME` recording the buildx fix and why the build/push split cannot survive it unchanged.

**Actions on mutable refs are pinned by commit SHA**, with the version in a trailing comment. That covers the three on branches (`crate-ci/typos@master`, `dtolnay/rust-toolchain@master`, `jlumbroso/free-disk-space@main`) and the four carrying the most privilege, which were on floating major tags: `action-gh-release` and `git-cliff-action` (release publishing, `contents: write` + `id-token: write`), `claude-code-action` (`@claude`), and `issue-labeler`. The two `dtolnay/rust-toolchain@stable` uses also gain an explicit `toolchain: stable` — the `@stable` *branch* ships an `action.yml` that defaults that input, while the pinned `v1` tree marks it `required: true` and hard-fails when empty, so a bare SHA pin would have broken both C/C++ workflows. Vendor-owned `actions/*` and `docker/*` stay on major tags; that is a deliberate line, not an oversight. `.github/dependabot.yml` keeps the pins moving — a SHA pin with no updater also stops receiving upstream security fixes and lets the `# vN` comments rot.

Every pinned SHA was verified to resolve to a real action upstream at the tag it claims, and each pin preserves the version already in use (`issue-labeler` stays on v3.1 rather than jumping to the current v3.5). All 17 workflows and `dependabot.yml` parse; no mutable action refs remain; all 40 `rust-toolchain` uses carry an explicit `toolchain`. The new gate was tested red/green on four cases, including a force-added `.adora-token` (the historical failure), a `.pem`, `.env.production`, and `.env.example` correctly passing.

No Rust changed, so the compile and test gates are not implicated. `typos` and `ripgrep` are not installed in the review container, so those two gates were not run locally; CI covers both.
