### PR TITLE
docs(operator-api-types): document dora_read_data's consume-on-read contract

### DIFF
--- a/apis/c/operator/operator_types.h
+++ b/apis/c/operator/operator_types.h
@@ -169,10 +169,12 @@ dora_free_input_id (
  *  `None` is returned — never an error type — in every non-success case:
  *  - the data was already taken by a previous call (see above);
  *  - the Arrow FFI import of the payload failed;
- *  - the payload's Arrow type is unsupported by this raw-byte API, which
- *  exposes only `UInt8` (and empty) payloads. A payload of any other Arrow
- *  type (e.g. an `Int32`/`Float` array from another node) yields `None`, so a
- *  `None` result is not by itself proof that the message carried no data.
+ *  - the payload's Arrow type is unsupported by this raw-byte API, which reads
+ *  only `UInt8` payloads (a zero-length `UInt8` array reads back as an empty
+ *  vector). A payload of any other Arrow type — including a metadata-only
+ *  `()` payload, which is a null array, and an `Int32`/`Float` array from
+ *  another node — yields `None`, so a `None` result is not by itself proof
+ *  that the message carried no data.
  *
  *  Each of these logs a diagnostic to stderr.
  *

--- a/apis/c/operator/operator_types.h
+++ b/apis/c/operator/operator_types.h
@@ -154,7 +154,33 @@ void
 dora_free_input_id (
     char * _input_id);
 
-/** <No documentation available> */
+/** \brief
+ *  Read an input's data payload as a freshly-owned byte vector.
+ *
+ *  # Consume-on-read
+ *
+ *  This **mutates** `input`: the first successful call moves the payload out of
+ *  `input`, so a second call on the same `input` returns `None` (and logs a
+ *  "double read?" note to stderr) rather than the same bytes again. Read the
+ *  data at most once per event.
+ *
+ *  # `None` cases
+ *
+ *  `None` is returned — never an error type — in every non-success case:
+ *  - the data was already taken by a previous call (see above);
+ *  - the Arrow FFI import of the payload failed;
+ *  - the payload's Arrow type is unsupported by this raw-byte API, which
+ *  exposes only `UInt8` (and empty) payloads. A payload of any other Arrow
+ *  type (e.g. an `Int32`/`Float` array from another node) yields `None`, so a
+ *  `None` result is not by itself proof that the message carried no data.
+ *
+ *  Each of these logs a diagnostic to stderr.
+ *
+ *  # Ownership
+ *
+ *  The returned vector is an owned copy of the payload; free it with
+ *  [`dora_free_data`] when it is no longer needed.
+ */
 Vec_uint8_t
 dora_read_data (
     Input_t * input);

--- a/apis/rust/operator/types/src/lib.rs
+++ b/apis/rust/operator/types/src/lib.rs
@@ -173,10 +173,12 @@ pub fn dora_free_input_id(_input_id: char_p_boxed) {}
 /// `None` is returned — never an error type — in every non-success case:
 /// - the data was already taken by a previous call (see above);
 /// - the Arrow FFI import of the payload failed;
-/// - the payload's Arrow type is unsupported by this raw-byte API, which
-///   exposes only `UInt8` (and empty) payloads. A payload of any other Arrow
-///   type (e.g. an `Int32`/`Float` array from another node) yields `None`, so a
-///   `None` result is not by itself proof that the message carried no data.
+/// - the payload's Arrow type is unsupported by this raw-byte API, which reads
+///   only `UInt8` payloads (a zero-length `UInt8` array reads back as an empty
+///   vector). A payload of any other Arrow type — including a metadata-only
+///   `()` payload, which is a null array, and an `Int32`/`Float` array from
+///   another node — yields `None`, so a `None` result is not by itself proof
+///   that the message carried no data.
 ///
 /// Each of these logs a diagnostic to stderr.
 ///

--- a/apis/rust/operator/types/src/lib.rs
+++ b/apis/rust/operator/types/src/lib.rs
@@ -159,6 +159,31 @@ pub fn dora_read_input_id(input: &Input) -> char_p_boxed {
 #[ffi_export]
 pub fn dora_free_input_id(_input_id: char_p_boxed) {}
 
+/// Read an input's data payload as a freshly-owned byte vector.
+///
+/// # Consume-on-read
+///
+/// This **mutates** `input`: the first successful call moves the payload out of
+/// `input`, so a second call on the same `input` returns `None` (and logs a
+/// "double read?" note to stderr) rather than the same bytes again. Read the
+/// data at most once per event.
+///
+/// # `None` cases
+///
+/// `None` is returned — never an error type — in every non-success case:
+/// - the data was already taken by a previous call (see above);
+/// - the Arrow FFI import of the payload failed;
+/// - the payload's Arrow type is unsupported by this raw-byte API, which
+///   exposes only `UInt8` (and empty) payloads. A payload of any other Arrow
+///   type (e.g. an `Int32`/`Float` array from another node) yields `None`, so a
+///   `None` result is not by itself proof that the message carried no data.
+///
+/// Each of these logs a diagnostic to stderr.
+///
+/// # Ownership
+///
+/// The returned vector is an owned copy of the payload; free it with
+/// [`dora_free_data`] when it is no longer needed.
 #[ffi_export]
 pub fn dora_read_data(input: &mut Input) -> Option<safer_ffi::Vec<u8>> {
     // `eprintln!`, not `tracing::error!`: this function is compiled into the


### PR DESCRIPTION
## Issue

`dora_read_data` is exported in the operator FFI ABI (re-exported as `dora_operator_api::types`) but carried **no doc comment**, unlike its sibling `dora_send_operator_output` (which has a full `# Safety` block). Its behavior is surprising for a reader of the generated header:

- It **mutates** `input` by taking the payload out, so a **second call returns `None`** rather than the same bytes (consume-on-read).
- It returns `None` (not an error) for an already-taken input, a failed Arrow FFI import, and — routinely, in cross-language dataflows — **any payload whose Arrow type is not `UInt8`**. So a `None` result is *not* proof that the message carried no data.

## Fix

Add a doc comment spelling out the consume-on-read semantics, the three `None` cases, and that the returned vector is an owned copy freed with `dora_free_data`. **Documentation only; no behavior change.**

## Validation

- `cargo doc -p dora-operator-api-types` with `-D rustdoc::broken_intra_doc_links` — clean (the `dora_free_data` intra-doc link resolves).
- `cargo fmt --check` and `cargo clippy --all-targets -D warnings` clean.

---

⚠️ **This is a machine-generated pull request**, authored by Claude (Anthropic's Claude Code) as part of an automated code-review pass. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KcSohD3sQ7whF7vxLKoeF

---
_Generated by [Claude Code](https://claude.ai/code/session_011KcSohD3sQ7whF7vxLKoeF)_