### PR TITLE
fix(cli): normalize CRLF when comparing the cli-surface.txt snapshot

### DIFF
--- a/binaries/cli/tests/cli_surface.rs
+++ b/binaries/cli/tests/cli_surface.rs
@@ -110,6 +110,10 @@ fn cli_surface_snapshot_is_current() {
             path.display()
         )
     });
+    // Windows checkouts of this repo can normalize the committed LF line
+    // endings to CRLF (e.g. via a global `core.autocrlf=true`), which would
+    // otherwise fail this raw comparison despite the surface being unchanged.
+    let recorded = recorded.replace("\r\n", "\n");
 
     if recorded != current {
         let recorded_lines: BTreeSet<_> = recorded.lines().filter(|l| keep(l)).collect();


### PR DESCRIPTION
## Summary

Fixes the nightly regression reported in #3406: the `test-cross-platform` job failed on Windows with `cli_surface_snapshot_is_current` panicking with "the `dora` command surface changed", yet the panic message's own line-based diff showed `removed: (none)` and `added: (none)`.

Root cause: `binaries/cli/tests/cli_surface.rs` compares the checked-in `cli-surface.txt` snapshot against a freshly generated string using raw string equality (`recorded != current`). On the Windows nightly runner, git checks out the repo's LF-committed text files as CRLF (this repo has no `.gitattributes` pinning line endings, and GitHub Actions' Windows git installs commonly default to `core.autocrlf=true`). The generated `current` string is always LF-only (built via `format!`/`join("\n")` in Rust source), so the raw comparison fails even though the actual surface content is identical — which is exactly why the diagnostic line-based diff (which normalizes `\r\n`/`\n` via `str::lines()`) showed nothing changed.

## Fix

Normalize the file-read `recorded` string (`.replace("\r\n", "\n")`) before comparing, mirroring the same idiom already used elsewhere in the codebase for the same reason (e.g. `tests/example-tests.rs`, `examples/rust-dataflow/*/src/tests.rs`).

## Follow-up considered, not included here

A repo-wide `.gitattributes` (e.g. `* text=auto eol=lf`) would fix this whole class of bug for every current and future snapshot/golden-file test, not just this one. That's a larger, repo-wide change (re-normalizes checkout behavior for every tracked file) that deserves its own discussion rather than being bundled into this narrow nightly-regression fix, so I left it out of scope here.

## Test plan

- [x] `cargo test -p dora-cli --test cli_surface` passes (both `cli_surface_snapshot_is_current` and `snapshot_covers_the_command_tree`)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -p dora-cli --all-targets -- -D warnings` passes
- [x] Reviewed via `/review` and `/simplify` (4-angle parallel review): no correctness issues found; confirmed this is the minimal, precedented fix and the `.gitattributes` alternative is out of scope for this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VLPNpyzi3pJ6Xoe9kYV59t

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLPNpyzi3pJ6Xoe9kYV59t)_