### PR TITLE
feat(node-cxx)!: let a C++ node see that a node restarted

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking
+
+- **`DoraEventType` has a new `NodeRestarted` variant** ([#3046](https://github.com/dora-rs/dora/issues/3046)). A restart of an upstream node reached C++ as `Unknown`, so a node could not reset state, resend work it had in flight, or even tell that anything had happened. It now arrives as `DoraEventType::NodeRestarted`, with `event_as_node_restarted(event)` returning the restarted node's id. This changes what existing C++ nodes see: a `switch` over `DoraEventType` without a `default` arm stops compiling under `-Werror=switch`. Add a `default`, or handle the new variant.
+
 ### Fixed
 
 - **A `queue_policy: backpressure` input is no longer discarded by a timer flood** ([#3428](https://github.com/dora-rs/dora/issues/3428)). The direct node-to-node zenoh path hands each message to the receiver with a non-blocking send into one ingress channel shared by all of the receiver's inputs, so a fast timer could fill that channel while the receiver was busy and the next backpressure message was dropped before the per-input policy saw it. Any output with a `backpressure` consumer now stays on the daemon path, whose delivery into that channel blocks instead of dropping. This costs the whole output its zero-copy path and puts it under the daemon's 64 MiB per-message limit; the daemon path remains a bounded buffer, not a guarantee (see `docs/yaml-spec.md`). `dora node add`/`replace` now refuse a `backpressure` input whose producer is already running with the output on the direct path, since a running producer cannot be re-routed. `dora replay` marks every unset input `backpressure`, so replay dataflows run on the daemon path.

--- a/apis/c++/node/README.md
+++ b/apis/c++/node/README.md
@@ -250,6 +250,13 @@ The `event` field also carries a matching `DoraEventType` (`Timeout` /
 `server_node_id` yields `DoraPatternStatus::InvalidArgument` rather than
 aborting the process.
 
+`ServerRestarted` is reported for a restart that lands while a wait is
+running, because the correlation is reading the stream then. One that lands
+between calls reaches your own loop as `DoraEventType::NodeRestarted` (use
+`event_as_node_restarted` for the id). Ignore it and the next request will
+wait out its whole deadline against a server you had already been told had
+restarted.
+
 The server must echo the request's `request_id` back, which is why it needs
 `event_as_input_with_metadata`:
 

--- a/apis/c++/node/src/lib.rs
+++ b/apis/c++/node/src/lib.rs
@@ -65,6 +65,14 @@ mod ffi {
         /// exists so C++ nodes can react to reloads (e.g. flushing
         /// caches) rather than treating them as `Unknown`.
         Reload,
+        /// An upstream node restarted after a failure. Use
+        /// `event_as_node_restarted` for its id.
+        ///
+        /// Same reason as `Reload`: without a variant of its own this
+        /// arrived as `Unknown`, so a C++ node could not reset state or
+        /// re-send work it had in flight, and could not even tell that
+        /// anything had happened.
+        NodeRestarted,
     }
 
     struct DoraInput {
@@ -225,6 +233,12 @@ mod ffi {
         fn event_as_input_with_metadata(event: Box<DoraEvent>) -> Result<DoraInputWithMetadata>;
         /// Extract the failure payload from a `NodeFailed` event.
         fn event_as_node_failed(event: Box<DoraEvent>) -> Result<DoraNodeFailed>;
+        /// Id of the node that restarted, for a `NodeRestarted` event.
+        ///
+        /// Errors for any other event, so a caller that branched on
+        /// `event_type` wrongly is told rather than handed something
+        /// plausible.
+        fn event_as_node_restarted(event: Box<DoraEvent>) -> Result<String>;
         /// Selectively close one or more of this node's outputs without
         /// shutting the whole node down. Subsequent downstream
         /// subscribers see the corresponding `InputClosed` event.
@@ -623,6 +637,7 @@ fn event_type(event: &DoraEvent) -> ffi::DoraEventType {
             Event::Error(_) => ffi::DoraEventType::Error,
             Event::NodeFailed { .. } => ffi::DoraEventType::NodeFailed,
             Event::Reload { .. } => ffi::DoraEventType::Reload,
+            Event::NodeRestarted { .. } => ffi::DoraEventType::NodeRestarted,
             _ => ffi::DoraEventType::Unknown,
         },
         EventOrReason::Closed => ffi::DoraEventType::AllInputsClosed,
@@ -695,6 +710,14 @@ fn event_as_node_failed(event: Box<DoraEvent>) -> eyre::Result<ffi::DoraNodeFail
         error,
         source_node_id: source_node_id.to_string(),
     })
+}
+
+#[allow(clippy::boxed_local)] // `Box<DoraEvent>` is mandated by the cxx bridge signature.
+fn event_as_node_restarted(event: Box<DoraEvent>) -> eyre::Result<String> {
+    let EventOrReason::Event(Event::NodeRestarted { id }) = event.0 else {
+        bail!("not a NodeRestarted event");
+    };
+    Ok(id.to_string())
 }
 
 /// Parse a caller-supplied output id via `FromStr` instead of the panicking
@@ -2152,6 +2175,36 @@ mod tests {
             log.error.contains("poisoned"),
             "non-send node operations must fail-stop as well: {}",
             log.error
+        );
+    }
+
+    /// A restart must reach C++ as itself, not as `Unknown`.
+    ///
+    /// Without this the event still arrived — it simply could not be
+    /// identified, so a node had no way to reset state or resend work,
+    /// and no way to know anything had happened at all.
+    #[test]
+    fn a_node_restart_is_reported_as_itself_not_unknown() {
+        let event = Box::new(DoraEvent(EventOrReason::Event(Event::NodeRestarted {
+            id: dora_node_api::dora_core::config::NodeId::from("calc".to_string()),
+        })));
+        assert!(matches!(
+            event_type(&event),
+            ffi::DoraEventType::NodeRestarted
+        ));
+
+        let id = event_as_node_restarted(event).expect("a NodeRestarted event carries its id");
+        assert_eq!(id, "calc");
+    }
+
+    #[test]
+    fn event_as_node_restarted_rejects_other_events() {
+        let event = Box::new(DoraEvent(EventOrReason::Event(Event::Stop(
+            dora_node_api::StopCause::Manual,
+        ))));
+        assert!(
+            event_as_node_restarted(event).is_err(),
+            "a caller that branched wrongly must be told, not handed a plausible id"
         );
     }
 }


### PR DESCRIPTION
**1 of 4** — splitting #3047 as requested in [its review](https://github.com/dora-rs/dora/pull/3047#issuecomment-5602533090). Independent of the other three; this one can land on its own.

A restart of an upstream node reached C++ as `DoraEventType::Unknown`. The event arrived — it simply could not be identified, so a node had no way to reset state, resend work it had in flight, or even tell that anything had happened.

`DoraEventType::NodeRestarted` names it, and `event_as_node_restarted` returns the restarted node's id, erroring for any other event so a caller that branched wrongly is told rather than handed a plausible id.

This matters to the correlated receives in particular. They report `ServerRestarted` for a restart that lands *while a wait is running*, because the correlation owns the stream then. One that lands between calls arrives as this event instead, and a client that ignores it waits out the next request's whole deadline against a server it had already been told was gone.

### Breaking

A `switch` over `DoraEventType` without a `default` arm stops compiling under `-Werror=switch`. Add a `default`, or handle the new variant. Noted in `Changelog.md`.

### Verification

`cargo test -p dora-node-api-cxx` — 21 passed, including two new tests covering the happy path and the wrong-event rejection. `cargo fmt --check` and `cargo clippy -- -D warnings` clean.

Refs #3046.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
