### PR TITLE
ci: gate every surface dora 1.x freezes, on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -811,10 +811,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Deliberately a shallow checkout. The gate needs one released tag, and
-      # `fetch-depth: 0` would pull 1.3 GB of history on every PR to get it —
-      # breaking-changes.sh resolves the tag name over `ls-remote` and fetches
+      # `fetch-depth: 0` would pull 1.3 GB of history on every PR to get it.
+      # The steps below name the tag over `ls-remote` (no objects) and fetch
       # that single tag at depth 1 instead.
       - uses: actions/checkout@v6
+      # Resolved once and shared with the semver step below. Each resolution
+      # costs an `ls-remote` against a repo with 140-odd tags, and both steps
+      # must compare against the same release anyway.
+      - name: Resolve the release to compare against
+        run: |
+          echo "BREAKING_BASELINE=$(python3 scripts/qa/breaking_changes.py --print-baseline)" \
+            >> "$GITHUB_ENV"
       - name: Frozen surfaces vs the last release
         env:
           # Lets surfaces the last release predates — anything whose snapshot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -810,14 +810,19 @@ jobs:
     name: Breaking changes
     runs-on: ubuntu-latest
     steps:
-      # Deliberately a shallow checkout. The gate needs one released tag, and
-      # `fetch-depth: 0` would pull 1.3 GB of history on every PR to get it.
-      # The steps below name the tag over `ls-remote` (no objects) and fetch
-      # that single tag at depth 1 instead.
+      # Full history, unlike every other job here, because this one compares
+      # against a release tag and the default shallow checkout has no tags at
+      # all. Working around that is the classic shallow-clone tax: `git
+      # describe` and `git merge-base` do not work, which is exactly how the
+      # semver step first broke. Measured on this repo, the extra cost is
+      # small — a depth-1 checkout of one branch is 3.6 MB, all of `main`'s
+      # history is 5.9 MB, and every branch and tag together is 45 MB — so
+      # the tag-fetching machinery it would save was not worth its own bugs.
       - uses: actions/checkout@v6
-      # Resolved once and shared with the semver step below. Each resolution
-      # costs an `ls-remote` against a repo with 140-odd tags, and both steps
-      # must compare against the same release anyway.
+        with:
+          fetch-depth: 0
+      # Resolved once and shared with the semver step below: both halves must
+      # compare against the same release.
       - name: Resolve the release to compare against
         run: |
           echo "BREAKING_BASELINE=$(python3 scripts/qa/breaking_changes.py --print-baseline)" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -842,7 +842,7 @@ jobs:
         with:
           tool: cargo-semver-checks
       - name: Rust API of the crates 1.0 covers
-        run: scripts/qa/semver.sh
+        run: make qa-semver
 
   # ===== License check =====
   # Restored from upstream dora CI — explicit license validation.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@
 #
 #   Cheap (every PR, ~5-10 min):
 #     fmt, clippy, check (cargo check --all + --examples),
-#     typos, audit, unwrap-budget, check-license.
+#     typos, audit, unwrap-budget, breaking-changes, check-license.
 #     These gate entry into the Trunk Merge Queue.
 #
 #   Expensive (push to main, merge-queue batches, workflow_dispatch):
@@ -780,6 +780,69 @@ jobs:
       - name: Install ripgrep
         run: sudo apt-get update && sudo apt-get install -y ripgrep
       - run: make qa-unwrap
+
+  # ===== Compatibility gate =====
+  # dora 1.0 freezes a set of surfaces for the life of 1.x (docs/api-rust.md,
+  # "Stability scope at 1.0"). Until now nothing checked most of them: the
+  # publish-graph gate and the exact version pins are cargo mechanisms, and
+  # cargo-semver-checks — which was laptop-only — sees rustdoc and nothing
+  # else. A deleted `dora` subcommand, a reordered postcard field, a YAML key
+  # that became required, a raised Python floor: all of those would have
+  # reached users with every check green.
+  #
+  # Two steps, cheapest first, because they fail for different reasons and the
+  # first one is nearly free:
+  #
+  #   1. The surface diff. No compilation — every surface is read out of source
+  #      text or a checked-in snapshot on both sides — so it finishes in
+  #      seconds and runs on every PR.
+  #   2. cargo-semver-checks on the crates whose Rust API is covered. This one
+  #      compiles rustdoc for two revisions. It is kept on the PR tier because
+  #      a breaking change is much cheaper to fix before review than after
+  #      release; if it turns out to be the slowest cheap gate, move just this
+  #      step to the expensive tier with the same
+  #      `if: github.event_name != 'pull_request'` the `test` job uses.
+  #
+  # Not here: freshness of the CLI snapshot the first step diffs. That needs
+  # `cargo test -p dora-cli`, which the `test` job already runs on every
+  # merge-queue batch, so a stale snapshot still cannot merge.
+  breaking-changes:
+    name: Breaking changes
+    runs-on: ubuntu-latest
+    steps:
+      # Deliberately a shallow checkout. The gate needs one released tag, and
+      # `fetch-depth: 0` would pull 1.3 GB of history on every PR to get it —
+      # breaking-changes.sh resolves the tag name over `ls-remote` and fetches
+      # that single tag at depth 1 instead.
+      - uses: actions/checkout@v6
+      - name: Frozen surfaces vs the last release
+        env:
+          # Lets surfaces the last release predates — anything whose snapshot
+          # was added after it — still be checked against the PR's base
+          # instead of sitting skipped until the next release.
+          BREAKING_FALLBACK_BASELINE: ${{ github.event.pull_request.base.sha }}
+        run: make qa-breaking ARGS="--fast"
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - name: Pin toolchain set for a stable rust-cache key (see header)
+        shell: bash
+        run: |
+          rustup default "$RUST_VERSION"
+          extra="$(rustup toolchain list | awk '{print $1}' | grep -vF "$RUST_VERSION" || true)"
+          for tc in $extra; do rustup toolchain uninstall "$tc" || true; done
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Its own key: rustdoc JSON for two revisions is a different artifact
+          # set from the dev-profile `workspace` cache, and mixing them would
+          # evict what the compile jobs restore from.
+          shared-key: semver
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-semver-checks
+      - name: Rust API of the crates 1.0 covers
+        run: scripts/qa/semver.sh
 
   # ===== License check =====
   # Restored from upstream dora CI — explicit license validation.

--- a/.github/workflows/regenerate-schemas.yml
+++ b/.github/workflows/regenerate-schemas.yml
@@ -26,6 +26,13 @@ jobs:
         with:
           cache-on-failure: true
 
+      # Schemas only, deliberately. `binaries/cli/cli-surface.txt` is the same
+      # shape of generated artifact, but it cannot drift on `main`: the
+      # `cli_surface` test fails a merge-queue batch that leaves it stale,
+      # while nothing runs the schema generator before a merge — which is why
+      # the schemas need this self-heal and the snapshot does not. Adding it
+      # here would build the whole CLI on every push to main and cache it,
+      # against a 10 GB per-repo budget (see the ci.yml header).
       - name: Update Schema
         run: cargo run -p dora-core --bin generate_schema
       - name: Open a schema-sync PR if the schema drifted

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,7 @@ make qa-test-python
 # cargo test -p <crate-name>
 ```
 
-**Shortcut**: `make qa-fast` runs fmt + clippy + supply-chain audit + unwrap budget + secret-files + typos + publish-graph in ~30 seconds. Use it as a sanity check before every commit. Then run the full `cargo test` above before `git push`.
+**Shortcut**: `make qa-fast` runs fmt + clippy + supply-chain audit + unwrap budget + secret-files + typos + publish-graph + the no-compile half of the 1.x compatibility gate in ~30 seconds. Use it as a sanity check before every commit. Then run the full `cargo test` above before `git push`.
 
 If you add new example dataflows, also run `./scripts/smoke-all.sh --rust-only` to verify smoke tests pass.
 
@@ -176,11 +176,12 @@ The deeper QA gates — `make qa-full`, `make qa-deep`, `make qa-nightly`, `make
 - `make qa-examples` — ~15-20 min. Runs all **smoke-eligible** example dataflows end-to-end via `scripts/smoke-all.sh`. Skips examples that need CUDA, ROS2, webcam, multi-machine deploy, C/C++ toolchains, or interactive CLI (run `scripts/smoke-all.sh -h` to see the SKIP list). Orthogonal to the qa-fast/full/deep ladder: those targets `--exclude dora-examples` to keep per-commit / pre-push budgets tight. Run this when you want actual dataflows exercised (after touching node/operator APIs, CLI subcommands, or the descriptor surface). Pass flags via `ARGS`, e.g. `make qa-examples ARGS="--rust-only"` or `make qa-examples ARGS="-v"`.
 - `make qa-coverage` — generates an lcov report locally. Run when you want to see what's covered.
 - `make qa-mutants` — mutation testing, slow. Run when investigating test quality on a specific file or on the PR diff.
-- `make qa-semver` — breaking-change check. Run before publishing to crates.io.
+- `make qa-semver` — the Rust-API half of the breaking-change check. Run before publishing to crates.io; `make qa-breaking` runs it as one step among the others.
+- `make qa-breaking` — the dora 1.x compatibility gate: every surface the 1.0 guarantee freezes, checked against the last release tag (`docs/api-rust.md`, "Stability scope at 1.0"). **Not a deep gate** — its no-compile half is in `qa-fast` and in PR CI, taking ~2 s. The default (full) form adds `cargo-semver-checks` and rebuilds the CLI/schema snapshots to prove they are current; run that when you touched the CLI, the descriptor, `dora-message`, or a node API. `make qa-breaking-update` re-records the snapshots after an addition.
 - `make qa-kani` — ~5-10 min cold, <1 min warm. Formal verification: runs the `#[kani::proof]` harnesses (Kani/CBMC model checker) in `dora-message` (auth `constant_time_eq`). A passing proof is exhaustive over the harness state space, not sampled. Run when touching files with `#[cfg(kani)]` proof modules and in pre-release gating; install via `make qa-kani-install`. See [`docs/formal-verification.md`](docs/formal-verification.md).
 - `make qa-pgo` — ~30-40 min. Profile-Guided Optimization measurement: builds `dora-cli` with `cargo-pgo` (instrument → train on `examples/benchmark/` → optimize), then runs the benchmark twice (baseline vs PGO) and prints a side-by-side comparison with a +5%-throughput-geomean verdict. Run on your target platform — PGO results don't transfer across OS/arch. macOS-arm64 first-measurement showed +25% throughput geomean, latency unchanged (see [#331](https://github.com/dora-rs/dora/issues/331)). **Do not add to CI** — the build pipeline cost is release-pipeline scope, not per-commit. Install via `make qa-pgo-install`.
 
-**Remote CI is deliberately kept lean** — only the fast hard gates (fmt, clippy, test on Linux, typos, supply chain audit, unwrap budget, publish-graph, E2E, contract tests, benchmark regression, license check) — so it stays fast (~30-45 min critical path) and runner capacity is not a bottleneck. Do not expand PR CI with slow jobs. See [`docs/qa-runbook.md`](docs/qa-runbook.md) for when and how to use each deep gate locally.
+**Remote CI is deliberately kept lean** — only the fast hard gates (fmt, clippy, test on Linux, typos, supply chain audit, unwrap budget, publish-graph, breaking changes, E2E, contract tests, benchmark regression, license check) — so it stays fast (~30-45 min critical path) and runner capacity is not a bottleneck. Do not expand PR CI with slow jobs. See [`docs/qa-runbook.md`](docs/qa-runbook.md) for when and how to use each deep gate locally.
 
 ### Remote CI jobs
 
