### PR TITLE
ci(docker): fix the multi-platform build and smoke the dora-slim image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,10 +1,21 @@
+# Builds `docker/slim/Dockerfile`, runs a dataflow inside the result, and
+# publishes it to ghcr.io/dora-rs/dora-slim:latest on merges to main.
+#
+# This job's subject is the *published* `dora-rs-cli` plus the image, not the
+# diff that triggered it -- the Dockerfile installs from PyPI, not from this
+# workspace. It can therefore go red over things no PR here caused. See
+# "3.14 `Docker Image CI/CD` failed" in docs/qa-runbook.md before bisecting.
+
 name: Docker Image CI/CD
 
 on:
   push:
     branches: ["main"]
     paths:
+      # This file is in the filter so edits to it are exercised by the very
+      # runs they change.
       - "docker/**"
+      - ".github/workflows/docker-image.yml"
   pull_request:
     types:
       - opened
@@ -13,56 +24,138 @@ on:
       - ready_for_review
     paths:
       - "docker/**"
+      - ".github/workflows/docker-image.yml"
+  # Nothing above reruns unless one of those paths changes, but what the image
+  # installs comes from PyPI and moves on its own. A manual trigger re-checks
+  # the image against today's PyPI without an empty commit under `docker/`.
+  workflow_dispatch:
+
+concurrency:
+  # Two merges to `docker/**` in quick succession would otherwise race in
+  # `publish`, and whichever finished last would win -- leaving `:latest`
+  # pointing at the older Dockerfile with both runs green.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Superseded PR runs are worth cancelling; a run that is mid-publish is not.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  # 32-bit arm is not here because this image cannot be built for it: there is
+  # no arm/v6 `python:3.12-slim` (the 32-bit variants are v5 and v7), and on
+  # arm/v7 `pip install dora-rs-cli` needs `pyarrow`, which has never published
+  # an armv7l wheel and whose sdist wants Arrow C++. Documented for users in
+  # docker/slim/README.md; keep the two in step.
+  PLATFORMS: linux/amd64,linux/arm64
+
+# No `cache-from`/`cache-to: type=gha` on any build below, deliberately.
+# The Actions cache is capped at 10 GB per repo and LRU-evicts; this repo
+# already sits at ~9 GB of Rust caches that every PR restores from, and
+# `mode=max` over a layer stack containing a full rustup toolchain, once per
+# platform, would evict them wholesale (the same budget that made nightly.yml
+# restore-only). This workflow fires only on the paths above, so it pays a cold
+# build a handful of times a year -- far cheaper than making every PR recompile
+# the workspace. Within a run the buildx builder still caches, so the platform
+# sweep reuses the amd64 layers built for the smoke.
 
 jobs:
-  build_and_push:
+  build-and-smoke:
+    name: Build and smoke the slim image
     runs-on: ubuntu-latest
+    # arm64 builds under QEMU, which is slow enough that the ceiling has to be
+    # generous; it is here to cap a wedged emulator, not to pace a healthy run.
+    timeout-minutes: 60
     permissions:
       contents: read
-      # Only the publish step below needs this, and it is gated to `push`.
-      # `permissions:` accepts no expressions, so the scope cannot be
-      # narrowed per event from here — genuinely withholding it on PR runs
-      # means splitting publish into its own job, which is only coherent
-      # once the build is fixed (see the FIXME below).
-      packages: write
     env:
-      IMAGE: ghcr.io/dora-rs/dora-slim:latest
+      # Local tag only. The published name lives in the `publish` job.
+      IMAGE: dora-slim:ci
     steps:
       - uses: actions/checkout@v7
 
