### PR TITLE
refactor(core): move the operator subtree out in resolve_aliases_and_set_defaults instead of cloning

### DIFF
--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -206,15 +206,22 @@ pub fn resolve_aliases_and_set_defaults_in_topology(
                 CoreNodeKind::Custom(custom)
             }
             classify::NodeClass::Runtime => {
-                let runtime = node.operators.as_ref().ok_or_eyre("no operators")?;
-                CoreNodeKind::Runtime(runtime.clone())
+                // `node` is already an owned copy (see `desc.nodes.clone()`
+                // above) and `ResolvedNode::from_node` never reads
+                // `operators`, so move the operator subtree out instead of
+                // deep-cloning it a second time.
+                let runtime = node.operators.take().ok_or_eyre("no operators")?;
+                CoreNodeKind::Runtime(runtime)
             }
             classify::NodeClass::Operator => {
-                let op = node.operator.as_ref().ok_or_eyre("no operator")?;
+                // Move the operator out of the owned `node` rather than
+                // cloning its (potentially large) config; `from_node` does
+                // not read `operator`.
+                let op = node.operator.take().ok_or_eyre("no operator")?;
                 CoreNodeKind::Runtime(RuntimeNode {
                     operators: vec![OperatorDefinition {
-                        id: op.id.clone().unwrap_or_else(|| default_op_id.clone()),
-                        config: op.config.clone(),
+                        id: op.id.unwrap_or_else(|| default_op_id.clone()),
+                        config: op.config,
                     }],
                 })
             }
@@ -734,6 +741,59 @@ nodes:
                 assert_eq!(m.output, DataId::from("result".to_string()));
             }
             other => panic!("expected user mapping, got {other:?}"),
+        }
+    }
+
+    /// The operator subtree must survive resolution. The `Runtime`/`Operator`
+    /// arms move `node.operators` / `node.operator` out with `take()`, which
+    /// is only sound because `ResolvedNode::from_node` never reads those
+    /// fields. Pin that invariant: a regression that consumed the subtree
+    /// before building the `CoreNodeKind`, or a new `ResolvedNode` field
+    /// sourced from `node.operator` after the take (which would compile and
+    /// silently read `None`), surfaces here as a missing operator.
+    #[test]
+    fn resolve_preserves_operator_subtree() {
+        let desc: Descriptor = serde_yaml::from_str(
+            "\
+nodes:
+  - id: runtime_node
+    operators:
+      - id: op_a
+        python: a.py
+        outputs:
+          - out_a
+  - id: operator_node
+    operator:
+      python: b.py
+      outputs:
+        - out_b
+",
+        )
+        .expect("parse");
+
+        let resolved = desc.resolve_aliases_and_set_defaults().expect("resolve");
+
+        // A `runtime:` (operators) node keeps every declared operator.
+        match &resolved[&NodeId::from("runtime_node".to_string())].kind {
+            CoreNodeKind::Runtime(rt) => {
+                let ids: Vec<_> = rt.operators.iter().map(|o| o.id.to_string()).collect();
+                assert_eq!(ids, ["op_a"], "runtime operators must survive resolution");
+            }
+            other => panic!("expected Runtime kind, got {other:?}"),
+        }
+
+        // A single-`operator:` node resolves to a one-operator runtime,
+        // defaulting the operator id to `op`.
+        match &resolved[&NodeId::from("operator_node".to_string())].kind {
+            CoreNodeKind::Runtime(rt) => {
+                assert_eq!(
+                    rt.operators.len(),
+                    1,
+                    "the operator must survive resolution"
+                );
+                assert_eq!(rt.operators[0].id.to_string(), SINGLE_OPERATOR_DEFAULT_ID);
+            }
+            other => panic!("expected Runtime kind, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
## Summary

> ⚙️ **This is a machine-generated PR authored by Claude Code.** Please review carefully before merging.

`resolve_aliases_and_set_defaults` iterates over `desc.nodes.clone()`, so each `node` in the loop is already an owned deep copy. The `Standard` and `Ros2Bridge` arms correctly *drain* the owned node via `CustomNode::from_node(&mut node, …)`. But the `Runtime` and `Operator` arms cloned the operator subtree a **second** time:

```rust
classify::NodeClass::Runtime => {
    let runtime = node.operators.as_ref().ok_or_eyre("no operators")?;
    CoreNodeKind::Runtime(runtime.clone())            // deep-clone #2
}
classify::NodeClass::Operator => {
    let op = node.operator.as_ref().ok_or_eyre("no operator")?;
    CoreNodeKind::Runtime(RuntimeNode {
        operators: vec[OperatorDefinition {
            id: op.id.clone().unwrap_or_else(|| default_op_id.clone()),
            config: op.config.clone(),                // deep-clone #2
        }],
    })
}
```

`ResolvedNode::from_node(node, kind)` runs immediately after and consumes `node`, but it reads only `id`, `name`, `description`, `env`, `cpu_affinity`, and `deploy` — never `operators`/`operator`. So the second clone of the operator config (full input/output maps, types, framing) is pure waste.

## Fix

Move the operator subtree out of the owned `node` with `Option::take()` instead of `as_ref().clone()`, mirroring how the custom-node arms drain the node. This removes the redundant deep copy on the descriptor-resolution path, which is reached from validation entry points (`check_wiring`, `visualize_as_mermaid_with_boundaries`, …) that may run repeatedly.

## Validation

- Behavior is unchanged (`from_node` never reads the moved fields; confirmed against `descriptor.rs`).
- `cargo test -p dora-core` — 326 + 3 + 2 + 5 (doctests) passed.
- `cargo clippy -p dora-core --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xvohVeqSA6L3bMDmYJt9i

---
_Generated by [Claude Code](https://claude.ai/code/session_014xvohVeqSA6L3bMDmYJt9i)_