### PR TITLE
feat(python): ship CPython 3.10 wheels alongside the abi3 ones

### DIFF
--- a/.claude/skills/adora-project/SKILL.md
+++ b/.claude/skills/adora-project/SKILL.md
@@ -196,7 +196,7 @@ cargo clippy --all --exclude dora-node-api-python --exclude dora-operator-api-py
 - Python Node API: `apis/python/node/` -- `#[pyclass] Node` with iterator protocol
 - Python Operator API: `apis/python/operator/` -- type conversion utilities
 - Python CLI API: `apis/python/cli/` -- `build()`, `run()`, `start_runtime()`
-- Uses PyO3 0.29 with `eyre`, `abi3-py311`, `multiple-pymethods` features
+- Uses PyO3 0.29 with `eyre`, `multiple-pymethods` features; `abi3-py311` is a default-on `abi3` feature on the two built python crates (off for the cp310 wheels)
 - Arrow arrays passed zero-copy via `arrow::pyarrow` FFI
 - GIL released during blocking Rust ops (`py.detach()`)
 

--- a/.github/workflows/pip-release.yml
+++ b/.github/workflows/pip-release.yml
@@ -92,13 +92,26 @@ jobs:
         repository:
           - path: apis/python/node
             name: dora-node-api
+            no_abi3_features: tracing,metrics,async
           - path: apis/python/cli
             name: dora-rs-cli
+            no_abi3_features: telemetry
+        abi:
+          # Today's build, unchanged: one cp311-abi3 wheel that loads on 3.11
+          # and every later CPython.
+          - tag: abi3
+            python: "3.11"
+          # CPython 3.10 is exactly what abi3-py311 excludes, so it needs a
+          # version-specific wheel. `--no-default-features` drops the `abi3`
+          # feature and must re-state the crate's other defaults, which is what
+          # `no_abi3_features` on each repository entry carries.
+          - tag: cp310
+            python: "3.10"
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ matrix.abi.python }}
       - run: rustup default ${{ env.RUST_VERSION }}
       - run: rustup update ${{ env.RUST_VERSION }}
       # No rust-cache step here, deliberately. This job used to run
@@ -124,7 +137,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --zig
+          args: --release --out dist --zig ${{ matrix.abi.tag == 'cp310' && format('--no-default-features --features {0}', matrix.repository.no_abi3_features) || '' }}
           manylinux: manylinux_2_28
           # sccache's GitHub-cache backend writes one entry per compiled
           # object, flooding the 10 GB repo-wide cache with thousands of
@@ -148,7 +161,7 @@ jobs:
         if: github.event_name == 'release' || inputs.publish
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.repository.name }}-linux-${{ matrix.platform.target }}
+          name: ${{ matrix.repository.name }}-linux-${{ matrix.platform.target }}-${{ matrix.abi.tag }}
           path: ${{ matrix.repository.path }}/dist
 
   musllinux:
@@ -166,18 +179,31 @@ jobs:
         repository:
           - path: apis/python/node
             name: dora-node-api
+            no_abi3_features: tracing,metrics,async
           - path: apis/python/cli
             name: dora-rs-cli
+            no_abi3_features: telemetry
+        abi:
+          # Today's build, unchanged: one cp311-abi3 wheel that loads on 3.11
+          # and every later CPython.
+          - tag: abi3
+            python: "3.11"
+          # CPython 3.10 is exactly what abi3-py311 excludes, so it needs a
+          # version-specific wheel. `--no-default-features` drops the `abi3`
+          # feature and must re-state the crate's other defaults, which is what
+          # `no_abi3_features` on each repository entry carries.
+          - tag: cp310
+            python: "3.10"
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ matrix.abi.python }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist
+          args: --release --out dist ${{ matrix.abi.tag == 'cp310' && format('--no-default-features --features {0}', matrix.repository.no_abi3_features) || '' }}
           sccache: "false"
           manylinux: musllinux_1_2
           working-directory: ${{ matrix.repository.path }}
