### PR TITLE
fix(cli): don't let a stray dora-config.yml brick dora up/down

### DIFF
--- a/binaries/cli/src/command/up.rs
+++ b/binaries/cli/src/command/up.rs
@@ -707,8 +707,14 @@ pub(crate) fn down(
 }
 
 fn parse_dora_config(config_path: Option<&Path>) -> Result<UpConfig, eyre::ErrReport> {
-    let path = config_path.or_else(|| Some(Path::new("dora-config.yml")).filter(|p| p.exists()));
-    let config = match path {
+    // Only read a config file when one is passed explicitly via `--config`.
+    // We deliberately do *not* auto-detect a `dora-config.yml` in the current
+    // directory: `UpConfig` has no fields yet and uses `deny_unknown_fields`,
+    // so any non-empty `dora-config.yml` that happened to sit in the working
+    // directory (e.g. left by an unrelated tool) would fail to parse and make
+    // `dora up` / `dora down` unusable there. An explicit path still surfaces a
+    // parse error, which is what the user asked for by passing `--config`.
+    let config = match config_path {
         Some(path) => {
             let raw = fs::read_to_string(path)
                 .with_context(|| format!("failed to read `{}`", path.display()))?;


### PR DESCRIPTION
## Issue

`parse_dora_config` in `binaries/cli/src/command/up.rs` auto-detects a
`dora-config.yml` in the current directory whenever `--config` is not passed:

```rust
let path = config_path.or_else(|| Some(Path::new("dora-config.yml")).filter(|p| p.exists()));
```

But `UpConfig` has no fields and is declared `#[serde(deny_unknown_fields)]`:

```rust
#[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
#[serde(deny_unknown_fields)]
struct UpConfig {}
```

So **any** non-empty `dora-config.yml` that happens to sit in the working
directory — e.g. one left by an unrelated tool — fails to deserialize
("unknown field"), and both `dora up` and `dora down` hard-fail there with a
confusing `failed to parse dora-config.yml` error.

`dora-config.yml` is not a documented dora convention (the name appears
nowhere else in the tree), so the CWD auto-detection can currently only ever
no-op (empty file) or error — it never loads anything useful.

## Fix

Read a config file only when the user passes one explicitly via `--config`
(a hidden, experimental flag). An explicit path still surfaces a parse error,
which is the behavior a user asks for by passing `--config`. When the schema
grows real fields, deliberate CWD discovery can be reintroduced with a defined
format.

Because the schema accepts no fields today, this cannot break any working
configuration — it only removes the failure mode.

_Alternative considered:_ dropping `#[serde(deny_unknown_fields)]` so a
populated `dora-config.yml` is tolerated instead of ignored. Gating on
`--config` was chosen as the least-magic behavior for a hidden flag, but happy
to switch if maintainers prefer to keep CWD discovery.

## Validation

- `cargo clippy -p dora-cli --all-targets -- -D warnings` and
  `cargo fmt -- --check` pass.

---

⚠️ _This is a machine-generated pull request opened by Claude Code. Please review carefully before merging._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQYhwbEWdXbRrEdAGBHqJf

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQYhwbEWdXbRrEdAGBHqJf)_