### PR TITLE
fix(core): sanitize runtime-node subgraph IDs in Mermaid output

### DIFF
--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -1276,4 +1276,44 @@ nodes:
             Some("gpu-box")
         );
     }
+
+    /// A multi-operator runtime node whose id contains a `.` must emit a
+    /// Mermaid `subgraph` with a sanitized id (dots are invalid in subgraph
+    /// ids), mirroring the module-subgraph path. Node ids legally contain `.`,
+    /// and module expansion prefixes inner node ids with `{module_id}.`, so the
+    /// unsanitized `subgraph camera.front` this used to emit was an invalid
+    /// Mermaid document.
+    #[test]
+    fn runtime_node_subgraph_id_is_sanitized_for_dotted_ids() {
+        let yaml = r#"
+nodes:
+  - id: camera.front
+    operators:
+      - id: detect
+        python: detect.py
+        inputs:
+          tick: dora/timer/millis/100
+        outputs:
+          - bbox
+      - id: track
+        python: track.py
+        inputs:
+          bbox: camera.front/detect/bbox
+        outputs:
+          - tracks
+"#;
+        let desc: Descriptor = serde_yaml::from_str(yaml).expect("parse");
+        let resolved = desc.resolve_aliases_and_set_defaults().expect("resolve");
+        let flowchart =
+            visualize::visualize_nodes_with_boundaries(&resolved, &ModuleBoundaries::default());
+
+        assert!(
+            flowchart.contains("subgraph camera_front [camera.front]"),
+            "runtime-node subgraph id must be sanitized and labelled; got:\n{flowchart}"
+        );
+        assert!(
+            !flowchart.contains("subgraph camera.front"),
+            "an unsanitized dotted subgraph id is invalid Mermaid; got:\n{flowchart}"
+        );
+    }
 }

--- a/libraries/core/src/descriptor/visualize.rs
+++ b/libraries/core/src/descriptor/visualize.rs
@@ -159,7 +159,16 @@ fn visualize_runtime_node(
             writeln!(flowchart, "  {node_id}/{operator_id}[{node_id}]").unwrap();
         }
     } else {
-        writeln!(flowchart, "subgraph {node_id}").unwrap();
+        // Sanitize the id for Mermaid the same way the module-subgraph path
+        // above does (dots are invalid in subgraph IDs) and keep the original
+        // id as the readable label. Node ids legally contain `.`, and any
+        // runtime node inside a module is prefixed with `{module_id}.` during
+        // expansion, so an unsanitized `subgraph {node_id}` here emits an
+        // invalid Mermaid document for those nodes. The contained operator
+        // nodes keep their raw `{node_id}/{operator_id}` ids (dots are valid in
+        // node ids, only subgraph ids), so edges still line up.
+        let safe_id = node_id.as_ref().replace('.', "_");
+        writeln!(flowchart, "subgraph {safe_id} [{node_id}]").unwrap();
         for operator in operators {
             let operator_id = &operator.id;
             if operator.config.inputs.is_empty() {


### PR DESCRIPTION
## Issue

A multi-operator runtime node — or a single-operator node whose operator id is not the default `op` — is rendered as a Mermaid `subgraph`. That branch of `visualize_runtime_node` emitted `subgraph {node_id}` using the **raw** node id, while the module-subgraph path in the same file already sanitizes the id (`visualize.rs:31`, with the comment *"dots are invalid in subgraph IDs"*) and attaches a readable label.

Node ids legally contain `.` (the id validator accepts `[a-zA-Z0-9_.-]`), and module expansion prefixes every inner node id with `{module_id}.`. So any such runtime node inside a module — or any top-level dotted node with multiple/named operators — produced `subgraph camera.front`, an **invalid Mermaid document**.

### Reproduce

```yaml
nodes:
  - id: camera.front
    operators:
      - id: detect
        python: detect.py
        outputs: [bbox]
      - id: track
        python: track.py
        inputs: { bbox: camera.front/detect/bbox }
        outputs: [tracks]
```

`dora graph` on this dataflow emits `subgraph camera.front`, which Mermaid rejects.

## Fix

Sanitize the subgraph id the same way the module-subgraph path already does (`.` → `_`) and keep the original id as the label:

```rust
let safe_id = node_id.as_ref().replace('.', "_");
writeln!(flowchart, "subgraph {safe_id} [{node_id}]").unwrap();
```

The contained operator nodes keep their raw `{node_id}/{operator_id}` ids (dots are valid in node ids, only in subgraph ids), so the edges built by `visualize_node_inputs` still line up. This never turns a working diagram broken: the only collision case (two node ids differing solely by `.` vs `_`) was already an invalid document before this change.

## Validation

- New regression test `runtime_node_subgraph_id_is_sanitized_for_dotted_ids` (resolves a dotted multi-operator runtime node, asserts the subgraph id is sanitized + labelled). Verified it fails on `main` and passes with the fix.
- `cargo test -p dora-core` (327 tests) green; `cargo fmt --check` and `cargo clippy --all-targets -D warnings` clean.

---

⚠️ **This is a machine-generated pull request**, authored by Claude (Anthropic's Claude Code) as part of an automated code-review pass. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KcSohD3sQ7whF7vxLKoeF

---
_Generated by [Claude Code](https://claude.ai/code/session_011KcSohD3sQ7whF7vxLKoeF)_