-      # Registry credentials and the publish step are gated on `push`, i.e.
-      # a merge to main. This job also runs on `pull_request`, where the
-      # point is to prove the Dockerfile still builds -- not to publish it.
-      #
-      # Without the gate, a PR touching `docker/**` would overwrite the
-      # public `:latest` tag with its own unreviewed Dockerfile. Fork PRs
-      # could not (GitHub downgrades GITHUB_TOKEN to read-only there
-      # regardless of the `permissions:` block above), but PRs from branches
-      # in this repo -- how most work here lands -- carry the real write
-      # token. The hole was latent rather than exploited: the build step has
-      # failed on every run since at least 2026-03, so the push was never
-      # reached.
-      #
-      # FIXME: that failure is `Multi-platform build is not supported for
-      # the docker driver` -- plain `docker build` cannot do the four
-      # platforms this asks for. The fix is `docker/setup-buildx-action` +
-      # `docker/build-push-action` with `push: ${{ github.event_name ==
-      # 'push' }}`, which also makes the multi-arch manifest publishable at
-      # all (a buildx multi-platform build cannot be `--load`ed locally, so
-      # the build/push split below could not work even once buildx is set
-      # up). Deliberately left for a separate change: this one closes the
-      # publish hole without touching what the workflow builds.
-      - name: "Login to GitHub Container Registry"
-        if: github.event_name == 'push'
+      # Only the platform sweep needs emulation, and that is skipped on `push`.
+      - uses: docker/setup-qemu-action@v4
+        if: github.event_name != 'push'
+      # buildx is what can target a platform other than the runner's own.
+      - uses: docker/setup-buildx-action@v4
+
+      # Single-platform, and `load: true` so the image lands in the local
+      # daemon where the smoke steps can `docker run` it. A multi-platform
+      # build cannot be loaded -- there is no single image to load -- which is
+      # why the sweep is a separate step further down.
+      - name: Build the linux/amd64 image
+        uses: docker/build-push-action@v7
+        with:
+          context: docker/slim
+          platforms: linux/amd64
+          load: true
+          tags: ${{ env.IMAGE }}
+
+      # The non-interactive entry point docker/slim/README.md documents. Worth
+      # its own step because it is the one invocation shape the smoke below
+      # cannot cover: that one is `docker run ... bash /smoke.sh`, so it never
+      # exercises overriding CMD with `dora` itself.
+      - name: Smoke -- documented entry point
+        run: docker run --rm "$IMAGE" dora --help
+
+      # The difference between "the binary is present" and "the image can
+      # actually host a dataflow". See docker/slim/smoke.sh.
+      - name: Smoke -- run a dataflow inside the image
+        timeout-minutes: 10
+        run: |
+          docker run --rm \
+            -v "$PWD/docker/slim/smoke.sh:/smoke.sh:ro" \
+            "$IMAGE" bash /smoke.sh
+
+      # Proves the manifest `publish` will push still builds for every platform.
+      # Skipped on `push`, where `publish` builds the same thing for real.
+      - name: Build every target platform (no push)
+        if: github.event_name != 'push'
+        uses: docker/build-push-action@v7
+        with:
+          context: docker/slim
+          platforms: ${{ env.PLATFORMS }}
+          push: false
+
+  # The only job holding `packages: write`, and it cannot run on a
+  # `pull_request` at all: a skipped job is never handed a token, so a PR run
+  # carries no scope that could overwrite the public `:latest` tag.
+  #
+  # `needs:` means a Dockerfile that fails its smoke is never published. Note
+  # what that does and does not promise: this job builds again rather than
+  # pushing the bits smoked above, because a multi-platform manifest cannot be
+  # `--load`ed into a daemon to be run. It costs a second cold amd64 build (a
+  # few minutes, a few times a year); the alternative is carrying ~2 GB of
+  # layers between jobs, which is slower than rebuilding. Nothing about this
+  # image was reproducible anyway -- every layer below `FROM` resolves
+  # `apt-get update`, rustup and PyPI afresh. The gate is on the Dockerfile,
+  # not on a digest.
+  publish:
+    name: Publish to ghcr.io
+    needs: build-and-smoke
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Log in to the GitHub Container Registry
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
-          username: ${{github.actor}}
-          password: ${{secrets.GITHUB_TOKEN}}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build the Docker image
-        run: docker build docker/slim --platform linux/amd64,linux/arm64,linux/arm32v6,linux/arm32v7 -t multi-platform --tag "$IMAGE"
-
-      - name: Push the Docker image
-        if: github.event_name == 'push'
-        run: docker push "$IMAGE"
+      # A multi-platform manifest can only be produced by buildx and can only
+      # leave it by being pushed, so build and push are one step.
+      - name: Build and push the multi-platform image
+        uses: docker/build-push-action@v7
+        with:
+          context: docker/slim
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          tags: ghcr.io/dora-rs/dora-slim:latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,7 @@ All new features and bug fixes must follow the RED-GREEN-IMPROVE cycle:
 | New dataflow feature | Smoke test (both modes) | `tests/example-smoke.rs` using both `run_smoke_test()` and `run_smoke_test_local()` |
 | Bug fix | Regression test | Whichever tier reproduces the bug |
 | New example dataflow | Smoke test entry | Add to `tests/example-smoke.rs` and `scripts/smoke-all.sh` |
