### PR TITLE
docs(message): document public LogMessage / NodeExitStatus API and add an encode/decode doctest

### DIFF
--- a/libraries/message/src/common.rs
+++ b/libraries/message/src/common.rs
@@ -11,20 +11,38 @@ use crate::{BuildId, DataflowId, daemon_to_daemon::InterDaemonEvent, id::NodeId}
 
 pub use log::Level as LogLevel;
 
+/// A single log record delivered to `dora/logs` subscribers.
+///
+/// One of these is produced for every captured log line — a `tracing` event
+/// from a dora component or a line a node wrote to stdout/stderr — and carries
+/// both the message and the routing/provenance context a log consumer needs to
+/// attribute it (which dataflow, node, and daemon it came from).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
 #[must_use]
 pub struct LogMessage {
+    /// The build this record belongs to, when it originated during a build.
     pub build_id: Option<BuildId>,
+    /// The dataflow the emitting component was part of, if any.
     pub dataflow_id: Option<DataflowId>,
+    /// The node that emitted the record, if it came from a node.
     pub node_id: Option<NodeId>,
+    /// The daemon that captured and forwarded the record.
     pub daemon_id: Option<DaemonId>,
+    /// The severity, or [`LogLevelOrStdout::Stdout`] for a captured stdout line.
     pub level: LogLevelOrStdout,
+    /// The `tracing` target (typically the emitting module path), when known.
     pub target: Option<String>,
+    /// Source module path of the emitting code, when known.
     pub module_path: Option<String>,
+    /// Source file of the emitting code, when known.
     pub file: Option<String>,
+    /// Line within [`file`](Self::file) of the emitting code, when known.
     pub line: Option<u32>,
+    /// The log text itself.
     pub message: String,
+    /// When the record was produced.
     pub timestamp: DateTime<Utc>,
+    /// Structured key/value fields attached to a `tracing` event, if any.
     pub fields: Option<BTreeMap<String, String>>,
 }
 
@@ -212,16 +230,35 @@ pub enum NodeErrorCause {
     },
 }
 
+/// How a node process ended.
+///
+/// Built from the node process's [`ExitStatus`](std::process::ExitStatus) (see
+/// the [`From`] impl), so it distinguishes a clean exit, a non-zero exit code,
+/// a killing signal (Unix), and the case where the daemon could not even wait
+/// on the process ([`IoError`](Self::IoError)).
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub enum NodeExitStatus {
+    /// The process exited successfully (exit code 0).
     Success,
+    /// The daemon failed to launch or wait on the process.
     IoError(String),
+    /// The process exited with this non-zero code.
     ExitCode(i32),
+    /// The process was terminated by this signal (Unix only).
     Signal(i32),
+    /// The process ended in a way that is neither a code nor a signal.
     Unknown,
 }
 
 impl NodeExitStatus {
+    /// Whether the node exited cleanly (i.e. this is [`Success`](Self::Success)).
+    ///
+    /// ```
+    /// use dora_message::common::NodeExitStatus;
+    ///
+    /// assert!(NodeExitStatus::Success.is_success());
+    /// assert!(!NodeExitStatus::ExitCode(1).is_success());
+    /// ```
     pub fn is_success(&self) -> bool {
         matches!(self, NodeExitStatus::Success)
     }
@@ -284,6 +321,7 @@ impl DataMessage {
         }
     }
 
+    /// Whether the carried payload is empty (zero bytes).
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }

--- a/libraries/message/src/lib.rs
+++ b/libraries/message/src/lib.rs
@@ -22,6 +22,21 @@ const ENVELOPE_SIZE_HINT: usize = 512;
 ///
 /// This and [`encode_presized`] are the only encode entry points; call sites do
 /// not name the underlying codec, so it stays swappable from one file.
+///
+/// # Example
+///
+/// A value round-trips through [`encode`] and [`decode`]:
+///
+/// ```
+/// # fn main() -> eyre::Result<()> {
+/// use dora_message::common::NodeExitStatus;
+///
+/// let bytes = dora_message::encode(&NodeExitStatus::ExitCode(1))?;
+/// let decoded: NodeExitStatus = dora_message::decode(&bytes)?;
+/// assert!(!decoded.is_success());
+/// # Ok(())
+/// # }
+/// ```
 pub fn encode<T: serde::Serialize>(value: &T) -> postcard::Result<Vec<u8>> {
     encode_presized(value, 0)
 }


### PR DESCRIPTION
## What

Fills documentation gaps in the public API of `libraries/message` (which, unlike the node crate, does not enforce `#[warn(missing_docs)]`).

## Why

Several user-facing public items in `dora-message` had no documentation at all:

- **`LogMessage`** is the record delivered to `dora/logs` subscribers — the shape log-consuming nodes and tooling read — yet had no struct-level or field-level docs.
- **`NodeExitStatus`** and its variants (`Success`/`IoError`/`ExitCode`/`Signal`/`Unknown`) were undocumented, despite surfacing to users inspecting node/dataflow results.
- **`encode`/`decode`** are the two wire-format entry points; `encode` had prose but no example.
- **`DataMessage::is_empty`** lacked the one-line doc its sibling `len` already carries.

## The change

- Document the `LogMessage` struct and every public field (provenance/routing context + the message itself).
- Document `NodeExitStatus`, its variants, and add a **compile-checked doctest** to `is_success`.
- Add a `# Example` to `encode` demonstrating an `encode` → `decode` round-trip through a real public type (`NodeExitStatus`). It is compile-checked and run by `cargo test --doc`, so it guards the round-trip against drift.
- Add the missing one-line doc to `DataMessage::is_empty`.

Docs-only change: no public item is added, removed, renamed, or re-typed, so no wire format or API surface moves (the breaking-change / semver gate is unaffected).

## Validation

- `cargo test -p dora-message --doc` → new `encode` and `NodeExitStatus::is_success` doctests pass (17 passed, 0 failed)
- `cargo test -p dora-message` → all tests pass
- `cargo clippy -p dora-message --all-targets -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean

---

⚠️ **This is a machine-generated PR** produced by an automated Claude Code codebase-review run. No human authored or vetted the change beyond the automated checks above; please review with that in mind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrQPm6Vv8TobE2r3Bes7Q8

---
_Generated by [Claude Code](https://claude.ai/code/session_01HrQPm6Vv8TobE2r3Bes7Q8)_