### PR TITLE
fix(ros2-bridge): don't misclassify a member with `=` in its string default

### DIFF
--- a/libraries/extensions/ros2-bridge/msg-gen/src/parser/message.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/parser/message.rs
@@ -41,9 +41,27 @@ pub fn parse_message_string(
 
         let (_, rest) = split_once(line, ' ');
 
-        // rest is None when the line has no space (e.g. tab-separated or single-token);
-        // treat absence of '=' as a member definition rather than panicking.
-        if rest.is_some_and(|r| r.contains('=')) {
+        // A constant line is `TYPE NAME = VALUE`: the `=` binds the name
+        // (optionally with surrounding spaces, which `constant_def` accepts). A
+        // member line is `TYPE name [default]`, and a *string* default may
+        // itself contain `=` (e.g. `string url "http://h?a=b"`). Classifying by
+        // "does the remainder contain `=` anywhere" misroutes such a member to
+        // `constant_def`, which then rejects the lowercase field name and fails
+        // the whole message file. Instead, look only at the name position: the
+        // first non-space, non-`=` run after the type is the name, so the line
+        // is a constant iff the first character after that name (skipping
+        // spaces) is `=`.
+        //
+        // rest is None when the line has no space (e.g. tab-separated or
+        // single-token); that is never a constant, so it falls through to
+        // `member_def` rather than panicking.
+        let is_constant = rest.is_some_and(|r| {
+            r.trim_start()
+                .trim_start_matches(|c: char| !c.is_whitespace() && c != '=')
+                .trim_start()
+                .starts_with('=')
+        });
+        if is_constant {
             constants.push(constant_def(line)?);
         } else {
             members.push(member_def(line)?);
@@ -176,5 +194,35 @@ mod test {
         // error, not a panic.
         let result = parse_message_string("pkg", "Msg", "garbage");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn string_member_default_containing_eq_is_a_member_not_a_constant() {
+        // A string field whose default value contains `=` (e.g. a URL query
+        // string) must be parsed as a member. Classifying it as a constant
+        // (because the line contains `=` anywhere) rejects the lowercase field
+        // name and fails the whole message.
+        let msg = parse_message_string("pkg", "Msg", "string url \"http://h?a=b\"").unwrap();
+        assert_eq!(msg.members.len(), 1, "expected a member, got {msg:?}");
+        assert!(msg.constants.is_empty());
+        assert_eq!(msg.members[0].name, "url");
+    }
+
+    #[test]
+    fn constant_line_is_still_a_constant() {
+        // Regression guard the other way: a genuine constant must still be
+        // classified as one, both tightly written and with spaces around `=`.
+        let msg = parse_message_string("pkg", "Msg", "int32 X=5").unwrap();
+        assert_eq!(msg.constants.len(), 1, "expected a constant, got {msg:?}");
+        assert!(msg.members.is_empty());
+        assert_eq!(msg.constants[0].name, "X");
+
+        let spaced = parse_message_string("pkg", "Msg", "int32 Y = 7").unwrap();
+        assert_eq!(
+            spaced.constants.len(),
+            1,
+            "expected a constant, got {spaced:?}"
+        );
+        assert_eq!(spaced.constants[0].name, "Y");
     }
 }


### PR DESCRIPTION
## Issue

`parse_message_string` (msg-gen) decides constant-vs-member by whether the text after the first space contains `=` **anywhere**:

```rust
if rest.is_some_and(|r| r.contains('=')) {
    constants.push(constant_def(line)?);
} else {
    members.push(member_def(line)?);
}
```

A `.msg` member line whose type is a string and whose default value contains `=` — e.g. `string url "http://h?a=b"` — has an `=` in that remainder, so it is routed to `constant_def`. `constant_def` requires an uppercase `constant_name`, rejects the lowercase field name, and fails the **entire message file**. `rosidl` accepts such defaults; dora did not.

## Fix

ROS 2 constants are `TYPE NAME = VALUE` (the `=` binds the name, optionally with surrounding spaces, which `constant_def` accepts), while a member's string default carries the `=` only inside the quoted value, after the name. Classify by the **name position** instead: skip the name run (non-space, non-`=`) after the type and check whether the next non-space character is `=`.

```rust
let is_constant = rest.is_some_and(|r| {
    r.trim_start()
        .trim_start_matches(|c: char| !c.is_whitespace() && c != '=')
        .trim_start()
        .starts_with('=')
});
```

This still recognizes `int32 X=5` and `int32 Y = 7` as constants, while a member whose default merely contains `=` now parses correctly.

## Validation

- New regression tests: `string_member_default_containing_eq_is_a_member_not_a_constant` and `constant_line_is_still_a_constant` (both directions). Verified the member test fails on the old logic and passes with the fix.
- `cargo test -p dora-ros2-bridge-msg-gen` green; `cargo fmt --check` and `cargo clippy --all-targets -D warnings` clean.

## Out of scope (noted for a follow-up)

A separate, pre-existing bug in the same parse loop: comment stripping (`split_once(line, '#')`) is not quote-aware, so a `#` inside a quoted string default (e.g. `string url "http://h#frag"`) is truncated. That needs a quote-aware tokenizer and is left out of this focused fix.

---

⚠️ **This is a machine-generated pull request**, authored by Claude (Anthropic's Claude Code) as part of an automated code-review pass. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KcSohD3sQ7whF7vxLKoeF

---
_Generated by [Claude Code](https://claude.ai/code/session_011KcSohD3sQ7whF7vxLKoeF)_