+| Change to `docker/slim/Dockerfile` | Container deployment smoke | `docker/slim/smoke.sh`, run via `make qa-docker-slim` |
 
 ### Workflow
 

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,8 @@
 # `make qa-tier1` is a back-compat alias for `make qa-deep`.
 
 .PHONY: qa qa-fast qa-full qa-deep qa-tier1 qa-nightly qa-release-gate qa-mutation-audit \
-        qa-examples qa-cluster-e2e qa-cluster-record-replay ros2-zenoh-humble ros2-zenoh-kilted \
+        qa-examples qa-cluster-e2e qa-cluster-record-replay qa-docker-slim \
+        ros2-zenoh-humble ros2-zenoh-kilted \
         qa-fmt qa-audit qa-unwrap qa-secret-files qa-publish-graph qa-package-includes \
         qa-clippy qa-test qa-test-python \
         qa-test-python-node qa-coverage qa-mutants qa-semver qa-breaking qa-breaking-update \
@@ -104,6 +105,15 @@ qa-mutation-audit:
 #   make qa-examples ARGS="-v"    # stream dora output live
 qa-examples:
 	@scripts/smoke-all.sh $(ARGS)
+
+# Build the `dora-slim` container image and run a dataflow inside it, the
+# same two steps `.github/workflows/docker-image.yml` gates on. Needs a working
+# Docker daemon; deliberately NOT in the qa-fast/full/deep ladder, since it
+# costs minutes and a daemon the ladder does not assume. Run it when you touch
+# `docker/`.
+qa-docker-slim:
+	@docker build docker/slim -t dora-slim:local
+	@docker run --rm -v "$$PWD/docker/slim/smoke.sh:/smoke.sh:ro" dora-slim:local bash /smoke.sh
 
 # Real-sshd end-to-end test of `dora cluster up/status/down`. Linux-only.
 # Hard-fails if openssh-server is not installed (install via

--- a/docker/slim/README.md
+++ b/docker/slim/README.md
@@ -9,6 +9,20 @@ This Dockerfile provides a slim environment for running Dora applications with P
 - uv package manager
 - Latest Dora release
 
+## Supported Platforms
+
+`linux/amd64` and `linux/arm64`.
+
+32-bit arm is not supported and cannot be: there is no `arm/v6` variant of the `python:3.12-slim` base image, and on `arm/v7` the install stops at `pyarrow`, which has never published an armv7l wheel and whose sdist needs Arrow C++. (The `dora-rs` wheels themselves *are* built for armv7l — it is the Arrow dependency that is missing, not dora.) `.github/workflows/docker-image.yml` builds exactly the platforms listed here; keep the two in step.
+
+## Pulling the Image
+
+```bash
+docker pull ghcr.io/dora-rs/dora-slim:latest
+```
+
+Published on every merge to `main` that touches `docker/`, once the smoke below passes.
+
 ## Building the Image
 
 ```bash
@@ -49,3 +63,22 @@ dora run yolo.yml --uv
 ```
 
 This container is designed to provide a consistent environment for Dora development without requiring complex setup on the host machine.
