### PR TITLE
docs(message): document current_crate_version and InvalidId; use the helper in NodeRegisterRequest

### DIFF
--- a/libraries/message/src/id.rs
+++ b/libraries/message/src/id.rs
@@ -84,8 +84,19 @@ fn validate_data_id(id: &str) -> Result<(), InvalidId> {
     Ok(())
 }
 
+/// Error returned when a string fails validation as a [`NodeId`] or
+/// [`DataId`].
+///
+/// Produced by their [`FromStr`](std::str::FromStr) implementations. The
+/// wrapped `String` is a human-readable explanation of why the id was
+/// rejected (empty, a reserved name, a disallowed character, an empty path
+/// segment, …); its [`Display`](std::fmt::Display) forwards to that message.
+/// ([`OperatorId`] parsing is infallible and does not produce this error.)
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct InvalidId(pub String);
+pub struct InvalidId(
+    /// Human-readable reason the id was rejected.
+    pub String,
+);
 
 impl std::fmt::Display for InvalidId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/libraries/message/src/lib.rs
+++ b/libraries/message/src/lib.rs
@@ -253,6 +253,29 @@ impl std::fmt::Display for BuildId {
     }
 }
 
+/// This `dora-message` build's own version, as a parsed [`semver::Version`].
+///
+/// This is the compile-time [`VERSION`] (`CARGO_PKG_VERSION`) parsed into a
+/// structured [`semver::Version`] so it can be compared with a peer's
+/// version. dora's components stamp it into their connection handshakes and
+/// compare it against the version a peer reports — `cli_to_coordinator::ControlRequest::Hello`,
+/// the daemon's `daemon_to_coordinator::DaemonRegisterRequest`, and the node's
+/// `node_to_daemon::NodeRegisterRequest` — to detect an incompatible peer.
+///
+/// # Examples
+///
+/// ```
+/// // The structured version round-trips to the crate's `VERSION` string.
+/// assert_eq!(
+///     dora_message::current_crate_version().to_string(),
+///     dora_message::VERSION,
+/// );
+/// ```
+///
+/// # Panics
+///
+/// Parses [`VERSION`], which for any released build is a valid semver string
+/// baked in by Cargo, so this never panics in practice.
 pub fn current_crate_version() -> semver::Version {
     let crate_version_raw = env!("CARGO_PKG_VERSION");
 

--- a/libraries/message/src/node_to_daemon.rs
+++ b/libraries/message/src/node_to_daemon.rs
@@ -163,7 +163,7 @@ impl NodeRegisterRequest {
         Self {
             dataflow_id,
             node_id,
-            dora_version: semver::Version::parse(env!("CARGO_PKG_VERSION")).unwrap(),
+            dora_version: current_crate_version(),
             metadata_version: Metadata::CURRENT_VERSION,
         }
     }


### PR DESCRIPTION
## Summary

> ⚠️ **This is a machine-generated change (Claude Code).** It was produced by an automated code-review pass. Please review it before merging.

Two public items in `dora-message` carried no rustdoc while their neighbours are all documented:

- **`current_crate_version()`** (`lib.rs`) — used across the coordinator, CLI, daemon, and node connection handshakes to detect an incompatible peer, yet undocumented (and it silently `.unwrap()`s the parse). Added a doc comment relating it to `VERSION`, a `# Panics` note, and a **compile-checked doctest** asserting the parsed version round-trips to the crate's `VERSION` string.
- **`InvalidId`** and its public field (`id.rs`) — the error type returned by `NodeId`/`DataId`'s `FromStr`, undocumented despite the heavily documented panic-footgun sections in the same file. Documented the type and the wrapped reason string, and noted that `OperatorId` parsing is infallible and does not produce it.

Plus one small **reuse** cleanup surfaced while writing the docs: `NodeRegisterRequest::new` re-implemented `current_crate_version()` inline as `semver::Version::parse(env!("CARGO_PKG_VERSION")).unwrap()`, even though the same file already calls the helper in `check_version` right below. It now calls `current_crate_version()`, matching the doc that points to it as the canonical way to obtain the crate version.

Documentation plus a one-line reuse cleanup — no behavior change.

## Notes

- I deliberately left the `InputDef` enum (also undocumented and doc-linked from `Input`) alone here: it derives `JsonSchema`, so documenting its variants would churn the committed `dora-schema.json` snapshots and engage the breaking-change gate — out of proportion for a doc addition. It can be a separate change that regenerates the schema intentionally.

## Validation

- `cargo +1.97.1 test -p dora-message --doc` — passed (incl. the new `current_crate_version` doctest).
- `cargo +1.97.1 test -p dora-message --lib` — 161 passed, 0 failed.
- `cargo +1.97.1 clippy -p dora-message --all-targets -- -D warnings` — clean.
- `cargo +1.97.1 fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLDE3egzM4fhoVZG5qRyuA