### PR TITLE
fix(cli): validate dora new name against CMake/TOML-breaking characters

### DIFF
--- a/binaries/cli/src/template/c/mod.rs
+++ b/binaries/cli/src/template/c/mod.rs
@@ -1,5 +1,5 @@
 use dora_node_api_c::HEADER_NODE_API;
-use eyre::{Context, bail};
+use eyre::Context;
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -31,12 +31,7 @@ fn create_dataflow(
 ) -> Result<(), eyre::ErrReport> {
     const DATAFLOW_YML: &str = include_str!("dataflow-template.yml");
 
-    if name.contains('/') {
-        bail!("dataflow name must not contain `/` separators");
-    }
-    if !name.is_ascii() {
-        bail!("dataflow name must be ASCII");
-    }
+    super::validate_name(&name, false)?;
 
     // create directories
     let root = path.as_deref().unwrap_or_else(|| Path::new(&name));
@@ -99,12 +94,7 @@ fn create_custom_node(
     template_scripts: &str,
     use_path_deps: bool,
 ) -> Result<(), eyre::ErrReport> {
-    if name.contains('/') {
-        bail!("node name must not contain `/` separators");
-    }
-    if !name.is_ascii() {
-        bail!("node name must be ASCII");
-    }
+    super::validate_name(&name, false)?;
 
     // create directories
     let root = path.as_deref().unwrap_or_else(|| Path::new(&name));

--- a/binaries/cli/src/template/cxx/mod.rs
+++ b/binaries/cli/src/template/cxx/mod.rs
@@ -1,4 +1,4 @@
-use eyre::{Context, bail};
+use eyre::Context;
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -30,12 +30,7 @@ fn create_dataflow(
 ) -> Result<(), eyre::ErrReport> {
     const DATAFLOW_YML: &str = include_str!("dataflow-template.yml");
 
-    if name.contains('/') {
-        bail!("dataflow name must not contain `/` separators");
-    }
-    if !name.is_ascii() {
-        bail!("dataflow name must be ASCII");
-    }
+    super::validate_name(&name, false)?;
 
     // create directories
     let root = path.as_deref().unwrap_or_else(|| Path::new(&name));
@@ -98,12 +93,7 @@ fn create_custom_node(
     template_scripts: &str,
     use_path_deps: bool,
 ) -> Result<(), eyre::ErrReport> {
-    if name.contains('/') {
-        bail!("node name must not contain `/` separators");
-    }
-    if !name.is_ascii() {
-        bail!("node name must be ASCII");
-    }
+    super::validate_name(&name, false)?;
 
     // create directories
     let root = path.as_deref().unwrap_or_else(|| Path::new(&name));

--- a/binaries/cli/src/template/mod.rs
+++ b/binaries/cli/src/template/mod.rs
@@ -1,10 +1,39 @@
-use eyre::ContextCompat;
+use eyre::{ContextCompat, bail};
 use std::path::Path;
 
 mod c;
 mod cxx;
 mod python;
 mod rust;
+
+/// Validates a `dora new` project/node name.
+///
+/// The name is substituted, unescaped, into generated `CMakeLists.txt`
+/// (`project(___name___ ...)`, `add_executable(___name___ ...)`) and
+/// `Cargo.toml`/`pyproject.toml` (`name = "___name___"`), and used as a
+/// filesystem path component. An allow-list of ASCII letters, digits, `-`,
+/// and `_` keeps it safe in all three: none of those characters carry
+/// syntactic meaning in CMake's unquoted argument list, a quoted TOML
+/// string, or a path.
+///
+/// `allow_spaces` widens the set for the Python backend only, which
+/// normalizes spaces to `-`/`_` before the name touches a file and never
+/// emits CMake -- so a bare space can't break an unquoted CMake argument
+/// there the way it would for C/C++/Rust.
+pub(crate) fn validate_name(name: &str, allow_spaces: bool) -> eyre::Result<()> {
+    if name.is_empty() {
+        bail!("name must not be empty");
+    }
+    if let Some(c) = name.chars().find(|&c| {
+        !c.is_ascii_alphanumeric() && c != '_' && c != '-' && !(allow_spaces && c == ' ')
+    }) {
+        bail!(
+            "name contains invalid character '{c}' -- only ASCII letters, digits, `-`, `_`{} are allowed",
+            if allow_spaces { ", and spaces" } else { "" }
+        );
+    }
+    Ok(())
+}
 
 /// Path to the dora workspace root (two levels above the CLI crate
 /// manifest), used by the C/C++ templates to reference dora via path
@@ -49,5 +78,37 @@ mod tests {
         let normalized = normalize_for_cmake(r"C:\Users\example\dora");
         assert_eq!(normalized, "C:/Users/example/dora");
         assert!(!normalized.contains('\\'));
+    }
+
+    #[test]
+    fn validate_name_accepts_alnum_dash_underscore() {
+        assert!(validate_name("my-node_1", false).is_ok());
+        assert!(validate_name("MyNode123", false).is_ok());
+    }
+
+    #[test]
+    fn validate_name_rejects_empty() {
+        assert!(validate_name("", false).is_err());
+        assert!(validate_name("", true).is_err());
+    }
+
+    #[test]
+    fn validate_name_rejects_cmake_breaking_space_unless_allowed() {
+        assert!(validate_name("my node", false).is_err());
+        assert!(validate_name("my node", true).is_ok());
+    }
+
+    #[test]
+    fn validate_name_rejects_toml_breaking_characters_even_with_spaces_allowed() {
+        for name in ["foo\"bar", "foo\\bar", "foo/bar", "foo#bar", "café"] {
+            assert!(
+                validate_name(name, false).is_err(),
+                "expected {name:?} to be rejected"
+            );
+            assert!(
+                validate_name(name, true).is_err(),
+                "expected {name:?} to be rejected even with spaces allowed"
+            );
+        }
     }
 }

--- a/binaries/cli/src/template/python/mod.rs
+++ b/binaries/cli/src/template/python/mod.rs
@@ -1,4 +1,4 @@
-use eyre::{Context, bail};
+use eyre::Context;
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -39,15 +39,9 @@ fn create_custom_node(
     path: Option<PathBuf>,
     main: &str,
 ) -> Result<(), eyre::ErrReport> {
-    // Reject names that would turn into path separators or non-ASCII module
-    // directories, mirroring the validation in `create_dataflow`. Spaces are
-    // fine — they are normalized to `-`/`_` below.
-    if name.contains('/') {
-        bail!("node name must not contain `/` separators");
-    }
-    if !name.is_ascii() {
-        bail!("node name must be ASCII");
-    }
+    // Spaces are fine here -- they are normalized to `-`/`_` below before the
+    // name is used as a path component, and this backend never emits CMake.
+    super::validate_name(&name, true)?;
 
     // create directories
     let root = path.unwrap_or_else(|| PathBuf::from(name.replace(" ", "-")));
@@ -117,12 +111,7 @@ fn create_dataflow(
     const DATAFLOW_YML: &str = include_str!("dataflow-template.yml");
     const WORKSPACE_README: &str = include_str!("README.md");
 
-    if name.contains('/') {
-        bail!("dataflow name must not contain `/` separators");
-    }
-    if !name.is_ascii() {
-        bail!("dataflow name must be ASCII");
-    }
+    super::validate_name(&name, true)?;
 
     // create directories
     let root = path.as_deref().unwrap_or_else(|| Path::new(&name));

--- a/binaries/cli/src/template/rust/mod.rs
+++ b/binaries/cli/src/template/rust/mod.rs
@@ -1,4 +1,4 @@
-use eyre::{Context, bail};
+use eyre::Context;
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -31,12 +31,7 @@ fn create_dataflow(
     const DATAFLOW_YML: &str = include_str!("dataflow-template.yml");
     const WORKSPACE_CARGO_TOML: &str = include_str!("Cargo-template.toml");
 
-    if name.contains('/') {
-        bail!("dataflow name must not contain `/` separators");
-    }
-    if !name.is_ascii() {
-        bail!("dataflow name must be ASCII");
-    }
+    super::validate_name(&name, false)?;
 
     // create directories
     let root = path.as_deref().unwrap_or_else(|| Path::new(&name));
@@ -87,12 +82,7 @@ fn create_custom_node(
 ) -> Result<(), eyre::ErrReport> {
     const CARGO_TOML: &str = include_str!("node/Cargo-template.toml");
 
-    if name.contains('/') {
-        bail!("node name must not contain `/` separators");
-    }
-    if !name.is_ascii() {
-        bail!("node name must be ASCII");
-    }
+    super::validate_name(&name, false)?;
 
     // create directories
     let root = path.as_deref().unwrap_or_else(|| Path::new(&name));


### PR DESCRIPTION
Fixes #3440.

Validated locally with `cargo build`, `cargo test -p dora-cli --lib template`, `cargo fmt --all -- --check`, and `cargo clippy -p dora-cli -- -D warnings` — all clean.