### PR TITLE
perf(tracing): skip context serialization when no span is active

### DIFF
--- a/libraries/extensions/telemetry/tracing/src/telemetry.rs
+++ b/libraries/extensions/telemetry/tracing/src/telemetry.rs
@@ -1,5 +1,6 @@
 use eyre::Context as _;
 use opentelemetry::propagation::Extractor;
+use opentelemetry::trace::TraceContextExt as _;
 use opentelemetry::{Context, global};
 use opentelemetry_otlp::WithExportConfig;
 
@@ -78,6 +79,19 @@ const CONTEXT_ENTRY_SEP: char = '\n';
 /// OTel Baggage keys are stripped to prevent sensitive data from leaking
 /// across node boundaries in the dataflow.
 pub fn serialize_context(context: &Context) -> String {
+    // Fast path: with no valid active span there is nothing to propagate.
+    // The W3C `TraceContextPropagator` (the propagator dora installs, see
+    // `set_text_map_propagator` above) injects `traceparent`/`tracestate`
+    // only when the span context is valid, so for an invalid context the map
+    // below stays empty and this returns "". Nodes commonly enable telemetry
+    // for logging without an active OTel span, and `serialize_context` runs
+    // on the per-message send path (`DoraNode::send_output`) and per-event in
+    // the operator runtimes — skipping the `HashMap` allocation and the
+    // global-propagator call there avoids per-message overhead that only
+    // produces an empty string.
+    if !context.span().span_context().is_valid() {
+        return String::new();
+    }
     let mut map = HashMap::new();
     global::get_text_map_propagator(|propagator| propagator.inject_context(context, &mut map));
     // Strip baggage to avoid propagating sensitive data across nodes
@@ -192,6 +206,17 @@ mod tests {
         assert_eq!(recovered.trace_id(), span_context.trace_id());
         assert_eq!(recovered.span_id(), span_context.span_id());
         assert_eq!(recovered.trace_state().header(), trace_state.header());
+    }
+
+    #[test]
+    fn serialize_invalid_context_is_empty() {
+        use opentelemetry::Context;
+
+        // A default context carries no valid span, so there is nothing for the
+        // W3C propagator to inject. `serialize_context` must return an empty
+        // string here (the fast path skips the propagator/allocation entirely,
+        // and callers rely on "" to mean "no trace context to attach").
+        assert_eq!(serialize_context(&Context::new()), "");
     }
 
     #[test]

--- a/libraries/extensions/telemetry/tracing/src/telemetry.rs
+++ b/libraries/extensions/telemetry/tracing/src/telemetry.rs
@@ -80,15 +80,18 @@ const CONTEXT_ENTRY_SEP: char = '\n';
 /// across node boundaries in the dataflow.
 pub fn serialize_context(context: &Context) -> String {
     // Fast path: with no valid active span there is nothing to propagate.
-    // The W3C `TraceContextPropagator` (the propagator dora installs, see
-    // `set_text_map_propagator` above) injects `traceparent`/`tracestate`
-    // only when the span context is valid, so for an invalid context the map
-    // below stays empty and this returns "". Nodes commonly enable telemetry
-    // for logging without an active OTel span, and `serialize_context` runs
-    // on the per-message send path (`DoraNode::send_output`) and per-event in
-    // the operator runtimes — skipping the `HashMap` allocation and the
-    // global-propagator call there avoids per-message overhead that only
-    // produces an empty string.
+    // Every standard text-map propagator (W3C TraceContext, B3, Jaeger,
+    // X-Ray) injects nothing when the span context is invalid, and dora
+    // installs no propagator by default, so the process-global is
+    // OpenTelemetry's no-op propagator. Either way the map below would stay
+    // empty and this returns "". Nodes commonly enable telemetry for logging
+    // without ever opening an OTel span, and `serialize_context` runs on the
+    // per-message send path (`DoraNode::send_output`) and per-event in the
+    // operator runtimes; short-circuiting here skips the
+    // `global::get_text_map_propagator` lock acquisition and dynamic dispatch
+    // on every such call. The only behavior this would change is a custom
+    // third-party propagator that chose to inject on an invalid context —
+    // none is installed.
     if !context.span().span_context().is_valid() {
         return String::new();
     }
@@ -131,6 +134,12 @@ pub fn deserialize_to_hashmap(string_context: &str) -> HashMap<&str, &str> {
 mod tests {
     use super::service_resource;
     use opentelemetry::Key;
+    use std::sync::Mutex;
+
+    /// Serializes the tests that mutate the process-global text-map propagator
+    /// (`set_text_map_propagator` sets a single shared global with no restore),
+    /// so they don't race when the test binary runs them on separate threads.
+    static PROPAGATOR_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn service_resource_sets_service_name() {
@@ -152,9 +161,12 @@ mod tests {
         };
         use opentelemetry_sdk::propagation::TraceContextPropagator;
 
+        let _guard = PROPAGATOR_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
         // `serialize_context`/`deserialize_context` route through the process-global
-        // text-map propagator, exactly as production does; install the same W3C
-        // TraceContext propagator the daemon/runtime rely on.
+        // text-map propagator. dora installs none by default (the global is then a
+        // no-op), so this test installs the W3C TraceContext propagator to exercise
+        // the non-empty encode/decode path an embedding application would see.
         opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
 
         // A realistic multi-member W3C `tracestate`. Members are joined with `,`
@@ -209,14 +221,69 @@ mod tests {
     }
 
     #[test]
-    fn serialize_invalid_context_is_empty() {
+    fn serialize_skips_propagator_when_span_invalid() {
         use opentelemetry::Context;
+        use opentelemetry::propagation::text_map_propagator::FieldIter;
+        use opentelemetry::propagation::{Extractor, Injector, TextMapPropagator};
+        use opentelemetry::trace::{
+            SpanContext, SpanId, TraceContextExt, TraceFlags, TraceId, TraceState,
+        };
+        use std::sync::atomic::{AtomicUsize, Ordering};
 
-        // A default context carries no valid span, so there is nothing for the
-        // W3C propagator to inject. `serialize_context` must return an empty
-        // string here (the fast path skips the propagator/allocation entirely,
-        // and callers rely on "" to mean "no trace context to attach").
+        // Counts how often the installed propagator's `inject_context` runs, so
+        // the test can observe whether `serialize_context` consulted it at all.
+        static INJECT_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+        #[derive(Debug)]
+        struct CountingPropagator {
+            fields: Vec<String>,
+        }
+
+        impl TextMapPropagator for CountingPropagator {
+            fn inject_context(&self, _cx: &Context, _injector: &mut dyn Injector) {
+                INJECT_CALLS.fetch_add(1, Ordering::SeqCst);
+            }
+
+            fn extract_with_context(&self, cx: &Context, _extractor: &dyn Extractor) -> Context {
+                cx.clone()
+            }
+
+            fn fields(&self) -> FieldIter<'_> {
+                FieldIter::new(&self.fields)
+            }
+        }
+
+        let _guard = PROPAGATOR_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        opentelemetry::global::set_text_map_propagator(CountingPropagator { fields: Vec::new() });
+
+        // Invalid (default) context: the fast path must return "" WITHOUT
+        // consulting the propagator. Before the fast path existed,
+        // `serialize_context` reached `global::get_text_map_propagator` here, so
+        // this assertion fails on the pre-change code — it pins the change.
+        INJECT_CALLS.store(0, Ordering::SeqCst);
         assert_eq!(serialize_context(&Context::new()), "");
+        assert_eq!(
+            INJECT_CALLS.load(Ordering::SeqCst),
+            0,
+            "propagator must not be consulted for an invalid span context",
+        );
+
+        // A valid span context: the propagator IS consulted (the fast path is
+        // not taken), confirming the guard only short-circuits the invalid case.
+        let span_context = SpanContext::new(
+            TraceId::from_hex("0af7651916cd43dd8448eb211c80319c").unwrap(),
+            SpanId::from_hex("b7ad6b7169203331").unwrap(),
+            TraceFlags::SAMPLED,
+            true,
+            TraceState::default(),
+        );
+        let cx = Context::new().with_remote_span_context(span_context);
+        let _ = serialize_context(&cx);
+        assert_eq!(
+            INJECT_CALLS.load(Ordering::SeqCst),
+            1,
+            "propagator must be consulted when a valid span is active",
+        );
     }
 
     #[test]


### PR DESCRIPTION
> ⚠️ **Machine-generated PR.** This change was authored by Claude (an AI agent) during an automated code-review pass. A human should review it before merging.

## Problem

`serialize_context` (in `dora-tracing`) invoked the process-global text-map propagator on **every** call, even when the passed `Context` carries no valid span. In that case a standard propagator injects nothing, so the whole dance produces an empty string that the callers then discard.

This runs on hot paths:

- `DoraNode::send_output` → `send_output_sample` calls it **per message** when the `tracing` feature is enabled (`apis/rust/node/src/node/mod.rs`).
- The operator runtimes (`runtime-shared-lib`, `runtime-python`) and the daemon call it **per event** (`binaries/runtime-shared-lib/src/runner.rs`, `binaries/runtime-python/src/runner.rs`, `binaries/daemon/src/running_dataflow.rs`).

Nodes commonly enable telemetry for logging without ever opening an OpenTelemetry span, so the common case paid a `global::get_text_map_propagator` lock acquisition + dynamic dispatch on every send that only ever returned `""`. (The empty `HashMap`/`String` themselves do not allocate until written to, so the saving is the propagator call, not an allocation.)

## Fix

Add a fast path that returns an empty string immediately when the context's span is invalid:

```rust
if !context.span().span_context().is_valid() {
    return String::new();
}
```

**Why this is safe.** Every standard text-map propagator (W3C TraceContext, B3, Jaeger, X-Ray) injects nothing for an invalid span context, and dora installs no propagator by default — the OpenTelemetry global is then the no-op propagator — so this path already returned `""`. The only behavior that would differ is a custom third-party propagator that chose to inject on an invalid context, and none is installed.

## Validation

- Replaced the original assertion (which held under both the no-op and W3C propagators, so it passed on the pre-change code and pinned nothing) with `serialize_skips_propagator_when_span_invalid`: it installs a counting spy propagator and asserts `inject_context` is **not** consulted for an invalid context — this **fails without the fast path** — while it **is** consulted for a valid span. The two tests that mutate the process-global propagator now serialize behind a shared lock so they can't race in the test binary.
- Verified empirically that the new test fails when the fast path is removed and passes when it is present.
- `cargo test -p dora-tracing` — 9 unit tests + 1 doctest pass.
- `cargo clippy -p dora-tracing --all-targets -- -D warnings` — clean.
- `cargo fmt -- --check` — clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVmPuXRkthLSS3vJ4juxza