+
+## Verifying the image
+
+`smoke.sh` is the deployment smoke: it runs *inside* a built image and asserts that the `dora` it ships can actually host a dataflow. It reports the `dora-rs-cli` / `dora-rs` pair the image resolved at build time, then runs a two-node dataflow and checks that Arrow payloads arrive intact at the sink.
+
+From the repository root:
+
+```bash
+make qa-docker-slim
+```
+
+Or by hand, from this directory:
+
+```bash
+docker build . -t dora-slim
+docker run --rm -v "$PWD/smoke.sh:/smoke.sh:ro" dora-slim bash /smoke.sh
+```
+
+CI runs the same script against every build (`.github/workflows/docker-image.yml`), and the image is only published once it passes. The Dockerfile installs `dora-rs-cli` from PyPI rather than from the workspace, so the smoke covers the *published* CLI plus the image -- see `docs/qa-runbook.md` §3.14 for what a failure does and does not implicate.

--- a/docker/slim/smoke.sh
+++ b/docker/slim/smoke.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# Deployment smoke for the `dora-slim` image. Runs *inside* the built container
+# -- see `.github/workflows/docker-image.yml`. "Verifying the image" in
+# README.md has the run-it-by-hand recipe.
+#
+# `docker build` exiting 0 only says the layers assembled. This asserts the
+# thing the image exists for: that the `dora` it ships can host a dataflow --
+# spawn two nodes, route an Arrow message from one to the other, and shut them
+# both down again.
+#
+# The nodes are written out below rather than mounting one of the repo's
+# `examples/`, which would be less code. The examples are maintained against
+# the workspace bindings and gated by workspace tests; this container runs the
+# *published* `dora-rs` from PyPI, and those two have drifted before (#1710).
+# Mounting an example would couple this gate to that drift, and red a
+# `docker/**` PR over something that has nothing to do with the image. What is
+# written here uses only API that dora's 1.x guarantee freezes.
+
+set -euo pipefail
+
+cd "$(mktemp -d)"
+
+# Report the pair the image shipped, and then use it exactly as shipped.
+# `dora-rs-cli` depends on `dora-rs >= 0.3.9` -- an open range resolved at build
+# time, so the CLI and the Python bindings can come from different releases.
+# Deliberately not pinned or reinstalled here: what a user gets is the whole
+# subject of a deployment smoke, and the 1.x guarantee says the pair has to
+# interoperate. If it does not, the run below fails, and that is the finding.
+dora --version
+python - <<'PY'
+import dora
+import pyarrow
+
+print(f"smoke: dora-rs {getattr(dora, '__version__', 'unknown')}, pyarrow {pyarrow.__version__}")
+PY
+
+cat > source.py <<'PY'
+"""Timer-driven source: one Arrow array per tick."""
+
+import pyarrow as pa
+from dora import Node
+
+node = Node()
+sent = 0
+for event in node:
+    if event["type"] != "INPUT":
+        continue
+    node.send_output("value", pa.array([sent]))
+    sent += 1
+PY
+
+cat > sink.py <<'PY'
+"""Sink: prints the marker smoke.sh greps for, once routing is proven."""
+
+from dora import Node
+
+WANTED = 3
+
+node = Node()
+seen = 0
+for event in node:
+    if event["type"] != "INPUT":
+        continue
+    # Read the payload back, don't just count events: a value that survives the
+    # daemon as an Arrow array is what proves the data path, not the wake-up.
+    value = event["value"].to_pylist()
+    assert len(value) == 1 and isinstance(value[0], int), f"unexpected payload {value!r}"
+    seen += 1
+    if seen == WANTED:
+        # Keep this literal in sync with the grep at the end of smoke.sh.
+        print("DORA_SLIM_SMOKE_OK", flush=True)
+
+print(f"smoke: sink saw {seen} message(s)", flush=True)
+PY
+
+cat > dataflow.yml <<'YAML'
+nodes:
+  - id: source
+    path: source.py
+    inputs:
+      tick: dora/timer/millis/100
+    outputs:
+      - value
+
+  - id: sink
+    path: sink.py
+    inputs:
+      value: source/value
+YAML
+
+# No `dora build` first: `run.rs` calls `build_dataflow` itself before starting
+# the daemon, and neither node has a `build:` key anyway.
+dora run dataflow.yml --stop-after 10s 2>&1 | tee run.log
+
+# `dora run --stop-after` exits 0 whenever the daemon survived the window,
+# whether or not a node did its job -- on Unix a node killed at teardown reports
+# a clean Signal(15). So the verdict has to come from the node's own output.
+# `assert_clean_dataflow_run` in scripts/qa/ci-nightly-jobs.sh is the
+# workspace-side form of the same assertion (#1863); keep them in step.
+if ! grep -q DORA_SLIM_SMOKE_OK run.log; then
+    echo "smoke: sink never reported receiving messages -- see the log above" >&2
+    exit 1
+fi
+
+echo "smoke: dataflow ran inside the image"

