### PR TITLE
docs(node-api): add a compile-checked example to SampleAllocator::encode_arrow

### DIFF
--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -2923,6 +2923,27 @@ impl SampleAllocator {
     /// The returned sample shares no memory with `array`, so the caller may —
     /// and, when the payload is owned by a foreign runtime, **must** — drop
     /// `array` on its own thread rather than let it travel to the node.
+    ///
+    /// # Example
+    ///
+    /// The encoding needs no live node or zenoh session, so a heap allocator
+    /// ([`SampleAllocator::heap`]) is enough to encode an array and decode it
+    /// back — the sample carries a complete, self-describing Arrow IPC stream:
+    ///
+    /// ```
+    /// # fn main() -> eyre::Result<()> {
+    /// use dora_node_api::{IntoArrow, SampleAllocator};
+    /// use dora_node_api::arrow_utils::decode_arrow_ipc;
+    ///
+    /// let alloc = SampleAllocator::heap();
+    /// let encoded = alloc.encode_arrow(&vec![1u64, 2, 3].into_arrow())?;
+    ///
+    /// let decoded = decode_arrow_ipc(encoded.as_bytes())?;
+    /// let values: Vec<u64> = (&decoded).try_into()?;
+    /// assert_eq!(values, vec![1, 2, 3]);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn encode_arrow(&self, array: &DoraArray) -> NodeResult<EncodedSample> {
         self.encode_arrow_data(&dora_arrow_convert::internal::array_ref(array).to_data())
     }


### PR DESCRIPTION
## What

Adds a `# Example` doctest to `SampleAllocator::encode_arrow` in `apis/rust/node/src/node/mod.rs`.

## Why

`SampleAllocator::encode_arrow` is the operator-thread output-encoding entry point (#2742), but it carried no example. Unlike most of the node output path, it needs no live node or zenoh session: `SampleAllocator::heap()` builds a working encoder on its own, making this one of the few output-side APIs that is fully exercisable in a self-contained doctest.

## The change

The example encodes an array and decodes it back through `arrow_utils::decode_arrow_ipc`, demonstrating that the returned sample carries a complete, self-describing Arrow IPC stream:

```rust
let alloc = SampleAllocator::heap();
let encoded = alloc.encode_arrow(&vec[1u64, 2, 3].into_arrow())?;
let decoded = decode_arrow_ipc(encoded.as_bytes())?;
let values: Vec<u64> = (&decoded).try_into()?;
assert_eq!(values, vec[1, 2, 3]);
```

It mirrors the existing passing doctest on `arrow_utils::encode_arrow_ipc`, so the pattern is known-good. Because it is compile-checked and run by `cargo test --doc`, it also guards the `heap()` + `encode_arrow` + `EncodedSample::as_bytes` surface against future drift.

Docs-only change — no runtime behavior is affected.

## Validation

- `cargo test -p dora-node-api --doc` → new `SampleAllocator::encode_arrow` doctest passes (14 passed, 0 failed)
- `cargo test -p dora-node-api --lib` → 189 passed, 0 failed
- `cargo clippy -p dora-node-api --all-targets -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean

---

⚠️ **This is a machine-generated PR** produced by an automated Claude Code codebase-review run. No human authored or vetted the change beyond the automated checks above; please review with that in mind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrQPm6Vv8TobE2r3Bes7Q8

---
_Generated by [Claude Code](https://claude.ai/code/session_01HrQPm6Vv8TobE2r3Bes7Q8)_