### PR TITLE
fix(cli): reject record topics that collide under the ___ input-id encoding

### DIFF
--- a/binaries/cli/src/command/record.rs
+++ b/binaries/cli/src/command/record.rs
@@ -168,6 +168,31 @@ fn extend_prefixed_outputs(
     }
 }
 
+/// Build the record node's `{ input_id: topic }` map from the selected
+/// `(topic, input_id)` pairs.
+///
+/// Input ids can't contain `/`, so each `node/output` topic is re-encoded as
+/// `node___output`. That encoding is not injective: node `x` with output
+/// `y___z` and node `x___y` with output `z` both encode to `x___y___z`.
+/// Collecting straight into a map keyed by input id would let the second entry
+/// silently overwrite the first, dropping one topic from the recording with no
+/// error. Detect the collision and fail loudly instead.
+fn build_input_id_map<'a>(
+    topics: impl IntoIterator<Item = (&'a str, &'a str)>,
+) -> eyre::Result<BTreeMap<&'a str, &'a str>> {
+    let mut map: BTreeMap<&str, &str> = BTreeMap::new();
+    for (topic, input_id) in topics {
+        if let Some(existing) = map.insert(input_id, topic) {
+            bail!(
+                "record: topics `{existing}` and `{topic}` both map to the record-node \
+                 input id `{input_id}`; the `/` -> `___` encoding cannot tell them apart. \
+                 Rename one of the colliding node/output ids, or select only one with --topics."
+            );
+        }
+    }
+    Ok(map)
+}
+
 fn run_record(args: Record) -> eyre::Result<()> {
     let yaml_bytes =
         std::fs::read(&args.file).wrap_err_with(|| format!("failed to read {}", args.file))?;
@@ -216,10 +241,7 @@ fn run_record(args: Record) -> eyre::Result<()> {
     let record_node_bin = find_record_node_binary()?;
 
     // Build topic map JSON: { "input_id": "node/output" }
-    let topic_map: BTreeMap<&str, &str> = topics
-        .iter()
-        .map(|(topic, input_id)| (input_id.as_str(), topic.as_str()))
-        .collect();
+    let topic_map = build_input_id_map(topics.iter().map(|(t, i)| (t.as_str(), i.as_str())))?;
     let topics_json =
         serde_json::to_string(&topic_map).wrap_err("failed to serialize topic map")?;
 
@@ -721,6 +743,32 @@ mod tests {
             topics,
             vec!["standard/status", "single/image", "runtime/op/status"]
         );
+    }
+
+    #[test]
+    fn build_input_id_map_detects_encoding_collision() {
+        // Node `x` with output `y___z` and node `x___y` with output `z` both
+        // encode to the record-node input id `x___y___z`. Recording both must
+        // fail loudly rather than silently drop one.
+        let err = build_input_id_map([("x/y___z", "x___y___z"), ("x___y/z", "x___y___z")])
+            .expect_err("colliding input ids must be rejected");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("x___y___z") && msg.contains("x/y___z") && msg.contains("x___y/z"),
+            "error must name the colliding topics and input id: {msg}"
+        );
+    }
+
+    #[test]
+    fn build_input_id_map_accepts_distinct_input_ids() {
+        let map = build_input_id_map([
+            ("cam/frame", "cam___frame"),
+            ("lidar/points", "lidar___points"),
+        ])
+        .expect("distinct input ids must be accepted");
+        assert_eq!(map.len(), 2);
+        assert_eq!(map["cam___frame"], "cam/frame");
+        assert_eq!(map["lidar___points"], "lidar/points");
     }
 
     #[test]

