### PR TITLE
docs(tensor-pool): correct the handshake magic length in the auth doc

### DIFF
--- a/libraries/extensions/tensor-pool/src/daemon/auth.rs
+++ b/libraries/extensions/tensor-pool/src/daemon/auth.rs
@@ -27,8 +27,9 @@ pub(crate) fn cross_data_auth_token() -> Option<String> {
         .filter(|t| !t.is_empty())
 }
 
-/// Handshake frame: `[8-byte magic][u32 token_len][token]`, answered with
-/// a single byte (1 = accepted, 0 = rejected + connection close).
+/// Handshake frame: `[9-byte magic][u32 token_len][token]`, answered with
+/// a single byte (1 = accepted, 0 = rejected + connection close). The magic
+/// is the 9 bytes `DORA_AUTH`.
 pub(crate) const CROSS_DATA_AUTH_MAGIC: [u8; 9] = *b"DORA_AUTH";
 pub(crate) const AUTH_OK: u8 = 1;
 pub(crate) const AUTH_FAIL: u8 = 0;


### PR DESCRIPTION
## Issue

The doc comment on `CROSS_DATA_AUTH_MAGIC` describes the cross-data-plane handshake frame as `[8-byte magic][u32 token_len][token]`, but the magic is `DORA_AUTH` — **9 bytes** — as the constant's own type (`[u8; 9]`) and the receiver's `[0u8; 9]` read buffer in `auth_handshake_verify` both show. The documented frame layout was simply wrong about the magic length.

## Fix

Correct the documented length to 9 bytes so the frame description matches the wire format. **Documentation only; no behavior change.**

## Validation

- `cargo fmt --check` and `cargo clippy -p dora-tensor-pool --all-targets --all-features -D warnings` clean.

---

⚠️ **This is a machine-generated pull request**, authored by Claude (Anthropic's Claude Code) as part of an automated code-review pass. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KcSohD3sQ7whF7vxLKoeF

---
_Generated by [Claude Code](https://claude.ai/code/session_011KcSohD3sQ7whF7vxLKoeF)_