### PR TITLE
docs(message): fix misattached doc block on serialized_size / encode_presized

### DIFF
--- a/libraries/message/src/lib.rs
+++ b/libraries/message/src/lib.rs
@@ -26,13 +26,6 @@ pub fn encode<T: serde::Serialize>(value: &T) -> postcard::Result<Vec<u8>> {
     encode_presized(value, 0)
 }
 
-/// [`encode`], for a message carrying `bulk_bytes` bytes of bulk payload.
-///
-/// The encoder writes into a `Vec` that would otherwise start empty and
-/// reallocate as it grows — 10–80% of the encode cost on dora's messages, worst
-/// on the small control messages that dominate the daemon↔node TCP path. Pass
-/// `encode_size_hint()`, which the message types that carry a payload provide;
-/// the envelope slack is added here so that policy lives in one place.
 /// Exact length `value` takes in the binary wire format, computed without
 /// producing the encoding (bulk payloads are counted, not copied). Lets a
 /// sender size a frame before committing to it.
@@ -40,6 +33,13 @@ pub fn serialized_size<T: serde::Serialize>(value: &T) -> postcard::Result<usize
     postcard::experimental::serialized_size(value)
 }
 
+/// [`encode`], for a message carrying `bulk_bytes` bytes of bulk payload.
+///
+/// The encoder writes into a `Vec` that would otherwise start empty and
+/// reallocate as it grows — 10–80% of the encode cost on dora's messages, worst
+/// on the small control messages that dominate the daemon↔node TCP path. Pass
+/// `encode_size_hint()`, which the message types that carry a payload provide;
+/// the envelope slack is added here so that policy lives in one place.
 pub fn encode_presized<T: serde::Serialize>(
     value: &T,
     bulk_bytes: usize,


### PR DESCRIPTION
## Issue

In `libraries/message/src/lib.rs`, the doc comment sitting above `serialized_size` actually describes `encode_presized`, not `serialized_size`:

```rust
/// [`encode`], for a message carrying `bulk_bytes` bytes of bulk payload.
///
/// The encoder writes into a `Vec` that would otherwise start empty and
/// reallocate as it grows — 10–80% of the encode cost on dora's messages, worst
/// on the small control messages that dominate the daemon↔node TCP path. Pass
/// `encode_size_hint()`, which the message types that carry a payload provide;
/// the envelope slack is added here so that policy lives in one place.
/// Exact length `value` takes in the binary wire format, computed without
/// producing the encoding (bulk payloads are counted, not copied). Lets a
/// sender size a frame before committing to it.
pub fn serialized_size<T: serde::Serialize>(value: &T) -> postcard::Result<usize> { ... }

pub fn encode_presized<T: serde::Serialize>(value: &T, bulk_bytes: usize) -> ... { ... }
```

`serialized_size` takes no `bulk_bytes`, allocates nothing, and only measures the encoded length — so the first paragraph (bulk payload, buffer pre-sizing, `encode_size_hint()`, "the envelope slack is added here") cannot be about it. Only the trailing two sentences describe `serialized_size`. Meanwhile `encode_presized` — which `encode`'s own doc calls out as one of "the only encode entry points" — had **no** doc comment. The block was written for `encode_presized` and landed one item too high.

## Fix

Split the block:
- `serialized_size` keeps only the length-measurement sentences.
- `encode_presized` gets the buffer-pre-sizing paragraph that actually describes it.

## Validation

- `cargo doc -p dora-message --no-deps` — succeeds; the intra-doc links (`` [`encode`] ``, `` [`encode_presized`] ``) resolve.
- `cargo build -p dora-message` — succeeds.
- Documentation-only change; no code or behavior change.

---

> [!NOTE]
> This is a machine-generated PR produced by an automated Claude Code code-review run. A maintainer should review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJXugi4Zky3SV9Q2qmFGnr

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJXugi4Zky3SV9Q2qmFGnr)_