### PR TITLE
fix(daemon): contain pre-`init` orphans on a hard-killed `dora run` (#3473)

### DIFF
--- a/apis/rust/node/src/orphan_guard.rs
+++ b/apis/rust/node/src/orphan_guard.rs
@@ -27,23 +27,27 @@
 //! interpreter behind — the same orphan, one level down — so the guard signals
 //! the group, exactly as the daemon's own reaper does.
 //!
-//! # Why not `PR_SET_PDEATHSIG`
+//! # The daemon's pre-`init` complement (`PR_SET_PDEATHSIG`)
 //!
-//! Linux can ask the kernel to signal a child when its parent dies, which
-//! needs no thread and covers a node that is killed before it reaches `init`.
-//! It is not enough on its own, and it is not free:
+//! This guard only covers a node from `init` onwards, so the daemon closes the
+//! window *before* `init` from its side: on Linux, on the same `dora run` spawn
+//! path, it asks the kernel to `SIGKILL` the spawned child when its parent (the
+//! `dora run` process) dies (dora-rs/dora#3473). That needs no dora code in the
+//! child, so it also covers a `path: shell` node that never runs any
+//! (dora-rs/dora#3472).
+//!
+//! It is a complement, not the mechanism, because it is neither complete nor
+//! free:
 //!
 //! - It reaches only the *direct* child. Under `--uv` that child is `uv run
-//!   python ...` and the node is one level down, so the interpreter is left
-//!   exactly as orphaned as before — the shape this issue was reported for.
+//!   python ...` and the node is one level down, so the interpreter is covered
+//!   only once *it* reaches `init` and this guard takes over.
 //! - It fires when the parent **thread** exits, not the parent process. The
-//!   daemon spawns from a tokio worker thread, so the guarantee is only as
-//!   stable as which thread happened to run the spawn — a spawn moved behind
-//!   `spawn_blocking` would start killing nodes early, silently.
-//! - It is Linux-only, and the report is from macOS.
-//!
-//! It remains a reasonable *complement* for the pre-`init` window (see
-//! "Coverage" below); it is not the mechanism.
+//!   daemon spawns from a tokio worker thread, so past `init` — where a healthy
+//!   node may live for hours — the poll guard below is the safer owner. This
+//!   module therefore clears the signal (see [`clear_parent_death_signal`]) the
+//!   moment that guard is running, bounding the fragile window to startup.
+//! - It is Linux-only; on macOS the pre-`init` window remains a gap.
 //!
 //! # Why `SIGKILL` rather than a `SIGTERM` grace period first
 //!
@@ -55,11 +59,13 @@
 //!
 //! # Coverage
 //!
-//! A node is guarded from [`DoraNode::init`][crate::DoraNode::init] onwards, so
-//! two gaps remain. A process killed *before* it gets there — a Python node
-//! still in `import torch`, a `uv run` still resolving dependencies — is
-//! orphaned as before. And a node that never calls `init` at all (a `path:
-//! shell` command) is never guarded, because nothing of dora's runs in it.
+//! This guard owns the window from [`DoraNode::init`][crate::DoraNode::init]
+//! onwards. The pre-`init` window — a Python node still in `import torch`, a
+//! `uv run` still resolving dependencies, a `path: shell` command that never
+//! runs any dora code — is covered on Linux by the daemon's `PR_SET_PDEATHSIG`
+//! (above), with two residual gaps: on macOS, which has no `PDEATHSIG`
+//! equivalent, and the interpreter under a `--uv` wrapper, which the signal
+//! reaches only once that interpreter reaches `init` here.
 //!
 //! Unix only; on Windows this module compiles to a no-op and the gap remains.
 //! Windows has no process groups in this sense, so a node cannot contain its
@@ -129,15 +135,51 @@ fn arm(parent: u32) {
                 }
             }
         });
