### PR TITLE
docs(arrow-convert): document that into_vec truncates float→int casts

### DIFF
--- a/libraries/arrow-convert/src/lib.rs
+++ b/libraries/arrow-convert/src/lib.rs
@@ -201,12 +201,23 @@ macro_rules! register_array_handlers {
         /// so the source and target types need not match (e.g. a `UInt64Array`
         /// into a `Vec<f64>`).
         ///
+        /// # Precision
+        ///
+        /// The per-element cast goes through [`num::NumCast`]/[`num::ToPrimitive`],
+        /// so it is **lossy exactly where an `as` cast is**: a float source with a
+        /// fractional part is truncated toward zero into an integer target — it is
+        /// **not** rounded, and it does **not** error. Converting between integer
+        /// types that both hold the value, or widening an integer to a float, is
+        /// exact.
+        ///
         /// # Errors
         ///
         /// Returns an error if the array contains any null values (consistent
         /// with every other [`TryFrom<&DoraArray>`] impl in this crate), if the
         /// array's data type is not a supported integer or float type, or if any
-        /// element cannot be represented in `T` (an out-of-range cast).
+        /// element is out of `T`'s range (e.g. a negative float into an unsigned
+        /// target, or a magnitude the target cannot hold). A merely fractional
+        /// float is *in range* and is truncated, per **Precision** above.
         ///
         /// ```
         /// use dora_arrow_convert::{IntoArrow, into_vec};
@@ -215,6 +226,10 @@ macro_rules! register_array_handlers {
         /// let data = vec![1u64, 2, 3].into_arrow();
         /// assert_eq!(into_vec::<u64>(&data).ok(), Some(vec![1, 2, 3]));
         /// assert_eq!(into_vec::<f64>(&data).ok(), Some(vec![1.0, 2.0, 3.0]));
+        ///
+        /// // Float -> integer truncates toward zero (it does not round or error).
+        /// let floats = vec![1.9f64, -2.9].into_arrow();
+        /// assert_eq!(into_vec::<i64>(&floats).ok(), Some(vec![1, -2]));
         ///
         /// // Unsupported (non-numeric) array types are rejected.
         /// let strings = vec!["a".to_string(), "b".to_string()].into_arrow();


### PR DESCRIPTION
## Issue

`into_vec` (`libraries/arrow-convert/src/lib.rs`) casts each element to `T` via `num::NumCast`. Its doc's `# Errors` section listed only:

> …or if any element cannot be represented in `T` (an out-of-range cast).

which implies the conversion is otherwise lossless. It isn't: `NumCast::from` goes through `ToPrimitive`, so a float source with a fractional part is **truncated toward zero** into an integer target — silently, with no error and no rounding. For example `into_vec::<i64>` over `[1.9, -2.9]` yields `[1, -2]`. The "out-of-range" caveat leads a caller to expect otherwise.

## Fix

Documentation-only:
- Add a `# Precision` section spelling out the `as`-cast semantics (float→int truncates toward zero; integer↔integer and integer→float that fit are exact).
- Refine `# Errors` so a merely-fractional float reads as *in range and truncated*, not a cast error (genuine out-of-range values — e.g. a negative float into an unsigned target — still error).
- Add a doctest asserting the truncation, so the documented behavior is compile-checked.

No behavior change.

## Validation

- `cargo test -p dora-arrow-convert --doc` — 3 doctests pass, including the new truncation assertion (`[1.9, -2.9]` → `[1, -2]`).
- `cargo fmt -p dora-arrow-convert -- --check` — clean.
- (Verified with Rust 1.97.1, matching the repo's CI toolchain.)

---

> [!NOTE]
> This is a machine-generated PR produced by an automated Claude Code code-review run. A maintainer should review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJXugi4Zky3SV9Q2qmFGnr

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJXugi4Zky3SV9Q2qmFGnr)_