@@ -197,6 +198,7 @@ The deeper QA gates — `make qa-full`, `make qa-deep`, `make qa-nightly`, `make
 - Unwrap-budget check (production `.unwrap()` / `.expect(` ratchet)
 - Committed-credential check (`make qa-secret-files`, a step in the `Check` job): fails if git tracks a file whose name says it holds a secret. .gitignore is not enough on its own — it does not apply to files arriving through an import or a squash-merge of another repo's history, which is how `.adora-token` reached the public repo (#2194)
 - crates.io publish-graph check (`make qa-publish-graph`, a step in the `Check` job): no published crate may depend on a `publish = false` one, and the ordered publish lists in `release.yml` / `cargo-release.yml` must agree and list every dependency before its dependents (#3304)
+- Breaking-change gate (`make qa-breaking ARGS="--fast"` + `cargo-semver-checks`): every surface dora 1.x freezes — the C header, the cxx bridge, the dataflow YAML schema, the postcard wire format, the `dora` command snapshot, the Python floor, and the Rust API of the covered crates — diffed against the last release tag
 - License check (`cargo-lichking`)
 - Rust toolchain pinned to 1.97.1 (see `.github/workflows/ci.yml`)
 

--- a/Makefile
+++ b/Makefile
@@ -213,10 +213,7 @@ qa-breaking:
 # and the JSON schemas. Run this when a PR *adds* to either surface, and
 # commit the result -- that diff is how the addition gets reviewed.
 qa-breaking-update:
-	@UPDATE_CLI_SURFACE=1 cargo test -p dora-cli --test cli_surface
-	@cargo run --quiet -p dora-core --bin generate_schema
-	@git diff --stat -- dora-schema.json libraries/core/dora-schema.json \
-		libraries/core/dora-node-schema.json binaries/cli/cli-surface.txt
+	@scripts/qa/breaking-changes.sh --update
 
 # Check that a published release is complete: every crate on release.yml's
 # publish list is on crates.io, both wheels are on PyPI with the full

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@
 .PHONY: qa qa-fast qa-full qa-deep qa-tier1 qa-nightly qa-release-gate qa-mutation-audit \
         qa-examples qa-cluster-e2e qa-cluster-record-replay ros2-zenoh-humble ros2-zenoh-kilted \
         qa-fmt qa-audit qa-unwrap qa-secret-files qa-publish-graph qa-clippy qa-test qa-test-python \
-        qa-test-python-node qa-coverage qa-mutants qa-semver \
+        qa-test-python-node qa-coverage qa-mutants qa-semver qa-breaking qa-breaking-update \
         qa-adversarial qa-kani qa-pgo qa-install qa-pgo-install qa-kani-install \
         qa-verify-release
 
@@ -196,6 +196,27 @@ qa-mutants:
 
 qa-semver:
 	@scripts/qa/semver.sh
+
+# The dora 1.x compatibility gate: every surface the 1.0 guarantee freezes,
+# checked against the last released tag (docs/api-rust.md, "Stability scope
+# at 1.0"). `ARGS="--fast"` drops to the no-compile checks (seconds) -- that
+# subset is what PR CI runs and what `make qa-fast` includes; the default
+# adds cargo-semver-checks and the snapshot-freshness rebuild.
+#
+#   make qa-breaking
+#   make qa-breaking ARGS="--fast"
+#   make qa-breaking ARGS="--baseline v1.0.0"
+qa-breaking:
+	@scripts/qa/breaking-changes.sh $(ARGS)
+
+# Re-record the generated inputs the gate diffs: the `dora` command snapshot
+# and the JSON schemas. Run this when a PR *adds* to either surface, and
+# commit the result -- that diff is how the addition gets reviewed.
+qa-breaking-update:
+	@UPDATE_CLI_SURFACE=1 cargo test -p dora-cli --test cli_surface
+	@cargo run --quiet -p dora-core --bin generate_schema
+	@git diff --stat -- dora-schema.json libraries/core/dora-schema.json \
+		libraries/core/dora-node-schema.json binaries/cli/cli-surface.txt
 
 # Check that a published release is complete: every crate on release.yml's
 # publish list is on crates.io, both wheels are on PyPI with the full

--- a/README.md
+++ b/README.md
@@ -651,6 +651,7 @@ cargo install typos-cli
 - **Property testing** -- `proptest` on wire-protocol types; catches edge cases unit tests miss
 - **Miri** -- UB detection on pure-Rust unsafe hotspots (e.g., `dora-core::metadata`)
 - **SemVer check** -- `cargo-semver-checks` against the last git tag
+- **Breaking-change gate** -- every surface dora 1.x freezes, diffed against the last release tag: the C header, the cxx bridge, the dataflow YAML schema, the postcard wire format, the `dora` command, the Python floor, and the Rust API of the covered crates. Runs on every PR; the surface half needs no build (`make qa-breaking`)
 - **Adversarial LLM review** -- `scripts/qa/adversarial.sh` runs a *different* model on your diff to catch single-model blind spots (local today; CI pending API secret)
 
 **Reference docs:**

--- a/binaries/cli/cli-surface.txt
+++ b/binaries/cli/cli-surface.txt
@@ -365,6 +365,7 @@ dora trace view | <trace_id> (required)
 dora up
 dora up | --auth
 dora up | --config <value>
+dora up | --interface <value>
 dora up | --recreate-store
 dora validate
 dora validate | --node-manifest <value>

--- a/binaries/cli/cli-surface.txt
+++ b/binaries/cli/cli-surface.txt
@@ -1,0 +1,373 @@
+# The `dora` command surface, frozen for dora 1.x (docs/api-rust.md).
+#
+# Generated -- do not edit by hand:
+#     UPDATE_CLI_SURFACE=1 cargo test -p dora-cli --test cli_surface
+#
+# One line per command, then one per argument. Hidden commands are included:
+# `dora daemon` and `dora coordinator` are undocumented but scripted against.
+# Removing any line is a breaking change; adding one is not.
+
+dora
+dora build
+dora build | --coordinator-addr <value>
+dora build | --coordinator-port <value>
+dora build | --hub-override <value>
+dora build | --local
+dora build | --locked
+dora build | --lockfile <value>
+dora build | --offline
+dora build | --parallel
+dora build | --strict-types
+dora build | --uv
+dora build | --write-lockfile
+dora build | <dataflow> (required)
+dora clean
+dora clean | --coordinator-addr <value>
+dora clean | --coordinator-port <value>
+dora clean | -f/--format <value>
+dora clean | -q/--quiet
+dora cluster
+dora cluster down
+dora cluster down | --coordinator-addr <value>
+dora cluster down | --coordinator-port <value>
+dora cluster install
+dora cluster install | <config> (required)
+dora cluster restart
+dora cluster restart | <config> (required)
+dora cluster restart | <dataflow> (required)
+dora cluster status
+dora cluster status | --coordinator-addr <value>
+dora cluster status | --coordinator-port <value>
+dora cluster uninstall
+dora cluster uninstall | <config> (required)
+dora cluster up
+dora cluster up | <config> (required)
+dora cluster upgrade
+dora cluster upgrade | <config> (required)
+dora completion
+dora completion | <shell>
+dora coordinator
+dora coordinator | --auth
+dora coordinator | --interface <value>
+dora coordinator | --port <value>
+dora coordinator | --quiet
+dora coordinator | --store <value>
+dora daemon
+dora daemon | --allow-shell-nodes
+dora daemon | --coordinator-port <value>
+dora daemon | --labels <value>
+dora daemon | --local-listen-port <value>
+dora daemon | --machine-id <value>
+dora daemon | --quiet
+dora daemon | --rt
+dora daemon | --run-dataflow <value>
+dora daemon | --worker-threads <value>
+dora daemon | --zenoh-config-overlay <value>
+dora daemon | --zenoh-connect <value>
+dora daemon | --zenoh-listen <value>
+dora daemon | --zenoh-no-multicast
+dora daemon | --zenoh-peer <value>
+dora daemon | -c/--coordinator-addr <value>
+dora doctor
+dora doctor | --coordinator-addr <value>
+dora doctor | --coordinator-port <value>
+dora doctor | --dataflow <value>
+dora down
+dora down | --config <value>
+dora down | --coordinator-addr <value>
+dora down | --coordinator-port <value>
+dora down | --force
+dora down | alias: destroy
+dora expand
+dora expand | --module
+dora expand | <dataflow> (required)
+dora graph
+dora graph | --mermaid
+dora graph | --open
+dora graph | <dataflow> (required)
+dora hub
+dora hub fetch
+dora hub fetch | --target-dir <value>
+dora hub fetch | <target> (required)
+dora hub info
+dora hub info | --offline
+dora hub info | <package> (required)
+dora hub init
+dora hub init | <path>
+dora hub install
+dora hub install | <_args>
+dora hub list
+dora hub list | <dataflow> (required)
+dora hub outdated
+dora hub outdated | --offline
+dora hub outdated | <dataflow> (required)
+dora hub publish
+dora hub publish | --dry-run
+dora hub publish | --index <value>
+dora hub publish | --repo <value>
+dora hub publish | --rev <value>
+dora hub publish | --version <value>
+dora hub publish | <path>
+dora hub search
+dora hub search | --category <value>
+dora hub search | --offline
+dora hub search | --platform <value>
+dora hub search | <query>
+dora hub update
+dora hub update | --dry-run
+dora hub update | --offline
+dora hub update | <dataflow> (required)
+dora hub yank
+dora hub yank | --reason <value>
+dora hub yank | --undo
+dora hub yank | <package> (required)
+dora inspect
+dora inspect top
+dora inspect top | --coordinator-addr <value>
+dora inspect top | --coordinator-port <value>
+dora inspect top | --once
+dora inspect top | --refresh-interval <value>
+dora list
+dora list | --coordinator-addr <value>
+dora list | --coordinator-port <value>
+dora list | --name <value>
+dora list | --sort-by <value>
+dora list | --status <value>
+dora list | -f/--format <value>
+dora list | -q/--quiet
+dora list | alias: ps
+dora logs
+dora logs | --all-nodes
+dora logs | --coordinator-addr <value>
+dora logs | --coordinator-port <value>
+dora logs | --grep <value>
+dora logs | --level <value>
+dora logs | --local
+dora logs | --log-filter <value>
+dora logs | --log-format <value>
+dora logs | --since <value>
+dora logs | --tail <value>
+dora logs | --until <value>
+dora logs | -f/--follow
+dora logs | -n/--node <value>
+dora logs | <dataflow>
+dora logs | <legacy_node>
+dora new
+dora new | --internal-create-with-path-dependencies
+dora new | --kind <value>
+dora new | --lang <value>
+dora new | <name> (required)
+dora new | <path>
+dora node
+dora node add
+dora node add | --coordinator-addr <value>
+dora node add | --coordinator-port <value>
+dora node add | --from-yaml <value> (required)
+dora node add | -d/--dataflow <value>
+dora node connect
+dora node connect | --coordinator-addr <value>
+dora node connect | --coordinator-port <value>
+dora node connect | -d/--dataflow <value>
+dora node connect | <source> (required)
+dora node connect | <target> (required)
+dora node disconnect
+dora node disconnect | --coordinator-addr <value>
+dora node disconnect | --coordinator-port <value>
+dora node disconnect | -d/--dataflow <value>
+dora node disconnect | <source> (required)
+dora node disconnect | <target> (required)
+dora node info
+dora node info | --coordinator-addr <value>
+dora node info | --coordinator-port <value>
+dora node info | -d/--dataflow <value>
+dora node info | -f/--format <value>
+dora node info | <node> (required)
+dora node list
+dora node list | --coordinator-addr <value>
+dora node list | --coordinator-port <value>
+dora node list | -d/--dataflow <value>
+dora node list | -f/--format <value>
+dora node list | -q/--quiet
+dora node remove
+dora node remove | --coordinator-addr <value>
+dora node remove | --coordinator-port <value>
+dora node remove | --grace <value>
+dora node remove | -d/--dataflow <value>
+dora node remove | <node> (required)
+dora node replace
+dora node replace | --coordinator-addr <value>
+dora node replace | --coordinator-port <value>
+dora node replace | --from-yaml <value> (required)
+dora node replace | --grace <value>
+dora node replace | -d/--dataflow <value>
+dora node replace | <node> (required)
+dora node restart
+dora node restart | --coordinator-addr <value>
+dora node restart | --coordinator-port <value>
+dora node restart | --grace <value>
+dora node restart | -d/--dataflow <value>
+dora node restart | <node> (required)
+dora node stop
+dora node stop | --coordinator-addr <value>
+dora node stop | --coordinator-port <value>
+dora node stop | --grace <value>
+dora node stop | -d/--dataflow <value>
+dora node stop | <node> (required)
+dora param
+dora param delete
+dora param delete | --coordinator-addr <value>
+dora param delete | --coordinator-port <value>
+dora param delete | -d/--dataflow <value>
+dora param delete | <key> (required)
+dora param delete | <node> (required)
+dora param get
+dora param get | --coordinator-addr <value>
+dora param get | --coordinator-port <value>
+dora param get | -d/--dataflow <value>
+dora param get | <key> (required)
+dora param get | <node> (required)
+dora param list
+dora param list | --coordinator-addr <value>
+dora param list | --coordinator-port <value>
+dora param list | --format <value>
+dora param list | -d/--dataflow <value>
+dora param list | <node> (required)
+dora param set
+dora param set | --coordinator-addr <value>
+dora param set | --coordinator-port <value>
+dora param set | -d/--dataflow <value>
+dora param set | <key> (required)
+dora param set | <node> (required)
+dora param set | <value> (required)
+dora record
+dora record | --coordinator-addr <value>
+dora record | --coordinator-port <value>
+dora record | --name <value>
+dora record | --output-yaml <value>
+dora record | --proxy
+dora record | --topics <value>
+dora record | -o/--output <value>
+dora record | <file> (required)
+dora replay
+dora replay | --loop
+dora replay | --output-yaml <value>
+dora replay | --replace <value>
+dora replay | --speed <value>
+dora replay | <file> (required)
+dora restart
+dora restart | --coordinator-addr <value>
+dora restart | --coordinator-port <value>
+dora restart | --grace-duration <value>
+dora restart | -f/--force
+dora restart | -n/--name <value>
+dora restart | <identifier>
+dora run
+dora run | --allow-shell-nodes
+dora run | --debug
+dora run | --env <value>
+dora run | --exit-when-nodes-finish <value>
+dora run | --hub-override <value>
+dora run | --locked
+dora run | --lockfile <value>
+dora run | --log-filter <value>
+dora run | --log-format <value>
+dora run | --log-level <value>
+dora run | --stop-after <value>
+dora run | --uv
+dora run | --write-lockfile
+dora run | <dataflow> (required)
+dora runtime
+dora self
+dora self uninstall
+dora self uninstall | --force
+dora self update
+dora self update | --check-only
+dora start
+dora start | --attach
+dora start | --coordinator-addr <value>
+dora start | --coordinator-port <value>
+dora start | --debug
+dora start | --detach
+dora start | --env <value>
+dora start | --exit-when-nodes-finish <value>
+dora start | --hot-reload
+dora start | --uv
+dora start | -n/--name <value>
+dora start | <dataflow> (required)
+dora status
+dora status | --coordinator-addr <value>
+dora status | --coordinator-port <value>
+dora status | --dataflow <value>
+dora status | -f/--format <value>
+dora status | alias: check
+dora stop
+dora stop | --all
+dora stop | --coordinator-addr <value>
+dora stop | --coordinator-port <value>
+dora stop | --grace-duration <value>
+dora stop | -f/--force
+dora stop | -n/--name <value>
+dora stop | <identifier>
+dora system
+dora system status
+dora system status | --coordinator-addr <value>
+dora system status | --coordinator-port <value>
+dora system status | --dataflow <value>
+dora system status | -f/--format <value>
+dora top
+dora top | --coordinator-addr <value>
+dora top | --coordinator-port <value>
+dora top | --once
+dora top | --refresh-interval <value>
+dora topic
+dora topic echo
+dora topic echo | --coordinator-addr <value>
+dora topic echo | --coordinator-port <value>
+dora topic echo | --count <value>
+dora topic echo | --duration <value>
+dora topic echo | --format <value>
+dora topic echo | -d/--dataflow <value>
+dora topic echo | <data>
+dora topic hz
+dora topic hz | --coordinator-addr <value>
+dora topic hz | --coordinator-port <value>
+dora topic hz | --duration <value>
+dora topic hz | --window <value>
+dora topic hz | -d/--dataflow <value>
+dora topic hz | <data>
+dora topic info
+dora topic info | --coordinator-addr <value>
+dora topic info | --coordinator-port <value>
+dora topic info | --duration <value>
+dora topic info | -d/--dataflow <value>
+dora topic info | <data>
+dora topic list
+dora topic list | --coordinator-addr <value>
+dora topic list | --coordinator-port <value>
+dora topic list | --format <value>
+dora topic list | -d/--dataflow <value>
+dora topic pub
+dora topic pub | --coordinator-addr <value>
+dora topic pub | --coordinator-port <value>
+dora topic pub | --count <value>
+dora topic pub | --file <value>
+dora topic pub | -d/--dataflow <value>
+dora topic pub | <data>
+dora topic pub | <topic> (required)
+dora trace
+dora trace list
+dora trace list | --coordinator-addr <value>
+dora trace list | --coordinator-port <value>
+dora trace view
+dora trace view | --coordinator-addr <value>
+dora trace view | --coordinator-port <value>
+dora trace view | <trace_id> (required)
+dora up
+dora up | --auth
+dora up | --config <value>
+dora up | --recreate-store
+dora validate
+dora validate | --node-manifest <value>
+dora validate | --offline
+dora validate | --strict-types
+dora validate | <dataflow>

--- a/binaries/cli/tests/cli_surface.rs
+++ b/binaries/cli/tests/cli_surface.rs
@@ -1,0 +1,172 @@
+//! Pins the `dora` command surface, which dora 1.x freezes.
+//!
+//! `docs/api-rust.md` puts `dora-cli` inside the 1.0 guarantee: "the `dora`
+//! command, its subcommands, and the dataflow YAML schema". Nothing checked
+//! that. `cargo-semver-checks` cannot see a CLI -- the crate's Rust lib target
+//! is internal, and a deleted subcommand or a flag that grew a required value
+//! is invisible to it -- so a break here would have reached users' scripts
+//! with no gate having failed.
+//!
+//! The snapshot this test maintains is what makes the surface checkable
+//! *without* building the CLI: `scripts/qa/breaking-changes.sh` diffs the
+//! checked-in file against the one released with the baseline tag, which is
+//! why that gate can run on every PR in seconds. This test is the other half
+//! of the deal -- it keeps the file honest, so the cheap diff is comparing the
+//! real surface rather than a stale copy of it.
+//!
+//! Adding a command or a flag is fine; the snapshot just has to be updated in
+//! the same commit, which is what puts the change in front of a reviewer:
+//!
+//! ```text
+//! UPDATE_CLI_SURFACE=1 cargo test -p dora-cli --test cli_surface
+//! ```
+
+use std::{collections::BTreeSet, path::PathBuf};
+
+use clap::{Command, CommandFactory};
+use dora_cli::Args;
+
+const SNAPSHOT: &str = "cli-surface.txt";
+
+const HEADER: &str = "\
+# The `dora` command surface, frozen for dora 1.x (docs/api-rust.md).
+#
+# Generated -- do not edit by hand:
+#     UPDATE_CLI_SURFACE=1 cargo test -p dora-cli --test cli_surface
+#
+# One line per command, then one per argument. Hidden commands are included:
+# `dora daemon` and `dora coordinator` are undocumented but scripted against.
+# Removing any line is a breaking change; adding one is not.
+";
+
+/// Every line of the surface, sorted so the file diffs cleanly.
+fn surface() -> String {
+    let mut lines = BTreeSet::new();
+    walk(&Args::command(), "dora", &mut lines);
+    let body: Vec<_> = lines.into_iter().collect();
+    format!("{HEADER}\n{}\n", body.join("\n"))
+}
+
+fn walk(command: &Command, path: &str, lines: &mut BTreeSet<String>) {
+    lines.insert(path.to_owned());
+    for alias in command.get_all_aliases() {
+        lines.insert(format!("{path} | alias: {alias}"));
+    }
+    for arg in command.get_arguments() {
+        lines.insert(format!("{path} | {}", describe(arg)));
+    }
+    for sub in command.get_subcommands() {
+        walk(sub, &format!("{path} {}", sub.get_name()), lines);
+    }
+}
+
+/// One argument, in the terms a caller's script depends on: how it is spelled,
+/// whether it takes a value, and whether it may be omitted.
+fn describe(arg: &clap::Arg) -> String {
+    let mut spelling = Vec::new();
+    if let Some(short) = arg.get_short() {
+        spelling.push(format!("-{short}"));
+    }
+    if let Some(long) = arg.get_long() {
+        spelling.push(format!("--{long}"));
+    }
+    let mut item = if spelling.is_empty() {
+        format!("<{}>", arg.get_id())
+    } else {
+        spelling.join("/")
+    };
+    // An option that starts or stops taking a value breaks every existing
+    // invocation, so the value is part of the identity, not a detail. Read it
+    // off the action rather than `get_num_args`, which is only populated once
+    // clap has built the command -- and `Args::command()` hands back an
+    // unbuilt one, so every option would look like a bare flag.
+    if arg.get_action().takes_values() && arg.get_long().is_some() {
+        item.push_str(" <value>");
+    }
+    if arg.is_required_set() {
+        item.push_str(" (required)");
+    }
+    item
+}
+
+fn snapshot_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(SNAPSHOT)
+}
+
+#[test]
+fn cli_surface_snapshot_is_current() {
+    let path = snapshot_path();
+    let current = surface();
+
+    if std::env::var_os("UPDATE_CLI_SURFACE").is_some() {
+        std::fs::write(&path, &current).expect("failed to write the CLI surface snapshot");
+        return;
+    }
+
+    let recorded = std::fs::read_to_string(&path).unwrap_or_else(|error| {
+        panic!(
+            "cannot read {}: {error}\n\
+             Generate it with: UPDATE_CLI_SURFACE=1 cargo test -p dora-cli --test cli_surface",
+            path.display()
+        )
+    });
+
+    if recorded != current {
+        let recorded_lines: BTreeSet<_> = recorded.lines().filter(|l| keep(l)).collect();
+        let current_lines: BTreeSet<_> = current.lines().filter(|l| keep(l)).collect();
+        let removed: Vec<_> = recorded_lines.difference(&current_lines).collect();
+        let added: Vec<_> = current_lines.difference(&recorded_lines).collect();
+        panic!(
+            "the `dora` command surface changed.\n\n\
+             removed (breaking -- dora 1.x froze these):\n  {}\n\n\
+             added (fine, but record it):\n  {}\n\n\
+             Update the snapshot in this commit so the change is reviewed:\n  \
+             UPDATE_CLI_SURFACE=1 cargo test -p dora-cli --test cli_surface",
+            if removed.is_empty() {
+                "(none)".to_owned()
+            } else {
+                removed
+                    .iter()
+                    .map(|l| l.to_string())
+                    .collect::<Vec<_>>()
+                    .join("\n  ")
+            },
+            if added.is_empty() {
+                "(none)".to_owned()
+            } else {
+                added
+                    .iter()
+                    .map(|l| l.to_string())
+                    .collect::<Vec<_>>()
+                    .join("\n  ")
+            },
+        );
+    }
+}
+
+fn keep(line: &str) -> bool {
+    !line.trim().is_empty() && !line.trim_start().starts_with('#')
+}
+
+/// The snapshot is only worth anything if it covers the whole tree, so guard
+/// the two ways it could quietly shrink to nothing.
+#[test]
+fn snapshot_covers_the_command_tree() {
+    let text = surface();
+    for command in [
+        "dora build",
+        "dora start",
+        "dora run",
+        "dora up",
+        "dora daemon",
+    ] {
+        assert!(
+            text.lines().any(|line| line == command),
+            "`{command}` is missing from the generated surface"
+        );
+    }
+    assert!(
+        text.lines().filter(|l| keep(l)).count() > 100,
+        "the generated surface is implausibly small: the walk is not reaching the tree"
+    );
+}

--- a/binaries/cli/tests/cli_surface.rs
+++ b/binaries/cli/tests/cli_surface.rs
@@ -114,32 +114,25 @@ fn cli_surface_snapshot_is_current() {
     if recorded != current {
         let recorded_lines: BTreeSet<_> = recorded.lines().filter(|l| keep(l)).collect();
         let current_lines: BTreeSet<_> = current.lines().filter(|l| keep(l)).collect();
-        let removed: Vec<_> = recorded_lines.difference(&current_lines).collect();
-        let added: Vec<_> = current_lines.difference(&recorded_lines).collect();
+        let render = |lines: BTreeSet<&&str>| {
+            if lines.is_empty() {
+                "(none)".to_owned()
+            } else {
+                lines
+                    .iter()
+                    .map(|line| line.to_string())
+                    .collect::<Vec<_>>()
+                    .join("\n  ")
+            }
+        };
         panic!(
             "the `dora` command surface changed.\n\n\
              removed (breaking -- dora 1.x froze these):\n  {}\n\n\
              added (fine, but record it):\n  {}\n\n\
              Update the snapshot in this commit so the change is reviewed:\n  \
              UPDATE_CLI_SURFACE=1 cargo test -p dora-cli --test cli_surface",
-            if removed.is_empty() {
-                "(none)".to_owned()
-            } else {
-                removed
-                    .iter()
-                    .map(|l| l.to_string())
-                    .collect::<Vec<_>>()
-                    .join("\n  ")
-            },
-            if added.is_empty() {
-                "(none)".to_owned()
-            } else {
-                added
-                    .iter()
-                    .map(|l| l.to_string())
-                    .collect::<Vec<_>>()
-                    .join("\n  ")
-            },
+            render(recorded_lines.difference(&current_lines).collect()),
+            render(current_lines.difference(&recorded_lines).collect()),
         );
     }
 }

--- a/docs/api-rust.md
+++ b/docs/api-rust.md
@@ -835,7 +835,7 @@ crate depends on it, so it never reaches crates.io at all.
 
 ### How this is enforced
 
-Documentation alone would not survive contact with cargo, so four mechanisms
+Documentation alone would not survive contact with cargo, so five mechanisms
 back it:
 
 1. **Exact version pins.** Workspace crates depend on each other with `=`
@@ -857,6 +857,37 @@ back it:
    name that disappears fails; a new one fails until it is filed as either
    covered or exempt, so the choice is made deliberately rather than by
    whatever the module happened to export.
+
+5. **A compatibility gate on every PR.** `make qa-breaking`, run as the
+   `Breaking changes` job in `ci.yml`, checks each surface above against the
+   last released tag. (1)-(3) are cargo mechanisms and (4) covers one wheel,
+   which between them left most of this list unguarded: the `dora` command,
+   the dataflow YAML schema, the C header, the cxx bridge and the postcard
+   wire format are all invisible to rustdoc, and a change to any of them could
+   reach users with every check green.
+
+   | Surface | Checked by |
+   |---|---|
+   | `dora-node-api`, `dora-message`, `dora-arrow-convert` | `cargo-semver-checks` against the tag |
+   | `dora-node-api-c` | declaration diff of `apis/c/node/node_api.h`, enum ordinals included |
+   | `dora-node-api-cxx` | item diff of the `#[cxx::bridge]` block |
+   | `dora-node-api-python` | mechanism (4) above |
+   | `dora-cli` — the `dora` command | `binaries/cli/cli-surface.txt`, a clap-generated snapshot |
+   | `dora-cli` — the YAML schema | JSON-Schema-aware diff: removed property, newly required property, removed enum value, `additionalProperties` closing |
+   | the wire protocol | field and variant *order* of every serde type in `dora-message` — what postcard actually encodes |
+   | the Python floor | `requires-python` and the abi3 tag in both wheels |
+
+   Everything but the first row is read out of source text or a checked-in
+   snapshot, so that half needs no compilation and runs in seconds.
+
+   Two behaviours are worth knowing before they surprise someone. The gate
+   fails a **major version bump**: `cargo-semver-checks` reports nothing once
+   the version says breakage is allowed, so the bump would otherwise switch
+   the check off rather than trip it (`ALLOW_MAJOR_BUMP=1` when it is
+   deliberate). And it passes `--release-type minor` for the same reason —
+   left to infer the release type from an rc-to-release version move, it
+   skipped all 254 lints and reported "no semver update required" having
+   checked nothing.
 
 A consequence of (1): a patch fix in an internal crate requires re-releasing
 its dependents. With `shared-version = true` in `release.toml` that already

--- a/docs/api-rust.md
+++ b/docs/api-rust.md
@@ -880,13 +880,13 @@ back it:
    Everything but the first row is read out of source text or a checked-in
    snapshot, so that half needs no compilation and runs in seconds.
 
-   Two behaviours are worth knowing before they surprise someone. The gate
-   fails a **major version bump**: `cargo-semver-checks` reports nothing once
-   the version says breakage is allowed, so the bump would otherwise switch
-   the check off rather than trip it (`ALLOW_MAJOR_BUMP=1` when it is
-   deliberate). And it passes `--release-type minor` for the same reason —
-   left to infer the release type from an rc-to-release version move, it
-   skipped all 254 lints and reported "no semver update required" having
+   Two behaviours are worth knowing before they surprise someone. It fails a
+   **major version bump**, because a 2.0 withdraws the promises every check
+   is measuring against — green and red would both be misleading, so the bump
+   has to be stated (`ALLOW_MAJOR_BUMP=1`). Separately, `cargo-semver-checks`
+   runs with `--release-type minor`: left to infer the release type from an
+   rc-to-release version move it concluded breakage was already permitted,
+   skipped all 254 lints, and reported "no semver update required" having
    checked nothing.
 
 A consequence of (1): a patch fix in an internal crate requires re-releasing

--- a/docs/contributor-qa-cheatsheet.md
+++ b/docs/contributor-qa-cheatsheet.md
@@ -94,7 +94,9 @@ they're too slow for every PR (see `docs/plan-agentic-qa-strategy.md` §5):
 - coverage (already in `qa-full`)
 - adversarial LLM review (already in `qa-full`; skipped if tools missing)
 - mutation testing (diff-scoped)
-- semver checks
+- the compile half of the compatibility gate (`cargo-semver-checks`, plus a
+  rebuild proving the CLI and schema snapshots are current). Its no-compile
+  half already ran in `qa-fast`
 
 ### Overnight run on a powerful machine (full CI nightly parity)
 

--- a/docs/qa-runbook.md
+++ b/docs/qa-runbook.md
@@ -67,6 +67,8 @@ rustup component add miri --toolchain nightly   # optional; for unsafe-code anal
 | `make qa-coverage` | `cargo llvm-cov` (writes `lcov.info`) | ~5 min | To see coverage locally |
 | `make qa-mutants` | `cargo mutants --in-diff origin/main` on critical crates | ~5-30 min | To verify tests actually detect bugs |
 | `make qa-semver` | `cargo semver-checks` vs last tag | ~1-2 min | Before bumping published crate versions |
+| `make qa-breaking` | every surface dora 1.x freezes, vs the last release tag | ~2 s (`ARGS="--fast"`) / ~2-5 min (full) | The `--fast` half runs in `qa-fast` and in PR CI; run the full one when you touched the CLI, the descriptor, `dora-message`, or a node API |
+| `make qa-breaking-update` | re-record the CLI snapshot and the JSON schemas | ~1-2 min | After *adding* a command, flag or descriptor field — commit the diff |
 
 All targets call scripts under `scripts/qa/`. The scripts are the source of truth — if something looks wrong, read the script.
 
@@ -216,15 +218,30 @@ Construct an input where the mutated version produces a different output from th
 
 **Do not** waive mutations just to make the gate pass. The point of the gate is to surface weak tests.
 
-### 3.10 `semver` (soft) flagged
+### 3.10 `semver` flagged
 
 **Cause**: `cargo-semver-checks` found a breaking change in a publishable crate's public API since the last tag.
 
 **Fix**:
-- If the change is intentional: make sure the crate's version is bumped to a new major or minor (per SemVer rules) before release.
 - If unintentional: revert the breaking change.
+- If intentional: it needs a 2.0. Inside 1.x there is no version bump that makes it acceptable — that is what the 1.0 guarantee says (`docs/api-rust.md`).
 