@@ -186,7 +212,7 @@ jobs:
         if: github.event_name == 'release' || inputs.publish
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.repository.name }}-musllinux-${{ matrix.platform.target }}
+          name: ${{ matrix.repository.name }}-musllinux-${{ matrix.platform.target }}-${{ matrix.abi.tag }}
           path: ${{ matrix.repository.path }}/dist
 
   musleabi:
@@ -204,8 +230,21 @@ jobs:
         repository:
           - path: apis/python/node
             name: dora-node-api
+            no_abi3_features: tracing,metrics,async
           - path: apis/python/cli
             name: dora-rs-cli
+            no_abi3_features: telemetry
+        abi:
+          # Today's build, unchanged: one cp311-abi3 wheel that loads on 3.11
+          # and every later CPython.
+          - tag: abi3
+            python: "3.11"
+          # CPython 3.10 is exactly what abi3-py311 excludes, so it needs a
+          # version-specific wheel. `--no-default-features` drops the `abi3`
+          # feature and must re-state the crate's other defaults, which is what
+          # `no_abi3_features` on each repository entry carries.
+          - tag: cp310
+            python: "3.10"
     container:
       image: docker://messense/rust-musl-cross:${{ matrix.platform.image_tag }}
       env:
@@ -214,20 +253,20 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ matrix.abi.python }}
       - name: Build Wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
           manylinux: auto
           container: off
-          args: --release -o dist
+          args: --release -o dist ${{ matrix.abi.tag == 'cp310' && format('--no-default-features --features {0}', matrix.repository.no_abi3_features) || '' }}
           working-directory: ${{ matrix.repository.path }}
       - name: Upload wheels
         if: github.event_name == 'release' || inputs.publish
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.repository.name }}-musllinux-${{ matrix.platform.target }}
+          name: ${{ matrix.repository.name }}-musllinux-${{ matrix.platform.target }}-${{ matrix.abi.tag }}
           path: ${{ matrix.repository.path }}/dist
 
   windows:
@@ -241,19 +280,32 @@ jobs:
         repository:
           - path: apis/python/node
             name: dora-node-api
+            no_abi3_features: tracing,metrics,async
           - path: apis/python/cli
             name: dora-rs-cli
+            no_abi3_features: telemetry
+        abi:
+          # Today's build, unchanged: one cp311-abi3 wheel that loads on 3.11
+          # and every later CPython.
+          - tag: abi3
+            python: "3.11"
+          # CPython 3.10 is exactly what abi3-py311 excludes, so it needs a
+          # version-specific wheel. `--no-default-features` drops the `abi3`
+          # feature and must re-state the crate's other defaults, which is what
+          # `no_abi3_features` on each repository entry carries.
+          - tag: cp310
+            python: "3.10"
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ matrix.abi.python }}
           architecture: ${{ matrix.platform.target }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i ${{ env.PYTHON_VERSION }}
+          args: --release --out dist -i ${{ matrix.abi.python }} ${{ matrix.abi.tag == 'cp310' && format('--no-default-features --features {0}', matrix.repository.no_abi3_features) || '' }}
           # Was "true" — sccache floods the 10 GB repo cache with
           # per-object entries that evict PR CI's workspace caches. See
           # the linux job above for the full rationale.
@@ -263,7 +315,7 @@ jobs:
         if: github.event_name == 'release' || inputs.publish
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.repository.name }}-windows-${{ matrix.platform.target }}
+          name: ${{ matrix.repository.name }}-windows-${{ matrix.platform.target }}-${{ matrix.abi.tag }}
           path: ${{ matrix.repository.path }}/dist
 
   macos:
@@ -277,18 +329,31 @@ jobs:
         repository:
           - path: apis/python/node
             name: dora-node-api
+            no_abi3_features: tracing,metrics,async
           - path: apis/python/cli
             name: dora-rs-cli
