### PR TITLE
chore: bump workspace version to 1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "action-example-client"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrow 59.3.0",
  "dora-node-api",
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "action-example-server"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrow 59.3.0",
  "dora-node-api",
@@ -97,7 +97,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "always-crash-node"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -808,7 +808,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "benchmark-example-node"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -819,7 +819,7 @@ dependencies = [
 
 [[package]]
 name = "benchmark-example-sink"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1210,7 +1210,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clean-exit-node"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1420,7 +1420,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpu-affinity-probe"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1539,7 +1539,7 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "cross-language-rust-receiver"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1547,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "cross-language-rust-sender"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "delayed-crash-node"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -2080,7 +2080,7 @@ dependencies = [
 
 [[package]]
 name = "dora-arrow-convert"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrow 58.4.0",
  "arrow 59.3.0",
@@ -2093,7 +2093,7 @@ dependencies = [
 
 [[package]]
 name = "dora-cli"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrow 59.3.0",
  "arrow-json",
@@ -2152,7 +2152,7 @@ dependencies = [
 
 [[package]]
 name = "dora-cli-api-python"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-cli",
  "dora-runtime-python",
@@ -2164,7 +2164,7 @@ dependencies = [
 
 [[package]]
 name = "dora-coordinator"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrow 59.3.0",
  "axum",
@@ -2196,7 +2196,7 @@ dependencies = [
 
 [[package]]
 name = "dora-coordinator-store"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-message",
  "eyre",
@@ -2210,7 +2210,7 @@ dependencies = [
 
 [[package]]
 name = "dora-core"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrow-buffer 59.3.0",
  "arrow-schema 59.3.0",
@@ -2242,7 +2242,7 @@ dependencies = [
 
 [[package]]
 name = "dora-daemon"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "aligned-vec",
  "chrono",
@@ -2290,7 +2290,7 @@ dependencies = [
 
 [[package]]
 name = "dora-download"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "eyre",
  "percent-encoding",
@@ -2332,7 +2332,7 @@ dependencies = [
 
 [[package]]
 name = "dora-hub-client"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dirs 6.0.0",
  "dora-core",
@@ -2346,7 +2346,7 @@ dependencies = [
 
 [[package]]
 name = "dora-log-utils"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrow 59.3.0",
  "chrono",
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "dora-mavlink2-bridge"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrow 59.3.0",
  "eyre",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "dora-mavlink2-bridge-node"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrow 59.3.0",
  "dora-mavlink2-bridge",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "dora-message"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "aligned-vec",
  "arrow-data 59.3.0",
@@ -2419,7 +2419,7 @@ dependencies = [
 
 [[package]]
 name = "dora-metrics"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "eyre",
  "opentelemetry",
@@ -2430,7 +2430,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "aligned-vec",
  "arrow 58.4.0",
@@ -2467,7 +2467,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-c"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrow-array 59.3.0",
  "dora-node-api",
@@ -2477,7 +2477,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-cxx"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrow 59.3.0",
  "chrono",
@@ -2497,7 +2497,7 @@ dependencies = [
 
 [[package]]
 name = "dora-node-api-python"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrow 59.3.0",
  "chrono",
@@ -2524,7 +2524,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-arrow-convert",
  "dora-operator-api-macros",
@@ -2533,14 +2533,14 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-c"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-operator-api-types",
 ]
 
 [[package]]
 name = "dora-operator-api-cxx"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cxx",
  "cxx-build",
@@ -2549,7 +2549,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-macros"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2558,7 +2558,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-python"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "aligned-vec",
  "arrow 59.3.0",
@@ -2579,7 +2579,7 @@ dependencies = [
 
 [[package]]
 name = "dora-operator-api-types"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrow 59.3.0",
  "dora-arrow-convert",
@@ -2588,7 +2588,7 @@ dependencies = [
 
 [[package]]
 name = "dora-record-node"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "aligned-vec",
  "dora-message",
@@ -2601,7 +2601,7 @@ dependencies = [
 
 [[package]]
 name = "dora-recording"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "eyre",
  "tempfile",
@@ -2610,7 +2610,7 @@ dependencies = [
 
 [[package]]
 name = "dora-replay-node"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-message",
  "dora-node-api",
@@ -2620,7 +2620,7 @@ dependencies = [
 
 [[package]]
 name = "dora-ros2-bridge"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "array-init",
  "byteorder",
@@ -2652,7 +2652,7 @@ dependencies = [
 
 [[package]]
 name = "dora-ros2-bridge-arrow"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrow 59.3.0",
  "byteorder",
@@ -2665,7 +2665,7 @@ dependencies = [
 
 [[package]]
 name = "dora-ros2-bridge-msg-gen"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "glob",
@@ -2685,7 +2685,7 @@ dependencies = [
 
 [[package]]
 name = "dora-ros2-bridge-node"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrow 59.3.0",
  "dora-message",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "dora-ros2-bridge-python"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrow 59.3.0",
  "dora-message",
@@ -2725,7 +2725,7 @@ dependencies = [
 
 [[package]]
 name = "dora-runtime-api"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrow 59.3.0",
  "dora-core",
@@ -2745,7 +2745,7 @@ dependencies = [
 
 [[package]]
 name = "dora-runtime-python"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrow 59.3.0",
  "dora-core",
@@ -2769,7 +2769,7 @@ dependencies = [
 
 [[package]]
 name = "dora-runtime-shared-lib"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrow 59.3.0",
  "dora-core",
@@ -2789,7 +2789,7 @@ dependencies = [
 
 [[package]]
 name = "dora-tensor-pool"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-core",
  "dora-message",
@@ -2806,7 +2806,7 @@ dependencies = [
 
 [[package]]
 name = "dora-tensor-pool-python"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrow 59.3.0",
  "dora-message",
@@ -2822,7 +2822,7 @@ dependencies = [
 
 [[package]]
 name = "dora-tracing"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "eyre",
  "opentelemetry",
@@ -2836,7 +2836,7 @@ dependencies = [
 
 [[package]]
 name = "drain-recording-node"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -2919,7 +2919,7 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "emit-then-exit-source-node"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "event-log-observer-node"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -3191,7 +3191,7 @@ checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
 
 [[package]]
 name = "fire-and-forget-source-node"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -3577,7 +3577,7 @@ dependencies = [
 
 [[package]]
 name = "hang-after-init-node"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "input-closed-observer-node"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4365,7 +4365,7 @@ checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
 name = "late-dynamic-sender"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4583,7 +4583,7 @@ dependencies = [
 
 [[package]]
 name = "log-sink-alert"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-arrow-convert",
  "dora-log-utils",
@@ -4594,7 +4594,7 @@ dependencies = [
 
 [[package]]
 name = "log-sink-file"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-log-utils",
  "dora-node-api",
@@ -4603,7 +4603,7 @@ dependencies = [
 
 [[package]]
 name = "log-sink-tcp"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-log-utils",
  "dora-node-api",
@@ -4734,7 +4734,7 @@ dependencies = [
 
 [[package]]
 name = "mavlink2-bridge-example-heartbeat-emitter"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrow 59.3.0",
  "dora-mavlink2-bridge",
@@ -4745,7 +4745,7 @@ dependencies = [
 
 [[package]]
 name = "mavlink2-bridge-example-mavlink-sim"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-mavlink2-bridge",
  "dora-node-api",
@@ -4757,7 +4757,7 @@ dependencies = [
 
 [[package]]
 name = "mavlink2-bridge-example-telemetry-printer-rust"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrow 59.3.0",
  "dora-mavlink2-bridge",
@@ -4871,7 +4871,7 @@ dependencies = [
 
 [[package]]
 name = "multiple-daemons-example-node"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -4882,14 +4882,14 @@ dependencies = [
 
 [[package]]
 name = "multiple-daemons-example-operator"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-operator-api",
 ]
 
 [[package]]
 name = "multiple-daemons-example-sink"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -6469,7 +6469,7 @@ dependencies = [
 
 [[package]]
 name = "receive_data"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "chrono",
  "dora-node-api",
@@ -6478,7 +6478,7 @@ dependencies = [
 
 [[package]]
 name = "reconnect-survivor-node"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -6682,7 +6682,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-node"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -6695,7 +6695,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-sink"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -6703,7 +6703,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-sink-dynamic"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -6711,7 +6711,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dataflow-example-status-node"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -6720,7 +6720,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dynamic-add-remove-filter"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -6728,7 +6728,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dynamic-add-remove-receiver"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -6736,7 +6736,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dynamic-add-remove-sender"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -6755,14 +6755,14 @@ dependencies = [
 
 [[package]]
 name = "rust-operator-teardown-example-operator"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-operator-api",
 ]
 
 [[package]]
 name = "rust-ros2-example-node"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "dora-ros2-bridge",
@@ -7346,7 +7346,7 @@ dependencies = [
 
 [[package]]
 name = "service-example-client"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrow 59.3.0",
  "dora-node-api",
@@ -7355,7 +7355,7 @@ dependencies = [
 
 [[package]]
 name = "service-example-server"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrow 59.3.0",
  "dora-node-api",
@@ -7500,7 +7500,7 @@ dependencies = [
 
 [[package]]
 name = "sigterm-ignoring-node"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -7509,7 +7509,7 @@ dependencies = [
 
 [[package]]
 name = "silent-source-node"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -7749,7 +7749,7 @@ dependencies = [
 
 [[package]]
 name = "stop-delay-node"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -8107,7 +8107,7 @@ dependencies = [
 
 [[package]]
 name = "timed-burst-source-node"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -8115,7 +8115,7 @@ dependencies = [
 
 [[package]]
 name = "timer-tick-recorder-node"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -8788,7 +8788,7 @@ dependencies = [
 
 [[package]]
 name = "validated-pipeline-sink"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -8796,7 +8796,7 @@ dependencies = [
 
 [[package]]
 name = "validated-pipeline-source"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -8804,7 +8804,7 @@ dependencies = [
 
 [[package]]
 name = "validated-pipeline-transform"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "dora-node-api",
  "eyre",
@@ -9654,7 +9654,7 @@ dependencies = [
 
 [[package]]
 name = "yaml-bridge-action-goal"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrow 59.3.0",
  "dora-node-api",
@@ -9663,7 +9663,7 @@ dependencies = [
 
 [[package]]
 name = "yaml-bridge-action-server-handler"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrow 59.3.0",
  "dora-node-api",
@@ -9672,7 +9672,7 @@ dependencies = [
 
 [[package]]
 name = "yaml-bridge-service-handler"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrow 59.3.0",
  "dora-node-api",
@@ -9681,7 +9681,7 @@ dependencies = [
 
 [[package]]
 name = "yaml-bridge-service-requester"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrow 59.3.0",
  "dora-node-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ edition = "2024"
 # harnesses (#3090). Bump that one only against Kani's rustc.
 rust-version = "1.95.0"
 # Python packages derive version from CARGO_PKG_VERSION automatically.
-version = "1.0.0"
+version = "1.0.1"
 description = "`dora` goal is to be a low latency, composable, and distributed data flow."
 documentation = "https://dora-rs.ai"
 readme = "./README.md"
@@ -110,36 +110,36 @@ license = "Apache-2.0"
 repository = "https://github.com/dora-rs/dora/"
 
 [workspace.dependencies]
-dora-node-api = { version = "=1.0.0", path = "apis/rust/node", default-features = false }
-dora-node-api-python = { version = "=1.0.0", path = "apis/python/node", default-features = false }
-dora-operator-api = { version = "=1.0.0", path = "apis/rust/operator", default-features = false }
-dora-operator-api-macros = { version = "=1.0.0", path = "apis/rust/operator/macros" }
-dora-operator-api-types = { version = "=1.0.0", path = "apis/rust/operator/types" }
-dora-operator-api-python = { version = "=1.0.0", path = "apis/python/operator" }
-dora-operator-api-c = { version = "=1.0.0", path = "apis/c/operator" }
-dora-node-api-c = { version = "=1.0.0", path = "apis/c/node" }
-dora-core = { version = "=1.0.0", path = "libraries/core" }
-dora-hub-client = { version = "=1.0.0", path = "libraries/hub-client" }
-dora-recording = { version = "=1.0.0", path = "libraries/recording" }
-dora-arrow-convert = { version = "=1.0.0", path = "libraries/arrow-convert" }
-dora-tracing = { version = "=1.0.0", path = "libraries/extensions/telemetry/tracing" }
-dora-metrics = { version = "=1.0.0", path = "libraries/extensions/telemetry/metrics" }
-dora-download = { version = "=1.0.0", path = "libraries/extensions/download" }
-dora-log-utils = { version = "=1.0.0", path = "libraries/log-utils" }
-dora-coordinator-store = { version = "=1.0.0", path = "libraries/coordinator-store" }
-dora-cli = { version = "=1.0.0", path = "binaries/cli" }
-dora-runtime-api = { version = "=1.0.0", path = "binaries/runtime-api" }
-dora-runtime-shared-lib = { version = "=1.0.0", path = "binaries/runtime-shared-lib" }
-dora-runtime-python = { version = "=1.0.0", path = "binaries/runtime-python" }
-dora-daemon = { version = "=1.0.0", path = "binaries/daemon" }
-dora-coordinator = { version = "=1.0.0", path = "binaries/coordinator" }
-dora-ros2-bridge = { version = "=1.0.0", path = "libraries/extensions/ros2-bridge" }
-dora-ros2-bridge-msg-gen = { version = "=1.0.0", path = "libraries/extensions/ros2-bridge/msg-gen" }
+dora-node-api = { version = "=1.0.1", path = "apis/rust/node", default-features = false }
+dora-node-api-python = { version = "=1.0.1", path = "apis/python/node", default-features = false }
+dora-operator-api = { version = "=1.0.1", path = "apis/rust/operator", default-features = false }
+dora-operator-api-macros = { version = "=1.0.1", path = "apis/rust/operator/macros" }
+dora-operator-api-types = { version = "=1.0.1", path = "apis/rust/operator/types" }
+dora-operator-api-python = { version = "=1.0.1", path = "apis/python/operator" }
+dora-operator-api-c = { version = "=1.0.1", path = "apis/c/operator" }
+dora-node-api-c = { version = "=1.0.1", path = "apis/c/node" }
+dora-core = { version = "=1.0.1", path = "libraries/core" }
+dora-hub-client = { version = "=1.0.1", path = "libraries/hub-client" }
+dora-recording = { version = "=1.0.1", path = "libraries/recording" }
+dora-arrow-convert = { version = "=1.0.1", path = "libraries/arrow-convert" }
+dora-tracing = { version = "=1.0.1", path = "libraries/extensions/telemetry/tracing" }
+dora-metrics = { version = "=1.0.1", path = "libraries/extensions/telemetry/metrics" }
+dora-download = { version = "=1.0.1", path = "libraries/extensions/download" }
+dora-log-utils = { version = "=1.0.1", path = "libraries/log-utils" }
+dora-coordinator-store = { version = "=1.0.1", path = "libraries/coordinator-store" }
+dora-cli = { version = "=1.0.1", path = "binaries/cli" }
+dora-runtime-api = { version = "=1.0.1", path = "binaries/runtime-api" }
+dora-runtime-shared-lib = { version = "=1.0.1", path = "binaries/runtime-shared-lib" }
+dora-runtime-python = { version = "=1.0.1", path = "binaries/runtime-python" }
+dora-daemon = { version = "=1.0.1", path = "binaries/daemon" }
+dora-coordinator = { version = "=1.0.1", path = "binaries/coordinator" }
+dora-ros2-bridge = { version = "=1.0.1", path = "libraries/extensions/ros2-bridge" }
+dora-ros2-bridge-msg-gen = { version = "=1.0.1", path = "libraries/extensions/ros2-bridge/msg-gen" }
 dora-ros2-bridge-python = { path = "libraries/extensions/ros2-bridge/python" }
-dora-mavlink2-bridge = { version = "=1.0.0", path = "libraries/extensions/mavlink2-bridge" }
-dora-tensor-pool = { version = "=1.0.0", path = "libraries/extensions/tensor-pool" }
-dora-tensor-pool-python = { version = "=1.0.0", path = "libraries/extensions/tensor-pool/python" }
-dora-message = { version = "=1.0.0", path = "libraries/message" }
+dora-mavlink2-bridge = { version = "=1.0.1", path = "libraries/extensions/mavlink2-bridge" }
+dora-tensor-pool = { version = "=1.0.1", path = "libraries/extensions/tensor-pool" }
+dora-tensor-pool-python = { version = "=1.0.1", path = "libraries/extensions/tensor-pool/python" }
+dora-message = { version = "=1.0.1", path = "libraries/message" }
 # Declared here so `dora-ros2-bridge` and `dora-ros2-bridge-arrow` cannot drift
 # apart on the ROS distro. `humble` selects the 24-byte `Gid` layout used by
 # `rmw_dds_common` graph discovery (see `ros2-client`'s `src/gid.rs`), matching

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v1.0.1 (2026-09-03)
+
+Patch release. 1.0.0 could not be installed from crates.io.
+
+### Fixed
+
+- **`cargo install dora-cli` works again** ([#3400](https://github.com/dora-rs/dora/issues/3400)). `dora-operator-api-c`'s build script read its cmake templates from the sibling `apis/c/node/` crate with `include_str!("../node/cmake/…")`. `cargo package` builds a crate's tarball from that one directory and ships nothing else, so the published 1.0.0 crate did not contain the files its own build script names, and compiling it failed at the first line. The workspace build never saw this, because in a checkout the sibling crate is right there. The templates now live in `apis/c/operator/cmake/` as a crate-local copy, matching what the two C++ API crates already did for the same reason. Anyone who hit the error needs no change beyond upgrading; nothing about the C operator API itself moved.
+- **`dora-cli` no longer builds three crates it never used** ([#3402](https://github.com/dora-rs/dora/pull/3402)). `dora-operator-api-c`, `tokio-stream` and `tracing-log` were declared and never referenced. The first is why the packaging bug above broke `cargo install dora-cli` at all: installing the CLI compiled a C static-library crate the CLI does not call.
+
+### Internal
+
+- The release workflow publishes with verification instead of `--no-verify` ([#3403](https://github.com/dora-rs/dora/pull/3403)), so a crate that cannot build from its own tarball stops the release rather than reaching crates.io. `cargo-release.yml`, whose `release: published` trigger is never raised for a `GITHUB_TOKEN`-created release, is folded into `release.yml` ([#3404](https://github.com/dora-rs/dora/pull/3404)). A new `make qa-package-includes` gate fails any publishable crate whose `include_str!` target is not a git-tracked file inside that crate.
+
 ## v1.0.0 (2026-09-02)
 
 ### Breaking


### PR DESCRIPTION
Merge after #3401 and #3402 — this only sets the version they ship under.

Bumps `[workspace.package].version` to 1.0.1, the 29 internal `=1.0.0` pins that go with it, and the lockfile, and cuts a Changelog entry. Same shape as the 1.0.0 bump in #3121.

1.0.0 is not installable from crates.io: `cargo install dora-cli` fails compiling `dora-operator-api-c`, whose published tarball is missing the cmake templates its build script reads (#3400). A published version cannot be replaced, so the fix only reaches users as 1.0.1.

Both halves matter for that. #3401 repairs the C operator crate, which direct users of it need. #3402 removes the CLI's unused dependency on that crate, which is what made a C-API packaging bug break the documented quickstart — with it gone, `cargo package -p dora-cli` succeeds without the C operator crate in the graph at all.

The new breaking-change gate from #3389 reads the bump as expected: `Workspace version ... ok [1.0.0 -> 1.0.1]`, no breaking changes against v1.0.0.

The Changelog entry is dated 2026-09-03. Retitle it if the tag is pushed on a different day.

After merging, tag `v1.0.1` on `main` and push the tag — `release.yml` does the rest. If #3403 has landed by then, that publish runs with verification, so a crate that cannot build from its own tarball stops the release instead of shipping. Worth confirming `cargo package -p dora-operator-api-c` and `-p dora-cli` are green on the merge commit first; both were verified on the branches.
