### PR TITLE
fix(cli): report the actual path in Python template directory errors

### DIFF
--- a/binaries/cli/src/template/python/mod.rs
+++ b/binaries/cli/src/template/python/mod.rs
@@ -97,7 +97,7 @@ fn create_custom_node(
         .with_context(|| format!("failed to write `{}`", node_path.display()))?;
 
     // tests/tests___node_name__.py
-    let node_path = root.join("tests").join(format!(
+    let node_path = tests_path.join(format!(
         "test_{}.py",
         name.replace(" ", "_").replace("-", "_")
     ));

--- a/binaries/cli/src/template/python/mod.rs
+++ b/binaries/cli/src/template/python/mod.rs
@@ -55,11 +55,20 @@ fn create_custom_node(
     fs::create_dir(&root)
         .with_context(|| format!("failed to create root directory `{}`", root.display()))?;
 
-    fs::create_dir(&module_path)
-        .with_context(|| format!("failed to create module directory `{}`", root.display()))?;
+    fs::create_dir(&module_path).with_context(|| {
+        format!(
+            "failed to create module directory `{}`",
+            module_path.display()
+        )
+    })?;
 
-    fs::create_dir(root.join("tests"))
-        .with_context(|| format!("failed to create tests directory `{}`", root.display()))?;
+    let tests_path = root.join("tests");
+    fs::create_dir(&tests_path).with_context(|| {
+        format!(
+            "failed to create tests directory `{}`",
+            tests_path.display()
+        )
+    })?;
 
     // PYPROJECT.toml
     let node_path = root.join("pyproject.toml");
@@ -127,7 +136,7 @@ fn create_dataflow(
     // create directories
     let root = path.as_deref().unwrap_or_else(|| Path::new(&name));
     fs::create_dir(root)
-        .with_context(|| format!("failed to create module directory `{}`", root.display()))?;
+        .with_context(|| format!("failed to create root directory `{}`", root.display()))?;
 
     let dataflow_yml = DATAFLOW_YML.replace("___name___", &name);
     let dataflow_yml_path = root.join("dataflow.yml");


### PR DESCRIPTION
## Issue

In `binaries/cli/src/template/python/mod.rs`, `create_custom_node` creates the
module directory (`root/<module>`) and the `tests` directory, but both
`with_context` error closures interpolated `root.display()` instead of the
directory actually being created:

```rust
fs::create_dir(&module_path)
    .with_context(|| format!("failed to create module directory `{}`", root.display()))?;
fs::create_dir(root.join("tests"))
    .with_context(|| format!("failed to create tests directory `{}`", root.display()))?;
```

On a failure — e.g. a pre-existing module directory, or a permission error on
the nested path — the diagnostic points at the wrong directory (`root`)
instead of the one that failed.

Separately, `create_dataflow` labels its `root`-directory creation as a
"module directory" (right path, misleading label).

## Fix

- Interpolate `module_path.display()` and the `tests` path respectively.
- Change `create_dataflow`'s label from "module directory" to "root
  directory", matching `create_custom_node`.

## Validation

- Diagnostic-string-only change; no behavioral effect on the created files.
- `cargo clippy -p dora-cli --all-targets -- -D warnings` (compiles all test
  targets) and `cargo fmt -- --check` pass.

---

⚠️ _This is a machine-generated pull request opened by Claude Code. Please review carefully before merging._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQYhwbEWdXbRrEdAGBHqJf

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQYhwbEWdXbRrEdAGBHqJf)_