--- a/docs/qa-runbook.md
+++ b/docs/qa-runbook.md
@@ -251,6 +251,19 @@ Two failures that read oddly:
 - **"major version bump ..."** — a 2.0 withdraws the promises the gate measures against, so it stops there rather than reporting a green or a red that means nothing. When the bump is deliberate, `ALLOW_MAJOR_BUMP=1 make qa-breaking` (and set the same variable on the `breaking-changes` job for the PR that carries it).
 - **"the generated surface files are stale"** — regenerating changed the tree, so the comparison ran against an out-of-date snapshot and its "ok" meant nothing. Commit the regenerated files and read the report again.
 
+### 3.14 `Docker Image CI/CD` failed
+
+**Cause**: `.github/workflows/docker-image.yml` builds `docker/slim/Dockerfile` and runs a dataflow inside the image (`docker/slim/smoke.sh`). It only fires on `docker/**` and on the workflow file itself.
+
+Read the failure carefully before assuming your diff caused it. The Dockerfile installs `dora-rs-cli` from **PyPI**, not from this workspace, so the subject is the published CLI plus the image — what `docker pull` gives a user. It can go red for a bad `dora-rs-cli` release, a moved `python:3.12-slim` base, or a PyPI outage, none of which any PR here introduced.
+
+**Fix**, by which half failed:
+
+- **`docker build`** — a layer stopped resolving. Check whether `python:3.12-slim` moved or an apt/PyPI package disappeared. Reproduce with `make qa-docker-slim`.
+- **`Smoke -- documented entry point`** — `docker run --rm <image> dora --help` no longer works, i.e. the image's own entry point is broken. That is a real user-facing break.
+- **`Smoke -- run a dataflow inside the image`** — the CLI is present but cannot host a dataflow. The step prints the shipped `dora-rs-cli` / `dora-rs` pair first; if those two versions differ, suspect a 1.x compatibility break between the CLI and the Python bindings, which the smoke deliberately does not paper over.
+- **A platform you did not touch** — the published set is `linux/amd64,linux/arm64` (see `docker/slim/README.md`). 32-bit arm is absent because it cannot be built, not because it was forgotten; re-adding it needs an armv7l `pyarrow` wheel to exist first.
+
 ---
 
 ## 4. Running the adversarial LLM review (local only today)
@@ -384,7 +397,7 @@ If you want to add a new QA check:
 1. Write the check as a shell script under `scripts/qa/<name>.sh`.
 2. Make it executable, runnable standalone, and fail-fast.
 3. Add a target to `Makefile` (`qa-<name>`).
-4. Add it to `scripts/qa/all.sh` in the appropriate tier (fast / full / tier1).
+4. Add it to `scripts/qa/all.sh` in the appropriate tier (fast / full / tier1) — unless it needs infrastructure the ladder cannot assume (a Docker daemon, an sshd), in which case leave it out and say so in the Makefile target, as `qa-docker-slim` and `qa-cluster-e2e` do.
 5. Add a CI job to `.github/workflows/ci.yml` that calls `make qa-<name>`.
 6. Document it in this runbook (Section 3).
 

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -219,10 +219,11 @@ Topics covered: health check, list/stop/destroy requests, invalid JSON/params, c
 
 ## CI Pipeline
 