+            no_abi3_features: telemetry
+        abi:
+          # Today's build, unchanged: one cp311-abi3 wheel that loads on 3.11
+          # and every later CPython.
+          - tag: abi3
+            python: "3.11"
+          # CPython 3.10 is exactly what abi3-py311 excludes, so it needs a
+          # version-specific wheel. `--no-default-features` drops the `abi3`
+          # feature and must re-state the crate's other defaults, which is what
+          # `no_abi3_features` on each repository entry carries.
+          - tag: cp310
+            python: "3.10"
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ matrix.abi.python }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i ${{ env.PYTHON_VERSION }}
+          args: --release --out dist -i ${{ matrix.abi.python }} ${{ matrix.abi.tag == 'cp310' && format('--no-default-features --features {0}', matrix.repository.no_abi3_features) || '' }}
           # Explicit: never enable the sccache GitHub-cache backend here
           # (floods the 10 GB repo cache). See the linux job for details.
           sccache: "false"
@@ -297,7 +362,7 @@ jobs:
         if: github.event_name == 'release' || inputs.publish
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.repository.name }}-macos-${{ matrix.platform.target }}
+          name: ${{ matrix.repository.name }}-macos-${{ matrix.platform.target }}-${{ matrix.abi.tag }}
           path: ${{ matrix.repository.path }}/dist
 
   sdist:
@@ -308,8 +373,10 @@ jobs:
         repository:
           - path: apis/python/node
             name: dora-node-api
+            no_abi3_features: tracing,metrics,async
           - path: apis/python/cli
             name: dora-rs-cli
+            no_abi3_features: telemetry
     steps:
       - uses: actions/checkout@v7
       - name: Build sdist
@@ -355,10 +422,11 @@ jobs:
           # the distribution it publishes — hence the explicit `pypi` field.
           - path: apis/python/node
             name: dora-node-api
+            no_abi3_features: tracing,metrics,async
             pypi: dora-rs
           - path: apis/python/cli
             name: dora-rs-cli
-            pypi: dora-rs-cli
+            no_abi3_features: telemetry
     # Preserves the deployment-environment gate that release.yml's own
     # publish job used before it was folded into this workflow — whatever
     # protection rules are configured on `pypi` still apply.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,9 +164,16 @@ arrow-array = { version = "59" }
 arrow-json = { version = "59" }
 parquet = { version = "59" }
 # Kept in lockstep with `arrow-pyarrow` — see the `arrow` floor above.
