### PR TITLE
refactor(cli): drop no-op PathBuf round-trip in record --proxy output path

### DIFF
--- a/binaries/cli/src/command/record.rs
+++ b/binaries/cli/src/command/record.rs
@@ -376,11 +376,7 @@ fn run_record_proxy(args: Record) -> eyre::Result<()> {
     };
 
     let output_file = match &args.output {
-        Some(p) => {
-            // Resolve to filename only if user provided a bare name, otherwise use as-is
-            let path = PathBuf::from(p);
-            path.to_string_lossy().to_string()
-        }
+        Some(p) => p.clone(),
         None => {
             let ts = chrono::Local::now().format("%Y%m%d_%H%M%S");
             format!("recording_{ts}.drec")


### PR DESCRIPTION
## Issue

In `run_record_proxy` (`binaries/cli/src/command/record.rs`), the `--output` arm was:

```rust
Some(p) => {
    // Resolve to filename only if user provided a bare name, otherwise use as-is
    let path = PathBuf::from(p);
    path.to_string_lossy().to_string()
}
```

`p` is a `&String`, so `PathBuf::from(p).to_string_lossy().to_string()` reconstructs the identical string for every valid path — it is exactly `p.clone()`, which is precisely what the non-proxy `run_record` already does (`Some(p) => p.clone()`). The comment claims bare-name-vs-path resolution that is **never implemented** — there is no filename/path branching at all — so it only misleads the next reader into thinking normalization happens here (it doesn't; the resulting `File::create` uses the string verbatim).

## Fix

Replace the arm with `p.clone()` and drop the misleading comment. Dead code + a needless allocation + a comment documenting non-existent logic, all removed. No behavior change.

## Validation

- `cargo clippy -p dora-cli --all-targets -- -D warnings` — clean.
- `cargo fmt -p dora-cli -- --check` — clean.
- (Verified with Rust 1.97.1, matching the repo's CI toolchain.)

---

> [!NOTE]
> This is a machine-generated PR produced by an automated Claude Code code-review run. A maintainer should review before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJXugi4Zky3SV9Q2qmFGnr

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJXugi4Zky3SV9Q2qmFGnr)_