-The gate is soft during 0.x development — it only warns. It becomes a hard gate after the 1.0 release per `plan-dora-1.0-consolidation.md`.
+Soft during 0.x, hard from 1.0 on. It runs as a step of the `breaking-changes` gate below, which passes `--release-type minor` so the lints run whatever the version numbers say.
+
+### 3.11 `breaking-changes` failed
+
+**Cause**: a surface dora 1.x freezes changed. The report names the surface and the item — a removed `dora` flag, a reordered postcard field, a YAML property that became required, a raised `requires-python`.
+
+**Fix**, in the order worth trying:
+
+1. **Unintentional** (the common case): revert that part. The report quotes the old and new form, so the diff to undo is usually one line.
+2. **You added something, and the gate is complaining that a generated snapshot is stale.** Run `make qa-breaking-update` and commit the result. Additions are fine; the snapshot diff is how they get reviewed.
+3. **The change is genuinely needed and genuinely breaking.** Keep the old surface working alongside the new one — a deprecated alias, an added variant rather than a changed one, a new optional field rather than a required one. Removing the old form waits for 2.0.
+
+Two failures that read oddly:
+
+- **"major version bump ... silences cargo-semver-checks"** — bumping the major turns the Rust half of the gate off, so the gate stops at the bump itself. When the 2.0 is deliberate, `ALLOW_MAJOR_BUMP=1 make qa-breaking`.
+- **"the generated surface files are stale"** — regenerating changed the tree, so the comparison ran against an out-of-date snapshot and its "ok" meant nothing. Commit the regenerated files and read the report again.
 
 ---
 

--- a/docs/qa-runbook.md
+++ b/docs/qa-runbook.md
@@ -240,7 +240,7 @@ Soft during 0.x, hard from 1.0 on. It runs as a step of the `breaking-changes` g
 
 Two failures that read oddly:
 
-- **"major version bump ... silences cargo-semver-checks"** — bumping the major turns the Rust half of the gate off, so the gate stops at the bump itself. When the 2.0 is deliberate, `ALLOW_MAJOR_BUMP=1 make qa-breaking`.
+- **"major version bump ..."** — a 2.0 withdraws the promises the gate measures against, so it stops there rather than reporting a green or a red that means nothing. When the bump is deliberate, `ALLOW_MAJOR_BUMP=1 make qa-breaking` (and set the same variable on the `breaking-changes` job for the PR that carries it).
 - **"the generated surface files are stale"** — regenerating changed the tree, so the comparison ran against an out-of-date snapshot and its "ok" meant nothing. Commit the regenerated files and read the report again.
 
 ---

--- a/libraries/core/src/bin/generate_schema.rs
+++ b/libraries/core/src/bin/generate_schema.rs
@@ -103,14 +103,33 @@ mod tests {
     /// compares an out-of-date snapshot and passes for the wrong reason. This
     /// test runs wherever `cargo test` does, so a merge-queue batch cannot
     /// leave it behind.
+    ///
+    /// Compared as parsed JSON, not as text, because the key order is not
+    /// stable across build graphs: `dora-node-api` enables
+    /// `serde_json/preserve_order`, which unifies into this crate's
+    /// `serde_json` in any workspace-wide build. The same generator then
+    /// emits declaration order under `cargo test --all` and sorted order
+    /// under `cargo run -p dora-core`, so a text comparison fails in the
+    /// merge queue while passing on the laptop that recorded the file.
+    /// Order carries no meaning in a JSON Schema; drift in the *content* is
+    /// what this asserts.
+    ///
+    /// The gate's own freshness check is unaffected and stays textual: it
+    /// regenerates with `cargo run -p dora-core`, whose graph cannot reach
+    /// `preserve_order` -- that comes from `dora-node-api` and `dora-cli`,
+    /// neither of which `dora-core` depends on.
     #[test]
     fn checked_in_descriptor_schema_is_current() {
         let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
         let checked_in = fs::read_to_string(manifest_dir.join("dora-schema.json"))
             .expect("libraries/core/dora-schema.json is missing");
+        let checked_in: serde_json::Value = serde_json::from_str(&checked_in)
+            .expect("libraries/core/dora-schema.json is not valid JSON");
+        let generated: serde_json::Value = serde_json::from_str(&descriptor_schema_json())
+            .expect("the generated descriptor schema is not valid JSON");
 
         assert!(
-            checked_in == descriptor_schema_json(),
+            checked_in == generated,
             "libraries/core/dora-schema.json is out of date. Regenerate it:\n  \
              cargo run -p dora-core --bin generate_schema"
         );

--- a/libraries/core/src/bin/generate_schema.rs
+++ b/libraries/core/src/bin/generate_schema.rs
@@ -22,7 +22,12 @@ fn workspace_root(manifest_dir: &Path) -> Option<PathBuf> {
         .then(|| root.to_path_buf())
 }
 
-fn main() {
+/// The descriptor schema exactly as it is written to disk.
+///
+/// Factored out of `main` so a test can assert the checked-in copies match it:
+/// the post-processing below is part of the published artifact, so comparing
+/// against a bare `schema_for!` would not.
+fn descriptor_schema_json() -> String {
     let schema = schema_for!(Descriptor);
     let raw_schema =
         serde_json::to_string_pretty(&schema).expect("Could not serialize schema to json");
@@ -43,12 +48,16 @@ fn main() {
             }",
         "",
     );
-    let raw_schema = raw_schema.replace(
+    raw_schema.replace(
         "{
             \"$ref\": \"#/definitions/Input\"
           }",
         "true",
-    );
+    )
+}
+
+fn main() {
+    let raw_schema = descriptor_schema_json();
 
     // Get the Cargo root manifest directory
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is not set");
@@ -78,8 +87,34 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
-    use super::workspace_root;
+    use super::{descriptor_schema_json, workspace_root};
     use std::{fs, path::Path};
+
+    /// The checked-in descriptor schema must match what the generator produces.
+    ///
+    /// Nothing asserted this: `root_schema_matches_crate_copy` below only
+    /// checks the two copies against *each other*, so both could drift from
+    /// the descriptor together — and they did, silently, until a change to
+    /// `OperatorId`'s doc comment showed up in a regeneration.
+    ///
+    /// It matters more than a stale doc comment. `dora-cli`'s YAML schema is
+    /// inside the 1.0 guarantee, and `scripts/qa/breaking-changes.sh` checks
+    /// that promise by diffing this file against the last release. Stale, it
+    /// compares an out-of-date snapshot and passes for the wrong reason. This
+    /// test runs wherever `cargo test` does, so a merge-queue batch cannot
+    /// leave it behind.
+    #[test]
+    fn checked_in_descriptor_schema_is_current() {
+        let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let checked_in = fs::read_to_string(manifest_dir.join("dora-schema.json"))
+            .expect("libraries/core/dora-schema.json is missing");
+
+        assert!(
+            checked_in == descriptor_schema_json(),
+            "libraries/core/dora-schema.json is out of date. Regenerate it:\n  \
+             cargo run -p dora-core --bin generate_schema"
+        );
+    }
 
     /// The descriptor schema is published at two URLs: the repo-root copy that
     /// `docs/yaml-spec.md` and `guide/src/concepts/dataflow-yaml.md` paste into

--- a/scripts/qa/all.sh
+++ b/scripts/qa/all.sh
@@ -6,10 +6,11 @@
 #
 # Modes (increasing thoroughness):
 #   --fast            ~1 min     pre-commit sanity (fmt, clippy, audit, unwrap,
-#                                secret-files, typos, publish-graph)
+#                                secret-files, typos, publish-graph,
+#                                breaking-changes)
 #   --full            ~5-10 min  pre-push (fast + tests + coverage + optional adversarial)
 #   --deep            ~15 min    target Tier 1 gate, stronger than today's CI
-#                                (full + mutants on diff + semver; see strategy doc §5 for why the
+#                                (full + mutants on diff + breaking-changes; see strategy doc §5 for why the
 #                                extras are laptop-only)
 #   --tier1                      back-compat alias for --deep
 #   --nightly         ~3-4 hours   Full parity with .github/workflows/nightly.yml
@@ -31,7 +32,7 @@
 #                                Requires BOTH `uv` AND Python 3.12 (preflighted
 #                                with specific install hints; matches GHA's
 #                                actions/setup-python@3.12 + uv setup).
-#   --release-gate               Tier 3 automatable (deep + semver; audit+dogfood are human gates)
+#   --release-gate               Tier 3 automatable (deep + breaking-changes; audit+dogfood are human gates)
 #   --mutation-audit  ~10-18 hrs full-repo cargo-mutants across 6 critical crates
 #                                (1679+ mutants). Deliberate test-quality audit, not every nightly.
 #
@@ -110,6 +111,9 @@ Will run:
   5. secret-files   -- no credential-shaped filenames tracked by git
   6. typos          -- spell-check against _typos.toml allowlist
   7. publish-graph  -- crates.io publish order / no unpublished deps
+  8. breaking-changes -- 1.x frozen surfaces vs the last release tag
+                       (C header, cxx bridge, YAML schema, wire format,
+                        CLI snapshot, Python floor; no build)
 ============================================================
 EOF
       ;;
@@ -119,11 +123,12 @@ EOF
 ============================================================
 $header
 Will run:
-  1-7. everything from qa-fast                  (fmt/clippy/audit/unwrap/
-                                                 secret-files/typos/publish-graph)
-  8.   test         -- cargo test --all         (workspace test suite)
-  9.   coverage     -- cargo llvm-cov           (writes lcov.info)
-  10.  adversarial  -- codex/claude review      (optional; skipped if unavailable)
+  1-8. everything from qa-fast                  (fmt/clippy/audit/unwrap/
+                                                 secret-files/typos/publish-graph/
+                                                 breaking-changes)
+  9.   test         -- cargo test --all         (workspace test suite)
+  10.  coverage     -- cargo llvm-cov           (writes lcov.info)
+  11.  adversarial  -- codex/claude review      (optional; skipped if unavailable)
 ============================================================
 EOF
       ;;
@@ -138,15 +143,17 @@ test suite.
 qa-deep adds the planned Tier 1 extras (see
 docs/plan-agentic-qa-strategy.md §5) that are kept laptop-only today
 because they're too slow for every PR: coverage, adversarial review,
-diff-scoped mutation testing, semver.
+diff-scoped mutation testing, and the compile half of the
+compatibility gate.
 
 Will run:
-  1-7.  everything from qa-fast                 (in CI today)
-  8.    test         -- cargo test --all        (in CI today)
-  9.    coverage     -- cargo llvm-cov          (NOT in CI; laptop-only)
-  10.   adversarial  -- codex/claude review     (NOT in CI; skipped w/o tools)
-  11.   mutants      -- cargo-mutants on diff   (NOT in CI; laptop-only)
-  12.   semver       -- cargo-semver-checks     (NOT in CI; pre-release only)
+  1-8.  everything from qa-fast                 (in CI today)
+  9.    test         -- cargo test --all        (in CI today)
+  10.   coverage     -- cargo llvm-cov          (NOT in CI; laptop-only)
+  11.   adversarial  -- codex/claude review     (NOT in CI; skipped w/o tools)
+  12.   mutants      -- cargo-mutants on diff   (NOT in CI; laptop-only)
+  13.   breaking-changes -- cargo-semver-checks + snapshot freshness
+                       (the no-compile half already ran in step 8)
 ============================================================
 EOF
       ;;
@@ -156,13 +163,13 @@ EOF
 ============================================================
 $header
 For overnight runs on a powerful machine. Will run:
-  1-7.  everything from qa-fast
-  8-10. everything from qa-full                 (test, coverage, adversarial)
-  11.   mutants (diff-scoped)                   -- same as qa-deep
-  12.   semver                                  -- cargo-semver-checks vs last tag
-  13.   proptest @ 1000 cases per property      (vs 50 cases in Tier 1)
-  14.   miri                                    -- undefined-behavior check (SKIP if cargo +nightly miri missing)
-  15.   example-smoke                           -- tests/example-smoke.rs (52 tests;
+  1-8.  everything from qa-fast
+  9-11. everything from qa-full                 (test, coverage, adversarial)
+  12.   mutants (diff-scoped)                   -- same as qa-deep
+  13.   breaking-changes                        -- cargo-semver-checks + snapshot freshness
+  14.   proptest @ 1000 cases per property      (vs 50 cases in Tier 1)
+  15.   miri                                    -- undefined-behavior check (SKIP if cargo +nightly miri missing)
+  16.   example-smoke                           -- tests/example-smoke.rs (52 tests;
                                                    covers GHA smoke-suite + log-sinks
                                                    + service-action + streaming).
                                                    Runs inside a scratch uv venv that
@@ -170,14 +177,14 @@ For overnight runs on a powerful machine. Will run:
                                                    matching the GHA Python setup exactly
                                                    (so workspace Python bindings are used,
                                                    NOT PyPI). Requires uv.
-  16.   hub-smoke                              -- tests/hub-smoke.rs -- the Hub
+  17.   hub-smoke                              -- tests/hub-smoke.rs -- the Hub
                                                    e2e (publish / build / run /
                                                    yank / outdated / --hub-override
                                                    / binary / identity). Hermetic
                                                    (local git fixture, no network),
                                                    Rust-only -- no venv. Runs
                                                    regardless of the uv/3.12 setup.
-  17.   ci-nightly-jobs                         -- scripts/qa/ci-nightly-jobs.sh
+  18.   ci-nightly-jobs                         -- scripts/qa/ci-nightly-jobs.sh
                                                    Platform-aware: runs the subset of GHA
                                                    nightly jobs that applies to the dev's OS.
                                                    Covers record-replay, cluster-smoke,
@@ -245,10 +252,10 @@ EOF
 ============================================================
 $header
 The automatable parts of the Tier 3 release gate. Will run:
-  1-7.   everything from qa-fast
-  8-10.  everything from qa-full                 (test, coverage, adversarial)
-  11.    mutants (diff-scoped)
-  12.    semver
+  1-8.   everything from qa-fast
+  9-11.  everything from qa-full                 (test, coverage, adversarial)
+  12.    mutants (diff-scoped)
+  13.    breaking-changes                        -- every surface dora 1.x freezes
 Non-automatable Tier 3 gates (external security audit, 7-day dogfood
 campaign, migration validation on external repos) are human-gated --
 see docs/plan-agentic-qa-strategy.md §7.
@@ -272,6 +279,10 @@ run "unwrap-budget" scripts/qa/unwrap-budget.sh
 run "secret-files"  scripts/qa/secret-files.sh
 run "typos"         scripts/qa/typos.sh
 run "publish-graph" scripts/qa/publish-graph.sh
+# The no-compile half of the 1.x compatibility gate: C header, cxx bridge,
+# YAML schema, wire format, CLI snapshot, Python floor. Seconds, so it
+# belongs in the per-commit tier -- the compile half runs in --deep.
+run "breaking-changes" scripts/qa/breaking-changes.sh --fast
 
 case "$MODE" in
   --fast)
@@ -299,7 +310,9 @@ esac
 case "$MODE" in
   --deep|--nightly|--release-gate)
     run "mutants (diff-scoped)" scripts/qa/mutants.sh
-    run "semver"                scripts/qa/semver.sh
+    # Supersedes the bare `semver` step: this runs cargo-semver-checks (via
+    # semver.sh) *and* the surface checks rustdoc cannot see.
+    run "breaking-changes"      scripts/qa/breaking-changes.sh
     ;;
 esac
 

--- a/scripts/qa/baseline.sh
+++ b/scripts/qa/baseline.sh
@@ -11,22 +11,28 @@
 # its own baseline would silently end up comparing against `main`, or against
 # nothing.
 
+# Make `ref` readable in this checkout, fetching it at depth 1 if it is not.
+ensure_ref() {
+  local ref="$1"
+  git rev-parse -q --verify "${ref}^{commit}" >/dev/null 2>&1 && return 0
+
+  echo "fetching $ref (not in this checkout)" >&2
+  git fetch --quiet --depth=1 origin "refs/tags/${ref}:refs/tags/${ref}" 2>/dev/null && return 0
+  # Not a tag, or no such tag: try it as a plain commit-ish before giving up.
+  git fetch --quiet --depth=1 origin "$ref" 2>/dev/null && return 0
+  return 1
+}
+
 resolve_breaking_baseline() {
   local ref="${1:-${SEMVER_BASELINE:-${BREAKING_BASELINE:-}}}"
   if [ -z "$ref" ]; then
     ref=$(python3 scripts/qa/breaking_changes.py --print-baseline) || return 1
   fi
 
-  if ! git rev-parse -q --verify "${ref}^{commit}" >/dev/null 2>&1; then
-    echo "fetching baseline $ref (not in this checkout)" >&2
-    if ! git fetch --quiet --depth=1 origin "refs/tags/${ref}:refs/tags/${ref}" 2>/dev/null; then
-      # Not a tag, or no such tag: try it as a plain commit-ish before giving up.
-      git fetch --quiet --depth=1 origin "$ref" 2>/dev/null || {
-        echo "error: could not fetch baseline $ref" >&2
-        return 1
-      }
-    fi
-  fi
+  ensure_ref "$ref" || {
+    echo "error: could not fetch baseline $ref" >&2
+    return 1
+  }
 
   echo "$ref"
 }

--- a/scripts/qa/baseline.sh
+++ b/scripts/qa/baseline.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# scripts/qa/baseline.sh -- resolve the release the compatibility gate compares
+# against. Sourced by breaking-changes.sh and semver.sh, so the two halves of
+# the gate can never disagree about which release they are checking.
+#
+#   source scripts/qa/baseline.sh
+#   BASELINE=$(resolve_breaking_baseline)      # honours $BREAKING_BASELINE
+#
+# Also fetches the tag when it is missing. CI checkouts are shallow and carry
+# no tags at all -- and `git describe` fails there, so a caller that resolved
+# its own baseline would silently end up comparing against `main`, or against
+# nothing.
+
+resolve_breaking_baseline() {
+  local ref="${1:-${SEMVER_BASELINE:-${BREAKING_BASELINE:-}}}"
+  if [ -z "$ref" ]; then
+    ref=$(python3 scripts/qa/breaking_changes.py --print-baseline) || return 1
+  fi
+
+  if ! git rev-parse -q --verify "${ref}^{commit}" >/dev/null 2>&1; then
+    echo "fetching baseline $ref (not in this checkout)" >&2
+    if ! git fetch --quiet --depth=1 origin "refs/tags/${ref}:refs/tags/${ref}" 2>/dev/null; then
+      # Not a tag, or no such tag: try it as a plain commit-ish before giving up.
+      git fetch --quiet --depth=1 origin "$ref" 2>/dev/null || {
+        echo "error: could not fetch baseline $ref" >&2
+        return 1
+      }
+    fi
+  fi
+
+  echo "$ref"
+}

--- a/scripts/qa/breaking-changes.sh
+++ b/scripts/qa/breaking-changes.sh
@@ -32,30 +32,27 @@ set -euo pipefail
 cd "$(dirname "$0")/../.."
 
 MODE=full
-BASELINE_ARG=()
+# A plain string, not an array: an empty array under `set -u` aborts on bash
+# 3.2, which is what macOS ships -- `make qa-fast` would fail there on a clean
+# tree.
+BASELINE_OVERRIDE=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --fast) MODE=fast ;;
     --full) MODE=full ;;
