### PR TITLE
refactor(operator-api-cxx): dedupe the C++ event-dispatch arms

### DIFF
--- a/apis/c++/operator/src/lib.rs
+++ b/apis/c++/operator/src/lib.rs
@@ -108,71 +108,50 @@ impl DoraOperator for OperatorWrapper {
         event: &Event,
         output_sender: &mut DoraOutputSender,
     ) -> Result<DoraStatus, std::string::String> {
+        let operator = self
+            .operator
+            .as_mut()
+            .ok_or_else(|| "C++ new_operator() returned a null operator".to_string())?;
+        let mut output_sender = OutputSender(output_sender);
         match event {
             Event::Input {
                 id,
                 metadata: _,
                 data,
             } => {
-                let operator = self.operator.as_mut().unwrap();
-                let mut output_sender = OutputSender(output_sender);
                 let data: &[u8] = data
                     .try_into()
                     .map_err(|err| format!("expected byte array: {err}"))?;
-
-                let result = ffi::on_input(operator, id, data, &mut output_sender);
-                if result.error.is_empty() {
-                    Ok(match result.stop {
-                        false => DoraStatus::Continue,
-                        true => DoraStatus::Stop,
-                    })
-                } else {
-                    Err(result.error)
-                }
+                finish(ffi::on_input(operator, id, data, &mut output_sender))
             }
             Event::InputClosed { id } => {
-                let operator = self.operator.as_mut().unwrap();
-                let mut output_sender = OutputSender(output_sender);
-                let result = ffi::on_input_closed(operator, id, &mut output_sender);
-                if result.error.is_empty() {
-                    Ok(match result.stop {
-                        false => DoraStatus::Continue,
-                        true => DoraStatus::Stop,
-                    })
-                } else {
-                    Err(result.error)
-                }
+                finish(ffi::on_input_closed(operator, id, &mut output_sender))
             }
-            Event::Stop => {
-                let operator = self.operator.as_mut().unwrap();
-                let mut output_sender = OutputSender(output_sender);
-                let result = ffi::on_stop(operator, &mut output_sender);
-                if result.error.is_empty() {
-                    Ok(match result.stop {
-                        false => DoraStatus::Continue,
-                        true => DoraStatus::Stop,
-                    })
-                } else {
-                    Err(result.error)
-                }
-            }
-            Event::InputParseError { id, error } => {
-                let operator = self.operator.as_mut().unwrap();
-                let mut output_sender = OutputSender(output_sender);
-                let result = ffi::on_input_parse_error(operator, id, error, &mut output_sender);
-                if result.error.is_empty() {
-                    Ok(match result.stop {
-                        false => DoraStatus::Continue,
-                        true => DoraStatus::Stop,
-                    })
-                } else {
-                    Err(result.error)
-                }
-            }
+            Event::Stop => finish(ffi::on_stop(operator, &mut output_sender)),
+            Event::InputParseError { id, error } => finish(ffi::on_input_parse_error(
+                operator,
+                id,
+                error,
+                &mut output_sender,
+            )),
             // Other events (NodeFailed, Reload, Error, …) currently
             // have no operator-side callback. Operators that need to
             // react to them should subscribe via the node API instead.
             _ => Ok(DoraStatus::Continue),
         }
+    }
+}
+
+/// Translate a C++ callback result into a [`DoraStatus`], surfacing any
+/// non-empty error string to the operator runtime.
+fn finish(result: ffi::DoraOnInputResult) -> Result<DoraStatus, std::string::String> {
+    if result.error.is_empty() {
+        Ok(if result.stop {
+            DoraStatus::Stop
+        } else {
+            DoraStatus::Continue
+        })
+    } else {
+        Err(result.error)
     }
 }

--- a/apis/c++/operator/src/lib.rs
+++ b/apis/c++/operator/src/lib.rs
@@ -102,18 +102,25 @@ impl Default for OperatorWrapper {
     }
 }
 
