### PR TITLE
docs: add compile-checked doctests to public API helpers

### DIFF
--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -2381,6 +2381,25 @@ impl DoraNode {
     ///
     /// Uses a per-thread monotonic counter context to guarantee uniqueness
     /// even when multiple IDs are generated within the same clock tick.
+    ///
+    /// ```
+    /// use dora_node_api::DoraNode;
+    /// use dora_node_api::uuid::Uuid;
+    ///
+    /// let a = DoraNode::new_request_id();
+    /// let b = DoraNode::new_request_id();
+    ///
+    /// // Unique even when generated within the same clock tick.
+    /// assert_ne!(a, b);
+    /// // UUID v7 is time-ordered, so a later ID sorts after an earlier one.
+    /// assert!(b > a);
+    /// // Both are valid v7 UUIDs; `new_goal_id` is an alias returning the same shape.
+    /// assert_eq!(Uuid::parse_str(&a).unwrap().get_version_num(), 7);
+    /// assert_eq!(
+    ///     Uuid::parse_str(&DoraNode::new_goal_id()).unwrap().get_version_num(),
+    ///     7,
+    /// );
+    /// ```
     pub fn new_request_id() -> String {
         thread_local! {
             static CTX: uuid::ContextV7 = const { uuid::ContextV7::new() };
@@ -2958,6 +2977,16 @@ impl SampleAllocator {
     /// This is what a node without a zenoh session (interactive/testing mode)
     /// uses; it also lets callers that only need the encoding — tests, most
     /// obviously — build one without a live node.
+    ///
+    /// ```
+    /// use dora_node_api::SampleAllocator;
+    ///
+    /// // No zenoh session required — every allocation is a writable heap buffer.
+    /// let alloc = SampleAllocator::heap();
+    /// let mut sample = alloc.allocate(4).unwrap();
+    /// sample.copy_from_slice(&[1, 2, 3, 4]); // write straight into the buffer
+    /// assert_eq!(&sample[..], &[1, 2, 3, 4]);
+    /// ```
     pub fn heap() -> Self {
         Self {
             shm_provider: None,

--- a/libraries/message/src/config.rs
+++ b/libraries/message/src/config.rs
@@ -46,6 +46,18 @@ impl QueuePolicy {
     /// `add_event`, so the operator never receives a single message and the
     /// dataflow silently hangs. Clamp `queue_size: 0` to 1 (latest-only)
     /// instead of turning the input into a dead port.
+    ///
+    /// ```
+    /// use dora_message::config::QueuePolicy;
+    ///
+    /// // DropOldest keeps `queue_size`, but never a dead 0-capacity port.
+    /// assert_eq!(QueuePolicy::DropOldest.effective_cap(5), 5);
+    /// assert_eq!(QueuePolicy::DropOldest.effective_cap(0), 1);
+    ///
+    /// // Backpressure buffers 10x the configured size, with a floor of 100.
+    /// assert_eq!(QueuePolicy::Backpressure.effective_cap(5), 100);
+    /// assert_eq!(QueuePolicy::Backpressure.effective_cap(50), 500);
+    /// ```
     pub fn effective_cap(&self, queue_size: usize) -> usize {
         match self {
             Self::DropOldest => queue_size.max(1),


### PR DESCRIPTION
> 🤖 **Machine-generated PR.** This change was produced by an automated Claude Code review run. No human has vetted it — please review carefully before merging. Advisory only, not an approval.

## Issue

Three public API helpers carried clear prose documentation but no example. Each has a non-obvious contract that a compile-checked example makes concrete, and all three can be demonstrated without a running daemon, coordinator, or network:

- **`DoraNode::new_request_id` / `new_goal_id`** (`apis/rust/node/src/node/mod.rs`) — the docs state "UUID v7, time-ordered" and "unique even within the same clock tick", but nothing pins those claims or shows that `new_goal_id` is an alias.
- **`SampleAllocator::heap`** (`apis/rust/node/src/node/mod.rs`) — the prose advertises building an allocator "without a live node" for tests, but shows no example of doing so and writing into the resulting `DataSample`.
- **`QueuePolicy::effective_cap`** (`libraries/message/src/config.rs`) — the clamp/floor edge cases (`DropOldest` never returns 0; `Backpressure` is `10 * queue_size` with a floor of 100) are exactly what a user configuring `queue_size` needs, but weren't demonstrated.

## Fix

Added self-contained `///` doctests to each item:

- `new_request_id`: asserts two IDs are distinct, that a later ID sorts after an earlier one (v7 time-ordering), and that both `new_request_id` and `new_goal_id` return valid v7 UUIDs (via the crate's re-exported `uuid`).
- `SampleAllocator::heap`: builds a heap allocator, allocates a writable buffer, writes into it through `DerefMut`, and reads it back.
- `QueuePolicy::effective_cap`: pins the `DropOldest` (`5→5`, `0→1`) and `Backpressure` (`5→100`, `50→500`) results.

Doc-only — no signature or behavior change.

## Validation

Verified with the CI-pinned toolchain (`1.97.1`):

- `cargo test --doc -p dora-message -p dora-node-api` — the three new doctests compile and pass (message: 16 doctests green; node-api: 15 green + 4 pre-existing `ignored`).
- `cargo test --lib -p dora-message -p dora-node-api` — green (167 + 189 unit tests).
- `cargo clippy -p dora-message -p dora-node-api --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.

(The `zenoh_schema_cache` integration tests fail in the sandbox because they require real zenoh networking; they are unaffected by this doc-only change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015m1kVc6H6b8sG14P9aZubg

---
_Generated by [Claude Code](https://claude.ai/code/session_015m1kVc6H6b8sG14P9aZubg)_