### PR TITLE
fix(ros2-bridge): make msg-gen comment stripping string-literal-aware (#3460)

### DIFF
--- a/libraries/extensions/ros2-bridge/msg-gen/src/parser/message.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/parser/message.rs
@@ -10,6 +10,90 @@ fn split_once(s: &'_ str, pat: char) -> (&'_ str, Option<&'_ str>) {
     (items.next().unwrap(), items.next())
 }
 
+/// Byte index of the first occurrence of `target` that lies outside any
+/// single- or double-quoted string, or `None` if there is none.
+///
+/// Quoting follows the ROS 2 message-format string literals parsed by
+/// [`super::literal`]: a `"` or `'` opens a string that runs until the matching
+/// closing quote, and a backslash escapes the next byte (so `\"` does not close
+/// a double-quoted string). `target`, the quote characters and the backslash
+/// are all ASCII, and multi-byte UTF-8 continuation bytes never collide with
+/// them, so the returned index is always on a `char` boundary.
+fn find_unquoted(s: &str, target: u8) -> Option<usize> {
+    let bytes = s.as_bytes();
+    let mut quote: Option<u8> = None;
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        match quote {
+            Some(q) => {
+                if c == b'\\' {
+                    i += 1; // skip the escaped byte
+                } else if c == q {
+                    quote = None;
+                }
+            }
+            None => {
+                if c == target {
+                    return Some(i);
+                }
+                if c == b'"' || c == b'\'' {
+                    quote = Some(c);
+                }
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Whether `type_token` names a ROS `string`/`wstring` type in any of its forms
+/// (`string`, `wstring`, the bounded `string<=N` / `wstring<=N`, and the array /
+/// sequence variants such as `string[3]` or `wstring<=5[]`).
+///
+/// Only these lead to a value whose text may legally contain a `#` outside of
+/// quotes, so the check is deliberately exact: a custom message type whose name
+/// merely starts with `string` (e.g. `stringlike`) must not match.
+fn is_string_type(type_token: &str) -> bool {
+    ["string", "wstring"].iter().any(|base| {
+        type_token
+            .strip_prefix(base)
+            .is_some_and(|rest| rest.is_empty() || rest.starts_with('<') || rest.starts_with('['))
+    })
+}
+
+/// Strip a trailing `# comment` from a definition line, respecting ROS 2 string
+/// semantics so that a `#` that is part of a value is not mistaken for a comment.
+///
+/// Two cases the naive "cut at the first `#`" does wrong:
+///
+/// 1. A `#` inside a quoted string is part of the string, e.g. the default of
+///    `string greeting "hi # there"`. Cutting there truncates the value and, for
+///    a double-quoted value, leaves an unterminated quote that fails the whole
+///    file.
+/// 2. A string *constant*'s value runs to the end of the line and may contain an
+///    unquoted `#`, e.g. `string PATTERN=a#b`. The ROS 2 message format does not
+///    treat `#` as a comment delimiter inside a string constant value, so the
+///    line must be kept intact.
+///
+/// Non-string lines (and string *member* lines without a default value) keep the
+/// ordinary rule: the first `#` outside any quoted string begins a comment.
+fn strip_comment(line: &str) -> &str {
+    let trimmed = line.trim_start();
+    let type_token = trimmed.split([' ', '\t']).next().unwrap_or("");
+    // A string constant is `string NAME=VALUE`: a string-typed line with an `=`
+    // outside quotes after the type token. Its value extends to end-of-line, so
+    // leave the line untouched. (`string<=N` keeps its own `=` inside the type
+    // token, hence the search starts after the first whitespace run.)
+    if is_string_type(type_token)
+        && let Some((_, rest)) = trimmed.split_once([' ', '\t'])
+        && find_unquoted(rest, b'=').is_some()
+    {
+        return line;
+    }
+    find_unquoted(line, b'#').map_or(line, |idx| &line[..idx])
+}
+
 pub fn parse_message_file<P: AsRef<Path>>(pkg_name: &str, interface_file: P) -> Result<Message> {
     parse_message_string(
         pkg_name,
@@ -33,7 +117,7 @@ pub fn parse_message_string(
     let mut constants = vec![];
 
     for line in message_string.lines() {
-        let (line, _) = split_once(line, '#');
+        let line = strip_comment(line);
         let line = line.trim();
         if line.is_empty() {
             continue;
@@ -206,6 +290,52 @@ mod test {
         assert_eq!(msg.members.len(), 1, "expected a member, got {msg:?}");
         assert!(msg.constants.is_empty());
         assert_eq!(msg.members[0].name, "url");
+    }
+
+    #[test]
+    fn string_constant_value_may_contain_hash() {
+        // A `#` inside a string constant value is part of the value, not the
+        // start of a comment. Cutting at the first `#` silently truncated the
+        // value to "a".
+        let msg = parse_message_string("pkg", "Msg", "string PATTERN=a#b").unwrap();
+        assert_eq!(msg.constants.len(), 1, "expected a constant, got {msg:?}");
+        assert!(msg.members.is_empty());
+        assert_eq!(msg.constants[0].value, vec!["a#b".to_string()]);
+    }
+
+    #[test]
+    fn quoted_string_value_containing_hash_is_not_truncated() {
+        // A `#` inside a double-quoted value must not be treated as a comment;
+        // truncating there left an unterminated quote that failed the whole file.
+        let msg = parse_message_string("pkg", "Msg", r#"string GREETING="a # b""#).unwrap();
+        assert_eq!(msg.constants.len(), 1, "expected a constant, got {msg:?}");
+        assert_eq!(msg.constants[0].value, vec!["a # b".to_string()]);
+
+        // The same for a single-quoted member default.
+        let member = parse_message_string("pkg", "Msg", "string greeting 'hi # there'").unwrap();
+        assert_eq!(member.members.len(), 1, "expected a member, got {member:?}");
+        assert_eq!(
+            member.members[0].default,
+            Some(vec!["hi # there".to_string()])
+        );
+    }
+
+    #[test]
+    fn trailing_comment_is_still_stripped() {
+        // Ordinary trailing comments on non-string-constant lines must still be
+        // removed.
+        let msg = parse_message_string("pkg", "Msg", "int32 X=5 # the answer minus 37").unwrap();
+        assert_eq!(msg.constants.len(), 1, "expected a constant, got {msg:?}");
+        assert_eq!(msg.constants[0].value, vec!["5".to_string()]);
+
+        let member = parse_message_string("pkg", "Msg", "int32 count # a comment").unwrap();
+        assert_eq!(member.members.len(), 1, "expected a member, got {member:?}");
+        assert_eq!(member.members[0].name, "count");
+        assert!(member.members[0].default.is_none());
+
+        // A whole-line comment is ignored entirely.
+        let empty = parse_message_string("pkg", "Msg", "# just a comment").unwrap();
+        assert!(empty.constants.is_empty() && empty.members.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #3460 (the comment-stripping half — "Bug 1").

`parse_message_string` in `libraries/extensions/ros2-bridge/msg-gen/src/parser/message.rs` cut every line at the first `#` (`split_once(line, '#')`), even when the `#` was part of a string value. Two consequences:

- **Silent truncation** of unquoted string constant values: `string PATTERN=a#b` recorded the value as `"a"` instead of `"a#b"`.
- **Hard parse failure** for a quoted value containing `#`: `string GREETING="a # b"` was truncated to `string GREETING="a `, leaving an unterminated quote that failed the whole `.msg`/`.srv`/`.action` file.

> Note: the classification half of #3460 ("Bug 2" — `=` inside a string default misrouting a member to `constant_def`) is already fixed on `main`; this PR addresses the remaining comment-stripping bug.

## Change

Replaces the naive `split_once(line, '#')` with a `strip_comment` helper that is string-literal-aware:

- A `#` inside a single- or double-quoted string (honoring backslash escapes) is part of the value, not a comment.
- A string **constant** line (`string`/`wstring` type with an `=` outside quotes) is kept intact, because the ROS 2 message format runs a string constant's value to end-of-line and does not treat `#` as a comment delimiter there. This matches the `string_literal` parser, whose fallback branch already accepts unquoted text.
- Every other line keeps the ordinary rule: the first `#` outside any quoted string begins a comment — so trailing comments (`int32 X=5 # note`) and whole-line comments are still stripped.

The `is_string_type` check is deliberately exact (`string`, `wstring`, `string<=N`, `string[3]`, `wstring<=5[]`, …) so a custom type whose name merely starts with `string` (e.g. `stringlike`) does not match.

## Tests

New regression tests in the `parser::message` test module:

- `string_constant_value_may_contain_hash` — `string PATTERN=a#b` → value `a#b`.
- `quoted_string_value_containing_hash_is_not_truncated` — quoted constant and single-quoted member default with `#`.
- `trailing_comment_is_still_stripped` — trailing and whole-line comments on non-string lines are still removed.

## Validation

- `cargo +1.97.1 test -p dora-ros2-bridge-msg-gen` — 90 passed
- `cargo +1.97.1 clippy -p dora-ros2-bridge-msg-gen --all-targets -- -D warnings` — clean
- `cargo +1.97.1 fmt -p dora-ros2-bridge-msg-gen -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TaYuG1Y7NQa3nEm32SVH3K

---
_Generated by [Claude Code](https://claude.ai/code/session_01TaYuG1Y7NQa3nEm32SVH3K)_