### PR TITLE
refactor(message)!: make the descriptor structs non-exhaustive before 1.0

### DIFF
--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -1087,14 +1087,7 @@ impl DoraNode {
             node_id: "test-node"
                 .parse()
                 .map_err(|e| NodeError::Init(format!("{e}")))?,
-            run_config: NodeRunConfig {
-                inputs: Default::default(),
-                outputs: Default::default(),
-                output_types: Default::default(),
-                output_framing: Default::default(),
-                input_types: Default::default(),
-                shared_memory_pool_size: None,
-            },
+            run_config: NodeRunConfig::default(),
             daemon_communication: Some(DaemonCommunication::Interactive),
             dataflow_descriptor: serde_yaml::Value::Null,
             dynamic: false,
@@ -1124,14 +1117,7 @@ impl DoraNode {
             node_id: "test-node"
                 .parse()
                 .map_err(|e| NodeError::Init(format!("{e}")))?,
-            run_config: NodeRunConfig {
-                inputs: Default::default(),
-                outputs: Default::default(),
-                output_types: Default::default(),
-                output_framing: Default::default(),
-                input_types: Default::default(),
-                shared_memory_pool_size: None,
-            },
+            run_config: NodeRunConfig::default(),
             daemon_communication: None,
             dataflow_descriptor: serde_yaml::Value::Null,
             dynamic: false,

--- a/binaries/cli/src/common.rs
+++ b/binaries/cli/src/common.rs
@@ -406,12 +406,11 @@ mod tests {
     }
 
     fn deploy_with(machine: Option<&str>) -> Deploy {
-        Deploy {
-            machine: machine.map(str::to_owned),
-            working_dir: None,
-            labels: Default::default(),
-            distribute: Default::default(),
-        }
+        // `Deploy` is `#[non_exhaustive]`, so neither a struct literal nor
+        // functional-update syntax is available here.
+        let mut deploy = Deploy::default();
+        deploy.machine = machine.map(str::to_owned);
+        deploy
     }
 
     #[test]

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -4741,16 +4741,10 @@ fn resolve_single_node(
     node: Node,
     running_descriptor: &Descriptor,
 ) -> eyre::Result<(NodeId, ResolvedNode)> {
-    let tmp_desc = Descriptor {
-        nodes: vec![node],
-        deploy: None,
-        debug: Default::default(),
-        health_check_interval: None,
-        strict_types: None,
-        type_rules: Vec::new(),
-        env: running_descriptor.env.clone(),
-        exit_when_nodes_finish: None,
-    };
+    // Only `env` is carried over from the running dataflow — the rest stay at
+    // `Descriptor::new`'s defaults, as before.
+    let mut tmp_desc = Descriptor::new(vec![node]);
+    tmp_desc.env = running_descriptor.env.clone();
     dora_core::descriptor::resolve_aliases_and_set_defaults_in_topology(
         &tmp_desc,
         &running_descriptor.nodes,

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -7636,14 +7636,16 @@ trait CoreNodeKindExt {
 impl CoreNodeKindExt for CoreNodeKind {
     fn run_config(&self) -> NodeRunConfig {
         match self {
-            CoreNodeKind::Runtime(n) => NodeRunConfig {
-                inputs: runtime_node_inputs(n),
-                outputs: runtime_node_outputs(n),
-                output_types: BTreeMap::new(),
-                output_framing: BTreeMap::new(),
-                input_types: BTreeMap::new(),
-                shared_memory_pool_size: None,
-            },
+            CoreNodeKind::Runtime(n) => {
+                // A runtime node's I/O is the union of its operators', and the
+                // remaining keys (type annotations, framing, pool size) have no
+                // runtime-node surface — they stay at their defaults, which is
+                // also the right answer for any I/O key added later.
+                let mut run_config = NodeRunConfig::default();
+                run_config.inputs = runtime_node_inputs(n);
+                run_config.outputs = runtime_node_outputs(n);
+                run_config
+            }
             CoreNodeKind::Custom(n) => n.run_config.clone(),
         }
     }
@@ -8109,14 +8111,7 @@ mod fault_tolerance_tests {
             node_config: NodeConfig {
                 dataflow_id: Uuid::nil(),
                 node_id: NodeId::from("test".to_string()),
-                run_config: NodeRunConfig {
-                    inputs: BTreeMap::new(),
-                    outputs: BTreeSet::new(),
-                    output_types: BTreeMap::new(),
-                    input_types: BTreeMap::new(),
-                    output_framing: BTreeMap::new(),
-                    shared_memory_pool_size: None,
-                },
+                run_config: NodeRunConfig::default(),
                 daemon_communication: None,
                 dataflow_descriptor: serde_yaml::Value::Null,
                 dynamic: false,

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -3088,51 +3088,9 @@ impl Daemon {
                     // Construct a minimal Node from the inputs we
                     // already collected — only `id` and `inputs` are
                     // consulted by the daemon.
-                    dataflow
-                        .descriptor
-                        .nodes
-                        .push(dora_message::descriptor::Node {
-                            id: node_id.clone(),
-                            name: None,
-                            description: None,
-                            path: None,
-                            path_sha256: None,
-                            args: None,
-                            env: None,
-                            operators: None,
-                            operator: None,
-                            ros2: None,
-                            outputs: Default::default(),
-                            output_types: Default::default(),
-                            output_framing: Default::default(),
-                            inputs: inputs.into_iter().collect(),
-                            input_types: Default::default(),
-                            shared_memory_pool_size: None,
-                            output_metadata: Default::default(),
-                            pattern: None,
-                            send_stdout_as: None,
-                            send_logs_as: None,
-                            min_log_level: None,
-                            max_log_size: None,
-                            max_rotated_files: None,
-                            build: None,
-                            git: None,
-                            hub: None,
-                            branch: None,
-                            tag: None,
-                            rev: None,
-                            restart_policy: Default::default(),
-                            max_restarts: 0,
-                            restart_delay: None,
-                            max_restart_delay: None,
-                            restart_window: None,
-                            health_check_timeout: None,
-                            finish_grace_secs: None,
-                            module: None,
-                            params: Default::default(),
-                            cpu_affinity: None,
-                            deploy: None,
-                        });
+                    let mut added = dora_message::descriptor::Node::new(node_id.clone());
+                    added.inputs = inputs.into_iter().collect();
+                    dataflow.descriptor.nodes.push(added);
 
                     // Spawn timer tasks for any interval this node just
                     // registered. Timer tasks are only ever created in

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -96,16 +96,7 @@ pub mod bench_support {
         HLC,
         Vec<mpsc::Receiver<Timestamped<NodeEvent>>>,
     ) {
-        let descriptor = dora_message::descriptor::Descriptor {
-            nodes: vec![],
-            deploy: None,
-            debug: dora_message::descriptor::Debug::default(),
-            health_check_interval: None,
-            strict_types: None,
-            exit_when_nodes_finish: None,
-            type_rules: vec![],
-            env: None,
-        };
+        let descriptor = dora_message::descriptor::Descriptor::new(vec![]);
         let mut df = RunningDataflow::new(Uuid::nil(), DaemonId::new(None), descriptor);
 
         let sender_id: NodeId = "sender".to_string().into();
@@ -7956,23 +7947,11 @@ mod fault_tolerance_tests {
     use crate::running_dataflow::{HandleReplacement, StopProcessPolicy};
     use std::sync::atomic::AtomicU32;
 
-    use dora_message::{
-        daemon_to_node::NodeEvent,
-        descriptor::{Debug as DescriptorDebug, Descriptor},
-    };
+    use dora_message::{daemon_to_node::NodeEvent, descriptor::Descriptor};
     use std::sync::atomic::{AtomicBool, AtomicU64};
 
     fn test_dataflow() -> RunningDataflow {
-        let descriptor = Descriptor {
-            nodes: vec![],
-            deploy: None,
-            debug: DescriptorDebug::default(),
-            health_check_interval: None,
-            strict_types: None,
-            exit_when_nodes_finish: None,
-            type_rules: vec![],
-            env: None,
-        };
+        let descriptor = Descriptor::new(vec![]);
         RunningDataflow::new(Uuid::nil(), DaemonId::new(None), descriptor)
     }
 

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -1683,17 +1683,7 @@ mod tests {
     }
 
     fn empty_descriptor() -> Descriptor {
-        use dora_message::descriptor::Debug as DescriptorDebug;
-        Descriptor {
-            nodes: vec![],
-            deploy: None,
-            debug: DescriptorDebug::default(),
-            health_check_interval: None,
-            strict_types: None,
-            exit_when_nodes_finish: None,
-            type_rules: vec![],
-            env: None,
-        }
+        Descriptor::new(vec![])
     }
 
     #[test]

--- a/docs/migration-from-0.x.md
+++ b/docs/migration-from-0.x.md
@@ -20,7 +20,7 @@ The 0.x tree is preserved under the `v0.x-final` tag. It shares no history with 
 | Wire encoding | bincode | postcard | `libraries/message/Cargo.toml` |
 | Message-enum variants (`NodeEvent`, `DaemonCommunication`) | 0.x variant order | New variants inserted (`InputRecovered`, `NodeRestarted`, `ParamUpdate`, `ParamDeleted`, `Shmem`) — positional tags shifted | [`phase--1-audit-2026-04-16.md`](phase--1-audit-2026-04-16.md) §3 |
 | Wire-protocol enums in `dora-message` | exhaustively matchable | `#[non_exhaustive]` — a `_ =>` arm is required (#3151) | `libraries/message/src/` |
-| Descriptor structs in `dora-message` (incl. `NodeRunConfig`) | struct-literal constructible | `#[non_exhaustive]` — use `Node::new` / `Descriptor::new` / `Deploy::default()` (#3387) | `libraries/message/src/descriptor.rs` |
+| Descriptor structs in `dora-message` (incl. `NodeRunConfig`) | struct-literal constructible | `#[non_exhaustive]` — use `Node::new` / `Descriptor::new` / `Deploy::default()` (#3387) | `libraries/message/src/descriptor.rs`, `libraries/message/src/config.rs` |
 | CLI handshake | Optional `get_version()` RPC | Mandatory `ControlRequest::Hello` with semver check | `libraries/message/src/cli_to_coordinator.rs` |
 | Topic data channel | subscription carried no encoding version | `protocol_version` in both directions; mismatch is refused (#3160) | `docs/websocket-topic-data-channel.md` |
 | Recording file extension | `.adorec` | `.drec` (magic bytes were already `DORAREC\x00` / `DORAEND\x00`) | `libraries/recording/src/lib.rs` |
@@ -294,22 +294,26 @@ Pick the fallback to match the role: the coordinator warns and continues (a newe
 
 ### Descriptor structs are `#[non_exhaustive]` (#3387)
 
-`Descriptor`, `Node`, `CustomNode`, `ResolvedNode`, `Deploy`, `Debug`, `TypeRuleDef`, `OperatorConfig`, `SingleOperatorDefinition` and `NodeRunConfig` on the published `dora-message` crate now carry `#[non_exhaustive]`, so adding a descriptor key later is a minor release rather than a major one. Struct literals no longer compile from outside the crate — and neither does `..Default::default()`, which `#[non_exhaustive]` also bans across crate boundaries.
+`Descriptor`, `Node`, `CustomNode`, `ResolvedNode`, `Deploy`, `Debug`, `TypeRuleDef`, `OperatorConfig`, `SingleOperatorDefinition` and `NodeRunConfig` on the published `dora-message` crate now carry `#[non_exhaustive]`, so adding a descriptor key later is a minor release rather than a major one. Struct literals no longer compile from outside the crate. `..Default::default()` is not an escape hatch either: `#[non_exhaustive]` bans functional-update syntax across crate boundaries too, for the types that implement `Default` (`Deploy`, `Debug`, `NodeRunConfig` — `Node`, `Descriptor`, `CustomNode` and `ResolvedNode` never did, so in 0.x they were always spelled out field by field).
 
 Every field stays `pub`, so the migration is to construct from the entry point and then assign:
 
 ```rust
-// 0.x
+// 0.x — a struct literal naming every field
 let node = Node {
-    id: "camera".to_owned().into(),
+    id: "camera".parse()?,
     path: Some("./camera".to_owned()),
-    ..Default::default()
+    name: None,
+    description: None,
+    // … and every other field, explicitly
 };
 
 // 1.0 — construct, then assign
-let mut node = Node::new("camera".to_owned().into());
+let mut node = Node::new("camera".parse()?);
 node.path = Some("./camera".to_owned());
 ```
+
+`NodeId` is validated, so build it with `parse()` (fallible) rather than `.into()`, which panics on an invalid id — this matters for the `AddNode` path, where the id comes from a request.
 
 | Type | Entry point |
 |---|---|
@@ -321,7 +325,7 @@ node.path = Some("./camera".to_owned());
 | `TypeRuleDef` | `TypeRuleDef::new(from, to)` |
 | `OperatorConfig`, `SingleOperatorDefinition` | deserialization only |
 
-This affects Rust code that builds descriptors programmatically — the dynamic-topology `AddNode` surface is the common case. Reading and mutating an existing descriptor is unchanged. There is no YAML or wire-format change: the JSON schema regenerates byte-identical.
+This affects Rust code that builds descriptors programmatically — the dynamic-topology `AddNode` surface is the common case. Reading and mutating an existing descriptor is unchanged. There is no YAML, JSON-schema or wire-format change.
 
 The descriptor *enums* (`RestartPolicy`, `NodeSource`, `EnvValue`, `OutputFraming`, …) are deliberately **not** marked, so matches on them still compile unchanged. That means a new variant stays a major change — see the note on `RestartPolicy` in `descriptor.rs` for why that trade was made.
 

--- a/docs/migration-from-0.x.md
+++ b/docs/migration-from-0.x.md
@@ -20,6 +20,7 @@ The 0.x tree is preserved under the `v0.x-final` tag. It shares no history with 
 | Wire encoding | bincode | postcard | `libraries/message/Cargo.toml` |
 | Message-enum variants (`NodeEvent`, `DaemonCommunication`) | 0.x variant order | New variants inserted (`InputRecovered`, `NodeRestarted`, `ParamUpdate`, `ParamDeleted`, `Shmem`) — positional tags shifted | [`phase--1-audit-2026-04-16.md`](phase--1-audit-2026-04-16.md) §3 |
 | Wire-protocol enums in `dora-message` | exhaustively matchable | `#[non_exhaustive]` — a `_ =>` arm is required (#3151) | `libraries/message/src/` |
+| Descriptor structs in `dora-message` (incl. `NodeRunConfig`) | struct-literal constructible | `#[non_exhaustive]` — use `Node::new` / `Descriptor::new` / `Deploy::default()` (#3387) | `libraries/message/src/descriptor.rs` |
 | CLI handshake | Optional `get_version()` RPC | Mandatory `ControlRequest::Hello` with semver check | `libraries/message/src/cli_to_coordinator.rs` |
 | Topic data channel | subscription carried no encoding version | `protocol_version` in both directions; mismatch is refused (#3160) | `docs/websocket-topic-data-channel.md` |
 | Recording file extension | `.adorec` | `.drec` (magic bytes were already `DORAREC\x00` / `DORAEND\x00`) | `libraries/recording/src/lib.rs` |
@@ -290,6 +291,39 @@ match request {
 Pick the fallback to match the role: the coordinator warns and continues (a newer daemon must not be able to tear down its connection), the daemon replies with an explicit error (so a newer node fails loudly instead of hanging), and read-only observability paths skip.
 
 `dora_node_api::Event` was already `#[non_exhaustive]` in 0.x, so the four new variants (`InputRecovered`, `NodeRestarted`, `ParamUpdate`, `ParamDeleted`) do not break existing matches.
+
+### Descriptor structs are `#[non_exhaustive]` (#3387)
+
+`Descriptor`, `Node`, `CustomNode`, `ResolvedNode`, `Deploy`, `Debug`, `TypeRuleDef`, `OperatorConfig`, `SingleOperatorDefinition` and `NodeRunConfig` on the published `dora-message` crate now carry `#[non_exhaustive]`, so adding a descriptor key later is a minor release rather than a major one. Struct literals no longer compile from outside the crate — and neither does `..Default::default()`, which `#[non_exhaustive]` also bans across crate boundaries.
+
+Every field stays `pub`, so the migration is to construct from the entry point and then assign:
+
+```rust
+// 0.x
+let node = Node {
+    id: "camera".to_owned().into(),
+    path: Some("./camera".to_owned()),
+    ..Default::default()
+};
+
+// 1.0 — construct, then assign
+let mut node = Node::new("camera".to_owned().into());
+node.path = Some("./camera".to_owned());
+```
+
+| Type | Entry point |
+|---|---|
+| `Descriptor` | `Descriptor::new(nodes)` |
+| `Node` | `Node::new(id)` |
+| `CustomNode` | `CustomNode::new(path)` |
+| `ResolvedNode` | `ResolvedNode::new(id, kind)` |
+| `Deploy`, `Debug`, `NodeRunConfig` | `Default::default()` |
+| `TypeRuleDef` | `TypeRuleDef::new(from, to)` |
+| `OperatorConfig`, `SingleOperatorDefinition` | deserialization only |
+
+This affects Rust code that builds descriptors programmatically — the dynamic-topology `AddNode` surface is the common case. Reading and mutating an existing descriptor is unchanged. There is no YAML or wire-format change: the JSON schema regenerates byte-identical.
+
+The descriptor *enums* (`RestartPolicy`, `NodeSource`, `EnvValue`, `OutputFraming`, …) are deliberately **not** marked, so matches on them still compile unchanged. That means a new variant stays a major change — see the note on `RestartPolicy` in `descriptor.rs` for why that trade was made.
 
 ### Pool and pinned-memory requests replaced by the extension seam (#3219)
 

--- a/dora-schema.json
+++ b/dora-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "dora-rs specification",
-  "description": "The main configuration structure for defining a Dora dataflow. Dataflows are\nspecified through YAML files that describe the nodes, their connections, and\nexecution parameters.\n\n## Structure\n\nA dataflow consists of:\n- **Nodes**: The computational units that process data\n- **Deployment**: Optional deployment configuration (unstable)\n- **Debug options**: Optional development and debugging settings (unstable)\n\n## Example\n\n```\n# fn main() -> Result<(), Box<dyn std::error::Error>> {\nuse dora_message::descriptor::Descriptor;\nlet yaml = r#\"\nnodes:\n  - id: webcam\n    operator:\n      python: webcam.py\n      inputs:\n        tick: dora/timer/millis/100\n      outputs:\n        - image\n  - id: plot\n    operator:\n      python: plot.py\n      inputs:\n        image: webcam/image\n\"#;\nlet descriptor: Descriptor = serde_yaml::from_str(yaml)?;\nassert_eq!(descriptor.nodes.len(), 2);\n# Ok(())\n# }\n```",
+  "description": "The main configuration structure for defining a Dora dataflow. Dataflows are\nspecified through YAML files that describe the nodes, their connections, and\nexecution parameters.\n\n## Structure\n\nA dataflow consists of:\n- **Nodes**: The computational units that process data\n- **Deployment**: Optional deployment configuration (unstable)\n- **Debug options**: Optional development and debugging settings (unstable)\n\n## Example\n\n```\n# fn main() -> Result<(), Box<dyn std::error::Error>> {\nuse dora_message::descriptor::Descriptor;\nlet yaml = r#\"\nnodes:\n  - id: webcam\n    operator:\n      python: webcam.py\n      inputs:\n        tick: dora/timer/millis/100\n      outputs:\n        - image\n  - id: plot\n    operator:\n      python: plot.py\n      inputs:\n        image: webcam/image\n\"#;\nlet descriptor: Descriptor = serde_yaml::from_str(yaml)?;\nassert_eq!(descriptor.nodes.len(), 2);\n# Ok(())\n# }\n```\n\nConstruct with [`Descriptor::new`], then assign: `Descriptor` is\n`#[non_exhaustive]`, so struct literals and `..Default::default()` do not\nwork from another crate. The fields stay `pub`.",
   "type": "object",
   "properties": {
     "env": {
@@ -232,7 +232,7 @@
     },
     "Node": {
       "title": "Dora Node Configuration",
-      "description": "A node represents a computational unit in a Dora dataflow. Each node runs as a\nseparate process and can communicate with other nodes through inputs and outputs.",
+      "description": "A node represents a computational unit in a Dora dataflow. Each node runs as a\nseparate process and can communicate with other nodes through inputs and outputs.\n\nConstruct with [`Node::new`], then assign: `Node` is `#[non_exhaustive]`, so\nstruct literals and `..Default::default()` do not work from another crate.\nThe fields stay `pub`.",
       "type": "object",
       "properties": {
         "args": {
@@ -552,6 +552,7 @@
       "type": "string"
     },
     "OperatorDefinition": {
+      "description": "The per-operator descriptor keys, shared by single- and multi-operator nodes.\n\n`#[non_exhaustive]` with no constructor: deserialization is the only way to\nbuild one from another crate. Adding a constructor is a minor change, so\nopen an issue if you need to build one programmatically.",
       "type": "object",
       "properties": {
         "build": {
@@ -702,6 +703,7 @@
       ]
     },
     "OperatorId": {
+      "description": "The identifier of an operator running inside a `dora runtime` node.\n\nAn operator is addressed as `<node_id>/<operator_id>/<output_id>`, so an\n`OperatorId` is the middle segment of a runtime output's fully-qualified\nname.\n\nUnlike [`NodeId`] and [`DataId`], an `OperatorId` is **not** validated:\n[`FromStr`] is [`Infallible`] and [`From<String>`] accepts any string\nverbatim (this is why it derives `Deserialize` directly rather than through\na validating deserializer). Callers are responsible for not embedding a `/`\nin an operator id — a `/` collides with the `<node>/<operator>/<output>`\naddressing separator and makes the operator unaddressable (it would resolve\nto a different operator/output split).\n\n```\nuse dora_message::id::OperatorId;\n\n// Construction is infallible from both `&str` and `String`:\nlet from_str: OperatorId = \"detector\".parse().unwrap(); // FromStr is Infallible\nlet from_string = OperatorId::from(\"detector\".to_string());\nassert_eq!(from_str, from_string);\n\n// Display and AsRef expose the underlying id:\nassert_eq!(from_str.to_string(), \"detector\");\nassert_eq!(from_str.as_ref(), \"detector\");\n```",
       "type": "string"
     },
     "OutputFraming": {
@@ -1082,6 +1084,7 @@
       }
     },
     "SingleOperatorDefinition": {
+      "description": "The `operator:` key of a single-operator node.\n\n`#[non_exhaustive]` with no constructor: deserialization is the only way to\nbuild one from another crate. Adding a constructor is a minor change, so\nopen an issue if you need to build one programmatically.",
       "type": "object",
       "properties": {
         "build": {

--- a/dora-schema.json
+++ b/dora-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "dora-rs specification",
-  "description": "The main configuration structure for defining a Dora dataflow. Dataflows are\nspecified through YAML files that describe the nodes, their connections, and\nexecution parameters.\n\n## Structure\n\nA dataflow consists of:\n- **Nodes**: The computational units that process data\n- **Deployment**: Optional deployment configuration (unstable)\n- **Debug options**: Optional development and debugging settings (unstable)\n\n## Example\n\n```\n# fn main() -> Result<(), Box<dyn std::error::Error>> {\nuse dora_message::descriptor::Descriptor;\nlet yaml = r#\"\nnodes:\n  - id: webcam\n    operator:\n      python: webcam.py\n      inputs:\n        tick: dora/timer/millis/100\n      outputs:\n        - image\n  - id: plot\n    operator:\n      python: plot.py\n      inputs:\n        image: webcam/image\n\"#;\nlet descriptor: Descriptor = serde_yaml::from_str(yaml)?;\nassert_eq!(descriptor.nodes.len(), 2);\n# Ok(())\n# }\n```\n\nConstruct with [`Descriptor::new`], then assign: `Descriptor` is\n`#[non_exhaustive]`, so struct literals and `..Default::default()` do not\nwork from another crate. The fields stay `pub`.",
+  "description": "The main configuration structure for defining a Dora dataflow. Dataflows are\nspecified through YAML files that describe the nodes, their connections, and\nexecution parameters.\n\n## Structure\n\nA dataflow consists of:\n- **Nodes**: The computational units that process data\n- **Deployment**: Optional deployment configuration (unstable)\n- **Debug options**: Optional development and debugging settings (unstable)\n\n## Example\n\n```\n# fn main() -> Result<(), Box<dyn std::error::Error>> {\nuse dora_message::descriptor::Descriptor;\nlet yaml = r#\"\nnodes:\n  - id: webcam\n    operator:\n      python: webcam.py\n      inputs:\n        tick: dora/timer/millis/100\n      outputs:\n        - image\n  - id: plot\n    operator:\n      python: plot.py\n      inputs:\n        image: webcam/image\n\"#;\nlet descriptor: Descriptor = serde_yaml::from_str(yaml)?;\nassert_eq!(descriptor.nodes.len(), 2);\n# Ok(())\n# }\n```",
   "type": "object",
   "properties": {
     "env": {
@@ -232,7 +232,7 @@
     },
     "Node": {
       "title": "Dora Node Configuration",
-      "description": "A node represents a computational unit in a Dora dataflow. Each node runs as a\nseparate process and can communicate with other nodes through inputs and outputs.\n\nConstruct with [`Node::new`], then assign: `Node` is `#[non_exhaustive]`, so\nstruct literals and `..Default::default()` do not work from another crate.\nThe fields stay `pub`.",
+      "description": "A node represents a computational unit in a Dora dataflow. Each node runs as a\nseparate process and can communicate with other nodes through inputs and outputs.",
       "type": "object",
       "properties": {
         "args": {
@@ -552,7 +552,6 @@
       "type": "string"
     },
     "OperatorDefinition": {
-      "description": "The per-operator descriptor keys, shared by single- and multi-operator nodes.\n\n`#[non_exhaustive]` with no constructor: deserialization is the only way to\nbuild one from another crate. Adding a constructor is a minor change, so\nopen an issue if you need to build one programmatically.",
       "type": "object",
       "properties": {
         "build": {
@@ -1084,7 +1083,6 @@
       }
     },
     "SingleOperatorDefinition": {
-      "description": "The `operator:` key of a single-operator node.\n\n`#[non_exhaustive]` with no constructor: deserialization is the only way to\nbuild one from another crate. Adding a constructor is a minor change, so\nopen an issue if you need to build one programmatically.",
       "type": "object",
       "properties": {
         "build": {

--- a/libraries/core/dora-schema.json
+++ b/libraries/core/dora-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "dora-rs specification",
-  "description": "The main configuration structure for defining a Dora dataflow. Dataflows are\nspecified through YAML files that describe the nodes, their connections, and\nexecution parameters.\n\n## Structure\n\nA dataflow consists of:\n- **Nodes**: The computational units that process data\n- **Deployment**: Optional deployment configuration (unstable)\n- **Debug options**: Optional development and debugging settings (unstable)\n\n## Example\n\n```\n# fn main() -> Result<(), Box<dyn std::error::Error>> {\nuse dora_message::descriptor::Descriptor;\nlet yaml = r#\"\nnodes:\n  - id: webcam\n    operator:\n      python: webcam.py\n      inputs:\n        tick: dora/timer/millis/100\n      outputs:\n        - image\n  - id: plot\n    operator:\n      python: plot.py\n      inputs:\n        image: webcam/image\n\"#;\nlet descriptor: Descriptor = serde_yaml::from_str(yaml)?;\nassert_eq!(descriptor.nodes.len(), 2);\n# Ok(())\n# }\n```",
+  "description": "The main configuration structure for defining a Dora dataflow. Dataflows are\nspecified through YAML files that describe the nodes, their connections, and\nexecution parameters.\n\n## Structure\n\nA dataflow consists of:\n- **Nodes**: The computational units that process data\n- **Deployment**: Optional deployment configuration (unstable)\n- **Debug options**: Optional development and debugging settings (unstable)\n\n## Example\n\n```\n# fn main() -> Result<(), Box<dyn std::error::Error>> {\nuse dora_message::descriptor::Descriptor;\nlet yaml = r#\"\nnodes:\n  - id: webcam\n    operator:\n      python: webcam.py\n      inputs:\n        tick: dora/timer/millis/100\n      outputs:\n        - image\n  - id: plot\n    operator:\n      python: plot.py\n      inputs:\n        image: webcam/image\n\"#;\nlet descriptor: Descriptor = serde_yaml::from_str(yaml)?;\nassert_eq!(descriptor.nodes.len(), 2);\n# Ok(())\n# }\n```\n\nConstruct with [`Descriptor::new`], then assign: `Descriptor` is\n`#[non_exhaustive]`, so struct literals and `..Default::default()` do not\nwork from another crate. The fields stay `pub`.",
   "type": "object",
   "properties": {
     "env": {
@@ -232,7 +232,7 @@
     },
     "Node": {
       "title": "Dora Node Configuration",
-      "description": "A node represents a computational unit in a Dora dataflow. Each node runs as a\nseparate process and can communicate with other nodes through inputs and outputs.",
+      "description": "A node represents a computational unit in a Dora dataflow. Each node runs as a\nseparate process and can communicate with other nodes through inputs and outputs.\n\nConstruct with [`Node::new`], then assign: `Node` is `#[non_exhaustive]`, so\nstruct literals and `..Default::default()` do not work from another crate.\nThe fields stay `pub`.",
       "type": "object",
       "properties": {
         "args": {
@@ -552,6 +552,7 @@
       "type": "string"
     },
     "OperatorDefinition": {
+      "description": "The per-operator descriptor keys, shared by single- and multi-operator nodes.\n\n`#[non_exhaustive]` with no constructor: deserialization is the only way to\nbuild one from another crate. Adding a constructor is a minor change, so\nopen an issue if you need to build one programmatically.",
       "type": "object",
       "properties": {
         "build": {
@@ -702,6 +703,7 @@
       ]
     },
     "OperatorId": {
+      "description": "The identifier of an operator running inside a `dora runtime` node.\n\nAn operator is addressed as `<node_id>/<operator_id>/<output_id>`, so an\n`OperatorId` is the middle segment of a runtime output's fully-qualified\nname.\n\nUnlike [`NodeId`] and [`DataId`], an `OperatorId` is **not** validated:\n[`FromStr`] is [`Infallible`] and [`From<String>`] accepts any string\nverbatim (this is why it derives `Deserialize` directly rather than through\na validating deserializer). Callers are responsible for not embedding a `/`\nin an operator id — a `/` collides with the `<node>/<operator>/<output>`\naddressing separator and makes the operator unaddressable (it would resolve\nto a different operator/output split).\n\n```\nuse dora_message::id::OperatorId;\n\n// Construction is infallible from both `&str` and `String`:\nlet from_str: OperatorId = \"detector\".parse().unwrap(); // FromStr is Infallible\nlet from_string = OperatorId::from(\"detector\".to_string());\nassert_eq!(from_str, from_string);\n\n// Display and AsRef expose the underlying id:\nassert_eq!(from_str.to_string(), \"detector\");\nassert_eq!(from_str.as_ref(), \"detector\");\n```",
       "type": "string"
     },
     "OutputFraming": {
@@ -1082,6 +1084,7 @@
       }
     },
     "SingleOperatorDefinition": {
+      "description": "The `operator:` key of a single-operator node.\n\n`#[non_exhaustive]` with no constructor: deserialization is the only way to\nbuild one from another crate. Adding a constructor is a minor change, so\nopen an issue if you need to build one programmatically.",
       "type": "object",
       "properties": {
         "build": {

--- a/libraries/core/dora-schema.json
+++ b/libraries/core/dora-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "dora-rs specification",
-  "description": "The main configuration structure for defining a Dora dataflow. Dataflows are\nspecified through YAML files that describe the nodes, their connections, and\nexecution parameters.\n\n## Structure\n\nA dataflow consists of:\n- **Nodes**: The computational units that process data\n- **Deployment**: Optional deployment configuration (unstable)\n- **Debug options**: Optional development and debugging settings (unstable)\n\n## Example\n\n```\n# fn main() -> Result<(), Box<dyn std::error::Error>> {\nuse dora_message::descriptor::Descriptor;\nlet yaml = r#\"\nnodes:\n  - id: webcam\n    operator:\n      python: webcam.py\n      inputs:\n        tick: dora/timer/millis/100\n      outputs:\n        - image\n  - id: plot\n    operator:\n      python: plot.py\n      inputs:\n        image: webcam/image\n\"#;\nlet descriptor: Descriptor = serde_yaml::from_str(yaml)?;\nassert_eq!(descriptor.nodes.len(), 2);\n# Ok(())\n# }\n```\n\nConstruct with [`Descriptor::new`], then assign: `Descriptor` is\n`#[non_exhaustive]`, so struct literals and `..Default::default()` do not\nwork from another crate. The fields stay `pub`.",
+  "description": "The main configuration structure for defining a Dora dataflow. Dataflows are\nspecified through YAML files that describe the nodes, their connections, and\nexecution parameters.\n\n## Structure\n\nA dataflow consists of:\n- **Nodes**: The computational units that process data\n- **Deployment**: Optional deployment configuration (unstable)\n- **Debug options**: Optional development and debugging settings (unstable)\n\n## Example\n\n```\n# fn main() -> Result<(), Box<dyn std::error::Error>> {\nuse dora_message::descriptor::Descriptor;\nlet yaml = r#\"\nnodes:\n  - id: webcam\n    operator:\n      python: webcam.py\n      inputs:\n        tick: dora/timer/millis/100\n      outputs:\n        - image\n  - id: plot\n    operator:\n      python: plot.py\n      inputs:\n        image: webcam/image\n\"#;\nlet descriptor: Descriptor = serde_yaml::from_str(yaml)?;\nassert_eq!(descriptor.nodes.len(), 2);\n# Ok(())\n# }\n```",
   "type": "object",
   "properties": {
     "env": {
@@ -232,7 +232,7 @@
     },
     "Node": {
       "title": "Dora Node Configuration",
-      "description": "A node represents a computational unit in a Dora dataflow. Each node runs as a\nseparate process and can communicate with other nodes through inputs and outputs.\n\nConstruct with [`Node::new`], then assign: `Node` is `#[non_exhaustive]`, so\nstruct literals and `..Default::default()` do not work from another crate.\nThe fields stay `pub`.",
+      "description": "A node represents a computational unit in a Dora dataflow. Each node runs as a\nseparate process and can communicate with other nodes through inputs and outputs.",
       "type": "object",
       "properties": {
         "args": {
@@ -552,7 +552,6 @@
       "type": "string"
     },
     "OperatorDefinition": {
-      "description": "The per-operator descriptor keys, shared by single- and multi-operator nodes.\n\n`#[non_exhaustive]` with no constructor: deserialization is the only way to\nbuild one from another crate. Adding a constructor is a minor change, so\nopen an issue if you need to build one programmatically.",
       "type": "object",
       "properties": {
         "build": {
@@ -1084,7 +1083,6 @@
       }
     },
     "SingleOperatorDefinition": {
-      "description": "The `operator:` key of a single-operator node.\n\n`#[non_exhaustive]` with no constructor: deserialization is the only way to\nbuild one from another crate. Adding a constructor is a minor change, so\nopen an issue if you need to build one programmatically.",
       "type": "object",
       "properties": {
         "build": {

--- a/libraries/core/src/descriptor/expand.rs
+++ b/libraries/core/src/descriptor/expand.rs
@@ -150,16 +150,14 @@ pub fn expand_modules_with_boundaries(
         }
     }
 
-    // `Descriptor` is `#[non_exhaustive]`: build through `Descriptor::new` and
-    // carry over the dataflow-level options from the source descriptor.
-    let mut expanded = Descriptor::new(flat_nodes);
-    expanded.deploy = descriptor.deploy.clone();
-    expanded.debug = descriptor.debug.clone();
-    expanded.health_check_interval = descriptor.health_check_interval;
-    expanded.strict_types = descriptor.strict_types;
-    expanded.exit_when_nodes_finish = descriptor.exit_when_nodes_finish;
-    expanded.type_rules = descriptor.type_rules.clone();
-    expanded.env = descriptor.env.clone();
+    // Expansion rewrites `nodes` and nothing else, so clone the source
+    // descriptor and swap that one field. Listing the dataflow-level options
+    // individually would silently drop any option added later — `Descriptor` is
+    // `#[non_exhaustive]`, so a missing field is no longer a compile error. This
+    // also keeps the with-modules path structurally identical to the early
+    // return above, which already clones.
+    let mut expanded = descriptor.clone();
+    expanded.nodes = flat_nodes;
 
     Ok(ExpandedDescriptor {
         descriptor: expanded,
@@ -1292,15 +1290,15 @@ mod tests {
         serde_yaml::from_str(yaml).unwrap()
     }
 
-    /// dora-rs/dora#2920: expansion rebuilds the `Descriptor` field by
-    /// field, so any dataflow-level setting it forgets to copy is
-    /// silently dropped for every dataflow that uses modules. The
-    /// completion policy decides whether the graph can ever end, so
-    /// losing it turns a batch run into a hang.
+    /// dora-rs/dora#2920: a dataflow-level setting that expansion drops is
+    /// silently lost for every dataflow that uses modules. The completion
+    /// policy decides whether the graph can ever end, so losing it turns a
+    /// batch run into a hang.
     ///
-    /// The descriptor MUST contain a module: without one,
-    /// `expand_modules_with_boundaries` short-circuits to a whole-struct
-    /// clone and never reaches the field-by-field rebuild this guards.
+    /// Both paths now clone the source descriptor, so this is a regression
+    /// guard rather than the primary defense. The descriptor MUST still
+    /// contain a module: without one, `expand_modules_with_boundaries`
+    /// short-circuits before the expansion path this exercises.
     #[test]
     fn expand_preserves_exit_when_nodes_finish() {
         let tmp = TempDir::new().unwrap();

--- a/libraries/core/src/descriptor/expand.rs
+++ b/libraries/core/src/descriptor/expand.rs
@@ -150,17 +150,19 @@ pub fn expand_modules_with_boundaries(
         }
     }
 
+    // `Descriptor` is `#[non_exhaustive]`: build through `Descriptor::new` and
+    // carry over the dataflow-level options from the source descriptor.
+    let mut expanded = Descriptor::new(flat_nodes);
+    expanded.deploy = descriptor.deploy.clone();
+    expanded.debug = descriptor.debug.clone();
+    expanded.health_check_interval = descriptor.health_check_interval;
+    expanded.strict_types = descriptor.strict_types;
+    expanded.exit_when_nodes_finish = descriptor.exit_when_nodes_finish;
+    expanded.type_rules = descriptor.type_rules.clone();
+    expanded.env = descriptor.env.clone();
+
     Ok(ExpandedDescriptor {
-        descriptor: Descriptor {
-            nodes: flat_nodes,
-            deploy: descriptor.deploy.clone(),
-            debug: descriptor.debug.clone(),
-            health_check_interval: descriptor.health_check_interval,
-            strict_types: descriptor.strict_types,
-            exit_when_nodes_finish: descriptor.exit_when_nodes_finish,
-            type_rules: descriptor.type_rules.clone(),
-            env: descriptor.env.clone(),
-        },
+        descriptor: expanded,
         boundaries,
     })
 }

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -1141,6 +1141,11 @@ nodes:
         /// `resolve_aliases_and_set_defaults_in_topology`.
         const KIND_SPECIFIC: &[&str] = &["path", "source", "path_sha256", "build", "envs"];
 
+        // Field names come from the schema, so a field marked
+        // `#[schemars(skip)]` would never appear in `properties` and would slip
+        // past silently. `Node::deploy` is exactly such a field, and the
+        // classify test compensates with a hardcoded insert — do the same here
+        // if `CustomNode` ever gains one.
         let schema = schemars::schema_for!(dora_message::descriptor::CustomNode);
         let schema = serde_json::to_value(schema).expect("schema should serialize");
         let properties = schema

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -1,5 +1,5 @@
 use dora_message::{
-    config::{InputMapping, NodeRunConfig},
+    config::InputMapping,
     descriptor::EnvValue,
     id::{DataId, NodeId, OperatorId},
 };
@@ -195,31 +195,14 @@ pub fn resolve_aliases_and_set_defaults_in_topology(
             }
         }
 
-        // Take the fields the `ResolvedNode` itself needs before the match
-        // below moves `node`'s per-node keys out by value. `node` is then
-        // maybe-moved for the rest of the iteration, so a later read of a key
-        // that resolution already consumed stays a compile error instead of
-        // silently returning an emptied value.
-        let id = node.id.clone();
-        let name = node.name.take();
-        let description = node.description.take();
-        // Merge the dataflow-level `env` into the per-node `env`. Per-node keys
-        // win on conflict so a node can override a shared default (e.g. global
-        // `RUST_LOG=info` with one verbose node setting `RUST_LOG=debug`).
-        let env = merge_env(desc.env.as_ref(), node.env.take());
-        let cpu_affinity = node.cpu_affinity.take();
-        let deploy = node.deploy.take();
-
-        // resolve nodes
+        // resolve nodes. The two custom-node arms drain the custom-node keys
+        // out of `node` with `CustomNode::from_node`; the node-level keys stay
+        // behind for `ResolvedNode::from_node` below.
         let kind = match node_class {
             classify::NodeClass::Standard { source } => {
                 let path = node.path.take().ok_or_eyre("missing `path` attribute")?;
-                let path_sha256 = node.path_sha256.take();
-                let build = node.build.take();
-                let mut custom = custom_node_from(node, path);
+                let mut custom = CustomNode::from_node(&mut node, path);
                 custom.source = source;
-                custom.path_sha256 = path_sha256;
-                custom.build = build;
                 CoreNodeKind::Custom(custom)
             }
             classify::NodeClass::Runtime => {
@@ -247,70 +230,31 @@ pub fn resolve_aliases_and_set_defaults_in_topology(
                 );
 
                 // The bridge binary is fixed, so `path` is a constant and
-                // `source`/`path_sha256`/`build` stay at their defaults.
-                let mut custom = custom_node_from(node, "dora-ros2-bridge-node".to_string());
+                // `source` stays at its default. `path_sha256` and `build` are
+                // not accepted on a `ros2:` node (classification rejects them),
+                // so `from_node` finds them unset.
+                let mut custom =
+                    CustomNode::from_node(&mut node, "dora-ros2-bridge-node".to_string());
                 custom.envs = Some(envs);
                 CoreNodeKind::Custom(custom)
             }
         };
 
-        if resolved.contains_key(&id) {
-            eyre::bail!("duplicate node ID `{id}` — each node must have a unique `id`");
+        if resolved.contains_key(&node.id) {
+            eyre::bail!(
+                "duplicate node ID `{}` — each node must have a unique `id`",
+                node.id
+            );
         }
-        let mut resolved_node = ResolvedNode::new(id.clone(), kind);
-        resolved_node.name = name;
-        resolved_node.description = description;
-        resolved_node.env = env;
-        resolved_node.cpu_affinity = cpu_affinity;
-        resolved_node.deploy = deploy;
-        resolved.insert(id, resolved_node);
+        let mut resolved_node = ResolvedNode::from_node(node, kind);
+        // Merge the dataflow-level `env` into the per-node `env`. Per-node keys
+        // win on conflict so a node can override a shared default (e.g. global
+        // `RUST_LOG=info` with one verbose node setting `RUST_LOG=debug`).
+        resolved_node.env = merge_env(desc.env.as_ref(), resolved_node.env.take());
+        resolved.insert(resolved_node.id.clone(), resolved_node);
     }
 
     Ok(resolved)
-}
-
-/// Build the `CustomNode` for `node`, filling in every per-node descriptor key
-/// that all custom-node kinds resolve identically.
-///
-/// The caller then sets only what its kind differs on: `source`, `path_sha256`
-/// and `build` for a standard node, `envs` for the ROS2 bridge.
-///
-/// While `CustomNode` was constructible with a struct literal, the compiler
-/// caught a key added to one branch of
-/// [`resolve_aliases_and_set_defaults_in_topology`] and forgotten in the other.
-/// Now that it is `#[non_exhaustive]` it cannot, so the shared copy lives here
-/// instead: a new per-node key is wired in once and both kinds pick it up.
-///
-/// Takes `node` by value so the fields land in the `CustomNode` by move, the
-/// way the struct literals did — a caller cannot be left holding a partly
-/// emptied `Node`.
-fn custom_node_from(node: Node, path: String) -> CustomNode {
-    let mut custom = CustomNode::new(path);
-    custom.args = node.args;
-    custom.send_stdout_as = node.send_stdout_as;
-    custom.send_logs_as = node.send_logs_as;
-    custom.min_log_level = node.min_log_level;
-    custom.max_log_size = node.max_log_size;
-    custom.max_rotated_files = node.max_rotated_files;
-    custom.restart_policy = node.restart_policy;
-    custom.max_restarts = node.max_restarts;
-    custom.restart_delay = node.restart_delay;
-    custom.max_restart_delay = node.max_restart_delay;
-    custom.restart_window = node.restart_window;
-    custom.health_check_timeout = node.health_check_timeout;
-    custom.finish_grace_secs = node.finish_grace_secs;
-    // `NodeRunConfig` is `#[non_exhaustive]` too, so this is field-by-field
-    // rather than a literal. Its keys are `#[serde(flatten)]` into `CustomNode`,
-    // so `every_custom_node_field_is_carried_through` covers them alongside the
-    // rest — a new I/O key left unassigned here fails that test.
-    custom.run_config = NodeRunConfig::default();
-    custom.run_config.inputs = node.inputs;
-    custom.run_config.outputs = node.outputs;
-    custom.run_config.output_types = node.output_types;
-    custom.run_config.output_framing = node.output_framing;
-    custom.run_config.input_types = node.input_types;
-    custom.run_config.shared_memory_pool_size = node.shared_memory_pool_size;
-    custom
 }
 
 impl DescriptorExt for Descriptor {
@@ -663,6 +607,7 @@ mod tests {
     }
 
     use super::*;
+    use dora_message::descriptor::{GitRepoRev, NodeSource};
     use std::collections::BTreeSet;
 
     fn env(pairs: &[(&str, &str)]) -> BTreeMap<String, EnvValue> {
@@ -1118,9 +1063,9 @@ nodes:
     /// Every `CustomNode` field name, taken from its JSON schema.
     ///
     /// A field marked `#[schemars(skip)]` would never appear in `properties`
-    /// and would slip past the two tests below. `Node::deploy` is exactly such
-    /// a field, and the classify test compensates with a hardcoded insert — do
-    /// the same here if `CustomNode` ever gains one.
+    /// and would slip past the carried-through tests below. `Node::deploy` is
+    /// exactly such a field, and the classify test compensates with a
+    /// hardcoded insert — do the same here if `CustomNode` ever gains one.
     fn custom_node_field_names() -> BTreeSet<String> {
         let schema = schemars::schema_for!(dora_message::descriptor::CustomNode);
         let schema = serde_json::to_value(schema).expect("schema should serialize");
@@ -1135,83 +1080,10 @@ nodes:
             .collect()
     }
 
-    /// Every `CustomNode` field must be accounted for: either `custom_node_from`
-    /// copies it for all node kinds, or the kind-specific arm sets it.
-    ///
-    /// While `CustomNode` was constructible with a struct literal, forgetting a
-    /// field here was a compile error. `#[non_exhaustive]` traded that away, so
-    /// this is the replacement — modelled on
-    /// `classify::tests::all_node_fields_are_classified_or_marked_shared`. When
-    /// it fails, a key was added to `CustomNode` and nothing resolves it: decide
-    /// whether it is shared (add it to `custom_node_from` and to `SHARED`) or
-    /// kind-specific (set it in the arm and add it to `KIND_SPECIFIC`).
-    ///
-    /// This half only proves the name was thought about;
-    /// [`every_custom_node_field_is_carried_through`] proves the value actually
-    /// arrives.
-    #[test]
-    fn every_custom_node_field_is_resolved() {
-        /// Copied for every node kind by `custom_node_from`. `run_config` is
-        /// `#[serde(flatten)]`, so its keys appear inline in the schema.
-        const SHARED: &[&str] = &[
-            "args",
-            "send_stdout_as",
-            "send_logs_as",
-            "min_log_level",
-            "max_log_size",
-            "max_rotated_files",
-            "restart_policy",
-            "max_restarts",
-            "restart_delay",
-            "max_restart_delay",
-            "restart_window",
-            "health_check_timeout",
-            "finish_grace_secs",
-            "inputs",
-            "outputs",
-            "output_types",
-            "output_framing",
-            "input_types",
-            "shared_memory_pool_size",
-        ];
-        /// Set by the individual match arms of
-        /// `resolve_aliases_and_set_defaults_in_topology`.
-        const KIND_SPECIFIC: &[&str] = &["path", "source", "path_sha256", "build", "envs"];
-
-        let resolved: BTreeSet<String> = SHARED
-            .iter()
-            .chain(KIND_SPECIFIC)
-            .map(|name| (*name).to_owned())
-            .collect();
-
-        assert_eq!(custom_node_field_names(), resolved);
-    }
-
-    /// The name check above passes as soon as a field is *listed*, so adding a
-    /// key to `SHARED` without wiring it into `custom_node_from` turns it green
-    /// while the descriptor key is accepted in YAML and silently ignored on
-    /// every node. This is the behavioral half: resolve a node whose YAML sets
-    /// every key to a non-default value, and assert none of them arrived at
-    /// `CustomNode::new`'s default.
-    ///
-    /// When it fails for a newly added key, wire the key into `custom_node_from`
-    /// (or the kind-specific arm) *and* give it a non-default value in the YAML
-    /// below. Only a field that resolution structurally cannot make differ
-    /// belongs in `UNCHECKED`.
-    #[test]
-    fn every_custom_node_field_is_carried_through() {
-        /// `source` resolves to `NodeSource::Local` for a `path:` node, which is
-        /// already `CustomNode::new`'s default, so it can never differ here —
-        /// `classify`'s own tests cover the git/hub sources. `envs` is set only
-        /// by the ROS2-bridge arm and has no YAML surface of its own.
-        const UNCHECKED: &[&str] = &["source", "envs"];
-
-        let yaml = r#"
-nodes:
-  - id: full
-    path: ./full-node
-    path_sha256: abc123
-    build: cargo build
+    /// The per-node keys every custom-node kind resolves identically, each set
+    /// to a value that differs from `CustomNode::new`'s default — a YAML
+    /// fragment to append to a `- id:` entry.
+    const SHARED_CUSTOM_NODE_KEYS: &str = r#"
     args: --verbose
     send_stdout_as: stdout-topic
     send_logs_as: logs-topic
@@ -1237,32 +1109,171 @@ nodes:
     input_types:
       tick: arrow.uint64
 "#;
+
+    /// Resolve the single node in `yaml` and assert that every `CustomNode`
+    /// key outside `kind_specific` arrived carrying the value the YAML
+    /// declared — and that the YAML did set it to something other than
+    /// `CustomNode::new`'s default, so the comparison is never a trivial
+    /// `None == None`. Returns the resolved node for the kind-specific checks.
+    ///
+    /// `CustomNode::from_node` is a struct literal inside `dora-message`, so a
+    /// key added to `CustomNode` is already a compile error there. This is the
+    /// value-level half: it catches a key wired to the wrong `Node` field, or
+    /// left at its default. When it fails for a newly added key, carry the key
+    /// in `from_node` and give it a non-default value in
+    /// `SHARED_CUSTOM_NODE_KEYS`.
+    fn resolve_and_check_carried_through(yaml: &str, kind_specific: &[&str]) -> CustomNode {
         let desc: Descriptor = serde_yaml::from_str(yaml).expect("parse");
+        let declared = serde_json::to_value(&desc.nodes[0]).expect("serialize declared");
         let resolved = desc.resolve_aliases_and_set_defaults().expect("resolve");
         let node = resolved.values().next().expect("one node");
         let CoreNodeKind::Custom(custom) = &node.kind else {
             panic!("expected a custom node, got {:?}", node.kind);
         };
 
-        let resolved = serde_json::to_value(custom).expect("serialize resolved");
-        // A sentinel `path` that the YAML above does not use, so `path` itself
-        // is checked like every other field rather than comparing equal to it.
+        let actual = serde_json::to_value(custom).expect("serialize resolved");
+        // A sentinel `path` that no YAML here uses, so `path` itself is checked
+        // like every other field rather than comparing equal to it.
         let default =
             serde_json::to_value(CustomNode::new("<unset>".to_owned())).expect("serialize default");
 
         for field in custom_node_field_names() {
-            if UNCHECKED.contains(&field.as_str()) {
+            if kind_specific.contains(&field.as_str()) {
                 continue;
             }
             assert_ne!(
-                resolved.get(&field),
+                actual.get(&field),
                 default.get(&field),
                 "`{field}` is still at its `CustomNode::new` default after \
-                 resolution — the descriptor key is parsed and then dropped. \
-                 Wire it into `custom_node_from` (or the kind-specific match \
-                 arm) in `resolve_aliases_and_set_defaults_in_topology`. If the \
-                 YAML above does not set it, set it there too."
+                 resolution — either the YAML does not set it (add it to \
+                 `SHARED_CUSTOM_NODE_KEYS`) or the key is parsed and then \
+                 dropped (carry it in `CustomNode::from_node`)."
+            );
+            assert_eq!(
+                actual.get(&field),
+                declared.get(&field),
+                "`{field}` resolved to a different value than the YAML declared \
+                 — `CustomNode::from_node` copies it from the wrong `Node` field."
             );
         }
+        custom.clone()
+    }
+
+    /// A `path:` node: every shared key and the standard-only `path_sha256` /
+    /// `build` arrive. `source` resolves to `Local`, which is already the
+    /// default, and `envs` is set only by the ROS2-bridge arm — the two tests
+    /// below cover those.
+    #[test]
+    fn every_custom_node_field_is_carried_through() {
+        let yaml = format!(
+            "nodes:\n  - id: full\n    path: ./full-node\n    path_sha256: abc123\n    \
+             build: cargo build{SHARED_CUSTOM_NODE_KEYS}"
+        );
+        let custom = resolve_and_check_carried_through(&yaml, &["source", "envs"]);
+        assert!(
+            matches!(custom.source, NodeSource::Local),
+            "{:?}",
+            custom.source
+        );
+        assert!(custom.envs.is_none(), "{:?}", custom.envs);
+    }
+
+    /// The `source` a `git:` node classifies to must reach the resolved node:
+    /// it is the one assignment in the standard arm that `from_node` does not
+    /// cover, and dropping it would turn every git node into a local one.
+    #[test]
+    fn git_source_is_carried_through() {
+        let yaml = format!(
+            "nodes:\n  - id: full\n    path: node\n    path_sha256: abc123\n    \
+             build: cargo build\n    git: https://github.com/example/node.git\n    \
+             branch: main{SHARED_CUSTOM_NODE_KEYS}"
+        );
+        let custom = resolve_and_check_carried_through(&yaml, &["source", "envs"]);
+        assert!(
+            matches!(
+                &custom.source,
+                NodeSource::GitBranch { repo, rev: Some(GitRepoRev::Branch(branch)) }
+                    if repo == "https://github.com/example/node.git" && branch == "main"
+            ),
+            "{:?}",
+            custom.source
+        );
+        assert!(custom.envs.is_none(), "{:?}", custom.envs);
+    }
+
+    /// The ROS2-bridge arm: `path` is the bridge binary, `envs` carries the
+    /// bridge config the binary reads at startup, and every shared key still
+    /// arrives. `path_sha256` and `build` are rejected on a `ros2:` node by
+    /// classification, so they must stay unset.
+    #[test]
+    fn ros2_bridge_node_is_carried_through() {
+        let yaml = format!(
+            "nodes:\n  - id: bridge\n    ros2:\n      topic: /odom\n      \
+             message_type: nav_msgs/msg/Odometry\n      direction: subscribe\
+             {SHARED_CUSTOM_NODE_KEYS}"
+        );
+        let custom = resolve_and_check_carried_through(
+            &yaml,
+            &["path", "source", "path_sha256", "build", "envs"],
+        );
+        assert_eq!(custom.path, "dora-ros2-bridge-node");
+        assert!(
+            matches!(custom.source, NodeSource::Local),
+            "{:?}",
+            custom.source
+        );
+        assert!(custom.path_sha256.is_none(), "{:?}", custom.path_sha256);
+        assert!(custom.build.is_none(), "{:?}", custom.build);
+        let envs = custom
+            .envs
+            .expect("the bridge is configured through its environment");
+        let Some(EnvValue::String(config)) = envs.get("DORA_ROS2_BRIDGE_CONFIG") else {
+            panic!("DORA_ROS2_BRIDGE_CONFIG missing from {envs:?}");
+        };
+        assert!(config.contains("/odom"), "{config}");
+    }
+
+    /// The node-level keys — the ones `ResolvedNode::from_node` consumes once
+    /// `CustomNode::from_node` has drained the rest — must reach the resolved
+    /// node. `from_node` is a struct literal inside `dora-message`, so a new
+    /// `ResolvedNode` field is a compile error there; this checks the values,
+    /// including that the dataflow-level `env` is merged in with the per-node
+    /// key winning.
+    #[test]
+    fn node_level_keys_are_carried_through() {
+        let yaml = r#"
+env:
+  RUST_LOG: info
+  SHARED: global
+nodes:
+  - id: full
+    name: Full Node
+    description: Sets every node-level key
+    path: ./full-node
+    env:
+      SHARED: per-node
+    cpu_affinity: [0, 1]
+    deploy:
+      machine: gpu-box
+"#;
+        let desc: Descriptor = serde_yaml::from_str(yaml).expect("parse");
+        let resolved = desc.resolve_aliases_and_set_defaults().expect("resolve");
+        let node = resolved.values().next().expect("one node");
+
+        assert_eq!(node.id.to_string(), "full");
+        assert_eq!(node.name.as_deref(), Some("Full Node"));
+        assert_eq!(
+            node.description.as_deref(),
+            Some("Sets every node-level key")
+        );
+        assert_eq!(
+            node.env,
+            Some(env(&[("RUST_LOG", "info"), ("SHARED", "per-node")]))
+        );
+        assert_eq!(node.cpu_affinity, Some(vec![0, 1]));
+        assert_eq!(
+            node.deploy.as_ref().and_then(|d| d.machine.as_deref()),
+            Some("gpu-box")
+        );
     }
 }

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -1,6 +1,6 @@
 use dora_message::{
     config::{InputMapping, NodeRunConfig},
-    descriptor::{EnvValue, NodeSource},
+    descriptor::EnvValue,
     id::{DataId, NodeId, OperatorId},
 };
 use eyre::{Context, OptionExt, Result, bail};
@@ -198,35 +198,12 @@ pub fn resolve_aliases_and_set_defaults_in_topology(
         // resolve nodes
         let kind = match node_class {
             classify::NodeClass::Standard { source } => {
-                let path = node.path.as_ref().ok_or_eyre("missing `path` attribute")?;
-                CoreNodeKind::Custom(CustomNode {
-                    path: path.clone(),
-                    source,
-                    path_sha256: node.path_sha256,
-                    args: node.args,
-                    build: node.build,
-                    send_stdout_as: node.send_stdout_as,
-                    send_logs_as: node.send_logs_as,
-                    min_log_level: node.min_log_level,
-                    max_log_size: node.max_log_size,
-                    max_rotated_files: node.max_rotated_files,
-                    run_config: NodeRunConfig {
-                        inputs: node.inputs,
-                        outputs: node.outputs,
-                        output_types: node.output_types,
-                        output_framing: node.output_framing,
-                        input_types: node.input_types,
-                        shared_memory_pool_size: node.shared_memory_pool_size,
-                    },
-                    envs: None,
-                    restart_policy: node.restart_policy,
-                    max_restarts: node.max_restarts,
-                    restart_delay: node.restart_delay,
-                    max_restart_delay: node.max_restart_delay,
-                    restart_window: node.restart_window,
-                    health_check_timeout: node.health_check_timeout,
-                    finish_grace_secs: node.finish_grace_secs,
-                })
+                let path = node.path.take().ok_or_eyre("missing `path` attribute")?;
+                let mut custom = custom_node_from(&mut node, path);
+                custom.source = source;
+                custom.path_sha256 = node.path_sha256.take();
+                custom.build = node.build.take();
+                CoreNodeKind::Custom(custom)
             }
             classify::NodeClass::Runtime => {
                 let runtime = node.operators.as_ref().ok_or_eyre("no operators")?;
@@ -252,34 +229,11 @@ pub fn resolve_aliases_and_set_defaults_in_topology(
                     EnvValue::String(bridge_config_json),
                 );
 
-                CoreNodeKind::Custom(CustomNode {
-                    path: "dora-ros2-bridge-node".to_string(),
-                    source: NodeSource::Local,
-                    path_sha256: None,
-                    args: node.args,
-                    build: None,
-                    send_stdout_as: node.send_stdout_as,
-                    send_logs_as: node.send_logs_as,
-                    min_log_level: node.min_log_level,
-                    max_log_size: node.max_log_size,
-                    max_rotated_files: node.max_rotated_files,
-                    run_config: NodeRunConfig {
-                        inputs: node.inputs,
-                        outputs: node.outputs,
-                        output_types: node.output_types,
-                        output_framing: node.output_framing,
-                        input_types: node.input_types,
-                        shared_memory_pool_size: node.shared_memory_pool_size,
-                    },
-                    envs: Some(envs),
-                    restart_policy: node.restart_policy,
-                    max_restarts: node.max_restarts,
-                    restart_delay: node.restart_delay,
-                    max_restart_delay: node.max_restart_delay,
-                    restart_window: node.restart_window,
-                    health_check_timeout: node.health_check_timeout,
-                    finish_grace_secs: node.finish_grace_secs,
-                })
+                // The bridge binary is fixed, so `path` is a constant and
+                // `source`/`path_sha256`/`build` stay at their defaults.
+                let mut custom = custom_node_from(&mut node, "dora-ros2-bridge-node".to_string());
+                custom.envs = Some(envs);
+                CoreNodeKind::Custom(custom)
             }
         };
 
@@ -308,6 +262,43 @@ pub fn resolve_aliases_and_set_defaults_in_topology(
     }
 
     Ok(resolved)
+}
+
+/// Build the `CustomNode` for `node`, filling in every per-node descriptor key
+/// that all custom-node kinds resolve identically.
+///
+/// The caller then sets only what its kind differs on: `source`, `path_sha256`
+/// and `build` for a standard node, `envs` for the ROS2 bridge.
+///
+/// While `CustomNode` was constructible with a struct literal, the compiler
+/// caught a key added to one branch of
+/// [`resolve_aliases_and_set_defaults_in_topology`] and forgotten in the other.
+/// Now that it is `#[non_exhaustive]` it cannot, so the shared copy lives here
+/// instead: a new per-node key is wired in once and both kinds pick it up.
+fn custom_node_from(node: &mut Node, path: String) -> CustomNode {
+    let mut custom = CustomNode::new(path);
+    custom.args = node.args.take();
+    custom.send_stdout_as = node.send_stdout_as.take();
+    custom.send_logs_as = node.send_logs_as.take();
+    custom.min_log_level = node.min_log_level.take();
+    custom.max_log_size = node.max_log_size.take();
+    custom.max_rotated_files = node.max_rotated_files.take();
+    custom.restart_policy = node.restart_policy;
+    custom.max_restarts = node.max_restarts;
+    custom.restart_delay = node.restart_delay.take();
+    custom.max_restart_delay = node.max_restart_delay.take();
+    custom.restart_window = node.restart_window.take();
+    custom.health_check_timeout = node.health_check_timeout.take();
+    custom.finish_grace_secs = node.finish_grace_secs.take();
+    custom.run_config = NodeRunConfig {
+        inputs: std::mem::take(&mut node.inputs),
+        outputs: std::mem::take(&mut node.outputs),
+        output_types: std::mem::take(&mut node.output_types),
+        output_framing: std::mem::take(&mut node.output_framing),
+        input_types: std::mem::take(&mut node.input_types),
+        shared_memory_pool_size: node.shared_memory_pool_size.take(),
+    };
+    custom
 }
 
 impl DescriptorExt for Descriptor {
@@ -1109,5 +1100,60 @@ nodes:
             msg.contains("duplicate node ID") && msg.contains("my-node"),
             "unexpected error message: {msg}"
         );
+    }
+
+    /// Every `CustomNode` field must be accounted for: either `custom_node_from`
+    /// copies it for all node kinds, or the kind-specific arm sets it.
+    ///
+    /// While `CustomNode` was constructible with a struct literal, forgetting a
+    /// field here was a compile error. `#[non_exhaustive]` traded that away, so
+    /// this is the replacement — modelled on
+    /// `classify::tests::all_node_fields_are_classified_or_marked_shared`. When
+    /// it fails, a key was added to `CustomNode` and nothing resolves it: decide
+    /// whether it is shared (add it to `custom_node_from` and to `SHARED`) or
+    /// kind-specific (set it in the arm and add it to `KIND_SPECIFIC`).
+    #[test]
+    fn every_custom_node_field_is_resolved() {
+        /// Copied for every node kind by `custom_node_from`. `run_config` is
+        /// `#[serde(flatten)]`, so its keys appear inline in the schema.
+        const SHARED: &[&str] = &[
+            "args",
+            "send_stdout_as",
+            "send_logs_as",
+            "min_log_level",
+            "max_log_size",
+            "max_rotated_files",
+            "restart_policy",
+            "max_restarts",
+            "restart_delay",
+            "max_restart_delay",
+            "restart_window",
+            "health_check_timeout",
+            "finish_grace_secs",
+            "inputs",
+            "outputs",
+            "output_types",
+            "output_framing",
+            "input_types",
+            "shared_memory_pool_size",
+        ];
+        /// Set by the individual match arms of
+        /// `resolve_aliases_and_set_defaults_in_topology`.
+        const KIND_SPECIFIC: &[&str] = &["path", "source", "path_sha256", "build", "envs"];
+
+        let schema = schemars::schema_for!(dora_message::descriptor::CustomNode);
+        let schema = serde_json::to_value(schema).expect("schema should serialize");
+        let properties = schema
+            .pointer("/$defs/CustomNode/properties")
+            .or_else(|| schema.pointer("/definitions/CustomNode/properties"))
+            .or_else(|| schema.pointer("/properties"))
+            .and_then(serde_json::Value::as_object)
+            .expect("CustomNode schema should expose properties");
+
+        let actual: std::collections::BTreeSet<_> = properties.keys().map(String::as_str).collect();
+        let resolved: std::collections::BTreeSet<_> =
+            SHARED.iter().chain(KIND_SPECIFIC).copied().collect();
+
+        assert_eq!(actual, resolved);
     }
 }

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -195,14 +195,31 @@ pub fn resolve_aliases_and_set_defaults_in_topology(
             }
         }
 
+        // Take the fields the `ResolvedNode` itself needs before the match
+        // below moves `node`'s per-node keys out by value. `node` is then
+        // maybe-moved for the rest of the iteration, so a later read of a key
+        // that resolution already consumed stays a compile error instead of
+        // silently returning an emptied value.
+        let id = node.id.clone();
+        let name = node.name.take();
+        let description = node.description.take();
+        // Merge the dataflow-level `env` into the per-node `env`. Per-node keys
+        // win on conflict so a node can override a shared default (e.g. global
+        // `RUST_LOG=info` with one verbose node setting `RUST_LOG=debug`).
+        let env = merge_env(desc.env.as_ref(), node.env.take());
+        let cpu_affinity = node.cpu_affinity.take();
+        let deploy = node.deploy.take();
+
         // resolve nodes
         let kind = match node_class {
             classify::NodeClass::Standard { source } => {
                 let path = node.path.take().ok_or_eyre("missing `path` attribute")?;
-                let mut custom = custom_node_from(&mut node, path);
+                let path_sha256 = node.path_sha256.take();
+                let build = node.build.take();
+                let mut custom = custom_node_from(node, path);
                 custom.source = source;
-                custom.path_sha256 = node.path_sha256.take();
-                custom.build = node.build.take();
+                custom.path_sha256 = path_sha256;
+                custom.build = build;
                 CoreNodeKind::Custom(custom)
             }
             classify::NodeClass::Runtime => {
@@ -231,28 +248,22 @@ pub fn resolve_aliases_and_set_defaults_in_topology(
 
                 // The bridge binary is fixed, so `path` is a constant and
                 // `source`/`path_sha256`/`build` stay at their defaults.
-                let mut custom = custom_node_from(&mut node, "dora-ros2-bridge-node".to_string());
+                let mut custom = custom_node_from(node, "dora-ros2-bridge-node".to_string());
                 custom.envs = Some(envs);
                 CoreNodeKind::Custom(custom)
             }
         };
 
-        if resolved.contains_key(&node.id) {
-            eyre::bail!(
-                "duplicate node ID `{}` — each node must have a unique `id`",
-                node.id
-            );
+        if resolved.contains_key(&id) {
+            eyre::bail!("duplicate node ID `{id}` — each node must have a unique `id`");
         }
-        let mut resolved_node = ResolvedNode::new(node.id.clone(), kind);
-        resolved_node.name = node.name;
-        resolved_node.description = node.description;
-        // Merge the dataflow-level `env` into the per-node `env`. Per-node keys
-        // win on conflict so a node can override a shared default (e.g. global
-        // `RUST_LOG=info` with one verbose node setting `RUST_LOG=debug`).
-        resolved_node.env = merge_env(desc.env.as_ref(), node.env);
-        resolved_node.cpu_affinity = node.cpu_affinity;
-        resolved_node.deploy = node.deploy;
-        resolved.insert(node.id, resolved_node);
+        let mut resolved_node = ResolvedNode::new(id.clone(), kind);
+        resolved_node.name = name;
+        resolved_node.description = description;
+        resolved_node.env = env;
+        resolved_node.cpu_affinity = cpu_affinity;
+        resolved_node.deploy = deploy;
+        resolved.insert(id, resolved_node);
     }
 
     Ok(resolved)
@@ -269,29 +280,36 @@ pub fn resolve_aliases_and_set_defaults_in_topology(
 /// [`resolve_aliases_and_set_defaults_in_topology`] and forgotten in the other.
 /// Now that it is `#[non_exhaustive]` it cannot, so the shared copy lives here
 /// instead: a new per-node key is wired in once and both kinds pick it up.
-fn custom_node_from(node: &mut Node, path: String) -> CustomNode {
+///
+/// Takes `node` by value so the fields land in the `CustomNode` by move, the
+/// way the struct literals did — a caller cannot be left holding a partly
+/// emptied `Node`.
+fn custom_node_from(node: Node, path: String) -> CustomNode {
     let mut custom = CustomNode::new(path);
-    custom.args = node.args.take();
-    custom.send_stdout_as = node.send_stdout_as.take();
-    custom.send_logs_as = node.send_logs_as.take();
-    custom.min_log_level = node.min_log_level.take();
-    custom.max_log_size = node.max_log_size.take();
-    custom.max_rotated_files = node.max_rotated_files.take();
+    custom.args = node.args;
+    custom.send_stdout_as = node.send_stdout_as;
+    custom.send_logs_as = node.send_logs_as;
+    custom.min_log_level = node.min_log_level;
+    custom.max_log_size = node.max_log_size;
+    custom.max_rotated_files = node.max_rotated_files;
     custom.restart_policy = node.restart_policy;
     custom.max_restarts = node.max_restarts;
-    custom.restart_delay = node.restart_delay.take();
-    custom.max_restart_delay = node.max_restart_delay.take();
-    custom.restart_window = node.restart_window.take();
-    custom.health_check_timeout = node.health_check_timeout.take();
-    custom.finish_grace_secs = node.finish_grace_secs.take();
-    custom.run_config = NodeRunConfig {
-        inputs: std::mem::take(&mut node.inputs),
-        outputs: std::mem::take(&mut node.outputs),
-        output_types: std::mem::take(&mut node.output_types),
-        output_framing: std::mem::take(&mut node.output_framing),
-        input_types: std::mem::take(&mut node.input_types),
-        shared_memory_pool_size: node.shared_memory_pool_size.take(),
-    };
+    custom.restart_delay = node.restart_delay;
+    custom.max_restart_delay = node.max_restart_delay;
+    custom.restart_window = node.restart_window;
+    custom.health_check_timeout = node.health_check_timeout;
+    custom.finish_grace_secs = node.finish_grace_secs;
+    // `NodeRunConfig` is `#[non_exhaustive]` too, so this is field-by-field
+    // rather than a literal. Its keys are `#[serde(flatten)]` into `CustomNode`,
+    // so `every_custom_node_field_is_carried_through` covers them alongside the
+    // rest — a new I/O key left unassigned here fails that test.
+    custom.run_config = NodeRunConfig::default();
+    custom.run_config.inputs = node.inputs;
+    custom.run_config.outputs = node.outputs;
+    custom.run_config.output_types = node.output_types;
+    custom.run_config.output_framing = node.output_framing;
+    custom.run_config.input_types = node.input_types;
+    custom.run_config.shared_memory_pool_size = node.shared_memory_pool_size;
     custom
 }
 
@@ -645,6 +663,7 @@ mod tests {
     }
 
     use super::*;
+    use std::collections::BTreeSet;
 
     fn env(pairs: &[(&str, &str)]) -> BTreeMap<String, EnvValue> {
         pairs
@@ -1096,6 +1115,26 @@ nodes:
         );
     }
 
+    /// Every `CustomNode` field name, taken from its JSON schema.
+    ///
+    /// A field marked `#[schemars(skip)]` would never appear in `properties`
+    /// and would slip past the two tests below. `Node::deploy` is exactly such
+    /// a field, and the classify test compensates with a hardcoded insert — do
+    /// the same here if `CustomNode` ever gains one.
+    fn custom_node_field_names() -> BTreeSet<String> {
+        let schema = schemars::schema_for!(dora_message::descriptor::CustomNode);
+        let schema = serde_json::to_value(schema).expect("schema should serialize");
+        schema
+            .pointer("/$defs/CustomNode/properties")
+            .or_else(|| schema.pointer("/definitions/CustomNode/properties"))
+            .or_else(|| schema.pointer("/properties"))
+            .and_then(serde_json::Value::as_object)
+            .expect("CustomNode schema should expose properties")
+            .keys()
+            .cloned()
+            .collect()
+    }
+
     /// Every `CustomNode` field must be accounted for: either `custom_node_from`
     /// copies it for all node kinds, or the kind-specific arm sets it.
     ///
@@ -1106,6 +1145,10 @@ nodes:
     /// it fails, a key was added to `CustomNode` and nothing resolves it: decide
     /// whether it is shared (add it to `custom_node_from` and to `SHARED`) or
     /// kind-specific (set it in the arm and add it to `KIND_SPECIFIC`).
+    ///
+    /// This half only proves the name was thought about;
+    /// [`every_custom_node_field_is_carried_through`] proves the value actually
+    /// arrives.
     #[test]
     fn every_custom_node_field_is_resolved() {
         /// Copied for every node kind by `custom_node_from`. `run_config` is
@@ -1135,24 +1178,91 @@ nodes:
         /// `resolve_aliases_and_set_defaults_in_topology`.
         const KIND_SPECIFIC: &[&str] = &["path", "source", "path_sha256", "build", "envs"];
 
-        // Field names come from the schema, so a field marked
-        // `#[schemars(skip)]` would never appear in `properties` and would slip
-        // past silently. `Node::deploy` is exactly such a field, and the
-        // classify test compensates with a hardcoded insert — do the same here
-        // if `CustomNode` ever gains one.
-        let schema = schemars::schema_for!(dora_message::descriptor::CustomNode);
-        let schema = serde_json::to_value(schema).expect("schema should serialize");
-        let properties = schema
-            .pointer("/$defs/CustomNode/properties")
-            .or_else(|| schema.pointer("/definitions/CustomNode/properties"))
-            .or_else(|| schema.pointer("/properties"))
-            .and_then(serde_json::Value::as_object)
-            .expect("CustomNode schema should expose properties");
+        let resolved: BTreeSet<String> = SHARED
+            .iter()
+            .chain(KIND_SPECIFIC)
+            .map(|name| (*name).to_owned())
+            .collect();
 
-        let actual: std::collections::BTreeSet<_> = properties.keys().map(String::as_str).collect();
-        let resolved: std::collections::BTreeSet<_> =
-            SHARED.iter().chain(KIND_SPECIFIC).copied().collect();
+        assert_eq!(custom_node_field_names(), resolved);
+    }
 
-        assert_eq!(actual, resolved);
+    /// The name check above passes as soon as a field is *listed*, so adding a
+    /// key to `SHARED` without wiring it into `custom_node_from` turns it green
+    /// while the descriptor key is accepted in YAML and silently ignored on
+    /// every node. This is the behavioral half: resolve a node whose YAML sets
+    /// every key to a non-default value, and assert none of them arrived at
+    /// `CustomNode::new`'s default.
+    ///
+    /// When it fails for a newly added key, wire the key into `custom_node_from`
+    /// (or the kind-specific arm) *and* give it a non-default value in the YAML
+    /// below. Only a field that resolution structurally cannot make differ
+    /// belongs in `UNCHECKED`.
+    #[test]
+    fn every_custom_node_field_is_carried_through() {
+        /// `source` resolves to `NodeSource::Local` for a `path:` node, which is
+        /// already `CustomNode::new`'s default, so it can never differ here —
+        /// `classify`'s own tests cover the git/hub sources. `envs` is set only
+        /// by the ROS2-bridge arm and has no YAML surface of its own.
+        const UNCHECKED: &[&str] = &["source", "envs"];
+
+        let yaml = r#"
+nodes:
+  - id: full
+    path: ./full-node
+    path_sha256: abc123
+    build: cargo build
+    args: --verbose
+    send_stdout_as: stdout-topic
+    send_logs_as: logs-topic
+    min_log_level: debug
+    max_log_size: 4MB
+    max_rotated_files: 3
+    restart_policy: always
+    max_restarts: 7
+    restart_delay: 1.5
+    max_restart_delay: 9.5
+    restart_window: 60.0
+    health_check_timeout: 2.5
+    finish_grace_secs: 3.5
+    shared_memory_pool_size: 8MB
+    inputs:
+      tick: dora/timer/millis/100
+    outputs:
+      - out
+    output_types:
+      out: arrow.int32
+    output_framing:
+      out: arrow-ipc
+    input_types:
+      tick: arrow.uint64
+"#;
+        let desc: Descriptor = serde_yaml::from_str(yaml).expect("parse");
+        let resolved = desc.resolve_aliases_and_set_defaults().expect("resolve");
+        let node = resolved.values().next().expect("one node");
+        let CoreNodeKind::Custom(custom) = &node.kind else {
+            panic!("expected a custom node, got {:?}", node.kind);
+        };
+
+        let resolved = serde_json::to_value(custom).expect("serialize resolved");
+        // A sentinel `path` that the YAML above does not use, so `path` itself
+        // is checked like every other field rather than comparing equal to it.
+        let default =
+            serde_json::to_value(CustomNode::new("<unset>".to_owned())).expect("serialize default");
+
+        for field in custom_node_field_names() {
+            if UNCHECKED.contains(&field.as_str()) {
+                continue;
+            }
+            assert_ne!(
+                resolved.get(&field),
+                default.get(&field),
+                "`{field}` is still at its `CustomNode::new` default after \
+                 resolution — the descriptor key is parsed and then dropped. \
+                 Wire it into `custom_node_from` (or the kind-specific match \
+                 arm) in `resolve_aliases_and_set_defaults_in_topology`. If the \
+                 YAML above does not set it, set it there too."
+            );
+        }
     }
 }

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -243,22 +243,16 @@ pub fn resolve_aliases_and_set_defaults_in_topology(
                 node.id
             );
         }
-        resolved.insert(
-            node.id.clone(),
-            ResolvedNode {
-                id: node.id,
-                name: node.name,
-                description: node.description,
-                // Merge the dataflow-level `env` into the per-node `env`.
-                // Per-node keys win on conflict so a node can override a
-                // shared default (e.g. global `RUST_LOG=info` with one
-                // verbose node setting `RUST_LOG=debug`).
-                env: merge_env(desc.env.as_ref(), node.env),
-                cpu_affinity: node.cpu_affinity,
-                deploy: node.deploy,
-                kind,
-            },
-        );
+        let mut resolved_node = ResolvedNode::new(node.id.clone(), kind);
+        resolved_node.name = node.name;
+        resolved_node.description = node.description;
+        // Merge the dataflow-level `env` into the per-node `env`. Per-node keys
+        // win on conflict so a node can override a shared default (e.g. global
+        // `RUST_LOG=info` with one verbose node setting `RUST_LOG=debug`).
+        resolved_node.env = merge_env(desc.env.as_ref(), node.env);
+        resolved_node.cpu_affinity = node.cpu_affinity;
+        resolved_node.deploy = node.deploy;
+        resolved.insert(node.id, resolved_node);
     }
 
     Ok(resolved)

--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -3107,15 +3107,7 @@ nodes:
         let node = |n: u32| -> ResolvedNode {
             let mut custom = custom_node();
             custom.max_rotated_files = Some(n);
-            ResolvedNode {
-                id: NodeId::from("n".to_owned()),
-                name: None,
-                description: None,
-                env: None,
-                cpu_affinity: None,
-                deploy: None,
-                kind: CoreNodeKind::Custom(custom),
-            }
+            ResolvedNode::new(NodeId::from("n".to_owned()), CoreNodeKind::Custom(custom))
         };
 
         // 0 is a real configuration: keep the active log only, rotating the

--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -1453,27 +1453,7 @@ operators:
     }
 
     fn custom_node() -> dora_message::descriptor::CustomNode {
-        dora_message::descriptor::CustomNode {
-            path: "node".to_string(),
-            source: dora_message::descriptor::NodeSource::Local,
-            path_sha256: None,
-            args: None,
-            envs: None,
-            build: None,
-            send_stdout_as: None,
-            send_logs_as: None,
-            min_log_level: None,
-            max_log_size: None,
-            max_rotated_files: None,
-            restart_policy: Default::default(),
-            max_restarts: 0,
-            restart_delay: None,
-            max_restart_delay: None,
-            restart_window: None,
-            health_check_timeout: None,
-            finish_grace_secs: None,
-            run_config: serde_yaml::from_str("{}").unwrap(),
-        }
+        dora_message::descriptor::CustomNode::new("node".to_string())
     }
 
     #[test]

--- a/libraries/message/src/config.rs
+++ b/libraries/message/src/config.rs
@@ -55,15 +55,13 @@ impl QueuePolicy {
 }
 
 /// Contains the input and output configuration of the node.
-///
-/// Construct with `NodeRunConfig::default()`, then assign: `NodeRunConfig` is
-/// `#[non_exhaustive]`, so struct literals and `..Default::default()` do not
-/// work from another crate. The fields stay `pub`.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 // Same rationale as `descriptor::Node`: these six fields are `#[serde(flatten)]`
-// into `Node`/`CustomNode`, so they are top-level per-node YAML keys and a
-// seventh I/O key must stay a minor release. Marking this later would itself be
-// the major change, so it cannot wait for the conversion to be convenient.
+// into `CustomNode`, and `Node` declares the same six keys directly, so they
+// are top-level per-node YAML keys and a seventh I/O key must stay a minor
+// release. Marking this later would itself be the major change, so it cannot
+// wait for the conversion to be convenient. Construct with
+// `NodeRunConfig::default()`; the fields remain `pub`.
 #[non_exhaustive]
 pub struct NodeRunConfig {
     /// Inputs for the nodes as a map from input ID to `node_id/output_id`.

--- a/libraries/message/src/config.rs
+++ b/libraries/message/src/config.rs
@@ -55,7 +55,7 @@ impl QueuePolicy {
 }
 
 /// Contains the input and output configuration of the node.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct NodeRunConfig {
     /// Inputs for the nodes as a map from input ID to `node_id/output_id`.
     ///

--- a/libraries/message/src/config.rs
+++ b/libraries/message/src/config.rs
@@ -55,7 +55,16 @@ impl QueuePolicy {
 }
 
 /// Contains the input and output configuration of the node.
+///
+/// Construct with `NodeRunConfig::default()`, then assign: `NodeRunConfig` is
+/// `#[non_exhaustive]`, so struct literals and `..Default::default()` do not
+/// work from another crate. The fields stay `pub`.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+// Same rationale as `descriptor::Node`: these six fields are `#[serde(flatten)]`
+// into `Node`/`CustomNode`, so they are top-level per-node YAML keys and a
+// seventh I/O key must stay a minor release. Marking this later would itself be
+// the major change, so it cannot wait for the conversion to be convenient.
+#[non_exhaustive]
 pub struct NodeRunConfig {
     /// Inputs for the nodes as a map from input ID to `node_id/output_id`.
     ///

--- a/libraries/message/src/descriptor.rs
+++ b/libraries/message/src/descriptor.rs
@@ -71,6 +71,11 @@ pub const DYNAMIC_SOURCE: &str = "dynamic";
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 #[schemars(title = "dora-rs specification")]
+// Same rationale as `Node`: keeps a new *dataflow-level* key a minor release.
+// This is where `exit_when_nodes_finish`, `health_check_interval`, `type_rules`
+// and `strict_types` landed, so it grows at least as often as `Node` does.
+// Construct with `Descriptor::new`; the fields remain `pub`.
+#[non_exhaustive]
 pub struct Descriptor {
     /// List of nodes in the dataflow
     ///
@@ -184,6 +189,28 @@ pub struct Descriptor {
     pub env: Option<BTreeMap<String, EnvValue>>,
 }
 
+impl Descriptor {
+    /// A dataflow of `nodes` with every dataflow-level option left at its
+    /// default (the state a YAML file with only a `nodes:` key deserializes
+    /// to).
+    ///
+    /// `Descriptor` is `#[non_exhaustive]`, so other crates cannot build one
+    /// with a struct literal. Start here and assign the options you need — the
+    /// fields are all still `pub`.
+    pub fn new(nodes: Vec<Node>) -> Self {
+        Self {
+            nodes,
+            deploy: None,
+            debug: Default::default(),
+            health_check_interval: None,
+            strict_types: None,
+            exit_when_nodes_finish: None,
+            type_rules: Default::default(),
+            env: None,
+        }
+    }
+}
+
 /// A type compatibility rule declared in the dataflow YAML.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
@@ -213,8 +240,12 @@ pub enum RestartPolicy {
 }
 
 /// Deployment configuration for distributing nodes across machines.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
+// Same rationale as `Node`: keeps a new deployment key a minor release.
+// Every field has a meaningful default, so `Deploy::default()` is the
+// construction entry point rather than a bespoke `new`.
+#[non_exhaustive]
 pub struct Deploy {
     /// Target machine for deployment
     pub machine: Option<String>,
@@ -987,6 +1018,11 @@ impl Node {
 
 #[allow(missing_docs)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
+// Same rationale as `Node`: keeps a new per-node key a minor release. This is
+// where keys that are not custom-node-specific land — `cpu_affinity` and
+// `deploy` are threaded `Node` -> `ResolvedNode` without passing through
+// `CustomNode`. Construct with `ResolvedNode::new`; the fields remain `pub`.
+#[non_exhaustive]
 pub struct ResolvedNode {
     pub id: NodeId,
     pub name: Option<String>,
@@ -1005,6 +1041,24 @@ pub struct ResolvedNode {
 
 #[allow(missing_docs)]
 impl ResolvedNode {
+    /// A resolved node with the given ID and kind, and every other field left
+    /// at its default.
+    ///
+    /// `ResolvedNode` is `#[non_exhaustive]`, so other crates cannot build one
+    /// with a struct literal. Start here and assign the fields you need — they
+    /// are all still `pub`.
+    pub fn new(id: NodeId, kind: CoreNodeKind) -> Self {
+        Self {
+            id,
+            name: None,
+            description: None,
+            env: None,
+            cpu_affinity: None,
+            deploy: None,
+            kind,
+        }
+    }
+
     pub fn has_git_source(&self) -> bool {
         self.kind
             .as_custom()

--- a/libraries/message/src/descriptor.rs
+++ b/libraries/message/src/descriptor.rs
@@ -68,10 +68,6 @@ pub const DYNAMIC_SOURCE: &str = "dynamic";
 /// # Ok(())
 /// # }
 /// ```
-///
-/// Construct with [`Descriptor::new`], then assign: `Descriptor` is
-/// `#[non_exhaustive]`, so struct literals and `..Default::default()` do not
-/// work from another crate. The fields stay `pub`.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 #[schemars(title = "dora-rs specification")]
@@ -282,15 +278,12 @@ pub enum RestartPolicy {
 }
 
 /// Deployment configuration for distributing nodes across machines.
-///
-/// Construct with `Deploy::default()`, then assign: `Deploy` is
-/// `#[non_exhaustive]`, so struct literals and `..Default::default()` do not
-/// work from another crate. The fields stay `pub`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 // Same rationale as `Node`: keeps a new deployment key a minor release.
 // Every field has a meaningful default, so `Deploy::default()` is the
-// construction entry point rather than a bespoke `new`.
+// construction entry point rather than a bespoke `new`; the fields remain
+// `pub`.
 #[non_exhaustive]
 pub struct Deploy {
     /// Target machine for deployment
@@ -320,14 +313,12 @@ pub enum DistributeStrategy {
 }
 
 /// Debug options for dataflow development and troubleshooting.
-///
-/// Construct with `Debug::default()`, then assign: `Debug` is
-/// `#[non_exhaustive]`, so struct literals do not work from another crate.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 // See the note on `Node`: `debug:` is a dataflow-level YAML surface and a
 // second debug option must stay a minor release. Every field has a meaningful
-// default, so `Debug::default()` is the construction entry point.
+// default, so `Debug::default()` is the construction entry point; the fields
+// remain `pub`.
 #[non_exhaustive]
 pub struct Debug {
     /// When true, daemons mirror every node output to the coordinator WebSocket
@@ -341,10 +332,6 @@ pub struct Debug {
 ///
 /// A node represents a computational unit in a Dora dataflow. Each node runs as a
 /// separate process and can communicate with other nodes through inputs and outputs.
-///
-/// Construct with [`Node::new`], then assign: `Node` is `#[non_exhaustive]`, so
-/// struct literals and `..Default::default()` do not work from another crate.
-/// The fields stay `pub`.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 // Adding a descriptor key must stay a *minor* release. Without this, every new
@@ -357,6 +344,11 @@ pub struct Debug {
 // marked for the same reason in #3151, and `RunDataflowOptions` in the daemon
 // is the existing struct-shaped precedent. The descriptor *enums* are a
 // separate axis and are not covered — see the note on `RestartPolicy`.
+//
+// The construction advice lives here and on `Node::new`, not in the `///`
+// doc: that doc is the description schemars writes into `dora-schema.json`,
+// which YAML editors show to dataflow authors, and rustdoc already flags
+// `#[non_exhaustive]` types on its own.
 #[non_exhaustive]
 pub struct Node {
     /// Unique node identifier. Must not contain `/` characters.
@@ -1026,8 +1018,11 @@ impl Node {
     /// ```
     /// use dora_message::descriptor::Node;
     ///
-    /// let mut node = Node::new("camera".to_owned().into());
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut node = Node::new("camera".parse()?);
     /// node.path = Some("./camera".to_owned());
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn new(id: NodeId) -> Self {
         Self {
@@ -1076,16 +1071,14 @@ impl Node {
 }
 
 /// A [`Node`] after alias resolution and defaulting, as the daemon runs it.
-///
-/// Construct with [`ResolvedNode::new`], then assign: `ResolvedNode` is
-/// `#[non_exhaustive]`, so struct literals and `..Default::default()` do not
-/// work from another crate. The fields stay `pub`.
 #[allow(missing_docs)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 // Same rationale as `Node`: keeps a new per-node key a minor release. This is
 // where keys that are not custom-node-specific land — `cpu_affinity` and
 // `deploy` are threaded `Node` -> `ResolvedNode` without passing through
-// `CustomNode`.
+// `CustomNode`. Construct with `ResolvedNode::new`; the fields remain `pub`.
+// Resolution itself goes through `ResolvedNode::from_node`, the in-crate
+// literal that keeps a new field a compile error.
 #[non_exhaustive]
 pub struct ResolvedNode {
     pub id: NodeId,
@@ -1119,6 +1112,33 @@ impl ResolvedNode {
             env: None,
             cpu_affinity: None,
             deploy: None,
+            kind,
+        }
+    }
+
+    /// The resolved node for `node`'s node-level keys — `id`, `name`,
+    /// `description`, `env`, `cpu_affinity`, `deploy` — around an already
+    /// resolved `kind`. `env` is carried as declared; merging the
+    /// dataflow-level `env` into it is the caller's job.
+    ///
+    /// The kind-level keys are dropped: for a custom node
+    /// [`CustomNode::from_node`] has already moved them out, and a runtime
+    /// node's live in its `operators`.
+    ///
+    /// This is a struct literal on purpose. `ResolvedNode` is
+    /// `#[non_exhaustive]`, so a literal only compiles here, inside the
+    /// defining crate — exactly where the compiler still insists that every
+    /// field is accounted for. A field added to `ResolvedNode` is a build
+    /// error on this line, not a key that resolution silently leaves at its
+    /// default.
+    pub fn from_node(node: Node, kind: CoreNodeKind) -> Self {
+        Self {
+            id: node.id,
+            name: node.name,
+            description: node.description,
+            env: node.env,
+            cpu_affinity: node.cpu_affinity,
+            deploy: node.deploy,
             kind,
         }
     }
@@ -1169,17 +1189,13 @@ pub struct OperatorDefinition {
     pub config: OperatorConfig,
 }
 
-/// The `operator:` key of a single-operator node.
-///
-/// `#[non_exhaustive]` with no constructor: deserialization is the only way to
-/// build one from another crate. Adding a constructor is a minor change, so
-/// open an issue if you need to build one programmatically.
 #[allow(missing_docs)]
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
 // Same rationale as `Node`: keeps a new operator-level descriptor key a minor
 // release. No constructor yet because nothing constructs one outside this crate
 // — every instance comes from deserialization. Adding a constructor later is
-// itself a minor change, so only the `#[non_exhaustive]` half is time-critical.
+// itself a minor change, so only the `#[non_exhaustive]` half is time-critical;
+// open an issue if you need to build one programmatically.
 #[non_exhaustive]
 pub struct SingleOperatorDefinition {
     /// Operator identifier (optional for single operators)
@@ -1188,17 +1204,17 @@ pub struct SingleOperatorDefinition {
     pub config: OperatorConfig,
 }
 
-/// The per-operator descriptor keys, shared by single- and multi-operator nodes.
-///
-/// `#[non_exhaustive]` with no constructor: deserialization is the only way to
-/// build one from another crate. Adding a constructor is a minor change, so
-/// open an issue if you need to build one programmatically.
 #[allow(missing_docs)]
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
 // Same rationale as `Node`: keeps a new operator-level descriptor key a minor
 // release. No constructor yet because nothing constructs one outside this crate
 // — every instance comes from deserialization. Adding a constructor later is
-// itself a minor change, so only the `#[non_exhaustive]` half is time-critical.
+// itself a minor change, so only the `#[non_exhaustive]` half is time-critical;
+// open an issue if you need to build one programmatically.
+//
+// Kept as a `//` comment deliberately: a `///` doc here is `#[serde(flatten)]`ed
+// by schemars onto `OperatorDefinition`'s entry in `dora-schema.json`, which
+// YAML editors show to dataflow authors.
 #[non_exhaustive]
 pub struct OperatorConfig {
     /// Human-readable operator name
@@ -1336,7 +1352,9 @@ impl OperatorSource {
 #[allow(missing_docs)]
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 // See the note on `Node`: keeps a new resolved-node field a minor release.
-// Construct with `CustomNode::new`; the fields remain `pub`.
+// Construct with `CustomNode::new`; the fields remain `pub`. Resolution goes
+// through `CustomNode::from_node`, the in-crate literal that keeps a new field
+// a compile error rather than a silently dropped descriptor key.
 #[non_exhaustive]
 pub struct CustomNode {
     /// Path of the source code
@@ -1457,6 +1475,58 @@ impl CustomNode {
             health_check_timeout: None,
             finish_grace_secs: None,
             run_config: NodeRunConfig::default(),
+        }
+    }
+
+    /// Move the custom-node keys out of `node` into a `CustomNode` at `path`.
+    ///
+    /// Every key that all custom-node kinds resolve identically is taken from
+    /// `node`, leaving its `Option`s empty and its collections cleared. What
+    /// stays behind are the node-level keys — `id`, `name`, `description`,
+    /// `env`, `cpu_affinity`, `deploy` — for [`ResolvedNode::from_node`] to
+    /// consume next, plus the kind-selection keys (`git`, `hub`, `operators`,
+    /// `ros2`, …) that classification has already read.
+    ///
+    /// `source` and `envs` stay at their defaults: they are the two keys whose
+    /// value depends on the node kind, so the caller sets them — `source` from
+    /// classification for a `path:` node, `envs` for the ROS2 bridge, whose
+    /// `path` is its fixed binary.
+    ///
+    /// This is a struct literal on purpose. `CustomNode` and `NodeRunConfig`
+    /// are `#[non_exhaustive]`, so a literal only compiles here, inside the
+    /// defining crate — exactly where the compiler still insists that every
+    /// field is accounted for. A key added to either struct is a build error
+    /// on this line, not a descriptor key that parses and is then silently
+    /// dropped. `dora-core`'s `every_custom_node_field_is_carried_through`
+    /// checks the values on top.
+    pub fn from_node(node: &mut Node, path: String) -> Self {
+        Self {
+            path,
+            source: NodeSource::Local,
+            path_sha256: node.path_sha256.take(),
+            args: node.args.take(),
+            envs: None,
+            build: node.build.take(),
+            send_stdout_as: node.send_stdout_as.take(),
+            send_logs_as: node.send_logs_as.take(),
+            min_log_level: node.min_log_level.take(),
+            max_log_size: node.max_log_size.take(),
+            max_rotated_files: node.max_rotated_files.take(),
+            restart_policy: node.restart_policy,
+            max_restarts: node.max_restarts,
+            restart_delay: node.restart_delay.take(),
+            max_restart_delay: node.max_restart_delay.take(),
+            restart_window: node.restart_window.take(),
+            health_check_timeout: node.health_check_timeout.take(),
+            finish_grace_secs: node.finish_grace_secs.take(),
+            run_config: NodeRunConfig {
+                inputs: std::mem::take(&mut node.inputs),
+                outputs: std::mem::take(&mut node.outputs),
+                output_types: std::mem::take(&mut node.output_types),
+                output_framing: std::mem::take(&mut node.output_framing),
+                input_types: std::mem::take(&mut node.input_types),
+                shared_memory_pool_size: node.shared_memory_pool_size.take(),
+            },
         }
     }
 }
@@ -1720,61 +1790,68 @@ pub struct Ros2QosConfig {
 mod tests {
     use super::*;
 
-    /// `Node::new` must agree with what serde produces for a YAML node that
-    /// sets nothing but `id`.
+    /// Assert that `constructed` serializes to exactly what `yaml`
+    /// deserializes to — that a hand-written constructor agrees with the
+    /// per-field `#[serde(default)]`s.
     ///
-    /// The two are independent sources of the same defaults: serde's come from
-    /// the per-field `#[serde(default)]` attributes, `Node::new`'s are written
-    /// out by hand. The daemon builds dynamically registered nodes through
-    /// `Node::new` (`Daemon::handle_add_node`) and declared nodes through
-    /// serde, so a divergence — say a field that later grows a
+    /// The two are independent sources of the same defaults, and both are
+    /// used in production: the daemon builds dynamically registered nodes
+    /// through `Node::new` (`Daemon::handle_add_node`) and declared nodes
+    /// through serde, so a divergence — say a field that later grows a
     /// `#[serde(default = "…")]` custom default — would silently give the two
     /// kinds different configuration.
-    #[test]
-    fn node_new_matches_yaml_defaults() {
-        let from_yaml: Node = serde_yaml::from_str("id: some-node\n").unwrap();
-        let constructed = Node::new("some-node".to_owned().into());
+    fn assert_matches_yaml_defaults<T: Serialize + serde::de::DeserializeOwned>(
+        yaml: &str,
+        constructed: T,
+        what: &str,
+    ) {
+        let from_yaml: T = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(
             serde_yaml::to_value(&from_yaml).unwrap(),
             serde_yaml::to_value(&constructed).unwrap(),
-            "`Node::new` drifted from the descriptor defaults serde applies"
+            "`{what}` drifted from the defaults serde applies"
+        );
+    }
+
+    /// `Node::new` must agree with what serde produces for a YAML node that
+    /// sets nothing but `id`.
+    #[test]
+    fn node_new_matches_yaml_defaults() {
+        assert_matches_yaml_defaults(
+            "id: some-node\n",
+            Node::new("some-node".to_owned().into()),
+            "Node::new",
         );
     }
 
     /// The same contract for the other constructors this crate hands out.
     ///
-    /// `Descriptor::new` is what module expansion, the coordinator's `AddNode`
-    /// resolution and the daemon's bench support all build from, and
-    /// `Deploy::default()` is the documented entry point for `deploy:`. Both
-    /// document their result as the state YAML with nothing set deserializes
-    /// to, so a field that later grows a custom `#[serde(default = "…")]`
-    /// would silently give constructed and deserialized values different
-    /// configuration.
+    /// `Descriptor::new` is what the coordinator's `AddNode` resolution and the
+    /// daemon's bench support build from; `Deploy::default()` and
+    /// `Debug::default()` are the documented entry points for `deploy:` and
+    /// `debug:`; `NodeRunConfig::default()` is the runtime node's I/O config in
+    /// the daemon while custom nodes deserialize theirs.
     ///
-    /// `CustomNode::new` is not covered here: it has no YAML surface of its own
-    /// (resolution is the only producer), so its equivalent guard is
-    /// `dora_core::descriptor::tests::every_custom_node_field_is_carried_through`.
+    /// `CustomNode::new` is not covered here: `source` and `envs` have no serde
+    /// default, so there is no "nothing set" YAML for it. Its guard is
+    /// `CustomNode::from_node` — a struct literal in this crate, so a new field
+    /// is a compile error — plus
+    /// `dora_core::descriptor::tests::every_custom_node_field_is_carried_through`
+    /// for the values.
     #[test]
     fn constructors_match_yaml_defaults() {
-        let from_yaml: Descriptor = serde_yaml::from_str("nodes: []\n").unwrap();
-        assert_eq!(
-            serde_yaml::to_value(&from_yaml).unwrap(),
-            serde_yaml::to_value(Descriptor::new(Vec::new())).unwrap(),
-            "`Descriptor::new` drifted from the dataflow-level defaults serde applies"
+        assert_matches_yaml_defaults(
+            "nodes: []\n",
+            Descriptor::new(Vec::new()),
+            "Descriptor::new",
         );
-
-        let from_yaml: Deploy = serde_yaml::from_str("{}\n").unwrap();
-        assert_eq!(
-            serde_yaml::to_value(&from_yaml).unwrap(),
-            serde_yaml::to_value(Deploy::default()).unwrap(),
-            "`Deploy::default` drifted from the deploy defaults serde applies"
-        );
-
-        let from_yaml: Debug = serde_yaml::from_str("{}\n").unwrap();
-        assert_eq!(
-            serde_yaml::to_value(&from_yaml).unwrap(),
-            serde_yaml::to_value(Debug::default()).unwrap(),
-            "`Debug::default` drifted from the debug defaults serde applies"
+        assert_matches_yaml_defaults("{}\n", Deploy::default(), "Deploy::default");
+        assert_matches_yaml_defaults("{}\n", Debug::default(), "Debug::default");
+        assert_matches_yaml_defaults("{}\n", NodeRunConfig::default(), "NodeRunConfig::default");
+        assert_matches_yaml_defaults(
+            "from: a\nto: b\n",
+            TypeRuleDef::new("a".to_owned(), "b".to_owned()),
+            "TypeRuleDef::new",
         );
     }
 

--- a/libraries/message/src/descriptor.rs
+++ b/libraries/message/src/descriptor.rs
@@ -1053,6 +1053,11 @@ pub struct OperatorDefinition {
 
 #[allow(missing_docs)]
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
+// Same rationale as `Node`: keeps a new operator-level descriptor key a minor
+// release. No constructor yet because nothing constructs one outside this crate
+// — every instance comes from deserialization. Adding a constructor later is
+// itself a minor change, so only the `#[non_exhaustive]` half is time-critical.
+#[non_exhaustive]
 pub struct SingleOperatorDefinition {
     /// Operator identifier (optional for single operators)
     pub id: Option<OperatorId>,
@@ -1062,6 +1067,11 @@ pub struct SingleOperatorDefinition {
 
 #[allow(missing_docs)]
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
+// Same rationale as `Node`: keeps a new operator-level descriptor key a minor
+// release. No constructor yet because nothing constructs one outside this crate
+// — every instance comes from deserialization. Adding a constructor later is
+// itself a minor change, so only the `#[non_exhaustive]` half is time-critical.
+#[non_exhaustive]
 pub struct OperatorConfig {
     /// Human-readable operator name
     pub name: Option<String>,

--- a/libraries/message/src/descriptor.rs
+++ b/libraries/message/src/descriptor.rs
@@ -68,6 +68,10 @@ pub const DYNAMIC_SOURCE: &str = "dynamic";
 /// # Ok(())
 /// # }
 /// ```
+///
+/// Construct with [`Descriptor::new`], then assign: `Descriptor` is
+/// `#[non_exhaustive]`, so struct literals and `..Default::default()` do not
+/// work from another crate. The fields stay `pub`.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 #[schemars(title = "dora-rs specification")]
@@ -214,6 +218,10 @@ impl Descriptor {
 /// A type compatibility rule declared in the dataflow YAML.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
+// See the note on `Node`: `type_rules:` is a dataflow-level YAML surface, so a
+// per-rule option added later (a direction flag, a coercion mode) must stay a
+// minor release. Construct with `TypeRuleDef::new`; the fields remain `pub`.
+#[non_exhaustive]
 pub struct TypeRuleDef {
     /// Source type URN
     pub from: String,
@@ -221,9 +229,43 @@ pub struct TypeRuleDef {
     pub to: String,
 }
 
+impl TypeRuleDef {
+    /// A rule declaring that `from` is compatible with `to`.
+    ///
+    /// `TypeRuleDef` is `#[non_exhaustive]`, so other crates cannot build one
+    /// with a struct literal. Start here and assign any further options — the
+    /// fields are all still `pub`.
+    pub fn new(from: String, to: String) -> Self {
+        Self { from, to }
+    }
+}
+
 /// Specifies when a node should be restarted.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
+// The descriptor *enums* — this one, `OutputFraming`, `DistributeStrategy`,
+// `NodeSource`, `GitRepoRev`, `EnvValue`, `OperatorSource`, `PythonSourceDef`,
+// the four `Ros2*` enums and `config::QueuePolicy` — are deliberately NOT
+// `#[non_exhaustive]`, unlike the descriptor structs.
+//
+// The cost of that is real and known: adding a variant (`restart-policy:
+// unless-stopped`, a third `output_framing`, an rsync `distribute` strategy) is
+// `enum_variant_added` — a semver-major break — so it cannot land until 2.0.
+//
+// It is deliberate because the alternative is worse here. `#[non_exhaustive]`
+// forces a `_ =>` arm in every downstream match. Marking all of them stops the
+// build with 11 such matches in `dora-core` and the ROS2 bridge alone, before
+// it even reaches the ones in `dora-daemon` and `dora-cli` — restart decisions,
+// git-ref resolution, lockfile cache keys, operator-runtime dispatch, ROS2
+// transport selection. Those crates ship in lockstep with this one, so today a
+// new variant is a compile error naming every site that must handle it; behind
+// a catch-all it becomes a silent wrong answer (a new `GitRepoRev` colliding in
+// the build lockfile key, a new `RestartPolicy` reading as "never restart").
+// Exhaustive matching is the thing actually preventing those bugs, and no
+// external consumer gets a comparable guarantee back.
+//
+// The structs have no such tension: a new field breaks only struct literals,
+// which the `::new` constructors already replace.
 pub enum RestartPolicy {
     /// Never restart the node (default)
     #[default]
@@ -240,6 +282,10 @@ pub enum RestartPolicy {
 }
 
 /// Deployment configuration for distributing nodes across machines.
+///
+/// Construct with `Deploy::default()`, then assign: `Deploy` is
+/// `#[non_exhaustive]`, so struct literals and `..Default::default()` do not
+/// work from another crate. The fields stay `pub`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 // Same rationale as `Node`: keeps a new deployment key a minor release.
@@ -274,8 +320,15 @@ pub enum DistributeStrategy {
 }
 
 /// Debug options for dataflow development and troubleshooting.
+///
+/// Construct with `Debug::default()`, then assign: `Debug` is
+/// `#[non_exhaustive]`, so struct literals do not work from another crate.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
+// See the note on `Node`: `debug:` is a dataflow-level YAML surface and a
+// second debug option must stay a minor release. Every field has a meaningful
+// default, so `Debug::default()` is the construction entry point.
+#[non_exhaustive]
 pub struct Debug {
     /// When true, daemons mirror every node output to the coordinator WebSocket
     /// so that `dora topic echo`, `dora topic hz`, and `dora topic info` can
@@ -288,6 +341,10 @@ pub struct Debug {
 ///
 /// A node represents a computational unit in a Dora dataflow. Each node runs as a
 /// separate process and can communicate with other nodes through inputs and outputs.
+///
+/// Construct with [`Node::new`], then assign: `Node` is `#[non_exhaustive]`, so
+/// struct literals and `..Default::default()` do not work from another crate.
+/// The fields stay `pub`.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 // Adding a descriptor key must stay a *minor* release. Without this, every new
@@ -295,9 +352,11 @@ pub struct Debug {
 // for `dora-message` — which turns routine feature work into a "land it before
 // the next major or wait" scramble. `Node::new` is the construction entry point
 // for other crates; the fields stay `pub`, so they are still freely readable
-// and assignable. The message enums in this crate are already
-// `#[non_exhaustive]` for the same reason; `RunDataflowOptions` in the daemon
-// is the existing struct-shaped precedent.
+// and assignable. The *wire-protocol* enums in this crate (`daemon_to_node.rs`,
+// `node_to_daemon.rs`, `daemon_to_coordinator.rs`, `daemon_to_daemon.rs`) were
+// marked for the same reason in #3151, and `RunDataflowOptions` in the daemon
+// is the existing struct-shaped precedent. The descriptor *enums* are a
+// separate axis and are not covered — see the note on `RestartPolicy`.
 #[non_exhaustive]
 pub struct Node {
     /// Unique node identifier. Must not contain `/` characters.
@@ -1016,12 +1075,17 @@ impl Node {
     }
 }
 
+/// A [`Node`] after alias resolution and defaulting, as the daemon runs it.
+///
+/// Construct with [`ResolvedNode::new`], then assign: `ResolvedNode` is
+/// `#[non_exhaustive]`, so struct literals and `..Default::default()` do not
+/// work from another crate. The fields stay `pub`.
 #[allow(missing_docs)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 // Same rationale as `Node`: keeps a new per-node key a minor release. This is
 // where keys that are not custom-node-specific land — `cpu_affinity` and
 // `deploy` are threaded `Node` -> `ResolvedNode` without passing through
-// `CustomNode`. Construct with `ResolvedNode::new`; the fields remain `pub`.
+// `CustomNode`.
 #[non_exhaustive]
 pub struct ResolvedNode {
     pub id: NodeId,
@@ -1105,6 +1169,11 @@ pub struct OperatorDefinition {
     pub config: OperatorConfig,
 }
 
+/// The `operator:` key of a single-operator node.
+///
+/// `#[non_exhaustive]` with no constructor: deserialization is the only way to
+/// build one from another crate. Adding a constructor is a minor change, so
+/// open an issue if you need to build one programmatically.
 #[allow(missing_docs)]
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
 // Same rationale as `Node`: keeps a new operator-level descriptor key a minor
@@ -1119,6 +1188,11 @@ pub struct SingleOperatorDefinition {
     pub config: OperatorConfig,
 }
 
+/// The per-operator descriptor keys, shared by single- and multi-operator nodes.
+///
+/// `#[non_exhaustive]` with no constructor: deserialization is the only way to
+/// build one from another crate. Adding a constructor is a minor change, so
+/// open an issue if you need to build one programmatically.
 #[allow(missing_docs)]
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
 // Same rationale as `Node`: keeps a new operator-level descriptor key a minor
@@ -1664,6 +1738,43 @@ mod tests {
             serde_yaml::to_value(&from_yaml).unwrap(),
             serde_yaml::to_value(&constructed).unwrap(),
             "`Node::new` drifted from the descriptor defaults serde applies"
+        );
+    }
+
+    /// The same contract for the other constructors this crate hands out.
+    ///
+    /// `Descriptor::new` is what module expansion, the coordinator's `AddNode`
+    /// resolution and the daemon's bench support all build from, and
+    /// `Deploy::default()` is the documented entry point for `deploy:`. Both
+    /// document their result as the state YAML with nothing set deserializes
+    /// to, so a field that later grows a custom `#[serde(default = "…")]`
+    /// would silently give constructed and deserialized values different
+    /// configuration.
+    ///
+    /// `CustomNode::new` is not covered here: it has no YAML surface of its own
+    /// (resolution is the only producer), so its equivalent guard is
+    /// `dora_core::descriptor::tests::every_custom_node_field_is_carried_through`.
+    #[test]
+    fn constructors_match_yaml_defaults() {
+        let from_yaml: Descriptor = serde_yaml::from_str("nodes: []\n").unwrap();
+        assert_eq!(
+            serde_yaml::to_value(&from_yaml).unwrap(),
+            serde_yaml::to_value(Descriptor::new(Vec::new())).unwrap(),
+            "`Descriptor::new` drifted from the dataflow-level defaults serde applies"
+        );
+
+        let from_yaml: Deploy = serde_yaml::from_str("{}\n").unwrap();
+        assert_eq!(
+            serde_yaml::to_value(&from_yaml).unwrap(),
+            serde_yaml::to_value(Deploy::default()).unwrap(),
+            "`Deploy::default` drifted from the deploy defaults serde applies"
+        );
+
+        let from_yaml: Debug = serde_yaml::from_str("{}\n").unwrap();
+        assert_eq!(
+            serde_yaml::to_value(&from_yaml).unwrap(),
+            serde_yaml::to_value(Debug::default()).unwrap(),
+            "`Debug::default` drifted from the debug defaults serde applies"
         );
     }
 

--- a/libraries/message/src/descriptor.rs
+++ b/libraries/message/src/descriptor.rs
@@ -259,6 +259,15 @@ pub struct Debug {
 /// separate process and can communicate with other nodes through inputs and outputs.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
+// Adding a descriptor key must stay a *minor* release. Without this, every new
+// per-node field is `constructible_struct_adds_field` — a semver-major break
+// for `dora-message` — which turns routine feature work into a "land it before
+// the next major or wait" scramble. `Node::new` is the construction entry point
+// for other crates; the fields stay `pub`, so they are still freely readable
+// and assignable. The message enums in this crate are already
+// `#[non_exhaustive]` for the same reason; `RunDataflowOptions` in the daemon
+// is the existing struct-shaped precedent.
+#[non_exhaustive]
 pub struct Node {
     /// Unique node identifier. Must not contain `/` characters.
     ///
@@ -916,6 +925,66 @@ pub struct Node {
     pub deploy: Option<Deploy>,
 }
 
+impl Node {
+    /// A node with the given ID and every other field left at its descriptor
+    /// default (the state a YAML node with only an `id:` key deserializes to).
+    ///
+    /// `Node` is `#[non_exhaustive]`, so other crates cannot build one with a
+    /// struct literal. Start here and assign the fields you need — they are all
+    /// still `pub`:
+    ///
+    /// ```
+    /// use dora_message::descriptor::Node;
+    ///
+    /// let mut node = Node::new("camera".to_owned().into());
+    /// node.path = Some("./camera".to_owned());
+    /// ```
+    pub fn new(id: NodeId) -> Self {
+        Self {
+            id,
+            name: None,
+            description: None,
+            path: None,
+            path_sha256: None,
+            args: None,
+            env: None,
+            operators: None,
+            operator: None,
+            ros2: None,
+            outputs: Default::default(),
+            output_types: Default::default(),
+            output_framing: Default::default(),
+            inputs: Default::default(),
+            input_types: Default::default(),
+            shared_memory_pool_size: None,
+            output_metadata: Default::default(),
+            pattern: None,
+            send_stdout_as: None,
+            send_logs_as: None,
+            min_log_level: None,
+            max_log_size: None,
+            max_rotated_files: None,
+            build: None,
+            git: None,
+            hub: None,
+            branch: None,
+            tag: None,
+            rev: None,
+            restart_policy: Default::default(),
+            max_restarts: 0,
+            restart_delay: None,
+            max_restart_delay: None,
+            restart_window: None,
+            health_check_timeout: None,
+            finish_grace_secs: None,
+            module: None,
+            params: Default::default(),
+            cpu_affinity: None,
+            deploy: None,
+        }
+    }
+}
+
 #[allow(missing_docs)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResolvedNode {
@@ -1128,6 +1197,9 @@ impl OperatorSource {
 
 #[allow(missing_docs)]
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+// See the note on `Node`: keeps a new resolved-node field a minor release.
+// Construct with `CustomNode::new`; the fields remain `pub`.
+#[non_exhaustive]
 pub struct CustomNode {
     /// Path of the source code
     ///
@@ -1217,6 +1289,38 @@ pub struct CustomNode {
 
     #[serde(flatten)]
     pub run_config: NodeRunConfig,
+}
+
+impl CustomNode {
+    /// A local-source node at `path` with every other field left at its
+    /// default.
+    ///
+    /// `CustomNode` is `#[non_exhaustive]`, so other crates cannot build one
+    /// with a struct literal. Start here and assign the fields you need — they
+    /// are all still `pub`.
+    pub fn new(path: String) -> Self {
+        Self {
+            path,
+            source: NodeSource::Local,
+            path_sha256: None,
+            args: None,
+            envs: None,
+            build: None,
+            send_stdout_as: None,
+            send_logs_as: None,
+            min_log_level: None,
+            max_log_size: None,
+            max_rotated_files: None,
+            restart_policy: Default::default(),
+            max_restarts: 0,
+            restart_delay: None,
+            max_restart_delay: None,
+            restart_window: None,
+            health_check_timeout: None,
+            finish_grace_secs: None,
+            run_config: NodeRunConfig::default(),
+        }
+    }
 }
 
 #[allow(missing_docs)]
@@ -1477,6 +1581,27 @@ pub struct Ros2QosConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `Node::new` must agree with what serde produces for a YAML node that
+    /// sets nothing but `id`.
+    ///
+    /// The two are independent sources of the same defaults: serde's come from
+    /// the per-field `#[serde(default)]` attributes, `Node::new`'s are written
+    /// out by hand. The daemon builds dynamically registered nodes through
+    /// `Node::new` (`Daemon::handle_add_node`) and declared nodes through
+    /// serde, so a divergence — say a field that later grows a
+    /// `#[serde(default = "…")]` custom default — would silently give the two
+    /// kinds different configuration.
+    #[test]
+    fn node_new_matches_yaml_defaults() {
+        let from_yaml: Node = serde_yaml::from_str("id: some-node\n").unwrap();
+        let constructed = Node::new("some-node".to_owned().into());
+        assert_eq!(
+            serde_yaml::to_value(&from_yaml).unwrap(),
+            serde_yaml::to_value(&constructed).unwrap(),
+            "`Node::new` drifted from the descriptor defaults serde applies"
+        );
+    }
 
     #[test]
     fn ros2_transport_defaults_to_dds() {


### PR DESCRIPTION
Marks the descriptor structs `#[non_exhaustive]` so that adding a descriptor key stays a **minor** release.

Today they have all-`pub` fields and no `#[non_exhaustive]`, so any new key is `constructible_struct_adds_field` — a semver-major break for `dora-message`. That makes every future descriptor field a "land it before the next major or wait" scramble; `startup_timeout` (#3022, #3360) is the one that surfaced it. `#[non_exhaustive]` is itself a major change, so it has to land before 1.0.0 is published or it is blocked until 2.0.

Covered: `Node`, `CustomNode`, `Descriptor`, `ResolvedNode`, `Deploy`, `OperatorConfig`, `SingleOperatorDefinition`, plus `Debug`, `TypeRuleDef` and `NodeRunConfig`. That spans where descriptor keys have actually landed — of the four public-field additions to `descriptor.rs`/`config.rs` since 2026-06-06, two went to `Node`/`CustomNode` and one (`exit_when_nodes_finish`, #2974) to `Descriptor`. `ResolvedNode` matters because `cpu_affinity` and `deploy` are threaded `Node` -> `ResolvedNode` without passing through `CustomNode`. `NodeRunConfig` matters because its six fields are `#[serde(flatten)]` into `CustomNode` (and `Node` declares the same six keys), so they are top-level per-node YAML keys — and marking it later would itself be the major change.

Other crates construct through `Node::new(id)`, `CustomNode::new(path)`, `Descriptor::new(nodes)`, `ResolvedNode::new(id, kind)`, `TypeRuleDef::new(from, to)` and `Deploy::default()` / `Debug::default()` / `NodeRunConfig::default()`, then assign what they need — the fields stay `pub`. `#[non_exhaustive]` also bans functional-update syntax across crate boundaries, so `..Default::default()` is not an escape hatch either.

The descriptor **enums** are deliberately left exhaustive, with the reasoning on `RestartPolicy`. Marking them stops the build at 11 matches in `dora-core` and the ROS2 bridge alone, before reaching `dora-daemon` and `dora-cli` — restart decisions, git-ref resolution, lockfile cache keys, operator-runtime dispatch, transport selection. Those crates ship in lockstep with `dora-message`, so a new variant is currently a compile error naming every site that must handle it; behind a `_ =>` arm it becomes a silent wrong answer. The cost is stated rather than glossed: a new variant is major until 2.0.

No wire-format, YAML or JSON-schema change: the construction guidance lives in `//` comments and on the `new` fns, not in the `///` docs that schemars copies into `dora-schema.json` for YAML editors, and the regenerated schema is byte-identical to `main`.

`#[non_exhaustive]` only bans struct literals *across* crate boundaries, so the guarantee the exhaustive literals used to give is kept where it still holds — inside `dora-message` — rather than replaced by tests:

- `CustomNode::from_node(&mut Node, path)` and `ResolvedNode::from_node(Node, kind)` are struct literals in `dora-message`. Resolution in `dora-core` calls them in sequence (the first drains the custom-node keys, the second consumes the node-level ones) and sets only what depends on the kind: `source` for a `path:` node, `envs` for the ROS2 bridge. A field added to `CustomNode`, `NodeRunConfig` or `ResolvedNode` is a compile error on the literal, not a descriptor key that parses and is silently dropped.
- `every_custom_node_field_is_carried_through`, `git_source_is_carried_through` and `ros2_bridge_node_is_carried_through` cover the values: each resolves a node whose YAML sets every key non-default and asserts every resolved field equals what the YAML declared (so a same-typed swap fails too), plus the kind-specific `source` / `path` / `envs`. `node_level_keys_are_carried_through` does the same for `name`, `description`, merged `env`, `cpu_affinity` and `deploy`.
- `node_new_matches_yaml_defaults` and `constructors_match_yaml_defaults` assert `Node::new`, `Descriptor::new`, `TypeRuleDef::new`, `Deploy::default`, `Debug::default` and `NodeRunConfig::default` agree with serde's defaults. The daemon builds dynamically registered nodes through `Node::new` and declared nodes through serde, so a divergence would silently give the two kinds different configuration.
- `expand_modules_with_boundaries` clones the source descriptor and swaps `nodes`, rather than listing the dataflow-level options — a field-by-field rebuild is exactly where a future key would be silently dropped for every module-using dataflow.

`docs/migration-from-0.x.md` gains the breaking-change row and a section with the before/after and the per-type entry points, next to the existing `#[non_exhaustive]` wire-protocol-enum section (#3151).

Deliberately left out: `Ros2BridgeConfig` (the ROS2 bridge is outside the stability guarantee), `Input`/`InputDef::WithOptions` (needs a clone helper, since the three production sites are clone-with-one-change), and `RuntimeNode`/`OperatorDefinition` (structurally frozen — new keys land on `OperatorConfig`).
