### PR TITLE
docs(message): document Metadata::parameters and add a usage doctest

### DIFF
--- a/libraries/message/src/metadata.rs
+++ b/libraries/message/src/metadata.rs
@@ -8,10 +8,44 @@ use serde::{Deserialize, Serialize};
 /// Includes a timestamp and additional user-provided parameters. The payload is
 /// a self-describing Arrow IPC stream, so the message carries no separate type
 /// descriptor.
+///
+/// A node receives a `Metadata` alongside every input. The [`timestamp`] and
+/// [`metadata_version`] are read through accessors, while [`parameters`] — the
+/// user-provided key/value pairs — is a public field read and written directly.
+///
+/// [`timestamp`]: Self::timestamp
+/// [`metadata_version`]: Self::metadata_version
+/// [`parameters`]: Self::parameters
+///
+/// # Examples
+///
+/// ```
+/// use dora_message::metadata::{get_integer_param, Metadata, Parameter};
+///
+/// let timestamp = uhlc::HLC::default().new_timestamp();
+/// let mut metadata = Metadata::new(timestamp);
+///
+/// // A fresh `Metadata` carries the current wire-format version and no
+/// // user parameters.
+/// assert_eq!(metadata.metadata_version(), Metadata::CURRENT_VERSION);
+/// assert!(metadata.parameters.is_empty());
+///
+/// // Attach a typed parameter and read it back with the matching getter.
+/// metadata
+///     .parameters
+///     .insert("frame".to_string(), Parameter::Integer(7));
+/// assert_eq!(get_integer_param(&metadata.parameters, "frame"), Some(7));
+/// ```
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Metadata {
     metadata_version: u16,
     timestamp: uhlc::Timestamp,
+    /// User-provided key/value parameters carried alongside the payload.
+    ///
+    /// A [`BTreeMap`] of [`Parameter`] values keyed by name. Read the common
+    /// scalar cases through the type-checked [`get_string_param`],
+    /// [`get_integer_param`], and [`get_bool_param`] helpers rather than
+    /// matching on the [`Parameter`] variant directly.
     pub parameters: MetadataParameters,
 }
 


### PR DESCRIPTION
## Issue

`Metadata` is the type a node receives alongside **every** input, and `parameters` is its one public field — the user-provided key/value pairs that nodes read and write directly (the accessors only cover `timestamp` / `metadata_version` / OTel context). That field carried **no doc comment**, and the struct had **no usage example**. The one existing metadata doctest lives on `Parameter` and operates on a bare `MetadataParameters` map, not on a `Metadata` — so nothing showed how to reach `.parameters` from the `Metadata` a handler actually holds.

## Fix

Documentation-only change to `libraries/message/src/metadata.rs`:

- Add a `# Examples` doctest to the `Metadata` struct showing construction via `Metadata::new`, the freshly-stamped `CURRENT_VERSION`, and inserting/reading back a typed `Parameter` through the type-checked `get_integer_param` helper.
- Document the `parameters` field, pointing at the `get_*_param` helpers as the preferred way to read the common scalar cases.
- A short struct-doc sentence distinguishing the accessor-read fields from the directly-accessed public `parameters`.

No API surface change; no behavior change.

## Validation

Scoped to the only affected crate (`dora-message`), since the change is pure rustdoc:

- `cargo test -p dora-message --doc` → 16 passed, including the new `metadata::Metadata` doctest
- `cargo test -p dora-message --lib` → 167 passed
- `cargo clippy -p dora-message --all-targets -- -D warnings` → clean
- `cargo fmt -p dora-message -- --check` → clean
- `cargo doc -p dora-message --no-deps` → no new warnings; all intra-doc links added by this diff resolve (the 6 warnings emitted are pre-existing and in unchanged files)

---

⚠️ **This pull request was generated by an automated Claude Code review run — it is machine-generated and has not been vetted by a human. A maintainer should review before merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fpxiAAXtYQV5Ub4XqiZiT

---
_Generated by [Claude Code](https://claude.ai/code/session_012fpxiAAXtYQV5Ub4XqiZiT)_