### PR TITLE
docs(mavlink2-bridge): note SET_MODE.base_mode is stored as UInt8

### DIFF
--- a/libraries/extensions/mavlink2-bridge/src/arrow_convert.rs
+++ b/libraries/extensions/mavlink2-bridge/src/arrow_convert.rs
@@ -4,8 +4,10 @@
 //!
 //! * One row per call. `to_record_batch` returns a 1-row `RecordBatch`;
 //!   `from_record_batch` requires exactly one row and rejects anything else.
-//! * All MAVLink enums (regardless of wire width) are stored as `UInt32`
-//!   to match the Rust `repr(u32)` of the generated enum types.
+//! * MAVLink enums are stored as `UInt32` to match the Rust `repr(u32)` of the
+//!   generated enum types, regardless of their wire width. The sole exception is
+//!   `SET_MODE::base_mode`, kept at its `UInt8` wire width because the MAVLink
+//!   spec defines it as a `uint8` bitfield (see the `SET_MODE_DATA` impl below).
 //! * Bitflag fields are stored at their bitflag's natural width
 //!   (`MavModeFlag` is `u8`, `MavSysStatusSensor` is `u32`).
 //! * Primitive fields keep their wire width unchanged.


### PR DESCRIPTION
## Summary

The module-level "Arrow-side conventions" doc in `libraries/extensions/mavlink2-bridge/src/arrow_convert.rs` states:

> All MAVLink enums (regardless of wire width) are stored as `UInt32` to match the Rust `repr(u32)` of the generated enum types.

This is contradicted by the `SET_MODE_DATA` impl in the same file, which stores the `base_mode` enum at `UInt8`:

- `Field::new("base_mode", DataType::UInt8, false)` (schema)
- `arr_u8(self.base_mode as u8)` (`to_record_batch`)
- `read_u8(batch, "base_mode")` (`from_record_batch`)

`base_mode` is a genuine MAVLink enum (`MavMode`), so it falls under the "all enums" wording, yet it is the one enum kept at its `uint8` wire width (the spec defines `base_mode` as a `uint8` bitfield). Every other enum in the file (`command`, `result`, `fix_type`, `coordinate_frame`, `mavtype`, `autopilot`, `system_status`) does follow the `UInt32` rule; the `.bits()` fields at `UInt8`/`UInt32` are bitflags, already covered by a separate bullet.

## Impact

A developer building a `set_mode_cmd` `RecordBatch` by following the documented convention would size `base_mode` as `UInt32`. The `read_u8` downcast in `from_record_batch` then returns a "wrong type" error and the command never reaches the autopilot — a silent failure traceable directly to the incorrect doc.

## Fix

Document the `SET_MODE::base_mode` exception so the public trait contract matches the implementation. **Doc-only change — no behavior change.**

## Validation

- `cargo fmt -p dora-mavlink2-bridge -- --check` — clean
- `cargo clippy -p dora-mavlink2-bridge --all-targets -- -D warnings` — clean
- `cargo test -p dora-mavlink2-bridge` — 42 tests pass

(Run with rustc 1.95.0, the workspace MSRV.)

---

⚠️ This is a machine-generated change from an automated code-review pass. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012r1YKHcGgLSztkkah5kkG6

---
_Generated by [Claude Code](https://claude.ai/code/session_012r1YKHcGgLSztkkah5kkG6)_