### PR TITLE
refactor(coordinator): extract shared WS subscriber channel lifecycle

### DIFF
--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -140,6 +140,7 @@ mod log_subscriber;
 mod otel_metrics;
 mod run;
 mod state;
+mod subscriber_channel;
 mod timeout_streak;
 mod topic_subscriber;
 mod ws_control;

--- a/binaries/coordinator/src/log_subscriber.rs
+++ b/binaries/coordinator/src/log_subscriber.rs
@@ -1,19 +1,17 @@
-use crate::timeout_streak::TimeoutStreak;
+use crate::subscriber_channel::SubscriberChannel;
 use dora_message::coordinator_to_cli::LogMessage;
-use eyre::{Context, ContextCompat};
+use eyre::Context;
 
 pub struct LogSubscriber {
     pub level: log::LevelFilter,
-    sender: Option<tokio::sync::mpsc::Sender<String>>,
-    timeouts: TimeoutStreak,
+    channel: SubscriberChannel<String>,
 }
 
 impl LogSubscriber {
     pub fn new(level: log::LevelFilter, sender: tokio::sync::mpsc::Sender<String>) -> Self {
         Self {
             level,
-            sender: Some(sender),
-            timeouts: TimeoutStreak::default(),
+            channel: SubscriberChannel::new(sender),
         }
     }
 
@@ -34,7 +32,7 @@ impl LogSubscriber {
             dora_core::build::LogLevelOrStdout::Stdout => {}
         }
 
-        let sender = self.sender.as_ref().context("subscriber is closed")?;
+        let sender = self.channel.sender()?;
         let json = serde_json::to_string(&dora_message::ws_protocol::WsEvent {
             event: "log".to_string(),
             payload: serde_json::to_value(message)?,
@@ -49,23 +47,20 @@ impl LogSubscriber {
 
     /// Reset the consecutive-timeout streak after a successful send.
     pub fn reset_timeout_streak(&mut self) {
-        self.timeouts.reset();
+        self.channel.reset_timeout_streak();
     }
 
     /// Record a send timeout and return the new consecutive-timeout count.
     pub fn record_timeout(&mut self) -> usize {
-        self.timeouts.record()
+        self.channel.record_timeout()
     }
 
     pub fn is_closed(&self) -> bool {
-        match &self.sender {
-            None => true,
-            Some(sender) => sender.is_closed(),
-        }
+        self.channel.is_closed()
     }
 
     pub fn close(&mut self) {
-        self.sender = None;
+        self.channel.close();
     }
 }
 

--- a/binaries/coordinator/src/subscriber_channel.rs
+++ b/binaries/coordinator/src/subscriber_channel.rs
@@ -1,0 +1,89 @@
+use crate::timeout_streak::TimeoutStreak;
+
+/// The send-channel + timeout-streak lifecycle shared by the coordinator's
+/// bounded-channel WS subscribers.
+///
+/// Both `LogSubscriber` and `TopicSubscriber` wrap a bounded mpsc sender that
+/// is dropped (set to `None`) on close, alongside a [`TimeoutStreak`] for
+/// eviction. The close / `is_closed` / timeout bookkeeping is identical for
+/// both — only the payload type `T` and the serialization done in their
+/// `send_*` methods differ — so it lives here in one definition instead of
+/// being copied into each subscriber.
+pub(crate) struct SubscriberChannel<T> {
+    sender: Option<tokio::sync::mpsc::Sender<T>>,
+    timeouts: TimeoutStreak,
+}
+
+impl<T> SubscriberChannel<T> {
+    pub(crate) fn new(sender: tokio::sync::mpsc::Sender<T>) -> Self {
+        Self {
+            sender: Some(sender),
+            timeouts: TimeoutStreak::default(),
+        }
+    }
+
+    /// The live sender, or an error if the subscriber has been closed.
+    pub(crate) fn sender(&self) -> eyre::Result<&tokio::sync::mpsc::Sender<T>> {
+        self.sender
+            .as_ref()
+            .ok_or_else(|| eyre::eyre!("subscriber is closed"))
+    }
+
+    /// Reset the consecutive-timeout streak after a successful send.
+    pub(crate) fn reset_timeout_streak(&mut self) {
+        self.timeouts.reset();
+    }
+
+    /// Record a send timeout and return the new consecutive-timeout count.
+    pub(crate) fn record_timeout(&mut self) -> usize {
+        self.timeouts.record()
+    }
+
+    /// Whether the subscriber has been closed, or its receiver dropped.
+    pub(crate) fn is_closed(&self) -> bool {
+        match &self.sender {
+            None => true,
+            Some(sender) => sender.is_closed(),
+        }
+    }
+
+    /// Close the subscriber, dropping the sender so the receiver sees EOF.
+    pub(crate) fn close(&mut self) {
+        self.sender = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SubscriberChannel;
+
+    #[test]
+    fn timeouts_are_monotonic_and_reset() {
+        let (tx, _rx) = tokio::sync::mpsc::channel::<u8>(1);
+        let mut channel = SubscriberChannel::new(tx);
+        assert_eq!(channel.record_timeout(), 1);
+        assert_eq!(channel.record_timeout(), 2);
+        channel.reset_timeout_streak();
+        assert_eq!(channel.record_timeout(), 1);
+    }
+
+    #[test]
+    fn close_marks_closed_and_drops_sender() {
+        let (tx, _rx) = tokio::sync::mpsc::channel::<u8>(1);
+        let mut channel = SubscriberChannel::new(tx);
+        assert!(!channel.is_closed());
+        assert!(channel.sender().is_ok());
+        channel.close();
+        assert!(channel.is_closed());
+        assert!(channel.sender().is_err());
+    }
+
+    #[test]
+    fn is_closed_when_receiver_dropped() {
+        let (tx, rx) = tokio::sync::mpsc::channel::<u8>(1);
+        let channel = SubscriberChannel::new(tx);
+        assert!(!channel.is_closed());
+        drop(rx);
+        assert!(channel.is_closed());
+    }
+}

--- a/binaries/coordinator/src/topic_subscriber.rs
+++ b/binaries/coordinator/src/topic_subscriber.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeMap;
 
+use crate::subscriber_channel::SubscriberChannel;
+
 pub struct TopicFrame {
     pub subscription_id: uuid::Uuid,
     pub payload: std::sync::Arc<[u8]>,
@@ -10,8 +12,7 @@ pub(crate) struct TopicSubscriber {
         dora_message::common::DaemonId,
         Vec<(dora_message::id::NodeId, dora_message::id::DataId)>,
     >,
-    sender: Option<tokio::sync::mpsc::Sender<TopicFrame>>,
-    timeouts: crate::timeout_streak::TimeoutStreak,
+    channel: SubscriberChannel<TopicFrame>,
 }
 
 impl TopicSubscriber {
@@ -24,8 +25,7 @@ impl TopicSubscriber {
     ) -> Self {
         Self {
             outputs_by_daemon,
-            sender: Some(sender),
-            timeouts: crate::timeout_streak::TimeoutStreak::default(),
+            channel: SubscriberChannel::new(sender),
         }
     }
 
@@ -39,10 +39,7 @@ impl TopicSubscriber {
     }
 
     pub(crate) async fn send_frame(&mut self, frame: TopicFrame) -> eyre::Result<()> {
-        let sender = self
-            .sender
-            .as_ref()
-            .ok_or_else(|| eyre::eyre!("subscriber is closed"))?;
+        let sender = self.channel.sender()?;
         sender
             .send(frame)
             .await
@@ -51,22 +48,19 @@ impl TopicSubscriber {
     }
 
     pub(crate) fn reset_timeout_streak(&mut self) {
-        self.timeouts.reset();
+        self.channel.reset_timeout_streak();
     }
 
     pub(crate) fn record_timeout(&mut self) -> usize {
-        self.timeouts.record()
+        self.channel.record_timeout()
     }
 
     pub(crate) fn is_closed(&self) -> bool {
-        match &self.sender {
-            None => true,
-            Some(sender) => sender.is_closed(),
-        }
+        self.channel.is_closed()
     }
 
     pub(crate) fn close(&mut self) {
-        self.sender = None;
+        self.channel.close();
     }
 }
 


### PR DESCRIPTION
> 🤖 **Machine-generated PR.** This change was produced by an automated Claude Code review run. No human has vetted it — please review carefully before merging. Advisory only, not an approval.

## Issue

`LogSubscriber` (`log_subscriber.rs`) and `TopicSubscriber` (`topic_subscriber.rs`) are two coordinator WS subscribers that carried the **same** `Option<Sender<T>>` + `TimeoutStreak` field pair and four byte-for-byte identical methods:

```rust
pub fn reset_timeout_streak(&mut self) { self.timeouts.reset(); }
pub fn record_timeout(&mut self) -> usize { self.timeouts.record() }
pub fn is_closed(&self) -> bool {
    match &self.sender { None => true, Some(sender) => sender.is_closed() }
}
pub fn close(&mut self) { self.sender = None; }
```

plus the same "sender, or error if closed" guard in their `send_*` methods. `TimeoutStreak` was already factored out to keep the two eviction paths in sync, but the sender wrapper and the close/`is_closed` logic were still copied into each type. There was no single definition of "when is a WS subscriber closed / how is its timeout streak managed".

## Fix

Extract a small generic `SubscriberChannel<T>` (`subscriber_channel.rs`) that owns the sender + timeout streak and defines the `sender()` / `close` / `is_closed` / timeout contract **once**. Both subscribers now embed it and delegate; only their payload type (`String` vs. `TopicFrame`) and their `send_*` serialization — the parts that genuinely differ — remain distinct.

- Net: ~16 duplicated lines removed; one source of truth for the subscriber-close/timeout lifecycle.
- **No behavior change.** The public method surface of both subscribers is unchanged (all call sites in `handlers.rs` / `lib.rs` go through those methods), and the `"subscriber is closed"` / channel-closed error texts are preserved.

## Validation

Verified with the CI-pinned toolchain (`1.97.1`):

- `cargo test -p dora-coordinator` — green (160 lib tests incl. the existing `log_subscriber` / `topic_subscriber` tests, plus 3 new `SubscriberChannel` unit tests; integration + doc tests green).
- `cargo clippy -p dora-coordinator --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015m1kVc6H6b8sG14P9aZubg

---
_Generated by [Claude Code](https://claude.ai/code/session_015m1kVc6H6b8sG14P9aZubg)_