### PR TITLE
perf(message): size ParamUpdate/NodeFailed payloads in NodeEvent::encode_size_hint

### DIFF
--- a/libraries/message/src/daemon_to_node.rs
+++ b/libraries/message/src/daemon_to_node.rs
@@ -232,11 +232,53 @@ impl NodeEvent {
             | NodeEvent::InputRecovered { .. }
             | NodeEvent::NodeRestarted { .. }
             | NodeEvent::AllInputsClosed
-            | NodeEvent::ParamUpdate { .. }
-            | NodeEvent::ParamDeleted { .. }
-            | NodeEvent::NodeFailed { .. } => 0,
+            | NodeEvent::ParamDeleted { .. } => 0,
+            // Payload-carrying variants: count the variable-length field so the
+            // pre-sized buffer does not realloc on encode (matches the sibling
+            // `DaemonRequest::encode_size_hint`, which counts its own payloads).
+            NodeEvent::ParamUpdate { value_json, .. } => value_json.len(),
+            NodeEvent::NodeFailed { error, .. } => error.len(),
             NodeEvent::ExtensionDropped { namespace, key } => namespace.len() + key.len(),
         };
         payload.saturating_add(PER_EVENT_ENVELOPE)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_size_hint_counts_param_update_payload() {
+        let value_json = vec![0u8; 10_000];
+        let event = NodeEvent::ParamUpdate {
+            key: "some_param".to_string(),
+            value_json: value_json.clone(),
+        };
+        // The hint feeds `encode_presized`, so it must cover the payload or the
+        // pre-sized buffer reallocates while encoding — the exact cost the hint
+        // exists to avoid. Before the fix, ParamUpdate reported a flat envelope.
+        assert!(
+            event.encode_size_hint() >= value_json.len(),
+            "ParamUpdate hint ({}) must include its {}-byte value_json",
+            event.encode_size_hint(),
+            value_json.len()
+        );
+    }
+
+    #[test]
+    fn encode_size_hint_counts_node_failed_error() {
+        let error = "e".repeat(4096);
+        let event = NodeEvent::NodeFailed {
+            affected_input_ids: Vec::new(),
+            error: error.clone(),
+            source_node_id: NodeId::from("upstream".to_string()),
+        };
+        assert!(
+            event.encode_size_hint() >= error.len(),
+            "NodeFailed hint ({}) must include its {}-byte error string",
+            event.encode_size_hint(),
+            error.len()
+        );
     }
 }


### PR DESCRIPTION
## Issue

`NodeEvent::encode_size_hint` (`libraries/message/src/daemon_to_node.rs`) feeds `encode_presized`, which pre-sizes the encode buffer so the daemon→node TCP path doesn't reallocate mid-encode. Two payload-carrying variants were bucketed into the `=> 0` arm:

```rust
NodeEvent::ParamUpdate { .. }   // value_json: Vec<u8> — the dora param set blob
| NodeEvent::NodeFailed { .. }  // error: String — variable-length message
=> 0,
NodeEvent::ExtensionDropped { namespace, key } => namespace.len() + key.len(),
```

So a `ParamUpdate` carrying a large `value_json` reported only the flat 128-byte envelope; the buffer was sized too small and reallocated while encoding — the exact cost the hint exists to prevent. The omission was inconsistent within the same match (`ExtensionDropped` counts its two *short* strings) and with the sibling `DaemonRequest::encode_size_hint`, which counts `ExtensionStore.value` and `ExtensionRequest.payload`. That sibling's doc even warns that "a new payload-carrying variant that forgets to report its size would silently fall back to growing the buffer from empty… which no test would catch."

## Fix

Give `ParamUpdate` and `NodeFailed` their own arms counting the variable-length field:

```rust
NodeEvent::ParamUpdate { value_json, .. } => value_json.len(),
NodeEvent::NodeFailed { error, .. } => error.len(),
```

No wire-format change — the hint only affects buffer pre-sizing.

## Validation

- Added two regression tests asserting each hint covers its payload (`cargo test -p dora-message --lib encode_size_hint` — 2 passed).
- `cargo clippy -p dora-message --all-targets -- -D warnings` — clean.
- `cargo fmt -p dora-message -- --check` — clean.

---

> [!NOTE]
> This is a machine-generated PR produced by an automated Claude Code code-review run. A maintainer should review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJXugi4Zky3SV9Q2qmFGnr

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJXugi4Zky3SV9Q2qmFGnr)_