+# `abi3-py311` is deliberately NOT listed here. Cargo features are additive and
+# every python crate inherits this dep, so stating abi3 at the workspace level
+# makes it impossible to turn off for a single build. It now lives as a
+# default-on `abi3` feature on the two crates maturin actually builds
+# (`dora-node-api-python`, `dora-cli-api-python`), which is the only place it
+# has to be enabled for the whole graph to get it. Default builds are therefore
+# byte-for-byte the same configuration as before; `--no-default-features`
+# yields a version-specific (non-abi3) build. See docs/api-rust.md.
 pyo3 = { version = "0.29", features = [
     "eyre",
-    "abi3-py311",
     "multiple-pymethods",
 ] }
 pythonize = "0.29"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **CPython 3.10 wheels** ([#1833](https://github.com/dora-rs/dora/pull/1833) follow-up). `dora-rs` and `dora-rs-cli` now ship version-specific `cp310` wheels alongside the existing `cp311-abi3` ones, across the same platform matrix, and `requires-python` moves `>=3.11` → `>=3.10`. Nothing changes for 3.11+: `abi3` is now a **default-on** cargo feature on `dora-node-api-python` / `dora-cli-api-python`, so a default build is configured exactly as before; the cp310 leg builds with it off. abi3 is precisely what excluded 3.10 — the buffer-protocol slots `send_output_raw` needs entered the *stable* C API only in 3.11 — so `abi3-py310` is not an alternative and the interpreter needs its own wheel. **One documented gap:** on a cp310 wheel `Node.send_output_raw()` raises `NotImplementedError` pointing at `send_output()`; the stub upstream already maintained under `#[cfg(not(Py_3_11))]` is what users hit. Everything else — `next()`, `send_output()`, event iteration, the ROS 2 bridge, the CLI — is unchanged. Motivation is platforms whose interpreter is not the user's to choose (NVIDIA JetPack / Ubuntu 22.04 ship 3.10 as system Python). Note CPython 3.10 is EOL in October 2026; see the [Python version policy](docs/api-rust.md#python-version-policy) for the caveat and expected removal.
+
 ## v1.0.1 (2026-09-03)
 
 Patch release. 1.0.0 could not be installed from crates.io.

--- a/apis/python/cli/Cargo.toml
+++ b/apis/python/cli/Cargo.toml
@@ -11,8 +11,17 @@ repository.workspace = true
 publish = false  # PyO3 cdylib, shipped via PyPI as `dora-rs-cli`, not crates.io
 
 [features]
-default = ["telemetry"]
+default = ["telemetry", "abi3"]
 telemetry = ["dora-runtime-python/telemetry"]
+# Build an abi3-py311 wheel: one `cp311-abi3` artifact loads on 3.11 and every
+# later CPython. ON by default, so a normal build is configured exactly as it
+# was before this feature existed. Turn it OFF (`--no-default-features`, plus
+# the other defaults re-stated) to get a version-specific build — that is how
+# the cp310 wheels in pip-release.yml are produced, and the only supported
+# reason to do so. abi3 is what excludes 3.10: `abi3-py310` is not an
+# alternative, because the buffer-protocol slots `send_output_raw` needs
+# entered the STABLE C API only in 3.11 (#1833).
+abi3 = ["pyo3/abi3-py311"]
 
 [dependencies]
 dora-cli = { workspace = true, features = ["python"] }

--- a/apis/python/cli/pyproject.toml
+++ b/apis/python/cli/pyproject.toml
@@ -7,7 +7,16 @@ name = "dora-rs-cli"
 dynamic = ["version"]
 scripts = { "dora" = "dora_cli:py_main" }
 license = { text = "MIT" }
-requires-python = ">=3.11"
+# >=3.10, not >=3.11: the release matrix now ships BOTH a `cp311-abi3` wheel
+# (3.11 and every later CPython) and version-specific `cp310` wheels. Wheel
+# tags, not this floor, decide which one an interpreter gets — 3.10 cannot
+# select the abi3 wheel and 3.11+ never selects a cp310 one.
+#
+# Consequence worth knowing: on a platform with no cp310 wheel, pip on 3.10
+# falls through to the sdist, whose default features include `abi3`, and the
+# build fails in pyo3's config rather than resolving cleanly. Build such a
+# platform with `--no-default-features` (see the `abi3` feature in Cargo.toml).
+requires-python = ">=3.10"
 dependencies = ['dora-rs >= 0.3.9', 'uv']
 
 [tool.maturin]

--- a/apis/python/node/Cargo.toml
+++ b/apis/python/node/Cargo.toml
@@ -13,7 +13,7 @@ publish = false  # PyO3 cdylib, shipped via PyPI as `dora-rs`, not crates.io
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["tracing", "metrics", "async"]
+default = ["tracing", "metrics", "async", "abi3"]
 # Opt-in tensor-pool transport. NOT covered by dora's 1.0 compatibility
 # guarantees — see libraries/extensions/tensor-pool/README.md. Off by default
 # so a standard wheel neither builds nor exposes it.
@@ -21,6 +21,15 @@ tensor-pool = ["dep:dora-tensor-pool-python"]
 tracing = ["dora-node-api/tracing"]
 metrics = ["dora-node-api/metrics"]
 async = ["pyo3/experimental-async"]
+# Build an abi3-py311 wheel: one `cp311-abi3` artifact loads on 3.11 and every
+# later CPython. ON by default, so a normal build is configured exactly as it
+# was before this feature existed. Turn it OFF (`--no-default-features`, plus
+# the other defaults re-stated) to get a version-specific build — that is how
+# the cp310 wheels in pip-release.yml are produced, and the only supported
+# reason to do so. abi3 is what excludes 3.10: `abi3-py310` is not an
+# alternative, because the buffer-protocol slots `send_output_raw` needs
+# entered the STABLE C API only in 3.11 (#1833).
+abi3 = ["pyo3/abi3-py311"]
 
 [dependencies]
 dora-node-api = { workspace = true  }

--- a/apis/python/node/pyproject.toml
+++ b/apis/python/node/pyproject.toml
@@ -6,8 +6,16 @@ build-backend = "maturin"
 name = "dora-rs"
 dynamic = ["version"]
 # Install pyarrow at the same time of dora-rs.
-# Python >= 3.11 because abi3-py311 is the Cargo.toml floor (#1833 / #1291).
-requires-python = ">=3.11"
+# >=3.10, not >=3.11: the release matrix now ships BOTH a `cp311-abi3` wheel
+# (3.11 and every later CPython) and version-specific `cp310` wheels. Wheel
+# tags, not this floor, decide which one an interpreter gets — 3.10 cannot
+# select the abi3 wheel and 3.11+ never selects a cp310 one.
+#
+# Consequence worth knowing: on a platform with no cp310 wheel, pip on 3.10
+# falls through to the sdist, whose default features include `abi3`, and the
+# build fails in pyo3's config rather than resolving cleanly. Build such a
+# platform with `--no-default-features` (see the `abi3` feature in Cargo.toml).
+requires-python = ">=3.10"
 license = { text = "MIT" }
 readme = "README.md"
 dependencies = ['pyarrow>=14.0.1', "pyyaml>=6.0", "numpy>=1.20"]

--- a/apis/python/operator/Cargo.toml
+++ b/apis/python/operator/Cargo.toml
@@ -20,7 +20,7 @@ publish = false  # PyO3 glue, not a crates.io API -- see below
 
 [dependencies]
 dora-node-api = { workspace = true , features = ["arrow-v59"] }
-pyo3 = { workspace = true, features = ["eyre", "abi3-py311"] }
+pyo3 = { workspace = true, features = ["eyre"] }
 eyre = { workspace = true }
 serde_yaml = { workspace = true }
 flume = { workspace = true }

--- a/binaries/runtime-python/Cargo.toml
+++ b/binaries/runtime-python/Cargo.toml
@@ -36,7 +36,7 @@ dora-operator-api-types = { workspace = true }
 dora-tracing = { workspace = true, optional = true }
 arrow = { workspace = true, features = ["pyarrow"] }
 # pyo3-abi3 flag allow simpler linking. See: https://pyo3.rs/v0.13.2/building_and_distribution.html
-pyo3 = { workspace = true, features = ["eyre", "abi3-py311"] }
+pyo3 = { workspace = true, features = ["eyre"] }
 pythonize = { workspace = true }
 eyre = { workspace = true }
 flume = { workspace = true }

--- a/docs/api-rust.md
+++ b/docs/api-rust.md
@@ -895,10 +895,13 @@ happens on every release, so the extra cost is close to zero.
 
 ### Python version policy
 
-Both wheels are built `abi3-py311`, so **dora 1.x supports CPython 3.11 and
+Both wheels are built `abi3-py311`, and the release matrix additionally builds
+version-specific `cp310` wheels, so **dora 1.x supports CPython 3.10 and
 later**. That floor is part of the 1.0 guarantee: raising it inside 1.x would
 uninstall dora for users on a Python it used to support, and no crates.io
-semver check would ever see it.
+semver check would ever see it. Lowering it, as the cp310 wheels do, is
+additive — it cannot uninstall anyone — but it is still a deliberate decision
+rather than a drive-by, and it carries the caveat below.
 
 abi3 makes the two directions asymmetric, in dora's favour:
 
@@ -906,15 +909,32 @@ abi3 makes the two directions asymmetric, in dora's favour:
   no rebuild, so a new interpreter release does not require a new dora release.
   This is also the direction a pyo3 bump would otherwise threaten, which is why
   the pyo3 version can stay exempt.
-- **Older CPython** — `requires-python = ">=3.11"` in both `pyproject.toml`s
-  makes pip refuse to install. This is the direction that breaks users, and it
-  moves only if dora deliberately moves it.
+- **Older CPython** — abi3 cannot reach below its floor, so 3.10 is served by
+  separate `cp310` wheels built with the `abi3` cargo feature off. They are
+  built from the same commit and are identical in behaviour save for one
+  documented gap (below). `requires-python = ">=3.10"` in both
+  `pyproject.toml`s; wheel tags, not that floor, decide which artifact an
+  interpreter selects.
 
-Two limits stated rather than left implied:
+Three limits stated rather than left implied:
+
+- **`send_output_raw` is unavailable on 3.10.** The zero-copy send path uses the
+  buffer-protocol slots `bf_getbuffer`/`bf_releasebuffer`, which entered the
+  *stable* C API only in 3.11 (#1833). On a cp310 wheel the method raises
+  `NotImplementedError` pointing at `send_output()` (one copy). This is the one
+  behavioural difference between the two wheel kinds, and it is why 3.10 gets
+  its own wheel rather than a lowered abi3 floor — `abi3-py310` cannot express
+  it.
 
 - **Free-threaded builds are not supported.** abi3 does not cover
   `Py_GIL_DISABLED`; those interpreters need their own wheels and the release
   matrix builds none, so there is no dora wheel for `python3.13t` or `3.14t`.
+- **CPython 3.10 reaches end of life in October 2026**, i.e. almost
+  immediately. These wheels exist for platforms whose interpreter is not the
+  user's to choose — NVIDIA JetPack / Ubuntu 22.04 images ship 3.10 as the
+  system Python, and "upgrade the interpreter first" is not advice that
+  survives contact with a deployed robot. Expect them to be dropped once those
+  images move.
 - **CPython 3.11 reaches end of life in October 2027**, inside 1.x's expected
   life. pyo3 drops old interpreters over time, so dora will eventually have to
   either raise the floor — breaking users — or hold pyo3 back. Better decided

--- a/docs/migration-from-0.x.md
+++ b/docs/migration-from-0.x.md
@@ -507,7 +507,7 @@ output_sender.send("count", n.into_arrow())?;
 
 ### CPython 3.11 is the floor (was 3.8)
 
-`requires-python` moved from `>=3.8` to `>=3.11` and the wheels are built `abi3-py311`. If you are on 3.8 to 3.10, upgrade the interpreter first; there is no 1.0 wheel for those versions and no compatibility shim. Free-threaded builds (`python3.13t`, `python3.14t`) are not supported. The [Python version policy](api-rust.md#python-version-policy) has the full guarantee.
+`requires-python` moved from `>=3.8` to `>=3.10` and the primary wheels are built `abi3-py311`. If you are on 3.8 or 3.9, upgrade the interpreter first; there is no 1.0 wheel for those versions and no compatibility shim. **3.10 is supported by separate `cp310` wheels**, with one gap: `send_output_raw` raises `NotImplementedError` there — use `send_output()`. Free-threaded builds (`python3.13t`, `python3.14t`) are not supported. The [Python version policy](api-rust.md#python-version-policy) has the full guarantee.
 
 ### `numpy` is now a hard dependency
 

--- a/libraries/extensions/ros2-bridge/python/Cargo.toml
+++ b/libraries/extensions/ros2-bridge/python/Cargo.toml
@@ -18,7 +18,7 @@ dora-ros2-bridge = { path = "..", default-features = false }
 dora-ros2-bridge-msg-gen = { path = "../msg-gen" }
 dora-ros2-bridge-arrow = { path = "../arrow" }
 dora-message = { workspace = true }
-pyo3 = { workspace = true, features = ["eyre", "abi3-py311", "serde"] }
+pyo3 = { workspace = true, features = ["eyre", "serde"] }
 eyre = "0.6"
 serde = "1.0.228"
 arrow = { workspace = true, features = ["pyarrow"] }


### PR DESCRIPTION
Adds version-specific `cp310` wheels for `dora-rs` and `dora-rs-cli` across the
same platform matrix as today's `cp311-abi3` wheels, and moves `requires-python`
from `>=3.11` to `>=3.10`.

## Why abi3 had to become a feature

`abi3-py311` was stated on the **workspace** `pyo3` dep. Every python crate
inherits that, and cargo features are additive, so from there it cannot be
turned off for a single build — no combination of `--no-default-features` at the
leaf helps.

It moves to a **default-on `abi3` feature** on the only two crates maturin
builds, `dora-node-api-python` and `dora-cli-api-python`. That is the single
point the whole graph takes abi3 from, so turning it off there turns it off
everywhere. The three intermediate crates that re-stated `abi3-py311`
(`operator`, `ros2-bridge/python`, `runtime-python`) drop it, or unification
would pull it straight back in.

**A default build is configured exactly as before.** 3.11+ wheels are unaffected.

`abi3-py310` is not an alternative: abi3 is *precisely* what excludes 3.10. The
buffer-protocol slots `bf_getbuffer`/`bf_releasebuffer` that `send_output_raw`
needs entered the **stable** C API only in 3.11 (#1833), though they have been
in the full C API far longer. 3.10 therefore needs a non-abi3, version-specific
wheel.

## The one behavioural difference

On a cp310 wheel, `Node.send_output_raw()` raises `NotImplementedError` pointing
at `send_output()`. That stub isn't new — the tree already maintains it under
`#[cfg(not(Py_3_11))]`. This is simply the first shipped build configuration
that reaches it. `next()`, `send_output()`, event iteration, the ROS 2 bridge
and the CLI are unchanged.

## Motivation

Platforms whose interpreter is not the user's to choose. NVIDIA JetPack /
Ubuntu 22.04 images ship 3.10 as the system Python, and "upgrade the
interpreter first" is not advice that survives contact with a deployed robot.
dora is a robotics framework; this is a fairly central class of deployment.

## The arguments against, stated rather than buried

- **CPython 3.10 is EOL in October 2026** — about a month away. The policy
  section now says so explicitly and says to expect these wheels to be dropped
  once JetPack-class images move. If you'd rather not carry them at all, that
  is a completely reasonable read and this PR should be closed.
- **CI cost roughly doubles**: the wheel matrix goes from 20 expansions to 40.
  Given how carefully `pip-release.yml` already budgets cache and runner time,
  that is a real objection. Trimming cp310 to `linux/x86_64` + `linux/aarch64`
  (the platforms that actually motivate it) would cut most of that, at the cost
  of a partial matrix — happy to make that change if preferred.
- Lowering the floor is *additive* and cannot uninstall anyone, so it does not
  collide with the 1.0 guarantee the policy section is protecting. But it is
  still a deliberate decision, which is why it is written into the policy rather
  than left implied.

## Docs

Two documents asserted the opposite and are corrected, not left to rot:
`docs/api-rust.md` (the Python version policy said 3.11 is the floor) and
`docs/migration-from-0.x.md` (said there is no 1.0 wheel for 3.10 and no
compatibility shim).

## Verification — please read before merging

**I could not build this.** No cargo and no 3.10/3.11 interpreter on the
authoring machine, and `pip-release.yml` does not trigger on `pull_request`, so
this PR's own CI will not produce a wheel either.

What *was* checked:
- `abi3-py311` is reachable from exactly two feature definitions; no other crate
  re-enables it (so `--no-default-features` genuinely disables it graph-wide).
- All modified TOML and the workflow YAML parse.
- The publish job's `${{ matrix.repository.name }}-*` artifact glob still matches
  the renamed `-abi3` / `-cp310` artifacts.
- Matrix expands as intended: 16 linux / 12 musllinux / 4 musleabi / 4 windows /
  4 macos, with `sdist` and `release` deliberately left off the new axis.

**Before merging, please dispatch `pip-release.yml` on this branch with
`publish: false`.** That builds all 40 expansions and publishes nothing, which
is the only real proof the cp310 legs compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXJfxA7eYf3rsfxK7k8kW3