+impl OperatorWrapper {
+    /// The C++ operator instance, or an error if `new_operator()` returned
+    /// null. Acquired lazily so events without an operator-side callback do
+    /// not depend on it.
+    fn operator(&mut self) -> Result<std::pin::Pin<&mut ffi::Operator>, std::string::String> {
+        self.operator
+            .as_mut()
+            .ok_or_else(|| "C++ new_operator() returned a null operator".to_string())
+    }
+}
+
 impl DoraOperator for OperatorWrapper {
     fn on_event(
         &mut self,
         event: &Event,
         output_sender: &mut DoraOutputSender,
     ) -> Result<DoraStatus, std::string::String> {
-        let operator = self
-            .operator
-            .as_mut()
-            .ok_or_else(|| "C++ new_operator() returned a null operator".to_string())?;
         let mut output_sender = OutputSender(output_sender);
-        match event {
+        let result = match event {
             Event::Input {
                 id,
                 metadata: _,
@@ -122,23 +129,22 @@ impl DoraOperator for OperatorWrapper {
                 let data: &[u8] = data
                     .try_into()
                     .map_err(|err| format!("expected byte array: {err}"))?;
-                finish(ffi::on_input(operator, id, data, &mut output_sender))
+                ffi::on_input(self.operator()?, id, data, &mut output_sender)
             }
             Event::InputClosed { id } => {
-                finish(ffi::on_input_closed(operator, id, &mut output_sender))
+                ffi::on_input_closed(self.operator()?, id, &mut output_sender)
             }
-            Event::Stop => finish(ffi::on_stop(operator, &mut output_sender)),
-            Event::InputParseError { id, error } => finish(ffi::on_input_parse_error(
-                operator,
-                id,
-                error,
-                &mut output_sender,
-            )),
-            // Other events (NodeFailed, Reload, Error, …) currently
-            // have no operator-side callback. Operators that need to
-            // react to them should subscribe via the node API instead.
-            _ => Ok(DoraStatus::Continue),
-        }
+            Event::Stop => ffi::on_stop(self.operator()?, &mut output_sender),
+            Event::InputParseError { id, error } => {
+                ffi::on_input_parse_error(self.operator()?, id, error, &mut output_sender)
+            }
+            // Other events (NodeFailed, Reload, Error, …) currently have no
+            // operator-side callback, so they return `Continue` without
+            // requiring the operator. Operators that need to react to them
+            // should subscribe via the node API instead.
+            _ => return Ok(DoraStatus::Continue),
+        };
+        finish(result)
     }
 }
 


### PR DESCRIPTION
## Issue

In `apis/c++/operator/src/lib.rs`, `OperatorWrapper::on_event` has four
handled match arms (`Input`, `InputClosed`, `Stop`, `InputParseError`) that
each repeat the identical boilerplate:

```rust
let operator = self.operator.as_mut().unwrap();
let mut output_sender = OutputSender(output_sender);
let result = ffi::on_...(...);
if result.error.is_empty() {
    Ok(match result.stop {
        false => DoraStatus::Continue,
        true => DoraStatus::Stop,
    })
} else {
    Err(result.error)
}
```

Only the `ffi::on_*` call differs between arms.

## Fix

- Extract the result→`DoraStatus` mapping into a single `finish()` helper, so
  each arm names only its own `ffi::on_*` call.
- Acquire the operator handle lazily through a small `operator()` helper that
  each callback arm calls (`self.operator()?`), rather than hoisting it above
  the `match`. This matters for the catch-all: `NodeFailed` / `Reload` /
  `Error` have no operator-side callback and must return `Continue` **without**
  requiring the operator, exactly as before.

### Behavior change (intentional, scoped to the callback arms)

The four callback arms replace `self.operator.as_mut().unwrap()` — which
**panicked** if a C++ `new_operator()` factory returned `nullptr` — with a
descriptive surfaced error (`Err("C++ new_operator() returned a null
operator")`). The no-callback events are unaffected: they still return
`Ok(DoraStatus::Continue)` on a null operator, because the operator is never
acquired on that path.

## Validation

This crate is `#[cfg(not(test))]` (it compiles to nothing under `cfg(test)`),
so there are no unit tests to run; the available verification is compilation
plus the C++ operator examples:

- `cargo clippy -p dora-operator-api-cxx --all-targets -- -D warnings` builds
  clean — this exercises the `#[cxx::bridge]` codegen, and the bridge block
  itself is untouched, so there is no generated-header or ABI change.
- `cargo fmt -- --check` passes.

---

⚠️ _This is a machine-generated pull request opened by Claude Code. Please review carefully before merging._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQYhwbEWdXbRrEdAGBHqJf

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQYhwbEWdXbRrEdAGBHqJf)_