### PR TITLE
fix(ros2-bridge): fail closed instead of panicking on a non-ASCII type hash

### DIFF
--- a/libraries/extensions/ros2-bridge/msg-gen/src/type_description.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/type_description.rs
@@ -160,7 +160,11 @@ impl TypeDescriptionResolver {
 
 fn parse_hash(value: &str) -> Option<[u8; 32]> {
     let hex = value.strip_prefix("RIHS01_")?;
-    if hex.len() != 64 {
+    // `hex.len()` counts bytes, and the loop below slices `hex` by byte
+    // offsets. Reject anything that isn't 64 ASCII bytes so a multi-byte
+    // UTF-8 character can never land a slice boundary inside a `char`
+    // (which would panic instead of failing closed to `InvalidHash`).
+    if hex.len() != 64 || !hex.is_ascii() {
         return None;
     }
     let mut result = [0; 32];
@@ -192,7 +196,7 @@ struct HashEntry {
 
 #[cfg(test)]
 mod tests {
-    use super::{InterfaceKind, TypeDescriptionError, TypeDescriptionResolver};
+    use super::{InterfaceKind, TypeDescriptionError, TypeDescriptionResolver, parse_hash};
     use std::{
         fs,
         time::{SystemTime, UNIX_EPOCH},
@@ -281,6 +285,23 @@ mod tests {
             TypeDescriptionError::TypeNameMismatch { .. }
         ));
         fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn parse_hash_rejects_non_ascii_without_panicking() {
+        // 64 bytes total, but a 2-byte `é` (0xC3 0xA9) at an odd byte offset
+        // means a `hex[i*2..i*2+2]` window straddles the char boundary.
+        // Before the `is_ascii()` guard this panicked instead of returning
+        // `None` (which the caller maps to `TypeDescriptionError::InvalidHash`).
+        let hash = format!("RIHS01_a{}", "é".to_string() + &"0".repeat(61));
+        assert_eq!(hash.len(), "RIHS01_".len() + 64);
+        assert!(parse_hash(&hash).is_none());
+    }
+
+    #[test]
+    fn parse_hash_accepts_valid_official_hash() {
+        let hash = parse_hash(&format!("RIHS01_{}", "ab".repeat(32))).unwrap();
+        assert_eq!(hash, [0xab; 32]);
     }
 
     fn scratch(label: &str) -> std::path::PathBuf {


### PR DESCRIPTION
## Issue

`parse_hash` in the msg-gen type-description resolver
(`libraries/extensions/ros2-bridge/msg-gen/src/type_description.rs`) validates
that the hex portion of an `RIHS01_` hash string is 64 **bytes** long, then
slices it in 2-byte windows:

```rust
if hex.len() != 64 {
    return None;
}
let mut result = [0; 32];
for (index, byte) in result.iter_mut().enumerate() {
    *byte = u8::from_str_radix(&hex[index * 2..index * 2 + 2], 16).ok()?;
}
```

`hex.len()` counts bytes, and `&hex[i*2..i*2+2]` slices a `&str` by byte
offsets. String slicing **panics** when an index falls in the interior of a
multi-byte UTF-8 character. So a type-description JSON — read at runtime from
`AMENT_PREFIX_PATH` via `TypeDescriptionResolver::resolve` — whose
`hash_string` is `RIHS01_` followed by 64 bytes that include a multi-byte
character such as `é` at an odd byte offset panics instead of failing closed.

This is inconsistent with the rest of the resolver, which turns every other
malformed-file case into a typed `TypeDescriptionError` (`Malformed`,
`TypeNameMismatch`, `InvalidHash`). `parse_hash` returning `None` already maps
to `InvalidHash`.

## Fix

Add an `is_ascii()` guard alongside the length check so a non-ASCII hash
returns `None` (→ `InvalidHash`) rather than panicking. Since the slice
windows only ever fall on ASCII byte boundaries afterward, the hot path is
unchanged.

## Validation

- New regression test `parse_hash_rejects_non_ascii_without_panicking`
  constructs a 64-byte hash containing `é` at an odd offset and asserts it
  returns `None` without panicking (this panicked before the fix).
- New positive test `parse_hash_accepts_valid_official_hash` confirms a valid
  `RIHS01_`-prefixed hash still parses.
- `cargo test -p dora-ros2-bridge-msg-gen`, `cargo clippy -p
  dora-ros2-bridge-msg-gen --all-targets -- -D warnings`, and `cargo fmt --
  --check` all pass.

---

⚠️ _This is a machine-generated pull request opened by Claude Code. Please review carefully before merging._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQYhwbEWdXbRrEdAGBHqJf

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQYhwbEWdXbRrEdAGBHqJf)_