-    if let Err(err) = spawned {
-        // Not fatal: the node works, it just loses the guarantee. Say so, since
-        // the symptom otherwise only appears much later as a stranded process.
-        warn(&format!(
-            "failed to start the orphan guard ({err}); this node may outlive a \
-             killed `dora run`"
-        ));
+    match spawned {
+        Ok(_handle) => {
+            // The poll guard now owns containment for this process's whole
+            // lifetime, and it is robust where the daemon's spawn-time
+            // `PR_SET_PDEATHSIG` is not: it tracks the parent *process* rather
+            // than the spawning thread, and re-derives its decision every
+            // interval. Drop that pre-`init` signal now so a healthy, long-lived
+            // node can never be SIGKILLed early were the daemon's spawning thread
+            // to exit (dora-rs/dora#3473). A no-op when it was never set: a
+            // wrapped node (`uv run python`) is a fork of the daemon's direct
+            // child, and `PDEATHSIG` is cleared across `fork`.
+            clear_parent_death_signal();
+        }
+        Err(err) => {
+            // Not fatal: the node works, it just loses the guarantee. Say so,
+            // since the symptom otherwise only appears much later as a stranded
+            // process. The daemon's `PR_SET_PDEATHSIG` is deliberately left armed
+            // here as the remaining fallback.
+            warn(&format!(
+                "failed to start the orphan guard ({err}); this node may outlive a \
+                 killed `dora run`"
+            ));
+        }
     }
 }
+
+/// Drop the parent-death signal the daemon set for the pre-`init` window.
+///
+/// The daemon arms `PR_SET_PDEATHSIG` at spawn so a node killed before it
+/// reaches [`arm_if_run_child`] is still contained (dora-rs/dora#3473). Once the
+/// poll guard is running that signal is not merely redundant but a liability —
+/// it fires on the death of the daemon *thread* that spawned this node, not the
+/// daemon process — so the guard drops it and contains the node alone.
+#[cfg(target_os = "linux")]
+fn clear_parent_death_signal() {
+    // SAFETY: `prctl` is async-signal-safe and this only clears this process's
+    // own parent-death setting.
+    unsafe {
+        libc::prctl(libc::PR_SET_PDEATHSIG, 0 as libc::c_ulong);
+    }
+}
+
+/// No parent-death signal is set outside Linux, so there is nothing to clear.
+#[cfg(all(unix, not(target_os = "linux")))]
+fn clear_parent_death_signal() {}
 
 /// What this node will do once `parent` is gone, decided while the parent is
 /// still alive and therefore still inspectable.

--- a/binaries/daemon/src/spawn/prepared.rs
+++ b/binaries/daemon/src/spawn/prepared.rs
@@ -690,6 +690,74 @@ impl PreparedNode {
                     }
                 }
 
+                // Close the pre-`init` orphan window on Linux (dora-rs/dora#3473).
+                //
+                // The in-node orphan guard (`apis/rust/node/src/orphan_guard.rs`)
+                // only arms once the node reaches `DoraNode::init`. A node
+                // SIGKILL-orphaned before that — a Python node still in `import
+                // torch`, a `path: shell` command that never runs any dora code
+                // (dora-rs/dora#3472) — is stranded with `ppid 1` exactly as
+                // before #3018. Ask the kernel to SIGKILL the child when its
+                // parent (this in-process `dora run` daemon) dies, which needs no
+                // dora code in the child and so covers that window.
+                //
+                // Gated on the same signal as the in-node guard: the presence of
+                // `DORA_RUN_PARENT_PID`, set only on the in-process `dora run` /
+                // `Daemon::run_dataflow` spawn path (`bind_nodes_to_parent`). The
+                // coordinator-attached path (`dora up` + `dora start`) must inject
+                // nothing, so a daemon restart does not take its nodes down
+                // (dora-rs/dora#2029, `tests/daemon-reconnect-e2e.rs`).
+                //
+                // Bounded on purpose: `PR_SET_PDEATHSIG` keys off the parent
+                // *thread*, and reaches only the direct child (under `--uv` that
+                // is the `uv` wrapper, not the interpreter). It is a complement
+                // for the startup window, never the post-`init` mechanism — the
+                // node clears it and hands over to the poll guard at `init`.
+                #[cfg(target_os = "linux")]
+                {
+                    use std::os::unix::process::CommandExt as _;
+
+                    let run_parent_pid: Option<libc::pid_t> = std_command
+                        .get_envs()
+                        .find(|(key, _)| {
+                            *key == std::ffi::OsStr::new(dora_core::topics::DORA_RUN_PARENT_PID_ENV)
+                        })
+                        .and_then(|(_, value)| value)
+                        .and_then(|value| value.to_str())
+                        .and_then(|value| value.trim().parse::<libc::pid_t>().ok());
+
+                    if let Some(parent) = run_parent_pid {
+                        // SAFETY: `prctl`, `getppid` and `_exit` are all
+                        // async-signal-safe, so they are sound to call in the
+                        // forked child before `exec`; the closure allocates
+                        // nothing and captures only a `Copy` pid.
+                        unsafe {
+                            std_command.pre_exec(move || {
+                                let ret = libc::prctl(
+                                    libc::PR_SET_PDEATHSIG,
+                                    libc::SIGKILL as libc::c_ulong,
+                                );
+                                // Best effort: a failure here only loses the
+                                // pre-`init` cover, and the in-node poll guard
+                                // still contains the node once it reaches `init`.
+                                if ret != 0 {
+                                    return Ok(());
+                                }
+                                // Close the fork/prctl race: if the parent already
+                                // died in the window between `fork` and the line
+                                // above, `PDEATHSIG` will never fire (the death it
+                                // waits for has passed), so this child would be the
+                                // very orphan the signal exists to prevent. A
+                                // reparented child reads a different `getppid`.
+                                if libc::getppid() != parent {
+                                    libc::_exit(0);
+                                }
+                                Ok(())
+                            });
+                        }
+                    }
+                }
+
                 let mut command = CommandWrap::from(tokio::process::Command::from(std_command));
 
                 #[cfg(unix)]

