### PR TITLE
docs(node-api): use output_channel in the integration-testing example

### DIFF
--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -305,7 +305,7 @@ fn test_main_function() -> eyre::Result<()> {
     let inputs = TestingInput::Input(
         IntegrationTestInput::new("node_id".parse().unwrap(), events),
     );
-    let (tx, mut rx) = integration_testing::unbounded_channel();
+    let (tx, mut rx) = integration_testing::output_channel();
     let outputs = TestingOutput::ToChannel(tx);
     let options = TestingOptions { skip_output_time_offsets: true };
 


### PR DESCRIPTION
## Summary

The snippet `docs/testing-guide.md` presents as the **recommended** way to integration-test a node doesn't compile.

#3239 (`refactor!: hide tokio from the integration-testing API`) removed the re-exported tokio channel and replaced it with the opaque `output_channel()` / `OutputSender` / `OutputReceiver` trio. The guide's example still calls the function that removal deleted:

```rust
let (tx, mut rx) = integration_testing::unbounded_channel();   // no longer exists
```

Interestingly the migration was half-applied — the line four below it already uses the new `drain_outputs(&mut rx)`, so `output_channel()` is the only thing left behind.

## Change

One identifier:

```diff
-    let (tx, mut rx) = integration_testing::unbounded_channel();
+    let (tx, mut rx) = integration_testing::output_channel();
```

`mut rx` stays, since `drain_outputs` takes `&mut OutputReceiver`.

## Verification

I compiled the snippet's API calls against the crate as it stands on `main` — as a temporary `tests/` file, not included here — to confirm `output_channel()` is the *only* stale part. Everything else in the example is current: the `IncomingEvent::Input` field names, `"tick".into()`, `IntegrationTestInput::new`, the `TestingOptions` literal, `setup_integration_testing`, and `drain_outputs`.

`typos` is clean. No code changes, so no other gate applies.

## Note

Nothing compile-checks the Rust snippets in `docs/`, which is how this drifted — the `drain_outputs` half of the migration landed while the `unbounded_channel` half didn't, and neither CI nor a doctest noticed. A gate that extracts and builds the documented snippets would catch the next one, but that's infrastructure well beyond this fix, so I've left it alone. Happy to open a separate issue for it if you think it's worth tracking.
