### PR TITLE
refactor(ros2-bridge): drop two unreachable int64 tags in the basic-type parser

### DIFF
--- a/libraries/extensions/ros2-bridge/msg-gen/src/parser/types.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/parser/types.rs
@@ -76,8 +76,6 @@ fn basic_type(s: &str) -> IResult<&str, BasicType> {
             tag("int16"),
             tag("int32"),
             tag("int64"),
-            tag("int64"),
-            tag("int64"),
             tag("float32"),
             tag("float64"),
             tag("bool"),


### PR DESCRIPTION
## Issue

The `basic_type` parser in
`libraries/extensions/ros2-bridge/msg-gen/src/parser/types.rs` lists
`tag("int64")` three times consecutively inside its `alt(...)`:

```rust
tag("int8"),
tag("int16"),
tag("int32"),
tag("int64"),
tag("int64"),   // dead
tag("int64"),   // dead
tag("float32"),
```

`nom`'s `alt` tries alternatives left-to-right and returns on the first
match, so the 2nd and 3rd copies are unreachable dead code — a copy-paste
artifact. The 13 ROS2 IDL basic types (`int8/16/32/64`, `uint8/16/32/64`,
`float32/64`, `bool`, `char`, `byte`) — matching `BasicType::parse` in
`types/primitives.rs` — are each already covered exactly once.

## Fix

Remove the two redundant tags.

## Validation

- No behavior change: the removed tags were unreachable.
- `cargo test -p dora-ros2-bridge-msg-gen` — all 82 tests pass.
- `cargo clippy -p dora-ros2-bridge-msg-gen --all-targets -- -D warnings` and
  `cargo fmt -- --check` pass.

---

⚠️ _This is a machine-generated pull request opened by Claude Code. Please review carefully before merging._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQYhwbEWdXbRrEdAGBHqJf

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQYhwbEWdXbRrEdAGBHqJf)_