-Two workflows split by cadence (#1716):
+Two workflows split by cadence (#1716), plus one gated on a path:
 
 - **`.github/workflows/ci.yml`** — runs on every PR and push to `main`. Linux-only. **Blocks merge.** Target ~30-45 min critical path.
 - **`.github/workflows/nightly.yml`** — daily 06:40 UTC cron + manual dispatch. Cross-platform. **Does NOT block PRs**; auto-files `nightly-regression` issue on failure. ~3-4 hours wall-clock.
+- **`.github/workflows/docker-image.yml`** — only on `docker/**` changes, so most PRs never see it. Builds the `dora-slim` image, runs a dataflow inside it (`docker/slim/smoke.sh`), and publishes to `ghcr.io` on merges to `main`. Locally: `make qa-docker-slim`. It smokes the *published* `dora-rs-cli`, not the workspace — see `qa-runbook.md` §3.14 before reading a failure as yours.
 
 ### PR CI (`ci.yml`) — fast Linux-only gate
 


### PR DESCRIPTION
Closes #3468.

The workflow published `dora-slim` to ghcr.io on the strength of `docker build` exiting 0, and since at least 2026-03 it had not even been doing that — every run failed with `Multi-platform build is not supported for the docker driver`. So: fix the build with buildx, then actually run something in the image.

**32-bit arm is gone from the platform list.** It was never buildable, on three independent counts: `linux/arm32v6`/`linux/arm32v7` are Docker Hub namespaces rather than OCI platform strings; there is no `arm/v6` variant of `python:3.12-slim` to build FROM; and on `arm/v7`, `pip install dora-rs-cli` stops at `pyarrow`, which has never published an armv7l wheel (checked every release) and whose sdist needs Arrow C++. No arm32 image was ever published, so nothing regresses. The published set is now documented in `docker/slim/README.md` instead of living only in a CI env var.

**`docker/slim/smoke.sh`** runs inside the built image: it reports the `dora-rs-cli`/`dora-rs` pair the image resolved, then runs a two-node dataflow and checks Arrow payloads arrive intact at the sink. It deliberately does not pin that pair — `dora-rs >= 0.3.9` is what a user's build resolves, and under the 1.x guarantee the two have to interoperate, so a mismatch is the finding rather than something to paper over. The nodes are written out rather than mounting an `examples/` dataflow because the examples track the workspace bindings while this container runs the published ones, and those have drifted before (#1710).

**Publishing moves into its own job**, so `packages: write` cannot exist on a PR run at all — a skipped job is never handed a token. Previously the whole workflow held the scope and only gated the push *step* on the event.

Also: a `concurrency` group so two merges cannot leave `:latest` on the older Dockerfile; the workflow file added to its own path filter; and the gate registered the way `docs/qa-runbook.md` §10 asks — `make qa-docker-slim`, a tier-table row, and a §3.14 triage entry, since the image installs from PyPI and a red run does not necessarily implicate the diff that triggered it.

No layer cache: the repo's Actions cache is at 9.1 GB of its 10 GB cap, and `type=gha,mode=max` over a rustup-bearing image would evict the Rust caches every PR restores from.

### Verification

Docker is not available in my dev container, so the `docker build` / QEMU half is unverified locally — this PR touches `docker/**`, so its own run exercises it. The smoke script itself I rehearsed against the workspace `dora` with PyPI `dora-rs` 1.0.1:

- passes (marker printed, 95 messages routed in the 10s window, both nodes exit clean);
- fails with `sink saw 0 message(s)` when the source is patched to send nothing;
- fails with `AssertionError: unexpected payload ['not-an-int']` when the payload type is corrupted.

### Noticed, not fixed here

`pip-release.yml` builds `armv7l` wheels for `dora-rs` and `dora-rs-cli`, but they are effectively uninstallable via pip: `dora-rs` requires `pyarrow` and `numpy`, and neither has ever shipped an armv7l wheel. Worth its own issue.

---

_Authored by Claude Code on behalf of @phil-opp._
