### PR TITLE
perf(node-api-cxx): wait for events without busy-polling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2488,6 +2488,7 @@ dependencies = [
  "dora-ros2-bridge-msg-gen",
  "eyre",
  "futures-lite",
+ "futures-timer",
  "prettyplease",
  "rust-format",
  "serde",

--- a/apis/c++/node/Cargo.toml
+++ b/apis/c++/node/Cargo.toml
@@ -33,6 +33,7 @@ dora-node-api = { workspace = true , features = ["arrow-v59"] }
 eyre = { workspace = true }
 dora-ros2-bridge = { workspace = true, optional = true }
 futures-lite = { version = "2.6" }
+futures-timer = "3.0.4"
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde-big-array = { version = "0.5.1", optional = true }

--- a/apis/c++/node/src/lib.rs
+++ b/apis/c++/node/src/lib.rs
@@ -19,6 +19,8 @@ use dora_node_api::{
     merged::MergedEvent,
 };
 use eyre::{Result as EyreResult, bail, eyre};
+use futures_lite::future::{block_on, or};
+use futures_timer::Delay;
 use serde::Serialize;
 use serde_json::Value as JsonValue;
 
@@ -452,41 +454,53 @@ fn next_event(events: &mut Box<Events>) -> Box<DoraEvent> {
     events.next()
 }
 
-/// Block up to `timeout_ms` for the next event. Polls `try_recv` with
-/// an `Instant`-based deadline (and a short sleep between polls) so we
-/// can distinguish "timed out" from "stream closed" structurally —
-/// `EventStream::recv_timeout` returns `None` for both cases and
-/// matching on a wrapped `Event::Error(msg.contains("timed out"))`
-/// would be fragile (#1409 review feedback).
+/// Block up to `timeout_ms` for the next event.
+///
+/// Races the async receive against a timer so an incoming event wakes the
+/// thread immediately (no polling latency) and an idle wait consumes no CPU.
+/// The three outcomes are kept structurally distinct — event / stream closed
+/// / timed out — which is why this does not go through
+/// `EventStream::recv_timeout`: that folds a timeout into a wrapped
+/// `Event::Error` distinguishable only by matching its message text, which is
+/// fragile (#1409 review feedback).
 fn next_event_timeout(events: &mut Box<Events>, timeout_ms: u64) -> Box<DoraEvent> {
-    // `timeout_ms` arrives across the cxx::bridge as `u64`, so a C++
-    // caller can supply values that would panic the underlying
-    // `Instant + Duration` arithmetic on platforms with a bounded
-    // Instant range. Use `checked_add` and treat overflow as
-    // "effectively no deadline" -- keep polling indefinitely until
-    // an event arrives or the stream closes. Never returns
-    // `TimedOut` in the overflow case, matching the caller's
-    // intent ("wait as long as needed").
-    let deadline = Instant::now().checked_add(Duration::from_millis(timeout_ms));
-    // 1 ms keeps the busy-wait cost negligible while bounding overshoot
-    // of the caller-supplied deadline to ~1 ms in the worst case.
-    let poll_interval = Duration::from_millis(1);
-    loop {
-        match events.0.try_recv() {
-            Ok(event) => return Box::new(DoraEvent(EventOrReason::Event(event))),
-            Err(TryRecvError::Closed) => return Box::new(DoraEvent(EventOrReason::Closed)),
-            Err(TryRecvError::Empty) => match deadline {
-                Some(d) => {
-                    let now = Instant::now();
-                    if now >= d {
-                        return Box::new(DoraEvent(EventOrReason::TimedOut));
-                    }
-                    std::thread::sleep(std::cmp::min(d - now, poll_interval));
-                }
-                None => std::thread::sleep(poll_interval),
-            },
-        }
+    // `timeout_ms` crosses the cxx::bridge as an unbounded `u64`; clamp it to a
+    // duration whose `Instant::now() + dur` is representable so the timer's
+    // internal deadline arithmetic can never panic on a bogus `UINT64_MAX`.
+    // Shared with the pattern helpers via `clamp_pattern_timeout` so both paths
+    // treat an over-range timeout the same way ("wait a very long time").
+    let duration = clamp_pattern_timeout(timeout_ms);
+
+    // Fast path for a non-blocking probe (`timeout_ms == 0`): a single
+    // `try_recv`, avoiding arming a waker and a zero-length timer.
+    if duration.is_zero() {
+        return Box::new(DoraEvent(match events.0.try_recv() {
+            Ok(event) => EventOrReason::Event(event),
+            Err(TryRecvError::Closed) => EventOrReason::Closed,
+            Err(TryRecvError::Empty) => EventOrReason::TimedOut,
+        }));
     }
+
+    // The receive and the timer resolve to the same type so `or` can race them;
+    // whichever finishes first wins and the other future is dropped. Dropping
+    // the in-flight `recv_async` is sound — the Rust `EventStream::recv_*_timeout`
+    // helpers rely on the same cancel-on-timeout behavior.
+    enum Outcome {
+        Received(Option<Event>),
+        TimedOut,
+    }
+    let outcome = block_on(or(
+        async { Outcome::Received(events.0.recv_async().await) },
+        async {
+            Delay::new(duration).await;
+            Outcome::TimedOut
+        },
+    ));
+    Box::new(DoraEvent(match outcome {
+        Outcome::Received(Some(event)) => EventOrReason::Event(event),
+        Outcome::Received(None) => EventOrReason::Closed,
+        Outcome::TimedOut => EventOrReason::TimedOut,
+    }))
 }
 
 /// Non-blocking single poll. Returns `EventOrReason::Empty` (surfaced


### PR DESCRIPTION
> ⚠️ **Machine-generated PR.** This change was authored by Claude (an AI agent) during an automated code-review pass. A human should review it before merging.

## Problem

`next_event_timeout` — the C++ node's blocking-with-timeout receive — polled `try_recv` in a loop with a 1 ms sleep between attempts:

```rust
let poll_interval = Duration::from_millis(1);
loop {
    match events.0.try_recv() {
        Ok(event) => return ...,
        Err(TryRecvError::Closed) => return ...,
        Err(TryRecvError::Empty) => { ...; std::thread::sleep(min(d - now, poll_interval)); }
    }
}
```

On the C++ node receive hot path this costs up to ~1 ms of added latency per event and wakes the thread ~1000×/s while idle — burning CPU for a framework whose selling point is low latency.

The loop existed to keep the three outcomes (event / stream closed / timed out) **structurally distinct**: `EventStream::recv_timeout` folds a timeout into a wrapped `Event::Error` distinguishable only by matching its message text, which is fragile (#1409 review feedback).

## Fix

Replace the poll loop with an event-driven wait that races the async receive against a timer (`futures_lite::future::or` + `futures_timer::Delay`), so an incoming event wakes the thread immediately and an idle wait consumes no CPU. The three outcomes stay structurally distinct via an `Outcome` enum, so the `#1409` concern is preserved without polling. This mirrors the already-tested `EventStream::recv_async_timeout` select pattern (including cancelling the in-flight receive on timeout).

Two behaviors are preserved deliberately:

- **Overflow guard**: an over-range `timeout_ms` (whose `Instant::now() + dur` would panic the timer) is clamped via the existing `clamp_pattern_timeout` helper, so both this and the pattern helpers treat it the same way ("wait a very long time"). Reusing that helper keeps its doc comment — which claims parity with `next_event_timeout` — accurate.
- **Zero-timeout fast path**: `timeout_ms == 0` (a non-blocking probe) does a single `try_recv`, avoiding arming a waker and a zero-length timer.

## Validation

- `cargo test -p dora-node-api-cxx` — 16 tests pass.
- `cargo clippy -p dora-node-api-cxx --all-targets -- -D warnings` — clean.
- `cargo fmt` — clean.
- Ran `/code-review` and `/simplify` on the diff; the review flagged the `clamp_pattern_timeout` reuse/consistency point, which is incorporated above.

> Note: the full-workspace `cargo test --all` could not be run to completion in the review environment (the session's fixed disk allowance is exhausted by the debug build tree). The change is confined to one crate, whose full test suite passes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVmPuXRkthLSS3vJ4juxza

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVmPuXRkthLSS3vJ4juxza)_