-    --baseline) BASELINE_ARG=(--baseline "$2"); shift ;;
+    --baseline)
+      [[ $# -ge 2 ]] || { echo "--baseline needs a ref" >&2; exit 2; }
+      BASELINE_OVERRIDE="$2"; shift ;;
     -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
     *) echo "unknown argument: $1" >&2; exit 2 ;;
   esac
   shift
 done
 
-BASELINE=$(python3 scripts/qa/breaking_changes.py --print-baseline "${BASELINE_ARG[@]}")
+# shellcheck source=baseline.sh
+source "$(dirname "$0")/baseline.sh"
+BASELINE=$(resolve_breaking_baseline "$BASELINE_OVERRIDE") || exit 2
 FAILED=0
-
-# A CI checkout is shallow and carries no tags. Fetch the single tag the gate
-# needs rather than making every PR clone 1.3 GB of history for one diff.
-if ! git rev-parse -q --verify "${BASELINE}^{commit}" >/dev/null 2>&1; then
-  echo "fetching baseline $BASELINE (not in this checkout)"
-  git fetch --quiet --depth=1 origin "refs/tags/${BASELINE}:refs/tags/${BASELINE}" || {
-    echo "error: could not fetch $BASELINE -- the gate cannot run without a baseline" >&2
-    exit 2
-  }
-fi
 
 # Best-effort: the fallback covers surfaces the release predates, so a shallow
 # checkout that cannot reach the PR base just leaves those checks skipped.

--- a/scripts/qa/breaking-changes.sh
+++ b/scripts/qa/breaking-changes.sh
@@ -36,9 +36,7 @@ cd "$(dirname "$0")/../.."
 # The generated inputs the surface diff reads, and the commands that write
 # them. Defined once: the freshness check below and `--update` (which
 # `make qa-breaking-update` calls) must never disagree about the list.
-# Same path as `CLI_SURFACE` in breaking_changes.py.
-CLI_SNAPSHOT="binaries/cli/cli-surface.txt"
-GENERATED_FILES="dora-schema.json libraries/core/dora-schema.json libraries/core/dora-node-schema.json $CLI_SNAPSHOT"
+GENERATED_FILES="dora-schema.json libraries/core/dora-schema.json libraries/core/dora-node-schema.json binaries/cli/cli-surface.txt"
 
 regenerate_inputs() {
   UPDATE_CLI_SURFACE=1 cargo test -p dora-cli --test cli_surface >/dev/null
@@ -78,13 +76,10 @@ source scripts/qa/baseline.sh
 BASELINE=$(resolve_breaking_baseline "$BASELINE_OVERRIDE") || exit 2
 FAILED=0
 
-# The fallback exists for surfaces the release predates, and today that is
-# exactly one file. Fetching a whole commit for it when the baseline already
-# carries the snapshot would be several megabytes wasted on every PR, forever
-# -- so check first. Best-effort either way: a shallow checkout that cannot
-# reach the PR base just leaves that check skipped.
-if [[ -n "${BREAKING_FALLBACK_BASELINE:-}" ]] &&
-   ! git cat-file -e "${BASELINE}:${CLI_SNAPSHOT}" 2>/dev/null; then
+# Best-effort, and a no-op wherever the history is already present: a
+# checkout that cannot reach the PR base just leaves the fallback checks
+# skipped rather than failing the run.
+if [[ -n "${BREAKING_FALLBACK_BASELINE:-}" ]]; then
   ensure_ref "$BREAKING_FALLBACK_BASELINE" || true
 fi
 

--- a/scripts/qa/breaking-changes.sh
+++ b/scripts/qa/breaking-changes.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# scripts/qa/breaking-changes.sh -- the dora 1.x compatibility gate.
+#
+# dora 1.0 freezes a set of surfaces for the life of the 1.x series
+# (docs/api-rust.md, "Stability scope at 1.0"). This checks all of them
+# against the last released tag:
+#
+#   no compilation (seconds, runs on every PR)
+#     - the C node API header
+#     - the C++ node API (cxx bridge)
+#     - the dataflow YAML schema
+#     - the postcard wire format of dora-message
+#     - the `dora` command surface (via its checked-in snapshot)
+#     - the Python support floor (requires-python / abi3)
+#     - a major version bump, which would silence the check below
+#
+#   compilation required (--full, minutes)
+#     - the Rust API of the crates the guarantee covers (cargo-semver-checks)
+#     - freshness of the two generated inputs above: the CLI snapshot and the
+#       JSON schema. Without this a PR could break a surface *and* leave its
+#       snapshot stale, so the cheap diff would see nothing.
+#
+# Usage:
+#   scripts/qa/breaking-changes.sh                  # everything
+#   scripts/qa/breaking-changes.sh --fast           # no-compile checks only
+#   scripts/qa/breaking-changes.sh --baseline v1.0.0
+#
+# Env: BREAKING_BASELINE=<ref>, ALLOW_MAJOR_BUMP=1.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+MODE=full
+BASELINE_ARG=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --fast) MODE=fast ;;
+    --full) MODE=full ;;
+    --baseline) BASELINE_ARG=(--baseline "$2"); shift ;;
+    -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+BASELINE=$(python3 scripts/qa/breaking_changes.py --print-baseline "${BASELINE_ARG[@]}")
+FAILED=0
+
+# A CI checkout is shallow and carries no tags. Fetch the single tag the gate
+# needs rather than making every PR clone 1.3 GB of history for one diff.
+if ! git rev-parse -q --verify "${BASELINE}^{commit}" >/dev/null 2>&1; then
+  echo "fetching baseline $BASELINE (not in this checkout)"
+  git fetch --quiet --depth=1 origin "refs/tags/${BASELINE}:refs/tags/${BASELINE}" || {
+    echo "error: could not fetch $BASELINE -- the gate cannot run without a baseline" >&2
+    exit 2
+  }
+fi
+
+# Best-effort: the fallback covers surfaces the release predates, so a shallow
+# checkout that cannot reach the PR base just leaves those checks skipped.
+if [[ -n "${BREAKING_FALLBACK_BASELINE:-}" ]] &&
+   ! git rev-parse -q --verify "${BREAKING_FALLBACK_BASELINE}^{commit}" >/dev/null 2>&1; then
+  git fetch --quiet --depth=1 origin "$BREAKING_FALLBACK_BASELINE" 2>/dev/null || true
+fi
+
+# The differ is text-driven, so an upstream reformat could silently turn an
+# extractor into a no-op and every surface would report "ok" forever. Its own
+# tests feed known breaks through it; they take milliseconds, so they run
+# first, every time, rather than being a separate thing to remember.
+echo "=== differ self-test ==="
+if ! python3 -m unittest discover -s scripts/qa/tests -q; then
+  echo "the breaking-change differ is broken -- its findings cannot be trusted" >&2
+  exit 2
+fi
+echo
+
+echo "=== frozen surfaces (no build) ==="
+python3 scripts/qa/breaking_changes.py --baseline "$BASELINE" || FAILED=1
+echo
+
+if [[ "$MODE" == fast ]]; then
+  echo "Skipped (--fast): Rust API check, snapshot freshness."
+  exit "$FAILED"
+fi
+
+# Generated inputs must match what generates them, or the diff above is
+# comparing a stale file and passes for the wrong reason.
+echo "=== generated inputs are current ==="
+if [[ -n "${CARGO:-}" ]] || command -v cargo >/dev/null; then
+  UPDATE_CLI_SURFACE=1 cargo test -p dora-cli --test cli_surface >/dev/null
+  cargo run --quiet -p dora-core --bin generate_schema >/dev/null
+  SCHEMAS="dora-schema.json libraries/core/dora-schema.json libraries/core/dora-node-schema.json binaries/cli/cli-surface.txt"
+  if ! git diff --exit-code --stat -- $SCHEMAS; then
+    echo
+    echo "The generated surface files are stale. Regenerating them changed the"
+    echo "tree, which means the check above compared an out-of-date snapshot."
+    echo "Commit the regenerated files, then re-read the report."
+    FAILED=1
+  else
+    echo "  CLI snapshot and JSON schemas match their generators."
+  fi
+else
+  echo "  skipped: cargo not found"
+fi
+echo
+
+echo "=== Rust API (cargo-semver-checks) ==="
+# Delegated to semver.sh, which owns the crate list and the "which crates does
+# the guarantee cover" reasoning. The crates it does *not* list are not gaps:
+# dora-node-api-c and -cxx are checked above through their header and bridge,
+# dora-node-api-python through the frozen module test in
+# apis/python/node/tests/test_public_surface.py, and dora-cli through its
+# command snapshot -- all surfaces rustdoc cannot see.
+if ! BREAKING_BASELINE="$BASELINE" SEMVER_BASELINE="$BASELINE" scripts/qa/semver.sh; then
+  FAILED=1
+fi
+
+echo
+if [[ "$FAILED" == 1 ]]; then
+  echo "Breaking changes found against $BASELINE."
+  echo "dora 1.x freezes these surfaces -- see docs/api-rust.md."
+  exit 1
+fi
+echo "No breaking changes against $BASELINE."

--- a/scripts/qa/breaking-changes.sh
+++ b/scripts/qa/breaking-changes.sh
@@ -12,7 +12,8 @@
 #     - the postcard wire format of dora-message
 #     - the `dora` command surface (via its checked-in snapshot)
 #     - the Python support floor (requires-python / abi3)
-#     - a major version bump, which would silence the check below
+#     - a major version bump, which withdraws the promises the rest of
+#       this gate measures against
 #
 #   compilation required (--full, minutes)
 #     - the Rust API of the crates the guarantee covers (cargo-semver-checks)
@@ -23,6 +24,7 @@
 # Usage:
 #   scripts/qa/breaking-changes.sh                  # everything
 #   scripts/qa/breaking-changes.sh --fast           # no-compile checks only
+#   scripts/qa/breaking-changes.sh --update         # re-record the generated inputs
 #   scripts/qa/breaking-changes.sh --baseline v1.0.0
 #
 # Env: BREAKING_BASELINE=<ref>, ALLOW_MAJOR_BUMP=1.
@@ -30,6 +32,16 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/../.."
+
+# The generated inputs the surface diff reads, and the commands that write
+# them. Defined once: the freshness check below and `--update` (which
+# `make qa-breaking-update` calls) must never disagree about the list.
+GENERATED_FILES="dora-schema.json libraries/core/dora-schema.json libraries/core/dora-node-schema.json binaries/cli/cli-surface.txt"
+
+regenerate_inputs() {
+  UPDATE_CLI_SURFACE=1 cargo test -p dora-cli --test cli_surface >/dev/null
+  cargo run --quiet -p dora-core --bin generate_schema >/dev/null
+}
 
 MODE=full
 # A plain string, not an array: an empty array under `set -u` aborts on bash
@@ -40,6 +52,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --fast) MODE=fast ;;
     --full) MODE=full ;;
