### PR TITLE
fix(coordinator): validate Logs node id instead of panicking (#3450)

### DIFF
--- a/binaries/coordinator/src/handlers.rs
+++ b/binaries/coordinator/src/handlers.rs
@@ -488,6 +488,23 @@ fn resolve_log_daemon_id(
     }
 }
 
+/// Validate an untrusted `node` string from a [`ControlRequest::Logs`] into a
+/// [`NodeId`].
+///
+/// The wire field is a raw `String` (unlike every other node-id-bearing
+/// control request, which is typed as `NodeId` and validated at deserialize
+/// time), so it may be any bytes. Using the panicking `String -> NodeId`
+/// conversion here would unwind the coordinator's single event loop and drop
+/// every daemon/CLI connection — a control-plane DoS. Parsing returns a normal
+/// error the client receives instead. See #3450 (the node-id sub-case that
+/// #650's fix for #648 missed).
+///
+/// [`ControlRequest::Logs`]: dora_message::cli_to_coordinator::ControlRequest::Logs
+pub(crate) fn parse_logs_node_id(node: &str) -> eyre::Result<NodeId> {
+    node.parse::<NodeId>()
+        .map_err(|err| eyre!("invalid node id `{node}`: {err}"))
+}
+
 pub(crate) async fn retrieve_logs(
     running_dataflows: &HashMap<Uuid, RunningDataflow>,
     archived_dataflows: &indexmap::IndexMap<Uuid, ArchivedDataflow>,
@@ -777,6 +794,24 @@ mod tests {
             std::sync::Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             BTreeMap::new(),
         )
+    }
+
+    #[test]
+    fn parse_logs_node_id_rejects_invalid_ids_without_panicking() {
+        // A raw wire `node` string may be anything; the panicking `.into()`
+        // conversion here would take down the coordinator event loop (#3450).
+        // These must all come back as graceful errors instead.
+        for bad in ["bad name", "", ".hidden", "dora", "a/b", "node\0"] {
+            let err = parse_logs_node_id(bad)
+                .expect_err(&format!("invalid node id {bad:?} must error, not panic"));
+            assert!(err.to_string().contains("invalid node id"), "got: {err}");
+        }
+    }
+
+    #[test]
+    fn parse_logs_node_id_accepts_valid_ids() {
+        let node = parse_logs_node_id("cam.left").expect("a valid node id must parse");
+        assert_eq!(node, NodeId::from("cam.left".to_string()));
     }
 
     #[test]

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -11,9 +11,9 @@
 use crate::{
     events::set_up_ctrlc_handler,
     handlers::{
-        build_dataflow, dataflow_result, handle_destroy, reload_dataflow, resolve_name,
-        restart_node, retrieve_logs, send_heartbeat_message, send_log_message, send_topic_frames,
-        start_dataflow, stop_dataflow, stop_node,
+        build_dataflow, dataflow_result, handle_destroy, parse_logs_node_id, reload_dataflow,
+        resolve_name, restart_node, retrieve_logs, send_heartbeat_message, send_log_message,
+        send_topic_frames, start_dataflow, stop_dataflow, stop_node,
     },
     state::{
         ArchivedDataflow, CachedResult, ParamTarget, PendingRestart, RunningBuild, RunningDataflow,
@@ -1127,17 +1127,26 @@ async fn start_inner(
 
                             match dataflow_uuid {
                                 Ok(uuid) => {
-                                    let reply = retrieve_logs(
-                                        &running_dataflows,
-                                        &archived_dataflows,
-                                        uuid,
-                                        node.into(),
-                                        &mut daemon_connections,
-                                        clock.new_timestamp(),
-                                        tail,
-                                    )
-                                    .await
-                                    .map(ControlRequestReply::Logs);
+                                    // `node` arrives as a raw wire `String`, so it may be an
+                                    // invalid node id. Validate it instead of using the panicking
+                                    // `String -> NodeId` conversion, which would unwind the
+                                    // coordinator's single event loop and take down every
+                                    // daemon/CLI connection (control-plane DoS). See #3450 — the
+                                    // node-id sub-case that #650's fix for #648 missed.
+                                    let reply = match parse_logs_node_id(&node) {
+                                        Ok(node_id) => retrieve_logs(
+                                            &running_dataflows,
+                                            &archived_dataflows,
+                                            uuid,
+                                            node_id,
+                                            &mut daemon_connections,
+                                            clock.new_timestamp(),
+                                            tail,
+                                        )
+                                        .await
+                                        .map(ControlRequestReply::Logs),
+                                        Err(err) => Err(err),
+                                    };
                                     let _ = reply_sender.send(reply);
                                 }
                                 Err(err) => {


### PR DESCRIPTION
## Summary

Fixes #3450.

A control-plane client could crash the coordinator (control-plane DoS) by sending a `ControlRequest::Logs` whose `node` field is an invalid node id. The handler at `binaries/coordinator/src/lib.rs` force-converted the raw wire `String` with `NodeId::from` via `node.into()`, and `impl From<String> for NodeId` **panics** on invalid input (`libraries/message/src/id.rs`). That panic unwinds the coordinator's single event loop, dropping every daemon and CLI connection.

`Logs.node` is the only node-id-bearing `ControlRequest` field typed as a plain `String` — every other one (`RestartNode`, `StopNode`, `GetParam`, …) uses `NodeId`, whose `Deserialize` runs `validate_node_id` and rejects a bad id at the wire boundary. So a direct control-protocol client (a supported surface) can send `{"Logs":{"node":"bad name",...}}` and take the coordinator down.

This is the node-id sub-case of #648; #650 fixed the UUID/name resolution path but left the node conversion panicking.

## Fix

Validate the untrusted string with `parse::<NodeId>()` (which is fallible) via a new `parse_logs_node_id` helper in `handlers.rs`, and on an invalid id send a normal `ControlRequestReply::Error` back to the client — matching how every other request rejects a bad id and completing #650's fix for the node-id path.

## Testing

- `parse_logs_node_id_rejects_invalid_ids_without_panicking` — `"bad name"`, `""`, `".hidden"`, `"dora"`, `"a/b"`, `"node\0"` all return graceful errors.
- `parse_logs_node_id_accepts_valid_ids` — a valid dotted id (`cam.left`) still parses.
- `cargo test -p dora-coordinator --lib handlers::tests::parse_logs` — 2 passed.
- `cargo fmt --all -- --check` and `cargo clippy -p dora-coordinator --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ns4Cgf3GUWEN9VqmYryegX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ns4Cgf3GUWEN9VqmYryegX)_