### PR TITLE
refactor(daemon): collapse stderr marker scans to Iterator::any

### DIFF
--- a/binaries/daemon/src/extract_err_from_stderr.rs
+++ b/binaries/daemon/src/extract_err_from_stderr.rs
@@ -61,10 +61,8 @@ impl StderrMatcher {
             "Traceback (most recent call last):",
         ];
 
-        for marker in MARKERS.iter() {
-            if line.starts_with(marker) {
-                return true;
-            }
+        if MARKERS.iter().any(|marker| line.starts_with(marker)) {
+            return true;
         }
 
         if line.starts_with("SyntaxError: ") {
@@ -87,13 +85,9 @@ impl StderrMatcher {
         // common non-error log lines
         const NEGATIVE_MARKERS: &[&str] = &["Warning:"];
 
-        for marker in NEGATIVE_MARKERS.iter() {
-            if line.starts_with(marker) {
-                return true;
-            }
-        }
-
-        false
+        NEGATIVE_MARKERS
+            .iter()
+            .any(|marker| line.starts_with(marker))
     }
 }
 


### PR DESCRIPTION
## What

A small, self-contained readability cleanup in `binaries/daemon/src/extract_err_from_stderr.rs`.

## The change

`StderrMatcher::is_error_start_marker` and `is_negative_marker` each hand-rolled a marker scan:

```rust
for marker in MARKERS.iter() {
    if line.starts_with(marker) {
        return true;
    }
}
```

Both are exactly `MARKERS.iter().any(|m| line.starts_with(m))`. `is_negative_marker`'s entire body collapses to that single expression; `is_error_start_marker`'s first block becomes a one-line guard while the rest of its logic is untouched.

## Why it's safe

`Iterator::any` short-circuits on the first match just like the loop did, and the marker order is unchanged, so the boolean result is identical for every input. This is a readability-only change with no behavioral difference.

## Validation

- `cargo test -p dora-daemon extract_err_from_stderr` → 15 passed, 0 failed (the module's existing suite)
- `cargo clippy -p dora-daemon --all-targets -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean

---

⚠️ **This is a machine-generated PR** produced by an automated Claude Code codebase-review run. No human authored or vetted the change beyond the automated checks above; please review with that in mind. This is a minor cleanup — feel free to close if it isn't worth the churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrQPm6Vv8TobE2r3Bes7Q8

---
_Generated by [Claude Code](https://claude.ai/code/session_01HrQPm6Vv8TobE2r3Bes7Q8)_