--- a/binaries/cli/src/command/record.rs
+++ b/binaries/cli/src/command/record.rs
@@ -237,22 +237,28 @@ fn run_record(args: Record) -> eyre::Result<()> {
     let cwd = std::env::current_dir().wrap_err("failed to get current directory")?;
     let output_path = dunce::canonicalize(&cwd).unwrap_or(cwd).join(&output_file);
 
-    // Find record node binary
-    let record_node_bin = find_record_node_binary()?;
-
     // Build topic map JSON: { "input_id": "node/output" }
+    //
+    // Validate the input-id encoding *before* `find_record_node_binary` below,
+    // which can trigger a multi-minute `cargo build`/`cargo install`: a
+    // colliding topic set must fail fast, not after that build completes.
     let topic_map = build_input_id_map(topics.iter().map(|(t, i)| (t.as_str(), i.as_str())))?;
     let topics_json =
         serde_json::to_string(&topic_map).wrap_err("failed to serialize topic map")?;
 
-    // Build inputs mapping for the record node YAML entry
+    // Build the record node's YAML inputs from the validated map, so this
+    // second `input_id`-keyed structure cannot reintroduce a collision
+    // independently of `topic_map` (it would otherwise silently overwrite).
     let mut inputs_mapping = serde_yaml::Mapping::new();
-    for (topic, input_id) in &topics {
+    for (input_id, topic) in &topic_map {
         inputs_mapping.insert(
-            serde_yaml::Value::String(input_id.clone()),
-            serde_yaml::Value::String(topic.clone()),
+            serde_yaml::Value::String((*input_id).to_owned()),
+            serde_yaml::Value::String((*topic).to_owned()),
         );
     }
+
+    // Find record node binary
+    let record_node_bin = find_record_node_binary()?;
 
     // Build env vars
     let mut env_mapping = serde_yaml::Mapping::new();


### PR DESCRIPTION
## Issue

`dora record` injects a record node and subscribes it to each topic. Record-node input ids can't contain `/`, so every `node/output` topic is re-encoded as `node___output` (`binaries/cli/src/command/record.rs`). That encoding is **not injective**:

- node `x`, output `y___z` → input id `x___y___z`
- node `x___y`, output `z` → input id `x___y___z`

The `{ input_id: topic }` map (and the record node's `inputs` mapping) was built by collecting straight into a `BTreeMap` keyed by input id, so the second colliding entry silently overwrote the first — one of the two topics was **dropped from the recording with no error or warning**. Node and output ids legitimately permit underscores (`id.rs` allows `_` in both), so `___` is a reachable id shape.

## Fix

Extract the map construction into a small pure helper `build_input_id_map`, which detects a duplicate input id and bails with a message naming both colliding topics and the shared input id, rather than losing data silently:

```
record: topics `x/y___z` and `x___y/z` both map to the record-node input id
`x___y___z`; the `/` -> `___` encoding cannot tell them apart. Rename one of the
colliding node/output ids, or select only one with --topics.
```

The check runs on the post-`--topics`-filter set, so it only fires when both colliding topics are actually selected for recording.

Follow-up from review:

- **Validate before the expensive step.** The validation now runs *above* `find_record_node_binary`, which can trigger a multi-minute `cargo build`/`cargo install` — a colliding topic set fails fast instead of after that build.
- **No second unguarded map.** The record node's YAML `inputs_mapping` is now derived from the validated `topic_map` instead of being independently re-collected from `topics`. Previously it was a second `input_id`-keyed structure that would also silently overwrite on collision, safe only because the check bailed first — a load-bearing ordering dependency now removed.

## Behavior note

With no `--topics`, all topics are selected, so a dataflow containing one colliding pair now **fails `dora record` outright** instead of recording with one topic silently missing. That is the right trade for a data-capture tool, but it is a visible behavior change.

## Validation

- Added `build_input_id_map_detects_encoding_collision` and `build_input_id_map_accepts_distinct_input_ids` (`cargo test -p dora-cli --lib build_input_id_map` — 2 passed).
- `cargo clippy -p dora-cli --all-targets -- -D warnings` — clean.
- `cargo fmt -p dora-cli -- --check` — clean.
- (Verified with Rust 1.97.1, matching the repo's CI toolchain.)

---

> [!NOTE]
> This is a machine-generated PR produced by an automated Claude Code code-review run. A maintainer should review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJXugi4Zky3SV9Q2qmFGnr