--- a/tests/fault_tolerance/sigterm_ignoring_node/src/main.rs
+++ b/tests/fault_tolerance/sigterm_ignoring_node/src/main.rs
@@ -39,19 +39,27 @@ fn main() -> eyre::Result<()> {
         std::io::Error::last_os_error()
     );
 
+    // Optional pre-`init` sleep, for the pre-`init` orphan test
+    // (dora-rs/dora#3473). When set, publish the pid FIRST — nothing of dora
+    // runs yet, so writing the pid file is the only way the test can find this
+    // process during the window — then sleep before ever reaching `init`. The
+    // in-node poll guard has not armed here, so the ONLY thing that can contain
+    // a hard-killed `dora run`'s node in this window is the daemon's spawn-time
+    // `PR_SET_PDEATHSIG`, which is exactly what that test exercises.
+    let preinit_sleep = std::env::var("DORA_TEST_PREINIT_SLEEP_SECS")
+        .ok()
+        .and_then(|secs| secs.trim().parse::<u64>().ok());
+    if let Some(secs) = preinit_sleep {
+        publish_pid()?;
+        thread::sleep(Duration::from_secs(secs));
+    }
+
     let (_node, _events) = DoraNode::init_from_env()?;
 
-    // Publish our pid so the test can assert on THIS process rather than
-    // pattern-matching the process table, which would also catch a
-    // leftover from an earlier run and report a false failure.
-    //
-    // Written to a temp path and renamed, so a reader polling for the
-    // file can never observe a half-written pid and parse it as a
-    // different, valid-looking process.
-    if let Ok(path) = std::env::var("DORA_TEST_PID_FILE") {
-        let tmp = format!("{path}.tmp");
-        std::fs::write(&tmp, std::process::id().to_string())?;
-        std::fs::rename(&tmp, &path)?;
+    // The default path (no pre-`init` sleep) publishes only after `init`, so the
+    // #2856 / #2920 tests still observe a fully started node before they signal.
+    if preinit_sleep.is_none() {
+        publish_pid()?;
     }
 
     // Never read `_events`, so the cooperative Stop cannot be honored
@@ -65,6 +73,23 @@ fn main() -> eyre::Result<()> {
     // the test kills this process group on every exit path.
     for _ in 0..600 {
         thread::sleep(Duration::from_millis(500));
+    }
+    Ok(())
+}
+
+/// Publish our pid so the test can assert on THIS process rather than
+/// pattern-matching the process table, which would also catch a leftover from
+/// an earlier run and report a false failure.
+///
+/// Written to a temp path and renamed, so a reader polling for the file can
+/// never observe a half-written pid and parse it as a different,
+/// valid-looking process.
+#[cfg(unix)]
+fn publish_pid() -> eyre::Result<()> {
+    if let Ok(path) = std::env::var("DORA_TEST_PID_FILE") {
+        let tmp = format!("{path}.tmp");
+        std::fs::write(&tmp, std::process::id().to_string())?;
+        std::fs::rename(&tmp, &path)?;
     }
     Ok(())
 }

--- a/tests/node-lifecycle-e2e.rs
+++ b/tests/node-lifecycle-e2e.rs
@@ -2361,6 +2361,56 @@ fn run_killed_by_sigkill_does_not_orphan_nodes() {
     }
 }
 
