### PR TITLE
feat(arrow-convert): add IntoArrow for Vec<bool>

### DIFF
--- a/libraries/arrow-convert/src/into_impls.rs
+++ b/libraries/arrow-convert/src/into_impls.rs
@@ -19,6 +19,12 @@ impl IntoArrow for bool {
     }
 }
 
+impl IntoArrow for Vec<bool> {
+    fn into_arrow(self) -> DoraArray {
+        wrap(arrow::array::BooleanArray::from(self))
+    }
+}
+
 macro_rules! impl_into_arrow {
     ($($t:ty => $arrow_type:ty),*) => {
         $(
@@ -130,6 +136,21 @@ mod tests {
             .downcast_ref::<TimestampNanosecondArray>()
             .expect("timestamp array")
             .value(0)
+    }
+
+    #[test]
+    fn vec_bool_into_arrow_roundtrips() {
+        use arrow::array::BooleanArray;
+        let values = vec![true, false, true, true];
+        let arr = values.clone().into_arrow();
+        let boolean = crate::internal::array_ref(&arr)
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .expect("boolean array");
+        assert_eq!(boolean.len(), values.len());
+        assert_eq!(boolean.null_count(), 0);
+        let got: Vec<bool> = (0..boolean.len()).map(|i| boolean.value(i)).collect();
+        assert_eq!(got, values);
     }
 
     #[test]


### PR DESCRIPTION
## Issue

In `libraries/arrow-convert/src/into_impls.rs`, the `impl_into_arrow!` macro generates both a scalar and a `Vec<$t>` `IntoArrow` impl for every primitive (`u8`..`f64`), and `Vec<String>` is provided too — but `bool` has only the scalar impl (it's defined by hand, outside the macro).

So this doesn't compile:

```rust
node.send_output(id, params, vec[true, false]); // no `IntoArrow for Vec<bool>`
```

…unless the caller enables the `arrow-v59` feature and constructs a `BooleanArray` manually. Given `Vec<u8>`, `Vec<i32>`, `Vec<f64>`, `Vec<String>`, etc. all work, this asymmetry is a gap users hit.

## Fix

Add the missing impl, mirroring the scalar `bool` one:

```rust
impl IntoArrow for Vec<bool> {
    fn into_arrow(self) -> DoraArray {
        wrap(arrow::array::BooleanArray::from(self))
    }
}
```

Purely additive — no existing behavior changes.

## Validation

- Added `vec_bool_into_arrow_roundtrips` (`cargo test -p dora-arrow-convert vec_bool` — passed).
- `cargo clippy -p dora-arrow-convert --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt -p dora-arrow-convert -- --check` — clean.
- (Verified with Rust 1.97.1, matching the repo's CI toolchain.)

---

> [!NOTE]
> This is a machine-generated PR produced by an automated Claude Code code-review run. A maintainer should review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJXugi4Zky3SV9Q2qmFGnr

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJXugi4Zky3SV9Q2qmFGnr)_