### PR TITLE
fix(daemon): don't skip finished-dataflow cleanup when the coordinator report fails

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -2659,9 +2659,23 @@ impl Daemon {
             }
         }
 
-        // Finish dataflows after the loop to avoid borrow checker issues
+        // Finish dataflows after the loop to avoid borrow checker issues.
+        //
+        // `finish_dataflow` always runs each dataflow's local cleanup now,
+        // but it still surfaces a coordinator-report failure. A bare `?`
+        // here would abort the batch on the first such failure and leak the
+        // cleanup of every remaining dataflow in `dataflows_to_finish` — the
+        // same leak this whole path guards against, just moved to the batch
+        // siblings. Finish every dataflow, then return the first error so the
+        // caller's reconnect-on-error behavior is preserved.
+        let mut first_err = None;
         for dataflow_id in dataflows_to_finish {
-            self.finish_dataflow(dataflow_id).await?;
+            if let Err(err) = self.finish_dataflow(dataflow_id).await {
+                first_err.get_or_insert(err);
+            }
+        }
+        if let Some(err) = first_err {
+            return Err(err);
         }
 
         self.exit_when_all_finished = true;
@@ -6133,22 +6147,37 @@ impl Daemon {
             )
             .await;
 
-        if let Some(sender) = &self.coordinator_sender {
-            let msg = serde_json::to_vec(&Timestamped {
-                inner: CoordinatorRequest::Event {
-                    daemon_id: self.daemon_id.clone(),
-                    event: DaemonEvent::AllNodesFinished {
-                        dataflow_id,
-                        result,
+        // Report the finish to the coordinator, but do NOT let a failed
+        // report skip the local cleanup below. A coordinator connection
+        // blip commonly co-occurs with a finishing dataflow, and
+        // `send_event` returns `Err` exactly when that connection is gone.
+        // Propagating that error with `?` before the cleanup would leave
+        // the finished dataflow's listener loops unsignalled and its entry
+        // stranded in `self.running` forever (the daemon survives the
+        // reconnect), and the memory-pool subscriber task leaked. Capture
+        // the report result and surface it only after cleanup has run.
+        let report_result: eyre::Result<()> = async {
+            if let Some(sender) = &self.coordinator_sender {
+                let msg = serde_json::to_vec(&Timestamped {
+                    inner: CoordinatorRequest::Event {
+                        daemon_id: self.daemon_id.clone(),
+                        event: DaemonEvent::AllNodesFinished {
+                            dataflow_id,
+                            result,
+                        },
                     },
-                },
-                timestamp: self.clock.new_timestamp(),
-            })?;
-            sender
-                .send_event(&msg)
-                .await
-                .wrap_err("failed to report dataflow finish to dora-coordinator")?;
+                    timestamp: self.clock.new_timestamp(),
+                })
+                .wrap_err("failed to serialize dataflow-finish report")?;
+                sender
+                    .send_event(&msg)
+                    .await
+                    .wrap_err("failed to report dataflow finish to dora-coordinator")?;
+            }
+            Ok(())
         }
+        .await;
+
         // Signal all listener loops for this dataflow to shut down
         if let Some(df) = self.running.get(&dataflow_id) {
             let _ = df.listener_shutdown_tx.send(true);
@@ -6161,6 +6190,10 @@ impl Daemon {
         // tasks and can create duplicate consumers.
         #[cfg(feature = "tensor-pool")]
         self.pool_cleanup_dataflow(dataflow_id).await;
+
+        // Now that local cleanup has run, surface any coordinator-report
+        // failure to the caller (the reconnect loop) as before.
+        report_result?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

> ⚠️ **This is a machine-generated change (Claude Code).** It was produced by an automated code-review pass. Please review it with the same (or extra) scrutiny you would any PR before merging.

`Daemon::finish_dataflow` reported `AllNodesFinished` to the coordinator with a fallible `send_event(...).await?` **before** doing its local cleanup:

```rust
if let Some(sender) = &self.coordinator_sender {
    let msg = serde_json::to_vec(&Timestamped { ... AllNodesFinished ... })?;
    sender.send_event(&msg).await
        .wrap_err("failed to report dataflow finish to dora-coordinator")?;   // early return on error
}
// Signal all listener loops for this dataflow to shut down
if let Some(df) = self.running.get(&dataflow_id) { let _ = df.listener_shutdown_tx.send(true); }
self.running.remove(&dataflow_id);
// ... (tensor-pool) subscriber-task teardown
```

`send_event` returns `Err` exactly when the coordinator WS channel's receiver is gone — a coordinator connection blip, which commonly co-occurs with a dataflow finishing. On that error the `?` returns before the cleanup, so:

- the finished dataflow's **listener loops are never signalled to shut down**,
- its entry **lingers in `self.running` forever** — all three callers propagate the error up into the reconnect loop, and the `Daemon` itself survives the reconnect, so the leaked, already-finished dataflow is never cleaned up, and
- under the `tensor-pool` feature, the **memory-pool subscriber task is leaked**.

The daemon also never retries the finish report, so the coordinator never learns the dataflow finished.

## Fix

- In `finish_dataflow`: capture the coordinator-report result (in an `async {…}.await` try-block) instead of `?`-propagating it inline; run the local cleanup **unconditionally**; then surface the report error to the caller afterwards (same error path and message as before, just moved past the cleanup). The `serde_json::to_vec` step is inside the same block so a serialization failure can't skip cleanup either.
- In the batch caller `trigger_manual_stop`: it looped `finish_dataflow(id).await?`, so a `?` on the first failing report would abort the batch and leak the cleanup of every **remaining** dataflow — the same leak, moved to the batch siblings. It now finishes all queued dataflows and returns the first error afterwards, preserving the caller's reconnect-on-error behavior.

This mirrors how the surrounding code deliberately keeps a fallible *remote* report from tearing down *local* state (e.g. `handle_inter_daemon_event` catches and logs rather than unwinding).

## Validation

- `cargo +1.97.1 fmt --all -- --check` — clean.
- `cargo +1.97.1 clippy -p dora-daemon --all-targets -- -D warnings` — clean.
- `cargo +1.97.1 test -p dora-daemon --lib` — 249 passed, 0 failed.

The change is a control-flow reordering (report result captured, cleanup made unconditional, error surfaced at the end); a dedicated unit test would require standing up a full `Daemon` with a severed coordinator channel, which the crate has no lightweight harness for. The coordinator-disconnect behavior is exercised by the repo's fault-tolerance e2e suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLDE3egzM4fhoVZG5qRyuA