### PR TITLE
ci: swap waiting-for-author for waiting-for-review on author activity

### DIFF
--- a/.github/workflows/waiting-for-review.yml
+++ b/.github/workflows/waiting-for-review.yml
@@ -1,0 +1,167 @@
+# Hands a reviewed PR back to the maintainers: when a PR carrying
+# `waiting-for-author` moves again — new commits on the head branch, or a
+# comment from the PR author — the label is swapped for `waiting-for-review`.
+#
+# New commits count whoever pushed them, so a maintainer's "Update branch"
+# click on a PR that is still waiting for its author will also clear the label.
+# That is rare enough to be worth the simpler rule; comparing
+# `payload.sender.login` against the PR author would tighten it.
+#
+# The swap is deliberately one-directional. `waiting-for-author` stays a manual
+# maintainer decision; an earlier version of this workflow also *added* it
+# automatically on every maintainer review or comment and was reverted for
+# being too aggressive (46b4e68e4). This job only ever clears it, and a PR that
+# does not already carry it is left untouched — no PR gains a label it never
+# had.
+name: Waiting for review
+
+on:
+  # `synchronize` = new commits on the head branch. `ready_for_review` = the
+  # author took the PR out of draft, which is the one way a draft leaves the
+  # author's court (see the draft check below).
+  pull_request_target:
+    types: [synchronize, ready_for_review]
+  # A comment from the author, in each of the three shapes GitHub reports it:
+  # a top-level PR comment, a single inline review reply, and a submitted
+  # review body. A batched review fires both of the latter two; they land in
+  # one concurrency group, so the duplicate costs nothing.
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+# `pull_request_target` runs in the base-repo context, so the token has write
+# access even for PRs from forks. No PR code is checked out — this job only
+# calls the API.
+permissions:
+  # `issues: write` is for the repository-label endpoints that
+  # `ensureReviewLabelExists` calls; `pull-requests: write` only covers the
+  # PR-scoped label endpoints. Same split as needs-rebase.yml, which spells the
+  # reasoning out at length.
+  issues: write
+  pull-requests: write
+
+concurrency:
+  # Every run in a group performs the same idempotent swap, so superseding an
+  # in-flight one is safe: the newest run re-reads the PR and finishes the job.
+  # Matches needs-rebase.yml, the repo's other per-PR label workflow. Issue and
+  # PR numbers come from one sequence, so a comment on an issue cannot collide
+  # with a PR's group.
+  group: waiting-for-review-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  swap-label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Payload-level pre-filter. GitHub evaluates this before allocating a
+    # runner, so comments from anyone but the author — most of the repo's
+    # comment traffic — and pushes to drafts never start a job. The step below
+    # re-checks both against freshly fetched data; that costs two lines and
+    # keeps the script correct on its own terms.
+    if: >-
+      (github.event_name == 'pull_request_target'
+       && !github.event.pull_request.draft)
+      || (github.event_name == 'issue_comment'
+          && github.event.issue.pull_request
+          && github.event.comment.user.login == github.event.issue.user.login)
+      || (github.event_name == 'pull_request_review_comment'
+          && github.event.comment.user.login == github.event.pull_request.user.login)
+      || (github.event_name == 'pull_request_review'
+          && github.event.review.user.login == github.event.pull_request.user.login)
+    steps:
+      - name: Swap waiting-for-author for waiting-for-review
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const AUTHOR_LABEL = 'waiting-for-author';
+            const REVIEW_LABEL = 'waiting-for-review';
+            const REVIEW_LABEL_COLOR = 'FBCA04';
+            const REVIEW_LABEL_DESCRIPTION =
+              'Pull request is waiting for a review from maintainers.';
+
+            const { owner, repo } = context.repo;
+            const payload = context.payload;
+
+            async function ensureReviewLabelExists() {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name: REVIEW_LABEL });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+                // `addLabels` would create a missing label too, but with a
+                // random color and no description.
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name: REVIEW_LABEL,
+                  color: REVIEW_LABEL_COLOR,
+                  description: REVIEW_LABEL_DESCRIPTION,
+                });
+                core.info(`Created the ${REVIEW_LABEL} label.`);
+              }
+            }
+
+            // `issue_comment` is the one event that reports the PR as an issue.
+            const number = context.eventName === 'issue_comment'
+              ? payload.issue.number
+              : payload.pull_request.number;
+            // Null for pushes: any new commit counts, whoever pushed it.
+            const actor =
+              payload.comment?.user.login ?? payload.review?.user.login ?? null;
+
+            // Read the PR fresh: webhook payloads carry the label set from
+            // before the event, and a superseded run may have swapped already.
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: number,
+            });
+
+            if (pr.state !== 'open') {
+              core.info(`#${number} is ${pr.state} — nothing to do.`);
+              return;
+            }
+            if (actor !== null && actor !== pr.user.login) {
+              core.info(
+                `#${number}: comment by ${actor}, not the author (${pr.user.login}) — nothing to do.`
+              );
+              return;
+            }
+            // A draft is with its author by definition, so activity on one is
+            // not a review request. `ready_for_review` picks it back up.
+            if (pr.draft) {
+              core.info(`#${number} is a draft — leaving ${AUTHOR_LABEL} in place.`);
+              return;
+            }
+
+            const labels = pr.labels.map((label) => label.name);
+            if (!labels.includes(AUTHOR_LABEL)) {
+              core.info(`#${number} does not carry ${AUTHOR_LABEL} — nothing to do.`);
+              return;
+            }
+
+            // Add before removing: a failure in between leaves the PR carrying
+            // both labels, which a maintainer can see and fix, rather than
+            // neither, which drops it out of both queues. Both calls are
+            // idempotent, so re-adding a label the PR already has is free.
+            await ensureReviewLabelExists();
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: number,
+              labels: [REVIEW_LABEL],
+            });
+            try {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: number,
+                name: AUTHOR_LABEL,
+              });
+            } catch (error) {
+              // Someone, or a superseded run, removed it first.
+              if (error.status !== 404) throw error;
+            }
+            core.info(`#${number}: swapped ${AUTHOR_LABEL} for ${REVIEW_LABEL}.`);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,7 +213,9 @@ The deeper QA gates — `make qa-full`, `make qa-deep`, `make qa-nightly`, `make
 - MSRV check (`cargo-hack`)
 - Plus the integration smokes: record/replay, cluster (lifecycle smoke + ssh end-to-end), topic-and-top, cpu-affinity, redb-backend, daemon-reconnect, state-reconstruction, and the Kani formal-verification proofs (`kani-proofs`)
 
-**Label automation (`.github/workflows/needs-rebase.yml`):** API-only job (no runner build) that keeps a `needs-rebase` label in sync with GitHub's merge-conflict state. It labels a PR when it conflicts with `main` and removes the label as soon as it stops conflicting — on the PR's own pushes, on every push to `main` (which rescans all open PRs, so a conflict resolved by someone else's merge clears too), and via a daily sweep as a safety net.
+**Label automation:** two API-only workflows (no runner build) keep the PR queue labels honest.
+- `needs-rebase.yml` keeps `needs-rebase` in sync with GitHub's merge-conflict state: it labels a PR when it conflicts with `main` and removes the label as soon as it stops conflicting — on the PR's own pushes, on every push to `main` (which rescans all open PRs, so a conflict resolved by someone else's merge clears too), and via a daily sweep as a safety net.
+- `waiting-for-review.yml` swaps `waiting-for-author` for `waiting-for-review` when a PR moves again: new commits on the head branch (whoever pushed them), or a comment from the PR author. The swap is one-directional — `waiting-for-author` stays a manual maintainer decision, a PR that does not already carry it is left untouched, and a draft keeps it until `ready_for_review`.
 
 **Developer guidance:** for non-Linux verification before merge, run `make qa-test` or `make qa-examples` locally; `make qa-nightly` covers the full nightly matrix (except ROS2) locally in ~3-4 hours.
 


### PR DESCRIPTION
Maintainers label a PR `waiting-for-author` after a review, but nothing moves it back, so the review queue does not distinguish PRs that are still with their author from ones that have been answered.

Add a workflow that clears `waiting-for-author` in favour of `waiting-for-review` when a PR moves again: new commits on the head branch, or a comment from the PR author (top-level, inline review reply, or submitted review body).

The swap is deliberately one-directional. `waiting-for-author` stays a manual maintainer decision -- an earlier version of this automation also added it on every maintainer review or comment and was reverted in 46b4e68e4 as too aggressive. A PR that does not already carry the label is left untouched, and a draft keeps it until `ready_for_review`.