### PR TITLE
docs(quickstart): link examples to GitHub instead of broken relative paths (#3451)

### DIFF
--- a/guide/src/getting-started/quickstart.md
+++ b/guide/src/getting-started/quickstart.md
@@ -184,7 +184,7 @@ async def main():
 asyncio.run(main())
 ```
 
-See [examples/python-async](../../../examples/python-async) for a complete example.
+See [examples/python-async](https://github.com/dora-rs/dora/tree/main/examples/python-async) for a complete example.
 
 ## Logging
 
@@ -201,7 +201,7 @@ import logging
 logging.info("Processing item %d", i)
 ```
 
-See [examples/python-logging](../../../examples/python-logging) for logging module integration.
+See [examples/python-logging](https://github.com/dora-rs/dora/tree/main/examples/python-logging) for logging module integration.
 
 ## Timers
 
@@ -226,5 +226,5 @@ Also available: `dora/timer/hz/30` for 30 Hz.
 
 - [Python API Reference](../languages/python.md) -- full API docs for Node, Operator, DataflowBuilder, CUDA
 - [Communication Patterns](../concepts/patterns.md) -- service (request/reply) and action (goal/feedback/result) patterns
-- [Examples](../../examples/) -- python-dataflow, python-async, python-drain, python-concurrent-rw, python-multiple-arrays
+- [Examples](https://github.com/dora-rs/dora/tree/main/examples) -- python-dataflow, python-async, python-drain, python-concurrent-rw, python-multiple-arrays
 - [Distributed Deployment](../operations/distributed.md) -- running across multiple machines with `dora up`


### PR DESCRIPTION
## Summary

Fixes the 404 example links reported in #3451.

The quickstart guide is published at `https://dora-rs.ai/dora/getting-started/quickstart.html`. Three of its "See examples/..." links used repo-relative paths (`../../../examples/python-async`, `../../../examples/python-logging`, `../../examples/`). On the rendered mdbook site those resolve to `https://dora-rs.ai/examples/...`, which the site does not serve — so they returned **404** (e.g. `https://dora-rs.ai/examples/python-logging`).

The example directories live in the Git repository, not on the docs site, so the correct target is the GitHub tree URL. This matches the convention already used elsewhere in the guide (`guide/src/advanced/ros2-bridge.md`).

## Changes

`guide/src/getting-started/quickstart.md` — three links now point at `https://github.com/dora-rs/dora/tree/main/examples/...`:

| Link text | Before | After |
|-----------|--------|-------|
| examples/python-async | `../../../examples/python-async` | GitHub tree URL |
| examples/python-logging | `../../../examples/python-logging` | GitHub tree URL |
| Examples | `../../examples/` | GitHub tree URL |

All three target directories exist under `examples/`, so the new links are valid.

## Notes

- Docs-only change; no code or build impact.
- Scope kept to the quickstart page named in the issue. A few other guide pages (`operations/dynamic-topology.md`, `concepts/modules.md`) carry the same relative-link pattern and could be addressed as a follow-up if maintainers want a broader sweep.

Closes #3451

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MCvCydyBLn6YmRX2FUS5cj

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCvCydyBLn6YmRX2FUS5cj)_