### PR TITLE
docs(log-utils): correct parse_log_from_arrow's element-count contract

### DIFF
--- a/libraries/log-utils/src/lib.rs
+++ b/libraries/log-utils/src/lib.rs
@@ -32,9 +32,23 @@ pub fn parse_log(json: &str) -> Result<LogMessage> {
 
 /// Parse a [`LogMessage`] from Arrow input data.
 ///
-/// Convenience wrapper for node event handlers. The daemon sends one log
-/// entry per Arrow message, so this extracts the first string element and
-/// parses it as JSON. Additional elements (if any) are ignored.
+/// Convenience wrapper for node event handlers: the daemon sends one log
+/// entry per Arrow message as a single-element string array, and this
+/// extracts that element and parses it as JSON via [`parse_log`].
+///
+/// The input must be a string array of **exactly one** non-null element —
+/// the underlying `&str` conversion rejects empty, multi-element, and
+/// null arrays — so a batch of several strings is an error, not a case
+/// where the extra elements are silently ignored.
+///
+/// ```
+/// use dora_arrow_convert::IntoArrow;
+/// use dora_log_utils::parse_log_from_arrow;
+///
+/// // More than one element is rejected: exactly one is required.
+/// let batched = vec!["{}".to_string(), "{}".to_string()].into_arrow();
+/// assert!(parse_log_from_arrow(&batched).is_err());
+/// ```
 pub fn parse_log_from_arrow(data: &dora_arrow_convert::DoraArray) -> Result<LogMessage> {
     let json: &str = data.try_into().context("expected string arrow data")?;
     parse_log(json)


### PR DESCRIPTION
## Summary

> ⚙️ **This is a machine-generated PR authored by Claude Code.** Please review carefully before merging.

`parse_log_from_arrow`'s doc claimed:

> this extracts the first string element and parses it as JSON. Additional elements (if any) are ignored.

That is the opposite of the actual behavior. The function delegates to `TryFrom<&DoraArray> for &str`, which requires exactly one non-null element:

```rust
if array.is_empty()      { eyre::bail!("empty array"); }
if array.len() != 1      { eyre::bail!("expected length 1"); }
if array.null_count() != 0 { eyre::bail!("array has nulls"); }
```

So a multi-element string array is **rejected** (`"expected length 1"`), not truncated to its first element. The doc would mislead a caller into thinking batched log arrays are tolerated.

## Fix

Documentation only. Rewrite the doc comment to state the real contract (exactly one non-null string element) and add a compile-checked doctest asserting that a two-element array is rejected.

## Validation

- `cargo test -p dora-log-utils` — 4 unit tests + 1 doctest passed.
- `cargo clippy -p dora-log-utils --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xvohVeqSA6L3bMDmYJt9i

---
_Generated by [Claude Code](https://claude.ai/code/session_014xvohVeqSA6L3bMDmYJt9i)_