+/// dora-rs/dora#3473: a node SIGKILL-orphaned BEFORE it reaches
+/// `DoraNode::init` must not survive a hard-killed `dora run` either.
+///
+/// The sibling test above covers a node killed once it is up and guarded from
+/// inside. This one covers the window before that guard arms: the fixture
+/// publishes its pid and then sleeps — never reaching `init`, so nothing of
+/// dora runs in it — while `dora run` is SIGKILLed during that sleep. The only
+/// thing that can contain it here is the daemon's spawn-time `PR_SET_PDEATHSIG`.
+///
+/// Linux-only: `PR_SET_PDEATHSIG` is the mechanism, and macOS has no
+/// equivalent, so the pre-`init` window stays a documented gap there.
+#[test]
+#[cfg(target_os = "linux")]
+fn run_killed_before_node_init_does_not_orphan() {
+    let _guard = LIFECYCLE_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+    // The pre-`init` sleep (120s) is deliberately far longer than the 30s
+    // teardown deadline below: without containment the node is still sleeping --
+    // alive and detectable -- when the deadline passes, so an unfixed daemon
+    // fails this test rather than passing because the node happened to exit on
+    // its own (e.g. a later `init` that can no longer reach the dead daemon).
+    let mut run = StubbornRun::start_preinit("dora-3473-preinit-orphan", true, 120);
+    let node_pid = run.wait_for_node();
+
+    let killed = Command::new("kill")
+        .args(["-KILL", &run.cli.id().to_string()])
+        .status()
+        .expect("failed to run `kill`");
+    // Checked: an undelivered signal would make the wait below time out and
+    // report an orphan that was never actually orphaned.
+    assert!(killed.success(), "failed to SIGKILL `dora run`");
+    let status = run.cli.wait().expect("failed to reap `dora run`");
+    run.cli_reaped = true;
+
+    // `PR_SET_PDEATHSIG` lands the SIGKILL essentially the moment the parent
+    // dies; 30s is slack for a loaded runner while still bounding it, and is
+    // well inside the fixture's 120s pre-`init` sleep.
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    while node_is_fixture(node_pid) {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "node {node_pid} outlived a SIGKILLed `dora run` ({status}) by 30s while \
+             still before `init`: the pre-`init` orphan window is unguarded \
+             (#3473)\nstderr tail:\n{}",
+            run.stderr_tail()
+        );
+        std::thread::sleep(Duration::from_millis(250));
+    }
+}
+
 /// A `dora run` of the stubborn fixture, plus the RAII teardown both orphan
 /// tests need.
 ///