+    --update) MODE=update ;;
     --baseline)
       [[ $# -ge 2 ]] || { echo "--baseline needs a ref" >&2; exit 2; }
       BASELINE_OVERRIDE="$2"; shift ;;
@@ -49,16 +62,24 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
+if [[ "$MODE" == update ]]; then
+  regenerate_inputs
+  git diff --stat -- $GENERATED_FILES
+  exit 0
+fi
+
+# Relative to the repo root, which the `cd` above guarantees: `$(dirname $0)`
+# would be wrong when the script is invoked by a relative path from anywhere
+# but the root.
 # shellcheck source=baseline.sh
-source "$(dirname "$0")/baseline.sh"
+source scripts/qa/baseline.sh
 BASELINE=$(resolve_breaking_baseline "$BASELINE_OVERRIDE") || exit 2
 FAILED=0
 
 # Best-effort: the fallback covers surfaces the release predates, so a shallow
 # checkout that cannot reach the PR base just leaves those checks skipped.
-if [[ -n "${BREAKING_FALLBACK_BASELINE:-}" ]] &&
-   ! git rev-parse -q --verify "${BREAKING_FALLBACK_BASELINE}^{commit}" >/dev/null 2>&1; then
-  git fetch --quiet --depth=1 origin "$BREAKING_FALLBACK_BASELINE" 2>/dev/null || true
+if [[ -n "${BREAKING_FALLBACK_BASELINE:-}" ]]; then
+  ensure_ref "$BREAKING_FALLBACK_BASELINE" || true
 fi
 
 # The differ is text-driven, so an upstream reformat could silently turn an
@@ -85,10 +106,8 @@ fi
 # comparing a stale file and passes for the wrong reason.
 echo "=== generated inputs are current ==="
 if [[ -n "${CARGO:-}" ]] || command -v cargo >/dev/null; then
-  UPDATE_CLI_SURFACE=1 cargo test -p dora-cli --test cli_surface >/dev/null
-  cargo run --quiet -p dora-core --bin generate_schema >/dev/null
-  SCHEMAS="dora-schema.json libraries/core/dora-schema.json libraries/core/dora-node-schema.json binaries/cli/cli-surface.txt"
-  if ! git diff --exit-code --stat -- $SCHEMAS; then
+  regenerate_inputs
+  if ! git diff --exit-code --stat -- $GENERATED_FILES; then
     echo
     echo "The generated surface files are stale. Regenerating them changed the"
     echo "tree, which means the check above compared an out-of-date snapshot."

--- a/scripts/qa/breaking-changes.sh
+++ b/scripts/qa/breaking-changes.sh
@@ -36,7 +36,9 @@ cd "$(dirname "$0")/../.."
 # The generated inputs the surface diff reads, and the commands that write
 # them. Defined once: the freshness check below and `--update` (which
 # `make qa-breaking-update` calls) must never disagree about the list.
-GENERATED_FILES="dora-schema.json libraries/core/dora-schema.json libraries/core/dora-node-schema.json binaries/cli/cli-surface.txt"
+# Same path as `CLI_SURFACE` in breaking_changes.py.
+CLI_SNAPSHOT="binaries/cli/cli-surface.txt"
+GENERATED_FILES="dora-schema.json libraries/core/dora-schema.json libraries/core/dora-node-schema.json $CLI_SNAPSHOT"
 
 regenerate_inputs() {
   UPDATE_CLI_SURFACE=1 cargo test -p dora-cli --test cli_surface >/dev/null
@@ -76,9 +78,13 @@ source scripts/qa/baseline.sh
 BASELINE=$(resolve_breaking_baseline "$BASELINE_OVERRIDE") || exit 2
 FAILED=0
 
-# Best-effort: the fallback covers surfaces the release predates, so a shallow
-# checkout that cannot reach the PR base just leaves those checks skipped.
-if [[ -n "${BREAKING_FALLBACK_BASELINE:-}" ]]; then
+# The fallback exists for surfaces the release predates, and today that is
+# exactly one file. Fetching a whole commit for it when the baseline already
+# carries the snapshot would be several megabytes wasted on every PR, forever
+# -- so check first. Best-effort either way: a shallow checkout that cannot
+# reach the PR base just leaves that check skipped.
+if [[ -n "${BREAKING_FALLBACK_BASELINE:-}" ]] &&
+   ! git cat-file -e "${BASELINE}:${CLI_SNAPSHOT}" 2>/dev/null; then
   ensure_ref "$BREAKING_FALLBACK_BASELINE" || true
 fi
 

--- a/scripts/qa/breaking_changes.py
+++ b/scripts/qa/breaking_changes.py
@@ -21,6 +21,7 @@ Exit codes: 0 clean, 1 breaking changes found, 2 the gate could not run.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
@@ -127,6 +128,26 @@ def tag_sort_key(tag: str) -> tuple:
     major, minor, patch, pre = match.groups()
     # A prerelease sorts below the same version's final release.
     return (int(major), int(minor), int(patch), 0 if pre else 1, pre or "")
+
+
+def grep_tracked(root: Path, ref: str | None, pattern: str) -> dict[str, str]:
+    """Matching lines from tracked `Cargo.toml` files, keyed by path.
+
+    `ref` reads the tree at that revision; None reads the working tree.
+    """
+    command = ["git", "-C", str(root), "grep", pattern]
+    if ref:
+        command.append(ref)
+    command += ["--", "*Cargo.toml"]
+    output = subprocess.run(command, capture_output=True, text=True).stdout
+    hits: dict[str, str] = {}
+    for line in output.splitlines():
+        if ref and line.startswith(f"{ref}:"):
+            line = line[len(ref) + 1 :]
+        path, _, content = line.partition(":")
+        if path:
+            hits[path] = hits.get(path, "") + content + "\n"
+    return hits
 
 
 def resolve_baseline(root: Path) -> str:
@@ -488,6 +509,43 @@ def check_cxx_bridge(root: Path, baseline: Baseline) -> SurfaceResult:
 SCHEMAS = ["dora-schema.json", "libraries/core/dora-node-schema.json"]
 
 
+UNION_KEYS = ("oneOf", "anyOf", "allOf")
+
+
+def subschema_key(node) -> str:
+    """Stable identity for one alternative of a `oneOf` / `anyOf` list.
+
+    Not its index. schemars emits one alternative per enum variant, so an
+    added variant shifts every later index and an index-keyed diff then
+    compares unrelated alternatives -- reporting a pile of breaks for a purely
+    additive change. Keyed by content, an insertion is just an insertion.
+    """
+    if isinstance(node, dict):
+        if "$ref" in node:
+            return str(node["$ref"]).rsplit("/", 1)[-1]
+        if "const" in node:
+            return f"const={json.dumps(node['const'], sort_keys=True)}"
+        if isinstance(node.get("enum"), list):
+            return "enum=" + ",".join(sorted(json.dumps(v) for v in node["enum"]))
+        if isinstance(node.get("properties"), dict):
+            return "object{" + ",".join(sorted(node["properties"])) + "}"
+        if "type" in node:
+            t = node["type"]
+            return t if isinstance(t, str) else "|".join(sorted(t))
+    digest = hashlib.sha256(json.dumps(node, sort_keys=True).encode()).hexdigest()
+    return f"sha:{digest[:12]}"
+
+
+def union_member_keys(members: list) -> list[str]:
+    """`subschema_key` per member, disambiguated if two collide."""
+    keys, seen = [], {}
+    for member in members:
+        key = subschema_key(member)
+        seen[key] = seen.get(key, 0) + 1
+        keys.append(key if seen[key] == 1 else f"{key}#{seen[key]}")
+    return keys
+
+
 def flatten_schema(node, path: str = "#", out: dict | None = None) -> dict:
     """Map every schema location to the parts of it a dataflow can depend on.
 
@@ -510,10 +568,20 @@ def flatten_schema(node, path: str = "#", out: dict | None = None) -> dict:
             entry["type"] = sorted(t) if isinstance(t, list) else [t]
         if isinstance(node.get("additionalProperties"), bool):
             entry["additionalProperties"] = node["additionalProperties"]
+        unions = {}
+        for key in UNION_KEYS:
+            if isinstance(node.get(key), list):
+                unions[key] = union_member_keys(node[key])
+        if unions:
+            entry["unions"] = unions
         if entry:
             out[path] = entry
         for key, value in node.items():
-            flatten_schema(value, f"{path}/{key}", out)
+            if key in UNION_KEYS and isinstance(value, list):
+                for member_key, member in zip(unions[key], value):
+                    flatten_schema(member, f"{path}/{key}/{member_key}", out)
+            else:
+                flatten_schema(value, f"{path}/{key}", out)
     elif isinstance(node, list):
         for i, value in enumerate(node):
             flatten_schema(value, f"{path}/{i}", out)
@@ -530,11 +598,14 @@ def diff_schema(old: dict, new: dict) -> list[Finding]:
             if any(path.startswith(p + "/") for p in reported_gone):
                 continue
             reported_gone.append(path)
-            # A removed property is already reported against its parent, in
-            # the parent's own terms ("property `env` removed"). Reporting the
+            # A removed property or union alternative is already reported
+            # against its parent, in the parent's own terms. Reporting the
             # vanished path too says the same thing twice, less clearly.
             parent, _, _ = path.rpartition("/")
-            if parent.endswith("/properties") and parent.rpartition("/")[0] in new:
+            covered_by_parent = parent.endswith("/properties") or parent.endswith(
+                UNION_KEYS
+            )
+            if covered_by_parent and parent.rpartition("/")[0] in new:
                 continue
             findings.append(Finding(BREAK, f"{path}: removed from the schema"))
             continue
@@ -557,6 +628,13 @@ def diff_schema(old: dict, new: dict) -> list[Finding]:
         for t in old_entry.get("type", []):
             if t not in new_entry.get("type", []):
                 findings.append(Finding(BREAK, f"{path}: no longer accepts type `{t}`"))
+        for key, members in old_entry.get("unions", {}).items():
+            now = new_entry.get("unions", {}).get(key, [])
+            for member in members:
+                if member not in now:
+                    findings.append(
+                        Finding(BREAK, f"{path}: {key} no longer accepts `{member}`")
+                    )
         if new_entry.get("additionalProperties") is False and old_entry.get(
             "additionalProperties"
         ) is not False:
@@ -608,42 +686,52 @@ SERDE_WIRE_KEYS = (
 )
 
 
-def skip_attributes(text: str, i: int) -> int:
-    """Advance past whitespace and `#[...]` attributes starting at `i`."""
+def collect_attribute_run(text: str, i: int) -> tuple[list[str], int]:
+    """The run of `#[...]` attributes starting at `i`, and the index after it."""
+    attrs = []
     while True:
         while i < len(text) and text[i].isspace():
             i += 1
-        if text.startswith("#[", i):
-            depth = 0
-            while i < len(text):
-                if text[i] == "[":
-                    depth += 1
-                elif text[i] == "]":
-                    depth -= 1
-                    if depth == 0:
-                        i += 1
-                        break
-                i += 1
-        else:
-            return i
+        if not text.startswith("#[", i):
+            return attrs, i
+        depth, start = 0, i
+        while i < len(text):
+            if text[i] == "[":
+                depth += 1
+            elif text[i] == "]":
+                depth -= 1
+                if depth == 0:
+                    i += 1
+                    break
+            i += 1
+        attrs.append(text[start:i])
+
+
+def serde_wire_attrs(attrs: str) -> list[str]:
+    """The serde keys in `attrs` that change what goes on the wire.
+
+    `default`, `alias` and friends only widen decoding, so they are dropped:
+    treating them as changes would fail the gate on a strictly compatible edit.
+    """
+    kept = []
+    for attr in re.findall(r"#\[serde\(([^\]]*)\)\]", attrs):
+        for part in split_top_level(attr):
+            if part.split("=")[0].strip() in SERDE_WIRE_KEYS:
+                kept.append(collapse_ws(part))
+    return sorted(kept)
 
 
 def normalize_member(entry: str) -> str:
     """A member as the wire sees it: name, type, and the serde keys that move
-    bytes. `#[serde(default)]` and friends only widen decoding, so they are
-    dropped -- keeping them would report every such addition as a change."""
-    kept = []
-    for attr in re.findall(r"#\[serde\(([^\]]*)\)\]", entry):
-        for part in split_top_level(attr):
-            if part.split("=")[0].strip() in SERDE_WIRE_KEYS:
-                kept.append(collapse_ws(part))
+    bytes."""
+    kept = serde_wire_attrs(entry)
     entry = collapse_ws(re.sub(r"#\[[^\]]*\]", " ", entry))
     entry = re.sub(r"^pub(\([^)]*\))?\s+", "", entry)
     # A trailing comma inside a braced variant payload is rustfmt's choice, not
     # a wire change -- normalize it away so reformatting cannot fail the gate.
     entry = re.sub(r",\s*(?=[}\)])", " ", entry)
     entry = collapse_ws(entry)
-    suffix = f" [serde: {', '.join(sorted(kept))}]" if kept else ""
+    suffix = f" [serde: {', '.join(kept)}]" if kept else ""
     return entry + suffix
 
 
@@ -662,6 +750,11 @@ def strip_cfg_test_modules(text: str) -> str:
         text = text[: match.start()] + text[end:]
 
 
+ITEM_RE = re.compile(
+    r"(?:pub(?:\([^)]*\))?\s+)?(struct|enum)\s+(\w+)\s*(?:<[^>]*>)?\s*"
+)
+
+
 def parse_wire_types(files: dict[str, str]) -> dict[str, dict]:
     """Serde-derived types in `dora-message`, with members in declaration order.
 
@@ -672,27 +765,33 @@ def parse_wire_types(files: dict[str, str]) -> dict[str, dict]:
     other if this drifts.
 
     Newtypes count: `DataId(String)` becoming `DataId(u64)` changes the bytes
-    of every message carrying one.
+    of every message carrying one. So do container attributes: `#[serde(
+    untagged)]` decides whether a variant tag is written at all, and it can sit
+    on either side of the derive -- which is why whole attribute *runs* are
+    collected rather than scanned forward from the derive.
     """
     types: dict[str, dict] = {}
     for rel, text in sorted(files.items()):
         text = strip_cfg_test_modules(strip_rust_comments(text))
         module = Path(rel).stem
-        for m in re.finditer(r"#\[derive\(([^)]*)\)\]", text):
-            derives = m.group(1)
+        i = 0
+        while True:
+            at = text.find("#[", i)
+            if at == -1:
+                break
+            attrs, after = collect_attribute_run(text, at)
+            i = after
+            joined = " ".join(attrs)
+            derives = " ".join(re.findall(r"#\[derive\(([^)]*)\)\]", joined))
             if "Serialize" not in derives and "Deserialize" not in derives:
                 continue
-            i = skip_attributes(text, m.end())
-            item = re.match(
-                r"(?:pub(?:\([^)]*\))?\s+)?(struct|enum)\s+(\w+)\s*(?:<[^>]*>)?\s*",
-                text[i:],
-            )
+            item = ITEM_RE.match(text, after)
             if not item:
                 continue
             kind, name = item.group(1), item.group(2)
-            rest = i + item.end()
+            rest = item.end()
             if rest < len(text) and text[rest] == "{":
-                body, _ = balanced_block(text, rest)
+                body, i = balanced_block(text, rest)
                 members = [
                     normalize_member(e) for e in split_top_level(body) if e.strip()
                 ]
@@ -710,9 +809,15 @@ def parse_wire_types(files: dict[str, str]) -> dict[str, dict]:
                 members = [
                     f"{idx}: {normalize_member(f)}" for idx, f in enumerate(fields)
                 ]
+                i = j
             else:
                 members = []
-            types[f"{module}::{name}"] = {"kind": kind, "members": members}
+                i = rest
+            types[f"{module}::{name}"] = {
+                "kind": kind,
+                "members": members,
+                "container": serde_wire_attrs(joined),
+            }
     return types
 
 
@@ -740,6 +845,17 @@ def check_wire_format(root: Path, baseline: Baseline) -> SurfaceResult:
             )
             continue
         new_type = new[name]
+        if new_type.get("container") != old_type.get("container"):
+            # `untagged`, `tag`, `from`/`into`: these decide the framing of the
+            # whole type, so a change reshapes every message carrying it.
+            result.findings.append(
+                Finding(
+                    BREAK,
+                    f"`{name}`: serde container attributes changed "
+                    f"({old_type.get('container') or 'none'} -> "
+                    f"{new_type.get('container') or 'none'})",
+                )
+            )
         if new_type["kind"] != old_type["kind"]:
             result.findings.append(
                 Finding(
@@ -805,10 +921,16 @@ def parse_cli_surface(text: str) -> dict[str, set[str]]:
 def check_cli(root: Path, baseline: Baseline) -> SurfaceResult:
     result = SurfaceResult(name="`dora` command surface")
     current = root / CLI_SURFACE
+    old_text, used_ref = baseline.read_or_fallback(CLI_SURFACE)
     if not current.exists():
+        # Deleting the snapshot must not be the way to silence this check.
+        if old_text is not None:
+            result.findings.append(
+                Finding(BREAK, f"{CLI_SURFACE} was deleted, so the surface is unchecked")
+            )
+            return result
         result.skipped = f"{CLI_SURFACE} has not been generated"
         return result
-    old_text, used_ref = baseline.read_or_fallback(CLI_SURFACE)
     if old_text is None:
         result.skipped = (
             "no baseline snapshot (the first release carrying one becomes the "
@@ -837,7 +959,6 @@ def check_cli(root: Path, baseline: Baseline) -> SurfaceResult:
 # --------------------------------------------------------------------------
 
 PYPROJECTS = ["apis/python/node/pyproject.toml", "apis/python/cli/pyproject.toml"]
-ABI3_MANIFESTS = ["apis/python/node/Cargo.toml", "apis/python/cli/Cargo.toml"]
 
 
 def python_floor(text: str) -> str | None:
@@ -845,9 +966,17 @@ def python_floor(text: str) -> str | None:
     return match.group(1) if match else None
 
 
-def abi3_tag(text: str) -> str | None:
-    match = re.search(r"abi3-py(\d+)", text)
-    return f"abi3-py{match.group(1)}" if match else None
+def abi3_floor(text: str) -> tuple[int, int] | None:
+    """The lowest `abi3-pyXY` tag in `text`, as (major, minor).
+
+    Parsed digit by digit rather than through `version_tuple`, which reads the
+    `3` in "abi3" and returns the same answer for every tag.
+    """
+    tags = [
+        (int(m.group(1)), int(m.group(2)))
+        for m in re.finditer(r"abi3-py(\d)(\d+)", text)
+    ]
+    return min(tags) if tags else None
 
 
 def version_tuple(spec: str) -> tuple[int, ...]:
@@ -865,39 +994,60 @@ def check_python_floor(root: Path, baseline: Baseline) -> SurfaceResult:
         current = root / rel
         if old_text is None or not current.exists():
             continue
-        old_floor = python_floor(old_text)
-        new_floor = python_floor(current.read_text())
-        if old_floor is None or new_floor is None:
+        old_spec = python_floor(old_text)
+        new_spec = python_floor(current.read_text())
+        if old_spec is None or new_spec is None:
             continue
-        checked.append(new_floor)
-        if version_tuple(new_floor) > version_tuple(old_floor):
+        checked.append(new_spec)
+        if version_tuple(new_spec) > version_tuple(old_spec):
             result.findings.append(
                 Finding(
                     BREAK,
-                    f"{rel}: requires-python raised {old_floor} -> {new_floor}; "
+                    f"{rel}: requires-python raised {old_spec} -> {new_spec}; "
                     "pip refuses to install on interpreters dora used to support",
                 )
             )
-    for rel in ABI3_MANIFESTS:
-        old_text = baseline.read(rel)
-        current = root / rel
-        if old_text is None or not current.exists():
+
+    # The abi3 tag is set on the workspace `pyo3` dependency and repeated in
+    # the crates that name pyo3 directly, so scan every manifest rather than
+    # guessing which one holds it -- the two wheel crates inherit it and
+    # mention it only in comments. Compared per manifest, not as one lowest
+    # floor across all of them: a raise in the workspace dependency is what
+    # actually moves the wheels, and a single unraised crate elsewhere would
+    # otherwise hide it.
+    old_abi3 = grep_tracked(root, baseline.ref, "abi3-py")
+    new_abi3 = grep_tracked(root, None, "abi3-py")
+    floors = []
+    for rel, old_line in sorted(old_abi3.items()):
+        old_floor = abi3_floor(old_line)
+        new_floor = abi3_floor(new_abi3.get(rel, ""))
+        if not old_floor:
             continue
-        old_tag, new_tag = abi3_tag(old_text), abi3_tag(current.read_text())
-        if old_tag and new_tag and version_tuple(new_tag) > version_tuple(old_tag):
-            result.findings.append(
-                Finding(BREAK, f"{rel}: abi3 floor raised {old_tag} -> {new_tag}")
-            )
-        elif old_tag and not new_tag:
+        if not new_floor:
+            if rel in new_abi3 or (root / rel).exists():
+                result.findings.append(
+                    Finding(
+                        WARN,
+                        f"{rel}: the abi3 feature is gone, so its wheel is no "
+                        "longer built for a stable ABI",
+                    )
+                )
+            continue
+        floors.append(new_floor)
+        if new_floor > old_floor:
             result.findings.append(
                 Finding(
-                    WARN,
-                    f"{rel}: the abi3 feature is gone, so the wheel is no longer "
-                    "built for a stable ABI",
+                    BREAK,
+                    f"{rel}: abi3 floor raised py{old_floor[0]}{old_floor[1]} -> "
+                    f"py{new_floor[0]}{new_floor[1]}; wheels stop loading on "
+                    "interpreters dora used to support",
                 )
             )
+    if floors:
+        checked.append("abi3-py%d%d" % min(floors))
+
     if not checked:
-        result.skipped = "no pyproject.toml files in the baseline"
+        result.skipped = "no Python manifests in the baseline"
         return result
     result.summary = ", ".join(sorted(set(checked)))
     return result
@@ -966,7 +1116,28 @@ CHECKS = [
 
 def run(root: Path, ref: str, fallback: str | None = None) -> tuple[list[SurfaceResult], int]:
     baseline = Baseline(root, ref, fallback)
-    results = [check(root, baseline) for check in CHECKS]
+    results = []
+    for check in CHECKS:
+        try:
+            results.append(check(root, baseline))
+        except Exception as error:  # noqa: BLE001 - see below
+            # A surface that cannot be parsed is unchecked, and an unchecked
+            # frozen surface is a failure, not a traceback that also takes the
+            # remaining checks down with it. Deleting the C header or renaming
+            # the cxx bridge module both land here.
+            results.append(
+                SurfaceResult(
+                    name=getattr(check, "__name__", "check"),
+                    findings=[
+                        Finding(
+                            BREAK,
+                            f"could not be checked ({type(error).__name__}: {error}); "
+                            "treated as a failure because an unchecked surface "
+                            "is an unguarded one",
+                        )
+                    ],
+                )
+            )
     return results, sum(len(r.breaks()) for r in results)
 
 

--- a/scripts/qa/breaking_changes.py
+++ b/scripts/qa/breaking_changes.py
@@ -199,28 +199,26 @@ def strip_rust_comments(text: str) -> str:
     Block comments are left alone: they are rare in the files parsed here and
     stripping them naively would corrupt any `*/` inside a string literal.
     """
-    out = []
-    for line in text.splitlines():
-        stripped = re.sub(r"//[^\n]*", "", line)
-        out.append(stripped)
-    return "\n".join(out)
+    return re.sub(r"//[^\n]*", "", text)
 
 
 def collapse_ws(text: str) -> str:
     return re.sub(r"\s+", " ", text).strip()
 
 
-def balanced_block(text: str, open_idx: int) -> tuple[str, int]:
-    """Body of the `{...}` starting at `open_idx`, plus the index after it."""
+def balanced_block(
+    text: str, open_idx: int, open_ch: str = "{", close_ch: str = "}"
+) -> tuple[str, int]:
+    """Body of the bracketed group starting at `open_idx`, and the index after."""
     depth = 0
     for i in range(open_idx, len(text)):
-        if text[i] == "{":
+        if text[i] == open_ch:
             depth += 1
-        elif text[i] == "}":
+        elif text[i] == close_ch:
             depth -= 1
             if depth == 0:
                 return text[open_idx + 1 : i], i + 1
-    raise ValueError("unbalanced braces")
+    raise ValueError(f"unbalanced {open_ch}{close_ch}")
 
 
 def split_top_level(text: str, sep: str = ",") -> list[str]:
@@ -271,16 +269,70 @@ def compare_ordered(
             Finding(BREAK, f"{owner}: {kind} order changed ({reorder_note})")
         )
     # An addition anywhere but the end shifts every later member's position.
-    if added and not removed and kept_old == kept_new:
-        tail = new[len(new) - len(added) :]
-        if sorted(tail) != sorted(added):
+    # Nothing was removed and the shared members kept their order, so `old` is
+    # a subsequence of `new`: appending is exactly `new` starting with `old`.
+    if added and not removed and kept_old == kept_new and new[: len(old)] != old:
+        findings.append(
+            Finding(
+                BREAK,
+                f"{owner}: {kind} inserted before the end, shifting later "
+                f"{kind}s ({reorder_note})",
+            )
+        )
+    return findings
+
+
+def compare_signature_maps(
+    noun: str,
+    old: dict[str, str],
+    new: dict[str, str],
+    *,
+    added_level: str = WARN,
+) -> list[Finding]:
+    """Compare `name -> signature` maps: the C functions and the cxx fns."""
+    findings = []
+    for name, signature in old.items():
+        if name not in new:
+            findings.append(Finding(BREAK, f"{noun} `{name}` removed"))
+        elif new[name] != signature:
             findings.append(
                 Finding(
                     BREAK,
-                    f"{owner}: {kind} inserted before the end, shifting later "
-                    f"{kind}s ({reorder_note})",
+                    f"{noun} `{name}` signature changed: "
+                    f"`{signature}` -> `{new[name]}`",
                 )
             )
+    for name in new:
+        if name not in old:
+            findings.append(Finding(added_level, f"{noun} `{name}` added"))
+    return findings
+
+
+def compare_member_maps(
+    noun: str,
+    member_kind: str,
+    old: dict[str, list[str]],
+    new: dict[str, list[str]],
+    *,
+    added_level: str,
+    reorder_note: str,
+) -> list[Finding]:
+    """Compare `name -> ordered members` maps: C enums, cxx structs and enums."""
+    findings = []
+    for name, members in old.items():
+        if name not in new:
+            findings.append(Finding(BREAK, f"{noun} `{name}` removed"))
+            continue
+        findings.extend(
+            compare_ordered(
+                member_kind,
+                f"{noun} `{name}`",
+                members,
+                new[name],
+                added_level=added_level,
+                reorder_note=reorder_note,
+            )
+        )
     return findings
 
 
@@ -349,37 +401,19 @@ def check_c_header(root: Path, baseline: Baseline) -> SurfaceResult:
     old = parse_c_header(old_text)
     new = parse_c_header((root / C_HEADER).read_text())
 
-    for name, sig in old["functions"].items():
-        if name not in new["functions"]:
-            result.findings.append(Finding(BREAK, f"function `{name}` removed"))
-        elif new["functions"][name] != sig:
-            result.findings.append(
-                Finding(
-                    BREAK,
-                    f"function `{name}` signature changed: "
-                    f"`{sig}` -> `{new['functions'][name]}`",
-                )
-            )
-    for name in new["functions"]:
-        if name not in old["functions"]:
-            result.findings.append(Finding(WARN, f"function `{name}` added"))
-
-    for name, constants in old["enums"].items():
-        if name not in new["enums"]:
-            result.findings.append(Finding(BREAK, f"enum `{name}` removed"))
-            continue
-        # C enum constants are ABI: their ordinals are compiled into every
-        # node built against the old header.
-        result.findings.extend(
-            compare_ordered(
-                "constant",
-                f"enum `{name}`",
-                constants,
-                new["enums"][name],
-                added_level=WARN,
-                reorder_note="ordinals are compiled into existing nodes",
-            )
-        )
+    result.findings += compare_signature_maps(
+        "function", old["functions"], new["functions"]
+    )
+    # C enum constants are ABI: their ordinals are compiled into every node
+    # built against the old header.
+    result.findings += compare_member_maps(
+        "enum",
+        "constant",
+        old["enums"],
+        new["enums"],
+        added_level=WARN,
+        reorder_note="ordinals are compiled into existing nodes",
+    )
 
     result.summary = (
         f"{len(new['functions'])} functions, {len(new['enums'])} enums"
@@ -454,46 +488,26 @@ def check_cxx_bridge(root: Path, baseline: Baseline) -> SurfaceResult:
     old = parse_cxx_bridge(old_text)
     new = parse_cxx_bridge((root / CXX_BRIDGE).read_text())
 
-    for name, fields in old["structs"].items():
-        if name not in new["structs"]:
-            result.findings.append(Finding(BREAK, f"struct `{name}` removed"))
-            continue
-        result.findings.extend(
-            compare_ordered(
-                "field",
-                f"struct `{name}`",
-                fields,
-                new["structs"][name],
-                # A new field changes the generated C++ struct layout.
-                added_level=BREAK,
-                reorder_note="the generated C++ struct layout changes",
-            )
-        )
-    for name, variants in old["enums"].items():
-        if name not in new["enums"]:
-            result.findings.append(Finding(BREAK, f"enum `{name}` removed"))
-            continue
-        result.findings.extend(
-            compare_ordered(
-                "variant",
-                f"enum `{name}`",
-                variants,
-                new["enums"][name],
-                added_level=WARN,
-                reorder_note="discriminants are compiled into existing nodes",
-            )
-        )
-    for name, sig in old["functions"].items():
-        if name not in new["functions"]:
-            result.findings.append(Finding(BREAK, f"fn `{name}` removed"))
-        elif new["functions"][name] != sig:
-            result.findings.append(
-                Finding(
-                    BREAK,
-                    f"fn `{name}` signature changed: `{sig}` -> "
-                    f"`{new['functions'][name]}`",
-                )
-            )
+    result.findings += compare_member_maps(
+        "struct",
+        "field",
+        old["structs"],
+        new["structs"],
+        # A new field changes the generated C++ struct layout.
+        added_level=BREAK,
+        reorder_note="the generated C++ struct layout changes",
+    )
+    result.findings += compare_member_maps(
+        "enum",
+        "variant",
+        old["enums"],
+        new["enums"],
+        added_level=WARN,
+        reorder_note="discriminants are compiled into existing nodes",
+    )
+    result.findings += compare_signature_maps(
+        "fn", old["functions"], new["functions"]
+    )
 
     result.summary = (
         f"{len(new['structs'])} structs, {len(new['enums'])} enums, "
@@ -506,6 +520,10 @@ def check_cxx_bridge(root: Path, baseline: Baseline) -> SurfaceResult:
 # Surface 3: the dataflow YAML schema
 # --------------------------------------------------------------------------
 
+# `libraries/core/dora-schema.json` is deliberately absent: it is a byte-for-byte
+# copy of the root file (the generator writes both), so diffing it would report
+# every schema finding twice. The freshness check in breaking-changes.sh still
+# covers it -- there the point is that the copies stay in step.
 SCHEMAS = ["dora-schema.json", "libraries/core/dora-node-schema.json"]
 
 
@@ -773,7 +791,11 @@ def parse_wire_types(files: dict[str, str]) -> dict[str, dict]:
     types: dict[str, dict] = {}
     for rel, text in sorted(files.items()):
         text = strip_cfg_test_modules(strip_rust_comments(text))
-        module = Path(rel).stem
+        # Full relative path, not just the stem: two `mod.rs`-style files in
+        # different subdirectories would otherwise collide and one would
+        # silently overwrite the other, shrinking the checked set on both
+        # sides at once so the gate still reported "ok".
+        module = "::".join(Path(rel).with_suffix("").parts)
         i = 0
         while True:
             at = text.find("#[", i)
@@ -796,20 +818,11 @@ def parse_wire_types(files: dict[str, str]) -> dict[str, dict]:
                     normalize_member(e) for e in split_top_level(body) if e.strip()
                 ]
             elif rest < len(text) and text[rest] == "(":
-                depth, j = 0, rest
-                while j < len(text):
-                    if text[j] == "(":
-                        depth += 1
-                    elif text[j] == ")":
-                        depth -= 1
-                        if depth == 0:
-                            break
-                    j += 1
-                fields = split_top_level(text[rest + 1 : j])
+                body, i = balanced_block(text, rest, "(", ")")
                 members = [
-                    f"{idx}: {normalize_member(f)}" for idx, f in enumerate(fields)
+                    f"{idx}: {normalize_member(f)}"
+                    for idx, f in enumerate(split_top_level(body))
                 ]
-                i = j
             else:
                 members = []
                 i = rest
@@ -958,6 +971,8 @@ def check_cli(root: Path, baseline: Baseline) -> SurfaceResult:
 # Surface 6: the Python support floor
 # --------------------------------------------------------------------------
 
+# The two published wheels. `scripts/release/verify-release.py` keeps the same
+# pair as PYPI_MANIFESTS -- a third wheel has to be added in both places.
 PYPROJECTS = ["apis/python/node/pyproject.toml", "apis/python/cli/pyproject.toml"]
 
 
@@ -1064,12 +1079,19 @@ def workspace_version(text: str) -> str | None:
 
 
 def check_version_guard(root: Path, baseline: Baseline) -> SurfaceResult:
-    """Catch the one change that would silence every other check.
+    """Stop at a major version bump, which is the one thing this cannot judge.
 
-    `cargo-semver-checks` reports nothing when the version bump already allows
-    breakage, so a major bump turns the Rust half of this gate off. Post-1.0
-    that bump is exactly the event worth stopping at, so it is reported here
-    rather than being the thing that hides everything else.
+    Every check here asks "does this still honour what the last release
+    promised". A 2.0 changes the question: the promises are being withdrawn on
+    purpose, so a report of breaking changes is the expected answer rather than
+    a problem, and a gate that just went green or red would be misleading
+    either way. The bump therefore has to be stated (`ALLOW_MAJOR_BUMP=1`),
+    which puts a human on the decision.
+
+    Related but separate: `cargo-semver-checks` would *also* fall silent on a
+    major bump, concluding breakage is permitted. `semver.sh` passes
+    `--release-type minor` so it does not. This guard is not a workaround for
+    that -- do not remove either one on the strength of the other.
     """
     result = SurfaceResult(name="Workspace version")
     old_text = baseline.read("Cargo.toml")
@@ -1090,9 +1112,11 @@ def check_version_guard(root: Path, baseline: Baseline) -> SurfaceResult:
         result.findings.append(
             Finding(
                 BREAK,
-                f"major version bump {old} -> {new}: this silences "
-                "cargo-semver-checks, so breaking changes stop being reported. "
-                "Set ALLOW_MAJOR_BUMP=1 once that is deliberate.",
+                f"major version bump {old} -> {new}: a 2.0 withdraws the "
+                "promises every other check here is measuring against, so "
+                "they can no longer answer anything useful. Set "
+                "ALLOW_MAJOR_BUMP=1 (in the job or the shell) to say the bump "
+                "is deliberate.",
             )
         )
     result.summary = f"{old} -> {new}"
@@ -1127,7 +1151,7 @@ def run(root: Path, ref: str, fallback: str | None = None) -> tuple[list[Surface
             # the cxx bridge module both land here.
             results.append(
                 SurfaceResult(
-                    name=getattr(check, "__name__", "check"),
+                    name=check.__name__.removeprefix("check_").replace("_", " "),
                     findings=[
                         Finding(
                             BREAK,

--- a/scripts/qa/breaking_changes.py
+++ b/scripts/qa/breaking_changes.py
@@ -1,0 +1,1069 @@
+#!/usr/bin/env python3
+"""Compare every surface frozen by the dora 1.0 guarantee against a baseline.
+
+`docs/api-rust.md` ("Stability scope at 1.0") lists what 1.x freezes. Three
+mechanisms back it today -- exact version pins, feature gates, and the
+publish-graph gate -- and all three are about *cargo*. They say nothing about
+the surfaces users actually touch: the C header, the cxx bridge, the dataflow
+YAML schema, the `dora` command, and the postcard wire format. Those could all
+break with nothing failing until someone's deployment desynchronized.
+
+This script closes that gap without compiling anything: every surface here is
+extracted from source text (or a checked-in snapshot) on both sides, so the
+whole gate runs in seconds and can sit in PR CI. The compile-dependent halves
+live elsewhere and are wired up by `scripts/qa/breaking-changes.sh`:
+`cargo-semver-checks` for the Rust API, and the snapshot-freshness tests that
+keep the checked-in inputs here honest.
+
+Exit codes: 0 clean, 1 breaking changes found, 2 the gate could not run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# --------------------------------------------------------------------------
+# Findings
+# --------------------------------------------------------------------------
+
+BREAK = "BREAK"  # incompatible in at least one direction -- fails the gate
+WARN = "WARN"  # worth a human look, does not fail the gate
+
+
+@dataclass
+class Finding:
+    level: str
+    detail: str
+
+
+@dataclass
+class SurfaceResult:
+    name: str
+    findings: list[Finding] = field(default_factory=list)
+    skipped: str | None = None
+    summary: str = ""
+
+    def breaks(self) -> list[Finding]:
+        return [f for f in self.findings if f.level == BREAK]
+
+    def warns(self) -> list[Finding]:
+        return [f for f in self.findings if f.level == WARN]
+
+
+# --------------------------------------------------------------------------
+# Baseline access
+# --------------------------------------------------------------------------
+
+
+class Baseline:
+    """Read-only view of the tree at the baseline ref."""
+
+    def __init__(self, root: Path, ref: str, fallback: str | None = None):
+        self.root = root
+        self.ref = ref
+        self.fallback = fallback
+
+    def read_at(self, ref: str, rel: str) -> str | None:
+        proc = subprocess.run(
+            ["git", "-C", str(self.root), "show", f"{ref}:{rel}"],
+            capture_output=True,
+            text=True,
+        )
+        return proc.stdout if proc.returncode == 0 else None
+
+    def read(self, rel: str) -> str | None:
+        """File contents at the baseline ref, or None if it did not exist."""
+        return self.read_at(self.ref, rel)
+
+    def read_or_fallback(self, rel: str) -> tuple[str | None, str | None]:
+        """As `read`, falling back to a second ref for files the release
+        predates.
+
+        A surface file added after the last release has nothing to compare
+        against, so its check would sit skipped until the *next* release --
+        a window in which that surface is unguarded. CI passes the PR's base
+        commit as the fallback, which keeps the check live in the meantime by
+        asking a narrower question: did this branch remove anything?
+        """
+        text = self.read(rel)
+        if text is not None:
+            return text, self.ref
+        if self.fallback:
+            text = self.read_at(self.fallback, rel)
+            if text is not None:
+                return text, self.fallback
+        return None, None
+
+    def list_dir(self, rel: str) -> list[str]:
+        """Paths under `rel` at the baseline ref (recursive, repo-relative)."""
+        proc = subprocess.run(
+            ["git", "-C", str(self.root), "ls-tree", "-r", "--name-only", self.ref, rel],
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode != 0:
+            return []
+        return [line for line in proc.stdout.splitlines() if line]
+
+
+def tag_sort_key(tag: str) -> tuple:
+    """Semver ordering for a `vX.Y.Z[-pre]` tag.
+
+    Not `git tag --sort=-v:refname`: git sorts a prerelease suffix *after* the
+    release it precedes unless `versionsort.prereleaseSuffix` is configured, so
+    it would call `v1.0.0-rc.5` newer than `v1.0.0` and pick an rc as the
+    baseline for the release that superseded it.
+    """
+    match = re.fullmatch(r"v(\d+)\.(\d+)\.(\d+)(?:-(.+))?", tag)
+    if not match:
+        return ()
+    major, minor, patch, pre = match.groups()
+    # A prerelease sorts below the same version's final release.
+    return (int(major), int(minor), int(patch), 0 if pre else 1, pre or "")
+
+
+def resolve_baseline(root: Path) -> str:
+    """The newest released tag -- what deployed users are actually running.
+
+    Falls back to asking the remote for its tag *names* when the checkout has
+    none. A CI checkout is shallow and tagless, and the repo's pack is well
+    over a gigabyte, so `fetch-depth: 0` would make every PR pay a full clone
+    to read one file. `ls-remote` transfers no objects; the caller then fetches
+    just the one tag this returns.
+    """
+    proc = subprocess.run(
+        ["git", "-C", str(root), "tag", "--list", "v*"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    tags = [t for t in proc.stdout.splitlines() if t and tag_sort_key(t)]
+    if not tags:
+        remote = subprocess.run(
+            ["git", "-C", str(root), "ls-remote", "--tags", "origin"],
+            capture_output=True,
+            text=True,
+        )
+        tags = [
+            name
+            for line in remote.stdout.splitlines()
+            for name in [line.split("refs/tags/")[-1]]
+            if not name.endswith("^{}") and tag_sort_key(name)
+        ]
+    if not tags:
+        raise SystemExit("error: no release tags found; pass --baseline <ref> explicitly")
+    return max(tags, key=tag_sort_key)
+
+
+# --------------------------------------------------------------------------
+# Shared text helpers
+# --------------------------------------------------------------------------
+
+
+def strip_c_comments(text: str) -> str:
+    text = re.sub(r"/\*.*?\*/", " ", text, flags=re.S)
+    return re.sub(r"//[^\n]*", " ", text)
+
+
+def strip_rust_comments(text: str) -> str:
+    """Drop `//` line comments (doc comments included).
+
+    Block comments are left alone: they are rare in the files parsed here and
+    stripping them naively would corrupt any `*/` inside a string literal.
+    """
+    out = []
+    for line in text.splitlines():
+        stripped = re.sub(r"//[^\n]*", "", line)
+        out.append(stripped)
+    return "\n".join(out)
+
+
+def collapse_ws(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def balanced_block(text: str, open_idx: int) -> tuple[str, int]:
+    """Body of the `{...}` starting at `open_idx`, plus the index after it."""
+    depth = 0
+    for i in range(open_idx, len(text)):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[open_idx + 1 : i], i + 1
+    raise ValueError("unbalanced braces")
+
+
+def split_top_level(text: str, sep: str = ",") -> list[str]:
+    """Split on `sep`, ignoring separators nested in (), [], <> or {}."""
+    parts, depth, current = [], 0, []
+    for ch in text:
+        if ch in "([{<":
+            depth += 1
+        elif ch in ")]}>":
+            depth -= 1
+        if ch == sep and depth == 0:
+            parts.append("".join(current))
+            current = []
+        else:
+            current.append(ch)
+    parts.append("".join(current))
+    return [p.strip() for p in parts if p.strip()]
+
+
+def compare_ordered(
+    kind: str,
+    owner: str,
+    old: list[str],
+    new: list[str],
+    *,
+    added_level: str,
+    reorder_note: str,
+) -> list[Finding]:
+    """Compare two ordered member lists where position is part of the contract.
+
+    Used for anything whose encoding is positional: C enum constants (ordinals),
+    postcard struct fields and enum discriminants. Removal, rename and reorder
+    are all breaking; whether an *addition* breaks depends on the encoding, so
+    the caller passes its severity.
+    """
+    findings = []
+    removed = [m for m in old if m not in new]
+    added = [m for m in new if m not in old]
+    for m in removed:
+        findings.append(Finding(BREAK, f"{owner}: {kind} `{m}` removed"))
+    for m in added:
+        findings.append(Finding(added_level, f"{owner}: {kind} `{m}` added"))
+    # Reorder: compare the members present on both sides in their two orders.
+    kept_old = [m for m in old if m in new]
+    kept_new = [m for m in new if m in old]
+    if kept_old != kept_new and not removed:
+        findings.append(
+            Finding(BREAK, f"{owner}: {kind} order changed ({reorder_note})")
+        )
+    # An addition anywhere but the end shifts every later member's position.
+    if added and not removed and kept_old == kept_new:
+        tail = new[len(new) - len(added) :]
+        if sorted(tail) != sorted(added):
+            findings.append(
+                Finding(
+                    BREAK,
+                    f"{owner}: {kind} inserted before the end, shifting later "
+                    f"{kind}s ({reorder_note})",
+                )
+            )
+    return findings
+
+
+# --------------------------------------------------------------------------
+# Surface 1: the C node API header
+# --------------------------------------------------------------------------
+
+C_HEADER = "apis/c/node/node_api.h"
+
+
+def parse_c_header(text: str) -> dict:
+    """Functions (name -> type signature) and enums (name -> ordered constants).
+
+    Parameter *names* are dropped: renaming one is not a break in C, and keeping
+    them would report every doc-driven rename as a signature change.
+    """
+    text = strip_c_comments(text)
+
+    enums: dict[str, list[str]] = {}
+    for match in re.finditer(r"\benum\s+(\w+)\s*\{([^}]*)\}", text):
+        constants = []
+        for entry in split_top_level(match.group(2)):
+            name = entry.split("=")[0].strip()
+            if name:
+                constants.append(name)
+        enums[match.group(1)] = constants
+    # Remove the enum bodies so the function scan below cannot see into them.
+    text = re.sub(r"\benum\s+\w+\s*\{[^}]*\}", " ", text)
+
+    functions: dict[str, str] = {}
+    for match in re.finditer(r"([\w\s*]+?)\s*\b(\w+)\s*\(([^)]*)\)\s*;", text):
+        ret, name, params = match.group(1), match.group(2), match.group(3)
+        functions[name] = f"{normalize_c_type(ret)} ({normalize_c_params(params)})"
+
+    return {"functions": functions, "enums": enums}
+
+
+C_TYPE_KEYWORDS = {
+    "void", "char", "short", "int", "long", "float", "double", "signed",
+    "unsigned", "size_t", "const", "enum", "struct", "union", "_Bool",
+}
+
+
+def normalize_c_type(text: str) -> str:
+    return collapse_ws(text.replace("*", " * "))
+
+
+def normalize_c_params(params: str) -> str:
+    out = []
+    for param in split_top_level(params):
+        tokens = normalize_c_type(param).split()
+        # Drop a trailing parameter name, but never the type itself.
+        if len(tokens) > 1 and re.fullmatch(r"[A-Za-z_]\w*", tokens[-1]):
+            if tokens[-1] not in C_TYPE_KEYWORDS:
+                tokens = tokens[:-1]
+        out.append(" ".join(tokens))
+    return ", ".join(out)
+
+
+def check_c_header(root: Path, baseline: Baseline) -> SurfaceResult:
+    result = SurfaceResult(name=f"C node API ({C_HEADER})")
+    old_text = baseline.read(C_HEADER)
+    if old_text is None:
+        result.skipped = "not present in the baseline"
+        return result
+    old = parse_c_header(old_text)
+    new = parse_c_header((root / C_HEADER).read_text())
+
+    for name, sig in old["functions"].items():
+        if name not in new["functions"]:
+            result.findings.append(Finding(BREAK, f"function `{name}` removed"))
+        elif new["functions"][name] != sig:
+            result.findings.append(
+                Finding(
+                    BREAK,
+                    f"function `{name}` signature changed: "
+                    f"`{sig}` -> `{new['functions'][name]}`",
+                )
+            )
+    for name in new["functions"]:
+        if name not in old["functions"]:
+            result.findings.append(Finding(WARN, f"function `{name}` added"))
+
+    for name, constants in old["enums"].items():
+        if name not in new["enums"]:
+            result.findings.append(Finding(BREAK, f"enum `{name}` removed"))
+            continue
+        # C enum constants are ABI: their ordinals are compiled into every
+        # node built against the old header.
+        result.findings.extend(
+            compare_ordered(
+                "constant",
+                f"enum `{name}`",
+                constants,
+                new["enums"][name],
+                added_level=WARN,
+                reorder_note="ordinals are compiled into existing nodes",
+            )
+        )
+
+    result.summary = (
+        f"{len(new['functions'])} functions, {len(new['enums'])} enums"
+    )
+    return result
+
+
+# --------------------------------------------------------------------------
+# Surface 2: the C++ node API (cxx bridge)
+# --------------------------------------------------------------------------
+
+CXX_BRIDGE = "apis/c++/node/src/lib.rs"
+
+
+def parse_cxx_bridge(text: str) -> dict:
+    """Items declared in `#[cxx::bridge] mod ffi { ... }`.
+
+    That block *is* the C++ API: cxx generates the header from it, so every
+    struct field, enum variant and fn signature here is user-visible.
+    """
+    text = strip_rust_comments(text)
+    match = re.search(r"#\[cxx::bridge\][\s\S]*?\bmod\s+\w+\s*\{", text)
+    if not match:
+        raise ValueError("no #[cxx::bridge] module found")
+    body, _ = balanced_block(text, match.end() - 1)
+
+    structs: dict[str, list[str]] = {}
+    enums: dict[str, list[str]] = {}
+    functions: dict[str, str] = {}
+
+    for m in re.finditer(r"\b(?:pub\s+)?(struct|enum)\s+(\w+)\s*\{", body):
+        block, _ = balanced_block(body, m.end() - 1)
+        members = []
+        for entry in split_top_level(block):
+            entry = re.sub(r"#\[[^\]]*\]", " ", entry).strip()
+            if not entry:
+                continue
+            if m.group(1) == "struct":
+                members.append(collapse_ws(entry))
+            else:
+                members.append(entry.split("=")[0].split("(")[0].strip())
+        if m.group(1) == "struct":
+            structs[m.group(2)] = members
+        else:
+            enums[m.group(2)] = members
+
+    for m in re.finditer(r"\b(?:unsafe\s+)?extern\s+\"[^\"]+\"\s*\{", body):
+        block, _ = balanced_block(body, m.end() - 1)
+        # Strip out any nested attribute noise, then take `;`-terminated decls.
+        block = re.sub(r"#\[[^\]]*\]", " ", block)
+        for decl in block.split(";"):
+            decl = collapse_ws(decl)
+            fn = re.match(r"(?:pub\s+)?(?:unsafe\s+)?fn\s+(\w+)\s*(.*)", decl)
+            if fn:
+                name, sig = fn.group(1), collapse_ws(fn.group(2))
+                # `fn next` is declared once per receiver type, so the receiver
+                # is part of the identity -- keyed by name alone, dropping one
+                # of them would look like no change at all.
+                receiver = re.search(r"\bself\s*:\s*&(?:mut\s+)?(\w+)", sig)
+                key = f"{receiver.group(1)}::{name}" if receiver else name
+                functions[key] = sig
+
+    return {"structs": structs, "enums": enums, "functions": functions}
+
+
+def check_cxx_bridge(root: Path, baseline: Baseline) -> SurfaceResult:
+    result = SurfaceResult(name="C++ node API (cxx bridge)")
+    old_text = baseline.read(CXX_BRIDGE)
+    if old_text is None:
+        result.skipped = "not present in the baseline"
+        return result
+    old = parse_cxx_bridge(old_text)
+    new = parse_cxx_bridge((root / CXX_BRIDGE).read_text())
+
+    for name, fields in old["structs"].items():
+        if name not in new["structs"]:
+            result.findings.append(Finding(BREAK, f"struct `{name}` removed"))
+            continue
+        result.findings.extend(
+            compare_ordered(
+                "field",
+                f"struct `{name}`",
+                fields,
+                new["structs"][name],
+                # A new field changes the generated C++ struct layout.
+                added_level=BREAK,
+                reorder_note="the generated C++ struct layout changes",
+            )
+        )
+    for name, variants in old["enums"].items():
+        if name not in new["enums"]:
+            result.findings.append(Finding(BREAK, f"enum `{name}` removed"))
+            continue
+        result.findings.extend(
+            compare_ordered(
+                "variant",
+                f"enum `{name}`",
+                variants,
+                new["enums"][name],
+                added_level=WARN,
+                reorder_note="discriminants are compiled into existing nodes",
+            )
+        )
+    for name, sig in old["functions"].items():
+        if name not in new["functions"]:
+            result.findings.append(Finding(BREAK, f"fn `{name}` removed"))
+        elif new["functions"][name] != sig:
+            result.findings.append(
+                Finding(
+                    BREAK,
+                    f"fn `{name}` signature changed: `{sig}` -> "
+                    f"`{new['functions'][name]}`",
+                )
+            )
+
+    result.summary = (
+        f"{len(new['structs'])} structs, {len(new['enums'])} enums, "
+        f"{len(new['functions'])} fns"
+    )
+    return result
+
+
+# --------------------------------------------------------------------------
+# Surface 3: the dataflow YAML schema
+# --------------------------------------------------------------------------
+
+SCHEMAS = ["dora-schema.json", "libraries/core/dora-node-schema.json"]
+
+
+def flatten_schema(node, path: str = "#", out: dict | None = None) -> dict:
+    """Map every schema location to the parts of it a dataflow can depend on.
+
+    Keyed by JSON pointer, so `$defs` entries line up across versions even when
+    the file is reordered. `$ref` is not followed -- each definition is visited
+    once, where it is defined.
+    """
+    if out is None:
+        out = {}
+    if isinstance(node, dict):
+        entry = {}
+        if isinstance(node.get("properties"), dict):
+            entry["properties"] = sorted(node["properties"])
+        if isinstance(node.get("required"), list):
+            entry["required"] = sorted(str(r) for r in node["required"])
+        if isinstance(node.get("enum"), list):
+            entry["enum"] = sorted(json.dumps(v, sort_keys=True) for v in node["enum"])
+        if "type" in node:
+            t = node["type"]
+            entry["type"] = sorted(t) if isinstance(t, list) else [t]
+        if isinstance(node.get("additionalProperties"), bool):
+            entry["additionalProperties"] = node["additionalProperties"]
+        if entry:
+            out[path] = entry
+        for key, value in node.items():
+            flatten_schema(value, f"{path}/{key}", out)
+    elif isinstance(node, list):
+        for i, value in enumerate(node):
+            flatten_schema(value, f"{path}/{i}", out)
+    return out
+
+
+def diff_schema(old: dict, new: dict) -> list[Finding]:
+    findings = []
+    reported_gone: list[str] = []
+    for path, old_entry in old.items():
+        if path not in new:
+            # Only report the outermost removal: every child of a removed
+            # definition is also missing, and listing them all buries it.
+            if any(path.startswith(p + "/") for p in reported_gone):
+                continue
+            reported_gone.append(path)
+            # A removed property is already reported against its parent, in
+            # the parent's own terms ("property `env` removed"). Reporting the
+            # vanished path too says the same thing twice, less clearly.
+            parent, _, _ = path.rpartition("/")
+            if parent.endswith("/properties") and parent.rpartition("/")[0] in new:
+                continue
+            findings.append(Finding(BREAK, f"{path}: removed from the schema"))
+            continue
+        new_entry = new[path]
+        for prop in old_entry.get("properties", []):
+            if prop not in new_entry.get("properties", []):
+                findings.append(Finding(BREAK, f"{path}: property `{prop}` removed"))
+        for req in new_entry.get("required", []):
+            if req not in old_entry.get("required", []):
+                findings.append(
+                    Finding(
+                        BREAK,
+                        f"{path}: `{req}` is now required, so dataflows that "
+                        "omit it stop validating",
+                    )
+                )
+        for value in old_entry.get("enum", []):
+            if value not in new_entry.get("enum", []):
+                findings.append(Finding(BREAK, f"{path}: enum value {value} removed"))
+        for t in old_entry.get("type", []):
+            if t not in new_entry.get("type", []):
+                findings.append(Finding(BREAK, f"{path}: no longer accepts type `{t}`"))
+        if new_entry.get("additionalProperties") is False and old_entry.get(
+            "additionalProperties"
+        ) is not False:
+            findings.append(
+                Finding(BREAK, f"{path}: additional properties are now rejected")
+            )
+    return findings
+
+
+def check_schema(root: Path, baseline: Baseline) -> SurfaceResult:
+    result = SurfaceResult(name="Dataflow YAML schema")
+    checked = 0
+    for rel in SCHEMAS:
+        old_text = baseline.read(rel)
+        if old_text is None:
+            continue
+        current = root / rel
+        if not current.exists():
+            result.findings.append(Finding(BREAK, f"{rel}: schema file removed"))
+            continue
+        old = flatten_schema(json.loads(old_text))
+        new = flatten_schema(json.loads(current.read_text()))
+        for finding in diff_schema(old, new):
+            result.findings.append(Finding(finding.level, f"{rel} {finding.detail}"))
+        checked += 1
+    if checked == 0:
+        result.skipped = "no schema files in the baseline"
+        return result
+    result.summary = f"{checked} schema files"
+    return result
+
+
+# --------------------------------------------------------------------------
+# Surface 4: the postcard wire format (dora-message)
+# --------------------------------------------------------------------------
+
+WIRE_DIR = "libraries/message/src"
+
+
+SERDE_WIRE_KEYS = (
+    "rename",
+    "rename_all",
+    "flatten",
+    "skip",
+    "tag",
+    "untagged",
+    "content",
+    "with",
+)
+
+
+def skip_attributes(text: str, i: int) -> int:
+    """Advance past whitespace and `#[...]` attributes starting at `i`."""
+    while True:
+        while i < len(text) and text[i].isspace():
+            i += 1
+        if text.startswith("#[", i):
+            depth = 0
+            while i < len(text):
+                if text[i] == "[":
+                    depth += 1
+                elif text[i] == "]":
+                    depth -= 1
+                    if depth == 0:
+                        i += 1
+                        break
+                i += 1
+        else:
+            return i
+
+
+def normalize_member(entry: str) -> str:
+    """A member as the wire sees it: name, type, and the serde keys that move
+    bytes. `#[serde(default)]` and friends only widen decoding, so they are
+    dropped -- keeping them would report every such addition as a change."""
+    kept = []
+    for attr in re.findall(r"#\[serde\(([^\]]*)\)\]", entry):
+        for part in split_top_level(attr):
+            if part.split("=")[0].strip() in SERDE_WIRE_KEYS:
+                kept.append(collapse_ws(part))
+    entry = collapse_ws(re.sub(r"#\[[^\]]*\]", " ", entry))
+    entry = re.sub(r"^pub(\([^)]*\))?\s+", "", entry)
+    # A trailing comma inside a braced variant payload is rustfmt's choice, not
+    # a wire change -- normalize it away so reformatting cannot fail the gate.
+    entry = re.sub(r",\s*(?=[}\)])", " ", entry)
+    entry = collapse_ws(entry)
+    suffix = f" [serde: {', '.join(sorted(kept))}]" if kept else ""
+    return entry + suffix
+
+
+def strip_cfg_test_modules(text: str) -> str:
+    """Drop `#[cfg(test)] mod ... { ... }` blocks.
+
+    Test modules define serde types of their own -- `bulk_bytes.rs` has six --
+    and they are not the wire protocol. Left in, deleting a test fixture would
+    be reported as a protocol break.
+    """
+    while True:
+        match = re.search(r"#\[cfg\(test\)\]\s*(?:pub\s+)?mod\s+\w+\s*\{", text)
+        if not match:
+            return text
+        _, end = balanced_block(text, match.end() - 1)
+        text = text[: match.start()] + text[end:]
+
+
+def parse_wire_types(files: dict[str, str]) -> dict[str, dict]:
+    """Serde-derived types in `dora-message`, with members in declaration order.
+
+    postcard is positional and carries no field names or type descriptors, so
+    the *order* of a struct's fields and of an enum's variants is the wire
+    format. `versions_compatible` is semver-caret, so a 1.0 node and a 1.5
+    daemon are waved through the handshake and will then simply misparse each
+    other if this drifts.
+
+    Newtypes count: `DataId(String)` becoming `DataId(u64)` changes the bytes
+    of every message carrying one.
+    """
+    types: dict[str, dict] = {}
+    for rel, text in sorted(files.items()):
+        text = strip_cfg_test_modules(strip_rust_comments(text))
+        module = Path(rel).stem
+        for m in re.finditer(r"#\[derive\(([^)]*)\)\]", text):
+            derives = m.group(1)
+            if "Serialize" not in derives and "Deserialize" not in derives:
+                continue
+            i = skip_attributes(text, m.end())
+            item = re.match(
+                r"(?:pub(?:\([^)]*\))?\s+)?(struct|enum)\s+(\w+)\s*(?:<[^>]*>)?\s*",
+                text[i:],
+            )
+            if not item:
+                continue
+            kind, name = item.group(1), item.group(2)
+            rest = i + item.end()
+            if rest < len(text) and text[rest] == "{":
+                body, _ = balanced_block(text, rest)
+                members = [
+                    normalize_member(e) for e in split_top_level(body) if e.strip()
+                ]
+            elif rest < len(text) and text[rest] == "(":
+                depth, j = 0, rest
+                while j < len(text):
+                    if text[j] == "(":
+                        depth += 1
+                    elif text[j] == ")":
+                        depth -= 1
+                        if depth == 0:
+                            break
+                    j += 1
+                fields = split_top_level(text[rest + 1 : j])
+                members = [
+                    f"{idx}: {normalize_member(f)}" for idx, f in enumerate(fields)
+                ]
+            else:
+                members = []
+            types[f"{module}::{name}"] = {"kind": kind, "members": members}
+    return types
+
+
+def check_wire_format(root: Path, baseline: Baseline) -> SurfaceResult:
+    result = SurfaceResult(name="Wire format (dora-message)")
+    old_files = {
+        rel[len(WIRE_DIR) + 1 :]: baseline.read(rel) or ""
+        for rel in baseline.list_dir(WIRE_DIR)
+        if rel.endswith(".rs")
+    }
+    if not old_files:
+        result.skipped = "no dora-message sources in the baseline"
+        return result
+    new_files = {
+        str(p.relative_to(root / WIRE_DIR)): p.read_text()
+        for p in (root / WIRE_DIR).rglob("*.rs")
+    }
+    old = parse_wire_types(old_files)
+    new = parse_wire_types(new_files)
+
+    for name, old_type in old.items():
+        if name not in new:
+            result.findings.append(
+                Finding(BREAK, f"`{name}` removed from the wire protocol")
+            )
+            continue
+        new_type = new[name]
+        if new_type["kind"] != old_type["kind"]:
+            result.findings.append(
+                Finding(
+                    BREAK,
+                    f"`{name}` changed from {old_type['kind']} to {new_type['kind']}",
+                )
+            )
+            continue
+        if old_type["kind"] == "struct":
+            # Every field is length-free and positional: adding one makes new
+            # messages undecodable by old peers *and* old messages undecodable
+            # by new ones, so additions break both directions.
+            added_level = BREAK
+            note = "postcard encodes fields positionally"
+        else:
+            # A new variant only breaks new -> old (an old peer cannot decode a
+            # discriminant it has never heard of). Old messages still decode,
+            # so this is reported rather than blocked -- it is how the protocol
+            # is meant to grow.
+            added_level = WARN
+            note = "postcard encodes the variant index"
+        result.findings.extend(
+            compare_ordered(
+                "field" if old_type["kind"] == "struct" else "variant",
+                f"`{name}`",
+                old_type["members"],
+                new_type["members"],
+                added_level=added_level,
+                reorder_note=note,
+            )
+        )
+
+    result.summary = f"{len(new)} serde types"
+    return result
+
+
+# --------------------------------------------------------------------------
+# Surface 5: the `dora` command
+# --------------------------------------------------------------------------
+
+CLI_SURFACE = "binaries/cli/cli-surface.txt"
+
+
+def parse_cli_surface(text: str) -> dict[str, set[str]]:
+    """`command -> {items}` from the checked-in snapshot.
+
+    The snapshot is generated from clap by `dora-cli`'s `cli_surface` test, so
+    comparing two snapshots needs no build on either side -- which is the only
+    reason the `dora` command can be checked in a compile-free gate at all.
+    """
+    surface: dict[str, set[str]] = {}
+    for line in text.splitlines():
+        line = line.split("#")[0].strip()
+        if not line:
+            continue
+        command, _, item = line.partition("|")
+        surface.setdefault(command.strip(), set())
+        if item.strip():
+            surface[command.strip()].add(item.strip())
+    return surface
+
+
+def check_cli(root: Path, baseline: Baseline) -> SurfaceResult:
+    result = SurfaceResult(name="`dora` command surface")
+    current = root / CLI_SURFACE
+    if not current.exists():
+        result.skipped = f"{CLI_SURFACE} has not been generated"
+        return result
+    old_text, used_ref = baseline.read_or_fallback(CLI_SURFACE)
+    if old_text is None:
+        result.skipped = (
+            "no baseline snapshot (the first release carrying one becomes the "
+            "baseline for every release after it)"
+        )
+        return result
+    old = parse_cli_surface(old_text)
+    new = parse_cli_surface(current.read_text())
+
+    for command, items in old.items():
+        if command not in new:
+            result.findings.append(Finding(BREAK, f"`{command}` removed"))
+            continue
+        for item in sorted(items - new[command]):
+            result.findings.append(Finding(BREAK, f"`{command}`: {item} removed"))
+        for item in sorted(new[command] - items):
+            result.findings.append(Finding(WARN, f"`{command}`: {item} added"))
+    result.summary = f"{len(new)} commands"
+    if used_ref != baseline.ref:
+        result.summary += f", vs {used_ref[:12]} ({baseline.ref} predates the snapshot)"
+    return result
+
+
+# --------------------------------------------------------------------------
+# Surface 6: the Python support floor
+# --------------------------------------------------------------------------
+
+PYPROJECTS = ["apis/python/node/pyproject.toml", "apis/python/cli/pyproject.toml"]
+ABI3_MANIFESTS = ["apis/python/node/Cargo.toml", "apis/python/cli/Cargo.toml"]
+
+
+def python_floor(text: str) -> str | None:
+    match = re.search(r"""requires-python\s*=\s*["']([^"']+)["']""", text)
+    return match.group(1) if match else None
+
+
+def abi3_tag(text: str) -> str | None:
+    match = re.search(r"abi3-py(\d+)", text)
+    return f"abi3-py{match.group(1)}" if match else None
+
+
+def version_tuple(spec: str) -> tuple[int, ...]:
+    match = re.search(r"(\d+)(?:\.(\d+))?", spec)
+    if not match:
+        return ()
+    return tuple(int(g) for g in match.groups() if g is not None)
+
+
+def check_python_floor(root: Path, baseline: Baseline) -> SurfaceResult:
+    result = SurfaceResult(name="Python support floor")
+    checked = []
+    for rel in PYPROJECTS:
+        old_text = baseline.read(rel)
+        current = root / rel
+        if old_text is None or not current.exists():
+            continue
+        old_floor = python_floor(old_text)
+        new_floor = python_floor(current.read_text())
+        if old_floor is None or new_floor is None:
+            continue
+        checked.append(new_floor)
+        if version_tuple(new_floor) > version_tuple(old_floor):
+            result.findings.append(
+                Finding(
+                    BREAK,
+                    f"{rel}: requires-python raised {old_floor} -> {new_floor}; "
+                    "pip refuses to install on interpreters dora used to support",
+                )
+            )
+    for rel in ABI3_MANIFESTS:
+        old_text = baseline.read(rel)
+        current = root / rel
+        if old_text is None or not current.exists():
+            continue
+        old_tag, new_tag = abi3_tag(old_text), abi3_tag(current.read_text())
+        if old_tag and new_tag and version_tuple(new_tag) > version_tuple(old_tag):
+            result.findings.append(
+                Finding(BREAK, f"{rel}: abi3 floor raised {old_tag} -> {new_tag}")
+            )
+        elif old_tag and not new_tag:
+            result.findings.append(
+                Finding(
+                    WARN,
+                    f"{rel}: the abi3 feature is gone, so the wheel is no longer "
+                    "built for a stable ABI",
+                )
+            )
+    if not checked:
+        result.skipped = "no pyproject.toml files in the baseline"
+        return result
+    result.summary = ", ".join(sorted(set(checked)))
+    return result
+
+
+# --------------------------------------------------------------------------
+# The version guard
+# --------------------------------------------------------------------------
+
+
+def workspace_version(text: str) -> str | None:
+    match = re.search(r"^version\s*=\s*\"([^\"]+)\"", text, flags=re.M)
+    return match.group(1) if match else None
+
+
+def check_version_guard(root: Path, baseline: Baseline) -> SurfaceResult:
+    """Catch the one change that would silence every other check.
+
+    `cargo-semver-checks` reports nothing when the version bump already allows
+    breakage, so a major bump turns the Rust half of this gate off. Post-1.0
+    that bump is exactly the event worth stopping at, so it is reported here
+    rather than being the thing that hides everything else.
+    """
+    result = SurfaceResult(name="Workspace version")
+    old_text = baseline.read("Cargo.toml")
+    if old_text is None:
+        result.skipped = "no baseline Cargo.toml"
+        return result
+    old = workspace_version(old_text)
+    new = workspace_version((root / "Cargo.toml").read_text())
+    if not old or not new:
+        result.skipped = "could not read a workspace version"
+        return result
+    old_major = version_tuple(old)[:1]
+    new_major = version_tuple(new)[:1]
+    if os.environ.get("ALLOW_MAJOR_BUMP"):
+        result.summary = f"{old} -> {new} (major bump allowed)"
+        return result
+    if new_major > old_major and old_major >= (1,):
+        result.findings.append(
+            Finding(
+                BREAK,
+                f"major version bump {old} -> {new}: this silences "
+                "cargo-semver-checks, so breaking changes stop being reported. "
+                "Set ALLOW_MAJOR_BUMP=1 once that is deliberate.",
+            )
+        )
+    result.summary = f"{old} -> {new}"
+    return result
+
+
+# --------------------------------------------------------------------------
+# Driver
+# --------------------------------------------------------------------------
+
+CHECKS = [
+    check_version_guard,
+    check_c_header,
+    check_cxx_bridge,
+    check_schema,
+    check_wire_format,
+    check_cli,
+    check_python_floor,
+]
+
+
+def run(root: Path, ref: str, fallback: str | None = None) -> tuple[list[SurfaceResult], int]:
+    baseline = Baseline(root, ref, fallback)
+    results = [check(root, baseline) for check in CHECKS]
+    return results, sum(len(r.breaks()) for r in results)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--baseline",
+        help="git ref to compare against (default: the latest release tag)",
+    )
+    parser.add_argument("--root", default=".", help="repository root")
+    parser.add_argument(
+        "--fallback-baseline",
+        help="ref to compare surfaces the baseline predates against "
+        "(CI passes the PR base commit)",
+    )
+    parser.add_argument(
+        "--print-baseline",
+        action="store_true",
+        help="print the resolved baseline ref and exit (used by the shell driver)",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="emit findings as JSON instead of text"
+    )
+    args = parser.parse_args()
+
+    root = Path(args.root).resolve()
+    ref = args.baseline or os.environ.get("BREAKING_BASELINE") or resolve_baseline(root)
+    if args.print_baseline:
+        print(ref)
+        return 0
+    check = subprocess.run(
+        ["git", "-C", str(root), "rev-parse", "--verify", f"{ref}^{{commit}}"],
+        capture_output=True,
+        text=True,
+    )
+    if check.returncode != 0:
+        print(
+            f"error: baseline ref `{ref}` not found. In CI this usually means "
+            "tags were not fetched (actions/checkout needs fetch-depth: 0).",
+            file=sys.stderr,
+        )
+        return 2
+
+    results, break_count = run(
+        root, ref, args.fallback_baseline or os.environ.get("BREAKING_FALLBACK_BASELINE")
+    )
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "baseline": ref,
+                    "surfaces": [
+                        {
+                            "name": r.name,
+                            "skipped": r.skipped,
+                            "findings": [
+                                {"level": f.level, "detail": f.detail} for f in r.findings
+                            ],
+                        }
+                        for r in results
+                    ],
+                },
+                indent=2,
+            )
+        )
+        return 1 if break_count else 0
+
+    print(f"Breaking-change gate -- baseline {ref}\n")
+    for result in results:
+        if result.skipped:
+            status = f"skipped ({result.skipped})"
+        elif result.breaks():
+            status = f"BREAKING ({len(result.breaks())})"
+        elif result.warns():
+            status = f"ok, {len(result.warns())} additions"
+        else:
+            status = "ok"
+        detail = f" [{result.summary}]" if result.summary and not result.skipped else ""
+        print(f"  {result.name:.<46} {status}{detail}")
+        for finding in result.breaks():
+            print(f"      BREAK  {finding.detail}")
+        for finding in result.warns():
+            print(f"      note   {finding.detail}")
+
+    print()
+    if break_count:
+        print(f"{break_count} breaking change(s) against {ref}.")
+        print(
+            "dora 1.x freezes these surfaces (docs/api-rust.md, "
+            "'Stability scope at 1.0'). Either keep the old surface working "
+            "alongside the new one, or take the change to a 2.0 discussion."
+        )
+        return 1
+    print(f"No breaking changes against {ref}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/qa/breaking_changes.py
+++ b/scripts/qa/breaking_changes.py
@@ -151,14 +151,7 @@ def grep_tracked(root: Path, ref: str | None, pattern: str) -> dict[str, str]:
 
 
 def resolve_baseline(root: Path) -> str:
-    """The newest released tag -- what deployed users are actually running.
-
-    Falls back to asking the remote for its tag *names* when the checkout has
-    none. A CI checkout is shallow and tagless, and the repo's pack is well
-    over a gigabyte, so `fetch-depth: 0` would make every PR pay a full clone
-    to read one file. `ls-remote` transfers no objects; the caller then fetches
-    just the one tag this returns.
-    """
+    """The newest released tag -- what deployed users are actually running."""
     proc = subprocess.run(
         ["git", "-C", str(root), "tag", "--list", "v*"],
         capture_output=True,
@@ -167,19 +160,11 @@ def resolve_baseline(root: Path) -> str:
     )
     tags = [t for t in proc.stdout.splitlines() if t and tag_sort_key(t)]
     if not tags:
-        remote = subprocess.run(
-            ["git", "-C", str(root), "ls-remote", "--tags", "origin"],
-            capture_output=True,
-            text=True,
+        raise SystemExit(
+            "error: no release tags found. A shallow checkout has none — CI "
+            "uses `fetch-depth: 0` for this reason; locally, `git fetch "
+            "--tags`. Or name one with --baseline <ref>."
         )
-        tags = [
-            name
-            for line in remote.stdout.splitlines()
-            for name in [line.split("refs/tags/")[-1]]
-            if not name.endswith("^{}") and tag_sort_key(name)
-        ]
-    if not tags:
-        raise SystemExit("error: no release tags found; pass --baseline <ref> explicitly")
     return max(tags, key=tag_sort_key)
 
 

--- a/scripts/qa/semver.sh
+++ b/scripts/qa/semver.sh
@@ -34,17 +34,25 @@ PUBLIC_CRATES=(
   dora-arrow-convert
 )
 
-# dora-* crates are not yet published on crates.io, so use the last git
-# tag as the baseline. Override by exporting SEMVER_BASELINE=<ref> before
-# running this script.
-BASELINE="${SEMVER_BASELINE:-$(git describe --tags --abbrev=0 2>/dev/null || echo main)}"
+# Compare against the last released tag -- what deployed users are running.
+# `breaking-changes.sh` passes the ref it resolved so both halves of the gate
+# agree on one baseline; override by hand with SEMVER_BASELINE=<ref>.
+BASELINE="${SEMVER_BASELINE:-${BREAKING_BASELINE:-$(git describe --tags --abbrev=0 2>/dev/null || echo main)}}"
 echo "Baseline: $BASELINE"
 echo
 
 FAILED=0
 for crate in "${PUBLIC_CRATES[@]}"; do
   echo "--- $crate ---"
-  if ! cargo semver-checks check-release -p "$crate" --baseline-rev "$BASELINE"; then
+  # `--release-type minor` is what makes this mean anything. Left to derive
+  # the release type from the version numbers, cargo-semver-checks sees that
+  # the workspace version has already moved (an rc to its release, or 1.0 to
+  # 1.1), concludes breakage is permitted, and skips every lint -- printing
+  # "no semver update required" having run 0 of 254 checks. Forcing `minor`
+  # runs the major-breaking lints on every run, which is the post-1.0 rule:
+  # no breaking change without a deliberate 2.0.
+  if ! cargo semver-checks check-release -p "$crate" \
+      --baseline-rev "$BASELINE" --release-type minor; then
     FAILED=1
   fi
 done

--- a/scripts/qa/semver.sh
+++ b/scripts/qa/semver.sh
@@ -48,21 +48,31 @@ BASELINE=$(resolve_breaking_baseline) || exit 2
 echo "Baseline: $BASELINE"
 echo
 
-FAILED=0
+# Guarded because an empty list would silently turn into "check the whole
+# workspace", which is a different (and much slower) question.
+[ ${#PUBLIC_CRATES[@]} -gt 0 ] || { echo "error: PUBLIC_CRATES is empty" >&2; exit 2; }
+CRATE_ARGS=()
 for crate in "${PUBLIC_CRATES[@]}"; do
-  echo "--- $crate ---"
-  # `--release-type minor` is what makes this mean anything. Left to derive
-  # the release type from the version numbers, cargo-semver-checks sees that
-  # the workspace version has already moved (an rc to its release, or 1.0 to
-  # 1.1), concludes breakage is permitted, and skips every lint -- printing
-  # "no semver update required" having run 0 of 254 checks. Forcing `minor`
-  # runs the major-breaking lints on every run, which is the post-1.0 rule:
-  # no breaking change without a deliberate 2.0.
-  if ! cargo semver-checks check-release -p "$crate" \
-      --baseline-rev "$BASELINE" --release-type minor; then
-    FAILED=1
-  fi
+  CRATE_ARGS+=(-p "$crate")
 done
+
+FAILED=0
+# One invocation for all three, not one each: they depend on each other, so a
+# single run shares the `cargo metadata` pass, the baseline checkout and the
+# rustdoc build over the common dependency graph instead of repeating all of
+# it three times. On a cold CI runner that is the bulk of this job.
+#
+# `--release-type minor` is what makes this mean anything. Left to derive
+# the release type from the version numbers, cargo-semver-checks sees that
+# the workspace version has already moved (an rc to its release, or 1.0 to
+# 1.1), concludes breakage is permitted, and skips every lint -- printing
+# "no semver update required" having run 0 of 254 checks. Forcing `minor`
+# runs the major-breaking lints on every run, which is the post-1.0 rule:
+# no breaking change without a deliberate 2.0.
+if ! cargo semver-checks check-release "${CRATE_ARGS[@]}" \
+    --baseline-rev "$BASELINE" --release-type minor; then
+  FAILED=1
+fi
 
 if [[ "$FAILED" == "1" ]]; then
   echo

--- a/scripts/qa/semver.sh
+++ b/scripts/qa/semver.sh
@@ -35,9 +35,13 @@ PUBLIC_CRATES=(
 )
 
 # Compare against the last released tag -- what deployed users are running.
-# `breaking-changes.sh` passes the ref it resolved so both halves of the gate
-# agree on one baseline; override by hand with SEMVER_BASELINE=<ref>.
-BASELINE="${SEMVER_BASELINE:-${BREAKING_BASELINE:-$(git describe --tags --abbrev=0 2>/dev/null || echo main)}}"
+# Resolved by the shared helper so both halves of the gate check the same
+# release, and so this works in a shallow CI checkout: `git describe` fails
+# there, which would have silently made the baseline `main`. Override by hand
+# with SEMVER_BASELINE=<ref>.
+# shellcheck source=baseline.sh
+source "$(dirname "$0")/baseline.sh"
+BASELINE=$(resolve_breaking_baseline) || exit 2
 echo "Baseline: $BASELINE"
 echo
 

--- a/scripts/qa/semver.sh
+++ b/scripts/qa/semver.sh
@@ -39,8 +39,11 @@ PUBLIC_CRATES=(
 # release, and so this works in a shallow CI checkout: `git describe` fails
 # there, which would have silently made the baseline `main`. Override by hand
 # with SEMVER_BASELINE=<ref>.
+# Relative to the repo root, which the `cd` above guarantees: `$(dirname $0)`
+# would be wrong when the script is invoked by a relative path from anywhere
+# but the root.
 # shellcheck source=baseline.sh
-source "$(dirname "$0")/baseline.sh"
+source scripts/qa/baseline.sh
 BASELINE=$(resolve_breaking_baseline) || exit 2
 echo "Baseline: $BASELINE"
 echo

--- a/scripts/qa/tests/test_breaking_changes.py
+++ b/scripts/qa/tests/test_breaking_changes.py
@@ -378,5 +378,55 @@ class PythonFloorTest(unittest.TestCase):
         self.assertEqual(python_floor('requires-python = ">=3.11"'), ">=3.11")
 
 
+ROOT = Path(__file__).resolve().parents[3]
+
+
+class RealRepoCoverageTest(unittest.TestCase):
+    """Floors on what each extractor finds in the real tree.
+
+    Every test above runs on inline fixtures, which cannot see the failure that
+    matters most: an extractor that quietly stops matching. A narrowed regex or
+    a colliding key shrinks the checked set on *both* sides at once, so every
+    surface keeps reporting "ok" while guarding nothing. The floors are set far
+    below today's counts -- they exist to catch collapse, not to be updated
+    whenever the API grows. `cli_surface.rs` makes the same bargain for the
+    snapshot it generates.
+    """
+
+    def test_c_header(self):
+        parsed = parse_c_header((ROOT / "apis/c/node/node_api.h").read_text())
+        self.assertGreaterEqual(len(parsed["functions"]), 8)
+        self.assertGreaterEqual(len(parsed["enums"]), 1)
+
+    def test_cxx_bridge(self):
+        parsed = parse_cxx_bridge((ROOT / "apis/c++/node/src/lib.rs").read_text())
+        self.assertGreaterEqual(len(parsed["structs"]), 8)
+        self.assertGreaterEqual(len(parsed["enums"]), 3)
+        self.assertGreaterEqual(len(parsed["functions"]), 40)
+
+    def test_wire_types(self):
+        src = ROOT / "libraries/message/src"
+        files = {
+            str(path.relative_to(src)): path.read_text() for path in src.rglob("*.rs")
+        }
+        parsed = parse_wire_types(files)
+        self.assertGreaterEqual(len(parsed), 80)
+        # Every type must have been read past its opening brace.
+        empty = [name for name, t in parsed.items() if not t["members"]]
+        self.assertLessEqual(len(empty), 5, f"suspiciously many empty types: {empty}")
+
+    def test_dataflow_schema(self):
+        import json
+
+        flat = flatten_schema(json.loads((ROOT / "dora-schema.json").read_text()))
+        self.assertGreaterEqual(len(flat), 100)
+        self.assertIn("#/$defs/Node", flat)
+
+    def test_cli_snapshot(self):
+        parsed = parse_cli_surface((ROOT / "binaries/cli/cli-surface.txt").read_text())
+        self.assertGreaterEqual(len(parsed), 50)
+        self.assertIn("dora build", parsed)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/qa/tests/test_breaking_changes.py
+++ b/scripts/qa/tests/test_breaking_changes.py
@@ -19,6 +19,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from breaking_changes import (  # noqa: E402
     BREAK,
     WARN,
+    abi3_floor,
     compare_ordered,
     diff_schema,
     flatten_schema,
@@ -189,6 +190,21 @@ class WireFormatTest(unittest.TestCase):
         self.assertIn("m::Real", parsed)
         self.assertNotIn("m::Fixture", parsed)
 
+    def test_container_attributes_are_part_of_the_type(self):
+        # `untagged` decides whether a variant tag is written at all, and it
+        # can sit either side of the derive.
+        before = parse_wire_types(
+            {"m.rs": "#[derive(Serialize)]\npub enum E { A(u8), B(u16) }\n"}
+        )
+        after = parse_wire_types(
+            {
+                "m.rs": "#[serde(untagged)]\n#[derive(Serialize)]\n"
+                "pub enum E { A(u8), B(u16) }\n"
+            }
+        )
+        self.assertEqual(before["m::E"]["container"], [])
+        self.assertEqual(after["m::E"]["container"], ["untagged"])
+
     def test_non_serde_types_are_ignored(self):
         self.assertNotIn("m::S", parse_wire_types({"m.rs": "pub struct S { a: u8 }"}))
 
@@ -297,6 +313,48 @@ class BaselineTagTest(unittest.TestCase):
 
     def test_non_version_tags_are_rejected(self):
         self.assertFalse(tag_sort_key("v0.x-final"))
+
+
+class SchemaUnionTest(unittest.TestCase):
+    """`oneOf` / `anyOf` alternatives are identified by content, not index."""
+
+    BASE = {
+        "$defs": {
+            "Source": {
+                "oneOf": [
+                    {"$ref": "#/$defs/Git"},
+                    {"$ref": "#/$defs/Path"},
+                    {"$ref": "#/$defs/Url"},
+                ]
+            }
+        }
+    }
+
+    def diff(self, new):
+        return diff_schema(flatten_schema(self.BASE), flatten_schema(new))
+
+    def test_inserting_an_alternative_is_not_a_break(self):
+        # Index-keyed, this shifts Path and Url and reports them as changed.
+        new = {"$defs": {"Source": {"oneOf": [{"$ref": "#/$defs/Hub"}] +
+                                    self.BASE["$defs"]["Source"]["oneOf"]}}}
+        self.assertEqual(self.diff(new), [])
+
+    def test_removing_an_alternative_is_a_break(self):
+        new = {
+            "$defs": {"Source": {"oneOf": self.BASE["$defs"]["Source"]["oneOf"][:2]}}
+        }
+        self.assertTrue(find(self.diff(new), "no longer accepts `Url`"))
+
+
+class Abi3Test(unittest.TestCase):
+    def test_parses_the_interpreter_version_not_the_3_in_abi3(self):
+        self.assertEqual(abi3_floor('features = ["abi3-py311"]'), (3, 11))
+        self.assertEqual(abi3_floor('features = ["abi3-py38"]'), (3, 8))
+        self.assertLess(abi3_floor("abi3-py38"), abi3_floor("abi3-py311"))
+        self.assertIsNone(abi3_floor("no tag here"))
+
+    def test_lowest_tag_in_a_manifest_wins(self):
+        self.assertEqual(abi3_floor("abi3-py312 abi3-py311"), (3, 11))
 
 
 class CliSurfaceTest(unittest.TestCase):

--- a/scripts/qa/tests/test_breaking_changes.py
+++ b/scripts/qa/tests/test_breaking_changes.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Tests for the breaking-change differ.
+
+A gate that only ever reports "clean" is indistinguishable from a gate that
+does not work -- and this one is text-driven, so a refactor upstream (a header
+reformat, a serde attribute, a schema key rename) could quietly turn any
+extractor into a no-op. Every check below feeds a *known* break through the
+real differ and asserts it is caught.
+
+Run: python3 -m unittest discover -s scripts/qa/tests
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from breaking_changes import (  # noqa: E402
+    BREAK,
+    WARN,
+    compare_ordered,
+    diff_schema,
+    flatten_schema,
+    parse_c_header,
+    parse_cli_surface,
+    parse_cxx_bridge,
+    parse_wire_types,
+    python_floor,
+    tag_sort_key,
+    version_tuple,
+)
+
+C_HEADER = """
+#include <stddef.h>
+
+/* a comment mentioning free_dora_context(void *x); */
+void *init_dora_context_from_env();
+void free_dora_context(void *dora_context);
+int dora_send_output(void *ctx, const char *id, size_t id_len);
+
+enum DoraEventType
+{
+    DoraEventType_Stop,
+    DoraEventType_Input,
+};
+enum DoraEventType read_dora_event_type(void *dora_event);
+"""
+
+CXX_BRIDGE = """
+#[cxx::bridge]
+mod ffi {
+    struct DoraNode {
+        events: Box<Events>,
+    }
+
+    pub enum DoraEventType {
+        Stop,
+        Input,
+    }
+
+    extern "Rust" {
+        type Events;
+        fn init_dora_node() -> Result<DoraNode>;
+        fn next(self: &mut Events) -> Box<DoraEvent>;
+        fn next(self: &mut CombinedEvents) -> CombinedEvent;
+    }
+}
+"""
+
+WIRE = {
+    "daemon_to_node.rs": """
+#[derive(Debug, Serialize, Deserialize)]
+pub enum NodeEvent {
+    Stop,
+    Input { id: DataId, data: Vec<u8> },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Metadata {
+    pub metadata_version: u16,
+    pub timestamp: Timestamp,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DataId(String);
+""",
+}
+
+
+def find(findings, needle, level=BREAK):
+    return [f for f in findings if f.level == level and needle in f.detail]
+
+
+class CHeaderTest(unittest.TestCase):
+    def setUp(self):
+        self.parsed = parse_c_header(C_HEADER)
+
+    def test_extracts_every_declaration(self):
+        self.assertEqual(
+            sorted(self.parsed["functions"]),
+            [
+                "dora_send_output",
+                "free_dora_context",
+                "init_dora_context_from_env",
+                "read_dora_event_type",
+            ],
+        )
+        self.assertEqual(
+            self.parsed["enums"]["DoraEventType"],
+            ["DoraEventType_Stop", "DoraEventType_Input"],
+        )
+
+    def test_comments_are_not_declarations(self):
+        # The comment above mentions a call that must not be parsed as one.
+        self.assertEqual(len(self.parsed["functions"]), 4)
+
+    def test_parameter_rename_is_not_a_signature_change(self):
+        renamed = C_HEADER.replace("void *dora_context", "void *context")
+        self.assertEqual(
+            parse_c_header(renamed)["functions"]["free_dora_context"],
+            self.parsed["functions"]["free_dora_context"],
+        )
+
+    def test_parameter_type_change_is_a_signature_change(self):
+        retyped = C_HEADER.replace("size_t id_len", "int id_len")
+        self.assertNotEqual(
+            parse_c_header(retyped)["functions"]["dora_send_output"],
+            self.parsed["functions"]["dora_send_output"],
+        )
+
+
+class CxxBridgeTest(unittest.TestCase):
+    def setUp(self):
+        self.parsed = parse_cxx_bridge(CXX_BRIDGE)
+
+    def test_extracts_items(self):
+        self.assertEqual(self.parsed["structs"]["DoraNode"], ["events: Box<Events>"])
+        self.assertEqual(self.parsed["enums"]["DoraEventType"], ["Stop", "Input"])
+
+    def test_same_named_fns_are_kept_apart_by_receiver(self):
+        self.assertIn("Events::next", self.parsed["functions"])
+        self.assertIn("CombinedEvents::next", self.parsed["functions"])
+
+
+class WireFormatTest(unittest.TestCase):
+    def setUp(self):
+        self.parsed = parse_wire_types(WIRE)
+
+    def test_extracts_braced_and_tuple_types(self):
+        self.assertEqual(
+            self.parsed["daemon_to_node::NodeEvent"]["members"],
+            ["Stop", "Input { id: DataId, data: Vec<u8> }"],
+        )
+        self.assertEqual(
+            self.parsed["daemon_to_node::DataId"]["members"], ["0: String"]
+        )
+
+    def test_serde_rename_is_part_of_the_member(self):
+        renamed = {
+            "m.rs": '#[derive(Serialize)]\npub struct S {\n'
+            '    #[serde(rename = "ts")]\n    pub timestamp: u64,\n}\n'
+        }
+        self.assertEqual(
+            parse_wire_types(renamed)["m::S"]["members"],
+            ['timestamp: u64 [serde: rename = "ts"]'],
+        )
+
+    def test_default_attribute_is_not_part_of_the_member(self):
+        # `#[serde(default)]` only widens decoding; treating it as a change
+        # would fail the gate on a strictly compatible edit.
+        widened = {
+            "m.rs": "#[derive(Serialize)]\npub struct S {\n"
+            "    #[serde(default)]\n    pub timestamp: u64,\n}\n"
+        }
+        self.assertEqual(
+            parse_wire_types(widened)["m::S"]["members"], ["timestamp: u64"]
+        )
+
+    def test_cfg_test_fixtures_are_not_the_wire_protocol(self):
+        # bulk_bytes.rs defines six serde types inside `#[cfg(test)]`. Counting
+        # them would report deleting a test fixture as a protocol break.
+        source = {
+            "m.rs": "#[derive(Serialize)]\npub struct Real { pub a: u8 }\n"
+            "#[cfg(test)]\nmod tests {\n"
+            "    #[derive(Serialize)]\n    pub struct Fixture { pub b: u8 }\n}\n"
+        }
+        parsed = parse_wire_types(source)
+        self.assertIn("m::Real", parsed)
+        self.assertNotIn("m::Fixture", parsed)
+
+    def test_non_serde_types_are_ignored(self):
+        self.assertNotIn("m::S", parse_wire_types({"m.rs": "pub struct S { a: u8 }"}))
+
+
+class SchemaTest(unittest.TestCase):
+    BASE = {
+        "$defs": {
+            "Node": {
+                "type": "object",
+                "properties": {"id": {"type": "string"}, "env": {"type": "object"}},
+                "required": ["id"],
+            },
+            "Level": {"enum": ["debug", "info"]},
+        }
+    }
+
+    def diff(self, new):
+        return diff_schema(flatten_schema(self.BASE), flatten_schema(new))
+
+    def test_clean(self):
+        self.assertEqual(self.diff(self.BASE), [])
+
+    def test_a_removed_property_is_reported_once(self):
+        new = {"$defs": {"Node": {"type": "object", "properties": {"id": {}}}}}
+        base = {
+            "$defs": {"Node": {"type": "object", "properties": {"id": {}, "env": {}}}}
+        }
+        findings = diff_schema(flatten_schema(base), flatten_schema(new))
+        self.assertEqual(len(findings), 1, [f.detail for f in findings])
+
+    def test_removed_property(self):
+        new = {"$defs": {**self.BASE["$defs"]}}
+        new["$defs"]["Node"] = {
+            "type": "object",
+            "properties": {"id": {"type": "string"}},
+            "required": ["id"],
+        }
+        self.assertTrue(find(self.diff(new), "property `env` removed"))
+
+    def test_newly_required_property(self):
+        new = {"$defs": {**self.BASE["$defs"]}}
+        new["$defs"]["Node"] = {**self.BASE["$defs"]["Node"], "required": ["id", "env"]}
+        self.assertTrue(find(self.diff(new), "`env` is now required"))
+
+    def test_removed_enum_value(self):
+        new = {"$defs": {**self.BASE["$defs"], "Level": {"enum": ["info"]}}}
+        self.assertTrue(find(self.diff(new), "enum value"))
+
+    def test_added_property_is_not_a_break(self):
+        new = {"$defs": {**self.BASE["$defs"]}}
+        new["$defs"]["Node"] = {
+            "type": "object",
+            "properties": {
+                "id": {"type": "string"},
+                "env": {"type": "object"},
+                "cpu": {"type": "string"},
+            },
+            "required": ["id"],
+        }
+        self.assertEqual(self.diff(new), [])
+
+    def test_closing_additional_properties(self):
+        new = {"$defs": {**self.BASE["$defs"]}}
+        new["$defs"]["Node"] = {
+            **self.BASE["$defs"]["Node"],
+            "additionalProperties": False,
+        }
+        self.assertTrue(find(self.diff(new), "additional properties are now rejected"))
+
+
+class OrderedComparisonTest(unittest.TestCase):
+    """Positional encodings: what counts as a break is about *position*."""
+
+    def compare(self, old, new, added_level=BREAK):
+        return compare_ordered(
+            "field", "T", old, new, added_level=added_level, reorder_note="n"
+        )
+
+    def test_append_is_allowed_when_additions_are_allowed(self):
+        # An enum variant appended at the end only breaks new -> old, which is
+        # how the protocol is meant to grow; a struct field passes BREAK here.
+        findings = self.compare(["a", "b"], ["a", "b", "c"], WARN)
+        self.assertEqual([f.level for f in findings], [WARN])
+
+    def test_insert_in_the_middle_shifts_later_members(self):
+        levels = self.compare(["a", "b"], ["a", "c", "b"], WARN)
+        self.assertTrue(find(levels, "inserted before the end"))
+
+    def test_reorder_is_a_break(self):
+        self.assertTrue(find(self.compare(["a", "b"], ["b", "a"]), "order changed"))
+
+    def test_removal_is_a_break(self):
+        self.assertTrue(find(self.compare(["a", "b"], ["a"]), "`b` removed"))
+
+    def test_identical_is_clean(self):
+        self.assertEqual(self.compare(["a", "b"], ["a", "b"]), [])
+
+
+class BaselineTagTest(unittest.TestCase):
+    def test_a_prerelease_sorts_below_its_release(self):
+        # git's own version sort gets this backwards without configuration,
+        # which would pick an rc as the baseline for the release after it.
+        tags = ["v1.0.0", "v1.0.0-rc.5", "v0.5.0", "v1.0.1"]
+        self.assertEqual(max(tags, key=tag_sort_key), "v1.0.1")
+        self.assertLess(tag_sort_key("v1.0.0-rc.5"), tag_sort_key("v1.0.0"))
+
+    def test_non_version_tags_are_rejected(self):
+        self.assertFalse(tag_sort_key("v0.x-final"))
+
+
+class CliSurfaceTest(unittest.TestCase):
+    SNAPSHOT = """
+# comment
+dora build | --uv
+dora build | <dataflow>
+dora start
+"""
+
+    def test_parse(self):
+        parsed = parse_cli_surface(self.SNAPSHOT)
+        self.assertEqual(parsed["dora build"], {"--uv", "<dataflow>"})
+        self.assertEqual(parsed["dora start"], set())
+
+
+class PythonFloorTest(unittest.TestCase):
+    def test_floor_ordering(self):
+        self.assertGreater(version_tuple(">=3.12"), version_tuple(">=3.11"))
+        self.assertEqual(version_tuple(">=3.11"), version_tuple(">= 3.11"))
+        self.assertEqual(python_floor('requires-python = ">=3.11"'), ">=3.11")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`docs/api-rust.md` lists what 1.0 freezes, and four mechanisms back it: exact version pins, feature gates, the publish-graph gate, and the frozen Python module test. The first three are cargo mechanisms and the fourth covers one wheel, so between them they guard the part of the guarantee cargo can see. Most of the list is not that — the `dora` command, the dataflow YAML schema, the C header, the cxx bridge and the postcard wire format are all invisible to rustdoc, and a change to any of them would reach users with every check green.

`make qa-breaking` checks all of them against the last released tag, as a new `Breaking changes` job on every PR.

| Surface | Checked by |
|---|---|
| `dora-node-api`, `dora-message`, `dora-arrow-convert` | `cargo-semver-checks` against the tag |
| `dora-node-api-c` | declaration diff of `node_api.h`, enum ordinals included |
| `dora-node-api-cxx` | item diff of the `#[cxx::bridge]` block |
| `dora-cli` — the `dora` command | `binaries/cli/cli-surface.txt`, a clap-generated snapshot |
| `dora-cli` — the YAML schema | JSON-Schema-aware diff: removed property, newly required property, removed enum value, removed `oneOf` alternative |
| the wire protocol | field and variant *order* of every serde type in `dora-message` — what postcard actually encodes — plus container attributes like `untagged` |
| the Python floor | `requires-python` and the abi3 tag |

`dora-node-api-python` is already covered by `test_public_surface.py` and is left there.

Everything but the first row is read out of source text or a checked-in snapshot on both sides, so that half compiles nothing and finishes in **well under a second**. `cargo-semver-checks` is the second step of the same job; if it turns out to be the slowest cheap gate, moving that one step to the expensive tier is the same one-line `if:` the `test` job uses.

The job takes `fetch-depth: 0`, unlike every other one here, because it compares against a release tag and the default shallow checkout has no tags. On this repo that costs little: a depth-1 checkout of one branch is 3.6 MB, all of `main`'s history is 5.9 MB, and every branch and tag together is 45 MB.

Two things writing it turned up:

- **`make qa-semver` was reporting nothing.** rc.5 → 1.0.0 reads as a major bump, so `cargo-semver-checks` concluded breakage was already permitted and skipped all 254 lints while printing "no semver update required". `--release-type minor` makes them run — 196 checks per covered crate where there were 0. Separately, the gate stops at a **major version bump**: a 2.0 withdraws the promises every check here measures against, so green and red would both mislead (`ALLOW_MAJOR_BUMP=1` says it is deliberate).
- **The checked-in JSON schema had drifted** from a doc comment added to `OperatorId`, and nothing would have said so before a merge: `root_schema_matches_crate_copy` compares the two copies to each other, not to `schema_for!(Descriptor)`. Regenerated here, and `checked_in_descriptor_schema_is_current` now asserts it — a `#[test]`, so the merge queue catches it rather than a laptop-only step.

The differ is text-driven, so an upstream reformat could quietly turn an extractor into a no-op and leave every surface reporting "ok" forever. Its 32 tests feed known breaks through the real differ and run first, every time. Two false positives they caught while being written: rustfmt's trailing comma inside a variant payload, and the six `#[cfg(test)]` serde fixtures in `bulk_bytes.rs`, which are not the wire protocol.

Verified by injecting a break into each surface in turn — removed C function, reordered cxx enum, added `Metadata` field, newly required YAML property, raised `requires-python`, raised abi3 floor, removed `dora build --uv`, deleted snapshot, major bump — each caught with the item named, and a clean tree reports clean.

One gap worth naming: v1.0.0 is tagged without `cli-surface.txt`, so until the next release the command surface is compared against the PR's base commit instead of the tag. The job passes that fallback; the report says which ref it used.