@@ -2427,6 +2477,22 @@ impl StubbornRun {
     /// will not look, and the failure would surface later as a misleading "node
     /// never reported its pid".
     fn start(prefix: &str, own_process_group: bool) -> Self {
+        Self::start_with(prefix, own_process_group, None)
+    }
+
+    /// Like [`Self::start`], but the fixture sleeps `preinit_sleep_secs` seconds
+    /// **before** it reaches `DoraNode::init` — the pre-`init` orphan window
+    /// (dora-rs/dora#3473), where the in-node poll guard has not armed yet.
+    ///
+    /// The sleep must outlast the test's teardown deadline, so a node that is
+    /// NOT contained is still alive (and detectably so) when the deadline
+    /// passes, rather than exiting on its own once the sleep ends.
+    #[cfg(target_os = "linux")]
+    fn start_preinit(prefix: &str, own_process_group: bool, preinit_sleep_secs: u64) -> Self {
+        Self::start_with(prefix, own_process_group, Some(preinit_sleep_secs))
+    }
+
+    fn start_with(prefix: &str, own_process_group: bool, preinit_sleep_secs: Option<u64>) -> Self {
         use std::os::unix::process::CommandExt as _;
 
         ensure_cli_built();
@@ -2452,18 +2518,28 @@ impl StubbornRun {
         }
         let scratch = |ext: &str| target.join(format!("{prefix}-{}.{ext}", std::process::id()));
         let (yaml, pid_file, log) = (scratch("yml"), scratch("pid"), scratch("log"));
+        // Optional pre-`init` sleep, injected as a sibling `env:` entry of
+        // `DORA_TEST_PID_FILE` (six-space indent, under the node's `env:`).
+        let preinit_env = match preinit_sleep_secs {
+            Some(secs) => format!("      DORA_TEST_PREINIT_SLEEP_SECS: \"{secs}\"\n"),
+            None => String::new(),
+        };
         fs::write(
             &yaml,
             format!(
-                "nodes:\n  \
-                 - id: stubborn\n    \
-                   path: \"{node}\"\n    \
-                   env:\n      \
-                     DORA_TEST_PID_FILE: \"{pid_file}\"\n    \
-                   inputs:\n      \
-                     tick: dora/timer/millis/100\n",
+                concat!(
+                    "nodes:\n",
+                    "  - id: stubborn\n",
+                    "    path: \"{node}\"\n",
+                    "    env:\n",
+                    "      DORA_TEST_PID_FILE: \"{pid_file}\"\n",
+                    "{preinit_env}",
+                    "    inputs:\n",
+                    "      tick: dora/timer/millis/100\n",
+                ),
                 node = target.join("debug/sigterm-ignoring-node").display(),
                 pid_file = pid_file.display(),
+                preinit_env = preinit_env,
             ),
         )
         .expect("failed to write dataflow yaml");


### PR DESCRIPTION
Closes #3473.

## Problem

The in-node orphan guard (`apis/rust/node/src/orphan_guard.rs`, from #3018) only arms once a node reaches `DoraNode::init`. A node SIGKILL-orphaned **before** that is stranded with `ppid 1`, exactly as before #3018:

- a Python node still in `import torch` / `import cv2`,
- `uv run python …` still resolving or installing dependencies,
- any node doing real work (model download, device open) before `Node()` / `DoraNode::init`.

## Fix

Close the window from the daemon side on Linux, on the same `dora run` / in-process `Daemon::run_dataflow` spawn path (`binaries/daemon/src/spawn/prepared.rs`):

- In a `pre_exec` hook on the spawned child, `prctl(PR_SET_PDEATHSIG, SIGKILL)` so the kernel SIGKILLs the child when its parent (the in-process `dora run` daemon) dies. This needs **no dora code in the child**, so it covers the pre-`init` window — and `path: shell` nodes (#3472) — for free.
- Paired with a post-`prctl` `getppid()` check to close the fork/prctl race (the parent dying in the window between `fork` and the signal being armed, where `PDEATHSIG` would otherwise never fire).

Gated on the presence of `DORA_RUN_PARENT_PID` — the same `bind_nodes_to_parent` signal the in-node guard already keys off — so the coordinator-attached path (`dora up` + `dora start`) injects nothing and a daemon restart still does **not** take its nodes down (#2029, `tests/daemon-reconnect-e2e.rs`).

`PR_SET_PDEATHSIG` keys off the parent **thread**, not the process, and reaches only the **direct** child. It is therefore a startup-window *complement*, never the post-`init` mechanism. So the node clears it the moment its poll guard is running (`clear_parent_death_signal` in `orphan_guard.rs`), bounding the fragile window to startup and handing a healthy, long-lived node back to the robust process-pid poll guard.

## Scope and remaining gaps (documented)

- **macOS**: no `PDEATHSIG` equivalent — the pre-`init` window stays a gap there (out of scope for this PR, needs a `kqueue`-based follow-up).
- **`--uv` wrapper**: the direct child is the `uv` wrapper; the interpreter one level down is covered only once *it* reaches `init` and takes over. Killing the wrapper is what the issue's Direction accepts.
- **Windows** (#3474): unaffected — Job-Object containment is a separate change that needs a Windows runner.

## Tests

New `#[cfg(target_os = "linux")]` e2e in `tests/node-lifecycle-e2e.rs`: `run_killed_before_node_init_does_not_orphan`. The fixture (`sigterm-ignoring-node`, extended with an optional pre-`init` sleep via `DORA_TEST_PREINIT_SLEEP_SECS`) publishes its pid and then sleeps 120 s **before** `init`; the test `kill -9`s `dora run` during that window and asserts the node is gone within 30 s. The sleep is deliberately far longer than the deadline so an unfixed daemon fails rather than passing because the node exited on its own.

## Validation (local, Linux, rustc 1.97.1)

- `cargo fmt --all -- --check` ✓
- `cargo clippy -p dora-daemon -p dora-node-api -p sigterm-ignoring-node --all-targets -- -D warnings` ✓
- `cargo test -p dora-node-api --lib orphan_guard` ✓ (2 passed)
- `cargo test -p dora-daemon --lib` ✓ (270 passed)
- `cargo test --test node-lifecycle-e2e does_not_orphan` ✓ (2 passed — the new pre-`init` test and the existing #2856 SIGKILL test)

macOS/Windows paths are unchanged and remain nightly's job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxMTc5TFz6NME4Htsncops

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxMTc5TFz6NME4Htsncops)_